### PR TITLE
skills+integrations: /repair skill, port-collision warning, error-class docs

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -24,11 +24,17 @@ The skill spawns `airc connect` under the Monitor tool, so inbound messages surf
 | Skill | What it does |
 |-------|-------------|
 | `/connect [join]` | Host or join — pairs and starts streaming inbound |
-| `/send <peer> <msg>` | Send (peer is required); mirror-first, `[SEND FAILED]` marker on wire failure |
+| `/send <peer> <msg>` | Send to a peer; mirror-first, queues on transient network failure, dies loud on auth failure |
 | `/rename <new>` | Rename this identity, broadcasts `[rename]` to paired peers |
 | `/send-file <peer> <path>` | Send a file via scp under the airc identity key |
-| `/doctor [scenario]` | Run the integration suite (33 assertions) |
-| `/teardown [--flush]` | Kill THIS scope's airc processes (and wipe state with --flush) |
+| `/doctor [scenario]` | Run the integration suite |
+| `/teardown [--flush]` | Kill THIS scope's airc processes (add `--flush` to also wipe state) |
+| `/repair [invite]` | **Nuclear re-pair** — `teardown --flush` + reconnect. Use when sends mysteriously don't reach anyone. |
+| `/status [--probe]` | Liveness view: monitor, queue, last send/recv, `--probe` does a fast auth check |
+
+## Common failure + fix
+
+If your mesh mysteriously goes quiet (no messages from peers, your sends seem to succeed but nobody responds), 90% of the time the cause is stale auth or port collision with another host on the same machine. Run `/repair` (optionally with a fresh invite string from the host). Don't iterate through `/teardown` + `/connect` — that sequence without `--flush` is specifically the path that silently leaves you broken.
 
 ## Manual Bash usage
 

--- a/integrations/cursor/README.md
+++ b/integrations/cursor/README.md
@@ -15,11 +15,16 @@ Then add to `.cursorrules`:
 
 ```
 You have access to AIRC, a peer-to-peer messaging fabric for agents.
-- Send: airc send <peer> "<message>"
+- Send: airc send @<peer> "<message>"   (or `airc send "<msg>"` to broadcast)
 - Inbound history: airc logs 20
 - Peers: airc peers
+- Status: airc status (add --probe for an auth check)
 - Live tail: airc monitor (run in the integrated terminal)
-Every send is mirrored locally first; failed deliveries leave a [SEND FAILED] marker in the log.
+Error handling:
+- Every send is mirrored locally first.
+- If a send dies with "Authentication failure — re-pair required", run `airc teardown --flush && airc connect <invite-string>` using the invite the error printed.
+- If a send says "queued for retry", the host is transiently unreachable; the monitor drains pending.jsonl when it comes back.
+- If messages seem to succeed but nobody receives them, you may be on the wrong host (port collision — run `airc peers` and check the host name).
 ```
 
 ## Usage

--- a/integrations/generic/README.md
+++ b/integrations/generic/README.md
@@ -10,11 +10,23 @@ AIRC uses JSONL (one JSON object per line) at `~/.airc/messages.jsonl` (or `$AIR
 {"from":"agentName","ts":"2026-04-13T12:00:00Z","msg":"hello","sig":"base64..."}
 ```
 
-Outbound sends are mirrored locally first; wire failures append a marker:
+Outbound sends are mirrored locally first; what happens on wire failure depends on the error class:
 
 ```json
-{"from":"airc","ts":"...","msg":"[SEND FAILED to peer] <stderr>"}
+// Network / transient — queued in pending.jsonl, flush loop will retry
+{"from":"airc","ts":"...","msg":"[QUEUED to peer — network error, will retry] <stderr>"}
+
+// Authentication — NOT queued, exits 1, re-pair required
+{"from":"airc","ts":"...","msg":"[AUTH FAILED to peer — repair required, NOT queued] <stderr>"}
+
+// New-peer-joined marker, emitted by host during pair handshake
+{"from":"airc","ts":"...","msg":"[joined] name=<peer> host=<user@host>"}
+
+// Peer-left marker, emitted by joiner's trap on exit
+{"from":"airc","ts":"...","msg":"[left] name=<peer>"}
 ```
+
+Watch for `[joined]` / `[left]` / `[rename]` / `[AUTH FAILED]` / `[QUEUED]` / `[DRAINED]` / `[REJECTED]` lines if your agent needs to react to mesh lifecycle events.
 
 ## Receiving
 

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -15,9 +15,20 @@ Then add to your project instructions so Codex knows the surface:
 
 ```
 You are paired on AIRC. Send messages with:
-  airc send <peer> "message"
-List peers with `airc peers`. Recent activity with `airc logs 20`.
-For a live tail of inbound messages, run `airc monitor` in a side terminal.
+  airc send @<peer> "message"         # DM
+  airc send "message"                 # broadcast
+List peers: airc peers
+Recent activity: airc logs 20
+Liveness snapshot: airc status
+Live tail of inbound messages: airc monitor (in a side terminal)
+
+Error handling:
+- Auth failures exit 1 with clear stderr and a repair command. Follow it verbatim
+  (`airc teardown --flush && airc connect <invite-string>`), don't retry the send.
+- Network failures queue automatically to pending.jsonl; the monitor's background
+  loop drains when the host comes back.
+- If messages seem to succeed but no peer ever responds, you may be paired with
+  the wrong host (port collision). Check `airc peers` and confirm the host name.
 ```
 
 ## Usage

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -15,12 +15,20 @@ Then add to your project's `AGENTS.md` (or equivalent opencode rules file) so th
 
 ```
 You are paired on AIRC, a peer-to-peer messaging fabric for agents.
-- Send: airc send <peer> "<message>"
+- Send: airc send @<peer> "<message>"   (DM) or `airc send "<msg>"` to broadcast
 - Inbound history: airc logs 20
 - Peers: airc peers
+- Status: airc status
 - Live tail: airc monitor (run in a side terminal)
-Every send is mirrored locally first; failed deliveries leave a
-[SEND FAILED] marker in the log so nothing is silently dropped.
+
+Error classes (read stderr):
+- "Authentication failure — re-pair required" → exit 1. Run
+  `airc teardown --flush && airc connect <invite-string>` using the
+  invite string the error output prints. Don't just retry the send.
+- "Network error reaching host — message queued for retry" → exit 0.
+  Queued in pending.jsonl; monitor's flush loop drains on reconnect.
+- "Pending queue at cap" → exit 1. Host has been unreachable too long;
+  repair the pairing or bump AIRC_PENDING_MAX.
 ```
 
 ## Usage

--- a/integrations/windsurf/README.md
+++ b/integrations/windsurf/README.md
@@ -15,10 +15,17 @@ Then add to your Windsurf rules:
 
 ```
 You are paired on AIRC. CLI surface:
-  airc send <peer> "<message>"   send a signed message
+  airc send @<peer> "<message>"  DM (add @ for DM, omit for broadcast)
   airc logs 10                   recent inbound + your own sends
   airc peers                     list paired peers
+  airc status                    liveness snapshot (queue, last activity)
   airc monitor                   live tail (run in a terminal)
+
+If a send fails, read stderr. Auth failures require re-pair
+(airc teardown --flush && airc connect <invite-string>); network
+failures queue automatically. If sends seem to succeed but no peer
+responds, check `airc peers` — you may have paired with the wrong
+host on a shared machine (port collision).
 ```
 
 ## Usage

--- a/skills/connect/SKILL.md
+++ b/skills/connect/SKILL.md
@@ -37,6 +37,10 @@ Monitor(persistent=true, command="airc connect <join-string>")
 
 Wait for the monitor's first event to confirm the pair succeeded.
 
+**Paste the join string VERBATIM.** If the host is on a non-default port (anything other than 7547 because of collisions on a shared machine), the port is in the invite string like `name@user@host:7548#...`. Trimming the `:7548` silently makes you pair with whoever happens to be on default 7547 — could be a different host entirely, and everything will look "connected" but you're talking to the wrong mesh. This happened in production and cost hours.
+
+After pairing, run `airc peers` and eyeball the host name it reports — if it's not who you expected, you hit the collision case.
+
 ## 3. Tell the human how to keep the mesh alive
 
 **The Monitor subprocess stops when the machine sleeps.** If the user's laptop goes to sleep (closed lid, idle timeout), the airc host on their machine dies silently. Every peer sees the same "mesh just went quiet" symptom even though nothing is wrong with airc itself.
@@ -68,4 +72,6 @@ The relay prints actual errors. Read them.
 - **SSH not working on host:** relay prints the exact sudo command. Show it to the user; they type `! sudo ...` to run it; retry.
 - **Can't reach host:** host isn't running `airc connect`, address is wrong, or Tailscale isn't up.
 - **Host went quiet after a long pause:** host machine probably went to sleep. See section 3 — tell the human to `caffeinate` (mac) / `systemd-inhibit` (linux) / disable idle sleep (windows). After they do, they need to `airc connect` again; monitor doesn't auto-resurrect from a sleep-killed process.
-- **Port collision on host:** set `AIRC_PORT=7548` in the host's environment before `airc connect`. The printed join string will carry the port automatically.
+- **Port collision on host:** set `AIRC_PORT=7548` in the host's environment before `airc connect`. The printed join string will carry the port automatically. Make sure joiners use the invite string WITH the port — trimming it makes them pair with whoever has the default port, which may not be you.
+- **Resume dies with "Resume aborted — re-pair required":** saved pairing has a stale SSH key. The error output includes the reconstructed invite string + the exact repair command. Run `airc teardown --flush && airc connect <that-invite-string>`.
+- **Pair handshake silently binds to wrong host:** if the invite points at port 7547 but somebody else's host is there, you pair with THEM. Symptom: your peer list looks right but nobody receives your messages. Fix: make sure the invite has an explicit port (`:NNNN` between host and `#`) and regenerate if missing.

--- a/skills/invite/SKILL.md
+++ b/skills/invite/SKILL.md
@@ -28,6 +28,10 @@ Show the output to the user like this:
 > /connect <the join string>
 > ```
 
+**Check the port before pasting.** The join string format is `name@user@host[:port]#pubkey`. If the port section is present (non-default — anything other than 7547), the other agent MUST paste it with the port intact. Trimming `:7548` silently makes them pair with whoever has port 7547, which may be a different host on the same Tailscale IP. This happened in production (cost hours to diagnose). When showing the invite to the user, call out the port explicitly if non-default:
+
+> "Paste this exactly — note the `:7548` port, don't trim it."
+
 ## Failure modes
 
 - `ERROR: Not initialized. Run: airc connect` — you haven't paired yet, so there's nothing to share. Run `/connect` first.

--- a/skills/repair/SKILL.md
+++ b/skills/repair/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: airc:repair
+description: Full re-pair of a stale airc mesh — `teardown --flush` + reconnect using the saved invite string. Use when your sends silently fail or `resume` reports stale auth.
+user-invocable: true
+allowed-tools: Bash, Monitor
+argument-hint: "[invite-string]"
+---
+
+# airc repair
+
+The one-command recovery for the most common airc failure: your saved pairing is stale (SSH key rotated, host regenerated identity, reinstall broke things, you accidentally paired with the wrong host because of a port collision). Runs the full nuclear repair sequence so you don't have to remember the flag names or hunt for the invite string.
+
+## Execute
+
+If `$ARGUMENTS` contains an invite string (looks like `name@user@host[:port]#<base64>`), use it directly. Otherwise reconstruct from the saved config before wiping.
+
+### Step 1 — extract the saved invite before wiping
+
+```bash
+# Grab the pieces the host wrote into config during the last pair.
+HOST_NAME=$(python3 -c "import json; print(json.load(open('$(airc debug-scope)/config.json')).get('host_name',''))" 2>/dev/null)
+HOST_TARGET=$(python3 -c "import json; print(json.load(open('$(airc debug-scope)/config.json')).get('host_target',''))" 2>/dev/null)
+HOST_PORT=$(python3 -c "import json; print(json.load(open('$(airc debug-scope)/config.json')).get('host_port',7547))" 2>/dev/null)
+HOST_PUB=$(python3 -c "import json; print(json.load(open('$(airc debug-scope)/config.json')).get('host_ssh_pub',''))" 2>/dev/null)
+PUB_B64=$(printf '%s\n' "$HOST_PUB" | base64 | tr -d '\n')
+
+if [ -n "$HOST_NAME" ] && [ -n "$HOST_TARGET" ] && [ -n "$HOST_PUB" ]; then
+  SUFFIX=""
+  [ "$HOST_PORT" != "7547" ] && SUFFIX=":$HOST_PORT"
+  INVITE="${HOST_NAME}@${HOST_TARGET}${SUFFIX}#${PUB_B64}"
+fi
+```
+
+If `$ARGUMENTS` was passed, override `$INVITE` with it — the user may be repairing to a new host.
+
+### Step 2 — teardown --flush
+
+```bash
+airc teardown --flush
+```
+
+Wipes identity, peer records, saved pairing, messages. State is gone.
+
+### Step 3 — reconnect with the invite
+
+```
+Monitor(persistent=true, command="airc connect $INVITE")
+```
+
+Fresh handshake, fresh identity keys get pushed to the host's authorized_keys, clean pair.
+
+## When to use
+
+- `airc connect` (resume) exited with `Resume aborted — re-pair required`.
+- `airc send` exited with `Authentication failure — re-pair required`.
+- You re-installed airc and your mesh stopped working.
+- You suspect you paired with the wrong host because of a port collision — `airc peers` reports a host name you didn't expect.
+- "Nothing works and I don't know why" — repair is the cheap nuclear option.
+
+## Failure modes
+
+- No invite reconstructable + none passed — config is too stale (missing `host_ssh_pub` or `host_target`). User needs a fresh invite from the host. Ask them to get `/invite` output from the host and pass it as the argument.
+- Repair succeeds but still no messages — you may genuinely be on the wrong host. Run `airc peers` and confirm the host name matches who you meant to pair with. If not, ask the host to paste their `/invite` output and try `/repair <that-invite>`.
+
+## Notes
+
+- This is intentionally destructive. Identity keys, peer records, message mirror — all gone. The messages on the shared host log survive; only YOUR local mirror resets.
+- Safer than guessing which flag to `airc teardown` with. Pre-repair-skill, users reliably typed `airc teardown` (no flush) + `airc connect` (resume) and silently stayed broken. Using this skill removes the footgun.

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -27,6 +27,8 @@ Wrap with the Monitor tool so inbound streams as Claude Code notifications. `air
 ## Failure modes
 
 - `Not initialized (<scope>). Run: airc connect` — scope is fresh (no saved pairing). The user needs an actual join string from the host; use `/connect <join>` instead.
+- `Resume aborted — re-pair required` — saved SSH key no longer authenticates against the host (reinstall regenerated keys, host rotated authorized_keys, etc.). The error output prints the exact repair command + reconstructs the saved invite string so the user doesn't have to hunt for it. Follow it verbatim: `airc teardown --flush && airc connect <invite-string>`.
+- Silent resume (monitor running but no inbound ever arrives): used to be a silent failure mode pre-fix. Now the auth probe catches it at connect time. If you somehow still see this, the host genuinely is unreachable — check `airc status --probe` to confirm.
 
 ## Notes
 

--- a/skills/send/SKILL.md
+++ b/skills/send/SKILL.md
@@ -33,10 +33,13 @@ airc send @alice quick question
 
 On success: exit 0. Message is written to the host's shared `messages.jsonl` over SSH AND mirrored to your own local mirror so `airc logs` shows the audit trail.
 
-On failure: exit 1 with `ERROR: Failed to deliver to host (…)`. Common causes:
-- SSH auth broken — try `airc teardown` and re-pair
-- Peer's host is down — they need to re-run `airc connect`
-- Wrong peer name — check `airc peers` for the canonical list
+On failure, read the stderr — it tells you which class:
+
+- **`Authentication failure — re-pair required`**: SSH key no longer authenticates against the host. Retry will fail identically. The stderr includes the exact repair command + reconstructed invite string. Run `airc teardown --flush && airc connect <invite-string>`.
+- **`Network error reaching host — message queued for retry`**: host is transiently unreachable. Message is queued in `pending.jsonl`; the monitor's flush loop will drain it automatically when the host comes back. Exit 0 in this case (queued = success for resilience purposes).
+- **`Pending queue at cap`**: host has been unreachable too long; queue hit `AIRC_PENDING_MAX` (default 10000). Either the host is permanently gone (you need to re-pair) or you need to bump the cap. Exit 1.
+
+Past guidance said "try `airc teardown` and re-pair" which is wrong — it needs `--flush` to actually wipe the stale state. See `/teardown` skill.
 
 ## Notes
 

--- a/skills/teardown/SKILL.md
+++ b/skills/teardown/SKILL.md
@@ -17,6 +17,19 @@ Run this yourself — don't ask the user. It's idempotent and scope-safe.
 - "Pair refused" / "Failed to deliver" errors that don't make sense — nuke and re-pair
 - Before `airc connect` with a new identity, to avoid pairing with your own stale listener
 
+## `--flush` vs plain teardown — when to use which
+
+**Plain `airc teardown`**: kills processes, keeps state. Use when you know the pairing is still valid and you just want to stop/restart the monitor (e.g. to pick up a new airc binary).
+
+**`airc teardown --flush`**: kills processes AND wipes identity, peer records, saved pairing, messages. Use in ANY of these cases:
+- `airc connect` (resume) died with "Resume aborted — re-pair required" (stale SSH key)
+- `airc send` died with auth error pointing at "re-pair required"
+- You just reinstalled airc and your identity keys may no longer be authorized on the host
+- You're not sure what's broken but you definitely can't reach your peers anymore
+- You're changing which host you pair with
+
+**Rule of thumb**: if anything about your pairing feels uncertain, use `--flush`. The nuclear option is cheap — you pair again via the invite string and keep going. The half-measure (plain teardown with stale state, then resume) has burned hours in production by silently reconnecting to a broken pairing.
+
 ## What it does
 
 ```bash


### PR DESCRIPTION
Today's bug tour crammed years of user pain into one day: port-7547 collision between two hosts on the same Tailscale IP, memento silently paired with the wrong host for hours, stale-auth resume looping invisibly, and the docs said \"try teardown and re-pair\" without \`--flush\` — the exact wrong advice.

The code fixes landed in #17 (auth-error surfacing), #18 (resume auth probe), and the port-collision diagnosis. This PR aligns **docs + skills** with the new reality so future users and agents don't hit the same footguns.

## New

- **`/repair` skill** — nuclear one-command re-pair: reconstructs the saved invite from config, runs `teardown --flush && connect`. Takes optional invite argument if you need to repair onto a new host.

## Updated skills

- `/connect` — paste invite VERBATIM including `:port`; troubleshooting covers the resume-auth-probe case + wrong-host-on-shared-machine
- `/teardown` — explicit rule for when to use `--flush` (the half-measure is a footgun)
- `/resume` — documents the auth probe + follow the repair command from stderr
- `/invite` — warns to include the port when non-default
- `/send` — replaced misleading \"try teardown and re-pair\" with the three actual error classes (auth / network / pending-cap) and correct repair for each

## Updated integrations

All six (claude-code, cursor, generic, openai-codex, opencode, windsurf) now document:
- Auth vs network error distinction
- Repair sequence
- Port-collision symptom
- Lifecycle markers ([joined], [left], [QUEUED], [DRAINED], [AUTH FAILED])

## Why now

After today's hotfixes, the error messages the code prints are correct. But the docs a user reads first still had the broken-by-default guidance. A user following old docs would follow the wrong repair path and stay broken.