### PR TITLE
fix: stale-pairing detect + Git-Bash winget + gh scope regex + bootstrap pwsh-relaunch (closes #83 #90 #91)

### DIFF
--- a/airc
+++ b/airc
@@ -4201,7 +4201,7 @@ _doctor_connect_preflight() {
     printf "  [BLOCKED] gh authenticated\n"
     printf "         Fix: gh auth login -s gist\n"
     issues=$((issues+1))
-  elif ! gh auth status 2>&1 | grep -qiE "(scopes:|token scopes:)[^\\n]*\\bgist\\b"; then
+  elif ! gh auth status 2>&1 | grep -qiE '(scopes|token scopes):.*\bgist\b'; then
     printf "  [BLOCKED] gh authed but missing 'gist' scope (room substrate needs it)\n"
     printf "         Fix: gh auth refresh -s gist\n"
     issues=$((issues+1))

--- a/airc
+++ b/airc
@@ -1296,6 +1296,42 @@ cmd_connect() {
         die "Re-run airc join after starting Tailscale."
       fi
 
+      # Stale-pairing detect (#83): if we resolved into the room via a
+      # gist (joiner-side gist_id was cached at pair time) and that gist
+      # is now gone or replaced, the room dissolved or got rehosted —
+      # the cached host_target is stale even if TCP would still answer.
+      # Catch this BEFORE SSH probe so we self-heal cleanly instead of
+      # silently re-pairing against a dead-but-reachable host or
+      # accidentally landing in a different room.
+      local _saved_gist_id=""
+      [ -f "$AIRC_WRITE_DIR/room_gist_id" ] && _saved_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null)
+      local _saved_room_resume=""
+      [ -f "$AIRC_WRITE_DIR/room_name" ] && _saved_room_resume=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null)
+      if [ -n "$_saved_gist_id" ] && command -v gh >/dev/null 2>&1; then
+        if ! gh api "gists/$_saved_gist_id" >/dev/null 2>&1; then
+          # Gist gone (host parted, or peer self-healed and replaced it).
+          # Trigger fresh discovery: clear the stale joiner state and
+          # re-exec ourselves into airc connect, which will re-resolve
+          # via the room name (or fall through to host-mode if no room
+          # gist exists — first-back-in-becomes-new-host).
+          echo ""
+          echo "  ⚠  Saved room gist ($_saved_gist_id) no longer on your gh — room dissolved or rehosted."
+          if [ -n "$_saved_room_resume" ]; then
+            echo "  Re-discovering #${_saved_room_resume} via fresh gist lookup..."
+          else
+            echo "  Re-pairing via fresh discovery..."
+          fi
+          # Wipe stale joiner state. Identity + peer records persist.
+          rm -f "$CONFIG" "$AIRC_WRITE_DIR/room_gist_id"
+          local _preserved_name; _preserved_name=$(get_name 2>/dev/null || echo "")
+          if [ -n "$_saved_room_resume" ]; then
+            exec env ${_preserved_name:+AIRC_NAME="$_preserved_name"} "$0" connect --room "$_saved_room_resume"
+          else
+            exec env ${_preserved_name:+AIRC_NAME="$_preserved_name"} "$0" connect
+          fi
+        fi
+      fi
+
       # Auth probe BEFORE committing to the monitor loop. Prior behavior
       # went straight into tail-over-SSH; if auth was broken (stale keys
       # after reinstall, authorized_keys rotation on host), ssh exited 255
@@ -1867,6 +1903,14 @@ record = {
 with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
     json.dump(record, f, indent=2)
 " 2>/dev/null || true
+
+    # If we resolved this pair via gist discovery (vs. inline-invite),
+    # persist the gist id so resume-time freshness checks can detect a
+    # gist-deletion / replacement before re-pairing against a stale host
+    # (issue #83). Cleared by cmd_part on graceful leave.
+    if [ -n "$_resolved_gist_id" ]; then
+      echo "$_resolved_gist_id" > "$AIRC_WRITE_DIR/room_gist_id"
+    fi
 
     # Persist host details in own config so `airc invite` can reconstruct
     # the join string for onward sharing without a fresh handshake. Also

--- a/airc.ps1
+++ b/airc.ps1
@@ -1337,7 +1337,7 @@ function Invoke-DoctorConnectPreflight {
             $script:DoctorIssues += 'gh-auth'
         } else {
             $authStatus = & gh auth status 2>&1 | Out-String
-            if ($authStatus -notmatch '(?im)^\s*(?:Token scopes|scopes):.*\bgist\b') {
+            if ($authStatus -notmatch '(?i)(?:Token scopes|scopes):.*\bgist\b') {
                 Write-Host "  [BLOCKED] gh authed but missing 'gist' scope (room substrate needs it)"
                 Write-Host '         Fix: gh auth refresh -s gist'
                 $script:DoctorIssues += 'gh-gist-scope'

--- a/airc.ps1
+++ b/airc.ps1
@@ -2125,6 +2125,44 @@ function Invoke-Connect {
             if (Advise-TailscaleIfDown -TargetHost $priorHost) {
                 Die 'Re-run airc join after starting Tailscale.'
             }
+
+            # Stale-pairing detect (#83): if we resolved into the room
+            # via gist discovery (joiner-side gist_id was cached at pair
+            # time) and that gist is now gone or replaced, the room
+            # dissolved or got rehosted. Catch BEFORE SSH probe so we
+            # self-heal cleanly instead of silently re-pairing against
+            # a dead-but-reachable host or the wrong room.
+            $savedGistFile = Join-Path $AIRC_WRITE_DIR 'room_gist_id'
+            $savedRoomFile = Join-Path $AIRC_WRITE_DIR 'room_name'
+            if ((Test-Path $savedGistFile) -and (Get-Command gh -ErrorAction SilentlyContinue)) {
+                $savedGistId = (Get-Content $savedGistFile -Raw -ErrorAction SilentlyContinue).Trim()
+                if ($savedGistId) {
+                    & gh api "gists/$savedGistId" 2>$null | Out-Null
+                    if ($LASTEXITCODE -ne 0) {
+                        $savedRoom = ''
+                        if (Test-Path $savedRoomFile) {
+                            $savedRoom = (Get-Content $savedRoomFile -Raw -ErrorAction SilentlyContinue).Trim()
+                        }
+                        Write-Host ''
+                        Write-Host "  ! Saved room gist ($savedGistId) no longer on your gh -- room dissolved or rehosted."
+                        if ($savedRoom) {
+                            Write-Host "  Re-discovering #$savedRoom via fresh gist lookup..."
+                        } else {
+                            Write-Host '  Re-pairing via fresh discovery...'
+                        }
+                        # Wipe stale joiner state (identity + peers persist).
+                        Remove-Item -Force $CONFIG -ErrorAction SilentlyContinue
+                        Remove-Item -Force $savedGistFile -ErrorAction SilentlyContinue
+                        $preservedName = Get-Name 2>$null
+                        $reExecArgs = @('connect')
+                        if ($savedRoom) { $reExecArgs += @('--room', $savedRoom) }
+                        if ($preservedName) { $env:AIRC_NAME = $preservedName }
+                        & $PSCommandPath @reExecArgs
+                        exit $LASTEXITCODE
+                    }
+                }
+            }
+
             # Auth probe before committing to monitor loop
             $sshKey = Join-Path $IDENTITY_DIR 'ssh_key'
             $probeErr = [System.IO.Path]::GetTempFileName()
@@ -2376,6 +2414,14 @@ function Invoke-Connect {
             host_name      = $peerName
             host_port      = $peerPort
             host_ssh_pub   = $resp.ssh_pub
+        }
+
+        # If we resolved this pair via gist discovery (vs. inline-invite),
+        # persist the gist id so resume-time freshness checks (#83) can
+        # detect a gist-deletion / replacement before re-pairing against
+        # a stale host. Cleared by Invoke-Part on graceful leave.
+        if ($resolvedGistId) {
+            Set-Content -Path (Join-Path $AIRC_WRITE_DIR 'room_gist_id') -Value $resolvedGistId -NoNewline
         }
 
         # Reminder from host

--- a/bootstrap-airc.ps1
+++ b/bootstrap-airc.ps1
@@ -34,6 +34,48 @@ function OK($msg)   { Write-Host "  -> $msg" -ForegroundColor Green }
 function Warn($msg) { Write-Host "  ! $msg"  -ForegroundColor Yellow }
 function FailOut($msg) { Write-Host "`nERROR: $msg" -ForegroundColor Red; exit 1 }
 
+# 0. PowerShell 7+ check — re-launch under pwsh if running on Windows PS 5.1
+# (the default Windows shell). airc.ps1 requires PS 7+; if we don't
+# re-launch here, every subsequent `airc` invocation in this script
+# fails with version-mismatch errors. Issue #91 (Toby's case 2026-04-25).
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    $pwshCandidates = @(
+        "$env:ProgramFiles\PowerShell\7\pwsh.exe"
+        "${env:ProgramFiles(x86)}\PowerShell\7\pwsh.exe"
+        "$env:LOCALAPPDATA\Microsoft\WindowsApps\pwsh.exe"
+    )
+    $pwshPath = (Get-Command pwsh -ErrorAction SilentlyContinue).Source
+    if (-not $pwshPath) {
+        foreach ($p in $pwshCandidates) {
+            if ($p -and (Test-Path $p)) { $pwshPath = $p; break }
+        }
+    }
+    if (-not $pwshPath) {
+        Step 'PowerShell 7+ not found -- installing via winget (airc.ps1 requires it)'
+        $winget = Get-Command winget -ErrorAction SilentlyContinue
+        if (-not $winget) {
+            FailOut 'winget not available. Install PowerShell 7 manually from https://github.com/PowerShell/PowerShell/releases, then re-run this script.'
+        }
+        & winget install --id Microsoft.PowerShell --silent --accept-source-agreements --accept-package-agreements
+        # Re-scan for pwsh
+        $pwshPath = (Get-Command pwsh -ErrorAction SilentlyContinue).Source
+        if (-not $pwshPath) {
+            foreach ($p in $pwshCandidates) {
+                if ($p -and (Test-Path $p)) { $pwshPath = $p; break }
+            }
+        }
+        if (-not $pwshPath) {
+            FailOut 'PowerShell 7 install completed but pwsh.exe still not found. Restart your shell + re-run this script.'
+        }
+        OK "Installed: $pwshPath"
+    }
+    Step "Re-launching under PowerShell 7 ($pwshPath)..."
+    $relaunchArgs = @('-NoProfile', '-File', $PSCommandPath)
+    if ($Mnemonic) { $relaunchArgs += @('-Mnemonic', $Mnemonic) }
+    & $pwshPath @relaunchArgs
+    exit $LASTEXITCODE
+}
+
 # 1. install if not present
 $airc = Get-Command airc -ErrorAction SilentlyContinue
 if (-not $airc) {

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,19 @@ detect_pkgmgr() {
       if command -v pacman  >/dev/null 2>&1; then echo "pacman"; return; fi
       if command -v apk     >/dev/null 2>&1; then echo "apk";    return; fi
       ;;
+    MINGW*|MSYS*|CYGWIN*|MINGW64*)
+      # Windows Git Bash / MSYS2 / Cygwin. winget is the standard
+      # package manager on modern Windows and what install.ps1 uses;
+      # it's reachable from Git Bash as winget.exe via PATH or as
+      # `cmd /c winget`. If winget isn't there (older Win10), fall
+      # through to the unknown branch which emits the manual prereq
+      # list. Issue #83 follow-up: pre-fix, install.sh on Git Bash
+      # said "Unknown package manager (uname=MINGW64_NT-10.0-26200)"
+      # and skipped prereq install entirely.
+      if command -v winget.exe >/dev/null 2>&1 || command -v winget >/dev/null 2>&1; then
+        echo "winget"; return
+      fi
+      ;;
   esac
   echo "unknown"
 }
@@ -61,11 +74,28 @@ pkgname_for() {
         dnf)    echo "openssh-clients" ;;
         pacman) echo "openssh" ;;
         apk)    echo "openssh-client" ;;
+        winget) echo "" ;;  # OpenSSH ships with modern Windows; nothing to install
+      esac ;;
+    openssl)
+      case "$mgr" in
+        winget) echo "" ;;  # bundled with Git for Windows; if Git is installed, openssl is there
+        *)      echo "openssl" ;;
       esac ;;
     python3)
       case "$mgr" in
         pacman) echo "python" ;;
+        winget) echo "Python.Python.3.12" ;;
         *)      echo "python3" ;;
+      esac ;;
+    git)
+      case "$mgr" in
+        winget) echo "Git.Git" ;;
+        *)      echo "git" ;;
+      esac ;;
+    gh)
+      case "$mgr" in
+        winget) echo "GitHub.cli" ;;
+        *)      echo "gh" ;;
       esac ;;
     *) echo "$prereq" ;;
   esac
@@ -81,6 +111,18 @@ install_with_pkgmgr() {
     dnf)    sudo dnf install -y "${pkgs[@]}" ;;
     pacman) sudo pacman -S --noconfirm --needed "${pkgs[@]}" ;;
     apk)    sudo apk add --no-cache "${pkgs[@]}" ;;
+    winget)
+      # winget on Git Bash: install one ID at a time, --accept-* flags so
+      # it doesn't prompt during the script. winget.exe is the binary;
+      # plain `winget` works if PATHEXT is honored.
+      local wbin; wbin=$(command -v winget.exe 2>/dev/null || command -v winget 2>/dev/null || true)
+      [ -z "$wbin" ] && return 1
+      local pkg
+      for pkg in "${pkgs[@]}"; do
+        [ -z "$pkg" ] && continue
+        "$wbin" install --id "$pkg" --silent --accept-source-agreements --accept-package-agreements 2>&1 \
+          || warn "winget install $pkg returned non-zero (may already be installed; continuing)"
+      done ;;
     *)      return 1 ;;
   esac
 }


### PR DESCRIPTION
## Summary

Four fixes folded into one PR — all about Windows-on-canary cleanliness Joel + Toby hit while dogfooding the new bootstrap path. All four close existing issues.

## #83 — Stale-pairing detect on resume

Joiner-side now caches `room_gist_id` after pair-via-gist-discovery. On resume, before SSH probe, check if that gist still exists on the user's gh. If gone (host parted, or peer self-healed and replaced it), wipe stale joiner state and re-exec into `airc connect` (re-resolves via room name OR falls through to host-mode for first-back-in-becomes-host). Bash + ps1 in lockstep.

## install.sh Git-Bash / winget support (dogfood)

Joel hit `Unknown package manager (uname=MINGW64_NT-10.0-26200)` running `airc update` from Git Bash. Added `MINGW*/MSYS*/CYGWIN*` → `winget` detection in `detect_pkgmgr`, prereq mappings to winget IDs (`Git.Git`, `GitHub.cli`, `Python.Python.3.12`), and `install_with_pkgmgr` winget case with `--silent --accept-{source,package}-agreements`.

## #90 — `doctor --connect` gist scope regex

Bash regex used `[^\\n]*` (\"not backslash or n\") which is wrong. PS regex anchored on `^\s*` which doesn't match modern gh output's `- Token scopes:` leading dash. Both simplified to case-insensitive `(token )?scopes:.*gist` anywhere on a line. Verified against actual gh output.

## #91 — bootstrap re-launches under pwsh

`airc.ps1` requires PS 7+. Default Windows shell is PS 5.1. Bootstrap previously failed at first `& airc` call. Now detects `$PSVersionTable.PSVersion.Major -lt 7` at script start, finds pwsh.exe (or winget-installs it), re-launches itself under pwsh with the same args.

## Test plan

- [x] 133/133 integration tests pass
- [x] Bash + ps1 syntax checks
- [x] Verified gh-scope regex against actual `gh auth status` output on this Mac
- [x] Stale-pairing logic verified on bash side via local sim
- [ ] Live Windows verify (Toby has AWS Win Server 2022 VM with Claude Code installed, ready to test on his side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)