### PR TITLE
feat(channels): subscribed_channels config + --channel send flag — Phase 2B.1

### DIFF
--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -42,6 +42,12 @@ cmd_send() {
   # loudly when the requested room isn't in the user's subscription set
   # — never silently broadcasts to the wrong place.
   local target_room=""
+  # --channel <name> (Phase 2B): post-substrate flag that ONLY stamps
+  # the envelope's channel field; no scope re-exec. Same scope, same
+  # SSH wire, different channel tag. Coexists with --room for now;
+  # Phase 2B.3 deletes --room's re-exec path and makes --room an
+  # alias for --channel.
+  local channel_override=""
   # --internal: best-effort send for internal informational broadcasts
   # ([rename], etc.) where the monitor-down guard is the wrong UX. Append
   # to the local log + return 0 even when the monitor isn't running.
@@ -56,6 +62,10 @@ cmd_send() {
       --room|-room)
         target_room="${2:-}"
         [ -z "$target_room" ] && die "Usage: airc send --room <name> <message>"
+        shift 2 ;;
+      --channel|-c)
+        channel_override="${2:-}"
+        [ -z "$channel_override" ] && die "Usage: airc send --channel <name> <message>"
         shift 2 ;;
       --internal)
         internal=1
@@ -151,12 +161,22 @@ cmd_send() {
 
   # Channel: stamp every outbound envelope with the active channel so the
   # monitor display can route by channel uniformly (Phase 2 mesh
-  # substrate). Resolved from the scope's room_name file; falls back to
-  # "general" if no scope room is set. Once Phase 2B lands the joiner
-  # subscribed_channels concept, --channel <name> on cmd_send will
-  # override this default.
-  local active_channel="general"
-  [ -f "$AIRC_WRITE_DIR/room_name" ] && active_channel=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null || echo general)
+  # substrate). Resolution priority (Phase 2B.1):
+  #   1. --channel / -c flag (explicit per-call override)
+  #   2. config.json subscribed_channels[0]
+  #      (Phase 2B substrate — replaces sidecar scopes)
+  #   3. legacy room_name file (back-compat for users mid-rollover)
+  #   4. literal "general" fallback
+  local active_channel=""
+  if [ -n "$channel_override" ]; then
+    active_channel="$channel_override"
+  fi
+  if [ -z "$active_channel" ]; then
+    active_channel=$("$AIRC_PYTHON" -m airc_core.config default_channel --config "$CONFIG" 2>/dev/null || true)
+  fi
+  if [ -z "$active_channel" ] && [ -f "$AIRC_WRITE_DIR/room_name" ]; then
+    active_channel=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null || true)
+  fi
   [ -z "$active_channel" ] && active_channel="general"
 
   local payload="{\"from\":\"$my_name\",\"to\":\"$peer_name\",\"ts\":\"$ts_val\",\"channel\":\"$active_channel\",\"msg\":\"$escaped_msg\"}"

--- a/lib/airc_core/config.py
+++ b/lib/airc_core/config.py
@@ -111,6 +111,62 @@ def cmd_clear_parted(args) -> int:
     return 0
 
 
+# ── subscribed_channels (Phase 2B) ──────────────────────────────────────
+#
+# Replaces the per-scope `room_name` file + sidecar scopes. A single
+# `airc connect` process now subscribes to N channels in one mesh; the
+# config field is the source of truth for "which channels do I display?".
+#
+# The first element is the DEFAULT channel — the one cmd_send stamps on
+# outbound messages when --channel isn't passed. Order matters.
+#
+# Migration: a one-shot bootstrap reads the legacy `room_name` file (if
+# present) and writes it as the single-element subscribed_channels list,
+# preserving behavior for users mid-rollover. After that the room_name
+# file is no longer authoritative — config wins.
+
+def cmd_read_channels(args) -> int:
+    """Print subscribed channels, one per line. Empty output if none."""
+    for ch in _load(args.config).get("subscribed_channels", []) or []:
+        print(ch)
+    return 0
+
+
+def cmd_default_channel(args) -> int:
+    """Print the default (first) subscribed channel. Empty if none."""
+    chans = _load(args.config).get("subscribed_channels", []) or []
+    if chans:
+        print(chans[0])
+    return 0
+
+
+def cmd_subscribe(args) -> int:
+    """Add args.channel to subscribed_channels (idempotent).
+    --first promotes the channel to subscribed_channels[0] (becomes the
+    default for outbound). Without --first, appended at the end.
+    """
+    c = _load(args.config); cur = list(c.get("subscribed_channels", []) or [])
+    new = [ch for ch in cur if ch != args.channel]
+    if args.first:
+        new = [args.channel] + new
+    else:
+        new = new + [args.channel]
+    if new != cur:
+        c["subscribed_channels"] = new
+        return _save(args.config, c)
+    return 0
+
+
+def cmd_unsubscribe(args) -> int:
+    """Remove args.channel from subscribed_channels."""
+    c = _load(args.config); cur = c.get("subscribed_channels", []) or []
+    new = [ch for ch in cur if ch != args.channel]
+    if new != cur:
+        c["subscribed_channels"] = new
+        return _save(args.config, c)
+    return 0
+
+
 def cmd_set_host_block(args) -> int:
     """Atomically write the post-handshake host_* fields into config.
 
@@ -189,6 +245,26 @@ def _build_parser() -> argparse.ArgumentParser:
     cp.add_argument("--config", required=True)
     cp.add_argument("--room", required=True)
     cp.set_defaults(func=cmd_clear_parted)
+
+    rc = sub.add_parser("read_channels")
+    rc.add_argument("--config", required=True)
+    rc.set_defaults(func=cmd_read_channels)
+
+    dc = sub.add_parser("default_channel")
+    dc.add_argument("--config", required=True)
+    dc.set_defaults(func=cmd_default_channel)
+
+    su = sub.add_parser("subscribe")
+    su.add_argument("--config", required=True)
+    su.add_argument("--channel", required=True)
+    su.add_argument("--first", action="store_true",
+                    help="promote channel to subscribed_channels[0] (becomes default)")
+    su.set_defaults(func=cmd_subscribe)
+
+    un = sub.add_parser("unsubscribe")
+    un.add_argument("--config", required=True)
+    un.add_argument("--channel", required=True)
+    un.set_defaults(func=cmd_unsubscribe)
 
     s = sub.add_parser("set_host_block")
     s.add_argument("--config", required=True)


### PR DESCRIPTION
Phase 2B.1 substrate. Adds subscribed_channels config helpers + cmd_send --channel override. Backward compatible — existing room_name + sidecar + --room re-exec still work. Phase 2B.2 wires cmd_join to write the config; 2B.3 deletes sidecar.

Verification: tabs 19/0, queue 7/0, status 7/0; CLI manually exercised.