### PR TITLE
Fix collaboration health and bearer gist rotation

### DIFF
--- a/airc
+++ b/airc
@@ -1393,12 +1393,19 @@ _monitor_multi_channel() {
           for entry in "${_pids[@]}"; do
             pid="${entry%%:*}"
             ch="${entry#*:}"
-            if printf '%s\n' "$_current_map" | awk -F '\t' -v c="$ch" '$1 == c {found=1} END {exit found ? 0 : 1}'; then
-              _kept+=("$entry")
-            else
+            local _mapped_gid
+            _mapped_gid=$(printf '%s\n' "$_current_map" | awk -F '\t' -v c="$ch" '$1 == c {print $2; exit}')
+            if [ -z "$_mapped_gid" ]; then
               echo "airc: #${ch} removed from channel_gists; stopping its bearer while other channels continue" >&2
               kill "$pid" 2>/dev/null || true
+              continue
             fi
+            if ! ps -p "$pid" -o command= 2>/dev/null | grep -q -- "--room-gist-id ${_mapped_gid}"; then
+              echo "airc: #${ch} channel_gists changed; rotating bearer to ${_mapped_gid} without full monitor restart" >&2
+              kill "$pid" 2>/dev/null || true
+              continue
+            fi
+            _kept+=("$entry")
           done
           _pids=("${_kept[@]}")
 

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -548,9 +548,13 @@ _doctor_health() {
     peer_count=$(find "$PEERS_DIR" -maxdepth 1 -name '*.json' -type f 2>/dev/null | wc -l | tr -d ' ')
   fi
   if [ "${peer_count:-0}" -eq 0 ] 2>/dev/null; then
-    printf "  [BLOCKED] collaboration mesh has 0 peer records — local transport may be alive, but this is a solo island\n"
-    printf "         Check: airc peers; ask peers to run 'airc update --channel canary && airc connect <current invite>'\n"
-    issues=$((issues+1))
+    local _collab_rc=0
+    "$AIRC_PYTHON" -m airc_core.collaboration doctor \
+      --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" || _collab_rc=$?
+    case "$_collab_rc" in
+      1) warns=$((warns+1)) ;;
+      2) issues=$((issues+1)) ;;
+    esac
   else
     printf "  [ok] collaboration mesh has %s peer record(s)\n" "$peer_count"
   fi

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -567,12 +567,38 @@ else:
   # is what was missing when "5 peers earlier today, 1 now" looked
   # identical to "5 peers, all silent for 30 min" in the listing —
   # silent records persist on disk regardless of liveness.
+  if ! find "$PEERS_DIR" -maxdepth 1 -name '*.json' -type f 2>/dev/null | grep -q .; then
+    "$AIRC_PYTHON" -m airc_core.collaboration peers-fallback \
+      --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" && return
+    echo "  No peers yet."
+    return
+  fi
+
   "$AIRC_PYTHON" -c "
 import json, os, sys, time, calendar
 
 primary_scope = os.path.expanduser('$AIRC_WRITE_DIR')
 peers_dir = os.path.join(primary_scope, 'peers')
 messages_log = os.path.join(primary_scope, 'messages.jsonl')
+
+def _epoch(ts_str):
+    if not ts_str:
+        return None
+    try:
+        t = time.strptime(ts_str.replace('Z',''), '%Y-%m-%dT%H:%M:%S')
+        return calendar.timegm(t)
+    except Exception:
+        return None
+
+now = int(time.time())
+def _fmt_age(ts):
+    if ts is None:
+        return 'never'
+    age = max(0, now - ts)
+    if age < 60:    return f'{age}s ago'
+    if age < 3600:  return f'{age // 60}m ago'
+    if age < 86400: return f'{age // 3600}h ago'
+    return f'{age // 86400}d ago'
 
 if not os.path.isdir(peers_dir):
     print('  No peers yet.')
@@ -604,14 +630,6 @@ if not peers_by_id:
 # default), so the scan cost is bounded and we get the most recent
 # ts naturally as the loop terminates.
 last_seen = {}
-def _epoch(ts_str):
-    if not ts_str:
-        return None
-    try:
-        t = time.strptime(ts_str.replace('Z',''), '%Y-%m-%dT%H:%M:%S')
-        return calendar.timegm(t)
-    except Exception:
-        return None
 try:
     with open(messages_log) as f:
         for line in f:
@@ -628,16 +646,6 @@ try:
                 last_seen[who] = ts
 except OSError:
     pass
-
-now = int(time.time())
-def _fmt_age(ts):
-    if ts is None:
-        return 'never'
-    age = max(0, now - ts)
-    if age < 60:    return f'{age}s ago'
-    if age < 3600:  return f'{age // 60}m ago'
-    if age < 86400: return f'{age // 3600}h ago'
-    return f'{age // 86400}d ago'
 
 # Render. Each peer once, with room annotations + last-seen marker.
 # Silent >1h gets a (silent) flag so the eye catches it immediately.

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -676,7 +676,8 @@ cmd_send() {
       _peer_count=$(find "$PEERS_DIR" -maxdepth 1 -name '*.json' -type f 2>/dev/null | wc -l | tr -d ' ')
     fi
     if [ "${_peer_count:-0}" -eq 0 ] 2>/dev/null; then
-      echo "  ⚠ collaboration: 0 peer records in this scope; this may be a solo mesh. Run 'airc peers' and verify others joined this gist." >&2
+      "$AIRC_PYTHON" -m airc_core.collaboration send-warning \
+        --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" 2>/dev/null || true
     fi
   fi
 }

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -176,73 +176,8 @@ _airc_collaboration_health_report() {
   # Local transport health is not the same as collaboration health. A
   # self-healed host can have fresh bearer heartbeats while nobody else is
   # paired to this mesh. Surface that split-brain shape explicitly.
-  AIRC_STATUS_HOME="$AIRC_WRITE_DIR" AIRC_STATUS_MY_NAME="$(get_name)" "$AIRC_PYTHON" - <<'PY'
-import calendar, json, os, sys, time
-
-home = os.environ.get("AIRC_STATUS_HOME", "")
-my_name = os.environ.get("AIRC_STATUS_MY_NAME", "")
-peers_dir = os.path.join(home, "peers")
-messages_log = os.path.join(home, "messages.jsonl")
-now = int(time.time())
-
-peer_records = 0
-if os.path.isdir(peers_dir):
-    for entry in os.listdir(peers_dir):
-        if not entry.endswith(".json"):
-            continue
-        try:
-            json.load(open(os.path.join(peers_dir, entry)))
-        except Exception:
-            continue
-        peer_records += 1
-
-last_remote = None
-last_remote_name = None
-def epoch(ts):
-    if not ts:
-        return None
-    try:
-        return calendar.timegm(time.strptime(ts.replace("Z", ""), "%Y-%m-%dT%H:%M:%S"))
-    except Exception:
-        return None
-
-try:
-    with open(messages_log) as f:
-        for line in f:
-            try:
-                msg = json.loads(line)
-            except Exception:
-                continue
-            sender = msg.get("from")
-            if not sender or sender in (my_name, "airc"):
-                continue
-            ts = epoch(msg.get("ts"))
-            if ts is None:
-                continue
-            if last_remote is None or ts > last_remote:
-                last_remote = ts
-                last_remote_name = sender
-except OSError:
-    pass
-
-if last_remote is None:
-    remote_desc = "no remote messages recorded"
-    remote_recent = False
-else:
-    age = max(0, now - last_remote)
-    remote_desc = f"last remote message {age}s ago from {last_remote_name}"
-    remote_recent = age < 600
-
-if peer_records == 0:
-    if remote_recent:
-        print(f"  collaboration: DEGRADED (0 peer records; {remote_desc})")
-        print("    DMs/whois/peer targeting may be broken; verify everyone is on the same gist with 'airc peers' and 'airc invite'.")
-    else:
-        print(f"  collaboration: SOLO (0 peer records; {remote_desc})")
-        print("    Sends may only land in this local/self-hosted gist until another agent joins this exact mesh.")
-else:
-    print(f"  collaboration: ok ({peer_records} peer record(s); {remote_desc})")
-PY
+  "$AIRC_PYTHON" -m airc_core.collaboration status \
+    --home "$AIRC_WRITE_DIR" --my-name "$(get_name)"
 }
 
 cmd_status() {

--- a/lib/airc_core/collaboration.py
+++ b/lib/airc_core/collaboration.py
@@ -1,0 +1,209 @@
+"""Collaboration health helpers.
+
+Keep peer-record and recent-traffic interpretation out of bash. Shell
+callers should ask this module for the user-facing lines instead of
+embedding Python snippets inline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import calendar
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+
+RECENT_REMOTE_WINDOW_SEC = 600
+
+
+@dataclass(frozen=True)
+class RemoteActivity:
+    name: str
+    ts: int
+
+
+def _epoch(ts: object) -> Optional[int]:
+    if not isinstance(ts, str) or not ts:
+        return None
+    try:
+        return calendar.timegm(time.strptime(ts.replace("Z", ""), "%Y-%m-%dT%H:%M:%S"))
+    except Exception:
+        return None
+
+
+def _fmt_age(ts: Optional[int], now: Optional[int] = None) -> str:
+    if ts is None:
+        return "never"
+    if now is None:
+        now = int(time.time())
+    age = max(0, now - ts)
+    if age < 60:
+        return f"{age}s ago"
+    if age < 3600:
+        return f"{age // 60}m ago"
+    if age < 86400:
+        return f"{age // 3600}h ago"
+    return f"{age // 86400}d ago"
+
+
+def peer_record_count(home: str) -> int:
+    peers_dir = os.path.join(home, "peers")
+    if not os.path.isdir(peers_dir):
+        return 0
+    count = 0
+    for entry in os.listdir(peers_dir):
+        if not entry.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(peers_dir, entry), encoding="utf-8") as f:
+                json.load(f)
+        except Exception:
+            continue
+        count += 1
+    return count
+
+
+def recent_remote_activity(home: str, my_name: str, window_sec: int = RECENT_REMOTE_WINDOW_SEC) -> Optional[RemoteActivity]:
+    messages_log = os.path.join(home, "messages.jsonl")
+    now = int(time.time())
+    last: Optional[RemoteActivity] = None
+    try:
+        with open(messages_log, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    msg = json.loads(line)
+                except Exception:
+                    continue
+                sender = msg.get("from")
+                if not sender or sender in (my_name, "airc"):
+                    continue
+                ts = _epoch(msg.get("ts"))
+                if ts is None:
+                    continue
+                if now - ts >= window_sec:
+                    continue
+                if last is None or ts > last.ts:
+                    last = RemoteActivity(str(sender), ts)
+    except OSError:
+        pass
+    return last
+
+
+def recent_remote_speakers(home: str, my_name: str, window_sec: int = RECENT_REMOTE_WINDOW_SEC) -> dict[str, int]:
+    messages_log = os.path.join(home, "messages.jsonl")
+    now = int(time.time())
+    speakers: dict[str, int] = {}
+    try:
+        with open(messages_log, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    msg = json.loads(line)
+                except Exception:
+                    continue
+                sender = msg.get("from")
+                if not sender or sender in (my_name, "airc"):
+                    continue
+                ts = _epoch(msg.get("ts"))
+                if ts is None or now - ts >= window_sec:
+                    continue
+                speakers[str(sender)] = max(speakers.get(str(sender), 0), ts)
+    except OSError:
+        pass
+    return speakers
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    count = peer_record_count(args.home)
+    recent = recent_remote_activity(args.home, args.my_name)
+    now = int(time.time())
+    if recent is None:
+        remote_desc = "no remote messages recorded"
+    else:
+        remote_desc = f"last remote message {max(0, now - recent.ts)}s ago from {recent.name}"
+
+    if count == 0:
+        if recent is not None:
+            print(f"  collaboration: DEGRADED (0 peer records; {remote_desc})")
+            print("    DMs/whois/peer targeting may be broken; broadcast traffic is flowing.")
+        else:
+            print(f"  collaboration: SOLO (0 peer records; {remote_desc})")
+            print("    Sends may only land in this local/self-hosted gist until another agent joins this exact mesh.")
+    else:
+        print(f"  collaboration: ok ({count} peer record(s); {remote_desc})")
+    return 0
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    count = peer_record_count(args.home)
+    recent = recent_remote_activity(args.home, args.my_name)
+    now = int(time.time())
+    if count > 0:
+        print(f"  [ok] collaboration mesh has {count} peer record(s)")
+        return 0
+    if recent is not None:
+        print(
+            f"  [WARN] collaboration mesh has 0 peer records, but remote traffic arrived "
+            f"{max(0, now - recent.ts)}s ago from {recent.name}"
+        )
+        print("         Peer metadata is degraded (DMs/whois may fail), but this is NOT a solo island.")
+        return 1
+    print("  [BLOCKED] collaboration mesh has 0 peer records — local transport may be alive, but this is a solo island")
+    print("         Check: airc peers; ask peers to run 'airc update --channel canary && airc connect <current invite>'")
+    return 2
+
+
+def cmd_send_warning(args: argparse.Namespace) -> int:
+    if peer_record_count(args.home) > 0:
+        return 0
+    recent = recent_remote_activity(args.home, args.my_name)
+    now = int(time.time())
+    if recent is not None:
+        print(
+            f"  ⚠ collaboration: 0 peer records, but remote traffic arrived "
+            f"{max(0, now - recent.ts)}s ago from {recent.name}; peer metadata degraded, bus is not solo.",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "  ⚠ collaboration: 0 peer records in this scope; this may be a solo mesh. "
+            "Run 'airc peers' and verify others joined this gist.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def cmd_peers_fallback(args: argparse.Namespace) -> int:
+    speakers = recent_remote_speakers(args.home, args.my_name)
+    if not speakers:
+        return 1
+    print("  No peer records yet, but recent remote traffic is visible:")
+    for who, ts in sorted(speakers.items(), key=lambda kv: kv[1], reverse=True):
+        print(f"  {who} → (broadcast-only)   [(from messages.jsonl)]   last seen {_fmt_age(ts)}")
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="airc_core.collaboration")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    for name in ("status", "doctor", "send-warning", "peers-fallback"):
+        p = sub.add_parser(name)
+        p.add_argument("--home", required=True)
+        p.add_argument("--my-name", default="")
+    args = parser.parse_args(argv)
+    if args.cmd == "status":
+        return cmd_status(args)
+    if args.cmd == "doctor":
+        return cmd_doctor(args)
+    if args.cmd == "send-warning":
+        return cmd_send_warning(args)
+    if args.cmd == "peers-fallback":
+        return cmd_peers_fallback(args)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2123,6 +2123,24 @@ JSON
     && pass "doctor summary is degraded, not clean healthy" \
     || fail "doctor summary still looked clean ($doctor_out)"
 
+  printf '{"from":"remote-agent","to":"all","ts":"%s","channel":"general","msg":"recent remote proof"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$home/messages.jsonl"
+
+  status_out=$(AIRC_HOME="$home" "$AIRC" status 2>&1)
+  echo "$status_out" | grep -q 'collaboration: DEGRADED (0 peer records; last remote message' \
+    && pass "status reports DEGRADED, not SOLO, when recent remote traffic exists" \
+    || fail "status did not distinguish recent remote traffic from solo island ($status_out)"
+
+  doctor_out=$(AIRC_HOME="$home" "$AIRC" doctor --health 2>&1)
+  echo "$doctor_out" | grep -q 'remote traffic arrived' \
+    && pass "doctor --health reports peer metadata degraded when traffic proves bus is not solo" \
+    || fail "doctor --health still treated recent remote traffic as solo ($doctor_out)"
+
+  peers_out=$(AIRC_HOME="$home" "$AIRC" peers 2>&1)
+  echo "$peers_out" | grep -q 'remote-agent → (broadcast-only)' \
+    && pass "airc peers falls back to recent broadcast-only traffic" \
+    || fail "airc peers hid recent remote traffic when peer records were empty ($peers_out)"
+
   rm -rf /tmp/airc-it-solo
   cleanup_all
 }

--- a/test/test_collaboration.py
+++ b/test/test_collaboration.py
@@ -1,0 +1,94 @@
+"""collaboration health tests.
+
+Run: cd test && python3 test_collaboration.py
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+from airc_core import collaboration  # noqa: E402
+
+
+class CollaborationHealthTests(unittest.TestCase):
+    def _scope(self):
+        tmp = tempfile.TemporaryDirectory()
+        home = Path(tmp.name)
+        (home / "peers").mkdir()
+        return tmp, home
+
+    def _remote_line(self, sender="remote-agent"):
+        return json.dumps({
+            "from": sender,
+            "to": "all",
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "channel": "general",
+            "msg": "hello",
+        }) + "\n"
+
+    def test_status_solo_without_records_or_remote_traffic(self):
+        tmp, home = self._scope()
+        with tmp:
+            out = io.StringIO()
+            with redirect_stdout(out):
+                rc = collaboration.main(["status", "--home", str(home), "--my-name", "me"])
+            self.assertEqual(rc, 0)
+            self.assertIn("collaboration: SOLO", out.getvalue())
+
+    def test_status_degraded_when_recent_remote_traffic_exists(self):
+        tmp, home = self._scope()
+        with tmp:
+            (home / "messages.jsonl").write_text(self._remote_line(), encoding="utf-8")
+            out = io.StringIO()
+            with redirect_stdout(out):
+                rc = collaboration.main(["status", "--home", str(home), "--my-name", "me"])
+            self.assertEqual(rc, 0)
+            text = out.getvalue()
+            self.assertIn("collaboration: DEGRADED", text)
+            self.assertNotIn("collaboration: SOLO", text)
+
+    def test_doctor_warns_not_blocks_when_remote_traffic_exists(self):
+        tmp, home = self._scope()
+        with tmp:
+            (home / "messages.jsonl").write_text(self._remote_line(), encoding="utf-8")
+            out = io.StringIO()
+            with redirect_stdout(out):
+                rc = collaboration.main(["doctor", "--home", str(home), "--my-name", "me"])
+            self.assertEqual(rc, 1)
+            self.assertIn("remote traffic arrived", out.getvalue())
+
+    def test_send_warning_says_not_solo_when_remote_traffic_exists(self):
+        tmp, home = self._scope()
+        with tmp:
+            (home / "messages.jsonl").write_text(self._remote_line(), encoding="utf-8")
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = collaboration.main(["send-warning", "--home", str(home), "--my-name", "me"])
+            self.assertEqual(rc, 0)
+            self.assertIn("bus is not solo", err.getvalue())
+
+    def test_peers_fallback_lists_recent_broadcast_speaker(self):
+        tmp, home = self._scope()
+        with tmp:
+            os.rmdir(home / "peers")
+            (home / "messages.jsonl").write_text(self._remote_line(), encoding="utf-8")
+            out = io.StringIO()
+            with redirect_stdout(out):
+                rc = collaboration.main(["peers-fallback", "--home", str(home), "--my-name", "me"])
+            self.assertEqual(rc, 0)
+            self.assertIn("remote-agent", out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- rotate a running channel bearer when channel_gists changes from one gist id to another, instead of only reacting to channel add/remove
- move collaboration health interpretation into airc_core.collaboration.py; shell invokes the module instead of embedding Python bodies
- make status/doctor/send/peers distinguish a true solo island from 0 peer records with recent remote broadcast traffic

## Validation findings that drove this
- after #472, continuum config mapped #general to canonical c68640..., but the running monitor kept polling stale solo gist 2d3b2... because _monitor_multi_channel never compared the live bearer gist against the refreshed mapping
- vhsm and continuum proved bidirectional broadcast delivery, but peer records stayed empty; reporting that as SOLO was false and made the bus look worse/different than it was
- GitHub rate limiting still blocks the hot path; this PR does not claim to solve that architecture problem

## Tests
- python3 test/test_collaboration.py
- python3 test/test_channel_gist.py
- python3 -m py_compile lib/airc_core/collaboration.py
- bash -n airc lib/airc_bash/cmd_doctor.sh lib/airc_bash/cmd_rooms.sh lib/airc_bash/cmd_send.sh lib/airc_bash/cmd_status.sh test/integration.sh
- bash test/integration.sh solo_mesh_warns

## Not the final fix
A true production fix still needs GitHub moved out of the hot message path. Solo mesh must remain a failure state, not a fallback.