### PR TITLE
feat(airc_core): Python truth-layer foundation + first migration (#152 Phase 0)

### DIFF
--- a/airc
+++ b/airc
@@ -54,6 +54,42 @@ else
 fi
 export AIRC_PYTHON
 
+# Resolve the airc install dir's lib/ path and prepend to PYTHONPATH so
+# Python heredocs + module invocations can import airc_core (the
+# Python truth-layer #152). Three resolution paths, first hit wins:
+#   1. $AIRC_DIR (explicit override / install.sh's working dir)
+#   2. dirname of this script (dev checkout — running from repo)
+#   3. $HOME/.airc-src (install.sh default)
+# When the lib/ dir doesn't exist (e.g. older install before this PR
+# landed), PYTHONPATH stays unmodified — heredocs still work.
+_airc_resolve_lib_dir() {
+  local _candidate _abs
+  for _candidate in \
+      "${AIRC_DIR:-}/lib" \
+      "$(dirname "$(readlink "$0" 2>/dev/null || echo "$0")")/lib" \
+      "$(dirname "$0")/lib" \
+      "$HOME/.airc-src/lib"; do
+    if [ -d "$_candidate/airc_core" ]; then
+      # Canonicalize to absolute path so PYTHONPATH stays valid even
+      # if cwd changes mid-script (heredocs that cd elsewhere). cd +
+      # pwd is the portable canonicalize idiom — `realpath` and
+      # `readlink -f` are not available everywhere (BSD readlink
+      # lacks -f, busybox lacks realpath).
+      _abs=$(cd "$_candidate" 2>/dev/null && pwd) || _abs="$_candidate"
+      printf '%s' "$_abs"
+      return 0
+    fi
+  done
+}
+_airc_lib_dir=$(_airc_resolve_lib_dir)
+if [ -n "${_airc_lib_dir:-}" ]; then
+  if [ -n "${PYTHONPATH:-}" ]; then
+    export PYTHONPATH="$_airc_lib_dir:$PYTHONPATH"
+  else
+    export PYTHONPATH="$_airc_lib_dir"
+  fi
+fi
+
 # One-time migration from pre-rename ~/.agent-relay → ~/.airc. Fires when user
 # is on vanilla defaults, the old dir exists as a real dir (not a symlink we
 # already left), and ~/.airc doesn't. Leaves a symlink ~/.agent-relay → ~/.airc
@@ -939,44 +975,20 @@ detect_platform() {
   esac
 }
 
-# Convert an ISO 8601 UTC timestamp (e.g. "2026-04-27T03:25:54Z") to a
-# Unix epoch (seconds since 1970). Echoes the epoch on success, empty
-# on failure. Tries in order:
-#   - BSD/macOS:    date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s
-#   - GNU/Linux:    date -u -d "$ts" +%s     (also works in Git Bash on
-#                                             Windows via MSYS coreutils)
-#   - python3:      datetime.strptime fallback for any environment where
-#                   neither `date` flavor parses (rare but real on some
-#                   minimal Cygwin/MSYS installs without coreutils).
+# Convert an ISO 8601 UTC timestamp to a Unix epoch (seconds since 1970).
+# Echoes the epoch on success, empty on failure.
 #
-# Why an adapter: the BSD-vs-GNU date split was inlined at 3 callsites
-# pre-canary. Each had its own `date -j -u -f ... || date -u -d ...`
-# fallback chain — so when WSL's date semantics drifted (it's GNU but
-# old enough to reject some flag combos) the fix had to land at every
-# site. Single adapter = single fix. Mac integration tests still cover
-# both branches because Mac's `date -j` succeeds first; the python
-# fallback is only reachable on hosts where both `date` flavors fail.
+# Migrated to airc_core.datetime as Phase 0a of the Python truth-layer
+# (#152 architecture). Pre-migration this was a 3-fallback adapter
+# chain inline in bash (BSD date / GNU date / python3 heredoc).
+# Post-migration the bash function is a one-line call into the
+# Python module — same contract, same stdout shape, but the logic
+# lives in a testable Python file with no bash → python heredoc
+# substitution risk. First migration; pattern for the rest.
 iso_to_epoch() {
   local ts="${1:-}"
   [ -z "$ts" ] && return 0
-  local epoch=""
-  if epoch=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null); then
-    echo "$epoch"; return 0
-  fi
-  if epoch=$(date -u -d "$ts" +%s 2>/dev/null); then
-    echo "$epoch"; return 0
-  fi
-  if [ -n "${AIRC_PYTHON:-}" ]; then
-    "$AIRC_PYTHON" -c "
-import datetime, sys
-try:
-    dt = datetime.datetime.strptime('$ts', '%Y-%m-%dT%H:%M:%SZ')
-    dt = dt.replace(tzinfo=datetime.timezone.utc)
-    print(int(dt.timestamp()))
-except Exception:
-    sys.exit(1)
-" 2>/dev/null
-  fi
+  "$AIRC_PYTHON" -m airc_core.datetime iso_to_epoch "$ts" 2>/dev/null
 }
 
 # ── End platform adapters ───────────────────────────────────────────────
@@ -5880,6 +5892,11 @@ case "${1:-help}" in
   debug-scope) echo "$AIRC_WRITE_DIR" ;;
   debug-name)  resolve_name ;;
   debug-host)  get_host ;;
+  debug-pythonpath)
+    echo "AIRC_PYTHON=$AIRC_PYTHON"
+    echo "lib_dir=${_airc_lib_dir:-<not-resolved>}"
+    echo "PYTHONPATH=${PYTHONPATH:-<unset>}"
+    "$AIRC_PYTHON" -c "import airc_core; print(f'airc_core import ok: v{airc_core.__version__}')" 2>&1 ;;
   help|--help|-h)
     echo "AIRC — Agentic Internet Relay Chat for AI peers"
     echo "(IRC verbs work as primary; airc-classic names also accepted)"

--- a/lib/airc_core/__init__.py
+++ b/lib/airc_core/__init__.py
@@ -1,0 +1,26 @@
+"""airc_core — shared Python truth-layer for airc.
+
+Both the bash entrypoint (airc) and the PowerShell entrypoint (airc.ps1)
+invoke functions in this package instead of duplicating logic across
+shell heredocs. Goals:
+
+1. **One source of truth for business logic.** Config CRUD, gist envelope
+   parse/build, pair handshake JSON, monitor formatting, etc. live here.
+   The shell scripts become thin dispatch + arg parsers.
+
+2. **No bash → python heredoc fragility.** Every fix today (silent
+   SyntaxErrors when bash variable substitution drifted into the python
+   source, function-export leaks across $() subshells, etc.) was a
+   symptom of mixing the two. Python files are parsed once, tested
+   once, and behave identically across shells.
+
+3. **Cross-port consistency.** Bash on macOS/Linux/Git-Bash and
+   PowerShell on Windows can call the SAME Python module. Drift
+   between airc bash and airc.ps1 (which today is ~20 PRs behind)
+   becomes mechanical to detect — same input → same output.
+
+This package is sourced by setting PYTHONPATH to include the parent
+'lib' directory. The airc bash script does this at startup.
+"""
+
+__version__ = "0.1.0"

--- a/lib/airc_core/datetime.py
+++ b/lib/airc_core/datetime.py
@@ -1,0 +1,62 @@
+"""ISO 8601 ↔ Unix epoch conversion for airc.
+
+Migrated from the bash `iso_to_epoch` adapter (PR #151) into the Python
+truth-layer (PR #152 architecture). The bash adapter handled three
+fallback paths (BSD date, GNU date, python3 datetime); now that we
+have Python as the canonical layer, we just use stdlib datetime.
+
+The bash side calls into this module via:
+
+    "$AIRC_PYTHON" -m airc_core.datetime iso_to_epoch <ts>
+
+That subprocess call is the new shape — bash never re-implements logic
+that lives here.
+"""
+
+from __future__ import annotations
+
+import datetime
+import sys
+
+
+def iso_to_epoch(ts: str) -> int | None:
+    """Convert an ISO 8601 UTC timestamp to a Unix epoch integer.
+
+    Accepts the canonical airc gist envelope timestamp shape
+    `YYYY-MM-DDTHH:MM:SSZ` (e.g. `2026-04-27T03:25:54Z`). Returns None
+    on parse failure rather than raising — callers in bash use the
+    empty/non-empty distinction to decide whether to skip a stale
+    check (matches the pre-migration adapter contract).
+    """
+    if not ts:
+        return None
+    try:
+        dt = datetime.datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+        return int(dt.timestamp())
+    except (ValueError, TypeError):
+        return None
+
+
+def _cli() -> int:
+    """CLI entry: `python -m airc_core.datetime iso_to_epoch <ts>`.
+
+    Echoes the epoch on success; empty output on failure (exit 0).
+    Matches the bash adapter's stdout contract — callers do
+    `epoch=$(... iso_to_epoch "$ts")` and check for empty.
+    """
+    if len(sys.argv) < 2:
+        return 2
+    cmd = sys.argv[1]
+    if cmd == "iso_to_epoch":
+        ts = sys.argv[2] if len(sys.argv) > 2 else ""
+        result = iso_to_epoch(ts)
+        if result is not None:
+            print(result)
+        return 0
+    print(f"unknown subcommand: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2762,8 +2762,15 @@ scenario_platform_adapters() {
   # safely source.
   local _adapters_extract; _adapters_extract=$(mktemp -t airc-it-pa.XXXXXX)
   awk '/^# ── Platform adapters/,/^# ── End platform adapters/' "$AIRC" > "$_adapters_extract"
+  # iso_to_epoch (post-PR #152 Phase 0a) calls into airc_core.datetime
+  # via "$AIRC_PYTHON" -m. The extracted-adapter test bash needs both
+  # vars set + lib/ on PYTHONPATH so the module resolves. Pre-Phase-0a
+  # this wasn't required (the bash adapter had inline date fallbacks).
+  local _airc_lib_dir; _airc_lib_dir=$(cd "$(dirname "$AIRC")/lib" 2>/dev/null && pwd)
   _adapter_call() {
-    bash -c "source '$_adapters_extract'; $*"
+    AIRC_PYTHON="${AIRC_PYTHON:-python3}" \
+    PYTHONPATH="${_airc_lib_dir}${PYTHONPATH:+:$PYTHONPATH}" \
+    bash -c "source '$_adapters_extract'; export AIRC_PYTHON='${AIRC_PYTHON:-python3}'; $*"
   }
 
   # ── proc_children ──


### PR DESCRIPTION
**Architectural pivot** per Joel 2026-04-27 ("3000 lines of code dear god" → "yes" start #152).

## Phase 0: foundation

- \`lib/airc_core/\` Python package with \`__init__.py\` (v0.1.0)
- airc bash resolves lib/ via 4 candidates (canonicalized absolute path), sets PYTHONPATH unconditionally
- New \`airc debug-pythonpath\` diagnostic command
- install.sh requires no changes (clone already pulls lib/)

## Phase 0a: first function migrated

- \`lib/airc_core/datetime.py\` with \`iso_to_epoch()\` + CLI entry
- Bash \`iso_to_epoch\` shrinks from 22 lines → 4 lines
- Test harness updated to set AIRC_PYTHON + PYTHONPATH for sourced adapter blocks

## Why iso_to_epoch first

Pure logic, no I/O, smallest blast radius, three downstream callsites prove the contract holds end-to-end.

## Test posture

- platform_adapters: 11/11 (iso_to_epoch trio green via Python module)
- part_persists / list / general_sidecar_default: all green (downstream consumers untouched semantically)

## Pattern for Phase 1

For each future migration: re-implement logic in airc_core/<module>.py, bash function becomes 1-line \`"\$AIRC_PYTHON" -m\` call, integration tests verify identical behavior. Phase 1 priority queue (high-fragility first): pair handshake JSON, gist envelope build/resolve, monitor_formatter, host_address_set, config CRUD.

## Why this shape

The 17 PRs today fixing bash-into-python heredoc fragility (silent SyntaxErrors, export-f leaks, missed sed patterns, swallowed stderr) are symptoms of mixing bash variable substitution with embedded python source. Each migration eliminates one site's worth of those silent-fail vectors permanently.

## Joel reviews shape before scaling

This PR establishes the pattern. If the shape is right, Phase 1 scales to the remaining ~30 heredocs in priority order. If the shape needs adjustment, we adjust before scaling.