### PR TITLE
feat(bearer): Phase 2a — SshBearer.recv_stream + liveness functional

### DIFF
--- a/lib/airc_core/bearer_ssh.py
+++ b/lib/airc_core/bearer_ssh.py
@@ -193,6 +193,8 @@ class SshBearer(Bearer):
         self._opened_peer_id: Optional[str] = None
         self._peer_meta: dict = peer_meta or {}
         self._closed = False
+        self._proc = None  # active recv_stream Popen, if any
+        self._last_recv_ts: Optional[float] = None
 
     def _check_alive(self) -> None:
         if self._closed:
@@ -275,21 +277,217 @@ class SshBearer(Bearer):
         return SendOutcome(kind=kind, detail=detail)
 
     def recv_stream(self) -> Iterator[ReceivedMessage]:
+        """Stream events from the host's messages.jsonl via SSH-tail.
+
+        Internally manages: ssh subprocess lifecycle, line-buffered stdout
+        parsing, JSON decoding, and reconnection on SSH death. Yields one
+        ReceivedMessage per valid envelope on the wire. Malformed lines
+        are dropped silently (the formatter has caught these for years
+        — preserving that behavior). close() makes the generator return.
+
+        Reconnection: SSH dies → wait briefly → reopen with the persisted
+        line offset → resume yielding. The offset is updated as events
+        flow so a reconnect mid-stream doesn't replay or skip. Watchdog,
+        escalation counter, and any UX response to extended silence are
+        CALLER concerns — the bearer's job is to keep producing events
+        and update its own liveness signal so liveness() answers honestly.
+
+        ABC contract reminder: callers must use line-buffered IO. SSH's
+        stdout is unbuffered when tail is the underlying command, so this
+        is naturally line-paced.
+        """
         self._check_alive()
-        raise NotImplementedError(
-            "SshBearer.recv_stream is Phase 2 work; the monitor still does "
-            "SSH-tail directly. The Phase 2 PR relocates that logic here."
+
+        host_target = self._peer_meta.get("host_target")
+        if not host_target:
+            raise SshBearerError(
+                "SshBearer.recv_stream called with no host_target in peer_meta"
+            )
+        remote_home = self._peer_meta.get("remote_home", "$HOME/.airc")
+        identity_key = self._peer_meta.get("identity_key")
+        offset_file = self._peer_meta.get("offset_file")
+
+        while not self._closed:
+            tail_pos = self._compute_tail_position(offset_file)
+            remote_cmd = f"tail {tail_pos} -F {remote_home}/messages.jsonl 2>/dev/null"
+            argv = _build_ssh_argv(host_target, identity_key, remote_cmd)
+
+            try:
+                proc = subprocess.Popen(
+                    argv,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.DEVNULL,
+                    bufsize=1,  # line-buffered
+                    text=False,
+                )
+            except OSError as e:
+                # Brief backoff so we don't hot-loop on a missing ssh binary
+                # or similar permanent error. Caller's watchdog will notice
+                # extended silence via liveness() and escalate.
+                self._sleep_or_break(3.0)
+                continue
+
+            self._proc = proc
+            try:
+                assert proc.stdout is not None  # Popen kw guarantees this
+                for raw_line in proc.stdout:
+                    if self._closed:
+                        break
+                    self._on_line_received(raw_line, offset_file)
+                    msg = self._parse_envelope(raw_line)
+                    if msg is None:
+                        continue
+                    yield msg
+            finally:
+                self._reap_proc(proc)
+                self._proc = None
+            # SSH died — backoff briefly, then reconnect (unless closed).
+            if not self._closed:
+                self._sleep_or_break(3.0)
+
+    @staticmethod
+    def _compute_tail_position(offset_file: Optional[str]) -> str:
+        """Decide tail's `-n` flag based on the persisted offset.
+
+        Mirrors the bash monitor's logic verbatim:
+          - empty / 0 / non-numeric → `-n 0` (start at EOF, no replay)
+          - positive integer N → `-n +N+1` (resume past line N)
+
+        Stale-offset detection (offset > host's current line count) is
+        deliberately NOT done here — that's a one-shot probe the caller
+        can run on first connect. Repeating it on every reconnect would
+        burn an SSH round-trip we don't need; the steady-state offset is
+        always sane because the formatter writes it monotonically.
+        """
+        if not offset_file:
+            return "-n 0"
+        try:
+            with open(offset_file, "r") as f:
+                raw = f.read().strip()
+        except OSError:
+            return "-n 0"
+        if not raw or not raw.isdigit():
+            return "-n 0"
+        try:
+            n = int(raw)
+        except ValueError:
+            return "-n 0"
+        if n <= 0:
+            return "-n 0"
+        return f"-n +{n + 1}"
+
+    def _on_line_received(self, raw_line: bytes, offset_file: Optional[str]) -> None:
+        """Update bearer-internal state on each received line.
+
+        - Bumps last_recv_ts so liveness() returns a fresh timestamp.
+        - Persists the new offset (line count) so reconnect resumes
+          past this line.
+        Persistence failures are swallowed — the bearer continues
+        streaming; a stale offset just means the next reconnect may
+        replay a few lines, which the caller can dedupe."""
+        import time as _time
+        self._last_recv_ts = _time.time()
+        if offset_file is None:
+            return
+        # Read-modify-write of the line count. Cheap because we're already
+        # the only writer (the formatter's old-path writer is replaced by
+        # this when monitor flips to recv_stream in Phase 2b).
+        try:
+            with open(offset_file, "r") as f:
+                cur = f.read().strip()
+            n = int(cur) if cur.isdigit() else 0
+        except (OSError, ValueError):
+            n = 0
+        try:
+            with open(offset_file, "w") as f:
+                f.write(str(n + 1))
+        except OSError:
+            pass
+
+    @staticmethod
+    def _parse_envelope(raw_line: bytes) -> Optional[ReceivedMessage]:
+        """Parse a single tail-stream line as a message envelope.
+
+        Returns None on malformed input — silent drop matches the prior
+        formatter behavior. Valid envelope = JSON object with at least
+        `from` and `channel` fields. The full envelope (including sig)
+        is preserved as the payload bytes so callers retain everything
+        they had before this seam existed.
+        """
+        line = raw_line.rstrip(b"\n").rstrip(b"\r")
+        if not line:
+            return None
+        import json as _json
+        try:
+            env = _json.loads(line)
+        except (ValueError, TypeError):
+            return None
+        if not isinstance(env, dict):
+            return None
+        sender = env.get("from")
+        channel = env.get("channel", "")
+        if not sender:
+            return None
+        return ReceivedMessage(
+            sender_peer_id=str(sender),
+            channel=str(channel),
+            payload=line,
+            bearer_metadata={"envelope": env},
         )
 
+    def _reap_proc(self, proc) -> None:
+        try:
+            if proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=1)
+        except OSError:
+            pass
+
+    def _sleep_or_break(self, seconds: float) -> None:
+        """Sleep `seconds` in small ticks so close() takes effect promptly.
+        Returns immediately if the bearer was closed during the wait."""
+        import time as _time
+        deadline = _time.time() + seconds
+        while not self._closed and _time.time() < deadline:
+            _time.sleep(0.1)
+
     def liveness(self, peer_id: str) -> LivenessResult:
+        """Report when this bearer last received an event from the peer.
+
+        SshBearer's natural liveness signal is "stream activity" — we
+        bump self._last_recv_ts on every line that comes through tail.
+        None means "no signal yet" (recv_stream hasn't yielded), not
+        "definitely dead." Caller's watchdog interprets staleness.
+
+        This is the bearer-side of the airc-status / airc-peers
+        observability fix from #270: instead of reading some external
+        heartbeat file, the SSH-bearer attests directly to "the SSH
+        stream produced an event N seconds ago."
+        """
         self._check_alive()
-        raise NotImplementedError(
-            "SshBearer.liveness is Phase 2 work; status surfaces still read "
-            "the heartbeat file directly."
+        if self._last_recv_ts is None:
+            return LivenessResult(
+                peer_id=peer_id,
+                last_seen_ts=None,
+                bearer_diag="no events received via ssh tail yet",
+            )
+        return LivenessResult(
+            peer_id=peer_id,
+            last_seen_ts=self._last_recv_ts,
+            bearer_diag="last event from ssh tail",
         )
 
     def close(self) -> None:
-        # Idempotent per ABC contract.
+        # Idempotent per ABC contract. Tear down the recv_stream
+        # subprocess if running so the generator returns promptly.
         self._closed = True
+        proc = self._proc
+        if proc is not None:
+            self._reap_proc(proc)
+            self._proc = None
         self._opened_peer_id = None
         self._peer_meta = {}

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -253,6 +253,171 @@ class SshBearerSendTests(unittest.TestCase):
             o.kind = "tampered"
 
 
+class SshBearerRecvStreamTests(unittest.TestCase):
+    """Phase 2a SshBearer.recv_stream() — yields ReceivedMessage events
+    parsed from ssh tail's stdout. Tests mock subprocess.Popen so no real
+    network is touched.
+    """
+
+    def _bearer(self, meta=None):
+        m = meta or {
+            "host_target": "alice@example:7547",
+            "remote_home": "$HOME/.airc",
+            "identity_key": "/tmp/fake_key",
+        }
+        b = SshBearer(m)
+        b.open("alice")
+        return b
+
+    def _fake_proc(self, lines, returncode=0):
+        """Build a mock subprocess that yields `lines` from stdout then ends."""
+        # Use BytesIO-style iterator. Popen's stdout iter yields bytes.
+        proc = mock.Mock()
+        proc.stdout = iter(lines)
+        proc.poll = mock.Mock(return_value=returncode)
+        proc.terminate = mock.Mock()
+        proc.wait = mock.Mock(return_value=returncode)
+        proc.kill = mock.Mock()
+        return proc
+
+    def test_recv_stream_without_host_target_raises(self):
+        b = SshBearer({})
+        b.open("alice")
+        with self.assertRaises(SshBearerError):
+            next(b.recv_stream())
+        b.close()
+
+    def test_envelope_parser_drops_non_json(self):
+        # Junk line → None
+        self.assertIsNone(SshBearer._parse_envelope(b"not json\n"))
+        # Empty line → None
+        self.assertIsNone(SshBearer._parse_envelope(b"\n"))
+        # JSON but not an object → None
+        self.assertIsNone(SshBearer._parse_envelope(b"[1,2,3]\n"))
+        # Object missing `from` → None
+        self.assertIsNone(SshBearer._parse_envelope(b'{"channel":"x"}\n'))
+
+    def test_envelope_parser_accepts_well_formed(self):
+        line = b'{"from":"bob","channel":"general","msg":"hi"}\n'
+        msg = SshBearer._parse_envelope(line)
+        self.assertIsNotNone(msg)
+        self.assertEqual(msg.sender_peer_id, "bob")
+        self.assertEqual(msg.channel, "general")
+        # Payload is the original line (sans trailing newline)
+        self.assertEqual(msg.payload, b'{"from":"bob","channel":"general","msg":"hi"}')
+        self.assertIn("envelope", msg.bearer_metadata)
+        self.assertEqual(msg.bearer_metadata["envelope"]["msg"], "hi")
+
+    def test_compute_tail_position_no_offset_file(self):
+        self.assertEqual(SshBearer._compute_tail_position(None), "-n 0")
+
+    def test_compute_tail_position_invalid_offsets(self):
+        import tempfile
+        for content in ("", "0", "abc", "-1", "  "):
+            with tempfile.NamedTemporaryFile("w", delete=False) as f:
+                f.write(content)
+                path = f.name
+            self.assertEqual(
+                SshBearer._compute_tail_position(path), "-n 0",
+                f"content={content!r} should produce -n 0",
+            )
+
+    def test_compute_tail_position_resumes_past_saved_line(self):
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            f.write("42")
+            path = f.name
+        self.assertEqual(SshBearer._compute_tail_position(path), "-n +43")
+
+    @mock.patch.object(bearer_ssh.subprocess, "Popen")
+    def test_recv_stream_yields_parsed_envelopes(self, mock_popen):
+        lines = [
+            b'{"from":"bob","channel":"general","msg":"hello"}\n',
+            b'{"from":"carol","channel":"general","msg":"world"}\n',
+            b'corrupted line\n',  # should be silently dropped
+            b'{"from":"dave","channel":"useideem","msg":"hi"}\n',
+        ]
+        mock_popen.return_value = self._fake_proc(lines)
+
+        b = self._bearer()
+        events = []
+        # Take 3 events then close (stops the iterator). The mock proc's
+        # stdout iterator will exhaust naturally.
+        gen = b.recv_stream()
+        for ev in gen:
+            events.append(ev)
+            if len(events) >= 3:
+                b.close()
+                break
+
+        self.assertEqual(len(events), 3)
+        self.assertEqual(events[0].sender_peer_id, "bob")
+        self.assertEqual(events[1].sender_peer_id, "carol")
+        # Note: events[2] is "dave" — the malformed line was skipped.
+        self.assertEqual(events[2].sender_peer_id, "dave")
+
+    @mock.patch.object(bearer_ssh.subprocess, "Popen")
+    def test_liveness_updates_on_each_event(self, mock_popen):
+        lines = [b'{"from":"bob","channel":"general","msg":"hi"}\n']
+        mock_popen.return_value = self._fake_proc(lines)
+
+        b = self._bearer()
+        # Pre-stream: no signal
+        live_before = b.liveness("alice")
+        self.assertIsNone(live_before.last_seen_ts)
+        self.assertIn("no events", live_before.bearer_diag.lower())
+
+        # Consume one event, check liveness BEFORE closing
+        gen = b.recv_stream()
+        next(gen)
+        live_after = b.liveness("alice")
+        self.assertIsNotNone(live_after.last_seen_ts)
+        self.assertIn("ssh tail", live_after.bearer_diag.lower())
+        b.close()
+
+    @mock.patch.object(bearer_ssh.subprocess, "Popen")
+    def test_recv_stream_persists_offset(self, mock_popen):
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            f.write("0")
+            offset_path = f.name
+
+        lines = [
+            b'{"from":"bob","channel":"general","msg":"a"}\n',
+            b'{"from":"bob","channel":"general","msg":"b"}\n',
+        ]
+        mock_popen.return_value = self._fake_proc(lines)
+
+        meta = {
+            "host_target": "alice@example:7547",
+            "remote_home": "$HOME/.airc",
+            "identity_key": "/tmp/fake_key",
+            "offset_file": offset_path,
+        }
+        b = self._bearer(meta)
+
+        gen = b.recv_stream()
+        next(gen)
+        next(gen)
+        b.close()
+
+        with open(offset_path) as f:
+            self.assertEqual(f.read().strip(), "2")
+
+    def test_close_terminates_recv_subprocess(self):
+        b = self._bearer()
+        # Simulate a running proc
+        fake_proc = mock.Mock()
+        fake_proc.poll = mock.Mock(return_value=None)  # still running
+        fake_proc.terminate = mock.Mock()
+        fake_proc.wait = mock.Mock(return_value=0)
+        fake_proc.kill = mock.Mock()
+        b._proc = fake_proc
+
+        b.close()
+        fake_proc.terminate.assert_called_once()
+
+
 class CgnatRegexTests(unittest.TestCase):
     """The Tailscale-CGNAT range matcher is the only Tailscale knowledge
     in the codebase outside install scripts. Until Phase 3 deletes it,


### PR DESCRIPTION
## Summary

Implements the recv side of the bearer abstraction. \`SshBearer\` now owns SSH-tail lifecycle, line-by-line JSON envelope parsing, reconnection on SSH death, offset persistence, and a stream-activity liveness signal.

Phase 2a is **scaffolding before cutover**: the monitor in \`airc\` top-level still uses the existing \`ssh | monitor_formatter\` pipeline. \`recv_stream()\` is fully implemented and unit-tested but no caller threads through it yet. Phase 2b does the cutover (and that PR carries all the production-traffic risk).

## What's bearer concern vs caller concern

Bearer (this PR):
- ssh subprocess lifecycle (Popen, reap, terminate-on-close)
- Tail-position computation from persisted offset
- JSON envelope parsing, malformed-line drops
- Reconnection backoff
- Offset persistence per event
- Liveness via \`_last_recv_ts\`

Caller (still in monitor / Phase 2b):
- Watchdog + escalation + daemon-respawn signaling
- Mirror events to local \`messages.jsonl\`
- Pipe through \`monitor_formatter\` for display
- Update peer membership (#270 fix lives here)

This split is the bearer.py contract: bearers produce events and report liveness honestly; what to *do* about silence is policy.

## Tests (35 total, +10 in this phase)

- \`recv_stream\` raises with no \`host_target\`
- \`_parse_envelope\` drops non-JSON, empty, array, missing-from
- \`_parse_envelope\` accepts well-formed, preserves payload, populates \`bearer_metadata.envelope\`
- \`_compute_tail_position\`: empty/0/abc/-1/whitespace → \`-n 0\`; \"42\" → \`-n +43\`
- \`recv_stream\` yields events for each valid line; skips malformed silently
- \`liveness\` returns None pre-stream, fresh ts post-event
- \`close()\` terminates active recv subprocess (Popen.terminate asserted)
- \`offset_file\` updates after each event

All mocks; zero real network.

## Phase plan

- ✅ Phase 0: ABC + skeleton (#271)
- ✅ Phase 1: cmd_send through bearer (#272)
- ✅ Phase 2a (this PR): recv_stream + liveness functional, no cutover
- **Phase 2b**: monitor in \`airc\` top-level flips to \`bearer.recv_stream()\`. Removes ~80 lines of bash SSH-tail loop, watchdog, reconnect from \`airc\`. **This is where production traffic moves.**
- **Phase 2c**: \`airc peers\` / \`airc status\` read peer membership + liveness through the bearer. Fixes the lies from #270.
- Phase 3: \`GhBearer\` + \`LocalBearer\`; \`SshBearer\` + Tailscale code deleted (#269)

## Test plan

- [x] \`cd test && python3 test_bearer.py\` — 35 tests pass
- [x] No file outside \`lib/airc_core/bearer_ssh.py\` and \`test/test_bearer.py\` touched
- [x] No production callsites touched — zero behavior change risk in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)