### PR TITLE
fix: detect_scope walks up to enclosing .airc/ ancestor (no more .airc/.airc)

### DIFF
--- a/airc
+++ b/airc
@@ -166,6 +166,21 @@ fi
 # one machine? Open each tab in its own dir (or repo) — they're distinct
 # peers automatically.
 #
+# Carve-out: if cwd is INSIDE an existing .airc/ ancestor (e.g. user
+# `cd`'d into the scope dir for forensic inspection), resolve to that
+# ancestor instead of appending /.airc to cwd. Pre-fix this produced
+# wrong nested paths like /repo/.airc/.airc — every command then died
+# with "Not initialized" against a scope that didn't exist. Discovered
+# 2026-05-01 on M5 while diagnosing a different airc issue: the very
+# act of `cd .airc; airc status` to inspect state broke airc.
+#
+# Doesn't change behaviour for the "fresh cwd, no enclosing scope"
+# case — that still gets $PWD/.airc, preserving the per-cwd identity
+# model. Doesn't walk up across non-.airc parents either, so cwd
+# /repo/src (with /repo/.airc existing) still creates /repo/src/.airc
+# the way it always has — that broader change would be a contract
+# shift worth its own design discussion.
+#
 # AIRC_HOME env var overrides, for tests / edge cases. Normal users don't
 # touch it.
 detect_scope() {
@@ -173,8 +188,23 @@ detect_scope() {
     echo "$AIRC_HOME"
     return
   fi
+
   # Resolve symlinks so /tmp/x and /private/tmp/x are the same scope.
-  echo "$(pwd -P)/.airc"
+  local cur; cur="$(pwd -P)"
+
+  # Walk up looking for an ancestor whose basename is .airc — that's
+  # the scope dir we should resolve to. Stops at / (or empty cur).
+  local probe; probe="$cur"
+  while [ -n "$probe" ] && [ "$probe" != "/" ]; do
+    if [ "$(basename "$probe")" = ".airc" ] && [ -d "$probe" ]; then
+      echo "$probe"
+      return
+    fi
+    probe="$(dirname "$probe")"
+  done
+
+  # No enclosing .airc/ ancestor — apply the documented per-cwd default.
+  echo "$cur/.airc"
 }
 
 # Short, clash-resistant name auto-derived from the scope path.


### PR DESCRIPTION
## What

When a user \`cd\`'d into the scope dir for forensic inspection (or any descendant), \`detect_scope()\` returned \`\$pwd/.airc\` — producing wrong nested paths like \`/repo/.airc/.airc\`. Every subsequent airc command then died with \"Not initialized\" against a directory that didn't exist.

## Repro

```bash
cd /your/repo                # cwd = /your/repo
airc status                  # works (scope = /your/repo/.airc)

cd .airc                     # cwd = /your/repo/.airc (forensic inspection)
airc status                  # ERROR: Not initialized (/your/repo/.airc/.airc)
```

Discovered live on M5 2026-05-01 while diagnosing a different airc issue: the very act of \`cd .airc; airc status\` broke airc.

## Fix

Walk up from cwd looking for an ancestor whose basename is \`.airc\`. If found, that's the scope. If not found, fall through to the documented \`\$pwd/.airc\` per-cwd default (unchanged behaviour for fresh cwd).

## Test cases (all 4 pass via inline test extraction)

| cwd | pre-fix | post-fix |
|---|---|---|
| \`/repo\` (no \`.airc\` anywhere) | \`/repo/.airc\` | \`/repo/.airc\` (same) |
| \`/repo\` (has child \`.airc\`) | \`/repo/.airc\` | \`/repo/.airc\` (same) |
| \`/repo/.airc\` **(BUG TRIGGER)** | \`/repo/.airc/.airc\` | **\`/repo/.airc\` ✓ FIXED** |
| \`/repo/.airc/identity\` | \`/repo/.airc/identity/.airc\` | **\`/repo/.airc\` ✓ FIXED** |
| \`AIRC_HOME=/x\` set | \`/x\` | \`/x\` (override unchanged) |

## Out of scope

Doesn't change behaviour for \"cwd is parallel to a sibling \`.airc/\`\" (e.g. \`cwd=/repo/src\` with \`/repo/.airc\` existing — that still creates \`/repo/src/.airc\` the way it always has). A broader \"find enclosing scope from any subdir\" change would shift the documented per-cwd identity contract; deserves its own design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)