### PR TITLE
fix(gist): keep channel canonical under heartbeat

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1657,40 +1657,13 @@ JSON
                 # joiners that lose connection re-discover and try the
                 # new address set.
                 local _hb_addrs; _hb_addrs=$(host_addresses_json "${_hb_port}")
-                # Phase 2C: build channels[] from recent message activity
-                # so joiners on different cwds can advertise their channels
-                # without coordinating with the host. Self-correcting —
-                # silent channels age out, active ones surface. Falls back
-                # to the host's primary room if no recent activity.
-                local _hb_channels
-                _hb_channels=$(AIRC_HB_MSGS="$_hb_messages" \
-                               AIRC_HB_ROOM="$_hb_room" \
-                               "$AIRC_PYTHON" -c '
-import json, os, sys
-log = os.environ.get("AIRC_HB_MSGS", "")
-fallback = os.environ.get("AIRC_HB_ROOM", "general") or "general"
-window = int(os.environ.get("AIRC_HB_RECENT", "200"))
-chans = []
-seen = set()
-try:
-    with open(log) as f:
-        # Read last N lines without slurping the full file.
-        lines = f.readlines()[-window:]
-    for line in lines:
-        try:
-            ch = json.loads(line).get("channel", "")
-        except Exception:
-            continue
-        if ch and ch not in seen:
-            seen.add(ch); chans.append(ch)
-except Exception:
-    pass
-if not chans:
-    chans = [fallback]
-elif fallback not in seen:
-    chans.append(fallback)
-print(json.dumps(chans))
-' 2>/dev/null || echo "[\"${_hb_room}\"]")
+                # One gist is the durable wire for one channel. Keep
+                # the host lease envelope single-channel even if this
+                # scope is subscribed to multiple channels; otherwise
+                # the resolver can stop treating the actual
+                # airc-room-<channel>.json gist as canonical and drift
+                # toward a newer solo invite duplicate.
+                local _hb_channels="[\"${_hb_room}\"]"
                 local _hb_payload; _hb_payload=$(cat <<JSON
 {
   "airc": 1,

--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -163,11 +163,17 @@ def _gh_api_get_gist(gist_id: str) -> Optional[dict]:
 
 
 def _is_single_channel_match(gist: dict, channel: str, require_invite: bool = False) -> bool:
-    """A gist is the canonical post-3c per-channel gist for `channel`
-    iff its envelope has channels=[<exactly channel>]. Single-element
-    list, exact match. The post-3c shape created by create_new()."""
+    """Return True for the canonical post-3c per-channel gist.
+
+    The canonical signal is the in-gist filename
+    `airc-room-<channel>.json`. Older hosts briefly wrote multiple
+    channel labels into that envelope during heartbeat refresh; do not
+    let that demote the actual per-channel chain below a newer solo
+    invite duplicate.
+    """
     files = gist.get("files") or {}
-    for entry in files.values():
+    exact_name = f"airc-room-{channel}.json"
+    for name, entry in files.items():
         content = entry.get("content")
         if not content:
             continue
@@ -180,6 +186,8 @@ def _is_single_channel_match(gist: dict, channel: str, require_invite: bool = Fa
         if require_invite and not env.get("invite"):
             continue
         channels = env.get("channels")
+        if name == exact_name and isinstance(channels, list) and channel in channels:
+            return True
         if isinstance(channels, list) and len(channels) == 1 and channels[0] == channel:
             return True
     return False


### PR DESCRIPTION
## Summary
- resolver treats `airc-room-<channel>.json` as canonical when its envelope contains that channel, even if the channel list is not single-element
- heartbeat refresh now keeps the host lease single-channel for the room gist
- prevents #466 repair logic from deciding a newer solo invite duplicate is canonical after the real room gist was refreshed with multiple channel labels

## Why
After #467 migration, daemon logs showed the bad loop:

`running monitor is on stale #cambriantech gist df40...; canonical is 2d3...`

That was wrong. `df40...` is the durable #cambriantech chain; it only lost resolver priority because heartbeat had written multiple channels into its envelope.

## Verification
- bash -n airc lib/airc_bash/cmd_connect.sh
- git diff --check
- PYTHONPATH=lib .venv/bin/python -m airc_core.channel_gist find --channel cambriantech => df40...
- PYTHONPATH=lib .venv/bin/python -m airc_core.channel_gist find --channel cambriantech --require-invite => df40...
- python3 test/test_channel_gist.py