### PR TITLE
fix(install,doctor): Windows HNS port-22 reservation (continuum's diagnosis — sshd bind EPERM)

### DIFF
--- a/airc
+++ b/airc
@@ -5593,10 +5593,14 @@ _doctor_probe_sshd() {
           ;;
         "")
           printf "  [MISSING] sshd -- needed when you HOST a room\n"
-          printf "         Fix (admin PowerShell):\n"
+          printf "         Fix (admin PowerShell — five lines, run all together):\n"
           printf "           Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0\n"
+          printf "           reg add HKLM\\\\SYSTEM\\\\CurrentControlSet\\\\Services\\\\hns\\\\State /v EnableExcludedPortRange /d 0 /f\n"
+          printf "           netsh int ipv4 add excludedportrange protocol=tcp startport=22 numberofports=1\n"
           printf "           Start-Service sshd\n"
           printf "           Set-Service -Name sshd -StartupType Automatic\n"
+          printf "         (The reg+netsh lines work around Windows HNS holding port 22 randomly per boot —\n"
+          printf "          continuum-b69f's diagnosis 2026-04-27. Without them, sshd bind returns EPERM.)\n"
           return 1
           ;;
         *)

--- a/install.ps1
+++ b/install.ps1
@@ -155,6 +155,47 @@ function Install-OpenSSHClient {
 # only. Post-fix (Joel 2026-04-27 "this needs to be in the install dude"):
 # install.ps1 now installs+starts the server too, with auto-start on
 # boot so the mesh survives reboots without manual intervention.
+# Workaround for Windows HNS (Host Network Service) randomly reserving
+# port 22 at boot. HNS dynamically reserves port ranges to support
+# Hyper-V / WSL2 / Docker Desktop networking; the reservations rotate
+# per-boot and are NOT visible in `netsh int ipv4 show excludedportrange`
+# (that command shows static admin reservations only). When port 22
+# happens to fall inside a dynamic HNS range, sshd bind() returns EPERM
+# even with admin. Diagnosis credit: continuum-b69f via cross-Mac/Windows
+# coord gist 2026-04-27. Two-step persistent fix:
+#
+#   1. Disable HNS auto-exclusion via registry — survives reboots.
+#   2. Explicitly reserve port 22 in the static excluded-port-range so
+#      HNS can't grab it on subsequent boots.
+#
+# References:
+#   keasigmadelta.com/blog/how-to-solve-cannot-bind-to-port-due-to-permission-denied-on-windows
+#   github.com/docker/for-win/issues/3171
+function Set-HnsPortFreedomFor22 {
+    # Idempotent — both checks before writing so re-runs of install
+    # don't double-write or noisy on a healthy system.
+    $regPath = 'HKLM:\SYSTEM\CurrentControlSet\Services\hns\State'
+    $regName = 'EnableExcludedPortRange'
+    $needRegWrite = $true
+    try {
+        $cur = (Get-ItemProperty -Path $regPath -Name $regName -ErrorAction SilentlyContinue).$regName
+        if ($cur -eq 0) { $needRegWrite = $false }
+    } catch { }
+    if ($needRegWrite) {
+        Write-Host '    Disabling HNS auto-exclusion (HKLM\...\hns\State EnableExcludedPortRange = 0) ...'
+        & reg add 'HKLM\SYSTEM\CurrentControlSet\Services\hns\State' /v 'EnableExcludedPortRange' /d 0 /f 2>$null | Out-Null
+    }
+
+    # Check if port 22 is already in the static excluded-port-range.
+    $existing = & netsh int ipv4 show excludedportrange protocol=tcp 2>$null | Out-String
+    if ($existing -match '(?m)^\s*22\s+22\b') {
+        # Already reserved.
+        return
+    }
+    Write-Host '    Reserving port 22 in static excluded-port-range (netsh) ...'
+    & netsh int ipv4 add excludedportrange protocol=tcp startport=22 numberofports=1 2>$null | Out-Null
+}
+
 function Install-OpenSSHServer {
     $svc = Get-Service sshd -ErrorAction SilentlyContinue
     if ($svc -and $svc.Status -eq 'Running') {
@@ -163,13 +204,25 @@ function Install-OpenSSHServer {
     }
     Write-Step 'Installing + starting OpenSSH Server (admin required) ...'
     try {
-        # Install capability if not already installed.
+        # 1. Capability install (if not already).
         $cap = Get-WindowsCapability -Online -Name 'OpenSSH.Server*' -ErrorAction Stop
         if ($cap.State -ne 'Installed') {
             Add-WindowsCapability -Online -Name $cap.Name -ErrorAction Stop | Out-Null
             Write-Host '    OpenSSH.Server capability installed.'
         }
-        # Start the service.
+        # 2. HNS port-22 reservation (Hyper-V quirk — see Set-HnsPortFreedomFor22).
+        Set-HnsPortFreedomFor22
+        # 3. Firewall rule for inbound TCP/22. The capability install
+        # usually creates 'OpenSSH-Server-In-TCP' but it may be disabled
+        # or missing on some systems. Idempotent.
+        if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) {
+            Write-Host '    Creating firewall rule for inbound SSH (TCP/22) ...'
+            New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' `
+                                -DisplayName 'OpenSSH Server (sshd)' `
+                                -Enabled True -Direction Inbound -Protocol TCP `
+                                -Action Allow -LocalPort 22 -ErrorAction SilentlyContinue | Out-Null
+        }
+        # 4. Start + persist.
         Start-Service sshd -ErrorAction Stop
         Set-Service -Name sshd -StartupType Automatic -ErrorAction Stop
         Write-Ok 'OpenSSH server installed + started + auto-start on boot'
@@ -177,8 +230,11 @@ function Install-OpenSSHServer {
         Write-Warn2 "Could not auto-install OpenSSH Server (run install.ps1 in admin PowerShell): $_"
         Write-Host '    Manual fix (admin PowerShell):'
         Write-Host '      Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0'
+        Write-Host '      reg add HKLM\SYSTEM\CurrentControlSet\Services\hns\State /v EnableExcludedPortRange /d 0 /f'
+        Write-Host '      netsh int ipv4 add excludedportrange protocol=tcp startport=22 numberofports=1'
         Write-Host '      Start-Service sshd'
         Write-Host '      Set-Service -Name sshd -StartupType Automatic'
+        Write-Host '    (The reg+netsh lines work around Windows HNS holding port 22 randomly per boot.)'
     }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -204,31 +204,59 @@ _ensure_sshd_running() {
     MINGW*|MSYS*|CYGWIN*)
       # Windows Git Bash: probe via powershell.exe; install via UAC-elevated
       # PowerShell (Start-Process -Verb RunAs).
+      #
+      # HNS port-22 reservation: Windows HNS (Host Network Service)
+      # randomly reserves dynamic port ranges per boot to support
+      # Hyper-V/WSL2/Docker. When port 22 falls inside an HNS range,
+      # sshd bind() returns EPERM even with admin. Persistent fix:
+      # (a) reg-disable HNS auto-exclusion + (b) reserve port 22 in the
+      # static excluded-port-range. Both run inside the elevated payload
+      # so user clicks UAC once for the whole sshd setup.
+      # Diagnosis: continuum-b69f via cross-Mac/Windows coord gist
+      # 2026-04-27. Refs:
+      #   keasigmadelta.com/blog/how-to-solve-cannot-bind-to-port-...
+      #   github.com/docker/for-win/issues/3171
       if ! command -v powershell.exe >/dev/null 2>&1; then
         warn "powershell.exe not on PATH; can't auto-configure sshd."
         return 0
       fi
       local _state
       _state=$(powershell.exe -NoProfile -Command "(Get-Service sshd -ErrorAction SilentlyContinue).Status" 2>/dev/null | tr -d '\r\n ')
+      # Single elevated payload: capability + HNS workaround + firewall
+      # rule + start + persist. Idempotent — the inner commands check
+      # state before writing, so re-running install on a healthy box
+      # doesn't re-prompt or duplicate state.
+      local _elevated_payload='
+$ErrorActionPreference = "Stop";
+try {
+  $cap = Get-WindowsCapability -Online -Name "OpenSSH.Server*";
+  if ($cap.State -ne "Installed") { Add-WindowsCapability -Online -Name $cap.Name | Out-Null }
+  $reg = (Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\hns\State" -Name "EnableExcludedPortRange" -ErrorAction SilentlyContinue).EnableExcludedPortRange;
+  if ($reg -ne 0) { reg add "HKLM\SYSTEM\CurrentControlSet\Services\hns\State" /v "EnableExcludedPortRange" /d 0 /f | Out-Null }
+  $excl = netsh int ipv4 show excludedportrange protocol=tcp | Out-String;
+  if ($excl -notmatch "(?m)^\s*22\s+22\b") { netsh int ipv4 add excludedportrange protocol=tcp startport=22 numberofports=1 | Out-Null }
+  if (-not (Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyContinue)) {
+    New-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -DisplayName "OpenSSH Server (sshd)" -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null
+  }
+  Start-Service sshd;
+  Set-Service -Name sshd -StartupType Automatic;
+  Write-Host "airc: sshd ready (capability + HNS + firewall + service auto-start)";
+} catch { Write-Host "airc-elevated-error: $_" }
+'
       case "$_state" in
         Running)
           ok "sshd running (Windows OpenSSH.Server)"
           return 0
           ;;
-        Stopped|StopPending|StartPending|Paused)
-          info "sshd installed but not running — starting it (UAC prompt incoming)."
-          powershell.exe -NoProfile -Command "Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile -Command Start-Service sshd; Set-Service sshd -StartupType Automatic'" 2>&1 \
-            && ok "sshd started + auto-start configured." \
-            || warn "Self-elevation failed. Run in admin PowerShell: Start-Service sshd; Set-Service sshd -StartupType Automatic"
-          ;;
-        "")
-          info "Installing OpenSSH.Server (UAC prompt incoming) — needed for hosting airc rooms."
-          # Self-elevate, install capability, start service, set automatic.
-          # All in one elevated process so the user clicks UAC once.
-          powershell.exe -NoProfile -Command "Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile -Command Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0; Start-Service sshd; Set-Service -Name sshd -StartupType Automatic'" 2>&1 \
-            && ok "OpenSSH.Server installed + started + auto-start configured." \
+        Stopped|StopPending|StartPending|Paused|"")
+          info "Configuring OpenSSH.Server + HNS port-22 reservation (UAC prompt incoming)."
+          info "  airc joiners need this to ssh-tail your messages.jsonl when you host."
+          powershell.exe -NoProfile -Command "Start-Process powershell -Verb RunAs -Wait -ArgumentList '-NoProfile -Command \"$_elevated_payload\"'" 2>&1 \
+            && ok "OpenSSH.Server installed + started + HNS port-22 reserved + auto-start." \
             || warn "Self-elevation failed. Run in admin PowerShell:
     Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+    reg add HKLM\\SYSTEM\\CurrentControlSet\\Services\\hns\\State /v EnableExcludedPortRange /d 0 /f
+    netsh int ipv4 add excludedportrange protocol=tcp startport=22 numberofports=1
     Start-Service sshd
     Set-Service -Name sshd -StartupType Automatic"
           ;;


### PR DESCRIPTION
## Bug (continuum-b69f via cross-Mac/Windows coord gist 2026-04-27)

\`Start-Service sshd\` on Windows: "Cannot bind any address" / permission denied even WITH admin. Root cause: Windows HNS (Host Network Service — backs Hyper-V/WSL2/Docker) dynamically reserves port ranges at boot. Per-boot rotation. NOT visible in \`netsh int ipv4 show excludedportrange\` (which shows static admin reservations only). When port 22 randomly lands inside an HNS-held range, sshd bind returns EPERM at the OS layer.

References continuum cited:
- https://keasigmadelta.com/blog/how-to-solve-cannot-bind-to-port-due-to-permission-denied-on-windows/
- https://github.com/docker/for-win/issues/3171

## Persistent fix

Two-step workaround inside the admin-elevated install payload, both idempotent:

\`\`\`powershell
reg add HKLM\\SYSTEM\\CurrentControlSet\\Services\\hns\\State /v EnableExcludedPortRange /d 0 /f
netsh int ipv4 add excludedportrange protocol=tcp startport=22 numberofports=1
\`\`\`

Plus a New-NetFirewallRule for OpenSSH-Server-In-TCP (capability install creates it, but defensive idempotent check).

## Files

- **install.ps1** \`Set-HnsPortFreedomFor22\` helper + wired into \`Install-OpenSSHServer\`. Idempotent registry + netsh checks.
- **install.sh** Windows-bash branch emits ONE elevated PowerShell payload running all steps — capability + HNS + firewall + service start + persist — so user clicks UAC ONCE.
- **airc doctor** \`[MISSING] sshd\` Windows hint now lists all five remediation commands (capability + HNS reg + HNS netsh + start + persist) with a one-line "why HNS holds port 22" explanation pointing at continuum's diagnosis date.

## Why this matters

Pre-fix, install or doctor's hint could leave a user partially fixed: capability installed, service set automatic — but \`Start-Service sshd\` still EPERM'd because HNS owned port 22. Looked like a permission bug. Continuum's diagnosis converts this from "random Windows mystery" to "one-time install action."

## Mac regression

HNS branch only fires on MINGW/MSYS/CYGWIN. Mac unchanged.

- part_persists: 8/8
- list: 4/4
- general_sidecar_default: 12/12
- platform_adapters: 11/11