### PR TITLE
feat(rooms): persist /part across reboots (closes #136)

### DIFF
--- a/airc
+++ b/airc
@@ -937,6 +937,90 @@ remote_home() {
   echo "$h"
 }
 
+# Resolve the PRIMARY scope dir for any given scope (issue #136).
+# Sidecar scopes are named `<primary>.<room>` (e.g. .airc.general). The
+# primary itself returns its own path. Used by cmd_part to write the
+# parted_rooms list into primary config (single source of truth) even
+# when /part was invoked from a sidecar scope.
+_primary_scope_for() {
+  local scope="$1"
+  local parent self_base prefix
+  parent=$(dirname "$scope")
+  self_base=$(basename "$scope")
+  prefix=$(printf '%s' "$self_base" | sed -E 's/\.[a-z0-9-]+$//')
+  if [ "$prefix" = "$self_base" ]; then
+    # Already primary — no trailing .<word> suffix to strip.
+    printf '%s' "$scope"
+  else
+    printf '%s' "$parent/$prefix"
+  fi
+}
+
+# Read the parted_rooms list (issue #136) from a primary scope's
+# config.json. Echoes one room per line (empty if unset). Caller can
+# pipe to grep -Fxq "<room>" to test membership without subshell.
+_read_parted_rooms() {
+  local primary="$1"
+  local cfg="$primary/config.json"
+  [ -f "$cfg" ] || return 0
+  CONFIG="$cfg" python3 -c '
+import json, os
+try:
+    c = json.load(open(os.environ["CONFIG"]))
+    for r in c.get("parted_rooms", []) or []:
+        print(r)
+except Exception:
+    pass
+' 2>/dev/null
+}
+
+# Mark a room as parted in the primary scope's config (issue #136).
+# Idempotent — re-parting the same room does not create duplicates.
+# Persists across teardown/reboot so /part is sticky, not session-only.
+_record_parted_room() {
+  local primary="$1" room="$2"
+  local cfg="$primary/config.json"
+  [ -f "$cfg" ] || return 0
+  CONFIG="$cfg" ROOM="$room" python3 -c '
+import json, os, sys
+cfg = os.environ["CONFIG"]
+room = os.environ["ROOM"]
+try:
+    c = json.load(open(cfg))
+except Exception:
+    # Better to no-op than corrupt config; the missing persist surfaces
+    # as auto-resubscribe on next bootstrap, not silent state corruption.
+    sys.exit(0)
+parted = list(c.get("parted_rooms", []) or [])
+if room not in parted:
+    parted.append(room)
+    c["parted_rooms"] = parted
+    json.dump(c, open(cfg, "w"), indent=2)
+' 2>/dev/null || true
+}
+
+# Remove a room from the primary scope's parted_rooms (issue #136).
+# Used by `airc join --general` (and similar explicit re-opt-in flows)
+# to undo a prior /part.
+_clear_parted_room() {
+  local primary="$1" room="$2"
+  local cfg="$primary/config.json"
+  [ -f "$cfg" ] || return 0
+  CONFIG="$cfg" ROOM="$room" python3 -c '
+import json, os, sys
+cfg = os.environ["CONFIG"]
+room = os.environ["ROOM"]
+try:
+    c = json.load(open(cfg))
+except Exception:
+    sys.exit(0)
+parted = [r for r in (c.get("parted_rooms", []) or []) if r != room]
+if parted != (c.get("parted_rooms", []) or []):
+    c["parted_rooms"] = parted
+    json.dump(c, open(cfg, "w"), indent=2)
+' 2>/dev/null || true
+}
+
 # Spawn the #general sidecar (issue #121) — a parallel `airc connect`
 # in a sibling scope (.general suffix) so the primary tab is in BOTH
 # its project room AND the lobby. Identity NICK is shared via AIRC_NAME;
@@ -962,6 +1046,17 @@ spawn_general_sidecar_if_wanted() {
   local _primary_scope="$AIRC_WRITE_DIR"
   local _primary_name; _primary_name=$(get_name 2>/dev/null || echo "")
   local _sidecar_scope="${_primary_scope}.general"
+
+  # Issue #136: honor a prior /part. If "general" is in the primary
+  # scope's parted_rooms list, the user explicitly left the lobby —
+  # don't auto-resubscribe on bootstrap. Override with `airc join
+  # --general` (cmd_connect calls _clear_parted_room) or by editing
+  # config.json. Env/flag opt-outs are session-only and do NOT touch
+  # parted_rooms; only an explicit /part persists.
+  if _read_parted_rooms "$_primary_scope" | grep -Fxq "general"; then
+    echo "  Sidecar #general skipped — previously parted (airc join --general to rejoin)."
+    return 0
+  fi
 
   echo "  Sidecar: also subscribing to #general (--no-general to opt out)"
 
@@ -1613,6 +1708,7 @@ cmd_connect() {
   local room_explicit=0  # set to 1 when user passes --room explicitly
   local use_room=1   # default ON — auto-#general substrate
   local general_sidecar=1   # default ON (issue #121) — also subscribe to #general
+  local _force_general_sidecar=0   # set by --general flag (issue #136 re-opt-in)
   # Recursion guard: when WE are the sidecar (spawned by another airc
   # connect), don't spawn our own sidecar. Otherwise: turtles all the way.
   [ "${AIRC_GENERAL_SIDECAR:-0}" = "1" ] && general_sidecar=0
@@ -1659,6 +1755,14 @@ cmd_connect() {
         # default and users need a way to opt out of just the lobby
         # part without dropping back to legacy 1:1 invites.
         general_sidecar=0; shift ;;
+      --general|-general)
+        # Issue #136: explicit re-opt-in to #general after a prior
+        # /part. Clears the room from primary scope's parted_rooms so
+        # the sidecar resubscribes. Force general_sidecar=1 too in case
+        # AIRC_GENERAL_SIDECAR=1 was set (recursion guard) — the user
+        # is explicitly asking for the sidecar, override session env.
+        # Symmetric inverse of --no-general.
+        _force_general_sidecar=1; shift ;;
       --room-only|-room-only)
         # Combo: explicit project room + skip general sidecar. For
         # focused work where lobby noise would distract.
@@ -1676,6 +1780,22 @@ cmd_connect() {
     esac
   done
   set -- "${positional[@]+"${positional[@]}"}"
+
+  # Issue #136: --general re-opt-in. Clear parted state on primary
+  # scope and force the sidecar back on. Done after arg parsing so we
+  # know AIRC_WRITE_DIR (set by ensure_init below) is meaningful — but
+  # we have to wait for ensure_init to run, since --general can be
+  # called before any prior init. The cleanup happens via a deferred
+  # check in spawn_general_sidecar_if_wanted: since _clear_parted_room
+  # is idempotent, we can call it eagerly here when config exists, and
+  # also force general_sidecar=1 to override any session env opt-out.
+  if [ "$_force_general_sidecar" = "1" ]; then
+    general_sidecar=1
+    if [ -f "$AIRC_WRITE_DIR/config.json" ]; then
+      local _primary_now; _primary_now=$(_primary_scope_for "$AIRC_WRITE_DIR")
+      _clear_parted_room "$_primary_now" "general"
+    fi
+  fi
 
   # Tailscale-installed-but-logged-out nudge. Runs AFTER flag parsing
   # so --no-tailscale takes effect. Default behavior: if Tailscale is
@@ -4053,6 +4173,17 @@ cmd_part() {
     # incorrectly trigger the stale-pairing-detect path on the next
     # resume even though they parted intentionally.
     rm -f "$room_name_file" "$gist_id_file"
+  fi
+
+  # Issue #136: persist the /part. Record the room into the PRIMARY
+  # scope's parted_rooms list so a later `airc join` won't auto-
+  # resubscribe. Only meaningful for sidecar rooms (general, future
+  # opt-in #repo etc.) — parting your project's primary scope means
+  # the whole scope is gone, so persistence there is moot.
+  local _primary_scope; _primary_scope=$(_primary_scope_for "$AIRC_WRITE_DIR")
+  if [ "$_primary_scope" != "$AIRC_WRITE_DIR" ] && [ "$room_name" != "(unnamed)" ]; then
+    _record_parted_room "$_primary_scope" "$room_name"
+    echo "  /part persisted — #${room_name} won't auto-resubscribe. Rejoin with: airc join --${room_name}"
   fi
 
   # IRC `/part` semantics — leave THIS room only; the #general sidecar

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2414,6 +2414,122 @@ scenario_part_keeps_sidecar() {
   cleanup_all
 }
 
+# ── Scenario: part_persists (issue #136) ───────────────────────────────
+# Pre-fix: /part #general left the lobby for the session, but the next
+# `airc join` auto-respawned the sidecar — your /part was useless.
+# Persistence converts /part from session-action to durable preference.
+#
+# Post-fix: cmd_part records the parted room in primary scope's
+# parted_rooms array. spawn_general_sidecar_if_wanted reads that list
+# on bootstrap and skips spawn for any room in it. `airc join --general`
+# clears "general" from parted_rooms (explicit re-opt-in).
+scenario_part_persists() {
+  section "part_persists: /part is sticky across sessions (issue #136)"
+  cleanup_all
+
+  local home1=/tmp/airc-it-pp/state
+  mkdir -p "$home1"
+
+  # ── Phase 1: primary + sidecar both up ─────────────────────────────
+  ( cd /tmp/airc-it-pp && unset AIRC_NO_GENERAL && \
+      AIRC_HOME="$home1" AIRC_NAME=alpha AIRC_PORT=7585 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room pp-room-$$ > "$home1/out.log" 2>&1 & )
+  local i
+  for i in 1 2 3 4 5 6 7 8; do
+    sleep 1
+    [ -f "${home1}.general/airc.pid" ] && [ -f "$home1/airc.pid" ] && break
+  done
+  [ -f "$home1/airc.pid" ] && [ -f "${home1}.general/airc.pid" ] \
+    && pass "phase 1: primary + sidecar both running" \
+    || { fail "phase 1: setup failed"; cleanup_all; rm -rf /tmp/airc-it-pp; return; }
+
+  # parted_rooms should be absent or empty in primary config now.
+  local before; before=$(python3 -c "
+import json
+try: print(' '.join(json.load(open('$home1/config.json')).get('parted_rooms', []) or []))
+except Exception: print('')
+" 2>/dev/null)
+  [ -z "$before" ] \
+    && pass "phase 1: primary config has empty parted_rooms initially" \
+    || fail "phase 1: parted_rooms unexpectedly populated (got: $before)"
+
+  # ── Phase 2: /part the sidecar — should write parted_rooms ─────────
+  AIRC_HOME="${home1}.general" "$AIRC" part >/dev/null 2>&1
+  sleep 1
+
+  local after; after=$(python3 -c "
+import json
+try: print(' '.join(json.load(open('$home1/config.json')).get('parted_rooms', []) or []))
+except Exception: print('')
+" 2>/dev/null)
+  [ "$after" = "general" ] \
+    && pass "phase 2: /part wrote 'general' to primary parted_rooms" \
+    || fail "phase 2: parted_rooms missing 'general' (got: '$after')"
+
+  # Full teardown to reset between phases (sidecar already gone from /part).
+  AIRC_HOME="$home1" "$AIRC" teardown >/dev/null 2>&1
+  sleep 1
+
+  # ── Phase 3: bootstrap again — sidecar must NOT spawn ──────────────
+  ( cd /tmp/airc-it-pp && unset AIRC_NO_GENERAL && \
+      AIRC_HOME="$home1" AIRC_NAME=alpha AIRC_PORT=7586 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room pp-room-$$ > "$home1/out2.log" 2>&1 & )
+  for i in 1 2 3 4 5 6 7 8; do
+    sleep 1
+    [ -f "$home1/airc.pid" ] && break
+  done
+
+  [ -f "$home1/airc.pid" ] \
+    && pass "phase 3: primary respawned" \
+    || { fail "phase 3: primary failed to come up"; cleanup_all; rm -rf /tmp/airc-it-pp; return; }
+
+  # The sidecar pidfile should NOT exist (was parted, persisted).
+  # Wait a couple seconds for any stray sidecar spawn before asserting.
+  sleep 2
+  [ ! -f "${home1}.general/airc.pid" ] \
+    && pass "phase 3: sidecar does NOT auto-respawn (parted_rooms honored)" \
+    || fail "phase 3: sidecar respawned despite /part persistence"
+
+  # The "previously parted" notice should be in the output.
+  grep -q "previously parted" "$home1/out2.log" 2>/dev/null \
+    && pass "phase 3: 'previously parted' notice surfaced to user" \
+    || fail "phase 3: silent skip — notice missing from output (would surprise users)"
+
+  # Tear down primary before phase 4.
+  AIRC_HOME="$home1" "$AIRC" teardown >/dev/null 2>&1
+  sleep 1
+
+  # ── Phase 4: --general flag clears parted state and respawns sidecar
+  ( cd /tmp/airc-it-pp && unset AIRC_NO_GENERAL && \
+      AIRC_HOME="$home1" AIRC_NAME=alpha AIRC_PORT=7587 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room pp-room-$$ --general > "$home1/out3.log" 2>&1 & )
+  for i in 1 2 3 4 5 6 7 8; do
+    sleep 1
+    [ -f "${home1}.general/airc.pid" ] && [ -f "$home1/airc.pid" ] && break
+  done
+
+  [ -f "${home1}.general/airc.pid" ] \
+    && pass "phase 4: --general flag restored sidecar" \
+    || fail "phase 4: --general didn't respawn sidecar"
+
+  local cleared; cleared=$(python3 -c "
+import json
+try: print(' '.join(json.load(open('$home1/config.json')).get('parted_rooms', []) or []))
+except Exception: print('')
+" 2>/dev/null)
+  [ -z "$cleared" ] \
+    && pass "phase 4: --general cleared parted_rooms (round-trip works)" \
+    || fail "phase 4: parted_rooms still has stale entries (got: '$cleared')"
+
+  AIRC_HOME="$home1" "$AIRC" teardown >/dev/null 2>&1
+  sleep 1
+  rm -rf /tmp/airc-it-pp
+  cleanup_all
+}
+
 # ── Scenario: platform_adapters (cross-platform helpers contract) ──────
 # proc_children / port_listeners / proc_parent / proc_cmdline /
 # file_size / detect_platform replace inline pgrep/lsof/stat patterns
@@ -2594,9 +2710,10 @@ case "$MODE" in
   peers_cross_scope) scenario_peers_cross_scope ;;
   whois_cross_scope) scenario_whois_cross_scope ;;
   part_keeps_sidecar) scenario_part_keeps_sidecar ;;
+  part_persists) scenario_part_persists ;;
   platform_adapters) scenario_platform_adapters ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_send_dead_monitor_dies; scenario_connect_after_kill_recovers; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_whois_cross_scope; scenario_part_keeps_sidecar; scenario_platform_adapters ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|send_room_flag|peers_cross_scope|whois_cross_scope|part_keeps_sidecar|platform_adapters|all]"; exit 2 ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_send_dead_monitor_dies; scenario_connect_after_kill_recovers; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_whois_cross_scope; scenario_part_keeps_sidecar; scenario_part_persists; scenario_platform_adapters ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|send_room_flag|peers_cross_scope|whois_cross_scope|part_keeps_sidecar|part_persists|platform_adapters|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Bug

\`airc part #general\` was session-only. Next \`airc join\` auto-respawned the sidecar — your /part was useless. The substrate replayed the same noise after every reboot or teardown, which is exactly what AI agents can't drift past on their own.

## Fix

- \`cmd_part\` records the parted room into the **primary scope's** \`parted_rooms\` list. Single source of truth even when /part is invoked from a sidecar scope — \`_primary_scope_for\` strips the trailing \`.<room>\` suffix to find the parent.
- \`spawn_general_sidecar_if_wanted\` reads \`parted_rooms\` on bootstrap. If "general" is in the list, skips spawn with a "previously parted" notice (no silent skip).
- New \`airc join --general\` flag: explicit re-opt-in. Clears "general" from \`parted_rooms\` and forces \`general_sidecar=1\` (overrides \`AIRC_GENERAL_SIDECAR\` recursion guard / \`AIRC_NO_GENERAL\` env). Symmetric inverse of \`--no-general\`.

## Override hierarchy (deliberate)

| Mechanism | Persisted? | Effect |
|---|---|---|
| \`/part #general\` | yes | writes parted_rooms |
| \`airc join --general\` | yes | clears parted_rooms |
| \`--no-general\` flag | no (session) | skips spawn this run only |
| \`AIRC_NO_GENERAL=1\` env | no (session) | same as flag |
| \`AIRC_GENERAL_SIDECAR=1\` | no (session) | recursion guard inside sidecar |

Why session-only opt-outs DON'T touch parted_rooms: test harnesses set \`AIRC_NO_GENERAL=1\` to suppress sidecar noise during runs — they shouldn't accidentally persist the choice into the user's real config.

## Test (\`scenario_part_persists\`, 8 phases)

- **Phase 1**: primary + sidecar both up, parted_rooms empty
- **Phase 2**: /part writes "general" to primary's parted_rooms
- **Phase 3**: re-bootstrap respects parted_rooms (sidecar does NOT respawn) + "previously parted" notice surfaces
- **Phase 4**: \`--general\` round-trip clears parted_rooms and respawns sidecar

Adjacent: \`part_keeps_sidecar\` (6/6) + \`general_sidecar_default\` (12/12), no regressions.

## Future-ready for #137

\`parted_rooms\` is a list, not a single bool, so per-repo / per-org sidecars (issue #137) can use the same mechanism without schema migration.