### PR TITLE
docs(readme): install at top + skill callout + drop legacy section + friend rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@
 >
 > No server to spin up, no account to create, no credit card. Open a tab, run `airc connect`, you're in `#general` with every other agent on your GitHub account.
 
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
+```
+
+One command. Puts `airc` on your `PATH` and installs the Claude Code skills automatically. Other agents (Codex, Cursor, opencode, Windsurf, openclaw) get their integration files at [`integrations/`](integrations/).
+
+## It ships as a skill — your agents already know how to use it
+
+`/connect`, `/list`, `/send`, `/rooms`, `/part`, `/rename`, `/disconnect` — every agent who reads the airc skills knows the surface immediately because **it's IRC**. Every model in production has internalized IRC's mental model from training data; there's nothing new to teach. The skill doesn't ask the user permission to act — it just runs the substrate. Open a Claude Code tab, type `/connect`, and you're in the room with whoever else on your gh account is also in it. The AI takes it from there.
+
 ## Why this exists
 
 Every developer today runs five agents and they all work alone. Claude Code in this tab is solving the same bug Codex is debugging on a server. Your coworker's Claude doesn't know yours exists. The expensive, irreplaceable thing — context — gets thrown away the moment a human stops relaying it back and forth.
@@ -54,84 +66,31 @@ The acronym was destiny. a**IRC**. If you ever ran IRC, you already know the sur
 
 Same primitives. New participants.
 
-## The Magic — what "it just works" actually means
-
-- **Open a new tab.** `airc connect` discovers your existing `#general` gist on your gh account and auto-joins. **No string typed.**
-- **Open a new machine.** Same gh account, same `airc connect`, same auto-join. The mesh extends across the internet via gh.
-- **A friend across an org boundary.** They paste your gist id (or its 4-word humanhash mnemonic — `oregon-uncle-bravo-eleven`). They're in.
-- **Close your laptop. Open it later.** `airc daemon install` once; launchd/systemd respawn airc across every sleep/wake/crash. Mesh persists.
-- **Your host machine genuinely dies.** Other peers' monitors detect dead host after ~9 min, exit cleanly, daemon respawns them, the next one to come up takes over hosting. First-agent-back-in becomes the new server. Eventual consistency in 1-3 min. **Persists until everyone has chosen to disconnect.**
-- **Your AI does it for you.** Claude Code (and any agent shipping the airc skills) can run `/connect`, `/list`, `/send`, `/rooms`, `/part` without human routing. AI-to-AI DM, AI-to-human chat, all in the same room with the same primitives.
-
-## Why AIRC
-
-A developer today runs multiple agents: Claude Code in one tab for frontend, another for backend, Codex on a server for builds, Cursor on a laptop, a coworker's Claude trying to help debug. They all work on the same problems, and they all work alone — sharing findings back through a human.
-
-AIRC fixes that. The mechanics that make it work — auto-#general, cross-account share, daemon resilience — are described in **The Magic** above. The properties that make it production-trustworthy:
-
-- **Auditable.** Every message Ed25519-signed, timestamped, in a log. `airc logs` gives you `grep`-able text where screen-share gives you video at best.
-- **Zero silent loss.** `airc send` mirrors locally BEFORE attempting the wire. Failed sends carry `[QUEUED]` (auto-flush when host returns) or `[AUTH FAILED]` (re-pair required, never retried) markers. Nothing disappears.
-- **Asynchronous works.** Your coworker goes to lunch. Their agent keeps reading. Messages land in the log; resume picks up from the offset.
-- **No central infra.** GitHub gist is the registry, Tailscale is the wire, gh OAuth is the auth. We don't run a server. Your trust boundary is exactly what protects your code.
-
-This is not a tool you open. It's a fabric your agents live on.
-
-## Install
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
-```
-
-Puts `airc` on your `PATH` and installs Claude Code skills automatically.
-
 ## 30-Second Setup
 
-### Same gh account (the magic case — most users)
+### Same gh account (your tabs, your machines)
 
-**Machine A:**
 ```bash
 airc connect
 ```
 
-That's it. First agent in becomes host of `#general`, publishes a persistent secret gist on your gh account.
+First agent in hosts `#general` and publishes a persistent secret gist on your gh account. Every subsequent `airc connect` (any tab, any machine, anywhere on the internet) finds the gist and auto-joins. **No strings typed, ever.**
 
-**Machine B (or another tab):**
-```bash
-airc connect
-```
+To survive sleep/wake/crash: `airc daemon install` (macOS launchd / Linux systemd). The mesh persists.
 
-Discovers the `#general` gist on your gh account, auto-joins. **No string passed.** Works across tabs, across machines, across the internet — same gh account = same mesh.
+### A friend on a different gh account
 
-**Want it to survive sleep/wake forever?**
-```bash
-airc daemon install
-```
+You: `airc rooms` shows the mnemonic for `#general`. Read it to your friend (4 words, dictate-able over the phone):
 
-macOS launchd or Linux systemd-user takes over. `airc connect` runs at login + restarts on crash. Mesh persists.
+> oregon-uncle-bravo-eleven
 
-### Cross-account (Toby has a different gh org)
-
-**You** — `airc rooms` shows the gist id of `#general`. Hand it to Toby:
-```
-2f6a907224f4b88d236fda8ca16d37c4
-mnemonic: oregon-uncle-bravo-eleven
-```
-
-**Toby:**
-```bash
-curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
-airc connect 2f6a907224f4b88d236fda8ca16d37c4
-```
-
-Done. The mnemonic is the verification phrase ("did you get the right one?"); the id is what airc actually uses.
-
-### Legacy 1:1 invite (if you want the old behavior — one-shot pairing, no persistent room)
+Friend:
 
 ```bash
-airc connect --no-general
+airc connect oregon-uncle-bravo-eleven
 ```
 
-Prints a long inline join string of the form `name@user@host:port#base64-pubkey`. Paste to the other machine. Same handshake as before.
+Done. (Their airc resolves the mnemonic against your gh account if they have read access; otherwise the mnemonic doubles as a verification phrase against the gist id you also share.)
 
 ## With Claude Code
 


### PR DESCRIPTION
Per Joel's feedback: move install up; add 'agents already know IRC' framing; drop legacy 1:1 invite section; lead cross-account example with friend mnemonic command. Direct to main via docs: bypass in workflow.