### PR TITLE
fix(monitor): disable no-inbound watchdog in host mode (#383)

### DIFF
--- a/lib/airc_core/monitor_formatter.py
+++ b/lib/airc_core/monitor_formatter.py
@@ -194,23 +194,31 @@ def run(my_name: str, peers_dir: str) -> int:
     local_log = os.path.join(scope_dir, "messages.jsonl")
     offset_path = os.path.join(scope_dir, "monitor_offset")
 
-    # Only mirror inbound to the local log when we are a joiner (tailing a
-    # REMOTE host over SSH). For a HOST, the local log IS the source the
-    # tail reads from — mirroring creates an infinite feedback loop.
+    # Host vs joiner detection drives the watchdog gate below. host_target
+    # empty = we are the host (we publish the room gist; joiners poll us);
+    # host_target set = we are a joiner (we poll the host's gist).
     is_joiner = False
     try:
         is_joiner = bool(json.load(open(config_path)).get("host_target", ""))
     except Exception:
         pass
 
-    # Watchdog stays armed for both hosts and joiners. Pre-fix it was
-    # disabled for hosts because there was no inbound traffic during
-    # idle and the alarm would trip every 150s. Post bearer-heartbeat
-    # (bearer_cli emits a sentinel line every AIRC_BEARER_HEARTBEAT_SEC
-    # whether the bearer yielded events or not), idle is no longer
-    # silent — heartbeats keep the watchdog re-armed. Stuck bearers
-    # produce no heartbeats, so the watchdog correctly trips and the
-    # bash multi-channel watcher respawns the recv pipe.
+    # #383: disable the no-inbound watchdog in host mode. The watchdog's
+    # original purpose is to catch joiner bearer-poll loops that hang
+    # silently (gh API stuck, middlebox dropping idle TCP) — that failure
+    # shape exists for joiners, not hosts. Hosts don't poll a remote;
+    # they serve writes, and "no inbound for 150s" is normal during quiet
+    # periods (overnight, weekends). The previous "heartbeats keep the
+    # watchdog re-armed" theory broke in field use: daemon mode runs
+    # `airc connect` in $HOME/.airc with KeepAlive, the watchdog tripped
+    # every 150s, launchctl re-spawned, ~1500-2000 spawns over 8 hours
+    # with last_exit_code=1 reported as "running" but never serving
+    # messages. Real host failures (bearer death, gh auth death) are
+    # caught independently — bash _monitor_multi_channel polls each
+    # bearer's child PID and respawns on death, so process-level signals
+    # still propagate.
+    if not is_joiner:
+        _disable_watchdog()
 
     # Room name for the chat-line prefix. Read once at startup; a rename
     # of the room would require a fresh airc connect to pick up. Default

--- a/test/test_monitor_formatter.py
+++ b/test/test_monitor_formatter.py
@@ -127,6 +127,73 @@ class AutoPongTests(unittest.TestCase):
         self.assertEqual(popens, [], "broadcast ping must not auto-pong")
 
 
+class HostModeWatchdogTests(unittest.TestCase):
+    """#383: the no-inbound watchdog must be disabled in host mode.
+
+    Without this gate, a daemon-launched `airc connect` in $HOME/.airc
+    (no host_target = host mode) trips the 150s watchdog every quiet
+    interval, launchctl re-spawns, and the daemon thrashes with
+    last_exit_code=1 while never actually serving messages.
+    """
+
+    def setUp(self):
+        self._scope = tempfile.mkdtemp(prefix="airc-mf-wd-test-")
+        self._peers = os.path.join(self._scope, "peers")
+        os.makedirs(self._peers, exist_ok=True)
+        # Re-arm the module-level flag in case a prior test disabled it.
+        mf._watchdog_active = True
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._scope, ignore_errors=True)
+        mf._watchdog_active = True
+
+    def _write_config(self, host_target):
+        cfg = {"name": "alice"}
+        if host_target:
+            cfg["host_target"] = host_target
+        with open(os.path.join(self._scope, "config.json"), "w") as f:
+            json.dump(cfg, f)
+
+    def _run_empty_stdin(self):
+        with mock.patch.object(mf.sys, "stdin", io.StringIO("")), \
+             mock.patch.object(mf.sys, "stdout", io.StringIO()):
+            mf.run("alice", self._peers)
+
+    def test_host_mode_disables_watchdog(self):
+        # Host mode = config has no host_target.
+        self._write_config(host_target=None)
+        with mock.patch.object(mf, "_disable_watchdog", wraps=mf._disable_watchdog) as spy:
+            self._run_empty_stdin()
+            self.assertEqual(spy.call_count, 1,
+                             "host mode must call _disable_watchdog exactly once")
+        self.assertFalse(mf._watchdog_active,
+                         "watchdog must be inactive after host-mode run()")
+
+    def test_joiner_mode_keeps_watchdog_armed(self):
+        # Joiner mode = config carries a non-empty host_target.
+        self._write_config(host_target="user@10.0.0.5")
+        with mock.patch.object(mf, "_disable_watchdog", wraps=mf._disable_watchdog) as spy:
+            self._run_empty_stdin()
+            self.assertEqual(spy.call_count, 0,
+                             "joiner mode must not call _disable_watchdog")
+        self.assertTrue(mf._watchdog_active,
+                        "watchdog must remain active after joiner-mode run()")
+
+    def test_missing_config_treated_as_host_mode(self):
+        # No config.json at all (transient startup window before cmd_join
+        # writes one) — fall through to host mode (is_joiner=False), which
+        # disables the watchdog. Conservative: a missing config is more
+        # often a fresh host than a joiner with corrupted state, and
+        # disabling the watchdog only loses an early-warning probe; real
+        # bearer death is still caught by the bash retry loop.
+        # (No _write_config call.)
+        with mock.patch.object(mf, "_disable_watchdog", wraps=mf._disable_watchdog) as spy:
+            self._run_empty_stdin()
+            self.assertEqual(spy.call_count, 1,
+                             "missing config must default to host-mode behavior")
+
+
 class HeartbeatSuppressionTests(unittest.TestCase):
     """bearer_cli heartbeat lines must be recognized + suppressed +
     arm the watchdog. Display would clutter chat with airc_heartbeat


### PR DESCRIPTION
## Summary

- Daemon-installed `airc connect` in `$HOME/.airc` thrashes (~1500-2000 launchctl re-spawns over 8h, `last_exit_code=1` reported as "running") because the 150s no-inbound watchdog fires every quiet period.
- Watchdog's purpose is catching joiner bearer-poll hangs (gh API stuck, middlebox idle-drop). Hosts don't poll — "no inbound for 150s" is normal idle, not a failure signal.
- Wires the already-computed (but dead-code) `is_joiner` to the already-existing `_disable_watchdog()` helper. Joiner mode keeps full watchdog. Real host failures (bearer death, gh auth death) still caught by `_monitor_multi_channel`'s per-child PID watch + bash retry loop.

Closes #383.

## What changed

`lib/airc_core/monitor_formatter.py`:
- `is_joiner` was set then never used (vestige of an earlier mirror conditional). Repurpose it to gate the watchdog.
- Comment block at lines 206-213 (the "heartbeats keep watchdog re-armed" theory) replaced with the post-#383 reasoning + field evidence.
- One new line: `if not is_joiner: _disable_watchdog()`.

`test/test_monitor_formatter.py`:
- New `HostModeWatchdogTests` class with three cases:
  - host mode disables watchdog (one call, flag false)
  - joiner mode keeps watchdog armed (zero calls, flag true)
  - missing config defaults to host-mode (conservative)

Net: 30 lines changed in monitor_formatter.py (mostly comment swap), 67 lines added in test file.

## Why not the more sophisticated fix?

Issue #383 also outlined a richer host-mode probe (bearer-state mtime + pending.jsonl growth + gh auth check). That's the right design eventually but adds new cross-file plumbing for failure-modes the bash retry loop already catches. Going with the issue's "or simpler: just disable in host mode" path — less code, less risk, fixes the immediate thrash bug.

If we observe a new failure shape post-merge that the formatter watchdog *would* have caught for a host, the richer probe is the right follow-up.

## Test plan

- [x] `python3 test/test_monitor_formatter.py` — 8 tests pass (3 new + 5 existing)
- [x] `python3 test/test_bearer.py` — 68 tests pass (no regression in adjacent module)
- [x] `python3 test/test_channel_gist.py` — 5 tests pass
- [ ] Field validation: re-run `airc daemon install` on Joel's primary Mac, observe `airc daemon status` shows healthy `last_exit_code=0` and stays alive across a 200s+ quiet window
- [ ] CI integration suite (will run on push)

## Coordination context

This is the 2026-04-30 morning Mac/Claude bug sweep, layered with #381 (continuum-b741, layer A) + #382 (continuum-2c54). Together: silent-send-drop fixed, daemon discoverability surfaced, daemon actually keeps the mesh alive instead of thrashing.

Mesh: airc-src-a500 (carl-mac, claude-code-opus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)