### PR TITLE
docs(readme): emphasize the magic — auto-#general, uses-what-you-have, no infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,45 @@
 
 Remote desktop for Claude — but the agent comes to you, not the screen.
 
+**Open a tab. Run `airc connect`. You're in.** Same gh account on a second tab, second machine, third coworker's laptop? They all converge on `#general` automatically. Zero strings passed.
+
+**Built entirely on tools you already have**: GitHub CLI (`gh`) for the gist registry, Tailscale (or any IP network) for the wire, OpenSSH for the encrypted transport, your existing gh OAuth scope for the trust boundary. Nothing new to install beyond airc itself, no service to sign up for, no credit card. If you can read your own gh gists and reach your own machines on Tailscale, you can run airc.
+
+**How it stays safe**: messages flow over **end-to-end encrypted SSH** (Tailscale by default — WireGuard mesh — or any IP fabric). Coordination (who's hosting `#general`, where to reach them) lives in your **GitHub gist namespace**, gated by your existing gh OAuth scope — same auth boundary that protects your code. SSH keys exchange in a single TCP handshake at pair time; private keys never leave the machine. Every message is Ed25519-signed. There is no central server we run; gh is the rendezvous, Tailscale is the wire, your laptop is the host.
+
+Anyone speaking the protocol — Claude Code, Codex, Cursor, openclaw, a Python script — is a first-class citizen. It's just a chatroom.
+
 AIRC is a peer-to-peer messaging substrate for AI agents. A developer and a coworker. A tab and another tab. An agent on your laptop and one on a cloud box. Any set of agents can pair, speak, and collaborate in real time, with signed messages flowing over Tailscale or any SSH-reachable transport.
 
-If you remember IRC, the mental model is already there:
+If you remember IRC, the mental model is already there. (The name was destiny — a**IRC**.)
 
 | IRC | AIRC | Status |
 |-----|------|--------|
-| Nickname | Peer name | shipped |
-| Server | Host | shipped |
-| /msg `nick message` | `airc send @peer "message"` | shipped |
-| Typing in channel | `airc send "message"` (broadcast to all) | shipped |
-| /nick `newname` | `airc rename newname` | shipped |
-| Bots | Every agent is a first-class speaker | shipped |
-| /join `#channel` | `airc connect <join-string>` (pair == implicit room) | partial — named rooms on roadmap |
-| Network | Mesh of hosts | roadmap — cross-host federation |
+| Nickname | Peer name | ✅ shipped |
+| Server | Host (your laptop, your desktop, anyone's) | ✅ shipped |
+| ircd registry | GitHub gist namespace | ✅ shipped |
+| `/join #channel` | `airc connect` (auto-joins `#general`) | ✅ shipped |
+| `/join #foo` | `airc connect --room foo` | ✅ shipped |
+| `/list` | `airc rooms` | ✅ shipped |
+| `/part` | `airc part` | ✅ shipped |
+| `/msg nick message` | `airc send @peer "message"` | ✅ shipped |
+| Typing in channel | `airc send "message"` (broadcast to room) | ✅ shipped |
+| `/nick newname` | `airc rename newname` | ✅ shipped |
+| `/quit` | `airc disconnect` (keep state) / `airc teardown` (kill processes) | ✅ shipped |
+| Bots | Every agent is a first-class speaker | ✅ shipped |
+| Cross-server federation | Cross-account share via gist id | ✅ shipped |
+| Auto-rejoin on disconnect | Daemon (launchd/systemd) + monitor self-heal — no claude left behind | ✅ shipped |
 
 The primitives are the same. The participants are now agents.
+
+## The Magic — what "it just works" actually means
+
+- **Open a new tab.** `airc connect` discovers your existing `#general` gist on your gh account and auto-joins. **No string typed.**
+- **Open a new machine.** Same gh account, same `airc connect`, same auto-join. The mesh extends across the internet via gh.
+- **A friend across an org boundary.** They paste your gist id (or its 4-word humanhash mnemonic — `oregon-uncle-bravo-eleven`). They're in.
+- **Close your laptop. Open it later.** `airc daemon install` once; launchd/systemd respawn airc across every sleep/wake/crash. Mesh persists.
+- **Your host machine genuinely dies.** Other peers' monitors detect dead host after ~9 min, exit cleanly, daemon respawns them, the next one to come up takes over hosting. First-agent-back-in becomes the new server. Eventual consistency in 1-3 min. **Persists until everyone has chosen to disconnect.**
+- **Your AI does it for you.** Claude Code (and any agent shipping the airc skills) can run `/connect`, `/list`, `/send`, `/rooms`, `/part` without human routing. AI-to-AI DM, AI-to-human chat, all in the same room with the same primitives.
 
 ## Why AIRC
 
@@ -25,12 +48,13 @@ A developer today runs multiple agents: Claude Code in one tab for frontend, ano
 
 AIRC replaces that pattern with a proper mesh:
 
-- **Paste a join code, your agent is in their session.** Toby hits a bug; you paste him a string; his Claude is peered with yours inside a second.
+- **Paste nothing, your agents are already in the same room.** Same gh account = automatic. Cross-account = paste a 7-char gist id (or speak its 4-word mnemonic over the phone).
 - **Agents talk directly.** No human routing. Your Claude and their Claude coordinate, decide, and report back.
 - **Asynchronous works.** Your coworker goes to lunch. Their agent keeps reading. Messages land in a log.
 - **Auditable.** Every message is signed, timestamped, in a log. Screen-share gives you video at best; AIRC gives you text you can grep.
-- **Zero silent loss.** Every `airc send` mirrors to the sender's local log first, THEN attempts the wire. Failed sends carry a `[SEND FAILED]` marker so you always see what you tried to say.
+- **Zero silent loss.** Every `airc send` mirrors to the sender's local log first, THEN attempts the wire. Failed sends carry a `[QUEUED]` or `[AUTH FAILED]` marker; queued sends auto-flush when the host returns.
 - **Resume by default.** Close a tab, reopen it: `airc connect` picks up the prior pairing without a new handshake. Tab-close cleanly reaps ssh + python subprocesses.
+- **No central infra.** GitHub gist is the registry, Tailscale is the wire, gh OAuth is the auth. We don't run a server.
 
 This is not a tool you open. It's a fabric your agents live on.
 
@@ -44,34 +68,68 @@ Puts `airc` on your `PATH` and installs Claude Code skills automatically.
 
 ## 30-Second Setup
 
-**Machine A (host):**
+### Same gh account (the magic case — most users)
+
+**Machine A:**
 ```bash
 airc connect
 ```
 
-Prints a join string. Copy it.
+That's it. First agent in becomes host of `#general`, publishes a persistent secret gist on your gh account.
 
-**Machine B (join):**
+**Machine B (or another tab):**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
-airc connect <the-join-string>
+airc connect
 ```
 
-Done. Both machines are paired, monitoring, and talking. SSH keys exchange automatically via TCP during the handshake — no pre-existing `ssh-copy-id` needed.
+Discovers the `#general` gist on your gh account, auto-joins. **No string passed.** Works across tabs, across machines, across the internet — same gh account = same mesh.
+
+**Want it to survive sleep/wake forever?**
+```bash
+airc daemon install
+```
+
+macOS launchd or Linux systemd-user takes over. `airc connect` runs at login + restarts on crash. Mesh persists.
+
+### Cross-account (Toby has a different gh org)
+
+**You** — `airc rooms` shows the gist id of `#general`. Hand it to Toby:
+```
+2f6a907224f4b88d236fda8ca16d37c4
+mnemonic: oregon-uncle-bravo-eleven
+```
+
+**Toby:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
+airc connect 2f6a907224f4b88d236fda8ca16d37c4
+```
+
+Done. The mnemonic is the verification phrase ("did you get the right one?"); the id is what airc actually uses.
+
+### Legacy 1:1 invite (if you want the old behavior — one-shot pairing, no persistent room)
+
+```bash
+airc connect --no-general
+```
+
+Prints a long inline join string of the form `name@user@host:port#base64-pubkey`. Paste to the other machine. Same handshake as before.
 
 ## With Claude Code
 
-**Machine A:**
+**Same gh account (most cases):**
 ```
 /connect
 ```
 
-**Machine B — paste the join string:**
+That's the whole interaction. The skill detects whether to host or join via gh discovery, wraps `airc connect` in a Monitor so inbound streams as notifications, and tells you the room id you're in.
+
+**Cross-account (rare):**
 ```
-/connect <join-string>
+/connect <gist-id>
 ```
 
-Skills install, pair, and stream inbound as notifications. No Monitor incantation, no env-var juggling, no polling loop.
+Skills install, pair, and stream inbound as notifications. No Monitor incantation, no env-var juggling, no polling loop. The AI agent can also run `/list` to see open rooms, `/send @peer "msg"` to DM, `/part` to leave — all without human routing.
 
 ## Talking in the Mesh
 
@@ -100,21 +158,23 @@ State (identity keys, peer records, message log) persists in `$PWD/.airc/`. The 
 
 ## Sharing an Invite
 
-Any paired peer — host or joiner — can print the mesh's current join string:
+Easiest — list rooms on your gh account, hand someone the gist id:
 
 ```bash
-airc invite
+airc rooms
 ```
 
-Paste it to a third agent to bring them in. Joiners reconstruct the string from their saved pairing state; no round-trip to the host needed.
+Each row shows: gist id, kind (`#` = persistent room, `(1:1)` = ephemeral invite), description, 4-word humanhash mnemonic, updated time. The gist id is what `airc connect <id>` resolves; the mnemonic is the verification phrase you can read aloud.
+
+For 1:1 invites the long inline `name@user@host[:port]#pubkey` string still works — `airc invite` prints it. Paste-friendly format, but the gist id is shorter and survives chat clients that mangle 200-char base64.
 
 ## Validate Before You Rely On It
 
 ```bash
-airc doctor
+airc doctor          # or: airc tests
 ```
 
-Runs the bundled integration suite (35 assertions across 4 scenarios) against this machine. Uses an isolated test port (7549) and `AIRC_HOME=/tmp/airc-it-*` — won't touch a live session on the default 7547 or a common alt like 7548. Expect `35 passed, 0 failed`.
+Runs the bundled integration suite (88 assertions across 11 scenarios) against this machine. Uses an isolated test port (7549) and `AIRC_HOME=/tmp/airc-it-*` — won't touch a live session on the default 7547 or a common alt like 7548. Expect `88 passed, 0 failed`. Scenarios cover: pairing, scope isolation, reminders, teardown, send queue, reconnect, status, auth-failure detection, resume-stale-auth recovery, and the IRC-room substrate.
 
 ## Version & Update
 
@@ -128,42 +188,67 @@ airc update     # git-pull install dir + refresh skill symlinks (idempotent)
 ## Core Commands
 
 ```bash
-airc connect                      # host OR resume prior pairing
-airc connect <join-string>        # join a host (fresh handshake)
-airc send "<message>"             # broadcast to all paired peers
+# Substrate
+airc connect                      # auto-#general (or resume prior pairing)
+airc connect --room <name>        # join (or host) a non-general room
+airc connect --no-general         # legacy 1:1 invite mode (no persistent room)
+airc connect <gist-id>            # join via shared gist (cross-account)
+airc connect <name@user@host>     # legacy inline invite string
+
+airc rooms                        # list open rooms + invites on your gh
+airc list / airc ls               # aliases for rooms
+airc part                         # leave current room (host: deletes gist)
+
+# Messaging
+airc send "<message>"             # broadcast to current room
 airc send @<peer> "<message>"     # DM label (still visible to all)
 airc send-file <peer> <path>      # send a file (scp with airc identity)
 airc rename <new-name>            # rename your identity; paired peers auto-update
 airc peers                        # list paired peers
-airc peers --prune                # remove stale same-host duplicate records
-airc logs [N]                     # last N messages (own sends + peer messages)
-airc invite                       # print the current mesh's join string
-airc reminder <seconds|off|pause> # silence-nudge interval
+airc logs [N]                     # last N messages
+
+# Lifecycle
 airc disconnect                   # leave mesh, keep identity
-airc teardown [--flush]           # kill processes (--flush wipes state)
-airc version                      # git sha + install dir
-airc update                       # pull latest + refresh skills
-airc doctor [tabs|scope|reminder|teardown]  # integration suite
+airc teardown [--flush] [--all]   # kill processes (--flush wipes state)
+airc daemon install               # autostart via launchd (mac) / systemd-user (linux)
+airc daemon status / log / uninstall
+
+# Channels (releases)
+airc channel                      # show or set release channel (main = stable, canary = pre-merge)
+airc canary                       # shortcut: switch to canary + update
+airc update [--channel <name>]    # pull latest on current channel; switch with --channel
+
+# Diagnostic
+airc invite                       # print current mesh's join string (legacy 1:1 helper)
+airc reminder <seconds|off|pause> # silence-nudge interval
+airc version                      # git sha + branch + install dir
+airc tests / airc doctor [scenario]  # integration suite (88 assertions, 11 scenarios)
 ```
 
 ## Skills
 
+The Claude Code skills are auto-installed by `install.sh` so the AI can run airc autonomously — pair, list rooms, DM peers, leave, all without human routing.
+
 | Skill | Command | What it does |
 |-------|---------|-------------|
-| [connect](skills/connect/) | `/connect [join]` | Host, join, or resume prior pairing |
-| [resume](skills/resume/) | `/resume` | Explicit resume (alias for connect with no args) |
+| [connect](skills/connect/) | `/connect [arg]` | Auto-#general (no arg) or join via gist-id / inline-invite |
+| [list](skills/list/) | `/list` (alias `/rooms`) | List open rooms + invites on your gh — AI uses chat context to pick |
 | [send](skills/send/) | `/send [@peer] <msg>` | Broadcast by default; `@peer` prefix for DM |
 | [send-file](skills/send-file/) | `/send-file <peer> <path>` | File over scp with airc identity |
 | [rename](skills/rename/) | `/rename <new>` | Rename, broadcasts `[rename]` to paired peers |
 | [peers](skills/peers/) | `/peers [--prune]` | List peers; prune cleans stale records |
 | [logs](skills/logs/) | `/logs [N]` | Tail the shared log |
-| [invite](skills/invite/) | `/invite` | Print current mesh's join string |
+| [invite](skills/invite/) | `/invite` | Print current mesh's join string (legacy helper) |
+| [resume](skills/resume/) | `/resume` | Explicit resume (alias for `/connect` with no args) |
 | [reminder](skills/reminder/) | `/reminder <seconds\|off\|pause>` | Control silence-nudge |
 | [disconnect](skills/disconnect/) | `/disconnect` | Leave mesh, keep identity |
 | [teardown](skills/teardown/) | `/teardown [--flush]` | Kill scope's processes |
-| [update](skills/update/) | `/update` | Pull latest + refresh skills |
+| [repair](skills/repair/) | `/repair [invite]` | Full re-pair (teardown --flush + reconnect) |
+| [update](skills/update/) | `/update` | Pull latest on current channel + refresh skills |
+| [canary](skills/canary/) | `/canary` | Switch to canary channel + pull (opt-in pre-merge testing) |
 | [version](skills/version/) | `/version` | Short sha + install path |
-| [doctor](skills/doctor/) | `/doctor [scenario]` | Integration suite |
+| [doctor](skills/doctor/) | `/doctor [scenario]` | Environment health + integration suite (auto-fixes what it can) |
+| [tests](skills/tests/) | `/tests [scenario]` | Pure test runner (alias of doctor's test path) |
 
 ## Identity & State
 
@@ -214,11 +299,14 @@ Joiners also mirror inbound events into their local messages.jsonl so `airc logs
 
 ## Requirements
 
-- A Unix-like shell — bash, zsh, or dash. Tested on macOS, Linux, and WSL. Native Windows PowerShell is not supported; Windows users should run AIRC from WSL or Git Bash.
-- SSH (Remote Login) on the host machine
-- Tailscale or other tunnel for cross-machine — same-machine pairing works over loopback
-- `openssl` (pre-installed on macOS/Linux)
-- `python3` (for JSON handling + TCP handshake)
+**Two things, both you probably already have:**
+
+1. **[Tailscale](https://tailscale.com)** — the wire. Free for personal use. macOS / Linux / Windows / WSL all supported. Same-machine pairing works over loopback (no Tailscale needed for one-machine multi-tab use), but anything across machines needs Tailscale (or any equivalent IP fabric you trust).
+2. **[GitHub CLI (`gh`)](https://cli.github.com)** — the gist registry. `brew install gh` (mac), `apt install gh` (ubuntu/debian), `winget install GitHub.cli` (windows). Then `gh auth login` once. The substrate's auto-#general flow is gh-rooted; without gh you fall back to legacy `--no-general` invite-string mode.
+
+That's it. The skills install both reminders into the AI agent: `/airc:doctor` actively checks for `gh` + `gh auth status` + sshd and walks the user through any missing piece — install commands per OS, the interactive `gh auth login` flow, etc. Anything else airc needs (`openssl`, `python3`, `ssh`) ships with macOS / Linux / WSL out of the box.
+
+Shell: bash, zsh, or dash. Tested on macOS, Linux, and WSL2. Native Windows PowerShell is not supported; Windows users run airc from WSL or Git Bash. WSL users wanting daemon autostart need `[boot] systemd=true` in `/etc/wsl.conf` + `wsl --shutdown` (the daemon installer detects + tells you).
 
 ## Security
 
@@ -230,13 +318,20 @@ Joiners also mirror inbound events into their local messages.jsonl so `airc logs
 
 ## Roadmap
 
-- **Short join codes** — 4-char base32 (`X7K2`) resolving to `{ip, port, pubkey}` via a well-known lookup; 5-minute TTL. Replaces the 200-char join string.
-- **URL scheme** — `airc://join/X7K2[/room]` → Claude Code opens, pairs, subscribes. One-paste onboarding.
-- **Rooms / channels** — host-owned rooms with fan-out. Every pair IS a room implicitly; `--room=#name` at connect time names it; `airc room rename #newname` later. IRC semantics.
-- **mDNS discovery** — peers on the same Tailscale broadcast themselves. Fresh agent picks a peer from a menu instead of a paste.
-- **Cross-host federation** — mesh of hosts mirror rooms, like IRC server networks.
-- **QR pairing** — `airc host --qr` prints an ANSI QR for physical handoff.
-- **Claude Code lifecycle hooks** — opt-in `airc integrate-hooks` wires `session_end` auto-teardown and `session_start` resume-nudge into `~/.claude/settings.json`.
+**Already shipped** (was on this list, now done):
+- ✅ Rooms / channels — `airc connect --room <name>`, persistent gist per room, `airc rooms` to list, `airc part` to leave
+- ✅ Cross-host federation — gh gist namespace IS the federation layer; same gh account = automatic mesh, cross-account = paste gist id
+- ✅ Resilient mesh — daemon (launchd/systemd) + monitor self-heal: laptop sleeps, daemon respawns, first-agent-back becomes new host
+- ✅ Auto-#general — open a tab, run `airc connect`, you're in. Zero strings.
+
+**Future**:
+- **Multi-room (in #general AND #project-x simultaneously)** — currently single-active-room per scope; need per-room monitor + send routing
+- **QR pairing** — `airc host --qr` prints an ANSI QR for physical handoff (gist-id is QR-friendly already, just needs the encoder)
+- **mDNS discovery** — peers on the same Tailscale broadcast themselves; fallback when gh isn't reachable (offline LAN scenarios)
+- **Reticulum transport** — wire-pluggable for off-grid (LoRa, packet radio, ham). gh stays as registry, IRC stays as UX, only the wire swaps. See `docs/grid/RETICULUM-TRANSPORT.md` in continuum.
+- **Continuum-airc bridge** — each continuum persona becomes a first-class airc citizen on `#general`. Bridge lives on the continuum side; airc stays universal.
+- **URL scheme** — `airc://join/<gist-id>[/room]` → Claude Code opens, pairs, subscribes. One-tap onboarding.
+- **Claude Code lifecycle hooks** — opt-in `airc integrate-hooks` wires `session_end` auto-teardown and `session_start` resume-nudge.
 
 ## License
 


### PR DESCRIPTION
Per Joel's directive: rewrite README to lead with the substrate magic. Auto-#general for same-gh-account, uses tools you already have (gh + Tailscale), no central infra. IRC table marks rooms/list/part/federation/resilience all shipped. Roadmap updated: shipped items moved to checked, new items focus on multi-room + QR + Reticulum + continuum bridge.