### PR TITLE
feat(airc_core): joiner handshake send → airc_core.handshake.send (#152 Phase 1)

### DIFF
--- a/airc
+++ b/airc
@@ -2601,29 +2601,18 @@ except Exception:
 
     local response
     local _pair_ok=1
-    response=$(MY_IDENTITY="$my_identity_json" "$AIRC_PYTHON" -c "
-import socket, json, sys, os
-payload = json.dumps({
-    'name': '$my_name',
-    'host': '$(whoami)@$(get_host)',
-    'ssh_pub': '''$my_ssh_pub''',
-    'sign_pub': '''$my_sign_pub''',
-    'airc_home': '$AIRC_WRITE_DIR',
-    'identity': json.loads(os.environ.get('MY_IDENTITY', '{}'))
-})
-sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-sock.settimeout(30)
-sock.connect(('$peer_host_only', $peer_port))
-sock.sendall((payload + '\n').encode())
-sock.shutdown(socket.SHUT_WR)
-data = b''
-while True:
-    chunk = sock.recv(4096)
-    if not chunk: break
-    data += chunk
-sock.close()
-print(data.decode().strip())
-" 2>&1) || _pair_ok=0
+    # Migrated to airc_core.handshake send (#152 Phase 1). Pre-migration
+    # this was an inline `python -c "..."` heredoc with five bash-
+    # variable substitutions INTO the python source — any special
+    # character in any field would silently break python parsing. Now:
+    # env vars + argv. Python source is fixed bytes.
+    response=$(MY_NAME="$my_name" \
+               MY_HOST="$(whoami)@$(get_host)" \
+               MY_SSH_PUB="$my_ssh_pub" \
+               MY_SIGN_PUB="$my_sign_pub" \
+               MY_AIRC_HOME="$AIRC_WRITE_DIR" \
+               MY_IDENTITY="$my_identity_json" \
+               "$AIRC_PYTHON" -m airc_core.handshake send "$peer_host_only" "$peer_port" 2>&1) || _pair_ok=0
 
     if [ "$_pair_ok" = "0" ]; then
       # ── Self-heal: stale-host takeover ─────────────────────────────

--- a/lib/airc_core/handshake.py
+++ b/lib/airc_core/handshake.py
@@ -36,6 +36,47 @@ def parse_response(response_json: str) -> dict:
         return {}
 
 
+def send(host: str, port: int) -> str:
+    """Joiner-side: build payload from env vars, connect to host:port,
+    send, read response, return as string. Caller checks for empty
+    string on failure.
+
+    Env vars:
+        MY_NAME, MY_HOST, MY_SSH_PUB, MY_SIGN_PUB, MY_AIRC_HOME,
+        MY_IDENTITY (JSON string of identity dict)
+
+    Pre-migration this was an inline `python -c "..."` heredoc with
+    five bash-variable substitutions INTO the python source. Any
+    special character in any field (apostrophe in bio, embedded
+    newline in ssh_pub) silently broke parsing. Now: env vars + argv.
+    """
+    import os
+    import socket as sock_mod
+
+    payload = json.dumps({
+        "name": os.environ.get("MY_NAME", ""),
+        "host": os.environ.get("MY_HOST", ""),
+        "ssh_pub": os.environ.get("MY_SSH_PUB", ""),
+        "sign_pub": os.environ.get("MY_SIGN_PUB", ""),
+        "airc_home": os.environ.get("MY_AIRC_HOME", ""),
+        "identity": json.loads(os.environ.get("MY_IDENTITY", "{}") or "{}"),
+    })
+
+    s = sock_mod.socket(sock_mod.AF_INET, sock_mod.SOCK_STREAM)
+    s.settimeout(30)
+    s.connect((host, int(port)))
+    s.sendall((payload + "\n").encode())
+    s.shutdown(sock_mod.SHUT_WR)
+    data = b""
+    while True:
+        chunk = s.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+    s.close()
+    return data.decode().strip()
+
+
 def _cli() -> int:
     if len(sys.argv) < 2:
         return 2
@@ -60,6 +101,20 @@ def _cli() -> int:
         else:
             print(v if v != "" else default)
         return 0
+    if cmd == "send":
+        if len(sys.argv) < 4:
+            return 2
+        host = sys.argv[2]
+        port = sys.argv[3]
+        try:
+            print(send(host, port))
+            return 0
+        except Exception as e:
+            # Stderr surfaces; bash's `2>&1` capture lets cmd_connect's
+            # die() print the actual error per the never-swallow-errors
+            # rule.
+            print(f"airc-handshake-send-error: {e}", file=sys.stderr)
+            return 1
     print(f"unknown subcommand: {cmd}", file=sys.stderr)
     return 2
 


### PR DESCRIPTION
The joiner's pair-handshake send was a 23-line inline \`python -c\` heredoc with five bash-variable substitutions into the python source. Migrated to airc_core.handshake.send via env vars.

## What

\`airc_core.handshake.send(host, port)\` reads MY_NAME / MY_HOST / MY_SSH_PUB / MY_SIGN_PUB / MY_AIRC_HOME / MY_IDENTITY from env. Bash callsite is a 8-line env-var-pass + module call.

## Why

- ssh_pub may have trailing newline (openssh-keygen quirk)
- identity is JSON-encoded user text (apostrophes, etc.)
- All five values previously substituted INTO python source code

Same silent-fail class continuum traced today.

## Test posture

| scenario | result |
|---|---|
| tabs | 19/19 |
| identity | 19/19 |
| whois | 5/5 |
| kick | 12/12 |
| part_persists | 8/8 |

## Phase 1 progress

5 migrations merged today: foundation (#166) + config CRUD (#167) + handshake parse (#168) + scope cleanup (#169) + this PR. Next targets: host's response BUILDER (line ~3236), self-heal heredocs, then monitor_formatter (the big one).