### PR TITLE
Repair missing scope config instead of reporting Not initialized

### DIFF
--- a/airc
+++ b/airc
@@ -399,13 +399,10 @@ _reexec_into() {
 # rejoin theirs, else take over the same gist in-place as host. Always
 # exec's via _reexec_into; does not return.
 #
-# User intent preservation across re-exec: pre-2026-04-29 this wiped
-# room_name + reexec'd with NO ARGS, which silently dropped the user's
-# `--room <name>` flag — auto-scope then took over and the user landed
-# on a different (cwd-derived) room than they asked for. Now we save
-# the explicit --room intent into AIRC_ROOM_INTENT before wiping local
-# state, restore it via env across the exec, and the post-exec arg
-# parser respects it as if the user had passed `--room` again.
+# User intent preservation across re-exec: save the explicit --room
+# intent into AIRC_ROOM_INTENT and keep config.json intact. Deleting
+# config before re-exec can leave a live transport scope that every
+# command reports as "Not initialized" if the re-exec is interrupted.
 _self_heal_stale_host() {
   local stale_id="$1"
   local jitter; jitter=$(awk -v r="$RANDOM" 'BEGIN{printf "%.3f", 0.1 + (r%1500)/1000}')
@@ -415,7 +412,6 @@ _self_heal_stale_host() {
   # explicit --room flag was used; anywhere else it's empty and we
   # reexec without the override (auto-scope decides as usual).
   local _saved_intent="${ROOM_INTENT_FOR_REEXEC:-${resolved_room_name:-${room_name:-}}}"
-  rm -f "$CONFIG" "$AIRC_WRITE_DIR/room_name"
   if [ -n "$_saved_intent" ]; then
     export AIRC_ROOM_INTENT="$_saved_intent"
   fi
@@ -583,6 +579,17 @@ _validate_peer_name() {
 }
 
 ensure_init() {
+  if [ -d "$AIRC_WRITE_DIR" ]; then
+    local _repair_out
+    if _repair_out=$("$AIRC_PYTHON" -m airc_core.scope_repair repair-config \
+        --home "$AIRC_WRITE_DIR" \
+        --config "$CONFIG" \
+        --default-name "$(derive_name)" \
+        --host "$(get_host)" 2>&1); then
+      [ -n "$_repair_out" ] && echo "  airc: $_repair_out" >&2
+      [ -f "$CONFIG" ] && return 0
+    fi
+  fi
   [ -f "$CONFIG" ] && return 0
   die "Not initialized ($AIRC_WRITE_DIR). Run: airc join"
 }

--- a/lib/airc_core/scope_repair.py
+++ b/lib/airc_core/scope_repair.py
@@ -1,0 +1,160 @@
+"""Repair local AIRC scope state without network access."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+GIST_RE = re.compile(r"^[0-9a-f]{32}$")
+GH_GET_RE = re.compile(r"_gh_api_get\(([0-9a-f]{32})\)")
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _channels_from_bearer_state(home: Path) -> list[str]:
+    channels = []
+    for path in sorted(home.glob("bearer_state.*.json")):
+        channel = path.name.removeprefix("bearer_state.").removesuffix(".json")
+        if channel and channel not in channels:
+            channels.append(channel)
+    return channels
+
+
+def _gist_from_bearer_log(home: Path, channel: str) -> str:
+    path = home / f"bearer_recv.{channel}.log"
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()[-200:]
+    except OSError:
+        return ""
+    for line in reversed(lines):
+        match = GH_GET_RE.search(line)
+        if match:
+            return match.group(1)
+    return ""
+
+
+def _name_from_messages(home: Path) -> str:
+    try:
+        lines = (home / "messages.jsonl").read_text(encoding="utf-8").splitlines()[-500:]
+    except OSError:
+        return ""
+    counts: Counter[str] = Counter()
+    for raw in lines:
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        sender = msg.get("from")
+        if isinstance(sender, str) and sender and sender not in {"airc", "unknown"}:
+            counts[sender] += 1
+    return counts.most_common(1)[0][0] if counts else ""
+
+
+def _name_from_ssh_comment(home: Path) -> str:
+    parts = _read(home / "identity" / "ssh_key.pub").split()
+    if len(parts) >= 3 and parts[2].startswith("airc-"):
+        return parts[2]
+    return ""
+
+
+def infer_config(home: Path, default_name: str, host: str, existing: dict | None = None) -> dict:
+    existing = existing or {}
+    room_name = _read(home / "room_name")
+    room_gist = _read(home / "room_gist_id")
+    host_gist = _read(home / "host_gist_id")
+
+    channels = list(existing.get("subscribed_channels", []) or [])
+    parted = set(existing.get("parted_rooms", []) or [])
+    for channel in _channels_from_bearer_state(home):
+        if channel not in channels and channel not in parted:
+            channels.append(channel)
+    if room_name and room_name not in channels:
+        channels.append(room_name)
+    if "cambriantech" in channels:
+        channels = ["cambriantech"] + [ch for ch in channels if ch != "cambriantech"]
+    elif room_name in channels:
+        channels = [room_name] + [ch for ch in channels if ch != room_name]
+
+    channel_gists: dict[str, str] = dict(existing.get("channel_gists", {}) or {})
+    if room_name and GIST_RE.match(room_gist):
+        channel_gists[room_name] = room_gist
+    for channel in channels:
+        log_gist = _gist_from_bearer_log(home, channel)
+        if GIST_RE.match(log_gist):
+            channel_gists[channel] = log_gist
+        elif channel not in channel_gists and channel != "general" and GIST_RE.match(host_gist):
+            channel_gists[channel] = host_gist
+
+    data = {
+        **existing,
+        "created": existing.get("created") or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "host": existing.get("host") or host,
+        "name": existing.get("name") or _name_from_messages(home) or _name_from_ssh_comment(home) or default_name or "airc",
+    }
+    if channels:
+        data["subscribed_channels"] = channels
+    if channel_gists:
+        data["channel_gists"] = channel_gists
+    return data
+
+
+def cmd_repair_config(args: argparse.Namespace) -> int:
+    home = Path(args.home).expanduser()
+    config = Path(args.config).expanduser()
+    existing: dict = {}
+    if config.exists():
+        try:
+            existing = json.loads(config.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            existing = {}
+    if not home.exists():
+        return 1
+    has_state = any((home / p).exists() for p in ("identity", "messages.jsonl", "room_gist_id", "host_gist_id"))
+    has_state = has_state or any(home.glob("bearer_state.*.json"))
+    if not has_state:
+        return 1
+    repaired = infer_config(home, args.default_name, args.host, existing)
+    if repaired == existing and config.exists():
+        return 0
+    _write_json(config, repaired)
+    if existing:
+        print(f"repaired incomplete config: {config}")
+    else:
+        print(f"repaired missing config: {config}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="airc_core.scope_repair")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    repair = sub.add_parser("repair-config")
+    repair.add_argument("--home", required=True)
+    repair.add_argument("--config", required=True)
+    repair.add_argument("--default-name", default="")
+    repair.add_argument("--host", default="")
+    args = parser.parse_args(argv)
+    if args.cmd == "repair-config":
+        return cmd_repair_config(args)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_scope_repair.py
+++ b/test/test_scope_repair.py
@@ -1,0 +1,113 @@
+"""Scope repair tests."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+from airc_core import scope_repair  # noqa: E402
+
+
+class ScopeRepairTests(unittest.TestCase):
+    def test_repairs_missing_config_from_durable_scope_state(self):
+        tmp = tempfile.TemporaryDirectory()
+        with tmp:
+            home = Path(tmp.name)
+            (home / "identity").mkdir()
+            (home / "identity" / "ssh_key.pub").write_text(
+                "ssh-ed25519 AAAATEST airc-fallback\n",
+                encoding="utf-8",
+            )
+            (home / "room_name").write_text("general\n", encoding="utf-8")
+            (home / "room_gist_id").write_text("c68640ec0144b422c16b2d8c83ad5ee5\n", encoding="utf-8")
+            (home / "host_gist_id").write_text("df40c8ae6c90f8e14009426fd6e16e22\n", encoding="utf-8")
+            (home / "bearer_state.cambriantech.json").write_text("{}\n", encoding="utf-8")
+            (home / "bearer_state.general.json").write_text("{}\n", encoding="utf-8")
+            (home / "bearer_recv.cambriantech.log").write_text(
+                "[airc:bearer_gh] _gh_api_get(df40c8ae6c90f8e14009426fd6e16e22): ok\n",
+                encoding="utf-8",
+            )
+            (home / "bearer_recv.general.log").write_text(
+                "[airc:bearer_gh] _gh_api_get(c68640ec0144b422c16b2d8c83ad5ee5): ok\n",
+                encoding="utf-8",
+            )
+            (home / "messages.jsonl").write_text(
+                json.dumps({"from": "airc-8a5e", "msg": "local"}) + "\n"
+                + json.dumps({"from": "airc", "msg": "system"}) + "\n",
+                encoding="utf-8",
+            )
+
+            config = home / "config.json"
+            rc = scope_repair.main(
+                [
+                    "repair-config",
+                    "--home",
+                    str(home),
+                    "--config",
+                    str(config),
+                    "--default-name",
+                    "default-name",
+                    "--host",
+                    "127.0.0.1",
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            data = json.loads(config.read_text(encoding="utf-8"))
+            self.assertEqual(data["name"], "airc-8a5e")
+            self.assertEqual(data["host"], "127.0.0.1")
+            self.assertEqual(data["subscribed_channels"], ["cambriantech", "general"])
+            self.assertEqual(
+                data["channel_gists"],
+                {
+                    "cambriantech": "df40c8ae6c90f8e14009426fd6e16e22",
+                    "general": "c68640ec0144b422c16b2d8c83ad5ee5",
+                },
+            )
+
+    def test_empty_scope_is_not_marked_initialized(self):
+        tmp = tempfile.TemporaryDirectory()
+        with tmp:
+            home = Path(tmp.name)
+            config = home / "config.json"
+            rc = scope_repair.main(["repair-config", "--home", str(home), "--config", str(config)])
+            self.assertEqual(rc, 1)
+            self.assertFalse(config.exists())
+
+    def test_repairs_incomplete_existing_config(self):
+        tmp = tempfile.TemporaryDirectory()
+        with tmp:
+            home = Path(tmp.name)
+            config = home / "config.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "name": "airc-8a5e",
+                        "host": "127.0.0.1",
+                        "created": "2026-05-05T00:00:00Z",
+                        "subscribed_channels": ["general"],
+                        "channel_gists": {"general": "91dfbe70f2358c7085e303e90016874c"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (home / "bearer_state.cambriantech.json").write_text("{}\n", encoding="utf-8")
+            (home / "bearer_recv.cambriantech.log").write_text(
+                "[airc:bearer_gh] _gh_api_get(df40c8ae6c90f8e14009426fd6e16e22): ok\n",
+                encoding="utf-8",
+            )
+            rc = scope_repair.main(["repair-config", "--home", str(home), "--config", str(config)])
+            self.assertEqual(rc, 0)
+            data = json.loads(config.read_text(encoding="utf-8"))
+            self.assertEqual(data["subscribed_channels"], ["cambriantech", "general"])
+            self.assertEqual(data["channel_gists"]["cambriantech"], "df40c8ae6c90f8e14009426fd6e16e22")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- stop stale-host self-heal from deleting `.airc/config.json` before re-exec
- add local-only scope repair for missing or incomplete `config.json` using durable scope state (`messages.jsonl`, `bearer_state.*.json`, channel bearer logs, identity keys)
- let `ensure_init` run that repair before reporting `Not initialized`, so `airc status` / `airc msg` recover instead of stranding a live transport scope

## Root Cause
A canary self-heal path preserved the mesh gist in-place, but still removed the local command metadata file (`config.json`) before re-exec. If the re-exec/daemon flow continued imperfectly, the scope kept transport artifacts but command verbs failed with `Not initialized`. We reproduced this in the Continuum scope after `airc version` was followed by `airc status` / `airc msg`.

## Validation
- Reproduced Continuum scope with missing/incomplete config; `airc status` repaired it back to `#cambriantech` + `#general` without `airc join`
- `bash -n airc`
- `python3 -m py_compile lib/airc_core/scope_repair.py test/test_scope_repair.py`
- `PYTHONPATH=lib python3 test/test_scope_repair.py`
- `./airc doctor --tests python_units`
- `./airc doctor --tests inbox`
