### PR TITLE
feat(update): release channels (main + canary) — bootstrap mechanism

### DIFF
--- a/airc
+++ b/airc
@@ -2035,26 +2035,108 @@ except Exception:
 }
 
 cmd_update() {
-  # Refresh install dir (git pull) AND re-run install.sh so new skills get
-  # symlinked into ~/.claude/skills/ and old ones get cleaned up. install.sh
-  # is idempotent — it handles the pull, the binary symlink, and the skill
+  # Refresh install dir AND re-run install.sh so new skills get symlinked
+  # into ~/.claude/skills/ and old ones get cleaned up. install.sh is
+  # idempotent — it handles the pull, the binary symlink, and the skill
   # directory refresh in one pass. Does NOT teardown or reconnect.
+  #
+  # Channels (#40 followup): airc supports release channels for opt-in
+  # pre-merge testing. main = stable; canary = features-not-yet-promoted.
+  # The chosen channel persists in $AIRC_DIR/.channel so subsequent
+  # `airc update` (no args) keeps the user on their chosen track.
+  #   airc update                    # stay on current channel (default: main)
+  #   airc update --channel canary   # switch to canary + update
+  #   airc update --channel main     # switch back to main + update
+  #   airc channel                   # show current channel without updating
   local dir="${AIRC_DIR:-$HOME/.airc-src}"
+  local channel_file="$dir/.channel"
+  local requested_channel=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --channel|-c)
+        requested_channel="${2:-}"
+        [ -z "$requested_channel" ] && die "Usage: airc update --channel <name>"
+        shift 2
+        ;;
+      --canary) requested_channel="canary"; shift ;;
+      --main)   requested_channel="main";   shift ;;
+      *) shift ;;
+    esac
+  done
+
   if [ ! -d "$dir/.git" ]; then
     die "No git checkout at $dir. Reinstall: curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash"
   fi
+
+  # Determine target channel: explicit request > saved preference > main.
+  local channel
+  if [ -n "$requested_channel" ]; then
+    channel="$requested_channel"
+  elif [ -f "$channel_file" ]; then
+    channel=$(cat "$channel_file" 2>/dev/null | tr -d '[:space:]')
+    [ -z "$channel" ] && channel="main"
+  else
+    channel="main"
+  fi
+
+  # Switch to the target branch BEFORE pulling. install.sh will then ff-pull
+  # whatever branch is checked out. Fail loud if the channel doesn't exist
+  # on origin — silently falling back to main would defeat the opt-in test
+  # purpose.
   local before; before=$(git -C "$dir" rev-parse --short HEAD 2>/dev/null)
+  local current_branch; current_branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  if [ "$current_branch" != "$channel" ]; then
+    git -C "$dir" fetch --quiet origin "$channel" 2>/dev/null \
+      || die "Channel '$channel' not found on origin. Try: airc channel (to see options)."
+    git -C "$dir" checkout -q "$channel" 2>/dev/null \
+      || git -C "$dir" checkout -q -B "$channel" "origin/$channel" 2>/dev/null \
+      || die "Failed to checkout '$channel'. Resolve manually in $dir."
+  fi
+
   if [ ! -x "$dir/install.sh" ]; then
     die "install.sh missing at $dir. Reinstall via curl|bash."
   fi
   AIRC_DIR="$dir" bash "$dir/install.sh" || die "install.sh failed."
+
+  # Persist channel choice AFTER successful update so a failed switch
+  # doesn't leave a dangling preference for a broken state.
+  echo "$channel" > "$channel_file"
+
   local after; after=$(git -C "$dir" rev-parse --short HEAD 2>/dev/null)
   if [ "$before" = "$after" ]; then
-    echo "  Already at ${after}. Skills refreshed."
+    echo "  Already at ${after} on channel '${channel}'. Skills refreshed."
   else
-    echo "  Updated: ${before} -> ${after}. Skills refreshed."
+    echo "  Updated: ${before} -> ${after} on channel '${channel}'. Skills refreshed."
     echo "  Running monitor still uses the old code. To pick up:  airc teardown && airc connect"
   fi
+}
+
+# ── cmd_channel: show or set the release channel without pulling ──────
+# `airc channel`           → print current channel + how to switch
+# `airc channel canary`    → set preferred channel; doesn't pull (use
+#                            `airc update` after to actually switch)
+# Allows the AI / human to inspect + decide before the heavier update.
+cmd_channel() {
+  local dir="${AIRC_DIR:-$HOME/.airc-src}"
+  local channel_file="$dir/.channel"
+  local current="main"
+  [ -f "$channel_file" ] && current=$(cat "$channel_file" 2>/dev/null | tr -d '[:space:]')
+  [ -z "$current" ] && current="main"
+
+  local target="${1:-}"
+  if [ -z "$target" ]; then
+    echo "  Channel: $current"
+    echo "  Available channels (any branch on origin can be a channel):"
+    echo "    main      — stable, what most users run"
+    echo "    canary    — features queued for the next main merge; opt-in testing"
+    echo "  Switch:"
+    echo "    airc channel <name>           # set preference (run 'airc update' after)"
+    echo "    airc update --channel <name>  # set + pull in one step"
+    return 0
+  fi
+
+  echo "$target" > "$channel_file"
+  echo "  Channel preference set: '$target'. Run 'airc update' to actually switch + pull."
 }
 
 cmd_version() {
@@ -2268,7 +2350,9 @@ case "${1:-help}" in
   rooms|list|ls) shift; cmd_rooms "$@" ;;
   part) shift; cmd_part "$@" ;;
   version|--version|-v) cmd_version ;;
-  update|upgrade|pull) cmd_update ;;
+  update|upgrade|pull) shift; cmd_update "$@" ;;
+  channel) shift; cmd_channel "$@" ;;
+  canary) shift; cmd_update --channel canary "$@" ;;
   logs)      shift; cmd_logs "$@" ;;
   status)    shift; cmd_status "$@" ;;
   doctor)    shift; cmd_doctor "$@" ;;
@@ -2287,6 +2371,10 @@ case "${1:-help}" in
     echo "  airc connect <name@user@host>   Join via inline invite string (legacy)"
     echo "  airc rooms / list / ls          List open rooms + invites on your gh account"
     echo "  airc part                       Leave current room (host: deletes room gist)"
+    echo "  airc update [--channel <name>]  Pull latest on current channel; switch with --channel canary|main"
+    echo "  airc channel [<name>]           Show or set release channel (main = stable, canary = pre-merge testing)"
+    echo "  airc canary                     Shortcut: airc update --channel canary"
+    echo "  airc tests / doctor [scenario]  Run integration suite (88 assertions across 11 scenarios)"
     echo "  airc send <peer> <message>      Send a message"
     echo "  airc ping @peer [timeout]       Monitor-liveness probe (ping/pong, 10s default)"
     echo "  airc rename <new-name>          Rename this session (notifies peers)"

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: airc:canary
+description: Switch this airc install to the canary channel — pre-merge features queued for the next main release. Use when Joel asks you to test something that hasn't landed on main yet, or when you want the bleeding edge.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: ""
+---
+
+# airc canary
+
+Run this yourself — don't ask the user.
+
+## What it does
+
+Switches this airc install to the `canary` channel. Under the covers:
+- `git fetch origin canary`
+- `git checkout canary`
+- `git pull --ff-only`
+- Refreshes skills + binary symlinks via `install.sh`
+- Persists the choice to `$AIRC_DIR/.channel` so subsequent `airc update` (no args) stays on canary
+
+## Execute
+
+```bash
+airc canary
+```
+
+Equivalent to `airc update --channel canary`. The shortcut exists because "go canary" is the common case for pre-merge testing.
+
+## What "canary" means
+
+| Channel | What it is | When to use |
+|---|---|---|
+| `main` | Stable. Most users run this. | Default. |
+| `canary` | Long-lived branch ahead of main. Features that haven't been merged to main yet land here first; we test on canary, then promote canary→main as a single integration commit. | When testing a not-yet-merged feature, OR when you want bleeding edge. |
+
+`canary` is just a git branch. Switching back is symmetric: `airc update --channel main` (or `airc channel main && airc update`).
+
+## Rollback
+
+If canary breaks something:
+
+```bash
+airc update --channel main
+airc teardown && airc connect
+```
+
+That's it. Branch switch + restart monitor on the new code. Identity, peers, room state all persist (they're in `$AIRC_HOME`, not `$AIRC_DIR`).
+
+## After switching
+
+Tell the user:
+
+> "Switched to canary (sha `<short-sha>`). Running monitor still uses old code — `airc teardown && airc connect` to pick up the new binary."
+
+Then if they had a paired session you should restart the monitor for them:
+```
+Monitor(persistent=true, command="airc connect")
+```
+
+## When to use this skill
+
+- Joel says "test the canary" / "try the new substrate work" / similar.
+- A new feature is queued in canary and bigmama / memento / anvil need to validate before promotion.
+- The user mentions a recent merged-to-canary PR by number (e.g. "test PR #40").
+
+## When NOT to use this skill
+
+- For routine updates → use `/airc:update` (stays on whatever channel they're on; doesn't switch).
+- For first-time install → use `/airc:connect` which auto-installs main.
+
+## Notes
+
+- This is not "experimental beta channel" — canary is "merged-but-not-yet-promoted." Code on canary has passed local tests + the contributor's review; it just hasn't earned its way to main yet via cross-machine validation.
+- Channel preference lives in `$AIRC_DIR/.channel`. Inspect with `airc channel`.
+- If `gh auth status` is clean, the substrate (`airc connect` zero-arg → #general) works exactly the same on canary as on main — channels affect the airc binary, not the gist namespace.


### PR DESCRIPTION
## Why this PR exists

The bigger substrate work is queued in \`canary\` (PR #40 already merged into canary, not main). For anyone to opt INTO canary, the channel mechanism itself has to be on main — otherwise users have no way to switch from main to canary except manual git ops.

So this is a **bootstrap PR**: cherry-picks the channel-feature commit (\`8a8dfbe\` from canary) directly onto main. Once this lands on main, every existing airc user can \`airc update\` → get the channel feature → \`airc canary\` to opt into the substrate testing track.

## What's in it

Single commit (\`0c73b04\`, cherry-picked from canary's \`8a8dfbe\`):

- \`airc update [--channel <name>]\` switches branches + pulls + reruns install.sh
- \`airc channel [<name>]\` shows / sets preference without pulling
- \`airc canary\` shortcut for \`airc update --channel canary\`
- \`.channel\` file persists choice in \`\$AIRC_DIR\` so subsequent \`airc update\` stays on track
- Rollback symmetric: \`airc update --channel main\`
- \`/airc:canary\` skill so the AI knows to switch when Joel says "test the canary"

## What's NOT in it (still queued in canary)

- The substrate test scenario + cmd_part bugfix + skills rewrites (PR #40, merged into canary)
- These wait on bigmama validation before promoting canary → main

## Workflow this enables

1. Merge this → main has channel mechanism
2. \`airc update\` from any machine → gets channel feature
3. \`airc canary\` → opts into the substrate testing track
4. Bigmama / memento / anvil iterate on canary
5. When canary is solid, single canary → main merge promotes everything

## Tested locally

- \`airc help\` shows new commands
- \`airc channel\` reports current = main (default, no \`.channel\` file)
- Cherry-pick clean (one auto-merge in airc, no conflicts)
- bash -n airc passes