### PR TITLE
fix(ci): TEST-NET-2 instead of 127.0.0.99 for unreachable-host fixtures

### DIFF
--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -65,12 +65,20 @@ cmd_rooms() {
   # rolled over yet, plus single-pair invites (`airc invite for`) for
   # cross-account ad-hoc pairing.
   # gh gist list columns: id  description  files  visibility  updated_at
-  local raw; raw=$(gh gist list --limit 50 2>/dev/null \
+  #
+  # CI fix: airc has \`set -euo pipefail\` at the top. \`gh gist list\` exits
+  # 4 when not authed; under pipefail that propagates and -e aborts the
+  # script with rc=4. The integration suite's scenario_list saw
+  # 'airc list crashed (rc=4)'. Tolerate gh's nonzero exit explicitly:
+  # capture stderr to /dev/null, OR-true the pipeline so an unauthed
+  # gh produces empty raw (which the count=0 branch handles cleanly).
+  local raw=""
+  raw=$( { gh gist list --limit 50 2>/dev/null || true; } \
     | awk -F'\t' '
         /airc mesh/         { print "mesh\t"   $1 "\t" $2 "\t" $5 }
         /airc room:/        { print "room\t"   $1 "\t" $2 "\t" $5 }
         /airc invite for/   { print "invite\t" $1 "\t" $2 "\t" $5 }
-      ')
+      ' || true)
   local count; count=$(printf '%s' "$raw" | grep -c . || true)
   if [ "$count" = "0" ]; then
     echo "  No open airc rooms or invites on your gh account."

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -250,12 +250,12 @@ scenario_tabs() {
   python3 -c "
 import json
 c = json.load(open('$fake_home/state/config.json'))
-c['host_target'] = 'nobody@127.0.0.99'
+c['host_target'] = 'nobody@198.51.100.99'
 c['host_airc_home'] = '/tmp/nowhere'
 json.dump(c, open('$fake_home/state/config.json', 'w'))
 "
   # Write a fake peer so resolution doesn't fail
-  echo '{"name":"ghost","host":"nobody@127.0.0.99","airc_home":"/tmp/nowhere"}' > "$fake_home/state/peers/ghost.json"
+  echo '{"name":"ghost","host":"nobody@198.51.100.99","airc_home":"/tmp/nowhere"}' > "$fake_home/state/peers/ghost.json"
   AIRC_HOME=$fake_home/state "$AIRC" send @ghost "this-should-fail-but-still-mirror" >/dev/null 2>&1
   # Exit should be non-zero (we die()), but local must have both the attempt AND the failure marker
   grep -q '"this-should-fail-but-still-mirror"' "$fake_home/state/messages.jsonl" 2>/dev/null && \
@@ -619,11 +619,11 @@ scenario_queue() {
 import json
 p = '/tmp/airc-it-q-j/state/config.json'
 c = json.load(open(p))
-c['host_target'] = 'nobody@127.0.0.99'
+c['host_target'] = 'nobody@198.51.100.99'
 json.dump(c, open(p, 'w'))
 "
   # Also fake the peer record so resolution doesn't fail on @qhost
-  echo '{"name":"qhost","host":"nobody@127.0.0.99","airc_home":"/tmp/nowhere"}' \
+  echo '{"name":"qhost","host":"nobody@198.51.100.99","airc_home":"/tmp/nowhere"}' \
     > /tmp/airc-it-q-j/state/peers/qhost.json
   pass "joiner: host_target flipped to unreachable (outage simulation)"
 
@@ -714,10 +714,10 @@ import json
 p = '/tmp/airc-it-s-j/state/config.json'
 c = json.load(open(p))
 c['_real_host_target'] = c['host_target']
-c['host_target'] = 'nobody@127.0.0.99'
+c['host_target'] = 'nobody@198.51.100.99'
 json.dump(c, open(p, 'w'))
 "
-  echo '{"name":"shost","host":"nobody@127.0.0.99","airc_home":"/tmp/nowhere"}' > /tmp/airc-it-s-j/state/peers/shost.json
+  echo '{"name":"shost","host":"nobody@198.51.100.99","airc_home":"/tmp/nowhere"}' > /tmp/airc-it-s-j/state/peers/shost.json
   AIRC_HOME=/tmp/airc-it-s-j/state "$AIRC" send @shost "status-queue-probe" >/dev/null 2>&1 || true
   local j_out3; j_out3=$(AIRC_HOME=/tmp/airc-it-s-j/state "$AIRC" status 2>&1)
   echo "$j_out3" | grep -Eq 'queue:\s+[1-9][0-9]* pending' \


### PR DESCRIPTION
127.0.0.99 is routed loopback on Linux; CI runners with localhost sshd hit auth-fail path → die. 198.51.100.99 (RFC 5737 test range) is non-routable everywhere → ssh times out → queue branch fires as intended.