### PR TITLE
canary → main: gh auth in install + doctor --fix (#331)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -751,13 +751,31 @@ ensure_prereqs() {
   # them via opt-in flag, but the default install no longer invokes them.
   : "Phase 3c: skipping sshd + Tailscale (gh-as-bearer is the cross-network path)"
 
-  # gh auth: required for the gist substrate (#general room discovery).
-  # We can't auto-login (browser flow), but we surface the exact command
-  # so the user runs it once before `airc join`.
+  # gh auth: required for the gist substrate. We CAN drive the login
+  # interactively when stdin is a TTY (Joel 2026-04-29: 'thought that'd
+  # be in setup or at least doctor (then claude could always do it for
+  # them)'). The browser/device-code flow needs a real user to click
+  # but doesn't need them to remember the command. Falls back to the
+  # warning path for non-interactive installs (curl|bash piped without
+  # a TTY, CI, etc).
   if command -v gh >/dev/null 2>&1; then
     if ! gh auth status >/dev/null 2>&1; then
-      warn "gh CLI is not authenticated. Run once before 'airc join':"
-      warn "    gh auth login -s gist"
+      if [ -t 0 ] && [ -t 1 ]; then
+        info "gh is not authenticated — launching 'gh auth login -s gist' now."
+        info "  (Browser will open; sign in to GitHub. The 'gist' scope is required for the substrate.)"
+        if gh auth login -h github.com -s gist; then
+          ok "gh auth complete"
+          # Re-run setup-git so the just-acquired token gets wired.
+          gh auth setup-git 2>/dev/null && info "  gh token wired into git credential helper" || true
+        else
+          warn "gh auth login did not complete — re-run when ready:"
+          warn "    gh auth login -h github.com -s gist"
+        fi
+      else
+        warn "gh CLI is not authenticated. Run once before 'airc join':"
+        warn "    gh auth login -h github.com -s gist"
+        warn "  (interactive; can't run from a non-TTY install)"
+      fi
     else
       # Wire gh's token into git's credential helper. Without this,
       # every git-over-HTTPS op (gist fetch/push -- airc's substrate

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -25,12 +25,15 @@ cmd_doctor() {
     -h|--help)
       echo "Usage: airc doctor [mode]"
       echo "  airc doctor              environment health check (default)"
+      echo "  airc doctor --fix        attempt to repair recoverable issues"
+      echo "                           (currently: gh auth re-login if invalid)"
       echo "  airc doctor --connect    pre-flight checks for 'airc connect'"
       echo "  airc doctor --tests      run the integration test suite"
       echo "                           (aliases: tests, test, run, suite)"
       return 0 ;;
     --tests|-t|tests|test|run|suite) shift; _doctor_run_tests "$@"; return ;;
     --connect|-c|connect)            shift; _doctor_connect_preflight "$@"; return ;;
+    --fix|fix)                       shift; _doctor_fix "$@"; return ;;
   esac
 
   echo ""
@@ -429,6 +432,49 @@ _doctor_connect_preflight() {
     echo "  ✗ BLOCKED on $issues issue(s) -- fix the items above before 'airc connect'."
     return 1
   fi
+}
+
+_doctor_fix() {
+  # Attempt to repair recoverable issues. Currently scoped to gh auth
+  # because that's the highest-impact silent-failure mode (Joel
+  # 2026-04-29 — token expired, every gh API call failed silently,
+  # peers froze). Future fixes can be added here as discrete recovery
+  # paths.
+  echo
+  echo "  airc doctor --fix"
+  echo "  -----------------"
+  local fixed=0 skipped=0 failed=0
+
+  # gh auth: if invalid, re-run gh auth login. Needs a TTY for the
+  # browser/device-code flow.
+  if command -v gh >/dev/null 2>&1; then
+    if gh auth status >/dev/null 2>&1; then
+      echo "  [skip] gh auth already valid"
+      skipped=$((skipped + 1))
+    elif [ -t 0 ] && [ -t 1 ]; then
+      echo "  [fix]  gh auth invalid — running 'gh auth login -h github.com -s gist'"
+      if gh auth login -h github.com -s gist; then
+        echo "  [ok]   gh auth restored"
+        # Re-wire git credential helper while we have the token.
+        gh auth setup-git 2>/dev/null && echo "  [ok]   gh token wired into git credential helper" || true
+        fixed=$((fixed + 1))
+      else
+        echo "  [FAIL] gh auth login did not complete; re-run when ready"
+        failed=$((failed + 1))
+      fi
+    else
+      echo "  [FAIL] gh auth invalid AND no TTY for the interactive login"
+      echo "         Run from a real shell:  gh auth login -h github.com -s gist"
+      failed=$((failed + 1))
+    fi
+  else
+    echo "  [skip] gh CLI not installed (separate fix — install via brew/apt/winget)"
+    skipped=$((skipped + 1))
+  fi
+
+  echo
+  echo "  Summary: $fixed fixed, $skipped skipped, $failed failed."
+  [ "$failed" = "0" ]
 }
 
 _doctor_run_tests() {


### PR DESCRIPTION
Pulls #331: install.sh runs 'gh auth login -h github.com -s gist' interactively, plus new 'airc doctor --fix' for mid-session repair. AI-driven setup no longer needs the user to remember the auth command.