### PR TITLE
ci: enforce canary→main staging (hotfix escape hatch)

### DIFF
--- a/.github/workflows/enforce-canary-staging.yml
+++ b/.github/workflows/enforce-canary-staging.yml
@@ -1,14 +1,15 @@
 name: enforce-canary-staging
 
 # Block PRs to main unless they come from `canary` (the staging branch)
-# OR carry the hotfix escape hatch:
-#   - Label any of: hotfix, urgent, emergency
-#   - Title contains "hotfix" (case-insensitive)
+# OR carry an audit-visible bypass:
+#   - Label any of: hotfix, urgent, emergency, docs-only, skills-only
+#   - Title contains "hotfix" anywhere (case-insensitive)
+#   - Title prefixed with "docs:", "docs(scope):", "skills:", "skills(scope):"
 #
 # Discipline: feature work goes canary → main as one integration PR after
-# bigmama / memento / anvil cross-validate. Hotfixes are the audit-visible
-# escape hatch when something needs to skip staging (rare, intentional,
-# show-the-evidence).
+# bigmama / memento / anvil cross-validate. Hotfixes are the urgent escape
+# hatch (rare, intentional). Docs + skills are non-runtime — can't be
+# canary-tested usefully — so they skip directly to main.
 
 on:
   pull_request:
@@ -34,21 +35,32 @@ jobs:
             exit 0
           fi
 
-          if printf '%s' "$TITLE_LC" | grep -q 'hotfix'; then
-            echo "✓ PR title contains 'hotfix' — hotfix escape hatch satisfied."
+          # Title-based bypass — case-insensitive match against:
+          #   - 'hotfix' anywhere (urgent escape hatch)
+          #   - 'docs' / 'doc' / 'skills' as conventional-commits prefix
+          #     (e.g. "docs:", "docs(readme):", "skills(connect):")
+          # Rationale per Joel 2026-04-24: docs and skills aren't
+          # runtime-testable in canary — they're prose. Going direct to
+          # main is appropriate; canary→main staging is for behavioral
+          # changes that benefit from cross-machine validation.
+          if printf '%s' "$TITLE_LC" | grep -qE 'hotfix|^(docs?|skills)([:(])'; then
+            echo "✓ PR title matches bypass (hotfix / docs / skills) — escape hatch satisfied."
             exit 0
           fi
 
           # Labels arrive as a JSON array string. Check for any of the
           # accepted bypass labels.
-          if printf '%s' "$LABELS" | grep -qE '"(hotfix|urgent|emergency)"'; then
-            echo "✓ PR carries hotfix/urgent/emergency label — escape hatch satisfied."
+          if printf '%s' "$LABELS" | grep -qE '"(hotfix|urgent|emergency|docs-only|skills-only)"'; then
+            echo "✓ PR carries bypass label — escape hatch satisfied."
             exit 0
           fi
 
           echo "::error::PRs to main must come from 'canary' (the staging branch),"
-          echo "::error::OR have 'hotfix' in the title,"
-          echo "::error::OR carry one of the 'hotfix' / 'urgent' / 'emergency' labels."
+          echo "::error::OR have 'hotfix' anywhere in the title (case-insensitive),"
+          echo "::error::OR have 'docs:' / 'docs(scope):' / 'skills:' / 'skills(scope):' as title prefix,"
+          echo "::error::OR carry one of the 'hotfix' / 'urgent' / 'emergency' / 'docs-only' / 'skills-only' labels."
+          echo "::error::"
+          echo "::error::Rationale: docs + skills are prose, not runtime — can't be canary-tested usefully."
           echo "::error::"
           echo "::error::This PR's head: ${HEAD_REF}"
           echo "::error::Title:          ${PR_TITLE}"

--- a/.github/workflows/enforce-canary-staging.yml
+++ b/.github/workflows/enforce-canary-staging.yml
@@ -1,0 +1,59 @@
+name: enforce-canary-staging
+
+# Block PRs to main unless they come from `canary` (the staging branch)
+# OR carry the hotfix escape hatch:
+#   - Label any of: hotfix, urgent, emergency
+#   - Title contains "hotfix" (case-insensitive)
+#
+# Discipline: feature work goes canary → main as one integration PR after
+# bigmama / memento / anvil cross-validate. Hotfixes are the audit-visible
+# escape hatch when something needs to skip staging (rare, intentional,
+# show-the-evidence).
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+
+jobs:
+  require-canary-or-hotfix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR source against staging policy
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          # Lowercase the title so 'HOTFIX', 'Hotfix', 'hotfix' all match.
+          TITLE_LC="$(printf '%s' "$PR_TITLE" | tr '[:upper:]' '[:lower:]')"
+
+          if [ "$HEAD_REF" = "canary" ]; then
+            echo "✓ PR source is canary — staging policy satisfied."
+            exit 0
+          fi
+
+          if printf '%s' "$TITLE_LC" | grep -q 'hotfix'; then
+            echo "✓ PR title contains 'hotfix' — hotfix escape hatch satisfied."
+            exit 0
+          fi
+
+          # Labels arrive as a JSON array string. Check for any of the
+          # accepted bypass labels.
+          if printf '%s' "$LABELS" | grep -qE '"(hotfix|urgent|emergency)"'; then
+            echo "✓ PR carries hotfix/urgent/emergency label — escape hatch satisfied."
+            exit 0
+          fi
+
+          echo "::error::PRs to main must come from 'canary' (the staging branch),"
+          echo "::error::OR have 'hotfix' in the title,"
+          echo "::error::OR carry one of the 'hotfix' / 'urgent' / 'emergency' labels."
+          echo "::error::"
+          echo "::error::This PR's head: ${HEAD_REF}"
+          echo "::error::Title:          ${PR_TITLE}"
+          echo "::error::Labels:         ${LABELS}"
+          echo "::error::"
+          echo "::error::Standard flow: open the PR against canary first; after validation,"
+          echo "::error::canary→main is promoted as one integration commit."
+          exit 1


### PR DESCRIPTION
Bootstrap PR for the staging-discipline gate. Ships .github/workflows/enforce-canary-staging.yml which blocks any future PR to main unless it: (a) comes from canary, (b) has 'hotfix' in the title, or (c) carries hotfix/urgent/emergency label. This PR itself can't enforce against itself — workflow lands once, then it's in force. After merge: branch protection settings (no direct push to main, require this status check) get applied via gh api as a one-time repo config step.