### PR TITLE
fix(monitor,daemon): skip bearer-state fallback in daemon context — kills 10-min takeover blackout (#4)

### DIFF
--- a/airc
+++ b/airc
@@ -535,6 +535,24 @@ _monitor_alive_with_bearer_fallback() {
   # Phase 2: bearer-state-freshness fallback. Only reached when pidfile
   # exists but kill -0 said all PIDs dead — could be real death, could
   # be sandbox blindness. bearer-state freshness disambiguates.
+  #
+  # Skip when AIRC_BACKGROUND_OK=1 — that env var is set by the daemon
+  # launcher (cmd_daemon.sh's .bat / launchd plist / systemd unit), and
+  # in daemon context kill -0 is reliable (no Codex-style sandbox
+  # blindness). The fallback's 600s window otherwise creates a
+  # 10-minute "daemon can't take over" blackout after an interactive
+  # airc connect dies: the dying process leaves bearer_state with a
+  # fresh last_recv_ts, the daemon's next launch sees it as "monitor
+  # alive," early-exits, and the .bat retries every 5s for 10 minutes
+  # before the window expires. b69f filed as #4 in the 2026-05-02
+  # daemon audit. Trust kill -0 in daemon context so takeover is
+  # immediate. Joel's BIOS-grade self-heal directive: substrate must
+  # work without a human in the loop, including across interactive
+  # process death.
+  if [ "${AIRC_BACKGROUND_OK:-0}" = "1" ]; then
+    echo "no"
+    return 0
+  fi
   local _reminder_secs=300
   if [ -f "$scope_dir/reminder" ]; then
     _reminder_secs=$(cat "$scope_dir/reminder" 2>/dev/null)


### PR DESCRIPTION
## Why

Last bug from b69f's 2026-05-02 daemon audit. Repro:

1. Interactive `airc connect` running, writing `bearer_state.json`
2. Process dies (Claude session end, Ctrl-C, crash)
3. Daemon launcher starts new `airc connect`
4. `_monitor_alive_with_bearer_fallback` Phase 1 (`kill -0`): all dead — falls through
5. Phase 2 (bearer_state freshness): `last_recv_ts` within 600s window → "yes"
6. New `airc connect` early-exits "monitor already running"
7. Launcher restarts every 5s, repeats until 600s window expires
8. **10-minute substrate blackout while daemon can't take over**

`daemon.err` fills with hundreds of `airc connect exited. Restarting in 5s.` lines per minute. Joel verbatim 2026-05-02: "brittle as hell."

Phase 2 was added (#370) for Codex sandbox blindness — `kill -0` lies in some sandboxes. The fallback disambiguates. But in **daemon context** (which sets `AIRC_BACKGROUND_OK=1`), `kill -0` is reliable; the fallback only causes false positives.

## What

3-line skip at the top of Phase 2: when `AIRC_BACKGROUND_OK=1`, trust `kill -0` and return `"no"` if all pidfile PIDs are dead.

```bash
if [ "${AIRC_BACKGROUND_OK:-0}" = "1" ]; then
  echo "no"
  return 0
fi
```

Effect: daemon takeover is **immediate** (next .bat iteration after interactive death) instead of delayed 10 minutes.

## Why this is safe

| Concern | Resolution |
|----|----|
| Codex sandbox loses fallback? | No — Codex doesn't set `AIRC_BACKGROUND_OK`. Behavior unchanged. |
| Wrong env var marker? | `cmd_daemon.sh:233` (.bat), `:160-162` (plist), `:331` (systemd) all set it. Cross-platform consistent. |
| False death detection? | In daemon context the only thing populating `bearer_state` is the previously-running airc connect. Phase 1 confirmed it's dead → no live monitor exists, fallback would only be lying. |

## Out of scope (follow-up)

When daemon legitimately CAN'T take over because another airc connect IS running (user has both interactive + daemon), the launcher still spams 5s restart cycles. Distinct exit code from "monitor already running" → longer .bat sleep would be the polish. Filing as follow-up.

## Closes b69f's daemon audit

| Bug | PR |
|-----|----|
| #1 launcher absolute paths | #408 + #409 (Mac) |
| #2 scope-aware install | #411 (b69f) |
| #3 status honesty | #410 (Mac) |
| **#4 daemon takeover blackout** | **THIS PR** |
| #5 join-path tip | #410 (Mac) |

5/5 audit bugs in PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)