### PR TITLE
fix(whois): walk sibling sidecar scopes (closes #134)

### DIFF
--- a/airc
+++ b/airc
@@ -3210,77 +3210,143 @@ json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
 # cached locally — no round-trip needed for self/host/local-peer. Cross-
 # peer (we're a joiner asking about another joiner of our host) falls
 # back to a single SSH read of the host's peer file.
+#
+# Cross-scope (issue #134): walks sibling scopes (.airc + .airc.<room>)
+# so a project-tab whois can find a peer who's only in the #general
+# sidecar's host. Without this, JOIN events in the sidecar room emit
+# names that whois can't resolve, breaking the IRC mental model where
+# every room member is reachable.
 cmd_whois() {
   ensure_init
   local target="${1:-}"
   local my_name; my_name=$(get_name)
 
-  # Self
+  # Self — same identity across all scopes, no walk needed.
   if [ -z "$target" ] || [ "$target" = "$my_name" ]; then
     _identity_show
     return 0
   fi
 
   # Reject path-traversal / shell-injection in target before it touches
-  # filesystem paths (local PEERS_DIR/<target>.json) or remote SSH cmds
-  # (cat $host_airc_home/peers/<target>.json).
+  # filesystem paths (local <scope>/peers/<target>.json) or remote SSH
+  # cmds (cat $host_airc_home/peers/<target>.json) in any scope.
   _validate_peer_name "$target"
 
-  # Host (we're a joiner, target is the host we paired with)
-  local host_name; host_name=$(get_config_val host_name "")
-  if [ -n "$host_name" ] && [ "$target" = "$host_name" ]; then
-    local host_id_blob; host_id_blob=$(CONFIG="$CONFIG" python3 -c '
-import json, os
-c = json.load(open(os.environ["CONFIG"]))
-print(json.dumps(c.get("host_identity", {}) or {}))
-' 2>/dev/null || echo "{}")
-    _whois_pretty "$target" "$host_id_blob" "$(get_config_val host_target '')"
+  # Try primary scope first, then walk sibling sidecar scopes. First
+  # hit wins. The order matters: primary scope's host/peer-file lookups
+  # are local-only (cheap); sibling scopes may add an SSH round-trip
+  # per scope for the cross-peer-via-host path.
+  if _whois_in_scope "$AIRC_WRITE_DIR" "$target"; then
     return 0
   fi
 
-  # Local peer file — flat layout: $PEERS_DIR/<peer>.json
-  local peer_file="$PEERS_DIR/$target.json"
+  local parent self_base prefix sibling
+  parent=$(dirname "$AIRC_WRITE_DIR")
+  self_base=$(basename "$AIRC_WRITE_DIR")
+  # Strip a trailing .<word> to recover the primary prefix. Mirrors the
+  # detection in cmd_peers (#124) so .airc / .airc.general both resolve
+  # to .airc as the prefix; in tests we see state / state.general → state.
+  prefix=$(printf '%s' "$self_base" | sed -E 's/\.[a-z0-9-]+$//')
+  if [ -d "$parent" ]; then
+    for sibling in "$parent/$prefix" "$parent/$prefix".*; do
+      [ -d "$sibling" ] || continue
+      [ "$sibling" = "$AIRC_WRITE_DIR" ] && continue
+      [ -f "$sibling/config.json" ] || continue
+      if _whois_in_scope "$sibling" "$target"; then
+        return 0
+      fi
+    done
+  fi
+
+  echo "  whois: no record for '$target' (try airc peers to list paired peers)"
+  return 1
+}
+
+# Per-scope whois lookup. Returns 0 + prints if found; non-zero if not.
+# Args: scope-dir, target-name. Caller has already validated target.
+_whois_in_scope() {
+  local scope="$1" target="$2"
+  local scope_config="$scope/config.json"
+  local scope_peers="$scope/peers"
+  [ -f "$scope_config" ] || return 1
+
+  # Host of this scope (we're a joiner, target is the host we paired with).
+  local host_name
+  host_name=$(SCOPE_CONFIG="$scope_config" python3 -c '
+import json, os
+try: print(json.load(open(os.environ["SCOPE_CONFIG"])).get("host_name", "") or "")
+except Exception: pass
+' 2>/dev/null || echo "")
+  if [ -n "$host_name" ] && [ "$target" = "$host_name" ]; then
+    local host_id_blob host_target_addr
+    host_id_blob=$(SCOPE_CONFIG="$scope_config" python3 -c '
+import json, os
+try: print(json.dumps(json.load(open(os.environ["SCOPE_CONFIG"])).get("host_identity", {}) or {}))
+except Exception: print("{}")
+' 2>/dev/null || echo "{}")
+    host_target_addr=$(SCOPE_CONFIG="$scope_config" python3 -c '
+import json, os
+try: print(json.load(open(os.environ["SCOPE_CONFIG"])).get("host_target", "") or "")
+except Exception: pass
+' 2>/dev/null || echo "")
+    _whois_pretty "$target" "$host_id_blob" "$host_target_addr"
+    return 0
+  fi
+
+  # Local peer file under this scope.
+  local peer_file="$scope_peers/$target.json"
   if [ -f "$peer_file" ]; then
-    local blob; blob=$(python3 -c "
-import json
-p = json.load(open('$peer_file'))
-print(json.dumps(p.get('identity', {}) or {}))
-" 2>/dev/null)
-    local host; host=$(python3 -c "
-import json
-print(json.load(open('$peer_file')).get('host', ''))
-" 2>/dev/null)
+    local blob host
+    blob=$(PEER_FILE="$peer_file" python3 -c '
+import json, os
+try: print(json.dumps(json.load(open(os.environ["PEER_FILE"])).get("identity", {}) or {}))
+except Exception: print("{}")
+' 2>/dev/null)
+    host=$(PEER_FILE="$peer_file" python3 -c '
+import json, os
+try: print(json.load(open(os.environ["PEER_FILE"])).get("host", "") or "")
+except Exception: pass
+' 2>/dev/null)
     _whois_pretty "$target" "$blob" "$host"
     return 0
   fi
 
-  # Cross-peer via host (we're a joiner; query host's peer file remotely)
-  local host_target; host_target=$(get_config_val host_target "")
-  local host_airc_home; host_airc_home=$(get_config_val host_airc_home "")
-  if [ -n "$host_target" ] && [ -n "$host_airc_home" ]; then
+  # Cross-peer via this scope's host (we're a joiner; query host's peer
+  # file remotely). Skipped when we're the host of this scope (no
+  # host_target). The SSH key for this scope is at $scope/identity/ssh_key
+  # — relay_ssh picks up IDENTITY_DIR from the env, so we set it for the
+  # subprocess.
+  local host_target_addr host_airc_home
+  host_target_addr=$(SCOPE_CONFIG="$scope_config" python3 -c '
+import json, os
+try: print(json.load(open(os.environ["SCOPE_CONFIG"])).get("host_target", "") or "")
+except Exception: pass
+' 2>/dev/null || echo "")
+  host_airc_home=$(SCOPE_CONFIG="$scope_config" python3 -c '
+import json, os
+try: print(json.load(open(os.environ["SCOPE_CONFIG"])).get("host_airc_home", "") or "")
+except Exception: pass
+' 2>/dev/null || echo "")
+  if [ -n "$host_target_addr" ] && [ -n "$host_airc_home" ]; then
     local remote_blob
-    remote_blob=$(relay_ssh "$host_target" "cat $host_airc_home/peers/$target.json 2>/dev/null" 2>/dev/null || true)
+    remote_blob=$(IDENTITY_DIR="$scope/identity" relay_ssh "$host_target_addr" "cat $host_airc_home/peers/$target.json 2>/dev/null" 2>/dev/null || true)
     if [ -n "$remote_blob" ]; then
-      local peer_id; peer_id=$(printf '%s' "$remote_blob" | python3 -c '
+      local peer_id peer_host
+      peer_id=$(printf '%s' "$remote_blob" | python3 -c '
 import sys, json
-try:
-    print(json.dumps(json.load(sys.stdin).get("identity", {}) or {}))
-except Exception:
-    print("{}")
+try: print(json.dumps(json.load(sys.stdin).get("identity", {}) or {}))
+except Exception: print("{}")
 ' 2>/dev/null)
-      local peer_host; peer_host=$(printf '%s' "$remote_blob" | python3 -c '
+      peer_host=$(printf '%s' "$remote_blob" | python3 -c '
 import sys, json
-try:
-    print(json.load(sys.stdin).get("host", ""))
-except Exception:
-    print("")
+try: print(json.load(sys.stdin).get("host", "") or "")
+except Exception: pass
 ' 2>/dev/null)
       _whois_pretty "$target" "$peer_id" "$peer_host"
       return 0
     fi
   fi
 
-  echo "  whois: no record for '$target' (try airc peers to list paired peers)"
   return 1
 }
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2249,6 +2249,97 @@ JSON
   cleanup_all
 }
 
+# ── Scenario: whois_cross_scope (issue #134) ───────────────────────────
+# Pre-fix: cmd_whois only consulted the primary scope. A peer who
+# was paired in the #general sidecar but not in the primary project
+# room returned "no record" — even though airc peers (post-#124)
+# already showed them. JOIN events in the sidecar emitted names
+# whois couldn't resolve.
+#
+# Post-fix: cmd_whois walks sibling scopes (.airc + .airc.<room>)
+# and tries each scope's host / local-peer / cross-peer-via-host
+# lookups. First hit wins; "no record" only after exhausting all.
+#
+# Test exercises the local-peer path in sibling scope (the SSH-based
+# cross-peer path is symmetric in code and covered by scenario_whois
+# at the primary scope). Also verifies sibling-scope HOST lookup
+# works — whois on the sidecar's host name should pull host_identity
+# out of the sidecar's config.json rather than 404.
+scenario_whois_cross_scope() {
+  section "whois_cross_scope: airc whois walks sibling scopes (issue #134)"
+  cleanup_all
+
+  local primary=/tmp/airc-it-wcs/state
+  local sidecar=/tmp/airc-it-wcs/state.general
+  mkdir -p "$primary/identity" "$primary/peers" "$sidecar/identity" "$sidecar/peers"
+  ssh-keygen -t ed25519 -f "$primary/identity/ssh_key" -N '' -q -C 'wcs-primary' 2>/dev/null
+  ssh-keygen -t ed25519 -f "$sidecar/identity/ssh_key" -N '' -q -C 'wcs-sidecar' 2>/dev/null
+  # Primary scope: paired with phost in #myproject. No fellow joiners.
+  cat > "$primary/config.json" <<'JSON'
+{
+  "name": "alpha",
+  "host_name": "phost",
+  "host_target": "joel@10.0.0.1",
+  "host_identity": {"pronouns":"they","role":"primary-host","bio":"primary host bio"}
+}
+JSON
+  echo "myproject" > "$primary/room_name"
+  # Sidecar scope: paired with shost in #general. Fellow joiner 'lobbymate'.
+  cat > "$sidecar/config.json" <<'JSON'
+{
+  "name": "alpha",
+  "host_name": "shost",
+  "host_target": "joel@10.0.0.2",
+  "host_identity": {"pronouns":"she","role":"general-host","bio":"general host bio"}
+}
+JSON
+  echo "general" > "$sidecar/room_name"
+  cat > "$sidecar/peers/lobbymate.json" <<'JSON'
+{"name":"lobbymate","host":"joel@10.0.0.99","ssh_pub":"ssh-ed25519 AAAA",
+ "identity":{"pronouns":"they","role":"fellow-joiner","bio":"in general only"}}
+JSON
+
+  local out
+  # ── from primary scope: sidecar peer should resolve ────────────────
+  out=$(AIRC_HOME="$primary" "$AIRC" whois lobbymate 2>&1)
+  echo "$out" | grep -q "role: *fellow-joiner" \
+    && pass "primary scope finds sidecar-only peer (role)" \
+    || fail "primary scope didn't find sidecar peer (got: $out)"
+  echo "$out" | grep -q "bio: *in general only" \
+    && pass "primary scope finds sidecar-only peer (bio)" \
+    || fail "primary scope sidecar peer missing bio (got: $out)"
+
+  # ── from primary scope: sidecar HOST should resolve ────────────────
+  # shost is the host of the sidecar's #general — primary scope's
+  # host_name is phost, so the lookup must walk into sidecar's config
+  # and read host_identity from there.
+  out=$(AIRC_HOME="$primary" "$AIRC" whois shost 2>&1)
+  echo "$out" | grep -q "role: *general-host" \
+    && pass "primary scope finds sidecar host via cross-scope walk" \
+    || fail "primary scope didn't resolve sidecar host (got: $out)"
+
+  # ── from primary scope: primary host still resolves (no regression)
+  out=$(AIRC_HOME="$primary" "$AIRC" whois phost 2>&1)
+  echo "$out" | grep -q "role: *primary-host" \
+    && pass "primary scope still resolves primary host (no regression)" \
+    || fail "primary host lookup regressed (got: $out)"
+
+  # ── from primary scope: unknown peer still graceful ────────────────
+  out=$(AIRC_HOME="$primary" "$AIRC" whois ghost-zzz 2>&1 || true)
+  echo "$out" | grep -q "no record for 'ghost-zzz'" \
+    && pass "unknown peer still 404s after walking all scopes" \
+    || fail "unknown peer error message regressed (got: $out)"
+
+  # ── from sidecar scope: same merged view (operator perspective) ────
+  out=$(AIRC_HOME="$sidecar" "$AIRC" whois phost 2>&1)
+  echo "$out" | grep -q "role: *primary-host" \
+    && pass "sidecar scope finds primary host (symmetric walk)" \
+    || fail "sidecar scope didn't resolve primary host (got: $out)"
+
+  rm -rf /tmp/airc-it-wcs
+  cleanup_all
+}
+
 # ── Scenario: part_keeps_sidecar (IRC /part semantics) ──────────────────
 # Pre-fix: `airc part` from the primary scope called cmd_teardown which
 # (post-#122) cleaned both primary AND sidecar scopes — so leaving
@@ -2501,10 +2592,11 @@ case "$MODE" in
   general_sidecar_default) scenario_general_sidecar_default ;;
   send_room_flag) scenario_send_room_flag ;;
   peers_cross_scope) scenario_peers_cross_scope ;;
+  whois_cross_scope) scenario_whois_cross_scope ;;
   part_keeps_sidecar) scenario_part_keeps_sidecar ;;
   platform_adapters) scenario_platform_adapters ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_send_dead_monitor_dies; scenario_connect_after_kill_recovers; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_part_keeps_sidecar; scenario_platform_adapters ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|send_room_flag|peers_cross_scope|part_keeps_sidecar|platform_adapters|all]"; exit 2 ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_send_dead_monitor_dies; scenario_connect_after_kill_recovers; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_whois_cross_scope; scenario_part_keeps_sidecar; scenario_platform_adapters ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|send_room_flag|peers_cross_scope|whois_cross_scope|part_keeps_sidecar|platform_adapters|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Bug

vhsm-d1f4 (paired in #useideem primary + #general sidecar) saw a JOIN event for continuum-b741 in #general. Then:

```
$ airc whois continuum-b741
whois: no record for 'continuum-b741' (try airc peers to list paired peers)
```

Issue #134.

## Root cause

`cmd_whois` only consulted the **primary** scope's lookups. A peer who's only in a sidecar scope returned "no record" — even though `airc peers` (post-#124) already aggregates across scopes.

## Fix

Walk sibling sidecar scopes using the same prefix-detection pattern cmd_peers uses. Per-scope lookup logic factored into `_whois_in_scope` (host name, local peer file, cross-peer-via-host SSH). Primary scope tried first, siblings second; first hit wins.

Cross-peer SSH uses the **scope's** ssh_key (not the primary's), so a sidecar joiner can authenticate to its sidecar host even when the primary scope is paired with a different host on different keys.

## Test

`scenario_whois_cross_scope` (6 assertions):
- sidecar local peer found from primary scope (the vhsm bug)
- sidecar HOST resolved from primary scope
- primary host still resolves (no regression)
- unknown peer still 404s after walking all scopes
- symmetric: sidecar→primary lookup works

Adjacent tests still green: `whois` (5/5), `identity` (19/19), `kick` (12/12).

## Compatibility

No wire-format change. Single-scope users get the identical fast path (primary scope hit ends the walk). Empty sibling list = no-op.