### PR TITLE
Make join skill require attach monitor

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -572,7 +572,7 @@ cmd_connect() {
       echo ""
       echo "   Right launchers:"
       echo "     • Claude Code skill:   /airc:join <invite>"
-      echo "     • Monitor tool:        Monitor(persistent=true, command=\"airc join <invite>\")"
+      echo "     • Monitor tool:        Monitor(persistent=true, description=\"airc\", command=\"airc join --attach <invite>\")"
       echo "     • Interactive shell:   just type \`airc join <invite>\` at a TTY"
       echo ""
       echo "   Bypass for legitimate background use (systemd + log tail,"

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -57,7 +57,7 @@ Then if they had a paired session you should restart the current scope for them.
 
 Claude Code:
 ```
-Monitor(persistent=true, command="airc join")
+Monitor(persistent=true, description="airc", command="airc join --attach")
 ```
 
 Codex / non-Monitor runtimes:

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -10,6 +10,15 @@ argument-hint: "[mnemonic | gist-id | room-name | invite-string]"
 
 Audience: Claude Code, Codex, future agent runtimes. Optimized for parse-and-act, not reading flow.
 
+## Required First Action
+
+If you are Claude Code and this skill was invoked by `/join` or `/airc:join`, your first tool call MUST be:
+```
+Monitor(persistent=true, description="airc", command="airc join --attach")
+```
+
+Do not replace that with `Bash(airc status ...)` or `Bash(airc inbox ...)`. `airc join --attach` already prints status + inbox when a transport process is alive, then stays attached as the visible Monitor stream. The user should see a Monitor task.
+
 ## Substrate facts
 
 - Wire = GitHub gist per channel. `gh api` polls + appends.

--- a/skills/repair/SKILL.md
+++ b/skills/repair/SKILL.md
@@ -45,7 +45,7 @@ Wipes identity, peer records, saved pairing, messages. State is gone.
 
 Claude Code:
 ```
-Monitor(persistent=true, command="airc join $INVITE")
+Monitor(persistent=true, description="airc", command="airc join --attach $INVITE")
 ```
 
 Codex / non-Monitor runtimes:

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -14,7 +14,7 @@ Run this yourself — don't ask the user.
 
 Claude Code:
 ```
-Monitor(persistent=true, description="airc", command="airc join")
+Monitor(persistent=true, description="airc", command="airc join --attach")
 ```
 
 Codex / non-Monitor runtimes:

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -30,7 +30,7 @@ Captures `before` and `after` SHAs. Prints one of:
 
 3. **Re-arm a new Monitor with `airc join`**:
    ```
-   Monitor(persistent=true, description="airc", command="airc join")
+   Monitor(persistent=true, description="airc", command="airc join --attach")
    ```
    Same shape the `/join` skill uses. The new Monitor's airc binary loads from disk fresh — picks up the just-pulled code automatically.
 


### PR DESCRIPTION
## Summary
- make the join skill put the Claude Code `Monitor(... airc join --attach)` call at the top as a required first action
- explicitly forbid substituting `Bash(airc status ...)` / `Bash(airc inbox ...)` for `/join`
- update resume/update/canary/repair skill examples and invite guidance to use `airc join --attach`

## Validation
- `bash -n airc lib/airc_bash/cmd_connect.sh`
- `git diff --check`
- scanned all skill Monitor examples: all now use `airc join --attach`
- real shared continuum scope: `AIRC_HOME=/Users/joelteply/Development/cambrian/continuum/.airc ./airc join --attach` prints status/inbox and stays attached as local stream
