### PR TITLE
fix(daemon,#408): Windows launcher redirects stdout → daemon.log (was missing)

### DIFF
--- a/lib/airc_bash/cmd_daemon.sh
+++ b/lib/airc_bash/cmd_daemon.sh
@@ -232,7 +232,15 @@ REM since the new airc bash from the exec is now the daemon.
 cd /d "$cwd_win"
 set AIRC_BACKGROUND_OK=1
 :loop
-"$bash_exe" -c "exec '$airc_bin_unix' connect"
+REM Stdout → daemon.log so the operator + the AI Monitor (when daemon
+REM is being read post-mortem) can see what airc actually emitted.
+REM Pre-fix: stdout went to nowhere (start /MIN cmd window had no
+REM redirect), only daemon.err captured the launcher's own restart
+REM messages — so 'airc daemon log' showed nothing useful, and
+REM "daemon.log doesn't exist" became a real symptom (b69f
+REM 2026-05-02 in #cambriantech). Stderr → daemon.err keeps the
+REM launcher's restart records separate from the airc event stream.
+"$bash_exe" -c "exec '$airc_bin_unix' connect" 1>> daemon.log 2>> daemon.err
 REM Did airc just intentionally re-exec? If marker exists and is recent,
 REM the new airc process from the exec is now the running daemon —
 REM exit the launcher loop instead of racing-respawn it.


### PR DESCRIPTION
**Direct repro of b69f's 'daemon.log doesn't exist' tonight.**

The Windows launcher .bat (generated by 'airc daemon install') invoked airc with NO stdout redirect — so airc's entire event stream went to nowhere. Only daemon.err had launcher restart records. Operator gets 'daemon.log doesn't exist' when they try to read post-mortem.

One-line fix: `1>> daemon.log 2>> daemon.err` on the airc invocation. Now stdout (event stream) → daemon.log; stderr (launcher messages) → daemon.err.

Bios-critical: daemon mode is the OS-supervised path that survives Claude session ends — but only useful if its logs exist for debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)