### PR TITLE
Do not create room gists during GitHub backoff

### DIFF
--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -659,6 +659,8 @@ def resolve(channel: str, create_if_missing: bool = False, require_invite: bool 
         if attempt < attempts - 1:
             _t.sleep(1.5 * (attempt + 1))  # 1.5s, then 3s
     if create_if_missing and not require_invite:
+        if gh_backoff.backoff_active():
+            return None
         return create_new(channel)
     return None
 

--- a/test/test_channel_gist.py
+++ b/test/test_channel_gist.py
@@ -267,6 +267,13 @@ class LocalCacheFallbackTests(unittest.TestCase):
                     ]),
                 )
 
+    def test_resolve_does_not_create_new_gist_during_gh_backoff(self):
+        with mock.patch.object(channel_gist, "find_existing", return_value=None), \
+             mock.patch.object(channel_gist.gh_backoff, "backoff_active", return_value=True), \
+             mock.patch.object(channel_gist, "create_new") as create_new:
+            self.assertIsNone(channel_gist.resolve("general", create_if_missing=True))
+            create_new.assert_not_called()
+
 
 class GistListCacheTests(unittest.TestCase):
     """Gist discovery should not spam GitHub during monitor/status churn."""


### PR DESCRIPTION
## Summary
- prevent channel_gist.resolve(create_if_missing=True) from creating a fresh room gist while the shared GitHub backoff window is active
- this distinguishes 'no room exists' from 'GitHub discovery is currently unavailable'
- adds a regression test that create_new is not called during backoff

## Validation
- python3 test/test_channel_gist.py
- bash -n airc lib/airc_bash/cmd_connect.sh
- git diff --check