### PR TITLE
fix(airc_core): config set_host_block — close last env-var-pass site (continuum's #174 follow-up)

### DIFF
--- a/airc
+++ b/airc
@@ -2384,23 +2384,14 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
     # to env-var pass — python reads from os.environ; bash never
     # touches the python source. Also emit stderr to surface failures
     # for the future debugger (not /dev/null).
-    HOST_AIRC_HOME="$host_airc_home" \
-    HOST_NAME="$peer_name" \
-    HOST_PORT="${peer_port:-7547}" \
-    HOST_SSH_PUB="$host_ssh_pub" \
-    HOST_IDENTITY="$host_identity_json" \
-    CONFIG="$CONFIG" \
-    "$AIRC_PYTHON" -c '
-import json, os
-c = json.load(open(os.environ["CONFIG"]))
-c["host_airc_home"] = os.environ.get("HOST_AIRC_HOME", "")
-c["host_name"]      = os.environ.get("HOST_NAME", "")
-try:    c["host_port"] = int(os.environ.get("HOST_PORT", "7547"))
-except: c["host_port"] = 7547
-c["host_ssh_pub"]   = os.environ.get("HOST_SSH_PUB", "")
-c["host_identity"]  = json.loads(os.environ.get("HOST_IDENTITY", "{}"))
-json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
-' || echo "  ⚠  config write failed (host_airc_home/host_name/host_port/host_ssh_pub may be unset). airc may still work if subsequent retries refresh." >&2
+    "$AIRC_PYTHON" -m airc_core.config set_host_block \
+        --config "$CONFIG" \
+        --host-airc-home "$host_airc_home" \
+        --host-name "$peer_name" \
+        --host-port "${peer_port:-7547}" \
+        --host-ssh-pub "$host_ssh_pub" \
+        --host-identity-json "$host_identity_json" \
+        || echo "  ⚠  config write failed (host_airc_home/host_name/host_port/host_ssh_pub may be unset). airc may still work if subsequent retries refresh." >&2
 
     # Pick up reminder setting from host
     local host_reminder

--- a/lib/airc_core/config.py
+++ b/lib/airc_core/config.py
@@ -44,6 +44,41 @@ def cmd_get_name(args) -> int:
     return 0
 
 
+def cmd_set_host_block(args) -> int:
+    """Atomically write the post-handshake host_* fields into config.
+
+    Replaces a fragile env-var-passed python heredoc that bit on MSYS
+    Git Bash (continuum-b69f's catch 2026-04-27): MSYS translates env
+    var values that look like Unix paths INTO the Windows-binary
+    subprocess, so /Users/... silently became C:/Program Files/Git/...
+    Argparse `--flags` are per-arg-predictable (callers can `//`-prefix
+    individual values or use MSYS2_ARG_CONV_EXCL targeted-ly), and
+    the python source is fixed bytes regardless of the values.
+    """
+    try:
+        c = json.load(open(args.config))
+    except (OSError, ValueError) as e:
+        print(f"airc-config-set-error: cannot read {args.config}: {e}", file=sys.stderr)
+        return 1
+    c["host_airc_home"] = args.host_airc_home or ""
+    c["host_name"] = args.host_name or ""
+    try:
+        c["host_port"] = int(args.host_port)
+    except (TypeError, ValueError):
+        c["host_port"] = 7547
+    c["host_ssh_pub"] = args.host_ssh_pub or ""
+    try:
+        c["host_identity"] = json.loads(args.host_identity_json or "{}")
+    except ValueError:
+        c["host_identity"] = {}
+    try:
+        json.dump(c, open(args.config, "w"), indent=2)
+        return 0
+    except OSError as e:
+        print(f"airc-config-set-error: cannot write {args.config}: {e}", file=sys.stderr)
+        return 1
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="airc_core.config")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -57,6 +92,15 @@ def _build_parser() -> argparse.ArgumentParser:
     n = sub.add_parser("get_name")
     n.add_argument("--config", required=True)
     n.set_defaults(func=cmd_get_name)
+
+    s = sub.add_parser("set_host_block")
+    s.add_argument("--config", required=True)
+    s.add_argument("--host-airc-home", default="")
+    s.add_argument("--host-name", default="")
+    s.add_argument("--host-port", default="7547")
+    s.add_argument("--host-ssh-pub", default="")
+    s.add_argument("--host-identity-json", default="{}")
+    s.set_defaults(func=cmd_set_host_block)
 
     return p
 


### PR DESCRIPTION
continuum-b69f's #174 retest caught the host_* config WRITE site (post-handshake "store host details" block) still using env-vars. Same MSYS path-translation silent-fail class as the rest of #174 — \$host_airc_home got mangled on Git Bash.

## Fix

New subcommand \`airc_core.config set_host_block\` with proper \`--flags\`. Bash callsite is one airc_core invocation; no env-var pass; no python heredoc with bash substitutions.

## Test posture

95 assertions / 9 scenarios green. Unit test of set_host_block confirms paths/keys/identity round-trip uncorrupted.

This was the LAST env-var-pass site in airc bash. With this PR, every airc_core invocation is argparse \`--flags\` end-to-end.