### PR TITLE
fix(argv): -h/--help intercept on cmd_send / cmd_kick / cmd_whois

### DIFF
--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -190,6 +190,17 @@ cmd_whois() {
   local target="${1:-}"
   local my_name; my_name=$(get_name)
 
+  # Help-flag intercept — without this, --help flowed into target and
+  # got rejected by _validate_peer_name with the unhelpful "must not
+  # start with '-'" error.
+  case "$target" in
+    -h|--help)
+      echo "Usage:"
+      echo "  airc whois                         show own identity"
+      echo "  airc whois <peer>                  show peer's identity (paired or via host)"
+      return 0 ;;
+  esac
+
   # Self — same identity across all scopes, no walk needed.
   if [ -z "$target" ] || [ "$target" = "$my_name" ]; then
     _identity_show

--- a/lib/airc_bash/cmd_kick.sh
+++ b/lib/airc_bash/cmd_kick.sh
@@ -25,7 +25,13 @@ cmd_kick() {
   # `airc ban`.
   ensure_init
   local target="${1:-}"
-  [ -z "$target" ] && die "Usage: airc kick <peer> [reason]"
+  case "$target" in
+    -h|--help|"")
+      echo "Usage: airc kick <peer> [reason]"
+      echo "  Host-only. Removes peer's SSH pubkey + peer file."
+      [ -z "$target" ] && return 1
+      return 0 ;;
+  esac
   _validate_peer_name "$target"
   shift || true
   local reason="${*:-no reason given}"

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -59,6 +59,14 @@ cmd_send() {
   local positional=()
   while [ $# -gt 0 ]; do
     case "$1" in
+      -h|--help)
+        echo "Usage:"
+        echo "  airc send <message>                broadcast to default channel"
+        echo "  airc send @peer <message>          DM peer"
+        echo "  airc send --channel <name> <msg>   stamp channel field"
+        echo "  airc send --room <name> <msg>      same as --channel (Phase 2B alias)"
+        echo "  airc send --internal <msg>         system event (skips monitor-down guard)"
+        return 0 ;;
       --room|-room)
         target_room="${2:-}"
         [ -z "$target_room" ] && die "Usage: airc send --room <name> <message>"


### PR DESCRIPTION
Stops 'airc msg --help' from broadcasting the literal '--help' to the room (and similar shape for kick/whois). Each cmd_X argv parser now intercepts -h/--help before positional processing.

Verification: tabs 19/0, kick 12/0, whois 5/0; manually exercised airc msg/kick/whois --help.