### PR TITLE
fix(airc): pair-listener parent-watch — orphan-process port-hold (#132)

### DIFF
--- a/airc
+++ b/airc
@@ -2779,18 +2779,41 @@ JSON
     fi
     echo ""
     echo "  Waiting for peers on port $host_port..."
-    # Background: accept peer registrations via TCP (public keys only)
-    while true; do
-      "$AIRC_PYTHON" -m airc_core.handshake accept_one \
-        --host-port "$host_port" \
-        --peers-dir "$PEERS_DIR" \
-        --identity-dir "$IDENTITY_DIR" \
-        --config "$CONFIG" \
-        --host-name "$name" \
-        --reminder-interval "$reminder_interval" \
-        --airc-home "$AIRC_WRITE_DIR" \
-        --messages "$MESSAGES" 2>/dev/null || true
-    done &
+    # Background: accept peer registrations via TCP (public keys only).
+    #
+    # Parent-watch (#132): the loop exits when its own parent disappears
+    # (PPID=1 = reparented to init = airc parent bash died). Without
+    # this, the loop survives terminal close / Monitor tool teardown /
+    # kill of the parent, keeps spawning fresh python listeners, and
+    # every joiner that hits the cached port gets a real-looking pair
+    # handshake against a ghost host. Pair-listener Python has its own
+    # 1s parent-watch thread (see airc_core.handshake._start_parent_watch)
+    # to catch the in-flight-handshake case; this loop check covers the
+    # between-iterations case before the next python is spawned.
+    _orphan_parent_pid=$$
+    (
+      # Loop while the airc parent bash is still alive. kill -0 is the
+      # cheapest "is PID still running" probe (no signal sent, just an
+      # error if the process is gone). When the parent dies, this exits
+      # before the next iteration so no fresh python is spawned.
+      #
+      # --watch-pid hands the same PID to the python listener, which
+      # spawns a 1s polling thread that os._exit()s mid-accept the
+      # moment the parent dies — covering the in-flight handshake
+      # case that the bash between-iterations check can't see.
+      while kill -0 "$_orphan_parent_pid" 2>/dev/null; do
+        "$AIRC_PYTHON" -m airc_core.handshake accept_one \
+          --host-port "$host_port" \
+          --peers-dir "$PEERS_DIR" \
+          --identity-dir "$IDENTITY_DIR" \
+          --config "$CONFIG" \
+          --host-name "$name" \
+          --reminder-interval "$reminder_interval" \
+          --airc-home "$AIRC_WRITE_DIR" \
+          --messages "$MESSAGES" \
+          --watch-pid "$_orphan_parent_pid" 2>/dev/null || true
+      done
+    ) &
     PAIR_PID=$!
 
     # Write PID file so `airc teardown` can find us later. Record us, the

--- a/lib/airc_core/handshake.py
+++ b/lib/airc_core/handshake.py
@@ -95,10 +95,53 @@ def cmd_send(args) -> int:
 # ── host: accept_one ────────────────────────────────────────────────────
 
 
+def _start_parent_watch(watch_pid: int):
+    """Daemon thread that os._exit()s the moment the watched PID dies (#132).
+
+    The accept_one process is a grandchild of the airc parent bash:
+        airc bash → accept-loop subshell → python accept_one
+    If the airc parent bash dies (terminal closed, kill, Monitor tool
+    teardown), the accept-loop subshell reparents to init but stays
+    alive (running its `while kill -0 PARENT` loop until the next
+    iteration). During python's in-flight accept() / recv() we'd miss
+    that — getppid() points at the accept-loop subshell, which is
+    still alive — so any joiner that connects during this window gets
+    a real-looking pair handshake against a ghost host (keys land in
+    authorized_keys, peer record gets written, no relay behind it).
+
+    Watching the airc bash PID directly (passed in via --watch-pid)
+    fixes this. `os.kill(pid, 0)` is the probe: it sends no signal,
+    just raises OSError if the PID is gone. Poll once a second; the
+    moment the airc bash disappears, os._exit(0) breaks out of any
+    blocking syscall and dies cleanly.
+
+    Daemon thread so it doesn't block clean shutdown when the parent
+    IS alive and accept_one returns normally.
+    """
+    import os
+    import threading
+    import time
+
+    def _watch():
+        while True:
+            try:
+                os.kill(watch_pid, 0)
+            except (OSError, ProcessLookupError):
+                # airc bash gone — break out of any blocking syscall.
+                os._exit(0)
+            time.sleep(1)
+
+    t = threading.Thread(target=_watch, daemon=True)
+    t.start()
+
+
 def cmd_accept_one(args) -> int:
     import datetime
     import os
     import socket
+
+    if args.watch_pid:
+        _start_parent_watch(args.watch_pid)
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -246,6 +289,10 @@ def _build_parser() -> argparse.ArgumentParser:
     a.add_argument("--reminder-interval", type=int, default=300)
     a.add_argument("--airc-home", required=True)
     a.add_argument("--messages", required=True)
+    # --watch-pid: airc parent bash PID. The listener spawns a daemon
+    # thread that os._exit()s the moment this PID disappears (#132).
+    # 0 disables the watch (legacy callers / direct invocations).
+    a.add_argument("--watch-pid", type=int, default=0)
     a.set_defaults(func=cmd_accept_one)
 
     return p


### PR DESCRIPTION
## Summary

Fixes #132. When airc parent bash dies (terminal close, kill, Monitor tool teardown), the accept-loop subshell reparents to init but stays alive — re-spawning fresh python listeners every iteration. Existing \`getppid()==1\` check never fires because each listener's parent is the still-alive accept-loop, not init. Orphan listeners hold the host port, accept incoming pair handshakes, write peer records, and stuff joiner SSH keys into \`authorized_keys\` — pointing at a dead host.

## Two-layer fix

- **Bash accept loop:** \`while kill -0 PARENT\` instead of \`while true\`. Captures airc bash's PID at startup; loop exits when that PID disappears.
- **Python listener:** new \`--watch-pid\` flag wires the same airc bash PID to a daemon thread that polls \`os.kill(pid, 0)\` every second. When the parent dies, \`os._exit(0)\` breaks out of any in-flight \`accept()\`/\`recv()\`.

Both layers watch the SAME PID (airc bash), not their immediate parent, because the immediate parent (accept-loop subshell) outlives airc bash by one iteration.

## Test plan
- [x] Orphan repro: SIGKILL airc bash → python exits via parent-watch within 1s, port freed
- [x] \`airc teardown\` still works (the existing teardown path is unchanged)
- [x] Integration suite: 183 passing (vs 180 baseline). Two long-standing flakes resolved: \`port 7549 still held after teardown\` + \`alpha still listening after teardown\`. One remaining flake (\`beta did NOT successfully pair\`) is unrelated — different scenario, will triage separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)