### PR TITLE
HOTFIX: cmd_send silently queued auth failures — memento couldn't reach host after reinstall

### DIFF
--- a/airc
+++ b/airc
@@ -986,13 +986,41 @@ cmd_send() {
       # `airc logs` makes the state obvious. Don't die() — queued is a form of
       # success. The user's shell scripts can still check pending.jsonl if
       # they need to block on delivery.
-      local stderr; stderr=$(tr '\n' ' ' < "$err" | sed 's/"/\\"/g' | cut -c1-200)
+      # Distinguish auth failures (user must re-pair — retrying won't help)
+      # from network failures (queue + retry makes sense). Prior behavior
+      # silently queued both the same way, hiding auth errors behind a
+      # misleading "Host unreachable" message. This bit the cross-mesh
+      # coordination: fresh-install joiner's SSH key wasn't in host's
+      # authorized_keys, cmd_send queued + returned 0, the joiner thought
+      # their send succeeded when the host never saw anything.
+      local stderr_raw; stderr_raw=$(cat "$err" 2>/dev/null)
+      local stderr; stderr=$(printf '%s' "$stderr_raw" | tr '\n' ' ' | sed 's/"/\\"/g' | cut -c1-300)
       rm -f "$err"
+
+      local is_auth_fail=0
+      if echo "$stderr_raw" | grep -qiE 'permission denied|publickey|host key verification|authentication fail|identification has changed|no supported authentication'; then
+        is_auth_fail=1
+      fi
+
+      if [ "$is_auth_fail" = "1" ]; then
+        local fail_marker; fail_marker=$(printf '{"from":"airc","ts":"%s","msg":"[AUTH FAILED to %s — repair required, NOT queued] %s"}' \
+          "$(timestamp)" "$peer_name" "${stderr:-no stderr}")
+        echo "$fail_marker" >> "$MESSAGES"
+        echo "  SSH auth to host FAILED. Message NOT queued — every retry would fail identically." >&2
+        echo "  SSH stderr: ${stderr}" >&2
+        echo "  Fix: airc teardown --flush && airc connect <invite-string>" >&2
+        die "Authentication failure — re-pair required"
+      fi
+
+      # Network-class wire failure: legitimately transient, queue for retry.
       echo "$full_msg" >> "$AIRC_WRITE_DIR/pending.jsonl"
-      local queue_marker; queue_marker=$(printf '{"from":"airc","ts":"%s","msg":"[QUEUED to %s — host unreachable, will retry] %s"}' \
+      local queue_marker; queue_marker=$(printf '{"from":"airc","ts":"%s","msg":"[QUEUED to %s — network error, will retry] %s"}' \
         "$(timestamp)" "$peer_name" "${stderr:-no stderr}")
       echo "$queue_marker" >> "$MESSAGES"
-      echo "  Host unreachable — message queued for retry. Monitor will flush when host returns." >&2
+      echo "  Network error reaching host — message queued for retry. Monitor will flush when host returns." >&2
+      # Surface the actual stderr so the user understands WHY — the old
+      # generic "host unreachable" was hiding real errors.
+      echo "  SSH stderr: ${stderr:-<none>}" >&2
     else
       rm -f "$err"
     fi

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -638,17 +638,88 @@ json.dump(c, open(p, 'w'))
   cleanup_all
 }
 
+scenario_auth_failure() {
+  section "auth_failure: fresh-install joiner with stale authorized_keys must fail LOUDLY"
+  cleanup_all
+
+  # This scenario mimics the exact situation memento hit today: a joiner
+  # reinstalls airc (regenerating identity keys), then runs `airc connect`
+  # with no args (resume from saved pairing). The host still has the OLD
+  # authorized_keys, so SSH auth fails. Pre-this-fix, cmd_send silently
+  # queued with a misleading "Host unreachable" message and exit 0 — the
+  # user thought their send succeeded when nothing reached the host.
+  #
+  # Correct behavior: auth failure is fundamentally different from a
+  # transient network error. Retry won't help — every attempt auths with
+  # the same (wrong) key. Must die() with clear stderr + repair instructions.
+
+  spawn_host /tmp/airc-it-af-h afhost 7549 || { fail "afhost failed to start"; return; }
+  local join; join=$(read_join_string /tmp/airc-it-af-h)
+  spawn_joiner /tmp/airc-it-af-j afjoiner "$join" || { fail "afjoiner join failed"; return; }
+  sleep 3
+
+  # Baseline: normal send works (pair-handshake added joiner's key).
+  as_home /tmp/airc-it-af-j send @afhost "pre-reinstall" >/dev/null 2>&1 \
+    && pass "baseline: send to host works after fresh pair" \
+    || { fail "baseline send broken — can't set up auth-fail test"; return; }
+
+  # ── Simulate joiner reinstall: regenerate identity keys in-place,
+  # keeping config.json (host_target etc) intact so `airc connect` with no
+  # args resumes with the stale host pairing. Host's authorized_keys still
+  # has the ORIGINAL joiner key, not the new one.
+  rm -f /tmp/airc-it-af-j/state/identity/ssh_key \
+        /tmp/airc-it-af-j/state/identity/ssh_key.pub
+  ssh-keygen -t ed25519 -f /tmp/airc-it-af-j/state/identity/ssh_key \
+             -N '' -q -C 'airc-fresh-reinstall' 2>/dev/null
+
+  # ── The test: joiner tries `airc send`. Expected: die loudly with
+  # auth stderr + repair instructions. NOT silent queue.
+  local err_file; err_file=$(mktemp -t airc-af-err.XXXXXX)
+  AIRC_HOME=/tmp/airc-it-af-j/state "$AIRC" send @afhost "post-reinstall" >/dev/null 2>"$err_file"
+  local af_exit=$?
+
+  [ $af_exit -ne 0 ] && pass "auth failure: cmd_send exits non-zero (was $af_exit)" \
+                     || fail "auth failure: cmd_send exited 0 — silent regression"
+
+  grep -qiE 'auth|permission|publickey' "$err_file" \
+    && pass "auth failure: stderr surfaces the actual SSH error" \
+    || fail "auth failure: stderr doesn't mention auth (got: $(cat "$err_file"))"
+
+  grep -qE 'teardown --flush|re-pair|invite' "$err_file" \
+    && pass "auth failure: stderr tells user HOW to fix (re-pair command)" \
+    || fail "auth failure: no repair guidance in stderr (got: $(cat "$err_file"))"
+
+  # Critically: message must NOT have been queued. Every retry would fail
+  # the same way, so queuing creates user confusion + log spam.
+  if [ -f /tmp/airc-it-af-j/state/pending.jsonl ]; then
+    grep -q 'post-reinstall' /tmp/airc-it-af-j/state/pending.jsonl \
+      && fail "auth failure: message WAS queued — will retry-fail forever" \
+      || pass "auth failure: message not queued (correct — retry wouldn't help)"
+  else
+    pass "auth failure: no pending.jsonl created (correct — retry wouldn't help)"
+  fi
+
+  # And the host's messages.jsonl must NOT contain the post-reinstall message.
+  grep -q 'post-reinstall' /tmp/airc-it-af-h/state/messages.jsonl 2>/dev/null \
+    && fail "auth failure: message somehow reached host (how? auth was broken)" \
+    || pass "auth failure: host correctly never received the message"
+
+  rm -f "$err_file"
+  cleanup_all
+}
+
 case "$MODE" in
-  tabs)        scenario_tabs  ;;
-  scope)       scenario_scope ;;
-  teardown)    scenario_teardown ;;
-  reminder)    scenario_reminder ;;
-  resilience)  scenario_resilience ;;
-  reconnect)   scenario_reconnect ;;
-  queue)       scenario_queue ;;
-  status)      scenario_status ;;
-  all)         scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|all]"; exit 2 ;;
+  tabs)         scenario_tabs  ;;
+  scope)        scenario_scope ;;
+  teardown)     scenario_teardown ;;
+  reminder)     scenario_reminder ;;
+  resilience)   scenario_resilience ;;
+  reconnect)    scenario_reconnect ;;
+  queue)        scenario_queue ;;
+  status)       scenario_status ;;
+  auth_failure) scenario_auth_failure ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## The bug

#12 queued ALL wire failures identically. After memento reinstalled airc today (regenerating keys), their SSH key wasn't in the host's authorized_keys. Every send:

1. SSH'd to host → `Permission denied (publickey)`
2. cmd_send: no `__APPENDED__` marker → wire-failure branch
3. Queued to pending.jsonl
4. Printed "Host unreachable — message queued for retry"
5. Exit 0

Memento thought sends succeeded. Host never saw any of them. Retries would fail the same way forever (same bad key). Every ping I was waiting for was invisibly destined to bounce.

## Fix

Detect auth-class failures via stderr substring match (`permission denied`, `publickey`, `host key verification`, `authentication fail`, `identification has changed`, `no supported authentication`). If matched:

- `[AUTH FAILED]` marker (not `[QUEUED]`)
- Print SSH stderr to user's terminal
- Print fix instructions: `airc teardown --flush && airc connect <invite-string>`
- `die` with exit 1

Non-auth wire failures (timeout, refused) still queue + retry. But now they also print the SSH stderr to the user so the error surface is honest.

## New test: `scenario_auth_failure`

Simulates memento's exact setup:

1. Host + joiner, baseline send works
2. Regenerate joiner's SSH key in-place (mimics reinstall)
3. Joiner's config still has saved host pairing (resume path)
4. Joiner calls `airc send`

Asserts: exit non-zero, stderr mentions auth, stderr has repair command, message NOT queued, host's log unchanged.

**Validated against pre-fix binary — 4 of 6 assertions FAIL pre-fix, proving it catches the regression.**

## Why this wasn't caught before

`scenario_tabs` spawns host + joiner in the same process with clean pair-handshake. Happy path. It never exercised a fresh joiner identity against stale authorized_keys. That was the gap. The class of test was missing — this PR adds it.

## Suite

- Before: 62/62
- After: **68/68**
- Ran the new scenario against pre-fix binary → 2/6 (exactly the 2 trivially-passing assertions; 4 of the user-facing assertions fail)

## Ship?

Yes, urgent — coordination between me + memento via airc is broken until this merges. Self-merging unless you say hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)