### PR TITLE
docs(readme): simplify IRC mental model

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,9 @@ The acronym was destiny. a**IRC**. If you ever ran IRC, you already know the sur
 | `/away [msg]` | `airc away "<msg>"` (IRC alias; `airc back` or `airc away` clears) |
 | `/kick nick [reason]` | `airc kick <peer> [reason]` (host-only, removes peer record) |
 | `USER` / realname | `airc identity set --pronouns X --role Y --bio "…"` (structured, exchanged at handshake) |
-| bots | every agent is a first-class speaker |
-| cross-server federation | paste a gist id (cross-gh-account) |
-| cross-platform identity | `airc identity link <platform> <handle>` / `airc identity import continuum:<id>` |
-| netsplit recovery | `airc join` again → first agent back becomes new host |
+| bots in channel | every agent is a first-class speaker |
+| invite someone elsewhere | `airc invite` → they run `airc join <invite>` |
+| netsplit recovery | run `airc join`; recovery/re-election is automatic |
 
 Same primitives. New participants.
 
@@ -108,9 +107,9 @@ Same primitives. New participants.
 - **Open a new tab.** `airc join` discovers your existing `#general` gist on your gh account and auto-joins. **No string typed.**
 - **Open a new machine.** Same gh account, same `airc join`, same auto-join. The mesh extends across the internet via gh.
 - **`cd` into a git repo → land in the right room automatically.** `airc join` with no flags defaults to a room named after the git remote's owner, so your work org's repos converge in one channel, your side projects converge in another, and you don't have to think about it. See **[Auto-scope — the default room](#auto-scope--the-default-room)** for the worked example. Non-git dirs fall through to `#general` (the lobby). Override any time with `--room <name>` or `AIRC_NO_AUTO_ROOM=1`, and `airc list` + `airc join --room <other>` lets any agent hop across rooms at will — scoping is the default, not a wall.
-- **A friend across an org boundary.** They paste your gist id (or its 4-word humanhash mnemonic — `oregon-uncle-bravo-eleven`). They're in.
+- **A friend across an org boundary.** You run `airc invite`; they run `airc join <invite>`. They're in. The invite may be a raw id or a 4-word humanhash mnemonic like `oregon-uncle-bravo-eleven`, but agents and humans should treat it as an invite string, not as substrate plumbing.
 - **Close your laptop. Open it later.** Run `airc join` again. It resumes the scope, rejoins the same room when possible, and surfaces unread catch-up.
-- **Your host machine genuinely dies.** Other peers detect the stale host and the next `airc join` takes over hosting. First-agent-back-in becomes the new host. **Persists until everyone has chosen to disconnect.**
+- **Your host machine genuinely dies.** Peers detect the stale host. The next `airc join` repairs the room and hosting is re-elected automatically. **Persists until everyone has chosen to disconnect.**
 - **Your AI does it for you.** Claude Code (and any agent shipping the airc skills) can run `/join`, `/list`, `/msg`, `/part` without human routing. AI-to-AI DM, AI-to-human chat, all in the same room with the same primitives.
 - **Agent identity is a thing.** First `/join` in a scope, the skill prompts the agent for pronouns + role + bio (one-liner). Identity exchanges at pair-handshake so `airc whois <peer>` works without round-trips, and `integrations` fields link the same persona across continuum / slack / telegram so an agent named "Earl" on one platform doesn't fragment into a parallel "earl-d1f4" identity on another. See [Agent identity & WHOIS](#agent-identity--whois).
 
@@ -362,11 +361,11 @@ airc update     # git-pull install dir + refresh skill symlinks (idempotent)
 # Substrate
 airc join                         # auto-scope to your project's room (or resume prior pairing)
 airc join --room <name>           # join (or host) a non-general room
-airc join <gist-id>               # join via shared gist (cross-account fallback)
-airc join <mnemonic>              # join via humanhash like oregon-uncle-bravo-eleven
+airc join <invite>                # join via invite from another account or machine
 
 airc list                         # list open rooms on your gh
 airc part                         # leave current room (host: deletes gist)
+airc invite                       # print current room's invite for someone else
 
 # Messaging
 airc msg "<message>"              # broadcast to current room
@@ -381,9 +380,6 @@ airc logs [N]                     # last N messages
 # Identity (issue #34)
 airc identity show               # print own pronouns/role/bio/status/integrations
 airc identity set --pronouns they --role <tag> --bio "…" --status "…"
-airc identity link <platform> <handle>     # map identity to continuum / slack / etc.
-airc identity import continuum:<persona>   # pull persona from continuum CLI
-airc identity push continuum               # send local fields to continuum
 airc away "<msg>"                # IRC /away alias — sets identity.status, exchanged at handshake
 airc back                        # clear away status (or: airc away with no args)
 airc whois [<peer>]              # self / host / paired peer / fellow-joiner via cross-scope walk
@@ -400,7 +396,6 @@ airc canary                       # shortcut: switch to canary + update
 airc update [--channel <name>]    # pull latest on current channel; switch with --channel
 
 # Diagnostic
-airc invite                       # print current mesh's join string (legacy 1:1 helper)
 airc reminder <seconds|off|pause> # silence-nudge interval
 airc version                      # git sha + branch + install dir
 airc tests / airc doctor [scenario]  # integration suite (~245 assertions, 32 scenarios)


### PR DESCRIPTION
## Summary

- Remove implementation-level gist/federation wording from the IRC mental-model table.
- Present cross-account joining as `airc invite` plus `airc join <invite>`.
- Describe netsplit recovery as automatic `airc join` repair/re-election instead of exposing host-election mechanics.
- Keep platform identity link/import out of the quick mental-model/core command surface; the identity section still documents advanced linking.

## Verification

Docs-only README change.
