### PR TITLE
fix(monitor): less noise — watchdog 180→600s + IRC-style one-liner formatter

### DIFF
--- a/airc
+++ b/airc
@@ -379,7 +379,18 @@ import sys, json, os, re, time, signal
 # a truly dead channel forces the formatter out and the reconnect loop
 # restarts the ssh. Normal chat traffic keeps resetting the alarm so
 # there is no penalty when the channel is healthy.
-WATCHDOG_SEC = 180
+#
+# Joel 2026-04-24: heartbeat is OFF by default (canary 95d9907), so
+# any idle channel WILL hit the watchdog if WATCHDOG_SEC is short.
+# At 180s, two genuinely-idle peers triggered restart-and-notification
+# every 3 minutes — pure noise that masked real events. 600s (10 min)
+# gives idle conversations breathing room without losing the dead-
+# channel detection (zombie connections still get caught within 10
+# minutes of going truly silent). Ratio: with reminder-interval=300s
+# and heartbeat OFF, the watchdog is now 2x the would-be heartbeat
+# cycle — large enough that any plausibly-alive channel still resets
+# it before firing.
+WATCHDOG_SEC = 600
 def _watchdog_exit(signum, frame):
     # Emit on stdout AS WELL as stderr so the line surfaces in the
     # Monitor task notification stream (which only sees stdout). Without
@@ -475,14 +486,14 @@ def handle_rename(msg, ts):
     old, new, host = m.group(1), m.group(2), m.group(3)
     # Primary path: name-keyed rename.
     if _rename_files(old, new):
-        print(f"airc: nick: {old} → {new}", flush=True)
+        print(f"airc: nick {old} → {new}", flush=True)
         return True
     # Fallback: peer file sits under a different (older) name due to a
     # previous chain break. Resolve via stable host field.
     if host:
         current = _find_peer_by_host(host)
         if current and current != new and _rename_files(current, new):
-            print(f"airc: nick (chain-repair): {current} → {new}", flush=True)
+            print(f"airc: nick (chain-repair) {current} → {new}", flush=True)
             return True
     return False
 
@@ -566,20 +577,27 @@ for line in sys.stdin:
         # cmd_ping picks PONG up by tailing messages.jsonl directly.
         # Suppress to keep the chat surface clean.
         continue
+    # Compact one-liner per event. Every line starts with `airc:` so
+    # the source is unambiguous when other Monitor tasks (continuum,
+    # tests, etc.) are also firing notifications. Long messages
+    # truncate to PREVIEW_LEN; full content stays in messages.jsonl
+    # for `airc logs` audit.
+    PREVIEW_LEN = 100
+    msg_preview = msg.replace("\\n", " ").strip()
+    if len(msg_preview) > PREVIEW_LEN:
+        msg_preview = msg_preview[:PREVIEW_LEN] + "…"
     if fr in ("airc", "sys"):
-        # System events (joins, parts, drain markers, auth failures) keep
-        # the airc-prefixed format — easy to scan past.
-        print(f"[#{room_name}] airc: {msg}", flush=True)
+        # System events (joins, parts, drain, auth, watchdog).
+        # Example:  airc: [#general] alice joined
+        print(f"airc: [#{room_name}] {msg_preview}", flush=True)
+    elif to and to not in ("all", ""):
+        # DM with addressed recipient.
+        # Example:  airc: [#general] bigmama → alice: quick question
+        print(f"airc: [#{room_name}] {fr} → {to}: {msg_preview}", flush=True)
     else:
-        # Real chat: compact IRC-feel format.
-        # Broadcast:  [#general] bigmama: hello everyone
-        # DM:         [#general] bigmama → alice: hey
-        # Joel 2026-04-24: "the goings on of our agents is fascinating
-        # to humans" — keep it readable, drop the verbose ISO timestamp.
-        if to and to not in ("all", ""):
-            print(f"[#{room_name}] {fr} → {to}: {msg}", flush=True)
-        else:
-            print(f"[#{room_name}] {fr}: {msg}", flush=True)
+        # Broadcast.
+        # Example:  airc: [#general] bigmama: hello everyone
+        print(f"airc: [#{room_name}] {fr}: {msg_preview}", flush=True)
 '
 }
 

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -13,7 +13,7 @@ Run this yourself — don't ask the user.
 ## Execute
 
 ```
-Monitor(persistent=true, command="airc join")
+Monitor(persistent=true, description="airc events", command="airc join")
 ```
 
 Wrap with the Monitor tool so inbound streams as Claude Code notifications. `airc join` with no args detects the stored pairing in this scope's config.json and restarts the monitor — no fresh handshake, no join string, no env vars.

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -230,7 +230,7 @@ json.dump(c, open('$fake_home/state/config.json', 'w'))
   # to 'nick: <old> → <new>' (IRC-canonical). Match the new format; old-format
   # backward-compat is intentionally NOT kept since the wire protocol [rename]
   # marker is what peers actually exchange — only the human-visible print changed.
-  grep -qE 'nick:.*alpha.*gamma|Peer renamed' /tmp/airc-it-j/out.log && pass "beta saw [rename] marker" \
+  grep -qE 'nick.*alpha.*gamma|Peer renamed' /tmp/airc-it-j/out.log && pass "beta saw [rename] marker" \
                                                 || fail "beta did NOT see rename marker"
 
   as_home /tmp/airc-it-j peers 2>/dev/null | grep -q gamma && pass "beta peers shows gamma" \


### PR DESCRIPTION
## Summary

Joel 2026-04-24 raised two related noise issues:

1. **Idle channels triggered watchdog restart every 180s** — \"host went quiet\" notification spam every 3 minutes during quiet periods.
2. **Per-event content was visually cluttered** — long messages produced multi-line notification bodies that were hard to scan.

Both are airc-side fixes. The orthogonal *\"Monitor `<summary>` headline should preview each event\"* issue is a **Claude Code framework limitation** (headline = static description, body = stdout) and is NOT addressed here. See `feedback_flag_framework_limits_upfront.md` — I should have flagged it on the first turn instead of building around it.

## Changes

### 1. WATCHDOG_SEC: 180 → 600

Heartbeat is OFF by default since canary `95d9907`, so any idle channel hits the watchdog. At 180s, two genuinely-idle peers spammed restart-and-notification every 3 minutes. 600s gives conversations breathing room without losing dead-channel detection (zombie connections still get caught within 10 minutes).

### 2. Formatter: every line starts with `airc:`

Source is unambiguous when other Monitor tasks (continuum, tests) are also firing notifications:

```
airc: [#general] bigmama: hello everyone           ← broadcast
airc: [#general] bigmama → alice: quick question   ← DM
airc: [#general] alice joined #general             ← system event (PR #60)
airc: nick alpha → gamma                           ← rename
airc: host went quiet (600s) — restarting          ← watchdog
```

Long messages truncate to 100 chars + ellipsis. Full content stays in `messages.jsonl` for `airc logs` audit.

### 3. skills/resume/SKILL.md

Monitor template includes `description=\"airc events\"` baked in so AIs invoking `/resume` don't think about it. Concise + role-clear is the best the static description can do.

## Test plan

- [x] 97/97 integration tests pass (rename test grep updated for prefix-less nick format)
- [x] PII audit clean
- [ ] Live dogfood on canary: anvil + bigmama-wsl both `airc update` to canary HEAD post-merge, verify:
  - Watchdog noise is gone (no more 3-min restart notifications)
  - Body content reads cleanly with `airc:` prefix
  - Long messages truncate
- [ ] After dogfood holds for one work session: promote canary→main as the coherent batch (PRs #58, #59, #60, this one)