### PR TITLE
fix(cmd_connect,#422 ci): skip gh-auth precheck on inline-invite (joiner) — unblocks integration-suite

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -271,15 +271,23 @@ cmd_connect() {
   # at connect time so the user gets a clear error instead of a
   # mystery timeout.
   #
-  # Gated on use_room=1: when the user opts into legacy 1:1 invite
-  # mode (--no-room), the substrate isn't used and gh is irrelevant.
-  # The CI clean-install smoke test specifically exercises that
-  # offline path with no gh auth — pre-#338 the unconditional check
-  # killed it before the host loop could start (PR #338 regression).
-  #
-  # Skipped entirely if a live monitor exists in this scope (handled
-  # by the trust-existing-monitor short-circuit above).
-  if [ "$use_room" = "1" ] && command -v gh >/dev/null 2>&1; then
+  # Skip cases (gh isn't needed):
+  #   1. --no-room → user opted into legacy 1:1 invite mode (no
+  #      substrate). Pre-#338 the unconditional check killed CI's
+  #      clean-install smoke test which exercises this path.
+  #   2. Inline invite-string positional arg (`name@user@host[:port]#pubkey`)
+  #      → JOIN MODE legacy direct-pair, also no substrate. The
+  #      integration suite's spawn_joiner uses this; pre-fix the
+  #      check fired and CI runners (no PAT) failed every joiner.
+  #      Pattern matches what JOIN MODE itself parses at line ~862.
+  #   3. Live monitor exists in this scope (trust-existing-monitor
+  #      short-circuit above already returned).
+  local _looks_like_invite=0
+  if [ "$#" -ge 1 ] && [[ "$1" == *@*@*#* ]]; then
+    _looks_like_invite=1
+  fi
+  if [ "$use_room" = "1" ] && [ "$_looks_like_invite" = "0" ] \
+     && command -v gh >/dev/null 2>&1; then
     # Pre-flight via the centralized state machine (lib_auth.sh).
     # ok → proceed; rate_limited → wait + retry (token fine);
     # invalid → airc instigates the browser self-heal in-process;


### PR DESCRIPTION
## Why

CI integration-suite has been red 35+ runs (since ~2026-04-30) with 10 joiner failures. After the dump-on-fail #426 added, the actual cause surfaced:

```
✗ gh CLI is installed but the GitHub token is invalid.
  Detail:
    You are not logged into any GitHub hosts. To log in, run: gh auth login
```

The integration suite's `spawn_joiner` runs `airc connect <inline-invite>` — the LEGACY direct-pair mode that doesn't use the gist substrate. But `cmd_connect`'s pre-flight gh-auth check was gated only on `use_room=1`, which is the default. The joiner doesn't pass `--no-room` (its target is parsed from the positional invite string), so the check fired on the runner which has no PAT.

## What

Add a positional-arg pattern check before the gh probe: if `$1` matches `*@*@*#*` (the inline invite string shape — same pattern JOIN MODE itself parses around line 862), skip the gh check. Pre-fix the only signal was `--no-room`, which callers had to remember; now the gating matches the actual semantic — gh is needed when the substrate is needed.

## Verification

```
$ JOIN="alpha@joelteply@192.168.1.250:7561#c3NoLWVkMjU1MTk="
$ [[ "$JOIN" == *@*@*#* ]] && echo MATCH
MATCH

$ NORMAL="--room foo"
$ [[ "$NORMAL" == *@*@*#* ]] || echo CORRECTLY-SKIPS
CORRECTLY-SKIPS
```

## Pairs with

- #426 (the dump-on-fail that revealed the actual cause)
- #422 (canary→main, 39 commits — unblocked by this so it can promote with green CI)

## Local-dev impact

None. Local-dev paths have valid gh auth, so the check was always passing for them — that's why this regression went undetected for 35+ runs on canary. CI was the only env hitting the no-PAT case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)