### PR TITLE
fix(connect): ignore seed-only channel gists during discovery

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -140,6 +140,7 @@ cmd_connect() {
   fi
   local general_sidecar=1   # default ON (issue #121) — also subscribe to #general
   local _force_general_sidecar=0   # set by --general flag (issue #136 re-opt-in)
+  local allow_takeover="${AIRC_ALLOW_TAKEOVER:-0}"
   # Recursion guard: when WE are the sidecar (spawned by another airc
   # connect), don't spawn our own sidecar. Otherwise: turtles all the way.
   [ "${AIRC_GENERAL_SIDECAR:-0}" = "1" ] && general_sidecar=0
@@ -187,6 +188,7 @@ cmd_connect() {
         echo "  --no-room                      disable substrate entirely (legacy 1:1 invite)"
         echo "  --no-general                   keep project room, skip #general subscription"
         echo "  --general                      re-opt-in to #general after a prior /part"
+        echo "  --takeover                     explicitly replace an unreachable/stale host"
         echo "  --no-gist                      don't publish/discover via gh gist (test mode)"
         echo "  --no-tailscale                 skip Tailscale even if installed"
         return 0 ;;
@@ -217,6 +219,8 @@ cmd_connect() {
         # is explicitly asking for the sidecar, override session env.
         # Symmetric inverse of --no-general.
         _force_general_sidecar=1; shift ;;
+      --takeover|-takeover)
+        allow_takeover=1; shift ;;
       --room-only|-room-only)
         # Combo: explicit project room + skip general sidecar. For
         # focused work where lobby noise would distract.
@@ -894,30 +898,26 @@ cmd_connect() {
   if [ -n "$target" ] && echo "$target" | grep -q '@'; then
     # ── JOIN MODE ──────────────────────────────────────────────────
 
-    # Stale-heartbeat fast-path takeover. If the gist we resolved had a
-    # last_heartbeat older than AIRC_HEARTBEAT_STALE (parsed above), the
-    # host is dead. Skip the SSH attempt entirely — no minute-long TCP
-    # timeout, no peer wondering "is this thing on" — go straight to
-    # take-over. Same operations as the SSH-failure self-heal at the
-    # bottom of JOIN MODE (delete stale gist, re-exec as host with
-    # AIRC_NO_DISCOVERY=1) but triggered from positive evidence (stale
-    # presence signal) rather than negative evidence (TCP timeout).
+    # Stale-heartbeat fast-path. Stale presence is evidence that the host
+    # may be gone, but it is not authority to mutate the shared mesh.
+    # Default join is read-only: preserve the existing gist and fail
+    # loudly. Operators must pass --takeover (or AIRC_ALLOW_TAKEOVER=1)
+    # to intentionally replace a stale host.
     #
     # Backward compat: pre-heartbeat gists have no last_heartbeat field,
     # _resolved_heartbeat_stale stays 0, this block is a no-op, and the
     # SSH-failure self-heal still catches the dead host (slower, but
     # correct).
     if [ "$_resolved_heartbeat_stale" = "1" ] && [ -n "$resolved_room_name" ] \
-       && [ -n "$_resolved_gist_id" ] && command -v gh >/dev/null 2>&1; then
+       && [ -n "$_resolved_gist_id" ]; then
       echo ""
-      echo "  ⚠  Host of #${resolved_room_name} is stale (last heartbeat ${_resolved_heartbeat_age}s ago) — taking over..."
+      echo "  ⚠  Host of #${resolved_room_name} is stale (last heartbeat ${_resolved_heartbeat_age}s ago)."
       echo "     (prior host's gist: $_resolved_gist_id)"
-
-      # Same race-loser detection as the SSH-failure self-heal path
-      # below. Two tabs concurrently deciding "host is stale" both
-      # delete + publish, end up with split-brain — caught only by
-      # running two tabs together.
-      _self_heal_stale_host "$_resolved_gist_id"
+      if [ "$allow_takeover" = "1" ] && command -v gh >/dev/null 2>&1; then
+        echo "     --takeover requested — replacing stale host explicitly."
+        _self_heal_stale_host "$_resolved_gist_id"
+      fi
+      die "Refusing automatic takeover of #${resolved_room_name}; existing mesh preserved. Re-run with --takeover only if you intentionally want to replace that host."
     fi
 
     # Parse name@user@host[:port]#pubkey
@@ -1110,52 +1110,19 @@ except Exception:
                   --my-identity-json "$my_identity_json" 2>&1) || _pair_ok=0
 
     if [ "$_pair_ok" = "0" ]; then
-      # ── Self-heal: stale-host takeover ─────────────────────────────
-      # If discovery handed us a kind:room gist AND the host listed in it
-      # is unreachable, the most likely cause is the prior host went away
-      # (laptop sleep, crash, network blip). Per Joel: "no claude left
-      # behind" — first agent back in becomes the new host of #general.
-      #
-      # Mechanics:
-      #   1. Delete the stale gist (we have gh perms because it's on our
-      #      own gh account, same auth as the discovery that found it).
-      #   2. Tear down the half-written CONFIG that pointed at the dead
-      #      host (else resume on next start would loop into the same
-      #      stale pair).
-      #   3. exec into a fresh airc connect in HOST mode for the same
-      #      room name. AIRC_NO_DISCOVERY=1 so we don't re-find the gist
-      #      we just deleted (gh propagation lag).
-      #
-      # Only fires when ALL FOUR are true:
-      #   - We resolved a kind:room gist (resolved_room_name + _resolved_gist_id non-empty)
-      #   - gh CLI is available (to delete the stale gist)
-      #   - Pair handshake failed (TCP unreachable / timeout)
-      #   - Address picker either succeeded ("picked") OR host published
-      #     no addresses[] at all ("no_addrs"). If picker ran but found
-      #     no reachable scope ("no_match"), the failure is THIS peer's
-      #     network mismatch — not host-down. Nuking the gist would
-      #     destroy reachability for other peers who CAN reach the host.
-      #     Bug observed live 2026-05-02: a Mac without tailscale joined
-      #     a Windows host whose only non-localhost entry was tailscale,
-      #     fell through to the invite-string ssh_target, TCP timed out,
-      #     self-heal nuked the gist that 4 other peers were happily
-      #     using. The address-picker reachability check (#397) prevents
-      #     the most common shape of this; this guard catches the
-      #     remaining "invite-string fallback after no_match" path.
-      # If any condition isn't met, fall through to the original die().
+      # Pair failure is read-only by default. An unreachable host is not
+      # proof the shared mesh should be deleted: this peer may lack the
+      # right network path, the host may be reachable to others, or the
+      # failure may be transient. Automatic takeover is the split-brain
+      # bug. Preserve the existing gist and fail loudly unless the
+      # operator explicitly requested --takeover.
       if [ -n "$resolved_room_name" ] && [ -n "$_resolved_gist_id" ] \
          && command -v gh >/dev/null 2>&1 \
-         && [ "$_addr_picker_state" != "no_match" ]; then
+         && [ "$_addr_picker_state" != "no_match" ] \
+         && [ "$allow_takeover" = "1" ]; then
         echo ""
-        echo "  ⚠  Host of #${resolved_room_name} unreachable — self-healing as new host..."
+        echo "  ⚠  Host of #${resolved_room_name} unreachable — --takeover requested, replacing host..."
         echo "     (prior host's gist: $_resolved_gist_id)"
-
-        # Jittered backoff before takeover. Without this, two tabs that
-        # hit the same dead gist concurrently both delete + publish
-        # within the same gh API window and you end up with two
-        # competing gists for the same room name (split-brain race —
-        # caught only by running two tabs against a stale gist
-        # simultaneously, NOT by the integration test).
         _self_heal_stale_host "$_resolved_gist_id"
       elif [ "$_addr_picker_state" = "no_match" ]; then
         # Picker found no scope this peer can reach. Surface the situation
@@ -1169,6 +1136,12 @@ except Exception:
         echo "  ⚠  Host of #${resolved_room_name} published no scope this peer can reach." >&2
         echo "     Skipping self-heal (gist preserved for peers who CAN reach the host)." >&2
         echo "     Direct pair unavailable; gh-bearer broadcasts still work via gist." >&2
+        echo "" >&2
+      elif [ -n "$resolved_room_name" ] && [ -n "$_resolved_gist_id" ]; then
+        echo "" >&2
+        echo "  ⚠  Host of #${resolved_room_name} unreachable; existing mesh preserved." >&2
+        echo "     Not creating a solo replacement mesh. Re-run with --takeover only if" >&2
+        echo "     you intentionally want to replace the current host gist: $_resolved_gist_id" >&2
         echo "" >&2
       fi
       # Either not a room flow, or no gh, or no resolved_room_name → original die.
@@ -1459,7 +1432,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
           # early mesh-find gate at line ~568.
           if [ "${AIRC_NO_DISCOVERY:-0}" != "1" ]; then
             _existing_room_gid=$("$AIRC_PYTHON" -m airc_core.channel_gist resolve \
-                                 --channel "$room_name" 2>/dev/null || true)
+                                 --channel "$room_name" --require-invite 2>/dev/null || true)
           fi
         fi
         if [ -n "$_existing_room_gid" ]; then

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -543,9 +543,9 @@ _doctor_health() {
     peer_count=$(find "$PEERS_DIR" -maxdepth 1 -name '*.json' -type f 2>/dev/null | wc -l | tr -d ' ')
   fi
   if [ "${peer_count:-0}" -eq 0 ] 2>/dev/null; then
-    printf "  [WARN] collaboration mesh has 0 peer records — local transport may be healthy but nobody is known to be connected\n"
+    printf "  [BLOCKED] collaboration mesh has 0 peer records — local transport may be alive, but this is a solo island\n"
     printf "         Check: airc peers; ask peers to run 'airc update --channel canary && airc connect <current invite>'\n"
-    warns=$((warns+1))
+    issues=$((issues+1))
   else
     printf "  [ok] collaboration mesh has %s peer record(s)\n" "$peer_count"
   fi

--- a/lib/airc_bash/mesh.sh
+++ b/lib/airc_bash/mesh.sh
@@ -54,7 +54,7 @@ _mesh_find() {
     channel=$("$AIRC_PYTHON" -m airc_core.config default_channel --config "$CONFIG" 2>/dev/null || true)
   fi
   [ -z "$channel" ] && channel="general"
-  "$AIRC_PYTHON" -m airc_core.channel_gist find --channel "$channel" 2>/dev/null || true
+  "$AIRC_PYTHON" -m airc_core.channel_gist find --channel "$channel" --require-invite 2>/dev/null || true
 }
 
 # Publish a new mesh gist. Echoes the new gist id, or empty on failure.

--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -96,7 +96,7 @@ def _gh_list_user_gists() -> list[dict]:
     return out
 
 
-def _gist_describes_channel(gist: dict, channel: str) -> bool:
+def _gist_describes_channel(gist: dict, channel: str, require_invite: bool = False) -> bool:
     """Decide whether a gist envelope is THIS channel's room gist.
 
     A gist is the channel's room iff:
@@ -132,6 +132,8 @@ def _gist_describes_channel(gist: dict, channel: str) -> bool:
                 continue
             if not isinstance(env, dict):
                 continue
+            if require_invite and not env.get("invite"):
+                continue
             channels = env.get("channels")
             if isinstance(channels, list) and channel in channels:
                 return True
@@ -160,7 +162,7 @@ def _gh_api_get_gist(gist_id: str) -> Optional[dict]:
         return None
 
 
-def _is_single_channel_match(gist: dict, channel: str) -> bool:
+def _is_single_channel_match(gist: dict, channel: str, require_invite: bool = False) -> bool:
     """A gist is the canonical post-3c per-channel gist for `channel`
     iff its envelope has channels=[<exactly channel>]. Single-element
     list, exact match. The post-3c shape created by create_new()."""
@@ -175,13 +177,15 @@ def _is_single_channel_match(gist: dict, channel: str) -> bool:
             continue
         if not isinstance(env, dict):
             continue
+        if require_invite and not env.get("invite"):
+            continue
         channels = env.get("channels")
         if isinstance(channels, list) and len(channels) == 1 and channels[0] == channel:
             return True
     return False
 
 
-def find_existing(channel: str) -> Optional[str]:
+def find_existing(channel: str, require_invite: bool = False) -> Optional[str]:
     """Look for an existing gist on this gh account hosting `channel`.
     Returns the gist id, or None if no match.
 
@@ -226,7 +230,7 @@ def find_existing(channel: str) -> Optional[str]:
         return matches[0].get("id")
 
     # Pass 1: canonical single-channel match (cheap, listing-response).
-    canonical_matches = [g for g in candidates if _is_single_channel_match(g, channel)]
+    canonical_matches = [g for g in candidates if _is_single_channel_match(g, channel, require_invite=require_invite)]
     chosen = _oldest(canonical_matches)
     if chosen:
         return chosen
@@ -241,7 +245,7 @@ def find_existing(channel: str) -> Optional[str]:
         full = _gh_api_get_gist(gid)
         if full is None:
             continue
-        if _is_single_channel_match(full, channel):
+        if _is_single_channel_match(full, channel, require_invite=require_invite):
             # Carry created_at from the listing so _oldest can sort.
             full.setdefault("created_at", g.get("created_at", ""))
             deep_canonical.append(full)
@@ -250,7 +254,7 @@ def find_existing(channel: str) -> Optional[str]:
         return chosen
 
     # Pass 2: legacy multi-channel fallback. Only if no canonical exists.
-    legacy_matches = [g for g in candidates if _gist_describes_channel(g, channel)]
+    legacy_matches = [g for g in candidates if _gist_describes_channel(g, channel, require_invite=require_invite)]
     chosen = _oldest(legacy_matches)
     if chosen:
         return chosen
@@ -263,7 +267,7 @@ def find_existing(channel: str) -> Optional[str]:
         full = _gh_api_get_gist(gid)
         if full is None:
             continue
-        if _gist_describes_channel(full, channel):
+        if _gist_describes_channel(full, channel, require_invite=require_invite):
             full.setdefault("created_at", g.get("created_at", ""))
             deep_legacy.append(full)
     return _oldest(deep_legacy)
@@ -318,7 +322,7 @@ def create_new(channel: str) -> Optional[str]:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
-def resolve(channel: str, create_if_missing: bool = False) -> Optional[str]:
+def resolve(channel: str, create_if_missing: bool = False, require_invite: bool = False) -> Optional[str]:
     """Resolve a channel name to its gist id on this gh account.
 
     Returns the gist id on success (existing or newly-created), None
@@ -345,12 +349,12 @@ def resolve(channel: str, create_if_missing: bool = False) -> Optional[str]:
     no_retry = _os.environ.get("AIRC_RESOLVE_NO_RETRY") == "1"
     attempts = 1 if no_retry else 3
     for attempt in range(attempts):
-        existing = find_existing(channel)
+        existing = find_existing(channel, require_invite=require_invite)
         if existing:
             return existing
         if attempt < attempts - 1:
             _t.sleep(1.5 * (attempt + 1))  # 1.5s, then 3s
-    if create_if_missing:
+    if create_if_missing and not require_invite:
         return create_new(channel)
     return None
 
@@ -365,20 +369,22 @@ def _cli() -> int:
     r = sub.add_parser("resolve", help="Print gist id for a channel; empty stdout if absent")
     r.add_argument("--channel", required=True)
     r.add_argument("--create-if-missing", action="store_true")
+    r.add_argument("--require-invite", action="store_true")
 
     f = sub.add_parser("find", help="Find existing only (no create)")
     f.add_argument("--channel", required=True)
+    f.add_argument("--require-invite", action="store_true")
 
     args = parser.parse_args()
 
     if args.cmd == "resolve":
-        gid = resolve(args.channel, create_if_missing=args.create_if_missing)
+        gid = resolve(args.channel, create_if_missing=args.create_if_missing, require_invite=args.require_invite)
         if gid:
             print(gid)
             return 0
         return 1
     if args.cmd == "find":
-        gid = find_existing(args.channel)
+        gid = find_existing(args.channel, require_invite=args.require_invite)
         if gid:
             print(gid)
             return 0

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -1644,7 +1644,7 @@ scenario_heartbeat() {
   mkdir -p /tmp/airc-it-j
   ( cd /tmp/airc-it-j && AIRC_HOME=/tmp/airc-it-j/state AIRC_NAME=beta AIRC_PORT=7550 \
       AIRC_HEARTBEAT_STALE=$hb_stale AIRC_HEARTBEAT_SEC=$hb_sec \
-      "$AIRC" connect --room "$rname" > /tmp/airc-it-j/out.log 2>&1 & )
+      "$AIRC" connect --room "$rname" --takeover > /tmp/airc-it-j/out.log 2>&1 & )
 
   for i in 1 2 3 4 5 6 7 8 9 10; do
     sleep 1
@@ -2035,8 +2035,8 @@ JSON
   echo "$doctor_out" | grep -q 'collaboration mesh has 0 peer records' \
     && pass "doctor --health warns about zero-peer collaboration mesh" \
     || fail "doctor --health did not warn about zero peers ($doctor_out)"
-  echo "$doctor_out" | grep -q 'Bus working, .*warning' \
-    && pass "doctor summary is warning, not clean healthy" \
+  echo "$doctor_out" | grep -q 'Bus DEGRADED' \
+    && pass "doctor summary is degraded, not clean healthy" \
     || fail "doctor summary still looked clean ($doctor_out)"
 
   rm -rf /tmp/airc-it-solo

--- a/test/test_channel_gist.py
+++ b/test/test_channel_gist.py
@@ -6,6 +6,7 @@ Run: cd test && python3 test_channel_gist.py
 from __future__ import annotations
 
 import sys
+import json
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -89,6 +90,20 @@ class FindExistingConvergenceTests(unittest.TestCase):
     def test_returns_none_when_no_match(self):
         with mock.patch.object(channel_gist, "_gh_list_user_gists", return_value=[]):
             self.assertIsNone(channel_gist.find_existing("nonexistent"))
+
+    def test_require_invite_skips_seed_only_channel_gist(self):
+        """Connect discovery needs a host envelope, not just a routing
+        seed. Seed-only channel gists are valid for cmd_send routing but
+        cannot be joined because they have no invite/host data."""
+        seed_only = self._gist("seed-only", "cambriantech", "2026-05-04T17:27:38Z")
+        host = self._gist("host", "cambriantech", "2026-05-04T17:28:38Z")
+        env = json.loads(host["files"]["airc-room-cambriantech.json"]["content"])
+        env["invite"] = "host@example"
+        host["files"]["airc-room-cambriantech.json"]["content"] = json.dumps(env)
+        with mock.patch.object(channel_gist, "_gh_list_user_gists",
+                               return_value=[seed_only, host]):
+            self.assertEqual(channel_gist.find_existing("cambriantech"), "seed-only")
+            self.assertEqual(channel_gist.find_existing("cambriantech", require_invite=True), "host")
 
     def test_returns_oldest_legacy_when_no_canonical(self):
         """If only legacy mesh gists exist (none canonical), still


### PR DESCRIPTION
## Summary
- add `--require-invite` mode to channel gist discovery for connect paths
- keep send/subscribe routing able to use seed-only channel gists
- require connect discovery and mesh-find to skip gists that cannot produce an invite/host
- stop automatic stale/unreachable-host takeover by default; failed joins now preserve the existing gist and fail loudly instead of creating a solo mesh
- make `doctor --health` report zero-peer solo meshes as BLOCKED/DEGRADED, not "Bus working"

## Why
This Codex scope failed to rejoin because discovery selected a seed-only channel gist (`airc room: #cambriantech`) that had no `invite`. After bypassing that, live testing exposed the worse split-brain behavior: when the discovered host was unreachable, AIRC deleted the existing shared gist and rehosted a solo island. That is not self-heal; it is destructive split-brain.

The new rule: join failures are read-only by default. Takeover is explicit via `--takeover` / `AIRC_ALLOW_TAKEOVER=1`.

## Tests
- `bash test/integration.sh solo_mesh_warns`
- `python3 test/test_channel_gist.py`
- `bash -n airc lib/airc_bash/cmd_connect.sh lib/airc_bash/cmd_doctor.sh lib/airc_bash/mesh.sh test/integration.sh`
- `git diff --check`
