### PR TITLE
fix(picker,host): joiner reachability + Windows host LAN enumeration

### DIFF
--- a/airc
+++ b/airc
@@ -743,12 +743,35 @@ host_address_set() {
   printf 'localhost|127.0.0.1|%s|\n' "$port"
 
   # LAN: enumerate interfaces, pick non-loopback IPv4s. macOS + Linux
-  # converge on `ifconfig`; we use that and reject loopback + CGNAT.
+  # converge on `ifconfig`; Windows Git Bash uses `ipconfig` (no
+  # ifconfig in MINGW). Either way, reject loopback (127.) and link-
+  # local (169.254.), and reject Tailscale's CGNAT range (100.64-127.)
+  # which is emitted separately below as scope=tailscale.
   local lan_ips
-  lan_ips=$(ifconfig 2>/dev/null \
-            | awk '/inet /{print $2}' \
-            | grep -vE '^(127\.|169\.254\.)' \
-            | grep -vE '^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.' )
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+      # Windows ipconfig output line:
+      #   "   IPv4 Address. . . . . . . . . . . : 192.168.1.42"
+      # CRLF needs stripping. The IP is the last colon-delimited field.
+      # Fix: pre-2026-05-02 Windows hosts emitted only [localhost,
+      # tailscale] in addresses[] — the bash ifconfig path returned
+      # nothing on Git Bash, so no lan entry — and joiners on the same
+      # /24 LAN had no way to reach the Windows host directly. Logged
+      # by Joel 2026-05-02: Windows peer joined as host but Mac
+      # joiner without Tailscale couldn't reach.
+      lan_ips=$(ipconfig 2>/dev/null \
+                | tr -d '\r' \
+                | awk -F': ' '/IPv4 Address/{print $NF}' \
+                | grep -vE '^(127\.|169\.254\.)' \
+                | grep -vE '^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.' )
+      ;;
+    *)
+      lan_ips=$(ifconfig 2>/dev/null \
+                | awk '/inet /{print $2}' \
+                | grep -vE '^(127\.|169\.254\.)' \
+                | grep -vE '^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.' )
+      ;;
+  esac
   if [ -n "$lan_ips" ]; then
     printf '%s\n' "$lan_ips" | while read -r ip; do
       [ -z "$ip" ] && continue
@@ -865,25 +888,80 @@ peer_pick_address() {
     fi
   fi
 
-  # Phase 3c: Tailscale-pick path removed. If localhost + same-LAN
-  # neither match, the joiner falls through to gh-as-bearer routing
-  # (no TCP pair-handshake needed once gh-pair lands; for now, the
-  # peer is unreachable for direct pair and gh-only messaging suffices).
+  # Tailscale: only pick if WE have a Tailscale interface ourselves.
+  # Without one, dialing 100.x just dies with "no route to host" —
+  # and (worse) the resulting "host unreachable" triggers the
+  # self-heal-as-new-host path in cmd_connect.sh which DEMOLISHES
+  # the working host's gist. Bug observed live 2026-05-02: a Mac
+  # without Tailscale fell through to the nonlocal-first fallback,
+  # picked Windows host's tailscale 100.x, failed, self-healed,
+  # nuked the gist that other peers were happily using. Joiner-side
+  # reachability is non-negotiable.
+  if _have_tailscale_locally; then
+    local pick; pick=$(printf '%s' "$addresses_json" \
+      | "$AIRC_PYTHON" -m airc_core.gistparse pick_addr tailscale 2>/dev/null)
+    if [ -n "$pick" ]; then printf '%s' "$pick"; return 0; fi
+  fi
 
-  # Fallback: first NON-LOCALHOST entry. The pre-fix `pick_addr_first`
-  # included localhost entries which the joiner — by definition on a
-  # different machine — would dial against THEIR own loopback (never
-  # reaches the host). Symptom: Joel's Windows peer subscribed to
-  # #cambriantech but stuck on a 127.0.0.1 connection because their
-  # IP didn't match the host's lan/24 subnet check + the fallback then
-  # picked the localhost entry that happened to be first in the gist's
-  # addresses[]. pick_addr_nonlocal_first skips localhost; if only
-  # localhost remains, returns empty so the caller falls through to
-  # gh-bearer-only routing (broadcast still works; direct-pair
-  # handshake is skipped). Aligns with the documented Phase 3c
-  # gh-as-bearer routing behaviour above.
+  # Fallback: first entry whose scope we can REACH. We've already
+  # tried localhost (machine_id match), lan (subnet match), and
+  # tailscale (local-presence check) above. What remains in
+  # addresses[] is some scope we don't model — e.g. a future "wan"
+  # entry, or a bespoke routing tag — give that a chance instead of
+  # ignoring it. But excluding localhost and tailscale here ensures
+  # we don't dial them blindly: localhost would mean our own loopback
+  # (never the host), and tailscale was already gated above on local
+  # presence — picking it here would re-introduce the destructive
+  # self-heal chain. Empty return → caller falls through to
+  # gh-bearer-only routing (broadcast still works; direct pair
+  # skipped).
   printf '%s' "$addresses_json" \
-    | "$AIRC_PYTHON" -m airc_core.gistparse pick_addr_nonlocal_first 2>/dev/null
+    | "$AIRC_PYTHON" -m airc_core.gistparse pick_addr_excluding localhost tailscale 2>/dev/null
+}
+
+# _have_tailscale_locally: do WE currently have a Tailscale interface
+# we can route packets through? Two probes, in priority order:
+#
+#   1. `tailscale status` reports a usable session. This is the
+#      authoritative signal — daemon is up AND signed in. Uses the
+#      same resolve_tailscale_bin chain as host_address_set so we
+#      catch winget/AppStore installs that aren't on PATH.
+#
+#   2. We have a 100.x interface. Catches the case where Tailscale
+#      is up but the CLI binary isn't reachable (e.g. macOS
+#      Tailscale.app pre-MacOS-CLI-helper, sandboxed daemon).
+#
+# Used by peer_pick_address to decide whether picking a host's
+# tailscale-scope address is reachable. Empty return on no = caller
+# treats tailscale entries as unreachable.
+_have_tailscale_locally() {
+  local ts_bin; ts_bin=$(resolve_tailscale_bin 2>/dev/null || true)
+  if [ -n "$ts_bin" ]; then
+    local ts_out; ts_out=$("$ts_bin" status 2>&1) || true
+    case "$ts_out" in
+      *"Logged out"*|*"NeedsLogin"*|*"stopped"*) ;;  # daemon down / signed out
+      *)
+        # Anything else from `tailscale status` (including the IP
+        # listing or "Tailscale is running") means we can route.
+        return 0
+        ;;
+    esac
+  fi
+  # Fallback: probe for a 100.x interface IP directly.
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+      ipconfig 2>/dev/null \
+        | tr -d '\r' \
+        | grep -qE 'IPv4 Address[^:]*: 100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.' \
+        && return 0
+      ;;
+    *)
+      ifconfig 2>/dev/null \
+        | grep -qE 'inet 100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.' \
+        && return 0
+      ;;
+  esac
+  return 1
 }
 
 # humanhash: hex string → human-readable mnemonic (e.g. "muffin-saturn-pluto-orange").

--- a/lib/airc_core/gistparse.py
+++ b/lib/airc_core/gistparse.py
@@ -175,6 +175,10 @@ def cmd_pick_addr_nonlocal_first(args) -> int:
     helper, the fallback skips localhost entries; if only localhost
     remains, returns empty so the caller falls through to gh-bearer-only
     routing instead of dialing an unreachable address.
+
+    Superseded by `pick_addr_excluding` (#395) for joiner-side
+    reachability — kept for backward compat in case external callers
+    rely on the name.
     """
     data = _read_stdin_json()
     if not isinstance(data, list):
@@ -184,6 +188,41 @@ def cmd_pick_addr_nonlocal_first(args) -> int:
             continue
         scope = entry.get("scope", "")
         if scope == "localhost":
+            continue
+        addr = entry.get("addr", "")
+        port = entry.get("port", "")
+        if addr and port != "":
+            print(f"{addr}|{port}")
+            return 0
+    return 0
+
+
+def cmd_pick_addr_excluding(args) -> int:
+    """Stdin is a list of {scope, addr, port, ...}. Print 'addr|port' for
+    the first entry whose scope is NOT in args.exclude_scopes. Empty if
+    every entry is excluded (or list is empty / malformed).
+
+    Why this exists: pick_addr_nonlocal_first hardcoded localhost as the
+    only excludable scope, but joiner-side reachability detection needs
+    to skip multiple scopes at once. Concrete case: a Mac without
+    Tailscale joining a Windows host whose addresses[] is
+    [localhost, tailscale]. The Mac can reach NEITHER. With the
+    nonlocal_first helper it would pick tailscale (first non-localhost),
+    fail to connect (no 100.x route), and trigger destructive self-heal
+    — demolishing the room gist that was working fine for everyone
+    else. With this helper, the joiner declares its unreachable scopes
+    upfront (e.g. `pick_addr_excluding localhost tailscale`), gets
+    empty back, and the caller falls through to gh-bearer-only routing.
+    """
+    excluded = set(args.exclude_scopes)
+    data = _read_stdin_json()
+    if not isinstance(data, list):
+        return 0
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        scope = entry.get("scope", "")
+        if scope in excluded:
             continue
         addr = entry.get("addr", "")
         port = entry.get("port", "")
@@ -265,6 +304,11 @@ def _build_parser() -> argparse.ArgumentParser:
 
     pnf = sub.add_parser("pick_addr_nonlocal_first")
     pnf.set_defaults(func=cmd_pick_addr_nonlocal_first)
+
+    pe = sub.add_parser("pick_addr_excluding")
+    pe.add_argument("exclude_scopes", nargs="+",
+                    help="Scope names to skip (e.g. localhost tailscale)")
+    pe.set_defaults(func=cmd_pick_addr_excluding)
 
     ll = sub.add_parser("list_lan_entries")
     ll.set_defaults(func=cmd_list_lan_entries)

--- a/test/test_gistparse.py
+++ b/test/test_gistparse.py
@@ -1,0 +1,152 @@
+"""gistparse tests — address-picker helpers used by peer_pick_address.
+
+Covers the address-filtering subcommands that bash callers pipe
+host.addresses[] JSON into. The picker chain is what decides whether
+the joiner dials localhost / lan / tailscale, so getting it wrong has
+real failure modes (loopback dials, destructive self-heal).
+
+Run: cd test && python3 test_gistparse.py
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+from airc_core import gistparse  # noqa: E402
+
+
+def _run_pick_addr_excluding(addrs, exclude_scopes):
+    """Run cmd_pick_addr_excluding with a fake stdin + capture stdout.
+    Returns the printed string with trailing newline stripped."""
+    fake_stdin = io.StringIO(json.dumps(addrs))
+    fake_args = mock.Mock(exclude_scopes=list(exclude_scopes))
+    out = io.StringIO()
+    with mock.patch("sys.stdin", fake_stdin), redirect_stdout(out):
+        rc = gistparse.cmd_pick_addr_excluding(fake_args)
+    assert rc == 0
+    return out.getvalue().rstrip("\n")
+
+
+class PickAddrExcludingTests(unittest.TestCase):
+    """Joiner-side reachability filter — must skip scopes the joiner
+    can't route to, and return EMPTY when nothing remains so the caller
+    falls through to gh-bearer-only routing instead of dialing into
+    the void (which triggers destructive self-heal)."""
+
+    LOCALHOST = {"scope": "localhost", "addr": "127.0.0.1", "port": "7547"}
+    LAN_42 = {"scope": "lan", "addr": "192.168.1.42",
+              "port": "7547", "subnet": "192.168.1.0/24"}
+    LAN_99 = {"scope": "lan", "addr": "10.0.0.99",
+              "port": "7547", "subnet": "10.0.0.0/24"}
+    TAILSCALE = {"scope": "tailscale", "addr": "100.79.156.3", "port": "7547"}
+
+    def test_excludes_localhost_picks_lan(self):
+        out = _run_pick_addr_excluding(
+            [self.LOCALHOST, self.LAN_42, self.TAILSCALE],
+            ["localhost"],
+        )
+        # Tailscale was first in the list after exclusion; lan was second.
+        # First-after-exclusion wins, so this should be lan if lan came first.
+        # Order in input: [localhost, lan, tailscale] → after excluding
+        # localhost: [lan, tailscale] → first = lan.
+        self.assertEqual(out, "192.168.1.42|7547")
+
+    def test_excludes_localhost_and_tailscale_picks_lan(self):
+        out = _run_pick_addr_excluding(
+            [self.LOCALHOST, self.LAN_42, self.TAILSCALE],
+            ["localhost", "tailscale"],
+        )
+        self.assertEqual(out, "192.168.1.42|7547")
+
+    def test_only_localhost_and_tailscale_returns_empty(self):
+        """The motivating case: Mac without Tailscale joins Windows
+        host whose addresses[] is [localhost, tailscale]. The Mac
+        excludes BOTH (localhost is its own loopback; tailscale is
+        unroutable without a tailscale interface). Empty return →
+        caller falls through to gh-bearer-only, NOT a doomed TCP
+        attempt that would trigger destructive self-heal."""
+        out = _run_pick_addr_excluding(
+            [self.LOCALHOST, self.TAILSCALE],
+            ["localhost", "tailscale"],
+        )
+        self.assertEqual(out, "")
+
+    def test_empty_input_returns_empty(self):
+        out = _run_pick_addr_excluding([], ["localhost"])
+        self.assertEqual(out, "")
+
+    def test_first_match_wins_among_remaining(self):
+        """Multiple non-excluded entries → first one wins."""
+        out = _run_pick_addr_excluding(
+            [self.LOCALHOST, self.LAN_42, self.LAN_99],
+            ["localhost"],
+        )
+        self.assertEqual(out, "192.168.1.42|7547")
+
+    def test_skips_entries_missing_addr_or_port(self):
+        """Malformed entries (missing addr/port) shouldn't be picked
+        even if their scope passes the exclusion check."""
+        broken = {"scope": "lan", "addr": "", "port": "7547"}
+        out = _run_pick_addr_excluding(
+            [broken, self.LAN_42],
+            ["localhost"],
+        )
+        self.assertEqual(out, "192.168.1.42|7547")
+
+    def test_non_dict_entries_skipped(self):
+        out = _run_pick_addr_excluding(
+            ["not a dict", 42, self.LAN_42],
+            ["localhost"],
+        )
+        self.assertEqual(out, "192.168.1.42|7547")
+
+    def test_malformed_input_returns_empty(self):
+        """Non-list stdin → empty (we preserve jq's quiet-on-malformed
+        behavior; the bash caller treats empty as 'falls through to
+        gh-bearer-only', which is the safe default)."""
+        fake_stdin = io.StringIO('{"not":"a list"}')
+        fake_args = mock.Mock(exclude_scopes=["localhost"])
+        out = io.StringIO()
+        with mock.patch("sys.stdin", fake_stdin), redirect_stdout(out):
+            rc = gistparse.cmd_pick_addr_excluding(fake_args)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.getvalue().rstrip("\n"), "")
+
+
+class PickAddrNonlocalFirstBackwardCompatTests(unittest.TestCase):
+    """pick_addr_nonlocal_first is superseded by pick_addr_excluding
+    but kept for backward compat. Verify it still behaves as before."""
+
+    def _run(self, addrs):
+        fake_stdin = io.StringIO(json.dumps(addrs))
+        out = io.StringIO()
+        with mock.patch("sys.stdin", fake_stdin), redirect_stdout(out):
+            rc = gistparse.cmd_pick_addr_nonlocal_first(mock.Mock())
+        assert rc == 0
+        return out.getvalue().rstrip("\n")
+
+    def test_skips_localhost_picks_lan(self):
+        out = self._run([
+            {"scope": "localhost", "addr": "127.0.0.1", "port": "7547"},
+            {"scope": "lan", "addr": "192.168.1.42", "port": "7547"},
+        ])
+        self.assertEqual(out, "192.168.1.42|7547")
+
+    def test_only_localhost_returns_empty(self):
+        out = self._run([
+            {"scope": "localhost", "addr": "127.0.0.1", "port": "7547"},
+        ])
+        self.assertEqual(out, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two cross-machine bugs uncovered when Joel's Windows peer hosted #cambriantech and a Mac without Tailscale tried to join. The Mac's monitor self-healed and **demolished the working room gist** because its picker chose a Tailscale address it couldn't reach.

- **Bug A (joiner picker, destructive):** post-#393 fallback picked tailscale entries even when the joiner had no Tailscale interface. Picking an unroutable scope is worse than picking nothing — empty falls through to gh-bearer-only routing; a doomed dial triggers the destructive self-heal-as-new-host chain that nukes the gist for everyone else too.
- **Bug B (Windows host LAN enumeration):** `host_address_set` used `ifconfig` to enumerate LAN IPs, but Git Bash on Windows has no `ifconfig` — Windows uses `ipconfig`. Result: Windows hosts emitted only `[localhost, tailscale]` in `host.addresses[]`, blocking same-LAN joiners from connecting directly.

## Fix

**Bug A — joiner reachability gating:**
1. New gistparse subcommand `pick_addr_excluding <scope>+` filters multiple scopes at once.
2. New `_have_tailscale_locally()` helper probes for usable Tailscale (binary signed-in OR 100.x interface present).
3. `peer_pick_address` restored Tailscale-pick path BUT gated on local presence.
4. Final fallback uses `pick_addr_excluding localhost tailscale` — empty return → gh-bearer-only routing as designed.

**Bug B — Windows ipconfig path:**
- `host_address_set` adds `MINGW*/MSYS*/CYGWIN*` branch parsing `ipconfig` output (CRLF-stripped, `IPv4 Address. . :` lines split on `: `, last field). Same loopback/link-local/CGNAT filtering as the ifconfig path.

## Tests

- `test/test_gistparse.py` (new, **10/10 passing**): `pick_addr_excluding` happy paths, empty-returns, malformed input, `pick_addr_nonlocal_first` backward-compat.
- bash syntax clean.
- Synthetic Windows `ipconfig` output → parser correctly extracts real LANs (`192.168.1.42`, `10.0.0.50`) and excludes `100.x` (Tailscale CGNAT, handled separately).

## Test plan

- [ ] CI green (Python tests + bash syntax)
- [ ] Live: Mac without Tailscale joining a Windows host → no destructive self-heal
- [ ] Live: Windows host's `host.addresses[]` includes `lan|<ip>|...` entries (verifiable via `gh api gists/<id>` after host comes online)
- [ ] Live: Mac WITH Tailscale joining same-tailnet host → still picks tailscale (regression check)

## Out of scope (separate PR)

Self-heal guard in `cmd_connect.sh:1050` — even with Bug A fixed, the self-heal still demolishes the gist when the handshake fails for ANY reason (e.g. TCP timeout on a routable address class because of firewall). Worth a guard like "only self-heal after N failed attempts on a believed-reachable address" — bigger refactor, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)