### PR TITLE
Add local bus fallback for gh rooms

### DIFF
--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -60,6 +60,8 @@ _GH_BIN = "gh"
 _MESSAGES_FILE = "messages.jsonl"
 _DEFAULT_POLL_INTERVAL = 15.0  # seconds; tuned for gh rate limit headroom
 _GH_API_TIMEOUT = 10.0          # per-call seconds; total wall time bounded by retry policy
+_LOCAL_BUS_ROOT_ENV = "AIRC_LOCAL_BUS_DIR"
+_DISABLE_LOCAL_BUS_ENV = "AIRC_DISABLE_LOCAL_BUS"
 
 # Rotation thresholds (gh hard limit on a gist file is 1MB; we trim
 # proactively well before that so the next append always has headroom).
@@ -72,6 +74,55 @@ _GH_API_TIMEOUT = 10.0          # per-call seconds; total wall time bounded by r
 # AIRC_GIST_KEEP_LINES) for tests + power users.
 _GIST_MAX_BYTES = 600_000   # rotate at 600KB (40% headroom under 1MB hard limit)
 _GIST_KEEP_LINES = 1000     # keep last 1000 lines after rotation
+
+
+def _safe_gist_id(gist_id: str) -> str:
+    return "".join(c if c.isalnum() else "_" for c in str(gist_id))
+
+
+def _local_bus_enabled(peer_meta: Optional[dict] = None) -> bool:
+    if os.environ.get(_DISABLE_LOCAL_BUS_ENV) == "1":
+        return False
+    if peer_meta and peer_meta.get("disable_local_bus"):
+        return False
+    return True
+
+
+def _local_bus_path(gist_id: str, peer_meta: Optional[dict] = None) -> Optional[str]:
+    if not gist_id or not _local_bus_enabled(peer_meta):
+        return None
+    root = os.environ.get(_LOCAL_BUS_ROOT_ENV)
+    if not root:
+        root = os.path.join(os.path.expanduser("~"), ".airc", "bus", "gh")
+    return os.path.join(root, _safe_gist_id(gist_id), _MESSAGES_FILE)
+
+
+def _local_bus_append(gist_id: str, line: str, peer_meta: Optional[dict] = None) -> tuple[bool, str]:
+    path = _local_bus_path(gist_id, peer_meta)
+    if not path:
+        return (False, "local bus disabled")
+    framed = line if line.endswith("\n") else line + "\n"
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            os.write(fd, framed.encode("utf-8"))
+        finally:
+            os.close(fd)
+    except OSError as e:
+        return (False, f"local bus append failed: {e}")
+    return (True, "")
+
+
+def _local_bus_read_lines(gist_id: str, peer_meta: Optional[dict] = None) -> list[str]:
+    path = _local_bus_path(gist_id, peer_meta)
+    if not path:
+        return []
+    try:
+        with open(path, encoding="utf-8") as f:
+            return f.read().splitlines()
+    except OSError:
+        return []
 
 
 def _resolve_gh_bin() -> str:
@@ -551,6 +602,8 @@ class GhBearer(Bearer):
         # Tracks how many lines of messages.jsonl we've already yielded.
         # Resumed from offset_file on first poll if available.
         self._consumed_lines: int = 0
+        self._local_consumed_lines: int = 0
+        self._seen_payloads: set[str] = set()
         # Polling cadence; can be overridden via peer_meta for tests.
         self._poll_interval: float = float(
             peer_meta.get("poll_interval", _DEFAULT_POLL_INTERVAL)
@@ -571,6 +624,7 @@ class GhBearer(Bearer):
         # doesn't reset to disk state mid-stream.
         offset_file = self._peer_meta.get("offset_file")
         self._consumed_lines = self._read_offset(offset_file)
+        self._local_consumed_lines = self._read_offset(self._local_offset_file(offset_file))
 
     def send(self, peer_id: str, channel: str, payload: bytes) -> SendOutcome:
         """Append `payload` to the room gist's messages.jsonl file with
@@ -618,6 +672,7 @@ class GhBearer(Bearer):
                 kind="transient_failure",
                 detail="payload is not utf-8; gh-bearer requires text envelopes",
             )
+        local_ok, local_detail = _local_bus_append(gist_id, framed_str, self._peer_meta)
 
         # Concurrency strategy: retry on BOTH explicit 409 conflicts
         # AND silent-clobber detected via verify-after-write. continuum-
@@ -642,6 +697,11 @@ class GhBearer(Bearer):
         for attempt in range(RETRIES):
             gist, get_kind = _gh_api_get_classified(gist_id)
             if gist is None:
+                if local_ok and get_kind in ("secondary_rate_limit", "transient_failure", "auth_failure"):
+                    return SendOutcome(
+                        kind="delivered",
+                        detail=f"delivered via local bus; gh publish deferred ({get_kind})",
+                    )
                 # GET failed — distinguish permanent (gone) / wait (rate)
                 # / re-auth (auth) / retry (transient). Old code coalesced
                 # all into transient_failure; new path propagates the
@@ -670,6 +730,11 @@ class GhBearer(Bearer):
                 if patch_kind == "conflict":
                     _time.sleep(_jittered_backoff(attempt))
                     continue
+                if local_ok and patch_kind in ("secondary_rate_limit", "transient_failure", "auth_failure"):
+                    return SendOutcome(
+                        kind="delivered",
+                        detail=f"delivered via local bus; gh publish deferred ({patch_kind})",
+                    )
                 # gone / secondary_rate_limit / auth_failure /
                 # transient_failure all propagate as-is.
                 return SendOutcome(kind=patch_kind, detail=detail)
@@ -690,9 +755,14 @@ class GhBearer(Bearer):
             last_detail = "verify-after-write: line not in gist post-PATCH (silent clobber)"
             _time.sleep(_jittered_backoff(attempt))
 
+        if local_ok:
+            return SendOutcome(
+                kind="delivered",
+                detail=f"delivered via local bus; gh conflict after {RETRIES} retries; last: {last_detail}",
+            )
         return SendOutcome(
             kind="transient_failure",
-            detail=f"concurrent-write conflict after {RETRIES} retries; last: {last_detail}",
+            detail=f"concurrent-write conflict after {RETRIES} retries; last: {last_detail}; local bus: {local_detail}",
         )
 
     def recv_stream(self) -> Iterator[ReceivedMessage]:
@@ -720,6 +790,10 @@ class GhBearer(Bearer):
         offset_file = self._peer_meta.get("offset_file")
 
         while not self._closed:
+            for msg in self._drain_local_bus(gist_id, offset_file):
+                yield msg
+                if self._closed:
+                    return
             gist = _gh_api_get(gist_id)
             if gist is None:
                 # Transient gh API failure. Sleep + retry. Caller's
@@ -745,9 +819,13 @@ class GhBearer(Bearer):
                 self._consumed_lines = len(lines)
                 self._on_line_received(self._consumed_lines, offset_file)
             for idx in range(self._consumed_lines, len(lines)):
-                raw = lines[idx].encode("utf-8")
+                line = lines[idx]
+                raw = line.encode("utf-8")
                 self._consumed_lines = idx + 1
                 self._on_line_received(self._consumed_lines, offset_file)
+                if line in self._seen_payloads:
+                    continue
+                self._seen_payloads.add(line)
                 msg = self._parse_envelope(raw)
                 if msg is None:
                     continue
@@ -757,6 +835,31 @@ class GhBearer(Bearer):
             if self._closed:
                 return
             self._sleep_or_break(self._poll_interval)
+
+    @staticmethod
+    def _local_offset_file(offset_file: Optional[str]) -> Optional[str]:
+        if not offset_file:
+            return None
+        return f"{offset_file}.local"
+
+    def _drain_local_bus(self, gist_id: str, offset_file: Optional[str]) -> Iterator[ReceivedMessage]:
+        lines = _local_bus_read_lines(gist_id, self._peer_meta)
+        local_offset = self._local_offset_file(offset_file)
+        if self._local_consumed_lines > len(lines):
+            self._local_consumed_lines = len(lines)
+            self._write_offset(local_offset, self._local_consumed_lines)
+        for idx in range(self._local_consumed_lines, len(lines)):
+            line = lines[idx]
+            self._local_consumed_lines = idx + 1
+            self._write_offset(local_offset, self._local_consumed_lines)
+            if line in self._seen_payloads:
+                continue
+            self._seen_payloads.add(line)
+            msg = self._parse_envelope(line.encode("utf-8"))
+            if msg is None:
+                continue
+            self._last_recv_ts = _time.time()
+            yield msg
 
     @staticmethod
     def _read_offset(offset_file: Optional[str]) -> int:
@@ -775,10 +878,8 @@ class GhBearer(Bearer):
         except ValueError:
             return 0
 
-    def _on_line_received(self, line_count: int, offset_file: Optional[str]) -> None:
-        """Bump last_recv_ts (for liveness) and persist offset (for resume).
-        Persistence failures are swallowed — the bearer keeps streaming."""
-        self._last_recv_ts = _time.time()
+    @staticmethod
+    def _write_offset(offset_file: Optional[str], line_count: int) -> None:
         if offset_file is None:
             return
         try:
@@ -786,6 +887,12 @@ class GhBearer(Bearer):
                 f.write(str(line_count))
         except OSError:
             pass
+
+    def _on_line_received(self, line_count: int, offset_file: Optional[str]) -> None:
+        """Bump last_recv_ts (for liveness) and persist offset (for resume).
+        Persistence failures are swallowed — the bearer keeps streaming."""
+        self._last_recv_ts = _time.time()
+        self._write_offset(offset_file, line_count)
 
     @staticmethod
     def _parse_envelope(raw_line: bytes) -> Optional[ReceivedMessage]:

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -8,7 +8,9 @@ or:  cd test && python -m unittest test_bearer
 from __future__ import annotations
 
 import argparse
+import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -1161,7 +1163,9 @@ class GhBearerSendTests(unittest.TestCase):
     (the write step) so no real gh API is touched."""
 
     def _bearer(self, meta=None):
-        m = meta or {"room_gist_id": "abc123"}
+        m = {"room_gist_id": "abc123", "disable_local_bus": True}
+        if meta:
+            m.update(meta)
         b = GhBearer(m)
         b.open("alice")
         return b
@@ -1318,7 +1322,9 @@ class GhBearerErrorClassificationTests(unittest.TestCase):
     recovery surface."""
 
     def _bearer(self, meta=None):
-        m = meta or {"room_gist_id": "abc123"}
+        m = {"room_gist_id": "abc123", "disable_local_bus": True}
+        if meta:
+            m.update(meta)
         b = GhBearer(m)
         b.open("alice")
         return b
@@ -1450,6 +1456,77 @@ class GhBearerErrorClassificationTests(unittest.TestCase):
         self.assertLess(max_observed, 50.0)
 
 
+class GhBearerLocalBusTests(unittest.TestCase):
+    """Same-machine fallback: gh room ids also address a local bus.
+
+    This is the production escape hatch for local agents when GitHub's
+    REST/gist path is throttled. GitHub remains the rendezvous/control
+    identity, but same-user processes on one machine can exchange the
+    signed envelope through a local append-only room log.
+    """
+
+    def _env(self, root):
+        return mock.patch.dict(os.environ, {"AIRC_LOCAL_BUS_DIR": root, "AIRC_DISABLE_LOCAL_BUS": ""})
+
+    def test_send_reports_delivered_when_gh_is_rate_limited_but_local_bus_wrote(self):
+        with tempfile.TemporaryDirectory() as tmp, self._env(tmp):
+            def _fake_get(_gist_id):
+                bearer_gh._gh_api_get._last_err = "gh: API rate limit exceeded (HTTP 403)"
+                return None
+
+            b = GhBearer({"room_gist_id": "abc123"})
+            b.open("alice")
+            with mock.patch.object(bearer_gh, "_gh_api_get", side_effect=_fake_get):
+                outcome = b.send("alice", "general", b'{"from":"me","channel":"general","msg":"local"}')
+
+            self.assertEqual(outcome.kind, "delivered")
+            self.assertIn("local bus", outcome.detail)
+            path = Path(tmp) / "abc123" / "messages.jsonl"
+            self.assertIn('"msg":"local"', path.read_text(encoding="utf-8"))
+
+    def test_recv_yields_local_bus_lines_when_gh_get_fails(self):
+        with tempfile.TemporaryDirectory() as tmp, self._env(tmp):
+            path = Path(tmp) / "abc123" / "messages.jsonl"
+            path.parent.mkdir(parents=True)
+            path.write_text('{"from":"local-peer","channel":"general","msg":"hi"}\n', encoding="utf-8")
+
+            b = GhBearer({"room_gist_id": "abc123", "poll_interval": 0})
+            b.open("alice")
+            with mock.patch.object(bearer_gh, "_gh_api_get", return_value=None):
+                events = []
+                for ev in b.recv_stream():
+                    events.append(ev)
+                    b.close()
+                    break
+
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0].sender_peer_id, "local-peer")
+            self.assertEqual(events[0].channel, "general")
+
+    def test_recv_dedupes_same_line_from_local_bus_and_gist(self):
+        line = '{"from":"peer","channel":"general","msg":"once"}'
+        with tempfile.TemporaryDirectory() as tmp, self._env(tmp):
+            path = Path(tmp) / "abc123" / "messages.jsonl"
+            path.parent.mkdir(parents=True)
+            path.write_text(line + "\n", encoding="utf-8")
+
+            b = GhBearer({"room_gist_id": "abc123", "poll_interval": 0})
+            b.open("alice")
+            second = '{"from":"peer","channel":"general","msg":"second"}'
+            with mock.patch.object(
+                bearer_gh, "_gh_api_get",
+                return_value={"files": {"messages.jsonl": {"content": line + "\n" + second + "\n"}}},
+            ):
+                events = []
+                for ev in b.recv_stream():
+                    events.append(ev)
+                    if len(events) >= 2:
+                        b.close()
+                        break
+
+            self.assertEqual([e.bearer_metadata["envelope"]["msg"] for e in events], ["once", "second"])
+
+
 class GhBearerRecvTests(unittest.TestCase):
     """GhBearer.recv_stream: poll the gist, yield new lines.
 
@@ -1458,7 +1535,9 @@ class GhBearerRecvTests(unittest.TestCase):
     15s default."""
 
     def _bearer(self, meta=None):
-        m = meta or {"room_gist_id": "abc123", "poll_interval": 0}
+        m = {"room_gist_id": "abc123", "poll_interval": 0, "disable_local_bus": True}
+        if meta:
+            m.update(meta)
         b = GhBearer(m)
         b.open("alice")
         return b


### PR DESCRIPTION
## Summary
- add a same-machine local append-only bus for gh room ids at ~/.airc/bus/gh/<room_gist_id>/messages.jsonl
- GhBearer.send writes the signed envelope to the local bus before attempting GitHub, and reports delivered for local agents when GitHub is transient/auth/rate limited
- GhBearer.recv_stream polls the local bus alongside the gist and dedupes identical lines when both paths eventually contain the same message

## Why
GitHub/gist is still useful as rendezvous/control, but it cannot be the only hot message path. Today we had active gh API 403 secondary-rate-limit failures while local agents on the same machine still needed to collaborate.

## Live validation
While gh GET/PATCH for c68640ec0144b422c16b2d8c83ad5ee5 was returning HTTP 403 rate-limit errors:
- continuum sent marker localbus-continuum-to-auth-1777923537
- marker appeared in ~/.airc/bus/gh/c68640ec0144b422c16b2d8c83ad5ee5/messages.jsonl
- authenticator received and mirrored it to /Users/joelteply/Development/ideem/authenticator/.airc/messages.jsonl
- authenticator ACKed; ACK appeared in continuum local log and same local bus

## Tests
- python3 test/test_bearer.py GhBearerLocalBusTests GhBearerSendTests GhBearerRecvTests GhBearerErrorClassificationTests
- python3 test/test_bearer.py
- python3 -m py_compile lib/airc_core/bearer_gh.py test/test_bearer.py

## Scope
This is a same-user/same-machine data-plane fallback. It does not solve LAN or cross-machine transport yet, but it stops local agents from being stranded by GitHub rate limits.