### PR TITLE
docs(invite): correct heredoc-quoting comment in _cmd_invite_human (Copilot review of #454)

### DIFF
--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -384,8 +384,16 @@ _cmd_invite_human() {
   # cross-account-safe form).
   #
   # Output is itself shell-pasteable: comment lines + commands.
-  # Heredoc has a quoted delimiter so $(whoami) doesn't expand at
-  # generation time; it expands at paste time on the receiver's shell.
+  #
+  # The heredoc uses an UNQUOTED delimiter (`<<PASTE`) so we can expand
+  # ${primary_chan} and ${primary_gid} from the host's state. The
+  # `$(whoami)` in the "say hi" line is explicitly ESCAPED as
+  # `\$(whoami)` so it survives host-side expansion and runs on the
+  # receiver's shell at paste time. Don't switch to a quoted delimiter
+  # without also restoring the channel + gist substitutions some other
+  # way — they're load-bearing for the paste-block.
+  # (Copilot's review of #454 flagged the previous comment as
+  # mis-describing this; comment now matches actual behavior.)
   local primary_chan primary_gid
   primary_chan=$("$AIRC_PYTHON" -m airc_core.config default_channel --config "$CONFIG" 2>/dev/null || true)
   if [ -n "$primary_chan" ]; then


### PR DESCRIPTION
## Summary

Copilot's review of #454 caught that the comment on `_cmd_invite_human`'s heredoc claimed it used a quoted delimiter, but the actual code is `<<PASTE` (unquoted) with explicit `\$(whoami)` escape. The behavior is correct (intentional — `${primary_chan}`/`${primary_gid}` need to expand on the host while `$(whoami)` survives to the receiver), but the comment was wrong.

Updated comment now matches the actual behavior + warns against accidentally re-quoting the delimiter without restoring the channel/gist substitutions.

No functional change.

## Other findings from Copilot's review of #454

For coordination — Copilot also flagged 4 issues in code I didn't author (Codex's #450/#451/#452):

1. `cmd_inbox` cursor advances on empty-read (cmd_status.sh:407) — late-arriving messages with timestamps before `read_started` could be permanently skipped
2. `_is_our_bearer` returns False on subprocess failure (bearer_cli.py:118) — could re-enable duplicate emission if ps is unavailable/truncated. Suggested conservative fix: treat as held when verification can't run
3. Comment header still says "Per-(scope, channel, gist)" after #452 made it per-(scope, gist) (bearer_cli.py:58) — doc inconsistency
4. Bearer restart diagnostics emit to stderr (airc:1356), invisible to Monitor — should emit a synthetic JSON event to stdout so monitor_formatter can surface it

These are Codex's surface — relayed via airc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)