### PR TITLE
feat(airc_core): migrate config CRUD to airc_core.config (#152 Phase 1)

### DIFF
--- a/airc
+++ b/airc
@@ -302,12 +302,18 @@ ensure_init() {
   die "Not initialized ($AIRC_WRITE_DIR). Run: airc connect"
 }
 
+# config CRUD migrated to airc_core.config (#152 Phase 1). Pre-
+# migration these were inline python heredocs with bash variable
+# substitution INTO the python source — every callsite (45+) was a
+# silent-fail vector if the substituted value broke python parsing.
+# Post-migration: CONFIG comes from env var; key + default come from
+# argv. Python source is fixed bytes; bash never touches it.
 get_name() {
-  "$AIRC_PYTHON" -c "import json; print(json.load(open('$CONFIG'))['name'])" 2>/dev/null || echo "unknown"
+  CONFIG="$CONFIG" "$AIRC_PYTHON" -m airc_core.config get_name 2>/dev/null || echo "unknown"
 }
 
 get_config_val() {
-  "$AIRC_PYTHON" -c "import json; print(json.load(open('$CONFIG')).get('$1','$2'))" 2>/dev/null || echo "$2"
+  CONFIG="$CONFIG" "$AIRC_PYTHON" -m airc_core.config get "$1" "${2:-}" 2>/dev/null || echo "${2:-}"
 }
 
 get_host() {

--- a/lib/airc_core/config.py
+++ b/lib/airc_core/config.py
@@ -1,0 +1,76 @@
+"""airc config.json CRUD.
+
+Migrated from bash get_config_val / get_name (45+ callsites) into the
+Python truth-layer (#152 Phase 1).
+
+Pre-migration each callsite was an inline `"$AIRC_PYTHON" -c "import
+json; print(json.load(open('$CONFIG')).get('$1','$2'))"` heredoc with
+bash-variable substitution INTO the python source. If the bash $1
+contained quotes, special chars, or empty, the python source could
+break in subtle ways and silently return the default. Continuum-b69f
+2026-04-27 traced one symptom (host_target reading empty even when
+config.json had it) to this class.
+
+Post-migration: config path comes from `CONFIG` env var, key/default
+come from argv. Python source is fixed bytes; bash never touches it.
+
+CLI shape (matches bash callsite expectations):
+
+    CONFIG=/path/to/config.json python -m airc_core.config get <key> [default]
+    CONFIG=/path/to/config.json python -m airc_core.config get_name
+
+`get_name` is a special case because the bash one threw on missing key
+(used `['name']` not `.get('name', ...)`). The CLI mirrors the
+existing contract — prints "unknown" on failure to match the bash
+fallback.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def get(config_path: str, key: str, default: str = "") -> str:
+    """Read a key from config.json. Returns default on any failure."""
+    try:
+        with open(config_path) as f:
+            c = json.load(f)
+        v = c.get(key)
+        if v is None:
+            return default
+        return str(v)
+    except (OSError, ValueError, KeyError):
+        return default
+
+
+def get_name(config_path: str) -> str:
+    """Read 'name' field; returns 'unknown' on failure (matches bash)."""
+    return get(config_path, "name", "unknown")
+
+
+def _cli() -> int:
+    cfg = os.environ.get("CONFIG", "")
+    if not cfg:
+        print("ERROR: CONFIG env var must point at config.json", file=sys.stderr)
+        return 2
+    if len(sys.argv) < 2:
+        return 2
+    cmd = sys.argv[1]
+    if cmd == "get":
+        if len(sys.argv) < 3:
+            return 2
+        key = sys.argv[2]
+        default = sys.argv[3] if len(sys.argv) > 3 else ""
+        print(get(cfg, key, default))
+        return 0
+    if cmd == "get_name":
+        print(get_name(cfg))
+        return 0
+    print(f"unknown subcommand: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())


### PR DESCRIPTION
Continuing the Python truth-layer migration. PR #166 established the foundation; this is the first big-impact migration.

## What

\`get_name\` + \`get_config_val\` (45+ callsites) now route through \`airc_core.config\` Python module via \`"\$AIRC_PYTHON" -m airc_core.config get <key> <default>\`.

## Why

Pre-migration each was an inline python heredoc with bash variable substitution into the python source. Continuum-b69f 2026-04-27 traced \`host_target\` reading empty (even with valid config) to this class of silent-fail. Now python source is fixed bytes; CONFIG comes from env var; key/default come from argv.

## Test posture

| scenario | result |
|---|---|
| identity | 19/19 |
| whois | 5/5 |
| part_persists | 8/8 |
| list | 4/4 |
| general_sidecar_default | 12/12 |
| platform_adapters | 11/11 |

Plus direct CLI unit tests: valid config, missing config, get_name on valid config — all pass.

## Pattern

Each migration in Phase 1 follows this shape: bash function shrinks to a 1-line `"$AIRC_PYTHON" -m airc_core.<module>` call; logic lives in a Python module with a CLI entry; integration tests verify identical bash-side behavior.

Next: pair handshake JSON build/parse → gist envelope build → resolve → monitor_formatter.