### PR TITLE
fix(doctor): drop sshd probe — post-3c the gist IS the wire (#341)

### DIFF
--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -53,7 +53,10 @@ cmd_doctor() {
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"     || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"    || issues=$((issues+1))
   _doctor_probe_cryptography                                            || issues=$((issues+1))
-  _doctor_probe_sshd                                                    || issues=$((issues+1))
+  # sshd probe removed post-3c: the gist IS the wire for ALL peers; airc no
+  # longer ssh's into the host's airc_home. ssh-keygen above stays (identity
+  # key generation), ssh client stays (occasional manual diagnostic + future
+  # wire-pluggable bearers). Issue #341 follow-up.
   _doctor_probe_tailscale "$mgr"  # optional, never increments issues
 
   echo ""
@@ -207,109 +210,6 @@ _doctor_probe_cryptography() {
   return 1
 }
 
-# Probe sshd (SSH server). airc joiners ssh into the host's airc_home
-# to `tail -F messages.jsonl`. So every airc user who'll host a room
-# (which is most users — first to discover a room becomes its host)
-# needs sshd running on their box. Pre-fix: airc doctor probed for the
-# ssh CLIENT but not the SERVER. Joel + continuum-b69f hit this on
-# 2026-04-27 mid-cross-machine bringup: TCP handshake worked, but
-# message stream silently failed because Windows ships OpenSSH client
-# but NOT the server enabled by default.
-#
-# Per-platform probes:
-#   macOS         — launchctl + systemsetup (Remote Login)
-#   linux / wsl   — systemctl is-active on ssh OR sshd unit names
-#                   (Debian/Ubuntu unit is 'ssh', RHEL/Fedora is 'sshd')
-#   windows-bash  — powershell.exe Get-Service sshd, distinguish
-#                   Running / Stopped / Missing-capability
-#
-# Returns 0 on ok, 1 on missing/broken, 0 on platforms we can't probe
-# (don't penalize if we can't tell).
-_doctor_probe_sshd() {
-  local plat; plat=$(detect_platform)
-  case "$plat" in
-    darwin)
-      # macOS Remote Login = launchd-managed sshd. Detect WITHOUT sudo:
-      #   - `launchctl list` (user scope) does NOT show system services
-      #     like com.openssh.sshd, so the user-scope probe always misses.
-      #   - `launchctl print system` DOES list system services and works
-      #     without sudo. Look for `com.openssh.sshd` (the service id).
-      #   - `systemsetup -getremotelogin` requires admin to read state
-      #     (returns "You need administrator access..." otherwise) — keep
-      #     it as the second-attempt fallback in case sudo is cached.
-      if launchctl print system 2>/dev/null | grep -qE 'com\.openssh\.sshd($|[[:space:]])'; then
-        printf "  [ok] sshd (Remote Login enabled)\n"
-        return 0
-      fi
-      if systemsetup -getremotelogin 2>/dev/null | grep -qi "Remote Login: On"; then
-        printf "  [ok] sshd (Remote Login enabled)\n"
-        return 0
-      fi
-      printf "  [MISSING] sshd -- needed when you HOST a room\n"
-      printf "         Fix: System Settings -> General -> Sharing -> Remote Login (toggle on)\n"
-      printf "         Or:  sudo systemsetup -setremotelogin on\n"
-      return 1
-      ;;
-    linux|wsl)
-      # Debian/Ubuntu uses 'ssh', RHEL/Fedora/Arch uses 'sshd'.
-      if systemctl is-active --quiet ssh 2>/dev/null || systemctl is-active --quiet sshd 2>/dev/null; then
-        printf "  [ok] sshd (systemd active)\n"
-        return 0
-      fi
-      printf "  [MISSING] sshd -- needed when you HOST a room\n"
-      printf "         Fix (Debian/Ubuntu): sudo apt-get install openssh-server && sudo systemctl enable --now ssh\n"
-      printf "         Fix (RHEL/Fedora):    sudo dnf install openssh-server && sudo systemctl enable --now sshd\n"
-      return 1
-      ;;
-    windows)
-      # powershell.exe is the canonical PS launcher in Git Bash. Some
-      # boxes also ship pwsh.exe (PS Core); prefer powershell.exe for
-      # broadest reach since OpenSSH service control works in both.
-      local _ps=""
-      if command -v powershell.exe >/dev/null 2>&1; then _ps="powershell.exe"
-      elif command -v pwsh.exe >/dev/null 2>&1; then _ps="pwsh.exe"
-      fi
-      if [ -z "$_ps" ]; then
-        printf "  [info] sshd probe skipped (powershell.exe not on PATH)\n"
-        return 0
-      fi
-      local _state
-      _state=$("$_ps" -NoProfile -Command "(Get-Service sshd -ErrorAction SilentlyContinue).Status" 2>/dev/null | tr -d '\r\n ')
-      case "$_state" in
-        Running)
-          printf "  [ok] sshd (Windows OpenSSH.Server running)\n"
-          return 0
-          ;;
-        Stopped|StopPending|StartPending|Paused)
-          printf "  [BROKEN] sshd -- installed but not running (state: %s)\n" "$_state"
-          printf "         Fix (admin PowerShell):  Start-Service sshd; Set-Service sshd -StartupType Automatic\n"
-          return 1
-          ;;
-        "")
-          printf "  [MISSING] sshd -- needed when you HOST a room\n"
-          printf "         Fix (admin PowerShell — five lines, run all together):\n"
-          printf "           Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0\n"
-          printf "           reg add HKLM\\\\SYSTEM\\\\CurrentControlSet\\\\Services\\\\hns\\\\State /v EnableExcludedPortRange /d 0 /f\n"
-          printf "           netsh int ipv4 add excludedportrange protocol=tcp startport=22 numberofports=1\n"
-          printf "           Start-Service sshd\n"
-          printf "           Set-Service -Name sshd -StartupType Automatic\n"
-          printf "         (The reg+netsh lines work around Windows HNS holding port 22 randomly per boot —\n"
-          printf "          continuum-b69f's diagnosis 2026-04-27. Without them, sshd bind returns EPERM.)\n"
-          return 1
-          ;;
-        *)
-          printf "  [info] sshd state unknown (Get-Service returned: '%s')\n" "$_state"
-          return 0
-          ;;
-      esac
-      ;;
-    *)
-      printf "  [info] sshd probe unsupported on platform '%s'\n" "$plat"
-      return 0
-      ;;
-  esac
-}
-
 _doctor_probe_tailscale() {
   local mgr="$1"
   # Use resolve_tailscale_bin so we find macOS GUI-installed Tailscale.app
@@ -363,7 +263,7 @@ _doctor_connect_preflight() {
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"    || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"   || issues=$((issues+1))
   _doctor_probe_cryptography                                           || issues=$((issues+1))
-  _doctor_probe_sshd                                                   || issues=$((issues+1))
+  # sshd probe removed post-3c — see cmd_doctor() in this file for rationale.
 
   # ── gh chain: installed → authed → gist scope → gists API reachable.
   # Single chain (early-return on first failure) so a missing gh isn't


### PR DESCRIPTION
Drops the last vestige of the pre-3c sshd dependency from `airc doctor`. install.sh comment 287 already notes "Post-3c: sshd setup + Tailscale install fully removed" — the doctor probe was the only thing still claiming sshd is required, and it surfaced as `[MISSING] sshd -- needed when you HOST a room` on every Mac/Linux/Windows box where Remote Login wasn't enabled. Carl on this rig flagged it as the third sub-bullet during the #341 QA pass.

Post-3c, every peer reads + writes the room gist via `gh api`. There is no ssh path remaining. ssh-keygen stays (identity key generation), the ssh client probe stays (manual diagnostic + future wire-pluggable bearers may want it), but **sshd is irrelevant**.

## Changes
- Remove `_doctor_probe_sshd()` function entirely (~100 lines of macOS launchctl / systemd / Windows OpenSSH.Server probe code)
- Remove both call sites: default `airc doctor` (line 56) and `airc doctor --connect` preflight (line 366)
- Replace each call site with a one-line comment explaining the removal so future readers don't add it back

## Tested on this Mac
Pre-fix:
```
[ok] cryptography (Ed25519 identity gen + signing)
[MISSING] sshd -- needed when you HOST a room
       Fix: System Settings -> General -> Sharing -> Remote Login (toggle on)
       Or:  sudo systemsetup -setremotelogin on
...
1 prereq(s) missing -- see fix lines above.
```

Post-fix:
```
[ok] cryptography (Ed25519 identity gen + signing)
[info] tailscale (optional) -- not installed; only needed for cross-LAN mesh
       Install: brew install --cask tailscale
...
All required prereqs present. Behavioral suite:  airc doctor --tests
```

## Out of scope
The dead sshd-comment chunk in `install.sh:268-287` (historical context, no actual logic) — fold into the next install.sh touch. Also: cmd_send.sh's `auth_failure` path still surfaces "your GitHub token is dead" without the rate-limit-vs-auth diagnose distinction (different code path, runs off bearer report) — separate follow-up.

## Test plan
- [x] `airc doctor` from a Carl-state Mac (LibreSSL only, no brew openssl, no Remote Login enabled) → "All required prereqs present"
- [x] `airc doctor` syntax check (`bash -n`)
- [ ] `airc doctor --connect` on a Mac → confirm sshd block is gone, rest of preflight intact
- [ ] Linux + Windows verify (no behavioral change expected since the probe is removed entirely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)