### PR TITLE
fix(platform_adapters): _to_win_path / _to_bash_path BSD-portable fallback

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,18 +29,18 @@ warn()  { printf '  \033[1;33m!\033[0m %s\n' "$*" >&2; }
 # (defined twice on purpose: install.sh runs pre-clone so it can't
 # source from $CLONE_DIR, and the helper bodies are tiny).
 _to_win_path() {
-  if command -v cygpath >/dev/null 2>&1; then
-    cygpath -w "$1" 2>/dev/null
-  else
-    printf '%s' "$1" | sed 's|^/\([a-z]\)/|\U\1:\\\\|; s|/|\\\\|g'
-  fi
+  if command -v cygpath >/dev/null 2>&1; then cygpath -w "$1" 2>/dev/null; return; fi
+  case "$1" in
+    /[a-zA-Z]/*) printf '%s' "${1:1:1}" | tr 'a-z' 'A-Z'; printf ':\\%s\n' "${1:3}" | tr '/' '\\';;
+    *)           printf '%s\n' "$1" | tr '/' '\\' ;;
+  esac
 }
 _to_bash_path() {
-  if command -v cygpath >/dev/null 2>&1; then
-    cygpath -u "$1" 2>/dev/null
-  else
-    printf '%s' "$1" | sed 's|\\|/|g; s|^\([A-Za-z]\):|/\L\1|'
-  fi
+  if command -v cygpath >/dev/null 2>&1; then cygpath -u "$1" 2>/dev/null; return; fi
+  case "$1" in
+    [a-zA-Z]:*) printf '/'; printf '%s' "${1:0:1}" | tr 'A-Z' 'a-z'; printf '%s\n' "${1:2}" | tr '\\' '/';;
+    *)          printf '%s\n' "$1" | tr '\\' '/' ;;
+  esac
 }
 
 # ── Prereq auto-install ─────────────────────────────────────────────────

--- a/lib/airc_bash/platform_adapters.sh
+++ b/lib/airc_bash/platform_adapters.sh
@@ -159,18 +159,20 @@ iso_to_epoch() {
 # Both directions exposed so callers don't have to remember which sed
 # regex inverts the other.
 _to_win_path() {
-  if command -v cygpath >/dev/null 2>&1; then
-    cygpath -w "$1" 2>/dev/null
-  else
-    printf '%s' "$1" | sed 's|^/\([a-z]\)/|\U\1:\\\\|; s|/|\\\\|g'
-  fi
+  if command -v cygpath >/dev/null 2>&1; then cygpath -w "$1" 2>/dev/null; return; fi
+  # Pure-bash fallback (BSD sed lacks GNU \U/\L). /c/Users/foo → C:\Users\foo
+  case "$1" in
+    /[a-zA-Z]/*) printf '%s' "${1:1:1}" | tr 'a-z' 'A-Z'; printf ':\\%s\n' "${1:3}" | tr '/' '\\';;
+    *)           printf '%s\n' "$1" | tr '/' '\\' ;;
+  esac
 }
 _to_bash_path() {
-  if command -v cygpath >/dev/null 2>&1; then
-    cygpath -u "$1" 2>/dev/null
-  else
-    printf '%s' "$1" | sed 's|\\|/|g; s|^\([A-Za-z]\):|/\L\1|'
-  fi
+  if command -v cygpath >/dev/null 2>&1; then cygpath -u "$1" 2>/dev/null; return; fi
+  # Inverse of _to_win_path. C:\Users\foo → /c/Users/foo
+  case "$1" in
+    [a-zA-Z]:*) printf '/'; printf '%s' "${1:0:1}" | tr 'A-Z' 'a-z'; printf '%s\n' "${1:2}" | tr '\\' '/';;
+    *)          printf '%s\n' "$1" | tr '\\' '/' ;;
+  esac
 }
 
 # ── End platform adapters ───────────────────────────────────────────────


### PR DESCRIPTION
Cygpath-missing fallback used GNU sed's `\U` / `\L` (case conversion in replacement) — broken on macOS / BSD sed.

`/c/Users/foo` → `Uc:\Users\foo` (literal 'U') instead of `C:\Users\foo`.

Replace with portable `case` + parameter expansion + `tr`. Verified on Mac:
- /c/Users/foo/bar → C:\Users\foo\bar
- D:\path → /d/path (lowercased)
- roundtrip clean

Both copies fixed (platform_adapters.sh + install.sh's pre-clone duplicate).