### PR TITLE
canary → main: morning fixes (#316 pidfile, #317 ping, #318 input-validation, #319 host bootstrap)

### DIFF
--- a/airc
+++ b/airc
@@ -413,6 +413,45 @@ relay_list() { [ -d "$AIRC_WRITE_DIR/$1" ] && ls -1 "$AIRC_WRITE_DIR/$1" 2>/dev/
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
+# Single source of truth for "is this scope's monitor running?" — pre-fix,
+# cmd_status used any-alive logic and cmd_send used all-alive logic, so a
+# pidfile with one stale orphan + one live process showed "monitor:
+# running" in status BUT "Send NOT delivered — pidfile stale" from msg.
+# vhsm-d1f4 + authenticator-448f independently reproduced 2026-04-29.
+#
+# Contract: a scope is "alive" if AT LEAST ONE pid in the pidfile is
+# alive. Stale pids are pruned in-place so the file converges on
+# truth. Echoes the live count to stdout (caller can branch on > 0)
+# and rewrites pidfile with only-living entries.
+#
+# Usage:
+#   if [ "$(prune_pidfile_and_count "$AIRC_WRITE_DIR/airc.pid")" -gt 0 ]; then
+#     ... monitor is up
+#   fi
+prune_pidfile_and_count() {
+  local pidfile="${1:-}"
+  [ -f "$pidfile" ] || { echo 0; return; }
+  local raw; raw=$(cat "$pidfile" 2>/dev/null)
+  local live=""
+  local p
+  for p in $raw; do
+    case "$p" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    if kill -0 "$p" 2>/dev/null; then
+      live="${live:+$live }$p"
+    fi
+  done
+  if [ "$raw" != "$live" ]; then
+    if [ -n "$live" ]; then
+      printf '%s\n' "$live" > "$pidfile" 2>/dev/null || true
+    else
+      rm -f "$pidfile" 2>/dev/null || true
+    fi
+  fi
+  if [ -z "$live" ]; then echo 0; else echo "$(printf '%s\n' $live | wc -w | tr -d ' ')"; fi
+}
+
 # Validate a peer name matches the allowed nick charset BEFORE using it in
 # filesystem paths or remote SSH commands. Same charset cmd_rename uses
 # (a-z 0-9 -) — anything else is unreachable as a real airc identity and

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1257,21 +1257,33 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
         echo "     Install: https://cli.github.com  (or: brew install gh)"
         echo "     Skipping gist push; long invite above is the only handoff."
       else
-        local _gist_tmp; _gist_tmp=$(mktemp -t airc-invite.XXXXXX)
+        # Bootstrap basename + description match channel_gist.create_new's
+        # canonical shape (airc-room-<channel>.json + "airc room: #X").
+        # Pre-fix the host path used a random mktemp basename
+        # (airc-invite.XXXXXX) and "airc mesh" description, then
+        # heartbeat (and channel_gist.find_existing on subsequent peers)
+        # tried to find/edit `airc-room-X.json` which didn't exist —
+        # heartbeat 'gh gist edit' silently failed → false eviction
+        # loop → gist deleted mid-conversation. Issue #301.
+        local _gist_tmpdir; _gist_tmpdir=$(mktemp -d -t airc-bootstrap.XXXXXX)
+        local _gist_tmp="$_gist_tmpdir/airc-room-${room_name}.json"
+        if [ "$use_room" != "1" ]; then
+          # Legacy single-pair invite mode keeps the old basename — it's
+          # short-lived (deleted post-pair).
+          _gist_tmp="$_gist_tmpdir/airc-invite.json"
+        fi
         local _now; _now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
         local _gist_kind="invite"
         local _gist_desc="airc invite for $name (delete after pair)"
         local _gist_payload=""
 
         if [ "$use_room" = "1" ]; then
-          # Mesh mode: ONE persistent gist per gh account (description
-          # "airc mesh"), shared by every `airc join` on the account.
-          # Same SSH-pair handshake under the hood — only the discovery
-          # contract changes from per-room to per-account-singleton.
-          #
-          # `channels` is an advisory list of the rooms this client
-          # cares about; in Phase 1 it's purely informational, in
-          # Phase 2 it'll drive message routing.
+          # Mesh-singleton discovery (joiner _mesh_find looks for this
+          # description literal). Filename is canonical airc-room-<channel>.json
+          # so heartbeat's gh-edit basename match works (#297).
+          # Migrating fully to per-channel gist shape is a follow-up
+          # (#301 doc note); changing description here would break
+          # the joiner's _mesh_find call without a paired update.
           _gist_kind="mesh"
           _gist_desc="$(_mesh_desc)"
           # last_heartbeat: host's presence signal, refreshed every
@@ -1337,7 +1349,7 @@ JSON
         # whoever holds the string can pair. Room gists persist; invite
         # gists should be deleted by the host after the first joiner.
         local _gist_url; _gist_url=$(gh gist create -d "$_gist_desc" "$_gist_tmp" 2>/dev/null | tail -1)
-        rm -f "$_gist_tmp"
+        rm -rf "$_gist_tmpdir"
         if [ -n "$_gist_url" ]; then
           local _gist_id="${_gist_url##*/}"
           local _hh; _hh=$(humanhash "$_gist_id" 2>/dev/null)

--- a/lib/airc_bash/cmd_rename.sh
+++ b/lib/airc_bash/cmd_rename.sh
@@ -47,6 +47,7 @@ cmd_rename() {
   # above — making the resulting name unreachable by `airc whois` /
   # `airc kick` (both reject leading-dash). Caught by Copilot review on
   # PR #75 follow-up.
+  local _input="$new_name"
   new_name=$(echo "$new_name" \
     | tr '[:upper:]' '[:lower:]' \
     | sed 's/[^a-z0-9-]/-/g' \
@@ -56,10 +57,28 @@ cmd_rename() {
   [ -z "$new_name" ] && die "Invalid name (must be a-z 0-9 -)"
   [ ! -f "$CONFIG" ] && die "Not initialized — run 'airc connect' first"
 
+  # Announce sanitization (vhsm-d1f4 caught 2026-04-29: 'two words' →
+  # 'two-words', 'VHSMD1F4' → 'vhsmd1f4' silently). Pre-fix the user
+  # had no signal that the name they typed wasn't the name that landed.
+  if [ "$_input" != "$new_name" ]; then
+    echo "  Sanitized: '$_input' → '$new_name' (allowed charset: a-z 0-9 -)"
+  fi
+
   local old_name; old_name=$(get_config_val name "")
   if [ "$old_name" = "$new_name" ]; then
     echo "  Already named '$new_name'."
     return
+  fi
+
+  # Collision check against the peer roster (continuum-b741 + ideem-
+  # local-4bef caught 2026-04-29: renaming to an active peer's name
+  # was accepted silently, both peers then visible as the same name,
+  # DM routing ambiguous). Refuse loudly. The roster is whatever
+  # peers/ records this scope has accumulated — not perfect (a peer
+  # we've never paired with won't trigger it), but catches the common
+  # case of a fresh peer typing an existing peer's nick.
+  if [ -d "$PEERS_DIR" ] && [ -f "$PEERS_DIR/$new_name.json" ]; then
+    die "name collision: '$new_name' is already a peer in this scope (use 'airc peers' to see the roster)"
   fi
 
   # Phase 1: write the new name into THIS scope's config (the truth-

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -65,6 +65,15 @@ cmd_send() {
   # issue. Exposed as a flag (not an env var) so call sites are
   # grep-able and the pattern matches the rest of the airc CLI surface.
   local internal=0
+  # --plaintext: skip envelope-layer encryption even when recipient
+  # x25519 pubkey is on file. For control traffic ([PING:uuid] /
+  # [PONG:uuid]) where the body is a public uuid with zero secret
+  # content. Pre-fix: pings encrypted asymmetrically (sender had
+  # recipient's pubkey; recipient lacked sender's pubkey) → recipient
+  # silently dropped with "missing pubkey/privkey for decrypt" → no
+  # auto-pong → cmd_ping timed out. Plaintext sidesteps the asymmetry
+  # entirely for these short-lived control messages.
+  local plaintext=0
   local positional=()
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -88,6 +97,9 @@ cmd_send() {
         shift 2 ;;
       --internal)
         internal=1
+        shift ;;
+      --plaintext|-plaintext)
+        plaintext=1
         shift ;;
       *) positional+=("$1"); shift ;;
     esac
@@ -221,7 +233,7 @@ cmd_send() {
     # package isn't installed). The wrap CLI passes through plaintext in
     # that case, transparently.
     local recipient_pub=""
-    if [ "$peer_name" != "all" ]; then
+    if [ "$peer_name" != "all" ] && [ "$plaintext" != "1" ]; then
       recipient_pub=$("$AIRC_PYTHON" -m airc_core.identity peer_pub \
         --peers-dir "$PEERS_DIR" --peer-name "$peer_name" 2>/dev/null || true)
     fi
@@ -396,7 +408,7 @@ cmd_send() {
     # we have their pubkey on file; broadcasts go plaintext (group
     # encryption is a future Phase E.4).
     local _host_recipient_pub=""
-    if [ "$peer_name" != "all" ]; then
+    if [ "$peer_name" != "all" ] && [ "$plaintext" != "1" ]; then
       _host_recipient_pub=$("$AIRC_PYTHON" -m airc_core.identity peer_pub \
         --peers-dir "$PEERS_DIR" --peer-name "$peer_name" 2>/dev/null || true)
     fi
@@ -517,13 +529,15 @@ cmd_ping() {
   local start_time
   start_time=$(date +%s)
 
-  # Route via #general (the universal lobby sidecar). Pre-fix: ping
-  # used the sender's default channel, but peers in different cwds
-  # auto-scope to different project channels (cambriantech vs ideem
-  # vs useideem) so the recipient often didn't poll the sender's
-  # default channel and never saw the ping. #general is the one
-  # channel everyone subscribes to — guaranteed common ground.
-  cmd_send --channel general "@$peer_name" "[PING:$ping_id]" >/dev/null || die "ping send failed (airc status)"
+  # Route via #general (universal lobby) and force PLAINTEXT. Encryption
+  # for [PING:uuid] adds zero security value (the body is a public uuid)
+  # and was the actual cause of #308: pair handshake was asymmetric, so
+  # one side dropped encrypted control traffic with "missing pubkey/
+  # privkey for decrypt" and the auto-pong silently never propagated.
+  # Plaintext sidesteps the asymmetry; the bigger pubkey-symmetry fix
+  # is its own follow-up.
+  cmd_send --channel general --plaintext "@$peer_name" "[PING:$ping_id]" >/dev/null \
+    || die "ping send failed (airc status)"
 
   echo "ping sent to $peer_name (id=$ping_id) — waiting up to ${timeout}s for pong..."
 

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -341,20 +341,15 @@ cmd_send() {
     # delivery, and the peer in the actual room waited forever for a
     # reply that never landed.
     #
-    # Detect: pidfile exists AND every PID in it is alive. Anything else
-    # = monitor dead = broadcasting into a void. Die loudly so the user
-    # immediately knows their cwd / scope / monitor state is wrong.
+    # Detect monitor liveness via the shared prune_pidfile_and_count
+    # helper (airc top-level). Same contract as cmd_status — pre-fix
+    # this used all-alive logic while status used any-alive, so a
+    # pidfile with 1 stale orphan + 2 live processes showed "monitor:
+    # running" but every msg refused. Helper auto-prunes the orphan.
     local _pidfile="$AIRC_WRITE_DIR/airc.pid"
     local _monitor_alive=0
-    if [ -f "$_pidfile" ]; then
-      local _pids; _pids=$(cat "$_pidfile" 2>/dev/null)
-      if [ -n "$_pids" ]; then
-        local _all_alive=1 _p
-        for _p in $_pids; do
-          kill -0 "$_p" 2>/dev/null || { _all_alive=0; break; }
-        done
-        [ "$_all_alive" = "1" ] && _monitor_alive=1
-      fi
+    if [ "$(prune_pidfile_and_count "$_pidfile")" -gt 0 ]; then
+      _monitor_alive=1
     fi
     if [ "$_monitor_alive" = "0" ]; then
       # --internal callers (informational broadcasts: [rename], etc.):

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -101,6 +101,20 @@ cmd_send() {
       --plaintext|-plaintext)
         plaintext=1
         shift ;;
+      --)
+        # POSIX flag-terminator: anything after this is positional even
+        # if it looks like a flag. Lets users send literal --strings in
+        # message bodies: `airc msg -- --foo bar`.
+        shift
+        while [ $# -gt 0 ]; do positional+=("$1"); shift; done
+        ;;
+      --*|-*)
+        # Unknown flag — pre-fix this fell into the *) catch-all and got
+        # silently absorbed into the message body, so 'airc msg
+        # --invalidflag value body' returned exit 0 broadcast (ideem-
+        # local-4bef caught 2026-04-29). Loud failure now; users with a
+        # literal --string in the message body can use the -- terminator.
+        die "Unknown flag: $1 (use -- to terminate flags if this is part of the message body)" ;;
       *) positional+=("$1"); shift ;;
     esac
   done
@@ -137,6 +151,17 @@ cmd_send() {
     case "$1" in
       @*)
         local _p="${1#@}"
+        # Reject empty `@` (continuum-b741 + ideem-local-4bef caught
+        # 2026-04-29: `airc msg @ body` silently broadcast). Reject
+        # double-@ `@@peer` while we're here (also caught: accepted as
+        # DM to literal '@peer'). Reject numeric-only DMs as per the
+        # peer-name charset rule (`@12345` is a likely typo, not a
+        # real peer).
+        case "$_p" in
+          "")           die "Empty @ recipient (use 'airc msg <message>' for broadcast, or 'airc msg @<peer> ...' for DM)" ;;
+          @*)           die "Double @ recipient '$1' — peer names are bare, not @-prefixed" ;;
+          *[!a-z0-9,-]*) die "Invalid peer name in '$1' — must match [a-z0-9-]+ (comma-separated for multi-DM)" ;;
+        esac
         if [ -z "$_peer_csv" ]; then
           _peer_csv="$_p"
         else
@@ -178,6 +203,12 @@ cmd_send() {
     peer_name="all"
     msg="$*"
   fi
+  # Reject empty broadcast bodies — pre-fix `airc msg ""` printed the
+  # usage line but exited 0 (continuum-b741 caught 2026-04-29). The
+  # other "no message" path already dies above; this one is the
+  # explicit-empty-string case that fell through.
+  [ "$peer_name" = "all" ] && [ -z "$msg" ] \
+    && die "empty message body (use 'airc msg <text>' or omit the empty quotes)"
   ensure_init
 
   local my_name ts_val

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -172,6 +172,14 @@ else:
 cmd_logs() {
   ensure_init
   local count="${1:-20}"
+  # Validate count: positive integer (ideem-local-4bef caught 2026-04-29:
+  # 'airc logs 0' and 'airc logs notanumber' silently exited 0 with no
+  # output). Tail with N=0 prints nothing; with non-numeric, tail errors
+  # and we swallow it.
+  case "$count" in
+    ''|*[!0-9]*) die "logs count must be a positive integer (got '$count')" ;;
+    0)           die "logs count must be ≥ 1 (got '$count')" ;;
+  esac
   local host_target
   host_target=$(get_config_val host_target "")
 

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -59,24 +59,19 @@ cmd_status() {
     fi
   fi
 
-  # Monitor alive? Read the scope's pidfile — cmd_connect writes its own PID
-  # there. pgrep'd descendants (python listener, tail loop) should be children
-  # of that PID. If the main PID is gone, the monitor is down.
+  # Monitor alive? Single helper at airc top-level (prune_pidfile_and_count)
+  # owns the contract: returns count of living pids and prunes dead orphans.
+  # Both cmd_status and cmd_send call it so they can never disagree
+  # again (the bug vhsm + authenticator hit 2026-04-29).
   local monitor_state="not running"
   local pidfile="$AIRC_WRITE_DIR/airc.pid"
-  if [ -f "$pidfile" ]; then
-    # cmd_connect writes multiple space-separated PIDs on one line (parent +
-    # python listener). Monitor is "running" if ANY of them is alive.
-    local pids_raw; pids_raw=$(cat "$pidfile" 2>/dev/null | tr '\n' ' ' || true)
-    local any_alive=""
-    for p in $pids_raw; do
-      if kill -0 "$p" 2>/dev/null; then any_alive="$p"; break; fi
-    done
-    if [ -n "$any_alive" ]; then
-      monitor_state="running (PID $any_alive)"
-    else
-      monitor_state="stale pidfile (PIDs $pids_raw not alive — run 'airc connect' to self-heal)"
-    fi
+  local live_count
+  live_count=$(prune_pidfile_and_count "$pidfile")
+  if [ "$live_count" -gt 0 ]; then
+    local first_alive; first_alive=$(awk '{print $1}' "$pidfile" 2>/dev/null)
+    monitor_state="running (PID $first_alive)"
+  elif [ -f "$pidfile" ]; then
+    monitor_state="stale pidfile (no live PIDs — run 'airc connect' to self-heal)"
   fi
   echo "  monitor:     $monitor_state"
 

--- a/lib/airc_core/monitor_formatter.py
+++ b/lib/airc_core/monitor_formatter.py
@@ -394,7 +394,12 @@ def run(my_name: str, peers_dir: str) -> int:
                 # received it).
                 ping_channel = m.get("channel", "")
                 import subprocess
-                cmd = ["airc", "send"]
+                # Auto-pong as PLAINTEXT (--plaintext) — encryption of
+                # control traffic was the root of #308: pair handshake
+                # asymmetry meant the sender often couldn't decrypt the
+                # encrypted PONG even when we DID auto-reply, so the
+                # round-trip silently failed.
+                cmd = ["airc", "send", "--plaintext"]
                 if ping_channel:
                     cmd += ["--channel", ping_channel]
                 cmd += [f"@{fr}", f"[PONG:{ping_id}]"]

--- a/test/integration_smoke.sh
+++ b/test/integration_smoke.sh
@@ -73,9 +73,23 @@ spawn_real() {
     )
   fi
   local i
-  for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+  for i in $(seq 1 20); do
     sleep 1
-    if grep -qE 'Hosting as|Connected to|Joined' "$home/out.log" 2>/dev/null; then
+    grep -qE 'Hosting as|Connected to|Joined' "$home/out.log" 2>/dev/null || continue
+    # For hosts: also wait until config.json has a channel_gists entry,
+    # i.e. the gist was actually published. Without this the next peer
+    # spawned right after sees no mesh on the account and bootstraps as
+    # its own host of the same room → two parallel gists, test fails.
+    if [ "$as_host" = "1" ]; then
+      python3 -c "
+import json,sys
+try:
+    c = json.load(open('$home/state/config.json'))
+    sys.exit(0 if c.get('channel_gists') else 1)
+except Exception:
+    sys.exit(1)
+" 2>/dev/null && return 0
+    else
       return 0
     fi
   done

--- a/test/test_monitor_formatter.py
+++ b/test/test_monitor_formatter.py
@@ -1,0 +1,156 @@
+"""monitor_formatter tests — auto-pong handler, heartbeat suppression.
+
+Run: cd test && python3 test_monitor_formatter.py
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+from airc_core import monitor_formatter as mf  # noqa: E402
+
+
+class AutoPongTests(unittest.TestCase):
+    """Pre-fix #308: auto-pong subprocess never fired even though the
+    [PING:uuid] line reached monitor_formatter via the gist. Test pipes
+    a [PING:] envelope to run() and asserts subprocess.Popen was called
+    with the right argv."""
+
+    def setUp(self):
+        self._scope = tempfile.mkdtemp(prefix="airc-mf-test-")
+        self._peers = os.path.join(self._scope, "peers")
+        os.makedirs(self._peers, exist_ok=True)
+        cfg = {
+            "name": "alice",
+            "subscribed_channels": ["general"],
+            "channel_gists": {"general": "abc123"},
+        }
+        with open(os.path.join(self._scope, "config.json"), "w") as f:
+            json.dump(cfg, f)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._scope, ignore_errors=True)
+
+    def _run_with_stdin(self, lines):
+        """Pipe `lines` to monitor_formatter.run, capture Popen calls.
+
+        Each line should be a dict (will be json.dumps'd) or a string."""
+        body = "\n".join(
+            json.dumps(l) if isinstance(l, dict) else str(l)
+            for l in lines
+        ) + "\n"
+        captured_popen = []
+
+        class _FakePopen:
+            def __init__(self, argv, **kwargs):
+                captured_popen.append(argv)
+            def wait(self, *_a, **_k): return 0
+
+        # Capture stdout to keep test output clean.
+        with mock.patch.object(mf.sys, "stdin", io.StringIO(body)), \
+             mock.patch.object(mf.sys, "stdout", io.StringIO()), \
+             mock.patch("subprocess.Popen", _FakePopen):
+            mf.run("alice", self._peers)
+
+        return captured_popen
+
+    def test_ping_addressed_to_me_fires_auto_pong(self):
+        envelope = {
+            "from": "bob",
+            "to": "alice",
+            "ts": "2026-04-29T00:00:00Z",
+            "channel": "general",
+            "msg": "[PING:11111111-2222-3333-4444-555555555555]",
+        }
+        popens = self._run_with_stdin([envelope])
+        self.assertEqual(len(popens), 1, f"expected exactly one Popen, got {popens}")
+        argv = popens[0]
+        self.assertEqual(argv[:2], ["airc", "send"])
+        self.assertIn("@bob", argv)
+        # PONG with the same uuid, in the same channel as the ping.
+        self.assertIn("[PONG:11111111-2222-3333-4444-555555555555]", argv)
+        self.assertIn("--channel", argv)
+        self.assertIn("general", argv)
+        # Plaintext is required for the round-trip — encryption of
+        # ping/pong was the actual #308 cause (pair-handshake asymmetry
+        # → one side dropped on decrypt → silent timeout).
+        self.assertIn("--plaintext", argv,
+                      "auto-pong must use --plaintext to dodge pair-handshake asymmetry")
+
+    def test_ping_addressed_to_someone_else_does_not_fire_pong(self):
+        envelope = {
+            "from": "bob",
+            "to": "carol",  # not me
+            "ts": "2026-04-29T00:00:00Z",
+            "channel": "general",
+            "msg": "[PING:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]",
+        }
+        popens = self._run_with_stdin([envelope])
+        self.assertEqual(popens, [], "must not auto-pong pings addressed to others")
+
+    def test_pong_is_suppressed_not_repeated(self):
+        # When an inbound PONG arrives (from another peer's auto-pong),
+        # monitor_formatter must NOT fire another PONG. Only the cmd_ping
+        # process polls the local log for the PONG marker.
+        envelope = {
+            "from": "bob",
+            "to": "alice",
+            "ts": "2026-04-29T00:00:00Z",
+            "channel": "general",
+            "msg": "[PONG:11111111-2222-3333-4444-555555555555]",
+        }
+        popens = self._run_with_stdin([envelope])
+        self.assertEqual(popens, [], "PONG must not trigger another Popen")
+
+    def test_broadcast_ping_does_not_fire_pong(self):
+        # A `to=all` ping is a discovery message the operator reads, not
+        # a round-trip. Auto-ponging it floods the room with N pongs.
+        envelope = {
+            "from": "bob",
+            "to": "all",
+            "ts": "2026-04-29T00:00:00Z",
+            "channel": "general",
+            "msg": "[PING:11111111-2222-3333-4444-555555555555]",
+        }
+        popens = self._run_with_stdin([envelope])
+        self.assertEqual(popens, [], "broadcast ping must not auto-pong")
+
+
+class HeartbeatSuppressionTests(unittest.TestCase):
+    """bearer_cli heartbeat lines must be recognized + suppressed +
+    arm the watchdog. Display would clutter chat with airc_heartbeat
+    JSON every 30s otherwise."""
+
+    def setUp(self):
+        self._scope = tempfile.mkdtemp(prefix="airc-mf-hb-test-")
+        self._peers = os.path.join(self._scope, "peers")
+        os.makedirs(self._peers, exist_ok=True)
+        with open(os.path.join(self._scope, "config.json"), "w") as f:
+            json.dump({"name": "alice"}, f)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._scope, ignore_errors=True)
+
+    def test_heartbeat_line_is_swallowed_no_stdout_output(self):
+        body = json.dumps({"airc_heartbeat": 1, "ts": 0, "channel": "general"}) + "\n"
+        out = io.StringIO()
+        with mock.patch.object(mf.sys, "stdin", io.StringIO(body)), \
+             mock.patch.object(mf.sys, "stdout", out):
+            mf.run("alice", self._peers)
+        self.assertEqual(out.getvalue(), "", "heartbeat must produce zero stdout output")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Bundle: 4 fixes from this morning's open-issue sweep.

- **#316 pidfile any-alive contract** — closes status/send liveness disagreement (vhsm + authenticator both repro'd).
- **#317 ping/pong plaintext** — sidesteps pair-handshake asymmetry that was silently dropping encrypted PONGs (#308).
- **#318 input-validation cluster** — 6 silent-accept bugs continuum + ideem caught: unknown msg flags, empty @ recipient, empty body, double-@, nick silent sanitization, nick collision, bad logs count.
- **#319 host bootstrap canonical filename** — pairs with #297 to close the heartbeat-fails-and-evicts loop (#301).

68/68 unit tests + 5/5 monitor_formatter tests + 4/4 integration_smoke pass.