### PR TITLE
fix(connect): tailscale-state pre-check on fresh-pair + gist-discovery paths (closes #78)

### DIFF
--- a/airc
+++ b/airc
@@ -1648,6 +1648,19 @@ json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
 
     # Exchange keys with host via TCP
     local peer_host_only="${ssh_target##*@}"
+
+    # Tailscale-down pre-flight on fresh-pair / gist-discovery paths.
+    # Resume path (line ~1241) already calls advise_tailscale_if_down, but
+    # that gate doesn't cover (a) cold-start `airc join <invite>` from a
+    # fresh scope or (b) the gist-discovery resolution that lands here
+    # with a tailnet host_target. Without this check, a logged-out
+    # Tailscale produced a silent unreachable-host + self-heal cascade
+    # (issue #78, Memento's case 2026-04-25). Same call site shape as the
+    # resume path: detect-and-instruct, do not auto-tailscale-up.
+    if ! advise_tailscale_if_down "$peer_host_only"; then
+      die "Re-run airc join after starting Tailscale."
+    fi
+
     echo "  Connecting to $peer_host_only:$peer_port..."
     local my_ssh_pub my_sign_pub
     my_ssh_pub=$(cat "$IDENTITY_DIR/ssh_key.pub" 2>/dev/null)

--- a/airc
+++ b/airc
@@ -310,6 +310,12 @@ is_peer_offline_in_tailnet() {
   # user's time blocking on a predictable failure.
   local target_host="${1:-}"
   [ -z "$target_host" ] && return 1
+  # Strip leading user@ if present — host_target is stored as `user@host`
+  # in config.json, but the CGNAT match below only recognizes strings
+  # starting with 100.x. Without this strip, every call from a resume
+  # path silently bypassed the CGNAT gate (issue #78 root cause, caught
+  # in PR #84 Copilot review).
+  target_host="${target_host##*@}"
   # CGNAT range only. LAN / DNS targets fall through to the normal path.
   case "$target_host" in
     100.6[4-9].*|100.[7-9][0-9].*|100.1[01][0-9].*|100.12[0-7].*) ;;
@@ -347,6 +353,10 @@ advise_tailscale_if_down() {
   [ "${AIRC_NO_TAILSCALE:-0}" = "1" ] && return 0
   local target_host="${1:-}"
   [ -z "$target_host" ] && return 0
+  # Strip leading user@ if present — host_target from config.json is
+  # `user@host` form. Without this strip, every resume-path call
+  # silently bypassed the CGNAT gate (Copilot caught this on PR #84).
+  target_host="${target_host##*@}"
   case "$target_host" in
     100.6[4-9].*|100.[7-9][0-9].*|100.1[01][0-9].*|100.12[0-7].*) ;;
     *) return 0 ;;

--- a/airc.ps1
+++ b/airc.ps1
@@ -2023,6 +2023,19 @@ function Invoke-Connect {
 
         # Pair handshake via TCP (.NET native, no embedded Python)
         $peerHostOnly = ($sshTarget -split '@')[-1]
+
+        # Tailscale-down pre-flight on fresh-pair / gist-discovery paths.
+        # Resume path (line ~1877) already calls Advise-TailscaleIfDown, but
+        # that gate doesn't cover (a) cold-start `airc join <invite>` from a
+        # fresh scope or (b) the gist-discovery resolution that lands here
+        # with a tailnet host_target. Without this check, a logged-out
+        # Tailscale produces a silent unreachable-host + self-heal cascade
+        # (issue #78, Memento's case 2026-04-25). Same call shape as resume
+        # path: detect-and-instruct, do not auto-tailscale-up.
+        if (Advise-TailscaleIfDown -TargetHost $peerHostOnly) {
+            Die 'Re-run airc join after starting Tailscale.'
+        }
+
         Write-Host "  Connecting to ${peerHostOnly}:$peerPort ..."
         $mySshPub  = (Get-Content (Join-Path $IDENTITY_DIR 'ssh_key.pub') -Raw -ErrorAction SilentlyContinue).Trim()
         $mySignPub = (Get-Content (Join-Path $IDENTITY_DIR 'public.pem') -Raw -ErrorAction SilentlyContinue)

--- a/airc.ps1
+++ b/airc.ps1
@@ -221,6 +221,10 @@ function Test-PeerOfflineInTailnet {
     # is_peer_offline_in_tailnet (commit 64b604d).
     param([string]$TargetHost)
     if (-not $TargetHost) { return $false }
+    # Strip leading user@ if present — host_target from config.json is
+    # `user@host` form. Without this strip, every resume-path call
+    # silently bypassed the CGNAT gate (Copilot caught this on PR #84).
+    if ($TargetHost -match '@') { $TargetHost = ($TargetHost -split '@')[-1] }
     if (-not (Test-CgnatIp -Ip $TargetHost)) { return $false }
     $ts = Resolve-TailscaleBin
     if (-not $ts) { return $false }
@@ -250,6 +254,10 @@ function Advise-TailscaleIfDown {
     param([string]$TargetHost)
     if ($env:AIRC_NO_TAILSCALE -eq '1') { return $false }
     if (-not $TargetHost) { return $false }
+    # Strip leading user@ if present — host_target from config.json is
+    # `user@host` form. Without this strip, every resume-path call
+    # silently bypassed the CGNAT gate (Copilot caught this on PR #84).
+    if ($TargetHost -match '@') { $TargetHost = ($TargetHost -split '@')[-1] }
     if (-not (Test-CgnatIp -Ip $TargetHost)) { return $false }
 
     $ts = Resolve-TailscaleBin


### PR DESCRIPTION
## Summary

Closes #78. The resume path already gates on `advise_tailscale_if_down` (bash) / `Advise-TailscaleIfDown` (ps1) before SSH-pair, but the cold-start `airc join <invite>` and gist-discovery paths land at the same SSH-pair point WITHOUT the gate. A logged-out Tailscale on those paths produces silent unreachable-host + self-heal cascade — Memento's case from 2026-04-25.

Symmetric one-block addition in both bash (`airc`) and PowerShell (`airc.ps1`) at the universal pair-attempt point, just before the \"Connecting to\" line. Reuses existing helpers — no new detection logic.

## Why both languages

Per pure-shell-cross-platform discipline + Joel: don't neglect Windows. Bash and ps1 ship in lockstep on this PR. green @green-022a — please validate on your native PS port.

## Test plan

- [x] `test/integration.sh` — 133/133 pass on canary HEAD with this change
- [x] bash syntax check
- [x] ps1: visual review (pwsh not on dev machine; relying on review + your test)
- [ ] Live verify on a Tailscale-logged-out Mac (cd into tailnet repo, `tailscale logout`, `airc join <CGNAT-host invite>`, expect loud message)
- [ ] Live verify on Windows native (green's lane)

## Out of scope (filed as follow-ups)

- Test harness for the down-state itself (needs mocking tailscale-status output, broader scope)
- #79 (self-heal gist-thrash race), #80 (`airc doctor --connect`), #81 (bootstrap-airc scripts), #82 (list-activity), #83 (stale-pairing detect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)