### PR TITLE
fix(connect): recover stale hosts in-place

### DIFF
--- a/airc
+++ b/airc
@@ -395,9 +395,9 @@ _reexec_into() {
 }
 
 # Stale-host self-heal + race-loser detection. Args: $1=stale gist id.
-# Random jitter, delete stale, re-list to see if another tab self-healed
-# first; if yes rejoin theirs, else take over as host. Always exec's via
-# _reexec_into; does not return.
+# Random jitter, re-list to see if another tab self-healed first; if yes
+# rejoin theirs, else take over the same gist in-place as host. Always
+# exec's via _reexec_into; does not return.
 #
 # User intent preservation across re-exec: pre-2026-04-29 this wiped
 # room_name + reexec'd with NO ARGS, which silently dropped the user's
@@ -410,11 +410,6 @@ _self_heal_stale_host() {
   local stale_id="$1"
   local jitter; jitter=$(awk -v r="$RANDOM" 'BEGIN{printf "%.3f", 0.1 + (r%1500)/1000}')
   sleep "$jitter"
-  if gh gist delete "$stale_id" --yes 2>/dev/null; then
-    echo "  ✓ Stale mesh gist removed."
-  else
-    echo "  ⚠  Stale mesh gist already gone — another tab may have taken over first."
-  fi
   # Capture the user's --room intent BEFORE wiping room_name. Caller
   # sets ROOM_INTENT_FOR_REEXEC in the cmd_connect frame whenever the
   # explicit --room flag was used; anywhere else it's empty and we
@@ -435,7 +430,8 @@ _self_heal_stale_host() {
     echo ""
     _reexec_into rejoin "$picked"
   fi
-  echo "  Re-execing into host mode (mesh singleton for this gh account)..."
+  export AIRC_ADOPT_GIST="$stale_id"
+  echo "  Re-execing into host mode on the existing mesh gist..."
   echo ""
   _reexec_into host
 }
@@ -1478,13 +1474,16 @@ _monitor_multi_channel() {
     fi
     if [ "$consecutive_timeouts" -ge "$ESCALATE_AFTER" ]; then
       local _daemon_present=0
-      if _daemon_installed >/dev/null 2>&1; then _daemon_present=1; fi
+      if command -v airc_daemon_is_running_for_scope >/dev/null 2>&1 \
+         && airc_daemon_is_running_for_scope "$AIRC_WRITE_DIR" 2>/dev/null; then
+        _daemon_present=1
+      fi
       echo ""
       if [ "$_daemon_present" = "1" ]; then
         echo "airc: mesh disconnected ($consecutive_timeouts cycles); daemon restart will self-heal"
       else
-        echo "airc: mesh disconnected ($consecutive_timeouts cycles); NO DAEMON installed, restart with: airc join"
-        echo "airc:   (for auto-recovery: airc daemon install)"
+        echo "airc: mesh disconnected ($consecutive_timeouts cycles); NO DAEMON running, restart with: airc join"
+        echo "airc:   (for auto-recovery: airc daemon restart || airc daemon install)"
       fi
       exit 99
     fi
@@ -1599,15 +1598,18 @@ monitor() {
         local saved_room=""
         [ -f "$AIRC_WRITE_DIR/room_name" ] && saved_room=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null)
         local _daemon_present=0
-        if _daemon_installed >/dev/null 2>&1; then _daemon_present=1; fi
+        if command -v airc_daemon_is_running_for_scope >/dev/null 2>&1 \
+           && airc_daemon_is_running_for_scope "$AIRC_WRITE_DIR" 2>/dev/null; then
+          _daemon_present=1
+        fi
         echo ""
         if [ "$_daemon_present" = "1" ]; then
           echo "airc: mesh disconnected — #${saved_room:-?} dead $consecutive_timeouts cycles; daemon restart will self-heal"
           echo "  ⚠  Exiting airc connect — daemon restart will trigger self-heal" >&2
         else
-          echo "airc: mesh disconnected — #${saved_room:-?} dead $consecutive_timeouts cycles; NO DAEMON installed, restart with: airc join"
-          echo "airc:   (for auto-recovery: airc daemon install)"
-          echo "  ⚠  Exiting airc connect — NO DAEMON installed; rerun 'airc join' to reconnect" >&2
+          echo "airc: mesh disconnected — #${saved_room:-?} dead $consecutive_timeouts cycles; NO DAEMON running, restart with: airc join"
+          echo "airc:   (for auto-recovery: airc daemon restart || airc daemon install)"
+          echo "  ⚠  Exiting airc connect — NO DAEMON running; rerun 'airc join' to reconnect" >&2
         fi
         exit 99
       fi
@@ -2084,8 +2086,9 @@ except Exception:
   done
 }
 
-# Self-heal loop: detect host gist rotation and swap channel_gists in
-# config without human-in-the-loop teardown+rejoin. Joel 2026-05-02:
+# Self-heal loop: detect host gist rotation OR stale host lease and swap
+# channel_gists / restart into recovery without human-in-the-loop
+# teardown+rejoin. Joel 2026-05-02:
 # "you have the easy part, must self-heal, no one can be there to fix
 # your umbilical cord for you." Tonight's repro: host (Mac) tore down
 # + rejoined → new mesh gist on the same gh account; joiner (b69f) kept
@@ -2134,6 +2137,22 @@ $("$AIRC_PYTHON" -m airc_core.config list_channel_gists \
       | awk -F'\t' 'NR==1 {print $1, $2}')
 EOF
     [ -n "$current_gist" ] || continue
+    # Same-gist host lease check. Rotation is not the only failure
+    # mode: if the hosting laptop sleeps/shuts down, the durable room
+    # gist is still the correct channel identity, but its host envelope
+    # is stale. Treat that as a restart-worthy condition so the next
+    # connect pass adopts this exact gist in-place and publishes a fresh
+    # lease. This runs continuously, not only at join time.
+    local hb_age hb_stale
+    hb_age=$(_mesh_gist_heartbeat_age "$current_gist" 2>/dev/null || true)
+    hb_stale="${AIRC_HEARTBEAT_STALE:-90}"
+    if [ -n "$hb_age" ] && [ "$hb_age" -gt "$hb_stale" ] 2>/dev/null; then
+      printf '[%s] airc: HOST LEASE STALE for #%s on gist %s (%ss > %ss). Restarting monitor so this peer can recover the same gist in-place.\n' \
+        "$(timestamp)" "$current_ch" "$current_gist" "$hb_age" "$hb_stale"
+      printf 'host lease stale for #%s on gist %s\n' "$current_ch" "$current_gist" > "$AIRC_WRITE_DIR/airc.restart-request" 2>/dev/null || true
+      kill -TERM "$_parent_pid" 2>/dev/null || true
+      return 99
+    fi
     local found_gist
     found_gist=$(_mesh_find "$current_ch" 2>/dev/null || true)
     [ -n "$found_gist" ] || continue

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -140,7 +140,6 @@ cmd_connect() {
   fi
   local general_sidecar=1   # default ON (issue #121) — also subscribe to #general
   local _force_general_sidecar=0   # set by --general flag (issue #136 re-opt-in)
-  local allow_takeover="${AIRC_ALLOW_TAKEOVER:-0}"
   # Recursion guard: when WE are the sidecar (spawned by another airc
   # connect), don't spawn our own sidecar. Otherwise: turtles all the way.
   [ "${AIRC_GENERAL_SIDECAR:-0}" = "1" ] && general_sidecar=0
@@ -155,9 +154,8 @@ cmd_connect() {
   local resolved_room_name=""
   # _resolved_gist_id is captured by the gist resolver when discovery resolves
   # a kind:"room" gist. Used by JOIN MODE's self-heal path: if the pair
-  # handshake fails because the host listed in the room gist is unreachable
-  # (sleep/crash/network), the joiner deletes the stale gist and re-execs
-  # itself in host mode — first-agent-back-in becomes the new host.
+  # handshake fails because the host listed in the room gist is unreachable,
+  # the joiner rewrites that same durable gist in host mode.
   local _resolved_gist_id=""
   # Heartbeat freshness vars - parsed by gist resolver in the room
   # case-arm. Must be defaulted here so the JOIN MODE early-takeover
@@ -188,7 +186,6 @@ cmd_connect() {
         echo "  --no-room                      disable substrate entirely (legacy 1:1 invite)"
         echo "  --no-general                   keep project room, skip #general subscription"
         echo "  --general                      re-opt-in to #general after a prior /part"
-        echo "  --takeover                     explicitly replace an unreachable/stale host"
         echo "  --no-gist                      don't publish/discover via gh gist (test mode)"
         echo "  --no-tailscale                 skip Tailscale even if installed"
         return 0 ;;
@@ -220,7 +217,8 @@ cmd_connect() {
         # Symmetric inverse of --no-general.
         _force_general_sidecar=1; shift ;;
       --takeover|-takeover)
-        allow_takeover=1; shift ;;
+        echo "  note: --takeover is no longer needed; stale hosts are recovered in-place." >&2
+        shift ;;
       --room-only|-room-only)
         # Combo: explicit project room + skip general sidecar. For
         # focused work where lobby noise would distract.
@@ -239,6 +237,11 @@ cmd_connect() {
     esac
   done
   set -- "${positional[@]+"${positional[@]}"}"
+
+  # One-shot marker used by child watchdogs to tell the parent "exit
+  # with restart semantics", not "fatal crash". Clear stale markers
+  # before this connect attempt starts.
+  rm -f "$AIRC_WRITE_DIR/airc.restart-request" 2>/dev/null || true
 
   # Trust-existing-monitor short-circuit (#369, sandbox-aware via
   # _monitor_alive_with_bearer_fallback per #372). If a live airc
@@ -694,8 +697,8 @@ cmd_connect() {
   if [ -n "$target" ] && ! echo "$target" | grep -q '@'; then
     local gist_id="${target#gist:}"
     # Capture for self-heal in JOIN MODE: if the host in this gist turns
-    # out to be unreachable, JOIN MODE deletes the gist by this id + takes
-    # over as the new host of the same room.
+    # out to be unreachable, JOIN MODE takes over this same gist as the
+    # new host of the same room.
     _resolved_gist_id="$gist_id"
     # Gist IDs are hex strings, typically 20-32 chars but accept any
     # plausible length so future GH ID schemes don't break us.
@@ -898,11 +901,10 @@ cmd_connect() {
   if [ -n "$target" ] && echo "$target" | grep -q '@'; then
     # ── JOIN MODE ──────────────────────────────────────────────────
 
-    # Stale-heartbeat fast-path. Stale presence is evidence that the host
-    # may be gone, but it is not authority to mutate the shared mesh.
-    # Default join is read-only: preserve the existing gist and fail
-    # loudly. Operators must pass --takeover (or AIRC_ALLOW_TAKEOVER=1)
-    # to intentionally replace a stale host.
+    # Stale-heartbeat fast-path. The gist is the durable room; the host is
+    # replaceable. If the host is stale, take over the SAME gist in place
+    # so every peer polling that room converges instead of getting a new
+    # solo island.
     #
     # Backward compat: pre-heartbeat gists have no last_heartbeat field,
     # _resolved_heartbeat_stale stays 0, this block is a no-op, and the
@@ -911,13 +913,9 @@ cmd_connect() {
     if [ "$_resolved_heartbeat_stale" = "1" ] && [ -n "$resolved_room_name" ] \
        && [ -n "$_resolved_gist_id" ]; then
       echo ""
-      echo "  ⚠  Host of #${resolved_room_name} is stale (last heartbeat ${_resolved_heartbeat_age}s ago)."
+      echo "  ⚠  Host of #${resolved_room_name} is stale (last heartbeat ${_resolved_heartbeat_age}s ago) — taking over existing mesh..."
       echo "     (prior host's gist: $_resolved_gist_id)"
-      if [ "$allow_takeover" = "1" ] && command -v gh >/dev/null 2>&1; then
-        echo "     --takeover requested — replacing stale host explicitly."
-        _self_heal_stale_host "$_resolved_gist_id"
-      fi
-      die "Refusing automatic takeover of #${resolved_room_name}; existing mesh preserved. Re-run with --takeover only if you intentionally want to replace that host."
+      _self_heal_stale_host "$_resolved_gist_id"
     fi
 
     # Parse name@user@host[:port]#pubkey
@@ -1110,18 +1108,15 @@ except Exception:
                   --my-identity-json "$my_identity_json" 2>&1) || _pair_ok=0
 
     if [ "$_pair_ok" = "0" ]; then
-      # Pair failure is read-only by default. An unreachable host is not
-      # proof the shared mesh should be deleted: this peer may lack the
-      # right network path, the host may be reachable to others, or the
-      # failure may be transient. Automatic takeover is the split-brain
-      # bug. Preserve the existing gist and fail loudly unless the
-      # operator explicitly requested --takeover.
+      # Pair failure recovers by taking over the SAME gist in place.
+      # Deleting the old gist and publishing a new one split-brained the
+      # bus; preserving and rewriting the durable room gist makes all
+      # pollers converge.
       if [ -n "$resolved_room_name" ] && [ -n "$_resolved_gist_id" ] \
          && command -v gh >/dev/null 2>&1 \
-         && [ "$_addr_picker_state" != "no_match" ] \
-         && [ "$allow_takeover" = "1" ]; then
+         && [ "$_addr_picker_state" != "no_match" ]; then
         echo ""
-        echo "  ⚠  Host of #${resolved_room_name} unreachable — --takeover requested, replacing host..."
+        echo "  ⚠  Host of #${resolved_room_name} unreachable — taking over existing mesh..."
         echo "     (prior host's gist: $_resolved_gist_id)"
         _self_heal_stale_host "$_resolved_gist_id"
       elif [ "$_addr_picker_state" = "no_match" ]; then
@@ -1136,12 +1131,6 @@ except Exception:
         echo "  ⚠  Host of #${resolved_room_name} published no scope this peer can reach." >&2
         echo "     Skipping self-heal (gist preserved for peers who CAN reach the host)." >&2
         echo "     Direct pair unavailable; gh-bearer broadcasts still work via gist." >&2
-        echo "" >&2
-      elif [ -n "$resolved_room_name" ] && [ -n "$_resolved_gist_id" ]; then
-        echo "" >&2
-        echo "  ⚠  Host of #${resolved_room_name} unreachable; existing mesh preserved." >&2
-        echo "     Not creating a solo replacement mesh. Re-run with --takeover only if" >&2
-        echo "     you intentionally want to replace the current host gist: $_resolved_gist_id" >&2
         echo "" >&2
       fi
       # Either not a room flow, or no gh, or no resolved_room_name → original die.
@@ -1225,8 +1214,8 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
 
     # If we resolved this pair via gist discovery (vs. inline-invite),
     # persist the gist id so resume-time freshness checks can detect a
-    # gist-deletion / replacement before re-pairing against a stale host
-    # (issue #83). Cleared by cmd_part on graceful leave.
+    # host-lease refresh or gist rotation before re-pairing against a
+    # stale host (issue #83). Cleared by cmd_part on graceful leave.
     if [ -n "$_resolved_gist_id" ]; then
       echo "$_resolved_gist_id" > "$AIRC_WRITE_DIR/room_gist_id"
       # #283: also map this channel→gist in channel_gists so the
@@ -1376,7 +1365,11 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
       # so cmd_send + future config-driven consumers see it.
       "$AIRC_PYTHON" -m airc_core.config subscribe \
         --config "$CONFIG" --channel "$room_name" --first 2>/dev/null || true
-      echo "  Hosting #${room_name} — no existing room on your gh account, fresh start."
+      if [ -n "${AIRC_ADOPT_GIST:-}" ]; then
+        echo "  Hosting #${room_name} — recovering existing room gist ${AIRC_ADOPT_GIST}."
+      else
+        echo "  Hosting #${room_name} — creating or adopting the canonical room gist."
+      fi
       echo "  Other agents on your gh account who run 'airc join' will auto-join."
     fi
 
@@ -1410,7 +1403,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
         # the same account: every --as-host bootstrap created its own
         # gist regardless of what was already there. With find-first,
         # all hosts on the gh account converge on the oldest canonical.
-        local _existing_room_gid=""
+        local _existing_room_gid="${AIRC_ADOPT_GIST:-}"
         if [ "$use_room" = "1" ]; then
           # Use full retry so gh's gist-listing eventual consistency
           # (a just-created gist may not appear in `gh gist list` for
@@ -1430,9 +1423,9 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
           # would block on it. When AIRC_NO_DISCOVERY=1, skip the
           # resolve and go straight to create_new — same as the
           # early mesh-find gate at line ~568.
-          if [ "${AIRC_NO_DISCOVERY:-0}" != "1" ]; then
+          if [ -z "$_existing_room_gid" ] && [ "${AIRC_NO_DISCOVERY:-0}" != "1" ]; then
             _existing_room_gid=$("$AIRC_PYTHON" -m airc_core.channel_gist resolve \
-                                 --channel "$room_name" --require-invite 2>/dev/null || true)
+                                 --channel "$room_name" 2>/dev/null || true)
           fi
         fi
         if [ -n "$_existing_room_gid" ]; then
@@ -1447,21 +1440,9 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
           echo "$room_name" > "$AIRC_WRITE_DIR/room_name"
           "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
             --config "$CONFIG" --channel "$room_name" --gist-id "$_gist_id" 2>/dev/null || true
-          # Skip the new-gist creation block below since we have one.
-          # Continue to the heartbeat + monitor setup as if we'd just
-          # created it — the gist exists, we own/share it, write to it.
           : >"$AIRC_WRITE_DIR/.using_existing_room_gist"
         fi
 
-        # Skip create-new entirely if we already adopted an existing
-        # canonical gist above (find-first convergence path). Still
-        # need to set the variables downstream heartbeat setup uses
-        # — _now (timestamp) and _machine_id — since the create-new
-        # block populates them and we're skipping it.
-        if [ -n "${_existing_room_gid:-}" ]; then
-          local _now; _now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          local _machine_id; _machine_id=$(host_machine_id)
-        else
         # Bootstrap basename + description match channel_gist.create_new's
         # canonical shape (airc-room-<channel>.json + "airc room: #X").
         # Pre-fix the host path used a random mktemp basename
@@ -1553,9 +1534,16 @@ JSON
         # ID itself is the secret. Same threat model as the long invite:
         # whoever holds the string can pair. Room gists persist; invite
         # gists should be deleted by the host after the first joiner.
-        local _gist_url; _gist_url=$(gh gist create -d "$_gist_desc" "$_gist_tmp" 2>/dev/null | tail -1)
+        local _gist_url=""
+        if [ -n "${_existing_room_gid:-}" ] && [ "$use_room" = "1" ]; then
+          if gh gist edit "$_existing_room_gid" "$_gist_tmp" >/dev/null 2>/dev/null \
+             || gh gist edit "$_existing_room_gid" -a "$_gist_tmp" >/dev/null 2>/dev/null; then
+            _gist_url="https://gist.github.com/$_existing_room_gid"
+          fi
+        else
+          _gist_url=$(gh gist create -d "$_gist_desc" "$_gist_tmp" 2>/dev/null | tail -1)
+        fi
         rm -rf "$_gist_tmpdir"
-        fi  # close: skip create-new when adopted existing canonical
         if [ -n "$_gist_url" ]; then
           local _gist_id="${_gist_url##*/}"
           local _hh; _hh=$(humanhash "$_gist_id" 2>/dev/null)
@@ -1582,10 +1570,10 @@ JSON
             #
             # Loop runs every AIRC_HEARTBEAT_SEC (default 30s) and dies
             # automatically when its parent (the host airc connect bash)
-            # exits — so kill -9 on the host stops heartbeats within one
+            # exits, so kill -9 on the host stops heartbeats within one
             # interval. Joiners treat last_heartbeat older than
             # AIRC_HEARTBEAT_STALE (default 90s = 3 missed beats) as
-            # stale and self-heal as new host.
+            # stale and self-heal in-place as the new host.
             local _heartbeat_sec="${AIRC_HEARTBEAT_SEC:-30}"
             local _hb_parent_pid=$$
             local _hb_invite="$_invite_long"
@@ -1601,8 +1589,8 @@ JSON
             local _hb_state_dir="$AIRC_WRITE_DIR"
             (
               # Detach from job control so a parent SIGINT kills the
-              # whole tree but normal exit lets us race the trap to
-              # delete the gist first.
+              # whole tree. The room gist itself is durable and is not
+              # deleted by normal host exit.
               local _consec_fail=0
               local _max_consec_fail="${AIRC_HB_MAX_FAIL:-3}"
               while sleep "$_heartbeat_sec"; do
@@ -1744,6 +1732,7 @@ JSON
                     # Drop the stale local-state files so the parent's
                     # next discovery re-elects via _mesh_find.
                     rm -f "$_hb_state_dir/host_gist_id" "$_hb_state_dir/room_gist_id" 2>/dev/null
+                    printf 'heartbeat failure: %s\n' "$_classified" > "$_hb_state_dir/airc.restart-request" 2>/dev/null || true
                     # SIGTERM the parent — its EXIT trap will reap
                     # children + clean up. With daemon installed,
                     # launchd/systemd respawns; without daemon, the
@@ -1777,7 +1766,10 @@ JSON
             # channel using the same content-based resolver as connect.
             # Description-only winner election can yield to unrelated
             # live test gists and split the mesh.
-            local _race; _race=$(_mesh_take_over "" "$_gist_id" "$room_name")
+            local _race="winner"
+            if [ -z "${_existing_room_gid:-}" ]; then
+              _race=$(_mesh_take_over "" "$_gist_id" "$room_name")
+            fi
             case "$_race" in
               winner|"")
                 : # we won (or _mesh_take_over couldn't probe — assume winner, heartbeat will sort it)
@@ -1885,9 +1877,9 @@ JSON
     echo "$$ $PAIR_PID $_hb_pid_persisted" > "$AIRC_WRITE_DIR/airc.pid"
     # Clean exit on tab close (SIGTERM/SIGINT from Claude Code's Monitor tool
     # going away, or any other signal): reap the accept loop, its python
-    # listener, the heartbeat loop, AND delete our hosted gist if any —
-    # don't leave orphans holding the port, the SSH session, or a stale
-    # gist pointing at a corpse. Single canonical trap (was previously
+    # listener and the heartbeat loop. The hosted room gist is durable
+    # channel identity; stale host leases are recovered in-place. Single
+    # canonical trap (was previously
     # split between this site + the gist-publish site, but bash traps are
     # last-set-wins per shell so the split lost the gist-cleanup half).
     trap '
@@ -1896,13 +1888,21 @@ JSON
       [ -f "$AIRC_WRITE_DIR/heartbeat.pid" ] && _exit_hb_pid=$(cat "$AIRC_WRITE_DIR/heartbeat.pid" 2>/dev/null)
       [ -f "$AIRC_WRITE_DIR/host_gist_id" ] && _exit_gist_id=$(cat "$AIRC_WRITE_DIR/host_gist_id" 2>/dev/null)
       [ -n "$_exit_hb_pid" ] && kill $_exit_hb_pid 2>/dev/null
-      if [ -n "$_exit_gist_id" ] && command -v gh >/dev/null 2>&1; then
-        gh gist delete "$_exit_gist_id" --yes >/dev/null 2>&1
+      _exit_restart=0
+      if [ -f "$AIRC_WRITE_DIR/airc.restart-request" ]; then
+        _exit_restart=99
+        _exit_reason=$(cat "$AIRC_WRITE_DIR/airc.restart-request" 2>/dev/null | head -1)
+        echo "airc: restart requested (${_exit_reason:-internal transition})" >&2
+        rm -f "$AIRC_WRITE_DIR/airc.restart-request" 2>/dev/null
       fi
+      # Room gists are durable channel identity. Normal host exit must
+      # leave the gist in place so another peer can refresh the host
+      # lease in-place. `airc part` is the explicit deletion path.
       rm -f "$AIRC_WRITE_DIR/airc.pid" "$AIRC_WRITE_DIR/heartbeat.pid" "$AIRC_WRITE_DIR/host_gist_id" 2>/dev/null
       for p in $PAIR_PID $(proc_children $PAIR_PID) $(proc_children $$); do
         kill $p 2>/dev/null
       done
+      [ "$_exit_restart" = "99" ] && exit 99
     ' EXIT INT TERM
 
     spawn_general_sidecar_if_wanted

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -458,20 +458,25 @@ _doctor_health() {
     fi
   fi
 
-  # ── Daemon installed-for-this-scope check. Pre-fix probed for a
+  # ── Daemon installed/running-for-this-scope check. Pre-fix probed for a
   # `daemon.pid` file that the daemon launcher never writes anywhere
   # (Copilot caught this on PR #422 review — `--health` always reported
   # "not installed" even when the daemon was running). Use the canonical
   # detector (`airc_daemon_is_installed_for_scope`) which checks the
-  # registered launchd plist / systemd unit / HKCU Run entry. Liveness
-  # itself (is the launcher actually running and successfully polling?)
-  # is what the per-channel bearer last-recv timestamps below measure
-  # transitively — if the daemon is installed AND bearer last-recv is
-  # fresh, the daemon is alive. Fresh state with no installed daemon =
-  # an interactive `airc connect` is doing the work.
+  # registered launchd plist / systemd unit / HKCU Run entry, then a
+  # separate running probe. Installed-on-disk is not liveness: Joel hit
+  # a scope with a valid plist, no launchctl job loaded, and stale
+  # bearer state. That must be loud.
   if command -v airc_daemon_is_installed_for_scope >/dev/null 2>&1 \
      && airc_daemon_is_installed_for_scope "$AIRC_WRITE_DIR" 2>/dev/null; then
-    printf "  [ok] daemon installed for this scope (liveness inferred from per-channel last-recv below)\n"
+    if command -v airc_daemon_is_running_for_scope >/dev/null 2>&1 \
+       && airc_daemon_is_running_for_scope "$AIRC_WRITE_DIR" 2>/dev/null; then
+      printf "  [ok] daemon loaded for this scope\n"
+    else
+      printf "  [BLOCKED] daemon installed for this scope but NOT loaded/running\n"
+      printf "           Fix: airc daemon restart  (or airc daemon install if restart fails)\n"
+      issues=$((issues+1))
+    fi
   else
     printf "  [info] daemon not installed (substrate runs in-shell only)\n"
     printf "         Optional: airc daemon install  (survives sleep/crash, see README → Optional layers)\n"

--- a/lib/airc_bash/lib_daemon_detect.sh
+++ b/lib/airc_bash/lib_daemon_detect.sh
@@ -144,3 +144,40 @@ airc_daemon_is_installed_for_scope() {
   esac
   return 1
 }
+
+# ── airc_daemon_is_running_for_scope <scope> ───────────────────────────
+#
+# Returns 0 only when the platform supervisor is actively loaded/running
+# for the given scope. "Installed" is not enough: a launchd plist or
+# systemd unit can exist on disk while the job is unloaded, crashed, or
+# never bootstrapped. Monitor recovery code must not claim "daemon will
+# self-heal" unless this probe is true.
+airc_daemon_is_running_for_scope() {
+  local target_scope="${1:-}"
+  [ -n "$target_scope" ] || return 1
+  airc_daemon_is_installed_for_scope "$target_scope" || return 1
+  local os; os=$(detect_platform)
+  case "$os" in
+    darwin)
+      launchctl list 2>/dev/null | awk '{print $3}' | grep -qFx "com.cambriantech.airc" && return 0
+      return 1
+      ;;
+    linux|wsl)
+      systemctl --user is-active --quiet airc.service 2>/dev/null && return 0
+      return 1
+      ;;
+    windows)
+      # HKCU Run starts the daemon at login; there is no supervisor API
+      # equivalent to launchd/systemd. Treat a live airc-daemon.bat or
+      # `airc connect` process for this scope as running.
+      if command -v powershell.exe >/dev/null 2>&1; then
+        local needle="$target_scope"
+        powershell.exe -NoProfile -Command \
+          "Get-CimInstance Win32_Process | Where-Object { \$_.CommandLine -like '*airc*' -and \$_.CommandLine -like '*$needle*' } | Select-Object -First 1 | ForEach-Object { 'yes' }" \
+          2>/dev/null | grep -q yes && return 0
+      fi
+      return 1
+      ;;
+  esac
+  return 1
+}

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -1620,9 +1620,14 @@ scenario_heartbeat() {
   fi
 
   # ── kill -9 the host. Heartbeat thread dies with it; gist persists.
-  local host_pids
-  host_pids=$(cat /tmp/airc-it-h/state/airc.pid 2>/dev/null)
-  [ -n "$host_pids" ] || { fail "no host pid recorded"; cleanup_all; return; }
+  # Some fast-fail paths can publish heartbeat state before monitor pid
+  # bookkeeping completes; the parent PID is enough to model a laptop
+  # power-off. Include any recorded child PIDs when present.
+  local host_pids host_parent
+  host_pids=$(cat /tmp/airc-it-h/state/airc.pid 2>/dev/null || true)
+  host_parent=$(pgrep -f "AIRC_HOME=/tmp/airc-it-h/state.*connect --room $rname" 2>/dev/null | head -1 || true)
+  [ -n "$host_parent" ] && host_pids="$host_pids $host_parent"
+  [ -n "$(printf '%s' "$host_pids" | tr -d '[:space:]')" ] || { fail "no host process found"; gh gist delete "$gist_id" --yes 2>/dev/null; cleanup_all; return; }
   kill -9 $host_pids 2>/dev/null || true
   sleep 1
   pass "host kill -9'd ($host_pids)"
@@ -1640,22 +1645,22 @@ scenario_heartbeat() {
   # ── Spawn joiner beta with discovery ON. Joiner should:
   #    - resolve the gist
   #    - detect last_heartbeat is stale
-  #    - take over: delete stale gist, exec into host mode
+  #    - take over the SAME gist in place (room gist is durable identity)
   mkdir -p /tmp/airc-it-j
   ( cd /tmp/airc-it-j && AIRC_HOME=/tmp/airc-it-j/state AIRC_NAME=beta AIRC_PORT=7550 \
       AIRC_HEARTBEAT_STALE=$hb_stale AIRC_HEARTBEAT_SEC=$hb_sec \
-      "$AIRC" connect --room "$rname" --takeover > /tmp/airc-it-j/out.log 2>&1 & )
+      "$AIRC" connect --room "$rname" > /tmp/airc-it-j/out.log 2>&1 & )
 
   for i in 1 2 3 4 5 6 7 8 9 10; do
     sleep 1
-    grep -qE 'taking over|self-healing as new host' /tmp/airc-it-j/out.log 2>/dev/null && break
+    grep -qE 'taking over existing mesh|recovering existing room gist' /tmp/airc-it-j/out.log 2>/dev/null && break
   done
 
-  grep -qE 'taking over|self-healing as new host' /tmp/airc-it-j/out.log \
-    && pass "beta detected stale heartbeat + initiated takeover" \
+  grep -qE 'taking over existing mesh|recovering existing room gist' /tmp/airc-it-j/out.log \
+    && pass "beta detected stale heartbeat + initiated in-place takeover" \
     || { fail "beta did NOT detect stale heartbeat (log: $(tail -20 /tmp/airc-it-j/out.log))"; cleanup_all; return; }
 
-  # Wait for beta to publish a fresh gist as new host.
+  # Wait for beta to adopt the same room gist as new host.
   for i in 1 2 3 4 5 6 7 8 9 10; do
     sleep 1
     [ -f /tmp/airc-it-j/state/room_gist_id ] && break
@@ -1663,35 +1668,34 @@ scenario_heartbeat() {
 
   local new_gist_id
   new_gist_id=$(cat /tmp/airc-it-j/state/room_gist_id 2>/dev/null)
-  if [ -n "$new_gist_id" ] && [ "$new_gist_id" != "$gist_id" ]; then
-    pass "beta published fresh gist as new host ($new_gist_id, replaces $gist_id)"
+  if [ "$new_gist_id" = "$gist_id" ]; then
+    pass "beta adopted original gist as new host ($new_gist_id)"
   else
-    fail "beta did not publish a fresh gist (got: '$new_gist_id', original: '$gist_id')"
+    fail "beta did not adopt original gist (got: '$new_gist_id', original: '$gist_id')"
   fi
 
-  # Old gist must be gone (beta deleted it during takeover).
-  if gh api "gists/$gist_id" >/dev/null 2>&1; then
-    fail "stale gist $gist_id still exists after takeover"
-    gh gist delete "$gist_id" --yes 2>/dev/null
+  # Original gist must still exist and now advertise beta as host.
+  local recovered_name
+  recovered_name=$(gh api "gists/$gist_id" --jq ".files[\"airc-room-${rname}.json\"].content" 2>/dev/null \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin).get("host",{}).get("name",""))' 2>/dev/null || true)
+  if [ "$recovered_name" = "beta" ]; then
+    pass "original gist preserved and host lease updated to beta"
   else
-    pass "stale gist $gist_id removed by takeover"
+    fail "original gist did not advertise beta after takeover (host='$recovered_name')"
   fi
 
-  # Cleanup: delete the new gist beta published.
-  if [ -n "$new_gist_id" ]; then
-    gh gist delete "$new_gist_id" --yes 2>/dev/null || true
-  fi
+  gh gist delete "$gist_id" --yes 2>/dev/null || true
   cleanup_all
 }
 
-# ── Scenario: bounce (teardown should not orphan the host's gist) ─────
-# host A → teardown → host A again. Each cycle must leave AT MOST ONE
-# gist for the room name on the gh account. Pre-fix, every bounce
-# accumulated an orphan because cmd_teardown's kill -9 skipped the
-# EXIT trap that would have deleted the gist (PR #110).
+# ── Scenario: bounce (teardown preserves durable room gist) ─────
+# host A → teardown → host A again. The room gist is channel identity,
+# not process lifetime. Teardown should stop local processes and leave
+# the gist for the next host to refresh in-place; `airc part` is the
+# explicit deletion path.
 # Skips if gh is unavailable.
 scenario_bounce() {
-  section "bounce: teardown deletes hosted gist (no orphan accumulation)"
+  section "bounce: teardown preserves and reuses hosted room gist"
   requires_gh_auth_or_skip "bounce" || return
 
   if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
@@ -1721,15 +1725,18 @@ scenario_bounce() {
   AIRC_HOME=/tmp/airc-it-h/state "$AIRC" teardown >/dev/null 2>&1
   sleep 2
 
-  # Verify gist deleted
+  # Verify gist persists. This is deliberate: if the hosting laptop is
+  # shut down, the next reachable peer must be able to refresh the same
+  # source-of-truth gist rather than create an island.
   if gh api "gists/$gid1" >/dev/null 2>&1; then
-    fail "teardown LEFT gist $gid1 on gh account (orphan)"
-    gh gist delete "$gid1" --yes 2>/dev/null  # cleanup our mess
+    pass "teardown preserved durable room gist $gid1"
   else
-    pass "teardown deleted gist $gid1 ✓"
+    fail "teardown deleted durable room gist $gid1"
+    cleanup_all
+    return
   fi
 
-  # Round 2: rehost same room, verify NO orphan from round 1.
+  # Round 2: rehost same room, verify it reuses the same gist.
   # Teardown leaves room_gist_id behind (it only wipes airc.pid +
   # host_gist_id), so we can't `[ -f room_gist_id ]` as a "round 2
   # ready" signal — that file already exists from round 1. Wait for
@@ -1745,15 +1752,15 @@ scenario_bounce() {
 
   local gid2; gid2=$(cat /tmp/airc-it-h/state/host_gist_id 2>/dev/null)
   [ -z "$gid2" ] && gid2=$(cat /tmp/airc-it-h/state/room_gist_id 2>/dev/null)
-  [ -n "$gid2" ] && [ "$gid2" != "$gid1" ] \
-    && pass "round 2: alpha re-hosted, fresh gist=$gid2" \
-    || fail "round 2: no fresh gist or same as orphan (gid1=$gid1 gid2=$gid2)"
+  [ "$gid2" = "$gid1" ] \
+    && pass "round 2: alpha re-hosted on same durable gist=$gid2" \
+    || fail "round 2: did not reuse durable gist (gid1=$gid1 gid2=$gid2)"
 
   local count
   count=$(gh gist list --limit 50 2>/dev/null | awk -F'\t' -v r="airc room: $rname" '$2==r' | wc -l | tr -d ' ')
   [ "$count" = "1" ] \
-    && pass "exactly one #${rname} gist on account after bounce ✓" \
-    || fail "expected 1 gist, found $count (orphan accumulation)"
+    && pass "exactly one #${rname} gist on account after bounce" \
+    || fail "expected 1 gist, found $count"
 
   # Cleanup
   AIRC_HOME=/tmp/airc-it-h/state "$AIRC" teardown >/dev/null 2>&1
@@ -2054,8 +2061,8 @@ JSON
 #   1. Two tabs paired (alpha hosting, beta joined). Beta's CONFIG now
 #      has host_target=alpha's-address.
 #   2. Alpha's process dies (machine restart, crash, kill -9). Alpha's
-#      gist may also be gone (graceful teardown deletes it; ungraceful
-#      leaves it stale).
+#      gist remains as the durable channel identity, but its host lease
+#      may be stale.
 #   3. Beta runs `airc connect` again.
 #
 # Pre-#130: beta's resume path SSH-probed alpha's cached address. If
@@ -2114,24 +2121,21 @@ scenario_connect_after_kill_recovers() {
     && pass "beta's CONFIG has cached host_target (pre-condition)" \
     || { fail "beta's CONFIG has no host_target — pre-condition broken"; cleanup_all; return; }
 
-  # ── Kill alpha hard. SIGKILL bypasses alpha's EXIT trap, so alpha's
-  # gist is left STALE on gh (host process gone, gist still exists).
-  # This is the worst case: a cached pairing pointing at a dead host
-  # whose gist still resolves.
+  # ── Stop alpha. The room gist stays on gh as durable channel identity;
+  # beta must not trust the cached host_target, and must recover through
+  # discovery / same-gist lease refresh instead.
   AIRC_HOME=/tmp/airc-it-cakr-h/state "$AIRC" teardown >/dev/null 2>&1
-  # teardown deletes the gist gracefully — do that for round 1 to
-  # exercise the gist-gone case. (The TCP-unreachable-but-gist-alive
-  # case is exercised by scenario_two_tab_localhost's host-crash branch.)
   sleep 2
   if gh api "gists/$gid_alpha" >/dev/null 2>&1; then
-    fail "alpha's gist not deleted by teardown (test pre-condition)"
-    gh gist delete "$gid_alpha" --yes 2>/dev/null
+    pass "alpha's room gist preserved (durable channel identity)"
   else
-    pass "alpha's gist deleted (gist-gone case set up)"
+    fail "alpha's room gist disappeared; durable identity pre-condition broken"
+    cleanup_all
+    return
   fi
 
   # Beta is now in the same state Joel hit: paired CONFIG with cached
-  # host_target pointing at a dead host, gist gone. Run beta's connect.
+  # host_target pointing at a dead host. Run beta's connect.
   AIRC_HOME=/tmp/airc-it-cakr-j/state "$AIRC" teardown >/dev/null 2>&1
   sleep 1
   local recover_log=/tmp/airc-it-cakr-j-recover.log
@@ -2168,6 +2172,7 @@ scenario_connect_after_kill_recovers() {
   AIRC_HOME=/tmp/airc-it-cakr-j/state "$AIRC" teardown >/dev/null 2>&1
   sleep 1
   rm -f "$recover_log"
+  gh gist delete "$gid_alpha" --yes 2>/dev/null || true
   rm -rf /tmp/airc-it-cakr-h /tmp/airc-it-cakr-j
   cleanup_all
 }


### PR DESCRIPTION
## Summary
- preserve room gists as durable channel identity; stale hosts rewrite the same gist instead of delete/create
- make the rediscovery loop periodically detect stale host leases, not just changed gist ids
- distinguish daemon installed from daemon loaded/running in doctor health and monitor restart messages
- add restart-request marker so intentional monitor recycle paths can surface as restart-class exits instead of silent fatal-looking deaths
- update integration expectations for heartbeat recovery and bounce reuse

## Review focus
- cmd_connect same-gist adoption path via AIRC_ADOPT_GIST
- _mesh_rediscover_loop stale-heartbeat recovery trigger
- launchd/systemd daemon running probe in lib_daemon_detect + doctor --health
- EXIT trap restart-request behavior and room gist preservation

## Verification
- bash -n airc lib/airc_bash/cmd_connect.sh lib/airc_bash/cmd_doctor.sh lib/airc_bash/lib_daemon_detect.sh test/integration.sh
- git diff --check
- python3 test/test_channel_gist.py
- bash test/integration.sh solo_mesh_warns
- patched ./airc doctor --health against continuum scope now reports daemon installed but NOT loaded/running instead of implying daemon liveness

Note: gh auth in this shell is invalid for gh-auth-gated write integration scenarios, so heartbeat/bounce gh-backed scenarios skip locally until a valid token is restored.