### PR TITLE
Require trusted gist discovery before room creation

### DIFF
--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -44,6 +44,7 @@ _GH_BIN = "gh"
 _GH_API_TIMEOUT = 10.0
 _GIST_LIST_LIMIT = 100   # `airc list` uses 50; we go a bit higher to be safe
 _GIST_ID_CHARS = set("0123456789abcdefABCDEF")
+_LAST_GIST_LIST_UNAVAILABLE = False
 def _cache_path(name: str) -> str:
     uid = str(os.getuid()) if hasattr(os, "getuid") else os.environ.get("USERNAME", "user")
     return os.path.join(tempfile.gettempdir(), f"airc-{name}-{uid}.json")
@@ -100,16 +101,20 @@ def _gh_list_user_gists() -> list[dict]:
     probe fails, stale cache default is 15m so peers can keep using the
     last-known room map instead of creating new islands.
     """
+    global _LAST_GIST_LIST_UNAVAILABLE
+    _LAST_GIST_LIST_UNAVAILABLE = False
     cache_sec = float(os.environ.get("AIRC_GIST_LIST_CACHE_SEC", "60"))
     stale_sec = float(os.environ.get("AIRC_GIST_LIST_STALE_SEC", "900"))
     cached = _load_cached_gist_list(cache_sec)
     if cached is not None:
         return cached
     if gh_backoff.backoff_active():
+        _LAST_GIST_LIST_UNAVAILABLE = True
         return _load_cached_gist_list(stale_sec) or []
 
     gh = _resolve_gh_bin()
     if gh is None:
+        _LAST_GIST_LIST_UNAVAILABLE = True
         return _load_cached_gist_list(stale_sec) or []
     try:
         r = subprocess.run(
@@ -119,8 +124,10 @@ def _gh_list_user_gists() -> list[dict]:
             timeout=_GH_API_TIMEOUT * 3,
         )
     except (subprocess.TimeoutExpired, OSError):
+        _LAST_GIST_LIST_UNAVAILABLE = True
         return _load_cached_gist_list(stale_sec) or []
     if r.returncode != 0:
+        _LAST_GIST_LIST_UNAVAILABLE = True
         gh_backoff.record_backoff((r.stderr or "") + (r.stdout or ""))
         return _load_cached_gist_list(stale_sec) or []
     out: list[dict] = []
@@ -136,6 +143,7 @@ def _gh_list_user_gists() -> list[dict]:
             return loaded
     except (ValueError, TypeError):
         pass
+    _LAST_GIST_LIST_UNAVAILABLE = True
     return out
 
 
@@ -659,7 +667,7 @@ def resolve(channel: str, create_if_missing: bool = False, require_invite: bool 
         if attempt < attempts - 1:
             _t.sleep(1.5 * (attempt + 1))  # 1.5s, then 3s
     if create_if_missing and not require_invite:
-        if gh_backoff.backoff_active():
+        if gh_backoff.backoff_active() or _LAST_GIST_LIST_UNAVAILABLE:
             return None
         return create_new(channel)
     return None

--- a/test/test_channel_gist.py
+++ b/test/test_channel_gist.py
@@ -274,6 +274,17 @@ class LocalCacheFallbackTests(unittest.TestCase):
             self.assertIsNone(channel_gist.resolve("general", create_if_missing=True))
             create_new.assert_not_called()
 
+    def test_resolve_does_not_create_new_gist_after_untrusted_discovery(self):
+        with mock.patch.object(channel_gist, "find_existing", return_value=None), \
+             mock.patch.object(channel_gist.gh_backoff, "backoff_active", return_value=False), \
+             mock.patch.object(channel_gist, "create_new") as create_new:
+            channel_gist._LAST_GIST_LIST_UNAVAILABLE = True
+            try:
+                self.assertIsNone(channel_gist.resolve("general", create_if_missing=True))
+                create_new.assert_not_called()
+            finally:
+                channel_gist._LAST_GIST_LIST_UNAVAILABLE = False
+
 
 class GistListCacheTests(unittest.TestCase):
     """Gist discovery should not spam GitHub during monitor/status churn."""


### PR DESCRIPTION
## Summary
- track when GitHub gist discovery is unavailable or untrusted
- do not create a new room gist after an unavailable discovery result
- keeps create-if-missing for real empty-account results, but blocks island creation during API/backoff/parser failure
- adds regression coverage for the untrusted-discovery path

## Validation
- python3 test/test_channel_gist.py
- bash -n airc lib/airc_bash/cmd_connect.sh
- git diff --check