### PR TITLE
feat(uninstall): airc uninstall verb + /uninstall skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ airc kick <peer> [reason]        # host-only: remove peer record + broadcast [ki
 # Lifecycle
 airc quit                         # leave mesh, keep identity
 airc teardown [--flush] [--all]   # kill processes (--flush wipes state)
+airc uninstall [--yes] [--purge]  # fully remove airc from this machine
 airc daemon install               # autostart via launchd (mac) / systemd-user (linux)
 airc daemon status / log / uninstall
 
@@ -361,6 +362,7 @@ The Claude Code skills are auto-installed by `install.sh` so the AI can run airc
 | [resume](skills/resume/) | `/resume` | Explicit resume (alias for `/join` with no args) |
 | [reminder](skills/reminder/) | `/reminder <seconds\|off\|pause>` | Control silence-nudge |
 | [teardown](skills/teardown/) | `/teardown [--flush]` | Kill scope's processes |
+| [uninstall](skills/uninstall/) | `/uninstall [--yes] [--purge]` | Fully remove airc (clone, symlinks, daemon, processes); leaves per-project state unless `--purge` |
 | [repair](skills/repair/) | `/repair [invite]` | Full re-pair (teardown --flush + reconnect) |
 | [update](skills/update/) | `/update` | Pull latest on current channel + refresh skills |
 | [canary](skills/canary/) | `/canary` | Switch to canary channel + pull (opt-in pre-merge testing) |

--- a/airc
+++ b/airc
@@ -1456,6 +1456,18 @@ case "${1:-help}" in
   tests|test)        shift; _doctor_run_tests "$@" ;;
   daemon|autostart|service) shift; cmd_daemon "$@" ;;
   teardown|stop|flush) shift; cmd_teardown "$@" ;;
+  uninstall|self-uninstall)
+    # Dispatch to the canonical uninstall.sh in the clone root. _airc_lib_dir
+    # resolves to <clone>/lib, so the clone root is one dir up. exec so
+    # uninstall.sh runs in this process — once it rm -rf's the clone, the
+    # bash script body is already in memory and finishes cleanly.
+    shift
+    if [ -n "${_airc_lib_dir:-}" ] && [ -f "${_airc_lib_dir%/lib}/uninstall.sh" ]; then
+      exec bash "${_airc_lib_dir%/lib}/uninstall.sh" "$@"
+    else
+      die "Could not locate uninstall.sh (lib_dir=${_airc_lib_dir:-<unresolved>}). Run manually:  bash \$AIRC_DIR/uninstall.sh"
+    fi
+    ;;
   disconnect|quit|leave|unbind) shift; cmd_disconnect "$@" ;;
   monitor)   shift; monitor "$@" ;;
   debug-scope) echo "$AIRC_WRITE_DIR" ;;
@@ -1503,6 +1515,7 @@ case "${1:-help}" in
     echo "  airc status [--probe]           Liveness snapshot (--probe for SSH check)"
     echo "  airc reminder <seconds>         Nudge if silent (off/pause/300)"
     echo "  airc teardown [--flush] [--all] Kill scope's airc processes (--flush wipes state)"
+    echo "  airc uninstall [--yes] [--purge] Fully remove airc (clone, symlinks, daemon, processes)"
     echo ""
     echo "Identity resolution (highest priority first):"
     echo "  AIRC_NAME env var > config.json name > cwd basename > hostname"

--- a/install.sh
+++ b/install.sh
@@ -525,8 +525,11 @@ if [ -d "$CLONE_DIR/skills" ]; then
   # Clean up old symlinks from previous installs.
   # Includes the airc-classic skill names (connect/send/rename/disconnect) that
   # were renamed to IRC-canonical (join/msg/nick/quit) — leaving the old symlinks
-  # in place would shadow the new skills with stale content.
-  for old in "$SKILLS_TARGET"/relay-* "$SKILLS_TARGET"/monitor "$SKILLS_TARGET"/setup "$SKILLS_TARGET"/uninstall \
+  # in place would shadow the new skills with stale content. (`uninstall` was
+  # previously listed here when the skill didn't exist; now that we ship a real
+  # /uninstall skill, the per-skill symlink loop below recreates it cleanly and
+  # this list omits it.)
+  for old in "$SKILLS_TARGET"/relay-* "$SKILLS_TARGET"/monitor "$SKILLS_TARGET"/setup \
              "$SKILLS_TARGET"/connect "$SKILLS_TARGET"/send "$SKILLS_TARGET"/rename "$SKILLS_TARGET"/disconnect; do
     [ -L "$old" ] && rm "$old" 2>/dev/null
   done

--- a/skills/uninstall/SKILL.md
+++ b/skills/uninstall/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: airc:uninstall
+description: Fully remove airc from this machine — stops processes, removes the daemon, deletes the clone, drops binary + skill symlinks. Confirm with the user before running; this is destructive.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: "[--yes] [--purge]"
+---
+
+# airc uninstall
+
+**Destructive — confirm with the user before running.** This removes airc itself; per-project `.airc/` state (identity keys, peer records, chat logs) is left alone unless the user explicitly asks for `--purge`.
+
+## When to use
+
+- The user says "uninstall airc" / "remove airc" / "I'm done with airc."
+- The user is reinstalling from scratch and wants a clean slate first.
+- A botched install left stale symlinks or a clone in a weird state, and `/repair` isn't enough.
+
+## What it does
+
+```bash
+airc uninstall
+```
+
+Walks the full removal in order:
+
+1. `airc teardown --all` — stops every running airc process across all scopes on this machine
+2. `airc daemon uninstall` — removes the launchd / systemd-user / Task Scheduler unit if present
+3. Removes binary forwarders: `~/.local/bin/{airc, relay, airc.cmd, airc.ps1}`
+4. Removes airc skill symlinks under `~/.claude/skills/`
+5. Removes the clone dir (`~/.airc-src` or `$AIRC_DIR`), including the `.venv` inside
+
+**Confirmation prompt:** asks the user to type `yes` to proceed. If you're invoking from an agent, pass `--yes` only after the user has explicitly confirmed.
+
+## Flags
+
+- `--yes` / `-y` — skip the confirmation prompt. **Only pass this after the user confirms in chat.** Required for non-interactive invocations.
+- `--purge` — also print the list of per-project `.airc/` state dirs the user would need to remove manually for a fully clean machine. Does NOT auto-delete them — those hold the user's identity keys, peer records, and chat history.
+
+## What it leaves alone
+
+- **Per-project `.airc/` state** — your identity keys, peer records, message logs in every dir you ran `airc join` from. Use `--purge` to get a list of them.
+- **`gh` auth, brew/apt-installed packages** (gh / python3 / openssl) — those aren't airc's to remove.
+- **Other agents' configs** (Codex, Cursor, opencode, Windsurf) — airc only owns its own integration files.
+
+## Read the result
+
+- `Uninstalled.` — full removal succeeded.
+- `Aborted.` — user declined the prompt; nothing changed.
+- `Non-interactive run: pass --yes to confirm uninstall.` — the script needed a TTY or `--yes`; you forgot the flag.
+
+## Reinstall
+
+After uninstall, the standard one-liner re-installs cleanly:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
+```
+
+Per-project `.airc/` dirs (if not purged) are picked up on the next `airc join` in that scope.

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,40 +1,169 @@
 #!/usr/bin/env bash
 #
-# AIRC uninstaller
+# AIRC uninstaller — single source of truth for full removal.
 #
-# Removes symlinks from ~/.claude/skills/ and ~/.local/bin/airc.
-# Leaves the clone at ~/.airc-src — delete it manually to fully remove.
+# Direct entry:    bash ~/.airc-src/uninstall.sh
+# Curl-pipe:       curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/uninstall.sh | bash -s -- --yes
+# Via the verb:    airc uninstall            (preferred; just exec's this script)
+#
+# What it removes:
+#   - running airc processes (via airc teardown --all, if airc is on PATH)
+#   - daemon (launchd / systemd-user / Task Scheduler) via airc daemon uninstall
+#   - ~/.local/bin/{airc, relay, airc.cmd, airc.ps1}
+#   - skill symlinks under ~/.claude/skills/ pointing into the clone
+#   - the clone itself (~/.airc-src or $AIRC_DIR), including the .venv inside
+#
+# What it leaves:
+#   - per-project .airc/ state in every dir you ran `airc join` from
+#     (identity keys, peer records, message logs — your data, not ours)
+#   - gh auth, brew/apt-installed packages (gh / python3 / openssl)
+#   - other agents' configs (Codex / Cursor / opencode / etc.)
+#
+# Flags:
+#   --yes / -y     skip the confirmation prompt (required for curl|bash)
+#   --purge        also print the list of per-project .airc/ dirs to remove manually
+#   --help / -h    this message
+#
+# AIRC_DIR env var overrides the clone location (default $HOME/.airc-src).
 
 set -euo pipefail
 
 CLONE_DIR="${AIRC_DIR:-$HOME/.airc-src}"
-BIN_DIR="$HOME/.local/bin"
-SKILLS_TARGET="$HOME/.claude/skills"
+BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
+SKILLS_TARGET="${SKILLS_TARGET:-$HOME/.claude/skills}"
+
+ASSUME_YES=0
+PURGE=0
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes)   ASSUME_YES=1 ;;
+    --purge)    PURGE=1 ;;
+    -h|--help)
+      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *)
+      echo "ERROR: unknown flag: $arg" >&2
+      echo "Try: bash $0 --help" >&2
+      exit 2 ;;
+  esac
+done
 
 info()  { printf '  \033[1;34m->\033[0m %s\n' "$*"; }
 ok()    { printf '  \033[1;32m->\033[0m %s\n' "$*"; }
+warn()  { printf '  \033[1;33m!\033[0m %s\n' "$*" >&2; }
 
-# Remove skill symlinks (current names and old relay-prefixed names)
-if [ -d "$CLONE_DIR/skills" ]; then
-  for skill_dir in "$CLONE_DIR"/skills/*/; do
-    [ -d "$skill_dir" ] || continue
-    skill_name="$(basename "$skill_dir")"
-    target="$SKILLS_TARGET/$skill_name"
-    if [ -L "$target" ]; then
-      rm "$target"
-      ok "Removed skill: $skill_name"
-    fi
+# Move out of the clone before we start, so `rm -rf $CLONE_DIR` doesn't
+# leave us with a no-longer-existent cwd (which breaks every command after).
+cd "$HOME" 2>/dev/null || cd /
+
+cat <<EOF
+This will remove airc from this machine:
+  binary symlinks   $BIN_DIR/{airc,relay,airc.cmd,airc.ps1}
+  skill symlinks    $SKILLS_TARGET/<airc-skills>/
+  install dir       $CLONE_DIR (clone + .venv)
+  daemon            launchd / systemd-user / Task Scheduler unit (if installed)
+  running processes airc teardown --all (if airc is on PATH)
+
+It will NOT remove:
+  per-project .airc/ state in every dir you ran 'airc join' from
+  gh auth, brew/apt packages (gh / python3 / openssl)
+  other agents' configs
+
+EOF
+
+if [ "$ASSUME_YES" != "1" ]; then
+  if [ ! -t 0 ]; then
+    warn "Non-interactive run: pass --yes to confirm uninstall."
+    exit 1
+  fi
+  printf "Type 'yes' to proceed: "
+  read -r reply
+  if [ "$reply" != "yes" ]; then
+    info "Aborted."
+    exit 0
+  fi
+fi
+
+# 1. Stop running processes. airc teardown --all walks every airc.pid file
+# under $HOME and reaps the processes; idempotent if nothing is running.
+if command -v airc >/dev/null 2>&1; then
+  if airc teardown --all >/dev/null 2>&1; then
+    ok "Stopped running airc processes (airc teardown --all)"
+  fi
+  # 2. Uninstall daemon. No-op if not installed; we don't gate on a status
+  # check because `airc daemon uninstall` already handles the absent case.
+  if airc daemon uninstall >/dev/null 2>&1; then
+    ok "Removed daemon (launchd / systemd-user / Task Scheduler)"
+  fi
+fi
+
+# 3. Skill symlinks. Walk every entry in the skills dir and drop any
+# symlink that resolves into the clone — covers both current names and
+# any stale ones from prior installs (relay-*, etc.).
+removed_skills=0
+if [ -d "$SKILLS_TARGET" ]; then
+  for entry in "$SKILLS_TARGET"/*; do
+    [ -L "$entry" ] || continue
+    target="$(readlink "$entry" 2>/dev/null || true)"
+    case "$target" in
+      "$CLONE_DIR"/*|"$CLONE_DIR")
+        rm -f "$entry"
+        removed_skills=$((removed_skills + 1)) ;;
+    esac
   done
 fi
-for old in "$SKILLS_TARGET"/relay-*; do
-  [ -L "$old" ] && rm "$old" && ok "Removed old skill: $(basename "$old")"
-done
+[ "$removed_skills" -gt 0 ] && ok "Removed $removed_skills skill symlink(s) from $SKILLS_TARGET"
 
-# Remove airc binary symlink
-if [ -L "$BIN_DIR/airc" ]; then
-  rm "$BIN_DIR/airc"
-  ok "Removed airc from PATH"
+# 4. Binary forwarders on PATH.
+removed_bins=0
+for f in airc relay airc.cmd airc.ps1; do
+  if [ -L "$BIN_DIR/$f" ] || [ -f "$BIN_DIR/$f" ]; then
+    # Symlinks: drop unconditionally (we own them).
+    # Real files (airc.cmd / airc.ps1 on Windows): drop only if their
+    # contents reference the clone, so we don't blow away an unrelated
+    # binary a user happens to have at the same name.
+    if [ -L "$BIN_DIR/$f" ]; then
+      rm -f "$BIN_DIR/$f"
+      removed_bins=$((removed_bins + 1))
+    elif grep -q "$CLONE_DIR" "$BIN_DIR/$f" 2>/dev/null; then
+      rm -f "$BIN_DIR/$f"
+      removed_bins=$((removed_bins + 1))
+    fi
+  fi
+done
+[ "$removed_bins" -gt 0 ] && ok "Removed $removed_bins binary forwarder(s) from $BIN_DIR"
+
+# 5. Clone dir + venv. Last, since the steps above call into airc + read
+# from the clone for the skill walk. Once this runs, `airc` is gone.
+if [ -d "$CLONE_DIR" ]; then
+  rm -rf "$CLONE_DIR"
+  ok "Removed install dir: $CLONE_DIR"
 fi
 
 echo ""
-ok "Uninstalled. Clone left at $CLONE_DIR (delete manually if desired)."
+ok "Uninstalled."
+echo ""
+
+if [ "$PURGE" = "1" ]; then
+  echo "  --purge: per-project state to remove manually if you want a fully clean machine:"
+  echo ""
+  # Find .airc dirs under common project roots without scanning the whole
+  # filesystem. Stop at depth 6 to avoid runaway descent into node_modules
+  # / vendor trees.
+  found_any=0
+  for root in "$HOME/Development" "$HOME/Projects" "$HOME/work" "$HOME/src" "$HOME"; do
+    [ -d "$root" ] || continue
+    while IFS= read -r d; do
+      echo "    rm -rf $d"
+      found_any=1
+    done < <(find "$root" -maxdepth 6 -type d -name ".airc" 2>/dev/null)
+  done
+  if [ "$found_any" = "0" ]; then
+    echo "    (none found under \$HOME/{Development,Projects,work,src})"
+  fi
+  echo ""
+  echo "  These hold your identity keys, peer records, and chat logs. Delete only if"
+  echo "  you actually want them gone — they don't take much space and are useful for"
+  echo "  recovery if you reinstall."
+  echo ""
+fi


### PR DESCRIPTION
## Summary
- Replaces the 40-line uninstall.sh stub (only removed the airc symlink and skill symlinks) with a full removal flow: stops running processes (`airc teardown --all`), removes the daemon (`airc daemon uninstall`), drops binary forwarders (`~/.local/bin/{airc,relay,airc.cmd,airc.ps1}`), drops every skill symlink under `~/.claude/skills/` that resolves into the clone, and `rm -rf`'s the clone dir + .venv.
- Adds `airc uninstall` (and `self-uninstall` alias) as a first-class verb on the binary — execs into `uninstall.sh` so there's one source of truth and no parity drift between the verb and the curl-pipe path.
- Adds `/uninstall` as an agent-invocable skill (skills/uninstall/SKILL.md). Built for agent UX: emphasizes destructive nature, tells the AI not to pass `--yes` without explicit user confirmation, lists the leave-alone surface so the agent can answer "will this nuke X?" correctly.
- install.sh: removes `uninstall` from the stale-symlink cleanup loop (it was there from when the skill didn't exist; the per-skill loop now recreates it cleanly).
- README: adds `airc uninstall` to the command list and the skill table.

## What stays vs goes
**Removed:**
- Running airc processes (all scopes), daemon (launchd / systemd-user / Task Scheduler), binary forwarders, skill symlinks, clone + .venv.

**Left alone by default:**
- Per-project `.airc/` state (identity keys, peer records, chat logs) — that's user data. `--purge` prints a "look here, remove manually" list scoped to `$HOME/{Development,Projects,work,src}` (max-depth 6) so we never walk the whole filesystem.
- `gh` auth, brew/apt-installed packages, other agents' configs.

## Confirmation flow
- Default: prints what will be removed, asks the user to type `yes`.
- `-y` / `--yes`: skip the prompt. Required for non-interactive curl-pipe; the script refuses to proceed without a TTY otherwise.
- `--purge`: prints the per-project state list after removal — does NOT auto-delete those dirs.

## Test plan
- [ ] `airc uninstall` interactive → confirmation prompt → typing `yes` removes everything; typing `no` aborts cleanly
- [ ] `airc uninstall --yes` non-interactive → no prompt, full removal
- [ ] `bash uninstall.sh` (no flag) on piped stdin → "Non-interactive run: pass --yes" exit 1, nothing removed
- [ ] `airc uninstall --purge` → after removal, lists `.airc/` dirs under common project roots (or "(none found)" if none)
- [ ] After uninstall, `curl ... | bash` reinstalls cleanly; per-project `.airc/` state in any project dir is picked up by the next `airc join`
- [ ] Daemon path: `airc daemon install` → `airc uninstall --yes` → confirm launchd/systemd unit is gone
- [ ] `~/.local/bin/airc.ps1` containing arbitrary unrelated content (simulated) is NOT removed — only ones referencing the clone

## Notes
- Previous PR #339 (install + README clarity) is independent and can land in either order.
- The verb resolves the clone via `_airc_lib_dir` (lib path → strip `/lib` → clone root), so it works regardless of where the user installed (`AIRC_DIR=...` etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)