### PR TITLE
fix(docs): skills are /<name>, not /airc:<name>

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ Done. Both machines are paired, monitoring, and talking. SSH keys exchange autom
 
 **Machine A:**
 ```
-/airc:connect
+/connect
 ```
 
 **Machine B — paste the join string:**
 ```
-/airc:connect <join-string>
+/connect <join-string>
 ```
 
 Skills install, pair, and stream inbound as notifications. No Monitor incantation, no env-var juggling, no polling loop.
@@ -150,20 +150,20 @@ airc doctor [tabs|scope|reminder|teardown]  # integration suite
 
 | Skill | Command | What it does |
 |-------|---------|-------------|
-| [connect](skills/connect/) | `/airc:connect [join]` | Host, join, or resume prior pairing |
-| [resume](skills/resume/) | `/airc:resume` | Explicit resume (alias for connect with no args) |
-| [send](skills/send/) | `/airc:send [@peer] <msg>` | Broadcast by default; `@peer` prefix for DM |
-| [send-file](skills/send-file/) | `/airc:send-file <peer> <path>` | File over scp with airc identity |
-| [rename](skills/rename/) | `/airc:rename <new>` | Rename, broadcasts `[rename]` to paired peers |
-| [peers](skills/peers/) | `/airc:peers [--prune]` | List peers; prune cleans stale records |
-| [logs](skills/logs/) | `/airc:logs [N]` | Tail the shared log |
-| [invite](skills/invite/) | `/airc:invite` | Print current mesh's join string |
-| [reminder](skills/reminder/) | `/airc:reminder <seconds\|off\|pause>` | Control silence-nudge |
-| [disconnect](skills/disconnect/) | `/airc:disconnect` | Leave mesh, keep identity |
-| [teardown](skills/teardown/) | `/airc:teardown [--flush]` | Kill scope's processes |
-| [update](skills/update/) | `/airc:update` | Pull latest + refresh skills |
-| [version](skills/version/) | `/airc:version` | Short sha + install path |
-| [doctor](skills/doctor/) | `/airc:doctor [scenario]` | Integration suite |
+| [connect](skills/connect/) | `/connect [join]` | Host, join, or resume prior pairing |
+| [resume](skills/resume/) | `/resume` | Explicit resume (alias for connect with no args) |
+| [send](skills/send/) | `/send [@peer] <msg>` | Broadcast by default; `@peer` prefix for DM |
+| [send-file](skills/send-file/) | `/send-file <peer> <path>` | File over scp with airc identity |
+| [rename](skills/rename/) | `/rename <new>` | Rename, broadcasts `[rename]` to paired peers |
+| [peers](skills/peers/) | `/peers [--prune]` | List peers; prune cleans stale records |
+| [logs](skills/logs/) | `/logs [N]` | Tail the shared log |
+| [invite](skills/invite/) | `/invite` | Print current mesh's join string |
+| [reminder](skills/reminder/) | `/reminder <seconds\|off\|pause>` | Control silence-nudge |
+| [disconnect](skills/disconnect/) | `/disconnect` | Leave mesh, keep identity |
+| [teardown](skills/teardown/) | `/teardown [--flush]` | Kill scope's processes |
+| [update](skills/update/) | `/update` | Pull latest + refresh skills |
+| [version](skills/version/) | `/version` | Short sha + install path |
+| [doctor](skills/doctor/) | `/doctor [scenario]` | Integration suite |
 
 ## Identity & State
 

--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ if [ -d "$CLONE_DIR/skills" ]; then
       rm "$target"
     fi
     ln -sf "$skill_dir" "$target"
-    ok "Skill: /airc:$skill_name"
+    ok "Skill: /$skill_name"
   done
 fi
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -13,8 +13,8 @@ curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh |
 Then in any Claude Code tab:
 
 ```
-/airc:connect                  # host — Claude prints the join string
-/airc:connect <join-string>    # join an existing host
+/connect                  # host — Claude prints the join string
+/connect <join-string>    # join an existing host
 ```
 
 The skill spawns `airc connect` under the Monitor tool, so inbound messages surface as notifications inside Claude Code automatically.
@@ -23,12 +23,12 @@ The skill spawns `airc connect` under the Monitor tool, so inbound messages surf
 
 | Skill | What it does |
 |-------|-------------|
-| `/airc:connect [join]` | Host or join — pairs and starts streaming inbound |
-| `/airc:send <peer> <msg>` | Send (peer is required); mirror-first, `[SEND FAILED]` marker on wire failure |
-| `/airc:rename <new>` | Rename this identity, broadcasts `[rename]` to paired peers |
-| `/airc:send-file <peer> <path>` | Send a file via scp under the airc identity key |
-| `/airc:doctor [scenario]` | Run the integration suite (33 assertions) |
-| `/airc:teardown [--flush]` | Kill THIS scope's airc processes (and wipe state with --flush) |
+| `/connect [join]` | Host or join — pairs and starts streaming inbound |
+| `/send <peer> <msg>` | Send (peer is required); mirror-first, `[SEND FAILED]` marker on wire failure |
+| `/rename <new>` | Rename this identity, broadcasts `[rename]` to paired peers |
+| `/send-file <peer> <path>` | Send a file via scp under the airc identity key |
+| `/doctor [scenario]` | Run the integration suite (33 assertions) |
+| `/teardown [--flush]` | Kill THIS scope's airc processes (and wipe state with --flush) |
 
 ## Manual Bash usage
 
@@ -41,4 +41,4 @@ Bash("airc send peerName 'message here'")
 
 ## Scope isolation
 
-Multiple Claude tabs can each run `/airc:connect` in different `AIRC_HOME` dirs — `airc teardown` only kills its own scope's processes. Validated by `/airc:doctor`.
+Multiple Claude tabs can each run `/connect` in different `AIRC_HOME` dirs — `airc teardown` only kills its own scope's processes. Validated by `/doctor`.

--- a/skills/connect/SKILL.md
+++ b/skills/connect/SKILL.md
@@ -28,7 +28,7 @@ Monitor(persistent=true, command="airc connect")
 ```
 
 The relay prints a join string. Show it to the user:
-> "Share this with the other peer: `/airc:connect <the join string>`"
+> "Share this with the other peer: `/connect <the join string>`"
 
 **Join mode** (one arg, the join string the host gave you):
 ```
@@ -56,10 +56,10 @@ Show them the platform-appropriate command. Don't make them research it.
 ## 4. After connecting
 
 - `airc peers` — list paired peers you can send to
-- `/airc:send <peer> <message>` — send to a specific peer
-- `/airc:rename <new-name>` — rename this identity; paired peers auto-update
-- `/airc:teardown` — kill this scope's airc processes (keep state for resume; add `--flush` to wipe)
-- `/airc:doctor` — self-diagnose: runs the integration suite
+- `/send <peer> <message>` — send to a specific peer
+- `/rename <new-name>` — rename this identity; paired peers auto-update
+- `/teardown` — kill this scope's airc processes (keep state for resume; add `--flush` to wipe)
+- `/doctor` — self-diagnose: runs the integration suite
 
 ## 5. Troubleshooting
 

--- a/skills/invite/SKILL.md
+++ b/skills/invite/SKILL.md
@@ -25,12 +25,12 @@ Show the output to the user like this:
 
 > "Paste this to the other agent:"
 > ```
-> /airc:connect <the join string>
+> /connect <the join string>
 > ```
 
 ## Failure modes
 
-- `ERROR: Not initialized. Run: airc connect` — you haven't paired yet, so there's nothing to share. Run `/airc:connect` first.
+- `ERROR: Not initialized. Run: airc connect` — you haven't paired yet, so there's nothing to share. Run `/connect` first.
 - `ERROR: Host info missing from config.` — your pairing state is incomplete (stale from a pre-feature install, or a partial pair). Teardown and re-pair: `airc teardown && airc connect <the original join string>`.
 
 ## When to use

--- a/skills/logs/SKILL.md
+++ b/skills/logs/SKILL.md
@@ -27,5 +27,5 @@ Prints one line per message: `[ts] from: msg`. Tails the host's shared `messages
 
 ## Notes
 
-- Output is read-only history. For live events, use `/airc:connect` (which wraps `airc connect` under Monitor so inbound surfaces as interrupts).
+- Output is read-only history. For live events, use `/connect` (which wraps `airc connect` under Monitor so inbound surfaces as interrupts).
 - Log reflects what the HOST saw, not just your local mirror. Canonical for the mesh.

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -26,9 +26,9 @@ Wrap with the Monitor tool so inbound streams as Claude Code notifications. `air
 
 ## Failure modes
 
-- `Not initialized (<scope>). Run: airc connect` — scope is fresh (no saved pairing). The user needs an actual join string from the host; use `/airc:connect <join>` instead.
+- `Not initialized (<scope>). Run: airc connect` — scope is fresh (no saved pairing). The user needs an actual join string from the host; use `/connect <join>` instead.
 
 ## Notes
 
 - `airc connect` (no args) and `airc resume` are the same command — `resume` is just a mnemonic alias.
-- Skills `/airc:connect` and `/airc:resume` both resolve to the same `airc connect` invocation; which one to use is a matter of user-facing intent ("I'm starting" vs "I'm coming back").
+- Skills `/connect` and `/resume` both resolve to the same `airc connect` invocation; which one to use is a matter of user-facing intent ("I'm starting" vs "I'm coming back").

--- a/skills/send/SKILL.md
+++ b/skills/send/SKILL.md
@@ -40,6 +40,6 @@ On failure: exit 1 with `ERROR: Failed to deliver to host (…)`. Common causes:
 
 ## Notes
 
-- `airc connect` must be running in a Monitor somewhere so inbound streams as notifications. If not connected, run `/airc:connect` first.
+- `airc connect` must be running in a Monitor somewhere so inbound streams as notifications. If not connected, run `/connect` first.
 - Every paired agent tails the host's log, so a `to=all` broadcast lands for everyone.
 - A `to=@peer` DM is still written to the same shared log — the `to` field is just a human-readable label, not a routing directive. Nothing hides inside airc.


### PR DESCRIPTION
install.sh symlinks flat to ~/.claude/skills/<name>, so the valid invocation is `/<name>` not `/airc:<name>`. Memento's tab typed `/airc:update` (following the docs), got "Unknown command", and had to guess `/update`. Docs now match reality.