### PR TITLE
Harden local bus fallback

### DIFF
--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -39,6 +39,7 @@ import subprocess
 import sys
 import tempfile
 import time as _time
+from collections import deque
 from typing import Iterator, Optional, Tuple
 
 from .bearer import (
@@ -62,6 +63,8 @@ _DEFAULT_POLL_INTERVAL = 15.0  # seconds; tuned for gh rate limit headroom
 _GH_API_TIMEOUT = 10.0          # per-call seconds; total wall time bounded by retry policy
 _LOCAL_BUS_ROOT_ENV = "AIRC_LOCAL_BUS_DIR"
 _DISABLE_LOCAL_BUS_ENV = "AIRC_DISABLE_LOCAL_BUS"
+_SEEN_PAYLOAD_MAX = 5000
+_TRUTHY = {"1", "true", "yes", "on"}
 
 # Rotation thresholds (gh hard limit on a gist file is 1MB; we trim
 # proactively well before that so the next append always has headroom).
@@ -80,10 +83,18 @@ def _safe_gist_id(gist_id: str) -> str:
     return "".join(c if c.isalnum() else "_" for c in str(gist_id))
 
 
-def _local_bus_enabled(peer_meta: Optional[dict] = None) -> bool:
-    if os.environ.get(_DISABLE_LOCAL_BUS_ENV) == "1":
+def _truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
         return False
-    if peer_meta and peer_meta.get("disable_local_bus"):
+    return str(value).strip().lower() in _TRUTHY
+
+
+def _local_bus_enabled(peer_meta: Optional[dict] = None) -> bool:
+    if _truthy(os.environ.get(_DISABLE_LOCAL_BUS_ENV)):
+        return False
+    if peer_meta and _truthy(peer_meta.get("disable_local_bus")):
         return False
     return True
 
@@ -103,26 +114,51 @@ def _local_bus_append(gist_id: str, line: str, peer_meta: Optional[dict] = None)
         return (False, "local bus disabled")
     framed = line if line.endswith("\n") else line + "\n"
     try:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        directory = os.path.dirname(path)
+        os.makedirs(directory, mode=0o700, exist_ok=True)
+        try:
+            os.chmod(directory, 0o700)
+        except OSError:
+            pass
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
         try:
             os.write(fd, framed.encode("utf-8"))
         finally:
             os.close(fd)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
     except OSError as e:
         return (False, f"local bus append failed: {e}")
     return (True, "")
 
 
-def _local_bus_read_lines(gist_id: str, peer_meta: Optional[dict] = None) -> list[str]:
+def _local_bus_read_from(gist_id: str, byte_offset: int, peer_meta: Optional[dict] = None) -> tuple[list[str], int]:
     path = _local_bus_path(gist_id, peer_meta)
     if not path:
-        return []
+        return ([], byte_offset)
     try:
-        with open(path, encoding="utf-8") as f:
-            return f.read().splitlines()
+        size = os.path.getsize(path)
+        if byte_offset > size:
+            byte_offset = 0
+        with open(path, "rb") as f:
+            f.seek(byte_offset)
+            chunk = f.read()
     except OSError:
-        return []
+        return ([], byte_offset)
+    if not chunk:
+        return ([], byte_offset)
+    newline = chunk.rfind(b"\n")
+    if newline < 0:
+        return ([], byte_offset)
+    complete = chunk[: newline + 1]
+    new_offset = byte_offset + len(complete)
+    try:
+        text = complete.decode("utf-8")
+    except UnicodeDecodeError:
+        return ([], byte_offset)
+    return (text.splitlines(), new_offset)
 
 
 def _resolve_gh_bin() -> str:
@@ -599,11 +635,13 @@ class GhBearer(Bearer):
         self._opened_peer_id: Optional[str] = None
         self._closed = False
         self._last_recv_ts: Optional[float] = None
+        self._last_recv_source: Optional[str] = None
         # Tracks how many lines of messages.jsonl we've already yielded.
         # Resumed from offset_file on first poll if available.
         self._consumed_lines: int = 0
-        self._local_consumed_lines: int = 0
+        self._local_byte_offset: int = 0
         self._seen_payloads: set[str] = set()
+        self._seen_payload_order: deque[str] = deque()
         # Polling cadence; can be overridden via peer_meta for tests.
         self._poll_interval: float = float(
             peer_meta.get("poll_interval", _DEFAULT_POLL_INTERVAL)
@@ -624,7 +662,7 @@ class GhBearer(Bearer):
         # doesn't reset to disk state mid-stream.
         offset_file = self._peer_meta.get("offset_file")
         self._consumed_lines = self._read_offset(offset_file)
-        self._local_consumed_lines = self._read_offset(self._local_offset_file(offset_file))
+        self._local_byte_offset = self._read_offset(self._local_offset_file(offset_file))
 
     def send(self, peer_id: str, channel: str, payload: bytes) -> SendOutcome:
         """Append `payload` to the room gist's messages.jsonl file with
@@ -817,18 +855,18 @@ class GhBearer(Bearer):
             # picked up.
             if self._consumed_lines > len(lines):
                 self._consumed_lines = len(lines)
-                self._on_line_received(self._consumed_lines, offset_file)
+                self._write_offset(offset_file, self._consumed_lines)
             for idx in range(self._consumed_lines, len(lines)):
                 line = lines[idx]
                 raw = line.encode("utf-8")
                 self._consumed_lines = idx + 1
-                self._on_line_received(self._consumed_lines, offset_file)
-                if line in self._seen_payloads:
+                self._write_offset(offset_file, self._consumed_lines)
+                if self._seen(line):
                     continue
-                self._seen_payloads.add(line)
                 msg = self._parse_envelope(raw)
                 if msg is None:
                     continue
+                self._mark_received("gh poll")
                 yield msg
                 if self._closed:
                     return
@@ -840,26 +878,32 @@ class GhBearer(Bearer):
     def _local_offset_file(offset_file: Optional[str]) -> Optional[str]:
         if not offset_file:
             return None
-        return f"{offset_file}.local"
+        return f"{offset_file}.local.bytes"
 
     def _drain_local_bus(self, gist_id: str, offset_file: Optional[str]) -> Iterator[ReceivedMessage]:
-        lines = _local_bus_read_lines(gist_id, self._peer_meta)
         local_offset = self._local_offset_file(offset_file)
-        if self._local_consumed_lines > len(lines):
-            self._local_consumed_lines = len(lines)
-            self._write_offset(local_offset, self._local_consumed_lines)
-        for idx in range(self._local_consumed_lines, len(lines)):
-            line = lines[idx]
-            self._local_consumed_lines = idx + 1
-            self._write_offset(local_offset, self._local_consumed_lines)
-            if line in self._seen_payloads:
+        lines, new_offset = _local_bus_read_from(gist_id, self._local_byte_offset, self._peer_meta)
+        if new_offset != self._local_byte_offset:
+            self._local_byte_offset = new_offset
+            self._write_offset(local_offset, self._local_byte_offset)
+        for line in lines:
+            if self._seen(line):
                 continue
-            self._seen_payloads.add(line)
             msg = self._parse_envelope(line.encode("utf-8"))
             if msg is None:
                 continue
-            self._last_recv_ts = _time.time()
+            self._mark_received("local bus")
             yield msg
+
+    def _seen(self, line: str) -> bool:
+        if line in self._seen_payloads:
+            return True
+        self._seen_payloads.add(line)
+        self._seen_payload_order.append(line)
+        while len(self._seen_payload_order) > _SEEN_PAYLOAD_MAX:
+            old = self._seen_payload_order.popleft()
+            self._seen_payloads.discard(old)
+        return False
 
     @staticmethod
     def _read_offset(offset_file: Optional[str]) -> int:
@@ -888,11 +932,10 @@ class GhBearer(Bearer):
         except OSError:
             pass
 
-    def _on_line_received(self, line_count: int, offset_file: Optional[str]) -> None:
-        """Bump last_recv_ts (for liveness) and persist offset (for resume).
-        Persistence failures are swallowed — the bearer keeps streaming."""
+    def _mark_received(self, source: str) -> None:
+        """Record actual delivered-message liveness."""
         self._last_recv_ts = _time.time()
-        self._write_offset(offset_file, line_count)
+        self._last_recv_source = source
 
     @staticmethod
     def _parse_envelope(raw_line: bytes) -> Optional[ReceivedMessage]:
@@ -934,12 +977,12 @@ class GhBearer(Bearer):
             return LivenessResult(
                 peer_id=peer_id,
                 last_seen_ts=None,
-                bearer_diag="no events received via gh poll yet",
+                bearer_diag="no events received via gh/local bus yet",
             )
         return LivenessResult(
             peer_id=peer_id,
             last_seen_ts=self._last_recv_ts,
-            bearer_diag="last event from gh poll",
+            bearer_diag=f"last event from {self._last_recv_source or 'gh/local bus'}",
         )
 
     def close(self) -> None:

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import stat
 import sys
 import tempfile
 import unittest
@@ -1483,6 +1484,9 @@ class GhBearerLocalBusTests(unittest.TestCase):
             self.assertIn("local bus", outcome.detail)
             path = Path(tmp) / "abc123" / "messages.jsonl"
             self.assertIn('"msg":"local"', path.read_text(encoding="utf-8"))
+            if os.name == "posix":
+                self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+                self.assertEqual(stat.S_IMODE(path.parent.stat().st_mode), 0o700)
 
     def test_recv_yields_local_bus_lines_when_gh_get_fails(self):
         with tempfile.TemporaryDirectory() as tmp, self._env(tmp):
@@ -1496,12 +1500,13 @@ class GhBearerLocalBusTests(unittest.TestCase):
                 events = []
                 for ev in b.recv_stream():
                     events.append(ev)
-                    b.close()
                     break
 
             self.assertEqual(len(events), 1)
             self.assertEqual(events[0].sender_peer_id, "local-peer")
             self.assertEqual(events[0].channel, "general")
+            self.assertIn("local bus", b.liveness("alice").bearer_diag)
+            b.close()
 
     def test_recv_dedupes_same_line_from_local_bus_and_gist(self):
         line = '{"from":"peer","channel":"general","msg":"once"}'
@@ -1525,6 +1530,82 @@ class GhBearerLocalBusTests(unittest.TestCase):
                         break
 
             self.assertEqual([e.bearer_metadata["envelope"]["msg"] for e in events], ["once", "second"])
+
+    def test_recv_does_not_advance_past_partial_local_line(self):
+        with tempfile.TemporaryDirectory() as tmp, self._env(tmp):
+            path = Path(tmp) / "abc123" / "messages.jsonl"
+            path.parent.mkdir(parents=True)
+            path.write_text('{"from":"peer","channel":"general","msg":"complete"}\n{"from":"peer"', encoding="utf-8")
+
+            b = GhBearer({"room_gist_id": "abc123", "poll_interval": 0})
+            b.open("alice")
+            with mock.patch.object(bearer_gh, "_gh_api_get", return_value=None):
+                events = []
+                for ev in b.recv_stream():
+                    events.append(ev)
+                    b.close()
+                    break
+
+            self.assertEqual([e.bearer_metadata["envelope"]["msg"] for e in events], ["complete"])
+            # The byte offset should stop after the newline-terminated record,
+            # leaving the partial tail to be retried once it is completed.
+            self.assertLess(b._local_byte_offset, path.stat().st_size)
+
+    def test_recv_uses_byte_offset_file_not_legacy_line_offset_file(self):
+        with tempfile.TemporaryDirectory() as tmp, self._env(tmp):
+            bus = Path(tmp) / "abc123" / "messages.jsonl"
+            bus.parent.mkdir(parents=True)
+            bus.write_text('{"from":"peer","channel":"general","msg":"first"}\n', encoding="utf-8")
+            offset = Path(tmp) / "state.offset"
+            offset.write_text("1", encoding="utf-8")
+            (Path(str(offset) + ".local")).write_text("3", encoding="utf-8")
+
+            b = GhBearer({"room_gist_id": "abc123", "poll_interval": 0, "offset_file": str(offset)})
+            b.open("alice")
+            with mock.patch.object(bearer_gh, "_gh_api_get", return_value=None):
+                events = []
+                for ev in b.recv_stream():
+                    events.append(ev)
+                    b.close()
+                    break
+
+            self.assertEqual([e.bearer_metadata["envelope"]["msg"] for e in events], ["first"])
+            self.assertTrue(Path(str(offset) + ".local.bytes").exists())
+            self.assertEqual((Path(str(offset) + ".local")).read_text(encoding="utf-8"), "3")
+
+    def test_recv_does_not_advance_past_invalid_utf8_local_line(self):
+        with tempfile.TemporaryDirectory() as tmp, self._env(tmp):
+            path = Path(tmp) / "abc123" / "messages.jsonl"
+            path.parent.mkdir(parents=True)
+            path.write_bytes(b'{"from":"peer","channel":"general","msg":"ok"}\n\xff\n')
+
+            lines, next_offset = bearer_gh._local_bus_read_from("abc123", 0, {})
+
+            self.assertEqual(lines, [])
+            self.assertEqual(next_offset, 0)
+
+    def test_truthy_env_disables_local_bus(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {"AIRC_LOCAL_BUS_DIR": tmp, "AIRC_DISABLE_LOCAL_BUS": "true"}):
+                def _fake_get(_gist_id):
+                    bearer_gh._gh_api_get._last_err = "gh: API rate limit exceeded (HTTP 403)"
+                    return None
+
+                b = GhBearer({"room_gist_id": "abc123"})
+                b.open("alice")
+                with mock.patch.object(bearer_gh, "_gh_api_get", side_effect=_fake_get):
+                    outcome = b.send("alice", "general", b'{"from":"me","channel":"general","msg":"local"}')
+
+            self.assertEqual(outcome.kind, "secondary_rate_limit")
+            self.assertFalse((Path(tmp) / "abc123" / "messages.jsonl").exists())
+
+    def test_seen_payload_cache_is_bounded(self):
+        b = GhBearer({"room_gist_id": "abc123", "disable_local_bus": True})
+        b.open("alice")
+        for i in range(bearer_gh._SEEN_PAYLOAD_MAX + 25):
+            self.assertFalse(b._seen(f"line-{i}"))
+        self.assertLessEqual(len(b._seen_payloads), bearer_gh._SEEN_PAYLOAD_MAX)
+        self.assertFalse(b._seen("line-0"), "oldest entries should be evicted from dedupe cache")
 
 
 class GhBearerRecvTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- address Copilot review findings from #474 after it merged to canary
- make local bus directory/file private (`0700` dir, `0600` messages file)
- replace full-file local bus reads with byte-offset incremental reads
- avoid consuming partial trailing JSONL records until newline-terminated
- bound the local/gist dedupe cache to the latest 5000 payloads
- report liveness source accurately (`local bus` vs `gh poll`)
- accept common truthy values for `AIRC_DISABLE_LOCAL_BUS`

## Tests
- python3 test/test_bearer.py GhBearerLocalBusTests GhBearerSendTests GhBearerRecvTests GhBearerErrorClassificationTests
- python3 test/test_bearer.py
- python3 -m py_compile lib/airc_core/bearer_gh.py test/test_bearer.py

## Notes
#474 already merged because CI was clean and live local-bus validation succeeded. This follow-up tightens the implementation before we rely on it more broadly.
