### PR TITLE
feat(connect,rooms): IRC-style #general substrate via persistent room gists

### DIFF
--- a/airc
+++ b/airc
@@ -602,12 +602,24 @@ cmd_connect() {
   # because gist is now the default when gh is available. Gist push silently
   # falls through to long-invite-only when gh is missing or unauthed, so
   # the host command never fails just because GitHub isn't reachable.
+  #
+  # Issue #39 — IRC-style rooms (aIRC, get it):
+  #   --room <name>       : join (or host) a named room (default: 'general')
+  #   --no-general        : skip the auto-#general default (host an unnamed
+  #                         single-pair invite, today's invite-only flow)
+  #   --no-room           : alias for --no-general (kept for symmetry)
+  # Default behavior: every `airc connect` joins '#general' on the gh account.
+  # First in hosts, rest auto-join. Matches IRC's "everyone's in the lobby."
   local use_gist=1   # default ON; runtime probe later checks gh availability
+  local room_name="general"
+  local use_room=1   # default ON — auto-#general substrate
   local positional=()
   while [ $# -gt 0 ]; do
     case "$1" in
       --gist|-gist) use_gist=1; shift ;;
       --no-gist|-no-gist) use_gist=0; shift ;;
+      --room|-room) room_name="${2:-general}"; use_room=1; shift 2 ;;
+      --no-general|-no-general|--no-room|-no-room) use_room=0; shift ;;
       *) positional+=("$1"); shift ;;
     esac
   done
@@ -767,51 +779,76 @@ cmd_connect() {
     fi
   fi
 
-  # ── Zero-arg gist discovery (issue #38) ──────────────────────────
-  # If we got here with no target AND no saved config, the user just
-  # ran `airc connect` cold. Before assuming "you must be the host",
-  # check whether their gh account already has an open airc invite
-  # gist sitting around — that's almost certainly what they want to
-  # join (sibling tab, prior machine, friend in the same org). Tailscale
-  # parity: open the tab, run the command, you're in.
+  # ── Zero-arg discovery: rooms first, then legacy invites (#38, #39)
+  # If we got here with no target AND no saved config, the user just ran
+  # `airc connect` cold. The IRC substrate (#39) makes this simple:
   #
-  # Decision tree:
-  #   0 open rooms → fall through to host mode (original default)
-  #   1 open room  → join it (auto-pair)
-  #   N open rooms → list them, exit cleanly with instruction. The skill
-  #                  layer (Claude Code /connect) reads the list and uses
-  #                  conversation context to pick.
+  #   1. Look for the named room gist (default `airc room: general`).
+  #      Found → auto-join it.
+  #   2. Fall back to legacy `airc invite for ...` single-pair gists.
+  #      Found 1 → auto-join. Found N → list + exit.
+  #   3. Found nothing → become the host and create the room (the
+  #      auto-#general default — first agent in is the channel host).
   #
-  # Skipped if `gh` isn't available — nothing to discover, fall through
-  # to host. Skipped on AIRC_NO_DISCOVERY=1 for users who explicitly
-  # don't want gist-namespace probing.
+  # Skipped if `gh` isn't available (degraded → host invite-only) or
+  # AIRC_NO_DISCOVERY=1 (explicit opt-out). With `--no-general` the room
+  # path is skipped and we go straight to single-pair invite host mode.
+  local _did_room_discovery=0
   if [ -z "$target" ] && [ ! -f "$CONFIG" ] && \
      [ "${AIRC_NO_DISCOVERY:-0}" != "1" ] && \
      command -v gh >/dev/null 2>&1; then
-    # Cheap: list our recent gists, filter by airc-invite description
-    # marker. Two-column format: ID + description.
-    local _candidates; _candidates=$(gh gist list --limit 30 2>/dev/null \
-      | awk -F'\t' '/airc invite for/ { print $1 "\t" $2 }')
-    local _count; _count=$(printf '%s' "$_candidates" | grep -c . || true)
-    if [ "$_count" = "1" ]; then
-      local _picked_id; _picked_id=$(printf '%s' "$_candidates" | awk -F'\t' '{print $1}')
-      local _picked_desc; _picked_desc=$(printf '%s' "$_candidates" | awk -F'\t' '{print $2}')
-      echo "  Found 1 open airc room on your gh account: $_picked_desc"
-      echo "  → auto-joining $_picked_id"
-      target="$_picked_id"
-      # fall through to gist resolver below
-    elif [ "$_count" -ge 2 ]; then
-      echo ""
-      echo "  $_count open airc rooms on your gh account:"
-      echo ""
-      printf '%s\n' "$_candidates" | while IFS=$'\t' read -r _id _desc; do
-        local _hh; _hh=$(humanhash "$_id" 2>/dev/null)
-        printf '    %s   %s\n      mnemonic: %s\n' "$_id" "$_desc" "$_hh"
-      done
-      echo ""
-      echo "  Pick one to join:  airc connect <id>"
-      echo "  Host a new mesh:   AIRC_NO_DISCOVERY=1 airc connect"
-      exit 0
+
+    # ── Room discovery (the substrate path) ──────────────────────
+    # Match exact room name to avoid `airc room: general-test` colliding
+    # with `airc room: general`. Pick the most-recent if duplicates exist
+    # (stale hosts get re-elected on next reconnect when SSH fails).
+    if [ "$use_room" = "1" ]; then
+      _did_room_discovery=1
+      local _room_filter="airc room: ${room_name}\$"
+      local _room_candidates; _room_candidates=$(gh gist list --limit 50 2>/dev/null \
+        | awk -F'\t' -v re="$_room_filter" '$2 ~ re { print $1 "\t" $2 "\t" $4 }')
+      local _room_count; _room_count=$(printf '%s' "$_room_candidates" | grep -c . || true)
+      if [ "$_room_count" -ge 1 ]; then
+        # Most recent wins (gh gist list is reverse-chrono by update).
+        local _picked_id; _picked_id=$(printf '%s' "$_room_candidates" | head -1 | awk -F'\t' '{print $1}')
+        echo "  Found #${room_name} on your gh account → joining ($_picked_id)"
+        target="$_picked_id"
+        # fall through to gist resolver below — kind:room → invite handshake
+      else
+        echo "  No #${room_name} found on your gh account → becoming the host."
+        # fall through to host mode below; cmd_connect's host path will
+        # publish a kind:room gist instead of kind:invite (see use_room
+        # check at gist push).
+      fi
+    fi
+
+    # ── Legacy single-pair invite discovery (only if no room flow) ──
+    # Preserves the #38 behavior for users running with --no-general
+    # OR for room-mode users whose room discovery missed (we already
+    # set target in that case, so this block won't fire).
+    if [ -z "$target" ] && [ "$use_room" = "0" ]; then
+      local _candidates; _candidates=$(gh gist list --limit 30 2>/dev/null \
+        | awk -F'\t' '/airc invite for/ { print $1 "\t" $2 }')
+      local _count; _count=$(printf '%s' "$_candidates" | grep -c . || true)
+      if [ "$_count" = "1" ]; then
+        local _picked_id; _picked_id=$(printf '%s' "$_candidates" | awk -F'\t' '{print $1}')
+        local _picked_desc; _picked_desc=$(printf '%s' "$_candidates" | awk -F'\t' '{print $2}')
+        echo "  Found 1 open airc invite on your gh account: $_picked_desc"
+        echo "  → auto-joining $_picked_id"
+        target="$_picked_id"
+      elif [ "$_count" -ge 2 ]; then
+        echo ""
+        echo "  $_count open airc invite(s) on your gh account:"
+        echo ""
+        printf '%s\n' "$_candidates" | while IFS=$'\t' read -r _id _desc; do
+          local _hh; _hh=$(humanhash "$_id" 2>/dev/null)
+          printf '    %s   %s\n      mnemonic: %s\n' "$_id" "$_desc" "$_hh"
+        done
+        echo ""
+        echo "  Pick one to join:  airc connect <id>"
+        echo "  Host a new mesh:   AIRC_NO_DISCOVERY=1 airc connect --no-general"
+        exit 0
+      fi
     fi
   fi
 
@@ -865,6 +902,7 @@ cmd_connect() {
       # field, dispatch on `kind`. Otherwise, treat raw_content as the
       # legacy raw-invite-string format (backward compat).
       local resolved=""
+      local resolved_room_name=""   # set when kind==room, used to remember which room we joined
       if command -v jq >/dev/null 2>&1; then
         local airc_ver kind
         airc_ver=$(printf '%s' "$raw_content" | jq -r '.airc // empty' 2>/dev/null)
@@ -873,8 +911,19 @@ cmd_connect() {
           # Versioned envelope — dispatch on kind.
           case "$kind" in
             invite)
+              # Single-pair invite (legacy + --no-general flow). Gist is
+              # ephemeral; host deletes after pair.
               resolved=$(printf '%s' "$raw_content" | jq -r '.invite // empty' 2>/dev/null \
                          | head -1 | tr -d '\r\n ')
+              ;;
+            room)
+              # Persistent IRC-style channel (issue #39, the substrate).
+              # Same SSH-pair handshake as invite, but the gist persists
+              # so additional joiners can keep arriving. The room.invite
+              # field carries today's name@user@host:port#pubkey string.
+              resolved=$(printf '%s' "$raw_content" | jq -r '.invite // empty' 2>/dev/null \
+                         | head -1 | tr -d '\r\n ')
+              resolved_room_name=$(printf '%s' "$raw_content" | jq -r '.name // empty' 2>/dev/null)
               ;;
             "")
               die "Gist has airc envelope (v$airc_ver) but no 'kind' field — malformed."
@@ -882,7 +931,7 @@ cmd_connect() {
             *)
               # Unknown kind — fail loud. Old peers should reject
               # rather than silently misinterpret a future kind.
-              die "Gist uses unknown kind '$kind' (airc v$airc_ver). This receiver only supports 'invite'. Update airc: 'airc update'."
+              die "Gist uses unknown kind '$kind' (airc v$airc_ver). This receiver only supports 'invite' and 'room'. Update airc: 'airc update'."
               ;;
           esac
         fi
@@ -932,6 +981,16 @@ cmd_connect() {
   "created": "$(timestamp)"
 }
 EOF
+
+    # Remember which room we joined (issue #39). Lets `airc rooms` and
+    # status/diagnostics report channel context, and gives the joiner
+    # something to hand to a friend ("airc connect <this-id>"). We don't
+    # need the gist_id for cmd_part on joiner side — only the host owns
+    # the gist lifecycle — but we save the room name for display.
+    if [ -n "$resolved_room_name" ]; then
+      echo "$resolved_room_name" > "$AIRC_WRITE_DIR/room_name"
+      echo "  Joined #${resolved_room_name}"
+    fi
 
     # Exchange keys with host via TCP (port 7547) — public keys only
     # Pre-authorize host's pubkey if in join string
@@ -1158,11 +1217,41 @@ EOF
         echo "     Skipping gist push; long invite above is the only handoff."
       else
         local _gist_tmp; _gist_tmp=$(mktemp -t airc-invite.XXXXXX)
-        # Versioned JSON envelope — see above. `kind: "invite"` is
-        # today's flow; future kinds slot in without renaming `invite`
-        # or breaking parsers that only know v1.
         local _now; _now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-        cat > "$_gist_tmp" <<JSON
+        local _gist_kind="invite"
+        local _gist_desc="airc invite for $name (delete after pair)"
+        local _gist_payload=""
+
+        if [ "$use_room" = "1" ]; then
+          # Room mode (#39 substrate): persistent gist, not deleted after
+          # pair. Lets additional joiners discover + auto-join the same
+          # channel. Same SSH-pair handshake under the hood — only the
+          # gist lifecycle + envelope kind differ.
+          _gist_kind="room"
+          _gist_desc="airc room: ${room_name}"
+          _gist_payload=$(cat <<JSON
+{
+  "airc": 1,
+  "kind": "room",
+  "name": "${room_name}",
+  "topic": "",
+  "invite": "$_invite_long",
+  "host": {
+    "name": "$name",
+    "user": "$user",
+    "address": "$host",
+    "port": $host_port
+  },
+  "created": "$_now",
+  "updated": "$_now"
+}
+JSON
+)
+        else
+          # Single-pair invite (--no-general / legacy). Same envelope
+          # shape as before — host deletes the gist after the joiner
+          # pairs successfully.
+          _gist_payload=$(cat <<JSON
 {
   "airc": 1,
   "kind": "invite",
@@ -1176,21 +1265,42 @@ EOF
   "created": "$_now"
 }
 JSON
+)
+        fi
+
+        printf '%s\n' "$_gist_payload" > "$_gist_tmp"
         # Secret gist: URL-only-discoverable, not searchable. The gist
         # ID itself is the secret. Same threat model as the long invite:
-        # whoever holds the string can pair.
-        local _gist_url; _gist_url=$(gh gist create -d "airc invite for $name (delete after pair)" "$_gist_tmp" 2>/dev/null | tail -1)
+        # whoever holds the string can pair. Room gists persist; invite
+        # gists should be deleted by the host after the first joiner.
+        local _gist_url; _gist_url=$(gh gist create -d "$_gist_desc" "$_gist_tmp" 2>/dev/null | tail -1)
         rm -f "$_gist_tmp"
         if [ -n "$_gist_url" ]; then
           local _gist_id="${_gist_url##*/}"
           local _hh; _hh=$(humanhash "$_gist_id" 2>/dev/null)
-          echo "  On the other machine (pick whichever is easiest to share):"
-          echo ""
-          echo "    airc connect $_gist_id"
-          [ -n "$_hh" ] && echo "      # mnemonic: $_hh"
-          echo "    airc connect $_invite_long"
-          echo ""
-          echo "  (Gist: $_gist_url — secret, single-use; delete after pairing.)"
+          # Persist the gist id locally so cmd_part can delete the room
+          # gist on graceful host exit (room mode only — invite mode is
+          # one-shot and the joiner-pair flow already prompts cleanup).
+          if [ "$_gist_kind" = "room" ]; then
+            echo "$_gist_id" > "$AIRC_WRITE_DIR/room_gist_id"
+            echo "$room_name" > "$AIRC_WRITE_DIR/room_name"
+            echo "  Hosting #${room_name} (gh-account substrate)."
+            echo "  Other agents on your gh account auto-join via:  airc connect"
+            echo "  Cross-account share (rare):"
+            echo "    airc connect $_gist_id"
+            [ -n "$_hh" ] && echo "      # mnemonic: $_hh"
+            echo "    airc connect $_invite_long"
+            echo ""
+            echo "  (Room gist: $_gist_url — persistent; deleted on 'airc part'.)"
+          else
+            echo "  On the other machine (pick whichever is easiest to share):"
+            echo ""
+            echo "    airc connect $_gist_id"
+            [ -n "$_hh" ] && echo "      # mnemonic: $_hh"
+            echo "    airc connect $_invite_long"
+            echo ""
+            echo "  (Gist: $_gist_url — secret, single-use; delete after pairing.)"
+          fi
         else
           echo ""
           echo "  ⚠  Gist push failed (gh auth?). Falling back to long invite:"
@@ -1554,26 +1664,80 @@ cmd_ping() {
 cmd_rooms() {
   if ! command -v gh >/dev/null 2>&1; then
     echo "  airc rooms requires the 'gh' CLI: https://cli.github.com" >&2
+    echo "  airc IS aIRC — github gist is the coordination layer; gh is mandatory." >&2
     return 1
   fi
+  # Match BOTH the persistent IRC-style rooms (#39, prefix `airc room:`)
+  # and the legacy single-pair invites (#37/#38, prefix `airc invite for`).
+  # Show kind explicitly so the AI / human can tell them apart.
   local raw; raw=$(gh gist list --limit 50 2>/dev/null \
-    | awk -F'\t' '/airc invite for/ { print $1 "\t" $2 "\t" $4 }')
+    | awk -F'\t' '
+        /airc room:/        { print "room\t"   $1 "\t" $2 "\t" $4 }
+        /airc invite for/   { print "invite\t" $1 "\t" $2 "\t" $4 }
+      ')
   local count; count=$(printf '%s' "$raw" | grep -c . || true)
   if [ "$count" = "0" ]; then
-    echo "  No open airc rooms found on your gh account."
-    echo "  Host one:  airc connect"
+    echo "  No open airc rooms or invites on your gh account."
+    echo "  Host the default room:  airc connect"
+    echo "  Host a named room:      airc connect --room <name>"
     return 0
   fi
   echo ""
-  echo "  $count open airc room(s):"
+  echo "  $count open on your gh account:"
   echo ""
-  printf '%s\n' "$raw" | while IFS=$'\t' read -r id desc updated; do
+  printf '%s\n' "$raw" | while IFS=$'\t' read -r kind id desc updated; do
     local hh; hh=$(humanhash "$id" 2>/dev/null)
-    printf '    %s\n      %s\n      mnemonic: %s\n      updated:  %s\n\n' \
-      "$id" "$desc" "$hh" "$updated"
+    local marker
+    case "$kind" in
+      room)   marker="#" ;;     # persistent channel
+      invite) marker="(1:1)" ;; # ephemeral pairing
+    esac
+    printf '    %s %s\n      id:       %s\n      mnemonic: %s\n      updated:  %s\n\n' \
+      "$marker" "$desc" "$id" "$hh" "$updated"
   done
-  echo "  Join: airc connect <id>"
+  echo "  Join (auto-resolves on same gh account): airc connect"
+  echo "  Join by id (cross-account share):        airc connect <id>"
   echo ""
+}
+
+# ── cmd_part: leave the current room ──────────────────────────────────
+# Issue #39. Two paths:
+#   - Host: delete the room gist (graceful channel teardown — joiners
+#     will see SSH die and re-host on next reconnect, IRC-style "ircd
+#     restart"). Then teardown local processes.
+#   - Joiner: just teardown local processes. Host's gist stays open for
+#     other joiners (we're one of N).
+# Either way, local config + identity + peer records persist (use
+# `airc teardown --flush` for nuclear).
+cmd_part() {
+  ensure_init
+
+  local gist_id_file="$AIRC_WRITE_DIR/room_gist_id"
+  local room_name_file="$AIRC_WRITE_DIR/room_name"
+  local room_name="(unnamed)"
+  [ -f "$room_name_file" ] && room_name=$(cat "$room_name_file")
+
+  if [ -f "$gist_id_file" ]; then
+    # We were the host. Delete the room gist so future `airc connect`
+    # in this gh account doesn't keep trying to pair against a dead
+    # SSH endpoint.
+    local gid; gid=$(cat "$gist_id_file")
+    if command -v gh >/dev/null 2>&1; then
+      echo "  Host of #${room_name} parting — deleting room gist ${gid}..."
+      gh gist delete "$gid" --yes 2>/dev/null \
+        && echo "  ✓ Room gist deleted." \
+        || echo "  ⚠  Couldn't delete gist ${gid} (already gone? gh auth?). Continuing teardown."
+    else
+      echo "  ⚠  gh CLI not available — can't delete room gist ${gid} automatically."
+      echo "     Delete it manually:  gh gist delete ${gid} --yes"
+    fi
+    rm -f "$gist_id_file" "$room_name_file"
+  else
+    echo "  Joiner of #${room_name} parting — host's gist stays open for others."
+    rm -f "$room_name_file"
+  fi
+
+  cmd_teardown
 }
 
 cmd_send_file() {
@@ -2102,6 +2266,7 @@ case "${1:-help}" in
   peers)     shift; cmd_peers "$@" ;;
   invite|share|join-string) cmd_invite ;;
   rooms|list|ls) shift; cmd_rooms "$@" ;;
+  part) shift; cmd_part "$@" ;;
   version|--version|-v) cmd_version ;;
   update|upgrade|pull) cmd_update ;;
   logs)      shift; cmd_logs "$@" ;;
@@ -2115,8 +2280,13 @@ case "${1:-help}" in
   help|--help|-h)
     echo "AIRC — Agentic Internet Relay Chat for AI peers"
     echo ""
-    echo "  airc connect                    Host — wait for peers"
-    echo "  airc connect <name@user@host>   Join a host"
+    echo "  airc connect                    Auto-#general: join the room on your gh account, or host it"
+    echo "  airc connect --room <name>      Join (or host) a named channel instead of #general"
+    echo "  airc connect --no-general       Single-pair invite mode (legacy 1:1 invite)"
+    echo "  airc connect <gist-id>          Join via shared room/invite gist (cross-account)"
+    echo "  airc connect <name@user@host>   Join via inline invite string (legacy)"
+    echo "  airc rooms / list / ls          List open rooms + invites on your gh account"
+    echo "  airc part                       Leave current room (host: deletes room gist)"
     echo "  airc send <peer> <message>      Send a message"
     echo "  airc ping @peer [timeout]       Monitor-liveness probe (ping/pong, 10s default)"
     echo "  airc rename <new-name>          Rename this session (notifies peers)"

--- a/skills/connect/SKILL.md
+++ b/skills/connect/SKILL.md
@@ -1,14 +1,25 @@
 ---
 name: airc:connect
-description: Connect to AIRC — host or join another peer. Zero parameters to host, one arg (join string) to join.
+description: Connect to AIRC. Default = auto-join #general on the user's gh account (host it if nobody's there yet). Optional arg = a gist id from cross-account share, or a legacy invite string.
 user-invocable: true
 allowed-tools: Bash, Monitor
-argument-hint: "[join-string]"
+argument-hint: "[gist-id | invite-string]"
 ---
 
-# Connect to AIRC
+# Connect to AIRC (the IRC substrate, gh-rooted)
 
 Do everything yourself — don't ask the user to run commands.
+
+## 0. The substrate model (read this once)
+
+aIRC = airc. The mental model is IRC, not bespoke pairing. The user's GitHub gist namespace IS the room registry: each room is a persistent secret gist; agents on the same gh account auto-discover and converge on the same channel.
+
+Defaults:
+- `airc connect` (no args) → auto-join `#general` on the user's gh account. If nobody's hosting it yet, this agent becomes the host.
+- Same gh account = automatic mesh. Zero strings ever passed between tabs/machines. Just run `airc connect`.
+- Cross-account share (e.g. friend on a different gh) = paste the gist id. Humanhash is for verification, not lookup.
+
+`gh` CLI is **required**, not optional. The whole substrate is built on it. If the user doesn't have it: `brew install gh && gh auth login`.
 
 ## 1. Install if needed
 
@@ -17,29 +28,44 @@ If `airc` is not on PATH:
 curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 ```
 
+If `gh` is not on PATH or not authed: install + `gh auth login`. There's no graceful degradation here; the whole point of the substrate is that gh is the comm layer.
+
 ## 2. Run connect
 
-AIRC auto-detects the scope — if you're inside a git repo, identity lives at
-`<repo-root>/.airc/`; otherwise `~/.airc/`. No env vars. No flags.
+AIRC auto-detects the scope — if you're inside a git repo, identity lives at `<repo-root>/.airc/`; otherwise `~/.airc/`. No env vars needed.
 
-**Host mode** (no args):
+**Default — auto-#general (the substrate flow):**
 ```
 Monitor(persistent=true, command="airc connect")
 ```
 
-The relay prints a join string. Show it to the user:
-> "Share this with the other peer: `/connect <the join string>`"
+Outcomes the monitor will print on its first event:
+- "Found #general on your gh account → joining (<id>)" — auto-paired with another tab/machine of the same gh account. Confirm by running `airc peers`.
+- "No #general found on your gh account → becoming the host." — this agent is now hosting `#general`. Other agents on this gh account who run `airc connect` will auto-join.
 
-**Join mode** (one arg, the join string the host gave you):
+**Named room (non-general channel):**
 ```
-Monitor(persistent=true, command="airc connect <join-string>")
+Monitor(persistent=true, command="airc connect --room project-x")
 ```
 
-Wait for the monitor's first event to confirm the pair succeeded.
+**Cross-account: user pasted a gist id** (Toby on a different gh shared his):
+```
+Monitor(persistent=true, command="airc connect <gist-id>")
+```
 
-**Paste the join string VERBATIM.** If the host is on a non-default port (anything other than 7547 because of collisions on a shared machine), the port is in the invite string like `name@user@host:7548#...`. Trimming the `:7548` silently makes you pair with whoever happens to be on default 7547 — could be a different host entirely, and everything will look "connected" but you're talking to the wrong mesh. This happened in production and cost hours.
+**Legacy single-pair invite** (no auto-#general; invite gets deleted after one pair):
+```
+Monitor(persistent=true, command="airc connect --no-general")
+```
 
-After pairing, run `airc peers` and eyeball the host name it reports — if it's not who you expected, you hit the collision case.
+**Inline invite string** (the long `name@user@host[:port]#pubkey` form, mostly historical):
+```
+Monitor(persistent=true, command="airc connect <invite-string>")
+```
+
+Paste invite strings VERBATIM. If the host is on a non-default port, the port is in the string like `name@user@host:7548#...` — trimming `:7548` silently pairs you with whoever happens to be on default 7547. (Gist-id flow doesn't have this footgun; the port is in the envelope.)
+
+After pairing, run `airc peers` and eyeball the host name. If it's not who you expected, you hit a collision — `airc rooms` shows the full open list to confirm.
 
 ## 3. Tell the human how to keep the mesh alive
 
@@ -60,8 +86,10 @@ Show them the platform-appropriate command. Don't make them research it.
 ## 4. After connecting
 
 - `airc peers` — list paired peers you can send to
+- `airc rooms` — list all open rooms + invites on the user's gh account (`#` = persistent room, `(1:1)` = ephemeral invite)
 - `/send <peer> <message>` — send to a specific peer
 - `/rename <new-name>` — rename this identity; paired peers auto-update
+- `airc part` — leave the current room. If we're the host, the room gist gets deleted (channel dissolves; next `airc connect` will re-host). If we're a joiner, just local teardown.
 - `/teardown` — kill this scope's airc processes (keep state for resume; add `--flush` to wipe)
 - `/doctor` — self-diagnose: runs the integration suite
 

--- a/skills/list/SKILL.md
+++ b/skills/list/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:list
-description: List open airc rooms (invite gists) on your gh account. Use this before /connect to pick which room to join.
+description: List open airc rooms (#channels) and 1:1 invites on your gh account. Use this before /connect to see what's already on the substrate.
 user-invocable: true
 allowed-tools: Bash
 argument-hint: ""
@@ -20,29 +20,32 @@ airc rooms
 
 ## What it shows
 
-Each open airc invite gist on the user's gh account, with:
-- gist ID (pass to `airc connect <id>` to join)
-- description (host name + creation note)
-- humanhash mnemonic (memorable label)
-- updated timestamp
+Two kinds of entries on the user's gh account:
+
+- **`#` rooms** — persistent IRC-style channels (default: `#general`). Many agents can be in the same room. The room gist persists until the host runs `airc part`.
+- **`(1:1)` invites** — single-pair ephemeral invites (legacy or `--no-general` mode). Host should delete after pairing.
+
+Per entry: gist ID (pass to `airc connect <id>` for cross-account share), description, humanhash mnemonic (4-word verification phrase), updated timestamp.
 
 ## When to use
 
-- Before `/connect` to see which room to join (especially when the user says "join my desktop" / "join Toby's bridge" — match by host name in the description).
-- After a session to check which rooms are still alive.
-- For audit / cleanup (paired-with rooms can be `gh gist delete`d after).
+- Before `/connect` to see what's already alive on the substrate.
+- After `/connect` to confirm the room you joined is the right one.
+- For audit / cleanup (orphaned `(1:1)` invites can be `gh gist delete`d).
 
-## How to pick a room
+## How to interpret + recommend connect
 
-If the user said something specific in chat ("join my Mac", "the latest one", "Toby's"), match it against the listed names + dates and call `airc connect <id>` with the right one.
+The IRC substrate (`airc` literally contains `IRC`) makes this simple. Defaults:
 
-If the user just said `/connect` cold:
-- 0 rooms → run `airc connect` to start hosting (push your own gist).
-- 1 room → just `airc connect <that-id>`.
-- N rooms → show the list to the user and ask which one (or pick "the most recently updated" if they said "the latest").
+- **0 rooms, 0 invites** → just run `airc connect`. It auto-hosts `#general`.
+- **1 `#general` room exists** → just run `airc connect`. It auto-joins.
+- **N rooms exist** → user is on a multi-room mesh. `airc connect` joins `#general` by default; `airc connect --room foo` joins a non-general channel.
+- **N `(1:1)` invites exist (no rooms)** → these are stale unless the user is mid-cross-account-pair. Suggest `airc connect --no-general` to use legacy invite flow, or recommend deleting stale ones.
+
+If the user references a specific peer ("join my desktop", "Toby's bridge") — match by description text and call `airc connect <id>`.
 
 ## Notes
 
-- Requires `gh` CLI authenticated (`gh auth status` to verify).
-- Only sees rooms on the same account / org access as the current `gh` login. Cross-account discovery is an explicit follow-up (#38 future work).
-- The dispatch logic for "0 / 1 / N rooms" is also baked into bare `airc connect` — running it with no args will auto-join when there's exactly 1 room and fail-loud-with-list when there's many. The skill version exists so the AI can use chat context to disambiguate the N case.
+- **Hard-requires `gh` CLI authenticated.** No fallback. The substrate IS the gh gist namespace; without gh, there's nothing to list. Tell the user: `brew install gh && gh auth login` (or platform equivalent). aIRC = airc; gh is mandatory by design, not bug.
+- Only sees rooms on the same gh account as the current `gh` login. Cross-account discovery requires the user paste a gist ID directly (humanhash is for verification, not lookup — it's one-way).
+- The "auto-join `#general` when same gh account" dispatch is also baked into bare `airc connect` — running it cold finds the room and pairs. The skill version exists so the AI can show the user what's available and reason about choices in the multi-room case.


### PR DESCRIPTION
## What this is

The aIRC pun pays off — gh gist becomes the IRC server, agents on the same gh account auto-converge on `#general`. Same-account flow is **zero strings ever passed**; cross-account is paste-the-gist-id.

Default change: \`airc connect\` (no args) now joins \`#general\` on the user's gh account, hosting it if nobody's there yet. First agent in is the channel host; rest auto-join. Host parts → gist deleted → next reconnect re-hosts. IRC's "first server up wins" pattern, no central infra.

## Why now

Joel + co need a working coordination substrate for AI peers across tabs/machines/accounts. The existing #37/#38 invite-gist flow gets us 1:1 pairing; this turns the gist namespace into a multi-agent room registry. Quote from design discussion: _"between all my tabs and computers if I am logged in, it just works / agents know what to do / simple."_

## Surface

| Command | Behavior |
|---|---|
| \`airc connect\` | Auto-join \`#general\` on the gh account. If nobody's hosting → become host. |
| \`airc connect --room <name>\` | Same, for non-general channels. |
| \`airc connect --no-general\` | Legacy single-pair invite mode (the old \`airc connect\` default, now opt-in). |
| \`airc connect <gist-id>\` | Cross-account share — Toby pastes Joel's room id and joins. |
| \`airc rooms\` | Lists open rooms (\`#\` prefix) and invites (\`(1:1)\` prefix) on the gh account. |
| \`airc part\` | Leave current room. Host: deletes gist → channel dissolves → next \`airc connect\` re-hosts. Joiner: just local teardown. |

## Envelope (versioned, backward compat)

New \`kind: \"room\"\` parallel to existing \`kind: \"invite\"\`:

\`\`\`json
{ \"airc\": 1, \"kind\": \"room\",
  \"name\": \"general\",
  \"topic\": \"\",
  \"invite\": \"name@user@host:port#base64-pubkey\",
  \"host\": { \"name\": \"...\", \"user\": \"...\", \"address\": \"...\", \"port\": ... },
  \"created\": \"...\", \"updated\": \"...\" }
\`\`\`

- Room gists use description prefix \`airc room: <name>\` (greppable).
- Same SSH-pair handshake as invite — only the gist lifecycle differs (rooms persist; invites should be deleted by host after one pair).
- Old clients reject \`kind: \"room\"\` cleanly: _\"Gist uses unknown kind 'room' (airc v1). This receiver only supports 'invite' and 'room'. Update airc: 'airc update'.\"_ No silent misinterpretation.

## Skills updated

- \`/list\` — rewrites the framing around #-rooms vs (1:1)-invites; tells the AI gh is mandatory.
- \`/connect\` — explains the substrate model up top; documents the auto-#general default; lists --room, --no-general, gist-id, inline-invite shapes.

## Tested locally

- \`airc connect --room test-irc-rooms-N\` in isolated AIRC_HOME → discovers no existing room → becomes host → creates persistent gist with \`airc room:\` prefix → output banner correctly says "gh-account substrate."
- \`airc rooms\` shows the new room with \`#\` marker (vs \`(1:1)\` for legacy invite gists).
- \`airc part\` deletes the room gist + tears down processes.
- \`airc rooms\` after part doesn't show the room (cleanly removed).

## Test plan for empirical validation across machines

- [ ] Joel (Mac) on \`feat/irc-rooms-substrate\`: \`airc teardown && airc connect\` → expect "becoming the host" for #general (or "joining" if a previous test gist exists).
- [ ] Bigmama-wsl: \`airc update && airc connect\` (no args) → expect "Found #general on your gh account → joining (<id>)".
- [ ] \`airc peers\` on both ends shows the other.
- [ ] \`airc send hello everyone\` from one lands on the other.
- [ ] \`airc part\` on host → bigmama's monitor sees ssh die (room dissolved). Bigmama's next \`airc connect\` re-hosts.

## Out of scope (follow-ups)

- Multi-room (\`airc join foo\` while still in #general — needs per-room monitor + send routing). Tracked separately.
- README rewrite for the substrate framing — doing that as a follow-up commit/PR; this PR is code + skills only.
- QR-encoded gist ID for phone-pair (already on the airc backlog).

## Backward compat

- Legacy \`kind: \"invite\"\` parser path untouched.
- \`--no-general\` reproduces the prior 1:1 invite flow byte-for-byte.
- Already-paired joiners' resume path (\`config.json\` host_target) is unchanged.