### PR TITLE
refactor(platform): extract proc/port/file/platform adapters

### DIFF
--- a/airc
+++ b/airc
@@ -771,6 +771,150 @@ sign_message() {
   rm -f "$tmpfile"
 }
 
+# ── Platform adapters ───────────────────────────────────────────────────
+#
+# Single-purpose helpers that hide platform-specific differences in the
+# process / port / filesystem APIs. Every callsite that needs "find
+# children of PID X" or "find PIDs listening on port Y" goes through
+# these helpers, NOT inline pgrep/lsof. That way:
+#
+#   1. The platform-specific implementation lives in ONE place per
+#      capability — adding a Windows fallback for `lsof` (e.g. via
+#      `netstat -ano`) means editing one helper, not 4+ callsites.
+#   2. The business logic above the adapter line stays platform-
+#      agnostic. Refactor risk drops.
+#   3. We hold the line on Joel's "fixing one platform shouldn't
+#      degrade another" rule (2026-04-26): without adapters, a Mac
+#      AI's tweak to a pgrep callsite easily diverges from the Linux
+#      AI's tweak. With adapters, both AIs touch the same helper.
+#
+# Each adapter takes simple inputs and emits a one-thing-per-line
+# stream, suitable for `while IFS= read -r` consumption. Callers can
+# `tr '\n' ' '` if they want space-separated, but the canonical
+# representation is newline-delimited (POSIX-friendly).
+#
+# Conventions:
+#   - `proc_*` — process / PID introspection
+#   - `port_*` — TCP port introspection
+#   - `file_*` — filesystem metadata
+#   - `detect_*` — environment classification
+
+# Return PIDs of direct children of $1, one per line.
+# Implementations: pgrep -P (POSIX/macOS/Linux), ps fallback for
+# environments without pgrep (Git Bash for Windows ships only msys
+# coreutils — no pgrep by default; the fallback uses `ps -axo pid,ppid`
+# which msys2 ps DOES support). Empty output if no children or pid is
+# already gone.
+proc_children() {
+  local pid="$1"
+  [ -z "$pid" ] && return 0
+  if command -v pgrep >/dev/null 2>&1; then
+    pgrep -P "$pid" 2>/dev/null
+  else
+    # POSIX-portable fallback. Works on Git Bash (msys ps), Linux ps,
+    # macOS ps. Awk filters by ppid column.
+    ps -axo pid,ppid 2>/dev/null | awk -v p="$pid" '$2 == p { print $1 }'
+  fi
+}
+
+# Return parent PID of $1. Empty if $1 is gone.
+proc_parent() {
+  local pid="$1"
+  [ -z "$pid" ] && return 0
+  ps -p "$pid" -o ppid= 2>/dev/null | tr -d ' '
+}
+
+# Return the command line of $1 (full argv, space-joined). Empty if gone.
+proc_cmdline() {
+  local pid="$1"
+  [ -z "$pid" ] && return 0
+  ps -p "$pid" -o command= 2>/dev/null
+}
+
+# Find airc-related PIDs owned by the current user matching a pattern.
+# Used by `airc teardown --all` to nuke every airc process.
+# Pattern is a regex passed to pgrep -f or to awk's =~.
+proc_airc_pids_matching() {
+  local pattern="$1"
+  [ -z "$pattern" ] && return 0
+  if command -v pgrep >/dev/null 2>&1; then
+    pgrep -u "$(id -u)" -f "$pattern" 2>/dev/null
+  else
+    # Fallback: ps + awk. Less precise than pgrep -f (no anchored regex)
+    # but covers the same shape. Filter by user since msys ps -u option
+    # may not match POSIX semantics.
+    local me; me=$(whoami 2>/dev/null)
+    ps -axo pid,user,command 2>/dev/null \
+      | awk -v u="$me" -v p="$pattern" 'NR>1 && $2 == u && $0 ~ p { print $1 }'
+  fi
+}
+
+# Return PIDs listening on TCP port $1 (LISTEN state), one per line.
+# Implementations:
+#   1. lsof -tiTCP:<port> -sTCP:LISTEN — macOS, most BSDs, modern Linux
+#      with lsof installed.
+#   2. ss -tlnp — modern Linux distros (iproute2 default since ~2017),
+#      replaces deprecated netstat. Output post-processing extracts pid.
+#   3. netstat -ano — Windows native (cmd / PowerShell), and also a
+#      fallback on minimal Linux containers without lsof or ss. Output
+#      shape differs per platform; awk parses the LISTENING column.
+# Empty output = nobody listening.
+port_listeners() {
+  local port="$1"
+  [ -z "$port" ] && return 0
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null
+  elif command -v ss >/dev/null 2>&1; then
+    # ss output: 'LISTEN 0 ... users:(("python",pid=12345,fd=4))'
+    # Awk extracts pid= number.
+    ss -tlnp "( sport = :$port )" 2>/dev/null \
+      | awk 'NR>1 { match($0, /pid=[0-9]+/); if (RSTART) print substr($0, RSTART+4, RLENGTH-4) }'
+  elif command -v netstat >/dev/null 2>&1; then
+    # netstat -ano output (Windows + some Linux):
+    #   TCP 0.0.0.0:7547 0.0.0.0:0 LISTENING 12345
+    # Trailing column is PID. Match $port at end of local-address column.
+    netstat -ano 2>/dev/null \
+      | awk -v p=":$port" '$2 ~ p"$" && /LISTEN/ { print $NF }'
+  fi
+}
+
+# Return file size in bytes. Empty / 0 on failure.
+# stat is not POSIX (different flags on BSD vs GNU); chain both with
+# fallback to wc -c which IS POSIX.
+file_size() {
+  local path="$1"
+  [ -f "$path" ] || { echo 0; return 0; }
+  stat -f%z "$path" 2>/dev/null \
+    || stat -c%s "$path" 2>/dev/null \
+    || wc -c < "$path" 2>/dev/null \
+    || echo 0
+}
+
+# Detect platform: emits one of macos, linux, wsl, windows-bash (Git Bash
+# on Windows native), unknown. Most callers don't need this — they
+# should use the proc_/port_/file_ adapters, which handle platform
+# differences internally. detect_platform is for the rare case where
+# a top-level decision genuinely depends on platform (e.g. Tailscale.app
+# launching on macOS).
+detect_platform() {
+  local s; s=$(uname -s 2>/dev/null)
+  case "$s" in
+    Darwin)               echo macos ;;
+    Linux)
+      # Detect WSL via /proc/version content (kernel string contains
+      # 'microsoft' or 'WSL'). Bare Linux otherwise.
+      if grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then
+        echo wsl
+      else
+        echo linux
+      fi ;;
+    MINGW*|MSYS*|CYGWIN*) echo windows-bash ;;
+    *)                    echo unknown ;;
+  esac
+}
+
+# ── End platform adapters ───────────────────────────────────────────────
+
 relay_ssh() {
   local ssh_key="$IDENTITY_DIR/ssh_key"
   # ConnectTimeout 10 so unreachable hosts fail fast instead of hanging ~60s
@@ -1658,7 +1802,7 @@ cmd_connect() {
       # that would abort this block *before* reaching the rm on line 442 that
       # self-heals the stale pidfile. Result: joiner wedged forever after a
       # parent crash / laptop sleep until someone manually rm'd the pidfile.
-      all_stale="$all_stale $(pgrep -P "$p" 2>/dev/null | tr '\n' ' ' || true)"
+      all_stale="$all_stale $(proc_children "$p" | tr '\n' ' ' || true)"
     done
     # Quiet kill — don't warn unless there was actually a live process.
     if [ -n "$all_stale" ]; then
@@ -1930,7 +2074,7 @@ cmd_connect() {
       echo $$ > "$AIRC_WRITE_DIR/airc.pid"
       trap '
         rm -f "$AIRC_WRITE_DIR/airc.pid" 2>/dev/null
-        for p in $(pgrep -P $$ 2>/dev/null); do kill $p 2>/dev/null; done
+        for p in $(proc_children $$); do kill $p 2>/dev/null; done
       ' EXIT INT TERM
       spawn_general_sidecar_if_wanted
       monitor
@@ -2606,7 +2750,7 @@ json.dump(c, open('$CONFIG', 'w'), indent=2)
     # remote doesn't see an orphaned session and the port doesn't linger.
     trap '
       rm -f "$AIRC_WRITE_DIR/airc.pid" 2>/dev/null
-      for p in $(pgrep -P $$ 2>/dev/null); do kill $p 2>/dev/null; done
+      for p in $(proc_children $$); do kill $p 2>/dev/null; done
     ' EXIT INT TERM
 
     spawn_general_sidecar_if_wanted
@@ -2647,7 +2791,7 @@ json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
     local host_port="${AIRC_PORT:-7547}"
     local original_port="$host_port"
     local tried=0
-    while lsof -iTCP:"$host_port" -sTCP:LISTEN >/dev/null 2>&1; do
+    while [ -n "$(port_listeners "$host_port")" ]; do
       host_port=$((host_port + 1))
       tried=$((tried + 1))
       if [ "$tried" -ge 20 ]; then
@@ -3103,7 +3247,7 @@ except Exception:
         gh gist delete "$_exit_gist_id" --yes >/dev/null 2>&1
       fi
       rm -f "$AIRC_WRITE_DIR/airc.pid" "$AIRC_WRITE_DIR/heartbeat.pid" "$AIRC_WRITE_DIR/host_gist_id" 2>/dev/null
-      for p in $PAIR_PID $(pgrep -P $PAIR_PID 2>/dev/null) $(pgrep -P $$ 2>/dev/null); do
+      for p in $PAIR_PID $(proc_children $PAIR_PID) $(proc_children $$); do
         kill $p 2>/dev/null
       done
     ' EXIT INT TERM
@@ -4121,7 +4265,7 @@ cmd_send_file() {
     die "Failed to transfer $filename: $scp_out"
   fi
 
-  local filesize; filesize=$(stat -f%z "$filepath" 2>/dev/null || stat -c%s "$filepath" 2>/dev/null || echo "0")
+  local filesize; filesize=$(file_size "$filepath")
   cmd_send "$peer_name" "Sent file: $filename ($filesize bytes)"
   echo "Sent $filename ($filesize bytes)"
 }
@@ -4315,7 +4459,7 @@ cmd_teardown() {
     # Bash airc-connect processes (any path that ends in /airc connect or
     # the /tmp/airc-prefix bootstrap variant the curl|bash installer uses).
     local bash_pids
-    bash_pids=$(pgrep -u "$(id -u)" -f '(airc|airc-prefix)[[:space:]]+connect' 2>/dev/null || true)
+    bash_pids=$(proc_airc_pids_matching '(airc|airc-prefix)[[:space:]]+connect' || true)
     if [ -n "$bash_pids" ]; then
       echo "  --all: killing airc bash processes: $(echo $bash_pids | tr '\n' ' ')"
       kill -9 $bash_pids 2>/dev/null || true
@@ -4326,10 +4470,10 @@ cmd_teardown() {
     local port
     for port in 7547 7548 7549 7550 7551 7552 7553 7554 7555 7556 7557 7558 7559; do
       local lpids
-      lpids=$(lsof -tiTCP:$port -sTCP:LISTEN 2>/dev/null || true)
+      lpids=$(port_listeners "$port" || true)
       for lpid in $lpids; do
         local cmd
-        cmd=$(ps -p "$lpid" -o command= 2>/dev/null || true)
+        cmd=$(proc_cmdline "$lpid" || true)
         if echo "$cmd" | grep -q "socket.SOCK_STREAM\|socket.AF_INET"; then
           echo "  --all: freeing port $port (python pid $lpid)"
           kill -9 "$lpid" 2>/dev/null || true
@@ -4340,7 +4484,7 @@ cmd_teardown() {
     # Stale tail/ssh subprocesses that look like airc message tails
     # (ssh ... tail -F .../.airc/messages.jsonl).
     local tail_pids
-    tail_pids=$(pgrep -u "$(id -u)" -f '\.airc/messages\.jsonl' 2>/dev/null || true)
+    tail_pids=$(proc_airc_pids_matching '\.airc/messages\.jsonl' || true)
     if [ -n "$tail_pids" ]; then
       echo "  --all: killing stale airc message tails: $(echo $tail_pids | tr '\n' ' ')"
       kill -9 $tail_pids 2>/dev/null || true
@@ -4402,7 +4546,7 @@ cmd_teardown() {
       if [ -n "$_sc_pids" ]; then
         local _all_sc="$_sc_pids"
         for _p in $_sc_pids; do
-          local _kids; _kids=$(pgrep -P "$_p" 2>/dev/null | tr '\n' ' ' || true)
+          local _kids; _kids=$(proc_children "$_p" | tr '\n' ' ' || true)
           [ -n "$_kids" ] && _all_sc="$_all_sc $_kids"
         done
         _all_sc=$(echo "$_all_sc" | tr ' ' '\n' | sort -u | grep -v '^$' || true)
@@ -4433,7 +4577,7 @@ cmd_teardown() {
       local all_pids="$main_pids"
       for pid in $main_pids; do
         local kids
-        kids=$(pgrep -P "$pid" 2>/dev/null | tr '\n' ' ' || true)
+        kids=$(proc_children "$pid" | tr '\n' ' ' || true)
         [ -n "$kids" ] && all_pids="$all_pids $kids"
       done
       all_pids=$(echo "$all_pids" | tr ' ' '\n' | sort -u | grep -v '^$' || true)
@@ -4449,7 +4593,7 @@ cmd_teardown() {
           local _sc_pids; _sc_pids=$(cat "$_sc_pidfile" 2>/dev/null | tr '\n' ' ')
           for _scp in $_sc_pids; do
             _exclude_pids="$_exclude_pids $_scp"
-            local _scp_kids; _scp_kids=$(pgrep -P "$_scp" 2>/dev/null | tr '\n' ' ' || true)
+            local _scp_kids; _scp_kids=$(proc_children "$_scp" | tr '\n' ' ' || true)
             [ -n "$_scp_kids" ] && _exclude_pids="$_exclude_pids $_scp_kids"
           done
         fi
@@ -4484,14 +4628,14 @@ cmd_teardown() {
   [ "$ports" != "7547" ] && ports="$ports 7547"
   for port in $ports; do
     local lpids
-    lpids=$(lsof -tiTCP:$port -sTCP:LISTEN 2>/dev/null || true)
+    lpids=$(port_listeners "$port" || true)
     for lpid in $lpids; do
       # `|| true` on both — $lpid came from lsof a moment ago; if the process
       # exited in the interim, `ps -p` returns 1 and pipefail/errexit would
       # abort the port-reap loop mid-scan, leaving later ports unchecked.
       # Empty parent/cmd → the `if` below falls through, which is correct.
-      local parent; parent=$(ps -p "$lpid" -o ppid= 2>/dev/null | tr -d ' ' || true)
-      local cmd; cmd=$(ps -p "$lpid" -o command= 2>/dev/null || true)
+      local parent; parent=$(proc_parent "$lpid" || true)
+      local cmd; cmd=$(proc_cmdline "$lpid" || true)
       # Reap if orphaned AND is a python socket listener.
       if [ "$parent" = "1" ] && echo "$cmd" | grep -q "socket.SOCK_STREAM"; then
         echo "  freeing orphaned port $port (pid $lpid)"
@@ -5338,12 +5482,10 @@ _doctor_connect_preflight() {
 
   # ── Connect-specific: AIRC_PORT free or auto-shift available ──
   local target_port="${AIRC_PORT:-7547}"
-  if command -v lsof >/dev/null 2>&1; then
-    if lsof -iTCP:"$target_port" -sTCP:LISTEN >/dev/null 2>&1; then
-      printf "  [info] port %s busy -- airc will auto-shift to next free port\n" "$target_port"
-    else
-      printf "  [ok] port %s available for hosting\n" "$target_port"
-    fi
+  if [ -n "$(port_listeners "$target_port")" ]; then
+    printf "  [info] port %s busy -- airc will auto-shift to next free port\n" "$target_port"
+  else
+    printf "  [ok] port %s available for hosting\n" "$target_port"
   fi
 
   # ── Connect-specific: cached host_target reachable (resume scenario) ──

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2313,15 +2313,21 @@ scenario_general_sidecar_default() {
     && pass "sidecar scope has room_name=general" \
     || fail "sidecar scope room_name wrong (got: $(cat "${home1}.general/room_name" 2>/dev/null))"
 
-  # Sidecar PID should be appended to primary's airc.pid
-  grep -qE '^[0-9]+$' "$home1/airc.pid" \
-    && pass "primary airc.pid has at least one entry" \
-    || fail "primary airc.pid empty or malformed"
+  # Primary's airc.pid contains primary's host-mode PIDs ($$ PAIR_PID
+  # hb_pid on one line). The sidecar's PID lives in its OWN scope's
+  # airc.pid — separate file, separate ownership. (PR #122 originally
+  # appended sidecar PID to primary's airc.pid, but PR #125 reverted
+  # that to make `airc part` work cleanly without nuking the sidecar.)
+  [ -s "$home1/airc.pid" ] \
+    && pass "primary airc.pid is non-empty (host PIDs recorded)" \
+    || fail "primary airc.pid empty or missing"
 
-  # Sidecar bash should be alive
-  local _sc_pid; _sc_pid=$(tail -1 "$home1/airc.pid" 2>/dev/null)
+  # Sidecar bash should be alive — read sidecar's OWN pidfile.
+  # awk '{print $1; exit}' grabs just the first PID since host-mode
+  # airc.pid has multiple space-separated PIDs on one line.
+  local _sc_pid; _sc_pid=$(awk '{print $1; exit}' "${home1}.general/airc.pid" 2>/dev/null)
   if [ -n "$_sc_pid" ] && kill -0 "$_sc_pid" 2>/dev/null; then
-    pass "sidecar PID ${_sc_pid} (last entry in primary's airc.pid) is alive"
+    pass "sidecar bash PID ${_sc_pid} (from sidecar scope's own airc.pid) is alive"
   else
     fail "sidecar PID not alive (pid=${_sc_pid:-<empty>})"
   fi
@@ -2619,6 +2625,159 @@ scenario_part_keeps_sidecar() {
   cleanup_all
 }
 
+# ── Scenario: platform_adapters (cross-platform helpers contract) ──────
+# proc_children / port_listeners / proc_parent / proc_cmdline /
+# file_size / detect_platform replace inline pgrep/lsof/stat patterns
+# scattered through the codebase. This scenario verifies their
+# contract: input → output shape, fallback paths, and behavior when
+# the primary backing tool is missing (simulated by hiding it via
+# a PATH that excludes it).
+#
+# Catches: regressions where one platform's adapter implementation
+# diverges from another's. Refactoring these helpers should not
+# change observable behavior on any platform.
+scenario_platform_adapters() {
+  section "platform_adapters: proc_children / port_listeners / file_size / detect_platform"
+  cleanup_all
+
+  # Source the airc script in a way that gives us its functions without
+  # triggering its top-level argument processing. The script is a CLI
+  # so it dispatches on $1; we just want the helpers. Workaround: pass
+  # 'help' as $1 (no-op for our purposes) inside a subshell we can
+  # short-circuit OR re-exec the script with a marker. Simpler:
+  # extract the function definitions via grep + eval.
+  #
+  # Reliable approach: invoke the helpers via a tiny test driver that
+  # sources airc up to the helper definitions and then calls them.
+  # The script has no `if __name__ == '__main__'` equivalent in shell,
+  # so use a custom $1 that hits a dummy code path. Easiest: run airc
+  # in a subshell, override the dispatch by setting $1 to something
+  # unreachable, and just call the function directly. That requires
+  # we trust the script's structure — function definitions all run
+  # before the dispatch. So `bash -c 'source airc 2>/dev/null; func args'`
+  # works IF source is allowed (no exit/return at top level).
+  #
+  # The airc script does have top-level exec paths (auto-migration of
+  # ~/.agent-relay → ~/.airc, gh PATH-fixup, etc.) but those are
+  # idempotent. Sourcing should be fine.
+
+  # Helper: invoke an adapter without running airc's main dispatch.
+  # Sourcing $AIRC directly would trigger the bottom-of-file case
+  # statement and either die ("Unknown command") or print cmd_help.
+  # Extract just the marked adapter section into a temp file we can
+  # safely source.
+  local _adapters_extract; _adapters_extract=$(mktemp -t airc-it-pa.XXXXXX)
+  awk '/^# ── Platform adapters/,/^# ── End platform adapters/' "$AIRC" > "$_adapters_extract"
+  _adapter_call() {
+    bash -c "source '$_adapters_extract'; $*"
+  }
+
+  # ── proc_children ──
+  # Spawn a sleep, then check proc_children of the test harness PID
+  # finds it.
+  ( sleep 30 ) &
+  local _child_pid=$!
+  sleep 0.3
+  local _kids; _kids=$(_adapter_call "proc_children $$" | tr '\n' ' ')
+  echo "$_kids" | grep -qE "(^| )${_child_pid}( |$)" \
+    && pass "proc_children: finds direct child PID" \
+    || fail "proc_children: did NOT find spawned child $_child_pid (got: '$_kids')"
+  kill -9 $_child_pid 2>/dev/null
+  wait $_child_pid 2>/dev/null
+
+  # ── proc_parent ──
+  ( sleep 30 ) &
+  _child_pid=$!
+  sleep 0.3
+  local _ppid; _ppid=$(_adapter_call "proc_parent $_child_pid")
+  [ "$_ppid" = "$$" ] \
+    && pass "proc_parent: returns harness PID for spawned child" \
+    || fail "proc_parent: expected $$, got '$_ppid'"
+  kill -9 $_child_pid 2>/dev/null
+  wait $_child_pid 2>/dev/null
+
+  # ── proc_cmdline ──
+  ( sleep 30 ) &
+  _child_pid=$!
+  sleep 0.3
+  local _cmd; _cmd=$(_adapter_call "proc_cmdline $_child_pid")
+  echo "$_cmd" | grep -q 'sleep' \
+    && pass "proc_cmdline: returns command containing 'sleep'" \
+    || fail "proc_cmdline: didn't contain 'sleep' (got: '$_cmd')"
+  kill -9 $_child_pid 2>/dev/null
+  wait $_child_pid 2>/dev/null
+
+  # ── port_listeners ──
+  # Bring up a python listener on a random high port, verify
+  # port_listeners returns its PID.
+  local _test_port=49917
+  python3 -c "
+import socket, time, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', $_test_port))
+s.listen(1)
+sys.stderr.write(f'pid={__import__(\"os\").getpid()}\n')
+sys.stderr.flush()
+time.sleep(30)
+" 2> /tmp/airc-it-pa-listener.err &
+  local _listener_pid=$!
+  sleep 0.5
+  local _detected; _detected=$(_adapter_call "port_listeners $_test_port" | tr '\n' ' ')
+  echo "$_detected" | grep -qE "(^| )${_listener_pid}( |$)" \
+    && pass "port_listeners: finds python listener on :$_test_port" \
+    || fail "port_listeners: missed listener $_listener_pid (got: '$_detected', stderr: $(cat /tmp/airc-it-pa-listener.err 2>/dev/null))"
+  kill -9 $_listener_pid 2>/dev/null
+  wait $_listener_pid 2>/dev/null
+  rm -f /tmp/airc-it-pa-listener.err
+
+  # ── file_size ──
+  local _testfile; _testfile=$(mktemp -t airc-it-pa-fs.XXXXXX)
+  printf 'hello world' > "$_testfile"   # 11 bytes
+  local _sz; _sz=$(_adapter_call "file_size '$_testfile'")
+  [ "$_sz" = "11" ] \
+    && pass "file_size: returns 11 bytes for 'hello world'" \
+    || fail "file_size: expected 11, got '$_sz'"
+  rm -f "$_testfile"
+
+  _sz=$(_adapter_call "file_size /nonexistent/path/here")
+  [ "$_sz" = "0" ] \
+    && pass "file_size: returns 0 for missing file" \
+    || fail "file_size on missing: expected 0, got '$_sz'"
+
+  # ── detect_platform ──
+  local _plat; _plat=$(_adapter_call "detect_platform")
+  case "$_plat" in
+    macos|linux|wsl|windows-bash|unknown)
+      pass "detect_platform: returns valid value '$_plat'" ;;
+    *)
+      fail "detect_platform: unexpected value '$_plat'" ;;
+  esac
+  case "$(uname -s 2>/dev/null)" in
+    Darwin) [ "$_plat" = "macos" ] \
+      && pass "detect_platform: 'macos' on Darwin matches uname" \
+      || fail "detect_platform: Darwin should map to 'macos' (got '$_plat')" ;;
+    Linux)
+      case "$_plat" in
+        linux|wsl) pass "detect_platform: '$_plat' on Linux matches uname (linux or wsl)" ;;
+        *)         fail "detect_platform: Linux should map to linux or wsl (got '$_plat')" ;;
+      esac ;;
+  esac
+
+  # ── proc_children fallback (Windows compat path) ──
+  # Skipping the simulated-pgrep-missing test on platforms that have
+  # pgrep — naive PATH manipulation removes co-located tools (awk, ps)
+  # and breaks the very fallback we'd be exercising. The fallback is
+  # tested for real when running on Git Bash for Windows, where pgrep
+  # is genuinely absent. On those platforms this scenario's earlier
+  # proc_children assertion validates the ps-based code path
+  # automatically (no special simulation needed).
+  echo "  (proc_children fallback exercised for real on platforms without pgrep — see Windows runs)"
+
+  rm -f "$_adapters_extract"
+  cleanup_all
+}
+
 case "$MODE" in
   tabs)         scenario_tabs  ;;
   scope)        scenario_scope ;;
@@ -2649,8 +2808,9 @@ case "$MODE" in
   send_room_flag) scenario_send_room_flag ;;
   peers_cross_scope) scenario_peers_cross_scope ;;
   part_keeps_sidecar) scenario_part_keeps_sidecar ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_room_overrides_resume; scenario_stale_auth_room_selfheal; scenario_send_dead_monitor_dies; scenario_resume_404_gist_no_silent_exit; scenario_resume_prints_connected_banner; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_part_keeps_sidecar ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|room_overrides_resume|stale_auth_room_selfheal|send_dead_monitor_dies|resume_404_gist_no_silent_exit|resume_prints_connected_banner|general_sidecar_default|send_room_flag|peers_cross_scope|part_keeps_sidecar|all]"; exit 2 ;;
+  platform_adapters) scenario_platform_adapters ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_resume_stale_auth; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_room_overrides_resume; scenario_stale_auth_room_selfheal; scenario_send_dead_monitor_dies; scenario_resume_404_gist_no_silent_exit; scenario_resume_prints_connected_banner; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_part_keeps_sidecar; scenario_platform_adapters ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|resume_stale_auth|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|room_overrides_resume|stale_auth_room_selfheal|send_dead_monitor_dies|resume_404_gist_no_silent_exit|resume_prints_connected_banner|general_sidecar_default|send_room_flag|peers_cross_scope|part_keeps_sidecar|platform_adapters|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary

Joel, 2026-04-26: *\"we mess each other up if we dont abstract.\"* / *\"fixing one [platform] can degrade the other.\"*

Consolidates ~17 inline platform-specific shell calls (`pgrep -P`, `lsof`, `stat -f%z`, etc.) behind 7 named adapters near the top of \`airc\`. Business logic stays platform-agnostic; porting work happens once per capability.

## Adapters added

- \`proc_children <pid>\` — pgrep primary, ps fallback
- \`proc_parent <pid>\`, \`proc_cmdline <pid>\` — ps -p X -o ppid=/command=
- \`proc_airc_pids_matching <regex>\` — pgrep -u/-f primary, ps + awk fallback
- \`port_listeners <port>\` — lsof primary, ss fallback (Linux), netstat -ano fallback (Windows)
- \`file_size <path>\` — stat -f%z (BSD) → stat -c%s (GNU) → wc -c (POSIX)
- \`detect_platform\` — macos/linux/wsl/windows-bash/unknown

## Callsites converted

- 8 \`pgrep -P\` sites → proc_children
- 2 \`pgrep -u\` sites → proc_airc_pids_matching
- 4 \`lsof -tiTCP\` sites → port_listeners
- 3 \`ps -p X -o\` sites → proc_parent / proc_cmdline
- 1 \`stat -f%z || stat -c%s\` site → file_size

## Test plan
- [x] \`bash test/integration.sh platform_adapters\` — 8/8 pass
- [x] Full \`mode=all\` regression sweep on macOS — 194/195 (1 pre-existing rename flake, passed on retry)
- [x] No new platform deps. Mac/Linux behavior unchanged. Windows compat strictly improved (Git Bash without pgrep now has a working ps fallback).
- [ ] Windows native dogfood (next phase)

## Why now
Joel taking on Windows soon. Adapters first means Windows fallback edits are 1-helper changes with contained blast radius, instead of N-callsite touches that risk regressing Mac/Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)