### PR TITLE
fix(copilot): 5 critical residuals from PR #422 review — pre-promote cleanup

### DIFF
--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -458,19 +458,20 @@ _doctor_health() {
     fi
   fi
 
-  # ── Daemon liveness (if installed). Daemon is optional but if installed
-  # and DOWN, the bus is in degraded mode (sends fall back to direct PATCH
-  # per #420 L1 once that ships; receives fall back per L2).
-  local daemon_pidfile="$AIRC_WRITE_DIR/daemon.pid"
-  if [ -f "$daemon_pidfile" ]; then
-    local dpid; dpid=$(cat "$daemon_pidfile" 2>/dev/null)
-    if [ -n "$dpid" ] && kill -0 "$dpid" 2>/dev/null; then
-      printf "  [ok] daemon running (pid %s)\n" "$dpid"
-    else
-      printf "  [WARN] daemon installed but DOWN (stale pid %s)\n" "${dpid:-?}"
-      printf "         Fix: airc daemon restart  (or: airc daemon status for triage)\n"
-      warns=$((warns+1))
-    fi
+  # ── Daemon installed-for-this-scope check. Pre-fix probed for a
+  # `daemon.pid` file that the daemon launcher never writes anywhere
+  # (Copilot caught this on PR #422 review — `--health` always reported
+  # "not installed" even when the daemon was running). Use the canonical
+  # detector (`airc_daemon_is_installed_for_scope`) which checks the
+  # registered launchd plist / systemd unit / HKCU Run entry. Liveness
+  # itself (is the launcher actually running and successfully polling?)
+  # is what the per-channel bearer last-recv timestamps below measure
+  # transitively — if the daemon is installed AND bearer last-recv is
+  # fresh, the daemon is alive. Fresh state with no installed daemon =
+  # an interactive `airc connect` is doing the work.
+  if command -v airc_daemon_is_installed_for_scope >/dev/null 2>&1 \
+     && airc_daemon_is_installed_for_scope "$AIRC_WRITE_DIR" 2>/dev/null; then
+    printf "  [ok] daemon installed for this scope (liveness inferred from per-channel last-recv below)\n"
   else
     printf "  [info] daemon not installed (substrate runs in-shell only)\n"
     printf "         Optional: airc daemon install  (survives sleep/crash, see README → Optional layers)\n"

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -351,10 +351,19 @@ cmd_send() {
           # deleted?) and the user needs to see the original error.
           echo "  ↻ Retrying send post-heal..." >&2
           local retry_outcome retry_kind retry_detail
-          retry_outcome=$(send_via_bearer "$active_channel" "$full_msg" "$peer_name" 2>&1) || true
-          retry_kind=$(echo "$retry_outcome" | head -1)
-          retry_detail=$(echo "$retry_outcome" | tail -n +2)
-          if [ "$retry_kind" = "ok" ]; then
+          # Pre-fix called undefined `send_via_bearer` (Copilot caught
+          # this on PR #422 review — would crash at runtime under
+          # set -euo pipefail). Re-invoke the same bearer_cli pipeline
+          # the initial send used (lines ~316-320) so the retry path is
+          # exactly the original send path replayed against fresh auth.
+          retry_outcome=$(printf '%s' "$wire_msg" | "$AIRC_PYTHON" -m airc_core.bearer_cli send \
+            "$peer_name" "$active_channel" \
+            --host-target "$host_target" \
+            --remote-home "$rhome" \
+            --room-gist-id "$room_gist_id" 2>&1) || true
+          retry_kind=$(printf '%s' "$retry_outcome" | "$AIRC_PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("kind",""))' 2>/dev/null)
+          retry_detail=$(printf '%s' "$retry_outcome" | "$AIRC_PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("detail",""))' 2>/dev/null)
+          if [ "$retry_kind" = "delivered" ]; then
             echo "  ✓ Sent post-heal." >&2
             return 0
           fi

--- a/lib/airc_bash/cmd_teardown.sh
+++ b/lib/airc_bash/cmd_teardown.sh
@@ -151,13 +151,17 @@ cmd_teardown() {
   if [ "${AIRC_TEARDOWN_PART_ONLY:-0}" = "1" ]; then
     : # cmd_part path — skip sidecar
   elif [ -d "$_sidecar_scope" ]; then
-    if [ -f "$_sidecar_scope/host_gist_id" ] && command -v gh >/dev/null 2>&1; then
+    # PRESERVE sidecar #general gist (Copilot caught on PR #422 review:
+    # primary scope correctly preserves per #415's bus stability
+    # principle, but sidecar #general was still being deleted — defeating
+    # the same principle for the lobby. Apply #415's fix-shape here too.
+    # Use 'airc part #general' when you actually want to dissolve the
+    # lobby; otherwise let the gist persist across teardowns.
+    if [ -f "$_sidecar_scope/host_gist_id" ]; then
       local _td_sc_gist; _td_sc_gist=$(cat "$_sidecar_scope/host_gist_id" 2>/dev/null)
       if [ -n "$_td_sc_gist" ]; then
-        if gh gist delete "$_td_sc_gist" --yes >/dev/null 2>&1; then
-          echo "  deleted sidecar #general gist: $_td_sc_gist"
-        fi
-        rm -f "$_sidecar_scope/host_gist_id"
+        echo "  preserving sidecar #general gist: $_td_sc_gist (bus stability — use 'airc part #general' to dissolve)"
+        # Intentionally do NOT rm host_gist_id — next start re-uses it.
       fi
     fi
     if [ -f "$_sidecar_scope/airc.pid" ]; then

--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -143,7 +143,19 @@ def _classify_gh_error(combined_output: str, exit_nonzero: bool) -> str:
     # retry will keep returning 404 forever. Distinct from auth_failure
     # because re-auth does not help; only `airc join --room <name>` to
     # re-host (or another peer's takeover) will create a new mapping.
-    if "(http 404)" in body or "not found" in body:
+    #
+    # Pre-fix matched bare "not found" (Copilot caught on PR #422 review)
+    # — that substring is in the unrelated "gh CLI not found on PATH"
+    # message, which would mis-route to "gone" and trigger the wrong
+    # recovery (clearing channel_gists when the actual problem is
+    # missing tooling). Anchor the match: explicit HTTP 404 OR
+    # "not found"/"could not resolve" with gist/gh-API context.
+    if (
+        "(http 404)" in body
+        or "404 not found" in body
+        or "not found (404)" in body
+        or "gist not found" in body
+    ):
         return "gone"
 
     # 401 / 403 (without the rate-limit body matched above) — auth-class

--- a/lib/airc_core/monitor_formatter.py
+++ b/lib/airc_core/monitor_formatter.py
@@ -603,12 +603,23 @@ def run(my_name: str, peers_dir: str) -> int:
                 _maybe_emit_drop_warning(subs_norm)
                 continue
         try:
+            # `line_channel` comes from the envelope's "channel" field
+            # which is peer-controlled. Pre-fix it was printed raw in
+            # the `airc: [#...]` prefix on BOTH system + peer paths,
+            # leaving an injection surface OUTSIDE the <pm-NONCE> wrap
+            # (Copilot residual on #432). Sanitize to a strict charset
+            # — channel names should be alnum + dash + underscore only;
+            # anything else is suspicious and gets replaced with `_` so
+            # the line stays single-line + parseable. Strict-but-graceful
+            # rather than reject: reject would lose visibility of bad
+            # peer messages entirely.
+            line_channel_safe = re.sub(r'[^A-Za-z0-9_\-]', '_', line_channel or '')
             if fr in ("airc", "sys"):
                 # System events (joins, parts, drain, auth, watchdog).
                 # No sandbox wrap — system-source content is trusted
                 # (originated by airc itself, not a peer).
                 # Example:  airc: [#general] alice joined
-                print(f"airc: [#{line_channel}] {msg_one_line}", flush=True)
+                print(f"airc: [#{line_channel_safe}] {msg_one_line}", flush=True)
             else:
                 # PEER-SUPPLIED content. Sandbox-wrap per vuln-A
                 # mitigation (described in docs/fusion-transport.md
@@ -671,8 +682,12 @@ def run(my_name: str, peers_dir: str) -> int:
                 # Example output:
                 #   airc: [#general] <pm-a3f1b7e2 from="bigmama"
                 #   channel="general" to="alice">quick question</pm-a3f1b7e2>
+                # Outer `[#...]` prefix uses line_channel_safe (sanitized
+                # to alnum+dash+underscore) so a peer can't escape via
+                # the channel name; INSIDE the tag, ch_e is the real
+                # value (XML-escaped) so receivers see the truth.
                 print(
-                    f"airc: [#{line_channel}] {tag_open}\n"
+                    f"airc: [#{line_channel_safe}] {tag_open}\n"
                     f"{msg_e}\n"
                     f"{tag_close}",
                     flush=True,


### PR DESCRIPTION
Verified all 5 by reading the code. All real bugs.

| # | File | Bug | Fix |
|---|---|---|---|
| 1 | `cmd_doctor.sh` | `--health` probed `daemon.pid` that nothing writes — always false-negative | Use `airc_daemon_is_installed_for_scope`; per-channel last-recv = transitive liveness |
| 2 | `cmd_send.sh:354` | `send_via_bearer` undefined → runtime crash on auth_failure retry | Re-invoke same `bearer_cli send` pipeline |
| 3 | `bearer_gh.py:146` | `"not found"` substring matched `"gh CLI not found on PATH"` → mis-routed to gist-gone | Anchor to gist context: `(http 404)`/`404 not found`/`gist not found` |
| 4 | `monitor_formatter.py:675` | `line_channel` raw OUTSIDE `<pm-NONCE>` tag → vuln-A residual | Sanitize to alnum+dash+underscore for outer prefix; XML-escaped value preserved inside tag |
| 5 | `cmd_teardown.sh:154` | Sidecar #general gist deleted on every teardown → defeats #415 bus stability | Preserve sidecar gist same as primary; only `airc part #general` dissolves |

## Verification

- `bash -n` clean on 3 modified shell files
- AST parse clean on 2 modified .py files
- `airc doctor --health` runs cleanly
- bearer_gh classifier: 4/4 incl previously-mismatched "gh CLI not found on PATH"
- 12/12 monitor_formatter unit tests
- 81/81 bearer unit tests

## Pairs with

- #422 (canary→main — this clears the last critical Copilot residuals)
- #426 (first 7 Copilot fixes from same review series)
- #432 (vuln-A wire — this finishes the line_channel residual)
- #424 (vuln-A hardening — this is the #2 residual from same threat model)
- #415 (bus-stability gist preserve — extended to sidecar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)