### PR TITLE
fix(join skill): pre-flight diagnose runs SILENTLY, not as narrated debug session

### DIFF
--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -39,21 +39,23 @@ If `airc` is not on PATH:
 curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 ```
 
-If `gh` is not on PATH: install it (e.g. `brew install gh` on macOS, `apt install gh` on Debian/Ubuntu), then handle auth as below. There's no graceful degradation here; the whole point of the substrate is that gh is the comm layer.
+If `gh` is not on PATH: install it (e.g. `brew install gh` on macOS, `apt install gh` on Debian/Ubuntu). There's no graceful degradation here; the whole point of the substrate is that gh is the comm layer.
 
-### gh auth — run it yourself, don't tell the user to
+### gh auth — handle silently, only surface text when action is needed
 
-If `gh auth status` fails (or `airc join` dies with `gh auth invalid` / `GitHub token is invalid`), **execute the login flow yourself** — same as `install.sh` does. Don't dump a manual command on the user. Run:
+**Don't pre-flight gh auth.** Just run `airc join`. The user does not need to see `gh api rate_limit` probes or "token is actually fine" diagnostics — that chatter looks like a bug to a Carl who just typed `/join` and expects it to work. Pre-flight checks belong inside airc's own preflight (where they're invisible until they fire), not in your narration.
 
-```bash
-gh auth login -h github.com -s gist -p https -w
-```
+ONLY if `airc join` itself dies with a gh-auth message ("token invalid", "gh auth invalid", "rate-limited"), then react:
 
-The `-h`/`-p`/`-w` flags skip every interactive prompt; `-w` triggers the browser device-code flow. gh prints the device code + URL to stdout and BLOCKS until the user completes the browser auth — your Bash tool blocks with it, the user opens the URL + types the code, gh returns 0, you proceed to `airc join`.
+- **`airc join` says "GitHub rate-limited — retry in 5-15 min (token is fine)"**: airc already disambiguated for you (issue #344). Tell the user verbatim. Don't re-probe.
+- **`airc join` says "gh auth invalid — run 'gh auth login -h github.com' first"**: do it for them. Run silently:
+  ```bash
+  gh auth login -h github.com -s gist -p https -w
+  ```
+  The `-h`/`-p`/`-w` flags skip every interactive prompt; `-w` triggers the browser device-code flow. gh blocks until the user completes auth — your Bash tool blocks with it. **Do quote the device-code line back to the user prominently** (`First copy your one-time code: XXXX-XXXX`) — that's the one thing they need from gh's output. Once gh returns 0, retry `airc join` without further narration.
+- **gh isn't on PATH at all**: install + auth. One short line ("installing gh"), then proceed.
 
-Show the user the device code line from gh's output (`First copy your one-time code: XXXX-XXXX`) prominently so they don't miss it — Bash output buffering can hide it otherwise. Then keep going.
-
-**Pre-flight diagnose** — before falling through to "real auth failure", check `gh api rate_limit` (which is exempt from gh's secondary rate limit). If `rate_limit` works but `gh auth status` doesn't, the token is FINE — gh is misreporting a 403-from-secondary-rate-limit as "token invalid" (issue #341, fixed in cmd_connect.sh's preflight but worth handling at skill level too). Tell the user "GitHub rate-limited — wait 5-15 min" instead of triggering an unnecessary re-auth.
+The principle: a Carl running `/join` should see `airc join` events and outcomes, not your auth-handling internals. Internal disambiguation = silent. User-actionable result = one short sentence.
 
 ## 2. Run join
 


### PR DESCRIPTION
Caught minutes after #352 landed. The agent dutifully followed #352's "Pre-flight diagnose" instruction, narrated `Bash(gh api rate_limit)` + `Token is actually fine — gh api rate_limit returns 4860/5000 remaining. gh auth status is misreporting (the issue #341 case). Proceeding with join.` to the user, and produced exactly the "looks like a bug" output a Carl typing `/join` shouldn't see.

## What changed in the skill text

**Before** (added by #352): the agent was told to pre-flight `gh api rate_limit` to disambiguate before falling through to "real auth failure" — and to narrate that diagnose. Result: Carl sees what looks like the agent debugging itself.

**After** (this PR): don't pre-flight at all. Just run `airc join`. Only react to `airc join`'s OWN auth-message output, and even then react minimally:

| airc join says…                                              | agent does                                                              |
|--------------------------------------------------------------|-------------------------------------------------------------------------|
| `GitHub rate-limited — retry in 5-15 min (token is fine)`    | tells user verbatim, does nothing else (cmd_connect.sh #344 already disambiguated) |
| `gh auth invalid — run 'gh auth login -h github.com' first`  | runs `gh auth login -h github.com -s gist -p https -w` silently, surfaces only the device-code line, retries |
| `gh CLI not installed`                                        | installs + auths, one short line                                         |

The principle is now stated explicitly in the skill: **Carl running `/join` should see airc events + outcomes, not auth-handling internals.** Internal disambiguation = silent. User-actionable result = one short sentence.

## Why we don't need the rate-limit pre-flight at the skill level

cmd_connect.sh's preflight (added in #344) already does the `gh api rate_limit` probe BEFORE deciding to die. It dies with the right message — either "rate-limited; wait" or "token invalid; re-auth". The skill should trust that and react to the message, not re-do the probe.

## Caught from
Joel's two-tab cross-machine test on the QA rig — second Claude tab pulled the new skill (#352), ran /join, and surfaced the misreport-debug to the user. Joel: "to a user it looks like a bug."

## Test plan
- [ ] Fresh Carl tab where gh is healthy → `/join` proceeds with no `gh api rate_limit` chatter; user sees airc join events directly
- [ ] Fresh Carl tab where token is genuinely revoked → airc join dies with "gh auth invalid" → agent silently runs the login flow, surfaces ONLY the device-code line, retries on success
- [ ] Fresh Carl tab during a secondary rate limit → airc join dies with "GitHub rate-limited" → agent tells user verbatim, does not re-probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)