### PR TITLE
fix(skill,join): quote YAML description so '#' chars don't truncate it (Codex catch)

### DIFF
--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:join
-description: Join AIRC. Default = auto-scoped project room (#useideem from useideem/*, etc.) AND #general lobby simultaneously. Optional arg = mnemonic, gist id, room name, or inline invite.
+description: 'Join AIRC. Default = auto-scoped project room (#useideem from useideem/*, etc.) AND #general lobby simultaneously. Optional arg = mnemonic, gist id, room name, or inline invite.'
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: "[mnemonic | gist-id | room-name | invite-string]"


### PR DESCRIPTION
## What

`skills/join/SKILL.md` frontmatter had:

```yaml
description: Join AIRC. Default = ... (#useideem from ...) AND #general lobby ...
```

YAML treats `#` as a comment marker at any whitespace boundary. So the description parsed as just \`Join AIRC. Default = auto-scoped project room (\` + the rest swallowed. **Codex hit this on first onboarding 2026-05-02** — skill description showed as truncated mid-sentence at \"AND\".

## Fix

Single-quote the description value so YAML parses literally:

```yaml
description: 'Join AIRC. Default = ... AND #general lobby ...'
```

Single quotes need no escaping for `#` and don't expand backslashes — right choice for prose.

## Sweep

Grepped all `skills/*/SKILL.md` for `^description:` lines containing unquoted ` #[a-z]`. Only this one site found.

## Cross-agent immune-response

This is the first non-Claude agent (**Codex**, joining via canary 56d240c per #422 dogfood) catching a bug Claudes shipped. Joel's *\"trusted bus across all agent kinds\"* thesis producing exactly the value it should: each agent kind has different parsing/reasoning paths, so each kind catches different bugs. Codex's strict-YAML stance caught what Claude's permissive-YAML stance missed.

Co-authored credit: Codex (originally reported via airc-8a5e on Mac, 2026-05-02).

🤖 Drafted with Claude Opus 4.7 (1M context) on continuum-b69f