### PR TITLE
fix(join): three resume bugs from a single dogfooding session

### DIFF
--- a/airc
+++ b/airc
@@ -1437,22 +1437,34 @@ cmd_connect() {
   # --no-tailscale is the explicit opt-out for the few who don't.
   tailscale_login_check_or_prompt
 
-  # `airc join` (no args) joins #general. Period. Auto-scope-by-git-remote
-  # was a previous default that silently put agents in different cwds into
-  # different rooms ('#cambriantech' from one repo, '#useideem' from another),
-  # so two agents on the same gh account couldn't see each other and each
-  # wound up alone in its own "channel" — the opposite of the IRC-substrate
-  # mental model. Per-project rooms are still available via explicit
-  # `--room <name>`. AIRC_AUTO_SCOPE_ROOM=1 restores the old behavior for
-  # anyone who actually wanted it.
+  # `airc join` (no args) auto-scopes to the room matching the current cwd.
+  # Resolution: git remote org first ('useideem/authenticator' → #useideem),
+  # parent-dir basename second (local-only repos). Falls back to #general
+  # only when neither signal fires (non-git dir, no remote). The skill
+  # /join contract documents this as the default.
+  #
+  # The trade-off: two tabs in DIFFERENT projects on the same gh account
+  # land in different rooms (a #cambriantech tab can't see a #useideem
+  # tab). That's intentional — project work shouldn't mix with unrelated
+  # project chatter. Cross-project agents who need a shared lobby:
+  # `AIRC_NO_AUTO_ROOM=1 airc join` or `airc join --room general`.
+  #
+  # Two tabs in the SAME project converge automatically: both useideem
+  # tabs auto-scope to #useideem, both find each other. That's the case
+  # this default optimizes for.
+  #
+  # History: this was rolled back in PR #104 over the cross-project
+  # concern, then re-enabled here after dogfooding showed the converse
+  # bug (two same-project tabs both defaulting to #general and never
+  # converging on the project room) was the more painful failure mode.
   if [ "$use_room" = "1" ] && [ "$room_explicit" = "0" ] \
-     && [ "${AIRC_AUTO_SCOPE_ROOM:-0}" = "1" ]; then
+     && [ "${AIRC_NO_AUTO_ROOM:-0}" != "1" ]; then
     local _inferred
     _inferred=$(infer_default_room 2>/dev/null || true)
     if [ -n "$_inferred" ]; then
       room_name="${_inferred%|*}"
       local _source="${_inferred#*|}"
-      echo "  Auto-scoped: #${room_name} (AIRC_AUTO_SCOPE_ROOM=1, from git ${_source})"
+      echo "  Auto-scoped: #${room_name} (from git ${_source}; override with --room or AIRC_NO_AUTO_ROOM=1)"
     fi
   fi
 
@@ -1565,6 +1577,28 @@ cmd_connect() {
   if [ -z "$target" ] && [ -f "$CONFIG" ]; then
     local prior_host_target; prior_host_target=$(get_config_val host_target "")
     if [ -n "$prior_host_target" ]; then
+      # Explicit --room with a different saved room must not silently resume
+      # the saved pairing. Symptom (pre-fix): user runs `airc join --room foo`
+      # after having paired into #bar; resume blindly reconnects to #bar's
+      # host and the --room flag is ignored without a peep. The user has to
+      # `airc teardown --flush` before the explicit flag takes effect, which
+      # is a hidden footgun.
+      #
+      # Fix: when --room is explicit AND a saved room_name file says we were
+      # in a different room, skip resume and fall through to discovery for
+      # the requested room. Identity persists, no flush needed.
+      if [ "$room_explicit" = "1" ]; then
+        local _saved_room_check=""
+        [ -f "$AIRC_WRITE_DIR/room_name" ] && _saved_room_check=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null)
+        if [ -n "$_saved_room_check" ] && [ "$_saved_room_check" != "$room_name" ]; then
+          echo "  Saved pairing was for #${_saved_room_check}; --room #${room_name} requested → discarding stale pairing."
+          rm -f "$CONFIG" "$AIRC_WRITE_DIR/room_name" "$AIRC_WRITE_DIR/room_gist_id"
+          # Skip the resume block entirely and let discovery run below.
+          prior_host_target=""
+        fi
+      fi
+    fi
+    if [ -n "$prior_host_target" ]; then
       local prior_name; prior_name=$(get_config_val host_name "$(get_config_val name unknown)")
       echo "  Resuming as joiner of '$prior_name' ($prior_host_target)..."
 
@@ -1665,6 +1699,41 @@ cmd_connect() {
         # Auth failure → re-pair needed. Network failure → fall through,
         # monitor's retry loop handles transient outages correctly.
         if echo "$probe_stderr" | grep -qiE 'permission denied|publickey|host key verification|authentication fail|identification has changed|no supported authentication'; then
+          # Stale auth = saved pairing is dead from our side (host wiped
+          # our key, host machine reinstalled, or host_keys rotated). For
+          # room-mode pairings this is the same end-state as the host
+          # going unreachable: the saved pair is junk. If we have a
+          # saved room_name AND gh is available, fall through to fresh
+          # discovery — the room may have been re-hosted by another
+          # peer, or we'll become the new host. Identity persists, so
+          # re-pair is automatic.
+          #
+          # Without this self-heal the user had to manually run
+          # `airc teardown --flush` and paste an invite — exactly the
+          # toil airc's auto-discovery is supposed to eliminate. Hit
+          # twice in one session on 2026-04-26 (vhsm-2c84 dead host +
+          # regenerated key), which is what motivated this change.
+          local _saved_auth_room=""
+          [ -f "$AIRC_WRITE_DIR/room_name" ] && _saved_auth_room=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null)
+          if [ -n "$_saved_auth_room" ] && command -v gh >/dev/null 2>&1; then
+            echo ""
+            echo "  ⚠  SSH auth to host FAILED on resume — saved pairing for #${_saved_auth_room} is stale." >&2
+            echo "     (saved pair: ${prior_name} @ ${prior_host_target} — host rotated keys or reinstalled)" >&2
+            echo "  Self-healing: discarding stale pairing and re-discovering #${_saved_auth_room}..."
+            local _preserved_name_a; _preserved_name_a=$(get_config_val name "")
+            # Wipe joiner state but leave identity (ssh_key) and peer
+            # records intact — they'll be re-validated by the fresh
+            # handshake. room_name is wiped here and re-set after
+            # discovery succeeds, just like the non-auth self-heal does.
+            rm -f "$CONFIG" "$AIRC_WRITE_DIR/room_name" "$AIRC_WRITE_DIR/room_gist_id"
+            echo ""
+            exec env ${_preserved_name_a:+AIRC_NAME="$_preserved_name_a"} "$0" connect --room "$_saved_auth_room"
+          fi
+          # No saved room (legacy 1:1 invite scope) OR no gh: keep the
+          # explicit-die behavior. There's nothing to fall through to —
+          # discovery requires gh, and a 1:1 invite has no room to
+          # rejoin. The user genuinely needs to re-pair via the invite
+          # string.
           echo "  SSH auth to host FAILED on resume. Saved pairing is stale." >&2
           echo "  SSH stderr: ${probe_stderr}" >&2
           echo "  Fix: airc teardown --flush && airc connect <invite-string>" >&2

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -1701,6 +1701,264 @@ scenario_two_tab_localhost() {
   cleanup_all
 }
 
+# ── Scenario: auto_scope (default room derived from git remote org) ─────
+# The /join skill contract: bare `airc join` from a useideem/* checkout
+# lands in #useideem; from a cambriantech/* checkout lands in #cambriantech.
+# A previous PR (#104) gated this behind AIRC_AUTO_SCOPE_ROOM=1, which
+# left bare-launched agents stuck in #general regardless of cwd —
+# defeating the whole point. Re-enabled as default 2026-04-26 after a
+# session of dogfooding pain (two useideem tabs both hit #general
+# instead of converging on #useideem).
+#
+# Test plan: stand up a fake git repo with origin pointing to
+# `useideem/foo`, run `airc connect` in that cwd (gh-free, --no-gist),
+# verify the "Auto-scoped: #useideem (from git org; ...)" banner fires
+# and that room_name is "useideem". Then verify AIRC_NO_AUTO_ROOM=1
+# opts out cleanly (banner absent, falls back to #general).
+scenario_auto_scope() {
+  section "auto_scope: bare connect derives room from git remote org"
+  cleanup_all
+
+  local repo=/tmp/airc-it-auto-repo
+  rm -rf "$repo"; mkdir -p "$repo"
+  ( cd "$repo" && git init -q 2>/dev/null && git remote add origin https://github.com/useideem/foo.git ) \
+    || { fail "git scaffold failed"; cleanup_all; return; }
+
+  # Default ON: bare connect should auto-scope.
+  ( cd "$repo" && AIRC_HOME=/tmp/airc-it-auto-h/state AIRC_NAME=alpha AIRC_PORT=7561 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist > /tmp/airc-it-auto-h.log 2>&1 & )
+  local i
+  for i in 1 2 3 4 5; do
+    sleep 1
+    grep -qE 'Hosting as|Auto-scoped' /tmp/airc-it-auto-h.log 2>/dev/null && break
+  done
+
+  grep -qE 'Auto-scoped: #useideem \(from git org' /tmp/airc-it-auto-h.log \
+    && pass "auto-scope banner: 'Auto-scoped: #useideem (from git org)'" \
+    || fail "auto-scope banner MISSING (got: $(head -3 /tmp/airc-it-auto-h.log | tr '\n' '|'))"
+
+  grep -qE 'Hosting #useideem' /tmp/airc-it-auto-h.log \
+    && pass "host banner reports #useideem (auto-scoped room took effect)" \
+    || fail "host banner not on #useideem (auto-scope didn't propagate to host setup)"
+
+  # Kill that run before testing the opt-out (port + scope reuse).
+  for f in /tmp/airc-it-auto-h/state/airc.pid; do
+    [ -f "$f" ] && kill -9 $(cat "$f") 2>/dev/null
+  done
+  sleep 1
+  rm -rf /tmp/airc-it-auto-h /tmp/airc-it-auto-h.log
+
+  # Opt-out: AIRC_NO_AUTO_ROOM=1 should bypass auto-scope entirely.
+  ( cd "$repo" && AIRC_HOME=/tmp/airc-it-auto-h2/state AIRC_NAME=alpha AIRC_PORT=7562 \
+      AIRC_NO_DISCOVERY=1 AIRC_NO_AUTO_ROOM=1 \
+      "$AIRC" connect --no-gist > /tmp/airc-it-auto-h2.log 2>&1 & )
+  for i in 1 2 3 4 5; do
+    sleep 1
+    grep -qE 'Hosting as' /tmp/airc-it-auto-h2.log 2>/dev/null && break
+  done
+
+  ! grep -qE 'Auto-scoped' /tmp/airc-it-auto-h2.log \
+    && pass "AIRC_NO_AUTO_ROOM=1 suppresses auto-scope banner" \
+    || fail "AIRC_NO_AUTO_ROOM=1 still printed Auto-scoped (opt-out broken)"
+
+  grep -qE 'Hosting #general' /tmp/airc-it-auto-h2.log \
+    && pass "AIRC_NO_AUTO_ROOM=1 falls back to #general" \
+    || fail "AIRC_NO_AUTO_ROOM=1 didn't land on #general (got: $(grep Hosting /tmp/airc-it-auto-h2.log | head -1))"
+
+  for f in /tmp/airc-it-auto-h2/state/airc.pid; do
+    [ -f "$f" ] && kill -9 $(cat "$f") 2>/dev/null
+  done
+  sleep 1
+  rm -rf /tmp/airc-it-auto-h2 /tmp/airc-it-auto-h2.log "$repo"
+  cleanup_all
+}
+
+# ── Scenario: room_overrides_resume (--room discards stale saved pairing) ──
+# Pre-fix: `airc connect --room foo` after a prior pairing into #bar
+# silently ignored the flag and resumed #bar's host, because the resume
+# path didn't compare the saved room_name to the explicit --room. The
+# user had to manually `airc teardown --flush` before the flag took
+# effect — exactly the toil the substrate is supposed to eliminate.
+#
+# Post-fix: when --room is explicit AND saved room_name differs, the
+# resume path discards the stale CONFIG + room_name + room_gist_id and
+# falls through to discovery for the requested room. Identity persists
+# (no flush needed); ssh_key + peer records survive.
+scenario_room_overrides_resume() {
+  section "room_overrides_resume: explicit --room discards stale saved pairing"
+  cleanup_all
+
+  # Synthesize a saved joiner state for room #old-room with a dead host.
+  # We don't need a real host — the resume path checks --room/saved-room
+  # mismatch BEFORE attempting any SSH probe, and bails early if they
+  # differ. (The probe itself is exercised by scenario_resume_stale_auth.)
+  local home=/tmp/airc-it-ror/state
+  mkdir -p "$home/identity"
+  ssh-keygen -t ed25519 -f "$home/identity/ssh_key" -N '' -q -C 'airc-test-ror' 2>/dev/null
+  cat > "$home/config.json" <<'JSON'
+{
+  "name": "alpha",
+  "host_target": "deadhost@127.0.0.1:9999",
+  "host_name": "deadhost",
+  "host_port": 9999,
+  "host_ssh_pub": "ssh-ed25519 AAAAignored"
+}
+JSON
+  echo "old-room" > "$home/room_name"
+
+  # Run connect with --room new-room. Should discard stale pair, then
+  # proceed to host #new-room (AIRC_NO_DISCOVERY=1 + --no-gist keep
+  # this gh-free).
+  AIRC_HOME="$home" AIRC_NAME=alpha AIRC_PORT=7563 AIRC_NO_DISCOVERY=1 \
+    "$AIRC" connect --room new-room --no-gist > /tmp/airc-it-ror.log 2>&1 &
+  local pid=$!
+  local i
+  for i in 1 2 3 4 5 6; do
+    sleep 1
+    grep -qE 'Hosting #new-room|discarding stale pairing' /tmp/airc-it-ror.log 2>/dev/null && break
+  done
+
+  grep -qE 'Saved pairing was for #old-room.*--room #new-room.*discarding stale pairing' /tmp/airc-it-ror.log \
+    && pass "discard banner fires with old room + new room named" \
+    || fail "no discard banner (got: $(head -5 /tmp/airc-it-ror.log | tr '\n' '|'))"
+
+  grep -qE 'Hosting #new-room' /tmp/airc-it-ror.log \
+    && pass "fell through to host #new-room after discarding stale pair" \
+    || fail "did NOT host #new-room (got: $(grep -E 'Hosting|Resuming' /tmp/airc-it-ror.log | head -3 | tr '\n' '|'))"
+
+  ! grep -qE 'Resuming as joiner of .deadhost' /tmp/airc-it-ror.log \
+    && pass "did NOT resume the stale deadhost pairing" \
+    || fail "still tried to resume deadhost despite explicit --room"
+
+  # Identity must survive — ssh_key intact post-discard.
+  [ -f "$home/identity/ssh_key" ] \
+    && pass "identity (ssh_key) preserved across discard" \
+    || fail "ssh_key was wiped (over-broad cleanup)"
+
+  for f in "$home/airc.pid"; do
+    [ -f "$f" ] && kill -9 $(cat "$f") 2>/dev/null
+  done
+  sleep 1
+  rm -rf /tmp/airc-it-ror /tmp/airc-it-ror.log
+  cleanup_all
+}
+
+# ── Scenario: stale_auth_room_selfheal (room-mode auto-recover) ────────
+# Pre-fix companion to scenario_resume_stale_auth: when the saved
+# pairing has a saved room_name (i.e. we were in a #room, not a 1:1
+# invite), stale SSH auth shouldn't `die` and demand the user run
+# `airc teardown --flush`. It should fall through to fresh discovery
+# for that room — re-pair against whoever's now hosting, or become
+# the new host. Identity persists; the user does nothing.
+#
+# Without this self-heal, the bare `airc join` UX hits a forced manual
+# repair every time a host machine reinstalls / rotates keys / wipes
+# state — exactly the cliff Joel hit twice on 2026-04-26 (vhsm-2c84
+# dead host followed by the no-saved-pair-after-flush bug, which sent
+# us into #general instead of #useideem).
+#
+# This test covers ONLY the saved-room branch. The legacy 1:1 invite
+# branch (no saved room) keeps its die-loud behavior and is still
+# covered by scenario_resume_stale_auth.
+scenario_stale_auth_room_selfheal() {
+  section "stale_auth_room_selfheal: room-mode resume self-heals on stale auth"
+  cleanup_all
+
+  local rname="sars-test-$$"
+  mkdir -p /tmp/airc-it-sars-h /tmp/airc-it-sars-j
+
+  # Host alpha in room mode (gh-free).
+  ( cd /tmp/airc-it-sars-h && AIRC_HOME=/tmp/airc-it-sars-h/state AIRC_NAME=alpha AIRC_PORT=7564 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room "$rname" > /tmp/airc-it-sars-h/out.log 2>&1 & )
+  local i
+  for i in 1 2 3 4 5; do
+    sleep 1
+    grep -q 'Hosting as' /tmp/airc-it-sars-h/out.log 2>/dev/null && break
+  done
+  grep -q 'Hosting as' /tmp/airc-it-sars-h/out.log \
+    && pass "alpha hosting #${rname}" \
+    || { fail "alpha did not start"; cleanup_all; return; }
+
+  local join; join=$(read_join_string /tmp/airc-it-sars-h)
+  [ -n "$join" ] || { fail "no join string from alpha"; cleanup_all; return; }
+
+  # Joiner beta pairs into the room (also writes room_name on disk).
+  ( cd /tmp/airc-it-sars-j && AIRC_HOME=/tmp/airc-it-sars-j/state AIRC_NAME=beta \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect "$join" > /tmp/airc-it-sars-j/out.log 2>&1 & )
+  for i in 1 2 3 4 5 6; do
+    sleep 1
+    grep -q 'Connected to' /tmp/airc-it-sars-j/out.log 2>/dev/null && break
+  done
+  grep -q 'Connected to' /tmp/airc-it-sars-j/out.log \
+    && pass "beta paired with alpha" \
+    || { fail "beta join failed"; cleanup_all; return; }
+
+  # Beta's resume path needs a saved room_name to pick the self-heal
+  # branch over the die branch. The non-discovery inline-invite join
+  # path doesn't write room_name — synthesize it the way a discovery
+  # join would. (Production discovery join always writes this.)
+  echo "$rname" > /tmp/airc-it-sars-j/state/room_name
+
+  # Stale-auth simulation: kill beta, regenerate beta's SSH key. Alpha's
+  # authorized_keys still has the OLD key, so any resume probe will get
+  # "Permission denied (publickey)" — which is the trigger for the
+  # self-heal we're testing.
+  AIRC_HOME=/tmp/airc-it-sars-j/state "$AIRC" teardown >/dev/null 2>&1
+  sleep 1
+  rm -f /tmp/airc-it-sars-j/state/identity/ssh_key \
+        /tmp/airc-it-sars-j/state/identity/ssh_key.pub
+  ssh-keygen -t ed25519 -f /tmp/airc-it-sars-j/state/identity/ssh_key \
+             -N '' -q -C 'airc-stale-sars' 2>/dev/null
+
+  # Resume. Pre-fix would die (exit 1). Post-fix: re-execs with
+  # --room ${rname}. AIRC_NO_DISCOVERY is NOT inherited across the
+  # re-exec, but with no real gh probe configured here the discovery
+  # path will silently no-op and fall through to host mode — beta
+  # becomes the new host of #${rname}. We just need to verify it
+  # DIDN'T die and DID land in the room.
+  local resume_out=/tmp/airc-it-sars-j-resume.out
+  local resume_err=/tmp/airc-it-sars-j-resume.err
+  ( AIRC_HOME=/tmp/airc-it-sars-j/state AIRC_PORT=7565 AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist >"$resume_out" 2>"$resume_err" ) &
+  local resume_pid=$!
+  local exited=0
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 1
+    grep -qE "Hosting #${rname}|Self-healing|Resume aborted" "$resume_out" "$resume_err" 2>/dev/null && break
+    kill -0 $resume_pid 2>/dev/null || { exited=1; break; }
+  done
+
+  grep -qE 'Self-healing: discarding stale pairing' "$resume_out" \
+    && pass "self-heal banner fires on stale-auth resume in room mode" \
+    || fail "self-heal banner missing (got: $(head -10 "$resume_out" "$resume_err" | tr '\n' '|'))"
+
+  ! grep -qE 'Resume aborted — re-pair required' "$resume_err" \
+    && pass "did NOT die with 'Resume aborted' (room-mode self-heal took over)" \
+    || fail "still died with Resume aborted despite saved room_name"
+
+  grep -qE "Hosting #${rname}" "$resume_out" \
+    && pass "beta self-healed into hosting #${rname}" \
+    || fail "beta did NOT land in #${rname} after self-heal (got: $(grep -E 'Hosting|Found' "$resume_out" | head -3 | tr '\n' '|'))"
+
+  # Identity must survive the re-exec (peer records preserved means
+  # any future re-pair recognizes us as the same beta, not a stranger).
+  [ -f /tmp/airc-it-sars-j/state/identity/ssh_key ] \
+    && pass "identity (ssh_key) survived self-heal re-exec" \
+    || fail "ssh_key wiped during self-heal"
+
+  # Cleanup the resume process + harness.
+  kill -9 $resume_pid 2>/dev/null
+  for f in /tmp/airc-it-sars-h/state/airc.pid /tmp/airc-it-sars-j/state/airc.pid; do
+    [ -f "$f" ] && kill -9 $(cat "$f") 2>/dev/null
+  done
+  sleep 1
+  rm -f "$resume_out" "$resume_err"
+  cleanup_all
+}
+
 case "$MODE" in
   tabs)         scenario_tabs  ;;
   scope)        scenario_scope ;;
@@ -1721,8 +1979,11 @@ case "$MODE" in
   heartbeat)    scenario_heartbeat ;;
   bounce)       scenario_bounce ;;
   two_tab_localhost) scenario_two_tab_localhost ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|all]"; exit 2 ;;
+  auto_scope)   scenario_auto_scope ;;
+  room_overrides_resume) scenario_room_overrides_resume ;;
+  stale_auth_room_selfheal) scenario_stale_auth_room_selfheal ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_room_overrides_resume; scenario_stale_auth_room_selfheal ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|room_overrides_resume|stale_auth_room_selfheal|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary

Three bugs in the `airc join` resume / discovery flow, all hit back-to-back in one session on 2026-04-26 (vhsm-2c84 dead host → auto-scope siloing into #general instead of #useideem → explicit `--room useideem` ignored after a part). They compound: each fix surfaces the next.

1. **Auto-scope re-enabled as default.** PR #104 gated git-org-derived rooms behind `AIRC_AUTO_SCOPE_ROOM=1` to avoid cross-project siloing, but the converse bug was worse — two tabs in the same `useideem/authenticator` checkout both fell back to `#general` instead of converging on `#useideem`. Re-default to auto-scope; opt out via `AIRC_NO_AUTO_ROOM=1` or `--room general`. Comment captures the trade-off.

2. **Explicit `--room` discards a stale saved pairing for a different room.** Pre-fix: `airc join --room foo` after pairing into #bar silently resumed #bar. Post-fix: when `--room` is explicit and saved `room_name` differs, wipe `CONFIG`/`room_name`/`room_gist_id` and fall through to discovery. Identity (ssh_key, peer records) survives.

3. **Stale-auth resume in room mode self-heals instead of dying.** Pre-fix: stale SSH keys (host reinstalled, authorized_keys rotated) died with `Resume aborted — re-pair required` and demanded `teardown --flush` + paste invite. Post-fix: with a saved `room_name` and gh available, wipe stale pair + re-exec with `--room <saved>` so discovery either finds a live host or we become the new host. The 1:1 invite path (no saved room) keeps die-loud behavior — there's nothing to fall through to.

All three changes live in the platform-agnostic decision layer — no new platform-specific code, so WSL / Git-Bash-on-Windows / POSIX share identical logic with zero divergence.

## Test plan
- [x] `bash test/integration.sh auto_scope` — 4/4 pass (banner fires, room takes effect, `AIRC_NO_AUTO_ROOM=1` opt-out works, falls back to `#general`)
- [x] `bash test/integration.sh room_overrides_resume` — 4/4 pass (discard banner, host new-room, no resume of deadhost, ssh_key preserved)
- [x] `bash test/integration.sh stale_auth_room_selfheal` — 6/6 pass (self-heal banner fires, doesn't die, lands in saved room, ssh_key survives re-exec)
- [x] `bash test/integration.sh resume_stale_auth` — existing scenario for the 1:1-invite die-path still passes (covers the no-saved-room branch we kept unchanged)
- [ ] WSL dogfood: bare `airc join` from a cloned repo lands in the org room, not `#general`
- [ ] Windows native PowerShell + Git Bash dogfood: same as WSL

🤖 Generated with [Claude Code](https://claude.com/claude-code)