### PR TITLE
fix(codex): make join the uniform startup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Codex uses the same skills, plus an installed `UserPromptSubmit` hook. After ins
 /join
 ```
 
-The Codex skill starts AIRC with `airc codex-start`, which launches the local `airc join` owner outside Codex's shell-tool process group. Codex does not have Claude Code's live Monitor UI; the hook injects a compact unread digest before each user prompt, excluding this Codex session's own messages. During a long-running task, `airc codex-poll` is the manual catch-up command, and it reads only the local inbox cursor. Do not tail `airc logs` repeatedly as a substitute for the hook.
+Codex also uses `airc join`. The CLI detects Codex and launches the local AIRC owner outside Codex's shell-tool process group, so the public flow stays identical to Claude and humans. Codex does not have Claude Code's live Monitor UI; the hook injects a compact unread digest before each user prompt, excluding this Codex session's own messages. During a long-running task, `airc codex-poll` is the manual catch-up command, and it reads only the local inbox cursor. Do not tail `airc logs` repeatedly as a substitute for the hook.
 
 ## Talking in the Mesh
 

--- a/airc
+++ b/airc
@@ -2334,8 +2334,30 @@ fi
 
 # ── Dispatch ────────────────────────────────────────────────────────────
 
+_airc_should_use_codex_start() {
+  [ -n "${AIRC_CODEX_START_CHILD:-}" ] && return 1
+  [ -n "${AIRC_NO_CODEX_DETACH:-}" ] && return 1
+  [ -n "${AIRC_NO_ATTACH:-}" ] && return 1
+
+  local _arg
+  for _arg in "$@"; do
+    [ "$_arg" = "--attach" ] && return 1
+  done
+
+  [ -n "${CODEX_THREAD_ID:-}${CODEX_CI:-}${CODEX_MANAGED_BY_NPM:-}" ]
+}
+
+_airc_join_or_start() {
+  if _airc_should_use_codex_start "$@"; then
+    cmd_codex_start "$@"
+  else
+    cmd_connect "$@"
+  fi
+}
+
 case "${1:-help}" in
-  connect|setup|start|join|resume) shift; cmd_connect "$@" ;;
+  connect|setup|start) shift; cmd_connect "$@" ;;
+  join|resume) shift; _airc_join_or_start "$@" ;;
   send|msg|say)   shift; cmd_send "$@" ;;
   privmsg)   shift; cmd_send "$@" ;;
   send-file) shift; cmd_send_file "$@" ;;

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -185,14 +185,27 @@ _join_attach_local_stream() {
   echo "  Attaching this terminal to the local AIRC stream."
   echo "  Background AIRC owns transport; this process only displays new peer messages."
   local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
-  local _join_event_args=(join --home "$AIRC_WRITE_DIR" --name "$(get_name)")
-  [ -n "$_client_id" ] && _join_event_args+=(--client-id "$_client_id")
-  "$AIRC_PYTHON" -m airc_core.system_event "${_join_event_args[@]}" >/dev/null 2>&1 || true
   if [ -n "$_client_id" ]; then
     AIRC_CLIENT_ID="$_client_id" exec "$AIRC_PYTHON" -u -m airc_core.log_tail --home "$AIRC_WRITE_DIR" --my-name "$(get_name)"
   else
     exec "$AIRC_PYTHON" -u -m airc_core.log_tail --home "$AIRC_WRITE_DIR" --my-name "$(get_name)"
   fi
+}
+
+_join_emit_join_events() {
+  local _name="$1"
+  [ -z "$_name" ] && return 0
+  [ -f "$CONFIG" ] || return 0
+  local _channels _ch
+  _channels=$("$AIRC_PYTHON" -m airc_core.config read_channels --config "$CONFIG" 2>/dev/null || true)
+  [ -z "$_channels" ] && return 0
+  while IFS= read -r _ch; do
+    [ -z "$_ch" ] && continue
+    local _gid
+    _gid=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist --config "$CONFIG" --channel "$_ch" 2>/dev/null || true)
+    [ -z "$_gid" ] && continue
+    cmd_send --internal --system --channel "$_ch" "$_name joined #$_ch" >/dev/null 2>&1 || true
+  done <<< "$_channels"
 }
 
 _join_spawn_transport_for_attach() {
@@ -1603,6 +1616,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
     ' EXIT INT TERM
 
     spawn_general_sidecar_if_wanted
+    _join_emit_join_events "$my_name"
     echo "  Monitoring for messages..."
     monitor
 
@@ -2228,6 +2242,7 @@ JSON
     ' EXIT INT TERM
 
     spawn_general_sidecar_if_wanted
+    _join_emit_join_events "$name"
     echo "  Monitoring for messages..."
     monitor
     kill $PAIR_PID 2>/dev/null

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -244,6 +244,7 @@ cmd_part() {
     if [ -z "$_ch_gist" ]; then
       die "Not subscribed to #${arg_room} (no channel_gists mapping). Use 'airc list' to see open rooms; 'airc status' for your subscriptions."
     fi
+    cmd_send --internal --system --channel "$arg_room" "$(get_name) left #${arg_room}" >/dev/null 2>&1 || true
     # Delete the gist ONLY if we're hosting it — i.e., it appears
     # under our gh account. Try delete; ignore failure (someone else's
     # gist isn't ours to delete; gh will reject with 404/403).
@@ -263,6 +264,7 @@ cmd_part() {
   # ── Scope-default part (no arg, or arg matches default) ──
   if [ -z "$host_target" ]; then
     # ── Host path ──
+    [ "$room_name" != "(unnamed)" ] && cmd_send --internal --system --channel "$room_name" "$(get_name) left #${room_name}" >/dev/null 2>&1 || true
     if [ -f "$gist_id_file" ]; then
       local gid; gid=$(cat "$gist_id_file")
       if command -v gh >/dev/null 2>&1; then
@@ -283,6 +285,7 @@ cmd_part() {
   else
     # ── Joiner path ──
     echo "  Joiner of #${room_name} parting — host's gist stays open for others."
+    [ "$room_name" != "(unnamed)" ] && cmd_send --internal --system --channel "$room_name" "$(get_name) left #${room_name}" >/dev/null 2>&1 || true
     # Clear our cached gist_id too, matching the comment on the joiner-
     # side cache write site (PR #92 Copilot feedback). Without this, a
     # parted joiner that later reconnects via the same scope would

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -65,6 +65,10 @@ cmd_send() {
   # issue. Exposed as a flag (not an env var) so call sites are
   # grep-able and the pattern matches the rest of the airc CLI surface.
   local internal=0
+  # --system: protocol/system event. Uses the same send path as chat so
+  # peers see lifecycle state on gh/local transports, but stamps from=airc
+  # so monitor/inbox render it as a system notice instead of peer text.
+  local system_event=0
   # --plaintext: skip envelope-layer encryption even when recipient
   # x25519 pubkey is on file. For control traffic ([PING:uuid] /
   # [PONG:uuid]) where the body is a public uuid with zero secret
@@ -96,6 +100,10 @@ cmd_send() {
         _explicit_channel=1
         shift 2 ;;
       --internal)
+        internal=1
+        shift ;;
+      --system)
+        system_event=1
         internal=1
         shift ;;
       --plaintext|-plaintext)
@@ -264,7 +272,9 @@ cmd_send() {
   fi
   [ -z "$active_channel" ] && active_channel="general"
 
-  local payload="{\"from\":\"$my_name\",\"to\":\"$peer_name\",\"ts\":\"$ts_val\",\"channel\":\"$active_channel\",\"msg\":\"$escaped_msg\""
+  local from_name="$my_name"
+  [ "$system_event" = "1" ] && from_name="airc"
+  local payload="{\"from\":\"$from_name\",\"to\":\"$peer_name\",\"ts\":\"$ts_val\",\"channel\":\"$active_channel\",\"msg\":\"$escaped_msg\""
   [ -n "$escaped_client_id" ] && payload="${payload},\"client_id\":\"$escaped_client_id\""
   payload="${payload}}"
   local sig; sig=$(sign_message "$payload")

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -572,8 +572,6 @@ cmd_codex_hook() {
 }
 
 cmd_codex_start() {
-  ensure_init
-
   local _log="$AIRC_WRITE_DIR/codex-airc.log"
   "$AIRC_PYTHON" -m airc_core.codex_start \
     --airc "$0" \

--- a/lib/airc_core/codex_start.py
+++ b/lib/airc_core/codex_start.py
@@ -3,7 +3,7 @@
 Codex shell tool calls may clean up background children when the command
 returns. A plain `nohup airc join &` can therefore look healthy for a few
 seconds and then vanish. This module owns the runtime-specific detach detail
-so the public skill can stay simple: `airc codex-start`.
+so the public skill can stay simple: `airc join`.
 """
 
 from __future__ import annotations
@@ -37,6 +37,7 @@ def main(argv: list[str] | None = None) -> int:
 
     env = os.environ.copy()
     env["AIRC_HOME"] = str(home)
+    env["AIRC_CODEX_START_CHILD"] = "1"
 
     with open(os.devnull, "rb") as stdin, open(log_path, "ab", buffering=0) as out:
         proc = subprocess.Popen(
@@ -50,7 +51,7 @@ def main(argv: list[str] | None = None) -> int:
             start_new_session=True,
         )
 
-    print(f"airc codex-start: launched airc join for {home} (PID {proc.pid}, log {log_path})")
+    print(f"airc join: launched Codex-detached transport for {home} (PID {proc.pid}, log {log_path})")
     return 0
 
 

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -63,7 +63,7 @@ Monitor(persistent=true, description="airc", command="airc join")
 Codex / non-Monitor runtimes:
 ```bash
 airc teardown
-airc codex-start
+airc join
 ```
 
 ## When to use this skill

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -69,15 +69,15 @@ Monitor(persistent=true, description="airc", command="airc join --attach")
 ```
 Keep `description="airc"` — the headline shown in the UI is built from it. Plain `airc join` creates the live AIRC stream for the scope.
 
-**Codex / non-Monitor runtimes:** do not foreground `airc join` in the tool call unless you expect it to return quickly. It is a long-running process when this scope is not already active. Use the Codex adapter so the AIRC owner starts outside Codex's tool process group; plain `nohup airc join &` can be reaped when the tool call exits.
+**Codex / non-Monitor runtimes:** use the same public command. The CLI detects Codex and starts the AIRC owner outside Codex's tool process group; plain `nohup airc join &` can be reaped when the tool call exits.
 ```
-airc codex-start
+airc join
 airc msg "..."                     # broadcast
 airc msg @peer "..."               # DM
 ```
 Codex has no Claude-style Monitor callback, so airc installs a Codex `UserPromptSubmit` hook when hooks are supported. The hook runs `airc codex-hook user-prompt-submit` before each user prompt reaches the model, injects unread peer messages as developer context, excludes this client session's own messages, and advances the local unread cursor. For older sessions started before the hook was installed, run `airc codex-poll` manually at turn start.
 
-Do NOT poll `airc logs N` without `--since` — that re-injects the full tail every turn. Use `airc codex-poll` for manual Codex catch-up; use `airc codex-start` for initial setup and recovery.
+Do NOT poll `airc logs N` without `--since` — that re-injects the full tail every turn. Use `airc codex-poll` for manual Codex catch-up; use `airc join` for initial setup and recovery.
 
 ## Idempotency
 

--- a/skills/repair/SKILL.md
+++ b/skills/repair/SKILL.md
@@ -50,7 +50,7 @@ Monitor(persistent=true, description="airc", command="airc join $INVITE")
 
 Codex / non-Monitor runtimes:
 ```bash
-airc codex-start "$INVITE"
+airc join "$INVITE"
 ```
 
 Fresh handshake, fresh identity keys get pushed to the host's authorized_keys, clean pair.

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -19,7 +19,7 @@ Monitor(persistent=true, description="airc", command="airc join")
 
 Codex / non-Monitor runtimes:
 ```bash
-airc codex-start
+airc join
 ```
 
 `airc join` with no args detects the stored pairing in this scope's config.json and restarts the airc process — no fresh handshake, no join string, no env vars.

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -44,7 +44,7 @@ Codex has no `Monitor` or `TaskStop`. Do not call those tools. Use the shell lif
 
 ```bash
 airc teardown
-airc codex-start
+airc join
 ```
 
 After the bounce, run `airc status` and `airc inbox` for missed messages. Report one short sentence: `Updated to <new-sha>; airc process restarted on new code.`

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2225,6 +2225,49 @@ scenario_attach_spawn_strips_attach_flag() {
   cleanup_all
 }
 
+# ── Scenario: codex_join_detaches_transport ────────────────────────────
+# Public Codex flow is plain `airc join`. The shell dispatch detects Codex
+# and routes through the detach adapter, while the spawned child is guarded
+# from recursively detaching itself.
+scenario_codex_join_detaches_transport() {
+  section "codex_join_detaches_transport: Codex uses plain airc join without recursive detach"
+  cleanup_all
+
+  local root=/tmp/airc-it-codex-join
+  local home="$root/state"
+  local out="$root/out.log"
+  local err="$root/err.log"
+  mkdir -p "$root"
+
+  CODEX_THREAD_ID=airc-it-codex AIRC_HOME="$home" AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 \
+    "$AIRC" join --no-room --no-gist >"$out" 2>"$err"
+  local rc=$?
+
+  [ "$rc" = "0" ] \
+    && pass "codex join command returned success" \
+    || fail "codex join failed rc=$rc stdout=$(cat "$out" 2>/dev/null) stderr=$(cat "$err" 2>/dev/null)"
+  grep -q "airc join: launched Codex-detached transport" "$out" \
+    && pass "codex join used the internal detach adapter" \
+    || fail "codex join did not report detached launch (stdout=$(cat "$out" 2>/dev/null))"
+
+  local running=0 status_out="" i
+  for i in $(seq 1 10); do
+    status_out=$(AIRC_HOME="$home" "$AIRC" status 2>&1 || true)
+    if printf '%s\n' "$status_out" | grep -q "airc process:.*running"; then
+      running=1
+      break
+    fi
+    sleep 1
+  done
+  [ "$running" = "1" ] \
+    && pass "codex detached child left one live scope process" \
+    || fail "codex detached child was not running (status=$status_out; stdout=$(cat "$out" 2>/dev/null); stderr=$(cat "$err" 2>/dev/null))"
+
+  AIRC_HOME="$home" "$AIRC" teardown >/dev/null 2>&1 || true
+  rm -rf "$root"
+  cleanup_all
+}
+
 # ── Scenario: gh_secondary_rate_limit_degraded_startup (#479) ──────────
 # GitHub secondary throttling must not prevent monitor startup. On
 # 2026-05-04 Windows/WSL hit this shape: `gh auth status` tripped the
@@ -4517,6 +4560,7 @@ case "$MODE" in
   monitor_liveness_process_evidence) scenario_monitor_liveness_process_evidence ;;
   attach_starts_background_transport) scenario_attach_starts_background_transport ;;
   attach_spawn_strips_attach_flag) scenario_attach_spawn_strips_attach_flag ;;
+  codex_join_detaches_transport) scenario_codex_join_detaches_transport ;;
   gh_secondary_rate_limit_degraded_startup) scenario_gh_secondary_rate_limit_degraded_startup ;;
   solo_mesh_warns) scenario_solo_mesh_warns ;;
   connect_after_kill_recovers) scenario_connect_after_kill_recovers ;;
@@ -4553,7 +4597,7 @@ case "$MODE" in
     scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat
     scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope
     scenario_send_dead_monitor_dies; scenario_monitor_liveness_process_evidence
-    scenario_attach_starts_background_transport; scenario_attach_spawn_strips_attach_flag
+    scenario_attach_starts_background_transport; scenario_attach_spawn_strips_attach_flag; scenario_codex_join_detaches_transport
     scenario_gh_secondary_rate_limit_degraded_startup
     scenario_solo_mesh_warns
     scenario_connect_after_kill_recovers

--- a/test/test_codex_start.py
+++ b/test/test_codex_start.py
@@ -48,6 +48,7 @@ class CodexStartTests(unittest.TestCase):
             argv, kwargs = calls[0]
             self.assertEqual(argv, ["/usr/local/bin/airc", "join", "--room", "general"])
             self.assertEqual(kwargs["env"]["AIRC_HOME"], str(home.resolve()))
+            self.assertEqual(kwargs["env"]["AIRC_CODEX_START_CHILD"], "1")
             self.assertTrue(kwargs["start_new_session"])
             self.assertTrue(kwargs["close_fds"])
             self.assertEqual(kwargs["stderr"], codex_start.subprocess.STDOUT)


### PR DESCRIPTION
## Summary

- Make public Codex startup use plain `airc join`; the CLI detects Codex for `join`/`resume` and routes through the detached adapter internally.
- Guard the detached child with `AIRC_CODEX_START_CHILD=1` so `airc join` cannot recurse through the adapter.
- Remove the stale `ensure_init` precondition so Codex can be the first user in a fresh scope.
- Emit `joined` / `left` lifecycle notices through the normal message protocol as `from=airc` system events instead of local attach-only appends. Join notices are limited to channels with a gist mapping, so legacy `--no-room --no-gist` smoke starts stay untouched.
- Update Codex skills/docs away from public `airc codex-start`.

## Verification

- `bash -n airc lib/airc_bash/cmd_connect.sh lib/airc_bash/cmd_send.sh lib/airc_bash/cmd_rooms.sh lib/airc_bash/cmd_status.sh test/integration.sh`
- `python3 test/test_codex_start.py`
- `python3 test/test_system_event.py`
- `python3 test/test_collaboration.py`
- `./test/integration.sh codex_join_detaches_transport`
- Manual temp-scope check: clean-install style `airc connect --no-room --no-gist` still writes `airc.pid` promptly.
- Manual temp-scope check after #523: stale paired record plus fresh broadcast sender both appear in `airc peers`.

## Notes

PR #523 is already merged to canary as `5991086`; this branch is rebased on top of it.
