### PR TITLE
fix: bearer resyncs offset when gist shrinks — recover from rotation/clobber

### DIFF
--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -500,6 +500,18 @@ class GhBearer(Bearer):
             # each line to bytes for ReceivedMessage.payload symmetry
             # with SshBearer/LocalBearer (which produce bytes from disk).
             lines = content.splitlines()
+            # Shrink/rotation/clobber recovery: if our resume offset is
+            # ahead of the current gist content, the gist must have been
+            # truncated since we last polled (rotation hit, peer
+            # clobbered the file with a bad PATCH, host self-evicted +
+            # republished). Pre-2026-04-29 this stuck the bearer
+            # forever — the for-range was empty, no yield ever fired,
+            # the channel went dead-silent, the user saw "frozen"
+            # monitors. Resync to the current end so future appends are
+            # picked up.
+            if self._consumed_lines > len(lines):
+                self._consumed_lines = len(lines)
+                self._on_line_received(self._consumed_lines, offset_file)
             for idx in range(self._consumed_lines, len(lines)):
                 raw = lines[idx].encode("utf-8")
                 self._consumed_lines = idx + 1

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -1098,6 +1098,65 @@ class GhBearerRecvTests(unittest.TestCase):
         finally:
             _os.unlink(offset_path)
 
+    def test_recv_resyncs_after_gist_shrinks_below_offset(self):
+        # Production bug 2026-04-29: gist rotation (or peer-clobber, or
+        # host self-evict + republish) shrinks the file. Every peer
+        # whose offset > new_line_count goes silent forever — the
+        # for-range over (offset, len(lines)) is empty, no yield, no
+        # state change. Joel observed it as "monitor must bomb out
+        # because after awhile this gd thing dies."
+        #
+        # Fix: detect offset > current line count, snap offset to
+        # current end + persist, then continue. Subsequent appends
+        # land beyond the snapped offset and are seen normally.
+        import tempfile, os as _os
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            f.write("37")  # offset way past current content
+            offset_path = f.name
+        try:
+            # First poll: gist shrunk to 3 lines (rotation/clobber).
+            # Second poll: 1 new append after the snap.
+            responses = [
+                self._gist_response(
+                    '{"from":"bob","msg":"x"}\n'
+                    '{"from":"bob","msg":"y"}\n'
+                    '{"from":"bob","msg":"z"}\n'
+                ),
+                self._gist_response(
+                    '{"from":"bob","msg":"x"}\n'
+                    '{"from":"bob","msg":"y"}\n'
+                    '{"from":"bob","msg":"z"}\n'
+                    '{"from":"carol","msg":"new-after-resync"}\n'
+                ),
+            ]
+            with mock.patch.object(bearer_gh, "_gh_api_get", side_effect=responses):
+                b = self._bearer({
+                    "room_gist_id": "abc123",
+                    "poll_interval": 0,
+                    "offset_file": offset_path,
+                })
+                events = []
+                gen = b.recv_stream()
+                for ev in gen:
+                    events.append(ev)
+                    b.close()
+                    break
+
+            # The new line MUST surface (pre-fix, range was empty
+            # forever, this loop hung waiting for an event that
+            # could never come).
+            self.assertEqual(len(events), 1)
+            self.assertEqual(
+                events[0].bearer_metadata["envelope"]["msg"],
+                "new-after-resync",
+            )
+            # And the offset must have snapped to the new tail (3 from
+            # poll 1 + the 1 new line = 4).
+            with open(offset_path) as f:
+                self.assertEqual(f.read().strip(), "4")
+        finally:
+            _os.unlink(offset_path)
+
     def test_liveness_updates_on_each_event(self):
         with mock.patch.object(
             bearer_gh, "_gh_api_get",


### PR DESCRIPTION
## Why monitors keep dying
Joel 2026-04-29: \"monitor must bomb out because after awhile this gd thing dies\" + \"this would happen too if the trim function happend, cutting down by half the history.\"

Root cause: \`GhBearer.recv_stream\` tracks line offsets. When messages.jsonl SHRINKS below our offset (rotation past 600KB MAX_BYTES, peer-clobber, host self-eviction + republish), the resume loop's \`range(offset, len(lines))\` is empty forever. No yield, no advance, no state change. Bearer is alive but invisibly stuck. Looks like a dead monitor; isn't.

Trim fires whenever content crosses 600KB. Every peer with offset > new line count is permanently silent afterwards.

## Fix
At top of each poll cycle: if \`consumed_lines > len(lines)\`, snap to \`len(lines)\` + persist. Future appends are seen normally.

## Test
\`test_recv_resyncs_after_gist_shrinks_below_offset\` — offset 37 against 3-line gist, asserts 4th line yields + offset persists at 4. 65/65 pass.