### PR TITLE
fix(heartbeat): correct gist filename — closes the false-eviction loop

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1363,7 +1363,22 @@ print(json.dumps(chans))
 }
 JSON
 )
-                local _hb_tmp; _hb_tmp=$(mktemp -t airc-hb.XXXXXX)
+                # Heartbeat target file basename MUST match the canonical
+                # in-gist filename (`airc-room-<channel>.json` per
+                # channel_gist.py). When the gist has multiple files
+                # (messages.jsonl + the room-metadata JSON) and we pass
+                # gh a path with a basename that matches NEITHER, gh
+                # errors with "unsure what file to edit; either specify
+                # --filename or run interactively" — heartbeat fails N
+                # times in a row and the host self-evicts (deletes its
+                # own gist + respawns) when nothing was actually wrong.
+                # That eviction loop is the surface ideem-local-4bef
+                # root-caused 2026-04-29; it's also what nuked the
+                # #useideem gist mid-ping-debug. Ensuring the temp
+                # basename matches the canonical filename closes the
+                # whole convergent class.
+                local _hb_tmpdir; _hb_tmpdir=$(mktemp -d -t airc-hb.XXXXXX)
+                local _hb_tmp="${_hb_tmpdir}/airc-room-${_hb_room}.json"
                 printf '%s\n' "$_hb_payload" > "$_hb_tmp"
                 # Rotate the host's messages.jsonl when it exceeds the
                 # AIRC_LOG_MAX_LINES threshold (default 5000). Trims
@@ -1401,7 +1416,7 @@ JSON
                     exit 0
                   fi
                 fi
-                rm -f "$_hb_tmp"
+                rm -rf "$_hb_tmpdir"
               done
             ) &
             local _hb_pid=$!

--- a/lib/airc_bash/mesh.sh
+++ b/lib/airc_bash/mesh.sh
@@ -72,25 +72,34 @@ _mesh_find() {
 
 # Publish a new mesh gist. Echoes the new gist id, or empty on failure.
 # Caller writes the JSON envelope to a tempfile and passes the path.
+# Per CLAUDE.md "never swallow errors": gh's stderr (auth lapsed, rate
+# limited, etc) reaches the terminal so failures are diagnosable
+# instead of "create returned empty, no idea why."
 _mesh_publish() {
   local payload_path="${1:-}"
   [ -f "$payload_path" ] || return 1
   command -v gh >/dev/null 2>&1 || return 1
   local desc; desc=$(_mesh_desc)
-  local url; url=$(gh gist create -d "$desc" "$payload_path" 2>/dev/null | tail -1)
+  local url; url=$(gh gist create -d "$desc" "$payload_path" | tail -1)
   [ -z "$url" ] && return 1
   printf '%s\n' "${url##*/}"
 }
 
 # Update an existing mesh gist with a new payload. Used by the heartbeat
 # loop. Returns 0 on success, non-zero if the gist is gone or auth lapsed.
-# Caller passes the gist_id and a path to the new JSON envelope.
+# Caller passes the gist_id and a path to the new JSON envelope. The
+# basename of payload_path MUST match the canonical in-gist filename
+# (e.g. airc-room-<channel>.json) — gh disambiguates targets by
+# basename, and a mismatched basename on a multi-file gist surfaces
+# as "unsure what file to edit" with non-zero exit. Per CLAUDE.md
+# "never swallow errors", stderr propagates to the terminal so the
+# next debugger sees the actual failure.
 _mesh_update() {
   local gist_id="${1:-}" payload_path="${2:-}"
   [ -n "$gist_id" ] || return 1
   [ -f "$payload_path" ] || return 1
   command -v gh >/dev/null 2>&1 || return 1
-  gh gist edit "$gist_id" "$payload_path" >/dev/null 2>&1
+  gh gist edit "$gist_id" "$payload_path" >/dev/null
 }
 
 # Echo the seconds since last_heartbeat in the given mesh gist. Empty


### PR DESCRIPTION
## Summary
Convergent root cause for two surfaces ideem-local-4bef caught in QA 2026-04-29:
1. Heartbeat fails 3x → host self-evicts → deletes own gist → all peers lose the room (this wiped #useideem mid-ping-debug today)
2. Outbound \`airc msg\` queues for retry with bearer error: \"unsure what file to edit\"

Both stem from \`mktemp -t airc-hb.XXXXXX\` producing a basename that matches NEITHER file in post-#283 per-channel gists (\`messages.jsonl\` + \`airc-room-<channel>.json\`). gh refuses to disambiguate, heartbeat fails, false eviction fires.

Fix: heartbeat temp file basename now matches the canonical \`airc-room-<channel>.json\` filename. gh basename-match resolves. Also stop swallowing stderr in \`mesh.sh\` (\`_mesh_publish\` + \`_mesh_update\`) per CLAUDE.md \"never swallow errors\".

## Test plan
- [ ] Host runs for 5+ heartbeat cycles without false eviction (\`tail -f .airc/heartbeat_stderr\` stays empty)
- [ ] Joiner peers don't see \`[HOST EVICTED]\` markers in normal operation
- [ ] \`airc ping @<peer>\` round-trips before the gist is reaped
- [ ] If heartbeat genuinely fails (e.g. gist deleted by user), the actual gh error reaches the heartbeat_stderr file (no longer swallowed in mesh.sh)