### PR TITLE
fix(msys): MSYS2_ARG_CONV_EXCL — last layer; cross-machine VERIFIED end-to-end

### DIFF
--- a/airc
+++ b/airc
@@ -54,6 +54,19 @@ else
 fi
 export AIRC_PYTHON
 
+# MSYS Git Bash on Windows translates argv VALUES that look like
+# Unix-rooted paths when bash invokes a Windows-native binary. So
+# `--host-airc-home /Users/joelteply/.airc` arrives at python.exe as
+# `--host-airc-home C:/Program Files/Git/Users/joelteply/.airc` —
+# silently corrupting paths that the joiner later sends back over SSH
+# to a real Unix host. continuum-b69f traced + fixed this 2026-04-27;
+# the targeted exclude covers macOS / Linux / root home prefixes
+# without breaking `/tmp/` or `/c/` paths (which DO need translation
+# for `--config "$CONFIG"` where $CONFIG is on the local Windows
+# filesystem). Set once at airc startup, exported, every airc_core
+# invocation inherits the same translation policy.
+export MSYS2_ARG_CONV_EXCL="${MSYS2_ARG_CONV_EXCL:-/Users/;/home/;/root/}"
+
 # Resolve the airc install dir's lib/ path and prepend to PYTHONPATH so
 # Python heredocs + module invocations can import airc_core (the
 # Python truth-layer #152). Three resolution paths, first hit wins:


### PR DESCRIPTION
**continuum-b69f's diagnosis + verify.** With this fix Windows airc msg actually lands on Mac host. Verified live: continuum's "WORKING TEST" broadcast IS in my messages.jsonl.

## What MSYS does

Even with argparse \`--flags\`, MSYS Git Bash translates argv VALUES that look like Unix-rooted paths when bash invokes a Windows-native binary. \`--host-airc-home /Users/joelteply/.airc\` arrived at python.exe as \`--host-airc-home C:/Program Files/Git/Users/joelteply/.airc\`. Joiner cached the corrupted path. SSH command later failed.

## Fix

\`\`\`bash
export MSYS2_ARG_CONV_EXCL="\${MSYS2_ARG_CONV_EXCL:-/Users/;/home/;/root/}"
\`\`\`

Once at airc startup. Targeted prefixes — macOS / Linux / root home dirs excluded from translation; \`/tmp/\` and \`/c/\` still translated (needed for local config paths on Windows).

## End-to-end verified live

continuum's broadcast \`WORKING TEST: Windows-Mac airc msg via continuum-msyspatch\` landed in Mac host messages.jsonl. **Cross-machine Mac↔Windows airc working end-to-end.** First time today.

## Mac regression

10 scenarios / 102 assertions green. Env var has no effect on Mac.

## Today's chain

27+ PRs from #150 through this. Every layer revealed the next; continuum's traces caught the silent ones. Each fix architecturally correct (no quick fixes per Joel's mandate).