### PR TITLE
fix(argv): -h/--help intercept on all remaining cmd_X (class-wide sweep)

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -92,6 +92,22 @@ cmd_connect() {
   local positional=()
   while [ $# -gt 0 ]; do
     case "$1" in
+      -h|--help)
+        echo "Usage: airc connect [target] [flags]"
+        echo "  airc connect                   auto-discover mesh on your gh account"
+        echo "  airc connect <gist-id>         join via shared gist id (cross-account)"
+        echo "  airc connect <mnemonic>        join via humanhash phrase (same account)"
+        echo "  airc connect <invite-string>   join via inline invite (legacy)"
+        echo ""
+        echo "Flags:"
+        echo "  --room <name>                  set channel intent (auto-scoped from cwd if absent)"
+        echo "  --room-only <name>             --room + --no-general"
+        echo "  --no-room                      disable substrate entirely (legacy 1:1 invite)"
+        echo "  --no-general                   keep project room, skip #general subscription"
+        echo "  --general                      re-opt-in to #general after a prior /part"
+        echo "  --no-gist                      don't publish/discover via gh gist (test mode)"
+        echo "  --no-tailscale                 skip Tailscale even if installed"
+        return 0 ;;
       --gist|-gist) use_gist=1; shift ;;
       --no-gist|-no-gist) use_gist=0; shift ;;
       --room|-room) room_name="${2:-general}"; use_room=1; room_explicit=1; shift 2 ;;

--- a/lib/airc_bash/cmd_daemon.sh
+++ b/lib/airc_bash/cmd_daemon.sh
@@ -52,6 +52,13 @@ cmd_daemon() {
   local action="${1:-status}"
   shift 2>/dev/null || true
   case "$action" in
+    -h|--help|help)
+      echo "Usage: airc daemon [install|uninstall|status|log]"
+      echo "  install     register OS auto-restart (launchd/systemd/schtasks)"
+      echo "  uninstall   remove auto-restart registration"
+      echo "  status      print platform-native unit/plist state + log tail"
+      echo "  log [N]     tail the daemon stdout log (default 50 lines)"
+      return 0 ;;
     install)   cmd_daemon_install "$@" ;;
     uninstall|remove|stop) cmd_daemon_uninstall "$@" ;;
     status)    cmd_daemon_status "$@" ;;

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -22,6 +22,13 @@ cmd_doctor() {
   #   airc doctor tests        prior default behavior; aliased on the
   #                            dispatch via `tests|test`).
   case "${1:-}" in
+    -h|--help)
+      echo "Usage: airc doctor [mode]"
+      echo "  airc doctor              environment health check (default)"
+      echo "  airc doctor --connect    pre-flight checks for 'airc connect'"
+      echo "  airc doctor --tests      run the integration test suite"
+      echo "                           (aliases: tests, test, run, suite)"
+      return 0 ;;
     --tests|-t|tests|test|run|suite) shift; _doctor_run_tests "$@"; return ;;
     --connect|-c|connect)            shift; _doctor_connect_preflight "$@"; return ;;
   esac

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -50,6 +50,16 @@
 # (airc identity set --status) still works for scripted state changes.
 cmd_away() {
   ensure_init
+  # Intercept --help BEFORE building $msg from $* — vhsm-d1f4's verb-fuzz
+  # 2026-04-28 caught `airc away --help` writing "--help" as the status
+  # string. Same anti-pattern as #231/#236; same shape fix.
+  case "${1:-}" in
+    -h|--help)
+      echo "Usage:"
+      echo "  airc away             clear away status (back)"
+      echo "  airc away <message>   set away status to <message>"
+      return 0 ;;
+  esac
   if [ $# -eq 0 ]; then
     _identity_set --status "" >/dev/null
     echo "  back — away cleared."

--- a/lib/airc_bash/cmd_reminder.sh
+++ b/lib/airc_bash/cmd_reminder.sh
@@ -18,6 +18,13 @@ cmd_reminder() {
   local reminder_file="$AIRC_WRITE_DIR/reminder"
 
   case "$arg" in
+    -h|--help)
+      echo "Usage:"
+      echo "  airc reminder              show current state"
+      echo "  airc reminder <seconds>    set interval (e.g. 300)"
+      echo "  airc reminder pause        pause reminders without losing the saved interval"
+      echo "  airc reminder off          disable reminders entirely"
+      return 0 ;;
     off|0)
       rm -f "$reminder_file"
       echo "  Reminders off."
@@ -39,6 +46,16 @@ cmd_reminder() {
       fi
       ;;
     *)
+      # Defense in depth: only accept positive-integer seconds. Same
+      # anti-pattern as cmd_channel — without this, `airc reminder
+      # --foo` (any flag-shaped token we don't enumerate) would be
+      # written into the reminder file as the interval.
+      case "$arg" in
+        ''|*[!0-9]*)
+          echo "  Refusing to set reminder interval to '$arg' — must be a positive integer (seconds)." >&2
+          echo "  Try: airc reminder --help" >&2
+          return 2 ;;
+      esac
       echo "$arg" > "$reminder_file"
       echo "  Reminder every ${arg}s if no messages."
       ;;

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -16,6 +16,13 @@
 cmd_status() {
   # Human-readable liveness view. Fast — no network calls by default; `--probe`
   # opts into a 3s SSH reachability check.
+  case "${1:-}" in
+    -h|--help)
+      echo "Usage:"
+      echo "  airc status            print local liveness snapshot (fast)"
+      echo "  airc status --probe    add a 3s SSH reachability check to the host"
+      return 0 ;;
+  esac
   ensure_init
   local probe=0
   [ "${1:-}" = "--probe" ] && probe=1

--- a/lib/airc_bash/cmd_teardown.sh
+++ b/lib/airc_bash/cmd_teardown.sh
@@ -29,6 +29,12 @@ cmd_teardown() {
   local flush=0 all=0
   while [ $# -gt 0 ]; do
     case "$1" in
+      -h|--help)
+        echo "Usage:"
+        echo "  airc teardown          kill all airc processes for this scope"
+        echo "  airc teardown --flush  also wipe state dir (identity, peers, messages)"
+        echo "  airc teardown --all    nuke EVERY airc-looking process on this machine"
+        return 0 ;;
       --flush) flush=1 ;;
       --all)   all=1 ;;
       *) echo "  unknown teardown flag: $1" >&2; return 2 ;;

--- a/lib/airc_bash/cmd_update.sh
+++ b/lib/airc_bash/cmd_update.sh
@@ -35,6 +35,13 @@ cmd_update() {
   local requested_channel=""
   while [ $# -gt 0 ]; do
     case "$1" in
+      -h|--help)
+        echo "Usage:"
+        echo "  airc update                        pull latest on current channel"
+        echo "  airc update --channel <name>       switch channel + pull"
+        echo "  airc update --canary               shortcut for --channel canary"
+        echo "  airc update --main                 shortcut for --channel main"
+        return 0 ;;
       --channel|-c)
         requested_channel="${2:-}"
         [ -z "$requested_channel" ] && die "Usage: airc update --channel <name>"
@@ -124,6 +131,24 @@ cmd_channel() {
   [ -z "$current" ] && current="main"
 
   local target="${1:-}"
+  # Help-flag intercept BEFORE we'd write target to channel_file.
+  # vhsm-d1f4 + continuum-b741 + ideem-local-4bef caught this 2026-04-28:
+  # `airc channel --help` was writing "--help" as the channel preference,
+  # which would brick the next `airc update` (no such branch on origin).
+  case "$target" in
+    -h|--help)
+      target=""  # fall through to the no-arg path which prints usage
+      ;;
+  esac
+  # Reject any flag-shaped value as a channel name (channels are git
+  # branches; they can't start with '-'). Defensive against the same
+  # class of bug for arbitrary flags we don't enumerate.
+  case "$target" in
+    -*)
+      echo "  Refusing to set channel preference to '$target' — channel names cannot start with '-'." >&2
+      echo "  Run 'airc channel' (no args) to see the help block." >&2
+      return 2 ;;
+  esac
   if [ -z "$target" ]; then
     echo "  Channel: $current"
     echo "  Available channels (any branch on origin can be a channel):"


### PR DESCRIPTION
QA verb-fuzz from vhsm-d1f4 / continuum-b741 / ideem-local-4bef caught 3 destructive --help bugs (away, reminder, channel — last would brick airc update) plus 6 silent ones (status, connect, teardown, daemon, doctor, update). Class-wide sweep adds -h/--help intercepts to all + flag-shape rejection in cmd_channel/cmd_reminder.

After this: every lib/airc_bash/cmd_*.sh has the intercept.

Verification: tabs 19/0, room 14/0, general_sidecar_default 10/0, away 5/0; manual exercise of every --help.