### PR TITLE
fix(monitor): surface degraded channel health

### DIFF
--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -13,6 +13,165 @@
 #
 # Extracted from airc as part of #152 Phase 3 file split.
 
+_airc_monitor_health_report() {
+  # Args: all|degraded-only. Prints per-channel monitor truth from
+  # config + bearer_state.*.json + bearer_gist.*.pid. This deliberately
+  # fails closed: if a subscribed channel lacks fresh heartbeat evidence,
+  # say DEGRADED instead of "likely-alive".
+  local mode="${1:-all}"
+  AIRC_STATUS_CONFIG="$CONFIG" AIRC_STATUS_HOME="$AIRC_WRITE_DIR" AIRC_STATUS_MODE="$mode" "$AIRC_PYTHON" - <<'PY'
+import json, os, signal, sys, time
+
+config = os.environ.get("AIRC_STATUS_CONFIG", "")
+home = os.environ.get("AIRC_STATUS_HOME", "")
+mode = os.environ.get("AIRC_STATUS_MODE", "all")
+now = time.time()
+fresh_after = 90
+
+try:
+    cfg = json.load(open(config))
+except Exception:
+    cfg = {}
+
+subs = list(cfg.get("subscribed_channels") or [])
+gists = dict(cfg.get("channel_gists") or {})
+if not subs:
+    subs = list(gists.keys())
+if not subs:
+    sys.exit(0)
+
+def safe_gist(gist: str) -> str:
+    return "".join(c if c.isalnum() else "_" for c in gist)
+
+def pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+state_cache = {}
+
+def load_state(ch: str):
+    if ch in state_cache:
+        return state_cache[ch]
+    path = os.path.join(home, f"bearer_state.{ch}.json")
+    try:
+        state_cache[ch] = (json.load(open(path)), None, path)
+    except FileNotFoundError:
+        state_cache[ch] = ({}, "no bearer_state file", path)
+    except Exception as e:
+        state_cache[ch] = ({}, f"unreadable bearer_state: {e}", path)
+    return state_cache[ch]
+
+def signal_for_gist(ch: str, gist: str, own_state: dict):
+    """Return freshest heartbeat/recv evidence for this channel's wire.
+
+    #452 made the recv lock per gist, not per channel label. If two
+    subscribed channels intentionally share one gist, only one bearer may
+    own that wire and therefore only one bearer_state.<channel>.json may
+    carry the heartbeat. Treat that sibling heartbeat as proof for the
+    shared wire while still reporting the subscribed channel label.
+    """
+    candidates = [(ch, own_state)]
+    if gist:
+        for other in subs:
+            if other == ch or gists.get(other) != gist:
+                continue
+            other_state, _, _ = load_state(other)
+            if other_state:
+                candidates.append((other, other_state))
+
+    best = None
+    for source, state in candidates:
+        hb = state.get("last_heartbeat_ts")
+        recv = state.get("last_recv_ts")
+        ts = hb if hb is not None else recv
+        if ts is None:
+            continue
+        try:
+            ts_f = float(ts)
+        except Exception:
+            continue
+        if best is None or ts_f > best[0]:
+            best = (ts_f, source)
+    return best
+
+rows = []
+degraded = 0
+for ch in subs:
+    gist = gists.get(ch, "")
+    issues = []
+    age = None
+    state = {}
+
+    if not gist:
+        issues.append("missing channel_gists mapping")
+
+    state, state_issue, state_path = load_state(ch)
+    signal = signal_for_gist(ch, gist, state)
+    signal_source = ch
+    if signal is not None:
+        signal_ts, signal_source = signal
+        try:
+            age = int(now - signal_ts)
+            if age > fresh_after:
+                issues.append(f"stale heartbeat {age}s")
+        except Exception:
+            issues.append("invalid heartbeat timestamp")
+    elif state:
+        try:
+            mtime_age = int(now - os.path.getmtime(state_path))
+        except OSError:
+            mtime_age = None
+        if mtime_age is not None and mtime_age <= fresh_after:
+            age = mtime_age
+            issues.append("starting; no heartbeat yet")
+        else:
+            issues.append("no heartbeat evidence")
+    elif state_issue:
+        issues.append(state_issue)
+
+    pidfile = os.path.join(home, f"bearer_gist.{safe_gist(gist)}.pid") if gist else os.path.join(home, f"bearer_state.{ch}.pid")
+    try:
+        raw = open(pidfile).read().strip().split("\t", 1)[0]
+        pid = int(raw) if raw else 0
+    except FileNotFoundError:
+        pid = 0
+        issues.append("no bearer pidfile")
+    except Exception:
+        pid = 0
+        issues.append("unreadable bearer pidfile")
+    if pid and not pid_alive(pid):
+        issues.append(f"stale bearer pid {pid}")
+
+    level = "DEGRADED" if issues else "ok"
+    if issues:
+        degraded += 1
+    suffix = f"{age}s" if age is not None else "no-signal"
+    detail = "; ".join(issues) if issues else "fresh heartbeat"
+    if not issues and signal_source != ch:
+        detail = f"fresh heartbeat via shared gist #{signal_source}"
+    rows.append((level, ch, suffix, detail))
+
+if mode == "degraded-only" and degraded == 0:
+    sys.exit(0)
+
+if degraded:
+    print(f"  monitor health: DEGRADED ({degraded}/{len(rows)} channel(s) need attention)")
+else:
+    print(f"  monitor health: ok ({len(rows)} channel(s) fresh)")
+for level, ch, suffix, detail in rows:
+    if mode == "degraded-only" and level != "DEGRADED":
+        continue
+    print(f"    #{ch}: {level} ({suffix}) — {detail}")
+PY
+}
+
 cmd_status() {
   # Human-readable liveness view. Fast — no network calls by default; `--probe`
   # opts into a 3s SSH reachability check.
@@ -125,6 +284,7 @@ if fresh:
     monitor_state="stale pidfile (no live PIDs — run 'airc connect' to self-heal)"
   fi
   echo "  monitor:     $monitor_state"
+  _airc_monitor_health_report all
 
   # Host reachability. Only meaningful for joiners; opt-in via --probe to keep
   # `airc status` fast by default (SSH connect can hang for seconds).
@@ -394,8 +554,10 @@ cmd_inbox() {
   fi
 
   if [ -n "$out" ]; then
+    _airc_monitor_health_report degraded-only
     printf '%s\n' "$out"
   else
+    _airc_monitor_health_report degraded-only
     echo "No new airc messages since $since"
   fi
 

--- a/lib/airc_core/bearer_cli.py
+++ b/lib/airc_core/bearer_cli.py
@@ -45,6 +45,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 from dataclasses import asdict
 from typing import Optional, Tuple, Union
 
@@ -390,6 +391,8 @@ def cmd_recv(args) -> int:
                     except (BrokenPipeError, ValueError):
                         # Downstream gone or stdout closed; stop trying.
                         return
+                if state_file:
+                    _touch_state_heartbeat(state_file, _ti.time())
                 next_tick = now + _heartbeat_sec
             # Wake every 100ms so close() takes effect promptly.
             _stop_heartbeat.wait(0.1)
@@ -421,6 +424,7 @@ def cmd_recv(args) -> int:
                     "events_total": events_total,
                     "diag": live.bearer_diag,
                 })
+                _touch_state_heartbeat(state_file, time.time())
     except KeyboardInterrupt:
         pass
     finally:
@@ -457,6 +461,23 @@ def _write_state_file(path: str, state: dict) -> None:
                 pass
     except OSError:
         pass
+
+
+def _touch_state_heartbeat(path: str, ts: float) -> None:
+    """Record bearer-loop heartbeat without pretending a peer message arrived.
+
+    last_recv_ts remains the timestamp of the last real envelope. The
+    heartbeat timestamp lets `airc status` distinguish an idle but live
+    bearer from a dead channel, which is the signal users and agents need
+    when a monitor silently wedges.
+    """
+    try:
+        with open(path) as f:
+            state = json.load(f)
+    except Exception:
+        state = {}
+    state["last_heartbeat_ts"] = ts
+    _write_state_file(path, state)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -554,6 +554,29 @@ class BearerCliStateFileTests(unittest.TestCase):
         # Bearer's liveness ts was 1714435200 + (2 events × 1s for liveness call) + 1 (init) → check it's reasonable
         self.assertGreater(state["last_recv_ts"], 1714435200.0)
         self.assertEqual(state["kind"], "fake-ssh")
+        self.assertGreaterEqual(state["last_heartbeat_ts"], state["last_recv_ts"])
+
+    def test_heartbeat_touch_does_not_fake_receive(self):
+        import json as _json
+        import os as _os
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as f:
+            state_path = f.name
+            _json.dump({
+                "kind": "gh",
+                "peer_id": "alice",
+                "last_recv_ts": 123.0,
+                "events_total": 7,
+            }, f)
+
+        bearer_cli._touch_state_heartbeat(state_path, 456.0)
+
+        with open(state_path) as f:
+            state = _json.load(f)
+        self.assertEqual(state["last_recv_ts"], 123.0)
+        self.assertEqual(state["events_total"], 7)
+        self.assertEqual(state["last_heartbeat_ts"], 456.0)
+        _os.unlink(state_path)
 
     def test_no_state_file_means_no_writes(self):
         events = [ReceivedMessage(


### PR DESCRIPTION
## Summary
- write bearer heartbeat timestamps into bearer_state without faking message receive timestamps
- add `airc status` monitor health that fails closed when subscribed channels lack fresh heartbeat/pid evidence
- show degraded monitor health from `airc inbox`, so Codex/non-Monitor runtimes see listener failures during normal catch-up
- group heartbeat evidence by gist so channels sharing a wire after #452 do not false-alarm

## Verification
- `bash -n airc lib/airc_bash/cmd_status.sh`
- `python3 -m py_compile lib/airc_core/bearer_cli.py`
- `git diff --check`
- `python3 test/test_bearer.py`
- `./test/integration.sh inbox`
- live smoke: `/private/tmp/airc-monitor-visible/airc status --probe` showed monitor health for #general/#cambriantech; `/private/tmp/airc-monitor-visible/airc inbox --peek` exercised Codex catch-up path

This addresses the silent-failure class Joel flagged: wrapper/daemon presence is no longer enough; the UI surfaces actual bearer heartbeat evidence.