### PR TITLE
fix(install/airc): elevated transcript path; Tailscale Windows GUI fallback

### DIFF
--- a/airc
+++ b/airc
@@ -423,17 +423,41 @@ resolve_tailscale_bin() {
     return 0
   fi
   # Known-path fallbacks. Both common Windows install locations + the
-  # macOS .app bundle. Order matters: try the cheap PATH cases first.
+  # macOS .app bundle. Use [ -f ] not [ -x ] for the Windows .exe paths
+  # — Git Bash MSYS doesn't always reflect the executable bit on NTFS
+  # for files Windows considers runnable-by-extension. -f catches the
+  # file's existence; .exe is implicitly executable on Windows.
   local candidate
   for candidate in \
     "/c/Program Files/Tailscale/tailscale.exe" \
-    "/mnt/c/Program Files/Tailscale/tailscale.exe" \
-    "/Applications/Tailscale.app/Contents/MacOS/Tailscale"; do
-    if [ -x "$candidate" ]; then
+    "/c/Program Files (x86)/Tailscale/tailscale.exe" \
+    "/mnt/c/Program Files/Tailscale/tailscale.exe"; do
+    if [ -f "$candidate" ]; then
       echo "$candidate"
       return 0
     fi
   done
+  if [ -x /Applications/Tailscale.app/Contents/MacOS/Tailscale ]; then
+    echo "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+    return 0
+  fi
+  # Last resort: where.exe searches every PATH+PATHEXT location, catches
+  # winget user-scope installs (%LOCALAPPDATA%\...) that aren't in any
+  # of the hard-coded paths above (Joel 2026-04-28: install.sh's
+  # tailscale_present had the same blind spot).
+  if command -v where.exe >/dev/null 2>&1; then
+    local _wherewin
+    _wherewin=$(where.exe tailscale.exe 2>/dev/null | head -1 | tr -d '\r')
+    if [ -n "$_wherewin" ]; then
+      if command -v cygpath >/dev/null 2>&1; then
+        local _bash; _bash=$(cygpath -u "$_wherewin" 2>/dev/null || echo "")
+        [ -n "$_bash" ] && [ -f "$_bash" ] && { echo "$_bash"; return 0; }
+      else
+        local _bash; _bash=$(printf '%s' "$_wherewin" | sed 's|\\|/|g; s|^\([A-Za-z]\):|/\L\1|')
+        [ -f "$_bash" ] && { echo "$_bash"; return 0; }
+      fi
+    fi
+  fi
   return 1
 }
 
@@ -652,7 +676,32 @@ tailscale_login_check_or_prompt() {
   # same. No URL extraction, no bg jobs, no browser auto-launch. The
   # `|| true` lets us continue if the user cancels (Ctrl-C); we just
   # proceed without Tailscale, same-machine + same-LAN paths still work.
-  "$ts_bin" up || true
+  "$ts_bin" up || _ts_up_rc=$?
+  # On Windows, `tailscale up` from non-admin Git Bash can exit silently
+  # if the user's shell isn't allowed to talk to the daemon's named
+  # pipe. Detect that case and fall back to launching the GUI (tailscale-
+  # ipn.exe lives next to tailscale.exe) so the user can click "Log in"
+  # from the tray. Without this fallback, the user sees nothing, has
+  # no obvious next step, and we silently proceed with logged-out
+  # Tailscale (Joel 2026-04-28).
+  if [ "${_ts_up_rc:-0}" != "0" ]; then
+    case "$(uname -s)" in
+      MINGW*|MSYS*|CYGWIN*)
+        echo "" >&2
+        echo "  ⚠  'tailscale up' didn't complete (non-admin shell limitation on Windows)." >&2
+        local _ts_dir _ts_ipn
+        _ts_dir=$(dirname "$ts_bin")
+        _ts_ipn="$_ts_dir/tailscale-ipn.exe"
+        if [ -f "$_ts_ipn" ]; then
+          echo "  Opening Tailscale GUI — click the tray icon → Log in to authorize." >&2
+          "$_ts_ipn" >/dev/null 2>&1 &
+        else
+          echo "  Click the Tailscale tray icon (system tray) → Log in to authorize." >&2
+        fi
+        echo "" >&2
+        ;;
+    esac
+  fi
   echo "" >&2
   return 0
 }

--- a/install.sh
+++ b/install.sh
@@ -245,7 +245,11 @@ _ensure_sshd_running() {
        # below regardless of success/failure.
       local _elevated_payload='
 $ErrorActionPreference = "Stop";
-$logPath = Join-Path $env:TEMP "airc-install-elevated.log";
+# Use [System.IO.Path]::GetTempPath() not $env:TEMP — when called from
+# Git Bash, the inherited TEMP env var can be the bash-side /tmp, not
+# the Windows user temp directory. GetTempPath() asks the OS directly
+# (resolves to %LOCALAPPDATA%\Temp on Windows) regardless of the env.
+$logPath = Join-Path ([System.IO.Path]::GetTempPath()) "airc-install-elevated.log";
 Start-Transcript -Path $logPath -Force | Out-Null;
 try {
   Write-Host "==> OpenSSH.Server capability";
@@ -300,13 +304,20 @@ exit $global:LASTEXITCODE;
         Stopped|StopPending|StartPending|Paused|"")
           info "Configuring OpenSSH.Server + HNS port-22 reservation (UAC prompt incoming)."
           info "  airc joiners need this to ssh-tail your messages.jsonl when you host."
-          # Log path lives at %TEMP%\airc-install-elevated.log on Windows.
-          # Compute its bash-form so we can dump it below.
+          # Log path lives at %LOCALAPPDATA%\Temp\airc-install-elevated.log
+          # on Windows. Use [System.IO.Path]::GetTempPath() not $env:TEMP
+          # — Git Bash's inherited TEMP=/tmp leaks into powershell.exe and
+          # would resolve to /tmp instead of the real Windows user temp,
+          # making us look for the log at the wrong path (Joel 2026-04-28
+          # — \"Elevated transcript not written\" but the log was written;
+          # we just looked at /tmp/airc-install-elevated.log instead of
+          # C:\\Users\\green\\AppData\\Local\\Temp\\airc-install-elevated.log).
           local _ps_log_win _ps_log_bash _elev_rc=0
-          _ps_log_win=$(powershell.exe -NoProfile -Command "Join-Path \$env:TEMP 'airc-install-elevated.log'" 2>/dev/null | tr -d '\r')
+          _ps_log_win=$(powershell.exe -NoProfile -Command "Join-Path ([System.IO.Path]::GetTempPath()) 'airc-install-elevated.log'" 2>/dev/null | tr -d '\r')
           if command -v cygpath >/dev/null 2>&1; then
             _ps_log_bash=$(cygpath -u "$_ps_log_win" 2>/dev/null || echo "")
           else
+            # MSYS-style sed translation: 'C:\Users\...' → '/c/Users/...'
             _ps_log_bash=$(printf '%s' "$_ps_log_win" | sed 's|\\|/|g; s|^\([A-Za-z]\):|/\L\1|')
           fi
           info "  elevated log: $_ps_log_win  (also at $_ps_log_bash from Git Bash)"
@@ -693,6 +704,8 @@ ts_post_check() {
   local ts_bin=""
   if command -v tailscale >/dev/null 2>&1; then
     ts_bin="tailscale"
+  elif command -v tailscale.exe >/dev/null 2>&1; then
+    ts_bin="tailscale.exe"
   elif [ -x /Applications/Tailscale.app/Contents/MacOS/Tailscale ]; then
     ts_bin="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
   elif [ -x "/c/Program Files/Tailscale/tailscale.exe" ]; then
@@ -702,6 +715,19 @@ ts_post_check() {
     ts_bin="/c/Program Files/Tailscale/tailscale.exe"
   elif [ -x "/c/Program Files (x86)/Tailscale/tailscale.exe" ]; then
     ts_bin="/c/Program Files (x86)/Tailscale/tailscale.exe"
+  elif command -v where.exe >/dev/null 2>&1; then
+    # Last resort: where.exe searches every PATH+PATHEXT location.
+    # Catches winget user-scope installs (%LOCALAPPDATA%\...). Translate
+    # the returned Windows path to MSYS form for [ -x ].
+    local _wherewin
+    _wherewin=$(where.exe tailscale.exe 2>/dev/null | head -1 | tr -d '\r')
+    if [ -n "$_wherewin" ]; then
+      if command -v cygpath >/dev/null 2>&1; then
+        ts_bin=$(cygpath -u "$_wherewin" 2>/dev/null || echo "")
+      else
+        ts_bin=$(printf '%s' "$_wherewin" | sed 's|\\|/|g; s|^\([A-Za-z]\):|/\L\1|')
+      fi
+    fi
   fi
   [ -z "$ts_bin" ] && return 0   # not installed, nothing to nag about
 


### PR DESCRIPTION
Two Windows Git Bash issues Joel caught 2026-04-28:

1. **Elevated transcript path mismatch.** install.sh's elevated payload wrote to `%TEMP%\airc-install-elevated.log` (Windows TEMP) but bash side computed the path via `$env:TEMP` through a powershell.exe call that inherited bash's `TEMP=/tmp`, so we looked at `/tmp/airc-install-elevated.log`. Different file. Bash printed 'Elevated transcript not written' while the actual transcript sat untouched at `C:\Users\green\AppData\Local\Temp\airc-install-elevated.log`. Fix: `[System.IO.Path]::GetTempPath()` asks the OS directly, same path on both sides.

2. **Tailscale not detected / login not triggered on Windows.** `resolve_tailscale_bin` used `[ -x ]` for .exe paths, which Git Bash MSYS doesn't always recognize on NTFS. Switched to `[ -f ]` + added `where.exe` fallback for winget user-scope installs. Plus: `tailscale_login_check_or_prompt` now falls back to launching `tailscale-ipn.exe` (the GUI) when `tailscale up` from non-admin Git Bash exits silently (daemon pipe permission).