### PR TITLE
fix(install.sh): auto-run 'gh auth setup-git' so gist ops stop prompting

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -758,6 +758,21 @@ ensure_prereqs() {
     if ! gh auth status >/dev/null 2>&1; then
       warn "gh CLI is not authenticated. Run once before 'airc join':"
       warn "    gh auth login -s gist"
+    else
+      # Wire gh's token into git's credential helper. Without this,
+      # every git-over-HTTPS op (gist fetch/push -- airc's substrate
+      # hot path) prompts the user for a password, repeatedly. gh ships
+      # with `gh auth git-credential` for exactly this purpose; the
+      # `gh auth setup-git` one-liner registers it in ~/.gitconfig.
+      # Idempotent (no-op if already configured), safe to always run.
+      # Joel hit this on 2026-04-28 — Windows install where gh was
+      # auth'd-in-keyring but git itself didn't know. Resulted in a
+      # GUI password popup every airc operation that touched a gist.
+      if ! git config --global --get-all credential.https://github.com.helper 2>/dev/null | grep -q 'gh auth git-credential'; then
+        if gh auth setup-git 2>/dev/null; then
+          info "  gh token wired into git credential helper (no more password popups for gist ops)"
+        fi
+      fi
     fi
   fi
 }


### PR DESCRIPTION
## Summary
- Adds `gh auth setup-git` to install.sh's `ensure_prereqs` flow when gh is authenticated
- Kills the repeating GUI password popup Joel hit on Windows 2026-04-28: gh authed in keyring, but git itself didn't know about the token, so every gist fetch/push reprompted

## Why this matters

`gh auth login` puts the token in keyring/credman. But it does NOT register itself as git's credential helper unless the user explicitly runs `gh auth setup-git`. Most users don't know to do that. So gh CLI works (token-based, direct), but raw git HTTPS doesn't (it doesn't query keyring; falls back to GUI prompt).

airc's substrate is gist.github.com — the monitor self-heal flow, gist-discovery, room-create, etc. all do git pushes against gist. Without this, every install hits a popup loop.

`gh auth setup-git` is the official Microsoft-supported one-liner. Idempotent (no-op if already configured). I added an idempotency guard with `git config --get-all credential.https://github.com.helper | grep gh-credential` so we don't churn the gitconfig on every install.

## Test plan
- [x] Verified locally on continuum-b69f's Windows: post-fix, `git clone https://github.com/CambrianTech/airc.git` doesn't prompt
- [ ] CI clean-install jobs still green (linux/macos/windows)
- [ ] Mac/Linux fresh-install: should be a no-op if gh was set up via the GUI flow that auto-runs setup-git, otherwise a one-liner registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)