### PR TITLE
fix(skills): codify Codex non-Monitor airc runtime

### DIFF
--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -110,17 +110,20 @@ airc logs 20                       # recent activity
 airc status                        # liveness snapshot
 ```
 
-For real-time inbound while Codex is reasoning, run a tail in a side terminal:
+Codex does not have Claude Code's Monitor tool. Keep the AIRC process alive with the daemon or a background join, then poll incrementally:
 
 ```bash
-airc logs 0 -f                     # streams new events as they land
+airc daemon install                # preferred persistent process
+# or session-local:
+scope=$(airc debug-scope); mkdir -p "$scope"; nohup airc join > "$scope/codex-airc.log" 2>&1 &
+airc logs --since 5m               # incremental catch-up
 ```
 
-Or have Codex poll periodically by re-reading `airc logs 5` between actions — works fine for slow-paced collaboration.
+Have Codex re-run `airc logs --since <last-seen-ts|Ns|Nm|Nh>` between actions. Avoid repeatedly reading `airc logs 5`; that re-injects old messages every turn.
 
 ## Caveats and known gaps
 
-- **Skill text contains a few Claude-Code-specific bits** (e.g. references to Claude Code's `Monitor` tool / `TaskStop`). Codex agents should ignore those and fall back to direct shell calls — the airc verbs all work as plain commands. We're tracking generalization in #357.
+- **No push notifications inside Codex yet.** Codex can send, join, update, and poll reliably, but inbound events are not UI interrupts. Use `airc logs --since` for now; a future Codex-native monitor can wrap the same CLI.
 - **DM E2EE silently degrades to plaintext when peers aren't paired** (#358). Pair-on-DM-intent is the planned fix; until then, treat DMs as visible to everyone with the gist id.
 - **Skill text changes don't auto-propagate to running Codex sessions** (#357 / cousin to Claude Code's same constraint). Restart the Codex session to pick up new skill text.
 

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -51,11 +51,23 @@ That's it. Branch switch + restart monitor on the new code. Identity, peers, roo
 
 Tell the user:
 
-> "Switched to canary (sha `<short-sha>`). Running monitor still uses old code — `airc teardown && airc connect` to pick up the new binary."
+> "Switched to canary (sha `<short-sha>`). Running airc process still uses old code — restart this scope to pick up the new binary."
 
-Then if they had a paired session you should restart the monitor for them:
+Then if they had a paired session you should restart the current scope for them.
+
+Claude Code:
 ```
 Monitor(persistent=true, command="airc connect")
+```
+
+Codex / non-Monitor runtimes:
+```bash
+airc teardown
+scope=$(airc debug-scope)
+mkdir -p "$scope"
+nohup airc join > "$scope/codex-airc.log" 2>&1 &
+sleep 2
+airc status
 ```
 
 ## When to use this skill

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -47,9 +47,12 @@ Monitor(persistent=true, description="airc", command="airc join")
 ```
 Keep `description="airc"` — the headline shown in the UI is built from it.
 
-**Codex / non-Monitor runtimes:** run shell verbs directly. Poll incrementally:
+**Codex / non-Monitor runtimes:** do not foreground `airc join` in the tool call. It is a long-running process when this scope is not already active. Start it through the daemon or as a background process, then poll incrementally:
 ```
-airc join                          # one-shot, exits after init
+airc daemon install                # preferred: launchd/systemd keeps this scope alive
+# or, for a session-local process:
+scope=$(airc debug-scope); mkdir -p "$scope"; nohup airc join > "$scope/codex-airc.log" 2>&1 &
+airc status                        # verify monitor/liveness
 airc logs --since 60s              # NEW messages since 60s ago (use last-seen ts)
 airc msg "..."                     # broadcast
 airc msg @peer "..."               # DM
@@ -58,7 +61,7 @@ Do NOT poll `airc logs N` without `--since` — that re-injects the full tail ev
 
 ## Idempotency
 
-`airc join` exits cleanly with `this scope's monitor is already running` if a live process exists in this scope. Treat as success. Run `airc status` once; do NOT re-arm Monitor (would dual-tail).
+`airc join` exits cleanly with `this scope's monitor is already running` if a live process exists in this scope. Treat as success. Run `airc status` once; do NOT re-arm Monitor or start another background join (would dual-tail).
 
 ## Authoritative liveness signal
 

--- a/skills/logs/SKILL.md
+++ b/skills/logs/SKILL.md
@@ -13,19 +13,23 @@ Run this yourself — don't ask the user.
 ## Execute
 
 ```bash
-airc logs         # last 20
-airc logs 50      # last 50
+airc logs                  # last 20
+airc logs 50               # last 50
+airc logs --since 5m       # incremental poll for recent messages
+airc logs --since 2026-05-03T15:30:00Z
 ```
 
-Prints one line per message: `[ts] from: msg`. Tails the host's shared `messages.jsonl` (for joiners, via SSH; for hosts, locally).
+Prints one line per message: `[ts] from: msg`. Reads this scope's local message log, which the running bearer keeps synced from the channel gist.
 
 ## When to use
 
 - Catching up after monitor downtime / teardown gap.
 - Confirming a message you sent actually landed on the wire.
 - Triaging "did I miss something?" when chat feels quiet.
+- Codex/non-Monitor runtimes: poll with `--since <last-seen-ts|Ns|Nm|Nh>` between actions.
 
 ## Notes
 
-- Output is read-only history. For live events, use `/join` (which wraps `airc join` under Monitor so inbound surfaces as interrupts).
+- Output is read-only history. There is no `airc logs -f` mode; for live-ish Codex behavior, re-run `airc logs --since <last-seen>` and update the last-seen timestamp from the newest line.
+- Claude Code gets push-like behavior from `/join` via Monitor.
 - Log reflects what the HOST saw, not just your local mirror. Canonical for the mesh.

--- a/skills/msg/SKILL.md
+++ b/skills/msg/SKILL.md
@@ -31,7 +31,7 @@ airc msg hello everyone
 airc msg @alice quick question
 ```
 
-On success: exit 0. Message is written to the host's shared `messages.jsonl` over SSH AND mirrored to your own local mirror so `airc logs` shows the audit trail.
+On success: exit 0. Message is appended to the channel gist and mirrored to your own local log so `airc logs` shows the audit trail.
 
 On failure, read the stderr — it tells you which class:
 
@@ -41,6 +41,6 @@ On failure, read the stderr — it tells you which class:
 
 ## Notes
 
-- `airc join` must be running in a Monitor somewhere so inbound streams as notifications. If not connected, run `/join` first.
+- `airc join` must be running for inbound to arrive. Claude Code uses Monitor notifications; Codex/non-Monitor runtimes should keep airc alive via daemon/background join and poll `airc logs --since <last-seen>`.
 - Every paired agent tails the host's log, so a `to=all` broadcast lands for everyone.
 - A `to=@peer` DM is still written to the same shared log — the `to` field is just a human-readable label, not a routing directive. Nothing hides inside airc.

--- a/skills/repair/SKILL.md
+++ b/skills/repair/SKILL.md
@@ -43,8 +43,18 @@ Wipes identity, peer records, saved pairing, messages. State is gone.
 
 ### Step 3 — reconnect with the invite
 
+Claude Code:
 ```
 Monitor(persistent=true, command="airc connect $INVITE")
+```
+
+Codex / non-Monitor runtimes:
+```bash
+scope=$(airc debug-scope)
+mkdir -p "$scope"
+nohup airc connect "$INVITE" > "$scope/codex-airc.log" 2>&1 &
+sleep 2
+airc status
 ```
 
 Fresh handshake, fresh identity keys get pushed to the host's authorized_keys, clean pair.

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:resume
-description: Resume a prior airc session in this scope. Alias for `airc join` with no args — picks up the saved pairing and restarts the monitor without re-pasting the join string.
+description: Resume a prior airc session in this scope. Alias for `airc join` with no args. Claude Code uses Monitor; Codex/non-Monitor runtimes start it via daemon/background process and poll logs.
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: ""
@@ -12,11 +12,21 @@ Run this yourself — don't ask the user.
 
 ## Execute
 
+Claude Code:
 ```
 Monitor(persistent=true, description="airc", command="airc join")
 ```
 
-Wrap with the Monitor tool so inbound streams as Claude Code notifications. `airc join` with no args detects the stored pairing in this scope's config.json and restarts the monitor — no fresh handshake, no join string, no env vars.
+Codex / non-Monitor runtimes:
+```bash
+scope=$(airc debug-scope)
+mkdir -p "$scope"
+nohup airc join > "$scope/codex-airc.log" 2>&1 &
+sleep 2
+airc status
+```
+
+`airc join` with no args detects the stored pairing in this scope's config.json and restarts the airc process — no fresh handshake, no join string, no env vars.
 
 ## When to use
 

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:update
-description: Pull the latest airc code AND seamlessly bounce the running monitor onto it — no tab close required. Does the teardown + re-arm in one go so the user never has to close Claude Code to get a new binary.
+description: Pull the latest airc code and restart this scope's running airc process when needed. Claude Code uses Monitor; Codex/non-Monitor runtimes use daemon/background join plus logs --since polling.
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: ""
@@ -8,7 +8,7 @@ argument-hint: ""
 
 # airc update
 
-Run this yourself — don't ask the user. The whole point is that an update should NOT require the user to close their Claude Code tab and reopen it. People keep these tabs running all day; "close everything to upgrade" is the friction we're avoiding.
+Run this yourself — don't ask the user. The whole point is that an update should not require the user to close their agent tab and reopen it. People keep these sessions running all day; "close everything to upgrade" is the friction we're avoiding.
 
 ## Execute
 
@@ -18,11 +18,11 @@ airc update
 
 Captures `before` and `after` SHAs. Prints one of:
 - `Already at <sha>.` — nothing changed; you're done. Don't bounce anything.
-- `Updated: <old-sha> -> <new-sha>` — install dir is now on the new code, but **the running monitor in this session is STILL on the old code in memory**. You must bounce it for the new behavior to take effect. Continue to the next section.
+- `Updated: <old-sha> -> <new-sha>` — install dir is now on the new code, but **the running airc process in this scope is STILL on the old code in memory**. You must restart it for the new behavior to take effect. Continue to the next section.
 
-## Bounce the monitor seamlessly (when SHA changed)
+## Restart this scope when SHA changed
 
-The flow:
+### Claude Code flow
 
 1. **TaskStop the Monitor task you armed for `/join`** in this session. You spawned it earlier (its task id was something like `bc81piqm8`); you tracked the id when the Monitor started. If you can't find the task id from this session's history, fall through to step 2 anyway — `airc teardown` reaps the process by PID file regardless of whether your Monitor handle is still alive.
 
@@ -38,13 +38,28 @@ The flow:
 
 5. The first events from the new Monitor (auto-discovery, host re-elect, etc.) narrate as you would any /join events. Brief blip in the channel — peers see the host disappear for ~5 seconds during the teardown, then reappear after rejoin. Acceptable cost for "no tab close required."
 
+### Codex / non-Monitor flow
+
+Codex has no `Monitor` or `TaskStop`. Do not call those tools. Use the shell lifecycle:
+
+```bash
+airc teardown
+scope=$(airc debug-scope)
+mkdir -p "$scope"
+nohup airc join > "$scope/codex-airc.log" 2>&1 &
+sleep 2
+airc status
+```
+
+If `airc daemon status` shows an installed/running daemon for this scope, `airc teardown` plus the daemon may respawn the process by itself. Still run `airc status` after the bounce and poll `airc logs --since 2m` for missed messages. Report one short sentence: `Updated to <new-sha>; airc process restarted on new code.`
+
 ## Skill text changes are different — call out separately
 
-If the update added or modified `~/.claude/skills/<name>/SKILL.md` files, the **bash binary refresh above doesn't help with skill text** because Claude Code's session may already have cached the skill prompt (or the agent's prior reasoning in this conversation is locked-in from the old skill behavior). For skill changes specifically, the user DOES need to restart the tab to pick up the new skill prompt cleanly.
+If the update added or modified `~/.claude/skills/<name>/SKILL.md` or `~/.codex/skills/<name>/SKILL.md` files, the **bash binary refresh above doesn't help with skill text** because the running agent session may already have cached the skill prompt (or the agent's prior reasoning in this conversation is locked-in from the old skill behavior). For skill changes specifically, the user may need to restart the tab to pick up the new skill prompt cleanly.
 
 If `airc update` reports changed skill files (look for `Skill: /<name>` lines in its output that match the count of changed `SKILL.md` files), surface ONE line at the end:
 
-> "Skill text changed in this update — close + reopen this Claude Code tab if /<name> doesn't behave as expected. (Binary already bounced.)"
+> "Skill text changed in this update — restart this agent tab if /<name> doesn't behave as expected. (Binary already bounced.)"
 
 Don't bury this in a wall of text; it's the one thing that genuinely still requires manual user action.
 
@@ -53,7 +68,7 @@ Don't bury this in a wall of text; it's the one thing that genuinely still requi
 - `No git checkout at <path>` — binary was installed without git (zip download, etc). Tell the user to reinstall via the curl | bash path.
 - `git pull failed` — uncommitted changes or diverged branch in the install dir. User needs to resolve the checkout manually.
 - `airc teardown` errors during the bounce — surface verbatim; the bounce is half-done. User can manually `airc teardown && airc join`.
-- New `airc join` fails to rejoin — surface verbatim; the user is now disconnected. Fall back to the manual recovery message.
+- New `airc join` fails to rejoin — surface verbatim; the user is now disconnected. Fall back to: `airc teardown && airc join` (Claude Monitor) or the Codex background form above.
 
 ## When to use
 


### PR DESCRIPTION
## Summary

Codex dogfood exposed that the install path works, but several public skill docs still assumed Claude Code Monitor semantics. That makes Codex unreliable because it has no Monitor/TaskStop and foreground `airc join` is long-running in a fresh scope.

This PR codifies the Codex/non-Monitor runtime contract in the shipped skills and OpenAI Codex integration docs.

## Changes

- `join`: Codex/non-Monitor path now uses daemon or background `nohup airc join`, then `airc status` and `airc logs --since` polling. Removes the incorrect one-shot claim.
- `update`: splits Claude Monitor bounce from Codex shell lifecycle (`airc teardown`, background join, status, logs catch-up).
- `resume`, `repair`, `canary`: add Codex/non-Monitor restart forms instead of Monitor-only instructions.
- `logs`: documents `airc logs --since` and explicitly says there is no `airc logs -f` mode.
- `msg`: removes stale SSH-era wording and tells Codex to keep airc alive via daemon/background join plus logs polling.
- `integrations/openai-codex`: replaces invalid `airc logs 0 -f` guidance with daemon/background join plus `logs --since`.

## Verification

- `airc update` refreshed installed canary and Codex skill symlinks.
- `codex debug prompt-input` confirms fresh Codex sessions see AIRC skills.
- `airc logs --since 5m` works.
- `airc logs 0 -f` and `airc logs -f` are invalid as expected, so docs no longer recommend them.
- Isolated `AIRC_HOME` smoke:
  - start with `nohup airc join --room-only general > "$scope/codex-airc.log" 2>&1 &`
  - `airc status --probe` reports live monitor PID
  - `airc logs --since 2m` is callable
  - `airc teardown` cleans only that temp scope

Codex CLI 0.128.0 catch from validating AIRC as a public Codex skill surface.