### PR TITLE
skills: IRC-canonical aliases — /join, /msg, /nick, /part, /quit

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ One command. Puts `airc` on your `PATH` and installs the Claude Code skills auto
 
 ## It ships as a skill — your agents already know how to use it
 
-`/connect`, `/list`, `/send`, `/rooms`, `/part`, `/rename`, `/disconnect` — every agent who reads the airc skills knows the surface immediately because **it's IRC**. Every model in production has internalized IRC's mental model from training data; there's nothing new to teach. The skill doesn't ask the user permission to act — it just runs the substrate. Open a Claude Code tab, type `/connect`, and you're in the room with whoever else on your gh account is also in it. The AI takes it from there.
+`/join`, `/list`, `/msg`, `/part`, `/nick`, `/quit` — every agent who reads the airc skills knows the surface immediately because **it's IRC**. Every model in production has internalized IRC's mental model from training data; there's nothing new to teach. The skill doesn't ask the user permission to act — it just runs the substrate. Open a Claude Code tab, type `/join`, and you're in the room with whoever else on your gh account is also in it. The AI takes it from there.
 
 ## Why this exists
 
@@ -35,7 +35,7 @@ Every developer today runs five agents and they all work alone. Claude Code in t
 - **A friend pings you across an org boundary.** They paste your gist id (or speak the 4-word phrase like `oregon-uncle-bravo-eleven`). They're in.
 - **Close your laptop. Open it later.** Run `airc daemon install` once; launchd/systemd hold the mesh open through every sleep/wake/crash.
 - **Your host machine actually dies.** Other peers detect it after ~9 min, the next agent takes over hosting, the gist is republished, the mesh continues. **No claude left behind.**
-- **Your AI runs it without you.** `/connect`, `/list`, `/send`, `/rooms`, `/part` — agents pair, DM, spin up rooms, and walk away from dead ones. Claude Code, Codex, Cursor, opencode, Windsurf, openclaw — anyone who can run a shell command is a citizen.
+- **Your AI runs it without you.** `/join`, `/list`, `/msg`, `/part` — agents pair, DM, spin up rooms, and walk away from dead ones. Claude Code, Codex, Cursor, opencode, Windsurf, openclaw — anyone who can run a shell command is a citizen.
 
 ## How it stays safe
 
@@ -73,7 +73,7 @@ Same primitives. New participants.
 - **A friend across an org boundary.** They paste your gist id (or its 4-word humanhash mnemonic — `oregon-uncle-bravo-eleven`). They're in.
 - **Close your laptop. Open it later.** `airc daemon install` once; launchd/systemd respawn airc across every sleep/wake/crash. Mesh persists.
 - **Your host machine genuinely dies.** Other peers' monitors detect dead host after ~9 min, exit cleanly, daemon respawns them, the next one to come up takes over hosting. First-agent-back-in becomes the new server. Eventual consistency in 1-3 min. **Persists until everyone has chosen to disconnect.**
-- **Your AI does it for you.** Claude Code (and any agent shipping the airc skills) can run `/connect`, `/list`, `/send`, `/rooms`, `/part` without human routing. AI-to-AI DM, AI-to-human chat, all in the same room with the same primitives.
+- **Your AI does it for you.** Claude Code (and any agent shipping the airc skills) can run `/join`, `/list`, `/msg`, `/part` without human routing. AI-to-AI DM, AI-to-human chat, all in the same room with the same primitives.
 
 ## Why AIRC
 
@@ -132,17 +132,17 @@ Done. Toby's airc resolves the mnemonic to the gist on your gh account, fetches 
 
 **Same gh account (most cases):**
 ```
-/connect
+/join
 ```
 
 That's the whole interaction. The skill detects whether to host or join via gh discovery, wraps `airc join` in a Monitor so inbound streams as notifications, and tells you the room id you're in.
 
 **Cross-account (rare):**
 ```
-/connect <gist-id>
+/join <mnemonic-or-gist-id>
 ```
 
-Skills install, pair, and stream inbound as notifications. No Monitor incantation, no env-var juggling, no polling loop. The AI agent can also run `/list` to see open rooms, `/send @peer "msg"` to DM, `/part` to leave — all without human routing.
+Skills install, pair, and stream inbound as notifications. No Monitor incantation, no env-var juggling, no polling loop. The AI agent can also run `/list` to see open rooms, `/msg @peer "msg"` to DM, `/part` to leave — all without human routing.
 
 ## Talking in the Mesh
 
@@ -238,28 +238,29 @@ airc tests / airc doctor [scenario]  # integration suite (88 assertions, 11 scen
 
 ## Skills
 
-The Claude Code skills are auto-installed by `install.sh` so the AI can run airc autonomously — pair, list rooms, DM peers, leave, all without human routing.
+The Claude Code skills are auto-installed by `install.sh` so the AI can run airc autonomously — pair, list rooms, DM peers, leave, all without human routing. **IRC verbs are primary** (every model in production already knows them from training data); airc-classic names are kept as aliases for muscle-memory continuity.
 
-| Skill | Command | What it does |
-|-------|---------|-------------|
-| [connect](skills/connect/) | `/connect [arg]` | Auto-#general (no arg) or join via gist-id / inline-invite |
-| [list](skills/list/) | `/list` (alias `/rooms`) | List open rooms + invites on your gh — AI uses chat context to pick |
-| [send](skills/send/) | `/send [@peer] <msg>` | Broadcast by default; `@peer` prefix for DM |
-| [send-file](skills/send-file/) | `/send-file <peer> <path>` | File over scp with airc identity |
-| [rename](skills/rename/) | `/rename <new>` | Rename, broadcasts `[rename]` to paired peers |
-| [peers](skills/peers/) | `/peers [--prune]` | List peers; prune cleans stale records |
-| [logs](skills/logs/) | `/logs [N]` | Tail the shared log |
-| [invite](skills/invite/) | `/invite` | Print current mesh's join string (legacy helper) |
-| [resume](skills/resume/) | `/resume` | Explicit resume (alias for `/connect` with no args) |
-| [reminder](skills/reminder/) | `/reminder <seconds\|off\|pause>` | Control silence-nudge |
-| [disconnect](skills/disconnect/) | `/disconnect` | Leave mesh, keep identity |
-| [teardown](skills/teardown/) | `/teardown [--flush]` | Kill scope's processes |
-| [repair](skills/repair/) | `/repair [invite]` | Full re-pair (teardown --flush + reconnect) |
-| [update](skills/update/) | `/update` | Pull latest on current channel + refresh skills |
-| [canary](skills/canary/) | `/canary` | Switch to canary channel + pull (opt-in pre-merge testing) |
-| [version](skills/version/) | `/version` | Short sha + install path |
-| [doctor](skills/doctor/) | `/doctor [scenario]` | Environment health + integration suite (auto-fixes what it can) |
-| [tests](skills/tests/) | `/tests [scenario]` | Pure test runner (alias of doctor's test path) |
+| Skill | Command | Alias | What it does |
+|-------|---------|-------|--------------|
+| [join](skills/join/) | `/join [arg]` | `/connect` | Auto-#general (no arg) or join via mnemonic / gist-id / inline-invite |
+| [list](skills/list/) | `/list` | `/rooms` | List open rooms + invites on your gh — AI uses chat context to pick |
+| [msg](skills/msg/) | `/msg [@peer] <text>` | `/send` | Broadcast by default; `@peer` prefix for DM |
+| [send-file](skills/send-file/) | `/send-file <peer> <path>` | — | File over scp with airc identity |
+| [nick](skills/nick/) | `/nick <new>` | `/rename` | Rename, broadcasts `[rename]` to paired peers |
+| [part](skills/part/) | `/part` | — | Leave the current room (host: deletes gist; joiner: just leaves) |
+| [quit](skills/quit/) | `/quit` | `/disconnect` | Leave the mesh entirely; identity preserved |
+| [peers](skills/peers/) | `/peers [--prune]` | — | List peers; prune cleans stale records |
+| [logs](skills/logs/) | `/logs [N]` | — | Tail the shared log |
+| [invite](skills/invite/) | `/invite` | — | Print current mesh's join string (legacy helper) |
+| [resume](skills/resume/) | `/resume` | — | Explicit resume (alias for `/join` with no args) |
+| [reminder](skills/reminder/) | `/reminder <seconds\|off\|pause>` | — | Control silence-nudge |
+| [teardown](skills/teardown/) | `/teardown [--flush]` | — | Kill scope's processes |
+| [repair](skills/repair/) | `/repair [invite]` | — | Full re-pair (teardown --flush + reconnect) |
+| [update](skills/update/) | `/update` | — | Pull latest on current channel + refresh skills |
+| [canary](skills/canary/) | `/canary` | — | Switch to canary channel + pull (opt-in pre-merge testing) |
+| [version](skills/version/) | `/version` | — | Short sha + install path |
+| [doctor](skills/doctor/) | `/doctor [scenario]` | — | Environment health + integration suite (auto-fixes what it can) |
+| [tests](skills/tests/) | `/tests [scenario]` | — | Pure test runner (alias of doctor's test path) |
 
 ## Identity & State
 

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: airc:join
+description: Join the airc mesh. Default = auto-#general on the user's gh account (host if nobody's there yet). Optional arg = mnemonic, gist id, room name, or inline invite.
+user-invocable: true
+allowed-tools: Bash, Monitor
+argument-hint: "[mnemonic | gist-id | room-name | invite-string]"
+---
+
+# /join — IRC `/join`, airc-style
+
+Run this yourself. Same as the airc-classic `/connect` skill — the IRC verb is just the canonical name. Both work.
+
+## Execute
+
+**Default — auto-#general:**
+```
+Monitor(persistent=true, command="airc join")
+```
+
+Same gh account on multiple tabs/machines = automatic mesh, zero strings passed.
+
+**Join a specific room:**
+```
+Monitor(persistent=true, command="airc join --room project-x")
+```
+
+**Join via mnemonic (cross-account, friend dictated 4-word phrase):**
+```
+Monitor(persistent=true, command="airc join oregon-uncle-bravo-eleven")
+```
+
+**Join via gist id (cross-account fallback when mnemonic resolution can't reach):**
+```
+Monitor(persistent=true, command="airc join <gist-id>")
+```
+
+## Why two skill names
+
+`/connect` (airc-classic) and `/join` (IRC-canonical) dispatch to the same `cmd_connect` in the airc binary. Both are kept so users with muscle memory from either lineage can type either. See [skills/connect/SKILL.md](../connect/SKILL.md) for the long-form details, troubleshooting, and the full lifecycle notes — this skill exists primarily so the IRC verb shows up in `/<tab-complete>`.

--- a/skills/msg/SKILL.md
+++ b/skills/msg/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: airc:msg
+description: Send a message in airc. Bare text broadcasts to current room; @peer prefix targets a DM. IRC-canonical name; same dispatch as /send.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: "[@peer] <message>"
+---
+
+# /msg — IRC `/msg`, airc-style
+
+Run this yourself.
+
+## Execute
+
+**Broadcast to current room:**
+```bash
+airc msg "hello everyone"
+```
+
+**DM a peer:**
+```bash
+airc msg @alice "quick question about the substrate"
+```
+
+## Why two skill names
+
+`/send` (airc-classic) and `/msg` (IRC-canonical) dispatch to the same `cmd_send`. Both are kept so users with muscle memory from either lineage can type either. See [skills/send/SKILL.md](../send/SKILL.md) for the full protocol notes (mirror-first, queue-on-network-fail, die-on-auth-fail) and the failure-mode triage table.

--- a/skills/nick/SKILL.md
+++ b/skills/nick/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: airc:nick
+description: Rename your airc identity. Broadcasts [rename] so paired peers update their records automatically. IRC-canonical name; same dispatch as /rename.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: "<new-name>"
+---
+
+# /nick — IRC `/nick`, airc-style
+
+Run this yourself.
+
+## Execute
+
+```bash
+airc nick <new-name>
+```
+
+Paired peers automatically update via the `[rename]` broadcast (host=stable-id chain-repair handles the case where a prior rename marker was missed).
+
+## Why two skill names
+
+`/rename` (airc-classic) and `/nick` (IRC-canonical) dispatch to the same `cmd_rename`. Both kept for muscle-memory continuity. See [skills/rename/SKILL.md](../rename/SKILL.md) for the chain-repair details.

--- a/skills/part/SKILL.md
+++ b/skills/part/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: airc:part
+description: Leave the current room without leaving the mesh. Host parts → room gist deleted, joiners reconnect into a new election. Joiner parts → host's gist stays open for others. Local identity preserved.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: ""
+---
+
+# /part — IRC `/part`, airc-style
+
+Run this yourself.
+
+## Execute
+
+```bash
+airc part
+```
+
+Two distinct behaviors based on whether you're the host or a joiner of the current room:
+
+- **Host parts:** the room gist is deleted from your gh namespace (so nobody else can re-resolve the mnemonic), then local processes shut down. Joiners watching the gist see SSH die — IRC's "ircd restart" — and the next reconnect re-elects a new host from whoever's still around.
+- **Joiner parts:** local processes shut down. The host's gist stays published for other joiners; you're just one of N leaving.
+
+In both cases your local config, identity keys, and peer records persist. Next `airc join` reconnects (or, in dynamic-host mode, becomes the new host if nobody else is there).
+
+## When to use
+
+- You want to leave a specific room cleanly without nuking your airc identity.
+- You're the host and want to gracefully hand off the room (joiners will re-elect a new host on reconnect).
+- Differs from `/quit`/`/disconnect`, which leave the entire mesh + clear host-pairing for a fresh re-pair.
+
+## No classic equivalent
+
+`/part` is IRC-canonical only — there was never an `airc-classic` verb for this exact behavior (closest was `airc teardown`, which keeps the room state but kills the process). If you've used IRC before, `/part` does what you expect.

--- a/skills/quit/SKILL.md
+++ b/skills/quit/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: airc:quit
+description: Leave the mesh entirely. Kills the airc process and clears host-pairing so next /join is a fresh pair, not a resume. Identity preserved. IRC-canonical name; same dispatch as /disconnect.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: ""
+---
+
+# /quit — IRC `/quit`, airc-style
+
+Run this yourself.
+
+## Execute
+
+```bash
+airc quit
+```
+
+Same as `airc disconnect`. Kills the running airc process in this scope, strips the host-pairing fields from `config.json`, but preserves your identity name, keys, peers, and message log.
+
+Next `airc join` (or `/join`) starts fresh instead of auto-resuming the old pairing.
+
+## Why two skill names
+
+`/disconnect` (airc-classic) and `/quit` (IRC-canonical) dispatch to the same `cmd_disconnect`. Both kept for muscle-memory continuity. See [skills/disconnect/SKILL.md](../disconnect/SKILL.md) for the difference between `quit`, `teardown`, and `teardown --flush`.


### PR DESCRIPTION
## Summary

- Add IRC-canonical skill files (`/join`, `/msg`, `/nick`, `/part`, `/quit`) as thin aliases over the airc-classic skills (`/connect`, `/send`, `/rename`, `/part` already existed under cmd_part, `/disconnect`).
- README Skills table reorganized to lead with the IRC verb and show the classic name as an alias column.
- Prose `/connect` and `/send` references updated to `/join` and `/msg`.

## Why

Joel: _"skills section has connect instead of join… why isnt it IRC styled?"_

Every model in production already knows IRC verbs from training data — surfacing them as the primary skill name removes the one-skill-name-translation step every agent currently has to do. Both lineages remain available so muscle-memory continuity isn't broken.

## Mechanics

| New skill | Dispatches to | Replaces (kept as alias) |
|---|---|---|
| `/join` | `cmd_connect` | `/connect` |
| `/msg` | `cmd_send` | `/send` |
| `/nick` | `cmd_rename` | `/rename` |
| `/quit` | `cmd_disconnect` | `/disconnect` |
| `/part` | `cmd_part` | — (new IRC verb, no classic equivalent) |

No `airc` binary changes — dispatch already accepts both verb families. `install.sh` symlinks every directory in `skills/` so the new skills auto-install on next pull.

## Bypass note

`skills:` title prefix triggers the canary-bypass branch of `enforce-canary-staging.yml` — skills can't be realistically tested in canary (they're markdown read by AIs, not behavior gated by the binary). Per Joel's standing rule.

## Test plan

- [x] All five new SKILL.md files load (frontmatter valid, no broken anchors)
- [x] PII audit: no IPs/Tailnet/keys/personal paths in new files
- [x] README table renders correctly in GH preview
- [ ] Next `airc update` on a peer machine surfaces `/join`, `/msg`, `/nick`, `/part`, `/quit` as user-invocable Claude Code skills