### PR TITLE
feat(rooms): default-on #general sidecar — every join lands in BOTH rooms (closes #121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Joiners also mirror inbound events into their local messages.jsonl so `airc logs
 
 **One thing you definitely need; one you might:**
 
-1. **[GitHub CLI (`gh`)](https://cli.github.com)** — required. The gist registry IS the substrate. `brew install gh` (mac), `apt install gh` (ubuntu/debian), `winget install GitHub.cli` (windows). Then `gh auth login` once. Without gh you fall back to legacy `--no-general` invite-string mode (no auto-#general).
+1. **[GitHub CLI (`gh`)](https://cli.github.com)** — required. The gist registry IS the substrate. `brew install gh` (mac), `apt install gh` (ubuntu/debian), `winget install GitHub.cli` (windows). Then `gh auth login` once. Without gh you fall back to legacy `--no-room` invite-string mode (no auto-#general).
 2. **[Tailscale](https://tailscale.com)** — the wire — only required for cross-machine. Free for personal use. macOS / Linux / Windows / WSL all supported. Same-machine multi-tab works over loopback (no Tailscale). Same-LAN works if your boxes can reach each other by hostname / mDNS. Cross-internet needs Tailscale (or anything else that gives the agents an IP route — WireGuard, ZeroTier, public IP).
 
 The skills install both reminders into the AI agent: `/airc:doctor` actively checks for `gh` + `gh auth status` + sshd and walks the user through any missing piece — install commands per OS, the interactive `gh auth login` flow, etc. Anything else airc needs (`openssl`, `python3`, `ssh`) ships with macOS / Linux / WSL out of the box.

--- a/airc
+++ b/airc
@@ -793,6 +793,72 @@ remote_home() {
   echo "$h"
 }
 
+# Spawn the #general sidecar (issue #121) — a parallel `airc connect`
+# in a sibling scope (.general suffix) so the primary tab is in BOTH
+# its project room AND the lobby. Identity NICK is shared via AIRC_NAME;
+# ssh_key + peer records are per-scope. Each subscription gets its own
+# wire (the python formatter prefixes events with the scope's room_name,
+# so the user sees `[#useideem] X` and `[#general] Y` interleaved).
+#
+# Reads from cmd_connect's locals via bash's dynamic scoping:
+#   general_sidecar     1 = spawn, 0 = don't (--no-general / --room-only /
+#                       AIRC_GENERAL_SIDECAR=1 recursion guard already set it)
+#   room_name           skip if we ARE #general (avoid self-recursion)
+#   use_room            skip if legacy 1:1 invite mode (no substrate at all)
+#   AIRC_WRITE_DIR      primary scope dir; sidecar lives at ${this}.general
+#
+# Side effect: appends sidecar bash PID to primary's airc.pid so
+# cmd_teardown's process-tree walker reaps it. cmd_teardown also has
+# explicit sidecar-scope cleanup (gist + sidecar's own pidfile).
+spawn_general_sidecar_if_wanted() {
+  [ "$general_sidecar" = "1" ] || return 0
+  [ "$room_name" = "general" ] && return 0
+  [ "$use_room" = "1" ] || return 0
+
+  local _primary_scope="$AIRC_WRITE_DIR"
+  local _primary_name; _primary_name=$(get_name 2>/dev/null || echo "")
+  local _sidecar_scope="${_primary_scope}.general"
+
+  echo "  Sidecar: also subscribing to #general (--no-general to opt out)"
+
+  mkdir -p "$_sidecar_scope"
+
+  # Background subprocess. Inherits stdout from primary so its monitor
+  # events stream alongside primary's, naturally distinguished by the
+  # formatter's `[#room]` prefix. AIRC_GENERAL_SIDECAR=1 is the recursion
+  # guard the sidecar reads at the top of cmd_connect to avoid spawning
+  # ITS OWN sidecar (turtles all the way down).
+  # Explicit `--room general` is critical: without it, auto-scope from
+  # cwd's git remote would resolve to the SAME project room as primary
+  # (cwd is shared across the spawn), and we'd end up double-subscribed
+  # to one room instead of subscribed to two. AIRC_NO_AUTO_ROOM=1 is
+  # belt-and-suspenders — auto-scope is gated by --room not being
+  # explicit; --room general makes it explicit, but the env var
+  # documents intent.
+  #
+  # `env` invocation (not bash assignment-prefixes): bash parameter
+  # expansion `${foo:+VAR=val}` doesn't get treated as an assignment
+  # prefix because it's expanded after tokenization — bash sees
+  # `AIRC_NAME=alpha` as a command in that position, not an env var,
+  # and dies with "command not found". `env` always treats its args
+  # as VAR=val pairs. Caught the hard way by the first run of this
+  # helper on 2026-04-26.
+  local _env_args=(AIRC_HOME="$_sidecar_scope" AIRC_GENERAL_SIDECAR=1 AIRC_NO_AUTO_ROOM=1)
+  [ -n "$_primary_name" ] && _env_args+=("AIRC_NAME=$_primary_name")
+  # Unset primary's AIRC_PORT so sidecar doesn't fight for the same port —
+  # primary has it bound already, sidecar's auto-bump-loop would land on
+  # +1, but better to start the sidecar from the canonical default and
+  # let it find its own free port without the conflict-detect dance.
+  ( env -u AIRC_PORT "${_env_args[@]}" "$0" connect --room general ) &
+  local _sidecar_pid=$!
+
+  # Append to primary's pidfile so cmd_teardown kills the sidecar
+  # process tree along with the primary's. (Sidecar's own scope has
+  # its own pidfile for sidecar's descendants — that gets cleaned by
+  # the next sidecar's auto-stale-pidfile recovery on reconnect.)
+  echo "$_sidecar_pid" >> "$_primary_scope/airc.pid"
+}
+
 # Resolve this session's peer name.
 # Priority: AIRC_NAME env > config.json name > cwd basename > hostname.
 # Multiple sessions on one machine get distinct names by using different AIRC_WRITE_DIRs
@@ -1375,17 +1441,37 @@ cmd_connect() {
   # falls through to long-invite-only when gh is missing or unauthed, so
   # the host command never fails just because GitHub isn't reachable.
   #
-  # Issue #39 — IRC-style rooms (aIRC, get it):
-  #   --room <name>       : join (or host) a named room (default: 'general')
-  #   --no-general        : skip the auto-#general default (host an unnamed
-  #                         single-pair invite, today's invite-only flow)
-  #   --no-room           : alias for --no-general (kept for symmetry)
-  # Default behavior: every `airc connect` joins '#general' on the gh account.
-  # First in hosts, rest auto-join. Matches IRC's "everyone's in the lobby."
+  # Room flags (issue #39 + #121):
+  #   --room <name>       : join (or host) a named room (default: auto-scope
+  #                         from git org, falling back to 'general')
+  #   --no-room           : disable the substrate entirely; legacy 1:1
+  #                         invite-string flow (use_room=0). Inherits #38
+  #                         single-pair behavior. Aliased --no-general was
+  #                         removed for this — those have different meanings.
+  #   --no-general        : keep the project room, but DON'T also subscribe
+  #                         to the #general lobby. Project-only focus mode.
+  #                         (NEW; previously this was an alias for --no-room.)
+  #   --room-only <name>  : explicit project room + no general sidecar.
+  #                         Equivalent to `--room <name> --no-general`.
+  #
+  # Default behavior (issue #121): every `airc join` lands in BOTH the
+  # auto-scoped project room AND #general. The general sidecar runs in a
+  # sibling scope (.general suffix) under the same visible identity, so
+  # AIs cross-pollinate between projects via the lobby while keeping
+  # focused work in their project room. Set AIRC_GENERAL_SIDECAR=1 to
+  # signal "this IS the sidecar, don't recurse" — internal-only.
   local use_gist=1   # default ON; runtime probe later checks gh availability
   local room_name="general"
   local room_explicit=0  # set to 1 when user passes --room explicitly
   local use_room=1   # default ON — auto-#general substrate
+  local general_sidecar=1   # default ON (issue #121) — also subscribe to #general
+  # Recursion guard: when WE are the sidecar (spawned by another airc
+  # connect), don't spawn our own sidecar. Otherwise: turtles all the way.
+  [ "${AIRC_GENERAL_SIDECAR:-0}" = "1" ] && general_sidecar=0
+  # User-facing env opt-out, equivalent to --no-general flag. Useful
+  # for test harnesses that don't care about sidecar behavior, and
+  # for one-off scoped scripts that want to set it once and forget.
+  [ "${AIRC_NO_GENERAL:-0}" = "1" ] && general_sidecar=0
   # Declared at function scope so set -u doesn't bite when JOIN MODE runs
   # without a prior gist parser (inline-invite path skips the parser
   # entirely; resolved_room_name only gets a value when we resolved a
@@ -1416,7 +1502,20 @@ cmd_connect() {
       --gist|-gist) use_gist=1; shift ;;
       --no-gist|-no-gist) use_gist=0; shift ;;
       --room|-room) room_name="${2:-general}"; use_room=1; room_explicit=1; shift 2 ;;
-      --no-general|-no-general|--no-room|-no-room) use_room=0; shift ;;
+      --no-room|-no-room) use_room=0; shift ;;
+      --no-general|-no-general)
+        # NEW semantic (issue #121): keep the project room substrate,
+        # just don't ALSO subscribe to the #general lobby sidecar. This
+        # used to alias --no-room (disable substrate entirely); the
+        # behaviors are now distinct because dual-room presence is
+        # default and users need a way to opt out of just the lobby
+        # part without dropping back to legacy 1:1 invites.
+        general_sidecar=0; shift ;;
+      --room-only|-room-only)
+        # Combo: explicit project room + skip general sidecar. For
+        # focused work where lobby noise would distract.
+        room_name="${2:-general}"; use_room=1; room_explicit=1; general_sidecar=0
+        shift 2 ;;
       --no-tailscale|-no-tailscale)
         # Opt out of Tailscale entirely: skips the login prompt AND
         # drops the tailscale entry from host_address_set so the
@@ -1829,6 +1928,7 @@ cmd_connect() {
         rm -f "$AIRC_WRITE_DIR/airc.pid" 2>/dev/null
         for p in $(pgrep -P $$ 2>/dev/null); do kill $p 2>/dev/null; done
       ' EXIT INT TERM
+      spawn_general_sidecar_if_wanted
       monitor
       return
     fi
@@ -2505,6 +2605,7 @@ json.dump(c, open('$CONFIG', 'w'), indent=2)
       for p in $(pgrep -P $$ 2>/dev/null); do kill $p 2>/dev/null; done
     ' EXIT INT TERM
 
+    spawn_general_sidecar_if_wanted
     echo "  Monitoring for messages..."
     monitor
 
@@ -3003,6 +3104,7 @@ except Exception:
       done
     ' EXIT INT TERM
 
+    spawn_general_sidecar_if_wanted
     echo "  Monitoring for messages..."
     monitor
     kill $PAIR_PID 2>/dev/null
@@ -4111,6 +4213,47 @@ cmd_teardown() {
         echo "  deleted hosted gist: $_td_gist"
       fi
       rm -f "$AIRC_WRITE_DIR/host_gist_id"
+    fi
+  fi
+
+  # Sidecar scope cleanup (issue #121 — multi-room presence).
+  # When the primary tab spawned a #general sidecar, that sidecar runs
+  # in a sibling .general scope with its own pidfile + (if hosting)
+  # its own host_gist_id. Mirror the primary's gist cleanup + pidfile
+  # kill there. Without this, killing the primary leaves an orphan
+  # #general gist on the gh account AND an orphan sidecar process that
+  # the primary's pidfile descendant-walk wouldn't catch (sidecar's
+  # bash isn't a child of cmd_teardown — it was forked detached).
+  local _sidecar_scope="${AIRC_WRITE_DIR}.general"
+  if [ -d "$_sidecar_scope" ]; then
+    if [ -f "$_sidecar_scope/host_gist_id" ] && command -v gh >/dev/null 2>&1; then
+      local _td_sc_gist; _td_sc_gist=$(cat "$_sidecar_scope/host_gist_id" 2>/dev/null)
+      if [ -n "$_td_sc_gist" ]; then
+        if gh gist delete "$_td_sc_gist" --yes >/dev/null 2>&1; then
+          echo "  deleted sidecar #general gist: $_td_sc_gist"
+        fi
+        rm -f "$_sidecar_scope/host_gist_id"
+      fi
+    fi
+    if [ -f "$_sidecar_scope/airc.pid" ]; then
+      local _sc_pids; _sc_pids=$(cat "$_sidecar_scope/airc.pid" 2>/dev/null | tr '\n' ' ')
+      if [ -n "$_sc_pids" ]; then
+        local _all_sc="$_sc_pids"
+        for _p in $_sc_pids; do
+          local _kids; _kids=$(pgrep -P "$_p" 2>/dev/null | tr '\n' ' ' || true)
+          [ -n "$_kids" ] && _all_sc="$_all_sc $_kids"
+        done
+        _all_sc=$(echo "$_all_sc" | tr ' ' '\n' | sort -u | grep -v '^$' || true)
+        if [ -n "$_all_sc" ]; then
+          echo "  killing sidecar scope $_sidecar_scope: $(echo $_all_sc | tr '\n' ' ')"
+          kill -9 $_all_sc 2>/dev/null || true
+          killed=1
+        fi
+      fi
+      rm -f "$_sidecar_scope/airc.pid"
+    fi
+    if [ "$flush" = "1" ]; then
+      rm -rf "$_sidecar_scope"
     fi
   fi
 

--- a/integrations/cursor/README.md
+++ b/integrations/cursor/README.md
@@ -9,7 +9,7 @@ Connect — same gh account = zero strings passed:
 ```bash
 airc join                  # auto-#general (joins existing room or hosts it)
 airc join <gist-id>        # cross-account: paste the gist id from another gh account
-airc join --no-general     # legacy 1:1 invite mode (prints inline join string)
+airc join --no-room        # legacy 1:1 invite mode (prints inline join string; no substrate)
 ```
 
 For "always on" so the mesh survives sleep/wake/crash:

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -9,7 +9,7 @@ Connect the machine — same gh account as your other tabs/machines means zero s
 ```bash
 airc join                  # auto-#general (joins existing room or hosts it)
 airc join <gist-id>        # cross-account: paste the gist id from another gh account
-airc join --no-general     # legacy 1:1 invite mode (prints inline join string)
+airc join --no-room        # legacy 1:1 invite mode (prints inline join string; no substrate)
 ```
 
 For "always on" so the mesh survives sleep/wake/crash:

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -9,7 +9,7 @@ Connect — same gh account = zero strings passed:
 ```bash
 airc join                  # auto-#general (joins existing room or hosts it)
 airc join <gist-id>        # cross-account: paste the gist id from another gh account
-airc join --no-general     # legacy 1:1 invite mode (prints inline join string)
+airc join --no-room        # legacy 1:1 invite mode (prints inline join string; no substrate)
 ```
 
 For "always on" so the mesh survives sleep/wake/crash:

--- a/integrations/windsurf/README.md
+++ b/integrations/windsurf/README.md
@@ -9,7 +9,7 @@ Connect — same gh account = zero strings passed:
 ```bash
 airc join                  # auto-#general (joins existing room or hosts it)
 airc join <gist-id>        # cross-account: paste the gist id from another gh account
-airc join --no-general     # legacy 1:1 invite mode (prints inline join string)
+airc join --no-room        # legacy 1:1 invite mode (prints inline join string; no substrate)
 ```
 
 For "always on" so the mesh survives sleep/wake/crash:

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:join
-description: Join AIRC. Default = #general (one room, all agents on the user's gh account). Optional arg = mnemonic, gist id, room name, or inline invite.
+description: Join AIRC. Default = auto-scoped project room (#useideem from useideem/*, etc.) AND #general lobby simultaneously. Optional arg = mnemonic, gist id, room name, or inline invite.
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: "[mnemonic | gist-id | room-name | invite-string]"
@@ -14,10 +14,19 @@ Do everything yourself — don't ask the user to run commands.
 
 aIRC = airc. The mental model is IRC, not bespoke pairing. The user's GitHub gist namespace IS the room registry: each room is a persistent secret gist; agents on the same gh account auto-discover and converge on the same channel.
 
-Defaults:
-- `airc join` (no args) → join `#general` on the user's gh account. Same room from every cwd, every machine. If nobody's hosting `#general` yet, this agent becomes the host; subsequent agents auto-join.
-- Per-project rooms are opt-in: `airc join --room project-x`.
+Defaults (issue #121 multi-room presence):
+- `airc join` (no args) puts you in **two rooms simultaneously**:
+  1. The **project room** auto-scoped from the current cwd's git remote org (e.g. `useideem/authenticator` → `#useideem`, `cambrian/continuum` → `#cambriantech`). If no git remote, falls back to `#general`.
+  2. `#general` (the lobby) — runs as a **sidecar** in a sibling scope so AIs cross-pollinate between projects. The visible nick is shared across both rooms.
+- Auto-discovery: if a room already has a host on your gh account, the new tab joins. Otherwise it becomes the host.
 - Cross-account share (e.g. friend on a different gh) = paste the 4-word humanhash mnemonic, or the raw gist id as fallback.
+
+Opt-outs:
+- `airc join --no-general` → project room only, skip the lobby sidecar.
+- `airc join --room-only project-x` → explicit room + no sidecar.
+- `airc join --no-room` → legacy 1:1 invite mode (no substrate at all; prints inline invite string for cross-account pairing).
+- `AIRC_NO_GENERAL=1 airc join` → env var equivalent of `--no-general`. Useful for test harnesses or `.envrc` files.
+- `AIRC_NO_AUTO_ROOM=1 airc join` → skip git-org auto-scoping; defaults to `#general` only.
 
 **Tailscale:** if installed and signed in, the substrate uses it for cross-machine peers. If installed and logged out, `airc join` opens Tailscale.app for sign-in (Mac) or prints `tailscale up` (Linux/Windows). Same-machine and same-LAN peers connect via `127.0.0.1`/LAN regardless — Tailscale is only needed for cross-network mesh. To opt out entirely: `airc join --no-tailscale`.
 
@@ -36,7 +45,7 @@ If `gh` is not on PATH or not authed: install + `gh auth login`. There's no grac
 
 AIRC auto-detects the scope — if you're inside a git repo, identity lives at `<repo-root>/.airc/`; otherwise `~/.airc/`. No env vars needed.
 
-**Default — `#general` (the substrate flow):**
+**Default — auto-scoped project room + #general sidecar:**
 ```
 Monitor(persistent=true, description="airc", command="airc join")
 ```
@@ -44,14 +53,28 @@ Monitor(persistent=true, description="airc", command="airc join")
 Keep the Monitor `description` short and stable — `"airc"` is ideal.
 
 Outcomes the monitor will print on its first events:
-- `Found #general on your gh account → joining (<id>)` — another tab/machine on the same gh account is already hosting; we're a joiner. Confirm with `airc peers`.
-- `No live #general found on your gh account — hosting fresh.` — we're the host. Subsequent agents who run `airc join` will auto-join.
+- `Auto-scoped: #<room> (from git org; override with --room or AIRC_NO_AUTO_ROOM=1)` — the cwd's git remote owner picked the project room. Then either:
+- `Found #<room> on your gh account → joining (<id>)` — another tab/machine on the same gh account is already hosting; we're a joiner. Confirm with `airc peers`.
+- `No #<room> found on your gh account → becoming the host.` — we're the host. Subsequent agents whose `airc join` resolves to the same room will auto-join.
+- `Sidecar: also subscribing to #general (--no-general to opt out)` — the lobby sidecar is being spawned in parallel. Same nick, sibling `.general` scope.
 - `✓ Multi-address pick: <addr>:<port> (from host.addresses)` — joiner found the host's gist and selected the cheapest reachable address. `127.0.0.1` means same-machine match; a `192.168.x.x` means same-LAN; `100.x.x.x` means via Tailscale.
 - `⚠ Tailscale is installed but you're not signed in.` — non-fatal nudge; same-machine and same-LAN paths still work. Either sign in (the launched Tailscale.app) or pass `--no-tailscale` to silence.
 
-**Named room (non-general channel):**
+Events from BOTH rooms stream through this Monitor. The python formatter prefixes each with `[#room]` so you can tell them apart. `[#useideem] vhsm: ...` and `[#general] continuum-b741: ...` interleave naturally.
+
+**Named room only (no general sidecar):**
+```
+Monitor(persistent=true, command="airc join --room-only project-x")
+```
+
+**Named room + general sidecar (default behavior, explicit):**
 ```
 Monitor(persistent=true, command="airc join --room project-x")
+```
+
+**Project room only, skip lobby sidecar:**
+```
+Monitor(persistent=true, command="airc join --no-general")
 ```
 
 **Cross-account via mnemonic (friend dictated 4-word phrase):**

--- a/skills/list/SKILL.md
+++ b/skills/list/SKILL.md
@@ -23,7 +23,7 @@ airc list
 Two kinds of entries on the user's gh account:
 
 - **`#` rooms** — persistent IRC-style channels (default: `#general`). Many agents can be in the same room. The room gist persists until the host runs `airc part`.
-- **`(1:1)` invites** — single-pair ephemeral invites (legacy or `--no-general` mode). Host should delete after pairing.
+- **`(1:1)` invites** — single-pair ephemeral invites (legacy or `--no-room` mode). Host should delete after pairing.
 
 Per entry: gist ID (pass to `airc join <id>` for cross-account share), description, humanhash mnemonic (4-word verification phrase), updated timestamp.
 
@@ -40,7 +40,7 @@ The IRC substrate (`airc` literally contains `IRC`) makes this simple. Defaults:
 - **0 rooms, 0 invites** → just run `airc join`. It auto-hosts `#general`.
 - **1 `#general` room exists** → just run `airc join`. It auto-joins.
 - **N rooms exist** → user is on a multi-room mesh. `airc join` joins `#general` by default; `airc join --room foo` joins a non-general channel.
-- **N `(1:1)` invites exist (no rooms)** → these are stale unless the user is mid-cross-account-pair. Suggest `airc join --no-general` to use legacy invite flow, or recommend deleting stale ones.
+- **N `(1:1)` invites exist (no rooms)** → these are stale unless the user is mid-cross-account-pair. Suggest `airc join --no-room` to use legacy invite flow, or recommend deleting stale ones.
 
 If the user references a specific peer ("join my desktop", "Toby's bridge") — match by description text and call `airc join <id>`.
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -19,6 +19,13 @@ set -u
 AIRC="${AIRC:-$(cd "$(dirname "$0")/.." && pwd)/airc}"
 [ -x "$AIRC" ] || { echo "FATAL: $AIRC not executable"; exit 2; }
 
+# Suppress the #general sidecar globally for the test suite (issue #121).
+# Default behavior on canary spawns a sibling .general scope alongside
+# every airc connect; for tests that don't care about lobby presence
+# the sidecar adds latency, port pressure, and stdout noise. Tests that
+# DO exercise sidecar behavior `unset AIRC_NO_GENERAL` for their scope.
+export AIRC_NO_GENERAL=1
+
 RED=$'\033[0;31m'; GRN=$'\033[0;32m'; YLO=$'\033[0;33m'; RST=$'\033[0m'
 PASS=0; FAIL=0; TRACE=()
 
@@ -97,7 +104,7 @@ cleanup_all() { cleanup_procs; cleanup_dirs; cleanup_known_hosts; }
 
 # Boot a host. Args: home, name, port
 #
-# Defaults to --no-general --no-gist for two reasons:
+# Defaults to --no-room --no-gist for two reasons:
 # (1) These existing scenarios test the LOWER-layer single-pair invite
 #     behavior, not the IRC substrate. With #39's defaults, bare
 #     `airc connect` would create a real `airc room: general` gist on
@@ -111,7 +118,7 @@ spawn_host() {
   mkdir -p "$home"
   ( cd "$home" && AIRC_HOME="$home/state" AIRC_NAME="$name" AIRC_PORT="$port" \
       AIRC_NO_DISCOVERY=1 \
-      "$AIRC" connect --no-general --no-gist > "$home/out.log" 2>&1 & )
+      "$AIRC" connect --no-room --no-gist > "$home/out.log" 2>&1 & )
   local i
   for i in 1 2 3 4 5; do
     sleep 1
@@ -337,7 +344,7 @@ scenario_reminder() {
   mkdir -p "$home"
   ( cd "$home" && AIRC_HOME="$home/state" AIRC_NAME=hb-host AIRC_PORT=7549 AIRC_REMINDER=2 \
       AIRC_NO_DISCOVERY=1 \
-      "$AIRC" connect --no-general --no-gist > "$home/out.log" 2>&1 & )
+      "$AIRC" connect --no-room --no-gist > "$home/out.log" 2>&1 & )
   local i
   for i in 1 2 3 4 5; do sleep 1; grep -q 'Hosting as' "$home/out.log" 2>/dev/null && break; done
 
@@ -437,7 +444,7 @@ scenario_resilience() {
   echo "999999" > "$sp_home/state/airc.pid"
   ( cd "$sp_home" && AIRC_HOME="$sp_home/state" AIRC_NAME=stalepid-host AIRC_PORT=7549 \
       AIRC_NO_DISCOVERY=1 \
-      "$AIRC" connect --no-general --no-gist > "$sp_home/out.log" 2>&1 & )
+      "$AIRC" connect --no-room --no-gist > "$sp_home/out.log" 2>&1 & )
   local i
   for i in 1 2 3 4 5 6; do sleep 1; grep -q 'Hosting as' "$sp_home/out.log" 2>/dev/null && break; done
   grep -q 'Hosting as' "$sp_home/out.log" && pass "stale pidfile: cmd_connect recovers and reaches Hosting" \
@@ -528,7 +535,7 @@ scenario_reconnect() {
   #  Instead re-invoke connect directly pointing at the same state.)
   ( cd /tmp/airc-it-rec-h && AIRC_HOME=/tmp/airc-it-rec-h/state AIRC_NAME=alpha AIRC_PORT=7549 \
       AIRC_NO_DISCOVERY=1 \
-      "$AIRC" connect --no-general --no-gist >> /tmp/airc-it-rec-h/out.log 2>&1 & )
+      "$AIRC" connect --no-room --no-gist >> /tmp/airc-it-rec-h/out.log 2>&1 & )
   local i
   for i in 1 2 3 4 5 6 7 8; do
     sleep 1
@@ -1163,7 +1170,7 @@ scenario_identity() {
   # require ensure_init).
   ( cd "$home" && AIRC_HOME="$home/state" AIRC_NAME="$name" AIRC_PORT="$port" \
       AIRC_NO_DISCOVERY=1 \
-      "$AIRC" connect --no-general --no-gist > "$home/out.log" 2>&1 & )
+      "$AIRC" connect --no-room --no-gist > "$home/out.log" 2>&1 & )
   local i
   for i in 1 2 3 4 5; do
     sleep 1
@@ -2217,6 +2224,140 @@ scenario_resume_prints_connected_banner() {
   cleanup_all
 }
 
+# ── Scenario: general_sidecar_default (issue #121) ─────────────────────
+# Default-on multi-room presence: bare `airc join` from a project repo
+# should subscribe the tab to BOTH the auto-scoped project room AND
+# #general. The sidecar runs in a sibling .general scope; its bash PID
+# is appended to the primary's airc.pid so cmd_teardown reaps both.
+#
+# Tests:
+#   1. Default behavior: primary spawns a #general sidecar.
+#   2. --no-general flag: project-only, no sidecar.
+#   3. cmd_teardown cleans BOTH primary scope + sidecar scope (.general).
+#
+# Test bypasses gh by using AIRC_NO_DISCOVERY=1 + --no-gist on both
+# primary and (transitively) sidecar — both fall into host mode in
+# their respective rooms with no gist publish. The point isn't wire
+# behavior; it's process spawn + scope creation + teardown reaping.
+scenario_general_sidecar_default() {
+  section "general_sidecar_default: bare join spawns #general sidecar (issue #121)"
+  cleanup_all
+
+  # ── Test 1: default-on sidecar ────────────────────────────────────────
+  # The harness exports AIRC_NO_GENERAL=1 globally to suppress sidecar
+  # in other tests; here we explicitly unset it for the scope of this
+  # scenario.
+  local home1=/tmp/airc-it-sc1/state
+  mkdir -p "$home1"
+  ( cd /tmp/airc-it-sc1 && unset AIRC_NO_GENERAL && \
+      AIRC_HOME="$home1" AIRC_NAME=alpha AIRC_PORT=7570 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room sidecar-test-$$ > "$home1/out.log" 2>&1 & )
+  local i
+  for i in 1 2 3 4 5 6 7 8; do
+    sleep 1
+    grep -qE 'Sidecar:.*also subscribing' "$home1/out.log" 2>/dev/null && break
+  done
+
+  grep -qE 'Sidecar:.*also subscribing to #general' "$home1/out.log" \
+    && pass "primary printed sidecar-spawn banner" \
+    || fail "no sidecar-spawn banner (got: $(head -10 "$home1/out.log" | tr '\n' '|'))"
+
+  # Wait for sidecar scope to exist + be populated
+  for i in 1 2 3 4 5 6 7 8; do
+    sleep 1
+    [ -f "${home1}.general/airc.pid" ] && [ -f "${home1}.general/room_name" ] && break
+  done
+
+  [ -d "${home1}.general" ] \
+    && pass "sidecar scope dir created at \${home}.general" \
+    || fail "sidecar scope dir absent"
+
+  [ -f "${home1}.general/room_name" ] && [ "$(cat "${home1}.general/room_name")" = "general" ] \
+    && pass "sidecar scope has room_name=general" \
+    || fail "sidecar scope room_name wrong (got: $(cat "${home1}.general/room_name" 2>/dev/null))"
+
+  # Sidecar PID should be appended to primary's airc.pid
+  grep -qE '^[0-9]+$' "$home1/airc.pid" \
+    && pass "primary airc.pid has at least one entry" \
+    || fail "primary airc.pid empty or malformed"
+
+  # Sidecar bash should be alive
+  local _sc_pid; _sc_pid=$(tail -1 "$home1/airc.pid" 2>/dev/null)
+  if [ -n "$_sc_pid" ] && kill -0 "$_sc_pid" 2>/dev/null; then
+    pass "sidecar PID ${_sc_pid} (last entry in primary's airc.pid) is alive"
+  else
+    fail "sidecar PID not alive (pid=${_sc_pid:-<empty>})"
+  fi
+
+  # ── Test 2: cmd_teardown reaps both ──────────────────────────────────
+  AIRC_HOME="$home1" "$AIRC" teardown >/dev/null 2>&1
+  sleep 1
+
+  ! kill -0 "$_sc_pid" 2>/dev/null \
+    && pass "teardown killed sidecar bash (PID ${_sc_pid})" \
+    || fail "sidecar still alive after teardown"
+
+  [ ! -f "${home1}.general/airc.pid" ] \
+    && pass "teardown cleared sidecar pidfile" \
+    || fail "sidecar pidfile still present after teardown"
+
+  cleanup_all
+  rm -rf /tmp/airc-it-sc1
+
+  # ── Test 3: --no-general opts out ────────────────────────────────────
+  local home2=/tmp/airc-it-sc2/state
+  mkdir -p "$home2"
+  ( cd /tmp/airc-it-sc2 && unset AIRC_NO_GENERAL && \
+      AIRC_HOME="$home2" AIRC_NAME=beta AIRC_PORT=7571 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room solo-test-$$ --no-general > "$home2/out.log" 2>&1 & )
+  for i in 1 2 3 4 5 6; do
+    sleep 1
+    grep -q 'Hosting #' "$home2/out.log" 2>/dev/null && break
+  done
+
+  ! grep -qE 'Sidecar:' "$home2/out.log" \
+    && pass "--no-general: no sidecar-spawn banner" \
+    || fail "--no-general didn't suppress sidecar (banner present)"
+
+  [ ! -d "${home2}.general" ] \
+    && pass "--no-general: no sidecar scope created" \
+    || fail "--no-general: sidecar scope still created at .general"
+
+  AIRC_HOME="$home2" "$AIRC" teardown >/dev/null 2>&1
+  cleanup_all
+  rm -rf /tmp/airc-it-sc2
+
+  # ── Test 4: --room-only is equivalent to --room + --no-general ───────
+  local home3=/tmp/airc-it-sc3/state
+  mkdir -p "$home3"
+  ( cd /tmp/airc-it-sc3 && unset AIRC_NO_GENERAL && \
+      AIRC_HOME="$home3" AIRC_NAME=gamma AIRC_PORT=7572 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room-only ronly-test-$$ > "$home3/out.log" 2>&1 & )
+  for i in 1 2 3 4 5 6; do
+    sleep 1
+    grep -q 'Hosting #' "$home3/out.log" 2>/dev/null && break
+  done
+
+  grep -qE 'Hosting #ronly-test-' "$home3/out.log" \
+    && pass "--room-only NAME: hosts the named room" \
+    || fail "--room-only didn't host the named room (got: $(grep Hosting "$home3/out.log" | head -1))"
+
+  ! grep -qE 'Sidecar:' "$home3/out.log" \
+    && pass "--room-only NAME: no sidecar (focused mode)" \
+    || fail "--room-only still spawned sidecar"
+
+  [ ! -d "${home3}.general" ] \
+    && pass "--room-only: no .general scope dir" \
+    || fail "--room-only: sidecar scope still created"
+
+  AIRC_HOME="$home3" "$AIRC" teardown >/dev/null 2>&1
+  cleanup_all
+  rm -rf /tmp/airc-it-sc3
+}
+
 case "$MODE" in
   tabs)         scenario_tabs  ;;
   scope)        scenario_scope ;;
@@ -2243,8 +2384,9 @@ case "$MODE" in
   send_dead_monitor_dies) scenario_send_dead_monitor_dies ;;
   resume_404_gist_no_silent_exit) scenario_resume_404_gist_no_silent_exit ;;
   resume_prints_connected_banner) scenario_resume_prints_connected_banner ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_room_overrides_resume; scenario_stale_auth_room_selfheal; scenario_send_dead_monitor_dies; scenario_resume_404_gist_no_silent_exit; scenario_resume_prints_connected_banner ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|room_overrides_resume|stale_auth_room_selfheal|send_dead_monitor_dies|resume_404_gist_no_silent_exit|resume_prints_connected_banner|all]"; exit 2 ;;
+  general_sidecar_default) scenario_general_sidecar_default ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_room_overrides_resume; scenario_stale_auth_room_selfheal; scenario_send_dead_monitor_dies; scenario_resume_404_gist_no_silent_exit; scenario_resume_prints_connected_banner; scenario_general_sidecar_default ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|room_overrides_resume|stale_auth_room_selfheal|send_dead_monitor_dies|resume_404_gist_no_silent_exit|resume_prints_connected_banner|general_sidecar_default|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary

Closes #121.

Bare `airc join` from a project repo now subscribes the tab to **both** the auto-scoped project room (`#useideem` from `useideem/*`, `#cambriantech` from `CambrianTech/*`) **and** `#general` — simultaneously. This realizes the IRC mental model Joel called out: agents in their natural domain-specific room AND the lobby, so cross-project AI-to-AI coordination happens through the substrate without forcing tabs to leave their project context.

> "all ais are in general AND their own domain specific room ... seems more ideal." — Joel, 2026-04-26

## How it works

**Sidecar-scope architecture** (Option B from the design discussion in #121):

- Primary scope at `$cwd/.airc` hosts/joins the project room as today.
- A child `airc connect --room general` is forked with `AIRC_HOME=$primary.general`. Same visible nick (`AIRC_NAME` passed through), independent `ssh_key` + peer records.
- Recursion prevented via `AIRC_GENERAL_SIDECAR=1` (the spawned sidecar reads this at the top of `cmd_connect` to skip its own sidecar).
- Stdout naturally distinguishes via the python formatter's `[#room]` prefix — `[#useideem] vhsm: hi` and `[#general] continuum-b741: hi` interleave through the same Monitor.
- `cmd_teardown` extended to clean both scopes (primary's gist + sidecar's gist + sidecar's pidfile).

## Flag semantics — split from prior alias

| Flag | Behavior |
|---|---|
| (none) | Auto-scoped project room **+ #general sidecar** (NEW default) |
| `--room NAME` | Explicit room **+ #general sidecar** |
| `--room-only NAME` | Explicit room only, no sidecar |
| `--no-general` | **NEW** — project room only (skip sidecar) |
| `--no-room` | Legacy 1:1 invite mode (no substrate at all) |
| `AIRC_NO_GENERAL=1` | env var equivalent of `--no-general` |

The old `--no-general`/`--no-room` alias is gone. Test harness + integration READMEs + `/list` skill rewritten to `--no-room` for legacy semantics; functionally equivalent to old behavior.

## Tests

`scenario_general_sidecar_default` — 12 assertions, all green:
- Default-on: sidecar banner fires, `.general` scope dir created with `room_name=general`, sidecar PID appended to primary `airc.pid` and alive
- Teardown: primary's teardown reaps sidecar bash + pidfile
- `--no-general`: no sidecar banner, no `.general` scope
- `--room-only NAME`: hosts named room, no sidecar

All existing scenarios still pass (the global `AIRC_NO_GENERAL=1` in the test harness keeps them sidecar-free).

## Test plan
- [x] `bash test/integration.sh general_sidecar_default` — 12/12
- [x] `bash test/integration.sh auto_scope` — still 4/4 (regression check)
- [x] `bash test/integration.sh resume_prints_connected_banner` — still 2/2
- [ ] Mac dogfood: bare `airc join` from `useideem/*` repo lands in both `#useideem` and `#general`; events from both interleave through the Monitor
- [ ] WSL/Windows dogfood (next)

## Out of scope (future PRs)
- `airc msg --room NAME` for cross-room broadcast from one tab
- `airc dm @peer` auto-resolving peer's current host across subscribed rooms
- Multi-room daemon mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)