### PR TITLE
feat(channels): cmd_join writes subscribed_channels; cmd_part removes — Phase 2B.2

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -747,6 +747,12 @@ cmd_connect() {
     # the gist lifecycle — but we save the room name for display.
     if [ -n "$resolved_room_name" ]; then
       echo "$resolved_room_name" > "$AIRC_WRITE_DIR/room_name"
+      # Phase 2B.2: also write to subscribed_channels[0] so cmd_send picks
+      # this as the default channel without needing the legacy room_name
+      # file. --first promotes to index 0 in case a prior subscription
+      # already added other channels.
+      "$AIRC_PYTHON" -m airc_core.config subscribe \
+        --config "$CONFIG" --channel "$resolved_room_name" --first 2>/dev/null || true
       echo "  Joined #${resolved_room_name}"
     fi
 
@@ -1055,6 +1061,10 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
     # substrate framing took effect — emit unconditionally for room mode.
     if [ "$use_room" = "1" ]; then
       echo "$room_name" > "$AIRC_WRITE_DIR/room_name"
+      # Phase 2B.2: also seed subscribed_channels with our hosted channel
+      # so cmd_send + future config-driven consumers see it.
+      "$AIRC_PYTHON" -m airc_core.config subscribe \
+        --config "$CONFIG" --channel "$room_name" --first 2>/dev/null || true
       echo "  Hosting #${room_name} — no existing room on your gh account, fresh start."
       echo "  Other agents on your gh account who run 'airc join' will auto-join."
     fi

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -240,6 +240,15 @@ cmd_part() {
     echo "  /part persisted — #${room_name} won't auto-resubscribe. Rejoin with: airc join --${room_name}"
   fi
 
+  # Phase 2B.2: also remove the parted channel from this scope's
+  # subscribed_channels list. cmd_send won't pick it as default
+  # anymore, the monitor display drops the channel prefix from
+  # outbound, and a future cmd_join --room <name> re-adds it.
+  if [ "$room_name" != "(unnamed)" ]; then
+    "$AIRC_PYTHON" -m airc_core.config unsubscribe \
+      --config "$CONFIG" --channel "$room_name" 2>/dev/null || true
+  fi
+
   # IRC `/part` semantics — leave THIS room only; the #general sidecar
   # (or any other sibling subscription) keeps running. cmd_teardown
   # respects AIRC_TEARDOWN_PART_ONLY=1 by skipping its sidecar block,


### PR DESCRIPTION
Wires #225's substrate into the join/part lifecycle. cmd_join after pair calls subscribe --first; cmd_part calls unsubscribe. Legacy room_name file still written (Phase 2B.3 deletes the legacy path).

Verification: tabs 19/0, room 14/0.