### PR TITLE
feat(airc-bash): split — extract platform_adapters.sh as Phase 3 feasibility (#152)

### DIFF
--- a/airc
+++ b/airc
@@ -848,163 +848,21 @@ sign_message() {
 }
 
 # ── Platform adapters ───────────────────────────────────────────────────
-#
-# Single-purpose helpers that hide platform-specific differences in the
-# process / port / filesystem APIs. Every callsite that needs "find
-# children of PID X" or "find PIDs listening on port Y" goes through
-# these helpers, NOT inline pgrep/lsof. That way:
-#
-#   1. The platform-specific implementation lives in ONE place per
-#      capability — adding a Windows fallback for `lsof` (e.g. via
-#      `netstat -ano`) means editing one helper, not 4+ callsites.
-#   2. The business logic above the adapter line stays platform-
-#      agnostic. Refactor risk drops.
-#   3. We hold the line on Joel's "fixing one platform shouldn't
-#      degrade another" rule (2026-04-26): without adapters, a Mac
-#      AI's tweak to a pgrep callsite easily diverges from the Linux
-#      AI's tweak. With adapters, both AIs touch the same helper.
-#
-# Each adapter takes simple inputs and emits a one-thing-per-line
-# stream, suitable for `while IFS= read -r` consumption. Callers can
-# `tr '\n' ' '` if they want space-separated, but the canonical
-# representation is newline-delimited (POSIX-friendly).
-#
-# Conventions:
-#   - `proc_*` — process / PID introspection
-#   - `port_*` — TCP port introspection
-#   - `file_*` — filesystem metadata
-#   - `detect_*` — environment classification
-
-# Return PIDs of direct children of $1, one per line.
-# Implementations: pgrep -P (POSIX/macOS/Linux), ps fallback for
-# environments without pgrep (Git Bash for Windows ships only msys
-# coreutils — no pgrep by default; the fallback uses `ps -axo pid,ppid`
-# which msys2 ps DOES support). Empty output if no children or pid is
-# already gone.
-proc_children() {
-  local pid="$1"
-  [ -z "$pid" ] && return 0
-  if command -v pgrep >/dev/null 2>&1; then
-    pgrep -P "$pid" 2>/dev/null
-  else
-    # POSIX-portable fallback. Works on Git Bash (msys ps), Linux ps,
-    # macOS ps. Awk filters by ppid column.
-    ps -axo pid,ppid 2>/dev/null | awk -v p="$pid" '$2 == p { print $1 }'
-  fi
-}
-
-# Return parent PID of $1. Empty if $1 is gone.
-proc_parent() {
-  local pid="$1"
-  [ -z "$pid" ] && return 0
-  ps -p "$pid" -o ppid= 2>/dev/null | tr -d ' '
-}
-
-# Return the command line of $1 (full argv, space-joined). Empty if gone.
-proc_cmdline() {
-  local pid="$1"
-  [ -z "$pid" ] && return 0
-  ps -p "$pid" -o command= 2>/dev/null
-}
-
-# Find airc-related PIDs owned by the current user matching a pattern.
-# Used by `airc teardown --all` to nuke every airc process.
-# Pattern is a regex passed to pgrep -f or to awk's =~.
-proc_airc_pids_matching() {
-  local pattern="$1"
-  [ -z "$pattern" ] && return 0
-  if command -v pgrep >/dev/null 2>&1; then
-    pgrep -u "$(id -u)" -f "$pattern" 2>/dev/null
-  else
-    # Fallback: ps + awk. Less precise than pgrep -f (no anchored regex)
-    # but covers the same shape. Filter by user since msys ps -u option
-    # may not match POSIX semantics.
-    local me; me=$(whoami 2>/dev/null)
-    ps -axo pid,user,command 2>/dev/null \
-      | awk -v u="$me" -v p="$pattern" 'NR>1 && $2 == u && $0 ~ p { print $1 }'
-  fi
-}
-
-# Return PIDs listening on TCP port $1 (LISTEN state), one per line.
-# Implementations:
-#   1. lsof -tiTCP:<port> -sTCP:LISTEN — macOS, most BSDs, modern Linux
-#      with lsof installed.
-#   2. ss -tlnp — modern Linux distros (iproute2 default since ~2017),
-#      replaces deprecated netstat. Output post-processing extracts pid.
-#   3. netstat -ano — Windows native (cmd / PowerShell), and also a
-#      fallback on minimal Linux containers without lsof or ss. Output
-#      shape differs per platform; awk parses the LISTENING column.
-# Empty output = nobody listening.
-port_listeners() {
-  local port="$1"
-  [ -z "$port" ] && return 0
-  if command -v lsof >/dev/null 2>&1; then
-    lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null
-  elif command -v ss >/dev/null 2>&1; then
-    # ss output: 'LISTEN 0 ... users:(("python",pid=12345,fd=4))'
-    # Awk extracts pid= number.
-    ss -tlnp "( sport = :$port )" 2>/dev/null \
-      | awk 'NR>1 { match($0, /pid=[0-9]+/); if (RSTART) print substr($0, RSTART+4, RLENGTH-4) }'
-  elif command -v netstat >/dev/null 2>&1; then
-    # netstat -ano output (Windows + some Linux):
-    #   TCP 0.0.0.0:7547 0.0.0.0:0 LISTENING 12345
-    # Trailing column is PID. Match $port at end of local-address column.
-    netstat -ano 2>/dev/null \
-      | awk -v p=":$port" '$2 ~ p"$" && /LISTEN/ { print $NF }'
-  fi
-}
-
-# Return file size in bytes. Empty / 0 on failure.
-# stat is not POSIX (different flags on BSD vs GNU); chain both with
-# fallback to wc -c which IS POSIX.
-file_size() {
-  local path="$1"
-  [ -f "$path" ] || { echo 0; return 0; }
-  stat -f%z "$path" 2>/dev/null \
-    || stat -c%s "$path" 2>/dev/null \
-    || wc -c < "$path" 2>/dev/null \
-    || echo 0
-}
-
-# Detect platform: emits one of macos, linux, wsl, windows-bash (Git Bash
-# on Windows native), unknown. Most callers don't need this — they
-# should use the proc_/port_/file_ adapters, which handle platform
-# differences internally. detect_platform is for the rare case where
-# a top-level decision genuinely depends on platform (e.g. Tailscale.app
-# launching on macOS).
-detect_platform() {
-  local s; s=$(uname -s 2>/dev/null)
-  case "$s" in
-    Darwin)               echo macos ;;
-    Linux)
-      # Detect WSL via /proc/version content (kernel string contains
-      # 'microsoft' or 'WSL'). Bare Linux otherwise.
-      if grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then
-        echo wsl
-      else
-        echo linux
-      fi ;;
-    MINGW*|MSYS*|CYGWIN*) echo windows-bash ;;
-    *)                    echo unknown ;;
-  esac
-}
-
-# Convert an ISO 8601 UTC timestamp to a Unix epoch (seconds since 1970).
-# Echoes the epoch on success, empty on failure.
-#
-# Migrated to airc_core.datetime as Phase 0a of the Python truth-layer
-# (#152 architecture). Pre-migration this was a 3-fallback adapter
-# chain inline in bash (BSD date / GNU date / python3 heredoc).
-# Post-migration the bash function is a one-line call into the
-# Python module — same contract, same stdout shape, but the logic
-# lives in a testable Python file with no bash → python heredoc
-# substitution risk. First migration; pattern for the rest.
-iso_to_epoch() {
-  local ts="${1:-}"
-  [ -z "$ts" ] && return 0
-  "$AIRC_PYTHON" -m airc_core.datetime iso_to_epoch "$ts" 2>/dev/null
-}
-
+# Decomposed into lib/airc_bash/platform_adapters.sh (#152 Phase 3 — file
+# split). Sourced via the lib-dir resolver set at the top of airc. The
+# resolver's lib_dir already covers airc_core/ (Python truth-layer);
+# airc_bash/ is the bash-side companion that holds extracted adapters
+# and command files. Same precedence: AIRC_DIR / readlink / dirname /
+# $HOME/.airc-src.
+if [ -n "${_airc_lib_dir:-}" ] && [ -f "$_airc_lib_dir/airc_bash/platform_adapters.sh" ]; then
+  # shellcheck source=lib/airc_bash/platform_adapters.sh
+  source "$_airc_lib_dir/airc_bash/platform_adapters.sh"
+else
+  echo "ERROR: airc_bash/platform_adapters.sh not found via lib-dir resolver." >&2
+  echo "  Resolved lib_dir: ${_airc_lib_dir:-<empty>}" >&2
+  echo "  Re-run install.sh or check AIRC_DIR." >&2
+  exit 1
+fi
 # ── End platform adapters ───────────────────────────────────────────────
 
 relay_ssh() {

--- a/lib/airc_bash/platform_adapters.sh
+++ b/lib/airc_bash/platform_adapters.sh
@@ -1,0 +1,163 @@
+# Sourced by airc. Cross-platform helpers — proc_*, port_*, file_*,
+# detect_platform, iso_to_epoch. See top-of-file comment for the
+# extracted-from-airc rationale (#152 Phase 3).
+
+# ── Platform adapters ───────────────────────────────────────────────────
+#
+# Single-purpose helpers that hide platform-specific differences in the
+# process / port / filesystem APIs. Every callsite that needs "find
+# children of PID X" or "find PIDs listening on port Y" goes through
+# these helpers, NOT inline pgrep/lsof. That way:
+#
+#   1. The platform-specific implementation lives in ONE place per
+#      capability — adding a Windows fallback for `lsof` (e.g. via
+#      `netstat -ano`) means editing one helper, not 4+ callsites.
+#   2. The business logic above the adapter line stays platform-
+#      agnostic. Refactor risk drops.
+#   3. We hold the line on Joel's "fixing one platform shouldn't
+#      degrade another" rule (2026-04-26): without adapters, a Mac
+#      AI's tweak to a pgrep callsite easily diverges from the Linux
+#      AI's tweak. With adapters, both AIs touch the same helper.
+#
+# Each adapter takes simple inputs and emits a one-thing-per-line
+# stream, suitable for `while IFS= read -r` consumption. Callers can
+# `tr '\n' ' '` if they want space-separated, but the canonical
+# representation is newline-delimited (POSIX-friendly).
+#
+# Conventions:
+#   - `proc_*` — process / PID introspection
+#   - `port_*` — TCP port introspection
+#   - `file_*` — filesystem metadata
+#   - `detect_*` — environment classification
+
+# Return PIDs of direct children of $1, one per line.
+# Implementations: pgrep -P (POSIX/macOS/Linux), ps fallback for
+# environments without pgrep (Git Bash for Windows ships only msys
+# coreutils — no pgrep by default; the fallback uses `ps -axo pid,ppid`
+# which msys2 ps DOES support). Empty output if no children or pid is
+# already gone.
+proc_children() {
+  local pid="$1"
+  [ -z "$pid" ] && return 0
+  if command -v pgrep >/dev/null 2>&1; then
+    pgrep -P "$pid" 2>/dev/null
+  else
+    # POSIX-portable fallback. Works on Git Bash (msys ps), Linux ps,
+    # macOS ps. Awk filters by ppid column.
+    ps -axo pid,ppid 2>/dev/null | awk -v p="$pid" '$2 == p { print $1 }'
+  fi
+}
+
+# Return parent PID of $1. Empty if $1 is gone.
+proc_parent() {
+  local pid="$1"
+  [ -z "$pid" ] && return 0
+  ps -p "$pid" -o ppid= 2>/dev/null | tr -d ' '
+}
+
+# Return the command line of $1 (full argv, space-joined). Empty if gone.
+proc_cmdline() {
+  local pid="$1"
+  [ -z "$pid" ] && return 0
+  ps -p "$pid" -o command= 2>/dev/null
+}
+
+# Find airc-related PIDs owned by the current user matching a pattern.
+# Used by `airc teardown --all` to nuke every airc process.
+# Pattern is a regex passed to pgrep -f or to awk's =~.
+proc_airc_pids_matching() {
+  local pattern="$1"
+  [ -z "$pattern" ] && return 0
+  if command -v pgrep >/dev/null 2>&1; then
+    pgrep -u "$(id -u)" -f "$pattern" 2>/dev/null
+  else
+    # Fallback: ps + awk. Less precise than pgrep -f (no anchored regex)
+    # but covers the same shape. Filter by user since msys ps -u option
+    # may not match POSIX semantics.
+    local me; me=$(whoami 2>/dev/null)
+    ps -axo pid,user,command 2>/dev/null \
+      | awk -v u="$me" -v p="$pattern" 'NR>1 && $2 == u && $0 ~ p { print $1 }'
+  fi
+}
+
+# Return PIDs listening on TCP port $1 (LISTEN state), one per line.
+# Implementations:
+#   1. lsof -tiTCP:<port> -sTCP:LISTEN — macOS, most BSDs, modern Linux
+#      with lsof installed.
+#   2. ss -tlnp — modern Linux distros (iproute2 default since ~2017),
+#      replaces deprecated netstat. Output post-processing extracts pid.
+#   3. netstat -ano — Windows native (cmd / PowerShell), and also a
+#      fallback on minimal Linux containers without lsof or ss. Output
+#      shape differs per platform; awk parses the LISTENING column.
+# Empty output = nobody listening.
+port_listeners() {
+  local port="$1"
+  [ -z "$port" ] && return 0
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null
+  elif command -v ss >/dev/null 2>&1; then
+    # ss output: 'LISTEN 0 ... users:(("python",pid=12345,fd=4))'
+    # Awk extracts pid= number.
+    ss -tlnp "( sport = :$port )" 2>/dev/null \
+      | awk 'NR>1 { match($0, /pid=[0-9]+/); if (RSTART) print substr($0, RSTART+4, RLENGTH-4) }'
+  elif command -v netstat >/dev/null 2>&1; then
+    # netstat -ano output (Windows + some Linux):
+    #   TCP 0.0.0.0:7547 0.0.0.0:0 LISTENING 12345
+    # Trailing column is PID. Match $port at end of local-address column.
+    netstat -ano 2>/dev/null \
+      | awk -v p=":$port" '$2 ~ p"$" && /LISTEN/ { print $NF }'
+  fi
+}
+
+# Return file size in bytes. Empty / 0 on failure.
+# stat is not POSIX (different flags on BSD vs GNU); chain both with
+# fallback to wc -c which IS POSIX.
+file_size() {
+  local path="$1"
+  [ -f "$path" ] || { echo 0; return 0; }
+  stat -f%z "$path" 2>/dev/null \
+    || stat -c%s "$path" 2>/dev/null \
+    || wc -c < "$path" 2>/dev/null \
+    || echo 0
+}
+
+# Detect platform: emits one of macos, linux, wsl, windows-bash (Git Bash
+# on Windows native), unknown. Most callers don't need this — they
+# should use the proc_/port_/file_ adapters, which handle platform
+# differences internally. detect_platform is for the rare case where
+# a top-level decision genuinely depends on platform (e.g. Tailscale.app
+# launching on macOS).
+detect_platform() {
+  local s; s=$(uname -s 2>/dev/null)
+  case "$s" in
+    Darwin)               echo macos ;;
+    Linux)
+      # Detect WSL via /proc/version content (kernel string contains
+      # 'microsoft' or 'WSL'). Bare Linux otherwise.
+      if grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then
+        echo wsl
+      else
+        echo linux
+      fi ;;
+    MINGW*|MSYS*|CYGWIN*) echo windows-bash ;;
+    *)                    echo unknown ;;
+  esac
+}
+
+# Convert an ISO 8601 UTC timestamp to a Unix epoch (seconds since 1970).
+# Echoes the epoch on success, empty on failure.
+#
+# Migrated to airc_core.datetime as Phase 0a of the Python truth-layer
+# (#152 architecture). Pre-migration this was a 3-fallback adapter
+# chain inline in bash (BSD date / GNU date / python3 heredoc).
+# Post-migration the bash function is a one-line call into the
+# Python module — same contract, same stdout shape, but the logic
+# lives in a testable Python file with no bash → python heredoc
+# substitution risk. First migration; pattern for the rest.
+iso_to_epoch() {
+  local ts="${1:-}"
+  [ -z "$ts" ] && return 0
+  "$AIRC_PYTHON" -m airc_core.datetime iso_to_epoch "$ts" 2>/dev/null
+}
+
+# ── End platform adapters ───────────────────────────────────────────────

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2760,17 +2760,19 @@ scenario_platform_adapters() {
   # statement and either die ("Unknown command") or print cmd_help.
   # Extract just the marked adapter section into a temp file we can
   # safely source.
-  local _adapters_extract; _adapters_extract=$(mktemp -t airc-it-pa.XXXXXX)
-  awk '/^# ── Platform adapters/,/^# ── End platform adapters/' "$AIRC" > "$_adapters_extract"
-  # iso_to_epoch (post-PR #152 Phase 0a) calls into airc_core.datetime
-  # via "$AIRC_PYTHON" -m. The extracted-adapter test bash needs both
-  # vars set + lib/ on PYTHONPATH so the module resolves. Pre-Phase-0a
-  # this wasn't required (the bash adapter had inline date fallbacks).
+  # Phase 3 (#152): adapters live in lib/airc_bash/platform_adapters.sh,
+  # sourced by airc at startup. The test bash directly sources that file
+  # — no awk extraction needed any more.
   local _airc_lib_dir; _airc_lib_dir=$(cd "$(dirname "$AIRC")/lib" 2>/dev/null && pwd)
+  local _adapters_file="$_airc_lib_dir/airc_bash/platform_adapters.sh"
+  if [ ! -f "$_adapters_file" ]; then
+    fail "platform_adapters.sh not found at $_adapters_file"
+    return
+  fi
   _adapter_call() {
     AIRC_PYTHON="${AIRC_PYTHON:-python3}" \
     PYTHONPATH="${_airc_lib_dir}${PYTHONPATH:+:$PYTHONPATH}" \
-    bash -c "source '$_adapters_extract'; export AIRC_PYTHON='${AIRC_PYTHON:-python3}'; $*"
+    bash -c "source '$_adapters_file'; export AIRC_PYTHON='${AIRC_PYTHON:-python3}'; $*"
   }
 
   # ── proc_children ──
@@ -2902,7 +2904,9 @@ time.sleep(30)
     && pass "iso_to_epoch: garbage input → empty (no false-positive epoch)" \
     || fail "iso_to_epoch: garbage parsed to '$_epoch_bad' (should be empty)"
 
-  rm -f "$_adapters_extract"
+  # _adapters_extract no longer used post-Phase-3 (the file is sourced
+  # from its real location in lib/airc_bash/); nothing to clean up.
+  :
   cleanup_all
 }
 


### PR DESCRIPTION
Joel 2026-04-27: "think my bigger issue is 5000 line files... senior would have hit pause at 500."

Phase 3 of #152 architecture pivot: split airc bash into multiple files. Step 1 — extract the existing "Platform adapters" marked block to its own file as a feasibility proof.

## Impact

- airc bash: 5529 → 5371 lines
- New: \`lib/airc_bash/platform_adapters.sh\` (~158 lines, self-contained)
- Cumulative bash reduction this session (Phase 1 + Phase 3 step 1): ~530 lines

## Pattern for the rest

\`\`\`bash
if [ -n "\${_airc_lib_dir:-}" ] && [ -f "\$_airc_lib_dir/airc_bash/<name>.sh" ]; then
  source "\$_airc_lib_dir/airc_bash/<name>.sh"
fi
\`\`\`

Same lib-dir resolver as airc_core. Tests source the file directly instead of awk-extracting.

## Next slices

- cmd_connect (biggest cmd_*, ~1000-1500 lines)
- cmd_send / cmd_doctor / cmd_part / cmd_teardown
- helpers.sh (die, validate_peer_name, get_*)

Goal: no single file >600 lines after Phase 3 completes.

## Test posture

| scenario | result |
|---|---|
| platform_adapters | 11/11 (sourced from real file) |
| tabs | 19/19 |
| identity | 19/19 |
| whois | 5/5 |
| part_persists | 8/8 |
| list | 4/4 |
| general_sidecar_default | 12/12 |