### PR TITLE
feat(doctor,install): probe sshd readiness + scope strict-probe to python (PR #153 follow-up)

### DIFF
--- a/airc
+++ b/airc
@@ -5379,6 +5379,7 @@ cmd_doctor() {
   _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"     || issues=$((issues+1))
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"     || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"    || issues=$((issues+1))
+  _doctor_probe_sshd                                                    || issues=$((issues+1))
   _doctor_probe_tailscale "$mgr"  # optional, never increments issues
 
   echo ""
@@ -5458,18 +5459,28 @@ _doctor_install_cmd_for() {
 
 _doctor_probe() {
   local cmd="$1" mgr="$2" purpose="$3"
-  # Strict probe: command must exist on PATH AND respond to --version with
-  # exit 0. The bare `command -v` form is fooled by Windows's Microsoft
-  # Store python3.exe alias (continuum-b69f, 2026-04-27) — the file
-  # exists, satisfies command -v, but exits 49 with a Store-redirect
-  # message on stderr when actually invoked. Same story for Windows
-  # python.exe alias. Strict-probe version catches this fail-fast at
-  # doctor time instead of letting every later python3 -c "..."
-  # call die silently in cmd_connect.
-  if command -v "$cmd" >/dev/null 2>&1 && "$cmd" --version >/dev/null 2>&1; then
-    printf "  [ok] %s\n" "$cmd"
-    return 0
-  fi
+  # Strict-probe ONLY the binaries that have known shadow-aliases on
+  # Windows. PR #153's blanket strict-probe broke on macOS BSD utilities
+  # — `ssh-keygen --version` exits 1 ("illegal option") because BSD
+  # doesn't accept --version, and there's no portable single-flag that
+  # discriminates "real ssh-keygen" from "stub" anyway. Only the
+  # Microsoft Store {python.exe, python3.exe} aliases need defense
+  # against; everything else is uniquely shipped by the user's package
+  # manager (no shadowing ambiguity), so bare `command -v` is correct.
+  case "$cmd" in
+    python|python3)
+      if command -v "$cmd" >/dev/null 2>&1 && "$cmd" --version >/dev/null 2>&1; then
+        printf "  [ok] %s\n" "$cmd"
+        return 0
+      fi
+      ;;
+    *)
+      if command -v "$cmd" >/dev/null 2>&1; then
+        printf "  [ok] %s\n" "$cmd"
+        return 0
+      fi
+      ;;
+  esac
   # Distinguish "absent" from "stub on PATH" so the fix hint is correct.
   local fix
   if command -v "$cmd" >/dev/null 2>&1; then
@@ -5500,6 +5511,97 @@ _doctor_probe_gh_auth() {
   printf "  [MISSING] gh authenticated (gist scope)\n"
   printf "         Fix: gh auth login -s gist\n"
   return 1
+}
+
+# Probe sshd (SSH server). airc joiners ssh into the host's airc_home
+# to `tail -F messages.jsonl`. So every airc user who'll host a room
+# (which is most users — first to discover a room becomes its host)
+# needs sshd running on their box. Pre-fix: airc doctor probed for the
+# ssh CLIENT but not the SERVER. Joel + continuum-b69f hit this on
+# 2026-04-27 mid-cross-machine bringup: TCP handshake worked, but
+# message stream silently failed because Windows ships OpenSSH client
+# but NOT the server enabled by default.
+#
+# Per-platform probes:
+#   macOS         — launchctl + systemsetup (Remote Login)
+#   linux / wsl   — systemctl is-active on ssh OR sshd unit names
+#                   (Debian/Ubuntu unit is 'ssh', RHEL/Fedora is 'sshd')
+#   windows-bash  — powershell.exe Get-Service sshd, distinguish
+#                   Running / Stopped / Missing-capability
+#
+# Returns 0 on ok, 1 on missing/broken, 0 on platforms we can't probe
+# (don't penalize if we can't tell).
+_doctor_probe_sshd() {
+  local plat; plat=$(detect_platform)
+  case "$plat" in
+    macos)
+      if launchctl list 2>/dev/null | grep -q "com\.openssh\.sshd"; then
+        printf "  [ok] sshd (Remote Login enabled)\n"
+        return 0
+      fi
+      if systemsetup -getremotelogin 2>/dev/null | grep -qi "Remote Login: On"; then
+        printf "  [ok] sshd (Remote Login enabled)\n"
+        return 0
+      fi
+      printf "  [MISSING] sshd -- needed when you HOST a room\n"
+      printf "         Fix: System Settings -> General -> Sharing -> Remote Login (toggle on)\n"
+      printf "         Or:  sudo systemsetup -setremotelogin on\n"
+      return 1
+      ;;
+    linux|wsl)
+      # Debian/Ubuntu uses 'ssh', RHEL/Fedora/Arch uses 'sshd'.
+      if systemctl is-active --quiet ssh 2>/dev/null || systemctl is-active --quiet sshd 2>/dev/null; then
+        printf "  [ok] sshd (systemd active)\n"
+        return 0
+      fi
+      printf "  [MISSING] sshd -- needed when you HOST a room\n"
+      printf "         Fix (Debian/Ubuntu): sudo apt-get install openssh-server && sudo systemctl enable --now ssh\n"
+      printf "         Fix (RHEL/Fedora):    sudo dnf install openssh-server && sudo systemctl enable --now sshd\n"
+      return 1
+      ;;
+    windows-bash)
+      # powershell.exe is the canonical PS launcher in Git Bash. Some
+      # boxes also ship pwsh.exe (PS Core); prefer powershell.exe for
+      # broadest reach since OpenSSH service control works in both.
+      local _ps=""
+      if command -v powershell.exe >/dev/null 2>&1; then _ps="powershell.exe"
+      elif command -v pwsh.exe >/dev/null 2>&1; then _ps="pwsh.exe"
+      fi
+      if [ -z "$_ps" ]; then
+        printf "  [info] sshd probe skipped (powershell.exe not on PATH)\n"
+        return 0
+      fi
+      local _state
+      _state=$("$_ps" -NoProfile -Command "(Get-Service sshd -ErrorAction SilentlyContinue).Status" 2>/dev/null | tr -d '\r\n ')
+      case "$_state" in
+        Running)
+          printf "  [ok] sshd (Windows OpenSSH.Server running)\n"
+          return 0
+          ;;
+        Stopped|StopPending|StartPending|Paused)
+          printf "  [BROKEN] sshd -- installed but not running (state: %s)\n" "$_state"
+          printf "         Fix (admin PowerShell):  Start-Service sshd; Set-Service sshd -StartupType Automatic\n"
+          return 1
+          ;;
+        "")
+          printf "  [MISSING] sshd -- needed when you HOST a room\n"
+          printf "         Fix (admin PowerShell):\n"
+          printf "           Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0\n"
+          printf "           Start-Service sshd\n"
+          printf "           Set-Service -Name sshd -StartupType Automatic\n"
+          return 1
+          ;;
+        *)
+          printf "  [info] sshd state unknown (Get-Service returned: '%s')\n" "$_state"
+          return 0
+          ;;
+      esac
+      ;;
+    *)
+      printf "  [info] sshd probe unsupported on platform '%s'\n" "$plat"
+      return 0
+      ;;
+  esac
 }
 
 _doctor_probe_tailscale() {
@@ -5547,6 +5649,7 @@ _doctor_connect_preflight() {
   _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"    || issues=$((issues+1))
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"    || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"   || issues=$((issues+1))
+  _doctor_probe_sshd                                                   || issues=$((issues+1))
 
   # ── gh chain: installed → authed → gist scope → gists API reachable.
   # Single chain (early-return on first failure) so a missing gh isn't

--- a/install.sh
+++ b/install.sh
@@ -222,6 +222,55 @@ ensure_prereqs() {
     ok "All required prereqs present"
   fi
 
+  # sshd: airc joiners ssh into the host's airc_home to tail messages.
+  # Every airc user who'll host a room (which is most users — first to
+  # discover becomes the host) needs sshd RUNNING on their box. Pre-fix
+  # 2026-04-27: install printed "All required prereqs present" against
+  # systems with no sshd, then airc connect's first cross-machine pair
+  # silently failed at the ssh-tail step. Now we detect + provide the
+  # platform-specific fix.
+  case "$(uname -s 2>/dev/null)" in
+    Darwin)
+      # macOS: sshd is launchd-managed via Remote Login.
+      if ! launchctl list 2>/dev/null | grep -q "com\.openssh\.sshd" \
+         && ! systemsetup -getremotelogin 2>/dev/null | grep -qi "Remote Login: On"; then
+        warn "sshd not running (Remote Login OFF) — needed when you HOST a room."
+        warn "  Enable: System Settings -> General -> Sharing -> Remote Login"
+        warn "  Or:     sudo systemsetup -setremotelogin on"
+      fi
+      ;;
+    Linux)
+      if ! systemctl is-active --quiet ssh 2>/dev/null && ! systemctl is-active --quiet sshd 2>/dev/null; then
+        warn "sshd not running — needed when you HOST a room."
+        warn "  Debian/Ubuntu: sudo apt-get install openssh-server && sudo systemctl enable --now ssh"
+        warn "  RHEL/Fedora:   sudo dnf install openssh-server && sudo systemctl enable --now sshd"
+      fi
+      ;;
+    MINGW*|MSYS*|CYGWIN*)
+      # Windows Git Bash: probe via powershell.exe.
+      if command -v powershell.exe >/dev/null 2>&1; then
+        _SSHD_STATE=$(powershell.exe -NoProfile -Command "(Get-Service sshd -ErrorAction SilentlyContinue).Status" 2>/dev/null | tr -d '\r\n ')
+        case "$_SSHD_STATE" in
+          Running) ok "sshd running (OpenSSH.Server service)" ;;
+          Stopped|StopPending|StartPending|Paused)
+            warn "sshd installed but not running (state: $_SSHD_STATE) — needed when you HOST."
+            warn "  Run in admin PowerShell:"
+            warn "    Start-Service sshd"
+            warn "    Set-Service sshd -StartupType Automatic"
+            ;;
+          "")
+            warn "sshd NOT installed — needed when you HOST a room."
+            warn "  Run in admin PowerShell (one-time):"
+            warn "    Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0"
+            warn "    Start-Service sshd"
+            warn "    Set-Service -Name sshd -StartupType Automatic"
+            warn "  Then re-run install.sh."
+            ;;
+        esac
+      fi
+      ;;
+  esac
+
   # Tailscale is optional -- only needed for cross-LAN mesh. LAN-only
   # works fine without it, so we attempt install but don't fail loud.
   if ! tailscale_present; then


### PR DESCRIPTION
## Why

Joel 2026-04-27: "Both need to host so just part of doctor and/or install."

airc design assumes every peer is a first-class host candidate. Windows ships OpenSSH **client** but not **server** (server is opt-in capability since Win10 1809). Pre-fix install printed "All required prereqs present" against a Windows install with no sshd; airc doctor probed ssh client only. First cross-machine pair silently failed at the ssh-tail step.

## What

**\`airc doctor\` — new \`_doctor_probe_sshd\`**:
- macOS: \`launchctl\` + \`systemsetup\` (Remote Login)
- Linux/WSL: \`systemctl is-active ssh\`/\`sshd\`
- Windows-bash: \`powershell.exe Get-Service sshd\` distinguishing Running / Stopped / Missing
- Each branch prints platform-specific fix hints.

**\`install.sh\` — same probe**:
- Warn-only (admin elevation needed on Windows; we print the commands rather than try to elevate)
- Same per-platform fix hints

**\`_doctor_probe\` regression fix (from PR #153)**:
- PR #153 made the probe strict (\`--version >/dev/null 2>&1\`) for all binaries to defeat the Microsoft Store python3 stub.
- Side effect: macOS BSD \`ssh-keygen\` exits 1 on \`--version\` (BSD only accepts \`-V\`, but that's also exit 1). False-positive [BROKEN] on every Mac. Surfaced when the new sshd probe ran on clean output.
- Fix: scope strict-probe to python/python3 ONLY. Other binaries are uniquely shipped (no shadow-alias problem); bare \`command -v\` is correct + portable.

## Live test (Mac doctor output)

\`\`\`
[ok] git
[ok] gh
[ok] gh authenticated
[ok] openssl
[ok] ssh
[ok] ssh-keygen
[ok] python3
[MISSING] sshd -- needed when you HOST a room
       Fix: System Settings -> General -> Sharing -> Remote Login (toggle on)
       Or:  sudo systemsetup -setremotelogin on
[info] tailscale (optional) -- not installed; only needed for cross-LAN mesh
\`\`\`

This Mac has Remote Login OFF — correctly flagged.

## Mac regression

- part_persists: 8/8
- list: 4/4
- general_sidecar_default: 12/12
- platform_adapters: 11/11

## Out of scope

\`airc.ps1\` and \`install.ps1\` should grow equivalent probes + auto-install when elevated. Windows iteration step 3.