### PR TITLE
fix(monitor,#407): tighten mesh-rediscover cadence to 60s (was 300s)

### DIFF
--- a/airc
+++ b/airc
@@ -1947,10 +1947,15 @@ except Exception:
 # is out of scope; loud-fail (Mac's bearer_gh.py PR) covers that path.
 _mesh_rediscover_loop() {
   local _parent_pid="$PPID"
-  # Cadence in seconds. 300s = 5min. Joel's "satellite" framing argues
-  # for tighter cadence on critical infra; 60s would also be fine cost-
-  # wise but bursty races during legitimate teardowns get noisy.
-  local interval="${AIRC_MESH_REDISCOVER_SEC:-300}"
+  # Cadence: 60s default (was 300s). Joel's "satellite/bios" framing
+  # argues for the tightest cadence that's still gh-rate-limit safe.
+  # _mesh_find does ~1 gh api call (gist list filtered by description);
+  # 60 calls/hour/peer is well under the 5000/hr authenticated limit.
+  # Tonight's incident 2026-05-02 made this concrete: a host rotation
+  # + 5min cadence = 5min comms blackout = Joel having to manually
+  # notify every peer. 60s reduces that to <1min worst-case (still
+  # not great but 5x improvement over 300s).
+  local interval="${AIRC_MESH_REDISCOVER_SEC:-60}"
   while true; do
     sleep "$interval"
     if ! kill -0 "$_parent_pid" 2>/dev/null; then


### PR DESCRIPTION
Tonight's bus-rotation incident proved 300s too slow for satellite/bios semantics. 60s = 5x faster recovery, still gh-rate-limit safe (~60 calls/peer/hr).

When peers refresh, host-rotation blackouts drop from "5min + Joel manually notifies" to "<1min, transparent."

Companion fixes follow-up: on-bearer-fail immediate trigger (#408?), stale-binary detection on connect, aggressive `airc daemon install` prompting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)