### PR TITLE
Skip legacy Codex polling prompt when hook is active

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -747,8 +747,21 @@ fi
 
 _install_airc_codex_developer_instructions() {
   local config="$HOME/.codex/config.toml"
+  local hooks_json="$HOME/.codex/hooks.json"
   [ "${AIRC_SKIP_CODEX_INSTRUCTIONS:-0}" = "1" ] && return 0
   [ -f "$config" ] || return 0
+
+  if grep -qE '^[[:space:]]*codex_hooks[[:space:]]*=[[:space:]]*true' "$config" 2>/dev/null \
+     && [ -f "$hooks_json" ] \
+     && grep -qF 'airc codex-hook user-prompt-submit' "$hooks_json" 2>/dev/null; then
+    if grep -qF 'AIRC-CODEX-INSTRUCTIONS-START' "$config" 2>/dev/null; then
+      local _tmp; _tmp=$(mktemp)
+      sed '/^# AIRC-CODEX-INSTRUCTIONS-START/,/^# AIRC-CODEX-INSTRUCTIONS-END/d' "$config" > "$_tmp"
+      mv "$_tmp" "$config"
+    fi
+    info "  Codex AIRC hook already installed; skipping legacy developer_instructions polling contract"
+    return 0
+  fi
 
   if grep -qF 'AIRC-CODEX-INSTRUCTIONS-START' "$config" 2>/dev/null; then
     local _tmp; _tmp=$(mktemp)


### PR DESCRIPTION
## Summary
- when the Codex UserPromptSubmit hook is already installed and enabled, skip AIRC's legacy `developer_instructions` polling contract
- remove any stale AIRC-managed instruction block in that case
- avoids the confusing install output where update briefly added the old polling contract and then removed it

## Validation
- `bash -n install.sh`
- `AIRC_INSTALL_NO_DAEMON=1 ./install.sh` now prints `Codex AIRC hook already installed; skipping legacy developer_instructions polling contract`
- `./airc doctor --tests python_units`
- `./airc doctor --tests inbox`
