### PR TITLE
fix(formatter,#399): emit loud stdout warning when display filter drops peer chat

### DIFF
--- a/lib/airc_core/monitor_formatter.py
+++ b/lib/airc_core/monitor_formatter.py
@@ -22,6 +22,7 @@ import os
 import re
 import signal
 import sys
+import time
 
 # Inactivity watchdog: if no inbound line arrives in WATCHDOG_SEC,
 # exit with a distinct code so the caller's while-loop reconnects.
@@ -185,6 +186,61 @@ def _handle_rename(peers_dir: str, msg: str) -> bool:
             print(f"airc: nick (chain-repair) {current} → {new}", flush=True)
             return True
     return False
+
+
+# ── Display-filter drop tracking (#399 follow-up to #401) ───────────────
+# When monitor_formatter's display filter drops a peer broadcast (channel
+# stamped on the message isn't in our subscribed_channels set), we emit a
+# periodic stdout warning so the drop becomes loud — Claude Code's Monitor
+# wakes on stdout, not stderr (Mac entity 2026-05-02 PR #400 spec).
+# Without this, name-drift between sender's stamped channel and joiner's
+# subscribed_channels causes #399's 9hr silent blackout pattern.
+_filter_drop_count: dict[str, int] = {}
+_last_drop_warn_ts: float = 0.0
+DROP_WARN_INTERVAL_SEC = 60
+
+
+def _record_filter_drop(channel: str | None, fr: str) -> None:
+    if not channel:
+        return
+    _filter_drop_count[channel] = _filter_drop_count.get(channel, 0) + 1
+    # Stderr trace for daemon.log debuggability — gives the next debugger
+    # exact evidence even if stdout warning interval hasn't tripped yet.
+    try:
+        sys.stderr.write(
+            f"[airc:formatter] display-filter drop: from={fr} channel={channel!r}\n"
+        )
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+
+def _maybe_emit_drop_warning(subs_norm: set[str]) -> None:
+    """Emit one stdout warning per DROP_WARN_INTERVAL_SEC summarizing all
+    drops seen in that window. Resets the counter after emit so the
+    warning re-fires if drops continue. Stdout (not stderr) so the
+    Monitor surface sees it and the operator can run `airc subscribe`."""
+    global _last_drop_warn_ts
+    now = time.time()
+    if now - _last_drop_warn_ts < DROP_WARN_INTERVAL_SEC:
+        return
+    if not _filter_drop_count:
+        return
+    drops = ", ".join(
+        f"#{c}={n}" for c, n in sorted(_filter_drop_count.items(), key=lambda kv: -kv[1])
+    )
+    subs_str = sorted(subs_norm) if subs_norm else "[]"
+    try:
+        # ASCII-only — Windows cp1252 console can't encode unicode marks.
+        print(
+            f"airc: WARN display-filtered {drops} (subscribed: {subs_str}). "
+            f"To see them: airc subscribe <channel>",
+            flush=True,
+        )
+    except Exception:
+        pass
+    _filter_drop_count.clear()
+    _last_drop_warn_ts = now
 
 
 def run(my_name: str, peers_dir: str) -> int:
@@ -474,6 +530,18 @@ def run(my_name: str, peers_dir: str) -> int:
             line_norm = _norm(line_channel)
             subs_norm = {_norm(c) for c in subs}
             if line_norm and line_norm not in subs_norm and not addressed_to_me:
+                # b69f 2026-05-02: even after #401's '#'-prefix tolerance,
+                # legit drops still happen when the channel NAME differs
+                # (e.g. peer stamps channel='cambriantech', subs=['general'],
+                # both polling the same gist). #401 catches '#general' vs
+                # 'general'; this catches every other shape of name drift.
+                # Make the drop LOUD instead of silent — emit one stdout
+                # warning per minute summarizing what was dropped + how to
+                # subscribe. Stdout is what wakes Claude Code's Monitor;
+                # without this the bug reproduces #399's 9hr blackout
+                # under any name-mismatch (#401 only solves the # variant).
+                _record_filter_drop(line_norm, fr)
+                _maybe_emit_drop_warning(subs_norm)
                 continue
         try:
             if fr in ("airc", "sys"):

--- a/test/test_monitor_formatter.py
+++ b/test/test_monitor_formatter.py
@@ -219,5 +219,79 @@ class HeartbeatSuppressionTests(unittest.TestCase):
         self.assertEqual(out.getvalue(), "", "heartbeat must produce zero stdout output")
 
 
+class DisplayFilterLoudDropTests(unittest.TestCase):
+    """#399 follow-up to #401: when monitor_formatter's display filter
+    drops a peer broadcast (channel name truly differs, e.g.
+    'cambriantech' vs subs=['general'] — #401's '#'-prefix tolerance
+    cannot help), emit a stdout warning so Claude Code's Monitor wakes
+    + the operator sees they need `airc subscribe <channel>`.
+
+    Pre-fix: silent drop produced #399's 9-hour blackout pattern even
+    after #401 merged.
+    """
+
+    def setUp(self):
+        self._scope = tempfile.mkdtemp(prefix="airc-mf-drop-test-")
+        self._peers = os.path.join(self._scope, "peers")
+        os.makedirs(self._peers, exist_ok=True)
+        cfg = {"name": "alice", "subscribed_channels": ["general"]}
+        with open(os.path.join(self._scope, "config.json"), "w") as f:
+            json.dump(cfg, f)
+        # Force warning interval to 0 so a single drop fires the warning
+        # immediately — keeps the test deterministic.
+        self._saved_interval = mf.DROP_WARN_INTERVAL_SEC
+        mf.DROP_WARN_INTERVAL_SEC = 0
+        mf._filter_drop_count.clear()
+        mf._last_drop_warn_ts = 0.0
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._scope, ignore_errors=True)
+        mf.DROP_WARN_INTERVAL_SEC = self._saved_interval
+        mf._filter_drop_count.clear()
+        mf._last_drop_warn_ts = 0.0
+
+    def _run(self, lines):
+        body = "\n".join(json.dumps(l) for l in lines) + "\n"
+        out = io.StringIO()
+        err = io.StringIO()
+        with mock.patch.object(mf.sys, "stdin", io.StringIO(body)), \
+             mock.patch.object(mf.sys, "stdout", out), \
+             mock.patch.object(mf.sys, "stderr", err):
+            mf.run("alice", self._peers)
+        return out.getvalue(), err.getvalue()
+
+    def test_cross_channel_drop_emits_stdout_warning(self):
+        msg = {"from": "bob", "to": "all", "channel": "cambriantech",
+               "msg": "should drop", "ts": "2026-05-02T15:00:00Z"}
+        out, err = self._run([msg])
+        self.assertNotIn("should drop", out,
+            "cross-channel msg body must not display when subs filter rejects")
+        self.assertIn("WARN display-filtered", out,
+            "cross-channel drop must surface to stdout so Monitor wakes")
+        self.assertIn("cambriantech", out,
+            "warning must name the dropped channel so operator can subscribe")
+        self.assertIn("display-filter drop", err,
+            "stderr trace must record evidence for daemon.log debugging")
+
+    def test_subscribed_channel_does_not_drop(self):
+        msg = {"from": "bob", "to": "all", "channel": "general",
+               "msg": "should display", "ts": "2026-05-02T15:00:00Z"}
+        out, err = self._run([msg])
+        self.assertIn("should display", out,
+            "subscribed-channel msg must display normally")
+        self.assertNotIn("WARN display-filtered", out,
+            "subscribed-channel msg must not trigger drop warning")
+
+    def test_addressed_to_me_bypasses_filter(self):
+        msg = {"from": "bob", "to": "alice", "channel": "cambriantech",
+               "msg": "DM bypasses filter", "ts": "2026-05-02T15:00:00Z"}
+        out, err = self._run([msg])
+        self.assertIn("DM bypasses filter", out,
+            "DM addressed to us must surface across channel boundary")
+        self.assertNotIn("WARN display-filtered", out,
+            "DM bypass path must not warn-spam (no actual drop happened)")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

Closes the silent-drop pattern even after #401's '#'-prefix tolerance fix.

#401 normalizes leading '#' so '#general' == 'general' on either side. But channel names can **truly** differ — e.g. peer stamps `channel='cambriantech'`, joiner has `subscribed_channels=['general']`, both polling the same gist (host's room rename never propagated to joiner config). Pre-this-fix, the strict membership check silently dropped every cross-channel broadcast.

This is the exact 9-hour blackout pattern that produced #399 in the first place. b69f hit it again **today** (2026-05-02) — 27 peer broadcasts dropped, idle-reminder fired (separate timer; bypasses formatter), Joel had to nudge over chat to discover it.

## What

Each filter drop is recorded + every `DROP_WARN_INTERVAL_SEC=60` a single stdout warning surfaces:

```
airc: WARN display-filtered #cambriantech=27 (subscribed: ['general']). To see them: airc subscribe <channel>
```

**Stdout** — not stderr — so Claude Code's Monitor wakes (per #400's _'evidence is for the debugger, not the trash'_ rule).

Pairs with the existing fixes:
- #400: catches stuck bearers (no recv at all)
- #401: catches '#'-prefix mismatch only
- **this PR**: catches working bearers + dropping formatter (recv fine, display filter swallows on full name mismatch)

Per-drop stderr trace also written for daemon.log debugging (multi-channel debuggers get evidence even when the 60s warning interval hasn't tripped).

## Repro (real session, b69f → b741, today)

- joiner `config.subscribed_channels = ['general']`
- peer broadcasts stamped `channel='cambriantech'` (host renamed room, joiner config stale)
- 27 broadcasts in messages.jsonl, monitor_offset advancing, `bearer_state.last_recv_ts` fresh — Monitor surface saw zero chat for 9 hours
- Idle-reminder kept firing on separate timer, masking the drop as "nobody talking"

Post-fix: same scenario emits one stdout warning per minute naming the unsubscribed channel. Operator runs `airc subscribe cambriantech` (or has the AI do it) and unblocks. Warning re-fires until subscription change.

## Tests

11/11 pass (8 existing + 3 new):

- `test_cross_channel_drop_emits_stdout_warning` — drop produces stdout WARN + stderr trace
- `test_subscribed_channel_does_not_drop` — happy path still displays normally + no warn-spam
- `test_addressed_to_me_bypasses_filter` — DM across channels surfaces + no warn (no actual drop)

```
Ran 11 tests in 0.023s
OK
```

ASCII-only warning text — Windows cp1252 console can't encode unicode (per b69f memory).

## Out of scope

The deeper fix would be: when there's only ONE `channel_gists` entry, drop the display filter entirely (filtering across one channel is meaningless). Worth considering as a follow-up; for now the loud-warning approach is **strictly safer** — surfaces the bug instead of silently changing semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)