### PR TITLE
fix: 5 Copilot follow-ups on #92 (stale-pairing edge cases + winget pkg gaps)

### DIFF
--- a/airc
+++ b/airc
@@ -1303,31 +1303,53 @@ cmd_connect() {
       # Catch this BEFORE SSH probe so we self-heal cleanly instead of
       # silently re-pairing against a dead-but-reachable host or
       # accidentally landing in a different room.
+      #
+      # Two safety guards (Copilot caught both on PR #92 review):
+      # (a) Confirm gh is healthy first. Auth issues, missing scope,
+      #     rate limits, transient network all return non-zero from
+      #     `gh api gists/<id>` — treating those as "gist deleted"
+      #     would spuriously wipe joiner state on every flaky network
+      #     blip. Only act when we got an authoritative 404.
+      # (b) Capture the preserved name BEFORE deleting CONFIG; otherwise
+      #     get_name reads the now-deleted file and falls back to
+      #     "unknown", changing peer identity on re-exec.
       local _saved_gist_id=""
       [ -f "$AIRC_WRITE_DIR/room_gist_id" ] && _saved_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null)
       local _saved_room_resume=""
       [ -f "$AIRC_WRITE_DIR/room_name" ] && _saved_room_resume=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null)
       if [ -n "$_saved_gist_id" ] && command -v gh >/dev/null 2>&1; then
-        if ! gh api "gists/$_saved_gist_id" >/dev/null 2>&1; then
-          # Gist gone (host parted, or peer self-healed and replaced it).
-          # Trigger fresh discovery: clear the stale joiner state and
-          # re-exec ourselves into airc connect, which will re-resolve
-          # via the room name (or fall through to host-mode if no room
-          # gist exists — first-back-in-becomes-new-host).
-          echo ""
-          echo "  ⚠  Saved room gist ($_saved_gist_id) no longer on your gh — room dissolved or rehosted."
-          if [ -n "$_saved_room_resume" ]; then
-            echo "  Re-discovering #${_saved_room_resume} via fresh gist lookup..."
-          else
-            echo "  Re-pairing via fresh discovery..."
-          fi
-          # Wipe stale joiner state. Identity + peer records persist.
-          rm -f "$CONFIG" "$AIRC_WRITE_DIR/room_gist_id"
-          local _preserved_name; _preserved_name=$(get_name 2>/dev/null || echo "")
-          if [ -n "$_saved_room_resume" ]; then
-            exec env ${_preserved_name:+AIRC_NAME="$_preserved_name"} "$0" connect --room "$_saved_room_resume"
-          else
-            exec env ${_preserved_name:+AIRC_NAME="$_preserved_name"} "$0" connect
+        # Guard: only proceed if gh auth is healthy. If not, skip the
+        # check entirely — the regular SSH probe below handles network/
+        # auth issues with their own diagnosis. We never want a flaky
+        # network to be misread as "the host's gist disappeared."
+        if gh auth status >/dev/null 2>&1; then
+          # Probe with --silent so gh's own error text doesn't pollute
+          # our output. Capture stderr for 404-vs-other classification.
+          local _gist_probe_err; _gist_probe_err=$(mktemp -t airc-gist-probe.XXXXXX)
+          gh api "gists/$_saved_gist_id" >/dev/null 2>"$_gist_probe_err"
+          local _gist_probe_rc=$?
+          local _gist_probe_stderr; _gist_probe_stderr=$(cat "$_gist_probe_err" 2>/dev/null)
+          rm -f "$_gist_probe_err"
+          # 404 (gist gone) shows as "Not Found" or "404" in gh's stderr.
+          # Other failures (rate limit "API rate limit", auth "401",
+          # network "could not resolve") are explicitly NOT treated as
+          # gist-deleted.
+          if [ "$_gist_probe_rc" -ne 0 ] && echo "$_gist_probe_stderr" | grep -qiE '404|not found'; then
+            local _preserved_name; _preserved_name=$(get_name 2>/dev/null || echo "")
+            echo ""
+            echo "  ⚠  Saved room gist ($_saved_gist_id) no longer on your gh — room dissolved or rehosted."
+            if [ -n "$_saved_room_resume" ]; then
+              echo "  Re-discovering #${_saved_room_resume} via fresh gist lookup..."
+            else
+              echo "  Re-pairing via fresh discovery..."
+            fi
+            # Wipe stale joiner state. Identity + peer records persist.
+            rm -f "$CONFIG" "$AIRC_WRITE_DIR/room_gist_id"
+            if [ -n "$_saved_room_resume" ]; then
+              exec env ${_preserved_name:+AIRC_NAME="$_preserved_name"} "$0" connect --room "$_saved_room_resume"
+            else
+              exec env ${_preserved_name:+AIRC_NAME="$_preserved_name"} "$0" connect
+            fi
           fi
         fi
       fi
@@ -3145,7 +3167,12 @@ cmd_part() {
   else
     # ── Joiner path ──
     echo "  Joiner of #${room_name} parting — host's gist stays open for others."
-    rm -f "$room_name_file"
+    # Clear our cached gist_id too, matching the comment on the joiner-
+    # side cache write site (PR #92 Copilot feedback). Without this, a
+    # parted joiner that later reconnects via the same scope would
+    # incorrectly trigger the stale-pairing-detect path on the next
+    # resume even though they parted intentionally.
+    rm -f "$room_name_file" "$gist_id_file"
   fi
 
   cmd_teardown

--- a/airc
+++ b/airc
@@ -1318,13 +1318,22 @@ cmd_connect() {
       local _saved_room_resume=""
       [ -f "$AIRC_WRITE_DIR/room_name" ] && _saved_room_resume=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null)
       if [ -n "$_saved_gist_id" ] && command -v gh >/dev/null 2>&1; then
-        # Guard: only proceed if gh auth is healthy. If not, skip the
-        # check entirely — the regular SSH probe below handles network/
-        # auth issues with their own diagnosis. We never want a flaky
-        # network to be misread as "the host's gist disappeared."
-        if gh auth status >/dev/null 2>&1; then
-          # Probe with --silent so gh's own error text doesn't pollute
-          # our output. Capture stderr for 404-vs-other classification.
+        # Two-step gh-health gate. Both required before treating any 404
+        # as authoritative gist-deletion (else a scope-less token's auth
+        # error gets mis-classified):
+        #   (a) gh auth status passes (token is valid)
+        #   (b) gh has gist scope (matching the doctor --connect chain)
+        # Without (b), gist API calls return 401/403/404 depending on
+        # token state — could spuriously trigger teardown.
+        local _gh_healthy=0
+        if gh auth status >/dev/null 2>&1 \
+           && gh auth status 2>&1 | grep -qiE '(scopes|token scopes):.*\bgist\b'; then
+          _gh_healthy=1
+        fi
+        if [ "$_gh_healthy" = "1" ]; then
+          # Capture stderr for 404-vs-other classification. stdout is
+          # redirected to /dev/null so gh's normal output doesn't pollute
+          # our terminal regardless of outcome.
           local _gist_probe_err; _gist_probe_err=$(mktemp -t airc-gist-probe.XXXXXX)
           gh api "gists/$_saved_gist_id" >/dev/null 2>"$_gist_probe_err"
           local _gist_probe_rc=$?

--- a/airc.ps1
+++ b/airc.ps1
@@ -1529,7 +1529,11 @@ function Invoke-Part {
         Remove-Item $gistIdFile, $roomFile -Force -ErrorAction SilentlyContinue
     } else {
         Write-Host "  Joiner of #$roomName parting - host gist stays open for others."
-        Remove-Item $roomFile -Force -ErrorAction SilentlyContinue
+        # Clear cached gist_id too, matching #83's joiner-side cache
+        # write-site comment (Copilot caught this on PR #92 review).
+        # Without this, a parted joiner reconnecting in the same scope
+        # would spuriously trigger stale-pairing detect on next resume.
+        Remove-Item $roomFile, $gistIdFile -Force -ErrorAction SilentlyContinue
     }
     Invoke-Teardown
 }
@@ -2132,33 +2136,50 @@ function Invoke-Connect {
             # dissolved or got rehosted. Catch BEFORE SSH probe so we
             # self-heal cleanly instead of silently re-pairing against
             # a dead-but-reachable host or the wrong room.
+            #
+            # Two safety guards (Copilot caught both on PR #92 review):
+            # (a) Only trigger on authoritative 404. Auth/scope/rate-
+            #     limit/network issues all return non-zero from
+            #     `gh api gists/<id>` -- misreading those as "gist
+            #     deleted" would spuriously wipe joiner state on every
+            #     flaky network blip.
+            # (b) Capture preservedName BEFORE removing CONFIG; otherwise
+            #     Get-Name reads the deleted file and falls back to
+            #     "unknown", changing peer identity on re-exec.
             $savedGistFile = Join-Path $AIRC_WRITE_DIR 'room_gist_id'
             $savedRoomFile = Join-Path $AIRC_WRITE_DIR 'room_name'
             if ((Test-Path $savedGistFile) -and (Get-Command gh -ErrorAction SilentlyContinue)) {
                 $savedGistId = (Get-Content $savedGistFile -Raw -ErrorAction SilentlyContinue).Trim()
                 if ($savedGistId) {
-                    & gh api "gists/$savedGistId" 2>$null | Out-Null
-                    if ($LASTEXITCODE -ne 0) {
-                        $savedRoom = ''
-                        if (Test-Path $savedRoomFile) {
-                            $savedRoom = (Get-Content $savedRoomFile -Raw -ErrorAction SilentlyContinue).Trim()
+                    & gh auth status 2>$null | Out-Null
+                    if ($LASTEXITCODE -eq 0) {
+                        # Capture stderr to distinguish 404 from other failures.
+                        $probeErrFile = [System.IO.Path]::GetTempFileName()
+                        & gh api "gists/$savedGistId" 1>$null 2>$probeErrFile
+                        $probeRc = $LASTEXITCODE
+                        $probeErrText = (Get-Content $probeErrFile -Raw -ErrorAction SilentlyContinue) -as [string]
+                        Remove-Item $probeErrFile -Force -ErrorAction SilentlyContinue
+                        if ($probeRc -ne 0 -and $probeErrText -match '(?i)\b(404|not found)\b') {
+                            $preservedName = Get-Name 2>$null
+                            $savedRoom = ''
+                            if (Test-Path $savedRoomFile) {
+                                $savedRoom = (Get-Content $savedRoomFile -Raw -ErrorAction SilentlyContinue).Trim()
+                            }
+                            Write-Host ''
+                            Write-Host "  ! Saved room gist ($savedGistId) no longer on your gh -- room dissolved or rehosted."
+                            if ($savedRoom) {
+                                Write-Host "  Re-discovering #$savedRoom via fresh gist lookup..."
+                            } else {
+                                Write-Host '  Re-pairing via fresh discovery...'
+                            }
+                            Remove-Item -Force $CONFIG -ErrorAction SilentlyContinue
+                            Remove-Item -Force $savedGistFile -ErrorAction SilentlyContinue
+                            $reExecArgs = @('connect')
+                            if ($savedRoom) { $reExecArgs += @('--room', $savedRoom) }
+                            if ($preservedName) { $env:AIRC_NAME = $preservedName }
+                            & $PSCommandPath @reExecArgs
+                            exit $LASTEXITCODE
                         }
-                        Write-Host ''
-                        Write-Host "  ! Saved room gist ($savedGistId) no longer on your gh -- room dissolved or rehosted."
-                        if ($savedRoom) {
-                            Write-Host "  Re-discovering #$savedRoom via fresh gist lookup..."
-                        } else {
-                            Write-Host '  Re-pairing via fresh discovery...'
-                        }
-                        # Wipe stale joiner state (identity + peers persist).
-                        Remove-Item -Force $CONFIG -ErrorAction SilentlyContinue
-                        Remove-Item -Force $savedGistFile -ErrorAction SilentlyContinue
-                        $preservedName = Get-Name 2>$null
-                        $reExecArgs = @('connect')
-                        if ($savedRoom) { $reExecArgs += @('--room', $savedRoom) }
-                        if ($preservedName) { $env:AIRC_NAME = $preservedName }
-                        & $PSCommandPath @reExecArgs
-                        exit $LASTEXITCODE
                     }
                 }
             }

--- a/airc.ps1
+++ b/airc.ps1
@@ -2151,8 +2151,18 @@ function Invoke-Connect {
             if ((Test-Path $savedGistFile) -and (Get-Command gh -ErrorAction SilentlyContinue)) {
                 $savedGistId = (Get-Content $savedGistFile -Raw -ErrorAction SilentlyContinue).Trim()
                 if ($savedGistId) {
+                    # Two-step gh-health gate (matching bash + doctor --connect):
+                    # auth must pass AND gist scope must be present. Without
+                    # both, gh api errors get mis-classified.
+                    $ghHealthy = $false
                     & gh auth status 2>$null | Out-Null
                     if ($LASTEXITCODE -eq 0) {
+                        $authStatus = & gh auth status 2>&1 | Out-String
+                        if ($authStatus -match '(?i)(?:Token scopes|scopes):.*\bgist\b') {
+                            $ghHealthy = $true
+                        }
+                    }
+                    if ($ghHealthy) {
                         # Capture stderr to distinguish 404 from other failures.
                         $probeErrFile = [System.IO.Path]::GetTempFileName()
                         & gh api "gists/$savedGistId" 1>$null 2>$probeErrFile

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ detect_pkgmgr() {
       if command -v pacman  >/dev/null 2>&1; then echo "pacman"; return; fi
       if command -v apk     >/dev/null 2>&1; then echo "apk";    return; fi
       ;;
-    MINGW*|MSYS*|CYGWIN*|MINGW64*)
+    MINGW*|MSYS*|CYGWIN*)
       # Windows Git Bash / MSYS2 / Cygwin. winget is the standard
       # package manager on modern Windows and what install.ps1 uses;
       # it's reachable from Git Bash as winget.exe via PATH or as
@@ -165,19 +165,38 @@ ensure_prereqs() {
     return 0
   fi
 
-  local missing=() pkgs=()
+  local missing=() pkgs=() unmappable=()
   for cmd in git gh openssl ssh-keygen python3; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
       missing+=("$cmd")
-      pkgs+=("$(pkgname_for "$mgr" "$cmd")")
+      local pkg; pkg=$(pkgname_for "$mgr" "$cmd")
+      if [ -z "$pkg" ]; then
+        # Manager has no auto-install path for this prereq (e.g., winget
+        # treats ssh + openssl as bundled-with-Windows / Git-for-Windows
+        # but the user hits this case if those bundles are absent).
+        # Surface clearly instead of silently skipping (#92 Copilot).
+        unmappable+=("$cmd")
+      else
+        pkgs+=("$pkg")
+      fi
     fi
   done
   if [ ${#missing[@]} -gt 0 ]; then
     info "Installing missing prereqs via $mgr: ${missing[*]}"
-    if install_with_pkgmgr "$mgr" "${pkgs[@]}"; then
-      ok "Prereqs installed"
-    else
-      warn "Package install reported failure; airc may not run until you fix: ${missing[*]}"
+    if [ ${#pkgs[@]} -gt 0 ]; then
+      if install_with_pkgmgr "$mgr" "${pkgs[@]}"; then
+        ok "Auto-installable prereqs installed"
+      else
+        warn "Package install reported failure; airc may not run until you fix: ${missing[*]}"
+      fi
+    fi
+    if [ ${#unmappable[@]} -gt 0 ]; then
+      warn "These prereqs aren't auto-installable on $mgr: ${unmappable[*]}"
+      case "$mgr" in
+        winget)
+          warn "  ssh / ssh-keygen: Settings -> Apps -> Optional Features -> Add OpenSSH Client"
+          warn "  openssl: bundled with Git for Windows -- 'winget install Git.Git' will provide it" ;;
+      esac
     fi
   else
     ok "All required prereqs present"

--- a/install.sh
+++ b/install.sh
@@ -182,20 +182,22 @@ ensure_prereqs() {
     fi
   done
   if [ ${#missing[@]} -gt 0 ]; then
-    info "Installing missing prereqs via $mgr: ${missing[*]}"
     if [ ${#pkgs[@]} -gt 0 ]; then
+      info "Installing missing prereqs via $mgr: ${pkgs[*]}"
       if install_with_pkgmgr "$mgr" "${pkgs[@]}"; then
         ok "Auto-installable prereqs installed"
       else
         warn "Package install reported failure; airc may not run until you fix: ${missing[*]}"
       fi
+    else
+      warn "Missing prereqs not auto-installable on $mgr: ${missing[*]}"
     fi
     if [ ${#unmappable[@]} -gt 0 ]; then
-      warn "These prereqs aren't auto-installable on $mgr: ${unmappable[*]}"
+      warn "These prereqs need manual install on $mgr: ${unmappable[*]}"
       case "$mgr" in
         winget)
           warn "  ssh / ssh-keygen: Settings -> Apps -> Optional Features -> Add OpenSSH Client"
-          warn "  openssl: bundled with Git for Windows -- 'winget install Git.Git' will provide it" ;;
+          warn "  openssl: bundled with Git for Windows -- 'winget install Git.Git' provides it" ;;
       esac
     fi
   else


### PR DESCRIPTION
## Summary

Five issues Copilot caught on PR #92's post-merge review. Two are HIGH — preserved-name was always \"unknown\" because we deleted CONFIG before reading it, and stale-pairing-detect would falsely trigger on any non-404 gh failure (rate limits, network, auth). Three are smaller hygiene wins.

| # | Sev | What | Where |
|---|---|---|---|
| 1 | HIGH | `gh api` non-zero treated as gist-deleted; auth/rate-limit/network produced spurious teardown loops | bash + ps1 |
| 2 | HIGH | `preserved_name` read after `rm CONFIG` so always \"unknown\" — identity lost on stale-gist re-exec | bash + ps1 |
| 3 | MED | comment claimed `cmd_part` clears `room_gist_id` but joiner-side didn't | bash + ps1 |
| 4 | LOW | redundant `MINGW64*` in pkgmgr case-arm (already matched by `MINGW*`) | install.sh |
| 5 | MED | winget empty-pkgname silently skipped ssh/openssl, leaving user with \"installed\" + broken state | install.sh |

## Fix shapes

**#1**: Gate stale-pairing detect on `gh auth status` succeeding first, then capture stderr from `gh api` and only treat actual `404 / Not Found` as gist-deleted. Other failures fall through to the regular SSH probe path.

**#2**: Capture `preservedName` BEFORE removing CONFIG. Otherwise `get_name` reads the deleted file and falls back to a no-op default.

**#3**: Joiner's `cmd_part` / `Invoke-Part` now removes `room_gist_id` alongside `room_name`. Otherwise a parted-then-rejoined joiner would trigger stale-pairing detect spuriously on the next resume.

**#4**: dropped redundant pattern.

**#5**: Track unmappable prereqs separately; surface with platform-specific install guidance instead of \"all installed!\" + silent broken state.

## Test plan

- [x] 133/133 integration tests pass
- [x] Bash + ps1 syntax checks
- [ ] Live verify on Toby's AWS Windows Server 2022 VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)