### PR TITLE
fix(bearer): per-(scope, channel, gist) lock prevents duplicate emission

### DIFF
--- a/lib/airc_core/bearer_cli.py
+++ b/lib/airc_core/bearer_cli.py
@@ -39,13 +39,168 @@ nothing else.
 from __future__ import annotations
 
 import argparse
+import atexit
 import json
 import os
 import signal
+import subprocess
 import sys
 from dataclasses import asdict
+from typing import Optional, Tuple
 
 from .bearer_resolver import resolve
+
+
+# ── Per-(scope, channel, gist) bearer lock ─────────────────────────────
+# Without this lock, scope teardown that leaks orphan bearers OR a
+# host-gist-rotation respawn that races with the old bearer can end up
+# with TWO bearer_cli processes polling the same gist for the same
+# channel. Both yield each new line to their stdout. If their pipes
+# converge (the parent monitor's children share a downstream pipe, or
+# both feed an unprivileged log), each downstream message arrives twice.
+#
+# Repro Joel hit 2026-05-04: peer broadcast appeared TWICE in the
+# monitor stream with identical body + identical session nonce.
+# Diagnosed: 3 live bearer_cli processes for #general across leaked
+# test scopes + the live monitor's own respawned child.
+#
+# Pattern matches cmd_connect's #97 self-heal: pidfile + cmdline-shape
+# verification (kill -0 alone is unsafe — OS reuses PIDs after wake).
+
+
+def _pid_alive(pid: int) -> bool:
+    """True iff pid is a live process. Same `os.kill(pid, 0)` probe
+    cmd_connect / handshake use; no signal sent.
+
+    PermissionError (EPERM) means the PID exists but is owned by another
+    user — still counts as alive. ProcessLookupError (ESRCH) means dead.
+    Other OSError means we can't tell — be conservative, assume dead.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+def _is_our_bearer(pid: int, expected_gist: str) -> bool:
+    """True iff PID's cmdline matches bearer_cli recv for `expected_gist`.
+
+    Cross-platform via `ps -p <pid> -o command=`. The PID alone is unsafe
+    (OS reuses PIDs after sleep/wake — Joel hit this in #97). Verify the
+    process is actually a bearer_cli recv AND for our gist; otherwise
+    treat the pidfile as stale.
+    """
+    try:
+        out = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True, text=True, timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if out.returncode != 0:
+        return False
+    cmdline = (out.stdout or "").strip()
+    if "bearer_cli" not in cmdline or " recv " not in f" {cmdline} ":
+        return False
+    if expected_gist:
+        return f"--room-gist-id {expected_gist}" in cmdline
+    return True
+
+
+def _claim_recv_lock(args) -> Optional[Tuple[str, int]]:
+    """Per-(scope, channel, gist) bearer-recv lock.
+
+    Returns (pidfile_path, my_pid) on successful claim — caller registers
+    atexit cleanup. Returns None if another live bearer already serves
+    this stream — caller should exit 0 cleanly.
+
+    Pidfile path is derived from --state-file by replacing the .json
+    suffix with .pid (e.g. bearer_state.general.json → bearer.general.pid).
+    Without --state-file, no lock is taken (legacy / test invocations
+    that don't use state-file stay unaffected).
+
+    Stale-pidfile recovery:
+      - PID dead → stale; take over.
+      - PID alive but cmdline isn't a bearer_cli recv for OUR gist →
+        stale; take over. (Covers OS-PID-reuse after sleep/wake AND the
+        "old bearer is for a rotated-away gist" case.)
+      - PID alive AND cmdline is a bearer_cli recv for our gist →
+        another bearer is healthy; exit cleanly.
+    """
+    state_file = getattr(args, "state_file", None)
+    if not state_file:
+        return None
+    if state_file.endswith(".json"):
+        pidfile = state_file[: -len(".json")] + ".pid"
+    else:
+        pidfile = state_file + ".pid"
+
+    my_gist = getattr(args, "room_gist_id", None) or ""
+    my_pid = os.getpid()
+
+    if os.path.exists(pidfile):
+        try:
+            with open(pidfile, "r") as f:
+                data = f.read().strip()
+        except OSError:
+            data = ""
+        # Format: "<pid>\t<gist_id>". gist_id may be empty for non-gh bearers.
+        parts = data.split("\t", 1)
+        try:
+            other_pid = int(parts[0]) if parts and parts[0] else 0
+        except ValueError:
+            other_pid = 0
+        if other_pid > 0 and other_pid != my_pid \
+                and _pid_alive(other_pid) and _is_our_bearer(other_pid, my_gist):
+            print(
+                f"bearer_cli recv: another bearer for gist {my_gist or '(none)'} "
+                f"already running (PID {other_pid}); exiting cleanly to avoid "
+                f"duplicate emission",
+                file=sys.stderr, flush=True,
+            )
+            return None
+        # else: stale (dead pid, OS-reused, or old gist) → take over
+
+    try:
+        with open(pidfile, "w") as f:
+            f.write(f"{my_pid}\t{my_gist}\n")
+    except OSError as e:
+        # Loud, not silent — we'd rather know we couldn't lock than
+        # silently disable the dedup guarantee.
+        print(
+            f"bearer_cli recv: could not write pidfile {pidfile}: {e}; "
+            f"proceeding without lock (duplicate emission possible)",
+            file=sys.stderr, flush=True,
+        )
+        return None
+    return (pidfile, my_pid)
+
+
+def _release_lock(pidfile: str, my_pid: int) -> None:
+    """Remove the pidfile only if it still has OUR pid (don't stomp a
+    pidfile that some other bearer rewrote after we ran)."""
+    try:
+        with open(pidfile, "r") as f:
+            data = f.read().strip()
+    except OSError:
+        return
+    parts = data.split("\t", 1)
+    try:
+        owner = int(parts[0]) if parts and parts[0] else 0
+    except ValueError:
+        owner = 0
+    if owner == my_pid:
+        try:
+            os.unlink(pidfile)
+        except OSError:
+            pass
 
 
 def cmd_send(args) -> int:
@@ -99,6 +254,19 @@ def cmd_recv(args) -> int:
         the bash monitor's watchdog interprets that and decides whether
         to relaunch us.
     """
+    # Per-(scope, channel, gist) bearer lock. Prevents duplicate
+    # stream-emission when scope teardown leaks orphan bearers OR a
+    # host-gist-rotation respawn races with the old bearer (Joel's
+    # 2026-05-04 dup-message diagnosis). Without --state-file, no lock
+    # is taken — legacy / test invocations are unaffected.
+    lock = _claim_recv_lock(args)
+    if lock is None and getattr(args, "state_file", None):
+        # Another live bearer is already serving this stream.
+        # Exit cleanly so the parent monitor's watchdog doesn't escalate.
+        return 0
+    if lock is not None:
+        atexit.register(_release_lock, lock[0], lock[1])
+
     peer_meta = {
         "host_target": args.host_target,
         "remote_home": args.remote_home,

--- a/lib/airc_core/bearer_cli.py
+++ b/lib/airc_core/bearer_cli.py
@@ -46,7 +46,7 @@ import signal
 import subprocess
 import sys
 from dataclasses import asdict
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 from .bearer_resolver import resolve
 
@@ -66,6 +66,10 @@ from .bearer_resolver import resolve
 #
 # Pattern matches cmd_connect's #97 self-heal: pidfile + cmdline-shape
 # verification (kill -0 alone is unsafe — OS reuses PIDs after wake).
+
+_LOCK_DISABLED = "disabled"
+_LOCK_HELD = "held"
+RecvLockResult = Union[Tuple[str, int], str]
 
 
 def _pid_alive(pid: int) -> bool:
@@ -114,12 +118,29 @@ def _is_our_bearer(pid: int, expected_gist: str) -> bool:
     return True
 
 
-def _claim_recv_lock(args) -> Optional[Tuple[str, int]]:
+def _read_lock_owner(pidfile: str) -> Tuple[int, str]:
+    try:
+        with open(pidfile, "r") as f:
+            data = f.read().strip()
+    except OSError:
+        return (0, "")
+    parts = data.split("\t", 1)
+    try:
+        pid = int(parts[0]) if parts and parts[0] else 0
+    except ValueError:
+        pid = 0
+    gist = parts[1] if len(parts) > 1 else ""
+    return (pid, gist)
+
+
+def _claim_recv_lock(args) -> RecvLockResult:
     """Per-(scope, channel, gist) bearer-recv lock.
 
     Returns (pidfile_path, my_pid) on successful claim — caller registers
-    atexit cleanup. Returns None if another live bearer already serves
-    this stream — caller should exit 0 cleanly.
+    atexit cleanup. Returns _LOCK_HELD if another live bearer already
+    serves this stream — caller should exit 0 cleanly. Returns
+    _LOCK_DISABLED when no lock can/should be used, and caller should
+    continue without the duplicate-emission guarantee.
 
     Pidfile path is derived from --state-file by replacing the .json
     suffix with .pid (e.g. bearer_state.general.json → bearer.general.pid).
@@ -136,7 +157,7 @@ def _claim_recv_lock(args) -> Optional[Tuple[str, int]]:
     """
     state_file = getattr(args, "state_file", None)
     if not state_file:
-        return None
+        return _LOCK_DISABLED
     if state_file.endswith(".json"):
         pidfile = state_file[: -len(".json")] + ".pid"
     else:
@@ -145,57 +166,58 @@ def _claim_recv_lock(args) -> Optional[Tuple[str, int]]:
     my_gist = getattr(args, "room_gist_id", None) or ""
     my_pid = os.getpid()
 
-    if os.path.exists(pidfile):
+    lock_payload = f"{my_pid}\t{my_gist}\n".encode("utf-8")
+    for _ in range(3):
         try:
-            with open(pidfile, "r") as f:
-                data = f.read().strip()
-        except OSError:
-            data = ""
-        # Format: "<pid>\t<gist_id>". gist_id may be empty for non-gh bearers.
-        parts = data.split("\t", 1)
-        try:
-            other_pid = int(parts[0]) if parts and parts[0] else 0
-        except ValueError:
-            other_pid = 0
-        if other_pid > 0 and other_pid != my_pid \
-                and _pid_alive(other_pid) and _is_our_bearer(other_pid, my_gist):
+            fd = os.open(pidfile, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+            try:
+                os.write(fd, lock_payload)
+            finally:
+                os.close(fd)
+            return (pidfile, my_pid)
+        except FileExistsError:
+            # Format: "<pid>\t<gist_id>". gist_id may be empty for non-gh bearers.
+            other_pid, _other_gist = _read_lock_owner(pidfile)
+            if other_pid > 0 and other_pid != my_pid \
+                    and _pid_alive(other_pid) and _is_our_bearer(other_pid, my_gist):
+                print(
+                    f"bearer_cli recv: another bearer for gist {my_gist or '(none)'} "
+                    f"already running (PID {other_pid}); exiting cleanly to avoid "
+                    f"duplicate emission",
+                    file=sys.stderr, flush=True,
+                )
+                return _LOCK_HELD
+            # else: stale (dead pid, OS-reused, or old gist) → remove then
+            # retry O_EXCL claim. If another process wins the race, the next
+            # loop sees its pidfile and exits or retries accordingly.
+            try:
+                os.unlink(pidfile)
+            except FileNotFoundError:
+                pass
+            except OSError as e:
+                print(
+                    f"bearer_cli recv: could not remove stale pidfile {pidfile}: {e}; "
+                    f"proceeding without lock (duplicate emission possible)",
+                    file=sys.stderr, flush=True,
+                )
+                return _LOCK_DISABLED
+        except OSError as e:
+            # Loud, not silent — we'd rather know we couldn't lock than
+            # silently disable the dedup guarantee.
             print(
-                f"bearer_cli recv: another bearer for gist {my_gist or '(none)'} "
-                f"already running (PID {other_pid}); exiting cleanly to avoid "
-                f"duplicate emission",
+                f"bearer_cli recv: could not write pidfile {pidfile}: {e}; "
+                f"proceeding without lock (duplicate emission possible)",
                 file=sys.stderr, flush=True,
             )
-            return None
-        # else: stale (dead pid, OS-reused, or old gist) → take over
+            return _LOCK_DISABLED
 
-    try:
-        with open(pidfile, "w") as f:
-            f.write(f"{my_pid}\t{my_gist}\n")
-    except OSError as e:
-        # Loud, not silent — we'd rather know we couldn't lock than
-        # silently disable the dedup guarantee.
-        print(
-            f"bearer_cli recv: could not write pidfile {pidfile}: {e}; "
-            f"proceeding without lock (duplicate emission possible)",
-            file=sys.stderr, flush=True,
-        )
-        return None
-    return (pidfile, my_pid)
+    return _LOCK_DISABLED
 
 
 def _release_lock(pidfile: str, my_pid: int) -> None:
     """Remove the pidfile only if it still has OUR pid (don't stomp a
     pidfile that some other bearer rewrote after we ran)."""
-    try:
-        with open(pidfile, "r") as f:
-            data = f.read().strip()
-    except OSError:
-        return
-    parts = data.split("\t", 1)
-    try:
-        owner = int(parts[0]) if parts and parts[0] else 0
-    except ValueError:
-        owner = 0
+    owner, _gist = _read_lock_owner(pidfile)
     if owner == my_pid:
         try:
             os.unlink(pidfile)
@@ -260,11 +282,11 @@ def cmd_recv(args) -> int:
     # 2026-05-04 dup-message diagnosis). Without --state-file, no lock
     # is taken — legacy / test invocations are unaffected.
     lock = _claim_recv_lock(args)
-    if lock is None and getattr(args, "state_file", None):
+    if lock == _LOCK_HELD:
         # Another live bearer is already serving this stream.
         # Exit cleanly so the parent monitor's watchdog doesn't escalate.
         return 0
-    if lock is not None:
+    if isinstance(lock, tuple):
         atexit.register(_release_lock, lock[0], lock[1])
 
     peer_meta = {

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -618,7 +618,9 @@ class BearerCliRecvLockTests(unittest.TestCase):
       - Pidfile present, PID alive but for a DIFFERENT gist → stale
         (host-gist-rotation case); claim succeeds.
       - Pidfile present, PID alive AND for SAME gist → claim fails;
-        return None so caller exits cleanly.
+        return _LOCK_HELD so caller exits cleanly.
+      - Pidfile cannot be written → return _LOCK_DISABLED so caller
+        continues without the duplicate-emission guarantee.
       - Release removes pidfile only when it still contains our pid
         (don't stomp a successor that took the lock after we ran).
     """
@@ -655,7 +657,7 @@ class BearerCliRecvLockTests(unittest.TestCase):
         # take a lock — preserves backwards compat for callers that don't
         # have a writable scope dir to put the pidfile in.
         result = bearer_cli._claim_recv_lock(self._args(state_file=None))
-        self.assertIsNone(result)
+        self.assertEqual(result, bearer_cli._LOCK_DISABLED)
 
     def test_claim_writes_pidfile_when_absent(self):
         import os
@@ -712,12 +714,31 @@ class BearerCliRecvLockTests(unittest.TestCase):
         with mock.patch.object(bearer_cli, "_pid_alive", return_value=True), \
              mock.patch.object(bearer_cli, "_is_our_bearer", return_value=True):
             result = bearer_cli._claim_recv_lock(self._args(room_gist_id="abc123"))
-        self.assertIsNone(result, "live bearer for same gist must block claim")
+        self.assertEqual(result, bearer_cli._LOCK_HELD,
+                         "live bearer for same gist must block claim")
         # Pidfile contents must be UNCHANGED — we didn't take over.
         with open(self._pidfile) as f:
             content = f.read().strip()
         self.assertTrue(content.startswith(f"{my_other_pid}\t"),
                         "pidfile must NOT be overwritten when we lose the claim race")
+
+    def test_lock_write_failure_does_not_make_recv_exit_as_lock_held(self):
+        # If the pidfile cannot be created, _claim_recv_lock must report
+        # "disabled" rather than "held". cmd_recv should continue without
+        # the dedup guarantee; exiting would make AIRC silently stop
+        # receiving whenever the scope dir has a filesystem hiccup.
+        with mock.patch.object(bearer_cli.os, "open", side_effect=OSError("nope")):
+            result = bearer_cli._claim_recv_lock(self._args())
+        self.assertEqual(result, bearer_cli._LOCK_DISABLED)
+
+    def test_claim_uses_exclusive_create_for_absent_pidfile(self):
+        import os
+        with mock.patch.object(bearer_cli.os, "open", wraps=os.open) as mock_open:
+            result = bearer_cli._claim_recv_lock(self._args())
+        self.assertIsNotNone(result)
+        _path, flags, _mode = mock_open.call_args.args
+        self.assertTrue(flags & os.O_EXCL,
+                        "pidfile claim must use O_EXCL to avoid absent-file races")
 
     def test_release_removes_pidfile_only_when_we_own_it(self):
         # Claim, then release.

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -605,6 +605,142 @@ class BearerCliStateFileTests(unittest.TestCase):
         _os.unlink(state_path)
 
 
+class BearerCliRecvLockTests(unittest.TestCase):
+    """Per-(scope, channel, gist) bearer-lock prevents multiple bearer_cli
+    processes from polling the same gist concurrently — the duplicate
+    emission Joel diagnosed 2026-05-04 (scope teardown leaked orphan
+    bearers + host-gist-rotation respawned a second one).
+
+    Test contract for _claim_recv_lock / _release_lock:
+      - No --state-file → no lock taken (legacy / test paths unaffected).
+      - Pidfile absent → claim succeeds; pidfile written with our pid+gist.
+      - Pidfile present, PID dead → stale; claim succeeds (overwrites).
+      - Pidfile present, PID alive but for a DIFFERENT gist → stale
+        (host-gist-rotation case); claim succeeds.
+      - Pidfile present, PID alive AND for SAME gist → claim fails;
+        return None so caller exits cleanly.
+      - Release removes pidfile only when it still contains our pid
+        (don't stomp a successor that took the lock after we ran).
+    """
+
+    def setUp(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp(prefix="airc-cli-lock-test-")
+        self._state_file = self._tmpdir + "/bearer_state.general.json"
+        # Pidfile follows the .json → .pid rule baked into _claim_recv_lock.
+        self._pidfile = self._tmpdir + "/bearer_state.general.pid"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    _MISSING = object()
+
+    def _args(self, state_file=_MISSING, room_gist_id="abc123"):
+        # Explicit-None must pass through (test_no_state_file_means_no_lock
+        # exercises the no-lock path). _MISSING sentinel distinguishes
+        # "use the default scope state-file" from "really mean None."
+        return argparse.Namespace(
+            peer_id="self",
+            host_target=None,
+            identity_key=None,
+            remote_home=None,
+            offset_file=None,
+            state_file=self._state_file if state_file is self._MISSING else state_file,
+            room_gist_id=room_gist_id,
+        )
+
+    def test_no_state_file_means_no_lock(self):
+        # Legacy/test invocations that don't pass --state-file must NOT
+        # take a lock — preserves backwards compat for callers that don't
+        # have a writable scope dir to put the pidfile in.
+        result = bearer_cli._claim_recv_lock(self._args(state_file=None))
+        self.assertIsNone(result)
+
+    def test_claim_writes_pidfile_when_absent(self):
+        import os
+        result = bearer_cli._claim_recv_lock(self._args())
+        self.assertIsNotNone(result)
+        pidfile_path, my_pid = result
+        self.assertEqual(pidfile_path, self._pidfile)
+        self.assertEqual(my_pid, os.getpid())
+        self.assertTrue(os.path.exists(self._pidfile))
+        with open(self._pidfile) as f:
+            content = f.read().strip()
+        # Format: "<pid>\t<gist_id>"
+        parts = content.split("\t", 1)
+        self.assertEqual(int(parts[0]), os.getpid())
+        self.assertEqual(parts[1], "abc123")
+
+    def test_claim_takes_over_when_pidfile_pid_is_dead(self):
+        # Stale pidfile from a previous bearer that died ungracefully.
+        # New bearer must take over, not exit because of dead-PID.
+        import os
+        with open(self._pidfile, "w") as f:
+            f.write("99999999\tabc123\n")  # PID that virtually can't exist
+        result = bearer_cli._claim_recv_lock(self._args())
+        self.assertIsNotNone(result, "stale (dead-PID) pidfile must not block claim")
+        # And our PID is now in the file.
+        with open(self._pidfile) as f:
+            content = f.read().strip()
+        self.assertEqual(int(content.split("\t", 1)[0]), os.getpid())
+
+    def test_claim_takes_over_when_other_bearer_is_for_different_gist(self):
+        # Host-gist-rotation case: previous bearer is alive but polling
+        # the OLD gist; new bearer for the NEW gist should claim.
+        import os
+        my_other_pid = 99999998  # used as "live but not us" stub
+        with open(self._pidfile, "w") as f:
+            f.write(f"{my_other_pid}\told-gist-id\n")
+        with mock.patch.object(bearer_cli, "_pid_alive", return_value=True), \
+             mock.patch.object(bearer_cli, "_is_our_bearer") as mock_is_ours:
+            # _is_our_bearer should be called with my CURRENT gist; if the
+            # cmdline has the old gist it should report False → stale.
+            mock_is_ours.return_value = False
+            result = bearer_cli._claim_recv_lock(self._args(room_gist_id="new-gist-id"))
+        self.assertIsNotNone(result, "rotated-gist case: stale lock must be reclaimable")
+        with open(self._pidfile) as f:
+            content = f.read().strip()
+        parts = content.split("\t", 1)
+        self.assertEqual(int(parts[0]), os.getpid())
+        self.assertEqual(parts[1], "new-gist-id")
+
+    def test_claim_fails_when_live_bearer_serves_same_gist(self):
+        my_other_pid = 99999997
+        with open(self._pidfile, "w") as f:
+            f.write(f"{my_other_pid}\tabc123\n")
+        with mock.patch.object(bearer_cli, "_pid_alive", return_value=True), \
+             mock.patch.object(bearer_cli, "_is_our_bearer", return_value=True):
+            result = bearer_cli._claim_recv_lock(self._args(room_gist_id="abc123"))
+        self.assertIsNone(result, "live bearer for same gist must block claim")
+        # Pidfile contents must be UNCHANGED — we didn't take over.
+        with open(self._pidfile) as f:
+            content = f.read().strip()
+        self.assertTrue(content.startswith(f"{my_other_pid}\t"),
+                        "pidfile must NOT be overwritten when we lose the claim race")
+
+    def test_release_removes_pidfile_only_when_we_own_it(self):
+        # Claim, then release.
+        import os
+        result = bearer_cli._claim_recv_lock(self._args())
+        self.assertIsNotNone(result)
+        bearer_cli._release_lock(*result)
+        self.assertFalse(os.path.exists(self._pidfile),
+                         "release must remove our pidfile")
+
+        # Now simulate the case where someone else took the lock after us
+        # (different pid in the file) — release MUST NOT remove it.
+        with open(self._pidfile, "w") as f:
+            f.write("88888888\tother-gist\n")
+        # Try to release with our pid — file should be untouched.
+        bearer_cli._release_lock(self._pidfile, os.getpid())
+        self.assertTrue(os.path.exists(self._pidfile),
+                        "release must NOT stomp a pidfile owned by another bearer")
+        with open(self._pidfile) as f:
+            content = f.read().strip()
+        self.assertEqual(int(content.split("\t", 1)[0]), 88888888)
+
+
 class LocalBearerCanServeTests(unittest.TestCase):
     """Phase 3a: LocalBearer.can_serve must be conservative — only True
     when host_target is a literal loopback alias AND remote_home is a


### PR DESCRIPTION
## Summary

Joel diagnosed 2026-05-04: peer broadcasts arriving **twice** in the monitor stream with identical body + identical session nonce. Root cause: nothing prevents multiple `bearer_cli recv` processes from polling the same (scope, channel, gist) tuple. Each yields each new line independently → duplicate downstream.

Two paths produced it in practice:
- **Scope teardown leaks orphan bearers.** cmd_teardown kills via `airc.pid`, but bearer children spawned by the old monitor can be reparented to PID 1. They keep polling forever.
- **Host-gist-rotation respawns.** A new bearer for the new gist races a brief-still-alive old bearer for the old gist. If their stdouts share a downstream, every line arrives twice.

## Fix

`bearer_cli.cmd_recv` claims a **per-(scope, channel, gist) lock** at startup. Pidfile is `<state_file_basename>.pid` in the same scope dir (e.g. `bearer_state.general.json` → `bearer_state.general.pid`).

Stale-pidfile recovery matches `cmd_connect`'s #97 self-heal pattern (kill -0 alone is unsafe — OS reuses PIDs after sleep/wake; verify cmdline matches `bearer_cli recv` for OUR gist):

| Pidfile state | Action |
|---|---|
| absent | claim |
| PID dead | stale → claim |
| PID alive, different gist | stale (rotated case) → claim |
| PID alive, same gist | exit 0 cleanly with explanatory stderr |

Without `--state-file`, no lock is taken — preserves backwards compat for legacy / test invocations.

`_release_lock` is registered via `atexit` and **only removes the pidfile if it still contains our PID** — never stomps a successor that took the lock after we ran.

## Test plan

- [x] 6 new `BearerCliRecvLockTests` cover every claim branch + release-when-owned semantics
- [x] All 87 existing bearer tests pass (`python3 test/test_bearer.py`)
- [ ] CI clean-install matrix
- [ ] Local: spawn two bearer_cli recv processes for the same gist; second should exit 0 with the explanatory stderr

## Coordination

@codex-b741 — would value a second look. Touches the same bearer-internals surface as your #450 (inbox polling). Lock is keyed on (state_file → pidfile derivation), so any path that calls bearer_cli recv with a state-file gets dedup automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)