### PR TITLE
feat(monitor): event previews — pair-join, watchdog, nick format

### DIFF
--- a/airc
+++ b/airc
@@ -381,8 +381,16 @@ import sys, json, os, re, time, signal
 # there is no penalty when the channel is healthy.
 WATCHDOG_SEC = 180
 def _watchdog_exit(signum, frame):
-    sys.stderr.write(f"[airc:monitor] no inbound in {WATCHDOG_SEC}s — restarting\\n")
+    # Emit on stdout AS WELL as stderr so the line surfaces in the
+    # Monitor task notification stream (which only sees stdout). Without
+    # the stdout side, watchdog-triggered restarts are invisible — the
+    # Monitor task <summary> still shows whatever stale chat line was
+    # latest, telling humans/AIs nothing about the actual event.
+    msg = f"host went quiet ({WATCHDOG_SEC}s) — restarting"
+    sys.stderr.write(f"[airc:monitor] {msg}\\n")
     sys.stderr.flush()
+    sys.stdout.write(f"airc: {msg}\\n")
+    sys.stdout.flush()
     os._exit(2)
 signal.signal(signal.SIGALRM, _watchdog_exit)
 signal.alarm(WATCHDOG_SEC)
@@ -467,14 +475,14 @@ def handle_rename(msg, ts):
     old, new, host = m.group(1), m.group(2), m.group(3)
     # Primary path: name-keyed rename.
     if _rename_files(old, new):
-        print(f"[{ts}] airc: Peer renamed: {old} -> {new}", flush=True)
+        print(f"airc: nick: {old} → {new}", flush=True)
         return True
     # Fallback: peer file sits under a different (older) name due to a
     # previous chain break. Resolve via stable host field.
     if host:
         current = _find_peer_by_host(host)
         if current and current != new and _rename_files(current, new):
-            print(f"[{ts}] airc: Peer renamed (chain-repair via host): {current} -> {new}", flush=True)
+            print(f"airc: nick (chain-repair): {current} → {new}", flush=True)
             return True
     return False
 
@@ -1719,6 +1727,29 @@ conn.sendall((response + '\n').encode())
 conn.close()
 sock.close()
 print(f'  Peer joined: {jname}')
+# Surface the join as a system event in messages.jsonl so the monitor
+# formatter (and downstream Monitor task summaries on every paired peer)
+# render a one-liner like '[#general] airc: <peer> joined' instead of
+# silence. Without this, peer-joined is invisible to anyone reading
+# notifications — they only learn about the new peer when chat traffic
+# starts flowing. Joel 2026-04-24: 'preview of the message or the
+# connection or whatever happened, Anvil joined instead of generic'.
+import datetime
+try:
+    room_name_path = '$AIRC_WRITE_DIR/room_name'
+    room_name = open(room_name_path).read().strip() if os.path.isfile(room_name_path) else 'general'
+    event = {
+        'ts': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'from': 'airc',
+        'to': 'all',
+        'msg': f'{jname} joined #{room_name}',
+    }
+    with open('$MESSAGES', 'a') as f:
+        f.write(json.dumps(event) + '\n')
+except Exception:
+    # Don't fail the pair on event-emit error — pairing already
+    # succeeded by this point; the missing event line is cosmetic.
+    pass
 " 2>/dev/null || true
     done &
     PAIR_PID=$!

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -226,7 +226,11 @@ json.dump(c, open('$fake_home/state/config.json', 'w'))
                                                       || fail "rename failed"
 
   sleep 8
-  grep -q 'Peer renamed' /tmp/airc-it-j/out.log && pass "beta saw [rename] marker" \
+  # Joel 2026-04-24: rename print format changed from 'Peer renamed: <old> -> <new>'
+  # to 'nick: <old> → <new>' (IRC-canonical). Match the new format; old-format
+  # backward-compat is intentionally NOT kept since the wire protocol [rename]
+  # marker is what peers actually exchange — only the human-visible print changed.
+  grep -qE 'nick:.*alpha.*gamma|Peer renamed' /tmp/airc-it-j/out.log && pass "beta saw [rename] marker" \
                                                 || fail "beta did NOT see rename marker"
 
   as_home /tmp/airc-it-j peers 2>/dev/null | grep -q gamma && pass "beta peers shows gamma" \
@@ -922,6 +926,88 @@ scenario_room() {
   cleanup_all
 }
 
+# ── Scenario: events (Joel's monitor-preview ask) ──────────────────────
+# Joel 2026-04-24: "Anvil joined" instead of generic "monitor yada yada"
+# in Monitor task notifications. The preview comes from messages.jsonl
+# lines with from=airc; the formatter renders them as `[#room] airc:`.
+# Without lifecycle events flowing through the log, Monitor's <summary>
+# falls back to whatever stale chat line was latest — telling humans
+# nothing about what just happened.
+#
+# What we verify:
+#   - After successful pair, host's messages.jsonl contains a system
+#     event line with from=airc and msg matching '<peer> joined #<room>'
+#   - The line lands within a few seconds of pair (not stuck behind
+#     the formatter's own loop)
+scenario_events() {
+  section "events: pair-handshake emits 'beta joined #<room>' system event"
+  cleanup_all
+
+  local rname="test-events-$$"
+
+  mkdir -p /tmp/airc-it-h
+  ( cd /tmp/airc-it-h && AIRC_HOME=/tmp/airc-it-h/state AIRC_NAME=alpha AIRC_PORT=7549 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room "$rname" > /tmp/airc-it-h/out.log 2>&1 & )
+  local i
+  for i in 1 2 3 4 5; do
+    sleep 1
+    grep -q 'Hosting as' /tmp/airc-it-h/out.log 2>/dev/null && break
+  done
+  grep -q 'Hosting as' /tmp/airc-it-h/out.log \
+    && pass "alpha hosting (--room ${rname}, --no-gist)" \
+    || { fail "alpha host failed to start"; cleanup_all; return; }
+
+  local join; join=$(read_join_string /tmp/airc-it-h)
+  [ -n "$join" ] && pass "alpha join string captured" \
+                 || { fail "no join string in alpha log"; cleanup_all; return; }
+
+  spawn_joiner /tmp/airc-it-j beta "$join" \
+    && pass "beta joined alpha's room" \
+    || { fail "beta join failed"; cleanup_all; return; }
+
+  # Allow up to ~5s for the pair-accept python to finish writing the
+  # event line. The handshake itself completes in <1s; the event-emit
+  # is wrapped in try/except so any path that fails doesn't break the
+  # pair, which means we need to check what actually landed.
+  local seen=""
+  for i in 1 2 3 4 5; do
+    if [ -f /tmp/airc-it-h/state/messages.jsonl ] \
+       && grep -q '"from": *"airc"' /tmp/airc-it-h/state/messages.jsonl \
+       && grep -q "beta joined #${rname}" /tmp/airc-it-h/state/messages.jsonl; then
+      seen="yes"
+      break
+    fi
+    sleep 1
+  done
+  [ -n "$seen" ] \
+    && pass "host messages.jsonl contains 'beta joined #${rname}' event line" \
+    || fail "no 'beta joined' event line in host's messages.jsonl after 5s"
+
+  # The event must be JSON-parseable and have the structure the formatter
+  # expects (from=airc, to=all, msg + ts present). Otherwise it'll be
+  # silently skipped by the monitor formatter's json.loads guard.
+  if [ -n "$seen" ]; then
+    python3 -c "
+import json,sys
+ok=False
+for line in open('/tmp/airc-it-h/state/messages.jsonl'):
+    try:
+        m=json.loads(line)
+    except Exception:
+        continue
+    if m.get('from')=='airc' and 'beta joined' in m.get('msg',''):
+        if m.get('to')=='all' and m.get('ts'):
+            ok=True
+sys.exit(0 if ok else 1)
+" 2>/dev/null \
+      && pass "event has required fields (from=airc, to=all, ts, msg)" \
+      || fail "event line malformed — formatter will skip it"
+  fi
+
+  cleanup_all
+}
+
 # ── Scenario: get_host (LAN IP fallback when Tailscale absent/disabled) ─
 # Per Joel: Tailscale should be optional for same-LAN use. The new
 # get_host priority is Tailscale → LAN-IP-via-UDP-trick → hostname.
@@ -1049,9 +1135,10 @@ case "$MODE" in
   auth_failure) scenario_auth_failure ;;
   resume_stale_auth) scenario_resume_stale_auth ;;
   room)         scenario_room ;;
+  events)       scenario_events ;;
   get_host)     scenario_get_host ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_get_host ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|get_host|all]"; exit 2 ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary

Joel 2026-04-24: _\"Anvil joined instead of generic monitor yada yada which tells us nothing.\"_

Monitor task `<summary>` notifications fall back to whatever stale chat line was latest for non-chat events. Lifecycle events (peer joined, watchdog timeout) didn't flow through `messages.jsonl`, so the formatter never rendered them, so the summary extractor had no useful preview to surface.

## Three changes

### 1. Pair-accept loop emits a join event

After a successful pair, the host's pair-accept python now appends a system event to `messages.jsonl`:

```json
{\"from\":\"airc\",\"to\":\"all\",\"msg\":\"<peer> joined #<room>\",\"ts\":\"<UTC>\"}
```

The existing `from=airc` formatter branch renders it as:
```
[#general] airc: anvil joined #general
```

Which lands as the next Monitor `<summary>` text. Wrapped in try/except so an event-emit failure never breaks pairing (cosmetic; pairing already succeeded by the time we write it).

### 2. Watchdog timeout writes to stdout

Previously watchdog timeout only wrote to stderr — that doesn't reach the Monitor notification stream. Now it writes both:

- stderr: `[airc:monitor] host went quiet (180s) — restarting` (existing)
- stdout: `airc: host went quiet (180s) — restarting` (new — surfaces as `<summary>`)

### 3. Rename print format → IRC style

Old: `airc: Peer renamed: alpha -> gamma`
New: `airc: nick: alpha → gamma`

Wire-protocol `[rename]` marker unchanged — only the human-visible print on receivers changed. Chain-repair message similarly shortened to `airc: nick (chain-repair): <current> → <new>`.

## Test results

```
97 passed, 0 failed
```

That's 92 prior + 5 new assertions in `scenario_events`:
- alpha hosting (--room test-events-N, --no-gist)
- alpha join string captured
- beta joined alpha's room
- host messages.jsonl contains 'beta joined #<room>' event line
- event has required fields (from=airc, to=all, ts, msg)

Existing rename test's grep updated to match the new format.

## Staging

Per Joel's clear canary→main discipline (calls out PR #59 bypass as the wrong call): this lands on **canary**. Promote to main only after dogfood cycle (anvil + bigmama-wsl, both already on canary). No `skills:` title-prefix bypass — this is a binary change with real failure modes.

## Test plan

- [x] Integration suite green (97/97)
- [x] PII audit clean
- [x] Pair-accept event-emit wrapped to preserve pairing on event-emit failure
- [ ] Live dogfood: pair anvil ↔ a fresh test scope, observe `<summary>` shows `anvil joined #general` instead of stale chat line
- [ ] Live dogfood: trigger watchdog (kill SSH tail mid-session), observe `<summary>` shows `host went quiet — restarting`
- [ ] Live dogfood: rename a peer, observe other side's `<summary>` shows `nick: <old> → <new>`