### PR TITLE
Surface inbox catch-up in CLI

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -338,6 +338,7 @@ cmd_connect() {
     echo "    To stop it:        airc teardown"
     echo "    To restart it:     airc daemon restart   # or rerun airc connect if no daemon"
     echo "    To check it:       airc status"
+    echo "    To catch up:       airc inbox"
     return 0
     fi
   fi
@@ -1853,6 +1854,7 @@ JSON
       fi
     fi
     echo ""
+    echo "  Catch up unread messages with: airc inbox"
     echo "  Waiting for peers on port $host_port..."
     # Background: accept peer registrations via TCP (public keys only).
     #

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -366,6 +366,8 @@ else:
   else
     echo "  reminder:    off"
   fi
+
+  echo "  inbox:       airc inbox  (catch up unread; use --peek to preview)"
 }
 
 cmd_logs() {

--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -299,9 +299,11 @@ def _gh_api_get(gist_id: str) -> Optional[dict]:
         return None
     if r.returncode != 0:
         combined = (r.stderr or "") + (r.stdout or "")
-        sys.stderr.write(f"[airc:bearer_gh] _gh_api_get({gist_id}): gh api exit={r.returncode}: {combined.strip()[:500]}\n")
-        sys.stderr.flush()
         _gh_api_get._last_err = combined  # type: ignore[attr-defined]
+        kind = _classify_gh_error(combined, True)
+        if kind != "secondary_rate_limit" or _truthy(os.environ.get("AIRC_GH_DEBUG")):
+            sys.stderr.write(f"[airc:bearer_gh] _gh_api_get({gist_id}): gh api exit={r.returncode}: {combined.strip()[:500]}\n")
+            sys.stderr.flush()
         return None
     try:
         return json.loads(r.stdout)

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -1433,6 +1433,23 @@ class GhBearerErrorClassificationTests(unittest.TestCase):
             outcome = self._bearer().send("alice", "general", b'{"x":1}')
         self.assertEqual(outcome.kind, "secondary_rate_limit")
 
+    def test_get_secondary_rate_limit_is_classified_without_stderr_spam(self):
+        """Same-machine local bus can deliver while gh is throttled.
+        The expected 403 must not make a successful send look failed."""
+        import io
+        from contextlib import redirect_stderr
+
+        fake = mock.Mock(returncode=1, stdout="", stderr="gh: API rate limit exceeded (HTTP 403)")
+        with mock.patch.object(bearer_gh, "_resolve_gh_bin", return_value="gh"), \
+             mock.patch.object(bearer_gh.subprocess, "run", return_value=fake):
+            err = io.StringIO()
+            with redirect_stderr(err):
+                gist, kind = bearer_gh._gh_api_get_classified("abc123")
+
+        self.assertIsNone(gist)
+        self.assertEqual(kind, "secondary_rate_limit")
+        self.assertEqual(err.getvalue(), "")
+
     def test_send_returns_gone_when_patch_404s(self):
         """Pre-#381 the PATCH 404 case fell into the auth_failure branch
         (the old `if "404" in detail or "permission" in lower` mash-up).


### PR DESCRIPTION
## Summary
- surface `airc inbox` in `airc status` so agents discover the catch-up primitive without reading skill docs
- show `airc inbox` in the already-running `airc connect` short-circuit and host startup text
- suppress raw GitHub secondary-rate-limit stderr from `_gh_api_get`; the structured outcome still reports rate-limit while local-bus fallback can make the send succeed without scary false-failure output

## Validation
- live `airc status` in continuum shows the inbox catch-up line
- live `airc connect` already-running path shows the catch-up line
- `python3 test/test_bearer.py` (102 OK)
- `python3 test/test_inbox.py`
- `./test/integration.sh inbox`
