### PR TITLE
fix(teardown): reap scope parent chain when pidfile is stale

### DIFF
--- a/lib/airc_bash/cmd_teardown.sh
+++ b/lib/airc_bash/cmd_teardown.sh
@@ -270,6 +270,37 @@ cmd_teardown() {
     # which the if-block handles cleanly.
     _scope_path_pids=$(pgrep -f "$AIRC_WRITE_DIR" 2>/dev/null | sort -un || true)
     if [ -n "$_scope_path_pids" ]; then
+      # The scope-path match catches Python bearer/formatter children
+      # because their argv includes --state-file/--peers-dir paths. Their
+      # bash `airc join|connect` parents usually do NOT have AIRC_HOME in
+      # argv, only in env, so killing children alone can leave the parent
+      # alive to respawn them. Walk upward through airc-looking wrappers
+      # and reap those parents too.
+      local _scope_reap_pids="$_scope_path_pids"
+      local _sp
+      for _sp in $_scope_path_pids; do
+        local _ancestor _depth
+        _ancestor=$(proc_parent "$_sp" || true)
+        _depth=0
+        while [ -n "$_ancestor" ] && [ "$_ancestor" != "1" ] && [ "$_depth" -lt 6 ]; do
+          local _ancestor_cmd
+          _ancestor_cmd=$(proc_cmdline "$_ancestor" || true)
+          if echo "$_ancestor_cmd" | grep -Eq '(^|[[:space:]])/[^[:space:]]*/airc[[:space:]]+(connect|join)([[:space:]]|$)|(^|[[:space:]])airc[[:space:]]+(connect|join)([[:space:]]|$)|eval .*airc[[:space:]]+(connect|join)'; then
+            _scope_reap_pids="$_scope_reap_pids $_ancestor"
+            _ancestor=$(proc_parent "$_ancestor" || true)
+            _depth=$((_depth + 1))
+          else
+            break
+          fi
+        done
+      done
+      local _rp
+      for _rp in $_scope_reap_pids; do
+        local _rp_kids
+        _rp_kids=$(proc_children "$_rp" | tr '\n' ' ' || true)
+        [ -n "$_rp_kids" ] && _scope_reap_pids="$_scope_reap_pids $_rp_kids"
+      done
+      _scope_path_pids=$(echo "$_scope_reap_pids" | tr ' ' '\n' | sort -un || true)
       # Exclude our own pid + parent (this very teardown subshell) so
       # we don't suicide before completing the cleanup.
       local _self_pid="$$"

--- a/test/integration_smoke.sh
+++ b/test/integration_smoke.sh
@@ -480,6 +480,51 @@ scenario_teardown_kills_env_tagged_orphans() {
   fi
 }
 
+scenario_teardown_kills_scope_parent_chain() {
+  # Regression for Codex/non-Monitor bounce QA, 2026-05-03. In
+  # multi-channel mode the scope path is present on bearer/formatter
+  # children, but the bash `airc connect` parent argv does not include
+  # AIRC_HOME. If airc.pid is missing/stale, killing only the children
+  # leaves the parent alive to respawn them; `airc status` then reports
+  # monitor down while messages can still move.
+  section "teardown_kills_scope_parent_chain: stale pidfile still reaps airc parent"
+  require_gh || return
+
+  local rname="smoke-td-parent-$$"
+  local A_HOME
+  A_HOME=$(mktemp -d -t airc-td-parent.XXXXXX)
+  trap "cleanup_homes '$A_HOME'" RETURN
+
+  spawn_real "$A_HOME" "td-parent-$$" 7614 --room "$rname" --as-host \
+    || { fail "host failed to start"; return; }
+  sleep 3
+
+  local parent_pid
+  parent_pid=$(awk 'NR==1 {print $1; exit}' "$A_HOME/state/airc.pid" 2>/dev/null)
+  [ -n "$parent_pid" ] || { fail "no parent pid recorded"; return; }
+  pass "pre-teardown parent pid: $parent_pid"
+
+  echo "999999" > "$A_HOME/state/airc.pid"
+  AIRC_HOME="$A_HOME/state" "$AIRC" teardown >/dev/null 2>&1 || true
+  sleep 2
+
+  if kill -0 "$parent_pid" 2>/dev/null; then
+    fail "airc parent $parent_pid survived stale-pidfile teardown"
+    ps -p "$parent_pid" -o pid,ppid,command 2>/dev/null || true
+  else
+    pass "stale-pidfile teardown killed airc parent"
+  fi
+
+  local post_count
+  post_count=$(pgrep -f "$A_HOME/state" 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$post_count" = "0" ]; then
+    pass "post-teardown: zero scope-path-tagged procs"
+  else
+    fail "post-teardown: $post_count scope-path-tagged procs still alive"
+    pgrep -f "$A_HOME/state" 2>/dev/null | xargs -I{} ps -p {} -o pid,command 2>/dev/null | head -5
+  fi
+}
+
 scenario_my_scope_in_mesh() {
   # Joel 2026-04-29: 'remember you need to be part of it'. The other
   # scenarios spawn ephemeral test peers in /tmp and never include
@@ -682,11 +727,13 @@ case "${1:-all}" in
   stale_config_auto_resyncs)      scenario_stale_config_auto_resyncs ;;
   orphan_loops_self_reap)         scenario_orphan_loops_self_reap ;;
   teardown_kills_env_tagged_orphans) scenario_teardown_kills_env_tagged_orphans ;;
+  teardown_kills_scope_parent_chain) scenario_teardown_kills_scope_parent_chain ;;
   my_scope_in_mesh)               scenario_my_scope_in_mesh ;;
   all)
     scenario_clean_install_smoke
     scenario_orphan_loops_self_reap
     scenario_teardown_kills_env_tagged_orphans
+    scenario_teardown_kills_scope_parent_chain
     scenario_passive_recv
     scenario_round_trip
     scenario_status_agrees_with_send
@@ -697,7 +744,7 @@ case "${1:-all}" in
     scenario_idle_then_recv
     ;;
   *)
-    echo "Usage: $0 [passive_recv|round_trip|idle_then_recv|part_deletes_host_gist|status_agrees_with_send|stale_config_auto_resyncs|orphan_loops_self_reap|teardown_kills_env_tagged_orphans|my_scope_in_mesh|all]"
+    echo "Usage: $0 [passive_recv|round_trip|idle_then_recv|part_deletes_host_gist|status_agrees_with_send|stale_config_auto_resyncs|orphan_loops_self_reap|teardown_kills_env_tagged_orphans|teardown_kills_scope_parent_chain|my_scope_in_mesh|all]"
     exit 2
     ;;
 esac


### PR DESCRIPTION
## Summary
- Fixes a Codex/non-Monitor bounce robustness bug found after #445: stale or missing airc.pid plus multi-channel bearer children could leave the bash airc join/connect parent alive after teardown.
- Extends teardown's scope-path fallback to walk upward through airc-looking parent wrappers and reap their direct children, preventing respawn loops that make status report monitor down while traffic still moves.
- Adds a regression smoke for stale-pidfile teardown of a real gh-backed multi-channel host.

## Verification
- bash -n airc lib/airc_bash/cmd_teardown.sh test/integration_smoke.sh
- bash test/integration_smoke.sh teardown_kills_scope_parent_chain
- bash test/integration_smoke.sh teardown_kills_env_tagged_orphans
- Live continuum scope: patched teardown killed stale parent chain and daemon restarted; airc status --probe now reports likely-alive with fresh bearer state.