### PR TITLE
fix: pidfile any-alive contract — closes status/send disagreement

### DIFF
--- a/airc
+++ b/airc
@@ -413,6 +413,45 @@ relay_list() { [ -d "$AIRC_WRITE_DIR/$1" ] && ls -1 "$AIRC_WRITE_DIR/$1" 2>/dev/
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
+# Single source of truth for "is this scope's monitor running?" — pre-fix,
+# cmd_status used any-alive logic and cmd_send used all-alive logic, so a
+# pidfile with one stale orphan + one live process showed "monitor:
+# running" in status BUT "Send NOT delivered — pidfile stale" from msg.
+# vhsm-d1f4 + authenticator-448f independently reproduced 2026-04-29.
+#
+# Contract: a scope is "alive" if AT LEAST ONE pid in the pidfile is
+# alive. Stale pids are pruned in-place so the file converges on
+# truth. Echoes the live count to stdout (caller can branch on > 0)
+# and rewrites pidfile with only-living entries.
+#
+# Usage:
+#   if [ "$(prune_pidfile_and_count "$AIRC_WRITE_DIR/airc.pid")" -gt 0 ]; then
+#     ... monitor is up
+#   fi
+prune_pidfile_and_count() {
+  local pidfile="${1:-}"
+  [ -f "$pidfile" ] || { echo 0; return; }
+  local raw; raw=$(cat "$pidfile" 2>/dev/null)
+  local live=""
+  local p
+  for p in $raw; do
+    case "$p" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    if kill -0 "$p" 2>/dev/null; then
+      live="${live:+$live }$p"
+    fi
+  done
+  if [ "$raw" != "$live" ]; then
+    if [ -n "$live" ]; then
+      printf '%s\n' "$live" > "$pidfile" 2>/dev/null || true
+    else
+      rm -f "$pidfile" 2>/dev/null || true
+    fi
+  fi
+  if [ -z "$live" ]; then echo 0; else echo "$(printf '%s\n' $live | wc -w | tr -d ' ')"; fi
+}
+
 # Validate a peer name matches the allowed nick charset BEFORE using it in
 # filesystem paths or remote SSH commands. Same charset cmd_rename uses
 # (a-z 0-9 -) — anything else is unreachable as a real airc identity and

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -341,20 +341,15 @@ cmd_send() {
     # delivery, and the peer in the actual room waited forever for a
     # reply that never landed.
     #
-    # Detect: pidfile exists AND every PID in it is alive. Anything else
-    # = monitor dead = broadcasting into a void. Die loudly so the user
-    # immediately knows their cwd / scope / monitor state is wrong.
+    # Detect monitor liveness via the shared prune_pidfile_and_count
+    # helper (airc top-level). Same contract as cmd_status — pre-fix
+    # this used all-alive logic while status used any-alive, so a
+    # pidfile with 1 stale orphan + 2 live processes showed "monitor:
+    # running" but every msg refused. Helper auto-prunes the orphan.
     local _pidfile="$AIRC_WRITE_DIR/airc.pid"
     local _monitor_alive=0
-    if [ -f "$_pidfile" ]; then
-      local _pids; _pids=$(cat "$_pidfile" 2>/dev/null)
-      if [ -n "$_pids" ]; then
-        local _all_alive=1 _p
-        for _p in $_pids; do
-          kill -0 "$_p" 2>/dev/null || { _all_alive=0; break; }
-        done
-        [ "$_all_alive" = "1" ] && _monitor_alive=1
-      fi
+    if [ "$(prune_pidfile_and_count "$_pidfile")" -gt 0 ]; then
+      _monitor_alive=1
     fi
     if [ "$_monitor_alive" = "0" ]; then
       # --internal callers (informational broadcasts: [rename], etc.):

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -59,24 +59,19 @@ cmd_status() {
     fi
   fi
 
-  # Monitor alive? Read the scope's pidfile — cmd_connect writes its own PID
-  # there. pgrep'd descendants (python listener, tail loop) should be children
-  # of that PID. If the main PID is gone, the monitor is down.
+  # Monitor alive? Single helper at airc top-level (prune_pidfile_and_count)
+  # owns the contract: returns count of living pids and prunes dead orphans.
+  # Both cmd_status and cmd_send call it so they can never disagree
+  # again (the bug vhsm + authenticator hit 2026-04-29).
   local monitor_state="not running"
   local pidfile="$AIRC_WRITE_DIR/airc.pid"
-  if [ -f "$pidfile" ]; then
-    # cmd_connect writes multiple space-separated PIDs on one line (parent +
-    # python listener). Monitor is "running" if ANY of them is alive.
-    local pids_raw; pids_raw=$(cat "$pidfile" 2>/dev/null | tr '\n' ' ' || true)
-    local any_alive=""
-    for p in $pids_raw; do
-      if kill -0 "$p" 2>/dev/null; then any_alive="$p"; break; fi
-    done
-    if [ -n "$any_alive" ]; then
-      monitor_state="running (PID $any_alive)"
-    else
-      monitor_state="stale pidfile (PIDs $pids_raw not alive — run 'airc connect' to self-heal)"
-    fi
+  local live_count
+  live_count=$(prune_pidfile_and_count "$pidfile")
+  if [ "$live_count" -gt 0 ]; then
+    local first_alive; first_alive=$(awk '{print $1}' "$pidfile" 2>/dev/null)
+    monitor_state="running (PID $first_alive)"
+  elif [ -f "$pidfile" ]; then
+    monitor_state="stale pidfile (no live PIDs — run 'airc connect' to self-heal)"
   fi
   echo "  monitor:     $monitor_state"
 


### PR DESCRIPTION
vhsm + authenticator both repro'd: pidfile with 1 stale orphan + N live processes → status says 'running', msg says 'pidfile stale'. Extracted shared helper, both sites use it, dead orphans auto-pruned.