### PR TITLE
refactor(deps): remove jq dependency, route through airc_core.gistparse (closes #188)

### DIFF
--- a/airc
+++ b/airc
@@ -869,13 +869,16 @@ host_addresses_json() {
 peer_pick_address() {
   local addresses_json="${1:-}" host_machine="${2:-}"
   [ -z "$addresses_json" ] || [ "$addresses_json" = "null" ] && return 0
-  command -v jq >/dev/null 2>&1 || return 0
+
+  # #188: parse via airc_core.gistparse (Python stdlib JSON) instead of
+  # jq. Eliminates the jq hard dep — Python is already required for the
+  # truth-layer (#152 Phase 0); jq was redundant.
 
   # Same machine: use localhost.
   local my_machine; my_machine=$(host_machine_id)
   if [ -n "$host_machine" ] && [ "$host_machine" = "$my_machine" ]; then
     local pick; pick=$(printf '%s' "$addresses_json" \
-      | jq -r '.[] | select(.scope=="localhost") | "\(.addr)|\(.port)"' 2>/dev/null | head -1)
+      | "$AIRC_PYTHON" -m airc_core.gistparse pick_addr localhost 2>/dev/null)
     if [ -n "$pick" ]; then printf '%s' "$pick"; return 0; fi
   fi
 
@@ -886,13 +889,13 @@ peer_pick_address() {
   if [ -n "$my_lan_ips" ]; then
     local lan_entries
     lan_entries=$(printf '%s' "$addresses_json" \
-      | jq -c '.[] | select(.scope=="lan")' 2>/dev/null)
+      | "$AIRC_PYTHON" -m airc_core.gistparse list_lan_entries 2>/dev/null)
     if [ -n "$lan_entries" ]; then
       while IFS= read -r entry; do
         [ -z "$entry" ] && continue
-        local subnet; subnet=$(printf '%s' "$entry" | jq -r '.subnet // empty' 2>/dev/null)
-        local addr; addr=$(printf '%s' "$entry" | jq -r '.addr' 2>/dev/null)
-        local port; port=$(printf '%s' "$entry" | jq -r '.port' 2>/dev/null)
+        local subnet; subnet=$(printf '%s' "$entry" | "$AIRC_PYTHON" -m airc_core.gistparse get .subnet 2>/dev/null)
+        local addr;   addr=$(printf '%s' "$entry"   | "$AIRC_PYTHON" -m airc_core.gistparse get .addr 2>/dev/null)
+        local port;   port=$(printf '%s' "$entry"   | "$AIRC_PYTHON" -m airc_core.gistparse get .port 2>/dev/null)
         # subnet is like "192.168.1.0/24" — match the /24 prefix against my IPs.
         if [ -n "$subnet" ]; then
           local prefix="${subnet%/*}"   # 192.168.1.0
@@ -909,14 +912,14 @@ peer_pick_address() {
   local i_have_ts; i_have_ts=$(host_address_set 0 | awk -F'|' '$1=="tailscale"{print; exit}')
   if [ -n "$i_have_ts" ]; then
     local ts_pick; ts_pick=$(printf '%s' "$addresses_json" \
-      | jq -r '.[] | select(.scope=="tailscale") | "\(.addr)|\(.port)"' 2>/dev/null | head -1)
+      | "$AIRC_PYTHON" -m airc_core.gistparse pick_addr tailscale 2>/dev/null)
     if [ -n "$ts_pick" ]; then printf '%s' "$ts_pick"; return 0; fi
   fi
 
   # Fallback: first entry of any kind. Useful when neither side has a
   # clearly matching scope and we just want to try something.
   printf '%s' "$addresses_json" \
-    | jq -r '.[0] | "\(.addr)|\(.port)"' 2>/dev/null
+    | "$AIRC_PYTHON" -m airc_core.gistparse pick_addr_first 2>/dev/null
 }
 
 # humanhash: hex string → human-readable mnemonic (e.g. "muffin-saturn-pluto-orange").

--- a/install.sh
+++ b/install.sh
@@ -117,11 +117,6 @@ pkgname_for() {
         winget) echo "GitHub.cli" ;;
         *)      echo "gh" ;;
       esac ;;
-    jq)
-      case "$mgr" in
-        winget) echo "jqlang.jq" ;;
-        *)      echo "jq" ;;
-      esac ;;
     *) echo "$prereq" ;;
   esac
 }
@@ -662,16 +657,15 @@ ensure_prereqs() {
   fi
 
   local missing=() pkgs=() unmappable=()
-  # jq added 2026-04-27: airc's gist envelope parser uses jq for the
-  # canonical path; bash bare-grep fallback handles JSON-key-prefix
-  # leak now (PR fix), but jq is the right tool — without it the
-  # fallback can't extract host.addresses[] for multi-address pick.
-  # On Git Bash, jq is winget-installable as 'jqlang.jq'.
-  for cmd in git gh jq openssl ssh-keygen python3; do
+  # #188: jq removed — airc's gist envelope parser now uses Python's
+  # stdlib JSON (lib/airc_core/gistparse.py). Python was already a hard
+  # dep since #152 Phase 0; jq was redundant. Drop the dep + the
+  # winget step that would install it.
+  for cmd in git gh openssl ssh-keygen python3; do
     # Strict probe: presence on PATH AND a successful --version invocation.
     # Used selectively: python3 needs the strict variant because Windows
     # Store's python3.exe alias is on PATH but exits 49 with a Store-
-    # redirect (continuum-b69f, 2026-04-27). git/gh/jq/openssl all
+    # redirect (continuum-b69f, 2026-04-27). git/gh/openssl all
     # support --version cleanly. ssh-keygen does NOT have a version
     # flag at all (different from `ssh -V`); calling `ssh-keygen
     # --version` exits non-zero on every install, so the strict probe

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -515,12 +515,16 @@ cmd_connect() {
       # malformed JSON `"invite": "..."` line (quotes and all), pair
       # handshake failed on garbage host info, and self-heal didn't fire
       # because resolved_room_name was never extracted via the jq path.
-      if command -v gh >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+      # #188: Python (stdlib JSON) replaces jq. gh api → gistparse extracts
+      # the first file's content. This is the rest-API path; it's preferred
+      # over the gh gist view --raw path because the latter prepends the
+      # gist description as a header line that we'd then have to strip.
+      if command -v gh >/dev/null 2>&1; then
         raw_content=$( (gh api "gists/$gist_id" 2>/dev/null \
-                        | jq -r '.files | to_entries[0].value.content // empty' 2>/dev/null) || true )
+                        | "$AIRC_PYTHON" -m airc_core.gistparse gist_content 2>/dev/null) || true )
       fi
-      # Fallback path 1: gh without jq → degraded gh gist view --raw, with
-      # a description-strip in the consumer below.
+      # Fallback path 1: gh raw view (description leak handled by the
+      # awk strip below at "head -c 1 | grep '{'" cleanup).
       if [ -z "$raw_content" ] && command -v gh >/dev/null 2>&1; then
         raw_content=$(gh gist view "$gist_id" --raw 2>/dev/null || true)
       fi
@@ -548,11 +552,11 @@ cmd_connect() {
         fi
         [ -n "$_gist_tmp" ] && rm -rf "$_gist_tmp"
       fi
-      # Fallback path 3: anonymous curl + jq for environments without gh
-      # OR git. Last resort.
-      if [ -z "$raw_content" ] && command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+      # Fallback path 3: anonymous curl + Python for environments
+      # without gh OR git. Last resort. (#188 — was curl + jq.)
+      if [ -z "$raw_content" ] && command -v curl >/dev/null 2>&1; then
         raw_content=$( (curl -fsSL "https://api.github.com/gists/$gist_id" 2>/dev/null \
-                        | jq -r '.files | to_entries[0].value.content // empty' 2>/dev/null) || true )
+                        | "$AIRC_PYTHON" -m airc_core.gistparse gist_content 2>/dev/null) || true )
       fi
       # Last-resort cleanup: if raw_content still has the description-header
       # leak from a degraded gh-view path, strip lines before the first '{'
@@ -571,17 +575,19 @@ cmd_connect() {
       # at function-scope above so the JOIN MODE check sees them on the
       # inline-invite path too (where this gist block doesn't run).
       local resolved=""
-      if command -v jq >/dev/null 2>&1; then
-        local airc_ver kind
-        airc_ver=$(printf '%s' "$raw_content" | jq -r '.airc // empty' 2>/dev/null)
-        kind=$(printf '%s' "$raw_content" | jq -r '.kind // empty' 2>/dev/null)
-        if [ -n "$airc_ver" ]; then
+      # #188: was `if command -v jq`; now Python is the truth-layer
+      # (always available since #152 Phase 0). Drop the jq gate.
+      local airc_ver kind
+      airc_ver=$(printf '%s' "$raw_content" | "$AIRC_PYTHON" -m airc_core.gistparse get .airc 2>/dev/null)
+      kind=$(printf '%s' "$raw_content" | "$AIRC_PYTHON" -m airc_core.gistparse get .kind 2>/dev/null)
+      if [ -n "$airc_ver" ]; then
           # Versioned envelope — dispatch on kind.
           case "$kind" in
             invite)
               # Single-pair invite (legacy + --no-general flow). Gist is
               # ephemeral; host deletes after pair.
-              resolved=$(printf '%s' "$raw_content" | jq -r '.invite // empty' 2>/dev/null \
+              resolved=$(printf '%s' "$raw_content" \
+                         | "$AIRC_PYTHON" -m airc_core.gistparse get .invite 2>/dev/null \
                          | head -1 | tr -d '\r\n ')
               ;;
             mesh|room)
@@ -592,18 +598,22 @@ cmd_connect() {
               # for back-compat with gists that haven't rolled to mesh
               # yet (joiner can read either). The .invite field carries
               # today's name@user@host:port#pubkey string.
-              resolved=$(printf '%s' "$raw_content" | jq -r '.invite // empty' 2>/dev/null \
+              resolved=$(printf '%s' "$raw_content" \
+                         | "$AIRC_PYTHON" -m airc_core.gistparse get .invite 2>/dev/null \
                          | head -1 | tr -d '\r\n ')
               # New mesh shape: .channels[]; legacy room shape: .name.
               # Prefer channels[0] if present; fall back to .name.
-              resolved_room_name=$(printf '%s' "$raw_content" | jq -r '.channels[0] // .name // empty' 2>/dev/null)
+              resolved_room_name=$(printf '%s' "$raw_content" \
+                         | "$AIRC_PYTHON" -m airc_core.gistparse get_first_of '.channels[0]' '.name' 2>/dev/null)
               # Multi-address: capture host.addresses[] + host.machine_id
               # for the joiner's address-picker (peer_pick_address). Empty
               # if the host published a pre-multi-address envelope; in
               # that case JOIN MODE falls back to the parsed-from-invite
               # host:port (legacy single-address path).
-              _resolved_addresses_json=$(printf '%s' "$raw_content" | jq -c '.host.addresses // empty' 2>/dev/null)
-              _resolved_host_machine_id=$(printf '%s' "$raw_content" | jq -r '.host.machine_id // empty' 2>/dev/null)
+              _resolved_addresses_json=$(printf '%s' "$raw_content" \
+                         | "$AIRC_PYTHON" -m airc_core.gistparse get_json .host.addresses 2>/dev/null)
+              _resolved_host_machine_id=$(printf '%s' "$raw_content" \
+                         | "$AIRC_PYTHON" -m airc_core.gistparse get .host.machine_id 2>/dev/null)
 
               # Heartbeat freshness check — the structural fix for
               # orphan-gist class. Hosts update last_heartbeat every
@@ -616,7 +626,7 @@ cmd_connect() {
               # compat; their hosts will get caught by the existing
               # SSH-failure self-heal path at line ~1850.
               local _hb_iso _hb_ts _now_ts _hb_stale_sec
-              _hb_iso=$(printf '%s' "$raw_content" | jq -r '.last_heartbeat // empty' 2>/dev/null)
+              _hb_iso=$(printf '%s' "$raw_content" | "$AIRC_PYTHON" -m airc_core.gistparse get .last_heartbeat 2>/dev/null)
               _hb_stale_sec="${AIRC_HEARTBEAT_STALE:-90}"
               if [ -n "$_hb_iso" ]; then
                 # Cross-platform ISO→epoch via the iso_to_epoch adapter.
@@ -642,11 +652,11 @@ cmd_connect() {
               die "Gist uses unknown kind '$kind' (airc v$airc_ver). This receiver only supports 'invite', 'room', and 'mesh'. Update airc: 'airc update'."
               ;;
           esac
-        fi
       fi
       if [ -z "$resolved" ]; then
-        # Legacy raw-string format OR jq missing — take the first
-        # non-empty line that looks like an invite.
+        # Legacy raw-string format (pre-#222 envelope shape) — take the
+        # first non-empty line that looks like an invite. Still needed
+        # for cross-account paste of a hand-built invite without JSON.
         resolved=$(printf '%s' "$raw_content" | grep -E '@.*@' | head -1 | tr -d '\r\n ')
         # If the matched line is from a JSON envelope (e.g.
         # `"invite": "name@user@host:port#..."`), the grep grabs the

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -50,7 +50,6 @@ cmd_doctor() {
   _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"     || issues=$((issues+1))
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"     || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"    || issues=$((issues+1))
-  _doctor_probe "jq"           "$mgr" "Gist envelope parser (rooms, addresses)" || issues=$((issues+1))
   _doctor_probe_sshd                                                    || issues=$((issues+1))
   _doctor_probe_tailscale "$mgr"  # optional, never increments issues
 
@@ -341,7 +340,6 @@ _doctor_connect_preflight() {
   _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"    || issues=$((issues+1))
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"    || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"   || issues=$((issues+1))
-  _doctor_probe "jq"           "$mgr" "Gist envelope parser (rooms, addresses)" || issues=$((issues+1))
   _doctor_probe_sshd                                                   || issues=$((issues+1))
 
   # ── gh chain: installed → authed → gist scope → gists API reachable.

--- a/lib/airc_core/gistparse.py
+++ b/lib/airc_core/gistparse.py
@@ -1,0 +1,253 @@
+"""airc gist-envelope + address-array parser. Replaces jq dependency.
+
+Two clusters of jq usage existed (issue #188):
+
+1. **Address filtering** (airc top-level host_address_set): the gist's
+   `host.addresses` is a JSON list of `{scope, addr, port, [subnet]}`
+   records. We pick the best entry per scope (localhost / lan /
+   tailscale) for the joiner's connection-attempt order.
+
+2. **Envelope field extraction** (cmd_connect.sh discovery + parse):
+   read the gist content JSON to extract `.airc`, `.kind`, `.invite`,
+   `.channels[0]`, `.host.machine_id`, `.host.addresses`, `.last_heartbeat`,
+   etc.
+
+Both go through this one Python module via subcommands. Bash callers
+pipe the JSON in on stdin and pass a path/selector via flags.
+
+Path syntax (subset of jq):
+  .foo            → nested object key
+  .foo.bar        → multi-level
+  .foo[0]         → first array element
+  .foo[0].bar     → mixed
+  .[0]            → top-level first element
+
+CLI:
+  python -m airc_core.gistparse get [--default ""] <path>          (stdin → value or default)
+  python -m airc_core.gistparse get_json <path>                    (stdin → compact JSON)
+  python -m airc_core.gistparse pick_addr <scope>                  (stdin = host.addresses list)
+  python -m airc_core.gistparse pick_addr_first                    (stdin = host.addresses list, .[0])
+  python -m airc_core.gistparse list_lan_entries                   (stdin = host.addresses list)
+
+Each subcommand returns "" + exit 0 on missing field — bash callers
+read stdout into a local var. Errors (malformed JSON, etc.) also
+exit 0 with empty output unless --strict is passed; jq's behavior was
+quiet-and-empty for malformed input and we preserve that.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+
+_PATH_TOKEN = re.compile(r"""
+    \.                       # literal dot
+    (?:
+        (?P<key>[A-Za-z_][A-Za-z0-9_-]*)
+        (?:\[(?P<idx>\d+)\])?
+        |
+        \[(?P<top_idx>\d+)\]   # leading .[0]
+    )
+""", re.VERBOSE)
+
+
+def _navigate(data, path: str):
+    """Walk `data` per a dotted/indexed path. Returns None on miss."""
+    if not path or path == ".":
+        return data
+    pos = 0
+    while pos < len(path):
+        m = _PATH_TOKEN.match(path, pos)
+        if not m:
+            return None
+        if m.group("top_idx") is not None:
+            idx = int(m.group("top_idx"))
+            if not isinstance(data, list) or idx >= len(data):
+                return None
+            data = data[idx]
+        else:
+            key = m.group("key")
+            if not isinstance(data, dict):
+                return None
+            data = data.get(key)
+            if m.group("idx") is not None and data is not None:
+                idx = int(m.group("idx"))
+                if not isinstance(data, list) or idx >= len(data):
+                    return None
+                data = data[idx]
+            if data is None:
+                return None
+        pos = m.end()
+    return data
+
+
+def _read_stdin_json():
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return None
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def _emit(value, default=""):
+    """Print value the way jq -r would: string scalars unquoted, dict/list
+    as compact JSON, missing → default."""
+    if value is None:
+        print(default)
+    elif isinstance(value, (dict, list)):
+        print(json.dumps(value, separators=(",", ":")))
+    elif isinstance(value, bool):
+        print("true" if value else "false")
+    else:
+        print(value)
+
+
+def cmd_get(args) -> int:
+    data = _read_stdin_json()
+    if data is None:
+        print(args.default)
+        return 0
+    _emit(_navigate(data, args.path), default=args.default)
+    return 0
+
+
+def cmd_get_json(args) -> int:
+    """Same as get but always emits compact JSON (or empty string on miss)."""
+    data = _read_stdin_json()
+    if data is None:
+        print("")
+        return 0
+    v = _navigate(data, args.path)
+    if v is None:
+        print("")
+    else:
+        print(json.dumps(v, separators=(",", ":")))
+    return 0
+
+
+def cmd_pick_addr(args) -> int:
+    """Stdin is a list of {scope, addr, port, ...}. Print 'addr|port' for
+    the FIRST entry whose scope matches args.scope. Empty if no match."""
+    data = _read_stdin_json()
+    if not isinstance(data, list):
+        return 0
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("scope") == args.scope:
+            addr = entry.get("addr", "")
+            port = entry.get("port", "")
+            if addr and port != "":
+                print(f"{addr}|{port}")
+                return 0
+    return 0
+
+
+def cmd_pick_addr_first(args) -> int:
+    """Stdin is a list of {scope, addr, port, ...}. Print 'addr|port' for
+    the FIRST entry. Empty if list is empty."""
+    data = _read_stdin_json()
+    if isinstance(data, list) and data and isinstance(data[0], dict):
+        addr = data[0].get("addr", "")
+        port = data[0].get("port", "")
+        if addr and port != "":
+            print(f"{addr}|{port}")
+    return 0
+
+
+def cmd_gist_content(args) -> int:
+    """Stdin is a gh-api response for a gist (`gh api gists/<id>` or the
+    REST equivalent). Extract the first file's `.content`. Replaces:
+        gh api gists/$id | jq -r '.files | to_entries[0].value.content // empty'
+    """
+    data = _read_stdin_json()
+    if not isinstance(data, dict):
+        return 0
+    files = data.get("files")
+    if not isinstance(files, dict) or not files:
+        return 0
+    # Files dict: { "<filename>": {"filename":..., "content":...}, ... }
+    first_key = next(iter(files))
+    entry = files[first_key]
+    if isinstance(entry, dict):
+        content = entry.get("content", "")
+        if content:
+            print(content)
+    return 0
+
+
+def cmd_get_first_of(args) -> int:
+    """Try multiple paths in order; print the first non-null value's
+    string form. Replaces jq's `.a // .b // empty` fallback chain."""
+    data = _read_stdin_json()
+    if data is None:
+        print(args.default)
+        return 0
+    for path in args.paths:
+        v = _navigate(data, path)
+        if v is not None:
+            _emit(v, default=args.default)
+            return 0
+    print(args.default)
+    return 0
+
+
+def cmd_list_lan_entries(args) -> int:
+    """Stdin is a list of {scope, addr, port, subnet, ...}. Print each
+    LAN entry as compact JSON, one per line. Used by host_address_set
+    where we need to iterate every LAN addr (multi-NIC machines)."""
+    data = _read_stdin_json()
+    if not isinstance(data, list):
+        return 0
+    for entry in data:
+        if isinstance(entry, dict) and entry.get("scope") == "lan":
+            print(json.dumps(entry, separators=(",", ":")))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="airc_core.gistparse")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    g = sub.add_parser("get")
+    g.add_argument("path")
+    g.add_argument("--default", default="")
+    g.set_defaults(func=cmd_get)
+
+    gj = sub.add_parser("get_json")
+    gj.add_argument("path")
+    gj.set_defaults(func=cmd_get_json)
+
+    pa = sub.add_parser("pick_addr")
+    pa.add_argument("scope")
+    pa.set_defaults(func=cmd_pick_addr)
+
+    pf = sub.add_parser("pick_addr_first")
+    pf.set_defaults(func=cmd_pick_addr_first)
+
+    ll = sub.add_parser("list_lan_entries")
+    ll.set_defaults(func=cmd_list_lan_entries)
+
+    gc = sub.add_parser("gist_content")
+    gc.set_defaults(func=cmd_gist_content)
+
+    gfo = sub.add_parser("get_first_of")
+    gfo.add_argument("paths", nargs="+")
+    gfo.add_argument("--default", default="")
+    gfo.set_defaults(func=cmd_get_first_of)
+
+    return p
+
+
+def _cli() -> int:
+    args = _build_parser().parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())


### PR DESCRIPTION
27 jq sites → airc_core.gistparse (Python stdlib JSON). One less hard dep; install.sh prereq list drops from 6 to 5. Tests green.