### PR TITLE
Add Codex turn-start airc polling

### DIFF
--- a/airc
+++ b/airc
@@ -2324,7 +2324,8 @@ case "${1:-help}" in
   channel) shift; cmd_channel "$@" ;;
   canary) shift; cmd_update --channel canary "$@" ;;
   logs)      shift; cmd_logs "$@" ;;
-  inbox|poll|codex-poll) shift; cmd_inbox "$@" ;;
+  inbox|poll) shift; cmd_inbox "$@" ;;
+  codex-poll) shift; AIRC_INBOX_QUIET_EMPTY=1 AIRC_INBOX_EXCLUDE_SELF=1 cmd_inbox --count 50 "$@" ;;
   status)    shift; cmd_status "$@" ;;
   doctor)            shift; cmd_doctor "$@" ;;
   tests|test)        shift; _doctor_run_tests "$@" ;;

--- a/install.sh
+++ b/install.sh
@@ -731,6 +731,60 @@ if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
   _install_airc_codex_permission_profile
 fi
 
+# ── Codex model-visible AIRC turn contract ─────────────────────────────
+# Codex currently has no Claude-style Monitor tool. A daemon can keep
+# the transport alive, but the model will not notice inbound peer
+# traffic unless it polls local state during a turn. Install a small
+# model-visible instruction so future Codex sessions surface AIRC
+# traffic reliably without hitting GitHub: `airc codex-poll` reads the
+# local messages.jsonl cursor, suppresses empty output, and excludes
+# this identity's own messages.
+#
+# We only write this if the user has no existing developer_instructions
+# key. If they do, do not overwrite; they can copy the block manually or
+# opt into a profile. This keeps install.sh from clobbering unrelated
+# Codex configuration.
+
+_install_airc_codex_developer_instructions() {
+  local config="$HOME/.codex/config.toml"
+  [ "${AIRC_SKIP_CODEX_INSTRUCTIONS:-0}" = "1" ] && return 0
+  [ -f "$config" ] || return 0
+
+  if grep -qF 'AIRC-CODEX-INSTRUCTIONS-START' "$config" 2>/dev/null; then
+    local _tmp; _tmp=$(mktemp)
+    sed '/^# AIRC-CODEX-INSTRUCTIONS-START/,/^# AIRC-CODEX-INSTRUCTIONS-END/d' "$config" > "$_tmp"
+    mv "$_tmp" "$config"
+  fi
+
+  if grep -qE '^[[:space:]]*developer_instructions[[:space:]]*=' "$config" 2>/dev/null; then
+    info "  ~/.codex/config.toml already has developer_instructions; skipping airc Codex turn contract"
+    return 0
+  fi
+
+  local _tmp; _tmp=$(mktemp)
+  {
+    cat <<'TOML'
+# AIRC-CODEX-INSTRUCTIONS-START — managed by install.sh; remove this section through AIRC-CODEX-INSTRUCTIONS-END to opt out
+developer_instructions = """
+AIRC Codex runtime contract:
+- At the beginning of every user turn, before substantive work, if `airc` is available on PATH, run `airc codex-poll`.
+- `airc codex-poll` is local-only: it reads this scope's local message cursor, prints only unread peer messages, advances the cursor, and is silent when empty.
+- If `airc codex-poll` prints messages, briefly surface them to the user and account for them before continuing. If it is silent or says the scope is not initialized, continue normally.
+- Do not claim AIRC collaboration is healthy from process health alone. Distinguish transport/process liveness from whether this Codex session has actually polled and seen peer traffic.
+"""
+# AIRC-CODEX-INSTRUCTIONS-END
+
+TOML
+    cat "$config"
+  } > "$_tmp"
+  mv "$_tmp" "$config"
+  ok "Added Codex AIRC turn contract to ~/.codex/config.toml — restart Codex to activate automatic local inbox polling"
+}
+
+if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
+  _install_airc_codex_developer_instructions
+fi
+
 # ── Codex GH_TOKEN env injection ───────────────────────────────────────
 # Codex's sandbox can't reliably reach the macOS Keychain to validate
 # gh's stored token. Result: gh auth status flakes between ✓ and X

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -483,6 +483,8 @@ cmd_inbox() {
   local since=""
   local count="500"
   local peek=0
+  local quiet_empty="${AIRC_INBOX_QUIET_EMPTY:-0}"
+  local exclude_self="${AIRC_INBOX_EXCLUDE_SELF:-0}"
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -498,6 +500,10 @@ cmd_inbox() {
         count="${1#--count=}"; shift ;;
       --peek)
         peek=1; shift ;;
+      --quiet-empty)
+        quiet_empty=1; shift ;;
+      --exclude-self)
+        exclude_self=1; shift ;;
       --reset)
         "$AIRC_PYTHON" -m airc_core.inbox reset \
           --home "$AIRC_WRITE_DIR" --cursor-file "$cursor_file"
@@ -506,7 +512,9 @@ cmd_inbox() {
         echo "Usage: airc inbox [--peek] [--reset] [--since <ts|Ns|Nm|Nh>] [--count N]"
         echo "  Shows unread messages since this scope's last inbox check."
         echo "  Advances a per-scope cursor unless --peek is set."
-        echo "  Alias: airc poll, airc codex-poll"
+        echo "  --quiet-empty suppresses the 'No new airc messages' line."
+        echo "  --exclude-self hides messages from this identity."
+        echo "  Alias: airc poll, airc codex-poll (quiet + exclude-self by default)"
         return 0 ;;
       *) die "Unknown inbox option: $1" ;;
     esac
@@ -525,6 +533,10 @@ cmd_inbox() {
   local inbox_args=(read --home "$AIRC_WRITE_DIR" --cursor-file "$cursor_file" --count "$count")
   [ -n "$since" ] && inbox_args+=(--since "$since")
   [ "$peek" -eq 1 ] && inbox_args+=(--peek)
+  [ "$quiet_empty" = "1" ] && inbox_args+=(--quiet-empty)
+  if [ "$exclude_self" = "1" ]; then
+    inbox_args+=(--exclude-self --my-name "$(get_name)")
+  fi
   if ! out=$("$AIRC_PYTHON" -m airc_core.inbox "${inbox_args[@]}" 2>&1); then
     printf '%s\n' "$out" >&2
     return 1

--- a/lib/airc_core/inbox.py
+++ b/lib/airc_core/inbox.py
@@ -119,6 +119,9 @@ def cmd_read(args: argparse.Namespace) -> int:
                 except Exception:
                     last_offset = next_offset
                     continue
+                if args.exclude_self and line.get("from") == args.my_name:
+                    last_offset = next_offset
+                    continue
                 if since_dt is not None:
                     dt = _msg_dt(line)
                     if dt is None or dt <= since_dt:
@@ -130,7 +133,7 @@ def cmd_read(args: argparse.Namespace) -> int:
     except OSError:
         pass
 
-    if printed == 0:
+    if printed == 0 and not args.quiet_empty:
         print(f"No new airc messages since {since_arg or 'last inbox check'}")
     elif not args.peek:
         _write_cursor(args.cursor_file, last_offset)
@@ -146,6 +149,9 @@ def main(argv: list[str] | None = None) -> int:
     read.add_argument("--since", default="")
     read.add_argument("--count", type=int, default=500)
     read.add_argument("--peek", action="store_true")
+    read.add_argument("--quiet-empty", action="store_true")
+    read.add_argument("--exclude-self", action="store_true")
+    read.add_argument("--my-name", default="")
     reset = sub.add_parser("reset")
     reset.add_argument("--home", required=True)
     reset.add_argument("--cursor-file", required=True)

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -77,7 +77,9 @@ scope=$(airc debug-scope); mkdir -p "$scope"; nohup airc join > "$scope/codex-ai
 airc msg "..."                     # broadcast
 airc msg @peer "..."               # DM
 ```
-Do NOT poll `airc logs N` without `--since` — that re-injects the full tail every turn. `airc join` handles unread catch-up when it returns.
+Codex has no Claude-style Monitor callback. Future Codex sessions installed by airc get a model-visible turn contract in `~/.codex/config.toml`: run `airc codex-poll` at the beginning of each user turn. That command is local-only, quiet when empty, excludes this identity's own messages, and advances the unread cursor. If it prints peer messages, surface them before continuing.
+
+Do NOT poll `airc logs N` without `--since` — that re-injects the full tail every turn. Use `airc codex-poll` for Codex turn-start catch-up; use `airc join` for initial setup and recovery.
 
 ## Idempotency
 

--- a/skills/logs/SKILL.md
+++ b/skills/logs/SKILL.md
@@ -27,7 +27,7 @@ Prints one line per message: `[ts] from: msg`. Reads this scope's local message 
 - Catching up after monitor downtime / teardown gap.
 - Confirming a message you sent actually landed on the wire.
 - Triaging "did I miss something?" when chat feels quiet.
-- Codex/non-Monitor runtimes: prefer `airc join` between work blocks; it prints status + unread catch-up when the scope is already active. Use `logs --since` for explicit one-off forensic queries.
+- Codex/non-Monitor runtimes: use `airc codex-poll` at turn start. It is local-only, quiet when empty, excludes self messages, and advances the unread cursor. Use `logs --since` for explicit one-off forensic queries.
 
 ## Notes
 

--- a/skills/msg/SKILL.md
+++ b/skills/msg/SKILL.md
@@ -41,6 +41,6 @@ On failure, read the stderr — it tells you which class:
 
 ## Notes
 
-- `airc join` must be running for inbound to arrive. Claude Code uses Monitor notifications; Codex/non-Monitor runtimes should keep airc alive via daemon/background join; `airc join` prints status and inbox when it returns.
+- `airc join` must be running for inbound to arrive. Claude Code uses Monitor notifications; Codex/non-Monitor runtimes should keep airc alive via daemon/background join and run `airc codex-poll` at turn start for unread peer messages.
 - Every paired agent tails the host's log, so a `to=all` broadcast lands for everyone.
 - A `to=@peer` DM is still written to the same shared log — the `to` field is just a human-readable label, not a routing directive. Nothing hides inside airc.

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -3232,7 +3232,7 @@ scenario_inbox() {
   local home="$root/state"
   rm -rf "$root"
   mkdir -p "$home"
-  echo '{}' > "$home/config.json"
+  echo '{"name":"inbox-test"}' > "$home/config.json"
   {
     printf '%s\n' '{"ts":"2026-05-04T10:00:00Z","from":"alpha","msg":"first unread"}'
     printf '%s\n' '{"ts":"2026-05-04T10:01:00Z","from":"beta","msg":"second unread"}'
@@ -3258,6 +3258,18 @@ scenario_inbox() {
   printf '%s' "$out" | grep -q 'No new airc messages' \
     && pass "inbox uses saved cursor on next check" \
     || fail "inbox did not respect saved cursor: $out"
+
+  out=$(AIRC_HOME="$home" "$AIRC" codex-poll 2>&1)
+  [ -z "$out" ] \
+    && pass "codex-poll is quiet when empty" \
+    || fail "codex-poll should be quiet when empty, got: $out"
+
+  printf '%s\n' '{"ts":"2099-05-04T10:01:30Z","from":"inbox-test","msg":"self-only"}' >> "$home/messages.jsonl"
+  printf '%s\n' '{"ts":"2099-05-04T10:01:31Z","from":"peer-test","msg":"peer-only"}' >> "$home/messages.jsonl"
+  out=$(AIRC_HOME="$home" "$AIRC" codex-poll 2>&1)
+  printf '%s' "$out" | grep -q 'peer-only' && ! printf '%s' "$out" | grep -q 'self-only' \
+    && pass "codex-poll excludes self and prints peer messages" \
+    || fail "codex-poll self-filter wrong: $out"
 
   printf '%s\n' '{"ts":"2099-05-04T10:02:00Z","from":"gamma","msg":"third unread"}' >> "$home/messages.jsonl"
   out=$(AIRC_HOME="$home" "$AIRC" poll 2>&1)


### PR DESCRIPTION
## Summary
- add `airc codex-poll` as a first-class Codex/non-Monitor unread surface
- make `codex-poll` local-only, quiet when empty, and self-filtering so it only surfaces unread peer messages
- install an AIRC-managed `developer_instructions` block in `~/.codex/config.toml` so future Codex sessions run `airc codex-poll` at the start of each user turn
- update skills/docs to distinguish transport liveness from Codex actually polling and seeing peer traffic

## Validation
- `bash -n airc install.sh lib/airc_bash/cmd_status.sh`
- `.venv/bin/python -m py_compile lib/airc_core/inbox.py`
- `git diff --check`
- `./airc doctor --tests inbox` → 7 passed, 0 failed
- real continuum scope: `airc codex-poll` surfaced `vhsm-d1f4` ACK and advanced cursor
- ran install path with `AIRC_INSTALL_NO_DAEMON=1 AIRC_INSTALL_YES=1 ./install.sh`; config updated idempotently
- `codex debug prompt-input` shows the model-visible AIRC Codex runtime contract
- real continuum status now reports collaboration ok from recent broadcast traffic

## Note
This does not create a true asynchronous push callback inside Codex; Codex does not expose a Claude-style Monitor surface. It makes the reliable runtime contract explicit and installed: every future Codex turn polls local AIRC state before work, without hitting GitHub or spamming empty output.
