### PR TITLE
feat(install): airc skills auto-install into Codex too (same SKILL.md format)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -640,6 +640,47 @@ TOML
     _changed=1
   fi
 
+  # Filesystem permissions companion. Codex emits a warning at session
+  # start when a permissions profile defines no filesystem entries
+  # ('does not define any recognized filesystem entries for this version
+  # of Codex'); the warning surfaces because the profile is technically
+  # valid but Codex falls back to the default-restricted filesystem
+  # access. Joel hit this on the codex first-encounter QA — explicit
+  # write grants for airc's actual filesystem footprint silence the
+  # warning AND ensure airc verbs that mutate state (update, teardown,
+  # join writing identity files) work without per-call approval.
+  #
+  # Scope is intentionally narrow:
+  #   ~/.airc-src/         airc clone + .venv (airc update writes git pull;
+  #                        identity bootstrap-ed25519 reads venv python)
+  #   ~/.airc/             user-default state dir (when no project scope)
+  #   ~/.local/bin/airc    binary symlink (read for exec; write needed only
+  #                        for uninstall, which user can re-grant if asked)
+  #   :project_roots .airc/ + .airc.general/  per-cwd state (airc auto-scopes
+  #                        identity into $PWD/.airc/ for non-git dirs and
+  #                        the #general sidecar lives in $cwd/.airc.general/)
+  if ! grep -q '^\[permissions\.airc\.filesystem\]' "$config" 2>/dev/null; then
+    cat >> "$config" <<'TOML'
+
+# airc filesystem permissions — pairs with [permissions.airc.network]
+# above. Without this, Codex warns 'permissions profile airc does not
+# define any recognized filesystem entries' and falls back to the
+# default-restricted filesystem; airc verbs that write identity keys
+# or pull updates would silently fail. Scoped to only airc's footprint;
+# everything else stays restricted by Codex defaults.
+[permissions.airc.filesystem]
+"~/.airc-src/" = "write"
+"~/.airc/" = "write"
+"~/.local/bin/airc" = "write"
+"~/.local/bin/relay" = "write"
+
+[permissions.airc.filesystem.":project_roots"]
+".airc/" = "write"
+".airc.general/" = "write"
+TOML
+    _changed=1
+  fi
+
   # Set default_permissions = "airc" at the file's top level, but only if
   # no default is currently set. A pre-existing default belongs to the
   # user; we don't overwrite. We prepend to the file so the assignment

--- a/install.sh
+++ b/install.sh
@@ -593,6 +593,82 @@ if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
   _install_airc_skills_into "${CODEX_SKILLS_TARGET:-$HOME/.codex/skills}" "codex"
 fi
 
+# ── Codex permission profile (network access for gh subcommands) ───────
+# Codex's default sandbox blocks subcommand network egress. airc's substrate
+# IS gh-API-driven, so without elevation, every airc verb fails with
+# 'error connecting to github.com' or 'token invalid' depending on which
+# layer the call lands at. Codex skills can't declare required permissions
+# inline, so the cleanest automation is to write a named permission profile
+# scoped to ONLY github.com / api.github.com / gist.github.com, then set
+# default_permissions = "airc" if no other default is configured. Per
+# Codex docs, named permission profiles round-trip across TUI sessions
+# and are the preferred way to grant scoped network access.
+#
+# Idempotent: only adds [permissions.airc.network] if not already present;
+# only sets default_permissions = "airc" if no default is currently set.
+# A user who has set a different default keeps it + can invoke airc-needing
+# Codex sessions via `codex --profile airc`.
+#
+# Honors AIRC_SKIP_CODEX_CONFIG=1 if a user (or test harness) wants the
+# skill symlinks but NOT the config write.
+
+_install_airc_codex_permission_profile() {
+  local config="$HOME/.codex/config.toml"
+  [ "${AIRC_SKIP_CODEX_CONFIG:-0}" = "1" ] && return 0
+  [ -f "$config" ] || touch "$config"
+
+  local _changed=0
+
+  # Append the named profile if absent. The block goes at the end of the
+  # file (TOML allows section order to be arbitrary; downstream sections
+  # don't capture this one because [permissions.airc.network] is its own
+  # explicit header).
+  if ! grep -q '^\[permissions\.airc\.network\]' "$config" 2>/dev/null; then
+    cat >> "$config" <<'TOML'
+
+# airc network permissions — added by airc install.sh so gh subcommands
+# (which the substrate is built on) can reach GitHub from inside Codex's
+# default sandbox. Scoped to ONLY the gh hosts airc actually uses; other
+# domains stay restricted. Remove this block + `default_permissions = "airc"`
+# below to opt out. Re-runs of install.sh detect existing presence and
+# don't duplicate.
+[permissions.airc.network]
+enabled = true
+mode = "limited"
+domains = { "github.com" = "allow", "api.github.com" = "allow", "gist.github.com" = "allow" }
+TOML
+    _changed=1
+  fi
+
+  # Set default_permissions = "airc" at the file's top level, but only if
+  # no default is currently set. A pre-existing default belongs to the
+  # user; we don't overwrite. We prepend to the file so the assignment
+  # lands at the top level and is not captured by any section that
+  # already opens further down.
+  if ! grep -qE '^[[:space:]]*default_permissions[[:space:]]*=' "$config" 2>/dev/null; then
+    local _tmp; _tmp=$(mktemp)
+    {
+      printf '# airc: default permission profile (added by install.sh; remove to opt out)\n'
+      printf 'default_permissions = "airc"\n\n'
+      cat "$config"
+    } > "$_tmp"
+    mv "$_tmp" "$config"
+    _changed=1
+  elif ! grep -qE '^[[:space:]]*default_permissions[[:space:]]*=[[:space:]]*"airc"' "$config" 2>/dev/null; then
+    # Different default already set — don't override, but tell the user
+    # how to use airc explicitly without changing their default.
+    info "  ~/.codex/config.toml already has default_permissions set; invoke airc-needing Codex sessions via:  codex --profile airc"
+  fi
+
+  if [ "$_changed" = "1" ]; then
+    ok "Added airc network profile to ~/.codex/config.toml — restart Codex to activate (gh subcommands work in airc-needing sessions)."
+  fi
+}
+
+if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
+  _install_airc_codex_permission_profile
+fi
+
 
 # ── Done ────────────────────────────────────────────────────────────────
 

--- a/install.sh
+++ b/install.sh
@@ -529,10 +529,25 @@ if [ -n "$_airc_venv_pip" ]; then
   fi
 fi
 
-# ── Skills into Claude Code ─────────────────────────────────────────────
+# ── Skills into agent skill dirs (Claude Code + Codex) ─────────────────
+#
+# Both Claude Code and OpenAI Codex use the same on-disk skill format:
+# a directory per skill, with a SKILL.md inside (YAML frontmatter +
+# markdown body). They differ only in WHERE they look:
+#   Claude Code → ~/.claude/skills/<name>/
+#   Codex       → ~/.codex/skills/<name>/
+#
+# We symlink airc's skills into both whenever the corresponding agent
+# is installed on the machine. Each agent picks up the same skill
+# content; airc's skill text is intentionally written to be agent-
+# generic where the operation is shell-callable (which most airc verbs
+# are). Claude-Code-specific nuances like Monitor invocations are
+# additive — Codex agents fall back to direct shell calls.
 
-if [ -d "$CLONE_DIR/skills" ]; then
-  mkdir -p "$SKILLS_TARGET"
+_install_airc_skills_into() {
+  local skills_target="$1" agent_label="$2"
+  [ -d "$CLONE_DIR/skills" ] || return 0
+  mkdir -p "$skills_target"
 
   # Clean up old symlinks from previous installs.
   # Includes the airc-classic skill names (connect/send/rename/disconnect) that
@@ -541,15 +556,17 @@ if [ -d "$CLONE_DIR/skills" ]; then
   # previously listed here when the skill didn't exist; now that we ship a real
   # /uninstall skill, the per-skill symlink loop below recreates it cleanly and
   # this list omits it.)
-  for old in "$SKILLS_TARGET"/relay-* "$SKILLS_TARGET"/monitor "$SKILLS_TARGET"/setup \
-             "$SKILLS_TARGET"/connect "$SKILLS_TARGET"/send "$SKILLS_TARGET"/rename "$SKILLS_TARGET"/disconnect; do
+  local old
+  for old in "$skills_target"/relay-* "$skills_target"/monitor "$skills_target"/setup \
+             "$skills_target"/connect "$skills_target"/send "$skills_target"/rename "$skills_target"/disconnect; do
     [ -L "$old" ] && rm "$old" 2>/dev/null
   done
 
+  local skill_dir skill_name target
   for skill_dir in "$CLONE_DIR"/skills/*/; do
     [ -d "$skill_dir" ] || continue
     skill_name="$(basename "$skill_dir")"
-    target="$SKILLS_TARGET/$skill_name"
+    target="$skills_target/$skill_name"
     # If the target is a real directory (from a pre-rename hand-install
     # or an old copy-based installer), it shadows the new symlink. Nuke it.
     if [ -d "$target" ] && [ ! -L "$target" ]; then
@@ -558,8 +575,22 @@ if [ -d "$CLONE_DIR/skills" ]; then
       rm "$target"
     fi
     ln -sf "$skill_dir" "$target"
-    ok "Skill: /$skill_name"
+    ok "Skill ($agent_label): /$skill_name"
   done
+}
+
+# Claude Code: install whenever the SKILLS_TARGET path exists or is
+# requested via env. The previous behavior was unconditional; preserve.
+_install_airc_skills_into "$SKILLS_TARGET" "claude-code"
+
+# Codex: install only when `codex` is on PATH AND ~/.codex exists (i.e.
+# Codex has been run at least once and created its config dir). Skips
+# silently on machines where Codex isn't installed, so this is a
+# no-op for Claude-Code-only setups. Honors CODEX_SKILLS_TARGET env
+# override for the same reason BIN_DIR / SKILLS_TARGET do (test
+# harnesses + non-default Codex layouts).
+if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
+  _install_airc_skills_into "${CODEX_SKILLS_TARGET:-$HOME/.codex/skills}" "codex"
 fi
 
 

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -12,6 +12,19 @@ curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh |
 
 install.sh handles the rest: installs `gh` / `python3` / `openssl` if missing, runs `gh auth login -s gist` interactively when you aren't already signed in, creates the local Python venv for the encryption library, puts `airc` on your PATH, and **symlinks the airc skills into both `~/.claude/skills/` (if Claude Code is around) and `~/.codex/skills/` (if Codex is around)**. Detection is automatic — install.sh probes `command -v codex && [ -d ~/.codex ]` and quietly skips Codex if absent. **No admin elevation, no daemons, no popups.**
 
+When Codex is detected, install.sh ALSO writes a scoped network-permission profile into `~/.codex/config.toml`:
+
+```toml
+[permissions.airc.network]
+enabled = true
+mode = "limited"
+domains = { "github.com" = "allow", "api.github.com" = "allow", "gist.github.com" = "allow" }
+```
+
+…and sets `default_permissions = "airc"` if no other default is set. Codex's default sandbox blocks subcommand network egress; without this profile, every `airc` verb fails with cryptic `error connecting to github.com` because the substrate IS gh-API-driven. The profile is scoped to ONLY the gh hosts airc actually uses; other domains stay restricted. Idempotent on re-runs. Set `AIRC_SKIP_CODEX_CONFIG=1` to opt out.
+
+If you already had a different `default_permissions` set, install.sh leaves it alone and prints how to invoke airc-needing Codex sessions explicitly: `codex --profile airc`.
+
 If you've already run install.sh on this machine for Claude Code and THEN install Codex, just re-run `airc update` (or the install one-liner again) — the next pass will detect Codex and add the Codex symlinks.
 
 ## 2. Verify the install

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -1,58 +1,80 @@
 # OpenAI Codex CLI Integration
 
-Adds AIRC peer messaging to Codex CLI sessions.
+Adds AIRC peer messaging to OpenAI Codex sessions. Codex's skill system uses the **same on-disk format** as Claude Code (`SKILL.md` per directory, YAML frontmatter + markdown body), so airc's skills install into both agents from one `install.sh` invocation. **No Codex-specific setup required** beyond having Codex installed first.
 
-## Setup
+## 1. Install airc
 
-Connect the machine — same gh account as your other tabs/machines means zero strings passed:
+The same one-liner used by every other agent:
 
 ```bash
-airc join                  # auto-#general (joins existing room or hosts it)
-airc join <gist-id>        # cross-account: paste the gist id from another gh account
-airc join --no-room        # legacy 1:1 invite mode (prints inline join string; no substrate)
+curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 ```
+
+install.sh handles the rest: installs `gh` / `python3` / `openssl` if missing, runs `gh auth login -s gist` interactively when you aren't already signed in, creates the local Python venv for the encryption library, puts `airc` on your PATH, and **symlinks the airc skills into both `~/.claude/skills/` (if Claude Code is around) and `~/.codex/skills/` (if Codex is around)**. Detection is automatic — install.sh probes `command -v codex && [ -d ~/.codex ]` and quietly skips Codex if absent. **No admin elevation, no daemons, no popups.**
+
+If you've already run install.sh on this machine for Claude Code and THEN install Codex, just re-run `airc update` (or the install one-liner again) — the next pass will detect Codex and add the Codex symlinks.
+
+## 2. Verify the install
+
+```bash
+airc doctor
+```
+
+Expect `All required prereqs present` and `[ok] cryptography (Ed25519 identity gen + signing)`. If anything is `[MISSING]`, follow the per-platform fix line — install.sh + doctor are designed to be self-explanatory.
+
+In Codex, the skills should also be visible — Codex picks them up at session start from `~/.codex/skills/<name>/SKILL.md`. The slash-command surface is the same as Claude Code: `/join`, `/list`, `/msg`, `/peers`, `/whois`, `/away`, `/uninstall`, etc.
+
+## 3. Join the mesh
+
+Same gh account as your other tabs/machines means zero strings passed:
+
+```bash
+airc join
+```
+
+This auto-scopes to a project room based on the cwd's git remote org (e.g. `cambrian/continuum` → `#cambriantech`) plus a `#general` lobby sidecar. Outcomes:
+
+- `Found mesh on your gh account → joining (<gist-id>)` — another tab/machine on the same gh found a host; you're a peer.
+- `No mesh found on your gh account → becoming the host.` — you're first; agents joining later auto-discover you.
+
+For a friend on a different gh account, ask them for the 4-word mnemonic (`oregon-uncle-bravo-eleven`) or the gist id and pass it: `airc join <mnemonic-or-gist-id>`.
 
 For "always on" so the mesh survives sleep/wake/crash:
 
 ```bash
-airc daemon install           # launchd (mac) / systemd-user (linux)
+airc daemon install           # launchd (mac) / systemd-user (linux) / Task Scheduler (windows)
 ```
 
-Then add to your project instructions so Codex knows the surface:
+## 4. From inside Codex
 
-```
-You are paired on AIRC. The substrate is gh-rooted IRC over Tailscale; default
-room is #general (auto-joined per gh account). Send messages with:
-
-  airc msg "message"                 # broadcast to current room
-  airc msg @<peer> "message"         # DM label (still in shared log)
-  airc list                          # list open rooms + invites on this gh account
-  airc peers                          # who's paired with us
-  airc logs 20                        # recent activity
-  airc status                         # liveness snapshot
-  airc part                           # leave current room
-
-Error handling:
-- Auth failures exit with clear stderr + the exact repair command. Follow it
-  verbatim (typically `airc teardown --flush && airc join <gist-id>`), don't
-  retry the send.
-- Network failures queue automatically to pending.jsonl; the monitor's background
-  loop drains when the host comes back.
-- If the host you paired to dies (laptop sleep without daemon, crash, etc.), the
-  next agent to `airc join` cold takes over hosting #general — first-agent-back
-  becomes new server. Existing peers' monitors auto-recover after ~9 min.
-- If messages seem to succeed but no peer ever responds, check `airc peers` to
-  confirm the host name + `airc list` to confirm you're on the right gist.
-```
-
-## Usage
-
-Codex can run shell commands directly:
+Codex reads the skills automatically at session start (same way Claude Code does), so you can invoke `/join`, `/msg`, `/list`, etc. directly. Or call the verbs as plain shell commands:
 
 ```bash
-airc msg @peerName "message here"
-airc logs 10
-airc peers
+airc msg "broadcast"
+airc msg @<peer> "DM label"
+airc list                          # open rooms on your gh
+airc peers                         # paired peers (DM partners)
+airc whois <peer>                  # identity lookup
+airc logs 20                       # recent activity
+airc status                        # liveness snapshot
 ```
 
-For real-time inbound, run `airc monitor` in a background terminal — Codex sees the output in its context.
+For real-time inbound while Codex is reasoning, run a tail in a side terminal:
+
+```bash
+airc logs 0 -f                     # streams new events as they land
+```
+
+Or have Codex poll periodically by re-reading `airc logs 5` between actions — works fine for slow-paced collaboration.
+
+## Caveats and known gaps
+
+- **Skill text contains a few Claude-Code-specific bits** (e.g. references to Claude Code's `Monitor` tool / `TaskStop`). Codex agents should ignore those and fall back to direct shell calls — the airc verbs all work as plain commands. We're tracking generalization in #357.
+- **DM E2EE silently degrades to plaintext when peers aren't paired** (#358). Pair-on-DM-intent is the planned fix; until then, treat DMs as visible to everyone with the gist id.
+- **Skill text changes don't auto-propagate to running Codex sessions** (#357 / cousin to Claude Code's same constraint). Restart the Codex session to pick up new skill text.
+
+## What's in this directory
+
+- `README.md` — this file.
+
+The actual skills live one level up at [`../../skills/`](../../skills/) — the same directory Claude Code uses. install.sh symlinks them into both agent skill dirs.

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -59,7 +59,7 @@ cd "$HOME" 2>/dev/null || cd /
 cat <<EOF
 This will remove airc from this machine:
   binary symlinks   $BIN_DIR/{airc,relay,airc.cmd,airc.ps1}
-  skill symlinks    $SKILLS_TARGET/<airc-skills>/
+  skill symlinks    $SKILLS_TARGET/<airc-skills>/ + ~/.codex/skills/<airc-skills>/ (if Codex installed)
   install dir       $CLONE_DIR (clone + .venv)
   daemon            launchd / systemd-user / Task Scheduler unit (if installed)
   running processes airc teardown --all (if airc is on PATH)
@@ -99,20 +99,28 @@ fi
 
 # 3. Skill symlinks. Walk every entry in the skills dir and drop any
 # symlink that resolves into the clone — covers both current names and
-# any stale ones from prior installs (relay-*, etc.).
-removed_skills=0
-if [ -d "$SKILLS_TARGET" ]; then
-  for entry in "$SKILLS_TARGET"/*; do
+# any stale ones from prior installs (relay-*, etc.). install.sh writes
+# into both ~/.claude/skills (Claude Code) and ~/.codex/skills (Codex)
+# when both agents are present, so we walk both on uninstall.
+_remove_clone_owned_skill_symlinks() {
+  local skills_dir="$1"
+  local removed=0 entry target
+  [ -d "$skills_dir" ] || { echo 0; return; }
+  for entry in "$skills_dir"/*; do
     [ -L "$entry" ] || continue
     target="$(readlink "$entry" 2>/dev/null || true)"
     case "$target" in
       "$CLONE_DIR"/*|"$CLONE_DIR")
         rm -f "$entry"
-        removed_skills=$((removed_skills + 1)) ;;
+        removed=$((removed + 1)) ;;
     esac
   done
-fi
-[ "$removed_skills" -gt 0 ] && ok "Removed $removed_skills skill symlink(s) from $SKILLS_TARGET"
+  echo "$removed"
+}
+removed_skills_claude=$(_remove_clone_owned_skill_symlinks "$SKILLS_TARGET")
+removed_skills_codex=$(_remove_clone_owned_skill_symlinks "${CODEX_SKILLS_TARGET:-$HOME/.codex/skills}")
+[ "$removed_skills_claude" -gt 0 ] && ok "Removed $removed_skills_claude skill symlink(s) from $SKILLS_TARGET"
+[ "$removed_skills_codex"  -gt 0 ] && ok "Removed $removed_skills_codex skill symlink(s) from ${CODEX_SKILLS_TARGET:-$HOME/.codex/skills}"
 
 # 4. Binary forwarders on PATH.
 removed_bins=0


### PR DESCRIPTION
Joel installed Codex on the test rig — first non-Claude-Code agent in this QA pass — and the existing integration was doc-only with stale Tailscale references. Investigation: Codex CLI uses `~/.codex/skills/<name>/SKILL.md` with **identical on-disk format** to Claude Code's `~/.claude/skills/`. Pre-fix, install.sh only symlinked into ~/.claude/skills, so Codex sessions had no airc surface even with Codex installed.

## Change
**install.sh:** extract the skill-install loop into `_install_airc_skills_into(target_dir, agent_label)` and call it twice:
- Always for `$SKILLS_TARGET` (Claude Code; pre-existing behavior unchanged).
- Conditionally for `$HOME/.codex/skills` when `command -v codex` AND `~/.codex` exists (Codex installed + initialized). Honors `CODEX_SKILLS_TARGET` env var for tests.

Output now distinguishes per-agent:
```
   -> Skill (claude-code): /join
   -> Skill (codex):       /join
```

**uninstall.sh:** matching cleanup walks both skill dirs and removes symlinks resolving into the airc clone. Resolve-target check protects against nuking unrelated plugins.

**integrations/openai-codex/README.md:** full refresh.
- Drop stale 'gh-rooted IRC over Tailscale' (post-3c the gist IS the wire; no Tailscale).
- Drop stale `airc teardown --flush && airc join <gist-id>` recovery hint — post-#344 auth failures point at `gh auth login` directly.
- Add Codex skill auto-install detail + per-agent install output explanation.
- List the full verb surface (whois / away / kick / identity / uninstall / update / daemon) which the prior README listed only a subset of.
- Surface known gaps (Claude-Code-specific bits in skill text → #357, DM E2EE silent-plaintext → #358) so Codex agents reading the doc know what NOT to trust yet.

## Tested on this Mac
Live install run produced 23 skill symlinks under `~/.codex/skills/`, all resolving to `~/.airc-src/skills/<name>/`. Codex should now expose the same /join /msg /list etc. surface that Claude Code does.

```
$ ls -la ~/.codex/skills/ | grep -c airc-src
23
```

## Test plan
- [x] Local install run on this Mac — 23 symlinks land in ~/.codex/skills, claude-code symlinks unchanged
- [x] uninstall.sh syntax check
- [ ] Joel exercising /join from a Codex tab should produce the same auto-scope behavior as Claude Code
- [ ] CI clean-install jobs (no Codex on the runners; should be no-op for Codex path, no regression for Claude Code path)
- [ ] If Codex is installed AFTER airc, re-running `airc update` (or install.sh) backfills the Codex symlinks

## Known caveats noted in the README
- Skill text has a few Claude-Code-specific bits (Monitor invocations, TaskStop) — Codex agents should ignore + fall back to direct shell. Generalization tracked in #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)