### PR TITLE
fix(#388): address Copilot review — Windows/WSL daemon detect + ordering + stale text

### DIFF
--- a/airc
+++ b/airc
@@ -865,6 +865,21 @@ else
 fi
 # ── End auth self-heal helpers ──────────────────────────────────────────
 
+# ── Daemon-installed detector ───────────────────────────────────────────
+# airc_daemon_is_installed — single source of truth shared by
+# cmd_daemon.sh, cmd_connect.sh first-host tip, and install.sh's
+# daemon-install prompt. Pre-fix, three places had near-identical
+# detection that drifted across platforms; Copilot review on PR #388
+# caught Windows + WSL gaps. ONE detect, called from every site.
+if [ -n "${_airc_lib_dir:-}" ] && [ -f "$_airc_lib_dir/airc_bash/lib_daemon_detect.sh" ]; then
+  # shellcheck source=lib/airc_bash/lib_daemon_detect.sh
+  source "$_airc_lib_dir/airc_bash/lib_daemon_detect.sh"
+else
+  echo "ERROR: airc_bash/lib_daemon_detect.sh not found via lib-dir resolver." >&2
+  exit 1
+fi
+# ── End daemon-installed detector ───────────────────────────────────────
+
 relay_ssh() {
   local ssh_key="$IDENTITY_DIR/ssh_key"
   # ConnectTimeout 10 so unreachable hosts fail fast instead of hanging ~60s

--- a/install.sh
+++ b/install.sh
@@ -893,7 +893,7 @@ else
   airc_daemon_is_installed() { return 1; }
 fi
 
-# Order matters here. Three NON-prompt branches first, ordered so the
+# Order matters here. Four NON-prompt branches first, ordered so the
 # loudest user intent wins:
 #   1. AIRC_INSTALL_NO_DAEMON=1 — explicit opt-out trumps everything.
 #   2. AIRC_INSTALL_YES=1       — explicit auto-install (Copilot #388:

--- a/install.sh
+++ b/install.sh
@@ -872,36 +872,64 @@ fi
 #     config-management like Ansible/Chef/Nix)
 #   - AIRC_INSTALL_YES=1 (power-user one-liner: install the daemon
 #     without asking)
-_daemon_already_installed() {
-  case "$(uname -s 2>/dev/null)" in
-    Darwin) [ -f "$HOME/Library/LaunchAgents/com.cambriantech.airc.plist" ] ;;
-    Linux)  [ -f "$HOME/.config/systemd/user/airc.service" ] ;;
-    *) return 1 ;;  # treat unknown as "not installed" — best-effort prompt
-  esac
-}
+# Source the centralized cross-platform daemon detector + its dependency
+# (detect_platform from platform_adapters.sh). Lets install.sh ask the
+# same "is the daemon installed?" question that cmd_daemon.sh + cmd_connect.sh
+# ask, so the answer is consistent across darwin / linux / wsl / windows.
+# Pre-fix install.sh had its own _daemon_already_installed() that only
+# covered Darwin/Linux file paths — Copilot review on PR #388 caught
+# that this would re-prompt on every install rerun on Windows Git Bash
+# even after `airc daemon install` had registered the HKCU Run-key.
+if [ -f "$CLONE_DIR/lib/airc_bash/platform_adapters.sh" ] \
+   && [ -f "$CLONE_DIR/lib/airc_bash/lib_daemon_detect.sh" ]; then
+  # shellcheck source=lib/airc_bash/platform_adapters.sh
+  source "$CLONE_DIR/lib/airc_bash/platform_adapters.sh"
+  # shellcheck source=lib/airc_bash/lib_daemon_detect.sh
+  source "$CLONE_DIR/lib/airc_bash/lib_daemon_detect.sh"
+else
+  # Defensive fallback so install doesn't die on a weird CLONE_DIR layout.
+  # The prompt block below tolerates the function being absent (treats
+  # "unknown daemon state" as "not installed → offer prompt").
+  airc_daemon_is_installed() { return 1; }
+fi
 
-if _daemon_already_installed; then
-  info "airc daemon already installed (skipping prompt)"
-elif [ "${AIRC_INSTALL_NO_DAEMON:-0}" = "1" ]; then
+# Order matters here. Three NON-prompt branches first, ordered so the
+# loudest user intent wins:
+#   1. AIRC_INSTALL_NO_DAEMON=1 — explicit opt-out trumps everything.
+#   2. AIRC_INSTALL_YES=1       — explicit auto-install (Copilot #388:
+#                                 must come BEFORE the non-TTY check
+#                                 so `curl … | AIRC_INSTALL_YES=1 bash`
+#                                 actually installs instead of falling
+#                                 into the non-TTY tip branch).
+#   3. daemon already installed  — idempotent re-run; nothing to do.
+#   4. Non-TTY                   — no human to prompt; surface tip text.
+#   5. TTY interactive prompt    — default path.
+if [ "${AIRC_INSTALL_NO_DAEMON:-0}" = "1" ]; then
   info "AIRC_INSTALL_NO_DAEMON=1 — skipping daemon install prompt"
+elif [ "${AIRC_INSTALL_YES:-0}" = "1" ]; then
+  if airc_daemon_is_installed; then
+    info "AIRC_INSTALL_YES=1 — airc daemon already installed (no-op)"
+  else
+    info "AIRC_INSTALL_YES=1 — installing airc daemon"
+    if "$BIN_DIR/airc" daemon install; then
+      ok "airc daemon installed"
+    else
+      warn "airc daemon install returned non-zero (continuing — re-run manually if needed)"
+    fi
+  fi
+elif airc_daemon_is_installed; then
+  info "airc daemon already installed (skipping prompt)"
 elif [ ! -t 0 ] || [ ! -t 1 ]; then
   # Non-TTY install can't prompt. Surface the option so the user sees it
   # in their install transcript and can run it later — the help string
   # mirrors the post-disconnect tip in airc's reconnect path.
   info "Tip: run 'airc daemon install' to keep the mesh alive across machine sleep/wake/crash"
-elif [ "${AIRC_INSTALL_YES:-0}" = "1" ]; then
-  info "AIRC_INSTALL_YES=1 — installing airc daemon"
-  if "$BIN_DIR/airc" daemon install; then
-    ok "airc daemon installed"
-  else
-    warn "airc daemon install returned non-zero (continuing — re-run manually if needed)"
-  fi
 else
   printf '\n  \033[1;32m==>\033[0m Install the airc background daemon?\n'
   printf '      Keeps the mesh alive across machine sleep/wake/crash without\n'
   printf '      requiring you to re-run `airc connect` after every wake. Adds\n'
-  printf '      a launchd/systemd entry that auto-restarts the host process.\n'
-  printf '      Skip with --no-daemon-prompt next time, or set AIRC_INSTALL_NO_DAEMON=1.\n'
+  printf '      a launchd / systemd / HKCU-Run entry that auto-restarts the host.\n'
+  printf '      Skip next time by setting AIRC_INSTALL_NO_DAEMON=1.\n'
   printf '      [Y/n] '
   read -r _daemon_reply || _daemon_reply=""
   case "${_daemon_reply}" in

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1704,13 +1704,13 @@ JSON
             # Surface it earlier here, on first host-bootstrap, so the user
             # can flip auto-restart on while their mesh is still healthy.
             # Only fires when the daemon isn't already installed (idempotent
-            # re-runs / re-hosts stay silent).
-            _daemon_plist_or_unit=""
-            case "$(uname -s 2>/dev/null)" in
-              Darwin) _daemon_plist_or_unit="$HOME/Library/LaunchAgents/com.cambriantech.airc.plist" ;;
-              Linux)  _daemon_plist_or_unit="$HOME/.config/systemd/user/airc.service" ;;
-            esac
-            if [ -n "$_daemon_plist_or_unit" ] && [ ! -f "$_daemon_plist_or_unit" ]; then
+            # re-runs / re-hosts stay silent). Uses the centralized
+            # cross-platform detector (lib_daemon_detect.sh) so this fires
+            # correctly on darwin / linux / wsl / windows. Pre-fix this
+            # block only checked Darwin/Linux file paths and never fired
+            # on Windows where the daemon lives in HKCU\...\Run (Copilot
+            # review on PR #388 caught this gap).
+            if ! airc_daemon_is_installed; then
               echo "  Tip: 'airc daemon install' keeps this mesh alive across machine sleep."
             fi
           else

--- a/lib/airc_bash/cmd_daemon.sh
+++ b/lib/airc_bash/cmd_daemon.sh
@@ -103,16 +103,12 @@ _daemon_scope() {
 # (daemon present) or just kill the relay silently (no daemon — they
 # need to `airc join` again).
 _daemon_installed() {
-  local os; os=$(detect_platform)
-  case "$os" in
-    darwin)
-      [ -f "$HOME/Library/LaunchAgents/com.cambriantech.airc.plist" ] && return 0 ;;
-    linux|wsl)
-      [ -f "$HOME/.config/systemd/user/airc.service" ] && return 0 ;;
-    windows)
-      reg query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run" //v airc-monitor >/dev/null 2>&1 && return 0 ;;
-  esac
-  return 1
+  # Delegates to airc_daemon_is_installed (lib/airc_bash/lib_daemon_detect.sh).
+  # Kept as a thin wrapper to preserve the local-private-helper shape
+  # callers in this file use; the cross-platform detection logic lives
+  # in the shared detector so install.sh + cmd_connect.sh see the same
+  # answer (Copilot review #388 caught the prior drift).
+  airc_daemon_is_installed
 }
 
 cmd_daemon_install() {

--- a/lib/airc_bash/lib_daemon_detect.sh
+++ b/lib/airc_bash/lib_daemon_detect.sh
@@ -29,14 +29,15 @@
 # Detection strategy by platform:
 #   darwin    — $HOME/Library/LaunchAgents/com.cambriantech.airc.plist
 #   linux/wsl — $HOME/.config/systemd/user/airc.service
-#   windows   — HKCU\Software\Microsoft\Windows\CurrentVersion\Run\airc-monitor
-#               (matches the entry name cmd_daemon.sh's installer creates)
+#   windows   — HKCU\Software\Microsoft\Windows\CurrentVersion\Run
+#               (Run value name: airc-monitor; matches the entry name
+#               cmd_daemon.sh's installer creates)
 #
 # This MUST stay aligned with cmd_daemon.sh::cmd_daemon_install — if
 # the installer ever changes the path / unit name / entry name, this
 # detector is what tells the install-time + first-host UX whether the
 # offer/tip should fire. Misalignment = re-prompt loop or never-prompt
-# silent miss; both are users-experience bugs Copilot flagged.
+# silent miss; both are user experience bugs Copilot flagged.
 airc_daemon_is_installed() {
   local os; os=$(detect_platform)
   case "$os" in

--- a/lib/airc_bash/lib_daemon_detect.sh
+++ b/lib/airc_bash/lib_daemon_detect.sh
@@ -1,0 +1,54 @@
+# Sourced by airc + install.sh. Cross-platform "is the airc background
+# daemon installed?" detector — single source of truth shared between
+# the bootstrap installer and the runtime command surfaces.
+#
+# Why this exists: pre-fix, three places had near-identical detection
+# logic that drifted:
+#
+#   - cmd_daemon.sh::_daemon_installed   (covers darwin, linux/wsl, windows)
+#   - cmd_connect.sh first-host tip      (covered ONLY darwin + linux)
+#   - install.sh::_daemon_already_installed (covered ONLY darwin + linux)
+#
+# Copilot review on PR #388 caught the install.sh + cmd_connect.sh gaps
+# — the daemon-install prompt would re-prompt every install on Windows
+# Git Bash even after `airc daemon install` had registered the HKCU
+# Run-key entry, and the first-host tip never fired on Windows at all.
+# Joel's "modular not duplicated" rule applies: ONE detect, called from
+# every site that asks "is the daemon installed?".
+#
+# Depends on: detect_platform (lib/airc_bash/platform_adapters.sh).
+# install.sh sources both files explicitly from $CLONE_DIR before
+# calling this; runtime sources them via airc's lib-dir resolver.
+
+# ── airc_daemon_is_installed — yes/no probe across all supported OSes ──
+#
+# Returns:
+#   0 — daemon autostart entry IS installed for the current user
+#   1 — daemon entry NOT installed (or unsupported platform)
+#
+# Detection strategy by platform:
+#   darwin    — $HOME/Library/LaunchAgents/com.cambriantech.airc.plist
+#   linux/wsl — $HOME/.config/systemd/user/airc.service
+#   windows   — HKCU\Software\Microsoft\Windows\CurrentVersion\Run\airc-monitor
+#               (matches the entry name cmd_daemon.sh's installer creates)
+#
+# This MUST stay aligned with cmd_daemon.sh::cmd_daemon_install — if
+# the installer ever changes the path / unit name / entry name, this
+# detector is what tells the install-time + first-host UX whether the
+# offer/tip should fire. Misalignment = re-prompt loop or never-prompt
+# silent miss; both are users-experience bugs Copilot flagged.
+airc_daemon_is_installed() {
+  local os; os=$(detect_platform)
+  case "$os" in
+    darwin)
+      [ -f "$HOME/Library/LaunchAgents/com.cambriantech.airc.plist" ] && return 0 ;;
+    linux|wsl)
+      [ -f "$HOME/.config/systemd/user/airc.service" ] && return 0 ;;
+    windows)
+      # Same query cmd_daemon.sh:_daemon_installed uses. //v is the
+      # MSYS-friendly form of /v (the leading // gets stripped down to
+      # / by the MSYS path-mangling shim).
+      reg query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run" //v airc-monitor >/dev/null 2>&1 && return 0 ;;
+  esac
+  return 1
+}


### PR DESCRIPTION
## What

Follow-up to #388 (already merged) addressing all 4 Copilot review concerns + a small refactor that makes the underlying drift impossible.

## Concerns + fixes

| # | Copilot concern | Fix |
|---|---|---|
| 1 | Prompt copy mentions \`--no-daemon-prompt\` flag that doesn't exist | Removed the flag reference; kept only the working \`AIRC_INSTALL_NO_DAEMON=1\` env-var hint |
| 2 | \`_daemon_already_installed()\` only checks Darwin/Linux file paths — re-prompts every install on Windows even after \`airc daemon install\` registered the HKCU Run-key entry | Extracted cross-platform detector to \`lib/airc_bash/lib_daemon_detect.sh\`, sourced by install.sh from \`\$CLONE_DIR\`. Covers darwin / linux / wsl / windows. |
| 3 | \`AIRC_INSTALL_YES=1\` ordering bug: \`curl … \| AIRC_INSTALL_YES=1 bash\` falls into non-TTY tip branch instead of installing | Reordered branches so YES check fires BEFORE the \`!-t 0\` check |
| 4 | \`cmd_connect.sh:~1707\` first-host tip block also Darwin/Linux-only — never fires on Windows | Now uses the same \`airc_daemon_is_installed\` shared helper |

## The refactor

Pre-fix three places had near-identical detection logic that drifted:
- \`cmd_daemon.sh::_daemon_installed\` (covered all platforms correctly)
- \`cmd_connect.sh\` first-host tip (Darwin + Linux only — Copilot caught)
- \`install.sh::_daemon_already_installed\` (Darwin + Linux only — Copilot caught)

Post-fix: ONE detector in \`lib_daemon_detect.sh\`, used by all three. \`cmd_daemon.sh::_daemon_installed\` becomes a thin wrapper to preserve the file-private-helper shape its callers use.

Per Joel: "if you code modularly like we require" — three case statements collapse to one detector.

## install.sh branch ordering (top → bottom)

1. \`AIRC_INSTALL_NO_DAEMON=1\` — explicit opt-out trumps everything
2. \`AIRC_INSTALL_YES=1\` — explicit auto-install (now **before** non-TTY)
3. \`airc_daemon_is_installed\` — idempotent re-run no-op
4. \`!-t 0 || !-t 1\` — non-TTY tip text
5. interactive \`[Y/n]\` — default

## Test plan

- [x] \`bash -n\` clean on all 5 touched files
- [x] \`airc_daemon_is_installed\` against real Mac (daemon was installed via \`airc daemon install\` Apr 24): returns 0 ✓
- [x] against mocked-windows (\`reg query\` mocked to succeed): returns 0 ✓
- [x] \`cmd_daemon.sh::_daemon_installed\` wrapper still returns same value as direct call (delegation works)
- [x] install.sh ordering verified by inspection: YES check at line 909 precedes \`!-t 0\` at line 920+
- [ ] Live-validate on Windows Git Bash on next available Windows peer (BigMama Win-side or Toby's box)

## Out of scope

This PR doesn't change the underlying daemon-install flow itself — only the detect / prompt logic around it. The \`cmd_daemon_install\` Windows path that creates the HKCU Run-key entry is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)