### PR TITLE
canary→main bundle 3: Codex parity (centralized monitor liveness + command-rule pre-approval)

### DIFF
--- a/airc
+++ b/airc
@@ -461,6 +461,80 @@ prune_pidfile_and_count() {
   if [ -z "$live" ]; then echo 0; else echo "$(printf '%s\n' $live | wc -w | tr -d ' ')"; fi
 }
 
+# Liveness check that's robust to sandbox process-tree blindness.
+# Returns "yes" if the monitor is alive, "no" otherwise. Two-phase:
+#
+#   1. kill -0 on PIDs in pidfile (the canonical, fast path)
+#   2. bearer-state-freshness fallback when (1) returns no live PIDs but
+#      a pidfile is present — covers Codex's sandbox where kill -0 across
+#      process trees returns false-negative even when the monitor's
+#      bearer-recv loop is provably writing to bearer_state.<channel>.json
+#      every poll cycle. #370/#371/#372 root cause.
+#
+# Pure read — does NOT prune the pidfile (which would silently corrupt
+# state when phase 1 was wrong about death). Use prune_pidfile_and_count
+# only when you genuinely want pids removed (e.g. teardown).
+#
+# Phase-2 freshness window = 2x the reminder interval (default 300s →
+# 600s window). bearer-state's last_recv_ts is the truth: it's only
+# updated when a bearer_recv subprocess actually reads from the wire.
+_monitor_alive_with_bearer_fallback() {
+  local pidfile="${1:-}"
+  local scope_dir
+  scope_dir=$(dirname "$pidfile")
+
+  # Phase 1: kill -0 (works in non-sandboxed shells; blind in Codex).
+  if [ -f "$pidfile" ]; then
+    local p raw
+    raw=$(cat "$pidfile" 2>/dev/null)
+    for p in $raw; do
+      case "$p" in ''|*[!0-9]*) continue ;; esac
+      if kill -0 "$p" 2>/dev/null; then
+        echo "yes"
+        return 0
+      fi
+    done
+  else
+    # No pidfile = monitor was never started (or already torn down).
+    # Bearer-state fallback would lie in this case (stale state file
+    # from a prior session). Return no without checking phase 2.
+    echo "no"
+    return 0
+  fi
+
+  # Phase 2: bearer-state-freshness fallback. Only reached when pidfile
+  # exists but kill -0 said all PIDs dead — could be real death, could
+  # be sandbox blindness. bearer-state freshness disambiguates.
+  local _reminder_secs=300
+  if [ -f "$scope_dir/reminder" ]; then
+    _reminder_secs=$(cat "$scope_dir/reminder" 2>/dev/null)
+  fi
+  if [ -z "$_reminder_secs" ] || ! [ "$_reminder_secs" -gt 0 ] 2>/dev/null; then
+    _reminder_secs=300
+  fi
+  local _fresh_window=$((_reminder_secs * 2))
+  if ls "$scope_dir"/bearer_state.*.json >/dev/null 2>&1; then
+    if "$AIRC_PYTHON" -c "
+import json, glob, sys, time
+window = $_fresh_window
+for path in glob.glob('$scope_dir/bearer_state.*.json'):
+    try:
+        s = json.load(open(path))
+    except Exception:
+        continue
+    ts = s.get('last_recv_ts')
+    if ts and (time.time() - float(ts)) <= window:
+        sys.exit(0)
+sys.exit(1)
+" 2>/dev/null; then
+      echo "yes"
+      return 0
+    fi
+  fi
+
+  echo "no"
+}
+
 # Validate a peer name matches the allowed nick charset BEFORE using it in
 # filesystem paths or remote SSH commands. Same charset cmd_rename uses
 # (a-z 0-9 -) — anything else is unreachable as a real airc identity and

--- a/install.sh
+++ b/install.sh
@@ -804,6 +804,54 @@ if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
   _install_airc_codex_gh_token
 fi
 
+# ── Codex pre-approve airc command prefix ──────────────────────────────
+# Codex's per-command approval gate also restricts network access — a
+# command not in the user's "always run" allowlist runs in a stricter
+# sandbox where network is blocked. Joel's Codex first-encounter QA
+# hit this on `airc msg`: `airc join` had been pre-approved earlier so
+# its gh API calls reached the network, but `airc msg` hadn't, so its
+# gh API calls hit a network sandbox and failed. Codex prompted the
+# user to "always run commands that start with airc msg" and once
+# approved, it worked instantly.
+#
+# Codex supports declaring approved command prefixes statically in
+# config.toml's [rules] block (per Codex docs config-reference). Adding
+# `airc` as an allow-prefix pre-approves ALL airc verbs (join, msg,
+# status, peers, etc) so the user never sees the per-command approval
+# prompt cycle. Idempotent: only adds if not already present.
+#
+# Honors AIRC_SKIP_CODEX_RULES=1 if a user wants to manage approvals
+# manually.
+
+_install_airc_codex_command_rules() {
+  local config="$HOME/.codex/config.toml"
+  [ "${AIRC_SKIP_CODEX_RULES:-0}" = "1" ] && return 0
+  [ -f "$config" ] || return 0
+  if grep -qF 'AIRC-COMMAND-RULES-START' "$config" 2>/dev/null; then
+    return 0
+  fi
+  cat >> "$config" <<'TOML'
+
+# AIRC-COMMAND-RULES-START — managed by install.sh; pre-approves all
+# `airc *` commands so they aren't blocked by Codex's per-command approval
+# gate (which also restricts network access for un-approved commands).
+# Without this, only commands the user has manually approved-with-always
+# can reach the gist substrate; airc msg / airc status / etc would
+# silently fail in the sandbox until first-time approval. Remove this
+# block through AIRC-COMMAND-RULES-END to opt out.
+[rules]
+prefix_rules = [
+  { pattern = [{ token = "airc" }], decision = "allow" }
+]
+# AIRC-COMMAND-RULES-END
+TOML
+  ok "Codex airc-command pre-approval rule added to ~/.codex/config.toml — restart Codex to activate (no per-command approval prompts for airc verbs)"
+}
+
+if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
+  _install_airc_codex_command_rules
+fi
+
 
 # ── Done ────────────────────────────────────────────────────────────────
 

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -46,6 +46,23 @@ Codex's `[shell_environment_policy.set]` is documented as "explicit environment 
 
 When upstream openai/codex#10695 lands a fix that makes `dependency_env` propagate properly, this injection becomes a no-op safety net rather than a load-bearing workaround.
 
+## Per-command approval gate (Codex `[rules]` block)
+
+Codex's per-command approval gate doesn't just control prompts — **it also restricts network access** for un-approved commands. A command not in the user's "always run commands starting with X" allowlist runs in a stricter sandbox where its gh API calls are blocked. Caught live during the QA pass: `airc join` had been pre-approved earlier so its gh calls reached the network, but `airc msg` hadn't, so its gh calls hit the network sandbox and failed silently. Codex then prompted to approve `airc msg` with "always" — once approved, it worked instantly.
+
+Codex docs (config-reference) document a `[rules]` block with `prefix_rules` for declaring approved command prefixes statically. install.sh adds:
+
+```toml
+[rules]
+prefix_rules = [
+  { pattern = [{ token = "airc" }], decision = "allow" }
+]
+```
+
+This pre-approves ALL `airc *` verbs (join, msg, status, peers, etc.) so the user never sees the per-command approval cycle. Idempotent on re-runs. Set `AIRC_SKIP_CODEX_RULES=1` to opt out (e.g., if you'd rather grant approval interactively per-command).
+
+Combined with the GH_TOKEN injection above and the `[permissions.airc.network]` profile, Codex sessions get a fully-pre-configured airc surface — no manual flags, no approval-prompt friction, no keychain probe flakes.
+
 If you've already run install.sh on this machine for Claude Code and THEN install Codex, just re-run `airc update` (or the install one-liner again) — the next pass will detect Codex and add the Codex symlinks.
 
 ## 2. Verify the install

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -236,40 +236,31 @@ cmd_connect() {
   done
   set -- "${positional[@]+"${positional[@]}"}"
 
-  # Trust-existing-monitor short-circuit. If a live airc process is
-  # already in this scope (per airc.pid with at least one alive PID),
-  # the user's intent ("airc join") is satisfied — there's nothing
-  # to do, and the gh-auth probe below would only generate noise (or
-  # worse, false-positive failures from a flaky gh probe in environments
-  # like Codex's sandbox; #367) on a scope that's already working.
+  # Trust-existing-monitor short-circuit (#369, sandbox-aware via
+  # _monitor_alive_with_bearer_fallback per #372). If a live airc
+  # process is already in this scope, the user's intent ("airc join")
+  # is satisfied — there's nothing to do, and the gh-auth probe below
+  # would only generate noise (or false-positive failures from flaky
+  # gh probes in environments like Codex's sandbox; #367) on a scope
+  # that's already working.
   #
-  # The gh-auth probe is meant to catch "user is about to do real work,
-  # let's make sure their gh credential is healthy first." If real work
-  # is ALREADY HAPPENING in this scope (live monitor → live bearer →
-  # live gh API calls), the running monitor's own health is the
-  # authoritative signal, not an out-of-band probe.
-  #
-  # The downstream "monitor is already running" message at the canonical
-  # detection point (post-arg-parse, lines ~440 below) is what the user
-  # actually wants. Hoist that detection here; on a hit, return 0 with
-  # the same message, before any preflight noise can fire.
+  # Pre-#372 this used naked kill -0 inline, which returned false on
+  # Codex (sandbox process-tree blindness) even when the monitor was
+  # provably alive (bearer-state.json updates every poll cycle).
+  # The shared helper checks bearer-state freshness as a fallback, so
+  # Codex sessions ALSO hit this short-circuit when their monitor
+  # is alive — exactly the Carl-experience win for cross-vendor mesh.
   local _early_pidfile="$AIRC_WRITE_DIR/airc.pid"
-  if [ -f "$_early_pidfile" ]; then
-    local _early_pids _early_alive=0 _p
-    _early_pids=$(cat "$_early_pidfile" 2>/dev/null | tr '\n' ' ')
-    for _p in $_early_pids; do
-      kill -0 "$_p" 2>/dev/null && _early_alive=1
-    done
-    if [ "$_early_alive" = "1" ]; then
-      echo "  airc connect: this scope's monitor is already running (PIDs: $_early_pids)."
-      echo "    To stop it:        airc teardown"
-      echo "    To restart it:     airc teardown && airc connect"
-      echo "    To check it:       airc status"
-      return 0
-    fi
-    # Stale pidfile (no live PIDs) — leave for the canonical cleanup
-    # block below to remove + proceed normally with the connect flow.
+  if [ "$(_monitor_alive_with_bearer_fallback "$_early_pidfile")" = "yes" ]; then
+    local _early_pids; _early_pids=$(cat "$_early_pidfile" 2>/dev/null | tr '\n' ' ')
+    echo "  airc connect: this scope's monitor is already running (PIDs: $_early_pids)."
+    echo "    To stop it:        airc teardown"
+    echo "    To restart it:     airc teardown && airc connect"
+    echo "    To check it:       airc status"
+    return 0
   fi
+  # Stale or absent pidfile — leave for the canonical cleanup block
+  # below to remove + proceed normally with the connect flow.
 
   # Pre-flight: gh auth check. The gh keyring can silently invalidate
   # (token revoked / 2FA flow expired / brew upgrade replaced gh

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -391,14 +391,19 @@ cmd_send() {
     # delivery, and the peer in the actual room waited forever for a
     # reply that never landed.
     #
-    # Detect monitor liveness via the shared prune_pidfile_and_count
-    # helper (airc top-level). Same contract as cmd_status — pre-fix
-    # this used all-alive logic while status used any-alive, so a
-    # pidfile with 1 stale orphan + 2 live processes showed "monitor:
-    # running" but every msg refused. Helper auto-prunes the orphan.
+    # Detect monitor liveness via the shared sandbox-robust helper
+    # (_monitor_alive_with_bearer_fallback in airc top-level). Same
+    # contract as cmd_status post-#371. Phase 1 = kill -0 (canonical);
+    # phase 2 = bearer-state freshness (covers Codex's sandbox where
+    # kill -0 is process-tree-blind even when bearer-recv is provably
+    # writing to bearer_state.<channel>.json). Pre-fix this used the
+    # naked prune_pidfile_and_count helper which would ALSO actively
+    # delete the pidfile when phase 1 was wrong about death — silently
+    # corrupting state inside Codex's sandbox. The new helper is read-
+    # only + sandbox-aware. #370/#371/#372 root cause cluster.
     local _pidfile="$AIRC_WRITE_DIR/airc.pid"
     local _monitor_alive=0
-    if [ "$(prune_pidfile_and_count "$_pidfile")" -gt 0 ]; then
+    if [ "$(_monitor_alive_with_bearer_fallback "$_pidfile")" = "yes" ]; then
       _monitor_alive=1
     fi
     if [ "$_monitor_alive" = "0" ]; then

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -59,42 +59,31 @@ cmd_status() {
     fi
   fi
 
-  # Monitor alive? Single helper at airc top-level (prune_pidfile_and_count)
-  # owns the contract: returns count of living pids and prunes dead orphans.
-  # Both cmd_status and cmd_send call it so they can never disagree
-  # again (the bug vhsm + authenticator hit 2026-04-29).
-  #
-  # Cross-sandbox blindness fallback (#370): inside Codex's sandbox,
-  # `kill -0 <pid>` for processes spawned outside the sandbox returns
-  # failure even when the process is alive. Result: prune_pidfile_and_count
-  # returns 0, status reports "not running" when the monitor IS running
-  # and visibly streaming events. Fix: when kill -0 returns all-dead BUT
-  # any bearer_state.<channel>.json file in scope has a fresh last_recv_ts
-  # (within 2x the reminder interval), the bearer recv loop is provably
-  # alive — a different process than the parent monitor, but in the same
-  # tree, and only a live monitor can be updating that file. Report alive
-  # via bearer-attested freshness instead of falsely reporting "not running".
+  # Monitor alive? Use the shared sandbox-robust helper
+  # (_monitor_alive_with_bearer_fallback in airc top-level). Phase 1 =
+  # kill -0 against airc.pid (canonical, fast); phase 2 = bearer-state
+  # freshness fallback (covers Codex sandbox kill -0 blindness — see
+  # #370/#371/#372). The helper is read-only (doesn't prune the pidfile
+  # the way the older prune_pidfile_and_count did, which would silently
+  # corrupt state when phase 1 was wrong).
   local monitor_state="not running"
   local pidfile="$AIRC_WRITE_DIR/airc.pid"
-  local live_count
-  live_count=$(prune_pidfile_and_count "$pidfile")
-  if [ "$live_count" -gt 0 ]; then
-    local first_alive; first_alive=$(awk '{print $1}' "$pidfile" 2>/dev/null)
-    monitor_state="running (PID $first_alive)"
-  elif [ -f "$pidfile" ]; then
-    # Try the bearer-state freshness fallback before giving up. Walk all
-    # bearer_state.*.json files in the scope; if any has a last_recv_ts
-    # within the freshness window, the monitor's bearer-recv child is
-    # alive even though kill -0 didn't see it.
-    local _reminder_secs=300
-    [ -f "$AIRC_WRITE_DIR/reminder" ] && _reminder_secs=$(cat "$AIRC_WRITE_DIR/reminder" 2>/dev/null)
-    [ -z "$_reminder_secs" ] || ! [ "$_reminder_secs" -gt 0 ] 2>/dev/null && _reminder_secs=300
-    local _fresh_window=$((_reminder_secs * 2))
-    local _fresh_via_bearer=""
-    if ls "$AIRC_WRITE_DIR"/bearer_state.*.json >/dev/null 2>&1; then
-      _fresh_via_bearer=$("$AIRC_PYTHON" -c "
-import json, glob, sys, time
-window = $_fresh_window
+  if [ "$(_monitor_alive_with_bearer_fallback "$pidfile")" = "yes" ]; then
+    if [ -f "$pidfile" ]; then
+      local first_alive; first_alive=$(awk '{print $1}' "$pidfile" 2>/dev/null)
+      # Distinguish "alive per kill -0" (we have a verified PID) from
+      # "alive per bearer-state-only" (kill -0 blind, but bearer-recv
+      # child is provably writing to bearer_state). For the latter,
+      # surface the diagnostic so a Carl debugging "why does pid X
+      # show running when it's not in ps" has the answer.
+      if kill -0 "$first_alive" 2>/dev/null; then
+        monitor_state="running (PID $first_alive)"
+      else
+        # Walk bearer_state to find which channel is freshest, for the
+        # informational message. (The helper already proved freshness;
+        # we re-check just to extract the age + channel name.)
+        local _bs_summary; _bs_summary=$("$AIRC_PYTHON" -c "
+import json, glob, time
 fresh = []
 for path in glob.glob('$AIRC_WRITE_DIR/bearer_state.*.json'):
     try:
@@ -102,23 +91,19 @@ for path in glob.glob('$AIRC_WRITE_DIR/bearer_state.*.json'):
     except Exception:
         continue
     ts = s.get('last_recv_ts')
-    if ts is None:
-        continue
-    age = int(time.time() - float(ts))
-    if age <= window:
+    if ts:
         ch = path.split('bearer_state.', 1)[1].rsplit('.json', 1)[0]
-        fresh.append((age, ch))
+        fresh.append((int(time.time() - float(ts)), ch))
 if fresh:
     fresh.sort()
     age, ch = fresh[0]
     print(f'{age}s via #{ch}')
 " 2>/dev/null)
+        monitor_state="likely-alive (${_bs_summary:-bearer-state fresh}; kill -0 blind in this sandbox — see #370)"
+      fi
     fi
-    if [ -n "$_fresh_via_bearer" ]; then
-      monitor_state="likely-alive ($_fresh_via_bearer; kill -0 blind in this sandbox — see #370)"
-    else
-      monitor_state="stale pidfile (no live PIDs — run 'airc connect' to self-heal)"
-    fi
+  elif [ -f "$pidfile" ]; then
+    monitor_state="stale pidfile (no live PIDs — run 'airc connect' to self-heal)"
   fi
   echo "  monitor:     $monitor_state"
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -133,6 +133,12 @@ if [ -f "$codex_config" ]; then
     mv "$_tmp" "$codex_config"
     ok "Removed airc GH_TOKEN injection from $codex_config"
   fi
+  if grep -qF "AIRC-COMMAND-RULES-START" "$codex_config" 2>/dev/null; then
+    _tmp=$(mktemp)
+    sed '/^# AIRC-COMMAND-RULES-START/,/^# AIRC-COMMAND-RULES-END/d' "$codex_config" > "$_tmp"
+    mv "$_tmp" "$codex_config"
+    ok "Removed airc command-rules pre-approval from $codex_config"
+  fi
 fi
 
 # 4. Binary forwarders on PATH.


### PR DESCRIPTION
Third canary→main bundle of the day. Tight scope: the two Codex-parity follow-ups from tonight's deep QA.

## Bundled fixes (2 PRs)

- **#374** — \`fix(monitor-liveness): centralize via _monitor_alive_with_bearer_fallback (generalizes #371 to cmd_send + cmd_connect)\`. Extracts the bearer-state-freshness fallback into a shared airc-top-level helper. cmd_send + cmd_status + cmd_connect's #369 short-circuit all now use it. Codex's airc msg / airc connect work without hitting false "monitor isn't running" refusals from sandbox-blind kill -0.
- **#375** — \`feat(install): pre-approve airc command prefix in Codex via [rules] block — final piece for friction-free Codex\`. install.sh now writes a \`[rules] prefix_rules = [{ token = "airc" }]\` block to ~/.codex/config.toml, pre-approving every airc verb so Codex's per-command approval gate doesn't silently block their network access.

## Net effect
Combined with bundle 2 (#349, #350, #356, #361 etc):

- ✅ Fresh-Mac Carl install path solid (Claude Code AND Codex)
- ✅ Codex auto-config: skill symlinks + permission profile + GH_TOKEN injection + command-rules pre-approval — friction-free first-encounter
- ✅ Cross-vendor mesh proven (Codex + Claude Code peer-to-peer over gist substrate, real bidirectional comms tonight)

## Carl story end-to-end
Curl-install on a fresh Mac (LibreSSL only, no brew openssl, no Codex pre-config) → install.sh handles every prereq, gh auth, skills, Codex config — user runs codex, types /join, lands in the mesh. No friction prompts, no manual flags.

## Known followups (queued, all tracked)
- **#347** mesh-takeover blanks identity block
- **#357** stale-skill-cache drift detection
- **#358** DM E2EE silent plaintext fallback (A+B+C framing)
- **#359** monitor 600-char truncation
- **#372** Codex agent auto-receive surface (pre-turn hook recommended by mesh)
- **#373** integration-suite joiner failures (test-rig-specific, not real-user regression)
- **openai/codex#10695** upstream Codex sandbox bug — when fixed, our #368/#374/#375 workarounds become safety net

## Required gates
4 platforms green on each constituent PR. Integration-suite expected red per the documented #351 known-issue (cluster A+B fixed real regressions; remaining failures are scenario-specific test rig issues — separate from the real-user paths which are validated via clean-install + live mesh exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)