### PR TITLE
feat(e2e): Phase E.1 — envelope-layer crypto primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .airc/
 __pycache__/
 *.pyc
+.venv-dev

--- a/lib/airc_core/crypto.py
+++ b/lib/airc_core/crypto.py
@@ -1,0 +1,314 @@
+"""airc envelope-layer cryptography — boring primitives, no novel crypto.
+
+This module is the entire app-layer security surface for airc. Per the
+post-bearer-rewrite architecture (project memory: airc transport
+architecture), the bearer carries opaque bytes and the envelope is
+encrypted+signed at this layer. That makes every bearer a dumb pipe and
+collapses transport-encryption (SSH/Tailscale) into a redundant role
+that gets deleted in Phase 3c.
+
+Primitives (all from python-cryptography, all NIST/IETF-standard):
+    X25519        — elliptic-curve key agreement (RFC 7748)
+    ChaCha20-Poly1305 — AEAD cipher (RFC 8439)
+    HKDF-SHA256   — key derivation (RFC 5869)
+    Ed25519       — envelope signing (already used by airc, not added here)
+
+Non-goals (deliberate scope):
+    - No forward-secret ratchet (Signal/Olm). Pairwise static keys are
+      sufficient at airc's scale (rooms ≤10 peers, infrequent rotation).
+    - No group-key/sender-key (megolm). For N≤10 we can encrypt N times
+      per send without measurable cost. Phase E.2 if rooms grow.
+    - No anti-deniability. We don't need plausible deniability; signing
+      is a feature, not a bug.
+    - No password-based key derivation. Identity is keypairs from disk.
+
+Threat model:
+    - GitHub (gist content): assumed plaintext-readable. AEAD here makes
+      the gist content opaque to GitHub.
+    - ISP / public WiFi MITM: same — bearer is HTTPS to gh, but even
+      if it weren't, the AEAD layer protects.
+    - Other users on a shared machine: out of scope for the encryption
+      layer; identity-key file perms (0600) handle this.
+    - Compromised peer: their pairwise keys leak. Other peers' messages
+      to them are compromised but messages between OTHER peers remain
+      safe (pairwise model — that's the security boundary, deliberately).
+
+Test gating:
+    The cryptography package is a runtime dependency. install.sh creates
+    a venv and pip-installs it (Phase E install support). Test files
+    skip cleanly when the package is missing so a fresh checkout without
+    the venv set up doesn't error out the whole test suite.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import struct
+from typing import Optional
+
+# All imports from cryptography are here at module load time. If the
+# package isn't installed, importing crypto.py raises ImportError; callers
+# should guard with try/except at their own boundaries (cmd_send, etc).
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey,
+    X25519PublicKey,
+)
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+
+
+# Format version for serialized envelopes. Bump if the wire format
+# changes in a backward-incompatible way; recv side branches on this.
+ENVELOPE_VERSION = "v1"
+
+# Nonce size for ChaCha20-Poly1305 (RFC 8439): 96 bits = 12 bytes.
+_NONCE_LEN = 12
+
+# AEAD key size: 256 bits = 32 bytes.
+_KEY_LEN = 32
+
+
+# ──────────────────────────────────────────────────────────────────
+# X25519 keypairs — generation, save, load
+# ──────────────────────────────────────────────────────────────────
+
+def generate_x25519_keypair() -> tuple[bytes, bytes]:
+    """Generate a fresh X25519 keypair. Returns (priv_raw, pub_raw),
+    both 32 bytes. Raw format (not PEM) — easier to store as base64 in
+    JSON, smaller on disk, no parser surface area. cryptography handles
+    the underlying key generation via the OS RNG."""
+    priv = X25519PrivateKey.generate()
+    priv_raw = priv.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_raw = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return (priv_raw, pub_raw)
+
+
+def save_keypair(priv_raw: bytes, pub_raw: bytes, priv_path: str, pub_path: str) -> None:
+    """Write keypair to disk. Private key gets 0600 (user-only read/write);
+    public key gets 0644. Atomic write via temp + rename so a SIGKILL
+    mid-write doesn't leave a partial private key.
+
+    Why raw bytes rather than PEM/OpenSSH format: the only consumer of
+    these files is THIS module. PEM adds parser surface area and a
+    150-byte armor that base64'd raw is just 44 bytes. Trade-off in our
+    favor: less code, fewer footguns."""
+    _atomic_write_bytes(priv_path, priv_raw, mode=0o600)
+    _atomic_write_bytes(pub_path, pub_raw, mode=0o644)
+
+
+def load_priv(priv_path: str) -> bytes:
+    """Read 32-byte X25519 private key from disk. Raises FileNotFoundError
+    or ValueError if the file is malformed."""
+    with open(priv_path, "rb") as f:
+        raw = f.read()
+    if len(raw) != 32:
+        raise ValueError(
+            f"X25519 private key at {priv_path} is {len(raw)} bytes; expected 32"
+        )
+    return raw
+
+
+def load_pub(pub_path: str) -> bytes:
+    """Read 32-byte X25519 public key from disk."""
+    with open(pub_path, "rb") as f:
+        raw = f.read()
+    if len(raw) != 32:
+        raise ValueError(
+            f"X25519 public key at {pub_path} is {len(raw)} bytes; expected 32"
+        )
+    return raw
+
+
+# ──────────────────────────────────────────────────────────────────
+# ECDH + HKDF — derive a pairwise AEAD key from two keypairs
+# ──────────────────────────────────────────────────────────────────
+
+def derive_pairwise_key(
+    my_priv_raw: bytes,
+    their_pub_raw: bytes,
+    info: bytes = b"airc-aead-v1",
+) -> bytes:
+    """X25519 ECDH followed by HKDF-SHA256 to derive a 32-byte AEAD key
+    suitable for ChaCha20-Poly1305.
+
+    `info` is the HKDF context string. Domain-separating different
+    purposes (envelope encryption vs key-handoff vs whatever) by changing
+    info ensures keys derived for one purpose can't be misused for
+    another. The default `airc-aead-v1` is for envelope encryption;
+    bump v1→v2 only when the wire format changes incompatibly.
+
+    Both inputs MUST be 32 bytes (raw X25519 format). Salt is empty
+    (None per HKDF spec) — both peers' identities are already in the
+    info string and the ECDH shared secret is high-entropy.
+
+    Determinism: same inputs always produce the same output, allowing
+    both ends of a pair to derive the same key without communicating
+    intermediate state.
+    """
+    if len(my_priv_raw) != 32 or len(their_pub_raw) != 32:
+        raise ValueError("X25519 keys must be exactly 32 bytes")
+    priv = X25519PrivateKey.from_private_bytes(my_priv_raw)
+    pub = X25519PublicKey.from_public_bytes(their_pub_raw)
+    shared = priv.exchange(pub)
+    derived = HKDF(
+        algorithm=hashes.SHA256(),
+        length=_KEY_LEN,
+        salt=None,
+        info=info,
+    ).derive(shared)
+    return derived
+
+
+# ──────────────────────────────────────────────────────────────────
+# AEAD — encrypt + decrypt with associated data
+# ──────────────────────────────────────────────────────────────────
+
+def aead_encrypt(
+    key: bytes,
+    plaintext: bytes,
+    associated_data: bytes = b"",
+    nonce: Optional[bytes] = None,
+) -> tuple[bytes, bytes]:
+    """ChaCha20-Poly1305 AEAD encrypt. Returns (nonce, ciphertext_with_tag).
+
+    If `nonce` is None, a fresh 12-byte nonce is drawn from os.urandom.
+    Caller may pass an explicit nonce for counter-mode usage (e.g.
+    per-session counter) — but MUST NOT reuse a nonce under the same
+    key, ever. Reuse breaks AEAD catastrophically.
+
+    `associated_data` is authenticated but not encrypted — bind any
+    plaintext envelope fields (sender, channel, ts) here so an attacker
+    can't swap a recipient's view of who-sent-what without the auth
+    check failing.
+    """
+    if len(key) != _KEY_LEN:
+        raise ValueError(f"AEAD key must be {_KEY_LEN} bytes")
+    if nonce is None:
+        nonce = os.urandom(_NONCE_LEN)
+    elif len(nonce) != _NONCE_LEN:
+        raise ValueError(f"AEAD nonce must be {_NONCE_LEN} bytes")
+    aead = ChaCha20Poly1305(key)
+    ciphertext = aead.encrypt(nonce, plaintext, associated_data)
+    return (nonce, ciphertext)
+
+
+def aead_decrypt(
+    key: bytes,
+    nonce: bytes,
+    ciphertext_with_tag: bytes,
+    associated_data: bytes = b"",
+) -> bytes:
+    """ChaCha20-Poly1305 AEAD decrypt. Raises InvalidTag on auth failure.
+
+    Caller MUST handle the InvalidTag exception explicitly — silent
+    catch+drop is the classic crypto footgun that turns "decryption
+    failed" into "got an empty message" and breaks higher-layer logic.
+    The cryptography package raises a specific exception type so callers
+    can act on it (skip the line, log, alert, etc).
+    """
+    if len(key) != _KEY_LEN:
+        raise ValueError(f"AEAD key must be {_KEY_LEN} bytes")
+    if len(nonce) != _NONCE_LEN:
+        raise ValueError(f"AEAD nonce must be {_NONCE_LEN} bytes")
+    aead = ChaCha20Poly1305(key)
+    return aead.decrypt(nonce, ciphertext_with_tag, associated_data)
+
+
+# ──────────────────────────────────────────────────────────────────
+# Counter-based nonces — for replay-defense + nonce-reuse avoidance
+# ──────────────────────────────────────────────────────────────────
+
+def counter_nonce(counter: int) -> bytes:
+    """Build a 12-byte nonce from a 64-bit counter (8 bytes counter
+    big-endian + 4 zero bytes). Counter MUST monotonically increase per
+    pairwise key to guarantee no reuse.
+
+    Caller persists the counter; this function only encodes. We use BE
+    encoding so two implementations comparing nonces lexicographically
+    get the same ordering as numeric comparison — handy for any future
+    "highest-seen-nonce" replay-defense scheme."""
+    if counter < 0 or counter >= 2**64:
+        raise ValueError(f"counter {counter} out of 64-bit range")
+    return struct.pack(">Q", counter) + b"\x00\x00\x00\x00"
+
+
+def parse_counter_nonce(nonce: bytes) -> int:
+    """Inverse of counter_nonce(). Raises ValueError on a non-counter
+    nonce (random nonces don't round-trip; that's a feature)."""
+    if len(nonce) != _NONCE_LEN:
+        raise ValueError(f"nonce must be {_NONCE_LEN} bytes")
+    if nonce[8:] != b"\x00\x00\x00\x00":
+        raise ValueError("nonce is not in counter format (suffix nonzero)")
+    return struct.unpack(">Q", nonce[:8])[0]
+
+
+# ──────────────────────────────────────────────────────────────────
+# Public-key fingerprint — for invite strings / out-of-band verification
+# ──────────────────────────────────────────────────────────────────
+
+def fingerprint(pub_raw: bytes, length: int = 16) -> str:
+    """Return a short hex fingerprint of a public key, suitable for
+    embedding in invite strings. Default length = 16 hex chars (64 bits)
+    which gives ~10^19 collision space — sufficient for human-pairing
+    recognition, not security-critical (the actual key bytes do that
+    job).
+
+    Use SHA-256 because we already use it elsewhere; truncating to N
+    chars is standard practice for fingerprints (gpg, ssh, gist hashes
+    all do this)."""
+    if len(pub_raw) != 32:
+        raise ValueError("X25519 pubkey must be 32 bytes")
+    return hashlib.sha256(pub_raw).hexdigest()[:length]
+
+
+# ──────────────────────────────────────────────────────────────────
+# Base64 helpers — JSON envelopes carry binary fields as b64
+# ──────────────────────────────────────────────────────────────────
+
+def b64encode(data: bytes) -> str:
+    """URL-safe base64, no padding. Same convention as JWT — easier on
+    JSON envelopes and avoids '=' padding that bash sometimes mangles."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def b64decode(s: str) -> bytes:
+    """Inverse of b64encode. Re-pads on decode since urlsafe_b64decode
+    rejects unpadded input. Raises ValueError on malformed input."""
+    if not isinstance(s, str):
+        raise ValueError("b64decode expects str")
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+# ──────────────────────────────────────────────────────────────────
+# Internal: atomic write helper
+# ──────────────────────────────────────────────────────────────────
+
+def _atomic_write_bytes(path: str, data: bytes, mode: int = 0o600) -> None:
+    """Write `data` to `path` atomically via temp+rename. The temp file
+    is created with the target mode so there's never a window where the
+    file exists with default-and-broader perms.
+
+    On Windows, os.replace handles the rename atomically (Python 3.3+).
+    """
+    d = os.path.dirname(path) or "."
+    os.makedirs(d, exist_ok=True)
+    fd = os.open(
+        path + ".tmp", os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode
+    )
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+    os.replace(path + ".tmp", path)

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -1,0 +1,336 @@
+"""airc envelope-layer crypto tests.
+
+Run: cd test && python -m unittest test_crypto
+
+These tests exercise the primitives in lib/airc_core/crypto.py against
+their RFC contracts. Where possible, tests use known-answer vectors;
+where the underlying primitive is non-deterministic (random nonce
+generation), tests verify round-trip correctness instead.
+
+Skip behavior: if cryptography package isn't importable (fresh checkout
+with no venv), the whole module is skipped. The user-facing message
+points at install.sh to set up the venv. This avoids breaking the rest
+of the test suite for someone running without the dep.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+try:
+    from airc_core import crypto  # noqa: E402
+    _HAS_CRYPTO = True
+    _SKIP_REASON = ""
+except ImportError as e:
+    _HAS_CRYPTO = False
+    _SKIP_REASON = (
+        f"cryptography package not available ({e}). "
+        f"Run install.sh to set up the venv with airc's runtime dependencies."
+    )
+
+
+@unittest.skipUnless(_HAS_CRYPTO, _SKIP_REASON)
+class X25519KeypairTests(unittest.TestCase):
+    """Generate, save, load — round-trip private and public keys
+    through disk. Verify the on-disk format is exactly 32 raw bytes
+    (no PEM armor, no padding)."""
+
+    def test_generate_returns_32_byte_pair(self):
+        priv, pub = crypto.generate_x25519_keypair()
+        self.assertEqual(len(priv), 32)
+        self.assertEqual(len(pub), 32)
+        self.assertNotEqual(priv, pub)
+
+    def test_generate_is_random(self):
+        # Two keypairs in a row must differ (collisions are 2^-256 against).
+        kp1 = crypto.generate_x25519_keypair()
+        kp2 = crypto.generate_x25519_keypair()
+        self.assertNotEqual(kp1, kp2)
+        self.assertNotEqual(kp1[0], kp2[0])
+        self.assertNotEqual(kp1[1], kp2[1])
+
+    def test_save_and_load_round_trip(self):
+        import tempfile, os
+        priv, pub = crypto.generate_x25519_keypair()
+        with tempfile.TemporaryDirectory() as td:
+            ppath = os.path.join(td, "priv")
+            pubpath = os.path.join(td, "pub")
+            crypto.save_keypair(priv, pub, ppath, pubpath)
+            self.assertEqual(crypto.load_priv(ppath), priv)
+            self.assertEqual(crypto.load_pub(pubpath), pub)
+
+    def test_save_sets_priv_mode_0600(self):
+        import tempfile, os, stat
+        priv, pub = crypto.generate_x25519_keypair()
+        with tempfile.TemporaryDirectory() as td:
+            ppath = os.path.join(td, "priv")
+            pubpath = os.path.join(td, "pub")
+            crypto.save_keypair(priv, pub, ppath, pubpath)
+            priv_mode = stat.S_IMODE(os.stat(ppath).st_mode)
+            self.assertEqual(priv_mode, 0o600,
+                             f"private key mode is {oct(priv_mode)}, expected 0o600")
+
+    def test_load_priv_rejects_wrong_length(self):
+        import tempfile, os
+        with tempfile.TemporaryDirectory() as td:
+            ppath = os.path.join(td, "priv")
+            with open(ppath, "wb") as f:
+                f.write(b"\x00" * 16)  # too short
+            with self.assertRaises(ValueError):
+                crypto.load_priv(ppath)
+
+    def test_atomic_write_no_partial_state_on_kill(self):
+        # We can't easily simulate a SIGKILL mid-write, but we CAN check
+        # that the implementation uses a tmp + rename pattern by
+        # observing that the target path doesn't exist between generate
+        # and replace — a black-box assertion would require monkey-
+        # patching os.write. Instead, assert the simpler property: the
+        # final file matches the bytes passed in. (The atomicity is
+        # pieced together from os.replace docs + the implementation.)
+        import tempfile, os
+        priv, pub = crypto.generate_x25519_keypair()
+        with tempfile.TemporaryDirectory() as td:
+            ppath = os.path.join(td, "priv")
+            pubpath = os.path.join(td, "pub")
+            crypto.save_keypair(priv, pub, ppath, pubpath)
+            # No leftover .tmp files
+            self.assertFalse(os.path.exists(ppath + ".tmp"))
+            self.assertFalse(os.path.exists(pubpath + ".tmp"))
+
+
+@unittest.skipUnless(_HAS_CRYPTO, _SKIP_REASON)
+class ECDHDeriveTests(unittest.TestCase):
+    """X25519 ECDH + HKDF → 32-byte AEAD key. Both peers must derive
+    the SAME key from their own private + the other's public."""
+
+    def test_pair_derives_matching_key(self):
+        priv_a, pub_a = crypto.generate_x25519_keypair()
+        priv_b, pub_b = crypto.generate_x25519_keypair()
+        key_a = crypto.derive_pairwise_key(priv_a, pub_b)
+        key_b = crypto.derive_pairwise_key(priv_b, pub_a)
+        self.assertEqual(key_a, key_b,
+                         "both peers must derive the same pairwise key")
+        self.assertEqual(len(key_a), 32)
+
+    def test_different_pairs_derive_different_keys(self):
+        priv_a, pub_a = crypto.generate_x25519_keypair()
+        priv_b, pub_b = crypto.generate_x25519_keypair()
+        priv_c, pub_c = crypto.generate_x25519_keypair()
+        key_ab = crypto.derive_pairwise_key(priv_a, pub_b)
+        key_ac = crypto.derive_pairwise_key(priv_a, pub_c)
+        self.assertNotEqual(key_ab, key_ac)
+
+    def test_info_string_domain_separates(self):
+        # Same keys but different `info` MUST produce different keys.
+        # This is the HKDF domain-separation property — without it, an
+        # attacker who learns one purpose's key could misuse it for
+        # another purpose.
+        priv_a, _ = crypto.generate_x25519_keypair()
+        _, pub_b = crypto.generate_x25519_keypair()
+        key1 = crypto.derive_pairwise_key(priv_a, pub_b, info=b"purpose-1")
+        key2 = crypto.derive_pairwise_key(priv_a, pub_b, info=b"purpose-2")
+        self.assertNotEqual(key1, key2)
+
+    def test_rejects_wrong_length_keys(self):
+        priv, pub = crypto.generate_x25519_keypair()
+        with self.assertRaises(ValueError):
+            crypto.derive_pairwise_key(priv[:16], pub)
+        with self.assertRaises(ValueError):
+            crypto.derive_pairwise_key(priv, pub[:16])
+
+
+@unittest.skipUnless(_HAS_CRYPTO, _SKIP_REASON)
+class AEADTests(unittest.TestCase):
+    """ChaCha20-Poly1305 round-trip + auth-failure detection."""
+
+    def setUp(self):
+        priv_a, pub_a = crypto.generate_x25519_keypair()
+        priv_b, pub_b = crypto.generate_x25519_keypair()
+        self.key = crypto.derive_pairwise_key(priv_a, pub_b)
+
+    def test_encrypt_then_decrypt_round_trip(self):
+        plaintext = b"hello, world"
+        nonce, ct = crypto.aead_encrypt(self.key, plaintext)
+        recovered = crypto.aead_decrypt(self.key, nonce, ct)
+        self.assertEqual(recovered, plaintext)
+
+    def test_associated_data_authenticated(self):
+        plaintext = b"private payload"
+        ad = b"sender=alice|channel=general|ts=12345"
+        nonce, ct = crypto.aead_encrypt(self.key, plaintext, ad)
+        # Decrypt with same AD — works.
+        self.assertEqual(crypto.aead_decrypt(self.key, nonce, ct, ad), plaintext)
+        # Decrypt with different AD — fails with InvalidTag.
+        from cryptography.exceptions import InvalidTag
+        with self.assertRaises(InvalidTag):
+            crypto.aead_decrypt(self.key, nonce, ct, b"sender=mallory|channel=general|ts=12345")
+
+    def test_tampered_ciphertext_fails_auth(self):
+        nonce, ct = crypto.aead_encrypt(self.key, b"payload")
+        # Flip a byte in the ciphertext.
+        tampered = bytes([ct[0] ^ 0xFF]) + ct[1:]
+        from cryptography.exceptions import InvalidTag
+        with self.assertRaises(InvalidTag):
+            crypto.aead_decrypt(self.key, nonce, tampered)
+
+    def test_tampered_nonce_fails_auth(self):
+        nonce, ct = crypto.aead_encrypt(self.key, b"payload")
+        tampered_nonce = bytes([nonce[0] ^ 0xFF]) + nonce[1:]
+        from cryptography.exceptions import InvalidTag
+        with self.assertRaises(InvalidTag):
+            crypto.aead_decrypt(self.key, tampered_nonce, ct)
+
+    def test_explicit_nonce_round_trip(self):
+        # Counter nonce path: encrypt with nonce=counter_nonce(N).
+        nonce_in = crypto.counter_nonce(42)
+        nonce_out, ct = crypto.aead_encrypt(self.key, b"x", nonce=nonce_in)
+        self.assertEqual(nonce_out, nonce_in)
+        self.assertEqual(crypto.aead_decrypt(self.key, nonce_out, ct), b"x")
+
+    def test_rejects_wrong_key_length(self):
+        with self.assertRaises(ValueError):
+            crypto.aead_encrypt(b"\x00" * 16, b"x")  # 16-byte key (AES-128 size, not ChaCha)
+
+    def test_rejects_wrong_nonce_length(self):
+        with self.assertRaises(ValueError):
+            crypto.aead_encrypt(self.key, b"x", nonce=b"\x00" * 8)  # too short
+
+
+@unittest.skipUnless(_HAS_CRYPTO, _SKIP_REASON)
+class CounterNonceTests(unittest.TestCase):
+    """Counter nonces are deterministic and reversible. Replay-defense
+    higher up depends on this round-trip behavior."""
+
+    def test_round_trip(self):
+        for n in (0, 1, 42, 2**32 - 1, 2**63 - 1):
+            nonce = crypto.counter_nonce(n)
+            self.assertEqual(crypto.parse_counter_nonce(nonce), n)
+            self.assertEqual(len(nonce), 12)
+
+    def test_rejects_negative_counter(self):
+        with self.assertRaises(ValueError):
+            crypto.counter_nonce(-1)
+
+    def test_rejects_overflow(self):
+        with self.assertRaises(ValueError):
+            crypto.counter_nonce(2**64)
+
+    def test_parse_rejects_non_counter_format(self):
+        # Random nonce should NOT round-trip as a counter (suffix nonzero).
+        import os
+        random_nonce = os.urandom(12)
+        # If the random suffix happens to be all zeros (probability 2^-32),
+        # this test would mis-fire. Force a nonzero suffix.
+        random_nonce = random_nonce[:8] + b"\x00\x00\x00\x01"
+        with self.assertRaises(ValueError):
+            crypto.parse_counter_nonce(random_nonce)
+
+
+@unittest.skipUnless(_HAS_CRYPTO, _SKIP_REASON)
+class FingerprintTests(unittest.TestCase):
+    """Public-key fingerprint — short hex digest for invite strings."""
+
+    def test_default_length(self):
+        _, pub = crypto.generate_x25519_keypair()
+        fp = crypto.fingerprint(pub)
+        self.assertEqual(len(fp), 16)
+        # All hex chars
+        int(fp, 16)
+
+    def test_deterministic(self):
+        _, pub = crypto.generate_x25519_keypair()
+        self.assertEqual(crypto.fingerprint(pub), crypto.fingerprint(pub))
+
+    def test_different_pubkeys_have_different_fingerprints(self):
+        _, pub1 = crypto.generate_x25519_keypair()
+        _, pub2 = crypto.generate_x25519_keypair()
+        self.assertNotEqual(crypto.fingerprint(pub1), crypto.fingerprint(pub2))
+
+    def test_custom_length(self):
+        _, pub = crypto.generate_x25519_keypair()
+        self.assertEqual(len(crypto.fingerprint(pub, length=8)), 8)
+        self.assertEqual(len(crypto.fingerprint(pub, length=32)), 32)
+
+    def test_rejects_wrong_pub_length(self):
+        with self.assertRaises(ValueError):
+            crypto.fingerprint(b"\x00" * 16)
+
+
+@unittest.skipUnless(_HAS_CRYPTO, _SKIP_REASON)
+class B64Tests(unittest.TestCase):
+    """URL-safe base64 helpers used in JSON envelopes."""
+
+    def test_round_trip(self):
+        for data in (b"", b"x", b"hello world", bytes(range(256))):
+            encoded = crypto.b64encode(data)
+            self.assertIsInstance(encoded, str)
+            self.assertEqual(crypto.b64decode(encoded), data)
+
+    def test_no_padding_in_output(self):
+        # Default urlsafe_b64encode emits = padding; we strip it.
+        encoded = crypto.b64encode(b"x")  # 1 byte → 2 chars + 2 padding
+        self.assertNotIn("=", encoded)
+
+    def test_url_safe_alphabet(self):
+        # 1024 random bytes — the encoded form must be URL-safe (only
+        # [A-Za-z0-9_-] in addition to the unpadded length).
+        import os, re
+        encoded = crypto.b64encode(os.urandom(1024))
+        self.assertTrue(re.match(r"^[A-Za-z0-9_-]+$", encoded))
+
+    def test_decode_handles_unpadded_input(self):
+        # Our encode strips padding, so decode must re-pad. Verify by
+        # encoding without padding, then decoding.
+        for data in (b"x", b"xx", b"xxx", b"xxxx"):
+            self.assertEqual(crypto.b64decode(crypto.b64encode(data)), data)
+
+    def test_decode_rejects_non_str(self):
+        with self.assertRaises(ValueError):
+            crypto.b64decode(b"abc")  # bytes, not str
+
+
+@unittest.skipUnless(_HAS_CRYPTO, _SKIP_REASON)
+class FullPairwiseScenarioTests(unittest.TestCase):
+    """End-to-end exercise of the primitives in the way airc envelope
+    encryption will actually use them. Two peers each generate a keypair,
+    derive their shared key, exchange an AEAD-encrypted message bound
+    to a plaintext envelope (associated data), and decrypt it back."""
+
+    def test_alice_to_bob_full_envelope(self):
+        # Alice's identity
+        ap, AP = crypto.generate_x25519_keypair()
+        # Bob's identity
+        bp, BP = crypto.generate_x25519_keypair()
+
+        # Pair handshake exchanges public keys; both sides derive the same key.
+        alice_to_bob_key = crypto.derive_pairwise_key(ap, BP)
+        bob_to_alice_key = crypto.derive_pairwise_key(bp, AP)
+        self.assertEqual(alice_to_bob_key, bob_to_alice_key)
+
+        # Alice sends an envelope: plaintext metadata + encrypted body.
+        # The metadata is bound via associated data so a tampered "from"
+        # field would invalidate the auth tag.
+        metadata = b"from=alice|to=bob|channel=general|ts=2026-04-29T01:23:45Z"
+        body = b"the plaintext message contents"
+        nonce, ct = crypto.aead_encrypt(alice_to_bob_key, body, associated_data=metadata)
+
+        # Bob receives, decrypts.
+        recovered = crypto.aead_decrypt(bob_to_alice_key, nonce, ct, associated_data=metadata)
+        self.assertEqual(recovered, body)
+
+        # Mallory sees ciphertext + metadata. Without the key she can't
+        # decrypt; without re-deriving she can't forge.
+        mp, MP = crypto.generate_x25519_keypair()
+        mallory_alice_key = crypto.derive_pairwise_key(mp, AP)
+        from cryptography.exceptions import InvalidTag
+        with self.assertRaises(InvalidTag):
+            crypto.aead_decrypt(mallory_alice_key, nonce, ct, associated_data=metadata)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds the app-layer cryptography module — foundation for Phase E.2 (pair handshake) and E.3 (envelope encrypt/decrypt). Per the post-bearer-rewrite architecture, security goes ABOVE the bearer so every transport becomes a dumb pipe and SSH/Tailscale's transport-encryption role collapses into something we can delete.

## Primitives (all RFC-standard, python-cryptography package)
- X25519 ECDH (RFC 7748) — pairwise key agreement
- HKDF-SHA256 (RFC 5869) — key derivation with \`info\` for domain separation
- ChaCha20-Poly1305 AEAD (RFC 8439) — 12-byte nonce
- 64-bit counter nonce encoder — replay-defense primitive
- Truncated SHA-256 fingerprint — for invite-string display
- URL-safe base64 helpers — JSON-envelope friendly

## Adaptability (Joel's brief: "crypto can adapt to new ECDSA etc")
- bytes-in / bytes-out interfaces → swap X25519 for X448 or PQ primitives by editing one function body
- HKDF \`info\` string → migrate v1→v2 without breaking deployed peers on old keys
- AEAD AD field → binds plaintext envelope metadata so swapping ChaCha for AES-GCM is wire-compatible

## Test plan
- [x] venv-dev with cryptography installed: 32/32 pass in 15ms
- [x] system python without cryptography: 32/32 skip cleanly (graceful degradation; install.sh venv setup lands in E.2)
- [x] Existing bearer test suite (91 tests) unaffected by this PR
- [ ] CI clean-install matrix

## Coverage (32 tests)
| Suite | n | What |
|---|---|---|
| X25519KeypairTests | 6 | generate, save/load round-trip, 0o600 mode, atomic write, length validation |
| ECDHDeriveTests | 4 | both peers derive same key, different pairs differ, info domain-separates |
| AEADTests | 7 | round-trip, AD authenticated, ct/nonce tampering fails, length validation |
| CounterNonceTests | 4 | round-trip, negative/overflow rejection, non-counter parse-rejection |
| FingerprintTests | 5 | deterministic, different keys → different, length validation |
| B64Tests | 5 | round-trip, no padding, URL-safe alphabet, unpadded decode |
| FullPairwiseScenarioTests | 1 | end-to-end Alice→Bob+Mallory: actual airc use case shape |

## Notes
- No call sites yet — purely additive. E.2 wires into identity bootstrap + pair handshake; E.3 into cmd_send + monitor_formatter. After E.3 lands, transport-encryption becomes redundant and Phase 3c deletes SshBearer + Tailscale wholesale.
- Existing tests skip cleanly on a fresh checkout without venv. \`make test\` / \`integration.sh python_units\` still passes the same way it did before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)