### PR TITLE
Make attach mode own UI only

### DIFF
--- a/airc
+++ b/airc
@@ -11,6 +11,13 @@
 
 set -euo pipefail
 
+AIRC_SELF="${BASH_SOURCE[0]}"
+case "$AIRC_SELF" in
+  */*) AIRC_SELF="$(cd "$(dirname "$AIRC_SELF")" 2>/dev/null && pwd)/$(basename "$AIRC_SELF")" ;;
+  *)   AIRC_SELF="$(command -v "$AIRC_SELF" 2>/dev/null || printf '%s' "$AIRC_SELF")" ;;
+esac
+export AIRC_SELF
+
 # Cross-platform Python invocation. macOS / Linux / WSL all ship `python3`
 # on PATH; Git Bash on Windows typically has `python` only (the launcher
 # from python.org). Resolve once at startup; every `python3 ...` invocation

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -178,6 +178,46 @@ _join_attach_local_stream() {
   fi
 }
 
+_join_spawn_transport_for_attach() {
+  local _log="$AIRC_WRITE_DIR/airc-transport.log"
+  mkdir -p "$AIRC_WRITE_DIR"
+  echo ""
+  echo "  Starting scope-local AIRC transport in the background."
+  echo "  This terminal will attach to the local message stream."
+  (
+    AIRC_NO_ATTACH=1 AIRC_BACKGROUND_OK=1 "$AIRC_SELF" join "$@"
+  ) >>"$_log" 2>&1 &
+  local _transport_pid=$!
+  echo "  transport PID: $_transport_pid"
+  echo "  transport log: $_log"
+
+  local _pidfile="$AIRC_WRITE_DIR/airc.pid"
+  local _i
+  for _i in $(seq 1 30); do
+    if [ "$(_monitor_alive_with_bearer_fallback "$_pidfile")" = "yes" ]; then
+      _join_show_status_and_inbox
+      _join_attach_local_stream
+      return 0
+    fi
+    if ! kill -0 "$_transport_pid" 2>/dev/null; then
+      echo "  airc join: transport exited before it became healthy." >&2
+      if [ -s "$_log" ]; then
+        echo "  last transport log lines:" >&2
+        tail -25 "$_log" | sed 's/^/    /' >&2
+      fi
+      return 1
+    fi
+    sleep 1
+  done
+
+  echo "  airc join: transport did not become healthy within 30s." >&2
+  if [ -s "$_log" ]; then
+    echo "  last transport log lines:" >&2
+    tail -25 "$_log" | sed 's/^/    /' >&2
+  fi
+  return 1
+}
+
 _join_parent_chain_looks_like_claude_monitor() {
   local pid="$$" depth=0 parent="" cmd=""
   while [ -n "$pid" ] && [ "$pid" != "1" ] && [ "$depth" -lt 12 ]; do
@@ -194,6 +234,7 @@ _join_parent_chain_looks_like_claude_monitor() {
 }
 
 cmd_connect() {
+  local _orig_args=("$@")
   # Flag parsing. Issue #37 — host display shapes:
   #   default (gh installed + authed): gist ID + humanhash mnemonic + long invite
   #   default (no gh OR gh not authed): long invite only (today's behavior)
@@ -345,13 +386,14 @@ cmd_connect() {
     esac
   done
   set -- "${positional[@]+"${positional[@]}"}"
+  [ "${AIRC_NO_ATTACH:-0}" = "1" ] && attach=0
 
   # Plain `airc join` is the public UX. If the parent chain is Claude
   # Code, treat it as UI attach mode so a Monitor invocation remains a
   # visible event stream when transport is already alive. Codex/non-
   # Monitor runtimes keep the quick-return behavior unless they
   # explicitly set AIRC_ATTACH=1.
-  if [ "$attach" = "0" ]; then
+  if [ "$attach" = "0" ] && [ "${AIRC_NO_ATTACH:-0}" != "1" ]; then
     if [ "${AIRC_ATTACH:-0}" = "1" ] || _join_parent_chain_looks_like_claude_monitor; then
       attach=1
     fi
@@ -685,6 +727,19 @@ cmd_connect() {
     # Stale pidfile (no live airc processes — either dead, or PIDs were
     # reused by the OS for unrelated procs). Safe to clean.
     rm -f "$stale_pidfile"
+  fi
+
+  # UI attach mode should not make the Claude/WSL Monitor shell own the
+  # transport lifetime. On Windows WSL2, Claude Code launches Monitor
+  # commands through `wsl bash -lc ...`; that wrapper can disappear and
+  # take foreground shell subprocesses with it even after airc printed
+  # "Monitoring for messages...". Start the transport as a scope-local
+  # background owner, verify it, then attach this UI process to the
+  # local message stream. This is not an OS daemon; it is the same
+  # project-scope airc process `airc quit`/`airc teardown` manage.
+  if [ "$attach" = "1" ] && [ "${AIRC_NO_ATTACH:-0}" != "1" ]; then
+    _join_spawn_transport_for_attach "${_orig_args[@]}"
+    return $?
   fi
 
   # No resume code path. (#130, 2026-04-26.)

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -14,10 +14,10 @@ Audience: Claude Code, Codex, future agent runtimes. Optimized for parse-and-act
 
 If you are Claude Code and this skill was invoked by `/join` or `/airc:join`, your first tool call MUST be:
 ```
-Monitor(persistent=true, description="airc", command="airc join")
+Monitor(persistent=true, description="airc", command="airc join --attach")
 ```
 
-Do not replace that with `Bash(airc status ...)` or `Bash(airc inbox ...)`. Plain `airc join` auto-detects Claude Monitor and attaches when a transport process is alive; it also prints status + inbox. The user should see a Monitor task.
+Do not replace that with `Bash(airc status ...)` or `Bash(airc inbox ...)`. `--attach` starts or verifies the scope's transport owner, then attaches the Monitor UI to the local stream. The user should see a Monitor task.
 
 ## Substrate facts
 
@@ -65,7 +65,7 @@ Don't default-stamp project chatter onto the lobby. It drowns out cross-room sig
 
 **Claude Code:** wrap in Monitor for streaming events:
 ```
-Monitor(persistent=true, description="airc", command="airc join")
+Monitor(persistent=true, description="airc", command="airc join --attach")
 ```
 Keep `description="airc"` — the headline shown in the UI is built from it. Plain `airc join` creates the live AIRC stream for the scope.
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2128,6 +2128,61 @@ PY
   cleanup_all
 }
 
+# ── Scenario: attach_starts_background_transport ──────────────────────
+# Claude/WSL Monitor should be a UI stream, not the owner of transport
+# lifetime. `airc join --attach` starts a scope-local background
+# transport, verifies it, then attaches to messages.jsonl.
+scenario_attach_starts_background_transport() {
+  section "attach_starts_background_transport: UI attach is not the transport owner"
+  cleanup_all
+
+  local home=/tmp/airc-it-attach/state
+  local out=/tmp/airc-it-attach/out.log
+  local err=/tmp/airc-it-attach/err.log
+  mkdir -p /tmp/airc-it-attach
+
+  AIRC_HOME="$home" AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 \
+    "$AIRC" join --attach --no-room --no-gist >"$out" 2>"$err" &
+  local ui_pid=$!
+
+  local seen=0 status_out="" i
+  for i in $(seq 1 20); do
+    status_out=$(AIRC_HOME="$home" "$AIRC" status 2>&1 || true)
+    if echo "$status_out" | grep -qE 'airc process:\s+AIRC background process running for scope'; then
+      seen=1
+      break
+    fi
+    if ! kill -0 "$ui_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+
+  [ "$seen" = "1" ] \
+    && pass "attach mode starts a verified scope-local background transport" \
+    || fail "attach mode did not start transport (status=$status_out; stdout=$(cat "$out" 2>/dev/null); stderr=$(cat "$err" 2>/dev/null))"
+  kill -0 "$ui_pid" 2>/dev/null \
+    && pass "attach UI process stays alive after transport starts" \
+    || fail "attach UI process exited early (stdout=$(cat "$out" 2>/dev/null); stderr=$(cat "$err" 2>/dev/null))"
+  local attached=0
+  for i in $(seq 1 10); do
+    if grep -q 'airc: attached to local message stream for this scope' "$out"; then
+      attached=1
+      break
+    fi
+    sleep 1
+  done
+  [ "$attached" = "1" ] \
+    && pass "attach UI stream is active" \
+    || fail "attach UI stream did not announce attachment (stdout=$(cat "$out" 2>/dev/null))"
+
+  kill "$ui_pid" 2>/dev/null || true
+  wait "$ui_pid" 2>/dev/null || true
+  AIRC_HOME="$home" "$AIRC" teardown >/dev/null 2>&1 || true
+  rm -rf /tmp/airc-it-attach
+  cleanup_all
+}
+
 # ── Scenario: gh_secondary_rate_limit_degraded_startup (#479) ──────────
 # GitHub secondary throttling must not prevent monitor startup. On
 # 2026-05-04 Windows/WSL hit this shape: `gh auth status` tripped the
@@ -4418,6 +4473,7 @@ case "$MODE" in
   auto_scope)   scenario_auto_scope ;;
   send_dead_monitor_dies) scenario_send_dead_monitor_dies ;;
   monitor_liveness_process_evidence) scenario_monitor_liveness_process_evidence ;;
+  attach_starts_background_transport) scenario_attach_starts_background_transport ;;
   gh_secondary_rate_limit_degraded_startup) scenario_gh_secondary_rate_limit_degraded_startup ;;
   solo_mesh_warns) scenario_solo_mesh_warns ;;
   connect_after_kill_recovers) scenario_connect_after_kill_recovers ;;
@@ -4454,6 +4510,7 @@ case "$MODE" in
     scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat
     scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope
     scenario_send_dead_monitor_dies; scenario_monitor_liveness_process_evidence
+    scenario_attach_starts_background_transport
     scenario_gh_secondary_rate_limit_degraded_startup
     scenario_solo_mesh_warns
     scenario_connect_after_kill_recovers


### PR DESCRIPTION
## Summary
- make Claude `/join` invoke `airc join --attach` explicitly instead of relying on parent-chain detection across WSL
- change attach mode so it starts a scope-local background transport with `AIRC_BACKGROUND_OK=1`, verifies liveness, then execs the local UI attach stream
- add `AIRC_NO_ATTACH` for the internal child transport so it cannot recursively attach
- add an integration scenario proving attach mode starts verified background transport and keeps the UI stream active

This is a follow-up for #511 after Windows showed that the Claude Monitor `wsl bash -lc airc join` wrapper can disappear and leave no WSL-side airc/python processes alive. The new model makes the Monitor process UI-only; the transport is a project-scope airc process managed by `airc quit` / `airc teardown`, not an OS daemon.

## Tests
- bash -n airc lib/airc_bash/cmd_connect.sh test/integration.sh
- git diff --check
- python3 test/test_monitor_formatter.py && python3 test/test_scope_repair.py
- ./airc doctor --tests python_units
- bash test/integration.sh send_dead_monitor_dies
- bash test/integration.sh attach_starts_background_transport
- local no-GitHub attach smoke: `airc join --attach --no-room --no-gist` => status reported `AIRC background process running`; teardown cleaned it

## Windows retest
After merge to canary:
```bash
airc update --channel canary
airc join --attach
airc version
airc status
airc msg --channel general "windows ops-ok $(date -u +%FT%TZ)"
```

Expected: `airc status` shows an AIRC process running even if the Claude Monitor wrapper would otherwise disappear, and `airc msg` does not refuse with monitor down.