### PR TITLE
fix(monitor): isolate failed channel bearer restarts

### DIFF
--- a/airc
+++ b/airc
@@ -1333,37 +1333,51 @@ _monitor_multi_channel() {
         _pids+=("$!:$ch")
       done <<< "$channel_map"
 
-      # Watch loop: any child death → kill survivors + break.
+      # Watch loop: any child death → restart only that channel.
+      # Pre-#452 this killed every survivor and rebuilt the whole
+      # formatter pipe, so a flaky/stale project-room gist could disturb
+      # #general delivery. Keep healthy channels flowing; the failed
+      # channel gets its own retry loop.
       # macOS bash 3.2 lacks `wait -n`, so poll explicitly.
-      local _dead=""
       while [ "${#_pids[@]}" -gt 0 ]; do
         sleep 2
         local _alive=()
-        local entry pid ch
+        local entry pid ch gid
         for entry in "${_pids[@]}"; do
           pid="${entry%%:*}"
           ch="${entry#*:}"
           if kill -0 "$pid" 2>/dev/null; then
             _alive+=("$entry")
           else
-            _dead="$ch"
-            break 2
+            echo "airc: bearer recv for #${ch} died — see ${AIRC_WRITE_DIR}/bearer_recv.${ch}.log; restarting that channel only" >&2
+            # Surface the last-error tail so the user sees WHY without
+            # having to know to read the log file.
+            if [ -s "$AIRC_WRITE_DIR/bearer_recv.${ch}.log" ]; then
+              tail -3 "$AIRC_WRITE_DIR/bearer_recv.${ch}.log" | sed 's/^/airc:   /' >&2
+            fi
+            # Re-read the channel's gist from config. If the host rotated
+            # or send-path self-heal updated channel_gists while this
+            # bearer was dying, restart against the new gist. If the
+            # mapping disappeared, leave this channel down; healthy
+            # channels keep flowing and the next outer cycle/config
+            # refresh can pick it up again.
+            gid=$("$AIRC_PYTHON" -m airc_core.config list_channel_gists \
+              --config "$CONFIG" 2>/dev/null | awk -F '\t' -v c="$ch" '$1 == c {print $2; exit}')
+            if [ -n "$gid" ]; then
+              sleep 3
+              "$AIRC_PYTHON" -u -m airc_core.bearer_cli recv "self" \
+                --room-gist-id "$gid" \
+                --offset-file "$AIRC_WRITE_DIR/monitor_offset.${ch}" \
+                --state-file "$AIRC_WRITE_DIR/bearer_state.${ch}.json" \
+                2>>"$AIRC_WRITE_DIR/bearer_recv.${ch}.log" &
+              _alive+=("$!:$ch")
+            else
+              echo "airc: #${ch} has no channel_gists mapping; leaving it offline while other channels continue" >&2
+            fi
           fi
         done
         _pids=("${_alive[@]}")
       done
-      if [ -n "$_dead" ]; then
-        echo "airc: bearer recv for #${_dead} died — see ${AIRC_WRITE_DIR}/bearer_recv.${_dead}.log; restarting all channels" >&2
-        # Surface the last-error tail so the user sees WHY without
-        # having to know to read the log file.
-        if [ -s "$AIRC_WRITE_DIR/bearer_recv.${_dead}.log" ]; then
-          tail -3 "$AIRC_WRITE_DIR/bearer_recv.${_dead}.log" | sed 's/^/airc:   /' >&2
-        fi
-        for entry in "${_pids[@]}"; do
-          kill "${entry%%:*}" 2>/dev/null
-        done
-        wait 2>/dev/null
-      fi
     } | monitor_formatter "$my_name" || true
     local fmt_exit="${PIPESTATUS[1]:-0}"
 

--- a/lib/airc_core/bearer_cli.py
+++ b/lib/airc_core/bearer_cli.py
@@ -133,8 +133,26 @@ def _read_lock_owner(pidfile: str) -> Tuple[int, str]:
     return (pid, gist)
 
 
+def _recv_lock_pidfile(state_file: str, gist_id: str) -> str:
+    """Return the pidfile path for a recv lock.
+
+    Natural key is the wire, not the channel label. Two subscribed
+    channels may legitimately point at the same gist during host
+    bootstrap, gist rotation, or same-room aliases; only one bearer
+    should poll that gist in a scope. The envelope's channel field and
+    monitor_formatter handle display/routing downstream.
+    """
+    if gist_id:
+        lock_dir = os.path.dirname(state_file) or "."
+        safe = "".join(c if c.isalnum() else "_" for c in gist_id)
+        return os.path.join(lock_dir, f"bearer_gist.{safe}.pid")
+    if state_file.endswith(".json"):
+        return state_file[: -len(".json")] + ".pid"
+    return state_file + ".pid"
+
+
 def _claim_recv_lock(args) -> RecvLockResult:
-    """Per-(scope, channel, gist) bearer-recv lock.
+    """Per-(scope, gist) bearer-recv lock.
 
     Returns (pidfile_path, my_pid) on successful claim — caller registers
     atexit cleanup. Returns _LOCK_HELD if another live bearer already
@@ -142,10 +160,11 @@ def _claim_recv_lock(args) -> RecvLockResult:
     _LOCK_DISABLED when no lock can/should be used, and caller should
     continue without the duplicate-emission guarantee.
 
-    Pidfile path is derived from --state-file by replacing the .json
-    suffix with .pid (e.g. bearer_state.general.json → bearer.general.pid).
-    Without --state-file, no lock is taken (legacy / test invocations
-    that don't use state-file stay unaffected).
+    Pidfile path is derived from --state-file's directory and
+    --room-gist-id (e.g. bearer_gist.<gist>.pid). Without --state-file,
+    no lock is taken (legacy / test invocations that don't use
+    state-file stay unaffected). Without --room-gist-id, the legacy
+    state-file-derived path is used.
 
     Stale-pidfile recovery:
       - PID dead → stale; take over.
@@ -158,12 +177,9 @@ def _claim_recv_lock(args) -> RecvLockResult:
     state_file = getattr(args, "state_file", None)
     if not state_file:
         return _LOCK_DISABLED
-    if state_file.endswith(".json"):
-        pidfile = state_file[: -len(".json")] + ".pid"
-    else:
-        pidfile = state_file + ".pid"
 
     my_gist = getattr(args, "room_gist_id", None) or ""
+    pidfile = _recv_lock_pidfile(state_file, my_gist)
     my_pid = os.getpid()
 
     lock_payload = f"{my_pid}\t{my_gist}\n".encode("utf-8")

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -606,7 +606,7 @@ class BearerCliStateFileTests(unittest.TestCase):
 
 
 class BearerCliRecvLockTests(unittest.TestCase):
-    """Per-(scope, channel, gist) bearer-lock prevents multiple bearer_cli
+    """Per-(scope, gist) bearer-lock prevents multiple bearer_cli
     processes from polling the same gist concurrently — the duplicate
     emission Joel diagnosed 2026-05-04 (scope teardown leaked orphan
     bearers + host-gist-rotation respawned a second one).
@@ -619,6 +619,8 @@ class BearerCliRecvLockTests(unittest.TestCase):
         (host-gist-rotation case); claim succeeds.
       - Pidfile present, PID alive AND for SAME gist → claim fails;
         return _LOCK_HELD so caller exits cleanly.
+      - Different channel state-files with the SAME gist contend for the
+        same pidfile; gist is the wire, channel is just the display label.
       - Pidfile cannot be written → return _LOCK_DISABLED so caller
         continues without the duplicate-emission guarantee.
       - Release removes pidfile only when it still contains our pid
@@ -629,8 +631,8 @@ class BearerCliRecvLockTests(unittest.TestCase):
         import tempfile
         self._tmpdir = tempfile.mkdtemp(prefix="airc-cli-lock-test-")
         self._state_file = self._tmpdir + "/bearer_state.general.json"
-        # Pidfile follows the .json → .pid rule baked into _claim_recv_lock.
-        self._pidfile = self._tmpdir + "/bearer_state.general.pid"
+        # Pidfile follows the per-gist rule baked into _claim_recv_lock.
+        self._pidfile = self._tmpdir + "/bearer_gist.abc123.pid"
 
     def tearDown(self):
         import shutil
@@ -691,6 +693,7 @@ class BearerCliRecvLockTests(unittest.TestCase):
         # Host-gist-rotation case: previous bearer is alive but polling
         # the OLD gist; new bearer for the NEW gist should claim.
         import os
+        self._pidfile = self._tmpdir + "/bearer_gist.new_gist_id.pid"
         my_other_pid = 99999998  # used as "live but not us" stub
         with open(self._pidfile, "w") as f:
             f.write(f"{my_other_pid}\told-gist-id\n")
@@ -721,6 +724,26 @@ class BearerCliRecvLockTests(unittest.TestCase):
             content = f.read().strip()
         self.assertTrue(content.startswith(f"{my_other_pid}\t"),
                         "pidfile must NOT be overwritten when we lose the claim race")
+
+    def test_same_gist_different_channel_state_files_share_one_lock(self):
+        first_pidfile = self._tmpdir + "/bearer_gist.samegist.pid"
+        other_pid = 99999996
+        with open(first_pidfile, "w") as f:
+            f.write(f"{other_pid}\tsamegist\n")
+        self.assertEqual(first_pidfile, self._tmpdir + "/bearer_gist.samegist.pid")
+
+        second_args = self._args(
+            state_file=self._tmpdir + "/bearer_state.useideem.json",
+            room_gist_id="samegist",
+        )
+        with mock.patch.object(bearer_cli, "_pid_alive", return_value=True), \
+             mock.patch.object(bearer_cli, "_is_our_bearer", return_value=True):
+            second = bearer_cli._claim_recv_lock(second_args)
+        self.assertEqual(second, bearer_cli._LOCK_HELD,
+                         "same gist through a second channel must not spawn a duplicate bearer")
+        with open(first_pidfile) as f:
+            content = f.read().strip()
+        self.assertEqual(int(content.split("\t", 1)[0]), other_pid)
 
     def test_lock_write_failure_does_not_make_recv_exit_as_lock_held(self):
         # If the pidfile cannot be created, _claim_recv_lock must report


### PR DESCRIPTION
## Summary
- keep healthy channel bearers running when one subscribed channel bearer dies
- restart only the failed channel after re-reading its latest channel_gists mapping
- leave channels with missing mappings offline without breaking other subscribed channels
- change recv lock natural key from per-channel state-file to per-scope/per-gist so two channel labels mapped to the same gist do not spawn duplicate bearers

## Why
Two common monitor failures were found live:
1. A stale/flaky project-room gist can poison the whole multi-channel monitor because one bearer death kills all other channel bearers and rebuilds the formatter pipe. Healthy rooms like #general should keep flowing while the bad channel retries.
2. Two subscribed channel labels can resolve to the same gist. The #451 lock keyed by state-file allowed both bearers to run, so each yielded every message. Gist is the wire; channel is the display label.

## Verification
- `bash -n airc`
- `git diff --check`
- `./test/integration.sh inbox`
- `python3 -m py_compile lib/airc_core/bearer_cli.py`
- `python3 test/test_bearer.py` (90 tests OK)

## QA ask
Please test both common scenarios:
- healthy room + stale/flaky room: failed channel logs/retries, healthy channel messages continue
- two channel_gists entries pointing at the same gist: only one bearer should claim the gist lock; messages should emit once.