### PR TITLE
fix(status): require monitor process evidence

### DIFF
--- a/airc
+++ b/airc
@@ -490,22 +490,38 @@ prune_pidfile_and_count() {
 }
 
 # Liveness check that's robust to sandbox process-tree blindness.
-# Returns "yes" if the monitor is alive, "no" otherwise. Two-phase:
+# Returns "yes" if the scope monitor pipeline is alive, "no" otherwise.
+# Two-phase:
 #
 #   1. kill -0 on PIDs in pidfile (the canonical, fast path)
-#   2. bearer-state-freshness fallback when (1) returns no live PIDs but
+#   2. monitor_formatter process fallback when (1) returns no live PIDs but
 #      a pidfile is present — covers Codex's sandbox where kill -0 across
-#      process trees returns false-negative even when the monitor's
-#      bearer-recv loop is provably writing to bearer_state.<channel>.json
-#      every poll cycle. #370/#371/#372 root cause.
+#      process trees can be false-negative. The formatter argv includes
+#      --peers-dir <scope>/peers, which proves the scope has a monitor
+#      pipeline.
 #
 # Pure read — does NOT prune the pidfile (which would silently corrupt
 # state when phase 1 was wrong about death). Use prune_pidfile_and_count
 # only when you genuinely want pids removed (e.g. teardown).
 #
-# Phase-2 freshness window = 2x the reminder interval (default 300s →
-# 600s window). bearer-state's last_recv_ts is the truth: it's only
-# updated when a bearer_recv subprocess actually reads from the wire.
+# Fresh bearer_state is deliberately NOT accepted as monitor liveness.
+# Multiple Claude/Codex tabs can share one project .airc scope, and a
+# bearer can keep channel health files fresh while one tab's user-facing
+# Monitor is absent. bearer_state is channel health evidence; process
+# evidence is monitor evidence.
+_airc_scope_monitor_formatter_pids() {
+  local scope_dir="${1:-}"
+  [ -n "$scope_dir" ] || return 0
+  local p cmd
+  proc_airc_pids_matching 'airc_core\.monitor_formatter' 2>/dev/null | while IFS= read -r p; do
+    case "$p" in ''|*[!0-9]*) continue ;; esac
+    cmd=$(proc_cmdline "$p" 2>/dev/null || true)
+    printf '%s\n' "$cmd" | grep -Fq -- 'airc_core.monitor_formatter' || continue
+    printf '%s\n' "$cmd" | grep -Fq -- "--peers-dir $scope_dir/peers" || continue
+    printf '%s\n' "$p"
+  done
+}
+
 _monitor_alive_with_bearer_fallback() {
   local pidfile="${1:-}"
   local scope_dir
@@ -525,7 +541,7 @@ _monitor_alive_with_bearer_fallback() {
   # like an airc connect/join wrapper. Same regex shape as cmd_teardown's
   # parent-chain reaper (#446) — keeps the two paths in lockstep on what
   # "an airc process" means. PID reuse → cmdline doesn't match → treat as
-  # dead, fall through to Phase 2 (bearer-state freshness).
+  # dead, fall through to Phase 2 (scope formatter process evidence).
   if [ -f "$pidfile" ]; then
     local p raw
     raw=$(cat "$pidfile" 2>/dev/null)
@@ -540,7 +556,7 @@ _monitor_alive_with_bearer_fallback() {
         fi
         # PID alive but not airc-shaped — OS reused this PID after our
         # monitor died (sleep/wake, container restart, etc.). Skip; let
-        # Phase 2 bearer-state freshness be the truth.
+        # Phase 2 scope formatter process evidence decide.
       fi
     done
   else
@@ -551,52 +567,13 @@ _monitor_alive_with_bearer_fallback() {
     return 0
   fi
 
-  # Phase 2: bearer-state-freshness fallback. Only reached when pidfile
-  # exists but kill -0 said all PIDs dead — could be real death, could
-  # be sandbox blindness. bearer-state freshness disambiguates.
-  #
-  # Skip when AIRC_BACKGROUND_OK=1 — that env var is set by the daemon
-  # launcher (cmd_daemon.sh's .bat / launchd plist / systemd unit), and
-  # in daemon context kill -0 is reliable (no Codex-style sandbox
-  # blindness). The fallback's 600s window otherwise creates a
-  # 10-minute "daemon can't take over" blackout after an interactive
-  # airc connect dies: the dying process leaves bearer_state with a
-  # fresh last_recv_ts, the daemon's next launch sees it as "monitor
-  # alive," early-exits, and the .bat retries every 5s for 10 minutes
-  # before the window expires. b69f filed as #4 in the 2026-05-02
-  # daemon audit. Trust kill -0 in daemon context so takeover is
-  # immediate. Joel's BIOS-grade self-heal directive: substrate must
-  # work without a human in the loop, including across interactive
-  # process death.
-  if [ "${AIRC_BACKGROUND_OK:-0}" = "1" ]; then
-    echo "no"
+  # Phase 2: formatter-process fallback. Only reached when pidfile exists
+  # but kill -0/cmdline verification found no airc parent. This covers
+  # sandbox/process-tree blind spots without confusing fresh bearer state
+  # with a running Monitor.
+  if [ -n "$(_airc_scope_monitor_formatter_pids "$scope_dir" | head -1)" ]; then
+    echo "yes"
     return 0
-  fi
-  local _reminder_secs=300
-  if [ -f "$scope_dir/reminder" ]; then
-    _reminder_secs=$(cat "$scope_dir/reminder" 2>/dev/null)
-  fi
-  if [ -z "$_reminder_secs" ] || ! [ "$_reminder_secs" -gt 0 ] 2>/dev/null; then
-    _reminder_secs=300
-  fi
-  local _fresh_window=$((_reminder_secs * 2))
-  if ls "$scope_dir"/bearer_state.*.json >/dev/null 2>&1; then
-    if "$AIRC_PYTHON" -c "
-import json, glob, sys, time
-window = $_fresh_window
-for path in glob.glob('$scope_dir/bearer_state.*.json'):
-    try:
-        s = json.load(open(path))
-    except Exception:
-        continue
-    ts = s.get('last_recv_ts')
-    if ts and (time.time() - float(ts)) <= window:
-        sys.exit(0)
-sys.exit(1)
-" 2>/dev/null; then
-      echo "yes"
-      return 0
-    fi
   fi
 
   echo "no"

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -252,11 +252,10 @@ cmd_connect() {
   # that's already working.
   #
   # Pre-#372 this used naked kill -0 inline, which returned false on
-  # Codex (sandbox process-tree blindness) even when the monitor was
-  # provably alive (bearer-state.json updates every poll cycle).
-  # The shared helper checks bearer-state freshness as a fallback, so
-  # Codex sessions ALSO hit this short-circuit when their monitor
-  # is alive — exactly the Carl-experience win for cross-vendor mesh.
+  # Codex (sandbox process-tree blindness) even when the monitor pipeline
+  # was alive. The shared helper checks for a scope-owned
+  # monitor_formatter process as a fallback; it deliberately does NOT
+  # accept fresh bearer_state as proof that this tab has a Monitor.
   local _early_pidfile="$AIRC_WRITE_DIR/airc.pid"
   if [ "$(_monitor_alive_with_bearer_fallback "$_early_pidfile")" = "yes" ]; then
     # 2026-05-02 QA caught (B5): if user passed --room NEWNAME and that

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -458,14 +458,13 @@ cmd_send() {
     #
     # Detect monitor liveness via the shared sandbox-robust helper
     # (_monitor_alive_with_bearer_fallback in airc top-level). Same
-    # contract as cmd_status post-#371. Phase 1 = kill -0 (canonical);
-    # phase 2 = bearer-state freshness (covers Codex's sandbox where
-    # kill -0 is process-tree-blind even when bearer-recv is provably
-    # writing to bearer_state.<channel>.json). Pre-fix this used the
-    # naked prune_pidfile_and_count helper which would ALSO actively
-    # delete the pidfile when phase 1 was wrong about death — silently
-    # corrupting state inside Codex's sandbox. The new helper is read-
-    # only + sandbox-aware. #370/#371/#372 root cause cluster.
+    # contract as cmd_status. Phase 1 = kill -0 (canonical); phase 2 =
+    # scope-owned monitor_formatter process evidence (covers Codex's
+    # sandbox without confusing fresh bearer_state with a Monitor).
+    # Pre-fix this used the naked prune_pidfile_and_count helper which
+    # would ALSO actively delete the pidfile when phase 1 was wrong
+    # about death — silently corrupting state inside Codex's sandbox.
+    # The helper is read-only + sandbox-aware.
     local _pidfile="$AIRC_WRITE_DIR/airc.pid"
     local _monitor_alive=0
     if [ "$(_monitor_alive_with_bearer_fallback "$_pidfile")" = "yes" ]; then

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -292,66 +292,27 @@ cmd_status() {
   fi
   _airc_collaboration_health_report
 
-  # Monitor alive? Use the shared sandbox-robust helper
+  # Scope monitor alive? Use the shared sandbox-robust helper
   # (_monitor_alive_with_bearer_fallback in airc top-level). Phase 1 =
-  # kill -0 against airc.pid (canonical, fast); phase 2 = bearer-state
-  # freshness fallback (covers Codex sandbox kill -0 blindness — see
-  # #370/#371/#372). The helper is read-only (doesn't prune the pidfile
-  # the way the older prune_pidfile_and_count did, which would silently
-  # corrupt state when phase 1 was wrong).
+  # kill -0 against airc.pid (canonical, fast); phase 2 = scope-specific
+  # monitor_formatter process evidence (covers Codex sandbox kill -0
+  # blindness without treating bearer_state freshness as a Monitor).
+  # The helper is read-only (doesn't prune the pidfile the way the older
+  # prune_pidfile_and_count did, which would silently corrupt state when
+  # phase 1 was wrong).
   local monitor_state="not running"
   local pidfile="$AIRC_WRITE_DIR/airc.pid"
   if [ "$(_monitor_alive_with_bearer_fallback "$pidfile")" = "yes" ]; then
     if [ -f "$pidfile" ]; then
       local first_alive; first_alive=$(awk '{print $1}' "$pidfile" 2>/dev/null)
       # Distinguish "alive per kill -0" (we have a verified PID) from
-      # "alive per bearer-state-only" (kill -0 blind, but bearer-recv
-      # child is provably writing to bearer_state). For the latter,
-      # surface the diagnostic so a Carl debugging "why does pid X
-      # show running when it's not in ps" has the answer.
+      # "alive per formatter process only" (kill -0 blind against the
+      # pidfile, but the scope's monitor_formatter is visible by argv).
       if kill -0 "$first_alive" 2>/dev/null; then
-        monitor_state="running (PID $first_alive)"
+        monitor_state="running for scope (PID $first_alive)"
       else
-        # Walk bearer_state to find which channel is freshest, for the
-        # informational message. (The helper already proved freshness;
-        # we re-check just to extract the age + channel name.)
-        # Scope to subscribed_channels ONLY — same fix-shape as #428
-        # for --health. Pre-fix this globbed every bearer_state.*.json
-        # on disk INCLUDING stale files from prior subscriptions, so a
-        # parted #cambriantech room (last_recv_ts = 14kS ago) would
-        # show as the "freshest" stale value, making `airc status`
-        # report monitor age way off from actual liveness. QA caught
-        # this 2026-05-02 self-test.
-        local _bs_summary; _bs_summary=$("$AIRC_PYTHON" -c "
-import json, glob, time
-subs = set()
-try:
-    cfg = json.load(open('$CONFIG'))
-    for c in cfg.get('subscribed_channels') or []:
-        subs.add(c)
-except Exception:
-    pass
-fresh = []
-for path in glob.glob('$AIRC_WRITE_DIR/bearer_state.*.json'):
-    try:
-        s = json.load(open(path))
-    except Exception:
-        continue
-    ts = s.get('last_recv_ts')
-    if not ts:
-        continue
-    ch = path.split('bearer_state.', 1)[1].rsplit('.json', 1)[0]
-    # Skip channels we no longer subscribe to. Empty subs (legacy
-    # scope) falls back to all-files for backward compat.
-    if subs and ch not in subs:
-        continue
-    fresh.append((int(time.time() - float(ts)), ch))
-if fresh:
-    fresh.sort()
-    age, ch = fresh[0]
-    print(f'{age}s via #{ch}')
-" 2>/dev/null)
-        monitor_state="likely-alive (${_bs_summary:-bearer-state fresh}; kill -0 blind in this sandbox — see #370)"
+        local _fmt_pid; _fmt_pid=$(_airc_scope_monitor_formatter_pids "$AIRC_WRITE_DIR" | head -1)
+        monitor_state="running for scope (formatter PID ${_fmt_pid:-?}; pidfile not visible/alive)"
       fi
     fi
   elif [ -f "$pidfile" ]; then

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -1976,6 +1976,26 @@ JSON
     && pass "stderr names the offending scope dir" \
     || fail "stderr doesn't surface scope path (user can't tell where their cwd resolved)"
 
+  # Fresh bearer_state is NOT monitor liveness. In a shared project dir,
+  # another tab or leftover bearer can keep channel health fresh while
+  # this scope's visible Monitor is absent. `status` and `msg` must not
+  # turn that into "monitor running".
+  "${AIRC_PYTHON:-python3}" - <<PY
+import json, time
+with open("$home/bearer_state.general.json", "w") as f:
+    json.dump({"last_recv_ts": time.time(), "kind": "gist"}, f)
+PY
+  local status_out
+  status_out=$(AIRC_HOME="$home" "$AIRC" status 2>&1)
+  echo "$status_out" | grep -qE 'monitor:\s+stale pidfile|monitor:\s+not running' \
+    && pass "fresh bearer_state does not make status claim monitor running" \
+    || fail "fresh bearer_state falsely reported monitor running (got: $status_out)"
+  AIRC_HOME="$home" "$AIRC" msg "fresh bearer state is still void" >"$out" 2>"$err"
+  rc=$?
+  [ "$rc" -ne 0 ] \
+    && pass "fresh bearer_state does not bypass dead-monitor send guard" \
+    || fail "fresh bearer_state bypassed dead-monitor send guard"
+
   # Also test the absent-pidfile path (monitor never started in this scope).
   rm -f "$home/airc.pid"
   AIRC_HOME="$home" "$AIRC" msg "still void" >"$out" 2>"$err"


### PR DESCRIPTION
## Summary
- stop treating fresh bearer_state files as proof that a monitor is running
- require either an airc connect/join pidfile process or a scope-owned monitor_formatter process
- label status as `running for scope` so shared project dirs do not imply this specific tab has a Monitor attached
- add a regression where fresh bearer_state + stale pidfile still reports monitor down and refuses void sends

## Why
Multiple Claude/Codex tabs can share one project `.airc` scope. A bearer can keep channel health fresh while a tab-visible Monitor is absent, so bearer freshness must remain channel health evidence, not monitor liveness.

## Verification
- bash -n airc lib/airc_bash/cmd_status.sh lib/airc_bash/cmd_connect.sh lib/airc_bash/cmd_send.sh test/integration.sh
- git diff --check
- bash test/integration.sh send_dead_monitor_dies
- bash test/integration.sh solo_mesh_warns
- bash test/integration.sh status
- python3 test/test_bearer.py
- python3 test/test_monitor_formatter.py
