### PR TITLE
feat(bearer): Phase 3b — GhBearer for gh-as-transport (purely additive)

### DIFF
--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -1,0 +1,434 @@
+"""GhBearer — message transport over gh-gist.
+
+When two airc peers can't reach each other directly (different LANs,
+no Tailscale, asymmetric NATs), they fall back to gh-as-bearer: the
+host's room gist gets a `messages.jsonl` file, peers append envelopes
+to it via `gh gist edit`, and recv_stream polls the gist for new lines.
+
+Per the bearer abstraction's adapter rule, ALL gh-as-transport knowledge
+lives in this module: gh CLI invocations, gist read/parse, gist
+mutation, polling cadence, rate-limit handling. The room-registry role
+of gh (cmd_rooms, gistparse) lives elsewhere and is a separate concern.
+
+Why polling rather than push: gh has no streaming API for gist updates.
+Polling at a sane cadence (15s default) costs ~240 requests/hour/peer,
+well under gh's 5000/hour authenticated rate limit. ETag conditional
+GETs are a future optimization (saves bytes, still counts toward primary
+rate limit per gh docs); deferred until rotation pressure makes the
+read payload large enough that bandwidth matters.
+
+Why subprocess `gh api` rather than direct HTTPS: gh CLI handles auth
+(token discovery, refresh, GHE detection), retry on transient errors,
+and surface error messages we want users to see. Reimplementing that
+in Python would duplicate everything gh already does well.
+
+Phase 3b (current): GhBearer registered AFTER SshBearer. Production
+peer_meta from real pairings populates host_target (so SshBearer.can_serve
+wins). GhBearer activates only for peer_meta where host_target is empty
+but room_gist_id is set — a deliberate path the resolver doesn't reach
+today. Phase 3c flips the order and removes SshBearer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time as _time
+from typing import Iterator, Optional
+
+from .bearer import (
+    Bearer,
+    BearerError,
+    LivenessResult,
+    SendOutcome,
+    ReceivedMessage,
+)
+
+
+class GhBearerError(BearerError):
+    """gh-transport-class errors. Distinct subclass for diagnostic
+    clarity; callers branching on outcome kinds should rely on
+    SendOutcome.kind, not isinstance checks."""
+
+
+_GH_BIN = "gh"
+_MESSAGES_FILE = "messages.jsonl"
+_DEFAULT_POLL_INTERVAL = 15.0  # seconds; tuned for gh rate limit headroom
+_GH_API_TIMEOUT = 10.0          # per-call seconds; total wall time bounded by retry policy
+
+
+def _resolve_gh_bin() -> str:
+    """Locate gh CLI on PATH. Returns the path or raises GhBearerError.
+
+    Inherits the user's environment (PATH, GH_TOKEN, etc) so token
+    discovery, GHE host config, and proxy settings come from gh's own
+    rules — not duplicated here."""
+    found = shutil.which(_GH_BIN)
+    if not found:
+        raise GhBearerError(
+            "gh CLI not found on PATH; install GitHub CLI and run 'gh auth login'"
+        )
+    return found
+
+
+def _has_gh_auth() -> bool:
+    """Return True iff `gh auth status` reports an authenticated user.
+
+    Conservative check — used by can_serve. We do NOT raise on auth
+    failure; we just decline to serve, and the resolver falls through
+    to a different bearer (or PeerUnreachable if none can). This keeps
+    the abstraction's "can_serve is pure inspection" invariant intact:
+    one subprocess invocation, no side effects."""
+    try:
+        gh = _resolve_gh_bin()
+    except GhBearerError:
+        return False
+    try:
+        r = subprocess.run(
+            [gh, "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return r.returncode == 0
+
+
+def _gh_api_get(gist_id: str) -> Optional[dict]:
+    """GET gists/<id> via gh api. Returns parsed JSON dict or None on
+    failure (rate-limited, network blip, auth lost mid-stream).
+
+    No retry here — caller (recv_stream's poll loop, send's read step)
+    decides whether to retry or back off."""
+    try:
+        gh = _resolve_gh_bin()
+    except GhBearerError:
+        return None
+    try:
+        r = subprocess.run(
+            [gh, "api", f"gists/{gist_id}"],
+            capture_output=True,
+            text=True,
+            timeout=_GH_API_TIMEOUT,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        return json.loads(r.stdout)
+    except (ValueError, TypeError):
+        return None
+
+
+def _read_messages_content(gist_data: dict) -> str:
+    """Extract the messages.jsonl file content from a parsed gist GET
+    response. Returns empty string if the file doesn't exist yet (first
+    write creates it). gh api response shape:
+        {"files": {"<name>": {"content": "..."}}, ...}
+    """
+    files = gist_data.get("files") or {}
+    entry = files.get(_MESSAGES_FILE) or {}
+    return entry.get("content", "") or ""
+
+
+def _gh_gist_write_file(gist_id: str, content: str) -> tuple[bool, str]:
+    """Write `content` as the messages.jsonl file in `gist_id` via
+    `gh gist edit`. Returns (ok, detail). Creates the file if absent
+    (gh gist edit -a) or replaces if present (default behavior with
+    matching basename).
+
+    gh gist edit uses the local file's basename as the in-gist filename.
+    We write to a temp file literally named messages.jsonl in a unique
+    directory so the basename matches and the path is unique."""
+    try:
+        gh = _resolve_gh_bin()
+    except GhBearerError as e:
+        return (False, str(e))
+    tmpdir = tempfile.mkdtemp(prefix="airc-ghbearer-")
+    try:
+        path = os.path.join(tmpdir, _MESSAGES_FILE)
+        with open(path, "w") as f:
+            f.write(content)
+        # `gh gist edit` updates an existing file by name; the -a flag
+        # adds a NEW file. We need both behaviors to converge. Strategy:
+        # try -a first; if the file already exists gh exits non-zero
+        # with a recognizable message; fall back to plain edit (replace).
+        # Simpler in practice: just try plain edit; gh creates the file
+        # if absent in newer releases, and if not, we retry with -a.
+        try:
+            r = subprocess.run(
+                [gh, "gist", "edit", gist_id, path],
+                capture_output=True,
+                text=True,
+                timeout=_GH_API_TIMEOUT,
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            return (False, f"gh gist edit failed: {e}")
+        if r.returncode == 0:
+            return (True, "")
+        # Fallback: try with -a (add file). If THAT fails too, return
+        # the more informative error.
+        try:
+            r2 = subprocess.run(
+                [gh, "gist", "edit", gist_id, "-a", path],
+                capture_output=True,
+                text=True,
+                timeout=_GH_API_TIMEOUT,
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            return (False, f"gh gist edit -a failed: {e}")
+        if r2.returncode == 0:
+            return (True, "")
+        # Both failed — surface the FIRST error (the one caller saw
+        # via the natural-first-attempt path).
+        err = (r.stderr or r.stdout or "gh gist edit failed").strip()
+        return (False, err)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class GhBearer(Bearer):
+    KIND = "gh"
+
+    @classmethod
+    def can_serve(cls, peer_meta: dict) -> bool:
+        """Serve any peer with a room_gist_id and a working gh auth.
+
+        Why room_gist_id rather than peer_id-derived addressing: gh-as-
+        bearer uses the SHARED room gist for the substrate's message
+        log. Every peer in the room reads/writes the same gist file.
+        This matches how IRC works on a server — the channel is the
+        bearer's addressable surface, not individual peers.
+        """
+        if not peer_meta.get("room_gist_id"):
+            return False
+        return _has_gh_auth()
+
+    def __init__(self, peer_meta: Optional[dict] = None) -> None:
+        # No IO — concrete bearers MUST be cheap to instantiate.
+        # Even can_serve's gh auth check is run by the resolver, not
+        # by us at construction time.
+        self._peer_meta: dict = peer_meta or {}
+        self._opened_peer_id: Optional[str] = None
+        self._closed = False
+        self._last_recv_ts: Optional[float] = None
+        # Tracks how many lines of messages.jsonl we've already yielded.
+        # Resumed from offset_file on first poll if available.
+        self._consumed_lines: int = 0
+        # Polling cadence; can be overridden via peer_meta for tests.
+        self._poll_interval: float = float(
+            peer_meta.get("poll_interval", _DEFAULT_POLL_INTERVAL)
+        ) if peer_meta else _DEFAULT_POLL_INTERVAL
+
+    def _check_alive(self) -> None:
+        if self._closed:
+            raise GhBearerError("bearer already closed")
+
+    def open(self, peer_id: str) -> None:
+        """Cache peer_id; no IO. Like SshBearer / LocalBearer, gh-as-
+        bearer is connectionless from the bearer's POV — every send is
+        a discrete gh API round-trip, every recv-poll is independent."""
+        self._check_alive()
+        self._opened_peer_id = peer_id
+        # Initialize consumed_lines from offset_file if provided. Only
+        # done once at open (not at each poll) so an in-flight reconnect
+        # doesn't reset to disk state mid-stream.
+        offset_file = self._peer_meta.get("offset_file")
+        self._consumed_lines = self._read_offset(offset_file)
+
+    def send(self, peer_id: str, channel: str, payload: bytes) -> SendOutcome:
+        """Append `payload` to the room gist's messages.jsonl file.
+
+        Read-modify-write via gh CLI: GET current content, append our
+        line, edit the gist with combined content. Optimistic concurrency:
+        if two peers race, the loser's write OVERWRITES the winner's.
+        Real fix is ETag/If-Match (gh CLI doesn't expose this directly);
+        deferred to a follow-up — the conflict window is sub-second and
+        rare in practice for chat-pace traffic.
+
+        Outcome kinds:
+          delivered          — gh edit succeeded
+          transient_failure  — read failed, write failed, network blip,
+                               rate limit, gh auth lost mid-call
+          auth_failure       — gh auth status currently fails (the
+                               can_serve gate caught a stale state, but
+                               token expired between can_serve and now)
+        """
+        self._check_alive()
+
+        gist_id = self._peer_meta.get("room_gist_id")
+        if not gist_id:
+            raise GhBearerError(
+                f"GhBearer.send called for peer_id={peer_id!r} with no "
+                f"room_gist_id in peer_meta — open() called with stale meta?"
+            )
+
+        gist = _gh_api_get(gist_id)
+        if gist is None:
+            # Most common cause: rate-limited or transient gh API error.
+            # Auth-lost is a sub-case; we don't try to disambiguate
+            # here because caller's queue+retry handles both equally.
+            return SendOutcome(
+                kind="transient_failure",
+                detail=f"could not fetch gist {gist_id} (rate limit, network, or auth)",
+            )
+
+        framed = payload if payload.endswith(b"\n") else payload + b"\n"
+        try:
+            framed_str = framed.decode("utf-8")
+        except UnicodeDecodeError:
+            return SendOutcome(
+                kind="transient_failure",
+                detail="payload is not utf-8; gh-bearer requires text envelopes",
+            )
+        new_content = _read_messages_content(gist) + framed_str
+
+        ok, detail = _gh_gist_write_file(gist_id, new_content)
+        if ok:
+            return SendOutcome(kind="delivered", detail="")
+        # gh returns "permission denied" or "404" for auth issues.
+        # Treat those as auth_failure so the caller surfaces them
+        # loudly rather than queueing forever.
+        lower = detail.lower()
+        if "permission" in lower or "401" in lower or "not found" in lower:
+            return SendOutcome(kind="auth_failure", detail=detail)
+        return SendOutcome(kind="transient_failure", detail=detail)
+
+    def recv_stream(self) -> Iterator[ReceivedMessage]:
+        """Poll the room gist on a cadence; yield new envelopes.
+
+        Each poll:
+          1. GET gists/<id> via gh api
+          2. Split content of messages.jsonl into lines
+          3. For lines past self._consumed_lines, parse as envelope,
+             yield. Bump consumed_lines + offset file.
+          4. Sleep poll_interval (default 15s), repeat.
+
+        On gh API failure (rate limit, network blip), we sleep the same
+        cadence and try again. The bearer's job is to keep producing
+        events; the caller's watchdog observes extended silence via
+        liveness().
+        """
+        self._check_alive()
+
+        gist_id = self._peer_meta.get("room_gist_id")
+        if not gist_id:
+            raise GhBearerError(
+                "GhBearer.recv_stream called with no room_gist_id in peer_meta"
+            )
+        offset_file = self._peer_meta.get("offset_file")
+
+        while not self._closed:
+            gist = _gh_api_get(gist_id)
+            if gist is None:
+                # Transient gh API failure. Sleep + retry. Caller's
+                # watchdog observes extended silence and escalates.
+                self._sleep_or_break(self._poll_interval)
+                continue
+            content = _read_messages_content(gist)
+            # splitlines() on the str preserves multi-byte sequences and
+            # correctly handles trailing-newline absence. We re-encode
+            # each line to bytes for ReceivedMessage.payload symmetry
+            # with SshBearer/LocalBearer (which produce bytes from disk).
+            lines = content.splitlines()
+            for idx in range(self._consumed_lines, len(lines)):
+                raw = lines[idx].encode("utf-8")
+                self._consumed_lines = idx + 1
+                self._on_line_received(self._consumed_lines, offset_file)
+                msg = self._parse_envelope(raw)
+                if msg is None:
+                    continue
+                yield msg
+                if self._closed:
+                    return
+            if self._closed:
+                return
+            self._sleep_or_break(self._poll_interval)
+
+    @staticmethod
+    def _read_offset(offset_file: Optional[str]) -> int:
+        """Read offset_file as a line count; 0 on empty/invalid/missing."""
+        if not offset_file:
+            return 0
+        try:
+            with open(offset_file, "r") as f:
+                raw = f.read().strip()
+        except OSError:
+            return 0
+        if not raw or not raw.isdigit():
+            return 0
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            return 0
+
+    def _on_line_received(self, line_count: int, offset_file: Optional[str]) -> None:
+        """Bump last_recv_ts (for liveness) and persist offset (for resume).
+        Persistence failures are swallowed — the bearer keeps streaming."""
+        self._last_recv_ts = _time.time()
+        if offset_file is None:
+            return
+        try:
+            with open(offset_file, "w") as f:
+                f.write(str(line_count))
+        except OSError:
+            pass
+
+    @staticmethod
+    def _parse_envelope(raw_line: bytes) -> Optional[ReceivedMessage]:
+        """Same envelope contract as SshBearer / LocalBearer. Keeping
+        the parse identical lets monitor_formatter consume any bearer's
+        output uniformly."""
+        line = raw_line.rstrip(b"\n").rstrip(b"\r")
+        if not line:
+            return None
+        try:
+            env = json.loads(line)
+        except (ValueError, TypeError):
+            return None
+        if not isinstance(env, dict):
+            return None
+        sender = env.get("from")
+        channel = env.get("channel", "")
+        if not sender:
+            return None
+        return ReceivedMessage(
+            sender_peer_id=str(sender),
+            channel=str(channel),
+            payload=line,
+            bearer_metadata={"envelope": env},
+        )
+
+    def _sleep_or_break(self, seconds: float) -> None:
+        """Sleep in 100ms ticks so close() takes effect within ~100ms."""
+        deadline = _time.time() + seconds
+        while not self._closed and _time.time() < deadline:
+            _time.sleep(0.1)
+
+    def liveness(self, peer_id: str) -> LivenessResult:
+        """Last_recv_ts bumped on each yielded event. Same shape as
+        SshBearer / LocalBearer so cross-process consumers (airc status)
+        treat all bearers uniformly."""
+        self._check_alive()
+        if self._last_recv_ts is None:
+            return LivenessResult(
+                peer_id=peer_id,
+                last_seen_ts=None,
+                bearer_diag="no events received via gh poll yet",
+            )
+        return LivenessResult(
+            peer_id=peer_id,
+            last_seen_ts=self._last_recv_ts,
+            bearer_diag="last event from gh poll",
+        )
+
+    def close(self) -> None:
+        """Idempotent. Sets the close flag so any active poll loop
+        returns at the next sleep tick (within ~100ms)."""
+        self._closed = True
+        self._opened_peer_id = None

--- a/lib/airc_core/bearer_resolver.py
+++ b/lib/airc_core/bearer_resolver.py
@@ -10,14 +10,19 @@ Adding a transport: import its class, add to _REGISTRY at the right
 preference position. Done. Removing a transport: delete the import and
 the registry entry. Done. No other file moves.
 
-Phase 3a (current state): registry has LocalBearer + SshBearer.
-LocalBearer comes first because same-machine peers (loopback host_target
-+ local host_airc_home) get direct filesystem access — no SSH crypto
-overhead, no subprocess. SshBearer serves everyone else.
+Phase 3b (current state): registry has LocalBearer + SshBearer + GhBearer.
 
-Phase 3b adds GhBearer between LocalBearer and SshBearer (gh-as-bearer
-for cross-network peers when SSH/Tailscale aren't available). Phase 3c
-removes SshBearer + Tailscale entirely.
+GhBearer is registered LAST deliberately. Real production peer_meta
+populates host_target (so SshBearer.can_serve wins), so GhBearer only
+activates for peer_meta where host_target is empty but room_gist_id is
+set — a path the resolver doesn't reach in production today. This keeps
+3b purely additive: SshBearer keeps serving today's traffic; GhBearer
+exists in the seam, exercised by tests, ready for Phase 3c to flip.
+
+Phase 3c flips order to [LocalBearer, GhBearer], removes SshBearer +
+Tailscale entirely, and updates the join handshake so cross-network
+pairings populate room_gist_id (not host_target) — at which point
+GhBearer takes over all non-loopback traffic.
 """
 
 from __future__ import annotations
@@ -26,16 +31,21 @@ from typing import List, Type
 
 from .bearer import Bearer, PeerUnreachable
 from .bearer_local import LocalBearer
+from .bearer_gh import GhBearer
 from .bearer_ssh import SshBearer
 
 # Preference order. Earlier = preferred. The resolver tries each in turn
 # via can_serve() and falls through on PeerUnreachable from open().
-# LocalBearer first: same-machine peers skip the SSH layer entirely.
-# SshBearer last: the universal-fallback that serves anything reachable
-# over the network.
+#   LocalBearer — same-machine peers skip the SSH layer entirely.
+#   SshBearer   — direct-network peers (Tailscale, LAN, public). What
+#                 production uses today.
+#   GhBearer    — gh-as-bearer fallback for peers without direct-network
+#                 reachability. After Phase 3c becomes the cross-network
+#                 default and SshBearer is removed.
 _REGISTRY: List[Type[Bearer]] = [
     LocalBearer,
     SshBearer,
+    GhBearer,
 ]
 
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2837,6 +2837,176 @@ finally:
   cleanup_all
 }
 
+scenario_bearer_gh() {
+  # Phase 3b: GhBearer round-trip against a real gh gist. Creates a
+  # temporary gist, sends an envelope through the bearer, polls for
+  # it to appear via recv_stream, cleans up. Skip-guarded on gh auth.
+  #
+  # Why a real gist (not mocked): unit tests already cover the bearer's
+  # logic. This scenario validates the gh CLI invocations actually do
+  # what we expect — gh gist edit's filename rules, gh api response
+  # shape, error surfacing — none of which a mock can prove.
+  section "bearer (gh): send/recv round-trip via real gh gist"
+
+  if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
+    echo "  (skipped — gh not authed)"
+    return
+  fi
+
+  cleanup_all
+  local _lib_dir; _lib_dir="$(cd "$(dirname "$AIRC")/lib" && pwd)"
+
+  # Create a private gist with a non-empty seed line. gh refuses gists
+  # whose only file is blank (or even a bare newline). The bearer's
+  # envelope parser drops the seed line as malformed (no `from` field)
+  # so it's invisible in recv_stream output.
+  local seed; seed=$(mktemp -d -t airc-it-bg-seed.XXXXXX)
+  printf '# airc bearer_gh test seed\n' > "$seed/messages.jsonl"
+  local gist_url; gist_url=$(gh gist create -d "airc bearer_gh integration test" "$seed/messages.jsonl" 2>&1 | tail -1)
+  local gist_id; gist_id=$(printf '%s' "$gist_url" | awk -F/ '{print $NF}')
+  rm -rf "$seed"
+
+  if [ -z "$gist_id" ] || ! printf '%s' "$gist_id" | grep -qE '^[a-f0-9]+$'; then
+    fail "could not create test gist (got: $gist_url)"
+    return
+  fi
+  pass "test gist created: $gist_id"
+
+  # Always delete the gist before returning, even on failure. trap so
+  # an unexpected exit (e.g. signal during a long send) still cleans up.
+  local _cleanup_gist=1
+  _bearer_gh_cleanup() {
+    [ "${_cleanup_gist:-0}" = "1" ] && [ -n "${gist_id:-}" ] && \
+      gh gist delete "$gist_id" --yes 2>/dev/null || true
+  }
+  trap _bearer_gh_cleanup EXIT
+
+  local marker="gh-bearer-marker-$(date +%s%N)"
+  local probe='{"from":"alpha","to":"all","ts":"2026-04-29T00:00:00Z","channel":"general","msg":"'"$marker"'","sig":"x"}'
+
+  # Send via GhBearer.send (through the resolver, asserts kind=gh).
+  local send_out
+  send_out=$(PYTHONPATH="$_lib_dir" python3 -c "
+import sys
+sys.path.insert(0, '$_lib_dir')
+from airc_core.bearer_resolver import resolve
+
+bearer = resolve({'room_gist_id': '$gist_id'})
+print(f'KIND={bearer.KIND}')
+bearer.open('alpha')
+out = bearer.send('alpha', 'general', b'$probe')
+print(f'SEND_KIND={out.kind}')
+if out.detail:
+    print(f'SEND_DETAIL={out.detail}')
+bearer.close()
+" 2>&1)
+
+  if echo "$send_out" | grep -q '^KIND=gh$'; then
+    pass "resolver picks GhBearer for room_gist_id-only peer_meta"
+  else
+    fail "resolver did NOT pick GhBearer (got: $send_out)"
+    return
+  fi
+  if echo "$send_out" | grep -q '^SEND_KIND=delivered$'; then
+    pass "GhBearer.send returns delivered"
+  else
+    fail "GhBearer.send did not deliver (got: $send_out)"
+    return
+  fi
+
+  # Verify the marker actually landed in the gist.
+  local content; content=$(gh api "gists/$gist_id" 2>/dev/null \
+    | python3 -c "import sys, json; print(json.load(sys.stdin)['files']['messages.jsonl']['content'])" 2>/dev/null)
+  if printf '%s' "$content" | grep -q "$marker"; then
+    pass "payload visible in gist's messages.jsonl"
+  else
+    fail "payload NOT visible in gist (content: $content)"
+    return
+  fi
+
+  # Now exercise recv_stream: append a SECOND probe to the gist via gh
+  # CLI directly (simulating another peer's send), then verify
+  # GhBearer.recv_stream picks it up. Use poll_interval=1 to keep the
+  # test fast — production default is 15s.
+  local marker2="gh-bearer-recv-marker-$(date +%s%N)"
+  local probe2='{"from":"beta","to":"all","ts":"2026-04-29T00:00:01Z","channel":"general","msg":"'"$marker2"'","sig":"x"}'
+  local recv_out; recv_out=$(mktemp -t airc-it-bg-recv.XXXXXX)
+
+  local recv_err; recv_err=$(mktemp -t airc-it-bg-recv-err.XXXXXX)
+  PYTHONPATH="$_lib_dir" python3 -c "
+import sys, signal, time
+sys.path.insert(0, '$_lib_dir')
+from airc_core.bearer_resolver import resolve
+
+bearer = resolve({'room_gist_id': '$gist_id', 'poll_interval': 1})
+bearer.open('alpha')
+
+signal.alarm(30)
+out = open('$recv_out', 'w', buffering=1)
+try:
+    for ev in bearer.recv_stream():
+        env = ev.bearer_metadata.get('envelope', {})
+        if env.get('msg') == '$marker2':
+            live = bearer.liveness('alpha')
+            fresh = live.last_seen_ts is not None and (time.time() - live.last_seen_ts) < 30
+            out.write('FOUND\n')
+            out.write(f'LIVENESS={\"FRESH\" if fresh else \"STALE\"}\n')
+            break
+except Exception as e:
+    out.write(f'ERROR: {e}\n')
+finally:
+    out.close()
+    bearer.close()
+" >/dev/null 2>"$recv_err" &
+  local recv_pid=$!
+
+  # Give the bearer's first poll a beat, then append the marker.
+  # We must preserve ALL prior gist content (seed line + first probe);
+  # otherwise rewriting only probe+probe2 leaves line-count unchanged
+  # at 2, and the bearer's consumed_lines (advanced past those during
+  # poll 1) skips the new marker. gh gist edit replaces the file
+  # wholesale, so reconstruct the full content.
+  sleep 2
+  local prior_content; prior_content=$(gh api "gists/$gist_id" 2>/dev/null \
+    | python3 -c "import sys, json; print(json.load(sys.stdin)['files']['messages.jsonl']['content'], end='')" 2>/dev/null)
+  local seed2; seed2=$(mktemp -d -t airc-it-bg-seed2.XXXXXX)
+  {
+    printf '%s' "$prior_content"
+    # Ensure trailing newline before appending so probe2 lands on its own line.
+    case "$prior_content" in
+      *$'\n') ;;
+      *) printf '\n' ;;
+    esac
+    printf '%s\n' "$probe2"
+  } > "$seed2/messages.jsonl"
+  gh gist edit "$gist_id" "$seed2/messages.jsonl" >/dev/null 2>&1
+  rm -rf "$seed2"
+
+  local i
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+    sleep 1
+    grep -q '^FOUND' "$recv_out" 2>/dev/null && break
+  done
+  wait "$recv_pid" 2>/dev/null
+
+  if grep -q '^FOUND' "$recv_out" 2>/dev/null; then
+    pass "GhBearer.recv_stream picked up the appended marker"
+  else
+    fail "GhBearer.recv_stream did NOT see the marker (out: $(cat "$recv_out" 2>/dev/null) | err: $(cat "$recv_err" 2>/dev/null))"
+  fi
+  if grep -q '^LIVENESS=FRESH' "$recv_out" 2>/dev/null; then
+    pass "GhBearer.liveness reports fresh ts after recv event"
+  else
+    fail "GhBearer.liveness not fresh (out: $(cat "$recv_out" 2>/dev/null))"
+  fi
+
+  rm -f "$recv_out" "$recv_err"
+  # cleanup
+  trap - EXIT
+  _bearer_gh_cleanup
+  cleanup_all
+}
+
 scenario_bearer_observability() {
   # Phase 2c (#270): the bearer-attested liveness surface must replace
   # the messages.jsonl-mirror-derived "last recv" lie. After a real
@@ -2973,6 +3143,7 @@ case "$MODE" in
   bearer_cli_recv) scenario_bearer_cli_recv ;;
   bearer_observability) scenario_bearer_observability ;;
   bearer_local) scenario_bearer_local ;;
+  bearer_gh) scenario_bearer_gh ;;
   ""|all)
     # Default = run everything. The peers_cross_scope + whois_cross_scope
     # scenarios were removed in PR #239 (sidecar walk semantics deleted
@@ -2989,7 +3160,7 @@ case "$MODE" in
     scenario_list; scenario_quit; scenario_platform_adapters
     scenario_python_units
     scenario_bearer_ssh_send; scenario_bearer_ssh_recv; scenario_bearer_cli_recv
-    scenario_bearer_observability; scenario_bearer_local
+    scenario_bearer_observability; scenario_bearer_local; scenario_bearer_gh
     ;;
   *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|all]"; exit 2 ;;
 esac

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -32,8 +32,10 @@ from airc_core.bearer_resolver import (  # noqa: E402
 )
 from airc_core.bearer_ssh import SshBearer, SshBearerError  # noqa: E402
 from airc_core.bearer_local import LocalBearer, LocalBearerError  # noqa: E402
+from airc_core.bearer_gh import GhBearer, GhBearerError  # noqa: E402
 from airc_core import bearer_ssh  # noqa: E402
 from airc_core import bearer_local  # noqa: E402
+from airc_core import bearer_gh  # noqa: E402
 from airc_core import bearer_cli  # noqa: E402
 
 
@@ -1149,6 +1151,346 @@ class ResolverOrderTests(unittest.TestCase):
         self.assertIn("ssh", kinds)
         # local must come first (preference order).
         self.assertLess(kinds.index("local"), kinds.index("ssh"))
+
+
+class GhBearerCanServeTests(unittest.TestCase):
+    """Phase 3b: GhBearer.can_serve must require BOTH room_gist_id
+    AND a working gh auth. Either alone is insufficient — gist id with
+    no auth means we can't actually read/write; auth with no gist id
+    means we have nowhere to send to."""
+
+    def test_serves_with_gist_id_and_gh_auth(self):
+        with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=True):
+            self.assertTrue(GhBearer.can_serve({"room_gist_id": "abc123"}))
+
+    def test_rejects_without_gist_id(self):
+        with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=True):
+            self.assertFalse(GhBearer.can_serve({}))
+            self.assertFalse(GhBearer.can_serve({"room_gist_id": ""}))
+
+    def test_rejects_without_gh_auth(self):
+        with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=False):
+            self.assertFalse(GhBearer.can_serve({"room_gist_id": "abc123"}))
+
+    def test_can_serve_does_not_mutate_meta(self):
+        meta = {"room_gist_id": "abc123"}
+        before = dict(meta)
+        with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=True):
+            GhBearer.can_serve(meta)
+        self.assertEqual(meta, before)
+
+
+class GhBearerSendTests(unittest.TestCase):
+    """GhBearer.send: read-modify-write of the room gist's messages.jsonl
+    file. Tests mock _gh_api_get (the read step) and _gh_gist_write_file
+    (the write step) so no real gh API is touched."""
+
+    def _bearer(self, meta=None):
+        m = meta or {"room_gist_id": "abc123"}
+        b = GhBearer(m)
+        b.open("alice")
+        return b
+
+    def test_send_appends_to_existing_messages_file(self):
+        existing = '{"from":"x","msg":"old"}\n'
+        captured = {}
+
+        def fake_write(gist_id, content):
+            captured["gist_id"] = gist_id
+            captured["content"] = content
+            return (True, "")
+
+        with mock.patch.object(bearer_gh, "_gh_api_get",
+                               return_value={"files": {"messages.jsonl": {"content": existing}}}), \
+             mock.patch.object(bearer_gh, "_gh_gist_write_file", side_effect=fake_write):
+            outcome = self._bearer().send("alice", "general", b'{"from":"bob","msg":"hi"}')
+
+        self.assertEqual(outcome.kind, "delivered")
+        self.assertEqual(captured["gist_id"], "abc123")
+        self.assertEqual(
+            captured["content"],
+            existing + '{"from":"bob","msg":"hi"}\n',
+        )
+
+    def test_send_creates_messages_file_when_absent(self):
+        # First write to the gist — messages.jsonl doesn't exist yet.
+        captured = {}
+
+        def fake_write(gist_id, content):
+            captured["content"] = content
+            return (True, "")
+
+        with mock.patch.object(bearer_gh, "_gh_api_get",
+                               return_value={"files": {}}), \
+             mock.patch.object(bearer_gh, "_gh_gist_write_file", side_effect=fake_write):
+            outcome = self._bearer().send("alice", "general", b'{"from":"bob","msg":"first"}')
+
+        self.assertEqual(outcome.kind, "delivered")
+        self.assertEqual(captured["content"], '{"from":"bob","msg":"first"}\n')
+
+    def test_send_preserves_existing_trailing_newline(self):
+        captured = {}
+
+        def fake_write(gist_id, content):
+            captured["content"] = content
+            return (True, "")
+
+        with mock.patch.object(bearer_gh, "_gh_api_get",
+                               return_value={"files": {}}), \
+             mock.patch.object(bearer_gh, "_gh_gist_write_file", side_effect=fake_write):
+            self._bearer().send("alice", "general", b'{"x":1}\n')
+
+        self.assertEqual(captured["content"], '{"x":1}\n')
+
+    def test_send_transient_when_get_fails(self):
+        with mock.patch.object(bearer_gh, "_gh_api_get", return_value=None):
+            outcome = self._bearer().send("alice", "general", b'{"x":1}')
+        self.assertEqual(outcome.kind, "transient_failure")
+        self.assertIn("could not fetch gist", outcome.detail)
+
+    def test_send_transient_when_write_fails(self):
+        with mock.patch.object(bearer_gh, "_gh_api_get",
+                               return_value={"files": {}}), \
+             mock.patch.object(bearer_gh, "_gh_gist_write_file",
+                               return_value=(False, "Network is unreachable")):
+            outcome = self._bearer().send("alice", "general", b'{"x":1}')
+        self.assertEqual(outcome.kind, "transient_failure")
+        self.assertIn("Network is unreachable", outcome.detail)
+
+    def test_send_auth_failure_on_permission_denied(self):
+        with mock.patch.object(bearer_gh, "_gh_api_get",
+                               return_value={"files": {}}), \
+             mock.patch.object(bearer_gh, "_gh_gist_write_file",
+                               return_value=(False, "HTTP 401: Permission denied")):
+            outcome = self._bearer().send("alice", "general", b'{"x":1}')
+        self.assertEqual(outcome.kind, "auth_failure")
+
+    def test_send_without_gist_id_raises(self):
+        b = GhBearer({})
+        b.open("alice")
+        with self.assertRaises(GhBearerError):
+            b.send("alice", "general", b'{"x":1}')
+
+
+class GhBearerRecvTests(unittest.TestCase):
+    """GhBearer.recv_stream: poll the gist, yield new lines.
+
+    Tests use poll_interval=0 in peer_meta so the loop doesn't sleep
+    between iterations — keeps tests fast. Real production uses the
+    15s default."""
+
+    def _bearer(self, meta=None):
+        m = meta or {"room_gist_id": "abc123", "poll_interval": 0}
+        b = GhBearer(m)
+        b.open("alice")
+        return b
+
+    def _gist_response(self, content):
+        return {"files": {"messages.jsonl": {"content": content}}}
+
+    def test_recv_yields_new_lines_per_poll(self):
+        # First poll sees 2 lines; second poll sees 3 (1 new). Bearer
+        # must yield only the new line on the second poll.
+        responses = [
+            self._gist_response(
+                '{"from":"bob","channel":"general","msg":"a"}\n'
+                '{"from":"carol","channel":"general","msg":"b"}\n'
+            ),
+            self._gist_response(
+                '{"from":"bob","channel":"general","msg":"a"}\n'
+                '{"from":"carol","channel":"general","msg":"b"}\n'
+                '{"from":"dave","channel":"general","msg":"c"}\n'
+            ),
+        ]
+
+        b = self._bearer()
+        with mock.patch.object(bearer_gh, "_gh_api_get", side_effect=responses):
+            events = []
+            gen = b.recv_stream()
+            # Take the first 3 events: 2 from poll1, 1 from poll2.
+            for ev in gen:
+                events.append(ev)
+                if len(events) >= 3:
+                    b.close()
+                    break
+
+        msgs = [ev.bearer_metadata["envelope"]["msg"] for ev in events]
+        self.assertEqual(msgs, ["a", "b", "c"])
+
+    def test_recv_skips_malformed_lines(self):
+        with mock.patch.object(
+            bearer_gh, "_gh_api_get",
+            return_value=self._gist_response(
+                'not json\n'
+                '{"from":"bob","msg":"good"}\n'
+                '[1,2,3]\n'
+                '{"from":"carol","msg":"also good"}\n'
+            ),
+        ):
+            b = self._bearer()
+            events = []
+            gen = b.recv_stream()
+            for ev in gen:
+                events.append(ev)
+                if len(events) >= 2:
+                    b.close()
+                    break
+
+        self.assertEqual([e.sender_peer_id for e in events], ["bob", "carol"])
+
+    def test_recv_handles_get_failures_by_polling_again(self):
+        # First poll fails (None); second succeeds. Bearer should sleep
+        # and re-poll without crashing.
+        responses = [
+            None,  # transient
+            self._gist_response('{"from":"bob","msg":"hi"}\n'),
+        ]
+        with mock.patch.object(bearer_gh, "_gh_api_get", side_effect=responses):
+            b = self._bearer()
+            events = []
+            gen = b.recv_stream()
+            for ev in gen:
+                events.append(ev)
+                b.close()
+                break
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].sender_peer_id, "bob")
+
+    def test_recv_resumes_past_offset_file(self):
+        import tempfile, os as _os
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            f.write("2")  # skip first 2 lines
+            offset_path = f.name
+        try:
+            with mock.patch.object(
+                bearer_gh, "_gh_api_get",
+                return_value=self._gist_response(
+                    '{"from":"bob","msg":"a"}\n'
+                    '{"from":"bob","msg":"b"}\n'
+                    '{"from":"bob","msg":"c"}\n'
+                ),
+            ):
+                b = self._bearer({
+                    "room_gist_id": "abc123",
+                    "poll_interval": 0,
+                    "offset_file": offset_path,
+                })
+                events = []
+                gen = b.recv_stream()
+                for ev in gen:
+                    events.append(ev)
+                    b.close()
+                    break
+
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0].bearer_metadata["envelope"]["msg"], "c")
+        finally:
+            _os.unlink(offset_path)
+
+    def test_liveness_updates_on_each_event(self):
+        with mock.patch.object(
+            bearer_gh, "_gh_api_get",
+            return_value=self._gist_response('{"from":"bob","msg":"x"}\n'),
+        ):
+            b = self._bearer()
+            live_before = b.liveness("alice")
+            self.assertIsNone(live_before.last_seen_ts)
+            self.assertIn("no events", live_before.bearer_diag.lower())
+
+            gen = b.recv_stream()
+            next(gen)
+            live_after = b.liveness("alice")
+            self.assertIsNotNone(live_after.last_seen_ts)
+            self.assertIn("gh poll", live_after.bearer_diag.lower())
+            b.close()
+
+    def test_offset_persists_after_recv(self):
+        import tempfile, os as _os
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            f.write("0")
+            offset_path = f.name
+        try:
+            with mock.patch.object(
+                bearer_gh, "_gh_api_get",
+                return_value=self._gist_response(
+                    '{"from":"bob","msg":"a"}\n'
+                    '{"from":"bob","msg":"b"}\n'
+                ),
+            ):
+                b = self._bearer({
+                    "room_gist_id": "abc123",
+                    "poll_interval": 0,
+                    "offset_file": offset_path,
+                })
+                gen = b.recv_stream()
+                next(gen); next(gen)
+                b.close()
+
+            with open(offset_path) as f:
+                self.assertEqual(f.read().strip(), "2")
+        finally:
+            _os.unlink(offset_path)
+
+
+class GhBearerSkeletonTests(unittest.TestCase):
+    """ABC contract — same shape as SshBearerSkeleton/LocalBearerSkeleton."""
+
+    def test_kind_is_gh(self):
+        self.assertEqual(GhBearer.KIND, "gh")
+
+    def test_construct_is_cheap(self):
+        # Constructor must do NO IO. _has_gh_auth() must NOT run here —
+        # it's only invoked by can_serve. We verify by patching it to
+        # raise; if construction touched it, this would fail.
+        with mock.patch.object(bearer_gh, "_has_gh_auth",
+                               side_effect=AssertionError("must not run on construct")):
+            b = GhBearer({"room_gist_id": "abc"})
+            b.close()
+
+    def test_post_close_operations_raise(self):
+        b = GhBearer({"room_gist_id": "abc"})
+        b.open("alice")
+        b.close()
+        with self.assertRaises(GhBearerError):
+            b.send("alice", "general", b'{"x":1}')
+
+
+class ResolverIncludesGhBearerTests(unittest.TestCase):
+    """Phase 3b: GhBearer is registered (after SshBearer in 3b's
+    additive ordering). Production peer_meta with host_target still
+    routes to SshBearer; only meta lacking host_target reaches gh."""
+
+    def test_available_kinds_includes_gh(self):
+        from airc_core.bearer_resolver import available_kinds
+        kinds = available_kinds()
+        self.assertIn("gh", kinds)
+        # 3b: gh comes AFTER ssh so today's traffic isn't preempted.
+        self.assertGreater(kinds.index("gh"), kinds.index("ssh"))
+
+    def test_ssh_still_wins_when_host_target_present(self):
+        # Today's production peer_meta. Resolver picks SshBearer; gh
+        # never gets a turn.
+        bearer = resolve({
+            "host_target": "alice@example.com",
+            "remote_home": "/home/alice/.airc",
+        })
+        self.assertEqual(bearer.KIND, "ssh")
+
+    def test_gh_picked_when_only_room_gist_id(self):
+        # Phase 3b activation path. peer_meta has NO host_target
+        # (so SSH and Local both decline) but has a room_gist_id and
+        # gh auth works → GhBearer.
+        with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=True):
+            bearer = resolve({"room_gist_id": "abc123"})
+        self.assertEqual(bearer.KIND, "gh")
+
+    def test_unreachable_when_no_gh_auth_and_no_other_meta(self):
+        # Nothing can serve: no host_target (Ssh declines), no loopback
+        # (Local declines), no gh auth (Gh declines).
+        with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=False):
+            with self.assertRaises(PeerUnreachable):
+                resolve({"room_gist_id": "abc123"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds the third bearer kind. GhBearer uses gh-gist as transport: the room gist gets a \`messages.jsonl\` file, peers append envelopes via \`gh gist edit\`, recv_stream polls for new lines (15s default cadence). Registered AFTER SshBearer so production behavior is unchanged today — GhBearer only activates for \`peer_meta\` lacking \`host_target\` (a path the resolver doesn't reach until 3c flips the handshake).

## Why this split
Three bearers in the registry validates the seam end-to-end. The deletion sweep in 3c (SshBearer + all Tailscale knowledge) becomes a coherent removal PR rather than bundling new-mechanism with deletion-of-old.

## Mechanism
- \`lib/airc_core/bearer_gh.py\` — gh CLI subprocess for read (\`gh api gists/<id>\`) and write (\`gh gist edit\`). 15s polling = ~240 req/hour/peer, well under gh's 5000/hour authenticated limit. Optimistic concurrency via read-modify-write (ETag/If-Match deferred — gh CLI doesn't expose, conflict window sub-second in chat-pace).
- \`lib/airc_core/bearer_resolver.py\` — registry now \`[LocalBearer, SshBearer, GhBearer]\`. Order docs explicit about why GhBearer is LAST in 3b (purely additive) and what 3c flips.

Outcome contract identical to SshBearer/LocalBearer: \`delivered\` / \`transient_failure\` / \`auth_failure\`. Same envelope shape so monitor_formatter doesn't need to know which bearer produced a line.

## Test plan
- [x] \`python_units\` (test_bearer.py): 91/91 — 24 new across GhBearerCanServe/Send/Recv/Skeleton + ResolverIncludesGhBearer. All gh CLI subprocesses mocked; hermetic.
- [x] \`bearer_gh\` (new integration scenario, 6 assertions): REAL gh gist round-trip. Creates gist → resolver picks gh → send delivered → marker visible in gist content → recv_stream picks up appended line → liveness FRESH. Skip-guarded on gh auth, cleans up via trap.
- [x] \`bearer_local\`: 5/5 (no regression)
- [x] \`bearer_ssh_send\`: 6/6 (SSH still wins for today's peer_meta with host_target)
- [x] \`tabs\`: 19/19
- [ ] CI integration suite

## Notes
- Test debug: caught and fixed an evidence-eating \`2>/dev/null\` on the python recv subprocess. Per CLAUDE.md "never swallow errors" — stderr now lands in a captured tmpfile when the assertion fails.
- One real bug surfaced and fixed during scenario authoring: gist-edit overwrite was dropping seed line, line-count stayed at 2, bearer's \`consumed_lines=2\` skipped past the new marker. Fixed by reading prior content via \`gh api\` and reconstructing the full file before append. The bearer code itself was correct.
- Phase 3c is next: flip resolver to \`[LocalBearer, GhBearer]\`, delete SshBearer + all Tailscale code, update join handshake. Closes #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)