### PR TITLE
fix(gist): git-clone fallback + |\| true guards under rate-limit (this limit will kill people)

### DIFF
--- a/airc
+++ b/airc
@@ -2218,6 +2218,16 @@ cmd_connect() {
     if echo "$gist_id" | grep -qE '^[a-zA-Z0-9]{6,40}$'; then
       echo "  Resolving gist $gist_id ..."
       local raw_content=""
+      # Each path's `raw_content=$(cmd | filter)` is protected with
+      # `|| true` so a non-zero exit on the upstream command does NOT
+      # abort the script via `set -euo pipefail`. Pre-fix: when gh
+      # rate-limited (HTTP 403), `gh api ...` exited non-zero, pipefail
+      # propagated it, set -e aborted the whole script BEFORE the next
+      # fallback ran. Net: rate-limit hit = total resolution failure
+      # with no diagnostic. Joel 2026-04-27: "this limit will kill
+      # people." Fix: per-path `|| true` makes each path advisory; the
+      # `[ -z "$raw_content" ]` gates control fallthrough explicitly.
+      #
       # Prefer `gh api` over `gh gist view --raw` — the latter prepends
       # the gist description as a header line ("airc room: general\n\n{...}")
       # which breaks JSON parse downstream. `gh api` returns the file
@@ -2227,18 +2237,43 @@ cmd_connect() {
       # handshake failed on garbage host info, and self-heal didn't fire
       # because resolved_room_name was never extracted via the jq path.
       if command -v gh >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
-        raw_content=$(gh api "gists/$gist_id" 2>/dev/null \
-                      | jq -r '.files | to_entries[0].value.content // empty' 2>/dev/null)
+        raw_content=$( (gh api "gists/$gist_id" 2>/dev/null \
+                        | jq -r '.files | to_entries[0].value.content // empty' 2>/dev/null) || true )
       fi
       # Fallback path 1: gh without jq → degraded gh gist view --raw, with
       # a description-strip in the consumer below.
       if [ -z "$raw_content" ] && command -v gh >/dev/null 2>&1; then
-        raw_content=$(gh gist view "$gist_id" --raw 2>/dev/null)
+        raw_content=$(gh gist view "$gist_id" --raw 2>/dev/null || true)
       fi
-      # Fallback path 2: anonymous curl + jq for environments without gh.
+      # Fallback path 2: git clone the gist's git remote. CRITICAL — this
+      # is the rate-limit-bypass path. The REST API has a tight gist
+      # sub-bucket (~60 reads/hr); a busy session blows through it
+      # quickly and EVERY `gh api gists/<id>` and `gh gist view <id>`
+      # call HTTP 403's. Git transport at gist.github.com uses git HTTP
+      # over the same auth but on a separate quota — it keeps working
+      # when REST is throttled. The git-clone fallback adds ~1s on the
+      # slow path but unblocks discovery completely.
+      if [ -z "$raw_content" ] && command -v git >/dev/null 2>&1; then
+        local _gist_tmp; _gist_tmp=$(mktemp -d -t airc-gist-resolve.XXXXXX 2>/dev/null || echo "")
+        if [ -n "$_gist_tmp" ] && git clone --depth 1 --quiet "https://gist.github.com/$gist_id.git" "$_gist_tmp" 2>/dev/null; then
+          # Gists typically contain ONE file (airc envelopes always do).
+          # Take the first non-dotfile, non-.git entry. If a future gist
+          # shape ships multiple files we'll add an explicit airc-envelope
+          # filename convention; for now the single-file assumption is
+          # sound across every gist airc has ever published.
+          local _gist_file
+          _gist_file=$(find "$_gist_tmp" -maxdepth 1 -type f ! -name '.git*' 2>/dev/null | head -1 || true)
+          if [ -n "$_gist_file" ] && [ -f "$_gist_file" ]; then
+            raw_content=$(cat "$_gist_file" 2>/dev/null || true)
+          fi
+        fi
+        [ -n "$_gist_tmp" ] && rm -rf "$_gist_tmp"
+      fi
+      # Fallback path 3: anonymous curl + jq for environments without gh
+      # OR git. Last resort.
       if [ -z "$raw_content" ] && command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
-        raw_content=$(curl -fsSL "https://api.github.com/gists/$gist_id" 2>/dev/null \
-                      | jq -r '.files | to_entries[0].value.content // empty' 2>/dev/null)
+        raw_content=$( (curl -fsSL "https://api.github.com/gists/$gist_id" 2>/dev/null \
+                        | jq -r '.files | to_entries[0].value.content // empty' 2>/dev/null) || true )
       fi
       # Last-resort cleanup: if raw_content still has the description-header
       # leak from a degraded gh-view path, strip lines before the first '{'


### PR DESCRIPTION
## Bug

Joel mid-Windows-bringup 2026-04-27: continuum-b69f's airc on Windows hit "Resolving gist..." and hung. Mac side reproduced same hang shortly after — gh sub-bucket exhausted from the day's session activity. Joel: **"this limit will kill people."**

## Two bugs in one

### Bug A — set -e + pipefail aborts script on rate-limit

\`\`\`bash
# pre-fix
raw_content=$(gh api "gists/$gist_id" 2>/dev/null \
              | jq -r '.files | to_entries[0].value.content // empty' 2>/dev/null)
\`\`\`

With \`set -euo pipefail\` at airc:9, \`gh api\` returning 403 propagates non-zero up the pipeline → \`$(...)\` capture → set -e aborts the WHOLE script. None of the existing fallbacks ever ran. Foreground exit code: 5. Background: silent death after "Resolving gist...".

**Fix:** wrap each path with \`|| true\` so a non-zero exit becomes empty \`$raw_content\`; \`[ -z ]\` gates flow through to the next fallback. Pre-fix, the \`|| true\` was missing — the chain LOOKED fault-tolerant but wasn't.

### Bug B — all existing fallbacks share the throttled REST bucket

Paths A (\`gh api + jq\`) / B (\`gh gist view --raw\`) / C (\`curl + jq\`) ALL hit \`gists.github.com\` REST. When that's throttled, all three return empty. No fallback that uses different transport.

**Fix:** new fallback path — \`git clone --depth 1 https://gist.github.com/$gist_id.git\`. Git transport is on a separate quota; keeps working under REST throttle. Adds ~1s on the slow path; unblocks discovery completely.

## Verified live

While \`gh api\` returned 403 in <0.3s:

\`\`\`
+ raw_content=
+ command -v gh
+ raw_content=
+ '[' -z '' ']'
+ raw_content='{
  "airc": 1,
\`\`\`

Git-clone path populated raw_content with valid JSON envelope. Resolution succeeded under live rate-limit.

## New fallback order

1. \`gh api + jq\` (REST, fast — primary)
2. \`gh gist view --raw\` (REST, fallback)
3. **\`git clone\` gist remote (NEW — bypasses REST sub-bucket)**
4. \`curl + jq\` (REST, anonymous last resort)

If you have git, you survive rate-limit.

## Test posture

| scenario | result |
|---|---|
| part_persists | 8/8 |
| list | 4/4 |
| general_sidecar_default | 12/12 |

## Out of scope (separate)

\`airc.ps1\` has the same REST-only chain. Same fix applies; queued for Windows iteration step 2.