### PR TITLE
Make join restart stale bearer transport

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -133,6 +133,36 @@ _join_show_status_and_inbox() {
   cmd_inbox --count 50 2>&1 | sed 's/^/  /' || true
 }
 
+_join_transport_health_ok() {
+  [ -f "$CONFIG" ] || return 1
+  "$AIRC_PYTHON" -m airc_core.transport_health check \
+    --home "$AIRC_WRITE_DIR" \
+    --config "$CONFIG" \
+    --quiet >/dev/null 2>&1
+}
+
+_join_restart_scope_processes() {
+  local _pids=""
+  if [ -f "$AIRC_WRITE_DIR/airc.pid" ]; then
+    _pids="$_pids $(cat "$AIRC_WRITE_DIR/airc.pid" 2>/dev/null | tr '\n' ' ')"
+  fi
+  _pids="$_pids $(_airc_scope_monitor_formatter_pids "$AIRC_WRITE_DIR" 2>/dev/null | tr '\n' ' ')"
+  local _pidfile
+  for _pidfile in "$AIRC_WRITE_DIR"/bearer_gist.*.pid; do
+    [ -f "$_pidfile" ] || continue
+    _pids="$_pids $(cat "$_pidfile" 2>/dev/null | awk '{print $1}' | tr '\n' ' ')"
+  done
+  local _p _c
+  for _p in $_pids; do
+    case "$_p" in ''|*[!0-9]*) continue ;; esac
+    kill "$_p" 2>/dev/null || true
+    for _c in $(proc_children "$_p" 2>/dev/null); do
+      kill "$_c" 2>/dev/null || true
+    done
+  done
+  rm -f "$AIRC_WRITE_DIR/airc.pid" "$AIRC_WRITE_DIR"/bearer_gist.*.pid 2>/dev/null || true
+}
+
 _join_attach_local_stream() {
   echo ""
   echo "  Attaching this terminal to the local AIRC stream."
@@ -413,15 +443,15 @@ cmd_connect() {
       done <<< "$_map_lines"
     fi
     if [ "$_repair_running_monitor" = "1" ]; then
-      local _repair_pids; _repair_pids=$(cat "$_early_pidfile" 2>/dev/null | tr '\n' ' ')
       echo "  airc join: restarting this scope's AIRC process to leave the solo island."
-      for _p in $_repair_pids; do
-        kill "$_p" 2>/dev/null || true
-        for _c in $(proc_children "$_p" 2>/dev/null); do
-          kill "$_c" 2>/dev/null || true
-        done
-      done
-      rm -f "$_early_pidfile" 2>/dev/null || true
+      _join_restart_scope_processes
+      sleep 1
+    elif ! _join_transport_health_ok; then
+      echo "  airc join: AIRC process exists but transport is degraded; restarting this scope's AIRC process."
+      "$AIRC_PYTHON" -m airc_core.transport_health check \
+        --home "$AIRC_WRITE_DIR" \
+        --config "$CONFIG" 2>/dev/null | sed 's/^/    /' || true
+      _join_restart_scope_processes
       sleep 1
     else
     local _early_pids; _early_pids=$(cat "$_early_pidfile" 2>/dev/null | tr '\n' ' ')

--- a/lib/airc_core/transport_health.py
+++ b/lib/airc_core/transport_health.py
@@ -1,0 +1,162 @@
+"""Local transport health checks for AIRC scopes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class ChannelHealth:
+    channel: str
+    ok: bool
+    age: int | None
+    detail: str
+
+
+def _load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+def _safe_gist(gist: str) -> str:
+    return "".join(c if c.isalnum() else "_" for c in gist)
+
+
+def _read_pid(path: Path) -> int:
+    try:
+        raw = path.read_text(encoding="utf-8").strip().split("\t", 1)[0]
+        return int(raw) if raw else 0
+    except Exception:
+        return 0
+
+
+def _signal_for_gist(home: Path, channel: str, gist: str, subs: list[str], gists: dict[str, str], own_state: dict) -> tuple[float, str] | None:
+    candidates = [(channel, own_state)]
+    if gist:
+        for other in subs:
+            if other == channel or gists.get(other) != gist:
+                continue
+            other_state = _load_json(home / f"bearer_state.{other}.json")
+            if other_state:
+                candidates.append((other, other_state))
+
+    best: tuple[float, str] | None = None
+    for source, state in candidates:
+        ts = state.get("last_heartbeat_ts")
+        if ts is None:
+            ts = state.get("last_recv_ts")
+        if ts is None:
+            continue
+        try:
+            ts_f = float(ts)
+        except Exception:
+            continue
+        if best is None or ts_f > best[0]:
+            best = (ts_f, source)
+    return best
+
+
+def evaluate(home: Path, config: Path, fresh_after: int = 90, now: float | None = None) -> list[ChannelHealth]:
+    now = time.time() if now is None else now
+    cfg = _load_json(config)
+    subs = list(cfg.get("subscribed_channels") or [])
+    gists = dict(cfg.get("channel_gists") or {})
+    if not subs:
+        subs = list(gists.keys())
+    rows: list[ChannelHealth] = []
+    for channel in subs:
+        gist = gists.get(channel, "")
+        issues: list[str] = []
+        age: int | None = None
+        if not gist:
+            issues.append("missing channel_gists mapping")
+
+        state_path = home / f"bearer_state.{channel}.json"
+        state = _load_json(state_path)
+        signal_info = _signal_for_gist(home, channel, gist, subs, gists, state)
+        if signal_info is not None:
+            signal_ts, _source = signal_info
+            try:
+                age = int(now - signal_ts)
+                if age > fresh_after:
+                    issues.append(f"stale heartbeat {age}s")
+            except Exception:
+                issues.append("invalid heartbeat timestamp")
+        elif state:
+            try:
+                mtime_age = int(now - state_path.stat().st_mtime)
+            except OSError:
+                mtime_age = None
+            if mtime_age is not None and mtime_age <= fresh_after:
+                age = mtime_age
+                issues.append("starting; no heartbeat yet")
+            else:
+                issues.append("no heartbeat evidence")
+        else:
+            issues.append("no bearer_state file")
+
+        pid_path = home / f"bearer_gist.{_safe_gist(gist)}.pid" if gist else home / f"bearer_state.{channel}.pid"
+        pid = _read_pid(pid_path)
+        if not pid:
+            issues.append("no bearer pidfile")
+        elif not _pid_alive(pid):
+            issues.append(f"stale bearer pid {pid}")
+
+        rows.append(ChannelHealth(channel=channel, ok=not issues, age=age, detail="; ".join(issues) if issues else "fresh heartbeat"))
+    return rows
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    rows = evaluate(Path(args.home), Path(args.config), fresh_after=args.fresh_after)
+    if not rows:
+        return 1
+    bad = [row for row in rows if not row.ok]
+    if args.quiet:
+        return 1 if bad else 0
+    if bad:
+        print(f"transport health: DEGRADED ({len(bad)}/{len(rows)} channel(s) need attention)")
+    else:
+        print(f"transport health: ok ({len(rows)} channel(s) fresh)")
+    for row in rows:
+        suffix = f"{row.age}s" if row.age is not None else "no-signal"
+        print(f"#{row.channel}: {'ok' if row.ok else 'DEGRADED'} ({suffix}) — {row.detail}")
+    return 1 if bad else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="airc_core.transport_health")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    check = sub.add_parser("check")
+    check.add_argument("--home", required=True)
+    check.add_argument("--config", required=True)
+    check.add_argument("--fresh-after", type=int, default=90)
+    check.add_argument("--quiet", action="store_true")
+    args = parser.parse_args(argv)
+    if args.cmd == "check":
+        return cmd_check(args)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_transport_health.py
+++ b/test/test_transport_health.py
@@ -1,0 +1,58 @@
+"""Transport health tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+from airc_core import transport_health  # noqa: E402
+
+
+class TransportHealthTests(unittest.TestCase):
+    def _scope(self):
+        tmp = tempfile.TemporaryDirectory()
+        home = Path(tmp.name)
+        config = home / "config.json"
+        config.write_text(
+            json.dumps(
+                {
+                    "subscribed_channels": ["general"],
+                    "channel_gists": {"general": "c68640ec0144b422c16b2d8c83ad5ee5"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        return tmp, home, config
+
+    def test_fresh_heartbeat_and_live_pid_is_healthy(self):
+        tmp, home, config = self._scope()
+        with tmp:
+            now = time.time()
+            (home / "bearer_state.general.json").write_text(json.dumps({"last_heartbeat_ts": now}), encoding="utf-8")
+            (home / "bearer_gist.c68640ec0144b422c16b2d8c83ad5ee5.pid").write_text(str(os.getpid()), encoding="utf-8")
+            rows = transport_health.evaluate(home, config, now=now)
+            self.assertEqual(len(rows), 1)
+            self.assertTrue(rows[0].ok)
+
+    def test_formatter_without_fresh_bearer_is_degraded(self):
+        tmp, home, config = self._scope()
+        with tmp:
+            now = time.time()
+            (home / "bearer_state.general.json").write_text(json.dumps({"last_heartbeat_ts": now - 300}), encoding="utf-8")
+            (home / "bearer_gist.c68640ec0144b422c16b2d8c83ad5ee5.pid").write_text("999999", encoding="utf-8")
+            rows = transport_health.evaluate(home, config, now=now)
+            self.assertFalse(rows[0].ok)
+            self.assertIn("stale heartbeat", rows[0].detail)
+            self.assertIn("stale bearer pid", rows[0].detail)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `airc_core.transport_health` as a local-only per-channel transport health checker
- make `airc join` verify fresh bearer heartbeat + bearer pid evidence before trusting an existing formatter/process
- if a formatter exists but transport is degraded, restart only this scope's AIRC processes and fall through to normal join/daemon repair
- preserve the healthy short-circuit when transport is fresh

## Root Cause
After #506 repaired missing/incomplete config, this scope still exposed another recovery gap: `airc join` returned `already joined` because a formatter process existed, while both channel bearers were stale/dead. The daemon repair path fixed it manually, but `join` should do that itself.

## Validation
- `bash -n lib/airc_bash/cmd_connect.sh`
- `python3 -m py_compile lib/airc_core/transport_health.py test/test_transport_health.py`
- `PYTHONPATH=lib python3 test/test_transport_health.py`
- `./airc doctor --tests python_units`
- `./airc doctor --tests inbox`
- live Continuum healthy-path check: `airc join` still short-circuits when transport health is ok, with fresh `#cambriantech` + `#general` heartbeats
