### PR TITLE
fix(scope): _primary_scope_for empty-prefix guard (vhsm e2e catch on PR #144)

### DIFF
--- a/airc
+++ b/airc
@@ -948,8 +948,17 @@ _primary_scope_for() {
   parent=$(dirname "$scope")
   self_base=$(basename "$scope")
   prefix=$(printf '%s' "$self_base" | sed -E 's/\.[a-z0-9-]+$//')
-  if [ "$prefix" = "$self_base" ]; then
-    # Already primary — no trailing .<word> suffix to strip.
+  # Sidecar only if the regex stripped a real suffix AND left a non-empty
+  # prefix. Empty prefix means the entire basename was a leading-dot-name
+  # like '.airc' (canonical primary scope name in real deployments) — the
+  # regex eats the whole thing. Without the empty-prefix guard, '.airc'
+  # gets treated as a sidecar of '' under '<parent>/' which then can't
+  # find config.json and silently no-ops. Bug surfaced by vhsm-d1f4 in
+  # PR #144 e2e (2026-04-27): airc join --general silently failed because
+  # _clear_parted_room got the wrong path. Test scenario_part_persists
+  # passed because its fixture path is 'state'/'state.general' (no
+  # leading dot), masking the prefix='' code path entirely.
+  if [ -z "$prefix" ] || [ "$prefix" = "$self_base" ]; then
     printf '%s' "$scope"
   else
     printf '%s' "$parent/$prefix"

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2427,7 +2427,14 @@ scenario_part_persists() {
   section "part_persists: /part is sticky across sessions (issue #136)"
   cleanup_all
 
-  local home1=/tmp/airc-it-pp/state
+  # NOTE: fixture path basename starts with "." so _primary_scope_for sees
+  # a leading-dot scope (the real-world layout is $repo/.airc, not 'state').
+  # vhsm-d1f4 caught a regression in PR #144 e2e where _primary_scope_for's
+  # regex over-stripped '.airc' to '' and silently routed _clear_parted_room
+  # to a bogus path. Earlier fixture used 'state'/'state.general' which
+  # never exercised the leading-dot code path. Switching to '.airc' /
+  # '.airc.general' so the test matches production layout.
+  local home1=/tmp/airc-it-pp/.airc
   mkdir -p "$home1"
 
   # ── Phase 1: primary + sidecar both up ─────────────────────────────


### PR DESCRIPTION
## Bug (vhsm-d1f4 PR #144 e2e, 2026-04-27)

\`airc join --general\` silently no-op'd: parted_rooms stayed populated, sidecar stayed skipped, the "previously parted" notice fired every retry. README #143 documents \`airc join --general\` as THE re-opt-in path — would have shipped broken-as-documented if this hadn't been caught in the canary→main pre-merge e2e.

## Root cause (full trace, vhsm's analysis)

\`_primary_scope_for\` regex \`s/\\.[a-z0-9-]+\$//\` over-strips when basename IS a leading-dot-name:

| Input | Regex output (prefix) | Old behavior |
|---|---|---|
| \`.airc\` (primary, canonical) | \`""\` (empty) | returned \`<parent>/\` — BOGUS |
| \`.airc.general\` (sidecar) | \`.airc\` | returned \`<parent>/.airc\` ✓ |
| \`state\` (test fixture) | \`state\` | returned scope ✓ |
| \`state.general\` (test sidecar) | \`state\` | returned \`<parent>/state\` ✓ |

The "is this a sidecar?" check (\`prefix != self_base\`) was true for \`.airc\` (since \`"" != ".airc"\`), so the function returned a bogus path. Downstream \`_clear_parted_room\` got that path, found no config.json there, silently no-op'd via the python wrapper's FileNotFoundError → sys.exit(0).

## Fix

Empty-prefix guard: if the regex eats the entire basename, the basename was a leading-dot-only name (canonical primary), not a sidecar. Return self.

\`\`\`bash
if [ -z "\$prefix" ] || [ "\$prefix" = "\$self_base" ]; then
  printf '%s' "\$scope"
else
  printf '%s' "\$parent/\$prefix"
fi
\`\`\`

## Test fix (the deeper lesson)

\`scenario_part_persists\` used fixture path \`state\`/\`state.general\`. Basename \`state\` has no dots → regex no-ops → primary case. The leading-dot code path was NEVER exercised by integration tests. Real deployments use \`$repo/.airc\`.

Renamed fixture: \`/tmp/airc-it-pp/state\` → \`/tmp/airc-it-pp/.airc\`. With \`.airc\` basename, the test reproduces vhsm's bug pre-fix, passes post-fix.

| | pre-fix | post-fix |
|---|---|---|
| .airc fixture | phase 4 fails (2 assertions) | 8/8 pass |
| state fixture (old) | 8/8 (false-pass — bypasses code path) | 8/8 |

## Class of bug

Test fixture paths that diverge from real-world layout in ways that hide code paths. Any regex over basenames should account for leading-dot directories. Worth a grep over the codebase for similar patterns — separate audit.

## Unblocks

PR #144 (canary→main). vhsm's e2e was a HOLD on this exact issue; with this fix merged to canary, vhsm can re-run step 5 of their e2e and #144 ships.