### PR TITLE
fix(doctor): tailscale probe uses resolve_tailscale_bin (catch GUI install)

### DIFF
--- a/airc
+++ b/airc
@@ -5614,8 +5614,16 @@ _doctor_probe_sshd() {
 
 _doctor_probe_tailscale() {
   local mgr="$1"
-  if command -v tailscale >/dev/null 2>&1; then
-    if tailscale status >/dev/null 2>&1; then
+  # Use resolve_tailscale_bin so we find macOS GUI-installed Tailscale.app
+  # (the binary lives at /Applications/Tailscale.app/Contents/MacOS/Tailscale,
+  # not on PATH by default). Bare `command -v tailscale` false-negatives
+  # on every Mac that installed via the App Store / dmg — caught live
+  # 2026-04-27 when Mac doctor said "tailscale not installed" while
+  # airc was actively publishing a Tailscale IP from the running app.
+  local _ts_bin
+  _ts_bin=$(resolve_tailscale_bin 2>/dev/null || true)
+  if [ -n "$_ts_bin" ]; then
+    if "$_ts_bin" status >/dev/null 2>&1; then
       printf "  [ok] tailscale (optional) -- daemon up\n"
     else
       printf "  [info] tailscale (optional) -- installed but daemon not up\n"


### PR DESCRIPTION
Bare \`command -v tailscale\` false-negatives on every macOS Tailscale.app install (App Store / .dmg). Binary lives at \`/Applications/Tailscale.app/Contents/MacOS/Tailscale\` — not on PATH by default.

\`resolve_tailscale_bin()\` already exists and handles the GUI bundle path. Doctor probe just needs to use it.

**Pre-fix** (this Mac, Tailscale.app installed + running):
\`\`\`
[info] tailscale (optional) -- not installed; only needed for cross-LAN mesh
       Install: brew install --cask tailscale
\`\`\`

**Post-fix:**
\`\`\`
[ok] tailscale (optional) -- daemon up
\`\`\`