### PR TITLE
fix(attach): strip --attach from forwarded argv before recursive airc join

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -201,8 +201,26 @@ _join_spawn_transport_for_attach() {
   echo ""
   echo "  Starting scope-local AIRC transport in the background."
   echo "  This terminal will attach to the local message stream."
+  # Strip --attach / -attach from the forwarded argv. The child runs with
+  # AIRC_NO_ATTACH=1 (set below), so the flag is redundant; worse, leaving
+  # it in causes the child's parser to treat --attach as the positional
+  # `target` whenever cmd_connect's flag-loop bails early — observed on
+  # Windows + Claude Code Monitor where `airc status` then reports
+  # `identity: --attach (host)`. The host name and gist label both inherit
+  # that, breaking inbox routing. The child's own AIRC_NO_ATTACH=1
+  # already prevents the recursion loop, so dropping the flag here is safe
+  # in every code path.
+  local _spawn_args=()
+  local _arg
+  for _arg in "$@"; do
+    case "$_arg" in
+      --attach|-attach) ;;
+      *) _spawn_args+=("$_arg") ;;
+    esac
+  done
   (
-    AIRC_NO_ATTACH=1 AIRC_BACKGROUND_OK=1 "$AIRC_SELF" join "$@"
+    AIRC_NO_ATTACH=1 AIRC_BACKGROUND_OK=1 "$AIRC_SELF" join \
+      ${_spawn_args[@]+"${_spawn_args[@]}"}
   ) >>"$_log" 2>&1 &
   local _transport_pid=$!
   echo "  transport PID: $_transport_pid"

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2183,6 +2183,48 @@ scenario_attach_starts_background_transport() {
   cleanup_all
 }
 
+# ── Scenario: attach_spawn_strips_attach_flag ───────────────────────────
+# Regression for #511/#521: the attach UI wrapper recursively starts the
+# transport with AIRC_NO_ATTACH=1. That child must not see --attach as a
+# positional target/name, even if the original UI invocation had --attach.
+scenario_attach_spawn_strips_attach_flag() {
+  section "attach_spawn_strips_attach_flag: recursive transport never persists --attach as identity"
+  cleanup_all
+
+  local home=/tmp/airc-it-attach-strip/state
+  local out=/tmp/airc-it-attach-strip/out.log
+  local err=/tmp/airc-it-attach-strip/err.log
+  mkdir -p /tmp/airc-it-attach-strip
+
+  AIRC_HOME="$home" AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 \
+    "$AIRC" join --attach --no-room --no-gist >"$out" 2>"$err" &
+  local ui_pid=$!
+
+  local name="" status_out="" i
+  for i in $(seq 1 20); do
+    status_out=$(AIRC_HOME="$home" "$AIRC" status 2>&1 || true)
+    name=$(printf '%s\n' "$status_out" \
+      | sed -n 's/^  identity:[[:space:]]*//p' \
+      | sed 's/[[:space:]]*(.*$//' \
+      | head -1)
+    [ -n "$name" ] && break
+    sleep 1
+  done
+
+  [ -n "$name" ] \
+    && pass "attach child persisted an identity name" \
+    || fail "attach child did not persist identity (status=$status_out; stdout=$(cat "$out" 2>/dev/null); stderr=$(cat "$err" 2>/dev/null))"
+  [ "$name" != "--attach" ] \
+    && pass "attach flag was not persisted as identity" \
+    || fail "attach flag leaked into identity name (stdout=$(cat "$out" 2>/dev/null); stderr=$(cat "$err" 2>/dev/null))"
+
+  kill "$ui_pid" 2>/dev/null || true
+  wait "$ui_pid" 2>/dev/null || true
+  AIRC_HOME="$home" "$AIRC" teardown >/dev/null 2>&1 || true
+  rm -rf /tmp/airc-it-attach-strip
+  cleanup_all
+}
+
 # ── Scenario: gh_secondary_rate_limit_degraded_startup (#479) ──────────
 # GitHub secondary throttling must not prevent monitor startup. On
 # 2026-05-04 Windows/WSL hit this shape: `gh auth status` tripped the
@@ -4474,6 +4516,7 @@ case "$MODE" in
   send_dead_monitor_dies) scenario_send_dead_monitor_dies ;;
   monitor_liveness_process_evidence) scenario_monitor_liveness_process_evidence ;;
   attach_starts_background_transport) scenario_attach_starts_background_transport ;;
+  attach_spawn_strips_attach_flag) scenario_attach_spawn_strips_attach_flag ;;
   gh_secondary_rate_limit_degraded_startup) scenario_gh_secondary_rate_limit_degraded_startup ;;
   solo_mesh_warns) scenario_solo_mesh_warns ;;
   connect_after_kill_recovers) scenario_connect_after_kill_recovers ;;
@@ -4510,7 +4553,7 @@ case "$MODE" in
     scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat
     scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope
     scenario_send_dead_monitor_dies; scenario_monitor_liveness_process_evidence
-    scenario_attach_starts_background_transport
+    scenario_attach_starts_background_transport; scenario_attach_spawn_strips_attach_flag
     scenario_gh_secondary_rate_limit_degraded_startup
     scenario_solo_mesh_warns
     scenario_connect_after_kill_recovers


### PR DESCRIPTION
## Closes the second blocker on #511

### Symptom

After #518 cleared the early `set_config_val` crash, Windows + Claude Code Monitor + `airc join --attach` still failed:

```
$ airc msg --channel general "..."
ERROR: monitor down — refusing to silently broadcast into a void
$ grep name /mnt/c/Users/green/continuum/.airc/config.json
"name": "--attach",
```

The host's identity persisted as `--attach`. Subsequent `airc rename` was rejected because peers in the room had already seen this name.

### Root cause

`_join_spawn_transport_for_attach` at cmd_connect.sh:198 spawns the recursive transport via:

```bash
( AIRC_NO_ATTACH=1 AIRC_BACKGROUND_OK=1 "$AIRC_SELF" join "$@" ) >>"$_log" 2>&1 &
```

`"$@"` is the original args including `--attach`. The child has `AIRC_NO_ATTACH=1` so it forces `attach=0` after the parser shifts the flag off — that path works on Mac. On Windows + Claude Code Monitor I observed `--attach` survive the parser into `positional[]`, then `local target="${1:-}"` set `target="--attach"`, then `local name="${target:-}"`, then `set_config_val name "$name"` persisted it.

Tracing the parser yourself: the `--attach|-attach)` case-arm at cmd_connect.sh:397 SHOULD match. Empirically on this Windows path it doesn't — the flag bypasses the arm and falls through to `*) positional+=("$1")`. I haven't isolated whether that's WSL2 case-glob behavior, an env interaction, or a re-exec losing the parse — but the fix is independent of root cause:

### Fix

Strip `--attach` / `-attach` from `$@` before forwarding to the recursive join. The child's `AIRC_NO_ATTACH=1` already prevents the re-attach loop, so the flag is redundant; dropping it makes the bug impossible by construction:

```bash
local _spawn_args=()
local _arg
for _arg in "$@"; do
  case "$_arg" in
    --attach|-attach) ;;
    *) _spawn_args+=("$_arg") ;;
  esac
done
(
  AIRC_NO_ATTACH=1 AIRC_BACKGROUND_OK=1 "$AIRC_SELF" join \
    ${_spawn_args[@]+"${_spawn_args[@]}"}
) >>"$_log" 2>&1 &
```

### Verified end-to-end on Windows 11 + WSL2 + Claude Code Monitor

```
$ airc join --attach
...
identity:    continuum-b69f (hosting on port 7547)
airc process: AIRC background process running for scope (PID 66054)
[bearers spawn, channels start]

$ airc msg --channel general "windows ops-ok ..."
→ #general (broadcast)
```

Pre-fix: `identity: --attach (host)`, `monitor down`. Post-fix: identity preserved, transport alive, msg accepted.

### Test plan

- [ ] Mac: existing behavior unchanged (the codepath was already filtering --attach via env; explicit strip doesn't break the Mac flow)
- [ ] Windows: `airc join --attach; airc status; airc msg --channel general "..."` — full round trip works
- [ ] Integration tests still pass (no test stubs care about argv shape into the spawn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
