### PR TITLE
fix: channel_gist convergence — oldest gist wins on duplicates

### DIFF
--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -185,17 +185,24 @@ def find_existing(channel: str) -> Optional[str]:
     """Look for an existing gist on this gh account hosting `channel`.
     Returns the gist id, or None if no match.
 
-    Two-pass to fix #290 (substrate split): canonical single-channel
-    gists (channels=[<channel>] exactly, description "airc room: #<x>")
-    take priority over legacy multi-channel mesh gists (channels=[a,b,c]).
-    Without this priority, peers resolved different gists when both
-    shapes coexisted on the same gh account, splitting the substrate
-    silently.
+    Convergence rule: when multiple gists match (duplicates from
+    repeated host-takeovers / race-loser collisions / orphaned
+    re-creates), return the OLDEST by created_at. Deterministic
+    across ALL peers on the gh account → all peers converge on the
+    same gist → substrate is unified.
 
-    Pass 1: any gist with channels=[<exact channel>] — the post-3c
-            create_new shape; deterministic match.
-    Pass 2: legacy multi-channel match — channels list CONTAINS the
-            target. Returned only if no single-channel canonical exists.
+    Pre-2026-04-29 bug: order was whatever gh's list-response yielded
+    first (recency-ordered, may differ across calls). Two peers
+    polling the listing at slightly different times could pick
+    DIFFERENT duplicates, splitting the substrate. authenticator-448f
+    + continuum-b741 saw this on #general — peers thought they were
+    in the same room but were writing to different gists. Sends
+    looked successful, peers heard nothing.
+
+    Two-pass to fix #290 (canonical-vs-legacy split): single-channel
+    gists (channels=[<channel>] exactly) take priority over multi-
+    channel mesh gists (channels=[a,b,c]). Within each pass, oldest
+    wins for convergence.
 
     Each pass first checks the cheap listing-response content, then
     falls back to a full GET when the listing didn't inline content.
@@ -207,13 +214,26 @@ def find_existing(channel: str) -> Optional[str]:
         if desc.startswith("airc mesh") or desc.startswith("airc room:"):
             candidates.append(g)
 
+    def _oldest(matches: list[dict]) -> Optional[str]:
+        """Return the gist id of the oldest match by created_at, or None."""
+        if not matches:
+            return None
+        # gh's created_at is ISO-8601 ('2026-04-29T07:11:00Z') so
+        # lexicographic sort matches chronological. Empty/missing
+        # values sort first (treated as oldest), which is the safe
+        # bias when in doubt.
+        matches.sort(key=lambda g: g.get("created_at", ""))
+        return matches[0].get("id")
+
     # Pass 1: canonical single-channel match (cheap, listing-response).
-    for g in candidates:
-        if _is_single_channel_match(g, channel):
-            return g.get("id")
+    canonical_matches = [g for g in candidates if _is_single_channel_match(g, channel)]
+    chosen = _oldest(canonical_matches)
+    if chosen:
+        return chosen
 
     # Pass 1 (deep): full GET for each candidate whose listing-content
     # was truncated. Same single-channel criterion.
+    deep_canonical: list[dict] = []
     for g in candidates:
         gid = g.get("id")
         if not gid:
@@ -222,12 +242,20 @@ def find_existing(channel: str) -> Optional[str]:
         if full is None:
             continue
         if _is_single_channel_match(full, channel):
-            return gid
+            # Carry created_at from the listing so _oldest can sort.
+            full.setdefault("created_at", g.get("created_at", ""))
+            deep_canonical.append(full)
+    chosen = _oldest(deep_canonical)
+    if chosen:
+        return chosen
 
     # Pass 2: legacy multi-channel fallback. Only if no canonical exists.
-    for g in candidates:
-        if _gist_describes_channel(g, channel):
-            return g.get("id")
+    legacy_matches = [g for g in candidates if _gist_describes_channel(g, channel)]
+    chosen = _oldest(legacy_matches)
+    if chosen:
+        return chosen
+
+    deep_legacy: list[dict] = []
     for g in candidates:
         gid = g.get("id")
         if not gid:
@@ -236,9 +264,9 @@ def find_existing(channel: str) -> Optional[str]:
         if full is None:
             continue
         if _gist_describes_channel(full, channel):
-            return gid
-
-    return None
+            full.setdefault("created_at", g.get("created_at", ""))
+            deep_legacy.append(full)
+    return _oldest(deep_legacy)
 
 
 def create_new(channel: str) -> Optional[str]:

--- a/test/test_channel_gist.py
+++ b/test/test_channel_gist.py
@@ -1,0 +1,121 @@
+"""channel_gist tests — convergence on duplicate gists.
+
+Run: cd test && python3 test_channel_gist.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+from airc_core import channel_gist  # noqa: E402
+
+
+class FindExistingConvergenceTests(unittest.TestCase):
+    """When two+ gists describe the same channel (host-takeover races,
+    accidental dup creates), all peers must converge on ONE gist.
+    Pre-fix find_existing returned whichever happened to appear first
+    in gh's list-response, which is recency-ordered → different peers
+    saw different "first" → substrate split silently.
+
+    Convergence rule: oldest-by-created_at wins. Deterministic across
+    every peer on the gh account regardless of when they polled."""
+
+    def _gist(self, gid, channel, created_at, desc=None):
+        return {
+            "id": gid,
+            "description": desc or f"airc room: #{channel} (post-3c per-channel gist)",
+            "created_at": created_at,
+            "files": {
+                f"airc-room-{channel}.json": {
+                    "content": '{"airc": 1, "kind": "mesh", "channels": ["%s"]}' % channel,
+                    "truncated": False,
+                },
+            },
+        }
+
+    def test_returns_oldest_when_two_canonical_dups(self):
+        """Two gists describe #general with identical canonical shape;
+        find_existing must return the OLDEST regardless of list order."""
+        # gh list-response is recency-ordered: NEWER first.
+        listing = [
+            self._gist("newer-id", "general", "2026-04-29T15:00:00Z"),
+            self._gist("older-id", "general", "2026-04-29T07:00:00Z"),
+        ]
+        with mock.patch.object(channel_gist, "_gh_list_user_gists", return_value=listing):
+            chosen = channel_gist.find_existing("general")
+        self.assertEqual(chosen, "older-id",
+                         "must converge on the OLDEST duplicate, not newest")
+
+    def test_returns_oldest_across_three_dups(self):
+        listing = [
+            self._gist("middle", "general", "2026-04-29T10:00:00Z"),
+            self._gist("newest", "general", "2026-04-29T15:00:00Z"),
+            self._gist("oldest", "general", "2026-04-29T05:00:00Z"),
+        ]
+        with mock.patch.object(channel_gist, "_gh_list_user_gists", return_value=listing):
+            chosen = channel_gist.find_existing("general")
+        self.assertEqual(chosen, "oldest")
+
+    def test_canonical_wins_over_legacy_even_when_legacy_is_older(self):
+        """#290 contract preserved: canonical single-channel gists take
+        priority over legacy multi-channel mesh gists. Even if the
+        legacy mesh is OLDER, the canonical wins (oldest among
+        canonicals). This tiebreak avoids re-introducing the split
+        between [#general] and [a, b, c, general] gists."""
+        legacy_old = {
+            "id": "legacy-old",
+            "description": "airc mesh",
+            "created_at": "2026-04-29T01:00:00Z",
+            "files": {
+                "airc-room-mesh.json": {
+                    "content": '{"airc": 1, "kind": "mesh", "channels": ["a", "b", "general"]}',
+                    "truncated": False,
+                },
+            },
+        }
+        canonical_newer = self._gist("canonical-new", "general", "2026-04-29T08:00:00Z")
+        with mock.patch.object(channel_gist, "_gh_list_user_gists",
+                               return_value=[legacy_old, canonical_newer]):
+            chosen = channel_gist.find_existing("general")
+        self.assertEqual(chosen, "canonical-new",
+                         "canonical (single-channel) priority overrides legacy oldest")
+
+    def test_returns_none_when_no_match(self):
+        with mock.patch.object(channel_gist, "_gh_list_user_gists", return_value=[]):
+            self.assertIsNone(channel_gist.find_existing("nonexistent"))
+
+    def test_returns_oldest_legacy_when_no_canonical(self):
+        """If only legacy mesh gists exist (none canonical), still
+        converge on oldest among them."""
+        m_old = {
+            "id": "mesh-old",
+            "description": "airc mesh",
+            "created_at": "2026-04-29T05:00:00Z",
+            "files": {"airc-room-mesh.json": {
+                "content": '{"airc":1,"kind":"mesh","channels":["a","general","c"]}',
+                "truncated": False,
+            }},
+        }
+        m_new = {
+            "id": "mesh-new",
+            "description": "airc mesh",
+            "created_at": "2026-04-29T15:00:00Z",
+            "files": {"airc-room-mesh.json": {
+                "content": '{"airc":1,"kind":"mesh","channels":["general","x"]}',
+                "truncated": False,
+            }},
+        }
+        with mock.patch.object(channel_gist, "_gh_list_user_gists",
+                               return_value=[m_new, m_old]):
+            chosen = channel_gist.find_existing("general")
+        self.assertEqual(chosen, "mesh-old")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Real production bug Joel pinpointed: 'I can manually message them' — peers were on DIFFERENT #general gists (multiple dups on the gh account). Sends looked successful, peers heard nothing. find_existing returned whichever appeared first in gh's list-response (recency-ordered, non-deterministic). Now returns OLDEST by created_at, same rule _mesh_find uses. Test coverage: 5 cases. Critical for substrate convergence.