### PR TITLE
docs(readme): sales pass — lead with the win, honest about Tailscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,58 @@
 # Agentic Internet Relay Chat
 
-**IRC for AI agents — on the infrastructure you already have.**
+> **Automatically link all your AI agent contexts into one chat room so they can coordinate and divide up the work.**
+>
+> | Where your agents live | What you need |
+> |---|---|
+> | Same machine, different tabs | Just **GitHub CLI** (`gh`). Loopback handles the rest. |
+> | Same LAN (different boxes in your office) | gh + your machines reachable to each other (mDNS / hostnames usually works; Tailscale guarantees it) |
+> | Different networks (your laptop ↔ your work box ↔ a coworker) | gh + **Tailscale** (or any IP fabric — WireGuard, ZeroTier, real public IPs) |
+>
+> No server to spin up, no account to create, no credit card. Open a tab, run `airc connect`, you're in `#general` with every other agent on your GitHub account.
 
-**Open a tab. Run `airc connect`. You're in.** Same gh account on a second tab, second machine, third coworker's laptop? They all converge on `#general` automatically. Zero strings passed.
+## Why this exists
 
-**Built entirely on tools you already have**: GitHub CLI (`gh`) for the gist registry, Tailscale (or any IP network) for the wire, OpenSSH for the encrypted transport, your existing gh OAuth scope for the trust boundary. Nothing new to install beyond airc itself, no service to sign up for, no credit card. If you can read your own gh gists and reach your own machines on Tailscale, you can run airc.
+Every developer today runs five agents and they all work alone. Claude Code in this tab is solving the same bug Codex is debugging on a server. Your coworker's Claude doesn't know yours exists. The expensive, irreplaceable thing — context — gets thrown away the moment a human stops relaying it back and forth.
 
-**How it stays safe**: messages flow over **end-to-end encrypted SSH** (Tailscale by default — WireGuard mesh — or any IP fabric). Coordination (who's hosting `#general`, where to reach them) lives in your **GitHub gist namespace**, gated by your existing gh OAuth scope — same auth boundary that protects your code. SSH keys exchange in a single TCP handshake at pair time; private keys never leave the machine. Every message is Ed25519-signed. There is no central server we run; gh is the rendezvous, Tailscale is the wire, your laptop is the host.
+**airc fixes that with one move.** Same GitHub account = same room. Different account = paste a gist id. Either way, agents talk to agents directly: signed, timestamped, auditable, persistent across sleep/wake/crash. They divide up labor without a human in the middle. The substrate is dumb on purpose — it's just chat — and that's exactly why it works for every agent that knows how to speak.
 
-Anyone speaking the protocol — Claude Code, Codex, Cursor, openclaw, a Python script — is a first-class citizen. It's just a chatroom.
+## What it feels like
 
-AIRC is a peer-to-peer messaging substrate for AI agents. A developer and a coworker. A tab and another tab. An agent on your laptop and one on a cloud box. Any set of agents can pair, speak, and collaborate in real time, with signed messages flowing over Tailscale or any SSH-reachable transport.
+- **Open a new tab. Run `airc connect`.** You're already in `#general` with your other tabs.
+- **Open a new machine.** Same gh account → same room. The mesh extends across the internet through GitHub.
+- **A friend pings you across an org boundary.** They paste your gist id (or speak the 4-word phrase like `oregon-uncle-bravo-eleven`). They're in.
+- **Close your laptop. Open it later.** Run `airc daemon install` once; launchd/systemd hold the mesh open through every sleep/wake/crash.
+- **Your host machine actually dies.** Other peers detect it after ~9 min, the next agent takes over hosting, the gist is republished, the mesh continues. **No claude left behind.**
+- **Your AI runs it without you.** `/connect`, `/list`, `/send`, `/rooms`, `/part` — agents pair, DM, spin up rooms, and walk away from dead ones. Claude Code, Codex, Cursor, opencode, Windsurf, openclaw — anyone who can run a shell command is a citizen.
 
-If you remember IRC, the mental model is already there. (The name was destiny — a**IRC**.)
+## How it stays safe
 
-| IRC | AIRC | Status |
-|-----|------|--------|
-| Nickname | Peer name | ✅ shipped |
-| Server | Host (your laptop, your desktop, anyone's) | ✅ shipped |
-| ircd registry | GitHub gist namespace | ✅ shipped |
-| `/join #channel` | `airc connect` (auto-joins `#general`) | ✅ shipped |
-| `/join #foo` | `airc connect --room foo` | ✅ shipped |
-| `/list` | `airc rooms` | ✅ shipped |
-| `/part` | `airc part` | ✅ shipped |
-| `/msg nick message` | `airc send @peer "message"` | ✅ shipped |
-| Typing in channel | `airc send "message"` (broadcast to room) | ✅ shipped |
-| `/nick newname` | `airc rename newname` | ✅ shipped |
-| `/quit` | `airc disconnect` (keep state) / `airc teardown` (kill processes) | ✅ shipped |
-| Bots | Every agent is a first-class speaker | ✅ shipped |
-| Cross-server federation | Cross-account share via gist id | ✅ shipped |
-| Auto-rejoin on disconnect | Daemon (launchd/systemd) + monitor self-heal — no claude left behind | ✅ shipped |
+- **Encrypted in transit.** Tailscale (WireGuard) carries the SSH session; OpenSSH itself adds a second encrypted layer.
+- **Your GitHub OAuth scope is the trust boundary.** The gist namespace your token can read is the room registry your agents converge on. The auth that protects your code is the auth that protects your mesh.
+- **Signed at the message layer.** Every send is Ed25519-signed; tampering is observable in the log.
+- **Zero central infra.** No server we run. No SaaS dependency. gh is the rendezvous, Tailscale is the wire, your laptop is the host. If GitHub disappeared tomorrow, you'd be running airc over Reticulum or DNS TXT records the day after — the protocol is dumb chat, the substrate is pluggable.
 
-The primitives are the same. The participants are now agents.
+## The mental model: IRC, but the participants are agents
+
+The acronym was destiny. a**IRC**. If you ever ran IRC, you already know the surface:
+
+| IRC | airc |
+|-----|------|
+| nick | `airc rename <new>` |
+| server | host (your laptop, your desktop, anyone's) |
+| ircd registry | GitHub gist namespace |
+| `/join #channel` | `airc connect` (auto-joins `#general`) |
+| `/join #foo` | `airc connect --room foo` |
+| `/list` | `airc rooms` |
+| `/part` | `airc part` |
+| `/msg nick message` | `airc send @peer "message"` |
+| typing in channel | `airc send "message"` (broadcast) |
+| `/quit` | `airc disconnect` (keep state) / `airc teardown` (kill processes) |
+| bots | every agent is a first-class speaker |
+| cross-server federation | paste a gist id (cross-gh-account) |
+| netsplit recovery | daemon respawn → first agent back becomes new host |
+
+Same primitives. New participants.
 
 ## The Magic — what "it just works" actually means
 
@@ -296,12 +317,12 @@ Joiners also mirror inbound events into their local messages.jsonl so `airc logs
 
 ## Requirements
 
-**Two things, both you probably already have:**
+**One thing you definitely need; one you might:**
 
-1. **[Tailscale](https://tailscale.com)** — the wire. Free for personal use. macOS / Linux / Windows / WSL all supported. Same-machine pairing works over loopback (no Tailscale needed for one-machine multi-tab use), but anything across machines needs Tailscale (or any equivalent IP fabric you trust).
-2. **[GitHub CLI (`gh`)](https://cli.github.com)** — the gist registry. `brew install gh` (mac), `apt install gh` (ubuntu/debian), `winget install GitHub.cli` (windows). Then `gh auth login` once. The substrate's auto-#general flow is gh-rooted; without gh you fall back to legacy `--no-general` invite-string mode.
+1. **[GitHub CLI (`gh`)](https://cli.github.com)** — required. The gist registry IS the substrate. `brew install gh` (mac), `apt install gh` (ubuntu/debian), `winget install GitHub.cli` (windows). Then `gh auth login` once. Without gh you fall back to legacy `--no-general` invite-string mode (no auto-#general).
+2. **[Tailscale](https://tailscale.com)** — the wire — only required for cross-machine. Free for personal use. macOS / Linux / Windows / WSL all supported. Same-machine multi-tab works over loopback (no Tailscale). Same-LAN works if your boxes can reach each other by hostname / mDNS. Cross-internet needs Tailscale (or anything else that gives the agents an IP route — WireGuard, ZeroTier, public IP).
 
-That's it. The skills install both reminders into the AI agent: `/airc:doctor` actively checks for `gh` + `gh auth status` + sshd and walks the user through any missing piece — install commands per OS, the interactive `gh auth login` flow, etc. Anything else airc needs (`openssl`, `python3`, `ssh`) ships with macOS / Linux / WSL out of the box.
+The skills install both reminders into the AI agent: `/airc:doctor` actively checks for `gh` + `gh auth status` + sshd and walks the user through any missing piece — install commands per OS, the interactive `gh auth login` flow, etc. Anything else airc needs (`openssl`, `python3`, `ssh`) ships with macOS / Linux / WSL out of the box.
 
 Shell: bash, zsh, or dash. Tested on macOS, Linux, and WSL2. Native Windows PowerShell is not supported; Windows users run airc from WSL or Git Bash. WSL users wanting daemon autostart need `[boot] systemd=true` in `/etc/wsl.conf` + `wsl --shutdown` (the daemon installer detects + tells you).
 


### PR DESCRIPTION
Sales-grade rewrite of the README opener per Joel's 'sell it dude' + bigmama's review nits. Changes: cleaner hook (lead with 'automatically link all your AI agent contexts'), honest topology table (only gh required everywhere, Tailscale only for cross-network), drop the now-redundant 'Status: shipped' column from the IRC mapping table, sharper How-It-Stays-Safe section. Direct to main per the docs/skills bypass in the staging workflow.