### PR TITLE
Cache GitHub probes and honor rate backoff

### DIFF
--- a/airc
+++ b/airc
@@ -2080,8 +2080,10 @@ except Exception:
 # this loop, every host restart breaks the substrate until manual
 # intervention — the satellite-killer scenario.
 #
-# Cost: one `gh gist list` per cycle (~150 bytes over the wire). At
-# 300s default cadence: 12 calls/hour, well under gh's 5000/hr ceiling.
+# Cost is bounded by channel_gist's shared gist-list cache. Do not make
+# this a tight GitHub loop: several agents on one machine/account share
+# the same substrate, and "cheap" health/discovery probes can still trip
+# secondary limits when multiplied across tabs.
 #
 # Single-account scope: _mesh_find lists the CURRENT gh account's
 # gists. For mesh peers on the same gh account (the dominant case
@@ -2093,16 +2095,12 @@ except Exception:
 # is out of scope; loud-fail (Mac's bearer_gh.py PR) covers that path.
 _mesh_rediscover_loop() {
   local _parent_pid="$PPID"
-  # Cadence: 30s default. Was 300s → 60s in #407 → 30s here. Joel's
-  # "satellite/bios" framing wants the tightest cadence that's still
-  # gh-rate-limit safe. _mesh_find does ~1 gh api call per cycle
-  # (~120 calls/hour/peer at 30s), well under gh's 5000/hr limit.
-  # Tonight's repro 2026-05-02: I rotated my host gist via teardown,
-  # 60s+ later b69f still couldn't reach me — Joel had to relay.
-  # 30s halves that worst-case window and starts approaching the
-  # bearer's own 15s poll cadence so the rediscover happens at most
-  # 2 polls late from the bearer's PoV.
-  local interval="${AIRC_MESH_REDISCOVER_SEC:-30}"
+  # Cadence: 120s default. The prior 30s loop was survivable for one
+  # process but not for four agents on the same gh account plus humans
+  # running status/doctor. channel_gist caches the actual list call, so
+  # normal recovery is still fast enough without making GitHub a liveness
+  # dependency.
+  local interval="${AIRC_MESH_REDISCOVER_SEC:-120}"
   while true; do
     sleep "$interval"
     if ! kill -0 "$_parent_pid" 2>/dev/null; then

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -184,13 +184,29 @@ _doctor_probe_gh_auth() {
   if ! command -v gh >/dev/null 2>&1; then
     return 0  # already reported missing by the gh probe
   fi
-  if gh auth status >/dev/null 2>&1; then
-    printf "  [ok] gh authenticated\n"
-    return 0
-  fi
-  printf "  [MISSING] gh authenticated (gist scope)\n"
-  printf "         Fix: gh auth login -s gist\n"
-  return 1
+  local _state
+  _state="$(airc_detect_gh_auth_state 2>/dev/null || echo invalid)"
+  case "$_state" in
+    ok)
+      printf "  [ok] gh authenticated\n"
+      return 0
+      ;;
+    rate_limited)
+      printf "  [BLOCKED] gh secondary rate limit (abuse detection) — token is fine\n"
+      printf "         Fix: wait 5-15 min; airc caches probes so health checks do not deepen the throttle\n"
+      return 1
+      ;;
+    env_token_invalid)
+      printf "  [BLOCKED] GH_TOKEN is set but invalid\n"
+      printf "         Fix: unset/fix GH_TOKEN, then retry\n"
+      return 1
+      ;;
+    *)
+      printf "  [MISSING] gh authenticated (gist scope)\n"
+      printf "         Fix: gh auth login -s gist\n"
+      return 1
+      ;;
+  esac
 }
 
 # Probe the venv cryptography package — issue #341 follow-up. airc's
@@ -275,36 +291,43 @@ _doctor_connect_preflight() {
   # gist-scope-less token (Copilot caught this on #87 review).
   if ! _doctor_probe "gh" "$mgr" "Gist substrate (room discovery)"; then
     issues=$((issues+1))
-  elif ! gh auth status >/dev/null 2>&1; then
+  else
+    local _gh_state
+    _gh_state="$(airc_detect_gh_auth_state 2>/dev/null || echo invalid)"
+    if [ "$_gh_state" != "ok" ]; then
     # Distinguish a real auth failure from a GitHub secondary rate limit
     # (abuse detection). The /rate_limit endpoint is reachable during
     # secondary limits, so if it works, the token is fine — the user just
     # needs to wait. `gh auth status` probes /user, which gets 403'd, and
     # gh then misreports the symptom as 'token invalid'. Issue #341.
-    if gh api rate_limit >/dev/null 2>&1; then
+    if [ "$_gh_state" = "rate_limited" ]; then
       printf "  [BLOCKED] gh secondary rate limit (abuse detection) — token is fine\n"
-      printf "         Fix: wait 5-15 min then re-run; cause is too many gh API calls in a short window\n"
+      printf "         Fix: wait 5-15 min; airc caches probes so health checks do not deepen the throttle\n"
+    elif [ "$_gh_state" = "env_token_invalid" ]; then
+      printf "  [BLOCKED] GH_TOKEN is set but invalid\n"
+      printf "         Fix: unset/fix GH_TOKEN, then retry\n"
     else
       printf "  [BLOCKED] gh authenticated\n"
       printf "         Fix: gh auth login -s gist\n"
     fi
     issues=$((issues+1))
-  elif ! gh auth status 2>&1 | grep -qiE '(scopes|token scopes):.*\bgist\b'; then
+    elif ! gh auth status 2>&1 | grep -qiE '(scopes|token scopes):.*\bgist\b'; then
     printf "  [BLOCKED] gh authed but missing 'gist' scope (room substrate needs it)\n"
     printf "         Fix: gh auth refresh -s gist\n"
     issues=$((issues+1))
-  elif ! gh api 'gists?per_page=1' >/dev/null 2>&1; then
+    elif ! gh api 'gists?per_page=1' >/dev/null 2>&1; then
     # Same misdiagnosis risk here — distinguish rate-limit vs other.
-    if gh api rate_limit >/dev/null 2>&1; then
+    if airc_gh_rate_limit_json_cached >/dev/null 2>&1; then
       printf "  [BLOCKED] gh secondary rate limit (abuse detection) — token + scope are fine\n"
-      printf "         Fix: wait 5-15 min then re-run\n"
+      printf "         Fix: wait 5-15 min; airc caches probes so health checks do not deepen the throttle\n"
     else
       printf "  [BLOCKED] gist API not reachable -- network outage or token revoked\n"
       printf "         Fix: check internet; if persistent, run 'gh auth refresh'\n"
     fi
     issues=$((issues+1))
-  else
+    else
     printf "  [ok] gh authed with gist scope, gists API reachable\n"
+    fi
   fi
 
   # ── Connect-specific: tailscale state. The default doctor only marks
@@ -434,7 +457,7 @@ _doctor_health() {
   # the cliff that wedged the bus pre-#416/#419.
   if command -v gh >/dev/null 2>&1; then
     local rate_json
-    if rate_json=$(gh api rate_limit 2>/dev/null); then
+    if rate_json=$(airc_gh_rate_limit_json_cached); then
       local core_remaining core_limit
       core_remaining=$(echo "$rate_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['resources']['core']['remaining'])" 2>/dev/null || echo "")
       core_limit=$(echo "$rate_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['resources']['core']['limit'])" 2>/dev/null || echo "")

--- a/lib/airc_bash/lib_auth.sh
+++ b/lib/airc_bash/lib_auth.sh
@@ -29,6 +29,59 @@
 # (airc_self_heal_gh_auth) so callers control when re-auth is allowed
 # (interactive contexts only).
 
+# ── airc_gh_rate_limit_json_cached — cheap/budgeted rate-limit probe ──
+#
+# `gh api rate_limit` is cheaper than `/user`, but it is still a GitHub
+# request. During an outage humans and agents hammer `airc status` /
+# `doctor --health`, and repeated "health" probes can deepen the same
+# secondary throttle they are trying to diagnose. Cache successful JSON
+# briefly and cache failures even more briefly so observation has a
+# bounded request rate.
+#
+# Env:
+#   AIRC_GH_RATE_CACHE_SEC       success TTL, default 300s
+#   AIRC_GH_RATE_FAIL_CACHE_SEC  failure TTL, default 60s
+#
+# Returns:
+#   0 + prints JSON when fresh cache or live probe succeeds
+#   1 when gh missing, live probe fails, or recent failure backoff active
+airc_gh_rate_limit_json_cached() {
+  command -v gh >/dev/null 2>&1 || return 1
+
+  local _uid; _uid=$(id -u 2>/dev/null || echo nobody)
+  local _base="${TMPDIR:-/tmp}/airc-gh-rate-limit-${_uid}"
+  local _cache_file="${_base}.json"
+  local _fail_file="${_base}.fail"
+  local _ok_ttl="${AIRC_GH_RATE_CACHE_SEC:-300}"
+  local _fail_ttl="${AIRC_GH_RATE_FAIL_CACHE_SEC:-60}"
+  local _now; _now=$(date +%s 2>/dev/null || echo 0)
+
+  if [ -f "$_cache_file" ]; then
+    local _cache_mtime; _cache_mtime=$(file_mtime "$_cache_file" 2>/dev/null || echo 0)
+    if [ "$(( _now - _cache_mtime ))" -lt "$_ok_ttl" ] 2>/dev/null; then
+      cat "$_cache_file" 2>/dev/null && return 0
+    fi
+  fi
+
+  if [ -f "$_fail_file" ]; then
+    local _fail_mtime; _fail_mtime=$(file_mtime "$_fail_file" 2>/dev/null || echo 0)
+    if [ "$(( _now - _fail_mtime ))" -lt "$_fail_ttl" ] 2>/dev/null; then
+      return 1
+    fi
+  fi
+
+  local _json
+  if _json=$(gh api rate_limit 2>/dev/null) && [ -n "$_json" ]; then
+    printf '%s\n' "$_json" > "$_cache_file" 2>/dev/null || true
+    rm -f "$_fail_file" 2>/dev/null || true
+    printf '%s\n' "$_json"
+    return 0
+  fi
+
+  : > "$_fail_file" 2>/dev/null || true
+  return 1
+}
+
 # ── airc_detect_gh_auth_state — echo one of {ok, invalid, rate_limited, not_installed} ──
 #
 # Probes gh's auth state without side-effects. Output goes to STDOUT
@@ -110,7 +163,7 @@ airc_detect_gh_auth_state() {
   # (c) Real keyring auth failure (no GH_TOKEN env, keyring is dead).
   #     This is the common Joel-reports-FREQUENT case, and the case
   #     self-heal CAN fix via the browser flow.
-  if gh api rate_limit >/dev/null 2>&1; then
+  if airc_gh_rate_limit_json_cached >/dev/null 2>&1; then
     echo "rate_limited"
   elif [ -n "${GH_TOKEN:-}" ]; then
     # GH_TOKEN takes precedence over the keyring in gh's auth resolution.

--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -42,6 +42,7 @@ import time as _time
 from collections import deque
 from typing import Iterator, Optional, Tuple
 
+from . import gh_backoff
 from .bearer import (
     Bearer,
     BearerError,
@@ -285,9 +286,12 @@ def _gh_api_get(gist_id: str) -> Optional[dict]:
         sys.stderr.flush()
         _gh_api_get._last_err = str(e)  # type: ignore[attr-defined]
         return None
+    if gh_backoff.backoff_active():
+        _gh_api_get._last_err = "secondary rate limit backoff active"  # type: ignore[attr-defined]
+        return None
     try:
         r = subprocess.run(
-            [gh, "api", f"gists/{gist_id}"],
+            [gh, "api", "--include", f"gists/{gist_id}"],
             capture_output=True,
             text=True,
             timeout=_GH_API_TIMEOUT,
@@ -301,12 +305,16 @@ def _gh_api_get(gist_id: str) -> Optional[dict]:
         combined = (r.stderr or "") + (r.stdout or "")
         _gh_api_get._last_err = combined  # type: ignore[attr-defined]
         kind = _classify_gh_error(combined, True)
+        if kind == "secondary_rate_limit":
+            gh_backoff.record_backoff(combined)
         if kind != "secondary_rate_limit" or _truthy(os.environ.get("AIRC_GH_DEBUG")):
             sys.stderr.write(f"[airc:bearer_gh] _gh_api_get({gist_id}): gh api exit={r.returncode}: {combined.strip()[:500]}\n")
             sys.stderr.flush()
         return None
     try:
-        return json.loads(r.stdout)
+        headers, body = gh_backoff.split_include_output(r.stdout)
+        gh_backoff.record_backoff(headers)
+        return json.loads(body)
     except (ValueError, TypeError) as e:
         sys.stderr.write(f"[airc:bearer_gh] _gh_api_get({gist_id}): JSON parse failed: {e}; first 200 bytes: {(r.stdout or '')[:200]!r}\n")
         sys.stderr.flush()
@@ -369,10 +377,12 @@ def _gh_api_patch_messages_jsonl(gist_id: str, content: str) -> tuple[bool, str]
         gh = _resolve_gh_bin()
     except GhBearerError as e:
         return (False, str(e))
+    if gh_backoff.backoff_active():
+        return (False, "secondary rate limit backoff active")
     body = json.dumps({"files": {_MESSAGES_FILE: {"content": content}}})
     try:
         r = subprocess.run(
-            [gh, "api", "--method", "PATCH", f"gists/{gist_id}", "--input", "-"],
+            [gh, "api", "--include", "--method", "PATCH", f"gists/{gist_id}", "--input", "-"],
             input=body,
             capture_output=True,
             text=True,
@@ -381,8 +391,12 @@ def _gh_api_patch_messages_jsonl(gist_id: str, content: str) -> tuple[bool, str]
     except (subprocess.TimeoutExpired, OSError) as e:
         return (False, f"gh api PATCH failed: {e}")
     if r.returncode == 0:
+        headers, _ = gh_backoff.split_include_output(r.stdout)
+        gh_backoff.record_backoff(headers)
         return (True, "")
     err = (r.stderr or r.stdout or "gh api PATCH failed").strip()
+    if _classify_gh_error(err, True) == "secondary_rate_limit":
+        gh_backoff.record_backoff(err)
     return (False, err)
 
 

--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -33,8 +33,11 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from datetime import datetime, timezone
 from typing import Optional
+
+from . import gh_backoff
 
 
 _GH_BIN = "gh"
@@ -57,6 +60,40 @@ _LOCAL_SCAN_PRUNE = {
 }
 
 
+def _cache_path(name: str) -> str:
+    uid = str(os.getuid()) if hasattr(os, "getuid") else os.environ.get("USERNAME", "user")
+    return os.path.join(tempfile.gettempdir(), f"airc-{name}-{uid}.json")
+
+
+def _load_cached_gist_list(max_age: float) -> Optional[list[dict]]:
+    path = _cache_path("gh-gist-list")
+    try:
+        age = time.time() - os.path.getmtime(path)
+        if age > max_age:
+            return None
+        with open(path, encoding="utf-8") as f:
+            loaded = json.load(f)
+        if isinstance(loaded, list):
+            return loaded
+    except (OSError, ValueError, TypeError):
+        return None
+    return None
+
+
+def _save_cached_gist_list(gists: list[dict]) -> None:
+    path = _cache_path("gh-gist-list")
+    tmp = f"{path}.{os.getpid()}.tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(gists, f)
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
 def _resolve_gh_bin() -> Optional[str]:
     """Return path to gh CLI, or None if absent. Caller-visible None
     means we can't do gh-side resolution at all — return early."""
@@ -70,42 +107,48 @@ def _gh_list_user_gists() -> list[dict]:
     Uses `gh api gists` (with pagination) rather than `gh gist list`
     because the JSON shape is stable + complete. gh gist list output
     is human-shaped (tab-delimited) and shifts across versions.
+
+    Cached because this is the hottest GitHub control-plane path:
+    join discovery, send-path recovery, and the rediscovery loop all
+    call through here. One machine can run several agents on the same
+    gh account, so "one list every 30s" quickly becomes enough traffic
+    to trip secondary limits. Fresh cache default is 60s; if the live
+    probe fails, stale cache default is 15m so peers can keep using the
+    last-known room map instead of creating new islands.
     """
+    cache_sec = float(os.environ.get("AIRC_GIST_LIST_CACHE_SEC", "60"))
+    stale_sec = float(os.environ.get("AIRC_GIST_LIST_STALE_SEC", "900"))
+    cached = _load_cached_gist_list(cache_sec)
+    if cached is not None:
+        return cached
+    if gh_backoff.backoff_active():
+        return _load_cached_gist_list(stale_sec) or []
+
     gh = _resolve_gh_bin()
     if gh is None:
-        return []
+        return _load_cached_gist_list(stale_sec) or []
     try:
         r = subprocess.run(
-            [gh, "api", f"gists?per_page={_GIST_LIST_LIMIT}", "--paginate"],
+            [gh, "api", "--include", f"gists?per_page={_GIST_LIST_LIMIT}"],
             capture_output=True,
             text=True,
             timeout=_GH_API_TIMEOUT * 3,
         )
     except (subprocess.TimeoutExpired, OSError):
-        return []
+        return _load_cached_gist_list(stale_sec) or []
     if r.returncode != 0:
-        return []
+        gh_backoff.record_backoff((r.stderr or "") + (r.stdout or ""))
+        return _load_cached_gist_list(stale_sec) or []
     out: list[dict] = []
-    # `--paginate` concatenates JSON arrays inline. Split on `][` to
-    # rejoin pages without depending on gh's exact output shape.
-    raw = r.stdout.strip()
+    headers, body = gh_backoff.split_include_output(r.stdout)
+    gh_backoff.record_backoff(headers)
+    raw = body.strip()
     if not raw:
         return []
-    chunks = raw.replace("][", "],[")
-    if chunks.startswith("["):
-        chunks = chunks
     try:
-        # Try direct parse first (single-page or already-merged).
         loaded = json.loads(raw)
         if isinstance(loaded, list):
-            return loaded
-    except (ValueError, TypeError):
-        pass
-    # Fallback: split into separate JSON arrays and merge.
-    try:
-        joined = "[" + chunks.lstrip("[").rstrip("]") + "]"
-        loaded = json.loads(joined)
-        if isinstance(loaded, list):
+            _save_cached_gist_list(loaded)
             return loaded
     except (ValueError, TypeError):
         pass
@@ -163,17 +206,22 @@ def _gh_api_get_gist(gist_id: str) -> Optional[dict]:
     gh = _resolve_gh_bin()
     if gh is None:
         return None
+    if gh_backoff.backoff_active():
+        return None
     try:
         r = subprocess.run(
-            [gh, "api", f"gists/{gist_id}"],
+            [gh, "api", "--include", f"gists/{gist_id}"],
             capture_output=True, text=True, timeout=_GH_API_TIMEOUT,
         )
     except (subprocess.TimeoutExpired, OSError):
         return None
     if r.returncode != 0:
+        gh_backoff.record_backoff((r.stderr or "") + (r.stdout or ""))
         return None
+    headers, body = gh_backoff.split_include_output(r.stdout)
+    gh_backoff.record_backoff(headers)
     try:
-        return json.loads(r.stdout)
+        return json.loads(body)
     except (ValueError, TypeError):
         return None
 

--- a/lib/airc_core/gh_backoff.py
+++ b/lib/airc_core/gh_backoff.py
@@ -1,0 +1,75 @@
+"""Shared GitHub API backoff state for AIRC transports."""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+import time
+
+
+def _uid() -> str:
+    return str(os.getuid()) if hasattr(os, "getuid") else os.environ.get("USERNAME", "user")
+
+
+def backoff_path() -> str:
+    return os.path.join(tempfile.gettempdir(), f"airc-gh-backoff-until-{_uid()}")
+
+
+def backoff_until() -> float:
+    try:
+        with open(backoff_path(), encoding="utf-8") as f:
+            return float(f.read().strip() or "0")
+    except (OSError, ValueError):
+        return 0.0
+
+
+def backoff_active() -> bool:
+    return time.time() < backoff_until()
+
+
+def record_backoff(output: str) -> None:
+    """Record a shared GitHub backoff window from headers/body."""
+    body = (output or "").lower()
+    if not body:
+        return
+    now = time.time()
+    until = 0.0
+    retry = re.search(r"^retry-after:\s*(\d+)\s*$", body, re.MULTILINE)
+    if retry:
+        until = now + max(1, int(retry.group(1)))
+    else:
+        remaining = re.search(r"^x-ratelimit-remaining:\s*(\d+)\s*$", body, re.MULTILINE)
+        reset = re.search(r"^x-ratelimit-reset:\s*(\d+)\s*$", body, re.MULTILINE)
+        if remaining and reset and remaining.group(1) == "0":
+            until = float(reset.group(1))
+        elif (
+            "secondary rate limit" in body
+            or "rate limit exceeded" in body
+            or "abuse detection" in body
+        ):
+            until = now + 60.0
+    if until <= now:
+        return
+    path = backoff_path()
+    until = max(until, backoff_until())
+    tmp = f"{path}.{os.getpid()}.tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(str(int(until)))
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def split_include_output(raw: str) -> tuple[str, str]:
+    """Return (headers, body) from `gh api --include` output."""
+    text = raw or ""
+    normalized = text.replace("\r\n", "\n")
+    if normalized.startswith("HTTP/") and "\n\n" in normalized:
+        headers, body = normalized.split("\n\n", 1)
+        return headers, body
+    return "", text

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2105,6 +2105,7 @@ scenario_gh_secondary_rate_limit_degraded_startup() {
   local fakebin="$root/bin"
   local home="$root/state"
   mkdir -p "$fakebin" "$home" "$root/tmp"
+  rm -f "$root/tmp"/airc-gh-auth-ok-* "$root/tmp"/airc-gh-rate-limit-* "$root/tmp"/airc-gh-backoff-until-* 2>/dev/null || true
 
   cat > "$fakebin/gh" <<'SH'
 #!/bin/sh
@@ -2132,12 +2133,14 @@ SH
 
   (
     cd "$root" || exit 1
-    PATH="$fakebin:$PATH" \
+    env -i \
+      HOME="$HOME" \
+      PATH="$fakebin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" \
       AIRC_HOME="$home" \
       AIRC_NAME=gh-secondary-test \
       AIRC_NO_DISCOVERY=1 \
       AIRC_NO_GENERAL=1 \
-      AIRC_AUTH_CACHE_SEC=0 \
+      AIRC_AUTH_CACHE_SEC=-1 \
       AIRC_RATE_LIMIT_WAIT_SEC=1 \
       TMPDIR="$root/tmp" \
       "$AIRC" connect --room gh-secondary-test > "$root/out.log" 2>&1

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -38,6 +38,7 @@ from airc_core.bearer_gh import GhBearer, GhBearerError  # noqa: E402
 from airc_core import bearer_local  # noqa: E402
 from airc_core import bearer_gh  # noqa: E402
 from airc_core import bearer_cli  # noqa: E402
+from airc_core import gh_backoff  # noqa: E402
 
 
 class BearerInterfaceTests(unittest.TestCase):
@@ -1440,7 +1441,9 @@ class GhBearerErrorClassificationTests(unittest.TestCase):
         from contextlib import redirect_stderr
 
         fake = mock.Mock(returncode=1, stdout="", stderr="gh: API rate limit exceeded (HTTP 403)")
-        with mock.patch.object(bearer_gh, "_resolve_gh_bin", return_value="gh"), \
+        with tempfile.TemporaryDirectory() as tmp, \
+             mock.patch.object(tempfile, "gettempdir", return_value=tmp), \
+             mock.patch.object(bearer_gh, "_resolve_gh_bin", return_value="gh"), \
              mock.patch.object(bearer_gh.subprocess, "run", return_value=fake):
             err = io.StringIO()
             with redirect_stderr(err):
@@ -1449,6 +1452,31 @@ class GhBearerErrorClassificationTests(unittest.TestCase):
         self.assertIsNone(gist)
         self.assertEqual(kind, "secondary_rate_limit")
         self.assertEqual(err.getvalue(), "")
+
+    def test_secondary_rate_limit_records_shared_backoff(self):
+        fake = mock.Mock(returncode=1, stdout="", stderr="retry-after: 123\ngh: secondary rate limit")
+        with tempfile.TemporaryDirectory() as tmp, \
+             mock.patch.object(tempfile, "gettempdir", return_value=tmp), \
+             mock.patch.object(bearer_gh, "_resolve_gh_bin", return_value="gh"), \
+             mock.patch.object(bearer_gh.subprocess, "run", return_value=fake):
+            gist, kind = bearer_gh._gh_api_get_classified("abc123")
+            backoff_until = gh_backoff.backoff_until()
+
+        self.assertIsNone(gist)
+        self.assertEqual(kind, "secondary_rate_limit")
+        self.assertGreater(backoff_until, bearer_gh._time.time() + 100)
+
+    def test_backoff_active_skips_gh_get(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+             mock.patch.object(tempfile, "gettempdir", return_value=tmp), \
+             mock.patch.object(bearer_gh, "_resolve_gh_bin", return_value="gh"), \
+             mock.patch.object(bearer_gh.subprocess, "run") as run:
+            gh_backoff.record_backoff("retry-after: 120")
+            gist, kind = bearer_gh._gh_api_get_classified("abc123")
+
+        self.assertIsNone(gist)
+        self.assertEqual(kind, "secondary_rate_limit")
+        run.assert_not_called()
 
     def test_send_returns_gone_when_patch_404s(self):
         """Pre-#381 the PATCH 404 case fell into the auth_failure branch

--- a/test/test_channel_gist.py
+++ b/test/test_channel_gist.py
@@ -12,6 +12,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
+import subprocess
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "lib"))
@@ -204,6 +205,59 @@ class LocalCacheFallbackTests(unittest.TestCase):
                  mock.patch.object(channel_gist, "_gh_list_user_gists", return_value=[]), \
                  mock.patch.object(channel_gist, "_git_gist_snapshot", side_effect=lambda gid: snapshots.get(gid)):
                 self.assertEqual(channel_gist.find_existing("cambriantech"), current)
+
+
+class GistListCacheTests(unittest.TestCase):
+    """Gist discovery should not spam GitHub during monitor/status churn."""
+
+    def _cache_path(self, tmp: str) -> Path:
+        uid = str(os.getuid()) if hasattr(os, "getuid") else os.environ.get("USERNAME", "user")
+        return Path(tmp) / f"airc-gh-gist-list-{uid}.json"
+
+    def test_fresh_cache_avoids_gh_api_call(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            listing = [{"id": "cached", "description": "airc mesh", "files": {}}]
+            cache = self._cache_path(tmp)
+            cache.write_text(json.dumps(listing), encoding="utf-8")
+            with mock.patch.object(tempfile, "gettempdir", return_value=tmp), \
+                 mock.patch.dict(os.environ, {"AIRC_GIST_LIST_CACHE_SEC": "300"}), \
+                 mock.patch.object(channel_gist, "_resolve_gh_bin", return_value="/bin/gh"), \
+                 mock.patch.object(subprocess, "run") as run:
+                self.assertEqual(channel_gist._gh_list_user_gists(), listing)
+                run.assert_not_called()
+
+    def test_live_success_refreshes_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            listing = [{"id": "live", "description": "airc room: #general", "files": {}}]
+            completed = subprocess.CompletedProcess(
+                args=["gh"], returncode=0, stdout=json.dumps(listing), stderr=""
+            )
+            with mock.patch.object(tempfile, "gettempdir", return_value=tmp), \
+                 mock.patch.dict(os.environ, {"AIRC_GIST_LIST_CACHE_SEC": "0"}), \
+                 mock.patch.object(channel_gist, "_resolve_gh_bin", return_value="/bin/gh"), \
+                 mock.patch.object(subprocess, "run", return_value=completed):
+                self.assertEqual(channel_gist._gh_list_user_gists(), listing)
+            cache = self._cache_path(tmp)
+            self.assertEqual(json.loads(cache.read_text(encoding="utf-8")), listing)
+
+    def test_rate_limited_live_probe_uses_stale_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            listing = [{"id": "stale-but-useful", "description": "airc mesh", "files": {}}]
+            cache = self._cache_path(tmp)
+            cache.write_text(json.dumps(listing), encoding="utf-8")
+            old = 120
+            os.utime(cache, (os.path.getatime(cache) - old, os.path.getmtime(cache) - old))
+            completed = subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="secondary rate limit"
+            )
+            with mock.patch.object(tempfile, "gettempdir", return_value=tmp), \
+                 mock.patch.dict(os.environ, {
+                     "AIRC_GIST_LIST_CACHE_SEC": "0",
+                     "AIRC_GIST_LIST_STALE_SEC": "900",
+                 }), \
+                 mock.patch.object(channel_gist, "_resolve_gh_bin", return_value="/bin/gh"), \
+                 mock.patch.object(subprocess, "run", return_value=completed):
+                self.assertEqual(channel_gist._gh_list_user_gists(), listing)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add shared `airc_core.gh_backoff` state so one GitHub secondary-limit response creates a same-user backoff deadline all local AIRC processes respect.
- Parse `retry-after`, `x-ratelimit-remaining`, and `x-ratelimit-reset` from `gh api --include` responses on the requests AIRC already makes, instead of relying on extra `/rate_limit` probes.
- Cache gist-list discovery with stale fallback so rediscovery/join can keep using last-known room maps while GitHub is throttled instead of creating new islands.
- Slow the rediscovery loop default from 30s to 120s; the shared cache keeps recovery bounded without multiplying calls across local agents.
- Route doctor/status auth and rate-limit checks through cached helpers where possible.
- Harden the fake-GH secondary-throttle integration so it cannot accidentally use the real Homebrew `gh` from the shell environment.

## Validation
- `python3 -m py_compile lib/airc_core/bearer_gh.py lib/airc_core/channel_gist.py lib/airc_core/gh_backoff.py`
- `python3 test/test_bearer.py` (104 tests)
- `python3 test/test_channel_gist.py` (11 tests)
- `./test/integration.sh gh_secondary_rate_limit_degraded_startup`
- `./test/integration.sh solo_mesh_warns`
- `./test/integration.sh monitor_liveness_process_evidence`
- `bash -n airc lib/airc_bash/lib_auth.sh lib/airc_bash/cmd_doctor.sh lib/airc_bash/cmd_status.sh test/integration.sh`
- `git diff --check`

## Notes
Windows and other local tabs should stay paused until this lands on canary. After merge, do one controlled `airc update --channel canary && airc connect` per scope so every monitor loads the shared backoff/cache code.
