### PR TITLE
fix(airc): two PR #164 followups — sed missed line 1372 + harden host_* config write (continuum's retest)

### DIFF
--- a/airc
+++ b/airc
@@ -1369,7 +1369,7 @@ monitor() {
 # Handles [rename] protocol by updating peer records on disk.
 monitor_formatter() {
   local my_name="$1"
-  PEERS_DIR="$PEERS_DIR" python3 -u -c '
+  PEERS_DIR="$PEERS_DIR" "$AIRC_PYTHON" -u -c '
 import sys, json, os, re, time, signal
 
 # Inactivity watchdog: if no inbound line arrives in WATCHDOG_SEC,
@@ -2765,16 +2765,34 @@ except Exception:
     print("{}")
 ' 2>/dev/null)
     [ -z "$host_identity_json" ] && host_identity_json="{}"
-    HOST_IDENTITY="$host_identity_json" "$AIRC_PYTHON" -c "
+    # Pass values as env vars instead of bash-substituted into the
+    # python heredoc body. continuum-b69f's PR #164 retest 2026-04-27
+    # found host_airc_home / host_name / host_port / host_ssh_pub /
+    # host_identity all silently unwritten on Win→Mac join: if ANY of
+    # the bash substitutions broke the python source (newline in
+    # host_ssh_pub, weird char in host_airc_home, peer_port empty/
+    # non-numeric, etc.), the whole heredoc errored out via
+    # `2>/dev/null || true` and zero fields landed in config. Switch
+    # to env-var pass — python reads from os.environ; bash never
+    # touches the python source. Also emit stderr to surface failures
+    # for the future debugger (not /dev/null).
+    HOST_AIRC_HOME="$host_airc_home" \
+    HOST_NAME="$peer_name" \
+    HOST_PORT="${peer_port:-7547}" \
+    HOST_SSH_PUB="$host_ssh_pub" \
+    HOST_IDENTITY="$host_identity_json" \
+    CONFIG="$CONFIG" \
+    "$AIRC_PYTHON" -c '
 import json, os
-c = json.load(open('$CONFIG'))
-c['host_airc_home'] = '$host_airc_home'
-c['host_name']      = '$peer_name'
-c['host_port']      = ${peer_port:-7547}
-c['host_ssh_pub']   = '''$host_ssh_pub'''
-c['host_identity']  = json.loads(os.environ.get('HOST_IDENTITY', '{}'))
-json.dump(c, open('$CONFIG', 'w'), indent=2)
-" 2>/dev/null || true
+c = json.load(open(os.environ["CONFIG"]))
+c["host_airc_home"] = os.environ.get("HOST_AIRC_HOME", "")
+c["host_name"]      = os.environ.get("HOST_NAME", "")
+try:    c["host_port"] = int(os.environ.get("HOST_PORT", "7547"))
+except: c["host_port"] = 7547
+c["host_ssh_pub"]   = os.environ.get("HOST_SSH_PUB", "")
+c["host_identity"]  = json.loads(os.environ.get("HOST_IDENTITY", "{}"))
+json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
+' || echo "  ⚠  config write failed (host_airc_home/host_name/host_port/host_ssh_pub may be unset). airc may still work if subsequent retries refresh." >&2
 
     # Pick up reminder setting from host
     local host_reminder


### PR DESCRIPTION
continuum-b69f's PR #164 retest 2026-04-27 found two remaining issues.

## Bug A — line 1372 missed by PR #164's sed

\`python3 -u -c '\` (the unbuffered monitor_formatter launch) didn't match the \`python3 -c\` regex. On Windows with Store stub, monitor_formatter crashed silently — joiner monitor went dark, no inbound stream visible. One-line fix.

## Bug B — host_* config write silently no-op'd

continuum's joiner config had \`name\`, \`host\`, \`host_target\`, \`created\` but missing \`host_airc_home\`, \`host_name\`, \`host_port\`, \`host_ssh_pub\`, \`host_identity\` — all five written by ONE python heredoc whose body had five bash-substituted variables. If any substitution broke python parsing (special char, empty value, etc.), the heredoc errored, \`2>/dev/null || true\` swallowed it, all five fields stayed empty. Specifically host_airc_home empty meant cmd_send's SSH push targeted a wrong remote path → another silent-no-op direction even after PR #164.

Fix: pass values as env vars; python reads via \`os.environ.get(...)\`. Bash never touches python source. Stderr surfaces (warn line, not /dev/null). \`int(host_port)\` wrapped in try/except.

## Pattern note

\`"\$AIRC_PYTHON" -c "..."\` heredocs with bash-var substitutions are fragile by class. Filing follow-up to sweep all ~30 sites.

## Mac regression

| scenario | result |
|---|---|
| identity | 19/19 |
| whois | 5/5 |
| part_persists | 8/8 |
| list | 4/4 |
| general_sidecar_default | 12/12 |

Win→Mac e2e validation pending continuum's retest.