### PR TITLE
Dedupe monitor mirror by signature

### DIFF
--- a/lib/airc_core/monitor_formatter.py
+++ b/lib/airc_core/monitor_formatter.py
@@ -311,6 +311,24 @@ def run(my_name: str, peers_dir: str) -> int:
     local_log = os.path.join(scope_dir, "messages.jsonl")
     offset_path = os.path.join(scope_dir, "monitor_offset")
     client_id = current_client_id()
+    seen_sigs: set[str] = set()
+
+    def _load_seen_sigs(limit: int = 5000) -> None:
+        try:
+            with open(local_log, encoding="utf-8", errors="replace") as f:
+                lines = f.readlines()[-limit:]
+        except Exception:
+            return
+        for raw in lines:
+            try:
+                obj = json.loads(raw)
+            except Exception:
+                continue
+            sig = obj.get("sig")
+            if isinstance(sig, str) and sig:
+                seen_sigs.add(sig)
+
+    _load_seen_sigs()
 
     # Host vs joiner detection drives the watchdog gate below. host_target
     # empty = we are the host (we publish the room gist; joiners poll us);
@@ -457,6 +475,15 @@ def run(my_name: str, peers_dir: str) -> int:
             # readable content even though the wire was ciphertext.
             line = json.dumps(m)
         msg = m.get("msg", "")
+        sig = m.get("sig")
+        if isinstance(sig, str) and sig and sig in seen_sigs:
+            # Idempotent mirror boundary. Host-mode sends append locally
+            # immediately, then the host's own gist bearer can receive the
+            # exact same signed envelope back from the wire. Duplicate
+            # bearer processes can also replay the same line. The signature
+            # is the stable envelope identity, so if it is already in the
+            # local audit log, skip both mirror and display.
+            continue
         # Filter only this runtime's own sends. Multiple agents can share
         # one .airc scope and therefore one nick; filtering by `from`
         # hides same-scope collaborators. New sends may carry client_id
@@ -477,6 +504,8 @@ def run(my_name: str, peers_dir: str) -> int:
         try:
             with open(local_log, "a") as f:
                 f.write(line + "\n")
+            if isinstance(sig, str) and sig:
+                seen_sigs.add(sig)
         except Exception:
             pass
         # Rotate every ~100 mirrored lines. Without this, local logs

--- a/test/test_monitor_formatter.py
+++ b/test/test_monitor_formatter.py
@@ -220,6 +220,62 @@ class HeartbeatSuppressionTests(unittest.TestCase):
         self.assertEqual(out.getvalue(), "", "heartbeat must produce zero stdout output")
 
 
+class MirrorDedupeTests(unittest.TestCase):
+    """Host self-echo and duplicate bearer reads must not append or display
+    the same signed envelope twice."""
+
+    def setUp(self):
+        self._scope = tempfile.mkdtemp(prefix="airc-mf-dedupe-test-")
+        self._peers = os.path.join(self._scope, "peers")
+        os.makedirs(self._peers, exist_ok=True)
+        with open(os.path.join(self._scope, "config.json"), "w") as f:
+            json.dump({"name": "alice", "subscribed_channels": ["general"]}, f)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._scope, ignore_errors=True)
+
+    def _run(self, lines):
+        body = "\n".join(json.dumps(l) for l in lines) + "\n"
+        out = io.StringIO()
+        with mock.patch.object(mf.sys, "stdin", io.StringIO(body)), \
+             mock.patch.object(mf.sys, "stdout", out), \
+             mock.patch.object(mf, "current_client_id", return_value="test-client"):
+            mf.run("alice", self._peers)
+        return out.getvalue()
+
+    def test_duplicate_signature_in_stream_appends_once_and_displays_once(self):
+        msg = {
+            "from": "bob",
+            "to": "all",
+            "ts": "2026-05-05T05:42:03Z",
+            "channel": "general",
+            "msg": "hello once",
+            "client_id": "agent:bob",
+            "sig": "same-signature",
+        }
+        out = self._run([msg, dict(msg)])
+        self.assertEqual(out.count("hello once"), 1)
+        local_log = Path(self._scope) / "messages.jsonl"
+        self.assertEqual(local_log.read_text(encoding="utf-8").count("same-signature"), 1)
+
+    def test_signature_already_in_local_log_is_not_mirrored_or_displayed(self):
+        msg = {
+            "from": "alice",
+            "to": "all",
+            "ts": "2026-05-05T05:42:03Z",
+            "channel": "general",
+            "msg": "self echo",
+            "client_id": "other-tab",
+            "sig": "already-local",
+        }
+        local_log = Path(self._scope) / "messages.jsonl"
+        local_log.write_text(json.dumps(msg) + "\n", encoding="utf-8")
+        out = self._run([msg])
+        self.assertNotIn("self echo", out)
+        self.assertEqual(local_log.read_text(encoding="utf-8").count("already-local"), 1)
+
+
 class DisplayFilterLoudDropTests(unittest.TestCase):
     """#399 follow-up to #401: when monitor_formatter's display filter
     drops a peer broadcast (channel name truly differs, e.g.


### PR DESCRIPTION
## Summary
- prevent monitor_formatter from appending/displaying the same signed envelope twice
- load recent local `messages.jsonl` signatures at startup and treat `sig` as the envelope identity
- skip mirror+display when a gist receive replays a signature already present locally
- cover host self-echo and duplicate bearer reads with unit tests

Observed during the coordinated Mac reset after #514: raw `messages.jsonl` contained duplicate identical `sig` lines for `mac-reset-ok` and follow-up broadcasts. This patch fixes the mirror boundary instead of asking each sender path to avoid every possible echo.

## Tests
- python3 test/test_monitor_formatter.py
- ./airc doctor --tests python_units
- bash -n airc lib/airc_bash/cmd_connect.sh test/integration.sh
- git diff --check

Follow-up from #511/#514 validation.