### PR TITLE
fix(openssl): detect LibreSSL, auto-install brew openssl@3, loud die instead of silent exit (#341)

### DIFF
--- a/airc
+++ b/airc
@@ -81,6 +81,62 @@ else
 fi
 export AIRC_PYTHON
 
+# Resolve openssl with Ed25519 capability. Probed once at startup so that
+# init_identity / sign_message can trust the binary at runtime. macOS
+# /usr/bin/openssl is LibreSSL — it passes `openssl --version` (so a naive
+# probe says it's fine) but does NOT support `genpkey -algorithm Ed25519`.
+# Brew openssl@3 / openssl works. Search Mac brew layouts before falling
+# back to PATH; on Linux/Windows the PATH default is openssl 1.1.1+ which
+# is fine. AIRC_OPENSSL env var is the user override (custom layouts).
+# Tracking: issue #341.
+_resolve_openssl() {
+  local cands=() c
+  [ -n "${AIRC_OPENSSL:-}" ] && cands+=("$AIRC_OPENSSL")
+  case "$(uname -s 2>/dev/null)" in
+    Darwin)
+      [ -x /opt/homebrew/opt/openssl@3/bin/openssl ] && cands+=(/opt/homebrew/opt/openssl@3/bin/openssl)
+      [ -x /opt/homebrew/opt/openssl/bin/openssl   ] && cands+=(/opt/homebrew/opt/openssl/bin/openssl)
+      [ -x /usr/local/opt/openssl@3/bin/openssl    ] && cands+=(/usr/local/opt/openssl@3/bin/openssl)
+      [ -x /usr/local/opt/openssl/bin/openssl      ] && cands+=(/usr/local/opt/openssl/bin/openssl)
+      ;;
+  esac
+  local path_openssl; path_openssl=$(command -v openssl 2>/dev/null) || path_openssl=""
+  [ -n "$path_openssl" ] && cands+=("$path_openssl")
+  for c in "${cands[@]}"; do
+    if "$c" genpkey -algorithm Ed25519 -out /dev/null >/dev/null 2>&1; then
+      printf '%s' "$c"
+      return 0
+    fi
+  done
+  return 1
+}
+AIRC_OPENSSL=$(_resolve_openssl) || AIRC_OPENSSL=""
+export AIRC_OPENSSL
+
+_die_no_ed25519_openssl() {
+  cat >&2 <<EOF
+ERROR: airc identity needs an openssl that supports Ed25519, and none was found.
+
+  Resolved openssl on PATH: $(command -v openssl 2>/dev/null || echo '<none>')
+  $(openssl version 2>/dev/null || true)
+
+  macOS ships LibreSSL as /usr/bin/openssl — it does not implement Ed25519.
+  Fix:
+    brew install openssl@3
+    airc join
+
+  Or point AIRC_OPENSSL at a working binary:
+    AIRC_OPENSSL=/path/to/openssl airc join
+
+  Linux: install openssl 1.1.1+ from your package manager (most distros
+  ship it by default). Windows: Git for Windows bundles a working openssl;
+  ensure it's on PATH ahead of any older system one.
+
+  Tracking: https://github.com/CambrianTech/airc/issues/341
+EOF
+  exit 1
+}
+
 # MSYS Git Bash on Windows translates argv VALUES that look like
 # Unix-rooted paths when bash invokes a Windows-native binary. So
 # `--host-airc-home /Users/joelteply/.airc` arrives at python.exe as
@@ -730,9 +786,10 @@ humanhash() {
 }
 
 sign_message() {
+  [ -z "${AIRC_OPENSSL:-}" ] && _die_no_ed25519_openssl
   local tmpfile; tmpfile=$(mktemp)
   printf '%s' "$1" > "$tmpfile"
-  openssl pkeyutl -sign -inkey "$IDENTITY_DIR/private.pem" -in "$tmpfile" 2>/dev/null | base64
+  "$AIRC_OPENSSL" pkeyutl -sign -inkey "$IDENTITY_DIR/private.pem" -in "$tmpfile" 2>/dev/null | base64
   rm -f "$tmpfile"
 }
 
@@ -899,8 +956,9 @@ init_identity() {
   local name="$1"
   mkdir -p "$AIRC_WRITE_DIR" "$IDENTITY_DIR" "$PEERS_DIR"
   if [ ! -f "$IDENTITY_DIR/private.pem" ]; then
-    openssl genpkey -algorithm Ed25519 -out "$IDENTITY_DIR/private.pem" 2>/dev/null
-    openssl pkey -in "$IDENTITY_DIR/private.pem" -pubout -out "$IDENTITY_DIR/public.pem" 2>/dev/null
+    [ -z "${AIRC_OPENSSL:-}" ] && _die_no_ed25519_openssl
+    "$AIRC_OPENSSL" genpkey -algorithm Ed25519 -out "$IDENTITY_DIR/private.pem" 2>/dev/null
+    "$AIRC_OPENSSL" pkey -in "$IDENTITY_DIR/private.pem" -pubout -out "$IDENTITY_DIR/public.pem" 2>/dev/null
     chmod 600 "$IDENTITY_DIR/private.pem"
   fi
   if [ ! -f "$IDENTITY_DIR/ssh_key" ]; then

--- a/install.sh
+++ b/install.sh
@@ -259,6 +259,45 @@ ensure_prereqs() {
     ok "All required prereqs present"
   fi
 
+  # Capability probe: openssl --version is not enough — macOS ships LibreSSL
+  # as /usr/bin/openssl, which passes --version but does NOT support
+  # `genpkey -algorithm Ed25519` (the airc identity key). The probe loop
+  # above can't catch this because LibreSSL is "openssl" by name. Run an
+  # actual Ed25519 key gen against a tempfile; if it fails on Mac, install
+  # brew openssl@3 (keg-only, doesn't shadow /usr/bin/openssl — airc's
+  # runtime resolver locates it via /opt/homebrew/opt/). Issue #341.
+  if command -v openssl >/dev/null 2>&1 \
+     && ! openssl genpkey -algorithm Ed25519 -out /dev/null >/dev/null 2>&1; then
+    case "$(uname -s 2>/dev/null)" in
+      Darwin)
+        # Already-present keg-only openssl@3 is enough — no install needed.
+        _have_brew_ossl=0
+        for c in /opt/homebrew/opt/openssl@3/bin/openssl /usr/local/opt/openssl@3/bin/openssl; do
+          if [ -x "$c" ] && "$c" genpkey -algorithm Ed25519 -out /dev/null >/dev/null 2>&1; then
+            ok "openssl Ed25519 capability via $c (system openssl is LibreSSL)"
+            _have_brew_ossl=1
+            break
+          fi
+        done
+        if [ "$_have_brew_ossl" = "0" ] && command -v brew >/dev/null 2>&1; then
+          info "System openssl is LibreSSL (no Ed25519). Installing openssl@3 via brew..."
+          if brew install openssl@3 >/dev/null 2>&1; then
+            ok "openssl@3 installed (airc resolves it at runtime; no PATH change needed)"
+          else
+            warn "brew install openssl@3 failed. Run manually:  brew install openssl@3"
+          fi
+        elif [ "$_have_brew_ossl" = "0" ]; then
+          warn "System openssl is LibreSSL (no Ed25519) and brew is unavailable."
+          warn "  Install Homebrew + openssl@3, or set AIRC_OPENSSL=/path/to/openssl manually."
+        fi
+        ;;
+      *)
+        warn "openssl on this machine doesn't support 'genpkey -algorithm Ed25519'."
+        warn "  airc identity creation will fail. Install openssl 1.1.1+ or set AIRC_OPENSSL."
+        ;;
+    esac
+  fi
+
   # sshd: airc joiners ssh into the host's airc_home to tail messages.
   # Every airc user who'll host a room (which is most users — first to
   # discover becomes the host) needs sshd RUNNING. install.sh actually


### PR DESCRIPTION
Fixes the silent-`exit 1` Carl-on-fresh-Mac bug from #341. Minimal-scope fix; the bigger change (drop shell openssl entirely in favor of the venv `cryptography` module) is being picked up separately by other-mac.

## What Carl saw before
```
$ curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
   ... 'Installed.' ...
$ airc join
   No mesh found on your gh account → becoming the host.
$ echo $?
1
```
No error. No log. No doctor pointer. /usr/bin/openssl on macOS is LibreSSL 3.3.6, which doesn't implement Ed25519; the `2>/dev/null` on the openssl call swallowed the actual error and `set -e` killed the script.

## What Carl sees now

**Path A — install.sh detects LibreSSL on Mac and auto-installs brew openssl@3 during install:**
```
   ...
   -> All required prereqs present
   -> System openssl is LibreSSL (no Ed25519). Installing openssl@3 via brew...
   -> openssl@3 installed (airc resolves it at runtime; no PATH change needed)
   -> Installed.
$ airc join
   ... hosting #general normally ...
```

**Path B — install.sh ran on a Mac without brew:**
loud warning during install, AND if Carl skips it, the `airc join` failure path now prints actionable guidance pointing at `brew install openssl@3` (or `AIRC_OPENSSL=/path/to/openssl`), plus the issue link.

## Implementation

**`airc` binary:**
- New `_resolve_openssl()` runs at startup: probes `AIRC_OPENSSL` env var → `/opt/homebrew/opt/openssl@3` → `/opt/homebrew/opt/openssl` → `/usr/local/opt/openssl@3` → `/usr/local/opt/openssl` → PATH default. First candidate that successfully runs `genpkey -algorithm Ed25519 -out /dev/null` wins. On Mac this routes around `/usr/bin/openssl` (LibreSSL) when a working brew binary is present.
- `AIRC_OPENSSL` env var is the result, exported for downstream use AND as the user override for non-standard layouts.
- `init_identity()` and `sign_message()` gate on `AIRC_OPENSSL` non-empty; if empty, `_die_no_ed25519_openssl` prints a clear actionable error.
- The `2>/dev/null` stays on the actual openssl calls — it suppresses normal status noise on success. Failures now never reach those calls because the resolver pre-validated the binary at startup; if no capable openssl exists, we die early with a real message.

**`install.sh`:**
- After the existing prereq install loop, runs `openssl genpkey -algorithm Ed25519 -out /dev/null` against the on-PATH openssl. If it fails on Mac, looks for an existing brew openssl@3 (keg-only, `/opt/homebrew/opt/openssl@3/bin/openssl`); if absent and brew is available, runs `brew install openssl@3`. If neither, warns loudly with manual guidance.
- Brew openssl@3 is keg-only by design — it doesn't shadow `/usr/bin/openssl` (which would break system tools that depend on LibreSSL's behaviors). The `airc` binary's runtime resolver is what makes this work.

## Test results on this Mac

```
$ openssl version
LibreSSL 3.3.6                                  # /usr/bin/openssl

# Without my fix:
$ airc join
  No mesh found on your gh account → becoming the host.
$ echo $?
1                                                # silent

# With my fix, no brew openssl yet:
$ airc join
  No mesh found on your gh account → becoming the host.
ERROR: airc identity needs an openssl that supports Ed25519, and none was found.
  ...
  macOS ships LibreSSL as /usr/bin/openssl — it does not implement Ed25519.
  Fix:
    brew install openssl@3
    airc join
  ...

# After brew install openssl@3:
$ airc join
  No mesh found on your gh account → becoming the host.
  Hosting as 'airc-test-26f1' (reminder: 300s)
  Hosting #general — no existing room on your gh account, fresh start.
  ✓ Found canonical gist for #general on this gh account → using existing
  Hosting #general (gh-account substrate).
  ...                                            # works
```

## Out of scope (deliberately)

- **Drop shell openssl entirely** in favor of `lib/airc_core/identity.py` using `python-cryptography` (already a venv dep). Other-mac picked this up — same issue, separate PR.
- **Doctor scenario** for Ed25519 capability — worth adding once the migration lands; the probe shape will change.
- **Scope `.airc/` autoderive into `\$PWD/.airc/`** for non-project dirs (#341 sub-bullet) — separate fix, separate PR.

## Test plan
- [x] Fresh Mac with only LibreSSL → install.sh auto-installs brew openssl@3
- [x] Fresh Mac with brew openssl@3 already present → install.sh detects, no-op  
- [x] Fresh Mac with no brew at all → loud warning during install + actionable error at `airc join`
- [x] After brew openssl@3 installed → `airc join` succeeds, hosts #general
- [x] `AIRC_OPENSSL=/custom/path airc join` → uses the override
- [ ] Linux machine — should be no-op (PATH openssl already supports Ed25519)
- [ ] Windows Git Bash — Git for Windows openssl supports Ed25519, no-op expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)