### PR TITLE
feat(get_host): LAN-IP fallback so Tailscale becomes optional for same-LAN

### DIFF
--- a/airc
+++ b/airc
@@ -87,17 +87,64 @@ get_config_val() {
 }
 
 get_host() {
-  # Prefer Tailscale IP, fall back to hostname
+  # Address-resolution priority for the host endpoint baked into the room
+  # gist (and inline join strings):
+  #   1. Tailscale IP (100.x.y.z) — works internet-wide for tailnet members
+  #   2. LAN IP (192.168.*, 10.*, 172.16-31.*) — works for same-LAN peers
+  #      with no Tailscale required. This is the path Joel wanted: same
+  #      office, no Tailscale, gh + LAN-routable host = mesh works.
+  #   3. hostname — last-resort, only resolves cross-machine when mDNS
+  #      (.local) or DNS happens to know the name.
+  # AIRC_NO_TAILSCALE=1 forces the LAN/hostname fallback even when
+  # Tailscale is installed. Useful for testing the fallback path AND
+  # for users who want to bind the room to a LAN IP for same-LAN
+  # coordination without dragging guests into their tailnet.
   local ts_bin=""
-  if command -v tailscale >/dev/null 2>&1; then
-    ts_bin="tailscale"
-  elif [ -x "/Applications/Tailscale.app/Contents/MacOS/Tailscale" ]; then
-    ts_bin="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+  if [ "${AIRC_NO_TAILSCALE:-0}" != "1" ]; then
+    if command -v tailscale >/dev/null 2>&1; then
+      ts_bin="tailscale"
+    elif [ -x "/Applications/Tailscale.app/Contents/MacOS/Tailscale" ]; then
+      ts_bin="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+    fi
   fi
   if [ -n "$ts_bin" ]; then
     local ts_ip; ts_ip=$("$ts_bin" ip -4 2>/dev/null || true)
     [ -n "$ts_ip" ] && echo "$ts_ip" && return
   fi
+
+  # LAN IP via UDP-socket trick: open a UDP socket toward a public IP
+  # (no actual packet sent — UDP connect just chooses the route), then
+  # ask getsockname() which interface IP would be used. Works on macOS,
+  # Linux, WSL2 without parsing platform-specific ifconfig/ip output.
+  # Returns one of 192.168.*, 10.*, 172.16-31.* on a typical home/office
+  # LAN. Returns 127.0.0.1 if no internet route is available — which we
+  # treat as "no LAN" and fall through to hostname.
+  if command -v python3 >/dev/null 2>&1; then
+    local lan_ip
+    lan_ip=$(python3 -c "
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+try:
+    s.settimeout(0.5)
+    s.connect(('8.8.8.8', 80))
+    ip = s.getsockname()[0]
+    # Only emit if it looks like a routable LAN address. 127.0.0.1 means
+    # no default route; we want hostname fallback in that case.
+    if ip and not ip.startswith('127.'):
+        print(ip)
+except Exception:
+    pass
+finally:
+    s.close()
+" 2>/dev/null)
+    if [ -n "$lan_ip" ]; then
+      # Sanity: must look like an IPv4 address (skip exotic surprises).
+      case "$lan_ip" in
+        [0-9]*.[0-9]*.[0-9]*.[0-9]*) echo "$lan_ip" && return ;;
+      esac
+    fi
+  fi
+
   hostname
 }
 
@@ -2867,6 +2914,7 @@ case "${1:-help}" in
   monitor)   shift; monitor "$@" ;;
   debug-scope) echo "$AIRC_WRITE_DIR" ;;
   debug-name)  resolve_name ;;
+  debug-host)  get_host ;;
   help|--help|-h)
     echo "AIRC — Agentic Internet Relay Chat for AI peers"
     echo ""

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -922,6 +922,60 @@ scenario_room() {
   cleanup_all
 }
 
+# ── Scenario: get_host (LAN IP fallback when Tailscale absent/disabled) ─
+# Per Joel: Tailscale should be optional for same-LAN use. The new
+# get_host priority is Tailscale → LAN-IP-via-UDP-trick → hostname.
+# AIRC_NO_TAILSCALE=1 forces fallback for testing AND for LAN-only users.
+#
+# What we verify (no gh, no SSH — pure host-resolution test):
+#   - Default returns SOMETHING non-empty (could be tailscale ip, lan ip,
+#     or hostname depending on the machine the test runs on)
+#   - AIRC_NO_TAILSCALE=1 doesn't error and returns SOMETHING non-empty
+#     (LAN ip on most machines; hostname if no internet route)
+#   - When forced fallback returns an IP-shaped value, it's a valid
+#     RFC1918 LAN range (192.168/10/172.16-31) — i.e. routable on the
+#     local network, not the loopback noise we explicitly filter for
+scenario_get_host() {
+  section "get_host: priority Tailscale → LAN-IP → hostname"
+
+  local default_host
+  default_host=$("$AIRC" debug-host 2>/dev/null || echo "")
+  [ -n "$default_host" ] \
+    && pass "default get_host returned non-empty: $default_host" \
+    || fail "default get_host returned empty"
+
+  local fallback_host
+  fallback_host=$(AIRC_NO_TAILSCALE=1 "$AIRC" debug-host 2>/dev/null || echo "")
+  [ -n "$fallback_host" ] \
+    && pass "AIRC_NO_TAILSCALE=1 fallback returned non-empty: $fallback_host" \
+    || fail "AIRC_NO_TAILSCALE=1 fallback returned empty"
+
+  # If fallback looks like an IPv4 address, it must NOT be 127.* (we
+  # explicitly filter loopback in get_host) and SHOULD be RFC1918 if
+  # the test runner has typical home/office LAN routing.
+  case "$fallback_host" in
+    127.*)
+      fail "fallback returned loopback ($fallback_host) — get_host's UDP-trick filter regressed"
+      ;;
+    192.168.*|10.*|172.16.*|172.17.*|172.18.*|172.19.*|172.2[0-9].*|172.3[01].*)
+      pass "fallback is RFC1918 LAN address ($fallback_host) — UDP-trick worked"
+      ;;
+    [0-9]*.[0-9]*.[0-9]*.[0-9]*)
+      pass "fallback is an IPv4 ($fallback_host) — non-RFC1918 but routable"
+      ;;
+    *)
+      pass "fallback returned hostname-style value ($fallback_host) — UDP-trick path skipped (no internet route or no python3)"
+      ;;
+  esac
+
+  # Determinism: same env, same call → same value (no flapping).
+  local repeat
+  repeat=$(AIRC_NO_TAILSCALE=1 "$AIRC" debug-host 2>/dev/null || echo "")
+  [ "$repeat" = "$fallback_host" ] \
+    && pass "fallback is stable across repeated calls" \
+    || fail "fallback flapped: '$fallback_host' then '$repeat'"
+}
+
 case "$MODE" in
   tabs)         scenario_tabs  ;;
   scope)        scenario_scope ;;
@@ -934,8 +988,9 @@ case "$MODE" in
   auth_failure) scenario_auth_failure ;;
   resume_stale_auth) scenario_resume_stale_auth ;;
   room)         scenario_room ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|all]"; exit 2 ;;
+  get_host)     scenario_get_host ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_get_host ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|get_host|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
Per Joel: same-LAN coordination shouldn't need Tailscale. New priority Tailscale → LAN-IP-via-UDP-trick → hostname. AIRC_NO_TAILSCALE=1 env var forces fallback for testing + LAN-only users. New scenario_get_host (4 assertions). New airc debug-host subcommand. Empirically tested: 100.91.51.87 (tailscale) → 192.168.1.250 (LAN fallback) → stable. Closes README substrate-aware claim that same-LAN works without Tailscale.