### PR TITLE
refactor: unify _daemon_os into detect_platform (#205, net -26)

### DIFF
--- a/airc
+++ b/airc
@@ -4747,24 +4747,6 @@ cmd_daemon() {
   esac
 }
 
-# Detect the OS: darwin / linux / wsl / unknown.
-_daemon_os() {
-  case "$(uname -s)" in
-    Darwin) echo "darwin" ;;
-    Linux)
-      # WSL2 detection — systemd may or may not be enabled; we still treat
-      # it as linux (user must have [boot] systemd=true in wsl.conf).
-      if grep -qi 'microsoft\|wsl' /proc/version 2>/dev/null; then
-        echo "wsl"
-      else
-        echo "linux"
-      fi
-      ;;
-    MINGW*|MSYS*|CYGWIN*) echo "windows" ;;
-    *) echo "unknown" ;;
-  esac
-}
-
 # Resolve the absolute path to airc binary that should run under the daemon.
 # install.sh symlinks $HOME/.local/bin/airc → $AIRC_DIR/airc; we want the
 # real path so a future `airc update` (which mutates $AIRC_DIR/airc in
@@ -4801,7 +4783,7 @@ _daemon_scope() {
 # (daemon present) or just kill the relay silently (no daemon — they
 # need to `airc join` again).
 _daemon_installed() {
-  local os; os=$(_daemon_os)
+  local os; os=$(detect_platform)
   case "$os" in
     darwin)
       [ -f "$HOME/Library/LaunchAgents/com.cambriantech.airc.plist" ] && return 0 ;;
@@ -4814,7 +4796,7 @@ _daemon_installed() {
 }
 
 cmd_daemon_install() {
-  local os; os=$(_daemon_os)
+  local os; os=$(detect_platform)
   local airc_bin; airc_bin=$(_daemon_airc_path)
   local scope; scope=$(_daemon_scope)
   mkdir -p "$scope"
@@ -5038,7 +5020,7 @@ UNIT
 }
 
 cmd_daemon_uninstall() {
-  local os; os=$(_daemon_os)
+  local os; os=$(detect_platform)
   case "$os" in
     darwin)
       local plist_path="$HOME/Library/LaunchAgents/com.cambriantech.airc.plist"
@@ -5083,7 +5065,7 @@ cmd_daemon_uninstall() {
 }
 
 cmd_daemon_status() {
-  local os; os=$(_daemon_os)
+  local os; os=$(detect_platform)
   case "$os" in
     darwin)
       local plist_path="$HOME/Library/LaunchAgents/com.cambriantech.airc.plist"

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -199,7 +199,7 @@ _doctor_probe_gh_auth() {
 _doctor_probe_sshd() {
   local plat; plat=$(detect_platform)
   case "$plat" in
-    macos)
+    darwin)
       # macOS Remote Login = launchd-managed sshd. Detect WITHOUT sudo:
       #   - `launchctl list` (user scope) does NOT show system services
       #     like com.openssh.sshd, so the user-scope probe always misses.
@@ -232,7 +232,7 @@ _doctor_probe_sshd() {
       printf "         Fix (RHEL/Fedora):    sudo dnf install openssh-server && sudo systemctl enable --now sshd\n"
       return 1
       ;;
-    windows-bash)
+    windows)
       # powershell.exe is the canonical PS launcher in Git Bash. Some
       # boxes also ship pwsh.exe (PS Core); prefer powershell.exe for
       # broadest reach since OpenSSH service control works in both.

--- a/lib/airc_bash/platform_adapters.sh
+++ b/lib/airc_bash/platform_adapters.sh
@@ -128,18 +128,10 @@ file_size() {
 # a top-level decision genuinely depends on platform (e.g. Tailscale.app
 # launching on macOS).
 detect_platform() {
-  local s; s=$(uname -s 2>/dev/null)
-  case "$s" in
-    Darwin)               echo macos ;;
-    Linux)
-      # Detect WSL via /proc/version content (kernel string contains
-      # 'microsoft' or 'WSL'). Bare Linux otherwise.
-      if grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then
-        echo wsl
-      else
-        echo linux
-      fi ;;
-    MINGW*|MSYS*|CYGWIN*) echo windows-bash ;;
+  case "$(uname -s 2>/dev/null)" in
+    Darwin)               echo darwin ;;
+    Linux)                grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null && echo wsl || echo linux ;;
+    MINGW*|MSYS*|CYGWIN*) echo windows ;;
     *)                    echo unknown ;;
   esac
 }


### PR DESCRIPTION
Two near-identical OS-detection functions consolidated. `detect_platform` (lib/airc_bash/platform_adapters.sh) and `_daemon_os` (airc top-level) both did Darwin/Linux/MINGW switching with /proc/version WSL detection — unify on detect_platform's surface, with output names matching _daemon_os (darwin/linux/wsl/windows/unknown — closer to raw `uname -s`).

Diff: **+10 / -36 = -26 lines**. airc 5283 → 5265.

Continuum-b69f's #205 candidate #3 (OS-detection audit). Per his suggestion I leaned safe: pure cleanup, near-zero risk. Verified airc doctor + airc daemon status still work on Mac.