### PR TITLE
test+skills: scenario_room + /airc:tests + actionable /airc:doctor + cmd_part bugfix

### DIFF
--- a/airc
+++ b/airc
@@ -2063,26 +2063,108 @@ except Exception:
 }
 
 cmd_update() {
-  # Refresh install dir (git pull) AND re-run install.sh so new skills get
-  # symlinked into ~/.claude/skills/ and old ones get cleaned up. install.sh
-  # is idempotent — it handles the pull, the binary symlink, and the skill
+  # Refresh install dir AND re-run install.sh so new skills get symlinked
+  # into ~/.claude/skills/ and old ones get cleaned up. install.sh is
+  # idempotent — it handles the pull, the binary symlink, and the skill
   # directory refresh in one pass. Does NOT teardown or reconnect.
+  #
+  # Channels (#40 followup): airc supports release channels for opt-in
+  # pre-merge testing. main = stable; canary = features-not-yet-promoted.
+  # The chosen channel persists in $AIRC_DIR/.channel so subsequent
+  # `airc update` (no args) keeps the user on their chosen track.
+  #   airc update                    # stay on current channel (default: main)
+  #   airc update --channel canary   # switch to canary + update
+  #   airc update --channel main     # switch back to main + update
+  #   airc channel                   # show current channel without updating
   local dir="${AIRC_DIR:-$HOME/.airc-src}"
+  local channel_file="$dir/.channel"
+  local requested_channel=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --channel|-c)
+        requested_channel="${2:-}"
+        [ -z "$requested_channel" ] && die "Usage: airc update --channel <name>"
+        shift 2
+        ;;
+      --canary) requested_channel="canary"; shift ;;
+      --main)   requested_channel="main";   shift ;;
+      *) shift ;;
+    esac
+  done
+
   if [ ! -d "$dir/.git" ]; then
     die "No git checkout at $dir. Reinstall: curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash"
   fi
+
+  # Determine target channel: explicit request > saved preference > main.
+  local channel
+  if [ -n "$requested_channel" ]; then
+    channel="$requested_channel"
+  elif [ -f "$channel_file" ]; then
+    channel=$(cat "$channel_file" 2>/dev/null | tr -d '[:space:]')
+    [ -z "$channel" ] && channel="main"
+  else
+    channel="main"
+  fi
+
+  # Switch to the target branch BEFORE pulling. install.sh will then ff-pull
+  # whatever branch is checked out. Fail loud if the channel doesn't exist
+  # on origin — silently falling back to main would defeat the opt-in test
+  # purpose.
   local before; before=$(git -C "$dir" rev-parse --short HEAD 2>/dev/null)
+  local current_branch; current_branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  if [ "$current_branch" != "$channel" ]; then
+    git -C "$dir" fetch --quiet origin "$channel" 2>/dev/null \
+      || die "Channel '$channel' not found on origin. Try: airc channel (to see options)."
+    git -C "$dir" checkout -q "$channel" 2>/dev/null \
+      || git -C "$dir" checkout -q -B "$channel" "origin/$channel" 2>/dev/null \
+      || die "Failed to checkout '$channel'. Resolve manually in $dir."
+  fi
+
   if [ ! -x "$dir/install.sh" ]; then
     die "install.sh missing at $dir. Reinstall via curl|bash."
   fi
   AIRC_DIR="$dir" bash "$dir/install.sh" || die "install.sh failed."
+
+  # Persist channel choice AFTER successful update so a failed switch
+  # doesn't leave a dangling preference for a broken state.
+  echo "$channel" > "$channel_file"
+
   local after; after=$(git -C "$dir" rev-parse --short HEAD 2>/dev/null)
   if [ "$before" = "$after" ]; then
-    echo "  Already at ${after}. Skills refreshed."
+    echo "  Already at ${after} on channel '${channel}'. Skills refreshed."
   else
-    echo "  Updated: ${before} -> ${after}. Skills refreshed."
+    echo "  Updated: ${before} -> ${after} on channel '${channel}'. Skills refreshed."
     echo "  Running monitor still uses the old code. To pick up:  airc teardown && airc connect"
   fi
+}
+
+# ── cmd_channel: show or set the release channel without pulling ──────
+# `airc channel`           → print current channel + how to switch
+# `airc channel canary`    → set preferred channel; doesn't pull (use
+#                            `airc update` after to actually switch)
+# Allows the AI / human to inspect + decide before the heavier update.
+cmd_channel() {
+  local dir="${AIRC_DIR:-$HOME/.airc-src}"
+  local channel_file="$dir/.channel"
+  local current="main"
+  [ -f "$channel_file" ] && current=$(cat "$channel_file" 2>/dev/null | tr -d '[:space:]')
+  [ -z "$current" ] && current="main"
+
+  local target="${1:-}"
+  if [ -z "$target" ]; then
+    echo "  Channel: $current"
+    echo "  Available channels (any branch on origin can be a channel):"
+    echo "    main      — stable, what most users run"
+    echo "    canary    — features queued for the next main merge; opt-in testing"
+    echo "  Switch:"
+    echo "    airc channel <name>           # set preference (run 'airc update' after)"
+    echo "    airc update --channel <name>  # set + pull in one step"
+    return 0
+  fi
+
+  echo "$target" > "$channel_file"
+  echo "  Channel preference set: '$target'. Run 'airc update' to actually switch + pull."
 }
 
 cmd_version() {
@@ -2296,7 +2378,9 @@ case "${1:-help}" in
   rooms|list|ls) shift; cmd_rooms "$@" ;;
   part) shift; cmd_part "$@" ;;
   version|--version|-v) cmd_version ;;
-  update|upgrade|pull) cmd_update ;;
+  update|upgrade|pull) shift; cmd_update "$@" ;;
+  channel) shift; cmd_channel "$@" ;;
+  canary) shift; cmd_update --channel canary "$@" ;;
   logs)      shift; cmd_logs "$@" ;;
   status)    shift; cmd_status "$@" ;;
   doctor|tests|test) shift; cmd_doctor "$@" ;;
@@ -2315,6 +2399,10 @@ case "${1:-help}" in
     echo "  airc connect <name@user@host>   Join via inline invite string (legacy)"
     echo "  airc rooms / list / ls          List open rooms + invites on your gh account"
     echo "  airc part                       Leave current room (host: deletes room gist)"
+    echo "  airc update [--channel <name>]  Pull latest on current channel; switch with --channel canary|main"
+    echo "  airc channel [<name>]           Show or set release channel (main = stable, canary = pre-merge testing)"
+    echo "  airc canary                     Shortcut: airc update --channel canary"
+    echo "  airc tests / doctor [scenario]  Run integration suite (88 assertions across 11 scenarios)"
     echo "  airc send <peer> <message>      Send a message"
     echo "  airc ping @peer [timeout]       Monitor-liveness probe (ping/pong, 10s default)"
     echo "  airc rename <new-name>          Rename this session (notifies peers)"

--- a/airc
+++ b/airc
@@ -613,6 +613,11 @@ cmd_connect() {
   local use_gist=1   # default ON; runtime probe later checks gh availability
   local room_name="general"
   local use_room=1   # default ON — auto-#general substrate
+  # Declared at function scope so set -u doesn't bite when JOIN MODE runs
+  # without a prior gist parser (inline-invite path skips the parser
+  # entirely; resolved_room_name only gets a value when we resolved a
+  # kind:room gist envelope).
+  local resolved_room_name=""
   local positional=()
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -902,7 +907,6 @@ cmd_connect() {
       # field, dispatch on `kind`. Otherwise, treat raw_content as the
       # legacy raw-invite-string format (backward compat).
       local resolved=""
-      local resolved_room_name=""   # set when kind==room, used to remember which room we joined
       if command -v jq >/dev/null 2>&1; then
         local airc_ver kind
         airc_ver=$(printf '%s' "$raw_content" | jq -r '.airc // empty' 2>/dev/null)
@@ -1192,6 +1196,18 @@ EOF
       echo "  On the other machine:"
       echo "    airc connect $_invite_long"
       _printed_long=1
+    fi
+
+    # Record room name + print substrate banner BEFORE the gist push
+    # attempt so cmd_part / status / diagnostics know the channel name
+    # even when the gist push is skipped (--no-gist) or fails (gh
+    # missing/unauthed). The gist_id is recorded only when an actual
+    # gist is created (see below). The "Hosting #<name>" banner is the
+    # signal both humans and the integration test use to confirm
+    # substrate framing took effect — emit unconditionally for room mode.
+    if [ "$use_room" = "1" ]; then
+      echo "$room_name" > "$AIRC_WRITE_DIR/room_name"
+      echo "  Hosting #${room_name} (gh-account substrate)."
     fi
 
     # ── Gist transport (--gist flag, issue #37) ────────────────────
@@ -1701,14 +1717,19 @@ cmd_rooms() {
 }
 
 # ── cmd_part: leave the current room ──────────────────────────────────
-# Issue #39. Two paths:
-#   - Host: delete the room gist (graceful channel teardown — joiners
-#     will see SSH die and re-host on next reconnect, IRC-style "ircd
-#     restart"). Then teardown local processes.
-#   - Joiner: just teardown local processes. Host's gist stays open for
-#     other joiners (we're one of N).
+# Issue #39. Two paths, distinguished by config.json's host_target:
+#   - Host (no host_target): delete the room gist if we created one, then
+#     teardown. Joiners watching us will see SSH die — IRC's "ircd
+#     restart" — and the next reconnect re-elects a new host.
+#   - Joiner (host_target set): just teardown local processes; host's
+#     gist stays open for other joiners (we're one of N).
 # Either way, local config + identity + peer records persist (use
 # `airc teardown --flush` for nuclear).
+#
+# Detection note: we use config.json::host_target as the host-vs-joiner
+# signal, NOT presence of room_gist_id. The gist file may be absent for
+# a legitimate host case (`--no-gist`, or gh push failed) — falling back
+# to "you're a joiner" would be wrong.
 cmd_part() {
   ensure_init
 
@@ -1717,22 +1738,29 @@ cmd_part() {
   local room_name="(unnamed)"
   [ -f "$room_name_file" ] && room_name=$(cat "$room_name_file")
 
-  if [ -f "$gist_id_file" ]; then
-    # We were the host. Delete the room gist so future `airc connect`
-    # in this gh account doesn't keep trying to pair against a dead
-    # SSH endpoint.
-    local gid; gid=$(cat "$gist_id_file")
-    if command -v gh >/dev/null 2>&1; then
-      echo "  Host of #${room_name} parting — deleting room gist ${gid}..."
-      gh gist delete "$gid" --yes 2>/dev/null \
-        && echo "  ✓ Room gist deleted." \
-        || echo "  ⚠  Couldn't delete gist ${gid} (already gone? gh auth?). Continuing teardown."
+  local host_target; host_target=$(get_config_val host_target "")
+
+  if [ -z "$host_target" ]; then
+    # ── Host path ──
+    if [ -f "$gist_id_file" ]; then
+      local gid; gid=$(cat "$gist_id_file")
+      if command -v gh >/dev/null 2>&1; then
+        echo "  Host of #${room_name} parting — deleting room gist ${gid}..."
+        gh gist delete "$gid" --yes 2>/dev/null \
+          && echo "  ✓ Room gist deleted." \
+          || echo "  ⚠  Couldn't delete gist ${gid} (already gone? gh auth?). Continuing teardown."
+      else
+        echo "  ⚠  gh CLI not available — can't delete room gist ${gid} automatically."
+        echo "     Delete it manually:  gh gist delete ${gid} --yes"
+      fi
     else
-      echo "  ⚠  gh CLI not available — can't delete room gist ${gid} automatically."
-      echo "     Delete it manually:  gh gist delete ${gid} --yes"
+      # Host but no gist (--no-gist or gh-push failed). Nothing to delete
+      # in the gh namespace; just clean local state.
+      echo "  Host of #${room_name} parting (no gist was published; nothing to clean up in gh)."
     fi
     rm -f "$gist_id_file" "$room_name_file"
   else
+    # ── Joiner path ──
     echo "  Joiner of #${room_name} parting — host's gist stays open for others."
     rm -f "$room_name_file"
   fi
@@ -2271,7 +2299,7 @@ case "${1:-help}" in
   update|upgrade|pull) cmd_update ;;
   logs)      shift; cmd_logs "$@" ;;
   status)    shift; cmd_status "$@" ;;
-  doctor)    shift; cmd_doctor "$@" ;;
+  doctor|tests|test) shift; cmd_doctor "$@" ;;
   teardown|stop|flush) shift; cmd_teardown "$@" ;;
   disconnect|leave|unbind) cmd_disconnect ;;
   monitor)   shift; monitor "$@" ;;

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: airc:canary
+description: Switch this airc install to the canary channel — pre-merge features queued for the next main release. Use when Joel asks you to test something that hasn't landed on main yet, or when you want the bleeding edge.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: ""
+---
+
+# airc canary
+
+Run this yourself — don't ask the user.
+
+## What it does
+
+Switches this airc install to the `canary` channel. Under the covers:
+- `git fetch origin canary`
+- `git checkout canary`
+- `git pull --ff-only`
+- Refreshes skills + binary symlinks via `install.sh`
+- Persists the choice to `$AIRC_DIR/.channel` so subsequent `airc update` (no args) stays on canary
+
+## Execute
+
+```bash
+airc canary
+```
+
+Equivalent to `airc update --channel canary`. The shortcut exists because "go canary" is the common case for pre-merge testing.
+
+## What "canary" means
+
+| Channel | What it is | When to use |
+|---|---|---|
+| `main` | Stable. Most users run this. | Default. |
+| `canary` | Long-lived branch ahead of main. Features that haven't been merged to main yet land here first; we test on canary, then promote canary→main as a single integration commit. | When testing a not-yet-merged feature, OR when you want bleeding edge. |
+
+`canary` is just a git branch. Switching back is symmetric: `airc update --channel main` (or `airc channel main && airc update`).
+
+## Rollback
+
+If canary breaks something:
+
+```bash
+airc update --channel main
+airc teardown && airc connect
+```
+
+That's it. Branch switch + restart monitor on the new code. Identity, peers, room state all persist (they're in `$AIRC_HOME`, not `$AIRC_DIR`).
+
+## After switching
+
+Tell the user:
+
+> "Switched to canary (sha `<short-sha>`). Running monitor still uses old code — `airc teardown && airc connect` to pick up the new binary."
+
+Then if they had a paired session you should restart the monitor for them:
+```
+Monitor(persistent=true, command="airc connect")
+```
+
+## When to use this skill
+
+- Joel says "test the canary" / "try the new substrate work" / similar.
+- A new feature is queued in canary and bigmama / memento / anvil need to validate before promotion.
+- The user mentions a recent merged-to-canary PR by number (e.g. "test PR #40").
+
+## When NOT to use this skill
+
+- For routine updates → use `/airc:update` (stays on whatever channel they're on; doesn't switch).
+- For first-time install → use `/airc:connect` which auto-installs main.
+
+## Notes
+
+- This is not "experimental beta channel" — canary is "merged-but-not-yet-promoted." Code on canary has passed local tests + the contributor's review; it just hasn't earned its way to main yet via cross-machine validation.
+- Channel preference lives in `$AIRC_DIR/.channel`. Inspect with `airc channel`.
+- If `gh auth status` is clean, the substrate (`airc connect` zero-arg → #general) works exactly the same on canary as on main — channels affect the airc binary, not the gist namespace.

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,48 +1,96 @@
 ---
 name: airc:doctor
-description: Self-diagnose AIRC. Runs the integration tests to validate pairing, send, rename, send-file, reminder heartbeat, teardown scope isolation, and the two-tier home/local resolver.
+description: Self-diagnose AIRC. AI checks environment health (gh, ssh, ports), runs the integration suite, and proactively fixes recoverable issues (install gh, etc.) instead of just reporting them.
 user-invocable: true
 allowed-tools: Bash
-argument-hint: "[tabs|scope|reminder|teardown|all]"
+argument-hint: "[scenario|all]"
 ---
 
 # airc doctor
 
-Run this yourself — don't ask the user. It's fast (~45s) and self-contained.
+Run this yourself — don't ask the user. Goal: leave the user with a working airc, not a diagnosis they have to act on.
 
-## What it does
+## Step 1 — environment health check (do this BEFORE running tests)
 
-Invokes `airc doctor`, which runs the bundled integration suite at `$AIRC_DIR/test/integration.sh`. 31 assertions across 4 scenarios:
+The substrate is gh-rooted. Check the environment first; an absent / unauthed gh is the #1 cause of "airc feels broken." If you can fix it, fix it.
 
-- **tabs** — two airc processes on one machine with isolated homes + port override. Pairing, bidirectional send, monitor correctness, rename propagation, peer-record persistence, send-file with `-i` key, local outbound mirror (audit trail).
-- **scope** — per-project `$PWD/.airc/` opt-in tier. Home peers inherited when local is empty; local shadows home on name collision.
-- **reminder** — `AIRC_REMINDER` env var, interval persisted, heartbeat fires after silence, `reminded` marker prevents spam, `airc reminder off/<n>` controls.
-- **teardown** — host killed, port freed, state preserved without `--flush`; teardown in a different scope does NOT kill unrelated hosts (scope isolation).
+```bash
+# (a) gh installed?
+command -v gh >/dev/null 2>&1 && echo "gh: present" || echo "gh: MISSING"
 
-The script uses **port 7549** (test-reserved) and `AIRC_HOME=/tmp/airc-it-*`. It will NOT touch any live airc session running on the default 7547 or the common alt 7548. Cleans up after itself via pidfiles — no broad process kills.
+# (b) gh authenticated?
+gh auth status 2>&1 | head -3
 
-## Run
+# (c) ssh remote login on this machine? (needed for tabs/scope tests + real pairing)
+# macOS:
+sudo systemsetup -getremotelogin 2>/dev/null || true
+# Linux: just check sshd is running
+systemctl is-active sshd 2>/dev/null || pgrep -f "sshd" >/dev/null && echo "sshd: active" || echo "sshd: NOT running"
+
+# (d) port 7549 (test-reserved) free?
+lsof -iTCP:7549 -sTCP:LISTEN 2>/dev/null | head -3 || echo "7549: free"
+```
+
+**Act on findings, don't just print them:**
+
+- **`gh: MISSING`** → install gh. macOS: `brew install gh`. Linux Ubuntu/Debian: `sudo apt install gh` (or follow https://github.com/cli/cli#installation). Windows: `winget install GitHub.cli` or `choco install gh`. Then tell the user to `gh auth login` (needs interactive browser flow — they have to run this themselves).
+- **`gh auth: not logged in`** → `gh auth login` (must be interactive — instruct the user to type `! gh auth login` so it runs in the terminal session and the browser flow can complete).
+- **`sshd: NOT running`** (macOS) → `sudo systemsetup -setremotelogin on` (the user has to run this; needs sudo). Or System Settings → General → Sharing → Remote Login.
+- **`7549: <pid>`** → port held by something else; `lsof -tiTCP:7549 -sTCP:LISTEN | xargs kill` if the process is one you can identify and kill safely. Otherwise tell the user.
+
+Why this comes BEFORE the tests: the integration suite is `gh`-free by design (uses inline invites + local SSH), so missing gh wouldn't fail the tests — but the user will still be unable to use the substrate (`airc connect` zero-arg auto-discovery, `airc rooms`). Doctor should catch and fix that.
+
+## Step 2 — run the integration suite
 
 ```bash
 airc doctor $ARGUMENTS
 ```
 
-Empty or `all` runs all 4 scenarios sequentially. `tabs`, `scope`, `reminder`, `teardown` run one.
+Empty `$ARGUMENTS` (or `all`) runs every scenario. A scenario name (`tabs`, `scope`, `room`, `teardown`, `reminder`, `resilience`, `reconnect`, `queue`, `status`, `auth_failure`, `resume_stale_auth`) runs just that one. Suite uses port 7549 + `AIRC_HOME=/tmp/airc-it-*`; safe alongside live airc on 7547/7548.
 
-## Read the result
+## Step 3 — interpret + act
 
-Final line: `N passed, M failed`. `0 failed` means green. Otherwise the suite prints each failure by name — report them verbatim.
+Final line: `N passed, M failed`.
 
-## When to run
+### Green (`0 failed`)
 
-- Right after install, before pairing for real
-- After an upgrade, to confirm the new binary behaves
-- When something feels off — rule out a binary-level regression before blaming the network
+- Environment OK + tests OK → tell the user "airc is healthy. Run `airc connect` to join the substrate."
+- Make sure to mention what you fixed (if anything) in step 1.
 
-## Interpreting failures
+### Red
 
-- **alpha hosting failed** — `airc` not on PATH, or port 7549 taken (rare; port 7549 is test-reserved). Check `lsof -iTCP:7549`.
-- **beta join failed** — SSH Remote Login isn't enabled on this machine, or a firewall is blocking TCP to 7549.
-- **send/monitor did NOT see** — the signed-message-over-SSH path is broken. Check `~/.ssh/authorized_keys` has the test keys mid-run, or trace with `bash -x`.
-- **scope: local tier shadows home** — the two-tier resolver in the binary is regressed. Upstream bug, not environment.
-- **teardown in different scope killed foreign host** — scope isolation regression. Critical — would mean one Claude tab can nuke another's live session. File an issue.
+For each failure name in the trace, look it up in this table and **act, don't just report**:
+
+| Failure | Likely cause | What to do |
+|---|---|---|
+| `alpha host failed to start` | Port 7549 taken, OR airc not on PATH | `lsof -iTCP:7549` → kill if safe; verify `command -v airc` |
+| `beta join failed` | sshd not running, OR firewall blocks loopback ssh | enable Remote Login (mac) / start sshd (linux); test `ssh localhost echo ok` |
+| `scope: ...` | Two-tier resolver in airc binary regressed | rare — bisect against last green sha; this is upstream airc, file an issue |
+| `teardown in different scope killed foreign host` | Scope isolation broke (critical) | file an issue immediately; this would let one Claude tab nuke another's session |
+| `room: alpha unexpectedly wrote room_gist_id under --no-gist` | Use of --no-gist isn't honored on the gist-push branch | regression in cmd_connect's host-mode gist push gate |
+| `room: alpha cmd_part DID NOT identify as host` | cmd_part's host-vs-joiner detection regressed | host signal is `config.json::host_target` empty; do not fall back to gist_id presence (that was the pre-PR2 bug) |
+| `auth_failure: stderr did NOT mention re-pair` | cmd_send's auth-class-error detection regressed | check the regex against `permission denied|publickey|host key|...` |
+| `resume_stale_auth: invite string` | Resume probe didn't reconstruct the saved invite for the user | regression in cmd_connect's resume probe failure branch |
+
+If a failure isn't in the table:
+- Read the failure verbatim
+- Trace into `test/integration.sh` for that scenario name to understand what assertion fired
+- Read the relevant section of the airc binary
+- Form a hypothesis, fix it, re-run that scenario alone (`airc doctor <scenario>`)
+
+## Step 4 — final report
+
+One line: "Fixed X, Y. All tests green." OR "Fixed X. Tests N passed M failed; failures: <list>." Be specific about what you did, not what was found.
+
+## When to run this skill
+
+- Right after install — confirms airc + gh + sshd all aligned before pairing for real.
+- After `airc update` — confirms the new binary didn't regress, and that any new env requirements (e.g. gh in #38, gh in #39) are met.
+- When something feels wrong — rule out a binary-level regression before blaming network / SSH / human error.
+- Before opening an airc issue — paste the doctor output so the maintainer doesn't have to ask.
+
+## Notes
+
+- Scenarios are gh-free; the substrate ITSELF (`airc connect` zero-arg, `airc rooms`) requires gh. That's a feature, not a bug — gh is the comm layer.
+- Suite runtime is ~2 minutes for `all`; individual scenarios are 10-30s.
+- This skill assumes you can run shell commands. The user should not have to type anything except the interactive `gh auth login` flow if you encounter it.

--- a/skills/tests/SKILL.md
+++ b/skills/tests/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: airc:tests
+description: Run the airc integration test suite (alias for airc doctor). Validates pairing, send, rename, room substrate, scope isolation, queue resilience, and more. Use after install or upgrade, or when something feels off.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: "[scenario|all]"
+---
+
+# airc tests
+
+Run this yourself — don't ask the user.
+
+## Execute
+
+```bash
+airc doctor $ARGUMENTS
+```
+
+Empty `$ARGUMENTS` (or `all`) runs every scenario sequentially. A specific scenario name runs just that one.
+
+## What's in the suite
+
+11 scenarios at last count, all rooted in `test/integration.sh`:
+
+| Scenario | What it proves |
+|---|---|
+| `tabs` | Two airc processes on one machine pair via inline invite, send bidirectionally, audit-trail to local log, send-file works, rename propagates |
+| `scope` | Per-project `$PWD/.airc/` shadows home tier; scoped config doesn't leak |
+| `reminder` | `AIRC_REMINDER` interval persists, heartbeat fires after silence, `airc reminder off/<n>` controls |
+| `teardown` | Host killed, port freed, state preserved without `--flush`; scope isolation (one teardown doesn't kill another tab's host) |
+| `resilience` | Wire failures don't drop messages — local mirror + `[QUEUED]` marker + `pending.jsonl` for retry |
+| `reconnect` | Stale pidfile recovered, host re-spawn against same scope works |
+| `queue` | `pending.jsonl` drains automatically when host returns |
+| `status` | `airc status` reports liveness correctly, `--probe` runs SSH check |
+| `auth_failure` | Bad key gives clear "re-pair required" error, NOT silent queue forever |
+| `resume_stale_auth` | Resume detects stale SSH key at probe time, dies loud with reconstructed invite string |
+| `room` | #39 IRC substrate — `--room <name>` + cmd_part host/joiner detection + `room_name` state file |
+
+## How to read output
+
+Final line: `N passed, M failed`. `0 failed` means green. Failures print by name above the summary; report them verbatim to the user.
+
+## When to run
+
+- Right after install — `airc tests` to confirm the binary works on this machine before pairing for real.
+- After `airc update` — confirm the new binary didn't regress.
+- When something feels wrong — rule out a binary-level bug before blaming network / gh / SSH.
+- After local edits to `airc` script — fast feedback loop instead of pairing manually.
+
+## Common failure → diagnosis
+
+Most failures fall into a small set:
+
+- **`alpha host failed to start`** — `airc` not on PATH, or port 7549 (test-reserved) is taken. Check `lsof -iTCP:7549`. Killing whatever holds it usually fixes.
+- **`beta join failed`** — SSH Remote Login isn't enabled on this machine, OR a firewall is blocking TCP to 7549. macOS: System Settings → General → Sharing → Remote Login.
+- **`scope: local tier shadows home` / `home tier inheritance`** — the two-tier resolver in airc itself is regressed. Usually a recent edit broke `ensure_init` / `get_config_val`. Bisect against last known green sha.
+- **`teardown in different scope killed foreign host`** — scope isolation broke. Critical (one tab nuking another's session). File issue immediately.
+- **`alpha cmd_part DID NOT identify as host`** — cmd_part's host-vs-joiner detection regressed. The signal is `config.json::host_target` empty = host. Don't fall back to gist_id presence — that was the original bug (#39 PR2).
+
+## Notes
+
+- Suite uses port 7549 (test-reserved) and `AIRC_HOME=/tmp/airc-it-*`. Won't touch live airc on default 7547 or alt 7548.
+- All scenarios are `gh`-free — they use the inline invite handshake, not the gist transport. (This is by design; tests must run in CI without GH credentials.)
+- The room scenario uses `--no-gist --room <unique-name>` to exercise IRC-substrate flag plumbing without polluting the user's gh gist namespace.
+- Cleans up via pidfiles after itself — no broad `pkill` hammers. If something hangs, `airc teardown --all` is the manual recovery.

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -73,11 +73,22 @@ cleanup_known_hosts() {
 cleanup_all() { cleanup_procs; cleanup_dirs; cleanup_known_hosts; }
 
 # Boot a host. Args: home, name, port
+#
+# Defaults to --no-general --no-gist for two reasons:
+# (1) These existing scenarios test the LOWER-layer single-pair invite
+#     behavior, not the IRC substrate. With #39's defaults, bare
+#     `airc connect` would create a real `airc room: general` gist on
+#     the user's gh account and pollute the test environment for every
+#     subsequent scenario that bare-connects.
+# (2) Tests must run gh-free in CI; --no-gist is the explicit opt-out.
+# Scenarios that DO want substrate behavior (scenario_room) call airc
+# directly with their own flags rather than going through spawn_host.
 spawn_host() {
   local home="$1" name="$2" port="$3"
   mkdir -p "$home"
   ( cd "$home" && AIRC_HOME="$home/state" AIRC_NAME="$name" AIRC_PORT="$port" \
-      "$AIRC" connect > "$home/out.log" 2>&1 & )
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-general --no-gist > "$home/out.log" 2>&1 & )
   local i
   for i in 1 2 3 4 5; do
     sleep 1
@@ -87,10 +98,15 @@ spawn_host() {
 }
 
 # Join a host. Args: home, name, join-string
+#
+# AIRC_NO_DISCOVERY=1 also for tests — the joiner's target is always an
+# inline invite string in the existing scenarios; we don't want it
+# probing gh for a #general gist that may have been created out-of-band.
 spawn_joiner() {
   local home="$1" name="$2" join="$3"
   mkdir -p "$home"
   ( cd "$home" && AIRC_HOME="$home/state" AIRC_NAME="$name" \
+      AIRC_NO_DISCOVERY=1 \
       "$AIRC" connect "$join" > "$home/out.log" 2>&1 & )
   local i
   for i in 1 2 3 4 5 6; do
@@ -293,7 +309,8 @@ scenario_reminder() {
   local home=/tmp/airc-it-r
   mkdir -p "$home"
   ( cd "$home" && AIRC_HOME="$home/state" AIRC_NAME=hb-host AIRC_PORT=7549 AIRC_REMINDER=2 \
-      "$AIRC" connect > "$home/out.log" 2>&1 & )
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-general --no-gist > "$home/out.log" 2>&1 & )
   local i
   for i in 1 2 3 4 5; do sleep 1; grep -q 'Hosting as' "$home/out.log" 2>/dev/null && break; done
 
@@ -392,7 +409,8 @@ scenario_resilience() {
   # PID 1 always exists but can't be our parent, and pgrep -P 999999 always returns 1.
   echo "999999" > "$sp_home/state/airc.pid"
   ( cd "$sp_home" && AIRC_HOME="$sp_home/state" AIRC_NAME=stalepid-host AIRC_PORT=7549 \
-      "$AIRC" connect > "$sp_home/out.log" 2>&1 & )
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-general --no-gist > "$sp_home/out.log" 2>&1 & )
   local i
   for i in 1 2 3 4 5 6; do sleep 1; grep -q 'Hosting as' "$sp_home/out.log" 2>/dev/null && break; done
   grep -q 'Hosting as' "$sp_home/out.log" && pass "stale pidfile: cmd_connect recovers and reaches Hosting" \
@@ -482,7 +500,8 @@ scenario_reconnect() {
   # (Can't use spawn_host as-is because it mkdir's and overwrites state.
   #  Instead re-invoke connect directly pointing at the same state.)
   ( cd /tmp/airc-it-rec-h && AIRC_HOME=/tmp/airc-it-rec-h/state AIRC_NAME=alpha AIRC_PORT=7549 \
-      "$AIRC" connect >> /tmp/airc-it-rec-h/out.log 2>&1 & )
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-general --no-gist >> /tmp/airc-it-rec-h/out.log 2>&1 & )
   local i
   for i in 1 2 3 4 5 6 7 8; do
     sleep 1
@@ -786,6 +805,123 @@ scenario_resume_stale_auth() {
   cleanup_all
 }
 
+# ── Scenario: room (#39 — IRC-style #general substrate) ────────────────
+# Validates the room-mode flag plumbing, host-vs-joiner detection in
+# cmd_part, and that --no-gist still records local room state. Doesn't
+# touch GitHub at all (no gh dependency); all wire-level pairing reuses
+# the long-invite handshake the rest of the suite already proves.
+#
+# What we DO test:
+#   - --room flag accepted; banner reports "Hosting #<name> (gh-account substrate)"
+#   - room_name file written under AIRC_HOME (even with --no-gist)
+#   - joiner pairs via inline invite and bidirectional send works
+#   - cmd_part on host: detects host via config.host_target absence, runs
+#     teardown, removes room_name file, doesn't try to gh-delete (no
+#     gist_id stored under --no-gist)
+#   - cmd_part on joiner: reports joiner status, removes room_name only,
+#     leaves identity intact
+#
+# What we explicitly DON'T test (out of scope; covered by manual e2e
+# w/ real gh + the next PR's multi-room work):
+#   - Discovery of an existing #general gist on the gh account
+#   - Persistence of a room gist after pair (the gist itself isn't
+#     created here — `--no-gist` keeps the test gh-free)
+#   - Multi-joiner room (one host, N joiners) — single-joiner here
+#     proves the flag path; N-joiner is a topology test, not a flag test
+scenario_room() {
+  section "room: #39 IRC-style substrate (--room + cmd_part, no gh)"
+  cleanup_all
+
+  local rname="test-irc-$$"
+
+  # ── Host alpha in room mode, gist push disabled so the test runs
+  #    in any environment (CI, gh-less workstations).
+  mkdir -p /tmp/airc-it-h
+  ( cd /tmp/airc-it-h && AIRC_HOME=/tmp/airc-it-h/state AIRC_NAME=alpha AIRC_PORT=7549 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room "$rname" > /tmp/airc-it-h/out.log 2>&1 & )
+  local i
+  for i in 1 2 3 4 5; do
+    sleep 1
+    grep -q 'Hosting as' /tmp/airc-it-h/out.log 2>/dev/null && break
+  done
+  grep -q 'Hosting as' /tmp/airc-it-h/out.log \
+    && pass "alpha hosting in room mode (--room ${rname}, --no-gist)" \
+    || { fail "alpha host failed to start in room mode"; cleanup_all; return; }
+
+  # Banner asserts substrate framing: "Hosting #<name>" must appear so
+  # users (and the AI agent) can tell which channel they're on.
+  grep -qE "Hosting #${rname}" /tmp/airc-it-h/out.log \
+    && pass "alpha banner reports #${rname} (substrate framing)" \
+    || fail "alpha banner missing 'Hosting #${rname}' line"
+
+  # room_name file MUST be on disk even with --no-gist. cmd_part + status
+  # + diagnostics rely on it.
+  [ -f /tmp/airc-it-h/state/room_name ] && [ "$(cat /tmp/airc-it-h/state/room_name)" = "$rname" ] \
+    && pass "alpha room_name file recorded ($(cat /tmp/airc-it-h/state/room_name))" \
+    || fail "alpha room_name file missing or wrong value"
+
+  # No gist was pushed → no room_gist_id (this is the bug we just fixed:
+  # cmd_part previously used gist_id presence as the host-vs-joiner
+  # signal, which would misclassify --no-gist hosts as joiners).
+  [ ! -f /tmp/airc-it-h/state/room_gist_id ] \
+    && pass "alpha has no room_gist_id (--no-gist as expected)" \
+    || fail "alpha unexpectedly wrote room_gist_id under --no-gist"
+
+  # ── Joiner beta pairs via inline invite (long form, gh-free).
+  local join; join=$(read_join_string /tmp/airc-it-h)
+  [ -n "$join" ] && pass "alpha join string captured for beta to use" \
+                 || { fail "no join string in alpha log"; cleanup_all; return; }
+
+  spawn_joiner /tmp/airc-it-j beta "$join" \
+    && pass "beta joined alpha's room" \
+    || { fail "beta join failed"; cleanup_all; return; }
+
+  # Bidirectional send still works through a room (room-ness is purely
+  # at the discovery + lifecycle layer; the wire is unchanged).
+  sleep 3
+  as_home /tmp/airc-it-j send @alpha "room-msg-from-beta" >/dev/null 2>&1 \
+    && pass "beta → alpha send through room works" \
+    || fail "beta → alpha send through room FAILED"
+  sleep 3
+  grep -q 'room-msg-from-beta' /tmp/airc-it-h/out.log \
+    && pass "alpha received beta's message through room" \
+    || fail "alpha did NOT receive beta's message"
+
+  # ── cmd_part on JOINER (beta).
+  # Joiner has host_target in config → cmd_part takes joiner branch:
+  # removes room_name only, doesn't touch gist (we have none anyway),
+  # then runs teardown.
+  local part_out
+  part_out=$(as_home /tmp/airc-it-j part 2>&1)
+  echo "$part_out" | grep -q 'Joiner of #' \
+    && pass "beta cmd_part identifies as joiner (config.host_target detection)" \
+    || fail "beta cmd_part DID NOT identify as joiner: $part_out"
+  echo "$part_out" | grep -qE 'gh.*delete|gist delete' \
+    && fail "beta cmd_part attempted gh delete (joiner shouldn't)" \
+    || pass "beta cmd_part correctly skipped gh delete (joiner)"
+  [ ! -f /tmp/airc-it-j/state/room_name ] \
+    && pass "beta room_name removed after part" \
+    || fail "beta room_name still present after part"
+
+  # ── cmd_part on HOST (alpha).
+  # Host has no host_target → cmd_part takes host branch. With --no-gist
+  # there's no gist_id, so it should report "no gist was published"
+  # rather than mis-routing into joiner branch (the bug we just fixed).
+  part_out=$(as_home /tmp/airc-it-h part 2>&1)
+  echo "$part_out" | grep -q 'Host of #' \
+    && pass "alpha cmd_part identifies as host (config no host_target)" \
+    || fail "alpha cmd_part DID NOT identify as host: $part_out"
+  echo "$part_out" | grep -q 'no gist was published' \
+    && pass "alpha cmd_part correctly noted absent gist (--no-gist host case)" \
+    || fail "alpha cmd_part didn't acknowledge --no-gist case: $part_out"
+  [ ! -f /tmp/airc-it-h/state/room_name ] \
+    && pass "alpha room_name removed after part" \
+    || fail "alpha room_name still present after part"
+
+  cleanup_all
+}
+
 case "$MODE" in
   tabs)         scenario_tabs  ;;
   scope)        scenario_scope ;;
@@ -797,8 +933,9 @@ case "$MODE" in
   status)       scenario_status ;;
   auth_failure) scenario_auth_failure ;;
   resume_stale_auth) scenario_resume_stale_auth ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|all]"; exit 2 ;;
+  room)         scenario_room ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Followup on #39

The IRC-substrate code shipped in #39 (\`cf58c91\`) needed validation. While writing the test, found a real bug in \`cmd_part\` and fixed two more issues in \`airc\` itself.

## Bug found + fixed

**\`cmd_part\` host-vs-joiner misclassification.** Used \`room_gist_id\` file presence as the host signal — wrong, because:
- Host with \`--no-gist\` writes no \`room_gist_id\` → falls into joiner branch, prints wrong status, leaks room from gh namespace
- Host whose \`gh gist create\` failed → same misclassification

Fix: detect via \`config.json::host_target\` empty == host (same signal cmd_connect uses everywhere). \`room_gist_id\` is treated as an artifact, not a signal.

## Other airc fixes

- \`Hosting #<name> (gh-account substrate)\` banner only printed inside gist-push-success — moved it (and the \`room_name\` file write) outside so room state is consistent under \`--no-gist\` and gh-failure cases
- \`resolved_room_name\` was declared inside gist parser block; JOIN MODE crashed under \`set -u\` when joining via inline invite (which skips the parser). Hoisted to function scope
- \`airc tests\` + \`airc test\` now alias \`airc doctor\`

## New test scenario

\`scenario_room\` (\`test/integration.sh\`) — 14 assertions:
- \`--room\` flag accepted, banner reports \`Hosting #<name>\`
- \`room_name\` file written on disk under \`--no-gist\`
- No spurious \`room_gist_id\` written when \`--no-gist\`
- Bidirectional send works through a room (proves room-ness is purely discovery/lifecycle, wire is unchanged)
- \`cmd_part\` on joiner: identifies as joiner, skips gh delete, removes only \`room_name\`
- \`cmd_part\` on host: identifies as host (config detection), acknowledges absent gist, removes \`room_name\`

Gh-free — uses inline invite handshake, no gh dependency. Runs in CI.

## Pre-existing scenarios updated

\`spawn_host\` + 3 direct \`airc connect\` callsites now pass \`--no-general --no-gist\` + \`AIRC_NO_DISCOVERY=1\`. Required because with #39's defaults, bare \`airc connect\` would push a real \`airc room: general\` gist to the dev's gh account on every test run, then subsequent scenarios would auto-discover it and try to join a dead host. Tests caught this immediately — exactly the kind of regression the suite is for.

## New skill — \`/airc:tests\`

Thin wrapper around \`airc doctor\`. Maps each scenario to what it proves. Lists common failures + likely causes. Lets the AI pick one scenario for fast feedback when something specific is suspect.

## Rewritten skill — \`/airc:doctor\`

No longer "run tests + print results." Now:

1. **Environment health check FIRST** — gh present? gh authed? sshd up? port 7549 free?
2. **Acts on findings** — install gh if missing (platform-specific commands), tell user to run interactive \`gh auth login\`, etc.
3. **Then run tests**.
4. **Interpret with a what-to-do table** — not what-it-means, what-to-do.
5. **Final report**: "Fixed X. All green." not "Diagnosed X."

Point: AI fixes the user's environment, doesn't just hand them a problem.

## Test results

\`airc doctor all\` (or \`airc tests all\`):

\`\`\`
88 passed, 0 failed
\`\`\`

10 prior scenarios + 1 new = 11 scenarios green, no regressions.

## Followups

- README rewrite for the substrate framing (separate PR)
- Multi-room (in #general AND #project-x simultaneously) — separate PR, separate scope
- Continuum-airc bridge (continuum personas as airc citizens on the substrate) — much later, after #75 cognition work lands