### PR TITLE
HOTFIX: auth probe on resume — no more silent retry loop on stale auth

### DIFF
--- a/airc
+++ b/airc
@@ -536,6 +536,47 @@ cmd_connect() {
     if [ -n "$prior_host_target" ]; then
       local prior_name; prior_name=$(get_config_val host_name "$(get_config_val name unknown)")
       echo "  Resuming as joiner of '$prior_name' ($prior_host_target)..."
+
+      # Auth probe BEFORE committing to the monitor loop. Prior behavior
+      # went straight into tail-over-SSH; if auth was broken (stale keys
+      # after reinstall, authorized_keys rotation on host), ssh exited 255
+      # silently, the while loop retried forever, and the user's mesh was
+      # dead without any visible error. This was the "default broken" path:
+      # `airc teardown` + `airc connect` (no args = resume) is what every
+      # user does, and it silently bricked on stale auth.
+      local probe_key="$IDENTITY_DIR/ssh_key"
+      local probe_err; probe_err=$(mktemp -t airc-resume-probe.XXXXXX)
+      local probe_out
+      probe_out=$(ssh -i "$probe_key" -o StrictHostKeyChecking=accept-new \
+                      -o ConnectTimeout=5 -o BatchMode=yes \
+                      "$prior_host_target" "echo __AUTH_OK__" 2>"$probe_err" || true)
+      if ! echo "$probe_out" | grep -q '^__AUTH_OK__$'; then
+        local probe_stderr; probe_stderr=$(cat "$probe_err" 2>/dev/null | tr '\n' ' ' | cut -c1-300)
+        rm -f "$probe_err"
+        # Auth failure → re-pair needed. Network failure → fall through,
+        # monitor's retry loop handles transient outages correctly.
+        if echo "$probe_stderr" | grep -qiE 'permission denied|publickey|host key verification|authentication fail|identification has changed|no supported authentication'; then
+          echo "  SSH auth to host FAILED on resume. Saved pairing is stale." >&2
+          echo "  SSH stderr: ${probe_stderr}" >&2
+          echo "  Fix: airc teardown --flush && airc connect <invite-string>" >&2
+          # Reconstruct the invite string from saved config as a convenience.
+          local host_ssh_pub; host_ssh_pub=$(get_config_val host_ssh_pub "")
+          local host_port; host_port=$(get_config_val host_port 7547)
+          if [ -n "$host_ssh_pub" ] && [ -n "$prior_name" ]; then
+            local pub_b64; pub_b64=$(printf '%s\n' "$host_ssh_pub" | base64 | tr -d '\n')
+            local suffix=""; [ "$host_port" != "7547" ] && suffix=":$host_port"
+            echo "  Your saved invite string (for the above command):" >&2
+            echo "    ${prior_name}@${prior_host_target}${suffix}#${pub_b64}" >&2
+          fi
+          die "Resume aborted — re-pair required"
+        else
+          echo "  Host probe failed (non-auth). Monitor will retry in background." >&2
+          echo "  SSH stderr: ${probe_stderr:-<none>}" >&2
+        fi
+      else
+        rm -f "$probe_err"
+      fi
+
       echo $$ > "$AIRC_WRITE_DIR/airc.pid"
       trap '
         rm -f "$AIRC_WRITE_DIR/airc.pid" 2>/dev/null

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -708,6 +708,84 @@ scenario_auth_failure() {
   cleanup_all
 }
 
+scenario_resume_stale_auth() {
+  section "resume_stale_auth: teardown + resume with stale SSH key must fail LOUDLY, not silently"
+  cleanup_all
+
+  # This is the "default broken" path joel flagged. A user runs `airc teardown`
+  # (without --flush, so saved pairing stays) and then `airc connect` (no args,
+  # resume path). If their SSH key has been invalidated on the host — by a
+  # reinstall regenerating identity keys, by authorized_keys rotation, by ANY
+  # cause — the old resume path silently started a tail loop that retried
+  # forever while the user waited for a mesh that was never coming back.
+
+  spawn_host /tmp/airc-it-rsa-h rsahost 7549 || { fail "rsahost failed to start"; return; }
+  local join; join=$(read_join_string /tmp/airc-it-rsa-h)
+  spawn_joiner /tmp/airc-it-rsa-j rsajoiner "$join" || { fail "rsajoiner join failed"; return; }
+  sleep 3
+
+  # Baseline: confirm fresh pair works
+  as_home /tmp/airc-it-rsa-j send @rsahost "baseline" >/dev/null 2>&1 \
+    && pass "baseline: fresh pair works" || { fail "baseline broken"; return; }
+
+  # ── Simulate the stale-auth state: kill the joiner (non-flush — preserves
+  # config.json + identity + peer records), then regenerate the identity key
+  # BEHIND the host's back (the host's authorized_keys still has the old key).
+  AIRC_HOME=/tmp/airc-it-rsa-j/state AIRC_PORT=7549 "$AIRC" teardown >/dev/null 2>&1
+  sleep 1
+  rm -f /tmp/airc-it-rsa-j/state/identity/ssh_key \
+        /tmp/airc-it-rsa-j/state/identity/ssh_key.pub
+  ssh-keygen -t ed25519 -f /tmp/airc-it-rsa-j/state/identity/ssh_key \
+             -N '' -q -C 'airc-stale-post-reinstall' 2>/dev/null
+
+  # ── Now attempt a resume. PRE-FIX: silently starts a tail loop that
+  # retries forever. POST-FIX: auth probe detects the stale key and dies.
+  local resume_out; resume_out=$(mktemp -t airc-rsa-out.XXXXXX)
+  local resume_err; resume_err=$(mktemp -t airc-rsa-err.XXXXXX)
+  # Background with a timeout so the pre-fix silent-loop doesn't hang the test.
+  ( AIRC_HOME=/tmp/airc-it-rsa-j/state "$AIRC" connect >"$resume_out" 2>"$resume_err" ) &
+  local resume_pid=$!
+  # Give it up to 10s to either exit (post-fix) or go silent into the tail
+  # retry loop (pre-fix — we'll kill it).
+  local exited=0 i
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 1
+    if ! kill -0 $resume_pid 2>/dev/null; then exited=1; break; fi
+  done
+  if [ "$exited" = "0" ]; then
+    # Still running after 10s — pre-fix behavior. Kill it, record the failure.
+    kill -9 $resume_pid 2>/dev/null
+    fail "resume_stale_auth: connect still running after 10s — silent retry loop (pre-fix bug)"
+  else
+    pass "resume_stale_auth: connect exited promptly (${i}s) rather than silently looping"
+  fi
+
+  wait $resume_pid 2>/dev/null
+  local resume_exit=$?
+
+  # Post-fix expectations
+  if [ "$resume_exit" -ne 0 ]; then
+    pass "resume_stale_auth: connect exited non-zero ($resume_exit) on stale auth"
+  else
+    fail "resume_stale_auth: connect exited 0 despite broken auth"
+  fi
+
+  grep -qiE 'auth|permission|publickey' "$resume_err" \
+    && pass "resume_stale_auth: stderr surfaces the SSH auth error" \
+    || fail "resume_stale_auth: stderr doesn't mention auth (got: $(cat "$resume_err"))"
+
+  grep -qE 'teardown --flush' "$resume_err" \
+    && pass "resume_stale_auth: stderr tells user HOW to fix" \
+    || fail "resume_stale_auth: no --flush repair command in stderr"
+
+  grep -qE 'invite string' "$resume_err" \
+    && pass "resume_stale_auth: stderr reconstructs the saved invite string for convenience" \
+    || fail "resume_stale_auth: no reconstructed invite string in stderr"
+
+  rm -f "$resume_out" "$resume_err"
+  cleanup_all
+}
+
 case "$MODE" in
   tabs)         scenario_tabs  ;;
   scope)        scenario_scope ;;
@@ -718,8 +796,9 @@ case "$MODE" in
   queue)        scenario_queue ;;
   status)       scenario_status ;;
   auth_failure) scenario_auth_failure ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|all]"; exit 2 ;;
+  resume_stale_auth) scenario_resume_stale_auth ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## The default-broken path

\`airc teardown\` (no --flush) + \`airc connect\` (no args = resume) is what every user types. If the saved SSH key is stale for any reason — rotation, reinstall, authorized_keys change — the old resume path:

1. prints \"Resuming as joiner of X...\"
2. jumps into monitor()
3. runs \`while true; do ssh ... tail -F ... || true; sleep 3; done\`
4. SSH returns 255 on auth fail silently
5. \`|| true\` swallows it
6. loop retries forever, stderr gone

Net: mesh dead, user has no error, no clue how to recover. This is what bit memento.

## Fix

Probe SSH auth BEFORE entering the monitor loop:
\`\`\`
ssh -o ConnectTimeout=5 -o BatchMode=yes <host> \"echo __AUTH_OK__\"
\`\`\`

- Probe succeeds → continue to monitor (existing behavior)
- Probe fails with auth stderr → print stderr, print fix command, reconstruct saved invite string from config, die
- Probe fails with non-auth stderr → fall through to monitor (transient outages are what the retry loop is for), warn first so user knows why

## Test: \`scenario_resume_stale_auth\`

Simulates exact user flow: fresh pair → baseline works → \`airc teardown\` → regenerate ssh_key → \`airc connect\` (resume). Asserts the resume dies fast with full diagnostic.

Validated against pre-fix binary: **4 of 6 assertions fail**, including \"connect still running after 10s — silent retry loop (pre-fix bug)\". Post-fix: 6/6 green, dies in 1 second.

Full suite: **74/74** (was 68/68).

## Not in this PR (acknowledged)

- Auto-re-pair. User still types the command themselves. Safer for now.
- Sandboxed test harness. Integration tests still pollute \`~/.ssh/authorized_keys\` (102 test entries were accumulated when I started today). Separate follow-up: isolated sshd for integration.sh + Docker containers for true multi-machine e2e.

Refs #17, airc coordination outage 2026-04-15.