### PR TITLE
fix(monitor): don't override cmd_connect trap — fixes #21 orphaned SSH tail + Python formatter

### DIFF
--- a/airc
+++ b/airc
@@ -184,7 +184,13 @@ monitor() {
   # back. No-op on host-mode (empty host_target short-circuits).
   ( flush_pending_loop ) &
   local flush_pid=$!
-  trap "kill $reminder_pid $flush_pid 2>/dev/null" EXIT INT TERM
+  # DO NOT replace the outer trap set by cmd_connect — it owns the airc.pid
+  # cleanup + whole-subtree child reap (SSH tail, Python formatter, this
+  # function's background loops). Overriding it here leaked those children
+  # as orphans whenever the outer shell exited, which kept the SSH session
+  # open on the remote and left inbound streaming visible-but-untracked.
+  # The `pgrep -P $$` in cmd_connect's trap picks up reminder_pid/flush_pid
+  # transitively, so nothing extra is needed here.
 
   # Stream inbound via `tail -n 0 -F` (inotify/kqueue) — no polling, every
   # new line surfaces the moment it's written. Joiner tails the host over


### PR DESCRIPTION
## Summary

`monitor()` was overriding the EXIT/INT/TERM trap that `cmd_connect` had set up to clean up `airc.pid` and reap every child via `pgrep -P \$\$`. The override only killed `reminder_pid` and `flush_pid`, leaving the SSH tail and Python `monitor_formatter` as orphans whenever the outer shell exited. Tools wrapping `airc connect` (e.g. Claude Code's Monitor) lost visibility of the inbound event stream while the SSH session kept running on the remote.

Full repro + diagnosis in #21.

## Fix

Remove the `trap` override inside `monitor()`. The trap installed by `cmd_connect` (resume, join, host branches all set it) already reaps `reminder_pid` / `flush_pid` transitively via `pgrep -P \$\$`, so no replacement is needed. Keeps the invariant that the outer shell owns all cleanup.

## Test plan

- [x] `bash -n airc` — syntax OK
- [x] Manual: currently running `airc connect` (resume) in an active session, fix is narrow (7 lines, comment + removed trap line)
- [ ] `./test-two-instance.sh` host/join roundtrip — requires port 7547 free; can't run while the active session holds it
- [ ] `./test/integration.sh tabs` — same

Shipping on the narrow diff. The semantics are a strict subset of the previous trap behaviour (`pgrep -P \$\$` covers what the removed override covered, plus the SSH tail + formatter that were being leaked).

Fixes #21