### PR TITLE
Treat broadcast traffic as peer presence

### DIFF
--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -300,6 +300,10 @@ cmd_whois() {
   if _whois_in_scope "$AIRC_WRITE_DIR" "$target"; then
     return 0
   fi
+  if "$AIRC_PYTHON" -m airc_core.collaboration whois-fallback \
+      --home "$AIRC_WRITE_DIR" --my-name "$my_name" --peer-name "$target"; then
+    return 0
+  fi
 
   echo "  whois: no record for '$target' (try airc peers to list paired peers)"
   return 1

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -488,9 +488,8 @@ cmd_inbox() {
       --peek)
         peek=1; shift ;;
       --reset)
-        mkdir -p "$AIRC_WRITE_DIR"
-        date -u '+%Y-%m-%dT%H:%M:%SZ' > "$cursor_file"
-        echo "airc inbox cursor reset."
+        "$AIRC_PYTHON" -m airc_core.inbox reset \
+          --home "$AIRC_WRITE_DIR" --cursor-file "$cursor_file"
         return 0 ;;
       -h|--help)
         echo "Usage: airc inbox [--peek] [--reset] [--since <ts|Ns|Nm|Nh>] [--count N]"
@@ -508,33 +507,18 @@ cmd_inbox() {
   esac
 
   if [ -z "$since" ]; then
-    if [ -f "$cursor_file" ]; then
-      since=$(cat "$cursor_file" 2>/dev/null || true)
-    fi
-    since="${since:-5m}"
+    since=""
   fi
 
-  local read_started
-  read_started=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-
   local out
-  if ! out=$(cmd_logs "$count" --since "$since" 2>&1); then
+  local inbox_args=(read --home "$AIRC_WRITE_DIR" --cursor-file "$cursor_file" --count "$count")
+  [ -n "$since" ] && inbox_args+=(--since "$since")
+  [ "$peek" -eq 1 ] && inbox_args+=(--peek)
+  if ! out=$("$AIRC_PYTHON" -m airc_core.inbox "${inbox_args[@]}" 2>&1); then
     printf '%s\n' "$out" >&2
     return 1
   fi
 
-  if [ -n "$out" ]; then
-    _airc_monitor_health_report degraded-only
-    printf '%s\n' "$out"
-  else
-    _airc_monitor_health_report degraded-only
-    echo "No new airc messages since $since"
-  fi
-
-  if [ "$peek" -eq 0 ]; then
-    mkdir -p "$AIRC_WRITE_DIR"
-    local latest
-    latest=$(printf '%s\n' "$out" | sed -n 's/^\[\([^]]*\)\].*/\1/p' | tail -1)
-    printf '%s\n' "${latest:-$read_started}" > "$cursor_file"
-  fi
+  _airc_monitor_health_report degraded-only
+  printf '%s\n' "$out"
 }

--- a/lib/airc_bash/lib_daemon_detect.sh
+++ b/lib/airc_bash/lib_daemon_detect.sh
@@ -23,8 +23,21 @@
 airc_daemon_scope_id() {
   local target_scope="${1:-}"
   [ -n "$target_scope" ] || target_scope="${AIRC_HOME:-$HOME/.airc}"
-  python3 -c 'import hashlib,sys; print(hashlib.sha1(sys.argv[1].encode()).hexdigest()[:12])' "$target_scope" 2>/dev/null \
-    || printf '%s' "$target_scope" | shasum 2>/dev/null | awk '{print substr($1,1,12)}'
+  local id=""
+  id=$(python3 -c 'import hashlib,sys; print(hashlib.sha1(sys.argv[1].encode()).hexdigest()[:12])' "$target_scope" 2>/dev/null || true)
+  if [ -z "$id" ] && command -v sha1sum >/dev/null 2>&1; then
+    id=$(printf '%s' "$target_scope" | sha1sum 2>/dev/null | awk '{print substr($1,1,12)}')
+  fi
+  if [ -z "$id" ] && command -v shasum >/dev/null 2>&1; then
+    id=$(printf '%s' "$target_scope" | shasum 2>/dev/null | awk '{print substr($1,1,12)}')
+  fi
+  if [ -z "$id" ] && command -v openssl >/dev/null 2>&1; then
+    id=$(printf '%s' "$target_scope" | openssl dgst -sha1 2>/dev/null | awk '{print substr($NF,1,12)}')
+  fi
+  if [ -z "$id" ]; then
+    id=$(printf '%s' "$target_scope" | tr -c 'A-Za-z0-9' '_' | tail -c 12)
+  fi
+  printf '%s\n' "${id:-aircdefault0}"
 }
 
 airc_daemon_service_name_for_scope() {

--- a/lib/airc_core/bearer_cli.py
+++ b/lib/airc_core/bearer_cli.py
@@ -46,17 +46,18 @@ import signal
 import subprocess
 import sys
 import time
+import threading
 from dataclasses import asdict
 from typing import Optional, Tuple, Union
 
 from .bearer_resolver import resolve
 
 
-# ── Per-(scope, channel, gist) bearer lock ─────────────────────────────
+# ── Per-(scope, gist) bearer lock ─────────────────────────────────────
 # Without this lock, scope teardown that leaks orphan bearers OR a
 # host-gist-rotation respawn that races with the old bearer can end up
-# with TWO bearer_cli processes polling the same gist for the same
-# channel. Both yield each new line to their stdout. If their pipes
+# with TWO bearer_cli processes polling the same gist. Both yield each
+# new line to their stdout. If their pipes
 # converge (the parent monitor's children share a downstream pipe, or
 # both feed an unprivileged log), each downstream message arrives twice.
 #
@@ -71,6 +72,7 @@ from .bearer_resolver import resolve
 _LOCK_DISABLED = "disabled"
 _LOCK_HELD = "held"
 RecvLockResult = Union[Tuple[str, int], str]
+_STATE_FILE_LOCK = threading.RLock()
 
 
 def _pid_alive(pid: int) -> bool:
@@ -79,7 +81,7 @@ def _pid_alive(pid: int) -> bool:
 
     PermissionError (EPERM) means the PID exists but is owned by another
     user — still counts as alive. ProcessLookupError (ESRCH) means dead.
-    Other OSError means we can't tell — be conservative, assume dead.
+    Other OSError means we can't tell — be conservative, assume alive.
     """
     if pid <= 0:
         return False
@@ -91,7 +93,26 @@ def _pid_alive(pid: int) -> bool:
     except PermissionError:
         return True
     except OSError:
+        return True
+
+
+def _bearer_cmdline_matches(pid: int, expected_gist: str) -> Optional[bool]:
+    """Return True/False when process shape is known, None when unknown."""
+    try:
+        out = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True, text=True, timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    cmdline = (out.stdout or "").strip()
+    if "bearer_cli" not in cmdline or " recv " not in f" {cmdline} ":
         return False
+    if expected_gist:
+        return f"--room-gist-id {expected_gist}" in cmdline
+    return True
 
 
 def _is_our_bearer(pid: int, expected_gist: str) -> bool:
@@ -102,21 +123,7 @@ def _is_our_bearer(pid: int, expected_gist: str) -> bool:
     process is actually a bearer_cli recv AND for our gist; otherwise
     treat the pidfile as stale.
     """
-    try:
-        out = subprocess.run(
-            ["ps", "-p", str(pid), "-o", "command="],
-            capture_output=True, text=True, timeout=2,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return False
-    if out.returncode != 0:
-        return False
-    cmdline = (out.stdout or "").strip()
-    if "bearer_cli" not in cmdline or " recv " not in f" {cmdline} ":
-        return False
-    if expected_gist:
-        return f"--room-gist-id {expected_gist}" in cmdline
-    return True
+    return _bearer_cmdline_matches(pid, expected_gist) is True
 
 
 def _read_lock_owner(pidfile: str) -> Tuple[int, str]:
@@ -195,18 +202,33 @@ def _claim_recv_lock(args) -> RecvLockResult:
         except FileExistsError:
             # Format: "<pid>\t<gist_id>". gist_id may be empty for non-gh bearers.
             other_pid, _other_gist = _read_lock_owner(pidfile)
-            if other_pid > 0 and other_pid != my_pid \
-                    and _pid_alive(other_pid) and _is_our_bearer(other_pid, my_gist):
-                print(
-                    f"bearer_cli recv: another bearer for gist {my_gist or '(none)'} "
-                    f"already running (PID {other_pid}); exiting cleanly to avoid "
-                    f"duplicate emission",
-                    file=sys.stderr, flush=True,
-                )
-                return _LOCK_HELD
-            # else: stale (dead pid, OS-reused, or old gist) → remove then
-            # retry O_EXCL claim. If another process wins the race, the next
-            # loop sees its pidfile and exits or retries accordingly.
+            if other_pid <= 0:
+                # A competing process may have won O_EXCL but not yet
+                # written the payload. Treat empty/partial owner records as
+                # in-progress, not stale, or we defeat the lock.
+                time.sleep(0.05)
+                continue
+            if other_pid != my_pid and _pid_alive(other_pid):
+                cmd_match = _bearer_cmdline_matches(other_pid, my_gist)
+                if cmd_match is True or (cmd_match is None and _other_gist == my_gist):
+                    print(
+                        f"bearer_cli recv: another bearer for gist {my_gist or '(none)'} "
+                        f"already running (PID {other_pid}); exiting cleanly to avoid "
+                        f"duplicate emission",
+                        file=sys.stderr, flush=True,
+                    )
+                    return _LOCK_HELD
+                if cmd_match is None:
+                    print(
+                        f"bearer_cli recv: pidfile {pidfile} is held by live PID {other_pid} "
+                        f"but cmdline could not be verified; treating lock as held",
+                        file=sys.stderr, flush=True,
+                    )
+                    return _LOCK_HELD
+            # else: stale (dead pid, OS-reused with known non-bearer shape,
+            # or old gist with known non-matching shape) → remove then retry
+            # O_EXCL claim. If another process wins the race, the next loop
+            # sees its pidfile and exits or retries accordingly.
             try:
                 os.unlink(pidfile)
             except FileNotFoundError:
@@ -228,7 +250,12 @@ def _claim_recv_lock(args) -> RecvLockResult:
             )
             return _LOCK_DISABLED
 
-    return _LOCK_DISABLED
+    print(
+        f"bearer_cli recv: pidfile {pidfile} stayed in an in-progress state; "
+        f"treating lock as held to avoid duplicate emission",
+        file=sys.stderr, flush=True,
+    )
+    return _LOCK_HELD
 
 
 def _release_lock(pidfile: str, my_pid: int) -> None:
@@ -447,20 +474,21 @@ def _write_state_file(path: str, state: dict) -> None:
     """
     import os
     import tempfile
-    try:
-        d = os.path.dirname(path) or "."
-        fd, tmp = tempfile.mkstemp(prefix=".bearer_state-", dir=d)
+    with _STATE_FILE_LOCK:
         try:
-            with os.fdopen(fd, "w") as f:
-                json.dump(state, f)
-            os.replace(tmp, path)
-        except Exception:
+            d = os.path.dirname(path) or "."
+            fd, tmp = tempfile.mkstemp(prefix=".bearer_state-", dir=d)
             try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-    except OSError:
-        pass
+                with os.fdopen(fd, "w") as f:
+                    json.dump(state, f)
+                os.replace(tmp, path)
+            except Exception:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+        except OSError:
+            pass
 
 
 def _touch_state_heartbeat(path: str, ts: float) -> None:
@@ -471,13 +499,14 @@ def _touch_state_heartbeat(path: str, ts: float) -> None:
     bearer from a dead channel, which is the signal users and agents need
     when a monitor silently wedges.
     """
-    try:
-        with open(path) as f:
-            state = json.load(f)
-    except Exception:
-        state = {}
-    state["last_heartbeat_ts"] = ts
-    _write_state_file(path, state)
+    with _STATE_FILE_LOCK:
+        try:
+            with open(path) as f:
+                state = json.load(f)
+        except Exception:
+            state = {}
+        state["last_heartbeat_ts"] = ts
+        _write_state_file(path, state)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/lib/airc_core/collaboration.py
+++ b/lib/airc_core/collaboration.py
@@ -118,6 +118,7 @@ def recent_remote_speakers(home: str, my_name: str, window_sec: int = RECENT_REM
 
 def cmd_status(args: argparse.Namespace) -> int:
     count = peer_record_count(args.home)
+    speakers = recent_remote_speakers(args.home, args.my_name)
     recent = recent_remote_activity(args.home, args.my_name)
     now = int(time.time())
     if recent is None:
@@ -126,9 +127,10 @@ def cmd_status(args: argparse.Namespace) -> int:
         remote_desc = f"last remote message {max(0, now - recent.ts)}s ago from {recent.name}"
 
     if count == 0:
-        if recent is not None:
-            print(f"  collaboration: DEGRADED (0 peer records; {remote_desc})")
-            print("    DMs/whois/peer targeting may be broken; broadcast traffic is flowing.")
+        if speakers:
+            label = "broadcast peer" if len(speakers) == 1 else "broadcast peers"
+            print(f"  collaboration: ok ({len(speakers)} {label}; 0 direct peer records; {remote_desc})")
+            print("    Presence is derived from recent signed room traffic.")
         else:
             print(f"  collaboration: SOLO (0 peer records; {remote_desc})")
             print("    Sends may only land in this local/self-hosted gist until another agent joins this exact mesh.")
@@ -139,10 +141,19 @@ def cmd_status(args: argparse.Namespace) -> int:
 
 def cmd_doctor(args: argparse.Namespace) -> int:
     count = peer_record_count(args.home)
+    speakers = recent_remote_speakers(args.home, args.my_name)
     recent = recent_remote_activity(args.home, args.my_name)
     now = int(time.time())
     if count > 0:
         print(f"  [ok] collaboration mesh has {count} peer record(s)")
+        return 0
+    if speakers and recent is not None:
+        label = "broadcast peer" if len(speakers) == 1 else "broadcast peers"
+        print(
+            f"  [ok] collaboration mesh has {len(speakers)} recent {label} "
+            f"from signed room traffic (0 direct peer records)"
+        )
+        print(f"       last remote message {max(0, now - recent.ts)}s ago from {recent.name}")
         return 0
     if recent is not None:
         print(
@@ -159,17 +170,9 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 def cmd_send_warning(args: argparse.Namespace) -> int:
     if peer_record_count(args.home) > 0:
         return 0
-    recent = recent_remote_activity(args.home, args.my_name)
-    now = int(time.time())
-    if recent is not None:
+    if not recent_remote_speakers(args.home, args.my_name):
         print(
-            f"  ⚠ collaboration: 0 peer records, but remote traffic arrived "
-            f"{max(0, now - recent.ts)}s ago from {recent.name}; peer metadata degraded, bus is not solo.",
-            file=sys.stderr,
-        )
-    else:
-        print(
-            "  ⚠ collaboration: 0 peer records in this scope; this may be a solo mesh. "
+            "  WARN: collaboration has no direct peer records or recent broadcast peers. "
             "Run 'airc peers' and verify others joined this gist.",
             file=sys.stderr,
         )
@@ -180,9 +183,24 @@ def cmd_peers_fallback(args: argparse.Namespace) -> int:
     speakers = recent_remote_speakers(args.home, args.my_name)
     if not speakers:
         return 1
-    print("  No peer records yet, but recent remote traffic is visible:")
+    print("  Recent broadcast peers:")
     for who, ts in sorted(speakers.items(), key=lambda kv: kv[1], reverse=True):
-        print(f"  {who} → (broadcast-only)   [(from messages.jsonl)]   last seen {_fmt_age(ts)}")
+        print(f"  {who} → broadcast room   [(from signed messages.jsonl)]   last seen {_fmt_age(ts)}")
+    return 0
+
+
+def cmd_whois_fallback(args: argparse.Namespace) -> int:
+    speakers = recent_remote_speakers(args.home, args.my_name)
+    ts = speakers.get(args.peer_name)
+    if ts is None:
+        return 1
+    print(f"  name:      {args.peer_name}")
+    print("  pronouns:  (unknown)")
+    print("  role:      broadcast peer")
+    print("  bio:       seen in recent signed room traffic")
+    print("  status:    (unknown)")
+    print("  integrations: (none)")
+    print(f"  presence:  broadcast-only, last seen {_fmt_age(ts)}")
     return 0
 
 
@@ -193,6 +211,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         p = sub.add_parser(name)
         p.add_argument("--home", required=True)
         p.add_argument("--my-name", default="")
+    p = sub.add_parser("whois-fallback")
+    p.add_argument("--home", required=True)
+    p.add_argument("--my-name", default="")
+    p.add_argument("--peer-name", required=True)
     args = parser.parse_args(argv)
     if args.cmd == "status":
         return cmd_status(args)
@@ -202,6 +224,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         return cmd_send_warning(args)
     if args.cmd == "peers-fallback":
         return cmd_peers_fallback(args)
+    if args.cmd == "whois-fallback":
+        return cmd_whois_fallback(args)
     return 1
 
 

--- a/lib/airc_core/gistparse.py
+++ b/lib/airc_core/gistparse.py
@@ -38,6 +38,7 @@ quiet-and-empty for malformed input and we preserve that.
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import re
 import sys
@@ -99,6 +100,15 @@ def _read_json_text(text: str):
         return json.loads(text)
     except (ValueError, TypeError):
         return None
+
+
+def _heartbeat_epoch(value: object) -> float:
+    if not isinstance(value, str) or not value:
+        return 0.0
+    try:
+        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return 0.0
 
 
 def _emit(value, default=""):
@@ -268,7 +278,7 @@ def cmd_gist_content(args) -> int:
             env = _read_json_text(content)
             channels = env.get("channels") if isinstance(env, dict) else None
             if isinstance(channels, list) and channel in channels:
-                matches.append((str(env.get("last_heartbeat", "")), name == exact_name, content))
+                matches.append((_heartbeat_epoch(env.get("last_heartbeat")), name == exact_name, content))
         if matches:
             matches.sort(key=lambda item: (item[0], item[1]), reverse=True)
             print(matches[0][2])

--- a/lib/airc_core/inbox.py
+++ b/lib/airc_core/inbox.py
@@ -1,0 +1,161 @@
+"""Stateful unread polling for non-Monitor runtimes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+
+def _parse_since(value: str) -> Optional[datetime]:
+    if not value:
+        return None
+    unit = value[-1:]
+    number = value[:-1]
+    if unit in "smhd" and number.isdigit():
+        n = int(number)
+        delta = {
+            "s": timedelta(seconds=n),
+            "m": timedelta(minutes=n),
+            "h": timedelta(hours=n),
+            "d": timedelta(days=n),
+        }[unit]
+        return datetime.now(timezone.utc) - delta
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        raise SystemExit(f"airc inbox --since: cannot parse '{value}'")
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _msg_dt(line: dict) -> Optional[datetime]:
+    raw = line.get("ts", "")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _format(line: dict) -> str:
+    return f"[{line.get('ts', '')}] {line.get('from', '?')}: {line.get('msg', '')}"
+
+
+def _read_cursor(path: str) -> tuple[Optional[int], str]:
+    try:
+        with open(path, encoding="utf-8") as f:
+            raw = f.read().strip()
+    except OSError:
+        return (None, "")
+    if not raw:
+        return (None, "")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return (None, raw)
+    offset = data.get("offset")
+    if isinstance(offset, int) and offset >= 0:
+        return (offset, "")
+    return (None, "")
+
+
+def _write_cursor(path: str, offset: int) -> None:
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    tmp = f"{path}.tmp.{os.getpid()}"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump({"offset": max(0, offset)}, f, separators=(",", ":"))
+        f.write("\n")
+    os.replace(tmp, path)
+
+
+def cmd_reset(args: argparse.Namespace) -> int:
+    log_path = os.path.join(args.home, "messages.jsonl")
+    try:
+        offset = os.path.getsize(log_path)
+    except OSError:
+        offset = 0
+    _write_cursor(args.cursor_file, offset)
+    print("airc inbox cursor reset.")
+    return 0
+
+
+def cmd_read(args: argparse.Namespace) -> int:
+    log_path = os.path.join(args.home, "messages.jsonl")
+    cursor_offset, legacy_since = _read_cursor(args.cursor_file)
+    since_arg = args.since or ""
+    if not since_arg and cursor_offset is None:
+        since_arg = legacy_since or "5m"
+    since_dt = _parse_since(since_arg) if since_arg else None
+
+    try:
+        size = os.path.getsize(log_path)
+    except OSError:
+        size = 0
+    start_offset = 0
+    if since_dt is None and cursor_offset is not None:
+        start_offset = cursor_offset if cursor_offset <= size else 0
+
+    printed = 0
+    last_offset = start_offset
+    try:
+        with open(log_path, "rb") as f:
+            f.seek(start_offset)
+            while printed < args.count:
+                raw = f.readline()
+                if not raw:
+                    break
+                next_offset = f.tell()
+                try:
+                    line = json.loads(raw.decode("utf-8"))
+                except Exception:
+                    last_offset = next_offset
+                    continue
+                if since_dt is not None:
+                    dt = _msg_dt(line)
+                    if dt is None or dt <= since_dt:
+                        last_offset = next_offset
+                        continue
+                print(_format(line))
+                printed += 1
+                last_offset = next_offset
+    except OSError:
+        pass
+
+    if printed == 0:
+        print(f"No new airc messages since {since_arg or 'last inbox check'}")
+    elif not args.peek:
+        _write_cursor(args.cursor_file, last_offset)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="airc_core.inbox")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    read = sub.add_parser("read")
+    read.add_argument("--home", required=True)
+    read.add_argument("--cursor-file", required=True)
+    read.add_argument("--since", default="")
+    read.add_argument("--count", type=int, default=500)
+    read.add_argument("--peek", action="store_true")
+    reset = sub.add_parser("reset")
+    reset.add_argument("--home", required=True)
+    reset.add_argument("--cursor-file", required=True)
+    args = parser.parse_args(argv)
+    if args.cmd == "read":
+        return cmd_read(args)
+    if args.cmd == "reset":
+        return cmd_reset(args)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2130,9 +2130,9 @@ JSON
     "$((now_ts - 3600))" "$now_ts" > "$home/bearer_state.general.json"
 
   status_out=$(AIRC_HOME="$home" "$AIRC" status 2>&1)
-  echo "$status_out" | grep -q 'collaboration: DEGRADED (0 peer records; last remote message' \
-    && pass "status reports DEGRADED, not SOLO, when recent remote traffic exists" \
-    || fail "status did not distinguish recent remote traffic from solo island ($status_out)"
+  echo "$status_out" | grep -q 'collaboration: ok (1 broadcast peer; 0 direct peer records' \
+    && pass "status treats recent signed traffic as broadcast peer presence" \
+    || fail "status did not recognize broadcast peer presence ($status_out)"
 
   doctor_out=$(AIRC_HOME="$home" "$AIRC" doctor --health 2>&1)
   echo "$doctor_out" | grep -q '\[ok\] #general — bearer heartbeat' \
@@ -2141,14 +2141,20 @@ JSON
   echo "$doctor_out" | grep -q '\[BLOCKED\] #general' \
     && fail "doctor falsely blocked a heartbeating idle channel ($doctor_out)" \
     || pass "doctor does not block a heartbeating idle channel"
-  echo "$doctor_out" | grep -q 'remote traffic arrived' \
-    && pass "doctor --health reports peer metadata degraded when traffic proves bus is not solo" \
-    || fail "doctor --health still treated recent remote traffic as solo ($doctor_out)"
+  echo "$doctor_out" | grep -q 'recent broadcast peer' \
+    && pass "doctor --health accepts broadcast peer presence as collaboration" \
+    || fail "doctor --health did not accept broadcast peer presence ($doctor_out)"
 
   peers_out=$(AIRC_HOME="$home" "$AIRC" peers 2>&1)
-  echo "$peers_out" | grep -q 'remote-agent → (broadcast-only)' \
+  echo "$peers_out" | grep -q 'remote-agent → broadcast room' \
     && pass "airc peers falls back to recent broadcast-only traffic" \
     || fail "airc peers hid recent remote traffic when peer records were empty ($peers_out)"
+
+  local whois_out
+  whois_out=$(AIRC_HOME="$home" "$AIRC" whois remote-agent 2>&1)
+  echo "$whois_out" | grep -q 'role: *broadcast peer' \
+    && pass "airc whois returns limited identity for broadcast peer" \
+    || fail "airc whois did not resolve broadcast peer ($whois_out)"
 
   rm -rf /tmp/airc-it-solo
   cleanup_all
@@ -3164,9 +3170,9 @@ scenario_inbox() {
 
   out=$(AIRC_HOME="$home" "$AIRC" inbox --since 2026-05-04T09:59:00Z 2>&1)
   local cursor; cursor=$(cat "$home/inbox_cursor" 2>/dev/null || true)
-  [ "$cursor" = "2026-05-04T10:01:00Z" ] \
-    && pass "inbox advances cursor to newest printed message" \
-    || fail "inbox cursor = '$cursor' (expected newest message ts); output: $out"
+  printf '%s' "$cursor" | grep -q '"offset":[1-9]' \
+    && pass "inbox advances byte cursor after printed messages" \
+    || fail "inbox cursor = '$cursor' (expected byte offset JSON); output: $out"
 
   out=$(AIRC_HOME="$home" "$AIRC" inbox 2>&1)
   printf '%s' "$out" | grep -q 'No new airc messages' \
@@ -3177,7 +3183,7 @@ scenario_inbox() {
   out=$(AIRC_HOME="$home" "$AIRC" poll 2>&1)
   cursor=$(cat "$home/inbox_cursor" 2>/dev/null || true)
   printf '%s' "$out" | grep -q 'third unread' \
-    && [ "$cursor" = "2099-05-04T10:02:00Z" ] \
+    && printf '%s' "$cursor" | grep -q '"offset":[1-9]' \
     && pass "poll alias reads only new messages and advances cursor" \
     || fail "poll alias failed; cursor='$cursor' output: $out"
 }

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -724,7 +724,7 @@ class BearerCliRecvLockTests(unittest.TestCase):
         with open(self._pidfile, "w") as f:
             f.write(f"{my_other_pid}\told-gist-id\n")
         with mock.patch.object(bearer_cli, "_pid_alive", return_value=True), \
-             mock.patch.object(bearer_cli, "_is_our_bearer") as mock_is_ours:
+             mock.patch.object(bearer_cli, "_bearer_cmdline_matches") as mock_is_ours:
             # _is_our_bearer should be called with my CURRENT gist; if the
             # cmdline has the old gist it should report False → stale.
             mock_is_ours.return_value = False
@@ -741,7 +741,7 @@ class BearerCliRecvLockTests(unittest.TestCase):
         with open(self._pidfile, "w") as f:
             f.write(f"{my_other_pid}\tabc123\n")
         with mock.patch.object(bearer_cli, "_pid_alive", return_value=True), \
-             mock.patch.object(bearer_cli, "_is_our_bearer", return_value=True):
+             mock.patch.object(bearer_cli, "_bearer_cmdline_matches", return_value=True):
             result = bearer_cli._claim_recv_lock(self._args(room_gist_id="abc123"))
         self.assertEqual(result, bearer_cli._LOCK_HELD,
                          "live bearer for same gist must block claim")
@@ -763,7 +763,7 @@ class BearerCliRecvLockTests(unittest.TestCase):
             room_gist_id="samegist",
         )
         with mock.patch.object(bearer_cli, "_pid_alive", return_value=True), \
-             mock.patch.object(bearer_cli, "_is_our_bearer", return_value=True):
+             mock.patch.object(bearer_cli, "_bearer_cmdline_matches", return_value=True):
             second = bearer_cli._claim_recv_lock(second_args)
         self.assertEqual(second, bearer_cli._LOCK_HELD,
                          "same gist through a second channel must not spawn a duplicate bearer")
@@ -779,6 +779,26 @@ class BearerCliRecvLockTests(unittest.TestCase):
         with mock.patch.object(bearer_cli.os, "open", side_effect=OSError("nope")):
             result = bearer_cli._claim_recv_lock(self._args())
         self.assertEqual(result, bearer_cli._LOCK_DISABLED)
+
+    def test_empty_pidfile_is_treated_as_in_progress_not_reclaimed(self):
+        with open(self._pidfile, "w") as f:
+            f.write("")
+        with mock.patch.object(bearer_cli.time, "sleep", return_value=None):
+            result = bearer_cli._claim_recv_lock(self._args(room_gist_id="abc123"))
+        self.assertEqual(result, bearer_cli._LOCK_HELD)
+        with open(self._pidfile) as f:
+            self.assertEqual(f.read(), "")
+
+    def test_live_same_gist_with_unverifiable_cmdline_holds_lock(self):
+        other_pid = 99999995
+        with open(self._pidfile, "w") as f:
+            f.write(f"{other_pid}\tabc123\n")
+        with mock.patch.object(bearer_cli, "_pid_alive", return_value=True), \
+             mock.patch.object(bearer_cli, "_bearer_cmdline_matches", return_value=None):
+            result = bearer_cli._claim_recv_lock(self._args(room_gist_id="abc123"))
+        self.assertEqual(result, bearer_cli._LOCK_HELD)
+        with open(self._pidfile) as f:
+            self.assertEqual(f.read().strip(), f"{other_pid}\tabc123")
 
     def test_claim_uses_exclusive_create_for_absent_pidfile(self):
         import os

--- a/test/test_collaboration.py
+++ b/test/test_collaboration.py
@@ -46,7 +46,7 @@ class CollaborationHealthTests(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertIn("collaboration: SOLO", out.getvalue())
 
-    def test_status_degraded_when_recent_remote_traffic_exists(self):
+    def test_status_ok_when_recent_remote_traffic_exists(self):
         tmp, home = self._scope()
         with tmp:
             (home / "messages.jsonl").write_text(self._remote_line(), encoding="utf-8")
@@ -55,20 +55,21 @@ class CollaborationHealthTests(unittest.TestCase):
                 rc = collaboration.main(["status", "--home", str(home), "--my-name", "me"])
             self.assertEqual(rc, 0)
             text = out.getvalue()
-            self.assertIn("collaboration: DEGRADED", text)
+            self.assertIn("collaboration: ok (1 broadcast peer", text)
+            self.assertIn("Presence is derived", text)
             self.assertNotIn("collaboration: SOLO", text)
 
-    def test_doctor_warns_not_blocks_when_remote_traffic_exists(self):
+    def test_doctor_ok_when_recent_remote_traffic_exists(self):
         tmp, home = self._scope()
         with tmp:
             (home / "messages.jsonl").write_text(self._remote_line(), encoding="utf-8")
             out = io.StringIO()
             with redirect_stdout(out):
                 rc = collaboration.main(["doctor", "--home", str(home), "--my-name", "me"])
-            self.assertEqual(rc, 1)
-            self.assertIn("remote traffic arrived", out.getvalue())
+            self.assertEqual(rc, 0)
+            self.assertIn("recent broadcast peer", out.getvalue())
 
-    def test_send_warning_says_not_solo_when_remote_traffic_exists(self):
+    def test_send_warning_silent_when_remote_traffic_exists(self):
         tmp, home = self._scope()
         with tmp:
             (home / "messages.jsonl").write_text(self._remote_line(), encoding="utf-8")
@@ -76,7 +77,7 @@ class CollaborationHealthTests(unittest.TestCase):
             with redirect_stderr(err):
                 rc = collaboration.main(["send-warning", "--home", str(home), "--my-name", "me"])
             self.assertEqual(rc, 0)
-            self.assertIn("bus is not solo", err.getvalue())
+            self.assertEqual("", err.getvalue())
 
     def test_peers_fallback_lists_recent_broadcast_speaker(self):
         tmp, home = self._scope()
@@ -88,6 +89,24 @@ class CollaborationHealthTests(unittest.TestCase):
                 rc = collaboration.main(["peers-fallback", "--home", str(home), "--my-name", "me"])
             self.assertEqual(rc, 0)
             self.assertIn("remote-agent", out.getvalue())
+            self.assertIn("broadcast room", out.getvalue())
+
+    def test_whois_fallback_describes_recent_broadcast_speaker(self):
+        tmp, home = self._scope()
+        with tmp:
+            (home / "messages.jsonl").write_text(self._remote_line(), encoding="utf-8")
+            out = io.StringIO()
+            with redirect_stdout(out):
+                rc = collaboration.main([
+                    "whois-fallback",
+                    "--home", str(home),
+                    "--my-name", "me",
+                    "--peer-name", "remote-agent",
+                ])
+            self.assertEqual(rc, 0)
+            text = out.getvalue()
+            self.assertIn("name:      remote-agent", text)
+            self.assertIn("role:      broadcast peer", text)
 
 
 if __name__ == "__main__":

--- a/test/test_gistparse.py
+++ b/test/test_gistparse.py
@@ -75,6 +75,30 @@ class GistContentTests(unittest.TestCase):
         out = _run_gist_content(gist, channel="cambriantech")
         self.assertEqual(json.loads(out)["invite"], "fresh-host@example")
 
+    def test_channel_freshness_uses_timestamp_parse_not_lexicographic_sort(self):
+        malformed = {
+            "airc": 1,
+            "kind": "mesh",
+            "channels": ["general"],
+            "last_heartbeat": "not-a-timestamp-z-wins-lexically",
+            "invite": "malformed-host@example",
+        }
+        fresh = {
+            "airc": 1,
+            "kind": "mesh",
+            "channels": ["general"],
+            "last_heartbeat": "2026-05-04T17:14:09+00:00",
+            "invite": "fresh-host@example",
+        }
+        gist = {
+            "files": {
+                "airc-room-general.json": {"content": json.dumps(malformed)},
+                "airc-room-other.json": {"content": json.dumps(fresh)},
+            },
+        }
+        out = _run_gist_content(gist, channel="general")
+        self.assertEqual(json.loads(out)["invite"], "fresh-host@example")
+
     def test_without_channel_preserves_first_file_fallback(self):
         gist = {
             "files": {

--- a/test/test_inbox.py
+++ b/test/test_inbox.py
@@ -1,0 +1,80 @@
+"""airc inbox cursor tests."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+from airc_core import inbox  # noqa: E402
+
+
+class InboxTests(unittest.TestCase):
+    def _scope(self):
+        tmp = tempfile.TemporaryDirectory()
+        home = Path(tmp.name)
+        return tmp, home, home / "cursor.json"
+
+    def _line(self, sender: str, ts: str, msg: str) -> str:
+        return json.dumps({"from": sender, "ts": ts, "msg": msg}) + "\n"
+
+    def test_same_second_messages_are_not_dropped(self):
+        tmp, home, cursor = self._scope()
+        with tmp:
+            log = home / "messages.jsonl"
+            log.write_text(
+                self._line("a", "2026-05-04T20:00:00Z", "one")
+                + self._line("b", "2026-05-04T20:00:00Z", "two"),
+                encoding="utf-8",
+            )
+            out = io.StringIO()
+            with redirect_stdout(out):
+                inbox.main(["read", "--home", str(home), "--cursor-file", str(cursor), "--since", "2026-05-04T19:59:59Z", "--count", "1"])
+            self.assertIn("one", out.getvalue())
+            out = io.StringIO()
+            with redirect_stdout(out):
+                inbox.main(["read", "--home", str(home), "--cursor-file", str(cursor), "--count", "1"])
+            self.assertIn("two", out.getvalue())
+
+    def test_empty_read_does_not_advance_cursor(self):
+        tmp, home, cursor = self._scope()
+        with tmp:
+            log = home / "messages.jsonl"
+            log.write_text("", encoding="utf-8")
+            with redirect_stdout(io.StringIO()):
+                inbox.main(["read", "--home", str(home), "--cursor-file", str(cursor), "--since", "2026-05-04T19:59:59Z"])
+            self.assertFalse(cursor.exists())
+            log.write_text(self._line("a", "2026-05-04T20:00:00Z", "late"), encoding="utf-8")
+            out = io.StringIO()
+            with redirect_stdout(out):
+                inbox.main(["read", "--home", str(home), "--cursor-file", str(cursor), "--since", "2026-05-04T19:59:59Z"])
+            self.assertIn("late", out.getvalue())
+
+    def test_reset_sets_cursor_to_end(self):
+        tmp, home, cursor = self._scope()
+        with tmp:
+            log = home / "messages.jsonl"
+            log.write_text(self._line("a", "2026-05-04T20:00:00Z", "old"), encoding="utf-8")
+            with redirect_stdout(io.StringIO()):
+                inbox.main(["reset", "--home", str(home), "--cursor-file", str(cursor)])
+            log.write_text(
+                log.read_text(encoding="utf-8") + self._line("b", "2026-05-04T20:00:01Z", "new"),
+                encoding="utf-8",
+            )
+            out = io.StringIO()
+            with redirect_stdout(out):
+                inbox.main(["read", "--home", str(home), "--cursor-file", str(cursor), "--count", "10"])
+            text = out.getvalue()
+            self.assertNotIn("old", text)
+            self.assertIn("new", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- treat recent signed room traffic as broadcast peer presence instead of degraded collaboration when direct peer records are absent
- add limited whois fallback for broadcast peers seen in the room log
- move inbox to a local byte-offset cursor so Codex/non-Monitor polling cannot drop same-second, delayed, or future-timestamp messages and does not depend on SSH host log reads
- harden bearer recv locks against empty/in-progress pidfiles and unverifiable live same-gist owners
- serialize bearer state-file writes and parse gist heartbeat timestamps numerically
- make daemon scope-id fallback non-empty on systems with sha1sum but no shasum/python

## Copilot #454 check
Addressed still-current reliability comments around broadcast peer degradation, recv lock races, state-file races, inbox cursor/message loss, daemon scope id fallback, and gist heartbeat ordering. Several older comments were already stale on canary (e.g. quoted heredoc wording, gh takeover gating) or are lower-priority follow-ups (structured monitor restart events, daemon loaded-scope verification).

## Validation
- live continuum -> authenticator marker exact-once in both real .airc logs
- live authenticator -> continuum marker exact-once in both real .airc logs
- live continuum status now reports collaboration ok with 1 broadcast peer
- live continuum doctor --health reports Bus healthy
- python3 test/test_bearer.py
- python3 test/test_inbox.py
- python3 test/test_collaboration.py
- python3 test/test_gistparse.py
- ./test/integration.sh inbox
- ./test/integration.sh solo_mesh_warns