### PR TITLE
fix(heartbeat): port bearer_gh.py edit-then-add fallback + classify gh stderr (#348)

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1588,18 +1588,46 @@ JSON
                   --max-lines "${AIRC_LOG_MAX_LINES:-5000}" \
                   --keep-lines "${AIRC_LOG_KEEP_LINES:-2500}" >/dev/null 2>&1 || true
                 # Capture stderr to a state file (per never-swallow-errors
-                # rule). Track consecutive failures: after N in a row,
-                # detect active-host-evicted (#224) and self-heal — kill
-                # the parent so the daemon (or user) respawns into a
-                # fresh discovery + rejoin path.
+                # rule). Try edit-replace first; if that fails with the
+                # multi-file-disambiguation error (basename not yet in
+                # gist after a take-over / fresh-host race — bearer_gh.py
+                # has the same defense for #285), retry as add. Track
+                # consecutive failures: after N in a row, detect
+                # active-host-evicted (#224) and self-heal.
+                _hb_tried_add=0
                 if gh gist edit "$_gist_id" "$_hb_tmp" >/dev/null 2>"$_hb_stderr"; then
                   _consec_fail=0
+                elif grep -qE 'unsure what file to edit|file does not exist|no such file' "$_hb_stderr" 2>/dev/null \
+                     && gh gist edit "$_gist_id" -a "$_hb_tmp" >/dev/null 2>"$_hb_stderr"; then
+                  # Add-as-new succeeded — gist now has the canonical
+                  # heartbeat file; subsequent edits will hit the replace
+                  # path. Treat as success.
+                  _consec_fail=0
+                  _hb_tried_add=1
                 else
                   _consec_fail=$((_consec_fail + 1))
                   if [ "$_consec_fail" -ge "$_max_consec_fail" ]; then
                     local _stderr_tail; _stderr_tail=$(tail -1 "$_hb_stderr" 2>/dev/null | tr -d '\n' | tr '"' "'")
-                    local _evict_marker; _evict_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[HOST EVICTED] heartbeat to gist %s failed %d consecutive times — self-healing. last stderr: %s"}' \
-                      "$_hb_now" "$_hb_room" "$_gist_id" "$_consec_fail" "${_stderr_tail:-<empty>}")
+                    # Classify the gh error into airc-vocabulary so the
+                    # event log doesn't leak gh CLI internals to the
+                    # user. Issue #348.
+                    local _classified
+                    case "$_stderr_tail" in
+                      *'rate limit'*|*'abuse detection'*|*'secondary rate'*|*'API rate limit exceeded'*)
+                        _classified="rate-limit (gh secondary; back off 5-15 min before retry)" ;;
+                      *'unsure what file to edit'*|*'file does not exist'*|*'no such file'*)
+                        _classified="multi-file gist disambiguation (#348 — airc bug, please report)" ;;
+                      *'401'*|*'Unauthorized'*|*'token'*|*'keyring'*|*'auth'*)
+                        _classified="gh auth failure (run 'gh auth login -h github.com')" ;;
+                      *'network'*|*'connection refused'*|*'timeout'*|*'DNS'*|*'temporary failure'*|*'unreachable'*)
+                        _classified="network error" ;;
+                      '')
+                        _classified="unknown (no stderr captured)" ;;
+                      *)
+                        _classified="$_stderr_tail" ;;
+                    esac
+                    local _evict_marker; _evict_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[HOST EVICTED] heartbeat to gist %s failed %d consecutive times — self-healing. cause: %s"}' \
+                      "$_hb_now" "$_hb_room" "$_gist_id" "$_consec_fail" "$_classified")
                     echo "$_evict_marker" >> "$_hb_messages" 2>/dev/null || true
                     # Drop the stale local-state files so the parent's
                     # next discovery re-elects via _mesh_find.


### PR DESCRIPTION
Fixes #348. bash heartbeat (cmd_connect.sh:1595) had two issues that bearer_gh.py already solved for the message-send path back in #285:

## 1. `gh gist edit GIST FILE` doesn't handle "file not yet in gist"
After a take-over / fresh-host race, the canonical `airc-room-<channel>.json` may not yet be in the gist. Plain `gh gist edit GIST FILE` then fails with `unsure what file to edit; either specify --filename or run interactively` (or per #285 silently no-ops). bearer_gh.py handles this by checking gist contents first and using `-a` (add) when the file isn't there. Ported the same defense to bash via a check-edit-then-fallback-to-add pattern.

## 2. Raw gh stderr leaked into the airc event log
On eviction, the `[HOST EVICTED]` marker appended the raw gh stderr verbatim. Carl saw gh's vocabulary (`unsure what file to edit`, `401 Unauthorized`, `API rate limit exceeded`) in their airc event stream — opaque, off-vocabulary, no clear next action. Now classified into airc-readable buckets per the #348 comment thread:

| gh stderr matches                              | airc event reads as                                  |
|------------------------------------------------|------------------------------------------------------|
| rate limit / abuse detection / secondary       | `rate-limit (gh secondary; back off 5-15 min before retry)` |
| unsure what file / file does not exist         | `multi-file gist disambiguation (#348 — airc bug, please report)` |
| 401 / Unauthorized / token / keyring / auth    | `gh auth failure (run 'gh auth login -h github.com')` |
| network / connection refused / timeout / DNS   | `network error`                                       |
| (empty)                                        | `unknown (no stderr captured)`                        |
| anything else                                  | raw stderr (fallback)                                 |

## What it doesn't change

- Eviction threshold (still 3 consecutive failures, configurable via `AIRC_HB_MAX_FAIL`)
- Self-heal mechanism (still SIGTERM parent → daemon respawns → fresh discovery)
- Local-state cleanup (`host_gist_id`, `room_gist_id` still removed before eviction)

## Test plan
- [x] Syntax check passes (`bash -n cmd_connect.sh`)
- [ ] Live take-over scenario: take over a stale host whose gist exists with `messages.jsonl` only (no `airc-room-<channel>.json` yet) → first heartbeat should hit the disambig stderr → fallback `-a` should succeed → no eviction
- [ ] Live eviction scenario: revoke gh token mid-host → 3 consecutive failures → eviction emits `[HOST EVICTED] ... cause: gh auth failure (run 'gh auth login -h github.com')` instead of raw `401 Unauthorized` text
- [ ] Doctor scenario `heartbeat_persists_through_multifile_gist` (suggested in #348) — separate follow-up PR; not in scope here

## Out of scope
The same classifier shape would help in `cmd_send.sh`'s `auth_failure` branch (still surfaces "your GitHub token is dead" without the rate-limit-vs-auth distinction). Separate follow-up — needs a look at the Python bearer's auth_failure determination first.

Ready for review when CI clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)