### PR TITLE
Dedupe local signed log appends

### DIFF
--- a/airc
+++ b/airc
@@ -1399,7 +1399,7 @@ _monitor_multi_channel() {
             fi
           fi
         done
-        _pids=("${_alive[@]}")
+        _pids=(${_alive[@]+"${_alive[@]}"})
 
         # Live channel-map refresh. `airc join --room X` can add a
         # channel while the monitor is already healthy; pre-fix the
@@ -1430,7 +1430,7 @@ _monitor_multi_channel() {
             fi
             _kept+=("$entry")
           done
-          _pids=("${_kept[@]}")
+          _pids=(${_kept[@]+"${_kept[@]}"})
 
           # Build the set of gists currently served by live bearers,
           # so the add-loop doesn't double-spawn for a gist that's

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -226,6 +226,12 @@ cmd_send() {
     && die "empty message body (use 'airc msg <text>' or omit the empty quotes)"
   ensure_init
 
+  _airc_append_local_signed() {
+    if ! printf '%s\n' "$1" | "$AIRC_PYTHON" -m airc_core.log_append append --path "$MESSAGES" >/dev/null; then
+      echo "$1" >> "$MESSAGES"
+    fi
+  }
+
   local my_name ts_val
   my_name=$(get_name)
   ts_val=$(timestamp)
@@ -275,7 +281,7 @@ cmd_send() {
     # audit log of what they sent — the alternative would force `airc
     # logs` to decrypt own outbound, which is silly). Wire form may be
     # encrypted below if the recipient has a stored x25519_pub.
-    echo "$full_msg" >> "$MESSAGES"
+    _airc_append_local_signed "$full_msg"
 
     # Phase E.3: wrap the wire envelope with envelope-layer encryption
     # if we have the recipient's X25519 pubkey on file. Empty pubkey =
@@ -490,7 +496,7 @@ cmd_send() {
       # multi-scope state) would give the rename feature a worse UX
       # than no-propagation had.
       if [ "$internal" = "1" ]; then
-        echo "$full_msg" >> "$MESSAGES"
+        _airc_append_local_signed "$full_msg"
         date +%s > "$AIRC_WRITE_DIR/last_sent" 2>/dev/null
         rm -f "$AIRC_WRITE_DIR/reminded" 2>/dev/null
         return 0
@@ -562,7 +568,10 @@ cmd_send() {
           # this happened unconditionally before the publish attempt, so
           # the user's own monitor would echo their message back even when
           # joiners never saw it — false success surface (#381 RCA).
-          echo "$full_msg" >> "$MESSAGES"
+          # GhBearer.send already writes to the local bus. The monitor mirrors
+          # that signed envelope into messages.jsonl; appending here races with
+          # the mirror and creates duplicate local audit rows.
+          :
           ;;
         auth_failure)
           # Hard failure mirror of joiner branch above. Don't queue —
@@ -659,7 +668,7 @@ cmd_send() {
       esac
     else
       echo "  ⚠ No room_gist_id set ($AIRC_WRITE_DIR/room_gist_id missing) — host send is local-only." >&2
-      echo "$full_msg" >> "$MESSAGES"
+      _airc_append_local_signed "$full_msg"
     fi
   fi
 

--- a/lib/airc_core/log_append.py
+++ b/lib/airc_core/log_append.py
@@ -1,0 +1,114 @@
+"""Idempotent appends for airc messages.jsonl."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+LOCK_STALE_SEC = 30.0
+LOCK_WAIT_SEC = 5.0
+LOCK_SLEEP_SEC = 0.05
+TAIL_LIMIT = 5000
+
+
+def _line_sig(line: str) -> str:
+    try:
+        obj = json.loads(line)
+    except Exception:
+        return ""
+    sig = obj.get("sig")
+    return sig if isinstance(sig, str) else ""
+
+
+def _recent_sigs(path: str, limit: int = TAIL_LIMIT) -> set[str]:
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()[-limit:]
+    except (FileNotFoundError, OSError):
+        return set()
+    sigs: set[str] = set()
+    for raw in lines:
+        sig = _line_sig(raw)
+        if sig:
+            sigs.add(sig)
+    return sigs
+
+
+def _acquire_lock(path: str) -> str:
+    lock_path = f"{path}.lock"
+    deadline = time.time() + LOCK_WAIT_SEC
+    payload = f"{os.getpid()}\n".encode("ascii", errors="replace")
+    while True:
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            try:
+                os.write(fd, payload)
+            finally:
+                os.close(fd)
+            return lock_path
+        except FileExistsError:
+            try:
+                age = time.time() - os.path.getmtime(lock_path)
+                if age > LOCK_STALE_SEC:
+                    os.unlink(lock_path)
+                    continue
+            except FileNotFoundError:
+                continue
+            except OSError:
+                pass
+            if time.time() >= deadline:
+                raise TimeoutError(f"timed out waiting for log lock: {lock_path}")
+            time.sleep(LOCK_SLEEP_SEC)
+
+
+def append_unique_sig(path: str, line: str) -> str:
+    """Append `line`, skipping if its JSON sig already exists in the log tail."""
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    framed = line if line.endswith("\n") else line + "\n"
+    sig = _line_sig(framed)
+    lock_path = _acquire_lock(path)
+    try:
+        if sig and sig in _recent_sigs(path):
+            return "skipped"
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            os.write(fd, framed.encode("utf-8"))
+        finally:
+            os.close(fd)
+        return "appended"
+    finally:
+        try:
+            os.unlink(lock_path)
+        except OSError:
+            pass
+
+
+def cmd_append(args) -> int:
+    line = sys.stdin.read()
+    if not line:
+        return 0
+    try:
+        print(append_unique_sig(args.path, line))
+    except Exception as e:
+        print(f"airc-log-append: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="airc_core.log_append")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    append = sub.add_parser("append")
+    append.add_argument("--path", required=True)
+    append.set_defaults(func=cmd_append)
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/airc_core/monitor_formatter.py
+++ b/lib/airc_core/monitor_formatter.py
@@ -25,6 +25,7 @@ import sys
 import time
 
 from airc_core.client_id import current_client_id
+from airc_core.log_append import append_unique_sig
 
 # Inactivity watchdog: if no inbound line arrives in WATCHDOG_SEC,
 # exit with a distinct code so the caller's while-loop reconnects.
@@ -484,13 +485,6 @@ def run(my_name: str, peers_dir: str) -> int:
             # is the stable envelope identity, so if it is already in the
             # local audit log, skip both mirror and display.
             continue
-        # Filter only this runtime's own sends. Multiple agents can share
-        # one .airc scope and therefore one nick; filtering by `from`
-        # hides same-scope collaborators. New sends may carry client_id
-        # from CODEX_THREAD_ID / CLAUDE_* / AIRC_CLIENT_ID; old messages
-        # without client_id are displayed rather than silently dropped.
-        if client_id and m.get("client_id") == client_id:
-            continue
         # Mirror inbound to local messages.jsonl. Post-3c (gh substrate)
         # the gist is the canonical source of truth for ALL peers — the
         # "host" no longer has a privileged local log that everyone tails
@@ -502,12 +496,20 @@ def run(my_name: str, peers_dir: str) -> int:
         # [PONG:uuid] and timed out forever) and any other reader of
         # the local audit trail.
         try:
-            with open(local_log, "a") as f:
-                f.write(line + "\n")
+            result = append_unique_sig(local_log, line)
             if isinstance(sig, str) and sig:
                 seen_sigs.add(sig)
+            if result == "skipped":
+                continue
         except Exception:
             pass
+        # Filter only this runtime's own sends from display, not from the
+        # audit log. Multiple agents can share one .airc scope and therefore
+        # one nick; filtering by `from` hides same-scope collaborators. New
+        # sends may carry client_id from CODEX_THREAD_ID / CLAUDE_* /
+        # AIRC_CLIENT_ID; old messages without client_id are displayed.
+        if client_id and m.get("client_id") == client_id:
+            continue
         # Rotate every ~100 mirrored lines. Without this, local logs
         # grow forever (Joel's audit 2026-04-28).
         if (offset_counter % 100) == 0:

--- a/test/test_monitor_formatter.py
+++ b/test/test_monitor_formatter.py
@@ -275,6 +275,21 @@ class MirrorDedupeTests(unittest.TestCase):
         self.assertNotIn("self echo", out)
         self.assertEqual(local_log.read_text(encoding="utf-8").count("already-local"), 1)
 
+    def test_own_client_message_is_mirrored_but_not_displayed(self):
+        msg = {
+            "from": "alice",
+            "to": "all",
+            "ts": "2026-05-05T05:42:03Z",
+            "channel": "general",
+            "msg": "own audit only",
+            "client_id": "test-client",
+            "sig": "own-client-sig",
+        }
+        out = self._run([msg])
+        self.assertNotIn("own audit only", out)
+        local_log = Path(self._scope) / "messages.jsonl"
+        self.assertEqual(local_log.read_text(encoding="utf-8").count("own-client-sig"), 1)
+
 
 class DisplayFilterLoudDropTests(unittest.TestCase):
     """#399 follow-up to #401: when monitor_formatter's display filter


### PR DESCRIPTION
## Summary
- add an idempotent signed-envelope append helper for local messages.jsonl
- mirror own-client messages into the audit log while suppressing display echo
- stop host send from racing the monitor mirror after gh/local-bus delivery
- harden bearer supervisor empty-array assignments for macOS bash 3.2 + set -u

## Validation
- bash -n airc lib/airc_bash/cmd_send.sh lib/airc_bash/cmd_connect.sh lib/airc_bash/cmd_teardown.sh test/integration.sh
- git diff --check
- python3 test/test_monitor_formatter.py
- ./airc doctor --tests python_units
- real continuum scope: nohup background join stayed healthy >70s; marker delivered once (delta=1)

## Not in this PR
- startup serialization for two simultaneous stale-host takeovers. I tried a scope lock and rejected it after live testing because it still allowed competing host owners through the re-exec path. That needs a cleaner design, not a half patch.
