### PR TITLE
Use bearer heartbeat in doctor health

### DIFF
--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -511,8 +511,24 @@ _doctor_health() {
         continue
       fi
       found_state=1
-      local last_recv_ts
-      last_recv_ts=$(python3 -c "import sys,json; d=json.load(open('$state_file')); print(int(d.get('last_recv_ts',0)))" 2>/dev/null || echo 0)
+      local state_ts last_recv_ts last_heartbeat_ts heartbeat_age
+      state_ts=$("$AIRC_PYTHON" -m airc_core.bearer_state "$state_file" 2>/dev/null || echo "0 0")
+      last_recv_ts=${state_ts%% *}
+      last_heartbeat_ts=${state_ts#* }
+      [ "$last_recv_ts" = "$state_ts" ] && last_heartbeat_ts=0
+      heartbeat_age=999999
+      if [ "${last_heartbeat_ts:-0}" -gt 0 ] 2>/dev/null; then
+        heartbeat_age=$((now - last_heartbeat_ts))
+      fi
+      if [ "$heartbeat_age" -lt 120 ]; then
+        if [ "$last_recv_ts" = "0" ]; then
+          printf "  [ok] #%s — bearer heartbeat %ds ago (idle; no messages received yet)\n" "$channel" "$heartbeat_age"
+        else
+          local recv_age=$((now - last_recv_ts))
+          printf "  [ok] #%s — bearer heartbeat %ds ago (last message %ds ago)\n" "$channel" "$heartbeat_age" "$recv_age"
+        fi
+        continue
+      fi
       if [ "$last_recv_ts" = "0" ]; then
         printf "  [WARN] #%s — bearer state has no last_recv_ts (never received?)\n" "$channel"
         warns=$((warns+1))

--- a/lib/airc_core/bearer_state.py
+++ b/lib/airc_core/bearer_state.py
@@ -1,0 +1,36 @@
+"""Helpers for reading bearer state JSON from shell commands."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def _int_ts(value: Any) -> int:
+    if value is None:
+        return 0
+    try:
+        return max(0, int(float(value)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        print("usage: python -m airc_core.bearer_state <state.json>", file=sys.stderr)
+        return 2
+    try:
+        with open(args[0], "r", encoding="utf-8") as f:
+            state = json.load(f)
+    except OSError:
+        return 1
+    except json.JSONDecodeError:
+        return 1
+    print(f"{_int_ts(state.get('last_recv_ts'))} {_int_ts(state.get('last_heartbeat_ts'))}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2125,6 +2125,9 @@ JSON
 
   printf '{"from":"remote-agent","to":"all","ts":"%s","channel":"general","msg":"recent remote proof"}\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$home/messages.jsonl"
+  local now_ts; now_ts=$(date +%s)
+  printf '{"kind":"gh","peer_id":"self","last_recv_ts":%s,"last_sender":"remote-agent","events_total":1,"diag":"last event from gh poll","last_heartbeat_ts":%s}\n' \
+    "$((now_ts - 3600))" "$now_ts" > "$home/bearer_state.general.json"
 
   status_out=$(AIRC_HOME="$home" "$AIRC" status 2>&1)
   echo "$status_out" | grep -q 'collaboration: DEGRADED (0 peer records; last remote message' \
@@ -2132,6 +2135,12 @@ JSON
     || fail "status did not distinguish recent remote traffic from solo island ($status_out)"
 
   doctor_out=$(AIRC_HOME="$home" "$AIRC" doctor --health 2>&1)
+  echo "$doctor_out" | grep -q '\[ok\] #general — bearer heartbeat' \
+    && pass "doctor treats fresh heartbeat as live even when last message is old" \
+    || fail "doctor did not use heartbeat evidence for bearer health ($doctor_out)"
+  echo "$doctor_out" | grep -q '\[BLOCKED\] #general' \
+    && fail "doctor falsely blocked a heartbeating idle channel ($doctor_out)" \
+    || pass "doctor does not block a heartbeating idle channel"
   echo "$doctor_out" | grep -q 'remote traffic arrived' \
     && pass "doctor --health reports peer metadata degraded when traffic proves bus is not solo" \
     || fail "doctor --health still treated recent remote traffic as solo ($doctor_out)"


### PR DESCRIPTION
## Summary
- classify live bearer health from fresh heartbeat evidence before treating stale/no receive timestamps as blocked
- keep idle rooms from making doctor --health report Bus DEGRADED when the monitor is alive
- move bearer-state JSON parsing into airc_core.bearer_state instead of embedding Python in shell

## Validation
- live continuum/authenticator real-bus soak: 3 bidirectional rounds exact-once in both real .airc/messages.jsonl logs
- live authenticator doctor now reports heartbeating #useideem as ok instead of BLOCKED
- ./test/integration.sh solo_mesh_warns
- python3 test/test_collaboration.py
- python3 -m py_compile lib/airc_core/bearer_state.py lib/airc_core/collaboration.py