### PR TITLE
Condense Codex hook inbox into AI digest

### DIFF
--- a/lib/airc_core/codex_hook.py
+++ b/lib/airc_core/codex_hook.py
@@ -10,10 +10,22 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import re
 import sys
 from contextlib import redirect_stdout
+from dataclasses import dataclass
 
 from airc_core import inbox
+
+
+INBOX_LINE_RE = re.compile(r"^\[(?P<ts>[^\]]+)\] (?P<sender>[^:]+): (?P<msg>.*)$")
+
+
+@dataclass
+class InboxMessage:
+    ts: str
+    sender: str
+    msg: str
 
 
 def _read_stdin_json() -> dict:
@@ -49,17 +61,74 @@ def _poll_context(args: argparse.Namespace) -> str:
     return out.getvalue().strip()
 
 
+def _parse_inbox(text: str) -> list[InboxMessage]:
+    messages = []
+    for line in text.splitlines():
+        match = INBOX_LINE_RE.match(line)
+        if not match:
+            continue
+        messages.append(InboxMessage(ts=match.group("ts"), sender=match.group("sender"), msg=match.group("msg")))
+    return messages
+
+
+def _summarize_text(value: str, max_len: int = 180) -> str:
+    one_line = " ".join(value.split())
+    if len(one_line) <= max_len:
+        return one_line
+    return f"{one_line[: max_len - 3].rstrip()}..."
+
+
+def _dedupe_messages(messages: list[InboxMessage]) -> list[InboxMessage]:
+    seen = set()
+    deduped: list[InboxMessage] = []
+    for msg in messages:
+        key = (msg.sender, msg.msg)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(msg)
+    return deduped
+
+
+def _digest(context: str, max_items: int = 8) -> str:
+    messages = _dedupe_messages(_parse_inbox(context))
+    if not messages:
+        return context
+
+    hidden = max(0, len(messages) - max_items)
+    shown = messages[-max_items:]
+    senders = []
+    for msg in messages:
+        if msg.sender not in senders:
+            senders.append(msg.sender)
+
+    lines = [
+        f"AIRC digest: {len(messages)} unread unique message(s)"
+        + (f" from {', '.join(senders[:4])}" if senders else "")
+        + (f" (+{len(senders) - 4} more senders)" if len(senders) > 4 else "")
+        + ".",
+    ]
+    if hidden:
+        lines.append(f"Showing latest {len(shown)}; {hidden} older unread message(s) were omitted from this hook digest.")
+    for msg in shown:
+        lines.append(f"- {msg.ts} {msg.sender}: {_summarize_text(msg.msg)}")
+    lines.append("If the digest is insufficient for the current task, run: airc inbox --peek --count 50")
+    return "\n".join(lines)
+
+
 def cmd_user_prompt_submit(args: argparse.Namespace) -> int:
     _read_stdin_json()
     context = _poll_context(args)
     if not context:
         return 0
+    if not args.raw:
+        context = _digest(context, max_items=args.max_items)
     payload = {
         "hookSpecificOutput": {
             "hookEventName": "UserPromptSubmit",
             "additionalContext": (
-                "Unread AIRC messages received before this user turn. "
-                "Account for them before continuing:\n\n"
+                "Unread AIRC messages arrived before this user turn. "
+                "Use this AI-oriented digest as current collaboration state.\n\n"
                 f"{context}"
             ),
         }
@@ -77,6 +146,8 @@ def main(argv: list[str] | None = None) -> int:
     user_prompt.add_argument("--my-name", default="")
     user_prompt.add_argument("--client-id", default="")
     user_prompt.add_argument("--count", type=int, default=50)
+    user_prompt.add_argument("--max-items", type=int, default=8)
+    user_prompt.add_argument("--raw", action="store_true")
     args = parser.parse_args(argv)
     if args.cmd == "user-prompt-submit":
         return cmd_user_prompt_submit(args)

--- a/test/test_codex_hook.py
+++ b/test/test_codex_hook.py
@@ -56,9 +56,43 @@ class CodexHookTests(unittest.TestCase):
             self.assertEqual(rc, 0)
             payload = json.loads(out.getvalue())
             context = payload["hookSpecificOutput"]["additionalContext"]
+            self.assertIn("AIRC digest: 1 unread unique message", context)
             self.assertIn("peer: hello", context)
             self.assertNotIn("me: self", context)
             self.assertTrue(cursor.exists())
+
+    def test_user_prompt_hook_dedupes_and_limits_digest(self):
+        tmp, home, cursor = self._scope()
+        with tmp:
+            (home / "messages.jsonl").write_text(
+                self._line("peer", "2099-05-04T20:00:01Z", "duplicate", "peer-client")
+                + self._line("peer", "2099-05-04T20:00:02Z", "duplicate", "peer-client")
+                + self._line("peer", "2099-05-04T20:00:03Z", "newest", "peer-client"),
+                encoding="utf-8",
+            )
+            out = io.StringIO()
+            with patch("sys.stdin", io.StringIO("{}")):
+                with redirect_stdout(out):
+                    rc = codex_hook.main(
+                        [
+                            "user-prompt-submit",
+                            "--home",
+                            str(home),
+                            "--cursor-file",
+                            str(cursor),
+                            "--client-id",
+                            "self-client",
+                            "--max-items",
+                            "1",
+                        ]
+                    )
+            self.assertEqual(rc, 0)
+            context = json.loads(out.getvalue())["hookSpecificOutput"]["additionalContext"]
+            self.assertIn("AIRC digest: 2 unread unique message", context)
+            self.assertIn("Showing latest 1", context)
+            self.assertIn("newest", context)
+            self.assertNotIn("duplicate", context)
+            self.assertIn("If the digest is insufficient", context)
 
     def test_user_prompt_hook_is_silent_when_empty(self):
         tmp, home, cursor = self._scope()


### PR DESCRIPTION
## Summary
- change Codex `UserPromptSubmit` AIRC context from raw inbox lines to an AI-oriented digest
- dedupe repeated messages by sender/body
- show the latest bounded set of unique messages with sender/timestamp/action text
- keep raw inbox available only as an explicit fallback command when the digest is insufficient

## Why
The audience for the hook is another AI turn, not a human transcript reader. Raw inbox injection can overwhelm context and duplicate validation chatter; the default should preserve collaboration state with minimal attention cost.

## Validation
- `PYTHONPATH=lib python3 test/test_codex_hook.py`
- `./airc doctor --tests python_units`
- local hook smoke shows duplicate collapse and compact digest output
