### PR TITLE
feat(install): pre-approve airc command prefix in Codex via [rules] block — final piece for friction-free Codex

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -804,6 +804,54 @@ if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
   _install_airc_codex_gh_token
 fi
 
+# ── Codex pre-approve airc command prefix ──────────────────────────────
+# Codex's per-command approval gate also restricts network access — a
+# command not in the user's "always run" allowlist runs in a stricter
+# sandbox where network is blocked. Joel's Codex first-encounter QA
+# hit this on `airc msg`: `airc join` had been pre-approved earlier so
+# its gh API calls reached the network, but `airc msg` hadn't, so its
+# gh API calls hit a network sandbox and failed. Codex prompted the
+# user to "always run commands that start with airc msg" and once
+# approved, it worked instantly.
+#
+# Codex supports declaring approved command prefixes statically in
+# config.toml's [rules] block (per Codex docs config-reference). Adding
+# `airc` as an allow-prefix pre-approves ALL airc verbs (join, msg,
+# status, peers, etc) so the user never sees the per-command approval
+# prompt cycle. Idempotent: only adds if not already present.
+#
+# Honors AIRC_SKIP_CODEX_RULES=1 if a user wants to manage approvals
+# manually.
+
+_install_airc_codex_command_rules() {
+  local config="$HOME/.codex/config.toml"
+  [ "${AIRC_SKIP_CODEX_RULES:-0}" = "1" ] && return 0
+  [ -f "$config" ] || return 0
+  if grep -qF 'AIRC-COMMAND-RULES-START' "$config" 2>/dev/null; then
+    return 0
+  fi
+  cat >> "$config" <<'TOML'
+
+# AIRC-COMMAND-RULES-START — managed by install.sh; pre-approves all
+# `airc *` commands so they aren't blocked by Codex's per-command approval
+# gate (which also restricts network access for un-approved commands).
+# Without this, only commands the user has manually approved-with-always
+# can reach the gist substrate; airc msg / airc status / etc would
+# silently fail in the sandbox until first-time approval. Remove this
+# block through AIRC-COMMAND-RULES-END to opt out.
+[rules]
+prefix_rules = [
+  { pattern = [{ token = "airc" }], decision = "allow" }
+]
+# AIRC-COMMAND-RULES-END
+TOML
+  ok "Codex airc-command pre-approval rule added to ~/.codex/config.toml — restart Codex to activate (no per-command approval prompts for airc verbs)"
+}
+
+if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
+  _install_airc_codex_command_rules
+fi
+
 
 # ── Done ────────────────────────────────────────────────────────────────
 

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -46,6 +46,23 @@ Codex's `[shell_environment_policy.set]` is documented as "explicit environment 
 
 When upstream openai/codex#10695 lands a fix that makes `dependency_env` propagate properly, this injection becomes a no-op safety net rather than a load-bearing workaround.
 
+## Per-command approval gate (Codex `[rules]` block)
+
+Codex's per-command approval gate doesn't just control prompts — **it also restricts network access** for un-approved commands. A command not in the user's "always run commands starting with X" allowlist runs in a stricter sandbox where its gh API calls are blocked. Caught live during the QA pass: `airc join` had been pre-approved earlier so its gh calls reached the network, but `airc msg` hadn't, so its gh calls hit the network sandbox and failed silently. Codex then prompted to approve `airc msg` with "always" — once approved, it worked instantly.
+
+Codex docs (config-reference) document a `[rules]` block with `prefix_rules` for declaring approved command prefixes statically. install.sh adds:
+
+```toml
+[rules]
+prefix_rules = [
+  { pattern = [{ token = "airc" }], decision = "allow" }
+]
+```
+
+This pre-approves ALL `airc *` verbs (join, msg, status, peers, etc.) so the user never sees the per-command approval cycle. Idempotent on re-runs. Set `AIRC_SKIP_CODEX_RULES=1` to opt out (e.g., if you'd rather grant approval interactively per-command).
+
+Combined with the GH_TOKEN injection above and the `[permissions.airc.network]` profile, Codex sessions get a fully-pre-configured airc surface — no manual flags, no approval-prompt friction, no keychain probe flakes.
+
 If you've already run install.sh on this machine for Claude Code and THEN install Codex, just re-run `airc update` (or the install one-liner again) — the next pass will detect Codex and add the Codex symlinks.
 
 ## 2. Verify the install

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -133,6 +133,12 @@ if [ -f "$codex_config" ]; then
     mv "$_tmp" "$codex_config"
     ok "Removed airc GH_TOKEN injection from $codex_config"
   fi
+  if grep -qF "AIRC-COMMAND-RULES-START" "$codex_config" 2>/dev/null; then
+    _tmp=$(mktemp)
+    sed '/^# AIRC-COMMAND-RULES-START/,/^# AIRC-COMMAND-RULES-END/d' "$codex_config" > "$_tmp"
+    mv "$_tmp" "$codex_config"
+    ok "Removed airc command-rules pre-approval from $codex_config"
+  fi
 fi
 
 # 4. Binary forwarders on PATH.


### PR DESCRIPTION
**Closes the per-command-approval-gate finding** that Codex's deep diagnostic surfaced in tonight's QA. With this merged, every Codex Carl gets a friction-free airc surface from first install — no per-command approval prompts, no manual flag-passing.

## What Codex's diagnostic uncovered
Codex's per-command approval gate **also restricts network access**, not just prompts. A command not in the user's "always run commands starting with X" allowlist runs in a stricter sandbox where its gh API calls are blocked silently. The pattern:

- \`airc join\` had been pre-approved early in the session → its gh calls reached the network → join succeeded
- \`airc msg\` hadn't been pre-approved → its gh calls hit the network sandbox → silent fail
- After Codex prompted + user approved \`airc msg\` with "always" → it worked instantly
- Same pattern for every other airc verb

## The fix
Codex's \`[rules]\` block (per [config-reference docs](https://developers.openai.com/codex/config-reference)) lets us declare approved command prefixes statically:

\`\`\`toml
# AIRC-COMMAND-RULES-START — managed by install.sh; pre-approves all
# `airc *` commands so they aren't blocked by Codex's per-command approval
# gate (which also restricts network access for un-approved commands).
[rules]
prefix_rules = [
  { pattern = [{ token = "airc" }], decision = "allow" }
]
# AIRC-COMMAND-RULES-END
\`\`\`

install.sh writes this idempotently to \`~/.codex/config.toml\` whenever Codex is detected. uninstall.sh strips it. \`AIRC_SKIP_CODEX_RULES=1\` opts out.

## Three Codex-side auto-config layers now compose
1. **\`[permissions.airc.network]\`** (#364) — scoped network access for github.com / api.github.com / gist.github.com
2. **\`[shell_environment_policy.set] GH_TOKEN\`** (#368) — injects gh token at session start, bypasses keychain probe flake
3. **\`[rules] prefix_rules = [{ token = "airc" }]\`** (this PR) — pre-approves every \`airc *\` verb so the network-aware sandbox doesn't gate them

User installs Codex + runs install.sh + restarts Codex → friction-free airc on first try.

## Tested on this Mac
- install.sh writes block (one line of output)
- Codex starts clean post-write
- Re-run idempotent (no-op, no duplicate)
- \`bash -n\` syntax check on both install.sh + uninstall.sh

## Joel's framing
> "if we get this, we can now have codex and decent claude code airc, fairly reliable into main"

This PR is that "this." After merge, the Codex story is shippable end-to-end without the per-command friction we hit tonight.

## Followup
- #372 (Codex agent auto-receive via pre-turn hook) — still queued; that's the LISTEN side of "Codex on the mesh like the others"

🤖 Generated with [Claude Code](https://claude.com/claude-code)