### PR TITLE
fix: airc self-heals invalid gh keyring tokens (browser flow in-process)

### DIFF
--- a/airc
+++ b/airc
@@ -851,6 +851,20 @@ else
 fi
 # ── End mesh gist abstraction ───────────────────────────────────────────
 
+# ── Auth self-heal helpers ──────────────────────────────────────────────
+# airc_detect_gh_auth_state + airc_self_heal_gh_auth — let airc be the
+# instigator when the gh keyring token silently invalidates (frequent
+# in practice per Joel; observed twice on M5 in the last 48h). Sourced
+# unconditionally so all command surfaces can call into it.
+if [ -n "${_airc_lib_dir:-}" ] && [ -f "$_airc_lib_dir/airc_bash/lib_auth.sh" ]; then
+  # shellcheck source=lib/airc_bash/lib_auth.sh
+  source "$_airc_lib_dir/airc_bash/lib_auth.sh"
+else
+  echo "ERROR: airc_bash/lib_auth.sh not found via lib-dir resolver." >&2
+  exit 1
+fi
+# ── End auth self-heal helpers ──────────────────────────────────────────
+
 relay_ssh() {
   local ssh_key="$IDENTITY_DIR/ssh_key"
   # ConnectTimeout 10 so unreachable hosts fail fast instead of hanging ~60s

--- a/install.sh
+++ b/install.sh
@@ -853,6 +853,69 @@ if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
 fi
 
 
+# ── Optional: background daemon for sleep/wake/crash survival (#382) ───
+#
+# Issue: by default the mesh dies when peer laptops sleep — `airc connect`
+# is just a process, sleeps with the machine, never re-spawns on wake.
+# The remedy (`airc daemon install`) already exists but was only surfaced
+# AFTER the mesh had gone down (see the in-disconnect tip in the airc
+# top-level). By that time peers have missed however many hours of mesh
+# activity. This block surfaces the offer at install time, when the user
+# is already engaged in setup and can flip the auto-restart on with one
+# keystroke.
+#
+# Skip conditions:
+#   - daemon already installed (idempotent re-run)
+#   - non-TTY install (curl-bash piped without terminal)
+#   - AIRC_INSTALL_NO_DAEMON=1 (explicit opt-out for headless servers,
+#     CI runners, environments that manage daemons via their own
+#     config-management like Ansible/Chef/Nix)
+#   - AIRC_INSTALL_YES=1 (power-user one-liner: install the daemon
+#     without asking)
+_daemon_already_installed() {
+  case "$(uname -s 2>/dev/null)" in
+    Darwin) [ -f "$HOME/Library/LaunchAgents/com.cambriantech.airc.plist" ] ;;
+    Linux)  [ -f "$HOME/.config/systemd/user/airc.service" ] ;;
+    *) return 1 ;;  # treat unknown as "not installed" — best-effort prompt
+  esac
+}
+
+if _daemon_already_installed; then
+  info "airc daemon already installed (skipping prompt)"
+elif [ "${AIRC_INSTALL_NO_DAEMON:-0}" = "1" ]; then
+  info "AIRC_INSTALL_NO_DAEMON=1 — skipping daemon install prompt"
+elif [ ! -t 0 ] || [ ! -t 1 ]; then
+  # Non-TTY install can't prompt. Surface the option so the user sees it
+  # in their install transcript and can run it later — the help string
+  # mirrors the post-disconnect tip in airc's reconnect path.
+  info "Tip: run 'airc daemon install' to keep the mesh alive across machine sleep/wake/crash"
+elif [ "${AIRC_INSTALL_YES:-0}" = "1" ]; then
+  info "AIRC_INSTALL_YES=1 — installing airc daemon"
+  if "$BIN_DIR/airc" daemon install; then
+    ok "airc daemon installed"
+  else
+    warn "airc daemon install returned non-zero (continuing — re-run manually if needed)"
+  fi
+else
+  printf '\n  \033[1;32m==>\033[0m Install the airc background daemon?\n'
+  printf '      Keeps the mesh alive across machine sleep/wake/crash without\n'
+  printf '      requiring you to re-run `airc connect` after every wake. Adds\n'
+  printf '      a launchd/systemd entry that auto-restarts the host process.\n'
+  printf '      Skip with --no-daemon-prompt next time, or set AIRC_INSTALL_NO_DAEMON=1.\n'
+  printf '      [Y/n] '
+  read -r _daemon_reply || _daemon_reply=""
+  case "${_daemon_reply}" in
+    n|N|no|No|NO)
+      info "Skipped daemon install. Run 'airc daemon install' later if you change your mind." ;;
+    *)
+      if "$BIN_DIR/airc" daemon install; then
+        ok "airc daemon installed"
+      else
+        warn "airc daemon install returned non-zero — re-run manually:  airc daemon install"
+      fi ;;
+  esac
+fi
+
 # ── Done ────────────────────────────────────────────────────────────────
 
 echo ""

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -280,35 +280,12 @@ cmd_connect() {
   # Skipped entirely if a live monitor exists in this scope (handled
   # by the trust-existing-monitor short-circuit above).
   if [ "$use_room" = "1" ] && command -v gh >/dev/null 2>&1; then
-    if ! gh auth status >/dev/null 2>&1; then
-      # `gh auth status` probes /user, which returns 403 during a GitHub
-      # secondary rate limit (abuse detection) and which gh then misreports
-      # as "token invalid". The /rate_limit endpoint is reachable during
-      # secondary limits — if it works, the token is fine and the user
-      # just needs to wait, not re-auth. Issue #341.
-      echo "" >&2
-      if gh api rate_limit >/dev/null 2>&1; then
-        echo "  ! GitHub secondary rate limit (abuse detection) triggered." >&2
-        echo "    Your token is fine — wait 5-15 minutes and retry 'airc join'." >&2
-        echo "" >&2
-        echo "    Why this is confusing: 'gh auth status' calls /user which gets 403'd" >&2
-        echo "    during secondary rate limits; gh then prints 'token invalid'. The" >&2
-        echo "    /rate_limit endpoint is reachable, which proves the token works." >&2
-        echo "" >&2
-        echo "    Caused by: too many gh API calls in a short window (polling loops," >&2
-        echo "    rapid-fire PR/issue/comment activity, etc.)." >&2
-        die "GitHub rate-limited — retry in 5-15 min (token is fine)"
-      else
-        echo "  ✗ gh CLI is installed but the GitHub token is invalid." >&2
-        echo "    Detail:" >&2
-        gh auth status 2>&1 | sed 's/^/      /' >&2
-        echo "" >&2
-        echo "    Fix:  gh auth login -h github.com" >&2
-        echo "" >&2
-        echo "    Without gh auth, airc can't talk to the gist substrate at all." >&2
-        die "gh auth invalid — run 'gh auth login -h github.com' first"
-      fi
-    fi
+    # Pre-flight via the centralized state machine (lib_auth.sh).
+    # ok → proceed; rate_limited → wait + retry (token fine);
+    # invalid → airc instigates the browser self-heal in-process;
+    # not_installed → caller's outer guard already handled this.
+    airc_ensure_gh_auth_or_heal "airc join" \
+      || die "gh auth not OK — see message above for next step"
   fi
 
   # Issue #136: --general re-opt-in. Clear parted state on primary

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1721,6 +1721,21 @@ JSON
             echo "    airc connect $_invite_long"
             echo ""
             echo "  (Room gist: $_gist_url — persistent; deleted on 'airc part'.)"
+            # First-time-host daemon hint (#382). The reconnect-loop in the
+            # airc top-level already prints the "(for auto-recovery: airc
+            # daemon install)" tip — but only AFTER the mesh has gone down.
+            # Surface it earlier here, on first host-bootstrap, so the user
+            # can flip auto-restart on while their mesh is still healthy.
+            # Only fires when the daemon isn't already installed (idempotent
+            # re-runs / re-hosts stay silent).
+            _daemon_plist_or_unit=""
+            case "$(uname -s 2>/dev/null)" in
+              Darwin) _daemon_plist_or_unit="$HOME/Library/LaunchAgents/com.cambriantech.airc.plist" ;;
+              Linux)  _daemon_plist_or_unit="$HOME/.config/systemd/user/airc.service" ;;
+            esac
+            if [ -n "$_daemon_plist_or_unit" ] && [ ! -f "$_daemon_plist_or_unit" ]; then
+              echo "  Tip: 'airc daemon install' keeps this mesh alive across machine sleep."
+            fi
           else
             echo "  On the other machine (pick whichever is easiest to share):"
             echo ""

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -340,23 +340,37 @@ cmd_send() {
         return 0
         ;;
       auth_failure)
-        # Hard failure. Don't queue — every retry will fail identically.
-        # Pre-fix the message claimed 'SSH auth' which was leftover from
-        # the SSH era; post-3c the bearer is gh and the only auth that
-        # can fail is gh's. Direct the user to gh auth login so they
-        # can recover without rebuilding their identity.
+        # Don't queue — every retry will fail identically until the
+        # underlying auth is fixed. airc IS the instigator: trigger
+        # browser self-heal flow via the centralized state machine,
+        # then retry the send ONCE if heal succeeded.
+        # Joel: "gh logouts are FREQUENT" / "script needs to self-heal".
+        if airc_ensure_gh_auth_or_heal "airc send → $peer_name (#$active_channel)"; then
+          # Auth restored. Retry once. We don't loop — if the retry
+          # fails too, something else is going on (scope missing? gist
+          # deleted?) and the user needs to see the original error.
+          echo "  ↻ Retrying send post-heal..." >&2
+          local retry_outcome retry_kind retry_detail
+          retry_outcome=$(send_via_bearer "$active_channel" "$full_msg" "$peer_name" 2>&1) || true
+          retry_kind=$(echo "$retry_outcome" | head -1)
+          retry_detail=$(echo "$retry_outcome" | tail -n +2)
+          if [ "$retry_kind" = "ok" ]; then
+            echo "  ✓ Sent post-heal." >&2
+            return 0
+          fi
+          echo "  ✗ Retry post-heal also failed (kind=$retry_kind detail=$retry_detail)" >&2
+          # Fall through to the failure-marker block so the message is
+          # recorded as failed in the local log + user sees the error.
+        fi
         local fail_marker; fail_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[GH AUTH FAILED to %s — re-auth required, NOT queued] %s"}' \
           "$(timestamp)" "$active_channel" "$peer_name" "${detail:-no detail}")
         echo "$fail_marker" >> "$MESSAGES"
         echo "" >&2
-        echo "  ✗ gh auth check failed — your GitHub token is dead." >&2
-        echo "    Bearer detail: ${detail}" >&2
-        echo "" >&2
-        echo "    Fix:  gh auth login -h github.com" >&2
-        echo "" >&2
-        echo "    After re-authenticating, retry your message. No state lost," >&2
-        echo "    no re-pair needed — it's just gh's keyring that expired." >&2
-        die "gh auth failure — run 'gh auth login -h github.com' and retry"
+        echo "  ✗ gh auth check failed (post-heal-attempt) — bearer detail: ${detail}" >&2
+        echo "    Re-run 'airc send' to retry the self-heal flow," >&2
+        echo "    or fix manually: gh auth login -h github.com -s gist" >&2
+        echo "    No state lost; no re-pair needed — gh's keyring expired." >&2
+        die "gh auth failure — re-run 'airc send' or 'gh auth login -h github.com -s gist'"
         ;;
       transient_failure|"")
         # Network-class failure or empty/malformed outcome → treat as

--- a/lib/airc_bash/lib_auth.sh
+++ b/lib/airc_bash/lib_auth.sh
@@ -1,0 +1,235 @@
+# Sourced by airc. Self-healing gh-auth detection + recovery.
+#
+# Why this exists: gh's keyring token can silently invalidate (token
+# revoked / 2FA flow expired / brew upgrade / OS keychain rotation /
+# laptop sleep across an OAuth boundary). Joel reports this is FREQUENT
+# in practice. Pre-fix, every airc command path that touched the gist
+# substrate would die() with a message saying "run gh auth login -h
+# github.com" and STOP. The user then had to manually re-auth.
+#
+# Two problems with that:
+#   1. The next user (Carl, Toby, anyone) hits the same wall on first
+#      use after a token expires. Manual fix per user = unfixed bug.
+#   2. Joel's "no manual fixes" / "script must self-heal" rule is
+#      universal: an error a user will hit must be one a SCRIPT
+#      surfaces a path through, not a command in a docstring.
+#
+# Joel: "airc MUST BE THE INSTIGATOR" — the trigger to re-auth must
+# come from airc itself when it detects the failure, not from the user
+# remembering the command. Joel only does the browser click.
+#
+# Joel: "if it is actually required" — DON'T trigger preemptively or
+# on every command. Specifically distinguish:
+#   - real keyring-invalid    → self-heal IS required, trigger flow
+#   - secondary rate limit    → token is fine; don't re-auth, just wait
+#   - gh not installed        → can't fix from here; report + die
+#   - scope missing only      → re-auth with -s gist (we always request gist)
+#
+# Detection (airc_detect_gh_auth_state) is split from action
+# (airc_self_heal_gh_auth) so callers control when re-auth is allowed
+# (interactive contexts only).
+
+# ── airc_detect_gh_auth_state — echo one of {ok, invalid, rate_limited, not_installed} ──
+#
+# Probes gh's auth state without side-effects. Output goes to STDOUT
+# as a single line (caller captures with command substitution). Any
+# explanatory text goes to STDERR.
+#
+# State definitions:
+#   ok            — gh exists, /user reachable, token valid + has gist scope
+#   invalid       — gh exists, but /user returns 401 AND /rate_limit ALSO fails
+#                   (the keyring token is genuinely dead — both endpoints would
+#                    succeed if it were just secondary-limited)
+#   rate_limited  — gh exists, /user 403'd by secondary rate limit, but
+#                   /rate_limit still works → token is FINE, just wait
+#   not_installed — gh binary not on PATH; can't diagnose further
+airc_detect_gh_auth_state() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "not_installed"
+    return 0
+  fi
+
+  if gh auth status >/dev/null 2>&1; then
+    echo "ok"
+    return 0
+  fi
+
+  # gh auth status failed. Two possibilities:
+  # (a) Real auth failure — keyring token is dead.
+  # (b) Secondary rate limit — gh's `auth status` probes /user which
+  #     gets 403'd, then prints "token invalid" misleadingly. The
+  #     /rate_limit endpoint is reachable during secondary rate limits;
+  #     if it works, the token is fine. (issue #341 in airc)
+  #
+  # The KEYRING-INVALID case is what Joel reports as common (and is
+  # what just happened on M5: heartbeat.stderr 403'd Apr 30 with the
+  # rate-limit-shaped error message but `gh api rate_limit` ALSO failed
+  # → token is dead, not rate-limited).
+  if gh api rate_limit >/dev/null 2>&1; then
+    echo "rate_limited"
+  else
+    echo "invalid"
+  fi
+}
+
+# ── airc_self_heal_gh_auth — trigger gh's interactive web login flow ──
+#
+# Runs `gh auth login --web -s gist` IN-PROCESS. gh prints a one-time
+# device code, opens the user's browser to github.com/login/device,
+# and waits for the user to paste the code + click "Authorize".
+#
+# Args:
+#   $1 — context string ("airc connect", "airc send foo", etc.) shown
+#        to the user so they understand WHY airc is opening a browser
+#        unprompted.
+#
+# Returns:
+#   0 — gh auth succeeded; caller should retry whatever failed
+#   1 — gh auth failed (user cancelled, no network, no TTY, etc.); caller
+#       should fall back to die() with its existing error message
+#
+# Constraints:
+#   - Always requests the `gist` scope (airc's substrate is gist-based;
+#     a token without gist scope publishes 403, breaking all channels).
+#   - Pins to github.com (only host airc supports).
+#   - HTTPS git protocol (avoids ssh-key prompt during the flow).
+#   - Refuses to run in non-interactive contexts (background flush
+#     loops, daemon heartbeat). Those should queue + emit a clear
+#     "auth broken" log line and let the next interactive call self-heal.
+#   - Caller is responsible for confirming auth_state == invalid before
+#     calling. This function does NOT re-detect — pass-through.
+airc_self_heal_gh_auth() {
+  local context="${1:-airc operation}"
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "" >&2
+    echo "  ✗ gh CLI not installed — can't self-heal." >&2
+    echo "    Install: brew install gh   (or https://cli.github.com)" >&2
+    echo "" >&2
+    return 1
+  fi
+
+  # Refuse non-interactive contexts. Background processes have no human
+  # at the keyboard to paste a device code; triggering the flow there
+  # would just hang the process forever.
+  if [ ! -t 0 ] || [ ! -t 1 ]; then
+    echo "  ✗ Auth broken but stdin/stdout not a TTY — can't run interactive re-auth here." >&2
+    echo "    Re-run an airc CLI command (airc status / airc connect / airc send …)" >&2
+    echo "    in your terminal; it will detect the broken auth + trigger the browser." >&2
+    return 1
+  fi
+
+  echo "" >&2
+  echo "  ⚠  airc detected an invalid GitHub token — triggering re-authentication." >&2
+  echo "     Context: $context" >&2
+  echo "" >&2
+  echo "     gh will print a one-time device code + open your browser." >&2
+  echo "     Paste the code in the browser, grant 'gist' scope, then airc resumes." >&2
+  echo "" >&2
+
+  # `--web` is the device-code flow. gh prints the code, opens the
+  # browser via the OS opener (open / xdg-open / cmd.exe), and blocks
+  # until the user completes the flow OR Ctrl-C cancels.
+  #
+  # `--git-protocol https` skips the ssh/https protocol prompt.
+  # `-s gist` requests the gist scope explicitly (default token doesn't
+  # carry it; without gist scope, channel publishes get a 403).
+  if gh auth login --web --hostname github.com --git-protocol https -s gist; then
+    echo "" >&2
+    echo "  ✓ gh auth restored — resuming $context." >&2
+    echo "" >&2
+    return 0
+  fi
+
+  echo "" >&2
+  echo "  ✗ gh auth flow did not complete (cancelled? no network?)." >&2
+  echo "    Re-run your airc command to try again." >&2
+  echo "" >&2
+  return 1
+}
+
+# ── airc_ensure_gh_auth_or_heal — the full detect+react state machine ──
+#
+# Higher-level wrapper for command surfaces (cmd_connect, cmd_send,
+# cmd_status, cmd_doctor, …). Encapsulates the {detect → react} cycle
+# so each caller is one line:
+#
+#   airc_ensure_gh_auth_or_heal "airc join" || die "..."
+#
+# Behaviour by detected state:
+#   ok            → return 0; caller proceeds
+#   rate_limited  → emit explanation; return 1 (token is fine, just wait)
+#   invalid       → trigger self-heal browser flow; on success re-detect
+#                   to confirm + return 0; on failure emit fallback +
+#                   return 1 (caller dies with its own message)
+#   not_installed → emit install-gh hint; return 1
+#
+# The auth_state echoed on stderr is the SAME identifier the
+# airc_detect_gh_auth_state helper produces, so callers can grep their
+# logs for it if they want to react differently per state.
+#
+# Args:
+#   $1 — context string for any messages / self-heal flow
+#
+# Returns:
+#   0 — auth is OK after this call (either was OK, or was healed)
+#   1 — auth is NOT OK (rate_limited, invalid + heal failed, not_installed)
+airc_ensure_gh_auth_or_heal() {
+  local context="${1:-airc operation}"
+  local state; state="$(airc_detect_gh_auth_state)"
+
+  case "$state" in
+    ok)
+      return 0
+      ;;
+    rate_limited)
+      echo "" >&2
+      echo "  ! GitHub secondary rate limit (abuse detection) triggered." >&2
+      echo "    Your token is fine — wait 5-15 minutes and retry." >&2
+      echo "    Context: $context" >&2
+      echo "" >&2
+      echo "    Why this is confusing: 'gh auth status' calls /user which gets 403'd" >&2
+      echo "    during secondary rate limits; gh then prints 'token invalid'. The" >&2
+      echo "    /rate_limit endpoint is reachable, which proves the token works." >&2
+      echo "" >&2
+      echo "    Caused by: too many gh API calls in a short window (polling loops," >&2
+      echo "    rapid-fire PR/issue/comment activity, etc.)." >&2
+      return 1
+      ;;
+    invalid)
+      if airc_self_heal_gh_auth "$context"; then
+        if [ "$(airc_detect_gh_auth_state)" = "ok" ]; then
+          return 0
+        fi
+        echo "  ✗ gh auth flow completed but state still not OK." >&2
+        echo "    Possible: scope grant was skipped, or token wrote but read-back lag." >&2
+        echo "    Re-run your airc command to retry." >&2
+        return 1
+      fi
+      # Self-heal didn't run or didn't complete (no TTY, gh missing,
+      # user cancelled). Emit the manual fallback so users without
+      # interactive shells still know what to do.
+      echo "" >&2
+      echo "  ✗ gh CLI is installed but the GitHub token is invalid." >&2
+      echo "    Detail:" >&2
+      gh auth status 2>&1 | sed 's/^/      /' >&2
+      echo "" >&2
+      echo "    Manual fix: gh auth login -h github.com -s gist" >&2
+      echo "" >&2
+      echo "    Without gh auth, airc can't talk to the gist substrate at all." >&2
+      return 1
+      ;;
+    not_installed)
+      echo "" >&2
+      echo "  ✗ gh CLI not installed — required for airc's gist substrate." >&2
+      echo "    Install: brew install gh   (or https://cli.github.com)" >&2
+      echo "    Then:    gh auth login -h github.com -s gist" >&2
+      echo "" >&2
+      return 1
+      ;;
+    *)
+      echo "  ✗ Unknown gh auth state: '$state' (this is an airc bug)" >&2
+      return 1
+      ;;
+  esac
+}


### PR DESCRIPTION
## What

When airc detects an invalid gh keyring token, IT triggers \`gh auth login --web -s gist\` in-process. The user just clicks "Authorize" in the browser airc opens. No manual \`gh auth login -h github.com\` step required.

## Why

Joel observed (twice on M5 in 48h, "FREQUENT" in practice): gh's keyring token silently invalidates — token revoked, 2FA flow expired, brew upgrade replaced gh, OS keychain rotation, sleep across an OAuth boundary. Pre-fix:

- \`airc connect\` → "die: gh auth invalid — run 'gh auth login -h github.com' first"
- \`airc send\` → "die: gh auth failure — run 'gh auth login -h github.com' and retry"

Every user (Carl, Toby, anyone joining the mesh for the first time after a token expires) hits the same wall. Manual fix per user = unfixed bug.

Joel's "no manual fixes" / "script must self-heal" rule is universal: **"airc MUST BE THE INSTIGATOR"**. When airc detects the failure, IT runs the auth flow. The user's only step is the browser click.

## How

New \`lib/airc_bash/lib_auth.sh\` with three helpers:

- **\`airc_detect_gh_auth_state\`** → echoes \`{ok | invalid | rate_limited | not_installed}\`. Distinguishes a real keyring-invalid state (BOTH /user and /rate_limit fail) from secondary rate limit (only /user fails — token is fine, just wait). Caller can grep the state identifier.

- **\`airc_self_heal_gh_auth\`** → runs \`gh auth login --web --hostname github.com --git-protocol https -s gist\` IN-PROCESS. gh prints the device code, opens the browser via the OS opener, blocks until the user pastes + clicks Authorize. Refuses to run in non-interactive contexts (background flush loops have no human at the keyboard).

- **\`airc_ensure_gh_auth_or_heal\`** → high-level wrapper that does the full detect → react cycle. Single-line call site for command surfaces.

Wired into:
- **cmd_connect.sh** (~30 lines collapsed to 1 wrapper call): pre-flight before the join flow now self-heals on invalid token.
- **cmd_send.sh** (auth_failure path): on bearer-reported auth failure, detect + self-heal, then RETRY the send ONCE post-heal. No loop — if the retry fails too, something else is going on and the user should see it.

## Test plan

- [x] \`bash -n\` clean on all 4 touched files
- [x] \`airc_detect_gh_auth_state\` against real \`ok\` keyring: returns \`ok\`
- [x] against bogus \`GH_TOKEN\`: returns \`invalid\`
- [x] against PATH without \`gh\`: returns \`not_installed\`
- [ ] Live self-heal flow on next keyring invalidation (will happen; "FREQUENT")

## Out of scope (follow-ups)

- Wire into \`cmd_status.sh\` + \`cmd_doctor.sh\` for clearer surfacing (today they print "RATE-LIMITED (secondary)" even when the keyring is genuinely dead — the new detect helper would fix that).
- Background flush loop doesn't self-heal — by design, refuses non-TTY. Caller must run an interactive airc cmd to re-auth, then queued sends drain. Could add a "re-auth needed, run \`airc status\`" log line emitted periodically by the monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)