### PR TITLE
fix(connect+skill): trust running monitor over gh-auth-probe noise (closes #367)

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -236,6 +236,41 @@ cmd_connect() {
   done
   set -- "${positional[@]+"${positional[@]}"}"
 
+  # Trust-existing-monitor short-circuit. If a live airc process is
+  # already in this scope (per airc.pid with at least one alive PID),
+  # the user's intent ("airc join") is satisfied — there's nothing
+  # to do, and the gh-auth probe below would only generate noise (or
+  # worse, false-positive failures from a flaky gh probe in environments
+  # like Codex's sandbox; #367) on a scope that's already working.
+  #
+  # The gh-auth probe is meant to catch "user is about to do real work,
+  # let's make sure their gh credential is healthy first." If real work
+  # is ALREADY HAPPENING in this scope (live monitor → live bearer →
+  # live gh API calls), the running monitor's own health is the
+  # authoritative signal, not an out-of-band probe.
+  #
+  # The downstream "monitor is already running" message at the canonical
+  # detection point (post-arg-parse, lines ~440 below) is what the user
+  # actually wants. Hoist that detection here; on a hit, return 0 with
+  # the same message, before any preflight noise can fire.
+  local _early_pidfile="$AIRC_WRITE_DIR/airc.pid"
+  if [ -f "$_early_pidfile" ]; then
+    local _early_pids _early_alive=0 _p
+    _early_pids=$(cat "$_early_pidfile" 2>/dev/null | tr '\n' ' ')
+    for _p in $_early_pids; do
+      kill -0 "$_p" 2>/dev/null && _early_alive=1
+    done
+    if [ "$_early_alive" = "1" ]; then
+      echo "  airc connect: this scope's monitor is already running (PIDs: $_early_pids)."
+      echo "    To stop it:        airc teardown"
+      echo "    To restart it:     airc teardown && airc connect"
+      echo "    To check it:       airc status"
+      return 0
+    fi
+    # Stale pidfile (no live PIDs) — leave for the canonical cleanup
+    # block below to remove + proceed normally with the connect flow.
+  fi
+
   # Pre-flight: gh auth check. The gh keyring can silently invalidate
   # (token revoked / 2FA flow expired / brew upgrade replaced gh
   # without re-auth) and EVERY downstream gh API call then fails
@@ -250,6 +285,9 @@ cmd_connect() {
   # The CI clean-install smoke test specifically exercises that
   # offline path with no gh auth — pre-#338 the unconditional check
   # killed it before the host loop could start (PR #338 regression).
+  #
+  # Skipped entirely if a live monitor exists in this scope (handled
+  # by the trust-existing-monitor short-circuit above).
   if [ "$use_room" = "1" ] && command -v gh >/dev/null 2>&1; then
     if ! gh auth status >/dev/null 2>&1; then
       # `gh auth status` probes /user, which returns 403 during a GitHub

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -61,12 +61,20 @@ The principle: a Carl running `/join` should see `airc join` events and outcomes
 
 AIRC auto-detects the scope — if you're inside a git repo, identity lives at `<repo-root>/.airc/`; otherwise at `$PWD/.airc/` (per-cwd by design — every tab in a different dir is a distinct peer, never colliding). Set `AIRC_HOME=/path` to force a specific scope dir.
 
+### `airc status` is the ground truth — always trust it over noise
+
+Before reasoning about what to do next, **`airc status` is the authoritative signal** for whether this scope is in the mesh. It's a fast, local-only command (no gh probe, no network call). If it shows `monitor: running` and `bearer: <Ns> ago via gh` (or `bearer: n/a (this scope is hosting; ...)` for a host), the scope IS in the mesh, period. Anything else (gh-auth probe complaining, peers showing empty, /join saying "monitor already running") is downstream noise that doesn't override this fact.
+
+This matters because: gh-auth-status probes are inherently flaky in some environments (Codex's sandbox especially — see #341, #367, #368). `airc status` doesn't probe gh; it reads local state. When the two disagree, trust `airc status`.
+
 **Default — auto-scoped project room + #general sidecar:**
 ```
 Monitor(persistent=true, description="airc", command="airc join")
 ```
 
 Keep the Monitor `description` short and stable — `"airc"` is ideal.
+
+**If `airc join` exits cleanly with "this scope's monitor is already running"** — that's a successful no-op, NOT a failure. Run `airc status` once to confirm + narrate to the user: "already in the mesh as `<nick>` in `<rooms>`, host or joiner". Don't re-arm the Monitor (the existing process is already streaming events; arming a second Monitor would dual-tail the same scope). Done.
 
 Outcomes the monitor will print on its first events:
 - `Auto-scoped: #<room> (from git org; override with --room or AIRC_NO_AUTO_ROOM=1)` — the cwd's git remote owner picked the project room. Then either:


### PR DESCRIPTION
Closes #367. Joel's exact framing: "if the skill constantly causes this, it seems broken to everyone. do the most correct and robust [fix]."

## The user-visible bug
In environments where gh's auth probe is flaky (Codex sandbox especially — openai/codex#10695), `airc join`'s preflight hard-died with `"token invalid"` even when the scope's airc monitor was already running and bearer was actively reading/writing gh gists. The skill then reacted to the (wrong) token-invalid message by trying `gh auth login -w` — which also fails in the same flaky env — and Carl saw a multi-step debug-loop wreckage on a scope that was actually fine.

This was reproduced live during today's Codex first-encounter QA on Joel's rig, four times in a row.

## Two-layer fix

### LAYER 1 — `cmd_connect.sh` trust-existing-monitor short-circuit
Hoist the `"this scope's monitor is already running"` detection (which already lived ~200 lines below in cmd_connect) to **before** the gh-auth preflight. On a hit (live PID in `airc.pid`), emit the canonical message + return 0. The gh-auth preflight runs ONLY when no live monitor exists.

The gh-auth probe was always meant to catch *"user is about to do real work, ensure their gh credential is healthy first."* If real work is **already happening** in this scope (live monitor → live bearer → live gh API calls), the running monitor's own health is the authoritative signal, not an out-of-band probe.

Stale pidfile (file present, no live PIDs) falls through to the canonical cleanup block below — that path was already correct, no duplication.

### LAYER 2 — `/join` skill: `airc status` as ground truth
Adds a section telling the agent: **`airc status` is the authoritative signal** for whether this scope is in the mesh. Local-only — no gh probe, no network call. When gh-auth-status probes disagree with `airc status`, trust `airc status`.

Plus explicit handling for the `"monitor already running"` exit: that's a successful no-op, NOT a failure. Run `airc status` once to confirm + narrate `"already in the mesh as <nick> in <rooms>"`. Do NOT re-arm a Monitor (would dual-tail the same scope).

## Generalization
Both layers fix the Codex-sandbox-flake class AND the rate-limit-misreport class (#344-era) AND any future "gh probe noisy but airc actually works" class. The principle — **trust the operation's own state over out-of-band probes** — is durable.

## Tested on this Mac
With a live monitor in the scope:
```
$ airc status
  ... monitor: running (PID 53788) ...
$ airc join
  airc connect: this scope's monitor is already running (PIDs: 53788 54164 ...).
    To stop it:        airc teardown
    To restart it:     airc teardown && airc connect
    To check it:       airc status
$ echo $?
0
```
No gh-auth preflight ran. Before this change, the preflight always fired first; on flaky environments, that was the source of the cascade.

## Test plan
- [x] `bash -n cmd_connect.sh` syntax check
- [x] Live: with live monitor in scope, `airc join` short-circuits cleanly without gh-auth probe
- [ ] Live: Joel restarts Codex, runs `/join` from the airc skill — expect "already in the mesh" path (the prior Claude Code session in same dir established the host)
- [ ] Fresh scope (no monitor): preflight still runs as before; gh-auth-invalid case unchanged
- [ ] CI: clean-install + integration-suite (cluster A+B fixes already merged)

## Related
- Closes #367 (the deferred skill-side fix — now folded into the airc-binary fix at the right layer)
- Complements #344 (rate-limit disambiguation in the preflight that still fires when no monitor)
- Complements #368 (GH_TOKEN injection — still ships as no-op safety net for upstream openai/codex#10695)
- Companion to #353 (silent diagnose pattern in skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)