### PR TITLE
Install Codex UserPromptSubmit hook for AIRC inbox

### DIFF
--- a/airc
+++ b/airc
@@ -2311,6 +2311,7 @@ case "${1:-help}" in
   logs)      shift; cmd_logs "$@" ;;
   inbox|poll) shift; cmd_inbox "$@" ;;
   codex-poll) shift; AIRC_INBOX_QUIET_EMPTY=1 AIRC_INBOX_EXCLUDE_SELF=1 cmd_inbox --count 50 "$@" ;;
+  codex-hook) shift; cmd_codex_hook "$@" ;;
   status)    shift; cmd_status "$@" ;;
   doctor)            shift; cmd_doctor "$@" ;;
   tests|test)        shift; _doctor_run_tests "$@" ;;

--- a/install.sh
+++ b/install.sh
@@ -785,6 +785,46 @@ if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
   _install_airc_codex_developer_instructions
 fi
 
+# ── Codex lifecycle hook for local AIRC inbox injection ────────────────
+# Newer Codex CLI builds can run deterministic hooks at turn boundaries.
+# Install a UserPromptSubmit hook so unread airc messages become
+# developer context before each user prompt reaches the model. This is
+# the closest Codex equivalent to Claude Code's Monitor notifications:
+# no GitHub calls, no log-tail polling in the model, and no dependence
+# on the agent remembering the turn contract.
+
+_install_airc_codex_hooks() {
+  [ "${AIRC_SKIP_CODEX_HOOKS:-0}" = "1" ] && return 0
+  [ -f "$HOME/.codex/config.toml" ] || return 0
+
+  local _python="${_airc_venv_python_bin:-}"
+  if [ -z "$_python" ]; then
+    if command -v python3 >/dev/null 2>&1; then
+      _python=python3
+    elif command -v python >/dev/null 2>&1; then
+      _python=python
+    else
+      warn "Could not install Codex AIRC hook: python not found"
+      return 0
+    fi
+  fi
+
+  local out
+  if out=$(PYTHONPATH="$CLONE_DIR/lib${PYTHONPATH:+:$PYTHONPATH}" "$_python" -m airc_core.codex_install --codex-home "$HOME/.codex" install-hooks 2>&1); then
+    if [ -n "$out" ]; then
+      printf '%s\n' "$out" | while IFS= read -r line; do
+        ok "Codex AIRC hook: $line"
+      done
+    fi
+  else
+    warn "Could not install Codex AIRC hook: $out"
+  fi
+}
+
+if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
+  _install_airc_codex_hooks
+fi
+
 # ── Codex GH_TOKEN env injection ───────────────────────────────────────
 # Codex's sandbox can't reliably reach the macOS Keychain to validate
 # gh's stored token. Result: gh auth status flakes between ✓ and X

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -111,7 +111,7 @@ airc inbox                         # unread activity, cursor tracked
 airc status                        # liveness snapshot
 ```
 
-Codex does not have Claude Code's Monitor tool. Keep the AIRC process alive with the daemon or a background join, then check the stateful inbox:
+Codex does not have Claude Code's Monitor tool. AIRC installs a Codex `UserPromptSubmit` hook in `~/.codex/hooks.json` and enables `codex_hooks` in `~/.codex/config.toml` when Codex is present. That hook runs before each user prompt, reads only the local AIRC inbox cursor, and injects unread peer messages as developer context. Keep the AIRC process alive with the daemon or a background join:
 
 ```bash
 airc daemon install                # preferred persistent process
@@ -119,13 +119,14 @@ airc daemon install                # preferred persistent process
 scope=$(airc debug-scope); mkdir -p "$scope"; nohup airc join > "$scope/codex-airc.log" 2>&1 &
 airc inbox                         # unread since last inbox check
 airc inbox --peek                  # read without advancing the cursor
+airc codex-poll                    # manual Codex catch-up; quiet when empty
 ```
 
-Have Codex re-run `airc inbox` between actions. It stores a per-scope cursor on disk, so future checks only show unread messages. Use `airc logs --since <last-seen-ts|Ns|Nm|Nh>` for explicit one-off history queries. Avoid repeatedly reading `airc logs 5`; that re-injects old messages every turn.
+The hook and `airc codex-poll` share the same per-scope cursor, so future checks only show unread messages. Use `airc logs --since <last-seen-ts|Ns|Nm|Nh>` for explicit one-off history queries. Avoid repeatedly reading `airc logs 5`; that re-injects old messages every turn.
 
 ## Caveats and known gaps
 
-- **No push notifications inside Codex yet.** Codex can send, join, update, and poll reliably, but inbound events are not UI interrupts. Use `airc inbox` as the repeatable satellite check-in; it wraps incremental logs with a cursor so Codex does not have to remember timestamps manually.
+- **Codex hook support is turn-boundary, not a live UI interrupt.** Codex receives unread AIRC context before the next user prompt. During long-running work, use `airc codex-poll` as a manual catch-up if needed.
 - **DM E2EE silently degrades to plaintext when peers aren't paired** (#358). Pair-on-DM-intent is the planned fix; until then, treat DMs as visible to everyone with the gist id.
 - **Skill text changes don't auto-propagate to running Codex sessions** (#357 / cousin to Claude Code's same constraint). Restart the Codex session to pick up new skill text.
 

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -546,3 +546,27 @@ cmd_inbox() {
   _airc_monitor_health_report degraded-only
   printf '%s\n' "$out"
 }
+
+cmd_codex_hook() {
+  ensure_init
+
+  local sub="${1:-}"
+  shift || true
+  case "$sub" in
+    user-prompt-submit)
+      local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
+      "$AIRC_PYTHON" -m airc_core.codex_hook user-prompt-submit \
+        --home "$AIRC_WRITE_DIR" \
+        --cursor-file "$AIRC_WRITE_DIR/inbox_cursor" \
+        --my-name "$(get_name)" \
+        --client-id "$_client_id" \
+        "$@"
+      ;;
+    -h|--help|'')
+      echo "Usage: airc codex-hook user-prompt-submit"
+      echo "  Codex lifecycle hook adapter. Emits UserPromptSubmit JSON context for unread local airc messages."
+      ;;
+    *)
+      die "Unknown codex-hook command: $sub" ;;
+  esac
+}

--- a/lib/airc_core/codex_hook.py
+++ b/lib/airc_core/codex_hook.py
@@ -1,0 +1,87 @@
+"""Codex lifecycle hook adapter for airc.
+
+Codex hooks run outside the model turn and can inject extra developer
+context. This adapter converts the local airc inbox cursor into the
+UserPromptSubmit JSON shape Codex documents, without touching GitHub.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import sys
+from contextlib import redirect_stdout
+
+from airc_core import inbox
+
+
+def _read_stdin_json() -> dict:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _poll_context(args: argparse.Namespace) -> str:
+    out = io.StringIO()
+    argv = [
+        "read",
+        "--home",
+        args.home,
+        "--cursor-file",
+        args.cursor_file,
+        "--count",
+        str(args.count),
+        "--quiet-empty",
+        "--exclude-self",
+        "--my-name",
+        args.my_name,
+        "--client-id",
+        args.client_id,
+    ]
+    with redirect_stdout(out):
+        inbox.main(argv)
+    return out.getvalue().strip()
+
+
+def cmd_user_prompt_submit(args: argparse.Namespace) -> int:
+    _read_stdin_json()
+    context = _poll_context(args)
+    if not context:
+        return 0
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": (
+                "Unread AIRC messages received before this user turn. "
+                "Account for them before continuing:\n\n"
+                f"{context}"
+            ),
+        }
+    }
+    print(json.dumps(payload, separators=(",", ":")))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="airc_core.codex_hook")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    user_prompt = sub.add_parser("user-prompt-submit")
+    user_prompt.add_argument("--home", required=True)
+    user_prompt.add_argument("--cursor-file", required=True)
+    user_prompt.add_argument("--my-name", default="")
+    user_prompt.add_argument("--client-id", default="")
+    user_prompt.add_argument("--count", type=int, default=50)
+    args = parser.parse_args(argv)
+    if args.cmd == "user-prompt-submit":
+        return cmd_user_prompt_submit(args)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/airc_core/codex_install.py
+++ b/lib/airc_core/codex_install.py
@@ -1,0 +1,226 @@
+"""Codex config installer helpers for airc.
+
+Shell scripts call this module instead of embedding config-editing Python.
+It preserves user hooks and only manages the airc-owned hook entry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+AIRC_HOOK_COMMAND = "airc codex-hook user-prompt-submit"
+AIRC_HOOK_STATUS = "Checking AIRC inbox"
+AIRC_INSTRUCTIONS_START = "# AIRC-CODEX-INSTRUCTIONS-START"
+AIRC_INSTRUCTIONS_END = "# AIRC-CODEX-INSTRUCTIONS-END"
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _set_codex_hooks_feature(config: Path) -> bool:
+    text = _read_text(config)
+    if "codex_hooks" in text:
+        return False
+    lines = text.splitlines()
+    for idx, line in enumerate(lines):
+        if line.strip() == "[features]":
+            lines.insert(idx + 1, "# AIRC-CODEX-HOOKS-FEATURE")
+            lines.insert(idx + 2, "codex_hooks = true")
+            _write_text(config, "\n".join(lines) + "\n")
+            return True
+
+    block = "\n# AIRC-CODEX-HOOKS-FEATURE-START\n[features]\ncodex_hooks = true\n# AIRC-CODEX-HOOKS-FEATURE-END\n"
+    suffix = "" if text.endswith("\n") or not text else "\n"
+    _write_text(config, text + suffix + block)
+    return True
+
+
+def _remove_codex_hooks_feature(config: Path) -> bool:
+    text = _read_text(config)
+    if not text:
+        return False
+    original = text
+    lines = text.splitlines()
+    out: list[str] = []
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
+        if line.strip() == "# AIRC-CODEX-HOOKS-FEATURE-START":
+            idx += 1
+            while idx < len(lines) and lines[idx].strip() != "# AIRC-CODEX-HOOKS-FEATURE-END":
+                idx += 1
+            idx += 1
+            continue
+        if line.strip() == "# AIRC-CODEX-HOOKS-FEATURE":
+            idx += 1
+            if idx < len(lines) and lines[idx].strip() == "codex_hooks = true":
+                idx += 1
+            continue
+        out.append(line)
+        idx += 1
+    new_text = "\n".join(out).rstrip() + ("\n" if out else "")
+    if new_text != original:
+        _write_text(config, new_text)
+        return True
+    return False
+
+
+def _remove_managed_developer_instructions(config: Path) -> bool:
+    text = _read_text(config)
+    if AIRC_INSTRUCTIONS_START not in text:
+        return False
+    lines = text.splitlines()
+    out: list[str] = []
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
+        if line.startswith(AIRC_INSTRUCTIONS_START):
+            idx += 1
+            while idx < len(lines) and not lines[idx].startswith(AIRC_INSTRUCTIONS_END):
+                idx += 1
+            if idx < len(lines):
+                idx += 1
+            while idx < len(lines) and lines[idx] == "":
+                idx += 1
+            continue
+        out.append(line)
+        idx += 1
+    _write_text(config, "\n".join(out).rstrip() + "\n")
+    return True
+
+
+def _load_hooks(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"hooks": {}}
+    if not isinstance(data, dict):
+        return {"hooks": {}}
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        data["hooks"] = {}
+    return data
+
+
+def _hook_entry() -> dict:
+    return {
+        "hooks": [
+            {
+                "type": "command",
+                "command": AIRC_HOOK_COMMAND,
+                "timeout": 5,
+                "statusMessage": AIRC_HOOK_STATUS,
+            }
+        ]
+    }
+
+
+def _install_hooks_json(path: Path) -> bool:
+    data = _load_hooks(path)
+    event = data.setdefault("hooks", {}).setdefault("UserPromptSubmit", [])
+    if not isinstance(event, list):
+        data["hooks"]["UserPromptSubmit"] = []
+        event = data["hooks"]["UserPromptSubmit"]
+
+    for group in event:
+        if not isinstance(group, dict):
+            continue
+        for hook in group.get("hooks", []):
+            if isinstance(hook, dict) and hook.get("command") == AIRC_HOOK_COMMAND:
+                return False
+
+    event.append(_hook_entry())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return True
+
+
+def _uninstall_hooks_json(path: Path) -> bool:
+    data = _load_hooks(path)
+    hooks = data.get("hooks", {})
+    event = hooks.get("UserPromptSubmit")
+    if not isinstance(event, list):
+        return False
+    changed = False
+    new_event = []
+    for group in event:
+        if not isinstance(group, dict):
+            new_event.append(group)
+            continue
+        group_hooks = group.get("hooks")
+        if not isinstance(group_hooks, list):
+            new_event.append(group)
+            continue
+        kept = [h for h in group_hooks if not (isinstance(h, dict) and h.get("command") == AIRC_HOOK_COMMAND)]
+        if len(kept) != len(group_hooks):
+            changed = True
+        if kept:
+            new_group = dict(group)
+            new_group["hooks"] = kept
+            new_event.append(new_group)
+    if not changed:
+        return False
+    if new_event:
+        hooks["UserPromptSubmit"] = new_event
+    else:
+        hooks.pop("UserPromptSubmit", None)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return True
+
+
+def cmd_install(args: argparse.Namespace) -> int:
+    codex_home = Path(args.codex_home).expanduser()
+    config = codex_home / "config.toml"
+    hooks_json = codex_home / "hooks.json"
+    changed_feature = _set_codex_hooks_feature(config)
+    changed_hook = _install_hooks_json(hooks_json)
+    removed_instructions = _remove_managed_developer_instructions(config)
+    if changed_feature:
+        print(f"enabled codex_hooks in {config}")
+    if changed_hook:
+        print(f"installed AIRC UserPromptSubmit hook in {hooks_json}")
+    if removed_instructions:
+        print(f"removed legacy AIRC Codex polling instructions from {config}")
+    return 0
+
+
+def cmd_uninstall(args: argparse.Namespace) -> int:
+    codex_home = Path(args.codex_home).expanduser()
+    config = codex_home / "config.toml"
+    hooks_json = codex_home / "hooks.json"
+    if _remove_codex_hooks_feature(config):
+        print(f"removed airc-managed codex_hooks feature from {config}")
+    if _uninstall_hooks_json(hooks_json):
+        print(f"removed AIRC UserPromptSubmit hook from {hooks_json}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="airc_core.codex_install")
+    parser.add_argument("--codex-home", default=os.path.join(os.path.expanduser("~"), ".codex"))
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("install-hooks")
+    sub.add_parser("uninstall-hooks")
+    args = parser.parse_args(argv)
+    if args.cmd == "install-hooks":
+        return cmd_install(args)
+    if args.cmd == "uninstall-hooks":
+        return cmd_uninstall(args)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -77,9 +77,9 @@ scope=$(airc debug-scope); mkdir -p "$scope"; nohup airc join > "$scope/codex-ai
 airc msg "..."                     # broadcast
 airc msg @peer "..."               # DM
 ```
-Codex has no Claude-style Monitor callback. Future Codex sessions installed by airc get a model-visible turn contract in `~/.codex/config.toml`: run `airc codex-poll` at the beginning of each user turn. That command is local-only, quiet when empty, excludes this identity's own messages, and advances the unread cursor. If it prints peer messages, surface them before continuing.
+Codex has no Claude-style Monitor callback, so airc installs a Codex `UserPromptSubmit` hook when hooks are supported. The hook runs `airc codex-hook user-prompt-submit` before each user prompt reaches the model, injects unread peer messages as developer context, excludes this client session's own messages, and advances the local unread cursor. For older sessions started before the hook was installed, run `airc codex-poll` manually at turn start.
 
-Do NOT poll `airc logs N` without `--since` — that re-injects the full tail every turn. Use `airc codex-poll` for Codex turn-start catch-up; use `airc join` for initial setup and recovery.
+Do NOT poll `airc logs N` without `--since` — that re-injects the full tail every turn. Use `airc codex-poll` for manual Codex catch-up; use `airc join` for initial setup and recovery.
 
 ## Idempotency
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -3295,6 +3295,13 @@ scenario_inbox() {
     && printf '%s' "$cursor" | grep -q '"offset":[1-9]' \
     && pass "poll alias reads only new messages and advances cursor" \
     || fail "poll alias failed; cursor='$cursor' output: $out"
+
+  printf '%s\n' '{"ts":"2099-05-04T10:03:00Z","from":"peer-test","client_id":"peer-client","msg":"hook-visible"}' >> "$home/messages.jsonl"
+  out=$(printf '{"hook_event_name":"UserPromptSubmit"}' | AIRC_CLIENT_ID=test-client AIRC_HOME="$home" "$AIRC" codex-hook user-prompt-submit 2>&1)
+  printf '%s' "$out" | grep -q '"hookEventName":"UserPromptSubmit"' \
+    && printf '%s' "$out" | grep -q 'hook-visible' \
+    && pass "codex-hook emits UserPromptSubmit context for unread local messages" \
+    || fail "codex-hook did not emit expected UserPromptSubmit JSON: $out"
 }
 
 scenario_host_msg_publishes_to_gist() {

--- a/test/test_codex_hook.py
+++ b/test/test_codex_hook.py
@@ -1,0 +1,157 @@
+"""Codex hook adapter tests."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+from airc_core import codex_hook, codex_install  # noqa: E402
+
+
+class CodexHookTests(unittest.TestCase):
+    def _scope(self):
+        tmp = tempfile.TemporaryDirectory()
+        home = Path(tmp.name)
+        return tmp, home, home / "inbox_cursor"
+
+    def _line(self, sender: str, ts: str, msg: str, client_id: str = "") -> str:
+        data = {"from": sender, "ts": ts, "msg": msg}
+        if client_id:
+            data["client_id"] = client_id
+        return json.dumps(data) + "\n"
+
+    def test_user_prompt_hook_emits_additional_context_for_unread_peer_messages(self):
+        tmp, home, cursor = self._scope()
+        with tmp:
+            (home / "messages.jsonl").write_text(
+                self._line("me", "2099-05-04T20:00:00Z", "self", "self-client")
+                + self._line("peer", "2099-05-04T20:00:01Z", "hello", "peer-client"),
+                encoding="utf-8",
+            )
+            out = io.StringIO()
+            with patch("sys.stdin", io.StringIO('{"hook_event_name":"UserPromptSubmit"}')):
+                with redirect_stdout(out):
+                    rc = codex_hook.main(
+                        [
+                            "user-prompt-submit",
+                            "--home",
+                            str(home),
+                            "--cursor-file",
+                            str(cursor),
+                            "--my-name",
+                            "me",
+                            "--client-id",
+                            "self-client",
+                        ]
+                    )
+            self.assertEqual(rc, 0)
+            payload = json.loads(out.getvalue())
+            context = payload["hookSpecificOutput"]["additionalContext"]
+            self.assertIn("peer: hello", context)
+            self.assertNotIn("me: self", context)
+            self.assertTrue(cursor.exists())
+
+    def test_user_prompt_hook_is_silent_when_empty(self):
+        tmp, home, cursor = self._scope()
+        with tmp:
+            (home / "messages.jsonl").write_text("", encoding="utf-8")
+            out = io.StringIO()
+            with patch("sys.stdin", io.StringIO("{}")):
+                with redirect_stdout(out):
+                    rc = codex_hook.main(
+                        [
+                            "user-prompt-submit",
+                            "--home",
+                            str(home),
+                            "--cursor-file",
+                            str(cursor),
+                            "--client-id",
+                            "self-client",
+                        ]
+                    )
+            self.assertEqual(rc, 0)
+            self.assertEqual(out.getvalue(), "")
+
+    def test_codex_hook_installer_preserves_existing_hooks(self):
+        tmp = tempfile.TemporaryDirectory()
+        with tmp:
+            codex_home = Path(tmp.name)
+            (codex_home / "config.toml").write_text("[features]\nother = true\n", encoding="utf-8")
+            (codex_home / "hooks.json").write_text(
+                json.dumps(
+                    {
+                        "hooks": {
+                            "UserPromptSubmit": [
+                                {
+                                    "hooks": [
+                                        {
+                                            "type": "command",
+                                            "command": "echo existing",
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with redirect_stdout(io.StringIO()):
+                codex_install.main(["--codex-home", str(codex_home), "install-hooks"])
+            config = (codex_home / "config.toml").read_text(encoding="utf-8")
+            hooks = json.loads((codex_home / "hooks.json").read_text(encoding="utf-8"))
+            commands = [
+                hook["command"]
+                for group in hooks["hooks"]["UserPromptSubmit"]
+                for hook in group["hooks"]
+                if "command" in hook
+            ]
+            self.assertIn("other = true", config)
+            self.assertIn("codex_hooks = true", config)
+            self.assertIn("echo existing", commands)
+            self.assertIn(codex_install.AIRC_HOOK_COMMAND, commands)
+
+    def test_codex_hook_installer_appends_new_features_table(self):
+        tmp = tempfile.TemporaryDirectory()
+        with tmp:
+            codex_home = Path(tmp.name)
+            (codex_home / "config.toml").write_text(
+                'default_permissions = "airc"\n[profiles.default]\nmodel = "gpt-5"\n',
+                encoding="utf-8",
+            )
+            with redirect_stdout(io.StringIO()):
+                codex_install.main(["--codex-home", str(codex_home), "install-hooks"])
+            config = (codex_home / "config.toml").read_text(encoding="utf-8")
+            self.assertRegex(config, r'default_permissions = "airc"\n\[profiles\.default\]')
+            self.assertRegex(config, r'\[features\]\ncodex_hooks = true')
+
+    def test_codex_hook_installer_removes_legacy_managed_polling_instructions(self):
+        tmp = tempfile.TemporaryDirectory()
+        with tmp:
+            codex_home = Path(tmp.name)
+            (codex_home / "config.toml").write_text(
+                '# AIRC-CODEX-INSTRUCTIONS-START — managed by install.sh\n'
+                'developer_instructions = """run airc codex-poll"""\n'
+                '# AIRC-CODEX-INSTRUCTIONS-END\n\n'
+                'default_permissions = "airc"\n',
+                encoding="utf-8",
+            )
+            with redirect_stdout(io.StringIO()):
+                codex_install.main(["--codex-home", str(codex_home), "install-hooks"])
+            config = (codex_home / "config.toml").read_text(encoding="utf-8")
+            self.assertNotIn("AIRC-CODEX-INSTRUCTIONS", config)
+            self.assertNotIn("developer_instructions", config)
+            self.assertIn('default_permissions = "airc"', config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -139,6 +139,15 @@ if [ -f "$codex_config" ]; then
     mv "$_tmp" "$codex_config"
     ok "Removed airc command-rules pre-approval from $codex_config"
   fi
+  if [ -x "$CLONE_DIR/.venv/bin/python" ]; then
+    if out=$(PYTHONPATH="$CLONE_DIR/lib${PYTHONPATH:+:$PYTHONPATH}" "$CLONE_DIR/.venv/bin/python" -m airc_core.codex_install --codex-home "$HOME/.codex" uninstall-hooks 2>&1); then
+      if [ -n "$out" ]; then
+        printf '%s\n' "$out" | while IFS= read -r line; do
+          ok "Codex AIRC hook: $line"
+        done
+      fi
+    fi
+  fi
 fi
 
 # 4. Binary forwarders on PATH.


### PR DESCRIPTION
## Summary
- add `airc codex-hook user-prompt-submit` to inject unread local AIRC messages into Codex `UserPromptSubmit` developer context
- install a user-level `~/.codex/hooks.json` hook and enable `codex_hooks` without clobbering existing hooks
- remove AIRC's legacy managed `developer_instructions` polling block once the hook is installed, so fresh Codex sessions use one receive path
- document the Codex hook path and add focused unit + integration coverage

## Validation
- `bash -n airc install.sh uninstall.sh lib/airc_bash/cmd_status.sh`
- `python3 -m py_compile lib/airc_core/codex_hook.py lib/airc_core/codex_install.py test/test_codex_hook.py`
- `PYTHONPATH=lib python3 test/test_codex_hook.py`
- `./airc doctor --tests python_units`
- `./airc doctor --tests inbox`
- end-to-end `codex exec` smoke in a temp AIRC scope returned `HOOK_SMOKE_1777949555` from hook-injected context, with no manual `airc codex-poll` fallback

## Notes
- Hook shape follows OpenAI Codex hooks docs: `UserPromptSubmit` JSON with `hookSpecificOutput.additionalContext`.
- The live install on this machine has been repaired to use the hook and no longer has AIRC's legacy managed `developer_instructions` block.
