### PR TITLE
fix(self-heal): verify PID cmdline before treating as live monitor — closes Task #97 (airc-bios)

### DIFF
--- a/airc
+++ b/airc
@@ -513,15 +513,36 @@ _monitor_alive_with_bearer_fallback() {
   local scope_dir
   scope_dir=$(dirname "$pidfile")
 
-  # Phase 1: kill -0 (works in non-sandboxed shells; blind in Codex).
+  # Phase 1: kill -0 + cmdline verify (works in non-sandboxed shells; blind in Codex).
+  #
+  # PID-reuse trap: bare `kill -0 $pid` returns true for ANY live process at
+  # that PID, including processes the OS has REUSED the PID for after sleep+wake
+  # (or container restart, or any session that spawned through the same PID
+  # range). Joel hit this 2026-05-03: laptop slept, airc Monitor died, OS
+  # later reused the PIDs for unrelated bash/python procs, `airc status`
+  # then said "monitor running" pointing at zombie PIDs that weren't ours.
+  # Mesh effectively partitioned with no diagnosis path.
+  #
+  # Fix: a PID is only "ours" if `kill -0` says alive AND its cmdline shapes
+  # like an airc connect/join wrapper. Same regex shape as cmd_teardown's
+  # parent-chain reaper (#446) — keeps the two paths in lockstep on what
+  # "an airc process" means. PID reuse → cmdline doesn't match → treat as
+  # dead, fall through to Phase 2 (bearer-state freshness).
   if [ -f "$pidfile" ]; then
     local p raw
     raw=$(cat "$pidfile" 2>/dev/null)
     for p in $raw; do
       case "$p" in ''|*[!0-9]*) continue ;; esac
       if kill -0 "$p" 2>/dev/null; then
-        echo "yes"
-        return 0
+        local _cmd
+        _cmd=$(proc_cmdline "$p" 2>/dev/null || true)
+        if echo "$_cmd" | grep -Eq '(^|[[:space:]])/[^[:space:]]*/airc[[:space:]]+(connect|join)([[:space:]]|$)|(^|[[:space:]])airc[[:space:]]+(connect|join)([[:space:]]|$)|eval .*airc[[:space:]]+(connect|join)'; then
+          echo "yes"
+          return 0
+        fi
+        # PID alive but not airc-shaped — OS reused this PID after our
+        # monitor died (sleep/wake, container restart, etc.). Skip; let
+        # Phase 2 bearer-state freshness be the truth.
       fi
     done
   else

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -484,21 +484,38 @@ cmd_connect() {
   # multi-tab sanity-checking destructive. Post-fix: detect liveness,
   # print a one-liner pointing to the right tools, exit 0 cleanly.
   # Stale pidfile (no live PIDs) still gets cleaned up + we proceed.
+  #
+  # 2026-05-03 (#97 self-heal): bare `kill -0 $pid` returns true for ANY
+  # live process at that PID, including processes the OS has REUSED the
+  # PID for after sleep/wake. Joel hit this — slept laptop, airc died,
+  # OS reused PIDs, this block then saw "alive" against zombie PIDs and
+  # refused to self-heal. Verify cmdline shapes like airc before treating
+  # the PID as ours. Same regex shape as cmd_teardown's parent-chain
+  # reaper (#446) and the helper in airc::_monitor_alive_with_bearer_fallback.
   local stale_pidfile="$AIRC_WRITE_DIR/airc.pid"
   if [ -f "$stale_pidfile" ]; then
     local stale_pids; stale_pids=$(cat "$stale_pidfile" 2>/dev/null | tr '\n' ' ')
     local any_alive=0
+    local alive_pids=""
     for p in $stale_pids; do
-      kill -0 "$p" 2>/dev/null && any_alive=1
+      if kill -0 "$p" 2>/dev/null; then
+        local _cmd
+        _cmd=$(proc_cmdline "$p" 2>/dev/null || true)
+        if echo "$_cmd" | grep -Eq '(^|[[:space:]])/[^[:space:]]*/airc[[:space:]]+(connect|join)([[:space:]]|$)|(^|[[:space:]])airc[[:space:]]+(connect|join)([[:space:]]|$)|eval .*airc[[:space:]]+(connect|join)'; then
+          any_alive=1
+          alive_pids="$alive_pids $p"
+        fi
+      fi
     done
     if [ "$any_alive" = "1" ]; then
-      echo "  airc connect: this scope's monitor is already running (PIDs: $stale_pids)."
+      echo "  airc connect: this scope's monitor is already running (PIDs:$alive_pids)."
       echo "    To stop it:        airc teardown"
       echo "    To restart it:     airc teardown && airc connect"
       echo "    To check it:       airc status"
       return 0
     fi
-    # Stale pidfile (no live processes) — safe to clean.
+    # Stale pidfile (no live airc processes — either dead, or PIDs were
+    # reused by the OS for unrelated procs). Safe to clean.
     rm -f "$stale_pidfile"
   fi
 


### PR DESCRIPTION
## Summary

Closes Task #97 — the airc-bios self-heal gap Joel hit 2026-05-03 ("airc went down and must be remedied" → "you don't investigate").

## Bug

After laptop sleep + wake, the OS reuses PIDs for unrelated processes (bash, python, etc.). Bare `kill -0 $pid` against the stale airc.pid returns true against those zombie PIDs → caller thinks the airc monitor is alive when it's actually long dead. Mesh effectively partitioned with no diagnosis path.

Per the airc-bios memory rule: **"Self-healing is mandatory life-support, NOT an optimization."** Bare kill-0 is the single biggest false-positive that prevents self-heal in practice.

## Two call sites fixed

1. **`airc::_monitor_alive_with_bearer_fallback`** (Phase 1 of the shared liveness probe used by cmd_status, cmd_send, cmd_connect's early short-circuit). Previously: any `kill -0` true → "yes". Now: also requires cmdline regex match. PID-reused-by-OS path falls through to Phase 2 bearer-state freshness check (the truth — bearer-recv only updates that file when actually reading from the wire).

2. **`cmd_connect.sh` canonical pidfile-cleanup block** (line ~488). Previously: any `kill -0` true → refuse to start, "monitor already running" message pointing at zombie PIDs. Now: same cmdline verification → PID-reuse case treats pidfile as stale → `rm -f` → proceed with normal connect flow → mesh reforms.

## Cmdline regex shape

Identical to cmd_teardown's parent-chain reaper (#446). Three alternatives cover absolute-path / bare / eval-wrapped `airc connect|join`. Keeps the codebase consistent on what counts as "an airc process."

## What it does NOT change

- Live monitor in same scope: still detected, still respected (cmdline regex matches an actual airc connect|join).
- Sibling shells running airc: unaffected; we still refuse to stomp a real live monitor (#292's original concern).
- Bearer-state Phase 2 fallback: unchanged. Codex sandbox path (kill -0 blind) still works because bearer-state freshness is authoritative there.

## Verification

- `bash -n airc lib/airc_bash/cmd_connect.sh` clean.
- `bash test/integration_smoke.sh round_trip` 2 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)