### PR TITLE
Let join start under GitHub secondary throttling

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -372,10 +372,12 @@ cmd_connect() {
   if [ "$use_room" = "1" ] && [ "$_looks_like_invite" = "0" ] \
      && command -v gh >/dev/null 2>&1; then
     # Pre-flight via the centralized state machine (lib_auth.sh).
-    # ok → proceed; rate_limited → wait + retry (token fine);
-    # invalid → airc instigates the browser self-heal in-process;
-    # not_installed → caller's outer guard already handled this.
-    airc_ensure_gh_auth_or_heal "airc join" \
+    # ok → proceed; rate_limited → proceed degraded so the monitor can
+    # start and use cached/local transport while GH's burst throttle
+    # clears; invalid → airc instigates the browser self-heal
+    # in-process; not_installed → caller's outer guard already handled
+    # this.
+    AIRC_GH_RATE_LIMIT_NONFATAL=1 airc_ensure_gh_auth_or_heal "airc join" \
       || die "gh auth not OK — see message above for next step"
   fi
 

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -330,15 +330,25 @@ else:
   # The substrate is gh-as-bearer; when gh's keyring goes invalid,
   # everything stops working but nothing surfaces unless they look here.
   if command -v gh >/dev/null 2>&1; then
-    if gh auth status >/dev/null 2>&1; then
-      echo "  gh auth:     ok"
-    elif gh api rate_limit >/dev/null 2>&1; then
-      # Token works (rate_limit reachable); /user got 403'd by secondary
-      # rate limit and gh misreports it as 'token invalid'. Issue #341.
-      echo "  gh auth:     RATE-LIMITED (secondary; token is fine — wait 5-15 min)"
-    else
-      echo "  gh auth:     ✗ INVALID — run 'gh auth login -h github.com' to fix"
-    fi
+    # Use the centralized auth detector instead of raw `gh auth status`
+    # so status reads the OK cache and does not turn frequent health
+    # checks into /user traffic that trips GitHub's secondary limiter.
+    local _gh_state
+    _gh_state="$(airc_detect_gh_auth_state 2>/dev/null || echo invalid)"
+    case "$_gh_state" in
+      ok)
+        echo "  gh auth:     ok"
+        ;;
+      rate_limited)
+        echo "  gh auth:     RATE-LIMITED (secondary; token is fine — wait 5-15 min)"
+        ;;
+      env_token_invalid)
+        echo "  gh auth:     ✗ INVALID GH_TOKEN — unset/fix GH_TOKEN, then retry"
+        ;;
+      *)
+        echo "  gh auth:     ✗ INVALID — run 'gh auth login -h github.com' to fix"
+        ;;
+    esac
   else
     echo "  gh auth:     gh CLI not installed"
   fi

--- a/lib/airc_bash/lib_auth.sh
+++ b/lib/airc_bash/lib_auth.sh
@@ -210,7 +210,10 @@ airc_self_heal_gh_auth() {
 #
 # Behaviour by detected state:
 #   ok                → return 0; caller proceeds
-#   rate_limited      → emit explanation; return 1 (token is fine, wait)
+#   rate_limited      → emit explanation; return 1 by default (token is
+#                       fine, wait). If AIRC_GH_RATE_LIMIT_NONFATAL=1,
+#                       return 0 after warning so monitor startup can
+#                       continue in degraded/cached transport mode.
 #   invalid           → trigger self-heal browser flow; on success re-detect
 #                       to confirm + return 0; on failure emit fallback +
 #                       return 1 (caller dies with its own message)
@@ -254,6 +257,13 @@ airc_ensure_gh_auth_or_heal() {
       echo "    Your token is fine — wait 5-15 minutes and retry." >&2
       echo "    Context: $context" >&2
       echo "" >&2
+      if [ "${AIRC_GH_RATE_LIMIT_NONFATAL:-0}" = "1" ]; then
+        echo "    Continuing in degraded mode: monitor will start; GH-backed" >&2
+        echo "    discovery/publish operations may queue or fail until the" >&2
+        echo "    secondary throttle clears." >&2
+        echo "" >&2
+        return 0
+      fi
       if [ "${AIRC_BACKGROUND_OK:-0}" = "1" ]; then
         local _wait_secs="${AIRC_RATE_LIMIT_WAIT_SEC:-600}"
         echo "    [daemon mode] sleeping ${_wait_secs}s in-process (avoids respawn cascade)..." >&2

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2091,6 +2091,78 @@ PY
   cleanup_all
 }
 
+# ── Scenario: gh_secondary_rate_limit_degraded_startup (#479) ──────────
+# GitHub secondary throttling must not prevent monitor startup. On
+# 2026-05-04 Windows/WSL hit this shape: `gh auth status` tripped the
+# secondary limiter, `gh api rate_limit` still worked, and `airc join`
+# died before the monitor could start or any local/cached transport could
+# recover. Rate limiting is degraded transport, not invalid auth.
+scenario_gh_secondary_rate_limit_degraded_startup() {
+  section "gh_secondary_rate_limit_degraded_startup: join starts degraded under gh secondary throttle"
+  cleanup_all
+
+  local root=/tmp/airc-it-gh-secondary
+  local fakebin="$root/bin"
+  local home="$root/state"
+  mkdir -p "$fakebin" "$home" "$root/tmp"
+
+  cat > "$fakebin/gh" <<'SH'
+#!/bin/sh
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  echo "github.com: token invalid" >&2
+  echo "gh: API rate limit exceeded for user ID 1" >&2
+  exit 1
+fi
+if [ "$1" = "api" ] && [ "$2" = "rate_limit" ]; then
+  echo '{"resources":{"core":{"remaining":4999}}}'
+  exit 0
+fi
+if [ "$1" = "api" ]; then
+  echo "gh: API rate limit exceeded for user ID 1" >&2
+  exit 1
+fi
+if [ "$1" = "gist" ]; then
+  echo "gh: API rate limit exceeded for user ID 1" >&2
+  exit 1
+fi
+echo "fake gh: unsupported $*" >&2
+exit 1
+SH
+  chmod +x "$fakebin/gh"
+
+  (
+    cd "$root" || exit 1
+    PATH="$fakebin:$PATH" \
+      AIRC_HOME="$home" \
+      AIRC_NAME=gh-secondary-test \
+      AIRC_NO_DISCOVERY=1 \
+      AIRC_NO_GENERAL=1 \
+      AIRC_AUTH_CACHE_SEC=0 \
+      AIRC_RATE_LIMIT_WAIT_SEC=1 \
+      TMPDIR="$root/tmp" \
+      "$AIRC" connect --room gh-secondary-test > "$root/out.log" 2>&1
+  ) &
+  local pid=$!
+  sleep 6
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+
+  local out
+  out=$(cat "$root/out.log" 2>/dev/null)
+  echo "$out" | grep -q 'Continuing in degraded mode' \
+    && pass "join treats gh secondary throttle as degraded, not fatal" \
+    || fail "join did not enter degraded mode under gh secondary throttle ($out)"
+  echo "$out" | grep -q 'gh auth not OK' \
+    && fail "join still hard-failed gh auth under secondary throttle ($out)" \
+    || pass "join did not print fatal gh-auth failure under secondary throttle"
+  echo "$out" | grep -q 'Hosting #gh-secondary-test' \
+    && pass "join proceeded far enough to start the room monitor path" \
+    || fail "join did not proceed to room startup after degraded auth ($out)"
+
+  rm -rf "$root"
+  cleanup_all
+}
+
 # ── Scenario: solo_mesh_warns (transport health != collaboration) ───────
 # A self-healed host can have fresh local transport/bearer state while no
 # peers are actually paired to the mesh. `airc status` / `doctor --health`
@@ -4277,6 +4349,7 @@ case "$MODE" in
   auto_scope)   scenario_auto_scope ;;
   send_dead_monitor_dies) scenario_send_dead_monitor_dies ;;
   monitor_liveness_process_evidence) scenario_monitor_liveness_process_evidence ;;
+  gh_secondary_rate_limit_degraded_startup) scenario_gh_secondary_rate_limit_degraded_startup ;;
   solo_mesh_warns) scenario_solo_mesh_warns ;;
   connect_after_kill_recovers) scenario_connect_after_kill_recovers ;;
   general_sidecar_default) scenario_general_sidecar_default ;;
@@ -4312,6 +4385,7 @@ case "$MODE" in
     scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat
     scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope
     scenario_send_dead_monitor_dies; scenario_monitor_liveness_process_evidence
+    scenario_gh_secondary_rate_limit_degraded_startup
     scenario_solo_mesh_warns
     scenario_connect_after_kill_recovers
     scenario_general_sidecar_default; scenario_away
@@ -4324,7 +4398,7 @@ case "$MODE" in
     scenario_custom_room_creates_gist
     scenario_invite_human
     ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|monitor_liveness_process_evidence|solo_mesh_warns|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|monitor_liveness_process_evidence|gh_secondary_rate_limit_degraded_startup|solo_mesh_warns|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary
- Treat GitHub secondary rate limiting as degraded startup for `airc join` instead of a fatal auth failure.
- Keep invalid/revoked auth fatal/self-healing, but let monitors start when `/user` is throttled and `/rate_limit` proves the token is still valid.
- Route `airc status` through the cached auth detector so repeated health checks do not spam `gh auth status` and worsen the throttle.
- Add an integration scenario with a fake throttled `gh` covering the Windows/WSL #479 failure shape.

## Validation
- `bash -n lib/airc_bash/lib_auth.sh lib/airc_bash/cmd_connect.sh lib/airc_bash/cmd_status.sh test/integration.sh`
- `./test/integration.sh gh_secondary_rate_limit_degraded_startup`
- `./test/integration.sh monitor_liveness_process_evidence`
- `./test/integration.sh solo_mesh_warns`
- `python3 test/test_bearer.py` (102 tests)
- `git diff --check`

## Notes
This does not pretend a solo mesh is healthy. It only prevents GitHub's secondary throttle from stopping the monitor before local/cached transport and visible diagnostics can do their job.

Fixes #479.
