### PR TITLE
fix(ux): cmd_kick accepts @peer; identity link is honest about unlink semantics

### DIFF
--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -174,12 +174,21 @@ c = json.load(open(os.environ["CONFIG"]))
 ints = c.setdefault("identity", {}).setdefault("integrations", {})
 platform = os.environ["PLATFORM"]
 handle = os.environ.get("HANDLE", "").strip()
+prev = ints.get(platform)
 if handle:
     ints[platform] = handle
-    print(f"  linked: {platform} -> {handle}")
-else:
+    if prev and prev != handle:
+        print(f"  linked: {platform} -> {handle} (was: {prev})")
+    else:
+        print(f"  linked: {platform} -> {handle}")
+elif prev:
+    # QA-pass clarification 2026-04-28: be explicit about "you said
+    # link but I unlinked" — happens when user omits the handle.
     ints.pop(platform, None)
-    print(f"  unlinked: {platform}")
+    print(f"  unlinked: {platform} (was: {prev}; pass a handle to (re)link)")
+else:
+    # Nothing was linked. Be explicit instead of saying "unlinked" for a no-op.
+    print(f"  no {platform} integration to unlink. Pass a handle to link: airc identity link {platform} <handle>")
 json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
 '
 }

--- a/lib/airc_bash/cmd_kick.sh
+++ b/lib/airc_bash/cmd_kick.sh
@@ -27,11 +27,16 @@ cmd_kick() {
   local target="${1:-}"
   case "$target" in
     -h|--help|"")
-      echo "Usage: airc kick <peer> [reason]"
+      echo "Usage: airc kick <peer> [reason]   (or: airc kick @peer)"
       echo "  Host-only. Removes peer's SSH pubkey + peer file."
       [ -z "$target" ] && return 1
       return 0 ;;
   esac
+  # Accept @-prefix for parity with `airc msg @peer`. QA pass found
+  # the @-rejection inconsistent — users who write @ for DM naturally
+  # write @ for kick. Strip BEFORE validation; the rest of the function
+  # uses $target (not $1).
+  target="${target#@}"
   _validate_peer_name "$target"
   shift || true
   local reason="${*:-no reason given}"


### PR DESCRIPTION
Two QA bugs (#7 + #8). cmd_kick now strips @ for parity with msg; identity link's no-handle path is explicit about whether anything was actually unlinked.