### PR TITLE
Fix same-scope agent self filtering

### DIFF
--- a/airc
+++ b/airc
@@ -598,6 +598,10 @@ get_config_val()   { "$AIRC_PYTHON" -m airc_core.config get --config "$CONFIG" "
 set_config_val()   { "$AIRC_PYTHON" -m airc_core.config set --config "$CONFIG" --key "$1" --value "$2"; }
 unset_config_keys() { "$AIRC_PYTHON" -m airc_core.config unset_keys --config "$CONFIG" "$@"; }
 
+airc_client_id() {
+  "$AIRC_PYTHON" -m airc_core.client_id 2>/dev/null
+}
+
 # Same as get_config_val but reads from an arbitrary config.json path.
 # Used by _whois_in_scope (#134 cross-scope walk) and other places
 # that need to read sibling-scope state without changing $CONFIG.
@@ -1635,7 +1639,12 @@ monitor_formatter() {
   # while airc's own monitor_formatter (no -X utf8) drops events.
   # Same fix here closes the gap at the SOURCE rather than relying on
   # each operator to add their own tail-pipeline.
-  "$AIRC_PYTHON" -u -X utf8 -m airc_core.monitor_formatter --peers-dir "$PEERS_DIR" --my-name "$my_name"
+  local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
+  if [ -n "$_client_id" ]; then
+    AIRC_CLIENT_ID="$_client_id" "$AIRC_PYTHON" -u -X utf8 -m airc_core.monitor_formatter --peers-dir "$PEERS_DIR" --my-name "$my_name"
+  else
+    "$AIRC_PYTHON" -u -X utf8 -m airc_core.monitor_formatter --peers-dir "$PEERS_DIR" --my-name "$my_name"
+  fi
 }
 
 # Drain pending.jsonl when the host is reachable again. Runs in background

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -137,7 +137,12 @@ _join_attach_local_stream() {
   echo ""
   echo "  Attaching this terminal to the local AIRC stream."
   echo "  Background AIRC owns transport; this process only displays new peer messages."
-  exec "$AIRC_PYTHON" -u -m airc_core.log_tail --home "$AIRC_WRITE_DIR" --my-name "$(get_name)"
+  local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
+  if [ -n "$_client_id" ]; then
+    AIRC_CLIENT_ID="$_client_id" exec "$AIRC_PYTHON" -u -m airc_core.log_tail --home "$AIRC_WRITE_DIR" --my-name "$(get_name)"
+  else
+    exec "$AIRC_PYTHON" -u -m airc_core.log_tail --home "$AIRC_WRITE_DIR" --my-name "$(get_name)"
+  fi
 }
 
 _join_parent_chain_looks_like_claude_monitor() {

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -229,9 +229,14 @@ cmd_send() {
   local my_name ts_val
   my_name=$(get_name)
   ts_val=$(timestamp)
+  local client_id; client_id=$(airc_client_id 2>/dev/null || true)
 
   local escaped_msg
   escaped_msg=$(printf '%s' "$msg" | "$AIRC_PYTHON" -c "import sys,json; print(json.dumps(sys.stdin.read())[1:-1])")
+  local escaped_client_id=""
+  if [ -n "$client_id" ]; then
+    escaped_client_id=$(printf '%s' "$client_id" | "$AIRC_PYTHON" -c "import sys,json; print(json.dumps(sys.stdin.read())[1:-1])")
+  fi
 
   # Channel: stamp every outbound envelope with the active channel so the
   # monitor display can route by channel uniformly (Phase 2 mesh
@@ -253,9 +258,12 @@ cmd_send() {
   fi
   [ -z "$active_channel" ] && active_channel="general"
 
-  local payload="{\"from\":\"$my_name\",\"to\":\"$peer_name\",\"ts\":\"$ts_val\",\"channel\":\"$active_channel\",\"msg\":\"$escaped_msg\"}"
+  local payload="{\"from\":\"$my_name\",\"to\":\"$peer_name\",\"ts\":\"$ts_val\",\"channel\":\"$active_channel\",\"msg\":\"$escaped_msg\""
+  [ -n "$escaped_client_id" ] && payload="${payload},\"client_id\":\"$escaped_client_id\""
+  payload="${payload}}"
   local sig; sig=$(sign_message "$payload")
-  local full_msg="{\"from\":\"$my_name\",\"to\":\"$peer_name\",\"ts\":\"$ts_val\",\"channel\":\"$active_channel\",\"msg\":\"$escaped_msg\",\"sig\":\"$sig\"}"
+  local full_msg="${payload%}}"
+  full_msg="${full_msg},\"sig\":\"$sig\"}"
 
   local host_target
   host_target=$(get_config_val host_target "")

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -535,7 +535,8 @@ cmd_inbox() {
   [ "$peek" -eq 1 ] && inbox_args+=(--peek)
   [ "$quiet_empty" = "1" ] && inbox_args+=(--quiet-empty)
   if [ "$exclude_self" = "1" ]; then
-    inbox_args+=(--exclude-self --my-name "$(get_name)")
+    local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
+    inbox_args+=(--exclude-self --my-name "$(get_name)" --client-id "$_client_id")
   fi
   if ! out=$("$AIRC_PYTHON" -m airc_core.inbox "${inbox_args[@]}" 2>&1); then
     printf '%s\n' "$out" >&2

--- a/lib/airc_core/client_id.py
+++ b/lib/airc_core/client_id.py
@@ -1,0 +1,65 @@
+"""Runtime client identity helpers.
+
+An airc identity/nick belongs to a scope, not necessarily to one UI
+session. Multiple Claude or Codex tabs can share one `.airc` directory
+and one nick, so local self-filtering needs a per-agent runtime key.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def agent_process_client_id() -> str:
+    """Return a stable-ish id for the owning Claude/Codex process."""
+
+    pid = os.getpid()
+    for _ in range(16):
+        try:
+            out = subprocess.check_output(
+                ["ps", "-p", str(pid), "-o", "ppid=,command="],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        except Exception:
+            return ""
+        if not out:
+            return ""
+        parts = out.split(None, 1)
+        parent = parts[0] if parts else ""
+        cmd = parts[1] if len(parts) > 1 else ""
+        argv0 = cmd.split()[0] if cmd.split() else ""
+        base = os.path.basename(argv0)
+        if base in {"claude", "codex"} or "/codex/codex" in cmd:
+            return f"agent-pid:{pid}"
+        if not parent or parent == "1":
+            return ""
+        pid = int(parent)
+    return ""
+
+
+def current_client_id() -> str:
+    if os.environ.get("AIRC_CLIENT_ID"):
+        return os.environ["AIRC_CLIENT_ID"]
+    if os.environ.get("CODEX_THREAD_ID"):
+        return f"codex:{os.environ['CODEX_THREAD_ID']}"
+    if os.environ.get("CLAUDE_CODE_SESSION_ID"):
+        return f"claude:{os.environ['CLAUDE_CODE_SESSION_ID']}"
+    if os.environ.get("CLAUDE_SESSION_ID"):
+        return f"claude:{os.environ['CLAUDE_SESSION_ID']}"
+    return agent_process_client_id()
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv
+    client_id = current_client_id()
+    if not client_id:
+        return 1
+    print(client_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/lib/airc_core/inbox.py
+++ b/lib/airc_core/inbox.py
@@ -119,7 +119,7 @@ def cmd_read(args: argparse.Namespace) -> int:
                 except Exception:
                     last_offset = next_offset
                     continue
-                if args.exclude_self and line.get("from") == args.my_name:
+                if args.exclude_self and args.client_id and line.get("client_id") == args.client_id:
                     last_offset = next_offset
                     continue
                 if since_dt is not None:
@@ -152,6 +152,7 @@ def main(argv: list[str] | None = None) -> int:
     read.add_argument("--quiet-empty", action="store_true")
     read.add_argument("--exclude-self", action="store_true")
     read.add_argument("--my-name", default="")
+    read.add_argument("--client-id", default="")
     reset = sub.add_parser("reset")
     reset.add_argument("--home", required=True)
     reset.add_argument("--cursor-file", required=True)

--- a/lib/airc_core/log_tail.py
+++ b/lib/airc_core/log_tail.py
@@ -17,6 +17,8 @@ import secrets
 import sys
 import time
 
+from airc_core.client_id import current_client_id
+
 
 def _read_channels(config_path: str) -> set[str] | None:
     try:
@@ -43,6 +45,7 @@ def run(home: str, my_name: str) -> int:
     log_path = os.path.join(home, "messages.jsonl")
     config_path = os.path.join(home, "config.json")
     nonce = secrets.token_hex(4)
+    client_id = current_client_id()
     contract_printed = False
     inode = None
     f = _open_at_eof(log_path)
@@ -73,7 +76,7 @@ def run(home: str, my_name: str) -> int:
                 continue
 
             fr = str(msg.get("from") or "?")
-            if fr == my_name:
+            if client_id and msg.get("client_id") == client_id:
                 continue
             channel = str(msg.get("channel") or "").lstrip("#")
             subscribed = _read_channels(config_path)

--- a/lib/airc_core/monitor_formatter.py
+++ b/lib/airc_core/monitor_formatter.py
@@ -24,6 +24,8 @@ import signal
 import sys
 import time
 
+from airc_core.client_id import current_client_id
+
 # Inactivity watchdog: if no inbound line arrives in WATCHDOG_SEC,
 # exit with a distinct code so the caller's while-loop reconnects.
 # Why: the outer SSH tail can hang silently — middleboxes drop idle
@@ -308,6 +310,7 @@ def run(my_name: str, peers_dir: str) -> int:
     config_path = os.path.join(scope_dir, "config.json")
     local_log = os.path.join(scope_dir, "messages.jsonl")
     offset_path = os.path.join(scope_dir, "monitor_offset")
+    client_id = current_client_id()
 
     # Host vs joiner detection drives the watchdog gate below. host_target
     # empty = we are the host (we publish the room gist; joiners poll us);
@@ -454,9 +457,12 @@ def run(my_name: str, peers_dir: str) -> int:
             # readable content even though the wire was ciphertext.
             line = json.dumps(m)
         msg = m.get("msg", "")
-        # Filter own sends early, including our own [rename] markers. Read
-        # the name fresh so a mid-session rename takes effect immediately.
-        if fr == current_name():
+        # Filter only this runtime's own sends. Multiple agents can share
+        # one .airc scope and therefore one nick; filtering by `from`
+        # hides same-scope collaborators. New sends may carry client_id
+        # from CODEX_THREAD_ID / CLAUDE_* / AIRC_CLIENT_ID; old messages
+        # without client_id are displayed rather than silently dropped.
+        if client_id and m.get("client_id") == client_id:
             continue
         # Mirror inbound to local messages.jsonl. Post-3c (gh substrate)
         # the gist is the canonical source of truth for ALL peers — the

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -3264,11 +3264,16 @@ scenario_inbox() {
     && pass "codex-poll is quiet when empty" \
     || fail "codex-poll should be quiet when empty, got: $out"
 
-  printf '%s\n' '{"ts":"2099-05-04T10:01:30Z","from":"inbox-test","msg":"self-only"}' >> "$home/messages.jsonl"
-  printf '%s\n' '{"ts":"2099-05-04T10:01:31Z","from":"peer-test","msg":"peer-only"}' >> "$home/messages.jsonl"
-  out=$(AIRC_HOME="$home" "$AIRC" codex-poll 2>&1)
-  printf '%s' "$out" | grep -q 'peer-only' && ! printf '%s' "$out" | grep -q 'self-only' \
-    && pass "codex-poll excludes self and prints peer messages" \
+  printf '%s\n' '{"ts":"2099-05-04T10:01:30Z","from":"inbox-test","client_id":"test-client","msg":"self-only"}' >> "$home/messages.jsonl"
+  printf '%s\n' '{"ts":"2099-05-04T10:01:31Z","from":"inbox-test","client_id":"other-client","msg":"same-nick-peer"}' >> "$home/messages.jsonl"
+  printf '%s\n' '{"ts":"2099-05-04T10:01:32Z","from":"inbox-test","msg":"legacy-same-name-visible"}' >> "$home/messages.jsonl"
+  printf '%s\n' '{"ts":"2099-05-04T10:01:33Z","from":"peer-test","client_id":"peer-client","msg":"peer-only"}' >> "$home/messages.jsonl"
+  out=$(AIRC_CLIENT_ID=test-client AIRC_HOME="$home" "$AIRC" codex-poll 2>&1)
+  printf '%s' "$out" | grep -q 'peer-only' \
+    && printf '%s' "$out" | grep -q 'same-nick-peer' \
+    && printf '%s' "$out" | grep -q 'legacy-same-name-visible' \
+    && ! printf '%s' "$out" | grep -q 'self-only' \
+    && pass "codex-poll excludes same-client self and prints same-nick peers" \
     || fail "codex-poll self-filter wrong: $out"
 
   printf '%s\n' '{"ts":"2099-05-04T10:02:00Z","from":"gamma","msg":"third unread"}' >> "$home/messages.jsonl"


### PR DESCRIPTION
## Summary
- stamp outbound messages with a per-client id derived from AIRC_CLIENT_ID, agent session env, or the owning Claude/Codex process
- filter self messages by client_id instead of shared airc nick in codex-poll, log_tail, and monitor_formatter
- add inbox coverage proving same-nick peers are visible while same-client self messages are hidden

## Validation
- bash -n airc lib/airc_bash/cmd_send.sh lib/airc_bash/cmd_status.sh
- .venv/bin/python -m py_compile lib/airc_core/client_id.py lib/airc_core/monitor_formatter.py lib/airc_core/log_tail.py lib/airc_core/inbox.py
- ./airc doctor --tests inbox
- synthetic log_tail test: same-nick/client-b visible, client-a hidden
- synthetic monitor_formatter test: same-nick/client-b visible, client-a hidden

## Notes
This addresses the shared-scope case Joel hit: multiple Claude/Codex tabs in the same repo all share one .airc identity/nick, so name-based self filtering hides real collaborators. The self key needs to be the runtime client, not the scope identity.