### PR TITLE
fix(monitor): surface zombie reconnect-loop in airc status (#25 bug 2)

### DIFF
--- a/airc
+++ b/airc
@@ -215,8 +215,41 @@ monitor() {
     local rhome; rhome=$(remote_home)
     local ssh_key="$IDENTITY_DIR/ssh_key"
     local ssh_opts="-i $ssh_key -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=3"
+    # Connection-health state surfaced to `airc status`. An attempt that
+    # returns in <MIN_HOLD_SEC is an immediate failure (connection refused,
+    # key reject, wrong port) — distinct from a held channel that later
+    # dropped. After FAST_FAIL_THRESHOLD consecutive fast failures we're
+    # zombie-looping against a dead host; status should say so instead of
+    # reporting "monitor: running" indefinitely.
+    local conn_state_file="$AIRC_WRITE_DIR/connection_state"
+    local MIN_HOLD_SEC=10
+    local FAST_FAIL_THRESHOLD=5
+    local fast_fail_count=0
+    local fast_fail_since=""
+    rm -f "$conn_state_file" 2>/dev/null
     while true; do
+      local attempt_start; attempt_start=$(date +%s)
       ssh $ssh_opts "$host_target" "tail $tail_pos -F $rhome/messages.jsonl 2>/dev/null" 2>/dev/null | monitor_formatter "$my_name" || true
+      local attempt_end; attempt_end=$(date +%s)
+      local held=$(( attempt_end - attempt_start ))
+      if [ "$held" -lt "$MIN_HOLD_SEC" ]; then
+        fast_fail_count=$(( fast_fail_count + 1 ))
+        [ -z "$fast_fail_since" ] && fast_fail_since="$attempt_start"
+        if [ "$fast_fail_count" -ge "$FAST_FAIL_THRESHOLD" ]; then
+          # Atomic write so `airc status` never reads a half-written line.
+          printf 'unreachable since=%s host=%s consecutive_failures=%d\n' \
+            "$fast_fail_since" "$host_target" "$fast_fail_count" \
+            > "$conn_state_file.tmp" 2>/dev/null \
+            && mv "$conn_state_file.tmp" "$conn_state_file" 2>/dev/null
+        fi
+      else
+        # Channel was up for at least MIN_HOLD_SEC; reset the counter
+        # whether it dropped later or not. This is the recovery signal —
+        # any sustained SSH session means the host is reachable now.
+        fast_fail_count=0
+        fast_fail_since=""
+        rm -f "$conn_state_file" 2>/dev/null
+      fi
       # Subsequent reconnects use the now-persisted offset updated by the formatter.
       tail_pos="-n +$(($(cat "$offset_file" 2>/dev/null || echo 0) + 1))"
       sleep 3
@@ -1418,11 +1451,39 @@ cmd_status() {
     done
     if [ -n "$any_alive" ]; then
       monitor_state="running (PID $any_alive)"
+      # Even with the monitor subprocess alive, the SSH reconnect loop
+      # may be zombie-looping against a dead host. Read the
+      # connection_state file written by cmd_monitor's reconnect loop;
+      # when present it carries the consecutive-failure count + since-ts.
+      local conn_state_file="$AIRC_WRITE_DIR/connection_state"
+      if [ -f "$conn_state_file" ]; then
+        local line; line=$(cat "$conn_state_file" 2>/dev/null || true)
+        if echo "$line" | grep -q '^unreachable '; then
+          local since_ts; since_ts=$(echo "$line" | sed -n 's/.*since=\([0-9]*\).*/\1/p')
+          local fails;    fails=$(echo "$line" | sed -n 's/.*consecutive_failures=\([0-9]*\).*/\1/p')
+          local ago=""
+          if [ -n "$since_ts" ] && [ "$since_ts" -gt 0 ] 2>/dev/null; then
+            local now_ts; now_ts=$(date +%s)
+            ago=" since $(( now_ts - since_ts ))s ago"
+          fi
+          monitor_state="reconnect-looping (${fails:-?} consecutive ssh failures${ago})"
+        fi
+      fi
     else
       monitor_state="stale pidfile (PIDs $pids_raw not alive — run 'airc connect' to self-heal)"
     fi
   fi
   echo "  monitor:     $monitor_state"
+  # When reconnect-looping, point the user at the fix. Reading the same
+  # state file again is fine — the `[ -f ]` check is cheap and the file
+  # only exists on the failure path.
+  if [ -n "$host_target" ] && [ -f "$AIRC_WRITE_DIR/connection_state" ]; then
+    local line; line=$(cat "$AIRC_WRITE_DIR/connection_state" 2>/dev/null || true)
+    if echo "$line" | grep -q '^unreachable '; then
+      echo "               host ${host_target}:${host_port} unreachable"
+      echo "               try: airc teardown --flush && airc connect <fresh-join-string>"
+    fi
+  fi
 
   # Host reachability. Only meaningful for joiners; opt-in via --probe to keep
   # `airc status` fast by default (SSH connect can hang for seconds).


### PR DESCRIPTION
Fixes bug 2 of #25.

## Problem

When the host a joiner is paired to disappears, the reconnect loop churns forever against a dead target. Each SSH attempt returns in <1s. The 180s inactivity watchdog (from #24) exits the formatter cleanly — but the outer loop just restarts SSH against the same dead target. \`airc status\` keeps showing \`monitor: running\` forever. Users stare at an 8+ hour \`last recv\` assuming the peer is quiet.

Observed in the field: joiner side stalled for 8h with \`monitor: running (PID X)\`, \`last send: 7s ago\`, \`last recv: 31884s ago\`. Only \`teardown --flush + connect <new-string>\` recovered.

## Fix

### Detection (cmd_monitor)

Time each SSH attempt. Held <10s = fast failure (connection refused / key reject / wrong port). Held ≥10s = channel was up at some point → reset counter. After 5 consecutive fast failures, atomically write \`\$AIRC_WRITE_DIR/connection_state\`:

\`\`\`
unreachable since=1713721234 host=joelteply-aa30@... consecutive_failures=5
\`\`\`

tmp-then-mv so \`airc status\` can never read a half-written line. Cleared on any held channel — recovery announces itself.

### Surface (cmd_status)

When the pidfile process is alive AND \`connection_state\` exists, render:

\`\`\`
monitor:     reconnect-looping (5 consecutive ssh failures since 45s ago)
             host joelteply-aa30@100.91.51.87:7549 unreachable
             try: airc teardown --flush && airc connect <fresh-join-string>
\`\`\`

instead of the misleading \`monitor: running\`.

## Cost

Healthy path: one extra \`date +%s\` per SSH attempt + a single \`rm -f\` on reset. \`airc status\`: one extra \`[ -f ]\` stat. Negligible.

## Threshold rationale

- \`MIN_HOLD_SEC = 10\`: SSH connect-failure typically resolves in <2s; a successful tail holds open for minutes. 10s is well above the failure ceiling and well below the hold floor, so it separates cleanly.
- \`FAST_FAIL_THRESHOLD = 5\`: 5 fast failures × 3s sleep = ~15s minimum before declaring unreachable. Tolerates a brief network hiccup (1–2 failures during routing flip) without false-positive alarm.

## Test

Manual (no test harness for bash-level scenarios exists yet):

1. Start a host, pair a joiner. Confirm \`airc status\` on joiner shows \`monitor: running (PID X)\`.
2. Teardown host, do NOT restart. On joiner, wait 20s for 5 fast failures.
3. \`airc status\` should now show \`reconnect-looping (≥5 consecutive ssh failures since Xs ago)\` plus the recovery hint.
4. Restart host under same identity/port. Next successful SSH attempt resets counter → \`monitor: running\` returns on the following \`airc status\`.

## Companion

Paired with #26 (teardown state hint). Together they close the recovery-path blind spots in #25.