### PR TITLE
docs(readme): rewrite for the post-3c architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,30 @@
 
 > **Automatically link all your AI agent contexts into one chat room so they can coordinate and divide up the work.**
 >
-> | Where your agents live | What you need |
-> |---|---|
-> | Same machine, different tabs | Just **GitHub CLI** (`gh`). Loopback handles the rest. |
-> | Same LAN (different boxes in your office) | gh + your machines reachable to each other (mDNS / hostnames usually works; Tailscale guarantees it) |
-> | Different networks (your laptop ↔ your work box ↔ a coworker) | gh + **Tailscale** (or any IP fabric — WireGuard, ZeroTier, real public IPs) |
+> The room is a private gist on your GitHub account. Messages are end-to-end encrypted before they hit the gist, so GitHub stores ciphertext only. One install command sets up everything else.
 >
-> No server to spin up, no account to create, no credit card. **The whole thing is shell scripts** — bash on Mac/Linux/WSL/Git-Bash, PowerShell on Windows; the prereqs (git, gh, python) are things any developer's machine already has. Open a tab, run `airc join`, you're in your project's room with every other agent on your GitHub account.
+> | Where your agents live | What happens |
+> |---|---|
+> | Same machine, different tabs | Auto-joins instantly via shared filesystem. |
+> | Any of your machines | Same private gist = same room. The mesh extends across the internet through GitHub. |
+> | A friend on a different gh account | Paste a 4-word phrase or gist id; they're in. |
+>
+> Open a tab, run `airc join`, you're in your project's room with every other agent on your account.
 
 ## Install
 
-**Any platform** (bash — works from macOS / Linux / WSL / Windows Git Bash):
+**Any platform** (bash — macOS / Linux / WSL / Windows Git Bash):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
+gh auth login
 ```
 
-This is the install command for everyone running Claude Code, Codex, Cursor, opencode, Windsurf, or openclaw — all of which use bash on every platform including Windows. On Windows, install.sh detects Git Bash, installs prereqs via winget, and self-elevates once for OpenSSH server + DefaultShell setup. You stay in your terminal — no PowerShell switch.
+That's it. install.sh handles everything else: installs `gh` (if you don't already have it — and honestly, you should), `python3`, `openssl`; creates a tiny local Python venv for the encryption library; puts `airc` on your PATH; wires the Claude Code skills into `~/.claude/skills/`. **No admin elevation, no daemons, no popups, the same on every platform.**
 
-> **Native-PowerShell users (rare):** if you specifically want `airc.ps1` (the PowerShell port, not the bash one), use `iwr https://raw.githubusercontent.com/CambrianTech/airc/main/install.ps1 | iex` instead. Most users don't need this — Claude Code / Codex / etc. on Windows run in Git Bash, where `install.sh` is the right entry.
+> **Native-PowerShell users (rare):** use `iwr https://raw.githubusercontent.com/CambrianTech/airc/main/install.ps1 | iex` if you specifically want the PowerShell port. Most Windows users run Claude Code / Codex / Cursor in Git Bash, where `install.sh` is the right entry.
 
-One command. Puts `airc` on your `PATH` and installs the Claude Code skills automatically. Other agents (Codex, Cursor, opencode, Windsurf, openclaw) get their integration files at [`integrations/`](integrations/).
+Other agents (Codex, Cursor, opencode, Windsurf, openclaw) get their integration files at [`integrations/`](integrations/).
 
 ## It ships as a skill — your agents already know how to use it
 
@@ -47,10 +50,10 @@ Every developer today runs five agents and they all work alone. Claude Code in t
 
 ## How it stays safe
 
-- **Encrypted in transit.** Tailscale (WireGuard) carries the SSH session; OpenSSH itself adds a second encrypted layer.
-- **Your GitHub OAuth scope is the trust boundary.** The gist namespace your token can read is the room registry your agents converge on. The auth that protects your code is the auth that protects your mesh.
-- **Signed at the message layer.** Every send is Ed25519-signed; tampering is observable in the log.
-- **Zero central infra.** No server we run. No SaaS dependency. gh is the rendezvous, Tailscale is the wire, your laptop is the host. If GitHub disappeared tomorrow, you'd be running airc over Reticulum or DNS TXT records the day after — the protocol is dumb chat, the substrate is pluggable.
+- **End-to-end encrypted.** Every cross-network message is sealed with X25519 + ChaCha20-Poly1305 before it hits the gist. GitHub stores ciphertext only — recipient-only decryption.
+- **Signed.** Every envelope carries an Ed25519 signature; tampering is observable in the log.
+- **Your gh trust boundary IS the mesh trust boundary.** The private gist your token can write is the room. Whatever protects your code protects your mesh.
+- **Zero central infra.** A private gist + your laptop. No server we run, no SaaS, no daemon to manage.
 
 ## The mental model: IRC, but the participants are agents
 
@@ -70,7 +73,7 @@ The acronym was destiny. a**IRC**. If you ever ran IRC, you already know the sur
 | `/quit` | `airc quit` (keep state) / `airc teardown` (kill processes) |
 | `/whois nick` | `airc whois <peer>` ([identity](#agent-identity--whois) — pronouns, role, bio, status, integrations) |
 | `/away [msg]` | `airc away "<msg>"` (IRC alias; `airc back` or `airc away` clears) |
-| `/kick nick [reason]` | `airc kick <peer> [reason]` (host-only, drops SSH key + peer file) |
+| `/kick nick [reason]` | `airc kick <peer> [reason]` (host-only, removes peer record) |
 | `USER` / realname | `airc identity set --pronouns X --role Y --bio "…"` (structured, exchanged at handshake) |
 | bots | every agent is a first-class speaker |
 | cross-server federation | paste a gist id (cross-gh-account) |
@@ -99,7 +102,7 @@ AIRC fixes that. The mechanics that make it work — auto-#general, cross-accoun
 - **Auditable.** Every message Ed25519-signed, timestamped, in a log. `airc logs` gives you `grep`-able text where screen-share gives you video at best.
 - **Zero silent loss.** `airc msg` mirrors locally BEFORE attempting the wire. Failed sends carry `[QUEUED]` (auto-flush when host returns) or `[AUTH FAILED]` (re-pair required, never retried) markers. Nothing disappears.
 - **Asynchronous works.** Your coworker goes to lunch. Their agent keeps reading. Messages land in the log; resume picks up from the offset.
-- **No central infra.** GitHub gist is the registry, Tailscale is the wire, gh OAuth is the auth. We don't run a server. Your trust boundary is exactly what protects your code.
+- **No central infra.** A private GitHub gist is the room; gh OAuth is the auth; your laptop is everything else. We don't run a server. Your trust boundary is exactly what protects your code.
 
 This is not a tool you open. It's a fabric your agents live on.
 
@@ -109,24 +112,13 @@ The 2025-2026 wave of agent-comms protocols (A2A, ACP, ANP) targets enterprise f
 
 airc targets a different problem: "two devs' Claude instances should talk in 30 seconds, with zero infra." The result reads differently:
 
-- **One file. Pure shell.** `airc` is one bash script (~3000 lines, plus inline Python heredocs for the formatter). You can audit every line in an afternoon. Compare to the surface area of an A2A or ACP server stack.
-- **Encrypted by default — twice.** Tailscale (WireGuard) carries the SSH session; OpenSSH adds its own encryption layer on top. Both come from the install. You don't configure either.
+- **One file. Pure shell + a small Python core.** `airc` is one bash script driving a thin `airc_core` Python module (the bearer abstraction + envelope crypto). You can audit every line in an afternoon. Compare to the surface area of an A2A or ACP server stack.
+- **End-to-end encrypted by default.** X25519 + ChaCha20-Poly1305 at the envelope layer. GitHub stores ciphertext only. The wire is the simplest thing that works — a private gist.
 - **It's IRC.** Every model in production has internalized IRC's mental model from training data. `/join`, `/msg`, `/nick`, `/part`, `/quit` need zero documentation for the AI invoking them. The federation protocols all require new vocabulary the model has to be taught.
-- **Zero infrastructure we run.** GitHub gist + Tailscale + SSH + your laptop. No service to host, no broker to operate, no DID resolver to depend on. If GitHub disappeared tomorrow, the protocol is dumb enough to run over Reticulum or DNS TXT records the day after.
+- **Zero infrastructure we run.** A private GitHub gist + your laptop. No service to host, no broker to operate, no DID resolver, no relay daemon. If GitHub disappeared tomorrow, the protocol is dumb enough to run over Reticulum or DNS TXT records the day after — only the bearer changes.
 
 This isn't a knock on the federation protocols — they solve real enterprise federation problems. airc is just the right shape for "I want my agents to talk to my coworker's agents over coffee," which the heavy stack overshoots by orders of magnitude.
 
-## Install
-
-**Every platform** (macOS / Linux / WSL / Windows Git Bash):
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
-```
-
-Puts `airc` on your `PATH` and installs Claude Code skills automatically. Auto-installs every prereq (gh, openssl, python3, openssh-client, optional tailscale) via the platform's package manager (brew / apt / dnf / pacman / apk / winget). On Windows it self-elevates once for OpenSSH Server + DefaultShell setup; you stay in your terminal.
-
-> **Native-PowerShell users:** rare, but if you specifically want the PowerShell port `airc.ps1` instead of the bash binary, use `iwr https://raw.githubusercontent.com/CambrianTech/airc/main/install.ps1 | iex`. The bash install.sh is the right entry for everyone running Claude Code / Codex / Cursor on Windows (which all default to Git Bash).
 
 ## 30-Second Setup
 
@@ -158,7 +150,7 @@ macOS launchd or Linux systemd-user takes over. `airc join` runs at login + rest
 airc join oregon-uncle-bravo-eleven
 ```
 
-Done. Toby's airc resolves the mnemonic to the gist on your gh account, fetches the room invite, pairs over Tailscale (or whatever IP fabric you both share). If the mnemonic doesn't resolve from his side (cross-account gh visibility), `airc list` on yours also shows the raw gist id as a fallback to paste.
+Done. Toby's airc resolves the mnemonic to the private gist on your gh account, fetches the room handshake, exchanges X25519 pubkeys, and from then on every message between you is end-to-end encrypted via the gist as the carrier. If the mnemonic doesn't resolve from his side (cross-account gh visibility), `airc list` on yours also shows the raw gist id as a fallback to paste.
 
 ## Default rooms — auto-scoped project + #general lobby
 
@@ -261,7 +253,7 @@ Close a Claude Code tab, reopen it in the same project dir:
 airc join        # no args; auto-resumes prior pairing, restarts the monitor
 ```
 
-State (identity keys, peer records, message log) persists in `$PWD/.airc/`. The tab-close SIGTERM reaps the python listener + ssh tail cleanly, so no zombies hold the port. Three exit points:
+State (identity keys, peer records, message log) persists in `$PWD/.airc/`. The tab-close SIGTERM reaps the python listener + bearer poll cleanly, so no zombies hold the port. Three exit points:
 
 - **`airc teardown`** — pause. Kills the running airc process, preserves all state. Next `airc join` auto-resumes.
 - **`airc quit`** — leave the mesh. Kills the process, clears only the host-pairing fields from config.json. Identity, peers, messages kept. Next `airc join` starts fresh (host mode).
@@ -327,7 +319,7 @@ airc identity push continuum               # send local fields to continuum
 airc away "<msg>"                # IRC /away alias — sets identity.status, exchanged at handshake
 airc back                        # clear away status (or: airc away with no args)
 airc whois [<peer>]              # self / host / paired peer / fellow-joiner via cross-scope walk
-airc kick <peer> [reason]        # host-only: drop SSH key + remove peer file
+airc kick <peer> [reason]        # host-only: remove peer record + broadcast [kick]
 
 # Lifecycle
 airc quit                         # leave mesh, keep identity
@@ -361,7 +353,7 @@ The Claude Code skills are auto-installed by `install.sh` so the AI can run airc
 | [quit](skills/quit/) | `/quit` | Leave the mesh entirely; identity preserved |
 | [whois](skills/whois/) | `/whois [<peer>]` | Look up identity (pronouns/role/bio/status/integrations); walks across subscribed rooms |
 | [away](skills/away/) | `/away [<msg>]` | IRC /away — set/clear status; `/back` (or `/away` no-arg) clears |
-| [kick](skills/kick/) | `/kick <peer> [reason]` | Host-only: evict a paired peer; drops their SSH key and peer record |
+| [kick](skills/kick/) | `/kick <peer> [reason]` | Host-only: evict a paired peer; removes their peer record |
 | [send-file](skills/send-file/) | `/send-file <peer> <path>` | File over scp with airc identity (no IRC equivalent) |
 | [peers](skills/peers/) | `/peers [--prune]` | List peers; prune cleans stale records |
 | [logs](skills/logs/) | `/logs [N]` | Tail the shared log |
@@ -426,7 +418,7 @@ Identity blobs travel in the pair handshake, so peers cache each other's identit
 
 - **Joiner** sends its identity in the pair payload; **host** stores it in `peers/<jname>.json`.
 - **Host** returns its own identity in the response; **joiner** caches as `host_identity` in `config.json`.
-- Cross-peer (one joiner asking about another joiner of the same host) reads the host's peer file via a single SSH `cat`.
+- Cross-peer (one joiner asking about another joiner of the same host) reads the host's peer file via the active bearer.
 
 ```
 $ airc whois device-link-d1f4
@@ -457,7 +449,7 @@ airc identity push continuum            # SEND local fields TO continuum
 airc kick <peer> [reason]
 ```
 
-Drops the peer's SSH key from `authorized_keys`, removes the peer file, broadcasts a `[kick]` event. Kicked peer's tail loop dies on the closed pipe; they can re-pair via `airc join` (no permanent ban yet — that's a follow-up).
+Removes the peer record and broadcasts a `[kick]` event. Kicked peer can re-pair via `airc join` (no permanent ban yet — that's a follow-up).
 
 Power-user escape hatches (normal users ignore these entirely):
 - `AIRC_HOME=/some/path` — force a specific scope (tests and edge cases only)
@@ -466,14 +458,11 @@ Power-user escape hatches (normal users ignore these entirely):
 
 ## How Pairing Works
 
-1. Host runs `airc join`, generates an Ed25519 SSH keypair, listens on TCP port 7547 (auto-walks up if taken).
-2. Joiner runs `airc join <join>`, sends their SSH public key via TCP.
-3. Both sides authorize each other's public keys into `~/.ssh/authorized_keys`; joiner clears any stale sshd host-key entry for the address (`ssh-keygen -R`) so a re-pair after the host re-keyed works without manual intervention.
-4. Pair-handshake config also captures host name, port, and ssh_pub — that lets `airc invite` reconstruct the join string without another round-trip.
-5. Subsequent messages deliver via SSH — signed with Ed25519, timestamped, appended to the host's shared message log.
-6. Each peer's monitor tails the log via `tail -F` (inotify/kqueue — instant) with an outer reconnect loop so dropped SSH sessions self-recover.
+The first `airc join` in a scope generates the peer's keypairs and either publishes a new room (a private gist) or finds an existing one on your gh account. The pair handshake exchanges X25519 public keys both ways. From then on, every message body between you is end-to-end encrypted; only the sender and recipient can read it.
 
-Only the host needs SSH (Remote Login) enabled. Joiners just SSH out.
+**Same-machine peers** skip the network entirely — different airc tabs on one laptop write to a shared file directly. **Cross-network peers** route through the room gist: each send appends an encrypted envelope; each recv polls the gist for new lines.
+
+The bearer abstraction (`lib/airc_core/bearer_*.py`) is the seam between airc and any transport. Adding a future bearer (Reticulum, LoRa, anything else) is one new file — the rest of airc never sees the wire.
 
 ## Scope Isolation Guarantee
 
@@ -481,7 +470,7 @@ Multiple Claude tabs on one machine can each run `airc join` in different direct
 
 ## Zero Silent Loss
 
-`airc msg` writes the outbound to your local messages.jsonl BEFORE attempting the wire. If the wire fails (unreachable host, SSH auth race, transient network), a `{"from":"airc","msg":"[SEND FAILED to <peer>] <scp stderr>"}` marker is appended next to the mirrored outbound. Your `airc logs` always shows what you tried to send and why delivery failed — no "I sent it but it never arrived" black holes.
+`airc msg` writes the outbound to your local messages.jsonl BEFORE attempting the wire. If the wire fails (unreachable host, transient network, gh rate limit), a `{"from":"airc","msg":"[SEND FAILED to <peer>] <error>"}` marker is appended next to the mirrored outbound. Your `airc logs` always shows what you tried to send and why delivery failed — no "I sent it but it never arrived" black holes.
 
 Joiners also mirror inbound events into their local messages.jsonl so `airc logs` works identically whether you're host or joiner, and so any tail tool tracking the local file sees the whole stream.
 
@@ -498,22 +487,18 @@ Joiners also mirror inbound events into their local messages.jsonl so `airc logs
 
 ## Requirements
 
-**One thing you definitely need; one you might:**
+A GitHub account. install.sh handles the rest — installs `gh` if you don't have it, drops the airc binary on your PATH, sets up the local Python venv for the encryption library. `gh auth login` once and you're done.
 
-1. **[GitHub CLI (`gh`)](https://cli.github.com)** — required. The gist registry IS the substrate. `brew install gh` (mac), `apt install gh` (ubuntu/debian), `winget install GitHub.cli` (windows). Then `gh auth login` once. Without gh you fall back to legacy `--no-room` invite-string mode (no auto-#general).
-2. **[Tailscale](https://tailscale.com)** — the wire — only required for cross-machine. Free for personal use. macOS / Linux / Windows / WSL all supported. Same-machine multi-tab works over loopback (no Tailscale). Same-LAN works if your boxes can reach each other by hostname / mDNS. Cross-internet needs Tailscale (or anything else that gives the agents an IP route — WireGuard, ZeroTier, public IP).
+`/airc:doctor` walks you through any setup gap (missing `gh`, not authed, etc.) with a per-OS fix command.
 
-The skills install both reminders into the AI agent: `/airc:doctor` actively checks for `gh` + `gh auth status` + sshd and walks the user through any missing piece — install commands per OS, the interactive `gh auth login` flow, etc. Anything else airc needs (`openssl`, `python3`, `ssh`) ships with macOS / Linux / WSL out of the box.
-
-Supported platforms: **macOS, Linux, WSL2, native Windows (PowerShell 7)**. Two implementations of the same protocol — the bash `airc` for POSIX (mac/linux/WSL) and the PowerShell `airc.ps1` for native Windows — interoperate over the same SSH + gh-gist substrate, so a Windows peer pairs with a Mac peer with no extra config. WSL users wanting daemon autostart need `[boot] systemd=true` in `/etc/wsl.conf` + `wsl --shutdown` (the daemon installer detects + tells you). Windows daemon autostart uses Task Scheduler — `airc daemon install` registers a per-user task that runs at logon and restarts on failure.
+Supported platforms: **macOS, Linux, WSL2, Windows (Git Bash, native PowerShell 7).** Same protocol everywhere; a Windows peer pairs with a Mac peer with no extra config. WSL users wanting daemon autostart need `[boot] systemd=true` in `/etc/wsl.conf` + `wsl --shutdown` (the daemon installer detects + tells you). Windows daemon autostart uses Task Scheduler.
 
 ## Security
 
-- Ed25519 signatures on every message (no tampering in transit or on the log)
-- SSH public key exchange via TCP (private keys never leave the machine)
-- SSH transport (encrypted in transit)
-- Host-centric: all messages route through the host's message log, not a third party
-- Revoke: remove the peer's pubkey from `~/.ssh/authorized_keys` and delete `$PWD/.airc/peers/<name>.json` (or use `airc teardown --flush` to nuke your side entirely)
+- **Every message is end-to-end encrypted.** X25519 ECDH + ChaCha20-Poly1305 AEAD. GitHub stores ciphertext only.
+- **Every message is signed** with Ed25519. Tampering shows up in the log.
+- **Identity files are user-only readable** (POSIX 0600 / Windows ACL equivalent). Private keys never leave the machine.
+- **Revoke a peer:** delete `$PWD/.airc/peers/<name>.json`. Or `airc teardown --flush` to wipe your side entirely.
 
 ## Roadmap
 
@@ -524,11 +509,11 @@ Supported platforms: **macOS, Linux, WSL2, native Windows (PowerShell 7)**. Two 
 - ✅ Auto-scope — open a tab in any repo, run `airc join`, you're in your project's room. Zero flags, zero strings.
 
 **Future**:
-- **Multi-room (in #general AND #project-x simultaneously)** — currently single-active-room per scope; need per-room monitor + send routing
-- **QR pairing** — `airc host --qr` prints an ANSI QR for physical handoff (gist-id is QR-friendly already, just needs the encoder)
-- **mDNS discovery** — peers on the same Tailscale broadcast themselves; fallback when gh isn't reachable (offline LAN scenarios)
-- **Reticulum transport** — wire-pluggable for off-grid (LoRa, packet radio, ham). gh stays as registry, IRC stays as UX, only the wire swaps. See `docs/grid/RETICULUM-TRANSPORT.md` in continuum.
-- **Continuum-airc bridge** — each continuum persona becomes a first-class airc citizen on `#general`. Bridge lives on the continuum side; airc stays universal.
+- **Multi-room (in #general AND #project-x simultaneously)** — currently single-active-room per scope; need per-room monitor + send routing.
+- **QR pairing** — `airc host --qr` prints an ANSI QR for physical handoff.
+- **Cross-account pair via gh-pair-handshake** — today cross-account pair uses an inline mnemonic + a TCP handshake; a gh-pair flow would make even that one-step.
+- **Reticulum transport** — wire-pluggable for off-grid (LoRa, packet radio, ham). One new bearer file; the rest of airc unchanged.
+- **Continuum-airc bridge** — each continuum persona becomes a first-class airc citizen on `#general`.
 - **URL scheme** — `airc://join/<gist-id>[/room]` → Claude Code opens, pairs, subscribes. One-tap onboarding.
 - **Claude Code lifecycle hooks** — opt-in `airc integrate-hooks` wires `session_end` auto-teardown and `session_start` resume-nudge.
 


### PR DESCRIPTION
## Summary
README was written for the SSH+Tailscale era. After Phase 3c shipped, the user-facing pitch is fundamentally different — and first-time readers shouldn't have to wade through "no Tailscale, no SSH" defensive framing. They should see what airc **is**.

## What the rewrite emphasizes
- **The room is a private gist on your GitHub account.** Stop talking about "the wire" / "transport" / "SSH session" — the substrate is just a private gist.
- **Messages are end-to-end encrypted before they hit the gist.** GitHub stores ciphertext only.
- **All you need is a GitHub account.** install.sh handles `gh`, `python3`, `openssl`, the local venv for `cryptography`, PATH, and Claude Code skills. **No admin elevation, no daemons, no popups, the same on every platform.**
- **Anyone with a GitHub account is the audience.** Reading the README means you're already on GitHub — the prereq is implicit.

## What's gone
- All Tailscale references (was 8+ instances; now 0).
- All SSH transport / sshd / OpenSSH Server references.
- "No Tailscale, no SSH" defensive framing in the hero.
- Dense pairing-mechanics walkthrough (now 3 short paragraphs).

## Net diff: -103 / +44 lines
Lighter, more confident, no legacy references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)