### PR TITLE
fix(qa): 4 real bugs caught by self-QA pass — pre-promote cleanup

### DIFF
--- a/lib/airc_bash/cmd_daemon.sh
+++ b/lib/airc_bash/cmd_daemon.sh
@@ -53,17 +53,31 @@ cmd_daemon() {
   shift 2>/dev/null || true
   case "$action" in
     -h|--help|help)
-      echo "Usage: airc daemon [install|uninstall|status|log]"
+      echo "Usage: airc daemon [install|uninstall|restart|status|log]"
       echo "  install     register OS auto-restart (launchd/systemd/schtasks)"
       echo "  uninstall   remove auto-restart registration"
+      echo "  restart     uninstall + install (pick up new airc binary)"
       echo "  status      print platform-native unit/plist state + log tail"
       echo "  log [N]     tail the daemon stdout log (default 50 lines)"
       return 0 ;;
     install)   cmd_daemon_install "$@" ;;
-    uninstall|remove|stop) cmd_daemon_uninstall "$@" ;;
+    uninstall|remove) cmd_daemon_uninstall "$@" ;;
+    restart)   shift; cmd_daemon_uninstall "$@" >/dev/null && cmd_daemon_install "$@" ;;
     status)    cmd_daemon_status "$@" ;;
     log|logs)  cmd_daemon_log "$@" ;;
-    *)         die "Usage: airc daemon [install|uninstall|status|log]" ;;
+    stop|start)
+      # 2026-05-02 QA caught: 'stop' was silently aliased to uninstall
+      # (removes registration entirely, not just halts the running
+      # process). systemd/launchd convention: stop = halt, disable =
+      # unregister. Pre-fix users typing 'airc daemon stop' got the
+      # daemon UNINSTALLED, which broke auto-restart on next login.
+      # Surface this honestly + point at the right command.
+      die "airc daemon $action is not a verb. Use:
+  airc daemon uninstall   — remove the registration entirely
+  airc daemon restart     — bounce the daemon to pick up new airc binary
+  airc daemon install     — re-register (idempotent if already installed)
+The OS launchd/systemd/HKCU manages start/stop of registered units automatically." ;;
+    *)         die "Usage: airc daemon [install|uninstall|restart|status|log]" ;;
   esac
 }
 

--- a/lib/airc_bash/cmd_rename.sh
+++ b/lib/airc_bash/cmd_rename.sh
@@ -86,20 +86,43 @@ cmd_rename() {
     die "name collision: '$new_name' is already a paired peer (run 'airc peers' to see the roster)"
   fi
   if [ -f "$MESSAGES" ]; then
+    # 2026-05-02 QA caught: my OWN historical nick (visible in
+    # messages.jsonl from before my last rename) was being treated as
+    # an "active peer" collision, blocking the natural rename-back
+    # workflow (rename to test, rename back to original). Fix: walk
+    # the [rename] chain inside the same 200-line window to mark all
+    # nicks that were US, exclude them from the collision set. The
+    # check still blocks renaming TO another peer's nick — original
+    # safety property preserved.
     if tail -200 "$MESSAGES" 2>/dev/null \
-         | "$AIRC_PYTHON" -c "
-import sys, json
-target = '$new_name'
+         | AIRC_NEW_NAME="$new_name" AIRC_OLD_NAME="$old_name" "$AIRC_PYTHON" -c "
+import sys, os, json, re
+target = os.environ.get('AIRC_NEW_NAME', '')
+my_current = os.environ.get('AIRC_OLD_NAME', '')
 seen = set()
+my_history = {my_current}  # current nick is always 'mine'
+_rn = re.compile(r'\[rename\] old=([a-z0-9-]+) new=([a-z0-9-]+)')
 for line in sys.stdin:
     try:
         m = json.loads(line)
         fr = m.get('from')
-        if fr: seen.add(fr)
-    except: pass
-sys.exit(0 if target in seen else 1)
+        msg = m.get('msg', '') or ''
+        if fr:
+            seen.add(fr)
+        # Trace [rename] chain: if either side of a rename was us,
+        # both sides are us. Multi-pass would be more correct, but
+        # the linear pass catches the common case (consecutive renames).
+        mm = _rn.match(msg)
+        if mm:
+            old_n, new_n = mm.group(1), mm.group(2)
+            if old_n in my_history or new_n in my_history:
+                my_history.add(old_n)
+                my_history.add(new_n)
+    except Exception:
+        pass
+sys.exit(0 if (target in seen and target not in my_history) else 1)
 " 2>/dev/null; then
-      die "name collision: '$new_name' has been seen as an active peer in this room (use 'airc logs' to verify)"
+      die "name collision: '$new_name' has been seen as an active (foreign) peer in this room (use 'airc logs' to verify)"
     fi
   fi
 

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -82,8 +82,22 @@ cmd_status() {
         # Walk bearer_state to find which channel is freshest, for the
         # informational message. (The helper already proved freshness;
         # we re-check just to extract the age + channel name.)
+        # Scope to subscribed_channels ONLY — same fix-shape as #428
+        # for --health. Pre-fix this globbed every bearer_state.*.json
+        # on disk INCLUDING stale files from prior subscriptions, so a
+        # parted #cambriantech room (last_recv_ts = 14kS ago) would
+        # show as the "freshest" stale value, making `airc status`
+        # report monitor age way off from actual liveness. QA caught
+        # this 2026-05-02 self-test.
         local _bs_summary; _bs_summary=$("$AIRC_PYTHON" -c "
 import json, glob, time
+subs = set()
+try:
+    cfg = json.load(open('$CONFIG'))
+    for c in cfg.get('subscribed_channels') or []:
+        subs.add(c)
+except Exception:
+    pass
 fresh = []
 for path in glob.glob('$AIRC_WRITE_DIR/bearer_state.*.json'):
     try:
@@ -91,9 +105,14 @@ for path in glob.glob('$AIRC_WRITE_DIR/bearer_state.*.json'):
     except Exception:
         continue
     ts = s.get('last_recv_ts')
-    if ts:
-        ch = path.split('bearer_state.', 1)[1].rsplit('.json', 1)[0]
-        fresh.append((int(time.time() - float(ts)), ch))
+    if not ts:
+        continue
+    ch = path.split('bearer_state.', 1)[1].rsplit('.json', 1)[0]
+    # Skip channels we no longer subscribe to. Empty subs (legacy
+    # scope) falls back to all-files for backward compat.
+    if subs and ch not in subs:
+        continue
+    fresh.append((int(time.time() - float(ts)), ch))
 if fresh:
     fresh.sort()
     age, ch = fresh[0]

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2539,17 +2539,21 @@ time.sleep(30)
     || fail "file_size on missing: expected 0, got '$_sz'"
 
   # ── detect_platform ──
+  # Canonical values per platform_adapters.sh:detect_platform —
+  # darwin / linux / wsl / windows / unknown. (2026-05-02 QA: test
+  # was originally written with 'macos'/'windows-bash' which never
+  # matched the implementation; aligned to actual emit values.)
   local _plat; _plat=$(_adapter_call "detect_platform")
   case "$_plat" in
-    macos|linux|wsl|windows-bash|unknown)
+    darwin|linux|wsl|windows|unknown)
       pass "detect_platform: returns valid value '$_plat'" ;;
     *)
       fail "detect_platform: unexpected value '$_plat'" ;;
   esac
   case "$(uname -s 2>/dev/null)" in
-    Darwin) [ "$_plat" = "macos" ] \
-      && pass "detect_platform: 'macos' on Darwin matches uname" \
-      || fail "detect_platform: Darwin should map to 'macos' (got '$_plat')" ;;
+    Darwin) [ "$_plat" = "darwin" ] \
+      && pass "detect_platform: 'darwin' on Darwin matches uname" \
+      || fail "detect_platform: Darwin should map to 'darwin' (got '$_plat')" ;;
     Linux)
       case "$_plat" in
         linux|wsl) pass "detect_platform: '$_plat' on Linux matches uname (linux or wsl)" ;;


### PR DESCRIPTION
Self-regression test on canary surfaced 4 real bugs:

| # | File | Bug | Fix |
|---|---|---|---|
| 1 | `cmd_status.sh` | monitor-state read every `bearer_state.*.json` (incl stale prior subs) → reported 4-hr-old freshness | Intersect with `subscribed_channels` from config (same fix-shape as #428) |
| 2 | `cmd_rename.sh` | own historical nick treated as collision → rename-back broken | Walk [rename] chain to mark self-history; exclude from collision set |
| 3 | `cmd_daemon.sh` | `airc daemon stop` silently ran full uninstall (broke auto-restart) | Remove misleading alias, add clear error + new `restart` verb |
| 4 | `test/integration.sh` | `detect_platform` test expected `macos`/`windows-bash` but impl emits `darwin`/`windows` | Align test to impl (callers use the impl values consistently) |

## Verification

- All 3 `bash -n` clean
- `airc daemon stop` now: `ERROR: airc daemon stop is not a verb. Use: uninstall / restart / install`
- `airc daemon restart` round-trip works
- `airc doctor --tests platform_adapters` (with AIRC_DIR=local checkout): **11/11 pass** (was 9/11)
- Self-rename forward + back works after fix; foreign-peer rename still correctly blocks

## Pairs with

- #422 (canary→main — this clears 4 real-world QA findings)
- #428 (cmd_doctor --health stale-channel — same fix-shape as B1)
- #435 (5 Copilot residuals — companion cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)