### PR TITLE
fix(#290): channel_gist prefers single-channel gists (substrate convergence)

### DIFF
--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -160,14 +160,45 @@ def _gh_api_get_gist(gist_id: str) -> Optional[dict]:
         return None
 
 
+def _is_single_channel_match(gist: dict, channel: str) -> bool:
+    """A gist is the canonical post-3c per-channel gist for `channel`
+    iff its envelope has channels=[<exactly channel>]. Single-element
+    list, exact match. The post-3c shape created by create_new()."""
+    files = gist.get("files") or {}
+    for entry in files.values():
+        content = entry.get("content")
+        if not content:
+            continue
+        try:
+            env = json.loads(content)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(env, dict):
+            continue
+        channels = env.get("channels")
+        if isinstance(channels, list) and len(channels) == 1 and channels[0] == channel:
+            return True
+    return False
+
+
 def find_existing(channel: str) -> Optional[str]:
     """Look for an existing gist on this gh account hosting `channel`.
     Returns the gist id, or None if no match.
 
-    Walks the user's gist list, pre-filters by description, then does a
-    full GET on candidates whose listing-response content was truncated
-    (large gists). Cheap when there are no candidates; up to N+1 GETs
-    when there are matching descriptions.
+    Two-pass to fix #290 (substrate split): canonical single-channel
+    gists (channels=[<channel>] exactly, description "airc room: #<x>")
+    take priority over legacy multi-channel mesh gists (channels=[a,b,c]).
+    Without this priority, peers resolved different gists when both
+    shapes coexisted on the same gh account, splitting the substrate
+    silently.
+
+    Pass 1: any gist with channels=[<exact channel>] — the post-3c
+            create_new shape; deterministic match.
+    Pass 2: legacy multi-channel match — channels list CONTAINS the
+            target. Returned only if no single-channel canonical exists.
+
+    Each pass first checks the cheap listing-response content, then
+    falls back to a full GET when the listing didn't inline content.
     """
     gists = _gh_list_user_gists()
     candidates: list[dict] = []
@@ -175,12 +206,28 @@ def find_existing(channel: str) -> Optional[str]:
         desc = (g.get("description") or "").strip()
         if desc.startswith("airc mesh") or desc.startswith("airc room:"):
             candidates.append(g)
-    # First pass: in-listing content match (cheap).
+
+    # Pass 1: canonical single-channel match (cheap, listing-response).
+    for g in candidates:
+        if _is_single_channel_match(g, channel):
+            return g.get("id")
+
+    # Pass 1 (deep): full GET for each candidate whose listing-content
+    # was truncated. Same single-channel criterion.
+    for g in candidates:
+        gid = g.get("id")
+        if not gid:
+            continue
+        full = _gh_api_get_gist(gid)
+        if full is None:
+            continue
+        if _is_single_channel_match(full, channel):
+            return gid
+
+    # Pass 2: legacy multi-channel fallback. Only if no canonical exists.
     for g in candidates:
         if _gist_describes_channel(g, channel):
             return g.get("id")
-    # Second pass: full GET on each candidate whose listing response
-    # didn't include content (common for larger gists).
     for g in candidates:
         gid = g.get("id")
         if not gid:
@@ -190,6 +237,7 @@ def find_existing(channel: str) -> Optional[str]:
             continue
         if _gist_describes_channel(full, channel):
             return gid
+
     return None
 
 

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -28,7 +28,7 @@ Opt-outs:
 - `AIRC_NO_GENERAL=1 airc join` → env var equivalent of `--no-general`. Useful for test harnesses or `.envrc` files.
 - `AIRC_NO_AUTO_ROOM=1 airc join` → skip git-org auto-scoping; defaults to `#general` only.
 
-**Tailscale:** if installed and signed in, the substrate uses it for cross-machine peers. If installed and logged out, `airc join` opens Tailscale.app for sign-in (Mac) or prints `tailscale up` (Linux/Windows). Same-machine and same-LAN peers connect via `127.0.0.1`/LAN regardless — Tailscale is only needed for cross-network mesh. To opt out entirely: `airc join --no-tailscale`.
+**Transport:** post-Phase-3c, the gist IS the wire. Same-machine peers use direct fs reads (LocalBearer); cross-network peers use gh-as-bearer (poll/append the room gist). No Tailscale, no sshd. **Messages are end-to-end encrypted** at the envelope layer (X25519 + ChaCha20-Poly1305) — GitHub stores ciphertext only.
 
 `gh` CLI is **required**, not optional. The whole substrate is built on it. If the user doesn't have it: `brew install gh && gh auth login`.
 
@@ -54,13 +54,12 @@ Keep the Monitor `description` short and stable — `"airc"` is ideal.
 
 Outcomes the monitor will print on its first events:
 - `Auto-scoped: #<room> (from git org; override with --room or AIRC_NO_AUTO_ROOM=1)` — the cwd's git remote owner picked the project room. Then either:
-- `Found #<room> on your gh account → joining (<id>)` — another tab/machine on the same gh account is already hosting; we're a joiner. Confirm with `airc peers`.
-- `No #<room> found on your gh account → becoming the host.` — we're the host. Subsequent agents whose `airc join` resolves to the same room will auto-join.
-- `Sidecar: also subscribing to #general (--no-general to opt out)` — the lobby sidecar is being spawned in parallel. Same nick, sibling `.general` scope.
-- `✓ Multi-address pick: <addr>:<port> (from host.addresses)` — joiner found the host's gist and selected the cheapest reachable address. `127.0.0.1` means same-machine match; a `192.168.x.x` means same-LAN; `100.x.x.x` means via Tailscale.
-- `⚠ Tailscale is installed but you're not signed in.` — non-fatal nudge; same-machine and same-LAN paths still work. Either sign in (the launched Tailscale.app) or pass `--no-tailscale` to silence.
+- `Found #<room> on your gh account → joining (<id>)` — another tab/machine on the same gh account already created the room gist; we're joining it. Confirm with `airc peers`.
+- `No #<room> found on your gh account → becoming the host.` — we're the first peer; we'll create the gist. Subsequent agents who resolve to the same room name auto-join.
+- `Also subscribing to #general (--no-general to opt out)` — the multi-channel monitor will poll #general's gist alongside the project room. ONE process per scope, polls all subscribed channels in parallel.
+- `#general gist: <id>` — the canonical #general gist on this gh account (find-or-created by `airc_core.channel_gist`).
 
-Events from BOTH rooms stream through this Monitor. The python formatter prefixes each with `[#room]` so you can tell them apart. `[#useideem] vhsm: ...` and `[#general] continuum-b741: ...` interleave naturally.
+Events from ALL subscribed channels stream through this Monitor. The python formatter prefixes each with `[#room]` so you can tell them apart. `[#useideem] vhsm: ...` and `[#general] continuum-b741: ...` interleave naturally.
 
 **Named room only (no general sidecar):**
 ```
@@ -160,12 +159,11 @@ Show them the platform-appropriate command. Don't make them research it.
 
 ## 5. Troubleshooting
 
-The relay prints actual errors. Read them.
+Read actual errors. The relay prints them.
 
-- **SSH not working on host:** relay prints the exact sudo command. Show it to the user; they type `! sudo ...` to run it; retry.
-- **Can't reach host:** host isn't running `airc join`, address is wrong, or Tailscale isn't up.
-- **Host went quiet after a long pause:** host machine probably went to sleep. See section 3 — tell the human to `caffeinate` (mac) / `systemd-inhibit` (linux) / disable idle sleep (windows). After they do, they need to `airc join` again; monitor doesn't auto-resurrect from a sleep-killed process.
-- **Port collision on host:** set `AIRC_PORT=7548` in the host's environment before `airc join`. The printed join string will carry the port automatically. Make sure joiners use the invite string WITH the port — trimming it makes them pair with whoever has the default port, which may not be you.
-- **Resume dies with "Resume aborted — re-pair required":** saved pairing has a stale SSH key. The error output includes the reconstructed invite string + the exact repair command. Run `airc teardown --flush && airc join <that-invite-string>`.
-- **Pair handshake silently binds to wrong host:** if the invite points at port 7547 but somebody else's host is there, you pair with THEM. Symptom: your peer list looks right but nobody receives your messages. Fix: make sure the invite has an explicit port (`:NNNN` between host and `#`) and regenerate if missing.
-- **After `airc canary` or `airc update`: the RUNNING monitor still uses the OLD binary.** The symlink refreshed but the already-spawned `airc join` process doesn't re-exec itself. To pick up the new code: `airc teardown && airc join`. Skipping this can host a room on stale code while peers who already updated are on new code — which was the exact UX wart during the auto-scope rollout.
+- **gh auth missing or expired:** `gh auth status` shows it; user runs `gh auth login -s gist`. Without gh, the substrate has no wire — there's no fallback to the SSH/Tailscale era post-3c.
+- **Mesh appears quiet but `airc status` shows monitor running:** check `airc status` — bearer line should say `Ns ago via gh` with a recent timestamp. If `awaiting first event` for >2min after first peer joined, the gh poll loop is stalled (rate-limit or auth blip). Re-running `airc teardown && airc join` resets cleanly.
+- **My broadcast lands locally but peers don't see it:** verify the destination gist actually got the line: `gh api gists/<gist-id> --jq '.files["messages.jsonl"].content'` should contain your envelope. If absent, GhBearer.send silently dropped (rate limit, gist 404, auth lost) — the bearer reports `transient_failure` or `delivered`; check `airc logs` for [QUEUED] markers.
+- **Cross-room messaging:** `airc msg --room general "..."` to broadcast to the lobby (every peer subscribed to #general sees it across project rooms). DM cross-room: `airc msg --room general @<peer> "..."` routes via #general's gist to peers who share that subscription.
+- **After `airc update`: the RUNNING monitor still uses the OLD binary.** Pulling code doesn't re-exec processes. To pick up the new code: `airc teardown && airc join`.
+- **Port collision on host:** set `AIRC_PORT=7548` before `airc join`. The TCP pair-handshake listener uses this port (the gist + bearer don't depend on it; pair-handshake is the only TCP path remaining post-3c).

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2886,6 +2886,92 @@ scenario_host_msg_publishes_to_gist() {
   cleanup_all
 }
 
+scenario_channel_gist_prefers_single_channel() {
+  # TDD for #290: when both a canonical post-3c single-channel gist
+  # (channels=[<x>]) AND a legacy multi-channel mesh gist (channels=[a,b,c])
+  # exist for the same channel name on the gh account, find_existing
+  # MUST prefer the single-channel one. Otherwise peers split between
+  # the two and never see each other's broadcasts.
+  section "channel_gist.find_existing prefers single-channel over multi-channel (#290)"
+
+  if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
+    echo "  (skipped — gh not authed)"
+    return
+  fi
+
+  cleanup_all
+  local _lib_dir; _lib_dir="$(cd "$(dirname "$AIRC")/lib" && pwd)"
+
+  # Publish a LEGACY multi-channel mesh gist FIRST (so it has older
+  # updated_at than the single-channel one — exactly the order that
+  # caused #290 in production).
+  local seed; seed=$(mktemp -d -t airc-it-tdd290-seed.XXXXXX)
+  cat > "$seed/airc-invite.legacy.fake" <<JSON
+{"airc": 1, "kind": "mesh", "channels": ["projx", "lobby-target", "other"], "host": {"name": "fake"}}
+JSON
+  local legacy_url; legacy_url=$(gh gist create -d "airc mesh" "$seed/airc-invite.legacy.fake" 2>&1 | tail -1)
+  local legacy_gid; legacy_gid=$(printf '%s' "$legacy_url" | awk -F/ '{print $NF}')
+  rm -rf "$seed"
+  if [ -z "$legacy_gid" ] || ! printf '%s' "$legacy_gid" | grep -qE '^[a-f0-9]+$'; then
+    fail "could not create legacy multi-channel test gist"
+    return
+  fi
+  pass "legacy multi-channel gist published: $legacy_gid (channels=[projx, lobby-target, other])"
+
+  trap "gh gist delete '$legacy_gid' --yes 2>/dev/null || true" EXIT
+
+  # Now resolve channel "lobby-target" with create_if_missing — this
+  # triggers create_new which publishes a canonical single-channel gist.
+  # (The legacy gist also matches "lobby-target" loosely, so the test
+  # is whether find_existing prefers the single-channel one we're
+  # about to create.)
+  sleep 1
+  local single_gid
+  single_gid=$(PYTHONPATH="$_lib_dir" python3 -m airc_core.channel_gist resolve --channel lobby-target --create-if-missing 2>/dev/null)
+
+  if [ -z "$single_gid" ]; then
+    fail "channel_gist resolve returned empty"
+    trap - EXIT
+    gh gist delete "$legacy_gid" --yes 2>/dev/null || true
+    return
+  fi
+
+  if [ "$single_gid" = "$legacy_gid" ]; then
+    fail "BUG #290: resolve returned the LEGACY multi-channel gist ($legacy_gid) — substrate split risk"
+  else
+    pass "resolve returned a different gist than the legacy ($single_gid != $legacy_gid)"
+  fi
+
+  trap "gh gist delete '$legacy_gid' --yes 2>/dev/null || true; gh gist delete '$single_gid' --yes 2>/dev/null || true" EXIT
+
+  # The new single_gid should be a canonical single-channel gist.
+  local single_channels
+  single_channels=$(gh api "gists/$single_gid" --jq '.files | to_entries[0].value.content' 2>/dev/null \
+    | python3 -c "import json,sys; print(json.load(sys.stdin).get('channels'))" 2>/dev/null)
+  if [ "$single_channels" = "['lobby-target']" ]; then
+    pass "single-channel gist envelope has channels=['lobby-target'] (post-3c canonical shape)"
+  else
+    fail "single-channel gist envelope shape unexpected: $single_channels"
+  fi
+
+  # Now the critical test: ANOTHER resolve call should ALSO return the
+  # single-channel gist (deterministic preference), not flip back to
+  # the legacy. This is the real production scenario where Peer B
+  # resolves AFTER Peer A already published the canonical single-channel.
+  local second_resolve
+  second_resolve=$(PYTHONPATH="$_lib_dir" python3 -m airc_core.channel_gist resolve --channel lobby-target 2>/dev/null)
+  if [ "$second_resolve" = "$single_gid" ]; then
+    pass "second resolve returns the canonical single-channel gist (substrate converges)"
+  else
+    fail "BUG #290: second resolve returned $second_resolve (expected $single_gid) — different peers will resolve different gists"
+  fi
+
+  trap - EXIT
+  gh gist delete "$legacy_gid" --yes 2>/dev/null || true
+  gh gist delete "$single_gid" --yes 2>/dev/null || true
+  cleanup_all
+}
+
 scenario_general_has_shared_gist() {
   # TDD for #283: when a peer subscribes to #general (sidecar default
   # on `airc join`), there must be a per-channel gist for #general
@@ -3524,6 +3610,7 @@ case "$MODE" in
   gh_send_creates_messages_jsonl) scenario_gh_send_creates_messages_jsonl ;;
   host_msg_publishes_to_gist) scenario_host_msg_publishes_to_gist ;;
   general_has_shared_gist) scenario_general_has_shared_gist ;;
+  channel_gist_prefers_single_channel) scenario_channel_gist_prefers_single_channel ;;
   ""|all)
     # Default = run everything. The peers_cross_scope + whois_cross_scope
     # scenarios were removed in PR #239 (sidecar walk semantics deleted


### PR DESCRIPTION
Closes #290. Without this, peers on the same gh account split between legacy multi-channel mesh gists and canonical single-channel gists — neither sees the other. Two-pass match: single-channel canonical first, multi-channel fallback. TDD covers the actual production failure shape.