### PR TITLE
fix(gh): distinguish secondary rate limit from auth failure + skill scope-doc correction (#341)

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -252,15 +252,33 @@ cmd_connect() {
   # killed it before the host loop could start (PR #338 regression).
   if [ "$use_room" = "1" ] && command -v gh >/dev/null 2>&1; then
     if ! gh auth status >/dev/null 2>&1; then
+      # `gh auth status` probes /user, which returns 403 during a GitHub
+      # secondary rate limit (abuse detection) and which gh then misreports
+      # as "token invalid". The /rate_limit endpoint is reachable during
+      # secondary limits — if it works, the token is fine and the user
+      # just needs to wait, not re-auth. Issue #341.
       echo "" >&2
-      echo "  ✗ gh CLI is installed but the GitHub token is invalid." >&2
-      echo "    Detail:" >&2
-      gh auth status 2>&1 | sed 's/^/      /' >&2
-      echo "" >&2
-      echo "    Fix:  gh auth login -h github.com" >&2
-      echo "" >&2
-      echo "    Without gh auth, airc can't talk to the gist substrate at all." >&2
-      die "gh auth invalid — run 'gh auth login -h github.com' first"
+      if gh api rate_limit >/dev/null 2>&1; then
+        echo "  ! GitHub secondary rate limit (abuse detection) triggered." >&2
+        echo "    Your token is fine — wait 5-15 minutes and retry 'airc join'." >&2
+        echo "" >&2
+        echo "    Why this is confusing: 'gh auth status' calls /user which gets 403'd" >&2
+        echo "    during secondary rate limits; gh then prints 'token invalid'. The" >&2
+        echo "    /rate_limit endpoint is reachable, which proves the token works." >&2
+        echo "" >&2
+        echo "    Caused by: too many gh API calls in a short window (polling loops," >&2
+        echo "    rapid-fire PR/issue/comment activity, etc.)." >&2
+        die "GitHub rate-limited — retry in 5-15 min (token is fine)"
+      else
+        echo "  ✗ gh CLI is installed but the GitHub token is invalid." >&2
+        echo "    Detail:" >&2
+        gh auth status 2>&1 | sed 's/^/      /' >&2
+        echo "" >&2
+        echo "    Fix:  gh auth login -h github.com" >&2
+        echo "" >&2
+        echo "    Without gh auth, airc can't talk to the gist substrate at all." >&2
+        die "gh auth invalid — run 'gh auth login -h github.com' first"
+      fi
     fi
   fi
 

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -353,16 +353,32 @@ _doctor_connect_preflight() {
   if ! _doctor_probe "gh" "$mgr" "Gist substrate (room discovery)"; then
     issues=$((issues+1))
   elif ! gh auth status >/dev/null 2>&1; then
-    printf "  [BLOCKED] gh authenticated\n"
-    printf "         Fix: gh auth login -s gist\n"
+    # Distinguish a real auth failure from a GitHub secondary rate limit
+    # (abuse detection). The /rate_limit endpoint is reachable during
+    # secondary limits, so if it works, the token is fine — the user just
+    # needs to wait. `gh auth status` probes /user, which gets 403'd, and
+    # gh then misreports the symptom as 'token invalid'. Issue #341.
+    if gh api rate_limit >/dev/null 2>&1; then
+      printf "  [BLOCKED] gh secondary rate limit (abuse detection) — token is fine\n"
+      printf "         Fix: wait 5-15 min then re-run; cause is too many gh API calls in a short window\n"
+    else
+      printf "  [BLOCKED] gh authenticated\n"
+      printf "         Fix: gh auth login -s gist\n"
+    fi
     issues=$((issues+1))
   elif ! gh auth status 2>&1 | grep -qiE '(scopes|token scopes):.*\bgist\b'; then
     printf "  [BLOCKED] gh authed but missing 'gist' scope (room substrate needs it)\n"
     printf "         Fix: gh auth refresh -s gist\n"
     issues=$((issues+1))
   elif ! gh api 'gists?per_page=1' >/dev/null 2>&1; then
-    printf "  [BLOCKED] gist API not reachable -- network outage or rate-limit\n"
-    printf "         Fix: check internet; if persistent, run 'gh auth refresh'\n"
+    # Same misdiagnosis risk here — distinguish rate-limit vs other.
+    if gh api rate_limit >/dev/null 2>&1; then
+      printf "  [BLOCKED] gh secondary rate limit (abuse detection) — token + scope are fine\n"
+      printf "         Fix: wait 5-15 min then re-run\n"
+    else
+      printf "  [BLOCKED] gist API not reachable -- network outage or token revoked\n"
+      printf "         Fix: check internet; if persistent, run 'gh auth refresh'\n"
+    fi
     issues=$((issues+1))
   else
     printf "  [ok] gh authed with gist scope, gists API reachable\n"

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -151,6 +151,10 @@ else:
   if command -v gh >/dev/null 2>&1; then
     if gh auth status >/dev/null 2>&1; then
       echo "  gh auth:     ok"
+    elif gh api rate_limit >/dev/null 2>&1; then
+      # Token works (rate_limit reachable); /user got 403'd by secondary
+      # rate limit and gh misreports it as 'token invalid'. Issue #341.
+      echo "  gh auth:     RATE-LIMITED (secondary; token is fine — wait 5-15 min)"
     else
       echo "  gh auth:     ✗ INVALID — run 'gh auth login -h github.com' to fix"
     fi

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -43,7 +43,7 @@ If `gh` is not on PATH or not authed: install + `gh auth login`. There's no grac
 
 ## 2. Run join
 
-AIRC auto-detects the scope — if you're inside a git repo, identity lives at `<repo-root>/.airc/`; otherwise `~/.airc/`. No env vars needed.
+AIRC auto-detects the scope — if you're inside a git repo, identity lives at `<repo-root>/.airc/`; otherwise at `$PWD/.airc/` (per-cwd by design — every tab in a different dir is a distinct peer, never colliding). Set `AIRC_HOME=/path` to force a specific scope dir.
 
 **Default — auto-scoped project room + #general sidecar:**
 ```


### PR DESCRIPTION
Two small Carl-UX fixes from the QA pass on #341.

## 1. Rate-limit-vs-auth diagnose

`gh auth status` calls `/user`, which returns 403 during a GitHub secondary rate limit (abuse detection). gh interprets the 403 as 'token invalid' and prints exactly that. airc surfaced it verbatim — Carl saw 'GitHub token is invalid' during a rate-limit cooldown, ran 'gh auth login' fruitlessly, and got nowhere because the token was actually fine.

The `/rate_limit` endpoint is reachable during secondary rate limits. If it works, the token works. Use it as the discriminator.

Three sites fixed (all use `gh auth status` as a preflight or status check):
- **`cmd_connect.sh` (`airc join` preflight)**: dies with 'GitHub rate-limited — retry in 5-15 min (token is fine)' when `/rate_limit` is reachable, with a brief explanation of why gh misreports.
- **`cmd_doctor.sh`**: '[BLOCKED] gh authenticated' becomes '[BLOCKED] gh secondary rate limit (abuse detection) — token is fine' under the same condition. Same fix applied to the downstream gist-API-reachable check.
- **`cmd_status.sh`**: 'gh auth: ✗ INVALID' becomes 'gh auth: RATE-LIMITED (secondary; token is fine — wait 5-15 min)'.

Live-tested on this Mac (which tripped the secondary rate limit during the QA pass when a 15s issue-comment polling Monitor combined with rapid PR/issue/comment activity). Pre-fix `airc join` died with 'token invalid'; post-fix it dies with the accurate rate-limit message.

Doesn't touch `cmd_send.sh`'s `auth_failure` path — that runs off a bearer report, not a direct gh probe, and needs a separate look at the Python bearer's auth_failure determination logic. Filed as a follow-up under #341.

## 2. /join skill scope-doc correction

The /join skill said non-git-repo cwds put state in `~/.airc/`. Code actually writes to `$PWD/.airc/` (`detect_scope` in `airc:162`). README is correct on three different lines (256, 375, 501) — only the skill disagreed. Carl reading the skill expected `~/.airc/`, saw state appear in `/Users/joel/Development/.airc/` when running from a non-project dir, got confused.

Per-cwd-by-default is intentional — multi-tab on one machine: each tab in its own dir = distinct identity, never colliding. The fix updates the skill text to match actual behavior + mentions `AIRC_HOME` as the override knob.

## Test plan
- [x] `airc join` from a clean cwd while secondary rate limit is active → prints actionable 'rate-limited; wait 5-15 min' instead of 'token invalid'
- [x] `airc join` with a genuinely revoked / missing token → still prints original 'token invalid' message + `gh auth login` guidance
- [x] `airc doctor` mid-rate-limit → '[BLOCKED] gh secondary rate limit ...' instead of '[BLOCKED] gh authenticated'
- [x] `airc status` mid-rate-limit → 'gh auth: RATE-LIMITED' line instead of '✗ INVALID'
- [x] /join skill text reads $PWD/.airc/ for non-git cwds, matches code

🤖 Generated with [Claude Code](https://claude.com/claude-code)