### PR TITLE
feat(tailscale): just-works default + --no-tailscale opt-out

### DIFF
--- a/airc
+++ b/airc
@@ -515,6 +515,46 @@ advise_tailscale_if_down() {
 
 timestamp() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
+# tailscale_login_check_or_prompt: at the top of every cmd_connect, if
+# Tailscale is installed but the daemon reports Logged out / NeedsLogin,
+# tell the user + open the GUI sign-in (mac) / print 'tailscale up'
+# (linux/win). Non-fatal: returns 0 always. Same-machine + same-LAN
+# substrate paths still work without Tailscale; this prompt is for
+# the host-goal-is-mesh case Joel pointed at: "if you got it use it".
+#
+# Opt-out: AIRC_NO_TAILSCALE=1 (env var) — explicit user preference
+# for "I'm intentionally running without Tailscale; stop nagging."
+# Distinct from advise_tailscale_if_down which fires only on a
+# CGNAT-targeted SSH attempt; this one is the unconditional startup
+# nudge for both host and joiner roles.
+tailscale_login_check_or_prompt() {
+  [ "${AIRC_NO_TAILSCALE:-0}" = "1" ] && return 0
+  local ts_bin; ts_bin=$(resolve_tailscale_bin 2>/dev/null || true)
+  [ -z "$ts_bin" ] && return 0   # not installed; no nag (Tailscale truly optional)
+  local out; out=$("$ts_bin" status 2>&1)
+  case "$out" in
+    *"Logged out"*|*"NeedsLogin"*) ;;
+    *) return 0 ;;
+  esac
+  echo "" >&2
+  echo "  ⚠  Tailscale is installed but you're not signed in." >&2
+  echo "     Same-machine and same-LAN peers reach you fine; remote peers" >&2
+  echo "     (other machines on your gh account) can't until you sign in." >&2
+  case "$(uname -s)" in
+    Darwin)
+      if [ -d /Applications/Tailscale.app ]; then
+        echo "     Opening Tailscale.app — sign in there. (To opt out: AIRC_NO_TAILSCALE=1)" >&2
+        open -a Tailscale 2>/dev/null || true
+      else
+        echo "     Sign in:  tailscale up   (or set AIRC_NO_TAILSCALE=1 to opt out)" >&2
+      fi
+      ;;
+    *) echo "     Sign in:  tailscale up   (or set AIRC_NO_TAILSCALE=1 to opt out)" >&2 ;;
+  esac
+  echo "" >&2
+  return 0
+}
+
 # host_machine_id: stable per-machine identifier. Same machine, two
 # terminals: same value. Different machines: different. Used by the
 # multi-address gist envelope so a same-machine joiner knows to dial
@@ -1369,10 +1409,25 @@ cmd_connect() {
       --no-gist|-no-gist) use_gist=0; shift ;;
       --room|-room) room_name="${2:-general}"; use_room=1; room_explicit=1; shift 2 ;;
       --no-general|-no-general|--no-room|-no-room) use_room=0; shift ;;
+      --no-tailscale|-no-tailscale)
+        # Opt out of Tailscale entirely: skips the login prompt AND
+        # drops the tailscale entry from host_address_set so the
+        # gist envelope advertises only localhost+LAN. The flag is
+        # the primary user-facing API; AIRC_NO_TAILSCALE=1 stays as
+        # an internal toggle for code that already reads it.
+        export AIRC_NO_TAILSCALE=1
+        shift ;;
       *) positional+=("$1"); shift ;;
     esac
   done
   set -- "${positional[@]+"${positional[@]}"}"
+
+  # Tailscale-installed-but-logged-out nudge. Runs AFTER flag parsing
+  # so --no-tailscale takes effect. Default behavior: if Tailscale is
+  # installed, "just works" — prompt the user to sign in (Mac: opens
+  # Tailscale.app). The 90% case is "I have it and want it on";
+  # --no-tailscale is the explicit opt-out for the few who don't.
+  tailscale_login_check_or_prompt
 
   # `airc join` (no args) joins #general. Period. Auto-scope-by-git-remote
   # was a previous default that silently put agents in different cwds into
@@ -2430,7 +2485,7 @@ json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
     # substrate framing took effect — emit unconditionally for room mode.
     if [ "$use_room" = "1" ]; then
       echo "$room_name" > "$AIRC_WRITE_DIR/room_name"
-      echo "  No live #${room_name} found on your gh account — hosting fresh."
+      echo "  Hosting #${room_name} — no existing room on your gh account, fresh start."
       echo "  Other agents on your gh account who run 'airc join' will auto-join."
     fi
 

--- a/airc.ps1
+++ b/airc.ps1
@@ -349,6 +349,26 @@ function Advise-TailscaleIfDown {
     return $true
 }
 
+# Test-TailscaleLoginOrPrompt: PS parity for bash tailscale_login_check_or_prompt.
+# Called at the top of Invoke-Connect. If Tailscale is installed but the
+# daemon reports Logged out / NeedsLogin, surface a non-fatal warning.
+# Same-machine + same-LAN substrate paths still work without Tailscale.
+# AIRC_NO_TAILSCALE=1 opts out (explicit "I'm running without it").
+function Test-TailscaleLoginOrPrompt {
+    if ($env:AIRC_NO_TAILSCALE -eq '1') { return }
+    $ts = Resolve-TailscaleBin
+    if (-not $ts) { return }   # not installed; no nag
+    $out = & $ts status 2>&1 | Out-String
+    if ($out -notmatch 'Logged out|NeedsLogin') { return }
+    Write-Host ''
+    Write-Host "  ! Tailscale is installed but you're not signed in."
+    Write-Host '     Same-machine and same-LAN peers reach you fine; remote peers'
+    Write-Host "     (other machines on your gh account) can't until you sign in."
+    Write-Host '     Click the Tailscale tray icon to sign in, or run:  tailscale up'
+    Write-Host '     (To opt out of this nag: set AIRC_NO_TAILSCALE=1)'
+    Write-Host ''
+}
+
 # -- get_host: tailscale IP > LAN IP > hostname -------------------------
 # Priority order matches bash: tailscale IP first (works across the whole
 # tailnet), LAN IP next (no Tailscale required for same-LAN mesh), then
@@ -2112,9 +2132,16 @@ function Invoke-Connect {
             '^(--no-gist|-no-gist)$' { $useGist = $false }
             '^(--room|-room)$' { $roomName = $Argv[$i + 1]; $useRoom = $true; $i++ }
             '^(--no-general|-no-general|--no-room|-no-room)$' { $useRoom = $false }
+            '^(--no-tailscale|-no-tailscale)$' { $env:AIRC_NO_TAILSCALE = '1' }
             default { $positional += $Argv[$i] }
         }
     }
+
+    # Tailscale-installed-but-logged-out nudge. AFTER flag parsing so
+    # --no-tailscale takes effect. Default: prompt to sign in if it's
+    # installed but logged out (90% case is "I want it on, just got
+    # logged out"). --no-tailscale is the explicit opt-out.
+    Test-TailscaleLoginOrPrompt
     $target = if ($positional.Count -gt 0) { $positional[0] } else { '' }
     $reminderInterval = if ($env:AIRC_REMINDER) { [int]$env:AIRC_REMINDER }
                        elseif ($positional.Count -gt 1) { [int]$positional[1] }

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:join
-description: Join AIRC. Default = auto-scope to the room matching the current git repo's owner (e.g. #my-org, #cambriantech); falls back to #general for non-git dirs. Optional arg = mnemonic, gist id, room name, or inline invite.
+description: Join AIRC. Default = #general (one room, all agents on the user's gh account). Optional arg = mnemonic, gist id, room name, or inline invite.
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: "[mnemonic | gist-id | room-name | invite-string]"
@@ -15,10 +15,11 @@ Do everything yourself — don't ask the user to run commands.
 aIRC = airc. The mental model is IRC, not bespoke pairing. The user's GitHub gist namespace IS the room registry: each room is a persistent secret gist; agents on the same gh account auto-discover and converge on the same channel.
 
 Defaults:
-- `airc join` (no args) → auto-scope to the room matching the current git repo's owner: a `github.com/my-org/*` checkout lands in `#my-org`, a personal `github.com/your-username/*` side project lands in `#your-username`. Non-git dir or unparseable remote → `#general` (the lobby). If nobody's hosting the resolved room yet on the user's gh account, this agent becomes the host.
-- Same gh account, same repo org = automatic mesh. Zero strings, zero flags — just run `airc join` from any checkout and you're in the project's channel.
+- `airc join` (no args) → join `#general` on the user's gh account. Same room from every cwd, every machine. If nobody's hosting `#general` yet, this agent becomes the host; subsequent agents auto-join.
+- Per-project rooms are opt-in: `airc join --room project-x`.
 - Cross-account share (e.g. friend on a different gh) = paste the 4-word humanhash mnemonic, or the raw gist id as fallback.
-- Overrides: `airc join --room <name>` to pick explicitly; `AIRC_NO_AUTO_ROOM=1 airc join` to force the fallback and land in `#general` regardless of pwd.
+
+**Tailscale:** if installed and signed in, the substrate uses it for cross-machine peers. If installed and logged out, `airc join` opens Tailscale.app for sign-in (Mac) or prints `tailscale up` (Linux/Windows). Same-machine and same-LAN peers connect via `127.0.0.1`/LAN regardless — Tailscale is only needed for cross-network mesh. To opt out entirely: `airc join --no-tailscale`.
 
 `gh` CLI is **required**, not optional. The whole substrate is built on it. If the user doesn't have it: `brew install gh && gh auth login`.
 
@@ -35,17 +36,18 @@ If `gh` is not on PATH or not authed: install + `gh auth login`. There's no grac
 
 AIRC auto-detects the scope — if you're inside a git repo, identity lives at `<repo-root>/.airc/`; otherwise `~/.airc/`. No env vars needed.
 
-**Default — auto-scope (the substrate flow):**
+**Default — `#general` (the substrate flow):**
 ```
 Monitor(persistent=true, description="airc", command="airc join")
 ```
 
-Keep the Monitor `description` short and stable — `"airc"` is ideal. DO NOT encode the room name ("airc join #my-org", "airc join (auto-#general)", etc.). The room is resolved at runtime based on the current git repo and the user's UI renders the description once per event, so anything clever-looking just goes stale the moment the user `cd`s to another repo. Event bodies land in your tool-result stream — narrate them per §2b.
+Keep the Monitor `description` short and stable — `"airc"` is ideal.
 
 Outcomes the monitor will print on its first events:
-- `Auto-scoped: #<room> (from git org; override with --room or AIRC_NO_AUTO_ROOM=1)` — the resolver fired; `<room>` is the owner segment of `origin` (e.g. `my-org`, `cambriantech`) or the parent-dir fallback.
-- `Found #<room> on your gh account → joining (<id>)` — another tab/machine on the same gh account is already hosting; we're a joiner. Confirm with `airc peers`.
-- `No #<room> found on your gh account → becoming the host.` — we're the host. Subsequent agents whose `airc join` resolves to the same room will auto-pair with us.
+- `Found #general on your gh account → joining (<id>)` — another tab/machine on the same gh account is already hosting; we're a joiner. Confirm with `airc peers`.
+- `No live #general found on your gh account — hosting fresh.` — we're the host. Subsequent agents who run `airc join` will auto-join.
+- `✓ Multi-address pick: <addr>:<port> (from host.addresses)` — joiner found the host's gist and selected the cheapest reachable address. `127.0.0.1` means same-machine match; a `192.168.x.x` means same-LAN; `100.x.x.x` means via Tailscale.
+- `⚠ Tailscale is installed but you're not signed in.` — non-fatal nudge; same-machine and same-LAN paths still work. Either sign in (the launched Tailscale.app) or pass `--no-tailscale` to silence.
 
 **Named room (non-general channel):**
 ```
@@ -93,7 +95,7 @@ Every line airc writes to stdout is a Monitor event. Claude Code's UI renders ea
 
 After every event, write one short sentence in chat paraphrasing what happened. Examples:
 
-- `Auto-scoped to #my-org; hosting (gist published, mnemonic: <4-word phrase>).`
+- `Hosting #general (gist published, mnemonic: <4-word phrase>).`
 - `Peer <peer-name> just joined.` — and run `airc whois <peer-name>`, surface their role + bio in one line so context loads. New peer the user hasn't seen this session = always investigate.
 - `<peer-name> → us: <one-line paraphrase of their message>.`
 - `Reminder fired (5-min idle) — ignoring.`


### PR DESCRIPTION
Default to prompting for sign-in when Tailscale is installed but logged out (Joel: 'logs out all the time; if you got it use it'). `--no-tailscale` is the explicit opt-out for the few who don't want it. Bash + PS parity. Skill doc updated.