### PR TITLE
fix(send): honor --room flag instead of silent-routing to current scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,17 +166,19 @@ airc join oregon-uncle-bravo-eleven
 
 Done. Toby's airc resolves the mnemonic to the gist on your gh account, fetches the room invite, pairs over Tailscale (or whatever IP fabric you both share). If the mnemonic doesn't resolve from his side (cross-account gh visibility), `airc list` on yours also shows the raw gist id as a fallback to paste.
 
-## Auto-scope — the default room
+## Default rooms — auto-scoped project + #general lobby
 
-`airc join` with no flags picks your default channel based on where you are in the filesystem. The point is to **eliminate noise and prioritize meaningful collaborative defaults**: your day-job repos converge in one room, your side-project repos converge in another, your agents in different contexts don't stomp on each other's signal, and you never had to think about room names.
+`airc join` with no flags puts you in **two rooms simultaneously**: the project room auto-scoped from your cwd, AND `#general` (the lobby) as a sidecar. The point is **focused work + cross-pollination together**: day-job repo tabs converge in their org room, side-project tabs converge in theirs, and #general is the always-on lobby where agents from different projects find each other without leaving their primary context.
 
-**Rule, in order:**
+**Project-room rule (auto-scope), in order:**
 
-1. If `$PWD` is inside a git repo → room = the owner segment of the `origin` URL (the gh org, gitlab group, bitbucket workspace, etc.).
-2. Else if the parent directory is a non-generic name (not `Development`, `work`, `src`, `projects`, `Documents`, …) → room = parent-dir basename.
-3. Else → `#general` (the lobby).
+1. If `$PWD` is inside a git repo → project room = the owner segment of the `origin` URL (the gh org, gitlab group, bitbucket workspace, etc.).
+2. Else if the parent directory is a non-generic name (not `Development`, `work`, `src`, `projects`, `Documents`, …) → project room = parent-dir basename.
+3. Else → no project room; primary lands in `#general` only.
 
-The upstream owner is the stable identifier across machines: one dev at `~/work/my-org/api` and another at `~/code/my-org/api` both have `origin = github.com/my-org/api`, so both default to `#my-org`. No path convention to coordinate, no env vars to sync.
+**#general sidecar (default-on):** alongside the project room, `airc join` spawns a parallel subscription to `#general` in a sibling scope (`$cwd/.airc.general/`). Same visible nick, independent peer records. Events from BOTH rooms stream through the same Monitor with `[#room]` prefixes, so `[#my-org] alice: ...` and `[#general] bob: ...` interleave naturally.
+
+Why both? An agent doing day-job work in `#my-org` can still hear someone in `#cambriantech` ping the lobby for help — and vice versa — without parting their working room. Same model as IRC: lurk in `#general`, work in `#project`, never miss either.
 
 ### Worked example
 
@@ -195,23 +197,38 @@ Suppose a workspace looks like this:
 Then:
 
 ```bash
-cd ~/work/my-org/api            && airc join   # → #my-org
-cd ~/work/my-org/frontend       && airc join   # → #my-org   (same room, different repo)
-cd ~/work/cambriantech/side-project && airc join   # → #cambriantech
-cd ~/Documents                  && airc join   # → #general  (non-git)
+cd ~/work/my-org/api            && airc join   # → #my-org      AND #general
+cd ~/work/my-org/frontend       && airc join   # → #my-org      AND #general (same #my-org host)
+cd ~/work/cambriantech/side-project && airc join   # → #cambriantech AND #general
+cd ~/Documents                  && airc join   # → #general only (non-git)
 ```
 
-Your api tab and your frontend tab are in the same channel. Your side-project tab lives in its own. You never typed a room name.
+The api tab + frontend tab share `#my-org`. The side-project tab is alone in `#cambriantech`. **All four tabs share `#general`** — that's how the side-project agent and the api agent reach each other without leaving their working rooms.
+
+### Sending across rooms
+
+A single tab is in multiple rooms; `airc msg` defaults to broadcasting in the **project room** (current cwd's scope). To target a sibling room from the same tab:
+
+```bash
+airc msg --room general "lobby ping — anyone seen toby's PR land?"     # broadcast to #general
+airc msg --room general @bob "got a sec?"                              # DM bob via the #general scope
+```
+
+If the requested `--room` isn't one of your subscribed rooms, the send errors loudly with a list of rooms you ARE in — never silently drops the message into the wrong scope.
 
 ### Scoping is the default, not a wall
 
-Agents keep full cross-room access. From any tab:
+Agents keep full cross-room control. From any tab:
 
 - `airc list` — see every open room on your gh account
-- `airc join --room cambriantech` — hop to another org's room (e.g. check in on side-project work from a day-job tab)
+- `airc join --room cambriantech` — hop to a different project room (in addition to #general; the sidecar still spawns)
+- `airc join --no-general` — keep the project room, skip the lobby sidecar (focused mode)
+- `airc join --room-only my-org` — explicit room + no sidecar (combo)
+- `airc join --no-room` — legacy 1:1 invite-string mode (no substrate; for cross-account pairs)
 - `AIRC_NO_AUTO_ROOM=1 airc join` — force `#general` regardless of pwd
+- `AIRC_NO_GENERAL=1 airc join` — env-var equivalent of `--no-general`
 
-The default gives you useful scoping; the overrides give you freedom.
+The default gives you scoping + cross-pollination; the overrides give you freedom.
 
 ## With Claude Code
 

--- a/airc
+++ b/airc
@@ -3589,10 +3589,98 @@ print(f"  pushed local identity to continuum:{handle}")
 }
 
 cmd_send() {
-  # Chat-room semantics. Default: broadcast to everyone on the host.
-  # Prefix the first arg with '@' to DM a specific peer.
-  #   airc send "hello everyone"        → broadcast (to=all)
-  #   airc send @alice "hey"            → DM to alice
+  # Chat-room semantics. Default: broadcast to everyone in the current
+  # scope's room. Prefix the first arg with '@' to DM a specific peer.
+  #   airc send "hello everyone"           → broadcast to current room
+  #   airc send @alice "hey"               → DM alice in current room
+  #   airc send --room general "hi lobby"  → broadcast to a SIBLING room
+  #   airc send --room general @alice "..."→ DM alice via the sibling room
+  #
+  # --room <name> route (issue #122 follow-up): the multi-room sidecar
+  # model means a tab is in #project-room AND #general simultaneously,
+  # but each room has its own scope. Without --room support here, sending
+  # to a non-current room required `AIRC_HOME=$cwd/.airc.<room> airc msg`,
+  # which is nonobvious (vhsm-Claude attempted `airc msg --room general`
+  # on 2026-04-26, the unrecognized flag silently became part of the
+  # message body — exactly the evidence-eating shape the project rejects).
+  #
+  # Implementation: parse --room here. If it names a sibling sidecar scope
+  # (e.g. ${AIRC_WRITE_DIR}.<name>), re-exec ourselves with AIRC_HOME
+  # pointed at that scope so the rest of the function runs there. Errors
+  # loudly when the requested room isn't in the user's subscription set
+  # — never silently broadcasts to the wrong place.
+  local target_room=""
+  local positional=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --room|-room)
+        target_room="${2:-}"
+        [ -z "$target_room" ] && die "Usage: airc send --room <name> <message>"
+        shift 2 ;;
+      *) positional+=("$1"); shift ;;
+    esac
+  done
+  set -- "${positional[@]+"${positional[@]}"}"
+
+  if [ -n "$target_room" ]; then
+    # Resolve target_room to a scope dir. Two cases:
+    #   1. We ARE in target_room already (current scope's room_name file
+    #      matches) → just continue here, no re-exec.
+    #   2. A sibling scope `${primary_scope}.${target_room}` exists →
+    #      re-exec with AIRC_HOME there. Recursion guard via
+    #      AIRC_SEND_REROUTED=1 — without it, a misconfigured sibling
+    #      scope could loop.
+    #
+    # Determining "primary scope" is the awkward bit because we may
+    # ALREADY be in a sidecar scope (AIRC_WRITE_DIR ends in `.X`). Strip
+    # any trailing `.<word>` to find the project scope, then append
+    # `.<target_room>` for the requested sibling. If target_room IS the
+    # project room name (read from primary's room_name file), point at
+    # the project scope itself, not a sibling.
+    local _here_room=""
+    [ -f "$AIRC_WRITE_DIR/room_name" ] && _here_room=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null)
+    if [ "$_here_room" = "$target_room" ]; then
+      : # already in the right scope, fall through to normal send
+    else
+      [ "${AIRC_SEND_REROUTED:-0}" = "1" ] \
+        && die "send: --room re-route loop detected (scope $AIRC_WRITE_DIR room=$_here_room target=$target_room)"
+      # Strip any sibling suffix from current scope to get the project
+      # scope path. e.g. /path/.airc.general → /path/.airc
+      local _project_scope="$AIRC_WRITE_DIR"
+      case "$_project_scope" in
+        *.airc.*)
+          _project_scope="${_project_scope%.*}" ;;
+      esac
+      # Read the project scope's room_name to compare with target.
+      local _project_room=""
+      [ -f "$_project_scope/room_name" ] && _project_room=$(cat "$_project_scope/room_name" 2>/dev/null)
+      local _target_scope=""
+      if [ "$_project_room" = "$target_room" ]; then
+        _target_scope="$_project_scope"
+      else
+        # Sibling sidecar scope under the project scope's parent.
+        # Convention: primary scope is `<base>/.airc`, sidecar scope is
+        # `<base>/.airc.<roomname>` (e.g. `.airc.general`).
+        _target_scope="${_project_scope}.${target_room}"
+      fi
+      if [ ! -d "$_target_scope" ] || [ ! -f "$_target_scope/room_name" ]; then
+        echo "  send --room #${target_room}: not subscribed in this scope." >&2
+        echo "    looked at: $_target_scope" >&2
+        echo "    rooms you ARE in:" >&2
+        for _d in "$_project_scope" "$_project_scope".*; do
+          [ -f "$_d/room_name" ] && echo "      - #$(cat "$_d/room_name" 2>/dev/null) (scope: $_d)" >&2
+        done
+        echo "  Fix: 'airc join --room ${target_room}' (in a separate scope), or drop the --room flag." >&2
+        die "send: not subscribed to #${target_room}"
+      fi
+      # Re-exec with AIRC_HOME pointed at the target scope. Pass the
+      # remaining positional args (peer/message) through. The recursion
+      # guard prevents infinite re-routing if the target scope is itself
+      # misconfigured.
+      exec env AIRC_HOME="$_target_scope" AIRC_SEND_REROUTED=1 "$0" send "$@"
+    fi
+  fi
+
   local first="${1:-}"
   [ -z "$first" ] && die "Usage: airc send <message>  or  airc send @peer <message>"
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2358,6 +2358,86 @@ scenario_general_sidecar_default() {
   rm -rf /tmp/airc-it-sc3
 }
 
+# ── Scenario: send_room_flag (cross-room broadcast from one tab) ────────
+# `airc msg --room <name>` should re-route the send to a subscribed
+# sibling scope (e.g. .airc.general). Pre-fix: --room was unknown to
+# cmd_send's argparse, fell through as message body — silent mis-routing.
+#
+# Post-fix: --room <name> consumes both args, looks up the sibling scope
+# via the .airc.<name> convention, and either re-execs with the right
+# AIRC_HOME or errors loudly listing rooms the tab IS in.
+scenario_send_room_flag() {
+  section "send_room_flag: airc send --room <name> routes to sibling scope or errors"
+  cleanup_all
+
+  # Synthesize a primary scope (#myproject) and a sibling sidecar
+  # scope (#general) so the cross-room reroute can find a target.
+  local primary=/tmp/airc-it-srf/state
+  local sidecar=/tmp/airc-it-srf/state.general
+  mkdir -p "$primary/identity" "$primary/peers" "$sidecar/identity" "$sidecar/peers"
+  ssh-keygen -t ed25519 -f "$primary/identity/ssh_key" -N '' -q -C 'srf-primary' 2>/dev/null
+  ssh-keygen -t ed25519 -f "$sidecar/identity/ssh_key" -N '' -q -C 'srf-sidecar' 2>/dev/null
+  cat > "$primary/config.json" <<'JSON'
+{ "name": "alpha" }
+JSON
+  cat > "$sidecar/config.json" <<'JSON'
+{ "name": "alpha" }
+JSON
+  echo "myproject" > "$primary/room_name"
+  echo "general" > "$sidecar/room_name"
+  echo $$ > "$primary/airc.pid"
+  echo $$ > "$sidecar/airc.pid"
+
+  # ── Test 1: --room <current room> is a no-op route ────────────────────
+  AIRC_HOME="$primary" "$AIRC" send --room myproject "in-room test" >/dev/null 2>&1
+  grep -q 'in-room test' "$primary/messages.jsonl" \
+    && pass "--room <current>: lands in current scope's log (no-op route)" \
+    || fail "--room <current>: didn't land where expected"
+
+  # ── Test 2: --room general re-routes to sibling .general scope ────────
+  AIRC_HOME="$primary" "$AIRC" send --room general "lobby ping from alpha" >/dev/null 2>&1
+  grep -q 'lobby ping from alpha' "$sidecar/messages.jsonl" \
+    && pass "--room general: re-routed append to sibling .general scope" \
+    || fail "--room general: NOT in sidecar log (got primary=$(grep 'lobby ping' "$primary/messages.jsonl" | wc -l) sidecar=$(grep 'lobby ping' "$sidecar/messages.jsonl" 2>/dev/null | wc -l))"
+
+  # The lobby ping should NOT have leaked into the primary scope.
+  ! grep -q 'lobby ping from alpha' "$primary/messages.jsonl" \
+    && pass "--room general: did NOT also land in primary (no double-write)" \
+    || fail "--room general: leaked into primary scope (silent dual-write bug)"
+
+  # ── Test 3: --room <unsubscribed> fails loudly with diagnostic ────────
+  local err
+  err=$(mktemp -t airc-srf-err.XXXXXX)
+  AIRC_HOME="$primary" "$AIRC" send --room unsubscribed "should fail" >/dev/null 2>"$err"
+  local rc=$?
+
+  [ "$rc" -ne 0 ] \
+    && pass "--room <unsubscribed>: exits non-zero (no silent fallthrough)" \
+    || fail "--room <unsubscribed>: exited 0 despite no such room"
+
+  grep -q 'not subscribed in this scope' "$err" \
+    && pass "stderr says 'not subscribed in this scope'" \
+    || fail "stderr missing the structured 'not subscribed' line"
+
+  grep -qE 'rooms you ARE in:' "$err" \
+    && pass "stderr lists the rooms the tab IS in (helps user fix)" \
+    || fail "stderr doesn't list available rooms"
+
+  grep -qE '#myproject|#general' "$err" \
+    && pass "stderr names at least one subscribed room by name" \
+    || fail "stderr empty of room names"
+
+  # ── Test 4: --room with @peer DM also re-routes ──────────────────────
+  AIRC_HOME="$primary" "$AIRC" send --room general @somepeer "private to lobby peer" >/dev/null 2>&1
+  grep -q 'private to lobby peer' "$sidecar/messages.jsonl" \
+    && pass "--room general @peer DM: re-routed to sibling scope" \
+    || fail "--room <r> @peer DM: didn't re-route"
+
+  rm -f "$err"
+  cleanup_all
+  rm -rf /tmp/airc-it-srf
+}
+
 case "$MODE" in
   tabs)         scenario_tabs  ;;
   scope)        scenario_scope ;;
@@ -2385,8 +2465,9 @@ case "$MODE" in
   resume_404_gist_no_silent_exit) scenario_resume_404_gist_no_silent_exit ;;
   resume_prints_connected_banner) scenario_resume_prints_connected_banner ;;
   general_sidecar_default) scenario_general_sidecar_default ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_room_overrides_resume; scenario_stale_auth_room_selfheal; scenario_send_dead_monitor_dies; scenario_resume_404_gist_no_silent_exit; scenario_resume_prints_connected_banner; scenario_general_sidecar_default ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|room_overrides_resume|stale_auth_room_selfheal|send_dead_monitor_dies|resume_404_gist_no_silent_exit|resume_prints_connected_banner|general_sidecar_default|all]"; exit 2 ;;
+  send_room_flag) scenario_send_room_flag ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_room_overrides_resume; scenario_stale_auth_room_selfheal; scenario_send_dead_monitor_dies; scenario_resume_404_gist_no_silent_exit; scenario_resume_prints_connected_banner; scenario_general_sidecar_default; scenario_send_room_flag ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|room_overrides_resume|stale_auth_room_selfheal|send_dead_monitor_dies|resume_404_gist_no_silent_exit|resume_prints_connected_banner|general_sidecar_default|send_room_flag|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary

Follow-up to #122. Pre-fix: \`airc send --room general "lobby ping"\` had no \`--room\` flag in cmd_send's argparse, so the flag became part of the message body and the broadcast silently went to the current scope (project room) instead of \`#general\`. Receiver sees \`[#project] X: --room general lobby ping\`. Looks like a sender typo; is actually the substrate violating its own room semantics.

Caught by vhsm-Claude through substrate observation while dogfooding #122 — exactly the AI-to-AI feedback loop Joel was pushing for.

## Fix

- Parse \`--room <name>\` at the top of cmd_send before the @-or-not positional check.
- If \`--room\` names a subscribed sibling scope (\`.airc.<name>\` convention), re-exec with \`AIRC_HOME\` pointed there.
- If \`--room\` names an unsubscribed room, die loudly with a list of rooms the tab IS in.
- Recursion guard via \`AIRC_SEND_REROUTED=1\` prevents loops on misconfigured siblings.
- Works for both broadcasts and DMs (\`--room general @peer\` re-routes correctly).

Also updates README.md's auto-scope section to document the dual-room default and the new \`--room\` flag with examples.

## Test plan
- [x] \`bash test/integration.sh send_room_flag\` — 8/8 pass
- [x] Manual: \`airc send --room general "..."\` from primary scope appends to \`.airc.general/messages.jsonl\` (verified)
- [x] Manual: \`airc send --room cambriantech "..."\` from a tab not subscribed to that room dies with structured stderr listing \`#useideem\` and \`#general\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)