### PR TITLE
Make join skill use no-arg join

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -313,14 +313,11 @@ cmd_connect() {
   done
   set -- "${positional[@]+"${positional[@]}"}"
 
-  # Defense against cached older Claude skills: some running sessions
-  # still invoke plain `airc join` inside a Monitor even after the
-  # on-disk skill was updated to `airc join --attach`. In daemon-repair
-  # paths plain join returns after bootstrapping the daemon, which makes
-  # the visible Monitor task end. If the parent chain is Claude Code,
-  # treat the invocation as UI attach mode. Codex/non-Monitor runtimes
-  # keep the documented quick-return behavior unless they explicitly set
-  # AIRC_ATTACH=1.
+  # Plain `airc join` is the public UX. If the parent chain is Claude
+  # Code, treat it as UI attach mode so a Monitor invocation remains a
+  # visible event stream when transport is already alive. Codex/non-
+  # Monitor runtimes keep the quick-return behavior unless they
+  # explicitly set AIRC_ATTACH=1.
   if [ "$attach" = "0" ]; then
     if [ "${AIRC_ATTACH:-0}" = "1" ] || _join_parent_chain_looks_like_claude_monitor; then
       attach=1
@@ -606,7 +603,7 @@ cmd_connect() {
       echo ""
       echo "   Right launchers:"
       echo "     • Claude Code skill:   /airc:join <invite>"
-      echo "     • Monitor tool:        Monitor(persistent=true, description=\"airc\", command=\"airc join --attach <invite>\")"
+      echo "     • Monitor tool:        Monitor(persistent=true, description=\"airc\", command=\"airc join <invite>\")"
       echo "     • Interactive shell:   just type \`airc join <invite>\` at a TTY"
       echo ""
       echo "   Bypass for legitimate background use (systemd + log tail,"

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -57,7 +57,7 @@ Then if they had a paired session you should restart the current scope for them.
 
 Claude Code:
 ```
-Monitor(persistent=true, description="airc", command="airc join --attach")
+Monitor(persistent=true, description="airc", command="airc join")
 ```
 
 Codex / non-Monitor runtimes:

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -14,10 +14,10 @@ Audience: Claude Code, Codex, future agent runtimes. Optimized for parse-and-act
 
 If you are Claude Code and this skill was invoked by `/join` or `/airc:join`, your first tool call MUST be:
 ```
-Monitor(persistent=true, description="airc", command="airc join --attach")
+Monitor(persistent=true, description="airc", command="airc join")
 ```
 
-Do not replace that with `Bash(airc status ...)` or `Bash(airc inbox ...)`. `airc join --attach` already prints status + inbox when a transport process is alive, then stays attached as the visible Monitor stream. The user should see a Monitor task.
+Do not replace that with `Bash(airc status ...)` or `Bash(airc inbox ...)`. Plain `airc join` auto-detects Claude Monitor and attaches when a transport process is alive; it also prints status + inbox. The user should see a Monitor task.
 
 ## Substrate facts
 
@@ -65,9 +65,9 @@ Don't default-stamp project chatter onto the lobby. It drowns out cross-room sig
 
 **Claude Code:** wrap in Monitor for streaming events:
 ```
-Monitor(persistent=true, description="airc", command="airc join --attach")
+Monitor(persistent=true, description="airc", command="airc join")
 ```
-Keep `description="airc"` — the headline shown in the UI is built from it. `--attach` creates a real Claude Monitor stream when a background/daemon AIRC process already owns transport for the scope.
+Keep `description="airc"` — the headline shown in the UI is built from it. Plain `airc join` creates a real Claude Monitor stream when a background/daemon AIRC process already owns transport for the scope.
 
 **Codex / non-Monitor runtimes:** do not foreground `airc join` in the tool call unless you expect it to return quickly. It is a long-running process when this scope is not already active. Start it through the daemon or as a background process; when `airc join` does return, it prints status and inbox itself:
 ```

--- a/skills/repair/SKILL.md
+++ b/skills/repair/SKILL.md
@@ -45,7 +45,7 @@ Wipes identity, peer records, saved pairing, messages. State is gone.
 
 Claude Code:
 ```
-Monitor(persistent=true, description="airc", command="airc join --attach $INVITE")
+Monitor(persistent=true, description="airc", command="airc join $INVITE")
 ```
 
 Codex / non-Monitor runtimes:

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -14,7 +14,7 @@ Run this yourself — don't ask the user.
 
 Claude Code:
 ```
-Monitor(persistent=true, description="airc", command="airc join --attach")
+Monitor(persistent=true, description="airc", command="airc join")
 ```
 
 Codex / non-Monitor runtimes:

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -30,7 +30,7 @@ Captures `before` and `after` SHAs. Prints one of:
 
 3. **Re-arm a new Monitor with `airc join`**:
    ```
-   Monitor(persistent=true, description="airc", command="airc join --attach")
+   Monitor(persistent=true, description="airc", command="airc join")
    ```
    Same shape the `/join` skill uses. The new Monitor's airc binary loads from disk fresh — picks up the just-pulled code automatically.
 


### PR DESCRIPTION
## Summary
- update Claude-facing join/resume/update/canary/repair skill instructions to use plain `airc join`
- keep `--attach` as an internal compatibility flag only
- update cmd_connect comments/help text so the public Monitor form is `airc join`

## Rationale
The common case should be foolproof: `/join` means make this tab usable. Runtime-specific attach behavior belongs inside `airc join`, which already detects Claude Monitor parent chains and attaches automatically.

## Validation
- bash -n airc lib/airc_bash/cmd_connect.sh
- rg confirms no user-facing skill text mentions `join --attach`; only the hidden parser branch remains
- git diff --check