### PR TITLE
fix(picker): fallback skips localhost so cross-machine joiners do not dial 127.0.0.1

### DIFF
--- a/airc
+++ b/airc
@@ -800,10 +800,20 @@ peer_pick_address() {
   # (no TCP pair-handshake needed once gh-pair lands; for now, the
   # peer is unreachable for direct pair and gh-only messaging suffices).
 
-  # Fallback: first entry of any kind. Useful when neither side has a
-  # clearly matching scope and we just want to try something.
+  # Fallback: first NON-LOCALHOST entry. The pre-fix `pick_addr_first`
+  # included localhost entries which the joiner — by definition on a
+  # different machine — would dial against THEIR own loopback (never
+  # reaches the host). Symptom: Joel's Windows peer subscribed to
+  # #cambriantech but stuck on a 127.0.0.1 connection because their
+  # IP didn't match the host's lan/24 subnet check + the fallback then
+  # picked the localhost entry that happened to be first in the gist's
+  # addresses[]. pick_addr_nonlocal_first skips localhost; if only
+  # localhost remains, returns empty so the caller falls through to
+  # gh-bearer-only routing (broadcast still works; direct-pair
+  # handshake is skipped). Aligns with the documented Phase 3c
+  # gh-as-bearer routing behaviour above.
   printf '%s' "$addresses_json" \
-    | "$AIRC_PYTHON" -m airc_core.gistparse pick_addr_first 2>/dev/null
+    | "$AIRC_PYTHON" -m airc_core.gistparse pick_addr_nonlocal_first 2>/dev/null
 }
 
 # humanhash: hex string → human-readable mnemonic (e.g. "muffin-saturn-pluto-orange").

--- a/lib/airc_core/gistparse.py
+++ b/lib/airc_core/gistparse.py
@@ -160,6 +160,39 @@ def cmd_pick_addr_first(args) -> int:
     return 0
 
 
+def cmd_pick_addr_nonlocal_first(args) -> int:
+    """Stdin is a list of {scope, addr, port, ...}. Print 'addr|port' for
+    the first entry whose scope is NOT 'localhost'. Empty if all entries
+    are localhost (or list is empty / malformed).
+
+    Why this exists: peer_pick_address's bash-side fallback was "first
+    entry of any kind" — but the gist's host.addresses[] often has
+    `localhost` first (127.0.0.1, the host's loopback). For a different
+    machine's joiner, picking that means dialing their OWN loopback,
+    which never reaches the host. Symptom: Joel's Windows peer subscribed
+    to #cambriantech but stuck on a 127.0.0.1 connection because their
+    Windows IP didn't match the host's lan/24 subnet check. With this
+    helper, the fallback skips localhost entries; if only localhost
+    remains, returns empty so the caller falls through to gh-bearer-only
+    routing instead of dialing an unreachable address.
+    """
+    data = _read_stdin_json()
+    if not isinstance(data, list):
+        return 0
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        scope = entry.get("scope", "")
+        if scope == "localhost":
+            continue
+        addr = entry.get("addr", "")
+        port = entry.get("port", "")
+        if addr and port != "":
+            print(f"{addr}|{port}")
+            return 0
+    return 0
+
+
 def cmd_gist_content(args) -> int:
     """Stdin is a gh-api response for a gist (`gh api gists/<id>` or the
     REST equivalent). Extract the first file's `.content`. Replaces:
@@ -229,6 +262,9 @@ def _build_parser() -> argparse.ArgumentParser:
 
     pf = sub.add_parser("pick_addr_first")
     pf.set_defaults(func=cmd_pick_addr_first)
+
+    pnf = sub.add_parser("pick_addr_nonlocal_first")
+    pnf.set_defaults(func=cmd_pick_addr_nonlocal_first)
 
     ll = sub.add_parser("list_lan_entries")
     ll.set_defaults(func=cmd_list_lan_entries)


### PR DESCRIPTION
Joel live-observed: Windows peer subscribed to #cambriantech but stuck on 127.0.0.1 because peer_pick_address fallback returned the localhost entry from host.addresses[]. Fix: new pick_addr_nonlocal_first helper that skips localhost; empty result falls through to gh-bearer-only routing per the documented Phase 3c behaviour.

Tailscale-pick re-add is separate followup.

🤖 Generated with Claude Code