### PR TITLE
fix(airc_core): use argparse --flags for all paths, not env vars (continuum's MSYS catch)

### DIFF
--- a/airc
+++ b/airc
@@ -302,18 +302,15 @@ ensure_init() {
   die "Not initialized ($AIRC_WRITE_DIR). Run: airc connect"
 }
 
-# config CRUD migrated to airc_core.config (#152 Phase 1). Pre-
-# migration these were inline python heredocs with bash variable
-# substitution INTO the python source — every callsite (45+) was a
-# silent-fail vector if the substituted value broke python parsing.
-# Post-migration: CONFIG comes from env var; key + default come from
-# argv. Python source is fixed bytes; bash never touches it.
+# config CRUD via airc_core.config — proper argparse --flags so paths
+# are per-arg-predictable across MSYS path-translation. Each call passes
+# `--config <path>` explicitly.
 get_name() {
-  CONFIG="$CONFIG" "$AIRC_PYTHON" -m airc_core.config get_name 2>/dev/null || echo "unknown"
+  "$AIRC_PYTHON" -m airc_core.config get_name --config "$CONFIG" 2>/dev/null || echo "unknown"
 }
 
 get_config_val() {
-  CONFIG="$CONFIG" "$AIRC_PYTHON" -m airc_core.config get "$1" "${2:-}" 2>/dev/null || echo "${2:-}"
+  "$AIRC_PYTHON" -m airc_core.config get --config "$CONFIG" "$1" "${2:-}" 2>/dev/null || echo "${2:-}"
 }
 
 # Same as get_config_val but reads from an arbitrary config.json path.
@@ -321,7 +318,7 @@ get_config_val() {
 # that need to read sibling-scope state without changing $CONFIG.
 get_config_val_in() {
   local cfg="$1" key="$2" default="${3:-}"
-  CONFIG="$cfg" "$AIRC_PYTHON" -m airc_core.config get "$key" "$default" 2>/dev/null || echo "$default"
+  "$AIRC_PYTHON" -m airc_core.config get --config "$cfg" "$key" "$default" 2>/dev/null || echo "$default"
 }
 
 get_host() {
@@ -1259,7 +1256,7 @@ monitor() {
 # same env vars (PEERS_DIR) and argv (my_name).
 monitor_formatter() {
   local my_name="$1"
-  PEERS_DIR="$PEERS_DIR" "$AIRC_PYTHON" -u -m airc_core.monitor_formatter "$my_name"
+  "$AIRC_PYTHON" -u -m airc_core.monitor_formatter --peers-dir "$PEERS_DIR" --my-name "$my_name"
 }
 
 # Drain pending.jsonl when the host is reachable again. Runs in background
@@ -2201,18 +2198,20 @@ except Exception:
 
     local response
     local _pair_ok=1
-    # Migrated to airc_core.handshake send (#152 Phase 1). Pre-migration
-    # this was an inline `python -c "..."` heredoc with five bash-
-    # variable substitutions INTO the python source — any special
-    # character in any field would silently break python parsing. Now:
-    # env vars + argv. Python source is fixed bytes.
-    response=$(MY_NAME="$my_name" \
-               MY_HOST="$(whoami)@$(get_host)" \
-               MY_SSH_PUB="$my_ssh_pub" \
-               MY_SIGN_PUB="$my_sign_pub" \
-               MY_AIRC_HOME="$AIRC_WRITE_DIR" \
-               MY_IDENTITY="$my_identity_json" \
-               "$AIRC_PYTHON" -m airc_core.handshake send "$peer_host_only" "$peer_port" 2>&1) || _pair_ok=0
+    # Migrated to airc_core.handshake send with proper --flags (not env
+    # vars). MSYS path-translation on Git Bash silently mangles env-var
+    # values that look like Unix paths (/Users/... → C:/Program
+    # Files/Git/Users/...) when they cross to a Windows-binary subprocess.
+    # argparse --flags are per-arg-predictable (callers can //-prefix
+    # or set MSYS2_ARG_CONV_EXCL targeted-ly). Continuum-b69f 2026-04-27
+    # traced the env-var path-mangling class.
+    response=$("$AIRC_PYTHON" -m airc_core.handshake send "$peer_host_only" "$peer_port" \
+                  --my-name "$my_name" \
+                  --my-host "$(whoami)@$(get_host)" \
+                  --my-ssh-pub "$my_ssh_pub" \
+                  --my-sign-pub "$my_sign_pub" \
+                  --my-airc-home "$AIRC_WRITE_DIR" \
+                  --my-identity-json "$my_identity_json" 2>&1) || _pair_ok=0
 
     if [ "$_pair_ok" = "0" ]; then
       # ── Self-heal: stale-host takeover ─────────────────────────────
@@ -2768,15 +2767,15 @@ JSON
     echo "  Waiting for peers on port $host_port..."
     # Background: accept peer registrations via TCP (public keys only)
     while true; do
-      HOST_PORT="$host_port" \
-      PEERS_DIR="$PEERS_DIR" \
-      IDENTITY_DIR="$IDENTITY_DIR" \
-      CONFIG="$CONFIG" \
-      HOST_NAME="$name" \
-      REMINDER_INTERVAL="$reminder_interval" \
-      AIRC_WRITE_DIR="$AIRC_WRITE_DIR" \
-      MESSAGES="$MESSAGES" \
-      "$AIRC_PYTHON" -m airc_core.handshake accept_one 2>/dev/null || true
+      "$AIRC_PYTHON" -m airc_core.handshake accept_one \
+        --host-port "$host_port" \
+        --peers-dir "$PEERS_DIR" \
+        --identity-dir "$IDENTITY_DIR" \
+        --config "$CONFIG" \
+        --host-name "$name" \
+        --reminder-interval "$reminder_interval" \
+        --airc-home "$AIRC_WRITE_DIR" \
+        --messages "$MESSAGES" 2>/dev/null || true
     done &
     PAIR_PID=$!
 

--- a/lib/airc_core/config.py
+++ b/lib/airc_core/config.py
@@ -1,41 +1,21 @@
 """airc config.json CRUD.
 
-Migrated from bash get_config_val / get_name (45+ callsites) into the
-Python truth-layer (#152 Phase 1).
-
-Pre-migration each callsite was an inline `"$AIRC_PYTHON" -c "import
-json; print(json.load(open('$CONFIG')).get('$1','$2'))"` heredoc with
-bash-variable substitution INTO the python source. If the bash $1
-contained quotes, special chars, or empty, the python source could
-break in subtle ways and silently return the default. Continuum-b69f
-2026-04-27 traced one symptom (host_target reading empty even when
-config.json had it) to this class.
-
-Post-migration: config path comes from `CONFIG` env var, key/default
-come from argv. Python source is fixed bytes; bash never touches it.
-
-CLI shape (matches bash callsite expectations):
-
-    CONFIG=/path/to/config.json python -m airc_core.config get <key> [default]
-    CONFIG=/path/to/config.json python -m airc_core.config get_name
-
-`get_name` is a special case because the bash one threw on missing key
-(used `['name']` not `.get('name', ...)`). The CLI mirrors the
-existing contract — prints "unknown" on failure to match the bash
-fallback.
+CLI takes paths as `--config /path/to/config.json` (argparse args), not
+env vars. Avoids MSYS path-translation surprises on Git Bash and makes
+the module present as a normal Python CLI.
 """
 
 from __future__ import annotations
 
+import argparse
 import json
-import os
 import sys
 
 
 def get(config_path: str, key: str, default: str = "") -> str:
     """Read a key from config.json. Returns default on any failure.
     Nested objects (dicts/lists) round-trip as JSON-encoded strings so
-    callers can re-parse if needed (matches handshake.get_field shape).
+    callers can re-parse if needed.
     """
     try:
         with open(config_path) as f:
@@ -51,30 +31,39 @@ def get(config_path: str, key: str, default: str = "") -> str:
 
 
 def get_name(config_path: str) -> str:
-    """Read 'name' field; returns 'unknown' on failure (matches bash)."""
     return get(config_path, "name", "unknown")
 
 
+def cmd_get(args) -> int:
+    print(get(args.config, args.key, args.default))
+    return 0
+
+
+def cmd_get_name(args) -> int:
+    print(get_name(args.config))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="airc_core.config")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    g = sub.add_parser("get")
+    g.add_argument("--config", required=True)
+    g.add_argument("key")
+    g.add_argument("default", nargs="?", default="")
+    g.set_defaults(func=cmd_get)
+
+    n = sub.add_parser("get_name")
+    n.add_argument("--config", required=True)
+    n.set_defaults(func=cmd_get_name)
+
+    return p
+
+
 def _cli() -> int:
-    cfg = os.environ.get("CONFIG", "")
-    if not cfg:
-        print("ERROR: CONFIG env var must point at config.json", file=sys.stderr)
-        return 2
-    if len(sys.argv) < 2:
-        return 2
-    cmd = sys.argv[1]
-    if cmd == "get":
-        if len(sys.argv) < 3:
-            return 2
-        key = sys.argv[2]
-        default = sys.argv[3] if len(sys.argv) > 3 else ""
-        print(get(cfg, key, default))
-        return 0
-    if cmd == "get_name":
-        print(get_name(cfg))
-        return 0
-    print(f"unknown subcommand: {cmd}", file=sys.stderr)
-    return 2
+    args = _build_parser().parse_args()
+    return args.func(args)
 
 
 if __name__ == "__main__":

--- a/lib/airc_core/handshake.py
+++ b/lib/airc_core/handshake.py
@@ -1,28 +1,34 @@
-"""Pair-handshake response parsing for airc.
+"""airc pair-handshake — joiner send + host accept + response field reads.
 
-When a joiner connects to a host, the host returns a JSON envelope
-with fields the joiner caches in its config (host's name, ssh_pub,
-airc_home, reminder interval, identity blob). Pre-migration each
-field-extract was an inline `python -c "import json; print(...)"`
-heredoc; bash variable substitution into the python source was a
-silent-fail vector (continuum-b69f's PR #164/#165 retest 2026-04-27
-caught the host_airc_home write-side; this is the read-side).
+CLI tools take ARGS, not env vars. Paths come in via --airc-home /
+--peers-dir / --identity-dir / --config / --messages so MSYS path-
+translation behavior is predictable per-arg (callers can `//`-prefix
+or set MSYS2_ARG_CONV_EXCL targeted-ly), and so the modules look
+like normal Python CLIs instead of bash-shaped env-var contraptions.
 
-Post-migration: response JSON comes via stdin, field name + default
-via argv. Python source is fixed bytes; bash never touches it.
+Subcommands:
 
-CLI:
+    python -m airc_core.handshake send <host> <port>
+        --my-name X --my-host Y --my-ssh-pub Z --my-sign-pub W
+        --my-airc-home /path --my-identity-json '{}'
 
-    echo "$response" | python -m airc_core.handshake get_field <name> [default]
+    python -m airc_core.handshake accept_one
+        --host-port 7547 --peers-dir /path --identity-dir /path
+        --config /path/config.json --host-name X
+        --reminder-interval 300 --airc-home /path --messages /path
 
-Empty stdout on parse failure (matches the bash `|| true` fallback
-pattern). Exit always 0 — caller checks the value.
+    python -m airc_core.handshake get_field <name> [default]
+        # reads JSON envelope from stdin, prints field
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
+
+
+# ── parse_response + get_field ──────────────────────────────────────────
 
 
 def parse_response(response_json: str) -> dict:
@@ -36,52 +42,74 @@ def parse_response(response_json: str) -> dict:
         return {}
 
 
-def accept_one() -> int:
-    """Host-side: bind a TCP listener, accept ONE incoming joiner,
-    process its handshake payload, send response, log peer-joined
-    event. Exits 0 on success, 0 on parent-death-timeout.
+def cmd_get_field(args) -> int:
+    try:
+        response = sys.stdin.read()
+    except Exception:
+        print(args.default)
+        return 0
+    obj = parse_response(response)
+    v = obj.get(args.field, args.default)
+    if isinstance(v, (dict, list)):
+        print(json.dumps(v))
+    else:
+        print(v if v != "" else args.default)
+    return 0
 
-    Reads from env:
-        HOST_PORT, PEERS_DIR, IDENTITY_DIR, CONFIG, HOST_NAME,
-        REMINDER_INTERVAL, AIRC_WRITE_DIR, MESSAGES
 
-    The outer bash `while true; do ... done &` loop calls this once
-    per iteration; one accept per call. Parent-death detection
-    (os.getppid() == 1) lets us self-exit cleanly when the airc
-    bash dies between pairings — no orphan port-holder.
+# ── joiner: send ────────────────────────────────────────────────────────
 
-    Pre-migration this was a 125-line heredoc with EIGHT bash
-    variable substitutions INTO the python source ($host_port,
-    $PEERS_DIR, $(timestamp), $IDENTITY_DIR, $CONFIG, $name,
-    $reminder_interval, $AIRC_WRITE_DIR, $MESSAGES). Each was a
-    silent-fail class continuum traced today.
-    """
+
+def cmd_send(args) -> int:
+    import socket
+
+    payload = json.dumps({
+        "name": args.my_name,
+        "host": args.my_host,
+        "ssh_pub": args.my_ssh_pub,
+        "sign_pub": args.my_sign_pub,
+        "airc_home": args.my_airc_home,
+        "identity": json.loads(args.my_identity_json or "{}"),
+    })
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(30)
+    try:
+        s.connect((args.host, args.port))
+        s.sendall((payload + "\n").encode())
+        s.shutdown(socket.SHUT_WR)
+        data = b""
+        while True:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+        s.close()
+        print(data.decode().strip())
+        return 0
+    except Exception as e:
+        print(f"airc-handshake-send-error: {e}", file=sys.stderr)
+        return 1
+
+
+# ── host: accept_one ────────────────────────────────────────────────────
+
+
+def cmd_accept_one(args) -> int:
     import datetime
     import os
-    import socket as sock_mod
+    import socket
 
-    host_port = int(os.environ.get("HOST_PORT", "7547"))
-    peers_dir = os.path.expanduser(os.environ.get("PEERS_DIR", ""))
-    identity_dir = os.path.expanduser(os.environ.get("IDENTITY_DIR", ""))
-    config_path = os.environ.get("CONFIG", "")
-    host_name = os.environ.get("HOST_NAME", "")
-    reminder_interval = int(os.environ.get("REMINDER_INTERVAL", "300"))
-    airc_write_dir = os.environ.get("AIRC_WRITE_DIR", "")
-    messages_path = os.environ.get("MESSAGES", "")
-
-    sock = sock_mod.socket(sock_mod.AF_INET, sock_mod.SOCK_STREAM)
-    sock.setsockopt(sock_mod.SOL_SOCKET, sock_mod.SO_REUSEADDR, 1)
-    sock.bind(("0.0.0.0", host_port))
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("0.0.0.0", args.host_port))
     sock.listen(1)
-    # Short accept timeout + parent-death check means if the outer bash
-    # dies between pairings, this python exits cleanly on the next
-    # timeout instead of orphaning and holding the port forever.
     sock.settimeout(10)
     while True:
         try:
             conn, _addr = sock.accept()
             break
-        except sock_mod.timeout:
+        except socket.timeout:
             if os.getppid() == 1:
                 sock.close()
                 return 0
@@ -109,24 +137,20 @@ def accept_one() -> int:
                 f.write(ssh_key.strip() + "\n")
             os.chmod(ak, 0o600)
 
-    # Save joiner as peer — but first drop any existing records that share
-    # this joiner's host (stable identity across renames). Otherwise a
-    # rename chain leaves stale '<old-name>.json' alongside the new one.
+    # Save joiner as peer (with stable-host stale cleanup).
+    peers_dir = os.path.expanduser(args.peers_dir)
     os.makedirs(peers_dir, exist_ok=True)
     jname = joiner["name"]
     jhost = joiner.get("host", "")
     if jhost and os.path.isdir(peers_dir):
         for entry in os.listdir(peers_dir):
-            if not entry.endswith(".json"):
-                continue
-            if entry == jname + ".json":
+            if not entry.endswith(".json") or entry == jname + ".json":
                 continue
             try:
                 d = json.load(open(os.path.join(peers_dir, entry)))
             except Exception:
                 continue
             if d.get("host") == jhost:
-                # Same machine+user pairing under a different name — stale.
                 for ext in (".json", ".pub"):
                     p = os.path.join(peers_dir, entry[:-5] + ext)
                     if os.path.isfile(p):
@@ -142,35 +166,27 @@ def accept_one() -> int:
             "host": joiner.get("host", ""),
             "airc_home": joiner.get("airc_home", ""),
             "paired": timestamp,
-            # Cache joiner's SSH pubkey so airc kick can remove it from
-            # authorized_keys later. Without this, kick has no way to find
-            # the right line in authorized_keys and the kicked peer keeps
-            # SSH access — Copilot caught this on PR #73 review.
             "ssh_pub": joiner.get("ssh_pub", ""),
-            # Cache joiner's identity blob (issue #34 v2). Empty on legacy
-            # peers that don't send the field — airc whois prints the
-            # 'not exchanged yet' fallback gracefully.
             "identity": joiner.get("identity", {}),
         }, f, indent=2)
     if joiner.get("sign_pub"):
         with open(os.path.join(peers_dir, jname + ".pub"), "w") as f:
             f.write(joiner["sign_pub"])
 
-    # Send back host's SSH pubkey + airc_home + own identity blob (issue
-    # #34 v2). Joiner caches under host_identity so 'airc whois
-    # <host-name>' works locally without a round-trip.
+    # Build response.
+    identity_dir = os.path.expanduser(args.identity_dir)
     host_pub = open(os.path.join(identity_dir, "ssh_key.pub")).read().strip()
     host_identity = {}
     try:
-        host_config = json.load(open(config_path))
+        host_config = json.load(open(args.config))
         host_identity = host_config.get("identity", {}) or {}
     except Exception:
         pass
     response = json.dumps({
         "ssh_pub": host_pub,
-        "name": host_name,
-        "reminder": reminder_interval,
-        "airc_home": airc_write_dir,
+        "name": args.host_name,
+        "reminder": args.reminder_interval,
+        "airc_home": args.airc_home,
         "identity": host_identity,
     })
     conn.sendall((response + "\n").encode())
@@ -178,14 +194,9 @@ def accept_one() -> int:
     sock.close()
 
     print(f"  Peer joined: {jname}")
-    # Surface the join as a system event in messages.jsonl so the monitor
-    # formatter (and downstream Monitor task summaries on every paired peer)
-    # render a one-liner like '[#general] airc: <peer> joined' instead of
-    # silence. Without this, peer-joined is invisible to anyone reading
-    # notifications — they only learn about the new peer when chat traffic
-    # starts flowing.
+    # Surface the join as a system event in messages.jsonl.
     try:
-        room_name_path = os.path.join(airc_write_dir, "room_name")
+        room_name_path = os.path.join(args.airc_home, "room_name")
         room_name = open(room_name_path).read().strip() if os.path.isfile(room_name_path) else "general"
         event = {
             "ts": timestamp,
@@ -193,102 +204,56 @@ def accept_one() -> int:
             "to": "all",
             "msg": f"{jname} joined #{room_name}",
         }
-        with open(messages_path, "a") as f:
+        with open(args.messages, "a") as f:
             f.write(json.dumps(event) + "\n")
     except Exception:
-        # Don't fail the pair on event-emit error — pairing already
-        # succeeded; missing event line is cosmetic.
         pass
     return 0
 
 
-def send(host: str, port: int) -> str:
-    """Joiner-side: build payload from env vars, connect to host:port,
-    send, read response, return as string. Caller checks for empty
-    string on failure.
+# ── CLI entry ───────────────────────────────────────────────────────────
 
-    Env vars:
-        MY_NAME, MY_HOST, MY_SSH_PUB, MY_SIGN_PUB, MY_AIRC_HOME,
-        MY_IDENTITY (JSON string of identity dict)
 
-    Pre-migration this was an inline `python -c "..."` heredoc with
-    five bash-variable substitutions INTO the python source. Any
-    special character in any field (apostrophe in bio, embedded
-    newline in ssh_pub) silently broke parsing. Now: env vars + argv.
-    """
-    import os
-    import socket as sock_mod
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="airc_core.handshake")
+    sub = p.add_subparsers(dest="cmd", required=True)
 
-    payload = json.dumps({
-        "name": os.environ.get("MY_NAME", ""),
-        "host": os.environ.get("MY_HOST", ""),
-        "ssh_pub": os.environ.get("MY_SSH_PUB", ""),
-        "sign_pub": os.environ.get("MY_SIGN_PUB", ""),
-        "airc_home": os.environ.get("MY_AIRC_HOME", ""),
-        "identity": json.loads(os.environ.get("MY_IDENTITY", "{}") or "{}"),
-    })
+    # get_field — stdin-driven response field extract
+    g = sub.add_parser("get_field")
+    g.add_argument("field")
+    g.add_argument("default", nargs="?", default="")
+    g.set_defaults(func=cmd_get_field)
 
-    s = sock_mod.socket(sock_mod.AF_INET, sock_mod.SOCK_STREAM)
-    s.settimeout(30)
-    s.connect((host, int(port)))
-    s.sendall((payload + "\n").encode())
-    s.shutdown(sock_mod.SHUT_WR)
-    data = b""
-    while True:
-        chunk = s.recv(4096)
-        if not chunk:
-            break
-        data += chunk
-    s.close()
-    return data.decode().strip()
+    # send — joiner-side TCP handshake
+    s = sub.add_parser("send")
+    s.add_argument("host")
+    s.add_argument("port", type=int)
+    s.add_argument("--my-name", default="")
+    s.add_argument("--my-host", default="")
+    s.add_argument("--my-ssh-pub", default="")
+    s.add_argument("--my-sign-pub", default="")
+    s.add_argument("--my-airc-home", default="")
+    s.add_argument("--my-identity-json", default="{}")
+    s.set_defaults(func=cmd_send)
+
+    # accept_one — host-side TCP listener (one accept per call)
+    a = sub.add_parser("accept_one")
+    a.add_argument("--host-port", type=int, default=7547)
+    a.add_argument("--peers-dir", required=True)
+    a.add_argument("--identity-dir", required=True)
+    a.add_argument("--config", required=True)
+    a.add_argument("--host-name", required=True)
+    a.add_argument("--reminder-interval", type=int, default=300)
+    a.add_argument("--airc-home", required=True)
+    a.add_argument("--messages", required=True)
+    a.set_defaults(func=cmd_accept_one)
+
+    return p
 
 
 def _cli() -> int:
-    if len(sys.argv) < 2:
-        return 2
-    cmd = sys.argv[1]
-    if cmd == "get_field":
-        if len(sys.argv) < 3:
-            return 2
-        field = sys.argv[2]
-        default = sys.argv[3] if len(sys.argv) > 3 else ""
-        try:
-            response = sys.stdin.read()
-        except Exception:
-            print(default)
-            return 0
-        obj = parse_response(response)
-        v = obj.get(field, default)
-        # Numbers (e.g. reminder=300) round-trip cleanly through str();
-        # nested objects (e.g. identity={}) need json.dumps so callers
-        # get a parseable string back rather than Python repr.
-        if isinstance(v, (dict, list)):
-            print(json.dumps(v))
-        else:
-            print(v if v != "" else default)
-        return 0
-    if cmd == "send":
-        if len(sys.argv) < 4:
-            return 2
-        host = sys.argv[2]
-        port = sys.argv[3]
-        try:
-            print(send(host, port))
-            return 0
-        except Exception as e:
-            # Stderr surfaces; bash's `2>&1` capture lets cmd_connect's
-            # die() print the actual error per the never-swallow-errors
-            # rule.
-            print(f"airc-handshake-send-error: {e}", file=sys.stderr)
-            return 1
-    if cmd == "accept_one":
-        try:
-            return accept_one()
-        except Exception as e:
-            print(f"airc-handshake-accept-error: {e}", file=sys.stderr)
-            return 1
-    print(f"unknown subcommand: {cmd}", file=sys.stderr)
-    return 2
+    args = _build_parser().parse_args()
+    return args.func(args)
 
 
 if __name__ == "__main__":

--- a/lib/airc_core/monitor_formatter.py
+++ b/lib/airc_core/monitor_formatter.py
@@ -12,7 +12,7 @@ a real .py file with no `'\\''` shell-escape gymnastics.
 
 CLI:
 
-    PEERS_DIR=<peers-dir> python -u -m airc_core.monitor_formatter <my_name>
+    python -u -m airc_core.monitor_formatter --peers-dir <path> --my-name <name>
 """
 
 from __future__ import annotations
@@ -147,9 +147,8 @@ def _handle_rename(peers_dir: str, msg: str) -> bool:
     return False
 
 
-def run(my_name: str) -> int:
+def run(my_name: str, peers_dir: str) -> int:
     """Stream the formatter loop. Returns process exit code."""
-    peers_dir = os.environ.get("PEERS_DIR", "")
     scope_dir = os.path.dirname(peers_dir)
     config_path = os.path.join(scope_dir, "config.json")
     local_log = os.path.join(scope_dir, "messages.jsonl")
@@ -303,8 +302,12 @@ def run(my_name: str) -> int:
 
 
 def _cli() -> int:
-    my_name = sys.argv[1] if len(sys.argv) > 1 else ""
-    return run(my_name)
+    import argparse
+    p = argparse.ArgumentParser(prog="airc_core.monitor_formatter")
+    p.add_argument("--peers-dir", required=True)
+    p.add_argument("--my-name", required=True)
+    args = p.parse_args()
+    return run(args.my_name, args.peers_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Joel 2026-04-27: "they arent stupid, --params are far fucking better" + "NEVER DO THE QUICK FIX ALWAYS THE BEST."

The quick-fix-I-almost-shipped (\`MSYS_NO_PATHCONV=1\` per-callsite) is the wrong shape. The correct fix is to give every airc_core module a proper argparse CLI so paths arrive as \`--airc-home /path\` flags. Per-arg predictable across MSYS path translation; module looks like a normal Python CLI.

## Changes

- \`airc_core.handshake\`: \`send\`, \`accept_one\`, \`get_field\` all use argparse subcommands + \`--flags\` for paths.
- \`airc_core.config\`: \`get\` / \`get_name\` take \`--config /path\`.
- \`airc_core.monitor_formatter\`: takes \`--peers-dir\` and \`--my-name\`.
- All bash callsites updated to pass --flags instead of env vars.

## Memory

\`feedback_no_quick_fixes.md\` saved: AIs don't have the human time pressure that justifies quick fixes; the 5-minute right answer and the 1-minute hack arrive in the same conversation turn from Joel's perspective. Always architectural correctness.

## Test posture

101 assertions / 10 scenarios green: tabs (19), identity (19), whois (5), part_persists (8), list (4), general_sidecar_default (12), kick (12), events (5), platform_adapters (11), whois_cross_scope (6).