### PR TITLE
fix(portable): wrap stat in numeric-validating helpers — kills MSYS 'File: unbound variable' bug from #419

### DIFF
--- a/lib/airc_bash/lib_auth.sh
+++ b/lib/airc_bash/lib_auth.sh
@@ -74,7 +74,13 @@ airc_detect_gh_auth_state() {
   if [ -f "$_cache_file" ]; then
     local _cache_age=0
     local _now; _now=$(date +%s 2>/dev/null || echo 0)
-    local _cache_mtime; _cache_mtime=$(stat -f %m "$_cache_file" 2>/dev/null || stat -c %Y "$_cache_file" 2>/dev/null || echo 0)
+    # Use file_mtime helper from platform_adapters.sh — handles the
+    # MSYS-trap where `stat -f %m` exits 0 with filesystem-info junk
+    # instead of an mtime, breaking the `||` fallback chain. Pre-fix,
+    # _cache_mtime captured `  File: "<path>" / ID: ... / Block size:`
+    # multi-line junk and `$(( _now - _cache_mtime ))` arithmetic
+    # tripped strict-mode "File: unbound variable" via word-splitting.
+    local _cache_mtime; _cache_mtime=$(file_mtime "$_cache_file")
     _cache_age=$(( _now - _cache_mtime ))
     if [ "$_cache_age" -lt "$_cache_ttl" ] 2>/dev/null; then
       echo "ok"

--- a/lib/airc_bash/platform_adapters.sh
+++ b/lib/airc_bash/platform_adapters.sh
@@ -109,16 +109,52 @@ port_listeners() {
   fi
 }
 
-# Return file size in bytes. Empty / 0 on failure.
-# stat is not POSIX (different flags on BSD vs GNU); chain both with
-# fallback to wc -c which IS POSIX.
+# ── Portable stat helpers — must validate numeric output, not just exit code ──
+#
+# stat differs across BSD/GNU AND has a Windows-MSYS trap: `stat -f` is
+# BSD's "format specifier" but GNU's "filesystem info." On MSYS Git Bash
+# (GNU stat), `stat -f %m FILE` exits 0 and prints multi-line filesystem
+# metadata to STDOUT — silently succeeding with non-numeric junk. The
+# usual `bsd_cmd || gnu_cmd || fallback` chain DOESN'T fall through
+# because the BSD attempt exits 0. b69f 2026-05-02 hit this on Windows:
+# arithmetic at lib_auth.sh:78 expanded the captured string and bash
+# strict-mode flagged "File: unbound variable" because the captured
+# value started with `  File: "<path>"`.
+#
+# Fix shape: each helper validates that the output is a non-empty
+# all-digits string. If not, fall through to the next strategy. Final
+# fallback echoes "0" (safe for arithmetic, signals "couldn't tell").
+
+# Internal: emit value to stdout if it's a non-negative integer, else
+# return non-zero so the caller's || chain advances.
+_emit_if_numeric() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    *) printf '%s\n' "$1"; return 0 ;;
+  esac
+}
+
+# Return file mtime as epoch seconds. Echoes 0 on any failure.
+# Try GNU stat first (Linux + MSYS) since BSD `stat -f` on MSYS
+# silently succeeds with filesystem metadata — that's the trap.
+file_mtime() {
+  local path="$1"
+  [ -f "$path" ] || { echo 0; return 0; }
+  local v
+  if v=$(stat -c %Y "$path" 2>/dev/null) && _emit_if_numeric "$v"; then return 0; fi
+  if v=$(stat -f %m "$path" 2>/dev/null) && _emit_if_numeric "$v"; then return 0; fi
+  echo 0
+}
+
+# Return file size in bytes. Echoes 0 on any failure.
 file_size() {
   local path="$1"
   [ -f "$path" ] || { echo 0; return 0; }
-  stat -f%z "$path" 2>/dev/null \
-    || stat -c%s "$path" 2>/dev/null \
-    || wc -c < "$path" 2>/dev/null \
-    || echo 0
+  local v
+  if v=$(stat -c %s "$path" 2>/dev/null) && _emit_if_numeric "$v"; then return 0; fi
+  if v=$(stat -f %z "$path" 2>/dev/null) && _emit_if_numeric "$v"; then return 0; fi
+  if v=$(wc -c < "$path" 2>/dev/null | tr -d '[:space:]') && _emit_if_numeric "$v"; then return 0; fi
+  echo 0
 }
 
 # Detect platform: emits one of macos, linux, wsl, windows-bash (Git Bash


### PR DESCRIPTION
## Hotfix for active regression

#419 (auth-state cache) introduced a Windows-fatal bug. Symptom: `airc connect` fails with:

```
lib_auth.sh: line 78: File: unbound variable
ERROR: gh auth not OK — see message above for next step
```

Affects every Windows Git Bash user post-#419. Likely missed in review because Mac has BSD stat where the bug doesn't fire.

## Root cause

`stat -f` is BSD's 'format specifier' but GNU's '--file-system'. On MSYS Git Bash (GNU stat), `stat -f %m FILE` exits 0 and emits multi-line filesystem metadata to stdout instead of mtime. The `bsd_cmd || gnu_cmd || fallback` chain doesn't trigger fallback because BSD attempt exits 0 — captured value becomes `  File: "<path>" / ID: ... / Block size: ...`. Then `$(( _now - _cache_mtime ))` arithmetic word-splits it, bash strict-mode flags 'File: unbound variable.'

## Fix

Per Joel: 'wrap in function possibly' + 'search for more violations.'

Two violations found:
1. `lib/airc_bash/lib_auth.sh:77` (the breaker)
2. `lib/airc_bash/platform_adapters.sh:118` (file_size — same pattern, hadn't bitten yet)

Both routed through new `file_mtime` / `file_size` helpers in `platform_adapters.sh`. Each helper:

1. Tries GNU stat first (Linux + MSYS = broader audience)
2. **Validates output is numeric** via `_emit_if_numeric` — the missing piece in the original chain. Exit code wasn't enough; output had to be checked too.
3. Falls through to BSD stat (macOS) on validation failure
4. `file_size` has additional POSIX `wc -c` fallback
5. Final fallback: `echo 0`

`_emit_if_numeric` uses bash case-statement glob (`*[!0-9]*`) — not regex — so it works across bash versions including 3.2 (macOS default).

## Verified end-to-end on Windows

```
$ touch /tmp/foo
$ file_mtime /tmp/foo               # 1777746712 (clean integer)
$ file_size /tmp/foo                 # 12
$ now=$(date +%s); mt=$(file_mtime /tmp/foo); echo $(( now - mt ))
# 0   ← arithmetic works, NO 'File: unbound variable'

$ airc connect
# succeeds, monitor running, takes over as host of #general per #405 self-heal
```

## Joel's broader principle ('adapt to systems')

This whole class of bug — BSD vs GNU command flag drift — bites every cross-platform shell project. The pattern fix is: don't trust exit code alone when the command might silently succeed with the wrong shape of output. Validate semantics, fall through if not what you expected.

Worth applying to other portability sites in airc as a follow-up sweep, but this PR is hotfix-scoped to the active breaker.

🤖 Drafted with Claude Opus 4.7 (1M context)
