### PR TITLE
fix(update): codify Codex install-state repeatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .airc/
+.channel
 __pycache__/
 *.pyc
 .venv

--- a/lib/airc_bash/cmd_update.sh
+++ b/lib/airc_bash/cmd_update.sh
@@ -33,6 +33,7 @@ cmd_update() {
   local dir="${AIRC_DIR:-$HOME/.airc-src}"
   local channel_file="$dir/.channel"
   local requested_channel=""
+  local force=0
   while [ $# -gt 0 ]; do
     case "$1" in
       -h|--help)
@@ -50,6 +51,7 @@ cmd_update() {
         ;;
       --canary) requested_channel="canary"; shift ;;
       --main)   requested_channel="main";   shift ;;
+      --force|-f) force=1; shift ;;
       *) shift ;;
     esac
   done
@@ -74,10 +76,6 @@ cmd_update() {
   # surfaced a hostile install.sh failure with no recovery path. Either
   # auto-stash with --force, OR print a single-line copy-pasteable
   # recovery suggestion. Defaults to safety (refuse without consent).
-  local force=0
-  for _arg in "$@"; do
-    case "$_arg" in --force|-f) force=1 ;; esac
-  done
   if ! git -C "$dir" diff --quiet 2>/dev/null || ! git -C "$dir" diff --cached --quiet 2>/dev/null; then
     if [ "$force" = "1" ]; then
       echo "  ⚠  Local mods detected in $dir; --force passed → auto-stash."


### PR DESCRIPTION
## Summary

Codex dogfood exposed two install/update repeatability issues that should live in the public repo, not as local machine patches:

- airc update --force advertised auto-stash, but cmd_update shifted all args before checking for --force, so the force flag was never observed. airc update --channel canary --force and airc update --force still refused over local tracked edits.
- .channel is per-install release-channel state, but it was not ignored, so installed checkouts show dirty after normal airc channel canary / airc update use. That makes airc version report dirty for a clean install-state file.

## Fix

- Parse --force / -f in the main option loop before args are shifted away.
- Add .channel to .gitignore.

## Verification

- bash -n lib/airc_bash/cmd_update.sh
- git check-ignore -v .channel
- Temp install-clone validation: dirty tracked README.md, .channel=canary, then airc update --channel canary --force auto-stashed successfully, stayed on canary, and refreshed both Claude Code and Codex skill symlinks with no .channel dirty status.

Codex CLI 0.128.0 dogfood catch while validating #428 / #422 Codex install path.