### PR TITLE
fix(tailscale): PS parity for logged-out detection

### DIFF
--- a/airc.ps1
+++ b/airc.ps1
@@ -307,13 +307,20 @@ function Advise-TailscaleIfDown {
     if (-not (Test-CgnatIp -Ip $TargetHost)) { return $false }
 
     $ts = Resolve-TailscaleBin
+    $tsOut = ''
+    $tsRc  = 1
     if ($ts) {
-        & $ts status 2>$null | Out-Null
-        if ($LASTEXITCODE -eq 0) { return $false }   # daemon up, proceed
+        $tsOut = & $ts status 2>&1 | Out-String
+        $tsRc  = $LASTEXITCODE
+        # Status command rc=0 AND output doesn't say "Logged out" / "NeedsLogin"
+        # = daemon up + signed in, proceed.
+        if ($tsRc -eq 0 -and $tsOut -notmatch 'Logged out|NeedsLogin') {
+            return $false
+        }
     }
 
     Write-Host ''
-    Write-Host "X airc: can't reach Tailscale-routed host $TargetHost -- Tailscale appears down on this machine."
+    Write-Host "X airc: can't reach Tailscale-routed host $TargetHost -- Tailscale isn't ready on this machine."
     Write-Host ''
     if (-not $ts) {
         Write-Host '   Tailscale is not installed. airc needs it only for cross-machine mesh.'
@@ -324,6 +331,17 @@ function Advise-TailscaleIfDown {
         Write-Host '   After install, bring the tailnet up and re-run airc join.'
         return $true
     }
+
+    # Distinguish "logged out" from "daemon down" - they need different
+    # fixes and used to print the same wrong "start the daemon" message.
+    if ($tsOut -match 'Logged out|NeedsLogin') {
+        Write-Host '   Tailscale is installed and running but you''re not signed in.'
+        Write-Host '     Click the Tailscale tray icon to sign in,'
+        Write-Host '     or run:  tailscale up'
+        Write-Host ''
+        return $true
+    }
+
     Write-Host '   Tailscale CLI is installed but the daemon is not running. Start it:'
     Write-Host '     (Windows) Click the Tailscale tray icon to start the app.'
     Write-Host '               Or from an elevated PowerShell:  Start-Service Tailscale'

--- a/install.ps1
+++ b/install.ps1
@@ -323,6 +323,28 @@ if (Test-Path $skillsSrc) {
     }
 }
 
+# -- Tailscale login check -----------------------------------------------
+# Tailscale-installed-but-logged-out is the most common 'tailscale down'
+# state in practice (post-reboot, fresh install, expired auth). Detect
+# proactively and tell the user to sign in before they hit a confusing
+# 'daemon down' error on their first 'airc join'. Mirrors install.sh
+# ts_post_check.
+$tsBin = $null
+if (Get-Command tailscale -ErrorAction SilentlyContinue) {
+    $tsBin = 'tailscale'
+} elseif (Test-Path 'C:\Program Files\Tailscale\tailscale.exe') {
+    $tsBin = 'C:\Program Files\Tailscale\tailscale.exe'
+}
+if ($tsBin) {
+    $tsOut = & $tsBin status 2>&1 | Out-String
+    if ($tsOut -match 'Logged out|NeedsLogin') {
+        Write-Host ''
+        Write-Warn2 "Tailscale is installed but you're not signed in."
+        Write-Host '    Click the Tailscale tray icon to sign in, or run:  tailscale up'
+        Write-Host '    Do this BEFORE airc join, or cross-machine joins will hang.'
+    }
+}
+
 # -- Final guidance ------------------------------------------------------
 Write-Host ''
 Write-Ok 'airc installed.'
@@ -330,7 +352,7 @@ Write-Host ''
 Write-Host '  Next:'
 Write-Host '    1. Open a NEW PowerShell window (so PATH refreshes)'
 Write-Host '    2. Authenticate gh once:    gh auth login -s gist'
-Write-Host "    3. Bring Tailscale up:      tailscale up    (or skip - LAN works without it)"
+Write-Host "    3. Sign in to Tailscale:    click tray icon, or 'tailscale up'  (or skip - LAN works without it)"
 Write-Host '    4. Join the mesh:           airc join'
 Write-Host ''
 Write-Host '  Diagnose anytime:    airc doctor'


### PR DESCRIPTION
Mirror PR #105 (bash + install.sh) onto airc.ps1 + install.ps1. Without this, Windows users hitting Tailscale-installed-but-logged-out get the same wrong 'start the daemon' message that bash users used to get.