### PR TITLE
fix(argv): -h/--help intercept on cmd_peers/disconnect/quit/invite/version/ping/tests (round 2)

### DIFF
--- a/airc
+++ b/airc
@@ -1596,10 +1596,10 @@ case "${1:-help}" in
   kick)      shift; cmd_kick "$@" ;;
   reminder)  shift; cmd_reminder "$@" ;;
   peers)     shift; cmd_peers "$@" ;;
-  invite|share|join-string) cmd_invite ;;
+  invite|share|join-string) shift; cmd_invite "$@" ;;
   rooms|list|ls) shift; cmd_rooms "$@" ;;
   part) shift; cmd_part "$@" ;;
-  version|--version|-v) cmd_version ;;
+  version|--version|-v) shift; cmd_version "$@" ;;
   update|upgrade|pull) shift; cmd_update "$@" ;;
   channel) shift; cmd_channel "$@" ;;
   canary) shift; cmd_update --channel canary "$@" ;;
@@ -1609,7 +1609,7 @@ case "${1:-help}" in
   tests|test)        shift; _doctor_run_tests "$@" ;;
   daemon|autostart|service) shift; cmd_daemon "$@" ;;
   teardown|stop|flush) shift; cmd_teardown "$@" ;;
-  disconnect|quit|leave|unbind) cmd_disconnect ;;
+  disconnect|quit|leave|unbind) shift; cmd_disconnect "$@" ;;
   monitor)   shift; monitor "$@" ;;
   debug-scope) echo "$AIRC_WRITE_DIR" ;;
   debug-name)  resolve_name ;;

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -437,6 +437,14 @@ _doctor_run_tests() {
   # Behavioral suite -- the prior cmd_doctor entry point. Kept reachable
   # via `airc doctor --tests` (or the `tests`/`test` aliases in dispatch)
   # so existing CI / muscle memory still works.
+  case "${1:-}" in
+    -h|--help)
+      echo "Usage:"
+      echo "  airc tests              run the full integration suite"
+      echo "  airc tests <scenario>   run one scenario (see test/integration.sh)"
+      echo "  airc doctor --tests     same as 'airc tests'"
+      return 0 ;;
+  esac
   local script="${AIRC_DIR:-$HOME/.airc-src}/test/integration.sh"
   if [ ! -x "$script" ]; then
     local self; self="$(realpath "$0" 2>/dev/null || echo "$0")"

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -309,6 +309,13 @@ cmd_send_file() {
 }
 
 cmd_invite() {
+  case "${1:-}" in
+    -h|--help)
+      echo "Usage:"
+      echo "  airc invite             print cross-account share invite (one-time pairing string)"
+      echo "  airc share / join-string  aliases"
+      return 0 ;;
+  esac
   ensure_init
   local host_target pubkey_b64 join_string
   host_target=$(get_config_val host_target "")
@@ -356,6 +363,13 @@ cmd_invite() {
 }
 
 cmd_peers() {
+  case "${1:-}" in
+    -h|--help)
+      echo "Usage:"
+      echo "  airc peers              list paired peers in primary scope"
+      echo "  airc peers --prune      remove stale dup records (same host, older paired)"
+      return 0 ;;
+  esac
   ensure_init
   # `airc peers --prune` — remove stale records that share a host with a
   # newer record (cruft left from rename chain-breaks before the stable-host

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -354,6 +354,13 @@ cmd_send() {
 #   airc ping @peer 30        # 30s timeout
 cmd_ping() {
   local first="${1:-}"
+  case "$first" in
+    -h|--help)
+      echo "Usage:"
+      echo "  airc ping @peer                liveness probe (default 10s timeout)"
+      echo "  airc ping @peer <timeout>      override timeout (positive integer seconds)"
+      return 0 ;;
+  esac
   [ -z "$first" ] && die "Usage: airc ping @peer [timeout_secs]"
   case "$first" in
     @*) ;;

--- a/lib/airc_bash/cmd_teardown.sh
+++ b/lib/airc_bash/cmd_teardown.sh
@@ -262,6 +262,13 @@ cmd_disconnect() {
   # args) starts fresh host mode instead of auto-resuming the prior pairing.
   # Use when you want to switch to a different mesh or host a new one, but
   # keep your agent identity stable.
+  case "${1:-}" in
+    -h|--help)
+      echo "Usage:"
+      echo "  airc disconnect / quit    leave the mesh: kill processes + clear host pairing"
+      echo "                            (identity, peers, message history preserved)"
+      return 0 ;;
+  esac
   cmd_teardown >/dev/null 2>&1 || true
   if [ -f "$CONFIG" ]; then
     "$AIRC_PYTHON" -c "

--- a/lib/airc_bash/cmd_update.sh
+++ b/lib/airc_bash/cmd_update.sh
@@ -199,6 +199,13 @@ cmd_channel() {
 }
 
 cmd_version() {
+  case "${1:-}" in
+    -h|--help)
+      echo "Usage:"
+      echo "  airc version            print git rev + branch + install path"
+      echo "  airc -v / --version     aliases"
+      return 0 ;;
+  esac
   # Report git state for whichever airc actually ran. Prefer the binary's
   # own directory so a dev-checkout run doesn't lie about AIRC_DIR.
   local self; self="$(realpath "$0" 2>/dev/null || echo "$0")"


### PR DESCRIPTION
continuum-b741 verb-fuzz round 2 found 6 verbs missed by #237's sweep — including 'airc disconnect/quit --help' which actually EXECUTED. Fixes both function-level intercepts AND the no-args dispatch branches in airc top-level.