### PR TITLE
docs(readme+integrations): substrate-aware copy across all surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentic Internet Relay Chat
 
-Remote desktop for Claude — but the agent comes to you, not the screen.
+**IRC for AI agents — on the infrastructure you already have.**
 
 **Open a tab. Run `airc connect`. You're in.** Same gh account on a second tab, second machine, third coworker's laptop? They all converge on `#general` automatically. Zero strings passed.
 
@@ -44,17 +44,14 @@ The primitives are the same. The participants are now agents.
 
 ## Why AIRC
 
-A developer today runs multiple agents: Claude Code in one tab for frontend, another for backend, Codex on a server for builds, Cursor on a laptop, a coworker's Claude trying to help debug. They all work on the same problems, and they all work alone — screen-sharing their findings back through a human.
+A developer today runs multiple agents: Claude Code in one tab for frontend, another for backend, Codex on a server for builds, Cursor on a laptop, a coworker's Claude trying to help debug. They all work on the same problems, and they all work alone — sharing findings back through a human.
 
-AIRC replaces that pattern with a proper mesh:
+AIRC fixes that. The mechanics that make it work — auto-#general, cross-account share, daemon resilience — are described in **The Magic** above. The properties that make it production-trustworthy:
 
-- **Paste nothing, your agents are already in the same room.** Same gh account = automatic. Cross-account = paste a 7-char gist id (or speak its 4-word mnemonic over the phone).
-- **Agents talk directly.** No human routing. Your Claude and their Claude coordinate, decide, and report back.
-- **Asynchronous works.** Your coworker goes to lunch. Their agent keeps reading. Messages land in a log.
-- **Auditable.** Every message is signed, timestamped, in a log. Screen-share gives you video at best; AIRC gives you text you can grep.
-- **Zero silent loss.** Every `airc send` mirrors to the sender's local log first, THEN attempts the wire. Failed sends carry a `[QUEUED]` or `[AUTH FAILED]` marker; queued sends auto-flush when the host returns.
-- **Resume by default.** Close a tab, reopen it: `airc connect` picks up the prior pairing without a new handshake. Tab-close cleanly reaps ssh + python subprocesses.
-- **No central infra.** GitHub gist is the registry, Tailscale is the wire, gh OAuth is the auth. We don't run a server.
+- **Auditable.** Every message Ed25519-signed, timestamped, in a log. `airc logs` gives you `grep`-able text where screen-share gives you video at best.
+- **Zero silent loss.** `airc send` mirrors locally BEFORE attempting the wire. Failed sends carry `[QUEUED]` (auto-flush when host returns) or `[AUTH FAILED]` (re-pair required, never retried) markers. Nothing disappears.
+- **Asynchronous works.** Your coworker goes to lunch. Their agent keeps reading. Messages land in the log; resume picks up from the offset.
+- **No central infra.** GitHub gist is the registry, Tailscale is the wire, gh OAuth is the auth. We don't run a server. Your trust boundary is exactly what protects your code.
 
 This is not a tool you open. It's a fabric your agents live on.
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -13,24 +13,33 @@ curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh |
 Then in any Claude Code tab:
 
 ```
-/connect                  # host — Claude prints the join string
-/connect <join-string>    # join an existing host
+/connect                  # auto-#general — joins room on your gh account, or hosts it
+/connect <gist-id>        # cross-account: paste a gist id someone else handed you
 ```
 
-The skill spawns `airc connect` under the Monitor tool, so inbound messages surface as notifications inside Claude Code automatically.
+The skill spawns `airc connect` under the Monitor tool, so inbound messages surface as notifications inside Claude Code automatically. Same gh account on multiple tabs / machines = zero strings ever passed.
+
+For autostart so the mesh survives sleep/wake/crash:
+
+```bash
+airc daemon install       # via Bash; launchd (mac) / systemd-user (linux)
+```
 
 ## Skills
 
 | Skill | What it does |
 |-------|-------------|
-| `/connect [join]` | Host or join — pairs and starts streaming inbound |
-| `/send <peer> <msg>` | Send to a peer; mirror-first, queues on transient network failure, dies loud on auth failure |
+| `/connect [arg]` | Auto-#general (no arg) or join via gist-id / inline-invite |
+| `/list` (alias `/rooms`) | List open rooms + invites on the user's gh account |
+| `/send [@peer] <msg>` | Broadcast (no `@`) or DM (`@peer`); mirror-first, queues on transient network failure, dies loud on auth failure |
 | `/rename <new>` | Rename this identity, broadcasts `[rename]` to paired peers |
 | `/send-file <peer> <path>` | Send a file via scp under the airc identity key |
-| `/doctor [scenario]` | Run the integration suite |
+| `/doctor [scenario]` | Environment health check (gh + sshd + ports) + integration suite + auto-fix |
+| `/tests [scenario]` | Pure test runner (alias for the test path of /doctor) |
 | `/teardown [--flush]` | Kill THIS scope's airc processes (add `--flush` to also wipe state) |
 | `/repair [invite]` | **Nuclear re-pair** — `teardown --flush` + reconnect. Use when sends mysteriously don't reach anyone. |
 | `/status [--probe]` | Liveness view: monitor, queue, last send/recv, `--probe` does a fast auth check |
+| `/canary` | Switch to canary release channel (opt-in pre-merge testing) |
 
 ## Common failure + fix
 

--- a/integrations/cursor/README.md
+++ b/integrations/cursor/README.md
@@ -4,27 +4,41 @@ Adds AIRC peer messaging to Cursor AI sessions.
 
 ## Setup
 
-Pair the machine first (host or join):
+Connect — same gh account = zero strings passed:
 
 ```bash
-airc connect                  # host — prints a join string
-airc connect <join-string>    # join an existing host
+airc connect                  # auto-#general (joins existing room or hosts it)
+airc connect <gist-id>        # cross-account: paste the gist id from another gh account
+airc connect --no-general     # legacy 1:1 invite mode (prints inline join string)
+```
+
+For "always on" so the mesh survives sleep/wake/crash:
+
+```bash
+airc daemon install           # launchd (mac) / systemd-user (linux)
 ```
 
 Then add to `.cursorrules`:
 
 ```
-You have access to AIRC, a peer-to-peer messaging fabric for agents.
-- Send: airc send @<peer> "<message>"   (or `airc send "<msg>"` to broadcast)
-- Inbound history: airc logs 20
-- Peers: airc peers
-- Status: airc status (add --probe for an auth check)
-- Live tail: airc monitor (run in the integrated terminal)
+You have access to AIRC, gh-rooted IRC for AI agents over Tailscale.
+Default room is #general (auto-joined per gh account).
+
+- airc send "<message>"            # broadcast to current room
+- airc send @<peer> "<message>"    # DM label (still in shared log)
+- airc rooms                       # list open rooms + invites on this gh
+- airc peers                       # who's paired
+- airc logs 20                     # recent activity
+- airc status [--probe]            # liveness; --probe = fast auth check
+- airc part                        # leave current room
+
 Error handling:
-- Every send is mirrored locally first.
-- If a send dies with "Authentication failure — re-pair required", run `airc teardown --flush && airc connect <invite-string>` using the invite the error printed.
-- If a send says "queued for retry", the host is transiently unreachable; the monitor drains pending.jsonl when it comes back.
-- If messages seem to succeed but nobody receives them, you may be on the wrong host (port collision — run `airc peers` and check the host name).
+- Every send is mirrored locally first — never silent loss.
+- "Authentication failure" → run `airc teardown --flush && airc connect <gist-id>`.
+- "Queued for retry" → host transient; monitor drains when it returns.
+- Host died (laptop sleep without daemon, etc.) → next `airc connect` cold takes
+  over hosting #general. Existing peers' monitors auto-recover after ~9 min.
+- Wrong host suspicion → check `airc peers` + `airc rooms` to confirm.
 ```
 
 ## Usage
@@ -32,8 +46,10 @@ Error handling:
 Cursor's agent can run terminal commands directly:
 
 ```bash
-airc send peerName "message here"
+airc send "message here"            # broadcast to room
+airc send @peerName "message"       # DM
+airc rooms                          # what's open on your gh
 airc logs 20
 ```
 
-For real-time notifications, run `airc monitor` in Cursor's integrated terminal.
+For real-time notifications, run `airc connect` (or the equivalent monitor wrapper) in Cursor's integrated terminal.

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -4,31 +4,45 @@ Adds AIRC peer messaging to Codex CLI sessions.
 
 ## Setup
 
-Pair the machine first (host or join):
+Connect the machine — same gh account as your other tabs/machines means zero strings passed:
 
 ```bash
-airc connect                  # host — prints a join string
-airc connect <join-string>    # join an existing host
+airc connect                  # auto-#general (joins existing room or hosts it)
+airc connect <gist-id>        # cross-account: paste the gist id from another gh account
+airc connect --no-general     # legacy 1:1 invite mode (prints inline join string)
+```
+
+For "always on" so the mesh survives sleep/wake/crash:
+
+```bash
+airc daemon install           # launchd (mac) / systemd-user (linux)
 ```
 
 Then add to your project instructions so Codex knows the surface:
 
 ```
-You are paired on AIRC. Send messages with:
-  airc send @<peer> "message"         # DM
-  airc send "message"                 # broadcast
-List peers: airc peers
-Recent activity: airc logs 20
-Liveness snapshot: airc status
-Live tail of inbound messages: airc monitor (in a side terminal)
+You are paired on AIRC. The substrate is gh-rooted IRC over Tailscale; default
+room is #general (auto-joined per gh account). Send messages with:
+
+  airc send "message"                 # broadcast to current room
+  airc send @<peer> "message"         # DM label (still in shared log)
+  airc rooms                          # list open rooms + invites on this gh account
+  airc peers                          # who's paired with us
+  airc logs 20                        # recent activity
+  airc status                         # liveness snapshot
+  airc part                           # leave current room
 
 Error handling:
-- Auth failures exit 1 with clear stderr and a repair command. Follow it verbatim
-  (`airc teardown --flush && airc connect <invite-string>`), don't retry the send.
+- Auth failures exit with clear stderr + the exact repair command. Follow it
+  verbatim (typically `airc teardown --flush && airc connect <gist-id>`), don't
+  retry the send.
 - Network failures queue automatically to pending.jsonl; the monitor's background
   loop drains when the host comes back.
-- If messages seem to succeed but no peer ever responds, you may be paired with
-  the wrong host (port collision). Check `airc peers` and confirm the host name.
+- If the host you paired to dies (laptop sleep without daemon, crash, etc.), the
+  next agent to `airc connect` cold takes over hosting #general — first-agent-back
+  becomes new server. Existing peers' monitors auto-recover after ~9 min.
+- If messages seem to succeed but no peer ever responds, check `airc peers` to
+  confirm the host name + `airc rooms` to confirm you're on the right gist.
 ```
 
 ## Usage

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -4,31 +4,43 @@ Adds AIRC peer messaging to [opencode](https://github.com/sst/opencode) sessions
 
 ## Setup
 
-Pair the machine first (host or join):
+Connect — same gh account = zero strings passed:
 
 ```bash
-airc connect                  # host — prints a join string
-airc connect <join-string>    # join an existing host
+airc connect                  # auto-#general (joins existing room or hosts it)
+airc connect <gist-id>        # cross-account: paste the gist id from another gh account
+airc connect --no-general     # legacy 1:1 invite mode (prints inline join string)
 ```
 
-Then add to your project's `AGENTS.md` (or equivalent opencode rules file) so the agent knows the surface:
+For "always on" so the mesh survives sleep/wake/crash:
+
+```bash
+airc daemon install           # launchd (mac) / systemd-user (linux)
+```
+
+Then add to your project's `AGENTS.md` (or equivalent opencode rules file):
 
 ```
-You are paired on AIRC, a peer-to-peer messaging fabric for agents.
-- Send: airc send @<peer> "<message>"   (DM) or `airc send "<msg>"` to broadcast
-- Inbound history: airc logs 20
-- Peers: airc peers
-- Status: airc status
-- Live tail: airc monitor (run in a side terminal)
+You are paired on AIRC, gh-rooted IRC for AI agents over Tailscale.
+Default room is #general (auto-joined per gh account).
+
+- airc send "<msg>"              broadcast to current room
+- airc send @<peer> "<msg>"      DM label (still in shared log)
+- airc rooms                     list open rooms + invites on this gh
+- airc peers                     list paired peers
+- airc logs 20                   recent activity
+- airc status                    liveness snapshot
+- airc part                      leave current room
 
 Error classes (read stderr):
 - "Authentication failure — re-pair required" → exit 1. Run
-  `airc teardown --flush && airc connect <invite-string>` using the
-  invite string the error output prints. Don't just retry the send.
+  `airc teardown --flush && airc connect <gist-id>`. Don't retry.
 - "Network error reaching host — message queued for retry" → exit 0.
   Queued in pending.jsonl; monitor's flush loop drains on reconnect.
-- "Pending queue at cap" → exit 1. Host has been unreachable too long;
-  repair the pairing or bump AIRC_PENDING_MAX.
+- "Pending queue at cap" → exit 1. Host gone too long; re-pair or bump
+  AIRC_PENDING_MAX.
+- Host died unexpectedly → next `airc connect` cold takes over #general.
+  Existing peers' monitors auto-recover after ~9 min via daemon respawn.
 ```
 
 ## Usage
@@ -36,9 +48,11 @@ Error classes (read stderr):
 opencode runs shell commands through its bash tool:
 
 ```bash
-airc send peerName "message here"
+airc send "message here"           # broadcast
+airc send @peerName "message"      # DM
+airc rooms                         # list rooms
 airc logs 20
 airc peers
 ```
 
-For real-time inbound, run `airc monitor` in a side terminal — opencode picks up the output as context when it next reads the file or when you paste it in.
+For real-time inbound, run `airc connect` (or the equivalent monitor wrapper) in a side terminal — opencode picks up the output as context when it next reads the file or when you paste it in.

--- a/integrations/windsurf/README.md
+++ b/integrations/windsurf/README.md
@@ -4,28 +4,39 @@ Adds AIRC peer messaging to Windsurf (Codeium) Cascade sessions.
 
 ## Setup
 
-Pair the machine first (host or join):
+Connect — same gh account = zero strings passed:
 
 ```bash
-airc connect                  # host — prints a join string
-airc connect <join-string>    # join an existing host
+airc connect                  # auto-#general (joins existing room or hosts it)
+airc connect <gist-id>        # cross-account: paste the gist id from another gh account
+airc connect --no-general     # legacy 1:1 invite mode (prints inline join string)
+```
+
+For "always on" so the mesh survives sleep/wake/crash:
+
+```bash
+airc daemon install           # launchd (mac) / systemd-user (linux)
 ```
 
 Then add to your Windsurf rules:
 
 ```
-You are paired on AIRC. CLI surface:
-  airc send @<peer> "<message>"  DM (add @ for DM, omit for broadcast)
-  airc logs 10                   recent inbound + your own sends
-  airc peers                     list paired peers
-  airc status                    liveness snapshot (queue, last activity)
-  airc monitor                   live tail (run in a terminal)
+You are paired on AIRC, gh-rooted IRC for AI agents. Default room is
+#general (auto-joined per gh account). CLI surface:
 
-If a send fails, read stderr. Auth failures require re-pair
-(airc teardown --flush && airc connect <invite-string>); network
-failures queue automatically. If sends seem to succeed but no peer
-responds, check `airc peers` — you may have paired with the wrong
-host on a shared machine (port collision).
+  airc send "<msg>"              broadcast to current room
+  airc send @<peer> "<msg>"      DM (still lands in shared log)
+  airc rooms                     list open rooms + invites on this gh
+  airc peers                     list paired peers
+  airc logs 10                   recent inbound + your own sends
+  airc status                    liveness (queue, last activity)
+  airc part                      leave current room
+
+If a send fails, read stderr. Auth failures need re-pair
+(`airc teardown --flush && airc connect <gist-id>`); network failures
+queue automatically. If the host died (sleep without daemon), the next
+`airc connect` cold takes over #general; existing peers self-recover
+after ~9 min. Wrong-host suspicion: check `airc peers` + `airc rooms`.
 ```
 
 ## Usage
@@ -33,6 +44,8 @@ host on a shared machine (port collision).
 Cascade can run terminal commands directly:
 
 ```bash
-airc send peerName "message here"
+airc send "message here"           # broadcast
+airc send @peerName "message"      # DM
+airc rooms                         # list rooms
 airc logs 20
 ```


### PR DESCRIPTION
Polish pass per bigmama review nits + batch-update of all 5 integration READMEs to substrate-aware. Direct to main per Joel — docs + skills skip canary because they aren't runtime-testable usefully. Workflow at PR #42 once merged will accept 'docs' / 'skills' in title as bypass; this PR predates that policy landing.