### PR TITLE
fix(monitor): inactivity watchdog — detect silently-dead SSH tails

### DIFF
--- a/airc
+++ b/airc
@@ -235,7 +235,24 @@ monitor() {
 monitor_formatter() {
   local my_name="$1"
   PEERS_DIR="$PEERS_DIR" python3 -u -c '
-import sys, json, os, re, time
+import sys, json, os, re, time, signal
+
+# Inactivity watchdog: if no inbound line arrives in WATCHDOG_SEC,
+# exit with a distinct code so the caller'\''s while-loop reconnects.
+# Why: the outer SSH tail can hang silently — middleboxes drop idle
+# TCP while still ACK'\''ing SSH ServerAlive keepalives, so SSH does
+# not notice the channel is dead, and tail -F never returns EOF. The
+# Python read just blocks forever. With an application-level watchdog,
+# a truly dead channel forces the formatter out and the reconnect loop
+# restarts the ssh. Normal chat traffic keeps resetting the alarm so
+# there is no penalty when the channel is healthy.
+WATCHDOG_SEC = 180
+def _watchdog_exit(signum, frame):
+    sys.stderr.write(f"[airc:monitor] no inbound in {WATCHDOG_SEC}s — restarting\\n")
+    sys.stderr.flush()
+    os._exit(2)
+signal.signal(signal.SIGALRM, _watchdog_exit)
+signal.alarm(WATCHDOG_SEC)
 
 peers_dir = os.environ.get("PEERS_DIR", "")
 scope_dir = os.path.dirname(peers_dir)
@@ -326,6 +343,9 @@ except Exception:
     pass
 
 for line in sys.stdin:
+    # Any inbound line — real message, heartbeat, whatever — means the
+    # channel is alive. Reset the watchdog.
+    signal.alarm(WATCHDOG_SEC)
     line = line.strip()
     if not line: continue
     offset_counter += 1


### PR DESCRIPTION
## Symptom

`airc status` reports `monitor: running` while `last_recv` climbs into the minutes. Messages stop being delivered. Teardown + `airc connect` restores flow. Observed repeatedly on 2026-04-20 in a multi-hour multi-agent session (memento + anvil); Joel called it out directly as the recurring productivity-killer.

## Root cause

SSH's `ServerAliveInterval` / `ServerAliveCountMax` only catches "no ACKs to keepalive packets." Some middleboxes / sleeping hosts / long-idle tailscale paths silently drop the TCP **payload** channel while still ACKing SSH keepalives at the TCP layer. SSH thinks the connection is healthy and does not close; the remote `tail -F` keeps running but its output never reaches the local ssh pipe. The local `monitor_formatter`'s Python `for line in sys.stdin:` blocks on read forever. Pipeline stays open, bash while-loop never iterates, status check sees a live PID and reports `running`.

The existing SSH keepalive options help but are insufficient for this class of failure.

## Fix

Application-level inactivity watchdog inside `monitor_formatter`. If no line arrives in `WATCHDOG_SEC` (180s — longer than typical chat idle, shorter than frustration threshold), Python exits non-zero via `os._exit(2)`. The pipeline closes, ssh exits, the while-loop's `|| true` catches it, \`sleep 3\`, reconnect.

Normal traffic resets the alarm on every inbound line — zero penalty for healthy channels. A stderr line surfaces the event so operators can see *why* the tail restarted, instead of the previous invisible silent hang.

## Test plan

- [x] \`bash -n airc\` — syntax OK
- [x] diff review — 21 lines added, 1 line removed, scoped to \`monitor_formatter\`
- [ ] Live: simulate network stall; verify monitor exits within 180s and reconnects

Pairs with #22 (trap preservation). Together they cover the long-tail of connection failures that do NOT trigger SSH's built-in detection.