### PR TITLE
fix: ping/pong universal break + phantom-room sends (demo blockers)

### DIFF
--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -48,6 +48,15 @@ cmd_send() {
   # Phase 2B.3 deletes --room's re-exec path and makes --room an
   # alias for --channel.
   local channel_override=""
+  # _explicit_channel: user used --room/--channel to target a specific
+  # channel. When set, we MUST find a gist mapping for that channel —
+  # silently falling back to the scope's primary room_gist_id has the
+  # phantom-room failure mode (banner says "→ #qa-experiment", message
+  # actually goes to #general's gist with channel field "qa-experiment",
+  # no new gist ever created). User reported 2026-04-29: "I sent to
+  # #qa-experiment, #qa-sub-room-test, #x — all 'succeeded' with banner,
+  # NONE created a gist."
+  local _explicit_channel=0
   # --internal: best-effort send for internal informational broadcasts
   # ([rename], etc.) where the monitor-down guard is the wrong UX. Append
   # to the local log + return 0 even when the monitor isn't running.
@@ -70,10 +79,12 @@ cmd_send() {
       --room|-room)
         target_room="${2:-}"
         [ -z "$target_room" ] && die "Usage: airc send --room <name> <message>"
+        _explicit_channel=1
         shift 2 ;;
       --channel|-c)
         channel_override="${2:-}"
         [ -z "$channel_override" ] && die "Usage: airc send --channel <name> <message>"
+        _explicit_channel=1
         shift 2 ;;
       --internal)
         internal=1
@@ -244,8 +255,18 @@ cmd_send() {
     local room_gist_id=""
     room_gist_id=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
       --config "$CONFIG" --channel "$active_channel" 2>/dev/null || true)
-    if [ -z "$room_gist_id" ] && [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
-      room_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
+    # Phantom-room guard: when --room/--channel was used explicitly,
+    # NEVER fall back to the scope's primary room_gist_id — that publishes
+    # to the wrong gist with the right channel-tag, creating an invisible
+    # mis-route ("phantom success"). Only the no-override path falls back
+    # for back-compat with single-channel scopes.
+    if [ -z "$room_gist_id" ]; then
+      if [ "$_explicit_channel" = "1" ]; then
+        die "no gist mapping for channel '$active_channel' — run 'airc join --room $active_channel' first to create the room"
+      fi
+      if [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
+        room_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
+      fi
     fi
 
     local outcome
@@ -392,12 +413,20 @@ cmd_send() {
     fi
 
     # Route by channel via channel_gists (post-#283); fall back to the
-    # scope's primary room_gist_id so single-room hosts keep working.
+    # scope's primary room_gist_id so single-room hosts keep working —
+    # but only when the user did NOT explicitly target a different room
+    # (otherwise the fallback turns --room into a phantom success that
+    # silently mis-routes to the primary gist; see _explicit_channel).
     local _host_room_gist_id=""
     _host_room_gist_id=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
       --config "$CONFIG" --channel "$active_channel" 2>/dev/null || true)
-    if [ -z "$_host_room_gist_id" ] && [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
-      _host_room_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
+    if [ -z "$_host_room_gist_id" ]; then
+      if [ "$_explicit_channel" = "1" ]; then
+        die "no gist mapping for channel '$active_channel' — run 'airc join --room $active_channel' first to create the room"
+      fi
+      if [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
+        _host_room_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
+      fi
     fi
 
     if [ -n "$_host_room_gist_id" ]; then

--- a/lib/airc_core/monitor_formatter.py
+++ b/lib/airc_core/monitor_formatter.py
@@ -322,31 +322,33 @@ def run(my_name: str, peers_dir: str) -> int:
         # the name fresh so a mid-session rename takes effect immediately.
         if fr == current_name():
             continue
-        # Mirror inbound to the local messages.jsonl ONLY when we are a
-        # joiner (tailing the remote host). For a host the local log is
-        # already the source of truth; mirroring would create a feedback
-        # loop (tail sees line -> we append line -> tail sees it again).
-        if is_joiner:
+        # Mirror inbound to local messages.jsonl. Post-3c (gh substrate)
+        # the gist is the canonical source of truth for ALL peers — the
+        # "host" no longer has a privileged local log that everyone tails
+        # over SSH. Both hosts and joiners pull from the gist via
+        # bearer_cli recv (offset-tracked), so there is no feedback loop:
+        # the monitor never re-reads what it appended here. Without this
+        # mirror, hosts never see inbound traffic in messages.jsonl,
+        # which broke `airc ping` (cmd_ping greps the local log for
+        # [PONG:uuid] and timed out forever) and any other reader of
+        # the local audit trail.
+        try:
+            with open(local_log, "a") as f:
+                f.write(line + "\n")
+        except Exception:
+            pass
+        # Rotate every ~100 mirrored lines. Without this, local logs
+        # grow forever (Joel's audit 2026-04-28).
+        if (offset_counter % 100) == 0:
             try:
-                with open(local_log, "a") as f:
-                    f.write(line + "\n")
+                from airc_core.log import rotate_if_needed
+                rotate_if_needed(
+                    local_log,
+                    int(os.environ.get("AIRC_LOG_MAX_LINES", "5000")),
+                    int(os.environ.get("AIRC_LOG_KEEP_LINES", "2500")),
+                )
             except Exception:
                 pass
-            # Rotate every ~100 mirrored lines (cheap no-op when under
-            # threshold). Without this, joiner local logs grow forever —
-            # Joel's audit 2026-04-28. Host's log is rotated by the
-            # heartbeat loop on the host side; this is the joiner-side
-            # equivalent.
-            if (offset_counter % 100) == 0:
-                try:
-                    from airc_core.log import rotate_if_needed
-                    rotate_if_needed(
-                        local_log,
-                        int(os.environ.get("AIRC_LOG_MAX_LINES", "5000")),
-                        int(os.environ.get("AIRC_LOG_KEEP_LINES", "2500")),
-                    )
-                except Exception:
-                    pass
         if _handle_rename(peers_dir, msg):
             continue
         # Ping/pong monitor-liveness probe. Prefix marker on a normal
@@ -370,15 +372,30 @@ def run(my_name: str, peers_dir: str) -> int:
                 # Auto-reply pong via subprocess. Fire-and-forget. Uses
                 # airc send so the reply rides the same signed-message
                 # path as normal traffic (no protocol divergence).
+                # Preserve the ping's channel — without --channel the
+                # pong goes to the responder's default channel, which
+                # may be a channel the original sender doesn't poll,
+                # so cmd_ping's local-log grep times out forever even
+                # though we did reply (the channel of the original ping
+                # is already in our channel_gists or we wouldn't have
+                # received it).
+                ping_channel = m.get("channel", "")
                 import subprocess
+                cmd = ["airc", "send"]
+                if ping_channel:
+                    cmd += ["--channel", ping_channel]
+                cmd += [f"@{fr}", f"[PONG:{ping_id}]"]
                 try:
+                    # Stderr unredirected per CLAUDE.md "never swallow
+                    # errors" — auto-pong failures are exactly the kind
+                    # of evidence the next debugger needs.
                     subprocess.Popen(
-                        ["airc", "send", f"@{fr}", f"[PONG:{ping_id}]"],
+                        cmd,
                         stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
                     )
-                except Exception:
-                    pass
+                except Exception as e:
+                    sys.stderr.write(f"[airc:monitor] auto-pong spawn failed: {e}\n")
+                    sys.stderr.flush()
             # Suppress from user-visible output (control traffic),
             # regardless of whether we auto-ponged.
             continue


### PR DESCRIPTION
## Summary
- **Ping/pong universal timeout** — `monitor_formatter.py` only mirrored inbound to local `messages.jsonl` when `is_joiner=True`, leftover from SSH-tail days. Post-3c every peer polls the gist as source of truth; without the mirror, hosts never saw [PONG:] in their local log, so `cmd_ping` timed out forever even though the pong was on the wire. Fix: drop the gate, always mirror inbound.
- **Phantom-room sends** — `airc msg --room qa-experiment "hi"` silently fell back to the scope's primary `room_gist_id` and published with `channel="qa-experiment"` to the WRONG gist while the banner claimed "→ #qa-experiment (broadcast)" and no new gist was ever created. Fix: track `_explicit_channel`; when set and no `channel_gists` mapping exists, die loudly pointing at `airc join --room <name>`.
- Auto-pong now preserves the ping's `--channel` so the response returns on the originating room (not the responder's default), and stops swallowing subprocess stderr (CLAUDE.md "never swallow errors").

## Bugs found by
QA pass on canary 2026-04-29 by vhsm-d1f4 + continuum-b741 + ideem-local-4bef. 3/3 timeouts on `airc ping`, three "phantom success" rooms (qa-experiment, qa-sub-room-test, x) with zero gists created.

## Test plan
- [ ] AI peers update + retest ping with `airc ping @<peer>`
- [ ] Verify `airc msg --room newroom "hi"` now fails with the join hint instead of phantom-succeeding
- [ ] Verify `airc msg "hi"` (no override) still works on single-channel scopes