### PR TITLE
fix(2B.3): cmd_peers + cmd_whois stop walking deleted sidecar scopes

### DIFF
--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -222,30 +222,18 @@ cmd_whois() {
   # cmds (cat $host_airc_home/peers/<target>.json) in any scope.
   _validate_peer_name "$target"
 
-  # Try primary scope first, then walk sibling sidecar scopes. First
-  # hit wins. The order matters: primary scope's host/peer-file lookups
-  # are local-only (cheap); sibling scopes may add an SSH round-trip
-  # per scope for the cross-peer-via-host path.
+  # Phase 2B.3 onward: only the primary scope. Sibling sidecar scopes
+  # are no longer spawned; any leftover .airc.<word> dirs have stale
+  # peer records that would resurface as ghosts (e.g. integration-test
+  # fixtures from /tmp/airc-trace2 surviving for days).
+  #
+  # Phase 2C+ TODO: cross-mesh whois resolution (ask the host for a
+  # peer record we don't have locally). Without that, indirect peers
+  # in the singleton mesh — peers paired with the host but not with
+  # us directly — return "no record". Tracked as the wart that
+  # ideem-local-4bef + continuum-b741 surfaced 2026-04-28.
   if _whois_in_scope "$AIRC_WRITE_DIR" "$target"; then
     return 0
-  fi
-
-  local parent self_base prefix sibling
-  parent=$(dirname "$AIRC_WRITE_DIR")
-  self_base=$(basename "$AIRC_WRITE_DIR")
-  # Strip a trailing .<word> to recover the primary prefix. Mirrors the
-  # detection in cmd_peers (#124) so .airc / .airc.general both resolve
-  # to .airc as the prefix; in tests we see state / state.general → state.
-  prefix=$(printf '%s' "$self_base" | sed -E 's/\.[a-z0-9-]+$//')
-  if [ -d "$parent" ]; then
-    for sibling in "$parent/$prefix" "$parent/$prefix".*; do
-      [ -d "$sibling" ] || continue
-      [ "$sibling" = "$AIRC_WRITE_DIR" ] && continue
-      [ -f "$sibling/config.json" ] || continue
-      if _whois_in_scope "$sibling" "$target"; then
-        return 0
-      fi
-    done
   fi
 
   echo "  whois: no record for '$target' (try airc peers to list paired peers)"

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -387,47 +387,23 @@ else:
     return
   fi
 
-  # Walk scopes that count as "subscribed rooms" for this tab: primary
-  # (current AIRC_WRITE_DIR) plus any sibling sidecar scopes (.airc.<room>
-  # pattern under the project scope's parent). For each, read peers/
-  # records and annotate with the scope's room_name. Same peer in both
-  # scopes folds into one line with both room tags.
+  # Phase 2B.3 onward: walk ONLY the primary scope. Sibling sidecar
+  # scopes (.airc.<room>) are no longer spawned; any leftover dirs are
+  # detritus from pre-2B.3 runs and contain stale peer records (e.g.
+  # the integration-test 'tr' peer from /tmp/airc-trace2 surfacing
+  # months later). Walking them was useful when sidecars were live;
+  # post-2B.3 it just resurfaces ghosts.
   #
-  # Intent (issue #121 follow-up): multi-room presence shouldn't fragment
-  # the operator's view of "who am I connected to" into separate per-scope
-  # listings. From the user's perspective they're in N rooms; airc peers
-  # should reflect that as one unified roster with room context per peer.
+  # The unified-roster intent from issue #121 still holds, but in the
+  # singleton-mesh world EVERY peer is in the primary scope's peers/.
+  # Multi-channel context comes from envelope.channel (Phase 2A) +
+  # subscribed_channels (Phase 2B), not from sibling scopes.
   "$AIRC_PYTHON" -c "
 import json, os, sys, re
 
 primary_scope = os.path.expanduser('$AIRC_WRITE_DIR')
-parent = os.path.dirname(primary_scope)
-self_basename = os.path.basename(primary_scope)
-
-# Prefix detection: a sidecar scope is named like \`<prefix>.<room>\`
-# (e.g. .airc.general). Strip a trailing .<word> to recover the
-# primary scope's basename. Works for both production layout
-# (.airc / .airc.general) and test ad-hoc paths (state / state.general)
-# without baking in the .airc literal.
-prefix_match = re.match(r'(.+?)\.[a-z0-9-]+\$', self_basename)
-prefix = prefix_match.group(1) if prefix_match else self_basename
-
-# Collect: the primary scope itself, plus every sibling whose name is
-# <prefix>.<something>. We additionally require room_name + peers/ on
-# each candidate so unrelated dirs in the same parent (e.g. .airc-old,
-# .airc.bak) don't pollute the listing.
-candidates = []
-if os.path.isdir(parent):
-    for entry in sorted(os.listdir(parent)):
-        if entry == prefix or entry.startswith(prefix + '.'):
-            candidates.append(os.path.join(parent, entry))
-scopes = [s for s in candidates
-          if os.path.isfile(os.path.join(s, 'room_name'))
-          and os.path.isdir(os.path.join(s, 'peers'))]
-# Always include primary even if it doesn't have room_name yet — that's
-# the legacy 1:1 invite mode case (use_room=0).
-if primary_scope not in scopes and os.path.isdir(os.path.join(primary_scope, 'peers')):
-    scopes.insert(0, primary_scope)
+# Phase 2B.3: only walk the primary scope. Sidecar scopes are gone.
+scopes = [primary_scope] if os.path.isdir(os.path.join(primary_scope, 'peers')) else []
 
 # Build {(name, host): [room1, room2, ...]} by walking each scope's peers/.
 peers_by_id = {}

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2173,167 +2173,6 @@ JSON
 # scope, merging peer records by (name, host) and tagging each peer with
 # the rooms they're in. Same peer in both rooms shows as one line with
 # [#room1, #room2].
-scenario_peers_cross_scope() {
-  section "peers_cross_scope: airc peers aggregates across primary + sidecar scopes"
-  cleanup_all
-
-  local primary=/tmp/airc-it-pcs/state
-  local sidecar=/tmp/airc-it-pcs/state.general
-  mkdir -p "$primary/identity" "$primary/peers" "$sidecar/identity" "$sidecar/peers"
-  ssh-keygen -t ed25519 -f "$primary/identity/ssh_key" -N '' -q -C 'pcs-primary' 2>/dev/null
-  ssh-keygen -t ed25519 -f "$sidecar/identity/ssh_key" -N '' -q -C 'pcs-sidecar' 2>/dev/null
-  cat > "$primary/config.json" <<'JSON'
-{ "name": "alpha" }
-JSON
-  cat > "$sidecar/config.json" <<'JSON'
-{ "name": "alpha" }
-JSON
-  echo "myproject" > "$primary/room_name"
-  echo "general" > "$sidecar/room_name"
-
-  # Peer records: 'shared' is in both scopes; 'projonly' only in primary;
-  # 'lobbyonly' only in sidecar. Verifies merge + per-scope tagging.
-  cat > "$primary/peers/shared.json" <<'JSON'
-{"name":"shared","host":"joel@10.0.0.1","ssh_pub":"ssh-ed25519 AAAA"}
-JSON
-  cat > "$primary/peers/projonly.json" <<'JSON'
-{"name":"projonly","host":"joel@10.0.0.2","ssh_pub":"ssh-ed25519 BBBB"}
-JSON
-  cat > "$sidecar/peers/shared.json" <<'JSON'
-{"name":"shared","host":"joel@10.0.0.1","ssh_pub":"ssh-ed25519 AAAA"}
-JSON
-  cat > "$sidecar/peers/lobbyonly.json" <<'JSON'
-{"name":"lobbyonly","host":"joel@10.0.0.3","ssh_pub":"ssh-ed25519 CCCC"}
-JSON
-
-  local out
-  out=$(AIRC_HOME="$primary" "$AIRC" peers 2>&1)
-
-  echo "$out" | grep -qE 'shared.*joel@10.0.0.1.*\[#myproject.*#general\]|shared.*joel@10.0.0.1.*\[#general.*#myproject\]' \
-    && pass "shared peer shows tagged with BOTH rooms" \
-    || fail "shared peer missing dual-room tag (got: $(echo "$out" | grep shared))"
-
-  echo "$out" | grep -qE 'projonly.*joel@10.0.0.2.*\[#myproject\]' \
-    && pass "primary-only peer tagged with #myproject" \
-    || fail "projonly peer missing primary tag (got: $(echo "$out" | grep projonly))"
-
-  echo "$out" | grep -qE 'lobbyonly.*joel@10.0.0.3.*\[#general\]' \
-    && pass "sidecar-only peer visible from primary scope, tagged with #general" \
-    || fail "lobbyonly peer NOT visible from primary scope (got: $(echo "$out" | grep lobbyonly))"
-
-  # Same query from the sidecar scope should return the same merged set
-  # (operator perspective shouldn't change based on which scope they
-  # happen to invoke from).
-  local out2
-  out2=$(AIRC_HOME="$sidecar" "$AIRC" peers 2>&1)
-  echo "$out2" | grep -qE 'projonly' \
-    && pass "from sidecar scope: still sees primary-only peer" \
-    || fail "from sidecar scope: lost primary-only peer (got: $(echo "$out2" | head -3))"
-
-  rm -rf /tmp/airc-it-pcs
-  cleanup_all
-}
-
-# ── Scenario: whois_cross_scope (issue #134) ───────────────────────────
-# Pre-fix: cmd_whois only consulted the primary scope. A peer who
-# was paired in the #general sidecar but not in the primary project
-# room returned "no record" — even though airc peers (post-#124)
-# already showed them. JOIN events in the sidecar emitted names
-# whois couldn't resolve.
-#
-# Post-fix: cmd_whois walks sibling scopes (.airc + .airc.<room>)
-# and tries each scope's host / local-peer / cross-peer-via-host
-# lookups. First hit wins; "no record" only after exhausting all.
-#
-# Test exercises the local-peer path in sibling scope (the SSH-based
-# cross-peer path is symmetric in code and covered by scenario_whois
-# at the primary scope). Also verifies sibling-scope HOST lookup
-# works — whois on the sidecar's host name should pull host_identity
-# out of the sidecar's config.json rather than 404.
-scenario_whois_cross_scope() {
-  section "whois_cross_scope: airc whois walks sibling scopes (issue #134)"
-  cleanup_all
-
-  local primary=/tmp/airc-it-wcs/state
-  local sidecar=/tmp/airc-it-wcs/state.general
-  mkdir -p "$primary/identity" "$primary/peers" "$sidecar/identity" "$sidecar/peers"
-  ssh-keygen -t ed25519 -f "$primary/identity/ssh_key" -N '' -q -C 'wcs-primary' 2>/dev/null
-  ssh-keygen -t ed25519 -f "$sidecar/identity/ssh_key" -N '' -q -C 'wcs-sidecar' 2>/dev/null
-  # Primary scope: paired with phost in #myproject. No fellow joiners.
-  cat > "$primary/config.json" <<'JSON'
-{
-  "name": "alpha",
-  "host_name": "phost",
-  "host_target": "joel@10.0.0.1",
-  "host_identity": {"pronouns":"they","role":"primary-host","bio":"primary host bio"}
-}
-JSON
-  echo "myproject" > "$primary/room_name"
-  # Sidecar scope: paired with shost in #general. Fellow joiner 'lobbymate'.
-  cat > "$sidecar/config.json" <<'JSON'
-{
-  "name": "alpha",
-  "host_name": "shost",
-  "host_target": "joel@10.0.0.2",
-  "host_identity": {"pronouns":"she","role":"general-host","bio":"general host bio"}
-}
-JSON
-  echo "general" > "$sidecar/room_name"
-  cat > "$sidecar/peers/lobbymate.json" <<'JSON'
-{"name":"lobbymate","host":"joel@10.0.0.99","ssh_pub":"ssh-ed25519 AAAA",
- "identity":{"pronouns":"they","role":"fellow-joiner","bio":"in general only"}}
-JSON
-
-  local out
-  # ── from primary scope: sidecar peer should resolve ────────────────
-  out=$(AIRC_HOME="$primary" "$AIRC" whois lobbymate 2>&1)
-  echo "$out" | grep -q "role: *fellow-joiner" \
-    && pass "primary scope finds sidecar-only peer (role)" \
-    || fail "primary scope didn't find sidecar peer (got: $out)"
-  echo "$out" | grep -q "bio: *in general only" \
-    && pass "primary scope finds sidecar-only peer (bio)" \
-    || fail "primary scope sidecar peer missing bio (got: $out)"
-
-  # ── from primary scope: sidecar HOST should resolve ────────────────
-  # shost is the host of the sidecar's #general — primary scope's
-  # host_name is phost, so the lookup must walk into sidecar's config
-  # and read host_identity from there.
-  out=$(AIRC_HOME="$primary" "$AIRC" whois shost 2>&1)
-  echo "$out" | grep -q "role: *general-host" \
-    && pass "primary scope finds sidecar host via cross-scope walk" \
-    || fail "primary scope didn't resolve sidecar host (got: $out)"
-
-  # ── from primary scope: primary host still resolves (no regression)
-  out=$(AIRC_HOME="$primary" "$AIRC" whois phost 2>&1)
-  echo "$out" | grep -q "role: *primary-host" \
-    && pass "primary scope still resolves primary host (no regression)" \
-    || fail "primary host lookup regressed (got: $out)"
-
-  # ── from primary scope: unknown peer still graceful ────────────────
-  out=$(AIRC_HOME="$primary" "$AIRC" whois ghost-zzz 2>&1 || true)
-  echo "$out" | grep -q "no record for 'ghost-zzz'" \
-    && pass "unknown peer still 404s after walking all scopes" \
-    || fail "unknown peer error message regressed (got: $out)"
-
-  # ── from sidecar scope: same merged view (operator perspective) ────
-  out=$(AIRC_HOME="$sidecar" "$AIRC" whois phost 2>&1)
-  echo "$out" | grep -q "role: *primary-host" \
-    && pass "sidecar scope finds primary host (symmetric walk)" \
-    || fail "sidecar scope didn't resolve primary host (got: $out)"
-
-  rm -rf /tmp/airc-it-wcs
-  cleanup_all
-}
-
-# ── Scenario: part_keeps_sidecar (IRC /part semantics) ──────────────────
-# Pre-fix: `airc part` from the primary scope called cmd_teardown which
-# (post-#122) cleaned both primary AND sidecar scopes — so leaving
-# #useideem also dropped #general unintentionally. IRC convention is
-# /part leaves ONE channel; the lobby should persist.
-#
-# Post-fix: cmd_part sets AIRC_TEARDOWN_PART_ONLY=1 before calling
-# cmd_teardown, which makes cmd_teardown skip the sidecar cleanup
-# block. Sidecar process + gist + scope dir survive.
 scenario_part_keeps_sidecar() {
   section "part_keeps_sidecar: airc part leaves project room only, #general sidecar lives"
   cleanup_all
@@ -2919,15 +2758,12 @@ case "$MODE" in
   connect_after_kill_recovers) scenario_connect_after_kill_recovers ;;
   general_sidecar_default) scenario_general_sidecar_default ;;
   send_room_flag) scenario_send_room_flag ;;
-  peers_cross_scope) scenario_peers_cross_scope ;;
-  whois_cross_scope) scenario_whois_cross_scope ;;
   part_keeps_sidecar) scenario_part_keeps_sidecar ;;
   part_persists) scenario_part_persists ;;
   away) scenario_away ;;
   list) scenario_list ;;
   quit) scenario_quit ;;
   platform_adapters) scenario_platform_adapters ;;
-  all)          scenario_tabs; scenario_scope; scenario_reminder; scenario_teardown; scenario_resilience; scenario_reconnect; scenario_queue; scenario_status; scenario_auth_failure; scenario_room; scenario_events; scenario_get_host; scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat; scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope; scenario_send_dead_monitor_dies; scenario_connect_after_kill_recovers; scenario_general_sidecar_default; scenario_send_room_flag; scenario_peers_cross_scope; scenario_whois_cross_scope; scenario_part_keeps_sidecar; scenario_part_persists; scenario_away; scenario_list; scenario_quit; scenario_platform_adapters ;;
   *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|send_room_flag|peers_cross_scope|whois_cross_scope|part_keeps_sidecar|part_persists|away|list|quit|platform_adapters|all]"; exit 2 ;;
 esac
 


### PR DESCRIPTION
Post-Phase-2B.3 the .airc.<word> dirs aren't maintained but cmd_peers/whois still walked them, surfacing ghost peers (e.g. integration-test 'tr' from /tmp/airc-trace2). Now only walks primary. Phase 2C+ TODO: cross-mesh whois via host. Test scenarios for the deleted walk also removed.