### PR TITLE
Treat first-user solo mesh as waiting

### DIFF
--- a/lib/airc_core/collaboration.py
+++ b/lib/airc_core/collaboration.py
@@ -68,6 +68,14 @@ def peer_record_count(home: str) -> int:
 
 
 def recent_remote_activity(home: str, my_name: str, window_sec: int = RECENT_REMOTE_WINDOW_SEC) -> Optional[RemoteActivity]:
+    return _remote_activity(home, my_name, window_sec=window_sec)
+
+
+def any_remote_activity(home: str, my_name: str) -> Optional[RemoteActivity]:
+    return _remote_activity(home, my_name, window_sec=None)
+
+
+def _remote_activity(home: str, my_name: str, window_sec: Optional[int]) -> Optional[RemoteActivity]:
     messages_log = os.path.join(home, "messages.jsonl")
     now = int(time.time())
     last: Optional[RemoteActivity] = None
@@ -84,7 +92,7 @@ def recent_remote_activity(home: str, my_name: str, window_sec: int = RECENT_REM
                 ts = _epoch(msg.get("ts"))
                 if ts is None:
                     continue
-                if now - ts >= window_sec:
+                if window_sec is not None and now - ts >= window_sec:
                     continue
                 if last is None or ts > last.ts:
                     last = RemoteActivity(str(sender), ts)
@@ -120,17 +128,21 @@ def cmd_status(args: argparse.Namespace) -> int:
     count = peer_record_count(args.home)
     speakers = recent_remote_speakers(args.home, args.my_name)
     recent = recent_remote_activity(args.home, args.my_name)
+    any_recent = recent if recent is not None else any_remote_activity(args.home, args.my_name)
     now = int(time.time())
-    if recent is None:
+    if any_recent is None:
         remote_desc = "no remote messages recorded"
     else:
-        remote_desc = f"last remote message {max(0, now - recent.ts)}s ago from {recent.name}"
+        remote_desc = f"last remote message {max(0, now - any_recent.ts)}s ago from {any_recent.name}"
 
     if count == 0:
         if speakers:
             label = "broadcast peer" if len(speakers) == 1 else "broadcast peers"
             print(f"  collaboration: ok ({len(speakers)} {label}; 0 direct peer records; {remote_desc})")
             print("    Presence is derived from recent signed room traffic.")
+        elif any_recent is None:
+            print(f"  collaboration: waiting for peers (0 peer records; {remote_desc})")
+            print("    First agent in a room is expected to be alone until another agent joins this gist.")
         else:
             print(f"  collaboration: SOLO (0 peer records; {remote_desc})")
             print("    Sends may only land in this local/self-hosted gist until another agent joins this exact mesh.")
@@ -143,6 +155,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     count = peer_record_count(args.home)
     speakers = recent_remote_speakers(args.home, args.my_name)
     recent = recent_remote_activity(args.home, args.my_name)
+    any_recent = recent if recent is not None else any_remote_activity(args.home, args.my_name)
     now = int(time.time())
     if count > 0:
         print(f"  [ok] collaboration mesh has {count} peer record(s)")
@@ -162,7 +175,14 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         )
         print("         Peer metadata is degraded (DMs/whois may fail), but this is NOT a solo island.")
         return 1
-    print("  [BLOCKED] collaboration mesh has 0 peer records — local transport may be alive, but this is a solo island")
+    if any_recent is None:
+        print("  [info] collaboration mesh has 0 peer records and no remote history — waiting for first peer")
+        print("         Share the invite or ask another agent to join this room; first-user startup is OK.")
+        return 0
+    print(
+        f"  [BLOCKED] collaboration mesh has 0 peer records — last remote traffic was "
+        f"{max(0, now - any_recent.ts)}s ago from {any_recent.name}; this may be a solo island"
+    )
     print("         Check: airc peers; ask peers to run 'airc update --channel canary && airc connect <current invite>'")
     return 2
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2169,8 +2169,8 @@ SH
 # ── Scenario: solo_mesh_warns (transport health != collaboration) ───────
 # A self-healed host can have fresh local transport/bearer state while no
 # peers are actually paired to the mesh. `airc status` / `doctor --health`
-# must not report that as simply healthy; the user needs to know they may
-# be talking to a solo gist.
+# must not report stale prior collaboration as simply healthy, but a true
+# first user with no remote history should not be blocked.
 scenario_solo_mesh_warns() {
   section "solo_mesh_warns: status and doctor distinguish local health from collaboration"
   cleanup_all
@@ -2186,20 +2186,25 @@ JSON
 
   local status_out doctor_out
   status_out=$(AIRC_HOME="$home" "$AIRC" status 2>&1)
-  echo "$status_out" | grep -q 'collaboration: SOLO' \
-    && pass "status reports SOLO when peer records are empty" \
-    || fail "status did not report solo collaboration state ($status_out)"
+  echo "$status_out" | grep -q 'collaboration: waiting for peers' \
+    && pass "status reports waiting state for first user with no peers" \
+    || fail "status did not report first-user waiting state ($status_out)"
 
   doctor_out=$(AIRC_HOME="$home" "$AIRC" doctor --health 2>&1)
-  echo "$doctor_out" | grep -q 'collaboration mesh has 0 peer records' \
-    && pass "doctor --health warns about zero-peer collaboration mesh" \
-    || fail "doctor --health did not warn about zero peers ($doctor_out)"
-  echo "$doctor_out" | grep -q 'Bus DEGRADED' \
-    && pass "doctor summary is degraded, not clean healthy" \
-    || fail "doctor summary still looked clean ($doctor_out)"
+  echo "$doctor_out" | grep -q 'waiting for first peer' \
+    && pass "doctor --health treats first-user solo as informational" \
+    || fail "doctor --health did not surface first-user waiting state ($doctor_out)"
 
+  printf '{"from":"remote-agent","to":"all","ts":"%s","channel":"general","msg":"stale remote proof"}\n' \
+    "$(date -u -v-2H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ)" >> "$home/messages.jsonl"
+  doctor_out=$(AIRC_HOME="$home" "$AIRC" doctor --health 2>&1 || true)
+  echo "$doctor_out" | grep -q 'may be a solo island' \
+    && pass "doctor --health blocks zero-peer mesh when prior remote traffic went stale" \
+    || fail "doctor --health did not block stale prior remote traffic ($doctor_out)"
+
+  : > "$home/messages.jsonl"
   printf '{"from":"remote-agent","to":"all","ts":"%s","channel":"general","msg":"recent remote proof"}\n' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$home/messages.jsonl"
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$home/messages.jsonl"
   local now_ts; now_ts=$(date +%s)
   printf '{"kind":"gh","peer_id":"self","last_recv_ts":%s,"last_sender":"remote-agent","events_total":1,"diag":"last event from gh poll","last_heartbeat_ts":%s}\n' \
     "$((now_ts - 3600))" "$now_ts" > "$home/bearer_state.general.json"

--- a/test/test_collaboration.py
+++ b/test/test_collaboration.py
@@ -37,14 +37,40 @@ class CollaborationHealthTests(unittest.TestCase):
             "msg": "hello",
         }) + "\n"
 
-    def test_status_solo_without_records_or_remote_traffic(self):
+    def test_status_waiting_without_records_or_remote_traffic(self):
         tmp, home = self._scope()
         with tmp:
             out = io.StringIO()
             with redirect_stdout(out):
                 rc = collaboration.main(["status", "--home", str(home), "--my-name", "me"])
             self.assertEqual(rc, 0)
-            self.assertIn("collaboration: SOLO", out.getvalue())
+            self.assertIn("collaboration: waiting for peers", out.getvalue())
+
+    def test_doctor_info_without_records_or_remote_traffic(self):
+        tmp, home = self._scope()
+        with tmp:
+            out = io.StringIO()
+            with redirect_stdout(out):
+                rc = collaboration.main(["doctor", "--home", str(home), "--my-name", "me"])
+            self.assertEqual(rc, 0)
+            self.assertIn("waiting for first peer", out.getvalue())
+
+    def test_doctor_blocked_when_remote_history_is_stale(self):
+        tmp, home = self._scope()
+        with tmp:
+            stale_ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - 7200))
+            (home / "messages.jsonl").write_text(json.dumps({
+                "from": "remote-agent",
+                "to": "all",
+                "ts": stale_ts,
+                "channel": "general",
+                "msg": "old",
+            }) + "\n", encoding="utf-8")
+            out = io.StringIO()
+            with redirect_stdout(out):
+                rc = collaboration.main(["doctor", "--home", str(home), "--my-name", "me"])
+            self.assertEqual(rc, 2)
+            self.assertIn("may be a solo island", out.getvalue())
 
     def test_status_ok_when_recent_remote_traffic_exists(self):
         tmp, home = self._scope()


### PR DESCRIPTION
## Summary
- Distinguish true first-user startup from split-brain solo state.
- Zero peer records plus no remote history now reports 'waiting for first peer' and exits healthy.
- Zero peer records plus stale prior remote traffic still reports degraded/blocked.

## Validation
- bash -n airc
- python3 test/test_collaboration.py
- python3 test/test_channel_gist.py
- python3 test/test_bearer.py
- airc doctor --tests solo_mesh_warns
- live continuum doctor still blocks because it has stale remote traffic and no peer records