### PR TITLE
fix: bearer heartbeat — detect stuck-but-alive recv (the 'monitor dies' bug)

### DIFF
--- a/lib/airc_core/bearer_cli.py
+++ b/lib/airc_core/bearer_cli.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import signal
 import sys
 from dataclasses import asdict
@@ -141,14 +142,64 @@ def cmd_recv(args) -> int:
             "events_total": 0,
             "diag": "bearer open, no events yet",
         })
+
+    # Heartbeat: emit a sentinel JSON line to stdout every N seconds
+    # regardless of bearer activity. Two purposes:
+    #   1. Lets monitor_formatter's stdin-watchdog distinguish "bearer
+    #      idle" (heartbeats arriving) from "bearer stuck" (silence).
+    #      Pre-fix the watchdog was disabled for hosts because there
+    #      was no signal during idle; with heartbeats, it's safe on.
+    #   2. Liveness probe for the bash multi-channel watcher. A
+    #      heartbeat in stdout proves the python loop made it past
+    #      the GH poll, not just that the process is alive.
+    # Joel 2026-04-29: "polling easily shuts down on its own OR never
+    # even worked, sending/pinging triggered anything to occur." This
+    # was the missing signal.
+    import threading as _t
+    try:
+        _heartbeat_sec = float(os.environ.get("AIRC_BEARER_HEARTBEAT_SEC", "30"))
+    except (TypeError, ValueError):
+        _heartbeat_sec = 30.0
+    _stop_heartbeat = _t.Event()
+    _stdout_lock = _t.Lock()
+
+    def _emit_heartbeat():
+        import time as _ti
+        room = getattr(args, "room_gist_id", "") or ""
+        # Tick on a short interval so close() is responsive without
+        # missing the cadence target.
+        next_tick = _ti.monotonic() + _heartbeat_sec
+        while not _stop_heartbeat.is_set():
+            now = _ti.monotonic()
+            if now >= next_tick:
+                line = (json.dumps({
+                    "airc_heartbeat": 1,
+                    "ts": _ti.time(),
+                    "channel": room,
+                }) + "\n").encode("utf-8")
+                with _stdout_lock:
+                    try:
+                        out.write(line)
+                        out.flush()
+                    except (BrokenPipeError, ValueError):
+                        # Downstream gone or stdout closed; stop trying.
+                        return
+                next_tick = now + _heartbeat_sec
+            # Wake every 100ms so close() takes effect promptly.
+            _stop_heartbeat.wait(0.1)
+
+    _hb_thread = _t.Thread(target=_emit_heartbeat, daemon=True)
+    _hb_thread.start()
+
     try:
         for ev in bearer.recv_stream():
             line = ev.payload
             if not line.endswith(b"\n"):
                 line = line + b"\n"
             try:
-                out.write(line)
-                out.flush()
+                with _stdout_lock:
+                    out.write(line)
+                    out.flush()
             except BrokenPipeError:
                 # Downstream formatter exited. Caller's watchdog will
                 # observe the broken cycle and reconnect us if needed.
@@ -167,7 +218,11 @@ def cmd_recv(args) -> int:
     except KeyboardInterrupt:
         pass
     finally:
+        _stop_heartbeat.set()
         bearer.close()
+        # Brief join — daemon=True means we don't hang if the thread
+        # is mid-write; the daemon flag handles process exit.
+        _hb_thread.join(timeout=0.3)
     return 0
 
 

--- a/lib/airc_core/monitor_formatter.py
+++ b/lib/airc_core/monitor_formatter.py
@@ -203,15 +203,14 @@ def run(my_name: str, peers_dir: str) -> int:
     except Exception:
         pass
 
-    # Host mode: disable the inactivity watchdog. The watchdog was
-    # designed to detect a silently-dead SSH tail on the joiner side
-    # (no SIGPIPE, no exit, just no inbound). Hosts read their own
-    # local messages.jsonl — there's no remote pipe to die silently;
-    # idle just means the channel is quiet. Without this disable, the
-    # host formatter cycles every 150s and leaves a 1s+ dead window
-    # where [PING:] arrivals don't get auto-pong'd.
-    if not is_joiner:
-        _disable_watchdog()
+    # Watchdog stays armed for both hosts and joiners. Pre-fix it was
+    # disabled for hosts because there was no inbound traffic during
+    # idle and the alarm would trip every 150s. Post bearer-heartbeat
+    # (bearer_cli emits a sentinel line every AIRC_BEARER_HEARTBEAT_SEC
+    # whether the bearer yielded events or not), idle is no longer
+    # silent — heartbeats keep the watchdog re-armed. Stuck bearers
+    # produce no heartbeats, so the watchdog correctly trips and the
+    # bash multi-channel watcher respawns the recv pipe.
 
     # Room name for the chat-line prefix. Read once at startup; a rename
     # of the room would require a fresh airc connect to pick up. Default
@@ -273,6 +272,16 @@ def run(my_name: str, peers_dir: str) -> int:
         try:
             m = json.loads(line)
         except Exception:
+            continue
+        # bearer_cli emits a sentinel heartbeat line every
+        # AIRC_BEARER_HEARTBEAT_SEC even when the bearer is idle. The
+        # heartbeat's only job is to prove "the python loop completed
+        # a poll cycle" — re-arm the inactivity watchdog and suppress
+        # from user-visible output. If heartbeats stop arriving,
+        # bearer is stuck (Joel 2026-04-29 freeze pattern); watchdog
+        # trips, formatter exits 2, bash watcher respawns the pipe.
+        if m.get("airc_heartbeat") == 1:
+            _arm_watchdog()
             continue
         fr = m.get("from", "?")
         to = m.get("to", "")

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -331,6 +331,111 @@ class BearerCliRecvTests(unittest.TestCase):
         self.assertIs(ns.func, bearer_cli.cmd_recv)
 
 
+class BearerCliHeartbeatTests(unittest.TestCase):
+    """The 'monitor dies after a while' bug Joel caught 2026-04-29.
+
+    bearer_cli recv only writes to stdout when bearer.recv_stream
+    yields an event. If the bearer is alive but stuck (gh CLI hang
+    after laptop sleep, network blip, etc), stdout stays silent
+    indefinitely. The bash multi-channel watcher's `kill -0` check
+    sees the process as alive (it is — just stuck), so #302 never
+    triggers a respawn. Result: monitor looks healthy, no events
+    ever flow.
+
+    Fix: bearer_cli emits a periodic heartbeat line to stdout
+    regardless of bearer activity. monitor_formatter recognizes the
+    sentinel + arms its watchdog (existing 150s alarm). Stuck bearer
+    → no heartbeats reach formatter → watchdog trips → formatter
+    exits 2 → outer bash loop kills children + respawns.
+
+    This test enforces the contract: cmd_recv must emit at least one
+    heartbeat per AIRC_BEARER_HEARTBEAT_SEC interval even when the
+    bearer yields nothing. Without it, the production stuck-bearer
+    bug is undetectable.
+    """
+
+    class _IdleBearer:
+        """Yields nothing; recv_stream blocks for `block_seconds` then
+        returns (so cmd_recv exits and the test doesn't hang)."""
+        KIND = "idle-test"
+        def __init__(self, _meta=None):
+            self.closed = False
+        def open(self, _peer_id):
+            pass
+        def recv_stream(self):
+            import time as _t
+            _t.sleep(self._block_seconds)
+            return
+            yield  # unreachable; makes this a generator
+        def close(self):
+            self.closed = True
+        def liveness(self, peer_id):
+            return LivenessResult(peer_id=peer_id, last_seen_ts=None, bearer_diag="idle")
+
+    def _make_args(self, **overrides):
+        ns = argparse.Namespace(
+            peer_id="alice",
+            host_target="alice@example",
+            identity_key=None,
+            remote_home=None,
+            room_gist_id="abc123",
+            offset_file=None,
+            state_file=None,
+        )
+        for k, v in overrides.items():
+            setattr(ns, k, v)
+        return ns
+
+    def _capture_stdout_bytes(self):
+        import io
+        captured = io.BytesIO()
+        fake_stdout = mock.Mock()
+        fake_stdout.buffer = captured
+        return fake_stdout, captured
+
+    def test_recv_emits_heartbeats_when_bearer_idle(self):
+        # Idle for 2.5s; with 1s heartbeat interval, expect ≥2 heartbeats.
+        bearer = self._IdleBearer()
+        bearer._block_seconds = 2.5
+
+        fake_stdout, captured = self._capture_stdout_bytes()
+        import os as _os
+        with mock.patch.dict(_os.environ, {"AIRC_BEARER_HEARTBEAT_SEC": "1"}), \
+             mock.patch.object(bearer_cli, "resolve", return_value=bearer), \
+             mock.patch.object(bearer_cli.sys, "stdout", fake_stdout):
+            bearer_cli.cmd_recv(self._make_args())
+
+        lines = [l for l in captured.getvalue().splitlines() if l.strip()]
+        heartbeats = [l for l in lines if b'"airc_heartbeat"' in l]
+        self.assertGreaterEqual(
+            len(heartbeats), 2,
+            f"expected ≥2 heartbeats in 2.5s @ 1s interval; "
+            f"got {len(heartbeats)} heartbeats / {len(lines)} total lines",
+        )
+
+    def test_heartbeat_line_is_valid_json_with_sentinel(self):
+        # Heartbeat must be a JSON line with airc_heartbeat=1 so
+        # monitor_formatter can identify + suppress + arm watchdog.
+        import json as _json
+        bearer = self._IdleBearer()
+        bearer._block_seconds = 1.5
+
+        fake_stdout, captured = self._capture_stdout_bytes()
+        import os as _os
+        with mock.patch.dict(_os.environ, {"AIRC_BEARER_HEARTBEAT_SEC": "0.5"}), \
+             mock.patch.object(bearer_cli, "resolve", return_value=bearer), \
+             mock.patch.object(bearer_cli.sys, "stdout", fake_stdout):
+            bearer_cli.cmd_recv(self._make_args())
+
+        for raw in captured.getvalue().splitlines():
+            if not raw.strip(): continue
+            if b'"airc_heartbeat"' not in raw: continue
+            obj = _json.loads(raw)
+            self.assertEqual(obj.get("airc_heartbeat"), 1)
+            return  # at least one valid heartbeat is enough
+        self.fail("no heartbeat line emitted")
+
+
 class BearerCliStateFileTests(unittest.TestCase):
     """Phase 2c: bearer_cli recv writes a per-event state file that
     `airc status` reads. The state file is the bearer-attested liveness


### PR DESCRIPTION
Joel: 'polling easily shuts down on its own OR never even worked.' Confirmed in production. #302 only catches DEAD; STUCK looks alive.

Fix: bearer_cli emits {airc_heartbeat:1} on stdout every AIRC_BEARER_HEARTBEAT_SEC (30s default). Formatter recognizes + arms watchdog + suppresses display. Stuck bearer → no heartbeats → watchdog trips → bash respawns pipe.

Watchdog re-enabled for hosts (heartbeats keep it armed during legitimate idle).

TDD: 2 new tests — `test_recv_emits_heartbeats_when_bearer_idle` and `test_heartbeat_line_is_valid_json_with_sentinel`. 68/68 pass.