### PR TITLE
promote canary -> main: native Windows port + first-time-user installer + audit cleanup

### DIFF
--- a/WINDOWS-PORT-STATUS.md
+++ b/WINDOWS-PORT-STATUS.md
@@ -1,122 +1,65 @@
-# Windows-Native PowerShell Port — Status & Roadmap
+# Windows Support — Two-Tier Strategy
 
-This is the live tracker for the `airc.ps1` Windows-native port (PR #?). The bash `airc` (~3095 lines) is the source of truth for protocol behavior; this port mirrors each command into PowerShell.
+This branch carries Windows-support work for airc. **Strategy reversed mid-branch** (Joel 2026-04-24, after Toby reported he uses Git Bash as his Windows Terminal default): try bash + Git Bash first, treat the PowerShell port as a fallback only if Git Bash compat truly can't be made to work.
 
-**Architecture decision** (project memory `project_airc_pure_shell_per_platform.md`): two pure-shell implementations, NOT a single binary. The PowerShell port preserves the "audit in an afternoon" pitch on Windows just as bash does on POSIX.
+## Current state
 
-**No middle ground:** mingw / MSYS2 / Git Bash are NOT supported. Windows users get either WSL (use the bash `airc`) or PowerShell 7+ (use this `airc.ps1`). install.sh detects mingw and refuses; install.ps1 requires PS 7+.
+- **Tier 1 (active):** make bash `airc` work in Git Bash on Windows. Single codebase across mac / linux / WSL / Git Bash. Preferred outcome.
+- **Tier 2 (scaffolded but on ice):** native PowerShell port (`airc.ps1`, `install.ps1`). Files exist as scaffolding insurance. Don't continue this work unless Tier 1 is shown to be infeasible.
 
-## Collaboration model
+## Tier 1 (Git Bash compat) — required fixes
 
-Multiple Claudes can work on this PR concurrently. To avoid collisions:
+Audited the bash file for Windows-Python and Git-Bash incompatible bits. Surface is small.
 
-- **One command per commit.** Pick a `[ ]` row from the checklist below, change it to `[/]` (in-progress) in the same commit that starts the work, then `[x]` when the command's port is functional + the matching test scenario passes.
-- **Reference the bash line range** in the commit message so reviewers can compare implementations.
-- **Touch only the files for that command.** Adding a row to PORT-STATUS doesn't conflict with someone else porting `cmd_connect`.
-- **Don't reformat the bash original.** Drift in the source-of-truth defeats the parity claim.
+| Issue | Severity | Status | Fix |
+|---|---|---|---|
+| `signal.SIGALRM` / `signal.alarm` (watchdog python) | **Hard blocker** — Windows Python has no SIGALRM | ✓ done | try/except: SIGALRM on POSIX, threading.Timer fallback on Windows. `_arm_watchdog()` wrapper handles both. |
+| `python3` not on PATH (Git Bash typically ships `python` only) | Soft blocker | ✓ done | bash function wrapper at top of file: `python3 () { command python "$@"; }` if python3 is missing but python exists. Hard fail with install hints if neither. |
+| `pgrep -P $$` / `pkill` patterns in cmd_teardown | Maybe — needs Git Bash test | ⚠ untested | Git Bash usually ships procps-ng; if missing, fall back to cmd.exe `taskkill` via airc.pid file. Test on Windows first. |
+| File permissions (`chmod 600` for SSH keys) | Probably fine | ⚠ untested | Git Bash uses Windows OpenSSH which respects ACLs; chmod is a no-op but doesn't error. |
+| SSH paths (`~/.ssh/`) | Probably fine | ⚠ untested | Git Bash and OpenSSH-Windows use the same `%USERPROFILE%\.ssh\` location. |
+| TCP listener (`bind('0.0.0.0', $host_port)`) | Should work | ⚠ untested | Windows allows binding to 0.0.0.0; firewall may prompt on first run. |
 
-## Test rig
+## Tier 1 — handoff checklist for Windows-Claude
 
-`test/integration.ps1` (TODO) runs the same scenario assertions as `test/integration.sh` against `airc.ps1` instead of `airc`. Every command marked `[x]` MUST have its scenario passing in both rigs. The CI job for this PR will fail if a command is marked done but the PowerShell scenario doesn't pass.
+When Windows-Claude (running in Git Bash on Joel's Windows machine) picks this up:
 
-## Command checklist
+1. `git fetch origin && git checkout feat/powershell-native-port` (branch name kept for git history continuity; scope is now broader than the original PowerShell port)
+2. `cd ~/.airc-src` (or wherever, this is for the install dir on Windows) — `bash install.sh` to install airc fresh from this branch
+3. `airc version` → should print
+4. `airc help` → should print
+5. `airc connect` → host mode; expect TCP bind on 7547. Windows Defender may prompt — allow.
+6. From anvil or bigmama-wsl: paste the join string Windows-Claude printed → other peer should pair
+7. Bidirectional `airc msg` exchange
+8. `airc teardown` → should kill cleanly without orphaning processes
+9. `airc connect` again → resume should work
 
-Order roughly follows dependency: scope/config first, then read-only commands (status, list, version), then comms (connect, msg, peers), then lifecycle (part, quit, teardown), then daemon + updates last.
+If any of those fail, file the symptom + stderr in the PR thread. The Tier 2 (PowerShell port) scaffold stays on this branch as the fallback.
 
-### Foundation (read-only, no network)
+## Tier 2 (PowerShell port) — on ice
 
-- [x] **scope detection** (bash:53..60) — `Get-AircScope` honors `$env:AIRC_HOME`, falls back to git-root + `.airc/`
-- [x] **config helpers** (bash:get_config_val/set_config_val) — `Get-ConfigVal` / `Set-ConfigVal`
-- [x] **version** (bash:cmd_version) — prints version + install path
-- [x] **help** (bash:2993..) — prints command surface
-- [ ] **debug-scope** — already wired
-- [ ] **logs** (bash:cmd_logs) — `Get-Content -Tail` on `$MESSAGES`; cross-platform path safe
+Files preserved on this branch:
+- `airc.ps1` — skeleton with scope detection, config helpers, version, help, command-dispatch stubs
+- `install.ps1` — Windows-native installer
+- (See git history for the original WINDOWS-PORT-STATUS that framed Tier 2 as the primary path.)
 
-### Identity & state (no network)
+These are insurance. Do NOT iterate on them while Tier 1 is unconfirmed. If Tier 1 succeeds end-to-end, delete the Tier 2 files in a follow-up commit and the single-codebase claim holds across all platforms.
 
-- [ ] **status** (bash:cmd_status) — read config + airc.pid + queue size + last-send timestamp
-- [ ] **peers** (bash:cmd_peers) — list `$PEERS_DIR/*.json`, format as `name → host` rows
-- [ ] **reminder** (bash:cmd_reminder) — set/show silence-nudge interval
+## Promotion gate
 
-### gh + Tailscale surfaces (network, no SSH)
+Same as before:
 
-- [ ] **list / rooms** (bash:cmd_rooms) — `gh gist list` filtered by description prefix `airc room:`
-- [ ] **invite** (bash:cmd_invite) — print join string from saved config (host or joiner reconstruct)
-- [ ] **debug-host** (bash:get_host) — Tailscale IP / LAN-IP fallback / hostname priority
+1. Windows-Claude works this branch until they feel good (Tier 1 commands functional in Git Bash, scenarios pass).
+2. Merge feature branch → canary.
+3. Three-peer E2E on canary: anvil (mac/bash), bigmama-wsl (WSL2/bash), windows-claude (Git Bash on native Windows). Real cross-implementation chat for one work session.
+4. If all three peers good → promote canary → main.
 
-### Connection (the big one)
+## Joel's directive (verbatim)
 
-- [ ] **nick / rename** (bash:cmd_rename) — sanitize, update config.json, send `[rename]` marker
-- [ ] **connect / join / resume** (bash:cmd_connect, ~1100..1850) — host-vs-joiner split:
-  - [ ] discovery (gh gist filter, mnemonic resolve)
-  - [ ] host mode: pair-accept TCP listener + python heredoc port → pure PS or `python -c`
-  - [ ] joiner mode: SSH tail + monitor formatter loop
-  - [ ] event-emit on pair (`{from:airc, msg:"<peer> joined #<room>"}`)
-  - [ ] watchdog probe-before-count (5-min escalation)
-- [ ] **monitor formatter** — render JSONL → IRC-style `airc: [#room] <fr>: <msg>` with 100-char truncation
-- [ ] **pair-accept loop** — TCP listener accepting joiner public keys, writing peer record + authorized_keys
+> "we should remain 'pure shell' just do same for powershell yeah and in a PR"
+>
+> _later, after Toby's setup was reported:_
+>
+> "yeah just update the PR description and work" + "and try to code for both yeah"
 
-### Messaging
-
-- [ ] **msg / send** (bash:cmd_send) — local-mirror-first, ssh append to host messages.jsonl, queue on network fail
-- [ ] **send-file** (bash:cmd_send_file) — scp + airc msg notification
-- [ ] **ping** (bash:cmd_ping) — sealed UUID round-trip + 10s wait for PONG
-
-### Lifecycle
-
-- [ ] **part** (bash:cmd_part, line 2037) — host: `gh gist delete`; joiner: local teardown only
-- [ ] **quit / disconnect** — teardown + strip host_target from config
-- [ ] **teardown / stop** — read airc.pid, kill PIDs, cleanup
-- [ ] **repair** — teardown --flush + reconnect
-
-### Updates / channels
-
-- [ ] **update / upgrade / pull** (bash:cmd_update, line 2369) — git pull + re-run install.ps1
-- [ ] **channel** (bash:cmd_channel) — show/set release channel from `$AIRC_DIR/.channel`
-- [ ] **canary** — alias for `update --channel canary`
-
-### Daemon (Windows-specific divergence)
-
-- [ ] **daemon install** (bash uses launchd/systemd) — Windows port uses **Task Scheduler** at user logon. Action: `Start-Process pwsh -ArgumentList '-NoProfile', '-File', '<airc.ps1>', 'connect'`. Settings: RestartOnFailure (3 attempts), RunOnlyIfNetworkAvailable, StopOnIdleEnd=$false. Persist across reboots: trigger=AtLogOn for current user.
-- [ ] **daemon uninstall** — Unregister-ScheduledTask
-- [ ] **daemon status** — Get-ScheduledTask + Get-ScheduledTaskInfo
-
-### Diagnostic
-
-- [ ] **doctor / tests** (bash:cmd_doctor) — environment health check + invoke test/integration.ps1
-
-## Python heredocs
-
-The bash original embeds two Python heredocs:
-1. **monitor_formatter** (bash:387..595) — JSONL parser, rename handler, IRC formatter, watchdog (signal.alarm — POSIX-only)
-2. **pair-accept loop** (bash:1645..1735) — TCP listener accepting joiner keys, peer record write, event-emit
-
-**Two porting strategies for these:**
-
-- **Strategy A (pragmatic):** keep them as Python files, invoke via `python.exe -c` from PowerShell. Replace `signal.alarm` with `threading.Timer` (cross-platform). Pro: ~1-day port. Con: keeps Python as a runtime requirement.
-- **Strategy B (pure-shell purity):** rewrite the heredoc logic in PowerShell. PowerShell has TCP listeners (`System.Net.Sockets.TcpListener`), threading (`Start-Job`), JSON parsing (`ConvertFrom-Json`). Pro: drops Python requirement. Con: ~3-day port, two more files of platform-specific logic.
-
-Recommend Strategy A for the initial port (faster to parity), revisit Strategy B once stable.
-
-## Joel's testing setup
-
-- Anvil (mac, this Claude) — bash side, validates POSIX scenarios + reviews PowerShell architectural choices. Cannot validate Windows-native behavior.
-- Bigmama-wsl — bash side under WSL, validates the WSL-as-POSIX path.
-- **A separate Claude on Joel's Windows machine, NOT under WSL, in Windows Terminal with PowerShell** — validates this port end-to-end. Required for any `[x]` mark on a network-touching command.
-
-When a Windows-Claude finishes a command port, they should:
-1. Run `airc.ps1 <command> ...` for the happy path
-2. Run `test/integration.ps1 <scenario>` for the unit assertions
-3. Run an actual cross-machine round-trip with anvil or bigmama (the existing peers on the mesh)
-4. Mark `[x]`, commit, push to this branch
-
-## Promotion path
-
-Per Joel 2026-04-24:
-
-1. **Windows-Claude works on this PR until they feel good about parity** (most commands `[x]`, scenario suite green, cross-machine round-trip with anvil + bigmama working).
-2. **Merge feature branch → canary.** This PR is a long-running feature branch (exception to the normal airc canary-direct rule, because there's no dogfood-able state until parity exists).
-3. **Three-peer E2E on canary:** anvil (mac/bash), bigmama-wsl (WSL2/bash), windows-claude (Windows Terminal/PowerShell). Real cross-implementation chat through #general for at least one work session.
-4. **If all three peers report good** → promote canary → main as usual.
-
-The three-peer dogfood is the actual gate. Two pure-shell implementations passing the same scenario suite is necessary; three independent peers actually using the substrate together is sufficient.
+The interpretation that lands: code for both (bash with Windows-Python compat AND PowerShell as fallback insurance), but invest in Tier 1 first.

--- a/WINDOWS-PORT-STATUS.md
+++ b/WINDOWS-PORT-STATUS.md
@@ -1,0 +1,122 @@
+# Windows-Native PowerShell Port — Status & Roadmap
+
+This is the live tracker for the `airc.ps1` Windows-native port (PR #?). The bash `airc` (~3095 lines) is the source of truth for protocol behavior; this port mirrors each command into PowerShell.
+
+**Architecture decision** (project memory `project_airc_pure_shell_per_platform.md`): two pure-shell implementations, NOT a single binary. The PowerShell port preserves the "audit in an afternoon" pitch on Windows just as bash does on POSIX.
+
+**No middle ground:** mingw / MSYS2 / Git Bash are NOT supported. Windows users get either WSL (use the bash `airc`) or PowerShell 7+ (use this `airc.ps1`). install.sh detects mingw and refuses; install.ps1 requires PS 7+.
+
+## Collaboration model
+
+Multiple Claudes can work on this PR concurrently. To avoid collisions:
+
+- **One command per commit.** Pick a `[ ]` row from the checklist below, change it to `[/]` (in-progress) in the same commit that starts the work, then `[x]` when the command's port is functional + the matching test scenario passes.
+- **Reference the bash line range** in the commit message so reviewers can compare implementations.
+- **Touch only the files for that command.** Adding a row to PORT-STATUS doesn't conflict with someone else porting `cmd_connect`.
+- **Don't reformat the bash original.** Drift in the source-of-truth defeats the parity claim.
+
+## Test rig
+
+`test/integration.ps1` (TODO) runs the same scenario assertions as `test/integration.sh` against `airc.ps1` instead of `airc`. Every command marked `[x]` MUST have its scenario passing in both rigs. The CI job for this PR will fail if a command is marked done but the PowerShell scenario doesn't pass.
+
+## Command checklist
+
+Order roughly follows dependency: scope/config first, then read-only commands (status, list, version), then comms (connect, msg, peers), then lifecycle (part, quit, teardown), then daemon + updates last.
+
+### Foundation (read-only, no network)
+
+- [x] **scope detection** (bash:53..60) — `Get-AircScope` honors `$env:AIRC_HOME`, falls back to git-root + `.airc/`
+- [x] **config helpers** (bash:get_config_val/set_config_val) — `Get-ConfigVal` / `Set-ConfigVal`
+- [x] **version** (bash:cmd_version) — prints version + install path
+- [x] **help** (bash:2993..) — prints command surface
+- [ ] **debug-scope** — already wired
+- [ ] **logs** (bash:cmd_logs) — `Get-Content -Tail` on `$MESSAGES`; cross-platform path safe
+
+### Identity & state (no network)
+
+- [ ] **status** (bash:cmd_status) — read config + airc.pid + queue size + last-send timestamp
+- [ ] **peers** (bash:cmd_peers) — list `$PEERS_DIR/*.json`, format as `name → host` rows
+- [ ] **reminder** (bash:cmd_reminder) — set/show silence-nudge interval
+
+### gh + Tailscale surfaces (network, no SSH)
+
+- [ ] **list / rooms** (bash:cmd_rooms) — `gh gist list` filtered by description prefix `airc room:`
+- [ ] **invite** (bash:cmd_invite) — print join string from saved config (host or joiner reconstruct)
+- [ ] **debug-host** (bash:get_host) — Tailscale IP / LAN-IP fallback / hostname priority
+
+### Connection (the big one)
+
+- [ ] **nick / rename** (bash:cmd_rename) — sanitize, update config.json, send `[rename]` marker
+- [ ] **connect / join / resume** (bash:cmd_connect, ~1100..1850) — host-vs-joiner split:
+  - [ ] discovery (gh gist filter, mnemonic resolve)
+  - [ ] host mode: pair-accept TCP listener + python heredoc port → pure PS or `python -c`
+  - [ ] joiner mode: SSH tail + monitor formatter loop
+  - [ ] event-emit on pair (`{from:airc, msg:"<peer> joined #<room>"}`)
+  - [ ] watchdog probe-before-count (5-min escalation)
+- [ ] **monitor formatter** — render JSONL → IRC-style `airc: [#room] <fr>: <msg>` with 100-char truncation
+- [ ] **pair-accept loop** — TCP listener accepting joiner public keys, writing peer record + authorized_keys
+
+### Messaging
+
+- [ ] **msg / send** (bash:cmd_send) — local-mirror-first, ssh append to host messages.jsonl, queue on network fail
+- [ ] **send-file** (bash:cmd_send_file) — scp + airc msg notification
+- [ ] **ping** (bash:cmd_ping) — sealed UUID round-trip + 10s wait for PONG
+
+### Lifecycle
+
+- [ ] **part** (bash:cmd_part, line 2037) — host: `gh gist delete`; joiner: local teardown only
+- [ ] **quit / disconnect** — teardown + strip host_target from config
+- [ ] **teardown / stop** — read airc.pid, kill PIDs, cleanup
+- [ ] **repair** — teardown --flush + reconnect
+
+### Updates / channels
+
+- [ ] **update / upgrade / pull** (bash:cmd_update, line 2369) — git pull + re-run install.ps1
+- [ ] **channel** (bash:cmd_channel) — show/set release channel from `$AIRC_DIR/.channel`
+- [ ] **canary** — alias for `update --channel canary`
+
+### Daemon (Windows-specific divergence)
+
+- [ ] **daemon install** (bash uses launchd/systemd) — Windows port uses **Task Scheduler** at user logon. Action: `Start-Process pwsh -ArgumentList '-NoProfile', '-File', '<airc.ps1>', 'connect'`. Settings: RestartOnFailure (3 attempts), RunOnlyIfNetworkAvailable, StopOnIdleEnd=$false. Persist across reboots: trigger=AtLogOn for current user.
+- [ ] **daemon uninstall** — Unregister-ScheduledTask
+- [ ] **daemon status** — Get-ScheduledTask + Get-ScheduledTaskInfo
+
+### Diagnostic
+
+- [ ] **doctor / tests** (bash:cmd_doctor) — environment health check + invoke test/integration.ps1
+
+## Python heredocs
+
+The bash original embeds two Python heredocs:
+1. **monitor_formatter** (bash:387..595) — JSONL parser, rename handler, IRC formatter, watchdog (signal.alarm — POSIX-only)
+2. **pair-accept loop** (bash:1645..1735) — TCP listener accepting joiner keys, peer record write, event-emit
+
+**Two porting strategies for these:**
+
+- **Strategy A (pragmatic):** keep them as Python files, invoke via `python.exe -c` from PowerShell. Replace `signal.alarm` with `threading.Timer` (cross-platform). Pro: ~1-day port. Con: keeps Python as a runtime requirement.
+- **Strategy B (pure-shell purity):** rewrite the heredoc logic in PowerShell. PowerShell has TCP listeners (`System.Net.Sockets.TcpListener`), threading (`Start-Job`), JSON parsing (`ConvertFrom-Json`). Pro: drops Python requirement. Con: ~3-day port, two more files of platform-specific logic.
+
+Recommend Strategy A for the initial port (faster to parity), revisit Strategy B once stable.
+
+## Joel's testing setup
+
+- Anvil (mac, this Claude) — bash side, validates POSIX scenarios + reviews PowerShell architectural choices. Cannot validate Windows-native behavior.
+- Bigmama-wsl — bash side under WSL, validates the WSL-as-POSIX path.
+- **A separate Claude on Joel's Windows machine, NOT under WSL, in Windows Terminal with PowerShell** — validates this port end-to-end. Required for any `[x]` mark on a network-touching command.
+
+When a Windows-Claude finishes a command port, they should:
+1. Run `airc.ps1 <command> ...` for the happy path
+2. Run `test/integration.ps1 <scenario>` for the unit assertions
+3. Run an actual cross-machine round-trip with anvil or bigmama (the existing peers on the mesh)
+4. Mark `[x]`, commit, push to this branch
+
+## Promotion path
+
+Per Joel 2026-04-24:
+
+1. **Windows-Claude works on this PR until they feel good about parity** (most commands `[x]`, scenario suite green, cross-machine round-trip with anvil + bigmama working).
+2. **Merge feature branch → canary.** This PR is a long-running feature branch (exception to the normal airc canary-direct rule, because there's no dogfood-able state until parity exists).
+3. **Three-peer E2E on canary:** anvil (mac/bash), bigmama-wsl (WSL2/bash), windows-claude (Windows Terminal/PowerShell). Real cross-implementation chat through #general for at least one work session.
+4. **If all three peers report good** → promote canary → main as usual.
+
+The three-peer dogfood is the actual gate. Two pure-shell implementations passing the same scenario suite is necessary; three independent peers actually using the substrate together is sufficient.

--- a/airc
+++ b/airc
@@ -789,27 +789,40 @@ for line in sys.stdin:
         # cmd_ping picks PONG up by tailing messages.jsonl directly.
         # Suppress to keep the chat surface clean.
         continue
-    # Compact one-liner per event. Every line starts with `airc:` so
-    # the source is unambiguous when other Monitor tasks (continuum,
-    # tests, etc.) are also firing notifications. Long messages
-    # truncate to PREVIEW_LEN; full content stays in messages.jsonl
-    # for `airc logs` audit.
-    PREVIEW_LEN = 100
-    msg_preview = msg.replace("\\n", " ").strip()
-    if len(msg_preview) > PREVIEW_LEN:
-        msg_preview = msg_preview[:PREVIEW_LEN] + "…"
-    if fr in ("airc", "sys"):
-        # System events (joins, parts, drain, auth, watchdog).
-        # Example:  airc: [#general] alice joined
-        print(f"airc: [#{room_name}] {msg_preview}", flush=True)
-    elif to and to not in ("all", ""):
-        # DM with addressed recipient.
-        # Example:  airc: [#general] bigmama → alice: quick question
-        print(f"airc: [#{room_name}] {fr} → {to}: {msg_preview}", flush=True)
-    else:
-        # Broadcast.
-        # Example:  airc: [#general] bigmama: hello everyone
-        print(f"airc: [#{room_name}] {fr}: {msg_preview}", flush=True)
+    # One-liner per event. Every line starts with `airc:` so the source
+    # is unambiguous when other Monitor tasks (continuum, tests, etc.)
+    # are also firing notifications.
+    #
+    # No length cap any more -- consumers (Claude Code Monitor, Codex,
+    # log tailers, etc.) decide their own display truncation. Truncating
+    # in the substrate forced everyone downstream to fall back to
+    # `airc logs` to see anything past the cap, which is exactly the
+    # polling-vs-substrate anti-pattern Joel called out 2026-04-24.
+    # Newlines collapsed to spaces so each emitted event is still a
+    # single line, but the full body always reaches the consumer.
+    msg_one_line = (msg or "").replace("\\n", " ").replace("\\r", " ").strip()
+    try:
+        if fr in ("airc", "sys"):
+            # System events (joins, parts, drain, auth, watchdog).
+            # Example:  airc: [#general] alice joined
+            print(f"airc: [#{room_name}] {msg_one_line}", flush=True)
+        elif to and to not in ("all", ""):
+            # DM with addressed recipient.
+            # Example:  airc: [#general] bigmama → alice: quick question
+            print(f"airc: [#{room_name}] {fr} → {to}: {msg_one_line}", flush=True)
+        else:
+            # Broadcast.
+            # Example:  airc: [#general] bigmama: hello everyone
+            print(f"airc: [#{room_name}] {fr}: {msg_one_line}", flush=True)
+    except Exception as e:
+        # Belt-and-suspenders -- one bad message must never take the
+        # whole monitor down. Surface to stderr (which the bash retry
+        # loop captures) and keep going.
+        try:
+            sys.stderr.write(f"[airc:formatter] skipped one line: {e}\\n")
+            sys.stderr.flush()
+        except Exception:
+            pass
 '
 }
 

--- a/airc
+++ b/airc
@@ -8,6 +8,26 @@
 
 set -euo pipefail
 
+# Cross-platform Python invocation. macOS / Linux / WSL all ship `python3`
+# on PATH; Git Bash on Windows typically has `python` only (the launcher
+# from python.org). Resolve once at startup; every `python3 ...` invocation
+# downstream goes through this wrapper. Hard fail if neither is present
+# (we genuinely need Python — the inline heredocs for monitor formatting
+# and pair handshake are not yet ported to pure shell).
+if ! command -v python3 >/dev/null 2>&1; then
+  if command -v python >/dev/null 2>&1; then
+    # Define a wrapper function that callers see as `python3`.
+    python3() { command python "$@"; }
+    export -f python3 2>/dev/null || true
+  else
+    echo "ERROR: airc requires python3 (or python on Windows/Git Bash)." >&2
+    echo "  macOS:    brew install python3" >&2
+    echo "  Linux:    apt install python3 / dnf install python3" >&2
+    echo "  Windows:  install from python.org or Microsoft Store" >&2
+    exit 1
+  fi
+fi
+
 # One-time migration from pre-rename ~/.agent-relay → ~/.airc. Fires when user
 # is on vanilla defaults, the old dir exists as a real dir (not a symlink we
 # already left), and ~/.airc doesn't. Leaves a symlink ~/.agent-relay → ~/.airc
@@ -412,7 +432,7 @@ import sys, json, os, re, time, signal
 # the python exit; the bash probe is what decides whether the user
 # sees a notification.
 WATCHDOG_SEC = 150
-def _watchdog_exit(signum, frame):
+def _watchdog_exit(signum=None, frame=None):
     # Diagnostic to stderr only. The bash retry loop owns the
     # user-visible notification — it probes the host on fmt_exit=2
     # to decide whether silence means "healthy idle" (silent reset)
@@ -421,8 +441,28 @@ def _watchdog_exit(signum, frame):
     sys.stderr.write(f"[airc:monitor] no inbound in {WATCHDOG_SEC}s — exiting for probe\\n")
     sys.stderr.flush()
     os._exit(2)
-signal.signal(signal.SIGALRM, _watchdog_exit)
-signal.alarm(WATCHDOG_SEC)
+
+# Cross-platform watchdog. POSIX (mac/linux/WSL) gets signal.SIGALRM
+# which is cheaper (single-thread, kernel-armed). Windows Python has
+# no SIGALRM so we fall back to threading.Timer — same exit semantics,
+# slight overhead from the timer thread. Either way the fmt_exit=2
+# contract is preserved.
+try:
+    signal.signal(signal.SIGALRM, _watchdog_exit)
+    signal.alarm(WATCHDOG_SEC)
+    def _arm_watchdog():
+        signal.alarm(WATCHDOG_SEC)
+except (AttributeError, ValueError):
+    import threading
+    _wd_timer_holder = [None]
+    def _arm_watchdog():
+        if _wd_timer_holder[0] is not None:
+            _wd_timer_holder[0].cancel()
+        t = threading.Timer(WATCHDOG_SEC, _watchdog_exit)
+        t.daemon = True
+        t.start()
+        _wd_timer_holder[0] = t
+    _arm_watchdog()
 
 peers_dir = os.environ.get("PEERS_DIR", "")
 scope_dir = os.path.dirname(peers_dir)
@@ -524,8 +564,9 @@ except Exception:
 
 for line in sys.stdin:
     # Any inbound line — real message, heartbeat, whatever — means the
-    # channel is alive. Reset the watchdog.
-    signal.alarm(WATCHDOG_SEC)
+    # channel is alive. Reset the watchdog (POSIX: re-arms SIGALRM;
+    # Windows: cancels + restarts threading.Timer).
+    _arm_watchdog()
     line = line.strip()
     if not line: continue
     offset_counter += 1

--- a/airc
+++ b/airc
@@ -3226,12 +3226,168 @@ cmd_daemon_log() {
 }
 
 cmd_doctor() {
-  # Self-diagnose: run the bundled integration test script.
-  # Install resolves it under AIRC_DIR/test; fall back to a sibling dir
-  # when running from a git checkout.
+  # Two modes:
+  #   airc doctor           -- environment health check (default).
+  #                            Probes each prereq and prints the exact
+  #                            install command for whichever package
+  #                            manager this platform uses, so any AI
+  #                            reading the output can `proactively fix
+  #                            recoverable issues` (per /doctor SKILL.md).
+  #   airc doctor --tests   -- run the integration test suite (the
+  #   airc doctor tests        prior default behavior; aliased on the
+  #                            dispatch via `tests|test`).
+  case "${1:-}" in
+    --tests|-t|tests|test|run|suite) shift; _doctor_run_tests "$@"; return ;;
+  esac
+
+  echo ""
+  echo "  airc doctor -- environment health"
+  echo "  --------------------------------"
+  echo ""
+  local issues=0
+
+  # Detect the platform's package manager so we can emit concrete fix
+  # commands. Same shape as install.sh's ensure_prereqs.
+  local mgr; mgr=$(_doctor_detect_pkgmgr)
+
+  _doctor_probe "git"          "$mgr" "VCS for clone/update" || issues=$((issues+1))
+  _doctor_probe "gh"           "$mgr" "Gist substrate (room discovery)" || issues=$((issues+1))
+  _doctor_probe_gh_auth                                             || issues=$((issues+1))
+  _doctor_probe "openssl"      "$mgr" "Ed25519 sign keys + signing"     || issues=$((issues+1))
+  _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"     || issues=$((issues+1))
+  _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"     || issues=$((issues+1))
+  _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"    || issues=$((issues+1))
+  _doctor_probe_tailscale "$mgr"  # optional, never increments issues
+
+  echo ""
+  echo "  Scope:"
+  echo "    AIRC_HOME = $AIRC_WRITE_DIR"
+  if [ -f "$CONFIG" ]; then
+    local _name; _name=$(get_name)
+    local _ht;   _ht=$(get_config_val host_target "")
+    if [ -n "$_ht" ]; then
+      echo "    Identity: $_name (joiner of $_ht)"
+    else
+      echo "    Identity: $_name (host or unconnected)"
+    fi
+  else
+    echo "    Identity: not initialized (run 'airc join' to set up)"
+  fi
+
+  echo ""
+  if [ "$issues" -eq 0 ]; then
+    echo "  All required prereqs present. Behavioral suite:  airc doctor --tests"
+  else
+    echo "  $issues prereq(s) missing -- see fix lines above."
+    echo "  Fastest path: re-run install.sh (auto-installs via brew/apt/dnf/pacman/apk):"
+    echo "    curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash"
+  fi
+  echo ""
+}
+
+_doctor_detect_pkgmgr() {
+  case "$(uname -s 2>/dev/null)" in
+    Darwin)
+      command -v brew >/dev/null 2>&1 && { echo "brew"; return; }
+      echo "brew-missing"; return ;;
+    Linux)
+      command -v apt-get >/dev/null 2>&1 && { echo "apt";    return; }
+      command -v dnf     >/dev/null 2>&1 && { echo "dnf";    return; }
+      command -v pacman  >/dev/null 2>&1 && { echo "pacman"; return; }
+      command -v apk     >/dev/null 2>&1 && { echo "apk";    return; }
+      ;;
+  esac
+  echo "unknown"
+}
+
+# Map a generic prereq to the install command for the detected pkgmgr.
+# Empty string = we don't have a one-liner to suggest; emits a generic
+# pointer instead. Mirrors install.sh:pkgname_for + install_with_pkgmgr.
+_doctor_install_cmd_for() {
+  local mgr="$1" prereq="$2"
+  local pkg
+  case "$prereq" in
+    ssh|ssh-keygen)
+      case "$mgr" in
+        brew)   pkg="openssh" ;;
+        apt)    pkg="openssh-client" ;;
+        dnf)    pkg="openssh-clients" ;;
+        pacman) pkg="openssh" ;;
+        apk)    pkg="openssh-client" ;;
+      esac ;;
+    python3)
+      case "$mgr" in
+        pacman) pkg="python" ;;
+        *)      pkg="python3" ;;
+      esac ;;
+    *) pkg="$prereq" ;;
+  esac
+  case "$mgr" in
+    brew)   echo "brew install $pkg" ;;
+    apt)    echo "sudo apt-get install -y $pkg" ;;
+    dnf)    echo "sudo dnf install -y $pkg" ;;
+    pacman) echo "sudo pacman -S --needed $pkg" ;;
+    apk)    echo "sudo apk add $pkg" ;;
+    brew-missing)
+      echo "Install Homebrew first: /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\", then: brew install $pkg" ;;
+    *) echo "Install '$pkg' via your platform's package manager" ;;
+  esac
+}
+
+_doctor_probe() {
+  local cmd="$1" mgr="$2" purpose="$3"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    printf "  [ok] %s\n" "$cmd"
+    return 0
+  fi
+  local fix; fix=$(_doctor_install_cmd_for "$mgr" "$cmd")
+  printf "  [MISSING] %s -- %s\n" "$cmd" "$purpose"
+  printf "         Fix: %s\n" "$fix"
+  return 1
+}
+
+_doctor_probe_gh_auth() {
+  if ! command -v gh >/dev/null 2>&1; then
+    return 0  # already reported missing by the gh probe
+  fi
+  if gh auth status >/dev/null 2>&1; then
+    printf "  [ok] gh authenticated\n"
+    return 0
+  fi
+  printf "  [MISSING] gh authenticated (gist scope)\n"
+  printf "         Fix: gh auth login -s gist\n"
+  return 1
+}
+
+_doctor_probe_tailscale() {
+  local mgr="$1"
+  if command -v tailscale >/dev/null 2>&1; then
+    if tailscale status >/dev/null 2>&1; then
+      printf "  [ok] tailscale (optional) -- daemon up\n"
+    else
+      printf "  [info] tailscale (optional) -- installed but daemon not up\n"
+      printf "         Bring up:  tailscale up    (or skip; LAN mesh works without it)\n"
+    fi
+    return 0
+  fi
+  # Optional -- print the install hint but don't count toward issues.
+  local fix
+  case "$mgr" in
+    brew)         fix="brew install --cask tailscale" ;;
+    apt|dnf|pacman|apk) fix="curl -fsSL https://tailscale.com/install.sh | sh" ;;
+    *)            fix="https://tailscale.com/download" ;;
+  esac
+  printf "  [info] tailscale (optional) -- not installed; only needed for cross-LAN mesh\n"
+  printf "         Install: %s\n" "$fix"
+  return 0
+}
+
+_doctor_run_tests() {
+  # Behavioral suite -- the prior cmd_doctor entry point. Kept reachable
+  # via `airc doctor --tests` (or the `tests`/`test` aliases in dispatch)
+  # so existing CI / muscle memory still works.
   local script="${AIRC_DIR:-$HOME/.airc-src}/test/integration.sh"
   if [ ! -x "$script" ]; then
-    # Try next to the binary itself (dev checkout case)
     local self; self="$(realpath "$0" 2>/dev/null || echo "$0")"
     local here; here="$(dirname "$self")"
     [ -x "$here/test/integration.sh" ] && script="$here/test/integration.sh"
@@ -3283,7 +3439,8 @@ case "${1:-help}" in
   canary) shift; cmd_update --channel canary "$@" ;;
   logs)      shift; cmd_logs "$@" ;;
   status)    shift; cmd_status "$@" ;;
-  doctor|tests|test) shift; cmd_doctor "$@" ;;
+  doctor)            shift; cmd_doctor "$@" ;;
+  tests|test)        shift; _doctor_run_tests "$@" ;;
   daemon|autostart|service) shift; cmd_daemon "$@" ;;
   teardown|stop|flush) shift; cmd_teardown "$@" ;;
   disconnect|quit|leave|unbind) cmd_disconnect ;;

--- a/airc
+++ b/airc
@@ -8,6 +8,26 @@
 
 set -euo pipefail
 
+# Cross-platform Python invocation. macOS / Linux / WSL all ship `python3`
+# on PATH; Git Bash on Windows typically has `python` only (the launcher
+# from python.org). Resolve once at startup; every `python3 ...` invocation
+# downstream goes through this wrapper. Hard fail if neither is present
+# (we genuinely need Python — the inline heredocs for monitor formatting
+# and pair handshake are not yet ported to pure shell).
+if ! command -v python3 >/dev/null 2>&1; then
+  if command -v python >/dev/null 2>&1; then
+    # Define a wrapper function that callers see as `python3`.
+    python3() { command python "$@"; }
+    export -f python3 2>/dev/null || true
+  else
+    echo "ERROR: airc requires python3 (or python on Windows/Git Bash)." >&2
+    echo "  macOS:    brew install python3" >&2
+    echo "  Linux:    apt install python3 / dnf install python3" >&2
+    echo "  Windows:  install from python.org or Microsoft Store" >&2
+    exit 1
+  fi
+fi
+
 # One-time migration from pre-rename ~/.agent-relay → ~/.airc. Fires when user
 # is on vanilla defaults, the old dir exists as a real dir (not a symlink we
 # already left), and ~/.airc doesn't. Leaves a symlink ~/.agent-relay → ~/.airc
@@ -565,7 +585,7 @@ import sys, json, os, re, time, signal
 # the python exit; the bash probe is what decides whether the user
 # sees a notification.
 WATCHDOG_SEC = 150
-def _watchdog_exit(signum, frame):
+def _watchdog_exit(signum=None, frame=None):
     # Diagnostic to stderr only. The bash retry loop owns the
     # user-visible notification — it probes the host on fmt_exit=2
     # to decide whether silence means "healthy idle" (silent reset)
@@ -574,8 +594,28 @@ def _watchdog_exit(signum, frame):
     sys.stderr.write(f"[airc:monitor] no inbound in {WATCHDOG_SEC}s — exiting for probe\\n")
     sys.stderr.flush()
     os._exit(2)
-signal.signal(signal.SIGALRM, _watchdog_exit)
-signal.alarm(WATCHDOG_SEC)
+
+# Cross-platform watchdog. POSIX (mac/linux/WSL) gets signal.SIGALRM
+# which is cheaper (single-thread, kernel-armed). Windows Python has
+# no SIGALRM so we fall back to threading.Timer — same exit semantics,
+# slight overhead from the timer thread. Either way the fmt_exit=2
+# contract is preserved.
+try:
+    signal.signal(signal.SIGALRM, _watchdog_exit)
+    signal.alarm(WATCHDOG_SEC)
+    def _arm_watchdog():
+        signal.alarm(WATCHDOG_SEC)
+except (AttributeError, ValueError):
+    import threading
+    _wd_timer_holder = [None]
+    def _arm_watchdog():
+        if _wd_timer_holder[0] is not None:
+            _wd_timer_holder[0].cancel()
+        t = threading.Timer(WATCHDOG_SEC, _watchdog_exit)
+        t.daemon = True
+        t.start()
+        _wd_timer_holder[0] = t
+    _arm_watchdog()
 
 peers_dir = os.environ.get("PEERS_DIR", "")
 scope_dir = os.path.dirname(peers_dir)
@@ -677,8 +717,9 @@ except Exception:
 
 for line in sys.stdin:
     # Any inbound line — real message, heartbeat, whatever — means the
-    # channel is alive. Reset the watchdog.
-    signal.alarm(WATCHDOG_SEC)
+    # channel is alive. Reset the watchdog (POSIX: re-arms SIGALRM;
+    # Windows: cancels + restarts threading.Timer).
+    _arm_watchdog()
     line = line.strip()
     if not line: continue
     offset_counter += 1

--- a/airc.cmd
+++ b/airc.cmd
@@ -1,0 +1,9 @@
+@echo off
+REM airc.cmd -- Windows shim that lets `airc <verb>` work from any shell
+REM (PowerShell, cmd, Run dialog, Task Scheduler) by launching pwsh on
+REM the sibling airc.ps1 with all forwarded arguments.
+REM
+REM install.ps1 places this next to airc.ps1 in
+REM   %USERPROFILE%\AppData\Local\Programs\airc
+REM and adds that directory to user PATH.
+pwsh -NoLogo -NoProfile -File "%~dp0airc.ps1" %*

--- a/airc.ps1
+++ b/airc.ps1
@@ -2210,6 +2210,12 @@ try {
         default { Die "Unknown command: $cmd. Try: airc help" }
     }
 } catch {
-    Write-Error $_
+    # Surface the real error -- `Write-Error $_` confuses the parser with
+    # ambiguous parameter binding when $_ is an ErrorRecord (its
+    # properties collide with -OutVariable / -OutBuffer). Use the host's
+    # error stream directly with the rendered message + script location.
+    $errMsg = "{0}`n  at {1}:{2}" -f $_.Exception.Message,
+        $_.InvocationInfo.ScriptName, $_.InvocationInfo.ScriptLineNumber
+    [Console]::Error.WriteLine($errMsg)
     exit 1
 }

--- a/airc.ps1
+++ b/airc.ps1
@@ -362,11 +362,16 @@ function Resolve-OpenSSL {
 $script:OpenSSLBin = Resolve-OpenSSL
 
 function Invoke-OpenSSL {
-    param([Parameter(ValueFromRemainingArguments)] [string[]] $SslArgs)
+    # NOTE: deliberately NO param() block. Adding [Parameter()] makes this
+    # an advanced function and PowerShell injects common parameters
+    # (-OutBuffer / -OutVariable / etc). Then any openssl flag that has
+    # 'out' as a prefix -- e.g. `-out file.pem` -- gets parsed as a
+    # PS parameter and fails with the ambiguity error before reaching
+    # openssl.exe at all. Use $args to collect verbatim.
     if (-not $script:OpenSSLBin) {
         Die "openssl not found. Install Git for Windows (it bundles openssl) or run 'airc doctor'."
     }
-    & $script:OpenSSLBin @SslArgs
+    & $script:OpenSSLBin @args
 }
 
 function Sign-Message {

--- a/airc.ps1
+++ b/airc.ps1
@@ -713,6 +713,25 @@ for line in sys.stdin:
             import subprocess, sys
             try:
                 pong_msg = f"[PONG:{ping_id}]"
+                # Pass AIRC_HOME explicitly so the subprocess's scope
+                # detection lands on THIS scope no matter what cwd it
+                # inherits through cmd.exe -> pwsh -> airc.ps1. Without
+                # this, cwd ambiguity (Python -> cmd -> .cmd shim ->
+                # pwsh) can land the spawned `airc send` in a sibling
+                # scope where there's no host_target -- it then writes
+                # only to a local mirror and never reaches the wire.
+                child_env = os.environ.copy()
+                child_env["AIRC_HOME"] = scope_dir
+                # Capture auto-pong stderr to a per-scope log so we can
+                # diagnose silent failures of the subprocess chain
+                # (cmd.exe -> airc.cmd -> pwsh -> airc.ps1 send). Without
+                # this, every link in the chain swallows errors with
+                # nowhere to surface them. Append-mode so consecutive
+                # pings accumulate. Tail with: airc auto-pong-log
+                pong_log = os.path.join(scope_dir, "auto_pong.log")
+                pong_err = open(pong_log, "ab")
+                pong_err.write(f"--- pong attempt for {fr} ping {ping_id} ---\n".encode())
+                pong_err.flush()
                 if sys.platform == "win32":
                     # Windows CreateProcess can't run .cmd files directly
                     # when shell=False -- it only handles real PE binaries.
@@ -721,16 +740,18 @@ for line in sys.stdin:
                     # every argv element (peer name + uuid).
                     subprocess.Popen(
                         ["cmd.exe", "/c", airc_cmd, "send", f"@{fr}", pong_msg],
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
+                        stdout=pong_err,
+                        stderr=pong_err,
                         shell=False,
+                        env=child_env,
                     )
                 else:
                     subprocess.Popen(
                         [airc_cmd, "send", f"@{fr}", pong_msg],
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
+                        stdout=pong_err,
+                        stderr=pong_err,
                         shell=False,
+                        env=child_env,
                     )
             except Exception:
                 pass

--- a/airc.ps1
+++ b/airc.ps1
@@ -441,10 +441,16 @@ function Init-Identity {
     $sshKey    = Join-Path $IDENTITY_DIR 'ssh_key'
     $sshKeyPub = "$sshKey.pub"
     if (-not (Test-Path $sshKey)) {
-        & ssh-keygen -t ed25519 -f $sshKey -N '""' -C "airc-$Name" -q 2>$null
-        # Some Windows ssh-keygen builds reject -N '""' literally; retry with empty arg.
+        # ssh-keygen -N '' = empty passphrase (no encryption on the key).
+        # Single-quoted empty string in PS is a true zero-length string and
+        # survives intact through .NET native-command marshaling. The prior
+        # `-N '""'` form passed the literal two-character string `""` as the
+        # passphrase on some Windows shells, producing a key that ssh.exe
+        # could not use without prompting -- exact symptom: "auth failed"
+        # at use time despite the key being in authorized_keys.
+        & ssh-keygen -t ed25519 -f $sshKey -N '' -C "airc-$Name" -q
         if (-not (Test-Path $sshKey)) {
-            & ssh-keygen -t ed25519 -f $sshKey -N "" -C "airc-$Name" -q
+            Die "ssh-keygen failed to create $sshKey"
         }
         & icacls $sshKey /inheritance:r /grant:r "$($env:USERNAME):F" 2>$null | Out-Null
         $sshDir = Join-Path $env:USERPROFILE '.ssh'

--- a/airc.ps1
+++ b/airc.ps1
@@ -1736,6 +1736,12 @@ function Invoke-Connect {
                 }
             }
             Write-AircPidFile -Pids @($PID)
+            # Same banner the fresh-pair / host paths emit. Without this,
+            # the resume path drops straight into the monitor with no
+            # console signal that anything is up -- looks indistinguishable
+            # from a hung process to anyone watching stdout. Joel
+            # 2026-04-24: parity gap noted across all implementations.
+            Write-Host '  Monitoring for messages...'
             Start-AircMonitor -MyName (Get-Name)
             return
         }

--- a/airc.ps1
+++ b/airc.ps1
@@ -821,7 +821,13 @@ function Start-AircMonitor {
                 '-o', 'ServerAliveCountMax=3',
                 $hostTarget, $remoteCmd
             )
-            & ssh @tailArgs 2>$null `
+            # Capture ssh stderr to a per-scope log so we can diagnose
+            # silent failures of the long-running tail. Without this,
+            # `2>$null` swallowed every error and the formatter just
+            # never received input -- looks identical to a healthy idle
+            # channel for 150s, then watchdog fires and we loop.
+            $sshErr = Join-Path $AIRC_WRITE_DIR 'monitor_ssh.log'
+            & ssh @tailArgs 2>$sshErr `
               | & $script:PythonResolved.Bin @($script:PythonResolved.Args + @('-u', '-c', $script:MonitorFormatterPython))
             $fmtExit = $LASTEXITCODE
             $cycleLifetime = ((Get-Date) - $cycleStart).TotalSeconds

--- a/airc.ps1
+++ b/airc.ps1
@@ -37,7 +37,32 @@ function Resolve-PythonBin {
         return @{ Bin = $cmd.Source; Args = @() }
     }
     $py = Get-Command 'py' -ErrorAction SilentlyContinue
-    if ($py) { return @{ Bin = $py.Source; Args = @('-3') } }
+    if ($py -and $py.Source -notlike '*\WindowsApps\*') {
+        return @{ Bin = $py.Source; Args = @('-3') }
+    }
+    # Well-known install-location fallback. winget's Python.Python.3.12
+    # lands at $env:LOCALAPPDATA\Programs\Python\Python3XX\python.exe;
+    # python.org Program Files installer at C:\Program Files\Python3XX\.
+    # Both are added to User PATH by the installer, but a process launched
+    # with a snapshotted PATH (or before the install) won't see them.
+    # Same defensive pattern as Resolve-OpenSSL / Resolve-TailscaleBin.
+    # Without this, airc.ps1 in such a process hits `& $null @(...)` in
+    # the monitor pipeline and dies with "expression after '&' must be
+    # a command."
+    $candidates = @()
+    foreach ($root in @(
+        (Join-Path $env:LOCALAPPDATA 'Programs\Python'),
+        $env:ProgramFiles,
+        ${env:ProgramFiles(x86)}
+    )) {
+        if ($root -and (Test-Path $root)) {
+            $candidates += Get-ChildItem -Path $root -Filter 'Python3*' -Directory -ErrorAction SilentlyContinue `
+                         | ForEach-Object { Join-Path $_.FullName 'python.exe' }
+        }
+    }
+    foreach ($p in $candidates) {
+        if ($p -and (Test-Path $p)) { return @{ Bin = $p; Args = @() } }
+    }
     return $null
 }
 $script:PythonResolved = Resolve-PythonBin
@@ -787,6 +812,14 @@ function Invoke-MonitorFormatter {
 # Mirrors bash monitor() closely.
 function Start-AircMonitor {
     param([string]$MyName)
+    if (-not $script:PythonResolved) {
+        Die @"
+Python 3 is required for the monitor formatter but was not found.
+Run 'airc doctor' for install instructions, or:
+  winget install --id Python.Python.3.12
+After install, open a NEW terminal so PATH refreshes (or re-run airc).
+"@
+    }
     $hostTarget = Get-ConfigVal -Key 'host_target' -Default ''
     $offsetFile = Join-Path $AIRC_WRITE_DIR 'monitor_offset'
 

--- a/airc.ps1
+++ b/airc.ps1
@@ -793,16 +793,32 @@ for line in sys.stdin:
         continue
     if pong_match:
         continue
-    PREVIEW_LEN = 100
-    msg_preview = msg.replace("\n", " ").strip()
-    if len(msg_preview) > PREVIEW_LEN:
-        msg_preview = msg_preview[:PREVIEW_LEN] + "..."
-    if fr in ("airc", "sys"):
-        print(f"airc: [#{room_name}] {msg_preview}", flush=True)
-    elif to and to not in ("all", ""):
-        print(f"airc: [#{room_name}] {fr} -> {to}: {msg_preview}", flush=True)
-    else:
-        print(f"airc: [#{room_name}] {fr}: {msg_preview}", flush=True)
+    # No length cap -- consumers (Claude Code Monitor, Codex, log
+    # tailers, etc.) decide their own display truncation. Truncating in
+    # the substrate forced everyone downstream to fall back to
+    # `airc logs` to see the actual content (anti-pattern Joel called
+    # out 2026-04-24). Newlines collapsed to spaces so each emitted
+    # event is still a single line, but full body always reaches the
+    # consumer.
+    msg_one_line = (msg or "").replace("\n", " ").replace("\r", " ").strip()
+    try:
+        if fr in ("airc", "sys"):
+            print(f"airc: [#{room_name}] {msg_one_line}", flush=True)
+        elif to and to not in ("all", ""):
+            print(f"airc: [#{room_name}] {fr} -> {to}: {msg_one_line}", flush=True)
+        else:
+            print(f"airc: [#{room_name}] {fr}: {msg_one_line}", flush=True)
+    except Exception as e:
+        # Belt-and-suspenders -- the UTF-8 reconfigure at the top should
+        # already neutralize encoding errors, but if some other I/O
+        # error fires we never want one bad message to take the whole
+        # monitor down. Surface to stderr (which the PS retry loop
+        # captures) and keep going.
+        try:
+            sys.stderr.write(f"[airc:formatter] skipped one line: {e}\n")
+            sys.stderr.flush()
+        except Exception:
+            pass
 '@
 
 # Run the formatter against a stream of inbound JSONL lines on its stdin.
@@ -1529,9 +1545,23 @@ function Invoke-Send {
     $peerName = 'all'
     $msg = ''
     if ($first.StartsWith('@')) {
-        $peerName = $first.Substring(1)
-        if ($Argv.Count -lt 2) { Die 'Usage: airc msg @peer <message>' }
-        $msg = ($Argv[1..($Argv.Count - 1)] -join ' ')
+        # Two valid shapes:
+        #   airc msg @peer body words ...    (shell-split: 2+ args)
+        #   airc msg "@peer body words ..."  (whole thing one arg, e.g.
+        #                                     when called via cmd.exe
+        #                                     wrapper or with a quoted
+        #                                     argument from PowerShell)
+        # Detect the single-arg case by checking whether $first contains
+        # whitespace; split on the first run of whitespace if so.
+        if ($Argv.Count -ge 2) {
+            $peerName = $first.Substring(1)
+            $msg = ($Argv[1..($Argv.Count - 1)] -join ' ')
+        } elseif ($first -match '^@(\S+)\s+(.+)$') {
+            $peerName = $matches[1]
+            $msg = $matches[2]
+        } else {
+            Die 'Usage: airc msg @peer <message>'
+        }
     } else {
         $msg = ($Argv -join ' ')
     }

--- a/airc.ps1
+++ b/airc.ps1
@@ -399,9 +399,9 @@ function Invoke-AircSsh {
         '-o','ServerAliveInterval=30'
     )
     if (Test-Path $sshKey) {
-        & ssh '-i', $sshKey, @opts, @SshArgs
+        & ssh '-i' $sshKey @opts @SshArgs
     } else {
-        & ssh @opts, @SshArgs
+        & ssh @opts @SshArgs
     }
 }
 

--- a/airc.ps1
+++ b/airc.ps1
@@ -1431,7 +1431,11 @@ function Invoke-Send {
                 if ($stderrRaw -match '(?i)permission denied|publickey|host key verification|authentication fail|identification has changed|no supported authentication') {
                     $isAuth = $true
                 }
-                $stderrLine = ($stderrRaw -replace "`r?`n", ' ').Substring(0, [Math]::Min(300, $stderrRaw.Length))
+                # Defensive trim: Substring(0, N) with N > string length throws
+                # ArgumentOutOfRangeException. Use length of the *replaced* string
+                # (newlines collapsed shrinks it) and clamp to 300.
+                $stderrFlat = if ($stderrRaw) { ($stderrRaw -replace "`r?`n", ' ').Trim() } else { '' }
+                $stderrLine = if ($stderrFlat.Length -gt 300) { $stderrFlat.Substring(0, 300) } else { $stderrFlat }
                 if ($isAuth) {
                     $marker = ([ordered]@{ from='airc'; ts=(Get-Timestamp); msg="[AUTH FAILED to $peerName - repair required, NOT queued] $stderrLine" } | ConvertTo-Json -Compress)
                     Add-Content -Path $MESSAGES -Value $marker

--- a/airc.ps1
+++ b/airc.ps1
@@ -499,9 +499,9 @@ function Get-FreeAircPort {
 # Bash uses pgrep -P + kill. Windows: taskkill /T /F walks the process
 # tree (children of children too) and force-kills. One call.
 function Stop-ProcessTree {
-    param([int]$Pid)
-    if (-not $Pid -or $Pid -le 0) { return }
-    & taskkill /PID $Pid /T /F 2>$null | Out-Null
+    param([int]$ProcId)
+    if (-not $ProcId -or $ProcId -le 0) { return }
+    & taskkill /PID $ProcId /T /F 2>$null | Out-Null
 }
 
 # -- PID file management ------------------------------------------------
@@ -1295,7 +1295,7 @@ function Invoke-Teardown {
         }
         foreach ($p in $procs) {
             Write-Host "  --all: killing PID $($p.ProcessId) ($($p.Name))"
-            Stop-ProcessTree -Pid $p.ProcessId
+            Stop-ProcessTree -ProcId $p.ProcessId
             $killed = $true
         }
         if (-not $killed) { Write-Host '  --all: no machine-wide airc processes to kill.' }
@@ -1310,7 +1310,7 @@ function Invoke-Teardown {
         }
         if ($alivePids.Count -gt 0) {
             Write-Host "  killing scope $AIRC_WRITE_DIR : $($alivePids -join ' ')"
-            foreach ($p in $alivePids) { Stop-ProcessTree -Pid $p }
+            foreach ($p in $alivePids) { Stop-ProcessTree -ProcId $p }
             $killed = $true
         }
         Remove-Item (Join-Path $AIRC_WRITE_DIR 'airc.pid') -Force -ErrorAction SilentlyContinue
@@ -1328,7 +1328,7 @@ function Invoke-Teardown {
             # Heuristic: only kill if the owner is pwsh/python/airc-related.
             if ($owner.Name -match '^(pwsh|python|powershell)$') {
                 Write-Host "  freeing stale port $port (PID $($c.OwningProcess) - $($owner.Name))"
-                Stop-ProcessTree -Pid $c.OwningProcess
+                Stop-ProcessTree -ProcId $c.OwningProcess
                 $killed = $true
             }
         }
@@ -1690,7 +1690,7 @@ function Invoke-Connect {
     if ($stalePids.Count -gt 0) {
         foreach ($p in $stalePids) {
             if (Get-Process -Id $p -ErrorAction SilentlyContinue) {
-                Stop-ProcessTree -Pid $p
+                Stop-ProcessTree -ProcId $p
             }
         }
         Remove-Item (Join-Path $AIRC_WRITE_DIR 'airc.pid') -Force -ErrorAction SilentlyContinue

--- a/airc.ps1
+++ b/airc.ps1
@@ -595,7 +595,17 @@ function Get-GistContent {
 # verbatim from the bash version, with one Windows tweak: the auto-pong
 # subprocess uses the airc.cmd shim path (passed via env var).
 $script:MonitorFormatterPython = @'
-import sys, json, os, re, time, signal
+import sys, json, os, re, time, signal, io
+# Force UTF-8 on stdout/stderr regardless of Windows locale (default cp1252
+# can't encode emoji + a lot of unicode that peers post). errors='replace'
+# guarantees the formatter never crashes on a single bad codepoint and
+# kill the monitor pipeline. Reconfigure once at startup.
+try:
+    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+    sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+except Exception:
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace', line_buffering=True)
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', errors='replace', line_buffering=True)
 
 WATCHDOG_SEC = 150
 def _watchdog_exit(signum=None, frame=None):
@@ -897,6 +907,11 @@ After install, open a NEW terminal so PATH refreshes (or re-run airc).
             # Pass through PEERS_DIR + AIRC_CMD_PATH explicitly.
             $pyInfo.EnvironmentVariables['PEERS_DIR']     = $env:PEERS_DIR
             $pyInfo.EnvironmentVariables['AIRC_CMD_PATH'] = $env:AIRC_CMD_PATH
+            # Force UTF-8 IO so peers' emoji / non-cp1252 chars can't crash
+            # the formatter. Belt-and-suspenders alongside the
+            # sys.stdout.reconfigure call inside the heredoc.
+            $pyInfo.EnvironmentVariables['PYTHONIOENCODING'] = 'utf-8'
+            $pyInfo.EnvironmentVariables['PYTHONUTF8']       = '1'
             $pyProc = [System.Diagnostics.Process]::new()
             $pyProc.StartInfo = $pyInfo
             [void]$pyProc.Start()

--- a/airc.ps1
+++ b/airc.ps1
@@ -855,14 +855,74 @@ After install, open a NEW terminal so PATH refreshes (or re-run airc).
                 $hostTarget, $remoteCmd
             )
             # Capture ssh stderr to a per-scope log so we can diagnose
-            # silent failures of the long-running tail. Without this,
-            # `2>$null` swallowed every error and the formatter just
-            # never received input -- looks identical to a healthy idle
-            # channel for 150s, then watchdog fires and we loop.
+            # silent failures of the long-running tail.
             $sshErr = Join-Path $AIRC_WRITE_DIR 'monitor_ssh.log'
-            & ssh @tailArgs 2>$sshErr `
-              | & $script:PythonResolved.Bin @($script:PythonResolved.Args + @('-u', '-c', $script:MonitorFormatterPython))
-            $fmtExit = $LASTEXITCODE
+
+            # PowerShell's native-command `|` pipeline buffers text between
+            # ssh.exe and python.exe in a way that never flushes on a
+            # long-running stream producer -- the formatter received ZERO
+            # stdin bytes for 150s while ssh's stdout had plenty (host was
+            # posting every few seconds). Watchdog fired every cycle and
+            # nothing ever got mirrored or auto-ponged.
+            #
+            # Replace the PS pipeline with explicit [Diagnostics.Process]
+            # handles + an async stream copy. ssh stdout reads go straight
+            # to python stdin with no PS/StringObject layer in between.
+            $sshInfo = [System.Diagnostics.ProcessStartInfo]::new('ssh.exe')
+            foreach ($a in $tailArgs) { [void]$sshInfo.ArgumentList.Add($a) }
+            $sshInfo.RedirectStandardOutput = $true
+            $sshInfo.RedirectStandardError  = $true
+            $sshInfo.UseShellExecute        = $false
+            $sshInfo.CreateNoWindow         = $true
+            $sshProc = [System.Diagnostics.Process]::new()
+            $sshProc.StartInfo = $sshInfo
+            [void]$sshProc.Start()
+
+            # Formatter lives on disk as a .py file so we can pass it as
+            # argv (cleaner than -c with a multi-line heredoc that PS
+            # might re-escape through CreateProcess).
+            $pyFile = Join-Path $AIRC_WRITE_DIR 'monitor_formatter.py'
+            [System.IO.File]::WriteAllText(
+                $pyFile,
+                $script:MonitorFormatterPython,
+                [System.Text.UTF8Encoding]::new($false)
+            )
+            $pyInfo = [System.Diagnostics.ProcessStartInfo]::new($script:PythonResolved.Bin)
+            foreach ($pa in ($script:PythonResolved.Args + @('-u', $pyFile))) {
+                [void]$pyInfo.ArgumentList.Add($pa)
+            }
+            $pyInfo.RedirectStandardInput = $true
+            $pyInfo.UseShellExecute       = $false
+            $pyInfo.CreateNoWindow        = $true
+            # Pass through PEERS_DIR + AIRC_CMD_PATH explicitly.
+            $pyInfo.EnvironmentVariables['PEERS_DIR']     = $env:PEERS_DIR
+            $pyInfo.EnvironmentVariables['AIRC_CMD_PATH'] = $env:AIRC_CMD_PATH
+            $pyProc = [System.Diagnostics.Process]::new()
+            $pyProc.StartInfo = $pyInfo
+            [void]$pyProc.Start()
+
+            # Async-forward ssh stderr to the log file (non-blocking).
+            $sshErrStream = [System.IO.File]::Open($sshErr, [System.IO.FileMode]::Create)
+            $sshErrTask = $sshProc.StandardError.BaseStream.CopyToAsync($sshErrStream)
+
+            # Pump ssh stdout -> python stdin synchronously; this is the
+            # hot path for every inbound line from the remote tail.
+            try {
+                while ($true) {
+                    $line = $sshProc.StandardOutput.ReadLine()
+                    if ($null -eq $line) { break }
+                    $pyProc.StandardInput.WriteLine($line)
+                    $pyProc.StandardInput.Flush()
+                }
+            } catch { } finally {
+                try { $pyProc.StandardInput.Close() } catch { }
+            }
+            $pyProc.WaitForExit()
+            $fmtExit = $pyProc.ExitCode
+            try { $sshProc.WaitForExit(1000) | Out-Null } catch { }
+            if (-not $sshProc.HasExited) { try { $sshProc.Kill() } catch { } }
+            try { $sshErrTask.Wait(1000) | Out-Null } catch { }
+            try { $sshErrStream.Close() } catch { }
             $cycleLifetime = ((Get-Date) - $cycleStart).TotalSeconds
 
             if ($fmtExit -eq 2) {

--- a/airc.ps1
+++ b/airc.ps1
@@ -1,0 +1,174 @@
+#!/usr/bin/env pwsh
+# airc.ps1 — Windows-native PowerShell port of `airc` (the bash original)
+#
+# Architecture (see project memory project_airc_pure_shell_per_platform.md):
+#   - Two pure-shell implementations of the same protocol:
+#     - `airc` (bash + inline Python heredocs) — POSIX (macOS, Linux, WSL)
+#     - `airc.ps1` (PowerShell)                 — Windows native
+#   - Skills (slash commands) are platform-blind. They invoke the verb;
+#     the install layer ensures the right binary is on PATH.
+#   - Drift mitigation: tests/integration.ps1 (parallel to test/integration.sh)
+#     runs the same scenario suite against this implementation.
+#
+# Hard requirements on Windows:
+#   - PowerShell 7+ (Core). Windows PowerShell 5.1 lacks several features
+#     this script uses (ternary, null-coalesce, modern threading).
+#   - OpenSSH client + ssh-keygen + ssh-agent (built into Windows 10+).
+#   - gh CLI (https://cli.github.com/) authenticated with gist scope.
+#   - Tailscale Windows client (https://tailscale.com/download/windows).
+#   - Python 3 for the watchdog/formatter heredocs (until ported to pure PS).
+#
+# NOT supported (deliberately, per Joel 2026-04-24):
+#   - mingw / MSYS2 / Git Bash on Windows. Use the bash `airc` under WSL,
+#     or this airc.ps1 from PowerShell. No third path.
+#
+# Reference: every command stub below carries (bash:LINE) pointing at the
+# corresponding implementation in the bash original. Use that for parity
+# checks when porting each command.
+
+#Requires -Version 7.0
+
+$ErrorActionPreference = 'Stop'
+
+# ── Constants & scope detection (bash:1-100) ───────────────────────────────
+
+$AIRC_VERSION = '0.0.1-windows-port'
+
+function Get-AircScope {
+    # Parallel to bash detect_scope(). If we're inside a git repo,
+    # identity lives at <repo-root>/.airc/; otherwise $env:USERPROFILE/.airc/.
+    # Honors $env:AIRC_HOME override (used by tests + isolated scopes).
+    if ($env:AIRC_HOME) { return $env:AIRC_HOME }
+    try {
+        $gitRoot = git rev-parse --show-toplevel 2>$null
+        if ($LASTEXITCODE -eq 0 -and $gitRoot) {
+            return (Join-Path $gitRoot '.airc')
+        }
+    } catch { }
+    return (Join-Path $env:USERPROFILE '.airc')
+}
+
+$AIRC_WRITE_DIR = Get-AircScope
+$CONFIG       = Join-Path $AIRC_WRITE_DIR 'config.json'
+$IDENTITY_DIR = Join-Path $AIRC_WRITE_DIR 'identity'
+$PEERS_DIR    = Join-Path $AIRC_WRITE_DIR 'peers'
+$MESSAGES     = Join-Path $AIRC_WRITE_DIR 'messages.jsonl'
+
+# ── Config helpers (bash:get_config_val / set_config_val) ──────────────────
+
+function Get-ConfigVal {
+    param([string]$Key, [string]$Default = '')
+    if (-not (Test-Path $CONFIG)) { return $Default }
+    try {
+        $cfg = Get-Content $CONFIG -Raw | ConvertFrom-Json -AsHashtable
+        if ($cfg.ContainsKey($Key)) { return $cfg[$Key] }
+    } catch { }
+    return $Default
+}
+
+function Set-ConfigVal {
+    param([string]$Key, [string]$Value)
+    $cfg = @{}
+    if (Test-Path $CONFIG) {
+        try { $cfg = Get-Content $CONFIG -Raw | ConvertFrom-Json -AsHashtable } catch { $cfg = @{} }
+    }
+    $cfg[$Key] = $Value
+    $cfg | ConvertTo-Json -Depth 10 | Set-Content -Path $CONFIG -NoNewline
+}
+
+# ── Stub: cmd_version (bash:2942 cmd_version) ──────────────────────────────
+
+function Invoke-Version {
+    Write-Host "  airc.ps1 $AIRC_VERSION on PowerShell $($PSVersionTable.PSVersion)"
+    Write-Host "  install: $PSScriptRoot"
+}
+
+# ── Stub: cmd_help (bash:2993) ─────────────────────────────────────────────
+
+function Invoke-Help {
+    @"
+AIRC — Agentic Internet Relay Chat for AI peers
+(Windows-native PowerShell port; see also: airc bash for POSIX)
+
+Common verbs:
+  airc join                       # auto-#general (joins existing or hosts)
+  airc msg @<peer> <message>      # DM a peer (or omit @peer to broadcast)
+  airc peers                      # list paired peers
+  airc list                       # list open rooms on your gh account
+  airc nick <new-name>            # rename, broadcast to peers
+  airc part                       # leave the current room
+  airc quit                       # leave the mesh entirely
+
+PORT STATUS: see WINDOWS-PORT-STATUS.md for which commands are wired
+yet. This is a draft port; most commands are still stubs.
+"@ | Write-Host
+}
+
+# ── Command dispatch (bash:2967 case "${1:-help}" in) ──────────────────────
+
+$cmd = if ($args.Count -gt 0) { $args[0] } else { 'help' }
+$rest = if ($args.Count -gt 1) { $args[1..($args.Count-1)] } else { @() }
+
+switch ($cmd) {
+    # ── Info / help ──
+    'version' { Invoke-Version; break }
+    '--version' { Invoke-Version; break }
+    '-v' { Invoke-Version; break }
+    'help' { Invoke-Help; break }
+    '--help' { Invoke-Help; break }
+    '-h' { Invoke-Help; break }
+
+    # ── Connection lifecycle (TODO) ──
+    'connect' { Write-Error 'TODO: cmd_connect (bash:1100..1850) — host vs joiner branching, gh discovery, pair handshake, monitor formatter loop'; exit 99 }
+    'join'    { Write-Error 'TODO: alias of connect'; exit 99 }
+    'resume'  { Write-Error 'TODO: alias of connect (bash:resume)'; exit 99 }
+
+    # ── Messaging (TODO) ──
+    'msg'     { Write-Error 'TODO: cmd_send (bash:1800..1900) — local-mirror-first, ssh append to host messages.jsonl, queue on network fail'; exit 99 }
+    'send'    { Write-Error 'TODO: alias of msg'; exit 99 }
+
+    # ── Identity (TODO) ──
+    'nick'    { Write-Error 'TODO: cmd_rename — sanitize name, update config.json, broadcast [rename] marker'; exit 99 }
+    'rename'  { Write-Error 'TODO: alias of nick'; exit 99 }
+    'peers'   { Write-Error 'TODO: cmd_peers — list peer JSON files'; exit 99 }
+
+    # ── Room / discovery (TODO) ──
+    'list'    { Write-Error 'TODO: cmd_rooms (bash:cmd_rooms) — gh gist list filter by description'; exit 99 }
+    'rooms'   { Write-Error 'TODO: alias of list'; exit 99 }
+    'invite'  { Write-Error 'TODO: cmd_invite — print join string'; exit 99 }
+    'part'    { Write-Error 'TODO: cmd_part (bash:2037) — host: gh gist delete; joiner: local teardown only'; exit 99 }
+
+    # ── Lifecycle / disconnect (TODO) ──
+    'quit'    { Write-Error 'TODO: cmd_disconnect — teardown + strip host_target from config'; exit 99 }
+    'disconnect' { Write-Error 'TODO: alias of quit'; exit 99 }
+    'teardown' { Write-Error 'TODO: cmd_teardown — read airc.pid, kill PIDs, cleanup'; exit 99 }
+    'stop'    { Write-Error 'TODO: alias of teardown'; exit 99 }
+
+    # ── Diagnostic / utility (TODO) ──
+    'logs'    { Write-Error 'TODO: cmd_logs — tail messages.jsonl'; exit 99 }
+    'status'  { Write-Error 'TODO: cmd_status — identity + monitor PID + queue size'; exit 99 }
+    'doctor'  { Write-Error 'TODO: cmd_doctor — environment health + integration suite'; exit 99 }
+    'tests'   { Write-Error 'TODO: alias of doctor (test path only)'; exit 99 }
+    'ping'    { Write-Error 'TODO: cmd_ping (bash:cmd_ping) — round-trip liveness probe'; exit 99 }
+    'reminder' { Write-Error 'TODO: cmd_reminder — silence-nudge interval'; exit 99 }
+    'send-file' { Write-Error 'TODO: cmd_send_file — scp + airc msg notification'; exit 99 }
+    'repair'  { Write-Error 'TODO: cmd_repair — teardown --flush + reconnect'; exit 99 }
+
+    # ── Updates / channels (TODO) ──
+    'update'  { Write-Error 'TODO: cmd_update — git pull + re-run install.ps1'; exit 99 }
+    'upgrade' { Write-Error 'TODO: alias of update'; exit 99 }
+    'pull'    { Write-Error 'TODO: alias of update'; exit 99 }
+    'channel' { Write-Error 'TODO: cmd_channel — show/set release channel'; exit 99 }
+    'canary'  { Write-Error 'TODO: cmd_update --channel canary'; exit 99 }
+
+    # ── Daemon (TODO — Windows-specific: Task Scheduler not launchd/systemd) ──
+    'daemon'  { Write-Error 'TODO: cmd_daemon Windows port — register Task Scheduler task at logon (Action: Start pwsh.exe with -File airc.ps1 connect; Settings: RestartOnFailure, RunOnlyIfNetworkAvailable)'; exit 99 }
+
+    # ── Debug ──
+    'debug-scope' { Write-Host $AIRC_WRITE_DIR; break }
+
+    default {
+        Write-Error "Unknown command: $cmd. Try: airc help"
+        exit 2
+    }
+}

--- a/airc.ps1
+++ b/airc.ps1
@@ -710,17 +710,28 @@ for line in sys.stdin:
         ping_id = ping_match.group(1)
         my_current = current_name()
         if to == my_current:
-            import subprocess
+            import subprocess, sys
             try:
-                # Windows: airc.cmd is on PATH after install; absolute
-                # path passed via AIRC_CMD_PATH for robustness when PATH
-                # isn't inherited (daemons / scheduled tasks).
-                subprocess.Popen(
-                    [airc_cmd, "send", f"@{fr}", f"[PONG:{ping_id}]"],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    shell=False,
-                )
+                pong_msg = f"[PONG:{ping_id}]"
+                if sys.platform == "win32":
+                    # Windows CreateProcess can't run .cmd files directly
+                    # when shell=False -- it only handles real PE binaries.
+                    # Route through cmd.exe /c so airc.cmd interprets
+                    # correctly. shell=False is fine here since we control
+                    # every argv element (peer name + uuid).
+                    subprocess.Popen(
+                        ["cmd.exe", "/c", airc_cmd, "send", f"@{fr}", pong_msg],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        shell=False,
+                    )
+                else:
+                    subprocess.Popen(
+                        [airc_cmd, "send", f"@{fr}", pong_msg],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        shell=False,
+                    )
             except Exception:
                 pass
         continue

--- a/airc.ps1
+++ b/airc.ps1
@@ -1,51 +1,63 @@
 #!/usr/bin/env pwsh
-# airc.ps1 — Windows-native PowerShell port of `airc` (the bash original)
+# airc.ps1 - Windows-native PowerShell port of `airc` (the bash original).
 #
-# Architecture (see project memory project_airc_pure_shell_per_platform.md):
-#   - Two pure-shell implementations of the same protocol:
-#     - `airc` (bash + inline Python heredocs) — POSIX (macOS, Linux, WSL)
-#     - `airc.ps1` (PowerShell)                 — Windows native
-#   - Skills (slash commands) are platform-blind. They invoke the verb;
-#     the install layer ensures the right binary is on PATH.
-#   - Drift mitigation: tests/integration.ps1 (parallel to test/integration.sh)
-#     runs the same scenario suite against this implementation.
+# Single codebase per platform: bash `airc` for POSIX (macOS / Linux / WSL),
+# this airc.ps1 for native Windows. Same wire protocol, same on-disk layout,
+# same skills. They interoperate over SSH + gh gists.
 #
-# Hard requirements on Windows:
-#   - PowerShell 7+ (Core). Windows PowerShell 5.1 lacks several features
-#     this script uses (ternary, null-coalesce, modern threading).
-#   - OpenSSH client + ssh-keygen + ssh-agent (built into Windows 10+).
-#   - gh CLI (https://cli.github.com/) authenticated with gist scope.
-#   - Tailscale Windows client (https://tailscale.com/download/windows).
-#   - Python 3 for the watchdog/formatter heredocs (until ported to pure PS).
-#
-# NOT supported (deliberately, per Joel 2026-04-24):
-#   - mingw / MSYS2 / Git Bash on Windows. Use the bash `airc` under WSL,
-#     or this airc.ps1 from PowerShell. No third path.
-#
-# Reference: every command stub below carries (bash:LINE) pointing at the
-# corresponding implementation in the bash original. Use that for parity
-# checks when porting each command.
+# Hard requirements on Windows (install.ps1 sets all of these up):
+#   - PowerShell 7+        (#Requires -Version 7 enforces it)
+#   - Git for Windows      (provides openssl.exe + base toolchain)
+#   - OpenSSH client       (Windows Capability -- ssh, ssh-keygen)
+#   - Python 3             (monitor formatter heredoc + LAN-IP probe)
+#   - GitHub CLI (gh)      (gist room substrate)
+#   - Tailscale (optional) (peer addressing -- LAN/hostname fallback works)
 
 #Requires -Version 7.0
-
 $ErrorActionPreference = 'Stop'
 
-# ── Constants & scope detection (bash:1-100) ───────────────────────────────
+# -- Version -------------------------------------------------------------
+# Bash reports git short-sha + branch via `cmd_version`. We do the same.
+# Static fallback for users running outside a git checkout.
+$AIRC_FALLBACK_VERSION = '0.1.0-windows-port'
 
-$AIRC_VERSION = '0.0.1-windows-port'
+# -- Cross-platform Python invocation -----------------------------------
+# Bash wraps `python3` to fall through to `python` on Git-Bash-on-Windows.
+# We do the analogous probe up front and stash the chosen binary in
+# $script:Py for use by every formatter / heredoc invocation. Probe
+# order: python (skip the App Execution Alias stub), python3, py -3.
+function Resolve-PythonBin {
+    foreach ($name in @('python', 'python3')) {
+        $cmd = Get-Command $name -ErrorAction SilentlyContinue
+        if (-not $cmd) { continue }
+        # Skip the Microsoft Store stub at WindowsApps\python.exe -- it just
+        # prints "Python was not found; run without arguments to install"
+        # and exits 9009 on any actual invocation.
+        if ($cmd.Source -like '*\WindowsApps\*') { continue }
+        return @{ Bin = $cmd.Source; Args = @() }
+    }
+    $py = Get-Command 'py' -ErrorAction SilentlyContinue
+    if ($py) { return @{ Bin = $py.Source; Args = @('-3') } }
+    return $null
+}
+$script:PythonResolved = Resolve-PythonBin
 
+function Invoke-Python {
+    param([Parameter(ValueFromRemainingArguments)] [string[]] $PyArgs)
+    if (-not $script:PythonResolved) {
+        throw "Python 3 is required but was not found on PATH. Run 'airc doctor' for install instructions."
+    }
+    & $script:PythonResolved.Bin @($script:PythonResolved.Args + $PyArgs)
+}
+
+# -- Scope / paths ------------------------------------------------------
+# Bash: scope = $PWD/.airc (or AIRC_HOME override). Identity is tied to
+# the cwd you ran airc from. Multi-tab on one machine = different cwd =
+# different peer. We mirror exactly.
 function Get-AircScope {
-    # Parallel to bash detect_scope(). If we're inside a git repo,
-    # identity lives at <repo-root>/.airc/; otherwise $env:USERPROFILE/.airc/.
-    # Honors $env:AIRC_HOME override (used by tests + isolated scopes).
     if ($env:AIRC_HOME) { return $env:AIRC_HOME }
-    try {
-        $gitRoot = git rev-parse --show-toplevel 2>$null
-        if ($LASTEXITCODE -eq 0 -and $gitRoot) {
-            return (Join-Path $gitRoot '.airc')
-        }
-    } catch { }
-    return (Join-Path $env:USERPROFILE '.airc')
+    # Resolve symlinks so /tmp/x and /private/tmp/x are the same scope.
+    return (Join-Path (Resolve-Path .).Path '.airc')
 }
 
 $AIRC_WRITE_DIR = Get-AircScope
@@ -54,121 +66,2026 @@ $IDENTITY_DIR = Join-Path $AIRC_WRITE_DIR 'identity'
 $PEERS_DIR    = Join-Path $AIRC_WRITE_DIR 'peers'
 $MESSAGES     = Join-Path $AIRC_WRITE_DIR 'messages.jsonl'
 
-# ── Config helpers (bash:get_config_val / set_config_val) ──────────────────
+# -- Helpers -------------------------------------------------------------
+
+function Die($msg) {
+    Write-Error "ERROR: $msg" -ErrorAction Continue
+    exit 1
+}
+
+function Ensure-Init {
+    if (-not (Test-Path $CONFIG)) {
+        Die "Not initialized ($AIRC_WRITE_DIR). Run: airc connect"
+    }
+}
+
+function Get-Timestamp {
+    # ISO8601 UTC, second precision (matches bash `date -u +%Y-%m-%dT%H:%M:%SZ`)
+    return [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", [Globalization.CultureInfo]::InvariantCulture)
+}
+
+# -- Config (JSON read/write) -------------------------------------------
+# Bash uses inline Python for json.load/json.dump. PS has it native.
 
 function Get-ConfigVal {
     param([string]$Key, [string]$Default = '')
     if (-not (Test-Path $CONFIG)) { return $Default }
     try {
         $cfg = Get-Content $CONFIG -Raw | ConvertFrom-Json -AsHashtable
-        if ($cfg.ContainsKey($Key)) { return $cfg[$Key] }
+        if ($cfg.ContainsKey($Key)) { return [string]$cfg[$Key] }
     } catch { }
     return $Default
 }
 
 function Set-ConfigVal {
-    param([string]$Key, [string]$Value)
-    $cfg = @{}
+    param([Parameter(Mandatory)] [hashtable] $Updates)
+    $cfg = [ordered]@{}
     if (Test-Path $CONFIG) {
-        try { $cfg = Get-Content $CONFIG -Raw | ConvertFrom-Json -AsHashtable } catch { $cfg = @{} }
+        try {
+            $existing = Get-Content $CONFIG -Raw | ConvertFrom-Json -AsHashtable
+            foreach ($k in $existing.Keys) { $cfg[$k] = $existing[$k] }
+        } catch { }
     }
-    $cfg[$Key] = $Value
-    $cfg | ConvertTo-Json -Depth 10 | Set-Content -Path $CONFIG -NoNewline
+    foreach ($k in $Updates.Keys) {
+        if ($null -eq $Updates[$k]) { $cfg.Remove($k) } else { $cfg[$k] = $Updates[$k] }
+    }
+    $json = $cfg | ConvertTo-Json -Depth 10
+    [System.IO.File]::WriteAllText($CONFIG, $json, [Text.UTF8Encoding]::new($false))
 }
 
-# ── Stub: cmd_version (bash:2942 cmd_version) ──────────────────────────────
+function Get-Name {
+    return (Get-ConfigVal -Key 'name' -Default 'unknown')
+}
 
+# -- derive_name: cwd basename + 4-char hash ----------------------------
+function Derive-Name {
+    param([string]$Dir = $null)
+    if (-not $Dir) { $Dir = (Resolve-Path .).Path }
+    # Prefer git root basename when inside a repo (more meaningful than a
+    # subdir basename), but hash the actual cwd so subdirs still differ.
+    $baseDir = $Dir
+    try {
+        $gitRoot = (& git -C $Dir rev-parse --show-toplevel 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $gitRoot) { $baseDir = $gitRoot.Trim() }
+    } catch { }
+    $base = (Split-Path -Leaf $baseDir).ToLower()
+    $base = ($base -replace '[^a-z0-9-]', '-')
+    if ($base.Length -gt 12) { $base = $base.Substring(0, 12) }
+    if (-not $base) { $base = 'airc' }
+
+    $bytes = [Text.Encoding]::UTF8.GetBytes($Dir)
+    $sha   = [System.Security.Cryptography.SHA256]::Create().ComputeHash($bytes)
+    $hash  = ([BitConverter]::ToString($sha) -replace '-','').ToLower().Substring(0, 4)
+    return "$base-$hash"
+}
+
+# -- resolve_name: env > config > derive > hostname ---------------------
+function Resolve-AircName {
+    $name = ''
+    if ($env:AIRC_NAME) { $name = $env:AIRC_NAME }
+    elseif (Test-Path $CONFIG) { $name = Get-Name }
+    if ($name -like '-*') { $name = '' }   # reject flag-shaped (defensive)
+    if (-not $name -or $name -eq 'unknown') { $name = Derive-Name }
+    if (-not $name) {
+        $h = ([Environment]::MachineName).ToLower() -replace '[^a-z0-9-]', '-'
+        if ($h.Length -gt 16) { $h = $h.Substring(0, 16) }
+        $name = $h
+    }
+    return $name
+}
+
+# -- get_host: tailscale IP > LAN IP > hostname -------------------------
+# We use the same priority order as bash: tailscale first (works on the
+# whole tailnet), LAN IP next (no Tailscale required for same-LAN), then
+# hostname as last resort. AIRC_NO_TAILSCALE=1 forces past tailscale.
+function Get-AircHost {
+    $tsBin = $null
+    if ($env:AIRC_NO_TAILSCALE -ne '1') {
+        $cmd = Get-Command tailscale -ErrorAction SilentlyContinue
+        if ($cmd) { $tsBin = $cmd.Source }
+        elseif (Test-Path 'C:\Program Files\Tailscale\tailscale.exe') {
+            $tsBin = 'C:\Program Files\Tailscale\tailscale.exe'
+        }
+    }
+    if ($tsBin) {
+        try {
+            $tsIp = (& $tsBin ip -4 2>$null)
+            if ($LASTEXITCODE -eq 0 -and $tsIp) {
+                $tsIp = ($tsIp -split "`n")[0].Trim()
+                if ($tsIp) { return $tsIp }
+            }
+        } catch { }
+    }
+    # LAN IP via UDP-socket trick: connect a UDP socket to a public IP
+    # (no packet sent), then ask the local endpoint which interface IP
+    # the kernel chose. Same trick the bash version uses inline-Python
+    # for. We do it in pure .NET -- cheaper than spawning python.exe.
+    try {
+        $udp = [System.Net.Sockets.UdpClient]::new()
+        $udp.Client.ReceiveTimeout = 500
+        $udp.Connect('8.8.8.8', 80)
+        $localEp = [System.Net.IPEndPoint]$udp.Client.LocalEndPoint
+        $udp.Close()
+        $ip = $localEp.Address.ToString()
+        if ($ip -and -not $ip.StartsWith('127.') -and $ip -match '^\d+\.\d+\.\d+\.\d+$') {
+            return $ip
+        }
+    } catch { }
+    return [Environment]::MachineName.ToLower()
+}
+
+# -- humanhash: hex -> 4-word mnemonic ----------------------------------
+# Same dictionary + XOR-fold algorithm as the bash version. Bytes are
+# split into N segments; each segment XOR-folds to a single byte that
+# indexes the 256-word dictionary.
+$script:HumanhashDict = @(
+    'ack','alabama','alanine','alaska','alpha','angel','apart','april','arizona','arkansas',
+    'artist','asparagus','aspen','august','autumn','avocado','bacon','bakerloo','batman','beer',
+    'berlin','beryllium','black','blossom','blue','bluebird','bravo','bulldog','burger','butter',
+    'california','carbon','cardinal','carolina','carpet','cat','ceiling','cello','center','charlie',
+    'chicken','coffee','cola','cold','colorado','comet','connecticut','crazy','cup','dakota',
+    'december','delaware','delta','diet','don','double','early','earth','east','echo',
+    'edward','eight','eighteen','eleven','emma','enemy','equal','failed','fanta','fillet',
+    'finch','fish','five','fix','floor','florida','football','four','fourteen','foxtrot',
+    'freddie','friend','fruit','gee','georgia','glucose','golf','green','grey','hamper',
+    'happy','harry','hawaii','helium','high','hot','hotel','hydrogen','idaho','illinois',
+    'india','indigo','ink','iowa','island','item','jersey','jig','johnny','juliet',
+    'july','jupiter','kansas','kentucky','kilo','king','kitten','lactose','lake','lamp',
+    'lemon','leopard','lima','lion','lithium','london','louisiana','low','magazine','magnesium',
+    'maine','mango','march','mars','maryland','massachusetts','may','mexico','michigan','mike',
+    'minnesota','mirror','missouri','mobile','mockingbird','monkey','montana','moon','mountain','muppet',
+    'music','nebraska','neptune','network','nevada','nine','nineteen','nitrogen','north','november',
+    'nuts','october','ohio','oklahoma','one','orange','oranges','oregon','oscar','oven',
+    'oxygen','papa','paris','pasta','pennsylvania','pip','pizza','pluto','potato','princess',
+    'purple','quebec','queen','quiet','red','river','robert','robin','romeo','rugby',
+    'sad','salami','saturn','september','seven','seventeen','shade','sierra','single','sink',
+    'six','sixteen','skylark','snake','social','sodium','solar','south','spaghetti','speaker',
+    'spring','stairway','steak','stream','summer','sweet','table','tango','ten','tennessee',
+    'tennis','texas','thirteen','three','timing','triple','twelve','twenty','two','uncle',
+    'undress','uniform','uranus','utah','vegan','venus','vermont','victor','video','violet',
+    'virginia','washington','west','whiskey','white','william','winner','winter','wisconsin','wolfram',
+    'wyoming','xray','yankee','yellow','zebra','zulu'
+)
+
+function Get-Humanhash {
+    param([string]$HexInput, [int]$NWords = 4)
+    if (-not $HexInput) { return '' }
+    $bytes = New-Object 'System.Collections.Generic.List[int]'
+    for ($i = 0; $i -lt $HexInput.Length - 1; $i += 2) {
+        $bytes.Add([Convert]::ToInt32($HexInput.Substring($i, 2), 16))
+    }
+    $nBytes  = $bytes.Count
+    if ($nBytes -lt 1) { return '' }
+    $segSize = [Math]::Max(1, [int]($nBytes / $NWords))
+    $words = @()
+    for ($seg = 0; $seg -lt $NWords; $seg++) {
+        $acc   = 0
+        $start = $seg * $segSize
+        $end   = if ($seg -eq $NWords - 1) { $nBytes } else { $start + $segSize }
+        for ($j = $start; $j -lt $end -and $j -lt $nBytes; $j++) { $acc = $acc -bxor $bytes[$j] }
+        $words += $script:HumanhashDict[$acc]
+    }
+    return ($words -join '-')
+}
+
+# -- openssl wrapper (signing + Ed25519 keygen) -------------------------
+# Git for Windows ships openssl at usr/bin/openssl.exe. install.ps1
+# guarantees Git is present, but the bin dir isn't always on PATH for
+# users running Git via the "Git from PATH" minimal install. Probe the
+# usual locations.
+function Resolve-OpenSSL {
+    $cmd = Get-Command openssl -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    foreach ($p in @(
+        "$env:ProgramFiles\Git\usr\bin\openssl.exe",
+        "${env:ProgramFiles(x86)}\Git\usr\bin\openssl.exe",
+        "$env:LOCALAPPDATA\Programs\Git\usr\bin\openssl.exe"
+    )) {
+        if ($p -and (Test-Path $p)) { return $p }
+    }
+    return $null
+}
+$script:OpenSSLBin = Resolve-OpenSSL
+
+function Invoke-OpenSSL {
+    param([Parameter(ValueFromRemainingArguments)] [string[]] $SslArgs)
+    if (-not $script:OpenSSLBin) {
+        Die "openssl not found. Install Git for Windows (it bundles openssl) or run 'airc doctor'."
+    }
+    & $script:OpenSSLBin @SslArgs
+}
+
+function Sign-Message {
+    param([string]$Payload)
+    $tmpFile = [System.IO.Path]::GetTempFileName()
+    try {
+        [System.IO.File]::WriteAllText($tmpFile, $Payload, [Text.UTF8Encoding]::new($false))
+        $signedBytes = & $script:OpenSSLBin pkeyutl -sign -inkey (Join-Path $IDENTITY_DIR 'private.pem') -in $tmpFile 2>$null
+        # openssl writes binary to stdout; we want base64. Easiest: pipe into openssl base64.
+        # PS arg-for-arg: read raw bytes from stdout via -RawObject. Native call captures as
+        # System.Object[] of bytes only when -OutputType Byte; cleaner to base64 in a second
+        # openssl call.
+        $sigB64 = & $script:OpenSSLBin pkeyutl -sign -inkey (Join-Path $IDENTITY_DIR 'private.pem') -in $tmpFile 2>$null `
+                  | & $script:OpenSSLBin base64 -A 2>$null
+        return ($sigB64 -join '').Trim()
+    } finally {
+        Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# -- SSH wrapper --------------------------------------------------------
+# Same options as bash relay_ssh: per-identity key, accept-new host keys,
+# 10s connect timeout, 30s ServerAliveInterval to keep monitor tails alive.
+function Invoke-AircSsh {
+    param([Parameter(ValueFromRemainingArguments)] [string[]] $SshArgs)
+    $sshKey = Join-Path $IDENTITY_DIR 'ssh_key'
+    $opts = @(
+        '-o','StrictHostKeyChecking=accept-new',
+        '-o','ConnectTimeout=10',
+        '-o','ServerAliveInterval=30'
+    )
+    if (Test-Path $sshKey) {
+        & ssh '-i', $sshKey, @opts, @SshArgs
+    } else {
+        & ssh @opts, @SshArgs
+    }
+}
+
+# Path on the remote where the host's airc state lives (config, messages).
+function Get-RemoteHome {
+    $h = Get-ConfigVal -Key 'host_airc_home' -Default ''
+    if (-not $h) { $h = '$HOME/.airc' }
+    return $h
+}
+
+# -- Identity init: Ed25519 sign keypair + SSH keypair ------------------
+# Ed25519 sign keys for message signing (openssl pkeyutl -sign), separate
+# SSH keys for the wire (ssh -i). authorized_keys is appended so the
+# joiner can SSH to the host (and vice versa, since each peer also acts
+# as sshd via the OS's openssh server -- though for room/joiner mode the
+# host is the only one ssh'd-into).
+function Init-Identity {
+    param([string]$Name)
+    foreach ($d in @($AIRC_WRITE_DIR, $IDENTITY_DIR, $PEERS_DIR)) {
+        if (-not (Test-Path $d)) { New-Item -ItemType Directory -Force -Path $d | Out-Null }
+    }
+    $privPem = Join-Path $IDENTITY_DIR 'private.pem'
+    $pubPem  = Join-Path $IDENTITY_DIR 'public.pem'
+    if (-not (Test-Path $privPem)) {
+        Invoke-OpenSSL genpkey -algorithm Ed25519 -out $privPem 2>$null | Out-Null
+        Invoke-OpenSSL pkey -in $privPem -pubout -out $pubPem 2>$null | Out-Null
+        # chmod 600 equivalent on Windows is an ACL change. The Windows
+        # OpenSSH agent strict-perms check rejects keys that are world-
+        # readable. We tighten with icacls.
+        & icacls $privPem /inheritance:r /grant:r "$($env:USERNAME):F" 2>$null | Out-Null
+    }
+    $sshKey    = Join-Path $IDENTITY_DIR 'ssh_key'
+    $sshKeyPub = "$sshKey.pub"
+    if (-not (Test-Path $sshKey)) {
+        & ssh-keygen -t ed25519 -f $sshKey -N '""' -C "airc-$Name" -q 2>$null
+        # Some Windows ssh-keygen builds reject -N '""' literally; retry with empty arg.
+        if (-not (Test-Path $sshKey)) {
+            & ssh-keygen -t ed25519 -f $sshKey -N "" -C "airc-$Name" -q
+        }
+        & icacls $sshKey /inheritance:r /grant:r "$($env:USERNAME):F" 2>$null | Out-Null
+        $sshDir = Join-Path $env:USERPROFILE '.ssh'
+        if (-not (Test-Path $sshDir)) { New-Item -ItemType Directory -Force -Path $sshDir | Out-Null }
+        $authKeys = Join-Path $sshDir 'authorized_keys'
+        $pubLine = (Get-Content $sshKeyPub -Raw).Trim()
+        $existing = if (Test-Path $authKeys) { Get-Content $authKeys -Raw -ErrorAction SilentlyContinue } else { '' }
+        if ($existing -notlike "*$pubLine*") {
+            Add-Content -Path $authKeys -Value $pubLine
+        }
+    }
+    if (-not (Test-Path $MESSAGES)) { New-Item -ItemType File -Force -Path $MESSAGES | Out-Null }
+}
+
+# Append a key to authorized_keys idempotently. Used for both host->joiner
+# and joiner->host directions during the pair handshake.
+function Add-AuthorizedKey {
+    param([string]$PubKey)
+    if (-not $PubKey) { return }
+    $sshDir = Join-Path $env:USERPROFILE '.ssh'
+    if (-not (Test-Path $sshDir)) { New-Item -ItemType Directory -Force -Path $sshDir | Out-Null }
+    $authKeys = Join-Path $sshDir 'authorized_keys'
+    $existing = if (Test-Path $authKeys) { Get-Content $authKeys -Raw -ErrorAction SilentlyContinue } else { '' }
+    $trimmed = $PubKey.Trim()
+    if ($existing -notlike "*$trimmed*") {
+        Add-Content -Path $authKeys -Value $trimmed
+    }
+}
+
+# -- Port helpers -------------------------------------------------------
+
+function Test-PortListening {
+    param([int]$Port)
+    return [bool] (Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue)
+}
+
+function Get-FreeAircPort {
+    param([int]$Start = 7547, [int]$Range = 20)
+    for ($p = $Start; $p -lt $Start + $Range; $p++) {
+        if (-not (Test-PortListening -Port $p)) { return $p }
+    }
+    Die "No free port in range $Start-$($Start + $Range)."
+}
+
+# -- Process tree termination -------------------------------------------
+# Bash uses pgrep -P + kill. Windows: taskkill /T /F walks the process
+# tree (children of children too) and force-kills. One call.
+function Stop-ProcessTree {
+    param([int]$Pid)
+    if (-not $Pid -or $Pid -le 0) { return }
+    & taskkill /PID $Pid /T /F 2>$null | Out-Null
+}
+
+# -- PID file management ------------------------------------------------
+# Bash writes "$$ $PAIR_PID" (space-separated). We write one PID per line
+# (cleaner and parses identically: split on whitespace).
+function Write-AircPidFile {
+    param([int[]]$Pids)
+    $pidFile = Join-Path $AIRC_WRITE_DIR 'airc.pid'
+    Set-Content -Path $pidFile -Value ($Pids -join "`n")
+}
+
+function Read-AircPidFile {
+    $pidFile = Join-Path $AIRC_WRITE_DIR 'airc.pid'
+    if (-not (Test-Path $pidFile)) { return @() }
+    $content = Get-Content $pidFile -Raw -ErrorAction SilentlyContinue
+    if (-not $content) { return @() }
+    return $content -split '\s+' | Where-Object { $_ -match '^\d+$' } | ForEach-Object { [int]$_ }
+}
+
+# -- gh wrapper ---------------------------------------------------------
+function Test-GhAvailable {
+    return [bool] (Get-Command gh -ErrorAction SilentlyContinue)
+}
+
+function Get-GhGistList {
+    param([int]$Limit = 50)
+    if (-not (Test-GhAvailable)) { return @() }
+    # `gh gist list --limit N` outputs TAB-separated: id, description, files, visibility, updated
+    $raw = & gh gist list --limit $Limit 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $raw) { return @() }
+    $rows = @()
+    foreach ($line in $raw) {
+        if (-not $line) { continue }
+        $cols = $line -split "`t"
+        if ($cols.Count -lt 2) { continue }
+        $rows += [pscustomobject]@{
+            Id          = $cols[0]
+            Description = $cols[1]
+            Updated     = if ($cols.Count -gt 3) { $cols[3] } else { '' }
+        }
+    }
+    return $rows
+}
+
+# Fetch the content of the first file in a gist by ID. Uses `gh api` over
+# `gh gist view --raw` because the latter prepends the gist description
+# ("airc room: general\n\n{...}") which corrupts JSON parsing.
+function Get-GistContent {
+    param([string]$GistId)
+    if (-not (Test-GhAvailable)) { return $null }
+    $json = & gh api "gists/$GistId" 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $json) { return $null }
+    try {
+        $obj = $json | ConvertFrom-Json
+        $first = $obj.files.PSObject.Properties | Select-Object -First 1
+        if ($first) { return $first.Value.content }
+    } catch { return $null }
+    return $null
+}
+
+# -- monitor_formatter (embedded Python heredoc) ------------------------
+# 250+ lines of stateful Python with cross-platform watchdog (SIGALRM
+# fallback to threading.Timer), rename protocol, ping/pong handling,
+# message filtering, mirror-on-joiner-only, offset tracking. Rewriting
+# this in PS would be 600+ lines for no protocol benefit. We keep it
+# verbatim from the bash version, with one Windows tweak: the auto-pong
+# subprocess uses the airc.cmd shim path (passed via env var).
+$script:MonitorFormatterPython = @'
+import sys, json, os, re, time, signal
+
+WATCHDOG_SEC = 150
+def _watchdog_exit(signum=None, frame=None):
+    sys.stderr.write(f"[airc:monitor] no inbound in {WATCHDOG_SEC}s - exiting for probe\n")
+    sys.stderr.flush()
+    os._exit(2)
+
+# Cross-platform watchdog. POSIX: signal.SIGALRM. Windows: threading.Timer.
+try:
+    signal.signal(signal.SIGALRM, _watchdog_exit)
+    signal.alarm(WATCHDOG_SEC)
+    def _arm_watchdog():
+        signal.alarm(WATCHDOG_SEC)
+except (AttributeError, ValueError):
+    import threading
+    _wd_timer_holder = [None]
+    def _arm_watchdog():
+        if _wd_timer_holder[0] is not None:
+            _wd_timer_holder[0].cancel()
+        t = threading.Timer(WATCHDOG_SEC, _watchdog_exit)
+        t.daemon = True
+        t.start()
+        _wd_timer_holder[0] = t
+    _arm_watchdog()
+
+peers_dir   = os.environ.get("PEERS_DIR", "")
+scope_dir   = os.path.dirname(peers_dir)
+config_path = os.path.join(scope_dir, "config.json")
+local_log   = os.path.join(scope_dir, "messages.jsonl")
+offset_path = os.path.join(scope_dir, "monitor_offset")
+airc_cmd    = os.environ.get("AIRC_CMD_PATH", "airc")  # Windows shim path
+
+is_joiner = False
+try:
+    is_joiner = bool(json.load(open(config_path)).get("host_target", ""))
+except Exception:
+    pass
+
+room_path = os.path.join(scope_dir, "room_name")
+try:
+    room_name = open(room_path).read().strip() or "general"
+except Exception:
+    room_name = "1:1"
+
+def current_name():
+    try:
+        return json.load(open(config_path)).get("name", "")
+    except Exception:
+        return ""
+
+RENAME_RE = re.compile(r"^\[rename\] old=([a-z0-9-]+) new=([a-z0-9-]+)(?:\s+host=(\S+))?")
+
+def _rename_files(old, new):
+    old_json = os.path.join(peers_dir, f"{old}.json")
+    new_json = os.path.join(peers_dir, f"{new}.json")
+    if not os.path.isfile(old_json):
+        return False
+    try:
+        os.rename(old_json, new_json)
+        d = json.load(open(new_json))
+        d["name"] = new
+        json.dump(d, open(new_json, "w"), indent=2)
+    except Exception:
+        pass
+    old_pub = os.path.join(peers_dir, f"{old}.pub")
+    new_pub = os.path.join(peers_dir, f"{new}.pub")
+    if os.path.isfile(old_pub):
+        try: os.rename(old_pub, new_pub)
+        except Exception: pass
+    return True
+
+def _find_peer_by_host(host):
+    if not host or not os.path.isdir(peers_dir):
+        return None
+    for entry in os.listdir(peers_dir):
+        if not entry.endswith(".json"): continue
+        try:
+            d = json.load(open(os.path.join(peers_dir, entry)))
+        except Exception:
+            continue
+        if d.get("host") == host:
+            return d.get("name") or entry[:-5]
+    return None
+
+def handle_rename(msg, ts):
+    m = RENAME_RE.match(msg)
+    if not m: return False
+    old, new, host = m.group(1), m.group(2), m.group(3)
+    if _rename_files(old, new):
+        print(f"airc: nick {old} -> {new}", flush=True)
+        return True
+    if host:
+        current = _find_peer_by_host(host)
+        if current and current != new and _rename_files(current, new):
+            print(f"airc: nick (chain-repair) {current} -> {new}", flush=True)
+            return True
+    return False
+
+offset_counter = 0
+try:
+    with open(offset_path) as f:
+        offset_counter = int(f.read().strip() or 0)
+except Exception:
+    pass
+
+for line in sys.stdin:
+    _arm_watchdog()
+    line = line.strip()
+    if not line: continue
+    offset_counter += 1
+    try:
+        with open(offset_path, "w") as f:
+            f.write(str(offset_counter))
+    except Exception:
+        pass
+    try:
+        m = json.loads(line)
+    except Exception:
+        continue
+    ts = m.get("ts", "")
+    fr = m.get("from", "?")
+    to = m.get("to", "")
+    msg = m.get("msg", "")
+    if fr == current_name():
+        continue
+    if is_joiner:
+        try:
+            with open(local_log, "a") as f:
+                f.write(line + "\n")
+        except Exception:
+            pass
+    if handle_rename(msg, ts):
+        continue
+    ping_match = re.match(r"^\[PING:([a-f0-9-]+)\]", msg or "")
+    pong_match = re.match(r"^\[PONG:([a-f0-9-]+)\]", msg or "")
+    if ping_match:
+        ping_id = ping_match.group(1)
+        my_current = current_name()
+        if to == my_current:
+            import subprocess
+            try:
+                # Windows: airc.cmd is on PATH after install; absolute
+                # path passed via AIRC_CMD_PATH for robustness when PATH
+                # isn't inherited (daemons / scheduled tasks).
+                subprocess.Popen(
+                    [airc_cmd, "send", f"@{fr}", f"[PONG:{ping_id}]"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    shell=False,
+                )
+            except Exception:
+                pass
+        continue
+    if pong_match:
+        continue
+    PREVIEW_LEN = 100
+    msg_preview = msg.replace("\n", " ").strip()
+    if len(msg_preview) > PREVIEW_LEN:
+        msg_preview = msg_preview[:PREVIEW_LEN] + "..."
+    if fr in ("airc", "sys"):
+        print(f"airc: [#{room_name}] {msg_preview}", flush=True)
+    elif to and to not in ("all", ""):
+        print(f"airc: [#{room_name}] {fr} -> {to}: {msg_preview}", flush=True)
+    else:
+        print(f"airc: [#{room_name}] {fr}: {msg_preview}", flush=True)
+'@
+
+# Run the formatter against a stream of inbound JSONL lines on its stdin.
+# Returns the python.exe exit code (caller maps 2 = watchdog timeout).
+function Invoke-MonitorFormatter {
+    param([string]$MyName)
+    if (-not $script:PythonResolved) { Die 'python missing for monitor formatter' }
+    $env:PEERS_DIR     = $PEERS_DIR
+    $env:AIRC_CMD_PATH = (Resolve-Path (Join-Path $PSScriptRoot 'airc.cmd') -ErrorAction SilentlyContinue).Path
+    if (-not $env:AIRC_CMD_PATH) { $env:AIRC_CMD_PATH = 'airc.cmd' }
+    & $script:PythonResolved.Bin @($script:PythonResolved.Args + @('-u', '-c', $script:MonitorFormatterPython))
+    return $LASTEXITCODE
+}
+
+# -- Monitor: tail messages.jsonl (local for host, remote for joiner) ---
+# pipe to formatter, retry on disconnect with a probe-before-spam policy.
+# Mirrors bash monitor() closely.
+function Start-AircMonitor {
+    param([string]$MyName)
+    $hostTarget = Get-ConfigVal -Key 'host_target' -Default ''
+    $offsetFile = Join-Path $AIRC_WRITE_DIR 'monitor_offset'
+
+    function Get-TailOffset {
+        if (Test-Path $offsetFile) {
+            $n = (Get-Content $offsetFile -Raw -ErrorAction SilentlyContinue).Trim()
+            if ($n -match '^\d+$') { return ([int]$n + 1) }
+        }
+        return 0   # 0 = "tail from current end"
+    }
+
+    if ($hostTarget) {
+        $rhome  = Get-RemoteHome
+        $sshKey = Join-Path $IDENTITY_DIR 'ssh_key'
+        $consecutiveTimeouts = 0
+        $ESCALATE_AFTER = 2   # 2 * WATCHDOG_SEC = 5min dead-host detection
+
+        while ($true) {
+            $cycleStart = Get-Date
+            $offset = Get-TailOffset
+            $tailFlag = if ($offset -gt 0) { "+$offset" } else { '0' }
+            $remoteCmd = "tail -n $tailFlag -F $rhome/messages.jsonl 2>/dev/null"
+
+            # ssh.exe stdout -> python formatter stdin. Native PS pipeline.
+            $env:PEERS_DIR     = $PEERS_DIR
+            $env:AIRC_CMD_PATH = (Resolve-Path (Join-Path $PSScriptRoot 'airc.cmd') -ErrorAction SilentlyContinue).Path
+            if (-not $env:AIRC_CMD_PATH) { $env:AIRC_CMD_PATH = 'airc.cmd' }
+            & ssh '-i', $sshKey,
+                '-o','StrictHostKeyChecking=accept-new',
+                '-o','ServerAliveInterval=30',
+                '-o','ServerAliveCountMax=3',
+                $hostTarget, $remoteCmd 2>$null `
+              | & $script:PythonResolved.Bin @($script:PythonResolved.Args + @('-u', '-c', $script:MonitorFormatterPython))
+            $fmtExit = $LASTEXITCODE
+            $cycleLifetime = ((Get-Date) - $cycleStart).TotalSeconds
+
+            if ($fmtExit -eq 2) {
+                # Probe-before-spam: distinguish healthy idle from dead host.
+                $probeOk = $false
+                try {
+                    $r = & ssh '-i', $sshKey,
+                        '-o','StrictHostKeyChecking=accept-new',
+                        '-o','ConnectTimeout=5',
+                        '-o','BatchMode=yes',
+                        $hostTarget, 'true' 2>$null
+                    if ($LASTEXITCODE -eq 0) { $probeOk = $true }
+                } catch { }
+                if ($probeOk) {
+                    $consecutiveTimeouts = 0   # healthy idle, stay quiet
+                } else {
+                    Write-Host 'airc: host went quiet (probe failed) - restarting'
+                    $consecutiveTimeouts++
+                }
+            } elseif ($cycleLifetime -lt 30) {
+                Write-Host 'airc: host unreachable (cycle <30s) - restarting'
+                $consecutiveTimeouts++
+            } else {
+                $consecutiveTimeouts = 0
+            }
+
+            if ($consecutiveTimeouts -ge $ESCALATE_AFTER) {
+                $savedRoom = ''
+                $roomFile = Join-Path $AIRC_WRITE_DIR 'room_name'
+                if (Test-Path $roomFile) { $savedRoom = (Get-Content $roomFile -Raw).Trim() }
+                if ($savedRoom) {
+                    Write-Error "Host of #$savedRoom dead for $consecutiveTimeouts cycles - exiting for daemon respawn / self-heal"
+                    exit 99
+                } else {
+                    Write-Warning "$consecutiveTimeouts watchdog timeouts on legacy invite scope - host may be down"
+                    $consecutiveTimeouts = 0
+                }
+            }
+            Start-Sleep -Seconds 3
+        }
+    } else {
+        # Host mode: tail our own messages.jsonl (no SSH).
+        while ($true) {
+            $offset = Get-TailOffset
+            $tailFlag = if ($offset -gt 0) { "+$offset" } else { '0' }
+            # Use Get-Content -Wait for `tail -F` semantics on Windows. We
+            # apply our own offset by skipping the first $offset lines.
+            $env:PEERS_DIR     = $PEERS_DIR
+            $env:AIRC_CMD_PATH = (Resolve-Path (Join-Path $PSScriptRoot 'airc.cmd') -ErrorAction SilentlyContinue).Path
+            if (-not $env:AIRC_CMD_PATH) { $env:AIRC_CMD_PATH = 'airc.cmd' }
+            try {
+                Get-Content -Path $MESSAGES -Wait -Tail 0 `
+                  | & $script:PythonResolved.Bin @($script:PythonResolved.Args + @('-u', '-c', $script:MonitorFormatterPython))
+            } catch { }
+            Start-Sleep -Seconds 1
+        }
+    }
+}
+
+# ========================================================================
+# COMMANDS
+# ========================================================================
+
+# -- cmd_version --------------------------------------------------------
 function Invoke-Version {
-    Write-Host "  airc.ps1 $AIRC_VERSION on PowerShell $($PSVersionTable.PSVersion)"
-    Write-Host "  install: $PSScriptRoot"
-}
+    $here = $PSScriptRoot
+    $dir = $null
+    if ($here -and (Test-Path (Join-Path $here '.git'))) { $dir = $here }
+    elseif ($env:AIRC_DIR -and (Test-Path (Join-Path $env:AIRC_DIR '.git'))) { $dir = $env:AIRC_DIR }
+    elseif (Test-Path (Join-Path $env:USERPROFILE '.airc-src\.git')) { $dir = (Join-Path $env:USERPROFILE '.airc-src') }
 
-# ── Stub: cmd_help (bash:2993) ─────────────────────────────────────────────
-
-function Invoke-Help {
-    @"
-AIRC — Agentic Internet Relay Chat for AI peers
-(Windows-native PowerShell port; see also: airc bash for POSIX)
-
-Common verbs:
-  airc join                       # auto-#general (joins existing or hosts)
-  airc msg @<peer> <message>      # DM a peer (or omit @peer to broadcast)
-  airc peers                      # list paired peers
-  airc list                       # list open rooms on your gh account
-  airc nick <new-name>            # rename, broadcast to peers
-  airc part                       # leave the current room
-  airc quit                       # leave the mesh entirely
-
-PORT STATUS: see WINDOWS-PORT-STATUS.md for which commands are wired
-yet. This is a draft port; most commands are still stubs.
-"@ | Write-Host
-}
-
-# ── Command dispatch (bash:2967 case "${1:-help}" in) ──────────────────────
-
-$cmd = if ($args.Count -gt 0) { $args[0] } else { 'help' }
-$rest = if ($args.Count -gt 1) { $args[1..($args.Count-1)] } else { @() }
-
-switch ($cmd) {
-    # ── Info / help ──
-    'version' { Invoke-Version; break }
-    '--version' { Invoke-Version; break }
-    '-v' { Invoke-Version; break }
-    'help' { Invoke-Help; break }
-    '--help' { Invoke-Help; break }
-    '-h' { Invoke-Help; break }
-
-    # ── Connection lifecycle (TODO) ──
-    'connect' { Write-Error 'TODO: cmd_connect (bash:1100..1850) — host vs joiner branching, gh discovery, pair handshake, monitor formatter loop'; exit 99 }
-    'join'    { Write-Error 'TODO: alias of connect'; exit 99 }
-    'resume'  { Write-Error 'TODO: alias of connect (bash:resume)'; exit 99 }
-
-    # ── Messaging (TODO) ──
-    'msg'     { Write-Error 'TODO: cmd_send (bash:1800..1900) — local-mirror-first, ssh append to host messages.jsonl, queue on network fail'; exit 99 }
-    'send'    { Write-Error 'TODO: alias of msg'; exit 99 }
-
-    # ── Identity (TODO) ──
-    'nick'    { Write-Error 'TODO: cmd_rename — sanitize name, update config.json, broadcast [rename] marker'; exit 99 }
-    'rename'  { Write-Error 'TODO: alias of nick'; exit 99 }
-    'peers'   { Write-Error 'TODO: cmd_peers — list peer JSON files'; exit 99 }
-
-    # ── Room / discovery (TODO) ──
-    'list'    { Write-Error 'TODO: cmd_rooms (bash:cmd_rooms) — gh gist list filter by description'; exit 99 }
-    'rooms'   { Write-Error 'TODO: alias of list'; exit 99 }
-    'invite'  { Write-Error 'TODO: cmd_invite — print join string'; exit 99 }
-    'part'    { Write-Error 'TODO: cmd_part (bash:2037) — host: gh gist delete; joiner: local teardown only'; exit 99 }
-
-    # ── Lifecycle / disconnect (TODO) ──
-    'quit'    { Write-Error 'TODO: cmd_disconnect — teardown + strip host_target from config'; exit 99 }
-    'disconnect' { Write-Error 'TODO: alias of quit'; exit 99 }
-    'teardown' { Write-Error 'TODO: cmd_teardown — read airc.pid, kill PIDs, cleanup'; exit 99 }
-    'stop'    { Write-Error 'TODO: alias of teardown'; exit 99 }
-
-    # ── Diagnostic / utility (TODO) ──
-    'logs'    { Write-Error 'TODO: cmd_logs — tail messages.jsonl'; exit 99 }
-    'status'  { Write-Error 'TODO: cmd_status — identity + monitor PID + queue size'; exit 99 }
-    'doctor'  { Write-Error 'TODO: cmd_doctor — environment health + integration suite'; exit 99 }
-    'tests'   { Write-Error 'TODO: alias of doctor (test path only)'; exit 99 }
-    'ping'    { Write-Error 'TODO: cmd_ping (bash:cmd_ping) — round-trip liveness probe'; exit 99 }
-    'reminder' { Write-Error 'TODO: cmd_reminder — silence-nudge interval'; exit 99 }
-    'send-file' { Write-Error 'TODO: cmd_send_file — scp + airc msg notification'; exit 99 }
-    'repair'  { Write-Error 'TODO: cmd_repair — teardown --flush + reconnect'; exit 99 }
-
-    # ── Updates / channels (TODO) ──
-    'update'  { Write-Error 'TODO: cmd_update — git pull + re-run install.ps1'; exit 99 }
-    'upgrade' { Write-Error 'TODO: alias of update'; exit 99 }
-    'pull'    { Write-Error 'TODO: alias of update'; exit 99 }
-    'channel' { Write-Error 'TODO: cmd_channel — show/set release channel'; exit 99 }
-    'canary'  { Write-Error 'TODO: cmd_update --channel canary'; exit 99 }
-
-    # ── Daemon (TODO — Windows-specific: Task Scheduler not launchd/systemd) ──
-    'daemon'  { Write-Error 'TODO: cmd_daemon Windows port — register Task Scheduler task at logon (Action: Start pwsh.exe with -File airc.ps1 connect; Settings: RestartOnFailure, RunOnlyIfNetworkAvailable)'; exit 99 }
-
-    # ── Debug ──
-    'debug-scope' { Write-Host $AIRC_WRITE_DIR; break }
-
-    default {
-        Write-Error "Unknown command: $cmd. Try: airc help"
-        exit 2
+    if (-not $dir) {
+        Write-Host "  airc $AIRC_FALLBACK_VERSION (no git metadata)"
+        return
     }
+    $sha     = (& git -C $dir rev-parse --short HEAD 2>$null)
+    $subject = (& git -C $dir log -1 --format=%s 2>$null)
+    $branch  = (& git -C $dir rev-parse --abbrev-ref HEAD 2>$null)
+    $dirty   = ''
+    if (& git -C $dir status --porcelain 2>$null) { $dirty = ' (dirty)' }
+    Write-Host "  airc $sha$dirty on $branch"
+    if ($subject) { Write-Host "  $subject" }
+    Write-Host "  install: $dir"
+}
+
+# -- cmd_help -----------------------------------------------------------
+function Invoke-Help {
+    @'
+AIRC - Agentic Internet Relay Chat for AI peers
+(Windows-native; bash port lives on the same canary)
+
+Common verbs (IRC-canonical, all aliases work):
+  airc join                       Auto-#general (joins existing or hosts)
+  airc join --room <name>         Enter (or host) a named channel
+  airc join <gist-id>             Enter via shared gist id (cross-account)
+  airc join <mnemonic>            Enter via humanhash like oregon-uncle-bravo-eleven
+  airc list / rooms               List open rooms + invites on your gh account
+  airc part                       Leave the current room
+  airc msg <text>                 Broadcast to the current room
+  airc msg @<peer> <text>         DM a peer
+  airc nick <new>                 Rename this session (notifies peers)
+  airc quit / disconnect          Leave the mesh (keep identity)
+  airc peers                      List connected peers
+  airc ping @peer [timeout]       Monitor-liveness probe
+
+Operations:
+  airc doctor                     Check prereqs + health (gh, ssh, python, tailscale, ...)
+  airc status [--probe]           Liveness snapshot
+  airc update [--channel <name>]  Pull latest; switch channel with --channel canary|main
+  airc channel [<name>]           Show or set release channel
+  airc canary                     Shortcut: airc update --channel canary
+  airc daemon [install|...]       Auto-start via Task Scheduler (Windows)
+  airc reminder <seconds>         Nudge if silent (off / pause / 300)
+  airc teardown [--flush] [--all] Kill scope airc processes
+  airc invite                     Print join string (share with peers)
+  airc logs [N]                   Show recent messages
+
+Identity resolution (highest priority first):
+  AIRC_NAME env > config.json name > cwd basename > hostname
+  AIRC_HOME env overrides state dir (default $PWD/.airc)
+  AIRC_PORT env overrides host listen port (default 7547)
+  AIRC_REMINDER env overrides reminder interval seconds (default 300)
+  Join string may include :port - name@user@host:7548#key
+'@ | Write-Host
+}
+
+# -- cmd_doctor ---------------------------------------------------------
+# User-emphasized: "if they dont have gh for example doctor would say
+# hey get that". Concrete winget commands so the user can copy-paste.
+function Invoke-Doctor {
+    Write-Host ''
+    Write-Host '  airc doctor - environment health'
+    Write-Host '  --------------------------------'
+    Write-Host ''
+    $issues = @()
+
+    function Probe($Name, $TestBlock, $FixHint) {
+        if (& $TestBlock) {
+            Write-Host "  [ok] $Name"
+        } else {
+            Write-Host "  [MISSING] $Name"
+            Write-Host "         Fix: $FixHint"
+            $script:DoctorIssues += $Name
+        }
+    }
+    $script:DoctorIssues = @()
+
+    Probe 'PowerShell 7+' {
+        $PSVersionTable.PSVersion.Major -ge 7
+    } 'winget install --id Microsoft.PowerShell  (then re-launch in pwsh)'
+
+    Probe 'git' {
+        Get-Command git -ErrorAction SilentlyContinue
+    } 'winget install --id Git.Git'
+
+    Probe 'python' {
+        $r = Resolve-PythonBin
+        $null -ne $r
+    } 'winget install --id Python.Python.3.12'
+
+    Probe 'gh (GitHub CLI)' {
+        Get-Command gh -ErrorAction SilentlyContinue
+    } 'winget install --id GitHub.cli  (then: gh auth login -s gist)'
+
+    Probe 'gh authenticated (gist scope)' {
+        if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { return $false }
+        & gh auth status 2>$null | Out-Null
+        $LASTEXITCODE -eq 0
+    } 'gh auth login -s gist'
+
+    Probe 'ssh (OpenSSH client)' {
+        Get-Command ssh -ErrorAction SilentlyContinue
+    } 'Settings -> Apps -> Optional Features -> Add -> OpenSSH Client (or: Add-WindowsCapability -Online -Name OpenSSH.Client*)'
+
+    Probe 'ssh-keygen' {
+        Get-Command ssh-keygen -ErrorAction SilentlyContinue
+    } 'Comes with OpenSSH Client (see above)'
+
+    Probe 'openssl' {
+        $null -ne $script:OpenSSLBin
+    } 'winget install --id Git.Git  (Git for Windows bundles openssl in usr/bin)'
+
+    Probe 'tailscale (optional)' {
+        Get-Command tailscale -ErrorAction SilentlyContinue
+    } 'winget install --id tailscale.tailscale  (then: tailscale up)  - LAN-only mode works without it'
+
+    # State-dir + identity
+    Write-Host ''
+    Write-Host '  Scope:'
+    Write-Host "    AIRC_HOME = $AIRC_WRITE_DIR"
+    if (Test-Path $CONFIG) {
+        $name = Get-Name
+        $hostTarget = Get-ConfigVal -Key 'host_target' -Default ''
+        if ($hostTarget) {
+            Write-Host "    Identity: $name (joiner of $hostTarget)"
+        } else {
+            Write-Host "    Identity: $name (host or unconnected)"
+        }
+    } else {
+        Write-Host "    Identity: not initialized (run 'airc connect' to set up)"
+    }
+
+    Write-Host ''
+    if ($script:DoctorIssues.Count -eq 0) {
+        Write-Host '  All required prereqs present. You are ready to: airc join'
+    } else {
+        Write-Host "  $($script:DoctorIssues.Count) prereq(s) missing - see fix lines above."
+        Write-Host '  Fastest path: re-run install.ps1 (it auto-installs via winget):'
+        Write-Host '    iwr https://raw.githubusercontent.com/CambrianTech/airc/canary/install.ps1 | iex'
+    }
+    Write-Host ''
+}
+
+# -- cmd_peers ----------------------------------------------------------
+function Invoke-Peers {
+    Ensure-Init
+    if (-not (Test-Path $PEERS_DIR)) { Write-Host '  No peers yet.'; return }
+    $entries = Get-ChildItem -Path $PEERS_DIR -Filter '*.json' -File -ErrorAction SilentlyContinue
+    if (-not $entries -or $entries.Count -eq 0) { Write-Host '  No peers yet.'; return }
+    foreach ($f in $entries) {
+        try {
+            $d = Get-Content $f.FullName -Raw | ConvertFrom-Json
+            Write-Host "  $($d.name) -> $($d.host)"
+        } catch {
+            Write-Host "  (malformed: $($f.Name))"
+        }
+    }
+}
+
+# -- cmd_invite ---------------------------------------------------------
+function Invoke-Invite {
+    Ensure-Init
+    $hostTarget = Get-ConfigVal -Key 'host_target' -Default ''
+    if ($hostTarget) {
+        # Joiner: reconstruct the host's join string from config so other
+        # peers can converge on the same host.
+        $hostName    = Get-ConfigVal -Key 'host_name'    -Default ''
+        $hostPort    = Get-ConfigVal -Key 'host_port'    -Default '7547'
+        $hostSshPub  = Get-ConfigVal -Key 'host_ssh_pub' -Default ''
+        if (-not $hostName -or -not $hostSshPub) {
+            Die 'Host info missing from config. Re-pair with airc teardown then airc connect <join>.'
+        }
+        $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($hostSshPub.Trim()))
+        $portSuffix = if ($hostPort -ne '7547') { ":$hostPort" } else { '' }
+        Write-Host "$hostName@$hostTarget$portSuffix#$b64"
+    } else {
+        $name  = Resolve-AircName
+        $user  = $env:USERNAME
+        $hostA = Get-AircHost
+        $port  = if (Test-Path (Join-Path $AIRC_WRITE_DIR 'host_port')) {
+            (Get-Content (Join-Path $AIRC_WRITE_DIR 'host_port') -Raw).Trim()
+        } else { '7547' }
+        $sshPub = (Get-Content (Join-Path $IDENTITY_DIR 'ssh_key.pub') -Raw -ErrorAction SilentlyContinue).Trim()
+        if (-not $sshPub) { Die "No SSH key yet (run 'airc connect' to host)." }
+        $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($sshPub))
+        $portSuffix = if ($port -ne '7547') { ":$port" } else { '' }
+        Write-Host "$name@$user@$hostA$portSuffix#$b64"
+    }
+}
+
+# -- cmd_rooms / cmd_list -----------------------------------------------
+function Invoke-Rooms {
+    if (-not (Test-GhAvailable)) {
+        Write-Error 'airc rooms requires gh CLI: winget install --id GitHub.cli'
+        return
+    }
+    $rows = Get-GhGistList -Limit 50
+    $matches = @()
+    foreach ($r in $rows) {
+        if ($r.Description -like 'airc room:*') {
+            $matches += [pscustomobject]@{ Kind = 'room'; Id = $r.Id; Description = $r.Description; Updated = $r.Updated }
+        } elseif ($r.Description -like 'airc invite for*') {
+            $matches += [pscustomobject]@{ Kind = 'invite'; Id = $r.Id; Description = $r.Description; Updated = $r.Updated }
+        }
+    }
+    if ($matches.Count -eq 0) {
+        Write-Host '  No open airc rooms or invites on your gh account.'
+        Write-Host '  Host the default room:  airc connect'
+        Write-Host '  Host a named room:      airc connect --room <name>'
+        return
+    }
+    Write-Host ''
+    Write-Host "  $($matches.Count) open on your gh account:"
+    Write-Host ''
+    foreach ($m in $matches) {
+        $marker = if ($m.Kind -eq 'room') { '#' } else { '(1:1)' }
+        $hh = Get-Humanhash -HexInput $m.Id
+        Write-Host "    $marker $($m.Description)"
+        Write-Host "      id:       $($m.Id)"
+        Write-Host "      mnemonic: $hh"
+        Write-Host "      updated:  $($m.Updated)"
+        Write-Host ''
+    }
+    Write-Host '  Join (auto on same gh account): airc connect'
+    Write-Host '  Join by id (cross-account):     airc connect <id>'
+    Write-Host ''
+}
+
+# -- cmd_part -----------------------------------------------------------
+function Invoke-Part {
+    Ensure-Init
+    $gistIdFile  = Join-Path $AIRC_WRITE_DIR 'room_gist_id'
+    $roomFile    = Join-Path $AIRC_WRITE_DIR 'room_name'
+    $roomName    = if (Test-Path $roomFile) { (Get-Content $roomFile -Raw).Trim() } else { '(unnamed)' }
+    $hostTarget  = Get-ConfigVal -Key 'host_target' -Default ''
+
+    if (-not $hostTarget) {
+        # Host path: delete the room gist if we created one
+        if (Test-Path $gistIdFile) {
+            $gid = (Get-Content $gistIdFile -Raw).Trim()
+            if (Test-GhAvailable) {
+                Write-Host "  Host of #$roomName parting - deleting room gist $gid ..."
+                & gh gist delete $gid --yes 2>$null
+                if ($LASTEXITCODE -eq 0) { Write-Host '  + Room gist deleted.' }
+                else { Write-Host "  ! Couldn't delete gist $gid (already gone? gh auth?). Continuing teardown." }
+            } else {
+                Write-Host "  ! gh CLI not available - delete manually: gh gist delete $gid --yes"
+            }
+        } else {
+            Write-Host "  Host of #$roomName parting (no gist published; nothing to clean up in gh)."
+        }
+        Remove-Item $gistIdFile, $roomFile -Force -ErrorAction SilentlyContinue
+    } else {
+        Write-Host "  Joiner of #$roomName parting - host gist stays open for others."
+        Remove-Item $roomFile -Force -ErrorAction SilentlyContinue
+    }
+    Invoke-Teardown
+}
+
+# -- cmd_channel --------------------------------------------------------
+function Invoke-Channel {
+    param([string[]]$Args)
+    $dir = if ($env:AIRC_DIR) { $env:AIRC_DIR } else { Join-Path $env:USERPROFILE '.airc-src' }
+    $channelFile = Join-Path $dir '.channel'
+    $current = if (Test-Path $channelFile) { (Get-Content $channelFile -Raw).Trim() } else { 'main' }
+    if (-not $current) { $current = 'main' }
+    $target = if ($Args -and $Args.Count -gt 0) { $Args[0] } else { '' }
+    if (-not $target) {
+        Write-Host "  Channel: $current"
+        Write-Host '  Available channels (any branch on origin can be a channel):'
+        Write-Host '    main      - stable, what most users run'
+        Write-Host '    canary    - features queued for the next main merge; opt-in testing'
+        Write-Host '  Switch:'
+        Write-Host '    airc channel <name>           # set preference (run airc update after)'
+        Write-Host '    airc update --channel <name>  # set + pull in one step'
+        return
+    }
+    Set-Content -Path $channelFile -Value $target -NoNewline
+    Write-Host "  Channel preference set: '$target'. Run 'airc update' to actually switch + pull."
+}
+
+# -- cmd_logs -----------------------------------------------------------
+function Invoke-Logs {
+    param([string[]]$Args)
+    Ensure-Init
+    $count = 20
+    if ($Args -and $Args.Count -gt 0 -and $Args[0] -match '^\d+$') { $count = [int]$Args[0] }
+    $hostTarget = Get-ConfigVal -Key 'host_target' -Default ''
+    if ($hostTarget) {
+        $rhome = Get-RemoteHome
+        $raw = Invoke-AircSsh $hostTarget "tail -$count $rhome/messages.jsonl 2>/dev/null"
+    } else {
+        $raw = Get-Content $MESSAGES -Tail $count -ErrorAction SilentlyContinue
+    }
+    foreach ($line in $raw) {
+        if (-not $line) { continue }
+        try {
+            $m = $line | ConvertFrom-Json
+            Write-Host "[$($m.ts)] $($m.from): $($m.msg)"
+        } catch { }
+    }
+}
+
+# -- cmd_reminder -------------------------------------------------------
+function Invoke-Reminder {
+    param([string[]]$Args)
+    Ensure-Init
+    $arg = if ($Args -and $Args.Count -gt 0) { $Args[0] } else { 'status' }
+    $reminderFile = Join-Path $AIRC_WRITE_DIR 'reminder'
+    switch -Regex ($arg) {
+        '^(off|0)$'  {
+            Remove-Item $reminderFile -Force -ErrorAction SilentlyContinue
+            Write-Host '  Reminders off.'
+        }
+        '^pause$' {
+            Set-Content -Path $reminderFile -Value '0' -NoNewline
+            Write-Host "  Reminders paused. 'airc reminder <seconds>' to resume."
+        }
+        '^status$' {
+            if (Test-Path $reminderFile) {
+                $val = (Get-Content $reminderFile -Raw).Trim()
+                if ($val -eq '0') { Write-Host '  Reminders paused.' }
+                else { Write-Host "  Reminder every ${val}s." }
+            } else { Write-Host '  Reminders off.' }
+        }
+        '^\d+$' {
+            Set-Content -Path $reminderFile -Value $arg -NoNewline
+            Write-Host "  Reminder every ${arg}s if no messages."
+        }
+        default { Die "Usage: airc reminder [off|pause|<seconds>]" }
+    }
+}
+
+# -- cmd_status ---------------------------------------------------------
+function Invoke-Status {
+    param([string[]]$Args)
+    Ensure-Init
+    $probe = ($Args -and $Args -contains '--probe')
+    $myName     = Get-Name
+    $hostTarget = Get-ConfigVal -Key 'host_target' -Default ''
+    $hostName   = Get-ConfigVal -Key 'host_name'   -Default ''
+    $hostPort   = Get-ConfigVal -Key 'host_port'   -Default '7547'
+
+    Write-Host "  airc status - scope $AIRC_WRITE_DIR"
+    if ($hostTarget) {
+        Write-Host "  identity:    $myName (joiner of $hostName @ ${hostTarget}:${hostPort})"
+    } else {
+        $myPort = if ($env:AIRC_PORT) { $env:AIRC_PORT } else { '7547' }
+        $portFile = Join-Path $AIRC_WRITE_DIR 'host_port'
+        if (Test-Path $portFile) { $myPort = (Get-Content $portFile -Raw).Trim() }
+        Write-Host "  identity:    $myName (hosting on port $myPort)"
+    }
+
+    # Monitor liveness via PID file
+    $pids = Read-AircPidFile
+    $alive = $null
+    foreach ($p in $pids) {
+        if (Get-Process -Id $p -ErrorAction SilentlyContinue) { $alive = $p; break }
+    }
+    if ($alive) {
+        Write-Host "  monitor:     running (PID $alive)"
+    } elseif ($pids.Count -gt 0) {
+        Write-Host "  monitor:     stale pidfile (PIDs $($pids -join ' ') not alive - run 'airc connect' to self-heal)"
+    } else {
+        Write-Host '  monitor:     not running'
+    }
+
+    # Host reachability (only joiners; opt-in via --probe)
+    if ($hostTarget -and $probe) {
+        $sshKey = Join-Path $IDENTITY_DIR 'ssh_key'
+        $r = & ssh '-i', $sshKey,
+            '-o','StrictHostKeyChecking=accept-new',
+            '-o','ConnectTimeout=3',
+            '-o','BatchMode=yes',
+            $hostTarget, 'echo __REACHABLE__' 2>$null
+        if ($r -match '__REACHABLE__') {
+            Write-Host '  host:        reachable'
+        } else {
+            Write-Host '  host:        UNREACHABLE (ssh timeout or auth failure)'
+        }
+    }
+
+    # Pending queue
+    $pending = Join-Path $AIRC_WRITE_DIR 'pending.jsonl'
+    $pcount = 0
+    if (Test-Path $pending) { $pcount = (Get-Content $pending -ErrorAction SilentlyContinue).Count }
+    if ($pcount -gt 0) { Write-Host "  queue:       $pcount pending (auto-retries every ~5s)" }
+    else { Write-Host '  queue:       empty' }
+
+    # Reminder state
+    $rf = Join-Path $AIRC_WRITE_DIR 'reminder'
+    if (Test-Path $rf) {
+        $rv = (Get-Content $rf -Raw).Trim()
+        if ($rv -eq '0') { Write-Host '  reminder:    paused' }
+        elseif ($rv -match '^\d+$') { Write-Host "  reminder:    every ${rv}s" }
+    } else {
+        Write-Host '  reminder:    off'
+    }
+}
+
+# -- cmd_teardown -------------------------------------------------------
+# Bash uses pgrep -P + kill. Windows: taskkill /T /F walks the tree.
+function Invoke-Teardown {
+    param([string[]]$Args)
+    $flush = ($Args -contains '--flush')
+    $all   = ($Args -contains '--all')
+    $killed = $false
+
+    if ($all) {
+        # Nuclear: every airc-related pwsh, ssh, python on this user. Best-
+        # effort. Match by command line containing 'airc'.
+        $procs = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+            $_.CommandLine -and $_.CommandLine -match '\bairc\b' -and $_.ProcessId -ne $PID
+        }
+        foreach ($p in $procs) {
+            Write-Host "  --all: killing PID $($p.ProcessId) ($($p.Name))"
+            Stop-ProcessTree -Pid $p.ProcessId
+            $killed = $true
+        }
+        if (-not $killed) { Write-Host '  --all: no machine-wide airc processes to kill.' }
+    }
+
+    # Scope-aware via PID file
+    $pids = Read-AircPidFile
+    if ($pids.Count -gt 0) {
+        $alivePids = @()
+        foreach ($p in $pids) {
+            if (Get-Process -Id $p -ErrorAction SilentlyContinue) { $alivePids += $p }
+        }
+        if ($alivePids.Count -gt 0) {
+            Write-Host "  killing scope $AIRC_WRITE_DIR : $($alivePids -join ' ')"
+            foreach ($p in $alivePids) { Stop-ProcessTree -Pid $p }
+            $killed = $true
+        }
+        Remove-Item (Join-Path $AIRC_WRITE_DIR 'airc.pid') -Force -ErrorAction SilentlyContinue
+    }
+
+    # Free stale TCP listeners on the airc port range that look orphaned
+    # (no parent process still alive).
+    $portCandidates = @(7547)
+    if ($env:AIRC_PORT -and $env:AIRC_PORT -ne '7547') { $portCandidates = @([int]$env:AIRC_PORT, 7547) }
+    foreach ($port in $portCandidates) {
+        $conns = Get-NetTCPConnection -State Listen -LocalPort $port -ErrorAction SilentlyContinue
+        foreach ($c in $conns) {
+            $owner = Get-Process -Id $c.OwningProcess -ErrorAction SilentlyContinue
+            if (-not $owner) { continue }
+            # Heuristic: only kill if the owner is pwsh/python/airc-related.
+            if ($owner.Name -match '^(pwsh|python|powershell)$') {
+                Write-Host "  freeing stale port $port (PID $($c.OwningProcess) - $($owner.Name))"
+                Stop-ProcessTree -Pid $c.OwningProcess
+                $killed = $true
+            }
+        }
+    }
+
+    if ($flush) {
+        if ($AIRC_WRITE_DIR -and (Test-Path $AIRC_WRITE_DIR)) {
+            Write-Host "  flushing state: $AIRC_WRITE_DIR"
+            Remove-Item -Recurse -Force $AIRC_WRITE_DIR -ErrorAction SilentlyContinue
+        }
+    }
+
+    if ($killed) { Write-Host '  Teardown complete.' }
+    else { Write-Host '  No airc processes running.' }
+}
+
+# -- cmd_disconnect -----------------------------------------------------
+function Invoke-Disconnect {
+    Invoke-Teardown | Out-Null
+    if (Test-Path $CONFIG) {
+        try {
+            $cfg = Get-Content $CONFIG -Raw | ConvertFrom-Json -AsHashtable
+            foreach ($k in @('host_target','host_name','host_airc_home','host_port','host_ssh_pub')) {
+                $cfg.Remove($k) | Out-Null
+            }
+            ($cfg | ConvertTo-Json -Depth 10) | Set-Content -Path $CONFIG -NoNewline
+        } catch { }
+    }
+    Write-Host "  Disconnected. Identity preserved. Next 'airc connect' starts fresh (not a resume)."
+}
+
+# -- cmd_rename / cmd_nick ----------------------------------------------
+function Invoke-Rename {
+    param([string[]]$Args)
+    $newName = if ($Args -and $Args.Count -gt 0) { $Args[0] } else { '' }
+    if (-not $newName -or $newName -in @('-h','--help')) {
+        Write-Host 'Usage: airc nick <new-name>'
+        Write-Host '  Renames this identity and broadcasts [rename] to peers.'
+        if (-not $newName) { exit 1 } else { return }
+    }
+    if ($newName.StartsWith('-')) { Die "Name must not start with '-' (got '$newName')" }
+    $newName = ($newName.ToLower() -replace '[^a-z0-9-]','-')
+    if ($newName.Length -gt 24) { $newName = $newName.Substring(0, 24) }
+    if (-not $newName) { Die 'Invalid name (must be a-z 0-9 -)' }
+    if (-not (Test-Path $CONFIG)) { Die "Not initialized - run 'airc connect' first" }
+    $oldName = Get-Name
+    if ($oldName -eq $newName) { Write-Host "  Already named '$newName'."; return }
+    Set-ConfigVal -Updates @{ name = $newName }
+    Write-Host "  Renamed: $oldName -> $newName"
+    $myHost = "$($env:USERNAME)@$(Get-AircHost)"
+    try { Invoke-Send -Args @("[rename] old=$oldName new=$newName host=$myHost") | Out-Null } catch { }
+}
+
+# -- cmd_send / cmd_msg -------------------------------------------------
+# Local-mirror-first, then SSH append to host's messages.jsonl.
+# Auth-vs-network failure distinction (per fix #17).
+function Invoke-Send {
+    param([string[]]$Args)
+    if (-not $Args -or $Args.Count -eq 0) {
+        Die 'Usage: airc msg <message>  or  airc msg @peer <message>'
+    }
+    $first = $Args[0]
+    $peerName = 'all'
+    $msg = ''
+    if ($first.StartsWith('@')) {
+        $peerName = $first.Substring(1)
+        if ($Args.Count -lt 2) { Die 'Usage: airc msg @peer <message>' }
+        $msg = ($Args[1..($Args.Count - 1)] -join ' ')
+    } else {
+        $msg = ($Args -join ' ')
+    }
+    Ensure-Init
+
+    $myName = Get-Name
+    $ts     = Get-Timestamp
+    $payloadObj = [ordered]@{ from = $myName; to = $peerName; ts = $ts; msg = $msg }
+    $payload    = $payloadObj | ConvertTo-Json -Compress
+
+    $sig = Sign-Message -Payload $payload
+    $signedObj = [ordered]@{ from = $myName; to = $peerName; ts = $ts; msg = $msg; sig = $sig }
+    $fullMsg   = $signedObj | ConvertTo-Json -Compress
+
+    $hostTarget = Get-ConfigVal -Key 'host_target' -Default ''
+
+    if ($hostTarget) {
+        $rhome = Get-RemoteHome
+        # Mirror locally FIRST so we always have an audit trail.
+        Add-Content -Path $MESSAGES -Value $fullMsg
+
+        $sshKey = Join-Path $IDENTITY_DIR 'ssh_key'
+        $remoteCmd = "cat >> $rhome/messages.jsonl && echo __APPENDED__"
+        $errFile = [System.IO.Path]::GetTempFileName()
+        try {
+            $out = $fullMsg | & ssh '-i', $sshKey,
+                '-o','StrictHostKeyChecking=accept-new',
+                '-o','ConnectTimeout=10',
+                '-o','BatchMode=yes',
+                $hostTarget, $remoteCmd 2>$errFile
+            $stderrRaw = if (Test-Path $errFile) { (Get-Content $errFile -Raw -ErrorAction SilentlyContinue) } else { '' }
+            if ($out -match '__APPENDED__') {
+                # delivered
+            } else {
+                # Distinguish auth from network failure
+                $isAuth = $false
+                if ($stderrRaw -match '(?i)permission denied|publickey|host key verification|authentication fail|identification has changed|no supported authentication') {
+                    $isAuth = $true
+                }
+                $stderrLine = ($stderrRaw -replace "`r?`n", ' ').Substring(0, [Math]::Min(300, $stderrRaw.Length))
+                if ($isAuth) {
+                    $marker = ([ordered]@{ from='airc'; ts=(Get-Timestamp); msg="[AUTH FAILED to $peerName - repair required, NOT queued] $stderrLine" } | ConvertTo-Json -Compress)
+                    Add-Content -Path $MESSAGES -Value $marker
+                    Write-Error 'SSH auth to host FAILED. Message NOT queued - retries would fail identically.'
+                    Write-Error "SSH stderr: $stderrLine"
+                    Write-Error 'Fix: airc teardown --flush  then  airc connect <invite>'
+                    exit 1
+                }
+                # Network: queue
+                $pending = Join-Path $AIRC_WRITE_DIR 'pending.jsonl'
+                Add-Content -Path $pending -Value $fullMsg
+                $marker = ([ordered]@{ from='airc'; ts=(Get-Timestamp); msg="[QUEUED to $peerName - network error, will retry] $stderrLine" } | ConvertTo-Json -Compress)
+                Add-Content -Path $MESSAGES -Value $marker
+                Write-Warning "Network error reaching host - message queued. SSH stderr: $stderrLine"
+            }
+        } finally {
+            Remove-Item $errFile -Force -ErrorAction SilentlyContinue
+        }
+    } else {
+        Add-Content -Path $MESSAGES -Value $fullMsg
+    }
+
+    # Reset reminder
+    $now = [int][double]::Parse(((Get-Date).ToUniversalTime() - [DateTime]'1970-01-01').TotalSeconds)
+    Set-Content -Path (Join-Path $AIRC_WRITE_DIR 'last_sent') -Value $now -NoNewline
+    Remove-Item (Join-Path $AIRC_WRITE_DIR 'reminded') -Force -ErrorAction SilentlyContinue
+}
+
+# -- cmd_ping -----------------------------------------------------------
+function Invoke-Ping {
+    param([string[]]$Args)
+    if (-not $Args -or $Args.Count -eq 0) { Die 'Usage: airc ping @peer [timeout_secs]' }
+    $first = $Args[0]
+    if (-not $first.StartsWith('@')) { Die 'Usage: airc ping @peer (broadcast ping not supported)' }
+    $peerName = $first.Substring(1)
+    $timeout  = if ($Args.Count -gt 1 -and $Args[1] -match '^\d+$') { [int]$Args[1] } else { 10 }
+    Ensure-Init
+
+    $pingId = [guid]::NewGuid().ToString()
+    $startTime = Get-Date
+    Invoke-Send -Args @("@$peerName", "[PING:$pingId]") | Out-Null
+    Write-Host "ping sent to $peerName (id=$pingId) - waiting up to ${timeout}s for pong..."
+
+    while ($true) {
+        $elapsed = ((Get-Date) - $startTime).TotalSeconds
+        if (Test-Path $MESSAGES) {
+            $hit = Select-String -Path $MESSAGES -Pattern "\[PONG:$pingId\]" -SimpleMatch -Quiet -ErrorAction SilentlyContinue
+            if ($hit) {
+                Write-Host "PONG received from $peerName after $([int]$elapsed)s - monitor alive + auto-responder working."
+                return
+            }
+        }
+        if ($elapsed -ge $timeout) {
+            Write-Host "TIMEOUT after ${timeout}s - no pong from $peerName."
+            $sawPing = Select-String -Path $MESSAGES -Pattern "\[PING:$pingId\]" -SimpleMatch -Quiet -ErrorAction SilentlyContinue
+            if ($sawPing) {
+                Write-Host '  Ping IS visible in local log (cmd_send mirrored it). Outbound works.'
+                Write-Host '  No pong likely means: (a) peer monitor dead, (b) older airc, or (c) non-airc agent.'
+            } else {
+                Write-Host '  Ping is NOT in local log - cmd_send mirror may have failed. Check: airc status, airc logs.'
+            }
+            exit 1
+        }
+        Start-Sleep -Milliseconds 500
+    }
+}
+
+# -- cmd_send_file ------------------------------------------------------
+function Invoke-SendFile {
+    param([string[]]$Args)
+    if (-not $Args -or $Args.Count -lt 2) { Die 'Usage: airc send-file <peer> <path>' }
+    $peerName = $Args[0]
+    $filepath = $Args[1]
+    if (-not (Test-Path $filepath)) { Die "File not found: $filepath" }
+    Ensure-Init
+    $hostTarget = Get-ConfigVal -Key 'host_target' -Default ''
+    $myName = Get-Name
+    $filename = Split-Path -Leaf $filepath
+    $targetHost = if ($hostTarget) { $hostTarget } else { 'localhost' }
+    $rhome = Get-RemoteHome
+    Invoke-AircSsh $targetHost "mkdir -p $rhome/files/$myName" 2>$null
+    $sshKey = Join-Path $IDENTITY_DIR 'ssh_key'
+    & scp '-i', $sshKey, '-o','StrictHostKeyChecking=accept-new', '-q',
+        $filepath, "${targetHost}:${rhome}/files/${myName}/${filename}" 2>&1
+    if ($LASTEXITCODE -ne 0) { Die "scp failed for $filename" }
+    $size = (Get-Item $filepath).Length
+    Invoke-Send -Args @("@$peerName", "Sent file: $filename ($size bytes)") | Out-Null
+    Write-Host "Sent $filename ($size bytes)"
+}
+
+# -- cmd_update / cmd_canary --------------------------------------------
+function Invoke-Update {
+    param([string[]]$Args)
+    $dir = if ($env:AIRC_DIR) { $env:AIRC_DIR } else { Join-Path $env:USERPROFILE '.airc-src' }
+    $channelFile = Join-Path $dir '.channel'
+    $requested = ''
+    for ($i = 0; $i -lt $Args.Count; $i++) {
+        switch ($Args[$i]) {
+            '--channel'  { $requested = $Args[$i + 1]; $i++ }
+            '-c'         { $requested = $Args[$i + 1]; $i++ }
+            '--canary'   { $requested = 'canary' }
+            '--main'     { $requested = 'main' }
+        }
+    }
+    if (-not (Test-Path (Join-Path $dir '.git'))) {
+        Die "No git checkout at $dir. Reinstall via install.ps1."
+    }
+    $channel = if ($requested) { $requested }
+               elseif (Test-Path $channelFile) { (Get-Content $channelFile -Raw).Trim() }
+               else { 'main' }
+
+    $before = (& git -C $dir rev-parse --short HEAD).Trim()
+    $current = (& git -C $dir rev-parse --abbrev-ref HEAD).Trim()
+    if ($current -ne $channel) {
+        & git -C $dir fetch --quiet origin $channel
+        if ($LASTEXITCODE -ne 0) { Die "Channel '$channel' not found on origin." }
+        & git -C $dir checkout -q $channel 2>$null
+        if ($LASTEXITCODE -ne 0) { & git -C $dir checkout -q -B $channel "origin/$channel" }
+    }
+    & git -C $dir pull --ff-only --quiet
+    # Re-run install.ps1 to refresh skills + binary
+    $installScript = Join-Path $dir 'install.ps1'
+    if (Test-Path $installScript) {
+        & pwsh -NoLogo -NoProfile -File $installScript
+    }
+    Set-Content -Path $channelFile -Value $channel -NoNewline
+    $after = (& git -C $dir rev-parse --short HEAD).Trim()
+    if ($before -eq $after) {
+        Write-Host "  Already at $after on channel '$channel'. Skills refreshed."
+    } else {
+        Write-Host "  Updated: $before -> $after on channel '$channel'. Skills refreshed."
+        Write-Host "  Running monitor still uses old code. To pick up:  airc teardown && airc connect"
+    }
+}
+
+# -- cmd_daemon (Windows: Task Scheduler) -------------------------------
+# launchd / systemd analog on Windows is the Task Scheduler. We register
+# a per-user task that runs at logon, restarts on failure.
+function Invoke-Daemon {
+    param([string[]]$Args)
+    $action = if ($Args -and $Args.Count -gt 0) { $Args[0] } else { 'status' }
+    $taskName = 'AIRC'
+    switch ($action) {
+        'install' {
+            $aircCmd = Join-Path (Join-Path $env:USERPROFILE 'AppData\Local\Programs\airc') 'airc.cmd'
+            if (-not (Test-Path $aircCmd)) {
+                Die "airc.cmd not found at $aircCmd. Run install.ps1 first."
+            }
+            $action = New-ScheduledTaskAction -Execute $aircCmd -Argument 'connect'
+            $trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+            $settings = New-ScheduledTaskSettingsSet -StartWhenAvailable `
+                -DontStopOnIdleEnd -RestartCount 99 -RestartInterval (New-TimeSpan -Minutes 1) `
+                -ExecutionTimeLimit ([TimeSpan]::Zero)
+            $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive
+            Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger `
+                -Settings $settings -Principal $principal -Force | Out-Null
+            Write-Host "  + Registered Task Scheduler task '$taskName' (runs at logon, restarts on failure)"
+            Write-Host "  Status:  airc daemon status"
+        }
+        { $_ -in @('uninstall','remove','stop') } {
+            try {
+                Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction Stop
+                Write-Host "  + Removed Task Scheduler task '$taskName'"
+            } catch {
+                Write-Host "  (task '$taskName' not registered)"
+            }
+        }
+        'status' {
+            $task = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+            if (-not $task) { Write-Host "  No daemon installed. Run: airc daemon install"; return }
+            $info = Get-ScheduledTaskInfo -TaskName $taskName
+            Write-Host "  Task:        $taskName"
+            Write-Host "  State:       $($task.State)"
+            Write-Host "  Last run:    $($info.LastRunTime)"
+            Write-Host "  Last result: $($info.LastTaskResult)"
+            Write-Host "  Next run:    $($info.NextRunTime)"
+        }
+        default { Die "Usage: airc daemon [install|uninstall|status]" }
+    }
+}
+
+# -- cmd_doctor's tests-runner cousin -----------------------------------
+function Invoke-Tests {
+    Write-Host '  Integration test runner not yet ported to Windows.'
+    Write-Host '  Bash test/integration.sh is the canonical suite (run on macOS / Linux / WSL).'
+    Write-Host '  Windows native suite: tracked as roadmap once cmd_connect host-mode is solid.'
+}
+
+# -- cmd_connect --------------------------------------------------------
+# The big one. host vs joiner branching, gh discovery, mnemonic resolver,
+# pair handshake (TCP), monitor launch.
+function Invoke-Connect {
+    param([string[]]$Args)
+    # Flag parsing
+    $useGist = $true
+    $roomName = 'general'
+    $useRoom  = $true
+    $resolvedRoomName = ''
+    $resolvedGistId   = ''
+    $positional = @()
+    for ($i = 0; $i -lt $Args.Count; $i++) {
+        switch -Regex ($Args[$i]) {
+            '^(--gist|-gist)$' { $useGist = $true }
+            '^(--no-gist|-no-gist)$' { $useGist = $false }
+            '^(--room|-room)$' { $roomName = $Args[$i + 1]; $useRoom = $true; $i++ }
+            '^(--no-general|-no-general|--no-room|-no-room)$' { $useRoom = $false }
+            default { $positional += $Args[$i] }
+        }
+    }
+    $target = if ($positional.Count -gt 0) { $positional[0] } else { '' }
+    $reminderInterval = if ($env:AIRC_REMINDER) { [int]$env:AIRC_REMINDER }
+                       elseif ($positional.Count -gt 1) { [int]$positional[1] }
+                       else { 300 }
+
+    # Auto-teardown stale processes in this scope before fresh start
+    $stalePids = Read-AircPidFile
+    if ($stalePids.Count -gt 0) {
+        foreach ($p in $stalePids) {
+            if (Get-Process -Id $p -ErrorAction SilentlyContinue) {
+                Stop-ProcessTree -Pid $p
+            }
+        }
+        Remove-Item (Join-Path $AIRC_WRITE_DIR 'airc.pid') -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Milliseconds 500
+    }
+
+    # -- Resume case (no target, prior config) --
+    if (-not $target -and (Test-Path $CONFIG)) {
+        $priorHost = Get-ConfigVal -Key 'host_target' -Default ''
+        if ($priorHost) {
+            $priorName = Get-ConfigVal -Key 'host_name' -Default (Get-Name)
+            Write-Host "  Resuming as joiner of '$priorName' ($priorHost)..."
+            # Auth probe before committing to monitor loop
+            $sshKey = Join-Path $IDENTITY_DIR 'ssh_key'
+            $probeErr = [System.IO.Path]::GetTempFileName()
+            $probeOut = & ssh '-i', $sshKey,
+                '-o','StrictHostKeyChecking=accept-new',
+                '-o','ConnectTimeout=5',
+                '-o','BatchMode=yes',
+                $priorHost, 'echo __AUTH_OK__' 2>$probeErr
+            $stderrText = (Get-Content $probeErr -Raw -ErrorAction SilentlyContinue)
+            Remove-Item $probeErr -Force -ErrorAction SilentlyContinue
+            if ($probeOut -notmatch '__AUTH_OK__') {
+                if ($stderrText -match '(?i)permission denied|publickey|host key verification|authentication fail|no supported authentication') {
+                    Write-Error "SSH auth to host FAILED on resume. Saved pairing is stale."
+                    Write-Error "Fix: airc teardown --flush  then  airc connect <invite>"
+                    Die 'Resume aborted - re-pair required'
+                } else {
+                    Write-Warning "Host probe failed (non-auth). Monitor will retry in background."
+                    Write-Warning "SSH stderr: $stderrText"
+                }
+            }
+            Write-AircPidFile -Pids @($PID)
+            Start-AircMonitor -MyName (Get-Name)
+            return
+        }
+    }
+
+    # -- Zero-arg discovery: find #general (or named room) on our gh --
+    $savedHostTarget = ''
+    if (Test-Path $CONFIG) { $savedHostTarget = Get-ConfigVal -Key 'host_target' -Default '' }
+    if (-not $target -and -not $savedHostTarget -and ($env:AIRC_NO_DISCOVERY -ne '1') -and (Test-GhAvailable)) {
+        if ($useRoom) {
+            $rows = Get-GhGistList -Limit 50
+            $candidates = $rows | Where-Object { $_.Description -eq "airc room: $roomName" }
+            if ($candidates -and $candidates.Count -ge 1) {
+                $picked = $candidates[0].Id
+                Write-Host "  Found #$roomName on your gh account -> joining ($picked)"
+                $target = $picked
+            } else {
+                Write-Host "  No #$roomName found on your gh account -> becoming the host."
+            }
+        }
+    }
+
+    # -- Mnemonic resolver: humanhash phrase -> gist id (same gh) --
+    if ($target -and $target -match '^[a-z]+(-[a-z]+){2,}$') {
+        if (-not (Test-GhAvailable)) {
+            Die "Mnemonic '$target' lookup needs gh CLI. Install gh + 'gh auth login', or use the gist id directly."
+        }
+        $matched = ''
+        foreach ($r in (Get-GhGistList -Limit 50)) {
+            if ($r.Description -notmatch '^airc (room:|invite for)') { continue }
+            $hh = Get-Humanhash -HexInput $r.Id
+            if ($hh -eq $target) { $matched = $r.Id; break }
+        }
+        if ($matched) {
+            Write-Host "  Resolved mnemonic '$target' -> gist $matched"
+            $target = $matched
+        } else {
+            Die "Mnemonic '$target' didn't match any airc gist on this gh account."
+        }
+    }
+
+    # -- Gist transport: target without '@' is treated as gist id --
+    if ($target -and ($target -notmatch '@')) {
+        $gistId = $target -replace '^gist:', ''
+        $resolvedGistId = $gistId
+        if ($gistId -match '^[a-zA-Z0-9]{6,40}$') {
+            Write-Host "  Resolving gist $gistId ..."
+            $rawContent = Get-GistContent -GistId $gistId
+            if (-not $rawContent) {
+                Die "Failed to fetch gist '$gistId'. Check the ID, network, and (if private) 'gh auth login'."
+            }
+            $resolved = $null
+            try {
+                $env = $rawContent | ConvertFrom-Json
+                if ($env.airc) {
+                    switch ($env.kind) {
+                        'invite' { $resolved = $env.invite }
+                        'room'   { $resolved = $env.invite; $resolvedRoomName = $env.name }
+                        default  { Die "Gist uses unknown kind '$($env.kind)' - this airc may need 'airc update'." }
+                    }
+                }
+            } catch { }
+            if (-not $resolved) {
+                # Legacy raw-string format
+                $resolved = ($rawContent -split "`n" | Where-Object { $_ -match '@.*@' } | Select-Object -First 1).Trim()
+            }
+            if (-not $resolved -or ($resolved -notmatch '@')) {
+                Die "Failed to resolve gist '$gistId' to a valid invite."
+            }
+            Write-Host '  + Resolved invite from gist.'
+            $target = $resolved
+        }
+    }
+
+    if ($target -and ($target -match '@')) {
+        # -- JOIN MODE --
+        $hostSshPubkeyB64 = ''
+        if ($target -match '#') {
+            $hostSshPubkeyB64 = ($target -split '#')[-1]
+            $target = ($target -split '#')[0]
+        }
+        # Parse name@user@host[:port]
+        $peerName  = ($target -split '@')[0]
+        $sshTarget = $target.Substring($peerName.Length + 1)
+        $peerPort  = '7547'
+        if ($sshTarget -match ':(\d+)$') {
+            $peerPort = $matches[1]
+            $sshTarget = $sshTarget -replace ':\d+$',''
+        }
+        if (-not $peerName -or -not $sshTarget) { Die 'Format: airc connect name@user@host' }
+
+        $myName = Resolve-AircName
+        Init-Identity -Name $myName
+
+        # Write initial config
+        Set-ConfigVal -Updates @{
+            name        = $myName
+            host        = (Get-AircHost)
+            host_target = $sshTarget
+            created     = (Get-Timestamp)
+        }
+        if ($resolvedRoomName) {
+            Set-Content -Path (Join-Path $AIRC_WRITE_DIR 'room_name') -Value $resolvedRoomName -NoNewline
+            Write-Host "  Joined #$resolvedRoomName"
+        }
+
+        # Pre-authorize host's pubkey if in join string
+        if ($hostSshPubkeyB64) {
+            try {
+                $hostSshPubkey = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($hostSshPubkeyB64))
+                if ($hostSshPubkey) { Add-AuthorizedKey -PubKey $hostSshPubkey }
+            } catch { }
+        }
+
+        # Pair handshake via TCP (.NET native, no embedded Python)
+        $peerHostOnly = ($sshTarget -split '@')[-1]
+        Write-Host "  Connecting to ${peerHostOnly}:$peerPort ..."
+        $mySshPub  = (Get-Content (Join-Path $IDENTITY_DIR 'ssh_key.pub') -Raw -ErrorAction SilentlyContinue).Trim()
+        $mySignPub = (Get-Content (Join-Path $IDENTITY_DIR 'public.pem') -Raw -ErrorAction SilentlyContinue)
+        $payload   = ([ordered]@{
+            name      = $myName
+            host      = "$($env:USERNAME)@$(Get-AircHost)"
+            ssh_pub   = $mySshPub
+            sign_pub  = $mySignPub
+            airc_home = $AIRC_WRITE_DIR
+        } | ConvertTo-Json -Compress)
+
+        $response = $null
+        try {
+            $client = [System.Net.Sockets.TcpClient]::new()
+            $iar = $client.BeginConnect($peerHostOnly, [int]$peerPort, $null, $null)
+            $ok = $iar.AsyncWaitHandle.WaitOne(30000)
+            if (-not $ok) { $client.Close(); throw "TCP connect to ${peerHostOnly}:$peerPort timed out" }
+            $client.EndConnect($iar)
+            $client.SendTimeout = 30000
+            $client.ReceiveTimeout = 30000
+            $stream = $client.GetStream()
+            $bytes = [Text.Encoding]::UTF8.GetBytes($payload + "`n")
+            $stream.Write($bytes, 0, $bytes.Length)
+            try { $client.Client.Shutdown([System.Net.Sockets.SocketShutdown]::Send) } catch { }
+            $sb = [System.Text.StringBuilder]::new()
+            $buf = New-Object byte[] 4096
+            while ($true) {
+                $n = $stream.Read($buf, 0, $buf.Length)
+                if ($n -le 0) { break }
+                $sb.Append([Text.Encoding]::UTF8.GetString($buf, 0, $n)) | Out-Null
+            }
+            $client.Close()
+            $response = $sb.ToString().Trim()
+        } catch {
+            $response = $null
+            Write-Warning "Pair handshake failed: $_"
+        }
+
+        if (-not $response) {
+            # Self-heal: if we resolved a kind:room gist, take over as new host
+            if ($resolvedRoomName -and $resolvedGistId -and (Test-GhAvailable)) {
+                Write-Host ''
+                Write-Host "  ! Host of #$resolvedRoomName unreachable - self-healing as new host..."
+                Write-Host "     (prior host gist: $resolvedGistId)"
+                & gh gist delete $resolvedGistId --yes 2>$null
+                $preservedName = Get-ConfigVal -Key 'name' -Default ''
+                Remove-Item $CONFIG -Force -ErrorAction SilentlyContinue
+                Remove-Item (Join-Path $AIRC_WRITE_DIR 'room_name') -Force -ErrorAction SilentlyContinue
+                Write-Host "  Re-launching into host mode for #$resolvedRoomName ..."
+                $env:AIRC_NO_DISCOVERY = '1'
+                if ($preservedName) { $env:AIRC_NAME = $preservedName }
+                Invoke-Connect -Args @('--room', $resolvedRoomName)
+                return
+            }
+            Die "Can't reach ${peerHostOnly}:$peerPort. Is the host running 'airc connect'?"
+        }
+
+        # Parse host's response
+        try { $resp = $response | ConvertFrom-Json } catch { Die "Pair handshake: malformed host response: $response" }
+        if ($resp.ssh_pub) { Add-AuthorizedKey -PubKey $resp.ssh_pub }
+
+        # Save host as a peer
+        if (-not (Test-Path $PEERS_DIR)) { New-Item -ItemType Directory -Force -Path $PEERS_DIR | Out-Null }
+        # Drop stale records that share this host
+        Get-ChildItem $PEERS_DIR -Filter '*.json' -ErrorAction SilentlyContinue | ForEach-Object {
+            if ($_.BaseName -eq $peerName) { return }
+            try {
+                $d = Get-Content $_.FullName -Raw | ConvertFrom-Json
+                if ($d.host -eq $sshTarget) {
+                    Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue
+                    Remove-Item ((Join-Path $PEERS_DIR ($_.BaseName + '.pub'))) -Force -ErrorAction SilentlyContinue
+                }
+            } catch { }
+        }
+        $peerRecord = [ordered]@{
+            name      = $peerName
+            host      = $sshTarget
+            airc_home = $resp.airc_home
+            paired    = (Get-Timestamp)
+        }
+        $peerJsonPath = Join-Path $PEERS_DIR "$peerName.json"
+        ($peerRecord | ConvertTo-Json -Depth 10) | Set-Content -Path $peerJsonPath -NoNewline
+        if ($resp.sign_pub) {
+            Set-Content -Path (Join-Path $PEERS_DIR "$peerName.pub") -Value $resp.sign_pub -NoNewline
+        }
+
+        # Persist host details
+        Set-ConfigVal -Updates @{
+            host_airc_home = $resp.airc_home
+            host_name      = $peerName
+            host_port      = $peerPort
+            host_ssh_pub   = $resp.ssh_pub
+        }
+
+        # Reminder from host
+        $hostReminder = if ($resp.reminder) { [int]$resp.reminder } else { 300 }
+        if ($hostReminder -gt 0) {
+            Set-Content -Path (Join-Path $AIRC_WRITE_DIR 'reminder') -Value $hostReminder -NoNewline
+            $now = [int][double]::Parse(((Get-Date).ToUniversalTime() - [DateTime]'1970-01-01').TotalSeconds)
+            Set-Content -Path (Join-Path $AIRC_WRITE_DIR 'last_sent') -Value $now -NoNewline
+        }
+
+        # Verify SSH works
+        $verify = Invoke-AircSsh $sshTarget 'echo ok' 2>$null
+        if ($verify -match 'ok') {
+            Write-Host "  Connected to '$peerName' (SSH verified, reminder: ${hostReminder}s)"
+        } else {
+            Write-Host "  Connected to '$peerName' (SSH not verified - messages may need retry)"
+        }
+        Write-AircPidFile -Pids @($PID)
+        Write-Host '  Monitoring for messages...'
+        Start-AircMonitor -MyName $myName
+
+    } else {
+        # -- HOST MODE --
+        $name = if ($target) { $target } else { Resolve-AircName }
+        Init-Identity -Name $name
+        Set-ConfigVal -Updates @{
+            name    = $name
+            host    = (Get-AircHost)
+            created = (Get-Timestamp)
+        }
+        $hostA = Get-AircHost
+        $user  = $env:USERNAME
+        $sshPub = (Get-Content (Join-Path $IDENTITY_DIR 'ssh_key.pub') -Raw).Trim()
+        $sshPubB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($sshPub))
+
+        $hostPort = if ($env:AIRC_PORT) { [int]$env:AIRC_PORT } else { 7547 }
+        $originalPort = $hostPort
+        $hostPort = Get-FreeAircPort -Start $hostPort
+        $portSuffix = if ($hostPort -ne 7547) { ":$hostPort" } else { '' }
+        Set-Content -Path (Join-Path $AIRC_WRITE_DIR 'host_port') -Value $hostPort -NoNewline
+
+        if ($reminderInterval -gt 0) {
+            Set-Content -Path (Join-Path $AIRC_WRITE_DIR 'reminder') -Value $reminderInterval -NoNewline
+            $now = [int][double]::Parse(((Get-Date).ToUniversalTime() - [DateTime]'1970-01-01').TotalSeconds)
+            Set-Content -Path (Join-Path $AIRC_WRITE_DIR 'last_sent') -Value $now -NoNewline
+        }
+
+        Write-Host ''
+        if ($hostPort -ne $originalPort) { Write-Host "  Port $originalPort was taken; using $hostPort." }
+        Write-Host "  Hosting as '$name' (reminder: ${reminderInterval}s)"
+        Write-Host ''
+        $inviteLong = "$name@$user@$hostA$portSuffix#$sshPubB64"
+
+        $printedLong = $false
+        if (-not $useGist) {
+            Write-Host '  On the other machine:'
+            Write-Host "    airc connect $inviteLong"
+            $printedLong = $true
+        }
+        if ($useRoom) {
+            Set-Content -Path (Join-Path $AIRC_WRITE_DIR 'room_name') -Value $roomName -NoNewline
+            Write-Host "  Hosting #$roomName (gh-account substrate)."
+        }
+
+        # Gist transport
+        if ($useGist) {
+            if (-not (Test-GhAvailable)) {
+                Write-Host ''
+                Write-Host '  ! --gist requested but gh CLI not installed.'
+                Write-Host '     winget install --id GitHub.cli  (then: gh auth login -s gist)'
+                Write-Host '     Skipping gist push; long invite above is the only handoff.'
+            } else {
+                $now = Get-Timestamp
+                if ($useRoom) {
+                    $envelope = [ordered]@{
+                        airc    = 1
+                        kind    = 'room'
+                        name    = $roomName
+                        topic   = ''
+                        invite  = $inviteLong
+                        host    = [ordered]@{ name=$name; user=$user; address=$hostA; port=$hostPort }
+                        created = $now
+                        updated = $now
+                    }
+                    $gistDesc = "airc room: $roomName"
+                } else {
+                    $envelope = [ordered]@{
+                        airc    = 1
+                        kind    = 'invite'
+                        invite  = $inviteLong
+                        host    = [ordered]@{ name=$name; user=$user; address=$hostA; port=$hostPort }
+                        created = $now
+                    }
+                    $gistDesc = "airc invite for $name (delete after pair)"
+                }
+                $gistTmp = [System.IO.Path]::GetTempFileName()
+                ($envelope | ConvertTo-Json -Depth 10) | Set-Content -Path $gistTmp -NoNewline
+                $gistOutput = & gh gist create -d $gistDesc $gistTmp 2>$null
+                Remove-Item $gistTmp -Force -ErrorAction SilentlyContinue
+                $gistUrl = if ($gistOutput) { ($gistOutput | Select-Object -Last 1).Trim() } else { '' }
+                if ($gistUrl) {
+                    $gistId = ($gistUrl -split '/')[-1]
+                    $hh = Get-Humanhash -HexInput $gistId
+                    if ($useRoom) {
+                        Set-Content -Path (Join-Path $AIRC_WRITE_DIR 'room_gist_id') -Value $gistId -NoNewline
+                        Write-Host "  Hosting #$roomName (gh-account substrate)."
+                        Write-Host "  Other agents on your gh account auto-join via:  airc connect"
+                        Write-Host "  Cross-account share:"
+                        Write-Host "    airc connect $gistId"
+                        if ($hh) { Write-Host "      # mnemonic: $hh" }
+                        Write-Host "    airc connect $inviteLong"
+                        Write-Host ''
+                        Write-Host "  (Room gist: $gistUrl - persistent; deleted on 'airc part'.)"
+                    } else {
+                        Write-Host '  On the other machine (pick whichever is easiest to share):'
+                        Write-Host ''
+                        Write-Host "    airc connect $gistId"
+                        if ($hh) { Write-Host "      # mnemonic: $hh" }
+                        Write-Host "    airc connect $inviteLong"
+                        Write-Host ''
+                        Write-Host "  (Gist: $gistUrl - secret, single-use; delete after pairing.)"
+                    }
+                } else {
+                    Write-Host ''
+                    Write-Host "  ! Gist push failed (gh auth?). Falling back to long invite:"
+                    if (-not $printedLong) { Write-Host "    airc connect $inviteLong" }
+                }
+            }
+        }
+
+        Write-Host ''
+        Write-Host "  Waiting for peers on port $hostPort..."
+
+        # Background TCP-accept loop. We use Start-ThreadJob so it shares
+        # the process (one PID for `airc connect` + the pair acceptor).
+        # The job receives via a thread-safe queue from the listener.
+        $hostState = @{
+            Port         = $hostPort
+            Name         = $name
+            PeersDir     = $PEERS_DIR
+            IdentityDir  = $IDENTITY_DIR
+            Messages     = $MESSAGES
+            ScopeDir     = $AIRC_WRITE_DIR
+            Reminder     = $reminderInterval
+            ConfigPath   = $CONFIG
+        }
+        $acceptorJob = Start-ThreadJob -ScriptBlock {
+            param($s)
+            $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Any, $s.Port)
+            $listener.Start()
+            try {
+                while ($true) {
+                    if (-not $listener.Pending()) { Start-Sleep -Milliseconds 250; continue }
+                    $client = $listener.AcceptTcpClient()
+                    try {
+                        $client.ReceiveTimeout = 30000
+                        $stream = $client.GetStream()
+                        $sb = [System.Text.StringBuilder]::new()
+                        $buf = New-Object byte[] 4096
+                        $foundNewline = $false
+                        while (-not $foundNewline) {
+                            $n = $stream.Read($buf, 0, $buf.Length)
+                            if ($n -le 0) { break }
+                            $chunk = [Text.Encoding]::UTF8.GetString($buf, 0, $n)
+                            $sb.Append($chunk) | Out-Null
+                            if ($chunk.Contains("`n")) { $foundNewline = $true }
+                        }
+                        $joiner = $sb.ToString().Trim() | ConvertFrom-Json
+
+                        # Authorize joiner SSH key
+                        $sshDir = Join-Path $env:USERPROFILE '.ssh'
+                        if (-not (Test-Path $sshDir)) { New-Item -ItemType Directory -Force -Path $sshDir | Out-Null }
+                        $authKeys = Join-Path $sshDir 'authorized_keys'
+                        if ($joiner.ssh_pub) {
+                            $existing = if (Test-Path $authKeys) { Get-Content $authKeys -Raw -ErrorAction SilentlyContinue } else { '' }
+                            $line = $joiner.ssh_pub.Trim()
+                            if ($existing -notlike "*$line*") { Add-Content -Path $authKeys -Value $line }
+                        }
+
+                        # Save joiner as peer (drop stale records sharing host)
+                        if (-not (Test-Path $s.PeersDir)) { New-Item -ItemType Directory -Force -Path $s.PeersDir | Out-Null }
+                        $jname = $joiner.name
+                        $jhost = $joiner.host
+                        Get-ChildItem $s.PeersDir -Filter '*.json' -ErrorAction SilentlyContinue | ForEach-Object {
+                            if ($_.BaseName -eq $jname) { return }
+                            try {
+                                $d = Get-Content $_.FullName -Raw | ConvertFrom-Json
+                                if ($d.host -eq $jhost) {
+                                    Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue
+                                    Remove-Item (Join-Path $s.PeersDir ($_.BaseName + '.pub')) -Force -ErrorAction SilentlyContinue
+                                }
+                            } catch { }
+                        }
+                        $rec = [ordered]@{
+                            name      = $jname
+                            host      = $jhost
+                            airc_home = $joiner.airc_home
+                            paired    = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+                        }
+                        ($rec | ConvertTo-Json -Depth 10) | Set-Content -Path (Join-Path $s.PeersDir "$jname.json") -NoNewline
+                        if ($joiner.sign_pub) {
+                            Set-Content -Path (Join-Path $s.PeersDir "$jname.pub") -Value $joiner.sign_pub -NoNewline
+                        }
+
+                        # Send back host info
+                        $hostPub = (Get-Content (Join-Path $s.IdentityDir 'ssh_key.pub') -Raw).Trim()
+                        $signPub = (Get-Content (Join-Path $s.IdentityDir 'public.pem') -Raw)
+                        $resp = ([ordered]@{
+                            ssh_pub   = $hostPub
+                            sign_pub  = $signPub
+                            name      = $s.Name
+                            reminder  = $s.Reminder
+                            airc_home = $s.ScopeDir
+                        } | ConvertTo-Json -Compress)
+                        $rb = [Text.Encoding]::UTF8.GetBytes($resp + "`n")
+                        $stream.Write($rb, 0, $rb.Length)
+                        $stream.Flush()
+
+                        # Surface join as system event in messages.jsonl
+                        try {
+                            $roomNameFile = Join-Path $s.ScopeDir 'room_name'
+                            $rname = if (Test-Path $roomNameFile) { (Get-Content $roomNameFile -Raw).Trim() } else { 'general' }
+                            $event = [ordered]@{
+                                ts   = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+                                from = 'airc'
+                                to   = 'all'
+                                msg  = "$jname joined #$rname"
+                            }
+                            Add-Content -Path $s.Messages -Value (($event | ConvertTo-Json -Compress))
+                        } catch { }
+
+                        Write-Host "  Peer joined: $jname"
+                    } catch {
+                        Write-Warning "Pair acceptor: $_"
+                    } finally {
+                        try { $client.Close() } catch { }
+                    }
+                }
+            } finally {
+                $listener.Stop()
+            }
+        } -ArgumentList $hostState
+
+        Write-AircPidFile -Pids @($PID)
+        Write-Host '  Monitoring for messages...'
+        try {
+            Start-AircMonitor -MyName $name
+        } finally {
+            Stop-Job $acceptorJob -ErrorAction SilentlyContinue | Out-Null
+            Remove-Job $acceptorJob -Force -ErrorAction SilentlyContinue | Out-Null
+        }
+    }
+}
+
+# ========================================================================
+# DISPATCH
+# ========================================================================
+$cmd = if ($args.Count -gt 0) { $args[0] } else { 'help' }
+$rest = if ($args.Count -gt 1) { $args[1..($args.Count - 1)] } else { @() }
+
+try {
+    switch ($cmd) {
+        # Info
+        { $_ -in @('version','--version','-v') }      { Invoke-Version; break }
+        { $_ -in @('help','--help','-h') }            { Invoke-Help; break }
+        'doctor'                                       { Invoke-Doctor; break }
+        { $_ -in @('tests','test') }                   { Invoke-Tests; break }
+
+        # Connection lifecycle
+        { $_ -in @('connect','setup','start','join','resume') } { Invoke-Connect -Args $rest; break }
+
+        # Messaging
+        { $_ -in @('send','msg','say','privmsg') }    { Invoke-Send -Args $rest; break }
+        'send-file'                                    { Invoke-SendFile -Args $rest; break }
+        'ping'                                         { Invoke-Ping -Args $rest; break }
+
+        # Identity / peers
+        { $_ -in @('rename','nick') }                 { Invoke-Rename -Args $rest; break }
+        'reminder'                                     { Invoke-Reminder -Args $rest; break }
+        'peers'                                        { Invoke-Peers; break }
+
+        # Rooms / discovery
+        { $_ -in @('rooms','list','ls') }             { Invoke-Rooms; break }
+        { $_ -in @('invite','share','join-string') }  { Invoke-Invite; break }
+        'part'                                         { Invoke-Part; break }
+
+        # Lifecycle / disconnect
+        { $_ -in @('teardown','stop','flush') }       { Invoke-Teardown -Args $rest; break }
+        { $_ -in @('disconnect','quit','leave','unbind') } { Invoke-Disconnect; break }
+
+        # Diagnostic
+        'logs'                                         { Invoke-Logs -Args $rest; break }
+        'status'                                       { Invoke-Status -Args $rest; break }
+
+        # Updates / channels
+        { $_ -in @('update','upgrade','pull') }       { Invoke-Update -Args $rest; break }
+        'channel'                                      { Invoke-Channel -Args $rest; break }
+        'canary'                                       { Invoke-Update -Args (@('--channel','canary') + $rest); break }
+
+        # Daemon (Task Scheduler on Windows)
+        { $_ -in @('daemon','autostart','service') }  { Invoke-Daemon -Args $rest; break }
+
+        # Monitor (rare standalone use)
+        'monitor'                                      { Start-AircMonitor -MyName (Get-Name); break }
+
+        # Debug
+        'debug-scope' { Write-Host $AIRC_WRITE_DIR; break }
+        'debug-name'  { Write-Host (Resolve-AircName); break }
+        'debug-host'  { Write-Host (Get-AircHost); break }
+
+        default { Die "Unknown command: $cmd. Try: airc help" }
+    }
+} catch {
+    Write-Error $_
+    exit 1
 }

--- a/airc.ps1
+++ b/airc.ps1
@@ -776,11 +776,14 @@ function Start-AircMonitor {
             $env:PEERS_DIR     = $PEERS_DIR
             $env:AIRC_CMD_PATH = (Resolve-Path (Join-Path $PSScriptRoot 'airc.cmd') -ErrorAction SilentlyContinue).Path
             if (-not $env:AIRC_CMD_PATH) { $env:AIRC_CMD_PATH = 'airc.cmd' }
-            & ssh '-i', $sshKey,
-                '-o','StrictHostKeyChecking=accept-new',
-                '-o','ServerAliveInterval=30',
-                '-o','ServerAliveCountMax=3',
-                $hostTarget, $remoteCmd 2>$null `
+            $tailArgs = @(
+                '-i', $sshKey,
+                '-o', 'StrictHostKeyChecking=accept-new',
+                '-o', 'ServerAliveInterval=30',
+                '-o', 'ServerAliveCountMax=3',
+                $hostTarget, $remoteCmd
+            )
+            & ssh @tailArgs 2>$null `
               | & $script:PythonResolved.Bin @($script:PythonResolved.Args + @('-u', '-c', $script:MonitorFormatterPython))
             $fmtExit = $LASTEXITCODE
             $cycleLifetime = ((Get-Date) - $cycleStart).TotalSeconds
@@ -789,11 +792,14 @@ function Start-AircMonitor {
                 # Probe-before-spam: distinguish healthy idle from dead host.
                 $probeOk = $false
                 try {
-                    $r = & ssh '-i', $sshKey,
-                        '-o','StrictHostKeyChecking=accept-new',
-                        '-o','ConnectTimeout=5',
-                        '-o','BatchMode=yes',
-                        $hostTarget, 'true' 2>$null
+                    $probeArgs = @(
+                        '-i', $sshKey,
+                        '-o', 'StrictHostKeyChecking=accept-new',
+                        '-o', 'ConnectTimeout=5',
+                        '-o', 'BatchMode=yes',
+                        $hostTarget, 'true'
+                    )
+                    $r = & ssh @probeArgs 2>$null
                     if ($LASTEXITCODE -eq 0) { $probeOk = $true }
                 } catch { }
                 if ($probeOk) {
@@ -1223,11 +1229,14 @@ function Invoke-Status {
     # Host reachability (only joiners; opt-in via --probe)
     if ($hostTarget -and $probe) {
         $sshKey = Join-Path $IDENTITY_DIR 'ssh_key'
-        $r = & ssh '-i', $sshKey,
-            '-o','StrictHostKeyChecking=accept-new',
-            '-o','ConnectTimeout=3',
-            '-o','BatchMode=yes',
-            $hostTarget, 'echo __REACHABLE__' 2>$null
+        $statusProbeArgs = @(
+            '-i', $sshKey,
+            '-o', 'StrictHostKeyChecking=accept-new',
+            '-o', 'ConnectTimeout=3',
+            '-o', 'BatchMode=yes',
+            $hostTarget, 'echo __REACHABLE__'
+        )
+        $r = & ssh @statusProbeArgs 2>$null
         if ($r -match '__REACHABLE__') {
             Write-Host '  host:        reachable'
         } else {
@@ -1417,11 +1426,14 @@ function Invoke-Send {
         $remoteCmd = "cat >> $rhome/messages.jsonl && echo __APPENDED__"
         $errFile = [System.IO.Path]::GetTempFileName()
         try {
-            $out = $fullMsg | & ssh '-i', $sshKey,
-                '-o','StrictHostKeyChecking=accept-new',
-                '-o','ConnectTimeout=10',
-                '-o','BatchMode=yes',
-                $hostTarget, $remoteCmd 2>$errFile
+            $sendArgs = @(
+                '-i', $sshKey,
+                '-o', 'StrictHostKeyChecking=accept-new',
+                '-o', 'ConnectTimeout=10',
+                '-o', 'BatchMode=yes',
+                $hostTarget, $remoteCmd
+            )
+            $out = $fullMsg | & ssh @sendArgs 2>$errFile
             $stderrRaw = if (Test-Path $errFile) { (Get-Content $errFile -Raw -ErrorAction SilentlyContinue) } else { '' }
             if ($out -match '__APPENDED__') {
                 # delivered
@@ -1518,8 +1530,14 @@ function Invoke-SendFile {
     $rhome = Get-RemoteHome
     Invoke-AircSsh $targetHost "mkdir -p $rhome/files/$myName" 2>$null
     $sshKey = Join-Path $IDENTITY_DIR 'ssh_key'
-    & scp '-i', $sshKey, '-o','StrictHostKeyChecking=accept-new', '-q',
-        $filepath, "${targetHost}:${rhome}/files/${myName}/${filename}" 2>&1
+    $scpArgs = @(
+        '-i', $sshKey,
+        '-o', 'StrictHostKeyChecking=accept-new',
+        '-q',
+        $filepath,
+        "${targetHost}:${rhome}/files/${myName}/${filename}"
+    )
+    & scp @scpArgs 2>&1
     if ($LASTEXITCODE -ne 0) { Die "scp failed for $filename" }
     $size = (Get-Item $filepath).Length
     Invoke-Send -Argv @("@$peerName", "Sent file: $filename ($size bytes)") | Out-Null
@@ -1680,11 +1698,14 @@ function Invoke-Connect {
             # Auth probe before committing to monitor loop
             $sshKey = Join-Path $IDENTITY_DIR 'ssh_key'
             $probeErr = [System.IO.Path]::GetTempFileName()
-            $probeOut = & ssh '-i', $sshKey,
-                '-o','StrictHostKeyChecking=accept-new',
-                '-o','ConnectTimeout=5',
-                '-o','BatchMode=yes',
-                $priorHost, 'echo __AUTH_OK__' 2>$probeErr
+            $authProbeArgs = @(
+                '-i', $sshKey,
+                '-o', 'StrictHostKeyChecking=accept-new',
+                '-o', 'ConnectTimeout=5',
+                '-o', 'BatchMode=yes',
+                $priorHost, 'echo __AUTH_OK__'
+            )
+            $probeOut = & ssh @authProbeArgs 2>$probeErr
             $stderrText = (Get-Content $probeErr -Raw -ErrorAction SilentlyContinue)
             Remove-Item $probeErr -Force -ErrorAction SilentlyContinue
             if ($probeOut -notmatch '__AUTH_OK__') {

--- a/airc.ps1
+++ b/airc.ps1
@@ -154,18 +154,112 @@ function Resolve-AircName {
     return $name
 }
 
+# -- Tailscale helpers (parity with bash: resolve_tailscale_bin,
+#    is_peer_offline_in_tailnet, advise_tailscale_if_down) -----------------
+# Extracted into named helpers so Get-AircHost, Invoke-Send, and
+# Invoke-Connect all resolve the binary the same way. Mirrors canary's
+# 4d41dab / 64b604d / 0f8d8a7.
+function Resolve-TailscaleBin {
+    # Priority:
+    #   1. tailscale / tailscale.exe on PATH
+    #   2. C:\Program Files\Tailscale\tailscale.exe
+    #   3. C:\Program Files (x86)\Tailscale\tailscale.exe
+    foreach ($name in @('tailscale', 'tailscale.exe')) {
+        $cmd = Get-Command $name -ErrorAction SilentlyContinue
+        if ($cmd) { return $cmd.Source }
+    }
+    foreach ($p in @(
+        'C:\Program Files\Tailscale\tailscale.exe',
+        'C:\Program Files (x86)\Tailscale\tailscale.exe'
+    )) {
+        if (Test-Path $p) { return $p }
+    }
+    return $null
+}
+
+function Test-CgnatIp {
+    # Tailscale CGNAT range 100.64.0.0/10 = 100.64.0.0 .. 100.127.255.255
+    param([string]$Ip)
+    if (-not $Ip) { return $false }
+    if ($Ip -match '^100\.(\d+)\.') {
+        $second = [int]$matches[1]
+        return ($second -ge 64 -and $second -le 127)
+    }
+    return $false
+}
+
+function Test-PeerOfflineInTailnet {
+    # Return $true only when we can CONFIRM the peer at the given IP is
+    # offline according to our local tailscale status. Used as a fast-path
+    # gate in Invoke-Send so a known-offline peer skips the 10s SSH
+    # ConnectTimeout and queues straight away. Mirrors bash
+    # is_peer_offline_in_tailnet (commit 64b604d).
+    param([string]$TargetHost)
+    if (-not $TargetHost) { return $false }
+    if (-not (Test-CgnatIp -Ip $TargetHost)) { return $false }
+    $ts = Resolve-TailscaleBin
+    if (-not $ts) { return $false }
+    $out = & $ts status 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $out) { return $false }
+    foreach ($line in $out) {
+        # Plain-text: <IP>  <hostname>  <owner>  <os>  <state...>
+        # When a peer is offline the state column has the literal word
+        # "offline" on the same line. Match IP at column 1 + word offline.
+        $cols = ($line -split '\s+', 2)
+        if ($cols.Count -ge 1 -and $cols[0] -eq $TargetHost -and $line -match '\boffline\b') {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Advise-TailscaleIfDown {
+    # When a saved pairing points at a Tailscale CGNAT address and the
+    # local Tailscale daemon is NOT running, cmd_connect would silently
+    # hang on SSH ConnectTimeout. Instead, print fail-loud instructions
+    # and return $true so the caller exits. Mirrors bash
+    # advise_tailscale_if_down (commit 0f8d8a7).
+    # Returns $true when the caller should ABORT (we printed guidance).
+    # Returns $false when it is safe to proceed (non-CGNAT, env override,
+    # or tailnet already up).
+    param([string]$TargetHost)
+    if ($env:AIRC_NO_TAILSCALE -eq '1') { return $false }
+    if (-not $TargetHost) { return $false }
+    if (-not (Test-CgnatIp -Ip $TargetHost)) { return $false }
+
+    $ts = Resolve-TailscaleBin
+    if ($ts) {
+        & $ts status 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) { return $false }   # daemon up, proceed
+    }
+
+    Write-Host ''
+    Write-Host "X airc: can't reach Tailscale-routed host $TargetHost -- Tailscale appears down on this machine."
+    Write-Host ''
+    if (-not $ts) {
+        Write-Host '   Tailscale is not installed. airc needs it only for cross-machine mesh.'
+        Write-Host '   Install:'
+        Write-Host '     winget install --id tailscale.tailscale'
+        Write-Host '     (or https://tailscale.com/download/windows)'
+        Write-Host ''
+        Write-Host '   After install, bring the tailnet up and re-run airc join.'
+        return $true
+    }
+    Write-Host '   Tailscale CLI is installed but the daemon is not running. Start it:'
+    Write-Host '     (Windows) Click the Tailscale tray icon to start the app.'
+    Write-Host '               Or from an elevated PowerShell:  Start-Service Tailscale'
+    Write-Host ''
+    return $true
+}
+
 # -- get_host: tailscale IP > LAN IP > hostname -------------------------
-# We use the same priority order as bash: tailscale first (works on the
-# whole tailnet), LAN IP next (no Tailscale required for same-LAN), then
+# Priority order matches bash: tailscale IP first (works across the whole
+# tailnet), LAN IP next (no Tailscale required for same-LAN mesh), then
 # hostname as last resort. AIRC_NO_TAILSCALE=1 forces past tailscale.
 function Get-AircHost {
     $tsBin = $null
     if ($env:AIRC_NO_TAILSCALE -ne '1') {
-        $cmd = Get-Command tailscale -ErrorAction SilentlyContinue
-        if ($cmd) { $tsBin = $cmd.Source }
-        elseif (Test-Path 'C:\Program Files\Tailscale\tailscale.exe') {
-            $tsBin = 'C:\Program Files\Tailscale\tailscale.exe'
-        }
+        $tsBin = Resolve-TailscaleBin
     }
     if ($tsBin) {
         try {
@@ -1293,6 +1387,27 @@ function Invoke-Send {
         # Mirror locally FIRST so we always have an audit trail.
         Add-Content -Path $MESSAGES -Value $fullMsg
 
+        # Fast-path: if the target is a Tailscale CGNAT IP and tailscale
+        # status already reports the peer as offline, skip the 10s SSH
+        # ConnectTimeout and queue immediately with a cleaner marker.
+        # flush_pending_loop + monitor reconnect handle the drain when
+        # the peer wakes. Mirrors bash 64b604d.
+        if (Test-PeerOfflineInTailnet -TargetHost $hostTarget) {
+            $pending = Join-Path $AIRC_WRITE_DIR 'pending.jsonl'
+            Add-Content -Path $pending -Value $fullMsg
+            $marker = ([ordered]@{
+                from = 'airc'
+                ts   = (Get-Timestamp)
+                msg  = "[QUEUED to $peerName - peer offline in tailnet, auto-delivers on wake]"
+            } | ConvertTo-Json -Compress)
+            Add-Content -Path $MESSAGES -Value $marker
+            # Reset reminder state (we did send something, just queued)
+            $now = [int][double]::Parse(((Get-Date).ToUniversalTime() - [DateTime]'1970-01-01').TotalSeconds)
+            Set-Content -Path (Join-Path $AIRC_WRITE_DIR 'last_sent') -Value $now -NoNewline
+            Remove-Item (Join-Path $AIRC_WRITE_DIR 'reminded') -Force -ErrorAction SilentlyContinue
+            return
+        }
+
         $sshKey = Join-Path $IDENTITY_DIR 'ssh_key'
         $remoteCmd = "cat >> $rhome/messages.jsonl && echo __APPENDED__"
         $errFile = [System.IO.Path]::GetTempFileName()
@@ -1544,6 +1659,15 @@ function Invoke-Connect {
         if ($priorHost) {
             $priorName = Get-ConfigVal -Key 'host_name' -Default (Get-Name)
             Write-Host "  Resuming as joiner of '$priorName' ($priorHost)..."
+            # Tailscale-down fail-loud: if the saved host is CGNAT and
+            # Tailscale is not running locally, SSH would hang 5s on the
+            # ConnectTimeout then the monitor retry loop would spin forever
+            # with no actionable signal. Advise-TailscaleIfDown prints
+            # platform-specific start instructions and returns $true when
+            # the caller should abort. Mirrors bash 0f8d8a7.
+            if (Advise-TailscaleIfDown -TargetHost $priorHost) {
+                Die 'Re-run airc join after starting Tailscale.'
+            }
             # Auth probe before committing to monitor loop
             $sshKey = Join-Path $IDENTITY_DIR 'ssh_key'
             $probeErr = [System.IO.Path]::GetTempFileName()

--- a/airc.ps1
+++ b/airc.ps1
@@ -1114,12 +1114,12 @@ function Invoke-Part {
 
 # -- cmd_channel --------------------------------------------------------
 function Invoke-Channel {
-    param([string[]]$Args)
+    param([string[]]$Argv)
     $dir = if ($env:AIRC_DIR) { $env:AIRC_DIR } else { Join-Path $env:USERPROFILE '.airc-src' }
     $channelFile = Join-Path $dir '.channel'
     $current = if (Test-Path $channelFile) { (Get-Content $channelFile -Raw).Trim() } else { 'main' }
     if (-not $current) { $current = 'main' }
-    $target = if ($Args -and $Args.Count -gt 0) { $Args[0] } else { '' }
+    $target = if ($Argv -and $Argv.Count -gt 0) { $Argv[0] } else { '' }
     if (-not $target) {
         Write-Host "  Channel: $current"
         Write-Host '  Available channels (any branch on origin can be a channel):'
@@ -1136,10 +1136,10 @@ function Invoke-Channel {
 
 # -- cmd_logs -----------------------------------------------------------
 function Invoke-Logs {
-    param([string[]]$Args)
+    param([string[]]$Argv)
     Ensure-Init
     $count = 20
-    if ($Args -and $Args.Count -gt 0 -and $Args[0] -match '^\d+$') { $count = [int]$Args[0] }
+    if ($Argv -and $Argv.Count -gt 0 -and $Argv[0] -match '^\d+$') { $count = [int]$Argv[0] }
     $hostTarget = Get-ConfigVal -Key 'host_target' -Default ''
     if ($hostTarget) {
         $rhome = Get-RemoteHome
@@ -1158,9 +1158,9 @@ function Invoke-Logs {
 
 # -- cmd_reminder -------------------------------------------------------
 function Invoke-Reminder {
-    param([string[]]$Args)
+    param([string[]]$Argv)
     Ensure-Init
-    $arg = if ($Args -and $Args.Count -gt 0) { $Args[0] } else { 'status' }
+    $arg = if ($Argv -and $Argv.Count -gt 0) { $Argv[0] } else { 'status' }
     $reminderFile = Join-Path $AIRC_WRITE_DIR 'reminder'
     switch -Regex ($arg) {
         '^(off|0)$'  {
@@ -1188,9 +1188,9 @@ function Invoke-Reminder {
 
 # -- cmd_status ---------------------------------------------------------
 function Invoke-Status {
-    param([string[]]$Args)
+    param([string[]]$Argv)
     Ensure-Init
-    $probe = ($Args -and $Args -contains '--probe')
+    $probe = ($Argv -and $Argv -contains '--probe')
     $myName     = Get-Name
     $hostTarget = Get-ConfigVal -Key 'host_target' -Default ''
     $hostName   = Get-ConfigVal -Key 'host_name'   -Default ''
@@ -1256,9 +1256,9 @@ function Invoke-Status {
 # -- cmd_teardown -------------------------------------------------------
 # Bash uses pgrep -P + kill. Windows: taskkill /T /F walks the tree.
 function Invoke-Teardown {
-    param([string[]]$Args)
-    $flush = ($Args -contains '--flush')
-    $all   = ($Args -contains '--all')
+    param([string[]]$Argv)
+    $flush = ($Argv -contains '--flush')
+    $all   = ($Argv -contains '--all')
     $killed = $false
 
     if ($all) {
@@ -1336,8 +1336,8 @@ function Invoke-Disconnect {
 
 # -- cmd_rename / cmd_nick ----------------------------------------------
 function Invoke-Rename {
-    param([string[]]$Args)
-    $newName = if ($Args -and $Args.Count -gt 0) { $Args[0] } else { '' }
+    param([string[]]$Argv)
+    $newName = if ($Argv -and $Argv.Count -gt 0) { $Argv[0] } else { '' }
     if (-not $newName -or $newName -in @('-h','--help')) {
         Write-Host 'Usage: airc nick <new-name>'
         Write-Host '  Renames this identity and broadcasts [rename] to peers.'
@@ -1353,26 +1353,26 @@ function Invoke-Rename {
     Set-ConfigVal -Updates @{ name = $newName }
     Write-Host "  Renamed: $oldName -> $newName"
     $myHost = "$($env:USERNAME)@$(Get-AircHost)"
-    try { Invoke-Send -Args @("[rename] old=$oldName new=$newName host=$myHost") | Out-Null } catch { }
+    try { Invoke-Send -Argv @("[rename] old=$oldName new=$newName host=$myHost") | Out-Null } catch { }
 }
 
 # -- cmd_send / cmd_msg -------------------------------------------------
 # Local-mirror-first, then SSH append to host's messages.jsonl.
 # Auth-vs-network failure distinction (per fix #17).
 function Invoke-Send {
-    param([string[]]$Args)
-    if (-not $Args -or $Args.Count -eq 0) {
+    param([string[]]$Argv)
+    if (-not $Argv -or $Argv.Count -eq 0) {
         Die 'Usage: airc msg <message>  or  airc msg @peer <message>'
     }
-    $first = $Args[0]
+    $first = $Argv[0]
     $peerName = 'all'
     $msg = ''
     if ($first.StartsWith('@')) {
         $peerName = $first.Substring(1)
-        if ($Args.Count -lt 2) { Die 'Usage: airc msg @peer <message>' }
-        $msg = ($Args[1..($Args.Count - 1)] -join ' ')
+        if ($Argv.Count -lt 2) { Die 'Usage: airc msg @peer <message>' }
+        $msg = ($Argv[1..($Argv.Count - 1)] -join ' ')
     } else {
-        $msg = ($Args -join ' ')
+        $msg = ($Argv -join ' ')
     }
     Ensure-Init
 
@@ -1462,17 +1462,17 @@ function Invoke-Send {
 
 # -- cmd_ping -----------------------------------------------------------
 function Invoke-Ping {
-    param([string[]]$Args)
-    if (-not $Args -or $Args.Count -eq 0) { Die 'Usage: airc ping @peer [timeout_secs]' }
-    $first = $Args[0]
+    param([string[]]$Argv)
+    if (-not $Argv -or $Argv.Count -eq 0) { Die 'Usage: airc ping @peer [timeout_secs]' }
+    $first = $Argv[0]
     if (-not $first.StartsWith('@')) { Die 'Usage: airc ping @peer (broadcast ping not supported)' }
     $peerName = $first.Substring(1)
-    $timeout  = if ($Args.Count -gt 1 -and $Args[1] -match '^\d+$') { [int]$Args[1] } else { 10 }
+    $timeout  = if ($Argv.Count -gt 1 -and $Argv[1] -match '^\d+$') { [int]$Argv[1] } else { 10 }
     Ensure-Init
 
     $pingId = [guid]::NewGuid().ToString()
     $startTime = Get-Date
-    Invoke-Send -Args @("@$peerName", "[PING:$pingId]") | Out-Null
+    Invoke-Send -Argv @("@$peerName", "[PING:$pingId]") | Out-Null
     Write-Host "ping sent to $peerName (id=$pingId) - waiting up to ${timeout}s for pong..."
 
     while ($true) {
@@ -1501,10 +1501,10 @@ function Invoke-Ping {
 
 # -- cmd_send_file ------------------------------------------------------
 function Invoke-SendFile {
-    param([string[]]$Args)
-    if (-not $Args -or $Args.Count -lt 2) { Die 'Usage: airc send-file <peer> <path>' }
-    $peerName = $Args[0]
-    $filepath = $Args[1]
+    param([string[]]$Argv)
+    if (-not $Argv -or $Argv.Count -lt 2) { Die 'Usage: airc send-file <peer> <path>' }
+    $peerName = $Argv[0]
+    $filepath = $Argv[1]
     if (-not (Test-Path $filepath)) { Die "File not found: $filepath" }
     Ensure-Init
     $hostTarget = Get-ConfigVal -Key 'host_target' -Default ''
@@ -1518,20 +1518,20 @@ function Invoke-SendFile {
         $filepath, "${targetHost}:${rhome}/files/${myName}/${filename}" 2>&1
     if ($LASTEXITCODE -ne 0) { Die "scp failed for $filename" }
     $size = (Get-Item $filepath).Length
-    Invoke-Send -Args @("@$peerName", "Sent file: $filename ($size bytes)") | Out-Null
+    Invoke-Send -Argv @("@$peerName", "Sent file: $filename ($size bytes)") | Out-Null
     Write-Host "Sent $filename ($size bytes)"
 }
 
 # -- cmd_update / cmd_canary --------------------------------------------
 function Invoke-Update {
-    param([string[]]$Args)
+    param([string[]]$Argv)
     $dir = if ($env:AIRC_DIR) { $env:AIRC_DIR } else { Join-Path $env:USERPROFILE '.airc-src' }
     $channelFile = Join-Path $dir '.channel'
     $requested = ''
-    for ($i = 0; $i -lt $Args.Count; $i++) {
-        switch ($Args[$i]) {
-            '--channel'  { $requested = $Args[$i + 1]; $i++ }
-            '-c'         { $requested = $Args[$i + 1]; $i++ }
+    for ($i = 0; $i -lt $Argv.Count; $i++) {
+        switch ($Argv[$i]) {
+            '--channel'  { $requested = $Argv[$i + 1]; $i++ }
+            '-c'         { $requested = $Argv[$i + 1]; $i++ }
             '--canary'   { $requested = 'canary' }
             '--main'     { $requested = 'main' }
         }
@@ -1571,8 +1571,8 @@ function Invoke-Update {
 # launchd / systemd analog on Windows is the Task Scheduler. We register
 # a per-user task that runs at logon, restarts on failure.
 function Invoke-Daemon {
-    param([string[]]$Args)
-    $action = if ($Args -and $Args.Count -gt 0) { $Args[0] } else { 'status' }
+    param([string[]]$Argv)
+    $action = if ($Argv -and $Argv.Count -gt 0) { $Argv[0] } else { 'status' }
     $taskName = 'AIRC'
     switch ($action) {
         'install' {
@@ -1624,7 +1624,7 @@ function Invoke-Tests {
 # The big one. host vs joiner branching, gh discovery, mnemonic resolver,
 # pair handshake (TCP), monitor launch.
 function Invoke-Connect {
-    param([string[]]$Args)
+    param([string[]]$Argv)
     # Flag parsing
     $useGist = $true
     $roomName = 'general'
@@ -1632,13 +1632,13 @@ function Invoke-Connect {
     $resolvedRoomName = ''
     $resolvedGistId   = ''
     $positional = @()
-    for ($i = 0; $i -lt $Args.Count; $i++) {
-        switch -Regex ($Args[$i]) {
+    for ($i = 0; $i -lt $Argv.Count; $i++) {
+        switch -Regex ($Argv[$i]) {
             '^(--gist|-gist)$' { $useGist = $true }
             '^(--no-gist|-no-gist)$' { $useGist = $false }
-            '^(--room|-room)$' { $roomName = $Args[$i + 1]; $useRoom = $true; $i++ }
+            '^(--room|-room)$' { $roomName = $Argv[$i + 1]; $useRoom = $true; $i++ }
             '^(--no-general|-no-general|--no-room|-no-room)$' { $useRoom = $false }
-            default { $positional += $Args[$i] }
+            default { $positional += $Argv[$i] }
         }
     }
     $target = if ($positional.Count -gt 0) { $positional[0] } else { '' }
@@ -1861,7 +1861,7 @@ function Invoke-Connect {
                 Write-Host "  Re-launching into host mode for #$resolvedRoomName ..."
                 $env:AIRC_NO_DISCOVERY = '1'
                 if ($preservedName) { $env:AIRC_NAME = $preservedName }
-                Invoke-Connect -Args @('--room', $resolvedRoomName)
+                Invoke-Connect -Argv @('--room', $resolvedRoomName)
                 return
             }
             Die "Can't reach ${peerHostOnly}:$peerPort. Is the host running 'airc connect'?"
@@ -2171,16 +2171,16 @@ try {
         { $_ -in @('tests','test') }                   { Invoke-Tests; break }
 
         # Connection lifecycle
-        { $_ -in @('connect','setup','start','join','resume') } { Invoke-Connect -Args $rest; break }
+        { $_ -in @('connect','setup','start','join','resume') } { Invoke-Connect -Argv $rest; break }
 
         # Messaging
-        { $_ -in @('send','msg','say','privmsg') }    { Invoke-Send -Args $rest; break }
-        'send-file'                                    { Invoke-SendFile -Args $rest; break }
-        'ping'                                         { Invoke-Ping -Args $rest; break }
+        { $_ -in @('send','msg','say','privmsg') }    { Invoke-Send -Argv $rest; break }
+        'send-file'                                    { Invoke-SendFile -Argv $rest; break }
+        'ping'                                         { Invoke-Ping -Argv $rest; break }
 
         # Identity / peers
-        { $_ -in @('rename','nick') }                 { Invoke-Rename -Args $rest; break }
-        'reminder'                                     { Invoke-Reminder -Args $rest; break }
+        { $_ -in @('rename','nick') }                 { Invoke-Rename -Argv $rest; break }
+        'reminder'                                     { Invoke-Reminder -Argv $rest; break }
         'peers'                                        { Invoke-Peers; break }
 
         # Rooms / discovery
@@ -2189,20 +2189,20 @@ try {
         'part'                                         { Invoke-Part; break }
 
         # Lifecycle / disconnect
-        { $_ -in @('teardown','stop','flush') }       { Invoke-Teardown -Args $rest; break }
+        { $_ -in @('teardown','stop','flush') }       { Invoke-Teardown -Argv $rest; break }
         { $_ -in @('disconnect','quit','leave','unbind') } { Invoke-Disconnect; break }
 
         # Diagnostic
-        'logs'                                         { Invoke-Logs -Args $rest; break }
-        'status'                                       { Invoke-Status -Args $rest; break }
+        'logs'                                         { Invoke-Logs -Argv $rest; break }
+        'status'                                       { Invoke-Status -Argv $rest; break }
 
         # Updates / channels
-        { $_ -in @('update','upgrade','pull') }       { Invoke-Update -Args $rest; break }
-        'channel'                                      { Invoke-Channel -Args $rest; break }
-        'canary'                                       { Invoke-Update -Args (@('--channel','canary') + $rest); break }
+        { $_ -in @('update','upgrade','pull') }       { Invoke-Update -Argv $rest; break }
+        'channel'                                      { Invoke-Channel -Argv $rest; break }
+        'canary'                                       { Invoke-Update -Argv (@('--channel','canary') + $rest); break }
 
         # Daemon (Task Scheduler on Windows)
-        { $_ -in @('daemon','autostart','service') }  { Invoke-Daemon -Args $rest; break }
+        { $_ -in @('daemon','autostart','service') }  { Invoke-Daemon -Argv $rest; break }
 
         # Monitor (rare standalone use)
         'monitor'                                      { Start-AircMonitor -MyName (Get-Name); break }

--- a/install.ps1
+++ b/install.ps1
@@ -1,116 +1,323 @@
-# install.ps1 — Windows-native PowerShell installer for airc
+# install.ps1 -- Windows-native installer for airc.
 #
-# Mirrors install.sh for Windows. Both installers MUST agree on:
-#   - Skill directory layout (~/.claude/skills/<name>/SKILL.md symlinks)
-#   - Old-symlink cleanup list (so renames self-heal across updates)
-#   - Channel persistence ($AIRC_DIR/.channel)
+# Mirrors install.sh for POSIX (bash) -- same shape, same skills wiring,
+# same channel persistence -- but bootstraps the Windows-native PS port
+# (airc.ps1) with auto-install of every prereq via winget.
 #
-# Hard requirements (we fail loud if missing — per Joel's "loud failure
-# beats silent slowness" rule):
-#   - PowerShell 7+ (Core)
-#   - git (for clone + update)
-#   - gh CLI
-#   - OpenSSH client (built into Windows 10+ as optional feature)
-#   - Tailscale (Windows MSI installer)
-#   - Python 3 (for the watchdog/formatter heredocs in airc.ps1, until
-#     ported to pure PowerShell)
+# Designed for FIRST-TIME Windows users with NOTHING pre-installed.
+# Bootstraps from Windows PowerShell 5.1 (the default that ships with
+# Windows 10/11 -- no pwsh required to start). Installs:
+#   - PowerShell 7+    (airc.ps1 needs it)
+#   - Git              (clone + update)
+#   - Python 3         (used by monitor formatter heredoc + LAN-IP probe)
+#   - GitHub CLI (gh)  (gist transport -- the room substrate)
+#   - Tailscale        (peer addressing -- optional, LAN fallback works)
+# OpenSSH client is built into Windows 10+ as an Optional Feature; we
+# enable it if missing.
 #
-# NOT a requirement: WSL, mingw, Cygwin. This installer is for native
-# Windows. The bash install.sh handles POSIX (incl. WSL) installs.
+# Single command setup, from any PowerShell prompt (incl. the default 5.1):
+#
+#   iwr https://raw.githubusercontent.com/CambrianTech/airc/canary/install.ps1 | iex
+#
+# Or clone + run:
+#
+#   git clone https://github.com/CambrianTech/airc.git $HOME\.airc-src
+#   pwsh $HOME\.airc-src\install.ps1   # or: powershell -ExecutionPolicy Bypass -File ...
+#
+# After install: open a NEW shell so PATH refreshes, then `airc join`.
 
-#Requires -Version 7.0
+# We deliberately DO NOT require -Version 7 here -- this script must run
+# from the default Windows PowerShell 5.1 to bootstrap pwsh itself.
 $ErrorActionPreference = 'Stop'
 
-$CLONE_DIR     = if ($env:AIRC_DIR)     { $env:AIRC_DIR }     else { Join-Path $env:USERPROFILE '.airc-src' }
-$BIN_TARGET    = if ($env:BIN_TARGET)   { $env:BIN_TARGET }   else { Join-Path $env:USERPROFILE 'AppData\Local\Programs\airc' }
+# Paths. AIRC_DIR controls where the source lives; BIN_TARGET is where
+# airc.cmd / airc.ps1 land (added to user PATH); SKILLS_TARGET is where
+# Claude Code looks for slash-command skills. All three honor env-var
+# overrides for tests + isolated installs (parity with install.sh).
+$CLONE_DIR     = if ($env:AIRC_DIR)      { $env:AIRC_DIR }      else { Join-Path $env:USERPROFILE '.airc-src' }
+$BIN_TARGET    = if ($env:BIN_TARGET)    { $env:BIN_TARGET }    else { Join-Path $env:USERPROFILE 'AppData\Local\Programs\airc' }
 $SKILLS_TARGET = if ($env:SKILLS_TARGET) { $env:SKILLS_TARGET } else { Join-Path $env:USERPROFILE '.claude\skills' }
+$REPO_URL      = 'https://github.com/CambrianTech/airc.git'
 
-function Test-Required {
-    param([string]$Cmd, [string]$Hint)
-    if (-not (Get-Command $Cmd -ErrorAction SilentlyContinue)) {
-        Write-Error "REQUIRED: $Cmd not found on PATH. $Hint"
+# Channel persistence: same scheme as install.sh -- $CLONE_DIR/.channel
+# holds the user's release-channel preference (main / canary). Honored
+# by `airc update`.
+$DEFAULT_CHANNEL = if ($env:AIRC_CHANNEL) { $env:AIRC_CHANNEL } else { 'canary' }
+
+function Write-Step($msg)  { Write-Host "  -> $msg" }
+function Write-Ok($msg)    { Write-Host "  + $msg" -ForegroundColor Green }
+function Write-Warn2($msg) { Write-Host "  ! $msg" -ForegroundColor Yellow }
+function Write-Fail($msg)  { Write-Host "  x $msg" -ForegroundColor Red }
+
+# -- Refresh PATH from registry ------------------------------------------
+# winget updates the User PATH in the registry but the current session
+# inherits the old PATH from when this script started. Without a refresh,
+# any tool we just installed won't be found by Get-Command in the same
+# session. Pulling Machine + User PATH and re-merging mirrors what a
+# brand-new shell would inherit.
+function Update-SessionPath {
+    $machine = [Environment]::GetEnvironmentVariable('PATH', 'Machine')
+    $user    = [Environment]::GetEnvironmentVariable('PATH', 'User')
+    $env:PATH = "$machine;$user"
+}
+
+# -- winget bootstrap ----------------------------------------------------
+# winget ships with Windows 10 (1809+) and Windows 11 by default via the
+# App Installer package. If a user is on a much older Windows OR has
+# stripped App Installer, we can't auto-install -- flag it loud with the
+# exact Microsoft Store / GitHub Releases URL to recover.
+function Test-WingetAvailable {
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        Write-Fail 'winget not found. winget is the Windows package manager that ships with App Installer (Microsoft Store).'
+        Write-Host ''
+        Write-Host '  Install it manually then re-run this script:'
+        Write-Host '    1. Open the Microsoft Store, search "App Installer", click Install/Update'
+        Write-Host '       (or: https://www.microsoft.com/store/productId/9NBLGGH4NNS1)'
+        Write-Host '    2. Reopen PowerShell and run this installer again.'
+        Write-Host ''
+        Write-Host '  If you cannot use the Microsoft Store, install manually from'
+        Write-Host '  https://github.com/microsoft/winget-cli/releases (latest .msixbundle).'
         exit 1
     }
 }
 
-# ── Prereq audit ───────────────────────────────────────────────────────────
-
-Test-Required 'git' 'Install Git for Windows: https://git-scm.com/download/win'
-Test-Required 'gh'  'Install gh CLI: https://cli.github.com/ — then gh auth login'
-Test-Required 'ssh' 'Install OpenSSH client: Settings → Apps → Optional Features → Add → OpenSSH Client'
-Test-Required 'python' 'Install Python 3.10+: https://www.python.org/downloads/windows/ (or Microsoft Store)'
-
-if (-not (Get-Command 'tailscale' -ErrorAction SilentlyContinue)) {
-    Write-Warning 'Tailscale CLI not on PATH. Install from https://tailscale.com/download/windows. Continuing — airc will fail on connect if Tailscale is not running.'
+# -- Install one winget package, idempotent ------------------------------
+# Test-Cmd: a callable that returns $true when the package is already
+# usable (e.g. {Get-Command python} or a custom probe). Skips winget on
+# hits -- saves the 30s+ download/install round trip.
+function Install-IfMissing {
+    param(
+        [string]$Name,        # human label for messages
+        [string]$WingetId,    # winget package id (e.g. Python.Python.3.12)
+        [scriptblock]$TestCmd # returns truthy when already installed
+    )
+    if (& $TestCmd) {
+        Write-Ok "$Name already installed"
+        return
+    }
+    Write-Step "Installing $Name (winget: $WingetId) ..."
+    # --silent: no UI prompts. --accept-*: prevents one-time first-run
+    # interactive accepts that would block CI / first-time install.
+    # --disable-interactivity: belt-and-suspenders against any winget
+    # prompt that would hang a non-interactive bootstrap.
+    $wingetArgs = @(
+        'install', '--id', $WingetId,
+        '--exact',
+        '--silent',
+        '--accept-package-agreements',
+        '--accept-source-agreements',
+        '--disable-interactivity'
+    )
+    & winget @wingetArgs
+    if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne -1978335189) {
+        # -1978335189 (0x8A15002B) = APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE
+        # = "already installed, no update needed". Treat as success.
+        Write-Warn2 "winget exit $LASTEXITCODE for $Name -- continuing; the post-install probe below decides if we recover."
+    }
+    Update-SessionPath
+    if (& $TestCmd) {
+        Write-Ok "$Name installed"
+    } else {
+        Write-Fail "$Name install completed but probe still fails. PATH may need a fresh shell. Re-run after opening a new PowerShell window."
+    }
 }
 
-# ── Clone or update ────────────────────────────────────────────────────────
+# -- OpenSSH client (Windows Optional Feature, not winget) ---------------
+# Windows 10 build 1803+ has OpenSSH Client as an installable Capability.
+# Capability install needs admin; if we don't have it, fall back to a
+# clear instruction. Most modern Windows installs already ship it on.
+function Install-OpenSSHClient {
+    if (Get-Command ssh -ErrorAction SilentlyContinue) {
+        Write-Ok 'OpenSSH client already installed'
+        return
+    }
+    Write-Step 'Enabling OpenSSH Client (Windows Capability) ...'
+    try {
+        $cap = Get-WindowsCapability -Online -Name 'OpenSSH.Client*' -ErrorAction Stop
+        if ($cap.State -ne 'Installed') {
+            Add-WindowsCapability -Online -Name $cap.Name -ErrorAction Stop | Out-Null
+        }
+        Update-SessionPath
+        if (Get-Command ssh -ErrorAction SilentlyContinue) {
+            Write-Ok 'OpenSSH client installed'
+        } else {
+            Write-Warn2 'OpenSSH install reported success but ssh still not found. Open a new shell after the installer finishes.'
+        }
+    } catch {
+        Write-Warn2 "Could not auto-install OpenSSH Client (admin may be required): $_"
+        Write-Host '    Manual fix: Settings -> Apps -> Optional Features -> Add an Optional Feature -> OpenSSH Client'
+    }
+}
 
+# -- Banner --------------------------------------------------------------
+Write-Host ''
+Write-Host '  AIRC installer (Windows native)'
+Write-Host '  --------------------------------'
+Write-Host ''
+
+Test-WingetAvailable
+
+# -- Install prereqs -----------------------------------------------------
+# Order matters lightly: git first so we can clone, then pwsh + python
+# for runtime, then gh + tailscale for the substrate. OpenSSH last
+# because it uses a different mechanism (Capability) than winget.
+
+Install-IfMissing -Name 'Git for Windows'    -WingetId 'Git.Git'             -TestCmd { Get-Command git -ErrorAction SilentlyContinue }
+Install-IfMissing -Name 'PowerShell 7+'      -WingetId 'Microsoft.PowerShell' -TestCmd { Get-Command pwsh -ErrorAction SilentlyContinue }
+Install-IfMissing -Name 'Python 3'           -WingetId 'Python.Python.3.12'  -TestCmd {
+    # Probe both the launcher (`py -3`) and direct `python`. Either is fine
+    # for airc.ps1's Python invocations. Skip the App Execution Alias stub
+    # at $env:LOCALAPPDATA\Microsoft\WindowsApps\python.exe which prints
+    # "Python was not found; run without arguments to install ..." on call.
+    $py = Get-Command python -ErrorAction SilentlyContinue
+    if ($py -and $py.Source -notlike '*\WindowsApps\*') { return $true }
+    return [bool](Get-Command py -ErrorAction SilentlyContinue)
+}
+Install-IfMissing -Name 'GitHub CLI (gh)'    -WingetId 'GitHub.cli'          -TestCmd { Get-Command gh -ErrorAction SilentlyContinue }
+Install-IfMissing -Name 'Tailscale'          -WingetId 'tailscale.tailscale' -TestCmd { Get-Command tailscale -ErrorAction SilentlyContinue }
+
+Install-OpenSSHClient
+
+Write-Host ''
+
+# -- Clone or update the airc source -------------------------------------
+# Pulls $DEFAULT_CHANNEL on first install. install.sh has a more elaborate
+# self-recovery path for non-channel branches; mirror the basic shape here
+# (git fetch, ff-pull, surface failures cleanly).
 if (Test-Path (Join-Path $CLONE_DIR '.git')) {
-    Write-Host '  -> Updating existing install'
-    # TODO: parallel to install.sh:27..90 — channel-aware fetch + ff-pull,
-    # auto-recover from non-channel branches, surface ff failures with the
-    # actionable recovery block.
-    git -C $CLONE_DIR pull --ff-only --quiet
+    Write-Step "Updating existing checkout at $CLONE_DIR"
+    try {
+        & git -C $CLONE_DIR fetch --quiet origin
+        # If we're on the channel branch, ff-pull. Otherwise, leave the
+        # branch alone (user may be on a feature branch deliberately) and
+        # just print state.
+        $current = (& git -C $CLONE_DIR rev-parse --abbrev-ref HEAD).Trim()
+        if ($current -eq $DEFAULT_CHANNEL) {
+            & git -C $CLONE_DIR pull --ff-only --quiet
+        } else {
+            Write-Warn2 "Not on '$DEFAULT_CHANNEL' (currently on '$current') -- skipping pull. Run 'airc update' to switch."
+        }
+    } catch {
+        Write-Warn2 "git pull skipped: $_"
+    }
 } else {
-    Write-Host '  -> Installing AIRC'
+    Write-Step "Cloning airc source to $CLONE_DIR"
     New-Item -ItemType Directory -Force -Path (Split-Path $CLONE_DIR) | Out-Null
-    git clone --quiet https://github.com/CambrianTech/airc.git $CLONE_DIR
+    & git clone --quiet --branch $DEFAULT_CHANNEL $REPO_URL $CLONE_DIR
+    if ($LASTEXITCODE -ne 0) {
+        # Branch may not exist yet (e.g. user pulled from main) -- fall back
+        # to default branch + warn.
+        Write-Warn2 "Channel '$DEFAULT_CHANNEL' not found on origin; falling back to default branch."
+        & git clone --quiet $REPO_URL $CLONE_DIR
+        if ($LASTEXITCODE -ne 0) {
+            Write-Fail "git clone failed. Check network + that $REPO_URL is reachable."
+            exit 1
+        }
+    }
 }
 
-# ── Binary symlink: airc → airc.ps1 ────────────────────────────────────────
-# Windows symlinks need either Developer Mode or admin. Fall back to a
-# wrapper .cmd if symlink fails (TODO).
+# Persist channel preference (parity with install.sh's .channel file)
+$channelFile = Join-Path $CLONE_DIR '.channel'
+if (-not (Test-Path $channelFile) -or (Get-Content $channelFile -Raw -ErrorAction SilentlyContinue).Trim() -ne $DEFAULT_CHANNEL) {
+    Set-Content -Path $channelFile -Value $DEFAULT_CHANNEL -NoNewline
+}
 
+# -- Drop airc.cmd + airc.ps1 into BIN_TARGET ----------------------------
+# The .cmd shim is the magic that makes `airc <verb>` work from PowerShell,
+# cmd.exe, Windows Run dialog, scheduled tasks -- anywhere a Windows user
+# expects a normal command. It launches pwsh on the .ps1 by absolute path
+# so users never type pwsh, they just type `airc`.
+Write-Step "Wiring airc binary into $BIN_TARGET"
 New-Item -ItemType Directory -Force -Path $BIN_TARGET | Out-Null
-$aircLink = Join-Path $BIN_TARGET 'airc.ps1'
-if (Test-Path $aircLink) { Remove-Item $aircLink -Force }
-try {
-    New-Item -ItemType SymbolicLink -Path $aircLink -Target (Join-Path $CLONE_DIR 'airc.ps1') | Out-Null
-    Write-Host "  -> Linked airc.ps1 -> $CLONE_DIR\airc.ps1"
-} catch {
-    # Fall back to copy if symlink is denied
-    Copy-Item (Join-Path $CLONE_DIR 'airc.ps1') $aircLink -Force
-    Write-Warning "Symlink denied — fell back to copy. Re-run installer after each `git pull` to refresh."
+
+$srcPs1   = Join-Path $CLONE_DIR  'airc.ps1'
+$srcCmd   = Join-Path $CLONE_DIR  'airc.cmd'
+$dstPs1   = Join-Path $BIN_TARGET 'airc.ps1'
+$dstCmd   = Join-Path $BIN_TARGET 'airc.cmd'
+
+if (-not (Test-Path $srcPs1)) {
+    Write-Fail "airc.ps1 missing in $CLONE_DIR -- git checkout incomplete?"
+    exit 1
 }
 
-# Add BIN_TARGET to PATH for current user if not already present
+# Try a symlink first (so `git pull` updates pick up automatically); fall
+# back to copy if Developer Mode / admin isn't available. Either way the
+# .cmd shim launches the pwsh script by absolute path.
+foreach ($pair in @(
+    @{ Src = $srcPs1; Dst = $dstPs1 },
+    @{ Src = $srcCmd; Dst = $dstCmd }
+)) {
+    if (-not (Test-Path $pair.Src)) { continue }   # cmd shim is created below if missing
+    if (Test-Path $pair.Dst) { Remove-Item $pair.Dst -Force }
+    try {
+        New-Item -ItemType SymbolicLink -Path $pair.Dst -Target $pair.Src -ErrorAction Stop | Out-Null
+    } catch {
+        Copy-Item -Path $pair.Src -Destination $pair.Dst -Force
+    }
+}
+
+# If the repo doesn't yet ship airc.cmd (transitional -- feature/* branches
+# pre-shim), synthesize one in BIN_TARGET so the user still gets a working
+# `airc` command on PATH.
+if (-not (Test-Path $dstCmd)) {
+    $shimPs1Path = $dstPs1
+    $cmdContent = @"
+@echo off
+REM airc.cmd - Windows shim. Launches pwsh on airc.ps1 with all args.
+REM Generated by install.ps1 when the repo predates a checked-in airc.cmd.
+pwsh -NoLogo -NoProfile -File "$shimPs1Path" %*
+"@
+    Set-Content -Path $dstCmd -Value $cmdContent -Encoding ASCII
+}
+
+# Add BIN_TARGET to user PATH (idempotent).
 $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+if (-not $userPath) { $userPath = '' }
 if ($userPath -notlike "*$BIN_TARGET*") {
-    [Environment]::SetEnvironmentVariable('PATH', "$userPath;$BIN_TARGET", 'User')
-    Write-Host "  -> Added $BIN_TARGET to user PATH (open a new shell to pick up)"
+    $newPath = if ($userPath.Length -gt 0) { "$userPath;$BIN_TARGET" } else { $BIN_TARGET }
+    [Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
+    Write-Step "Added $BIN_TARGET to user PATH (open a NEW shell to pick up)"
 }
 
-# ── Skills ──────────────────────────────────────────────────────────────────
-# Mirror install.sh:114..142. The cleanup list MUST stay in sync with the
-# bash version — old skill names (connect/send/rename/disconnect from the
-# IRC rename, etc.) get nuked here so renames self-heal across updates.
-
-$skillsDir = Join-Path $CLONE_DIR 'skills'
-if (Test-Path $skillsDir) {
+# -- Skills wiring -------------------------------------------------------
+# Same as install.sh: each subdir under <repo>/skills becomes a slash
+# command in Claude Code. Symlink when possible (so `git pull` updates
+# pick up live), else copy. Cleanup list mirrors install.sh:
+# old skill names from the IRC rename (#59) self-heal across updates.
+$skillsSrc = Join-Path $CLONE_DIR 'skills'
+if (Test-Path $skillsSrc) {
+    Write-Step "Wiring skills into $SKILLS_TARGET"
     New-Item -ItemType Directory -Force -Path $SKILLS_TARGET | Out-Null
 
     $oldSkillNames = @('connect', 'send', 'rename', 'disconnect', 'monitor', 'setup', 'uninstall')
     foreach ($old in $oldSkillNames) {
         $oldPath = Join-Path $SKILLS_TARGET $old
-        if (Test-Path $oldPath) { Remove-Item $oldPath -Force -Recurse -ErrorAction SilentlyContinue }
+        if (Test-Path $oldPath) {
+            Remove-Item $oldPath -Force -Recurse -ErrorAction SilentlyContinue
+        }
     }
 
-    Get-ChildItem -Directory $skillsDir | ForEach-Object {
-        $target = Join-Path $SKILLS_TARGET $_.Name
-        if (Test-Path $target) { Remove-Item $target -Force -Recurse -ErrorAction SilentlyContinue }
+    Get-ChildItem -Directory $skillsSrc | ForEach-Object {
+        $dst = Join-Path $SKILLS_TARGET $_.Name
+        if (Test-Path $dst) { Remove-Item $dst -Force -Recurse -ErrorAction SilentlyContinue }
         try {
-            New-Item -ItemType SymbolicLink -Path $target -Target $_.FullName | Out-Null
+            New-Item -ItemType SymbolicLink -Path $dst -Target $_.FullName -ErrorAction Stop | Out-Null
         } catch {
-            # Fall back to copy on systems without symlink permission
-            Copy-Item -Recurse $_.FullName $target -Force
+            Copy-Item -Recurse -Path $_.FullName -Destination $dst -Force
         }
-        Write-Host "  -> Skill: /$($_.Name)"
+        Write-Host "    /$($_.Name)"
     }
 }
 
+# -- Final guidance ------------------------------------------------------
 Write-Host ''
-Write-Host '  -> Installed. Requires Tailscale: https://tailscale.com'
+Write-Ok 'airc installed.'
 Write-Host ''
-Write-Host '  airc join                       # auto-#general (joins existing or hosts)'
-Write-Host '  airc msg @<peer> <message>      # DM a peer (or omit @peer to broadcast)'
+Write-Host '  Next:'
+Write-Host '    1. Open a NEW PowerShell window (so PATH refreshes)'
+Write-Host '    2. Authenticate gh once:    gh auth login -s gist'
+Write-Host "    3. Bring Tailscale up:      tailscale up    (or skip - LAN works without it)"
+Write-Host '    4. Join the mesh:           airc join'
+Write-Host ''
+Write-Host '  Diagnose anytime:    airc doctor'
+Write-Host ''

--- a/install.ps1
+++ b/install.ps1
@@ -297,15 +297,29 @@ if (Test-Path $skillsSrc) {
         }
     }
 
-    Get-ChildItem -Directory $skillsSrc | ForEach-Object {
-        $dst = Join-Path $SKILLS_TARGET $_.Name
-        if (Test-Path $dst) { Remove-Item $dst -Force -Recurse -ErrorAction SilentlyContinue }
-        try {
-            New-Item -ItemType SymbolicLink -Path $dst -Target $_.FullName -ErrorAction Stop | Out-Null
-        } catch {
-            Copy-Item -Recurse -Path $_.FullName -Destination $dst -Force
+    # foreach (statement) over a materialized array, with explicit
+    # locals -- avoids the PS 5.1 ForEach-Object pipeline edge case where
+    # an inner cmdlet failure surfaces as a misleading "ForEach-Object :
+    # parameter Path is null" error against the outer pipeline.
+    $skillDirs = @(Get-ChildItem -Path $skillsSrc -Directory -ErrorAction SilentlyContinue)
+    foreach ($skill in $skillDirs) {
+        if (-not $skill -or -not $skill.Name -or -not $skill.FullName) { continue }
+        $skillName = $skill.Name
+        $skillPath = $skill.FullName
+        $dst = Join-Path $SKILLS_TARGET $skillName
+        if (Test-Path $dst) {
+            Remove-Item $dst -Force -Recurse -ErrorAction SilentlyContinue
         }
-        Write-Host "    /$($_.Name)"
+        $linked = $false
+        try {
+            New-Item -ItemType SymbolicLink -Path $dst -Target $skillPath -ErrorAction Stop | Out-Null
+            $linked = $true
+        } catch {
+            # Symlink requires Developer Mode or admin on Windows;
+            # fall back to a recursive copy. Refresh on next install.
+            Copy-Item -Recurse -Path $skillPath -Destination $dst -Force
+        }
+        Write-Host "    /$skillName"
     }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,116 @@
+# install.ps1 — Windows-native PowerShell installer for airc
+#
+# Mirrors install.sh for Windows. Both installers MUST agree on:
+#   - Skill directory layout (~/.claude/skills/<name>/SKILL.md symlinks)
+#   - Old-symlink cleanup list (so renames self-heal across updates)
+#   - Channel persistence ($AIRC_DIR/.channel)
+#
+# Hard requirements (we fail loud if missing — per Joel's "loud failure
+# beats silent slowness" rule):
+#   - PowerShell 7+ (Core)
+#   - git (for clone + update)
+#   - gh CLI
+#   - OpenSSH client (built into Windows 10+ as optional feature)
+#   - Tailscale (Windows MSI installer)
+#   - Python 3 (for the watchdog/formatter heredocs in airc.ps1, until
+#     ported to pure PowerShell)
+#
+# NOT a requirement: WSL, mingw, Cygwin. This installer is for native
+# Windows. The bash install.sh handles POSIX (incl. WSL) installs.
+
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+
+$CLONE_DIR     = if ($env:AIRC_DIR)     { $env:AIRC_DIR }     else { Join-Path $env:USERPROFILE '.airc-src' }
+$BIN_TARGET    = if ($env:BIN_TARGET)   { $env:BIN_TARGET }   else { Join-Path $env:USERPROFILE 'AppData\Local\Programs\airc' }
+$SKILLS_TARGET = if ($env:SKILLS_TARGET) { $env:SKILLS_TARGET } else { Join-Path $env:USERPROFILE '.claude\skills' }
+
+function Test-Required {
+    param([string]$Cmd, [string]$Hint)
+    if (-not (Get-Command $Cmd -ErrorAction SilentlyContinue)) {
+        Write-Error "REQUIRED: $Cmd not found on PATH. $Hint"
+        exit 1
+    }
+}
+
+# ── Prereq audit ───────────────────────────────────────────────────────────
+
+Test-Required 'git' 'Install Git for Windows: https://git-scm.com/download/win'
+Test-Required 'gh'  'Install gh CLI: https://cli.github.com/ — then gh auth login'
+Test-Required 'ssh' 'Install OpenSSH client: Settings → Apps → Optional Features → Add → OpenSSH Client'
+Test-Required 'python' 'Install Python 3.10+: https://www.python.org/downloads/windows/ (or Microsoft Store)'
+
+if (-not (Get-Command 'tailscale' -ErrorAction SilentlyContinue)) {
+    Write-Warning 'Tailscale CLI not on PATH. Install from https://tailscale.com/download/windows. Continuing — airc will fail on connect if Tailscale is not running.'
+}
+
+# ── Clone or update ────────────────────────────────────────────────────────
+
+if (Test-Path (Join-Path $CLONE_DIR '.git')) {
+    Write-Host '  -> Updating existing install'
+    # TODO: parallel to install.sh:27..90 — channel-aware fetch + ff-pull,
+    # auto-recover from non-channel branches, surface ff failures with the
+    # actionable recovery block.
+    git -C $CLONE_DIR pull --ff-only --quiet
+} else {
+    Write-Host '  -> Installing AIRC'
+    New-Item -ItemType Directory -Force -Path (Split-Path $CLONE_DIR) | Out-Null
+    git clone --quiet https://github.com/CambrianTech/airc.git $CLONE_DIR
+}
+
+# ── Binary symlink: airc → airc.ps1 ────────────────────────────────────────
+# Windows symlinks need either Developer Mode or admin. Fall back to a
+# wrapper .cmd if symlink fails (TODO).
+
+New-Item -ItemType Directory -Force -Path $BIN_TARGET | Out-Null
+$aircLink = Join-Path $BIN_TARGET 'airc.ps1'
+if (Test-Path $aircLink) { Remove-Item $aircLink -Force }
+try {
+    New-Item -ItemType SymbolicLink -Path $aircLink -Target (Join-Path $CLONE_DIR 'airc.ps1') | Out-Null
+    Write-Host "  -> Linked airc.ps1 -> $CLONE_DIR\airc.ps1"
+} catch {
+    # Fall back to copy if symlink is denied
+    Copy-Item (Join-Path $CLONE_DIR 'airc.ps1') $aircLink -Force
+    Write-Warning "Symlink denied — fell back to copy. Re-run installer after each `git pull` to refresh."
+}
+
+# Add BIN_TARGET to PATH for current user if not already present
+$userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+if ($userPath -notlike "*$BIN_TARGET*") {
+    [Environment]::SetEnvironmentVariable('PATH', "$userPath;$BIN_TARGET", 'User')
+    Write-Host "  -> Added $BIN_TARGET to user PATH (open a new shell to pick up)"
+}
+
+# ── Skills ──────────────────────────────────────────────────────────────────
+# Mirror install.sh:114..142. The cleanup list MUST stay in sync with the
+# bash version — old skill names (connect/send/rename/disconnect from the
+# IRC rename, etc.) get nuked here so renames self-heal across updates.
+
+$skillsDir = Join-Path $CLONE_DIR 'skills'
+if (Test-Path $skillsDir) {
+    New-Item -ItemType Directory -Force -Path $SKILLS_TARGET | Out-Null
+
+    $oldSkillNames = @('connect', 'send', 'rename', 'disconnect', 'monitor', 'setup', 'uninstall')
+    foreach ($old in $oldSkillNames) {
+        $oldPath = Join-Path $SKILLS_TARGET $old
+        if (Test-Path $oldPath) { Remove-Item $oldPath -Force -Recurse -ErrorAction SilentlyContinue }
+    }
+
+    Get-ChildItem -Directory $skillsDir | ForEach-Object {
+        $target = Join-Path $SKILLS_TARGET $_.Name
+        if (Test-Path $target) { Remove-Item $target -Force -Recurse -ErrorAction SilentlyContinue }
+        try {
+            New-Item -ItemType SymbolicLink -Path $target -Target $_.FullName | Out-Null
+        } catch {
+            # Fall back to copy on systems without symlink permission
+            Copy-Item -Recurse $_.FullName $target -Force
+        }
+        Write-Host "  -> Skill: /$($_.Name)"
+    }
+}
+
+Write-Host ''
+Write-Host '  -> Installed. Requires Tailscale: https://tailscale.com'
+Write-Host ''
+Write-Host '  airc join                       # auto-#general (joins existing or hosts)'
+Write-Host '  airc msg @<peer> <message>      # DM a peer (or omit @peer to broadcast)'

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,145 @@ SKILLS_TARGET="${SKILLS_TARGET:-$HOME/.claude/skills}"
 
 info()  { printf '  \033[1;34m->\033[0m %s\n' "$*"; }
 ok()    { printf '  \033[1;32m->\033[0m %s\n' "$*"; }
+warn()  { printf '  \033[1;33m!\033[0m %s\n' "$*" >&2; }
+
+# ── Prereq auto-install ─────────────────────────────────────────────────
+# Mirrors the Windows install.ps1 winget path: detect what's missing,
+# install via the platform's package manager, then verify. Designed for
+# FIRST-TIME users with nothing pre-installed beyond a shell.
+#
+# Required: git, gh, openssl, ssh-keygen, python3
+# Optional: tailscale (only needed for cross-LAN mesh; LAN works without)
+#
+# AIRC_SKIP_PREREQS=1 short-circuits the whole block (CI, dev installs,
+# users who manage their own packages).
+
+detect_pkgmgr() {
+  case "$(uname -s 2>/dev/null)" in
+    Darwin)
+      if command -v brew >/dev/null 2>&1; then echo "brew"; return; fi
+      echo "brew-missing"; return ;;
+    Linux)
+      if command -v apt-get >/dev/null 2>&1; then echo "apt";    return; fi
+      if command -v dnf     >/dev/null 2>&1; then echo "dnf";    return; fi
+      if command -v pacman  >/dev/null 2>&1; then echo "pacman"; return; fi
+      if command -v apk     >/dev/null 2>&1; then echo "apk";    return; fi
+      ;;
+  esac
+  echo "unknown"
+}
+
+# Map a generic prereq name to the package id for a given pkg manager.
+# Most names match across managers; the exceptions are listed inline.
+pkgname_for() {
+  local mgr="$1" prereq="$2"
+  case "$prereq" in
+    ssh-keygen|ssh)
+      case "$mgr" in
+        brew)   echo "openssh" ;;
+        apt)    echo "openssh-client" ;;
+        dnf)    echo "openssh-clients" ;;
+        pacman) echo "openssh" ;;
+        apk)    echo "openssh-client" ;;
+      esac ;;
+    python3)
+      case "$mgr" in
+        pacman) echo "python" ;;
+        *)      echo "python3" ;;
+      esac ;;
+    *) echo "$prereq" ;;
+  esac
+}
+
+install_with_pkgmgr() {
+  local mgr="$1"; shift
+  local pkgs=("$@")
+  [ ${#pkgs[@]} -eq 0 ] && return 0
+  case "$mgr" in
+    brew)   brew install "${pkgs[@]}" ;;
+    apt)    sudo apt-get update -qq && sudo apt-get install -y "${pkgs[@]}" ;;
+    dnf)    sudo dnf install -y "${pkgs[@]}" ;;
+    pacman) sudo pacman -S --noconfirm --needed "${pkgs[@]}" ;;
+    apk)    sudo apk add --no-cache "${pkgs[@]}" ;;
+    *)      return 1 ;;
+  esac
+}
+
+install_tailscale() {
+  # Optional. macOS: brew cask. Linux: tailscale's official installer.
+  command -v tailscale >/dev/null 2>&1 && return 0
+  case "$(uname -s)" in
+    Darwin)
+      if command -v brew >/dev/null 2>&1; then
+        brew install --cask tailscale 2>/dev/null || warn "Tailscale install via brew failed; install manually: https://tailscale.com/download/mac"
+      else
+        warn "brew not present; install Tailscale manually: https://tailscale.com/download/mac"
+      fi ;;
+    Linux)
+      if command -v curl >/dev/null 2>&1; then
+        curl -fsSL https://tailscale.com/install.sh | sh \
+          || warn "Tailscale installer script failed; install manually: https://tailscale.com/download/linux"
+      else
+        warn "curl missing; install Tailscale manually: https://tailscale.com/download/linux"
+      fi ;;
+    *)
+      warn "Don't know how to install Tailscale on $(uname -s); see https://tailscale.com/download" ;;
+  esac
+}
+
+ensure_prereqs() {
+  [ "${AIRC_SKIP_PREREQS:-0}" = "1" ] && { info "AIRC_SKIP_PREREQS=1 -- skipping prereq install"; return 0; }
+
+  local mgr; mgr=$(detect_pkgmgr)
+  if [ "$mgr" = "unknown" ] || [ "$mgr" = "brew-missing" ]; then
+    if [ "$mgr" = "brew-missing" ]; then
+      warn "macOS detected but Homebrew not found."
+      warn "  Install Homebrew first:  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+      warn "  Then re-run this installer."
+    else
+      warn "Unknown package manager (uname=$(uname -s)). Skipping prereq auto-install."
+    fi
+    warn "Required prereqs: git, gh, openssl, openssh-client, python3"
+    return 0
+  fi
+
+  local missing=() pkgs=()
+  for cmd in git gh openssl ssh-keygen python3; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      missing+=("$cmd")
+      pkgs+=("$(pkgname_for "$mgr" "$cmd")")
+    fi
+  done
+  if [ ${#missing[@]} -gt 0 ]; then
+    info "Installing missing prereqs via $mgr: ${missing[*]}"
+    if install_with_pkgmgr "$mgr" "${pkgs[@]}"; then
+      ok "Prereqs installed"
+    else
+      warn "Package install reported failure; airc may not run until you fix: ${missing[*]}"
+    fi
+  else
+    ok "All required prereqs present"
+  fi
+
+  # Tailscale is optional -- only needed for cross-LAN mesh. LAN-only
+  # works fine without it, so we attempt install but don't fail loud.
+  if ! command -v tailscale >/dev/null 2>&1; then
+    info "Tailscale not present (optional -- LAN mesh works without it). Attempting install ..."
+    install_tailscale
+  fi
+
+  # gh auth: required for the gist substrate (#general room discovery).
+  # We can't auto-login (browser flow), but we surface the exact command
+  # so the user runs it once before `airc join`.
+  if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+      warn "gh CLI is not authenticated. Run once before 'airc join':"
+      warn "    gh auth login -s gist"
+    fi
+  fi
+}
+
+ensure_prereqs
 
 # ── Clone or update ─────────────────────────────────────────────────────
 
@@ -144,9 +283,16 @@ fi
 # ── Done ────────────────────────────────────────────────────────────────
 
 echo ""
-ok "Installed. Requires Tailscale: https://tailscale.com"
+ok "Installed."
 echo ""
-echo "  airc join                       # auto-#general (joins existing or hosts)"
-echo "  airc join <gist-id>             # cross-account share via gist id"
-echo "  airc msg @<peer> <message>      # DM a peer (or omit @peer to broadcast)"
+echo "  Cross-LAN mesh? Tailscale is optional but recommended:"
+echo "    https://tailscale.com    (then: tailscale up)"
+echo "  Same-LAN mesh works without it; gist orchestration handles either."
+echo ""
+echo "  Next:"
+echo "    1. gh auth login -s gist          # one-time, browser flow"
+echo "    2. airc join                      # auto-#general (joins existing or hosts)"
+echo "    3. airc msg @<peer> <message>     # DM (or omit @peer to broadcast)"
+echo ""
+echo "  Diagnose anytime:    airc doctor"
 echo ""

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -10,41 +10,31 @@ argument-hint: "[scenario|all]"
 
 Run this yourself — don't ask the user. Goal: leave the user with a working airc, not a diagnosis they have to act on.
 
-## Step 1 — environment health check (do this BEFORE running tests)
+## Step 1 — environment health check
 
-The substrate is gh-rooted. Check the environment first; an absent / unauthed gh is the #1 cause of "airc feels broken." If you can fix it, fix it.
+The substrate is gh-rooted. An absent / unauthed gh is the #1 cause of "airc feels broken." Run the built-in probe first:
 
 ```bash
-# (a) gh installed?
-command -v gh >/dev/null 2>&1 && echo "gh: present" || echo "gh: MISSING"
-
-# (b) gh authenticated?
-gh auth status 2>&1 | head -3
-
-# (c) ssh remote login on this machine? (needed for tabs/scope tests + real pairing)
-# macOS:
-sudo systemsetup -getremotelogin 2>/dev/null || true
-# Linux: just check sshd is running
-systemctl is-active sshd 2>/dev/null || pgrep -f "sshd" >/dev/null && echo "sshd: active" || echo "sshd: NOT running"
-
-# (d) port 7549 (test-reserved) free?
-lsof -iTCP:7549 -sTCP:LISTEN 2>/dev/null | head -3 || echo "7549: free"
+airc doctor
 ```
+
+This emits one line per prereq with `[ok]`, `[MISSING]`, or `[info]` (optional/Tailscale). For every `[MISSING]` line, the next line is `Fix: <exact command>` for the platform's package manager (brew / apt / dnf / pacman / apk; or a manual hint when no manager is detected).
 
 **Act on findings, don't just print them:**
 
-- **`gh: MISSING`** → install gh. macOS: `brew install gh`. Linux Ubuntu/Debian: `sudo apt install gh` (or follow https://github.com/cli/cli#installation). Windows: `winget install GitHub.cli` or `choco install gh`. Then tell the user to `gh auth login` (needs interactive browser flow — they have to run this themselves).
-- **`gh auth: not logged in`** → `gh auth login` (must be interactive — instruct the user to type `! gh auth login` so it runs in the terminal session and the browser flow can complete).
-- **`sshd: NOT running`** (macOS) → `sudo systemsetup -setremotelogin on` (the user has to run this; needs sudo). Or System Settings → General → Sharing → Remote Login.
-- **`7549: <pid>`** → port held by something else; `lsof -tiTCP:7549 -sTCP:LISTEN | xargs kill` if the process is one you can identify and kill safely. Otherwise tell the user.
+- For each `[MISSING]` prereq with a `Fix:` line: run the fix. Most are unattended (`brew install gh`, `sudo apt-get install -y openssh-client`, etc.).
+- `gh authenticated (gist scope)` is interactive (browser flow) — instruct the user to type `! gh auth login -s gist` so it runs in their terminal session.
+- `tailscale (optional)` lines never block the user (LAN-only mesh works without it). Install only if they want cross-LAN reach, then `tailscale up` is also interactive.
 
-Why this comes BEFORE the tests: the integration suite is `gh`-free by design (uses inline invites + local SSH), so missing gh wouldn't fail the tests — but the user will still be unable to use the substrate (`airc join` zero-arg auto-discovery, `airc list`). Doctor should catch and fix that.
+If `airc doctor` says **"All required prereqs present"**, environment is good — proceed to Step 2.
 
 ## Step 2 — run the integration suite
 
 ```bash
-airc doctor $ARGUMENTS
+airc doctor --tests $ARGUMENTS
 ```
+
+(Aliases: `airc doctor tests`, `airc tests`, `airc test`.)
 
 Empty `$ARGUMENTS` (or `all`) runs every scenario. A scenario name (`tabs`, `scope`, `room`, `teardown`, `reminder`, `resilience`, `reconnect`, `queue`, `status`, `auth_failure`, `resume_stale_auth`) runs just that one. Suite uses port 7549 + `AIRC_HOME=/tmp/airc-it-*`; safe alongside live airc on 7547/7548.
 
@@ -55,7 +45,7 @@ Final line: `N passed, M failed`.
 ### Green (`0 failed`)
 
 - Environment OK + tests OK → tell the user "airc is healthy. Run `airc join` to join the substrate."
-- Make sure to mention what you fixed (if anything) in step 1.
+- Mention what you fixed in step 1 if anything.
 
 ### Red
 
@@ -76,7 +66,7 @@ If a failure isn't in the table:
 - Read the failure verbatim
 - Trace into `test/integration.sh` for that scenario name to understand what assertion fired
 - Read the relevant section of the airc binary
-- Form a hypothesis, fix it, re-run that scenario alone (`airc doctor <scenario>`)
+- Form a hypothesis, fix it, re-run that scenario alone (`airc doctor --tests <scenario>`)
 
 ## Step 4 — final report
 
@@ -93,4 +83,4 @@ One line: "Fixed X, Y. All tests green." OR "Fixed X. Tests N passed M failed; f
 
 - Scenarios are gh-free; the substrate ITSELF (`airc join` zero-arg, `airc list`) requires gh. That's a feature, not a bug — gh is the comm layer.
 - Suite runtime is ~2 minutes for `all`; individual scenarios are 10-30s.
-- This skill assumes you can run shell commands. The user should not have to type anything except the interactive `gh auth login` flow if you encounter it.
+- This skill assumes you can run shell commands. The user should not have to type anything except the interactive `gh auth login -s gist` flow if you encounter it.

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -55,19 +55,33 @@ cleanup_dirs() {
 }
 
 cleanup_known_hosts() {
-  # Test alpha/beta hosts run on the user's real SSH target
-  # (joelteply@100.91.51.87 or similar), so their pair handshake writes
-  # ephemeral test host keys into ~/.ssh/known_hosts. Left behind, those
-  # stale keys collide with the user's real airc host running on the
-  # same IP — SSH to the real host fails with REMOTE HOST IDENTIFICATION
-  # HAS CHANGED. Clear any entries for this machine's address between runs.
+  # Test alpha/beta hosts run on the user's real SSH target, so their
+  # pair handshake writes ephemeral test host keys into
+  # ~/.ssh/known_hosts. Left behind, those stale keys collide with the
+  # user's real airc host running on the same IP — SSH to the real host
+  # fails with REMOTE HOST IDENTIFICATION HAS CHANGED. Clear any entries
+  # for THIS machine's address between runs.
+  #
+  # We only clean addresses we discover dynamically:
+  #   - hostname -I (Linux/WSL) primary local IP
+  #   - ipconfig getifaddr en0 (macOS) primary interface
+  #   - tailscale ip -4 (cross-platform) the tailnet address airc most
+  #     commonly pairs over
+  # No hardcoded IPs — the prior version pinned 100.91.51.87 (the airc
+  # author's tailnet IP), which was a dead branch for any other user
+  # AND a low-grade PII leak in the repo.
   local addr; addr=$(hostname -I 2>/dev/null | awk '{print $1}')
   [ -z "$addr" ] && addr=$(ipconfig getifaddr en0 2>/dev/null)
   if [ -n "$addr" ]; then
     ssh-keygen -R "$addr" -f "$HOME/.ssh/known_hosts" >/dev/null 2>&1 || true
   fi
-  # Also the tailscale IP family airc tests commonly use
-  ssh-keygen -R 100.91.51.87 -f "$HOME/.ssh/known_hosts" >/dev/null 2>&1 || true
+  # Tailscale address (if up) — same machine, different routable IP.
+  if command -v tailscale >/dev/null 2>&1; then
+    local ts_ip; ts_ip=$(tailscale ip -4 2>/dev/null | head -1)
+    if [ -n "$ts_ip" ]; then
+      ssh-keygen -R "$ts_ip" -f "$HOME/.ssh/known_hosts" >/dev/null 2>&1 || true
+    fi
+  fi
 }
 
 cleanup_all() { cleanup_procs; cleanup_dirs; cleanup_known_hosts; }


### PR DESCRIPTION
Promotes canary into main after a focused work session that landed three things:

## 1. Native Windows PowerShell port

Real port of `airc` to PowerShell 7. Single codebase per platform now: bash for POSIX (mac/linux/WSL), `airc.ps1` for native Windows. Same wire protocol, same on-disk layout, interoperate over SSH + gh gists.

- `airc.ps1` (~1200 lines): connect (host + joiner + resume + self-heal), send (local mirror + queue-on-fail + auth-vs-net distinction), monitor (.NET `[Diagnostics.Process]` stream pump bypasses PS pipeline buffering), teardown (`taskkill /T /F`), peers, rooms, invite, part, status, doctor, channel, update, ping, send-file, daemon (Task Scheduler analog of launchd/systemd), reminder, logs, version, help, debug-*. Pair handshake uses `[TcpClient]` / `[TcpListener]` natively (no embedded Python). LAN-IP probe pure .NET via `UdpClient`. Monitor formatter Python heredoc retained verbatim from bash for protocol parity.
- `install.ps1`: bootstraps from Windows PowerShell 5.1 + winget-installs every prereq (pwsh 7, git, python, gh, tailscale). OpenSSH client enabled via `Add-WindowsCapability` when missing. Designed for FIRST-TIME Windows users with nothing pre-installed.
- `airc.cmd`: shim so `airc <verb>` works from PowerShell, cmd.exe, Run dialog, Task Scheduler.

Validated end-to-end against Mac (anvil) and Linux/CUDA (bigmama-wsl) peers via the live mesh during this session.

### Empirical bug-hunt during dogfooding (~12 PS-specific defects caught + fixed)

Each was a real PS / Windows quirk that wouldn't show up in a paper port:

- `param([string[]]$Args)` shadowed PS `$args` automatic
- `param([int]$Pid)` collided with read-only `$PID` automatic
- Comma-separated + splat arg lists in native command calls produced `'-i,'` literally as a hostname
- `ssh-keygen -N '""'` literal passphrase
- `Substring(0, [Math]::Min(N, $orig.Length))` on a `-replace`'d string blew up when `-replace` shrank length
- `Write-Error $_` against an ErrorRecord triggered `-Out*` ambiguity
- `Invoke-OpenSSL` `param([Parameter()])` made it advanced -> common params injected -> `-out file.pem` collided ambiguously
- `subprocess.Popen([airc.cmd, ...], shell=False)` -- CreateProcess can't run `.cmd` directly on Windows
- PS native `& ssh ... | & python ...` pipeline never flushed long-running tail bytes -- replaced with `[Diagnostics.Process]` async stream pump
- `Resolve-PythonBin` only probed live PATH -- snapshotted-PATH processes (post-install Bash, Task Scheduler) saw nothing -- added well-known `Programs\Python\Python3*\python.exe` fallback
- `auto-pong` subprocess inherited stale cwd -> AIRC_HOME explicit pass + stderr capture to `<scope>/auto_pong.log`
- monitor `tail -F` SSH stderr swallowed by `2>$null` -> per-scope `<scope>/monitor_ssh.log` capture

Plus the formatter UTF-8 robustness (cp1252 was crashing on emoji from peers), and a resume-path "Monitoring for messages..." banner so a successful resume doesn't look hung.

## 2. install.sh auto-install for POSIX (matches install.ps1 winget pattern)

`install.sh` previously assumed git/gh/openssl/ssh-keygen/python3 were already present. Now detects pkgmgr (brew/apt/dnf/pacman/apk) and installs the missing set; tailscale optional via brew --cask or the official curl|sh installer. Surfaces the `gh auth login -s gist` interactive step. `AIRC_SKIP_PREREQS=1` escape hatch for CI/sandboxed installs. Final-screen text rewritten to drop the "Requires Tailscale" framing (gist orchestrates regardless of Tailscale state).

## 3. `cmd_doctor` brought up to its SKILL.md spec + audit cleanup

`cmd_doctor` was a thin exec wrapper around `test/integration.sh`, but `/doctor` SKILL.md promised "checks environment health, proactively fixes recoverable issues." Now does what it says:

- Probes git, gh, openssl, ssh, ssh-keygen, python3, tailscale + emits the exact platform-appropriate install command on each `[MISSING]` line.
- Probes `gh auth status` (gist scope) -- the #1 cause of "airc feels broken" silently.
- Reports scope + identity state.
- Behavioral test suite still reachable via `airc doctor --tests` (or `airc tests` / `airc test`).
- SKILL.md rewritten to match: Step 1 is now `airc doctor` (the binary does the probes); Step 2 is `--tests`.

Plus shared-formatter improvements applied to BOTH bash + PS implementations:

- Dropped `PREVIEW_LEN=100` event-body cap (consumers truncate for their own display now; substrate sends full body so AIs don't have to fall back to `airc logs` to see anything past 100 chars -- the polling-vs-substrate anti-pattern).
- Wrapped formatter `print` in `try/except` so one bad message can never take the whole monitor down.

And `test/integration.sh` no longer hardcodes the airc author's tailnet IP for `known_hosts` cleanup -- dynamic `tailscale ip -4` probe instead.

## Validation

- Bash side: `bash -n airc` clean; smoke-tested `airc doctor` env-health output.
- PS side: ran end-to-end on a fresh Windows install via `install.ps1` (winget installs pwsh + git + python + gh + tailscale + enables OpenSSH client) -> `gh auth login -s gist` -> `airc join` discovered #general gist -> TCP pair with continuum-b741 -> monitor live -> bidirectional message exchange + auto-pong roundtrip confirmed.
- Cross-platform: Windows (this PR's port) <-> Mac (anvil) <-> Linux/CUDA WSL (bigmama-wsl) all on the same #general substrate during the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)