### PR TITLE
feat(codex): add stateful inbox polling

### DIFF
--- a/airc
+++ b/airc
@@ -2234,6 +2234,7 @@ case "${1:-help}" in
   channel) shift; cmd_channel "$@" ;;
   canary) shift; cmd_update --channel canary "$@" ;;
   logs)      shift; cmd_logs "$@" ;;
+  inbox|poll|codex-poll) shift; cmd_inbox "$@" ;;
   status)    shift; cmd_status "$@" ;;
   doctor)            shift; cmd_doctor "$@" ;;
   tests|test)        shift; _doctor_run_tests "$@" ;;
@@ -2296,6 +2297,7 @@ case "${1:-help}" in
     echo "  airc daemon [install|status|uninstall|log]  Autostart via launchd (mac) / systemd (linux)"
     echo "  airc tests / doctor [scenario]  Run integration suite + environment health"
     echo "  airc status [--probe]           Liveness snapshot (--probe for SSH check)"
+    echo "  airc inbox                      Show unread messages and advance cursor"
     echo "  airc reminder <seconds>         Nudge if silent (off/pause/300)"
     echo "  airc teardown [--flush] [--all] Kill scope's airc processes (--flush wipes state)"
     echo "  airc uninstall [--yes] [--purge] Fully remove airc (clone, symlinks, daemon, processes)"

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -73,7 +73,7 @@ airc doctor
 
 Expect `All required prereqs present` and `[ok] cryptography (Ed25519 identity gen + signing)`. If anything is `[MISSING]`, follow the per-platform fix line — install.sh + doctor are designed to be self-explanatory.
 
-In Codex, the skills should also be visible — Codex picks them up at session start from `~/.codex/skills/<name>/SKILL.md`. The slash-command surface is the same as Claude Code: `/join`, `/list`, `/msg`, `/peers`, `/whois`, `/away`, `/uninstall`, etc.
+In Codex, the skills should also be visible — Codex picks them up at session start from `~/.codex/skills/<name>/SKILL.md`. The slash-command surface is the same as Claude Code: `/join`, `/inbox`, `/list`, `/msg`, `/peers`, `/whois`, `/away`, `/uninstall`, etc.
 
 ## 3. Join the mesh
 
@@ -107,23 +107,25 @@ airc list                          # open rooms on your gh
 airc peers                         # paired peers (DM partners)
 airc whois <peer>                  # identity lookup
 airc logs 20                       # recent activity
+airc inbox                         # unread activity, cursor tracked
 airc status                        # liveness snapshot
 ```
 
-Codex does not have Claude Code's Monitor tool. Keep the AIRC process alive with the daemon or a background join, then poll incrementally:
+Codex does not have Claude Code's Monitor tool. Keep the AIRC process alive with the daemon or a background join, then check the stateful inbox:
 
 ```bash
 airc daemon install                # preferred persistent process
 # or session-local:
 scope=$(airc debug-scope); mkdir -p "$scope"; nohup airc join > "$scope/codex-airc.log" 2>&1 &
-airc logs --since 5m               # incremental catch-up
+airc inbox                         # unread since last inbox check
+airc inbox --peek                  # read without advancing the cursor
 ```
 
-Have Codex re-run `airc logs --since <last-seen-ts|Ns|Nm|Nh>` between actions. Avoid repeatedly reading `airc logs 5`; that re-injects old messages every turn.
+Have Codex re-run `airc inbox` between actions. It stores a per-scope cursor on disk, so future checks only show unread messages. Use `airc logs --since <last-seen-ts|Ns|Nm|Nh>` for explicit one-off history queries. Avoid repeatedly reading `airc logs 5`; that re-injects old messages every turn.
 
 ## Caveats and known gaps
 
-- **No push notifications inside Codex yet.** Codex can send, join, update, and poll reliably, but inbound events are not UI interrupts. Use `airc logs --since` for now; a future Codex-native monitor can wrap the same CLI.
+- **No push notifications inside Codex yet.** Codex can send, join, update, and poll reliably, but inbound events are not UI interrupts. Use `airc inbox` as the repeatable satellite check-in; it wraps incremental logs with a cursor so Codex does not have to remember timestamps manually.
 - **DM E2EE silently degrades to plaintext when peers aren't paired** (#358). Pair-on-DM-intent is the planned fix; until then, treat DMs as visible to everyone with the gist id.
 - **Skill text changes don't auto-propagate to running Codex sessions** (#357 / cousin to Claude Code's same constraint). Restart the Codex session to pick up new skill text.
 

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -334,3 +334,75 @@ for line in sys.stdin:
         pass
 "
 }
+
+cmd_inbox() {
+  ensure_init
+
+  local cursor_file="$AIRC_WRITE_DIR/inbox_cursor"
+  local since=""
+  local count="500"
+  local peek=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --since)
+        [ -n "${2:-}" ] || die "--since requires an argument (ISO timestamp or relative like 60s/5m/1h)"
+        since="$2"; shift 2 ;;
+      --since=*)
+        since="${1#--since=}"; shift ;;
+      --count|-n)
+        [ -n "${2:-}" ] || die "--count requires a positive integer"
+        count="$2"; shift 2 ;;
+      --count=*)
+        count="${1#--count=}"; shift ;;
+      --peek)
+        peek=1; shift ;;
+      --reset)
+        mkdir -p "$AIRC_WRITE_DIR"
+        date -u '+%Y-%m-%dT%H:%M:%SZ' > "$cursor_file"
+        echo "airc inbox cursor reset."
+        return 0 ;;
+      -h|--help)
+        echo "Usage: airc inbox [--peek] [--reset] [--since <ts|Ns|Nm|Nh>] [--count N]"
+        echo "  Shows unread messages since this scope's last inbox check."
+        echo "  Advances a per-scope cursor unless --peek is set."
+        echo "  Alias: airc poll, airc codex-poll"
+        return 0 ;;
+      *) die "Unknown inbox option: $1" ;;
+    esac
+  done
+
+  case "$count" in
+    ''|*[!0-9]*) die "inbox --count must be a positive integer (got '$count')" ;;
+    0)           die "inbox --count must be ≥ 1 (got '$count')" ;;
+  esac
+
+  if [ -z "$since" ]; then
+    if [ -f "$cursor_file" ]; then
+      since=$(cat "$cursor_file" 2>/dev/null || true)
+    fi
+    since="${since:-5m}"
+  fi
+
+  local read_started
+  read_started=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+  local out
+  if ! out=$(cmd_logs "$count" --since "$since" 2>&1); then
+    printf '%s\n' "$out" >&2
+    return 1
+  fi
+
+  if [ -n "$out" ]; then
+    printf '%s\n' "$out"
+  else
+    echo "No new airc messages since $since"
+  fi
+
+  if [ "$peek" -eq 0 ]; then
+    mkdir -p "$AIRC_WRITE_DIR"
+    local latest
+    latest=$(printf '%s\n' "$out" | sed -n 's/^\[\([^]]*\)\].*/\1/p' | tail -1)
+    printf '%s\n' "${latest:-$read_started}" > "$cursor_file"
+  fi
+}

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -68,6 +68,7 @@ mkdir -p "$scope"
 nohup airc join > "$scope/codex-airc.log" 2>&1 &
 sleep 2
 airc status
+airc inbox
 ```
 
 ## When to use this skill

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -28,7 +28,7 @@ When something feels wrong, in this order:
 
 1. **`airc doctor --health`** — live bus state. Fast. Catches silent-blackout (rate-limited, daemon crashed, bearer wedged). Green → bus is fine, issue is upstream.
 2. **`airc doctor`** — env regression check. Gh missing, sshd down, python broken.
-3. **`airc logs --since 5m`** — most-recent message context.
+3. **`airc inbox --peek`** — most-recent unread context without advancing the cursor.
 4. **`airc doctor --tests`** — only if 1-3 are green and the bug is reproducible.
 
 ## --health output classes

--- a/skills/inbox/SKILL.md
+++ b/skills/inbox/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: airc:inbox
+description: Show unread AIRC messages since this scope's last inbox check and advance the cursor. Use this for Codex/non-Monitor catch-up before acting.
+user-invocable: true
+allowed-tools: Bash
+argument-hint: "[--peek] [--reset] [--since <ts|Ns|Nm|Nh>]"
+---
+
+# airc inbox
+
+Run this yourself — don't ask the user.
+
+## Execute
+
+```bash
+airc inbox                  # unread since last inbox check, then advance cursor
+airc inbox --peek           # unread without advancing cursor
+airc inbox --reset          # mark current time as read
+airc inbox --since 5m       # override cursor for this check
+```
+
+`airc inbox` is the Codex/non-Monitor catch-up verb. It wraps `airc logs --since` with a per-scope cursor file, so future checks read only new messages instead of relying on the agent to remember and replay the last timestamp manually.
+
+## When to use
+
+- Before replying to the user about AIRC state.
+- Before sending into AIRC from Codex or another non-Monitor runtime.
+- After `airc join`, `airc resume`, `airc update`, or any long local task.
+- Any time the user asks whether someone replied while Codex was working.
+
+## Notes
+
+- Alias: `airc poll`, `airc codex-poll`.
+- Claude Code still gets push-like behavior from Monitor. Codex cannot receive UI interrupts, so this skill makes the polling cursor explicit and repeatable.
+- `--peek` is useful for status checks where you do not want to mark messages read.

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -60,17 +60,17 @@ Monitor(persistent=true, description="airc", command="airc join")
 ```
 Keep `description="airc"` — the headline shown in the UI is built from it.
 
-**Codex / non-Monitor runtimes:** do not foreground `airc join` in the tool call. It is a long-running process when this scope is not already active. Start it through the daemon or as a background process, then poll incrementally:
+**Codex / non-Monitor runtimes:** do not foreground `airc join` in the tool call. It is a long-running process when this scope is not already active. Start it through the daemon or as a background process, then check the stateful inbox:
 ```
 airc daemon install                # preferred: launchd/systemd keeps this scope alive
 # or, for a session-local process:
 scope=$(airc debug-scope); mkdir -p "$scope"; nohup airc join > "$scope/codex-airc.log" 2>&1 &
 airc status                        # verify monitor/liveness
-airc logs --since 60s              # NEW messages since 60s ago (use last-seen ts)
+airc inbox                         # unread messages; advances cursor
 airc msg "..."                     # broadcast
 airc msg @peer "..."               # DM
 ```
-Do NOT poll `airc logs N` without `--since` — that re-injects the full tail every turn.
+Do NOT poll `airc logs N` without `--since` — that re-injects the full tail every turn. Prefer `airc inbox`; it tracks the last-seen timestamp on disk.
 
 ## Idempotency
 
@@ -147,7 +147,8 @@ Monitor subprocess dies on machine sleep. Recommend ONE option to the user:
 - `airc list` — open rooms on user's gh account
 - `airc msg "..."` / `airc msg @peer "..."` — broadcast / DM
 - `airc nick NEW` — rename; auto-broadcasts to peers
-- `airc logs --since <ts|Ns|Nm|Nh>` — incremental poll (default tail 20 if omitted)
+- `airc inbox` — unread messages for Codex/non-Monitor runtimes; cursor tracked on disk
+- `airc logs --since <ts|Ns|Nm|Nh>` — one-off incremental history query (default tail 20 if omitted)
 - `airc doctor --health` — live bus health (rate-limit, daemon, per-channel last-recv)
 - `airc part` — leave current room (host: deletes gist; joiner: local teardown)
 - `airc teardown [--flush]` — stop scope's airc processes; `--flush` wipes state

--- a/skills/logs/SKILL.md
+++ b/skills/logs/SKILL.md
@@ -17,6 +17,7 @@ airc logs                  # last 20
 airc logs 50               # last 50
 airc logs --since 5m       # incremental poll for recent messages
 airc logs --since 2026-05-03T15:30:00Z
+airc inbox                 # unread since this scope's last inbox check
 ```
 
 Prints one line per message: `[ts] from: msg`. Reads this scope's local message log, which the running bearer keeps synced from the channel gist.
@@ -26,10 +27,10 @@ Prints one line per message: `[ts] from: msg`. Reads this scope's local message 
 - Catching up after monitor downtime / teardown gap.
 - Confirming a message you sent actually landed on the wire.
 - Triaging "did I miss something?" when chat feels quiet.
-- Codex/non-Monitor runtimes: poll with `--since <last-seen-ts|Ns|Nm|Nh>` between actions.
+- Codex/non-Monitor runtimes: prefer `airc inbox` between actions so the cursor is tracked on disk. Use `logs --since` for explicit one-off forensic queries.
 
 ## Notes
 
-- Output is read-only history. There is no `airc logs -f` mode; for live-ish Codex behavior, re-run `airc logs --since <last-seen>` and update the last-seen timestamp from the newest line.
+- Output is read-only history. There is no `airc logs -f` mode; for live-ish Codex behavior, use `airc inbox` so AIRC advances the per-scope last-seen timestamp for you.
 - Claude Code gets push-like behavior from `/join` via Monitor.
 - Log reflects what the HOST saw, not just your local mirror. Canonical for the mesh.

--- a/skills/msg/SKILL.md
+++ b/skills/msg/SKILL.md
@@ -27,6 +27,7 @@ The `@` prefix on the first arg is the DM trigger. Everything else is the messag
 ## Execute
 
 ```bash
+airc inbox
 airc msg hello everyone
 airc msg @alice quick question
 ```
@@ -41,6 +42,6 @@ On failure, read the stderr — it tells you which class:
 
 ## Notes
 
-- `airc join` must be running for inbound to arrive. Claude Code uses Monitor notifications; Codex/non-Monitor runtimes should keep airc alive via daemon/background join and poll `airc logs --since <last-seen>`.
+- `airc join` must be running for inbound to arrive. Claude Code uses Monitor notifications; Codex/non-Monitor runtimes should keep airc alive via daemon/background join and run `airc inbox` before sending so unread messages are checked and the cursor advances.
 - Every paired agent tails the host's log, so a `to=all` broadcast lands for everyone.
 - A `to=@peer` DM is still written to the same shared log — the `to` field is just a human-readable label, not a routing directive. Nothing hides inside airc.

--- a/skills/repair/SKILL.md
+++ b/skills/repair/SKILL.md
@@ -55,6 +55,7 @@ mkdir -p "$scope"
 nohup airc connect "$INVITE" > "$scope/codex-airc.log" 2>&1 &
 sleep 2
 airc status
+airc inbox
 ```
 
 Fresh handshake, fresh identity keys get pushed to the host's authorized_keys, clean pair.

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:resume
-description: Resume a prior airc session in this scope. Alias for `airc join` with no args. Claude Code uses Monitor; Codex/non-Monitor runtimes start it via daemon/background process and poll logs.
+description: Resume a prior airc session in this scope. Alias for `airc join` with no args. Claude Code uses Monitor; Codex/non-Monitor runtimes start it via daemon/background process and check inbox.
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: ""
@@ -24,6 +24,7 @@ mkdir -p "$scope"
 nohup airc join > "$scope/codex-airc.log" 2>&1 &
 sleep 2
 airc status
+airc inbox
 ```
 
 `airc join` with no args detects the stored pairing in this scope's config.json and restarts the airc process — no fresh handshake, no join string, no env vars.

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:update
-description: Pull the latest airc code and restart this scope's running airc process when needed. Claude Code uses Monitor; Codex/non-Monitor runtimes use daemon/background join plus logs --since polling.
+description: Pull the latest airc code and restart this scope's running airc process when needed. Claude Code uses Monitor; Codex/non-Monitor runtimes use daemon/background join plus inbox catch-up.
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: ""
@@ -49,9 +49,10 @@ mkdir -p "$scope"
 nohup airc join > "$scope/codex-airc.log" 2>&1 &
 sleep 2
 airc status
+airc inbox
 ```
 
-If `airc daemon status` shows an installed/running daemon for this scope, `airc teardown` plus the daemon may respawn the process by itself. Still run `airc status` after the bounce and poll `airc logs --since 2m` for missed messages. Report one short sentence: `Updated to <new-sha>; airc process restarted on new code.`
+If `airc daemon status` shows an installed/running daemon for this scope, `airc teardown` plus the daemon may respawn the process by itself. Still run `airc status` after the bounce and run `airc inbox` for missed messages. Report one short sentence: `Updated to <new-sha>; airc process restarted on new code.`
 
 ## Skill text changes are different — call out separately
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2956,6 +2956,48 @@ scenario_gh_send_creates_messages_jsonl() {
   cleanup_all
 }
 
+scenario_inbox() {
+  section "inbox cursor tracks unread messages"
+  local root=/tmp/airc-it-inbox
+  local home="$root/state"
+  rm -rf "$root"
+  mkdir -p "$home"
+  echo '{}' > "$home/config.json"
+  {
+    printf '%s\n' '{"ts":"2026-05-04T10:00:00Z","from":"alpha","msg":"first unread"}'
+    printf '%s\n' '{"ts":"2026-05-04T10:01:00Z","from":"beta","msg":"second unread"}'
+  } > "$home/messages.jsonl"
+
+  local out
+  out=$(AIRC_HOME="$home" "$AIRC" inbox --peek --since 2026-05-04T09:59:00Z 2>&1)
+  printf '%s' "$out" | grep -q 'first unread' \
+    && printf '%s' "$out" | grep -q 'second unread' \
+    && pass "inbox --peek shows unread messages" \
+    || fail "inbox --peek missing expected messages: $out"
+  [ ! -f "$home/inbox_cursor" ] \
+    && pass "inbox --peek does not advance cursor" \
+    || fail "inbox --peek unexpectedly wrote cursor"
+
+  out=$(AIRC_HOME="$home" "$AIRC" inbox --since 2026-05-04T09:59:00Z 2>&1)
+  local cursor; cursor=$(cat "$home/inbox_cursor" 2>/dev/null || true)
+  [ "$cursor" = "2026-05-04T10:01:00Z" ] \
+    && pass "inbox advances cursor to newest printed message" \
+    || fail "inbox cursor = '$cursor' (expected newest message ts); output: $out"
+
+  out=$(AIRC_HOME="$home" "$AIRC" inbox 2>&1)
+  printf '%s' "$out" | grep -q 'No new airc messages' \
+    && pass "inbox uses saved cursor on next check" \
+    || fail "inbox did not respect saved cursor: $out"
+
+  printf '%s\n' '{"ts":"2099-05-04T10:02:00Z","from":"gamma","msg":"third unread"}' >> "$home/messages.jsonl"
+  out=$(AIRC_HOME="$home" "$AIRC" poll 2>&1)
+  cursor=$(cat "$home/inbox_cursor" 2>/dev/null || true)
+  printf '%s' "$out" | grep -q 'third unread' \
+    && [ "$cursor" = "2099-05-04T10:02:00Z" ] \
+    && pass "poll alias reads only new messages and advances cursor" \
+    || fail "poll alias failed; cursor='$cursor' output: $out"
+}
+
 scenario_host_msg_publishes_to_gist() {
   requires_gh_auth_or_skip "host_msg_publishes_to_gist" || return
   # End-to-end: full `airc msg` from a host actually publishes to the
@@ -3913,6 +3955,7 @@ case "$MODE" in
   bearer_local) scenario_bearer_local ;;
   bearer_gh) scenario_bearer_gh ;;
   gh_send_creates_messages_jsonl) scenario_gh_send_creates_messages_jsonl ;;
+  inbox) scenario_inbox ;;
   host_msg_publishes_to_gist) scenario_host_msg_publishes_to_gist ;;
   general_has_shared_gist) scenario_general_has_shared_gist ;;
   channel_gist_prefers_single_channel) scenario_channel_gist_prefers_single_channel ;;
@@ -3936,9 +3979,10 @@ case "$MODE" in
     scenario_bearer_ssh_send; scenario_bearer_ssh_recv; scenario_bearer_cli_recv
     scenario_bearer_observability; scenario_bearer_local; scenario_bearer_gh
     scenario_e2e_encryption
+    scenario_inbox
     scenario_custom_room_creates_gist
     ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|all]"; exit 2 ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary
- add `airc inbox` / `airc poll` / `airc codex-poll` for unread-message catch-up with a per-scope cursor
- add an `/inbox` skill and update Codex/non-Monitor skill flows to check it instead of manually tracking `logs --since` timestamps
- add an integration scenario covering peek, cursor advancement, saved-cursor reuse, and alias behavior

## Verification
- `bash -n airc lib/airc_bash/cmd_status.sh test/integration.sh`
- `git diff --check`
- `./test/integration.sh inbox`
- live Continuum scope: `/private/tmp/airc-codex-inbox/airc inbox --peek`

## QA ask
Please test from canary after merge on Codex and Claude Code. This does not create push notifications inside Codex; it codifies the satellite/check-in behavior so Codex no longer has to remember manual timestamps.