### PR TITLE
Block host bootstrap when gist discovery is unavailable

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1476,8 +1476,12 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
           # resolve and go straight to create_new — same as the
           # early mesh-find gate at line ~568.
           if [ -z "$_existing_room_gid" ] && [ "${AIRC_NO_DISCOVERY:-0}" != "1" ]; then
-            _existing_room_gid=$("$AIRC_PYTHON" -m airc_core.channel_gist resolve \
-                                 --channel "$room_name" 2>/dev/null || true)
+            local _host_preflight_rc=0
+            _existing_room_gid=$("$AIRC_PYTHON" -m airc_core.channel_gist host-preflight \
+                                 --channel "$room_name" 2>/dev/null) || _host_preflight_rc=$?
+            if [ "${_host_preflight_rc:-0}" = "2" ]; then
+              die "GitHub room discovery is unavailable for #${room_name}; refusing to create a new solo room. Retry after the GitHub backoff clears."
+            fi
           fi
         fi
         if [ -n "$_existing_room_gid" ]; then

--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -673,6 +673,26 @@ def resolve(channel: str, create_if_missing: bool = False, require_invite: bool 
     return None
 
 
+def host_preflight(channel: str) -> tuple[str, Optional[str]]:
+    """Return the host bootstrap decision for a channel.
+
+    - ("existing", gid): use this canonical gist.
+    - ("blocked", None): discovery was unavailable; do not create.
+    - ("create", None): discovery was trusted and no gist exists.
+
+    Host bootstrap writes a richer invite envelope than create_new(), so
+    bash still owns the actual gist create. This helper owns the safety
+    decision so a failed GitHub listing cannot be mistaken for an empty
+    account.
+    """
+    existing = find_existing(channel)
+    if existing:
+        return "existing", existing
+    if gh_backoff.backoff_active() or _LAST_GIST_LIST_UNAVAILABLE:
+        return "blocked", None
+    return "create", None
+
+
 # ── CLI entry — bash invokes this from cmd_connect / cmd_subscribe ──
 
 def _cli() -> int:
@@ -689,6 +709,9 @@ def _cli() -> int:
     f.add_argument("--channel", required=True)
     f.add_argument("--require-invite", action="store_true")
 
+    hp = sub.add_parser("host-preflight", help="Print existing gist id, or exit 2 when discovery is unavailable")
+    hp.add_argument("--channel", required=True)
+
     args = parser.parse_args()
 
     if args.cmd == "resolve":
@@ -702,6 +725,14 @@ def _cli() -> int:
         if gid:
             print(gid)
             return 0
+        return 1
+    if args.cmd == "host-preflight":
+        decision, gid = host_preflight(args.channel)
+        if decision == "existing" and gid:
+            print(gid)
+            return 0
+        if decision == "blocked":
+            return 2
         return 1
     return 1
 

--- a/test/test_channel_gist.py
+++ b/test/test_channel_gist.py
@@ -285,6 +285,21 @@ class LocalCacheFallbackTests(unittest.TestCase):
             finally:
                 channel_gist._LAST_GIST_LIST_UNAVAILABLE = False
 
+    def test_host_preflight_blocks_when_discovery_untrusted(self):
+        with mock.patch.object(channel_gist, "find_existing", return_value=None), \
+             mock.patch.object(channel_gist.gh_backoff, "backoff_active", return_value=False):
+            channel_gist._LAST_GIST_LIST_UNAVAILABLE = True
+            try:
+                self.assertEqual(channel_gist.host_preflight("general"), ("blocked", None))
+            finally:
+                channel_gist._LAST_GIST_LIST_UNAVAILABLE = False
+
+    def test_host_preflight_allows_create_only_after_trusted_empty_discovery(self):
+        with mock.patch.object(channel_gist, "find_existing", return_value=None), \
+             mock.patch.object(channel_gist.gh_backoff, "backoff_active", return_value=False):
+            channel_gist._LAST_GIST_LIST_UNAVAILABLE = False
+            self.assertEqual(channel_gist.host_preflight("general"), ("create", None))
+
 
 class GistListCacheTests(unittest.TestCase):
     """Gist discovery should not spam GitHub during monitor/status churn."""


### PR DESCRIPTION
## Summary
- add channel_gist host-preflight so bash host bootstrap can distinguish existing gist, trusted empty account, and unavailable discovery
- refuse to create a new room gist when GitHub discovery is unavailable/backed off
- prevents a failed lookup from becoming a fresh solo room

## Validation
- python3 test/test_channel_gist.py
- PYTHONPATH=/Users/joelteply/.airc-src/lib python3 -m airc_core.channel_gist host-preflight --channel codex-no-create-probe-177793 -> rc=2 under forced backoff
- bash -n airc lib/airc_bash/cmd_connect.sh
- git diff --check