### PR TITLE
feat(identity): bootstrap nudge in binary on first join (closes #146)

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -805,6 +805,11 @@ cmd_connect() {
           --config "$CONFIG" --channel "$resolved_room_name" 2>/dev/null || true
         echo "  Joined mesh — host primarily labels #${resolved_room_name}; subscribed: #${_intent} (default), #${resolved_room_name}"
       fi
+      # Identity bootstrap nudge (#146). Skill /join SKILL.md prompts
+      # AIs to set pronouns/role/bio at first join, but users running
+      # airc directly (no skill) never get the prompt and end up with
+      # all-(unset) whois forever. Code-level one-time nudge here.
+      _identity_bootstrap_nudge_if_unset || true
     fi
 
     # Exchange keys with host via TCP (port 7547) — public keys only

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -92,6 +92,39 @@ cmd_identity() {
   esac
 }
 
+# Identity bootstrap nudge (#146). Called once after a successful
+# `airc connect` join. If pronouns/role/bio are all (unset), print a
+# one-time prompt encouraging the user to set them. Idempotent: the
+# nudge file under $AIRC_WRITE_DIR/.identity_nudged_v1 records that
+# we've nudged, so we don't nag every reconnect. The skill /join can
+# still drive interactive bootstrap; this is the binary-side fallback
+# for users running airc directly.
+_identity_bootstrap_nudge_if_unset() {
+  local nudge_file="$AIRC_WRITE_DIR/.identity_nudged_v1"
+  [ -f "$nudge_file" ] && return 0
+  CONFIG="$CONFIG" "$AIRC_PYTHON" -c '
+import json, os, sys
+try:
+    c = json.load(open(os.environ["CONFIG"]))
+except Exception:
+    sys.exit(0)
+ident = c.get("identity", {}) or {}
+unset = [k for k in ("pronouns", "role", "bio") if not ident.get(k)]
+if len(unset) == 3:
+    sys.exit(2)  # all three unset → nudge
+sys.exit(0)
+' || {
+    if [ "$?" = "2" ]; then
+      echo ""
+      echo "  Tip: set your identity so peers know who they are talking to. One-line example:"
+      echo "    airc identity set --pronouns they --role 'your role' --bio 'one-sentence bio'"
+      echo "  Done? Suppress this nudge: touch $nudge_file"
+      echo ""
+    fi
+  }
+  : > "$nudge_file" 2>/dev/null || true
+}
+
 _identity_show() {
   CONFIG="$CONFIG" "$AIRC_PYTHON" -c '
 import json, os

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -44,6 +44,21 @@ cmd_status() {
     echo "  identity:    $my_name (hosting on port ${my_port})"
   fi
 
+  # Channel participation (#149). Post-Phase-2B.3 the canonical source
+  # is config.json's subscribed_channels; first element is the default
+  # channel that cmd_send stamps. Display the list with a marker for
+  # the default.
+  local _channels; _channels=$("$AIRC_PYTHON" -m airc_core.config read_channels --config "$CONFIG" 2>/dev/null)
+  if [ -n "$_channels" ]; then
+    local _default; _default=$(echo "$_channels" | head -1)
+    local _rest; _rest=$(echo "$_channels" | tail -n +2 | tr '\n' ',' | sed 's/,$//' | sed 's/,/, #/g')
+    if [ -n "$_rest" ]; then
+      echo "  channels:    #${_default} (default), #${_rest}"
+    else
+      echo "  channels:    #${_default}"
+    fi
+  fi
+
   # Monitor alive? Read the scope's pidfile — cmd_connect writes its own PID
   # there. pgrep'd descendants (python listener, tail loop) should be children
   # of that PID. If the main PID is gone, the monitor is down.


### PR DESCRIPTION
Skill drives bootstrap; binary now also nudges on first join when all of pronouns/role/bio are unset. Idempotent via sentinel file.