### PR TITLE
fix(daemon,join): #3 status honesty + #5 join-path daemon tip (b69f's daemon audit, my half)

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1244,6 +1244,16 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
       echo "  Connected to '$peer_name' (SSH not verified — messages may need retry)"
     fi
 
+    # Daemon-install discoverability on the joiner success-path (#5 from
+    # b69f's 2026-05-02 daemon audit). Pre-fix the prompt only fired
+    # at install.sh time + the post-disconnect tip in the host branch
+    # (line ~1763). Daily 'airc join' users never saw it. Adding here
+    # so every successful joiner gets the visibility — non-blocking,
+    # silent on already-installed scopes (idempotent check).
+    if ! airc_daemon_is_installed; then
+      echo "  Tip: 'airc daemon install' keeps this mesh alive across Claude session ends + sleep/wake."
+    fi
+
     # Write PID file so `airc teardown` can find us later.
     echo $$ > "$AIRC_WRITE_DIR/airc.pid"
     # Clean exit on tab close / signal: reap the ssh tail subprocess so the

--- a/lib/airc_bash/cmd_daemon.sh
+++ b/lib/airc_bash/cmd_daemon.sh
@@ -438,8 +438,24 @@ cmd_daemon_status() {
         # look for the airc-connect process (PPID=1 = orphaned-into-
         # init, which is what `start /B` produces on Windows). Falling
         # back to airc.pid lookup if that fails.
+        # Bug #3 from b69f's 2026-05-02 audit: pre-fix reported RUNNING
+        # whenever ps-ef awk matched, WITHOUT verifying with kill -0.
+        # ps-ef can report zombie/defunct/stale matches. ALWAYS verify
+        # the matched PID with kill -0 before claiming RUNNING.
+        # Also verify the launcher .bat still exists — if registry points
+        # to a deleted path, status must surface STALE rather than say
+        # RUNNING based on an unrelated airc-connect process.
+        local launcher_bat="$scope/airc-daemon.bat"
+        local launcher_status="ok"
+        if [ ! -f "$launcher_bat" ]; then
+          launcher_status="missing"
+        fi
         local live_pid
-        live_pid=$(ps -ef 2>/dev/null | awk '$3 == 1 && /airc.*connect/ && !/grep/ {print $2; exit}')
+        local raw_pid
+        raw_pid=$(ps -ef 2>/dev/null | awk '$3 == 1 && /airc.*connect/ && !/grep/ {print $2; exit}')
+        if [ -n "$raw_pid" ] && kill -0 "$raw_pid" 2>/dev/null; then
+          live_pid="$raw_pid"
+        fi
         if [ -z "$live_pid" ] && [ -f "$scope/airc.pid" ]; then
           local pidfile_pid
           pidfile_pid=$(head -1 "$scope/airc.pid" 2>/dev/null | tr -d '[:space:]')
@@ -447,10 +463,19 @@ cmd_daemon_status() {
             live_pid="$pidfile_pid (from airc.pid)"
           fi
         fi
-        if [ -n "$live_pid" ]; then
-          echo "  Status:  RUNNING (PID $live_pid)"
+        # Status decision tree, in priority order so the user sees the
+        # actionable failure mode first when more than one applies:
+        #   1. launcher_status=missing → MISSING_LAUNCHER (registry
+        #      points to a path that doesn't exist; reinstall needed)
+        #   2. live_pid set + launcher present → RUNNING (truly alive)
+        #   3. launcher present, no live pid → registered (waiting on
+        #      next logon OR daemon was killed; user can re-fire)
+        if [ "$launcher_status" = "missing" ]; then
+          echo "  Status:  MISSING_LAUNCHER ($launcher_bat absent — registry stale; reinstall: airc daemon uninstall && airc daemon install)"
+        elif [ -n "$live_pid" ]; then
+          echo "  Status:  RUNNING (PID $live_pid, launcher exists, kill -0 verified)"
         else
-          echo "  Status:  registered (will start at next logon — or 'airc daemon install' to start now)"
+          echo "  Status:  STALE/STOPPED (launcher exists but no live airc process; will start at next logon — or 'airc daemon install' to start now)"
         fi
       else
         echo "  No daemon installed. Run: airc daemon install"


### PR DESCRIPTION
Two of b69f's 5 daemon bugs from the 2026-05-02 audit:

**#3 STATUS LIES**: `airc daemon status` reported RUNNING whenever ps-ef awk matched, no kill -0 verify, no .bat existence check. Now triages: launcher missing → MISSING_LAUNCHER, ps-ef + kill -0 verified → RUNNING, otherwise STALE/STOPPED.

**#5 JOIN-PATH TIP**: daemon-install offer fired only at install.sh + post-disconnect — daily `airc join` users never saw it. Added idempotent tip on joiner success-path (matches existing host-success tip pattern).

b69f taking #2 (non-idempotent install) + #4 (crashloop research) in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)