### PR TITLE
docs(readme): note Tailscale as optional fast-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,8 @@ A GitHub account. install.sh handles the rest — installs `gh` if you don't hav
 
 `/airc:doctor` walks you through any setup gap (missing `gh`, not authed, etc.) with a per-OS fix command.
 
+**Tailscale is optional.** When two peers are on the same tailnet (signed in to Tailscale on both ends), airc advertises the tailnet IP alongside the LAN/loopback ones and the pair-handshake takes a direct WireGuard hop — instant, no polling latency. When Tailscale isn't installed (or isn't signed in, or peers are on different tailnets), the gh-bearer path carries everything via the gist; same end-to-end semantics, ~30s polling cadence. Either way the mesh works without you doing anything; Tailscale is purely a fast-path optimization for cross-network peers.
+
 Supported platforms: **macOS, Linux, WSL2, Windows (Git Bash, native PowerShell 7).** Same protocol everywhere; a Windows peer pairs with a Mac peer with no extra config. WSL users wanting daemon autostart need `[boot] systemd=true` in `/etc/wsl.conf` + `wsl --shutdown` (the daemon installer detects + tells you). Windows daemon autostart uses Task Scheduler.
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ A GitHub account. install.sh handles the rest — installs `gh` if you don't hav
 
 `/airc:doctor` walks you through any setup gap (missing `gh`, not authed, etc.) with a per-OS fix command.
 
-**Tailscale is optional.** When two peers are on the same tailnet (signed in to Tailscale on both ends), airc advertises the tailnet IP alongside the LAN/loopback ones and the pair-handshake takes a direct WireGuard hop — instant, no polling latency. When Tailscale isn't installed (or isn't signed in, or peers are on different tailnets), the gh-bearer path carries everything via the gist; same end-to-end semantics, ~30s polling cadence. Either way the mesh works without you doing anything; Tailscale is purely a fast-path optimization for cross-network peers.
+**Tailscale is optional.** airc works without it — the gist is the wire by default, no VPN setup needed. But if you want your laptop to talk to your own home systems (or any boxes you own), Tailscale is the nicest design: install it on both ends, sign in, and airc automatically picks the direct WireGuard hop instead of round-tripping through gh. Same protocol, same security model, just instant rather than ~30s polling cadence. Nothing to configure on the airc side — it auto-detects whether Tailscale is signed in and routes accordingly.
 
 Supported platforms: **macOS, Linux, WSL2, Windows (Git Bash, native PowerShell 7).** Same protocol everywhere; a Windows peer pairs with a Mac peer with no extra config. WSL users wanting daemon autostart need `[boot] systemd=true` in `/etc/wsl.conf` + `wsl --shutdown` (the daemon installer detects + tells you). Windows daemon autostart uses Task Scheduler.
 


### PR DESCRIPTION
## Summary

Joel just updated the GitHub repo About to call out Tailscale as optional for remote VPN connections; README didn't yet reflect it. Adds one paragraph in the Requirements section.

## What lands

A short paragraph immediately after the `/airc:doctor` line in **Requirements**, before the supported-platforms paragraph. Says:

- Tailscale is purely a fast-path optimization
- Same-tailnet peers get direct WireGuard hops (no polling latency)
- gh-bearer is the universal fallback (~30s cadence) when Tailscale isn't installed, isn't signed in, or peers are on different tailnets
- The mesh works without Tailscale; nothing to configure to opt out

Mirrors the code change in #394 (`host_address_set` restored Tailscale entry when daemon signed in).

## Why not also in "How airc compares"

That section positions airc against federation protocols (A2A/ACP/ANP/MCP). Adding transport details there dilutes the positioning. Requirements is the natural home for "what optional thing does what."

## Targeting main

`docs:` title prefix passes the `require-canary-or-hotfix` policy gate (no canary staging needed for prose-only changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)