### PR TITLE
feat(status): airc status — liveness view for #7 (monitor, queue, last-activity)

### DIFF
--- a/airc
+++ b/airc
@@ -1284,6 +1284,139 @@ cmd_version() {
   echo "  install: $dir"
 }
 
+cmd_status() {
+  # Human-readable liveness view. Fast — no network calls by default; `--probe`
+  # opts into a 3s SSH reachability check.
+  ensure_init
+  local probe=0
+  [ "${1:-}" = "--probe" ] && probe=1
+
+  local my_name host_target host_name host_port
+  my_name=$(get_name)
+  host_target=$(get_config_val host_target "")
+  host_name=$(get_config_val host_name "")
+  host_port=$(get_config_val host_port 7547)
+
+  echo "  airc status — scope $AIRC_WRITE_DIR"
+
+  # Identity + role line.
+  if [ -n "$host_target" ]; then
+    echo "  identity:    $my_name (joiner of ${host_name:-?} @ ${host_target}:${host_port})"
+  else
+    local my_port; my_port="${AIRC_PORT:-7547}"
+    [ -f "$AIRC_WRITE_DIR/host_port" ] && my_port=$(cat "$AIRC_WRITE_DIR/host_port" 2>/dev/null)
+    echo "  identity:    $my_name (hosting on port ${my_port})"
+  fi
+
+  # Monitor alive? Read the scope's pidfile — cmd_connect writes its own PID
+  # there. pgrep'd descendants (python listener, tail loop) should be children
+  # of that PID. If the main PID is gone, the monitor is down.
+  local monitor_state="not running"
+  local pidfile="$AIRC_WRITE_DIR/airc.pid"
+  if [ -f "$pidfile" ]; then
+    # cmd_connect writes multiple space-separated PIDs on one line (parent +
+    # python listener). Monitor is "running" if ANY of them is alive.
+    local pids_raw; pids_raw=$(cat "$pidfile" 2>/dev/null | tr '\n' ' ' || true)
+    local any_alive=""
+    for p in $pids_raw; do
+      if kill -0 "$p" 2>/dev/null; then any_alive="$p"; break; fi
+    done
+    if [ -n "$any_alive" ]; then
+      monitor_state="running (PID $any_alive)"
+    else
+      monitor_state="stale pidfile (PIDs $pids_raw not alive — run 'airc connect' to self-heal)"
+    fi
+  fi
+  echo "  monitor:     $monitor_state"
+
+  # Host reachability. Only meaningful for joiners; opt-in via --probe to keep
+  # `airc status` fast by default (SSH connect can hang for seconds).
+  if [ -n "$host_target" ] && [ "$probe" = "1" ]; then
+    local ssh_key="$IDENTITY_DIR/ssh_key"
+    local probe_out
+    probe_out=$(ssh -i "$ssh_key" -o StrictHostKeyChecking=accept-new \
+                    -o ConnectTimeout=3 -o BatchMode=yes \
+                    "$host_target" "echo __REACHABLE__" 2>/dev/null || true)
+    if echo "$probe_out" | grep -q '^__REACHABLE__$'; then
+      echo "  host:        reachable"
+    else
+      echo "  host:        UNREACHABLE (ssh timeout or auth failure)"
+    fi
+  fi
+
+  # Last send / receive timestamps. last_sent is a unix epoch written by
+  # cmd_send. last receive: tail the local messages.jsonl for the most recent
+  # inbound line (from != $my_name).
+  local now; now=$(date +%s)
+  if [ -f "$AIRC_WRITE_DIR/last_sent" ]; then
+    local ls; ls=$(cat "$AIRC_WRITE_DIR/last_sent" 2>/dev/null)
+    if [ -n "$ls" ] && [ "$ls" -gt 0 ] 2>/dev/null; then
+      echo "  last send:   $(( now - ls ))s ago"
+    else
+      echo "  last send:   never"
+    fi
+  else
+    echo "  last send:   never"
+  fi
+
+  if [ -s "$MESSAGES" ]; then
+    local last_rx_ts
+    last_rx_ts=$(PEERS_DIR="$PEERS_DIR" MY_NAME="$my_name" python3 -c "
+import sys, json, os, calendar, time
+name = os.environ.get('MY_NAME', '')
+last_ts = None
+try:
+    with open('$MESSAGES') as f:
+        for line in f:
+            try:
+                m = json.loads(line)
+                if m.get('from') and m.get('from') != name and m.get('from') != 'airc':
+                    last_ts = m.get('ts')
+            except: pass
+except: pass
+if last_ts:
+    # ts is ISO8601 UTC (Z-suffix). Convert to epoch.
+    try:
+        t = time.strptime(last_ts.replace('Z',''), '%Y-%m-%dT%H:%M:%S')
+        print(int(calendar.timegm(t)))
+    except: print('')
+else:
+    print('')
+" 2>/dev/null)
+    if [ -n "$last_rx_ts" ]; then
+      echo "  last recv:   $(( now - last_rx_ts ))s ago"
+    else
+      echo "  last recv:   never"
+    fi
+  else
+    echo "  last recv:   never"
+  fi
+
+  # Pending queue — how many sends are waiting for a drain. Populated by
+  # cmd_send's wire-failure branch; drained by flush_pending_loop.
+  local pending="$AIRC_WRITE_DIR/pending.jsonl"
+  local pending_count=0
+  [ -f "$pending" ] && pending_count=$(grep -c '^.' "$pending" 2>/dev/null || echo 0)
+  if [ "$pending_count" -gt 0 ]; then
+    echo "  queue:       ${pending_count} pending (auto-retries every ~5s)"
+  else
+    echo "  queue:       empty"
+  fi
+
+  # Reminder state
+  local reminder_file="$AIRC_WRITE_DIR/reminder"
+  if [ -f "$reminder_file" ]; then
+    local rv; rv=$(cat "$reminder_file" 2>/dev/null)
+    if [ "$rv" = "0" ]; then
+      echo "  reminder:    paused"
+    elif [ -n "$rv" ] && [ "$rv" -gt 0 ] 2>/dev/null; then
+      echo "  reminder:    every ${rv}s"
+    fi
+  else
+    echo "  reminder:    off"
+  fi
+}
+
 cmd_doctor() {
   # Self-diagnose: run the bundled integration test script.
   # Install resolves it under AIRC_DIR/test; fall back to a sibling dir
@@ -1335,6 +1468,7 @@ case "${1:-help}" in
   version|--version|-v) cmd_version ;;
   update|upgrade|pull) cmd_update ;;
   logs)      shift; cmd_logs "$@" ;;
+  status)    shift; cmd_status "$@" ;;
   doctor)    shift; cmd_doctor "$@" ;;
   teardown|stop|flush) shift; cmd_teardown "$@" ;;
   disconnect|leave|unbind) cmd_disconnect ;;
@@ -1350,6 +1484,7 @@ case "${1:-help}" in
     echo "  airc rename <new-name>          Rename this session (notifies peers)"
     echo "  airc reminder <seconds>         Nudge if silent (off/pause/300)"
     echo "  airc peers                      List connected peers"
+    echo "  airc status [--probe]           Liveness: monitor, queue, last send/recv (add --probe for SSH check)"
     echo "  airc doctor [tabs|scope|all]    Self-test: pairing, send, rename, scope"
     echo "  airc teardown [--flush]         Kill local airc processes (and wipe state with --flush)"
     echo ""

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -584,6 +584,60 @@ json.dump(c, open(p, 'w'))
   cleanup_all
 }
 
+scenario_status() {
+  section "status: liveness view reflects identity, monitor, queue, last-activity"
+  cleanup_all
+
+  spawn_host /tmp/airc-it-s-h shost 7549 || { fail "shost failed to start"; return; }
+  local join; join=$(read_join_string /tmp/airc-it-s-h)
+  spawn_joiner /tmp/airc-it-s-j sjoiner "$join" || { fail "sjoiner join failed"; return; }
+  sleep 2
+
+  # Host status: should show "hosting on port 7549" + monitor running
+  local h_out
+  h_out=$(AIRC_HOME=/tmp/airc-it-s-h/state "$AIRC" status 2>&1)
+  echo "$h_out" | grep -q 'hosting on port 7549' && pass "host status: identity line reads 'hosting on port 7549'" \
+                                                 || fail "host status missing port (got: $h_out)"
+  echo "$h_out" | grep -Eq 'monitor:\s+running' && pass "host status: monitor shown running" \
+                                                || fail "host status: monitor not shown running"
+  echo "$h_out" | grep -q 'queue:.*empty' && pass "host status: queue empty (no pending)" \
+                                          || fail "host status: queue line wrong"
+
+  # Joiner status: should show "joiner of shost"
+  local j_out
+  j_out=$(AIRC_HOME=/tmp/airc-it-s-j/state "$AIRC" status 2>&1)
+  echo "$j_out" | grep -q 'joiner of' && pass "joiner status: identity line shows joiner role" \
+                                      || fail "joiner status missing joiner-of line (got: $j_out)"
+  echo "$j_out" | grep -q ':7549' && pass "joiner status: host port visible" \
+                                  || fail "joiner status missing host port"
+
+  # Send a message then assert status reflects activity
+  as_home /tmp/airc-it-s-j send @shost "status-probe" >/dev/null 2>&1
+  sleep 1
+  local j_out2; j_out2=$(AIRC_HOME=/tmp/airc-it-s-j/state "$AIRC" status 2>&1)
+  echo "$j_out2" | grep -Eq 'last send:\s+[0-9]+s ago' && pass "joiner status: last-send shows elapsed seconds" \
+                                                       || fail "joiner status: last send not updated (got: $(echo "$j_out2" | grep 'last send'))"
+
+  # Pending queue: simulate an outage by flipping host_target and sending, then assert queue size.
+  # Reuse the same fake-target pattern as scenario_queue.
+  python3 -c "
+import json
+p = '/tmp/airc-it-s-j/state/config.json'
+c = json.load(open(p))
+c['_real_host_target'] = c['host_target']
+c['host_target'] = 'nobody@127.0.0.99'
+json.dump(c, open(p, 'w'))
+"
+  echo '{"name":"shost","host":"nobody@127.0.0.99","airc_home":"/tmp/nowhere"}' > /tmp/airc-it-s-j/state/peers/shost.json
+  AIRC_HOME=/tmp/airc-it-s-j/state "$AIRC" send @shost "status-queue-probe" >/dev/null 2>&1 || true
+  local j_out3; j_out3=$(AIRC_HOME=/tmp/airc-it-s-j/state "$AIRC" status 2>&1)
+  echo "$j_out3" | grep -Eq 'queue:\s+[1-9][0-9]* pending' \
+    && pass "joiner status: queue shows 1+ pending after outage send" \
+    || fail "joiner status: queue line didn't reflect pending (got: $(echo "$j_out3" | grep 'queue'))"
+
+  cleanup_all
+}
+
 case "$MODE" in
   tabs)        scenario_tabs  ;;
   scope)       scenario_scope ;;
@@ -592,8 +646,9 @@ case "$MODE" in
   resilience)  scenario_resilience ;;
   reconnect)   scenario_reconnect ;;
   queue)       scenario_queue ;;
-  all)         scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|all]"; exit 2 ;;
+  status)      scenario_status ;;
+  all)         scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary

Adds `airc status` — a one-command snapshot of mesh health. Last visible-resilience item on #7's umbrella list.

### Example — joiner

\`\`\`
$ airc status
  airc status — scope /Users/you/project/.airc
  identity:    m5-test (joiner of host-abc @ you@100.91.51.87:7547)
  monitor:     running (PID 50580)
  last send:   94s ago
  last recv:   156s ago
  queue:       empty
  reminder:    every 300s
\`\`\`

### Example — host

\`\`\`
$ airc status
  identity:    host-abc (hosting on port 7547)
  monitor:     running (PID 12345)
  ...
\`\`\`

### Opt-in SSH reachability probe

\`\`\`
$ airc status --probe
  ...
  host:        reachable
\`\`\`

3s \`ConnectTimeout\` + \`BatchMode=yes\` — never hangs the terminal. Kept off-by-default so the plain \`airc status\` stays instant.

## Fields

| Field | Source |
|---|---|
| identity + role | `get_name` + `host_target` presence |
| monitor | ALL PIDs in `airc.pid`, alive if ANY is; reports "stale pidfile" with hint to run `airc connect` |
| last send | `AIRC_WRITE_DIR/last_sent` (written by `cmd_send`) |
| last recv | newest inbound in local `messages.jsonl` (filters own name + system 'airc' source) |
| queue | line count of `pending.jsonl` |
| reminder | off / paused / every Ns |

## Test plan

- [x] Hand-tested against a live mesh (joiner + host modes, pending queue populated)
- [x] New `scenario_status` (7 assertions): identity line, monitor line, queue empty, joiner role visible, last-send reflects activity, queue shows pending after simulated outage send
- [x] Full suite: **62/62** (was 55/55)

## Related

- Closes item 3 of #7 umbrella (\"\`airc status\` liveness view\")
- Complements #12 (pending-queue feature — status surfaces the queue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)