### PR TITLE
feat(connect): emit notification when origin/<branch> advances past local HEAD

### DIFF
--- a/airc
+++ b/airc
@@ -621,6 +621,58 @@ cmd_connect() {
     ) &
   fi
 
+  # ── Branch-behind notification (issue #33) ─────────────────────────
+  # When two AI peers are paired on the same git repo, silently working on a
+  # stale checkout duplicates fixes (we have a "pull-before-work" discipline
+  # rule, but discipline is fragile). If the airc scope IS a git repo, poll
+  # `git ls-remote origin <branch>` periodically and emit a one-shot
+  # notification when the remote SHA advances past local HEAD. The notification
+  # surfaces on stdout where Claude Code's Monitor (or any other reader)
+  # picks it up immediately.
+  #
+  # Cheap: ls-remote is a HEAD ref query, no objects fetched. Quiet by
+  # default: emits ONE line per actual remote change, not per poll.
+  # Opt out: AIRC_NO_PULL_PROMPT=1 disables the poll entirely.
+  if [ -z "${AIRC_NO_PULL_PROMPT:-}" ] && command -v git >/dev/null 2>&1; then
+    local scope_git_dir; scope_git_dir="$(cd "$AIRC_WRITE_DIR/.." 2>/dev/null && git rev-parse --git-dir 2>/dev/null || true)"
+    if [ -n "$scope_git_dir" ]; then
+      local scope_repo_dir; scope_repo_dir="$(cd "$AIRC_WRITE_DIR/.." 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null || true)"
+      if [ -n "$scope_repo_dir" ]; then
+        # State file: last remote SHA we notified about. Empty on first run.
+        # Stored INSIDE the airc scope so it follows the pairing identity.
+        local pull_state_file="$AIRC_WRITE_DIR/last_remote_sha"
+        (
+          # Always work in the scope's git repo
+          cd "$scope_repo_dir" || exit 0
+          while sleep 60; do
+            local branch; branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+            [ -z "$branch" ] || [ "$branch" = "HEAD" ] && continue  # detached HEAD or no repo
+            # Cheap remote head check — no object fetch.
+            local remote_sha; remote_sha="$(git ls-remote --heads origin "$branch" 2>/dev/null | awk '{print $1}')"
+            [ -z "$remote_sha" ] && continue  # no remote tracking, skip
+            local local_sha; local_sha="$(git rev-parse HEAD 2>/dev/null)"
+            # Only notify when remote is AHEAD and we haven't already notified
+            # about THIS exact remote SHA.
+            if [ "$remote_sha" != "$local_sha" ]; then
+              local already_notified=""
+              [ -f "$pull_state_file" ] && already_notified="$(cat "$pull_state_file" 2>/dev/null)"
+              if [ "$remote_sha" != "$already_notified" ]; then
+                # Verify remote is actually AHEAD (not just different — could
+                # be a force-push scenario, still worth flagging but with
+                # different verbiage).
+                local ahead_count; ahead_count="$(git rev-list --count HEAD.."$remote_sha" 2>/dev/null || echo "?")"
+                local short_remote; short_remote="${remote_sha:0:9}"
+                local short_local;  short_local="${local_sha:0:9}"
+                echo "  [airc] origin/$branch is at $short_remote (you have $short_local, $ahead_count commits ahead). Run \`git pull\` before next edit. AIRC_NO_PULL_PROMPT=1 to silence."
+                echo "$remote_sha" > "$pull_state_file"
+              fi
+            fi
+          done
+        ) &
+      fi
+    fi
+  fi
+
   # Auto-teardown any stale airc process in this scope before starting fresh.
   # Previously users had to run `airc teardown` manually before `airc connect`
   # if a prior monitor was still around — easy to forget, often resulted in


### PR DESCRIPTION
## Summary

Closes #33.

Two AI peers paired in airc on the same git repo can silently work on a stale checkout, duplicating fixes the other already pushed. The "pull-before-work" discipline rule is fragile — agents forget. Airc already knows the scope (the repo it's running in) and the connection state (peers); it can detect when the remote has advanced past local HEAD and surface that as a notification on the existing monitor stream the AI is already reading.

## Behavior

In `cmd_connect`, after the heartbeat block, spawn a background subshell that polls `git ls-remote --heads origin <branch>` every 60s. ls-remote is a HEAD ref query — no objects fetched, ~50ms over a fast network.

When the remote SHA differs from local HEAD (and we haven't already notified for THIS remote SHA), emit one line on stdout:

```
  [airc] origin/feature/persona-recipes is at e3a013a86 (you have f10547662, 2 commits ahead). Run `git pull` before next edit. AIRC_NO_PULL_PROMPT=1 to silence.
```

State tracked in `<scope-dir>/last_remote_sha` so we fire **once per actual remote-SHA advance**, not periodically.

## Skipped when

- `AIRC_NO_PULL_PROMPT=1` set
- git not on PATH
- Scope is not inside a git repo
- Branch is detached HEAD or has no remote tracking

Auto-killed by the existing EXIT/INT/TERM trap (same as the heartbeat subshell).

## Test plan

- [x] `bash -n airc` syntax check
- [ ] Manual: pair two agents on a git repo, push from one, observe single notification on the other within 60s
- [ ] AIRC_NO_PULL_PROMPT=1 → no notifications even after remote advances
- [ ] Scope outside a git repo → no errors, silent
- [ ] Same remote SHA stays at remote → no repeat notification (fires once)

## Why this matters (real workflow gap)

Surfaced live 2026-04-23 in CambrianTech/continuum: paired agents on the same branch were depending on the discipline rule "pull before work." Joel: "maybe our airc could PROMPT the ais that their branch is behind?" → refined to "or when new changes are committed really, not like nagging." This implementation is the event-sensitive version: silent until real change, fires exactly once per change.