### PR TITLE
feat(channels): drop sidecar + cmd_send re-exec — Phase 2B.3

### DIFF
--- a/airc
+++ b/airc
@@ -1067,88 +1067,31 @@ _clear_parted_room()  { [ -f "$1/config.json" ] && "$AIRC_PYTHON" -m airc_core.c
 # cmd_teardown's process-tree walker reaps it. cmd_teardown also has
 # explicit sidecar-scope cleanup (gist + sidecar's own pidfile).
 spawn_general_sidecar_if_wanted() {
+  # Phase 2B.3: the sidecar process is GONE. With Phase 1's mesh-singleton
+  # substrate (one gist + one host per gh account), a separate `airc
+  # connect` process for #general would discover the same mesh and yield
+  # to the same host — pure overhead. Instead we just add "general" to
+  # this scope's subscribed_channels list. cmd_send default-channel logic
+  # (Phase 2B.1) and the monitor formatter's per-envelope channel display
+  # (Phase 2A) handle the rest in one process.
+  #
+  # The function name + callsites stay so cmd_connect's flow doesn't
+  # need rewiring; only the body changed.
   [ "$general_sidecar" = "1" ] || return 0
   [ "$room_name" = "general" ] && return 0
   [ "$use_room" = "1" ] || return 0
 
-  local _primary_scope="$AIRC_WRITE_DIR"
-  local _primary_name; _primary_name=$(get_name 2>/dev/null || echo "")
-  local _sidecar_scope="${_primary_scope}.general"
-
-  # Issue #136: honor a prior /part. If "general" is in the primary
-  # scope's parted_rooms list, the user explicitly left the lobby —
-  # don't auto-resubscribe on bootstrap. Override with `airc join
-  # --general` (cmd_connect calls _clear_parted_room) or by editing
-  # config.json. Env/flag opt-outs are session-only and do NOT touch
-  # parted_rooms; only an explicit /part persists.
-  if _read_parted_rooms "$_primary_scope" | grep -Fxq "general"; then
-    echo "  Sidecar #general skipped — previously parted (airc join --general to rejoin)."
+  # Honor a prior /part: if "general" is in parted_rooms, don't
+  # auto-resubscribe. Override with `airc join --general` (which
+  # already calls _clear_parted_room) or by editing config.json.
+  if _read_parted_rooms "$AIRC_WRITE_DIR" | grep -Fxq "general"; then
+    echo "  #general subscription skipped — previously parted (airc join --general to rejoin)."
     return 0
   fi
 
-  echo "  Sidecar: also subscribing to #general (--no-general to opt out)"
-
-  mkdir -p "$_sidecar_scope"
-
-  # Background subprocess. Inherits stdout from primary so its monitor
-  # events stream alongside primary's, naturally distinguished by the
-  # formatter's `[#room]` prefix. AIRC_GENERAL_SIDECAR=1 is the recursion
-  # guard the sidecar reads at the top of cmd_connect to avoid spawning
-  # ITS OWN sidecar (turtles all the way down).
-  # Explicit `--room general` is critical: without it, auto-scope from
-  # cwd's git remote would resolve to the SAME project room as primary
-  # (cwd is shared across the spawn), and we'd end up double-subscribed
-  # to one room instead of subscribed to two. AIRC_NO_AUTO_ROOM=1 is
-  # belt-and-suspenders — auto-scope is gated by --room not being
-  # explicit; --room general makes it explicit, but the env var
-  # documents intent.
-  #
-  # `env` invocation (not bash assignment-prefixes): bash parameter
-  # expansion `${foo:+VAR=val}` doesn't get treated as an assignment
-  # prefix because it's expanded after tokenization — bash sees
-  # `AIRC_NAME=alpha` as a command in that position, not an env var,
-  # and dies with "command not found". `env` always treats its args
-  # as VAR=val pairs. Caught the hard way by the first run of this
-  # helper on 2026-04-26.
-  local _env_args=(AIRC_HOME="$_sidecar_scope" AIRC_GENERAL_SIDECAR=1 AIRC_NO_AUTO_ROOM=1)
-  [ -n "$_primary_name" ] && _env_args+=("AIRC_NAME=$_primary_name")
-  # Inherit primary's --no-gist flag so test fixtures don't leak a real
-  # #general gist into the live joelteply gh namespace via the sidecar.
-  # Bug found by continuum-b69f 2026-04-27 across the cross-Mac/Windows
-  # substrate-bypass channel: scenario_part_persists et al spawn the
-  # primary with `--no-gist --no-discovery`, but those flags do not
-  # propagate to the sidecar's spawn here. The sidecar then publishes
-  # an `airc room: general` gist with the test fixture's host info
-  # (e.g. host=alpha, port=7556). Test exits via cleanup_all's `kill -9`
-  # which bypasses the on-exit gist-delete trap, leaving the gist
-  # orphaned. Real users (continuum-b69f's Windows tab) discover it,
-  # try to TCP-connect, get RST. Two layers of test isolation hole;
-  # this fix patches the upstream half. (The downstream half — kill -9
-  # bypassing the trap — is harder to fix; tracked separately.)
-  #
-  # AIRC_NO_DISCOVERY=1 propagates automatically via the subshell env;
-  # only --no-gist needs explicit forwarding because it's a flag, not
-  # an env var.
-  local _sidecar_args=(connect --room general)
-  if [ "${use_gist:-1}" = "0" ]; then
-    _sidecar_args+=(--no-gist)
-  fi
-  # Unset primary's AIRC_PORT so sidecar doesn't fight for the same port —
-  # primary has it bound already, sidecar's auto-bump-loop would land on
-  # +1, but better to start the sidecar from the canonical default and
-  # let it find its own free port without the conflict-detect dance.
-  ( env -u AIRC_PORT "${_env_args[@]}" "$0" "${_sidecar_args[@]}" ) &
-  local _sidecar_pid=$!
-
-  # Sidecar's own scope writes its own airc.pid for its bash + descendants.
-  # cmd_teardown walks $AIRC_WRITE_DIR.general/airc.pid explicitly to kill
-  # the sidecar tree, so we DON'T append the sidecar bash PID to the
-  # primary's airc.pid. Earlier (PR #122) we did — but that broke
-  # cmd_part, which walks the same primary pidfile and ends up killing
-  # the sidecar too even though IRC semantics say `/part` should leave
-  # only the current channel and keep others (e.g. #general) alive.
-  # Pidfiles per scope; cmd_teardown is the only path that walks both.
-  :
+  echo "  Also subscribing to #general (--no-general to opt out)"
+  "$AIRC_PYTHON" -m airc_core.config subscribe \
+    --config "$CONFIG" --channel general 2>/dev/null || true
 }
 
 # Resolve this session's peer name.

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -76,61 +76,13 @@ cmd_send() {
   set -- "${positional[@]+"${positional[@]}"}"
 
   if [ -n "$target_room" ]; then
-    # Resolve target_room to a scope dir. Two cases:
-    #   1. We ARE in target_room already (current scope's room_name file
-    #      matches) → just continue here, no re-exec.
-    #   2. A sibling scope `${primary_scope}.${target_room}` exists →
-    #      re-exec with AIRC_HOME there. Recursion guard via
-    #      AIRC_SEND_REROUTED=1 — without it, a misconfigured sibling
-    #      scope could loop.
-    #
-    # Determining "primary scope" is the awkward bit because we may
-    # ALREADY be in a sidecar scope (AIRC_WRITE_DIR ends in `.X`). Strip
-    # any trailing `.<word>` to find the project scope, then append
-    # `.<target_room>` for the requested sibling. If target_room IS the
-    # project room name (read from primary's room_name file), point at
-    # the project scope itself, not a sibling.
-    local _here_room=""
-    [ -f "$AIRC_WRITE_DIR/room_name" ] && _here_room=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null)
-    if [ "$_here_room" = "$target_room" ]; then
-      : # already in the right scope, fall through to normal send
-    else
-      [ "${AIRC_SEND_REROUTED:-0}" = "1" ] \
-        && die "send: --room re-route loop detected (scope $AIRC_WRITE_DIR room=$_here_room target=$target_room)"
-      # Strip any sibling suffix from current scope to get the project
-      # scope path. e.g. /path/.airc.general → /path/.airc
-      local _project_scope="$AIRC_WRITE_DIR"
-      case "$_project_scope" in
-        *.airc.*)
-          _project_scope="${_project_scope%.*}" ;;
-      esac
-      # Read the project scope's room_name to compare with target.
-      local _project_room=""
-      [ -f "$_project_scope/room_name" ] && _project_room=$(cat "$_project_scope/room_name" 2>/dev/null)
-      local _target_scope=""
-      if [ "$_project_room" = "$target_room" ]; then
-        _target_scope="$_project_scope"
-      else
-        # Sibling sidecar scope under the project scope's parent.
-        # Convention: primary scope is `<base>/.airc`, sidecar scope is
-        # `<base>/.airc.<roomname>` (e.g. `.airc.general`).
-        _target_scope="${_project_scope}.${target_room}"
-      fi
-      if [ ! -d "$_target_scope" ] || [ ! -f "$_target_scope/room_name" ]; then
-        echo "  send --room #${target_room}: not subscribed in this scope." >&2
-        echo "    looked at: $_target_scope" >&2
-        echo "    rooms you ARE in:" >&2
-        for _d in "$_project_scope" "$_project_scope".*; do
-          [ -f "$_d/room_name" ] && echo "      - #$(cat "$_d/room_name" 2>/dev/null) (scope: $_d)" >&2
-        done
-        echo "  Fix: 'airc join --room ${target_room}' (in a separate scope), or drop the --room flag." >&2
-        die "send: not subscribed to #${target_room}"
-      fi
-      # Re-exec with AIRC_HOME pointed at the target scope. Pass the
-      # remaining positional args (peer/message) through. The recursion
-      # guard prevents infinite re-routing if the target scope is itself
-      # misconfigured.
-      exec env AIRC_HOME="$_target_scope" AIRC_SEND_REROUTED=1 "$0" send "$@"
+    # Phase 2B.3: --room becomes equivalent to --channel. The pre-mesh
+    # sidecar model required re-exec'ing into a sibling scope because
+    # each room had its OWN host process; in the post-mesh world there
+    # is ONE host per gh account, so all channels share the same wire.
+    # Just stamp the channel field and continue.
+    if [ -z "$channel_override" ]; then
+      channel_override="$target_room"
     fi
   fi
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -1958,26 +1958,22 @@ scenario_connect_after_kill_recovers() {
   cleanup_all
 }
 
-# ── Scenario: general_sidecar_default (issue #121) ─────────────────────
-# Default-on multi-room presence: bare `airc join` from a project repo
-# should subscribe the tab to BOTH the auto-scoped project room AND
-# #general. The sidecar runs in a sibling .general scope; its bash PID
-# is appended to the primary's airc.pid so cmd_teardown reaps both.
+# ── Scenario: general_sidecar_default (Phase 2B.3 — sidecar deletion) ──
+# Phase 2B.3 collapses the multi-scope sidecar into a single scope with
+# subscribed_channels=["<project-room>", "general"]. Default-on multi-
+# room presence is preserved, but as ONE process subscribing to both
+# channels — not a separate `.general` sidecar process.
 #
 # Tests:
-#   1. Default behavior: primary spawns a #general sidecar.
-#   2. --no-general flag: project-only, no sidecar.
-#   3. cmd_teardown cleans BOTH primary scope + sidecar scope (.general).
-#
-# Test bypasses gh by using AIRC_NO_DISCOVERY=1 + --no-gist on both
-# primary and (transitively) sidecar — both fall into host mode in
-# their respective rooms with no gist publish. The point isn't wire
-# behavior; it's process spawn + scope creation + teardown reaping.
+#   1. Default behavior: bare `airc join` adds "general" to
+#      subscribed_channels (no separate scope/process).
+#   2. --no-general flag: project-only, no general subscription.
+#   3. --room-only is equivalent to --room + --no-general.
 scenario_general_sidecar_default() {
-  section "general_sidecar_default: bare join spawns #general sidecar (issue #121)"
+  section "general_sidecar_default: subscribed_channels (Phase 2B.3)"
   cleanup_all
 
-  # ── Test 1: default-on sidecar ────────────────────────────────────────
+  # ── Test 1: default-on subscription, no separate process ─────────────
   # The harness exports AIRC_NO_GENERAL=1 globally to suppress sidecar
   # in other tests; here we explicitly unset it for the scope of this
   # scenario.
@@ -1990,57 +1986,46 @@ scenario_general_sidecar_default() {
   local i
   for i in 1 2 3 4 5 6 7 8; do
     sleep 1
-    grep -qE 'Sidecar:.*also subscribing' "$home1/out.log" 2>/dev/null && break
+    grep -qE 'Also subscribing to #general' "$home1/out.log" 2>/dev/null && break
   done
 
-  grep -qE 'Sidecar:.*also subscribing to #general' "$home1/out.log" \
-    && pass "primary printed sidecar-spawn banner" \
-    || fail "no sidecar-spawn banner (got: $(head -10 "$home1/out.log" | tr '\n' '|'))"
+  grep -qE 'Also subscribing to #general' "$home1/out.log" \
+    && pass "primary printed subscribe-to-general banner" \
+    || fail "no subscribe banner (got: $(head -15 "$home1/out.log" | tr '\n' '|'))"
 
-  # Wait for sidecar scope to exist + be populated
+  # NEW: subscribed_channels in primary's config.json should include "general"
+  # (and the project room). No separate .general scope dir.
   for i in 1 2 3 4 5 6 7 8; do
     sleep 1
-    [ -f "${home1}.general/airc.pid" ] && [ -f "${home1}.general/room_name" ] && break
+    [ -f "$home1/config.json" ] && grep -q 'subscribed_channels' "$home1/config.json" && break
   done
 
-  [ -d "${home1}.general" ] \
-    && pass "sidecar scope dir created at \${home}.general" \
-    || fail "sidecar scope dir absent"
+  if [ -f "$home1/config.json" ] && python3 -c "
+import json,sys
+c=json.load(open('$home1/config.json'))
+chans=c.get('subscribed_channels',[])
+sys.exit(0 if 'general' in chans else 1)
+" 2>/dev/null; then
+    pass "subscribed_channels includes 'general'"
+  else
+    fail "subscribed_channels missing 'general' (config: $(cat "$home1/config.json" 2>/dev/null))"
+  fi
 
-  [ -f "${home1}.general/room_name" ] && [ "$(cat "${home1}.general/room_name")" = "general" ] \
-    && pass "sidecar scope has room_name=general" \
-    || fail "sidecar scope room_name wrong (got: $(cat "${home1}.general/room_name" 2>/dev/null))"
+  [ ! -d "${home1}.general" ] \
+    && pass "no .general sidecar scope created (Phase 2B.3)" \
+    || fail ".general sidecar scope STILL created — sidecar deletion not effective"
 
-  # Primary's airc.pid contains primary's host-mode PIDs ($$ PAIR_PID
-  # hb_pid on one line). The sidecar's PID lives in its OWN scope's
-  # airc.pid — separate file, separate ownership. (PR #122 originally
-  # appended sidecar PID to primary's airc.pid, but PR #125 reverted
-  # that to make `airc part` work cleanly without nuking the sidecar.)
   [ -s "$home1/airc.pid" ] \
     && pass "primary airc.pid is non-empty (host PIDs recorded)" \
     || fail "primary airc.pid empty or missing"
 
-  # Sidecar bash should be alive — read sidecar's OWN pidfile.
-  # awk '{print $1; exit}' grabs just the first PID since host-mode
-  # airc.pid has multiple space-separated PIDs on one line.
-  local _sc_pid; _sc_pid=$(awk '{print $1; exit}' "${home1}.general/airc.pid" 2>/dev/null)
-  if [ -n "$_sc_pid" ] && kill -0 "$_sc_pid" 2>/dev/null; then
-    pass "sidecar bash PID ${_sc_pid} (from sidecar scope's own airc.pid) is alive"
-  else
-    fail "sidecar PID not alive (pid=${_sc_pid:-<empty>})"
-  fi
-
-  # ── Test 2: cmd_teardown reaps both ──────────────────────────────────
+  # ── Test 2: cmd_teardown reaps the single scope ──────────────────────
   AIRC_HOME="$home1" "$AIRC" teardown >/dev/null 2>&1
   sleep 1
 
-  ! kill -0 "$_sc_pid" 2>/dev/null \
-    && pass "teardown killed sidecar bash (PID ${_sc_pid})" \
-    || fail "sidecar still alive after teardown"
-
-  [ ! -f "${home1}.general/airc.pid" ] \
-    && pass "teardown cleared sidecar pidfile" \
-    || fail "sidecar pidfile still present after teardown"
+  [ ! -f "$home1/airc.pid" ] \
+    && pass "teardown cleared primary pidfile" \
+    || fail "primary pidfile still present after teardown"
 
   cleanup_all
   rm -rf /tmp/airc-it-sc1


### PR DESCRIPTION
Final 2B piece. Sidecar process collapses to a single subscribe-to-general call; cmd_send --room re-exec deleted (with mesh singleton, all channels share one wire). Net -120 lines.

Verification: tabs 19/0, room 14/0, queue 7/0, general_sidecar_default rewrite 10/0.