### PR TITLE
fix(parser,prereq): jq is required — fallback parser corrupts gist envelopes without it (continuum's diagnosis)

### DIFF
--- a/airc
+++ b/airc
@@ -2364,6 +2364,29 @@ cmd_connect() {
         # Legacy raw-string format OR jq missing — take the first
         # non-empty line that looks like an invite.
         resolved=$(printf '%s' "$raw_content" | grep -E '@.*@' | head -1 | tr -d '\r\n ')
+        # If the matched line is from a JSON envelope (e.g.
+        # `"invite": "name@user@host:port#..."`), the grep grabs the
+        # whole quoted line including the JSON-key prefix. Strip
+        # leading non-name characters: anything before the first letter
+        # is JSON syntax (quotes, colons, whitespace). Found by
+        # continuum-b69f Win→Mac e2e 2026-04-27 — bash on Git Bash
+        # ships without jq, falls through to this path, captured
+        # `"invite":"authenticator-fd63@...` as the invite, then the
+        # downstream @-split made the displayed peer name include
+        # the JSON-key fragment AND prevented resolved_room_name from
+        # ever being set (no JSON parse, no .name extraction). Strip
+        # everything up to the first letter or hyphen, then re-validate.
+        resolved=$(printf '%s' "$resolved" | sed -E 's/^[^a-zA-Z]+//')
+        # Fallback room-name extraction when jq is missing: grep the
+        # raw_content for `"name": "..."` and capture the value. Same
+        # JSON envelope shape as the jq path; sed-only so it works on
+        # bare-bones environments. Empty if not present (legacy gist).
+        if [ -z "$resolved_room_name" ]; then
+          resolved_room_name=$(printf '%s' "$raw_content" \
+            | grep -oE '"name"[[:space:]]*:[[:space:]]*"[^"]+"' \
+            | head -1 \
+            | sed -E 's/^"name"[[:space:]]*:[[:space:]]*"([^"]+)"$/\1/')
+        fi
       fi
       if [ -z "$resolved" ] || ! echo "$resolved" | grep -q '@'; then
         die "Failed to resolve gist '$gist_id' to a valid invite (got: $(printf '%s' "$raw_content" | head -c 80)...)"
@@ -5379,6 +5402,7 @@ cmd_doctor() {
   _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"     || issues=$((issues+1))
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"     || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"    || issues=$((issues+1))
+  _doctor_probe "jq"           "$mgr" "Gist envelope parser (rooms, addresses)" || issues=$((issues+1))
   _doctor_probe_sshd                                                    || issues=$((issues+1))
   _doctor_probe_tailscale "$mgr"  # optional, never increments issues
 
@@ -5669,6 +5693,7 @@ _doctor_connect_preflight() {
   _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"    || issues=$((issues+1))
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"    || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"   || issues=$((issues+1))
+  _doctor_probe "jq"           "$mgr" "Gist envelope parser (rooms, addresses)" || issues=$((issues+1))
   _doctor_probe_sshd                                                   || issues=$((issues+1))
 
   # ── gh chain: installed → authed → gist scope → gists API reachable.

--- a/install.ps1
+++ b/install.ps1
@@ -263,6 +263,7 @@ Install-IfMissing -Name 'Python 3'           -WingetId 'Python.Python.3.12'  -Te
     return [bool](Get-Command py -ErrorAction SilentlyContinue)
 }
 Install-IfMissing -Name 'GitHub CLI (gh)'    -WingetId 'GitHub.cli'          -TestCmd { Get-Command gh -ErrorAction SilentlyContinue }
+Install-IfMissing -Name 'jq'                 -WingetId 'jqlang.jq'           -TestCmd { Get-Command jq -ErrorAction SilentlyContinue }
 Install-IfMissing -Name 'Tailscale'          -WingetId 'tailscale.tailscale' -TestCmd { Get-Command tailscale -ErrorAction SilentlyContinue }
 
 Install-OpenSSHClient

--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,11 @@ pkgname_for() {
         winget) echo "GitHub.cli" ;;
         *)      echo "gh" ;;
       esac ;;
+    jq)
+      case "$mgr" in
+        winget) echo "jqlang.jq" ;;
+        *)      echo "jq" ;;
+      esac ;;
     *) echo "$prereq" ;;
   esac
 }
@@ -321,7 +326,12 @@ ensure_prereqs() {
   fi
 
   local missing=() pkgs=() unmappable=()
-  for cmd in git gh openssl ssh-keygen python3; do
+  # jq added 2026-04-27: airc's gist envelope parser uses jq for the
+  # canonical path; bash bare-grep fallback handles JSON-key-prefix
+  # leak now (PR fix), but jq is the right tool — without it the
+  # fallback can't extract host.addresses[] for multi-address pick.
+  # On Git Bash, jq is winget-installable as 'jqlang.jq'.
+  for cmd in git gh jq openssl ssh-keygen python3; do
     # Strict probe: presence on PATH AND a successful --version invocation.
     # The bare `command -v` form is fooled by Windows's Microsoft Store
     # python3.exe alias (continuum-b69f, 2026-04-27) — the file exists,


### PR DESCRIPTION
## Bug (continuum-b69f Win→Mac e2e 2026-04-27)

Windows airc connect "succeeded" but:
- displayed peer name was \`'\"invite\":\"authenticator-fd63'\` (JSON syntax leaked)
- \`room_name\` file never written to disk
- subsequent \`airc msg\` stored with \`from:"unknown"\` and never landed on mac host

## Root cause

\`cmd_connect\`'s gist resolver has two paths. The JSON-envelope parse path is gated on \`command -v jq\`. **Windows Git Bash ships without jq by default.** Falls through to grep-based fallback that captures the JSON \`"invite":"...\` key prefix into the parsed invite, AND never sets \`resolved_room_name\`. Hence both the corrupt peer name AND the missing room_name file.

## Three-layer fix

**1. jq is now a required prereq.** install.sh, install.ps1, airc doctor — all updated. winget id \`jqlang.jq\`; brew/apt/dnf/pacman/apk all use bare \`jq\`.

**2. Legacy fallback strips JSON-key prefix.** \`sed -E 's/^[^a-zA-Z]+//'\` before @-split. Defense in depth for any minimal environment that escapes layer 1.

**3. Legacy fallback extracts room name.** Walks raw_content for \`"name": "..."\` regex and captures the value when jq is absent. Same envelope shape; works without any JSON parser.

## Test posture

Doctor live on this Mac shows new \`[ok] jq\`. Mac regression all green (part_persists 8/8, list 4/4, general_sidecar_default 12/12, platform_adapters 11/11).