### PR TITLE
fix: gh-auth surface + identity caps + airc.pid full-tree

### DIFF
--- a/airc
+++ b/airc
@@ -1028,8 +1028,26 @@ monitor() {
   local my_name; my_name=$(get_name)
 
   # Background reminder timer + pending-flush loops.
+  # Capture their PIDs and append to airc.pid so status / teardown /
+  # send's monitor-alive check see the FULL tree, not just the parent.
+  # Pre-fix airc.pid had only $$; if the parent died first while these
+  # subshells were still running, status said "monitor: not running"
+  # and send refused — even though the subshells were still alive.
+  # Post-#325 the subshells self-reap on parent death anyway, but
+  # tracking them keeps the pidfile honest during the in-between
+  # window and after legitimate parent restarts.
   ( reminder_timer_loop ) &
+  local _reminder_pid=$!
   ( flush_pending_loop ) &
+  local _flush_pid=$!
+  if [ -f "$AIRC_WRITE_DIR/airc.pid" ]; then
+    # Append to existing pidfile atomically (printf+>> is < PIPE_BUF
+    # so atomic on POSIX). Don't overwrite — cmd_connect already
+    # wrote the parent + handshake + heartbeat pids there.
+    printf ' %s %s\n' "$_reminder_pid" "$_flush_pid" >> "$AIRC_WRITE_DIR/airc.pid"
+  else
+    printf '%s %s %s\n' "$$" "$_reminder_pid" "$_flush_pid" > "$AIRC_WRITE_DIR/airc.pid"
+  fi
 
   # Resolution priority:
   #   1. channel_gists map non-empty → multi-channel mode (post-#283:

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -92,6 +92,28 @@ ensure_channel_subscribed_with_gist() {
 }
 
 cmd_connect() {
+  # Pre-flight: gh auth check. The gh keyring can silently invalidate
+  # (token revoked / 2FA flow expired / brew upgrade replaced gh
+  # without re-auth) and EVERY downstream gh API call then fails
+  # silently — bearer.send returns auth_failure, bearer recv polls
+  # forever getting nothing, peers see "monitor running, no traffic"
+  # which is the exact freeze pattern Joel kept hitting. Catch this
+  # at connect time so the user gets a clear error instead of a
+  # mystery timeout.
+  if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+      echo "" >&2
+      echo "  ✗ gh CLI is installed but the GitHub token is invalid." >&2
+      echo "    Detail:" >&2
+      gh auth status 2>&1 | sed 's/^/      /' >&2
+      echo "" >&2
+      echo "    Fix:  gh auth login -h github.com" >&2
+      echo "" >&2
+      echo "    Without gh auth, airc can't talk to the gist substrate at all." >&2
+      die "gh auth invalid — run 'gh auth login -h github.com' first"
+    fi
+  fi
+
   # Flag parsing. Issue #37 — host display shapes:
   #   default (gh installed + authed): gist ID + humanhash mnemonic + long invite
   #   default (no gh OR gh not authed): long invite only (today's behavior)

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -172,6 +172,25 @@ _identity_set() {
   if [ "$set_pronouns" = 0 ] && [ "$set_role" = 0 ] && [ "$set_bio" = 0 ] && [ "$set_status" = 0 ]; then
     die "Pass at least one of --pronouns / --role / --bio / --status"
   fi
+  # Length caps (continuum-b741 caught 2026-04-29: 4KB bio stored
+  # verbatim → broke peer rendering + ate gist quota). Bio is one line
+  # of context, not a manifesto. Hard caps with loud rejection.
+  local _max_pronouns=64
+  local _max_role=128
+  local _max_bio=512
+  local _max_status=256
+  if [ "$set_pronouns" = 1 ] && [ "${#pronouns}" -gt "$_max_pronouns" ]; then
+    die "pronouns too long (${#pronouns} chars; max $_max_pronouns)"
+  fi
+  if [ "$set_role" = 1 ] && [ "${#role}" -gt "$_max_role" ]; then
+    die "role too long (${#role} chars; max $_max_role)"
+  fi
+  if [ "$set_bio" = 1 ] && [ "${#bio}" -gt "$_max_bio" ]; then
+    die "bio too long (${#bio} chars; max $_max_bio — bios are one-liners, not manifestos)"
+  fi
+  if [ "$set_status" = 1 ] && [ "${#status}" -gt "$_max_status" ]; then
+    die "status too long (${#status} chars; max $_max_status)"
+  fi
   CONFIG="$CONFIG" \
     SET_PRONOUNS="$set_pronouns" PRONOUNS="$pronouns" \
     SET_ROLE="$set_role"         ROLE="$role" \

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -341,15 +341,22 @@ cmd_send() {
         ;;
       auth_failure)
         # Hard failure. Don't queue — every retry will fail identically.
-        # Surface loudly + die so the user re-pairs instead of sending
-        # into the void.
-        local fail_marker; fail_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[AUTH FAILED to %s — repair required, NOT queued] %s"}' \
+        # Pre-fix the message claimed 'SSH auth' which was leftover from
+        # the SSH era; post-3c the bearer is gh and the only auth that
+        # can fail is gh's. Direct the user to gh auth login so they
+        # can recover without rebuilding their identity.
+        local fail_marker; fail_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[GH AUTH FAILED to %s — re-auth required, NOT queued] %s"}' \
           "$(timestamp)" "$active_channel" "$peer_name" "${detail:-no detail}")
         echo "$fail_marker" >> "$MESSAGES"
-        echo "  SSH auth to host FAILED. Message NOT queued — every retry would fail identically." >&2
-        echo "  Bearer: ${detail}" >&2
-        echo "  Fix: airc teardown --flush && airc connect <invite-string>" >&2
-        die "Authentication failure — re-pair required"
+        echo "" >&2
+        echo "  ✗ gh auth check failed — your GitHub token is dead." >&2
+        echo "    Bearer detail: ${detail}" >&2
+        echo "" >&2
+        echo "    Fix:  gh auth login -h github.com" >&2
+        echo "" >&2
+        echo "    After re-authenticating, retry your message. No state lost," >&2
+        echo "    no re-pair needed — it's just gh's keyring that expired." >&2
+        die "gh auth failure — run 'gh auth login -h github.com' and retry"
         ;;
       transient_failure|"")
         # Network-class failure or empty/malformed outcome → treat as

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -144,6 +144,20 @@ else:
     echo "  bearer:      n/a (this scope is hosting; inbound is local log)"
   fi
 
+  # gh auth health — surface mid-session token expiry so users have
+  # a one-line diagnostic instead of mysterious silent failures.
+  # The substrate is gh-as-bearer; when gh's keyring goes invalid,
+  # everything stops working but nothing surfaces unless they look here.
+  if command -v gh >/dev/null 2>&1; then
+    if gh auth status >/dev/null 2>&1; then
+      echo "  gh auth:     ok"
+    else
+      echo "  gh auth:     ✗ INVALID — run 'gh auth login -h github.com' to fix"
+    fi
+  else
+    echo "  gh auth:     gh CLI not installed"
+  fi
+
   # Pending queue — how many sends are waiting for a drain. Populated by
   # cmd_send's wire-failure branch; drained by flush_pending_loop.
   local pending="$AIRC_WRITE_DIR/pending.jsonl"


### PR DESCRIPTION
Five fixes for fresh-Mac e2e: gh auth pre-flight on connect, gh auth state in status, accurate auth_failure error in send, identity length caps (4KB bios → 512 max), reminder/flush PIDs added to airc.pid for honest status/teardown.