### PR TITLE
feat(rooms): relative-time + (stale) annotation on airc list (closes #82)

### DIFF
--- a/airc
+++ b/airc
@@ -2971,10 +2971,14 @@ cmd_rooms() {
   # Match BOTH the persistent IRC-style rooms (#39, prefix `airc room:`)
   # and the legacy single-pair invites (#37/#38, prefix `airc invite for`).
   # Show kind explicitly so the AI / human can tell them apart.
+  # gh gist list columns: id  description  files  visibility  updated_at
+  # Use $5 (timestamp) for the updated field — pre-#82 we were using
+  # $4 (visibility, "secret") under the "updated:" label, which is a
+  # display bug fixed here on the way to adding stale markers.
   local raw; raw=$(gh gist list --limit 50 2>/dev/null \
     | awk -F'\t' '
-        /airc room:/        { print "room\t"   $1 "\t" $2 "\t" $4 }
-        /airc invite for/   { print "invite\t" $1 "\t" $2 "\t" $4 }
+        /airc room:/        { print "room\t"   $1 "\t" $2 "\t" $5 }
+        /airc invite for/   { print "invite\t" $1 "\t" $2 "\t" $5 }
       ')
   local count; count=$(printf '%s' "$raw" | grep -c . || true)
   if [ "$count" = "0" ]; then
@@ -2993,12 +2997,62 @@ cmd_rooms() {
       room)   marker="#" ;;     # persistent channel
       invite) marker="(1:1)" ;; # ephemeral pairing
     esac
-    printf '    %s %s\n      id:       %s\n      mnemonic: %s\n      updated:  %s\n\n' \
-      "$marker" "$desc" "$id" "$hh" "$updated"
+    local age_str; age_str=$(_format_relative_time "$updated")
+    local stale_marker=""
+    if _is_stale "$updated"; then
+      stale_marker="  (stale)"
+    fi
+    printf '    %s %s%s\n      id:       %s\n      mnemonic: %s\n      updated:  %s\n\n' \
+      "$marker" "$desc" "$stale_marker" "$id" "$hh" "$age_str"
   done
   echo "  Join (auto-resolves on same gh account): airc connect"
   echo "  Join by id (cross-account share):        airc connect <id>"
   echo ""
+}
+
+# Convert an ISO 8601 timestamp into a relative-time string ("12m ago",
+# "3h ago", "2d ago"). Handles both macOS BSD date and GNU/Linux date
+# syntax differences. Falls back to the raw timestamp on parse failure.
+# Used by cmd_rooms to display gist activity (#82).
+_format_relative_time() {
+  local ts="${1:-}"
+  [ -z "$ts" ] && { echo "(unknown)"; return; }
+  local epoch
+  if epoch=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null); then
+    : # BSD/macOS
+  elif epoch=$(date -u -d "$ts" +%s 2>/dev/null); then
+    : # GNU/Linux/WSL
+  else
+    echo "$ts"
+    return
+  fi
+  local now; now=$(date -u +%s)
+  local diff=$((now - epoch))
+  if [ "$diff" -lt 0 ]; then echo "$ts"; return; fi
+  if [ "$diff" -lt 60 ]; then       echo "${diff}s ago"
+  elif [ "$diff" -lt 3600 ]; then   echo "$((diff / 60))m ago"
+  elif [ "$diff" -lt 86400 ]; then  echo "$((diff / 3600))h ago"
+  else                              echo "$((diff / 86400))d ago"
+  fi
+}
+
+# Return 0 if the given ISO timestamp is older than AIRC_STALE_HOURS
+# (default 24h). Used to mark abandoned rooms in cmd_rooms output (#82).
+_is_stale() {
+  local ts="${1:-}"
+  local threshold_hours="${AIRC_STALE_HOURS:-24}"
+  [ -z "$ts" ] && return 1
+  local epoch
+  if epoch=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null); then
+    :
+  elif epoch=$(date -u -d "$ts" +%s 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  local now; now=$(date -u +%s)
+  local diff=$((now - epoch))
+  [ "$diff" -gt $((threshold_hours * 3600)) ]
 }
 
 # ── cmd_part: leave the current room ──────────────────────────────────

--- a/airc.ps1
+++ b/airc.ps1
@@ -608,7 +608,10 @@ function Test-GhAvailable {
 function Get-GhGistList {
     param([int]$Limit = 50)
     if (-not (Test-GhAvailable)) { return @() }
-    # `gh gist list --limit N` outputs TAB-separated: id, description, files, visibility, updated
+    # `gh gist list --limit N` outputs TAB-separated: id, description, files, visibility, updated_at
+    # Pre-#82 we read $cols[3] (visibility) into Updated -- a display bug
+    # where rooms list showed "updated: secret" instead of an actual time.
+    # Fixed here on the way to adding stale-marker logic.
     $raw = & gh gist list --limit $Limit 2>$null
     if ($LASTEXITCODE -ne 0 -or -not $raw) { return @() }
     $rows = @()
@@ -619,10 +622,44 @@ function Get-GhGistList {
         $rows += [pscustomobject]@{
             Id          = $cols[0]
             Description = $cols[1]
-            Updated     = if ($cols.Count -gt 3) { $cols[3] } else { '' }
+            Updated     = if ($cols.Count -gt 4) { $cols[4] } else { '' }
         }
     }
     return $rows
+}
+
+# Convert ISO 8601 timestamp into relative-time string ("12m ago",
+# "3h ago", "2d ago"). Falls back to raw timestamp on parse failure.
+# #82 — used by Invoke-Rooms to display gist activity.
+function _FormatRelativeTime {
+    param([string]$Ts)
+    if (-not $Ts) { return '(unknown)' }
+    try {
+        $dt = [datetime]::Parse($Ts).ToUniversalTime()
+    } catch {
+        return $Ts
+    }
+    $diff = ([datetime]::UtcNow - $dt).TotalSeconds
+    if ($diff -lt 0)      { return $Ts }
+    if ($diff -lt 60)     { return "$([int]$diff)s ago" }
+    if ($diff -lt 3600)   { return "$([int]($diff / 60))m ago" }
+    if ($diff -lt 86400)  { return "$([int]($diff / 3600))h ago" }
+    return "$([int]($diff / 86400))d ago"
+}
+
+# Return $true if ISO timestamp is older than AIRC_STALE_HOURS
+# (default 24h). #82 — used to mark abandoned rooms.
+function _IsStale {
+    param([string]$Ts)
+    if (-not $Ts) { return $false }
+    $thresholdHours = if ($env:AIRC_STALE_HOURS) { [int]$env:AIRC_STALE_HOURS } else { 24 }
+    try {
+        $dt = [datetime]::Parse($Ts).ToUniversalTime()
+    } catch {
+        return $false
+    }
+    $diffSec = ([datetime]::UtcNow - $dt).TotalSeconds
+    return ($diffSec -gt ($thresholdHours * 3600))
 }
 
 # Fetch the content of the first file in a gist by ID. Uses `gh api` over
@@ -1453,10 +1490,12 @@ function Invoke-Rooms {
     foreach ($m in $matches) {
         $marker = if ($m.Kind -eq 'room') { '#' } else { '(1:1)' }
         $hh = Get-Humanhash -HexInput $m.Id
-        Write-Host "    $marker $($m.Description)"
+        $ageStr = _FormatRelativeTime -Ts $m.Updated
+        $stale = if (_IsStale -Ts $m.Updated) { '  (stale)' } else { '' }
+        Write-Host "    $marker $($m.Description)$stale"
         Write-Host "      id:       $($m.Id)"
         Write-Host "      mnemonic: $hh"
-        Write-Host "      updated:  $($m.Updated)"
+        Write-Host "      updated:  $ageStr"
         Write-Host ''
     }
     Write-Host '  Join (auto on same gh account): airc connect'


### PR DESCRIPTION
## Summary

Closes #82. Adds relative-time display + `(stale)` marker for rooms inactive >24h (configurable via `AIRC_STALE_HOURS`).

**Side fix:** the existing rooms list was reading column 4 (visibility = \"secret\") into the \"updated\" field — a display bug fixed here on the way to adding activity annotation. Pre-#82 the rooms list literally printed \"updated:  secret\".

## Output before / after

Before:
```
    # airc room: general
      id:       dca151bf...
      mnemonic: moon-yankee-steak-grey
      updated:  secret
```

After:
```
    # airc room: general
      id:       dca151bf...
      mnemonic: moon-yankee-steak-grey
      updated:  1h ago

    (1:1) airc invite for continuum-a25c (delete after pair)  (stale)
      ...
      updated:  1d ago
```

## Test plan

- [x] Bash syntax check
- [x] 133/133 integration tests pass
- [x] Verified locally on Mac: `airc list` now shows actual timestamps + stale markers
- [x] Tested with multiple time-ranges (1h, 15h, 1d) — relative formatting correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)