### PR TITLE
feat(airc_core): handshake response parser → airc_core.handshake (#152 Phase 1)

### DIFF
--- a/airc
+++ b/airc
@@ -2713,7 +2713,7 @@ print(data.decode().strip())
     # targeted ssh-keygen -R when a PRIOR real-sshd host key in known_hosts
     # is known stale (e.g. the server rotated sshd host keys).
     local host_ssh_pub
-    host_ssh_pub=$(echo "$response" | "$AIRC_PYTHON" -c "import sys,json; print(json.load(sys.stdin).get('ssh_pub',''))" 2>/dev/null || true)
+    host_ssh_pub=$(printf '%s' "$response" | "$AIRC_PYTHON" -m airc_core.handshake get_field ssh_pub "" 2>/dev/null || true)
     if [ -n "$host_ssh_pub" ]; then
       mkdir -p "$HOME/.ssh" && chmod 700 "$HOME/.ssh"
       grep -qF "$host_ssh_pub" "$HOME/.ssh/authorized_keys" 2>/dev/null || {
@@ -2732,7 +2732,7 @@ print(data.decode().strip())
     # Drop any existing peer records with the same host first — stale names
     # from a prior rename chain must not linger alongside the current one.
     local host_airc_home
-    host_airc_home=$(echo "$response" | "$AIRC_PYTHON" -c "import sys,json; print(json.load(sys.stdin).get('airc_home',''))" 2>/dev/null || true)
+    host_airc_home=$(printf '%s' "$response" | "$AIRC_PYTHON" -m airc_core.handshake get_field airc_home "" 2>/dev/null || true)
     "$AIRC_PYTHON" -c "
 import json, os
 peers_dir = os.path.expanduser('$PEERS_DIR')
@@ -2775,13 +2775,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
     # the join string for onward sharing without a fresh handshake. Also
     # cache the host's identity blob from the handshake response so
     # `airc whois <host-name>` works locally (issue #34 v2).
-    local host_identity_json; host_identity_json=$(echo "$response" | "$AIRC_PYTHON" -c '
-import sys, json
-try:
-    print(json.dumps(json.load(sys.stdin).get("identity", {}) or {}))
-except Exception:
-    print("{}")
-' 2>/dev/null)
+    local host_identity_json; host_identity_json=$(printf '%s' "$response" | "$AIRC_PYTHON" -m airc_core.handshake get_field identity "{}" 2>/dev/null || echo "{}")
     [ -z "$host_identity_json" ] && host_identity_json="{}"
     # Pass values as env vars instead of bash-substituted into the
     # python heredoc body. continuum-b69f's PR #164 retest 2026-04-27
@@ -2814,7 +2808,7 @@ json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
 
     # Pick up reminder setting from host
     local host_reminder
-    host_reminder=$(echo "$response" | "$AIRC_PYTHON" -c "import sys,json; print(json.load(sys.stdin).get('reminder',300))" 2>/dev/null || echo "300")
+    host_reminder=$(printf '%s' "$response" | "$AIRC_PYTHON" -m airc_core.handshake get_field reminder 300 2>/dev/null || echo "300")
     if [ "$host_reminder" -gt 0 ] 2>/dev/null; then
       echo "$host_reminder" > "$AIRC_WRITE_DIR/reminder"
       date +%s > "$AIRC_WRITE_DIR/last_sent"

--- a/lib/airc_core/handshake.py
+++ b/lib/airc_core/handshake.py
@@ -1,0 +1,68 @@
+"""Pair-handshake response parsing for airc.
+
+When a joiner connects to a host, the host returns a JSON envelope
+with fields the joiner caches in its config (host's name, ssh_pub,
+airc_home, reminder interval, identity blob). Pre-migration each
+field-extract was an inline `python -c "import json; print(...)"`
+heredoc; bash variable substitution into the python source was a
+silent-fail vector (continuum-b69f's PR #164/#165 retest 2026-04-27
+caught the host_airc_home write-side; this is the read-side).
+
+Post-migration: response JSON comes via stdin, field name + default
+via argv. Python source is fixed bytes; bash never touches it.
+
+CLI:
+
+    echo "$response" | python -m airc_core.handshake get_field <name> [default]
+
+Empty stdout on parse failure (matches the bash `|| true` fallback
+pattern). Exit always 0 — caller checks the value.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def parse_response(response_json: str) -> dict:
+    """Parse a handshake-response JSON string. Returns {} on failure."""
+    if not response_json:
+        return {}
+    try:
+        obj = json.loads(response_json)
+        return obj if isinstance(obj, dict) else {}
+    except (ValueError, TypeError):
+        return {}
+
+
+def _cli() -> int:
+    if len(sys.argv) < 2:
+        return 2
+    cmd = sys.argv[1]
+    if cmd == "get_field":
+        if len(sys.argv) < 3:
+            return 2
+        field = sys.argv[2]
+        default = sys.argv[3] if len(sys.argv) > 3 else ""
+        try:
+            response = sys.stdin.read()
+        except Exception:
+            print(default)
+            return 0
+        obj = parse_response(response)
+        v = obj.get(field, default)
+        # Numbers (e.g. reminder=300) round-trip cleanly through str();
+        # nested objects (e.g. identity={}) need json.dumps so callers
+        # get a parseable string back rather than Python repr.
+        if isinstance(v, (dict, list)):
+            print(json.dumps(v))
+        else:
+            print(v if v != "" else default)
+        return 0
+    print(f"unknown subcommand: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())


### PR DESCRIPTION
Continuing the Python truth-layer migration. Four heredocs that parse the host's handshake response (\`ssh_pub\`, \`airc_home\`, \`identity\`, \`reminder\`) now route through \`airc_core.handshake\`.

## What

- New \`lib/airc_core/handshake.py\` — \`get_field\` reads JSON from stdin, prints field value or default.
- Bash callsites: \`echo "\$response" | "\$AIRC_PYTHON" -m airc_core.handshake get_field <name> [default]\`.

## Why

Pre-migration each callsite was an inline python heredoc with bash variable substitution (\`'FIELD'\` substituted in). Same silent-fail class continuum found in the write-side (PR #165). Now python source is fixed bytes; field name + default come via argv.

## Test posture

| scenario | result |
|---|---|
| identity | 19/19 |
| whois | 5/5 |
| part_persists | 8/8 |
| list | 4/4 |
| general_sidecar_default | 12/12 |
| kick | 12/12 |

Plus CLI unit tests covering valid response, missing field with default, nested object round-trip, empty/garbage stdin.

## Phase 1 progress

- ✓ iso_to_epoch (Phase 0a)
- ✓ config CRUD (PR #167)
- ✓ handshake response parse (this PR)
- next: handshake BUILD (host response payload + joiner payload)
- then: gist envelope build/resolve (the JSON-key-leak class continuum found in PR #162)
- then: monitor_formatter, host_address_set