### PR TITLE
fix: resolve_gh_bin fallback to known winget paths (closes #85)

### DIFF
--- a/airc
+++ b/airc
@@ -161,6 +161,50 @@ infer_default_room() {
   return 1
 }
 
+# Resolve the path to a working gh CLI binary across platforms.
+# Same shape as resolve_tailscale_bin (defined later) and same problem:
+# on Windows native + Git Bash, gh is installed via winget at
+# `C:\Program Files\GitHub CLI\gh.exe` but the path doesn't get
+# inherited into Git Bash's PATH. Without a fallback, airc skips its
+# gist substrate entirely, leaving the user stuck on legacy long-
+# invite-string flow with no auto-discovery. Issue #85.
+# Defined here (before script-init) so the PATH-fixup below can use it.
+resolve_gh_bin() {
+  if command -v gh >/dev/null 2>&1; then
+    echo "gh"
+    return 0
+  fi
+  if command -v gh.exe >/dev/null 2>&1; then
+    echo "gh.exe"
+    return 0
+  fi
+  local candidate
+  for candidate in \
+    "/c/Program Files/GitHub CLI/gh.exe" \
+    "/mnt/c/Program Files/GitHub CLI/gh.exe" \
+    "/c/Program Files (x86)/GitHub CLI/gh.exe" \
+    "/usr/local/bin/gh" \
+    "/opt/homebrew/bin/gh"; do
+    if [ -x "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# gh PATH-fixup: if gh isn't on PATH but a fallback resolves it (e.g.
+# Git Bash on Windows where winget installed gh at a standard location
+# that PATH doesn't inherit), prepend its directory to PATH so every
+# subsequent `gh` invocation in this script finds it. Issue #85 — the
+# alternative was to wrap every gh callsite, which is ~20 places + ps1
+# parallel; PATH-prepend is a one-liner that fixes all of them.
+_gh_resolved=$(resolve_gh_bin 2>/dev/null || true)
+if [ -n "$_gh_resolved" ] && ! command -v gh >/dev/null 2>&1; then
+  export PATH="$(dirname "$_gh_resolved"):$PATH"
+fi
+unset _gh_resolved
+
 AIRC_WRITE_DIR="$(detect_scope)"
 CONFIG="$AIRC_WRITE_DIR/config.json"
 IDENTITY_DIR="$AIRC_WRITE_DIR/identity"

--- a/airc.ps1
+++ b/airc.ps1
@@ -85,6 +85,33 @@ function Get-AircScope {
     return (Join-Path (Resolve-Path .).Path '.airc')
 }
 
+# Resolve gh CLI binary path early. Same problem the bash script handles:
+# winget-installed gh sits at a standard location that doesn't always end
+# up on the running shell's PATH (Windows native shells especially).
+# Defined inline here so the PATH-fixup below can use it before the
+# main helpers section below runs. Issue #85.
+function _Resolve-GhBinEarly {
+    foreach ($name in @('gh', 'gh.exe')) {
+        $cmd = Get-Command $name -ErrorAction SilentlyContinue
+        if ($cmd) { return $cmd.Source }
+    }
+    foreach ($p in @(
+        'C:\Program Files\GitHub CLI\gh.exe',
+        'C:\Program Files (x86)\GitHub CLI\gh.exe'
+    )) {
+        if (Test-Path $p) { return $p }
+    }
+    return $null
+}
+
+# gh PATH-fixup: if gh resolved via fallback rather than PATH, prepend its
+# directory to PATH so every later `gh` invocation transparently finds it.
+$_ghResolved = _Resolve-GhBinEarly
+if ($_ghResolved -and -not (Get-Command 'gh' -ErrorAction SilentlyContinue)) {
+    $env:PATH = (Split-Path $_ghResolved -Parent) + [IO.Path]::PathSeparator + $env:PATH
+}
+Remove-Variable _ghResolved -ErrorAction SilentlyContinue
+
 $AIRC_WRITE_DIR = Get-AircScope
 $CONFIG       = Join-Path $AIRC_WRITE_DIR 'config.json'
 $IDENTITY_DIR = Join-Path $AIRC_WRITE_DIR 'identity'
@@ -196,6 +223,25 @@ function Resolve-TailscaleBin {
     foreach ($p in @(
         'C:\Program Files\Tailscale\tailscale.exe',
         'C:\Program Files (x86)\Tailscale\tailscale.exe'
+    )) {
+        if (Test-Path $p) { return $p }
+    }
+    return $null
+}
+
+function Resolve-GhBin {
+    # Same shape as Resolve-TailscaleBin. Issue #85: on Windows native +
+    # Git Bash, gh is installed via winget at the standard location but
+    # the path doesn't get inherited into Git Bash's PATH. The bash side
+    # has the equivalent helper; ps1 keeps lockstep so gist substrate
+    # works without manual PATH edits.
+    foreach ($name in @('gh', 'gh.exe')) {
+        $cmd = Get-Command $name -ErrorAction SilentlyContinue
+        if ($cmd) { return $cmd.Source }
+    }
+    foreach ($p in @(
+        'C:\Program Files\GitHub CLI\gh.exe',
+        'C:\Program Files (x86)\GitHub CLI\gh.exe'
     )) {
         if (Test-Path $p) { return $p }
     }


### PR DESCRIPTION
## Summary

Closes #85 — the BigMama 5090 case where Git Bash on Windows had gh installed via winget but not on PATH, silently disabling airc's gist substrate.

Mirrors the existing \`resolve_tailscale_bin\` pattern: check PATH first, fall back to known platform install locations. PATH-prepend at startup if found via fallback so every existing \`gh\` callsite keeps working transparently — no need to wrap each invocation.

## Test plan

- [x] 133/133 integration tests pass
- [x] bash syntax check
- [x] PATH-prepend logic doesn't break the gh-already-on-PATH case (Mac default)
- [ ] Live verify on Windows native + Git Bash (Toby / BigMama 5090): airc resolves gh from `C:\\Program Files\\GitHub CLI\\gh.exe` without manual ~/.bashrc edit

## Why bash + ps1 together

Per joel: don't neglect Windows. Keeps the lockstep discipline from #84.

## Related issues

- #84 (tailscale state pre-check) — same friction class, independent code path
- #80 (`airc doctor --connect` pre-flight) — would surface this kind of issue at install-time too; bigger PR, future
- #81 (bootstrap-airc.ps1) — handles this case as part of single-command setup; future

🤖 Generated with [Claude Code](https://claude.com/claude-code)