### PR TITLE
feat(identity): migrate Ed25519 to venv cryptography (closes #341)

### DIFF
--- a/airc
+++ b/airc
@@ -81,61 +81,14 @@ else
 fi
 export AIRC_PYTHON
 
-# Resolve openssl with Ed25519 capability. Probed once at startup so that
-# init_identity / sign_message can trust the binary at runtime. macOS
-# /usr/bin/openssl is LibreSSL — it passes `openssl --version` (so a naive
-# probe says it's fine) but does NOT support `genpkey -algorithm Ed25519`.
-# Brew openssl@3 / openssl works. Search Mac brew layouts before falling
-# back to PATH; on Linux/Windows the PATH default is openssl 1.1.1+ which
-# is fine. AIRC_OPENSSL env var is the user override (custom layouts).
-# Tracking: issue #341.
-_resolve_openssl() {
-  local cands=() c
-  [ -n "${AIRC_OPENSSL:-}" ] && cands+=("$AIRC_OPENSSL")
-  case "$(uname -s 2>/dev/null)" in
-    Darwin)
-      [ -x /opt/homebrew/opt/openssl@3/bin/openssl ] && cands+=(/opt/homebrew/opt/openssl@3/bin/openssl)
-      [ -x /opt/homebrew/opt/openssl/bin/openssl   ] && cands+=(/opt/homebrew/opt/openssl/bin/openssl)
-      [ -x /usr/local/opt/openssl@3/bin/openssl    ] && cands+=(/usr/local/opt/openssl@3/bin/openssl)
-      [ -x /usr/local/opt/openssl/bin/openssl      ] && cands+=(/usr/local/opt/openssl/bin/openssl)
-      ;;
-  esac
-  local path_openssl; path_openssl=$(command -v openssl 2>/dev/null) || path_openssl=""
-  [ -n "$path_openssl" ] && cands+=("$path_openssl")
-  for c in "${cands[@]}"; do
-    if "$c" genpkey -algorithm Ed25519 -out /dev/null >/dev/null 2>&1; then
-      printf '%s' "$c"
-      return 0
-    fi
-  done
-  return 1
-}
-AIRC_OPENSSL=$(_resolve_openssl) || AIRC_OPENSSL=""
-export AIRC_OPENSSL
-
-_die_no_ed25519_openssl() {
-  cat >&2 <<EOF
-ERROR: airc identity needs an openssl that supports Ed25519, and none was found.
-
-  Resolved openssl on PATH: $(command -v openssl 2>/dev/null || echo '<none>')
-  $(openssl version 2>/dev/null || true)
-
-  macOS ships LibreSSL as /usr/bin/openssl — it does not implement Ed25519.
-  Fix:
-    brew install openssl@3
-    airc join
-
-  Or point AIRC_OPENSSL at a working binary:
-    AIRC_OPENSSL=/path/to/openssl airc join
-
-  Linux: install openssl 1.1.1+ from your package manager (most distros
-  ship it by default). Windows: Git for Windows bundles a working openssl;
-  ensure it's on PATH ahead of any older system one.
-
-  Tracking: https://github.com/CambrianTech/airc/issues/341
-EOF
-  exit 1
-}
+# Issue #341 follow-up: shell openssl is no longer used for Ed25519
+# identity gen / signing. Both paths now route through the venv
+# cryptography module (airc_core.identity bootstrap-ed25519 / sign-
+# ed25519). The prior _resolve_openssl + AIRC_OPENSSL + _die helper
+# were #342's loud-failure mitigation; once truth moved to Python they
+# became dead code and were removed in this commit. ssh-keygen still
+# stays — that's an OpenSSH client tool, separate from libcrypto, and
+# every supported platform ships a working version.
 
 # MSYS Git Bash on Windows translates argv VALUES that look like
 # Unix-rooted paths when bash invokes a Windows-native binary. So
@@ -786,11 +739,11 @@ humanhash() {
 }
 
 sign_message() {
-  [ -z "${AIRC_OPENSSL:-}" ] && _die_no_ed25519_openssl
-  local tmpfile; tmpfile=$(mktemp)
-  printf '%s' "$1" > "$tmpfile"
-  "$AIRC_OPENSSL" pkeyutl -sign -inkey "$IDENTITY_DIR/private.pem" -in "$tmpfile" 2>/dev/null | base64
-  rm -f "$tmpfile"
+  # Sign message bytes via the venv cryptography path (issue #341 — the
+  # prior shell openssl call broke on macOS LibreSSL silently). Identity
+  # module's sign-ed25519 reads from stdin, prints base64 sig matching
+  # the prior `openssl pkeyutl -sign | base64` output byte-for-byte.
+  printf '%s' "$1" | "$AIRC_PYTHON" -m airc_core.identity sign-ed25519 --dir "$IDENTITY_DIR"
 }
 
 # ── Platform adapters ───────────────────────────────────────────────────
@@ -955,11 +908,16 @@ resolve_name() {
 init_identity() {
   local name="$1"
   mkdir -p "$AIRC_WRITE_DIR" "$IDENTITY_DIR" "$PEERS_DIR"
+  # Ed25519 envelope-signing keypair via the venv cryptography path
+  # (issue #341 — the prior shell openssl path broke on macOS LibreSSL
+  # silently). Idempotent: airc_core.identity.bootstrap_ed25519 returns
+  # cleanly without rewriting if the files already exist. Same on-disk
+  # PEM format the openssl path produced, so existing scopes upgrade
+  # in place without rotating keys.
   if [ ! -f "$IDENTITY_DIR/private.pem" ]; then
-    [ -z "${AIRC_OPENSSL:-}" ] && _die_no_ed25519_openssl
-    "$AIRC_OPENSSL" genpkey -algorithm Ed25519 -out "$IDENTITY_DIR/private.pem" 2>/dev/null
-    "$AIRC_OPENSSL" pkey -in "$IDENTITY_DIR/private.pem" -pubout -out "$IDENTITY_DIR/public.pem" 2>/dev/null
-    chmod 600 "$IDENTITY_DIR/private.pem"
+    if ! "$AIRC_PYTHON" -m airc_core.identity bootstrap-ed25519 --dir "$IDENTITY_DIR"; then
+      die "Ed25519 identity bootstrap failed — check that the venv has the cryptography package (re-run install.sh)"
+    fi
   fi
   if [ ! -f "$IDENTITY_DIR/ssh_key" ]; then
     ssh-keygen -t ed25519 -f "$IDENTITY_DIR/ssh_key" -N "" -C "airc-${name}" -q

--- a/install.sh
+++ b/install.sh
@@ -48,8 +48,11 @@ _to_bash_path() {
 # install via the platform's package manager, then verify. Designed for
 # FIRST-TIME users with nothing pre-installed beyond a shell.
 #
-# Required: git, gh, openssl, ssh-keygen, python3
+# Required: git, gh, ssh-keygen, python3 (+ cryptography via venv pip)
 # Optional: tailscale (only needed for cross-LAN mesh; LAN works without)
+# Deliberately not required: openssl. Issue #341 — identity Ed25519 ops
+# moved to the venv cryptography module so we don't depend on system
+# openssl flavoring (LibreSSL vs OpenSSL etc).
 #
 # AIRC_SKIP_PREREQS=1 short-circuits the whole block (CI, dev installs,
 # users who manage their own packages).
@@ -95,11 +98,6 @@ pkgname_for() {
         pacman) echo "openssh" ;;
         apk)    echo "openssh-client" ;;
         winget) echo "" ;;  # OpenSSH ships with modern Windows; nothing to install
-      esac ;;
-    openssl)
-      case "$mgr" in
-        winget) echo "" ;;  # bundled with Git for Windows; if Git is installed, openssl is there
-        *)      echo "openssl" ;;
       esac ;;
     python3)
       case "$mgr" in
@@ -194,7 +192,7 @@ ensure_prereqs() {
       fi
     else
       warn "Unknown package manager (uname=$(uname -s)). Skipping prereq auto-install."
-      warn "Required prereqs: git, gh, openssl, python3"
+      warn "Required prereqs: git, gh, python3 (cryptography via pip)"
       return 0
     fi
   fi
@@ -204,11 +202,16 @@ ensure_prereqs() {
   # stdlib JSON (lib/airc_core/gistparse.py). Python was already a hard
   # dep since #152 Phase 0; jq was redundant. Drop the dep + the
   # winget step that would install it.
-  for cmd in git gh openssl ssh-keygen python3; do
+  # Issue #341 follow-up: openssl removed from the prereq list. airc
+  # no longer shells out to it for Ed25519 — identity gen + signing
+  # both route through the venv cryptography module (which is already
+  # a hard dep, pip-installed below). LibreSSL on macOS used to make
+  # this an ordeal; now it's a non-issue at the source.
+  for cmd in git gh ssh-keygen python3; do
     # Strict probe: presence on PATH AND a successful --version invocation.
     # Used selectively: python3 needs the strict variant because Windows
     # Store's python3.exe alias is on PATH but exits 49 with a Store-
-    # redirect (continuum-b69f, 2026-04-27). git/gh/openssl all
+    # redirect (continuum-b69f, 2026-04-27). git/gh all
     # support --version cleanly. ssh-keygen does NOT have a version
     # flag at all (different from `ssh -V`); calling `ssh-keygen
     # --version` exits non-zero on every install, so the strict probe
@@ -251,52 +254,16 @@ ensure_prereqs() {
       warn "These prereqs need manual install on $mgr: ${unmappable[*]}"
       case "$mgr" in
         winget)
-          warn "  ssh / ssh-keygen: Settings -> Apps -> Optional Features -> Add OpenSSH Client"
-          warn "  openssl: bundled with Git for Windows -- 'winget install Git.Git' provides it" ;;
+          warn "  ssh / ssh-keygen: Settings -> Apps -> Optional Features -> Add OpenSSH Client" ;;
       esac
     fi
   else
     ok "All required prereqs present"
   fi
-
-  # Capability probe: openssl --version is not enough — macOS ships LibreSSL
-  # as /usr/bin/openssl, which passes --version but does NOT support
-  # `genpkey -algorithm Ed25519` (the airc identity key). The probe loop
-  # above can't catch this because LibreSSL is "openssl" by name. Run an
-  # actual Ed25519 key gen against a tempfile; if it fails on Mac, install
-  # brew openssl@3 (keg-only, doesn't shadow /usr/bin/openssl — airc's
-  # runtime resolver locates it via /opt/homebrew/opt/). Issue #341.
-  if command -v openssl >/dev/null 2>&1 \
-     && ! openssl genpkey -algorithm Ed25519 -out /dev/null >/dev/null 2>&1; then
-    case "$(uname -s 2>/dev/null)" in
-      Darwin)
-        # Already-present keg-only openssl@3 is enough — no install needed.
-        _have_brew_ossl=0
-        for c in /opt/homebrew/opt/openssl@3/bin/openssl /usr/local/opt/openssl@3/bin/openssl; do
-          if [ -x "$c" ] && "$c" genpkey -algorithm Ed25519 -out /dev/null >/dev/null 2>&1; then
-            ok "openssl Ed25519 capability via $c (system openssl is LibreSSL)"
-            _have_brew_ossl=1
-            break
-          fi
-        done
-        if [ "$_have_brew_ossl" = "0" ] && command -v brew >/dev/null 2>&1; then
-          info "System openssl is LibreSSL (no Ed25519). Installing openssl@3 via brew..."
-          if brew install openssl@3 >/dev/null 2>&1; then
-            ok "openssl@3 installed (airc resolves it at runtime; no PATH change needed)"
-          else
-            warn "brew install openssl@3 failed. Run manually:  brew install openssl@3"
-          fi
-        elif [ "$_have_brew_ossl" = "0" ]; then
-          warn "System openssl is LibreSSL (no Ed25519) and brew is unavailable."
-          warn "  Install Homebrew + openssl@3, or set AIRC_OPENSSL=/path/to/openssl manually."
-        fi
-        ;;
-      *)
-        warn "openssl on this machine doesn't support 'genpkey -algorithm Ed25519'."
-        warn "  airc identity creation will fail. Install openssl 1.1.1+ or set AIRC_OPENSSL."
-        ;;
-    esac
-  fi
+  # Issue #341 follow-up: openssl Ed25519-capability probe + brew
+  # install dance removed. Identity gen + signing live in the venv
+  # cryptography module now; the system openssl version (LibreSSL or
+  # otherwise) is irrelevant to airc.
 
   # sshd: airc joiners ssh into the host's airc_home to tail messages.
   # Every airc user who'll host a room (which is most users — first to

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -49,10 +49,10 @@ cmd_doctor() {
   _doctor_probe "git"          "$mgr" "VCS for clone/update" || issues=$((issues+1))
   _doctor_probe "gh"           "$mgr" "Gist substrate (room discovery)" || issues=$((issues+1))
   _doctor_probe_gh_auth                                             || issues=$((issues+1))
-  _doctor_probe "openssl"      "$mgr" "Ed25519 sign keys + signing"     || issues=$((issues+1))
   _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"     || issues=$((issues+1))
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"     || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"    || issues=$((issues+1))
+  _doctor_probe_cryptography                                            || issues=$((issues+1))
   _doctor_probe_sshd                                                    || issues=$((issues+1))
   _doctor_probe_tailscale "$mgr"  # optional, never increments issues
 
@@ -184,6 +184,26 @@ _doctor_probe_gh_auth() {
   fi
   printf "  [MISSING] gh authenticated (gist scope)\n"
   printf "         Fix: gh auth login -s gist\n"
+  return 1
+}
+
+# Probe the venv cryptography package — issue #341 follow-up. airc's
+# Ed25519 identity gen + signing now route through python-cryptography;
+# without it init_identity / sign_message hard-fail. install.sh's venv
+# step pip-installs it, so the failure surface here is "venv setup
+# didn't complete cleanly" or "the system python the resolver picked
+# differs from the venv one". Either way: surface clearly so doctor
+# tells the user to re-run install.sh.
+_doctor_probe_cryptography() {
+  if ! command -v "${AIRC_PYTHON:-python3}" >/dev/null 2>&1; then
+    return 0  # already reported missing by the python3 probe
+  fi
+  if "${AIRC_PYTHON:-python3}" -c "import cryptography.hazmat.primitives.asymmetric.ed25519" >/dev/null 2>&1; then
+    printf "  [ok] cryptography (Ed25519 identity gen + signing)\n"
+    return 0
+  fi
+  printf "  [MISSING] cryptography (Python package, used for Ed25519 identity)\n"
+  printf "         Fix: re-run install.sh (sets up the venv with cryptography)\n"
   return 1
 }
 
@@ -339,10 +359,10 @@ _doctor_connect_preflight() {
 
   # ── Required prereqs (same as default doctor) ──
   _doctor_probe "git"          "$mgr" "VCS for clone/update"           || issues=$((issues+1))
-  _doctor_probe "openssl"      "$mgr" "Ed25519 sign keys + signing"    || issues=$((issues+1))
   _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"    || issues=$((issues+1))
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"    || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"   || issues=$((issues+1))
+  _doctor_probe_cryptography                                           || issues=$((issues+1))
   _doctor_probe_sshd                                                   || issues=$((issues+1))
 
   # ── gh chain: installed → authed → gist scope → gists API reachable.

--- a/lib/airc_core/crypto.py
+++ b/lib/airc_core/crypto.py
@@ -55,6 +55,10 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import (
     X25519PrivateKey,
     X25519PublicKey,
 )
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives import hashes
@@ -128,6 +132,80 @@ def load_pub(pub_path: str) -> bytes:
             f"X25519 public key at {pub_path} is {len(raw)} bytes; expected 32"
         )
     return raw
+
+
+# ──────────────────────────────────────────────────────────────────
+# Ed25519 keypairs — generation, save, load, sign
+#
+# Different on-disk format from X25519 above: Ed25519 keys live as PEM
+# files (PKCS#8 for private, SubjectPublicKeyInfo for public) at fixed
+# names `private.pem` / `public.pem` for compatibility with the prior
+# shell-openssl-generated identity layout. Existing scopes that paired
+# under the openssl path will load cleanly here — `cryptography`'s
+# load_pem_private_key parses the same PKCS#8 wrapping that
+# `openssl genpkey -algorithm Ed25519` writes. Verified: round-trip
+# byte-equal between the two for the same seed material.
+#
+# Why PEM (not raw like X25519): X25519 keys are this module's truth,
+# only ever read by Python. Ed25519 keys pre-existed in shell-openssl
+# format and we maintain the same disk shape so nobody's identity
+# silently rotates on upgrade.
+# ──────────────────────────────────────────────────────────────────
+
+def generate_ed25519_keypair_pem() -> tuple[bytes, bytes]:
+    """Generate a fresh Ed25519 keypair, return (priv_pem, pub_pem) bytes.
+
+    Output format matches `openssl genpkey -algorithm Ed25519` (PKCS#8 PEM)
+    and `openssl pkey -pubout` (SPKI PEM) byte-for-byte modulo the random
+    seed. Existing peers that signed under shell-openssl Ed25519 verify
+    correctly against pubkeys generated here and vice versa — both are
+    the same NIST/IETF-standard primitive.
+    """
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return (priv_pem, pub_pem)
+
+
+def load_ed25519_priv_pem(priv_path: str) -> Ed25519PrivateKey:
+    """Read an Ed25519 PKCS#8 PEM private key from disk. Raises
+    FileNotFoundError or ValueError on malformed input. Used by
+    sign_ed25519_pem below; exposed so callers can do their own
+    framing if they prefer."""
+    with open(priv_path, "rb") as f:
+        pem = f.read()
+    key = serialization.load_pem_private_key(pem, password=None)
+    if not isinstance(key, Ed25519PrivateKey):
+        raise ValueError(
+            f"key at {priv_path} is not Ed25519 ({type(key).__name__})"
+        )
+    return key
+
+
+def sign_ed25519_pem(priv_path: str, data: bytes) -> bytes:
+    """Sign `data` with the Ed25519 private key at `priv_path`. Returns
+    the raw 64-byte signature — same as `openssl pkeyutl -sign` output
+    on the same key+message. Caller base64-encodes if needed; we keep
+    bytes here so the layer above decides on encoding.
+    """
+    return load_ed25519_priv_pem(priv_path).sign(data)
+
+
+def save_ed25519_keypair_pem(
+    priv_pem: bytes, pub_pem: bytes, priv_path: str, pub_path: str
+) -> None:
+    """Write Ed25519 PEMs to disk with appropriate perms (0600 / 0644).
+    Atomic via temp + rename so SIGKILL mid-write can't leave partial
+    state. Mirror of save_keypair() above for X25519."""
+    _atomic_write_bytes(priv_path, priv_pem, mode=0o600)
+    _atomic_write_bytes(pub_path, pub_pem, mode=0o644)
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/lib/airc_core/identity.py
+++ b/lib/airc_core/identity.py
@@ -30,6 +30,15 @@ from typing import Optional
 X25519_PRIV_FILENAME = "x25519_priv"
 X25519_PUB_FILENAME = "x25519_pub"
 
+# Ed25519 envelope-signing keypair lives as PEM files at fixed names —
+# matching the on-disk shape that prior shell-openssl init wrote, so a
+# scope upgraded across the cryptography-migration boundary doesn't see
+# its identity rotate. Different file names from X25519 (which uses raw
+# bytes) because the openssl-created private.pem / public.pem pre-date
+# this module and we keep them.
+ED25519_PRIV_FILENAME = "private.pem"
+ED25519_PUB_FILENAME = "public.pem"
+
 
 def x25519_paths(identity_dir: str) -> tuple[str, str]:
     """Return (priv_path, pub_path) for an identity directory."""
@@ -69,6 +78,60 @@ def bootstrap(identity_dir: str) -> tuple[bytes, bytes]:
     priv, pub = crypto.generate_x25519_keypair()
     crypto.save_keypair(priv, pub, priv_path, pub_path)
     return (priv, pub)
+
+
+# ── Ed25519 envelope-signing keypair (issue #341 migration) ────────
+#
+# Pre-#341 init_identity() shelled out to `openssl genpkey -algorithm
+# Ed25519`. macOS LibreSSL doesn't implement Ed25519, which silently
+# broke fresh-Mac installs (the `2>/dev/null` ate the error). The
+# cryptography venv module already supports Ed25519 natively and is
+# already an install.sh prereq for envelope encryption — so the shell
+# openssl is a redundant footgun. These functions are the migration
+# target.
+
+def ed25519_paths(identity_dir: str) -> tuple[str, str]:
+    """Return (priv_path, pub_path) for an identity directory."""
+    return (
+        os.path.join(identity_dir, ED25519_PRIV_FILENAME),
+        os.path.join(identity_dir, ED25519_PUB_FILENAME),
+    )
+
+
+def has_ed25519_keypair(identity_dir: str) -> bool:
+    priv_path, pub_path = ed25519_paths(identity_dir)
+    return os.path.isfile(priv_path) and os.path.isfile(pub_path)
+
+
+def bootstrap_ed25519(identity_dir: str) -> None:
+    """Idempotent: generate the Ed25519 envelope-signing keypair if
+    missing. Writes private.pem (PKCS#8 PEM, 0600) + public.pem (SPKI
+    PEM, 0644) — same on-disk format the prior `openssl genpkey` path
+    produced, so an upgraded scope's identity is unchanged.
+
+    Raises ImportError if cryptography is unavailable. Callers higher
+    up (`airc init_identity` bash) treat that as a hard fatal: the
+    envelope signing key is required, not optional.
+    """
+    from . import crypto
+
+    priv_path, pub_path = ed25519_paths(identity_dir)
+    if has_ed25519_keypair(identity_dir):
+        return
+    os.makedirs(identity_dir, exist_ok=True)
+    priv_pem, pub_pem = crypto.generate_ed25519_keypair_pem()
+    crypto.save_ed25519_keypair_pem(priv_pem, pub_pem, priv_path, pub_path)
+
+
+def sign_ed25519(identity_dir: str, data: bytes) -> bytes:
+    """Sign `data` with the scope's Ed25519 private key. Raw 64-byte
+    signature output — same as `openssl pkeyutl -sign` produces. Caller
+    base64s for invite-string / envelope embedding.
+    """
+    from . import crypto
+
+    priv_path, _ = ed25519_paths(identity_dir)
+    return crypto.sign_ed25519_pem(priv_path, data)
 
 
 def cryptography_available() -> bool:
@@ -221,6 +284,20 @@ def _cli() -> int:
     )
     pp.add_argument("--peers-dir", required=True)
     pp.add_argument("--peer-name", required=True)
+    # Ed25519 envelope-signing key — replaces the prior shell openssl
+    # path. bootstrap_ed25519 is invoked from airc's init_identity;
+    # sign_ed25519 from sign_message. See module docstring (Ed25519
+    # block above) for migration context.
+    be = sub.add_parser(
+        "bootstrap-ed25519",
+        help="Generate Ed25519 envelope-signing keypair if missing",
+    )
+    be.add_argument("--dir", required=True, help="Identity directory path")
+    se = sub.add_parser(
+        "sign-ed25519",
+        help="Sign stdin bytes; print base64 signature on stdout",
+    )
+    se.add_argument("--dir", required=True, help="Identity directory path")
     args = parser.parse_args()
 
     if args.cmd == "bootstrap":
@@ -261,6 +338,48 @@ def _cli() -> int:
             return 0
         from . import crypto
         print(crypto.b64encode(pub))
+        return 0
+
+    if args.cmd == "bootstrap-ed25519":
+        # Hard-fatal if cryptography missing — Ed25519 signing is required
+        # for the envelope path, not optional. install.sh's prereq check
+        # ensures the venv has cryptography; if we got here without it,
+        # the install is broken.
+        if not cryptography_available():
+            print(
+                "cryptography package not available; airc envelope signing "
+                "requires it. Re-run install.sh to set up the venv.",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            bootstrap_ed25519(args.dir)
+        except OSError as e:
+            print(f"ed25519 bootstrap failed: {e}", file=sys.stderr)
+            return 1
+        return 0
+
+    if args.cmd == "sign-ed25519":
+        # Reads message bytes from stdin (binary-safe; bash pipes message
+        # data via `printf '%s' "$msg" | python -m airc_core.identity
+        # sign-ed25519 ...`). Prints b64 signature on stdout, matching
+        # the prior `openssl pkeyutl -sign | base64` output shape so
+        # callers don't need to change.
+        if not cryptography_available():
+            print("cryptography missing", file=sys.stderr)
+            return 1
+        try:
+            data = sys.stdin.buffer.read()
+            sig = sign_ed25519(args.dir, data)
+        except (OSError, ValueError) as e:
+            print(f"ed25519 sign failed: {e}", file=sys.stderr)
+            return 1
+        # Standard base64 (with padding, newline-terminated) — matches
+        # `openssl pkeyutl -sign | base64` byte-for-byte. Don't use the
+        # urlsafe variant `crypto.b64encode` here; bash callers expect
+        # the openssl-compatible format.
+        import base64
+        sys.stdout.write(base64.b64encode(sig).decode("ascii") + "\n")
         return 0
 
     return 1


### PR DESCRIPTION
## Summary

Identity gen + envelope-signing both routed via system \`openssl\`, which broke silently on macOS LibreSSL (no \`genpkey -algorithm Ed25519\`). #342 made the failure loud and auto-installed \`brew openssl@3\`. This PR removes the dependency on system openssl entirely by routing through the venv \`cryptography\` module that's already installed for envelope encryption.

Closes #341.

## What changed

- **\`lib/airc_core/crypto.py\`**: add \`generate_ed25519_keypair_pem\`, \`load_ed25519_priv_pem\`, \`sign_ed25519_pem\`, \`save_ed25519_keypair_pem\`. PEM format (PKCS#8 priv, SPKI pub) matches openssl byte-for-byte — existing scopes load + verify cleanly.
- **\`lib/airc_core/identity.py\`**: \`bootstrap_ed25519\` + \`sign_ed25519\` siblings to the existing X25519 functions, plus \`bootstrap-ed25519\` / \`sign-ed25519\` CLI subcommands.
- **\`airc\` top-level**: \`sign_message\` + \`init_identity\` now invoke the python CLI. Removed \`_resolve_openssl\`, \`AIRC_OPENSSL\`, \`_die_no_ed25519_openssl\` — dead code post-migration.
- **\`install.sh\`**: drop openssl from prereqs + drop the LibreSSL-detect + brew-install-openssl@3 dance.
- **\`cmd_doctor.sh\`**: replace the openssl probe with a \`cryptography\` import probe.

## Backward compat

Existing scopes' \`private.pem\` / \`public.pem\` files (created by shell openssl in any prior version) load unchanged via \`load_pem_private_key\`. Cross-checked: signing a Python-generated key via \`openssl pkeyutl -sign\` and signing the same message via the new Python path produces byte-identical base64 output. No identity rotation triggered by upgrade.

## Test plan

- [x] Local: \`airc connect --no-room --no-gist\` writes \`private.pem\` (119 bytes, 0600) + \`public.pem\` (113 bytes, 0644) — same shape as openssl
- [x] Local: \`airc doctor\` reports \`[ok] cryptography (Ed25519 identity gen + signing)\`
- [x] Cross-compat: \`openssl pkeyutl -sign\` vs new Python \`sign-ed25519\` on the same key + message → byte-identical b64 output
- [x] Cross-compat: openssl-generated \`private.pem\` loaded + signed via Python with byte-identical signature
- [ ] CI: clean-install matrix (4 platforms) — green
- [ ] Carl's fresh-Mac rerun: \`airc join\` no longer requires \`brew install openssl@3\` (the LibreSSL system binary is irrelevant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)