### PR TITLE
fix(qa-deeper): 3 bugs from deeper QA — multi-room subscribe + part output + send-file silent hang

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -252,6 +252,41 @@ cmd_connect() {
   # is alive — exactly the Carl-experience win for cross-vendor mesh.
   local _early_pidfile="$AIRC_WRITE_DIR/airc.pid"
   if [ "$(_monitor_alive_with_bearer_fallback "$_early_pidfile")" = "yes" ]; then
+    # 2026-05-02 QA caught (B5): if user passed --room NEWNAME and that
+    # name is NOT in subscribed_channels yet, the user's intent is
+    # "subscribe to a NEW room" — NOT "check if I'm already in mesh".
+    # Pre-fix the short-circuit always returned 0, blocking multi-room
+    # workflow. Now: if the requested room is fresh, fall through to
+    # the subscribe path so it gets added.
+    local _add_subscription=0
+    if [ "$room_explicit" = "1" ] && [ -n "$room_name" ] && [ -f "$CONFIG" ]; then
+      local _existing_subs; _existing_subs=$("$AIRC_PYTHON" -m airc_core.config read_channels --config "$CONFIG" 2>/dev/null || true)
+      if ! printf '%s\n' "$_existing_subs" | grep -qFx "$room_name"; then
+        _add_subscription=1
+      fi
+    fi
+    if [ "$_add_subscription" = "1" ]; then
+      echo "  airc connect: monitor already running; subscribing to additional room #${room_name}..."
+      # Add #room_name to subscribed_channels + resolve its gist
+      # (create if missing). The bearer for this channel will be
+      # picked up on the next _monitor_multi_channel cycle (which
+      # re-reads channel_map at top of each outer poll).
+      "$AIRC_PYTHON" -m airc_core.config subscribe --config "$CONFIG" --channel "$room_name" 2>/dev/null || true
+      # Resolve --create-if-missing: returns the gist id (find existing
+      # or create new gist named "airc room: #<channel>").
+      local _new_gist; _new_gist=$("$AIRC_PYTHON" -m airc_core.channel_gist resolve \
+          --channel "$room_name" --create-if-missing 2>&1)
+      if [ -n "$_new_gist" ] && printf '%s' "$_new_gist" | grep -qE '^[0-9a-f]{32}$'; then
+        # Save the channel→gist mapping in config so cmd_send can route to it.
+        "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
+          --config "$CONFIG" --channel "$room_name" --gist-id "$_new_gist" 2>/dev/null || true
+        echo "  ✓ Subscribed to #${room_name} (gist $_new_gist). Bearer respawn picks it up within ~30s."
+      else
+        echo "  ⚠ Subscribed to #${room_name} but gist resolve failed: $_new_gist"
+        echo "  Bearer may not pick up new room until next cycle. Try: airc list to verify gist."
+      fi
+      return 0
+    fi
     local _early_pids; _early_pids=$(cat "$_early_pidfile" 2>/dev/null | tr '\n' ' ')
     echo "  airc connect: this scope's monitor is already running (PIDs: $_early_pids)."
     echo "    To stop it:        airc teardown"

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -291,9 +291,28 @@ cmd_send_file() {
   host_target=$(get_config_val host_target "")
   my_name=$(get_name)
 
+  # Precheck: send-file uses scp which requires the destination peer to
+  # have authorized our identity-key via the local pair-handshake. Post-
+  # Phase-3c (#281), gh-only peers (joined via gist substrate, never
+  # via TCP pair-handshake) have NO SSH authorization in the host's
+  # authorized_keys — scp would hang on "Permission denied (publickey)"
+  # for 30+ seconds with no useful error. Caught 2026-05-02 self-QA (B7).
+  #
+  # Detect the broken case + fail loud with a clear remediation.
+  if [ -z "$host_target" ]; then
+    die "send-file requires a directly-paired peer with host_target set.
+Current scope has no host_target — you're either:
+  • A host yourself (send-file is for sending TO peers, not from)
+  • A gh-only joiner whose host pair-handshake never ran
+Post-Phase-3c, send-file works only for local-pair peers (same machine
+or LAN with TCP pair-handshake). For gh-substrate peers, file transfer
+is not yet supported (gh gist has a 1MB hard limit; tracked separately).
+Use 'airc msg @${peer_name} <text>' to message via gh-bus instead, or
+share a link if the file is hosted elsewhere."
+  fi
+
   local filename; filename=$(basename "$filepath")
   local target_host="$host_target"
-  [ -z "$target_host" ] && target_host="localhost"
 
   local rhome; rhome=$(remote_home)
   relay_ssh "$target_host" "mkdir -p $rhome/files/${my_name}" 2>/dev/null

--- a/lib/airc_bash/cmd_teardown.sh
+++ b/lib/airc_bash/cmd_teardown.sh
@@ -125,7 +125,11 @@ cmd_teardown() {
   if [ "$flush" = "1" ]; then
     : # don't delete gist on --flush either; bus stays for peers
   fi
-  if [ -f "$AIRC_WRITE_DIR/host_gist_id" ]; then
+  # Skip the "preserving" message when cmd_part is the caller (it
+  # already handles its own gist-deletion + the message would
+  # contradict the "✓ Room gist deleted" line cmd_part just printed
+  # for the same scope. Caught 2026-05-02 self-QA — B6).
+  if [ -f "$AIRC_WRITE_DIR/host_gist_id" ] && [ "${AIRC_TEARDOWN_PART_ONLY:-0}" != "1" ]; then
     local _td_gist; _td_gist=$(cat "$AIRC_WRITE_DIR/host_gist_id" 2>/dev/null)
     if [ -n "$_td_gist" ]; then
       echo "  preserving hosted gist: $_td_gist (bus stability — use 'airc part' to actually delete the channel)"


### PR DESCRIPTION
Continuing 'fix till totally reliable' grind. 3 more real bugs from deeper QA on canary 2ca8073:

| # | Bug | Fix |
|---|---|---|
| **B5** | `airc join --room NEW` blocked by trust-existing-monitor short-circuit | Detect new-room intent + bypass short-circuit; subscribe + resolve gist + add mapping |
| **B6** | `airc part X` prints contradictory '✓ deleted' + 'preserving' messages | Gate teardown's preserve message on `AIRC_TEARDOWN_PART_ONLY != 1` |
| **B7** | `airc send-file PEER` hangs silently for gh-only peers | Precheck empty host_target; die loud with clear error + alternatives |

## B5 details

Multi-room workflow was broken. To add a new subscription you had to teardown + rejoin (losing all running state). Now `airc join --room NEW` on a live scope appends the subscription cleanly; bearer respawn picks it up within ~30s.

## B7 details

Post-#281 substrate is gh-only. send-file uses scp+ssh which require local pair-handshake — gh-only peers have no SSH authorization. Pre-fix scp hung 30+s with no output; user saw nothing. Now: clear error explaining the constraint + suggests alternatives.

## Verification

- `bash -n` clean on all 3 files
- B7 reproduced + fixed: clear error message instead of silent hang

## Pairs with

- #422 (keep clearing real bugs before promote)
- #438 (earlier QA-pass fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)