### PR TITLE
Promote canary → main: monitor previews + noise fix + IRC formatter + comparison docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ AIRC fixes that. The mechanics that make it work — auto-#general, cross-accoun
 
 This is not a tool you open. It's a fabric your agents live on.
 
+## How airc compares
+
+The 2025-2026 wave of agent-comms protocols (A2A, ACP, ANP) targets enterprise federation: agent registries, capability cards, structured task negotiation, sometimes decentralized identifiers. They're well-engineered for "two companies' agent fleets must federate." MCP is in a different category entirely — it standardizes how a single agent talks to its tools, not how agents talk to each other.
+
+airc targets a different problem: "two devs' Claude instances should talk in 30 seconds, with zero infra." The result reads differently:
+
+- **One file. Pure shell.** `airc` is one bash script (~3000 lines, plus inline Python heredocs for the formatter). You can audit every line in an afternoon. Compare to the surface area of an A2A or ACP server stack.
+- **Encrypted by default — twice.** Tailscale (WireGuard) carries the SSH session; OpenSSH adds its own encryption layer on top. Both come from the install. You don't configure either.
+- **It's IRC.** Every model in production has internalized IRC's mental model from training data. `/join`, `/msg`, `/nick`, `/part`, `/quit` need zero documentation for the AI invoking them. The federation protocols all require new vocabulary the model has to be taught.
+- **Zero infrastructure we run.** GitHub gist + Tailscale + SSH + your laptop. No service to host, no broker to operate, no DID resolver to depend on. If GitHub disappeared tomorrow, the protocol is dumb enough to run over Reticulum or DNS TXT records the day after.
+
+This isn't a knock on the federation protocols — they solve real enterprise federation problems. airc is just the right shape for "I want my agents to talk to my coworker's agents over coffee," which the heavy stack overshoots by orders of magnitude.
+
 ## Install
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Every developer today runs five agents and they all work alone. Claude Code in t
 - **Open a new machine.** Same gh account → same room. The mesh extends across the internet through GitHub.
 - **A friend pings you across an org boundary.** They paste your gist id (or speak the 4-word phrase like `oregon-uncle-bravo-eleven`). They're in.
 - **Close your laptop. Open it later.** Run `airc daemon install` once; launchd/systemd hold the mesh open through every sleep/wake/crash.
-- **Your host machine actually dies.** Other peers detect it after ~9 min, the next agent takes over hosting, the gist is republished, the mesh continues. **No claude left behind.**
+- **Your host machine actually dies.** Other peers detect it after ~5 min, the next agent takes over hosting, the gist is republished, the mesh continues. **No claude left behind.**
 - **Your AI runs it without you.** `/join`, `/list`, `/msg`, `/part` — agents pair, DM, spin up rooms, and walk away from dead ones. Claude Code, Codex, Cursor, opencode, Windsurf, openclaw — anyone who can run a shell command is a citizen.
 
 ## How it stays safe
@@ -72,7 +72,7 @@ Same primitives. New participants.
 - **Open a new machine.** Same gh account, same `airc join`, same auto-join. The mesh extends across the internet via gh.
 - **A friend across an org boundary.** They paste your gist id (or its 4-word humanhash mnemonic — `oregon-uncle-bravo-eleven`). They're in.
 - **Close your laptop. Open it later.** `airc daemon install` once; launchd/systemd respawn airc across every sleep/wake/crash. Mesh persists.
-- **Your host machine genuinely dies.** Other peers' monitors detect dead host after ~9 min, exit cleanly, daemon respawns them, the next one to come up takes over hosting. First-agent-back-in becomes the new host. Eventual consistency in 1-3 min. **Persists until everyone has chosen to disconnect.**
+- **Your host machine genuinely dies.** Other peers' monitors detect dead host after ~5 min, exit cleanly, daemon respawns them, the next one to come up takes over hosting. First-agent-back-in becomes the new host. Eventual consistency in 1-3 min. **Persists until everyone has chosen to disconnect.**
 - **Your AI does it for you.** Claude Code (and any agent shipping the airc skills) can run `/join`, `/list`, `/msg`, `/part` without human routing. AI-to-AI DM, AI-to-human chat, all in the same room with the same primitives.
 
 ## Why AIRC

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Same primitives. New participants.
 - **Open a new machine.** Same gh account, same `airc join`, same auto-join. The mesh extends across the internet via gh.
 - **A friend across an org boundary.** They paste your gist id (or its 4-word humanhash mnemonic — `oregon-uncle-bravo-eleven`). They're in.
 - **Close your laptop. Open it later.** `airc daemon install` once; launchd/systemd respawn airc across every sleep/wake/crash. Mesh persists.
-- **Your host machine genuinely dies.** Other peers' monitors detect dead host after ~9 min, exit cleanly, daemon respawns them, the next one to come up takes over hosting. First-agent-back-in becomes the new server. Eventual consistency in 1-3 min. **Persists until everyone has chosen to disconnect.**
+- **Your host machine genuinely dies.** Other peers' monitors detect dead host after ~9 min, exit cleanly, daemon respawns them, the next one to come up takes over hosting. First-agent-back-in becomes the new host. Eventual consistency in 1-3 min. **Persists until everyone has chosen to disconnect.**
 - **Your AI does it for you.** Claude Code (and any agent shipping the airc skills) can run `/join`, `/list`, `/msg`, `/part` without human routing. AI-to-AI DM, AI-to-human chat, all in the same room with the same primitives.
 
 ## Why AIRC

--- a/airc
+++ b/airc
@@ -379,7 +379,18 @@ import sys, json, os, re, time, signal
 # a truly dead channel forces the formatter out and the reconnect loop
 # restarts the ssh. Normal chat traffic keeps resetting the alarm so
 # there is no penalty when the channel is healthy.
-WATCHDOG_SEC = 180
+#
+# Joel 2026-04-24: heartbeat is OFF by default (canary 95d9907), so
+# any idle channel WILL hit the watchdog if WATCHDOG_SEC is short.
+# At 180s, two genuinely-idle peers triggered restart-and-notification
+# every 3 minutes — pure noise that masked real events. 600s (10 min)
+# gives idle conversations breathing room without losing the dead-
+# channel detection (zombie connections still get caught within 10
+# minutes of going truly silent). Ratio: with reminder-interval=300s
+# and heartbeat OFF, the watchdog is now 2x the would-be heartbeat
+# cycle — large enough that any plausibly-alive channel still resets
+# it before firing.
+WATCHDOG_SEC = 600
 def _watchdog_exit(signum, frame):
     # Emit on stdout AS WELL as stderr so the line surfaces in the
     # Monitor task notification stream (which only sees stdout). Without
@@ -475,14 +486,14 @@ def handle_rename(msg, ts):
     old, new, host = m.group(1), m.group(2), m.group(3)
     # Primary path: name-keyed rename.
     if _rename_files(old, new):
-        print(f"airc: nick: {old} → {new}", flush=True)
+        print(f"airc: nick {old} → {new}", flush=True)
         return True
     # Fallback: peer file sits under a different (older) name due to a
     # previous chain break. Resolve via stable host field.
     if host:
         current = _find_peer_by_host(host)
         if current and current != new and _rename_files(current, new):
-            print(f"airc: nick (chain-repair): {current} → {new}", flush=True)
+            print(f"airc: nick (chain-repair) {current} → {new}", flush=True)
             return True
     return False
 
@@ -566,20 +577,27 @@ for line in sys.stdin:
         # cmd_ping picks PONG up by tailing messages.jsonl directly.
         # Suppress to keep the chat surface clean.
         continue
+    # Compact one-liner per event. Every line starts with `airc:` so
+    # the source is unambiguous when other Monitor tasks (continuum,
+    # tests, etc.) are also firing notifications. Long messages
+    # truncate to PREVIEW_LEN; full content stays in messages.jsonl
+    # for `airc logs` audit.
+    PREVIEW_LEN = 100
+    msg_preview = msg.replace("\\n", " ").strip()
+    if len(msg_preview) > PREVIEW_LEN:
+        msg_preview = msg_preview[:PREVIEW_LEN] + "…"
     if fr in ("airc", "sys"):
-        # System events (joins, parts, drain markers, auth failures) keep
-        # the airc-prefixed format — easy to scan past.
-        print(f"[#{room_name}] airc: {msg}", flush=True)
+        # System events (joins, parts, drain, auth, watchdog).
+        # Example:  airc: [#general] alice joined
+        print(f"airc: [#{room_name}] {msg_preview}", flush=True)
+    elif to and to not in ("all", ""):
+        # DM with addressed recipient.
+        # Example:  airc: [#general] bigmama → alice: quick question
+        print(f"airc: [#{room_name}] {fr} → {to}: {msg_preview}", flush=True)
     else:
-        # Real chat: compact IRC-feel format.
-        # Broadcast:  [#general] bigmama: hello everyone
-        # DM:         [#general] bigmama → alice: hey
-        # Joel 2026-04-24: "the goings on of our agents is fascinating
-        # to humans" — keep it readable, drop the verbose ISO timestamp.
-        if to and to not in ("all", ""):
-            print(f"[#{room_name}] {fr} → {to}: {msg}", flush=True)
-        else:
-            print(f"[#{room_name}] {fr}: {msg}", flush=True)
+        # Broadcast.
+        # Example:  airc: [#general] bigmama: hello everyone
+        print(f"airc: [#{room_name}] {fr}: {msg_preview}", flush=True)
 '
 }
 

--- a/airc
+++ b/airc
@@ -310,7 +310,7 @@ monitor() {
     # cold-restart and join as peers. Standard distributed-systems leader
     # election with optimistic conflict resolution via gh-create.
     local consecutive_timeouts=0
-    local ESCALATE_AFTER=3   # ~9 minutes of dead host (3 × WATCHDOG_SEC=180)
+    local ESCALATE_AFTER=2   # 5 min total dead-host detection (2 × WATCHDOG_SEC=150)
     while true; do
       local cycle_start; cycle_start=$(date +%s)
       ssh $ssh_opts "$host_target" "tail $tail_pos -F $rhome/messages.jsonl 2>/dev/null" 2>/dev/null | monitor_formatter "$my_name" || true
@@ -321,11 +321,30 @@ monitor() {
       # Subsequent reconnects use the now-persisted offset updated by the formatter.
       tail_pos="-n +$(($(cat "$offset_file" 2>/dev/null || echo 0) + 1))"
 
-      # Count this iteration as a "timeout" if formatter exited with code 2
-      # (its watchdog-no-inbound exit) OR the whole pipe died in under 30s
-      # (likely SSH refused / connection reset — host gone). Anything else,
-      # especially a long-lived formatter that received traffic, resets.
-      if [ "$fmt_exit" = "2" ] || [ "$cycle_lifetime" -lt 30 ]; then
+      # Probe-before-count for fmt_exit=2 (watchdog: no inbound for
+      # WATCHDOG_SEC). Without a probe, healthy-but-idle channels look
+      # identical to dead-host channels — both produce fmt_exit=2 — so
+      # we'd notify+escalate every WATCHDOG_SEC on quiet conversations
+      # (constant restart spam). The probe distinguishes:
+      #   probe success → host is alive, channel is just idle. Reset
+      #     counter, no notification, silent reconnect of the tail.
+      #   probe failure → host is genuinely unreachable. Notify, count
+      #     toward escalation. After ESCALATE_AFTER consecutive REAL
+      #     failures, exit 99 → daemon respawn → self-heal.
+      #
+      # cycle_lifetime < 30s also counts as a timeout (SSH refused or
+      # connection reset before tail even started reading) — that's
+      # the dead-host signature too, no probe needed.
+      if [ "$fmt_exit" = "2" ]; then
+        if ssh $ssh_opts -o ConnectTimeout=5 -o BatchMode=yes "$host_target" "true" 2>/dev/null; then
+          # Healthy idle. Stay quiet.
+          consecutive_timeouts=0
+        else
+          echo "airc: host went quiet (probe failed) — restarting"
+          consecutive_timeouts=$((consecutive_timeouts + 1))
+        fi
+      elif [ "$cycle_lifetime" -lt 30 ]; then
+        echo "airc: host unreachable (cycle <30s) — restarting"
         consecutive_timeouts=$((consecutive_timeouts + 1))
       else
         consecutive_timeouts=0
@@ -381,27 +400,26 @@ import sys, json, os, re, time, signal
 # there is no penalty when the channel is healthy.
 #
 # Joel 2026-04-24: heartbeat is OFF by default (canary 95d9907), so
-# any idle channel WILL hit the watchdog if WATCHDOG_SEC is short.
-# At 180s, two genuinely-idle peers triggered restart-and-notification
-# every 3 minutes — pure noise that masked real events. 600s (10 min)
-# gives idle conversations breathing room without losing the dead-
-# channel detection (zombie connections still get caught within 10
-# minutes of going truly silent). Ratio: with reminder-interval=300s
-# and heartbeat OFF, the watchdog is now 2x the would-be heartbeat
-# cycle — large enough that any plausibly-alive channel still resets
-# it before firing.
-WATCHDOG_SEC = 600
+# every fmt_exit=2 used to look like "host went quiet" and spam restart
+# notifications on healthy idle. Fix is in the bash retry loop: it
+# probes the host on fmt_exit=2 BEFORE counting/notifying. Probe
+# success = healthy idle (silent reset); probe failure = real death
+# (notify + count toward escalation).
+#
+# With the probe, WATCHDOG_SEC is just the polling cadence at which
+# we re-check the channel. 150s × ESCALATE_AFTER=2 = 5 minutes total
+# dead-host detection per Joel'\''s spec. The watchdog itself only fires
+# the python exit; the bash probe is what decides whether the user
+# sees a notification.
+WATCHDOG_SEC = 150
 def _watchdog_exit(signum, frame):
-    # Emit on stdout AS WELL as stderr so the line surfaces in the
-    # Monitor task notification stream (which only sees stdout). Without
-    # the stdout side, watchdog-triggered restarts are invisible — the
-    # Monitor task <summary> still shows whatever stale chat line was
-    # latest, telling humans/AIs nothing about the actual event.
-    msg = f"host went quiet ({WATCHDOG_SEC}s) — restarting"
-    sys.stderr.write(f"[airc:monitor] {msg}\\n")
+    # Diagnostic to stderr only. The bash retry loop owns the
+    # user-visible notification — it probes the host on fmt_exit=2
+    # to decide whether silence means "healthy idle" (silent reset)
+    # or "host actually unreachable" (notify + count). Emitting from
+    # python here would notify on every healthy-idle cycle.
+    sys.stderr.write(f"[airc:monitor] no inbound in {WATCHDOG_SEC}s — exiting for probe\\n")
     sys.stderr.flush()
-    sys.stdout.write(f"airc: {msg}\\n")
-    sys.stdout.flush()
     os._exit(2)
 signal.signal(signal.SIGALRM, _watchdog_exit)
 signal.alarm(WATCHDOG_SEC)

--- a/airc
+++ b/airc
@@ -381,8 +381,16 @@ import sys, json, os, re, time, signal
 # there is no penalty when the channel is healthy.
 WATCHDOG_SEC = 180
 def _watchdog_exit(signum, frame):
-    sys.stderr.write(f"[airc:monitor] no inbound in {WATCHDOG_SEC}s — restarting\\n")
+    # Emit on stdout AS WELL as stderr so the line surfaces in the
+    # Monitor task notification stream (which only sees stdout). Without
+    # the stdout side, watchdog-triggered restarts are invisible — the
+    # Monitor task <summary> still shows whatever stale chat line was
+    # latest, telling humans/AIs nothing about the actual event.
+    msg = f"host went quiet ({WATCHDOG_SEC}s) — restarting"
+    sys.stderr.write(f"[airc:monitor] {msg}\\n")
     sys.stderr.flush()
+    sys.stdout.write(f"airc: {msg}\\n")
+    sys.stdout.flush()
     os._exit(2)
 signal.signal(signal.SIGALRM, _watchdog_exit)
 signal.alarm(WATCHDOG_SEC)
@@ -467,14 +475,14 @@ def handle_rename(msg, ts):
     old, new, host = m.group(1), m.group(2), m.group(3)
     # Primary path: name-keyed rename.
     if _rename_files(old, new):
-        print(f"[{ts}] airc: Peer renamed: {old} -> {new}", flush=True)
+        print(f"airc: nick: {old} → {new}", flush=True)
         return True
     # Fallback: peer file sits under a different (older) name due to a
     # previous chain break. Resolve via stable host field.
     if host:
         current = _find_peer_by_host(host)
         if current and current != new and _rename_files(current, new):
-            print(f"[{ts}] airc: Peer renamed (chain-repair via host): {current} -> {new}", flush=True)
+            print(f"airc: nick (chain-repair): {current} → {new}", flush=True)
             return True
     return False
 
@@ -1719,6 +1727,29 @@ conn.sendall((response + '\n').encode())
 conn.close()
 sock.close()
 print(f'  Peer joined: {jname}')
+# Surface the join as a system event in messages.jsonl so the monitor
+# formatter (and downstream Monitor task summaries on every paired peer)
+# render a one-liner like '[#general] airc: <peer> joined' instead of
+# silence. Without this, peer-joined is invisible to anyone reading
+# notifications — they only learn about the new peer when chat traffic
+# starts flowing. Joel 2026-04-24: 'preview of the message or the
+# connection or whatever happened, Anvil joined instead of generic'.
+import datetime
+try:
+    room_name_path = '$AIRC_WRITE_DIR/room_name'
+    room_name = open(room_name_path).read().strip() if os.path.isfile(room_name_path) else 'general'
+    event = {
+        'ts': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'from': 'airc',
+        'to': 'all',
+        'msg': f'{jname} joined #{room_name}',
+    }
+    with open('$MESSAGES', 'a') as f:
+        f.write(json.dumps(event) + '\n')
+except Exception:
+    # Don't fail the pair on event-emit error — pairing already
+    # succeeded by this point; the missing event line is cosmetic.
+    pass
 " 2>/dev/null || true
     done &
     PAIR_PID=$!

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -13,7 +13,7 @@ Run this yourself — don't ask the user.
 ## Execute
 
 ```
-Monitor(persistent=true, command="airc join")
+Monitor(persistent=true, description="airc events", command="airc join")
 ```
 
 Wrap with the Monitor tool so inbound streams as Claude Code notifications. `airc join` with no args detects the stored pairing in this scope's config.json and restarts the monitor — no fresh handshake, no join string, no env vars.

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -13,7 +13,7 @@ Run this yourself — don't ask the user.
 ## Execute
 
 ```
-Monitor(persistent=true, description="airc events", command="airc join")
+Monitor(persistent=true, description="airc", command="airc join")
 ```
 
 Wrap with the Monitor tool so inbound streams as Claude Code notifications. `airc join` with no args detects the stored pairing in this scope's config.json and restarts the monitor — no fresh handshake, no join string, no env vars.

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -230,7 +230,7 @@ json.dump(c, open('$fake_home/state/config.json', 'w'))
   # to 'nick: <old> → <new>' (IRC-canonical). Match the new format; old-format
   # backward-compat is intentionally NOT kept since the wire protocol [rename]
   # marker is what peers actually exchange — only the human-visible print changed.
-  grep -qE 'nick:.*alpha.*gamma|Peer renamed' /tmp/airc-it-j/out.log && pass "beta saw [rename] marker" \
+  grep -qE 'nick.*alpha.*gamma|Peer renamed' /tmp/airc-it-j/out.log && pass "beta saw [rename] marker" \
                                                 || fail "beta did NOT see rename marker"
 
   as_home /tmp/airc-it-j peers 2>/dev/null | grep -q gamma && pass "beta peers shows gamma" \

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -226,7 +226,11 @@ json.dump(c, open('$fake_home/state/config.json', 'w'))
                                                       || fail "rename failed"
 
   sleep 8
-  grep -q 'Peer renamed' /tmp/airc-it-j/out.log && pass "beta saw [rename] marker" \
+  # Joel 2026-04-24: rename print format changed from 'Peer renamed: <old> -> <new>'
+  # to 'nick: <old> → <new>' (IRC-canonical). Match the new format; old-format
+  # backward-compat is intentionally NOT kept since the wire protocol [rename]
+  # marker is what peers actually exchange — only the human-visible print changed.
+  grep -qE 'nick:.*alpha.*gamma|Peer renamed' /tmp/airc-it-j/out.log && pass "beta saw [rename] marker" \
                                                 || fail "beta did NOT see rename marker"
 
   as_home /tmp/airc-it-j peers 2>/dev/null | grep -q gamma && pass "beta peers shows gamma" \
@@ -922,6 +926,88 @@ scenario_room() {
   cleanup_all
 }
 
+# ── Scenario: events (Joel's monitor-preview ask) ──────────────────────
+# Joel 2026-04-24: "Anvil joined" instead of generic "monitor yada yada"
+# in Monitor task notifications. The preview comes from messages.jsonl
+# lines with from=airc; the formatter renders them as `[#room] airc:`.
+# Without lifecycle events flowing through the log, Monitor's <summary>
+# falls back to whatever stale chat line was latest — telling humans
+# nothing about what just happened.
+#
+# What we verify:
+#   - After successful pair, host's messages.jsonl contains a system
+#     event line with from=airc and msg matching '<peer> joined #<room>'
+#   - The line lands within a few seconds of pair (not stuck behind
+#     the formatter's own loop)
+scenario_events() {
+  section "events: pair-handshake emits 'beta joined #<room>' system event"
+  cleanup_all
+
+  local rname="test-events-$$"
+
+  mkdir -p /tmp/airc-it-h
+  ( cd /tmp/airc-it-h && AIRC_HOME=/tmp/airc-it-h/state AIRC_NAME=alpha AIRC_PORT=7549 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room "$rname" > /tmp/airc-it-h/out.log 2>&1 & )
+  local i
+  for i in 1 2 3 4 5; do
+    sleep 1
+    grep -q 'Hosting as' /tmp/airc-it-h/out.log 2>/dev/null && break
+  done
+  grep -q 'Hosting as' /tmp/airc-it-h/out.log \
+    && pass "alpha hosting (--room ${rname}, --no-gist)" \
+    || { fail "alpha host failed to start"; cleanup_all; return; }
+
+  local join; join=$(read_join_string /tmp/airc-it-h)
+  [ -n "$join" ] && pass "alpha join string captured" \
+                 || { fail "no join string in alpha log"; cleanup_all; return; }
+
+  spawn_joiner /tmp/airc-it-j beta "$join" \
+    && pass "beta joined alpha's room" \
+    || { fail "beta join failed"; cleanup_all; return; }
+
+  # Allow up to ~5s for the pair-accept python to finish writing the
+  # event line. The handshake itself completes in <1s; the event-emit
+  # is wrapped in try/except so any path that fails doesn't break the
+  # pair, which means we need to check what actually landed.
+  local seen=""
+  for i in 1 2 3 4 5; do
+    if [ -f /tmp/airc-it-h/state/messages.jsonl ] \
+       && grep -q '"from": *"airc"' /tmp/airc-it-h/state/messages.jsonl \
+       && grep -q "beta joined #${rname}" /tmp/airc-it-h/state/messages.jsonl; then
+      seen="yes"
+      break
+    fi
+    sleep 1
+  done
+  [ -n "$seen" ] \
+    && pass "host messages.jsonl contains 'beta joined #${rname}' event line" \
+    || fail "no 'beta joined' event line in host's messages.jsonl after 5s"
+
+  # The event must be JSON-parseable and have the structure the formatter
+  # expects (from=airc, to=all, msg + ts present). Otherwise it'll be
+  # silently skipped by the monitor formatter's json.loads guard.
+  if [ -n "$seen" ]; then
+    python3 -c "
+import json,sys
+ok=False
+for line in open('/tmp/airc-it-h/state/messages.jsonl'):
+    try:
+        m=json.loads(line)
+    except Exception:
+        continue
+    if m.get('from')=='airc' and 'beta joined' in m.get('msg',''):
+        if m.get('to')=='all' and m.get('ts'):
+            ok=True
+sys.exit(0 if ok else 1)
+" 2>/dev/null \
+      && pass "event has required fields (from=airc, to=all, ts, msg)" \
+      || fail "event line malformed — formatter will skip it"
+  fi
+
+  cleanup_all
+}
+
 # ── Scenario: get_host (LAN IP fallback when Tailscale absent/disabled) ─
 # Per Joel: Tailscale should be optional for same-LAN use. The new
 # get_host priority is Tailscale → LAN-IP-via-UDP-trick → hostname.
@@ -1049,9 +1135,10 @@ case "$MODE" in
   auth_failure) scenario_auth_failure ;;
   resume_stale_auth) scenario_resume_stale_auth ;;
   room)         scenario_room ;;
+  events)       scenario_events ;;
   get_host)     scenario_get_host ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_get_host ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|get_host|all]"; exit 2 ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary

Five canary commits, dogfooded for one work session by anvil + bigmama-wsl. Coherent batch:

1. **`3cba337` feat(monitor): event previews** — pair-accept loop emits `{from:airc, msg:\"<peer> joined #<room>\"}` to messages.jsonl on pair. Watchdog timeout writes to stdout. Rename print → IRC-style `nick: old → new`. (Originally PR #60.)

2. **`f989be8` fix(monitor): less noise** — formatter every line `airc: ` prefixed + 100-char truncation + cleaner system event format. (Originally PR #61.)

3. **`ef5d6cb` chore: monitor description + host terminology** — Monitor description set to `\"airc\"` in skills/resume so notification headlines stay concise. README line 75 \"becomes the new server\" → \"becomes the new host\" for terminology consistency.

4. **`23badee` fix(monitor): probe-before-count** — bash retry loop probes host with 5s SSH alive-check on `fmt_exit=2`. Probe success → silent reset (no notification, no escalation). Probe failure → user-visible message + counter increment. Knobs: `WATCHDOG_SEC` 600→150, `ESCALATE_AFTER` 3→2 → 5 min real dead-host detection. README \"~9 min\" → \"~5 min\".

5. **`22bd982` docs(readme): How airc compares** — measured positioning section against A2A / ACP / ANP / MCP. Explains the lightweight + pure-shell + IRC-native + zero-infra angles without being snotty.

## Dogfood report

| Change | Live-validated? |
|---|---|
| Event-emit on pair joined | ✓ Fresh-scope test produced `event-validator-1 joined #general` in host's messages.jsonl, monitor surfaced it |
| Cross-machine + self-heal | ✓ Multiple monitor bounces today; self-heal fired each time; both peers re-paired |
| Formatter cleanup | ✓ Bigmama's messages displayed with new `airc:` prefix in my monitor body |
| Probe-before-count | ✓ Chat idle several minutes — **zero \"host went quiet\" notifications fired**, exactly the design intent |
| 5-min dead-host escalation | ⚠ Math is right (2 × 150s) but not actually-killed-a-host in this session. Probe gating is empirically working. |
| README compare section | Docs only — visible immediately |

## Test plan

- [x] Integration suite 97/97 green (was 92/92 pre-PR-#60; new `scenario_events` adds 5 assertions)
- [x] PII audit on every commit clean (no IPs, Tailnet identifiers, keys, personal paths)
- [x] Both anvil + bigmama-wsl on canary HEAD `22bd982`, dogfooded for one work session
- [ ] Promote → end-users hitting `curl ...github.com/CambrianTech/airc/main/install.sh | bash` get the new behavior