### PR TITLE
fix(install): respect BIN_DIR + SKILLS_TARGET env overrides

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,8 +10,14 @@ set -euo pipefail
 
 REPO_URL="https://github.com/CambrianTech/airc.git"
 CLONE_DIR="${AIRC_DIR:-$HOME/.airc-src}"
-BIN_DIR="$HOME/.local/bin"
-SKILLS_TARGET="$HOME/.claude/skills"
+# BIN_DIR + SKILLS_TARGET respect env-var overrides so test harnesses
+# (and packagers, distros, etc.) can point install.sh at a sandbox
+# instead of stomping ~/.local/bin and ~/.claude/skills. Pre-fix, a
+# test passing BIN_DIR=/tmp/foo would be silently ignored and the
+# real ~/.local/bin/airc symlink would get rewritten to point at the
+# test dir — caught when our own canary test corrupted the real install.
+BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
+SKILLS_TARGET="${SKILLS_TARGET:-$HOME/.claude/skills}"
 
 info()  { printf '  \033[1;34m->\033[0m %s\n' "$*"; }
 ok()    { printf '  \033[1;32m->\033[0m %s\n' "$*"; }


### PR DESCRIPTION
Caught while testing the previous install.sh fix (#43). Hardcoded BIN_DIR + SKILLS_TARGET meant test harnesses passing those as env vars got silently ignored, and the real ~/.local/bin/airc symlink got stomped. Fix: use `${VAR:-default}` pattern. Tested: real install untouched when env overrides supplied. Bugs-are-gifts loop.