### PR TITLE
fix(mesh): prefer canonical room gist over solo invites

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -588,11 +588,20 @@ cmd_connect() {
     # no longer drives gist discovery — every subscriber on the account
     # converges on the same host.
     _did_room_discovery=1
-    local _mesh_id; _mesh_id=$(_mesh_find "$room_name")
+    local _mesh_id; _mesh_id=$(_mesh_find_any "$room_name")
     if [ -n "$_mesh_id" ]; then
-      echo "  Found mesh on your gh account → joining ($_mesh_id)"
-      target="$_mesh_id"
-      # fall through to gist resolver below
+      local _mesh_invite_id; _mesh_invite_id=$(_mesh_find "$room_name")
+      if [ -n "$_mesh_invite_id" ] && [ "$_mesh_invite_id" = "$_mesh_id" ]; then
+        echo "  Found mesh on your gh account → joining ($_mesh_id)"
+        target="$_mesh_id"
+        # fall through to gist resolver below
+      else
+        echo "  Found canonical room gist for #${room_name} → becoming host on that existing gist ($_mesh_id)."
+        export AIRC_ADOPT_GIST="$_mesh_id"
+        # Host branch below will rewrite the same gist with a fresh
+        # invite/host lease. Do not join a newer invite-bearing duplicate:
+        # that is the solo-island trap.
+      fi
     else
       echo "  No mesh found on your gh account → becoming the host."
       # Race against a concurrent host attempt is handled POST-publish

--- a/lib/airc_bash/mesh.sh
+++ b/lib/airc_bash/mesh.sh
@@ -57,6 +57,20 @@ _mesh_find() {
   "$AIRC_PYTHON" -m airc_core.channel_gist find --channel "$channel" --require-invite 2>/dev/null || true
 }
 
+# Find the canonical channel gist whether or not it currently has a host
+# invite. This is the durable room identity lookup. Zero-arg discovery
+# uses it to decide whether to host/adopt the existing chain instead of
+# being attracted to a newer invite-bearing solo island.
+_mesh_find_any() {
+  command -v gh >/dev/null 2>&1 || return 0
+  local channel="${1:-${room_name:-}}"
+  if [ -z "$channel" ] && [ -n "${CONFIG:-}" ] && [ -f "$CONFIG" ]; then
+    channel=$("$AIRC_PYTHON" -m airc_core.config default_channel --config "$CONFIG" 2>/dev/null || true)
+  fi
+  [ -z "$channel" ] && channel="general"
+  "$AIRC_PYTHON" -m airc_core.channel_gist find --channel "$channel" 2>/dev/null || true
+}
+
 # Publish a new mesh gist. Echoes the new gist id, or empty on failure.
 # Caller writes the JSON envelope to a tempfile and passes the path.
 # Per CLAUDE.md "never swallow errors": gh's stderr (auth lapsed, rate


### PR DESCRIPTION
## Summary
- zero-arg discovery now resolves the durable canonical channel gist first, even when it has no current invite
- if the canonical gist differs from a newer invite-bearing duplicate, connect hosts/adopts the canonical gist in-place instead of joining the solo island
- keeps invite-bearing lookup for the case where the canonical gist itself is live and joinable

## Why
After #464, live recovery still had one split-brain path: `channel_gist find --require-invite` could prefer a newer solo invite gist (`2d3...`) over the older canonical `#cambriantech` room gist (`df40...`). That would preserve the wrong island. This patch makes the durable room chain win.

## Verification
- bash -n airc lib/airc_bash/cmd_connect.sh lib/airc_bash/mesh.sh
- git diff --check
- PYTHONPATH=lib .venv/bin/python -m airc_core.channel_gist find --channel cambriantech => df40...
- PYTHONPATH=lib .venv/bin/python -m airc_core.channel_gist find --channel cambriantech --require-invite => 2d3...
- bash test/integration.sh solo_mesh_warns

Review focus: zero-arg discovery behavior in cmd_connect.sh and the new _mesh_find_any helper.