### PR TITLE
fix(update skill): seamlessly bounce monitor onto new code — no tab close required (#354)

### DIFF
--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: airc:update
-description: Pull the latest airc code into the install dir. Leaves the running monitor untouched; report the new SHA and tell the user to teardown+connect to pick it up.
+description: Pull the latest airc code AND seamlessly bounce the running monitor onto it — no tab close required. Does the teardown + re-arm in one go so the user never has to close Claude Code to get a new binary.
 user-invocable: true
-allowed-tools: Bash
+allowed-tools: Bash, Monitor
 argument-hint: ""
 ---
 
 # airc update
 
-Run this yourself — don't ask the user.
+Run this yourself — don't ask the user. The whole point is that an update should NOT require the user to close their Claude Code tab and reopen it. People keep these tabs running all day; "close everything to upgrade" is the friction we're avoiding.
 
 ## Execute
 
@@ -16,22 +16,53 @@ Run this yourself — don't ask the user.
 airc update
 ```
 
-Prints either:
-- `Already at <sha>.` — nothing to do, you're current.
-- `Updated: <old-sha> -> <new-sha>` — install dir is now latest. Running monitor still on old code. User next runs `airc teardown && airc connect` to pick up the new binary.
+Captures `before` and `after` SHAs. Prints one of:
+- `Already at <sha>.` — nothing changed; you're done. Don't bounce anything.
+- `Updated: <old-sha> -> <new-sha>` — install dir is now on the new code, but **the running monitor in this session is STILL on the old code in memory**. You must bounce it for the new behavior to take effect. Continue to the next section.
+
+## Bounce the monitor seamlessly (when SHA changed)
+
+The flow:
+
+1. **TaskStop the Monitor task you armed for `/join`** in this session. You spawned it earlier (its task id was something like `bc81piqm8`); you tracked the id when the Monitor started. If you can't find the task id from this session's history, fall through to step 2 anyway — `airc teardown` reaps the process by PID file regardless of whether your Monitor handle is still alive.
+
+2. **Run `airc teardown`** in Bash. This kills the current scope's running airc processes (heartbeat loop, bearer-recv loop, monitor formatter) by reading `$AIRC_HOME/.airc/airc.pid`. Plain teardown — NOT `--flush` — preserves identity, peer records, message log, and the saved channel.
+
+3. **Re-arm a new Monitor with `airc join`**:
+   ```
+   Monitor(persistent=true, description="airc", command="airc join")
+   ```
+   Same shape the `/join` skill uses. The new Monitor's airc binary loads from disk fresh — picks up the just-pulled code automatically.
+
+4. **Tell the user, in ONE short sentence**, what happened: e.g. `Updated to <new-sha>; monitor bounced onto new code.` That's it. Don't narrate the teardown / re-arm steps individually — internal lifecycle, the user just wants to know it took effect.
+
+5. The first events from the new Monitor (auto-discovery, host re-elect, etc.) narrate as you would any /join events. Brief blip in the channel — peers see the host disappear for ~5 seconds during the teardown, then reappear after rejoin. Acceptable cost for "no tab close required."
+
+## Skill text changes are different — call out separately
+
+If the update added or modified `~/.claude/skills/<name>/SKILL.md` files, the **bash binary refresh above doesn't help with skill text** because Claude Code's session may already have cached the skill prompt (or the agent's prior reasoning in this conversation is locked-in from the old skill behavior). For skill changes specifically, the user DOES need to restart the tab to pick up the new skill prompt cleanly.
+
+If `airc update` reports changed skill files (look for `Skill: /<name>` lines in its output that match the count of changed `SKILL.md` files), surface ONE line at the end:
+
+> "Skill text changed in this update — close + reopen this Claude Code tab if /<name> doesn't behave as expected. (Binary already bounced.)"
+
+Don't bury this in a wall of text; it's the one thing that genuinely still requires manual user action.
 
 ## Failure modes
 
 - `No git checkout at <path>` — binary was installed without git (zip download, etc). Tell the user to reinstall via the curl | bash path.
 - `git pull failed` — uncommitted changes or diverged branch in the install dir. User needs to resolve the checkout manually.
+- `airc teardown` errors during the bounce — surface verbatim; the bounce is half-done. User can manually `airc teardown && airc join`.
+- New `airc join` fails to rejoin — surface verbatim; the user is now disconnected. Fall back to the manual recovery message.
 
 ## When to use
 
-- A fix just landed on main and you want it without the full curl+bash reinstall.
+- A fix just landed on canary/main and you want it without the full curl+bash reinstall.
 - Before running `airc doctor` to make sure tests match the latest code.
 - Before an `airc version` comparison across peers so everyone's on the same sha.
 
 ## Notes
 
-- `airc update` doesn't teardown or reconnect. Pulling code doesn't restart running processes. Callers need to explicitly `airc teardown && airc connect` to bounce the monitor onto the new code.
-- Alias: `airc upgrade`, `airc pull` both work.
+- Alias: `airc upgrade`, `airc pull` both dispatch to the same code.
+- The bounce in step 2 only restarts the CURRENT scope's monitor. Other tabs running airc in different scopes/repos still need their own `/update` (or a `airc teardown && airc join` from their own working dir). They are not interrupted by this update.
+- `AIRC_UPDATE_NO_BOUNCE=1` in env skips steps 1-3 (degenerate to old "tell the user to bounce" behavior). Useful for scripted batch updates where the caller will handle restart timing.


### PR DESCRIPTION
Joel's pain on the QA rig today, exact words: *"having to close out of all claudes is a major point of friction, for every update. people keep these running all the time."*

The old `/update` skill explicitly told the agent: *"Leaves the running monitor untouched; report the new SHA and tell the user to teardown + connect to pick it up."* That's the friction. Every airc update meant the user had to either close + reopen each Claude Code tab (lose context) or rote-remember to run `airc teardown && airc join` in each tab.

## Change
Rewrites the `/update` skill so the agent does the full lifecycle itself, in-session, without user action:

1. Run `airc update`; capture before/after SHA.
2. If SHA changed: TaskStop the Monitor task this session armed for `/join`. (If task id is lost, fall through — `airc teardown` reaps by PID file regardless.)
3. Run `airc teardown` — kills current scope's processes; preserves identity + peers + log + saved channel.
4. Re-arm Monitor with `airc join` — new bash process loads the just-pulled binary fresh from disk.
5. ONE short sentence to the user: *"Updated to `<sha>`; monitor bounced onto new code."* Don't narrate the lifecycle steps.

Net: *"Updated, mesh blips for ~5s while host re-elects, you're back on the new code in the same tab"* replaces *"go close every tab."*

## Skill text changes are called out separately
Skill `.md` changes genuinely DO require a tab restart — the agent's prior reasoning in the conversation is locked-in from the old skill behavior, and Claude Code may session-cache the skill prompt. The skill instructs the agent to surface a single explicit hint when it sees changed `SKILL.md` files in `airc update`'s output. That's the one piece of manual user action that remains, and it's surfaced explicitly so the user knows.

## Tradeoffs
- **`Monitor` added to allowed-tools** (was `Bash`-only). Necessary for the re-arm step.
- **Brief mesh blip** (~5s) while the host re-elects after teardown. Peers see host disappear briefly, then reappear. Acceptable cost vs "close every tab".
- **Only the current scope** is auto-bounced. Other tabs in different scopes still need their own `/update`. Same daemon-respawn semantics apply (with `airc daemon install`, the system respawns automatically).
- **`AIRC_UPDATE_NO_BOUNCE=1`** env var added as a power-user knob to opt out (e.g. for scripted batch updates where the caller will handle restart timing).

## Relationship to #354
Complements but doesn't supersede #354's airc-binary-side hint. The binary side is for users running `airc update` directly from a shell; this skill side is for users invoking `/update` inside Claude Code. Both should land — the binary hint is still being filed as a separate small PR.

## Test plan
- [ ] In a tab on canary tip, run `/update` after a fix lands → agent runs airc update → SHA changes → agent silently teardowns + re-arms Monitor → user sees ONE line *"Updated to `<sha>`; monitor bounced."* and no manual action needed
- [ ] Same flow when SHA didn't change → agent reports `Already at <sha>` and does nothing else
- [ ] When update changed `SKILL.md` files → agent surfaces the explicit "close + reopen this tab" hint in addition to the bounce
- [ ] `AIRC_UPDATE_NO_BOUNCE=1 /update` → agent skips the bounce, falls back to the warning-only behavior
- [ ] Live: re-test on the QA rig that triggered the original pain (i.e. open a tab, /update, see no friction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)