### PR TITLE
fix(encoding): PYTHONIOENCODING=utf-8 at airc startup (continuum's silent-drop catch)

### DIFF
--- a/airc
+++ b/airc
@@ -67,6 +67,16 @@ export AIRC_PYTHON
 # invocation inherits the same translation policy.
 export MSYS2_ARG_CONV_EXCL="${MSYS2_ARG_CONV_EXCL:-/Users/;/home/;/root/}"
 
+# Force UTF-8 for stdin/stdout/stderr in every airc_core invocation.
+# Windows Python defaults to the local code page (cp1252 on most US/EU
+# installs) which can't encode common Unicode chars like → or em-dashes;
+# write attempts raise UnicodeEncodeError, the formatter's per-line
+# error handler catches it, and the message gets silently dropped from
+# the user's view. PYTHONIOENCODING=utf-8 is the standard remedy —
+# applies to every Python subprocess airc spawns. Honors user override.
+# continuum-b69f's catch + verify 2026-04-27.
+export PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}"
+
 # Resolve the airc install dir's lib/ path and prepend to PYTHONPATH so
 # Python heredocs + module invocations can import airc_core (the
 # Python truth-layer #152). Three resolution paths, first hit wins:


### PR DESCRIPTION
continuum-b69f traced silent message drops on Windows: \`'charmap' codec can't encode character '→'...\`. Windows Python defaults to cp1252 stdio; can't encode →, em-dashes, ✓, etc.; formatter catches the exception per-line; user just sees missing messages.

## Fix

\`\`\`bash
export PYTHONIOENCODING="\${PYTHONIOENCODING:-utf-8}"
\`\`\`

Once at airc startup. Every Python subprocess inherits utf-8 stdio. Same shape as #177's MSYS2_ARG_CONV_EXCL — env-level architectural fix.

## Why env, not per-module sys.stdout reconfiguration

- Per-module fix requires editing every airc_core module + future ones.
- One env var covers every Python subprocess airc spawns.
- Architectural shape per Joel's "always the best fix."

## Test posture

10 scenarios / 102 assertions green on Mac. Live print of \`→ ✓ ⚠ — em-dash\` works.

Closes the silent-drop class filed earlier as #163.