### PR TITLE
fix(sidecar): inherit --no-gist flag so tests stop leaking live #general gists

### DIFF
--- a/airc
+++ b/airc
@@ -1152,11 +1152,32 @@ spawn_general_sidecar_if_wanted() {
   # helper on 2026-04-26.
   local _env_args=(AIRC_HOME="$_sidecar_scope" AIRC_GENERAL_SIDECAR=1 AIRC_NO_AUTO_ROOM=1)
   [ -n "$_primary_name" ] && _env_args+=("AIRC_NAME=$_primary_name")
+  # Inherit primary's --no-gist flag so test fixtures don't leak a real
+  # #general gist into the live joelteply gh namespace via the sidecar.
+  # Bug found by continuum-b69f 2026-04-27 across the cross-Mac/Windows
+  # substrate-bypass channel: scenario_part_persists et al spawn the
+  # primary with `--no-gist --no-discovery`, but those flags do not
+  # propagate to the sidecar's spawn here. The sidecar then publishes
+  # an `airc room: general` gist with the test fixture's host info
+  # (e.g. host=alpha, port=7556). Test exits via cleanup_all's `kill -9`
+  # which bypasses the on-exit gist-delete trap, leaving the gist
+  # orphaned. Real users (continuum-b69f's Windows tab) discover it,
+  # try to TCP-connect, get RST. Two layers of test isolation hole;
+  # this fix patches the upstream half. (The downstream half — kill -9
+  # bypassing the trap — is harder to fix; tracked separately.)
+  #
+  # AIRC_NO_DISCOVERY=1 propagates automatically via the subshell env;
+  # only --no-gist needs explicit forwarding because it's a flag, not
+  # an env var.
+  local _sidecar_args=(connect --room general)
+  if [ "${use_gist:-1}" = "0" ]; then
+    _sidecar_args+=(--no-gist)
+  fi
   # Unset primary's AIRC_PORT so sidecar doesn't fight for the same port —
   # primary has it bound already, sidecar's auto-bump-loop would land on
   # +1, but better to start the sidecar from the canonical default and
   # let it find its own free port without the conflict-detect dance.
-  ( env -u AIRC_PORT "${_env_args[@]}" "$0" connect --room general ) &
+  ( env -u AIRC_PORT "${_env_args[@]}" "$0" "${_sidecar_args[@]}" ) &
   local _sidecar_pid=$!
 
   # Sidecar's own scope writes its own airc.pid for its bash + descendants.


### PR DESCRIPTION
## Bug (continuum-b69f via cross-machine QA, 2026-04-27)

After PR #153 unblocked airc on Windows, continuum's first \`airc connect\` discovered \`airc room: general\` gist \`2ae0eda255...\` advertising host=alpha port=7556. Mac-side: alpha was a test-fixture process that exited 38 minutes earlier. Heartbeat frozen at creation timestamp. Continuum got TCP RST on connect.

## Root cause

\`spawn_general_sidecar_if_wanted\` at airc:1159 spawns the sidecar with \`--room general\` only:

\`\`\`bash
( env -u AIRC_PORT "${_env_args[@]}" "$0" connect --room general ) &
\`\`\`

If the primary has \`--no-gist\`, the flag does NOT propagate. The sidecar happily publishes a real gist for #general on the live gh account. cleanup_all's \`kill -9\` bypasses the on-exit gist-delete trap, leaving the gist orphaned. Other peers (real users on the same gh account) discover the orphan and try to connect to its dead host.

## Fix

\`\`\`bash
local _sidecar_args=(connect --room general)
if [ "${use_gist:-1}" = "0" ]; then
  _sidecar_args+=(--no-gist)
fi
( env -u AIRC_PORT "${_env_args[@]}" "$0" "${_sidecar_args[@]}" ) &
\`\`\`

\`AIRC_NO_DISCOVERY=1\` inherits via subshell env automatically; only the flag needs explicit forwarding.

## Why integration tests didn't catch this

Tests run as Joel against his own gh account → leaked gists are invisible to test assertions but very visible to real users on the SAME gh account. Cross-account QA caught it — continuum-b69f's Windows tab discovered an orphan that Mac integration tests had created an hour earlier.

## Test posture

- part_keeps_sidecar: 6/6 ✓
- part_persists: 8/8 ✓
- general_sidecar_default: 12/12 ✓

## Out of scope (separate bug)

The \`kill -9\` → trap-bypassed leakage is the OTHER half of the test isolation hole. Tests should kill politely (SIGTERM, then SIGKILL after a grace period) so the trap can clean up. File for follow-up.