### PR TITLE
test+wip: substrate-truth scenarios + host-bootstrap find-first (partial)

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1257,6 +1257,43 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
         echo "     Install: https://cli.github.com  (or: brew install gh)"
         echo "     Skipping gist push; long invite above is the only handoff."
       else
+        # Convergence-first (#321 follow-up): before bootstrapping a NEW
+        # gist for this channel, consult channel_gist.find_existing.
+        # If a canonical gist for this room name already exists on the
+        # gh account, USE IT — don't create yet another duplicate. This
+        # was the pre-fix bug that produced multiple #general gists on
+        # the same account: every --as-host bootstrap created its own
+        # gist regardless of what was already there. With find-first,
+        # all hosts on the gh account converge on the oldest canonical.
+        local _existing_room_gid=""
+        if [ "$use_room" = "1" ]; then
+          _existing_room_gid=$("$AIRC_PYTHON" -m airc_core.channel_gist resolve \
+                               --channel "$room_name" 2>/dev/null || true)
+        fi
+        if [ -n "$_existing_room_gid" ]; then
+          echo "  ✓ Found canonical gist for #${room_name} on this gh account → using existing ($_existing_room_gid)"
+          local _gist_id="$_existing_room_gid"
+          local _gist_url="https://gist.github.com/$_gist_id"
+          local _gist_kind="room"
+          # Persist the canonical mapping. Heartbeat + sends route here
+          # automatically; first send creates messages.jsonl in the
+          # existing gist.
+          echo "$_gist_id" > "$AIRC_WRITE_DIR/room_gist_id"
+          echo "$room_name" > "$AIRC_WRITE_DIR/room_name"
+          "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
+            --config "$CONFIG" --channel "$room_name" --gist-id "$_gist_id" 2>/dev/null || true
+          # Skip the new-gist creation block below since we have one.
+          # Continue to the heartbeat + monitor setup as if we'd just
+          # created it — the gist exists, we own/share it, write to it.
+          : >"$AIRC_WRITE_DIR/.using_existing_room_gist"
+        fi
+
+        # Skip create-new entirely if we already adopted an existing
+        # canonical gist above (find-first convergence path).
+        if [ -n "${_existing_room_gid:-}" ]; then
+          true  # No-op; downstream heartbeat + monitor setup uses
+                # _gist_id / _gist_url already set above.
+        else
         # Bootstrap basename + description match channel_gist.create_new's
         # canonical shape (airc-room-<channel>.json + "airc room: #X").
         # Pre-fix the host path used a random mktemp basename
@@ -1350,6 +1387,7 @@ JSON
         # gists should be deleted by the host after the first joiner.
         local _gist_url; _gist_url=$(gh gist create -d "$_gist_desc" "$_gist_tmp" 2>/dev/null | tail -1)
         rm -rf "$_gist_tmpdir"
+        fi  # close: skip create-new when adopted existing canonical
         if [ -n "$_gist_url" ]; then
           local _gist_id="${_gist_url##*/}"
           local _hh; _hh=$(humanhash "$_gist_id" 2>/dev/null)

--- a/test/integration_smoke.sh
+++ b/test/integration_smoke.sh
@@ -272,6 +272,91 @@ scenario_idle_then_recv() {
 # `airc part` from the host should delete the room gist on gh.
 # Joiners parting just teardown locally (host's gist persists).
 # ─────────────────────────────────────────────────────────────────────
+scenario_status_agrees_with_send() {
+  # Today's bug Joel called out: 'airc status' said monitor: not running
+  # while 'airc msg' worked + landed in gist. The two diagnostics
+  # disagreed, which is exactly the silent-broken class CLAUDE.md
+  # forbids. If sends work, status MUST report monitor running.
+  section "status_agrees_with_send: if msg lands in gist, status must say running"
+  require_gh || return
+
+  local rname="smoke-statusagree-$$"
+  local A_HOME
+  A_HOME=$(mktemp -d -t airc-statusagree.XXXXXX)
+  trap "cleanup_homes '$A_HOME'" RETURN
+
+  spawn_real "$A_HOME" "smoke-sa-$$" 7607 --room "$rname" --as-host \
+    || { fail "host failed to start"; return; }
+  sleep 2
+
+  local marker="status-agree-$(date +%s%N)"
+  AIRC_HOME="$A_HOME/state" "$AIRC" msg --room "$rname" "$marker" >/dev/null 2>&1
+  sleep 3
+
+  local gid; gid=$(python3 -c "import json;print(json.load(open('$A_HOME/state/config.json')).get('channel_gists',{}).get('$rname',''))")
+  local landed=0
+  gh api "gists/$gid" --jq '.files["messages.jsonl"].content // ""' 2>/dev/null | grep -qF "$marker" && landed=1
+  [ "$landed" = "1" ] || { fail "msg didn't land in gist — substrate broken, can't test status"; return; }
+
+  local status_out; status_out=$(AIRC_HOME="$A_HOME/state" "$AIRC" status 2>&1)
+  if printf '%s' "$status_out" | grep -qE "monitor: *running"; then
+    pass "msg landed AND status says monitor running (diagnostics agree)"
+  else
+    fail "msg LANDED but status reports monitor not running — diagnostics lie"
+    printf '%s' "$status_out" | sed 's/^/    /'
+  fi
+}
+
+scenario_stale_config_auto_resyncs() {
+  # Pre-seed channel_gists with a bogus gist id (simulates a peer
+  # who paired with a non-canonical dup pre-#321). After bounce,
+  # the host's subscription must self-heal to the actual gist on
+  # disk. Pre-fix peers stuck on stale mappings forever.
+  section "stale_config_auto_resyncs: bogus channel_gists is replaced on bounce"
+  require_gh || return
+
+  local rname="smoke-resync-$$"
+  local A_HOME
+  A_HOME=$(mktemp -d -t airc-resync.XXXXXX)
+  trap "cleanup_homes '$A_HOME'" RETURN
+
+  spawn_real "$A_HOME" "smoke-rs-$$" 7608 --room "$rname" --as-host \
+    || { fail "first spawn failed"; return; }
+  local good_gid; good_gid=$(python3 -c "import json;print(json.load(open('$A_HOME/state/config.json')).get('channel_gists',{}).get('$rname',''))")
+  [ -n "$good_gid" ] || { fail "first spawn didn't write channel_gists"; return; }
+  pass "first spawn: channel_gists['$rname']=$good_gid"
+
+  AIRC_HOME="$A_HOME/state" "$AIRC" teardown >/dev/null 2>&1
+
+  # Poison: replace channel_gists[$rname] with a bogus id
+  python3 -c "
+import json
+p = '$A_HOME/state/config.json'
+c = json.load(open(p))
+c['channel_gists'] = {'$rname': 'deadbeefcafebabe000000000000beef'}
+json.dump(c, open(p,'w'), indent=2)
+"
+
+  ( cd "$A_HOME" && AIRC_HOME="$A_HOME/state" AIRC_NAME="smoke-rs-$$" AIRC_PORT=7609 \
+      AIRC_NO_DISCOVERY=1 AIRC_NO_AUTO_ROOM=1 AIRC_NO_GENERAL=1 AIRC_NO_IDENTITY_PROMPT=1 \
+      "$AIRC" connect --room "$rname" > "$A_HOME/out2.log" 2>&1 & )
+  local i
+  for i in $(seq 1 15); do
+    sleep 1
+    grep -qE "Hosting as|Connected to|Joined" "$A_HOME/out2.log" 2>/dev/null && break
+  done
+  sleep 3
+
+  local final_gid; final_gid=$(python3 -c "import json;print(json.load(open('$A_HOME/state/config.json')).get('channel_gists',{}).get('$rname',''))")
+  if [ "$final_gid" = "$good_gid" ]; then
+    pass "auto-resync replaced bogus 'deadbeef...' with the canonical gist"
+  elif [ "$final_gid" = "deadbeefcafebabe000000000000beef" ]; then
+    fail "STILL bogus after bounce — channel_gists was trusted blindly, no auto-resync"
+  else
+    fail "channel_gists['$rname']='$final_gid' (neither canonical nor bogus — created a 3rd duplicate?)"
+  fi
+}
+
 scenario_part_deletes_host_gist() {
   section "part: host's airc part deletes the gist; joiner's part doesn't"
   require_gh || return
@@ -311,19 +396,23 @@ scenario_part_deletes_host_gist() {
 # Dispatch
 # ─────────────────────────────────────────────────────────────────────
 case "${1:-all}" in
-  passive_recv)         scenario_passive_recv ;;
-  round_trip)           scenario_round_trip ;;
-  idle_then_recv)       scenario_idle_then_recv ;;
-  part_deletes_host_gist) scenario_part_deletes_host_gist ;;
+  passive_recv)              scenario_passive_recv ;;
+  round_trip)                scenario_round_trip ;;
+  idle_then_recv)            scenario_idle_then_recv ;;
+  part_deletes_host_gist)    scenario_part_deletes_host_gist ;;
+  status_agrees_with_send)   scenario_status_agrees_with_send ;;
+  stale_config_auto_resyncs) scenario_stale_config_auto_resyncs ;;
   all)
     scenario_passive_recv
     scenario_round_trip
+    scenario_status_agrees_with_send
+    scenario_stale_config_auto_resyncs
     scenario_part_deletes_host_gist
-    # idle_then_recv last — it's the slow one (45s+ idle wait)
+    # idle_then_recv last — slow (45s+ idle wait)
     scenario_idle_then_recv
     ;;
   *)
-    echo "Usage: $0 [passive_recv|round_trip|idle_then_recv|part_deletes_host_gist|all]"
+    echo "Usage: $0 [passive_recv|round_trip|idle_then_recv|part_deletes_host_gist|status_agrees_with_send|stale_config_auto_resyncs|all]"
     exit 2
     ;;
 esac


### PR DESCRIPTION
Two new TDD scenarios catch real diagnostic-disagreement + stale-config-recovery gaps. status_agrees_with_send is green; stale_config_auto_resyncs is red and ships as a regression guard until the host-bootstrap helper unification lands. The clean-state convergence path #321 works in production (4 peers converged today).