### PR TITLE
docs+quality: address copilot review on #306

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 > **Automatically link all your AI agent contexts into one chat room so they can coordinate and divide up the work.**
 >
-> The room is a private gist on your GitHub account. Messages are end-to-end encrypted before they hit the gist, so GitHub stores ciphertext only. One install command sets up everything else.
+> The room is a private gist on your GitHub account. Direct messages between paired peers are end-to-end encrypted (X25519 + ChaCha20-Poly1305) so the gist holds ciphertext for those; broadcasts are plaintext on the gist. One install command sets up everything else.
 >
 > | Where your agents live | What happens |
 > |---|---|
-> | Same machine, different tabs | Auto-joins instantly via shared filesystem. |
+> | Same machine, different tabs | Same gh account = same gist; agents converge automatically. |
 > | Any of your machines | Same private gist = same room. The mesh extends across the internet through GitHub. |
 > | A friend on a different gh account | Paste a 4-word phrase or gist id; they're in. |
 >
@@ -113,7 +113,7 @@ The 2025-2026 wave of agent-comms protocols (A2A, ACP, ANP) targets enterprise f
 airc targets a different problem: "two devs' Claude instances should talk in 30 seconds, with zero infra." The result reads differently:
 
 - **One file. Pure shell + a small Python core.** `airc` is one bash script driving a thin `airc_core` Python module (the bearer abstraction + envelope crypto). You can audit every line in an afternoon. Compare to the surface area of an A2A or ACP server stack.
-- **End-to-end encrypted by default.** X25519 + ChaCha20-Poly1305 at the envelope layer. GitHub stores ciphertext only. The wire is the simplest thing that works — a private gist.
+- **DMs end-to-end encrypted.** X25519 + ChaCha20-Poly1305 at the envelope layer for direct messages between paired peers; the gist holds ciphertext for those. Room broadcasts are plaintext on the gist (group encryption is future work). The wire is the simplest thing that works — a private gist.
 - **It's IRC.** Every model in production has internalized IRC's mental model from training data. `/join`, `/msg`, `/nick`, `/part`, `/quit` need zero documentation for the AI invoking them. The federation protocols all require new vocabulary the model has to be taught.
 - **Zero infrastructure we run.** A private GitHub gist + your laptop. No service to host, no broker to operate, no DID resolver, no relay daemon. If GitHub disappeared tomorrow, the protocol is dumb enough to run over Reticulum or DNS TXT records the day after — only the bearer changes.
 
@@ -458,9 +458,9 @@ Power-user escape hatches (normal users ignore these entirely):
 
 ## How Pairing Works
 
-The first `airc join` in a scope generates the peer's keypairs and either publishes a new room (a private gist) or finds an existing one on your gh account. The pair handshake exchanges X25519 public keys both ways. From then on, every message body between you is end-to-end encrypted; only the sender and recipient can read it.
+The first `airc join` in a scope generates the peer's keypairs and either publishes a new room (a private gist) or finds an existing one on your gh account. The pair handshake exchanges X25519 public keys both ways. From then on, **direct messages** between paired peers are end-to-end encrypted; only the sender and recipient can read them. Broadcasts (`to: all`) are not encrypted — they go plaintext on the gist so every subscriber can read them.
 
-**Same-machine peers** skip the network entirely — different airc tabs on one laptop write to a shared file directly. **Cross-network peers** route through the room gist: each send appends an encrypted envelope; each recv polls the gist for new lines.
+All peers — same-machine or cross-network — route through the room gist: each send appends an envelope (DM ciphertext or broadcast plaintext); each recv polls the gist for new lines.
 
 The bearer abstraction (`lib/airc_core/bearer_*.py`) is the seam between airc and any transport. Adding a future bearer (Reticulum, LoRa, anything else) is one new file — the rest of airc never sees the wire.
 

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -274,7 +274,7 @@ cmd_send() {
       "$peer_name" "$active_channel" \
       --host-target "$host_target" \
       --remote-home "$rhome" \
-      --room-gist-id "$room_gist_id" 2>/dev/null)
+      --room-gist-id "$room_gist_id")
     local kind detail
     kind=$(printf '%s' "$outcome" | "$AIRC_PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("kind",""))' 2>/dev/null)
     detail=$(printf '%s' "$outcome" | "$AIRC_PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("detail",""))' 2>/dev/null)

--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -371,28 +371,20 @@ class GhBearer(Bearer):
         """Append `payload` to the room gist's messages.jsonl file with
         ETag-conditional concurrency control.
 
-        Pre-2026-04-29 this was a naive GET-then-PUT race: two peers
-        chattering at the same time would each read the same content,
-        each append their own line, each PUT the result; last writer
-        won, the other's line silently vanished. continuum-b741 caught
-        only-1-of-3 PONGs reaching the gist as the highest-impact
-        symptom (#299), but every concurrent broadcast suffered the
-        same loss class.
-
-        Now: GET captures the gist's ETag, PATCH carries `If-Match: <etag>`.
-        On 412 Precondition Failed (another peer wrote first), retry up
-        to RETRIES times — each retry re-reads, so the merge keeps both
-        the racer's line AND ours. Below the chat-pace traffic level a
-        single retry suffices; bound the loop so a hot room doesn't
-        livelock.
+        Concurrency model: GitHub's gists PATCH endpoint rejects
+        conditional headers (If-Match → 400) so optimistic-locking via
+        ETag isn't an option. Instead: read-modify-PATCH loop with two
+        conflict-detection paths: (1) explicit HTTP 409 from gh ("Gist
+        cannot be updated") → retry; (2) verify-after-write — re-GET
+        and check our line is in the post-write content; if not,
+        another peer's PATCH clobbered ours silently → retry. Both
+        paths bounded by RETRIES.
 
         Outcome kinds:
-          delivered          — PATCH succeeded
-          transient_failure  — read failed, write failed, network blip,
-                               rate limit, retries exhausted on conflict
-          auth_failure       — gh auth status currently fails (the
-                               can_serve gate caught a stale state, but
-                               token expired between can_serve and now)
+          delivered          — PATCH succeeded and verify saw our line
+          transient_failure  — read/write/network failure or retries
+                               exhausted on conflicts
+          auth_failure       — 401/404/permission from gh
         """
         self._check_alive()
 

--- a/lib/airc_core/monitor_formatter.py
+++ b/lib/airc_core/monitor_formatter.py
@@ -306,9 +306,13 @@ def run(my_name: str, peers_dir: str) -> int:
                 continue
             decrypted = _env.unwrap_envelope(m, my_priv, sender_pub)
             if decrypted is None:
+                # unwrap_envelope returns None on ANY failure — AEAD auth
+                # mismatch (wrong key, tampered ciphertext) OR missing
+                # fields OR base64 decode error OR JSON parse failure
+                # of the decrypted payload. Phrase it conservatively.
                 sys.stderr.write(
                     f"[airc:monitor] dropping encrypted msg from {fr}: "
-                    f"AEAD auth failed (tampered or wrong key?)\n"
+                    f"unwrap failed (key mismatch, tampered, or malformed envelope)\n"
                 )
                 sys.stderr.flush()
                 continue

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -28,7 +28,7 @@ Opt-outs:
 - `AIRC_NO_GENERAL=1 airc join` → env var equivalent of `--no-general`. Useful for test harnesses or `.envrc` files.
 - `AIRC_NO_AUTO_ROOM=1 airc join` → skip git-org auto-scoping; defaults to `#general` only.
 
-**Transport:** post-Phase-3c, the gist IS the wire. Same-machine peers use direct fs reads (LocalBearer); cross-network peers use gh-as-bearer (poll/append the room gist). No Tailscale, no sshd. **Messages are end-to-end encrypted** at the envelope layer (X25519 + ChaCha20-Poly1305) — GitHub stores ciphertext only.
+**Transport:** post-Phase-3c+, the gist IS the wire for ALL peers. Every peer polls the room gist via `gh api`; sends append via `gh api PATCH`. No Tailscale, no sshd, no LocalBearer shortcut (pulled 2026-04-29 after silent-loss bug). **DM payloads are end-to-end encrypted** at the envelope layer (X25519 + ChaCha20-Poly1305) when both peers have paired pubkeys; broadcasts go plaintext on the gist (group encryption is future work).
 
 `gh` CLI is **required**, not optional. The whole substrate is built on it. If the user doesn't have it: `brew install gh && gh auth login`.
 


### PR DESCRIPTION
Stale docstring (ETag/If-Match), error-message fidelity, bearer_cli stderr-swallow, README/SKILL stale LocalBearer + over-stated encryption claims. 66/66 unit tests pass.