### PR TITLE
fix(mesh): converge on one canonical gist resolver

### DIFF
--- a/airc
+++ b/airc
@@ -420,10 +420,12 @@ _self_heal_stale_host() {
   # explicit --room flag was used; anywhere else it's empty and we
   # reexec without the override (auto-scope decides as usual).
   local _saved_intent="${ROOM_INTENT_FOR_REEXEC:-}"
-  # _mesh_find returns the singleton mesh gist (oldest-by-created if
-  # multiple are present from a race). If something is there, another
-  # tab beat us — rejoin pointed at it.
-  local picked; picked=$(_mesh_find)
+  # _mesh_find uses the same content-based channel_gist resolver as
+  # connect/subscribe/send. If something canonical is there, another
+  # tab beat us — rejoin pointed at it. Description-only lookup caused
+  # split-brain when one path chose "airc mesh" and another chose an
+  # older live "airc room:" envelope.
+  local picked; picked=$(_mesh_find "${_saved_intent:-${room_name:-}}")
   rm -f "$CONFIG" "$AIRC_WRITE_DIR/room_name"
   if [ -n "$_saved_intent" ]; then
     export AIRC_ROOM_INTENT="$_saved_intent"
@@ -2084,13 +2086,15 @@ _mesh_rediscover_loop() {
     # Resolve the current default-channel gist from config. We compare
     # against the singleton mesh, so any divergence on the default
     # channel implies host rotation.
-    local current_gist
-    current_gist=$("$AIRC_PYTHON" -m airc_core.config list_channel_gists \
+    local current_ch current_gist
+    read -r current_ch current_gist <<EOF
+$("$AIRC_PYTHON" -m airc_core.config list_channel_gists \
       --config "$CONFIG" 2>/dev/null \
-      | awk -F'\t' 'NR==1 {print $2}')
+      | awk -F'\t' 'NR==1 {print $1, $2}')
+EOF
     [ -n "$current_gist" ] || continue
     local found_gist
-    found_gist=$(_mesh_find 2>/dev/null || true)
+    found_gist=$(_mesh_find "$current_ch" 2>/dev/null || true)
     [ -n "$found_gist" ] || continue
     if [ "$found_gist" = "$current_gist" ]; then
       continue

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -569,18 +569,19 @@ cmd_connect() {
      [ "${AIRC_NO_DISCOVERY:-0}" != "1" ] && \
      command -v gh >/dev/null 2>&1; then
 
-    # ── Mesh discovery (singleton per gh account) ────────────────
-    # Architectural shift from the per-room model: ONE gist per gh
-    # account, description literal "airc mesh". Every `airc join` on
-    # the account converges on it. _mesh_find returns the singleton
-    # (oldest-by-created if multiple are present from a race).
+    # ── Mesh discovery (canonical channel gist) ──────────────────
+    # Every `airc join` resolves the requested/default channel through
+    # the same content-based channel_gist rule used by subscribe/send.
+    # Do NOT match only the human description "airc mesh": stale
+    # "airc room:" gists can still carry the live envelope, and using a
+    # different resolver here is exactly how #general split-brained.
     #
     # The --room flag still records the channel(s) this client wants
     # to subscribe to (Phase 2 will route messages by channel), but it
     # no longer drives gist discovery — every subscriber on the account
     # converges on the same host.
     _did_room_discovery=1
-    local _mesh_id; _mesh_id=$(_mesh_find)
+    local _mesh_id; _mesh_id=$(_mesh_find "$room_name")
     if [ -n "$_mesh_id" ]; then
       echo "  Found mesh on your gh account → joining ($_mesh_id)"
       target="$_mesh_id"

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -533,6 +533,23 @@ _doctor_health() {
     printf "         Fix: airc join  (then re-run airc doctor --health)\n"
   fi
 
+  # ── Collaboration membership. A local bearer can be healthy while the
+  # mesh is effectively solo after host self-heal / gist rotation. That
+  # is not a healthy collaboration bus: messages may append to a fresh
+  # gist nobody else is polling. Keep this separate from transport
+  # health so users can see "wire is alive, but nobody is connected."
+  local peer_count=0
+  if [ -d "$PEERS_DIR" ]; then
+    peer_count=$(find "$PEERS_DIR" -maxdepth 1 -name '*.json' -type f 2>/dev/null | wc -l | tr -d ' ')
+  fi
+  if [ "${peer_count:-0}" -eq 0 ] 2>/dev/null; then
+    printf "  [WARN] collaboration mesh has 0 peer records — local transport may be healthy but nobody is known to be connected\n"
+    printf "         Check: airc peers; ask peers to run 'airc update --channel canary && airc connect <current invite>'\n"
+    warns=$((warns+1))
+  else
+    printf "  [ok] collaboration mesh has %s peer record(s)\n" "$peer_count"
+  fi
+
   echo
   if [ "$issues" -eq 0 ] && [ "$warns" -eq 0 ]; then
     echo "  ✓ Bus healthy."

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -672,6 +672,13 @@ cmd_send() {
     else
       echo "  → @${peer_name} on #${active_channel}"
     fi
+    local _peer_count=0
+    if [ -d "$PEERS_DIR" ]; then
+      _peer_count=$(find "$PEERS_DIR" -maxdepth 1 -name '*.json' -type f 2>/dev/null | wc -l | tr -d ' ')
+    fi
+    if [ "${_peer_count:-0}" -eq 0 ] 2>/dev/null; then
+      echo "  ⚠ collaboration: 0 peer records in this scope; this may be a solo mesh. Run 'airc peers' and verify others joined this gist." >&2
+    fi
   fi
 }
 

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -172,6 +172,79 @@ for level, ch, suffix, detail in rows:
 PY
 }
 
+_airc_collaboration_health_report() {
+  # Local transport health is not the same as collaboration health. A
+  # self-healed host can have fresh bearer heartbeats while nobody else is
+  # paired to this mesh. Surface that split-brain shape explicitly.
+  AIRC_STATUS_HOME="$AIRC_WRITE_DIR" AIRC_STATUS_MY_NAME="$(get_name)" "$AIRC_PYTHON" - <<'PY'
+import calendar, json, os, sys, time
+
+home = os.environ.get("AIRC_STATUS_HOME", "")
+my_name = os.environ.get("AIRC_STATUS_MY_NAME", "")
+peers_dir = os.path.join(home, "peers")
+messages_log = os.path.join(home, "messages.jsonl")
+now = int(time.time())
+
+peer_records = 0
+if os.path.isdir(peers_dir):
+    for entry in os.listdir(peers_dir):
+        if not entry.endswith(".json"):
+            continue
+        try:
+            json.load(open(os.path.join(peers_dir, entry)))
+        except Exception:
+            continue
+        peer_records += 1
+
+last_remote = None
+last_remote_name = None
+def epoch(ts):
+    if not ts:
+        return None
+    try:
+        return calendar.timegm(time.strptime(ts.replace("Z", ""), "%Y-%m-%dT%H:%M:%S"))
+    except Exception:
+        return None
+
+try:
+    with open(messages_log) as f:
+        for line in f:
+            try:
+                msg = json.loads(line)
+            except Exception:
+                continue
+            sender = msg.get("from")
+            if not sender or sender in (my_name, "airc"):
+                continue
+            ts = epoch(msg.get("ts"))
+            if ts is None:
+                continue
+            if last_remote is None or ts > last_remote:
+                last_remote = ts
+                last_remote_name = sender
+except OSError:
+    pass
+
+if last_remote is None:
+    remote_desc = "no remote messages recorded"
+    remote_recent = False
+else:
+    age = max(0, now - last_remote)
+    remote_desc = f"last remote message {age}s ago from {last_remote_name}"
+    remote_recent = age < 600
+
+if peer_records == 0:
+    if remote_recent:
+        print(f"  collaboration: DEGRADED (0 peer records; {remote_desc})")
+        print("    DMs/whois/peer targeting may be broken; verify everyone is on the same gist with 'airc peers' and 'airc invite'.")
+    else:
+        print(f"  collaboration: SOLO (0 peer records; {remote_desc})")
+        print("    Sends may only land in this local/self-hosted gist until another agent joins this exact mesh.")
+else:
+    print(f"  collaboration: ok ({peer_records} peer record(s); {remote_desc})")
+PY
+}
+
 cmd_status() {
   # Human-readable liveness view. Fast — no network calls by default; `--probe`
   # opts into a 3s SSH reachability check.
@@ -217,6 +290,7 @@ cmd_status() {
       echo "  channels:    #${_default}"
     fi
   fi
+  _airc_collaboration_health_report
 
   # Monitor alive? Use the shared sandbox-robust helper
   # (_monitor_alive_with_bearer_fallback in airc top-level). Phase 1 =

--- a/lib/airc_bash/mesh.sh
+++ b/lib/airc_bash/mesh.sh
@@ -37,37 +37,24 @@ _mesh_desc() {
 # Singleton lookup: find the mesh gist on the current gh account.
 # Echoes the gist id (one line) or empty.
 #
-# If the listing returns 2+ candidates (race-loser collision, gh
-# replication lag, or an old per-room gist incorrectly tagged), keep
-# the OLDEST by created_at. The oldest is the legitimate winner of
-# any post-publish race because it was created first; any other entry
-# is a duplicate that should be reaped on the next takeover cycle.
+# Production invariant: the gist envelope content is the source of
+# truth, not the human description. Pre-fix this matched only gists
+# whose description was exactly "airc mesh"; meanwhile
+# airc_core.channel_gist.resolve found older "airc room: ..." gists
+# by envelope content. Two discovery systems, two answers, split-brain.
+#
+# Delegate lookup to channel_gist.find_existing so connect, subscribe,
+# send, and rediscovery all use the same canonical channel→gist rule.
+# Optional arg = channel name. Empty falls back to cmd_connect's dynamic
+# room_name, then config's default channel, then #general.
 _mesh_find() {
   command -v gh >/dev/null 2>&1 || return 0
-  local desc; desc=$(_mesh_desc)
-  # gh gist list output: <id>\t<desc>\t<files>\t<visibility>\t<updated>
-  # Filter on EXACT desc match (anchor with ^ and $ in awk).
-  local ids
-  ids=$(gh gist list --limit 50 2>/dev/null \
-    | awk -F'\t' -v d="$desc" '$2 == d { print $1 }')
-  local count; count=$(printf '%s\n' "$ids" | grep -c . || true)
-  case "$count" in
-    0) return 0 ;;
-    1) printf '%s\n' "$ids" ;;
-    *)
-      # Multiple matches — pick the oldest by created_at. Same tiebreaker
-      # cmd_connect's race-loser detection uses; centralized here.
-      local oldest="" oldest_ts=""
-      while IFS= read -r gid; do
-        [ -z "$gid" ] && continue
-        local ts; ts=$(gh api "gists/$gid" --jq '.created_at' 2>/dev/null || echo "")
-        if [ -z "$oldest_ts" ] || [ "$ts" \< "$oldest_ts" ]; then
-          oldest="$gid"; oldest_ts="$ts"
-        fi
-      done <<< "$ids"
-      [ -n "$oldest" ] && printf '%s\n' "$oldest"
-      ;;
-  esac
+  local channel="${1:-${room_name:-}}"
+  if [ -z "$channel" ] && [ -n "${CONFIG:-}" ] && [ -f "$CONFIG" ]; then
+    channel=$("$AIRC_PYTHON" -m airc_core.config default_channel --config "$CONFIG" 2>/dev/null || true)
+  fi
+  [ -z "$channel" ] && channel="general"
+  "$AIRC_PYTHON" -m airc_core.channel_gist find --channel "$channel" 2>/dev/null || true
 }
 
 # Publish a new mesh gist. Echoes the new gist id, or empty on failure.

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2007,6 +2007,42 @@ JSON
   cleanup_all
 }
 
+# ── Scenario: solo_mesh_warns (transport health != collaboration) ───────
+# A self-healed host can have fresh local transport/bearer state while no
+# peers are actually paired to the mesh. `airc status` / `doctor --health`
+# must not report that as simply healthy; the user needs to know they may
+# be talking to a solo gist.
+scenario_solo_mesh_warns() {
+  section "solo_mesh_warns: status and doctor distinguish local health from collaboration"
+  cleanup_all
+
+  local home=/tmp/airc-it-solo/state
+  mkdir -p "$home/identity" "$home/peers"
+  scaffold_identity "$home/identity" 'airc-test-solo'
+  cat > "$home/config.json" <<'JSON'
+{ "name": "solo-host", "subscribed_channels": ["general"], "channel_gists": {"general": "abc123"} }
+JSON
+  echo general > "$home/room_name"
+  echo abc123 > "$home/room_gist_id"
+
+  local status_out doctor_out
+  status_out=$(AIRC_HOME="$home" "$AIRC" status 2>&1)
+  echo "$status_out" | grep -q 'collaboration: SOLO' \
+    && pass "status reports SOLO when peer records are empty" \
+    || fail "status did not report solo collaboration state ($status_out)"
+
+  doctor_out=$(AIRC_HOME="$home" "$AIRC" doctor --health 2>&1)
+  echo "$doctor_out" | grep -q 'collaboration mesh has 0 peer records' \
+    && pass "doctor --health warns about zero-peer collaboration mesh" \
+    || fail "doctor --health did not warn about zero peers ($doctor_out)"
+  echo "$doctor_out" | grep -q 'Bus working, .*warning' \
+    && pass "doctor summary is warning, not clean healthy" \
+    || fail "doctor summary still looked clean ($doctor_out)"
+
+  rm -rf /tmp/airc-it-solo
+  cleanup_all
+}
+
 # ── Scenario: connect_after_kill_recovers (#130, replaces resume_*) ──────
 # The architectural property of #130: cached pairing in CONFIG is NEVER
 # trusted. Every `airc connect` runs discovery and re-pairs against the
@@ -4125,6 +4161,7 @@ case "$MODE" in
   two_tab_localhost) scenario_two_tab_localhost ;;
   auto_scope)   scenario_auto_scope ;;
   send_dead_monitor_dies) scenario_send_dead_monitor_dies ;;
+  solo_mesh_warns) scenario_solo_mesh_warns ;;
   connect_after_kill_recovers) scenario_connect_after_kill_recovers ;;
   general_sidecar_default) scenario_general_sidecar_default ;;
   away) scenario_away ;;
@@ -4158,7 +4195,8 @@ case "$MODE" in
     scenario_auth_failure; scenario_room; scenario_events; scenario_get_host
     scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat
     scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope
-    scenario_send_dead_monitor_dies; scenario_connect_after_kill_recovers
+    scenario_send_dead_monitor_dies; scenario_solo_mesh_warns
+    scenario_connect_after_kill_recovers
     scenario_general_sidecar_default; scenario_away
     scenario_list; scenario_quit; scenario_platform_adapters
     scenario_python_units
@@ -4169,7 +4207,7 @@ case "$MODE" in
     scenario_custom_room_creates_gist
     scenario_invite_human
     ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|solo_mesh_warns|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary
- replace description-only `_mesh_find` with the same content-based `airc_core.channel_gist` resolver used by subscribe/send
- update connect discovery, stale-host rejoin, and rediscover to pass the relevant channel into that resolver
- keep the health guardrails from the first commit so status/doctor/send expose zero-peer solo meshes instead of saying clean healthy

## Root Cause
AIRC had two sources of truth for the mesh:

1. `_mesh_find` matched only gists whose description was exactly `airc mesh`.
2. `channel_gist.resolve/find_existing` matched envelope content and could choose an older `airc room: ...` gist that still carried the live `general`/`cambriantech` channel envelope.

Live account evidence showed exactly that split: `_mesh_find` chose `0fc919c...` (fresh empty exact-description mesh), while channel routing and active peer heartbeat were on `c56fda...` (older room-described gist with `airc-room-general.json` and b69f heartbeat). Agents then believed they were joined while writing to different gists.

## Verification
- `bash -n airc lib/airc_bash/mesh.sh lib/airc_bash/cmd_connect.sh lib/airc_bash/cmd_status.sh lib/airc_bash/cmd_doctor.sh lib/airc_bash/cmd_send.sh test/integration.sh`
- `git diff --check`
- `PYTHONPATH=lib python3 test/test_channel_gist.py`
- `./test/integration.sh send_dead_monitor_dies` (sequential; 8/8)
- `./test/integration.sh solo_mesh_warns` (sequential; 3/3)
- Live resolver smoke on Joel account: patched `_mesh_find general` and `_mesh_find cambriantech` both return `c56fdaaf8e2af0a277bedf432975a23c`, not the empty `0fc919c5ce642d2c1ea55534c312de6c`.

## Notes
This is the production fix for the split-brain class: one canonical channel→gist resolver. The zero-peer health warnings remain as defense-in-depth, but are not the primary fix.