### PR TITLE
fix(qa): daemon bootstrap I/O error + 'airc msg @peer text' quoted-arg parse

### DIFF
--- a/lib/airc_bash/cmd_daemon.sh
+++ b/lib/airc_bash/cmd_daemon.sh
@@ -197,10 +197,37 @@ _daemon_install_launchd() {
 PLIST
   echo "  Wrote $plist_path"
   # Bootout first to reset any prior load (idempotent install).
-  launchctl bootout "gui/$(id -u)/com.cambriantech.airc" 2>/dev/null || true
-  launchctl bootstrap "gui/$(id -u)" "$plist_path" 2>&1 \
-    || die "launchctl bootstrap failed. Plist written but not loaded; check Console.app for errors."
-  launchctl enable "gui/$(id -u)/com.cambriantech.airc" 2>/dev/null || true
+  # 2026-05-02 QA caught (#9): on a re-install over an existing
+  # daemon (e.g., switching scopes), bootout removes the registration
+  # but the previous launchd-managed PID can still be in-flight when
+  # the next bootstrap fires → "Input/output error 5" (launchd's
+  # "service already loaded" signal). Wait for the PID to actually
+  # exit before bootstrapping the new plist.
+  local _service="com.cambriantech.airc"
+  local _domain="gui/$(id -u)"
+  launchctl bootout "$_domain/$_service" 2>/dev/null || true
+  # Wait up to 3s for launchd to fully unload (poll launchctl list).
+  local _i
+  for _i in 1 2 3 4 5 6; do
+    launchctl list 2>/dev/null | awk '{print $3}' | grep -qFx "$_service" || break
+    sleep 0.5
+  done
+  # Bootstrap. Capture stderr for verification — "Input/output error"
+  # can appear even when the bootstrap actually succeeded (launchd's
+  # error reporting on re-bootstrap is unreliable). Don't die() on
+  # stderr alone; verify by checking launchctl list for the service.
+  local _bs_out
+  _bs_out=$(launchctl bootstrap "$_domain" "$plist_path" 2>&1) || true
+  if launchctl list 2>/dev/null | awk '{print $3}' | grep -qFx "$_service"; then
+    : # success — service is in launchd's list; bootstrap stderr (if any) is noise
+  else
+    # Genuine failure — service not loaded.
+    if [ -n "$_bs_out" ]; then
+      echo "  ⚠  launchctl stderr: $_bs_out" >&2
+    fi
+    die "launchctl bootstrap failed — service not loaded after bootstrap call. Check Console.app for com.cambriantech.airc errors."
+  fi
+  launchctl enable "$_domain/$_service" 2>/dev/null || true
   _daemon_install_done "Loaded into launchd (gui/$(id -u)/com.cambriantech.airc)" "$scope" \
     "Note: if 'airc canary' / gist push fails under launchd, the gh keychain may not be unlocked at boot. Workaround: 'gh auth status' once after login to unlock; airc daemon picks it up on next restart."
 }

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -147,6 +147,21 @@ cmd_send() {
   # Mixed:          airc msg @user1,user2 @user3 message
   local peer_name="" msg=""
   local _peer_csv=""
+  # Pre-process: if first arg starts with `@` AND contains whitespace,
+  # the user ran `airc msg "@peer message text"` (single quoted arg).
+  # 2026-05-02 QA catch (#10): the strict charset reject below would
+  # die on the spaces. Split on first whitespace: front = @peer-token,
+  # rest = message body. Common UX intuition; matches IRC `/msg peer
+  # the message`. Bash's set -- rebuild positional args.
+  if [ $# -ge 1 ]; then
+    case "$1" in
+      @*[[:space:]]*)
+        local _front="${1%% *}"
+        local _back="${1#* }"
+        set -- "$_front" "$_back" "${@:2}"
+        ;;
+    esac
+  fi
   while [ $# -gt 0 ]; do
     case "$1" in
       @*)


### PR DESCRIPTION
Two fresh-install bugs caught while answering Joel's 'is daemon clean for new installs?' question.

| # | Bug | Fix |
|---|---|---|
| **9** | macOS daemon install emits scary 'Bootstrap failed: 5: Input/output error' + dies, even when service IS loaded | Wait for bootout to complete; verify install via `launchctl list` instead of trusting stderr |
| **10** | `airc msg "@peer some text"` (quoted single-arg) rejected as invalid peer name | Pre-process $@ to split @-arg with whitespace into separate args before parse loop |

## Why both matter for fresh installs

- #9 is a confidence-killer. New users see ERROR messages on a daemon install that actually worked. Many will assume it's broken + give up.
- #10 is an obvious UX intuition (IRC `/msg peer text` is a single line). Strict parsing was correct for safety, hostile for first-use.

## Verification

- `bash -n` clean
- #10 reproduced + fixed: parse error gone, message proceeds to send/init step

## Pairs with

- #422 (canary→main — keep grinding first-time-user UX)
- #439 (deeper-QA fixes — same pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)