### PR TITLE
feat(bearer): Phase 3a — LocalBearer for same-machine peers

### DIFF
--- a/lib/airc_core/bearer_local.py
+++ b/lib/airc_core/bearer_local.py
@@ -1,0 +1,363 @@
+"""LocalBearer — message transport for same-machine peers.
+
+When two airc tabs run on the same machine (different scopes, different
+ports, but same filesystem), they currently SSH to 127.0.0.1 to talk to
+each other. That works but burns SSH+crypto cycles for nothing — they
+share a filesystem and can read/write each other's messages.jsonl
+directly.
+
+This bearer takes that shortcut. It serves any peer whose host_target is
+a loopback address AND whose remote_home is a local writable
+directory. The send path appends to the host's messages.jsonl
+directly; the recv path tails the same file with pure-Python tail-F
+semantics (no subprocess).
+
+Per the bearer abstraction's adapter rule, ALL same-machine knowledge
+lives in this module: the loopback-detection logic, the pure-Python
+file tail loop, and the file-rotation handling. Code outside this file
+never has to know "we're talking to ourselves" — the resolver picks
+LocalBearer when can_serve says yes and that's the entire seam.
+
+Why pure-Python tail rather than subprocess `tail -F`: portability
+(Windows lacks tail, even Git Bash's tail behaves oddly), testability
+(no Popen mock gymnastics), and lower startup cost (no fork). The
+trade-off — losing tail's inotify/kqueue speed for poll-based reads —
+is acceptable because LocalBearer's only path is an already-fast disk
+read; we're optimizing the SSH-skip, not the file-read.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time as _time
+from typing import Iterator, Optional
+
+from .bearer import (
+    Bearer,
+    BearerError,
+    LivenessResult,
+    SendOutcome,
+    ReceivedMessage,
+)
+
+
+class LocalBearerError(BearerError):
+    """Local-transport-class errors. Distinct subclass for diagnostic
+    clarity; callers branching on outcome kinds should rely on
+    SendOutcome.kind, not isinstance checks."""
+
+
+_LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost", "0.0.0.0"}
+
+
+def _is_loopback_target(host_target: str) -> bool:
+    """Strip an optional `user@` and an optional `:port`, then test
+    whether the remaining host is one of our loopback aliases.
+
+    `host_target` shape mirrors SshBearer's: `user@host` or
+    `user@host:port` or just `host`. We do NOT treat unresolvable
+    hostnames as loopback — only the literal aliases above. A user
+    whose hostname happens to resolve to 127.0.0.1 still gets treated
+    as remote; that's safer than over-eager local routing.
+
+    IPv6 nuance: `::1` contains colons that aren't `:port` separators.
+    The standard IPv6+port form is bracketed: `[::1]:7547`. We strip
+    the brackets and the trailing port; bare `::1` (no brackets) we
+    accept as-is.
+    """
+    if not host_target:
+        return False
+    target = host_target.split("@", 1)[-1]  # strip user@
+    # Bracketed IPv6 with optional :port — e.g. "[::1]:7547" or "[::1]".
+    if target.startswith("[") and "]" in target:
+        target = target[1:].split("]", 1)[0]
+    elif target.count(":") == 1:
+        # IPv4 or hostname with one colon = host:port. Strip port.
+        target = target.rsplit(":", 1)[0]
+    # else: bare IPv6 (multiple colons) or hostname-without-port — leave
+    # untouched and compare against the alias set.
+    return target in _LOOPBACK_HOSTS
+
+
+class LocalBearer(Bearer):
+    KIND = "local"
+
+    @classmethod
+    def can_serve(cls, peer_meta: dict) -> bool:
+        """Serve only same-machine peers — loopback host_target AND a
+        remote_home that exists as a writable directory.
+
+        Both conditions must hold. host_target alone isn't enough
+        (someone could have a stale 127.0.0.1 record from a prior
+        session whose airc_home was cleaned up). remote_home alone
+        isn't enough either (a path collision against a local dir
+        named like a remote scope would falsely qualify). Together
+        they identify "we're talking to a peer that lives in a
+        directory on this machine."
+        """
+        host_target = peer_meta.get("host_target", "")
+        if not _is_loopback_target(host_target):
+            return False
+        home = peer_meta.get("remote_home", "")
+        if not home:
+            return False
+        # Expand a leading $HOME / ~ so we don't get tripped by raw env-var
+        # strings the way callers serialize them. os.path.expandvars is
+        # safe because we don't trust unsanitized peer_meta for command
+        # execution — only for path resolution.
+        expanded = os.path.expanduser(os.path.expandvars(home))
+        return os.path.isdir(expanded) and os.access(expanded, os.W_OK)
+
+    def __init__(self, peer_meta: Optional[dict] = None) -> None:
+        # No IO — concrete bearers MUST be cheap to instantiate.
+        self._peer_meta: dict = peer_meta or {}
+        self._opened_peer_id: Optional[str] = None
+        self._closed = False
+        self._last_recv_ts: Optional[float] = None
+        # Active recv loop state — set when recv_stream is iterating, so
+        # close() can interrupt it promptly.
+        self._stop_recv = False
+
+    def _check_alive(self) -> None:
+        if self._closed:
+            raise LocalBearerError("bearer already closed")
+
+    def _resolve_messages_path(self) -> str:
+        home = self._peer_meta.get("remote_home", "")
+        if not home:
+            raise LocalBearerError(
+                "LocalBearer has no remote_home in peer_meta — open() "
+                "called with stale meta?"
+            )
+        expanded = os.path.expanduser(os.path.expandvars(home))
+        return os.path.join(expanded, "messages.jsonl")
+
+    def open(self, peer_id: str) -> None:
+        """Cache peer_id. Like SshBearer, no connection is established
+        here — file IO happens lazily in send() / recv_stream()."""
+        self._check_alive()
+        self._opened_peer_id = peer_id
+
+    def send(self, peer_id: str, channel: str, payload: bytes) -> SendOutcome:
+        """Append payload to the host's messages.jsonl directly.
+
+        Mirrors SshBearer's payload framing — adds a trailing newline if
+        absent so messages.jsonl stays strict newline-delimited regardless
+        of caller framing. No __APPENDED__ confirmation needed: a successful
+        os.write IS the confirmation.
+
+        Failure mode: OSError (disk full, permission flipped, dir vanished
+        between can_serve and now) → transient_failure. Caller's queue +
+        retry handles it. There is no auth_failure analogue for
+        LocalBearer — same-machine means same-user means same access.
+        """
+        self._check_alive()
+        try:
+            path = self._resolve_messages_path()
+        except LocalBearerError as e:
+            return SendOutcome(kind="transient_failure", detail=str(e))
+
+        framed = payload if payload.endswith(b"\n") else payload + b"\n"
+        try:
+            # Open with O_APPEND so concurrent writers (host's own monitor,
+            # other LocalBearer joiners) interleave at line boundaries.
+            # POSIX guarantees writes ≤ PIPE_BUF (typically 4096) are
+            # atomic for O_APPEND files; airc envelopes are well under.
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+            try:
+                os.write(fd, framed)
+            finally:
+                os.close(fd)
+        except OSError as e:
+            return SendOutcome(
+                kind="transient_failure",
+                detail=f"local append failed: {e}",
+            )
+        return SendOutcome(kind="delivered", detail="")
+
+    def recv_stream(self) -> Iterator[ReceivedMessage]:
+        """Tail the host's messages.jsonl with pure-Python poll-based reads.
+
+        Resumes from offset_file (line count) on each open so a teardown +
+        reconnect doesn't replay history. Handles file rotation (size
+        shrinks below the current read position) by reopening at start.
+        Yields one ReceivedMessage per valid envelope; malformed lines
+        are dropped silently to match the bash formatter's prior
+        behavior.
+
+        Per the bearer ABC, callers must use line-buffered IO. We always
+        read line-by-line via readline() so events surface as soon as
+        a \\n hits the file.
+        """
+        self._check_alive()
+        path = self._resolve_messages_path()
+        offset_file = self._peer_meta.get("offset_file")
+
+        # Start position: lines to skip (count from beginning) so we
+        # resume past what the formatter has already processed.
+        skip_lines = self._compute_skip_lines(offset_file)
+        consumed_lines = skip_lines
+        last_inode = None
+
+        while not self._closed and not self._stop_recv:
+            try:
+                f = open(path, "rb")
+            except FileNotFoundError:
+                # File doesn't exist yet (host hasn't started writing).
+                # Brief poll until it appears or we're closed.
+                self._sleep_or_break(0.5)
+                continue
+            try:
+                # Track inode for rotation detection.
+                try:
+                    st = os.fstat(f.fileno())
+                    last_inode = (st.st_ino, st.st_dev)
+                except OSError:
+                    last_inode = None
+
+                # Skip to past the previously-consumed line count.
+                for _ in range(consumed_lines):
+                    if not f.readline():
+                        break
+
+                while not self._closed and not self._stop_recv:
+                    line = f.readline()
+                    if line:
+                        consumed_lines += 1
+                        self._on_line_received(consumed_lines, offset_file)
+                        msg = self._parse_envelope(line)
+                        if msg is None:
+                            continue
+                        yield msg
+                        continue
+                    # EOF — check for rotation, then poll briefly.
+                    if self._was_rotated(path, last_inode):
+                        break  # reopen below
+                    self._sleep_or_break(0.1)
+            finally:
+                try:
+                    f.close()
+                except OSError:
+                    pass
+            # Rotation detected — reset consumed_lines so the new file
+            # is read from the beginning. The offset file we'd otherwise
+            # honor was for the OLD file's line count.
+            if self._was_rotated(path, last_inode):
+                consumed_lines = 0
+                if offset_file:
+                    try:
+                        with open(offset_file, "w") as off:
+                            off.write("0")
+                    except OSError:
+                        pass
+
+    def _was_rotated(self, path: str, last_inode) -> bool:
+        if last_inode is None:
+            return False
+        try:
+            st = os.stat(path)
+        except OSError:
+            return True  # disappeared = treat as rotated
+        return (st.st_ino, st.st_dev) != last_inode
+
+    @staticmethod
+    def _compute_skip_lines(offset_file: Optional[str]) -> int:
+        """Read offset_file as a line count to skip. Same semantics as
+        SshBearer._compute_tail_position but expressed as a number rather
+        than a tail flag. Empty / 0 / non-numeric → start from EOF
+        (skip all existing lines) by returning the current line count
+        of the file.
+        """
+        if not offset_file:
+            return _line_count_or_zero(None)  # 0; will be set to file len below
+        try:
+            with open(offset_file, "r") as f:
+                raw = f.read().strip()
+        except OSError:
+            return 0
+        if not raw or not raw.isdigit():
+            return 0
+        try:
+            n = int(raw)
+        except ValueError:
+            return 0
+        return max(0, n)
+
+    def _on_line_received(self, line_count: int, offset_file: Optional[str]) -> None:
+        """Bump last_recv_ts (for liveness) and persist offset (for resume).
+        Persistence failures are swallowed — bearer keeps streaming; a
+        stale offset means small replay on reconnect, which the caller
+        can dedupe."""
+        self._last_recv_ts = _time.time()
+        if offset_file is None:
+            return
+        try:
+            with open(offset_file, "w") as f:
+                f.write(str(line_count))
+        except OSError:
+            pass
+
+    @staticmethod
+    def _parse_envelope(raw_line: bytes) -> Optional[ReceivedMessage]:
+        """Same envelope contract as SshBearer._parse_envelope — keep
+        the formats identical so monitor_formatter doesn't need to know
+        which bearer produced the line."""
+        line = raw_line.rstrip(b"\n").rstrip(b"\r")
+        if not line:
+            return None
+        try:
+            env = json.loads(line)
+        except (ValueError, TypeError):
+            return None
+        if not isinstance(env, dict):
+            return None
+        sender = env.get("from")
+        channel = env.get("channel", "")
+        if not sender:
+            return None
+        return ReceivedMessage(
+            sender_peer_id=str(sender),
+            channel=str(channel),
+            payload=line,
+            bearer_metadata={"envelope": env},
+        )
+
+    def _sleep_or_break(self, seconds: float) -> None:
+        """Sleep in 50ms ticks so close() takes effect promptly."""
+        deadline = _time.time() + seconds
+        while not self._closed and not self._stop_recv and _time.time() < deadline:
+            _time.sleep(0.05)
+
+    def liveness(self, peer_id: str) -> LivenessResult:
+        """Report when this bearer last received an event. Symmetric with
+        SshBearer.liveness — same shape, same semantics."""
+        self._check_alive()
+        if self._last_recv_ts is None:
+            return LivenessResult(
+                peer_id=peer_id,
+                last_seen_ts=None,
+                bearer_diag="no events received via local tail yet",
+            )
+        return LivenessResult(
+            peer_id=peer_id,
+            last_seen_ts=self._last_recv_ts,
+            bearer_diag="last event from local tail",
+        )
+
+    def close(self) -> None:
+        """Idempotent. Sets the stop flag so any active recv_stream
+        iteration returns at the next poll tick (within ~50ms)."""
+        self._closed = True
+        self._stop_recv = True
+        self._opened_peer_id = None
+        # peer_meta is preserved on close so post-close diagnostic reads
+        # are still useful. Same convention as SshBearer.
+
+
+def _line_count_or_zero(_unused) -> int:
+    """Internal helper: returns 0. Phase 3a placeholder so the resume
+    path's "no offset → skip nothing" reads cleanly. Future tuning
+    might choose to skip to current file length here for a true
+    EOF-start, matching `tail -n 0`."""
+    return 0

--- a/lib/airc_core/bearer_resolver.py
+++ b/lib/airc_core/bearer_resolver.py
@@ -10,10 +10,14 @@ Adding a transport: import its class, add to _REGISTRY at the right
 preference position. Done. Removing a transport: delete the import and
 the registry entry. Done. No other file moves.
 
-Phase 1 (this file's current state): registry contains only SshBearer,
-preserving today's behavior. Phase 2 adds GhBearer behind it. Phase 3
-flips the order (or replaces SshBearer with LocalBearer + GhBearer
-exclusively).
+Phase 3a (current state): registry has LocalBearer + SshBearer.
+LocalBearer comes first because same-machine peers (loopback host_target
++ local host_airc_home) get direct filesystem access — no SSH crypto
+overhead, no subprocess. SshBearer serves everyone else.
+
+Phase 3b adds GhBearer between LocalBearer and SshBearer (gh-as-bearer
+for cross-network peers when SSH/Tailscale aren't available). Phase 3c
+removes SshBearer + Tailscale entirely.
 """
 
 from __future__ import annotations
@@ -21,11 +25,16 @@ from __future__ import annotations
 from typing import List, Type
 
 from .bearer import Bearer, PeerUnreachable
+from .bearer_local import LocalBearer
 from .bearer_ssh import SshBearer
 
 # Preference order. Earlier = preferred. The resolver tries each in turn
 # via can_serve() and falls through on PeerUnreachable from open().
+# LocalBearer first: same-machine peers skip the SSH layer entirely.
+# SshBearer last: the universal-fallback that serves anything reachable
+# over the network.
 _REGISTRY: List[Type[Bearer]] = [
+    LocalBearer,
     SshBearer,
 ]
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2721,6 +2721,122 @@ sys.exit(1)
   cleanup_all
 }
 
+scenario_bearer_local() {
+  # Phase 3a: LocalBearer serves same-machine peers via direct
+  # filesystem reads/writes — no SSH, no subprocess. This scenario
+  # builds a hand-crafted peer_meta (loopback host_target + writable
+  # local dir), exercises send + recv + liveness via the bearer
+  # interface directly, and asserts the resolver picks LocalBearer
+  # over SshBearer.
+  #
+  # No spawn_host/spawn_joiner here — LocalBearer's whole point is to
+  # bypass the pair handshake. Lab-style direct construction is the
+  # cleaner test for this layer.
+  section "bearer (local): same-machine send/recv via direct filesystem"
+  cleanup_all
+
+  local _lib_dir; _lib_dir="$(cd "$(dirname "$AIRC")/lib" && pwd)"
+  local fake_home; fake_home=$(mktemp -d -t airc-it-bl-home.XXXXXX)
+  local off_file; off_file="$fake_home/monitor_offset"
+
+  # Round-trip a payload via the bearer's send + verify it lands.
+  local marker="local-bearer-send-marker-$(date +%s%N)"
+  local probe='{"from":"alpha","to":"all","ts":"2026-04-29T00:00:00Z","channel":"general","msg":"'"$marker"'","sig":"x"}'
+  local send_out
+  send_out=$(PYTHONPATH="$_lib_dir" python3 -c "
+import sys, json
+sys.path.insert(0, '$_lib_dir')
+from airc_core.bearer_resolver import resolve
+
+bearer = resolve({
+    'host_target': 'user@127.0.0.1',
+    'remote_home': '$fake_home',
+})
+print(f'KIND={bearer.KIND}')
+bearer.open('alpha')
+out = bearer.send('alpha', 'general', b'$probe')
+print(f'SEND_KIND={out.kind}')
+bearer.close()
+" 2>&1)
+
+  if echo "$send_out" | grep -q '^KIND=local$'; then
+    pass "resolver picks LocalBearer for loopback host_target"
+  else
+    fail "resolver did NOT pick LocalBearer (got: $send_out)"
+    rm -rf "$fake_home"
+    return
+  fi
+  if echo "$send_out" | grep -q '^SEND_KIND=delivered$'; then
+    pass "LocalBearer.send returns delivered"
+  else
+    fail "LocalBearer.send did not deliver (got: $send_out)"
+  fi
+  if grep -q "$marker" "$fake_home/messages.jsonl" 2>/dev/null; then
+    pass "payload landed in $fake_home/messages.jsonl"
+  else
+    fail "payload NOT visible in messages.jsonl (contents: $(cat "$fake_home/messages.jsonl" 2>/dev/null))"
+  fi
+
+  # Now exercise recv: append a second probe and verify recv_stream picks it up.
+  local marker2="local-bearer-recv-marker-$(date +%s%N)"
+  local probe2='{"from":"beta","to":"all","ts":"2026-04-29T00:00:01Z","channel":"general","msg":"'"$marker2"'","sig":"x"}'
+  local recv_out; recv_out=$(mktemp -t airc-it-bl-recv.XXXXXX)
+
+  PYTHONPATH="$_lib_dir" python3 -c "
+import sys, signal, time, json
+sys.path.insert(0, '$_lib_dir')
+from airc_core.bearer_resolver import resolve
+
+bearer = resolve({
+    'host_target': '127.0.0.1',
+    'remote_home': '$fake_home',
+})
+bearer.open('alpha')
+
+signal.alarm(10)
+out = open('$recv_out', 'w', buffering=1)
+try:
+    for ev in bearer.recv_stream():
+        env = ev.bearer_metadata.get('envelope', {})
+        if env.get('msg') == '$marker2':
+            live = bearer.liveness('alpha')
+            fresh = live.last_seen_ts is not None and (time.time() - live.last_seen_ts) < 10
+            out.write('FOUND\n')
+            out.write(f'LIVENESS={\"FRESH\" if fresh else \"STALE\"}\n')
+            break
+except Exception as e:
+    out.write(f'ERROR: {e}\n')
+finally:
+    out.close()
+    bearer.close()
+" >/dev/null 2>&1 &
+  local recv_pid=$!
+
+  sleep 1
+  echo "$probe2" >> "$fake_home/messages.jsonl"
+
+  local i
+  for i in 1 2 3 4 5 6 7 8; do
+    sleep 1
+    grep -q '^FOUND' "$recv_out" 2>/dev/null && break
+  done
+  wait "$recv_pid" 2>/dev/null
+
+  if grep -q '^FOUND' "$recv_out" 2>/dev/null; then
+    pass "LocalBearer.recv_stream picked up the appended marker"
+  else
+    fail "LocalBearer.recv_stream did NOT see the marker (out: $(cat "$recv_out" 2>/dev/null))"
+  fi
+  if grep -q '^LIVENESS=FRESH' "$recv_out" 2>/dev/null; then
+    pass "LocalBearer.liveness reports fresh ts after recv event"
+  else
+    fail "LocalBearer.liveness not fresh (out: $(cat "$recv_out" 2>/dev/null))"
+  fi
+
+  rm -rf "$fake_home" "$recv_out"
+  cleanup_all
+}
+
 scenario_bearer_observability() {
   # Phase 2c (#270): the bearer-attested liveness surface must replace
   # the messages.jsonl-mirror-derived "last recv" lie. After a real
@@ -2856,6 +2972,7 @@ case "$MODE" in
   bearer_ssh_recv) scenario_bearer_ssh_recv ;;
   bearer_cli_recv) scenario_bearer_cli_recv ;;
   bearer_observability) scenario_bearer_observability ;;
+  bearer_local) scenario_bearer_local ;;
   ""|all)
     # Default = run everything. The peers_cross_scope + whois_cross_scope
     # scenarios were removed in PR #239 (sidecar walk semantics deleted
@@ -2872,7 +2989,7 @@ case "$MODE" in
     scenario_list; scenario_quit; scenario_platform_adapters
     scenario_python_units
     scenario_bearer_ssh_send; scenario_bearer_ssh_recv; scenario_bearer_cli_recv
-    scenario_bearer_observability
+    scenario_bearer_observability; scenario_bearer_local
     ;;
   *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|all]"; exit 2 ;;
 esac

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -31,7 +31,9 @@ from airc_core.bearer_resolver import (  # noqa: E402
     resolve,
 )
 from airc_core.bearer_ssh import SshBearer, SshBearerError  # noqa: E402
+from airc_core.bearer_local import LocalBearer, LocalBearerError  # noqa: E402
 from airc_core import bearer_ssh  # noqa: E402
+from airc_core import bearer_local  # noqa: E402
 from airc_core import bearer_cli  # noqa: E402
 
 
@@ -832,6 +834,321 @@ class BearerCliStateFileTests(unittest.TestCase):
             state = _json.load(f)  # must not raise
         self.assertEqual(state["events_total"], 5)
         _os.unlink(state_path)
+
+
+class LocalBearerCanServeTests(unittest.TestCase):
+    """Phase 3a: LocalBearer.can_serve must be conservative — only True
+    when host_target is a literal loopback alias AND remote_home is a
+    writable local directory. Both conditions must hold; either alone is
+    a footgun (stale loopback record without dir, or unrelated local
+    dir whose path collides with a remote scope name)."""
+
+    def setUp(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp(prefix="airc-test-localbearer-")
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_serves_loopback_with_writable_dir(self):
+        for ht in ("127.0.0.1", "localhost", "::1", "[::1]",
+                   "user@127.0.0.1", "user@localhost",
+                   "user@127.0.0.1:7547", "127.0.0.1:7547",
+                   "user@[::1]:7547"):
+            self.assertTrue(
+                LocalBearer.can_serve({"host_target": ht, "remote_home": self._tmpdir}),
+                f"should serve loopback host_target={ht!r}",
+            )
+
+    def test_rejects_non_loopback(self):
+        for ht in ("alice@example.com", "user@192.168.1.5",
+                   "user@100.91.51.87", "100.64.0.1",
+                   "user@10.0.0.5"):
+            self.assertFalse(
+                LocalBearer.can_serve({"host_target": ht, "remote_home": self._tmpdir}),
+                f"should NOT serve non-loopback host_target={ht!r}",
+            )
+
+    def test_rejects_when_remote_home_missing(self):
+        self.assertFalse(
+            LocalBearer.can_serve({"host_target": "127.0.0.1"}),
+            "should reject when remote_home is absent",
+        )
+        self.assertFalse(
+            LocalBearer.can_serve({"host_target": "127.0.0.1", "remote_home": ""}),
+            "should reject when remote_home is empty string",
+        )
+
+    def test_rejects_when_remote_home_does_not_exist(self):
+        bogus = self._tmpdir + "/does-not-exist"
+        self.assertFalse(
+            LocalBearer.can_serve({"host_target": "127.0.0.1", "remote_home": bogus}),
+            "should reject when remote_home points at missing dir",
+        )
+
+    def test_rejects_when_remote_home_is_a_file(self):
+        import os
+        path = os.path.join(self._tmpdir, "not-a-dir.txt")
+        with open(path, "w") as f:
+            f.write("hi")
+        self.assertFalse(
+            LocalBearer.can_serve({"host_target": "127.0.0.1", "remote_home": path}),
+            "should reject when remote_home points at a file (not dir)",
+        )
+
+    def test_can_serve_is_pure(self):
+        # No IO outside of the os.access call. Repeat invocations don't
+        # mutate peer_meta.
+        meta = {"host_target": "127.0.0.1", "remote_home": self._tmpdir}
+        before = dict(meta)
+        for _ in range(3):
+            LocalBearer.can_serve(meta)
+        self.assertEqual(meta, before)
+
+
+class LocalBearerSendTests(unittest.TestCase):
+    """LocalBearer.send appends to remote_home/messages.jsonl directly."""
+
+    def setUp(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp(prefix="airc-test-local-send-")
+        self._bearer = LocalBearer({
+            "host_target": "127.0.0.1",
+            "remote_home": self._tmpdir,
+        })
+        self._bearer.open("alice")
+
+    def tearDown(self):
+        import shutil
+        self._bearer.close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_send_appends_with_trailing_newline(self):
+        outcome = self._bearer.send("alice", "general", b'{"from":"bob","msg":"hi"}')
+        self.assertEqual(outcome.kind, "delivered")
+        import os
+        path = os.path.join(self._tmpdir, "messages.jsonl")
+        with open(path, "rb") as f:
+            content = f.read()
+        self.assertEqual(content, b'{"from":"bob","msg":"hi"}\n')
+
+    def test_send_preserves_existing_trailing_newline(self):
+        self._bearer.send("alice", "general", b'{"x":1}\n')
+        import os
+        with open(os.path.join(self._tmpdir, "messages.jsonl"), "rb") as f:
+            content = f.read()
+        self.assertEqual(content, b'{"x":1}\n', "must not double-newline")
+
+    def test_send_appends_does_not_truncate(self):
+        self._bearer.send("alice", "general", b'{"a":1}')
+        self._bearer.send("alice", "general", b'{"b":2}')
+        import os
+        with open(os.path.join(self._tmpdir, "messages.jsonl"), "rb") as f:
+            content = f.read()
+        self.assertEqual(content, b'{"a":1}\n{"b":2}\n')
+
+    def test_send_reports_transient_when_dir_vanishes(self):
+        # Race: directory disappears between can_serve and send.
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        outcome = self._bearer.send("alice", "general", b'{"x":1}')
+        self.assertEqual(outcome.kind, "transient_failure")
+        self.assertIn("local append failed", outcome.detail)
+        # Re-create for tearDown to clean up cleanly.
+        import os
+        os.makedirs(self._tmpdir, exist_ok=True)
+
+
+class LocalBearerRecvTests(unittest.TestCase):
+    """LocalBearer.recv_stream tails remote_home/messages.jsonl with
+    pure-Python poll-based reads. Tests the file format contract; the
+    integration scenario covers real-time tail behavior under load."""
+
+    def setUp(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp(prefix="airc-test-local-recv-")
+        self._meta = {
+            "host_target": "127.0.0.1",
+            "remote_home": self._tmpdir,
+        }
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _write(self, lines):
+        import os
+        with open(os.path.join(self._tmpdir, "messages.jsonl"), "ab") as f:
+            for ln in lines:
+                f.write(ln if ln.endswith(b"\n") else ln + b"\n")
+
+    def test_recv_yields_pre_existing_lines_when_no_offset(self):
+        # No offset_file → start position is 0 (read from beginning).
+        # That matches "skip 0 lines" in _compute_skip_lines.
+        self._write([
+            b'{"from":"bob","channel":"general","msg":"first"}',
+            b'{"from":"carol","channel":"general","msg":"second"}',
+        ])
+        b = LocalBearer(self._meta)
+        b.open("alice")
+        events = []
+        gen = b.recv_stream()
+        for ev in gen:
+            events.append(ev)
+            if len(events) >= 2:
+                b.close()
+                break
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0].sender_peer_id, "bob")
+        self.assertEqual(events[1].sender_peer_id, "carol")
+
+    def test_recv_resumes_past_offset_file(self):
+        import os, tempfile
+        self._write([
+            b'{"from":"bob","msg":"a"}',
+            b'{"from":"bob","msg":"b"}',
+            b'{"from":"bob","msg":"c"}',
+        ])
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            f.write("2")  # skip first 2 lines
+            offset_path = f.name
+        try:
+            meta = dict(self._meta, offset_file=offset_path)
+            b = LocalBearer(meta)
+            b.open("alice")
+            events = []
+            gen = b.recv_stream()
+            for ev in gen:
+                events.append(ev)
+                if len(events) >= 1:
+                    b.close()
+                    break
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0].bearer_metadata["envelope"]["msg"], "c")
+        finally:
+            os.unlink(offset_path)
+
+    def test_recv_drops_malformed_lines_silently(self):
+        self._write([
+            b'not json',
+            b'{"from":"bob","msg":"good"}',
+            b'[1,2,3]',  # JSON but not an object
+            b'{"from":"carol","msg":"also good"}',
+        ])
+        b = LocalBearer(self._meta)
+        b.open("alice")
+        events = []
+        gen = b.recv_stream()
+        for ev in gen:
+            events.append(ev)
+            if len(events) >= 2:
+                b.close()
+                break
+        self.assertEqual([e.sender_peer_id for e in events], ["bob", "carol"])
+
+    def test_liveness_updates_on_each_event(self):
+        self._write([b'{"from":"bob","msg":"x"}'])
+        b = LocalBearer(self._meta)
+        b.open("alice")
+        live_before = b.liveness("alice")
+        self.assertIsNone(live_before.last_seen_ts)
+        gen = b.recv_stream()
+        next(gen)
+        live_after = b.liveness("alice")
+        self.assertIsNotNone(live_after.last_seen_ts)
+        self.assertIn("local tail", live_after.bearer_diag.lower())
+        b.close()
+
+    def test_offset_persists_after_recv(self):
+        import os, tempfile
+        self._write([
+            b'{"from":"bob","msg":"a"}',
+            b'{"from":"bob","msg":"b"}',
+        ])
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            f.write("0")
+            offset_path = f.name
+        try:
+            meta = dict(self._meta, offset_file=offset_path)
+            b = LocalBearer(meta)
+            b.open("alice")
+            gen = b.recv_stream()
+            next(gen); next(gen)
+            b.close()
+            with open(offset_path) as f:
+                self.assertEqual(f.read().strip(), "2")
+        finally:
+            os.unlink(offset_path)
+
+
+class LocalBearerSkeletonTests(unittest.TestCase):
+    """Bearer ABC contract — same shape as SshBearerSkeletonTests."""
+
+    def test_kind_is_local(self):
+        self.assertEqual(LocalBearer.KIND, "local")
+
+    def test_construct_is_cheap(self):
+        # Constructor must not touch IO. Pass a peer_meta with a
+        # nonexistent dir; construction succeeds, no exception.
+        b = LocalBearer({"host_target": "127.0.0.1", "remote_home": "/nope/nope"})
+        # Closing without open is a no-op (idempotent).
+        b.close()
+
+    def test_post_close_operations_raise(self):
+        b = LocalBearer({"host_target": "127.0.0.1", "remote_home": "/tmp"})
+        b.open("alice")
+        b.close()
+        with self.assertRaises(LocalBearerError):
+            b.send("alice", "general", b'{"x":1}')
+
+
+class ResolverOrderTests(unittest.TestCase):
+    """Phase 3a: LocalBearer must be picked over SshBearer when both
+    can serve a peer. SshBearer is the universal fallback; LocalBearer
+    is the same-machine optimization. Reversing this order would make
+    every same-machine 2-tab session waste SSH crypto cycles."""
+
+    def setUp(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp(prefix="airc-test-resolver-")
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_local_first_for_same_machine_peer(self):
+        bearer = resolve({
+            "host_target": "user@127.0.0.1",
+            "remote_home": self._tmpdir,
+        })
+        self.assertEqual(bearer.KIND, "local",
+                         "same-machine peer must resolve to LocalBearer")
+
+    def test_ssh_for_remote_peer(self):
+        bearer = resolve({
+            "host_target": "alice@example.com",
+            "remote_home": "/home/alice/.airc",
+        })
+        self.assertEqual(bearer.KIND, "ssh",
+                         "remote peer must resolve to SshBearer")
+
+    def test_ssh_when_loopback_target_but_no_local_dir(self):
+        # Stale loopback record without a host_airc_home that exists →
+        # LocalBearer.can_serve is False → fall through to SshBearer.
+        bearer = resolve({
+            "host_target": "user@127.0.0.1",
+            "remote_home": "/this/path/definitely/does/not/exist",
+        })
+        self.assertEqual(bearer.KIND, "ssh")
+
+    def test_available_kinds_includes_local(self):
+        from airc_core.bearer_resolver import available_kinds
+        kinds = available_kinds()
+        self.assertIn("local", kinds)
+        self.assertIn("ssh", kinds)
+        # local must come first (preference order).
+        self.assertLess(kinds.index("local"), kinds.index("ssh"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds the second registered bearer kind. LocalBearer serves peers whose \`host_target\` is a loopback alias AND whose \`remote_home\` is a writable local directory — i.e., two airc tabs on the same machine. They currently SSH to 127.0.0.1; LocalBearer skips that entirely with direct filesystem reads/writes.

## Why this matters now (before 3b/3c)
- **Validates the seam.** Two bearers in the registry exercises the resolver's preference logic for the first time. Phase 3b's GhBearer plugs in the same way.
- **Same-machine 2-tab sessions stop burning SSH crypto cycles.** Hot path for dev workflows where multiple AI agents spawn on one laptop.
- **Resolver-order test is now a guarded contract.** Reversing it would silently regress all same-machine traffic to SSH.

## Mechanism
- \`lib/airc_core/bearer_local.py\` — pure-Python tail-F with rotation detection, atomic O_APPEND send, offset persistence, same envelope-parse contract as SshBearer so monitor_formatter doesn't need to care which bearer produced a line.
- \`lib/airc_core/bearer_resolver.py\` — registry now \`[LocalBearer, SshBearer]\`. Order is documented load-bearing.

## Test plan
- [x] \`python_units\` (test_bearer.py): 67/67 — 22 new tests across LocalBearerCanServe (6), LocalBearerSend (4), LocalBearerRecv (5), LocalBearerSkeleton (3), ResolverOrder (4)
- [x] \`bearer_local\` (new integration scenario): 5/5 — resolver picks LocalBearer, send delivered, payload lands in messages.jsonl, recv_stream picks up the marker, liveness FRESH
- [x] \`bearer_ssh_send\`: 6/6 (no regression — SSH peer_meta doesn't satisfy LocalBearer.can_serve, falls through cleanly)
- [x] \`bearer_ssh_recv\`: 4/4
- [x] \`tabs\` (full bidirectional + peers): 19/19
- [ ] CI integration suite

## Notes
- IPv6 nuance: \`::1\` as bare host vs \`[::1]:7547\` bracketed-with-port. Both accepted; tested.
- No bash changes. Production behavior is unchanged today because real pairings populate host_target with a Tailscale IP, not loopback. LocalBearer activates organically once same-machine discovery is exercised — no migration needed.
- can_serve requires BOTH loopback target AND writable local dir. Either alone is a footgun (stale loopback record, or unrelated local dir colliding with a remote scope name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)