### PR TITLE
Fix WSL join liveness detection

### DIFF
--- a/airc
+++ b/airc
@@ -507,6 +507,36 @@ _airc_scope_monitor_formatter_pids() {
   done
 }
 
+_airc_cmdline_is_monitor_wrapper() {
+  local cmd="${1:-}"
+  # Primary shape: a visible airc join/connect command.
+  echo "$cmd" | grep -Eq '(^|[[:space:]])/[^[:space:]]*/airc[[:space:]]+(connect|join)([[:space:]]|$)|(^|[[:space:]])airc[[:space:]]+(connect|join)([[:space:]]|$)|eval .*airc[[:space:]]+(connect|join)' \
+    && return 0
+
+  # WSL/Claude Monitor can preserve only the script path in `ps` even
+  # though the PID came from this scope's airc.pid. Accept that narrower
+  # shape only after pidfile ownership + kill -0 have already been proven
+  # by the caller.
+  echo "$cmd" | grep -Eq '(^|[[:space:]])/[^[:space:]]*/airc([[:space:]]|$)|(^|[[:space:]])airc([[:space:]]|$)'
+}
+
+_airc_pidfile_live_monitor_pids() {
+  local pidfile="${1:-}"
+  [ -f "$pidfile" ] || return 0
+  local p raw
+  raw=$(cat "$pidfile" 2>/dev/null)
+  for p in $raw; do
+    case "$p" in ''|*[!0-9]*) continue ;; esac
+    if kill -0 "$p" 2>/dev/null; then
+      local _cmd
+      _cmd=$(proc_cmdline "$p" 2>/dev/null || true)
+      if _airc_cmdline_is_monitor_wrapper "$_cmd"; then
+        printf '%s\n' "$p"
+      fi
+    fi
+  done
+}
+
 _monitor_alive_with_bearer_fallback() {
   local pidfile="${1:-}"
   local scope_dir
@@ -523,27 +553,19 @@ _monitor_alive_with_bearer_fallback() {
   # Mesh effectively partitioned with no diagnosis path.
   #
   # Fix: a PID is only "ours" if `kill -0` says alive AND its cmdline shapes
-  # like an airc connect/join wrapper. Same regex shape as cmd_teardown's
-  # parent-chain reaper (#446) — keeps the two paths in lockstep on what
-  # "an airc process" means. PID reuse → cmdline doesn't match → treat as
-  # dead, fall through to Phase 2 (scope formatter process evidence).
+  # like an airc wrapper. Same shape as cmd_teardown's parent-chain reaper
+  # (#446), with one WSL/Claude Monitor allowance: if the PID came from this
+  # scope's pidfile, a visible /path/to/airc wrapper is enough even when `ps`
+  # drops the join/connect argument. PID reuse → cmdline doesn't match →
+  # treat as dead, fall through to Phase 2 (scope formatter process evidence).
   if [ -f "$pidfile" ]; then
-    local p raw
-    raw=$(cat "$pidfile" 2>/dev/null)
-    for p in $raw; do
-      case "$p" in ''|*[!0-9]*) continue ;; esac
-      if kill -0 "$p" 2>/dev/null; then
-        local _cmd
-        _cmd=$(proc_cmdline "$p" 2>/dev/null || true)
-        if echo "$_cmd" | grep -Eq '(^|[[:space:]])/[^[:space:]]*/airc[[:space:]]+(connect|join)([[:space:]]|$)|(^|[[:space:]])airc[[:space:]]+(connect|join)([[:space:]]|$)|eval .*airc[[:space:]]+(connect|join)'; then
-          echo "yes"
-          return 0
-        fi
-        # PID alive but not airc-shaped — OS reused this PID after our
-        # monitor died (sleep/wake, container restart, etc.). Skip; let
-        # Phase 2 scope formatter process evidence decide.
-      fi
-    done
+    if [ -n "$(_airc_pidfile_live_monitor_pids "$pidfile" | head -1)" ]; then
+      echo "yes"
+      return 0
+    fi
+    # PID alive but not airc-shaped — OS reused this PID after our
+    # monitor died (sleep/wake, container restart, etc.). Skip; let
+    # Phase 2 scope formatter process evidence decide.
   else
     # No pidfile = monitor was never started (or already torn down).
     # Bearer-state fallback would lie in this case (stale state file

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -239,11 +239,11 @@ cmd_status() {
   local pidfile="$AIRC_WRITE_DIR/airc.pid"
   if [ "$(_monitor_alive_with_bearer_fallback "$pidfile")" = "yes" ]; then
     if [ -f "$pidfile" ]; then
-      local first_alive; first_alive=$(awk '{print $1}' "$pidfile" 2>/dev/null)
+      local first_alive; first_alive=$(_airc_pidfile_live_monitor_pids "$pidfile" | head -1)
       # Distinguish "alive per kill -0" (we have a verified PID) from
       # "alive per formatter process only" (kill -0 blind against the
       # pidfile, but the scope's monitor_formatter is visible by argv).
-      if kill -0 "$first_alive" 2>/dev/null; then
+      if [ -n "$first_alive" ] && kill -0 "$first_alive" 2>/dev/null; then
         monitor_state="AIRC background process running for scope (PID $first_alive)"
       else
         local _fmt_pid; _fmt_pid=$(_airc_scope_monitor_formatter_pids "$AIRC_WRITE_DIR" | head -1)

--- a/lib/airc_bash/cmd_update.sh
+++ b/lib/airc_bash/cmd_update.sh
@@ -238,7 +238,7 @@ cmd_version() {
   branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null)
   dirty=""
   [ -n "$(git -C "$dir" status --porcelain 2>/dev/null)" ] && dirty=" (dirty)"
-  echo "  airc ${sha}${dirty} on ${branch}"
-  [ -n "$subject" ] && echo "  ${subject}"
-  echo "  install: $dir"
+  printf '  airc %s%s on %s\n' "${sha:-unknown}" "$dirty" "${branch:-unknown}"
+  [ -n "$subject" ] && printf '  %s\n' "$subject"
+  printf '  install: %s\n' "$dir"
 }

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2040,6 +2040,31 @@ PY
     && pass "client_id send line is valid JSON with sig" \
     || fail "client_id send line is malformed JSON or missing fields: $(tail -1 "$home/messages.jsonl" 2>/dev/null)"
   kill "$fake_airc_pid" 2>/dev/null || true
+  wait "$fake_airc_pid" 2>/dev/null || true
+
+  # #511 regression: on Windows/WSL via Claude Code Monitor, ps can show
+  # a pidfile-owned live wrapper as just "/path/to/airc" without preserving
+  # the join/connect argument. That still proves liveness when the PID came
+  # from this scope's pidfile and kill -0 succeeds. Also cover multi-PID
+  # host pidfiles where stale siblings surround the live wrapper.
+  ( exec -a "/home/joel/.local/bin/airc" sleep 60 ) &
+  fake_airc_pid=$!
+  printf '99999 %s\n88888\n' "$fake_airc_pid" > "$home/airc.pid"
+  AIRC_CLIENT_ID="test-client-wsl-monitor" AIRC_HOME="$home" "$AIRC" msg "wsl wrapper live monitor probe" >"$out" 2>"$err"
+  rc=$?
+  [ "$rc" = "0" ] \
+    && pass "WSL-style pidfile-owned airc wrapper satisfies monitor liveness" \
+    || fail "WSL-style airc wrapper incorrectly rejected (rc=$rc, stderr=$(cat "$err"))"
+  grep -q 'wsl wrapper live monitor probe' "$home/messages.jsonl" \
+    && pass "WSL-style live wrapper: message appended to local log" \
+    || fail "WSL-style live wrapper: message NOT in log (log=$(cat "$home/messages.jsonl" 2>/dev/null))"
+  local status_out
+  status_out=$(AIRC_HOME="$home" "$AIRC" status 2>&1)
+  echo "$status_out" | grep -qE "airc process:\s+AIRC background process running for scope \\(PID $fake_airc_pid\\)" \
+    && pass "status reports the verified live PID from a multi-PID pidfile" \
+    || fail "status did not report verified live PID $fake_airc_pid (got: $status_out)"
+  kill "$fake_airc_pid" 2>/dev/null || true
+  wait "$fake_airc_pid" 2>/dev/null || true
 
   rm -f "$out" "$err"
   rm -rf /tmp/airc-it-sdmd


### PR DESCRIPTION
## Summary
- fix monitor liveness so pidfile-owned WSL/Claude Monitor wrappers that show as /path/to/airc still count as alive
- keep PID-reuse protection by requiring the PID to come from this scope airc.pid and pass kill -0 before accepting the narrower WSL command shape
- report the verified live PID in status, not just the first pidfile token
- harden airc version output with printf fallbacks

Fixes #511.

## Tests
- bash -n airc lib/airc_bash/cmd_status.sh lib/airc_bash/cmd_send.sh lib/airc_bash/cmd_update.sh test/integration.sh
- python3 test/test_scope_repair.py && python3 test/test_monitor_formatter.py
- ./airc doctor --tests python_units
- bash test/integration.sh send_dead_monitor_dies
- bash test/integration.sh monitor_liveness_process_evidence

## Windows Retest
After this lands on canary, Windows should run:

```bash
airc update --channel canary
airc join
airc version
airc status
airc daemon status
airc msg --channel general "windows ops-ok $(date -u +%FT%TZ)"
```

Expected: status reports a running AIRC process or formatter for the scope, and msg does not refuse with monitor down while the Monitor stream is alive.