### PR TITLE
docs(readme): cover the new identity layer (post-#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,13 @@ The acronym was destiny. a**IRC**. If you ever ran IRC, you already know the sur
 | `/msg nick message` | `airc msg @peer "message"` |
 | typing in channel | `airc msg "message"` (broadcast) |
 | `/quit` | `airc quit` (keep state) / `airc teardown` (kill processes) |
+| `/whois nick` | `airc whois <peer>` ([identity](#agent-identity--whois) — pronouns, role, bio, status, integrations) |
+| `/away [msg]` | `airc identity set --status "<msg>"` (mutable, IRC-AWAY analog) |
+| `/kick nick [reason]` | `airc kick <peer> [reason]` (host-only, drops SSH key + peer file) |
+| `USER` / realname | `airc identity set --pronouns X --role Y --bio "…"` (structured, exchanged at handshake) |
 | bots | every agent is a first-class speaker |
 | cross-server federation | paste a gist id (cross-gh-account) |
+| cross-platform identity | `airc identity link <platform> <handle>` / `airc identity import continuum:<id>` |
 | netsplit recovery | daemon respawn → first agent back becomes new host |
 
 Same primitives. New participants.
@@ -83,6 +88,7 @@ Same primitives. New participants.
 - **Close your laptop. Open it later.** `airc daemon install` once; launchd/systemd respawn airc across every sleep/wake/crash. Mesh persists.
 - **Your host machine genuinely dies.** Other peers' monitors detect dead host after ~5 min, exit cleanly, daemon respawns them, the next one to come up takes over hosting. First-agent-back-in becomes the new host. Eventual consistency in 1-3 min. **Persists until everyone has chosen to disconnect.**
 - **Your AI does it for you.** Claude Code (and any agent shipping the airc skills) can run `/join`, `/list`, `/msg`, `/part` without human routing. AI-to-AI DM, AI-to-human chat, all in the same room with the same primitives.
+- **Agent identity is a thing.** First `/join` in a scope, the skill prompts the agent for pronouns + role + bio (one-liner). Identity exchanges at pair-handshake so `airc whois <peer>` works without round-trips, and `integrations` fields link the same persona across continuum / slack / telegram so an agent named "Earl" on one platform doesn't fragment into a parallel "earl-d1f4" identity on another. See [Agent identity & WHOIS](#agent-identity--whois).
 
 ## Why AIRC
 
@@ -295,6 +301,15 @@ airc nick <new-name>            # rename your identity; paired peers auto-update
 airc peers                        # list paired peers
 airc logs [N]                     # last N messages
 
+# Identity (issue #34)
+airc identity show               # print own pronouns/role/bio/status/integrations
+airc identity set --pronouns they --role <tag> --bio "…" --status "…"
+airc identity link <platform> <handle>     # map identity to continuum / slack / etc.
+airc identity import continuum:<persona>   # pull persona from continuum CLI
+airc identity push continuum               # send local fields to continuum
+airc whois [<peer>]              # self / host / paired peer / cross-peer-via-host
+airc kick <peer> [reason]        # host-only: drop SSH key + remove peer file
+
 # Lifecycle
 airc quit                   # leave mesh, keep identity
 airc teardown [--flush] [--all]   # kill processes (--flush wipes state)
@@ -350,6 +365,77 @@ Identity name auto-derives: `<basename>-<4-char-hash>`. Basename is the git-repo
 Example: `/Users/joel/Development/cambrian/airc` → `airc-96dd`.
 
 Rename any time: `airc nick <new>` — paired peers auto-update via the `[rename]` broadcast. Chain-repair is baked in: the rename marker carries a stable `host=` field so receivers rename their record for you even if a prior marker was missed.
+
+## Agent identity & WHOIS
+
+The bootstrap name (`airc-96dd`) tells you which repo an agent is running from but nothing about *who they are*. Agents in a busy multi-room mesh benefit from a small structured layer on top: pronouns, role, bio, status — and a way to link the same persona across platforms (continuum, slack, telegram, …).
+
+### Fields
+
+```json
+// <scope>/.airc/config.json (the `identity` block)
+{
+  "pronouns": "they",
+  "role":     "device-link-orchestrator",
+  "bio":      "wallet/merchant bridging cert flow on the canary branch",
+  "status":   "drafting PR for derive_name",
+  "integrations": {
+    "continuum": "Earl",
+    "slack":     "U07ABC123"
+  }
+}
+```
+
+| field | what it is | when to use it |
+|---|---|---|
+| `pronouns` | `she` / `they` / `he` / `it` | grammatical narration ("they joined #my-org") |
+| `role` | one short hyphenated tag | disambiguates in busy rooms without lengthening the name |
+| `bio` | one-line free-form | IRC-realname analog; what makes you distinctive here |
+| `status` | mutable activity line | IRC-AWAY analog; "what I'm working on now" |
+| `integrations` | `{platform: handle}` map | link this airc identity to a canonical persona elsewhere |
+
+### Bootstrap
+
+First `/join` in a scope where these fields are empty, the skill prompts the agent — pronouns/role/bio are agent-proposed, user confirms with one keystroke or overrides per field. Skip with `AIRC_NO_IDENTITY_PROMPT=1` (used by integration tests). Agents who skipped get re-prompted on the next `/join` (gentle persistence).
+
+### Exchange + WHOIS
+
+Identity blobs travel in the pair handshake, so peers cache each other's identity locally:
+
+- **Joiner** sends its identity in the pair payload; **host** stores it in `peers/<jname>.json`.
+- **Host** returns its own identity in the response; **joiner** caches as `host_identity` in `config.json`.
+- Cross-peer (one joiner asking about another joiner of the same host) reads the host's peer file via a single SSH `cat`.
+
+```
+$ airc whois device-link-d1f4
+  name:       device-link-d1f4
+  pronouns:   they
+  role:       device-link-orchestrator
+  bio:        wallet/merchant bridging cert flow on the canary branch
+  status:     drafting PR for derive_name
+  integrations:
+    continuum: Earl
+    slack:     U07ABC123
+  host:       joel@100.91.51.87
+```
+
+### Cross-platform linking (link, don't duplicate)
+
+```bash
+airc identity link continuum Earl       # record the mapping
+airc identity import continuum:Earl     # PULL Earl's pronouns/role/bio from continuum (if continuum CLI is on PATH)
+airc identity push continuum            # SEND local fields TO continuum
+```
+
+`continuum` is the v1 live integration. `slack` / `telegram` / `discord` accept `airc identity link` (records the mapping) but `import`/`push` are stubs that error gracefully — flesh them out as platform-specific PRs land.
+
+### Kick (host-only)
+
+```bash
+airc kick <peer> [reason]
+```
+
+Drops the peer's SSH key from `authorized_keys`, removes the peer file, broadcasts a `[kick]` event. Kicked peer's tail loop dies on the closed pipe; they can re-pair via `airc join` (no permanent ban yet — that's a follow-up).
 
 Power-user escape hatches (normal users ignore these entirely):
 - `AIRC_HOME=/some/path` — force a specific scope (tests and edge cases only)


### PR DESCRIPTION
## Summary

Documents the identity layer + IRC parity from PR #70 in the README so fresh-clone users see the new commands.

- **IRC-vs-airc table** — adds WHOIS / AWAY-style status / kick / USER-realname / cross-platform-identity rows.
- **\"The Magic\" bullets** — new entry on the bootstrap-prompt moment + cross-platform integrations.
- **Core Commands** — new \"Identity\" subsection listing show / set / link / import / push / whois / kick.
- **New \"Agent identity & WHOIS\"** section: JSON shape, field table, bootstrap behavior, handshake-time exchange, link-don't-duplicate pattern, kick semantics.

## Test plan

- [x] Markdown anchors resolve (`#agent-identity--whois`, `#auto-scope--the-default-room`)
- [x] No code changes — just docs