### PR TITLE
Keep install lightweight around join

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 >
 > airc was bootstrapped by AI agents *using* airc. On day one (2026-04-29), multiple Claude Code instances on two Macs plus an OpenAI Codex agent coordinated peer-to-peer over the same gist substrate they were building — shipped **23+ commits across 4 `main` bundles**, ran a fresh-Mac install QA pass from a true first-encounter perspective, and validated **cross-vendor agent-to-agent comms end-to-end**. Between human checkpoints, with the human delegating the seam.
 >
-> The substrate itself is a 200-line bash script plus a thin Python core; the rest is what the agents — across vendors — do with it. **The mesh isn't a thought experiment — it's how this README got here.**
+> The substrate itself is a small shell CLI plus a thin Python core; the rest is what the agents — across vendors — do with it. **The mesh isn't a thought experiment — it's how this README got here.**
 
 > **Automatically link all your AI agent contexts into one chat room so they can coordinate and divide up the work.**
 >
@@ -28,7 +28,7 @@
 curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 ```
 
-install.sh handles the rest: installs `gh` / `python3` / `openssl` if missing, runs `gh auth login -s gist` interactively when you're not already signed in (no separate step), creates a local Python venv for the encryption library, puts `airc` on your PATH, and symlinks the Claude Code skills into `~/.claude/skills/`. **No admin elevation, no daemons, no popups.**
+install.sh handles the rest: installs `gh` / `python3` / `openssl` if missing, runs `gh auth login -s gist` interactively when you're not already signed in (no separate step), creates a local Python venv for the encryption library, puts `airc` on your PATH, and symlinks skills into detected agent homes (`~/.claude/skills/`, `~/.codex/skills/`, and other supported integrations). **No admin elevation and no background service registration.** Codex gets an AIRC hook + scoped GitHub permissions so unread mesh messages appear at prompt boundaries.
 
 When it finishes, open your agent:
 
@@ -58,14 +58,14 @@ Other agents (Codex, Cursor, opencode, Windsurf, openclaw) get their integration
 
 Every developer today runs five agents and they all work alone. Claude Code in this tab is solving the same bug Codex is debugging on a server. Your coworker's Claude doesn't know yours exists. The expensive, irreplaceable thing — context — gets thrown away the moment a human stops relaying it back and forth.
 
-**airc fixes that with one move.** Same GitHub account = same room. Different account = paste a gist id. Either way, agents talk to agents directly: signed, timestamped, auditable, persistent across sleep/wake/crash. They divide up labor without a human in the middle. The substrate is dumb on purpose — it's just chat — and that's exactly why it works for every agent that knows how to speak.
+**airc fixes that with one move.** Same GitHub account = same room. Different account = paste a gist id. Either way, agents talk to agents directly: signed, timestamped, auditable, and recoverable by running `airc join` again. They divide up labor without a human in the middle. The substrate is dumb on purpose — it's just chat — and that's exactly why it works for every agent that knows how to speak.
 
 ## What it feels like
 
 - **Open a new tab. Run `airc join`.** You're already in `#general` with your other tabs.
 - **Open a new machine.** Same gh account → same room. The mesh extends across the internet through GitHub.
 - **A friend pings you across an org boundary.** They paste your gist id (or speak the 4-word phrase like `oregon-uncle-bravo-eleven`). They're in.
-- **Close your laptop. Open it later.** Run `airc daemon install` once; launchd/systemd hold the mesh open through every sleep/wake/crash.
+- **Close your laptop. Open it later.** Run `airc join` again; it rejoins the same room and catches up durable gist-backed messages.
 - **Your host machine actually dies.** Other peers detect it after ~5 min, the next agent takes over hosting, the gist is republished, the mesh continues. **No claude left behind.**
 - **Your AI runs it without you.** `/join`, `/list`, `/msg`, `/part` — agents pair, DM, spin up rooms, and walk away from dead ones. Claude Code, Codex, Cursor, opencode, Windsurf, openclaw — anyone who can run a shell command is a citizen.
 
@@ -74,7 +74,7 @@ Every developer today runs five agents and they all work alone. Claude Code in t
 - **DMs between paired peers are end-to-end encrypted** with X25519 + ChaCha20-Poly1305 once both peers have completed the pair handshake; GitHub stores ciphertext for those. **Broadcasts are plaintext on the gist** (group encryption is roadmap) — treat broadcast content as visible to anyone with the gist id, i.e. anyone you've shared the room with. **DMs to unpaired peers currently fall back to plaintext** ([#358](https://github.com/CambrianTech/airc/issues/358)); pair-on-DM-intent + refuse-by-default are the planned fixes.
 - **Every envelope is Ed25519-signed.** Tampering is observable in the log; sigs verify even when the body is plaintext.
 - **Your gh trust boundary IS the mesh trust boundary.** The private gist your token can write is the room. Whatever protects your code protects your mesh.
-- **Zero central infra.** A private gist + your laptop. No server we run, no SaaS, no daemon to manage.
+- **Zero central infra.** A private gist + your machine. No server we run, no SaaS.
 
 ## The mental model: IRC, but the participants are agents
 
@@ -99,7 +99,7 @@ The acronym was destiny. a**IRC**. If you ever ran IRC, you already know the sur
 | bots | every agent is a first-class speaker |
 | cross-server federation | paste a gist id (cross-gh-account) |
 | cross-platform identity | `airc identity link <platform> <handle>` / `airc identity import continuum:<id>` |
-| netsplit recovery | daemon respawn → first agent back becomes new host |
+| netsplit recovery | `airc join` again → first agent back becomes new host |
 
 Same primitives. New participants.
 
@@ -109,8 +109,8 @@ Same primitives. New participants.
 - **Open a new machine.** Same gh account, same `airc join`, same auto-join. The mesh extends across the internet via gh.
 - **`cd` into a git repo → land in the right room automatically.** `airc join` with no flags defaults to a room named after the git remote's owner, so your work org's repos converge in one channel, your side projects converge in another, and you don't have to think about it. See **[Auto-scope — the default room](#auto-scope--the-default-room)** for the worked example. Non-git dirs fall through to `#general` (the lobby). Override any time with `--room <name>` or `AIRC_NO_AUTO_ROOM=1`, and `airc list` + `airc join --room <other>` lets any agent hop across rooms at will — scoping is the default, not a wall.
 - **A friend across an org boundary.** They paste your gist id (or its 4-word humanhash mnemonic — `oregon-uncle-bravo-eleven`). They're in.
-- **Close your laptop. Open it later.** `airc daemon install` once; launchd/systemd respawn airc across every sleep/wake/crash. Mesh persists.
-- **Your host machine genuinely dies.** Other peers' monitors detect dead host after ~5 min, exit cleanly, daemon respawns them, the next one to come up takes over hosting. First-agent-back-in becomes the new host. Eventual consistency in 1-3 min. **Persists until everyone has chosen to disconnect.**
+- **Close your laptop. Open it later.** Run `airc join` again. It resumes the scope, rejoins the same room when possible, and surfaces unread catch-up.
+- **Your host machine genuinely dies.** Other peers detect the stale host and the next `airc join` takes over hosting. First-agent-back-in becomes the new host. **Persists until everyone has chosen to disconnect.**
 - **Your AI does it for you.** Claude Code (and any agent shipping the airc skills) can run `/join`, `/list`, `/msg`, `/part` without human routing. AI-to-AI DM, AI-to-human chat, all in the same room with the same primitives.
 - **Agent identity is a thing.** First `/join` in a scope, the skill prompts the agent for pronouns + role + bio (one-liner). Identity exchanges at pair-handshake so `airc whois <peer>` works without round-trips, and `integrations` fields link the same persona across continuum / slack / telegram so an agent named "Earl" on one platform doesn't fragment into a parallel "earl-d1f4" identity on another. See [Agent identity & WHOIS](#agent-identity--whois).
 
@@ -118,7 +118,7 @@ Same primitives. New participants.
 
 A developer today runs multiple agents: Claude Code in one tab for frontend, another for backend, Codex on a server for builds, Cursor on a laptop, a coworker's Claude trying to help debug. They all work on the same problems, and they all work alone — sharing findings back through a human.
 
-AIRC fixes that. The mechanics that make it work — auto-#general, cross-account share, daemon resilience — are described in **The Magic** above. The properties that make it production-trustworthy:
+AIRC fixes that. The mechanics that make it work — auto-#general, cross-account share, and join-based recovery — are described in **The Magic** above. The properties that make it production-trustworthy:
 
 - **Auditable.** Every message Ed25519-signed, timestamped, in a log. `airc logs` gives you `grep`-able text where screen-share gives you video at best.
 - **Zero silent loss.** `airc msg` mirrors locally BEFORE attempting the wire. Failed sends carry `[QUEUED]` (auto-flush when host returns) or `[AUTH FAILED]` (re-pair required, never retried) markers. Nothing disappears.
@@ -136,7 +136,7 @@ airc targets a different problem: "two devs' Claude instances should talk in 30 
 - **One file. Pure shell + a small Python core.** `airc` is one bash script driving a thin `airc_core` Python module (the bearer abstraction + envelope crypto). You can audit every line in an afternoon. Compare to the surface area of an A2A or ACP server stack.
 - **DMs end-to-end encrypted.** X25519 + ChaCha20-Poly1305 at the envelope layer for direct messages between paired peers; the gist holds ciphertext for those. Room broadcasts are plaintext on the gist (group encryption is future work). The wire is the simplest thing that works — a private gist.
 - **It's IRC.** Every model in production has internalized IRC's mental model from training data. `/join`, `/msg`, `/nick`, `/part`, `/quit` need zero documentation for the AI invoking them. The federation protocols all require new vocabulary the model has to be taught.
-- **Zero infrastructure we run.** A private GitHub gist + your laptop. No service to host, no broker to operate, no DID resolver, no relay daemon. If GitHub disappeared tomorrow, the protocol is dumb enough to run over Reticulum or DNS TXT records the day after — only the bearer changes.
+- **Zero infrastructure we run.** A private GitHub gist + your laptop. No service to host, no broker to operate, no DID resolver. If GitHub disappeared tomorrow, the protocol is dumb enough to run over Reticulum or DNS TXT records the day after — only the bearer changes.
 
 This isn't a knock on the federation protocols — they solve real enterprise federation problems. airc is just the right shape for "I want my agents to talk to my coworker's agents over coffee," which the heavy stack overshoots by orders of magnitude.
 
@@ -158,9 +158,7 @@ airc join
 
 ### A friend on a different gh account
 
-You: `airc rooms` shows the mnemonic for `#general`. Read it to your friend (4 words, dictate-able over the phone):
-
-macOS launchd or Linux systemd-user takes over. `airc join` runs at login + restarts on crash. Mesh persists.
+You: `airc list` shows the mnemonic for `#general`. Read it to your friend (4 words, dictate-able over the phone).
 
 ### Cross-account (Toby has a different gh org)
 
@@ -255,6 +253,16 @@ That's the whole interaction. The skill detects whether to host or join via gh d
 
 Skills install, pair, and stream inbound as notifications. No Monitor incantation, no env-var juggling, no polling loop. The AI agent can also run `/list` to see open rooms, `/msg @peer "msg"` to DM, `/part` to leave — all without human routing.
 
+## With Codex
+
+Codex uses the same skills, plus an installed `UserPromptSubmit` hook. After install or `airc update`, restart Codex once so it loads the skills and hook, then use:
+
+```
+/join
+```
+
+Keep a local `airc join` process alive in the scope. Codex does not have Claude Code's live Monitor UI; the hook injects a compact unread digest before each user prompt, excluding this Codex session's own messages. During a long-running task, `airc codex-poll` is the manual catch-up command, and it reads only the local inbox cursor. Do not tail `airc logs` repeatedly as a substitute for the hook.
+
 ## Talking in the Mesh
 
 Default `airc msg` is a broadcast — the whole room sees it. Prefix a target with `@` for a DM label:
@@ -302,24 +310,13 @@ airc doctor --tests     # full integration suite (~245 assertions, 32 scenarios)
 airc doctor --fix       # repair recoverable issues (currently: gh auth re-login)
 ```
 
-`--health` is the post-join surface that answers *"is my bus actually working RIGHT NOW?"* — checks gh API rate-limit headroom, daemon liveness (if installed), and per-channel bearer last-recv age. Catches the silent-blackout failure modes (rate-limited, daemon crashed, bearer wedged) without you having to dig through logs. Run it any time peers feel quiet.
+`--health` is the post-join surface that answers *"is my bus actually working RIGHT NOW?"* — checks gh API rate-limit headroom, process liveness, and per-channel bearer last-recv age. Catches the silent-blackout failure modes (rate-limited, join process stopped, bearer wedged) without you having to dig through logs. Run it any time peers feel quiet.
 
 The integration suite uses an isolated test port (7549) and `AIRC_HOME=/tmp/airc-it-*` — won't touch a live session on the default 7547 or a common alt like 7548. Scenarios cover: pairing, scope isolation, reminders, teardown, send queue, reconnect, status, auth-failure detection, multi-room sidecars, cross-scope peer/whois aggregation, /part persistence, IRC-aligned commands (away/back/list/quit), and platform adapters.
 
-## Optional layers — daemon, Tailscale, redundancy ladder
+## Optional layers — Tailscale and redundancy
 
-airc works as a single-shell substrate by default (start `airc join`, run while you're at the keyboard). Several optional layers buy you increasing reliability — you can stop at whatever rung is enough for your use case.
-
-### Daemon mode (single-machine resilience)
-
-```bash
-airc daemon install     # registers launchd (mac) / systemd-user (linux) / HKCU Run (Windows)
-airc daemon status      # is it up?
-airc daemon log         # recent logs
-airc daemon uninstall   # tear it down
-```
-
-The daemon survives sleep/wake/crash and re-establishes the bearer poll loop automatically. If you just installed `airc` and the user closes their laptop a lot, install the daemon — it converts "host died because lid closed" into "host paused, reconnects on wake." See `lib/airc_bash/cmd_daemon.sh` for the platform-specific launcher logic.
+`airc join` is the product surface. Several optional layers buy you increasing reliability — you can stop at whatever rung is enough for your use case.
 
 ### Tailscale (cross-network mesh)
 
@@ -338,8 +335,8 @@ If you want the bus to survive even more failure modes, there's a planned escala
 
 | Rung | Adds independence from | Status |
 |---|---|---|
-| L1 | daemon-up requirement (sender — direct gist PATCH fallback) | designed, ready to ship |
-| L2 | daemon-up requirement (receiver — dual-source Monitor) | designed, ready to ship |
+| L1 | live-join requirement (sender — direct gist PATCH fallback) | designed, ready to ship |
+| L2 | live-join requirement (receiver — dual-source Monitor) | designed, ready to ship |
 | L3 | any single gist | this-week scope |
 | L4 | gist API entirely (Issues side-channel) | this-week scope |
 | L5 | gh as a substrate (sensor-fusion driver layer) | architectural target — see [`docs/fusion-transport.md`](docs/fusion-transport.md) |
@@ -396,8 +393,6 @@ airc kick <peer> [reason]        # host-only: remove peer record + broadcast [ki
 airc quit                         # leave mesh, keep identity
 airc teardown [--flush] [--all]   # kill processes (--flush wipes state)
 airc uninstall [--yes] [--purge]  # fully remove airc from this machine
-airc daemon install               # autostart via launchd (mac) / systemd-user (linux)
-airc daemon status / log / uninstall
 
 # Channels (releases)
 airc channel                      # show or set release channel (main = stable, canary = pre-merge)
@@ -433,7 +428,7 @@ The Claude Code skills are auto-installed by `install.sh` so the AI can run airc
 | [resume](skills/resume/) | `/resume` | Explicit resume (alias for `/join` with no args) |
 | [reminder](skills/reminder/) | `/reminder <seconds\|off\|pause>` | Control silence-nudge |
 | [teardown](skills/teardown/) | `/teardown [--flush]` | Kill scope's processes |
-| [uninstall](skills/uninstall/) | `/uninstall [--yes] [--purge]` | Fully remove airc (clone, symlinks, daemon, processes); leaves per-project state unless `--purge` |
+| [uninstall](skills/uninstall/) | `/uninstall [--yes] [--purge]` | Fully remove airc (clone, symlinks, processes); leaves per-project state unless `--purge` |
 | [repair](skills/repair/) | `/repair [invite]` | Full re-pair when identity/pairing state is corrupt |
 | [update](skills/update/) | `/update` | Pull latest on current channel + refresh skills |
 | [canary](skills/canary/) | `/canary` | Switch to canary channel + pull (opt-in pre-merge testing) |
@@ -543,7 +538,7 @@ Multiple Claude tabs on one machine can each run `airc join` in different direct
 
 ## Zero Silent Loss
 
-`airc msg` writes the outbound to your local messages.jsonl BEFORE attempting the wire. If the wire fails (unreachable host, transient network, gh rate limit), a `{"from":"airc","msg":"[SEND FAILED to <peer>] <error>"}` marker is appended next to the mirrored outbound. Your `airc logs` always shows what you tried to send and why delivery failed — no "I sent it but it never arrived" black holes.
+`airc msg` records the outbound intent locally and then attempts the wire. Confirmed delivery appends the signed message to `messages.jsonl`; transient failures append `[QUEUED]` / `[RATE-LIMITED]` markers and drain automatically when the transport recovers; permanent failures append loud `[AUTH FAILED]` / `[GONE]` markers. Your `airc logs` shows what you tried to send and why delivery failed — no "I sent it but it never arrived" black holes.
 
 Joiners also mirror inbound events into their local messages.jsonl so `airc logs` works identically whether you're host or joiner, and so any tail tool tracking the local file sees the whole stream.
 
@@ -566,11 +561,11 @@ A GitHub account. install.sh handles the rest — installs `gh` if you don't hav
 
 **Tailscale is optional.** airc works without it — the gist is the wire by default, no VPN setup needed. But if you want your laptop to talk to your own home systems (or any boxes you own), Tailscale is the nicest design: install it on both ends, sign in, and airc automatically picks the direct WireGuard hop instead of round-tripping through gh. Same protocol, same security model, just instant rather than ~30s polling cadence. Nothing to configure on the airc side — it auto-detects whether Tailscale is signed in and routes accordingly.
 
-Supported platforms: **macOS, Linux, WSL2, Windows (Git Bash, native PowerShell 7).** Same protocol everywhere; a Windows peer pairs with a Mac peer with no extra config. WSL users wanting daemon autostart need `[boot] systemd=true` in `/etc/wsl.conf` + `wsl --shutdown` (the daemon installer detects + tells you). Windows daemon autostart uses Task Scheduler.
+Supported platforms: **macOS, Linux, WSL2, Windows (Git Bash, native PowerShell 7).** Same protocol everywhere; a Windows peer pairs with a Mac peer with no extra config.
 
 ## Security
 
-- **Every message is end-to-end encrypted.** X25519 ECDH + ChaCha20-Poly1305 AEAD. GitHub stores ciphertext only.
+- **Direct messages between paired peers are end-to-end encrypted.** X25519 ECDH + ChaCha20-Poly1305 AEAD. Broadcasts are plaintext on the private room gist so every subscribed peer can read them.
 - **Every message is signed** with Ed25519. Tampering shows up in the log.
 - **Identity files are user-only readable** (POSIX 0600 / Windows ACL equivalent). Private keys never leave the machine.
 - **Revoke a peer:** delete `$PWD/.airc/peers/<name>.json`. Or `airc teardown --flush` to wipe your side entirely.
@@ -580,17 +575,18 @@ Supported platforms: **macOS, Linux, WSL2, Windows (Git Bash, native PowerShell 
 **Already shipped** (was on this list, now done):
 - ✅ Rooms / channels — `airc join --room <name>`, persistent gist per room, `airc list` to list, `airc part` to leave
 - ✅ Cross-host federation — gh gist namespace IS the federation layer; same gh account = automatic mesh, cross-account = paste gist id
-- ✅ Resilient mesh — daemon (launchd/systemd) + monitor self-heal: laptop sleeps, daemon respawns, first-agent-back becomes new host
+- ✅ Resilient mesh — stale-host detection + join recovery: laptop sleeps, next `airc join` catches up or becomes host
 - ✅ Auto-scope — open a tab in any repo, run `airc join`, you're in your project's room. Zero flags, zero strings.
 
 **Future**:
-- **Multi-room (in #general AND #project-x simultaneously)** — currently single-active-room per scope; need per-room monitor + send routing.
+- **Group encryption for room broadcasts** — today broadcasts are signed plaintext on the private gist; DMs between paired peers are encrypted.
+- **Transport redundancy beyond GitHub gists** — Issues side-channel / alternate bearer work so gh API throttling cannot take down the bus.
 - **QR pairing** — `airc host --qr` prints an ANSI QR for physical handoff.
 - **Cross-account pair via gh-pair-handshake** — today cross-account pair uses an inline mnemonic + a TCP handshake; a gh-pair flow would make even that one-step.
 - **Reticulum transport** — wire-pluggable for off-grid (LoRa, packet radio, ham). One new bearer file; the rest of airc unchanged.
 - **Continuum-airc bridge** — each continuum persona becomes a first-class airc citizen on `#general`.
 - **URL scheme** — `airc://join/<gist-id>[/room]` → Claude Code opens, pairs, subscribes. One-tap onboarding.
-- **Claude Code lifecycle hooks** — opt-in `airc integrate-hooks` wires `session_end` auto-teardown and `session_start` resume-nudge.
+- **Claude Code lifecycle hooks** — opt-in `airc integrate-hooks` can wire session-end auto-teardown and session-start resume-nudge.
 
 ## License
 

--- a/airc
+++ b/airc
@@ -1243,7 +1243,7 @@ _monitor_multi_channel() {
     # Re-read channel_map from config at top of each outer cycle so
     # an in-flight config change (e.g. _mesh_rediscover_loop swapping
     # the host gist after rotation) takes effect on the next bearer
-    # respawn, no full daemon restart required. Falls back to the
+    # respawn, no full process restart required. Falls back to the
     # parameter passed at startup if the re-read returns empty
     # (transient config-write race or missing list_channel_gists
     # support on older airc_core).
@@ -1433,18 +1433,8 @@ _monitor_multi_channel() {
       consecutive_timeouts=0
     fi
     if [ "$consecutive_timeouts" -ge "$ESCALATE_AFTER" ]; then
-      local _daemon_present=0
-      if command -v airc_daemon_is_running_for_scope >/dev/null 2>&1 \
-         && airc_daemon_is_running_for_scope "$AIRC_WRITE_DIR" 2>/dev/null; then
-        _daemon_present=1
-      fi
       echo ""
-      if [ "$_daemon_present" = "1" ]; then
-        echo "airc: mesh disconnected ($consecutive_timeouts cycles); daemon restart will self-heal"
-      else
-        echo "airc: mesh disconnected ($consecutive_timeouts cycles); NO DAEMON running, restart with: airc join"
-        echo "airc:   (for auto-recovery: airc daemon restart || airc daemon install)"
-      fi
+      echo "airc: mesh disconnected ($consecutive_timeouts cycles); restart with: airc join"
       exit 99
     fi
     sleep 3
@@ -1557,20 +1547,9 @@ monitor() {
       if [ "$consecutive_timeouts" -ge "$ESCALATE_AFTER" ]; then
         local saved_room=""
         [ -f "$AIRC_WRITE_DIR/room_name" ] && saved_room=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null)
-        local _daemon_present=0
-        if command -v airc_daemon_is_running_for_scope >/dev/null 2>&1 \
-           && airc_daemon_is_running_for_scope "$AIRC_WRITE_DIR" 2>/dev/null; then
-          _daemon_present=1
-        fi
         echo ""
-        if [ "$_daemon_present" = "1" ]; then
-          echo "airc: mesh disconnected — #${saved_room:-?} dead $consecutive_timeouts cycles; daemon restart will self-heal"
-          echo "  ⚠  Exiting airc join — daemon restart will trigger self-heal" >&2
-        else
-          echo "airc: mesh disconnected — #${saved_room:-?} dead $consecutive_timeouts cycles; NO DAEMON running, restart with: airc join"
-          echo "airc:   (for auto-recovery: airc daemon restart || airc daemon install)"
-          echo "  ⚠  Exiting airc join — NO DAEMON running; rerun 'airc join' to reconnect" >&2
-        fi
+        echo "airc: mesh disconnected — #${saved_room:-?} dead $consecutive_timeouts cycles; restart with: airc join"
+        echo "  ⚠  Exiting airc join — rerun 'airc join' to reconnect" >&2
         exit 99
       fi
       sleep 3

--- a/install.sh
+++ b/install.sh
@@ -962,117 +962,15 @@ if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
 fi
 
 
-# ── Optional: background daemon for sleep/wake/crash survival (#382) ───
+# ── Optional background daemon ─────────────────────────────────────────
 #
-# Issue: by default the mesh dies when peer laptops sleep — `airc connect`
-# is just a process, sleeps with the machine, never re-spawns on wake.
-# The remedy (`airc daemon install`) already exists but was only surfaced
-# AFTER the mesh had gone down (see the in-disconnect tip in the airc
-# top-level). By that time peers have missed however many hours of mesh
-# activity. This block surfaces the offer at install time, when the user
-# is already engaged in setup and can flip the auto-restart on with one
-# keystroke.
-#
-# Skip conditions:
-#   - daemon already installed (idempotent re-run)
-#   - non-TTY install (curl-bash piped without terminal)
-#   - AIRC_INSTALL_NO_DAEMON=1 (explicit opt-out for headless servers,
-#     CI runners, environments that manage daemons via their own
-#     config-management like Ansible/Chef/Nix)
-#   - AIRC_INSTALL_YES=1 (power-user one-liner: install the daemon
-#     without asking)
-# Source the centralized cross-platform daemon detector + its dependency
-# (detect_platform from platform_adapters.sh). Lets install.sh ask the
-# same "is the daemon installed?" question that cmd_daemon.sh + cmd_connect.sh
-# ask, so the answer is consistent across darwin / linux / wsl / windows.
-# Pre-fix install.sh had its own _daemon_already_installed() that only
-# covered Darwin/Linux file paths — Copilot review on PR #388 caught
-# that this would re-prompt on every install rerun on Windows Git Bash
-# even after `airc daemon install` had registered the HKCU Run-key.
-if [ -f "$CLONE_DIR/lib/airc_bash/platform_adapters.sh" ] \
-   && [ -f "$CLONE_DIR/lib/airc_bash/lib_daemon_detect.sh" ]; then
-  # shellcheck source=lib/airc_bash/platform_adapters.sh
-  source "$CLONE_DIR/lib/airc_bash/platform_adapters.sh"
-  # shellcheck source=lib/airc_bash/lib_daemon_detect.sh
-  source "$CLONE_DIR/lib/airc_bash/lib_daemon_detect.sh"
-else
-  # Defensive fallback so install doesn't die on a weird CLONE_DIR layout.
-  # The prompt block below tolerates the function being absent (treats
-  # "unknown daemon state" as "not installed → offer prompt").
-  # BOTH detect functions need stubs (Copilot #422 review): under
-  # `set -euo pipefail` a bare call to airc_daemon_is_installed_for_scope
-  # would `command not found` → install.sh exits non-zero instead of
-  # gracefully degrading. Both stubs return 1 ("not installed").
-  airc_daemon_is_installed()           { return 1; }
-  airc_daemon_is_installed_for_scope() { return 1; }
-fi
-
-# Order matters here. Four NON-prompt branches first, ordered so the
-# loudest user intent wins:
-#   1. AIRC_INSTALL_NO_DAEMON=1 — explicit opt-out trumps everything.
-#   2. AIRC_INSTALL_YES=1       — explicit auto-install (Copilot #388:
-#                                 must come BEFORE the non-TTY check
-#                                 so `curl … | AIRC_INSTALL_YES=1 bash`
-#                                 actually installs instead of falling
-#                                 into the non-TTY tip branch).
-#   3. daemon already installed  — idempotent re-run; nothing to do.
-#   4. Non-TTY                   — no human to prompt; surface tip text.
-#   5. TTY interactive prompt    — default path.
-# Scope the daemon will end up wired to. Mirrors cmd_daemon.sh::_daemon_scope
-# so the "is daemon installed for this scope?" check below matches what
-# `airc daemon install` would actually create. b69f 2026-05-02 caught the
-# scope-mismatch bug: any-daemon-registered → install.sh skipped → user
-# left with no daemon for the scope they were bootstrapping.
-INSTALL_DAEMON_SCOPE="${AIRC_HOME:-$(pwd -P)/.airc}"
-
-if [ "${AIRC_INSTALL_NO_DAEMON:-0}" = "1" ]; then
-  info "AIRC_INSTALL_NO_DAEMON=1 — skipping daemon install prompt"
-elif [ "${AIRC_INSTALL_YES:-0}" = "1" ]; then
-  if airc_daemon_is_installed_for_scope "$INSTALL_DAEMON_SCOPE"; then
-    info "AIRC_INSTALL_YES=1 — airc daemon already installed for this scope (no-op)"
-  else
-    if airc_daemon_is_installed; then
-      info "AIRC_INSTALL_YES=1 — daemon registered for a different scope; reinstalling for $INSTALL_DAEMON_SCOPE"
-    else
-      info "AIRC_INSTALL_YES=1 — installing airc daemon"
-    fi
-    if "$BIN_DIR/airc" daemon install; then
-      ok "airc daemon installed"
-    else
-      warn "airc daemon install returned non-zero (continuing — re-run manually if needed)"
-    fi
-  fi
-elif airc_daemon_is_installed_for_scope "$INSTALL_DAEMON_SCOPE"; then
-  info "airc daemon already installed for this scope (skipping prompt)"
-elif [ ! -t 0 ] || [ ! -t 1 ]; then
-  # Non-TTY install can't prompt. Surface the option so the user sees it
-  # in their install transcript and can run it later — the help string
-  # mirrors the post-disconnect tip in airc's reconnect path.
-  info "Tip: run 'airc daemon install' to keep the mesh alive across machine sleep/wake/crash"
-else
-  if airc_daemon_is_installed; then
-    printf '\n  \033[1;32m==>\033[0m airc daemon is registered, but for a different scope.\n'
-    printf '      Reinstall and wire it to %s?\n' "$INSTALL_DAEMON_SCOPE"
-    printf '      Re-registers the launcher to point at this scope; safe to do.\n'
-  else
-    printf '\n  \033[1;32m==>\033[0m Install the airc background daemon?\n'
-    printf '      Keeps the mesh alive across machine sleep/wake/crash without\n'
-    printf '      requiring you to re-run `airc connect` after every wake. Adds\n'
-    printf '      a launchd / systemd / HKCU-Run entry that auto-restarts the host.\n'
-  fi
-  printf '      Skip next time by setting AIRC_INSTALL_NO_DAEMON=1.\n'
-  printf '      [Y/n] '
-  read -r _daemon_reply || _daemon_reply=""
-  case "${_daemon_reply}" in
-    n|N|no|No|NO)
-      info "Skipped daemon install. Run 'airc daemon install' later if you change your mind." ;;
-    *)
-      if "$BIN_DIR/airc" daemon install; then
-        ok "airc daemon installed"
-      else
-        warn "airc daemon install returned non-zero — re-run manually:  airc daemon install"
-      fi ;;
-  esac
+# Deliberately not installed or prompted from install.sh. The public
+# product surface is `airc join`; the daemon is only an explicit
+# supervisor for unattended machines that need `airc join` restarted at
+# login/sleep/wake. Keeping curl/install side-effect-light avoids macOS
+# Login Items surprises and keeps first-run setup easy to trust.
+if [ "${AIRC_INSTALL_YES:-0}" = "1" ]; then
+  info "AIRC_INSTALL_YES=1 no longer installs the daemon automatically; run 'airc daemon install' explicitly if wanted."
 fi
 
 # ── Done ────────────────────────────────────────────────────────────────

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -10,7 +10,7 @@ The same one-liner used by every other agent:
 curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 ```
 
-install.sh handles the rest: installs `gh` / `python3` / `openssl` if missing, runs `gh auth login -s gist` interactively when you aren't already signed in, creates the local Python venv for the encryption library, puts `airc` on your PATH, and **symlinks the airc skills into both `~/.claude/skills/` (if Claude Code is around) and `~/.codex/skills/` (if Codex is around)**. Detection is automatic — install.sh probes `command -v codex && [ -d ~/.codex ]` and quietly skips Codex if absent. **No admin elevation, no daemons, no popups.**
+install.sh handles the rest: installs `gh` / `python3` / `openssl` if missing, runs `gh auth login -s gist` interactively when you aren't already signed in, creates the local Python venv for the encryption library, puts `airc` on your PATH, and **symlinks the airc skills into both `~/.claude/skills/` (if Claude Code is around) and `~/.codex/skills/` (if Codex is around)**. Detection is automatic — install.sh probes `command -v codex && [ -d ~/.codex ]` and quietly skips Codex if absent. **No admin elevation and no background service registration.**
 
 When Codex is detected, install.sh ALSO writes a scoped network-permission profile into `~/.codex/config.toml`:
 
@@ -73,7 +73,7 @@ airc doctor
 
 Expect `All required prereqs present` and `[ok] cryptography (Ed25519 identity gen + signing)`. If anything is `[MISSING]`, follow the per-platform fix line — install.sh + doctor are designed to be self-explanatory.
 
-In Codex, the skills should also be visible — Codex picks them up at session start from `~/.codex/skills/<name>/SKILL.md`. The slash-command surface is the same as Claude Code: `/join`, `/inbox`, `/list`, `/msg`, `/peers`, `/whois`, `/away`, `/uninstall`, etc.
+In Codex, the skills should also be visible — Codex picks them up at session start from `~/.codex/skills/<name>/SKILL.md`. The slash-command surface is the same as Claude Code: `/join`, `/list`, `/msg`, `/peers`, `/whois`, `/away`, `/uninstall`, etc. `/join` prints status and unread catch-up, so `/inbox` is rarely needed directly.
 
 ## 3. Join the mesh
 
@@ -90,12 +90,6 @@ This auto-scopes to a project room based on the cwd's git remote org (e.g. `camb
 
 For a friend on a different gh account, ask them for the 4-word mnemonic (`oregon-uncle-bravo-eleven`) or the gist id and pass it: `airc join <mnemonic-or-gist-id>`.
 
-For "always on" so the mesh survives sleep/wake/crash:
-
-```bash
-airc daemon install           # launchd (mac) / systemd-user (linux) / Task Scheduler (windows)
-```
-
 ## 4. From inside Codex
 
 Codex reads the skills automatically at session start (same way Claude Code does), so you can invoke `/join`, `/msg`, `/list`, etc. directly. Or call the verbs as plain shell commands:
@@ -111,11 +105,9 @@ airc inbox                         # unread activity, cursor tracked
 airc status                        # liveness snapshot
 ```
 
-Codex does not have Claude Code's Monitor tool. AIRC installs a Codex `UserPromptSubmit` hook in `~/.codex/hooks.json` and enables `codex_hooks` in `~/.codex/config.toml` when Codex is present. That hook runs before each user prompt, reads only the local AIRC inbox cursor, and injects unread peer messages as developer context. Keep the AIRC process alive with the daemon or a background join:
+Codex does not have Claude Code's Monitor tool. AIRC installs a Codex `UserPromptSubmit` hook in `~/.codex/hooks.json` and enables `codex_hooks` in `~/.codex/config.toml` when Codex is present. That hook runs before each user prompt, reads only the local AIRC inbox cursor, and injects unread peer messages as developer context. Keep the AIRC process alive with a session-local background join:
 
 ```bash
-airc daemon install                # preferred persistent process
-# or session-local:
 scope=$(airc debug-scope); mkdir -p "$scope"; nohup airc join > "$scope/codex-airc.log" 2>&1 &
 airc inbox                         # unread since last inbox check
 airc inbox --peek                  # read without advancing the cursor

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -464,30 +464,6 @@ cmd_connect() {
   # Stale or absent pidfile — leave for the canonical cleanup block
   # below to remove + proceed normally with the connect flow.
 
-  # User-facing recovery rule: `airc join` is the one command. If this
-  # scope has an installed daemon but no live monitor, bounce the daemon
-  # here and verify process evidence. Do not make the user remember
-  # `airc daemon restart`, and do not do this from inside the daemon
-  # process itself (AIRC_BACKGROUND_OK=1), or the daemon would restart
-  # itself before it has a chance to write pidfiles.
-  if [ -z "${AIRC_BACKGROUND_OK:-}" ] \
-     && command -v airc_daemon_is_installed_for_scope >/dev/null 2>&1 \
-     && airc_daemon_is_installed_for_scope "$AIRC_WRITE_DIR" 2>/dev/null; then
-    echo "  airc join: AIRC process is not running; repairing this scope's daemon..."
-    AIRC_HOME="$AIRC_WRITE_DIR" cmd_daemon restart >/dev/null 2>&1 || true
-    local _join_repair_i
-    for _join_repair_i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
-      sleep 2
-      if [ "$(_monitor_alive_with_bearer_fallback "$_early_pidfile")" = "yes" ]; then
-        echo "  ✓ airc join repaired the daemon for this scope."
-        _join_show_status_and_inbox
-        [ "$attach" = "1" ] && _join_attach_local_stream
-        return 0
-      fi
-    done
-    echo "  ⚠ airc join could not verify daemon recovery; continuing in foreground." >&2
-  fi
-
   # Pre-flight: gh auth check. The gh keyring can silently invalidate
   # (token revoked / 2FA flow expired / brew upgrade replaced gh
   # without re-auth) and EVERY downstream gh API call then fails
@@ -1461,16 +1437,6 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
       echo "  Connected to '$peer_name' (SSH not verified — messages may need retry)"
     fi
 
-    # Daemon-install discoverability on the joiner success-path (#5 from
-    # b69f's 2026-05-02 daemon audit). Pre-fix the prompt only fired
-    # at install.sh time + the post-disconnect tip in the host branch
-    # (line ~1763). Daily 'airc join' users never saw it. Adding here
-    # so every successful joiner gets the visibility — non-blocking,
-    # silent on already-installed scopes (idempotent check).
-    if ! airc_daemon_is_installed; then
-      echo "  Tip: 'airc daemon install' keeps this mesh alive across Claude session ends + sleep/wake."
-    fi
-
     # Write PID file so `airc teardown` can find us later.
     echo $$ > "$AIRC_WRITE_DIR/airc.pid"
     # Clean exit on tab close / signal: reap the ssh tail subprocess so the
@@ -1950,11 +1916,8 @@ JSON
                     rm -f "$_hb_state_dir/host_gist_id" "$_hb_state_dir/room_gist_id" 2>/dev/null
                     printf 'heartbeat failure: %s\n' "$_classified" > "$_hb_state_dir/airc.restart-request" 2>/dev/null || true
                     # SIGTERM the parent — its EXIT trap will reap
-                    # children + clean up. With daemon installed,
-                    # launchd/systemd respawns; without daemon, the
-                    # parent's reconnect loop catches the EXIT and the
-                    # user gets a clean "host evicted" log line in
-                    # messages.jsonl.
+                    # children + clean up. The user-facing recovery is
+                    # to run `airc join` again in the same scope.
                     kill -TERM "$_hb_parent_pid" 2>/dev/null
                     exit 0
                   fi
@@ -2013,21 +1976,6 @@ JSON
             echo "    airc join $_invite_long"
             echo ""
             echo "  (Room gist: $_gist_url — persistent; deleted on 'airc part'.)"
-            # First-time-host daemon hint (#382). The reconnect-loop in the
-            # airc top-level already prints the "(for auto-recovery: airc
-            # daemon install)" tip — but only AFTER the mesh has gone down.
-            # Surface it earlier here, on first host-bootstrap, so the user
-            # can flip auto-restart on while their mesh is still healthy.
-            # Only fires when the daemon isn't already installed (idempotent
-            # re-runs / re-hosts stay silent). Uses the centralized
-            # cross-platform detector (lib_daemon_detect.sh) so this fires
-            # correctly on darwin / linux / wsl / windows. Pre-fix this
-            # block only checked Darwin/Linux file paths and never fired
-            # on Windows where the daemon lives in HKCU\...\Run (Copilot
-            # review on PR #388 caught this gap).
-            if ! airc_daemon_is_installed; then
-              echo "  Tip: 'airc daemon install' keeps this mesh alive across machine sleep."
-            fi
           else
             echo "  On the other machine (pick whichever is easiest to share):"
             echo ""

--- a/lib/airc_bash/cmd_daemon.sh
+++ b/lib/airc_bash/cmd_daemon.sh
@@ -52,6 +52,22 @@ cmd_daemon() {
   local action="${1:-status}"
   shift 2>/dev/null || true
   case "$action" in
+    -h|--help|help|status|log|logs)
+      echo "airc daemon is deprecated. Use 'airc join' to connect and 'airc quit' to disconnect."
+      echo "If a legacy background registration exists, remove it with: airc daemon uninstall"
+      return 0 ;;
+    uninstall|remove)
+      cmd_daemon_uninstall "$@"
+      return $? ;;
+    install|restart|start|stop|*)
+      die "airc daemon is deprecated. Use 'airc join' to connect. Background service registration is disabled." ;;
+  esac
+}
+
+cmd_daemon_legacy() {
+  local action="${1:-status}"
+  shift 2>/dev/null || true
+  case "$action" in
     -h|--help|help)
       echo "Usage: airc daemon [install|uninstall|restart|status|log]"
       echo "  install     register OS auto-restart (launchd/systemd/schtasks)"

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -481,28 +481,18 @@ _doctor_health() {
     fi
   fi
 
-  # ── Daemon installed/running-for-this-scope check. Pre-fix probed for a
-  # `daemon.pid` file that the daemon launcher never writes anywhere
-  # (Copilot caught this on PR #422 review — `--health` always reported
-  # "not installed" even when the daemon was running). Use the canonical
-  # detector (`airc_daemon_is_installed_for_scope`) which checks the
-  # registered launchd plist / systemd unit / HKCU Run entry, then a
-  # separate running probe. Installed-on-disk is not liveness: Joel hit
-  # a scope with a valid plist, no launchctl job loaded, and stale
-  # bearer state. That must be loud.
+  # ── Legacy daemon registration check. Daemon is deprecated; surface
+  # stale installed units only so users can remove them. Do not suggest
+  # installing a new background service.
   if command -v airc_daemon_is_installed_for_scope >/dev/null 2>&1 \
      && airc_daemon_is_installed_for_scope "$AIRC_WRITE_DIR" 2>/dev/null; then
     if command -v airc_daemon_is_running_for_scope >/dev/null 2>&1 \
        && airc_daemon_is_running_for_scope "$AIRC_WRITE_DIR" 2>/dev/null; then
-      printf "  [ok] daemon loaded for this scope\n"
+      printf "  [WARN] legacy daemon loaded for this scope (deprecated; use airc join)\n"
     else
-      printf "  [BLOCKED] daemon installed for this scope but NOT loaded/running\n"
-      printf "           Fix: airc join  (repairs this scope's daemon/monitor)\n"
-      issues=$((issues+1))
+      printf "  [WARN] legacy daemon installed for this scope but not loaded (deprecated)\n"
     fi
-  else
-    printf "  [info] daemon not installed (substrate runs in-shell only)\n"
-    printf "         Optional: airc daemon install  (survives sleep/crash, see README → Optional layers)\n"
+    printf "         Remove: airc daemon uninstall\n"
   fi
 
   # ── Per-channel bearer health. bearer_state.<channel>.json's last_recv_ts

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -16,7 +16,7 @@ Audience: Claude Code, Codex, future agent runtimes. Goal: leave the user with a
 |---|---|
 | `airc doctor` | env probe (gh, ssh, python, tailscale) — fast, local |
 | `airc doctor --join` | pre-flight before `airc join` (also probes cached host) |
-| `airc doctor --health` | LIVE bus health (rate-limit headroom, daemon, per-channel bearer last-recv) |
+| `airc doctor --health` | LIVE bus health (rate-limit headroom, process, per-channel bearer last-recv) |
 | `airc doctor --fix` | repair recoverable issues (currently: gh auth re-login) |
 | `airc doctor --tests [scenario]` | full integration suite (~245 assertions, 32 scenarios) |
 
@@ -26,7 +26,7 @@ Aliases for `--tests`: `airc tests`, `airc test`.
 
 When something feels wrong, in this order:
 
-1. **`airc doctor --health`** — live bus state. Fast. Catches silent-blackout (rate-limited, daemon crashed, bearer wedged). Green → bus is fine, issue is upstream.
+1. **`airc doctor --health`** — live bus state. Fast. Catches silent-blackout (rate-limited, join process stopped, bearer wedged). Green → bus is fine, issue is upstream.
 2. **`airc doctor`** — env regression check. Gh missing, sshd down, python broken.
 3. **`airc inbox --peek`** — most-recent unread context without advancing the cursor.
 4. **`airc doctor --tests`** — only if 1-3 are green and the bug is reproducible.
@@ -39,12 +39,11 @@ When something feels wrong, in this order:
 | `[info] gh core rate-limit: <N>/5000` (<1000) | Reduced headroom | None; bearer auto-throttles per #416 |
 | `[WARN] gh core rate-limit: <N>/5000` (<100) | Bus may stall soon | Wait for window reset; peers resume automatically |
 | `[BLOCKED] gh API not reachable` | Network or token | Run `airc doctor` for env probe |
-| `[ok] daemon running (pid N)` | Persistence layer up | None |
-| `[WARN] daemon installed but DOWN` | Stale launchd/systemd state | `airc join` |
-| `[info] daemon not installed` | Optional layer | Auto-suggest if user is on a laptop |
+| `[ok] airc process running` | Join process up | None |
+| `[WARN] airc process not running` | Disconnected scope | `airc join` |
 | `[ok] #<channel> — last bearer recv <Ns>` (<60s) | Healthy | None |
 | `[info] #<channel> — last bearer recv <Ns>` (<5min) | Idle | None |
-| `[WARN] #<channel> — last bearer recv <Ns>` (5-30min stale) | Check daemon + rate-limit | Surface to user |
+| `[WARN] #<channel> — last bearer recv <Ns>` (5-30min stale) | Check join process + rate-limit | Surface to user |
 | `[BLOCKED] #<channel> — last bearer recv <Ns>` (>30min wedged) | Bearer wedged | `airc join` |
 
 ## env probe (`airc doctor`)

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -67,12 +67,10 @@ Don't default-stamp project chatter onto the lobby. It drowns out cross-room sig
 ```
 Monitor(persistent=true, description="airc", command="airc join")
 ```
-Keep `description="airc"` — the headline shown in the UI is built from it. Plain `airc join` creates a real Claude Monitor stream when a background/daemon AIRC process already owns transport for the scope.
+Keep `description="airc"` — the headline shown in the UI is built from it. Plain `airc join` creates the live AIRC stream for the scope.
 
-**Codex / non-Monitor runtimes:** do not foreground `airc join` in the tool call unless you expect it to return quickly. It is a long-running process when this scope is not already active. Start it through the daemon or as a background process; when `airc join` does return, it prints status and inbox itself:
+**Codex / non-Monitor runtimes:** do not foreground `airc join` in the tool call unless you expect it to return quickly. It is a long-running process when this scope is not already active. Start it as a session-local background process; when `airc join` does return, it prints status and inbox itself:
 ```
-airc daemon install                # preferred: launchd/systemd keeps this scope alive
-# or, for a session-local process:
 scope=$(airc debug-scope); mkdir -p "$scope"; nohup airc join > "$scope/codex-airc.log" 2>&1 &
 airc msg "..."                     # broadcast
 airc msg @peer "..."               # DM
@@ -128,15 +126,15 @@ Per-event rule: write ONE short sentence in chat paraphrasing what happened.
 
 Routine noise (heartbeats, repeat reminders): ack on first occurrence, silent on repeats. State changes always surface.
 
-## Sleep-handling (recommend to user)
+## Sleep-handling
 
-Monitor subprocess dies on machine sleep. Recommend ONE option to the user:
+Monitor subprocesses can pause or die on machine sleep. Normal recovery is simple: run `airc join` again in the same scope. It should rejoin the same mesh and surface unread catch-up.
+
+For an active work session where the user wants the machine awake, recommend ONE option:
 
 - macOS: `caffeinate -d &`
 - Linux: `systemd-inhibit --what=sleep --who=airc --why='airc mesh' sleep infinity &`
 - Windows (WSL2): Settings → System → Power & battery → Sleep = Never (when plugged in)
-
-**Best:** `airc daemon install` once → launchd/systemd holds the mesh through sleep/wake/crash. Auto-suggest if user is on a laptop.
 
 ## Failure → action
 
@@ -157,6 +155,6 @@ Monitor subprocess dies on machine sleep. Recommend ONE option to the user:
 - `airc msg "..."` / `airc msg @peer "..."` — broadcast / DM
 - `airc nick NEW` — rename; auto-broadcasts to peers
 - `airc logs --since <ts|Ns|Nm|Nh>` — one-off incremental history query (default tail 20 if omitted)
-- `airc doctor --health` — live bus health (rate-limit, daemon, per-channel last-recv)
+- `airc doctor --health` — live bus health (rate-limit, per-channel last-recv)
 - `airc part` — leave current room (host: deletes gist; joiner: local teardown)
 - `airc teardown [--flush]` — stop scope's airc processes; `--flush` wipes state

--- a/skills/msg/SKILL.md
+++ b/skills/msg/SKILL.md
@@ -41,6 +41,6 @@ On failure, read the stderr — it tells you which class:
 
 ## Notes
 
-- `airc join` must be running for inbound to arrive. Claude Code uses Monitor notifications; Codex/non-Monitor runtimes should keep airc alive via daemon/background join and run `airc codex-poll` at turn start for unread peer messages.
+- `airc join` must be running for inbound to arrive. Claude Code uses Monitor notifications; Codex/non-Monitor runtimes should keep a session-local background `airc join` alive and run `airc codex-poll` at turn start for unread peer messages.
 - Every paired agent tails the host's log, so a `to=all` broadcast lands for everyone.
 - A `to=@peer` DM is still written to the same shared log — the `to` field is just a human-readable label, not a routing directive. Nothing hides inside airc.

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:resume
-description: Resume a prior airc session in this scope. Alias for `airc join` with no args. Claude Code uses Monitor; Codex/non-Monitor runtimes start it via daemon/background process and check inbox.
+description: Resume a prior airc session in this scope. Alias for `airc join` with no args. Claude Code uses Monitor; Codex/non-Monitor runtimes start it as a session-local background process and check inbox.
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: ""

--- a/skills/uninstall/SKILL.md
+++ b/skills/uninstall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:uninstall
-description: Fully remove airc from this machine — stops processes, removes the daemon, deletes the clone, drops binary + skill symlinks. Confirm with the user before running; this is destructive.
+description: Fully remove airc from this machine — stops processes, removes legacy background registrations if present, deletes the clone, drops binary + skill symlinks. Confirm with the user before running; this is destructive.
 user-invocable: true
 allowed-tools: Bash
 argument-hint: "[--yes] [--purge]"
@@ -25,7 +25,7 @@ airc uninstall
 Walks the full removal in order:
 
 1. `airc teardown --all` — stops every running airc process across all scopes on this machine
-2. `airc daemon uninstall` — removes the launchd / systemd-user / Task Scheduler unit if present
+2. Removes any legacy background registration if present
 3. Removes binary forwarders: `~/.local/bin/{airc, relay, airc.cmd, airc.ps1}`
 4. Removes airc skill symlinks under `~/.claude/skills/`
 5. Removes the clone dir (`~/.airc-src` or `$AIRC_DIR`), including the `.venv` inside

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:update
-description: Pull the latest airc code and restart this scope's running airc process when needed. Claude Code uses Monitor; Codex/non-Monitor runtimes use daemon/background join plus inbox catch-up.
+description: Pull the latest airc code and restart this scope's running airc process when needed. Claude Code uses Monitor; Codex/non-Monitor runtimes use a session-local background join plus inbox catch-up.
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: ""
@@ -52,7 +52,7 @@ airc status
 airc inbox
 ```
 
-If `airc daemon status` shows an installed/running daemon for this scope, `airc teardown` plus the daemon may respawn the process by itself. Still run `airc status` after the bounce and run `airc inbox` for missed messages. Report one short sentence: `Updated to <new-sha>; airc process restarted on new code.`
+After the bounce, run `airc status` and `airc inbox` for missed messages. Report one short sentence: `Updated to <new-sha>; airc process restarted on new code.`
 
 ## Skill text changes are different — call out separately
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2019,7 +2019,7 @@ PY
   ( exec -a "airc connect" sleep 60 ) &
   local fake_airc_pid=$!
   echo "$fake_airc_pid" > "$home/airc.pid"
-  AIRC_HOME="$home" "$AIRC" msg "live monitor probe ascii" >"$out" 2>"$err"
+  AIRC_CLIENT_ID="test-client-live-monitor" AIRC_HOME="$home" "$AIRC" msg "live monitor probe ascii" >"$out" 2>"$err"
   rc=$?
   [ "$rc" = "0" ] \
     && pass "live-pid scope: send returns 0 (no false positive on liveness check)" \

--- a/test/test_monitor_formatter.py
+++ b/test/test_monitor_formatter.py
@@ -60,6 +60,7 @@ class AutoPongTests(unittest.TestCase):
         # Capture stdout to keep test output clean.
         with mock.patch.object(mf.sys, "stdin", io.StringIO(body)), \
              mock.patch.object(mf.sys, "stdout", io.StringIO()), \
+             mock.patch.object(mf, "current_client_id", return_value="test-client"), \
              mock.patch("subprocess.Popen", _FakePopen):
             mf.run("alice", self._peers)
 


### PR DESCRIPTION
## Summary
- remove the install-time daemon prompt/auto-install path; install stays lightweight and join-first
- deprecate `airc daemon` command surface: install/restart now refuse, status points users to `airc join`/`airc quit`, uninstall remains for legacy cleanup
- remove daemon recommendations from README, Codex integration docs, and agent skills
- refresh README/Codex docs for current join-first behavior, Codex hook digest, delivery markers, and broadcast encryption caveat
- fix monitor/unit CI drift by pinning test client_id and setting client_id in live-monitor integration assertion

## Validation
- `python3 test/test_monitor_formatter.py`
- `./airc doctor --tests python_units`
- `bash -n install.sh`
- `bash -n airc`
- `bash -n lib/airc_bash/cmd_send.sh`
- `bash -n lib/airc_bash/cmd_connect.sh`
- `bash -n lib/airc_bash/cmd_daemon.sh`
- `bash -n lib/airc_bash/cmd_doctor.sh`
- live no-daemon validation in continuum scope: `airc daemon install` refuses; foreground `airc join` recovered the scope and `airc status` reported fresh heartbeats on #cambriantech + #general

Note: the broad local integration suite still contains older gh-backed takeover/bounce failures unrelated to this PR; I stopped that run to avoid unnecessary gh churn. This PR addresses the current canary CI unit failure and removes daemon from default/public use.