### PR TITLE
fix(#381 layer B): host-side queue/drain symmetry for transient gist failures

### DIFF
--- a/airc
+++ b/airc
@@ -1139,6 +1139,22 @@ monitor() {
   if [ -n "$_ht" ]; then
     ( flush_pending_loop ) &
     _flush_pid=$!
+  else
+    # Host mode — spawn the host-side mirror loop. Same pidfile-honesty
+    # rule as the joiner branch above: only spawn when there's a
+    # publishable route (channel_gists OR legacy room_gist_id), otherwise
+    # the subshell exits immediately and airc.pid lists a dead PID.
+    local _has_pub=0
+    if "$AIRC_PYTHON" -m airc_core.config list_channel_gists --config "$CONFIG" 2>/dev/null | grep -q .; then
+      _has_pub=1
+    fi
+    if [ "$_has_pub" = "0" ] && [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
+      _has_pub=1
+    fi
+    if [ "$_has_pub" = "1" ]; then
+      ( flush_pending_host_loop ) &
+      _flush_pid=$!
+    fi
   fi
   # Build the appended PID list — only include _flush_pid when we
   # actually spawned it.
@@ -1336,6 +1352,164 @@ flush_pending_loop() {
       drain_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[DRAINED %d queued message(s) to host]"}' \
         "$(timestamp)" "$_drain_chan" "$delivered")
       echo "$drain_marker" >> "$MESSAGES"
+    fi
+
+    rm -f "$snapshot" "$unsent" 2>/dev/null
+  done
+}
+
+# Host-side mirror of flush_pending_loop. Drains pending.jsonl via gist
+# publish (bearer_cli send) instead of SSH push to a host. Symmetric to the
+# joiner-side loop above so host-side cmd_send can queue on transient gist
+# failure without dropping the broadcast on the floor (#381 layer B).
+#
+# Pre-fix: host-side cmd_send had no queue path at all — gist publish
+# failure printed a warning and exited 0, with the message permanently
+# lost from peers' POV. This loop closes the gap: cmd_send writes to
+# pending.jsonl on transient_failure; this loop replays those lines on
+# the same 5s tick the joiner uses, retrying until gh API recovers or
+# the user tears down.
+flush_pending_host_loop() {
+  local pending="$AIRC_WRITE_DIR/pending.jsonl"
+  local host_target; host_target=$(get_config_val host_target "")
+  # Joiner-mode handled by flush_pending_loop; we're host-only.
+  [ -n "$host_target" ] && return 0
+
+  # Standalone (--no-gist) hosts have no publishable route. Self-check
+  # at startup so the spawn site can rely on a quick return when nothing
+  # to do, mirroring the joiner-side host_target gate.
+  local _has_route=0
+  if "$AIRC_PYTHON" -m airc_core.config list_channel_gists --config "$CONFIG" 2>/dev/null | grep -q .; then
+    _has_route=1
+  fi
+  if [ "$_has_route" = "0" ] && [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
+    _has_route=1
+  fi
+  [ "$_has_route" = "0" ] && return 0
+
+  # Parent-liveness gate (#324 follow-up — same orphan-subshell rationale
+  # as flush_pending_loop above). Without this the loop survives parent
+  # death and keeps publishing to dead-scope state forever.
+  local _parent_pid="$PPID"
+
+  while true; do
+    sleep 5
+    if ! kill -0 "$_parent_pid" 2>/dev/null; then
+      return 0
+    fi
+    [ -s "$pending" ] || continue
+
+    local snapshot; snapshot=$(mktemp -t airc-pending-host-snap.XXXXXX)
+    local unsent;   unsent=$(mktemp -t airc-pending-host-unsent.XXXXXX)
+    # Atomic-ish snapshot: mv is atomic on same FS so concurrent cmd_send
+    # invocations during drain land in a fresh pending.jsonl.
+    mv "$pending" "$snapshot" 2>/dev/null || { rm -f "$snapshot" "$unsent"; continue; }
+
+    local delivered=0 failed=0
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+
+      # Extract channel from the queued line (plaintext signed JSON,
+      # never the wrapped envelope — cmd_send queues pre-wrap so the
+      # drain can re-resolve recipient pubkey at retry time).
+      local _line_channel
+      _line_channel=$(printf '%s\n' "$line" | "$AIRC_PYTHON" -c 'import json,sys
+try:
+  print(json.loads(sys.stdin.readline()).get("channel",""))
+except Exception:
+  print("")' 2>/dev/null)
+
+      # Resolve channel → gist. Fall back to legacy room_gist_id only
+      # when the line carries no channel (older queued lines may pre-date
+      # the channel field).
+      local _line_gist=""
+      if [ -n "$_line_channel" ]; then
+        _line_gist=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
+          --config "$CONFIG" --channel "$_line_channel" 2>/dev/null || true)
+      fi
+      if [ -z "$_line_gist" ] && [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
+        _line_gist=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
+      fi
+      if [ -z "$_line_gist" ]; then
+        # No route — keep in pending; channel_gists may populate later
+        # via 'airc join --room <name>'.
+        echo "$line" >> "$unsent"
+        failed=$((failed + 1))
+        continue
+      fi
+
+      # Re-resolve recipient pubkey at drain time. Pre-pair queued lines
+      # shipped plaintext; post-pair drain wraps them with the new pubkey.
+      local _line_to
+      _line_to=$(printf '%s\n' "$line" | "$AIRC_PYTHON" -c 'import json,sys
+try:
+  print(json.loads(sys.stdin.readline()).get("to",""))
+except Exception:
+  print("")' 2>/dev/null)
+      local _line_pub=""
+      if [ -n "$_line_to" ] && [ "$_line_to" != "all" ]; then
+        _line_pub=$("$AIRC_PYTHON" -m airc_core.identity peer_pub \
+          --peers-dir "$PEERS_DIR" --peer-name "$_line_to" 2>/dev/null || true)
+      fi
+      local _wire="$line"
+      if [ -n "$_line_pub" ]; then
+        _wire=$(printf '%s' "$line" | "$AIRC_PYTHON" -m airc_core.envelope wrap \
+          --recipient-pub "$_line_pub" \
+          --identity-dir "$IDENTITY_DIR" 2>/dev/null || printf '%s' "$line")
+      fi
+
+      local _outcome _kind
+      _outcome=$(printf '%s' "$_wire" | "$AIRC_PYTHON" -m airc_core.bearer_cli send \
+        "${_line_to:-all}" "$_line_channel" \
+        --room-gist-id "$_line_gist" 2>/dev/null || echo '{"kind":"transient_failure"}')
+      _kind=$(printf '%s' "$_outcome" | "$AIRC_PYTHON" -c 'import json,sys
+try:
+  print(json.load(sys.stdin).get("kind",""))
+except Exception:
+  print("")' 2>/dev/null)
+
+      case "$_kind" in
+        delivered)
+          # Append the now-delivered original line to local audit log.
+          # cmd_send.sh's transient_failure branch withheld this write
+          # specifically so the user's chat widget wouldn't echo a
+          # message that hadn't actually shipped (the false-success
+          # bug from #381 RCA). Drain confirms delivery → safe to
+          # reflect in the local log.
+          echo "$line" >> "$MESSAGES"
+          delivered=$((delivered + 1))
+          ;;
+        *)
+          # transient_failure / auth_failure / unknown — keep queued.
+          # auth_failure here is awkward (can't fix without user re-auth)
+          # but the next cmd_send invocation will surface it loudly via
+          # the auth_failure case + die. We don't want a background loop
+          # to die or block on auth state.
+          echo "$line" >> "$unsent"
+          failed=$((failed + 1))
+          ;;
+      esac
+    done < "$snapshot"
+
+    # Prepend failures back to head of pending so they retry first on
+    # next iteration (mirror joiner-side flow).
+    if [ -s "$unsent" ]; then
+      if [ -s "$pending" ]; then
+        cat "$unsent" "$pending" > "${pending}.new" && mv "${pending}.new" "$pending"
+      else
+        mv "$unsent" "$pending"
+        unsent=""
+      fi
+    fi
+
+    if [ "$delivered" -gt 0 ]; then
+      local _drain_chan="general"
+      [ -f "$AIRC_WRITE_DIR/room_name" ] && _drain_chan=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null || echo general)
+      [ -z "$_drain_chan" ] && _drain_chan="general"
+      local _drain_marker
+      _drain_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[DRAINED %d queued message(s) via gist publish]"}' \
+        "$(timestamp)" "$_drain_chan" "$delivered")
+      echo "$_drain_marker" >> "$MESSAGES"
     fi
 
     rm -f "$snapshot" "$unsent" 2>/dev/null

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -436,9 +436,6 @@ cmd_send() {
       die "monitor down — refusing to silently broadcast into a void"
     fi
 
-    # Local audit log — plaintext, the user's own record of what they sent.
-    echo "$full_msg" >> "$MESSAGES"
-
     # Phase 3c critical fix (#285): host-side cmd_send must ALSO publish
     # to the room gist so joiners (who poll the gist via GhBearer) see
     # broadcasts and DMs from the host. Pre-3c, joiners tailed the host's
@@ -484,17 +481,59 @@ cmd_send() {
       _host_outcome=$(printf '%s' "$_host_wire_msg" | "$AIRC_PYTHON" -m airc_core.bearer_cli send \
         "$peer_name" "$active_channel" \
         --room-gist-id "$_host_room_gist_id")
-      local _host_kind
+      local _host_kind _host_detail
       _host_kind=$(printf '%s' "$_host_outcome" | "$AIRC_PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("kind",""))' 2>/dev/null)
+      _host_detail=$(printf '%s' "$_host_outcome" | "$AIRC_PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("detail",""))' 2>/dev/null)
       case "$_host_kind" in
-        delivered) : ;;
+        delivered)
+          # Append to local audit log only on confirmed delivery. Pre-fix
+          # this happened unconditionally before the publish attempt, so
+          # the user's own monitor would echo their message back even when
+          # joiners never saw it — false success surface (#381 RCA).
+          echo "$full_msg" >> "$MESSAGES"
+          ;;
+        auth_failure)
+          # Hard failure mirror of joiner branch above. Don't queue —
+          # every retry hits the same dead token. Surface re-auth path
+          # loudly + die so the caller knows to fix gh before retrying.
+          local _host_fail_marker; _host_fail_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[GH AUTH FAILED on host gist publish — re-auth required, NOT queued] %s"}' \
+            "$(timestamp)" "$active_channel" "${_host_detail:-no detail}")
+          echo "$_host_fail_marker" >> "$MESSAGES"
+          echo "" >&2
+          echo "  ✗ gh auth check failed during host gist publish — your GitHub token is dead." >&2
+          echo "    Bearer detail: ${_host_detail}" >&2
+          echo "" >&2
+          echo "    Fix:  gh auth login -h github.com" >&2
+          echo "" >&2
+          echo "    After re-authenticating, retry. No state lost — it's just gh's keyring that expired." >&2
+          die "gh auth failure on host gist publish — run 'gh auth login -h github.com' and retry"
+          ;;
+        transient_failure|"")
+          # Mirror joiner-side queue/drain symmetry (#381 layer B). Pre-fix
+          # the host branch printed a warning + dropped the message on
+          # the floor: exit 0 with the broadcast never reaching peers.
+          # Now the message goes to pending.jsonl + a [QUEUED] marker
+          # surfaces in the user's own log so the chat widget reads
+          # 'queued for retry' instead of 'sent successfully'.
+          # flush_pending_host_loop (in airc top-level) drains this on
+          # the same 5s tick joiners use.
+          echo "$full_msg" >> "$AIRC_WRITE_DIR/pending.jsonl"
+          local _host_queue_marker; _host_queue_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[QUEUED to gist %s — network error, will retry] %s"}' \
+            "$(timestamp)" "$active_channel" "$_host_room_gist_id" "${_host_detail:-no detail}")
+          echo "$_host_queue_marker" >> "$MESSAGES"
+          echo "  Network error reaching gist — broadcast queued for retry. Monitor will flush when gist returns." >&2
+          echo "  Bearer: ${_host_detail:-<none>}" >&2
+          ;;
         *)
-          echo "  ⚠ Gist publish failed (kind=${_host_kind:-empty}); broadcast did not reach joiners." >&2
-          echo "    Local audit log has the message; joiners polling the gist see nothing." >&2
+          # Unknown kind — bearer_cli added an outcome without updating
+          # callers. Queue defensively + log loudly so it gets caught.
+          echo "$full_msg" >> "$AIRC_WRITE_DIR/pending.jsonl"
+          echo "  Unknown bearer outcome kind '${_host_kind}' on host send (detail: ${_host_detail}). Queued defensively. Update cmd_send.sh." >&2
           ;;
       esac
     else
       echo "  ⚠ No room_gist_id set ($AIRC_WRITE_DIR/room_gist_id missing) — host send is local-only." >&2
+      echo "$full_msg" >> "$MESSAGES"
     fi
   fi
 


### PR DESCRIPTION
## Summary

Closes the host-side half of #381 (silent broadcast drop on transient gist failures). Pre-fix: `cmd_send`'s host branch printed a warning + dropped the message on the floor with exit 0, so joiners never saw the broadcast but the user's own chat widget echoed it back as 'sent' (because the local-mirror append happened BEFORE the publish attempt).

This change mirrors the joiner-side queue + drain semantics across to host mode:

- **`cmd_send.sh`** — local audit log write moves into the `delivered)` case only (no false echo on failure). `transient_failure`/empty kinds queue to `pending.jsonl` + emit a `[QUEUED]` marker. `auth_failure` mirrors the joiner branch (die loudly with re-auth instructions). Unknown bearer kinds queue defensively.
- **`airc`** — adds `flush_pending_host_loop`: symmetric to `flush_pending_loop` but routes via `bearer_cli send` (gist publish) instead of SSH push. Same 5s tick, parent-liveness gate, snapshot/unsent flow. Per-line: extracts channel from queued JSON, looks up gist, re-resolves recipient pubkey for DM wrap (so post-queue pairings get used at retry), publishes, on `delivered` writes to local audit log + `[DRAINED N]` marker.
- `monitor()` spawn site: when `host_target` is empty AND we have a publishable route, spawn the host flush loop. Same pidfile-honesty gate as the joiner branch — skip the spawn when standalone (`--no-gist`) so `airc.pid` doesn't list a PID that exited two seconds ago.

## Composes with #381 layer A

Layer A (continuum-b741) makes outcomes accurate (404 → `gone`, transient → retry, etc.). Layer B (this PR) makes non-`delivered` outcomes recoverable. Together: the gh API can flake for hours, the message lives in `pending.jsonl`, the next drain tick recovers it.

If layer A lands first and adds a `gone` outcome kind, the `*)` defensive-queue branch in `cmd_send.sh` will catch it; layer A can refine to a proper `gone)` case at that time.

## Edge case (documented)

The drain re-runs the wrap step. If the original `cmd_send` used `--plaintext` to a peer with a known X25519 pubkey, the queued `\$full_msg` is re-wrapped at drain time. Mirrors the asymmetry already in the joiner-side flow (which SSHes plaintext over) and is rare enough to leave to a follow-up.

## Test plan

- [x] `bash -n airc lib/airc_bash/cmd_send.sh` clean
- [ ] Manual repro: force a transient gist failure on a host scope, confirm `pending.jsonl` populates, `[QUEUED]` marker shows, drain tick delivers + emits `[DRAINED 1]`
- [ ] Integration suite (per #351 known-issue, may show pre-existing reds; required gates should pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)