### PR TITLE
feat(logs): airc logs --since <ts|Ns|Nm|Nh> + 2 install-state .gitignore additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 .airc/
 .channel
+# Per-install runtime state — would otherwise show as `(dirty)` in
+# `airc version`. daemon.err = post-#421 daemon launcher stderr.
+# install-elevated.ps1 = Windows elevation helper from install.ps1.
+# b69f's Windows QA on #430 surfaced these as the remaining 1/7.
+daemon.err
+install-elevated.ps1
 __pycache__/
 *.pyc
 .venv

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -221,6 +221,35 @@ else:
 
 cmd_logs() {
   ensure_init
+  # Parse optional --since <ts|Ns|Nm|Nh> first, then positional count.
+  # --since enables incremental polling — agents that run `airc logs`
+  # every prompt-cycle (Codex's satellite mode, Claude polling between
+  # Monitor events, etc.) re-ingest only NEW messages instead of the
+  # full tail. This is the diff between O(N) per-turn context burn
+  # and O(delta) per-turn — Codex hit context exhaustion 2026-05-02
+  # because polling `logs 50` every turn re-injected ~7K tokens.
+  local since=""
+  local positional=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --since)
+        [ -n "${2:-}" ] || die "--since requires an argument (ISO timestamp or relative like 60s/5m/1h)"
+        since="$2"; shift 2 ;;
+      --since=*)
+        since="${1#--since=}"; shift ;;
+      -h|--help)
+        echo "Usage: airc logs [N] [--since <ts|Ns|Nm|Nh>]"
+        echo "  N           tail this many recent messages (default 20)"
+        echo "  --since X   filter to messages newer than X. X can be:"
+        echo "              ISO timestamp (2026-05-02T19:30:00Z)"
+        echo "              relative offset (60s, 5m, 1h, 2d)"
+        echo "              For incremental polling — re-poll using the"
+        echo "              ts of the last message you saw."
+        return 0 ;;
+      *) positional+=("$1"); shift ;;
+    esac
+  done
+  set -- "${positional[@]+"${positional[@]}"}"
   local count="${1:-20}"
   # Validate count: positive integer (ideem-local-4bef caught 2026-04-29:
   # 'airc logs 0' and 'airc logs notanumber' silently exited 0 with no
@@ -240,12 +269,49 @@ cmd_logs() {
   else
     raw=$(tail -"$count" "$MESSAGES" 2>/dev/null) || true
   fi
-  echo "$raw" | "$AIRC_PYTHON" -c "
-import sys, json
+  # Pass --since as env var (not bash-interpolated into Python) so empty
+  # value doesn't produce malformed Python like `since_arg = or ''`.
+  AIRC_LOGS_SINCE="$since" echo "$raw" | AIRC_LOGS_SINCE="$since" "$AIRC_PYTHON" -c "
+import sys, json, re, os
+from datetime import datetime, timezone, timedelta
+
+since_arg = os.environ.get('AIRC_LOGS_SINCE', '')
+since_dt = None
+if since_arg:
+    # Relative offset: <N><unit> where unit is s|m|h|d
+    m = re.fullmatch(r'(\d+)([smhd])', since_arg)
+    if m:
+        n, unit = int(m.group(1)), m.group(2)
+        delta = {'s': timedelta(seconds=n), 'm': timedelta(minutes=n),
+                 'h': timedelta(hours=n),   'd': timedelta(days=n)}[unit]
+        since_dt = datetime.now(timezone.utc) - delta
+    else:
+        # ISO timestamp — accept Z suffix or +00:00
+        try:
+            since_dt = datetime.fromisoformat(since_arg.replace('Z', '+00:00'))
+            if since_dt.tzinfo is None:
+                since_dt = since_dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            sys.stderr.write(f\"airc logs --since: cannot parse '{since_arg}' (use ISO timestamp or 60s/5m/1h/2d)\n\")
+            sys.exit(2)
+
 for line in sys.stdin:
     try:
         m = json.loads(line.strip())
+        if since_dt is not None:
+            ts = m.get('ts', '')
+            if not ts:
+                continue
+            try:
+                msg_dt = datetime.fromisoformat(ts.replace('Z', '+00:00'))
+                if msg_dt.tzinfo is None:
+                    msg_dt = msg_dt.replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue
+            if msg_dt <= since_dt:
+                continue
         print(f\"[{m.get('ts','')}] {m.get('from','?')}: {m.get('msg','')}\")
-    except: pass
+    except Exception:
+        pass
 "
 }


### PR DESCRIPTION
Codex hit context exhaustion 2026-05-02 — `airc logs N` polled every prompt-cycle re-injects ~7K tokens at N=50. `--since` enables incremental polling (O(delta) per turn instead of O(N)).

```
airc logs --since 5m         # only msgs newer than 5min ago
airc logs --since 60s        # 60 seconds ago
airc logs --since 2026-05-02T19:30:00Z   # ISO timestamp
airc logs 100 --since 5m     # tail 100 then filter
```

Backward-compatible (no flag = old behavior). Bogus --since fails clearly + exits 2.

**6/6 verification:** backward compat, relative offset, impossible window, bogus arg, ISO timestamp, --help.

**Bonus:** folded b69f's Windows QA finding from #430 — adds `daemon.err` + `install-elevated.ps1` to .gitignore (both untracked install-state at repo root that trigger `(dirty)` in version output). Same fix-shape as #430's .channel; combined here since both are context-noise-reduction related.

Pairs with #430 + #422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)