### PR TITLE
Honor GitHub backoff in gh recv loop

### DIFF
--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -829,10 +829,9 @@ class GhBearer(Bearer):
              yield. Bump consumed_lines + offset file.
           4. Sleep poll_interval (default 15s), repeat.
 
-        On gh API failure (rate limit, network blip), we sleep the same
-        cadence and try again. The bearer's job is to keep producing
-        events; the caller's watchdog observes extended silence via
-        liveness().
+        On gh API failure, keep the bearer alive. Secondary rate limits
+        honor the shared GitHub backoff window instead of polling every
+        15s and extending the throttle.
         """
         self._check_alive()
 
@@ -848,11 +847,15 @@ class GhBearer(Bearer):
                 yield msg
                 if self._closed:
                     return
-            gist = _gh_api_get(gist_id)
+            gist, get_kind = _gh_api_get_classified(gist_id)
             if gist is None:
-                # Transient gh API failure. Sleep + retry. Caller's
-                # watchdog observes extended silence and escalates.
-                self._sleep_or_break(self._poll_interval)
+                if get_kind == "secondary_rate_limit":
+                    delay = max(self._poll_interval, gh_backoff.backoff_until() - _time.time(), 60.0)
+                    self._sleep_or_break(delay)
+                else:
+                    # Transient gh API failure. Sleep + retry. Caller's
+                    # watchdog observes extended silence and escalates.
+                    self._sleep_or_break(self._poll_interval)
                 continue
             content = _read_messages_content(gist)
             # splitlines() on the str preserves multi-byte sequences and

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -1760,6 +1760,29 @@ class GhBearerRecvTests(unittest.TestCase):
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0].sender_peer_id, "bob")
 
+    def test_recv_secondary_rate_limit_sleeps_through_shared_backoff(self):
+        b = self._bearer({"poll_interval": 15})
+        sleeps = []
+
+        def fake_sleep(seconds):
+            sleeps.append(seconds)
+            b.close()
+
+        with mock.patch.object(
+            bearer_gh,
+            "_gh_api_get_classified",
+            return_value=(None, "secondary_rate_limit"),
+        ), mock.patch.object(
+            bearer_gh.gh_backoff,
+            "backoff_until",
+            return_value=bearer_gh._time.time() + 120,
+        ), mock.patch.object(b, "_sleep_or_break", side_effect=fake_sleep):
+            list(b.recv_stream())
+
+        self.assertEqual(len(sleeps), 1)
+        self.assertGreaterEqual(sleeps[0], 60)
+        self.assertGreater(sleeps[0], 100)
+
     def test_recv_resumes_past_offset_file(self):
         import tempfile, os as _os
         with tempfile.NamedTemporaryFile("w", delete=False) as f:


### PR DESCRIPTION
## Summary
- GhBearer.recv_stream now uses classified GET results
- secondary-rate-limit recv failures sleep through the shared GitHub backoff window instead of polling every 15s
- prevents monitors from extending GH secondary throttles while staying alive/degraded

## Validation
- python3 test/test_bearer.py
- python3 test/test_channel_gist.py
- bash -n airc lib/airc_bash/cmd_connect.sh
- git diff --check