### PR TITLE
fix(ping): only auto-pong when ping is addressed to us

### DIFF
--- a/airc
+++ b/airc
@@ -387,19 +387,29 @@ for line in sys.stdin:
     pong_match = re.match(r"^\[PONG:([a-f0-9-]+)\]", msg or "")
     if ping_match:
         ping_id = ping_match.group(1)
-        # Auto-reply pong via subprocess. Fire-and-forget. Uses
-        # airc send so the reply rides the same signed-message path
-        # as normal traffic (no protocol divergence).
-        import subprocess
-        try:
-            subprocess.Popen(
-                ["airc", "send", f"@{fr}", f"[PONG:{ping_id}]"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-        except Exception:
-            pass
-        # Suppress from user-visible output (control traffic).
+        # Only auto-pong when the ping is addressed to US specifically.
+        # Without this check every peer on the mesh auto-replies to
+        # every ping they see in the log (monitor tails are shared
+        # across the whole host), so a single ping fans out to N
+        # PONGs and makes liveness diagnosis meaningless. Broadcast
+        # pings (to=all) also skip here  a broadcast ping is a
+        # discovery message the operator reads, not a round-trip.
+        my_current = current_name()
+        if to == my_current:
+            # Auto-reply pong via subprocess. Fire-and-forget. Uses
+            # airc send so the reply rides the same signed-message
+            # path as normal traffic (no protocol divergence).
+            import subprocess
+            try:
+                subprocess.Popen(
+                    ["airc", "send", f"@{fr}", f"[PONG:{ping_id}]"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            except Exception:
+                pass
+        # Suppress from user-visible output (control traffic),
+        # regardless of whether we auto-ponged.
         continue
     if pong_match:
         # cmd_ping picks PONG up by tailing messages.jsonl directly.


### PR DESCRIPTION
## Summary

Initial ping patch (#28) had every peer on the mesh auto-reply to every ping they saw in the log. Monitor tails are shared across the whole host, so a single addressed ping fanned out to N PONGs (one per live peer running the new code), not one.

**Caught empirically 2026-04-21**: `airc ping @joelteply-aa30 5` from the host caused `memento` (a different peer) to auto-pong a ping that wasn't addressed to them.

## Fix

Check `to == current_name()` before auto-ponging. Broadcast pings (`to=all`) also skip auto-reply — a broadcast ping is a discovery message the operator reads, not a liveness round-trip. Adding broadcast support would need a different shape (first-to-respond wins, multiple pongs expected) and isn't part of this fix.

Suppress-from-user-output behavior is **unchanged** — PING/PONG are still filtered from the chat surface for every peer, addressed or not. Control traffic stays invisible even when we're not the target.

## Test plan

- [x] Syntax check
- [x] `current_name()` reads config.json live (already in the file, no new dependency)
- [ ] After merge + update on both peers: `airc ping @memento` should get exactly one PONG from memento, not N. The previous bug was specifically memento auto-ponging a ping addressed to joelteply-aa30.