### PR TITLE
feat(bearer): Phase 0 — abstract bearer seam, no behavior change

### DIFF
--- a/lib/airc_core/bearer.py
+++ b/lib/airc_core/bearer.py
@@ -1,0 +1,179 @@
+"""Bearer abstraction — the seam between airc and any message transport.
+
+A bearer carries opaque payload bytes between identified peers across some
+transport (today: SSH; coming: gh; future: anything). The interface speaks
+ONLY in peer-id strings, channel names, opaque bytes, and lifecycle. It
+does not know about SSH, gh, addresses, ports, hosts, signatures, or
+identities.
+
+If a future reader can read this file alone and tell which transport airc
+uses, the abstraction is wrong. The abstraction is the seam; the seam's
+job is to be ignorant of what's on either side.
+
+Modularity invariant (load-bearing — do not weaken):
+    Concrete bearers (bearer_ssh.py, bearer_gh.py, etc.) are imported by
+    bearer_resolver.py and NOWHERE ELSE. Caller code (cmd_send, monitor)
+    obtains a Bearer instance via the resolver and only ever sees the
+    abstract interface. Adding a transport = one new file + one resolver
+    case. Removing a transport = delete one file + delete one resolver
+    case. If anything else has to move, the seam leaked.
+
+Per-transport encapsulation (the adapter rule):
+    Each transport's knowledge lives ENTIRELY in its bearer module.
+    Tailscale-specific code (address scopes, daemon checks, sign-in
+    nudges, share-node prompts, anything that mentions Tailscale by
+    name) lives only in bearer_tailscale.py — not in install scripts,
+    not in cmd_connect, not in the address picker. gh-as-transport
+    code (gist mutation, ETag handling, polling cadence, gh-API rate
+    limit handling) lives only in bearer_gh.py.
+
+    Note the role qualifier on gh: gh ALSO serves as airc's identity /
+    room registry / control plane (gist-as-registry, gh-account as
+    namespace). That is a separate concern from gh-as-transport, and
+    its code lives elsewhere (cmd_rooms, gistparse). The bearer
+    abstraction encapsulates gh ONLY in its transport role. If a
+    bearer module ends up doing identity or room-registry work, the
+    seam leaked the wrong way.
+
+    Test of correctness: grep for the transport's name (e.g. "tailscale",
+    "ssh", "ssh-tail") across the codebase. After Phase 3, every match
+    that survives is in that transport's bearer module or its tests.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Iterator, Optional
+
+
+@dataclass(frozen=True)
+class ReceivedMessage:
+    """A message handed up by a bearer.
+
+    `payload` is opaque bytes. The bearer does not parse it — signing,
+    envelope format, and identity verification are caller concerns
+    layered on top. `bearer_metadata` is a free-form diagnostic dict
+    populated by the bearer (e.g. SSH latency, gh ETag, gist file shard
+    name); callers must not introspect it for routing decisions.
+    """
+    sender_peer_id: str
+    channel: str
+    payload: bytes
+    bearer_metadata: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class LivenessResult:
+    """Result of a liveness probe against a peer.
+
+    `last_seen_ts` is a Unix timestamp of the most recent activity the
+    bearer can attest to, or None if the bearer has no signal. `bearer_diag`
+    is a short human-readable diagnostic string for surfacing in `airc
+    status` / `airc doctor`.
+    """
+    peer_id: str
+    last_seen_ts: Optional[float]
+    bearer_diag: str
+
+
+class BearerError(Exception):
+    """Base class for bearer-layer errors. Concrete bearers raise
+    subclasses (e.g. SshBearerError, GhBearerError) so callers can branch
+    on transport-class without importing concrete bearer modules."""
+
+
+class PeerUnreachable(BearerError):
+    """Raised by open() when a peer cannot be reached via this bearer.
+    Callers (typically the resolver) should fall through to a different
+    bearer rather than treating this as fatal."""
+
+
+class Bearer(ABC):
+    """Abstract bearer interface.
+
+    Lifecycle: open() → send()/recv_stream()/liveness() (any order, any
+    number of times) → close(). open() may be called multiple times for
+    different peer_ids on the same bearer instance — bearers are
+    multi-peer where transport allows.
+
+    Implementations MUST be safe to instantiate without side effects;
+    network/IO happens in open(). This keeps the resolver cheap and lets
+    `airc doctor` introspect available bearers without committing to
+    connections.
+
+    Each concrete bearer declares a class-level `KIND` string (its short
+    name, e.g. "ssh", "gh", "tailscale", "local") and a class method
+    `can_serve(peer_meta)` that returns whether it can serve a peer given
+    that peer's known metadata. The resolver iterates registered bearers
+    in preference order, picks the first that says yes, falls through on
+    PeerUnreachable. This is the property that makes adding a transport
+    a one-file change AND makes runtime fallback (e.g. gh rate-limited
+    → try the next bearer) work without callers knowing.
+    """
+
+    # Override in concrete subclasses. Resolver and `airc doctor` use this
+    # for reporting; never gate behavior on KIND from caller code (that
+    # would defeat the abstraction).
+    KIND: str = "abstract"
+
+    @classmethod
+    @abstractmethod
+    def can_serve(cls, peer_meta: dict) -> bool:
+        """Return True iff this bearer can plausibly serve a peer with
+        the given metadata. Pure inspection — no IO, no side effects.
+
+        Resolver calls this BEFORE instantiating the bearer to decide
+        candidacy. A True return is not a delivery guarantee; open() may
+        still raise PeerUnreachable when actual connection is attempted.
+        """
+
+    @abstractmethod
+    def open(self, peer_id: str) -> None:
+        """Establish whatever the bearer needs to send/recv to/from peer_id.
+
+        Raises PeerUnreachable if the bearer cannot serve this peer (e.g.
+        SshBearer asked about a peer with no reachable IP). Callers should
+        treat PeerUnreachable as fall-through-to-next-bearer, not fatal.
+        """
+
+    @abstractmethod
+    def send(self, peer_id: str, channel: str, payload: bytes) -> None:
+        """Deliver `payload` to `peer_id` on `channel`. Bytes are opaque.
+
+        Returns when the bearer has accepted responsibility for delivery.
+        Some bearers may complete delivery synchronously (SSH-loopback);
+        others queue and deliver asynchronously (gh polling). Either way,
+        a successful return means the bearer has the bytes; subsequent
+        delivery failures surface via liveness() / recv-stream errors.
+        """
+
+    @abstractmethod
+    def recv_stream(self) -> Iterator[ReceivedMessage]:
+        """Yield ReceivedMessage events as they arrive on this bearer.
+
+        Generator; blocks between events. Closing the bearer (close())
+        raises StopIteration in the active iteration. Implementations
+        must use `--line-buffered`-equivalent IO so events surface
+        promptly (matters for low-latency bearers; harmless for polling
+        ones).
+        """
+
+    @abstractmethod
+    def liveness(self, peer_id: str) -> LivenessResult:
+        """Probe `peer_id` for liveness via this bearer's natural signal.
+
+        Always returns a LivenessResult — never raises for unreachability.
+        last_seen_ts=None means "no signal," not "definitely dead." A bearer
+        should distinguish "I have no record of this peer" from "I have a
+        stale record" via bearer_diag.
+        """
+
+    @abstractmethod
+    def close(self) -> None:
+        """Tear down all resources held by this bearer.
+
+        Idempotent — calling close() on an already-closed bearer is a no-op.
+        After close(), subsequent send()/recv_stream()/liveness() calls
+        raise BearerError.
+        """

--- a/lib/airc_core/bearer_resolver.py
+++ b/lib/airc_core/bearer_resolver.py
@@ -1,0 +1,63 @@
+"""Bearer resolver — the ONLY module that imports concrete bearers.
+
+The resolver maintains an ordered registry of bearer types and, given a
+peer's metadata, picks the first bearer that says it can serve. Order is
+preference: faster / cheaper bearers come first, more-universal ones
+later. Callers receive an opaque Bearer instance and never see which
+concrete type it is.
+
+Adding a transport: import its class, add to _REGISTRY at the right
+preference position. Done. Removing a transport: delete the import and
+the registry entry. Done. No other file moves.
+
+Phase 1 (this file's current state): registry contains only SshBearer,
+preserving today's behavior. Phase 2 adds GhBearer behind it. Phase 3
+flips the order (or replaces SshBearer with LocalBearer + GhBearer
+exclusively).
+"""
+
+from __future__ import annotations
+
+from typing import List, Type
+
+from .bearer import Bearer, PeerUnreachable
+from .bearer_ssh import SshBearer
+
+# Preference order. Earlier = preferred. The resolver tries each in turn
+# via can_serve() and falls through on PeerUnreachable from open().
+_REGISTRY: List[Type[Bearer]] = [
+    SshBearer,
+]
+
+
+def available_kinds() -> List[str]:
+    """Names of registered bearer kinds, in preference order. Used by
+    `airc doctor` and status surfaces to report what transports the
+    binary can speak."""
+    return [b.KIND for b in _REGISTRY]
+
+
+def resolve(peer_meta: dict) -> Bearer:
+    """Pick a bearer for the given peer metadata.
+
+    Iterates _REGISTRY in preference order; returns the first bearer
+    whose can_serve() returns True. Raises PeerUnreachable if no bearer
+    can serve the peer — at that point the peer truly is unreachable
+    by any means we know.
+
+    The returned bearer is instantiated but NOT opened. Callers must
+    call open(peer_id) before send/recv. This split keeps resolution
+    cheap for status surfaces that want to know "what would we use"
+    without committing to a connection.
+    """
+    candidates = [b for b in _REGISTRY if b.can_serve(peer_meta)]
+    if not candidates:
+        raise PeerUnreachable(
+            f"no registered bearer can serve peer_meta={peer_meta!r}; "
+            f"available kinds: {available_kinds()}"
+        )
+    # Use the first candidate. Future enhancement: try each in turn,
+    # fall through on PeerUnreachable from open(). That's intentionally
+    # not in Phase 1 — it'd require concrete bearers to be cheap to
+    # construct, which is the documented invariant but not yet tested.
+    return candidates[0]()

--- a/lib/airc_core/bearer_ssh.py
+++ b/lib/airc_core/bearer_ssh.py
@@ -1,0 +1,102 @@
+"""SshBearer — message transport over SSH.
+
+ALL SSH-specific knowledge lives in this module: ssh binary location, key
+selection, host/port resolution, MSYS path translation, the
+`__APPENDED__` confirmation protocol, error classification (auth vs
+network), pending-queue semantics for offline peers. Code outside this
+file does not mention SSH.
+
+If a future contributor needs to find "how does airc do SSH," the answer
+is "open this file." If they need to add a new transport (gh, Reticulum,
+LoRa, websocket, anything), they write a sibling file in the same shape
+and register it in bearer_resolver.py. They never touch this one.
+
+Phase 0 (current state): skeleton. KIND + can_serve + cheap-construct
+invariant satisfied; send/recv/liveness/close raise NotImplementedError
+with explicit guidance pointing to the upcoming Phase 1 PR. The skeleton
+exists so the resolver and the seam tests are real, not vapor.
+
+Phase 1 (next PR): send() becomes functional by relocating cmd_send.sh's
+SSH delivery primitive into this module. The local-mirror, queue-on-fail,
+and remote __APPENDED__ confirmation logic moves here. cmd_send.sh shrinks
+to "build envelope, sign, hand to bearer."
+
+Phase 2: recv_stream() relocates the monitor's SSH-tail logic. liveness()
+relocates the heartbeat read.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+from .bearer import (
+    Bearer,
+    BearerError,
+    LivenessResult,
+    PeerUnreachable,
+    ReceivedMessage,
+)
+
+
+class SshBearerError(BearerError):
+    """SSH-transport-class errors. Distinct subclass so callers can branch
+    on transport without importing this module by name (they branch on
+    isinstance against BearerError subclasses if needed — but the
+    architectural preference is never to branch on transport at all)."""
+
+
+class SshBearer(Bearer):
+    KIND = "ssh"
+
+    @classmethod
+    def can_serve(cls, peer_meta: dict) -> bool:
+        """Return True if peer_meta describes an SSH-reachable peer.
+
+        SSH reachability requires: a `host_target` field populated by the
+        pair-handshake (user@host[:port]) AND a corresponding identity
+        key on disk. peer_meta is supplied by the caller, the disk-side
+        key check is handled lazily in open() — can_serve() stays pure.
+        """
+        return bool(peer_meta.get("host_target"))
+
+    def __init__(self) -> None:
+        # No IO here. Concrete bearers MUST be cheap to instantiate so
+        # the resolver can probe candidacy without committing.
+        self._opened_peer_id: str | None = None
+        self._closed = False
+
+    def open(self, peer_id: str) -> None:
+        if self._closed:
+            raise SshBearerError("bearer already closed")
+        # Phase 0: track open() for Phase 1 to wire up. No actual SSH
+        # work yet — that arrives when send() goes functional.
+        self._opened_peer_id = peer_id
+
+    def send(self, peer_id: str, channel: str, payload: bytes) -> None:
+        if self._closed:
+            raise SshBearerError("bearer already closed")
+        raise NotImplementedError(
+            "SshBearer.send is Phase 1 work; cmd_send.sh still does SSH "
+            "delivery directly. The Phase 1 PR relocates that logic here."
+        )
+
+    def recv_stream(self) -> Iterator[ReceivedMessage]:
+        if self._closed:
+            raise SshBearerError("bearer already closed")
+        raise NotImplementedError(
+            "SshBearer.recv_stream is Phase 2 work; the monitor still does "
+            "SSH-tail directly. The Phase 2 PR relocates that logic here."
+        )
+
+    def liveness(self, peer_id: str) -> LivenessResult:
+        if self._closed:
+            raise SshBearerError("bearer already closed")
+        raise NotImplementedError(
+            "SshBearer.liveness is Phase 2 work; status surfaces still read "
+            "the heartbeat file directly."
+        )
+
+    def close(self) -> None:
+        # Idempotent per ABC contract.
+        self._closed = True
+        self._opened_peer_id = None

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2460,6 +2460,28 @@ time.sleep(30)
   cleanup_all
 }
 
+scenario_python_units() {
+  # Python unit tests for airc_core/. Currently exercises the bearer
+  # abstraction (lib/airc_core/bearer.py + bearer_resolver.py +
+  # bearer_ssh.py). Add new test_*.py files in test/ as the airc_core
+  # surface grows — each file is auto-discovered by the loop below.
+  echo
+  echo "── scenario: python unit tests ──"
+  local _here; _here="$(cd "$(dirname "$0")" && pwd)"
+  local _failed=0
+  for _t in "$_here"/test_*.py; do
+    [ -f "$_t" ] || continue
+    local _name; _name=$(basename "$_t" .py)
+    if ( cd "$_here" && python3 "$_t" 2>&1 | tail -3 | grep -q '^OK' ); then
+      pass "python units: $_name"
+    else
+      fail "python units: $_name (run: cd test && python3 $(basename "$_t"))"
+      _failed=$((_failed + 1))
+    fi
+  done
+  return $_failed
+}
+
 case "$MODE" in
   tabs)         scenario_tabs  ;;
   scope)        scenario_scope ;;
@@ -2487,6 +2509,7 @@ case "$MODE" in
   list) scenario_list ;;
   quit) scenario_quit ;;
   platform_adapters) scenario_platform_adapters ;;
+  python_units) scenario_python_units ;;
   ""|all)
     # Default = run everything. The peers_cross_scope + whois_cross_scope
     # scenarios were removed in PR #239 (sidecar walk semantics deleted
@@ -2501,8 +2524,9 @@ case "$MODE" in
     scenario_send_dead_monitor_dies; scenario_connect_after_kill_recovers
     scenario_general_sidecar_default; scenario_away
     scenario_list; scenario_quit; scenario_platform_adapters
+    scenario_python_units
     ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|all]"; exit 2 ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|all]"; exit 2 ;;
 esac
 
 echo

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -1,0 +1,142 @@
+"""Bearer abstraction tests — the seam compiles, the ABC enforces its
+contract, and the resolver picks correctly.
+
+Run: python -m unittest test.test_bearer (from repo root)
+or:  cd test && python -m unittest test_bearer
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# Make lib/ importable when running this test from the repo root or test/.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+from airc_core.bearer import (  # noqa: E402
+    Bearer,
+    BearerError,
+    LivenessResult,
+    PeerUnreachable,
+    ReceivedMessage,
+)
+from airc_core.bearer_resolver import (  # noqa: E402
+    available_kinds,
+    resolve,
+)
+from airc_core.bearer_ssh import SshBearer  # noqa: E402
+
+
+class BearerInterfaceTests(unittest.TestCase):
+    """The ABC enforces its shape and refuses incomplete implementations."""
+
+    def test_cannot_instantiate_abstract_bearer(self):
+        with self.assertRaises(TypeError):
+            Bearer()
+
+    def test_partial_subclass_cannot_instantiate(self):
+        # Missing required abstract methods → instantiation refused.
+        class HalfBearer(Bearer):
+            KIND = "half"
+
+            @classmethod
+            def can_serve(cls, peer_meta):
+                return False
+
+            # Deliberately missing: open, send, recv_stream, liveness, close.
+
+        with self.assertRaises(TypeError):
+            HalfBearer()
+
+    def test_received_message_is_immutable(self):
+        m = ReceivedMessage(
+            sender_peer_id="alice",
+            channel="general",
+            payload=b"hello",
+        )
+        with self.assertRaises(Exception):
+            m.payload = b"tampered"  # frozen dataclass
+
+    def test_liveness_result_allows_unknown_last_seen(self):
+        r = LivenessResult(peer_id="bob", last_seen_ts=None, bearer_diag="no signal")
+        self.assertIsNone(r.last_seen_ts)
+
+
+class ResolverTests(unittest.TestCase):
+    """Resolver picks bearers based on can_serve, raises when no candidate."""
+
+    def test_available_kinds_includes_ssh_in_phase0(self):
+        kinds = available_kinds()
+        self.assertIn("ssh", kinds)
+
+    def test_resolves_ssh_for_peer_with_host_target(self):
+        bearer = resolve({"host_target": "user@host:7547"})
+        self.assertIsInstance(bearer, SshBearer)
+        self.assertEqual(bearer.KIND, "ssh")
+
+    def test_unreachable_when_no_bearer_can_serve(self):
+        with self.assertRaises(PeerUnreachable):
+            resolve({})  # no host_target, no bearer matches
+
+    def test_resolved_bearer_is_not_yet_open(self):
+        bearer = resolve({"host_target": "user@host:7547"})
+        # Resolution is cheap — no IO happens yet.
+        self.assertIsInstance(bearer, Bearer)
+
+
+class SshBearerSkeletonTests(unittest.TestCase):
+    """Phase 0 SshBearer skeleton: lifecycle methods, NotImplementedError
+    guidance for the parts that arrive in Phase 1+."""
+
+    def test_kind_is_ssh(self):
+        self.assertEqual(SshBearer.KIND, "ssh")
+
+    def test_can_serve_requires_host_target(self):
+        self.assertTrue(SshBearer.can_serve({"host_target": "u@h"}))
+        self.assertFalse(SshBearer.can_serve({}))
+        self.assertFalse(SshBearer.can_serve({"unrelated": "field"}))
+
+    def test_can_serve_is_pure(self):
+        # No IO, no side effects — calling it 100 times is free.
+        for _ in range(100):
+            SshBearer.can_serve({"host_target": "u@h"})
+
+    def test_construct_is_cheap(self):
+        # Cheap-construct invariant: resolver may build candidates
+        # speculatively. No IO on __init__.
+        b1 = SshBearer()
+        b2 = SshBearer()
+        self.assertIsNot(b1, b2)
+        b1.close()
+        b2.close()
+
+    def test_open_then_close_is_clean(self):
+        b = SshBearer()
+        b.open("alice")
+        b.close()
+        # close() is idempotent
+        b.close()
+
+    def test_post_close_operations_raise(self):
+        b = SshBearer()
+        b.close()
+        with self.assertRaises(BearerError):
+            b.open("alice")
+        with self.assertRaises(BearerError):
+            b.send("alice", "general", b"x")
+
+    def test_send_raises_not_implemented_with_phase_guidance(self):
+        b = SshBearer()
+        b.open("alice")
+        with self.assertRaises(NotImplementedError) as ctx:
+            b.send("alice", "general", b"x")
+        # The error message points at the next PR, so a future debugger
+        # finding it knows where the work belongs.
+        self.assertIn("Phase 1", str(ctx.exception))
+        b.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Introduces the bearer abstraction — the seam between airc and any message transport — as scaffolding only. Establishes the architecture without changing any existing behavior.

## Why this PR is small on purpose

Phase 1 will thread \`cmd_send\` through the seam, which is meaningful surgery on a 439-line file. Landing the seam definition in isolation makes Phase 1 reviewable as \"does the abstraction hold up under real callers?\" rather than \"does it both compile AND change behavior?\" The two questions deserve separate review.

This is the architectural foundation for #269 (gh-as-bearer RFC) and the answer to #270 (mesh silent-degradation root-caused as missing modularity).

## What's in the PR

- \`lib/airc_core/bearer.py\` — abstract base class. No transport knowledge. Speaks only in peer-id / channel / opaque bytes / lifecycle.
- \`lib/airc_core/bearer_resolver.py\` — the **only** module that imports concrete bearers. Adding a transport = one new import + one registry entry.
- \`lib/airc_core/bearer_ssh.py\` — skeleton. \`KIND = \"ssh\"\`, \`can_serve\` works, \`open\`/\`close\` lifecycle works, send/recv/liveness raise \`NotImplementedError\` with explicit \"this lands in Phase 1 PR\" guidance.
- \`test/test_bearer.py\` — 15 unit tests covering ABC enforcement, resolver behavior, SshBearer cheap-construct invariant, post-close safety, phase-pointer error messages.
- \`test/integration.sh\` — new \`scenario_python_units\` auto-discovers and runs every \`test/test_*.py\`. Runs as part of \`all\`.

## Modularity invariants codified in the docstring

If the abstraction has a leak, these are how a reviewer spots it:

1. The ABC imports nothing transport-related. A future reader of \`bearer.py\` cannot tell which transport airc uses.
2. Concrete bearers are imported by \`bearer_resolver.py\` and NOWHERE ELSE.
3. Per-transport encapsulation: ALL Tailscale-specific code in \`bearer_tailscale.py\` (if it exists); ALL gh-as-transport code in \`bearer_gh.py\`. After the rewrite, grepping for \"tailscale\" matches only that file + its tests.
4. gh has two roles in airc: identity/registry (control plane) and transport (data plane). The bearer abstraction encapsulates only the transport role. \`cmd_rooms\` / \`gistparse\` keep the registry role.

## Phase plan

- **Phase 0 (this PR)**: seam + skeleton + tests. No behavior change.
- **Phase 1 (next PR)**: \`cmd_send.sh\`'s SSH delivery primitive moves into \`SshBearer.send()\`. \`cmd_send.sh\` shrinks to \"build envelope, sign, hand to bearer.\"
- **Phase 2**: \`GhBearer\` added to the registry behind \`SshBearer\` (#269).
- **Phase 3**: cutover. Default to \`GhBearer\` for cross-machine, \`LocalBearer\` for same-machine. \`SshBearer\` + all Tailscale code deleted in this same PR. install.sh / install.ps1 lose Tailscale auto-detect.

## Test plan

- [x] \`bash test/integration.sh python_units\` passes
- [x] \`bash test/integration.sh all\` includes the new scenario
- [x] No bash files are modified outside \`test/integration.sh\` (no behavior change to ship)
- [x] No Python files outside \`lib/airc_core/bearer*.py\` are modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)