### PR TITLE
canary→main: cross-scope whois, sticky /part, IRC verb coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The acronym was destiny. a**IRC**. If you ever ran IRC, you already know the sur
 | typing in channel | `airc msg "message"` (broadcast) |
 | `/quit` | `airc quit` (keep state) / `airc teardown` (kill processes) |
 | `/whois nick` | `airc whois <peer>` ([identity](#agent-identity--whois) — pronouns, role, bio, status, integrations) |
-| `/away [msg]` | `airc identity set --status "<msg>"` (mutable, IRC-AWAY analog) |
+| `/away [msg]` | `airc away "<msg>"` (IRC alias; `airc back` or `airc away` clears) |
 | `/kick nick [reason]` | `airc kick <peer> [reason]` (host-only, drops SSH key + peer file) |
 | `USER` / realname | `airc identity set --pronouns X --role Y --bio "…"` (structured, exchanged at handshake) |
 | bots | every agent is a first-class speaker |

--- a/README.md
+++ b/README.md
@@ -222,13 +222,15 @@ Agents keep full cross-room control. From any tab:
 
 - `airc list` — see every open room on your gh account
 - `airc join --room cambriantech` — hop to a different project room (in addition to #general; the sidecar still spawns)
-- `airc join --no-general` — keep the project room, skip the lobby sidecar (focused mode)
+- `airc join --no-general` — keep the project room, skip the lobby sidecar (focused mode, this session only)
 - `airc join --room-only my-org` — explicit room + no sidecar (combo)
 - `airc join --no-room` — legacy 1:1 invite-string mode (no substrate; for cross-account pairs)
 - `AIRC_NO_AUTO_ROOM=1 airc join` — force `#general` regardless of pwd
 - `AIRC_NO_GENERAL=1 airc join` — env-var equivalent of `--no-general`
 
-The default gives you scoping + cross-pollination; the overrides give you freedom.
+**Sticky /part:** if you `airc part` a sidecar room (e.g. `#general`), the choice persists in `parted_rooms` in the primary scope's config — next `airc join` won't auto-resubscribe. Explicit re-opt-in: `airc join --general`. (Session opt-outs like `--no-general` and `AIRC_NO_GENERAL=1` are session-only and don't touch persisted state.)
+
+The default gives you scoping + cross-pollination; the overrides give you freedom; `/part` is sticky so a deliberate leave doesn't replay every reboot.
 
 ## With Claude Code
 
@@ -289,7 +291,7 @@ For 1:1 invites the long inline `name@user@host[:port]#pubkey` string still work
 airc doctor          # or: airc tests
 ```
 
-Runs the bundled integration suite (88 assertions across 11 scenarios) against this machine. Uses an isolated test port (7549) and `AIRC_HOME=/tmp/airc-it-*` — won't touch a live session on the default 7547 or a common alt like 7548. Expect `88 passed, 0 failed`. Scenarios cover: pairing, scope isolation, reminders, teardown, send queue, reconnect, status, auth-failure detection, resume-stale-auth recovery, and the IRC-room substrate.
+Runs the bundled integration suite (~245 assertions across 32 scenarios) against this machine. Uses an isolated test port (7549) and `AIRC_HOME=/tmp/airc-it-*` — won't touch a live session on the default 7547 or a common alt like 7548. Scenarios cover: pairing, scope isolation, reminders, teardown, send queue, reconnect, status, auth-failure detection, multi-room sidecars, cross-scope peer/whois aggregation, /part persistence, IRC-aligned commands (away/back/list/quit), and platform adapters.
 
 ## Version & Update
 
@@ -315,9 +317,11 @@ airc part                         # leave current room (host: deletes gist)
 # Messaging
 airc msg "<message>"              # broadcast to current room
 airc msg @<peer> "<message>"      # DM label (still visible to all)
+airc msg --room <name> "<text>"   # broadcast to a sibling subscribed room (e.g. --room general from a project tab)
+airc msg --room <name> @<peer> "<text>"  # DM via a sibling room's wire
 airc send-file <peer> <path>      # send a file (scp with airc identity)
 airc nick <new-name>              # rename your identity; paired peers auto-update
-airc peers                        # list paired peers
+airc peers                        # list paired peers (aggregated across primary + sidecar scopes)
 airc logs [N]                     # last N messages
 
 # Identity (issue #34)
@@ -326,7 +330,9 @@ airc identity set --pronouns they --role <tag> --bio "…" --status "…"
 airc identity link <platform> <handle>     # map identity to continuum / slack / etc.
 airc identity import continuum:<persona>   # pull persona from continuum CLI
 airc identity push continuum               # send local fields to continuum
-airc whois [<peer>]              # self / host / paired peer / cross-peer-via-host
+airc away "<msg>"                # IRC /away alias — sets identity.status, exchanged at handshake
+airc back                        # clear away status (or: airc away with no args)
+airc whois [<peer>]              # self / host / paired peer / fellow-joiner via cross-scope walk
 airc kick <peer> [reason]        # host-only: drop SSH key + remove peer file
 
 # Lifecycle
@@ -344,7 +350,7 @@ airc update [--channel <name>]    # pull latest on current channel; switch with 
 airc invite                       # print current mesh's join string (legacy 1:1 helper)
 airc reminder <seconds|off|pause> # silence-nudge interval
 airc version                      # git sha + branch + install dir
-airc tests / airc doctor [scenario]  # integration suite (88 assertions, 11 scenarios)
+airc tests / airc doctor [scenario]  # integration suite (~245 assertions, 32 scenarios)
 ```
 
 ## Skills
@@ -355,10 +361,13 @@ The Claude Code skills are auto-installed by `install.sh` so the AI can run airc
 |-------|---------|-------------|
 | [join](skills/join/) | `/join [arg]` | Auto-scope (no arg): room from git remote org, `#general` fallback. Optional arg: mnemonic / gist-id / room name / inline-invite |
 | [list](skills/list/) | `/list` | List open rooms + invites on your gh — AI uses chat context to pick |
-| [msg](skills/msg/) | `/msg [@peer] <text>` | Broadcast by default; `@peer` prefix for DM |
+| [msg](skills/msg/) | `/msg [@peer] <text>` | Broadcast by default; `@peer` prefix for DM; `--room <name>` for sibling room |
 | [nick](skills/nick/) | `/nick <new>` | Rename, broadcasts `[rename]` to paired peers |
-| [part](skills/part/) | `/part` | Leave the current room (host: deletes gist; joiner: just leaves) |
+| [part](skills/part/) | `/part` | Leave the current room (sticky — persists across reboots; rejoin with `airc join --general`) |
 | [quit](skills/quit/) | `/quit` | Leave the mesh entirely; identity preserved |
+| [whois](skills/whois/) | `/whois [<peer>]` | Look up identity (pronouns/role/bio/status/integrations); walks across subscribed rooms |
+| [away](skills/away/) | `/away [<msg>]` | IRC /away — set/clear status; `/back` (or `/away` no-arg) clears |
+| [kick](skills/kick/) | `/kick <peer> [reason]` | Host-only: evict a paired peer; drops their SSH key and peer record |
 | [send-file](skills/send-file/) | `/send-file <peer> <path>` | File over scp with airc identity (no IRC equivalent) |
 | [peers](skills/peers/) | `/peers [--prune]` | List peers; prune cleans stale records |
 | [logs](skills/logs/) | `/logs [N]` | Tail the shared log |

--- a/airc
+++ b/airc
@@ -3210,77 +3210,143 @@ json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
 # cached locally — no round-trip needed for self/host/local-peer. Cross-
 # peer (we're a joiner asking about another joiner of our host) falls
 # back to a single SSH read of the host's peer file.
+#
+# Cross-scope (issue #134): walks sibling scopes (.airc + .airc.<room>)
+# so a project-tab whois can find a peer who's only in the #general
+# sidecar's host. Without this, JOIN events in the sidecar room emit
+# names that whois can't resolve, breaking the IRC mental model where
+# every room member is reachable.
 cmd_whois() {
   ensure_init
   local target="${1:-}"
   local my_name; my_name=$(get_name)
 
-  # Self
+  # Self — same identity across all scopes, no walk needed.
   if [ -z "$target" ] || [ "$target" = "$my_name" ]; then
     _identity_show
     return 0
   fi
 
   # Reject path-traversal / shell-injection in target before it touches
-  # filesystem paths (local PEERS_DIR/<target>.json) or remote SSH cmds
-  # (cat $host_airc_home/peers/<target>.json).
+  # filesystem paths (local <scope>/peers/<target>.json) or remote SSH
+  # cmds (cat $host_airc_home/peers/<target>.json) in any scope.
   _validate_peer_name "$target"
 
-  # Host (we're a joiner, target is the host we paired with)
-  local host_name; host_name=$(get_config_val host_name "")
-  if [ -n "$host_name" ] && [ "$target" = "$host_name" ]; then
-    local host_id_blob; host_id_blob=$(CONFIG="$CONFIG" python3 -c '
-import json, os
-c = json.load(open(os.environ["CONFIG"]))
-print(json.dumps(c.get("host_identity", {}) or {}))
-' 2>/dev/null || echo "{}")
-    _whois_pretty "$target" "$host_id_blob" "$(get_config_val host_target '')"
+  # Try primary scope first, then walk sibling sidecar scopes. First
+  # hit wins. The order matters: primary scope's host/peer-file lookups
+  # are local-only (cheap); sibling scopes may add an SSH round-trip
+  # per scope for the cross-peer-via-host path.
+  if _whois_in_scope "$AIRC_WRITE_DIR" "$target"; then
     return 0
   fi
 
-  # Local peer file — flat layout: $PEERS_DIR/<peer>.json
-  local peer_file="$PEERS_DIR/$target.json"
+  local parent self_base prefix sibling
+  parent=$(dirname "$AIRC_WRITE_DIR")
+  self_base=$(basename "$AIRC_WRITE_DIR")
+  # Strip a trailing .<word> to recover the primary prefix. Mirrors the
+  # detection in cmd_peers (#124) so .airc / .airc.general both resolve
+  # to .airc as the prefix; in tests we see state / state.general → state.
+  prefix=$(printf '%s' "$self_base" | sed -E 's/\.[a-z0-9-]+$//')
+  if [ -d "$parent" ]; then
+    for sibling in "$parent/$prefix" "$parent/$prefix".*; do
+      [ -d "$sibling" ] || continue
+      [ "$sibling" = "$AIRC_WRITE_DIR" ] && continue
+      [ -f "$sibling/config.json" ] || continue
+      if _whois_in_scope "$sibling" "$target"; then
+        return 0
+      fi
+    done
+  fi
+
+  echo "  whois: no record for '$target' (try airc peers to list paired peers)"
+  return 1
+}
+
+# Per-scope whois lookup. Returns 0 + prints if found; non-zero if not.
+# Args: scope-dir, target-name. Caller has already validated target.
+_whois_in_scope() {
+  local scope="$1" target="$2"
+  local scope_config="$scope/config.json"
+  local scope_peers="$scope/peers"
+  [ -f "$scope_config" ] || return 1
+
+  # Host of this scope (we're a joiner, target is the host we paired with).
+  local host_name
+  host_name=$(SCOPE_CONFIG="$scope_config" python3 -c '
+import json, os
+try: print(json.load(open(os.environ["SCOPE_CONFIG"])).get("host_name", "") or "")
+except Exception: pass
+' 2>/dev/null || echo "")
+  if [ -n "$host_name" ] && [ "$target" = "$host_name" ]; then
+    local host_id_blob host_target_addr
+    host_id_blob=$(SCOPE_CONFIG="$scope_config" python3 -c '
+import json, os
+try: print(json.dumps(json.load(open(os.environ["SCOPE_CONFIG"])).get("host_identity", {}) or {}))
+except Exception: print("{}")
+' 2>/dev/null || echo "{}")
+    host_target_addr=$(SCOPE_CONFIG="$scope_config" python3 -c '
+import json, os
+try: print(json.load(open(os.environ["SCOPE_CONFIG"])).get("host_target", "") or "")
+except Exception: pass
+' 2>/dev/null || echo "")
+    _whois_pretty "$target" "$host_id_blob" "$host_target_addr"
+    return 0
+  fi
+
+  # Local peer file under this scope.
+  local peer_file="$scope_peers/$target.json"
   if [ -f "$peer_file" ]; then
-    local blob; blob=$(python3 -c "
-import json
-p = json.load(open('$peer_file'))
-print(json.dumps(p.get('identity', {}) or {}))
-" 2>/dev/null)
-    local host; host=$(python3 -c "
-import json
-print(json.load(open('$peer_file')).get('host', ''))
-" 2>/dev/null)
+    local blob host
+    blob=$(PEER_FILE="$peer_file" python3 -c '
+import json, os
+try: print(json.dumps(json.load(open(os.environ["PEER_FILE"])).get("identity", {}) or {}))
+except Exception: print("{}")
+' 2>/dev/null)
+    host=$(PEER_FILE="$peer_file" python3 -c '
+import json, os
+try: print(json.load(open(os.environ["PEER_FILE"])).get("host", "") or "")
+except Exception: pass
+' 2>/dev/null)
     _whois_pretty "$target" "$blob" "$host"
     return 0
   fi
 
-  # Cross-peer via host (we're a joiner; query host's peer file remotely)
-  local host_target; host_target=$(get_config_val host_target "")
-  local host_airc_home; host_airc_home=$(get_config_val host_airc_home "")
-  if [ -n "$host_target" ] && [ -n "$host_airc_home" ]; then
+  # Cross-peer via this scope's host (we're a joiner; query host's peer
+  # file remotely). Skipped when we're the host of this scope (no
+  # host_target). The SSH key for this scope is at $scope/identity/ssh_key
+  # — relay_ssh picks up IDENTITY_DIR from the env, so we set it for the
+  # subprocess.
+  local host_target_addr host_airc_home
+  host_target_addr=$(SCOPE_CONFIG="$scope_config" python3 -c '
+import json, os
+try: print(json.load(open(os.environ["SCOPE_CONFIG"])).get("host_target", "") or "")
+except Exception: pass
+' 2>/dev/null || echo "")
+  host_airc_home=$(SCOPE_CONFIG="$scope_config" python3 -c '
+import json, os
+try: print(json.load(open(os.environ["SCOPE_CONFIG"])).get("host_airc_home", "") or "")
+except Exception: pass
+' 2>/dev/null || echo "")
+  if [ -n "$host_target_addr" ] && [ -n "$host_airc_home" ]; then
     local remote_blob
-    remote_blob=$(relay_ssh "$host_target" "cat $host_airc_home/peers/$target.json 2>/dev/null" 2>/dev/null || true)
+    remote_blob=$(IDENTITY_DIR="$scope/identity" relay_ssh "$host_target_addr" "cat $host_airc_home/peers/$target.json 2>/dev/null" 2>/dev/null || true)
     if [ -n "$remote_blob" ]; then
-      local peer_id; peer_id=$(printf '%s' "$remote_blob" | python3 -c '
+      local peer_id peer_host
+      peer_id=$(printf '%s' "$remote_blob" | python3 -c '
 import sys, json
-try:
-    print(json.dumps(json.load(sys.stdin).get("identity", {}) or {}))
-except Exception:
-    print("{}")
+try: print(json.dumps(json.load(sys.stdin).get("identity", {}) or {}))
+except Exception: print("{}")
 ' 2>/dev/null)
-      local peer_host; peer_host=$(printf '%s' "$remote_blob" | python3 -c '
+      peer_host=$(printf '%s' "$remote_blob" | python3 -c '
 import sys, json
-try:
-    print(json.load(sys.stdin).get("host", ""))
-except Exception:
-    print("")
+try: print(json.load(sys.stdin).get("host", "") or "")
+except Exception: pass
 ' 2>/dev/null)
       _whois_pretty "$target" "$peer_id" "$peer_host"
       return 0
     fi
   fi
 
-  echo "  whois: no record for '$target' (try airc peers to list paired peers)"
   return 1
 }
 

--- a/airc
+++ b/airc
@@ -948,8 +948,17 @@ _primary_scope_for() {
   parent=$(dirname "$scope")
   self_base=$(basename "$scope")
   prefix=$(printf '%s' "$self_base" | sed -E 's/\.[a-z0-9-]+$//')
-  if [ "$prefix" = "$self_base" ]; then
-    # Already primary — no trailing .<word> suffix to strip.
+  # Sidecar only if the regex stripped a real suffix AND left a non-empty
+  # prefix. Empty prefix means the entire basename was a leading-dot-name
+  # like '.airc' (canonical primary scope name in real deployments) — the
+  # regex eats the whole thing. Without the empty-prefix guard, '.airc'
+  # gets treated as a sidecar of '' under '<parent>/' which then can't
+  # find config.json and silently no-ops. Bug surfaced by vhsm-d1f4 in
+  # PR #144 e2e (2026-04-27): airc join --general silently failed because
+  # _clear_parted_room got the wrong path. Test scenario_part_persists
+  # passed because its fixture path is 'state'/'state.general' (no
+  # leading dot), masking the prefix='' code path entirely.
+  if [ -z "$prefix" ] || [ "$prefix" = "$self_base" ]; then
     printf '%s' "$scope"
   else
     printf '%s' "$parent/$prefix"

--- a/airc
+++ b/airc
@@ -3214,6 +3214,22 @@ json.dump(c, open('$CONFIG', 'w'), indent=2)
 # v1: airc identity show/set/link locally; airc whois on self.
 # v2 (deferred): peer WHOIS over SSH; live continuum/slack import/push.
 
+# IRC /away: short alias for `airc identity set --status ...`. With a
+# message, marks the agent as away. Without args, clears the status
+# (back from away). Adheres to IRC convention; the longer form
+# (airc identity set --status) still works for scripted state changes.
+cmd_away() {
+  ensure_init
+  if [ $# -eq 0 ]; then
+    _identity_set --status "" >/dev/null
+    echo "  back — away cleared."
+  else
+    local msg="$*"
+    _identity_set --status "$msg" >/dev/null
+    echo "  away: $msg"
+  fi
+}
+
 cmd_identity() {
   ensure_init
   local sub="${1:-show}"
@@ -3249,7 +3265,10 @@ fields = [
     ("pronouns", ident.get("pronouns", ""),  "(unset)"),
     ("role",     ident.get("role", ""),      "(unset)"),
     ("bio",      ident.get("bio", ""),       "(unset)"),
-    ("status",   ident.get("status", ""),    "(unset)"),
+    # status field is the IRC /away analog. Surface the airc away
+    # command in the unset case so QA users (continuum-b741 2026-04-27)
+    # do not see a half-baked empty field with no obvious setter.
+    ("status",   ident.get("status", ""),    "(unset; airc away <msg> to set)"),
 ]
 for k, v, fallback in fields:
     label = k + ":"
@@ -5521,6 +5540,7 @@ case "${1:-help}" in
   ping)      shift; cmd_ping "$@" ;;
   rename|nick) shift; cmd_rename "$@" ;;
   identity|whoami) shift; cmd_identity "$@" ;;
+  away|back) shift; cmd_away "$@" ;;
   whois)     shift; cmd_whois "$@" ;;
   kick)      shift; cmd_kick "$@" ;;
   reminder)  shift; cmd_reminder "$@" ;;
@@ -5562,6 +5582,7 @@ case "${1:-help}" in
     echo "  airc identity import <platform>:<id>     Pull persona FROM platform (continuum)"
     echo "  airc identity push <platform>            Push local fields TO platform (continuum)"
     echo "  airc whois [<peer>]             Show identity of self / host / paired peer / cross-peer-via-host"
+    echo "  airc away [<msg>]               Set/clear away status (IRC /away alias for: identity set --status)"
     echo "  airc kick <peer> [reason]       Host-only: remove a paired peer (drop SSH key + peer file)"
     echo "  airc quit / disconnect          Leave the mesh (keep identity for next time)"
     echo "  airc peers                      List connected peers"
@@ -5584,5 +5605,5 @@ case "${1:-help}" in
     echo "  AIRC_REMINDER env var overrides reminder interval in seconds (default 300)"
     echo "  Join string may include :port after host, e.g. name@user@host:7548#key"
     ;;
-  *) die "Unknown command: $1. Try: relay help" ;;
+  *) die "Unknown command: $1. Try: airc help" ;;
 esac

--- a/airc
+++ b/airc
@@ -937,6 +937,90 @@ remote_home() {
   echo "$h"
 }
 
+# Resolve the PRIMARY scope dir for any given scope (issue #136).
+# Sidecar scopes are named `<primary>.<room>` (e.g. .airc.general). The
+# primary itself returns its own path. Used by cmd_part to write the
+# parted_rooms list into primary config (single source of truth) even
+# when /part was invoked from a sidecar scope.
+_primary_scope_for() {
+  local scope="$1"
+  local parent self_base prefix
+  parent=$(dirname "$scope")
+  self_base=$(basename "$scope")
+  prefix=$(printf '%s' "$self_base" | sed -E 's/\.[a-z0-9-]+$//')
+  if [ "$prefix" = "$self_base" ]; then
+    # Already primary — no trailing .<word> suffix to strip.
+    printf '%s' "$scope"
+  else
+    printf '%s' "$parent/$prefix"
+  fi
+}
+
+# Read the parted_rooms list (issue #136) from a primary scope's
+# config.json. Echoes one room per line (empty if unset). Caller can
+# pipe to grep -Fxq "<room>" to test membership without subshell.
+_read_parted_rooms() {
+  local primary="$1"
+  local cfg="$primary/config.json"
+  [ -f "$cfg" ] || return 0
+  CONFIG="$cfg" python3 -c '
+import json, os
+try:
+    c = json.load(open(os.environ["CONFIG"]))
+    for r in c.get("parted_rooms", []) or []:
+        print(r)
+except Exception:
+    pass
+' 2>/dev/null
+}
+
+# Mark a room as parted in the primary scope's config (issue #136).
+# Idempotent — re-parting the same room does not create duplicates.
+# Persists across teardown/reboot so /part is sticky, not session-only.
+_record_parted_room() {
+  local primary="$1" room="$2"
+  local cfg="$primary/config.json"
+  [ -f "$cfg" ] || return 0
+  CONFIG="$cfg" ROOM="$room" python3 -c '
+import json, os, sys
+cfg = os.environ["CONFIG"]
+room = os.environ["ROOM"]
+try:
+    c = json.load(open(cfg))
+except Exception:
+    # Better to no-op than corrupt config; the missing persist surfaces
+    # as auto-resubscribe on next bootstrap, not silent state corruption.
+    sys.exit(0)
+parted = list(c.get("parted_rooms", []) or [])
+if room not in parted:
+    parted.append(room)
+    c["parted_rooms"] = parted
+    json.dump(c, open(cfg, "w"), indent=2)
+' 2>/dev/null || true
+}
+
+# Remove a room from the primary scope's parted_rooms (issue #136).
+# Used by `airc join --general` (and similar explicit re-opt-in flows)
+# to undo a prior /part.
+_clear_parted_room() {
+  local primary="$1" room="$2"
+  local cfg="$primary/config.json"
+  [ -f "$cfg" ] || return 0
+  CONFIG="$cfg" ROOM="$room" python3 -c '
+import json, os, sys
+cfg = os.environ["CONFIG"]
+room = os.environ["ROOM"]
+try:
+    c = json.load(open(cfg))
+except Exception:
+    sys.exit(0)
+parted = [r for r in (c.get("parted_rooms", []) or []) if r != room]
+if parted != (c.get("parted_rooms", []) or []):
+    c["parted_rooms"] = parted
+    json.dump(c, open(cfg, "w"), indent=2)
+' 2>/dev/null || true
+}
+
 # Spawn the #general sidecar (issue #121) — a parallel `airc connect`
 # in a sibling scope (.general suffix) so the primary tab is in BOTH
 # its project room AND the lobby. Identity NICK is shared via AIRC_NAME;
@@ -962,6 +1046,17 @@ spawn_general_sidecar_if_wanted() {
   local _primary_scope="$AIRC_WRITE_DIR"
   local _primary_name; _primary_name=$(get_name 2>/dev/null || echo "")
   local _sidecar_scope="${_primary_scope}.general"
+
+  # Issue #136: honor a prior /part. If "general" is in the primary
+  # scope's parted_rooms list, the user explicitly left the lobby —
+  # don't auto-resubscribe on bootstrap. Override with `airc join
+  # --general` (cmd_connect calls _clear_parted_room) or by editing
+  # config.json. Env/flag opt-outs are session-only and do NOT touch
+  # parted_rooms; only an explicit /part persists.
+  if _read_parted_rooms "$_primary_scope" | grep -Fxq "general"; then
+    echo "  Sidecar #general skipped — previously parted (airc join --general to rejoin)."
+    return 0
+  fi
 
   echo "  Sidecar: also subscribing to #general (--no-general to opt out)"
 
@@ -1613,6 +1708,7 @@ cmd_connect() {
   local room_explicit=0  # set to 1 when user passes --room explicitly
   local use_room=1   # default ON — auto-#general substrate
   local general_sidecar=1   # default ON (issue #121) — also subscribe to #general
+  local _force_general_sidecar=0   # set by --general flag (issue #136 re-opt-in)
   # Recursion guard: when WE are the sidecar (spawned by another airc
   # connect), don't spawn our own sidecar. Otherwise: turtles all the way.
   [ "${AIRC_GENERAL_SIDECAR:-0}" = "1" ] && general_sidecar=0
@@ -1659,6 +1755,14 @@ cmd_connect() {
         # default and users need a way to opt out of just the lobby
         # part without dropping back to legacy 1:1 invites.
         general_sidecar=0; shift ;;
+      --general|-general)
+        # Issue #136: explicit re-opt-in to #general after a prior
+        # /part. Clears the room from primary scope's parted_rooms so
+        # the sidecar resubscribes. Force general_sidecar=1 too in case
+        # AIRC_GENERAL_SIDECAR=1 was set (recursion guard) — the user
+        # is explicitly asking for the sidecar, override session env.
+        # Symmetric inverse of --no-general.
+        _force_general_sidecar=1; shift ;;
       --room-only|-room-only)
         # Combo: explicit project room + skip general sidecar. For
         # focused work where lobby noise would distract.
@@ -1676,6 +1780,22 @@ cmd_connect() {
     esac
   done
   set -- "${positional[@]+"${positional[@]}"}"
+
+  # Issue #136: --general re-opt-in. Clear parted state on primary
+  # scope and force the sidecar back on. Done after arg parsing so we
+  # know AIRC_WRITE_DIR (set by ensure_init below) is meaningful — but
+  # we have to wait for ensure_init to run, since --general can be
+  # called before any prior init. The cleanup happens via a deferred
+  # check in spawn_general_sidecar_if_wanted: since _clear_parted_room
+  # is idempotent, we can call it eagerly here when config exists, and
+  # also force general_sidecar=1 to override any session env opt-out.
+  if [ "$_force_general_sidecar" = "1" ]; then
+    general_sidecar=1
+    if [ -f "$AIRC_WRITE_DIR/config.json" ]; then
+      local _primary_now; _primary_now=$(_primary_scope_for "$AIRC_WRITE_DIR")
+      _clear_parted_room "$_primary_now" "general"
+    fi
+  fi
 
   # Tailscale-installed-but-logged-out nudge. Runs AFTER flag parsing
   # so --no-tailscale takes effect. Default behavior: if Tailscale is
@@ -4053,6 +4173,17 @@ cmd_part() {
     # incorrectly trigger the stale-pairing-detect path on the next
     # resume even though they parted intentionally.
     rm -f "$room_name_file" "$gist_id_file"
+  fi
+
+  # Issue #136: persist the /part. Record the room into the PRIMARY
+  # scope's parted_rooms list so a later `airc join` won't auto-
+  # resubscribe. Only meaningful for sidecar rooms (general, future
+  # opt-in #repo etc.) — parting your project's primary scope means
+  # the whole scope is gone, so persistence there is moot.
+  local _primary_scope; _primary_scope=$(_primary_scope_for "$AIRC_WRITE_DIR")
+  if [ "$_primary_scope" != "$AIRC_WRITE_DIR" ] && [ "$room_name" != "(unnamed)" ]; then
+    _record_parted_room "$_primary_scope" "$room_name"
+    echo "  /part persisted — #${room_name} won't auto-resubscribe. Rejoin with: airc join --${room_name}"
   fi
 
   # IRC `/part` semantics — leave THIS room only; the #general sidecar

--- a/skills/away/SKILL.md
+++ b/skills/away/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: airc:away
+description: Set or clear the away status on this airc identity. IRC /away analog — exchanged at handshake so peers see the status in airc whois. Run with no args (or use 'airc back') to clear.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: "[<message>]"
+---
+
+# /away — Set or clear away status (IRC /away)
+
+Run this yourself — don't ask the user.
+
+## Parse `$ARGUMENTS`
+
+- With message → set status. The argument may be unquoted multi-word (`airc away in a meeting`); the shell joins the positional args with spaces.
+- Without arguments → clear status (back). `airc back` is a shortcut alias for the same clearing path.
+
+## Execute
+
+```bash
+airc away <message>
+```
+
+```bash
+airc away                # clears status
+airc back                # also clears status
+```
+
+On set, prints `away: <message>`. On clear, prints `back — away cleared.`.
+
+## How it surfaces
+
+- `airc whois <yourname>` reflects the status field immediately.
+- Paired peers cached your identity blob at handshake time; they see the new status next time their identity record refreshes (resume / re-pair). Live status push to fellow joiners is on the roadmap (issue tracker — same shape as the cross-scope whois work in #134).
+
+## When to use
+
+- Stepping away from your tab for a non-trivial pause and want peers to know your tab won't be responsive.
+- Marking yourself as on-task vs idle so other agents pick coordinator wisely.
+- Generally any time IRC users would `/away` — short, mutable, advisory; not a hard offline marker.
+
+## Notes
+
+- Equivalent verbose form: `airc identity set --status "<msg>"`. Both write to the same `identity.status` field; this skill is the IRC-aligned shortcut.
+- Status persists in `config.json` until cleared. Survives teardown + reconnect (it's identity material, not pairing state).
+- Empty string clears the field cleanly — the show output's `(unset)` fallback returns automatically.

--- a/skills/kick/SKILL.md
+++ b/skills/kick/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: airc:kick
+description: Host-only — remove a paired peer. Drops their SSH pubkey from authorized_keys and deletes their peer record. IRC /kick analog. Joiners cannot kick.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: "<peer-name> [reason]"
+---
+
+# /kick — Remove a paired peer (host only)
+
+Run this yourself — don't ask the user.
+
+## Execute
+
+```bash
+airc kick <peer-name> [optional reason]
+```
+
+If you're the host of the room: drops the peer's SSH key from `~/.ssh/authorized_keys`, deletes `peers/<name>.json` + `.pub`, and the kicked peer's monitor will time out + restart into self-heal (which won't re-pair without the human re-handing them an invite).
+
+If you're a joiner (not host): kick refuses with a helpful error. Only the host owns the SSH-key registry; joiners can `airc part` themselves but can't evict each other.
+
+## When to use
+
+- Peer's behavior is wrong and you need them gone (compromised credentials, stuck process spamming the room, etc.).
+- Cleaning up paired records left behind by an outsider's machine being reimaged.
+- Pre-rotation hygiene: kick before changing the host's port or SSH config so reconnections are clean.
+
+## What kick does NOT do
+
+- Doesn't touch the kicked peer's local state. Their config still says they're paired with you; they just can't reach you over SSH any more.
+- Doesn't broadcast a "kicked" event in the room (current behavior; an explicit broadcast was discussed in early kick PRs but the host-side notice was felt to be enough).
+- Doesn't permanently ban — if you re-hand them an invite, they can re-pair. (That's a feature, not a bug — banning is a UX layer above kick.)
+
+## Notes
+
+- Kick refuses path-traversal in peer name (`../../foo` and similar). Validated before any filesystem op.
+- The `[reason]` arg is currently informational only — printed by the command, not sent to the kicked peer (they're already off the wire by the time the message would arrive).
+- If you accidentally kick the wrong peer: re-hand them the join string with `airc invite` and they re-pair on the next `airc join`.

--- a/skills/whois/SKILL.md
+++ b/skills/whois/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: airc:whois
+description: Look up identity (name, pronouns, role, bio, status, integrations) for self / host / paired peer / fellow joiner across all subscribed rooms. IRC /whois analog.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: "[<peer-name>]"
+---
+
+# /whois — Look up identity for a peer
+
+Run this yourself — don't ask the user.
+
+## Execute
+
+```bash
+airc whois <peer-name>
+```
+
+```bash
+airc whois         # prints YOUR own identity (self)
+```
+
+Output is a structured block:
+
+```
+  name:      vhsm-d1f4
+  pronouns:  they
+  role:      vhsm-android-sdk
+  bio:       wallet/merchant bridging cert flow on vhsm-canary
+  status:    in a meeting til 3pm
+  integrations: (none)
+  host:      joelteply@100.91.51.87
+```
+
+## Resolution order (per scope)
+
+For each subscribed scope (primary first, then sidecars):
+
+1. **Self** — short-circuits, prints your own identity.
+2. **Host** — when target name matches the scope's `host_name`, reads `host_identity` cached at handshake.
+3. **Local peer file** — `<scope>/peers/<target>.json` if you've paired with the target directly.
+4. **Cross-peer-via-host** — single SSH read of host's `peers/<target>.json` for fellow joiners in the same room.
+
+If primary scope misses, sibling sidecar scopes are walked (issue #134) — so a peer who's only in your `#general` sidecar resolves cleanly from a project-scope cwd.
+
+## When to use
+
+- New peer joined the room → run `airc whois <them>` to load context (role, bio) before answering.
+- Peer mentions someone you don't know → whois them.
+- Triaging a coordination question — knowing pronouns/role lets the message be specific instead of generic.
+
+## When the lookup will 404
+
+- Target hasn't published identity yet (peer file exists but identity blob is empty → fields show `(unset)`).
+- Target is in a room you're not subscribed to (no scope to walk).
+- Target name is misspelled — names are lowercase alphanumeric + `-`.
+
+The error message lists `airc peers` as a hint so the user can list valid names.
+
+## Notes
+
+- Whois is a one-shot command. Doesn't require a running monitor. Safe to call any time.
+- Cross-scope walk runs at most one SSH per scope. Cheap.
+- Identity is cached at pair-handshake time — no live propagation if the peer changes their `identity` mid-session. They re-pair (or you do) to refresh.

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2249,6 +2249,97 @@ JSON
   cleanup_all
 }
 
+# ── Scenario: whois_cross_scope (issue #134) ───────────────────────────
+# Pre-fix: cmd_whois only consulted the primary scope. A peer who
+# was paired in the #general sidecar but not in the primary project
+# room returned "no record" — even though airc peers (post-#124)
+# already showed them. JOIN events in the sidecar emitted names
+# whois couldn't resolve.
+#
+# Post-fix: cmd_whois walks sibling scopes (.airc + .airc.<room>)
+# and tries each scope's host / local-peer / cross-peer-via-host
+# lookups. First hit wins; "no record" only after exhausting all.
+#
+# Test exercises the local-peer path in sibling scope (the SSH-based
+# cross-peer path is symmetric in code and covered by scenario_whois
+# at the primary scope). Also verifies sibling-scope HOST lookup
+# works — whois on the sidecar's host name should pull host_identity
+# out of the sidecar's config.json rather than 404.
+scenario_whois_cross_scope() {
+  section "whois_cross_scope: airc whois walks sibling scopes (issue #134)"
+  cleanup_all
+
+  local primary=/tmp/airc-it-wcs/state
+  local sidecar=/tmp/airc-it-wcs/state.general
+  mkdir -p "$primary/identity" "$primary/peers" "$sidecar/identity" "$sidecar/peers"
+  ssh-keygen -t ed25519 -f "$primary/identity/ssh_key" -N '' -q -C 'wcs-primary' 2>/dev/null
+  ssh-keygen -t ed25519 -f "$sidecar/identity/ssh_key" -N '' -q -C 'wcs-sidecar' 2>/dev/null
+  # Primary scope: paired with phost in #myproject. No fellow joiners.
+  cat > "$primary/config.json" <<'JSON'
+{
+  "name": "alpha",
+  "host_name": "phost",
+  "host_target": "joel@10.0.0.1",
+  "host_identity": {"pronouns":"they","role":"primary-host","bio":"primary host bio"}
+}
+JSON
+  echo "myproject" > "$primary/room_name"
+  # Sidecar scope: paired with shost in #general. Fellow joiner 'lobbymate'.
+  cat > "$sidecar/config.json" <<'JSON'
+{
+  "name": "alpha",
+  "host_name": "shost",
+  "host_target": "joel@10.0.0.2",
+  "host_identity": {"pronouns":"she","role":"general-host","bio":"general host bio"}
+}
+JSON
+  echo "general" > "$sidecar/room_name"
+  cat > "$sidecar/peers/lobbymate.json" <<'JSON'
+{"name":"lobbymate","host":"joel@10.0.0.99","ssh_pub":"ssh-ed25519 AAAA",
+ "identity":{"pronouns":"they","role":"fellow-joiner","bio":"in general only"}}
+JSON
+
+  local out
+  # ── from primary scope: sidecar peer should resolve ────────────────
+  out=$(AIRC_HOME="$primary" "$AIRC" whois lobbymate 2>&1)
+  echo "$out" | grep -q "role: *fellow-joiner" \
+    && pass "primary scope finds sidecar-only peer (role)" \
+    || fail "primary scope didn't find sidecar peer (got: $out)"
+  echo "$out" | grep -q "bio: *in general only" \
+    && pass "primary scope finds sidecar-only peer (bio)" \
+    || fail "primary scope sidecar peer missing bio (got: $out)"
+
+  # ── from primary scope: sidecar HOST should resolve ────────────────
+  # shost is the host of the sidecar's #general — primary scope's
+  # host_name is phost, so the lookup must walk into sidecar's config
+  # and read host_identity from there.
+  out=$(AIRC_HOME="$primary" "$AIRC" whois shost 2>&1)
+  echo "$out" | grep -q "role: *general-host" \
+    && pass "primary scope finds sidecar host via cross-scope walk" \
+    || fail "primary scope didn't resolve sidecar host (got: $out)"
+
+  # ── from primary scope: primary host still resolves (no regression)
+  out=$(AIRC_HOME="$primary" "$AIRC" whois phost 2>&1)
+  echo "$out" | grep -q "role: *primary-host" \
+    && pass "primary scope still resolves primary host (no regression)" \
+    || fail "primary host lookup regressed (got: $out)"
+
+  # ── from primary scope: unknown peer still graceful ────────────────
+  out=$(AIRC_HOME="$primary" "$AIRC" whois ghost-zzz 2>&1 || true)
+  echo "$out" | grep -q "no record for 'ghost-zzz'" \
+    && pass "unknown peer still 404s after walking all scopes" \
+    || fail "unknown peer error message regressed (got: $out)"
+
+  # ── from sidecar scope: same merged view (operator perspective) ────
+  out=$(AIRC_HOME="$sidecar" "$AIRC" whois phost 2>&1)
+  echo "$out" | grep -q "role: *primary-host" \
+    && pass "sidecar scope finds primary host (symmetric walk)" \
+    || fail "sidecar scope didn't resolve primary host (got: $out)"
+
+  rm -rf /tmp/airc-it-wcs
+  cleanup_all
+}
+
 # ── Scenario: part_keeps_sidecar (IRC /part semantics) ──────────────────
 # Pre-fix: `airc part` from the primary scope called cmd_teardown which
 # (post-#122) cleaned both primary AND sidecar scopes — so leaving
@@ -2501,10 +2592,11 @@ case "$MODE" in
   general_sidecar_default) scenario_general_sidecar_default ;;
   send_room_flag) scenario_send_room_flag ;;
   peers_cross_scope) scenario_peers_cross_scope ;;
+  whois_cross_scope) scenario_whois_cross_scope ;;
   part_keeps_sidecar) scenario_part_keeps_sidecar ;;
   platform_adapters) scenario_platform_adapters ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_send_dead_monitor_dies; scenario_connect_after_kill_recovers; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_part_keeps_sidecar; scenario_platform_adapters ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|send_room_flag|peers_cross_scope|part_keeps_sidecar|platform_adapters|all]"; exit 2 ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_send_dead_monitor_dies; scenario_connect_after_kill_recovers; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_whois_cross_scope; scenario_part_keeps_sidecar; scenario_platform_adapters ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|send_room_flag|peers_cross_scope|whois_cross_scope|part_keeps_sidecar|platform_adapters|all]"; exit 2 ;;
 esac
 
 echo

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2414,6 +2414,122 @@ scenario_part_keeps_sidecar() {
   cleanup_all
 }
 
+# ── Scenario: part_persists (issue #136) ───────────────────────────────
+# Pre-fix: /part #general left the lobby for the session, but the next
+# `airc join` auto-respawned the sidecar — your /part was useless.
+# Persistence converts /part from session-action to durable preference.
+#
+# Post-fix: cmd_part records the parted room in primary scope's
+# parted_rooms array. spawn_general_sidecar_if_wanted reads that list
+# on bootstrap and skips spawn for any room in it. `airc join --general`
+# clears "general" from parted_rooms (explicit re-opt-in).
+scenario_part_persists() {
+  section "part_persists: /part is sticky across sessions (issue #136)"
+  cleanup_all
+
+  local home1=/tmp/airc-it-pp/state
+  mkdir -p "$home1"
+
+  # ── Phase 1: primary + sidecar both up ─────────────────────────────
+  ( cd /tmp/airc-it-pp && unset AIRC_NO_GENERAL && \
+      AIRC_HOME="$home1" AIRC_NAME=alpha AIRC_PORT=7585 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room pp-room-$$ > "$home1/out.log" 2>&1 & )
+  local i
+  for i in 1 2 3 4 5 6 7 8; do
+    sleep 1
+    [ -f "${home1}.general/airc.pid" ] && [ -f "$home1/airc.pid" ] && break
+  done
+  [ -f "$home1/airc.pid" ] && [ -f "${home1}.general/airc.pid" ] \
+    && pass "phase 1: primary + sidecar both running" \
+    || { fail "phase 1: setup failed"; cleanup_all; rm -rf /tmp/airc-it-pp; return; }
+
+  # parted_rooms should be absent or empty in primary config now.
+  local before; before=$(python3 -c "
+import json
+try: print(' '.join(json.load(open('$home1/config.json')).get('parted_rooms', []) or []))
+except Exception: print('')
+" 2>/dev/null)
+  [ -z "$before" ] \
+    && pass "phase 1: primary config has empty parted_rooms initially" \
+    || fail "phase 1: parted_rooms unexpectedly populated (got: $before)"
+
+  # ── Phase 2: /part the sidecar — should write parted_rooms ─────────
+  AIRC_HOME="${home1}.general" "$AIRC" part >/dev/null 2>&1
+  sleep 1
+
+  local after; after=$(python3 -c "
+import json
+try: print(' '.join(json.load(open('$home1/config.json')).get('parted_rooms', []) or []))
+except Exception: print('')
+" 2>/dev/null)
+  [ "$after" = "general" ] \
+    && pass "phase 2: /part wrote 'general' to primary parted_rooms" \
+    || fail "phase 2: parted_rooms missing 'general' (got: '$after')"
+
+  # Full teardown to reset between phases (sidecar already gone from /part).
+  AIRC_HOME="$home1" "$AIRC" teardown >/dev/null 2>&1
+  sleep 1
+
+  # ── Phase 3: bootstrap again — sidecar must NOT spawn ──────────────
+  ( cd /tmp/airc-it-pp && unset AIRC_NO_GENERAL && \
+      AIRC_HOME="$home1" AIRC_NAME=alpha AIRC_PORT=7586 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room pp-room-$$ > "$home1/out2.log" 2>&1 & )
+  for i in 1 2 3 4 5 6 7 8; do
+    sleep 1
+    [ -f "$home1/airc.pid" ] && break
+  done
+
+  [ -f "$home1/airc.pid" ] \
+    && pass "phase 3: primary respawned" \
+    || { fail "phase 3: primary failed to come up"; cleanup_all; rm -rf /tmp/airc-it-pp; return; }
+
+  # The sidecar pidfile should NOT exist (was parted, persisted).
+  # Wait a couple seconds for any stray sidecar spawn before asserting.
+  sleep 2
+  [ ! -f "${home1}.general/airc.pid" ] \
+    && pass "phase 3: sidecar does NOT auto-respawn (parted_rooms honored)" \
+    || fail "phase 3: sidecar respawned despite /part persistence"
+
+  # The "previously parted" notice should be in the output.
+  grep -q "previously parted" "$home1/out2.log" 2>/dev/null \
+    && pass "phase 3: 'previously parted' notice surfaced to user" \
+    || fail "phase 3: silent skip — notice missing from output (would surprise users)"
+
+  # Tear down primary before phase 4.
+  AIRC_HOME="$home1" "$AIRC" teardown >/dev/null 2>&1
+  sleep 1
+
+  # ── Phase 4: --general flag clears parted state and respawns sidecar
+  ( cd /tmp/airc-it-pp && unset AIRC_NO_GENERAL && \
+      AIRC_HOME="$home1" AIRC_NAME=alpha AIRC_PORT=7587 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --no-gist --room pp-room-$$ --general > "$home1/out3.log" 2>&1 & )
+  for i in 1 2 3 4 5 6 7 8; do
+    sleep 1
+    [ -f "${home1}.general/airc.pid" ] && [ -f "$home1/airc.pid" ] && break
+  done
+
+  [ -f "${home1}.general/airc.pid" ] \
+    && pass "phase 4: --general flag restored sidecar" \
+    || fail "phase 4: --general didn't respawn sidecar"
+
+  local cleared; cleared=$(python3 -c "
+import json
+try: print(' '.join(json.load(open('$home1/config.json')).get('parted_rooms', []) or []))
+except Exception: print('')
+" 2>/dev/null)
+  [ -z "$cleared" ] \
+    && pass "phase 4: --general cleared parted_rooms (round-trip works)" \
+    || fail "phase 4: parted_rooms still has stale entries (got: '$cleared')"
+
+  AIRC_HOME="$home1" "$AIRC" teardown >/dev/null 2>&1
+  sleep 1
+  rm -rf /tmp/airc-it-pp
+  cleanup_all
+}
+
 # ── Scenario: platform_adapters (cross-platform helpers contract) ──────
 # proc_children / port_listeners / proc_parent / proc_cmdline /
 # file_size / detect_platform replace inline pgrep/lsof/stat patterns
@@ -2594,9 +2710,10 @@ case "$MODE" in
   peers_cross_scope) scenario_peers_cross_scope ;;
   whois_cross_scope) scenario_whois_cross_scope ;;
   part_keeps_sidecar) scenario_part_keeps_sidecar ;;
+  part_persists) scenario_part_persists ;;
   platform_adapters) scenario_platform_adapters ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_send_dead_monitor_dies; scenario_connect_after_kill_recovers; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_whois_cross_scope; scenario_part_keeps_sidecar; scenario_platform_adapters ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|send_room_flag|peers_cross_scope|whois_cross_scope|part_keeps_sidecar|platform_adapters|all]"; exit 2 ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_send_dead_monitor_dies; scenario_connect_after_kill_recovers; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_whois_cross_scope; scenario_part_keeps_sidecar; scenario_part_persists; scenario_platform_adapters ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|send_room_flag|peers_cross_scope|whois_cross_scope|part_keeps_sidecar|part_persists|platform_adapters|all]"; exit 2 ;;
 esac
 
 echo

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2530,6 +2530,188 @@ except Exception: print('')
   cleanup_all
 }
 
+# ── Scenario: away (IRC /away alias) ───────────────────────────────────
+# IRC convention: /away <msg> marks user as away with status, /away
+# (no arg) clears it. airc away wraps `airc identity set --status` so
+# every IRC verb in the README table has a direct CLI form.
+scenario_away() {
+  section "away: IRC /away alias for identity set --status"
+  cleanup_all
+
+  local home=/tmp/airc-it-aw/state
+  mkdir -p "$home/identity"
+  ssh-keygen -t ed25519 -f "$home/identity/ssh_key" -N '' -q -C 'aw-test' 2>/dev/null
+  cat > "$home/config.json" <<'JSON'
+{ "name": "alpha", "identity": {} }
+JSON
+
+  # ── Set away with message ──
+  AIRC_HOME="$home" "$AIRC" away "in a meeting til 3pm" >/dev/null 2>&1
+  local status; status=$(python3 -c "
+import json
+print(json.load(open('$home/config.json')).get('identity', {}).get('status', ''))
+" 2>/dev/null)
+  [ "$status" = "in a meeting til 3pm" ] \
+    && pass "away <msg> sets status field" \
+    || fail "away didn't set status (got: '$status')"
+
+  # ── airc whois self should reflect the away status ──
+  local out; out=$(AIRC_HOME="$home" "$AIRC" whois alpha 2>&1)
+  echo "$out" | grep -q "status: *in a meeting til 3pm" \
+    && pass "whois reflects away status" \
+    || fail "whois didn't show away status (got: $out)"
+
+  # ── Multi-word message via positional args ──
+  AIRC_HOME="$home" "$AIRC" away getting coffee >/dev/null 2>&1
+  status=$(python3 -c "
+import json
+print(json.load(open('$home/config.json')).get('identity', {}).get('status', ''))
+" 2>/dev/null)
+  [ "$status" = "getting coffee" ] \
+    && pass "away with multi-word arg joins with spaces" \
+    || fail "multi-word away dropped tokens (got: '$status')"
+
+  # ── airc back (no args) clears status ──
+  AIRC_HOME="$home" "$AIRC" away >/dev/null 2>&1
+  status=$(python3 -c "
+import json
+print(json.load(open('$home/config.json')).get('identity', {}).get('status', '(absent)'))
+" 2>/dev/null)
+  [ "$status" = "(absent)" ] \
+    && pass "away (no arg) clears status field (back)" \
+    || fail "away no-arg didn't clear status (got: '$status')"
+
+  # ── 'back' alias (IRC convention shortcut) ──
+  AIRC_HOME="$home" "$AIRC" away "afk" >/dev/null 2>&1
+  AIRC_HOME="$home" "$AIRC" back >/dev/null 2>&1
+  status=$(python3 -c "
+import json
+print(json.load(open('$home/config.json')).get('identity', {}).get('status', '(absent)'))
+" 2>/dev/null)
+  [ "$status" = "(absent)" ] \
+    && pass "back alias also clears status" \
+    || fail "back alias didn't clear (got: '$status')"
+
+  rm -rf /tmp/airc-it-aw
+  cleanup_all
+}
+
+# ── Scenario: list (rooms registry on gh account) ──────────────────────
+# Verifies airc list / rooms / ls all dispatch to cmd_rooms and the
+# output format meets the IRC /list contract: shows open channels with
+# enough info for any client to /join. Doesn't require a live gh
+# account — the empty-account path is the most reliable to test in CI.
+scenario_list() {
+  section "list: airc list / rooms / ls — IRC /list alias"
+  cleanup_all
+
+  # All three aliases should reach the same code path. Only test that
+  # they don't error and produce SOME output (real listing requires gh
+  # auth which the integration suite doesn't depend on).
+  local home=/tmp/airc-it-ls/state
+  mkdir -p "$home/identity"
+  ssh-keygen -t ed25519 -f "$home/identity/ssh_key" -N '' -q -C 'ls-test' 2>/dev/null
+  cat > "$home/config.json" <<'JSON'
+{ "name": "alpha" }
+JSON
+
+  local rc1 rc2 rc3
+  AIRC_HOME="$home" "$AIRC" list >/dev/null 2>&1; rc1=$?
+  AIRC_HOME="$home" "$AIRC" rooms >/dev/null 2>&1; rc2=$?
+  AIRC_HOME="$home" "$AIRC" ls >/dev/null 2>&1; rc3=$?
+
+  # Exit 0 (empty list / has gists) and exit 1 (no gh) both acceptable
+  # — we just verify dispatch works and the command runs to completion.
+  [ "$rc1" -eq 0 ] || [ "$rc1" -eq 1 ] \
+    && pass "airc list exits cleanly (rc=$rc1)" \
+    || fail "airc list crashed (rc=$rc1)"
+  [ "$rc2" -eq 0 ] || [ "$rc2" -eq 1 ] \
+    && pass "airc rooms exits cleanly (rc=$rc2)" \
+    || fail "airc rooms crashed (rc=$rc2)"
+  [ "$rc3" -eq 0 ] || [ "$rc3" -eq 1 ] \
+    && pass "airc ls exits cleanly (rc=$rc3)" \
+    || fail "airc ls crashed (rc=$rc3)"
+
+  # Output shape: when gh works, we expect either "No open airc rooms"
+  # or "<N> open on your gh account:" lines. Either signals the right
+  # code path was reached.
+  local out; out=$(AIRC_HOME="$home" "$AIRC" list 2>&1)
+  echo "$out" | grep -qE "open airc rooms|open on your gh account|requires the 'gh' CLI" \
+    && pass "list output has the expected shape" \
+    || fail "list output unexpected (got: $out)"
+
+  rm -rf /tmp/airc-it-ls
+  cleanup_all
+}
+
+# ── Scenario: quit (IRC /quit semantics) ──────────────────────────────
+# IRC /quit: leave the mesh, keep your identity. airc quit (alias for
+# disconnect) tears down the running scope's processes and clears
+# host-pairing fields from config — but identity (name, ssh_key,
+# pronouns/role/bio/status) survives so the next `airc connect` can
+# resume the same persona instead of re-bootstrapping.
+scenario_quit() {
+  section "quit: IRC /quit semantics — leave mesh, keep identity"
+  cleanup_all
+
+  local home=/tmp/airc-it-q-quit/state
+  mkdir -p "$home/identity"
+  ssh-keygen -t ed25519 -f "$home/identity/ssh_key" -N '' -q -C 'quit-test' 2>/dev/null
+  # Minimal config simulating a paired joiner: has name + identity AND
+  # host-pairing fields. quit should drop the pairing and keep identity.
+  cat > "$home/config.json" <<'JSON'
+{
+  "name": "alpha",
+  "host_target": "joel@1.2.3.4",
+  "host_name": "ahost",
+  "host_port": 7547,
+  "host_airc_home": "/home/joel/.airc",
+  "host_ssh_pub": "ssh-ed25519 AAAA",
+  "identity": {"pronouns": "they", "role": "agent", "bio": "test bio"}
+}
+JSON
+
+  AIRC_HOME="$home" "$AIRC" quit >/dev/null 2>&1
+  local rc=$?
+  [ "$rc" -eq 0 ] && pass "airc quit returns 0" || fail "airc quit non-zero (rc=$rc)"
+
+  # Identity preserved
+  local name pronouns role bio
+  name=$(python3 -c "import json; print(json.load(open('$home/config.json')).get('name',''))" 2>/dev/null)
+  pronouns=$(python3 -c "import json; print(json.load(open('$home/config.json')).get('identity',{}).get('pronouns',''))" 2>/dev/null)
+  role=$(python3 -c "import json; print(json.load(open('$home/config.json')).get('identity',{}).get('role',''))" 2>/dev/null)
+  bio=$(python3 -c "import json; print(json.load(open('$home/config.json')).get('identity',{}).get('bio',''))" 2>/dev/null)
+  [ "$name" = "alpha" ] && pass "name survives quit" || fail "name lost (got: '$name')"
+  [ "$pronouns" = "they" ] && pass "pronouns survive quit" || fail "pronouns lost (got: '$pronouns')"
+  [ "$role" = "agent" ] && pass "role survives quit" || fail "role lost (got: '$role')"
+  [ "$bio" = "test bio" ] && pass "bio survives quit" || fail "bio lost (got: '$bio')"
+
+  # Host-pairing fields cleared
+  local has_target has_name
+  has_target=$(python3 -c "import json; print('host_target' in json.load(open('$home/config.json')))" 2>/dev/null)
+  has_name=$(python3 -c "import json; print('host_name' in json.load(open('$home/config.json')))" 2>/dev/null)
+  [ "$has_target" = "False" ] && pass "host_target cleared by quit" || fail "host_target still present"
+  [ "$has_name" = "False" ] && pass "host_name cleared by quit" || fail "host_name still present"
+
+  # SSH key file preserved (identity material)
+  [ -f "$home/identity/ssh_key" ] && pass "ssh_key preserved (identity material)" || fail "ssh_key lost"
+
+  # Disconnect alias should be equivalent
+  cat > "$home/config.json" <<'JSON'
+{
+  "name": "alpha",
+  "host_target": "joel@1.2.3.4",
+  "identity": {"pronouns": "they"}
+}
+JSON
+  AIRC_HOME="$home" "$AIRC" disconnect >/dev/null 2>&1
+  has_target=$(python3 -c "import json; print('host_target' in json.load(open('$home/config.json')))" 2>/dev/null)
+  [ "$has_target" = "False" ] && pass "disconnect alias clears pairing too" || fail "disconnect alias didn't clear"
+
+  rm -rf /tmp/airc-it-q-quit
+  cleanup_all
+}
+
 # ── Scenario: platform_adapters (cross-platform helpers contract) ──────
 # proc_children / port_listeners / proc_parent / proc_cmdline /
 # file_size / detect_platform replace inline pgrep/lsof/stat patterns
@@ -2711,9 +2893,12 @@ case "$MODE" in
   whois_cross_scope) scenario_whois_cross_scope ;;
   part_keeps_sidecar) scenario_part_keeps_sidecar ;;
   part_persists) scenario_part_persists ;;
+  away) scenario_away ;;
+  list) scenario_list ;;
+  quit) scenario_quit ;;
   platform_adapters) scenario_platform_adapters ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_send_dead_monitor_dies; scenario_connect_after_kill_recovers; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_whois_cross_scope; scenario_part_keeps_sidecar; scenario_part_persists; scenario_platform_adapters ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|send_room_flag|peers_cross_scope|whois_cross_scope|part_keeps_sidecar|part_persists|platform_adapters|all]"; exit 2 ;;
+  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_send_dead_monitor_dies; scenario_connect_after_kill_recovers; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_whois_cross_scope; scenario_part_keeps_sidecar; scenario_part_persists; scenario_away; scenario_list; scenario_quit; scenario_platform_adapters ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|send_room_flag|peers_cross_scope|whois_cross_scope|part_keeps_sidecar|part_persists|away|list|quit|platform_adapters|all]"; exit 2 ;;
 esac
 
 echo

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2427,7 +2427,14 @@ scenario_part_persists() {
   section "part_persists: /part is sticky across sessions (issue #136)"
   cleanup_all
 
-  local home1=/tmp/airc-it-pp/state
+  # NOTE: fixture path basename starts with "." so _primary_scope_for sees
+  # a leading-dot scope (the real-world layout is $repo/.airc, not 'state').
+  # vhsm-d1f4 caught a regression in PR #144 e2e where _primary_scope_for's
+  # regex over-stripped '.airc' to '' and silently routed _clear_parted_room
+  # to a bogus path. Earlier fixture used 'state'/'state.general' which
+  # never exercised the leading-dot code path. Switching to '.airc' /
+  # '.airc.general' so the test matches production layout.
+  local home1=/tmp/airc-it-pp/.airc
   mkdir -p "$home1"
 
   # ── Phase 1: primary + sidecar both up ─────────────────────────────


### PR DESCRIPTION
Promotes 4 canary PRs to main. All merged to canary, dogfooded across 3-peer mesh (vhsm-d1f4, continuum-b741, this tab) on this Mac, validated through QA roundtrips today.

## Included

- **#135** `fix(whois)`: walk sibling sidecar scopes — the cross-scope bug vhsm hit when continuum joined #general
- **#138** `feat(rooms)`: persist /part across reboots — \`/part #general\` now sticks; \`airc join --general\` re-opts in
- **#139** `feat(irc)`: airc away/back + IRC verb coverage — closes vhsm+continuum QA findings, fixes "Try: relay help" stale string, hints \`airc away\` from the unset-status surface
- **#143** `chore(readme,skills)`: README counts updated (~245 assertions / 32 scenarios), Default Rooms documents /part stickiness, Skills table adds /whois /away /kick

## QA roundtrip evidence

vhsm-d1f4 verified PR #139 on canary 1e4d2bf:
> ✓ 'airc away thinking' → 'away: thinking'
> ✓ whois shows status: thinking after away
> ✓ 'airc back' → 'back — away cleared.'
> ✓ status field after back: '(unset; airc away <msg> to set)'
> ✓ 'airc list' tally: '11 open on your gh account:'
> ✓ Error string: 'Try: airc help' (was 'relay help')

continuum-b741 verified the cross-scope work via 3-peer mesh on the same SHA.

## Out of scope (filed)

- **#140** \`--room\` flag path-dependent (continuum's host-of-primary tab; vhsm couldn't reproduce from joiner-of-primary). Needs focused repro before fix.
- **#141** \`@bob looks good\` parsed as DM target. Design call deferred.
- **#142** \`airc list\` shows stale 1:1 invites with no auto-prune. UX paper cut.

## Test posture

10 IRC-relevant scenarios green: identity 19/19, whois 5/5, whois_cross_scope 6/6, kick 12/12, away 5/5, list 4/4, quit 9/9, part_persists 8/8, part_keeps_sidecar 6/6, general_sidecar_default 12/12. **86 assertions pass, 0 fail.** Pre-existing 2 teardown-thoroughness failures (port held / outage simulation) remain, deferred per session note.

## Risk

Low. Three of four PRs are additive (new commands / new persistence path). The fourth (#135) is a refactor of an existing code path (whois) with new test coverage and unchanged single-scope behavior. Worst-case rollback: revert the merge commit, no data migration needed (parted_rooms is opt-in via /part).