### PR TITLE
fix(join skill): auto-trigger gh auth login instead of dumping a manual command on the user

### DIFF
--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -39,7 +39,21 @@ If `airc` is not on PATH:
 curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 ```
 
-If `gh` is not on PATH or not authed: install + `gh auth login`. There's no graceful degradation here; the whole point of the substrate is that gh is the comm layer.
+If `gh` is not on PATH: install it (e.g. `brew install gh` on macOS, `apt install gh` on Debian/Ubuntu), then handle auth as below. There's no graceful degradation here; the whole point of the substrate is that gh is the comm layer.
+
+### gh auth — run it yourself, don't tell the user to
+
+If `gh auth status` fails (or `airc join` dies with `gh auth invalid` / `GitHub token is invalid`), **execute the login flow yourself** — same as `install.sh` does. Don't dump a manual command on the user. Run:
+
+```bash
+gh auth login -h github.com -s gist -p https -w
+```
+
+The `-h`/`-p`/`-w` flags skip every interactive prompt; `-w` triggers the browser device-code flow. gh prints the device code + URL to stdout and BLOCKS until the user completes the browser auth — your Bash tool blocks with it, the user opens the URL + types the code, gh returns 0, you proceed to `airc join`.
+
+Show the user the device code line from gh's output (`First copy your one-time code: XXXX-XXXX`) prominently so they don't miss it — Bash output buffering can hide it otherwise. Then keep going.
+
+**Pre-flight diagnose** — before falling through to "real auth failure", check `gh api rate_limit` (which is exempt from gh's secondary rate limit). If `rate_limit` works but `gh auth status` doesn't, the token is FINE — gh is misreporting a 403-from-secondary-rate-limit as "token invalid" (issue #341, fixed in cmd_connect.sh's preflight but worth handling at skill level too). Tell the user "GitHub rate-limited — wait 5-15 min" instead of triggering an unnecessary re-auth.
 
 ## 2. Run join
 


### PR DESCRIPTION
Carl on a fresh tab tried `/join`, hit `gh auth invalid`, and saw the agent dump:

> Run this in the prompt (the ! prefix runs it in this session so output lands here):
> 
>   ! gh auth login -h github.com -s gist

Joel had to close Claude and re-auth manually. **install.sh already does the auto-trigger** when stdin is TTY (via #339) — the skill just had stale text saying "install + `gh auth login`" without telling the agent to RUN it.

## Change
Updated `skills/join/SKILL.md` section 1:

- **Spell out the auto-trigger pattern explicitly**: agent runs `gh auth login -h github.com -s gist -p https -w` itself via Bash. The `-h`/`-p`/`-w` flags skip every interactive prompt; `-w` uses the browser device code; gh blocks until the user completes auth in the browser → Bash blocks with it → success returns → agent continues to `airc join`.
- **Note device-code-line surfacing** — Bash output buffering can hide the `First copy your one-time code: XXXX-XXXX` line if the agent isn't deliberately quoting it back to the user.
- **Add the rate-limit-vs-real-auth pre-flight** (mirrors the cmd_connect.sh fix from #344): probe `gh api rate_limit` first; if reachable, the token is fine and gh is misreporting a secondary-rate-limit 403 as 'token invalid'. Tell the user to wait, not re-auth.

## Why it's doc-only
Skills are markdown — the file IS the agent's runtime prompt. Updating it changes behavior on the next `/join` invocation across every Claude Code session that picks up the new skill (via `airc update` or fresh install). No code change needed.

## Caught from
Joel's two-tab cross-machine test on the QA rig — second Claude tab tried /join, told user to re-auth, user had to close Claude. The skill should mirror what install.sh already does.

## Test plan
- [ ] Fresh Carl tab where gh keyring token has been revoked → `/join` triggers `gh auth login` automatically; user clicks browser link; auth completes; airc join proceeds — no "close Claude and re-run" friction
- [ ] Same scenario but during a secondary-rate-limit cooldown → `/join` says "GitHub rate-limited, wait 5-15 min" instead of triggering an unneeded re-auth
- [ ] Agent shows the device-code line prominently (not buried in Bash output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)