### PR TITLE
feat(peers): aggregate across primary + sidecar scopes with [#room] tags

### DIFF
--- a/airc
+++ b/airc
@@ -4195,24 +4195,81 @@ else:
     return
   fi
 
-  local found=false
-  local entry
-  for entry in $(relay_list peers); do
-    case "$entry" in *.json) ;; *) continue ;; esac
-    local f; f=$(relay_path "peers/$entry")
-    [ -f "$f" ] || continue
-    found=true
-    local name host
-    # `|| true` — a malformed peer record shouldn't abort the whole peers list
-    # under `set -euo pipefail`. Empty name/host gets printed and the user can
-    # tell the record is broken; the rest of the list still enumerates.
-    name=$(python3 -c "import json; print(json.load(open('$f'))['name'])" 2>/dev/null || true)
-    host=$(python3 -c "import json; print(json.load(open('$f'))['host'])" 2>/dev/null || true)
-    echo "  $name → $host"
-  done
-  if [ "$found" = false ]; then
-    echo "  No peers yet."
-  fi
+  # Walk scopes that count as "subscribed rooms" for this tab: primary
+  # (current AIRC_WRITE_DIR) plus any sibling sidecar scopes (.airc.<room>
+  # pattern under the project scope's parent). For each, read peers/
+  # records and annotate with the scope's room_name. Same peer in both
+  # scopes folds into one line with both room tags.
+  #
+  # Intent (issue #121 follow-up): multi-room presence shouldn't fragment
+  # the operator's view of "who am I connected to" into separate per-scope
+  # listings. From the user's perspective they're in N rooms; airc peers
+  # should reflect that as one unified roster with room context per peer.
+  python3 -c "
+import json, os, sys, re
+
+primary_scope = os.path.expanduser('$AIRC_WRITE_DIR')
+parent = os.path.dirname(primary_scope)
+self_basename = os.path.basename(primary_scope)
+
+# Prefix detection: a sidecar scope is named like \`<prefix>.<room>\`
+# (e.g. .airc.general). Strip a trailing .<word> to recover the
+# primary scope's basename. Works for both production layout
+# (.airc / .airc.general) and test ad-hoc paths (state / state.general)
+# without baking in the .airc literal.
+prefix_match = re.match(r'(.+?)\.[a-z0-9-]+\$', self_basename)
+prefix = prefix_match.group(1) if prefix_match else self_basename
+
+# Collect: the primary scope itself, plus every sibling whose name is
+# <prefix>.<something>. We additionally require room_name + peers/ on
+# each candidate so unrelated dirs in the same parent (e.g. .airc-old,
+# .airc.bak) don't pollute the listing.
+candidates = []
+if os.path.isdir(parent):
+    for entry in sorted(os.listdir(parent)):
+        if entry == prefix or entry.startswith(prefix + '.'):
+            candidates.append(os.path.join(parent, entry))
+scopes = [s for s in candidates
+          if os.path.isfile(os.path.join(s, 'room_name'))
+          and os.path.isdir(os.path.join(s, 'peers'))]
+# Always include primary even if it doesn't have room_name yet — that's
+# the legacy 1:1 invite mode case (use_room=0).
+if primary_scope not in scopes and os.path.isdir(os.path.join(primary_scope, 'peers')):
+    scopes.insert(0, primary_scope)
+
+# Build {(name, host): [room1, room2, ...]} by walking each scope's peers/.
+peers_by_id = {}
+for scope in scopes:
+    peers_dir = os.path.join(scope, 'peers')
+    if not os.path.isdir(peers_dir):
+        continue
+    rn_file = os.path.join(scope, 'room_name')
+    room = '(?)'
+    if os.path.isfile(rn_file):
+        try: room = open(rn_file).read().strip()
+        except Exception: pass
+    for f in sorted(os.listdir(peers_dir)):
+        if not f.endswith('.json'): continue
+        try:
+            d = json.load(open(os.path.join(peers_dir, f)))
+        except Exception:
+            continue
+        key = (d.get('name', f[:-5]), d.get('host', ''))
+        peers_by_id.setdefault(key, []).append(room)
+
+if not peers_by_id:
+    print('  No peers yet.')
+    sys.exit(0)
+
+# Render. Each peer once, with room annotations sorted + deduped.
+for (name, host), rooms in sorted(peers_by_id.items()):
+    seen = set(); ordered = []
+    for r in rooms:
+        if r not in seen:
+            ordered.append(r); seen.add(r)
+    tags = ', '.join('#' + r for r in ordered)
+    print(f'  {name} → {host}   [{tags}]')
+"
 }
 
 cmd_teardown() {

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2438,6 +2438,77 @@ JSON
   rm -rf /tmp/airc-it-srf
 }
 
+# ── Scenario: peers_cross_scope (sidecar peers visible from primary) ────
+# Pre-fix: `airc peers` walked only the current scope's peers/ dir, so a
+# tab in primary scope (e.g. #useideem) couldn't see who else was in the
+# #general lobby without `cd`'ing into the .general sidecar. Multi-room
+# presence is meaningless if the operator can't see who's in each room.
+#
+# Post-fix: cmd_peers walks the project scope AND every sibling .airc.<room>
+# scope, merging peer records by (name, host) and tagging each peer with
+# the rooms they're in. Same peer in both rooms shows as one line with
+# [#room1, #room2].
+scenario_peers_cross_scope() {
+  section "peers_cross_scope: airc peers aggregates across primary + sidecar scopes"
+  cleanup_all
+
+  local primary=/tmp/airc-it-pcs/state
+  local sidecar=/tmp/airc-it-pcs/state.general
+  mkdir -p "$primary/identity" "$primary/peers" "$sidecar/identity" "$sidecar/peers"
+  ssh-keygen -t ed25519 -f "$primary/identity/ssh_key" -N '' -q -C 'pcs-primary' 2>/dev/null
+  ssh-keygen -t ed25519 -f "$sidecar/identity/ssh_key" -N '' -q -C 'pcs-sidecar' 2>/dev/null
+  cat > "$primary/config.json" <<'JSON'
+{ "name": "alpha" }
+JSON
+  cat > "$sidecar/config.json" <<'JSON'
+{ "name": "alpha" }
+JSON
+  echo "myproject" > "$primary/room_name"
+  echo "general" > "$sidecar/room_name"
+
+  # Peer records: 'shared' is in both scopes; 'projonly' only in primary;
+  # 'lobbyonly' only in sidecar. Verifies merge + per-scope tagging.
+  cat > "$primary/peers/shared.json" <<'JSON'
+{"name":"shared","host":"joel@10.0.0.1","ssh_pub":"ssh-ed25519 AAAA"}
+JSON
+  cat > "$primary/peers/projonly.json" <<'JSON'
+{"name":"projonly","host":"joel@10.0.0.2","ssh_pub":"ssh-ed25519 BBBB"}
+JSON
+  cat > "$sidecar/peers/shared.json" <<'JSON'
+{"name":"shared","host":"joel@10.0.0.1","ssh_pub":"ssh-ed25519 AAAA"}
+JSON
+  cat > "$sidecar/peers/lobbyonly.json" <<'JSON'
+{"name":"lobbyonly","host":"joel@10.0.0.3","ssh_pub":"ssh-ed25519 CCCC"}
+JSON
+
+  local out
+  out=$(AIRC_HOME="$primary" "$AIRC" peers 2>&1)
+
+  echo "$out" | grep -qE 'shared.*joel@10.0.0.1.*\[#myproject.*#general\]|shared.*joel@10.0.0.1.*\[#general.*#myproject\]' \
+    && pass "shared peer shows tagged with BOTH rooms" \
+    || fail "shared peer missing dual-room tag (got: $(echo "$out" | grep shared))"
+
+  echo "$out" | grep -qE 'projonly.*joel@10.0.0.2.*\[#myproject\]' \
+    && pass "primary-only peer tagged with #myproject" \
+    || fail "projonly peer missing primary tag (got: $(echo "$out" | grep projonly))"
+
+  echo "$out" | grep -qE 'lobbyonly.*joel@10.0.0.3.*\[#general\]' \
+    && pass "sidecar-only peer visible from primary scope, tagged with #general" \
+    || fail "lobbyonly peer NOT visible from primary scope (got: $(echo "$out" | grep lobbyonly))"
+
+  # Same query from the sidecar scope should return the same merged set
+  # (operator perspective shouldn't change based on which scope they
+  # happen to invoke from).
+  local out2
+  out2=$(AIRC_HOME="$sidecar" "$AIRC" peers 2>&1)
+  echo "$out2" | grep -qE 'projonly' \
+    && pass "from sidecar scope: still sees primary-only peer" \
+    || fail "from sidecar scope: lost primary-only peer (got: $(echo "$out2" | head -3))"
+
+  rm -rf /tmp/airc-it-pcs
+  cleanup_all
+}
+
 case "$MODE" in
   tabs)         scenario_tabs  ;;
   scope)        scenario_scope ;;
@@ -2466,8 +2537,9 @@ case "$MODE" in
   resume_prints_connected_banner) scenario_resume_prints_connected_banner ;;
   general_sidecar_default) scenario_general_sidecar_default ;;
   send_room_flag) scenario_send_room_flag ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_room_overrides_resume; scenario_stale_auth_room_selfheal; scenario_send_dead_monitor_dies; scenario_resume_404_gist_no_silent_exit; scenario_resume_prints_connected_banner; scenario_general_sidecar_default; scenario_send_room_flag ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|room_overrides_resume|stale_auth_room_selfheal|send_dead_monitor_dies|resume_404_gist_no_silent_exit|resume_prints_connected_banner|general_sidecar_default|send_room_flag|all]"; exit 2 ;;
+  peers_cross_scope) scenario_peers_cross_scope ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_room_overrides_resume; scenario_stale_auth_room_selfheal; scenario_send_dead_monitor_dies; scenario_resume_404_gist_no_silent_exit; scenario_resume_prints_connected_banner; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|room_overrides_resume|stale_auth_room_selfheal|send_dead_monitor_dies|resume_404_gist_no_silent_exit|resume_prints_connected_banner|general_sidecar_default|send_room_flag|peers_cross_scope|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary

Follow-up to #122. Pre-fix: \`airc peers\` walked only the current scope's \`peers/\` dir, so a tab in #useideem couldn't see who was in #general without \`cd\`'ing into \`.airc.general/\`. Multi-room presence is meaningless if the operator can't get a unified roster.

Post-fix: \`cmd_peers\` detects sibling sidecar scopes (any sibling dir matching \`<prefix>.<word>\` with \`room_name\` + \`peers/\`), merges peer records by (name, host) across scopes, tags each peer with their rooms:

\`\`\`
authenticator-fd63 → joel@127.0.0.1   [#useideem, #general]
vhsm-d1f4 → joel@100.91.51.87         [#useideem]
continuum-b741 → joel@100.91.51.87    [#general]
\`\`\`

Operator perspective stays consistent regardless of which scope invokes \`airc peers\`.

## Test plan
- [x] \`bash test/integration.sh peers_cross_scope\` — 4/4 pass
- [x] Live verification on this Mac with #useideem primary + #general sidecar — output matches design
- [x] Convention-flexible: works for both production (\`.airc\`/\`.airc.general\`) and test (\`state\`/\`state.general\`) layouts via prefix-detection (no \`.airc\` literal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)