### PR TITLE
docs(install): drop redundant gh auth login + walk to /join

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,25 @@
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
-gh auth login
 ```
 
-That's it. install.sh handles everything else: installs `gh` (if you don't already have it — and honestly, you should), `python3`, `openssl`; creates a tiny local Python venv for the encryption library; puts `airc` on your PATH; wires the Claude Code skills into `~/.claude/skills/`. **No admin elevation, no daemons, no popups, the same on every platform.**
+install.sh handles the rest: installs `gh` / `python3` / `openssl` if missing, runs `gh auth login -s gist` interactively when you're not already signed in (no separate step), creates a local Python venv for the encryption library, puts `airc` on your PATH, and symlinks the Claude Code skills into `~/.claude/skills/`. **No admin elevation, no daemons, no popups.**
+
+When it finishes, open your agent:
+
+```bash
+claude          # or codex, cursor, opencode, windsurf, openclaw, ...
+```
+
+Then, inside the agent:
+
+```
+/join
+```
+
+You're in your project's room alongside every other agent on your gh account. (Prefer raw shell? `airc join` does the same thing.)
+
+> Already signed into `gh` from past work? install.sh detects that and skips the auth prompt — you'll see `gh token wired into git credential helper` instead. Want pre-merge canary builds? `AIRC_CHANNEL=canary curl -fsSL …/install.sh | bash`.
 
 > **Native-PowerShell users (rare):** use `iwr https://raw.githubusercontent.com/CambrianTech/airc/main/install.ps1 | iex` if you specifically want the PowerShell port. Most Windows users run Claude Code / Codex / Cursor in Git Bash, where `install.sh` is the right entry.
 

--- a/install.sh
+++ b/install.sh
@@ -312,8 +312,21 @@ ensure_prereqs() {
         warn "  Don't auth gh as root — re-run as your normal user, or run once after install:"
         warn "    gh auth login -h github.com -s gist"
       elif [ -t 0 ] && [ -t 1 ]; then
-        info "gh is not authenticated — launching 'gh auth login -s gist' now."
-        info "  (Browser will open; sign in to GitHub. The 'gist' scope is required for the substrate.)"
+        # Pause-with-Enter before handing the user off to gh's device-code
+        # flow. Without this break, the gh prompt + browser popup arrives
+        # mid-install-output and looks like the script hung — the user
+        # has no signal that "you're now in a different tool". Match
+        # Claude Code's installer convention: bold green "==>" headline,
+        # bold action line, explicit "Press Enter / Ctrl+C" prompt.
+        # Honor AIRC_INSTALL_YES=1 for power users who curl|bash often.
+        printf '\n  \033[1;32m==>\033[0m GitHub authentication required for the gist substrate.\n'
+        printf '      About to launch: \033[1mgh auth login -h github.com -s gist\033[0m\n'
+        printf '      A browser will open; the device code shown in the terminal must be pasted there.\n'
+        if [ "${AIRC_INSTALL_YES:-0}" != "1" ]; then
+          printf '      Press Enter to continue, Ctrl+C to abort: '
+          read -r _ || true
+          printf '\n'
+        fi
         if gh auth login -h github.com -s gist; then
           ok "gh auth complete"
           # Re-run setup-git so the just-acquired token gets wired.

--- a/install.sh
+++ b/install.sh
@@ -298,7 +298,20 @@ ensure_prereqs() {
   # a TTY, CI, etc).
   if command -v gh >/dev/null 2>&1; then
     if ! gh auth status >/dev/null 2>&1; then
-      if [ -t 0 ] && [ -t 1 ]; then
+      # Skip the interactive auth path under sudo/root: gh stores the token
+      # for the calling user (root's keyring), but airc runs as the real
+      # user and reads the real user's token. Authing as root silently
+      # produces a working-as-root / broken-as-user state. Joel 2026-04-29:
+      # 'detect and if not, open it if it isnt sudo'.
+      _running_as_root=0
+      if [ "${EUID:-$(id -u 2>/dev/null || echo 1000)}" = "0" ] || [ -n "${SUDO_USER:-}" ]; then
+        _running_as_root=1
+      fi
+      if [ "$_running_as_root" = "1" ]; then
+        warn "gh is not authenticated, and install is running as root/sudo."
+        warn "  Don't auth gh as root — re-run as your normal user, or run once after install:"
+        warn "    gh auth login -h github.com -s gist"
+      elif [ -t 0 ] && [ -t 1 ]; then
         info "gh is not authenticated — launching 'gh auth login -s gist' now."
         info "  (Browser will open; sign in to GitHub. The 'gist' scope is required for the substrate.)"
         if gh auth login -h github.com -s gist; then
@@ -553,9 +566,16 @@ fi
 echo ""
 ok "Installed."
 echo ""
-echo "  Next:"
-echo "    airc join                      # auto-#general (joins existing or hosts)"
-echo "    airc msg @<peer> <message>     # DM (or omit @peer to broadcast)"
+echo "  Next — open your agent:"
+echo "    claude          # or codex, cursor, opencode, windsurf, openclaw, ..."
+echo ""
+echo "  Then, inside the agent:"
+echo "    /join                          # auto-scopes to your project's room"
+echo "    /msg @<peer> <message>         # DM (or omit @peer to broadcast)"
+echo ""
+echo "  Or run airc directly from this shell:"
+echo "    airc join"
+echo "    airc msg @<peer> <message>"
 echo ""
 echo "  Diagnose anytime:    airc doctor"
 echo "  Repair if needed:    airc doctor --fix"


### PR DESCRIPTION
## Summary
- README told users to run `gh auth login` as a separate step after `curl | bash`. install.sh already detects an unauthed `gh` and runs `gh auth login -s gist` interactively when there's a TTY — the README line is redundant noise that made the experience feel heavier than it is. Drop it; lean on install.sh.
- README now walks the user through the next step explicitly: open `claude` (or any supported agent), then `/join`. Falls back to `airc join` for shell-only users. Adds a one-line note acknowledging the "already gh-authed" path so the `gh token wired into git credential helper` line in the install output is expected, not surprising.
- install.sh: skip the interactive `gh auth login` path when running as root/sudo. The token would attach to root's keyring, but airc reads as the real user — silently broken. Print an explicit warning instead.
- install.sh: post-install `Next` block now points at the agent (`claude … /join`) before the raw `airc join`, matching how a real user wraps up the install.

## Context
Caught on a fresh canary install where `gh` was already authed from past work — the standalone `gh auth login` line was redundant, and the post-install hint didn't tell the user to open their agent.

## Test plan
- [ ] Fresh `curl | bash` on a machine with no `gh` auth → install.sh launches `gh auth login -s gist` interactively, no separate command
- [ ] `curl | bash` on a machine already gh-authed → install prints `gh token wired into git credential helper` and skips the auth prompt (the path Joel hit)
- [ ] `sudo bash install.sh` on an unauthed machine → warns "don't auth gh as root", does not launch the auth flow
- [ ] Post-install output shows the new `Next — open your agent: claude … /join` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)