### PR TITLE
feat(doctor): airc doctor --connect pre-flight check (closes #80)

### DIFF
--- a/airc
+++ b/airc
@@ -4087,22 +4087,32 @@ _doctor_connect_preflight() {
 
   # ── Required prereqs (same as default doctor) ──
   _doctor_probe "git"          "$mgr" "VCS for clone/update"           || issues=$((issues+1))
-  _doctor_probe "gh"           "$mgr" "Gist substrate (room discovery)" || issues=$((issues+1))
-  _doctor_probe_gh_auth                                                  || issues=$((issues+1))
-  _doctor_probe "openssl"      "$mgr" "Ed25519 sign keys + signing"     || issues=$((issues+1))
-  _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"     || issues=$((issues+1))
-  _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"     || issues=$((issues+1))
-  _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"    || issues=$((issues+1))
+  _doctor_probe "openssl"      "$mgr" "Ed25519 sign keys + signing"    || issues=$((issues+1))
+  _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"    || issues=$((issues+1))
+  _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"    || issues=$((issues+1))
+  _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"   || issues=$((issues+1))
 
-  # ── Connect-specific: gist API reachable ──
-  if command -v gh >/dev/null 2>&1; then
-    if gh api user >/dev/null 2>&1; then
-      printf "  [ok] github gists API reachable\n"
-    else
-      printf "  [BLOCKED] github gists API not reachable -- network or token issue\n"
-      printf "         Fix: check internet, then re-run 'gh auth login -s gist'\n"
-      issues=$((issues+1))
-    fi
+  # ── gh chain: installed → authed → gist scope → gists API reachable.
+  # Single chain (early-return on first failure) so a missing gh isn't
+  # counted 3-4x as a separate issue per dependent probe. Gist scope is
+  # checked explicitly because `gh auth status` alone passes for a
+  # gist-scope-less token (Copilot caught this on #87 review).
+  if ! _doctor_probe "gh" "$mgr" "Gist substrate (room discovery)"; then
+    issues=$((issues+1))
+  elif ! gh auth status >/dev/null 2>&1; then
+    printf "  [BLOCKED] gh authenticated\n"
+    printf "         Fix: gh auth login -s gist\n"
+    issues=$((issues+1))
+  elif ! gh auth status 2>&1 | grep -qiE "(scopes:|token scopes:)[^\\n]*\\bgist\\b"; then
+    printf "  [BLOCKED] gh authed but missing 'gist' scope (room substrate needs it)\n"
+    printf "         Fix: gh auth refresh -s gist\n"
+    issues=$((issues+1))
+  elif ! gh api 'gists?per_page=1' >/dev/null 2>&1; then
+    printf "  [BLOCKED] gist API not reachable -- network outage or rate-limit\n"
+    printf "         Fix: check internet; if persistent, run 'gh auth refresh'\n"
+    issues=$((issues+1))
+  else
+    printf "  [ok] gh authed with gist scope, gists API reachable\n"
   fi
 
   # ── Connect-specific: tailscale state. The default doctor only marks

--- a/airc
+++ b/airc
@@ -3906,18 +3906,25 @@ cmd_daemon_log() {
 }
 
 cmd_doctor() {
-  # Two modes:
+  # Three modes:
   #   airc doctor           -- environment health check (default).
   #                            Probes each prereq and prints the exact
   #                            install command for whichever package
   #                            manager this platform uses, so any AI
   #                            reading the output can `proactively fix
   #                            recoverable issues` (per /doctor SKILL.md).
+  #   airc doctor --connect -- pre-flight before `airc connect`. Runs
+  #                            the default health probes PLUS connect-
+  #                            specific checks (tailscale UP not just
+  #                            installed, gist API reachable, port free,
+  #                            cached host_target reachable). Issue #80.
+  #                            Use case: airc doctor --connect && airc connect
   #   airc doctor --tests   -- run the integration test suite (the
   #   airc doctor tests        prior default behavior; aliased on the
   #                            dispatch via `tests|test`).
   case "${1:-}" in
     --tests|-t|tests|test|run|suite) shift; _doctor_run_tests "$@"; return ;;
+    --connect|-c|connect)            shift; _doctor_connect_preflight "$@"; return ;;
   esac
 
   echo ""
@@ -4060,6 +4067,110 @@ _doctor_probe_tailscale() {
   printf "  [info] tailscale (optional) -- not installed; only needed for cross-LAN mesh\n"
   printf "         Install: %s\n" "$fix"
   return 0
+}
+
+_doctor_connect_preflight() {
+  # Pre-flight check before `airc connect`. Issue #80. Runs the default
+  # prereq probes PLUS connect-specific checks. Output is a checklist
+  # with fix commands; exit non-zero if any blocking issue. Use case:
+  #
+  #   airc doctor --connect && airc connect
+  #
+  # Catches the silent-fail classes that produced #78 / #85 / #79
+  # cascades for first-time users and surfaced as detective-work bugs.
+  echo ""
+  echo "  airc doctor --connect -- pre-flight checks"
+  echo "  ------------------------------------------"
+  echo ""
+  local issues=0
+  local mgr; mgr=$(_doctor_detect_pkgmgr)
+
+  # ── Required prereqs (same as default doctor) ──
+  _doctor_probe "git"          "$mgr" "VCS for clone/update"           || issues=$((issues+1))
+  _doctor_probe "gh"           "$mgr" "Gist substrate (room discovery)" || issues=$((issues+1))
+  _doctor_probe_gh_auth                                                  || issues=$((issues+1))
+  _doctor_probe "openssl"      "$mgr" "Ed25519 sign keys + signing"     || issues=$((issues+1))
+  _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"     || issues=$((issues+1))
+  _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"     || issues=$((issues+1))
+  _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"    || issues=$((issues+1))
+
+  # ── Connect-specific: gist API reachable ──
+  if command -v gh >/dev/null 2>&1; then
+    if gh api user >/dev/null 2>&1; then
+      printf "  [ok] github gists API reachable\n"
+    else
+      printf "  [BLOCKED] github gists API not reachable -- network or token issue\n"
+      printf "         Fix: check internet, then re-run 'gh auth login -s gist'\n"
+      issues=$((issues+1))
+    fi
+  fi
+
+  # ── Connect-specific: tailscale state. The default doctor only marks
+  # tailscale as "info" since it's optional for LAN-only mesh. In
+  # --connect mode, if there's a saved host_target in tailnet CGNAT
+  # range, Tailscale being UP is a HARD requirement.
+  local prior_host_target=""
+  [ -f "$CONFIG" ] && prior_host_target=$(get_config_val host_target "")
+  local prior_host_only="${prior_host_target##*@}"
+  local target_is_cgnat=0
+  case "$prior_host_only" in
+    100.6[4-9].*|100.[7-9][0-9].*|100.1[01][0-9].*|100.12[0-7].*) target_is_cgnat=1 ;;
+  esac
+  if [ "$target_is_cgnat" = "1" ]; then
+    # Use resolve_tailscale_bin so the .app-bundle / Program Files paths
+    # are checked, not just PATH (consistency with the rest of airc).
+    local ts_bin; ts_bin=$(resolve_tailscale_bin 2>/dev/null || true)
+    if [ -n "$ts_bin" ]; then
+      if "$ts_bin" status >/dev/null 2>&1; then
+        printf "  [ok] tailscale UP (cached host_target is tailnet CGNAT)\n"
+      else
+        printf "  [BLOCKED] tailscale CLI installed but DOWN -- cached host is tailnet, can't reach\n"
+        printf "         Fix: tailscale up\n"
+        issues=$((issues+1))
+      fi
+    else
+      printf "  [BLOCKED] tailscale CLI missing -- cached host is tailnet, can't reach\n"
+      printf "         Fix: install tailscale (https://tailscale.com/download), then 'tailscale up'\n"
+      issues=$((issues+1))
+    fi
+  else
+    _doctor_probe_tailscale "$mgr"  # optional, info-only
+  fi
+
+  # ── Connect-specific: AIRC_PORT free or auto-shift available ──
+  local target_port="${AIRC_PORT:-7547}"
+  if command -v lsof >/dev/null 2>&1; then
+    if lsof -iTCP:"$target_port" -sTCP:LISTEN >/dev/null 2>&1; then
+      printf "  [info] port %s busy -- airc will auto-shift to next free port\n" "$target_port"
+    else
+      printf "  [ok] port %s available for hosting\n" "$target_port"
+    fi
+  fi
+
+  # ── Connect-specific: cached host_target reachable (resume scenario) ──
+  if [ -n "$prior_host_target" ]; then
+    local probe_key="$IDENTITY_DIR/ssh_key"
+    if [ -f "$probe_key" ]; then
+      if ssh -i "$probe_key" -o StrictHostKeyChecking=accept-new \
+              -o ConnectTimeout=3 -o BatchMode=yes \
+              "$prior_host_target" "echo __PROBE_OK__" 2>/dev/null | grep -q __PROBE_OK__; then
+        printf "  [ok] cached host %s reachable + auth works\n" "$prior_host_target"
+      else
+        printf "  [warn] cached host %s not reachable -- may need re-pair\n" "$prior_host_target"
+        printf "         Fix: airc teardown --flush && airc join (fresh pairing)\n"
+        # Not blocking — fresh-pair flow handles this
+      fi
+    fi
+  fi
+
+  echo ""
+  if [ "$issues" -eq 0 ]; then
+    echo "  ✓ READY -- airc connect should work."
+    return 0
+  else
+    echo "  ✗ BLOCKED on $issues issue(s) -- fix the items above before 'airc connect'."
+    return 1
+  fi
 }
 
 _doctor_run_tests() {

--- a/airc.ps1
+++ b/airc.ps1
@@ -1263,7 +1263,7 @@ function Invoke-DoctorConnectPreflight {
         }
     }
 
-    # Required prereqs (mirror default doctor)
+    # Required prereqs (mirror default doctor — except gh chain, see below)
     Probe 'PowerShell 7+' {
         $PSVersionTable.PSVersion.Major -ge 7
     } 'winget install --id Microsoft.PowerShell  (then re-launch in pwsh)'
@@ -1274,14 +1274,6 @@ function Invoke-DoctorConnectPreflight {
         $r = Resolve-PythonBin
         $null -ne $r
     } 'winget install --id Python.Python.3.12'
-    Probe 'gh (GitHub CLI)' {
-        Get-Command gh -ErrorAction SilentlyContinue
-    } 'winget install --id GitHub.cli  (then: gh auth login -s gist)'
-    Probe 'gh authenticated (gist scope)' {
-        if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { return $false }
-        & gh auth status 2>$null | Out-Null
-        $LASTEXITCODE -eq 0
-    } 'gh auth login -s gist'
     Probe 'ssh (OpenSSH client)' {
         Get-Command ssh -ErrorAction SilentlyContinue
     } 'Settings -> Apps -> Optional Features -> Add -> OpenSSH Client'
@@ -1292,12 +1284,38 @@ function Invoke-DoctorConnectPreflight {
         $null -ne $script:OpenSSLBin
     } 'winget install --id Git.Git  (Git for Windows bundles openssl)'
 
-    # Connect-specific: github gists API reachable
-    Probe 'github gists API reachable' {
-        if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { return $false }
-        & gh api user 2>$null | Out-Null
-        $LASTEXITCODE -eq 0
-    } 'check internet, then re-run gh auth login -s gist'
+    # gh chain: installed -> authed -> gist scope -> gists API reachable.
+    # Single chain (early-return on first failure) so a missing gh isn't
+    # counted 3-4x. Gist scope is checked explicitly because gh auth
+    # status alone passes for a gist-scope-less token (Copilot #87 review).
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        Write-Host '  [MISSING] gh (GitHub CLI)'
+        Write-Host '         Fix: winget install --id GitHub.cli  (then: gh auth login -s gist)'
+        $script:DoctorIssues += 'gh-missing'
+    } else {
+        & gh auth status 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host '  [BLOCKED] gh authenticated'
+            Write-Host '         Fix: gh auth login -s gist'
+            $script:DoctorIssues += 'gh-auth'
+        } else {
+            $authStatus = & gh auth status 2>&1 | Out-String
+            if ($authStatus -notmatch '(?im)^\s*(?:Token scopes|scopes):.*\bgist\b') {
+                Write-Host "  [BLOCKED] gh authed but missing 'gist' scope (room substrate needs it)"
+                Write-Host '         Fix: gh auth refresh -s gist'
+                $script:DoctorIssues += 'gh-gist-scope'
+            } else {
+                & gh api 'gists?per_page=1' 2>$null | Out-Null
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Host '  [BLOCKED] gist API not reachable -- network outage or rate-limit'
+                    Write-Host "         Fix: check internet; if persistent, run 'gh auth refresh'"
+                    $script:DoctorIssues += 'gist-api'
+                } else {
+                    Write-Host '  [ok] gh authed with gist scope, gists API reachable'
+                }
+            }
+        }
+    }
 
     # Connect-specific: tailscale state when cached host_target is CGNAT
     $priorHostTarget = (Get-ConfigVal -Key 'host_target' -Default '')

--- a/airc.ps1
+++ b/airc.ps1
@@ -1140,7 +1140,24 @@ Identity resolution (highest priority first):
 # -- cmd_doctor ---------------------------------------------------------
 # User-emphasized: "if they dont have gh for example doctor would say
 # hey get that". Concrete winget commands so the user can copy-paste.
+# Three modes (mirrors bash):
+#   airc doctor              -- environment health (default)
+#   airc doctor --connect    -- pre-flight before airc connect (#80)
+#   airc doctor --tests      -- run integration suite
 function Invoke-Doctor {
+    param([string[]]$Argv = @())
+    if ($Argv -and $Argv.Count -gt 0) {
+        switch ($Argv[0]) {
+            { $_ -in @('--tests','-t','tests','test','run','suite') } {
+                Invoke-Tests
+                return
+            }
+            { $_ -in @('--connect','-c','connect') } {
+                Invoke-DoctorConnectPreflight
+                return
+            }
+        }
+    }
     Write-Host ''
     Write-Host '  airc doctor - environment health'
     Write-Host '  --------------------------------'
@@ -1220,6 +1237,126 @@ function Invoke-Doctor {
         Write-Host "  $($script:DoctorIssues.Count) prereq(s) missing - see fix lines above."
         Write-Host '  Fastest path: re-run install.ps1 (it auto-installs via winget):'
         Write-Host '    iwr https://raw.githubusercontent.com/CambrianTech/airc/canary/install.ps1 | iex'
+    }
+    Write-Host ''
+}
+
+# -- airc doctor --connect ---------------------------------------------
+# Issue #80: pre-flight check before airc connect. Runs default prereq
+# probes PLUS connect-specific checks (gh gist API reachable, tailscale
+# UP if cached host is CGNAT, port available, cached host reachable).
+# Use case: airc doctor --connect; if exit 0, airc connect.
+function Invoke-DoctorConnectPreflight {
+    Write-Host ''
+    Write-Host '  airc doctor --connect -- pre-flight checks'
+    Write-Host '  ------------------------------------------'
+    Write-Host ''
+    $script:DoctorIssues = @()
+
+    function Probe($Name, $TestBlock, $FixHint) {
+        if (& $TestBlock) {
+            Write-Host "  [ok] $Name"
+        } else {
+            Write-Host "  [MISSING] $Name"
+            Write-Host "         Fix: $FixHint"
+            $script:DoctorIssues += $Name
+        }
+    }
+
+    # Required prereqs (mirror default doctor)
+    Probe 'PowerShell 7+' {
+        $PSVersionTable.PSVersion.Major -ge 7
+    } 'winget install --id Microsoft.PowerShell  (then re-launch in pwsh)'
+    Probe 'git' {
+        Get-Command git -ErrorAction SilentlyContinue
+    } 'winget install --id Git.Git'
+    Probe 'python' {
+        $r = Resolve-PythonBin
+        $null -ne $r
+    } 'winget install --id Python.Python.3.12'
+    Probe 'gh (GitHub CLI)' {
+        Get-Command gh -ErrorAction SilentlyContinue
+    } 'winget install --id GitHub.cli  (then: gh auth login -s gist)'
+    Probe 'gh authenticated (gist scope)' {
+        if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { return $false }
+        & gh auth status 2>$null | Out-Null
+        $LASTEXITCODE -eq 0
+    } 'gh auth login -s gist'
+    Probe 'ssh (OpenSSH client)' {
+        Get-Command ssh -ErrorAction SilentlyContinue
+    } 'Settings -> Apps -> Optional Features -> Add -> OpenSSH Client'
+    Probe 'ssh-keygen' {
+        Get-Command ssh-keygen -ErrorAction SilentlyContinue
+    } 'Comes with OpenSSH Client (see above)'
+    Probe 'openssl' {
+        $null -ne $script:OpenSSLBin
+    } 'winget install --id Git.Git  (Git for Windows bundles openssl)'
+
+    # Connect-specific: github gists API reachable
+    Probe 'github gists API reachable' {
+        if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { return $false }
+        & gh api user 2>$null | Out-Null
+        $LASTEXITCODE -eq 0
+    } 'check internet, then re-run gh auth login -s gist'
+
+    # Connect-specific: tailscale state when cached host_target is CGNAT
+    $priorHostTarget = (Get-ConfigVal -Key 'host_target' -Default '')
+    $priorHostOnly = if ($priorHostTarget -match '@') { ($priorHostTarget -split '@')[-1] } else { $priorHostTarget }
+    if ($priorHostOnly -and (Test-CgnatIp -Ip $priorHostOnly)) {
+        $tsBin = Resolve-TailscaleBin
+        if ($tsBin) {
+            & $tsBin status 2>$null | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host '  [ok] tailscale UP (cached host_target is tailnet CGNAT)'
+            } else {
+                Write-Host "  [BLOCKED] tailscale CLI installed but DOWN -- cached host is tailnet, can't reach"
+                Write-Host '         Fix: tailscale up'
+                $script:DoctorIssues += 'tailscale-down'
+            }
+        } else {
+            Write-Host "  [BLOCKED] tailscale CLI missing -- cached host is tailnet, can't reach"
+            Write-Host '         Fix: winget install --id tailscale.tailscale  (then: tailscale up)'
+            $script:DoctorIssues += 'tailscale-missing'
+        }
+    } else {
+        Probe 'tailscale (optional)' {
+            $null -ne (Resolve-TailscaleBin)
+        } 'winget install --id tailscale.tailscale  (LAN-only mode works without it)'
+    }
+
+    # Connect-specific: AIRC_PORT free
+    $targetPort = if ($env:AIRC_PORT) { [int]$env:AIRC_PORT } else { 7547 }
+    try {
+        $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Any, $targetPort)
+        $listener.Start()
+        $listener.Stop()
+        Write-Host "  [ok] port $targetPort available for hosting"
+    } catch {
+        Write-Host "  [info] port $targetPort busy -- airc will auto-shift to next free port"
+    }
+
+    # Connect-specific: cached host_target reachable (resume scenario)
+    if ($priorHostTarget) {
+        $sshKey = Join-Path $IDENTITY_DIR 'ssh_key'
+        if (Test-Path $sshKey) {
+            $probeOut = & ssh -i $sshKey -o StrictHostKeyChecking=accept-new `
+                              -o ConnectTimeout=3 -o BatchMode=yes `
+                              $priorHostTarget 'echo __PROBE_OK__' 2>$null
+            if ($probeOut -match '__PROBE_OK__') {
+                Write-Host "  [ok] cached host $priorHostTarget reachable + auth works"
+            } else {
+                Write-Host "  [warn] cached host $priorHostTarget not reachable -- may need re-pair"
+                Write-Host '         Fix: airc teardown --flush; airc join (fresh pairing)'
+            }
+        }
+    }
+
+    Write-Host ''
+    if ($script:DoctorIssues.Count -eq 0) {
+        Write-Host '  [READY] -- airc connect should work.'
+    } else {
+        Write-Host "  [BLOCKED] on $($script:DoctorIssues.Count) issue(s) -- fix the items above before 'airc connect'."
+        exit 1
     }
     Write-Host ''
 }
@@ -2447,7 +2584,7 @@ try {
         # Info
         { $_ -in @('version','--version','-v') }      { Invoke-Version; break }
         { $_ -in @('help','--help','-h') }            { Invoke-Help; break }
-        'doctor'                                       { Invoke-Doctor; break }
+        'doctor'                                       { Invoke-Doctor -Argv $rest; break }
         { $_ -in @('tests','test') }                   { Invoke-Tests; break }
 
         # Connection lifecycle


### PR DESCRIPTION
## Summary

Closes #80. Adds `airc doctor --connect` pre-flight mode. Use case:

    airc doctor --connect && airc connect

Surfaces the silent-fail classes that produced #78 / #85 / #79 cascades for first-time users BEFORE the pair attempt instead of during. Each probe is [ok] / [BLOCKED] / [info] with a fix command; exit non-zero if any BLOCKED.

## What's checked

Default health probes plus connect-specific:

- **github gists API reachable** (catches network outages + token issues that silently break gist substrate)
- **tailscale UP** (not just installed) when cached host_target is tailnet CGNAT — Memento's exact failure mode (#78) caught earlier in the workflow
- **AIRC_PORT free** (info-only since airc handles port-shift gracefully)
- **Cached host_target reachable + ssh-auth works** (resume scenario — catches stale-pairing + dead-host before silent queue / dead-monitor cascade)

## Bash + PS1 lockstep

Per Joel's no-neglect-Windows rule. Both languages have the same probe set in their own idiom.

## Test plan

- [x] 133/133 integration tests pass
- [x] Bash syntax check
- [x] Verified locally on Mac: `airc doctor --connect` returns READY in healthy env, prints fix commands otherwise
- [ ] Live verify on Windows native (Toby / future test machine)

## Related issues

Closes #80. Complements landed #84 (resume + fresh-pair tailscale gate) + #86 (gh-bin winget fallback). Together these three eliminate the silent-fail classes at install/connect time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)