### PR TITLE
fix(install,connect): surface 'airc daemon install' earlier (#382)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -853,6 +853,69 @@ if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
 fi
 
 
+# ── Optional: background daemon for sleep/wake/crash survival (#382) ───
+#
+# Issue: by default the mesh dies when peer laptops sleep — `airc connect`
+# is just a process, sleeps with the machine, never re-spawns on wake.
+# The remedy (`airc daemon install`) already exists but was only surfaced
+# AFTER the mesh had gone down (see the in-disconnect tip in the airc
+# top-level). By that time peers have missed however many hours of mesh
+# activity. This block surfaces the offer at install time, when the user
+# is already engaged in setup and can flip the auto-restart on with one
+# keystroke.
+#
+# Skip conditions:
+#   - daemon already installed (idempotent re-run)
+#   - non-TTY install (curl-bash piped without terminal)
+#   - AIRC_INSTALL_NO_DAEMON=1 (explicit opt-out for headless servers,
+#     CI runners, environments that manage daemons via their own
+#     config-management like Ansible/Chef/Nix)
+#   - AIRC_INSTALL_YES=1 (power-user one-liner: install the daemon
+#     without asking)
+_daemon_already_installed() {
+  case "$(uname -s 2>/dev/null)" in
+    Darwin) [ -f "$HOME/Library/LaunchAgents/com.cambriantech.airc.plist" ] ;;
+    Linux)  [ -f "$HOME/.config/systemd/user/airc.service" ] ;;
+    *) return 1 ;;  # treat unknown as "not installed" — best-effort prompt
+  esac
+}
+
+if _daemon_already_installed; then
+  info "airc daemon already installed (skipping prompt)"
+elif [ "${AIRC_INSTALL_NO_DAEMON:-0}" = "1" ]; then
+  info "AIRC_INSTALL_NO_DAEMON=1 — skipping daemon install prompt"
+elif [ ! -t 0 ] || [ ! -t 1 ]; then
+  # Non-TTY install can't prompt. Surface the option so the user sees it
+  # in their install transcript and can run it later — the help string
+  # mirrors the post-disconnect tip in airc's reconnect path.
+  info "Tip: run 'airc daemon install' to keep the mesh alive across machine sleep/wake/crash"
+elif [ "${AIRC_INSTALL_YES:-0}" = "1" ]; then
+  info "AIRC_INSTALL_YES=1 — installing airc daemon"
+  if "$BIN_DIR/airc" daemon install; then
+    ok "airc daemon installed"
+  else
+    warn "airc daemon install returned non-zero (continuing — re-run manually if needed)"
+  fi
+else
+  printf '\n  \033[1;32m==>\033[0m Install the airc background daemon?\n'
+  printf '      Keeps the mesh alive across machine sleep/wake/crash without\n'
+  printf '      requiring you to re-run `airc connect` after every wake. Adds\n'
+  printf '      a launchd/systemd entry that auto-restarts the host process.\n'
+  printf '      Skip with --no-daemon-prompt next time, or set AIRC_INSTALL_NO_DAEMON=1.\n'
+  printf '      [Y/n] '
+  read -r _daemon_reply || _daemon_reply=""
+  case "${_daemon_reply}" in
+    n|N|no|No|NO)
+      info "Skipped daemon install. Run 'airc daemon install' later if you change your mind." ;;
+    *)
+      if "$BIN_DIR/airc" daemon install; then
+        ok "airc daemon installed"
+      else
+        warn "airc daemon install returned non-zero — re-run manually:  airc daemon install"
+      fi ;;
+  esac
+fi
+
 # ── Done ────────────────────────────────────────────────────────────────
 
 echo ""

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1721,6 +1721,21 @@ JSON
             echo "    airc connect $_invite_long"
             echo ""
             echo "  (Room gist: $_gist_url — persistent; deleted on 'airc part'.)"
+            # First-time-host daemon hint (#382). The reconnect-loop in the
+            # airc top-level already prints the "(for auto-recovery: airc
+            # daemon install)" tip — but only AFTER the mesh has gone down.
+            # Surface it earlier here, on first host-bootstrap, so the user
+            # can flip auto-restart on while their mesh is still healthy.
+            # Only fires when the daemon isn't already installed (idempotent
+            # re-runs / re-hosts stay silent).
+            _daemon_plist_or_unit=""
+            case "$(uname -s 2>/dev/null)" in
+              Darwin) _daemon_plist_or_unit="$HOME/Library/LaunchAgents/com.cambriantech.airc.plist" ;;
+              Linux)  _daemon_plist_or_unit="$HOME/.config/systemd/user/airc.service" ;;
+            esac
+            if [ -n "$_daemon_plist_or_unit" ] && [ ! -f "$_daemon_plist_or_unit" ]; then
+              echo "  Tip: 'airc daemon install' keeps this mesh alive across machine sleep."
+            fi
           else
             echo "  On the other machine (pick whichever is easiest to share):"
             echo ""


### PR DESCRIPTION
## Summary

Pushes \`airc daemon install\` discoverability from "after the mesh dies" to "at install time" + "first time you become a host." Closes #382.

## What changed

- **install.sh** — at the end of first install, prompt Y/n for daemon install. Skip conditions:
  - daemon already installed (idempotent re-run)
  - non-TTY install (curl-bash piped — surface as visible tip line in transcript)
  - AIRC_INSTALL_NO_DAEMON=1 (headless / config-managed envs)
  - AIRC_INSTALL_YES=1 (power-user one-liner — auto-install)
  Default-Y when prompted (user already opted in by running the installer).

- **lib/airc_bash/cmd_connect.sh** — when this scope first becomes a host (publishes a new room gist on gh-account substrate), print one extra line:
  \`Tip: 'airc daemon install' keeps this mesh alive across machine sleep.\`
  Only fires when daemon isn't already installed.

## Composition with sibling fixes for #381 / #383

This PR makes daemon-install easy to find. The other two open PRs make it actually work:
- **#387** (\`#381 layer A\`) — initial-GET retry composes with daemon being alive to drain the queue
- **#385** (\`#381 layer B\`, merged) — host-side queue/drain; daemon keeps the host process alive long enough to drain
- **#384** (\`#383\`) — host-mode watchdog; without that, daemon thrashes. Together with #384 the daemon-install offer is worth taking.

## Test plan

- [ ] Local: \`bash install.sh\` from a TTY → prompt fires, accept → daemon installed; reject → install completes with helpful skip line
- [ ] Local: \`AIRC_INSTALL_YES=1 bash install.sh\` → no prompt, daemon installed
- [ ] Local: \`AIRC_INSTALL_NO_DAEMON=1 bash install.sh\` → explicit-skip line, no prompt
- [ ] Local: \`bash install.sh\` piped (no TTY) → tip line in output, no hang on stdin
- [ ] Local: \`airc connect\` from a fresh scope → "Hosting #..." banner now ends with the daemon tip line; second \`airc connect\` (after \`airc daemon install\`) doesn't repeat the tip
- [ ] CI: clean-install matrix (4 platforms) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)