### PR TITLE
fix: address Copilot review on #73 (kick auth bug + path traversal) + README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Agentic Internet Relay Chat
 
+*Collaborative agentic systems are the unlock — proven in [continuum](https://github.com/CambrianTech/continuum). airc is the chat substrate that came out of that work, distilled into the IRC primitives every model already knows.*
+
 > **Automatically link all your AI agent contexts into one chat room so they can coordinate and divide up the work.**
 >
 > | Where your agents live | What you need |

--- a/airc
+++ b/airc
@@ -177,6 +177,20 @@ relay_list() { [ -d "$AIRC_WRITE_DIR/$1" ] && ls -1 "$AIRC_WRITE_DIR/$1" 2>/dev/
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
+# Validate a peer name matches the allowed nick charset BEFORE using it in
+# filesystem paths or remote SSH commands. Same charset cmd_rename uses
+# (a-z 0-9 -) — anything else is unreachable as a real airc identity and
+# almost certainly a path-traversal / shell-injection attempt
+# (`../config`, `; rm -rf /`, etc.). Rejects empty as well.
+_validate_peer_name() {
+  local name="${1:-}"
+  case "$name" in
+    "")              die "peer name required" ;;
+    *[!a-z0-9-]*)    die "invalid peer name '$name' — must match [a-z0-9-]+ (use airc peers to list valid names)" ;;
+    -*)              die "invalid peer name '$name' — must not start with '-'" ;;
+  esac
+}
+
 ensure_init() {
   [ -f "$CONFIG" ] && return 0
   die "Not initialized ($AIRC_WRITE_DIR). Run: airc connect"
@@ -2108,6 +2122,11 @@ with open(os.path.join(peers_dir, jname + '.json'), 'w') as f:
         'host': joiner.get('host',''),
         'airc_home': joiner.get('airc_home', ''),
         'paired': '$(timestamp)',
+        # Cache joiner's SSH pubkey so airc kick can remove it from
+        # authorized_keys later. Without this, kick has no way to find
+        # the right line in authorized_keys and the kicked peer keeps
+        # SSH access — Copilot caught this on PR #73 review.
+        'ssh_pub': joiner.get('ssh_pub', ''),
         # Cache joiner's identity blob (issue #34 v2). Empty on legacy
         # peers that don't send the field — airc whois prints the
         # 'not exchanged yet' fallback gracefully.
@@ -2259,7 +2278,7 @@ cmd_identity() {
       echo "Usage:"
       echo "  airc identity show                            Print own identity"
       echo "  airc identity set [--pronouns X] [--role Y] [--bio \"…\"] [--status \"…\"]"
-      echo "  airc identity link <platform> <handle>        Map this identity to a platform persona"
+      echo "  airc identity link <platform> [handle]        Map this identity to a platform persona (omit handle to unlink)"
       echo "  airc identity import <platform>:<id>          Pull persona from platform (continuum)"
       echo "  airc identity push <platform>                 Send local fields to platform (continuum)"
       ;;
@@ -2339,7 +2358,7 @@ print("  identity updated.")
 
 _identity_link() {
   local platform="${1:-}" handle="${2:-}"
-  [ -z "$platform" ] && die "Usage: airc identity link <platform> <handle>"
+  [ -z "$platform" ] && die "Usage: airc identity link <platform> [handle] (omit/blank handle to unlink)"
   CONFIG="$CONFIG" PLATFORM="$platform" HANDLE="$handle" python3 -c '
 import json, os
 c = json.load(open(os.environ["CONFIG"]))
@@ -2371,6 +2390,11 @@ cmd_whois() {
     _identity_show
     return 0
   fi
+
+  # Reject path-traversal / shell-injection in target before it touches
+  # filesystem paths (local PEERS_DIR/<target>.json) or remote SSH cmds
+  # (cat $host_airc_home/peers/<target>.json).
+  _validate_peer_name "$target"
 
   # Host (we're a joiner, target is the host we paired with)
   local host_name; host_name=$(get_config_val host_name "")
@@ -2465,13 +2489,16 @@ PYEOF
 
 cmd_kick() {
   # Host-only: forcibly remove a paired peer. IRC analog: /kick <user>.
-  # Steps: emit a system event, drop their pubkey from authorized_keys,
-  # remove the peer file. The next message they try to send will fail
-  # auth; their tail loop dies on the closed pipe. They can re-pair
-  # (no ban yet) — for that, see future `airc ban`.
+  # Steps: emit a system event, drop their SSH pubkey from authorized_keys,
+  # remove the peer file. The kicked peer's tail loop dies on the closed
+  # pipe AND any future auth attempts fail because their key is gone from
+  # authorized_keys — they can't silently keep operating after a kick.
+  # They can re-pair via airc connect (no ban yet) — for that, see future
+  # `airc ban`.
   ensure_init
   local target="${1:-}"
   [ -z "$target" ] && die "Usage: airc kick <peer> [reason]"
+  _validate_peer_name "$target"
   shift || true
   local reason="${*:-no reason given}"
 
@@ -2486,31 +2513,43 @@ cmd_kick() {
     die "kick: '$target' not in peers list (try: airc peers)"
   fi
 
-  # Pull peer's SSH pubkey out of authorized_keys (best-effort — pubkey
-  # lives in $PEERS_DIR/$target.pub if recorded; otherwise we leave the
-  # ssh key in place and rely on peer-file deletion to break the
-  # bookkeeping). Each step `|| true` since set -euo pipefail is active
-  # and benign no-match / missing-file cases are normal here.
-  local peer_pub_file="$PEERS_DIR/$target.pub"
-  if [ -f "$peer_pub_file" ] && [ -f "$HOME/.ssh/authorized_keys" ]; then
-    local peer_pub; peer_pub=$(cat "$peer_pub_file" 2>/dev/null || echo "")
-    if [ -n "$peer_pub" ]; then
-      # grep -v returns 1 when every line matches (or the file is empty);
-      # both are fine outcomes here, so eat the exit code.
-      grep -vF "$peer_pub" "$HOME/.ssh/authorized_keys" > "$HOME/.ssh/authorized_keys.tmp" 2>/dev/null || true
-      [ -f "$HOME/.ssh/authorized_keys.tmp" ] && mv "$HOME/.ssh/authorized_keys.tmp" "$HOME/.ssh/authorized_keys"
-      chmod 600 "$HOME/.ssh/authorized_keys" 2>/dev/null || true
-    fi
+  # Read the joiner's SSH pubkey from the peer JSON record (the host
+  # handshake stores it there — `<peer>.pub` holds the SIGNING pubkey,
+  # not the SSH auth key, so we can't use that file). Without this,
+  # kick would leave the joiner's SSH key in authorized_keys and the
+  # peer could keep authenticating despite the "kick" — caught by
+  # Copilot review on PR #73.
+  local peer_ssh_pub
+  peer_ssh_pub=$(PEER_FILE="$peer_file" python3 -c '
+import json, os
+try:
+    p = json.load(open(os.environ["PEER_FILE"]))
+    print((p.get("ssh_pub") or "").strip())
+except Exception:
+    pass
+' 2>/dev/null || echo "")
+
+  if [ -n "$peer_ssh_pub" ] && [ -f "$HOME/.ssh/authorized_keys" ]; then
+    # grep -v returns 1 when every line matches (or the file is empty);
+    # both are fine outcomes here, so eat the exit code.
+    grep -vF "$peer_ssh_pub" "$HOME/.ssh/authorized_keys" > "$HOME/.ssh/authorized_keys.tmp" 2>/dev/null || true
+    [ -f "$HOME/.ssh/authorized_keys.tmp" ] && mv "$HOME/.ssh/authorized_keys.tmp" "$HOME/.ssh/authorized_keys"
+    chmod 600 "$HOME/.ssh/authorized_keys" 2>/dev/null || true
   fi
 
-  # Remove peer files (rm -f is set-e-safe)
-  rm -f "$peer_file" "$peer_pub_file"
+  # Remove peer files (rm -f is set-e-safe). The .pub here is the
+  # signing key file, separate from authorized_keys.
+  rm -f "$peer_file" "$PEERS_DIR/$target.pub"
 
   # Emit a system event so the kicked peer (and others) see it in the
   # tail stream. Reuse cmd_send's plumbing.
   cmd_send "[kick] $target ($reason)" >/dev/null 2>&1 || true
 
-  echo "  Kicked $target ($reason). SSH key removed from authorized_keys; peer file gone."
+  if [ -n "$peer_ssh_pub" ]; then
+    echo "  Kicked $target ($reason). SSH key removed from authorized_keys; peer file gone."
+  else
+    echo "  Kicked $target ($reason). Peer file gone, but no SSH key recorded for this peer — they were paired before #34's handshake update; their authorized_keys entry survived. Run airc peers to confirm."
+  fi
   echo "  They can re-pair via airc connect; for permanent ban, see future 'airc ban'."
 }
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -1342,6 +1342,15 @@ scenario_kick() {
     && pass "joiner can't kick (rejected with helpful error)" \
     || fail "joiner kick attempt should be refused (got: $out)"
 
+  # ── Capture joiner's SSH pubkey BEFORE kick so we can assert removal ──
+  local kj_ssh_pub
+  kj_ssh_pub=$(cat /tmp/airc-it-k-j/state/identity/ssh_key.pub 2>/dev/null | tr -d '\n' || true)
+  if [ -n "$kj_ssh_pub" ] && [ -f "$HOME/.ssh/authorized_keys" ]; then
+    grep -qF "$kj_ssh_pub" "$HOME/.ssh/authorized_keys" \
+      && pass "joiner's SSH key present in authorized_keys before kick" \
+      || fail "joiner's SSH key missing from authorized_keys before kick (handshake regression?)"
+  fi
+
   # ── Host kicks joiner ──
   out=$(AIRC_HOME=/tmp/airc-it-k-h/state "$AIRC" kick kjoiner "scenario test" 2>&1)
   echo "$out" | grep -q "Kicked kjoiner" && pass "kick prints confirmation" || fail "kick missing confirmation (got: $out)"
@@ -1351,11 +1360,31 @@ scenario_kick() {
     && pass "kicked peer's file removed" \
     || fail "peer file still present after kick"
 
+  # ── SSH key actually removed from authorized_keys ──
+  # Without this assertion, kick's pubkey-removal could silently regress
+  # — Copilot's #73 review caught a bug where kick was reading the wrong
+  # .pub file and leaving the SSH key in place.
+  if [ -n "$kj_ssh_pub" ] && [ -f "$HOME/.ssh/authorized_keys" ]; then
+    grep -qF "$kj_ssh_pub" "$HOME/.ssh/authorized_keys" \
+      && fail "kicked peer's SSH key still in authorized_keys (kick didn't actually revoke access)" \
+      || pass "kicked peer's SSH key removed from authorized_keys"
+  fi
+
   # ── airc whois on the now-kicked peer is graceful ──
   out=$(AIRC_HOME=/tmp/airc-it-k-h/state "$AIRC" whois kjoiner 2>&1 || true)
   echo "$out" | grep -q "no record for 'kjoiner'" \
     && pass "whois post-kick prints no-record" \
     || fail "whois post-kick should report missing"
+
+  # ── Reject path-traversal attempts in peer name ──
+  out=$(AIRC_HOME=/tmp/airc-it-k-h/state "$AIRC" whois "../config" 2>&1 || true)
+  echo "$out" | grep -q "invalid peer name" \
+    && pass "whois rejects path-traversal in peer name" \
+    || fail "whois did NOT reject '../config' as a peer name (got: $out)"
+  out=$(AIRC_HOME=/tmp/airc-it-k-h/state "$AIRC" kick "../config" 2>&1 || true)
+  echo "$out" | grep -q "invalid peer name" \
+    && pass "kick rejects path-traversal in peer name" \
+    || fail "kick did NOT reject '../config' as a peer name (got: $out)"
 
   cleanup_all
 }


### PR DESCRIPTION
## Summary

Addresses [Copilot's review on PR #73](https://github.com/CambrianTech/airc/pull/73) and adds a README tagline per Joel.

### Copilot fixes

| # | severity | what | fix |
|---|---|---|---|
| 1 | **HIGH** | `cmd_kick` was reading `<peer>.pub` (signing key) from authorized_keys, not the SSH auth key — kicked peers retained SSH access | Host handshake now stores `ssh_pub` in peer JSON; cmd_kick reads from there |
| 2 | **HIGH** (security) | `cmd_whois` / `cmd_kick` interpolated peer name into local + remote paths without sanitization (path traversal, shell injection vector) | New `_validate_peer_name` helper, `[a-z0-9-]+` only |
| 3 | MED | scenario_kick never asserted `authorized_keys` actually changed | Now greps before/after for the joiner's SSH pubkey |
| 4 | LOW | `airc identity link` usage said handle was required, but empty handle unlinks | Usage + help updated to reflect optional |
| 5 | LOW | Regression test for path-traversal rejection in whois + kick | New assertions in scenario_kick |

One Copilot comment was a false positive: it read `shift 2>/dev/null` as `shift 2` (count 2), but `2>/dev/null` is stderr redirection — the shift count is 1, which is correct. No change needed.

### README tagline

One italic line right under the title:

> *Collaborative agentic systems are the unlock — proven in [continuum](https://github.com/CambrianTech/continuum). airc is the chat substrate that came out of that work, distilled into the IRC primitives every model already knows.*

Anvil DM'd separately for input — happy to revise to whatever Anvil's framing if she has a tighter line.

## Test plan

- [x] 130/130 integration tests pass (4 new in scenario_kick)
- [x] kick now actually removes SSH key from authorized_keys (verified by new assertion)
- [x] `airc whois ../config` and `airc kick ../config` both rejected with \"invalid peer name\"
- [x] `airc identity link continuum Earl` then `airc identity link continuum` (no handle) properly unlinks