### PR TITLE
Restart daemon without rediscovering known gists

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -69,10 +69,17 @@ ensure_channel_subscribed_with_gist() {
     return 1
   fi
 
-  # 2. Resolve-or-create the canonical gist on this gh account.
+  # 2. Resolve-or-create the canonical gist on this gh account. If this
+  # scope already knows the channel→gist mapping, trust that first: a
+  # daemon restart must not block on GitHub discovery just to re-subscribe
+  # to a room that is already in config.
   local _gid
-  _gid=$("$AIRC_PYTHON" -m airc_core.channel_gist resolve \
-         --channel "$channel" --create-if-missing 2>"$_err")
+  _gid=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
+         --config "$CONFIG" --channel "$channel" 2>/dev/null || true)
+  if [ -z "$_gid" ]; then
+    _gid=$("$AIRC_PYTHON" -m airc_core.channel_gist resolve \
+           --channel "$channel" --create-if-missing 2>"$_err")
+  fi
   if [ -z "$_gid" ]; then
     echo "  ⚠ Could not resolve gist for #${channel}:" >&2
     [ -s "$_err" ] && sed 's/^/      /' "$_err" >&2

--- a/lib/airc_bash/cmd_daemon.sh
+++ b/lib/airc_bash/cmd_daemon.sh
@@ -62,7 +62,7 @@ cmd_daemon() {
       return 0 ;;
     install)   cmd_daemon_install "$@" ;;
     uninstall|remove) cmd_daemon_uninstall "$@" ;;
-    restart)   shift; cmd_daemon_uninstall "$@" >/dev/null && cmd_daemon_install "$@" ;;
+    restart)   cmd_daemon_uninstall "$@" >/dev/null && cmd_daemon_install "$@" ;;
     status)    cmd_daemon_status "$@" ;;
     log|logs)  cmd_daemon_log "$@" ;;
     stop|start)

--- a/lib/airc_bash/mesh.sh
+++ b/lib/airc_bash/mesh.sh
@@ -54,6 +54,14 @@ _mesh_find() {
     channel=$("$AIRC_PYTHON" -m airc_core.config default_channel --config "$CONFIG" 2>/dev/null || true)
   fi
   [ -z "$channel" ] && channel="general"
+  if [ -n "${CONFIG:-}" ] && [ -f "$CONFIG" ]; then
+    local configured
+    configured=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist --config "$CONFIG" --channel "$channel" 2>/dev/null || true)
+    if [ -n "$configured" ]; then
+      printf '%s\n' "$configured"
+      return 0
+    fi
+  fi
   "$AIRC_PYTHON" -m airc_core.channel_gist find --channel "$channel" --require-invite 2>/dev/null || true
 }
 
@@ -68,6 +76,14 @@ _mesh_find_any() {
     channel=$("$AIRC_PYTHON" -m airc_core.config default_channel --config "$CONFIG" 2>/dev/null || true)
   fi
   [ -z "$channel" ] && channel="general"
+  if [ -n "${CONFIG:-}" ] && [ -f "$CONFIG" ]; then
+    local configured
+    configured=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist --config "$CONFIG" --channel "$channel" 2>/dev/null || true)
+    if [ -n "$configured" ]; then
+      printf '%s\n' "$configured"
+      return 0
+    fi
+  fi
   "$AIRC_PYTHON" -m airc_core.channel_gist find --channel "$channel" 2>/dev/null || true
 }
 


### PR DESCRIPTION
## Summary
- Fix airc daemon restart so it actually runs uninstall/install instead of exiting on an extra shift under set -e.
- Trust existing channel_gists mappings before GitHub discovery in mesh lookup and channel subscription.
- Prevent daemon restarts and #general sidecar startup from blocking on GitHub discovery when config already has the gist ids.

## Validation
- bash -n airc
- python3 test/test_channel_gist.py
- python3 test/test_collaboration.py
- airc doctor --tests auto_scope
- airc doctor --tests solo_mesh_warns
- live macOS launchd restart in continuum scope: daemon loaded, formatter PID present, two bearer_cli recv processes present, both channel heartbeats fresh after soak
