### PR TITLE
fix(teardown): warn about stale state when no processes to kill (#25 bug 1)

### DIFF
--- a/airc
+++ b/airc
@@ -1304,7 +1304,36 @@ cmd_teardown() {
     fi
   fi
 
-  [ "$killed" = "0" ] && echo "  No airc processes running." || echo "  Teardown complete."
+  if [ "$killed" = "0" ]; then
+    echo "  No airc processes running."
+    # Don't leave the user thinking they're clean when on-disk state still
+    # routes to a dead host. If config.json carries a host_target pointing
+    # at a host that's been torn down and rebuilt, a subsequent `airc
+    # connect` auto-resumes to the stale target and enters a zombie
+    # reconnect loop. The user sees "last recv: stale hours" and has to
+    # discover --flush themselves. Surface the hint at teardown time —
+    # it's the only chance the user has to act on it before the next
+    # connect attempt.
+    if [ "$flush" = "0" ]; then
+      local dir="$AIRC_WRITE_DIR"
+      local has_stale_state=0
+      if [ -f "$dir/config.json" ]; then
+        # Any config at all is potentially stale — even host-mode configs
+        # carry identity tied to a port that might be taken on next boot.
+        has_stale_state=1
+      elif [ -d "$dir/peers" ] && [ -n "$(ls -A "$dir/peers" 2>/dev/null)" ]; then
+        has_stale_state=1
+      fi
+      if [ "$has_stale_state" = "1" ]; then
+        echo "  (state dir still populated: $dir)"
+        echo "  If your remote host was torn down or rebuilt, run:"
+        echo "    airc teardown --flush"
+        echo "  to wipe identity/peers/config before the next connect."
+      fi
+    fi
+  else
+    echo "  Teardown complete."
+  fi
 }
 
 cmd_disconnect() {


### PR DESCRIPTION
Fixes bug 1 of #25.

## Problem

\`airc teardown\` prints \`No airc processes running.\` when the monitor subprocess already died — which is the common case, because the process crash is usually how the user discovered the stall in the first place. But identity, peers, and \`config.json\`'s \`host_target\` all survive. The next \`airc connect\` auto-resumes to that stale \`host_target\` and silently zombie-loops against a dead host. Users learn the \`--flush\` incantation the hard way.

## Fix

When \`teardown\` didn't kill anything AND the state dir still has \`config.json\` or populated \`peers/\`, emit a hint:

\`\`\`
No airc processes running.
  (state dir still populated: /path/to/.airc)
  If your remote host was torn down or rebuilt, run:
    airc teardown --flush
  to wipe identity/peers/config before the next connect.
\`\`\`

No behavior change — the teardown still exits without touching state. Just closes the information gap between "you think you're clean" and "next connect is a zombie loop."

## Test

Manual:
- Fresh state, no processes → prints "No airc processes running." alone (unchanged).
- Stale \`config.json\` with no processes → prints the new hint block.
- Active processes → kills them, prints "Teardown complete." (unchanged).
- \`teardown --flush\` → wipes state, prints "flushing state: …" + "Teardown complete." (unchanged).

## Companion

Bug 2 of #25 (zombie reconnect-loop visibility in \`airc status\`) is its own PR to keep review surfaces small.