### PR TITLE
Harden attach argument forwarding

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -766,7 +766,7 @@ cmd_connect() {
   # local message stream. This is not an OS daemon; it is the same
   # project-scope airc process `airc quit`/`airc teardown` manage.
   if [ "$attach" = "1" ] && [ "${AIRC_NO_ATTACH:-0}" != "1" ]; then
-    _join_spawn_transport_for_attach "${_orig_args[@]}"
+    _join_spawn_transport_for_attach ${_orig_args[@]+"${_orig_args[@]}"}
     return $?
   fi
 


### PR DESCRIPTION
## Summary
- harden attach transport argument forwarding when the original argv is empty
- keep the attach startup-grace fix from #516 compatible with older bash/set-u expansion semantics

## Validation
- bash -n lib/airc_bash/cmd_connect.sh airc test/integration.sh
- git diff --check origin/canary..HEAD
