### PR TITLE
fix(connect): stale-pidfile cleanup wedged by pipefail + dead parent (#6)

### DIFF
--- a/airc
+++ b/airc
@@ -428,7 +428,12 @@ cmd_connect() {
     local stale_pids; stale_pids=$(cat "$stale_pidfile" 2>/dev/null | tr '\n' ' ')
     local all_stale="$stale_pids"
     for p in $stale_pids; do
-      all_stale="$all_stale $(pgrep -P "$p" 2>/dev/null | tr '\n' ' ')"
+      # `|| true` — pgrep returns 1 when the parent PID is already dead (no
+      # children to find). With `set -euo pipefail` at the top of the script,
+      # that would abort this block *before* reaching the rm on line 442 that
+      # self-heals the stale pidfile. Result: joiner wedged forever after a
+      # parent crash / laptop sleep until someone manually rm'd the pidfile.
+      all_stale="$all_stale $(pgrep -P "$p" 2>/dev/null | tr '\n' ' ' || true)"
     done
     # Quiet kill — don't warn unless there was actually a live process.
     if [ -n "$all_stale" ]; then


### PR DESCRIPTION
## Summary

- `cmd_connect` aborted silently (exit 1, no stdout/stderr) whenever `.airc/airc.pid` referenced a dead parent PID — common after joiner laptop sleep, Claude tab crash, or any ungraceful parent exit.
- Root cause: `pgrep -P <dead-pid>` exits 1 with no children; `set -euo pipefail` promoted that through the `pgrep | tr` pipeline and killed `cmd_connect` **before** reaching the `rm -f "$stale_pidfile"` that would have self-healed it.
- One-line fix: add `|| true` to neutralize pipefail in the no-children case. Same pattern used on `airc:1068`.

## Repro

```bash
echo 99999 > .airc/airc.pid
airc connect          # exit=1, no output
ls .airc/airc.pid     # still there
```

After this patch:

```bash
airc connect          # proceeds to host/resume, pidfile cleared
```

## Test plan

- [x] Syntax check (`bash -n airc`)
- [x] Reproduced the wedge on main (exit 1, pidfile preserved)
- [x] Verified fix: pidfile removed, cmd_connect proceeds to hosting/resume
- [x] Live-process path is unchanged (only the dead-parent case was broken); `kill -0` check still gates the `kill -9` so no spurious kills

## Related

- Fixes #6
- Complements #7 (umbrella resilience) — this is item 1 in the ship-order.
- Does not conflict with memento's `fix/offline-resilience-issue-5` branch (docs-only so far).

🤖 Generated with [Claude Code](https://claude.com/claude-code)