### PR TITLE
fix: input-validation cluster — silent → loud rejection

### DIFF
--- a/lib/airc_bash/cmd_rename.sh
+++ b/lib/airc_bash/cmd_rename.sh
@@ -47,6 +47,7 @@ cmd_rename() {
   # above — making the resulting name unreachable by `airc whois` /
   # `airc kick` (both reject leading-dash). Caught by Copilot review on
   # PR #75 follow-up.
+  local _input="$new_name"
   new_name=$(echo "$new_name" \
     | tr '[:upper:]' '[:lower:]' \
     | sed 's/[^a-z0-9-]/-/g' \
@@ -56,10 +57,28 @@ cmd_rename() {
   [ -z "$new_name" ] && die "Invalid name (must be a-z 0-9 -)"
   [ ! -f "$CONFIG" ] && die "Not initialized — run 'airc connect' first"
 
+  # Announce sanitization (vhsm-d1f4 caught 2026-04-29: 'two words' →
+  # 'two-words', 'VHSMD1F4' → 'vhsmd1f4' silently). Pre-fix the user
+  # had no signal that the name they typed wasn't the name that landed.
+  if [ "$_input" != "$new_name" ]; then
+    echo "  Sanitized: '$_input' → '$new_name' (allowed charset: a-z 0-9 -)"
+  fi
+
   local old_name; old_name=$(get_config_val name "")
   if [ "$old_name" = "$new_name" ]; then
     echo "  Already named '$new_name'."
     return
+  fi
+
+  # Collision check against the peer roster (continuum-b741 + ideem-
+  # local-4bef caught 2026-04-29: renaming to an active peer's name
+  # was accepted silently, both peers then visible as the same name,
+  # DM routing ambiguous). Refuse loudly. The roster is whatever
+  # peers/ records this scope has accumulated — not perfect (a peer
+  # we've never paired with won't trigger it), but catches the common
+  # case of a fresh peer typing an existing peer's nick.
+  if [ -d "$PEERS_DIR" ] && [ -f "$PEERS_DIR/$new_name.json" ]; then
+    die "name collision: '$new_name' is already a peer in this scope (use 'airc peers' to see the roster)"
   fi
 
   # Phase 1: write the new name into THIS scope's config (the truth-

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -101,6 +101,20 @@ cmd_send() {
       --plaintext|-plaintext)
         plaintext=1
         shift ;;
+      --)
+        # POSIX flag-terminator: anything after this is positional even
+        # if it looks like a flag. Lets users send literal --strings in
+        # message bodies: `airc msg -- --foo bar`.
+        shift
+        while [ $# -gt 0 ]; do positional+=("$1"); shift; done
+        ;;
+      --*|-*)
+        # Unknown flag — pre-fix this fell into the *) catch-all and got
+        # silently absorbed into the message body, so 'airc msg
+        # --invalidflag value body' returned exit 0 broadcast (ideem-
+        # local-4bef caught 2026-04-29). Loud failure now; users with a
+        # literal --string in the message body can use the -- terminator.
+        die "Unknown flag: $1 (use -- to terminate flags if this is part of the message body)" ;;
       *) positional+=("$1"); shift ;;
     esac
   done
@@ -137,6 +151,17 @@ cmd_send() {
     case "$1" in
       @*)
         local _p="${1#@}"
+        # Reject empty `@` (continuum-b741 + ideem-local-4bef caught
+        # 2026-04-29: `airc msg @ body` silently broadcast). Reject
+        # double-@ `@@peer` while we're here (also caught: accepted as
+        # DM to literal '@peer'). Reject numeric-only DMs as per the
+        # peer-name charset rule (`@12345` is a likely typo, not a
+        # real peer).
+        case "$_p" in
+          "")           die "Empty @ recipient (use 'airc msg <message>' for broadcast, or 'airc msg @<peer> ...' for DM)" ;;
+          @*)           die "Double @ recipient '$1' — peer names are bare, not @-prefixed" ;;
+          *[!a-z0-9,-]*) die "Invalid peer name in '$1' — must match [a-z0-9-]+ (comma-separated for multi-DM)" ;;
+        esac
         if [ -z "$_peer_csv" ]; then
           _peer_csv="$_p"
         else
@@ -178,6 +203,12 @@ cmd_send() {
     peer_name="all"
     msg="$*"
   fi
+  # Reject empty broadcast bodies — pre-fix `airc msg ""` printed the
+  # usage line but exited 0 (continuum-b741 caught 2026-04-29). The
+  # other "no message" path already dies above; this one is the
+  # explicit-empty-string case that fell through.
+  [ "$peer_name" = "all" ] && [ -z "$msg" ] \
+    && die "empty message body (use 'airc msg <text>' or omit the empty quotes)"
   ensure_init
 
   local my_name ts_val

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -172,6 +172,14 @@ else:
 cmd_logs() {
   ensure_init
   local count="${1:-20}"
+  # Validate count: positive integer (ideem-local-4bef caught 2026-04-29:
+  # 'airc logs 0' and 'airc logs notanumber' silently exited 0 with no
+  # output). Tail with N=0 prints nothing; with non-numeric, tail errors
+  # and we swallow it.
+  case "$count" in
+    ''|*[!0-9]*) die "logs count must be a positive integer (got '$count')" ;;
+    0)           die "logs count must be ≥ 1 (got '$count')" ;;
+  esac
   local host_target
   host_target=$(get_config_val host_target "")
 


### PR DESCRIPTION
Batch fix for the silent-accept bugs continuum + ideem caught: cmd_send unknown flags, empty @ recipient, double-@, empty body; cmd_rename silent sanitization + collision-with-existing-peer; cmd_logs bad count. All previously exit-0 silent; now die loudly. CLAUDE.md anti-pattern crackdown.