### PR TITLE
Use current config gist in host preflight

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1478,7 +1478,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
           if [ -z "$_existing_room_gid" ] && [ "${AIRC_NO_DISCOVERY:-0}" != "1" ]; then
             local _host_preflight_rc=0
             _existing_room_gid=$("$AIRC_PYTHON" -m airc_core.channel_gist host-preflight \
-                                 --channel "$room_name" 2>/dev/null) || _host_preflight_rc=$?
+                                 --channel "$room_name" --config "$CONFIG" 2>/dev/null) || _host_preflight_rc=$?
             if [ "${_host_preflight_rc:-0}" = "2" ]; then
               die "GitHub room discovery is unavailable for #${room_name}; refusing to create a new solo room. Retry after the GitHub backoff clears."
             fi

--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -224,6 +224,19 @@ def _valid_gist_id(gist_id: object) -> bool:
     return 8 <= len(gist_id) <= 64 and all(c in _GIST_ID_CHARS for c in gist_id)
 
 
+def _config_channel_gist(config_path: Optional[str], channel: str) -> Optional[str]:
+    if not config_path:
+        return None
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            cfg = json.load(f)
+    except (OSError, ValueError, TypeError):
+        return None
+    gists = cfg.get("channel_gists") or {}
+    gid = gists.get(channel)
+    return gid if _valid_gist_id(gid) else None
+
+
 def _parse_ts(value: object) -> float:
     if not isinstance(value, str) or not value:
         return 0.0
@@ -673,7 +686,7 @@ def resolve(channel: str, create_if_missing: bool = False, require_invite: bool 
     return None
 
 
-def host_preflight(channel: str) -> tuple[str, Optional[str]]:
+def host_preflight(channel: str, config_path: Optional[str] = None) -> tuple[str, Optional[str]]:
     """Return the host bootstrap decision for a channel.
 
     - ("existing", gid): use this canonical gist.
@@ -685,6 +698,9 @@ def host_preflight(channel: str) -> tuple[str, Optional[str]]:
     decision so a failed GitHub listing cannot be mistaken for an empty
     account.
     """
+    configured = _config_channel_gist(config_path, channel)
+    if configured:
+        return "existing", configured
     existing = find_existing(channel)
     if existing:
         return "existing", existing
@@ -711,6 +727,7 @@ def _cli() -> int:
 
     hp = sub.add_parser("host-preflight", help="Print existing gist id, or exit 2 when discovery is unavailable")
     hp.add_argument("--channel", required=True)
+    hp.add_argument("--config", default="")
 
     args = parser.parse_args()
 
@@ -727,7 +744,7 @@ def _cli() -> int:
             return 0
         return 1
     if args.cmd == "host-preflight":
-        decision, gid = host_preflight(args.channel)
+        decision, gid = host_preflight(args.channel, config_path=args.config)
         if decision == "existing" and gid:
             print(gid)
             return 0

--- a/test/test_channel_gist.py
+++ b/test/test_channel_gist.py
@@ -294,11 +294,36 @@ class LocalCacheFallbackTests(unittest.TestCase):
             finally:
                 channel_gist._LAST_GIST_LIST_UNAVAILABLE = False
 
+    def test_host_preflight_uses_current_config_before_discovery(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "config.json"
+            cfg.write_text(
+                json.dumps({"channel_gists": {"general": "abcdef1234567890"}}),
+                encoding="utf-8",
+            )
+            with mock.patch.object(channel_gist, "find_existing") as find_existing:
+                self.assertEqual(
+                    channel_gist.host_preflight("general", config_path=str(cfg)),
+                    ("existing", "abcdef1234567890"),
+                )
+                find_existing.assert_not_called()
+
     def test_host_preflight_allows_create_only_after_trusted_empty_discovery(self):
         with mock.patch.object(channel_gist, "find_existing", return_value=None), \
              mock.patch.object(channel_gist.gh_backoff, "backoff_active", return_value=False):
             channel_gist._LAST_GIST_LIST_UNAVAILABLE = False
             self.assertEqual(channel_gist.host_preflight("general"), ("create", None))
+
+    def test_host_preflight_first_user_missing_config_can_create_after_trusted_empty_discovery(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing_config = str(Path(tmp) / "new-user" / ".airc" / "config.json")
+            with mock.patch.object(channel_gist, "find_existing", return_value=None), \
+                 mock.patch.object(channel_gist.gh_backoff, "backoff_active", return_value=False):
+                channel_gist._LAST_GIST_LIST_UNAVAILABLE = False
+                self.assertEqual(
+                    channel_gist.host_preflight("general", config_path=missing_config),
+                    ("create", None),
+                )
 
 
 class GistListCacheTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- host bootstrap preflight now accepts the current scope config path
- a valid channel_gists[channel] in that config is used before GitHub discovery
- preserves first-user behavior: missing config + trusted empty discovery still allows create
- prevents GH backoff from blocking recovery when the scope already knows the canonical gist

## Validation
- python3 test/test_channel_gist.py
- bash -n airc lib/airc_bash/cmd_connect.sh
- git diff --check
- live preflight with continuum config returned c68640ec0144b422c16b2d8c83ad5ee5