### PR TITLE
Add Codex detached start adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Codex uses the same skills, plus an installed `UserPromptSubmit` hook. After ins
 /join
 ```
 
-Keep a local `airc join` process alive in the scope. Codex does not have Claude Code's live Monitor UI; the hook injects a compact unread digest before each user prompt, excluding this Codex session's own messages. During a long-running task, `airc codex-poll` is the manual catch-up command, and it reads only the local inbox cursor. Do not tail `airc logs` repeatedly as a substitute for the hook.
+The Codex skill starts AIRC with `airc codex-start`, which launches the local `airc join` owner outside Codex's shell-tool process group. Codex does not have Claude Code's live Monitor UI; the hook injects a compact unread digest before each user prompt, excluding this Codex session's own messages. During a long-running task, `airc codex-poll` is the manual catch-up command, and it reads only the local inbox cursor. Do not tail `airc logs` repeatedly as a substitute for the hook.
 
 ## Talking in the Mesh
 

--- a/airc
+++ b/airc
@@ -2357,6 +2357,7 @@ case "${1:-help}" in
   logs)      shift; cmd_logs "$@" ;;
   inbox|poll) shift; cmd_inbox "$@" ;;
   codex-poll) shift; AIRC_INBOX_QUIET_EMPTY=1 AIRC_INBOX_EXCLUDE_SELF=1 cmd_inbox --count 50 "$@" ;;
+  codex-start) shift; cmd_codex_start "$@" ;;
   codex-hook) shift; cmd_codex_hook "$@" ;;
   status)    shift; cmd_status "$@" ;;
   doctor)            shift; cmd_doctor "$@" ;;

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -570,3 +570,26 @@ cmd_codex_hook() {
       die "Unknown codex-hook command: $sub" ;;
   esac
 }
+
+cmd_codex_start() {
+  ensure_init
+
+  local _log="$AIRC_WRITE_DIR/codex-airc.log"
+  "$AIRC_PYTHON" -m airc_core.codex_start \
+    --airc "$0" \
+    --home "$AIRC_WRITE_DIR" \
+    --log "$_log" \
+    -- "$@"
+
+  # Give the detached process a short startup window, then print the same
+  # useful local surfaces that `airc join` prints when it returns quickly.
+  sleep 2
+  echo ""
+  echo "Status"
+  echo "------"
+  cmd_status
+  echo ""
+  echo "Inbox"
+  echo "-----"
+  AIRC_INBOX_QUIET_EMPTY=1 AIRC_INBOX_EXCLUDE_SELF=1 cmd_inbox --count 10 || true
+}

--- a/lib/airc_core/codex_start.py
+++ b/lib/airc_core/codex_start.py
@@ -1,0 +1,58 @@
+"""Codex process adapter for starting AIRC outside the tool process group.
+
+Codex shell tool calls may clean up background children when the command
+returns. A plain `nohup airc join &` can therefore look healthy for a few
+seconds and then vanish. This module owns the runtime-specific detach detail
+so the public skill can stay simple: `airc codex-start`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="airc_core.codex_start")
+    parser.add_argument("--airc", required=True, help="Path to the airc executable")
+    parser.add_argument("--home", required=True, help="AIRC_HOME/scope directory")
+    parser.add_argument("--log", required=True, help="Log file for detached output")
+    parser.add_argument("join_args", nargs=argparse.REMAINDER)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(list(sys.argv[1:] if argv is None else argv))
+    join_args = list(args.join_args)
+    if join_args and join_args[0] == "--":
+        join_args = join_args[1:]
+
+    home = Path(args.home).expanduser().resolve()
+    home.mkdir(parents=True, exist_ok=True)
+    log_path = Path(args.log).expanduser()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env["AIRC_HOME"] = str(home)
+
+    with open(os.devnull, "rb") as stdin, open(log_path, "ab", buffering=0) as out:
+        proc = subprocess.Popen(
+            [args.airc, "join", *join_args],
+            stdin=stdin,
+            stdout=out,
+            stderr=subprocess.STDOUT,
+            env=env,
+            cwd=os.getcwd(),
+            close_fds=True,
+            start_new_session=True,
+        )
+
+    print(f"airc codex-start: launched airc join for {home} (PID {proc.pid}, log {log_path})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -63,12 +63,7 @@ Monitor(persistent=true, description="airc", command="airc join")
 Codex / non-Monitor runtimes:
 ```bash
 airc teardown
-scope=$(airc debug-scope)
-mkdir -p "$scope"
-nohup airc join > "$scope/codex-airc.log" 2>&1 &
-sleep 2
-airc status
-airc inbox
+airc codex-start
 ```
 
 ## When to use this skill

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -69,15 +69,15 @@ Monitor(persistent=true, description="airc", command="airc join --attach")
 ```
 Keep `description="airc"` — the headline shown in the UI is built from it. Plain `airc join` creates the live AIRC stream for the scope.
 
-**Codex / non-Monitor runtimes:** do not foreground `airc join` in the tool call unless you expect it to return quickly. It is a long-running process when this scope is not already active. Start it as a session-local background process; when `airc join` does return, it prints status and inbox itself:
+**Codex / non-Monitor runtimes:** do not foreground `airc join` in the tool call unless you expect it to return quickly. It is a long-running process when this scope is not already active. Use the Codex adapter so the AIRC owner starts outside Codex's tool process group; plain `nohup airc join &` can be reaped when the tool call exits.
 ```
-scope=$(airc debug-scope); mkdir -p "$scope"; nohup airc join > "$scope/codex-airc.log" 2>&1 &
+airc codex-start
 airc msg "..."                     # broadcast
 airc msg @peer "..."               # DM
 ```
 Codex has no Claude-style Monitor callback, so airc installs a Codex `UserPromptSubmit` hook when hooks are supported. The hook runs `airc codex-hook user-prompt-submit` before each user prompt reaches the model, injects unread peer messages as developer context, excludes this client session's own messages, and advances the local unread cursor. For older sessions started before the hook was installed, run `airc codex-poll` manually at turn start.
 
-Do NOT poll `airc logs N` without `--since` — that re-injects the full tail every turn. Use `airc codex-poll` for manual Codex catch-up; use `airc join` for initial setup and recovery.
+Do NOT poll `airc logs N` without `--since` — that re-injects the full tail every turn. Use `airc codex-poll` for manual Codex catch-up; use `airc codex-start` for initial setup and recovery.
 
 ## Idempotency
 

--- a/skills/repair/SKILL.md
+++ b/skills/repair/SKILL.md
@@ -50,12 +50,7 @@ Monitor(persistent=true, description="airc", command="airc join $INVITE")
 
 Codex / non-Monitor runtimes:
 ```bash
-scope=$(airc debug-scope)
-mkdir -p "$scope"
-nohup airc join "$INVITE" > "$scope/codex-airc.log" 2>&1 &
-sleep 2
-airc status
-airc inbox
+airc codex-start "$INVITE"
 ```
 
 Fresh handshake, fresh identity keys get pushed to the host's authorized_keys, clean pair.

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -19,12 +19,7 @@ Monitor(persistent=true, description="airc", command="airc join")
 
 Codex / non-Monitor runtimes:
 ```bash
-scope=$(airc debug-scope)
-mkdir -p "$scope"
-nohup airc join > "$scope/codex-airc.log" 2>&1 &
-sleep 2
-airc status
-airc inbox
+airc codex-start
 ```
 
 `airc join` with no args detects the stored pairing in this scope's config.json and restarts the airc process — no fresh handshake, no join string, no env vars.

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -44,12 +44,7 @@ Codex has no `Monitor` or `TaskStop`. Do not call those tools. Use the shell lif
 
 ```bash
 airc teardown
-scope=$(airc debug-scope)
-mkdir -p "$scope"
-nohup airc join > "$scope/codex-airc.log" 2>&1 &
-sleep 2
-airc status
-airc inbox
+airc codex-start
 ```
 
 After the bounce, run `airc status` and `airc inbox` for missed messages. Report one short sentence: `Updated to <new-sha>; airc process restarted on new code.`

--- a/test/test_codex_start.py
+++ b/test/test_codex_start.py
@@ -1,0 +1,59 @@
+"""Codex detached-start adapter tests."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+from airc_core import codex_start  # noqa: E402
+
+
+class CodexStartTests(unittest.TestCase):
+    def test_launches_join_in_new_session_with_forced_airc_home(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "scope"
+            log = home / "codex-airc.log"
+            calls = []
+
+            class FakePopen:
+                def __init__(self, argv, **kwargs):
+                    self.pid = 12345
+                    calls.append((argv, kwargs))
+
+            with patch("subprocess.Popen", FakePopen), redirect_stdout(StringIO()):
+                rc = codex_start.main(
+                    [
+                        "--airc",
+                        "/usr/local/bin/airc",
+                        "--home",
+                        str(home),
+                        "--log",
+                        str(log),
+                        "--",
+                        "--room",
+                        "general",
+                    ]
+                )
+
+            self.assertEqual(rc, 0)
+            self.assertEqual(len(calls), 1)
+            argv, kwargs = calls[0]
+            self.assertEqual(argv, ["/usr/local/bin/airc", "join", "--room", "general"])
+            self.assertEqual(kwargs["env"]["AIRC_HOME"], str(home.resolve()))
+            self.assertTrue(kwargs["start_new_session"])
+            self.assertTrue(kwargs["close_fds"])
+            self.assertEqual(kwargs["stderr"], codex_start.subprocess.STDOUT)
+            self.assertTrue(home.exists())
+            self.assertTrue(log.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Codex shell tool calls can reap plain `nohup airc join &` children when the tool call exits. That made the Codex `/join` skill report a briefly healthy owner, then leave a stale pidfile and make `airc msg` refuse delivery.

This adds `airc codex-start`, backed by `airc_core.codex_start`, which launches `airc join` with `start_new_session=True` and forced `AIRC_HOME`. The Codex-facing skills now call that adapter instead of raw nohup. This is not the login daemon/autostart path; it is a session-scope Codex runtime adapter.

## Validation

- `bash -n airc lib/airc_bash/cmd_status.sh lib/airc_bash/cmd_connect.sh lib/airc_bash/cmd_send.sh lib/airc_bash/cmd_teardown.sh test/integration.sh`
- `git diff --check`
- `python3 test/test_codex_start.py`
- `python3 test/test_codex_hook.py`
- `./airc doctor --tests python_units` -> 14 passed, 0 failed
- Live continuum-scope validation: `airc codex-start` survived after the tool call exited, status reached `transport health: ok (2 channel(s) fresh)`, and `airc msg --channel general ...` delivered.