### PR TITLE
fix(#285): host airc msg publishes to gist (silent-loss + TDD)

### DIFF
--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -355,12 +355,57 @@ cmd_send() {
       else
         echo "    pidfile:  absent (monitor never started in this scope)" >&2
       fi
-      echo "  Joiners ride on the monitor's SSH tail; with the monitor down, your message reaches no one." >&2
       echo "  Fix: run 'airc connect' to start (or resume) this scope's monitor, then retry." >&2
       echo "       OR cd into the scope you actually meant to send from." >&2
       die "monitor down — refusing to silently broadcast into a void"
     fi
+
+    # Local audit log — plaintext, the user's own record of what they sent.
     echo "$full_msg" >> "$MESSAGES"
+
+    # Phase 3c critical fix (#285): host-side cmd_send must ALSO publish
+    # to the room gist so joiners (who poll the gist via GhBearer) see
+    # broadcasts and DMs from the host. Pre-3c, joiners tailed the host's
+    # local messages.jsonl over SSH; with SSH gone, joiners poll the gist
+    # — local-only append disappears into a void. Worst silent-loss
+    # class until this fix landed.
+    #
+    # Same wrap-if-recipient-known logic as the joiner branch above:
+    # encrypt msg field with recipient's X25519 pub when it's a DM and
+    # we have their pubkey on file; broadcasts go plaintext (group
+    # encryption is a future Phase E.4).
+    local _host_recipient_pub=""
+    if [ "$peer_name" != "all" ]; then
+      _host_recipient_pub=$("$AIRC_PYTHON" -m airc_core.identity peer_pub \
+        --peers-dir "$PEERS_DIR" --peer-name "$peer_name" 2>/dev/null || true)
+    fi
+    local _host_wire_msg="$full_msg"
+    if [ -n "$_host_recipient_pub" ]; then
+      _host_wire_msg=$(printf '%s' "$full_msg" | "$AIRC_PYTHON" -m airc_core.envelope wrap \
+        --recipient-pub "$_host_recipient_pub" \
+        --identity-dir "$IDENTITY_DIR" || printf '%s' "$full_msg")
+    fi
+
+    local _host_room_gist_id=""
+    [ -f "$AIRC_WRITE_DIR/room_gist_id" ] && _host_room_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
+
+    if [ -n "$_host_room_gist_id" ]; then
+      local _host_outcome
+      _host_outcome=$(printf '%s' "$_host_wire_msg" | "$AIRC_PYTHON" -m airc_core.bearer_cli send \
+        "$peer_name" "$active_channel" \
+        --room-gist-id "$_host_room_gist_id")
+      local _host_kind
+      _host_kind=$(printf '%s' "$_host_outcome" | "$AIRC_PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("kind",""))' 2>/dev/null)
+      case "$_host_kind" in
+        delivered) : ;;
+        *)
+          echo "  ⚠ Gist publish failed (kind=${_host_kind:-empty}); broadcast did not reach joiners." >&2
+          echo "    Local audit log has the message; joiners polling the gist see nothing." >&2
+          ;;
+      esac
+    else
+      echo "  ⚠ No room_gist_id set ($AIRC_WRITE_DIR/room_gist_id missing) — host send is local-only." >&2
+    fi
   fi
 
   # Reset reminder — you sent something, clock restarts

--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -137,10 +137,19 @@ def _read_messages_content(gist_data: dict) -> str:
 
 
 def _gh_gist_write_file(gist_id: str, content: str) -> tuple[bool, str]:
-    """Write `content` as the messages.jsonl file in `gist_id` via
-    `gh gist edit`. Returns (ok, detail). Creates the file if absent
-    (gh gist edit -a) or replaces if present (default behavior with
-    matching basename).
+    """Write `content` as the messages.jsonl file in `gist_id`.
+
+    Critical detail caught in production (#285): `gh gist edit GIST_ID
+    file` (no flag) returns exit 0 BUT silently no-ops when the target
+    filename doesn't already exist in the gist. Bug surface: bearer
+    reports 'delivered', gh CLI reports success, gist is unchanged.
+
+    Fix: read the gist's file list FIRST, then choose the correct
+    subcommand:
+      - file already in gist  → `gh gist edit GIST file`        (replace)
+      - file NOT in gist      → `gh gist edit GIST -a file`     (add)
+    The flag is required for new files. Trying plain edit first
+    silently succeeds without writing — that's the trap.
 
     gh gist edit uses the local file's basename as the in-gist filename.
     We write to a temp file literally named messages.jsonl in a unique
@@ -149,43 +158,51 @@ def _gh_gist_write_file(gist_id: str, content: str) -> tuple[bool, str]:
         gh = _resolve_gh_bin()
     except GhBearerError as e:
         return (False, str(e))
+
+    # Detect whether messages.jsonl exists in the gist BEFORE choosing
+    # subcommand. Single extra GET, but eliminates the silent-no-op
+    # trap. If the GET fails, default to -a (add) since that path
+    # surfaces real errors when the file already exists (gh complains
+    # about duplicate filename), whereas plain edit silently no-ops.
+    existing = _gh_api_get(gist_id)
+    file_exists_in_gist = (
+        existing is not None
+        and isinstance(existing.get("files"), dict)
+        and _MESSAGES_FILE in existing["files"]
+    )
+
     tmpdir = tempfile.mkdtemp(prefix="airc-ghbearer-")
     try:
         path = os.path.join(tmpdir, _MESSAGES_FILE)
         with open(path, "w") as f:
             f.write(content)
-        # `gh gist edit` updates an existing file by name; the -a flag
-        # adds a NEW file. We need both behaviors to converge. Strategy:
-        # try -a first; if the file already exists gh exits non-zero
-        # with a recognizable message; fall back to plain edit (replace).
-        # Simpler in practice: just try plain edit; gh creates the file
-        # if absent in newer releases, and if not, we retry with -a.
+        if file_exists_in_gist:
+            argv = [gh, "gist", "edit", gist_id, path]          # replace
+        else:
+            argv = [gh, "gist", "edit", gist_id, "-a", path]    # add new
         try:
             r = subprocess.run(
-                [gh, "gist", "edit", gist_id, path],
-                capture_output=True,
-                text=True,
-                timeout=_GH_API_TIMEOUT,
+                argv, capture_output=True, text=True, timeout=_GH_API_TIMEOUT,
             )
         except (subprocess.TimeoutExpired, OSError) as e:
             return (False, f"gh gist edit failed: {e}")
         if r.returncode == 0:
             return (True, "")
-        # Fallback: try with -a (add file). If THAT fails too, return
-        # the more informative error.
+        # Defense: if our existence check disagreed with reality (race —
+        # another peer added the file between our GET and our edit),
+        # try the OTHER subcommand once before giving up.
+        alt_argv = (
+            [gh, "gist", "edit", gist_id, path] if not file_exists_in_gist
+            else [gh, "gist", "edit", gist_id, "-a", path]
+        )
         try:
             r2 = subprocess.run(
-                [gh, "gist", "edit", gist_id, "-a", path],
-                capture_output=True,
-                text=True,
-                timeout=_GH_API_TIMEOUT,
+                alt_argv, capture_output=True, text=True, timeout=_GH_API_TIMEOUT,
             )
         except (subprocess.TimeoutExpired, OSError) as e:
-            return (False, f"gh gist edit -a failed: {e}")
+            return (False, f"gh gist edit retry failed: {e}")
         if r2.returncode == 0:
             return (True, "")
-        # Both failed — surface the FIRST error (the one caller saw
-        # via the natural-first-attempt path).
         err = (r.stderr or r.stdout or "gh gist edit failed").strip()
         return (False, err)
     finally:

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2721,6 +2721,171 @@ sys.exit(1)
   cleanup_all
 }
 
+scenario_gh_send_creates_messages_jsonl() {
+  # TDD test for the "host broadcast disappears" bug Joel hit during the
+  # post-3c QA pass. Repro shape:
+  #   1. A gist exists with a non-messages.jsonl file (e.g. airc-invite
+  #      seed — what `airc join` actually creates as the room gist's
+  #      first file).
+  #   2. GhBearer.send is invoked to publish a message.
+  #   3. The send must CREATE messages.jsonl in the gist (the file
+  #      doesn't exist yet — first ever send to this room).
+  #   4. The gist after the send must contain messages.jsonl with the
+  #      sent envelope.
+  #
+  # The pre-fix bug: `gh gist edit GIST_ID file` (no -a flag) returns
+  # exit 0 but silently does nothing when the target file doesn't already
+  # exist in the gist. GhBearer's _gh_gist_write_file tried that first,
+  # got a false-success returncode 0, never invoked the -a fallback.
+  # Net: gh CLI no-op + GhBearer reports "delivered" + nothing on the
+  # wire. Worst silent-loss class.
+  #
+  # scenario_bearer_gh masked this bug because IT seeds the gist with
+  # messages.jsonl already present, so the first send is a replace, not
+  # a create. Production (`airc join`) seeds with airc-invite — first
+  # send is a create. The seed shape was the difference.
+  section "gh send creates messages.jsonl (first-send-to-empty-room) — TDD for #285"
+
+  if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
+    echo "  (skipped — gh not authed)"
+    return
+  fi
+
+  cleanup_all
+  local _lib_dir; _lib_dir="$(cd "$(dirname "$AIRC")/lib" && pwd)"
+
+  # Seed the gist the way `airc join` actually does: a file named like
+  # airc-invite.* (NOT messages.jsonl). The first send must add
+  # messages.jsonl as a new file.
+  local seed; seed=$(mktemp -d -t airc-it-tdd-seed.XXXXXX)
+  printf '# room invite seed (placeholder)\n' > "$seed/airc-invite.placeholder"
+  local gist_url; gist_url=$(gh gist create -d "airc TDD: first-send-to-empty-room (#285)" "$seed/airc-invite.placeholder" 2>&1 | tail -1)
+  local gist_id; gist_id=$(printf '%s' "$gist_url" | awk -F/ '{print $NF}')
+  rm -rf "$seed"
+
+  if [ -z "$gist_id" ] || ! printf '%s' "$gist_id" | grep -qE '^[a-f0-9]+$'; then
+    fail "could not create test gist (got: $gist_url)"
+    return
+  fi
+  pass "test gist created with airc-invite seed: $gist_id"
+
+  # Verify the seed-only state (no messages.jsonl yet).
+  local pre_files; pre_files=$(gh api "gists/$gist_id" --jq '.files | keys | join(",")' 2>/dev/null)
+  if printf '%s' "$pre_files" | grep -q 'messages.jsonl'; then
+    fail "test setup wrong: gist already has messages.jsonl (expected only airc-invite seed)"
+    gh gist delete "$gist_id" --yes 2>/dev/null || true
+    return
+  fi
+  pass "pre-send: gist has only airc-invite seed (no messages.jsonl)"
+
+  trap "gh gist delete '$gist_id' --yes 2>/dev/null || true" EXIT
+
+  # Run GhBearer.send via bearer_cli (the same path airc msg uses).
+  local marker="tdd-first-send-marker-$(date +%s%N)"
+  local probe='{"from":"alpha","to":"all","ts":"2026-04-29T00:00:00Z","channel":"general","msg":"'"$marker"'","sig":"x"}'
+  local outcome
+  outcome=$(printf '%s' "$probe" | PYTHONPATH="$_lib_dir" python3 -m airc_core.bearer_cli send all general --room-gist-id "$gist_id" 2>&1)
+  local kind; kind=$(printf '%s' "$outcome" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("kind",""))' 2>/dev/null)
+
+  if [ "$kind" = "delivered" ]; then
+    pass "bearer_cli send returned 'delivered'"
+  else
+    fail "bearer_cli send did NOT return 'delivered' (got: $outcome)"
+    trap - EXIT
+    gh gist delete "$gist_id" --yes 2>/dev/null || true
+    cleanup_all
+    return
+  fi
+
+  # The critical assertion: gist must NOW have messages.jsonl with the marker.
+  # Pre-fix this fails: gh gist edit silently no-ops, gist still has only
+  # airc-invite, send returned delivered with NO actual delivery.
+  local post_files; post_files=$(gh api "gists/$gist_id" --jq '.files | keys | join(",")' 2>/dev/null)
+  if printf '%s' "$post_files" | grep -q 'messages.jsonl'; then
+    pass "post-send: gist now has messages.jsonl (file was created)"
+  else
+    fail "POST-SEND BUG: gist still has only [$post_files] — messages.jsonl was NOT created. bearer_cli reported delivered but gh gist edit silently no-op'd."
+  fi
+
+  # Verify the message body actually landed.
+  local content; content=$(gh api "gists/$gist_id" --jq '.files["messages.jsonl"].content // ""' 2>/dev/null)
+  if printf '%s' "$content" | grep -q "$marker"; then
+    pass "post-send: gist messages.jsonl contains the marker"
+  else
+    fail "post-send: gist messages.jsonl missing marker (content len: ${#content})"
+  fi
+
+  trap - EXIT
+  gh gist delete "$gist_id" --yes 2>/dev/null || true
+  cleanup_all
+}
+
+scenario_host_msg_publishes_to_gist() {
+  # End-to-end: full `airc msg` from a host actually publishes to the
+  # room gist. The TDD scenario above (gh_send_creates_messages_jsonl)
+  # tests the bearer in isolation; THIS one tests the cmd_send → bearer
+  # path, catching breaks where cmd_send doesn't even invoke the bearer
+  # (the original #285 hole — host's else-branch was a local-only
+  # append, never called bearer_cli).
+  section "host: airc msg publishes to room gist (#285 cmd_send→bearer chain)"
+
+  if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
+    echo "  (skipped — gh not authed)"
+    return
+  fi
+
+  cleanup_all
+
+  # Spawn a host with a real gh room (NO --no-room / --no-gist — that's
+  # what masked the bug; tests must exercise the production path).
+  local rname="tdd-host-publishes-$$"
+  mkdir -p /tmp/airc-it-tdd-h /tmp/airc-it-tdd-h/state
+  ( cd /tmp/airc-it-tdd-h && AIRC_HOME=/tmp/airc-it-tdd-h/state AIRC_NAME=tdd-host AIRC_PORT=7556 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --room "$rname" > /tmp/airc-it-tdd-h/out.log 2>&1 & )
+  local i
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    sleep 1
+    [ -f /tmp/airc-it-tdd-h/state/room_gist_id ] && break
+  done
+
+  local gid; gid=$(cat /tmp/airc-it-tdd-h/state/room_gist_id 2>/dev/null)
+  if [ -z "$gid" ]; then
+    fail "host did not publish room gist (room_gist_id absent)"
+    cleanup_all; return
+  fi
+  pass "host published room gist: $gid"
+
+  trap "gh gist delete '$gid' --yes 2>/dev/null || true" EXIT
+
+  # Pre-flight: gist initially has only the airc-invite seed (NOT
+  # messages.jsonl). This is the production state where the bug lived.
+  local pre_files; pre_files=$(gh api "gists/$gid" --jq '.files | keys | join(",")' 2>/dev/null)
+  if printf '%s' "$pre_files" | grep -q messages.jsonl; then
+    info "pre-send: gist already has messages.jsonl (host bootstrap created it; bug less likely to trip)"
+  fi
+
+  # Run airc msg from the host scope, broadcasting a unique marker.
+  local marker="tdd-host-publish-marker-$(date +%s%N)"
+  AIRC_HOME=/tmp/airc-it-tdd-h/state "$AIRC" msg "$marker" >/dev/null 2>&1 || true
+
+  # Give gh's eventual-consistency a moment.
+  sleep 2
+
+  # The critical assertion: gist's messages.jsonl now contains the marker.
+  local content; content=$(gh api "gists/$gid" --jq '.files["messages.jsonl"].content // ""' 2>/dev/null)
+  if printf '%s' "$content" | grep -q "$marker"; then
+    pass "host's airc msg broadcast landed in gist's messages.jsonl"
+  else
+    local post_files; post_files=$(gh api "gists/$gid" --jq '.files | keys | join(",")' 2>/dev/null)
+    fail "POST-SEND BUG: marker NOT in gist. files: [$post_files]; content len: ${#content}. cmd_send → bearer chain is broken (#285 regression)."
+  fi
+
+  trap - EXIT
+  gh gist delete "$gid" --yes 2>/dev/null || true
+  cleanup_all
+}
+
 scenario_bearer_local() {
   # Phase 3a: LocalBearer serves same-machine peers via direct
   # filesystem reads/writes — no SSH, no subprocess. This scenario
@@ -3246,6 +3411,8 @@ case "$MODE" in
   e2e_encryption) scenario_e2e_encryption ;;
   bearer_local) scenario_bearer_local ;;
   bearer_gh) scenario_bearer_gh ;;
+  gh_send_creates_messages_jsonl) scenario_gh_send_creates_messages_jsonl ;;
+  host_msg_publishes_to_gist) scenario_host_msg_publishes_to_gist ;;
   ""|all)
     # Default = run everything. The peers_cross_scope + whois_cross_scope
     # scenarios were removed in PR #239 (sidecar walk semantics deleted


### PR DESCRIPTION
## Summary
Closes #285. Two compounding bugs caused host \`airc msg\` to silently lose every broadcast and DM:
1. **\`cmd_send.sh\` host path was local-append-only** — relic of pre-3c when SSH bearer's tail-F was the wire. After Phase 3c moved joiners to GhBearer polling the gist, a local-only host append disappeared.
2. **\`gh gist edit GIST file\` silent no-op** — when the target file doesn't exist in the gist, gh CLI returns exit 0 but writes nothing. Production gists start with an airc-invite seed (NO messages.jsonl), so EVERY first host send hit the trap.

## TDD
- \`scenario_gh_send_creates_messages_jsonl\` — bearer-level: seed gist with airc-invite (matching production), invoke bearer_cli send, assert messages.jsonl appears with the marker.
- \`scenario_host_msg_publishes_to_gist\` — end-to-end: real \`airc connect --room\`, real \`airc msg\`, assert gist content updated.

Both scenarios fail on canary tip (12fa1fc) and pass after this fix.

## Why existing 123 integration tests didn't catch this
- Most scenarios use \`--no-room --no-gist\` for speed → bypass gh entirely → test rig still exercises the pre-3c TCP-pair path.
- \`scenario_bearer_gh\` uses real gh BUT pre-seeds the gist with messages.jsonl. Production starts with airc-invite seed → first send is a CREATE → silent-no-op trap.

The seed shape was the difference. New scenarios use production-shaped seeds.

## Files
- \`lib/airc_bash/cmd_send.sh\` — host path now also calls bearer_cli send with --room-gist-id
- \`lib/airc_core/bearer_gh.py\` — \`_gh_gist_write_file\` reads the gist file list first, chooses correct subcommand (-a for add, plain edit for replace)
- \`test/integration.sh\` — two new TDD scenarios

## Not covered (separate issues)
- #283 sidecar spawn — TDD + fix in next PR
- #284 cross-room DM silent success — TDD + fix in next PR

Both will follow the same TDD-first pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)