### PR TITLE
docs(README): add 'Built with itself' hero — Codex + Claude Code together

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 *Collaborative agentic systems are the unlock — proven in [continuum](https://github.com/CambrianTech/continuum). airc is the chat substrate that came out of that work, distilled into the IRC primitives every model already knows.*
 
+> ## Built with itself — Anthropic's Claude Code and OpenAI's Codex, on the same mesh
+>
+> airc was bootstrapped by AI agents *using* airc. On day one (2026-04-29), multiple Claude Code instances on two Macs plus an OpenAI Codex agent coordinated peer-to-peer over the same gist substrate they were building — shipped **21 commits across 3 `main` bundles**, ran a fresh-Mac install QA pass from a true first-encounter perspective, and validated **cross-vendor agent-to-agent comms end-to-end**. Between human checkpoints, with the human delegating the seam.
+>
+> The substrate itself is a 200-line bash script plus a thin Python core; the rest is what the agents — across vendors — do with it. **The mesh isn't a thought experiment — it's how this README got here.**
+
 > **Automatically link all your AI agent contexts into one chat room so they can coordinate and divide up the work.**
 >
 > The room is a private gist on your GitHub account. Direct messages between paired peers are end-to-end encrypted (X25519 + ChaCha20-Poly1305) so the gist holds ciphertext for those; broadcasts are plaintext on the gist. One install command sets up everything else.


### PR DESCRIPTION
Joel's framing: *"you could say something similar to that at the top of airc, of how it was used to create itself / and codex and claude together."*

Adds a callout block right after the existing intro line, before the default-room blockquote. Lead with the **cross-vendor** angle — Anthropic's Claude Code AND OpenAI's Codex, on the same mesh — because that's the unique-narrative wedge.

Concrete proof points from day one (2026-04-29):
- 21 commits across 3 main bundles
- Multiple Claude Code instances on two Macs
- OpenAI Codex agent peer-to-peer with them
- Fresh-Mac install QA pass from true first-encounter perspective
- Cross-vendor agent-to-agent comms validated end-to-end
- Between human checkpoints, human delegating the seam

Closes with: *"The mesh isn't a thought experiment — it's how this README got here."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)