### PR TITLE
Avoid pipefail in monitor pid lookup

### DIFF
--- a/airc
+++ b/airc
@@ -537,6 +537,24 @@ _airc_pidfile_live_monitor_pids() {
   done
 }
 
+_airc_pidfile_first_live_monitor_pid() {
+  local pidfile="${1:-}"
+  [ -f "$pidfile" ] || return 0
+  local p raw
+  raw=$(cat "$pidfile" 2>/dev/null)
+  for p in $raw; do
+    case "$p" in ''|*[!0-9]*) continue ;; esac
+    if kill -0 "$p" 2>/dev/null; then
+      local _cmd
+      _cmd=$(proc_cmdline "$p" 2>/dev/null || true)
+      if _airc_cmdline_is_monitor_wrapper "$_cmd"; then
+        printf '%s\n' "$p"
+        return 0
+      fi
+    fi
+  done
+}
+
 _monitor_alive_with_bearer_fallback() {
   local pidfile="${1:-}"
   local scope_dir
@@ -559,7 +577,7 @@ _monitor_alive_with_bearer_fallback() {
   # drops the join/connect argument. PID reuse → cmdline doesn't match →
   # treat as dead, fall through to Phase 2 (scope formatter process evidence).
   if [ -f "$pidfile" ]; then
-    if [ -n "$(_airc_pidfile_live_monitor_pids "$pidfile" | head -1)" ]; then
+    if [ -n "$(_airc_pidfile_first_live_monitor_pid "$pidfile")" ]; then
       echo "yes"
       return 0
     fi

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -239,7 +239,7 @@ cmd_status() {
   local pidfile="$AIRC_WRITE_DIR/airc.pid"
   if [ "$(_monitor_alive_with_bearer_fallback "$pidfile")" = "yes" ]; then
     if [ -f "$pidfile" ]; then
-      local first_alive; first_alive=$(_airc_pidfile_live_monitor_pids "$pidfile" | head -1)
+      local first_alive; first_alive=$(_airc_pidfile_first_live_monitor_pid "$pidfile")
       # Distinguish "alive per kill -0" (we have a verified PID) from
       # "alive per formatter process only" (kill -0 blind against the
       # pidfile, but the scope's monitor_formatter is visible by argv).


### PR DESCRIPTION
## Summary
- fix a follow-up shell bug from #512 where `_airc_pidfile_live_monitor_pids | head -1` can SIGPIPE under pipefail when a host pidfile has multiple live AIRC PIDs
- add `_airc_pidfile_first_live_monitor_pid` so liveness/status get the first verified PID without piping
- verified local `airc status` now prints full monitor/transport health instead of exiting after collaboration

## Tests
- bash -n airc lib/airc_bash/cmd_status.sh
- airc status in the continuum scope
- bash test/integration.sh send_dead_monitor_dies
- bash test/integration.sh monitor_liveness_process_evidence

Follow-up to #512 / #511.