### PR TITLE
Use generic org examples for room auto-scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Done. Toby's airc resolves the mnemonic to the private gist on your gh account, 
 
 **#general sidecar (default-on):** alongside the project room, `airc join` spawns a parallel subscription to `#general` in a sibling scope (`$cwd/.airc.general/`). Same visible nick, independent peer records. Events from BOTH rooms stream through the same Monitor with `[#room]` prefixes, so `[#my-org] alice: ...` and `[#general] bob: ...` interleave naturally.
 
-Why both? An agent doing day-job work in `#my-org` can still hear someone in `#cambriantech` ping the lobby for help — and vice versa — without parting their working room. Same model as IRC: lurk in `#general`, work in `#project`, never miss either.
+Why both? An agent doing day-job work in `#my-org` can still hear someone in another project room ping the lobby for help — and vice versa — without parting their working room. Same model as IRC: lurk in `#general`, work in `#project`, never miss either.
 
 ### Worked example
 
@@ -197,8 +197,8 @@ Suppose a workspace looks like this:
 │   ├── api             (origin: github.com/my-org/api)
 │   ├── frontend        (origin: github.com/my-org/frontend)
 │   └── infra           (origin: github.com/my-org/infra)
-└── cambriantech/
-    └── side-project    (origin: github.com/cambriantech/side-project)
+└── other-org/
+    └── side-project    (origin: github.com/other-org/side-project)
 ```
 
 Then:
@@ -206,11 +206,11 @@ Then:
 ```bash
 cd ~/work/my-org/api            && airc join   # → #my-org      AND #general
 cd ~/work/my-org/frontend       && airc join   # → #my-org      AND #general (same #my-org host)
-cd ~/work/cambriantech/side-project && airc join   # → #cambriantech AND #general
+cd ~/work/other-org/side-project && airc join   # → #other-org   AND #general
 cd ~/Documents                  && airc join   # → #general only (non-git)
 ```
 
-The api tab + frontend tab share `#my-org`. The side-project tab is alone in `#cambriantech`. **All four tabs share `#general`** — that's how the side-project agent and the api agent reach each other without leaving their working rooms.
+The api tab + frontend tab share `#my-org`. The side-project tab is alone in `#other-org`. **All four tabs share `#general`** — that's how the side-project agent and the api agent reach each other without leaving their working rooms.
 
 ### Sending across rooms
 
@@ -228,7 +228,7 @@ If the requested `--room` isn't one of your subscribed rooms, the send errors lo
 Agents keep full cross-room control. From any tab:
 
 - `airc list` — see every open room on your gh account
-- `airc join --room cambriantech` — hop to a different project room (in addition to #general; the sidecar still spawns)
+- `airc join --room other-org` — hop to a different project room (in addition to #general; the sidecar still spawns)
 - `airc join --no-general` — keep the project room, skip the lobby sidecar (focused mode, this session only)
 - `airc join --room-only my-org` — explicit room + no sidecar (combo)
 - `airc join --no-room` — legacy 1:1 invite-string mode (no substrate; for cross-account pairs)

--- a/airc
+++ b/airc
@@ -31,7 +31,7 @@ set -euo pipefail
 # cmd_send then took the HOST path (no host_target) and mirrored
 # locally without ever attempting the SSH push. Net: every Win→Mac
 # broadcast silently no-op'd while pretending success. Caught by
-# continuum-b69f via cross-Mac/Windows substrate-bypass gist
+# a cross-Mac/Windows substrate-bypass gist
 # 2026-04-27.
 #
 # Fix: env-var holds the resolved interpreter path. Bash variables
@@ -95,7 +95,7 @@ export AIRC_PYTHON
 # `--host-airc-home /Users/joelteply/.airc` arrives at python.exe as
 # `--host-airc-home C:/Program Files/Git/Users/joelteply/.airc` —
 # silently corrupting paths that the joiner later sends back over SSH
-# to a real Unix host. continuum-b69f traced + fixed this 2026-04-27;
+# to a real Unix host. Traced + fixed 2026-04-27;
 # the targeted exclude covers macOS / Linux / root home prefixes
 # without breaking `/tmp/` or `/c/` paths (which DO need translation
 # for `--config "$CONFIG"` where $CONFIG is on the local Windows
@@ -110,7 +110,7 @@ export MSYS2_ARG_CONV_EXCL="${MSYS2_ARG_CONV_EXCL:-/Users/;/home/;/root/}"
 # error handler catches it, and the message gets silently dropped from
 # the user's view. PYTHONIOENCODING=utf-8 is the standard remedy —
 # applies to every Python subprocess airc spawns. Honors user override.
-# continuum-b69f's catch + verify 2026-04-27.
+# traced + verified 2026-04-27.
 export PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}"
 
 # Resolve the airc install dir's lib/ path and prepend to PYTHONPATH so
@@ -245,9 +245,9 @@ derive_name() {
 # Two signals, tried in order:
 #
 #   1. gh org from `origin` remote URL (the stable, cross-machine ID).
-#      useideem/vHSM on Joel's Mac + useideem/authenticator on Brian's
-#      Linux box both default to #useideem. No matter where on disk
-#      either of us keeps the checkout, the remote URL fingerprints it.
+#      acme/api on one machine + acme/frontend on another both default
+#      to #acme. No matter where on disk either checkout lives, the
+#      remote URL fingerprints the shared project owner.
 #      Handles github / gitlab / bitbucket / self-hosted (just the
 #      owner segment between host and repo). Matches airc's "gh OAuth
 #      scope IS the trust boundary" philosophy — the org that owns the
@@ -443,7 +443,7 @@ die() { echo "ERROR: $*" >&2; exit 1; }
 # cmd_status used any-alive logic and cmd_send used all-alive logic, so a
 # pidfile with one stale orphan + one live process showed "monitor:
 # running" in status BUT "Send NOT delivered — pidfile stale" from msg.
-# vhsm-d1f4 + authenticator-448f independently reproduced 2026-04-29.
+# Independently reproduced by two agents 2026-04-29.
 #
 # Contract: a scope is "alive" if AT LEAST ONE pid in the pidfile is
 # alive. Stale pids are pruned in-place so the file converges on
@@ -1115,7 +1115,7 @@ _primary_scope_for() {
   # like '.airc' (canonical primary scope name in real deployments) — the
   # regex eats the whole thing. Without the empty-prefix guard, '.airc'
   # gets treated as a sidecar of '' under '<parent>/' which then can't
-  # find config.json and silently no-ops. Bug surfaced by vhsm-d1f4 in
+  # find config.json and silently no-ops. Bug surfaced during QA in
   # PR #144 e2e (2026-04-27): airc join --general silently failed because
   # _clear_parted_room got the wrong path. Test scenario_part_persists
   # passed because its fixture path is 'state'/'state.general' (no
@@ -1138,7 +1138,7 @@ _clear_parted_room()  { [ -f "$1/config.json" ] && "$AIRC_PYTHON" -m airc_core.c
 # its project room AND the lobby. Identity NICK is shared via AIRC_NAME;
 # ssh_key + peer records are per-scope. Each subscription gets its own
 # wire (the python formatter prefixes events with the scope's room_name,
-# so the user sees `[#useideem] X` and `[#general] Y` interleaved).
+# so the user sees `[#acme] X` and `[#general] Y` interleaved).
 #
 # Reads from cmd_connect's locals via bash's dynamic scoping:
 #   general_sidecar     1 = spawn, 0 = don't (--no-general / --room-only /
@@ -1952,7 +1952,7 @@ reminder_timer_loop() {
       # ancient last_recv_ts values that, if included in the MAX, would
       # silently rot the beacon's calculation. Caught live 2026-05-02:
       # beacon reported '288919s silent' on a fresh-restart bearer
-      # because bearer_state.useideem.json from 80hrs prior had a
+      # because bearer_state.old-room.json from 80hrs prior had a
       # positive last_recv_ts that won the MAX over the freshly-opened
       # bearer's null. The freshly-opened bearer's correct read should
       # have been "small recv_silent because the file was just written"

--- a/install.sh
+++ b/install.sh
@@ -211,7 +211,7 @@ ensure_prereqs() {
     # Strict probe: presence on PATH AND a successful --version invocation.
     # Used selectively: python3 needs the strict variant because Windows
     # Store's python3.exe alias is on PATH but exits 49 with a Store-
-    # redirect (continuum-b69f, 2026-04-27). git/gh all
+    # redirect (2026-04-27). git/gh all
     # support --version cleanly. ssh-keygen does NOT have a version
     # flag at all (different from `ssh -V`); calling `ssh-keygen
     # --version` exits non-zero on every install, so the strict probe
@@ -427,7 +427,7 @@ else
   # First install. Honor AIRC_CHANNEL if set so users can land on canary
   # directly via `AIRC_CHANNEL=canary curl|bash` without a follow-up
   # `airc canary && airc update` dance. Default to main (the release
-  # branch) when AIRC_CHANNEL is unset. Caught by vhsm-d1f4 2026-04-28
+  # branch) when AIRC_CHANNEL is unset. Caught by QA 2026-04-28
   # during the #191 release-gate fresh-install verification: env var was
   # silently ignored, install landed on main.
   CHANNEL_TARGET="${AIRC_CHANNEL:-main}"
@@ -460,7 +460,7 @@ ln -sf "$CLONE_DIR/airc" "$BIN_DIR/relay"
 # made airc.ps1 a thin forwarder to bash, but that's moot if the
 # .ps1 isn't on PATH. cp (not ln -sf) — Windows symlinks are
 # privileged + flaky; copying is universal. Caught by
-# continuum-b69f 2026-04-29 (issue #249 PowerShell row).
+# 2026-04-29 (issue #249 PowerShell row).
 case "$(uname -s 2>/dev/null)" in
   MINGW*|MSYS*|CYGWIN*)
     [ -f "$CLONE_DIR/airc.cmd" ] && cp -f "$CLONE_DIR/airc.cmd" "$BIN_DIR/airc.cmd"

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -402,19 +402,19 @@ cmd_connect() {
   # daemon required. See project_airc_transport_architecture memory.
 
   # `airc join` (no args) auto-scopes to the room matching the current cwd.
-  # Resolution: git remote org first ('useideem/authenticator' → #useideem),
+  # Resolution: git remote org first ('acme/api' → #acme),
   # parent-dir basename second (local-only repos). Falls back to #general
   # only when neither signal fires (non-git dir, no remote). The skill
   # /join contract documents this as the default.
   #
   # The trade-off: two tabs in DIFFERENT projects on the same gh account
-  # land in different rooms (a #cambriantech tab can't see a #useideem
-  # tab). That's intentional — project work shouldn't mix with unrelated
+  # land in different rooms (an #acme tab can't see an #example
+  # tab by default). That's intentional — project work shouldn't mix with unrelated
   # project chatter. Cross-project agents who need a shared lobby:
   # `AIRC_NO_AUTO_ROOM=1 airc join` or `airc join --room general`.
   #
-  # Two tabs in the SAME project converge automatically: both useideem
-  # tabs auto-scope to #useideem, both find each other. That's the case
+  # Two tabs in the SAME project converge automatically: both acme
+  # tabs auto-scope to #acme, both find each other. That's the case
   # this default optimizes for.
   #
   # History: this was rolled back in PR #104 over the cross-project
@@ -433,7 +433,7 @@ cmd_connect() {
     [ -f "$AIRC_WRITE_DIR/room_name" ] && _saved_room=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null)
     if [ -n "$_saved_room" ]; then
       room_name="$_saved_room"
-      # Phase 2C clarity (continuum-b741's report): the mesh substrate
+      # Phase 2C clarity: the mesh substrate
       # may steer us to a different host channel than our saved
       # preference. State the preference as INTENT, not promise — the
       # post-discovery banner is the authoritative "what you actually
@@ -923,7 +923,7 @@ cmd_connect() {
         # whole quoted line including the JSON-key prefix. Strip
         # leading non-name characters: anything before the first letter
         # is JSON syntax (quotes, colons, whitespace). Found by
-        # continuum-b69f Win→Mac e2e 2026-04-27 — bash on Git Bash
+        # Win→Mac e2e 2026-04-27 — bash on Git Bash
         # ships without jq, falls through to this path, captured
         # `"invite":"authenticator-fd63@...` as the invite, then the
         # downstream @-split made the displayed peer name include
@@ -1061,13 +1061,13 @@ cmd_connect() {
     # need the gist_id for cmd_part on joiner side — only the host owns
     # the gist lifecycle — but we save the room name for display.
     if [ -n "$resolved_room_name" ]; then
-      # Phase 2B.2.1 (continuum-b741's WART 1): joiner's cwd-derived or
+      # Phase 2B.2.1: joiner's cwd-derived or
       # explicit --room intent must NOT be overwritten by the host's
-      # advertised channel. If the user wanted #cambriantech (cwd) and
-      # the mesh host happens to advertise #useideem, the joiner is
+      # advertised channel. If the user wanted #acme (cwd) and the
+      # mesh host happens to advertise #example, the joiner is
       # subscribed to BOTH — cmd_send default = user's intent; the
       # host's channel is tagged on too so their traffic still displays
-      # via [#useideem] prefix.
+      # via [#example] prefix.
       #
       # The legacy room_name file gets the user's intent when it differs
       # (so cmd_send's third-priority fallback also picks the right
@@ -1186,7 +1186,7 @@ except Exception:
         echo "" >&2
       fi
       # Either not a room flow, or no gh, or no resolved_room_name → original die.
-      # Surface the captured pair-handshake stderr (continuum-b69f 2026-04-27:
+      # Surface the captured pair-handshake stderr (2026-04-27:
       # Windows users got "Can't reach ..." with no clue the real cause was
       # a Microsoft Store python3.exe stub returning exit 49). Per the
       # global "never swallow errors" rule — evidence is for the debugger,
@@ -1285,7 +1285,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
     local host_identity_json; host_identity_json=$(printf '%s' "$response" | "$AIRC_PYTHON" -m airc_core.handshake get_field identity "{}" 2>/dev/null || echo "{}")
     [ -z "$host_identity_json" ] && host_identity_json="{}"
     # Pass values as env vars instead of bash-substituted into the
-    # python heredoc body. continuum-b69f's PR #164 retest 2026-04-27
+    # python heredoc body. PR #164 retest 2026-04-27
     # found host_airc_home / host_name / host_port / host_ssh_pub /
     # host_identity all silently unwritten on Win→Mac join: if ANY of
     # the bash substitutions broke the python source (newline in
@@ -1699,9 +1699,9 @@ JSON
                 # --filename or run interactively" — heartbeat fails N
                 # times in a row and the host self-evicts (deletes its
                 # own gist + respawns) when nothing was actually wrong.
-                # That eviction loop is the surface ideem-local-4bef
+                # That eviction loop is the surface QA
                 # root-caused 2026-04-29; it's also what nuked the
-                # #useideem gist mid-ping-debug. Ensuring the temp
+                # #example gist mid-ping-debug. Ensuring the temp
                 # basename matches the canonical filename closes the
                 # whole convergent class.
                 local _hb_tmpdir; _hb_tmpdir=$(mktemp -d -t airc-hb.XXXXXX)

--- a/lib/airc_bash/cmd_daemon.sh
+++ b/lib/airc_bash/cmd_daemon.sh
@@ -102,7 +102,7 @@ _daemon_airc_path() {
 # pointed at $HOME/.airc (empty / wrong room) while the user's actual
 # join state lives at $cwd/.airc. Joel 2026-04-28: "lol obv if it
 # worked you would have a monitor and be online. FAIL" -- caught the
-# scope mismatch on continuum-b69f's box.
+# scope mismatch on a multi-scope machine.
 _daemon_scope() {
   if [ -n "${AIRC_HOME:-}" ]; then
     echo "$AIRC_HOME"
@@ -287,7 +287,7 @@ REM Pre-fix: stdout went to nowhere (start /MIN cmd window had no
 REM redirect), only daemon.err captured the launcher's own restart
 REM messages — so 'airc daemon log' showed nothing useful, and
 REM "daemon.log doesn't exist" became a real symptom (b69f
-REM 2026-05-02 in #cambriantech). Stderr → daemon.err keeps the
+REM 2026-05-02 in a project room). Stderr → daemon.err keeps the
 REM launcher's restart records separate from the airc event stream.
 "$bash_exe" -c "exec '$airc_bin_unix' connect" 1>> "$scope_win\\daemon.log" 2>> "$scope_win\\daemon.err"
 REM Did airc just intentionally re-exec? If marker exists and is recent,

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -512,7 +512,7 @@ _doctor_health() {
   # Scope to subscribed_channels ONLY (Codex's first-run report 2026-05-02
   # exposed this — same fix-shape as #406's beacon scoping). Pre-fix the
   # probe globbed every bearer_state.*.json on disk INCLUDING stale files
-  # from prior subscriptions (a #cambriantech the user parted, an old
+  # from prior subscriptions (an #old-project the user parted, an old
   # qa-foo room from a previous test, etc.). Codex correctly identified
   # the noise: "sees stale bearer-state files for older channels". Real
   # fix is to intersect with the current subscribed_channels list — same

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -50,7 +50,7 @@
 # (airc identity set --status) still works for scripted state changes.
 cmd_away() {
   ensure_init
-  # Intercept --help BEFORE building $msg from $* — vhsm-d1f4's verb-fuzz
+  # Intercept --help BEFORE building $msg from $* — verb fuzzing
   # 2026-04-28 caught `airc away --help` writing "--help" as the status
   # string. Same anti-pattern as #231/#236; same shape fix.
   case "${1:-}" in
@@ -176,7 +176,7 @@ _identity_set() {
   if [ "$set_pronouns" = 0 ] && [ "$set_role" = 0 ] && [ "$set_bio" = 0 ] && [ "$set_status" = 0 ]; then
     die "Pass at least one of --pronouns / --role / --bio / --status"
   fi
-  # Length caps (continuum-b741 caught 2026-04-29: 4KB bio stored
+  # Length caps (caught 2026-04-29: 4KB bio stored
   # verbatim → broke peer rendering + ate gist quota). Bio is one line
   # of context, not a manifesto. Hard caps with loud rejection.
   local _max_pronouns=64
@@ -296,7 +296,7 @@ cmd_whois() {
   # peer record we don't have locally). Without that, indirect peers
   # in the singleton mesh — peers paired with the host but not with
   # us directly — return "no record". Tracked as the wart that
-  # ideem-local-4bef + continuum-b741 surfaced 2026-04-28.
+  # surfaced during QA 2026-04-28.
   if _whois_in_scope "$AIRC_WRITE_DIR" "$target"; then
     return 0
   fi

--- a/lib/airc_bash/cmd_rename.sh
+++ b/lib/airc_bash/cmd_rename.sh
@@ -57,7 +57,7 @@ cmd_rename() {
   [ -z "$new_name" ] && die "Invalid name (must be a-z 0-9 -)"
   [ ! -f "$CONFIG" ] && die "Not initialized — run 'airc connect' first"
 
-  # Announce sanitization (vhsm-d1f4 caught 2026-04-29: 'two words' →
+  # Announce sanitization (caught 2026-04-29: 'two words' →
   # 'two-words', 'VHSMD1F4' → 'vhsmd1f4' silently). Pre-fix the user
   # had no signal that the name they typed wasn't the name that landed.
   if [ "$_input" != "$new_name" ]; then
@@ -70,7 +70,7 @@ cmd_rename() {
     return
   fi
 
-  # Collision check (continuum-b741 + ideem-local-4bef caught
+  # Collision check (caught
   # 2026-04-29: renaming to an active peer's name was accepted
   # silently, both peers then visible as the same name, DM routing
   # ambiguous). Two-source roster:
@@ -136,7 +136,7 @@ sys.exit(0 if (target in seen and target not in my_history) else 1)
   echo "  Renamed: $old_name → $new_name"
 
   # Phase 2: propagate the config write to sibling scopes BEFORE
-  # broadcasting (#179 — vhsm-d1f4 + ideem-local-4bef caught 2026-04-28
+  # broadcasting (#179 — caught 2026-04-28
   # that nick rename only updated the current scope's config, leaving
   # any sidecar to broadcast under the OLD name).
   #

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -215,7 +215,7 @@ cmd_part() {
 
   ensure_init
 
-  # CRITICAL bug fix 2026-05-02 (B8 from continuum-b69f): pre-fix
+  # CRITICAL bug fix 2026-05-02: pre-fix
   # `airc part QANAME` IGNORED the room arg and parted the scope's
   # DEFAULT room — deleting #general's gist when user thought they
   # were parting a test room. Mesh-splitting catastrophe: every peer

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -32,7 +32,7 @@ cmd_send() {
   # model means a tab is in #project-room AND #general simultaneously,
   # but each room has its own scope. Without --room support here, sending
   # to a non-current room required `AIRC_HOME=$cwd/.airc.<room> airc msg`,
-  # which is nonobvious (vhsm-Claude attempted `airc msg --room general`
+  # which is nonobvious (an agent attempted `airc msg --room general`
   # on 2026-04-26, the unrecognized flag silently became part of the
   # message body — exactly the evidence-eating shape the project rejects).
   #
@@ -166,7 +166,7 @@ cmd_send() {
     case "$1" in
       @*)
         local _p="${1#@}"
-        # Reject empty `@` (continuum-b741 + ideem-local-4bef caught
+        # Reject empty `@` (caught
         # 2026-04-29: `airc msg @ body` silently broadcast). Reject
         # double-@ `@@peer` while we're here (also caught: accepted as
         # DM to literal '@peer'). Reject numeric-only DMs as per the
@@ -219,7 +219,7 @@ cmd_send() {
     msg="$*"
   fi
   # Reject empty broadcast bodies — pre-fix `airc msg ""` printed the
-  # usage line but exited 0 (continuum-b741 caught 2026-04-29). The
+  # usage line but exited 0 (caught 2026-04-29). The
   # other "no message" path already dies above; this one is the
   # explicit-empty-string case that fell through.
   [ "$peer_name" = "all" ] && [ -z "$msg" ] \

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -412,7 +412,7 @@ cmd_logs() {
   done
   set -- "${positional[@]+"${positional[@]}"}"
   local count="${1:-20}"
-  # Validate count: positive integer (ideem-local-4bef caught 2026-04-29:
+  # Validate count: positive integer (caught 2026-04-29:
   # 'airc logs 0' and 'airc logs notanumber' silently exited 0 with no
   # output). Tail with N=0 prints nothing; with non-numeric, tail errors
   # and we swallow it.

--- a/lib/airc_bash/cmd_update.sh
+++ b/lib/airc_bash/cmd_update.sh
@@ -117,7 +117,7 @@ cmd_update() {
   # install.sh runs, install.sh sees the stale value and switches our
   # just-completed branch back to the old channel. Net effect: airc
   # version reports the old branch, airc channel reports the new
-  # channel — the disagreement continuum-b741 hit during regression.
+  # channel — the disagreement found during regression.
   #
   # Write order now: (a) cmd_update checks out the requested branch,
   # (b) write .channel = requested, (c) install.sh ff-pulls + sees
@@ -136,7 +136,7 @@ cmd_update() {
     echo "  Updated: ${before} -> ${after} on channel '${channel}'. Skills refreshed."
   fi
 
-  # Stale-running-monitor detection (vhsm-d1f4's gotcha 2026-04-28):
+  # Stale-running-monitor detection (2026-04-28):
   # bash sources its functions in-memory at process start; an airc
   # connect that's been running since BEFORE this update is still
   # executing the old version. We can't auto-restart safely (would
@@ -173,7 +173,7 @@ cmd_channel() {
   local target="${1:-}"
   # Help-flag intercept BEFORE we'd write target to channel_file.
   # First version (#237) just fell through to the no-args path which
-  # prints the current channel info — continuum-b69f's #244 Windows
+  # prints the current channel info — #244 Windows
   # e2e flagged that as inconsistent with the other --help intercepts
   # (no "Usage:" header). Now prints a proper Usage block.
   case "$target" in

--- a/lib/airc_bash/lib_auth.sh
+++ b/lib/airc_bash/lib_auth.sh
@@ -113,7 +113,7 @@ airc_detect_gh_auth_state() {
   # Cache the OK state for AIRC_AUTH_CACHE_SEC seconds to avoid hitting
   # /user (gh auth status's probe target) on every airc-connect startup.
   # Repeated calls trip GitHub's secondary rate limiter — discovered
-  # 2026-05-02 by continuum-b69f when daemon respawn cascade made many
+  # 2026-05-02 when daemon respawn cascade made many
   # calls/min and the secondary throttle locked us out for ~15 min.
   # Core API limit was fine (4766/5000); /user-specific throttle was
   # the actual cause. Caching reduces /user hits from

--- a/lib/airc_core/channel_gist.py
+++ b/lib/airc_core/channel_gist.py
@@ -1,8 +1,8 @@
 """channel_gist — find-or-create the canonical gist for a channel name on
 the user's gh account.
 
-Single concern: given a channel name (e.g. "general", "useideem",
-"continuum"), return the gist id that hosts that channel for THIS gh
+Single concern: given a channel name (e.g. "general", "acme",
+"example"), return the gist id that hosts that channel for THIS gh
 account. If no such gist exists and create_if_missing=True, publish a
 new mesh-shaped gist and return its id.
 
@@ -503,8 +503,8 @@ def find_existing(channel: str, require_invite: bool = False) -> Optional[str]:
     Pre-2026-04-29 bug: order was whatever gh's list-response yielded
     first (recency-ordered, may differ across calls). Two peers
     polling the listing at slightly different times could pick
-    DIFFERENT duplicates, splitting the substrate. authenticator-448f
-    + continuum-b741 saw this on #general — peers thought they were
+    DIFFERENT duplicates, splitting the substrate. Two agents saw this
+    on #general — peers thought they were
     in the same room but were writing to different gists. Sends
     looked successful, peers heard nothing.
 

--- a/lib/airc_core/config.py
+++ b/lib/airc_core/config.py
@@ -174,7 +174,7 @@ def cmd_unsubscribe(args) -> int:
 # without re-doing gh-account discovery on every send.
 #
 # Format in config.json:
-#   "channel_gists": {"general": "<id>", "useideem": "<id>", ...}
+#   "channel_gists": {"general": "<id>", "acme": "<id>", ...}
 #
 # Single source of truth for "given a channel name, what gist?" — bash
 # never reads config.json directly for this; it goes through these
@@ -218,7 +218,7 @@ def cmd_set_host_block(args) -> int:
     """Atomically write the post-handshake host_* fields into config.
 
     Replaces a fragile env-var-passed python heredoc that bit on MSYS
-    Git Bash (continuum-b69f's catch 2026-04-27): MSYS translates env
+    Git Bash (caught 2026-04-27): MSYS translates env
     var values that look like Unix paths INTO the Windows-binary
     subprocess, so /Users/... silently became C:/Program Files/Git/...
     Argparse `--flags` are per-arg-predictable (callers can `//`-prefix

--- a/lib/airc_core/gistparse.py
+++ b/lib/airc_core/gistparse.py
@@ -186,8 +186,8 @@ def cmd_pick_addr_nonlocal_first(args) -> int:
     entry of any kind" — but the gist's host.addresses[] often has
     `localhost` first (127.0.0.1, the host's loopback). For a different
     machine's joiner, picking that means dialing their OWN loopback,
-    which never reaches the host. Symptom: Joel's Windows peer subscribed
-    to #cambriantech but stuck on a 127.0.0.1 connection because their
+    which never reaches the host. Symptom: a Windows peer subscribed
+    to #acme but stuck on a 127.0.0.1 connection because their
     Windows IP didn't match the host's lan/24 subnet check. With this
     helper, the fallback skips localhost entries; if only localhost
     remains, returns empty so the caller falls through to gh-bearer-only

--- a/lib/airc_core/monitor_formatter.py
+++ b/lib/airc_core/monitor_formatter.py
@@ -145,7 +145,7 @@ def _find_peer_by_host(peers_dir: str, host: str):
 
     #180 fix: only return a name when the host is UNAMBIGUOUS (exactly
     one peer record matches). Same-machine peers share the host field
-    (e.g. multiple Claudes on Joel's box all have host=joel@127.0.0.1),
+    (e.g. multiple agents on one box all have host=user@127.0.0.1),
     so picking one arbitrarily corrupts an unrelated peer's record.
     Ambiguous-host → return None → chain-repair skips, no phantom."""
     if not host or not os.path.isdir(peers_dir):
@@ -563,7 +563,7 @@ def run(my_name: str, peers_dir: str) -> int:
         # pre-Phase-2 messages that don't carry the envelope field.
         line_channel = m.get("channel") or room_name
 
-        # Phase 2C+ (continuum-b741's #9 from QA pass 2026-04-28):
+        # Phase 2C+ (QA pass 2026-04-28):
         # filter display by subscribed_channels. If the user is
         # subscribed to specific channels and this message is on a
         # different channel, skip display. DMs addressed to us bypass
@@ -577,8 +577,8 @@ def run(my_name: str, peers_dir: str) -> int:
             addressed_to_me = bool(to) and to not in ("", "all") and current_name() in to.split(",")
             # Channel-name comparison must be tolerant of leading "#"
             # on either side. Pre-fix: subs read from config might be
-            # ['cambriantech', 'general'] (no #), but envelopes can
-            # carry channel='#cambriantech' (with #) — or vice versa.
+            # ['acme', 'general'] (no #), but envelopes can
+            # carry channel='#acme' (with #) — or vice versa.
             # The strict `line_channel not in subs` check then misfires
             # and silently drops legit broadcasts. b69f filed this as
             # #399: joiner Monitor surfaces substrate events but room
@@ -591,7 +591,7 @@ def run(my_name: str, peers_dir: str) -> int:
             if line_norm and line_norm not in subs_norm and not addressed_to_me:
                 # b69f 2026-05-02: even after #401's '#'-prefix tolerance,
                 # legit drops still happen when the channel NAME differs
-                # (e.g. peer stamps channel='cambriantech', subs=['general'],
+                # (e.g. peer stamps channel='acme', subs=['general'],
                 # both polling the same gist). #401 catches '#general' vs
                 # 'general'; this catches every other shape of name drift.
                 # Make the drop LOUD instead of silent — emit one stdout
@@ -623,7 +623,7 @@ def run(my_name: str, peers_dir: str) -> int:
             else:
                 # PEER-SUPPLIED content. Sandbox-wrap per vuln-A
                 # mitigation (described in docs/fusion-transport.md
-                # "Pairs with" section, identified by continuum-b69f
+                # "Pairs with" section, identified during QA
                 # 2026-05-02; b69f also recommended the per-session
                 # contract notice below).
                 #

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:join
-description: "Join AIRC. Default = auto-scoped project room (#useideem from useideem/*, etc.) AND #general lobby simultaneously. Optional arg = mnemonic, gist id, room name, or inline invite."
+description: "Join AIRC. Default = auto-scoped project room (from the git remote owner) AND #general lobby simultaneously. Optional arg = mnemonic, gist id, room name, or inline invite."
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: "[mnemonic | gist-id | room-name | invite-string]"
@@ -50,7 +50,7 @@ Don't default-stamp project chatter onto the lobby. It drowns out cross-room sig
 - In a git repo → `<repo-root>/.airc/`
 - Otherwise → `$PWD/.airc/`
 - Always overridable with `AIRC_HOME`.
-- Org → room map: `useideem/*` → `#useideem`, `cambrian/*` → `#cambriantech`, no remote → `#general`.
+- Org → room map: `github.com/acme/api` → `#acme`, `gitlab.com/example/frontend` → `#example`, no remote → `#general`.
 
 ## Runtime contract
 

--- a/skills/whois/SKILL.md
+++ b/skills/whois/SKILL.md
@@ -23,10 +23,10 @@ airc whois         # prints YOUR own identity (self)
 Output is a structured block:
 
 ```
-  name:      vhsm-d1f4
+  name:      build-d1f4
   pronouns:  they
-  role:      vhsm-android-sdk
-  bio:       wallet/merchant bridging cert flow on vhsm-canary
+  role:      build-runner
+  bio:       CI and release coordination for the current project
   status:    in a meeting til 3pm
   integrations: (none)
   host:      joelteply@100.91.51.87

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -172,7 +172,7 @@ requires_local_pair_bearer_or_skip() {
 # pks-test-NNNN / etc` entries — confusing during dogfood and slowly
 # filling gist quota. Skipped silently if gh isn't authed (CI without
 # gh) or has no gist scope. Filters by description-prefix to avoid
-# touching real rooms (#general / #useideem / #cambriantech etc).
+# touching real rooms (#general / #acme / #example etc).
 cleanup_test_gists() {
   command -v gh >/dev/null 2>&1 || return 0
   gh auth status >/dev/null 2>&1 || return 0
@@ -180,7 +180,7 @@ cleanup_test_gists() {
   # Test-scope room name prefixes — keep this list in sync with
   # scenarios that publish real gists. Anything not on this list is
   # left alone (real rooms or someone else's tests).
-  local _test_prefix_re='airc room: (sars-test-|pks-test-|pks-debug|debug-room|sidecar-test-|solo-test-|ronly-test-|new-room|myproject|hb-test-|bounce-test-|ttl-test-|test-irc-|useideem-test-|stalepid-)'
+  local _test_prefix_re='airc room: (sars-test-|pks-test-|pks-debug|debug-room|sidecar-test-|solo-test-|ronly-test-|new-room|myproject|hb-test-|bounce-test-|ttl-test-|test-irc-|acme-test-|stalepid-)'
   local _ids
   _ids=$(gh gist list --limit 50 2>/dev/null | awk -F'\t' -v re="$_test_prefix_re" '$2 ~ re { print $1 }')
   if [ -n "$_ids" ]; then
@@ -1840,18 +1840,18 @@ scenario_two_tab_localhost() {
 }
 
 # ── Scenario: auto_scope (default room derived from git remote org) ─────
-# The /join skill contract: bare `airc join` from a useideem/* checkout
-# lands in #useideem; from a cambriantech/* checkout lands in #cambriantech.
+# The /join skill contract: bare `airc join` from an acme/* checkout
+# lands in #acme; from an example/* checkout lands in #example.
 # A previous PR (#104) gated this behind AIRC_AUTO_SCOPE_ROOM=1, which
 # left bare-launched agents stuck in #general regardless of cwd —
 # defeating the whole point. Re-enabled as default 2026-04-26 after a
-# session of dogfooding pain (two useideem tabs both hit #general
-# instead of converging on #useideem).
+# session of dogfooding pain (two same-org tabs both hit #general
+# instead of converging on the project room).
 #
 # Test plan: stand up a fake git repo with origin pointing to
-# `useideem/foo`, run `airc connect` in that cwd (gh-free, --no-gist),
-# verify the "Auto-scoped: #useideem (from git org; ...)" banner fires
-# and that room_name is "useideem". Then verify AIRC_NO_AUTO_ROOM=1
+# `acme/foo`, run `airc connect` in that cwd (gh-free, --no-gist),
+# verify the "Auto-scoped: #acme (from git org; ...)" banner fires
+# and that room_name is "acme". Then verify AIRC_NO_AUTO_ROOM=1
 # opts out cleanly (banner absent, falls back to #general).
 scenario_auto_scope() {
   section "auto_scope: bare connect derives room from git remote org"
@@ -1860,7 +1860,7 @@ scenario_auto_scope() {
 
   local repo=/tmp/airc-it-auto-repo
   rm -rf "$repo"; mkdir -p "$repo"
-  ( cd "$repo" && git init -q 2>/dev/null && git remote add origin https://github.com/useideem/foo.git ) \
+  ( cd "$repo" && git init -q 2>/dev/null && git remote add origin https://github.com/acme/foo.git ) \
     || { fail "git scaffold failed"; cleanup_all; return; }
 
   # Default ON: bare connect should auto-scope.
@@ -1873,13 +1873,13 @@ scenario_auto_scope() {
     grep -qE 'Hosting as|Auto-scoped' /tmp/airc-it-auto-h.log 2>/dev/null && break
   done
 
-  grep -qE 'Auto-scoped: #useideem \(from git org' /tmp/airc-it-auto-h.log \
-    && pass "auto-scope banner: 'Auto-scoped: #useideem (from git org)'" \
+  grep -qE 'Auto-scoped: #acme \(from git org' /tmp/airc-it-auto-h.log \
+    && pass "auto-scope banner: 'Auto-scoped: #acme (from git org)'" \
     || fail "auto-scope banner MISSING (got: $(head -3 /tmp/airc-it-auto-h.log | tr '\n' '|'))"
 
-  grep -qE 'Hosting #useideem' /tmp/airc-it-auto-h.log \
-    && pass "host banner reports #useideem (auto-scoped room took effect)" \
-    || fail "host banner not on #useideem (auto-scope didn't propagate to host setup)"
+  grep -qE 'Hosting #acme' /tmp/airc-it-auto-h.log \
+    && pass "host banner reports #acme (auto-scoped room took effect)" \
+    || fail "host banner not on #acme (auto-scope didn't propagate to host setup)"
 
   # Kill that run before testing the opt-out (port + scope reuse).
   for f in /tmp/airc-it-auto-h/state/airc.pid; do

--- a/test/integration_smoke.sh
+++ b/test/integration_smoke.sh
@@ -529,7 +529,7 @@ scenario_my_scope_in_mesh() {
   # Joel 2026-04-29: 'remember you need to be part of it'. The other
   # scenarios spawn ephemeral test peers in /tmp and never include
   # the user's actual long-running airc scope. This one DOES — it
-  # asserts that the live authenticator-448f scope (whatever scope
+  # asserts that the live local test scope (whatever scope
   # is running in the user's primary cwd) receives messages a fresh
   # test peer sends. If my own scope's monitor is broken, this catches
   # it where the isolated tests can't.

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -760,7 +760,7 @@ class BearerCliRecvLockTests(unittest.TestCase):
         self.assertEqual(first_pidfile, self._tmpdir + "/bearer_gist.samegist.pid")
 
         second_args = self._args(
-            state_file=self._tmpdir + "/bearer_state.useideem.json",
+            state_file=self._tmpdir + "/bearer_state.acme.json",
             room_gist_id="samegist",
         )
         with mock.patch.object(bearer_cli, "_pid_alive", return_value=True), \
@@ -1302,7 +1302,7 @@ class GhBearerSendTests(unittest.TestCase):
         self.assertEqual(captured[1], racer_line + my_line)
 
     def test_send_retries_on_409_conflict(self):
-        # continuum-b741 caught HTTP 409 4/5 on a 5-way burst (#299).
+        # HTTP 409 was caught 4/5 on a 5-way burst (#299).
         # First PATCH 409s → loop → second PATCH succeeds → verify ok.
         gets = [
             {"files": {}},

--- a/test/test_channel_gist.py
+++ b/test/test_channel_gist.py
@@ -99,15 +99,15 @@ class FindExistingConvergenceTests(unittest.TestCase):
         """Connect discovery needs a host envelope, not just a routing
         seed. Seed-only channel gists are valid for cmd_send routing but
         cannot be joined because they have no invite/host data."""
-        seed_only = self._gist("seed-only", "cambriantech", "2026-05-04T17:27:38Z")
-        host = self._gist("host", "cambriantech", "2026-05-04T17:28:38Z")
-        env = json.loads(host["files"]["airc-room-cambriantech.json"]["content"])
+        seed_only = self._gist("seed-only", "acme", "2026-05-04T17:27:38Z")
+        host = self._gist("host", "acme", "2026-05-04T17:28:38Z")
+        env = json.loads(host["files"]["airc-room-acme.json"]["content"])
         env["invite"] = "host@example"
-        host["files"]["airc-room-cambriantech.json"]["content"] = json.dumps(env)
+        host["files"]["airc-room-acme.json"]["content"] = json.dumps(env)
         with mock.patch.object(channel_gist, "_gh_list_user_gists",
                                return_value=[seed_only, host]):
-            self.assertEqual(channel_gist.find_existing("cambriantech"), "seed-only")
-            self.assertEqual(channel_gist.find_existing("cambriantech", require_invite=True), "host")
+            self.assertEqual(channel_gist.find_existing("acme"), "seed-only")
+            self.assertEqual(channel_gist.find_existing("acme", require_invite=True), "host")
 
     def test_returns_oldest_legacy_when_no_canonical(self):
         """If only legacy mesh gists exist (none canonical), still
@@ -184,7 +184,7 @@ class LocalCacheFallbackTests(unittest.TestCase):
             snapshots = {
                 stale: self._snapshot(stale, "general", ["general"], "2026-04-30T12:00:00Z"),
                 current: self._snapshot(current, "general", ["general"], "2026-05-04T18:11:00Z"),
-                island: self._snapshot(island, "general", ["general", "cambriantech"], "2026-05-04T18:27:00Z"),
+                island: self._snapshot(island, "general", ["general", "acme"], "2026-05-04T18:27:00Z"),
             }
             roots = os.pathsep.join([
                 str(Path(tmp) / "old-worktree" / ".airc"),
@@ -200,11 +200,11 @@ class LocalCacheFallbackTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             old = "dddddddd"
             current = "eeeeeeee"
-            self._write_cfg(tmp, "old", "cambriantech", old)
-            self._write_cfg(tmp, "current", "cambriantech", current)
+            self._write_cfg(tmp, "old", "acme", old)
+            self._write_cfg(tmp, "current", "acme", current)
             snapshots = {
-                old: self._snapshot(old, "cambriantech", ["cambriantech", "general"], "2026-05-04T17:40:00Z"),
-                current: self._snapshot(current, "cambriantech", ["cambriantech", "general"], "2026-05-04T18:22:49Z"),
+                old: self._snapshot(old, "acme", ["acme", "general"], "2026-05-04T17:40:00Z"),
+                current: self._snapshot(current, "acme", ["acme", "general"], "2026-05-04T18:22:49Z"),
             }
             roots = os.pathsep.join([
                 str(Path(tmp) / "old" / ".airc"),
@@ -213,7 +213,7 @@ class LocalCacheFallbackTests(unittest.TestCase):
             with mock.patch.dict(os.environ, {"AIRC_GIST_CACHE_ROOTS": roots, "AIRC_DISABLE_LOCAL_GIST_FALLBACK": ""}), \
                  mock.patch.object(channel_gist, "_gh_list_user_gists", return_value=[]), \
                  mock.patch.object(channel_gist, "_git_gist_snapshot", side_effect=lambda gid: snapshots.get(gid)):
-                self.assertEqual(channel_gist.find_existing("cambriantech"), current)
+                self.assertEqual(channel_gist.find_existing("acme"), current)
 
     def test_default_local_fallback_only_reads_current_airc_home_config(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/test/test_gistparse.py
+++ b/test/test_gistparse.py
@@ -55,24 +55,24 @@ class GistContentTests(unittest.TestCase):
         stale = {
             "airc": 1,
             "kind": "mesh",
-            "channels": ["general", "cambriantech"],
+            "channels": ["general", "acme"],
             "last_heartbeat": "2026-05-04T12:54:15Z",
             "invite": "stale-host@example",
         }
         fresh = {
             "airc": 1,
             "kind": "mesh",
-            "channels": ["cambriantech", "general"],
+            "channels": ["acme", "general"],
             "last_heartbeat": "2026-05-04T17:14:09Z",
             "invite": "fresh-host@example",
         }
         gist = {
             "files": {
-                "airc-room-cambriantech.json": {"content": json.dumps(stale)},
+                "airc-room-acme.json": {"content": json.dumps(stale)},
                 "airc-room-general.json": {"content": json.dumps(fresh)},
             },
         }
-        out = _run_gist_content(gist, channel="cambriantech")
+        out = _run_gist_content(gist, channel="acme")
         self.assertEqual(json.loads(out)["invite"], "fresh-host@example")
 
     def test_channel_freshness_uses_timestamp_parse_not_lexicographic_sort(self):

--- a/test/test_monitor_formatter.py
+++ b/test/test_monitor_formatter.py
@@ -222,7 +222,7 @@ class HeartbeatSuppressionTests(unittest.TestCase):
 class DisplayFilterLoudDropTests(unittest.TestCase):
     """#399 follow-up to #401: when monitor_formatter's display filter
     drops a peer broadcast (channel name truly differs, e.g.
-    'cambriantech' vs subs=['general'] — #401's '#'-prefix tolerance
+    'acme' vs subs=['general'] — #401's '#'-prefix tolerance
     cannot help), emit a stdout warning so Claude Code's Monitor wakes
     + the operator sees they need `airc join --room <channel>`.
 
@@ -262,14 +262,14 @@ class DisplayFilterLoudDropTests(unittest.TestCase):
         return out.getvalue(), err.getvalue()
 
     def test_cross_channel_drop_emits_stdout_warning(self):
-        msg = {"from": "bob", "to": "all", "channel": "cambriantech",
+        msg = {"from": "bob", "to": "all", "channel": "acme",
                "msg": "should drop", "ts": "2026-05-02T15:00:00Z"}
         out, err = self._run([msg])
         self.assertNotIn("should drop", out,
             "cross-channel msg body must not display when subs filter rejects")
         self.assertIn("WARN display-filtered", out,
             "cross-channel drop must surface to stdout so Monitor wakes")
-        self.assertIn("cambriantech", out,
+        self.assertIn("acme", out,
             "warning must name the dropped channel so operator can subscribe")
         self.assertIn("display-filter drop", err,
             "stderr trace must record evidence for daemon.log debugging")
@@ -284,7 +284,7 @@ class DisplayFilterLoudDropTests(unittest.TestCase):
             "subscribed-channel msg must not trigger drop warning")
 
     def test_addressed_to_me_bypasses_filter(self):
-        msg = {"from": "bob", "to": "alice", "channel": "cambriantech",
+        msg = {"from": "bob", "to": "alice", "channel": "acme",
                "msg": "DM bypasses filter", "ts": "2026-05-02T15:00:00Z"}
         out, err = self._run([msg])
         self.assertIn("DM bypasses filter", out,


### PR DESCRIPTION
## Summary
- Replace dogfood org/project names in public auto-scope docs, skills, comments, and tests with generic org examples.
- Keep runtime auto-scope generic: git remote owner maps to #<owner>; no Cambrian/Continuum special case.
- Keep actual CambrianTech package identifiers/install URLs unchanged.

## Validation
- bash -n airc
- python3 test/test_channel_gist.py
- python3 test/test_gistparse.py
- python3 test/test_monitor_formatter.py
- python3 test/test_bearer.py
- airc doctor --tests scope
- airc doctor --tests auto_scope