### PR TITLE
refactor: _to_win_path / _to_bash_path helpers (#205 Target #3)

### DIFF
--- a/airc
+++ b/airc
@@ -467,13 +467,8 @@ resolve_tailscale_bin() {
     local _wherewin
     _wherewin=$(where.exe tailscale.exe 2>/dev/null | head -1 | tr -d '\r')
     if [ -n "$_wherewin" ]; then
-      if command -v cygpath >/dev/null 2>&1; then
-        local _bash; _bash=$(cygpath -u "$_wherewin" 2>/dev/null || echo "")
-        [ -n "$_bash" ] && [ -f "$_bash" ] && { echo "$_bash"; return 0; }
-      else
-        local _bash; _bash=$(printf '%s' "$_wherewin" | sed 's|\\|/|g; s|^\([A-Za-z]\):|/\L\1|')
-        [ -f "$_bash" ] && { echo "$_bash"; return 0; }
-      fi
+      local _bash; _bash=$(_to_bash_path "$_wherewin")
+      [ -n "$_bash" ] && [ -f "$_bash" ] && { echo "$_bash"; return 0; }
     fi
   fi
   return 1
@@ -5015,14 +5010,8 @@ _daemon_install_schtasks() {
   [ -z "$bash_exe" ] && die "bash.exe not found at any standard Git for Windows path. Install Git for Windows + re-run."
 
   # Convert paths to Windows form; cmd.exe can't read /c/Users/... .
-  local airc_bin_win scope_win
-  if command -v cygpath >/dev/null 2>&1; then
-    airc_bin_win=$(cygpath -w "$airc_bin")
-    scope_win=$(cygpath -w "$scope")
-  else
-    airc_bin_win=$(printf '%s' "$airc_bin" | sed 's|^/\([a-z]\)/|\U\1:\\\\|; s|/|\\\\|g')
-    scope_win=$(printf '%s' "$scope" | sed 's|^/\([a-z]\)/|\U\1:\\\\|; s|/|\\\\|g')
-  fi
+  local airc_bin_win; airc_bin_win=$(_to_win_path "$airc_bin")
+  local scope_win; scope_win=$(_to_win_path "$scope")
 
   # Stage a launcher .bat in $scope. Loops with 5s pause for airc-crash
   # auto-restart (matches launchd KeepAlive=true / systemd Restart=always).
@@ -5043,23 +5032,12 @@ _daemon_install_schtasks() {
   # Absolute Unix-form path to airc: bash with -c doesn't read
   # ~/.bashrc, so PATH may not include ~/.local/bin. Hard-coding
   # the resolved unix path makes the invocation independent of PATH.
-  local cwd_win airc_bin_unix
-  if command -v cygpath >/dev/null 2>&1; then
-    cwd_win=$(cygpath -w "$(pwd -P)")
-    airc_bin_unix=$(cygpath -u "$airc_bin" 2>/dev/null)
-    [ -z "$airc_bin_unix" ] && airc_bin_unix="$airc_bin"
-  else
-    cwd_win=$(printf '%s' "$(pwd -P)" | sed 's|^/\([a-z]\)/|\U\1:\\\\|; s|/|\\\\|g')
-    airc_bin_unix="$airc_bin"
-  fi
+  local cwd_win; cwd_win=$(_to_win_path "$(pwd -P)")
+  local airc_bin_unix; airc_bin_unix=$(_to_bash_path "$airc_bin")
+  [ -z "$airc_bin_unix" ] && airc_bin_unix="$airc_bin"
   # Marker path the .bat polls to distinguish intentional re-exec
   # (written by _reexec_into) from "actual crash" (#203/#204).
-  local marker_win
-  if command -v cygpath >/dev/null 2>&1; then
-    marker_win=$(cygpath -w "$scope/airc.reexec-marker")
-  else
-    marker_win=$(printf '%s' "$scope/airc.reexec-marker" | sed 's|^/\([a-z]\)/|\U\1:\\\\|; s|/|\\\\|g')
-  fi
+  local marker_win; marker_win=$(_to_win_path "$scope/airc.reexec-marker")
   local launcher_bash="$scope/airc-daemon.bat"
   cat > "$launcher_bash" <<EOF
 @echo off
@@ -5090,12 +5068,7 @@ echo [%date% %time%] airc connect exited. Restarting in 5s. >> daemon.err
 timeout /t 5 /nobreak >nul
 goto loop
 EOF
-  local launcher_win
-  if command -v cygpath >/dev/null 2>&1; then
-    launcher_win=$(cygpath -w "$launcher_bash")
-  else
-    launcher_win=$(printf '%s' "$launcher_bash" | sed 's|^/\([a-z]\)/|\U\1:\\\\|; s|/|\\\\|g')
-  fi
+  local launcher_win; launcher_win=$(_to_win_path "$launcher_bash")
 
   # The Run-key value is what cmd.exe runs at user logon. We wrap with
   # `cmd /c start "" /MIN ... ` so the daemon launches detached + with

--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,26 @@ info()  { printf '  \033[1;34m->\033[0m %s\n' "$*"; }
 ok()    { printf '  \033[1;32m->\033[0m %s\n' "$*"; }
 warn()  { printf '  \033[1;33m!\033[0m %s\n' "$*" >&2; }
 
+# MSYS / Git Bash path conversion. Three callsites in this file used the
+# same `if command -v cygpath ... else sed ...` block; #205 Target #3
+# collapsed them. Mirrors lib/airc_bash/platform_adapters.sh's helpers
+# (defined twice on purpose: install.sh runs pre-clone so it can't
+# source from $CLONE_DIR, and the helper bodies are tiny).
+_to_win_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$1" 2>/dev/null
+  else
+    printf '%s' "$1" | sed 's|^/\([a-z]\)/|\U\1:\\\\|; s|/|\\\\|g'
+  fi
+}
+_to_bash_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$1" 2>/dev/null
+  else
+    printf '%s' "$1" | sed 's|\\|/|g; s|^\([A-Za-z]\):|/\L\1|'
+  fi
+}
+
 # ── Prereq auto-install ─────────────────────────────────────────────────
 # Mirrors the Windows install.ps1 winget path: detect what's missing,
 # install via the platform's package manager, then verify. Designed for
@@ -461,13 +481,7 @@ PSPAYLOAD
 
       # Translate the .ps1 path to Windows form for Start-Process -File
       # and the parse-check below.
-      local _elevated_ps1_win
-      if command -v cygpath >/dev/null 2>&1; then
-        _elevated_ps1_win=$(cygpath -w "$_elevated_ps1" 2>/dev/null)
-      else
-        # Fallback: /c/Users/foo/.airc-src/install-elevated.ps1 → C:\Users\foo\.airc-src\install-elevated.ps1
-        _elevated_ps1_win=$(printf '%s' "$_elevated_ps1" | sed 's|^/\([a-z]\)/|\U\1:\\\\|; s|/|\\\\|g')
-      fi
+      local _elevated_ps1_win; _elevated_ps1_win=$(_to_win_path "$_elevated_ps1")
 
       # Pre-flight parse-check: catch syntax errors in the staged .ps1
       # BEFORE we trigger UAC. Without this, a parser error means the
@@ -507,12 +521,7 @@ PSPAYLOAD
           # C:\\Users\\green\\AppData\\Local\\Temp\\airc-install-elevated.log).
           local _ps_log_win _ps_log_bash _elev_rc=0
           _ps_log_win=$(powershell.exe -NoProfile -Command "Join-Path ([System.IO.Path]::GetTempPath()) 'airc-install-elevated.log'" 2>/dev/null | tr -d '\r')
-          if command -v cygpath >/dev/null 2>&1; then
-            _ps_log_bash=$(cygpath -u "$_ps_log_win" 2>/dev/null || echo "")
-          else
-            # MSYS-style sed translation: 'C:\Users\...' → '/c/Users/...'
-            _ps_log_bash=$(printf '%s' "$_ps_log_win" | sed 's|\\|/|g; s|^\([A-Za-z]\):|/\L\1|')
-          fi
+          _ps_log_bash=$(_to_bash_path "$_ps_log_win")
           info "  elevated payload: $_elevated_ps1_win"
           info "  elevated log:     $_ps_log_win"
           info "  (bash log path:   $_ps_log_bash)"
@@ -943,13 +952,7 @@ ts_post_check() {
     # the returned Windows path to MSYS form for [ -x ].
     local _wherewin
     _wherewin=$(where.exe tailscale.exe 2>/dev/null | head -1 | tr -d '\r')
-    if [ -n "$_wherewin" ]; then
-      if command -v cygpath >/dev/null 2>&1; then
-        ts_bin=$(cygpath -u "$_wherewin" 2>/dev/null || echo "")
-      else
-        ts_bin=$(printf '%s' "$_wherewin" | sed 's|\\|/|g; s|^\([A-Za-z]\):|/\L\1|')
-      fi
-    fi
+    [ -n "$_wherewin" ] && ts_bin=$(_to_bash_path "$_wherewin")
   fi
   [ -z "$ts_bin" ] && return 0   # not installed, nothing to nag about
 

--- a/lib/airc_bash/platform_adapters.sh
+++ b/lib/airc_bash/platform_adapters.sh
@@ -160,4 +160,25 @@ iso_to_epoch() {
   "$AIRC_PYTHON" -m airc_core.datetime iso_to_epoch "$ts" 2>/dev/null
 }
 
+# MSYS / Git Bash path conversion. Six callsites in airc + three in
+# install.sh used the same `if command -v cygpath ... else sed ...`
+# block; #205 Target #3 collapsed them. cygpath when present (MSYS2,
+# modern Git Bash); sed fallback for stripped-down environments.
+# Both directions exposed so callers don't have to remember which sed
+# regex inverts the other.
+_to_win_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$1" 2>/dev/null
+  else
+    printf '%s' "$1" | sed 's|^/\([a-z]\)/|\U\1:\\\\|; s|/|\\\\|g'
+  fi
+}
+_to_bash_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$1" 2>/dev/null
+  else
+    printf '%s' "$1" | sed 's|\\|/|g; s|^\([A-Za-z]\):|/\L\1|'
+  fi
+}
+
 # ── End platform adapters ───────────────────────────────────────────────


### PR DESCRIPTION
Six `if command -v cygpath ... else sed ...` blocks consolidated into two helpers. Net diff: **+53 / -56 = -3 lines.** Smaller than continuum's ~30 estimate because install.sh runs pre-clone and can't source from $CLONE_DIR, so helpers are inline-duplicated there (~14 lines).

Real value is code quality: future cygpath sites call the helper, can't drift in their sed regex. Surface non-overlapping with continuum-b69f's Target #1 (the `_reexec_into` helper for the 5× exec sites in cmd_connect).

## Test plan
- [x] bash -n passes on airc + install.sh
- [x] `airc daemon status` works on Mac (sed fallback path; cygpath not present on Mac so sed is exercised)
- [x] `bash install.sh` runs clean on Mac (CI=true mode)
- [ ] continuum-b69f re-tests on Windows MINGW64 (no functional change expected; cygpath path identical to before)