### PR TITLE
feat(channels): heartbeat builds channels[] from recent messages — Phase 2C

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1250,11 +1250,45 @@ JSON
                 # joiners that lose connection re-discover and try the
                 # new address set.
                 local _hb_addrs; _hb_addrs=$(host_addresses_json "${_hb_port}")
+                # Phase 2C: build channels[] from recent message activity
+                # so joiners on different cwds can advertise their channels
+                # without coordinating with the host. Self-correcting —
+                # silent channels age out, active ones surface. Falls back
+                # to the host's primary room if no recent activity.
+                local _hb_channels
+                _hb_channels=$(AIRC_HB_MSGS="$_hb_messages" \
+                               AIRC_HB_ROOM="$_hb_room" \
+                               "$AIRC_PYTHON" -c '
+import json, os, sys
+log = os.environ.get("AIRC_HB_MSGS", "")
+fallback = os.environ.get("AIRC_HB_ROOM", "general") or "general"
+window = int(os.environ.get("AIRC_HB_RECENT", "200"))
+chans = []
+seen = set()
+try:
+    with open(log) as f:
+        # Read last N lines without slurping the full file.
+        lines = f.readlines()[-window:]
+    for line in lines:
+        try:
+            ch = json.loads(line).get("channel", "")
+        except Exception:
+            continue
+        if ch and ch not in seen:
+            seen.add(ch); chans.append(ch)
+except Exception:
+    pass
+if not chans:
+    chans = [fallback]
+elif fallback not in seen:
+    chans.append(fallback)
+print(json.dumps(chans))
+' 2>/dev/null || echo "[\"${_hb_room}\"]")
                 local _hb_payload; _hb_payload=$(cat <<JSON
 {
   "airc": 1,
   "kind": "mesh",
-  "channels": ["${_hb_room}"],
+  "channels": ${_hb_channels},
   "invite": "${_hb_invite}",
   "host": {
     "name": "${_hb_name}",


### PR DESCRIPTION
Mesh gist's channels[] becomes self-correcting. Host's heartbeat scans last 200 lines of messages.jsonl, extracts unique channel envelope fields, writes that union (with host's primary room as fallback) as channels[].

Joiners no longer need to push subscriptions — they just tag messages with their channel and the host's next heartbeat picks it up. Silent channels age out via the window.

Verification: tabs 19/0, room 14/0, general_sidecar_default 10/0. Standalone fixture exercise confirms order-preserving dedupe + fallback merge.