### PR TITLE
fix(bearer): pull LocalBearer from resolver — silent-loss class fix

### DIFF
--- a/lib/airc_core/bearer_resolver.py
+++ b/lib/airc_core/bearer_resolver.py
@@ -10,14 +10,25 @@ Adding a transport: import its class, add to _REGISTRY at the right
 preference position. Done. Removing a transport: delete the import and
 the registry entry. Done. No other file moves.
 
-Phase 3c (current state): registry is [LocalBearer, GhBearer]. SshBearer
-and all Tailscale knowledge are deleted. The architecture is now:
-  * Same-machine peers → LocalBearer (direct fs read/write)
-  * Everyone else → GhBearer (gh-gist as transport, polling)
-Encryption is handled at the envelope layer (lib/airc_core/envelope.py),
-making transport-layer encryption (SSH, WireGuard) redundant and letting
-us drop the install-time complexity that came with both — no more
+Phase 3c+ (current state): registry is [GhBearer] only. Encryption is
+handled at the envelope layer (lib/airc_core/envelope.py), making
+transport-layer encryption (SSH, WireGuard) redundant and letting us
+drop the install-time complexity that came with both — no more
 Windows OpenSSH-Server admin elevation, no more Tailscale daemon.
+
+LocalBearer was disabled here on 2026-04-29 after it was caught
+silently dropping every joiner-side broadcast. Its premise — "skip the
+network roundtrip when the peer is on this filesystem" — was correct
+in the SSH-tail era when the host's `messages.jsonl` was the substrate
+that joiners tailed. Post-3c the substrate is the room gist; everyone
+(host AND joiner, same-machine or not) polls the gist via bearer_cli
+recv. LocalBearer's send appended to `<host>/messages.jsonl` directly,
+which nobody reads anymore — `bearer.send()` returned `delivered`
+(file write succeeded) and the message was eaten. Bug was invisible
+because the success contract was at the wrong layer. Until LocalBearer
+is rewritten to write to the gist (or to ALSO write to the gist), it
+must not be in the registry: the gist is the only correct
+destination.
 
 Latency cost: 1-2s typical message latency (gh poll cadence) instead of
 SSH's <100ms. For chat-pace AI traffic this is invisible; if a future
@@ -30,18 +41,14 @@ from __future__ import annotations
 from typing import List, Type
 
 from .bearer import Bearer, PeerUnreachable
-from .bearer_local import LocalBearer
 from .bearer_gh import GhBearer
 
 # Preference order. Earlier = preferred. The resolver tries each in turn
 # via can_serve() and falls through on PeerUnreachable from open().
-#   LocalBearer — same-machine peers (loopback host_target + writable
-#                 remote_home). Direct filesystem; zero crypto overhead;
-#                 no network.
-#   GhBearer    — everyone else. gh-gist as transport. Encryption lives
-#                 at the envelope layer above.
+#   GhBearer — gh-gist as transport. Encryption lives at the envelope
+#              layer above. Single source of truth post-3c+ (see the
+#              module docstring for the LocalBearer history).
 _REGISTRY: List[Type[Bearer]] = [
-    LocalBearer,
     GhBearer,
 ]
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -3175,33 +3175,63 @@ except Exception:
 }
 
 scenario_bearer_local() {
-  # Phase 3a: LocalBearer serves same-machine peers via direct
-  # filesystem reads/writes — no SSH, no subprocess. This scenario
-  # builds a hand-crafted peer_meta (loopback host_target + writable
-  # local dir), exercises send + recv + liveness via the bearer
-  # interface directly, and asserts the resolver picks LocalBearer
-  # over SshBearer.
+  # LocalBearer used to serve same-machine peers via direct filesystem
+  # reads/writes — a "skip the network" optimization correct in the
+  # SSH-tail era when the host's messages.jsonl was the substrate.
+  # Pulled from the resolver registry on 2026-04-29: post-3c the gist
+  # is the substrate, and writing to the host's local file lands in a
+  # place nobody reads (silent loss every joiner-side broadcast).
   #
-  # No spawn_host/spawn_joiner here — LocalBearer's whole point is to
-  # bypass the pair handshake. Lab-style direct construction is the
-  # cleaner test for this layer.
-  section "bearer (local): same-machine send/recv via direct filesystem"
+  # This scenario now ALSO asserts the resolver does NOT route loopback
+  # peers to LocalBearer (the production-blocking guarantee). The
+  # bearer class itself is still tested via direct construction since
+  # we may revive a gh-aware variant later.
+  section "bearer (local): direct filesystem send/recv (deprecated; resolver opt-out)"
   cleanup_all
 
   local _lib_dir; _lib_dir="$(cd "$(dirname "$AIRC")/lib" && pwd)"
   local fake_home; fake_home=$(mktemp -d -t airc-it-bl-home.XXXXXX)
   local off_file; off_file="$fake_home/monitor_offset"
 
-  # Round-trip a payload via the bearer's send + verify it lands.
+  # Production guard: resolver MUST refuse to route a loopback peer to
+  # LocalBearer (would cause silent loss against the gist substrate).
+  local resolver_out
+  resolver_out=$(PYTHONPATH="$_lib_dir" python3 -c "
+import sys
+sys.path.insert(0, '$_lib_dir')
+from airc_core.bearer_resolver import resolve, available_kinds
+from airc_core.bearer import PeerUnreachable
+
+print('KINDS=' + ','.join(available_kinds()))
+try:
+    b = resolve({'host_target': 'user@127.0.0.1', 'remote_home': '$fake_home'})
+    print(f'PICKED={b.KIND}')
+except PeerUnreachable:
+    print('PICKED=none')
+" 2>&1)
+  if echo "$resolver_out" | grep -q '^KINDS=' && ! echo "$resolver_out" | grep -q 'KINDS=.*local'; then
+    pass "resolver registry no longer contains LocalBearer (post-3c+)"
+  else
+    fail "resolver registry STILL has LocalBearer — silent-loss bug returns. (got: $resolver_out)"
+  fi
+  if echo "$resolver_out" | grep -qE '^PICKED=(gh|none)$'; then
+    pass "resolver routes loopback peers away from LocalBearer (got: $(echo "$resolver_out" | grep ^PICKED=))"
+  else
+    fail "resolver picked LocalBearer for loopback peer — would cause silent loss (got: $resolver_out)"
+  fi
+
+  # Direct-construction smoke test: the LocalBearer class still works as
+  # a pure file-tail transport. Round-trip a payload through send and
+  # verify it lands on disk.
   local marker="local-bearer-send-marker-$(date +%s%N)"
   local probe='{"from":"alpha","to":"all","ts":"2026-04-29T00:00:00Z","channel":"general","msg":"'"$marker"'","sig":"x"}'
   local send_out
   send_out=$(PYTHONPATH="$_lib_dir" python3 -c "
-import sys, json
+import sys
 sys.path.insert(0, '$_lib_dir')
-from airc_core.bearer_resolver import resolve
+from airc_core.bearer_local import LocalBearer
 
-bearer = resolve({
+bearer = LocalBearer({
     'host_target': 'user@127.0.0.1',
     'remote_home': '$fake_home',
 })
@@ -3213,9 +3243,9 @@ bearer.close()
 " 2>&1)
 
   if echo "$send_out" | grep -q '^KIND=local$'; then
-    pass "resolver picks LocalBearer for loopback host_target"
+    pass "LocalBearer class still constructs (kept on disk for possible revival)"
   else
-    fail "resolver did NOT pick LocalBearer (got: $send_out)"
+    fail "LocalBearer construction failed (got: $send_out)"
     rm -rf "$fake_home"
     return
   fi
@@ -3238,9 +3268,9 @@ bearer.close()
   PYTHONPATH="$_lib_dir" python3 -c "
 import sys, signal, time, json
 sys.path.insert(0, '$_lib_dir')
-from airc_core.bearer_resolver import resolve
+from airc_core.bearer_local import LocalBearer
 
-bearer = resolve({
+bearer = LocalBearer({
     'host_target': '127.0.0.1',
     'remote_home': '$fake_home',
 })

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -75,11 +75,15 @@ class BearerInterfaceTests(unittest.TestCase):
 class ResolverTests(unittest.TestCase):
     """Resolver picks bearers based on can_serve, raises when no candidate."""
 
-    def test_available_kinds_after_phase3c(self):
+    def test_available_kinds_after_phase3c_plus(self):
         kinds = available_kinds()
-        # Post-3c registry: LocalBearer + GhBearer; SshBearer deleted.
-        self.assertEqual(set(kinds), {"local", "gh"})
+        # Post-3c+ registry: GhBearer only. LocalBearer was removed
+        # 2026-04-29 after it was caught silently dropping every
+        # joiner-side broadcast (wrote to host's local file when the
+        # substrate is the gist). SshBearer was deleted in Phase 3c.
+        self.assertEqual(set(kinds), {"gh"})
         self.assertNotIn("ssh", kinds)
+        self.assertNotIn("local", kinds)
 
     def test_unreachable_when_no_bearer_can_serve(self):
         # Empty peer_meta + no gh auth → PeerUnreachable.
@@ -87,14 +91,17 @@ class ResolverTests(unittest.TestCase):
             with self.assertRaises(PeerUnreachable):
                 resolve({})
 
-    def test_resolved_bearer_is_not_yet_open(self):
-        # LocalBearer.can_serve takes a writable dir — pick a tmpdir.
+    def test_resolver_refuses_loopback_peer_without_gist(self):
+        # Production guard: a same-machine peer without a room_gist_id
+        # is unreachable post-3c+. The old resolver routed this to
+        # LocalBearer, which silently dropped every send. Resolver
+        # MUST raise rather than route into the silent-loss path.
         import tempfile
         td = tempfile.mkdtemp()
         try:
-            bearer = resolve({"host_target": "127.0.0.1", "remote_home": td})
-            self.assertIsInstance(bearer, Bearer)
-            bearer.close()
+            with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=True):
+                with self.assertRaises(PeerUnreachable):
+                    resolve({"host_target": "127.0.0.1", "remote_home": td})
         finally:
             import shutil
             shutil.rmtree(td, ignore_errors=True)
@@ -759,11 +766,12 @@ class LocalBearerSkeletonTests(unittest.TestCase):
 
 
 class ResolverOrderTests(unittest.TestCase):
-    """Phase 3c: registry is [LocalBearer, GhBearer] — SshBearer deleted.
-    LocalBearer for same-machine peers; GhBearer for everyone else.
-    Same-machine resolution must prefer LocalBearer to avoid burning
-    gh API calls (and incurring 1-2s polling latency) for what's
-    really just a filesystem write."""
+    """Post-3c+: registry is [GhBearer] only. LocalBearer was pulled
+    2026-04-29 after it silently dropped every joiner-side broadcast
+    (wrote to host's local file when the substrate is the gist).
+    Same-machine peers must therefore route through GhBearer too —
+    paying the 1-2s polling latency is fine; sending into a void is
+    not. See bearer_resolver.py docstring for the full history."""
 
     def setUp(self):
         import tempfile
@@ -773,37 +781,40 @@ class ResolverOrderTests(unittest.TestCase):
         import shutil
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
-    def test_local_first_for_same_machine_peer(self):
-        bearer = resolve({
-            "host_target": "user@127.0.0.1",
-            "remote_home": self._tmpdir,
-        })
-        self.assertEqual(bearer.KIND, "local",
-                         "same-machine peer must resolve to LocalBearer")
+    def test_loopback_peer_without_gist_is_unreachable(self):
+        # Production-blocking guarantee: a same-machine peer with no
+        # room_gist_id MUST raise PeerUnreachable rather than silently
+        # routing to LocalBearer. This is the regression test for the
+        # silent-loss bug fixed 2026-04-29.
+        with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=True):
+            with self.assertRaises(PeerUnreachable):
+                resolve({
+                    "host_target": "user@127.0.0.1",
+                    "remote_home": self._tmpdir,
+                })
 
     def test_gh_for_remote_peer_with_room_gist(self):
-        # peer_meta has only a room_gist_id (no remote_home pointing at
-        # something locally writable). Resolver picks GhBearer.
         with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=True):
             bearer = resolve({"room_gist_id": "abc123"})
         self.assertEqual(bearer.KIND, "gh",
-                         "non-local peer with room_gist_id must resolve to GhBearer")
+                         "peer with room_gist_id must resolve to GhBearer")
 
-    def test_gh_when_loopback_target_but_no_local_dir(self):
-        # Stale loopback record without remote_home → LocalBearer
-        # rejects → fall through to GhBearer (if room_gist_id present).
+    def test_gh_for_loopback_peer_with_room_gist(self):
+        # Same-machine peer that has a room_gist_id resolves to gh
+        # (not local). Locality is informational; the gist is the
+        # substrate.
         with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=True):
             bearer = resolve({
                 "host_target": "user@127.0.0.1",
-                "remote_home": "/this/path/definitely/does/not/exist",
+                "remote_home": self._tmpdir,
                 "room_gist_id": "abc123",
             })
         self.assertEqual(bearer.KIND, "gh")
 
-    def test_available_kinds_local_then_gh(self):
+    def test_available_kinds_gh_only(self):
         from airc_core.bearer_resolver import available_kinds
         kinds = available_kinds()
-        self.assertEqual(kinds, ["local", "gh"])
+        self.assertEqual(kinds, ["gh"])
 
 
 class GhBearerCanServeTests(unittest.TestCase):
@@ -1109,15 +1120,16 @@ class GhBearerSkeletonTests(unittest.TestCase):
             b.send("alice", "general", b'{"x":1}')
 
 
-class ResolverPostPhase3cTests(unittest.TestCase):
-    """Phase 3c: registry is [LocalBearer, GhBearer]. Same-machine →
-    Local; everyone else with a room_gist_id → Gh. SshBearer deleted."""
+class ResolverPostPhase3cPlusTests(unittest.TestCase):
+    """Post-3c+: registry is [GhBearer] only. LocalBearer pulled
+    2026-04-29 (silent-loss bug). SshBearer deleted in Phase 3c."""
 
-    def test_available_kinds_local_and_gh_only(self):
+    def test_available_kinds_gh_only(self):
         from airc_core.bearer_resolver import available_kinds
         kinds = available_kinds()
-        self.assertEqual(set(kinds), {"local", "gh"})
+        self.assertEqual(set(kinds), {"gh"})
         self.assertNotIn("ssh", kinds)
+        self.assertNotIn("local", kinds)
 
     def test_gh_picked_when_only_room_gist_id(self):
         # peer_meta has only room_gist_id + gh auth available → GhBearer.
@@ -1125,9 +1137,8 @@ class ResolverPostPhase3cTests(unittest.TestCase):
             bearer = resolve({"room_gist_id": "abc123"})
         self.assertEqual(bearer.KIND, "gh")
 
-    def test_unreachable_when_no_gh_auth_and_no_other_meta(self):
-        # Nothing can serve: no loopback (Local declines), no gh auth
-        # (Gh declines).
+    def test_unreachable_when_no_gh_auth(self):
+        # Without gh auth, nothing can serve.
         with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=False):
             with self.assertRaises(PeerUnreachable):
                 resolve({"room_gist_id": "abc123"})


### PR DESCRIPTION
## Summary
Caught in production on canary 2026-04-29: every joiner-side broadcast was vanishing. \`airc msg --room general\` from a joiner returned success banner, landed in local audit log, but the room gist was never updated — peers polling the gist saw nothing for hours.

Root cause: \`bearer_resolver.resolve()\` picked LocalBearer for any peer whose \`remote_home\` was a writable local directory. LocalBearer's send appended directly to \`<host>/messages.jsonl\` and returned \`{"kind":"delivered"}\` — correct in the SSH-tail era when joiners tailed the host's file, **wrong** post-3c when the gist is the substrate.

Fix: remove LocalBearer from \`_REGISTRY\`. Everyone (including same-machine peers) routes through GhBearer. Latency goes from ~10ms to ~1-2s for same-machine peers — imperceptible at chat pace, vastly better than silent loss. LocalBearer the class stays on disk for possible revival as a gh-aware variant.

## Coverage
- \`test_bearer.py\`: \`ResolverOrderTests\` now asserts loopback peers without \`room_gist_id\` **raise \`PeerUnreachable\`** (regression guard); \`available_kinds()\` is \`['gh']\` only.
- \`integration.sh\` \`scenario_bearer_local\`: asserts resolver registry no longer contains LocalBearer + resolver does NOT route loopback peers to it. Bearer-class tests now use direct construction.
- 62/62 \`test_bearer.py\` unit tests pass.

## Test plan
- [ ] Joiner runs \`airc msg --room general "ping"\` — message appears in the gist (verifiable via \`gh api gists/<id>\`)
- [ ] Same-machine peer with no \`room_gist_id\` in their config gets a clear \`PeerUnreachable\` rather than silent success
- [ ] Existing \`scenario_bearer_gh\` still passes (GhBearer round-trip unaffected)