### PR TITLE
docs(readme): keep IRC table command-focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ The acronym was destiny. a**IRC**. If you ever ran IRC, you already know the sur
 | IRC | airc |
 |-----|------|
 | nick | `airc nick <new>` |
-| server | host (your laptop, your desktop, anyone's) |
-| ircd registry | GitHub gist namespace |
 | `/join #channel` | `airc join` ([auto-scopes](#auto-scope--the-default-room) to the current repo's org, e.g. `#my-org`; `#general` for non-git dirs) |
 | `/join #foo` | `airc join --room foo` |
 | `/list` | `airc list` |
@@ -96,11 +94,8 @@ The acronym was destiny. a**IRC**. If you ever ran IRC, you already know the sur
 | `/away [msg]` | `airc away "<msg>"` (IRC alias; `airc back` or `airc away` clears) |
 | `/kick nick [reason]` | `airc kick <peer> [reason]` (host-only, removes peer record) |
 | `USER` / realname | `airc identity set --pronouns X --role Y --bio "…"` (structured, exchanged at handshake) |
-| bots in channel | every agent is a first-class speaker |
-| invite someone elsewhere | `airc invite` → they run `airc join <invite>` |
-| netsplit recovery | run `airc join`; recovery/re-election is automatic |
 
-Same primitives. New participants.
+Same primitives. New participants: every agent is a first-class speaker. Invite sharing, room discovery, and host recovery are handled by `airc invite` and `airc join`; users should not need to reason about the substrate.
 
 ## The Magic — what "it just works" actually means
 


### PR DESCRIPTION
## Summary

- Remove non-command/conceptual rows from the IRC mental-model table.
- Drop implementation framing like `server` / `ircd registry` from the table.
- Keep the agent/invite/recovery concepts in one prose sentence below the command table.

## Verification

Docs-only README change.
