### PR TITLE
feat: bootstrap-airc.sh + .ps1 single-command first-time setup (closes #81)

### DIFF
--- a/bootstrap-airc.ps1
+++ b/bootstrap-airc.ps1
@@ -1,0 +1,108 @@
+# bootstrap-airc.ps1 -- cold install + first-time setup + room join in one command
+#
+# Usage:
+#   .\bootstrap-airc.ps1 [mnemonic-or-gist-id]
+#   iwr https://raw.githubusercontent.com/CambrianTech/airc/canary/bootstrap-airc.ps1 | iex
+#   (with mnemonic: download first, then .\bootstrap-airc.ps1 oregon-uncle-bravo-eleven)
+#
+# What it does:
+#   1. Runs install.ps1 if airc isn't already on PATH (handles prereqs
+#      via winget + adds airc to PATH).
+#   2. Runs `airc doctor --connect` to verify the env can pair (catches
+#      Tailscale-down / gh-missing / network-out before they silently fail).
+#   3. Walks gh auth if not already done.
+#   4. Joins a room: with the mnemonic-or-gist-id argument if given,
+#      otherwise auto-scope from the current git repo (or #general).
+#   5. Sets a default identity if pronouns are still unset.
+#   6. Prints a final whois + next-step hints.
+#
+# Designed for first-time users (especially first-EXTERNAL users like
+# Toby) so the path from "got the SMS with a 4-word phrase" to "in the
+# room" is a single command, not seven.
+#
+# Issue #81. Pairs with bootstrap-airc.sh for Mac/Linux/Git-Bash.
+
+[CmdletBinding()]
+param(
+    [string]$Mnemonic = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Step($msg) { Write-Host "`n==> $msg" -ForegroundColor Blue }
+function OK($msg)   { Write-Host "  -> $msg" -ForegroundColor Green }
+function Warn($msg) { Write-Host "  ! $msg"  -ForegroundColor Yellow }
+function FailOut($msg) { Write-Host "`nERROR: $msg" -ForegroundColor Red; exit 1 }
+
+# 1. install if not present
+$airc = Get-Command airc -ErrorAction SilentlyContinue
+if (-not $airc) {
+    Step 'airc not on PATH -- running installer (canary channel)'
+    iwr 'https://raw.githubusercontent.com/CambrianTech/airc/canary/install.ps1' -UseBasicParsing | iex
+    # Refresh PATH for this session
+    $env:PATH = [Environment]::GetEnvironmentVariable('PATH','User') + [IO.Path]::PathSeparator + $env:PATH
+    $airc = Get-Command airc -ErrorAction SilentlyContinue
+    if (-not $airc) {
+        FailOut 'airc still not on PATH after install. Restart your shell and re-run this script.'
+    }
+    OK "airc installed: $($airc.Source)"
+} else {
+    OK "airc already on PATH: $($airc.Source)"
+}
+
+# 2. pre-flight (catches Tailscale-down, gh-missing, network-out, etc.)
+Step 'Pre-flight: airc doctor --connect'
+& airc doctor --connect
+if ($LASTEXITCODE -ne 0) {
+    FailOut 'Pre-flight failed. Fix the items above, then re-run this script.'
+}
+
+# 3. gh auth if needed
+& gh auth status 2>$null | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Step "Authenticating gh (need 'gist' scope for room substrate)"
+    & gh auth login -s gist
+    if ($LASTEXITCODE -ne 0) {
+        FailOut 'gh auth failed. Re-run this script after logging in manually.'
+    }
+}
+
+# 4. join the room
+if ($Mnemonic) {
+    Step "Joining room via mnemonic / gist-id: $Mnemonic"
+    & airc join $Mnemonic
+} else {
+    Step 'Joining auto-scoped room (no mnemonic given -- using git remote org or #general)'
+    & airc join
+}
+
+# Give the pair handshake a moment to settle before identity check.
+Start-Sleep -Seconds 1
+
+# 5. set default identity if unset
+$identityOut = & airc identity show 2>$null
+if ($identityOut -match 'pronouns:\s*\(unset\)') {
+    Step 'Setting default identity (override later with: airc identity set ...)'
+    & airc identity set `
+        --pronouns it `
+        --role onboarded-via-bootstrap `
+        --bio 'Joined via bootstrap-airc.ps1'
+}
+
+# 6. final summary
+Write-Host ''
+OK 'Bootstrap complete. Your airc identity:'
+Write-Host ''
+$whois = & airc whois 2>&1
+foreach ($line in $whois) { Write-Host "    $line" }
+Write-Host ''
+OK 'Next steps:'
+@'
+    airc msg "hello room"           # broadcast to your room
+    airc msg @<peer> "hi"           # DM a peer
+    airc peers                      # list paired peers
+    airc whois <peer>               # see another peer's identity
+    airc list                       # see all rooms on your gh account
+    airc help                       # full command list
+'@ | Write-Host
+Write-Host ''

--- a/bootstrap-airc.sh
+++ b/bootstrap-airc.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# bootstrap-airc.sh -- cold install + first-time setup + room join in one command
+#
+# Usage:
+#   ./bootstrap-airc.sh [mnemonic-or-gist-id]
+#   curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/canary/bootstrap-airc.sh \
+#     | bash -s -- [mnemonic-or-gist-id]
+#
+# What it does:
+#   1. Runs install.sh if airc isn't already on PATH (handles prereqs +
+#      symlinks the binary into ~/.local/bin).
+#   2. Runs `airc doctor --connect` to verify the env can pair (catches
+#      Tailscale-down / gh-missing / network-out before they silently fail).
+#   3. Walks gh auth if not already done.
+#   4. Joins a room: with the mnemonic-or-gist-id argument if given,
+#      otherwise auto-scope from the current git repo (or #general).
+#   5. Sets a default identity if pronouns are still unset.
+#   6. Prints a final whois + next-step hints.
+#
+# Designed for first-time users (especially first-EXTERNAL users like
+# Toby) so the path from "got the SMS with a 4-word phrase" to "in the
+# room" is a single command, not seven.
+#
+# Issue #81. Pairs with bootstrap-airc.ps1 for Windows native.
+
+set -euo pipefail
+
+MNEMONIC="${1:-}"
+
+step() { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+ok()   { printf '  \033[1;32m->\033[0m %s\n' "$*"; }
+warn() { printf '  \033[1;33m!\033[0m %s\n' "$*" >&2; }
+die()  { printf '\n\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# 1. install if not present
+if ! command -v airc >/dev/null 2>&1; then
+  step "airc not on PATH -- running installer (canary channel)"
+  curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/canary/install.sh | bash
+  # Pick up the freshly-installed binary in this same session.
+  export PATH="$HOME/.local/bin:$PATH"
+  if ! command -v airc >/dev/null 2>&1; then
+    die "airc still not on PATH after install. Add ~/.local/bin to PATH and re-run."
+  fi
+  ok "airc installed: $(command -v airc)"
+else
+  ok "airc already on PATH: $(command -v airc)"
+fi
+
+# 2. pre-flight (catches Tailscale-down, gh-missing, network-out, etc.)
+step "Pre-flight: airc doctor --connect"
+if ! airc doctor --connect; then
+  die "Pre-flight failed. Fix the items above, then re-run this script."
+fi
+
+# 3. gh auth if needed
+if ! gh auth status >/dev/null 2>&1; then
+  step "Authenticating gh (need 'gist' scope for room substrate)"
+  gh auth login -s gist
+fi
+
+# 4. join the room
+if [ -n "$MNEMONIC" ]; then
+  step "Joining room via mnemonic / gist-id: $MNEMONIC"
+  airc join "$MNEMONIC"
+else
+  step "Joining auto-scoped room (no mnemonic given -- using git remote org or #general)"
+  airc join
+fi
+
+# Give the pair handshake a moment to settle before identity check.
+sleep 1
+
+# 5. set default identity if unset
+if airc identity show 2>/dev/null | grep -qE 'pronouns: *\(unset\)'; then
+  step "Setting default identity (override later with: airc identity set ...)"
+  airc identity set \
+    --pronouns it \
+    --role onboarded-via-bootstrap \
+    --bio "Joined via bootstrap-airc.sh"
+fi
+
+# 6. final summary
+echo ""
+ok "Bootstrap complete. Your airc identity:"
+echo ""
+airc whois 2>&1 | sed 's/^/    /'
+echo ""
+ok "Next steps:"
+cat <<'EOF'
+    airc msg "hello room"           # broadcast to your room
+    airc msg @<peer> "hi"           # DM a peer
+    airc peers                      # list paired peers
+    airc whois <peer>               # see another peer's identity
+    airc list                       # see all rooms on your gh account
+    airc help                       # full command list
+EOF
+echo ""


### PR DESCRIPTION
## Summary

Closes #81. Adds bootstrap-airc.sh (Mac/Linux/Git-Bash) and bootstrap-airc.ps1 (Windows native). Single-command path from cold machine to in-the-room — designed for first-external-user cases (Toby's exact onboarding path).

```bash
# Mac / Linux / Git-Bash
bash bootstrap-airc.sh oregon-uncle-bravo-eleven
```
```powershell
# Windows native
.\bootstrap-airc.ps1 oregon-uncle-bravo-eleven
```

## Flow

1. **Install** if airc not on PATH — runs `install.{sh,ps1}` (existing) which handles prereqs via package manager.
2. **Pre-flight** — runs `airc doctor --connect` (PR #87) to catch silent-fail classes before pair attempt: tailscale-down, gh-missing, network-out, stale pairing, etc.
3. **gh auth** if not authed — interactive `gh auth login -s gist`.
4. **Join** — `airc join <mnemonic>` if mnemonic given, else auto-scope from current git repo (or #general).
5. **Default identity** — sets `pronouns/role/bio` if unset; user can override later.
6. **Final summary** — prints `airc whois` + next-step command hints.

## What it solves

The seven-step onboarding problem collapsed to one. Each prior step had its own failure mode and required diagnostic detective work when it failed. With pre-flight + bootstrap, failures surface in one place with one actionable message.

## Pure orchestration

No new airc-side code. ~80 lines each (bash + ps1) wrapping existing tools (install, doctor --connect, gh auth, airc join, airc identity set, airc whois).

## Test plan

- [x] Bash syntax check
- [x] 133/133 integration tests still pass (no airc-binary changes in this PR)
- [ ] Live verify on Mac (after #87 merges to canary so doctor --connect is in canary)
- [ ] Live verify on Windows native (Toby / future test)

## Depends on

- #87 (doctor --connect) — bootstrap relies on that mode existing in canary. Recommend merge order: #87 → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)