### PR TITLE
fix(peers): show recent broadcast peers even when paired records exist

### DIFF
--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -574,7 +574,7 @@ else:
     return
   fi
 
-  "$AIRC_PYTHON" -c "
+  AIRC_PEERS_MY_NAME="$(get_name)" "$AIRC_PYTHON" -c "
 import json, os, sys, time, calendar
 
 primary_scope = os.path.expanduser('$AIRC_WRITE_DIR')
@@ -649,6 +649,10 @@ except OSError:
 
 # Render. Each peer once, with room annotations + last-seen marker.
 # Silent >1h gets a (silent) flag so the eye catches it immediately.
+#
+# Track which paired-record names we've already rendered so the
+# broadcast-peer pass below doesn't double-list them.
+rendered = set()
 for (name, host), rooms in sorted(peers_by_id.items()):
     seen = set(); ordered = []
     for r in rooms:
@@ -663,5 +667,24 @@ for (name, host), rooms in sorted(peers_by_id.items()):
     elif last_ts is None:
         silent_flag = ' (no recorded activity)'
     print(f'  {name} → {host}   [{tags}]   last seen {age_str}{silent_flag}')
+    rendered.add(name)
+
+# Also surface broadcast-only peers (no DM-paired record). Pre-fix,
+# stale paired records masked recent peers entirely — codex on Mac saw
+# 'vhsm-d1f4' (an old paired host) but not 'continuum-8e97' even after
+# multiple broadcast messages within the recent window. Mirror the
+# behaviour of the empty-peers-dir fallback path so listings remain
+# consistent regardless of whether stale records exist.
+my_name = os.environ.get('AIRC_PEERS_MY_NAME', '')
+RECENT_WINDOW = 600
+broadcast_only = []
+for who, ts in last_seen.items():
+    if who in rendered: continue
+    if who == my_name or who == 'airc': continue
+    if now - ts >= RECENT_WINDOW: continue
+    broadcast_only.append((who, ts))
+broadcast_only.sort(key=lambda kv: kv[1], reverse=True)
+for who, ts in broadcast_only:
+    print(f'  {who} → broadcast room   [(from signed messages.jsonl)]   last seen {_fmt_age(ts)}')
 "
 }


### PR DESCRIPTION
## Caught by codex during the post-#522 noisy validation pass

Codex on Mac reported during the multi-agent validation:

> peers does NOT list continuum-8e97; only stale vhsm-d1f4, so peer presence metadata is still lagging gh-room reality

continuum-8e97 was actively broadcasting to #cambriantech (every 30s, within the recent window), but `airc peers` on Mac kept showing only the stale `vhsm-d1f4` paired record from a prior pair handshake.

## Root cause

`cmd_peers` in `lib/airc_bash/cmd_rooms.sh` has two render paths:

1. **PEERS_DIR empty** → falls through to `airc_core.collaboration peers-fallback`, which reads `messages.jsonl` and lists everyone seen in the last 600s. **Works correctly.**
2. **PEERS_DIR has *.json** → uses the inline python listing, which **only enumerates paired records** from `peers/*.json`. Broadcast-only peers from `messages.jsonl` are silently dropped.

So one stale paired record is enough to hide every genuinely-active broadcast peer.

The same `messages.jsonl` scan was already happening for `last_seen` (the age column on paired peers); the data just wasn't fanned out to non-paired senders.

## Fix

After rendering paired records, walk `last_seen` for any sender that wasn't already rendered, filter out self + the `airc` sentinel + anyone outside the 600s window, and print them in the same shape the empty-dir fallback uses.

## Verified live on Windows + WSL2

```
$ airc peers
  stub-peer-test → test-host-stub   [#cambriantech]   last seen never (no recorded activity)
  airc-8a5e → broadcast room   [(from signed messages.jsonl)]   last seen 7m ago
```

Pre-fix the same state listed only `stub-peer-test`. Post-fix lists both — the stale paired record AND the recent broadcast peer.

## Test plan

- [x] PEERS_DIR with stale json + broadcasting peer → both visible (verified above)
- [x] PEERS_DIR empty → unchanged (peers-fallback path is untouched)
- [ ] Mac: codex's `airc peers` should now show `continuum-8e97` after pulling this branch + a broadcast within 600s
- [ ] CI: `bash -n` already passes; existing peers-fallback integration test stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
