### PR TITLE
fix(send): do not claim delivery after dissolved gist

### DIFF
--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -69,6 +69,10 @@ cmd_send() {
   # peers see lifecycle state on gh/local transports, but stamps from=airc
   # so monitor/inbox render it as a system notice instead of peer text.
   local system_event=0
+  # Final user-facing confirmation state. The transport branches below
+  # may queue or fail after writing a loud diagnostic; the shared footer
+  # must not print the same delivered arrow for those cases.
+  local _airc_delivery_state="delivered"
   # --plaintext: skip envelope-layer encryption even when recipient
   # x25519 pubkey is on file. For control traffic ([PING:uuid] /
   # [PONG:uuid]) where the body is a public uuid with zero secret
@@ -436,6 +440,7 @@ cmd_send() {
         echo "  ✗ Gist for #${active_channel} returned 404 — channel dissolved." >&2
         echo "    Stale channel_gists[${active_channel}] cleared." >&2
         echo "    Re-host:  airc join --room ${active_channel}" >&2
+        return 1
         ;;
       secondary_rate_limit)
         # gh secondary throttle (#381 layer A). Queue + distinct marker.
@@ -446,6 +451,7 @@ cmd_send() {
         echo "  ⏳ gh secondary rate limit — message queued. Drain loop retries when window clears (~60-180s)." >&2
         echo "  Avoid sending more for ~2 minutes." >&2
         echo "  Bearer: ${detail:-<none>}" >&2
+        _airc_delivery_state="queued"
         ;;
       transient_failure|"")
         # Network-class failure or empty/malformed outcome → treat as
@@ -458,6 +464,7 @@ cmd_send() {
         echo "$queue_marker" >> "$MESSAGES"
         echo "  Network error reaching host — message queued for retry. Monitor will flush when host returns." >&2
         echo "  Bearer: ${detail:-<none>}" >&2
+        _airc_delivery_state="queued"
         ;;
       *)
         # Unknown kind. The bearer.py SendOutcome contract enumerates the
@@ -465,6 +472,7 @@ cmd_send() {
         # updating callers. Queue defensively + log loudly so it's caught.
         echo "$full_msg" >> "$AIRC_WRITE_DIR/pending.jsonl"
         echo "  Unknown bearer outcome kind '${kind}' (detail: ${detail}). Queued defensively. Update cmd_send.sh." >&2
+        _airc_delivery_state="queued"
         ;;
     esac
   else
@@ -632,6 +640,7 @@ cmd_send() {
           echo "" >&2
           echo "    To re-host this channel: airc join --room ${active_channel}" >&2
           echo "    To wait for a peer to take over: leave it; next 'airc join' that resolves the mesh-singleton will publish a fresh gist." >&2
+          return 1
           ;;
         secondary_rate_limit)
           # gh per-burst write throttle (#381 layer A — HTTP 403 with
@@ -652,6 +661,7 @@ cmd_send() {
           echo "  ⏳ gh secondary rate limit hit — broadcast queued. Drain loop will retry once the burst window clears (60-180s typical)." >&2
           echo "  Avoid sending more for ~2 minutes to let the throttle clear." >&2
           echo "  Bearer: ${_host_detail:-<none>}" >&2
+          _airc_delivery_state="queued"
           ;;
         transient_failure|"")
           # Mirror joiner-side queue/drain symmetry (#381 layer B). Pre-fix
@@ -668,12 +678,14 @@ cmd_send() {
           echo "$_host_queue_marker" >> "$MESSAGES"
           echo "  Network error reaching gist — broadcast queued for retry. Monitor will flush when gist returns." >&2
           echo "  Bearer: ${_host_detail:-<none>}" >&2
+          _airc_delivery_state="queued"
           ;;
         *)
           # Unknown kind — bearer_cli added an outcome without updating
           # callers. Queue defensively + log loudly so it gets caught.
           echo "$full_msg" >> "$AIRC_WRITE_DIR/pending.jsonl"
           echo "  Unknown bearer outcome kind '${_host_kind}' on host send (detail: ${_host_detail}). Queued defensively. Update cmd_send.sh." >&2
+          _airc_delivery_state="queued"
           ;;
       esac
     else
@@ -693,7 +705,13 @@ cmd_send() {
   # propagation, etc.) stay silent on purpose; the user-invoked surface
   # gets the confirmation.
   if [ "$internal" != "1" ]; then
-    if [ "$peer_name" = "all" ]; then
+    if [ "$_airc_delivery_state" = "queued" ]; then
+      if [ "$peer_name" = "all" ]; then
+        echo "  ↻ queued for #${active_channel}"
+      else
+        echo "  ↻ queued for @${peer_name} on #${active_channel}"
+      fi
+    elif [ "$peer_name" = "all" ]; then
       echo "  → #${active_channel} (broadcast)"
     else
       echo "  → @${peer_name} on #${active_channel}"

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -113,6 +113,8 @@ for ch in subs:
         issues.append("missing channel_gists mapping")
 
     state, state_issue, state_path = load_state(ch)
+    if state.get("last_error"):
+        issues.append(f"bearer error: {state.get('last_error')}")
     signal = signal_for_gist(ch, gist, state)
     signal_source = ch
     if signal is not None:

--- a/lib/airc_core/bearer_cli.py
+++ b/lib/airc_core/bearer_cli.py
@@ -454,6 +454,20 @@ def cmd_recv(args) -> int:
                 _touch_state_heartbeat(state_file, time.time())
     except KeyboardInterrupt:
         pass
+    except Exception as e:
+        if state_file:
+            _write_state_file(state_file, {
+                "kind": getattr(bearer, "KIND", "unknown"),
+                "peer_id": args.peer_id,
+                "last_recv_ts": None,
+                "last_sender": None,
+                "events_total": events_total,
+                "diag": f"bearer recv failed: {e}",
+                "last_error": str(e),
+                "last_error_ts": time.time(),
+            })
+        print(f"bearer recv: stream failed: {e}", file=sys.stderr, flush=True)
+        return 3
     finally:
         _stop_heartbeat.set()
         bearer.close()

--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -849,6 +849,10 @@ class GhBearer(Bearer):
                     return
             gist, get_kind = _gh_api_get_classified(gist_id)
             if gist is None:
+                if get_kind == "gone":
+                    raise GhBearerError(
+                        f"room gist {gist_id} returned 404 (gone)"
+                    )
                 if get_kind == "secondary_rate_limit":
                     delay = max(self._poll_interval, gh_backoff.backoff_until() - _time.time(), 60.0)
                     self._sleep_or_break(delay)

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2071,6 +2071,116 @@ PY
   cleanup_all
 }
 
+# ── Scenario: send_gone_gist_does_not_claim_delivery (#525) ─────────────
+# A dissolved gh room (HTTP 404) is a permanent send failure. Pre-fix,
+# cmd_send printed the correct "channel dissolved" diagnostic and then
+# fell through to the shared success footer:
+#
+#   ✗ Gist for #general returned 404 — channel dissolved.
+#   → @peer on #general
+#
+# That is worse than failure: it trains agents and humans to trust a
+# message that never landed. This scenario stubs only bearer_cli send;
+# all config, signing, and cmd_send shell behavior stays real.
+scenario_send_gone_gist_does_not_claim_delivery() {
+  section "send_gone_gist_does_not_claim_delivery: 404 suppresses delivered banner"
+  cleanup_all
+
+  local root=/tmp/airc-it-gone
+  local home="$root/state"
+  local fakebin="$root/bin"
+  mkdir -p "$home/identity" "$home/peers" "$fakebin"
+  scaffold_identity "$home/identity" 'airc-test-gone' || {
+    fail "could not scaffold identity"
+    cleanup_all; return
+  }
+  cat > "$home/config.json" <<'JSON'
+{
+  "name": "gone-joiner",
+  "host_target": "nobody@127.0.0.1",
+  "host_airc_home": "/tmp/airc-it-gone/host",
+  "subscribed_channels": ["general"],
+  "channel_gists": {
+    "general": "deadbeefdeadbeefdeadbeefdeadbeef"
+  }
+}
+JSON
+
+  printf '{"kind":"gh","peer_id":"self","last_recv_ts":null,"events_total":0,"diag":"bearer recv failed: room gist deadbeef returned 404 (gone)","last_error":"room gist deadbeef returned 404 (gone)","last_error_ts":%s,"last_heartbeat_ts":%s}\n' \
+    "$(date +%s)" "$(date +%s)" > "$home/bearer_state.general.json"
+  local status_out
+  status_out=$(AIRC_HOME="$home" "$AIRC" status 2>&1)
+  echo "$status_out" | grep -q 'transport health: DEGRADED' \
+    && echo "$status_out" | grep -q 'bearer error: room gist deadbeef returned 404' \
+    && pass "status reports recv-side 404 as degraded despite fresh heartbeat" \
+    || fail "status treated recv-side 404 as healthy (got: $status_out)"
+
+  local real_py="${AIRC_PYTHON:-$(command -v python3)}"
+  cat > "$fakebin/python" <<SH
+#!/bin/bash
+if [ "\${1:-}" = "-m" ] && [ "\${2:-}" = "airc_core.bearer_cli" ] && [ "\${3:-}" = "send" ]; then
+  cat >/dev/null
+  case "\${AIRC_FAKE_BEARER_KIND:-gone}" in
+    gone)
+      printf '%s\n' '{"kind":"gone","detail":"GET gists/deadbeefdeadbeefdeadbeefdeadbeef failed: gone"}'
+      exit 0
+      ;;
+    transient_failure)
+      printf '%s\n' '{"kind":"transient_failure","detail":"simulated network outage"}'
+      exit 0
+      ;;
+  esac
+fi
+exec "$real_py" "\$@"
+SH
+  chmod +x "$fakebin/python"
+
+  local out err rc
+  out=$(mktemp -t airc-gone-out.XXXXXX)
+  err=$(mktemp -t airc-gone-err.XXXXXX)
+  AIRC_HOME="$home" AIRC_PYTHON="$fakebin/python" "$AIRC" msg @ghost "lost forever" >"$out" 2>"$err"
+  rc=$?
+
+  [ "$rc" -ne 0 ] \
+    && pass "404 send exits non-zero" \
+    || fail "404 send exited 0"
+
+  grep -qE 'returned 404|channel dissolved|message NOT delivered|Re-host' "$err" \
+    && pass "stderr surfaces dissolved-channel recovery" \
+    || fail "stderr missed dissolved-channel diagnostic (got: $(cat "$err"))"
+
+  if grep -qE '→ @ghost|→ #general' "$out"; then
+    fail "printed delivered arrow after 404 (stdout: $(cat "$out"))"
+  else
+    pass "404 does not print delivered arrow"
+  fi
+
+  local mapping
+  mapping=$(AIRC_HOME="$home" "$real_py" -m airc_core.config get_channel_gist \
+    --config "$home/config.json" --channel general 2>/dev/null || true)
+  [ -z "$mapping" ] \
+    && pass "stale channel gist mapping cleared" \
+    || fail "stale channel gist mapping still present: $mapping"
+
+  AIRC_FAKE_BEARER_KIND=transient_failure AIRC_HOME="$home" AIRC_PYTHON="$fakebin/python" \
+    "$AIRC" msg @ghost "retry later" >"$out" 2>"$err"
+  rc=$?
+  [ "$rc" -eq 0 ] \
+    && pass "transient send still queues successfully" \
+    || fail "transient queue exited non-zero ($rc)"
+  if grep -qE '→ @ghost|→ #general' "$out"; then
+    fail "printed delivered arrow for queued send (stdout: $(cat "$out"))"
+  elif grep -q '↻ queued for @ghost on #general' "$out"; then
+    pass "queued send prints queued banner, not delivered banner"
+  else
+    fail "queued send missing queued banner (stdout: $(cat "$out"); stderr: $(cat "$err"))"
+  fi
+
+  rm -f "$out" "$err"
+  rm -rf "$root"
+  cleanup_all
+}
+
 # ── Scenario: monitor_liveness_process_evidence ────────────────────────
 # A project .airc scope can be shared by several Claude/Codex tabs. This
 # scenario keeps monitor liveness honest at the process-evidence layer:
@@ -4557,6 +4667,7 @@ case "$MODE" in
   two_tab_localhost) scenario_two_tab_localhost ;;
   auto_scope)   scenario_auto_scope ;;
   send_dead_monitor_dies) scenario_send_dead_monitor_dies ;;
+  send_gone_gist_does_not_claim_delivery) scenario_send_gone_gist_does_not_claim_delivery ;;
   monitor_liveness_process_evidence) scenario_monitor_liveness_process_evidence ;;
   attach_starts_background_transport) scenario_attach_starts_background_transport ;;
   attach_spawn_strips_attach_flag) scenario_attach_spawn_strips_attach_flag ;;
@@ -4596,7 +4707,7 @@ case "$MODE" in
     scenario_auth_failure; scenario_room; scenario_events; scenario_get_host
     scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat
     scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope
-    scenario_send_dead_monitor_dies; scenario_monitor_liveness_process_evidence
+    scenario_send_dead_monitor_dies; scenario_send_gone_gist_does_not_claim_delivery; scenario_monitor_liveness_process_evidence
     scenario_attach_starts_background_transport; scenario_attach_spawn_strips_attach_flag; scenario_codex_join_detaches_transport
     scenario_gh_secondary_rate_limit_degraded_startup
     scenario_solo_mesh_warns
@@ -4611,7 +4722,7 @@ case "$MODE" in
     scenario_custom_room_creates_gist
     scenario_invite_human
     ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|monitor_liveness_process_evidence|gh_secondary_rate_limit_degraded_startup|solo_mesh_warns|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|send_gone_gist_does_not_claim_delivery|monitor_liveness_process_evidence|gh_secondary_rate_limit_degraded_startup|solo_mesh_warns|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
 esac
 
 echo

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -582,6 +582,33 @@ class BearerCliStateFileTests(unittest.TestCase):
         self.assertEqual(state["last_heartbeat_ts"], 456.0)
         _os.unlink(state_path)
 
+    def test_stream_exception_marks_state_failed(self):
+        import json as _json
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as f:
+            state_path = f.name
+
+        class _FailingBearer(self._FakeBearer):
+            def recv_stream(self):
+                raise RuntimeError("room gist abc123 returned 404 (gone)")
+                yield  # pragma: no cover
+
+        fake = _FailingBearer({})
+        fake_stdout, _ = self._capture_stdout_bytes()
+        fake_stderr = mock.Mock()
+        with mock.patch.object(bearer_cli, "resolve", return_value=fake), \
+             mock.patch.object(bearer_cli.sys, "stdout", fake_stdout), \
+             mock.patch.object(bearer_cli.sys, "stderr", fake_stderr):
+            rc = bearer_cli.cmd_recv(self._make_args(state_path))
+
+        self.assertEqual(rc, 3)
+        with open(state_path) as f:
+            state = _json.load(f)
+        self.assertIn("returned 404", state["last_error"])
+        self.assertIn("bearer recv failed", state["diag"])
+        self.assertIsNone(state["last_recv_ts"])
+        self.assertTrue(fake.closed)
+
     def test_no_state_file_means_no_writes(self):
         events = [ReceivedMessage(
             sender_peer_id="bob",
@@ -1759,6 +1786,18 @@ class GhBearerRecvTests(unittest.TestCase):
 
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0].sender_peer_id, "bob")
+
+    def test_recv_raises_when_gist_is_gone(self):
+        b = self._bearer()
+        with mock.patch.object(
+            bearer_gh,
+            "_gh_api_get_classified",
+            return_value=(None, "gone"),
+        ):
+            with self.assertRaises(GhBearerError) as ctx:
+                next(b.recv_stream())
+
+        self.assertIn("returned 404", str(ctx.exception))
 
     def test_recv_secondary_rate_limit_sleeps_through_shared_backoff(self):
         b = self._bearer({"poll_interval": 15})


### PR DESCRIPTION
## Summary
- make gh 404/gone sends exit non-zero instead of falling through to the delivered arrow
- show queued sends as queued instead of using the delivered arrow
- make recv-side gh 404 stop the bearer stream and record `last_error` instead of continuing fresh heartbeats against a dissolved gist
- teach `airc status` to report bearer `last_error` as degraded
- add hermetic integration + unit regression coverage

## Validation
- `bash -n lib/airc_bash/cmd_send.sh lib/airc_bash/cmd_status.sh test/integration.sh`
- `./test/integration.sh send_gone_gist_does_not_claim_delivery`
- `python3 test/test_bearer.py`

## Context
Caught from the vHSM -> authenticator DM failure. The bearer correctly classified the dissolved gist as gone, but `cmd_send` still printed `→ @authenticator-448f on #general`. Follow-up inspection found vHSM's recv log repeatedly polling a 404 gist while status reported fresh heartbeat; this PR fixes both the false send success and the false recv health.