### PR TITLE
fix(#299, follow-up): drop If-Match, use verify-after-write

### DIFF
--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -137,96 +137,39 @@ def _gh_api_get(gist_id: str) -> Optional[dict]:
         return None
 
 
-def _gh_api_get_with_etag(gist_id: str) -> Optional[tuple[dict, str]]:
-    """Like _gh_api_get but also returns the ETag for conditional PATCH.
+def _gh_api_patch_messages_jsonl(gist_id: str, content: str) -> tuple[bool, str]:
+    """PATCH gists/<id> with messages.jsonl=content via gh api.
 
-    Implementation: `gh api -i` includes response headers in stdout
-    before the JSON body (RFC 7230 — headers, blank line, body).
-    Parse the ETag header; the body is everything after the first
-    blank line.
+    Returns (ok, detail). No If-Match: GitHub's gists PATCH endpoint
+    EXPLICITLY rejects conditional request headers ("Conditional
+    request headers are not allowed in unsafe requests unless
+    supported by the endpoint"), confirmed empirically 2026-04-29.
+    Concurrency control is the caller's problem (see GhBearer.send's
+    verify-after-write loop).
 
-    Returns (gist_dict, etag) on success, None on any failure. Empty
-    etag string is acceptable — caller will skip If-Match and accept
-    the lost-write risk; that mirrors pre-2026-04-29 behavior, used
-    only when this helper degrades gracefully on older gh CLI versions
-    that don't surface headers cleanly.
-    """
-    try:
-        gh = _resolve_gh_bin()
-    except GhBearerError:
-        return None
-    try:
-        r = subprocess.run(
-            [gh, "api", "-i", f"gists/{gist_id}"],
-            capture_output=True,
-            text=True,
-            timeout=_GH_API_TIMEOUT,
-        )
-    except (subprocess.TimeoutExpired, OSError):
-        return None
-    if r.returncode != 0:
-        return None
-    head, _, body = r.stdout.partition("\r\n\r\n")
-    if not body:
-        head, _, body = r.stdout.partition("\n\n")
-    etag = ""
-    for line in head.splitlines():
-        if line.lower().startswith("etag:"):
-            etag = line.split(":", 1)[1].strip()
-            break
-    try:
-        return (json.loads(body), etag)
-    except (ValueError, TypeError):
-        return None
-
-
-def _gh_api_patch_messages_jsonl(
-    gist_id: str, content: str, etag: str
-) -> tuple[bool, int, str]:
-    """PATCH gists/<id> with messages.jsonl=content and If-Match: <etag>.
-
-    Returns (ok, http_status, detail).
-      ok=True              — write landed (status 200)
-      ok=False, status=412 — conflict, ETag stale, caller retries
-      ok=False, other      — fatal-ish, caller surfaces
-
-    Empty etag → unconditional write (no If-Match header). That's the
-    fallback when _gh_api_get_with_etag couldn't parse the ETag; same
-    last-writer-wins risk as pre-fix, but at least the call still
-    works. Loud-fail would be worse here than degrade.
+    Body is built via json.dumps so the file content's newlines /
+    quotes / unicode are properly escaped — embedded literal newlines
+    in the JSON string would silently 400.
     """
     try:
         gh = _resolve_gh_bin()
     except GhBearerError as e:
-        return (False, 0, str(e))
+        return (False, str(e))
     body = json.dumps({"files": {_MESSAGES_FILE: {"content": content}}})
-    argv = [gh, "api", "--method", "PATCH", "-i", f"gists/{gist_id}", "--input", "-"]
-    if etag:
-        argv += ["-H", f"If-Match: {etag}"]
     try:
         r = subprocess.run(
-            argv,
+            [gh, "api", "--method", "PATCH", f"gists/{gist_id}", "--input", "-"],
             input=body,
             capture_output=True,
             text=True,
             timeout=_GH_API_TIMEOUT,
         )
     except (subprocess.TimeoutExpired, OSError) as e:
-        return (False, 0, f"gh api PATCH failed: {e}")
-    # Parse status line from headers (HTTP/1.1 <code> <msg>\r\n...).
-    head = r.stdout.split("\r\n\r\n", 1)[0] if "\r\n\r\n" in r.stdout else \
-           r.stdout.split("\n\n", 1)[0]
-    status = 0
-    for line in head.splitlines():
-        if line.startswith("HTTP/"):
-            parts = line.split()
-            if len(parts) >= 2 and parts[1].isdigit():
-                status = int(parts[1])
-            break
-    if r.returncode == 0 and 200 <= status < 300:
-        return (True, status, "")
+        return (False, f"gh api PATCH failed: {e}")
+    if r.returncode == 0:
+        return (True, "")
     err = (r.stderr or r.stdout or "gh api PATCH failed").strip()
-    return (False, status, err)
+    return (False, err)
 
 
 def _rotate_if_needed(content: str) -> str:
@@ -469,44 +412,55 @@ class GhBearer(Bearer):
                 detail="payload is not utf-8; gh-bearer requires text envelopes",
             )
 
+        # Concurrency strategy: verify-after-write. GitHub's gists PATCH
+        # doesn't support If-Match (returns 400), so optimistic
+        # concurrency must be detected POST-write by re-reading and
+        # checking that our framed line is present. If it isn't, another
+        # peer's write clobbered ours between our read and our PATCH —
+        # retry with fresh content. Cost: 1 extra GET per send. Benefit:
+        # no silent loss on concurrent traffic.
         RETRIES = 4
         last_detail = ""
         for attempt in range(RETRIES):
-            result = _gh_api_get_with_etag(gist_id)
-            if result is None:
-                # GET-with-headers failed; fall back to plain GET +
-                # unconditional PATCH (degraded mode, last-writer-wins).
-                gist = _gh_api_get(gist_id)
-                if gist is None:
-                    return SendOutcome(
-                        kind="transient_failure",
-                        detail=f"could not fetch gist {gist_id} (rate limit, network, or auth)",
-                    )
-                etag = ""
-            else:
-                gist, etag = result
-
+            gist = _gh_api_get(gist_id)
+            if gist is None:
+                return SendOutcome(
+                    kind="transient_failure",
+                    detail=f"could not fetch gist {gist_id} (rate limit, network, or auth)",
+                )
             existing = _read_messages_content(gist)
             new_content = _rotate_if_needed(existing) + framed_str
 
-            ok, status, detail = _gh_api_patch_messages_jsonl(gist_id, new_content, etag)
-            if ok:
+            ok, detail = _gh_api_patch_messages_jsonl(gist_id, new_content)
+            if not ok:
+                last_detail = detail
+                lower = detail.lower()
+                if "permission" in lower or "401" in lower or "not found" in lower or "404" in lower:
+                    return SendOutcome(kind="auth_failure", detail=detail)
+                return SendOutcome(kind="transient_failure", detail=detail)
+
+            # Verify our line landed. If a concurrent writer's PATCH
+            # arrived after our GET but before ours, our PATCH replaced
+            # the whole file with content that doesn't include their
+            # line — and on read-back we'd see THEIR line missing too,
+            # but we only check OUR line because we don't know what
+            # else was in flight. Worst case the racer also retries
+            # and sees us; bounded by RETRIES.
+            verify = _gh_api_get(gist_id)
+            if verify is None:
+                # Verify GET failed but PATCH succeeded — assume delivered;
+                # next send will re-read fresh state. Don't retry blindly.
                 return SendOutcome(kind="delivered", detail="")
-            last_detail = detail
-            if status == 412:
-                # Another peer wrote between our GET and PATCH — retry
-                # with fresh ETag. Tiny backoff so concurrent retriers
-                # don't lockstep.
-                _time.sleep(0.05 * (attempt + 1))
-                continue
-            lower = detail.lower()
-            if "permission" in lower or status == 401 or "not found" in lower or status == 404:
-                return SendOutcome(kind="auth_failure", detail=detail)
-            return SendOutcome(kind="transient_failure", detail=detail)
+            if framed_str.rstrip("\n") in _read_messages_content(verify):
+                return SendOutcome(kind="delivered", detail="")
+            # Our line isn't there → got clobbered. Retry with fresh
+            # state. Tiny backoff so concurrent retriers don't lockstep.
+            last_detail = "verify-after-write: line not in gist post-PATCH (concurrent clobber)"
+            _time.sleep(0.05 * (attempt + 1))
 
         return SendOutcome(
             kind="transient_failure",
-            detail=f"ETag conflict after {RETRIES} retries (room very busy?); last: {last_detail}",
+            detail=f"clobbered by concurrent writers after {RETRIES} retries; last: {last_detail}",
         )
 
     def recv_stream(self) -> Iterator[ReceivedMessage]:

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -857,123 +857,123 @@ class GhBearerSendTests(unittest.TestCase):
 
     def test_send_appends_to_existing_messages_file(self):
         existing = '{"from":"x","msg":"old"}\n'
+        my_line = '{"from":"bob","msg":"hi"}\n'
         captured = {}
 
-        def fake_patch(gist_id, content, etag):
+        def fake_patch(gist_id, content):
             captured["gist_id"] = gist_id
             captured["content"] = content
-            captured["etag"] = etag
-            return (True, 200, "")
+            return (True, "")
 
-        with mock.patch.object(bearer_gh, "_gh_api_get_with_etag",
-                               return_value=({"files": {"messages.jsonl": {"content": existing}}}, '"e0"')), \
+        # Verify-after-write: send issues 2 GETs (read, then verify).
+        # Both return our merged content so the verify check passes.
+        verify_state = {"files": {"messages.jsonl": {"content": existing + my_line}}}
+        gets = [{"files": {"messages.jsonl": {"content": existing}}}, verify_state]
+        with mock.patch.object(bearer_gh, "_gh_api_get", side_effect=lambda _: gets.pop(0)), \
              mock.patch.object(bearer_gh, "_gh_api_patch_messages_jsonl", side_effect=fake_patch):
-            outcome = self._bearer().send("alice", "general", b'{"from":"bob","msg":"hi"}')
+            outcome = self._bearer().send("alice", "general", my_line.encode().rstrip(b"\n"))
 
         self.assertEqual(outcome.kind, "delivered")
         self.assertEqual(captured["gist_id"], "abc123")
-        self.assertEqual(captured["etag"], '"e0"')
-        self.assertEqual(
-            captured["content"],
-            existing + '{"from":"bob","msg":"hi"}\n',
-        )
+        self.assertEqual(captured["content"], existing + my_line)
 
     def test_send_creates_messages_file_when_absent(self):
+        my_line = '{"from":"bob","msg":"first"}\n'
         captured = {}
 
-        def fake_patch(gist_id, content, etag):
+        def fake_patch(gist_id, content):
             captured["content"] = content
-            return (True, 200, "")
+            return (True, "")
 
-        with mock.patch.object(bearer_gh, "_gh_api_get_with_etag",
-                               return_value=({"files": {}}, '"e0"')), \
+        gets = [{"files": {}}, {"files": {"messages.jsonl": {"content": my_line}}}]
+        with mock.patch.object(bearer_gh, "_gh_api_get", side_effect=lambda _: gets.pop(0)), \
              mock.patch.object(bearer_gh, "_gh_api_patch_messages_jsonl", side_effect=fake_patch):
-            outcome = self._bearer().send("alice", "general", b'{"from":"bob","msg":"first"}')
+            outcome = self._bearer().send("alice", "general", my_line.encode().rstrip(b"\n"))
 
         self.assertEqual(outcome.kind, "delivered")
-        self.assertEqual(captured["content"], '{"from":"bob","msg":"first"}\n')
+        self.assertEqual(captured["content"], my_line)
 
     def test_send_preserves_existing_trailing_newline(self):
+        my_line = '{"x":1}\n'
         captured = {}
 
-        def fake_patch(gist_id, content, etag):
+        def fake_patch(gist_id, content):
             captured["content"] = content
-            return (True, 200, "")
+            return (True, "")
 
-        with mock.patch.object(bearer_gh, "_gh_api_get_with_etag",
-                               return_value=({"files": {}}, '"e0"')), \
+        gets = [{"files": {}}, {"files": {"messages.jsonl": {"content": my_line}}}]
+        with mock.patch.object(bearer_gh, "_gh_api_get", side_effect=lambda _: gets.pop(0)), \
              mock.patch.object(bearer_gh, "_gh_api_patch_messages_jsonl", side_effect=fake_patch):
-            self._bearer().send("alice", "general", b'{"x":1}\n')
+            self._bearer().send("alice", "general", my_line.encode())
 
-        self.assertEqual(captured["content"], '{"x":1}\n')
+        self.assertEqual(captured["content"], my_line)
 
     def test_send_transient_when_get_fails(self):
-        with mock.patch.object(bearer_gh, "_gh_api_get_with_etag", return_value=None), \
-             mock.patch.object(bearer_gh, "_gh_api_get", return_value=None):
+        with mock.patch.object(bearer_gh, "_gh_api_get", return_value=None):
             outcome = self._bearer().send("alice", "general", b'{"x":1}')
         self.assertEqual(outcome.kind, "transient_failure")
         self.assertIn("could not fetch gist", outcome.detail)
 
     def test_send_transient_when_write_fails(self):
-        with mock.patch.object(bearer_gh, "_gh_api_get_with_etag",
-                               return_value=({"files": {}}, '"e0"')), \
+        with mock.patch.object(bearer_gh, "_gh_api_get",
+                               return_value={"files": {}}), \
              mock.patch.object(bearer_gh, "_gh_api_patch_messages_jsonl",
-                               return_value=(False, 500, "Network is unreachable")):
+                               return_value=(False, "Network is unreachable")):
             outcome = self._bearer().send("alice", "general", b'{"x":1}')
         self.assertEqual(outcome.kind, "transient_failure")
         self.assertIn("Network is unreachable", outcome.detail)
 
     def test_send_auth_failure_on_permission_denied(self):
-        with mock.patch.object(bearer_gh, "_gh_api_get_with_etag",
-                               return_value=({"files": {}}, '"e0"')), \
+        with mock.patch.object(bearer_gh, "_gh_api_get",
+                               return_value={"files": {}}), \
              mock.patch.object(bearer_gh, "_gh_api_patch_messages_jsonl",
-                               return_value=(False, 401, "HTTP 401: Permission denied")):
+                               return_value=(False, "HTTP 401: Permission denied")):
             outcome = self._bearer().send("alice", "general", b'{"x":1}')
         self.assertEqual(outcome.kind, "auth_failure")
 
-    def test_send_retries_on_412_then_succeeds(self):
-        # Concurrent-write conflict: first PATCH returns 412 (someone
-        # wrote between our GET and PATCH), retry's GET returns the
-        # newer content + ETag, second PATCH succeeds. This is the
-        # core regression guard for #299.
+    def test_send_retries_on_concurrent_clobber_then_succeeds(self):
+        # Verify-after-write detection: first PATCH "succeeds" but the
+        # post-write GET shows our line is missing (concurrent peer
+        # clobbered us). Retry: re-read fresh state, re-PATCH, verify
+        # passes. This is the core regression guard for #299.
+        my_line = '{"from":"me","msg":"hi"}\n'
+        racer_line = '{"from":"racer","msg":"first"}\n'
+        # GET sequence:
+        #   attempt 1: read (empty) → patch → verify (empty — clobbered!)
+        #   attempt 2: read (racer's line landed) → patch → verify (both lines)
         gets = [
-            ({"files": {"messages.jsonl": {"content": '{"from":"racer","msg":"first"}\n'}}}, '"e1"'),
-            ({"files": {"messages.jsonl": {"content": '{"from":"racer","msg":"first"}\n'}}}, '"e2"'),
-        ]
-        patches = [
-            (False, 412, "HTTP 412: Precondition Failed"),
-            (True, 200, ""),
+            {"files": {}},                                                    # attempt 1 read
+            {"files": {"messages.jsonl": {"content": racer_line}}},           # attempt 1 verify (clobbered)
+            {"files": {"messages.jsonl": {"content": racer_line}}},           # attempt 2 read
+            {"files": {"messages.jsonl": {"content": racer_line + my_line}}}, # attempt 2 verify
         ]
         captured = []
 
-        def fake_get(_):
-            return gets.pop(0)
+        def fake_patch(gist_id, content):
+            captured.append(content)
+            return (True, "")
 
-        def fake_patch(gist_id, content, etag):
-            captured.append((etag, content))
-            return patches.pop(0)
-
-        with mock.patch.object(bearer_gh, "_gh_api_get_with_etag", side_effect=fake_get), \
+        with mock.patch.object(bearer_gh, "_gh_api_get", side_effect=lambda _: gets.pop(0)), \
              mock.patch.object(bearer_gh, "_gh_api_patch_messages_jsonl", side_effect=fake_patch):
-            outcome = self._bearer().send("alice", "general", b'{"from":"me","msg":"hi"}')
+            outcome = self._bearer().send("alice", "general", my_line.encode().rstrip(b"\n"))
 
         self.assertEqual(outcome.kind, "delivered")
         self.assertEqual(len(captured), 2)
-        self.assertEqual(captured[0][0], '"e1"')
-        self.assertEqual(captured[1][0], '"e2"')
-        # Second attempt must include BOTH the racer's earlier line
-        # AND ours — that's the whole point of the retry.
-        self.assertIn('"first"', captured[1][1])
-        self.assertIn('"hi"', captured[1][1])
+        # Attempt 1 wrote just our line (didn't see racer yet).
+        self.assertEqual(captured[0], my_line)
+        # Attempt 2 merged racer + ours.
+        self.assertEqual(captured[1], racer_line + my_line)
 
-    def test_send_transient_when_412_retries_exhausted(self):
-        with mock.patch.object(bearer_gh, "_gh_api_get_with_etag",
-                               return_value=({"files": {}}, '"e"')), \
+    def test_send_transient_when_clobber_retries_exhausted(self):
+        # Pathological: every verify fails. Bound the loop, surface
+        # transient_failure (no silent loss).
+        empty = {"files": {}}
+        with mock.patch.object(bearer_gh, "_gh_api_get", return_value=empty), \
              mock.patch.object(bearer_gh, "_gh_api_patch_messages_jsonl",
-                               return_value=(False, 412, "Precondition Failed")):
+                               return_value=(True, "")):
             outcome = self._bearer().send("alice", "general", b'{"x":1}')
         self.assertEqual(outcome.kind, "transient_failure")
-        self.assertIn("ETag conflict", outcome.detail)
+        self.assertIn("clobbered", outcome.detail)
 
     def test_send_without_gist_id_raises(self):
         b = GhBearer({})


### PR DESCRIPTION
## Why a follow-up
PR #303 tried ETag-conditional PATCH (\`If-Match: <etag>\`). GitHub's gists API EXPLICITLY rejects conditional headers on PATCH:

  HTTP 400 Bad Request
  \`{\"errors\":[\"Conditional request headers are not allowed in unsafe requests unless supported by the endpoint\"]}\`

So #303 was DOA — every joiner-side send 400'd in production until this lands. Reverting If-Match; replacing with verify-after-write.

## New approach
GET → PATCH → re-GET → check our line is in content. If not, retry up to 4×. Detects concurrent-writer clobbers that pure last-writer-wins missed.

Tradeoffs vs proper ETag (preferred if API supported it):
- Slightly more bandwidth (extra GET per send)
- Larger detection window — bounded by retry count not atomic short-circuit
- For chat-pace traffic this is invisible

## Tests
- \`test_send_retries_on_concurrent_clobber_then_succeeds\`: simulates verify-failed state, asserts retry merges both lines.
- \`test_send_transient_when_clobber_retries_exhausted\`: pathological → transient_failure (no silent loss).
- 64/64 unit tests pass.
- Live-checked: \`outcome.kind=delivered\`, line lands on the wire.

Note: peer chat history was clobbered while I was debugging the API contract — sorry, demo-day cost.