### PR TITLE
Fix client-id send JSON and emit join events

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -138,6 +138,9 @@ _join_attach_local_stream() {
   echo "  Attaching this terminal to the local AIRC stream."
   echo "  Background AIRC owns transport; this process only displays new peer messages."
   local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
+  local _join_event_args=(join --home "$AIRC_WRITE_DIR" --name "$(get_name)")
+  [ -n "$_client_id" ] && _join_event_args+=(--client-id "$_client_id")
+  "$AIRC_PYTHON" -m airc_core.system_event "${_join_event_args[@]}" >/dev/null 2>&1 || true
   if [ -n "$_client_id" ]; then
     AIRC_CLIENT_ID="$_client_id" exec "$AIRC_PYTHON" -u -m airc_core.log_tail --home "$AIRC_WRITE_DIR" --my-name "$(get_name)"
   else

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -262,7 +262,7 @@ cmd_send() {
   [ -n "$escaped_client_id" ] && payload="${payload},\"client_id\":\"$escaped_client_id\""
   payload="${payload}}"
   local sig; sig=$(sign_message "$payload")
-  local full_msg="${payload%}}"
+  local full_msg="${payload%?}"
   full_msg="${full_msg},\"sig\":\"$sig\"}"
 
   local host_target

--- a/lib/airc_core/system_event.py
+++ b/lib/airc_core/system_event.py
@@ -1,0 +1,62 @@
+"""Append local airc system events to messages.jsonl."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _channels(config_path: str) -> list[str]:
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            channels = json.load(f).get("subscribed_channels")
+        if isinstance(channels, list):
+            cleaned = [str(ch).lstrip("#") for ch in channels if str(ch).strip()]
+            if cleaned:
+                return cleaned
+    except Exception:
+        pass
+    return ["general"]
+
+
+def append_join(home: str, name: str, client_id: str = "") -> int:
+    channels = _channels(os.path.join(home, "config.json"))
+    os.makedirs(home, exist_ok=True)
+    log_path = os.path.join(home, "messages.jsonl")
+    with open(log_path, "a", encoding="utf-8") as f:
+        for channel in channels:
+            event = {
+                "ts": _timestamp(),
+                "from": "airc",
+                "to": "all",
+                "channel": channel,
+                "msg": f"{name} joined #{channel}",
+            }
+            if client_id:
+                event["client_id"] = client_id
+            f.write(json.dumps(event, separators=(",", ":")) + "\n")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="airc_core.system_event")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    join = sub.add_parser("join")
+    join.add_argument("--home", required=True)
+    join.add_argument("--name", required=True)
+    join.add_argument("--client-id", default="")
+    args = parser.parse_args(argv)
+
+    if args.cmd == "join":
+        return append_join(args.home, args.name, args.client_id)
+    raise AssertionError(args.cmd)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2027,6 +2027,18 @@ PY
   grep -q 'live monitor probe ascii' "$home/messages.jsonl" \
     && pass "live-pid scope: message appended to local log as expected" \
     || fail "live-pid scope: message NOT in log despite rc=0 (log=$(cat "$home/messages.jsonl" 2>/dev/null))"
+  python3 - <<PY
+import json, sys
+for line in open("$home/messages.jsonl"):
+    obj = json.loads(line)
+    if obj.get("msg") == "live monitor probe ascii":
+        if obj.get("client_id") and obj.get("sig"):
+            sys.exit(0)
+sys.exit(1)
+PY
+  [ "$?" = "0" ] \
+    && pass "client_id send line is valid JSON with sig" \
+    || fail "client_id send line is malformed JSON or missing fields: $(tail -1 "$home/messages.jsonl" 2>/dev/null)"
   kill "$fake_airc_pid" 2>/dev/null || true
 
   rm -f "$out" "$err"

--- a/test/test_system_event.py
+++ b/test/test_system_event.py
@@ -1,0 +1,42 @@
+"""System event tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(ROOT, "lib"))
+
+from airc_core import system_event  # noqa: E402
+
+
+class JoinEventTests(unittest.TestCase):
+    def test_join_event_for_each_subscribed_channel(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / "config.json").write_text(
+                json.dumps({"subscribed_channels": ["cambriantech", "general"]}),
+                encoding="utf-8",
+            )
+
+            system_event.append_join(str(home), "airc-8a5e", "agent:test")
+
+            lines = [
+                json.loads(line)
+                for line in (home / "messages.jsonl").read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual([line["channel"] for line in lines], ["cambriantech", "general"])
+            self.assertEqual(lines[0]["from"], "airc")
+            self.assertEqual(lines[0]["to"], "all")
+            self.assertEqual(lines[0]["client_id"], "agent:test")
+            self.assertEqual(lines[0]["msg"], "airc-8a5e joined #cambriantech")
+            self.assertEqual(lines[1]["msg"], "airc-8a5e joined #general")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix malformed outbound JSON when `client_id` is present (`payload%?` instead of the broken suffix trim)
- add a regression that parses the actual `messages.jsonl` line and requires `client_id` + `sig`
- add `airc_core.system_event` and emit IRC-style local join events when a Claude Monitor attaches

## Live validation
- Before fix: Codex messages with `client_id` wrote invalid JSON like `..."client_id":"..."}},"sig":"..."`, so same-scope Claude `log_tail` skipped them.
- After fix: sent `fixed-json-same-scope-1777944333`; Claude continuum tab ACKed without Joel relay: `agent:uranus-lithium-uncle-five` / Monitor `bay3frhkb` saw it.

## Validation
- bash -n airc lib/airc_bash/cmd_send.sh lib/airc_bash/cmd_connect.sh test/integration.sh
- .venv/bin/python -m py_compile lib/airc_core/system_event.py test/test_system_event.py
- PYTHONPATH=lib .venv/bin/python test/test_system_event.py
- ./airc doctor --tests send_dead_monitor_dies
- ./airc doctor --tests python_units
- git diff --check