### PR TITLE
fix(daemon,install): scope-aware idempotency (#2 from b69f's daemon audit)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -904,31 +904,48 @@ fi
 #   3. daemon already installed  — idempotent re-run; nothing to do.
 #   4. Non-TTY                   — no human to prompt; surface tip text.
 #   5. TTY interactive prompt    — default path.
+# Scope the daemon will end up wired to. Mirrors cmd_daemon.sh::_daemon_scope
+# so the "is daemon installed for this scope?" check below matches what
+# `airc daemon install` would actually create. b69f 2026-05-02 caught the
+# scope-mismatch bug: any-daemon-registered → install.sh skipped → user
+# left with no daemon for the scope they were bootstrapping.
+INSTALL_DAEMON_SCOPE="${AIRC_HOME:-$(pwd -P)/.airc}"
+
 if [ "${AIRC_INSTALL_NO_DAEMON:-0}" = "1" ]; then
   info "AIRC_INSTALL_NO_DAEMON=1 — skipping daemon install prompt"
 elif [ "${AIRC_INSTALL_YES:-0}" = "1" ]; then
-  if airc_daemon_is_installed; then
-    info "AIRC_INSTALL_YES=1 — airc daemon already installed (no-op)"
+  if airc_daemon_is_installed_for_scope "$INSTALL_DAEMON_SCOPE"; then
+    info "AIRC_INSTALL_YES=1 — airc daemon already installed for this scope (no-op)"
   else
-    info "AIRC_INSTALL_YES=1 — installing airc daemon"
+    if airc_daemon_is_installed; then
+      info "AIRC_INSTALL_YES=1 — daemon registered for a different scope; reinstalling for $INSTALL_DAEMON_SCOPE"
+    else
+      info "AIRC_INSTALL_YES=1 — installing airc daemon"
+    fi
     if "$BIN_DIR/airc" daemon install; then
       ok "airc daemon installed"
     else
       warn "airc daemon install returned non-zero (continuing — re-run manually if needed)"
     fi
   fi
-elif airc_daemon_is_installed; then
-  info "airc daemon already installed (skipping prompt)"
+elif airc_daemon_is_installed_for_scope "$INSTALL_DAEMON_SCOPE"; then
+  info "airc daemon already installed for this scope (skipping prompt)"
 elif [ ! -t 0 ] || [ ! -t 1 ]; then
   # Non-TTY install can't prompt. Surface the option so the user sees it
   # in their install transcript and can run it later — the help string
   # mirrors the post-disconnect tip in airc's reconnect path.
   info "Tip: run 'airc daemon install' to keep the mesh alive across machine sleep/wake/crash"
 else
-  printf '\n  \033[1;32m==>\033[0m Install the airc background daemon?\n'
-  printf '      Keeps the mesh alive across machine sleep/wake/crash without\n'
-  printf '      requiring you to re-run `airc connect` after every wake. Adds\n'
-  printf '      a launchd / systemd / HKCU-Run entry that auto-restarts the host.\n'
+  if airc_daemon_is_installed; then
+    printf '\n  \033[1;32m==>\033[0m airc daemon is registered, but for a different scope.\n'
+    printf '      Reinstall and wire it to %s?\n' "$INSTALL_DAEMON_SCOPE"
+    printf '      Re-registers the launcher to point at this scope; safe to do.\n'
+  else
+    printf '\n  \033[1;32m==>\033[0m Install the airc background daemon?\n'
+    printf '      Keeps the mesh alive across machine sleep/wake/crash without\n'
+    printf '      requiring you to re-run `airc connect` after every wake. Adds\n'
+    printf '      a launchd / systemd / HKCU-Run entry that auto-restarts the host.\n'
+  fi
   printf '      Skip next time by setting AIRC_INSTALL_NO_DAEMON=1.\n'
   printf '      [Y/n] '
   read -r _daemon_reply || _daemon_reply=""

--- a/lib/airc_bash/lib_daemon_detect.sh
+++ b/lib/airc_bash/lib_daemon_detect.sh
@@ -53,3 +53,90 @@ airc_daemon_is_installed() {
   esac
   return 1
 }
+
+# ── airc_daemon_is_installed_for_scope <scope> ─────────────────────────
+#
+# STRICTER variant: returns 0 only when the daemon's autostart entry is
+# installed AND wired to the given scope (i.e. a launcher / unit / plist
+# pointing at <scope>'s .bat or AIRC_HOME=<scope>).
+#
+# Use case: install.sh idempotency. The plain airc_daemon_is_installed
+# answers "user has any airc daemon" — fine for global presence checks
+# (post-disconnect tip, status banner). It returns true even when the
+# registered daemon is wired to a DIFFERENT scope from the one being
+# bootstrapped. b69f 2026-05-02 hit this: installed daemon while in
+# /c/.airc-src, then re-ran AIRC_INSTALL_YES=1 install.sh from
+# ~/continuum — install.sh saw "any airc daemon registered" → no-op'd
+# the prompt → ~/continuum had no daemon serving it. The fix is for
+# install.sh to ask scope-aware: "does the registered daemon point at
+# THIS scope?" If not, regenerate.
+#
+# Returns:
+#   0 — daemon entry exists AND points at <scope>
+#   1 — no daemon entry OR points at a different scope OR the launcher
+#       file the entry points at no longer exists on disk
+#
+# Detection strategy by platform:
+#   darwin    — read AIRC_HOME from plist EnvironmentVariables; match scope
+#   linux/wsl — grep Environment=AIRC_HOME=<scope> from systemd unit
+#   windows   — extract launcher .bat path from registry value, match
+#               against expected <scope>/airc-daemon.bat AND verify
+#               the .bat file exists
+airc_daemon_is_installed_for_scope() {
+  local target_scope="${1:-}"
+  [ -n "$target_scope" ] || return 1
+  local os; os=$(detect_platform)
+  case "$os" in
+    darwin)
+      local plist_path="$HOME/Library/LaunchAgents/com.cambriantech.airc.plist"
+      [ -f "$plist_path" ] || return 1
+      local got
+      got=$(plutil -extract EnvironmentVariables.AIRC_HOME raw "$plist_path" 2>/dev/null)
+      [ "$got" = "$target_scope" ] && return 0
+      return 1
+      ;;
+    linux|wsl)
+      local unit_path="$HOME/.config/systemd/user/airc.service"
+      [ -f "$unit_path" ] || return 1
+      # Match Environment="AIRC_HOME=<scope>" or Environment=AIRC_HOME=<scope>.
+      grep -qE "Environment=\"?AIRC_HOME=${target_scope//\//\\/}\"?($|[[:space:]])" "$unit_path" \
+        && return 0
+      return 1
+      ;;
+    windows)
+      airc_daemon_is_installed || return 1
+      # Extract registered launcher cmd line. Format from cmd_daemon.sh:
+      # `cmd /c start "" /MIN "<scope_win>\airc-daemon.bat"`.
+      local got_value
+      got_value=$(reg query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run" //v airc-monitor 2>/dev/null \
+                  | awk -F'    ' '/REG_SZ/ {print $NF}')
+      [ -n "$got_value" ] || return 1
+      # Need _to_win_path from platform_adapters.sh. Both install.sh and
+      # the airc lib-dir resolver source platform_adapters before this
+      # file. If somehow absent (atypical), fall back to a substring
+      # match on the unix-form scope which the registered .bat path
+      # won't contain — caller will see "different scope, not installed
+      # for me" which is the safer side of the failure mode (re-prompts
+      # vs falsely claims-already-installed).
+      local target_bat_win=""
+      if command -v _to_win_path >/dev/null 2>&1; then
+        target_bat_win="$(_to_win_path "$target_scope/airc-daemon.bat")"
+      fi
+      local target_bat_unix="$target_scope/airc-daemon.bat"
+      # Match either path representation in the registered cmd line.
+      # Windows form is what cmd_daemon writes, but defense-in-depth.
+      case "$got_value" in
+        *"$target_bat_win"*)
+          [ -f "$target_bat_unix" ] && return 0
+          return 1
+          ;;
+        *"$target_bat_unix"*)
+          [ -f "$target_bat_unix" ] && return 0
+          return 1
+          ;;
+      esac
+      return 1
+      ;;
+  esac
+  return 1
+}


### PR DESCRIPTION
## Why

b69f hit it 2026-05-02:
1. Installed daemon while in `/c/.airc-src`
2. Re-ran `AIRC_INSTALL_YES=1 bash install.sh` from `~/continuum`
3. `install.sh` saw "any airc daemon registered" → no-op'd the prompt
4. `~/continuum` had no daemon serving it; surface looked installed but launcher .bat pointed at the wrong scope

The `cmd_daemon_install` function itself IS idempotent (force-overwrites .bat + `reg add //f`). The bug was `install.sh`'s coarse pre-check — `airc_daemon_is_installed` answered _"any daemon anywhere?"_ not _"the daemon for THIS scope?"_.

Pairs with #410 (Mac's #3 status honesty + #5 join tip) — both make the daemon stop lying about its own state.

## What

### New: `airc_daemon_is_installed_for_scope <scope>` in `lib_daemon_detect.sh`

Stricter sibling of `airc_daemon_is_installed`. Returns 0 only when the registered launcher / unit / plist is wired to the given scope:

| OS | Check |
|----|-------|
| darwin | plist's `EnvironmentVariables.AIRC_HOME == scope` |
| linux/wsl | systemd unit has `Environment="AIRC_HOME=<scope>"` |
| windows | registry value contains `<scope>/airc-daemon.bat` AND .bat exists on disk |

Plain `airc_daemon_is_installed` is preserved unchanged for callers that want _"any daemon presence"_ (post-disconnect tip, status banner).

### `install.sh` updated

Both branches (`AIRC_INSTALL_YES=1` + interactive prompt) now use `airc_daemon_is_installed_for_scope "$INSTALL_DAEMON_SCOPE"` where `INSTALL_DAEMON_SCOPE` mirrors `cmd_daemon.sh::_daemon_scope`: `${AIRC_HOME:-$(pwd)/.airc}`.

Net effect:

| Scenario | Pre-fix | Post-fix |
|----|----|----|
| `AIRC_INSTALL_YES=1` + already installed for THIS scope | no-op | no-op (unchanged) |
| `AIRC_INSTALL_YES=1` + registered for DIFFERENT scope | **no-op** (silent miss) | **reinstall for new scope** |
| Interactive + already installed for THIS scope | skip prompt | skip prompt (unchanged) |
| Interactive + registered for DIFFERENT scope | skip prompt (silent miss) | prompt with clear "registered for a different scope; reinstall and wire to `<new>`?" |

## Tests

End-to-end smoke on Windows Git Bash with this branch:

```
$ cd ~/continuum && airc daemon install
$ airc_daemon_is_installed_for_scope ~/continuum/.airc; echo $?
0     ← was 1 pre-fix when registry pointed at different scope
$ airc_daemon_is_installed_for_scope /tmp/other/.airc; echo $?
1
$ airc daemon uninstall
$ airc_daemon_is_installed_for_scope ~/continuum/.airc; echo $?
1
```

Existing 11/11 `monitor_formatter` tests still pass.

## Pairs with b69f's 5-bug daemon audit

| Bug | Owner | Status |
|-----|-------|--------|
| #1 launcher absolute paths | Mac | #408+#409 merged |
| **#2 scope-aware install** | **b69f** | **THIS PR** |
| #3 status honesty | Mac | #410 merged |
| #4 Windows crashloop | b69f | research, next |
| #5 join-path tip | Mac | #410 merged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)