### PR TITLE
feat(mesh): one gist per gh account — Phase 1 substrate switch

### DIFF
--- a/airc
+++ b/airc
@@ -317,27 +317,30 @@ _reexec_into() {
 # room_name first since both pointed at the dead host. Replaces 2
 # duplicated 22-line blocks in cmd_connect (#205 target 4).
 _self_heal_stale_host() {
-  local stale_id="$1" room_name="$2"
+  # Mesh-gist takeover. Inputs: stale_id only — the room_name argument
+  # from the per-room era is gone; mesh is per-account singleton, so
+  # there's nothing to discriminate on.
+  local stale_id="$1"
   local jitter; jitter=$(awk -v r="$RANDOM" 'BEGIN{printf "%.3f", 0.1 + (r%1500)/1000}')
   sleep "$jitter"
   if gh gist delete "$stale_id" --yes 2>/dev/null; then
-    echo "  ✓ Stale gist removed."
+    echo "  ✓ Stale mesh gist removed."
   else
-    echo "  ⚠  Stale gist already gone — another tab may have taken over first."
+    echo "  ⚠  Stale mesh gist already gone — another tab may have taken over first."
   fi
-  local picked
-  picked=$(gh gist list --limit 50 2>/dev/null \
-    | awk -F'\t' -v re="airc room: ${room_name}\$" -v skip="$stale_id" \
-        '$2 ~ re && $1 != skip { print $1; exit }')
+  # _mesh_find returns the singleton mesh gist (oldest-by-created if
+  # multiple are present from a race). If something is there, another
+  # tab beat us — rejoin pointed at it.
+  local picked; picked=$(_mesh_find)
   rm -f "$CONFIG" "$AIRC_WRITE_DIR/room_name"
-  if [ -n "$picked" ]; then
-    echo "  ✓ Another tab beat us to it — joining their fresh gist ($picked)"
+  if [ -n "$picked" ] && [ "$picked" != "$stale_id" ]; then
+    echo "  ✓ Another tab beat us to it — joining their fresh mesh gist ($picked)"
     echo ""
     _reexec_into rejoin "$picked"
   fi
-  echo "  Re-execing into host mode for #${room_name}..."
+  echo "  Re-execing into host mode (mesh singleton for this gh account)..."
   echo ""
-  _reexec_into host --room "$room_name"
+  _reexec_into host
 }
 CONFIG="$AIRC_WRITE_DIR/config.json"
 IDENTITY_DIR="$AIRC_WRITE_DIR/identity"
@@ -976,6 +979,19 @@ else
   exit 1
 fi
 # ── End platform adapters ───────────────────────────────────────────────
+
+# ── Mesh gist abstraction ───────────────────────────────────────────────
+# ONE gist per gh account (description literal: "airc mesh"). All
+# discovery, publish, takeover, heartbeat-freshness checks go through
+# these helpers so the per-account-singleton invariant has one home.
+if [ -n "${_airc_lib_dir:-}" ] && [ -f "$_airc_lib_dir/airc_bash/mesh.sh" ]; then
+  # shellcheck source=lib/airc_bash/mesh.sh
+  source "$_airc_lib_dir/airc_bash/mesh.sh"
+else
+  echo "ERROR: airc_bash/mesh.sh not found via lib-dir resolver." >&2
+  exit 1
+fi
+# ── End mesh gist abstraction ───────────────────────────────────────────
 
 relay_ssh() {
   local ssh_key="$IDENTITY_DIR/ssh_key"

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -348,35 +348,33 @@ cmd_connect() {
      [ "${AIRC_NO_DISCOVERY:-0}" != "1" ] && \
      command -v gh >/dev/null 2>&1; then
 
-    # ── Room discovery (the substrate path) ──────────────────────
-    # Match exact room name to avoid `airc room: general-test` colliding
-    # with `airc room: general`. Pick the most-recent if duplicates exist
-    # (stale hosts get re-elected on next reconnect when SSH fails).
-    if [ "$use_room" = "1" ]; then
-      _did_room_discovery=1
-      local _room_filter="airc room: ${room_name}\$"
-      local _room_candidates; _room_candidates=$(gh gist list --limit 50 2>/dev/null \
-        | awk -F'\t' -v re="$_room_filter" '$2 ~ re { print $1 "\t" $2 "\t" $4 }')
-      local _room_count; _room_count=$(printf '%s' "$_room_candidates" | grep -c . || true)
-      if [ "$_room_count" -ge 1 ]; then
-        # Most recent wins (gh gist list is reverse-chrono by update).
-        local _picked_id; _picked_id=$(printf '%s' "$_room_candidates" | head -1 | awk -F'\t' '{print $1}')
-        echo "  Found #${room_name} on your gh account → joining ($_picked_id)"
-        target="$_picked_id"
-        # fall through to gist resolver below — kind:room → invite handshake
-      else
-        echo "  No #${room_name} found on your gh account → becoming the host."
-        # Race against a concurrent host attempt is handled POST-publish
-        # (see "race-loser detection" near host_gist_id write below).
-        # Pre-publish recheck doesn't help — neither tab's gist is
-        # globally visible yet at this point.
-      fi
+    # ── Mesh discovery (singleton per gh account) ────────────────
+    # Architectural shift from the per-room model: ONE gist per gh
+    # account, description literal "airc mesh". Every `airc join` on
+    # the account converges on it. _mesh_find returns the singleton
+    # (oldest-by-created if multiple are present from a race).
+    #
+    # The --room flag still records the channel(s) this client wants
+    # to subscribe to (Phase 2 will route messages by channel), but it
+    # no longer drives gist discovery — every subscriber on the account
+    # converges on the same host.
+    _did_room_discovery=1
+    local _mesh_id; _mesh_id=$(_mesh_find)
+    if [ -n "$_mesh_id" ]; then
+      echo "  Found mesh on your gh account → joining ($_mesh_id)"
+      target="$_mesh_id"
+      # fall through to gist resolver below
+    else
+      echo "  No mesh found on your gh account → becoming the host."
+      # Race against a concurrent host attempt is handled POST-publish
+      # via _mesh_take_over (see host-publish path below).
     fi
 
-    # ── Legacy single-pair invite discovery (only if no room flow) ──
-    # Preserves the #38 behavior for users running with --no-general
-    # OR for room-mode users whose room discovery missed (we already
-    # set target in that case, so this block won't fire).
+    # ── Legacy single-pair invite discovery ──────────────────────
+    # Preserved for cross-account ad-hoc pairing where a friend on a
+    # DIFFERENT gh account shares an `airc invite for ...` gist id.
+    # Same-account discovery uses the mesh path above; this only
+    # fires when the user explicitly opted out of mesh + room.
     if [ -z "$target" ] && [ "$use_room" = "0" ]; then
       local _candidates; _candidates=$(gh gist list --limit 30 2>/dev/null \
         | awk -F'\t' '/airc invite for/ { print $1 "\t" $2 }')
@@ -432,7 +430,7 @@ cmd_connect() {
         _matched_gist_id="$_gid"
         break
       fi
-    done < <(gh gist list --limit 50 2>/dev/null | awk -F'\t' '/airc room:|airc invite for/ { print $1 "\t" $2 }')
+    done < <(gh gist list --limit 50 2>/dev/null | awk -F'\t' '/airc mesh|airc room:|airc invite for/ { print $1 "\t" $2 }')
     if [ -n "$_matched_gist_id" ]; then
       echo "  Resolved mnemonic '$target' → gist $_matched_gist_id"
       target="$_matched_gist_id"
@@ -565,14 +563,19 @@ cmd_connect() {
               resolved=$(printf '%s' "$raw_content" | jq -r '.invite // empty' 2>/dev/null \
                          | head -1 | tr -d '\r\n ')
               ;;
-            room)
-              # Persistent IRC-style channel (issue #39, the substrate).
-              # Same SSH-pair handshake as invite, but the gist persists
-              # so additional joiners can keep arriving. The room.invite
-              # field carries today's name@user@host:port#pubkey string.
+            mesh|room)
+              # Mesh: ONE persistent gist per gh account, shared across
+              # all subscribers. Same SSH-pair handshake as invite; the
+              # gist persists so additional joiners keep arriving. The
+              # `room` kind is the legacy per-room shape — handled here
+              # for back-compat with gists that haven't rolled to mesh
+              # yet (joiner can read either). The .invite field carries
+              # today's name@user@host:port#pubkey string.
               resolved=$(printf '%s' "$raw_content" | jq -r '.invite // empty' 2>/dev/null \
                          | head -1 | tr -d '\r\n ')
-              resolved_room_name=$(printf '%s' "$raw_content" | jq -r '.name // empty' 2>/dev/null)
+              # New mesh shape: .channels[]; legacy room shape: .name.
+              # Prefer channels[0] if present; fall back to .name.
+              resolved_room_name=$(printf '%s' "$raw_content" | jq -r '.channels[0] // .name // empty' 2>/dev/null)
               # Multi-address: capture host.addresses[] + host.machine_id
               # for the joiner's address-picker (peer_pick_address). Empty
               # if the host published a pre-multi-address envelope; in
@@ -615,7 +618,7 @@ cmd_connect() {
             *)
               # Unknown kind — fail loud. Old peers should reject
               # rather than silently misinterpret a future kind.
-              die "Gist uses unknown kind '$kind' (airc v$airc_ver). This receiver only supports 'invite' and 'room'. Update airc: 'airc update'."
+              die "Gist uses unknown kind '$kind' (airc v$airc_ver). This receiver only supports 'invite', 'room', and 'mesh'. Update airc: 'airc update'."
               ;;
           esac
         fi
@@ -682,7 +685,7 @@ cmd_connect() {
       # below. Two tabs concurrently deciding "host is stale" both
       # delete + publish, end up with split-brain — caught only by
       # running two tabs together.
-      _self_heal_stale_host "$_resolved_gist_id" "$resolved_room_name"
+      _self_heal_stale_host "$_resolved_gist_id"
     fi
 
     # Parse name@user@host[:port]#pubkey
@@ -844,7 +847,7 @@ except Exception:
         # competing gists for the same room name (split-brain race —
         # caught only by running two tabs against a stale gist
         # simultaneously, NOT by the integration test).
-        _self_heal_stale_host "$_resolved_gist_id" "$resolved_room_name"
+        _self_heal_stale_host "$_resolved_gist_id"
       fi
       # Either not a room flow, or no gh, or no resolved_room_name → original die.
       # Surface the captured pair-handshake stderr (continuum-b69f 2026-04-27:
@@ -1085,12 +1088,16 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
         local _gist_payload=""
 
         if [ "$use_room" = "1" ]; then
-          # Room mode (#39 substrate): persistent gist, not deleted after
-          # pair. Lets additional joiners discover + auto-join the same
-          # channel. Same SSH-pair handshake under the hood — only the
-          # gist lifecycle + envelope kind differ.
-          _gist_kind="room"
-          _gist_desc="airc room: ${room_name}"
+          # Mesh mode: ONE persistent gist per gh account (description
+          # "airc mesh"), shared by every `airc join` on the account.
+          # Same SSH-pair handshake under the hood — only the discovery
+          # contract changes from per-room to per-account-singleton.
+          #
+          # `channels` is an advisory list of the rooms this client
+          # cares about; in Phase 1 it's purely informational, in
+          # Phase 2 it'll drive message routing.
+          _gist_kind="mesh"
+          _gist_desc="$(_mesh_desc)"
           # last_heartbeat: host's presence signal, refreshed every
           # AIRC_HEARTBEAT_SEC (default 30s) by the bg loop spawned
           # below. Joiners detect stale → take over deterministically.
@@ -1110,9 +1117,8 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
           _gist_payload=$(cat <<JSON
 {
   "airc": 1,
-  "kind": "room",
-  "name": "${room_name}",
-  "topic": "",
+  "kind": "mesh",
+  "channels": ["${room_name}"],
   "invite": "$_invite_long",
   "host": {
     "name": "$name",
@@ -1159,10 +1165,11 @@ JSON
         if [ -n "$_gist_url" ]; then
           local _gist_id="${_gist_url##*/}"
           local _hh; _hh=$(humanhash "$_gist_id" 2>/dev/null)
-          # Persist the gist id locally so cmd_part can delete the room
-          # gist on graceful host exit (room mode only — invite mode is
-          # one-shot and the joiner-pair flow already prompts cleanup).
-          if [ "$_gist_kind" = "room" ]; then
+          # Persist the gist id locally so cmd_part can manage the
+          # mesh gist on graceful host exit (mesh/room mode only —
+          # invite mode is one-shot and the joiner-pair flow already
+          # prompts cleanup).
+          if [ "$_gist_kind" = "mesh" ] || [ "$_gist_kind" = "room" ]; then
             echo "$_gist_id" > "$AIRC_WRITE_DIR/room_gist_id"
             echo "$room_name" > "$AIRC_WRITE_DIR/room_name"
 
@@ -1211,9 +1218,8 @@ JSON
                 local _hb_payload; _hb_payload=$(cat <<JSON
 {
   "airc": 1,
-  "kind": "room",
-  "name": "${_hb_room}",
-  "topic": "",
+  "kind": "mesh",
+  "channels": ["${_hb_room}"],
   "invite": "${_hb_invite}",
   "host": {
     "name": "${_hb_name}",
@@ -1246,27 +1252,23 @@ JSON
             echo "$_hb_pid"  >  "$AIRC_WRITE_DIR/heartbeat.pid"
             echo "$_gist_id" >  "$AIRC_WRITE_DIR/host_gist_id"
 
-            # Post-publish race-loser detection. Two tabs that ran
-            # `airc join --room X` simultaneously can BOTH see empty
-            # gist list (gh propagation lag) and BOTH publish — pre-
-            # publish recheck doesn't help because neither's gist is
-            # globally visible yet. Solution: after publishing, look
-            # for OTHER gists with the same room name. Deterministic
-            # tiebreaker (lowest gist id alphabetically) picks the
-            # winner; loser deletes its gist + re-execs as joiner
-            # targeting the winner. Light jitter spreads the listing
-            # so we both see the same set.
-            local _race_jit; _race_jit=$(awk -v r="$RANDOM" 'BEGIN{printf "%.3f", 0.5 + (r%1000)/1000}')
-            sleep "$_race_jit"
-            local _peer_rooms; _peer_rooms=$(gh gist list --limit 50 2>/dev/null \
-              | awk -F'\t' -v re="airc room: ${room_name}\$" '$2 ~ re {print $1}' \
-              | sort)
-            local _peer_count; _peer_count=$(printf '%s\n' "$_peer_rooms" | grep -c . || true)
-            if [ "$_peer_count" -gt 1 ]; then
-              local _winner_id; _winner_id=$(printf '%s\n' "$_peer_rooms" | head -1)
-              if [ "$_winner_id" != "$_gist_id" ]; then
+            # Post-publish race-loser detection via _mesh_take_over.
+            # Two tabs that ran `airc join` simultaneously can BOTH see
+            # empty mesh-gist listing (gh propagation lag) and BOTH
+            # publish. Pre-publish recheck doesn't help — neither
+            # gist is globally visible yet at this point. _mesh_take_over
+            # waits a jitter, lists all "airc mesh" gists, picks the
+            # OLDEST by created_at as winner, and reports whether we won
+            # or lost. Loser deletes its gist + re-execs as joiner.
+            local _race; _race=$(_mesh_take_over "" "$_gist_id")
+            case "$_race" in
+              winner|"")
+                : # we won (or _mesh_take_over couldn't probe — assume winner, heartbeat will sort it)
+                ;;
+              loser:*)
+                local _winner_id="${_race#loser:}"
                 echo ""
-                echo "  ⚠  Concurrent host detected for #${room_name} — yielding to winner ($_winner_id)."
+                echo "  ⚠  Concurrent host detected — yielding to winner ($_winner_id)."
                 # Stop our heartbeat, delete our gist, clear state, re-exec as joiner.
                 kill "$_hb_pid" 2>/dev/null || true
                 gh gist delete "$_gist_id" --yes >/dev/null 2>&1 || true
@@ -1275,8 +1277,8 @@ JSON
                       "$AIRC_WRITE_DIR/room_gist_id" \
                       "$AIRC_WRITE_DIR/room_name"
                 _reexec_into rejoin "$_winner_id"
-              fi
-            fi
+                ;;
+            esac
 
             echo "  Hosting #${room_name} (gh-account substrate)."
             echo "  Other agents on your gh account auto-join via:  airc connect"

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -60,15 +60,14 @@ cmd_rooms() {
     echo "  airc IS aIRC — github gist is the coordination layer; gh is mandatory." >&2
     return 1
   fi
-  # Match BOTH the persistent IRC-style rooms (#39, prefix `airc room:`)
-  # and the legacy single-pair invites (#37/#38, prefix `airc invite for`).
-  # Show kind explicitly so the AI / human can tell them apart.
+  # Match the new mesh gist (one per gh account, description "airc mesh"),
+  # plus legacy per-room gists (`airc room:`) for accounts that haven't
+  # rolled over yet, plus single-pair invites (`airc invite for`) for
+  # cross-account ad-hoc pairing.
   # gh gist list columns: id  description  files  visibility  updated_at
-  # Use $5 (timestamp) for the updated field — pre-#82 we were using
-  # $4 (visibility, "secret") under the "updated:" label, which is a
-  # display bug fixed here on the way to adding stale markers.
   local raw; raw=$(gh gist list --limit 50 2>/dev/null \
     | awk -F'\t' '
+        /airc mesh/         { print "mesh\t"   $1 "\t" $2 "\t" $5 }
         /airc room:/        { print "room\t"   $1 "\t" $2 "\t" $5 }
         /airc invite for/   { print "invite\t" $1 "\t" $2 "\t" $5 }
       ')
@@ -122,8 +121,9 @@ cmd_rooms() {
     local hh; hh=$(humanhash "$id" 2>/dev/null)
     local marker
     case "$kind" in
-      room)   marker="#" ;;     # persistent channel
-      invite) marker="(1:1)" ;; # ephemeral pairing
+      mesh)   marker="◆" ;;     # mesh singleton (one per gh account)
+      room)   marker="#" ;;     # legacy persistent per-room channel
+      invite) marker="(1:1)" ;; # ephemeral cross-account pairing
     esac
     local age_str; age_str=$(_format_relative_time "$updated")
     local stale_marker=""

--- a/lib/airc_bash/mesh.sh
+++ b/lib/airc_bash/mesh.sh
@@ -1,0 +1,169 @@
+# Sourced by airc. Mesh gist abstraction — ONE gist per gh account.
+#
+# Architectural shift from the per-room model. Joel 2026-04-27:
+#   "B is the god damn correct shift. They all share the same gist,
+#   stop being stupid. one goes down first one to resolve, posts to
+#   gist. host goes down, new host, first one that posts, becomes it."
+#
+# Old model: every `airc join --room X` created a gist `airc room: X`,
+# with its own host process and own port. A user with 3 projects had
+# 3 independent host processes on 3 ports + 3 gists.
+#
+# New model: ONE gist per gh account, description literal `airc mesh`.
+# Every `airc join` on the account converges on it. Channels are
+# advisory tags inside the gist envelope (and in Phase 2, on each
+# message). One host machine, one sshd, one mesh.
+#
+# This file holds the primitives — lookup, publish, update, takeover.
+# cmd_connect.sh calls these instead of inline `gh gist create -d "airc
+# room:..."`. Single source of truth for the gist description literal,
+# the singleton-lookup contract, and race-loser semantics.
+#
+# Conventions:
+#   - All functions echo their result to stdout (one line) or stay silent.
+#   - Errors print to stderr; non-zero exit only when the operation
+#     genuinely failed (gh missing, network down, auth lapsed). Empty
+#     stdout + zero exit = "ran cleanly, found nothing."
+#   - Functions are pure stateless wrappers around gh + jq/awk; no
+#     side effects on local files. cmd_connect.sh keeps state.
+
+# Canonical gist description. Every site that creates, lists, or
+# matches the mesh gist routes through this — change once, change
+# everywhere.
+_mesh_desc() {
+  echo "airc mesh"
+}
+
+# Singleton lookup: find the mesh gist on the current gh account.
+# Echoes the gist id (one line) or empty.
+#
+# If the listing returns 2+ candidates (race-loser collision, gh
+# replication lag, or an old per-room gist incorrectly tagged), keep
+# the OLDEST by created_at. The oldest is the legitimate winner of
+# any post-publish race because it was created first; any other entry
+# is a duplicate that should be reaped on the next takeover cycle.
+_mesh_find() {
+  command -v gh >/dev/null 2>&1 || return 0
+  local desc; desc=$(_mesh_desc)
+  # gh gist list output: <id>\t<desc>\t<files>\t<visibility>\t<updated>
+  # Filter on EXACT desc match (anchor with ^ and $ in awk).
+  local ids
+  ids=$(gh gist list --limit 50 2>/dev/null \
+    | awk -F'\t' -v d="$desc" '$2 == d { print $1 }')
+  local count; count=$(printf '%s\n' "$ids" | grep -c . || true)
+  case "$count" in
+    0) return 0 ;;
+    1) printf '%s\n' "$ids" ;;
+    *)
+      # Multiple matches — pick the oldest by created_at. Same tiebreaker
+      # cmd_connect's race-loser detection uses; centralized here.
+      local oldest="" oldest_ts=""
+      while IFS= read -r gid; do
+        [ -z "$gid" ] && continue
+        local ts; ts=$(gh api "gists/$gid" --jq '.created_at' 2>/dev/null || echo "")
+        if [ -z "$oldest_ts" ] || [ "$ts" \< "$oldest_ts" ]; then
+          oldest="$gid"; oldest_ts="$ts"
+        fi
+      done <<< "$ids"
+      [ -n "$oldest" ] && printf '%s\n' "$oldest"
+      ;;
+  esac
+}
+
+# Publish a new mesh gist. Echoes the new gist id, or empty on failure.
+# Caller writes the JSON envelope to a tempfile and passes the path.
+_mesh_publish() {
+  local payload_path="${1:-}"
+  [ -f "$payload_path" ] || return 1
+  command -v gh >/dev/null 2>&1 || return 1
+  local desc; desc=$(_mesh_desc)
+  local url; url=$(gh gist create -d "$desc" "$payload_path" 2>/dev/null | tail -1)
+  [ -z "$url" ] && return 1
+  printf '%s\n' "${url##*/}"
+}
+
+# Update an existing mesh gist with a new payload. Used by the heartbeat
+# loop. Returns 0 on success, non-zero if the gist is gone or auth lapsed.
+# Caller passes the gist_id and a path to the new JSON envelope.
+_mesh_update() {
+  local gist_id="${1:-}" payload_path="${2:-}"
+  [ -n "$gist_id" ] || return 1
+  [ -f "$payload_path" ] || return 1
+  command -v gh >/dev/null 2>&1 || return 1
+  gh gist edit "$gist_id" "$payload_path" >/dev/null 2>&1
+}
+
+# Echo the seconds since last_heartbeat in the given mesh gist. Empty
+# (and zero exit) on any failure — caller treats empty as "can't tell,
+# assume stale" or "assume fresh" depending on policy.
+_mesh_age_secs() {
+  local gist_id="${1:-}"
+  [ -n "$gist_id" ] || return 0
+  command -v gh >/dev/null 2>&1 || return 0
+  local content; content=$(gh api "gists/$gist_id" --jq '.files | to_entries[0].value.content' 2>/dev/null || true)
+  [ -z "$content" ] && return 0
+  local hb; hb=$(printf '%s' "$content" | "$AIRC_PYTHON" -c '
+import sys, json
+try:
+    print(json.loads(sys.stdin.read()).get("last_heartbeat", ""))
+except Exception:
+    pass
+' 2>/dev/null || true)
+  [ -z "$hb" ] && return 0
+  local hb_epoch; hb_epoch=$("$AIRC_PYTHON" -m airc_core.datetime iso_to_epoch "$hb" 2>/dev/null || true)
+  [ -z "$hb_epoch" ] && return 0
+  local now_epoch; now_epoch=$(date -u +%s)
+  echo $(( now_epoch - hb_epoch ))
+}
+
+# Race-aware takeover. Inputs: $1 = stale gist id we want to replace.
+# Caller has already PUBLISHED their own replacement (returned id in $2)
+# and is checking whether they actually won the race.
+#
+# Echoes one of:
+#   "winner"   — caller's gist is the canonical mesh; old stale was
+#                deleted, no other contenders.
+#   "loser:<winner_id>"
+#              — somebody else's publish is older; caller should delete
+#                their own and rejoin pointed at <winner_id>.
+#
+# Algorithm:
+#   1. Try to delete the stale gist (idempotent — another tab may have
+#      gotten there first; treat that as success).
+#   2. Light jitter so all racers see the same gh-side state.
+#   3. List all mesh gists. If only ours is left, we won.
+#   4. If multiple, pick the OLDEST by created_at as winner. If that's
+#      ours, we won. Else echo "loser:<winner_id>".
+_mesh_take_over() {
+  local stale_id="${1:-}" my_id="${2:-}"
+  [ -n "$my_id" ] || return 1
+  command -v gh >/dev/null 2>&1 || return 1
+  if [ -n "$stale_id" ] && [ "$stale_id" != "$my_id" ]; then
+    gh gist delete "$stale_id" --yes >/dev/null 2>&1 || true
+  fi
+  # Jitter: 200..1200ms. Spreads races so all tabs see the same listing.
+  local jitter; jitter=$(awk -v r="$RANDOM" 'BEGIN{printf "%.3f", 0.2 + (r%1000)/1000}')
+  sleep "$jitter"
+  local desc; desc=$(_mesh_desc)
+  local ids; ids=$(gh gist list --limit 50 2>/dev/null \
+    | awk -F'\t' -v d="$desc" '$2 == d { print $1 }')
+  local count; count=$(printf '%s\n' "$ids" | grep -c . || true)
+  if [ "$count" -le 1 ]; then
+    echo "winner"
+    return 0
+  fi
+  # Multiple — pick oldest by created_at.
+  local oldest="" oldest_ts=""
+  while IFS= read -r gid; do
+    [ -z "$gid" ] && continue
+    local ts; ts=$(gh api "gists/$gid" --jq '.created_at' 2>/dev/null || echo "")
+    if [ -z "$oldest_ts" ] || [ "$ts" \< "$oldest_ts" ]; then
+      oldest="$gid"; oldest_ts="$ts"
+    fi
+  done <<< "$ids"
+  if [ "$oldest" = "$my_id" ]; then
+    echo "winner"
+  else
+    echo "loser:$oldest"
+  fi
+}


### PR DESCRIPTION
## Summary

Architectural shift from per-room gists to per-account-singleton mesh. Joel 2026-04-27:
> "B is the god damn correct shift. They all share the same gist, stop being stupid. one goes down first one to resolve, posts to gist. host goes down, new host, first one that posts, becomes it."

## What changes

- **New \`lib/airc_bash/mesh.sh\`** — primitives for the mesh-gist abstraction: \`_mesh_desc\`, \`_mesh_find\` (singleton lookup), \`_mesh_publish\`, \`_mesh_update\`, \`_mesh_age_secs\`, \`_mesh_take_over\` (race-aware oldest-by-created election).
- **airc top-level**: sources mesh.sh; \`_self_heal_stale_host\` now takes only stale_id (no room_name discriminator — mesh is per-account, nothing to discriminate on).
- **cmd_connect.sh**:
  - Discovery: singleton lookup via \`_mesh_find\` (was: per-room awk filter)
  - Host publish: description \`\"airc mesh\"\`, payload kind \`\"mesh\"\`, \`channels: [\$room_name]\` array (replaces \`.name\` + \`.topic\`)
  - Heartbeat payload: same shape change
  - Race-loser: \`_mesh_take_over\` (jitter, list, oldest-by-created wins)
  - Joiner: kind \`\"mesh\"\` handled alongside legacy \`\"room\"\` for back-compat
- **cmd_rooms.sh**: list display recognizes mesh (◆), room (#), invite (1:1) — three kinds during the transition.

## What's deferred (intentionally)

- **Phase 2:** joiners adding their own channels to the mesh gist; channel-as-message-metadata for routing.
- **Phase 3:** \`.general\` sidecar deletion (still spawned today).
- **Phase 4:** sweep of legacy \`airc room: *\` gists on rollover.

## Verification

- \`bash -n\` clean on all four files
- \`test/integration.sh status\`: 7/0 ✓
- \`test/integration.sh room\`: 14/0 ✓
- \`test/integration.sh general_sidecar_default\`: 12/0 ✓
- \`test/integration.sh tabs\`: 1/3 (rename-marker timing flake; 0/3 on pristine canary HEAD too — predates this PR)
- \`test/integration.sh platform_adapters\`: 9/2 (darwin/macos rename from #211, unrelated)

## Test plan (e2e — requires QA team)

- [ ] CI: integration suite on push to canary
- [ ] **e2e convergence**: continuum-b69f (Windows) + Mac Claude on same gh account both run \`airc update && airc join\` — confirm both converge on a single new \`airc mesh\` gist; first to publish wins; second becomes joiner.
- [ ] **e2e takeover**: kill the host, confirm joiner detects stale heartbeat and becomes new host via \`_mesh_take_over\`.
- [ ] **migration grace**: existing \`airc room: *\` gists left untouched; new mesh gist created alongside; \`airc rooms\` shows both with separate markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)