### PR TITLE
Constrain local gist fallback to known AIRC configs

### DIFF
--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -44,22 +44,6 @@ _GH_BIN = "gh"
 _GH_API_TIMEOUT = 10.0
 _GIST_LIST_LIMIT = 100   # `airc list` uses 50; we go a bit higher to be safe
 _GIST_ID_CHARS = set("0123456789abcdefABCDEF")
-_LOCAL_SCAN_MAX_DEPTH = 7
-_LOCAL_SCAN_PRUNE = {
-    ".git",
-    ".hg",
-    ".svn",
-    ".venv",
-    "__pycache__",
-    "node_modules",
-    "target",
-    "dist",
-    "build",
-    ".next",
-    ".turbo",
-}
-
-
 def _cache_path(name: str) -> str:
     uid = str(os.getuid()) if hasattr(os, "getuid") else os.environ.get("USERNAME", "user")
     return os.path.join(tempfile.gettempdir(), f"airc-{name}-{uid}.json")
@@ -311,28 +295,28 @@ def _strict_single_channel_match(gist: dict, channel: str, require_invite: bool 
     return False
 
 
-def _local_scan_roots() -> list[str]:
+def _local_config_paths() -> list[str]:
     raw = os.environ.get("AIRC_GIST_CACHE_ROOTS", "")
-    roots: list[str] = []
+    paths: list[str] = []
     if raw:
-        roots.extend(p for p in raw.split(os.pathsep) if p)
+        for entry in (p for p in raw.split(os.pathsep) if p):
+            expanded = os.path.abspath(os.path.expanduser(entry))
+            if os.path.isdir(expanded):
+                paths.append(os.path.join(expanded, "config.json"))
+            else:
+                paths.append(expanded)
     airc_home = os.environ.get("AIRC_HOME", "")
     if airc_home:
-        roots.append(os.path.dirname(os.path.dirname(os.path.abspath(airc_home))))
-    cwd = os.getcwd()
-    roots.append(cwd)
-    home = os.path.expanduser("~")
-    for rel in ("Development", "dev", "src", "Code"):
-        roots.append(os.path.join(home, rel))
+        paths.append(os.path.join(os.path.abspath(airc_home), "config.json"))
 
     out: list[str] = []
     seen: set[str] = set()
-    for root in roots:
-        root = os.path.abspath(os.path.expanduser(root))
-        if root in seen or not os.path.isdir(root):
+    for path in paths:
+        path = os.path.abspath(os.path.expanduser(path))
+        if path in seen or not os.path.isfile(path):
             continue
-        seen.add(root)
-        out.append(root)
+        seen.add(path)
+        out.append(path)
     return out
 
 
@@ -341,33 +325,27 @@ def _local_config_gist_candidates(channel: str) -> list[tuple[str, float]]:
 
     This is deliberately read-only evidence. It lets a machine recover
     a previously-known canonical room while the gh REST listing surface
-    is unavailable, without creating a new island.
+    is unavailable, without creating a new island. Default discovery is
+    intentionally constrained to the current AIRC_HOME; broader scans
+    are opt-in through AIRC_GIST_CACHE_ROOTS so background daemons do not
+    crawl user folders or trip OS privacy prompts.
     """
     found: dict[str, float] = {}
-    for root in _local_scan_roots():
-        root_depth = root.rstrip(os.sep).count(os.sep)
-        for dirpath, dirnames, filenames in os.walk(root):
-            dirnames[:] = [d for d in dirnames if d not in _LOCAL_SCAN_PRUNE]
-            if dirpath.rstrip(os.sep).count(os.sep) - root_depth > _LOCAL_SCAN_MAX_DEPTH:
-                dirnames[:] = []
-                continue
-            if "config.json" not in filenames or os.path.basename(dirpath) != ".airc":
-                continue
-            path = os.path.join(dirpath, "config.json")
-            try:
-                with open(path, encoding="utf-8") as f:
-                    cfg = json.load(f)
-            except (OSError, ValueError, TypeError):
-                continue
-            gists = cfg.get("channel_gists") or {}
-            gid = gists.get(channel)
-            if not _valid_gist_id(gid):
-                continue
-            try:
-                mtime = os.path.getmtime(path)
-            except OSError:
-                mtime = 0.0
-            found[gid] = max(found.get(gid, 0.0), mtime)
+    for path in _local_config_paths():
+        try:
+            with open(path, encoding="utf-8") as f:
+                cfg = json.load(f)
+        except (OSError, ValueError, TypeError):
+            continue
+        gists = cfg.get("channel_gists") or {}
+        gid = gists.get(channel)
+        if not _valid_gist_id(gid):
+            continue
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            mtime = 0.0
+        found[gid] = max(found.get(gid, 0.0), mtime)
     return list(found.items())
 
 

--- a/test/test_channel_gist.py
+++ b/test/test_channel_gist.py
@@ -186,7 +186,12 @@ class LocalCacheFallbackTests(unittest.TestCase):
                 current: self._snapshot(current, "general", ["general"], "2026-05-04T18:11:00Z"),
                 island: self._snapshot(island, "general", ["general", "cambriantech"], "2026-05-04T18:27:00Z"),
             }
-            with mock.patch.dict(os.environ, {"AIRC_GIST_CACHE_ROOTS": tmp, "AIRC_DISABLE_LOCAL_GIST_FALLBACK": ""}), \
+            roots = os.pathsep.join([
+                str(Path(tmp) / "old-worktree" / ".airc"),
+                str(Path(tmp) / "current-worktree" / ".airc"),
+                str(Path(tmp) / "solo-island" / ".airc"),
+            ])
+            with mock.patch.dict(os.environ, {"AIRC_GIST_CACHE_ROOTS": roots, "AIRC_DISABLE_LOCAL_GIST_FALLBACK": ""}), \
                  mock.patch.object(channel_gist, "_gh_list_user_gists", return_value=[]), \
                  mock.patch.object(channel_gist, "_git_gist_snapshot", side_effect=lambda gid: snapshots.get(gid)):
                 self.assertEqual(channel_gist.find_existing("general"), current)
@@ -201,10 +206,66 @@ class LocalCacheFallbackTests(unittest.TestCase):
                 old: self._snapshot(old, "cambriantech", ["cambriantech", "general"], "2026-05-04T17:40:00Z"),
                 current: self._snapshot(current, "cambriantech", ["cambriantech", "general"], "2026-05-04T18:22:49Z"),
             }
-            with mock.patch.dict(os.environ, {"AIRC_GIST_CACHE_ROOTS": tmp, "AIRC_DISABLE_LOCAL_GIST_FALLBACK": ""}), \
+            roots = os.pathsep.join([
+                str(Path(tmp) / "old" / ".airc"),
+                str(Path(tmp) / "current" / ".airc"),
+            ])
+            with mock.patch.dict(os.environ, {"AIRC_GIST_CACHE_ROOTS": roots, "AIRC_DISABLE_LOCAL_GIST_FALLBACK": ""}), \
                  mock.patch.object(channel_gist, "_gh_list_user_gists", return_value=[]), \
                  mock.patch.object(channel_gist, "_git_gist_snapshot", side_effect=lambda gid: snapshots.get(gid)):
                 self.assertEqual(channel_gist.find_existing("cambriantech"), current)
+
+    def test_default_local_fallback_only_reads_current_airc_home_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            broad = home / "Development" / "project" / ".airc"
+            current = home / "current" / ".airc"
+            broad.mkdir(parents=True)
+            current.mkdir(parents=True)
+            (broad / "config.json").write_text(
+                json.dumps({"channel_gists": {"general": "broadscan"}}),
+                encoding="utf-8",
+            )
+            current_gid = "cccccccc"
+            (current / "config.json").write_text(
+                json.dumps({"channel_gists": {"general": current_gid}}),
+                encoding="utf-8",
+            )
+            old_home = os.environ.get("HOME")
+            env = {"AIRC_HOME": str(current), "AIRC_DISABLE_LOCAL_GIST_FALLBACK": ""}
+            with mock.patch.dict(os.environ, env, clear=False), \
+                 mock.patch("os.path.expanduser", side_effect=lambda p: str(home) if p == "~" else p), \
+                 mock.patch("os.walk", side_effect=AssertionError("local fallback must not crawl directories")), \
+                 mock.patch.object(channel_gist, "_git_gist_snapshot", return_value=None) as snapshot:
+                candidates = channel_gist._local_config_gist_candidates("general")
+            if old_home is not None:
+                os.environ["HOME"] = old_home
+            self.assertEqual(candidates, [(current_gid, os.path.getmtime(current / "config.json"))])
+            snapshot.assert_not_called()
+
+    def test_explicit_local_fallback_roots_are_config_files_or_airc_dirs_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            first = Path(tmp) / "first.airc"
+            second = Path(tmp) / "second-config.json"
+            first.mkdir()
+            (first / "config.json").write_text(
+                json.dumps({"channel_gists": {"general": "11111111"}}),
+                encoding="utf-8",
+            )
+            second.write_text(
+                json.dumps({"channel_gists": {"general": "22222222"}}),
+                encoding="utf-8",
+            )
+            roots = os.pathsep.join([str(first), str(second)])
+            with mock.patch.dict(os.environ, {"AIRC_GIST_CACHE_ROOTS": roots, "AIRC_HOME": ""}), \
+                 mock.patch("os.walk", side_effect=AssertionError("local fallback must not crawl directories")):
+                self.assertEqual(
+                    sorted(channel_gist._local_config_gist_candidates("general")),
+                    sorted([
+                        ("11111111", os.path.getmtime(first / "config.json")),
+                        ("22222222", os.path.getmtime(second)),
+                    ]),
+                )
 
 
 class GistListCacheTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- remove recursive local folder scans from channel gist fallback
- default fallback now reads only the current AIRC_HOME/config.json
- optional AIRC_GIST_CACHE_ROOTS entries are treated as explicit config files or explicit .airc directories, not crawl roots
- add regression tests that fail if local fallback calls os.walk

## Validation
- python3 test/test_channel_gist.py
- bash -n airc lib/airc_bash/cmd_connect.sh lib/airc_bash/cmd_daemon.sh
- git diff --check