### PR TITLE
feat(send): pending.jsonl queue — auto-retry when host returns (closes #5 Option B)

### DIFF
--- a/airc
+++ b/airc
@@ -180,7 +180,11 @@ monitor() {
   # interval, resets when the user sends (cmd_send removes the marker).
   ( reminder_timer_loop ) &
   local reminder_pid=$!
-  trap "kill $reminder_pid 2>/dev/null" EXIT INT TERM
+  # Background pending-flush loop — drains queued sends when the host comes
+  # back. No-op on host-mode (empty host_target short-circuits).
+  ( flush_pending_loop ) &
+  local flush_pid=$!
+  trap "kill $reminder_pid $flush_pid 2>/dev/null" EXIT INT TERM
 
   # Stream inbound via `tail -n 0 -F` (inotify/kqueue) — no polling, every
   # new line surfaces the moment it's written. Joiner tails the host over
@@ -354,6 +358,81 @@ for line in sys.stdin:
         label = fr
     print(f"[{ts}] {label}: {msg}", flush=True)
 '
+}
+
+# Drain pending.jsonl when the host is reachable again. Runs in background
+# during monitor. If the joiner tried to send while the host was unreachable
+# (laptop asleep, network out, SSH timing out), cmd_send appended the full
+# signed payload to pending.jsonl and returned 0 instead of die()ing. This
+# loop periodically retries each pending line; on success, the line is
+# dropped; on failure, it stays for the next attempt.
+#
+# Atomicity note: we snapshot pending.jsonl (mv to tmp) before replaying so
+# concurrent cmd_send invocations during the drain still land in a fresh
+# pending.jsonl rather than getting clobbered. Anything we couldn't deliver
+# gets prepended back to the current pending file.
+flush_pending_loop() {
+  local pending="$AIRC_WRITE_DIR/pending.jsonl"
+  local host_target; host_target=$(get_config_val host_target "")
+  # Host-mode: no wire, no pending — nothing to do.
+  [ -z "$host_target" ] && return 0
+  local rhome; rhome=$(remote_home)
+  local ssh_key="$IDENTITY_DIR/ssh_key"
+
+  while true; do
+    sleep 5
+    [ -s "$pending" ] || continue
+
+    # Re-read host_target each iteration — user might have re-paired.
+    host_target=$(get_config_val host_target "")
+    [ -z "$host_target" ] && continue
+    rhome=$(remote_home)
+
+    local snapshot; snapshot=$(mktemp -t airc-pending-snap.XXXXXX)
+    local unsent;   unsent=$(mktemp -t airc-pending-unsent.XXXXXX)
+    # Atomic-ish snapshot: mv is atomic on same filesystem, so new sends that
+    # arrive after this line go to a fresh pending.jsonl and aren't in-flight.
+    mv "$pending" "$snapshot" 2>/dev/null || { rm -f "$snapshot" "$unsent"; continue; }
+
+    local delivered=0 failed=0
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      local out
+      out=$(printf '%s\n' "$line" | \
+            ssh -i "$ssh_key" -o StrictHostKeyChecking=accept-new \
+                -o ConnectTimeout=5 -o BatchMode=yes \
+                "$host_target" \
+                "cat >> $rhome/messages.jsonl && echo __APPENDED__" \
+                2>/dev/null || true)
+      if echo "$out" | grep -q '^__APPENDED__$'; then
+        delivered=$((delivered + 1))
+      else
+        echo "$line" >> "$unsent"
+        failed=$((failed + 1))
+      fi
+    done < "$snapshot"
+
+    # Put failures back at the head of pending, preserving any sends that
+    # landed while we were draining (they'd be in a fresh pending file now).
+    if [ -s "$unsent" ]; then
+      if [ -s "$pending" ]; then
+        cat "$unsent" "$pending" > "${pending}.new" && mv "${pending}.new" "$pending"
+      else
+        mv "$unsent" "$pending"
+        unsent=""
+      fi
+    fi
+
+    # Announce success in the local log so `airc logs` shows the drain event.
+    if [ "$delivered" -gt 0 ]; then
+      local drain_marker
+      drain_marker=$(printf '{"from":"airc","ts":"%s","msg":"[DRAINED %d queued message(s) to host]"}' \
+        "$(timestamp)" "$delivered")
+      echo "$drain_marker" >> "$MESSAGES"
+    fi
+
+    rm -f "$snapshot" "$unsent" 2>/dev/null
+  done
 }
 
 # Separate loop, runs in background during monitor.
@@ -902,16 +981,21 @@ cmd_send() {
     err=$(mktemp -t airc-send-err.XXXXXX)
     out=$(printf '%s\n' "$full_msg" | relay_ssh "$host_target" "cat >> $rhome/messages.jsonl && echo __APPENDED__" 2>"$err" || true)
     if ! echo "$out" | grep -q '^__APPENDED__$'; then
-      # Wire failed. Append a failure marker next to the mirrored line so the
-      # user's `airc logs` shows the message AND the failure reason.
+      # Wire failed. Queue the payload for automatic retry by flush_pending_loop
+      # in the monitor, then annotate the local log with a [QUEUED] marker so
+      # `airc logs` makes the state obvious. Don't die() — queued is a form of
+      # success. The user's shell scripts can still check pending.jsonl if
+      # they need to block on delivery.
       local stderr; stderr=$(tr '\n' ' ' < "$err" | sed 's/"/\\"/g' | cut -c1-200)
       rm -f "$err"
-      local fail_marker; fail_marker=$(printf '{"from":"airc","ts":"%s","msg":"[SEND FAILED to %s] %s"}' \
+      echo "$full_msg" >> "$AIRC_WRITE_DIR/pending.jsonl"
+      local queue_marker; queue_marker=$(printf '{"from":"airc","ts":"%s","msg":"[QUEUED to %s — host unreachable, will retry] %s"}' \
         "$(timestamp)" "$peer_name" "${stderr:-no stderr}")
-      echo "$fail_marker" >> "$MESSAGES"
-      die "Failed to deliver to host ($host_target): ${stderr:-no stderr}"
+      echo "$queue_marker" >> "$MESSAGES"
+      echo "  Host unreachable — message queued for retry. Monitor will flush when host returns." >&2
+    else
+      rm -f "$err"
     fi
-    rm -f "$err"
   else
     echo "$full_msg" >> "$MESSAGES"
   fi

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -162,8 +162,9 @@ scenario_tabs() {
     || fail "send-file ran but no payload on host"
 
   # Resilience: if the wire fails, the outbound MUST still be in local log
-  # with a [SEND FAILED] marker. Simulate by sending with a bogus host_target
-  # via a temp config override. Prevents silent loss.
+  # with a [QUEUED] marker AND enqueued in pending.jsonl for automatic retry.
+  # (Prior to send-queue: a [SEND FAILED] marker and no retry; see scenario_queue
+  # for the end-to-end drain test.) Simulate by sending with a bogus host_target.
   local fake_home=/tmp/airc-it-fail-test
   mkdir -p "$fake_home/state/peers" "$fake_home/state/identity"
   cp /tmp/airc-it-j/state/identity/* "$fake_home/state/identity/" 2>/dev/null
@@ -183,9 +184,13 @@ json.dump(c, open('$fake_home/state/config.json', 'w'))
   grep -q '"this-should-fail-but-still-mirror"' "$fake_home/state/messages.jsonl" 2>/dev/null && \
     pass "failed send: outbound still mirrored to local log (no silent loss)" \
     || fail "failed send: outbound NOT in local log (silent loss regression)"
-  grep -q 'SEND FAILED' "$fake_home/state/messages.jsonl" 2>/dev/null && \
-    pass "failed send: [SEND FAILED] marker present in local log" \
-    || fail "failed send: no [SEND FAILED] marker — user can't tell it failed"
+  grep -q 'QUEUED' "$fake_home/state/messages.jsonl" 2>/dev/null && \
+    pass "failed send: [QUEUED] marker present in local log" \
+    || fail "failed send: no [QUEUED] marker — user can't tell it was queued"
+  [ -s "$fake_home/state/pending.jsonl" ] && \
+    grep -q 'this-should-fail-but-still-mirror' "$fake_home/state/pending.jsonl" 2>/dev/null && \
+    pass "failed send: message also enqueued in pending.jsonl for retry" \
+    || fail "failed send: pending.jsonl missing — message won't auto-retry"
   rm -rf "$fake_home"
 
   send_err=$(as_home /tmp/airc-it-h send @beta "m2-from-alpha" 2>&1 >/dev/null)
@@ -507,6 +512,78 @@ scenario_reconnect() {
   cleanup_all
 }
 
+scenario_queue() {
+  section "queue: SSH-unreachable sends land in pending.jsonl, drain when host returns"
+  cleanup_all
+
+  # Realistic #5 scenario isn't "airc process killed on host" (SSH still up +
+  # cat >> messages.jsonl still works without airc running). It's "host MACHINE
+  # unreachable" — laptop asleep, network out, SSH times out. We simulate by
+  # pointing host_target at an unreachable IP, then restoring it to test drain.
+
+  spawn_host /tmp/airc-it-q-h qhost 7549 || { fail "qhost failed to start"; return; }
+  local join; join=$(read_join_string /tmp/airc-it-q-h)
+  spawn_joiner /tmp/airc-it-q-j qjoiner "$join" || { fail "qjoiner join failed"; return; }
+  sleep 3
+
+  # Snapshot the real host_target, then flip to an unreachable address.
+  local real_target
+  real_target=$(python3 -c "import json; print(json.load(open('/tmp/airc-it-q-j/state/config.json'))['host_target'])")
+  [ -n "$real_target" ] || { fail "no host_target recorded in joiner config"; return; }
+
+  python3 -c "
+import json
+p = '/tmp/airc-it-q-j/state/config.json'
+c = json.load(open(p))
+c['host_target'] = 'nobody@127.0.0.99'
+json.dump(c, open(p, 'w'))
+"
+  # Also fake the peer record so resolution doesn't fail on @qhost
+  echo '{"name":"qhost","host":"nobody@127.0.0.99","airc_home":"/tmp/nowhere"}' \
+    > /tmp/airc-it-q-j/state/peers/qhost.json
+  pass "joiner: host_target flipped to unreachable (outage simulation)"
+
+  # ── Send during outage ─────────────────────────────────────────────
+  AIRC_HOME=/tmp/airc-it-q-j/state "$AIRC" send @qhost "queued-during-outage" >/dev/null 2>&1
+  local send_exit=$?
+  [ $send_exit -eq 0 ] && pass "send during outage: exit 0 (queued is success)" \
+                       || fail "send during outage: exit $send_exit — should queue gracefully, not die"
+
+  local pending=/tmp/airc-it-q-j/state/pending.jsonl
+  [ -f "$pending" ] && grep -q 'queued-during-outage' "$pending" \
+    && pass "send during outage: message landed in pending.jsonl" \
+    || fail "send during outage: pending.jsonl missing or empty"
+
+  grep -q 'QUEUED' /tmp/airc-it-q-j/state/messages.jsonl \
+    && pass "send during outage: [QUEUED] marker visible in local log" \
+    || fail "send during outage: no [QUEUED] marker in local messages.jsonl"
+
+  # ── Recovery: restore real host_target, wait for flush loop ─────────
+  python3 -c "
+import json
+p = '/tmp/airc-it-q-j/state/config.json'
+c = json.load(open(p))
+c['host_target'] = '$real_target'
+json.dump(c, open(p, 'w'))
+"
+  pass "joiner: host_target restored (recovery simulation)"
+
+  # Flush loop on joiner polls every ~5s; give up to 25s.
+  local delivered=0 drained=0
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25; do
+    sleep 1
+    grep -q 'queued-during-outage' /tmp/airc-it-q-h/state/messages.jsonl 2>/dev/null && delivered=1
+    [ ! -s "$pending" ] && drained=1
+    [ "$delivered" = "1" ] && [ "$drained" = "1" ] && break
+  done
+  [ "$delivered" = "1" ] && pass "recovery: queued message drained to host (${i}s)" \
+                         || fail "recovery: queued message NOT delivered to host within 25s"
+  [ "$drained" = "1" ] && pass "recovery: pending.jsonl cleared after successful drain" \
+                       || fail "recovery: pending.jsonl still has content ($(wc -l < "$pending" 2>/dev/null) lines)"
+
+  cleanup_all
+}
+
 case "$MODE" in
   tabs)        scenario_tabs  ;;
   scope)       scenario_scope ;;
@@ -514,8 +591,9 @@ case "$MODE" in
   reminder)    scenario_reminder ;;
   resilience)  scenario_resilience ;;
   reconnect)   scenario_reconnect ;;
-  all)         scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|all]"; exit 2 ;;
+  queue)       scenario_queue ;;
+  all)         scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary

The other half of #5's offline resilience. Paired with #11 (receive-side reconnect), this gives the "laptop sleeps, nothing is lost, mesh self-heals when it wakes" property memento asked for.

### Before

```
$ airc send @peer "important message"
ERROR: Failed to deliver to host (joelteply@100.91.51.87): ssh: connect to host 100.91.51.87 port 22: Operation timed out
# → exit 1, message dropped, [SEND FAILED] marker in local log
```

### After

```
$ airc send @peer "important message"
  Host unreachable — message queued for retry. Monitor will flush when host returns.
# → exit 0, message in .airc/pending.jsonl, [QUEUED ...] marker in local log
# ...host comes back...
# → flush_pending_loop delivers it within ~5s, writes [DRAINED N] marker
```

## Changes

**`cmd_send` wire-failure branch**
- Appends full signed payload to `.airc/pending.jsonl`
- Writes `[QUEUED to <peer> — host unreachable, will retry]` to local `messages.jsonl`
- Stderr warning for interactive users
- Returns 0 (queuing is success — nothing lost)

**New `flush_pending_loop`**, backgrounded from `monitor()` alongside `reminder_timer_loop`
- 5s poll; no-op if pending is empty
- Atomic snapshot (`mv` to tmp) so concurrent sends during drain aren't clobbered
- Per-line retry with `ConnectTimeout=5` + `BatchMode=yes`
- Successful deliveries drop; failures prepend back to preserve ordering
- On drain, writes `[DRAINED N queued message(s) to host]` for operator visibility

## Test plan

- [x] New `scenario_queue` (7 assertions): outage → send → pending populated → recovery → drain in 2s
- [x] Updated `scenario_tabs` [SEND FAILED] → [QUEUED] assertions (2 assertions, tests what `cmd_send` actually does now)
- [x] Full suite: **55/55** (was 47/47)
- [x] `bash -n airc` + `bash -n test/integration.sh`

## Resilience story (after this lands)

With #8/#9/#10/#11 + this PR, airc now survives:

| Failure mode | Before | After |
|---|---|---|
| Stale pidfile after sleep/crash | Wedged forever | Self-heals on `airc connect` (#8) |
| `ps -p` race in teardown port-reap | Aborted mid-loop | Full scan completes (#9) |
| Malformed peer record | Peers listing died | Bad record skipped, rest enumerated (#9) |
| Host down → receive | Monitor died silently | Tail retries + offset resume (#11) |
| Host down → send | Message dropped | **Queued + auto-drain on recovery** (this PR) |

Remaining gaps from #7 umbrella:
- `airc status` liveness view (quick, would ship next)
- Peer-to-peer host-failover (bigger lift, Option A/C from #5 — probably overkill for <100 peer deployments)

## Related

- Closes Option B of #5
- Refs #7 umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)