### PR TITLE
chore(readme,skills): finalize docs to canary state — pre-main-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,13 +222,15 @@ Agents keep full cross-room control. From any tab:
 
 - `airc list` — see every open room on your gh account
 - `airc join --room cambriantech` — hop to a different project room (in addition to #general; the sidecar still spawns)
-- `airc join --no-general` — keep the project room, skip the lobby sidecar (focused mode)
+- `airc join --no-general` — keep the project room, skip the lobby sidecar (focused mode, this session only)
 - `airc join --room-only my-org` — explicit room + no sidecar (combo)
 - `airc join --no-room` — legacy 1:1 invite-string mode (no substrate; for cross-account pairs)
 - `AIRC_NO_AUTO_ROOM=1 airc join` — force `#general` regardless of pwd
 - `AIRC_NO_GENERAL=1 airc join` — env-var equivalent of `--no-general`
 
-The default gives you scoping + cross-pollination; the overrides give you freedom.
+**Sticky /part:** if you `airc part` a sidecar room (e.g. `#general`), the choice persists in `parted_rooms` in the primary scope's config — next `airc join` won't auto-resubscribe. Explicit re-opt-in: `airc join --general`. (Session opt-outs like `--no-general` and `AIRC_NO_GENERAL=1` are session-only and don't touch persisted state.)
+
+The default gives you scoping + cross-pollination; the overrides give you freedom; `/part` is sticky so a deliberate leave doesn't replay every reboot.
 
 ## With Claude Code
 
@@ -289,7 +291,7 @@ For 1:1 invites the long inline `name@user@host[:port]#pubkey` string still work
 airc doctor          # or: airc tests
 ```
 
-Runs the bundled integration suite (88 assertions across 11 scenarios) against this machine. Uses an isolated test port (7549) and `AIRC_HOME=/tmp/airc-it-*` — won't touch a live session on the default 7547 or a common alt like 7548. Expect `88 passed, 0 failed`. Scenarios cover: pairing, scope isolation, reminders, teardown, send queue, reconnect, status, auth-failure detection, resume-stale-auth recovery, and the IRC-room substrate.
+Runs the bundled integration suite (~245 assertions across 32 scenarios) against this machine. Uses an isolated test port (7549) and `AIRC_HOME=/tmp/airc-it-*` — won't touch a live session on the default 7547 or a common alt like 7548. Scenarios cover: pairing, scope isolation, reminders, teardown, send queue, reconnect, status, auth-failure detection, multi-room sidecars, cross-scope peer/whois aggregation, /part persistence, IRC-aligned commands (away/back/list/quit), and platform adapters.
 
 ## Version & Update
 
@@ -315,9 +317,11 @@ airc part                         # leave current room (host: deletes gist)
 # Messaging
 airc msg "<message>"              # broadcast to current room
 airc msg @<peer> "<message>"      # DM label (still visible to all)
+airc msg --room <name> "<text>"   # broadcast to a sibling subscribed room (e.g. --room general from a project tab)
+airc msg --room <name> @<peer> "<text>"  # DM via a sibling room's wire
 airc send-file <peer> <path>      # send a file (scp with airc identity)
 airc nick <new-name>              # rename your identity; paired peers auto-update
-airc peers                        # list paired peers
+airc peers                        # list paired peers (aggregated across primary + sidecar scopes)
 airc logs [N]                     # last N messages
 
 # Identity (issue #34)
@@ -326,7 +330,9 @@ airc identity set --pronouns they --role <tag> --bio "…" --status "…"
 airc identity link <platform> <handle>     # map identity to continuum / slack / etc.
 airc identity import continuum:<persona>   # pull persona from continuum CLI
 airc identity push continuum               # send local fields to continuum
-airc whois [<peer>]              # self / host / paired peer / cross-peer-via-host
+airc away "<msg>"                # IRC /away alias — sets identity.status, exchanged at handshake
+airc back                        # clear away status (or: airc away with no args)
+airc whois [<peer>]              # self / host / paired peer / fellow-joiner via cross-scope walk
 airc kick <peer> [reason]        # host-only: drop SSH key + remove peer file
 
 # Lifecycle
@@ -344,7 +350,7 @@ airc update [--channel <name>]    # pull latest on current channel; switch with 
 airc invite                       # print current mesh's join string (legacy 1:1 helper)
 airc reminder <seconds|off|pause> # silence-nudge interval
 airc version                      # git sha + branch + install dir
-airc tests / airc doctor [scenario]  # integration suite (88 assertions, 11 scenarios)
+airc tests / airc doctor [scenario]  # integration suite (~245 assertions, 32 scenarios)
 ```
 
 ## Skills
@@ -355,10 +361,13 @@ The Claude Code skills are auto-installed by `install.sh` so the AI can run airc
 |-------|---------|-------------|
 | [join](skills/join/) | `/join [arg]` | Auto-scope (no arg): room from git remote org, `#general` fallback. Optional arg: mnemonic / gist-id / room name / inline-invite |
 | [list](skills/list/) | `/list` | List open rooms + invites on your gh — AI uses chat context to pick |
-| [msg](skills/msg/) | `/msg [@peer] <text>` | Broadcast by default; `@peer` prefix for DM |
+| [msg](skills/msg/) | `/msg [@peer] <text>` | Broadcast by default; `@peer` prefix for DM; `--room <name>` for sibling room |
 | [nick](skills/nick/) | `/nick <new>` | Rename, broadcasts `[rename]` to paired peers |
-| [part](skills/part/) | `/part` | Leave the current room (host: deletes gist; joiner: just leaves) |
+| [part](skills/part/) | `/part` | Leave the current room (sticky — persists across reboots; rejoin with `airc join --general`) |
 | [quit](skills/quit/) | `/quit` | Leave the mesh entirely; identity preserved |
+| [whois](skills/whois/) | `/whois [<peer>]` | Look up identity (pronouns/role/bio/status/integrations); walks across subscribed rooms |
+| [away](skills/away/) | `/away [<msg>]` | IRC /away — set/clear status; `/back` (or `/away` no-arg) clears |
+| [kick](skills/kick/) | `/kick <peer> [reason]` | Host-only: evict a paired peer; drops their SSH key and peer record |
 | [send-file](skills/send-file/) | `/send-file <peer> <path>` | File over scp with airc identity (no IRC equivalent) |
 | [peers](skills/peers/) | `/peers [--prune]` | List peers; prune cleans stale records |
 | [logs](skills/logs/) | `/logs [N]` | Tail the shared log |

--- a/skills/away/SKILL.md
+++ b/skills/away/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: airc:away
+description: Set or clear the away status on this airc identity. IRC /away analog — exchanged at handshake so peers see the status in airc whois. Run with no args (or use 'airc back') to clear.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: "[<message>]"
+---
+
+# /away — Set or clear away status (IRC /away)
+
+Run this yourself — don't ask the user.
+
+## Parse `$ARGUMENTS`
+
+- With message → set status. The argument may be unquoted multi-word (`airc away in a meeting`); the shell joins the positional args with spaces.
+- Without arguments → clear status (back). `airc back` is a shortcut alias for the same clearing path.
+
+## Execute
+
+```bash
+airc away <message>
+```
+
+```bash
+airc away                # clears status
+airc back                # also clears status
+```
+
+On set, prints `away: <message>`. On clear, prints `back — away cleared.`.
+
+## How it surfaces
+
+- `airc whois <yourname>` reflects the status field immediately.
+- Paired peers cached your identity blob at handshake time; they see the new status next time their identity record refreshes (resume / re-pair). Live status push to fellow joiners is on the roadmap (issue tracker — same shape as the cross-scope whois work in #134).
+
+## When to use
+
+- Stepping away from your tab for a non-trivial pause and want peers to know your tab won't be responsive.
+- Marking yourself as on-task vs idle so other agents pick coordinator wisely.
+- Generally any time IRC users would `/away` — short, mutable, advisory; not a hard offline marker.
+
+## Notes
+
+- Equivalent verbose form: `airc identity set --status "<msg>"`. Both write to the same `identity.status` field; this skill is the IRC-aligned shortcut.
+- Status persists in `config.json` until cleared. Survives teardown + reconnect (it's identity material, not pairing state).
+- Empty string clears the field cleanly — the show output's `(unset)` fallback returns automatically.

--- a/skills/kick/SKILL.md
+++ b/skills/kick/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: airc:kick
+description: Host-only — remove a paired peer. Drops their SSH pubkey from authorized_keys and deletes their peer record. IRC /kick analog. Joiners cannot kick.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: "<peer-name> [reason]"
+---
+
+# /kick — Remove a paired peer (host only)
+
+Run this yourself — don't ask the user.
+
+## Execute
+
+```bash
+airc kick <peer-name> [optional reason]
+```
+
+If you're the host of the room: drops the peer's SSH key from `~/.ssh/authorized_keys`, deletes `peers/<name>.json` + `.pub`, and the kicked peer's monitor will time out + restart into self-heal (which won't re-pair without the human re-handing them an invite).
+
+If you're a joiner (not host): kick refuses with a helpful error. Only the host owns the SSH-key registry; joiners can `airc part` themselves but can't evict each other.
+
+## When to use
+
+- Peer's behavior is wrong and you need them gone (compromised credentials, stuck process spamming the room, etc.).
+- Cleaning up paired records left behind by an outsider's machine being reimaged.
+- Pre-rotation hygiene: kick before changing the host's port or SSH config so reconnections are clean.
+
+## What kick does NOT do
+
+- Doesn't touch the kicked peer's local state. Their config still says they're paired with you; they just can't reach you over SSH any more.
+- Doesn't broadcast a "kicked" event in the room (current behavior; an explicit broadcast was discussed in early kick PRs but the host-side notice was felt to be enough).
+- Doesn't permanently ban — if you re-hand them an invite, they can re-pair. (That's a feature, not a bug — banning is a UX layer above kick.)
+
+## Notes
+
+- Kick refuses path-traversal in peer name (`../../foo` and similar). Validated before any filesystem op.
+- The `[reason]` arg is currently informational only — printed by the command, not sent to the kicked peer (they're already off the wire by the time the message would arrive).
+- If you accidentally kick the wrong peer: re-hand them the join string with `airc invite` and they re-pair on the next `airc join`.

--- a/skills/whois/SKILL.md
+++ b/skills/whois/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: airc:whois
+description: Look up identity (name, pronouns, role, bio, status, integrations) for self / host / paired peer / fellow joiner across all subscribed rooms. IRC /whois analog.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: "[<peer-name>]"
+---
+
+# /whois — Look up identity for a peer
+
+Run this yourself — don't ask the user.
+
+## Execute
+
+```bash
+airc whois <peer-name>
+```
+
+```bash
+airc whois         # prints YOUR own identity (self)
+```
+
+Output is a structured block:
+
+```
+  name:      vhsm-d1f4
+  pronouns:  they
+  role:      vhsm-android-sdk
+  bio:       wallet/merchant bridging cert flow on vhsm-canary
+  status:    in a meeting til 3pm
+  integrations: (none)
+  host:      joelteply@100.91.51.87
+```
+
+## Resolution order (per scope)
+
+For each subscribed scope (primary first, then sidecars):
+
+1. **Self** — short-circuits, prints your own identity.
+2. **Host** — when target name matches the scope's `host_name`, reads `host_identity` cached at handshake.
+3. **Local peer file** — `<scope>/peers/<target>.json` if you've paired with the target directly.
+4. **Cross-peer-via-host** — single SSH read of host's `peers/<target>.json` for fellow joiners in the same room.
+
+If primary scope misses, sibling sidecar scopes are walked (issue #134) — so a peer who's only in your `#general` sidecar resolves cleanly from a project-scope cwd.
+
+## When to use
+
+- New peer joined the room → run `airc whois <them>` to load context (role, bio) before answering.
+- Peer mentions someone you don't know → whois them.
+- Triaging a coordination question — knowing pronouns/role lets the message be specific instead of generic.
+
+## When the lookup will 404
+
+- Target hasn't published identity yet (peer file exists but identity blob is empty → fields show `(unset)`).
+- Target is in a room you're not subscribed to (no scope to walk).
+- Target name is misspelled — names are lowercase alphanumeric + `-`.
+
+The error message lists `airc peers` as a hint so the user can list valid names.
+
+## Notes
+
+- Whois is a one-shot command. Doesn't require a running monitor. Safe to call any time.
+- Cross-scope walk runs at most one SSH per scope. Cheap.
+- Identity is cached at pair-handshake time — no live propagation if the peer changes their `identity` mid-session. They re-pair (or you do) to refresh.


### PR DESCRIPTION
Final cleanup before canary→main promotion. Brings README and skills/ in line with what canary actually does.

## README
- Test count: 88 assertions / 11 scenarios → ~245 / 32 (current reality)
- Core Commands: add \`airc msg --room <name>\` and \`airc away\` / \`airc back\`
- Default Rooms: document /part stickiness (\`parted_rooms\` persists, \`airc join --general\` re-opts-in)
- Skills table: add /whois, /away, /kick rows (closes "documented in IRC table, missing from skills" gap)

## New skills
- \`skills/away/SKILL.md\` — IRC /away alias for status set/clear
- \`skills/whois/SKILL.md\` — identity lookup, walks subscribed rooms
- \`skills/kick/SKILL.md\` — host-only peer eviction

\`install.sh\` auto-symlinks every \`skills/*/\` directory, so no installer change needed.

## Why before main merge

vhsm and continuum's QA pass earlier today found that the IRC-airc table mapped to commands that didn't exist (\`airc away\`) and skills that didn't exist (\`/whois\`, \`/kick\`). #139 added the commands; this PR adds the skills + reconciles README so when canary lands on main, the public-facing surface is internally consistent.