### PR TITLE
fix: custom rooms — helper extraction + --room preservation across self-heal

### DIFF
--- a/airc
+++ b/airc
@@ -328,25 +328,46 @@ AIRC_WRITE_DIR="$(detect_scope)"
 # Replaces 5 duplicated 3-line call sites in cmd_connect (#205 target 1).
 _reexec_into() {
   local mode="$1"; shift  # "rejoin" or "host"
-  printf '%d:%d\n' "$$" "$(date +%s)" > "$AIRC_WRITE_DIR/airc.reexec-marker" 2>/dev/null || true
+  # Best-effort: write the reexec sentinel marker. The .airc dir may
+  # have been wiped by self-heal; tolerate missing parent. Without the
+  # marker the daemon launcher (#203) can't tell intentional reexec
+  # from a crash, but the reexec itself still works — silent no-op
+  # here is the right tradeoff vs. failing the takeover.
+  if [ -d "$AIRC_WRITE_DIR" ]; then
+    printf '%d:%d\n' "$$" "$(date +%s)" > "$AIRC_WRITE_DIR/airc.reexec-marker" 2>/dev/null || true
+  fi
   local _name; _name=$(get_config_val name "")
+  # Preserve user's --room intent across exec when set (see
+  # _self_heal_stale_host). Without this, an explicit `airc join --room
+  # qa-foo` that triggers stale-host takeover loses --room and
+  # auto-scope decides instead.
+  local _intent="${AIRC_ROOM_INTENT:-}"
   if [ "$mode" = "host" ]; then
-    exec env AIRC_NO_DISCOVERY=1 ${_name:+AIRC_NAME="$_name"} "$0" connect "$@"
+    exec env AIRC_NO_DISCOVERY=1 \
+      ${_name:+AIRC_NAME="$_name"} \
+      ${_intent:+AIRC_ROOM_INTENT="$_intent"} \
+      "$0" connect "$@"
   else
-    exec env ${_name:+AIRC_NAME="$_name"} "$0" connect "$@"
+    exec env \
+      ${_name:+AIRC_NAME="$_name"} \
+      ${_intent:+AIRC_ROOM_INTENT="$_intent"} \
+      "$0" connect "$@"
   fi
 }
 
-# Stale-host self-heal + race-loser detection. Args: $1=stale gist id,
-# $2=room name. Random jitter, delete stale, re-list to see if another
-# tab self-healed first; if yes rejoin theirs, else take over as host.
-# Always exec's via _reexec_into; does not return. Wipes $CONFIG +
-# room_name first since both pointed at the dead host. Replaces 2
-# duplicated 22-line blocks in cmd_connect (#205 target 4).
+# Stale-host self-heal + race-loser detection. Args: $1=stale gist id.
+# Random jitter, delete stale, re-list to see if another tab self-healed
+# first; if yes rejoin theirs, else take over as host. Always exec's via
+# _reexec_into; does not return.
+#
+# User intent preservation across re-exec: pre-2026-04-29 this wiped
+# room_name + reexec'd with NO ARGS, which silently dropped the user's
+# `--room <name>` flag — auto-scope then took over and the user landed
+# on a different (cwd-derived) room than they asked for. Now we save
+# the explicit --room intent into AIRC_ROOM_INTENT before wiping local
+# state, restore it via env across the exec, and the post-exec arg
+# parser respects it as if the user had passed `--room` again.
 _self_heal_stale_host() {
-  # Mesh-gist takeover. Inputs: stale_id only — the room_name argument
-  # from the per-room era is gone; mesh is per-account singleton, so
-  # there's nothing to discriminate on.
   local stale_id="$1"
   local jitter; jitter=$(awk -v r="$RANDOM" 'BEGIN{printf "%.3f", 0.1 + (r%1500)/1000}')
   sleep "$jitter"
@@ -355,11 +376,19 @@ _self_heal_stale_host() {
   else
     echo "  ⚠  Stale mesh gist already gone — another tab may have taken over first."
   fi
+  # Capture the user's --room intent BEFORE wiping room_name. Caller
+  # sets ROOM_INTENT_FOR_REEXEC in the cmd_connect frame whenever the
+  # explicit --room flag was used; anywhere else it's empty and we
+  # reexec without the override (auto-scope decides as usual).
+  local _saved_intent="${ROOM_INTENT_FOR_REEXEC:-}"
   # _mesh_find returns the singleton mesh gist (oldest-by-created if
   # multiple are present from a race). If something is there, another
   # tab beat us — rejoin pointed at it.
   local picked; picked=$(_mesh_find)
   rm -f "$CONFIG" "$AIRC_WRITE_DIR/room_name"
+  if [ -n "$_saved_intent" ]; then
+    export AIRC_ROOM_INTENT="$_saved_intent"
+  fi
   if [ -n "$picked" ] && [ "$picked" != "$stale_id" ]; then
     echo "  ✓ Another tab beat us to it — joining their fresh mesh gist ($picked)"
     echo ""
@@ -797,21 +826,11 @@ spawn_general_sidecar_if_wanted() {
 
   echo "  Also subscribing to #general (--no-general to opt out)"
 
-  # 1. Subscribe in config.
-  "$AIRC_PYTHON" -m airc_core.config subscribe \
-    --config "$CONFIG" --channel general 2>/dev/null || true
-
-  # 2. Resolve the canonical #general gist on this gh account
-  #    (find existing or create new). Reuses the same find-or-create
-  #    discovery that the primary room bootstrap goes through.
+  # Subscribe + resolve-or-create + persist mapping. Same dance every
+  # channel-add path runs (helper extracted in cmd_connect.sh, post
+  # 2026-04-29 custom-rooms refactor).
   local _general_gid
-  _general_gid=$("$AIRC_PYTHON" -m airc_core.channel_gist resolve \
-    --channel general --create-if-missing 2>/dev/null || true)
-
-  if [ -n "$_general_gid" ]; then
-    # 3. Persist channel→gist mapping so cmd_send + monitor can route.
-    "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
-      --config "$CONFIG" --channel general --gist-id "$_general_gid" 2>/dev/null || true
+  if _general_gid=$(ensure_channel_subscribed_with_gist general); then
     echo "    #general gist: $_general_gid"
   else
     echo "  ⚠ Could not resolve #general gist (no gh auth?). #general subscription is config-only; cross-room messaging won't work until resolved." >&2

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -22,6 +22,75 @@
 # heartbeat are clearly separable), but step 1 is splitting it out of
 # the top-level monolith without changing behavior.
 
+# ensure_channel_subscribed_with_gist <channel> [--first]
+#
+# Single-concern helper: make this scope a fully-functional subscriber
+# of <channel>. Three steps that MUST happen together — pre-2026-04-29
+# they were inlined at 4+ call sites, the divergent-room path silently
+# omitted step 2, and custom rooms became uncreatable. Centralized so
+# every call site does the right thing; future channel-add paths just
+# call this.
+#
+#   1. Subscribe in config (subscribed_channels[]).
+#      --first: prepend (sets the scope's default channel).
+#      default: append.
+#   2. Resolve-or-create the canonical gist for the channel on the
+#      user's gh account (airc_core.channel_gist resolve
+#      --create-if-missing). Idempotent across runs.
+#   3. Persist the channel→gist mapping in channel_gists{} so cmd_send's
+#      route-by-channel and the multi-channel monitor's per-channel
+#      bearer_cli recv both have a destination.
+#
+# Echoes the gist id on success. Empty (and non-zero exit) on failure;
+# caller decides whether that's fatal — the #general sidecar path
+# treats it as a warning, the primary-room path treats it as fatal.
+#
+# Per CLAUDE.md "never swallow errors": stderr from the python
+# subprocesses is redirected to a status file, then echoed if non-empty
+# on failure. Routine 2>/dev/null suppression would have hidden the
+# heartbeat-multifile bug for another sprint.
+ensure_channel_subscribed_with_gist() {
+  local channel="${1:-}" mode="${2:-append}"
+  if [ -z "$channel" ]; then
+    echo "ensure_channel_subscribed_with_gist: missing channel arg" >&2
+    return 2
+  fi
+
+  local _err; _err=$(mktemp -t airc-ensure-ch.XXXXXX)
+  trap '[ -n "${_err:-}" ] && rm -f "$_err"' RETURN
+
+  # 1. Subscribe in config.
+  local _first_flag=""
+  [ "$mode" = "--first" ] && _first_flag="--first"
+  if ! "$AIRC_PYTHON" -m airc_core.config subscribe \
+       --config "$CONFIG" --channel "$channel" $_first_flag 2>"$_err"; then
+    echo "  ⚠ Could not subscribe to #${channel}:" >&2
+    [ -s "$_err" ] && sed 's/^/      /' "$_err" >&2
+    return 1
+  fi
+
+  # 2. Resolve-or-create the canonical gist on this gh account.
+  local _gid
+  _gid=$("$AIRC_PYTHON" -m airc_core.channel_gist resolve \
+         --channel "$channel" --create-if-missing 2>"$_err")
+  if [ -z "$_gid" ]; then
+    echo "  ⚠ Could not resolve gist for #${channel}:" >&2
+    [ -s "$_err" ] && sed 's/^/      /' "$_err" >&2
+    return 1
+  fi
+
+  # 3. Persist channel→gist mapping for cmd_send + monitor routing.
+  if ! "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
+       --config "$CONFIG" --channel "$channel" --gist-id "$_gid" 2>"$_err"; then
+    echo "  ⚠ Could not persist channel→gist mapping for #${channel}:" >&2
+    [ -s "$_err" ] && sed 's/^/      /' "$_err" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$_gid"
+  return 0
+}
+
 cmd_connect() {
   # Flag parsing. Issue #37 — host display shapes:
   #   default (gh installed + authed): gist ID + humanhash mnemonic + long invite
@@ -56,6 +125,19 @@ cmd_connect() {
   local room_name="general"
   local room_explicit=0  # set to 1 when user passes --room explicitly
   local use_room=1   # default ON — auto-#general substrate
+
+  # AIRC_ROOM_INTENT: re-exec env var preserving the user's --room
+  # across a stale-host-takeover exec. Pre-fix this was lost on every
+  # self-heal: user typed `airc join --room qa-foo`, we exec'd back
+  # into `airc connect` with NO ARGS, auto-scope decided based on cwd
+  # instead. Treat the env var as if --room was passed (since it was,
+  # one process ago).
+  if [ -n "${AIRC_ROOM_INTENT:-}" ] && [ "$room_explicit" = "0" ]; then
+    room_name="$AIRC_ROOM_INTENT"
+    use_room=1
+    room_explicit=1
+    unset AIRC_ROOM_INTENT  # one-shot — don't pollute child invocations
+  fi
   local general_sidecar=1   # default ON (issue #121) — also subscribe to #general
   local _force_general_sidecar=0   # set by --general flag (issue #136 re-opt-in)
   # Recursion guard: when WE are the sidecar (spawned by another airc
@@ -110,7 +192,14 @@ cmd_connect() {
         return 0 ;;
       --gist|-gist) use_gist=1; shift ;;
       --no-gist|-no-gist) use_gist=0; shift ;;
-      --room|-room) room_name="${2:-general}"; use_room=1; room_explicit=1; shift 2 ;;
+      --room|-room)
+        room_name="${2:-general}"
+        use_room=1
+        room_explicit=1
+        # Stash for re-exec preservation. Read by _self_heal_stale_host
+        # in airc top-level when a stale-host-takeover happens mid-flow.
+        ROOM_INTENT_FOR_REEXEC="$room_name"
+        shift 2 ;;
       --no-room|-no-room) use_room=0; shift ;;
       --no-general|-no-general)
         # NEW semantic (issue #121): keep the project room substrate,
@@ -132,6 +221,7 @@ cmd_connect() {
         # Combo: explicit project room + skip general sidecar. For
         # focused work where lobby noise would distract.
         room_name="${2:-general}"; use_room=1; room_explicit=1; general_sidecar=0
+        ROOM_INTENT_FOR_REEXEC="$room_name"  # preserve across self-heal exec
         shift 2 ;;
       --no-tailscale|-no-tailscale)
         # Opt out of Tailscale entirely: skips the login prompt AND
@@ -799,18 +889,20 @@ cmd_connect() {
       local _intent="$room_name"
       if [ -z "$_intent" ] || [ "$_intent" = "$resolved_room_name" ]; then
         echo "$resolved_room_name" > "$AIRC_WRITE_DIR/room_name"
-        "$AIRC_PYTHON" -m airc_core.config subscribe \
-          --config "$CONFIG" --channel "$resolved_room_name" --first 2>/dev/null || true
+        ensure_channel_subscribed_with_gist "$resolved_room_name" --first >/dev/null \
+          || die "Could not bootstrap #${resolved_room_name}; refusing to join with broken state"
         echo "  Joined #${resolved_room_name}"
       else
         # Diverged: user wanted X, host advertises Y. Subscribe to both,
         # X first (default for cmd_send), Y appended (display shows
-        # host's channel traffic too).
+        # host's channel traffic too). The user's intent gets a real
+        # gist (find-or-create) — that's what was missing pre-2026-04-29
+        # and turned `airc join --room qa-foo` into a phantom-room.
         echo "$_intent" > "$AIRC_WRITE_DIR/room_name"
-        "$AIRC_PYTHON" -m airc_core.config subscribe \
-          --config "$CONFIG" --channel "$_intent" --first 2>/dev/null || true
-        "$AIRC_PYTHON" -m airc_core.config subscribe \
-          --config "$CONFIG" --channel "$resolved_room_name" 2>/dev/null || true
+        ensure_channel_subscribed_with_gist "$_intent" --first >/dev/null \
+          || die "Could not bootstrap #${_intent}; refusing to join with broken state"
+        ensure_channel_subscribed_with_gist "$resolved_room_name" >/dev/null \
+          || echo "  ⚠ Could not bootstrap host's channel #${resolved_room_name}; subscribed to #${_intent} only" >&2
         echo "  Joined mesh — host primarily labels #${resolved_room_name}; subscribed: #${_intent} (default), #${resolved_room_name}"
       fi
       # Identity bootstrap nudge (#146). Skill /join SKILL.md prompts

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -3174,6 +3174,35 @@ except Exception:
   cleanup_all
 }
 
+scenario_custom_room_creates_gist() {
+  # Regression for the 2026-04-29 "phantom-room" + "auto-scope override"
+  # convergence: `airc join --room <new>` from a fresh scope must
+  # actually create a gist for <new>, set channel_gists[<new>], and
+  # subscribe in config — not silently fall back to git-org auto-scope
+  # or leave channel_gists empty.
+  section "custom room: airc join --room <new> creates the gist + mapping"
+  command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1 || { echo "  (skipped — gh not authed)"; return; }
+  cleanup_all
+  local rname="tdd-custom-room-$$"
+  local home; home=$(mktemp -d -t airc-it-customroom.XXXXXX)
+  ( cd "$home" && AIRC_HOME="$home/state" AIRC_NAME=tdd-cr-$$ AIRC_PORT=7565 AIRC_NO_DISCOVERY=1 AIRC_NO_AUTO_ROOM=1 \
+      "$AIRC" connect --room "$rname" --no-general > "$home/out.log" 2>&1 & )
+  local i; for i in 1 2 3 4 5 6 7 8; do sleep 1; [ -f "$home/state/config.json" ] && break; done
+  sleep 2
+  local gid; gid=$(python3 -c "import json,sys;print(json.load(open('$home/state/config.json')).get('channel_gists',{}).get('$rname',''))" 2>/dev/null)
+  trap "[ -n '$gid' ] && gh gist delete '$gid' --yes 2>/dev/null || true" EXIT
+  if [ -n "$gid" ]; then pass "channel_gists['$rname'] = $gid"; else fail "channel_gists['$rname'] empty — phantom room"; cleanup_all; return; fi
+  gh api "gists/$gid" --jq '.id' >/dev/null 2>&1 && pass "gist actually exists on gh" || fail "gist id present but gh has no such gist"
+  local marker="tdd-cr-$$"
+  AIRC_HOME="$home/state" "$AIRC" msg --room "$rname" "$marker" >/dev/null 2>&1
+  sleep 2
+  gh api "gists/$gid" --jq '.files["messages.jsonl"].content // ""' 2>/dev/null | grep -q "$marker" \
+    && pass "broadcast to #$rname landed in its gist" \
+    || fail "broadcast to #$rname did NOT land — channel routing broken"
+  trap - EXIT; gh gist delete "$gid" --yes 2>/dev/null || true
+  cleanup_all
+}
+
 scenario_bearer_local() {
   # LocalBearer used to serve same-machine peers via direct filesystem
   # reads/writes — a "skip the network" optimization correct in the
@@ -3734,6 +3763,7 @@ case "$MODE" in
   general_has_shared_gist) scenario_general_has_shared_gist ;;
   channel_gist_prefers_single_channel) scenario_channel_gist_prefers_single_channel ;;
   gist_rotates_under_size_limit) scenario_gist_rotates_under_size_limit ;;
+  custom_room_creates_gist) scenario_custom_room_creates_gist ;;
   ""|all)
     # Default = run everything. The peers_cross_scope + whois_cross_scope
     # scenarios were removed in PR #239 (sidecar walk semantics deleted
@@ -3752,6 +3782,7 @@ case "$MODE" in
     scenario_bearer_ssh_send; scenario_bearer_ssh_recv; scenario_bearer_cli_recv
     scenario_bearer_observability; scenario_bearer_local; scenario_bearer_gh
     scenario_e2e_encryption
+    scenario_custom_room_creates_gist
     ;;
   *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|all]"; exit 2 ;;
 esac


### PR DESCRIPTION
## Summary
Two stacked bugs blocked \`airc join --room <new-name>\` from actually creating a room:

1. **3-step dance inlined 4+ places, divergent path missing step 2.** \`subscribe + resolve-or-create gist + persist mapping\` was copy-pasted across the codebase; the divergent-joiner path silently skipped the resolve-or-create. User's --room intent went into config but no gist ever existed for it. Extracted \`ensure_channel_subscribed_with_gist\` helper; all paths call it now.
2. **\`_self_heal_stale_host\` dropped \`--room\` across re-exec.** \`_reexec_into host\` was called with NO args, plus room_name file was wiped pre-exec. User's \`--room qa-foo\` got lost; auto-scope.cwd took over. Now preserved via \`AIRC_ROOM_INTENT\` env var.

## TDD
\`scenario_custom_room_creates_gist\`: bootstrap scope with \`--room <new>\`, assert channel_gists[new] is set + gist exists on gh + broadcast actually lands in its messages.jsonl. None of these assertions existed before — exactly the test gap Joel called out (\"weird how these integration tests never tested basic stuff\").

Closes #298 (--room override).

## Follow-up filed
integration.sh is 4000 lines of inlined dance — needs splitting into \`test/scenarios/<concern>.sh\`. Separate PR; this one doesn't add to the slop (25 lines vs file's average 90 per scenario).