### PR TITLE
Use humanhash for agent client labels

### DIFF
--- a/airc
+++ b/airc
@@ -986,31 +986,7 @@ _have_tailscale_locally() {
 humanhash() {
   local input="${1:-}"
   [ -z "$input" ] && return 1
-  local n_words=4
-  local dict=(ack alabama alanine alaska alpha angel apart april arizona arkansas artist asparagus aspen august autumn avocado bacon bakerloo batman beer berlin beryllium black blossom blue bluebird bravo bulldog burger butter california carbon cardinal carolina carpet cat ceiling cello center charlie chicken coffee cola cold colorado comet connecticut crazy cup dakota december delaware delta diet don double early earth east echo edward eight eighteen eleven emma enemy equal failed fanta fillet finch fish five fix floor florida football four fourteen foxtrot freddie friend fruit gee georgia glucose golf green grey hamper happy harry hawaii helium high hot hotel hydrogen idaho illinois india indigo ink iowa island item jersey jig johnny juliet july jupiter kansas kentucky kilo king kitten lactose lake lamp lemon leopard lima lion lithium london louisiana low magazine magnesium maine mango march mars maryland massachusetts may mexico michigan mike minnesota mirror missouri mobile mockingbird monkey montana moon mountain muppet music nebraska neptune network nevada nine nineteen nitrogen north november nuts october ohio oklahoma one orange oranges oregon oscar oven oxygen papa paris pasta pennsylvania pip pizza pluto potato princess purple quebec queen quiet red river robert robin romeo rugby sad salami saturn september seven seventeen shade sierra single sink six sixteen skylark snake social sodium solar south spaghetti speaker spring stairway steak stream summer sweet table tango ten tennessee tennis texas thirteen three timing triple twelve twenty two uncle undress uniform uranus utah vegan venus vermont victor video violet virginia washington west whiskey white william winner winter wisconsin wolfram wyoming xray yankee yellow zebra zulu)
-  # Hex → byte values
-  local bytes=()
-  local i
-  for ((i=0; i<${#input}; i+=2)); do
-    bytes+=( $((16#${input:$i:2})) )
-  done
-  local n_bytes=${#bytes[@]}
-  local seg_size=$(( n_bytes / n_words ))
-  [ "$seg_size" -lt 1 ] && seg_size=1
-  local words=()
-  local seg start end acc j
-  for ((seg=0; seg<n_words; seg++)); do
-    acc=0
-    start=$(( seg * seg_size ))
-    end=$(( start + seg_size ))
-    [ "$seg" -eq $((n_words-1)) ] && end=$n_bytes  # last segment absorbs leftovers
-    for ((j=start; j<end; j++)); do
-      acc=$(( acc ^ bytes[j] ))
-    done
-    words+=( "${dict[$acc]}" )
-  done
-  local IFS=-
-  echo "${words[*]}"
+  "$AIRC_PYTHON" -m airc_core.humanhash "$input"
 }
 
 sign_message() {

--- a/lib/airc_core/client_id.py
+++ b/lib/airc_core/client_id.py
@@ -8,8 +8,11 @@ and one nick, so local self-filtering needs a per-agent runtime key.
 from __future__ import annotations
 
 import os
+import hashlib
 import subprocess
 import sys
+
+from airc_core.humanhash import humanhash
 
 
 def agent_process_client_id() -> str:
@@ -33,7 +36,8 @@ def agent_process_client_id() -> str:
         argv0 = cmd.split()[0] if cmd.split() else ""
         base = os.path.basename(argv0)
         if base in {"claude", "codex"} or "/codex/codex" in cmd:
-            return f"agent-pid:{pid}"
+            digest = hashlib.sha256(f"{pid}:{cmd}".encode("utf-8")).hexdigest()
+            return f"agent:{humanhash(digest, 4)}"
         if not parent or parent == "1":
             return ""
         pid = int(parent)

--- a/lib/airc_core/humanhash.py
+++ b/lib/airc_core/humanhash.py
@@ -1,0 +1,48 @@
+"""Human-readable hash mnemonics used by airc invites and agent labels."""
+
+from __future__ import annotations
+
+import argparse
+
+DICT = (
+    "ack alabama alanine alaska alpha angel apart april arizona arkansas artist asparagus aspen august autumn avocado bacon bakerloo batman beer berlin beryllium black blossom blue bluebird bravo bulldog burger butter california carbon cardinal carolina carpet cat ceiling cello center charlie chicken coffee cola cold colorado comet connecticut crazy cup dakota december delaware delta diet don double early earth east echo edward eight eighteen eleven emma enemy equal failed fanta fillet finch fish five fix floor florida football four fourteen foxtrot freddie friend fruit gee georgia glucose golf green grey hamper happy harry hawaii helium high hot hotel hydrogen idaho illinois india indigo ink iowa island item jersey jig johnny juliet july jupiter kansas kentucky kilo king kitten lactose lake lamp lemon leopard lima lion lithium london louisiana low magazine magnesium maine mango march mars maryland massachusetts may mexico michigan mike minnesota mirror missouri mobile mockingbird monkey montana moon mountain muppet music nebraska neptune network nevada nine nineteen nitrogen north november nuts october ohio oklahoma one orange oranges oregon oscar oven oxygen papa paris pasta pennsylvania pip pizza pluto potato princess purple quebec queen quiet red river robert robin romeo rugby sad salami saturn september seven seventeen shade sierra single sink six sixteen skylark snake social sodium solar south spaghetti speaker spring stairway steak stream summer sweet table tango ten tennessee tennis texas thirteen three timing triple twelve twenty two uncle undress uniform uranus utah vegan venus vermont victor video violet virginia washington west whiskey white william winner winter wisconsin wolfram wyoming xray yankee yellow zebra zulu"
+).split()
+
+
+def humanhash(hex_input: str, n_words: int = 4) -> str:
+    if not hex_input:
+        raise ValueError("empty input")
+    if n_words < 1:
+        raise ValueError("n_words must be >= 1")
+    if len(hex_input) % 2:
+        hex_input = f"0{hex_input}"
+    try:
+        data = bytes.fromhex(hex_input)
+    except ValueError as exc:
+        raise ValueError("input must be hex") from exc
+    if not data:
+        raise ValueError("empty input")
+
+    seg_size = max(len(data) // n_words, 1)
+    words: list[str] = []
+    for seg in range(n_words):
+        start = seg * seg_size
+        end = len(data) if seg == n_words - 1 else start + seg_size
+        acc = 0
+        for value in data[start:end]:
+            acc ^= value
+        words.append(DICT[acc])
+    return "-".join(words)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="airc_core.humanhash")
+    parser.add_argument("hex_input")
+    parser.add_argument("--words", type=int, default=4)
+    args = parser.parse_args(argv)
+    print(humanhash(args.hex_input, args.words))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_humanhash_client_id.py
+++ b/test/test_humanhash_client_id.py
@@ -1,0 +1,55 @@
+"""Mnemonic and runtime client id tests."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(ROOT, "lib"))
+
+from airc_core.humanhash import humanhash  # noqa: E402
+from airc_core import client_id  # noqa: E402
+
+
+class HumanhashTests(unittest.TestCase):
+    def test_known_mnemonic(self) -> None:
+        self.assertEqual(
+            humanhash("d7e247c0000000000000000000000000"),
+            "potato-ack-ack-ack",
+        )
+
+    def test_odd_hex_is_accepted(self) -> None:
+        self.assertEqual(humanhash("abc", 2), humanhash("0abc", 2))
+
+
+class ClientIdTests(unittest.TestCase):
+    def test_explicit_env_wins(self) -> None:
+        with mock.patch.dict(os.environ, {"AIRC_CLIENT_ID": "explicit"}, clear=True):
+            self.assertEqual(client_id.current_client_id(), "explicit")
+
+    def test_agent_process_uses_humanhash_label_not_raw_pid(self) -> None:
+        responses = {
+            100: "200 python -m airc_core.client_id",
+            200: "300 /bin/bash /path/to/airc msg hi",
+            300: "1 /Users/example/.local/bin/claude --resume",
+        }
+
+        def fake_check_output(argv: list[str], **_: object) -> str:
+            return responses[int(argv[2])]
+
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch("os.getpid", return_value=100),
+            mock.patch("subprocess.check_output", side_effect=fake_check_output),
+        ):
+            value = client_id.current_client_id()
+
+        self.assertRegex(value, r"^agent:[a-z]+-[a-z]+-[a-z]+-[a-z]+$")
+        self.assertNotIn("300", value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- move the invite/share mnemonic generator into `airc_core.humanhash` as the source of truth
- make shell `humanhash()` delegate to the Python module instead of carrying its own dictionary/algorithm
- make process-derived agent client ids use `agent:<humanhash>` labels instead of raw `agent-pid:<pid>`
- add unit coverage for humanhash + process-derived client labels

## Rationale
Same-scope agent tabs need distinct client labels, but raw process ids are not the right product surface. This uses the same shortword mechanism as share/invite mnemonics and keeps platform/process eccentricity inside the Python adapter.

## Validation
- bash -n airc lib/airc_bash/cmd_connect.sh lib/airc_bash/cmd_send.sh lib/airc_bash/cmd_status.sh
- .venv/bin/python -m py_compile lib/airc_core/humanhash.py lib/airc_core/client_id.py test/test_humanhash_client_id.py
- PYTHONPATH=lib .venv/bin/python test/test_humanhash_client_id.py
- ./airc doctor --tests python_units
- ./airc doctor --tests inbox
- git diff --check