### PR TITLE
hotfix: remove [permissions.airc.filesystem] block that breaks Codex startup (regression from #364)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -640,44 +640,63 @@ TOML
     _changed=1
   fi
 
-  # Filesystem permissions companion. Codex emits a warning at session
-  # start when a permissions profile defines no filesystem entries
-  # ('does not define any recognized filesystem entries for this version
-  # of Codex'); the warning surfaces because the profile is technically
-  # valid but Codex falls back to the default-restricted filesystem
-  # access. Joel hit this on the codex first-encounter QA — explicit
-  # write grants for airc's actual filesystem footprint silence the
-  # warning AND ensure airc verbs that mutate state (update, teardown,
-  # join writing identity files) work without per-call approval.
-  #
-  # Scope is intentionally narrow:
-  #   ~/.airc-src/         airc clone + .venv (airc update writes git pull;
-  #                        identity bootstrap-ed25519 reads venv python)
-  #   ~/.airc/             user-default state dir (when no project scope)
-  #   ~/.local/bin/airc    binary symlink (read for exec; write needed only
-  #                        for uninstall, which user can re-grant if asked)
-  #   :project_roots .airc/ + .airc.general/  per-cwd state (airc auto-scopes
-  #                        identity into $PWD/.airc/ for non-git dirs and
-  #                        the #general sidecar lives in $cwd/.airc.general/)
-  if ! grep -q '^\[permissions\.airc\.filesystem\]' "$config" 2>/dev/null; then
-    cat >> "$config" <<'TOML'
+  # Filesystem permissions: NOT WRITTEN. Initially we tried granting writes
+  # to ~/.airc-src/ + ~/.airc/ + ~/.local/bin/airc + a :project_roots
+  # block — Codex's runtime hard-rejected the profile at startup with:
+  #   "permissions profile requests filesystem writes outside the
+  #   workspace root, which is not supported until the runtime enforces
+  #   FileSystemSandboxPolicy directly"
+  # …meaning Codex 0.125 can't honor home-dir-scoped filesystem grants in
+  # named profiles yet. Even the :project_roots-only variant didn't help.
+  # The startup error broke every Codex session on the machine. We removed
+  # the block entirely; living with Codex's "does not define any recognized
+  # filesystem entries" warning is preferable to a hard-fail-on-startup.
+  # When Codex's runtime supports outside-workspace filesystem profiles,
+  # restore the block (history at git log -- install.sh).
 
-# airc filesystem permissions — pairs with [permissions.airc.network]
-# above. Without this, Codex warns 'permissions profile airc does not
-# define any recognized filesystem entries' and falls back to the
-# default-restricted filesystem; airc verbs that write identity keys
-# or pull updates would silently fail. Scoped to only airc's footprint;
-# everything else stays restricted by Codex defaults.
-[permissions.airc.filesystem]
-"~/.airc-src/" = "write"
-"~/.airc/" = "write"
-"~/.local/bin/airc" = "write"
-"~/.local/bin/relay" = "write"
-
-[permissions.airc.filesystem.":project_roots"]
-".airc/" = "write"
-".airc.general/" = "write"
-TOML
+  # Cleanup: machines that ran the buggy intermediate (3b20369..c1)
+  # still have the [permissions.airc.filesystem] block in their
+  # config.toml and Codex won't start. Detect and strip it on every
+  # install.sh run so Codex starts cleanly without the user having
+  # to hand-edit their config.
+  if grep -q '^\[permissions\.airc\.filesystem\]' "$config" 2>/dev/null; then
+    info "Removing stale [permissions.airc.filesystem] block from ~/.codex/config.toml (Codex 0.125 doesn't support outside-workspace filesystem profiles; was breaking session startup)..."
+    "${AIRC_PYTHON:-python3}" - "$config" <<'PY'
+import sys, re
+path = sys.argv[1]
+with open(path) as f:
+    text = f.read()
+# Strip from any '# airc filesystem permissions' header (or bare
+# [permissions.airc.filesystem] header) through end of that section
+# and any [permissions.airc.filesystem.<sub>] children. Section ends
+# at the next top-level header that is NOT under [permissions.airc.filesystem].
+lines = text.splitlines(keepends=True)
+out = []
+in_airc_fs = False
+for line in lines:
+    stripped = line.strip()
+    if stripped.startswith('# airc filesystem permissions'):
+        # Drop the leading comment block too (cohesive with the section)
+        in_airc_fs = True
+        continue
+    if stripped.startswith('[permissions.airc.filesystem'):
+        in_airc_fs = True
+        continue
+    if in_airc_fs:
+        # Continue dropping comment lines and key=value lines until we
+        # hit a new section header that isn't airc.filesystem.
+        if stripped.startswith('[') and not stripped.startswith('[permissions.airc.filesystem'):
+            in_airc_fs = False
+            out.append(line)
+        # else: drop (comment, blank, or key=value within the section)
+        continue
+    out.append(line)
+# Collapse runs of >2 blank lines that the strip might have left.
+result = ''.join(out)
+result = re.sub(r'\n{3,}', '\n\n', result)
+with open(path, 'w') as f:
+    f.write(result)
+PY
     _changed=1
   fi
 


### PR DESCRIPTION
🚨 **Hotfix — regression from #364 takes Codex offline.**

The filesystem-permission block added in #364's second commit broke Codex on startup with:

> Error loading configuration: permissions profile requests filesystem writes outside the workspace root, which is not supported until the runtime enforces FileSystemSandboxPolicy directly

Codex 0.125's runtime can't honor home-dir-scoped filesystem grants in named profiles yet. Even the `:project_roots`-only variant didn't help. **On every machine that ran the merged #364, the next codex invocation fails to start until the block is removed from `~/.codex/config.toml` manually.**

Surfaced live during Joel's codex first-encounter QA — Codex hard-failed at config load right after the post-#364 restart.

## Two-part hotfix

1. **Stop writing the `[permissions.airc.filesystem]` block.** Replaced the write code with a comment explaining why the block is omitted + pointer at git history for the prior version. Living with Codex's harmless `'does not define any recognized filesystem entries'` warning is preferable to a hard-fail-on-startup that takes Codex offline entirely.

2. **Add a cleanup step that detects + strips the broken block** in existing `~/.codex/config.toml` files. Without this, every user who already ran #364 has a permanently broken Codex until they hand-edit. Cleanup uses Python (we have the venv from cryptography) for section-aware strip — handles the leading `# airc filesystem permissions` comment and any `[permissions.airc.filesystem.<sub>]` children in one pass. Runs every install.sh invocation; idempotent (no-op when block absent).

## Tested on this Mac

```
$ # simulated stale block
$ AIRC_INSTALL_NO_PULL=1 AIRC_DIR=$HOME/.airc-src bash install.sh
   ...
   -> Removing stale [permissions.airc.filesystem] block from ~/.codex/config.toml ...

$ codex exec --skip-git-repo-check 'true'
OpenAI Codex v0.125.0 (research preview)        # ← starts cleanly now
$ echo $?
0
```

Network profile + skill symlinks from #364 stay intact and continue working — only the filesystem block is removed.

## Open follow-up

Codex's docs claim filesystem profiles are supported per the config-reference, but the runtime rejects them. Possibly a 0.125-vs-newer-version gap. When/if Codex's runtime adds support, restore the block — history is in `git log -- install.sh`.

## Test plan
- [x] Live test: simulated stale block in config.toml → install.sh detects + strips → codex exec starts (rc=0)
- [x] `bash -n install.sh` syntax check
- [x] Re-run idempotency: install.sh on cleaned config = no-op, no spurious changes
- [x] Network profile + skills still installed correctly
- [ ] CI: clean-install jobs pass on the 4 platforms (no regression elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)