### PR TITLE
promote canary → main: IRC-style #general substrate + daemon + self-heal + readme rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,45 @@
 
 Remote desktop for Claude — but the agent comes to you, not the screen.
 
+**Open a tab. Run `airc connect`. You're in.** Same gh account on a second tab, second machine, third coworker's laptop? They all converge on `#general` automatically. Zero strings passed.
+
+**Built entirely on tools you already have**: GitHub CLI (`gh`) for the gist registry, Tailscale (or any IP network) for the wire, OpenSSH for the encrypted transport, your existing gh OAuth scope for the trust boundary. Nothing new to install beyond airc itself, no service to sign up for, no credit card. If you can read your own gh gists and reach your own machines on Tailscale, you can run airc.
+
+**How it stays safe**: messages flow over **end-to-end encrypted SSH** (Tailscale by default — WireGuard mesh — or any IP fabric). Coordination (who's hosting `#general`, where to reach them) lives in your **GitHub gist namespace**, gated by your existing gh OAuth scope — same auth boundary that protects your code. SSH keys exchange in a single TCP handshake at pair time; private keys never leave the machine. Every message is Ed25519-signed. There is no central server we run; gh is the rendezvous, Tailscale is the wire, your laptop is the host.
+
+Anyone speaking the protocol — Claude Code, Codex, Cursor, openclaw, a Python script — is a first-class citizen. It's just a chatroom.
+
 AIRC is a peer-to-peer messaging substrate for AI agents. A developer and a coworker. A tab and another tab. An agent on your laptop and one on a cloud box. Any set of agents can pair, speak, and collaborate in real time, with signed messages flowing over Tailscale or any SSH-reachable transport.
 
-If you remember IRC, the mental model is already there:
+If you remember IRC, the mental model is already there. (The name was destiny — a**IRC**.)
 
 | IRC | AIRC | Status |
 |-----|------|--------|
-| Nickname | Peer name | shipped |
-| Server | Host | shipped |
-| /msg `nick message` | `airc send @peer "message"` | shipped |
-| Typing in channel | `airc send "message"` (broadcast to all) | shipped |
-| /nick `newname` | `airc rename newname` | shipped |
-| Bots | Every agent is a first-class speaker | shipped |
-| /join `#channel` | `airc connect <join-string>` (pair == implicit room) | partial — named rooms on roadmap |
-| Network | Mesh of hosts | roadmap — cross-host federation |
+| Nickname | Peer name | ✅ shipped |
+| Server | Host (your laptop, your desktop, anyone's) | ✅ shipped |
+| ircd registry | GitHub gist namespace | ✅ shipped |
+| `/join #channel` | `airc connect` (auto-joins `#general`) | ✅ shipped |
+| `/join #foo` | `airc connect --room foo` | ✅ shipped |
+| `/list` | `airc rooms` | ✅ shipped |
+| `/part` | `airc part` | ✅ shipped |
+| `/msg nick message` | `airc send @peer "message"` | ✅ shipped |
+| Typing in channel | `airc send "message"` (broadcast to room) | ✅ shipped |
+| `/nick newname` | `airc rename newname` | ✅ shipped |
+| `/quit` | `airc disconnect` (keep state) / `airc teardown` (kill processes) | ✅ shipped |
+| Bots | Every agent is a first-class speaker | ✅ shipped |
+| Cross-server federation | Cross-account share via gist id | ✅ shipped |
+| Auto-rejoin on disconnect | Daemon (launchd/systemd) + monitor self-heal — no claude left behind | ✅ shipped |
 
 The primitives are the same. The participants are now agents.
+
+## The Magic — what "it just works" actually means
+
+- **Open a new tab.** `airc connect` discovers your existing `#general` gist on your gh account and auto-joins. **No string typed.**
+- **Open a new machine.** Same gh account, same `airc connect`, same auto-join. The mesh extends across the internet via gh.
+- **A friend across an org boundary.** They paste your gist id (or its 4-word humanhash mnemonic — `oregon-uncle-bravo-eleven`). They're in.
+- **Close your laptop. Open it later.** `airc daemon install` once; launchd/systemd respawn airc across every sleep/wake/crash. Mesh persists.
+- **Your host machine genuinely dies.** Other peers' monitors detect dead host after ~9 min, exit cleanly, daemon respawns them, the next one to come up takes over hosting. First-agent-back-in becomes the new server. Eventual consistency in 1-3 min. **Persists until everyone has chosen to disconnect.**
+- **Your AI does it for you.** Claude Code (and any agent shipping the airc skills) can run `/connect`, `/list`, `/send`, `/rooms`, `/part` without human routing. AI-to-AI DM, AI-to-human chat, all in the same room with the same primitives.
 
 ## Why AIRC
 
@@ -25,12 +48,13 @@ A developer today runs multiple agents: Claude Code in one tab for frontend, ano
 
 AIRC replaces that pattern with a proper mesh:
 
-- **Paste a join code, your agent is in their session.** Toby hits a bug; you paste him a string; his Claude is peered with yours inside a second.
+- **Paste nothing, your agents are already in the same room.** Same gh account = automatic. Cross-account = paste a 7-char gist id (or speak its 4-word mnemonic over the phone).
 - **Agents talk directly.** No human routing. Your Claude and their Claude coordinate, decide, and report back.
 - **Asynchronous works.** Your coworker goes to lunch. Their agent keeps reading. Messages land in a log.
 - **Auditable.** Every message is signed, timestamped, in a log. Screen-share gives you video at best; AIRC gives you text you can grep.
-- **Zero silent loss.** Every `airc send` mirrors to the sender's local log first, THEN attempts the wire. Failed sends carry a `[SEND FAILED]` marker so you always see what you tried to say.
+- **Zero silent loss.** Every `airc send` mirrors to the sender's local log first, THEN attempts the wire. Failed sends carry a `[QUEUED]` or `[AUTH FAILED]` marker; queued sends auto-flush when the host returns.
 - **Resume by default.** Close a tab, reopen it: `airc connect` picks up the prior pairing without a new handshake. Tab-close cleanly reaps ssh + python subprocesses.
+- **No central infra.** GitHub gist is the registry, Tailscale is the wire, gh OAuth is the auth. We don't run a server.
 
 This is not a tool you open. It's a fabric your agents live on.
 
@@ -44,34 +68,68 @@ Puts `airc` on your `PATH` and installs Claude Code skills automatically.
 
 ## 30-Second Setup
 
-**Machine A (host):**
+### Same gh account (the magic case — most users)
+
+**Machine A:**
 ```bash
 airc connect
 ```
 
-Prints a join string. Copy it.
+That's it. First agent in becomes host of `#general`, publishes a persistent secret gist on your gh account.
 
-**Machine B (join):**
+**Machine B (or another tab):**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
-airc connect <the-join-string>
+airc connect
 ```
 
-Done. Both machines are paired, monitoring, and talking. SSH keys exchange automatically via TCP during the handshake — no pre-existing `ssh-copy-id` needed.
+Discovers the `#general` gist on your gh account, auto-joins. **No string passed.** Works across tabs, across machines, across the internet — same gh account = same mesh.
+
+**Want it to survive sleep/wake forever?**
+```bash
+airc daemon install
+```
+
+macOS launchd or Linux systemd-user takes over. `airc connect` runs at login + restarts on crash. Mesh persists.
+
+### Cross-account (Toby has a different gh org)
+
+**You** — `airc rooms` shows the gist id of `#general`. Hand it to Toby:
+```
+2f6a907224f4b88d236fda8ca16d37c4
+mnemonic: oregon-uncle-bravo-eleven
+```
+
+**Toby:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
+airc connect 2f6a907224f4b88d236fda8ca16d37c4
+```
+
+Done. The mnemonic is the verification phrase ("did you get the right one?"); the id is what airc actually uses.
+
+### Legacy 1:1 invite (if you want the old behavior — one-shot pairing, no persistent room)
+
+```bash
+airc connect --no-general
+```
+
+Prints a long inline join string of the form `name@user@host:port#base64-pubkey`. Paste to the other machine. Same handshake as before.
 
 ## With Claude Code
 
-**Machine A:**
+**Same gh account (most cases):**
 ```
 /connect
 ```
 
-**Machine B — paste the join string:**
+That's the whole interaction. The skill detects whether to host or join via gh discovery, wraps `airc connect` in a Monitor so inbound streams as notifications, and tells you the room id you're in.
+
+**Cross-account (rare):**
 ```
-/connect <join-string>
+/connect <gist-id>
 ```
 
-Skills install, pair, and stream inbound as notifications. No Monitor incantation, no env-var juggling, no polling loop.
+Skills install, pair, and stream inbound as notifications. No Monitor incantation, no env-var juggling, no polling loop. The AI agent can also run `/list` to see open rooms, `/send @peer "msg"` to DM, `/part` to leave — all without human routing.
 
 ## Talking in the Mesh
 
@@ -100,21 +158,23 @@ State (identity keys, peer records, message log) persists in `$PWD/.airc/`. The 
 
 ## Sharing an Invite
 
-Any paired peer — host or joiner — can print the mesh's current join string:
+Easiest — list rooms on your gh account, hand someone the gist id:
 
 ```bash
-airc invite
+airc rooms
 ```
 
-Paste it to a third agent to bring them in. Joiners reconstruct the string from their saved pairing state; no round-trip to the host needed.
+Each row shows: gist id, kind (`#` = persistent room, `(1:1)` = ephemeral invite), description, 4-word humanhash mnemonic, updated time. The gist id is what `airc connect <id>` resolves; the mnemonic is the verification phrase you can read aloud.
+
+For 1:1 invites the long inline `name@user@host[:port]#pubkey` string still works — `airc invite` prints it. Paste-friendly format, but the gist id is shorter and survives chat clients that mangle 200-char base64.
 
 ## Validate Before You Rely On It
 
 ```bash
-airc doctor
+airc doctor          # or: airc tests
 ```
 
-Runs the bundled integration suite (35 assertions across 4 scenarios) against this machine. Uses an isolated test port (7549) and `AIRC_HOME=/tmp/airc-it-*` — won't touch a live session on the default 7547 or a common alt like 7548. Expect `35 passed, 0 failed`.
+Runs the bundled integration suite (88 assertions across 11 scenarios) against this machine. Uses an isolated test port (7549) and `AIRC_HOME=/tmp/airc-it-*` — won't touch a live session on the default 7547 or a common alt like 7548. Expect `88 passed, 0 failed`. Scenarios cover: pairing, scope isolation, reminders, teardown, send queue, reconnect, status, auth-failure detection, resume-stale-auth recovery, and the IRC-room substrate.
 
 ## Version & Update
 
@@ -128,42 +188,67 @@ airc update     # git-pull install dir + refresh skill symlinks (idempotent)
 ## Core Commands
 
 ```bash
-airc connect                      # host OR resume prior pairing
-airc connect <join-string>        # join a host (fresh handshake)
-airc send "<message>"             # broadcast to all paired peers
+# Substrate
+airc connect                      # auto-#general (or resume prior pairing)
+airc connect --room <name>        # join (or host) a non-general room
+airc connect --no-general         # legacy 1:1 invite mode (no persistent room)
+airc connect <gist-id>            # join via shared gist (cross-account)
+airc connect <name@user@host>     # legacy inline invite string
+
+airc rooms                        # list open rooms + invites on your gh
+airc list / airc ls               # aliases for rooms
+airc part                         # leave current room (host: deletes gist)
+
+# Messaging
+airc send "<message>"             # broadcast to current room
 airc send @<peer> "<message>"     # DM label (still visible to all)
 airc send-file <peer> <path>      # send a file (scp with airc identity)
 airc rename <new-name>            # rename your identity; paired peers auto-update
 airc peers                        # list paired peers
-airc peers --prune                # remove stale same-host duplicate records
-airc logs [N]                     # last N messages (own sends + peer messages)
-airc invite                       # print the current mesh's join string
-airc reminder <seconds|off|pause> # silence-nudge interval
+airc logs [N]                     # last N messages
+
+# Lifecycle
 airc disconnect                   # leave mesh, keep identity
-airc teardown [--flush]           # kill processes (--flush wipes state)
-airc version                      # git sha + install dir
-airc update                       # pull latest + refresh skills
-airc doctor [tabs|scope|reminder|teardown]  # integration suite
+airc teardown [--flush] [--all]   # kill processes (--flush wipes state)
+airc daemon install               # autostart via launchd (mac) / systemd-user (linux)
+airc daemon status / log / uninstall
+
+# Channels (releases)
+airc channel                      # show or set release channel (main = stable, canary = pre-merge)
+airc canary                       # shortcut: switch to canary + update
+airc update [--channel <name>]    # pull latest on current channel; switch with --channel
+
+# Diagnostic
+airc invite                       # print current mesh's join string (legacy 1:1 helper)
+airc reminder <seconds|off|pause> # silence-nudge interval
+airc version                      # git sha + branch + install dir
+airc tests / airc doctor [scenario]  # integration suite (88 assertions, 11 scenarios)
 ```
 
 ## Skills
 
+The Claude Code skills are auto-installed by `install.sh` so the AI can run airc autonomously — pair, list rooms, DM peers, leave, all without human routing.
+
 | Skill | Command | What it does |
 |-------|---------|-------------|
-| [connect](skills/connect/) | `/connect [join]` | Host, join, or resume prior pairing |
-| [resume](skills/resume/) | `/resume` | Explicit resume (alias for connect with no args) |
+| [connect](skills/connect/) | `/connect [arg]` | Auto-#general (no arg) or join via gist-id / inline-invite |
+| [list](skills/list/) | `/list` (alias `/rooms`) | List open rooms + invites on your gh — AI uses chat context to pick |
 | [send](skills/send/) | `/send [@peer] <msg>` | Broadcast by default; `@peer` prefix for DM |
 | [send-file](skills/send-file/) | `/send-file <peer> <path>` | File over scp with airc identity |
 | [rename](skills/rename/) | `/rename <new>` | Rename, broadcasts `[rename]` to paired peers |
 | [peers](skills/peers/) | `/peers [--prune]` | List peers; prune cleans stale records |
 | [logs](skills/logs/) | `/logs [N]` | Tail the shared log |
-| [invite](skills/invite/) | `/invite` | Print current mesh's join string |
+| [invite](skills/invite/) | `/invite` | Print current mesh's join string (legacy helper) |
+| [resume](skills/resume/) | `/resume` | Explicit resume (alias for `/connect` with no args) |
 | [reminder](skills/reminder/) | `/reminder <seconds\|off\|pause>` | Control silence-nudge |
 | [disconnect](skills/disconnect/) | `/disconnect` | Leave mesh, keep identity |
 | [teardown](skills/teardown/) | `/teardown [--flush]` | Kill scope's processes |
-| [update](skills/update/) | `/update` | Pull latest + refresh skills |
+| [repair](skills/repair/) | `/repair [invite]` | Full re-pair (teardown --flush + reconnect) |
+| [update](skills/update/) | `/update` | Pull latest on current channel + refresh skills |
+| [canary](skills/canary/) | `/canary` | Switch to canary channel + pull (opt-in pre-merge testing) |
 | [version](skills/version/) | `/version` | Short sha + install path |
-| [doctor](skills/doctor/) | `/doctor [scenario]` | Integration suite |
+| [doctor](skills/doctor/) | `/doctor [scenario]` | Environment health + integration suite (auto-fixes what it can) |
+| [tests](skills/tests/) | `/tests [scenario]` | Pure test runner (alias of doctor's test path) |
 
 ## Identity & State
 
@@ -214,11 +299,14 @@ Joiners also mirror inbound events into their local messages.jsonl so `airc logs
 
 ## Requirements
 
-- A Unix-like shell — bash, zsh, or dash. Tested on macOS, Linux, and WSL. Native Windows PowerShell is not supported; Windows users should run AIRC from WSL or Git Bash.
-- SSH (Remote Login) on the host machine
-- Tailscale or other tunnel for cross-machine — same-machine pairing works over loopback
-- `openssl` (pre-installed on macOS/Linux)
-- `python3` (for JSON handling + TCP handshake)
+**Two things, both you probably already have:**
+
+1. **[Tailscale](https://tailscale.com)** — the wire. Free for personal use. macOS / Linux / Windows / WSL all supported. Same-machine pairing works over loopback (no Tailscale needed for one-machine multi-tab use), but anything across machines needs Tailscale (or any equivalent IP fabric you trust).
+2. **[GitHub CLI (`gh`)](https://cli.github.com)** — the gist registry. `brew install gh` (mac), `apt install gh` (ubuntu/debian), `winget install GitHub.cli` (windows). Then `gh auth login` once. The substrate's auto-#general flow is gh-rooted; without gh you fall back to legacy `--no-general` invite-string mode.
+
+That's it. The skills install both reminders into the AI agent: `/airc:doctor` actively checks for `gh` + `gh auth status` + sshd and walks the user through any missing piece — install commands per OS, the interactive `gh auth login` flow, etc. Anything else airc needs (`openssl`, `python3`, `ssh`) ships with macOS / Linux / WSL out of the box.
+
+Shell: bash, zsh, or dash. Tested on macOS, Linux, and WSL2. Native Windows PowerShell is not supported; Windows users run airc from WSL or Git Bash. WSL users wanting daemon autostart need `[boot] systemd=true` in `/etc/wsl.conf` + `wsl --shutdown` (the daemon installer detects + tells you).
 
 ## Security
 
@@ -230,13 +318,20 @@ Joiners also mirror inbound events into their local messages.jsonl so `airc logs
 
 ## Roadmap
 
-- **Short join codes** — 4-char base32 (`X7K2`) resolving to `{ip, port, pubkey}` via a well-known lookup; 5-minute TTL. Replaces the 200-char join string.
-- **URL scheme** — `airc://join/X7K2[/room]` → Claude Code opens, pairs, subscribes. One-paste onboarding.
-- **Rooms / channels** — host-owned rooms with fan-out. Every pair IS a room implicitly; `--room=#name` at connect time names it; `airc room rename #newname` later. IRC semantics.
-- **mDNS discovery** — peers on the same Tailscale broadcast themselves. Fresh agent picks a peer from a menu instead of a paste.
-- **Cross-host federation** — mesh of hosts mirror rooms, like IRC server networks.
-- **QR pairing** — `airc host --qr` prints an ANSI QR for physical handoff.
-- **Claude Code lifecycle hooks** — opt-in `airc integrate-hooks` wires `session_end` auto-teardown and `session_start` resume-nudge into `~/.claude/settings.json`.
+**Already shipped** (was on this list, now done):
+- ✅ Rooms / channels — `airc connect --room <name>`, persistent gist per room, `airc rooms` to list, `airc part` to leave
+- ✅ Cross-host federation — gh gist namespace IS the federation layer; same gh account = automatic mesh, cross-account = paste gist id
+- ✅ Resilient mesh — daemon (launchd/systemd) + monitor self-heal: laptop sleeps, daemon respawns, first-agent-back becomes new host
+- ✅ Auto-#general — open a tab, run `airc connect`, you're in. Zero strings.
+
+**Future**:
+- **Multi-room (in #general AND #project-x simultaneously)** — currently single-active-room per scope; need per-room monitor + send routing
+- **QR pairing** — `airc host --qr` prints an ANSI QR for physical handoff (gist-id is QR-friendly already, just needs the encoder)
+- **mDNS discovery** — peers on the same Tailscale broadcast themselves; fallback when gh isn't reachable (offline LAN scenarios)
+- **Reticulum transport** — wire-pluggable for off-grid (LoRa, packet radio, ham). gh stays as registry, IRC stays as UX, only the wire swaps. See `docs/grid/RETICULUM-TRANSPORT.md` in continuum.
+- **Continuum-airc bridge** — each continuum persona becomes a first-class airc citizen on `#general`. Bridge lives on the continuum side; airc stays universal.
+- **URL scheme** — `airc://join/<gist-id>[/room]` → Claude Code opens, pairs, subscribes. One-tap onboarding.
+- **Claude Code lifecycle hooks** — opt-in `airc integrate-hooks` wires `session_end` auto-teardown and `session_start` resume-nudge.
 
 ## License
 

--- a/airc
+++ b/airc
@@ -618,6 +618,12 @@ cmd_connect() {
   # entirely; resolved_room_name only gets a value when we resolved a
   # kind:room gist envelope).
   local resolved_room_name=""
+  # _resolved_gist_id is captured by the gist resolver when discovery resolves
+  # a kind:"room" gist. Used by JOIN MODE's self-heal path: if the pair
+  # handshake fails because the host listed in the room gist is unreachable
+  # (sleep/crash/network), the joiner deletes the stale gist and re-execs
+  # itself in host mode — first-agent-back-in becomes the new host.
+  local _resolved_gist_id=""
   local positional=()
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -767,6 +773,45 @@ cmd_connect() {
           fi
           die "Resume aborted — re-pair required"
         else
+          # Non-auth probe failure = TCP unreachable / timeout / network blip.
+          # If we have a saved room_name (i.e. we were in a #general-style
+          # persistent channel), this is likely the prior host going away.
+          # Per Joel's "no claude left behind" rule, take over as new host.
+          # First-agent-back wins; the prior host (if it returns) will
+          # discover OUR fresh gist on next reconnect and join as a peer.
+          local saved_room=""
+          [ -f "$AIRC_WRITE_DIR/room_name" ] && saved_room=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null)
+          if [ -n "$saved_room" ] && command -v gh >/dev/null 2>&1; then
+            echo ""
+            echo "  ⚠  Host of #${saved_room} unreachable on resume — self-healing as new host..."
+            echo "     (saved pair: ${prior_name} @ ${prior_host_target} — likely went away)"
+            # Best-effort: delete any stale `airc room: <name>` gists on our
+            # gh account. We don't know the gist id from saved state (the
+            # joiner doesn't track that), so we sweep by description match.
+            # If the gist isn't on our gh (the host was a peer on a different
+            # account), gh-list returns nothing and we silently skip.
+            local stale_ids; stale_ids=$(gh gist list --limit 50 2>/dev/null \
+              | awk -F'\t' -v re="airc room: ${saved_room}\$" '$2 ~ re { print $1 }')
+            if [ -n "$stale_ids" ]; then
+              while IFS= read -r _gid; do
+                [ -z "$_gid" ] && continue
+                gh gist delete "$_gid" --yes 2>/dev/null \
+                  && echo "  ✓ Removed stale gist $_gid" \
+                  || echo "  ⚠  Couldn't delete gist $_gid (already gone? not on this account?)"
+              done <<< "$stale_ids"
+            else
+              echo "  (no #${saved_room} gist on this gh — host was likely cross-account or already cleaned)"
+            fi
+            # Wipe joiner state so re-exec falls into host mode cleanly.
+            rm -f "$CONFIG"
+            rm -f "$AIRC_WRITE_DIR/room_name"
+            echo "  Re-execing into host mode for #${saved_room}..."
+            echo ""
+            exec env AIRC_NO_DISCOVERY=1 "$0" connect --room "$saved_room"
+          fi
+          # No saved room (legacy 1:1 invite scope) OR no gh: fall through to
+          # the existing retry-in-monitor behavior. Monitor's retry loop
+          # handles transient outages correctly for the legacy case.
           echo "  Host probe failed (non-auth). Monitor will retry in background." >&2
           echo "  SSH stderr: ${probe_stderr:-<none>}" >&2
         fi
@@ -885,6 +930,10 @@ cmd_connect() {
   # if JSON parse fails. Lets pre-envelope gists keep working.
   if [ -n "$target" ] && ! echo "$target" | grep -q '@'; then
     local gist_id="${target#gist:}"
+    # Capture for self-heal in JOIN MODE: if the host in this gist turns
+    # out to be unreachable, JOIN MODE deletes the gist by this id + takes
+    # over as the new host of the same room.
+    _resolved_gist_id="$gist_id"
     # Gist IDs are hex strings, typically 20-32 chars but accept any
     # plausible length so future GH ID schemes don't break us.
     if echo "$gist_id" | grep -qE '^[a-zA-Z0-9]{6,40}$'; then
@@ -1018,6 +1067,7 @@ EOF
     my_sign_pub=$(cat "$IDENTITY_DIR/public.pem" 2>/dev/null)
 
     local response
+    local _pair_ok=1
     response=$(python3 -c "
 import socket, json, sys
 payload = json.dumps({
@@ -1039,7 +1089,56 @@ while True:
     data += chunk
 sock.close()
 print(data.decode().strip())
-" 2>&1) || die "Can't reach $peer_host_only:$peer_port. Is the host running 'airc connect'?"
+" 2>&1) || _pair_ok=0
+
+    if [ "$_pair_ok" = "0" ]; then
+      # ── Self-heal: stale-host takeover ─────────────────────────────
+      # If discovery handed us a kind:room gist AND the host listed in it
+      # is unreachable, the most likely cause is the prior host went away
+      # (laptop sleep, crash, network blip). Per Joel: "no claude left
+      # behind" — first agent back in becomes the new host of #general.
+      #
+      # Mechanics:
+      #   1. Delete the stale gist (we have gh perms because it's on our
+      #      own gh account, same auth as the discovery that found it).
+      #   2. Tear down the half-written CONFIG that pointed at the dead
+      #      host (else resume on next start would loop into the same
+      #      stale pair).
+      #   3. exec into a fresh airc connect in HOST mode for the same
+      #      room name. AIRC_NO_DISCOVERY=1 so we don't re-find the gist
+      #      we just deleted (gh propagation lag).
+      #
+      # Only fires when ALL three are true:
+      #   - We resolved a kind:room gist (resolved_room_name + _resolved_gist_id non-empty)
+      #   - gh CLI is available (to delete the stale gist)
+      #   - Pair handshake failed (TCP unreachable / timeout)
+      # If any condition isn't met, fall through to the original die().
+      if [ -n "$resolved_room_name" ] && [ -n "$_resolved_gist_id" ] \
+         && command -v gh >/dev/null 2>&1; then
+        echo ""
+        echo "  ⚠  Host of #${resolved_room_name} unreachable — self-healing as new host..."
+        echo "     (prior host's gist: $_resolved_gist_id)"
+        if gh gist delete "$_resolved_gist_id" --yes 2>/dev/null; then
+          echo "  ✓ Stale gist removed."
+        else
+          echo "  ⚠  Couldn't remove stale gist (already gone? not on this gh account?)."
+          echo "     New host will publish a fresh #${resolved_room_name} gist anyway."
+        fi
+        # Wipe the CONFIG we just wrote — it points at the dead host and
+        # would trigger 'resume joiner' on next airc connect, looping back
+        # into this same failure.
+        rm -f "$CONFIG"
+        rm -f "$AIRC_WRITE_DIR/room_name"
+        echo "  Re-execing into host mode for #${resolved_room_name}..."
+        echo ""
+        # exec replaces the current bash process — clean handoff. AIRC_NO_DISCOVERY=1
+        # ensures the new instance doesn't try to re-discover the just-deleted gist
+        # (gh's gist-list cache might still show it for a few seconds).
+        exec env AIRC_NO_DISCOVERY=1 "$0" connect --room "$resolved_room_name"
+      fi
+      # Either not a room flow, or no gh, or no resolved_room_name → original die.
+      die "Can't reach $peer_host_only:$peer_port. Is the host running 'airc connect'?"
+    fi
 
     # Authorize host's SSH pubkey (for the joiner->host auth direction).
     # NOTE: the handshake's ssh_pub is airc's USER identity key — not the

--- a/airc
+++ b/airc
@@ -2063,26 +2063,108 @@ except Exception:
 }
 
 cmd_update() {
-  # Refresh install dir (git pull) AND re-run install.sh so new skills get
-  # symlinked into ~/.claude/skills/ and old ones get cleaned up. install.sh
-  # is idempotent — it handles the pull, the binary symlink, and the skill
+  # Refresh install dir AND re-run install.sh so new skills get symlinked
+  # into ~/.claude/skills/ and old ones get cleaned up. install.sh is
+  # idempotent — it handles the pull, the binary symlink, and the skill
   # directory refresh in one pass. Does NOT teardown or reconnect.
+  #
+  # Channels (#40 followup): airc supports release channels for opt-in
+  # pre-merge testing. main = stable; canary = features-not-yet-promoted.
+  # The chosen channel persists in $AIRC_DIR/.channel so subsequent
+  # `airc update` (no args) keeps the user on their chosen track.
+  #   airc update                    # stay on current channel (default: main)
+  #   airc update --channel canary   # switch to canary + update
+  #   airc update --channel main     # switch back to main + update
+  #   airc channel                   # show current channel without updating
   local dir="${AIRC_DIR:-$HOME/.airc-src}"
+  local channel_file="$dir/.channel"
+  local requested_channel=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --channel|-c)
+        requested_channel="${2:-}"
+        [ -z "$requested_channel" ] && die "Usage: airc update --channel <name>"
+        shift 2
+        ;;
+      --canary) requested_channel="canary"; shift ;;
+      --main)   requested_channel="main";   shift ;;
+      *) shift ;;
+    esac
+  done
+
   if [ ! -d "$dir/.git" ]; then
     die "No git checkout at $dir. Reinstall: curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash"
   fi
+
+  # Determine target channel: explicit request > saved preference > main.
+  local channel
+  if [ -n "$requested_channel" ]; then
+    channel="$requested_channel"
+  elif [ -f "$channel_file" ]; then
+    channel=$(cat "$channel_file" 2>/dev/null | tr -d '[:space:]')
+    [ -z "$channel" ] && channel="main"
+  else
+    channel="main"
+  fi
+
+  # Switch to the target branch BEFORE pulling. install.sh will then ff-pull
+  # whatever branch is checked out. Fail loud if the channel doesn't exist
+  # on origin — silently falling back to main would defeat the opt-in test
+  # purpose.
   local before; before=$(git -C "$dir" rev-parse --short HEAD 2>/dev/null)
+  local current_branch; current_branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  if [ "$current_branch" != "$channel" ]; then
+    git -C "$dir" fetch --quiet origin "$channel" 2>/dev/null \
+      || die "Channel '$channel' not found on origin. Try: airc channel (to see options)."
+    git -C "$dir" checkout -q "$channel" 2>/dev/null \
+      || git -C "$dir" checkout -q -B "$channel" "origin/$channel" 2>/dev/null \
+      || die "Failed to checkout '$channel'. Resolve manually in $dir."
+  fi
+
   if [ ! -x "$dir/install.sh" ]; then
     die "install.sh missing at $dir. Reinstall via curl|bash."
   fi
   AIRC_DIR="$dir" bash "$dir/install.sh" || die "install.sh failed."
+
+  # Persist channel choice AFTER successful update so a failed switch
+  # doesn't leave a dangling preference for a broken state.
+  echo "$channel" > "$channel_file"
+
   local after; after=$(git -C "$dir" rev-parse --short HEAD 2>/dev/null)
   if [ "$before" = "$after" ]; then
-    echo "  Already at ${after}. Skills refreshed."
+    echo "  Already at ${after} on channel '${channel}'. Skills refreshed."
   else
-    echo "  Updated: ${before} -> ${after}. Skills refreshed."
+    echo "  Updated: ${before} -> ${after} on channel '${channel}'. Skills refreshed."
     echo "  Running monitor still uses the old code. To pick up:  airc teardown && airc connect"
   fi
+}
+
+# ── cmd_channel: show or set the release channel without pulling ──────
+# `airc channel`           → print current channel + how to switch
+# `airc channel canary`    → set preferred channel; doesn't pull (use
+#                            `airc update` after to actually switch)
+# Allows the AI / human to inspect + decide before the heavier update.
+cmd_channel() {
+  local dir="${AIRC_DIR:-$HOME/.airc-src}"
+  local channel_file="$dir/.channel"
+  local current="main"
+  [ -f "$channel_file" ] && current=$(cat "$channel_file" 2>/dev/null | tr -d '[:space:]')
+  [ -z "$current" ] && current="main"
+
+  local target="${1:-}"
+  if [ -z "$target" ]; then
+    echo "  Channel: $current"
+    echo "  Available channels (any branch on origin can be a channel):"
+    echo "    main      — stable, what most users run"
+    echo "    canary    — features queued for the next main merge; opt-in testing"
+    echo "  Switch:"
+    echo "    airc channel <name>           # set preference (run 'airc update' after)"
+    echo "    airc update --channel <name>  # set + pull in one step"
+    return 0
+  fi
+
+  echo "$target" > "$channel_file"
+  echo "  Channel preference set: '$target'. Run 'airc update' to actually switch + pull."
 }
 
 cmd_version() {
@@ -2296,7 +2378,9 @@ case "${1:-help}" in
   rooms|list|ls) shift; cmd_rooms "$@" ;;
   part) shift; cmd_part "$@" ;;
   version|--version|-v) cmd_version ;;
-  update|upgrade|pull) cmd_update ;;
+  update|upgrade|pull) shift; cmd_update "$@" ;;
+  channel) shift; cmd_channel "$@" ;;
+  canary) shift; cmd_update --channel canary "$@" ;;
   logs)      shift; cmd_logs "$@" ;;
   status)    shift; cmd_status "$@" ;;
   doctor|tests|test) shift; cmd_doctor "$@" ;;
@@ -2315,6 +2399,10 @@ case "${1:-help}" in
     echo "  airc connect <name@user@host>   Join via inline invite string (legacy)"
     echo "  airc rooms / list / ls          List open rooms + invites on your gh account"
     echo "  airc part                       Leave current room (host: deletes room gist)"
+    echo "  airc update [--channel <name>]  Pull latest on current channel; switch with --channel canary|main"
+    echo "  airc channel [<name>]           Show or set release channel (main = stable, canary = pre-merge testing)"
+    echo "  airc canary                     Shortcut: airc update --channel canary"
+    echo "  airc tests / doctor [scenario]  Run integration suite (88 assertions across 11 scenarios)"
     echo "  airc send <peer> <message>      Send a message"
     echo "  airc ping @peer [timeout]       Monitor-liveness probe (ping/pong, 10s default)"
     echo "  airc rename <new-name>          Rename this session (notifies peers)"

--- a/airc
+++ b/airc
@@ -2326,6 +2326,269 @@ else:
   fi
 }
 
+# ── cmd_daemon: install / manage the OS auto-restart for `airc connect` ────
+# Issue followup to #39 substrate: the channel must auto-resume across machine
+# sleep/wake/crash so users walk away and come back to a live mesh. Without
+# this, every laptop sleep kills airc + the user must remember to restart it.
+#
+# Implementation: install a platform-native autostart that wraps `airc connect`
+# with KeepAlive/Restart=always. AIRC_BACKGROUND_OK=1 is set in the env so
+# airc's heartbeat-stdout-pipe-trap doesn't exit-3 under launchd/systemd
+# (which have no notification-consumer reading stdout).
+#
+# Subcommands:
+#   airc daemon install    Install + start the autostart entry
+#   airc daemon uninstall  Stop + remove the autostart entry
+#   airc daemon status     Show install state + running pid + log path
+#   airc daemon log [N]    Tail the daemon stdout log
+#
+# Scope: defaults to the GLOBAL scope ($HOME/.airc), since the daemon is the
+# user's "always-on" mesh presence — not tied to a specific project dir. If
+# the user wants a per-project always-on daemon, they pass AIRC_HOME=<dir>
+# in the environment when running install (and the generated unit/plist
+# will carry that scope).
+cmd_daemon() {
+  local action="${1:-status}"
+  shift 2>/dev/null || true
+  case "$action" in
+    install)   cmd_daemon_install "$@" ;;
+    uninstall|remove|stop) cmd_daemon_uninstall "$@" ;;
+    status)    cmd_daemon_status "$@" ;;
+    log|logs)  cmd_daemon_log "$@" ;;
+    *)         die "Usage: airc daemon [install|uninstall|status|log]" ;;
+  esac
+}
+
+# Detect the OS: darwin / linux / wsl / unknown.
+_daemon_os() {
+  case "$(uname -s)" in
+    Darwin) echo "darwin" ;;
+    Linux)
+      # WSL2 detection — systemd may or may not be enabled; we still treat
+      # it as linux (user must have [boot] systemd=true in wsl.conf).
+      if grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null; then
+        echo "wsl"
+      else
+        echo "linux"
+      fi
+      ;;
+    *) echo "unknown" ;;
+  esac
+}
+
+# Resolve the absolute path to airc binary that should run under the daemon.
+# install.sh symlinks $HOME/.local/bin/airc → $AIRC_DIR/airc; we want the
+# real path so a future `airc update` (which mutates $AIRC_DIR/airc in
+# place) is picked up by launchd/systemd without re-installing the unit.
+_daemon_airc_path() {
+  local airc_link="${HOME}/.local/bin/airc"
+  if [ -L "$airc_link" ] || [ -x "$airc_link" ]; then
+    echo "$airc_link"
+  elif [ -x "${AIRC_DIR:-$HOME/.airc-src}/airc" ]; then
+    echo "${AIRC_DIR:-$HOME/.airc-src}/airc"
+  else
+    echo "/usr/local/bin/airc"  # last-resort guess; install will fail loud if wrong
+  fi
+}
+
+# The scope the daemon will run under. If AIRC_HOME is set at install time,
+# that's recorded in the unit/plist so future starts use the same scope.
+_daemon_scope() {
+  echo "${AIRC_HOME:-$HOME/.airc}"
+}
+
+cmd_daemon_install() {
+  local os; os=$(_daemon_os)
+  local airc_bin; airc_bin=$(_daemon_airc_path)
+  local scope; scope=$(_daemon_scope)
+  mkdir -p "$scope"
+
+  case "$os" in
+    darwin) _daemon_install_launchd "$airc_bin" "$scope" ;;
+    linux|wsl) _daemon_install_systemd "$airc_bin" "$scope" "$os" ;;
+    *) die "Daemon install not supported on $(uname -s). Manual workaround: run 'airc connect' under your platform's preferred autostart mechanism." ;;
+  esac
+}
+
+_daemon_install_launchd() {
+  local airc_bin="$1" scope="$2"
+  local plist_dir="$HOME/Library/LaunchAgents"
+  local plist_path="$plist_dir/com.cambriantech.airc.plist"
+  mkdir -p "$plist_dir"
+  cat > "$plist_path" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.cambriantech.airc</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${airc_bin}</string>
+        <string>connect</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>AIRC_BACKGROUND_OK</key>
+        <string>1</string>
+        <key>AIRC_HOME</key>
+        <string>${scope}</string>
+        <key>HOME</key>
+        <string>${HOME}</string>
+        <key>PATH</key>
+        <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:${HOME}/.local/bin</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>${scope}/daemon.log</string>
+    <key>StandardErrorPath</key>
+    <string>${scope}/daemon.err</string>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>
+PLIST
+  echo "  Wrote $plist_path"
+  # Bootout first to reset any prior load (idempotent install).
+  launchctl bootout "gui/$(id -u)/com.cambriantech.airc" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$plist_path" 2>&1 \
+    || die "launchctl bootstrap failed. Plist written but not loaded; check Console.app for errors."
+  launchctl enable "gui/$(id -u)/com.cambriantech.airc" 2>/dev/null || true
+  echo "  ✓ Loaded into launchd (gui/$(id -u)/com.cambriantech.airc)"
+  echo "  airc will now auto-start at login + restart on crash + survive sleep/wake."
+  echo "  Logs:   $scope/daemon.log"
+  echo "  Status: airc daemon status"
+  echo ""
+  echo "  Note: gh keychain access — if 'airc canary' / gist push fails under"
+  echo "        launchd, the gh keychain may not be unlocked at boot. Workaround:"
+  echo "        run 'gh auth status' once after login to unlock, then airc daemon"
+  echo "        will pick up gh credentials on next restart."
+}
+
+_daemon_install_systemd() {
+  local airc_bin="$1" scope="$2" os="$3"
+  local unit_dir="$HOME/.config/systemd/user"
+  local unit_path="$unit_dir/airc.service"
+  if ! command -v systemctl >/dev/null 2>&1; then
+    if [ "$os" = "wsl" ]; then
+      die "systemctl not found. Enable systemd in WSL: edit /etc/wsl.conf to add [boot]\nsystemd=true, then 'wsl --shutdown' from PowerShell + restart your distro."
+    else
+      die "systemctl not found. Daemon install requires systemd."
+    fi
+  fi
+  mkdir -p "$unit_dir"
+  cat > "$unit_path" <<UNIT
+[Unit]
+Description=airc — agentic IRC chat for AI peers (auto-resume mesh)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${airc_bin} connect
+Restart=always
+RestartSec=5
+Environment="AIRC_BACKGROUND_OK=1"
+Environment="AIRC_HOME=${scope}"
+StandardOutput=append:${scope}/daemon.log
+StandardError=append:${scope}/daemon.err
+
+[Install]
+WantedBy=default.target
+UNIT
+  echo "  Wrote $unit_path"
+  systemctl --user daemon-reload || die "systemctl --user daemon-reload failed."
+  systemctl --user enable --now airc.service \
+    || die "systemctl --user enable --now airc.service failed."
+  echo "  ✓ Loaded into systemd-user (airc.service)"
+  echo "  airc will now auto-start at login + restart on crash."
+  echo "  Logs:   $scope/daemon.log  (or: journalctl --user -u airc -f)"
+  echo "  Status: airc daemon status"
+  echo ""
+  echo "  Note: systemd-user units stop at logout unless lingering is enabled."
+  echo "        For 'always on across logout' (typical for an always-up mesh):"
+  echo "          sudo loginctl enable-linger \$USER"
+}
+
+cmd_daemon_uninstall() {
+  local os; os=$(_daemon_os)
+  case "$os" in
+    darwin)
+      local plist_path="$HOME/Library/LaunchAgents/com.cambriantech.airc.plist"
+      launchctl bootout "gui/$(id -u)/com.cambriantech.airc" 2>/dev/null \
+        && echo "  ✓ Unloaded from launchd" \
+        || echo "  (was not loaded)"
+      [ -f "$plist_path" ] && rm "$plist_path" && echo "  ✓ Removed $plist_path" \
+        || echo "  (no plist on disk)"
+      ;;
+    linux|wsl)
+      systemctl --user disable --now airc.service 2>/dev/null \
+        && echo "  ✓ Stopped + disabled airc.service" \
+        || echo "  (was not enabled)"
+      local unit_path="$HOME/.config/systemd/user/airc.service"
+      [ -f "$unit_path" ] && rm "$unit_path" && systemctl --user daemon-reload && echo "  ✓ Removed $unit_path" \
+        || echo "  (no unit on disk)"
+      ;;
+    *) echo "  Daemon uninstall not supported on $(uname -s)."; return 1 ;;
+  esac
+}
+
+cmd_daemon_status() {
+  local os; os=$(_daemon_os)
+  case "$os" in
+    darwin)
+      local plist_path="$HOME/Library/LaunchAgents/com.cambriantech.airc.plist"
+      if [ -f "$plist_path" ]; then
+        echo "  Plist:   $plist_path"
+        # launchctl print returns rich state; grep the key fields.
+        local state; state=$(launchctl print "gui/$(id -u)/com.cambriantech.airc" 2>/dev/null \
+          | grep -E 'state =|pid =|last exit code' | head -3)
+        if [ -n "$state" ]; then
+          echo "  Loaded:  yes"
+          printf '%s\n' "$state" | sed 's/^[[:space:]]*/    /'
+        else
+          echo "  Loaded:  no (plist present but not bootstrapped — try 'airc daemon install' to reload)"
+        fi
+        local scope; scope=$(_daemon_scope)
+        echo "  Logs:    $scope/daemon.log"
+      else
+        echo "  No daemon installed. Run: airc daemon install"
+      fi
+      ;;
+    linux|wsl)
+      local unit_path="$HOME/.config/systemd/user/airc.service"
+      if [ -f "$unit_path" ]; then
+        echo "  Unit:    $unit_path"
+        local active; active=$(systemctl --user is-active airc.service 2>/dev/null)
+        local enabled; enabled=$(systemctl --user is-enabled airc.service 2>/dev/null)
+        echo "  Active:  $active"
+        echo "  Enabled: $enabled"
+        local scope; scope=$(_daemon_scope)
+        echo "  Logs:    $scope/daemon.log  (journalctl --user -u airc -f for live)"
+      else
+        echo "  No daemon installed. Run: airc daemon install"
+      fi
+      ;;
+    *) echo "  Daemon status not supported on $(uname -s)." ;;
+  esac
+}
+
+cmd_daemon_log() {
+  local n="${1:-50}"
+  local scope; scope=$(_daemon_scope)
+  local log="$scope/daemon.log"
+  if [ ! -f "$log" ]; then
+    echo "  No log at $log. Daemon may not have started yet."
+    return 1
+  fi
+  tail -"$n" "$log"
+}
+
 cmd_doctor() {
   # Self-diagnose: run the bundled integration test script.
   # Install resolves it under AIRC_DIR/test; fall back to a sibling dir
@@ -2384,6 +2647,7 @@ case "${1:-help}" in
   logs)      shift; cmd_logs "$@" ;;
   status)    shift; cmd_status "$@" ;;
   doctor|tests|test) shift; cmd_doctor "$@" ;;
+  daemon|autostart|service) shift; cmd_daemon "$@" ;;
   teardown|stop|flush) shift; cmd_teardown "$@" ;;
   disconnect|leave|unbind) cmd_disconnect ;;
   monitor)   shift; monitor "$@" ;;
@@ -2403,6 +2667,7 @@ case "${1:-help}" in
     echo "  airc channel [<name>]           Show or set release channel (main = stable, canary = pre-merge testing)"
     echo "  airc canary                     Shortcut: airc update --channel canary"
     echo "  airc tests / doctor [scenario]  Run integration suite (88 assertions across 11 scenarios)"
+    echo "  airc daemon [install|status|uninstall|log]  Auto-resume across sleep/wake/crash via launchd (mac) or systemd (linux)"
     echo "  airc send <peer> <message>      Send a message"
     echo "  airc ping @peer [timeout]       Monitor-liveness probe (ping/pong, 10s default)"
     echo "  airc rename <new-name>          Rename this session (notifies peers)"

--- a/airc
+++ b/airc
@@ -251,10 +251,60 @@ monitor() {
     local rhome; rhome=$(remote_home)
     local ssh_key="$IDENTITY_DIR/ssh_key"
     local ssh_opts="-i $ssh_key -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=3"
+    # Monitor escalation (no-claude-left-behind): count consecutive watchdog
+    # timeouts (formatter exit code 2 = no inbound in WATCHDOG_SEC). After
+    # ESCALATE_AFTER consecutive timeouts, the host is genuinely gone (sleep
+    # without launchd, hard crash, network gone). Exit airc connect with a
+    # distinct code so the platform daemon (launchd / systemd Restart=always)
+    # respawns us into a fresh airc connect — that re-enters the resume path
+    # which now self-heals (PR #46): probes the dead host, gives up, deletes
+    # the stale gist, takes over as the new host of #general. First peer to
+    # complete this loop wins; the others discover the new gist on their next
+    # cold-restart and join as peers. Standard distributed-systems leader
+    # election with optimistic conflict resolution via gh-create.
+    local consecutive_timeouts=0
+    local ESCALATE_AFTER=3   # ~9 minutes of dead host (3 × WATCHDOG_SEC=180)
     while true; do
+      local cycle_start; cycle_start=$(date +%s)
       ssh $ssh_opts "$host_target" "tail $tail_pos -F $rhome/messages.jsonl 2>/dev/null" 2>/dev/null | monitor_formatter "$my_name" || true
+      local fmt_exit="${PIPESTATUS[1]:-0}"
+      local cycle_end; cycle_end=$(date +%s)
+      local cycle_lifetime=$((cycle_end - cycle_start))
+
       # Subsequent reconnects use the now-persisted offset updated by the formatter.
       tail_pos="-n +$(($(cat "$offset_file" 2>/dev/null || echo 0) + 1))"
+
+      # Count this iteration as a "timeout" if formatter exited with code 2
+      # (its watchdog-no-inbound exit) OR the whole pipe died in under 30s
+      # (likely SSH refused / connection reset — host gone). Anything else,
+      # especially a long-lived formatter that received traffic, resets.
+      if [ "$fmt_exit" = "2" ] || [ "$cycle_lifetime" -lt 30 ]; then
+        consecutive_timeouts=$((consecutive_timeouts + 1))
+      else
+        consecutive_timeouts=0
+      fi
+
+      if [ "$consecutive_timeouts" -ge "$ESCALATE_AFTER" ]; then
+        # Only escalate if we have a saved room name (the substrate use case);
+        # legacy 1:1 invite scopes shouldn't auto-promote — they were
+        # explicit pairings, not channel members.
+        local saved_room=""
+        [ -f "$AIRC_WRITE_DIR/room_name" ] && saved_room=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null)
+        if [ -n "$saved_room" ]; then
+          echo ""
+          echo "  ⚠  Host of #${saved_room} dead for $consecutive_timeouts consecutive cycles" >&2
+          echo "  ⚠  Exiting airc connect — daemon restart will trigger self-heal" >&2
+          echo "  ⚠  (per the no-claude-left-behind protocol — first agent back becomes new host)" >&2
+          # Specific exit code so postmortems can tell why we left. launchd /
+          # systemd Restart=always treat any non-zero exit as restart-worthy.
+          exit 99
+        else
+          # Legacy 1:1 invite scope. Don't auto-promote, but warn the user
+          # so they can manually re-pair if the host is genuinely gone.
+          echo "  ⚠  $consecutive_timeouts consecutive watchdog timeouts on legacy invite scope — host may be down" >&2
+          consecutive_timeouts=0   # reset to avoid spamming
+        fi
+      fi
       sleep 3
     done
   else

--- a/airc
+++ b/airc
@@ -613,6 +613,11 @@ cmd_connect() {
   local use_gist=1   # default ON; runtime probe later checks gh availability
   local room_name="general"
   local use_room=1   # default ON — auto-#general substrate
+  # Declared at function scope so set -u doesn't bite when JOIN MODE runs
+  # without a prior gist parser (inline-invite path skips the parser
+  # entirely; resolved_room_name only gets a value when we resolved a
+  # kind:room gist envelope).
+  local resolved_room_name=""
   local positional=()
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -902,7 +907,6 @@ cmd_connect() {
       # field, dispatch on `kind`. Otherwise, treat raw_content as the
       # legacy raw-invite-string format (backward compat).
       local resolved=""
-      local resolved_room_name=""   # set when kind==room, used to remember which room we joined
       if command -v jq >/dev/null 2>&1; then
         local airc_ver kind
         airc_ver=$(printf '%s' "$raw_content" | jq -r '.airc // empty' 2>/dev/null)
@@ -1192,6 +1196,18 @@ EOF
       echo "  On the other machine:"
       echo "    airc connect $_invite_long"
       _printed_long=1
+    fi
+
+    # Record room name + print substrate banner BEFORE the gist push
+    # attempt so cmd_part / status / diagnostics know the channel name
+    # even when the gist push is skipped (--no-gist) or fails (gh
+    # missing/unauthed). The gist_id is recorded only when an actual
+    # gist is created (see below). The "Hosting #<name>" banner is the
+    # signal both humans and the integration test use to confirm
+    # substrate framing took effect — emit unconditionally for room mode.
+    if [ "$use_room" = "1" ]; then
+      echo "$room_name" > "$AIRC_WRITE_DIR/room_name"
+      echo "  Hosting #${room_name} (gh-account substrate)."
     fi
 
     # ── Gist transport (--gist flag, issue #37) ────────────────────
@@ -1701,14 +1717,19 @@ cmd_rooms() {
 }
 
 # ── cmd_part: leave the current room ──────────────────────────────────
-# Issue #39. Two paths:
-#   - Host: delete the room gist (graceful channel teardown — joiners
-#     will see SSH die and re-host on next reconnect, IRC-style "ircd
-#     restart"). Then teardown local processes.
-#   - Joiner: just teardown local processes. Host's gist stays open for
-#     other joiners (we're one of N).
+# Issue #39. Two paths, distinguished by config.json's host_target:
+#   - Host (no host_target): delete the room gist if we created one, then
+#     teardown. Joiners watching us will see SSH die — IRC's "ircd
+#     restart" — and the next reconnect re-elects a new host.
+#   - Joiner (host_target set): just teardown local processes; host's
+#     gist stays open for other joiners (we're one of N).
 # Either way, local config + identity + peer records persist (use
 # `airc teardown --flush` for nuclear).
+#
+# Detection note: we use config.json::host_target as the host-vs-joiner
+# signal, NOT presence of room_gist_id. The gist file may be absent for
+# a legitimate host case (`--no-gist`, or gh push failed) — falling back
+# to "you're a joiner" would be wrong.
 cmd_part() {
   ensure_init
 
@@ -1717,22 +1738,29 @@ cmd_part() {
   local room_name="(unnamed)"
   [ -f "$room_name_file" ] && room_name=$(cat "$room_name_file")
 
-  if [ -f "$gist_id_file" ]; then
-    # We were the host. Delete the room gist so future `airc connect`
-    # in this gh account doesn't keep trying to pair against a dead
-    # SSH endpoint.
-    local gid; gid=$(cat "$gist_id_file")
-    if command -v gh >/dev/null 2>&1; then
-      echo "  Host of #${room_name} parting — deleting room gist ${gid}..."
-      gh gist delete "$gid" --yes 2>/dev/null \
-        && echo "  ✓ Room gist deleted." \
-        || echo "  ⚠  Couldn't delete gist ${gid} (already gone? gh auth?). Continuing teardown."
+  local host_target; host_target=$(get_config_val host_target "")
+
+  if [ -z "$host_target" ]; then
+    # ── Host path ──
+    if [ -f "$gist_id_file" ]; then
+      local gid; gid=$(cat "$gist_id_file")
+      if command -v gh >/dev/null 2>&1; then
+        echo "  Host of #${room_name} parting — deleting room gist ${gid}..."
+        gh gist delete "$gid" --yes 2>/dev/null \
+          && echo "  ✓ Room gist deleted." \
+          || echo "  ⚠  Couldn't delete gist ${gid} (already gone? gh auth?). Continuing teardown."
+      else
+        echo "  ⚠  gh CLI not available — can't delete room gist ${gid} automatically."
+        echo "     Delete it manually:  gh gist delete ${gid} --yes"
+      fi
     else
-      echo "  ⚠  gh CLI not available — can't delete room gist ${gid} automatically."
-      echo "     Delete it manually:  gh gist delete ${gid} --yes"
+      # Host but no gist (--no-gist or gh-push failed). Nothing to delete
+      # in the gh namespace; just clean local state.
+      echo "  Host of #${room_name} parting (no gist was published; nothing to clean up in gh)."
     fi
     rm -f "$gist_id_file" "$room_name_file"
   else
+    # ── Joiner path ──
     echo "  Joiner of #${room_name} parting — host's gist stays open for others."
     rm -f "$room_name_file"
   fi
@@ -2271,7 +2299,7 @@ case "${1:-help}" in
   update|upgrade|pull) cmd_update ;;
   logs)      shift; cmd_logs "$@" ;;
   status)    shift; cmd_status "$@" ;;
-  doctor)    shift; cmd_doctor "$@" ;;
+  doctor|tests|test) shift; cmd_doctor "$@" ;;
   teardown|stop|flush) shift; cmd_teardown "$@" ;;
   disconnect|leave|unbind) cmd_disconnect ;;
   monitor)   shift; monitor "$@" ;;

--- a/airc
+++ b/airc
@@ -1004,14 +1004,33 @@ cmd_connect() {
     if echo "$gist_id" | grep -qE '^[a-zA-Z0-9]{6,40}$'; then
       echo "  Resolving gist $gist_id ..."
       local raw_content=""
-      if command -v gh >/dev/null 2>&1; then
+      # Prefer `gh api` over `gh gist view --raw` — the latter prepends
+      # the gist description as a header line ("airc room: general\n\n{...}")
+      # which breaks JSON parse downstream. `gh api` returns the file
+      # content cleanly. This bug bit hard during daemon-install dogfood:
+      # parser fell through to the @.*@ regex fallback which captured the
+      # malformed JSON `"invite": "..."` line (quotes and all), pair
+      # handshake failed on garbage host info, and self-heal didn't fire
+      # because resolved_room_name was never extracted via the jq path.
+      if command -v gh >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+        raw_content=$(gh api "gists/$gist_id" 2>/dev/null \
+                      | jq -r '.files | to_entries[0].value.content // empty' 2>/dev/null)
+      fi
+      # Fallback path 1: gh without jq → degraded gh gist view --raw, with
+      # a description-strip in the consumer below.
+      if [ -z "$raw_content" ] && command -v gh >/dev/null 2>&1; then
         raw_content=$(gh gist view "$gist_id" --raw 2>/dev/null)
       fi
+      # Fallback path 2: anonymous curl + jq for environments without gh.
       if [ -z "$raw_content" ] && command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
-        # Anonymous GitHub API call. Works for public + secret gists
-        # given the ID. No auth needed for read.
         raw_content=$(curl -fsSL "https://api.github.com/gists/$gist_id" 2>/dev/null \
                       | jq -r '.files | to_entries[0].value.content // empty' 2>/dev/null)
+      fi
+      # Last-resort cleanup: if raw_content still has the description-header
+      # leak from a degraded gh-view path, strip lines before the first '{'
+      # (room/invite envelopes are JSON, always start with '{').
+      if [ -n "$raw_content" ] && ! printf '%s' "$raw_content" | head -c 1 | grep -q '{'; then
+        raw_content=$(printf '%s' "$raw_content" | awk '/^\{/{flag=1} flag')
       fi
       if [ -z "$raw_content" ]; then
         die "Failed to fetch gist '$gist_id'. Check the ID, network, and (if private) 'gh auth login'."

--- a/airc
+++ b/airc
@@ -893,8 +893,23 @@ cmd_connect() {
   # Skipped if `gh` isn't available (degraded → host invite-only) or
   # AIRC_NO_DISCOVERY=1 (explicit opt-out). With `--no-general` the room
   # path is skipped and we go straight to single-pair invite host mode.
+  #
+  # IMPORTANT: discovery used to be gated on `[ ! -f CONFIG ]` to avoid
+  # running on resume. But that broke daemon installs into stale-state
+  # scopes: a CONFIG with identity-only data (no host_target — i.e. a
+  # prior host's leftover) skipped the resume path AND discovery, so the
+  # daemon fell through to host mode and created a DUPLICATE #general
+  # gist alongside the existing one.
+  #
+  # The right gate is "no host_target": if the prior CONFIG was a host
+  # (no host_target), we should still attempt discovery on the next
+  # connect — maybe someone else became the new host since we last ran,
+  # or our prior #general gist is still authoritative and we should join
+  # ourselves into it as a peer (the existing-room flow handles that).
   local _did_room_discovery=0
-  if [ -z "$target" ] && [ ! -f "$CONFIG" ] && \
+  local _saved_host_target=""
+  [ -f "$CONFIG" ] && _saved_host_target=$(get_config_val host_target "")
+  if [ -z "$target" ] && [ -z "$_saved_host_target" ] && \
      [ "${AIRC_NO_DISCOVERY:-0}" != "1" ] && \
      command -v gh >/dev/null 2>&1; then
 

--- a/airc
+++ b/airc
@@ -2664,6 +2664,37 @@ _daemon_install_systemd() {
       die "systemctl not found. Daemon install requires systemd."
     fi
   fi
+  # Probe the user-level systemd bus BEFORE writing the unit. WSL2 ships
+  # systemctl on PATH but typically has init (not systemd) as PID 1, so
+  # `systemctl --user` returns "Failed to connect to bus" — we'd write
+  # the unit then fail to load it, leaving cruft on disk. Detect early.
+  if ! systemctl --user is-system-running >/dev/null 2>&1 \
+     && ! systemctl --user list-units >/dev/null 2>&1; then
+    if [ "$os" = "wsl" ]; then
+      cat >&2 <<EOF
+ERROR: systemctl is on PATH but the user-level systemd bus isn't reachable
+       (Failed to connect to bus). On WSL2 this means systemd isn't running
+       as PID 1 — the default Ubuntu image launches with init instead.
+
+Enable systemd in WSL:
+  1. In your WSL distro, edit /etc/wsl.conf and add:
+
+       [boot]
+       systemd=true
+
+  2. From PowerShell on Windows:    wsl --shutdown
+  3. Reopen your WSL terminal. Confirm with:    ps -p 1 -o comm=    (should print "systemd")
+  4. Re-run:    airc daemon install
+
+Until systemd is enabled, airc daemon can't auto-resume on this WSL distro.
+A manual fallback for now:  run 'airc connect' in a tmux/screen session that
+won't get killed by your WSL shell exit.
+EOF
+      return 1
+    else
+      die "systemctl present but user-level systemd bus unreachable. Check: systemctl --user status (and ensure systemd is PID 1 on this host)."
+    fi
+  fi
   mkdir -p "$unit_dir"
   cat > "$unit_path" <<UNIT
 [Unit]

--- a/install.sh
+++ b/install.sh
@@ -10,8 +10,14 @@ set -euo pipefail
 
 REPO_URL="https://github.com/CambrianTech/airc.git"
 CLONE_DIR="${AIRC_DIR:-$HOME/.airc-src}"
-BIN_DIR="$HOME/.local/bin"
-SKILLS_TARGET="$HOME/.claude/skills"
+# BIN_DIR + SKILLS_TARGET respect env-var overrides so test harnesses
+# (and packagers, distros, etc.) can point install.sh at a sandbox
+# instead of stomping ~/.local/bin and ~/.claude/skills. Pre-fix, a
+# test passing BIN_DIR=/tmp/foo would be silently ignored and the
+# real ~/.local/bin/airc symlink would get rewritten to point at the
+# test dir — caught when our own canary test corrupted the real install.
+BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
+SKILLS_TARGET="${SKILLS_TARGET:-$HOME/.claude/skills}"
 
 info()  { printf '  \033[1;34m->\033[0m %s\n' "$*"; }
 ok()    { printf '  \033[1;32m->\033[0m %s\n' "$*"; }

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,67 @@ ok()    { printf '  \033[1;32m->\033[0m %s\n' "$*"; }
 
 if [ -d "$CLONE_DIR/.git" ]; then
   info "Updating existing install"
-  git -C "$CLONE_DIR" pull --ff-only --quiet
+  # Recovery: if the install dir is on a non-channel branch (e.g. someone
+  # / some AI checked out a feature branch for testing and forgot to
+  # switch back), the ff-pull below fails with cryptic "Not possible to
+  # fast-forward". Worse, the user can't escape via `airc canary` if
+  # they're on a pre-channels binary — `canary` is an unknown command
+  # there. So install.sh itself takes responsibility: detect non-channel
+  # branches + auto-switch to the saved channel (or main) before pulling.
+  CURRENT_BRANCH=$(git -C "$CLONE_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  SAVED_CHANNEL=""
+  [ -f "$CLONE_DIR/.channel" ] && SAVED_CHANNEL=$(tr -d '[:space:]' < "$CLONE_DIR/.channel")
+  TARGET_BRANCH="${SAVED_CHANNEL:-main}"
+  case "$CURRENT_BRANCH" in
+    main|canary)
+      # On a known channel — leave it alone unless the saved channel
+      # disagrees (e.g. user just `airc channel canary`'d but didn't
+      # update yet).
+      if [ -n "$SAVED_CHANNEL" ] && [ "$SAVED_CHANNEL" != "$CURRENT_BRANCH" ]; then
+        info "Saved channel '$SAVED_CHANNEL' differs from current branch '$CURRENT_BRANCH' — switching"
+        git -C "$CLONE_DIR" fetch --quiet origin "$SAVED_CHANNEL"
+        git -C "$CLONE_DIR" checkout -q "$SAVED_CHANNEL" \
+          || git -C "$CLONE_DIR" checkout -q -B "$SAVED_CHANNEL" "origin/$SAVED_CHANNEL"
+      fi
+      ;;
+    *)
+      info "Install dir on '$CURRENT_BRANCH' (not a known channel) — switching to '$TARGET_BRANCH'"
+      git -C "$CLONE_DIR" fetch --quiet origin "$TARGET_BRANCH" || {
+        echo "ERROR: Couldn't fetch origin/$TARGET_BRANCH. Network? gh auth?" >&2
+        exit 1
+      }
+      git -C "$CLONE_DIR" checkout -q "$TARGET_BRANCH" \
+        || git -C "$CLONE_DIR" checkout -q -B "$TARGET_BRANCH" "origin/$TARGET_BRANCH" \
+        || {
+          cat >&2 <<EOF
+ERROR: Couldn't switch $CLONE_DIR to '$TARGET_BRANCH'.
+Recover manually:
+  cd $CLONE_DIR
+  git fetch origin
+  git status               # see why checkout was blocked
+  git stash                # if you have local edits worth keeping
+  git checkout $TARGET_BRANCH
+  git pull --ff-only
+  bash install.sh
+EOF
+          exit 1
+        }
+      ;;
+  esac
+  if ! git -C "$CLONE_DIR" pull --ff-only --quiet 2>&1; then
+    cat >&2 <<EOF
+ERROR: Couldn't fast-forward $CLONE_DIR (currently on $(git -C "$CLONE_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)).
+Likely cause: local edits or a divergent history.
+Recover with:
+  cd $CLONE_DIR
+  git status
+  git stash               # if you have local edits worth keeping
+  git fetch origin
+  git reset --hard origin/$(git -C "$CLONE_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  bash install.sh
+EOF
+    exit 1
+  fi
 else
   info "Installing AIRC"
   git clone --quiet "$REPO_URL" "$CLONE_DIR"

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: airc:canary
+description: Switch this airc install to the canary channel — pre-merge features queued for the next main release. Use when Joel asks you to test something that hasn't landed on main yet, or when you want the bleeding edge.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: ""
+---
+
+# airc canary
+
+Run this yourself — don't ask the user.
+
+## What it does
+
+Switches this airc install to the `canary` channel. Under the covers:
+- `git fetch origin canary`
+- `git checkout canary`
+- `git pull --ff-only`
+- Refreshes skills + binary symlinks via `install.sh`
+- Persists the choice to `$AIRC_DIR/.channel` so subsequent `airc update` (no args) stays on canary
+
+## Execute
+
+```bash
+airc canary
+```
+
+Equivalent to `airc update --channel canary`. The shortcut exists because "go canary" is the common case for pre-merge testing.
+
+## What "canary" means
+
+| Channel | What it is | When to use |
+|---|---|---|
+| `main` | Stable. Most users run this. | Default. |
+| `canary` | Long-lived branch ahead of main. Features that haven't been merged to main yet land here first; we test on canary, then promote canary→main as a single integration commit. | When testing a not-yet-merged feature, OR when you want bleeding edge. |
+
+`canary` is just a git branch. Switching back is symmetric: `airc update --channel main` (or `airc channel main && airc update`).
+
+## Rollback
+
+If canary breaks something:
+
+```bash
+airc update --channel main
+airc teardown && airc connect
+```
+
+That's it. Branch switch + restart monitor on the new code. Identity, peers, room state all persist (they're in `$AIRC_HOME`, not `$AIRC_DIR`).
+
+## After switching
+
+Tell the user:
+
+> "Switched to canary (sha `<short-sha>`). Running monitor still uses old code — `airc teardown && airc connect` to pick up the new binary."
+
+Then if they had a paired session you should restart the monitor for them:
+```
+Monitor(persistent=true, command="airc connect")
+```
+
+## When to use this skill
+
+- Joel says "test the canary" / "try the new substrate work" / similar.
+- A new feature is queued in canary and bigmama / memento / anvil need to validate before promotion.
+- The user mentions a recent merged-to-canary PR by number (e.g. "test PR #40").
+
+## When NOT to use this skill
+
+- For routine updates → use `/airc:update` (stays on whatever channel they're on; doesn't switch).
+- For first-time install → use `/airc:connect` which auto-installs main.
+
+## Notes
+
+- This is not "experimental beta channel" — canary is "merged-but-not-yet-promoted." Code on canary has passed local tests + the contributor's review; it just hasn't earned its way to main yet via cross-machine validation.
+- Channel preference lives in `$AIRC_DIR/.channel`. Inspect with `airc channel`.
+- If `gh auth status` is clean, the substrate (`airc connect` zero-arg → #general) works exactly the same on canary as on main — channels affect the airc binary, not the gist namespace.

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,48 +1,96 @@
 ---
 name: airc:doctor
-description: Self-diagnose AIRC. Runs the integration tests to validate pairing, send, rename, send-file, reminder heartbeat, teardown scope isolation, and the two-tier home/local resolver.
+description: Self-diagnose AIRC. AI checks environment health (gh, ssh, ports), runs the integration suite, and proactively fixes recoverable issues (install gh, etc.) instead of just reporting them.
 user-invocable: true
 allowed-tools: Bash
-argument-hint: "[tabs|scope|reminder|teardown|all]"
+argument-hint: "[scenario|all]"
 ---
 
 # airc doctor
 
-Run this yourself — don't ask the user. It's fast (~45s) and self-contained.
+Run this yourself — don't ask the user. Goal: leave the user with a working airc, not a diagnosis they have to act on.
 
-## What it does
+## Step 1 — environment health check (do this BEFORE running tests)
 
-Invokes `airc doctor`, which runs the bundled integration suite at `$AIRC_DIR/test/integration.sh`. 31 assertions across 4 scenarios:
+The substrate is gh-rooted. Check the environment first; an absent / unauthed gh is the #1 cause of "airc feels broken." If you can fix it, fix it.
 
-- **tabs** — two airc processes on one machine with isolated homes + port override. Pairing, bidirectional send, monitor correctness, rename propagation, peer-record persistence, send-file with `-i` key, local outbound mirror (audit trail).
-- **scope** — per-project `$PWD/.airc/` opt-in tier. Home peers inherited when local is empty; local shadows home on name collision.
-- **reminder** — `AIRC_REMINDER` env var, interval persisted, heartbeat fires after silence, `reminded` marker prevents spam, `airc reminder off/<n>` controls.
-- **teardown** — host killed, port freed, state preserved without `--flush`; teardown in a different scope does NOT kill unrelated hosts (scope isolation).
+```bash
+# (a) gh installed?
+command -v gh >/dev/null 2>&1 && echo "gh: present" || echo "gh: MISSING"
 
-The script uses **port 7549** (test-reserved) and `AIRC_HOME=/tmp/airc-it-*`. It will NOT touch any live airc session running on the default 7547 or the common alt 7548. Cleans up after itself via pidfiles — no broad process kills.
+# (b) gh authenticated?
+gh auth status 2>&1 | head -3
 
-## Run
+# (c) ssh remote login on this machine? (needed for tabs/scope tests + real pairing)
+# macOS:
+sudo systemsetup -getremotelogin 2>/dev/null || true
+# Linux: just check sshd is running
+systemctl is-active sshd 2>/dev/null || pgrep -f "sshd" >/dev/null && echo "sshd: active" || echo "sshd: NOT running"
+
+# (d) port 7549 (test-reserved) free?
+lsof -iTCP:7549 -sTCP:LISTEN 2>/dev/null | head -3 || echo "7549: free"
+```
+
+**Act on findings, don't just print them:**
+
+- **`gh: MISSING`** → install gh. macOS: `brew install gh`. Linux Ubuntu/Debian: `sudo apt install gh` (or follow https://github.com/cli/cli#installation). Windows: `winget install GitHub.cli` or `choco install gh`. Then tell the user to `gh auth login` (needs interactive browser flow — they have to run this themselves).
+- **`gh auth: not logged in`** → `gh auth login` (must be interactive — instruct the user to type `! gh auth login` so it runs in the terminal session and the browser flow can complete).
+- **`sshd: NOT running`** (macOS) → `sudo systemsetup -setremotelogin on` (the user has to run this; needs sudo). Or System Settings → General → Sharing → Remote Login.
+- **`7549: <pid>`** → port held by something else; `lsof -tiTCP:7549 -sTCP:LISTEN | xargs kill` if the process is one you can identify and kill safely. Otherwise tell the user.
+
+Why this comes BEFORE the tests: the integration suite is `gh`-free by design (uses inline invites + local SSH), so missing gh wouldn't fail the tests — but the user will still be unable to use the substrate (`airc connect` zero-arg auto-discovery, `airc rooms`). Doctor should catch and fix that.
+
+## Step 2 — run the integration suite
 
 ```bash
 airc doctor $ARGUMENTS
 ```
 
-Empty or `all` runs all 4 scenarios sequentially. `tabs`, `scope`, `reminder`, `teardown` run one.
+Empty `$ARGUMENTS` (or `all`) runs every scenario. A scenario name (`tabs`, `scope`, `room`, `teardown`, `reminder`, `resilience`, `reconnect`, `queue`, `status`, `auth_failure`, `resume_stale_auth`) runs just that one. Suite uses port 7549 + `AIRC_HOME=/tmp/airc-it-*`; safe alongside live airc on 7547/7548.
 
-## Read the result
+## Step 3 — interpret + act
 
-Final line: `N passed, M failed`. `0 failed` means green. Otherwise the suite prints each failure by name — report them verbatim.
+Final line: `N passed, M failed`.
 
-## When to run
+### Green (`0 failed`)
 
-- Right after install, before pairing for real
-- After an upgrade, to confirm the new binary behaves
-- When something feels off — rule out a binary-level regression before blaming the network
+- Environment OK + tests OK → tell the user "airc is healthy. Run `airc connect` to join the substrate."
+- Make sure to mention what you fixed (if anything) in step 1.
 
-## Interpreting failures
+### Red
 
-- **alpha hosting failed** — `airc` not on PATH, or port 7549 taken (rare; port 7549 is test-reserved). Check `lsof -iTCP:7549`.
-- **beta join failed** — SSH Remote Login isn't enabled on this machine, or a firewall is blocking TCP to 7549.
-- **send/monitor did NOT see** — the signed-message-over-SSH path is broken. Check `~/.ssh/authorized_keys` has the test keys mid-run, or trace with `bash -x`.
-- **scope: local tier shadows home** — the two-tier resolver in the binary is regressed. Upstream bug, not environment.
-- **teardown in different scope killed foreign host** — scope isolation regression. Critical — would mean one Claude tab can nuke another's live session. File an issue.
+For each failure name in the trace, look it up in this table and **act, don't just report**:
+
+| Failure | Likely cause | What to do |
+|---|---|---|
+| `alpha host failed to start` | Port 7549 taken, OR airc not on PATH | `lsof -iTCP:7549` → kill if safe; verify `command -v airc` |
+| `beta join failed` | sshd not running, OR firewall blocks loopback ssh | enable Remote Login (mac) / start sshd (linux); test `ssh localhost echo ok` |
+| `scope: ...` | Two-tier resolver in airc binary regressed | rare — bisect against last green sha; this is upstream airc, file an issue |
+| `teardown in different scope killed foreign host` | Scope isolation broke (critical) | file an issue immediately; this would let one Claude tab nuke another's session |
+| `room: alpha unexpectedly wrote room_gist_id under --no-gist` | Use of --no-gist isn't honored on the gist-push branch | regression in cmd_connect's host-mode gist push gate |
+| `room: alpha cmd_part DID NOT identify as host` | cmd_part's host-vs-joiner detection regressed | host signal is `config.json::host_target` empty; do not fall back to gist_id presence (that was the pre-PR2 bug) |
+| `auth_failure: stderr did NOT mention re-pair` | cmd_send's auth-class-error detection regressed | check the regex against `permission denied|publickey|host key|...` |
+| `resume_stale_auth: invite string` | Resume probe didn't reconstruct the saved invite for the user | regression in cmd_connect's resume probe failure branch |
+
+If a failure isn't in the table:
+- Read the failure verbatim
+- Trace into `test/integration.sh` for that scenario name to understand what assertion fired
+- Read the relevant section of the airc binary
+- Form a hypothesis, fix it, re-run that scenario alone (`airc doctor <scenario>`)
+
+## Step 4 — final report
+
+One line: "Fixed X, Y. All tests green." OR "Fixed X. Tests N passed M failed; failures: <list>." Be specific about what you did, not what was found.
+
+## When to run this skill
+
+- Right after install — confirms airc + gh + sshd all aligned before pairing for real.
+- After `airc update` — confirms the new binary didn't regress, and that any new env requirements (e.g. gh in #38, gh in #39) are met.
+- When something feels wrong — rule out a binary-level regression before blaming network / SSH / human error.
+- Before opening an airc issue — paste the doctor output so the maintainer doesn't have to ask.
+
+## Notes
+
+- Scenarios are gh-free; the substrate ITSELF (`airc connect` zero-arg, `airc rooms`) requires gh. That's a feature, not a bug — gh is the comm layer.
+- Suite runtime is ~2 minutes for `all`; individual scenarios are 10-30s.
+- This skill assumes you can run shell commands. The user should not have to type anything except the interactive `gh auth login` flow if you encounter it.

--- a/skills/tests/SKILL.md
+++ b/skills/tests/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: airc:tests
+description: Run the airc integration test suite (alias for airc doctor). Validates pairing, send, rename, room substrate, scope isolation, queue resilience, and more. Use after install or upgrade, or when something feels off.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: "[scenario|all]"
+---
+
+# airc tests
+
+Run this yourself — don't ask the user.
+
+## Execute
+
+```bash
+airc doctor $ARGUMENTS
+```
+
+Empty `$ARGUMENTS` (or `all`) runs every scenario sequentially. A specific scenario name runs just that one.
+
+## What's in the suite
+
+11 scenarios at last count, all rooted in `test/integration.sh`:
+
+| Scenario | What it proves |
+|---|---|
+| `tabs` | Two airc processes on one machine pair via inline invite, send bidirectionally, audit-trail to local log, send-file works, rename propagates |
+| `scope` | Per-project `$PWD/.airc/` shadows home tier; scoped config doesn't leak |
+| `reminder` | `AIRC_REMINDER` interval persists, heartbeat fires after silence, `airc reminder off/<n>` controls |
+| `teardown` | Host killed, port freed, state preserved without `--flush`; scope isolation (one teardown doesn't kill another tab's host) |
+| `resilience` | Wire failures don't drop messages — local mirror + `[QUEUED]` marker + `pending.jsonl` for retry |
+| `reconnect` | Stale pidfile recovered, host re-spawn against same scope works |
+| `queue` | `pending.jsonl` drains automatically when host returns |
+| `status` | `airc status` reports liveness correctly, `--probe` runs SSH check |
+| `auth_failure` | Bad key gives clear "re-pair required" error, NOT silent queue forever |
+| `resume_stale_auth` | Resume detects stale SSH key at probe time, dies loud with reconstructed invite string |
+| `room` | #39 IRC substrate — `--room <name>` + cmd_part host/joiner detection + `room_name` state file |
+
+## How to read output
+
+Final line: `N passed, M failed`. `0 failed` means green. Failures print by name above the summary; report them verbatim to the user.
+
+## When to run
+
+- Right after install — `airc tests` to confirm the binary works on this machine before pairing for real.
+- After `airc update` — confirm the new binary didn't regress.
+- When something feels wrong — rule out a binary-level bug before blaming network / gh / SSH.
+- After local edits to `airc` script — fast feedback loop instead of pairing manually.
+
+## Common failure → diagnosis
+
+Most failures fall into a small set:
+
+- **`alpha host failed to start`** — `airc` not on PATH, or port 7549 (test-reserved) is taken. Check `lsof -iTCP:7549`. Killing whatever holds it usually fixes.
+- **`beta join failed`** — SSH Remote Login isn't enabled on this machine, OR a firewall is blocking TCP to 7549. macOS: System Settings → General → Sharing → Remote Login.
+- **`scope: local tier shadows home` / `home tier inheritance`** — the two-tier resolver in airc itself is regressed. Usually a recent edit broke `ensure_init` / `get_config_val`. Bisect against last known green sha.
+- **`teardown in different scope killed foreign host`** — scope isolation broke. Critical (one tab nuking another's session). File issue immediately.
+- **`alpha cmd_part DID NOT identify as host`** — cmd_part's host-vs-joiner detection regressed. The signal is `config.json::host_target` empty = host. Don't fall back to gist_id presence — that was the original bug (#39 PR2).
+
+## Notes
+
+- Suite uses port 7549 (test-reserved) and `AIRC_HOME=/tmp/airc-it-*`. Won't touch live airc on default 7547 or alt 7548.
+- All scenarios are `gh`-free — they use the inline invite handshake, not the gist transport. (This is by design; tests must run in CI without GH credentials.)
+- The room scenario uses `--no-gist --room <unique-name>` to exercise IRC-substrate flag plumbing without polluting the user's gh gist namespace.
+- Cleans up via pidfiles after itself — no broad `pkill` hammers. If something hangs, `airc teardown --all` is the manual recovery.

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -73,11 +73,22 @@ cleanup_known_hosts() {
 cleanup_all() { cleanup_procs; cleanup_dirs; cleanup_known_hosts; }
 
 # Boot a host. Args: home, name, port
+#
+# Defaults to --no-general --no-gist for two reasons:
+# (1) These existing scenarios test the LOWER-layer single-pair invite
+#     behavior, not the IRC substrate. With #39's defaults, bare
+#     `airc connect` would create a real `airc room: general` gist on
+#     the user's gh account and pollute the test environment for every
+#     subsequent scenario that bare-connects.
+# (2) Tests must run gh-free in CI; --no-gist is the explicit opt-out.
+# Scenarios that DO want substrate behavior (scenario_room) call airc
+# directly with their own flags rather than going through spawn_host.
 spawn_host() {
   local home="$1" name="$2" port="$3"
   mkdir -p "$home"
   ( cd "$home" && AIRC_HOME="$home/state" AIRC_NAME="$name" AIRC_PORT="$port" \
-      "$AIRC" connect > "$home/out.log" 2>&1 & )
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-general --no-gist > "$home/out.log" 2>&1 & )
   local i
   for i in 1 2 3 4 5; do
     sleep 1
@@ -87,10 +98,15 @@ spawn_host() {
 }
 
 # Join a host. Args: home, name, join-string
+#
+# AIRC_NO_DISCOVERY=1 also for tests — the joiner's target is always an
+# inline invite string in the existing scenarios; we don't want it
+# probing gh for a #general gist that may have been created out-of-band.
 spawn_joiner() {
   local home="$1" name="$2" join="$3"
   mkdir -p "$home"
   ( cd "$home" && AIRC_HOME="$home/state" AIRC_NAME="$name" \
+      AIRC_NO_DISCOVERY=1 \
       "$AIRC" connect "$join" > "$home/out.log" 2>&1 & )
   local i
   for i in 1 2 3 4 5 6; do
@@ -293,7 +309,8 @@ scenario_reminder() {
   local home=/tmp/airc-it-r
   mkdir -p "$home"
   ( cd "$home" && AIRC_HOME="$home/state" AIRC_NAME=hb-host AIRC_PORT=7549 AIRC_REMINDER=2 \
-      "$AIRC" connect > "$home/out.log" 2>&1 & )
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-general --no-gist > "$home/out.log" 2>&1 & )
   local i
   for i in 1 2 3 4 5; do sleep 1; grep -q 'Hosting as' "$home/out.log" 2>/dev/null && break; done
 
@@ -392,7 +409,8 @@ scenario_resilience() {
   # PID 1 always exists but can't be our parent, and pgrep -P 999999 always returns 1.
   echo "999999" > "$sp_home/state/airc.pid"
   ( cd "$sp_home" && AIRC_HOME="$sp_home/state" AIRC_NAME=stalepid-host AIRC_PORT=7549 \
-      "$AIRC" connect > "$sp_home/out.log" 2>&1 & )
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-general --no-gist > "$sp_home/out.log" 2>&1 & )
   local i
   for i in 1 2 3 4 5 6; do sleep 1; grep -q 'Hosting as' "$sp_home/out.log" 2>/dev/null && break; done
   grep -q 'Hosting as' "$sp_home/out.log" && pass "stale pidfile: cmd_connect recovers and reaches Hosting" \
@@ -482,7 +500,8 @@ scenario_reconnect() {
   # (Can't use spawn_host as-is because it mkdir's and overwrites state.
   #  Instead re-invoke connect directly pointing at the same state.)
   ( cd /tmp/airc-it-rec-h && AIRC_HOME=/tmp/airc-it-rec-h/state AIRC_NAME=alpha AIRC_PORT=7549 \
-      "$AIRC" connect >> /tmp/airc-it-rec-h/out.log 2>&1 & )
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-general --no-gist >> /tmp/airc-it-rec-h/out.log 2>&1 & )
   local i
   for i in 1 2 3 4 5 6 7 8; do
     sleep 1
@@ -786,6 +805,123 @@ scenario_resume_stale_auth() {
   cleanup_all
 }
 
+# ── Scenario: room (#39 — IRC-style #general substrate) ────────────────
+# Validates the room-mode flag plumbing, host-vs-joiner detection in
+# cmd_part, and that --no-gist still records local room state. Doesn't
+# touch GitHub at all (no gh dependency); all wire-level pairing reuses
+# the long-invite handshake the rest of the suite already proves.
+#
+# What we DO test:
+#   - --room flag accepted; banner reports "Hosting #<name> (gh-account substrate)"
+#   - room_name file written under AIRC_HOME (even with --no-gist)
+#   - joiner pairs via inline invite and bidirectional send works
+#   - cmd_part on host: detects host via config.host_target absence, runs
+#     teardown, removes room_name file, doesn't try to gh-delete (no
+#     gist_id stored under --no-gist)
+#   - cmd_part on joiner: reports joiner status, removes room_name only,
+#     leaves identity intact
+#
+# What we explicitly DON'T test (out of scope; covered by manual e2e
+# w/ real gh + the next PR's multi-room work):
+#   - Discovery of an existing #general gist on the gh account
+#   - Persistence of a room gist after pair (the gist itself isn't
+#     created here — `--no-gist` keeps the test gh-free)
+#   - Multi-joiner room (one host, N joiners) — single-joiner here
+#     proves the flag path; N-joiner is a topology test, not a flag test
+scenario_room() {
+  section "room: #39 IRC-style substrate (--room + cmd_part, no gh)"
+  cleanup_all
+
+  local rname="test-irc-$$"
+
+  # ── Host alpha in room mode, gist push disabled so the test runs
+  #    in any environment (CI, gh-less workstations).
+  mkdir -p /tmp/airc-it-h
+  ( cd /tmp/airc-it-h && AIRC_HOME=/tmp/airc-it-h/state AIRC_NAME=alpha AIRC_PORT=7549 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room "$rname" > /tmp/airc-it-h/out.log 2>&1 & )
+  local i
+  for i in 1 2 3 4 5; do
+    sleep 1
+    grep -q 'Hosting as' /tmp/airc-it-h/out.log 2>/dev/null && break
+  done
+  grep -q 'Hosting as' /tmp/airc-it-h/out.log \
+    && pass "alpha hosting in room mode (--room ${rname}, --no-gist)" \
+    || { fail "alpha host failed to start in room mode"; cleanup_all; return; }
+
+  # Banner asserts substrate framing: "Hosting #<name>" must appear so
+  # users (and the AI agent) can tell which channel they're on.
+  grep -qE "Hosting #${rname}" /tmp/airc-it-h/out.log \
+    && pass "alpha banner reports #${rname} (substrate framing)" \
+    || fail "alpha banner missing 'Hosting #${rname}' line"
+
+  # room_name file MUST be on disk even with --no-gist. cmd_part + status
+  # + diagnostics rely on it.
+  [ -f /tmp/airc-it-h/state/room_name ] && [ "$(cat /tmp/airc-it-h/state/room_name)" = "$rname" ] \
+    && pass "alpha room_name file recorded ($(cat /tmp/airc-it-h/state/room_name))" \
+    || fail "alpha room_name file missing or wrong value"
+
+  # No gist was pushed → no room_gist_id (this is the bug we just fixed:
+  # cmd_part previously used gist_id presence as the host-vs-joiner
+  # signal, which would misclassify --no-gist hosts as joiners).
+  [ ! -f /tmp/airc-it-h/state/room_gist_id ] \
+    && pass "alpha has no room_gist_id (--no-gist as expected)" \
+    || fail "alpha unexpectedly wrote room_gist_id under --no-gist"
+
+  # ── Joiner beta pairs via inline invite (long form, gh-free).
+  local join; join=$(read_join_string /tmp/airc-it-h)
+  [ -n "$join" ] && pass "alpha join string captured for beta to use" \
+                 || { fail "no join string in alpha log"; cleanup_all; return; }
+
+  spawn_joiner /tmp/airc-it-j beta "$join" \
+    && pass "beta joined alpha's room" \
+    || { fail "beta join failed"; cleanup_all; return; }
+
+  # Bidirectional send still works through a room (room-ness is purely
+  # at the discovery + lifecycle layer; the wire is unchanged).
+  sleep 3
+  as_home /tmp/airc-it-j send @alpha "room-msg-from-beta" >/dev/null 2>&1 \
+    && pass "beta → alpha send through room works" \
+    || fail "beta → alpha send through room FAILED"
+  sleep 3
+  grep -q 'room-msg-from-beta' /tmp/airc-it-h/out.log \
+    && pass "alpha received beta's message through room" \
+    || fail "alpha did NOT receive beta's message"
+
+  # ── cmd_part on JOINER (beta).
+  # Joiner has host_target in config → cmd_part takes joiner branch:
+  # removes room_name only, doesn't touch gist (we have none anyway),
+  # then runs teardown.
+  local part_out
+  part_out=$(as_home /tmp/airc-it-j part 2>&1)
+  echo "$part_out" | grep -q 'Joiner of #' \
+    && pass "beta cmd_part identifies as joiner (config.host_target detection)" \
+    || fail "beta cmd_part DID NOT identify as joiner: $part_out"
+  echo "$part_out" | grep -qE 'gh.*delete|gist delete' \
+    && fail "beta cmd_part attempted gh delete (joiner shouldn't)" \
+    || pass "beta cmd_part correctly skipped gh delete (joiner)"
+  [ ! -f /tmp/airc-it-j/state/room_name ] \
+    && pass "beta room_name removed after part" \
+    || fail "beta room_name still present after part"
+
+  # ── cmd_part on HOST (alpha).
+  # Host has no host_target → cmd_part takes host branch. With --no-gist
+  # there's no gist_id, so it should report "no gist was published"
+  # rather than mis-routing into joiner branch (the bug we just fixed).
+  part_out=$(as_home /tmp/airc-it-h part 2>&1)
+  echo "$part_out" | grep -q 'Host of #' \
+    && pass "alpha cmd_part identifies as host (config no host_target)" \
+    || fail "alpha cmd_part DID NOT identify as host: $part_out"
+  echo "$part_out" | grep -q 'no gist was published' \
+    && pass "alpha cmd_part correctly noted absent gist (--no-gist host case)" \
+    || fail "alpha cmd_part didn't acknowledge --no-gist case: $part_out"
+  [ ! -f /tmp/airc-it-h/state/room_name ] \
+    && pass "alpha room_name removed after part" \
+    || fail "alpha room_name still present after part"
+
+  cleanup_all
+}
+
 case "$MODE" in
   tabs)         scenario_tabs  ;;
   scope)        scenario_scope ;;
@@ -797,8 +933,9 @@ case "$MODE" in
   status)       scenario_status ;;
   auth_failure) scenario_auth_failure ;;
   resume_stale_auth) scenario_resume_stale_auth ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|all]"; exit 2 ;;
+  room)         scenario_room ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
Promoting canary at HEAD ed94d54 into main. All work below has been dogfood-validated on Mac (anvil daemon hosting #general live) and bigmama-wsl (paired across the substrate, overnight sleep cycles held).

## What's promoting

- **#39 substrate** — `airc connect` auto-#general via gh-rooted IRC; `--room <name>`, `airc rooms`, `airc part`. Same gh account = zero-string auto-discovery; cross-account = paste gist id.
- **#40 tests + skills + cmd_part bugfix** — scenario_room (14 assertions), /airc:tests, actionable /airc:doctor (env health + integration suite). cmd_part now uses config.host_target as host signal (was room_gist_id, broke under --no-gist hosts).
- **#41 release channels (already on main; this re-merges)** — main = stable, canary = pre-merge testing. `airc canary`, `airc channel`, /airc:canary skill.
- **#42 staging workflow** — enforce-canary-staging GitHub Action blocks PRs to main unless from canary OR carry hotfix label/title.
- **#43 install.sh stale-branch recovery** — auto-checks-out saved channel before pulling. Caught when daemon install hit the catch-22 on stale-branch state.
- **#44 install.sh env-override respect** — BIN_DIR / SKILLS_TARGET now honor env vars. Caught when test harness stomped real symlink.
- **#45 daemon install** — `airc daemon install` writes launchd plist (mac) / systemd-user unit (linux), starts it. Caveats explicit (gh keychain, loginctl enable-linger, wsl systemd).
- **#46 self-heal** — first-agent-back becomes new host of #general when prior host unreachable. Both cold-start and resume paths.
- **24f10aa monitor escalation** — running monitor exits 99 after 3 watchdog timeouts so daemon respawn can trigger self-heal. Closes the 'no claude left behind' chain.
- **f571f5c critical fix** — gh gist view --raw prepends description, daemon respawn loop. Switched to gh api gists/<id>.
- **c182483 fix** — discovery now runs on stale-host-config scopes (was skipping when CONFIG existed).
- **58f384b fix** — WSL2 systemd-bus probe before writing unit; fail loud with wsl.conf+shutdown instructions instead of silently leaving dead unit.
- **#47 readme rewrite** — substrate framing front and center; emphasizes uses-what-you-have (gh + Tailscale), no central infra; AIs use it autonomously.

## Empirical dogfood

- Mac daemon hosting #general continuously since 02:50 UTC (8h+). launchd respawn working across overnight sleep cycles.
- bigmama-wsl paired across the substrate via gh discovery from Linux/CUDA box.
- Heartbeats clean both ways. Zero silent drops. Zero peer disconnections.
- Two real bugs caught + fixed during dogfood (the ones above with 'critical fix' notes).

## Workflow note

Once this lands, the canary→main staging discipline is in force on main: future feature work must come via canary OR carry hotfix/urgent/emergency label or 'hotfix' in title. This PR itself is from canary, so the workflow accepts it.