### PR TITLE
fix(status): fall back to bearer-state freshness when kill -0 is blind (closes #370)

### DIFF
--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -63,6 +63,17 @@ cmd_status() {
   # owns the contract: returns count of living pids and prunes dead orphans.
   # Both cmd_status and cmd_send call it so they can never disagree
   # again (the bug vhsm + authenticator hit 2026-04-29).
+  #
+  # Cross-sandbox blindness fallback (#370): inside Codex's sandbox,
+  # `kill -0 <pid>` for processes spawned outside the sandbox returns
+  # failure even when the process is alive. Result: prune_pidfile_and_count
+  # returns 0, status reports "not running" when the monitor IS running
+  # and visibly streaming events. Fix: when kill -0 returns all-dead BUT
+  # any bearer_state.<channel>.json file in scope has a fresh last_recv_ts
+  # (within 2x the reminder interval), the bearer recv loop is provably
+  # alive — a different process than the parent monitor, but in the same
+  # tree, and only a live monitor can be updating that file. Report alive
+  # via bearer-attested freshness instead of falsely reporting "not running".
   local monitor_state="not running"
   local pidfile="$AIRC_WRITE_DIR/airc.pid"
   local live_count
@@ -71,7 +82,43 @@ cmd_status() {
     local first_alive; first_alive=$(awk '{print $1}' "$pidfile" 2>/dev/null)
     monitor_state="running (PID $first_alive)"
   elif [ -f "$pidfile" ]; then
-    monitor_state="stale pidfile (no live PIDs — run 'airc connect' to self-heal)"
+    # Try the bearer-state freshness fallback before giving up. Walk all
+    # bearer_state.*.json files in the scope; if any has a last_recv_ts
+    # within the freshness window, the monitor's bearer-recv child is
+    # alive even though kill -0 didn't see it.
+    local _reminder_secs=300
+    [ -f "$AIRC_WRITE_DIR/reminder" ] && _reminder_secs=$(cat "$AIRC_WRITE_DIR/reminder" 2>/dev/null)
+    [ -z "$_reminder_secs" ] || ! [ "$_reminder_secs" -gt 0 ] 2>/dev/null && _reminder_secs=300
+    local _fresh_window=$((_reminder_secs * 2))
+    local _fresh_via_bearer=""
+    if ls "$AIRC_WRITE_DIR"/bearer_state.*.json >/dev/null 2>&1; then
+      _fresh_via_bearer=$("$AIRC_PYTHON" -c "
+import json, glob, sys, time
+window = $_fresh_window
+fresh = []
+for path in glob.glob('$AIRC_WRITE_DIR/bearer_state.*.json'):
+    try:
+        s = json.load(open(path))
+    except Exception:
+        continue
+    ts = s.get('last_recv_ts')
+    if ts is None:
+        continue
+    age = int(time.time() - float(ts))
+    if age <= window:
+        ch = path.split('bearer_state.', 1)[1].rsplit('.json', 1)[0]
+        fresh.append((age, ch))
+if fresh:
+    fresh.sort()
+    age, ch = fresh[0]
+    print(f'{age}s via #{ch}')
+" 2>/dev/null)
+    fi
+    if [ -n "$_fresh_via_bearer" ]; then
+      monitor_state="likely-alive ($_fresh_via_bearer; kill -0 blind in this sandbox — see #370)"
+    else
+      monitor_state="stale pidfile (no live PIDs — run 'airc connect' to self-heal)"
+    fi
   fi
   echo "  monitor:     $monitor_state"
 


### PR DESCRIPTION
Closes #370. Codex sandbox-friendly status reporting.

## The bug
Inside Codex's sandbox, \`kill -0 <pid>\` for processes spawned outside the sandbox returns failure even when the process is alive. \`prune_pidfile_and_count\` returns 0, status reports \`monitor: not running\` while the monitor IS running and visibly streaming events. Caught live during the Codex first-encounter QA — Codex was hosting \`#cambriantech\` as continuum-2c54 with bearer events flowing, but \`airc status\` claimed the monitor was dead.

Same root cause as openai/codex#10695 sandbox process isolation; also hits \`pgrep\` cross-tree (sysmon failure). airc isn't going to win against the sandbox boundary; it can route around it.

## Fix
When \`prune_pidfile_and_count\` returns 0 BUT a pidfile exists (so a monitor was started here at some point), look at the scope's \`bearer_state.<channel>.json\` files. If any has a \`last_recv_ts\` within 2x the reminder interval (default 600s), the bearer-recv child is provably alive — only a live monitor's bearer-recv loop updates that file. Report \`likely-alive (<Ns> via #<channel>; kill -0 blind in this sandbox — see #370)\` instead of the false \`not running\`.

Falls through to the existing \`stale pidfile\` message when bearer state is also stale (i.e., the monitor really IS dead, not just sandbox-invisible). So we don't lose the genuine-failure signal.

## Why this works for Codex's specific case
Codex was hosting \`#cambriantech\` (host scope, no bearer_state for project room — host writes locally). BUT it was also subscribed to \`#general\` as a sidecar, and the \`#general\` bearer-recv loop DOES update \`bearer_state.general.json\` regardless of host status. Even host-of-X scopes have recv state for any sidecar they're subscribed to. That's the key insight.

## Test plan
- [x] Syntax check: \`bash -n cmd_status.sh\`
- [x] Local: scope with no pidfile (e.g. Claude Code shell from \`/Users/joel/.airc-src/.airc\`) → still reports \`monitor: not running\` (pidfile-present is the gate; correct behavior preserved)
- [ ] Live in Codex: from continuum-2c54 scope, run \`airc status\` after merge → expect \`monitor: likely-alive (<Ns> via #general; kill -0 blind ...)\` instead of false \`not running\`
- [ ] Live in genuine-dead-monitor scope: kill the monitor via SIGKILL, wait > reminder interval, run airc status → still reports \`stale pidfile\` (bearer-state went stale, fallback doesn't fire)
- [ ] CI: 4 platforms

## Related
- #369 (just merged) trust-existing-monitor short-circuit on \`airc connect\` — same theme: trust local activity over flaky out-of-band probes
- #344 rate-limit-vs-auth diagnose — the original "noisy probe ≠ broken state" pattern
- openai/codex#10695 upstream Codex sandbox bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)