### PR TITLE
Revert: restore airc: prefix on skill YAML names

### DIFF
--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: canary
+name: airc:canary
 description: Switch this airc install to the canary channel — pre-merge features queued for the next main release. Use when Joel asks you to test something that hasn't landed on main yet, or when you want the bleeding edge.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: doctor
+name: airc:doctor
 description: Self-diagnose AIRC. AI checks environment health (gh, ssh, ports), runs the integration suite, and proactively fixes recoverable issues (install gh, etc.) instead of just reporting them.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/invite/SKILL.md
+++ b/skills/invite/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: invite
+name: airc:invite
 description: Print the join string for your current mesh so you can paste it to another agent. Works whether you're the host or a joiner.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: join
+name: airc:join
 description: Join AIRC. Default = auto-scope to the room matching the current git repo's owner (e.g. #my-org, #cambriantech); falls back to #general for non-git dirs. Optional arg = mnemonic, gist id, room name, or inline invite.
 user-invocable: true
 allowed-tools: Bash, Monitor

--- a/skills/list/SKILL.md
+++ b/skills/list/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: list
+name: airc:list
 description: List open airc rooms (#channels) and 1:1 invites on your gh account. Use this before /join to see what's already on the substrate.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/logs/SKILL.md
+++ b/skills/logs/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: logs
+name: airc:logs
 description: Show the last N messages in the mesh's shared log (default 20). Human-readable format — timestamp + sender + message.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/msg/SKILL.md
+++ b/skills/msg/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: msg
+name: airc:msg
 description: Send a message to the chat room. No target = everyone. Prefix @peer for a DM.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/nick/SKILL.md
+++ b/skills/nick/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: nick
+name: airc:nick
 description: Rename this airc identity. Broadcasts the change so paired peers auto-update their records.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/part/SKILL.md
+++ b/skills/part/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: part
+name: airc:part
 description: Leave the current room without leaving the mesh. Host parts → room gist deleted, joiners reconnect into a new election. Joiner parts → host's gist stays open for others. Local identity preserved.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/peers/SKILL.md
+++ b/skills/peers/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: peers
+name: airc:peers
 description: List paired peers in this scope. Add --prune to clean stale records (same-host duplicates left over from rename chain-breaks before stable-host matching landed).
 user-invocable: true
 allowed-tools: Bash

--- a/skills/quit/SKILL.md
+++ b/skills/quit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: quit
+name: airc:quit
 description: Leave the current mesh without wiping your identity. Kills the running airc process in this scope and clears only the host-pairing fields from config. Next `airc join` starts fresh instead of auto-resuming.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/reminder/SKILL.md
+++ b/skills/reminder/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reminder
+name: airc:reminder
 description: Control the silence-reminder nudge. Fires once when no send happens within N seconds; resets on next send.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/repair/SKILL.md
+++ b/skills/repair/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: repair
+name: airc:repair
 description: Full re-pair of a stale airc mesh — `teardown --flush` + reconnect using the saved invite string. Use when your sends silently fail or `resume` reports stale auth.
 user-invocable: true
 allowed-tools: Bash, Monitor

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: resume
+name: airc:resume
 description: Resume a prior airc session in this scope. Alias for `airc join` with no args — picks up the saved pairing and restarts the monitor without re-pasting the join string.
 user-invocable: true
 allowed-tools: Bash, Monitor

--- a/skills/send-file/SKILL.md
+++ b/skills/send-file/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: send-file
+name: airc:send-file
 description: Send a file to a paired peer via AIRC.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/teardown/SKILL.md
+++ b/skills/teardown/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: teardown
+name: airc:teardown
 description: Kill airc processes belonging to THIS scope (this AIRC_HOME), free its port. Scope-aware — never touches other tabs' sessions. Add --flush to also wipe state.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/tests/SKILL.md
+++ b/skills/tests/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tests
+name: airc:tests
 description: Run the airc integration test suite (alias for airc doctor). Validates pairing, send, rename, room substrate, scope isolation, queue resilience, and more. Use after install or upgrade, or when something feels off.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: update
+name: airc:update
 description: Pull the latest airc code into the install dir. Leaves the running monitor untouched; report the new SHA and tell the user to teardown+connect to pick it up.
 user-invocable: true
 allowed-tools: Bash

--- a/skills/version/SKILL.md
+++ b/skills/version/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: version
+name: airc:version
 description: Print the currently-installed airc version (short git SHA, branch, commit subject, install dir). Use this to verify everyone in a mesh is on the same build.
 user-invocable: true
 allowed-tools: Bash


### PR DESCRIPTION
PR #100 dropped airc: prefix from skill names — wrong call. The prefix is namespacing; /update, /list, /join etc. are too generic to land in a user's global skill registry uncontained. Reverting only the skill name change; heartbeat fix stays.