### PR TITLE
fix(gist): select freshest channel envelope

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -722,7 +722,7 @@ cmd_connect() {
       # gist description as a header line that we'd then have to strip.
       if command -v gh >/dev/null 2>&1; then
         raw_content=$( (gh api "gists/$gist_id" 2>/dev/null \
-                        | "$AIRC_PYTHON" -m airc_core.gistparse gist_content 2>/dev/null) || true )
+                        | "$AIRC_PYTHON" -m airc_core.gistparse gist_content --channel "$room_name" 2>/dev/null) || true )
       fi
       # Fallback path 1: gh raw view (description leak handled by the
       # awk strip below at "head -c 1 | grep '{'" cleanup).
@@ -740,13 +740,13 @@ cmd_connect() {
       if [ -z "$raw_content" ] && command -v git >/dev/null 2>&1; then
         local _gist_tmp; _gist_tmp=$(mktemp -d -t airc-gist-resolve.XXXXXX 2>/dev/null || echo "")
         if [ -n "$_gist_tmp" ] && git clone --depth 1 --quiet "https://gist.github.com/$gist_id.git" "$_gist_tmp" 2>/dev/null; then
-          # Gists typically contain ONE file (airc envelopes always do).
-          # Take the first non-dotfile, non-.git entry. If a future gist
-          # shape ships multiple files we'll add an explicit airc-envelope
-          # filename convention; for now the single-file assumption is
-          # sound across every gist airc has ever published.
+          # Prefer the requested channel's envelope; fall back to the
+          # first non-dotfile for legacy single-file invite gists.
           local _gist_file
-          _gist_file=$(find "$_gist_tmp" -maxdepth 1 -type f ! -name '.git*' 2>/dev/null | head -1 || true)
+          _gist_file="$_gist_tmp/airc-room-${room_name}.json"
+          if [ ! -f "$_gist_file" ]; then
+            _gist_file=$(find "$_gist_tmp" -maxdepth 1 -type f ! -name '.git*' 2>/dev/null | head -1 || true)
+          fi
           if [ -n "$_gist_file" ] && [ -f "$_gist_file" ]; then
             raw_content=$(cat "$_gist_file" 2>/dev/null || true)
           fi
@@ -757,7 +757,7 @@ cmd_connect() {
       # without gh OR git. Last resort. (#188 — was curl + jq.)
       if [ -z "$raw_content" ] && command -v curl >/dev/null 2>&1; then
         raw_content=$( (curl -fsSL "https://api.github.com/gists/$gist_id" 2>/dev/null \
-                        | "$AIRC_PYTHON" -m airc_core.gistparse gist_content 2>/dev/null) || true )
+                        | "$AIRC_PYTHON" -m airc_core.gistparse gist_content --channel "$room_name" 2>/dev/null) || true )
       fi
       # Last-resort cleanup: if raw_content still has the description-header
       # leak from a degraded gh-view path, strip lines before the first '{'

--- a/lib/airc_bash/mesh.sh
+++ b/lib/airc_bash/mesh.sh
@@ -94,9 +94,17 @@ _mesh_update() {
 # assume stale" or "assume fresh" depending on policy.
 _mesh_age_secs() {
   local gist_id="${1:-}"
+  local channel="${2:-${room_name:-}}"
   [ -n "$gist_id" ] || return 0
   command -v gh >/dev/null 2>&1 || return 0
-  local content; content=$(gh api "gists/$gist_id" --jq '.files | to_entries[0].value.content' 2>/dev/null || true)
+  local content
+  if [ -n "$channel" ]; then
+    content=$(gh api "gists/$gist_id" 2>/dev/null \
+      | "$AIRC_PYTHON" -m airc_core.gistparse gist_content --channel "$channel" 2>/dev/null || true)
+  else
+    content=$(gh api "gists/$gist_id" 2>/dev/null \
+      | "$AIRC_PYTHON" -m airc_core.gistparse gist_content 2>/dev/null || true)
+  fi
   [ -z "$content" ] && return 0
   local hb; hb=$(printf '%s' "$content" | "$AIRC_PYTHON" -c '
 import sys, json

--- a/lib/airc_core/gistparse.py
+++ b/lib/airc_core/gistparse.py
@@ -94,6 +94,13 @@ def _read_stdin_json():
         return None
 
 
+def _read_json_text(text: str):
+    try:
+        return json.loads(text)
+    except (ValueError, TypeError):
+        return None
+
+
 def _emit(value, default=""):
     """Print value the way jq -r would: string scalars unquoted, dict/list
     as compact JSON, missing → default."""
@@ -234,8 +241,13 @@ def cmd_pick_addr_excluding(args) -> int:
 
 def cmd_gist_content(args) -> int:
     """Stdin is a gh-api response for a gist (`gh api gists/<id>` or the
-    REST equivalent). Extract the first file's `.content`. Replaces:
+    REST equivalent). Extract the relevant file's `.content`. Replaces:
         gh api gists/$id | jq -r '.files | to_entries[0].value.content // empty'
+
+    With --channel, select the freshest envelope whose channels[] contains
+    that channel. Multi-file legacy gists can hold a stale sibling file and
+    a fresh live file; first-file parsing can trigger destructive takeover
+    of the whole gist from the wrong channel's heartbeat.
     """
     data = _read_stdin_json()
     if not isinstance(data, dict):
@@ -243,6 +255,24 @@ def cmd_gist_content(args) -> int:
     files = data.get("files")
     if not isinstance(files, dict) or not files:
         return 0
+    channel = getattr(args, "channel", "") or ""
+    if channel:
+        exact_name = f"airc-room-{channel}.json"
+        matches = []
+        for name, entry in files.items():
+            if not isinstance(entry, dict):
+                continue
+            content = entry.get("content", "")
+            if not content:
+                continue
+            env = _read_json_text(content)
+            channels = env.get("channels") if isinstance(env, dict) else None
+            if isinstance(channels, list) and channel in channels:
+                matches.append((str(env.get("last_heartbeat", "")), name == exact_name, content))
+        if matches:
+            matches.sort(key=lambda item: (item[0], item[1]), reverse=True)
+            print(matches[0][2])
+            return 0
     # Files dict: { "<filename>": {"filename":..., "content":...}, ... }
     first_key = next(iter(files))
     entry = files[first_key]
@@ -314,6 +344,7 @@ def _build_parser() -> argparse.ArgumentParser:
     ll.set_defaults(func=cmd_list_lan_entries)
 
     gc = sub.add_parser("gist_content")
+    gc.add_argument("--channel", default="")
     gc.set_defaults(func=cmd_gist_content)
 
     gfo = sub.add_parser("get_first_of")

--- a/test/test_gistparse.py
+++ b/test/test_gistparse.py
@@ -24,6 +24,16 @@ sys.path.insert(0, str(REPO_ROOT / "lib"))
 from airc_core import gistparse  # noqa: E402
 
 
+def _run_gist_content(gist, channel=""):
+    fake_stdin = io.StringIO(json.dumps(gist))
+    fake_args = mock.Mock(channel=channel)
+    out = io.StringIO()
+    with mock.patch("sys.stdin", fake_stdin), redirect_stdout(out):
+        rc = gistparse.cmd_gist_content(fake_args)
+    assert rc == 0
+    return out.getvalue().rstrip("\n")
+
+
 def _run_pick_addr_excluding(addrs, exclude_scopes):
     """Run cmd_pick_addr_excluding with a fake stdin + capture stdout.
     Returns the printed string with trailing newline stripped."""
@@ -34,6 +44,45 @@ def _run_pick_addr_excluding(addrs, exclude_scopes):
         rc = gistparse.cmd_pick_addr_excluding(fake_args)
     assert rc == 0
     return out.getvalue().rstrip("\n")
+
+
+class GistContentTests(unittest.TestCase):
+    """Gist envelope selection must be channel-aware. A legacy gist may
+    contain multiple airc-room-*.json files with different heartbeat ages;
+    choosing the first file can make a live mesh look stale."""
+
+    def test_channel_selects_freshest_matching_envelope(self):
+        stale = {
+            "airc": 1,
+            "kind": "mesh",
+            "channels": ["general", "cambriantech"],
+            "last_heartbeat": "2026-05-04T12:54:15Z",
+            "invite": "stale-host@example",
+        }
+        fresh = {
+            "airc": 1,
+            "kind": "mesh",
+            "channels": ["cambriantech", "general"],
+            "last_heartbeat": "2026-05-04T17:14:09Z",
+            "invite": "fresh-host@example",
+        }
+        gist = {
+            "files": {
+                "airc-room-cambriantech.json": {"content": json.dumps(stale)},
+                "airc-room-general.json": {"content": json.dumps(fresh)},
+            },
+        }
+        out = _run_gist_content(gist, channel="cambriantech")
+        self.assertEqual(json.loads(out)["invite"], "fresh-host@example")
+
+    def test_without_channel_preserves_first_file_fallback(self):
+        gist = {
+            "files": {
+                "first.json": {"content": '{"which":"first"}'},
+                "second.json": {"content": '{"which":"second"}'},
+            },
+        }
+        self.assertEqual(json.loads(_run_gist_content(gist))["which"], "first")
 
 
 class PickAddrExcludingTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- make `gistparse gist_content --channel <name>` choose the freshest envelope whose `channels[]` contains that channel
- pass the requested channel when resolving a gist in `cmd_connect` and `_mesh_age_secs`
- keep first-file fallback only for legacy/single-file gists
- add regression coverage for multi-file gists with stale sibling files

## Root Cause
#459 fixed the split-brain resolver path, but live reconnect exposed a second destructive bug: after resolving the right multi-file gist, `gist_content` read the first file. In the live gist, one sibling file was stale while another file in the same gist had a fresh heartbeat. Reading the stale sibling made AIRC conclude the host was stale and delete/take over the whole gist.

A takeover decision must be based on the channel-relevant freshest envelope, not an arbitrary first file.

## Verification
- `bash -n airc lib/airc_bash/mesh.sh lib/airc_bash/cmd_connect.sh`
- `python3 test/test_gistparse.py`
- `PYTHONPATH=lib python3 test/test_channel_gist.py`
- `./test/integration.sh solo_mesh_warns`
- `git diff --check`

No live reconnect attempt until this lands; canary currently has #459 without this guard, so reconnecting can still make a bad takeover decision on multi-file gists.