### PR TITLE
fix: gist rotation + #288 dedup + #292 connect-stomp (tomorrow-demo blockers)

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -292,27 +292,28 @@ cmd_connect() {
   # if a prior monitor was still around — easy to forget, often resulted in
   # duplicate monitors or port collisions. Now a single `airc connect` or
   # `airc resume` does the right thing.
+  # #292 fix: refuse to stomp a live monitor. Pre-fix this block
+  # auto-killed any PIDs in airc.pid before continuing — which silently
+  # destroyed a live monitor in a sibling shell when the user ran
+  # `airc connect` from a second terminal to verify state. That made
+  # multi-tab sanity-checking destructive. Post-fix: detect liveness,
+  # print a one-liner pointing to the right tools, exit 0 cleanly.
+  # Stale pidfile (no live PIDs) still gets cleaned up + we proceed.
   local stale_pidfile="$AIRC_WRITE_DIR/airc.pid"
   if [ -f "$stale_pidfile" ]; then
     local stale_pids; stale_pids=$(cat "$stale_pidfile" 2>/dev/null | tr '\n' ' ')
-    local all_stale="$stale_pids"
+    local any_alive=0
     for p in $stale_pids; do
-      # `|| true` — pgrep returns 1 when the parent PID is already dead (no
-      # children to find). With `set -euo pipefail` at the top of the script,
-      # that would abort this block *before* reaching the rm on line 442 that
-      # self-heals the stale pidfile. Result: joiner wedged forever after a
-      # parent crash / laptop sleep until someone manually rm'd the pidfile.
-      all_stale="$all_stale $(proc_children "$p" | tr '\n' ' ' || true)"
+      kill -0 "$p" 2>/dev/null && any_alive=1
     done
-    # Quiet kill — don't warn unless there was actually a live process.
-    if [ -n "$all_stale" ]; then
-      local any_alive=0
-      for p in $all_stale; do kill -0 "$p" 2>/dev/null && any_alive=1; done
-      if [ "$any_alive" = "1" ]; then
-        kill -9 $all_stale 2>/dev/null || true
-        sleep 1
-      fi
+    if [ "$any_alive" = "1" ]; then
+      echo "  airc connect: this scope's monitor is already running (PIDs: $stale_pids)."
+      echo "    To stop it:        airc teardown"
+      echo "    To restart it:     airc teardown && airc connect"
+      echo "    To check it:       airc status"
+      return 0
     fi
+    # Stale pidfile (no live processes) — safe to clean.
     rm -f "$stale_pidfile"
   fi
 

--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -59,6 +59,18 @@ _MESSAGES_FILE = "messages.jsonl"
 _DEFAULT_POLL_INTERVAL = 15.0  # seconds; tuned for gh rate limit headroom
 _GH_API_TIMEOUT = 10.0          # per-call seconds; total wall time bounded by retry policy
 
+# Rotation thresholds (gh hard limit on a gist file is 1MB; we trim
+# proactively well before that so the next append always has headroom).
+# An average envelope post-Phase-E is ~300-500 bytes (sig + ts + AEAD
+# nonce + ciphertext); 600KB ≈ 1500-2000 envelopes per file. When we
+# cross _GIST_MAX_BYTES, we keep only the last _GIST_KEEP_LINES so the
+# substrate stays writable indefinitely. Older content is dropped —
+# losing it is preferable to the room going write-blocked forever.
+# Both can be tuned at runtime via env vars (AIRC_GIST_MAX_BYTES,
+# AIRC_GIST_KEEP_LINES) for tests + power users.
+_GIST_MAX_BYTES = 600_000   # rotate at 600KB (40% headroom under 1MB hard limit)
+_GIST_KEEP_LINES = 1000     # keep last 1000 lines after rotation
+
 
 def _resolve_gh_bin() -> str:
     """Locate gh CLI on PATH. Returns the path or raises GhBearerError.
@@ -123,6 +135,40 @@ def _gh_api_get(gist_id: str) -> Optional[dict]:
         return json.loads(r.stdout)
     except (ValueError, TypeError):
         return None
+
+
+def _rotate_if_needed(content: str) -> str:
+    """Trim the gist's messages.jsonl content if it's approaching gh's
+    1MB-per-file limit. Keep the last _GIST_KEEP_LINES so the substrate
+    stays writable forever; old content is dropped (the cost of an
+    eventually-write-blocked-room is far worse than losing old context).
+
+    Reads thresholds from env so tests + power users can tune:
+      AIRC_GIST_MAX_BYTES   — rotation trigger (default 600000)
+      AIRC_GIST_KEEP_LINES  — lines to retain after rotation (default 1000)
+
+    Idempotent below the threshold (returns content unchanged).
+    """
+    try:
+        max_bytes = int(os.environ.get("AIRC_GIST_MAX_BYTES", _GIST_MAX_BYTES))
+    except (TypeError, ValueError):
+        max_bytes = _GIST_MAX_BYTES
+    try:
+        keep_lines = int(os.environ.get("AIRC_GIST_KEEP_LINES", _GIST_KEEP_LINES))
+    except (TypeError, ValueError):
+        keep_lines = _GIST_KEEP_LINES
+
+    # Encode-aware byte count: gh measures bytes, not chars. UTF-8 means
+    # multibyte chars (cyrillic, CJK, emoji) count more than 1 byte each.
+    if len(content.encode("utf-8")) <= max_bytes:
+        return content
+
+    # Trim to the last keep_lines. Skip blank lines so we don't waste
+    # the budget on empties.
+    lines = [ln for ln in content.splitlines() if ln.strip()]
+    kept = lines[-keep_lines:] if len(lines) > keep_lines else lines
+    # Trailing newline so the next append starts on its own line.
+    return "\n".join(kept) + "\n"
 
 
 def _read_messages_content(gist_data: dict) -> str:
@@ -303,7 +349,8 @@ class GhBearer(Bearer):
                 kind="transient_failure",
                 detail="payload is not utf-8; gh-bearer requires text envelopes",
             )
-        new_content = _read_messages_content(gist) + framed_str
+        existing_content = _read_messages_content(gist)
+        new_content = _rotate_if_needed(existing_content) + framed_str
 
         ok, detail = _gh_gist_write_file(gist_id, new_content)
         if ok:

--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -138,37 +138,65 @@ def _gh_api_get(gist_id: str) -> Optional[dict]:
 
 
 def _rotate_if_needed(content: str) -> str:
-    """Trim the gist's messages.jsonl content if it's approaching gh's
-    1MB-per-file limit. Keep the last _GIST_KEEP_LINES so the substrate
-    stays writable forever; old content is dropped (the cost of an
-    eventually-write-blocked-room is far worse than losing old context).
+    """Trim the gist's messages.jsonl content when approaching gh's 1MB
+    file limit. Trim to a TARGET well below the trigger so we don't
+    re-rotate on every subsequent append — hysteresis between high-
+    and low-water marks gives the substrate breathing room.
 
-    Reads thresholds from env so tests + power users can tune:
-      AIRC_GIST_MAX_BYTES   — rotation trigger (default 600000)
-      AIRC_GIST_KEEP_LINES  — lines to retain after rotation (default 1000)
+    Per Joel 2026-04-29: "when you trim, you go PAST the number so it
+    takes longer to trim again, otherwise you are constantly trimming."
 
-    Idempotent below the threshold (returns content unchanged).
+    High-water (MAX_BYTES, default 600KB): when content crosses, rotate.
+    Low-water (post-trim ≤ MAX_BYTES/2, ~300KB default): the rotation
+    target. Gives ~300KB of headroom for the next write burst before
+    the next rotation fires.
+
+    Also caps at KEEP_LINES (default 1000) so a flood of tiny lines
+    doesn't blow the line-count budget for line-oriented downstream
+    consumers (formatter, offset tracking).
+
+    All three knobs are env-tunable for tests + power users:
+      AIRC_GIST_MAX_BYTES    (default 600000) — trigger
+      AIRC_GIST_TARGET_BYTES (default MAX/2)  — post-trim ceiling
+      AIRC_GIST_KEEP_LINES   (default 1000)   — line-count cap
+
+    Idempotent below the trigger (returns content unchanged).
     """
     try:
         max_bytes = int(os.environ.get("AIRC_GIST_MAX_BYTES", _GIST_MAX_BYTES))
     except (TypeError, ValueError):
         max_bytes = _GIST_MAX_BYTES
     try:
+        target_bytes = int(os.environ.get("AIRC_GIST_TARGET_BYTES", max_bytes // 2))
+    except (TypeError, ValueError):
+        target_bytes = max_bytes // 2
+    try:
         keep_lines = int(os.environ.get("AIRC_GIST_KEEP_LINES", _GIST_KEEP_LINES))
     except (TypeError, ValueError):
         keep_lines = _GIST_KEEP_LINES
 
-    # Encode-aware byte count: gh measures bytes, not chars. UTF-8 means
-    # multibyte chars (cyrillic, CJK, emoji) count more than 1 byte each.
+    # gh measures bytes, not chars; UTF-8 bytes is what counts.
     if len(content.encode("utf-8")) <= max_bytes:
         return content
 
-    # Trim to the last keep_lines. Skip blank lines so we don't waste
-    # the budget on empties.
+    # Walk the most-recent lines backward, accumulating bytes until we
+    # hit target_bytes OR keep_lines, whichever comes first. The walk
+    # gives us "the latest N lines that fit in target" — exactly the
+    # post-trim shape we want. Skip blanks so they don't burn the budget.
     lines = [ln for ln in content.splitlines() if ln.strip()]
-    kept = lines[-keep_lines:] if len(lines) > keep_lines else lines
-    # Trailing newline so the next append starts on its own line.
-    return "\n".join(kept) + "\n"
+    kept_reversed: list[str] = []
+    bytes_so_far = 0
+    for line in reversed(lines):
+        # +1 for the newline we'll add on join.
+        line_bytes = len(line.encode("utf-8")) + 1
+        if bytes_so_far + line_bytes > target_bytes:
+            break
+        if len(kept_reversed) >= keep_lines:
+            break
+        kept_reversed.append(line)
+        bytes_so_far += line_bytes
+    kept = list(reversed(kept_reversed))
+    return "\n".join(kept) + "\n" if kept else ""
 
 
 def _read_messages_content(gist_data: dict) -> str:

--- a/lib/airc_core/handshake.py
+++ b/lib/airc_core/handshake.py
@@ -184,12 +184,26 @@ def cmd_accept_one(args) -> int:
                 f.write(ssh_key.strip() + "\n")
             os.chmod(ak, 0o600)
 
-    # Save joiner as peer (with stable-host stale cleanup).
+    # Save joiner as peer (with rename-chain stale cleanup).
+    # #288 fix: match by X25519 pubkey, not host. Same-machine multi-tab
+    # peers all share `host: user@<machine-ip>` but have DIFFERENT
+    # pubkeys (each scope generates its own X25519 keypair). Pre-fix
+    # cleanup deleted legitimate distinct peers because their host
+    # field matched. Post-fix: identity is the X25519 pub; same pubkey
+    # = same peer (rename or re-pair); different pubkey = different
+    # peer (don't touch).
+    #
+    # Falls back to (host, airc_home) match when x25519_pub is absent
+    # (joiner on pre-Phase-E airc, or cryptography unavailable on
+    # their side). That's still safer than host-only — different
+    # scopes on the same machine have different airc_homes.
     peers_dir = os.path.expanduser(args.peers_dir)
     os.makedirs(peers_dir, exist_ok=True)
     jname = joiner["name"]
     jhost = joiner.get("host", "")
-    if jhost and os.path.isdir(peers_dir):
+    j_x25519 = joiner.get("x25519_pub", "")
+    j_airc_home = joiner.get("airc_home", "")
+    if os.path.isdir(peers_dir):
         for entry in os.listdir(peers_dir):
             if not entry.endswith(".json") or entry == jname + ".json":
                 continue
@@ -197,7 +211,14 @@ def cmd_accept_one(args) -> int:
                 d = json.load(open(os.path.join(peers_dir, entry)))
             except Exception:
                 continue
-            if d.get("host") == jhost:
+            # Decide: is this record the joiner's stale prior name?
+            same_identity = False
+            if j_x25519 and d.get("x25519_pub") == j_x25519:
+                same_identity = True
+            elif (jhost and d.get("host") == jhost
+                  and j_airc_home and d.get("airc_home") == j_airc_home):
+                same_identity = True
+            if same_identity:
                 for ext in (".json", ".pub"):
                     p = os.path.join(peers_dir, entry[:-5] + ext)
                     if os.path.isfile(p):

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2886,6 +2886,98 @@ scenario_host_msg_publishes_to_gist() {
   cleanup_all
 }
 
+scenario_gist_rotates_under_size_limit() {
+  # TDD: gh gists have a 1MB-per-file soft limit. If we never trim
+  # messages.jsonl, the room eventually goes write-blocked + dead
+  # forever. This scenario verifies rotation: pre-fill a gist near
+  # the threshold, run a send, assert the post-send content is
+  # under the limit AND contains the new line.
+  section "gh gist messages.jsonl rotates under size limit (write-block prevention)"
+
+  if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
+    echo "  (skipped — gh not authed)"
+    return
+  fi
+
+  cleanup_all
+  local _lib_dir; _lib_dir="$(cd "$(dirname "$AIRC")/lib" && pwd)"
+
+  # Build a synthetic messages.jsonl with N lines (each ~300 bytes) so
+  # total content is right at the rotation threshold. Then create a
+  # gist seeded with that content.
+  local seed; seed=$(mktemp -d -t airc-it-rot-seed.XXXXXX)
+  python3 - "$seed/messages.jsonl" <<'PYEOF'
+import sys, json
+out = sys.argv[1]
+with open(out, "w") as f:
+    for i in range(50):
+        env = {
+            "from": "seed",
+            "to": "all",
+            "ts": f"2026-04-29T00:00:{i:02d}Z",
+            "channel": "general",
+            "msg": f"line {i:04d} " + "x" * 200,
+            "sig": "x",
+        }
+        f.write(json.dumps(env) + "\n")
+PYEOF
+  if [ ! -s "$seed/messages.jsonl" ]; then
+    fail "could not generate seed messages.jsonl"
+    rm -rf "$seed"; return
+  fi
+  local pre_bytes; pre_bytes=$(wc -c < "$seed/messages.jsonl" | tr -d ' ')
+  local pre_lines; pre_lines=$(wc -l < "$seed/messages.jsonl" | tr -d ' ')
+  pass "seed messages.jsonl: ${pre_lines} lines, ${pre_bytes} bytes"
+
+  local gist_url; gist_url=$(gh gist create -d "airc room: #rotation-test (post-#rot)" "$seed/messages.jsonl" 2>&1 | tail -1)
+  local gist_id; gist_id=$(printf '%s' "$gist_url" | awk -F/ '{print $NF}')
+  rm -rf "$seed"
+  if [ -z "$gist_id" ] || ! printf '%s' "$gist_id" | grep -qE '^[a-f0-9]+$'; then
+    fail "could not create rotation-test gist"
+    return
+  fi
+  pass "rotation-test gist created: $gist_id"
+
+  trap "gh gist delete '$gist_id' --yes 2>/dev/null || true" EXIT
+
+  # Force an aggressive rotation threshold via env so the test triggers
+  # on a small file rather than producing ~600KB of content (slow + gh
+  # API noise). With AIRC_GIST_MAX_BYTES=2000 the seed (50 lines × ~250B
+  # ≈ 12.5KB) far exceeds the threshold; one send rotates.
+  local marker="rot-marker-$(date +%s%N)"
+  local probe='{"from":"alpha","to":"all","ts":"2026-04-29T00:00:00Z","channel":"rotation-test","msg":"'"$marker"'","sig":"x"}'
+  AIRC_GIST_MAX_BYTES=2000 AIRC_GIST_KEEP_LINES=10 \
+    PYTHONPATH="$_lib_dir" python3 -m airc_core.bearer_cli send all rotation-test \
+      --room-gist-id "$gist_id" <<< "$probe" >/dev/null 2>&1
+
+  sleep 1
+  local post_content; post_content=$(gh api "gists/$gist_id" --jq '.files["messages.jsonl"].content // ""' 2>/dev/null)
+  local post_bytes; post_bytes=$(printf '%s' "$post_content" | wc -c | tr -d ' ')
+  local post_lines; post_lines=$(printf '%s' "$post_content" | grep -c '^.' 2>/dev/null || echo 0)
+
+  if [ "$post_bytes" -le 4000 ]; then
+    pass "post-send: gist content trimmed under threshold ($post_bytes bytes)"
+  else
+    fail "BUG: gist content NOT rotated — $post_bytes bytes (expected ≤4000 with KEEP_LINES=10)"
+  fi
+
+  if [ "$post_lines" -le 11 ]; then
+    pass "post-send: line count is keep_lines + 1 new line (got $post_lines)"
+  else
+    fail "BUG: line count $post_lines exceeds expected (KEEP_LINES=10 + 1 new = 11)"
+  fi
+
+  if printf '%s' "$post_content" | grep -q "$marker"; then
+    pass "post-rotation: the new send's marker is preserved (not lost in trim)"
+  else
+    fail "BUG: rotation dropped the new line — marker missing"
+  fi
+
+  trap - EXIT
+  gh gist delete "$gist_id" --yes 2>/dev/null || true
+  cleanup_all
+}
+
 scenario_channel_gist_prefers_single_channel() {
   # TDD for #290: when both a canonical post-3c single-channel gist
   # (channels=[<x>]) AND a legacy multi-channel mesh gist (channels=[a,b,c])
@@ -3611,6 +3703,7 @@ case "$MODE" in
   host_msg_publishes_to_gist) scenario_host_msg_publishes_to_gist ;;
   general_has_shared_gist) scenario_general_has_shared_gist ;;
   channel_gist_prefers_single_channel) scenario_channel_gist_prefers_single_channel ;;
+  gist_rotates_under_size_limit) scenario_gist_rotates_under_size_limit ;;
   ""|all)
     # Default = run everything. The peers_cross_scope + whois_cross_scope
     # scenarios were removed in PR #239 (sidecar walk semantics deleted


### PR DESCRIPTION
Bundles three demo-blockers caught in tonight's live QA. All small + targeted.

## (a) Gist messages.jsonl rotation — \`bearer_gh.py\`
Without rotation, every active room dies forever once content crosses gh's 1MB-per-file limit. Trim to last 1000 lines (or AIRC_GIST_TARGET_BYTES, default MAX/2) when content > AIRC_GIST_MAX_BYTES (default 600KB). Hysteresis between trigger + post-trim avoids the constant-trim trap (per Joel: "go PAST the number"). TDD scenario_gist_rotates_under_size_limit covers it.

## (b) #288 — peer dedup by identity, not host
\`handshake.py\` matched purely by \`host\` field; same-machine multi-tab peers (all sharing \`host: user@<ip>\`) evicted each other as new peers paired. Fix: match by X25519 pubkey (identity), with (host, airc_home) fallback for pre-Phase-E peers.

## (c) #292 — \`airc connect\` from second shell stomped the live monitor
cmd_connect auto-killed any PIDs in airc.pid before continuing — destroyed live monitors when users re-ran \`airc connect\` from another terminal to verify state. Fix: detect liveness, print a friendly pointer (status / teardown), return 0.

## Why bundled
All three are small targeted fixes for the same scenario (tomorrow's same-machine multi-tab demo). Shipping separately costs CI cycles for changes that move the same release.

## Tests
- gist_rotates_under_size_limit: 5/5 (TDD covers the new rotation logic + hysteresis)
- peers ARE the test for #288 / #292 (per Joel: "i cant test anyway, literally we are testing on canary"). Will verify post-merge by re-running the live mesh.