### PR TITLE
fix(#283): per-channel gist + multi-channel monitor (rooms work for real)

### DIFF
--- a/airc
+++ b/airc
@@ -773,31 +773,49 @@ _clear_parted_room()  { [ -f "$1/config.json" ] && "$AIRC_PYTHON" -m airc_core.c
 # cmd_teardown's process-tree walker reaps it. cmd_teardown also has
 # explicit sidecar-scope cleanup (gist + sidecar's own pidfile).
 spawn_general_sidecar_if_wanted() {
-  # Phase 2B.3: the sidecar process is GONE. With Phase 1's mesh-singleton
-  # substrate (one gist + one host per gh account), a separate `airc
-  # connect` process for #general would discover the same mesh and yield
-  # to the same host — pure overhead. Instead we just add "general" to
-  # this scope's subscribed_channels list. cmd_send default-channel logic
-  # (Phase 2B.1) and the monitor formatter's per-envelope channel display
-  # (Phase 2A) handle the rest in one process.
+  # Subscribe this scope to #general by:
+  #   1. Adding "general" to subscribed_channels in primary config
+  #   2. Finding-or-creating the canonical #general gist on the gh
+  #      account, persisting its id under channel_gists.general so the
+  #      monitor (multi-gist poll) and cmd_send (route-by-channel) can
+  #      reach it.
   #
-  # The function name + callsites stay so cmd_connect's flow doesn't
-  # need rewiring; only the body changed.
+  # ONE monitor process per scope — it polls ALL subscribed channels'
+  # gists. No separate sidecar process. Per Joel 2026-04-29: "you can
+  # still have one monitor doesn't need to load one for every room,
+  # just always itself monitor each room."
   [ "$general_sidecar" = "1" ] || return 0
   [ "$room_name" = "general" ] && return 0
   [ "$use_room" = "1" ] || return 0
 
   # Honor a prior /part: if "general" is in parted_rooms, don't
-  # auto-resubscribe. Override with `airc join --general` (which
-  # already calls _clear_parted_room) or by editing config.json.
+  # auto-resubscribe. Override with `airc join --general`.
   if _read_parted_rooms "$AIRC_WRITE_DIR" | grep -Fxq "general"; then
     echo "  #general subscription skipped — previously parted (airc join --general to rejoin)."
     return 0
   fi
 
   echo "  Also subscribing to #general (--no-general to opt out)"
+
+  # 1. Subscribe in config.
   "$AIRC_PYTHON" -m airc_core.config subscribe \
     --config "$CONFIG" --channel general 2>/dev/null || true
+
+  # 2. Resolve the canonical #general gist on this gh account
+  #    (find existing or create new). Reuses the same find-or-create
+  #    discovery that the primary room bootstrap goes through.
+  local _general_gid
+  _general_gid=$("$AIRC_PYTHON" -m airc_core.channel_gist resolve \
+    --channel general --create-if-missing 2>/dev/null || true)
+
+  if [ -n "$_general_gid" ]; then
+    # 3. Persist channel→gist mapping so cmd_send + monitor can route.
+    "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
+      --config "$CONFIG" --channel general --gist-id "$_general_gid" 2>/dev/null || true
+    echo "    #general gist: $_general_gid"
+  else
+    echo "  ⚠ Could not resolve #general gist (no gh auth?). #general subscription is config-only; cross-room messaging won't work until resolved." >&2
+  fi
 }
 
 # Resolve this session's peer name.
@@ -844,28 +862,97 @@ init_identity() {
   touch "$MESSAGES"
 }
 
-monitor() {
-  local my_name host_target room_gist_id
-  my_name=$(get_name)
-  host_target=$(get_config_val host_target "")
-  room_gist_id=""
-  [ -f "$AIRC_WRITE_DIR/room_gist_id" ] && room_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
+_monitor_multi_channel() {
+  # Poll N channels' gists in parallel; merge events into one
+  # monitor_formatter pipe. Each channel has its own offset file +
+  # bearer_state file so resume + observability are per-channel.
+  #
+  # PIPE_BUF safety: each bearer_cli recv emits one JSONL line per
+  # event, well under POSIX's 4KB atomic-write threshold; concurrent
+  # writes to the parent's stdout interleave at line boundaries.
+  #
+  # Args: my_name, TAB-separated "channel<TAB>gist_id" lines (one per
+  # subscribed channel, from airc_core.config list_channel_gists).
+  local my_name="$1"
+  local channel_map="$2"
 
-  # Background reminder timer + pending-flush loops (unchanged from
-  # pre-Phase-3c). Trap and parent-PID handling are owned by cmd_connect.
+  local consecutive_timeouts=0
+  local ESCALATE_AFTER=4
+  while true; do
+    {
+      while IFS=$'\t' read -r ch gid; do
+        [ -z "$ch" ] && continue
+        [ -z "$gid" ] && continue
+        # Fire-and-forget: each bearer_cli recv runs as a child of this
+        # subshell; `wait` (after the loop) holds the subshell open
+        # until all of them exit, which they only do on close (broken
+        # pipe / SIGTERM). When the formatter on the other side of the
+        # pipe exits (e.g. watchdog 2), the broken pipe terminates the
+        # bearer_cli children, the wait completes, the subshell exits,
+        # the surrounding while-loop reconnects.
+        "$AIRC_PYTHON" -u -m airc_core.bearer_cli recv "self" \
+          --room-gist-id "$gid" \
+          --offset-file "$AIRC_WRITE_DIR/monitor_offset.${ch}" \
+          --state-file "$AIRC_WRITE_DIR/bearer_state.${ch}.json" \
+          2>/dev/null &
+      done <<< "$channel_map"
+      wait
+    } | monitor_formatter "$my_name" || true
+    local fmt_exit="${PIPESTATUS[1]:-0}"
+
+    if [ "$fmt_exit" = "2" ]; then
+      echo "airc: watchdog tripped — restarting multi-channel poll" >&2
+      consecutive_timeouts=$((consecutive_timeouts + 1))
+    else
+      consecutive_timeouts=0
+    fi
+    if [ "$consecutive_timeouts" -ge "$ESCALATE_AFTER" ]; then
+      local _daemon_present=0
+      if _daemon_installed >/dev/null 2>&1; then _daemon_present=1; fi
+      echo ""
+      if [ "$_daemon_present" = "1" ]; then
+        echo "airc: mesh disconnected ($consecutive_timeouts cycles); daemon restart will self-heal"
+      else
+        echo "airc: mesh disconnected ($consecutive_timeouts cycles); NO DAEMON installed, restart with: airc join"
+        echo "airc:   (for auto-recovery: airc daemon install)"
+      fi
+      exit 99
+    fi
+    sleep 3
+  done
+}
+
+monitor() {
+  local my_name; my_name=$(get_name)
+
+  # Background reminder timer + pending-flush loops.
   ( reminder_timer_loop ) &
   ( flush_pending_loop ) &
+
+  # Resolution priority:
+  #   1. channel_gists map non-empty → multi-channel mode (post-#283:
+  #      one monitor polls all subscribed channels' gists in parallel)
+  #   2. legacy room_gist_id only → single-gist mode (older scopes
+  #      that haven't been re-bootstrapped to populate channel_gists)
+  #   3. neither → local-tail mode (standalone tests, --no-room --no-gist)
+  local channel_map
+  channel_map=$("$AIRC_PYTHON" -m airc_core.config list_channel_gists \
+    --config "$CONFIG" 2>/dev/null || true)
+
+  if [ -n "$channel_map" ]; then
+    _monitor_multi_channel "$my_name" "$channel_map"
+    return
+  fi
+
+  local room_gist_id=""
+  [ -f "$AIRC_WRITE_DIR/room_gist_id" ] && room_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
 
   local offset_file="$AIRC_WRITE_DIR/monitor_offset"
 
   if [ -n "$room_gist_id" ]; then
-    # Phase 3c: gh-bearer mode. Poll the shared room gist for inbound
-    # messages. The bearer (lib/airc_core/bearer_gh.py) handles polling
-    # cadence (15s default), rate-limit recovery, and offset resume.
-    # This loop owns watchdog/escalation (formatter exit 2 = no inbound
-    # for WATCHDOG_SEC).
+    # Single-gist mode (legacy fallback).
     local consecutive_timeouts=0
-    local ESCALATE_AFTER=4   # ~10min total dead-room detection (4 × 150s)
+    local ESCALATE_AFTER=4
     while true; do
       "$AIRC_PYTHON" -u -m airc_core.bearer_cli recv "self" \
         --room-gist-id "$room_gist_id" \

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1001,6 +1001,12 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
     # (issue #83). Cleared by cmd_part on graceful leave.
     if [ -n "$_resolved_gist_id" ]; then
       echo "$_resolved_gist_id" > "$AIRC_WRITE_DIR/room_gist_id"
+      # #283: also map this channel→gist in channel_gists so the
+      # multi-channel monitor polls it and cmd_send routes by channel.
+      if [ -n "$resolved_room_name" ]; then
+        "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
+          --config "$CONFIG" --channel "$resolved_room_name" --gist-id "$_resolved_gist_id" 2>/dev/null || true
+      fi
     fi
 
     # Persist host details in own config so `airc invite` can reconstruct
@@ -1249,6 +1255,11 @@ JSON
           if [ "$_gist_kind" = "mesh" ] || [ "$_gist_kind" = "room" ]; then
             echo "$_gist_id" > "$AIRC_WRITE_DIR/room_gist_id"
             echo "$room_name" > "$AIRC_WRITE_DIR/room_name"
+            # #283: also map this channel→gist in channel_gists so
+            # the multi-channel monitor polls it and cmd_send routes
+            # by channel.
+            "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
+              --config "$CONFIG" --channel "$room_name" --gist-id "$_gist_id" 2>/dev/null || true
 
             # Heartbeat loop: keep last_heartbeat fresh in the gist so
             # joiners can deterministically detect a dead host. Without

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -237,11 +237,16 @@ cmd_send() {
     #   4. Branches on the structured SendOutcome.kind
     # Adding a new transport doesn't touch this file — only the
     # resolver registers it. (Phases 1-3 of bearer rewrite; #269 #270.)
-    # Phase 3c: pass room_gist_id so GhBearer can serve cross-machine peers.
-    # LocalBearer.can_serve still wins for loopback host_target + writable
-    # remote_home (same-machine 2-tab case). SshBearer is gone.
+    # Phase 3c+ (#283): route by channel. The active_channel's gist
+    # comes from channel_gists in config (populated at subscribe time).
+    # If the channel has no mapping, fall back to the scope's primary
+    # room_gist_id so single-room scopes keep working unchanged.
     local room_gist_id=""
-    [ -f "$AIRC_WRITE_DIR/room_gist_id" ] && room_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
+    room_gist_id=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
+      --config "$CONFIG" --channel "$active_channel" 2>/dev/null || true)
+    if [ -z "$room_gist_id" ] && [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
+      room_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
+    fi
 
     local outcome
     outcome=$(printf '%s' "$wire_msg" | "$AIRC_PYTHON" -m airc_core.bearer_cli send \
@@ -386,8 +391,14 @@ cmd_send() {
         --identity-dir "$IDENTITY_DIR" || printf '%s' "$full_msg")
     fi
 
+    # Route by channel via channel_gists (post-#283); fall back to the
+    # scope's primary room_gist_id so single-room hosts keep working.
     local _host_room_gist_id=""
-    [ -f "$AIRC_WRITE_DIR/room_gist_id" ] && _host_room_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
+    _host_room_gist_id=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
+      --config "$CONFIG" --channel "$active_channel" 2>/dev/null || true)
+    if [ -z "$_host_room_gist_id" ] && [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
+      _host_room_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
+    fi
 
     if [ -n "$_host_room_gist_id" ]; then
       local _host_outcome

--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -1,0 +1,298 @@
+"""channel_gist — find-or-create the canonical gist for a channel name on
+the user's gh account.
+
+Single concern: given a channel name (e.g. "general", "useideem",
+"continuum"), return the gist id that hosts that channel for THIS gh
+account. If no such gist exists and create_if_missing=True, publish a
+new mesh-shaped gist and return its id.
+
+This is the ONE place in the codebase that knows "channel name → gist
+id" lookup. cmd_connect uses it to bootstrap each subscribed channel;
+cmd_send uses it via airc_core.config to route by channel.
+
+Architecture (per Joel 2026-04-29): one gist per channel name per gh
+account. ALL of my tabs/machines that subscribe to #general read+write
+the same #general gist. Closing/opening tabs is benign — the gist
+persists. New peers joining a channel just discover the existing gist.
+
+Why a separate module rather than a function in cmd_rooms.sh: cmd_rooms
+already enumerates gh gists for the `airc list` UI surface, but its
+parse logic is wired into bash heredocs and shaped for human display
+(mnemonic, descriptions, kind tags). Extracting that for the
+machine-driven find-or-create here means a fresh, focused module
+instead of bash-flavored gymnastics. Same-shape concern as bearer_*:
+small, single-purpose, callable from both python and bash via a CLI
+seam.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Optional
+
+
+_GH_BIN = "gh"
+_GH_API_TIMEOUT = 10.0
+_GIST_LIST_LIMIT = 100   # `airc list` uses 50; we go a bit higher to be safe
+
+
+def _resolve_gh_bin() -> Optional[str]:
+    """Return path to gh CLI, or None if absent. Caller-visible None
+    means we can't do gh-side resolution at all — return early."""
+    return shutil.which(_GH_BIN)
+
+
+def _gh_list_user_gists() -> list[dict]:
+    """List ALL of the authenticated user's gists, returning parsed
+    JSON. Empty list on any failure (no gh auth, network blip, etc).
+
+    Uses `gh api gists` (with pagination) rather than `gh gist list`
+    because the JSON shape is stable + complete. gh gist list output
+    is human-shaped (tab-delimited) and shifts across versions.
+    """
+    gh = _resolve_gh_bin()
+    if gh is None:
+        return []
+    try:
+        r = subprocess.run(
+            [gh, "api", f"gists?per_page={_GIST_LIST_LIMIT}", "--paginate"],
+            capture_output=True,
+            text=True,
+            timeout=_GH_API_TIMEOUT * 3,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    if r.returncode != 0:
+        return []
+    out: list[dict] = []
+    # `--paginate` concatenates JSON arrays inline. Split on `][` to
+    # rejoin pages without depending on gh's exact output shape.
+    raw = r.stdout.strip()
+    if not raw:
+        return []
+    chunks = raw.replace("][", "],[")
+    if chunks.startswith("["):
+        chunks = chunks
+    try:
+        # Try direct parse first (single-page or already-merged).
+        loaded = json.loads(raw)
+        if isinstance(loaded, list):
+            return loaded
+    except (ValueError, TypeError):
+        pass
+    # Fallback: split into separate JSON arrays and merge.
+    try:
+        joined = "[" + chunks.lstrip("[").rstrip("]") + "]"
+        loaded = json.loads(joined)
+        if isinstance(loaded, list):
+            return loaded
+    except (ValueError, TypeError):
+        pass
+    return out
+
+
+def _gist_describes_channel(gist: dict, channel: str) -> bool:
+    """Decide whether a gist envelope is THIS channel's room gist.
+
+    A gist is the channel's room iff:
+      1. Its description starts with airc's room marker "airc mesh" or
+         "airc room:"
+      2. AND its messages.jsonl-style content (or the legacy room
+         envelope) lists this channel.
+
+    We tolerate two shapes:
+      - kind:"mesh"   with channels:["general", ...]   (Phase 2B+)
+      - kind:"room"   with channels:["general", ...]   (legacy)
+
+    The description field alone isn't enough — gh users may have
+    unrelated gists named "airc test" etc. The envelope JSON is the
+    authoritative signal.
+    """
+    desc = (gist.get("description") or "").strip()
+    if not desc:
+        return False
+    # Cheap pre-filter so we don't fetch+parse every gist on the account.
+    if not (desc.startswith("airc mesh") or desc.startswith("airc room:")):
+        return False
+    # Examine the gist's first file content (gist.files is a dict; pick
+    # any value's "content" field — short ones are inlined in the
+    # listing response, longer ones need a full GET).
+    files = gist.get("files") or {}
+    for entry in files.values():
+        content = entry.get("content")
+        if content:
+            try:
+                env = json.loads(content)
+            except (ValueError, TypeError):
+                continue
+            if not isinstance(env, dict):
+                continue
+            channels = env.get("channels")
+            if isinstance(channels, list) and channel in channels:
+                return True
+    return False
+
+
+def _gh_api_get_gist(gist_id: str) -> Optional[dict]:
+    """Full GET on a gist. Used when the listing response truncated
+    file content and we need the full envelope to confirm a channel
+    match."""
+    gh = _resolve_gh_bin()
+    if gh is None:
+        return None
+    try:
+        r = subprocess.run(
+            [gh, "api", f"gists/{gist_id}"],
+            capture_output=True, text=True, timeout=_GH_API_TIMEOUT,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        return json.loads(r.stdout)
+    except (ValueError, TypeError):
+        return None
+
+
+def find_existing(channel: str) -> Optional[str]:
+    """Look for an existing gist on this gh account hosting `channel`.
+    Returns the gist id, or None if no match.
+
+    Walks the user's gist list, pre-filters by description, then does a
+    full GET on candidates whose listing-response content was truncated
+    (large gists). Cheap when there are no candidates; up to N+1 GETs
+    when there are matching descriptions.
+    """
+    gists = _gh_list_user_gists()
+    candidates: list[dict] = []
+    for g in gists:
+        desc = (g.get("description") or "").strip()
+        if desc.startswith("airc mesh") or desc.startswith("airc room:"):
+            candidates.append(g)
+    # First pass: in-listing content match (cheap).
+    for g in candidates:
+        if _gist_describes_channel(g, channel):
+            return g.get("id")
+    # Second pass: full GET on each candidate whose listing response
+    # didn't include content (common for larger gists).
+    for g in candidates:
+        gid = g.get("id")
+        if not gid:
+            continue
+        full = _gh_api_get_gist(gid)
+        if full is None:
+            continue
+        if _gist_describes_channel(full, channel):
+            return gid
+    return None
+
+
+def create_new(channel: str) -> Optional[str]:
+    """Publish a new mesh-shaped gist for `channel`. Returns gist id
+    on success, None on failure.
+
+    The gist envelope is minimal — channel name + airc version + a
+    placeholder seed file (gh refuses gists with truly-empty files).
+    The first send to the gist via GhBearer.send populates messages.jsonl.
+
+    This is intentionally simpler than cmd_connect's full host-bootstrap
+    envelope (which carries machine_id + addresses[] for TCP
+    pair-handshake). After Phase 3c the TCP handshake is gone for
+    cross-network peers — gh-as-bearer is the wire — so the rich
+    addresses payload isn't needed for channel-only routing.
+    """
+    gh = _resolve_gh_bin()
+    if gh is None:
+        return None
+    envelope = {
+        "airc": 1,
+        "kind": "mesh",
+        "channels": [channel],
+    }
+    tmpdir = tempfile.mkdtemp(prefix="airc-channel-gist-")
+    try:
+        # Use airc-invite.<channel> as the seed filename; it's distinct
+        # from messages.jsonl (which the bearer creates on first send),
+        # so we don't shadow the wire file.
+        seed_path = os.path.join(tmpdir, f"airc-room-{channel}.json")
+        with open(seed_path, "w") as f:
+            json.dump(envelope, f)
+        desc = f"airc room: #{channel} (post-3c per-channel gist)"
+        try:
+            r = subprocess.run(
+                [gh, "gist", "create", "-d", desc, seed_path],
+                capture_output=True, text=True, timeout=_GH_API_TIMEOUT,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            return None
+        if r.returncode != 0:
+            return None
+        # Last URL line is the gist URL: https://gist.github.com/<user>/<id>
+        last = r.stdout.strip().splitlines()[-1] if r.stdout.strip() else ""
+        if not last:
+            return None
+        return last.rsplit("/", 1)[-1] or None
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def resolve(channel: str, create_if_missing: bool = False) -> Optional[str]:
+    """Resolve a channel name to its gist id on this gh account.
+
+    Returns the gist id on success (existing or newly-created), None
+    if the channel can't be resolved (no gh auth, no existing gist
+    AND create_if_missing=False, or creation failed).
+
+    Two-step: find_existing then optionally create_new. Keeps create
+    opt-in so callers that just want to look up don't accidentally
+    publish stray gists.
+    """
+    if not channel or not isinstance(channel, str):
+        return None
+    existing = find_existing(channel)
+    if existing:
+        return existing
+    if create_if_missing:
+        return create_new(channel)
+    return None
+
+
+# ── CLI entry — bash invokes this from cmd_connect / cmd_subscribe ──
+
+def _cli() -> int:
+    import argparse
+    parser = argparse.ArgumentParser(prog="airc_core.channel_gist")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    r = sub.add_parser("resolve", help="Print gist id for a channel; empty stdout if absent")
+    r.add_argument("--channel", required=True)
+    r.add_argument("--create-if-missing", action="store_true")
+
+    f = sub.add_parser("find", help="Find existing only (no create)")
+    f.add_argument("--channel", required=True)
+
+    args = parser.parse_args()
+
+    if args.cmd == "resolve":
+        gid = resolve(args.channel, create_if_missing=args.create_if_missing)
+        if gid:
+            print(gid)
+            return 0
+        return 1
+    if args.cmd == "find":
+        gid = find_existing(args.channel)
+        if gid:
+            print(gid)
+            return 0
+        return 1
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())

--- a/lib/airc_core/config.py
+++ b/lib/airc_core/config.py
@@ -167,6 +167,53 @@ def cmd_unsubscribe(args) -> int:
     return 0
 
 
+# ── channel_gists (Phase 2B+ multi-room routing) ────────────────────────
+# Per-channel gist mapping. After Phase 3c (#283), each subscribed
+# channel has its own gist on the user's gh account. This map persists
+# the channel-name → gist-id resolution so cmd_send + monitor can route
+# without re-doing gh-account discovery on every send.
+#
+# Format in config.json:
+#   "channel_gists": {"general": "<id>", "useideem": "<id>", ...}
+#
+# Single source of truth for "given a channel name, what gist?" — bash
+# never reads config.json directly for this; it goes through these
+# accessors.
+
+def cmd_get_channel_gist(args) -> int:
+    """Print the gist id for args.channel (or empty stdout if not set)."""
+    gists = _load(args.config).get("channel_gists", {}) or {}
+    gid = gists.get(args.channel, "")
+    if gid:
+        print(gid)
+    return 0
+
+
+def cmd_set_channel_gist(args) -> int:
+    """Set channel → gist_id mapping. Idempotent. Empty gist_id removes
+    the mapping (treat as 'unsubscribe from this channel's wire')."""
+    c = _load(args.config)
+    gists = dict(c.get("channel_gists", {}) or {})
+    if args.gist_id:
+        gists[args.channel] = args.gist_id
+    else:
+        gists.pop(args.channel, None)
+    c["channel_gists"] = gists
+    return _save(args.config, c)
+
+
+def cmd_list_channel_gists(args) -> int:
+    """Print TAB-separated 'channel\\tgist_id' lines for every mapped
+    channel. Used by the monitor to know which gists to poll. Empty
+    output = no channels configured (host hasn't bootstrapped, or no
+    sidecar subscriptions)."""
+    gists = _load(args.config).get("channel_gists", {}) or {}
+    for ch, gid in gists.items():
+        if ch and gid:
+            print(f"{ch}\t{gid}")
+    return 0
+
+
 def cmd_set_host_block(args) -> int:
     """Atomically write the post-handshake host_* fields into config.
 
@@ -265,6 +312,22 @@ def _build_parser() -> argparse.ArgumentParser:
     un.add_argument("--config", required=True)
     un.add_argument("--channel", required=True)
     un.set_defaults(func=cmd_unsubscribe)
+
+    # channel_gists accessors — single source of truth for channel→gist routing.
+    gcg = sub.add_parser("get_channel_gist")
+    gcg.add_argument("--config", required=True)
+    gcg.add_argument("--channel", required=True)
+    gcg.set_defaults(func=cmd_get_channel_gist)
+
+    scg = sub.add_parser("set_channel_gist")
+    scg.add_argument("--config", required=True)
+    scg.add_argument("--channel", required=True)
+    scg.add_argument("--gist-id", default="")
+    scg.set_defaults(func=cmd_set_channel_gist)
+
+    lcg = sub.add_parser("list_channel_gists")
+    lcg.add_argument("--config", required=True)
+    lcg.set_defaults(func=cmd_list_channel_gists)
 
     s = sub.add_parser("set_host_block")
     s.add_argument("--config", required=True)

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2886,6 +2886,116 @@ scenario_host_msg_publishes_to_gist() {
   cleanup_all
 }
 
+scenario_general_has_shared_gist() {
+  # TDD for #283: when a peer subscribes to #general (sidecar default
+  # on `airc join`), there must be a per-channel gist for #general
+  # that's findable/creatable on the gh account, and broadcasts to
+  # #general must land in THAT gist (not the project room's gist).
+  #
+  # Architecture (per Joel 2026-04-29): "one general, one continuum
+  # room, one ideem room etc — that's the whole point of rooms."
+  # Same gh account = ONE gist per channel name. All my tabs that
+  # subscribe to #general read+write the same #general gist.
+  #
+  # Pre-fix bug: spawn_general_sidecar_if_wanted only updates
+  # subscribed_channels in config.json. Nothing creates the canonical
+  # #general gist or routes traffic to it. Broadcasts on #general
+  # stamp the channel field but write to the project room's gist —
+  # other peers in different project rooms never see them.
+  section "general channel: shared gist resolved + traffic routed (#283)"
+
+  if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
+    echo "  (skipped — gh not authed)"
+    return
+  fi
+
+  cleanup_all
+  local _lib_dir; _lib_dir="$(cd "$(dirname "$AIRC")/lib" && pwd)"
+  local rname="tdd-general-$$"
+  mkdir -p /tmp/airc-it-tdd283-h /tmp/airc-it-tdd283-h/state
+
+  ( cd /tmp/airc-it-tdd283-h && AIRC_HOME=/tmp/airc-it-tdd283-h/state AIRC_NAME=tdd-h-283 AIRC_PORT=7561 \
+      AIRC_NO_DISCOVERY=1 \
+      "$AIRC" connect --room "$rname" --general > /tmp/airc-it-tdd283-h/out.log 2>&1 & )
+  local i
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    sleep 1
+    [ -f /tmp/airc-it-tdd283-h/state/room_gist_id ] && break
+  done
+  local proj_gid; proj_gid=$(cat /tmp/airc-it-tdd283-h/state/room_gist_id 2>/dev/null)
+  if [ -z "$proj_gid" ]; then
+    fail "host did not publish project room gist (room_gist_id absent)"
+    cleanup_all; return
+  fi
+  pass "host published project room gist: $proj_gid (for #$rname)"
+
+  trap "gh gist delete '$proj_gid' --yes 2>/dev/null || true; \
+        general_gid=\$(python3 -c \"import json; c=json.load(open('/tmp/airc-it-tdd283-h/state/config.json')); print(c.get('channel_gists',{}).get('general',''))\" 2>/dev/null); \
+        [ -n \"\$general_gid\" ] && [ \"\$general_gid\" != \"$proj_gid\" ] && gh gist delete \"\$general_gid\" --yes 2>/dev/null || true" EXIT
+
+  # Sleep a moment so the sidecar code has had a chance to also resolve
+  # the #general gist (network call to gh).
+  sleep 3
+
+  # Critical assertion 1: config.json must have a channel_gists map
+  # with "general" pointing at a gist id distinct from the project room.
+  local general_gid
+  general_gid=$(python3 -c "
+import json, sys
+try:
+    c = json.load(open('/tmp/airc-it-tdd283-h/state/config.json'))
+    print(c.get('channel_gists', {}).get('general', ''))
+except Exception:
+    pass
+" 2>/dev/null)
+
+  if [ -n "$general_gid" ]; then
+    pass "config.channel_gists['general'] resolved to: $general_gid"
+  else
+    fail "config.json missing channel_gists['general'] — #general sidecar didn't resolve a shared gist"
+    cleanup_all; return
+  fi
+
+  if [ "$general_gid" != "$proj_gid" ]; then
+    pass "#general gist is distinct from project room gist (no conflation)"
+  else
+    fail "channel_gists['general'] equals project room gist id — #general was not resolved as a separate room"
+  fi
+
+  # Critical assertion 2: the resolved #general gist must actually exist.
+  if gh api gists/$general_gid --jq '.id' >/dev/null 2>&1; then
+    pass "the resolved #general gist exists on gh"
+  else
+    fail "channel_gists['general'] points at a gist that doesn't exist on gh"
+  fi
+
+  # Critical assertion 3: airc msg --room general writes to the #general
+  # gist's messages.jsonl, not the project room's gist.
+  local marker="tdd283-general-marker-$(date +%s%N)"
+  AIRC_HOME=/tmp/airc-it-tdd283-h/state "$AIRC" msg --room general "$marker" >/dev/null 2>&1 || true
+  sleep 2
+
+  local general_content; general_content=$(gh api "gists/$general_gid" --jq '.files["messages.jsonl"].content // ""' 2>/dev/null)
+  if printf '%s' "$general_content" | grep -q "$marker"; then
+    pass "airc msg --room general landed in #general gist's messages.jsonl"
+  else
+    fail "BUG: marker NOT in #general gist (content len ${#general_content}); broadcast to #general routed wrong"
+  fi
+
+  # And it must NOT have landed in the project gist (would mean cross-channel pollution).
+  local proj_content; proj_content=$(gh api "gists/$proj_gid" --jq '.files["messages.jsonl"].content // ""' 2>/dev/null)
+  if printf '%s' "$proj_content" | grep -q "$marker"; then
+    fail "channel pollution: #general broadcast also landed in project room gist (channel routing wrong)"
+  else
+    pass "no channel pollution: project room gist did not receive the #general broadcast"
+  fi
+
+  trap - EXIT
+  gh gist delete "$proj_gid" --yes 2>/dev/null || true
+  [ -n "$general_gid" ] && [ "$general_gid" != "$proj_gid" ] && gh gist delete "$general_gid" --yes 2>/dev/null || true
+  cleanup_all
+}
+
 scenario_bearer_local() {
   # Phase 3a: LocalBearer serves same-machine peers via direct
   # filesystem reads/writes — no SSH, no subprocess. This scenario
@@ -3413,6 +3523,7 @@ case "$MODE" in
   bearer_gh) scenario_bearer_gh ;;
   gh_send_creates_messages_jsonl) scenario_gh_send_creates_messages_jsonl ;;
   host_msg_publishes_to_gist) scenario_host_msg_publishes_to_gist ;;
+  general_has_shared_gist) scenario_general_has_shared_gist ;;
   ""|all)
     # Default = run everything. The peers_cross_scope + whois_cross_scope
     # scenarios were removed in PR #239 (sidecar walk semantics deleted


### PR DESCRIPTION
## Summary
Closes #283. Phase 2B.3's "subscribed_channels handles it" claim was incomplete — the routing was never built. Tonight's QA pass made this visible: cross-project broadcasts to #general silently disappeared into the sender's project gist; peers in different project rooms saw nothing.

## Architecture (per Joel)
"One general, one continuum room, one ideem room etc — that's the whole point of rooms." ONE gist per channel name per gh account. ONE monitor process per scope, polls N subscribed channels' gists in parallel. The gist IS the host medium; closing tabs is fine, the gist persists.

## Modules
- **\`lib/airc_core/channel_gist.py\`** (new, ~280 lines) — find-or-create per channel. Single concern. CLI seam for bash.
- **\`lib/airc_core/config.py\`** — extended with \`channel_gists\` accessors (get/set/list). Single source of truth for "which gist for which channel."

## Wiring
- **\`airc\`** — \`_monitor_multi_channel\` helper spawns N bearer_cli recv subprocesses, all merged into one formatter. Per-channel offset + bearer_state files for observability.
- **\`spawn_general_sidecar_if_wanted\`** — find-or-creates #general gist via channel_gist module + persists in config. NO separate sidecar process.
- **\`cmd_connect\`** — primary room bootstrap also writes channel_gists[room_name].
- **\`cmd_send\`** — routes by channel via \`config.get_channel_gist\` lookup, falls back to scope's room_gist_id.

## TDD: 6/6 pass post-fix
\`scenario_general_has_shared_gist\` — full host bootstrap with --general flag, asserts:
1. Primary room gist created
2. config.channel_gists['general'] resolved + distinct
3. #general gist exists on gh
4. \`airc msg --room general\` lands in #general gist
5. NO cross-channel pollution into project gist

## Known follow-ups
- \`scenario_status\`'s "queue when host unreachable" check is obsolete (host_target isn't load-bearing post-3c). Needs updating.
- #284 partially mitigated by per-channel gists; cross-account DMs still need gh-pair-handshake (separate work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)