### PR TITLE
canary → main: gh-auth detection, identity caps, pidfile tracking, clean-install smoke

### DIFF
--- a/airc
+++ b/airc
@@ -1028,8 +1028,26 @@ monitor() {
   local my_name; my_name=$(get_name)
 
   # Background reminder timer + pending-flush loops.
+  # Capture their PIDs and append to airc.pid so status / teardown /
+  # send's monitor-alive check see the FULL tree, not just the parent.
+  # Pre-fix airc.pid had only $$; if the parent died first while these
+  # subshells were still running, status said "monitor: not running"
+  # and send refused — even though the subshells were still alive.
+  # Post-#325 the subshells self-reap on parent death anyway, but
+  # tracking them keeps the pidfile honest during the in-between
+  # window and after legitimate parent restarts.
   ( reminder_timer_loop ) &
+  local _reminder_pid=$!
   ( flush_pending_loop ) &
+  local _flush_pid=$!
+  if [ -f "$AIRC_WRITE_DIR/airc.pid" ]; then
+    # Append to existing pidfile atomically (printf+>> is < PIPE_BUF
+    # so atomic on POSIX). Don't overwrite — cmd_connect already
+    # wrote the parent + handshake + heartbeat pids there.
+    printf ' %s %s\n' "$_reminder_pid" "$_flush_pid" >> "$AIRC_WRITE_DIR/airc.pid"
+  else
+    printf '%s %s %s\n' "$$" "$_reminder_pid" "$_flush_pid" > "$AIRC_WRITE_DIR/airc.pid"
+  fi
 
   # Resolution priority:
   #   1. channel_gists map non-empty → multi-channel mode (post-#283:

--- a/airc
+++ b/airc
@@ -1146,8 +1146,23 @@ flush_pending_loop() {
   local rhome; rhome=$(remote_home)
   local ssh_key="$IDENTITY_DIR/ssh_key"
 
+  # Parent-liveness gate (#324 follow-up): when the bash parent that
+  # launched this subshell dies (bearer pipeline dies, formatter
+  # watchdog trips, signal kills the main connect process), this
+  # subshell is reparented to init and will keep running forever
+  # without a check. That produced the 'monitor frozen, only Reminder
+  # firing' symptom Joel kept seeing — one of these orphaned loops
+  # was alive while the rest of the scope was dead. Capture parent
+  # PID at start; exit when it dies.
+  local _parent_pid="$PPID"
+
   while true; do
     sleep 5
+    if ! kill -0 "$_parent_pid" 2>/dev/null; then
+      # Parent gone — we're orphaned. Exit so we don't keep doing
+      # work for a dead scope.
+      return 0
+    fi
     [ -s "$pending" ] || continue
 
     # Re-read host_target each iteration — user might have re-paired.
@@ -1209,8 +1224,17 @@ flush_pending_loop() {
 # Periodically checks whether the user has been silent longer than their
 # configured interval. Fires ONCE per silence period (via reminded marker).
 reminder_timer_loop() {
+  # Parent-liveness gate (#324 follow-up). Without this, this subshell
+  # survives parent death and keeps emitting "Reminder: you haven't
+  # sent a message in Ns" forever — the visible symptom of the
+  # "monitor frozen but reminder firing" pattern Joel kept seeing.
+  # Capture parent PID at start; exit when it dies.
+  local _parent_pid="$PPID"
   while true; do
     sleep 5
+    if ! kill -0 "$_parent_pid" 2>/dev/null; then
+      return 0
+    fi
     local reminder_file="$AIRC_WRITE_DIR/reminder"
     local reminded_file="$AIRC_WRITE_DIR/reminded"
     [ -f "$reminder_file" ] || continue

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1267,6 +1267,13 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
         # all hosts on the gh account converge on the oldest canonical.
         local _existing_room_gid=""
         if [ "$use_room" = "1" ]; then
+          # Use full retry so gh's gist-listing eventual consistency
+          # (a just-created gist may not appear in `gh gist list` for
+          # several seconds) doesn't cause the host to create a
+          # duplicate of a gist that already exists. Cost: up to
+          # ~4.5s on a fresh-account first-spawn (no existing gist
+          # ever); accepted as a one-time cost on bootstrap to
+          # guarantee convergence on every later restart.
           _existing_room_gid=$("$AIRC_PYTHON" -m airc_core.channel_gist resolve \
                                --channel "$room_name" 2>/dev/null || true)
         fi

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1257,6 +1257,43 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
         echo "     Install: https://cli.github.com  (or: brew install gh)"
         echo "     Skipping gist push; long invite above is the only handoff."
       else
+        # Convergence-first (#321 follow-up): before bootstrapping a NEW
+        # gist for this channel, consult channel_gist.find_existing.
+        # If a canonical gist for this room name already exists on the
+        # gh account, USE IT — don't create yet another duplicate. This
+        # was the pre-fix bug that produced multiple #general gists on
+        # the same account: every --as-host bootstrap created its own
+        # gist regardless of what was already there. With find-first,
+        # all hosts on the gh account converge on the oldest canonical.
+        local _existing_room_gid=""
+        if [ "$use_room" = "1" ]; then
+          _existing_room_gid=$("$AIRC_PYTHON" -m airc_core.channel_gist resolve \
+                               --channel "$room_name" 2>/dev/null || true)
+        fi
+        if [ -n "$_existing_room_gid" ]; then
+          echo "  ✓ Found canonical gist for #${room_name} on this gh account → using existing ($_existing_room_gid)"
+          local _gist_id="$_existing_room_gid"
+          local _gist_url="https://gist.github.com/$_gist_id"
+          local _gist_kind="room"
+          # Persist the canonical mapping. Heartbeat + sends route here
+          # automatically; first send creates messages.jsonl in the
+          # existing gist.
+          echo "$_gist_id" > "$AIRC_WRITE_DIR/room_gist_id"
+          echo "$room_name" > "$AIRC_WRITE_DIR/room_name"
+          "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
+            --config "$CONFIG" --channel "$room_name" --gist-id "$_gist_id" 2>/dev/null || true
+          # Skip the new-gist creation block below since we have one.
+          # Continue to the heartbeat + monitor setup as if we'd just
+          # created it — the gist exists, we own/share it, write to it.
+          : >"$AIRC_WRITE_DIR/.using_existing_room_gist"
+        fi
+
+        # Skip create-new entirely if we already adopted an existing
+        # canonical gist above (find-first convergence path).
+        if [ -n "${_existing_room_gid:-}" ]; then
+          true  # No-op; downstream heartbeat + monitor setup uses
+                # _gist_id / _gist_url already set above.
+        else
         # Bootstrap basename + description match channel_gist.create_new's
         # canonical shape (airc-room-<channel>.json + "airc room: #X").
         # Pre-fix the host path used a random mktemp basename
@@ -1350,6 +1387,7 @@ JSON
         # gists should be deleted by the host after the first joiner.
         local _gist_url; _gist_url=$(gh gist create -d "$_gist_desc" "$_gist_tmp" 2>/dev/null | tail -1)
         rm -rf "$_gist_tmpdir"
+        fi  # close: skip create-new when adopted existing canonical
         if [ -n "$_gist_url" ]; then
           local _gist_id="${_gist_url##*/}"
           local _hh; _hh=$(humanhash "$_gist_id" 2>/dev/null)

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -92,6 +92,28 @@ ensure_channel_subscribed_with_gist() {
 }
 
 cmd_connect() {
+  # Pre-flight: gh auth check. The gh keyring can silently invalidate
+  # (token revoked / 2FA flow expired / brew upgrade replaced gh
+  # without re-auth) and EVERY downstream gh API call then fails
+  # silently — bearer.send returns auth_failure, bearer recv polls
+  # forever getting nothing, peers see "monitor running, no traffic"
+  # which is the exact freeze pattern Joel kept hitting. Catch this
+  # at connect time so the user gets a clear error instead of a
+  # mystery timeout.
+  if command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+      echo "" >&2
+      echo "  ✗ gh CLI is installed but the GitHub token is invalid." >&2
+      echo "    Detail:" >&2
+      gh auth status 2>&1 | sed 's/^/      /' >&2
+      echo "" >&2
+      echo "    Fix:  gh auth login -h github.com" >&2
+      echo "" >&2
+      echo "    Without gh auth, airc can't talk to the gist substrate at all." >&2
+      die "gh auth invalid — run 'gh auth login -h github.com' first"
+    fi
+  fi
+
   # Flag parsing. Issue #37 — host display shapes:
   #   default (gh installed + authed): gist ID + humanhash mnemonic + long invite
   #   default (no gh OR gh not authed): long invite only (today's behavior)

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -172,6 +172,25 @@ _identity_set() {
   if [ "$set_pronouns" = 0 ] && [ "$set_role" = 0 ] && [ "$set_bio" = 0 ] && [ "$set_status" = 0 ]; then
     die "Pass at least one of --pronouns / --role / --bio / --status"
   fi
+  # Length caps (continuum-b741 caught 2026-04-29: 4KB bio stored
+  # verbatim → broke peer rendering + ate gist quota). Bio is one line
+  # of context, not a manifesto. Hard caps with loud rejection.
+  local _max_pronouns=64
+  local _max_role=128
+  local _max_bio=512
+  local _max_status=256
+  if [ "$set_pronouns" = 1 ] && [ "${#pronouns}" -gt "$_max_pronouns" ]; then
+    die "pronouns too long (${#pronouns} chars; max $_max_pronouns)"
+  fi
+  if [ "$set_role" = 1 ] && [ "${#role}" -gt "$_max_role" ]; then
+    die "role too long (${#role} chars; max $_max_role)"
+  fi
+  if [ "$set_bio" = 1 ] && [ "${#bio}" -gt "$_max_bio" ]; then
+    die "bio too long (${#bio} chars; max $_max_bio — bios are one-liners, not manifestos)"
+  fi
+  if [ "$set_status" = 1 ] && [ "${#status}" -gt "$_max_status" ]; then
+    die "status too long (${#status} chars; max $_max_status)"
+  fi
   CONFIG="$CONFIG" \
     SET_PRONOUNS="$set_pronouns" PRONOUNS="$pronouns" \
     SET_ROLE="$set_role"         ROLE="$role" \

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -341,15 +341,22 @@ cmd_send() {
         ;;
       auth_failure)
         # Hard failure. Don't queue — every retry will fail identically.
-        # Surface loudly + die so the user re-pairs instead of sending
-        # into the void.
-        local fail_marker; fail_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[AUTH FAILED to %s — repair required, NOT queued] %s"}' \
+        # Pre-fix the message claimed 'SSH auth' which was leftover from
+        # the SSH era; post-3c the bearer is gh and the only auth that
+        # can fail is gh's. Direct the user to gh auth login so they
+        # can recover without rebuilding their identity.
+        local fail_marker; fail_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[GH AUTH FAILED to %s — re-auth required, NOT queued] %s"}' \
           "$(timestamp)" "$active_channel" "$peer_name" "${detail:-no detail}")
         echo "$fail_marker" >> "$MESSAGES"
-        echo "  SSH auth to host FAILED. Message NOT queued — every retry would fail identically." >&2
-        echo "  Bearer: ${detail}" >&2
-        echo "  Fix: airc teardown --flush && airc connect <invite-string>" >&2
-        die "Authentication failure — re-pair required"
+        echo "" >&2
+        echo "  ✗ gh auth check failed — your GitHub token is dead." >&2
+        echo "    Bearer detail: ${detail}" >&2
+        echo "" >&2
+        echo "    Fix:  gh auth login -h github.com" >&2
+        echo "" >&2
+        echo "    After re-authenticating, retry your message. No state lost," >&2
+        echo "    no re-pair needed — it's just gh's keyring that expired." >&2
+        die "gh auth failure — run 'gh auth login -h github.com' and retry"
         ;;
       transient_failure|"")
         # Network-class failure or empty/malformed outcome → treat as

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -144,6 +144,20 @@ else:
     echo "  bearer:      n/a (this scope is hosting; inbound is local log)"
   fi
 
+  # gh auth health — surface mid-session token expiry so users have
+  # a one-line diagnostic instead of mysterious silent failures.
+  # The substrate is gh-as-bearer; when gh's keyring goes invalid,
+  # everything stops working but nothing surfaces unless they look here.
+  if command -v gh >/dev/null 2>&1; then
+    if gh auth status >/dev/null 2>&1; then
+      echo "  gh auth:     ok"
+    else
+      echo "  gh auth:     ✗ INVALID — run 'gh auth login -h github.com' to fix"
+    fi
+  else
+    echo "  gh auth:     gh CLI not installed"
+  fi
+
   # Pending queue — how many sends are waiting for a drain. Populated by
   # cmd_send's wire-failure branch; drained by flush_pending_loop.
   local pending="$AIRC_WRITE_DIR/pending.jsonl"

--- a/lib/airc_bash/cmd_teardown.sh
+++ b/lib/airc_bash/cmd_teardown.sh
@@ -216,6 +216,41 @@ cmd_teardown() {
     rm -f "$pidfile" 2>/dev/null
   fi
 
+  # Env-var-based catch-all: ANY process whose AIRC_HOME env points at
+  # this scope is ours, even if airc.pid never knew about it. This
+  # catches:
+  #   - Subshells reparented to init (bash forked detached from parent)
+  #   - Python heartbeat / bearer_cli children whose parent died
+  #     before airc.pid was updated
+  #   - Stale background loops surviving multi-bounce sessions
+  # `ps eww -o pid,command -E` includes environment in the output on
+  # macOS + Linux. Match scopes by AIRC_HOME=<exact path>. Skip if the
+  # AIRC_TEARDOWN_PART_ONLY guard is set (cmd_part shouldn't sweep).
+  if [ "${AIRC_TEARDOWN_PART_ONLY:-0}" != "1" ]; then
+    local _scope_env_pids
+    _scope_env_pids=$(ps eww -o pid,command 2>/dev/null \
+                      | awk -v home="AIRC_HOME=$AIRC_WRITE_DIR" \
+                          '$0 ~ home && $1 != PROCINFO["pid"] { print $1 }' \
+                      | sort -un)
+    if [ -n "$_scope_env_pids" ]; then
+      # Exclude our own pid + parent (this very teardown subshell) so
+      # we don't suicide before completing the cleanup.
+      local _self_pid="$$"
+      local _parent_pid="$PPID"
+      local _filter_pids=""
+      for _p in $_scope_env_pids; do
+        [ "$_p" = "$_self_pid" ] && continue
+        [ "$_p" = "$_parent_pid" ] && continue
+        _filter_pids="$_filter_pids $_p"
+      done
+      if [ -n "$_filter_pids" ]; then
+        echo "  killing AIRC_HOME-tagged orphans: $(echo $_filter_pids | tr '\n' ' ')"
+        kill -9 $_filter_pids 2>/dev/null || true
+        killed=1
+      fi
+    fi
+  fi
+
   # Brief pause to let the kernel reparent any airc python listener children
   # to init (PID 1) after we killed their bash parent. Then reap orphans.
   [ "$killed" = "1" ] && sleep 0.5

--- a/lib/airc_bash/cmd_teardown.sh
+++ b/lib/airc_bash/cmd_teardown.sh
@@ -216,35 +216,34 @@ cmd_teardown() {
     rm -f "$pidfile" 2>/dev/null
   fi
 
-  # Env-var-based catch-all: ANY process whose AIRC_HOME env points at
-  # this scope is ours, even if airc.pid never knew about it. This
-  # catches:
-  #   - Subshells reparented to init (bash forked detached from parent)
-  #   - Python heartbeat / bearer_cli children whose parent died
-  #     before airc.pid was updated
-  #   - Stale background loops surviving multi-bounce sessions
-  # `ps eww -o pid,command -E` includes environment in the output on
-  # macOS + Linux. Match scopes by AIRC_HOME=<exact path>. Skip if the
-  # AIRC_TEARDOWN_PART_ONLY guard is set (cmd_part shouldn't sweep).
+  # Scope-path catch-all: ANY process whose argv contains this scope's
+  # path is ours, even if airc.pid never knew about it. Catches:
+  #   - Python handshake / monitor_formatter / bearer_cli children
+  #     whose parent died before airc.pid was updated.
+  #   - Subshells reparented to init that still hold scope state.
+  #   - Stale processes from multi-bounce sessions.
+  # pgrep -f matches command + arguments (not env). Every airc python
+  # subprocess passes scope paths on its argv (--peers-dir,
+  # --offset-file, etc), so cmdline match catches them all. The bash
+  # parent doesn't have scope on argv but its python children dying
+  # cascades it down via SIGCHLD/SIGPIPE.
+  # Skipped under AIRC_TEARDOWN_PART_ONLY (cmd_part shouldn't sweep).
   if [ "${AIRC_TEARDOWN_PART_ONLY:-0}" != "1" ]; then
-    local _scope_env_pids
-    _scope_env_pids=$(ps eww -o pid,command 2>/dev/null \
-                      | awk -v home="AIRC_HOME=$AIRC_WRITE_DIR" \
-                          '$0 ~ home && $1 != PROCINFO["pid"] { print $1 }' \
-                      | sort -un)
-    if [ -n "$_scope_env_pids" ]; then
+    local _scope_path_pids
+    _scope_path_pids=$(pgrep -f "$AIRC_WRITE_DIR" 2>/dev/null | sort -un)
+    if [ -n "$_scope_path_pids" ]; then
       # Exclude our own pid + parent (this very teardown subshell) so
       # we don't suicide before completing the cleanup.
       local _self_pid="$$"
       local _parent_pid="$PPID"
       local _filter_pids=""
-      for _p in $_scope_env_pids; do
+      for _p in $_scope_path_pids; do
         [ "$_p" = "$_self_pid" ] && continue
         [ "$_p" = "$_parent_pid" ] && continue
         _filter_pids="$_filter_pids $_p"
       done
       if [ -n "$_filter_pids" ]; then
-        echo "  killing AIRC_HOME-tagged orphans: $(echo $_filter_pids | tr '\n' ' ')"
+        echo "  killing scope-path-tagged orphans: $(echo $_filter_pids | tr '\n' ' ')"
         kill -9 $_filter_pids 2>/dev/null || true
         killed=1
       fi

--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -325,15 +325,31 @@ def resolve(channel: str, create_if_missing: bool = False) -> Optional[str]:
     if the channel can't be resolved (no gh auth, no existing gist
     AND create_if_missing=False, or creation failed).
 
-    Two-step: find_existing then optionally create_new. Keeps create
-    opt-in so callers that just want to look up don't accidentally
-    publish stray gists.
+    Two-step: find_existing then optionally create_new.
+
+    Retry on miss: gh's gist listing has eventual consistency — a
+    just-created gist may not appear in `gh gist list` for several
+    seconds. Without retry, a peer who reconnects right after another
+    peer hosted misses the canonical and creates a duplicate. Retry
+    twice with backoff before giving up; bounded so create_if_missing
+    callers don't wait forever on a genuinely-empty account.
     """
     if not channel or not isinstance(channel, str):
         return None
-    existing = find_existing(channel)
-    if existing:
-        return existing
+    import os as _os
+    import time as _t
+    # AIRC_RESOLVE_NO_RETRY: callers that DON'T want to wait on gh's
+    # listing-consistency lag (host-bootstrap find-first — if no gist
+    # exists, we'll create one anyway, no point waiting). Joiner paths
+    # leave it unset so they retry through the propagation window.
+    no_retry = _os.environ.get("AIRC_RESOLVE_NO_RETRY") == "1"
+    attempts = 1 if no_retry else 3
+    for attempt in range(attempts):
+        existing = find_existing(channel)
+        if existing:
+            return existing
+        if attempt < attempts - 1:
+            _t.sleep(1.5 * (attempt + 1))  # 1.5s, then 3s
     if create_if_missing:
         return create_new(channel)
     return None

--- a/test/integration_smoke.sh
+++ b/test/integration_smoke.sh
@@ -272,6 +272,91 @@ scenario_idle_then_recv() {
 # `airc part` from the host should delete the room gist on gh.
 # Joiners parting just teardown locally (host's gist persists).
 # ─────────────────────────────────────────────────────────────────────
+scenario_status_agrees_with_send() {
+  # Today's bug Joel called out: 'airc status' said monitor: not running
+  # while 'airc msg' worked + landed in gist. The two diagnostics
+  # disagreed, which is exactly the silent-broken class CLAUDE.md
+  # forbids. If sends work, status MUST report monitor running.
+  section "status_agrees_with_send: if msg lands in gist, status must say running"
+  require_gh || return
+
+  local rname="smoke-statusagree-$$"
+  local A_HOME
+  A_HOME=$(mktemp -d -t airc-statusagree.XXXXXX)
+  trap "cleanup_homes '$A_HOME'" RETURN
+
+  spawn_real "$A_HOME" "smoke-sa-$$" 7607 --room "$rname" --as-host \
+    || { fail "host failed to start"; return; }
+  sleep 2
+
+  local marker="status-agree-$(date +%s%N)"
+  AIRC_HOME="$A_HOME/state" "$AIRC" msg --room "$rname" "$marker" >/dev/null 2>&1
+  sleep 3
+
+  local gid; gid=$(python3 -c "import json;print(json.load(open('$A_HOME/state/config.json')).get('channel_gists',{}).get('$rname',''))")
+  local landed=0
+  gh api "gists/$gid" --jq '.files["messages.jsonl"].content // ""' 2>/dev/null | grep -qF "$marker" && landed=1
+  [ "$landed" = "1" ] || { fail "msg didn't land in gist — substrate broken, can't test status"; return; }
+
+  local status_out; status_out=$(AIRC_HOME="$A_HOME/state" "$AIRC" status 2>&1)
+  if printf '%s' "$status_out" | grep -qE "monitor: *running"; then
+    pass "msg landed AND status says monitor running (diagnostics agree)"
+  else
+    fail "msg LANDED but status reports monitor not running — diagnostics lie"
+    printf '%s' "$status_out" | sed 's/^/    /'
+  fi
+}
+
+scenario_stale_config_auto_resyncs() {
+  # Pre-seed channel_gists with a bogus gist id (simulates a peer
+  # who paired with a non-canonical dup pre-#321). After bounce,
+  # the host's subscription must self-heal to the actual gist on
+  # disk. Pre-fix peers stuck on stale mappings forever.
+  section "stale_config_auto_resyncs: bogus channel_gists is replaced on bounce"
+  require_gh || return
+
+  local rname="smoke-resync-$$"
+  local A_HOME
+  A_HOME=$(mktemp -d -t airc-resync.XXXXXX)
+  trap "cleanup_homes '$A_HOME'" RETURN
+
+  spawn_real "$A_HOME" "smoke-rs-$$" 7608 --room "$rname" --as-host \
+    || { fail "first spawn failed"; return; }
+  local good_gid; good_gid=$(python3 -c "import json;print(json.load(open('$A_HOME/state/config.json')).get('channel_gists',{}).get('$rname',''))")
+  [ -n "$good_gid" ] || { fail "first spawn didn't write channel_gists"; return; }
+  pass "first spawn: channel_gists['$rname']=$good_gid"
+
+  AIRC_HOME="$A_HOME/state" "$AIRC" teardown >/dev/null 2>&1
+
+  # Poison: replace channel_gists[$rname] with a bogus id
+  python3 -c "
+import json
+p = '$A_HOME/state/config.json'
+c = json.load(open(p))
+c['channel_gists'] = {'$rname': 'deadbeefcafebabe000000000000beef'}
+json.dump(c, open(p,'w'), indent=2)
+"
+
+  ( cd "$A_HOME" && AIRC_HOME="$A_HOME/state" AIRC_NAME="smoke-rs-$$" AIRC_PORT=7609 \
+      AIRC_NO_DISCOVERY=1 AIRC_NO_AUTO_ROOM=1 AIRC_NO_GENERAL=1 AIRC_NO_IDENTITY_PROMPT=1 \
+      "$AIRC" connect --room "$rname" > "$A_HOME/out2.log" 2>&1 & )
+  local i
+  for i in $(seq 1 15); do
+    sleep 1
+    grep -qE "Hosting as|Connected to|Joined" "$A_HOME/out2.log" 2>/dev/null && break
+  done
+  sleep 3
+
+  local final_gid; final_gid=$(python3 -c "import json;print(json.load(open('$A_HOME/state/config.json')).get('channel_gists',{}).get('$rname',''))")
+  if [ "$final_gid" = "$good_gid" ]; then
+    pass "auto-resync replaced bogus 'deadbeef...' with the canonical gist"
+  elif [ "$final_gid" = "deadbeefcafebabe000000000000beef" ]; then
+    fail "STILL bogus after bounce — channel_gists was trusted blindly, no auto-resync"
+  else
+    fail "channel_gists['$rname']='$final_gid' (neither canonical nor bogus — created a 3rd duplicate?)"
+  fi
+}
+
 scenario_part_deletes_host_gist() {
   section "part: host's airc part deletes the gist; joiner's part doesn't"
   require_gh || return
@@ -311,19 +396,23 @@ scenario_part_deletes_host_gist() {
 # Dispatch
 # ─────────────────────────────────────────────────────────────────────
 case "${1:-all}" in
-  passive_recv)         scenario_passive_recv ;;
-  round_trip)           scenario_round_trip ;;
-  idle_then_recv)       scenario_idle_then_recv ;;
-  part_deletes_host_gist) scenario_part_deletes_host_gist ;;
+  passive_recv)              scenario_passive_recv ;;
+  round_trip)                scenario_round_trip ;;
+  idle_then_recv)            scenario_idle_then_recv ;;
+  part_deletes_host_gist)    scenario_part_deletes_host_gist ;;
+  status_agrees_with_send)   scenario_status_agrees_with_send ;;
+  stale_config_auto_resyncs) scenario_stale_config_auto_resyncs ;;
   all)
     scenario_passive_recv
     scenario_round_trip
+    scenario_status_agrees_with_send
+    scenario_stale_config_auto_resyncs
     scenario_part_deletes_host_gist
-    # idle_then_recv last — it's the slow one (45s+ idle wait)
+    # idle_then_recv last — slow (45s+ idle wait)
     scenario_idle_then_recv
     ;;
   *)
-    echo "Usage: $0 [passive_recv|round_trip|idle_then_recv|part_deletes_host_gist|all]"
+    echo "Usage: $0 [passive_recv|round_trip|idle_then_recv|part_deletes_host_gist|status_agrees_with_send|stale_config_auto_resyncs|all]"
     exit 2
     ;;
 esac

--- a/test/integration_smoke.sh
+++ b/test/integration_smoke.sh
@@ -272,6 +272,86 @@ scenario_idle_then_recv() {
 # `airc part` from the host should delete the room gist on gh.
 # Joiners parting just teardown locally (host's gist persists).
 # ─────────────────────────────────────────────────────────────────────
+scenario_clean_install_smoke() {
+  # Joel 2026-04-29: 'I have a fresh macbook ... we can make sure
+  # macbook e2e from nothing is covered.' This scenario runs install.sh
+  # in a sandbox (BIN_DIR + SKILLS_TARGET overrides + AIRC_DIR isolated)
+  # so it doesn't clobber the real install, then verifies the resulting
+  # airc binary is callable + recognizes the canonical commands.
+  #
+  # NOT a full e2e (we don't run airc join — that would need a fresh
+  # gh account). Catches: install.sh doesn't crash, the binary lands
+  # on PATH, skills land in SKILLS_TARGET, venv has cryptography.
+  section "clean_install_smoke: install.sh sandbox install lands a working airc"
+  command -v gh >/dev/null 2>&1 || { skip "gh not installed (install.sh would auto-install via brew, but harness can't sudo)"; return; }
+  command -v python3 >/dev/null 2>&1 || { skip "python3 not installed"; return; }
+  if ! command -v brew >/dev/null 2>&1; then
+    skip "brew not installed — install.sh would prompt for it"
+    return
+  fi
+
+  local SANDBOX
+  SANDBOX=$(mktemp -d -t airc-clean-install.XXXXXX)
+  trap "rm -rf '$SANDBOX'" RETURN
+
+  # Run install.sh into sandbox via the env-var overrides.
+  local install_log="$SANDBOX/install.log"
+  if ! AIRC_DIR="$SANDBOX/airc-src" \
+       BIN_DIR="$SANDBOX/bin" \
+       SKILLS_TARGET="$SANDBOX/skills" \
+       bash "$REPO_ROOT/install.sh" > "$install_log" 2>&1; then
+    fail "install.sh exited non-zero — see $install_log"
+    tail -10 "$install_log" | sed 's/^/    /'
+    return
+  fi
+  pass "install.sh completed cleanly"
+
+  # Binary on PATH within sandbox?
+  if [ -x "$SANDBOX/bin/airc" ] || [ -L "$SANDBOX/bin/airc" ]; then
+    pass "airc binary placed at \$BIN_DIR/airc"
+  else
+    fail "airc binary missing from \$BIN_DIR after install"
+    ls -la "$SANDBOX/bin/" 2>&1 | sed 's/^/    /'
+    return
+  fi
+
+  # Binary runs?
+  local version_out
+  version_out=$("$SANDBOX/bin/airc" version 2>&1 || true)
+  if printf '%s' "$version_out" | grep -qE 'airc [a-f0-9]{7}'; then
+    pass "airc version returns a sha"
+  else
+    fail "airc version output unexpected: $version_out"
+  fi
+
+  # help works (smoke for argument parsing)?
+  if "$SANDBOX/bin/airc" --help >/dev/null 2>&1 \
+       || "$SANDBOX/bin/airc" connect --help >/dev/null 2>&1; then
+    pass "airc help paths work"
+  else
+    fail "airc help paths broken"
+  fi
+
+  # Skills landed?
+  if [ -d "$SANDBOX/skills/join" ]; then
+    pass "skills wired to \$SKILLS_TARGET (join skill present)"
+  else
+    fail "skills not wired — \$SKILLS_TARGET/join missing"
+  fi
+
+  # Venv has cryptography (needed for envelope encryption)?
+  local venv_python="$SANDBOX/airc-src/.venv/bin/python3"
+  if [ -x "$venv_python" ]; then
+    if "$venv_python" -c "import cryptography" 2>/dev/null; then
+      pass "venv has cryptography (envelope encryption available)"
+    else
+      fail "venv exists but cryptography not importable"
+    fi
+  else
+    skip "venv not at expected location ($venv_python) — install.sh path may differ"
+  fi
+}
+
 scenario_orphan_loops_self_reap() {
   # Regression for #325. Bash subshells (reminder_timer_loop /
   # flush_pending_loop) capture $PPID at start; on parent death they
@@ -590,6 +670,7 @@ scenario_part_deletes_host_gist() {
 # Dispatch
 # ─────────────────────────────────────────────────────────────────────
 case "${1:-all}" in
+  clean_install_smoke)            scenario_clean_install_smoke ;;
   passive_recv)                   scenario_passive_recv ;;
   round_trip)                     scenario_round_trip ;;
   idle_then_recv)                 scenario_idle_then_recv ;;
@@ -600,6 +681,7 @@ case "${1:-all}" in
   teardown_kills_env_tagged_orphans) scenario_teardown_kills_env_tagged_orphans ;;
   my_scope_in_mesh)               scenario_my_scope_in_mesh ;;
   all)
+    scenario_clean_install_smoke
     scenario_orphan_loops_self_reap
     scenario_teardown_kills_env_tagged_orphans
     scenario_passive_recv

--- a/test/integration_smoke.sh
+++ b/test/integration_smoke.sh
@@ -73,7 +73,7 @@ spawn_real() {
     )
   fi
   local i
-  for i in $(seq 1 20); do
+  for i in $(seq 1 30); do
     sleep 1
     grep -qE 'Hosting as|Connected to|Joined' "$home/out.log" 2>/dev/null || continue
     # For hosts: also wait until config.json has a channel_gists entry,
@@ -327,6 +327,14 @@ scenario_stale_config_auto_resyncs() {
   pass "first spawn: channel_gists['$rname']=$good_gid"
 
   AIRC_HOME="$A_HOME/state" "$AIRC" teardown >/dev/null 2>&1
+  # Defensive: kill orphans that survived teardown's airc.pid-driven
+  # kill (background subshells re-write airc.pid after teardown, then
+  # stomp guard refuses spawn2). Aggressive pkill targeting just this
+  # test scope.
+  pkill -9 -f "$A_HOME" 2>/dev/null || true
+  sleep 2
+  # Also wipe airc.pid in case a surviving subshell re-wrote it.
+  rm -f "$A_HOME/state/airc.pid"
 
   # Poison: replace channel_gists[$rname] with a bogus id
   python3 -c "

--- a/test/integration_smoke.sh
+++ b/test/integration_smoke.sh
@@ -272,6 +272,192 @@ scenario_idle_then_recv() {
 # `airc part` from the host should delete the room gist on gh.
 # Joiners parting just teardown locally (host's gist persists).
 # ─────────────────────────────────────────────────────────────────────
+scenario_orphan_loops_self_reap() {
+  # Regression for #325. Bash subshells (reminder_timer_loop /
+  # flush_pending_loop) capture $PPID at start; on parent death they
+  # exit at next iteration. Pre-fix they survived parent and emitted
+  # "Reminder, silent" forever, the visible 'frozen monitor' symptom.
+  section "orphan_loops_self_reap: parent dies → reminder/flush exit within ~10s"
+  cleanup_homes_pre
+
+  local A_HOME
+  A_HOME=$(mktemp -d -t airc-orphan-loop.XXXXXX)
+  trap "cleanup_homes '$A_HOME'" RETURN
+  # Inline spawn — no gh, just need a process tree alive. Don't use
+  # spawn_real (which waits for channel_gists population, which never
+  # happens with --no-room --no-gist).
+  mkdir -p "$A_HOME/state"
+  ( cd "$A_HOME" \
+      && AIRC_HOME="$A_HOME/state" AIRC_NAME="orphan-A-$$" AIRC_PORT=7611 \
+         AIRC_NO_DISCOVERY=1 AIRC_NO_AUTO_ROOM=1 AIRC_NO_GENERAL=1 AIRC_NO_IDENTITY_PROMPT=1 \
+         "$AIRC" connect --no-room --no-gist > "$A_HOME/out.log" 2>&1 & )
+  local i
+  for i in $(seq 1 10); do
+    sleep 1
+    grep -q "Hosting as" "$A_HOME/out.log" 2>/dev/null && break
+  done
+  if ! grep -q "Hosting as" "$A_HOME/out.log" 2>/dev/null; then
+    fail "host bash never reached 'Hosting as'"; return
+  fi
+  sleep 3
+
+  # Find the parent bash via airc.pid (the parent writes its $$ there).
+  local parent_pid loop_pids
+  parent_pid=$(awk '{print $1}' "$A_HOME/state/airc.pid" 2>/dev/null)
+  [ -n "$parent_pid" ] || { fail "no airc.pid for the test scope"; return; }
+  # Filter to BASH subshell children only — those are the loops with
+  # the parent-liveness check (#325). Python descendants (handshake,
+  # monitor_formatter, etc) get reaped by other mechanisms and aren't
+  # what this test covers.
+  loop_pids=$(ps -ef | awk -v p="$parent_pid" '$3 == p && $0 ~ /\/bin\/bash/ {print $2}' | tr '\n' ' ')
+  pass "spawned: parent=$parent_pid loop-pids=[$loop_pids]"
+
+  # SIGKILL the parent (no traps run; loops are now reparented to init).
+  kill -9 "$parent_pid" 2>/dev/null
+  # Wait long enough for the 5s loop-tick to detect parent death.
+  sleep 9
+
+  # The reminder + flush loops (which #325 fixed) should be dead. The
+  # foreground monitor()'s tail/formatter pipeline children (still in
+  # progress until pipe breaks) may or may not be dead at this point
+  # depending on timing. Assert at least 2 of the loop_pids are dead
+  # — that's the regression guard for #325. Pre-fix all of them
+  # survived; post-fix at least the 2 fixed loops self-reap.
+  local total=0 dead=0
+  for p in $loop_pids; do
+    total=$((total+1))
+    kill -0 "$p" 2>/dev/null || dead=$((dead+1))
+  done
+  if [ "$dead" -ge 2 ]; then
+    pass "$dead of $total bash subshell loops self-reaped within 9s (#325 working)"
+  else
+    fail "only $dead of $total subshells exited — #325 parent-liveness check broken"
+    pkill -9 -f "$A_HOME/state" 2>/dev/null
+  fi
+}
+
+scenario_teardown_kills_env_tagged_orphans() {
+  # Regression for #326. Even when airc.pid gets out of sync (parent
+  # dies before children write their pids, or subshells reparent to
+  # init), teardown must catch every process whose env has
+  # AIRC_HOME=<scope> via the ps eww walk.
+  section "teardown_kills_env_tagged_orphans: every AIRC_HOME-tagged proc dies"
+  cleanup_homes_pre
+
+  local A_HOME
+  A_HOME=$(mktemp -d -t airc-td-orphan.XXXXXX)
+  trap "cleanup_homes '$A_HOME'" RETURN
+  mkdir -p "$A_HOME/state"
+  ( cd "$A_HOME" \
+      && AIRC_HOME="$A_HOME/state" AIRC_NAME="td-orphan-$$" AIRC_PORT=7612 \
+         AIRC_NO_DISCOVERY=1 AIRC_NO_AUTO_ROOM=1 AIRC_NO_GENERAL=1 AIRC_NO_IDENTITY_PROMPT=1 \
+         "$AIRC" connect --no-room --no-gist > "$A_HOME/out.log" 2>&1 & )
+  local i
+  for i in $(seq 1 10); do
+    sleep 1
+    grep -q "Hosting as" "$A_HOME/out.log" 2>/dev/null && break
+  done
+  grep -q "Hosting as" "$A_HOME/out.log" 2>/dev/null \
+    || { fail "host bash never reached 'Hosting as'"; return; }
+  sleep 3
+
+  # Count scope-path-tagged processes pre-teardown via pgrep -f
+  # (matches python children whose argv contains the scope path —
+  # the same matcher cmd_teardown.sh now uses for its sweep).
+  local pre_count
+  pre_count=$(pgrep -f "$A_HOME/state" 2>/dev/null | wc -l | tr -d ' ')
+  [ "$pre_count" -gt 0 ] || { fail "no scope-path-tagged procs found pre-teardown — broken setup"; return; }
+  pass "pre-teardown: $pre_count scope-path-tagged procs alive"
+
+  # Corrupt airc.pid to simulate the broken-tracking state — teardown
+  # must rely on its sweep, not the pidfile. Background + 15s timeout
+  # so a hung teardown doesn't wedge the test.
+  echo "999999" > "$A_HOME/state/airc.pid"
+  ( AIRC_HOME="$A_HOME/state" "$AIRC" teardown >/dev/null 2>&1 ) &
+  local td_pid=$!
+  local i
+  for i in $(seq 1 15); do
+    sleep 1
+    kill -0 "$td_pid" 2>/dev/null || break
+  done
+  if kill -0 "$td_pid" 2>/dev/null; then
+    fail "airc teardown hung beyond 15s — itself a regression"
+    kill -9 "$td_pid" 2>/dev/null
+    return
+  fi
+  sleep 1
+
+  local post_count
+  post_count=$(pgrep -f "$A_HOME/state" 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$post_count" = "0" ]; then
+    pass "post-teardown: zero scope-path-tagged procs (sweep worked)"
+  else
+    fail "post-teardown: $post_count procs still alive — #326 sweep didn't catch them"
+    pgrep -f "$A_HOME/state" 2>/dev/null | xargs -I{} ps -p {} -o pid,command 2>/dev/null | head -5
+  fi
+}
+
+scenario_my_scope_in_mesh() {
+  # Joel 2026-04-29: 'remember you need to be part of it'. The other
+  # scenarios spawn ephemeral test peers in /tmp and never include
+  # the user's actual long-running airc scope. This one DOES — it
+  # asserts that the live authenticator-448f scope (whatever scope
+  # is running in the user's primary cwd) receives messages a fresh
+  # test peer sends. If my own scope's monitor is broken, this catches
+  # it where the isolated tests can't.
+  section "my_scope_in_mesh: live local scope receives messages from a fresh peer"
+  require_gh || return
+
+  local MY_HOME="${HOME}/Development/ideem/authenticator/.airc"
+  if [ ! -f "$MY_HOME/config.json" ]; then
+    skip "primary scope ($MY_HOME) not initialized — run 'airc join' there first"
+    return
+  fi
+
+  # Confirm my scope's monitor is running. If not, the test pre-condition
+  # fails — the user must have a healthy scope before this test runs.
+  local my_pids
+  my_pids=$(ps eww -o pid,command 2>/dev/null \
+            | awk -v home="AIRC_HOME=$MY_HOME" '$0 ~ home {print $1}' | head -3)
+  if [ -z "$my_pids" ]; then
+    skip "no running airc procs for primary scope — start it with 'airc join'"
+    return
+  fi
+  pass "primary scope alive (pids: $(echo $my_pids | tr '\n' ' '))"
+
+  local marker; marker="my-scope-test-$(date +%s%N)"
+  local TEST_HOME
+  TEST_HOME=$(mktemp -d -t airc-myscope.XXXXXX)
+  trap "cleanup_homes '$TEST_HOME'" RETURN
+  spawn_real "$TEST_HOME" "myscope-tester-$$" 7613 \
+    || { fail "test peer failed to join"; return; }
+  sleep 4
+
+  AIRC_HOME="$TEST_HOME/state" "$AIRC" msg --room general "$marker" >/dev/null 2>&1
+  pass "test peer sent marker"
+
+  # Watch the user's primary log for ~45s (gh poll cycle + buffer).
+  local i seen=0
+  for i in $(seq 1 22); do
+    sleep 2
+    grep -qF "$marker" "$MY_HOME/messages.jsonl" 2>/dev/null && { seen=1; break; }
+  done
+
+  if [ "$seen" = "1" ]; then
+    pass "primary scope's local log received the marker via gist polling"
+  else
+    fail "primary scope did NOT see the marker in 45s — bearer pipeline broken in user scope"
+    echo "    user scope last 3 events: $(tail -3 $MY_HOME/messages.jsonl 2>/dev/null | head -c 400)"
+  fi
+}
+
+# Helper: pre-test cleanup of any leftover test-scope orphans on this
+# machine (conservative — only matches our test prefixes).
+cleanup_homes_pre() {
+  pkill -9 -f "/tmp/airc-orphan-loop\|/tmp/airc-td-orphan\|/tmp/airc-myscope" 2>/dev/null || true
+  sleep 1
+}
+
 scenario_status_agrees_with_send() {
   # Today's bug Joel called out: 'airc status' said monitor: not running
   # while 'airc msg' worked + landed in gist. The two diagnostics
@@ -404,23 +590,29 @@ scenario_part_deletes_host_gist() {
 # Dispatch
 # ─────────────────────────────────────────────────────────────────────
 case "${1:-all}" in
-  passive_recv)              scenario_passive_recv ;;
-  round_trip)                scenario_round_trip ;;
-  idle_then_recv)            scenario_idle_then_recv ;;
-  part_deletes_host_gist)    scenario_part_deletes_host_gist ;;
-  status_agrees_with_send)   scenario_status_agrees_with_send ;;
-  stale_config_auto_resyncs) scenario_stale_config_auto_resyncs ;;
+  passive_recv)                   scenario_passive_recv ;;
+  round_trip)                     scenario_round_trip ;;
+  idle_then_recv)                 scenario_idle_then_recv ;;
+  part_deletes_host_gist)         scenario_part_deletes_host_gist ;;
+  status_agrees_with_send)        scenario_status_agrees_with_send ;;
+  stale_config_auto_resyncs)      scenario_stale_config_auto_resyncs ;;
+  orphan_loops_self_reap)         scenario_orphan_loops_self_reap ;;
+  teardown_kills_env_tagged_orphans) scenario_teardown_kills_env_tagged_orphans ;;
+  my_scope_in_mesh)               scenario_my_scope_in_mesh ;;
   all)
+    scenario_orphan_loops_self_reap
+    scenario_teardown_kills_env_tagged_orphans
     scenario_passive_recv
     scenario_round_trip
     scenario_status_agrees_with_send
     scenario_stale_config_auto_resyncs
     scenario_part_deletes_host_gist
+    scenario_my_scope_in_mesh
     # idle_then_recv last — slow (45s+ idle wait)
     scenario_idle_then_recv
     ;;
   *)
-    echo "Usage: $0 [passive_recv|round_trip|idle_then_recv|part_deletes_host_gist|status_agrees_with_send|stale_config_auto_resyncs|all]"
+    echo "Usage: $0 [passive_recv|round_trip|idle_then_recv|part_deletes_host_gist|status_agrees_with_send|stale_config_auto_resyncs|orphan_loops_self_reap|teardown_kills_env_tagged_orphans|my_scope_in_mesh|all]"
     exit 2
     ;;
 esac


### PR DESCRIPTION
Bundle of recent fixes:

- #324 channel_gist resolve retry + host bootstrap find-first
- #325 reminder/flush loops self-reap on parent death
- #326 teardown env-var-tagged orphan sweep
- #327 teardown pgrep-f + 3 new TDD scenarios
- #328 gh-auth health surface + identity length caps + airc.pid full-tree tracking
- #329 clean_install_smoke for fresh-Mac e2e

68/68 unit tests + integration smoke passing locally.