### PR TITLE
feat(install): inject GH_TOKEN into Codex via [shell_environment_policy.set] — workaround openai/codex#10695

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -729,6 +729,81 @@ if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
   _install_airc_codex_permission_profile
 fi
 
+# ── Codex GH_TOKEN env injection ───────────────────────────────────────
+# Codex's sandbox can't reliably reach the macOS Keychain to validate
+# gh's stored token. Result: gh auth status flakes between ✓ and X
+# within a single Codex session, airc join trips on the X path even
+# though the token is real and valid (Joel hit this on the codex
+# first-encounter QA; openai/codex#10695 is the upstream tracking bug
+# with confirmation from a contributor that Codex's shell handlers
+# don't merge dependency env into spawned processes; patch in flight).
+#
+# Workaround per OpenAI's own maintainer guidance ("If echo $GH_TOKEN
+# is defined at app launch it's visible to sandboxed tools"): inject
+# the current gh token into Codex's [shell_environment_policy.set]
+# block. Codex's docs confirm this map is "Explicit environment
+# overrides injected into every subprocess" — exactly what we need.
+#
+# Token plaintext on disk in ~/.codex/config.toml is the security
+# trade-off. Same trust posture as ~/.codex/auth.json (which already
+# holds the user's OpenAI credentials); both are 0600-by-default in
+# the user's home dir. Joel signed off on this trade-off as cleaner
+# than (a) PATH-shadowing codex, (b) shellrc-exporting GH_TOKEN to
+# every shell, or (c) asking the user to type the launch one-liner
+# every time.
+#
+# Idempotent + token-refreshing: every install.sh run (including
+# `airc update`) strips any prior airc-managed block and rewrites
+# with the current `gh auth token` output. Bracket markers make the
+# block detectable + removable cleanly.
+#
+# Honors AIRC_SKIP_CODEX_TOKEN=1 if the user wants the network/
+# permission profile but NOT the token injection (e.g. they prefer
+# to manage GH_TOKEN themselves via shell alias).
+
+_install_airc_codex_gh_token() {
+  local config="$HOME/.codex/config.toml"
+  [ "${AIRC_SKIP_CODEX_TOKEN:-0}" = "1" ] && return 0
+  [ -f "$config" ] || return 0
+  command -v gh >/dev/null 2>&1 || return 0
+
+  # Pull current token. If gh is unauthed or fails for any reason,
+  # silently skip — better to leave existing block alone than write
+  # an empty token that breaks Codex sessions.
+  local token; token=$(gh auth token 2>/dev/null) || return 0
+  [ -z "$token" ] && return 0
+
+  local marker_start='# AIRC-GH-TOKEN-START — managed by install.sh; airc update refreshes the token; remove this section through AIRC-GH-TOKEN-END to opt out'
+  local marker_end='# AIRC-GH-TOKEN-END'
+
+  # Strip any prior airc-managed block (handles token rotation across
+  # install.sh runs). sed range-delete from start marker through end
+  # marker, inclusive.
+  if grep -qF "AIRC-GH-TOKEN-START" "$config" 2>/dev/null; then
+    local _tmp; _tmp=$(mktemp)
+    sed '/^# AIRC-GH-TOKEN-START/,/^# AIRC-GH-TOKEN-END/d' "$config" > "$_tmp"
+    mv "$_tmp" "$config"
+  fi
+
+  # Append fresh block. Uses [shell_environment_policy.set] sub-table
+  # rather than inline `set = { ... }` syntax so it composes with any
+  # user-defined [shell_environment_policy] keys at the parent level
+  # (e.g. inherit, include_only) without conflict.
+  cat >> "$config" <<TOML
+
+$marker_start
+[shell_environment_policy.set]
+GH_TOKEN = "$token"
+$marker_end
+TOML
+
+  ok "Codex GH_TOKEN injection refreshed in ~/.codex/config.toml (gh's current token; restart Codex to apply)"
+}
+
+if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
+  _install_airc_codex_gh_token
+fi
+
 
 # ── Done ────────────────────────────────────────────────────────────────
 

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -25,6 +25,27 @@ domains = { "github.com" = "allow", "api.github.com" = "allow", "gist.github.com
 
 If you already had a different `default_permissions` set, install.sh leaves it alone and prints how to invoke airc-needing Codex sessions explicitly: `codex --profile airc`.
 
+## GH_TOKEN injection (working around openai/codex#10695)
+
+Codex's sandbox can't reliably reach the macOS Keychain to validate gh's stored token. Symptom: `gh auth status` flakes between ✓ and X within a single Codex session, `airc join` trips on the X path even though the token is real and valid. This is a known upstream bug ([openai/codex#10695](https://github.com/openai/codex/issues/10695)) — patch in flight.
+
+Workaround per OpenAI's own maintainer guidance: inject GH_TOKEN at app launch, then sandboxed tools see it. install.sh automates this by writing a marker-bracketed block to `~/.codex/config.toml`:
+
+```toml
+# AIRC-GH-TOKEN-START — managed by install.sh; airc update refreshes the token; remove this section through AIRC-GH-TOKEN-END to opt out
+[shell_environment_policy.set]
+GH_TOKEN = "ghp_..."
+# AIRC-GH-TOKEN-END
+```
+
+Codex's `[shell_environment_policy.set]` is documented as "explicit environment overrides injected into every subprocess" — exactly what we need to bypass the sandbox/keychain flake. After Codex restarts, `gh` and `airc` see GH_TOKEN in env and never depend on the keychain.
+
+**Trade-off:** the token is plaintext on disk in `~/.codex/config.toml`, alongside `~/.codex/auth.json` (which already holds the user's OpenAI credentials). Same trust posture; both files are in your home dir at default 0600. Set `AIRC_SKIP_CODEX_TOKEN=1` in env when running install.sh to opt out of the injection (e.g. if you'd rather manage GH_TOKEN via shell alias yourself).
+
+**Token rotation:** every install.sh run (including `airc update`) re-fetches the current token via `gh auth token` and rewrites the block. If you `gh auth refresh` or rotate keys, just run `airc update` afterwards and Codex picks up the new token on next restart.
+
+When upstream openai/codex#10695 lands a fix that makes `dependency_env` propagate properly, this injection becomes a no-op safety net rather than a load-bearing workaround.
+
 If you've already run install.sh on this machine for Claude Code and THEN install Codex, just re-run `airc update` (or the install one-liner again) — the next pass will detect Codex and add the Codex symlinks.
 
 ## 2. Verify the install

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -122,6 +122,19 @@ removed_skills_codex=$(_remove_clone_owned_skill_symlinks "${CODEX_SKILLS_TARGET
 [ "$removed_skills_claude" -gt 0 ] && ok "Removed $removed_skills_claude skill symlink(s) from $SKILLS_TARGET"
 [ "$removed_skills_codex"  -gt 0 ] && ok "Removed $removed_skills_codex skill symlink(s) from ${CODEX_SKILLS_TARGET:-$HOME/.codex/skills}"
 
+# 3b. Codex config.toml cleanup. Strip the airc-managed GH_TOKEN block
+# (and the network-permission profile) if present. Keeps the rest of
+# the user's Codex config untouched. Marker-bracketed for safe sed delete.
+codex_config="$HOME/.codex/config.toml"
+if [ -f "$codex_config" ]; then
+  if grep -qF "AIRC-GH-TOKEN-START" "$codex_config" 2>/dev/null; then
+    _tmp=$(mktemp)
+    sed '/^# AIRC-GH-TOKEN-START/,/^# AIRC-GH-TOKEN-END/d' "$codex_config" > "$_tmp"
+    mv "$_tmp" "$codex_config"
+    ok "Removed airc GH_TOKEN injection from $codex_config"
+  fi
+fi
+
 # 4. Binary forwarders on PATH.
 removed_bins=0
 for f in airc relay airc.cmd airc.ps1; do


### PR DESCRIPTION
Codex's sandbox can't reliably reach the macOS Keychain to validate gh's stored token. Symptom from Joel's QA pass: `gh auth status` flakes between ✓ and X within a single Codex session, `airc join` trips on the X path even though the token is real and valid. This is the upstream bug at [openai/codex#10695](https://github.com/openai/codex/issues/10695) — patch in flight from a contributor (shell handlers don't merge `dependency_env` into spawned processes).

OpenAI's own maintainer guidance on #10695: *"If `echo $GH_TOKEN` is defined at app launch it's visible to sandboxed tools."* And Codex docs confirm `[shell_environment_policy.set]` is "explicit environment overrides injected into every subprocess" — exactly the right knob.

## What this PR does

`install.sh` now writes a marker-bracketed block to `~/.codex/config.toml` after the existing permission-profile setup:

```toml
# AIRC-GH-TOKEN-START — managed by install.sh; airc update refreshes the token; remove this section through AIRC-GH-TOKEN-END to opt out
[shell_environment_policy.set]
GH_TOKEN = "<gh auth token output>"
# AIRC-GH-TOKEN-END
```

After Codex restart, sandboxed `gh` and `airc` invocations see GH_TOKEN in env and never depend on the keychain probe. The flake disappears.

**Idempotent + self-refreshing:** every install.sh run (incl `airc update`) strips any prior airc-managed block via sed range-delete and rewrites with the current `gh auth token` output. Token rotation just works.

**Composes with user config:** uses `[shell_environment_policy.set]` sub-table form (not inline `set = {...}`) so it doesn't conflict with user-defined parent keys like `inherit` or `include_only`.

**Opt-out:** `AIRC_SKIP_CODEX_TOKEN=1` skips the injection (for users who prefer to manage GH_TOKEN via shell alias / launcher / CI secret).

**uninstall.sh:** matching cleanup strips the marker-bracketed block when airc is removed.

## Trade-offs (documented in the codex README)

- Token is plaintext on disk in `~/.codex/config.toml`. Similar trust posture to `~/.codex/auth.json` which already holds the user's OpenAI credentials. Both are in the user's home dir at default 0600.
- When openai/codex#10695 lands the upstream fix, this injection becomes a no-op safety net rather than load-bearing.

## Joel's preferences ruled out
- PATH-shadowing `codex` ("major interference to man-in-the-middle codex")
- Manual launch one-liner ("yuck")
- Shellrc-exporting GH_TOKEN to every shell (security leak)

## Tested on this Mac
- Live install run → block written with real token, Codex starts cleanly
- Re-run → prior block replaced (no duplicate), token refreshed
- Uninstall flow → strips block cleanly without touching other config

## Test plan
- [x] Syntax check: `bash -n install.sh && bash -n uninstall.sh`
- [x] Live: install.sh on Codex-installed Mac → marker block lands with current token, codex exec starts (rc=0)
- [x] Idempotency: second install.sh run → block replaced, no duplicate
- [x] Token rotation: `gh auth refresh` → next install.sh picks up new token (verified by SHA-comparing the GH_TOKEN value before/after)
- [ ] End-to-end: Joel restarts Codex post-merge, runs `/join` in airc tab, expect successful mesh join (no token-invalid flake)
- [ ] CI: clean-install jobs pass (no Codex on runners; no-op for them)

## Related
- #364 (codex skill auto-install + permission profile) — foundation
- #366 (filesystem-block hotfix) — preceding stability fix
- #367 (skill-side diagnostic when Forbidden hits) — companion fix; deferred
- openai/codex#10695 (upstream bug) — when it lands, this PR's mechanism becomes redundant safety net

🤖 Generated with [Claude Code](https://claude.com/claude-code)