### PR TITLE
fix(part): IRC /part semantics — leave one room, keep sidecar

### DIFF
--- a/airc
+++ b/airc
@@ -852,11 +852,15 @@ spawn_general_sidecar_if_wanted() {
   ( env -u AIRC_PORT "${_env_args[@]}" "$0" connect --room general ) &
   local _sidecar_pid=$!
 
-  # Append to primary's pidfile so cmd_teardown kills the sidecar
-  # process tree along with the primary's. (Sidecar's own scope has
-  # its own pidfile for sidecar's descendants — that gets cleaned by
-  # the next sidecar's auto-stale-pidfile recovery on reconnect.)
-  echo "$_sidecar_pid" >> "$_primary_scope/airc.pid"
+  # Sidecar's own scope writes its own airc.pid for its bash + descendants.
+  # cmd_teardown walks $AIRC_WRITE_DIR.general/airc.pid explicitly to kill
+  # the sidecar tree, so we DON'T append the sidecar bash PID to the
+  # primary's airc.pid. Earlier (PR #122) we did — but that broke
+  # cmd_part, which walks the same primary pidfile and ends up killing
+  # the sidecar too even though IRC semantics say `/part` should leave
+  # only the current channel and keep others (e.g. #general) alive.
+  # Pidfiles per scope; cmd_teardown is the only path that walks both.
+  :
 }
 
 # Resolve this session's peer name.
@@ -4078,6 +4082,12 @@ cmd_part() {
     rm -f "$room_name_file" "$gist_id_file"
   fi
 
+  # IRC `/part` semantics — leave THIS room only; the #general sidecar
+  # (or any other sibling subscription) keeps running. cmd_teardown
+  # respects AIRC_TEARDOWN_PART_ONLY=1 by skipping its sidecar block,
+  # so the kill is scope-local. cmd_teardown without this guard remains
+  # the "kill everything in this scope tree" command.
+  local AIRC_TEARDOWN_PART_ONLY=1
   cmd_teardown
 }
 
@@ -4369,8 +4379,15 @@ cmd_teardown() {
   # #general gist on the gh account AND an orphan sidecar process that
   # the primary's pidfile descendant-walk wouldn't catch (sidecar's
   # bash isn't a child of cmd_teardown — it was forked detached).
+  #
+  # Guard: AIRC_TEARDOWN_PART_ONLY=1 (set by cmd_part) skips the sidecar
+  # block. IRC `/part` should leave only the current channel; the
+  # sidecar (#general lobby) should keep running. cmd_teardown without
+  # this flag is the "kill everything in this scope tree" semantic.
   local _sidecar_scope="${AIRC_WRITE_DIR}.general"
-  if [ -d "$_sidecar_scope" ]; then
+  if [ "${AIRC_TEARDOWN_PART_ONLY:-0}" = "1" ]; then
+    : # cmd_part path — skip sidecar
+  elif [ -d "$_sidecar_scope" ]; then
     if [ -f "$_sidecar_scope/host_gist_id" ] && command -v gh >/dev/null 2>&1; then
       local _td_sc_gist; _td_sc_gist=$(cat "$_sidecar_scope/host_gist_id" 2>/dev/null)
       if [ -n "$_td_sc_gist" ]; then
@@ -4420,6 +4437,34 @@ cmd_teardown() {
         [ -n "$kids" ] && all_pids="$all_pids $kids"
       done
       all_pids=$(echo "$all_pids" | tr ' ' '\n' | sort -u | grep -v '^$' || true)
+      # Part-only path: exclude the sidecar's bash + its descendants so
+      # `airc part` doesn't sweep them via the primary's child-tree.
+      # The sidecar's bash is forked from primary, so pgrep -P picks it
+      # up here; without exclusion we'd kill the sidecar in violation
+      # of IRC /part semantics (leave one channel, keep others alive).
+      if [ "${AIRC_TEARDOWN_PART_ONLY:-0}" = "1" ] && [ -n "$all_pids" ]; then
+        local _exclude_pids=""
+        local _sc_pidfile="${AIRC_WRITE_DIR}.general/airc.pid"
+        if [ -f "$_sc_pidfile" ]; then
+          local _sc_pids; _sc_pids=$(cat "$_sc_pidfile" 2>/dev/null | tr '\n' ' ')
+          for _scp in $_sc_pids; do
+            _exclude_pids="$_exclude_pids $_scp"
+            local _scp_kids; _scp_kids=$(pgrep -P "$_scp" 2>/dev/null | tr '\n' ' ' || true)
+            [ -n "$_scp_kids" ] && _exclude_pids="$_exclude_pids $_scp_kids"
+          done
+        fi
+        if [ -n "$_exclude_pids" ]; then
+          local _filtered=""
+          for _p in $all_pids; do
+            local _skip=0
+            for _ex in $_exclude_pids; do
+              [ "$_p" = "$_ex" ] && { _skip=1; break; }
+            done
+            [ "$_skip" = "0" ] && _filtered="$_filtered $_p"
+          done
+          all_pids=$(echo "$_filtered" | tr ' ' '\n' | grep -v '^$' || true)
+        fi
+      fi
       if [ -n "$all_pids" ]; then
         echo "  killing scope $AIRC_WRITE_DIR: $(echo $all_pids | tr '\n' ' ')"
         kill -9 $all_pids 2>/dev/null || true

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2509,6 +2509,80 @@ JSON
   cleanup_all
 }
 
+# ── Scenario: part_keeps_sidecar (IRC /part semantics) ──────────────────
+# Pre-fix: `airc part` from the primary scope called cmd_teardown which
+# (post-#122) cleaned both primary AND sidecar scopes — so leaving
+# #useideem also dropped #general unintentionally. IRC convention is
+# /part leaves ONE channel; the lobby should persist.
+#
+# Post-fix: cmd_part sets AIRC_TEARDOWN_PART_ONLY=1 before calling
+# cmd_teardown, which makes cmd_teardown skip the sidecar cleanup
+# block. Sidecar process + gist + scope dir survive.
+scenario_part_keeps_sidecar() {
+  section "part_keeps_sidecar: airc part leaves project room only, #general sidecar lives"
+  cleanup_all
+
+  local home1=/tmp/airc-it-pks/state
+  mkdir -p "$home1"
+
+  # Spawn primary with sidecar enabled (unset the global suppression).
+  ( cd /tmp/airc-it-pks && unset AIRC_NO_GENERAL && \
+      AIRC_HOME="$home1" AIRC_NAME=alpha AIRC_PORT=7575 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room pks-test-$$ > "$home1/out.log" 2>&1 & )
+  local i
+  for i in 1 2 3 4 5 6 7 8; do
+    sleep 1
+    [ -f "${home1}.general/airc.pid" ] && [ -f "$home1/airc.pid" ] && break
+  done
+
+  [ -f "$home1/airc.pid" ] && [ -f "${home1}.general/airc.pid" ] \
+    && pass "primary + sidecar both running pre-part" \
+    || { fail "setup failed (primary or sidecar didn't start)"; cleanup_all; return; }
+
+  # Capture sidecar's bash PID so we can verify it survives the part.
+  # airc.pid in host mode contains multiple space-separated PIDs on
+  # one line ($$ $PAIR_PID $_hb_pid_persisted); we want just the
+  # main bash PID for the kill -0 check.
+  local _sc_pid; _sc_pid=$(awk '{print $1; exit}' "${home1}.general/airc.pid" 2>/dev/null)
+
+  # Run airc part on primary scope.
+  AIRC_HOME="$home1" "$AIRC" part >/dev/null 2>&1
+  sleep 1
+
+  # Primary's pidfile should be gone (parted).
+  [ ! -f "$home1/airc.pid" ] \
+    && pass "primary scope airc.pid removed by part" \
+    || fail "primary airc.pid still present after part"
+
+  # CRITICAL: sidecar should still be running.
+  if [ -n "$_sc_pid" ] && kill -0 "$_sc_pid" 2>/dev/null; then
+    pass "sidecar PID $_sc_pid still alive after primary's part"
+  else
+    fail "sidecar killed by primary's part (pre-fix bug regressed)"
+  fi
+
+  [ -d "${home1}.general" ] && [ -f "${home1}.general/airc.pid" ] \
+    && pass "sidecar scope dir + pidfile still present after part" \
+    || fail "sidecar scope wiped by part"
+
+  # Sidecar's room_name should still say 'general'.
+  [ -f "${home1}.general/room_name" ] && [ "$(cat "${home1}.general/room_name" 2>/dev/null)" = "general" ] \
+    && pass "sidecar room_name preserved" \
+    || fail "sidecar room_name lost"
+
+  # Now full teardown should reap the sidecar.
+  AIRC_HOME="$home1" "$AIRC" teardown >/dev/null 2>&1
+  sleep 1
+
+  ! kill -0 "$_sc_pid" 2>/dev/null \
+    && pass "subsequent airc teardown DOES reap the sidecar (full kill semantic preserved)" \
+    || fail "sidecar survived even airc teardown — over-skip bug"
+
+  rm -rf /tmp/airc-it-pks
+  cleanup_all
+}
+
 case "$MODE" in
   tabs)         scenario_tabs  ;;
   scope)        scenario_scope ;;
@@ -2538,8 +2612,9 @@ case "$MODE" in
   general_sidecar_default) scenario_general_sidecar_default ;;
   send_room_flag) scenario_send_room_flag ;;
   peers_cross_scope) scenario_peers_cross_scope ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_room_overrides_resume; scenario_stale_auth_room_selfheal; scenario_send_dead_monitor_dies; scenario_resume_404_gist_no_silent_exit; scenario_resume_prints_connected_banner; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|room_overrides_resume|stale_auth_room_selfheal|send_dead_monitor_dies|resume_404_gist_no_silent_exit|resume_prints_connected_banner|general_sidecar_default|send_room_flag|peers_cross_scope|all]"; exit 2 ;;
+  part_keeps_sidecar) scenario_part_keeps_sidecar ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_room_overrides_resume; scenario_stale_auth_room_selfheal; scenario_send_dead_monitor_dies; scenario_resume_404_gist_no_silent_exit; scenario_resume_prints_connected_banner; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_part_keeps_sidecar ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|room_overrides_resume|stale_auth_room_selfheal|send_dead_monitor_dies|resume_404_gist_no_silent_exit|resume_prints_connected_banner|general_sidecar_default|send_room_flag|peers_cross_scope|part_keeps_sidecar|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary

Follow-up to #122. Pre-fix: \`airc part\` from primary scope nuked the #general sidecar too (because cmd_teardown's pgrep-children walker reached the sidecar via the parent-child relationship). IRC convention is /part leaves ONE channel; the lobby should persist.

## Fix

- \`cmd_teardown\` reads \`AIRC_TEARDOWN_PART_ONLY=1\` and excludes sidecar's airc.pid + descendants from the kill set when set.
- \`cmd_part\` sets the flag before calling cmd_teardown, making part scope-local.
- Also: removed redundant sidecar-PID append to primary's airc.pid (cmd_teardown already walks sidecar's own pidfile explicitly via the .general block).

## Test plan
- [x] \`bash test/integration.sh part_keeps_sidecar\` — 6/6 pass (sidecar survives primary's part; subsequent full teardown still reaps it)
- [x] Manual: spawn primary + sidecar, run \`airc part\` from primary, verify sidecar bash PID still alive via \`kill -0\`

## Test bugfix included
read first PID from \`airc.pid\` via \`awk '{print \$1; exit}'\` instead of \`head -1\` — host-mode pidfile has multiple space-separated PIDs on one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)