### PR TITLE
fix(monitor): dedup bearer spawns by gist, not by channel — fixes infinite respawn loop when channels share a gist

### DIFF
--- a/airc
+++ b/airc
@@ -1333,7 +1333,28 @@ _monitor_multi_channel() {
           2>>"$AIRC_WRITE_DIR/bearer_recv.${ch}.log" &
         _pids+=("$!:$ch")
       }
+      # Dedup-by-gist at spawn time. The bearer's natural unit is the
+      # gist (the wire), not the channel (a logical label). When two
+      # subscribed channels map to the same gist (host advertising one
+      # mesh gist for both — the joiner-config Joel hit 2026-05-04),
+      # spawning one bearer per channel + relying on per-(scope, gist)
+      # lock to dedup produced an infinite respawn loop: lock-loser
+      # exits 0 cleanly, supervisor sees death, respawns, loses lock
+      # again, ad infinitum. Fix the design mismatch here at the
+      # supervisor: skip channels whose gist is already served by an
+      # earlier-iteration bearer. Messages route to all subscribed
+      # channels via envelope.channel downstream — one bearer reads
+      # the gist once and yields each line; monitor_formatter dispatches
+      # by channel field. (State files stay per-channel for now;
+      # per-gist state-files is a deeper refactor.)
+      local _served_gists=""
       while IFS=$'\t' read -r ch gid; do
+        [ -z "$ch" ] && continue
+        [ -z "$gid" ] && continue
+        case " $_served_gists " in
+          *" $gid "*) continue ;;
+        esac
+        _served_gists="$_served_gists $gid"
         _start_channel_bearer "$ch" "$gid"
       done <<< "$channel_map"
 
@@ -1406,16 +1427,36 @@ _monitor_multi_channel() {
           done
           _pids=("${_kept[@]}")
 
+          # Build the set of gists currently served by live bearers,
+          # so the add-loop doesn't double-spawn for a gist that's
+          # already covered by another channel's bearer (same dedup-by-
+          # gist invariant as the initial spawn loop above).
+          local _live_gists=""
+          local _entry_ch _entry_gid
+          for entry in "${_pids[@]}"; do
+            _entry_ch="${entry#*:}"
+            _entry_gid=$(printf '%s\n' "$_current_map" | awk -F '\t' -v c="$_entry_ch" '$1 == c {print $2; exit}')
+            [ -n "$_entry_gid" ] && _live_gists="$_live_gists $_entry_gid"
+          done
+
           while IFS=$'\t' read -r ch gid; do
             [ -z "$ch" ] && continue
+            [ -z "$gid" ] && continue
             local _already=0
             for entry in "${_pids[@]}"; do
               [ "${entry#*:}" = "$ch" ] && _already=1 && break
             done
-            if [ "$_already" = "0" ]; then
-              echo "airc: #${ch} added to channel_gists; starting bearer without full monitor restart" >&2
-              _start_channel_bearer "$ch" "$gid"
+            if [ "$_already" = "1" ]; then
+              continue
             fi
+            # Don't spawn if another channel's bearer already serves
+            # this gist — that bearer's stream already covers us.
+            case " $_live_gists " in
+              *" $gid "*) continue ;;
+            esac
+            _live_gists="$_live_gists $gid"
+            echo "airc: #${ch} added to channel_gists; starting bearer without full monitor restart" >&2
+            _start_channel_bearer "$ch" "$gid"
           done <<< "$_current_map"
         fi
       done


### PR DESCRIPTION
## The third bearer design-mismatch in one session

Joel called this out as "this keeps happening / dumb design / think it through" — fair. The pattern:

| Bug | Was | Is now |
|---|---|---|
| #451 | bearer process lifecycle (orphans + duplicate emission) | per-(scope, channel, gist) pidfile lock |
| #452 | lock-key was per-channel; same-gist-different-channel still produced duplicates | per-(scope, gist) lock |
| **This** | **supervisor still iterates channels and spawns one bearer per channel; the now-correct per-gist lock turns the redundant spawns into an infinite respawn loop** | **dedup by gist at the supervisor** |

Each fix was a layer on top of the wrong invariant. The right invariant — visible only after watching the third version of the same shape break — is: **bearer's natural unit is the gist (the wire), not the channel (a label).**

## What was happening

Joel's mesh: `channel_gists[useideem] == channel_gists[general]` (one gist for both). Per-(scope, gist) lock admits ONE bearer. The bash supervisor in `_monitor_multi_channel` spawns ONE bearer per subscribed channel — so it tries to spawn TWO. The second hits `_LOCK_HELD`, exits 0 cleanly with "another bearer for gist X already running". Supervisor sees exit, treats as death, respawns. Loop.

`bearer_recv.<ch>.log` fills with identical lines. `bearer_state.<ch>.json` shows `events_total=0` (this bearer never managed to read anything — it kept dying on the lock claim). Inbound messages on the second channel are effectively offline. **My local repro right now**: I missed Codex's #457-ownership ping on #general because of this exact loop on this exact mesh.

## Fix

`_monitor_multi_channel` now dedupes by gist BEFORE spawning, in both the initial spawn loop and the live-refresh add path:

```bash
local _served_gists=""
while IFS=$'\t' read -r ch gid; do
  case " $_served_gists " in
    *" $gid "*) continue ;;  # this gist already has a bearer
  esac
  _served_gists="$_served_gists $gid"
  _start_channel_bearer "$ch" "$gid"
done <<< "$channel_map"
```

The bearer reads the gist once, yields every line; `monitor_formatter` routes to subscribed channels per the envelope's `channel` field downstream. State files stay per-channel for now (per-gist state files is a deeper refactor that touches `status`, `doctor`, `cmd_send` — not blocking tonight's Toby remote-conn test).

## Test plan

- [x] `bash -n airc` clean
- [x] `bash test/integration.sh general_sidecar_default` — 10/10 pass (the closest existing scenario that exercises sidecar/multi-channel)
- [ ] Local live test: bounce monitor onto this branch, watch for absence of "another bearer for gist X already running" loop in `bearer_recv.<ch>.log`
- [ ] CI clean-install matrix

## Known follow-ups

This fix unblocks the respawn loop but `airc status` still asks "is there a bearer for #general?" by name and gets "no" when `general` shares a gist with `useideem` (the answer should be "yes — the useideem bearer covers it"). That's the per-gist state-file refactor, separate PR.

Codex is independently on the related "status says healthy when actually solo" structural issue (peers=0 should warn loudly). Both fixes converge on the same insight: **bus-up ≠ collaboration-connected**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)