### PR TITLE
feat: heartbeat-in-gist for deterministic dead-host detection

### DIFF
--- a/airc
+++ b/airc
@@ -1144,6 +1144,12 @@ cmd_connect() {
   # (sleep/crash/network), the joiner deletes the stale gist and re-execs
   # itself in host mode — first-agent-back-in becomes the new host.
   local _resolved_gist_id=""
+  # Heartbeat freshness vars - parsed by gist resolver in the room
+  # case-arm. Must be defaulted here so the JOIN MODE early-takeover
+  # check (which runs unconditionally if a target has '@') doesn't trip
+  # 'unbound variable' when target came in inline (no gist resolved).
+  local _resolved_heartbeat_stale=0
+  local _resolved_heartbeat_age=""
   local positional=()
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -1655,6 +1661,9 @@ cmd_connect() {
       # Try parse as airc JSON envelope first. If it parses + has airc
       # field, dispatch on `kind`. Otherwise, treat raw_content as the
       # legacy raw-invite-string format (backward compat).
+      # _resolved_heartbeat_stale + _resolved_heartbeat_age are declared
+      # at function-scope above so the JOIN MODE check sees them on the
+      # inline-invite path too (where this gist block doesn't run).
       local resolved=""
       if command -v jq >/dev/null 2>&1; then
         local airc_ver kind
@@ -1677,6 +1686,36 @@ cmd_connect() {
               resolved=$(printf '%s' "$raw_content" | jq -r '.invite // empty' 2>/dev/null \
                          | head -1 | tr -d '\r\n ')
               resolved_room_name=$(printf '%s' "$raw_content" | jq -r '.name // empty' 2>/dev/null)
+
+              # Heartbeat freshness check — the structural fix for
+              # orphan-gist class. Hosts update last_heartbeat every
+              # AIRC_HEARTBEAT_SEC (default 30s); if it's older than
+              # AIRC_HEARTBEAT_STALE (default 90s = 3 missed beats),
+              # the host is dead. We short-circuit the SSH attempt and
+              # take over directly — no minute-long timeout, no peer
+              # confusion about "is this thing on?". Pre-heartbeat
+              # gists (no field) are treated as fresh for backward
+              # compat; their hosts will get caught by the existing
+              # SSH-failure self-heal path at line ~1850.
+              local _hb_iso _hb_ts _now_ts _hb_stale_sec
+              _hb_iso=$(printf '%s' "$raw_content" | jq -r '.last_heartbeat // empty' 2>/dev/null)
+              _hb_stale_sec="${AIRC_HEARTBEAT_STALE:-90}"
+              if [ -n "$_hb_iso" ]; then
+                # Convert ISO-8601 UTC to epoch. GNU date and BSD date
+                # have incompatible flags; try GNU first (linux + git-bash),
+                # fall back to BSD (mac default). If both fail (busybox?),
+                # skip the check rather than mis-classify.
+                _hb_ts=$(date -u -d "$_hb_iso" +%s 2>/dev/null \
+                         || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$_hb_iso" +%s 2>/dev/null \
+                         || echo "")
+                if [ -n "$_hb_ts" ]; then
+                  _now_ts=$(date -u +%s)
+                  _resolved_heartbeat_age=$(( _now_ts - _hb_ts ))
+                  if [ "$_resolved_heartbeat_age" -gt "$_hb_stale_sec" ]; then
+                    _resolved_heartbeat_stale=1
+                  fi
+                fi
+              fi
               ;;
             "")
               die "Gist has airc envelope (v$airc_ver) but no 'kind' field — malformed."
@@ -1704,6 +1743,44 @@ cmd_connect() {
 
   if [ -n "$target" ] && echo "$target" | grep -q '@'; then
     # ── JOIN MODE ──────────────────────────────────────────────────
+
+    # Stale-heartbeat fast-path takeover. If the gist we resolved had a
+    # last_heartbeat older than AIRC_HEARTBEAT_STALE (parsed above), the
+    # host is dead. Skip the SSH attempt entirely — no minute-long TCP
+    # timeout, no peer wondering "is this thing on" — go straight to
+    # take-over. Same operations as the SSH-failure self-heal at the
+    # bottom of JOIN MODE (delete stale gist, re-exec as host with
+    # AIRC_NO_DISCOVERY=1) but triggered from positive evidence (stale
+    # presence signal) rather than negative evidence (TCP timeout).
+    #
+    # Backward compat: pre-heartbeat gists have no last_heartbeat field,
+    # _resolved_heartbeat_stale stays 0, this block is a no-op, and the
+    # SSH-failure self-heal still catches the dead host (slower, but
+    # correct).
+    if [ "$_resolved_heartbeat_stale" = "1" ] && [ -n "$resolved_room_name" ] \
+       && [ -n "$_resolved_gist_id" ] && command -v gh >/dev/null 2>&1; then
+      echo ""
+      echo "  ⚠  Host of #${resolved_room_name} is stale (last heartbeat ${_resolved_heartbeat_age}s ago) — taking over..."
+      echo "     (prior host's gist: $_resolved_gist_id)"
+      if gh gist delete "$_resolved_gist_id" --yes 2>/dev/null; then
+        echo "  ✓ Stale gist removed."
+      else
+        echo "  ⚠  Couldn't remove stale gist (already gone? not on this gh account?)."
+        echo "     New host will publish a fresh #${resolved_room_name} gist anyway."
+      fi
+      # Preserve identity name across re-exec — same reason as the
+      # SSH-failure self-heal: derive_name re-runs from cwd and can drift
+      # on case-aliasing, peers see a "new" peer.
+      local _preserved_name; _preserved_name=$(get_config_val name "")
+      # Wipe any half-written CONFIG (this path runs before we write,
+      # but be defensive in case a prior failed pair left state behind).
+      rm -f "$CONFIG"
+      rm -f "$AIRC_WRITE_DIR/room_name"
+      echo "  Re-execing into host mode for #${resolved_room_name}..."
+      echo ""
+      exec env AIRC_NO_DISCOVERY=1 ${_preserved_name:+AIRC_NAME="$_preserved_name"} "$0" connect --room "$resolved_room_name"
+    fi
+
     # Parse name@user@host[:port]#pubkey
     local host_ssh_pubkey_b64=""
     if echo "$target" | grep -q '#'; then
@@ -2111,6 +2188,14 @@ json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
           # gist lifecycle + envelope kind differ.
           _gist_kind="room"
           _gist_desc="airc room: ${room_name}"
+          # last_heartbeat field is the host's presence signal. Updated
+          # every AIRC_HEARTBEAT_SEC (default 30s) by a background loop
+          # spawned after gist create. Joiners check freshness on
+          # resolve — stale = host dead, take over deterministically.
+          # Without this, hosts that die ungracefully (machine sleep,
+          # kill -9, OOM, bash-bg-and-die) leave their gist pointing
+          # at a corpse forever — every today's mess was downstream of
+          # this. Issue: structural fix for #79 + #83.
           _gist_payload=$(cat <<JSON
 {
   "airc": 1,
@@ -2125,7 +2210,8 @@ json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
     "port": $host_port
   },
   "created": "$_now",
-  "updated": "$_now"
+  "updated": "$_now",
+  "last_heartbeat": "$_now"
 }
 JSON
 )
@@ -2166,6 +2252,82 @@ JSON
           if [ "$_gist_kind" = "room" ]; then
             echo "$_gist_id" > "$AIRC_WRITE_DIR/room_gist_id"
             echo "$room_name" > "$AIRC_WRITE_DIR/room_name"
+
+            # Heartbeat loop: keep last_heartbeat fresh in the gist so
+            # joiners can deterministically detect a dead host. Without
+            # this, a host that dies ungracefully (sleep, kill -9, OOM,
+            # crashed bash) leaves a gist pointing at a corpse forever.
+            # Every messy state cascade today (memento, my own
+            # bash-bg-and-die orphan, the manual gist-delete I had to
+            # run by hand) traces to this missing presence signal.
+            #
+            # Loop runs every AIRC_HEARTBEAT_SEC (default 30s) and dies
+            # automatically when its parent (the host airc connect bash)
+            # exits — so kill -9 on the host stops heartbeats within one
+            # interval. Joiners treat last_heartbeat older than
+            # AIRC_HEARTBEAT_STALE (default 90s = 3 missed beats) as
+            # stale and self-heal as new host.
+            local _heartbeat_sec="${AIRC_HEARTBEAT_SEC:-30}"
+            local _hb_parent_pid=$$
+            local _hb_invite="$_invite_long"
+            local _hb_name="$name"
+            local _hb_user="$user"
+            local _hb_host="$host"
+            local _hb_port="$host_port"
+            local _hb_room="$room_name"
+            local _hb_created="$_now"
+            (
+              # Detach from job control so a parent SIGINT kills the
+              # whole tree but normal exit lets us race the trap to
+              # delete the gist first.
+              while sleep "$_heartbeat_sec"; do
+                # Parent died (PID gone) → exit. This is the kill -9
+                # / OOM / sleep recovery path.
+                if ! kill -0 "$_hb_parent_pid" 2>/dev/null; then
+                  exit 0
+                fi
+                local _hb_now; _hb_now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                local _hb_payload; _hb_payload=$(cat <<JSON
+{
+  "airc": 1,
+  "kind": "room",
+  "name": "${_hb_room}",
+  "topic": "",
+  "invite": "${_hb_invite}",
+  "host": {
+    "name": "${_hb_name}",
+    "user": "${_hb_user}",
+    "address": "${_hb_host}",
+    "port": ${_hb_port}
+  },
+  "created": "${_hb_created}",
+  "updated": "${_hb_now}",
+  "last_heartbeat": "${_hb_now}"
+}
+JSON
+)
+                local _hb_tmp; _hb_tmp=$(mktemp -t airc-hb.XXXXXX)
+                printf '%s\n' "$_hb_payload" > "$_hb_tmp"
+                gh gist edit "$_gist_id" "$_hb_tmp" >/dev/null 2>&1 || true
+                rm -f "$_hb_tmp"
+              done
+            ) &
+            local _hb_pid=$!
+            # Track the heartbeat-loop PID so cmd_teardown can kill it
+            # cleanly. Also written to the airc.pid line so teardown's
+            # tree-walk picks it up.
+            echo "$_hb_pid" >> "$AIRC_WRITE_DIR/airc.pid"
+
+            # Graceful-exit trap: on EXIT/SIGINT/SIGTERM, kill the
+            # heartbeat + delete the gist. Doesn't help kill -9 (which
+            # is exactly what the heartbeat itself is the answer for),
+            # but covers Ctrl-C and normal teardown — gist gets cleaned
+            # up so peers don't even hit the stale window.
+            trap "
+              kill $_hb_pid 2>/dev/null
+              gh gist delete '$_gist_id' --yes >/dev/null 2>&1
+            " EXIT INT TERM
+
             echo "  Hosting #${room_name} (gh-account substrate)."
             echo "  Other agents on your gh account auto-join via:  airc connect"
             echo "  Cross-account share (rare):"

--- a/airc.ps1
+++ b/airc.ps1
@@ -2276,12 +2276,37 @@ function Invoke-Connect {
                 Die "Failed to fetch gist '$gistId'. Check the ID, network, and (if private) 'gh auth login'."
             }
             $resolved = $null
+            $resolvedHeartbeatStale = $false
+            $resolvedHeartbeatAge = 0
             try {
                 $env = $rawContent | ConvertFrom-Json
                 if ($env.airc) {
                     switch ($env.kind) {
                         'invite' { $resolved = $env.invite }
-                        'room'   { $resolved = $env.invite; $resolvedRoomName = $env.name }
+                        'room'   {
+                            $resolved = $env.invite
+                            $resolvedRoomName = $env.name
+                            # Heartbeat freshness check - structural fix for
+                            # orphan-gist class. Hosts update last_heartbeat
+                            # every AIRC_HEARTBEAT_SEC; older than
+                            # AIRC_HEARTBEAT_STALE = host dead, take over.
+                            # Pre-heartbeat gists (no field) treated as fresh
+                            # for backward compat - SSH-failure self-heal
+                            # still catches them.
+                            $hbStaleSec = 90
+                            if ($env:AIRC_HEARTBEAT_STALE) {
+                                try { $hbStaleSec = [int]$env:AIRC_HEARTBEAT_STALE } catch {}
+                            }
+                            if ($env.last_heartbeat) {
+                                try {
+                                    $hbDt = [DateTime]::Parse($env.last_heartbeat, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal)
+                                    $resolvedHeartbeatAge = [int]((Get-Date).ToUniversalTime() - $hbDt).TotalSeconds
+                                    if ($resolvedHeartbeatAge -gt $hbStaleSec) {
+                                        $resolvedHeartbeatStale = $true
+                                    }
+                                } catch {}
+                            }
+                        }
                         default  { Die "Gist uses unknown kind '$($env.kind)' - this airc may need 'airc update'." }
                     }
                 }
@@ -2300,6 +2325,29 @@ function Invoke-Connect {
 
     if ($target -and ($target -match '@')) {
         # -- JOIN MODE --
+
+        # Stale-heartbeat fast-path takeover. If the gist we resolved had a
+        # last_heartbeat older than AIRC_HEARTBEAT_STALE, the host is dead.
+        # Skip the SSH attempt entirely - go straight to take-over. Same
+        # operations as the SSH-failure self-heal path below, but triggered
+        # from positive evidence (stale presence signal) rather than
+        # negative evidence (TCP timeout).
+        if ($resolvedHeartbeatStale -and $resolvedRoomName -and $resolvedGistId -and (Test-GhAvailable)) {
+            Write-Host ''
+            Write-Host "  ! Host of #$resolvedRoomName is stale (last heartbeat ${resolvedHeartbeatAge}s ago) - taking over..."
+            Write-Host "     (prior host gist: $resolvedGistId)"
+            & gh gist delete $resolvedGistId --yes 2>$null | Out-Null
+            $preservedName = Get-ConfigVal -Key 'name' -Default ''
+            Remove-Item -Path $CONFIG -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path (Join-Path $AIRC_WRITE_DIR 'room_name') -Force -ErrorAction SilentlyContinue
+            Write-Host "  Re-launching into host mode for #$resolvedRoomName ..."
+            Write-Host ''
+            $env:AIRC_NO_DISCOVERY = '1'
+            if ($preservedName) { $env:AIRC_NAME = $preservedName }
+            Invoke-Connect -Argv @('--room', $resolvedRoomName)
+            return
+        }
+
         $hostSshPubkeyB64 = ''
         if ($target -match '#') {
             $hostSshPubkeyB64 = ($target -split '#')[-1]
@@ -2527,15 +2575,22 @@ function Invoke-Connect {
             } else {
                 $now = Get-Timestamp
                 if ($useRoom) {
+                    # last_heartbeat is the host's presence signal. Updated
+                    # every AIRC_HEARTBEAT_SEC (default 30s) by a background
+                    # job spawned after gist create. Joiners check freshness
+                    # on resolve - stale = host dead, take over deterministically.
+                    # Without this, hosts that die ungracefully (sleep, kill,
+                    # OOM) leave their gist pointing at a corpse forever.
                     $envelope = [ordered]@{
-                        airc    = 1
-                        kind    = 'room'
-                        name    = $roomName
-                        topic   = ''
-                        invite  = $inviteLong
-                        host    = [ordered]@{ name=$name; user=$user; address=$hostA; port=$hostPort }
-                        created = $now
-                        updated = $now
+                        airc           = 1
+                        kind           = 'room'
+                        name           = $roomName
+                        topic          = ''
+                        invite         = $inviteLong
+                        host           = [ordered]@{ name=$name; user=$user; address=$hostA; port=$hostPort }
+                        created        = $now
+                        updated        = $now
+                        last_heartbeat = $now
                     }
                     $gistDesc = "airc room: $roomName"
                 } else {
@@ -2558,6 +2613,70 @@ function Invoke-Connect {
                     $hh = Get-Humanhash -HexInput $gistId
                     if ($useRoom) {
                         Set-Content -Path (Join-Path $AIRC_WRITE_DIR 'room_gist_id') -Value $gistId -NoNewline
+
+                        # Heartbeat job: refresh last_heartbeat in the gist
+                        # every AIRC_HEARTBEAT_SEC seconds so joiners can
+                        # deterministically detect a dead host. Mirrors the
+                        # bash heartbeat loop. Start-ThreadJob runs in-process
+                        # so when this airc connect dies, the thread dies too.
+                        $heartbeatSec = 30
+                        if ($env:AIRC_HEARTBEAT_SEC) {
+                            try { $heartbeatSec = [int]$env:AIRC_HEARTBEAT_SEC } catch {}
+                        }
+                        $hbJob = Start-ThreadJob -ScriptBlock {
+                            param($GistId, $RoomName, $InviteLong, $Name, $User, $HostA, $HostPort, $Created, $IntervalSec)
+                            while ($true) {
+                                Start-Sleep -Seconds $IntervalSec
+                                $hbNow = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+                                $hbEnvelope = [ordered]@{
+                                    airc           = 1
+                                    kind           = 'room'
+                                    name           = $RoomName
+                                    topic          = ''
+                                    invite         = $InviteLong
+                                    host           = [ordered]@{ name=$Name; user=$User; address=$HostA; port=$HostPort }
+                                    created        = $Created
+                                    updated        = $hbNow
+                                    last_heartbeat = $hbNow
+                                }
+                                $hbTmp = [System.IO.Path]::GetTempFileName()
+                                try {
+                                    ($hbEnvelope | ConvertTo-Json -Depth 10) | Set-Content -Path $hbTmp -NoNewline
+                                    & gh gist edit $GistId $hbTmp 2>$null | Out-Null
+                                } catch {
+                                    # Suppress only network/transient errors; surface them as job-output for diagnose.
+                                    Write-Output "heartbeat update failed: $_"
+                                } finally {
+                                    Remove-Item $hbTmp -Force -ErrorAction SilentlyContinue
+                                }
+                            }
+                        } -ArgumentList $gistId, $roomName, $inviteLong, $name, $user, $hostA, $hostPort, $now, $heartbeatSec
+
+                        # Track heartbeat job-id so cmd_part / teardown can
+                        # stop it cleanly. Job is also killed automatically
+                        # when this PowerShell process exits (Start-ThreadJob
+                        # is in-process), which is the kill -9 / OOM path.
+                        Add-Content -Path (Join-Path $AIRC_WRITE_DIR 'airc.pid') -Value $PID
+
+                        # Graceful-exit cleanup: on PowerShell.Exiting, stop
+                        # the heartbeat job + delete the room gist so peers
+                        # don't even hit the stale window. Doesn't help kill -9
+                        # (which is exactly what the heartbeat itself is the
+                        # answer for), but covers Ctrl-C and normal teardown.
+                        # Use globals (not $using:) - the engine event runspace
+                        # captures globals reliably whereas $using: scoping
+                        # in -Action blocks is version-dependent.
+                        $global:_AircCleanupGistId  = $gistId
+                        $global:_AircCleanupHbJobId = $hbJob.Id
+                        Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action {
+                            if ($global:_AircCleanupHbJobId) {
+                                try { Stop-Job -Id $global:_AircCleanupHbJobId -ErrorAction SilentlyContinue } catch {}
+                            }
+                            if ($global:_AircCleanupGistId) {
+                                try { & gh gist delete $global:_AircCleanupGistId --yes 2>$null | Out-Null } catch {}
+                            }
+                        } | Out-Null
+
                         Write-Host "  Hosting #$roomName (gh-account substrate)."
                         Write-Host "  Other agents on your gh account auto-join via:  airc connect"
                         Write-Host "  Cross-account share:"

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:canary
+name: canary
 description: Switch this airc install to the canary channel — pre-merge features queued for the next main release. Use when Joel asks you to test something that hasn't landed on main yet, or when you want the bleeding edge.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:doctor
+name: doctor
 description: Self-diagnose AIRC. AI checks environment health (gh, ssh, ports), runs the integration suite, and proactively fixes recoverable issues (install gh, etc.) instead of just reporting them.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/invite/SKILL.md
+++ b/skills/invite/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:invite
+name: invite
 description: Print the join string for your current mesh so you can paste it to another agent. Works whether you're the host or a joiner.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:join
+name: join
 description: Join AIRC. Default = auto-scope to the room matching the current git repo's owner (e.g. #my-org, #cambriantech); falls back to #general for non-git dirs. Optional arg = mnemonic, gist id, room name, or inline invite.
 user-invocable: true
 allowed-tools: Bash, Monitor

--- a/skills/list/SKILL.md
+++ b/skills/list/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:list
+name: list
 description: List open airc rooms (#channels) and 1:1 invites on your gh account. Use this before /join to see what's already on the substrate.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/logs/SKILL.md
+++ b/skills/logs/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:logs
+name: logs
 description: Show the last N messages in the mesh's shared log (default 20). Human-readable format — timestamp + sender + message.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/msg/SKILL.md
+++ b/skills/msg/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:msg
+name: msg
 description: Send a message to the chat room. No target = everyone. Prefix @peer for a DM.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/nick/SKILL.md
+++ b/skills/nick/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:nick
+name: nick
 description: Rename this airc identity. Broadcasts the change so paired peers auto-update their records.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/part/SKILL.md
+++ b/skills/part/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:part
+name: part
 description: Leave the current room without leaving the mesh. Host parts → room gist deleted, joiners reconnect into a new election. Joiner parts → host's gist stays open for others. Local identity preserved.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/peers/SKILL.md
+++ b/skills/peers/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:peers
+name: peers
 description: List paired peers in this scope. Add --prune to clean stale records (same-host duplicates left over from rename chain-breaks before stable-host matching landed).
 user-invocable: true
 allowed-tools: Bash

--- a/skills/quit/SKILL.md
+++ b/skills/quit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:quit
+name: quit
 description: Leave the current mesh without wiping your identity. Kills the running airc process in this scope and clears only the host-pairing fields from config. Next `airc join` starts fresh instead of auto-resuming.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/reminder/SKILL.md
+++ b/skills/reminder/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:reminder
+name: reminder
 description: Control the silence-reminder nudge. Fires once when no send happens within N seconds; resets on next send.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/repair/SKILL.md
+++ b/skills/repair/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:repair
+name: repair
 description: Full re-pair of a stale airc mesh — `teardown --flush` + reconnect using the saved invite string. Use when your sends silently fail or `resume` reports stale auth.
 user-invocable: true
 allowed-tools: Bash, Monitor

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:resume
+name: resume
 description: Resume a prior airc session in this scope. Alias for `airc join` with no args — picks up the saved pairing and restarts the monitor without re-pasting the join string.
 user-invocable: true
 allowed-tools: Bash, Monitor

--- a/skills/send-file/SKILL.md
+++ b/skills/send-file/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:send-file
+name: send-file
 description: Send a file to a paired peer via AIRC.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/teardown/SKILL.md
+++ b/skills/teardown/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:teardown
+name: teardown
 description: Kill airc processes belonging to THIS scope (this AIRC_HOME), free its port. Scope-aware — never touches other tabs' sessions. Add --flush to also wipe state.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/tests/SKILL.md
+++ b/skills/tests/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:tests
+name: tests
 description: Run the airc integration test suite (alias for airc doctor). Validates pairing, send, rename, room substrate, scope isolation, queue resilience, and more. Use after install or upgrade, or when something feels off.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:update
+name: update
 description: Pull the latest airc code into the install dir. Leaves the running monitor untouched; report the new SHA and tell the user to teardown+connect to pick it up.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/version/SKILL.md
+++ b/skills/version/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: airc:version
+name: version
 description: Print the currently-installed airc version (short git SHA, branch, commit subject, install dir). Use this to verify everyone in a mesh is on the same build.
 user-invocable: true
 allowed-tools: Bash

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -1412,6 +1412,149 @@ scenario_kick() {
   cleanup_all
 }
 
+# ── Scenario: heartbeat (orphan-gist self-heal, structural fix) ───────
+# When a host dies ungracefully, its room gist persists pointing at the
+# corpse. With heartbeat: host updates last_heartbeat every
+# AIRC_HEARTBEAT_SEC; joiners check freshness on resolve and take over
+# deterministically when stale. This test:
+#   1. Hosts a room (real gh, real gist)
+#   2. Verifies last_heartbeat appears in the gist
+#   3. Verifies last_heartbeat advances over time
+#   4. kill -9's the host — heartbeat thread dies with it, gist NOT cleaned
+#   5. Waits past AIRC_HEARTBEAT_STALE
+#   6. Spawns a joiner with discovery enabled
+#   7. Verifies joiner deleted stale gist + published fresh one
+#
+# Skips entirely if gh is unavailable or unauthed — this scenario can't
+# run in gh-less CI. AIRC_HEARTBEAT_SEC=2 / AIRC_HEARTBEAT_STALE=5 keep
+# wall-time short; cleanup deletes any gist this scenario published.
+scenario_heartbeat() {
+  section "heartbeat: orphan-gist self-heal via stale presence signal"
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "  (skipped — gh CLI not installed)"
+    return
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "  (skipped — gh not authed: 'gh auth login -s gist')"
+    return
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  (skipped — jq not installed)"
+    return
+  fi
+
+  cleanup_all
+
+  local rname="hb-test-$$"
+  local hb_sec=2 hb_stale=5
+
+  # ── Host alpha in room mode WITH gh discovery + gist push.
+  mkdir -p /tmp/airc-it-h
+  ( cd /tmp/airc-it-h && AIRC_HOME=/tmp/airc-it-h/state AIRC_NAME=alpha AIRC_PORT=7549 \
+      AIRC_NO_DISCOVERY=1 AIRC_HEARTBEAT_SEC=$hb_sec \
+      "$AIRC" connect --room "$rname" > /tmp/airc-it-h/out.log 2>&1 & )
+
+  local i
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 1
+    [ -f /tmp/airc-it-h/state/room_gist_id ] && break
+  done
+
+  local gist_id
+  gist_id=$(cat /tmp/airc-it-h/state/room_gist_id 2>/dev/null)
+  [ -n "$gist_id" ] \
+    && pass "alpha published room gist ($gist_id)" \
+    || { fail "alpha did not publish a room gist within 10s"; cleanup_all; return; }
+
+  # Verify last_heartbeat field is present in the gist.
+  local hb1
+  hb1=$(gh api "gists/$gist_id" 2>/dev/null \
+        | jq -r '.files | to_entries[0].value.content' 2>/dev/null \
+        | jq -r '.last_heartbeat // empty' 2>/dev/null)
+  [ -n "$hb1" ] \
+    && pass "gist contains last_heartbeat field ($hb1)" \
+    || { fail "gist missing last_heartbeat field"; gh gist delete "$gist_id" --yes 2>/dev/null; cleanup_all; return; }
+
+  # Wait > 1 heartbeat interval, verify the field advanced.
+  sleep $((hb_sec + 2))
+  local hb2
+  hb2=$(gh api "gists/$gist_id" 2>/dev/null \
+        | jq -r '.files | to_entries[0].value.content' 2>/dev/null \
+        | jq -r '.last_heartbeat // empty' 2>/dev/null)
+  if [ -n "$hb2" ] && [ "$hb2" != "$hb1" ]; then
+    pass "last_heartbeat advanced after ${hb_sec}s ($hb2)"
+  else
+    fail "last_heartbeat did NOT advance ($hb1 → $hb2)"
+    gh gist delete "$gist_id" --yes 2>/dev/null
+    cleanup_all; return
+  fi
+
+  # ── kill -9 the host. Heartbeat thread dies with it; gist persists.
+  local host_pids
+  host_pids=$(cat /tmp/airc-it-h/state/airc.pid 2>/dev/null)
+  [ -n "$host_pids" ] || { fail "no host pid recorded"; cleanup_all; return; }
+  kill -9 $host_pids 2>/dev/null || true
+  sleep 1
+  pass "host kill -9'd ($host_pids)"
+
+  # Wait past the stale window. Use the earlier hb2 timestamp as our
+  # "now-ish" anchor — sleep enough that whatever the next gist read
+  # sees has aged past hb_stale. Buffer = 2x stale to be deterministic.
+  sleep $((hb_stale + 3))
+
+  # Verify gist still exists (host died ungracefully, so EXIT trap didn't fire).
+  gh api "gists/$gist_id" >/dev/null 2>&1 \
+    && pass "stale gist still present (host kill -9 = no graceful cleanup)" \
+    || fail "gist already gone — kill -9 path didn't behave as expected"
+
+  # ── Spawn joiner beta with discovery ON. Joiner should:
+  #    - resolve the gist
+  #    - detect last_heartbeat is stale
+  #    - take over: delete stale gist, exec into host mode
+  mkdir -p /tmp/airc-it-j
+  ( cd /tmp/airc-it-j && AIRC_HOME=/tmp/airc-it-j/state AIRC_NAME=beta AIRC_PORT=7550 \
+      AIRC_HEARTBEAT_STALE=$hb_stale AIRC_HEARTBEAT_SEC=$hb_sec \
+      "$AIRC" connect --room "$rname" > /tmp/airc-it-j/out.log 2>&1 & )
+
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 1
+    grep -qE 'taking over|self-healing as new host' /tmp/airc-it-j/out.log 2>/dev/null && break
+  done
+
+  grep -qE 'taking over|self-healing as new host' /tmp/airc-it-j/out.log \
+    && pass "beta detected stale heartbeat + initiated takeover" \
+    || { fail "beta did NOT detect stale heartbeat (log: $(tail -20 /tmp/airc-it-j/out.log))"; cleanup_all; return; }
+
+  # Wait for beta to publish a fresh gist as new host.
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 1
+    [ -f /tmp/airc-it-j/state/room_gist_id ] && break
+  done
+
+  local new_gist_id
+  new_gist_id=$(cat /tmp/airc-it-j/state/room_gist_id 2>/dev/null)
+  if [ -n "$new_gist_id" ] && [ "$new_gist_id" != "$gist_id" ]; then
+    pass "beta published fresh gist as new host ($new_gist_id, replaces $gist_id)"
+  else
+    fail "beta did not publish a fresh gist (got: '$new_gist_id', original: '$gist_id')"
+  fi
+
+  # Old gist must be gone (beta deleted it during takeover).
+  if gh api "gists/$gist_id" >/dev/null 2>&1; then
+    fail "stale gist $gist_id still exists after takeover"
+    gh gist delete "$gist_id" --yes 2>/dev/null
+  else
+    pass "stale gist $gist_id removed by takeover"
+  fi
+
+  # Cleanup: delete the new gist beta published.
+  if [ -n "$new_gist_id" ]; then
+    gh gist delete "$new_gist_id" --yes 2>/dev/null || true
+  fi
+  cleanup_all
+}
+
 case "$MODE" in
   tabs)         scenario_tabs  ;;
   scope)        scenario_scope ;;
@@ -1429,8 +1572,9 @@ case "$MODE" in
   identity)     scenario_identity ;;
   whois)        scenario_whois ;;
   kick)         scenario_kick ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|all]"; exit 2 ;;
+  heartbeat)    scenario_heartbeat ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|heartbeat|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary

Structural fix for the orphan-gist class. Hosts that died ungracefully (sleep, kill -9, OOM, bash-bg-and-die) left their room gist pointing at a corpse forever — every messy state cascade today's session traced to this missing presence signal.

- Room gist now carries `last_heartbeat`; bg loop refreshes every 30s; EXIT/INT/TERM trap (bash) + `Register-EngineEvent PowerShell.Exiting` (ps1) deletes gist on graceful shutdown.
- Joiner parses `last_heartbeat`, computes age (GNU/BSD date fallback), short-circuits SSH attempt + self-heals as new host if older than 90s.
- Skill names: dropped misleading `airc:` prefix from YAML — `/canary` now displays + works consistently (was silently failing as `/airc:canary`).

## Backward compat

- old host + new joiner: no `last_heartbeat` → falls through to existing SSH-failure self-heal.
- new host + old joiner: extra field ignored by old `jq` paths.
- old host + old joiner: untouched.
- new host + new joiner: deterministic takeover.

## Test plan

- [x] `scenario_heartbeat` — kill -9 the host, verify joiner detects stale + takes over (8/8 on real gh)
- [x] `scenario_room` regression check (14/14)
- [ ] Joel's macOS canary tab e2e after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)