### PR TITLE
fix(attach): detach transport via setsid -f so Monitor exit does not kill it

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -218,37 +218,6 @@ _join_spawn_transport_for_attach() {
       *) _spawn_args+=("$_arg") ;;
     esac
   done
-  # Detach the transport from the launcher shell's session so SIGHUP from
-  # parent exit doesn't cascade. On Windows + Claude Code Monitor (where
-  # the launcher is `wsl bash -lc 'airc join --attach'`), the wsl/bash
-  # wrapper exits ~immediately after spawning the background subshell;
-  # without HUP-protection every `( ... ) &` child in the join tree (the
-  # accept-loop, reminder-timer, mesh-rediscover, bearer_cli recv loops)
-  # gets SIGHUP'd by the kernel as the controlling-terminal session
-  # leader dies. From outside it looks like "airc join started, wrote
-  # pidfile, then went silent" — exactly the trace pattern in #511
-  # update 6 / Windows retest on 65adceb (transport-log mtime stops at
-  # the moment the launcher returned, no fresh writes).
-  #
-  # Approach: ignore SIGHUP in the subshell BEFORE exec'ing airc-self.
-  # POSIX semantics: a process started with SIGHUP set to SIG_IGN keeps
-  # SIG_IGN across exec() AND across fork() — every grandchild
-  # (handshake accept_one, bearer_cli recv loops, reminder timer,
-  # rediscover loop) inherits the same disposition unless it explicitly
-  # installs its own handler. Python's runtime resets SIG_DFL for many
-  # signals but PRESERVES SIG_IGN for SIGHUP unless code overrides it,
-  # so the python sidecars survive too.
-  #
-  # This keeps the watchdog at the bottom of the function intact:
-  # `kill -0 "$_transport_pid"` still tracks the wrapper subshell, and
-  # `_monitor_alive_with_bearer_fallback` reads airc.pid which airc
-  # writes after spawn. Both stay valid because the subshell does
-  # survive the parent shell's exit now.
-  #
-  # Mac's existing path doesn't hit this because Mac's launcher is a
-  # foreground bash that holds children alive until the user closes the
-  # tab — the subshell never receives SIGHUP. The trap is harmless
-  # there.
   # Detach the transport into its own session+pgroup so SIGHUP from the
   # launcher's session leader exit doesn't cascade. On Windows + Claude
   # Code Monitor (`wsl bash -lc 'airc join --attach'`) the launcher

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -218,12 +218,80 @@ _join_spawn_transport_for_attach() {
       *) _spawn_args+=("$_arg") ;;
     esac
   done
-  (
-    AIRC_NO_ATTACH=1 AIRC_BACKGROUND_OK=1 "$AIRC_SELF" join \
-      ${_spawn_args[@]+"${_spawn_args[@]}"}
-  ) >>"$_log" 2>&1 &
-  local _transport_pid=$!
-  echo "  transport PID: $_transport_pid"
+  # Detach the transport from the launcher shell's session so SIGHUP from
+  # parent exit doesn't cascade. On Windows + Claude Code Monitor (where
+  # the launcher is `wsl bash -lc 'airc join --attach'`), the wsl/bash
+  # wrapper exits ~immediately after spawning the background subshell;
+  # without HUP-protection every `( ... ) &` child in the join tree (the
+  # accept-loop, reminder-timer, mesh-rediscover, bearer_cli recv loops)
+  # gets SIGHUP'd by the kernel as the controlling-terminal session
+  # leader dies. From outside it looks like "airc join started, wrote
+  # pidfile, then went silent" — exactly the trace pattern in #511
+  # update 6 / Windows retest on 65adceb (transport-log mtime stops at
+  # the moment the launcher returned, no fresh writes).
+  #
+  # Approach: ignore SIGHUP in the subshell BEFORE exec'ing airc-self.
+  # POSIX semantics: a process started with SIGHUP set to SIG_IGN keeps
+  # SIG_IGN across exec() AND across fork() — every grandchild
+  # (handshake accept_one, bearer_cli recv loops, reminder timer,
+  # rediscover loop) inherits the same disposition unless it explicitly
+  # installs its own handler. Python's runtime resets SIG_DFL for many
+  # signals but PRESERVES SIG_IGN for SIGHUP unless code overrides it,
+  # so the python sidecars survive too.
+  #
+  # This keeps the watchdog at the bottom of the function intact:
+  # `kill -0 "$_transport_pid"` still tracks the wrapper subshell, and
+  # `_monitor_alive_with_bearer_fallback` reads airc.pid which airc
+  # writes after spawn. Both stay valid because the subshell does
+  # survive the parent shell's exit now.
+  #
+  # Mac's existing path doesn't hit this because Mac's launcher is a
+  # foreground bash that holds children alive until the user closes the
+  # tab — the subshell never receives SIGHUP. The trap is harmless
+  # there.
+  # Detach the transport into its own session+pgroup so SIGHUP from the
+  # launcher's session leader exit doesn't cascade. On Windows + Claude
+  # Code Monitor (`wsl bash -lc 'airc join --attach'`) the launcher
+  # bash is the controlling-terminal session leader; when it returns,
+  # kernel SIGHUPs the entire pgroup. `setsid -f` forks the transport
+  # into a new session AND a new pgroup AND disconnects it from the
+  # controlling terminal — the kill-all-on-launcher-exit semantics no
+  # longer apply.
+  #
+  # `setsid -f` returns immediately after fork (parent doesn't wait),
+  # so the captured `$!` is the bash subshell PID; the actual transport
+  # is the grandchild. We don't need that PID for the watchdog —
+  # `_monitor_alive_with_bearer_fallback` reads airc.pid (written by
+  # airc itself once spawned) which is the canonical aliveness signal.
+  # The kill-0 fallback used `_transport_pid` to detect catastrophic
+  # spawn failures; with setsid -f, the subshell exits cleanly after
+  # forking the grandchild, so kill-0 of subshell-PID is no longer a
+  # useful signal — the watchdog now relies entirely on airc.pid
+  # appearing within the timeout. AIRC_NO_DETACH=1 forces the inline
+  # form for harness tests that want process-tree reap semantics.
+  if [ "${AIRC_NO_DETACH:-0}" != "1" ] && command -v setsid >/dev/null 2>&1; then
+    setsid -f env AIRC_NO_ATTACH=1 AIRC_BACKGROUND_OK=1 \
+      "$AIRC_SELF" join \
+      ${_spawn_args[@]+"${_spawn_args[@]}"} \
+      >>"$_log" 2>&1
+  else
+    (
+      trap '' HUP
+      AIRC_NO_ATTACH=1 AIRC_BACKGROUND_OK=1 exec "$AIRC_SELF" join \
+        ${_spawn_args[@]+"${_spawn_args[@]}"}
+    ) >>"$_log" 2>&1 &
+  fi
+  # With setsid -f, $! is the parent shell pid which exited cleanly
+  # after forking the daemonized grandchild. The kill-0 watchdog can't
+  # use it. Set _transport_pid="" to disable that path; the airc.pid
+  # file written by the transport is the authoritative liveness check.
+  local _transport_pid=""
+  if [ "${AIRC_NO_DETACH:-0}" = "1" ] || ! command -v setsid >/dev/null 2>&1; then
+    _transport_pid=$!
+  fi
+  if [ -n "$_transport_pid" ]; then
+    echo "  transport PID: $_transport_pid"
+  fi
   echo "  transport log: $_log"
 
   local _pidfile="$AIRC_WRITE_DIR/airc.pid"
@@ -234,7 +302,7 @@ _join_spawn_transport_for_attach() {
       _join_attach_local_stream
       return 0
     fi
-    if ! kill -0 "$_transport_pid" 2>/dev/null; then
+    if [ -n "$_transport_pid" ] && ! kill -0 "$_transport_pid" 2>/dev/null; then
       echo "  airc join: transport exited before it became healthy." >&2
       if [ -s "$_log" ]; then
         echo "  last transport log lines:" >&2
@@ -420,6 +488,24 @@ cmd_connect() {
       *) positional+=("$1"); shift ;;
     esac
   done
+  # Belt for the suspenders: even if the case arm above failed to match
+  # `--attach` for a hidden-CR / NUL / encoding reason (only observed via
+  # Claude Code Monitor on Windows + WSL2 — the foreground bash path
+  # consumed it correctly), make sure it never lands in positional and
+  # poisons `target`. Symptom we're guarding against: `airc status`
+  # reporting `identity: --attach (host)` after the Monitor invocation,
+  # config.json's name field persisted as `--attach`. See #511.
+  if [ "${#positional[@]}" -gt 0 ]; then
+    local _kept_positional=()
+    local _p
+    for _p in "${positional[@]}"; do
+      case "$_p" in
+        --attach|-attach) attach=1 ;;
+        *) _kept_positional+=("$_p") ;;
+      esac
+    done
+    positional=("${_kept_positional[@]+"${_kept_positional[@]}"}")
+  fi
   set -- "${positional[@]+"${positional[@]}"}"
   [ "${AIRC_NO_ATTACH:-0}" = "1" ] && attach=0
 


### PR DESCRIPTION
## Closes the third Windows blocker on #511

After #518 cleared the empty-value argparse crash and #521 fixed the `--attach` identity leak, Windows + Claude Code Monitor + `airc join --attach` still produced **no live transport**. `airc status` reported `airc process: not running`, `airc msg` refused with `monitor down`, and the transport log mtime froze at "Found canonical gist" — exactly when SIGHUP would cascade.

## Root cause

`_join_spawn_transport_for_attach` spawned via `( ... ) >>"$_log" 2>&1 &` — same session + pgroup as the launcher bash. On Windows, the Monitor's `wsl bash -lc 'airc join --attach'` is the controlling-terminal session leader; when it returns, the kernel SIGHUPs the entire pgroup. Every child in the join tree (handshake accept_one, bearer_cli recv loops, reminder_timer_loop, _mesh_rediscover_loop) dies before `airc.pid` is ever written. Foreground bash on Mac doesn't hit this because the user's interactive shell stays alive holding children open.

## Fix

Detach the transport into a new session + pgroup with `setsid -f`. Kernel-cascade SIGHUP from the launcher's pgroup no longer reaches the transport. Watchdog reworked: `setsid -f` returns 0 immediately after fork so `$!` is no longer useful — `airc.pid` written by airc itself is the canonical liveness signal.

```bash
if [ "${AIRC_NO_DETACH:-0}" != "1" ] && command -v setsid >/dev/null 2>&1; then
  setsid -f env AIRC_NO_ATTACH=1 AIRC_BACKGROUND_OK=1 \
    "$AIRC_SELF" join \
    ${_spawn_args[@]+"${_spawn_args[@]}"} \
    >>"$_log" 2>&1
else
  # macOS / minimal envs: keep the existing background-subshell form
  ( trap '' HUP
    AIRC_NO_ATTACH=1 AIRC_BACKGROUND_OK=1 exec "$AIRC_SELF" join \
      ${_spawn_args[@]+"${_spawn_args[@]}"}
  ) >>"$_log" 2>&1 &
fi
```

## Verified end-to-end on Windows 11 + WSL2 + Claude Code Monitor

```
$ airc join --attach   (via Monitor)
$ pgrep -af airc
30211 /bin/bash /home/joel/.airc-src/airc join
30584 ...airc_core.handshake accept_one ...
30591 ...airc_core.bearer_cli recv ...
$ airc status
airc process: AIRC background process running for scope (PID 30211)
transport health: starting; bearers spawning per-channel
$ airc msg --channel general "windows ops-ok ..."
→ #general (broadcast)
```

Pre-fix: same sequence produced **zero** airc processes after Monitor's bash returned.

## Test plan

- [x] Windows + Claude Code Monitor: transport survives, msg accepted (verified above)
- [ ] macOS: existing inline-spawn form still active when setsid is absent or AIRC_NO_DETACH=1; should be unchanged behavior
- [ ] Linux non-Monitor: foreground `airc join --attach` keeps working — setsid path used (transport still survives correctly), or AIRC_NO_DETACH=1 reverts
- [ ] CI: `bash -n` already passes; existing integration tests don't simulate launcher exit so they should be unaffected. A test for "transport survives parent exit" would need a separate harness — happy to add if codex points at where to plug in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
