### PR TITLE
Tighten Codex hook digest output

### DIFF
--- a/lib/airc_core/codex_hook.py
+++ b/lib/airc_core/codex_hook.py
@@ -71,7 +71,7 @@ def _parse_inbox(text: str) -> list[InboxMessage]:
     return messages
 
 
-def _summarize_text(value: str, max_len: int = 180) -> str:
+def _summarize_text(value: str, max_len: int = 120) -> str:
     one_line = " ".join(value.split())
     if len(one_line) <= max_len:
         return one_line
@@ -103,16 +103,16 @@ def _digest(context: str, max_items: int = 8) -> str:
             senders.append(msg.sender)
 
     lines = [
-        f"AIRC digest: {len(messages)} unread unique message(s)"
-        + (f" from {', '.join(senders[:4])}" if senders else "")
-        + (f" (+{len(senders) - 4} more senders)" if len(senders) > 4 else "")
-        + ".",
+        f"AIRC: {len(messages)} unread"
+        + (f" from {', '.join(senders[:3])}" if senders else "")
+        + (f" +{len(senders) - 3}" if len(senders) > 3 else "")
     ]
     if hidden:
-        lines.append(f"Showing latest {len(shown)}; {hidden} older unread message(s) were omitted from this hook digest.")
+        lines.append(f"latest {len(shown)} shown; {hidden} older omitted")
     for msg in shown:
-        lines.append(f"- {msg.ts} {msg.sender}: {_summarize_text(msg.msg)}")
-    lines.append("If the digest is insufficient for the current task, run: airc inbox --peek --count 50")
+        lines.append(f"- {msg.sender}: {_summarize_text(msg.msg)}")
+    if hidden:
+        lines.append("more: airc inbox --peek --count 50")
     return "\n".join(lines)
 
 
@@ -126,11 +126,7 @@ def cmd_user_prompt_submit(args: argparse.Namespace) -> int:
     payload = {
         "hookSpecificOutput": {
             "hookEventName": "UserPromptSubmit",
-            "additionalContext": (
-                "Unread AIRC messages arrived before this user turn. "
-                "Use this AI-oriented digest as current collaboration state.\n\n"
-                f"{context}"
-            ),
+            "additionalContext": context,
         }
     }
     print(json.dumps(payload, separators=(",", ":")))

--- a/test/test_codex_hook.py
+++ b/test/test_codex_hook.py
@@ -56,7 +56,7 @@ class CodexHookTests(unittest.TestCase):
             self.assertEqual(rc, 0)
             payload = json.loads(out.getvalue())
             context = payload["hookSpecificOutput"]["additionalContext"]
-            self.assertIn("AIRC digest: 1 unread unique message", context)
+            self.assertIn("AIRC: 1 unread", context)
             self.assertIn("peer: hello", context)
             self.assertNotIn("me: self", context)
             self.assertTrue(cursor.exists())
@@ -88,11 +88,11 @@ class CodexHookTests(unittest.TestCase):
                     )
             self.assertEqual(rc, 0)
             context = json.loads(out.getvalue())["hookSpecificOutput"]["additionalContext"]
-            self.assertIn("AIRC digest: 2 unread unique message", context)
-            self.assertIn("Showing latest 1", context)
+            self.assertIn("AIRC: 2 unread", context)
+            self.assertIn("latest 1 shown", context)
             self.assertIn("newest", context)
             self.assertNotIn("duplicate", context)
-            self.assertIn("If the digest is insufficient", context)
+            self.assertIn("more: airc inbox --peek --count 50", context)
 
     def test_user_prompt_hook_is_silent_when_empty(self):
         tmp, home, cursor = self._scope()


### PR DESCRIPTION
## Summary
- tighten Codex hook context further for AI consumption
- remove intro prose and timestamps from the default digest
- keep concise `AIRC: N unread from ...` header plus short sender bullets
- only show the raw-inbox fallback command when older messages were omitted

## Validation
- `PYTHONPATH=lib python3 test/test_codex_hook.py`
- `./airc doctor --tests python_units`
- live hook turn already showed the compact digest shape in this Codex session
