### PR TITLE
fix(sshd-probe): macOS launchctl print system + osascript admin dialog (PR #156/#157 live-test followups)

### DIFF
--- a/airc
+++ b/airc
@@ -5535,7 +5535,15 @@ _doctor_probe_sshd() {
   local plat; plat=$(detect_platform)
   case "$plat" in
     macos)
-      if launchctl list 2>/dev/null | grep -q "com\.openssh\.sshd"; then
+      # macOS Remote Login = launchd-managed sshd. Detect WITHOUT sudo:
+      #   - `launchctl list` (user scope) does NOT show system services
+      #     like com.openssh.sshd, so the user-scope probe always misses.
+      #   - `launchctl print system` DOES list system services and works
+      #     without sudo. Look for `com.openssh.sshd` (the service id).
+      #   - `systemsetup -getremotelogin` requires admin to read state
+      #     (returns "You need administrator access..." otherwise) — keep
+      #     it as the second-attempt fallback in case sudo is cached.
+      if launchctl print system 2>/dev/null | grep -qE 'com\.openssh\.sshd($|[[:space:]])'; then
         printf "  [ok] sshd (Remote Login enabled)\n"
         return 0
       fi

--- a/install.sh
+++ b/install.sh
@@ -132,18 +132,39 @@ install_with_pkgmgr() {
 _ensure_sshd_running() {
   case "$(uname -s 2>/dev/null)" in
     Darwin)
-      # macOS: sshd is launchd-managed; "Remote Login" toggle drives it.
-      if launchctl list 2>/dev/null | grep -q "com\.openssh\.sshd" \
+      # macOS: sshd is launchd-managed via "Remote Login". Detection
+      # without sudo: `launchctl print system` shows system services
+      # including com.openssh.sshd when Remote Login is on. Bare
+      # `launchctl list` is user-scope and never shows it.
+      if launchctl print system 2>/dev/null | grep -qE 'com\.openssh\.sshd($|[[:space:]])' \
          || systemsetup -getremotelogin 2>/dev/null | grep -qi "Remote Login: On"; then
         ok "sshd running (Remote Login enabled)"
         return 0
       fi
-      info "Enabling Remote Login (sshd) — sudo prompt incoming."
+      info "Enabling Remote Login (sshd) — admin password prompt incoming."
       info "  airc joiners need this to ssh-tail your messages.jsonl when you host."
-      if sudo systemsetup -setremotelogin on 2>&1; then
-        ok "Remote Login enabled."
+      # Two paths: terminal sudo (if a TTY is attached) or osascript GUI
+      # admin prompt (when called from non-terminal context — e.g. a
+      # Monitor-spawned shell, or via curl|bash piping). The osascript
+      # path uses macOS native admin dialog with a branded prompt
+      # explaining what airc is doing — Joel 2026-04-27 (continuum
+      # relay): "if we can prompt the user, we do NOT have them do
+      # annoying setup shit we automate into install."
+      if [ -t 0 ] && [ -t 1 ]; then
+        # Interactive shell — sudo can read the password.
+        if sudo systemsetup -setremotelogin on 2>&1; then
+          ok "Remote Login enabled."
+        else
+          warn "systemsetup failed. Manual: System Settings -> General -> Sharing -> Remote Login."
+        fi
       else
-        warn "systemsetup failed. Manual fallback: System Settings -> General -> Sharing -> Remote Login (toggle on)."
+        # Non-interactive (Monitor/pipe/script) — use osascript GUI prompt.
+        if osascript -e 'do shell script "systemsetup -setremotelogin on" with administrator privileges with prompt "AIRC needs admin to enable Remote Login (sshd) — one-time setup so peers can ssh-tail your messages when you host an airc room."' 2>&1; then
+          ok "Remote Login enabled."
+        else
+          warn "osascript admin dialog cancelled or failed."
+          warn "  Manual: System Settings -> General -> Sharing -> Remote Login."
+        fi
       fi
       ;;
     Linux)


### PR DESCRIPTION
Two issues caught running the PR #156/#157 sshd work on a real Mac:

## Bug 1 — launchctl list (user scope) doesn't show system services

\`launchctl list\` is user-scope. Never shows system services like \`com.openssh.sshd\`. Doctor reported [MISSING] even with Remote Login enabled + active sshd-session processes forking.

**Fix:** \`launchctl print system\` (no sudo needed). Anchored regex so the service id matches but per-connection session subkeys don't false-positive.

## Bug 2 — install.sh sudo fails in non-interactive contexts

Monitor-spawned shells, curl|bash pipes, etc. don't have a TTY. \`sudo\` then errors with "a terminal is required to read the password." Same situation Joel hit running this through Claude Code's Bash tool.

**Fix:** TTY detection (\`[ -t 0 ] && [ -t 1 ]\`). Interactive → sudo. Non-interactive → osascript with native macOS admin GUI dialog and an airc-branded prompt explaining the action.

## Live verification

Doctor on this Mac with Remote Login enabled but pre-fix probe reported [MISSING]. Post-fix:

\`\`\`
[ok] sshd (Remote Login enabled)
\`\`\`

## Why this is critical

Without these fixes, even after a user has Remote Login on, doctor reports MISSING (confusing) and install.sh sudo path can't run from a non-terminal context (most install paths now are non-terminal: Claude Code Bash tool, Monitor, etc.).