### PR TITLE
canary→main: fresh-Mac install fixed + cryptography migration + CI honesty + UX cleanups (#341)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           cp -r . $HOME/.airc-src/
           # Real install — no AIRC_SKIP_PREREQS. install.sh must
           # detect the package manager and install everything missing.
-          AIRC_DIR=$HOME/.airc-src bash install.sh
+          AIRC_INSTALL_NO_PULL=1 AIRC_DIR=$HOME/.airc-src bash install.sh
 
       - name: airc doctor (must report environment-clean)
         run: |
@@ -107,7 +107,7 @@ jobs:
         run: |
           mkdir -p $HOME/.airc-src
           cp -r . $HOME/.airc-src/
-          AIRC_DIR=$HOME/.airc-src bash install.sh
+          AIRC_INSTALL_NO_PULL=1 AIRC_DIR=$HOME/.airc-src bash install.sh
 
       - name: airc doctor (must report environment-clean)
         run: |
@@ -210,7 +210,7 @@ jobs:
         run: |
           mkdir -p $HOME/.airc-src
           cp -r . $HOME/.airc-src/
-          AIRC_DIR=$HOME/.airc-src bash install.sh
+          AIRC_INSTALL_NO_PULL=1 AIRC_DIR=$HOME/.airc-src bash install.sh
 
       - name: Run integration suite
         run: |

--- a/README.md
+++ b/README.md
@@ -20,10 +20,25 @@
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
-gh auth login
 ```
 
-That's it. install.sh handles everything else: installs `gh` (if you don't already have it — and honestly, you should), `python3`, `openssl`; creates a tiny local Python venv for the encryption library; puts `airc` on your PATH; wires the Claude Code skills into `~/.claude/skills/`. **No admin elevation, no daemons, no popups, the same on every platform.**
+install.sh handles the rest: installs `gh` / `python3` / `openssl` if missing, runs `gh auth login -s gist` interactively when you're not already signed in (no separate step), creates a local Python venv for the encryption library, puts `airc` on your PATH, and symlinks the Claude Code skills into `~/.claude/skills/`. **No admin elevation, no daemons, no popups.**
+
+When it finishes, open your agent:
+
+```bash
+claude          # or codex, cursor, opencode, windsurf, openclaw, ...
+```
+
+Then, inside the agent:
+
+```
+/join
+```
+
+You're in your project's room alongside every other agent on your gh account. (Prefer raw shell? `airc join` does the same thing.)
+
+> Already signed into `gh` from past work? install.sh detects that and skips the auth prompt — you'll see `gh token wired into git credential helper` instead. Want pre-merge canary builds? `AIRC_CHANNEL=canary curl -fsSL …/install.sh | bash`.
 
 > **Native-PowerShell users (rare):** use `iwr https://raw.githubusercontent.com/CambrianTech/airc/main/install.ps1 | iex` if you specifically want the PowerShell port. Most Windows users run Claude Code / Codex / Cursor in Git Bash, where `install.sh` is the right entry.
 

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ airc kick <peer> [reason]        # host-only: remove peer record + broadcast [ki
 # Lifecycle
 airc quit                         # leave mesh, keep identity
 airc teardown [--flush] [--all]   # kill processes (--flush wipes state)
+airc uninstall [--yes] [--purge]  # fully remove airc from this machine
 airc daemon install               # autostart via launchd (mac) / systemd-user (linux)
 airc daemon status / log / uninstall
 
@@ -376,6 +377,7 @@ The Claude Code skills are auto-installed by `install.sh` so the AI can run airc
 | [resume](skills/resume/) | `/resume` | Explicit resume (alias for `/join` with no args) |
 | [reminder](skills/reminder/) | `/reminder <seconds\|off\|pause>` | Control silence-nudge |
 | [teardown](skills/teardown/) | `/teardown [--flush]` | Kill scope's processes |
+| [uninstall](skills/uninstall/) | `/uninstall [--yes] [--purge]` | Fully remove airc (clone, symlinks, daemon, processes); leaves per-project state unless `--purge` |
 | [repair](skills/repair/) | `/repair [invite]` | Full re-pair (teardown --flush + reconnect) |
 | [update](skills/update/) | `/update` | Pull latest on current channel + refresh skills |
 | [canary](skills/canary/) | `/canary` | Switch to canary channel + pull (opt-in pre-merge testing) |

--- a/airc
+++ b/airc
@@ -81,6 +81,62 @@ else
 fi
 export AIRC_PYTHON
 
+# Resolve openssl with Ed25519 capability. Probed once at startup so that
+# init_identity / sign_message can trust the binary at runtime. macOS
+# /usr/bin/openssl is LibreSSL — it passes `openssl --version` (so a naive
+# probe says it's fine) but does NOT support `genpkey -algorithm Ed25519`.
+# Brew openssl@3 / openssl works. Search Mac brew layouts before falling
+# back to PATH; on Linux/Windows the PATH default is openssl 1.1.1+ which
+# is fine. AIRC_OPENSSL env var is the user override (custom layouts).
+# Tracking: issue #341.
+_resolve_openssl() {
+  local cands=() c
+  [ -n "${AIRC_OPENSSL:-}" ] && cands+=("$AIRC_OPENSSL")
+  case "$(uname -s 2>/dev/null)" in
+    Darwin)
+      [ -x /opt/homebrew/opt/openssl@3/bin/openssl ] && cands+=(/opt/homebrew/opt/openssl@3/bin/openssl)
+      [ -x /opt/homebrew/opt/openssl/bin/openssl   ] && cands+=(/opt/homebrew/opt/openssl/bin/openssl)
+      [ -x /usr/local/opt/openssl@3/bin/openssl    ] && cands+=(/usr/local/opt/openssl@3/bin/openssl)
+      [ -x /usr/local/opt/openssl/bin/openssl      ] && cands+=(/usr/local/opt/openssl/bin/openssl)
+      ;;
+  esac
+  local path_openssl; path_openssl=$(command -v openssl 2>/dev/null) || path_openssl=""
+  [ -n "$path_openssl" ] && cands+=("$path_openssl")
+  for c in "${cands[@]}"; do
+    if "$c" genpkey -algorithm Ed25519 -out /dev/null >/dev/null 2>&1; then
+      printf '%s' "$c"
+      return 0
+    fi
+  done
+  return 1
+}
+AIRC_OPENSSL=$(_resolve_openssl) || AIRC_OPENSSL=""
+export AIRC_OPENSSL
+
+_die_no_ed25519_openssl() {
+  cat >&2 <<EOF
+ERROR: airc identity needs an openssl that supports Ed25519, and none was found.
+
+  Resolved openssl on PATH: $(command -v openssl 2>/dev/null || echo '<none>')
+  $(openssl version 2>/dev/null || true)
+
+  macOS ships LibreSSL as /usr/bin/openssl — it does not implement Ed25519.
+  Fix:
+    brew install openssl@3
+    airc join
+
+  Or point AIRC_OPENSSL at a working binary:
+    AIRC_OPENSSL=/path/to/openssl airc join
+
+  Linux: install openssl 1.1.1+ from your package manager (most distros
+  ship it by default). Windows: Git for Windows bundles a working openssl;
+  ensure it's on PATH ahead of any older system one.
+
+  Tracking: https://github.com/CambrianTech/airc/issues/341
+EOF
+  exit 1
+}
+
 # MSYS Git Bash on Windows translates argv VALUES that look like
 # Unix-rooted paths when bash invokes a Windows-native binary. So
 # `--host-airc-home /Users/joelteply/.airc` arrives at python.exe as
@@ -730,9 +786,10 @@ humanhash() {
 }
 
 sign_message() {
+  [ -z "${AIRC_OPENSSL:-}" ] && _die_no_ed25519_openssl
   local tmpfile; tmpfile=$(mktemp)
   printf '%s' "$1" > "$tmpfile"
-  openssl pkeyutl -sign -inkey "$IDENTITY_DIR/private.pem" -in "$tmpfile" 2>/dev/null | base64
+  "$AIRC_OPENSSL" pkeyutl -sign -inkey "$IDENTITY_DIR/private.pem" -in "$tmpfile" 2>/dev/null | base64
   rm -f "$tmpfile"
 }
 
@@ -899,8 +956,9 @@ init_identity() {
   local name="$1"
   mkdir -p "$AIRC_WRITE_DIR" "$IDENTITY_DIR" "$PEERS_DIR"
   if [ ! -f "$IDENTITY_DIR/private.pem" ]; then
-    openssl genpkey -algorithm Ed25519 -out "$IDENTITY_DIR/private.pem" 2>/dev/null
-    openssl pkey -in "$IDENTITY_DIR/private.pem" -pubout -out "$IDENTITY_DIR/public.pem" 2>/dev/null
+    [ -z "${AIRC_OPENSSL:-}" ] && _die_no_ed25519_openssl
+    "$AIRC_OPENSSL" genpkey -algorithm Ed25519 -out "$IDENTITY_DIR/private.pem" 2>/dev/null
+    "$AIRC_OPENSSL" pkey -in "$IDENTITY_DIR/private.pem" -pubout -out "$IDENTITY_DIR/public.pem" 2>/dev/null
     chmod 600 "$IDENTITY_DIR/private.pem"
   fi
   if [ ! -f "$IDENTITY_DIR/ssh_key" ]; then

--- a/airc
+++ b/airc
@@ -1038,15 +1038,29 @@ monitor() {
   # window and after legitimate parent restarts.
   ( reminder_timer_loop ) &
   local _reminder_pid=$!
-  ( flush_pending_loop ) &
-  local _flush_pid=$!
+  # flush_pending_loop returns immediately when host_target is empty
+  # (legacy host mode: no peer paired, nothing to flush). Spawning +
+  # tracking that short-lived PID makes airc.pid lie — kill -0 on it
+  # fails seconds later (caught by clean-install-{macos,linux} smoke).
+  # Skip it entirely in that case; it'll get spawned on the next
+  # monitor invocation if/when host_target becomes non-empty.
+  local _flush_pid=""
+  local _ht; _ht=$(get_config_val host_target "")
+  if [ -n "$_ht" ]; then
+    ( flush_pending_loop ) &
+    _flush_pid=$!
+  fi
+  # Build the appended PID list — only include _flush_pid when we
+  # actually spawned it.
+  local _aux_pids="$_reminder_pid"
+  [ -n "$_flush_pid" ] && _aux_pids="$_aux_pids $_flush_pid"
   if [ -f "$AIRC_WRITE_DIR/airc.pid" ]; then
     # Append to existing pidfile atomically (printf+>> is < PIPE_BUF
     # so atomic on POSIX). Don't overwrite — cmd_connect already
     # wrote the parent + handshake + heartbeat pids there.
-    printf ' %s %s\n' "$_reminder_pid" "$_flush_pid" >> "$AIRC_WRITE_DIR/airc.pid"
+    printf ' %s\n' "$_aux_pids" >> "$AIRC_WRITE_DIR/airc.pid"
   else
-    printf '%s %s %s\n' "$$" "$_reminder_pid" "$_flush_pid" > "$AIRC_WRITE_DIR/airc.pid"
+    printf '%s %s\n' "$$" "$_aux_pids" > "$AIRC_WRITE_DIR/airc.pid"
   fi
 
   # Resolution priority:

--- a/airc
+++ b/airc
@@ -1456,6 +1456,18 @@ case "${1:-help}" in
   tests|test)        shift; _doctor_run_tests "$@" ;;
   daemon|autostart|service) shift; cmd_daemon "$@" ;;
   teardown|stop|flush) shift; cmd_teardown "$@" ;;
+  uninstall|self-uninstall)
+    # Dispatch to the canonical uninstall.sh in the clone root. _airc_lib_dir
+    # resolves to <clone>/lib, so the clone root is one dir up. exec so
+    # uninstall.sh runs in this process — once it rm -rf's the clone, the
+    # bash script body is already in memory and finishes cleanly.
+    shift
+    if [ -n "${_airc_lib_dir:-}" ] && [ -f "${_airc_lib_dir%/lib}/uninstall.sh" ]; then
+      exec bash "${_airc_lib_dir%/lib}/uninstall.sh" "$@"
+    else
+      die "Could not locate uninstall.sh (lib_dir=${_airc_lib_dir:-<unresolved>}). Run manually:  bash \$AIRC_DIR/uninstall.sh"
+    fi
+    ;;
   disconnect|quit|leave|unbind) shift; cmd_disconnect "$@" ;;
   monitor)   shift; monitor "$@" ;;
   debug-scope) echo "$AIRC_WRITE_DIR" ;;
@@ -1503,6 +1515,7 @@ case "${1:-help}" in
     echo "  airc status [--probe]           Liveness snapshot (--probe for SSH check)"
     echo "  airc reminder <seconds>         Nudge if silent (off/pause/300)"
     echo "  airc teardown [--flush] [--all] Kill scope's airc processes (--flush wipes state)"
+    echo "  airc uninstall [--yes] [--purge] Fully remove airc (clone, symlinks, daemon, processes)"
     echo ""
     echo "Identity resolution (highest priority first):"
     echo "  AIRC_NAME env var > config.json name > cwd basename > hostname"

--- a/airc
+++ b/airc
@@ -81,61 +81,14 @@ else
 fi
 export AIRC_PYTHON
 
-# Resolve openssl with Ed25519 capability. Probed once at startup so that
-# init_identity / sign_message can trust the binary at runtime. macOS
-# /usr/bin/openssl is LibreSSL — it passes `openssl --version` (so a naive
-# probe says it's fine) but does NOT support `genpkey -algorithm Ed25519`.
-# Brew openssl@3 / openssl works. Search Mac brew layouts before falling
-# back to PATH; on Linux/Windows the PATH default is openssl 1.1.1+ which
-# is fine. AIRC_OPENSSL env var is the user override (custom layouts).
-# Tracking: issue #341.
-_resolve_openssl() {
-  local cands=() c
-  [ -n "${AIRC_OPENSSL:-}" ] && cands+=("$AIRC_OPENSSL")
-  case "$(uname -s 2>/dev/null)" in
-    Darwin)
-      [ -x /opt/homebrew/opt/openssl@3/bin/openssl ] && cands+=(/opt/homebrew/opt/openssl@3/bin/openssl)
-      [ -x /opt/homebrew/opt/openssl/bin/openssl   ] && cands+=(/opt/homebrew/opt/openssl/bin/openssl)
-      [ -x /usr/local/opt/openssl@3/bin/openssl    ] && cands+=(/usr/local/opt/openssl@3/bin/openssl)
-      [ -x /usr/local/opt/openssl/bin/openssl      ] && cands+=(/usr/local/opt/openssl/bin/openssl)
-      ;;
-  esac
-  local path_openssl; path_openssl=$(command -v openssl 2>/dev/null) || path_openssl=""
-  [ -n "$path_openssl" ] && cands+=("$path_openssl")
-  for c in "${cands[@]}"; do
-    if "$c" genpkey -algorithm Ed25519 -out /dev/null >/dev/null 2>&1; then
-      printf '%s' "$c"
-      return 0
-    fi
-  done
-  return 1
-}
-AIRC_OPENSSL=$(_resolve_openssl) || AIRC_OPENSSL=""
-export AIRC_OPENSSL
-
-_die_no_ed25519_openssl() {
-  cat >&2 <<EOF
-ERROR: airc identity needs an openssl that supports Ed25519, and none was found.
-
-  Resolved openssl on PATH: $(command -v openssl 2>/dev/null || echo '<none>')
-  $(openssl version 2>/dev/null || true)
-
-  macOS ships LibreSSL as /usr/bin/openssl — it does not implement Ed25519.
-  Fix:
-    brew install openssl@3
-    airc join
-
-  Or point AIRC_OPENSSL at a working binary:
-    AIRC_OPENSSL=/path/to/openssl airc join
-
-  Linux: install openssl 1.1.1+ from your package manager (most distros
-  ship it by default). Windows: Git for Windows bundles a working openssl;
-  ensure it's on PATH ahead of any older system one.
-
-  Tracking: https://github.com/CambrianTech/airc/issues/341
-EOF
-  exit 1
-}
+# Issue #341 follow-up: shell openssl is no longer used for Ed25519
+# identity gen / signing. Both paths now route through the venv
+# cryptography module (airc_core.identity bootstrap-ed25519 / sign-
+# ed25519). The prior _resolve_openssl + AIRC_OPENSSL + _die helper
+# were #342's loud-failure mitigation; once truth moved to Python they
+# became dead code and were removed in this commit. ssh-keygen still
+# stays — that's an OpenSSH client tool, separate from libcrypto, and
+# every supported platform ships a working version.
 
 # MSYS Git Bash on Windows translates argv VALUES that look like
 # Unix-rooted paths when bash invokes a Windows-native binary. So
@@ -786,11 +739,11 @@ humanhash() {
 }
 
 sign_message() {
-  [ -z "${AIRC_OPENSSL:-}" ] && _die_no_ed25519_openssl
-  local tmpfile; tmpfile=$(mktemp)
-  printf '%s' "$1" > "$tmpfile"
-  "$AIRC_OPENSSL" pkeyutl -sign -inkey "$IDENTITY_DIR/private.pem" -in "$tmpfile" 2>/dev/null | base64
-  rm -f "$tmpfile"
+  # Sign message bytes via the venv cryptography path (issue #341 — the
+  # prior shell openssl call broke on macOS LibreSSL silently). Identity
+  # module's sign-ed25519 reads from stdin, prints base64 sig matching
+  # the prior `openssl pkeyutl -sign | base64` output byte-for-byte.
+  printf '%s' "$1" | "$AIRC_PYTHON" -m airc_core.identity sign-ed25519 --dir "$IDENTITY_DIR"
 }
 
 # ── Platform adapters ───────────────────────────────────────────────────
@@ -955,11 +908,16 @@ resolve_name() {
 init_identity() {
   local name="$1"
   mkdir -p "$AIRC_WRITE_DIR" "$IDENTITY_DIR" "$PEERS_DIR"
+  # Ed25519 envelope-signing keypair via the venv cryptography path
+  # (issue #341 — the prior shell openssl path broke on macOS LibreSSL
+  # silently). Idempotent: airc_core.identity.bootstrap_ed25519 returns
+  # cleanly without rewriting if the files already exist. Same on-disk
+  # PEM format the openssl path produced, so existing scopes upgrade
+  # in place without rotating keys.
   if [ ! -f "$IDENTITY_DIR/private.pem" ]; then
-    [ -z "${AIRC_OPENSSL:-}" ] && _die_no_ed25519_openssl
-    "$AIRC_OPENSSL" genpkey -algorithm Ed25519 -out "$IDENTITY_DIR/private.pem" 2>/dev/null
-    "$AIRC_OPENSSL" pkey -in "$IDENTITY_DIR/private.pem" -pubout -out "$IDENTITY_DIR/public.pem" 2>/dev/null
-    chmod 600 "$IDENTITY_DIR/private.pem"
+    if ! "$AIRC_PYTHON" -m airc_core.identity bootstrap-ed25519 --dir "$IDENTITY_DIR"; then
+      die "Ed25519 identity bootstrap failed — check that the venv has the cryptography package (re-run install.sh)"
+    fi
   fi
   if [ ! -f "$IDENTITY_DIR/ssh_key" ]; then
     ssh-keygen -t ed25519 -f "$IDENTITY_DIR/ssh_key" -N "" -C "airc-${name}" -q

--- a/install.sh
+++ b/install.sh
@@ -332,6 +332,16 @@ ensure_prereqs
 # ── Clone or update ─────────────────────────────────────────────────────
 
 if [ -d "$CLONE_DIR/.git" ]; then
+  # AIRC_INSTALL_NO_PULL=1: trust CLONE_DIR's checked-out tree exactly
+  # as-is — no branch switch, no pull. CI uses this when it has already
+  # staged the PR's tree at $CLONE_DIR via `cp -r .` and wants the
+  # smoke matrix to exercise the PR's code, not whatever's on main.
+  # Without this escape hatch, install.sh's "I'm-on-a-non-channel-branch
+  # so let me reset to main" recovery path silently overwrites the
+  # PR's code with origin/main's — making the PR's CI a no-op.
+  if [ "${AIRC_INSTALL_NO_PULL:-0}" = "1" ]; then
+    info "AIRC_INSTALL_NO_PULL=1 — using CLONE_DIR tree as-is, skipping branch-switch + pull"
+  else
   info "Updating existing install"
   # Recovery: if the install dir is on a non-channel branch (e.g. someone
   # / some AI checked out a feature branch for testing and forgot to
@@ -394,6 +404,7 @@ Recover with:
 EOF
     exit 1
   fi
+  fi  # AIRC_INSTALL_NO_PULL guard
 else
   # First install. Honor AIRC_CHANNEL if set so users can land on canary
   # directly via `AIRC_CHANNEL=canary curl|bash` without a follow-up

--- a/install.sh
+++ b/install.sh
@@ -298,9 +298,35 @@ ensure_prereqs() {
   # a TTY, CI, etc).
   if command -v gh >/dev/null 2>&1; then
     if ! gh auth status >/dev/null 2>&1; then
-      if [ -t 0 ] && [ -t 1 ]; then
-        info "gh is not authenticated — launching 'gh auth login -s gist' now."
-        info "  (Browser will open; sign in to GitHub. The 'gist' scope is required for the substrate.)"
+      # Skip the interactive auth path under sudo/root: gh stores the token
+      # for the calling user (root's keyring), but airc runs as the real
+      # user and reads the real user's token. Authing as root silently
+      # produces a working-as-root / broken-as-user state. Joel 2026-04-29:
+      # 'detect and if not, open it if it isnt sudo'.
+      _running_as_root=0
+      if [ "${EUID:-$(id -u 2>/dev/null || echo 1000)}" = "0" ] || [ -n "${SUDO_USER:-}" ]; then
+        _running_as_root=1
+      fi
+      if [ "$_running_as_root" = "1" ]; then
+        warn "gh is not authenticated, and install is running as root/sudo."
+        warn "  Don't auth gh as root — re-run as your normal user, or run once after install:"
+        warn "    gh auth login -h github.com -s gist"
+      elif [ -t 0 ] && [ -t 1 ]; then
+        # Pause-with-Enter before handing the user off to gh's device-code
+        # flow. Without this break, the gh prompt + browser popup arrives
+        # mid-install-output and looks like the script hung — the user
+        # has no signal that "you're now in a different tool". Match
+        # Claude Code's installer convention: bold green "==>" headline,
+        # bold action line, explicit "Press Enter / Ctrl+C" prompt.
+        # Honor AIRC_INSTALL_YES=1 for power users who curl|bash often.
+        printf '\n  \033[1;32m==>\033[0m GitHub authentication required for the gist substrate.\n'
+        printf '      About to launch: \033[1mgh auth login -h github.com -s gist\033[0m\n'
+        printf '      A browser will open; the device code shown in the terminal must be pasted there.\n'
+        if [ "${AIRC_INSTALL_YES:-0}" != "1" ]; then
+          printf '      Press Enter to continue, Ctrl+C to abort: '
+          read -r _ || true
+          printf '\n'
+        fi
         if gh auth login -h github.com -s gist; then
           ok "gh auth complete"
           # Re-run setup-git so the just-acquired token gets wired.
@@ -553,9 +579,16 @@ fi
 echo ""
 ok "Installed."
 echo ""
-echo "  Next:"
-echo "    airc join                      # auto-#general (joins existing or hosts)"
-echo "    airc msg @<peer> <message>     # DM (or omit @peer to broadcast)"
+echo "  Next — open your agent:"
+echo "    claude          # or codex, cursor, opencode, windsurf, openclaw, ..."
+echo ""
+echo "  Then, inside the agent:"
+echo "    /join                          # auto-scopes to your project's room"
+echo "    /msg @<peer> <message>         # DM (or omit @peer to broadcast)"
+echo ""
+echo "  Or run airc directly from this shell:"
+echo "    airc join"
+echo "    airc msg @<peer> <message>"
 echo ""
 echo "  Diagnose anytime:    airc doctor"
 echo "  Repair if needed:    airc doctor --fix"

--- a/install.sh
+++ b/install.sh
@@ -551,8 +551,11 @@ if [ -d "$CLONE_DIR/skills" ]; then
   # Clean up old symlinks from previous installs.
   # Includes the airc-classic skill names (connect/send/rename/disconnect) that
   # were renamed to IRC-canonical (join/msg/nick/quit) — leaving the old symlinks
-  # in place would shadow the new skills with stale content.
-  for old in "$SKILLS_TARGET"/relay-* "$SKILLS_TARGET"/monitor "$SKILLS_TARGET"/setup "$SKILLS_TARGET"/uninstall \
+  # in place would shadow the new skills with stale content. (`uninstall` was
+  # previously listed here when the skill didn't exist; now that we ship a real
+  # /uninstall skill, the per-skill symlink loop below recreates it cleanly and
+  # this list omits it.)
+  for old in "$SKILLS_TARGET"/relay-* "$SKILLS_TARGET"/monitor "$SKILLS_TARGET"/setup \
              "$SKILLS_TARGET"/connect "$SKILLS_TARGET"/send "$SKILLS_TARGET"/rename "$SKILLS_TARGET"/disconnect; do
     [ -L "$old" ] && rm "$old" 2>/dev/null
   done

--- a/install.sh
+++ b/install.sh
@@ -265,29 +265,15 @@ ensure_prereqs() {
   # cryptography module now; the system openssl version (LibreSSL or
   # otherwise) is irrelevant to airc.
 
-  # sshd: airc joiners ssh into the host's airc_home to tail messages.
-  # Every airc user who'll host a room (which is most users — first to
-  # discover becomes the host) needs sshd RUNNING. install.sh actually
-  # turns it on instead of just warning, since "warn + leave it to the
-  # user" was Joel's "this needs to be in the install dude" pushback
-  # 2026-04-27. ONE sudo / UAC prompt during install (same shape as
-  # install_with_pkgmgr already uses for apt/dnf/etc); after that
-  # airc just works for hosting.
-  #
-  # AIRC_SKIP_SSHD=1 short-circuits the whole block — for headless CI
-  # boxes that genuinely don't host, or environments that manage sshd
-  # via their own config-management (Ansible, Chef).
-  #
-  # Auto-detect: GitHub Actions sets CI=true; so does almost every CI
-  # system (Travis, CircleCI, GitLab, BuildKite, Jenkins). On macOS
-  # specifically, the osascript admin-prompt path hangs forever in CI
-  # because there's no Touch ID / password input — the runner job
-  # silently runs for the full 6-hour timeout. Skip when CI=true so
-  # the install completes cleanly and CI tests the rest of the path.
   # Post-3c: sshd setup + Tailscale install fully removed. Cross-network
   # messaging routes through gh-as-bearer (envelope-encrypted gist),
   # which works on every platform with `gh auth login` — no privileged
-  # daemon, no sign-in popup, no admin elevation.
+  # daemon, no sign-in popup, no admin elevation. The earlier sshd-on-
+  # by-default block (with sudo/UAC prompt + AIRC_SKIP_SSHD escape +
+  # CI auto-detect) was deleted as part of issue #341 follow-up #345
+  # (doctor's sshd probe also dropped); leaving this single tombstone
+  # comment so a reader who finds 'sshd' in old git history sees why
+  # it's not here anymore.
 
   # gh auth: required for the gist substrate. We CAN drive the login
   # interactively when stdin is a TTY (Joel 2026-04-29: 'thought that'd

--- a/install.sh
+++ b/install.sh
@@ -259,6 +259,45 @@ ensure_prereqs() {
     ok "All required prereqs present"
   fi
 
+  # Capability probe: openssl --version is not enough — macOS ships LibreSSL
+  # as /usr/bin/openssl, which passes --version but does NOT support
+  # `genpkey -algorithm Ed25519` (the airc identity key). The probe loop
+  # above can't catch this because LibreSSL is "openssl" by name. Run an
+  # actual Ed25519 key gen against a tempfile; if it fails on Mac, install
+  # brew openssl@3 (keg-only, doesn't shadow /usr/bin/openssl — airc's
+  # runtime resolver locates it via /opt/homebrew/opt/). Issue #341.
+  if command -v openssl >/dev/null 2>&1 \
+     && ! openssl genpkey -algorithm Ed25519 -out /dev/null >/dev/null 2>&1; then
+    case "$(uname -s 2>/dev/null)" in
+      Darwin)
+        # Already-present keg-only openssl@3 is enough — no install needed.
+        _have_brew_ossl=0
+        for c in /opt/homebrew/opt/openssl@3/bin/openssl /usr/local/opt/openssl@3/bin/openssl; do
+          if [ -x "$c" ] && "$c" genpkey -algorithm Ed25519 -out /dev/null >/dev/null 2>&1; then
+            ok "openssl Ed25519 capability via $c (system openssl is LibreSSL)"
+            _have_brew_ossl=1
+            break
+          fi
+        done
+        if [ "$_have_brew_ossl" = "0" ] && command -v brew >/dev/null 2>&1; then
+          info "System openssl is LibreSSL (no Ed25519). Installing openssl@3 via brew..."
+          if brew install openssl@3 >/dev/null 2>&1; then
+            ok "openssl@3 installed (airc resolves it at runtime; no PATH change needed)"
+          else
+            warn "brew install openssl@3 failed. Run manually:  brew install openssl@3"
+          fi
+        elif [ "$_have_brew_ossl" = "0" ]; then
+          warn "System openssl is LibreSSL (no Ed25519) and brew is unavailable."
+          warn "  Install Homebrew + openssl@3, or set AIRC_OPENSSL=/path/to/openssl manually."
+        fi
+        ;;
+      *)
+        warn "openssl on this machine doesn't support 'genpkey -algorithm Ed25519'."
+        warn "  airc identity creation will fail. Install openssl 1.1.1+ or set AIRC_OPENSSL."
+        ;;
+    esac
+  fi
+
   # sshd: airc joiners ssh into the host's airc_home to tail messages.
   # Every airc user who'll host a room (which is most users — first to
   # discover becomes the host) needs sshd RUNNING. install.sh actually

--- a/install.sh
+++ b/install.sh
@@ -48,8 +48,11 @@ _to_bash_path() {
 # install via the platform's package manager, then verify. Designed for
 # FIRST-TIME users with nothing pre-installed beyond a shell.
 #
-# Required: git, gh, openssl, ssh-keygen, python3
+# Required: git, gh, ssh-keygen, python3 (+ cryptography via venv pip)
 # Optional: tailscale (only needed for cross-LAN mesh; LAN works without)
+# Deliberately not required: openssl. Issue #341 — identity Ed25519 ops
+# moved to the venv cryptography module so we don't depend on system
+# openssl flavoring (LibreSSL vs OpenSSL etc).
 #
 # AIRC_SKIP_PREREQS=1 short-circuits the whole block (CI, dev installs,
 # users who manage their own packages).
@@ -95,11 +98,6 @@ pkgname_for() {
         pacman) echo "openssh" ;;
         apk)    echo "openssh-client" ;;
         winget) echo "" ;;  # OpenSSH ships with modern Windows; nothing to install
-      esac ;;
-    openssl)
-      case "$mgr" in
-        winget) echo "" ;;  # bundled with Git for Windows; if Git is installed, openssl is there
-        *)      echo "openssl" ;;
       esac ;;
     python3)
       case "$mgr" in
@@ -194,7 +192,7 @@ ensure_prereqs() {
       fi
     else
       warn "Unknown package manager (uname=$(uname -s)). Skipping prereq auto-install."
-      warn "Required prereqs: git, gh, openssl, python3"
+      warn "Required prereqs: git, gh, python3 (cryptography via pip)"
       return 0
     fi
   fi
@@ -204,11 +202,16 @@ ensure_prereqs() {
   # stdlib JSON (lib/airc_core/gistparse.py). Python was already a hard
   # dep since #152 Phase 0; jq was redundant. Drop the dep + the
   # winget step that would install it.
-  for cmd in git gh openssl ssh-keygen python3; do
+  # Issue #341 follow-up: openssl removed from the prereq list. airc
+  # no longer shells out to it for Ed25519 — identity gen + signing
+  # both route through the venv cryptography module (which is already
+  # a hard dep, pip-installed below). LibreSSL on macOS used to make
+  # this an ordeal; now it's a non-issue at the source.
+  for cmd in git gh ssh-keygen python3; do
     # Strict probe: presence on PATH AND a successful --version invocation.
     # Used selectively: python3 needs the strict variant because Windows
     # Store's python3.exe alias is on PATH but exits 49 with a Store-
-    # redirect (continuum-b69f, 2026-04-27). git/gh/openssl all
+    # redirect (continuum-b69f, 2026-04-27). git/gh all
     # support --version cleanly. ssh-keygen does NOT have a version
     # flag at all (different from `ssh -V`); calling `ssh-keygen
     # --version` exits non-zero on every install, so the strict probe
@@ -251,52 +254,16 @@ ensure_prereqs() {
       warn "These prereqs need manual install on $mgr: ${unmappable[*]}"
       case "$mgr" in
         winget)
-          warn "  ssh / ssh-keygen: Settings -> Apps -> Optional Features -> Add OpenSSH Client"
-          warn "  openssl: bundled with Git for Windows -- 'winget install Git.Git' provides it" ;;
+          warn "  ssh / ssh-keygen: Settings -> Apps -> Optional Features -> Add OpenSSH Client" ;;
       esac
     fi
   else
     ok "All required prereqs present"
   fi
-
-  # Capability probe: openssl --version is not enough — macOS ships LibreSSL
-  # as /usr/bin/openssl, which passes --version but does NOT support
-  # `genpkey -algorithm Ed25519` (the airc identity key). The probe loop
-  # above can't catch this because LibreSSL is "openssl" by name. Run an
-  # actual Ed25519 key gen against a tempfile; if it fails on Mac, install
-  # brew openssl@3 (keg-only, doesn't shadow /usr/bin/openssl — airc's
-  # runtime resolver locates it via /opt/homebrew/opt/). Issue #341.
-  if command -v openssl >/dev/null 2>&1 \
-     && ! openssl genpkey -algorithm Ed25519 -out /dev/null >/dev/null 2>&1; then
-    case "$(uname -s 2>/dev/null)" in
-      Darwin)
-        # Already-present keg-only openssl@3 is enough — no install needed.
-        _have_brew_ossl=0
-        for c in /opt/homebrew/opt/openssl@3/bin/openssl /usr/local/opt/openssl@3/bin/openssl; do
-          if [ -x "$c" ] && "$c" genpkey -algorithm Ed25519 -out /dev/null >/dev/null 2>&1; then
-            ok "openssl Ed25519 capability via $c (system openssl is LibreSSL)"
-            _have_brew_ossl=1
-            break
-          fi
-        done
-        if [ "$_have_brew_ossl" = "0" ] && command -v brew >/dev/null 2>&1; then
-          info "System openssl is LibreSSL (no Ed25519). Installing openssl@3 via brew..."
-          if brew install openssl@3 >/dev/null 2>&1; then
-            ok "openssl@3 installed (airc resolves it at runtime; no PATH change needed)"
-          else
-            warn "brew install openssl@3 failed. Run manually:  brew install openssl@3"
-          fi
-        elif [ "$_have_brew_ossl" = "0" ]; then
-          warn "System openssl is LibreSSL (no Ed25519) and brew is unavailable."
-          warn "  Install Homebrew + openssl@3, or set AIRC_OPENSSL=/path/to/openssl manually."
-        fi
-        ;;
-      *)
-        warn "openssl on this machine doesn't support 'genpkey -algorithm Ed25519'."
-        warn "  airc identity creation will fail. Install openssl 1.1.1+ or set AIRC_OPENSSL."
-        ;;
-    esac
-  fi
+  # Issue #341 follow-up: openssl Ed25519-capability probe + brew
+  # install dance removed. Identity gen + signing live in the venv
+  # cryptography module now; the system openssl version (LibreSSL or
+  # otherwise) is irrelevant to airc.
 
   # sshd: airc joiners ssh into the host's airc_home to tail messages.
   # Every airc user who'll host a room (which is most users — first to

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -92,28 +92,6 @@ ensure_channel_subscribed_with_gist() {
 }
 
 cmd_connect() {
-  # Pre-flight: gh auth check. The gh keyring can silently invalidate
-  # (token revoked / 2FA flow expired / brew upgrade replaced gh
-  # without re-auth) and EVERY downstream gh API call then fails
-  # silently — bearer.send returns auth_failure, bearer recv polls
-  # forever getting nothing, peers see "monitor running, no traffic"
-  # which is the exact freeze pattern Joel kept hitting. Catch this
-  # at connect time so the user gets a clear error instead of a
-  # mystery timeout.
-  if command -v gh >/dev/null 2>&1; then
-    if ! gh auth status >/dev/null 2>&1; then
-      echo "" >&2
-      echo "  ✗ gh CLI is installed but the GitHub token is invalid." >&2
-      echo "    Detail:" >&2
-      gh auth status 2>&1 | sed 's/^/      /' >&2
-      echo "" >&2
-      echo "    Fix:  gh auth login -h github.com" >&2
-      echo "" >&2
-      echo "    Without gh auth, airc can't talk to the gist substrate at all." >&2
-      die "gh auth invalid — run 'gh auth login -h github.com' first"
-    fi
-  fi
-
   # Flag parsing. Issue #37 — host display shapes:
   #   default (gh installed + authed): gist ID + humanhash mnemonic + long invite
   #   default (no gh OR gh not authed): long invite only (today's behavior)
@@ -257,6 +235,34 @@ cmd_connect() {
     esac
   done
   set -- "${positional[@]+"${positional[@]}"}"
+
+  # Pre-flight: gh auth check. The gh keyring can silently invalidate
+  # (token revoked / 2FA flow expired / brew upgrade replaced gh
+  # without re-auth) and EVERY downstream gh API call then fails
+  # silently — bearer.send returns auth_failure, bearer recv polls
+  # forever getting nothing, peers see "monitor running, no traffic"
+  # which is the exact freeze pattern Joel kept hitting. Catch this
+  # at connect time so the user gets a clear error instead of a
+  # mystery timeout.
+  #
+  # Gated on use_room=1: when the user opts into legacy 1:1 invite
+  # mode (--no-room), the substrate isn't used and gh is irrelevant.
+  # The CI clean-install smoke test specifically exercises that
+  # offline path with no gh auth — pre-#338 the unconditional check
+  # killed it before the host loop could start (PR #338 regression).
+  if [ "$use_room" = "1" ] && command -v gh >/dev/null 2>&1; then
+    if ! gh auth status >/dev/null 2>&1; then
+      echo "" >&2
+      echo "  ✗ gh CLI is installed but the GitHub token is invalid." >&2
+      echo "    Detail:" >&2
+      gh auth status 2>&1 | sed 's/^/      /' >&2
+      echo "" >&2
+      echo "    Fix:  gh auth login -h github.com" >&2
+      echo "" >&2
+      echo "    Without gh auth, airc can't talk to the gist substrate at all." >&2
+      die "gh auth invalid — run 'gh auth login -h github.com' first"
+    fi
+  fi
 
   # Issue #136: --general re-opt-in. Clear parted state on primary
   # scope and force the sidecar back on. Done after arg parsing so we
@@ -1318,10 +1324,13 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
         fi
 
         # Skip create-new entirely if we already adopted an existing
-        # canonical gist above (find-first convergence path).
+        # canonical gist above (find-first convergence path). Still
+        # need to set the variables downstream heartbeat setup uses
+        # — _now (timestamp) and _machine_id — since the create-new
+        # block populates them and we're skipping it.
         if [ -n "${_existing_room_gid:-}" ]; then
-          true  # No-op; downstream heartbeat + monitor setup uses
-                # _gist_id / _gist_url already set above.
+          local _now; _now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          local _machine_id; _machine_id=$(host_machine_id)
         else
         # Bootstrap basename + description match channel_gist.create_new's
         # canonical shape (airc-room-<channel>.json + "airc room: #X").

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -252,15 +252,33 @@ cmd_connect() {
   # killed it before the host loop could start (PR #338 regression).
   if [ "$use_room" = "1" ] && command -v gh >/dev/null 2>&1; then
     if ! gh auth status >/dev/null 2>&1; then
+      # `gh auth status` probes /user, which returns 403 during a GitHub
+      # secondary rate limit (abuse detection) and which gh then misreports
+      # as "token invalid". The /rate_limit endpoint is reachable during
+      # secondary limits — if it works, the token is fine and the user
+      # just needs to wait, not re-auth. Issue #341.
       echo "" >&2
-      echo "  ✗ gh CLI is installed but the GitHub token is invalid." >&2
-      echo "    Detail:" >&2
-      gh auth status 2>&1 | sed 's/^/      /' >&2
-      echo "" >&2
-      echo "    Fix:  gh auth login -h github.com" >&2
-      echo "" >&2
-      echo "    Without gh auth, airc can't talk to the gist substrate at all." >&2
-      die "gh auth invalid — run 'gh auth login -h github.com' first"
+      if gh api rate_limit >/dev/null 2>&1; then
+        echo "  ! GitHub secondary rate limit (abuse detection) triggered." >&2
+        echo "    Your token is fine — wait 5-15 minutes and retry 'airc join'." >&2
+        echo "" >&2
+        echo "    Why this is confusing: 'gh auth status' calls /user which gets 403'd" >&2
+        echo "    during secondary rate limits; gh then prints 'token invalid'. The" >&2
+        echo "    /rate_limit endpoint is reachable, which proves the token works." >&2
+        echo "" >&2
+        echo "    Caused by: too many gh API calls in a short window (polling loops," >&2
+        echo "    rapid-fire PR/issue/comment activity, etc.)." >&2
+        die "GitHub rate-limited — retry in 5-15 min (token is fine)"
+      else
+        echo "  ✗ gh CLI is installed but the GitHub token is invalid." >&2
+        echo "    Detail:" >&2
+        gh auth status 2>&1 | sed 's/^/      /' >&2
+        echo "" >&2
+        echo "    Fix:  gh auth login -h github.com" >&2
+        echo "" >&2
+        echo "    Without gh auth, airc can't talk to the gist substrate at all." >&2
+        die "gh auth invalid — run 'gh auth login -h github.com' first"
+      fi
     fi
   fi
 

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -53,7 +53,10 @@ cmd_doctor() {
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"     || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"    || issues=$((issues+1))
   _doctor_probe_cryptography                                            || issues=$((issues+1))
-  _doctor_probe_sshd                                                    || issues=$((issues+1))
+  # sshd probe removed post-3c: the gist IS the wire for ALL peers; airc no
+  # longer ssh's into the host's airc_home. ssh-keygen above stays (identity
+  # key generation), ssh client stays (occasional manual diagnostic + future
+  # wire-pluggable bearers). Issue #341 follow-up.
   _doctor_probe_tailscale "$mgr"  # optional, never increments issues
 
   echo ""
@@ -207,109 +210,6 @@ _doctor_probe_cryptography() {
   return 1
 }
 
-# Probe sshd (SSH server). airc joiners ssh into the host's airc_home
-# to `tail -F messages.jsonl`. So every airc user who'll host a room
-# (which is most users — first to discover a room becomes its host)
-# needs sshd running on their box. Pre-fix: airc doctor probed for the
-# ssh CLIENT but not the SERVER. Joel + continuum-b69f hit this on
-# 2026-04-27 mid-cross-machine bringup: TCP handshake worked, but
-# message stream silently failed because Windows ships OpenSSH client
-# but NOT the server enabled by default.
-#
-# Per-platform probes:
-#   macOS         — launchctl + systemsetup (Remote Login)
-#   linux / wsl   — systemctl is-active on ssh OR sshd unit names
-#                   (Debian/Ubuntu unit is 'ssh', RHEL/Fedora is 'sshd')
-#   windows-bash  — powershell.exe Get-Service sshd, distinguish
-#                   Running / Stopped / Missing-capability
-#
-# Returns 0 on ok, 1 on missing/broken, 0 on platforms we can't probe
-# (don't penalize if we can't tell).
-_doctor_probe_sshd() {
-  local plat; plat=$(detect_platform)
-  case "$plat" in
-    darwin)
-      # macOS Remote Login = launchd-managed sshd. Detect WITHOUT sudo:
-      #   - `launchctl list` (user scope) does NOT show system services
-      #     like com.openssh.sshd, so the user-scope probe always misses.
-      #   - `launchctl print system` DOES list system services and works
-      #     without sudo. Look for `com.openssh.sshd` (the service id).
-      #   - `systemsetup -getremotelogin` requires admin to read state
-      #     (returns "You need administrator access..." otherwise) — keep
-      #     it as the second-attempt fallback in case sudo is cached.
-      if launchctl print system 2>/dev/null | grep -qE 'com\.openssh\.sshd($|[[:space:]])'; then
-        printf "  [ok] sshd (Remote Login enabled)\n"
-        return 0
-      fi
-      if systemsetup -getremotelogin 2>/dev/null | grep -qi "Remote Login: On"; then
-        printf "  [ok] sshd (Remote Login enabled)\n"
-        return 0
-      fi
-      printf "  [MISSING] sshd -- needed when you HOST a room\n"
-      printf "         Fix: System Settings -> General -> Sharing -> Remote Login (toggle on)\n"
-      printf "         Or:  sudo systemsetup -setremotelogin on\n"
-      return 1
-      ;;
-    linux|wsl)
-      # Debian/Ubuntu uses 'ssh', RHEL/Fedora/Arch uses 'sshd'.
-      if systemctl is-active --quiet ssh 2>/dev/null || systemctl is-active --quiet sshd 2>/dev/null; then
-        printf "  [ok] sshd (systemd active)\n"
-        return 0
-      fi
-      printf "  [MISSING] sshd -- needed when you HOST a room\n"
-      printf "         Fix (Debian/Ubuntu): sudo apt-get install openssh-server && sudo systemctl enable --now ssh\n"
-      printf "         Fix (RHEL/Fedora):    sudo dnf install openssh-server && sudo systemctl enable --now sshd\n"
-      return 1
-      ;;
-    windows)
-      # powershell.exe is the canonical PS launcher in Git Bash. Some
-      # boxes also ship pwsh.exe (PS Core); prefer powershell.exe for
-      # broadest reach since OpenSSH service control works in both.
-      local _ps=""
-      if command -v powershell.exe >/dev/null 2>&1; then _ps="powershell.exe"
-      elif command -v pwsh.exe >/dev/null 2>&1; then _ps="pwsh.exe"
-      fi
-      if [ -z "$_ps" ]; then
-        printf "  [info] sshd probe skipped (powershell.exe not on PATH)\n"
-        return 0
-      fi
-      local _state
-      _state=$("$_ps" -NoProfile -Command "(Get-Service sshd -ErrorAction SilentlyContinue).Status" 2>/dev/null | tr -d '\r\n ')
-      case "$_state" in
-        Running)
-          printf "  [ok] sshd (Windows OpenSSH.Server running)\n"
-          return 0
-          ;;
-        Stopped|StopPending|StartPending|Paused)
-          printf "  [BROKEN] sshd -- installed but not running (state: %s)\n" "$_state"
-          printf "         Fix (admin PowerShell):  Start-Service sshd; Set-Service sshd -StartupType Automatic\n"
-          return 1
-          ;;
-        "")
-          printf "  [MISSING] sshd -- needed when you HOST a room\n"
-          printf "         Fix (admin PowerShell — five lines, run all together):\n"
-          printf "           Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0\n"
-          printf "           reg add HKLM\\\\SYSTEM\\\\CurrentControlSet\\\\Services\\\\hns\\\\State /v EnableExcludedPortRange /d 0 /f\n"
-          printf "           netsh int ipv4 add excludedportrange protocol=tcp startport=22 numberofports=1\n"
-          printf "           Start-Service sshd\n"
-          printf "           Set-Service -Name sshd -StartupType Automatic\n"
-          printf "         (The reg+netsh lines work around Windows HNS holding port 22 randomly per boot —\n"
-          printf "          continuum-b69f's diagnosis 2026-04-27. Without them, sshd bind returns EPERM.)\n"
-          return 1
-          ;;
-        *)
-          printf "  [info] sshd state unknown (Get-Service returned: '%s')\n" "$_state"
-          return 0
-          ;;
-      esac
-      ;;
-    *)
-      printf "  [info] sshd probe unsupported on platform '%s'\n" "$plat"
-      return 0
-      ;;
-  esac
-}
-
 _doctor_probe_tailscale() {
   local mgr="$1"
   # Use resolve_tailscale_bin so we find macOS GUI-installed Tailscale.app
@@ -363,7 +263,7 @@ _doctor_connect_preflight() {
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"    || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"   || issues=$((issues+1))
   _doctor_probe_cryptography                                           || issues=$((issues+1))
-  _doctor_probe_sshd                                                   || issues=$((issues+1))
+  # sshd probe removed post-3c — see cmd_doctor() in this file for rationale.
 
   # ── gh chain: installed → authed → gist scope → gists API reachable.
   # Single chain (early-return on first failure) so a missing gh isn't

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -373,16 +373,32 @@ _doctor_connect_preflight() {
   if ! _doctor_probe "gh" "$mgr" "Gist substrate (room discovery)"; then
     issues=$((issues+1))
   elif ! gh auth status >/dev/null 2>&1; then
-    printf "  [BLOCKED] gh authenticated\n"
-    printf "         Fix: gh auth login -s gist\n"
+    # Distinguish a real auth failure from a GitHub secondary rate limit
+    # (abuse detection). The /rate_limit endpoint is reachable during
+    # secondary limits, so if it works, the token is fine — the user just
+    # needs to wait. `gh auth status` probes /user, which gets 403'd, and
+    # gh then misreports the symptom as 'token invalid'. Issue #341.
+    if gh api rate_limit >/dev/null 2>&1; then
+      printf "  [BLOCKED] gh secondary rate limit (abuse detection) — token is fine\n"
+      printf "         Fix: wait 5-15 min then re-run; cause is too many gh API calls in a short window\n"
+    else
+      printf "  [BLOCKED] gh authenticated\n"
+      printf "         Fix: gh auth login -s gist\n"
+    fi
     issues=$((issues+1))
   elif ! gh auth status 2>&1 | grep -qiE '(scopes|token scopes):.*\bgist\b'; then
     printf "  [BLOCKED] gh authed but missing 'gist' scope (room substrate needs it)\n"
     printf "         Fix: gh auth refresh -s gist\n"
     issues=$((issues+1))
   elif ! gh api 'gists?per_page=1' >/dev/null 2>&1; then
-    printf "  [BLOCKED] gist API not reachable -- network outage or rate-limit\n"
-    printf "         Fix: check internet; if persistent, run 'gh auth refresh'\n"
+    # Same misdiagnosis risk here — distinguish rate-limit vs other.
+    if gh api rate_limit >/dev/null 2>&1; then
+      printf "  [BLOCKED] gh secondary rate limit (abuse detection) — token + scope are fine\n"
+      printf "         Fix: wait 5-15 min then re-run\n"
+    else
+      printf "  [BLOCKED] gist API not reachable -- network outage or token revoked\n"
+      printf "         Fix: check internet; if persistent, run 'gh auth refresh'\n"
+    fi
     issues=$((issues+1))
   else
     printf "  [ok] gh authed with gist scope, gists API reachable\n"

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -49,10 +49,10 @@ cmd_doctor() {
   _doctor_probe "git"          "$mgr" "VCS for clone/update" || issues=$((issues+1))
   _doctor_probe "gh"           "$mgr" "Gist substrate (room discovery)" || issues=$((issues+1))
   _doctor_probe_gh_auth                                             || issues=$((issues+1))
-  _doctor_probe "openssl"      "$mgr" "Ed25519 sign keys + signing"     || issues=$((issues+1))
   _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"     || issues=$((issues+1))
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"     || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"    || issues=$((issues+1))
+  _doctor_probe_cryptography                                            || issues=$((issues+1))
   _doctor_probe_sshd                                                    || issues=$((issues+1))
   _doctor_probe_tailscale "$mgr"  # optional, never increments issues
 
@@ -184,6 +184,26 @@ _doctor_probe_gh_auth() {
   fi
   printf "  [MISSING] gh authenticated (gist scope)\n"
   printf "         Fix: gh auth login -s gist\n"
+  return 1
+}
+
+# Probe the venv cryptography package — issue #341 follow-up. airc's
+# Ed25519 identity gen + signing now route through python-cryptography;
+# without it init_identity / sign_message hard-fail. install.sh's venv
+# step pip-installs it, so the failure surface here is "venv setup
+# didn't complete cleanly" or "the system python the resolver picked
+# differs from the venv one". Either way: surface clearly so doctor
+# tells the user to re-run install.sh.
+_doctor_probe_cryptography() {
+  if ! command -v "${AIRC_PYTHON:-python3}" >/dev/null 2>&1; then
+    return 0  # already reported missing by the python3 probe
+  fi
+  if "${AIRC_PYTHON:-python3}" -c "import cryptography.hazmat.primitives.asymmetric.ed25519" >/dev/null 2>&1; then
+    printf "  [ok] cryptography (Ed25519 identity gen + signing)\n"
+    return 0
+  fi
+  printf "  [MISSING] cryptography (Python package, used for Ed25519 identity)\n"
+  printf "         Fix: re-run install.sh (sets up the venv with cryptography)\n"
   return 1
 }
 
@@ -339,10 +359,10 @@ _doctor_connect_preflight() {
 
   # ── Required prereqs (same as default doctor) ──
   _doctor_probe "git"          "$mgr" "VCS for clone/update"           || issues=$((issues+1))
-  _doctor_probe "openssl"      "$mgr" "Ed25519 sign keys + signing"    || issues=$((issues+1))
   _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"    || issues=$((issues+1))
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"    || issues=$((issues+1))
   _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"   || issues=$((issues+1))
+  _doctor_probe_cryptography                                           || issues=$((issues+1))
   _doctor_probe_sshd                                                   || issues=$((issues+1))
 
   # ── gh chain: installed → authed → gist scope → gists API reachable.

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -151,6 +151,10 @@ else:
   if command -v gh >/dev/null 2>&1; then
     if gh auth status >/dev/null 2>&1; then
       echo "  gh auth:     ok"
+    elif gh api rate_limit >/dev/null 2>&1; then
+      # Token works (rate_limit reachable); /user got 403'd by secondary
+      # rate limit and gh misreports it as 'token invalid'. Issue #341.
+      echo "  gh auth:     RATE-LIMITED (secondary; token is fine — wait 5-15 min)"
     else
       echo "  gh auth:     ✗ INVALID — run 'gh auth login -h github.com' to fix"
     fi

--- a/lib/airc_bash/cmd_teardown.sh
+++ b/lib/airc_bash/cmd_teardown.sh
@@ -230,7 +230,16 @@ cmd_teardown() {
   # Skipped under AIRC_TEARDOWN_PART_ONLY (cmd_part shouldn't sweep).
   if [ "${AIRC_TEARDOWN_PART_ONLY:-0}" != "1" ]; then
     local _scope_path_pids
-    _scope_path_pids=$(pgrep -f "$AIRC_WRITE_DIR" 2>/dev/null | sort -un)
+    # pgrep returns 1 when nothing matches. With pipefail + set -e
+    # (airc top-level uses set -euo pipefail), the pipe surfaces that
+    # 1, which dies the whole script HALFWAY through teardown — the
+    # caller never sees "Teardown complete" and the smoke check in CI
+    # was failing as exit 1 with no error message. Caught fresh-runner
+    # only because dev machines tend to have prior-test zombies that
+    # keep pgrep happy. `|| true` swallows the empty-match case;
+    # genuine errors (lsof permissions etc) still produce empty output
+    # which the if-block handles cleanly.
+    _scope_path_pids=$(pgrep -f "$AIRC_WRITE_DIR" 2>/dev/null | sort -un || true)
     if [ -n "$_scope_path_pids" ]; then
       # Exclude our own pid + parent (this very teardown subshell) so
       # we don't suicide before completing the cleanup.

--- a/lib/airc_core/crypto.py
+++ b/lib/airc_core/crypto.py
@@ -55,6 +55,10 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import (
     X25519PrivateKey,
     X25519PublicKey,
 )
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives import hashes
@@ -128,6 +132,80 @@ def load_pub(pub_path: str) -> bytes:
             f"X25519 public key at {pub_path} is {len(raw)} bytes; expected 32"
         )
     return raw
+
+
+# ──────────────────────────────────────────────────────────────────
+# Ed25519 keypairs — generation, save, load, sign
+#
+# Different on-disk format from X25519 above: Ed25519 keys live as PEM
+# files (PKCS#8 for private, SubjectPublicKeyInfo for public) at fixed
+# names `private.pem` / `public.pem` for compatibility with the prior
+# shell-openssl-generated identity layout. Existing scopes that paired
+# under the openssl path will load cleanly here — `cryptography`'s
+# load_pem_private_key parses the same PKCS#8 wrapping that
+# `openssl genpkey -algorithm Ed25519` writes. Verified: round-trip
+# byte-equal between the two for the same seed material.
+#
+# Why PEM (not raw like X25519): X25519 keys are this module's truth,
+# only ever read by Python. Ed25519 keys pre-existed in shell-openssl
+# format and we maintain the same disk shape so nobody's identity
+# silently rotates on upgrade.
+# ──────────────────────────────────────────────────────────────────
+
+def generate_ed25519_keypair_pem() -> tuple[bytes, bytes]:
+    """Generate a fresh Ed25519 keypair, return (priv_pem, pub_pem) bytes.
+
+    Output format matches `openssl genpkey -algorithm Ed25519` (PKCS#8 PEM)
+    and `openssl pkey -pubout` (SPKI PEM) byte-for-byte modulo the random
+    seed. Existing peers that signed under shell-openssl Ed25519 verify
+    correctly against pubkeys generated here and vice versa — both are
+    the same NIST/IETF-standard primitive.
+    """
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return (priv_pem, pub_pem)
+
+
+def load_ed25519_priv_pem(priv_path: str) -> Ed25519PrivateKey:
+    """Read an Ed25519 PKCS#8 PEM private key from disk. Raises
+    FileNotFoundError or ValueError on malformed input. Used by
+    sign_ed25519_pem below; exposed so callers can do their own
+    framing if they prefer."""
+    with open(priv_path, "rb") as f:
+        pem = f.read()
+    key = serialization.load_pem_private_key(pem, password=None)
+    if not isinstance(key, Ed25519PrivateKey):
+        raise ValueError(
+            f"key at {priv_path} is not Ed25519 ({type(key).__name__})"
+        )
+    return key
+
+
+def sign_ed25519_pem(priv_path: str, data: bytes) -> bytes:
+    """Sign `data` with the Ed25519 private key at `priv_path`. Returns
+    the raw 64-byte signature — same as `openssl pkeyutl -sign` output
+    on the same key+message. Caller base64-encodes if needed; we keep
+    bytes here so the layer above decides on encoding.
+    """
+    return load_ed25519_priv_pem(priv_path).sign(data)
+
+
+def save_ed25519_keypair_pem(
+    priv_pem: bytes, pub_pem: bytes, priv_path: str, pub_path: str
+) -> None:
+    """Write Ed25519 PEMs to disk with appropriate perms (0600 / 0644).
+    Atomic via temp + rename so SIGKILL mid-write can't leave partial
+    state. Mirror of save_keypair() above for X25519."""
+    _atomic_write_bytes(priv_path, priv_pem, mode=0o600)
+    _atomic_write_bytes(pub_path, pub_pem, mode=0o644)
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/lib/airc_core/identity.py
+++ b/lib/airc_core/identity.py
@@ -30,6 +30,15 @@ from typing import Optional
 X25519_PRIV_FILENAME = "x25519_priv"
 X25519_PUB_FILENAME = "x25519_pub"
 
+# Ed25519 envelope-signing keypair lives as PEM files at fixed names —
+# matching the on-disk shape that prior shell-openssl init wrote, so a
+# scope upgraded across the cryptography-migration boundary doesn't see
+# its identity rotate. Different file names from X25519 (which uses raw
+# bytes) because the openssl-created private.pem / public.pem pre-date
+# this module and we keep them.
+ED25519_PRIV_FILENAME = "private.pem"
+ED25519_PUB_FILENAME = "public.pem"
+
 
 def x25519_paths(identity_dir: str) -> tuple[str, str]:
     """Return (priv_path, pub_path) for an identity directory."""
@@ -69,6 +78,60 @@ def bootstrap(identity_dir: str) -> tuple[bytes, bytes]:
     priv, pub = crypto.generate_x25519_keypair()
     crypto.save_keypair(priv, pub, priv_path, pub_path)
     return (priv, pub)
+
+
+# ── Ed25519 envelope-signing keypair (issue #341 migration) ────────
+#
+# Pre-#341 init_identity() shelled out to `openssl genpkey -algorithm
+# Ed25519`. macOS LibreSSL doesn't implement Ed25519, which silently
+# broke fresh-Mac installs (the `2>/dev/null` ate the error). The
+# cryptography venv module already supports Ed25519 natively and is
+# already an install.sh prereq for envelope encryption — so the shell
+# openssl is a redundant footgun. These functions are the migration
+# target.
+
+def ed25519_paths(identity_dir: str) -> tuple[str, str]:
+    """Return (priv_path, pub_path) for an identity directory."""
+    return (
+        os.path.join(identity_dir, ED25519_PRIV_FILENAME),
+        os.path.join(identity_dir, ED25519_PUB_FILENAME),
+    )
+
+
+def has_ed25519_keypair(identity_dir: str) -> bool:
+    priv_path, pub_path = ed25519_paths(identity_dir)
+    return os.path.isfile(priv_path) and os.path.isfile(pub_path)
+
+
+def bootstrap_ed25519(identity_dir: str) -> None:
+    """Idempotent: generate the Ed25519 envelope-signing keypair if
+    missing. Writes private.pem (PKCS#8 PEM, 0600) + public.pem (SPKI
+    PEM, 0644) — same on-disk format the prior `openssl genpkey` path
+    produced, so an upgraded scope's identity is unchanged.
+
+    Raises ImportError if cryptography is unavailable. Callers higher
+    up (`airc init_identity` bash) treat that as a hard fatal: the
+    envelope signing key is required, not optional.
+    """
+    from . import crypto
+
+    priv_path, pub_path = ed25519_paths(identity_dir)
+    if has_ed25519_keypair(identity_dir):
+        return
+    os.makedirs(identity_dir, exist_ok=True)
+    priv_pem, pub_pem = crypto.generate_ed25519_keypair_pem()
+    crypto.save_ed25519_keypair_pem(priv_pem, pub_pem, priv_path, pub_path)
+
+
+def sign_ed25519(identity_dir: str, data: bytes) -> bytes:
+    """Sign `data` with the scope's Ed25519 private key. Raw 64-byte
+    signature output — same as `openssl pkeyutl -sign` produces. Caller
+    base64s for invite-string / envelope embedding.
+    """
+    from . import crypto
+
+    priv_path, _ = ed25519_paths(identity_dir)
+    return crypto.sign_ed25519_pem(priv_path, data)
 
 
 def cryptography_available() -> bool:
@@ -221,6 +284,20 @@ def _cli() -> int:
     )
     pp.add_argument("--peers-dir", required=True)
     pp.add_argument("--peer-name", required=True)
+    # Ed25519 envelope-signing key — replaces the prior shell openssl
+    # path. bootstrap_ed25519 is invoked from airc's init_identity;
+    # sign_ed25519 from sign_message. See module docstring (Ed25519
+    # block above) for migration context.
+    be = sub.add_parser(
+        "bootstrap-ed25519",
+        help="Generate Ed25519 envelope-signing keypair if missing",
+    )
+    be.add_argument("--dir", required=True, help="Identity directory path")
+    se = sub.add_parser(
+        "sign-ed25519",
+        help="Sign stdin bytes; print base64 signature on stdout",
+    )
+    se.add_argument("--dir", required=True, help="Identity directory path")
     args = parser.parse_args()
 
     if args.cmd == "bootstrap":
@@ -261,6 +338,48 @@ def _cli() -> int:
             return 0
         from . import crypto
         print(crypto.b64encode(pub))
+        return 0
+
+    if args.cmd == "bootstrap-ed25519":
+        # Hard-fatal if cryptography missing — Ed25519 signing is required
+        # for the envelope path, not optional. install.sh's prereq check
+        # ensures the venv has cryptography; if we got here without it,
+        # the install is broken.
+        if not cryptography_available():
+            print(
+                "cryptography package not available; airc envelope signing "
+                "requires it. Re-run install.sh to set up the venv.",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            bootstrap_ed25519(args.dir)
+        except OSError as e:
+            print(f"ed25519 bootstrap failed: {e}", file=sys.stderr)
+            return 1
+        return 0
+
+    if args.cmd == "sign-ed25519":
+        # Reads message bytes from stdin (binary-safe; bash pipes message
+        # data via `printf '%s' "$msg" | python -m airc_core.identity
+        # sign-ed25519 ...`). Prints b64 signature on stdout, matching
+        # the prior `openssl pkeyutl -sign | base64` output shape so
+        # callers don't need to change.
+        if not cryptography_available():
+            print("cryptography missing", file=sys.stderr)
+            return 1
+        try:
+            data = sys.stdin.buffer.read()
+            sig = sign_ed25519(args.dir, data)
+        except (OSError, ValueError) as e:
+            print(f"ed25519 sign failed: {e}", file=sys.stderr)
+            return 1
+        # Standard base64 (with padding, newline-terminated) — matches
+        # `openssl pkeyutl -sign | base64` byte-for-byte. Don't use the
+        # urlsafe variant `crypto.b64encode` here; bash callers expect
+        # the openssl-compatible format.
+        import base64
+        sys.stdout.write(base64.b64encode(sig).decode("ascii") + "\n")
         return 0
 
     return 1

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -43,7 +43,7 @@ If `gh` is not on PATH or not authed: install + `gh auth login`. There's no grac
 
 ## 2. Run join
 
-AIRC auto-detects the scope — if you're inside a git repo, identity lives at `<repo-root>/.airc/`; otherwise `~/.airc/`. No env vars needed.
+AIRC auto-detects the scope — if you're inside a git repo, identity lives at `<repo-root>/.airc/`; otherwise at `$PWD/.airc/` (per-cwd by design — every tab in a different dir is a distinct peer, never colliding). Set `AIRC_HOME=/path` to force a specific scope dir.
 
 **Default — auto-scoped project room + #general sidecar:**
 ```

--- a/skills/uninstall/SKILL.md
+++ b/skills/uninstall/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: airc:uninstall
+description: Fully remove airc from this machine — stops processes, removes the daemon, deletes the clone, drops binary + skill symlinks. Confirm with the user before running; this is destructive.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: "[--yes] [--purge]"
+---
+
+# airc uninstall
+
+**Destructive — confirm with the user before running.** This removes airc itself; per-project `.airc/` state (identity keys, peer records, chat logs) is left alone unless the user explicitly asks for `--purge`.
+
+## When to use
+
+- The user says "uninstall airc" / "remove airc" / "I'm done with airc."
+- The user is reinstalling from scratch and wants a clean slate first.
+- A botched install left stale symlinks or a clone in a weird state, and `/repair` isn't enough.
+
+## What it does
+
+```bash
+airc uninstall
+```
+
+Walks the full removal in order:
+
+1. `airc teardown --all` — stops every running airc process across all scopes on this machine
+2. `airc daemon uninstall` — removes the launchd / systemd-user / Task Scheduler unit if present
+3. Removes binary forwarders: `~/.local/bin/{airc, relay, airc.cmd, airc.ps1}`
+4. Removes airc skill symlinks under `~/.claude/skills/`
+5. Removes the clone dir (`~/.airc-src` or `$AIRC_DIR`), including the `.venv` inside
+
+**Confirmation prompt:** asks the user to type `yes` to proceed. If you're invoking from an agent, pass `--yes` only after the user has explicitly confirmed.
+
+## Flags
+
+- `--yes` / `-y` — skip the confirmation prompt. **Only pass this after the user confirms in chat.** Required for non-interactive invocations.
+- `--purge` — also print the list of per-project `.airc/` state dirs the user would need to remove manually for a fully clean machine. Does NOT auto-delete them — those hold the user's identity keys, peer records, and chat history.
+
+## What it leaves alone
+
+- **Per-project `.airc/` state** — your identity keys, peer records, message logs in every dir you ran `airc join` from. Use `--purge` to get a list of them.
+- **`gh` auth, brew/apt-installed packages** (gh / python3 / openssl) — those aren't airc's to remove.
+- **Other agents' configs** (Codex, Cursor, opencode, Windsurf) — airc only owns its own integration files.
+
+## Read the result
+
+- `Uninstalled.` — full removal succeeded.
+- `Aborted.` — user declined the prompt; nothing changed.
+- `Non-interactive run: pass --yes to confirm uninstall.` — the script needed a TTY or `--yes`; you forgot the flag.
+
+## Reinstall
+
+After uninstall, the standard one-liner re-installs cleanly:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
+```
+
+Per-project `.airc/` dirs (if not purged) are picked up on the next `airc join` in that scope.

--- a/test/integration_smoke.sh
+++ b/test/integration_smoke.sh
@@ -381,9 +381,12 @@ scenario_orphan_loops_self_reap() {
   fi
   sleep 3
 
-  # Find the parent bash via airc.pid (the parent writes its $$ there).
+  # Find the parent bash via airc.pid. The pidfile has multiple
+  # entries post-#328 (parent on line 1, appended subshells on
+  # subsequent lines). Parent is always the FIRST field of the
+  # FIRST line.
   local parent_pid loop_pids
-  parent_pid=$(awk '{print $1}' "$A_HOME/state/airc.pid" 2>/dev/null)
+  parent_pid=$(awk 'NR==1 {print $1; exit}' "$A_HOME/state/airc.pid" 2>/dev/null)
   [ -n "$parent_pid" ] || { fail "no airc.pid for the test scope"; return; }
   # Filter to BASH subshell children only — those are the loops with
   # the parent-liveness check (#325). Python descendants (handshake,

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,40 +1,169 @@
 #!/usr/bin/env bash
 #
-# AIRC uninstaller
+# AIRC uninstaller — single source of truth for full removal.
 #
-# Removes symlinks from ~/.claude/skills/ and ~/.local/bin/airc.
-# Leaves the clone at ~/.airc-src — delete it manually to fully remove.
+# Direct entry:    bash ~/.airc-src/uninstall.sh
+# Curl-pipe:       curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/uninstall.sh | bash -s -- --yes
+# Via the verb:    airc uninstall            (preferred; just exec's this script)
+#
+# What it removes:
+#   - running airc processes (via airc teardown --all, if airc is on PATH)
+#   - daemon (launchd / systemd-user / Task Scheduler) via airc daemon uninstall
+#   - ~/.local/bin/{airc, relay, airc.cmd, airc.ps1}
+#   - skill symlinks under ~/.claude/skills/ pointing into the clone
+#   - the clone itself (~/.airc-src or $AIRC_DIR), including the .venv inside
+#
+# What it leaves:
+#   - per-project .airc/ state in every dir you ran `airc join` from
+#     (identity keys, peer records, message logs — your data, not ours)
+#   - gh auth, brew/apt-installed packages (gh / python3 / openssl)
+#   - other agents' configs (Codex / Cursor / opencode / etc.)
+#
+# Flags:
+#   --yes / -y     skip the confirmation prompt (required for curl|bash)
+#   --purge        also print the list of per-project .airc/ dirs to remove manually
+#   --help / -h    this message
+#
+# AIRC_DIR env var overrides the clone location (default $HOME/.airc-src).
 
 set -euo pipefail
 
 CLONE_DIR="${AIRC_DIR:-$HOME/.airc-src}"
-BIN_DIR="$HOME/.local/bin"
-SKILLS_TARGET="$HOME/.claude/skills"
+BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
+SKILLS_TARGET="${SKILLS_TARGET:-$HOME/.claude/skills}"
+
+ASSUME_YES=0
+PURGE=0
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes)   ASSUME_YES=1 ;;
+    --purge)    PURGE=1 ;;
+    -h|--help)
+      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *)
+      echo "ERROR: unknown flag: $arg" >&2
+      echo "Try: bash $0 --help" >&2
+      exit 2 ;;
+  esac
+done
 
 info()  { printf '  \033[1;34m->\033[0m %s\n' "$*"; }
 ok()    { printf '  \033[1;32m->\033[0m %s\n' "$*"; }
+warn()  { printf '  \033[1;33m!\033[0m %s\n' "$*" >&2; }
 
-# Remove skill symlinks (current names and old relay-prefixed names)
-if [ -d "$CLONE_DIR/skills" ]; then
-  for skill_dir in "$CLONE_DIR"/skills/*/; do
-    [ -d "$skill_dir" ] || continue
-    skill_name="$(basename "$skill_dir")"
-    target="$SKILLS_TARGET/$skill_name"
-    if [ -L "$target" ]; then
-      rm "$target"
-      ok "Removed skill: $skill_name"
-    fi
+# Move out of the clone before we start, so `rm -rf $CLONE_DIR` doesn't
+# leave us with a no-longer-existent cwd (which breaks every command after).
+cd "$HOME" 2>/dev/null || cd /
+
+cat <<EOF
+This will remove airc from this machine:
+  binary symlinks   $BIN_DIR/{airc,relay,airc.cmd,airc.ps1}
+  skill symlinks    $SKILLS_TARGET/<airc-skills>/
+  install dir       $CLONE_DIR (clone + .venv)
+  daemon            launchd / systemd-user / Task Scheduler unit (if installed)
+  running processes airc teardown --all (if airc is on PATH)
+
+It will NOT remove:
+  per-project .airc/ state in every dir you ran 'airc join' from
+  gh auth, brew/apt packages (gh / python3 / openssl)
+  other agents' configs
+
+EOF
+
+if [ "$ASSUME_YES" != "1" ]; then
+  if [ ! -t 0 ]; then
+    warn "Non-interactive run: pass --yes to confirm uninstall."
+    exit 1
+  fi
+  printf "Type 'yes' to proceed: "
+  read -r reply
+  if [ "$reply" != "yes" ]; then
+    info "Aborted."
+    exit 0
+  fi
+fi
+
+# 1. Stop running processes. airc teardown --all walks every airc.pid file
+# under $HOME and reaps the processes; idempotent if nothing is running.
+if command -v airc >/dev/null 2>&1; then
+  if airc teardown --all >/dev/null 2>&1; then
+    ok "Stopped running airc processes (airc teardown --all)"
+  fi
+  # 2. Uninstall daemon. No-op if not installed; we don't gate on a status
+  # check because `airc daemon uninstall` already handles the absent case.
+  if airc daemon uninstall >/dev/null 2>&1; then
+    ok "Removed daemon (launchd / systemd-user / Task Scheduler)"
+  fi
+fi
+
+# 3. Skill symlinks. Walk every entry in the skills dir and drop any
+# symlink that resolves into the clone — covers both current names and
+# any stale ones from prior installs (relay-*, etc.).
+removed_skills=0
+if [ -d "$SKILLS_TARGET" ]; then
+  for entry in "$SKILLS_TARGET"/*; do
+    [ -L "$entry" ] || continue
+    target="$(readlink "$entry" 2>/dev/null || true)"
+    case "$target" in
+      "$CLONE_DIR"/*|"$CLONE_DIR")
+        rm -f "$entry"
+        removed_skills=$((removed_skills + 1)) ;;
+    esac
   done
 fi
-for old in "$SKILLS_TARGET"/relay-*; do
-  [ -L "$old" ] && rm "$old" && ok "Removed old skill: $(basename "$old")"
-done
+[ "$removed_skills" -gt 0 ] && ok "Removed $removed_skills skill symlink(s) from $SKILLS_TARGET"
 
-# Remove airc binary symlink
-if [ -L "$BIN_DIR/airc" ]; then
-  rm "$BIN_DIR/airc"
-  ok "Removed airc from PATH"
+# 4. Binary forwarders on PATH.
+removed_bins=0
+for f in airc relay airc.cmd airc.ps1; do
+  if [ -L "$BIN_DIR/$f" ] || [ -f "$BIN_DIR/$f" ]; then
+    # Symlinks: drop unconditionally (we own them).
+    # Real files (airc.cmd / airc.ps1 on Windows): drop only if their
+    # contents reference the clone, so we don't blow away an unrelated
+    # binary a user happens to have at the same name.
+    if [ -L "$BIN_DIR/$f" ]; then
+      rm -f "$BIN_DIR/$f"
+      removed_bins=$((removed_bins + 1))
+    elif grep -q "$CLONE_DIR" "$BIN_DIR/$f" 2>/dev/null; then
+      rm -f "$BIN_DIR/$f"
+      removed_bins=$((removed_bins + 1))
+    fi
+  fi
+done
+[ "$removed_bins" -gt 0 ] && ok "Removed $removed_bins binary forwarder(s) from $BIN_DIR"
+
+# 5. Clone dir + venv. Last, since the steps above call into airc + read
+# from the clone for the skill walk. Once this runs, `airc` is gone.
+if [ -d "$CLONE_DIR" ]; then
+  rm -rf "$CLONE_DIR"
+  ok "Removed install dir: $CLONE_DIR"
 fi
 
 echo ""
-ok "Uninstalled. Clone left at $CLONE_DIR (delete manually if desired)."
+ok "Uninstalled."
+echo ""
+
+if [ "$PURGE" = "1" ]; then
+  echo "  --purge: per-project state to remove manually if you want a fully clean machine:"
+  echo ""
+  # Find .airc dirs under common project roots without scanning the whole
+  # filesystem. Stop at depth 6 to avoid runaway descent into node_modules
+  # / vendor trees.
+  found_any=0
+  for root in "$HOME/Development" "$HOME/Projects" "$HOME/work" "$HOME/src" "$HOME"; do
+    [ -d "$root" ] || continue
+    while IFS= read -r d; do
+      echo "    rm -rf $d"
+      found_any=1
+    done < <(find "$root" -maxdepth 6 -type d -name ".airc" 2>/dev/null)
+  done
+  if [ "$found_any" = "0" ]; then
+    echo "    (none found under \$HOME/{Development,Projects,work,src})"
+  fi
+  echo ""
+  echo "  These hold your identity keys, peer records, and chat logs. Delete only if"
+  echo "  you actually want them gone — they don't take much space and are useful for"
+  echo "  recovery if you reinstall."
+  echo ""
+fi


### PR DESCRIPTION
## Summary

Triggered by Carl's fresh-Mac QA pass on #341 — `airc join` was silently exit-1 on a clean Mac because LibreSSL doesn't implement Ed25519 and the openssl call had `2>/dev/null`. Pulling that thread surfaced 8 real bugs across the install path, the CI rig, and the post-3c cleanup tail.

## Bundled fixes (8 PRs, oldest → newest)

- **#338** — `cmd_connect` find-first adopt branch crashed on `_now: unbound variable`; smoke test pidfile parsing broke after #328's multi-line format; `install.sh` self-update was overwriting PR code in CI; pre-flight gh-auth check fired even in `--no-room` legacy mode; `monitor()` recorded `flush_pending_loop`'s short-lived PID leaving a stale dead PID in `airc.pid`; `cmd_teardown` died mid-cleanup on fresh runners because `pgrep -f` returning 1 + pipefail tripped `set -e`.
- **#342** — `openssl genpkey` calls had `2>/dev/null`, hiding LibreSSL's "Algorithm Ed25519 not found" error. Made the failure loud + auto-installed `brew openssl@3` as the immediate unblocker.
- **#343** — Architectural fix: identity gen + signing migrated from shell openssl to the venv `cryptography` module (already a dep for envelope encryption). Drops openssl as a hard prereq entirely. Backward-compat verified — existing scopes' `private.pem` / `public.pem` load unchanged; cross-signing produces byte-identical output.
- **#339** — Drop redundant `gh auth login` from README; install.sh now drives the auth interactively (with green Enter pause); README walks user to `/join` via Claude.
- **#340** — Full `airc uninstall` verb + `/uninstall` skill replacing the prior 40-line stub.
- **#344** — Distinguish gh secondary rate limit from real auth failure (was silently classified as "your token is bad" before); `/join` skill scope-doc corrected (`\$PWD/.airc/` not `~/.airc/`).
- **#345** — Drop `_doctor_probe_sshd` — post-3c the gist IS the wire, ssh isn't on the message path anymore.
- **#346** — Tombstone for #345's residual install.sh sshd comment block.

## Themes

1. **Never swallow errors.** #342, #343, #344 — three of the eight PRs were unblocked by removing a `2>/dev/null` or distinguishing a "shouldn't happen" error from a routine one. Joel's hard rule, justified again here.
2. **Native-truth, thin-SDK-per-language.** #343 moved Ed25519 from shell openssl to Python `cryptography`. Identity is a security primitive; truth lives in the venv module the rest of the codebase already trusts, not in whatever libcrypto flavor `/usr/bin/openssl` happens to be.
3. **CI must test the PR, not main.** #338 surfaced that `install.sh`'s "I'm on a non-channel branch, let me pull main" recovery path silently overwrote the staged tree on every CI run. Every PR for the past N weeks was effectively a no-op against the CI matrix. `AIRC_INSTALL_NO_PULL=1` escape hatch fixes it.
4. **Drop Phase 3c residue.** #345, #346 — sshd is gone from the wire path; doctor + install no longer pretend it isn't.

## End-to-end proof

This bundle was coordinated peer-to-peer over **airc on canary itself** — both Macs paired via the gist substrate in `#general`, ran `airc msg --channel general` to exchange status, merged each other's PRs, all on the code being shipped here. The substrate fixed itself enough during the session to be the comm channel for shipping the fix.

## Test plan

- [x] Carl: full fresh-Mac validation (LibreSSL only, no brew openssl) → `airc join` succeeds, doctor reads `[ok] cryptography` and all-green
- [x] Both Macs paired in `#general` via airc itself (this PR coordinated over the wire)
- [x] CI clean-install matrix passing on each merged PR
- [ ] CI clean-install matrix passing on this bundle
- [ ] Post-merge: `curl ... | bash` from a fresh shell on the test rig produces a working install end-to-end

## Known followups (post-bundle)

- **#347** — Mesh takeover blanks identity block in config.json (nick + pronouns + role + bio). Caught live during this session when a re-exec from stale `#cambriantech` to fresh `#general` reverted Carl's `carl-mac` nick to `development-cf82`. Keys survive; identity metadata doesn't. Separate bug, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)