### PR TITLE
fix(update): loud stale-running-monitor warning on airc canary / update

### DIFF
--- a/lib/airc_bash/cmd_update.sh
+++ b/lib/airc_bash/cmd_update.sh
@@ -89,7 +89,25 @@ cmd_update() {
     echo "  Already at ${after} on channel '${channel}'. Skills refreshed."
   else
     echo "  Updated: ${before} -> ${after} on channel '${channel}'. Skills refreshed."
-    echo "  Running monitor still uses the old code. To pick up:  airc teardown && airc connect"
+  fi
+
+  # Stale-running-monitor detection (vhsm-d1f4's gotcha 2026-04-28):
+  # bash sources its functions in-memory at process start; an airc
+  # connect that's been running since BEFORE this update is still
+  # executing the old version. We can't auto-restart safely (would
+  # interrupt active SSH sessions), so we print a loud, action-shaped
+  # warning ONLY when a monitor is actually running in the current
+  # scope. Silent when nothing is running.
+  if [ -f "$AIRC_WRITE_DIR/airc.pid" ]; then
+    local _pid; _pid=$(awk '{print $1; exit}' "$AIRC_WRITE_DIR/airc.pid" 2>/dev/null)
+    if [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null; then
+      echo ""
+      echo "  ⚠  A running airc monitor (PID ${_pid}) is still on the OLD code."
+      echo "     Restart to pick up ${after}:"
+      echo ""
+      echo "       airc teardown && airc connect"
+      echo ""
+    fi
   fi
 }
 


### PR DESCRIPTION
vhsm-d1f4 ran 'airc canary' for #232, saw the dim 'Running monitor still uses old code' hint, missed it in install.sh's output, and ran on stale in-memory bash for a while. Phase 2C didn't surface until teardown+reconnect.

Fix: cmd_update probes $AIRC_WRITE_DIR/airc.pid; if alive, prints a multi-line action-shaped warning with the restart command on its own line. Silent when nothing's running.