### PR TITLE
docs+feat(doctor): README optional-layers + skills hints + airc doctor --health

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,10 +295,60 @@ For 1:1 invites the long inline `name@user@host[:port]#pubkey` string still work
 ## Validate Before You Rely On It
 
 ```bash
-airc doctor          # or: airc tests
+airc doctor             # environment health (gh, ssh, python, tailscale)
+airc doctor --connect   # pre-flight before `airc connect` (also probes cached host)
+airc doctor --health    # LIVE bus health AFTER you've joined
+airc doctor --tests     # full integration suite (~245 assertions, 32 scenarios)
+airc doctor --fix       # repair recoverable issues (currently: gh auth re-login)
 ```
 
-Runs the bundled integration suite (~245 assertions across 32 scenarios) against this machine. Uses an isolated test port (7549) and `AIRC_HOME=/tmp/airc-it-*` — won't touch a live session on the default 7547 or a common alt like 7548. Scenarios cover: pairing, scope isolation, reminders, teardown, send queue, reconnect, status, auth-failure detection, multi-room sidecars, cross-scope peer/whois aggregation, /part persistence, IRC-aligned commands (away/back/list/quit), and platform adapters.
+`--health` is the post-join surface that answers *"is my bus actually working RIGHT NOW?"* — checks gh API rate-limit headroom, daemon liveness (if installed), and per-channel bearer last-recv age. Catches the silent-blackout failure modes (rate-limited, daemon crashed, bearer wedged) without you having to dig through logs. Run it any time peers feel quiet.
+
+The integration suite uses an isolated test port (7549) and `AIRC_HOME=/tmp/airc-it-*` — won't touch a live session on the default 7547 or a common alt like 7548. Scenarios cover: pairing, scope isolation, reminders, teardown, send queue, reconnect, status, auth-failure detection, multi-room sidecars, cross-scope peer/whois aggregation, /part persistence, IRC-aligned commands (away/back/list/quit), and platform adapters.
+
+## Optional layers — daemon, Tailscale, redundancy ladder
+
+airc works as a single-shell substrate by default (start `airc join`, run while you're at the keyboard). Several optional layers buy you increasing reliability — you can stop at whatever rung is enough for your use case.
+
+### Daemon mode (single-machine resilience)
+
+```bash
+airc daemon install     # registers launchd (mac) / systemd-user (linux) / HKCU Run (Windows)
+airc daemon status      # is it up?
+airc daemon log         # recent logs
+airc daemon uninstall   # tear it down
+```
+
+The daemon survives sleep/wake/crash and re-establishes the bearer poll loop automatically. If you just installed `airc` and the user closes their laptop a lot, install the daemon — it converts "host died because lid closed" into "host paused, reconnects on wake." See `lib/airc_bash/cmd_daemon.sh` for the platform-specific launcher logic.
+
+### Tailscale (cross-network mesh)
+
+Same-machine and same-LAN peers connect via `127.0.0.1` / LAN automatically. For cross-network peers (different homes, different ISPs, mobile), Tailscale provides the wire:
+
+- **Install**: [tailscale.com/download](https://tailscale.com/download), then `tailscale up`.
+- **macOS**: `airc join` will launch Tailscale.app for sign-in if it's installed but logged out.
+- **Linux/Windows**: `airc join` prints the `tailscale up` hint.
+- **Opt out**: `airc join --no-tailscale` if you only need same-machine/LAN.
+
+Once both peers are on the same tailnet, airc auto-picks the cheapest reachable address from the host's `addresses` list (LAN first, tailnet fallback).
+
+### Bus reliability escalation ladder
+
+If you want the bus to survive even more failure modes, there's a planned escalation ladder ([`docs/bus-reliability-escalation.md`](docs/bus-reliability-escalation.md)):
+
+| Rung | Adds independence from | Status |
+|---|---|---|
+| L1 | daemon-up requirement (sender — direct gist PATCH fallback) | designed, ready to ship |
+| L2 | daemon-up requirement (receiver — dual-source Monitor) | designed, ready to ship |
+| L3 | any single gist | this-week scope |
+| L4 | gist API entirely (Issues side-channel) | this-week scope |
+| L5 | gh as a substrate (sensor-fusion driver layer) | architectural target — see [`docs/fusion-transport.md`](docs/fusion-transport.md) |
+
+Each rung is incremental — you don't need them all to start. The ladder lets you trade complexity for survivability based on what your peers actually need.
+
+### Vuln-A sandbox (security)
+
+Peer chat broadcasts arrive at the receiving Claude session wrapped in `<peer-message-{nonce} from="..." channel="..." to="...">...</peer-message-{nonce}>` tags with all peer-controlled fields XML-escaped and a per-session random nonce on the boundary token. A peer cannot guess the nonce so cannot forge a closing tag this session; literal `</peer-message>` in body is escaped. This raises the bar against prompt-injection from peer messages — see `lib/airc_core/monitor_formatter.py` and PRs #423 + #424 for details.
 
 ## Version & Update
 

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -28,11 +28,14 @@ cmd_doctor() {
       echo "  airc doctor --fix        attempt to repair recoverable issues"
       echo "                           (currently: gh auth re-login if invalid)"
       echo "  airc doctor --connect    pre-flight checks for 'airc connect'"
+      echo "  airc doctor --health     LIVE bus health (after join — daemon, gh"
+      echo "                           rate-limit headroom, channel last-recv age)"
       echo "  airc doctor --tests      run the integration test suite"
       echo "                           (aliases: tests, test, run, suite)"
       return 0 ;;
     --tests|-t|tests|test|run|suite) shift; _doctor_run_tests "$@"; return ;;
     --connect|-c|connect)            shift; _doctor_connect_preflight "$@"; return ;;
+    --health|-H|health)              shift; _doctor_health "$@"; return ;;
     --fix|fix)                       shift; _doctor_fix "$@"; return ;;
   esac
 
@@ -411,6 +414,115 @@ _doctor_fix() {
   echo
   echo "  Summary: $fixed fixed, $skipped skipped, $failed failed."
   [ "$failed" = "0" ]
+}
+
+_doctor_health() {
+  # LIVE bus-health probe — answers "is my bus actively working RIGHT NOW?"
+  # Complements --connect (pre-flight, before join) with post-join checks
+  # against the running substrate. Joel 2026-05-02: "maybe doctor can test /
+  # so doctor could check the connection health". Surfaces the silent-
+  # blackout failure modes that bit us through the bios-hardening sprint —
+  # bearer falling behind, daemon crashed, gh rate-limit eating throughput.
+  echo
+  echo "  airc doctor --health -- live bus health"
+  echo "  ---------------------------------------"
+  echo
+  local issues=0 warns=0
+  local now; now=$(date +%s 2>/dev/null || echo 0)
+
+  # ── gh API headroom (rate-limit). Cheap; reveals whether we're near
+  # the cliff that wedged the bus pre-#416/#419.
+  if command -v gh >/dev/null 2>&1; then
+    local rate_json
+    if rate_json=$(gh api rate_limit 2>/dev/null); then
+      local core_remaining core_limit
+      core_remaining=$(echo "$rate_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['resources']['core']['remaining'])" 2>/dev/null || echo "")
+      core_limit=$(echo "$rate_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['resources']['core']['limit'])" 2>/dev/null || echo "")
+      if [ -n "$core_remaining" ] && [ -n "$core_limit" ]; then
+        if [ "$core_remaining" -lt 100 ]; then
+          printf "  [WARN] gh core rate-limit: %s/%s remaining — bus may stall soon\n" "$core_remaining" "$core_limit"
+          printf "         Mitigation: bearer auto-throttles (#416); peers will resume when window resets\n"
+          warns=$((warns+1))
+        elif [ "$core_remaining" -lt 1000 ]; then
+          printf "  [info] gh core rate-limit: %s/%s remaining (healthy headroom)\n" "$core_remaining" "$core_limit"
+        else
+          printf "  [ok] gh core rate-limit: %s/%s remaining\n" "$core_remaining" "$core_limit"
+        fi
+      else
+        printf "  [info] gh rate_limit reachable but parse failed (skipping)\n"
+      fi
+    else
+      printf "  [BLOCKED] gh API not reachable — can't probe rate-limit\n"
+      printf "         Fix: airc doctor (full env probe will diagnose)\n"
+      issues=$((issues+1))
+    fi
+  fi
+
+  # ── Daemon liveness (if installed). Daemon is optional but if installed
+  # and DOWN, the bus is in degraded mode (sends fall back to direct PATCH
+  # per #420 L1 once that ships; receives fall back per L2).
+  local daemon_pidfile="$AIRC_WRITE_DIR/daemon.pid"
+  if [ -f "$daemon_pidfile" ]; then
+    local dpid; dpid=$(cat "$daemon_pidfile" 2>/dev/null)
+    if [ -n "$dpid" ] && kill -0 "$dpid" 2>/dev/null; then
+      printf "  [ok] daemon running (pid %s)\n" "$dpid"
+    else
+      printf "  [WARN] daemon installed but DOWN (stale pid %s)\n" "${dpid:-?}"
+      printf "         Fix: airc daemon restart  (or: airc daemon status for triage)\n"
+      warns=$((warns+1))
+    fi
+  else
+    printf "  [info] daemon not installed (substrate runs in-shell only)\n"
+    printf "         Optional: airc daemon install  (survives sleep/crash, see README → Optional layers)\n"
+  fi
+
+  # ── Per-channel bearer health. bearer_state.<channel>.json's last_recv_ts
+  # is the heartbeat — if it's > 5min stale, the bearer is wedged and the
+  # AI session is going dormant on that channel.
+  local found_state=0
+  if [ -d "$AIRC_WRITE_DIR" ]; then
+    for state_file in "$AIRC_WRITE_DIR"/bearer_state.*.json; do
+      [ -f "$state_file" ] || continue
+      found_state=1
+      local channel; channel=$(basename "$state_file" .json | sed 's/^bearer_state\.//')
+      local last_recv_ts
+      last_recv_ts=$(python3 -c "import sys,json; d=json.load(open('$state_file')); print(int(d.get('last_recv_ts',0)))" 2>/dev/null || echo 0)
+      if [ "$last_recv_ts" = "0" ]; then
+        printf "  [WARN] #%s — bearer state has no last_recv_ts (never received?)\n" "$channel"
+        warns=$((warns+1))
+      else
+        local age=$((now - last_recv_ts))
+        if [ "$age" -lt 60 ]; then
+          printf "  [ok] #%s — last bearer recv %ds ago (healthy)\n" "$channel" "$age"
+        elif [ "$age" -lt 300 ]; then
+          printf "  [info] #%s — last bearer recv %ds ago (idle channel?)\n" "$channel" "$age"
+        elif [ "$age" -lt 1800 ]; then
+          printf "  [WARN] #%s — last bearer recv %ds ago (>5min stale; check daemon/rate-limit)\n" "$channel" "$age"
+          warns=$((warns+1))
+        else
+          printf "  [BLOCKED] #%s — last bearer recv %ds ago (>30min — bearer is wedged)\n" "$channel" "$age"
+          printf "           Fix: airc teardown && airc join  (re-establishes bearer poll loop)\n"
+          issues=$((issues+1))
+        fi
+      fi
+    done
+  fi
+  if [ "$found_state" = "0" ]; then
+    printf "  [info] no bearer state files — not joined to any channel yet\n"
+    printf "         Fix: airc join  (then re-run airc doctor --health)\n"
+  fi
+
+  echo
+  if [ "$issues" -eq 0 ] && [ "$warns" -eq 0 ]; then
+    echo "  ✓ Bus healthy."
+    return 0
+  elif [ "$issues" -eq 0 ]; then
+    echo "  ⚠ Bus working, $warns warning(s) above worth a look."
+    return 0
+  else
+    echo "  ✗ Bus DEGRADED on $issues issue(s) ($warns warning(s)) — see fixes above."
+    return 1
+  fi
 }
 
 _doctor_run_tests() {

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -72,12 +72,27 @@ If a failure isn't in the table:
 
 One line: "Fixed X, Y. All tests green." OR "Fixed X. Tests N passed M failed; failures: <list>." Be specific about what you did, not what was found.
 
+## Live-bus health (post-join) — `airc doctor --health`
+
+If the user is already joined and peers feel quiet, **don't wait** — run `airc doctor --health` first. It probes the running substrate (not the env) and pinpoints the silent-blackout failure modes:
+
+```bash
+airc doctor --health
+```
+
+Surfaces:
+- **gh API rate-limit headroom** — `[WARN]` if <100 remaining (bus may stall soon), `[BLOCKED]` if API unreachable. Mitigation: bearer auto-throttles (#416); peers resume when window resets.
+- **Daemon liveness** — if installed but DOWN, suggests `airc daemon restart`. If not installed, suggests it as an optional layer (survives sleep/crash).
+- **Per-channel bearer last-recv age** — `[ok]` if <60s, `[info]` if <5min (idle), `[WARN]` if 5-30min stale (check daemon/rate-limit), `[BLOCKED]` if >30min (bearer wedged — `airc teardown && airc join`).
+
+Use it BEFORE diving into logs. If `--health` is green, the bus is fine and the issue is upstream (peer not running airc, peer's gh down, etc.). If `--health` flags something, the fix is right there.
+
 ## When to run this skill
 
 - Right after install — confirms airc + gh + sshd all aligned before pairing for real.
 - After `airc update` — confirms the new binary didn't regress, and that any new env requirements (e.g. gh in #38, gh in #39) are met.
-- When something feels wrong — rule out a binary-level regression before blaming network / SSH / human error.
-- Before opening an airc issue — paste the doctor output so the maintainer doesn't have to ask.
+- **When something feels wrong** — `airc doctor --health` first (live bus state). If green, then full `airc doctor` to rule out env regressions. Logs are the third resort, not the first.
+- Before opening an airc issue — paste the doctor output (BOTH `--health` and the full env probe) so the maintainer doesn't have to ask.
 
 ## Notes
 

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -185,6 +185,7 @@ Show them the platform-appropriate command. Don't make them research it.
 
 Read actual errors. The relay prints them.
 
+- **First step when peers feel quiet:** `airc doctor --health` — single command that checks gh API rate-limit headroom + daemon liveness + per-channel bearer last-recv age. Catches the silent-blackout failure modes (rate-limited, daemon crashed, bearer wedged) without you having to dig through logs. If green, the bus is fine and the issue is upstream.
 - **gh auth missing or expired:** `gh auth status` shows it; user runs `gh auth login -s gist`. Without gh, the substrate has no wire — there's no fallback to the SSH/Tailscale era post-3c.
 - **Mesh appears quiet but `airc status` shows monitor running:** check `airc status` — bearer line should say `Ns ago via gh` with a recent timestamp. If `awaiting first event` for >2min after first peer joined, the gh poll loop is stalled (rate-limit or auth blip). Re-running `airc teardown && airc join` resets cleanly.
 - **My broadcast lands locally but peers don't see it:** verify the destination gist actually got the line: `gh api gists/<gist-id> --jq '.files["messages.jsonl"].content'` should contain your envelope. If absent, GhBearer.send silently dropped (rate limit, gist 404, auth lost) — the bearer reports `transient_failure` or `delivered`; check `airc logs` for [QUEUED] markers.


### PR DESCRIPTION
## Why

Joel 2026-05-02: *"make sure the readme is updated with the optional layers / redundancy / maybe hints in skills docs for issues, or from doctor / maybe doctor can test / so doctor could check the connection health"*.

Three pieces in one PR (single coherent UX surface so AIs/humans hitting "peers feel quiet" get a one-command answer instead of grepping logs cold).

## 1. `airc doctor --health` (new mode)

LIVE bus-health probe — answers *"is my bus actively working RIGHT NOW?"* Complements `--connect` (pre-flight, before join) with post-join checks against the running substrate. Surfaces the silent-blackout failure modes that bit us through the bios-hardening sprint:

- **gh API rate-limit headroom** (parsed from `gh api rate_limit`):
  - <100 remaining → `[WARN]` bus may stall soon
  - <1000 remaining → `[info]` healthy headroom
  - reachable → `[ok]` with raw count
  - unreachable → `[BLOCKED]`
- **Daemon liveness**: pid file + `kill -0` check
- **Per-channel bearer last-recv age** (from `bearer_state.<ch>.json`'s `last_recv_ts`):
  - <60s → `[ok]`, <5min → `[info]` (idle), 5-30min → `[WARN]`, >30min → `[BLOCKED]` (wedged)

### Smoke test (this Mac)

```
[ok] gh core rate-limit: 4853/5000 remaining
[info] daemon not installed (substrate runs in-shell only)
       Optional: airc daemon install  (survives sleep/crash, see README → Optional layers)
[BLOCKED] #cambriantech — last bearer recv 57383s ago (>30min — bearer is wedged)
         Fix: airc teardown && airc join  (re-establishes bearer poll loop)
[info] #general — last bearer recv 105s ago (idle channel?)

✗ Bus DEGRADED on 1 issue(s) — see fixes above.
```

Correctly identifies real wedged state, not a false positive.

## 2. README — Optional layers section

New section between "Validate Before You Rely On It" and "Core Commands":

- **Daemon mode** (single-machine resilience — sleep/wake/crash survival)
- **Tailscale** (cross-network mesh; LAN/same-machine work without it)
- **Bus reliability escalation ladder L1→L5** (links to `docs/bus-reliability-escalation.md` + `docs/fusion-transport.md`)
- **Vuln-A sandbox** (security; documents the per-session nonce + escape shape from #423/#424)

Plus the "Validate" section now lists ALL doctor modes.

## 3. Skills hints

- `skills/doctor/SKILL.md` — new "Live-bus health (post-join)" section + "When to run" updated: `--health` FIRST, full env probe SECOND, logs THIRD.
- `skills/join/SKILL.md` — troubleshooting section now leads with *"First step when peers feel quiet: airc doctor --health"*.

## Pairs with

- #420 (escalation-ladder design — this is the "diagnose which rung you actually need" surface)
- #418 (long-term fusion architecture — `--health` becomes per-driver health under that model)
- #423/#424 (vuln-A sandbox — README documents the defense so users know what's protecting them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)