### PR TITLE
Recover channel gist discovery without REST listing

### DIFF
--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -522,17 +522,23 @@ class GhBearer(Bearer):
 
     @classmethod
     def can_serve(cls, peer_meta: dict) -> bool:
-        """Serve any peer with a room_gist_id and a working gh auth.
+        """Serve any peer with a room_gist_id.
 
         Why room_gist_id rather than peer_id-derived addressing: gh-as-
         bearer uses the SHARED room gist for the substrate's message
         log. Every peer in the room reads/writes the same gist file.
         This matches how IRC works on a server — the channel is the
         bearer's addressable surface, not individual peers.
+
+        Deliberately no gh-auth probe here. can_serve is resolver
+        metadata inspection, not transport I/O. Auth/rate/network
+        failures belong in send()/recv_stream() where they become
+        structured SendOutcome values and visible monitor diagnostics.
+        Pre-fix, a poisoned GH_TOKEN made the resolver report "no
+        registered bearer can serve" even though gh is the correct
+        bearer for a room_gist_id.
         """
-        if not peer_meta.get("room_gist_id"):
-            return False
-        return _has_gh_auth()
+        return bool(peer_meta.get("room_gist_id"))
 
     def __init__(self, peer_meta: Optional[dict] = None) -> None:
         # No IO — concrete bearers MUST be cheap to instantiate.

--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -33,12 +33,28 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timezone
 from typing import Optional
 
 
 _GH_BIN = "gh"
 _GH_API_TIMEOUT = 10.0
 _GIST_LIST_LIMIT = 100   # `airc list` uses 50; we go a bit higher to be safe
+_GIST_ID_CHARS = set("0123456789abcdefABCDEF")
+_LOCAL_SCAN_MAX_DEPTH = 7
+_LOCAL_SCAN_PRUNE = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".turbo",
+}
 
 
 def _resolve_gh_bin() -> Optional[str]:
@@ -160,6 +176,240 @@ def _gh_api_get_gist(gist_id: str) -> Optional[dict]:
         return json.loads(r.stdout)
     except (ValueError, TypeError):
         return None
+
+
+def _valid_gist_id(gist_id: object) -> bool:
+    if not isinstance(gist_id, str):
+        return False
+    return 8 <= len(gist_id) <= 64 and all(c in _GIST_ID_CHARS for c in gist_id)
+
+
+def _parse_ts(value: object) -> float:
+    if not isinstance(value, str) or not value:
+        return 0.0
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return 0.0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def _gist_activity_ts(gist: dict) -> float:
+    """Best-effort freshness signal from cloned gist contents.
+
+    GitHub REST `updated_at` is not available on the git fallback path.
+    The wire data itself is enough: room envelopes carry heartbeat-ish
+    timestamps and messages.jsonl lines carry message timestamps.
+    """
+    best = _parse_ts(gist.get("updated_at")) or _parse_ts(gist.get("created_at"))
+    files = gist.get("files") or {}
+    for name, entry in files.items():
+        content = entry.get("content")
+        if not isinstance(content, str) or not content:
+            continue
+        if name == "messages.jsonl":
+            for line in content.splitlines():
+                try:
+                    env = json.loads(line)
+                except (ValueError, TypeError):
+                    continue
+                if not isinstance(env, dict):
+                    continue
+                for key in ("ts", "updated", "last_heartbeat", "created"):
+                    best = max(best, _parse_ts(env.get(key)))
+            continue
+        try:
+            env = json.loads(content)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(env, dict):
+            continue
+        for key in ("updated", "updated_at", "last_heartbeat", "created", "created_at"):
+            best = max(best, _parse_ts(env.get(key)))
+    return best
+
+
+def _strict_single_channel_match(gist: dict, channel: str, require_invite: bool = False) -> bool:
+    """True only when the envelope is exclusively for this channel.
+
+    This is stricter than _is_single_channel_match, which deliberately
+    tolerates older heartbeat code adding sibling labels to an exact
+    filename. The local fallback uses this stricter tier first so a
+    newer multi-channel solo island cannot beat a real per-channel
+    chain during REST outage recovery.
+    """
+    files = gist.get("files") or {}
+    exact_name = f"airc-room-{channel}.json"
+    for name, entry in files.items():
+        content = entry.get("content")
+        if not content:
+            continue
+        try:
+            env = json.loads(content)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(env, dict):
+            continue
+        if require_invite and not env.get("invite"):
+            continue
+        channels = env.get("channels")
+        if isinstance(channels, list) and channels == [channel]:
+            return name == exact_name or len(files) == 1
+    return False
+
+
+def _local_scan_roots() -> list[str]:
+    raw = os.environ.get("AIRC_GIST_CACHE_ROOTS", "")
+    roots: list[str] = []
+    if raw:
+        roots.extend(p for p in raw.split(os.pathsep) if p)
+    airc_home = os.environ.get("AIRC_HOME", "")
+    if airc_home:
+        roots.append(os.path.dirname(os.path.dirname(os.path.abspath(airc_home))))
+    cwd = os.getcwd()
+    roots.append(cwd)
+    home = os.path.expanduser("~")
+    for rel in ("Development", "dev", "src", "Code"):
+        roots.append(os.path.join(home, rel))
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for root in roots:
+        root = os.path.abspath(os.path.expanduser(root))
+        if root in seen or not os.path.isdir(root):
+            continue
+        seen.add(root)
+        out.append(root)
+    return out
+
+
+def _local_config_gist_candidates(channel: str) -> list[tuple[str, float]]:
+    """Return locally remembered gist ids for channel across worktrees.
+
+    This is deliberately read-only evidence. It lets a machine recover
+    a previously-known canonical room while the gh REST listing surface
+    is unavailable, without creating a new island.
+    """
+    found: dict[str, float] = {}
+    for root in _local_scan_roots():
+        root_depth = root.rstrip(os.sep).count(os.sep)
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in _LOCAL_SCAN_PRUNE]
+            if dirpath.rstrip(os.sep).count(os.sep) - root_depth > _LOCAL_SCAN_MAX_DEPTH:
+                dirnames[:] = []
+                continue
+            if "config.json" not in filenames or os.path.basename(dirpath) != ".airc":
+                continue
+            path = os.path.join(dirpath, "config.json")
+            try:
+                with open(path, encoding="utf-8") as f:
+                    cfg = json.load(f)
+            except (OSError, ValueError, TypeError):
+                continue
+            gists = cfg.get("channel_gists") or {}
+            gid = gists.get(channel)
+            if not _valid_gist_id(gid):
+                continue
+            try:
+                mtime = os.path.getmtime(path)
+            except OSError:
+                mtime = 0.0
+            found[gid] = max(found.get(gid, 0.0), mtime)
+    return list(found.items())
+
+
+def _git_gist_snapshot(gist_id: str) -> Optional[dict]:
+    """Read a gist through the git endpoint, bypassing gh REST listing.
+
+    `git clone https://gist.github.com/<id>.git` has been reachable in
+    the same failures where `gh api /gists` is throttled or confused by
+    invalid env auth. We only use it for candidate ids already found in
+    local config, not for global discovery.
+    """
+    if not _valid_gist_id(gist_id) or shutil.which("git") is None:
+        return None
+    tmpdir = tempfile.mkdtemp(prefix="airc-gist-snapshot-")
+    try:
+        r = subprocess.run(
+            [
+                "git",
+                "-c",
+                "credential.helper=",
+                "clone",
+                "--quiet",
+                "--depth",
+                "1",
+                f"https://gist.github.com/{gist_id}.git",
+                tmpdir,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_GH_API_TIMEOUT,
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+        )
+        if r.returncode != 0:
+            return None
+        files: dict[str, dict] = {}
+        for name in os.listdir(tmpdir):
+            path = os.path.join(tmpdir, name)
+            if name == ".git" or not os.path.isfile(path):
+                continue
+            try:
+                with open(path, encoding="utf-8") as f:
+                    files[name] = {"content": f.read(), "truncated": False}
+            except OSError:
+                continue
+        if not files:
+            return None
+        desc = "airc mesh"
+        for name in files:
+            if name.startswith("airc-room-") and name.endswith(".json"):
+                room = name[len("airc-room-"):-len(".json")]
+                desc = f"airc room: #{room} (git fallback)"
+                break
+        return {"id": gist_id, "description": desc, "files": files}
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _choose_local_fallback(matches: list[tuple[dict, float]], channel: str, require_invite: bool) -> Optional[str]:
+    if not matches:
+        return None
+
+    def rank(item: tuple[dict, float]) -> tuple[int, float, float, str]:
+        gist, local_mtime = item
+        if _strict_single_channel_match(gist, channel, require_invite=require_invite):
+            tier = 3
+        elif _is_single_channel_match(gist, channel, require_invite=require_invite):
+            tier = 2
+        elif _gist_describes_channel(gist, channel, require_invite=require_invite):
+            tier = 1
+        else:
+            tier = 0
+        return (tier, _gist_activity_ts(gist), local_mtime, gist.get("id", ""))
+
+    valid = [item for item in matches if rank(item)[0] > 0]
+    if not valid:
+        return None
+    valid.sort(key=rank, reverse=True)
+    return valid[0][0].get("id")
+
+
+def _find_existing_via_local_cache(channel: str, require_invite: bool = False) -> Optional[str]:
+    if os.environ.get("AIRC_DISABLE_LOCAL_GIST_FALLBACK") == "1":
+        return None
+    snapshots: list[tuple[dict, float]] = []
+    for gid, local_mtime in _local_config_gist_candidates(channel):
+        snapshot = _git_gist_snapshot(gid)
+        if snapshot is None:
+            continue
+        snapshots.append((snapshot, local_mtime))
+    return _choose_local_fallback(snapshots, channel, require_invite)
 
 
 def _is_single_channel_match(gist: dict, channel: str, require_invite: bool = False) -> bool:
@@ -294,7 +544,11 @@ def find_existing(channel: str, require_invite: bool = False) -> Optional[str]:
         if _gist_describes_channel(full, channel, require_invite=require_invite):
             full.setdefault("created_at", g.get("created_at", ""))
             deep_legacy.append(full)
-    return _oldest(deep_legacy)
+    chosen = _oldest(deep_legacy)
+    if chosen:
+        return chosen
+
+    return _find_existing_via_local_cache(channel, require_invite=require_invite)
 
 
 def create_new(channel: str) -> Optional[str]:

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -1126,28 +1126,31 @@ class ResolverOrderTests(unittest.TestCase):
 
 
 class GhBearerCanServeTests(unittest.TestCase):
-    """Phase 3b: GhBearer.can_serve must require BOTH room_gist_id
-    AND a working gh auth. Either alone is insufficient — gist id with
-    no auth means we can't actually read/write; auth with no gist id
-    means we have nowhere to send to."""
+    """GhBearer.can_serve is metadata-only.
+
+    Auth/rate/network failures are transport outcomes from send/recv,
+    not resolver gating. Otherwise a bad GH_TOKEN turns a valid
+    room_gist_id into "no registered bearer can serve" and hides the
+    real failure class from users and retry logic.
+    """
 
     def test_serves_with_gist_id_and_gh_auth(self):
-        with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=True):
+        with mock.patch.object(bearer_gh, "_has_gh_auth", side_effect=AssertionError("can_serve must not probe gh auth")):
             self.assertTrue(GhBearer.can_serve({"room_gist_id": "abc123"}))
 
     def test_rejects_without_gist_id(self):
-        with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=True):
+        with mock.patch.object(bearer_gh, "_has_gh_auth", side_effect=AssertionError("can_serve must not probe gh auth")):
             self.assertFalse(GhBearer.can_serve({}))
             self.assertFalse(GhBearer.can_serve({"room_gist_id": ""}))
 
-    def test_rejects_without_gh_auth(self):
+    def test_serves_even_when_gh_auth_probe_would_fail(self):
         with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=False):
-            self.assertFalse(GhBearer.can_serve({"room_gist_id": "abc123"}))
+            self.assertTrue(GhBearer.can_serve({"room_gist_id": "abc123"}))
 
     def test_can_serve_does_not_mutate_meta(self):
         meta = {"room_gist_id": "abc123"}
         before = dict(meta)
-        with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=True):
+        with mock.patch.object(bearer_gh, "_has_gh_auth", side_effect=AssertionError("can_serve must not probe gh auth")):
             GhBearer.can_serve(meta)
         self.assertEqual(meta, before)
 
@@ -1702,16 +1705,16 @@ class ResolverPostPhase3cPlusTests(unittest.TestCase):
         self.assertNotIn("local", kinds)
 
     def test_gh_picked_when_only_room_gist_id(self):
-        # peer_meta has only room_gist_id + gh auth available → GhBearer.
-        with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=True):
+        # peer_meta has only room_gist_id → GhBearer. Actual auth is
+        # classified by the bearer operation, not by resolver selection.
+        with mock.patch.object(bearer_gh, "_has_gh_auth", side_effect=AssertionError("resolver must not probe gh auth")):
             bearer = resolve({"room_gist_id": "abc123"})
         self.assertEqual(bearer.KIND, "gh")
 
-    def test_unreachable_when_no_gh_auth(self):
-        # Without gh auth, nothing can serve.
+    def test_gh_still_picked_when_auth_probe_would_fail(self):
         with mock.patch.object(bearer_gh, "_has_gh_auth", return_value=False):
-            with self.assertRaises(PeerUnreachable):
-                resolve({"room_gist_id": "abc123"})
+            bearer = resolve({"room_gist_id": "abc123"})
+        self.assertEqual(bearer.KIND, "gh")
 
 
 if __name__ == "__main__":

--- a/test/test_channel_gist.py
+++ b/test/test_channel_gist.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import sys
 import json
+import os
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -88,7 +90,8 @@ class FindExistingConvergenceTests(unittest.TestCase):
                          "canonical (single-channel) priority overrides legacy oldest")
 
     def test_returns_none_when_no_match(self):
-        with mock.patch.object(channel_gist, "_gh_list_user_gists", return_value=[]):
+        with mock.patch.object(channel_gist, "_gh_list_user_gists", return_value=[]), \
+             mock.patch.object(channel_gist, "_find_existing_via_local_cache", return_value=None):
             self.assertIsNone(channel_gist.find_existing("nonexistent"))
 
     def test_require_invite_skips_seed_only_channel_gist(self):
@@ -130,6 +133,77 @@ class FindExistingConvergenceTests(unittest.TestCase):
                                return_value=[m_new, m_old]):
             chosen = channel_gist.find_existing("general")
         self.assertEqual(chosen, "mesh-old")
+
+
+class LocalCacheFallbackTests(unittest.TestCase):
+    """REST listing failures must not force a new solo room.
+
+    The fallback starts from locally remembered channel_gists, validates
+    those ids through the gist git endpoint, then chooses the best
+    recoverable room from wire evidence.
+    """
+
+    def _write_cfg(self, root: str, name: str, channel: str, gid: str) -> None:
+        airc = Path(root) / name / ".airc"
+        airc.mkdir(parents=True)
+        (airc / "config.json").write_text(
+            json.dumps({"channel_gists": {channel: gid}}),
+            encoding="utf-8",
+        )
+
+    def _snapshot(self, gid: str, channel: str, channels: list[str], ts: str, desc: str | None = None) -> dict:
+        return {
+            "id": gid,
+            "description": desc or f"airc room: #{channel} (git fallback)",
+            "files": {
+                f"airc-room-{channel}.json": {
+                    "content": json.dumps({
+                        "airc": 1,
+                        "kind": "mesh",
+                        "channels": channels,
+                        "last_heartbeat": ts,
+                    }),
+                    "truncated": False,
+                },
+                "messages.jsonl": {
+                    "content": json.dumps({"ts": ts, "from": "test", "msg": "marker"}) + "\n",
+                    "truncated": False,
+                },
+            },
+        }
+
+    def test_rest_miss_uses_local_git_cache_and_rejects_newer_multi_channel_island(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            stale = "aaaaaaaa"
+            current = "bbbbbbbb"
+            island = "cccccccc"
+            self._write_cfg(tmp, "old-worktree", "general", stale)
+            self._write_cfg(tmp, "current-worktree", "general", current)
+            self._write_cfg(tmp, "solo-island", "general", island)
+            snapshots = {
+                stale: self._snapshot(stale, "general", ["general"], "2026-04-30T12:00:00Z"),
+                current: self._snapshot(current, "general", ["general"], "2026-05-04T18:11:00Z"),
+                island: self._snapshot(island, "general", ["general", "cambriantech"], "2026-05-04T18:27:00Z"),
+            }
+            with mock.patch.dict(os.environ, {"AIRC_GIST_CACHE_ROOTS": tmp, "AIRC_DISABLE_LOCAL_GIST_FALLBACK": ""}), \
+                 mock.patch.object(channel_gist, "_gh_list_user_gists", return_value=[]), \
+                 mock.patch.object(channel_gist, "_git_gist_snapshot", side_effect=lambda gid: snapshots.get(gid)):
+                self.assertEqual(channel_gist.find_existing("general"), current)
+
+    def test_local_fallback_picks_recent_matching_multi_channel_when_no_strict_room_exists(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old = "dddddddd"
+            current = "eeeeeeee"
+            self._write_cfg(tmp, "old", "cambriantech", old)
+            self._write_cfg(tmp, "current", "cambriantech", current)
+            snapshots = {
+                old: self._snapshot(old, "cambriantech", ["cambriantech", "general"], "2026-05-04T17:40:00Z"),
+                current: self._snapshot(current, "cambriantech", ["cambriantech", "general"], "2026-05-04T18:22:49Z"),
+            }
+            with mock.patch.dict(os.environ, {"AIRC_GIST_CACHE_ROOTS": tmp, "AIRC_DISABLE_LOCAL_GIST_FALLBACK": ""}), \
+                 mock.patch.object(channel_gist, "_gh_list_user_gists", return_value=[]), \
+                 mock.patch.object(channel_gist, "_git_gist_snapshot", side_effect=lambda gid: snapshots.get(gid)):
+                self.assertEqual(channel_gist.find_existing("cambriantech"), current)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a local channel_gists cache fallback for channel_gist.find_existing when gh REST listing/deep GET returns no candidates
- validate remembered gist ids through the gist git endpoint and rank by strict per-channel shape plus wire activity, so a newer solo/multi-channel island does not beat the live #general chain
- make GhBearer.can_serve metadata-only so a poisoned GH_TOKEN no longer surfaces as 'no registered bearer can serve'; auth/rate/network failures are classified by send/recv instead

## Live failure this targets
- gh REST listing/auth state was unreliable while git clone https://gist.github.com/<id>.git still worked
- continuum had #general mapped to a newer solo island while other scopes remembered the active #general gist
- sends failed with resolver error: no registered bearer can serve peer_meta={'room_gist_id': ...}; available kinds: ['gh']

## Tests
- python3 test/test_channel_gist.py
- python3 test/test_bearer.py
- python3 -m py_compile lib/airc_core/channel_gist.py lib/airc_core/bearer_gh.py test/test_channel_gist.py test/test_bearer.py
- bash test/integration.sh monitor_liveness_process_evidence

## Notes
This is a recovery/control-plane hardening PR, not the final data-plane rewrite. The next production-design step is to move same-machine/LAN message traffic off GitHub/gist writes and keep GitHub as rendezvous/control only.