### PR TITLE
feat(bearer): Phase 2b — monitor consumes bearer.recv_stream() via bearer_cli

### DIFF
--- a/airc
+++ b/airc
@@ -1203,15 +1203,32 @@ monitor() {
     # election with optimistic conflict resolution via gh-create.
     local consecutive_timeouts=0
     local ESCALATE_AFTER=2   # 5 min total dead-host detection (2 × WATCHDOG_SEC=150)
+    # Phase 2b: stream inbound through bearer.recv_stream() instead of an
+    # inline ssh-tail. The bearer (lib/airc_core/bearer_ssh.py) owns
+    # transport-level reconnects, line-buffering, and offset resume across
+    # SSH drops. This bash loop now owns ONLY higher-level policy:
+    #   - watchdog (formatter exit 2 = no inbound for WATCHDOG_SEC)
+    #   - probe-on-quiet (idle host vs dead host)
+    #   - escalation counter → exit 99 → daemon respawn (no-claude-left-behind)
+    # The seam is intentional: swapping in GhBearer or LocalBearer in
+    # Phase 3 changes nothing here; the bearer just reads from a different
+    # transport and the same watchdog policy applies.
     while true; do
       local cycle_start; cycle_start=$(date +%s)
-      ssh $ssh_opts "$host_target" "tail $tail_pos -F $rhome/messages.jsonl 2>/dev/null" 2>/dev/null | monitor_formatter "$my_name" || true
+      # Stderr is NOT redirected — bearer_cli only writes there for
+      # structural failures (resolver error, missing args, exec failure).
+      # Per CLAUDE.md "never swallow errors", surface those. Transport-
+      # level SSH chatter is consumed inside the bearer (stderr=DEVNULL
+      # on the ssh subprocess) so it never reaches us here.
+      "$AIRC_PYTHON" -u -m airc_core.bearer_cli recv "$host_target" \
+        --host-target "$host_target" \
+        --identity-key "$ssh_key" \
+        --remote-home "$rhome" \
+        --offset-file "$offset_file" \
+        | monitor_formatter "$my_name" || true
       local fmt_exit="${PIPESTATUS[1]:-0}"
       local cycle_end; cycle_end=$(date +%s)
       local cycle_lifetime=$((cycle_end - cycle_start))
-
-      # Subsequent reconnects use the now-persisted offset updated by the formatter.
-      tail_pos="-n +$(($(cat "$offset_file" 2>/dev/null || echo 0) + 1))"
 
       # Probe-before-count for fmt_exit=2 (watchdog: no inbound for
       # WATCHDOG_SEC). Without a probe, healthy-but-idle channels look

--- a/lib/airc_core/bearer_cli.py
+++ b/lib/airc_core/bearer_cli.py
@@ -1,21 +1,33 @@
 """Bash-callable bearer CLI.
 
 The bridge between airc's bash command files and the Python bearer
-abstraction. Bash invokes:
+abstraction. Two subcommands:
 
     python -m airc_core.bearer_cli send <peer_id> <channel> \\
         --host-target <ht> --identity-key <k> --remote-home <rh>
 
-Payload is read from stdin (bytes; framing is the caller's concern —
+    python -m airc_core.bearer_cli recv <peer_id> \\
+        --host-target <ht> --identity-key <k> --remote-home <rh> \\
+        [--offset-file <path>]
+
+`send` reads payload from stdin (bytes; framing is the caller's concern —
 the bearer treats it as opaque). The outcome is printed to stdout as
 a single line of JSON:
 
     {"kind": "delivered", "detail": ""}
 
-Bash callers parse `kind` and branch. Exit code is always 0 unless
-something is structurally wrong (missing required arg, malformed
-invocation); send failures are reported via outcome.kind, not exit
-status, so the caller can do its own queue/error logic.
+`recv` opens bearer.recv_stream() and writes one line per inbound
+envelope to stdout — the raw envelope bytes (a JSON object terminated
+by newline). Suitable for piping directly into monitor_formatter, which
+already consumes JSONL. Exits 0 on EOF / signal / broken pipe; the
+bearer handles transport-level reconnects internally. If the caller's
+formatter dies (broken pipe), recv exits cleanly so the bash watchdog
+can observe the cycle end and decide whether to re-launch.
+
+Bash callers parse `send`'s outcome `kind` and branch. Exit code is
+always 0 unless something is structurally wrong (missing required arg,
+malformed invocation); send failures are reported via outcome.kind,
+not exit status, so the caller can do its own queue/error logic.
 
 Why a CLI rather than direct python imports from bash: bash has no
 way to invoke Python class methods without a process boundary anyway,
@@ -28,6 +40,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import signal
 import sys
 from dataclasses import asdict
 
@@ -62,6 +75,68 @@ def cmd_send(args) -> int:
     return 0
 
 
+def cmd_recv(args) -> int:
+    """Stream events from the bearer to stdout as raw envelope bytes.
+
+    One line per event. The line is the unmodified envelope bytes the
+    bearer captured from the wire (see ReceivedMessage.payload), which
+    is JSONL-shaped — directly pipeable into monitor_formatter.
+
+    The bearer handles transport-level reconnects (transient SSH drops,
+    polling cadence for gh-as-bearer, etc). This loop exits only on:
+      - EOF from recv_stream (bearer closed)
+      - SIGTERM / SIGINT
+      - BrokenPipeError (formatter on the other end of the pipe died);
+        the bash monitor's watchdog interprets that and decides whether
+        to relaunch us.
+    """
+    peer_meta = {
+        "host_target": args.host_target,
+        "remote_home": args.remote_home,
+        "identity_key": args.identity_key,
+        "offset_file": args.offset_file,
+    }
+    peer_meta = {k: v for k, v in peer_meta.items() if v}
+
+    try:
+        bearer = resolve(peer_meta)
+    except Exception as e:
+        # Same shape as cmd_send: keep stderr loud rather than silent (per
+        # CLAUDE.md "never swallow errors") so the bash monitor + a human
+        # tailing logs both see why we couldn't open a stream.
+        print(f"bearer recv: resolver error: {e}", file=sys.stderr, flush=True)
+        return 2
+
+    # Translate SIGTERM into a clean close — pytest / bash kill us this way.
+    # Default SIGINT handler already raises KeyboardInterrupt which we catch.
+    def _on_term(signum, frame):
+        bearer.close()
+    try:
+        signal.signal(signal.SIGTERM, _on_term)
+    except ValueError:
+        pass  # not on the main thread (test harness) — best-effort
+
+    bearer.open(args.peer_id)
+    out = sys.stdout.buffer
+    try:
+        for ev in bearer.recv_stream():
+            line = ev.payload
+            if not line.endswith(b"\n"):
+                line = line + b"\n"
+            try:
+                out.write(line)
+                out.flush()
+            except BrokenPipeError:
+                # Downstream formatter exited. Caller's watchdog will
+                # observe the broken cycle and reconnect us if needed.
+                break
+    except KeyboardInterrupt:
+        pass
+    finally:
+        bearer.close()
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="airc_core.bearer_cli")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -76,6 +151,18 @@ def _build_parser() -> argparse.ArgumentParser:
     send.add_argument("--remote-home", default=None,
                       help="Remote AIRC_WRITE_DIR path (e.g. '$HOME/.airc')")
     send.set_defaults(func=cmd_send)
+
+    recv = sub.add_parser("recv", help="Stream inbound events as JSONL on stdout")
+    recv.add_argument("peer_id")
+    recv.add_argument("--host-target", default=None,
+                      help="user@host[:port] for SSH bearer")
+    recv.add_argument("--identity-key", default=None,
+                      help="Path to private key file for SSH bearer")
+    recv.add_argument("--remote-home", default=None,
+                      help="Remote AIRC_WRITE_DIR path (e.g. '$HOME/.airc')")
+    recv.add_argument("--offset-file", default=None,
+                      help="Path to monitor_offset file for resume-on-reconnect")
+    recv.set_defaults(func=cmd_recv)
 
     return p
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2623,6 +2623,93 @@ finally:
   cleanup_all
 }
 
+scenario_bearer_cli_recv() {
+  # Phase 2b: prove `python -m airc_core.bearer_cli recv` (the bridge the
+  # bash monitor now uses instead of an inline ssh-tail) emits one line
+  # per envelope, payload-bytes verbatim, suitable for piping straight
+  # into monitor_formatter. If this scenario passes but the monitor still
+  # misses messages, the bug is in the formatter or in the watchdog —
+  # not in the bearer-CLI seam.
+  section "bearer_cli recv: emits one JSONL line per envelope"
+  cleanup_all
+
+  spawn_host /tmp/airc-it-cli-h alpha 7553 || { fail "alpha host failed to start"; return; }
+  pass "host alpha hosting on 7553"
+
+  local join; join=$(read_join_string /tmp/airc-it-cli-h)
+  [ -n "$join" ] || { fail "no join string from alpha"; return; }
+
+  spawn_joiner /tmp/airc-it-cli-j delta "$join" || { fail "delta joiner failed to start"; return; }
+  pass "joiner delta paired with alpha"
+
+  local jstate=/tmp/airc-it-cli-j/state
+  local host_target; host_target=$(python3 -c "import json; print(json.load(open('$jstate/config.json'))['host_target'])" 2>/dev/null)
+  local rhome;       rhome=$(python3 -c "import json; print(json.load(open('$jstate/config.json')).get('host_airc_home','\$HOME/.airc'))" 2>/dev/null)
+  local ikey="$jstate/identity/ssh_key"
+  local _lib_dir; _lib_dir="$(cd "$(dirname "$AIRC")/lib" && pwd)"
+  local hstate=/tmp/airc-it-cli-h/state
+
+  local marker="cli-recv-marker-$(date +%s%N)"
+  local probe='{"from":"alpha","to":"all","ts":"2026-04-29T00:00:00Z","channel":"general","msg":"'"$marker"'","sig":"x"}'
+  local cli_out; cli_out=$(mktemp -t airc-it-cli-recv.XXXXXX)
+  local cli_err; cli_err=$(mktemp -t airc-it-cli-err.XXXXXX)
+
+  # Run bearer_cli recv in the background, captured to a file. Different
+  # offset_file path per invocation so we don't fight the live joiner.
+  local off_file; off_file=$(mktemp -t airc-it-cli-off.XXXXXX); rm -f "$off_file"
+  PYTHONPATH="$_lib_dir" python3 -m airc_core.bearer_cli recv alpha \
+    --host-target "$host_target" \
+    --identity-key "$ikey" \
+    --remote-home "$rhome" \
+    --offset-file "$off_file" \
+    >"$cli_out" 2>"$cli_err" &
+  local cli_pid=$!
+
+  # Give ssh ~3s to connect.
+  sleep 3
+  echo "$probe" >> "$hstate/messages.jsonl"
+
+  # Poll output for the marker.
+  local i found=0
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    sleep 1
+    if grep -q "$marker" "$cli_out" 2>/dev/null; then
+      found=1
+      break
+    fi
+  done
+
+  # Tear down the CLI; SIGTERM should produce a clean exit.
+  kill "$cli_pid" 2>/dev/null
+  wait "$cli_pid" 2>/dev/null
+
+  if [ $found -eq 1 ]; then
+    pass "bearer_cli recv emitted line containing the planted marker"
+  else
+    fail "bearer_cli recv did NOT emit the marker; out: $(cat "$cli_out" 2>/dev/null); err: $(cat "$cli_err" 2>/dev/null)"
+  fi
+
+  # Verify the line is JSONL-shaped (parseable JSON object). Defends
+  # against accidental wrapping or pretty-printing in the CLI.
+  if [ $found -eq 1 ] && python3 -c "
+import json, sys
+for line in open('$cli_out'):
+    line = line.strip()
+    if not line: continue
+    obj = json.loads(line)
+    if obj.get('msg') == '$marker':
+        sys.exit(0)
+sys.exit(1)
+" 2>/dev/null; then
+    pass "bearer_cli recv output is parseable JSONL"
+  elif [ $found -eq 1 ]; then
+    fail "bearer_cli recv emitted the marker but output is not parseable JSONL: $(cat "$cli_out" 2>/dev/null)"
+  fi
+
+  rm -f "$cli_out" "$cli_err" "$off_file"
+  cleanup_all
+}
+
 scenario_python_units() {
   # Python unit tests for airc_core/. Currently exercises the bearer
   # abstraction (lib/airc_core/bearer.py + bearer_resolver.py +
@@ -2675,6 +2762,7 @@ case "$MODE" in
   python_units) scenario_python_units ;;
   bearer_ssh_send) scenario_bearer_ssh_send ;;
   bearer_ssh_recv) scenario_bearer_ssh_recv ;;
+  bearer_cli_recv) scenario_bearer_cli_recv ;;
   ""|all)
     # Default = run everything. The peers_cross_scope + whois_cross_scope
     # scenarios were removed in PR #239 (sidecar walk semantics deleted
@@ -2690,7 +2778,7 @@ case "$MODE" in
     scenario_general_sidecar_default; scenario_away
     scenario_list; scenario_quit; scenario_platform_adapters
     scenario_python_units
-    scenario_bearer_ssh_send; scenario_bearer_ssh_recv
+    scenario_bearer_ssh_send; scenario_bearer_ssh_recv; scenario_bearer_cli_recv
     ;;
   *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|all]"; exit 2 ;;
 esac

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -7,6 +7,7 @@ or:  cd test && python -m unittest test_bearer
 
 from __future__ import annotations
 
+import argparse
 import sys
 import unittest
 from pathlib import Path
@@ -31,6 +32,7 @@ from airc_core.bearer_resolver import (  # noqa: E402
 )
 from airc_core.bearer_ssh import SshBearer, SshBearerError  # noqa: E402
 from airc_core import bearer_ssh  # noqa: E402
+from airc_core import bearer_cli  # noqa: E402
 
 
 class BearerInterfaceTests(unittest.TestCase):
@@ -445,6 +447,219 @@ class CgnatRegexTests(unittest.TestCase):
             # No tailscale = always False. Just verify no crash on user@host form.
             self.assertFalse(bearer_ssh._is_peer_offline_in_tailnet("alice@100.64.0.1"))
             self.assertFalse(bearer_ssh._is_peer_offline_in_tailnet("alice@192.168.1.5"))
+
+
+class BearerCliRecvTests(unittest.TestCase):
+    """Phase 2b: `python -m airc_core.bearer_cli recv` is the bridge from
+    bash monitor → bearer.recv_stream(). The CLI must:
+      - Print one line per envelope (raw payload bytes + \\n)
+      - Pass offset_file through to the bearer for reconnect resume
+      - Exit cleanly on resolver error (with stderr explanation)
+      - Exit cleanly on BrokenPipeError (formatter died)
+    Tests substitute a fake bearer for the resolver to keep them hermetic.
+    """
+
+    class _FakeBearer:
+        """Records open()/close()/recv_stream() calls; yields fixed events."""
+        def __init__(self, peer_meta):
+            self.peer_meta = peer_meta
+            self.opened_for = None
+            self.closed = False
+            self._events = []
+
+        def set_events(self, events):
+            self._events = events
+
+        def open(self, peer_id):
+            self.opened_for = peer_id
+
+        def recv_stream(self):
+            for ev in self._events:
+                yield ev
+
+        def close(self):
+            self.closed = True
+
+    def _make_args(self, **overrides):
+        ns = argparse.Namespace(
+            peer_id="alice",
+            host_target="alice@example",
+            identity_key="/tmp/k",
+            remote_home="$HOME/.airc",
+            offset_file=None,
+        )
+        for k, v in overrides.items():
+            setattr(ns, k, v)
+        return ns
+
+    def _capture_stdout_bytes(self):
+        """Replace sys.stdout with one whose .buffer captures bytes.
+
+        cmd_recv writes to sys.stdout.buffer (binary). Our capture
+        intercepts at that level and lets us read what the CLI emitted.
+        """
+        import io
+        captured = io.BytesIO()
+        fake_stdout = mock.Mock()
+        fake_stdout.buffer = captured
+        return fake_stdout, captured
+
+    def test_recv_emits_one_line_per_envelope(self):
+        events = [
+            ReceivedMessage(
+                sender_peer_id="bob",
+                channel="general",
+                payload=b'{"from":"bob","channel":"general","msg":"hi"}',
+                bearer_metadata={},
+            ),
+            ReceivedMessage(
+                sender_peer_id="carol",
+                channel="general",
+                payload=b'{"from":"carol","channel":"general","msg":"hey"}\n',
+                bearer_metadata={},
+            ),
+        ]
+        fake = self._FakeBearer({})
+        fake.set_events(events)
+
+        fake_stdout, captured = self._capture_stdout_bytes()
+        with mock.patch.object(bearer_cli, "resolve", return_value=fake), \
+             mock.patch.object(bearer_cli.sys, "stdout", fake_stdout):
+            rc = bearer_cli.cmd_recv(self._make_args())
+
+        self.assertEqual(rc, 0)
+        out_lines = captured.getvalue().splitlines(keepends=True)
+        self.assertEqual(len(out_lines), 2)
+        # First payload had no newline; CLI must add one.
+        self.assertEqual(
+            out_lines[0],
+            b'{"from":"bob","channel":"general","msg":"hi"}\n',
+        )
+        # Second payload already had a trailing newline; CLI must not double it.
+        self.assertEqual(
+            out_lines[1],
+            b'{"from":"carol","channel":"general","msg":"hey"}\n',
+        )
+        self.assertTrue(fake.closed, "bearer.close() must be called")
+        self.assertEqual(fake.opened_for, "alice")
+
+    def test_recv_passes_offset_file_to_resolver(self):
+        captured_meta = {}
+
+        def fake_resolve(meta):
+            captured_meta.update(meta)
+            fake = self._FakeBearer(meta)
+            return fake
+
+        fake_stdout, _ = self._capture_stdout_bytes()
+        with mock.patch.object(bearer_cli, "resolve", side_effect=fake_resolve), \
+             mock.patch.object(bearer_cli.sys, "stdout", fake_stdout):
+            bearer_cli.cmd_recv(self._make_args(offset_file="/tmp/monitor_offset"))
+
+        self.assertEqual(captured_meta.get("offset_file"), "/tmp/monitor_offset")
+
+    def test_recv_drops_none_meta_fields(self):
+        captured_meta = {}
+
+        def fake_resolve(meta):
+            captured_meta.update(meta)
+            return self._FakeBearer(meta)
+
+        fake_stdout, _ = self._capture_stdout_bytes()
+        with mock.patch.object(bearer_cli, "resolve", side_effect=fake_resolve), \
+             mock.patch.object(bearer_cli.sys, "stdout", fake_stdout):
+            bearer_cli.cmd_recv(self._make_args(
+                identity_key=None, offset_file=None,
+            ))
+
+        self.assertNotIn("identity_key", captured_meta)
+        self.assertNotIn("offset_file", captured_meta)
+        self.assertEqual(captured_meta.get("host_target"), "alice@example")
+
+    def test_recv_resolver_error_returns_2(self):
+        fake_stderr = mock.Mock()
+
+        def fake_resolve(meta):
+            raise RuntimeError("no bearer can serve this peer")
+
+        with mock.patch.object(bearer_cli, "resolve", side_effect=fake_resolve), \
+             mock.patch.object(bearer_cli.sys, "stderr", fake_stderr):
+            rc = bearer_cli.cmd_recv(self._make_args())
+
+        self.assertEqual(rc, 2)
+        # The error must be surfaced (CLAUDE.md: never swallow errors).
+        printed = "".join(
+            call.args[0] if call.args else ""
+            for call in fake_stderr.print.call_args_list
+        ) if hasattr(fake_stderr, "print") else ""
+        # `print(file=sys.stderr)` calls .write on the file. Inspect that path.
+        write_calls = [c.args[0] for c in fake_stderr.write.call_args_list]
+        joined = "".join(str(x) for x in write_calls)
+        self.assertIn("resolver error", joined)
+
+    def test_recv_broken_pipe_exits_cleanly(self):
+        events = [
+            ReceivedMessage(
+                sender_peer_id="bob",
+                channel="general",
+                payload=b'{"from":"bob","channel":"general","msg":"first"}',
+                bearer_metadata={},
+            ),
+            ReceivedMessage(
+                sender_peer_id="bob",
+                channel="general",
+                payload=b'{"from":"bob","channel":"general","msg":"second"}',
+                bearer_metadata={},
+            ),
+        ]
+        fake = self._FakeBearer({})
+        fake.set_events(events)
+
+        # Buffer that raises BrokenPipeError on the second write — simulates
+        # the formatter exiting after consuming one line.
+        class _BrokenAfter:
+            def __init__(self, n):
+                self.n = n
+                self.writes = 0
+                self.flushes = 0
+
+            def write(self, _data):
+                self.writes += 1
+                if self.writes > self.n:
+                    raise BrokenPipeError()
+
+            def flush(self):
+                self.flushes += 1
+
+        broken = _BrokenAfter(n=1)
+        fake_stdout = mock.Mock()
+        fake_stdout.buffer = broken
+
+        with mock.patch.object(bearer_cli, "resolve", return_value=fake), \
+             mock.patch.object(bearer_cli.sys, "stdout", fake_stdout):
+            rc = bearer_cli.cmd_recv(self._make_args())
+
+        self.assertEqual(rc, 0, "broken pipe must produce graceful exit")
+        self.assertTrue(fake.closed, "bearer.close() must run on broken pipe")
+
+    def test_parser_recognizes_recv(self):
+        # Smoke-test: the recv subparser must be registered with the
+        # right defaults so a typo in cmd binding doesn't slip past.
+        parser = bearer_cli._build_parser()
+        ns = parser.parse_args([
+            "recv", "alice",
+            "--host-target", "alice@example",
+            "--identity-key", "/tmp/k",
+            "--remote-home", "$HOME/.airc",
+            "--offset-file", "/tmp/off",
+        ])
+        self.assertEqual(ns.cmd, "recv")
+        self.assertEqual(ns.peer_id, "alice")
+        self.assertEqual(ns.host_target, "alice@example")
+        self.assertEqual(ns.identity_key, "/tmp/k")
+        self.assertEqual(ns.remote_home, "$HOME/.airc")
+        self.assertEqual(ns.offset_file, "/tmp/off")
+        self.assertIs(ns.func, bearer_cli.cmd_recv)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Flips airc's monitor inbound seam from inline `ssh ... "tail -F messages.jsonl"` to `python -m airc_core.bearer_cli recv` piped into `monitor_formatter`.
- The bearer (lib/airc_core/bearer_ssh.py) owns transport-level reconnects, line-buffering, and offset resume. The bash loop owns ONLY higher-level policy: watchdog (fmt_exit=2), idle-vs-dead probe, escalation → exit 99 → daemon respawn.
- Adds `bearer_cli recv` subcommand + 6 unit tests + 1 integration scenario covering JSONL emission and parseable output.

## Why
With this seam in place, swapping SshBearer for GhBearer or LocalBearer in Phase 3 (#269) changes nothing in the bash monitor — the same watchdog policy applies to any transport. This is the load-bearing piece between Phase 1's send-cutover and Phase 3's Tailscale removal.

## Test plan
- [x] `python_units` (test_bearer.py): 41/41 pass — adds 6 BearerCliRecvTests covering emit/offset/none-drop/error/broken-pipe/parser
- [x] `bearer_cli_recv` (new integration scenario): 4/4 pass on real paired SSH
- [x] `bearer_ssh_send`: 6/6 pass (no regression)
- [x] `bearer_ssh_recv`: 4/4 pass (no regression)
- [x] `tabs` (full bidirectional monitor flow): 19/19 pass — proves both sides see messages through bearer-driven monitor
- [x] `events`: 5/5 pass — system events still flow through formatter
- [x] `reconnect` (host-down/up cycle): 7/7 pass — bearer's internal reconnect works end-to-end
- [x] `resilience` (stale pidfile + dead pidfile + malformed peer): 5/5 pass
- [x] `send_dead_monitor_dies` (no-silent-success rule): 8/8 pass
- [x] `status` (liveness + queue + last-activity): 7/7 pass
- [ ] CI integration suite full pass

## Notes
- Stderr is **not** redirected on the bearer_cli invocation. SSH transport chatter is consumed inside the bearer (stderr=DEVNULL on the ssh subprocess); bearer_cli only writes to stderr for structural failures (resolver error, missing args). Per CLAUDE.md "never swallow errors", those surface to the user.
- `--offset-file` is passed through to the bearer for reconnect resume. Both bearer and formatter currently write to the same offset file; race is benign because both writers count "lines processed" and produce identical values. Phase 2c will collapse offset ownership onto the bearer alone.
- The bash `cycle_lifetime < 30s` heuristic is preserved but rarely triggers now: the bearer reconnects internally, so the cycle only ends on watchdog timeout (canonical death signal) rather than every brief SSH drop. Net improvement — fewer false escalations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)