### PR TITLE
feat(bearer): Phase 2c — bearer-attested observability replaces #270 lies

### DIFF
--- a/airc
+++ b/airc
@@ -1225,6 +1225,7 @@ monitor() {
         --identity-key "$ssh_key" \
         --remote-home "$rhome" \
         --offset-file "$offset_file" \
+        --state-file "$AIRC_WRITE_DIR/bearer_state.json" \
         | monitor_formatter "$my_name" || true
       local fmt_exit="${PIPESTATUS[1]:-0}"
       local cycle_end; cycle_end=$(date +%s)

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -427,48 +427,98 @@ else:
   # months later). Walking them was useful when sidecars were live;
   # post-2B.3 it just resurfaces ghosts.
   #
-  # The unified-roster intent from issue #121 still holds, but in the
-  # singleton-mesh world EVERY peer is in the primary scope's peers/.
-  # Multi-channel context comes from envelope.channel (Phase 2A) +
-  # subscribed_channels (Phase 2B), not from sibling scopes.
+  # Phase 2c (#270): surface per-peer last-seen by scanning the local
+  # messages.jsonl for the most recent envelope from each peer. This
+  # is what was missing when "5 peers earlier today, 1 now" looked
+  # identical to "5 peers, all silent for 30 min" in the listing —
+  # silent records persist on disk regardless of liveness.
   "$AIRC_PYTHON" -c "
-import json, os, sys, re
+import json, os, sys, time, calendar
 
 primary_scope = os.path.expanduser('$AIRC_WRITE_DIR')
-# Phase 2B.3: only walk the primary scope. Sidecar scopes are gone.
-scopes = [primary_scope] if os.path.isdir(os.path.join(primary_scope, 'peers')) else []
+peers_dir = os.path.join(primary_scope, 'peers')
+messages_log = os.path.join(primary_scope, 'messages.jsonl')
 
-# Build {(name, host): [room1, room2, ...]} by walking each scope's peers/.
+if not os.path.isdir(peers_dir):
+    print('  No peers yet.')
+    sys.exit(0)
+
+# Build {(name, host): [room1, room2, ...]} from disk records.
 peers_by_id = {}
-for scope in scopes:
-    peers_dir = os.path.join(scope, 'peers')
-    if not os.path.isdir(peers_dir):
+rn_file = os.path.join(primary_scope, 'room_name')
+room = '(?)'
+if os.path.isfile(rn_file):
+    try: room = open(rn_file).read().strip()
+    except Exception: pass
+for f in sorted(os.listdir(peers_dir)):
+    if not f.endswith('.json'): continue
+    try:
+        d = json.load(open(os.path.join(peers_dir, f)))
+    except Exception:
         continue
-    rn_file = os.path.join(scope, 'room_name')
-    room = '(?)'
-    if os.path.isfile(rn_file):
-        try: room = open(rn_file).read().strip()
-        except Exception: pass
-    for f in sorted(os.listdir(peers_dir)):
-        if not f.endswith('.json'): continue
-        try:
-            d = json.load(open(os.path.join(peers_dir, f)))
-        except Exception:
-            continue
-        key = (d.get('name', f[:-5]), d.get('host', ''))
-        peers_by_id.setdefault(key, []).append(room)
+    key = (d.get('name', f[:-5]), d.get('host', ''))
+    peers_by_id.setdefault(key, []).append(room)
 
 if not peers_by_id:
     print('  No peers yet.')
     sys.exit(0)
 
-# Render. Each peer once, with room annotations sorted + deduped.
+# Compute last-seen per peer name from messages.jsonl. Scan once,
+# track the latest ts per 'from' field. Reading the file forward is
+# fine — it's append-only and rotates at AIRC_LOG_MAX_LINES (5000
+# default), so the scan cost is bounded and we get the most recent
+# ts naturally as the loop terminates.
+last_seen = {}
+def _epoch(ts_str):
+    if not ts_str:
+        return None
+    try:
+        t = time.strptime(ts_str.replace('Z',''), '%Y-%m-%dT%H:%M:%S')
+        return calendar.timegm(t)
+    except Exception:
+        return None
+try:
+    with open(messages_log) as f:
+        for line in f:
+            try:
+                m = json.loads(line)
+            except Exception:
+                continue
+            who = m.get('from')
+            if not who: continue
+            ts = _epoch(m.get('ts'))
+            if ts is None: continue
+            prev = last_seen.get(who)
+            if prev is None or ts > prev:
+                last_seen[who] = ts
+except OSError:
+    pass
+
+now = int(time.time())
+def _fmt_age(ts):
+    if ts is None:
+        return 'never'
+    age = max(0, now - ts)
+    if age < 60:    return f'{age}s ago'
+    if age < 3600:  return f'{age // 60}m ago'
+    if age < 86400: return f'{age // 3600}h ago'
+    return f'{age // 86400}d ago'
+
+# Render. Each peer once, with room annotations + last-seen marker.
+# Silent >1h gets a (silent) flag so the eye catches it immediately.
 for (name, host), rooms in sorted(peers_by_id.items()):
     seen = set(); ordered = []
     for r in rooms:
         if r not in seen:
             ordered.append(r); seen.add(r)
     tags = ', '.join('#' + r for r in ordered)
-    print(f'  {name} → {host}   [{tags}]')
+    last_ts = last_seen.get(name)
+    age_str = _fmt_age(last_ts)
+    silent_flag = ''
+    if last_ts is not None and (now - last_ts) > 3600:
+        silent_flag = ' (silent)'
+    elif last_ts is None:
+        silent_flag = ' (no recorded activity)'
+    print(f'  {name} → {host}   [{tags}]   last seen {age_str}{silent_flag}')
 "
 }

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -110,37 +110,43 @@ cmd_status() {
     echo "  last send:   never"
   fi
 
-  if [ -s "$MESSAGES" ]; then
-    local last_rx_ts
-    last_rx_ts=$(PEERS_DIR="$PEERS_DIR" MY_NAME="$my_name" "$AIRC_PYTHON" -c "
-import sys, json, os, calendar, time
-name = os.environ.get('MY_NAME', '')
-last_ts = None
+  # Last receive: read the bearer-attested state file written by
+  # bearer_cli recv on each event (Phase 2c, #270 fix). The previous
+  # implementation parsed messages.jsonl for the most recent inbound
+  # ts, but that lied for a 30+ minute mesh outage in #270 — the local
+  # mirror said "fresh" while the bearer was actually wedged. The
+  # bearer-state file is the truth: it's only updated when an event
+  # actually flows off the wire.
+  local bearer_state="$AIRC_WRITE_DIR/bearer_state.json"
+  if [ -f "$bearer_state" ]; then
+    local _bs_summary
+    _bs_summary=$("$AIRC_PYTHON" -c "
+import json, sys, time
 try:
-    with open('$MESSAGES') as f:
-        for line in f:
-            try:
-                m = json.loads(line)
-                if m.get('from') and m.get('from') != name and m.get('from') != 'airc':
-                    last_ts = m.get('ts')
-            except: pass
-except: pass
-if last_ts:
-    # ts is ISO8601 UTC (Z-suffix). Convert to epoch.
-    try:
-        t = time.strptime(last_ts.replace('Z',''), '%Y-%m-%dT%H:%M:%S')
-        print(int(calendar.timegm(t)))
-    except: print('')
+    s = json.load(open('$bearer_state'))
+except Exception as e:
+    print(f'unreadable: {e}'); sys.exit(0)
+ts = s.get('last_recv_ts')
+kind = s.get('kind', '?')
+diag = s.get('diag', '')
+total = s.get('events_total', 0)
+if ts is None:
+    print(f'awaiting first event (bearer={kind}, {diag})')
 else:
-    print('')
+    age = int(time.time() - float(ts))
+    print(f'{age}s ago via {kind} ({total} events; {diag})')
 " 2>/dev/null)
-    if [ -n "$last_rx_ts" ]; then
-      echo "  last recv:   $(( now - last_rx_ts ))s ago"
-    else
-      echo "  last recv:   never"
-    fi
+    echo "  bearer:      ${_bs_summary:-unreadable}"
+  elif [ -n "$host_target" ]; then
+    # Joiner with no bearer state — monitor never came up or hasn't
+    # opened the bearer yet. This was previously a silent gap: status
+    # claimed "monitor running" while the inbound path was dead.
+    echo "  bearer:      no state file ($AIRC_WRITE_DIR/bearer_state.json) — monitor not yet streaming"
   else
-    echo "  last recv:   never"
+    # Host: no inbound bearer (we ARE the host). The bearer-state file
+    # is a joiner-side artifact; on a host the local messages.jsonl IS
+    # the source of truth, but we still surface that explicitly.
+    echo "  bearer:      n/a (this scope is hosting; inbound is local log)"
   fi
 
   # Pending queue — how many sends are waiting for a drain. Populated by

--- a/lib/airc_core/bearer_cli.py
+++ b/lib/airc_core/bearer_cli.py
@@ -82,6 +82,13 @@ def cmd_recv(args) -> int:
     bearer captured from the wire (see ReceivedMessage.payload), which
     is JSONL-shaped — directly pipeable into monitor_formatter.
 
+    Optional --state-file: the bearer-attested liveness surface for
+    cross-process consumers (airc status, airc peers). After each event
+    we atomically rewrite the file with bearer kind, events_total,
+    last_recv_ts, last_sender, and the bearer's diagnostic. Phase 2c
+    of the bearer rewrite — replaces the messages.jsonl-mirror-derived
+    "last recv" lie that was passing 30+ minute silences as healthy.
+
     The bearer handles transport-level reconnects (transient SSH drops,
     polling cadence for gh-as-bearer, etc). This loop exits only on:
       - EOF from recv_stream (bearer closed)
@@ -118,6 +125,20 @@ def cmd_recv(args) -> int:
 
     bearer.open(args.peer_id)
     out = sys.stdout.buffer
+    state_file = args.state_file
+    events_total = 0
+    if state_file:
+        # Initial state on launch — distinguishes "bearer is up but no events
+        # yet" from "no bearer at all." Status surfaces this as
+        # "awaiting first event" rather than going silent.
+        _write_state_file(state_file, {
+            "kind": getattr(bearer, "KIND", "unknown"),
+            "peer_id": args.peer_id,
+            "last_recv_ts": None,
+            "last_sender": None,
+            "events_total": 0,
+            "diag": "bearer open, no events yet",
+        })
     try:
         for ev in bearer.recv_stream():
             line = ev.payload
@@ -130,11 +151,49 @@ def cmd_recv(args) -> int:
                 # Downstream formatter exited. Caller's watchdog will
                 # observe the broken cycle and reconnect us if needed.
                 break
+            if state_file:
+                events_total += 1
+                live = bearer.liveness(args.peer_id)
+                _write_state_file(state_file, {
+                    "kind": getattr(bearer, "KIND", "unknown"),
+                    "peer_id": args.peer_id,
+                    "last_recv_ts": live.last_seen_ts,
+                    "last_sender": ev.sender_peer_id,
+                    "events_total": events_total,
+                    "diag": live.bearer_diag,
+                })
     except KeyboardInterrupt:
         pass
     finally:
         bearer.close()
     return 0
+
+
+def _write_state_file(path: str, state: dict) -> None:
+    """Atomically rewrite the bearer-state file. Best-effort — failures
+    are swallowed because state-file IO must never break the recv loop;
+    the bash watchdog and the bearer's own liveness signal remain the
+    source of truth even if status surfacing goes stale.
+
+    Atomic rewrite via tmp + rename so a reader (airc status) never
+    sees a half-written file.
+    """
+    import os
+    import tempfile
+    try:
+        d = os.path.dirname(path) or "."
+        fd, tmp = tempfile.mkstemp(prefix=".bearer_state-", dir=d)
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(state, f)
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+    except OSError:
+        pass
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -162,6 +221,9 @@ def _build_parser() -> argparse.ArgumentParser:
                       help="Remote AIRC_WRITE_DIR path (e.g. '$HOME/.airc')")
     recv.add_argument("--offset-file", default=None,
                       help="Path to monitor_offset file for resume-on-reconnect")
+    recv.add_argument("--state-file", default=None,
+                      help="Path to bearer_state.json — bearer-attested liveness "
+                           "for cross-process consumers (airc status, airc peers)")
     recv.set_defaults(func=cmd_recv)
 
     return p

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -689,6 +689,10 @@ scenario_status() {
                                                 || fail "host status: monitor not shown running"
   echo "$h_out" | grep -q 'queue:.*empty' && pass "host status: queue empty (no pending)" \
                                           || fail "host status: queue line wrong"
+  # Phase 2c (#270): host has no inbound bearer — surface that explicitly
+  # rather than the messages.jsonl-mirror-derived "last recv" lie.
+  echo "$h_out" | grep -Eq 'bearer:\s+(n/a|.*hosting)' && pass "host status: bearer line marks 'n/a' (hosting)" \
+                                                       || fail "host status missing bearer:n/a line (got: $h_out)"
 
   # Joiner status: should show "joiner of shost". host port is whatever
   # shost actually bound to (auto-bump-aware) — the joiner records what
@@ -699,6 +703,13 @@ scenario_status() {
                                       || fail "joiner status missing joiner-of line (got: $j_out)"
   echo "$j_out" | grep -qE ':[0-9]+' && pass "joiner status: host port visible" \
                                      || fail "joiner status missing host port (got: $j_out)"
+  # Phase 2c (#270): joiner status MUST surface a bearer line. Either
+  # "awaiting first event" (bearer up but quiet) or "Ns ago via ssh"
+  # (events flowing). The pre-2c "last recv" computed from messages.jsonl
+  # is gone — that was the exact lie that hid 30+ minute outages.
+  echo "$j_out" | grep -qE 'bearer:\s+(awaiting first event|[0-9]+s ago via|no state file)' \
+    && pass "joiner status: bearer-attested liveness line present" \
+    || fail "joiner status missing bearer line (got: $j_out)"
 
   # Send a message then assert status reflects activity
   as_home /tmp/airc-it-s-j send @shost "status-probe" >/dev/null 2>&1
@@ -2710,6 +2721,87 @@ sys.exit(1)
   cleanup_all
 }
 
+scenario_bearer_observability() {
+  # Phase 2c (#270): the bearer-attested liveness surface must replace
+  # the messages.jsonl-mirror-derived "last recv" lie. After a real
+  # message lands on the joiner, bearer_state.json must reflect it AND
+  # `airc status` must report a fresh-seconds age (not a stale 30+ min
+  # gap). `airc peers` must annotate the silent peer with a last-seen
+  # marker so 30 days of silence is impossible to mistake for "active."
+  section "bearer observability: state file + status + peers reflect real liveness"
+  cleanup_all
+
+  spawn_host /tmp/airc-it-bo-h obs-host 7554 || { fail "obs-host failed to start"; return; }
+  pass "obs-host hosting on 7554"
+
+  local join; join=$(read_join_string /tmp/airc-it-bo-h)
+  spawn_joiner /tmp/airc-it-bo-j obs-joiner "$join" || { fail "obs-joiner failed to join"; return; }
+  pass "obs-joiner paired"
+
+  # Send a probe DM through the live monitor so the bearer's recv path
+  # actually fires. as_home picks up the joiner's scope.
+  local marker="bearer-obs-marker-$(date +%s)"
+  as_home /tmp/airc-it-bo-h send @obs-joiner "$marker" >/dev/null 2>&1 || true
+
+  # Give the joiner monitor a moment to receive + write state.
+  sleep 3
+
+  local state_file=/tmp/airc-it-bo-j/state/bearer_state.json
+  if [ -f "$state_file" ]; then
+    pass "bearer_state.json materialized in joiner scope"
+  else
+    fail "bearer_state.json missing — bearer never wrote it"
+    cleanup_all; return
+  fi
+
+  # last_recv_ts must be populated and recent (within 30s).
+  local fresh
+  fresh=$(python3 -c "
+import json, time
+s = json.load(open('$state_file'))
+ts = s.get('last_recv_ts')
+if ts is None:
+    print('NONE')
+elif time.time() - float(ts) > 30:
+    print('STALE')
+else:
+    print('FRESH')
+" 2>/dev/null)
+  case "$fresh" in
+    FRESH) pass "bearer_state.last_recv_ts is fresh (<30s)" ;;
+    STALE) fail "bearer_state.last_recv_ts is stale (state: $(cat "$state_file"))" ;;
+    *)     fail "bearer_state.last_recv_ts not set (state: $(cat "$state_file"))" ;;
+  esac
+
+  # kind must be "ssh" (the only registered bearer in Phase 2c).
+  local kind; kind=$(python3 -c "import json; print(json.load(open('$state_file'))['kind'])" 2>/dev/null)
+  if [ "$kind" = "ssh" ]; then
+    pass "bearer_state.kind == 'ssh' (bearer attests its own KIND)"
+  else
+    fail "bearer_state.kind != 'ssh' (got: $kind)"
+  fi
+
+  # `airc status` must report a fresh "via ssh" line — not a >30s gap.
+  local j_out; j_out=$(AIRC_HOME=/tmp/airc-it-bo-j/state "$AIRC" status 2>&1)
+  if echo "$j_out" | grep -qE 'bearer:\s+[0-9]+s ago via ssh'; then
+    pass "airc status surfaces bearer-attested 'Ns ago via ssh'"
+  else
+    fail "airc status bearer line missing fresh ts (got: $(echo "$j_out" | grep bearer))"
+  fi
+
+  # `airc peers` on the joiner must show the host with a last-seen marker.
+  # Since we just received a message FROM the host, the host's name should
+  # appear with a recent age (seconds, not minutes/hours).
+  local j_peers; j_peers=$(AIRC_HOME=/tmp/airc-it-bo-j/state "$AIRC" peers 2>&1)
+  if echo "$j_peers" | grep -qE 'last seen [0-9]+s ago'; then
+    pass "airc peers shows fresh per-peer last-seen"
+  else
+    fail "airc peers missing last-seen annotation (got: $j_peers)"
+  fi
+
+  cleanup_all
+}
+
 scenario_python_units() {
   # Python unit tests for airc_core/. Currently exercises the bearer
   # abstraction (lib/airc_core/bearer.py + bearer_resolver.py +
@@ -2763,6 +2855,7 @@ case "$MODE" in
   bearer_ssh_send) scenario_bearer_ssh_send ;;
   bearer_ssh_recv) scenario_bearer_ssh_recv ;;
   bearer_cli_recv) scenario_bearer_cli_recv ;;
+  bearer_observability) scenario_bearer_observability ;;
   ""|all)
     # Default = run everything. The peers_cross_scope + whois_cross_scope
     # scenarios were removed in PR #239 (sidecar walk semantics deleted
@@ -2779,6 +2872,7 @@ case "$MODE" in
     scenario_list; scenario_quit; scenario_platform_adapters
     scenario_python_units
     scenario_bearer_ssh_send; scenario_bearer_ssh_recv; scenario_bearer_cli_recv
+    scenario_bearer_observability
     ;;
   *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|all]"; exit 2 ;;
 esac

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -487,6 +487,7 @@ class BearerCliRecvTests(unittest.TestCase):
             identity_key="/tmp/k",
             remote_home="$HOME/.airc",
             offset_file=None,
+            state_file=None,
         )
         for k, v in overrides.items():
             setattr(ns, k, v)
@@ -652,6 +653,7 @@ class BearerCliRecvTests(unittest.TestCase):
             "--identity-key", "/tmp/k",
             "--remote-home", "$HOME/.airc",
             "--offset-file", "/tmp/off",
+            "--state-file", "/tmp/state",
         ])
         self.assertEqual(ns.cmd, "recv")
         self.assertEqual(ns.peer_id, "alice")
@@ -659,7 +661,177 @@ class BearerCliRecvTests(unittest.TestCase):
         self.assertEqual(ns.identity_key, "/tmp/k")
         self.assertEqual(ns.remote_home, "$HOME/.airc")
         self.assertEqual(ns.offset_file, "/tmp/off")
+        self.assertEqual(ns.state_file, "/tmp/state")
         self.assertIs(ns.func, bearer_cli.cmd_recv)
+
+
+class BearerCliStateFileTests(unittest.TestCase):
+    """Phase 2c: bearer_cli recv writes a per-event state file that
+    `airc status` reads. The state file is the bearer-attested liveness
+    surface that replaces the messages.jsonl-mirror lie identified in
+    #270 (status said 'fresh' while bearer was actually wedged).
+    Test contract:
+      - On launch, state file is initialized with last_recv_ts=None.
+      - Each event rewrites it with monotonically growing events_total.
+      - The write is atomic (no half-written file on race).
+      - kind/peer_id/diag passthrough from the bearer is preserved.
+    """
+
+    class _FakeBearer:
+        KIND = "fake-ssh"
+
+        def __init__(self, peer_meta):
+            self.peer_meta = peer_meta
+            self._events = []
+            self._next_ts = 1714435200.0
+            self.closed = False
+
+        def set_events(self, events):
+            self._events = events
+
+        def open(self, peer_id):
+            self._peer_id = peer_id
+
+        def recv_stream(self):
+            for ev in self._events:
+                yield ev
+
+        def liveness(self, peer_id):
+            self._next_ts += 1.0
+            return LivenessResult(
+                peer_id=peer_id,
+                last_seen_ts=self._next_ts,
+                bearer_diag="last event from fake bearer",
+            )
+
+        def close(self):
+            self.closed = True
+
+    def _make_args(self, state_file):
+        return argparse.Namespace(
+            peer_id="alice",
+            host_target="alice@example",
+            identity_key="/tmp/k",
+            remote_home="$HOME/.airc",
+            offset_file=None,
+            state_file=state_file,
+        )
+
+    def _capture_stdout_bytes(self):
+        import io
+        captured = io.BytesIO()
+        fake_stdout = mock.Mock()
+        fake_stdout.buffer = captured
+        return fake_stdout, captured
+
+    def test_state_file_initialized_on_launch(self):
+        import json as _json
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as f:
+            state_path = f.name
+
+        fake = self._FakeBearer({})
+        # No events; the bearer closes after the (empty) iter.
+        fake.set_events([])
+
+        fake_stdout, _ = self._capture_stdout_bytes()
+        with mock.patch.object(bearer_cli, "resolve", return_value=fake), \
+             mock.patch.object(bearer_cli.sys, "stdout", fake_stdout):
+            bearer_cli.cmd_recv(self._make_args(state_path))
+
+        with open(state_path) as f:
+            state = _json.load(f)
+        self.assertEqual(state["kind"], "fake-ssh")
+        self.assertEqual(state["peer_id"], "alice")
+        self.assertIsNone(state["last_recv_ts"])
+        self.assertEqual(state["events_total"], 0)
+        self.assertIn("no events yet", state["diag"].lower())
+
+    def test_state_file_updated_per_event(self):
+        import json as _json
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as f:
+            state_path = f.name
+
+        events = [
+            ReceivedMessage(
+                sender_peer_id="bob",
+                channel="general",
+                payload=b'{"from":"bob","channel":"general","msg":"hi"}',
+                bearer_metadata={},
+            ),
+            ReceivedMessage(
+                sender_peer_id="carol",
+                channel="general",
+                payload=b'{"from":"carol","channel":"general","msg":"hey"}',
+                bearer_metadata={},
+            ),
+        ]
+        fake = self._FakeBearer({})
+        fake.set_events(events)
+
+        fake_stdout, _ = self._capture_stdout_bytes()
+        with mock.patch.object(bearer_cli, "resolve", return_value=fake), \
+             mock.patch.object(bearer_cli.sys, "stdout", fake_stdout):
+            bearer_cli.cmd_recv(self._make_args(state_path))
+
+        with open(state_path) as f:
+            state = _json.load(f)
+        self.assertEqual(state["events_total"], 2)
+        self.assertEqual(state["last_sender"], "carol")
+        self.assertIsNotNone(state["last_recv_ts"])
+        # Bearer's liveness ts was 1714435200 + (2 events × 1s for liveness call) + 1 (init) → check it's reasonable
+        self.assertGreater(state["last_recv_ts"], 1714435200.0)
+        self.assertEqual(state["kind"], "fake-ssh")
+
+    def test_no_state_file_means_no_writes(self):
+        events = [ReceivedMessage(
+            sender_peer_id="bob",
+            channel="general",
+            payload=b'{"from":"bob","msg":"x"}',
+            bearer_metadata={},
+        )]
+        fake = self._FakeBearer({})
+        fake.set_events(events)
+
+        fake_stdout, captured = self._capture_stdout_bytes()
+        # Patch _write_state_file to detect any unwanted call.
+        with mock.patch.object(bearer_cli, "resolve", return_value=fake), \
+             mock.patch.object(bearer_cli.sys, "stdout", fake_stdout), \
+             mock.patch.object(bearer_cli, "_write_state_file") as mock_write:
+            bearer_cli.cmd_recv(self._make_args(state_file=None))
+
+        mock_write.assert_not_called()
+        # But events still flow to stdout — state-file is purely additive.
+        self.assertIn(b'{"from":"bob","msg":"x"}', captured.getvalue())
+
+    def test_state_file_write_is_atomic_via_replace(self):
+        """The write must use os.replace (or equivalent) so a reader
+        never sees a half-written file. We assert that no .json file
+        with broken JSON ever appears at the target path during write.
+        """
+        import json as _json
+        import tempfile
+        import os as _os
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as f:
+            f.write('{"old": "state"}')
+            state_path = f.name
+
+        # _write_state_file should leave the target either unchanged or
+        # fully rewritten — never empty/partial.
+        bearer_cli._write_state_file(state_path, {
+            "kind": "ssh",
+            "peer_id": "alice",
+            "last_recv_ts": 12345.0,
+            "last_sender": "bob",
+            "events_total": 5,
+            "diag": "ok",
+        })
+
+        with open(state_path) as f:
+            state = _json.load(f)  # must not raise
+        self.assertEqual(state["events_total"], 5)
+        _os.unlink(state_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Closes the observability lies in #270. The previous \`airc status\` / \`airc peers\` surfaces parsed messages.jsonl mirrors and disk records — both stale-by-construction signals that passed 30+ minute substrate outages as healthy. Now status reads a bearer-written state file (only updated when an event flows off the wire), and peers annotates per-peer last-seen so silent records can't masquerade as active.

## Why
Quoting #270: status reported \"last recv 2687s ago\" while every claim downstream (queue empty, send returns 0) said \"healthy.\" The bearer's own \`liveness()\` signal already existed from Phase 2a — this phase just bridges it cross-process via a state file the monitor's recv driver writes on each event.

## Mechanism
- \`bearer_cli recv\` accepts \`--state-file\` and atomically rewrites it with \`{kind, peer_id, last_recv_ts, last_sender, events_total, diag}\` per event. \`os.replace\` keeps readers safe from partials.
- \`airc\` wires the state-file path to \`$AIRC_WRITE_DIR/bearer_state.json\`.
- \`cmd_status\` reads it: \`bearer: Ns ago via ssh (N events; <diag>)\` — or \`awaiting first event\` / \`no state file\` for the bearer-up-but-quiet and bearer-not-running cases.
- \`cmd_peers\` scans \`messages.jsonl\` once per invocation, computes per-peer last-seen, formats \`last seen 5s ago\` / \`last seen 17m ago\` / \`last seen 2h ago (silent)\`. >1h triggers the silence flag.

## Test plan
- [x] \`python_units\` (test_bearer): 45/45 pass — 4 new BearerCliStateFileTests
- [x] \`bearer_observability\` (new): 7/7 — state file appears, ts fresh <30s, kind='ssh', status reports 'Ns ago via ssh', peers shows last-seen
- [x] \`status\` (with new bearer-line assertions): 9/9 pass on both host and joiner
- [x] \`tabs\` (full bidirectional + peers regression): 19/19 pass
- [x] \`whois\`: 5/5; \`kick\`: 12/12 — peer-record reads still clean
- [ ] CI integration suite

## Notes
- Bearer state-file is purely additive: omitting \`--state-file\` (any existing direct caller of bearer_cli) makes the CLI write nothing. Phase 2b's bearer_cli recv keeps working unchanged.
- The race I considered: bearer_cli writes state file on each event AT THE SAME TIME formatter writes monitor_offset. Different files, different concerns; no conflict.
- Once Phase 3 lands, status will read 'Ns ago via gh' or 'Ns ago via local' with zero changes here — the seam is load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)