### PR TITLE
feat(connect): mnemonic resolver — humanhash → gist id (same gh account)

### DIFF
--- a/airc
+++ b/airc
@@ -1014,6 +1014,44 @@ cmd_connect() {
     fi
   fi
 
+  # ── Mnemonic resolver (humanhash → gist id, same gh account) ─────
+  # Joel's UX target: a friend (or your own other tab) can type
+  #   airc connect oregon-uncle-bravo-eleven
+  # instead of pasting a 32-char hex gist id. Humanhash is one-way
+  # (XOR-fold of the gist id bytes), so we can't reverse it directly —
+  # but we CAN walk gh's gist list, hash each id, and pick the match.
+  #
+  # Detection: target looks like a hyphen-separated 3+ word phrase of
+  # lowercase alphabetic tokens (matches the humanhash dictionary
+  # convention — no digits, no underscores). Example acceptable form:
+  # `oregon-uncle-bravo-eleven`. Reject `2f6a907224f4...` (it's a hex id),
+  # `gist:abc123` (handled below), inline invites with `@`, etc.
+  #
+  # Scope: same-gh-account only (we list OUR own gists). Cross-account
+  # (Friend on a different gh) requires the `user/mnemonic` form which
+  # is roadmap. For now the friend pastes the gist id directly when
+  # accounts differ.
+  if [ -n "$target" ] && echo "$target" | grep -qE '^[a-z]+(-[a-z]+){2,}$'; then
+    if ! command -v gh >/dev/null 2>&1; then
+      die "Mnemonic '$target' lookup needs the 'gh' CLI. Install gh + 'gh auth login', or use the gist id directly: airc connect <id>"
+    fi
+    local _matched_gist_id=""
+    while IFS=$'\t' read -r _gid _; do
+      [ -z "$_gid" ] && continue
+      local _hh; _hh=$(humanhash "$_gid" 2>/dev/null)
+      if [ "$_hh" = "$target" ]; then
+        _matched_gist_id="$_gid"
+        break
+      fi
+    done < <(gh gist list --limit 50 2>/dev/null | awk -F'\t' '/airc room:|airc invite for/ { print $1 "\t" $2 }')
+    if [ -n "$_matched_gist_id" ]; then
+      echo "  Resolved mnemonic '$target' → gist $_matched_gist_id"
+      target="$_matched_gist_id"
+    else
+      die "Mnemonic '$target' didn't match any airc gist on this gh account. If your friend's gist is on a different gh, paste the gist id directly: airc connect <id>"
+    fi
+  fi
+
   # ── Gist transport (issue #37) ───────────────────────────────────
   # If the target doesn't look like an inline invite (no `@`), treat it
   # as a gist ID and fetch the real invite content from there. Three

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -976,6 +976,67 @@ scenario_get_host() {
     || fail "fallback flapped: '$fallback_host' then '$repeat'"
 }
 
+# ── Scenario: mnemonic (humanhash → gist id resolver) ──────────────────
+# Per Joel's UX target: a friend can type
+#   airc connect oregon-uncle-bravo-eleven
+# instead of a 32-char hex gist id. Same-account resolution = walk
+# `gh gist list`, hash each id, match against the input phrase.
+#
+# This scenario runs as a unit-style test (no host/joiner spawning):
+#   - Word-form input is detected (regex match)
+#   - Hex-form input is NOT misclassified
+#   - Without gh OR with no matching gist, fails LOUD with actionable error
+#
+# We don't depend on a real gh account here — instead we exercise the
+# detection regex by capturing airc's stderr/exit-code on a known-bad
+# mnemonic. The actual gh resolution path is exercised in dogfood (the
+# `Peer joined` event from the live host monitor when a test process
+# resolves the room mnemonic against the real gh account).
+scenario_mnemonic() {
+  section "mnemonic: humanhash → gist id resolver detection + error path"
+
+  # 1. Word-form (3+ hyphens, lowercase alpha) triggers the resolver.
+  #    Without gh, dies with mnemonic-needs-gh message.
+  #    With gh + no match, dies with no-match message.
+  # We run airc connect with the test bogus mnemonic in an isolated
+  # AIRC_HOME so we don't touch the user's real state.
+  local thome=/tmp/airc-it-mnem-$$
+  mkdir -p "$thome"
+
+  local out
+  out=$(AIRC_HOME="$thome" AIRC_NO_DISCOVERY=1 "$AIRC" connect zzzz-yyyy-xxxx-wwww 2>&1 || true)
+
+  # If gh is on PATH, expect the no-match error. If gh is missing,
+  # expect the install-gh error. Either way: must mention 'mnemonic'
+  # and exit non-zero.
+  if echo "$out" | grep -qi 'mnemonic'; then
+    pass "word-form input detected as mnemonic + dispatched to resolver"
+  else
+    fail "word-form input did NOT route through mnemonic resolver: $out"
+  fi
+
+  # 2. Hex-form input must NOT be misclassified. We don't actually pair —
+  # just check that the mnemonic resolver doesn't fire (the gist resolver
+  # downstream will fire instead, and either succeed or fail differently).
+  out=$(AIRC_HOME="$thome" AIRC_NO_DISCOVERY=1 "$AIRC" connect 2f6a907224f4b88d236fda8ca16d37c4 2>&1 || true)
+  if ! echo "$out" | grep -qi "didn't match any airc gist on this gh account"; then
+    pass "hex-form input not misclassified as mnemonic"
+  else
+    fail "hex-form input incorrectly routed through mnemonic resolver: $out"
+  fi
+
+  # 3. A 1-hyphen string (looks like a CLI flag value, not a mnemonic)
+  # should NOT trigger the resolver. The regex requires 2+ hyphens.
+  out=$(AIRC_HOME="$thome" AIRC_NO_DISCOVERY=1 "$AIRC" connect foo-bar 2>&1 || true)
+  if ! echo "$out" | grep -qi "didn't match any airc gist"; then
+    pass "1-hyphen string ('foo-bar') not misclassified as mnemonic"
+  else
+    fail "1-hyphen string incorrectly routed through mnemonic resolver: $out"
+  fi
+
+  rm -rf "$thome"
+}
+
 case "$MODE" in
   tabs)         scenario_tabs  ;;
   scope)        scenario_scope ;;


### PR DESCRIPTION
Per Joel: friends should be able to type 'airc connect oregon-uncle-bravo-eleven' instead of a 32-char hex id. Implementation: detect word-form input (3+ hyphen-separated lowercase alpha tokens), walk gh gist list, match humanhash, route to existing gist resolver. Same-account only (cross-account user/mnemonic form is roadmap). New scenario_mnemonic with 3 assertions. Empirically validated: live monitor saw Peer joined event when test resolved against real gist.