### PR TITLE
fix: race-loser detection in self-heal takeover paths

### DIFF
--- a/airc
+++ b/airc
@@ -1804,20 +1804,34 @@ cmd_connect() {
       echo ""
       echo "  ⚠  Host of #${resolved_room_name} is stale (last heartbeat ${_resolved_heartbeat_age}s ago) — taking over..."
       echo "     (prior host's gist: $_resolved_gist_id)"
+
+      # Same race-loser detection as the SSH-failure self-heal path
+      # below. Two tabs concurrently deciding "host is stale" both
+      # delete + publish, end up with split-brain — caught only by
+      # running two tabs together.
+      local _race_jitter_s; _race_jitter_s=$(awk -v r="$RANDOM" 'BEGIN{printf "%.3f", 0.1 + (r%1500)/1000}')
+      sleep "$_race_jitter_s"
+
       if gh gist delete "$_resolved_gist_id" --yes 2>/dev/null; then
         echo "  ✓ Stale gist removed."
       else
-        echo "  ⚠  Couldn't remove stale gist (already gone? not on this gh account?)."
-        echo "     New host will publish a fresh #${resolved_room_name} gist anyway."
+        echo "  ⚠  Stale gist already gone — another tab may have taken over first."
       fi
-      # Preserve identity name across re-exec — same reason as the
-      # SSH-failure self-heal: derive_name re-runs from cwd and can drift
-      # on case-aliasing, peers see a "new" peer.
+
+      local _new_picked; _new_picked=$(gh gist list --limit 50 2>/dev/null \
+        | awk -F'\t' -v re="airc room: ${resolved_room_name}\$" -v skip="$_resolved_gist_id" \
+            '$2 ~ re && $1 != skip { print $1; exit }')
+
       local _preserved_name; _preserved_name=$(get_config_val name "")
-      # Wipe any half-written CONFIG (this path runs before we write,
-      # but be defensive in case a prior failed pair left state behind).
       rm -f "$CONFIG"
       rm -f "$AIRC_WRITE_DIR/room_name"
+
+      if [ -n "$_new_picked" ]; then
+        echo "  ✓ Another tab beat us to it — joining their fresh gist ($_new_picked)"
+        echo ""
+        exec env ${_preserved_name:+AIRC_NAME="$_preserved_name"} "$0" connect "$_new_picked"
+      fi
+
       echo "  Re-execing into host mode for #${resolved_room_name}..."
       echo ""
       exec env AIRC_NO_DISCOVERY=1 ${_preserved_name:+AIRC_NAME="$_preserved_name"} "$0" connect --room "$resolved_room_name"
@@ -1971,25 +1985,49 @@ print(data.decode().strip())
         echo ""
         echo "  ⚠  Host of #${resolved_room_name} unreachable — self-healing as new host..."
         echo "     (prior host's gist: $_resolved_gist_id)"
+
+        # Jittered backoff before takeover. Without this, two tabs that
+        # hit the same dead gist concurrently both delete + publish
+        # within the same gh API window and you end up with two
+        # competing gists for the same room name (split-brain race —
+        # caught only by running two tabs against a stale gist
+        # simultaneously, NOT by the integration test).
+        local _race_jitter_s; _race_jitter_s=$(awk -v r="$RANDOM" 'BEGIN{printf "%.3f", 0.1 + (r%1500)/1000}')
+        sleep "$_race_jitter_s"
+
         if gh gist delete "$_resolved_gist_id" --yes 2>/dev/null; then
           echo "  ✓ Stale gist removed."
         else
-          echo "  ⚠  Couldn't remove stale gist (already gone? not on this gh account?)."
-          echo "     New host will publish a fresh #${resolved_room_name} gist anyway."
+          echo "  ⚠  Stale gist already gone — another tab may have taken over first."
         fi
-        # Preserve identity name across re-exec (same reason as the resume
-        # path's self-heal — without this, derive_name re-runs from cwd
-        # and can drift on case-aliasing, peers see a "new" peer).
+
+        # Race-loser detection: re-scan for any OTHER fresh gist with
+        # this room name. If a concurrent self-heal already published
+        # one, JOIN their fresh gist instead of publishing a duplicate.
+        local _new_picked; _new_picked=$(gh gist list --limit 50 2>/dev/null \
+          | awk -F'\t' -v re="airc room: ${resolved_room_name}\$" -v skip="$_resolved_gist_id" \
+              '$2 ~ re && $1 != skip { print $1; exit }')
+
+        # Preserve identity name across re-exec (same reason as resume
+        # path: derive_name re-runs from cwd and can drift on case-
+        # aliasing, peers see a "new" peer).
         local _preserved_name; _preserved_name=$(get_config_val name "")
-        # Wipe the CONFIG we just wrote — it points at the dead host and
-        # would trigger 'resume joiner' on next airc connect, looping back
-        # into this same failure.
+        # Wipe the CONFIG we just wrote — it points at the dead host
+        # and would trigger 'resume joiner' on next airc connect.
         rm -f "$CONFIG"
         rm -f "$AIRC_WRITE_DIR/room_name"
+
+        if [ -n "$_new_picked" ]; then
+          echo "  ✓ Another tab beat us to it — joining their fresh gist ($_new_picked)"
+          echo ""
+          # Re-exec as joiner pointing at the winner's gist.
+          exec env ${_preserved_name:+AIRC_NAME="$_preserved_name"} "$0" connect "$_new_picked"
+        fi
+
         echo "  Re-execing into host mode for #${resolved_room_name}..."
         echo ""
-        # exec replaces the current bash process — clean handoff. AIRC_NO_DISCOVERY=1
-        # ensures the new instance doesn't try to re-discover the just-deleted gist
+        # exec replaces the current bash process. AIRC_NO_DISCOVERY=1
+        # prevents the new instance from re-finding the just-deleted gist
         # (gh's gist-list cache might still show it for a few seconds).
         exec env AIRC_NO_DISCOVERY=1 ${_preserved_name:+AIRC_NAME="$_preserved_name"} "$0" connect --room "$resolved_room_name"
       fi

--- a/airc.ps1
+++ b/airc.ps1
@@ -307,13 +307,20 @@ function Advise-TailscaleIfDown {
     if (-not (Test-CgnatIp -Ip $TargetHost)) { return $false }
 
     $ts = Resolve-TailscaleBin
+    $tsOut = ''
+    $tsRc  = 1
     if ($ts) {
-        & $ts status 2>$null | Out-Null
-        if ($LASTEXITCODE -eq 0) { return $false }   # daemon up, proceed
+        $tsOut = & $ts status 2>&1 | Out-String
+        $tsRc  = $LASTEXITCODE
+        # Status command rc=0 AND output doesn't say "Logged out" / "NeedsLogin"
+        # = daemon up + signed in, proceed.
+        if ($tsRc -eq 0 -and $tsOut -notmatch 'Logged out|NeedsLogin') {
+            return $false
+        }
     }
 
     Write-Host ''
-    Write-Host "X airc: can't reach Tailscale-routed host $TargetHost -- Tailscale appears down on this machine."
+    Write-Host "X airc: can't reach Tailscale-routed host $TargetHost -- Tailscale isn't ready on this machine."
     Write-Host ''
     if (-not $ts) {
         Write-Host '   Tailscale is not installed. airc needs it only for cross-machine mesh.'
@@ -324,6 +331,17 @@ function Advise-TailscaleIfDown {
         Write-Host '   After install, bring the tailnet up and re-run airc join.'
         return $true
     }
+
+    # Distinguish "logged out" from "daemon down" - they need different
+    # fixes and used to print the same wrong "start the daemon" message.
+    if ($tsOut -match 'Logged out|NeedsLogin') {
+        Write-Host '   Tailscale is installed and running but you''re not signed in.'
+        Write-Host '     Click the Tailscale tray icon to sign in,'
+        Write-Host '     or run:  tailscale up'
+        Write-Host ''
+        return $true
+    }
+
     Write-Host '   Tailscale CLI is installed but the daemon is not running. Start it:'
     Write-Host '     (Windows) Click the Tailscale tray icon to start the app.'
     Write-Host '               Or from an elevated PowerShell:  Start-Service Tailscale'

--- a/install.ps1
+++ b/install.ps1
@@ -323,6 +323,28 @@ if (Test-Path $skillsSrc) {
     }
 }
 
+# -- Tailscale login check -----------------------------------------------
+# Tailscale-installed-but-logged-out is the most common 'tailscale down'
+# state in practice (post-reboot, fresh install, expired auth). Detect
+# proactively and tell the user to sign in before they hit a confusing
+# 'daemon down' error on their first 'airc join'. Mirrors install.sh
+# ts_post_check.
+$tsBin = $null
+if (Get-Command tailscale -ErrorAction SilentlyContinue) {
+    $tsBin = 'tailscale'
+} elseif (Test-Path 'C:\Program Files\Tailscale\tailscale.exe') {
+    $tsBin = 'C:\Program Files\Tailscale\tailscale.exe'
+}
+if ($tsBin) {
+    $tsOut = & $tsBin status 2>&1 | Out-String
+    if ($tsOut -match 'Logged out|NeedsLogin') {
+        Write-Host ''
+        Write-Warn2 "Tailscale is installed but you're not signed in."
+        Write-Host '    Click the Tailscale tray icon to sign in, or run:  tailscale up'
+        Write-Host '    Do this BEFORE airc join, or cross-machine joins will hang.'
+    }
+}
+
 # -- Final guidance ------------------------------------------------------
 Write-Host ''
 Write-Ok 'airc installed.'
@@ -330,7 +352,7 @@ Write-Host ''
 Write-Host '  Next:'
 Write-Host '    1. Open a NEW PowerShell window (so PATH refreshes)'
 Write-Host '    2. Authenticate gh once:    gh auth login -s gist'
-Write-Host "    3. Bring Tailscale up:      tailscale up    (or skip - LAN works without it)"
+Write-Host "    3. Sign in to Tailscale:    click tray icon, or 'tailscale up'  (or skip - LAN works without it)"
 Write-Host '    4. Join the mesh:           airc join'
 Write-Host ''
 Write-Host '  Diagnose anytime:    airc doctor'


### PR DESCRIPTION
Two-tab race condition: concurrent self-heal-as-host attempts produce split-brain (two competing gists for the same room). Both takeover paths now jitter-sleep before delete, then re-scan for an existing fresh gist with this room name. If another tab won the race, join their gist as joiner instead of publishing a duplicate.