### PR TITLE
docs(readme): leverage-what-you-have framing in the blockquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentic Internet Relay Chat
 
-*Collaborative agentic systems are the unlock — proven in [continuum](https://github.com/CambrianTech/continuum). airc is the chat substrate that came out of that work: shell scripts only (bash + PowerShell), no compiled binary, distilled into the IRC primitives every model already knows.*
+*Collaborative agentic systems are the unlock — proven in [continuum](https://github.com/CambrianTech/continuum). airc is the chat substrate that came out of that work, distilled into the IRC primitives every model already knows.*
 
 > **Automatically link all your AI agent contexts into one chat room so they can coordinate and divide up the work.**
 >
@@ -10,7 +10,7 @@
 > | Same LAN (different boxes in your office) | gh + your machines reachable to each other (mDNS / hostnames usually works; Tailscale guarantees it) |
 > | Different networks (your laptop ↔ your work box ↔ a coworker) | gh + **Tailscale** (or any IP fabric — WireGuard, ZeroTier, real public IPs) |
 >
-> No server to spin up, no account to create, no credit card. Open a tab, run `airc join`, you're in `#general` with every other agent on your GitHub account.
+> No server to spin up, no account to create, no credit card. **The whole thing is shell scripts** — bash on Mac/Linux/WSL/Git-Bash, PowerShell on Windows; the prereqs (git, gh, python) are things any developer's machine already has. Open a tab, run `airc join`, you're in your project's room with every other agent on your GitHub account.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Acts on Joel's framing post-Copilot review: the meaningful claim isn't \"no Python\" but \"no real changes to your system as it is — git + gh + python are things devs already have.\"

- **Tagline**: pulled \"shell scripts only (bash + PowerShell), no compiled binary\" out. The line is now back to thesis-only and doesn't overstate.
- **Blockquote** (line 13): replaces the previous closing sentence with the explained version: \"The whole thing is shell scripts — bash on Mac/Linux/WSL/Git-Bash, PowerShell on Windows; the prereqs (git, gh, python) are things any developer's machine already has.\" Lands the point with the explanation right where it lands, instead of a title-level shorthand.
- Stale \"you're in #general\" replaced with \"you're in your project's room\" — matches the auto-scope feature from #66.

## Test plan

- [x] Docs only; no code changes
- [x] Anchors unchanged (no link rot)