### PR TITLE
fix(join): reap duplicate same-scope transports

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -169,6 +169,7 @@ _join_restart_scope_processes() {
     [ -f "$_pidfile" ] || continue
     _pids="$_pids $(cat "$_pidfile" 2>/dev/null | awk '{print $1}' | tr '\n' ' ')"
   done
+  _pids="$_pids $(_join_scope_transport_pids 2>/dev/null | tr '\n' ' ')"
   local _p _c
   for _p in $_pids; do
     case "$_p" in ''|*[!0-9]*) continue ;; esac
@@ -178,6 +179,89 @@ _join_restart_scope_processes() {
     done
   done
   rm -f "$AIRC_WRITE_DIR/airc.pid" "$AIRC_WRITE_DIR"/bearer_gist.*.pid 2>/dev/null || true
+}
+
+_join_scope_transport_pids() {
+  # Scope-path catch-all for `airc join` self-heal. Pidfiles are not
+  # enough after Monitor restarts: old bearer_cli / monitor_formatter
+  # children can be reparented to init and keep serving the same scope
+  # while the new generation also runs. Match only transport/process
+  # owners for THIS scope; leave UI-only log_tail attach streams alone.
+  local _pids=""
+  local _pid _cmd
+  for _pid in $(proc_airc_pids_matching "$AIRC_WRITE_DIR" 2>/dev/null | sort -un || true); do
+    case "$_pid" in ''|*[!0-9]*) continue ;; esac
+    [ "$_pid" = "$$" ] && continue
+    [ "$_pid" = "$PPID" ] && continue
+    _cmd=$(proc_cmdline "$_pid" || true)
+    case "$_cmd" in
+      *airc_core.log_tail*) continue ;;
+      *airc_core.bearer_cli*recv*|*airc_core.monitor_formatter*|*airc_core.handshake*accept_one*)
+        _pids="$_pids $_pid"
+        ;;
+      *) continue ;;
+    esac
+
+    # Reap airc wrapper ancestors too. They often do not include
+    # AIRC_HOME in argv because the scope is in the environment, but if
+    # their Python children are ours, the wrapper is ours.
+    local _ancestor _depth _ancestor_cmd
+    _ancestor=$(proc_parent "$_pid" || true)
+    _depth=0
+    while [ -n "$_ancestor" ] && [ "$_ancestor" != "1" ] && [ "$_depth" -lt 6 ]; do
+      _ancestor_cmd=$(proc_cmdline "$_ancestor" || true)
+      if echo "$_ancestor_cmd" | grep -Eq '(^|[[:space:]])/[^[:space:]]*/airc[[:space:]]+(connect|join)([[:space:]]|$)|(^|[[:space:]])airc[[:space:]]+(connect|join)([[:space:]]|$)|eval .*airc[[:space:]]+(connect|join)'; then
+        _pids="$_pids $_ancestor"
+        _ancestor=$(proc_parent "$_ancestor" || true)
+        _depth=$((_depth + 1))
+      else
+        break
+      fi
+    done
+  done
+
+  # Include direct children of everything we found. This catches short
+  # wrapper trees without relying on one pidfile generation being current.
+  local _base _child
+  for _base in $_pids; do
+    for _child in $(proc_children "$_base" 2>/dev/null); do
+      _pids="$_pids $_child"
+    done
+  done
+  for _pid in $_pids; do
+    case "$_pid" in ''|*[!0-9]*) continue ;; esac
+    [ "$_pid" = "$$" ] && continue
+    [ "$_pid" = "$PPID" ] && continue
+    printf '%s\n' "$_pid"
+  done | sort -un
+}
+
+_join_scope_has_duplicate_transport() {
+  local _fmt_count
+  _fmt_count=$(_airc_scope_monitor_formatter_pids "$AIRC_WRITE_DIR" 2>/dev/null | wc -l | tr -d ' ')
+  if [ "${_fmt_count:-0}" -gt 1 ] 2>/dev/null; then
+    return 0
+  fi
+
+  local _seen_gists="" _pid _cmd _gid
+  for _pid in $(proc_airc_pids_matching 'airc_core\.bearer_cli[[:space:]]+recv' 2>/dev/null | sort -un || true); do
+    _cmd=$(proc_cmdline "$_pid" || true)
+    printf '%s\n' "$_cmd" | grep -Fq -- "$AIRC_WRITE_DIR" || continue
+    _gid=$(printf '%s\n' "$_cmd" | awk '{
+      for (i = 1; i <= NF; i++) {
+        if ($i == "--room-gist-id" && (i + 1) <= NF) {
+          print $(i + 1); exit
+        }
+      }
+    }')
+    [ -n "$_gid" ] || continue
+    case " $_seen_gists " in
+      *" $_gid "*) return 0 ;;
+      *) _seen_gists="$_seen_gists $_gid" ;;
+    esac
+  done
+
+  return 1
 }
 
 _join_attach_local_stream() {
@@ -589,6 +673,10 @@ cmd_connect() {
     fi
     if [ "$_repair_running_monitor" = "1" ]; then
       echo "  airc join: restarting this scope's AIRC process to leave the solo island."
+      _join_restart_scope_processes
+      sleep 1
+    elif _join_scope_has_duplicate_transport; then
+      echo "  airc join: duplicate same-scope transport generation detected; restarting this scope's AIRC process."
       _join_restart_scope_processes
       sleep 1
     else

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2378,6 +2378,56 @@ scenario_codex_join_detaches_transport() {
   cleanup_all
 }
 
+# ── Scenario: join_reaps_duplicate_scope_transport ─────────────────────
+# `airc join` is the public recovery verb. If prior Monitor / attach
+# bounces leave multiple same-scope transport generations alive, join
+# must repair the scope without requiring users to know about teardown.
+scenario_join_reaps_duplicate_scope_transport() {
+  section "join_reaps_duplicate_scope_transport: join restarts duplicate same-scope generations"
+  cleanup_all
+
+  local root=/tmp/airc-it-dup-scope
+  local home="$root/state"
+  local out="$root/out.log"
+  local err="$root/err.log"
+  mkdir -p "$home/peers" "$root"
+
+  echo "99999" > "$home/airc.pid"
+  ( exec -a "python -u -X utf8 -m airc_core.monitor_formatter --peers-dir $home/peers --my-name stale-one" sleep 60 ) &
+  local stale_one=$!
+  ( exec -a "python -u -X utf8 -m airc_core.monitor_formatter --peers-dir $home/peers --my-name stale-two" sleep 60 ) &
+  local stale_two=$!
+
+  AIRC_HOME="$home" AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 AIRC_NO_CODEX_DETACH=1 \
+    "$AIRC" join --no-room --no-gist >"$out" 2>"$err" &
+  local join_pid=$!
+
+  local saw=0 i
+  for i in $(seq 1 20); do
+    if grep -q 'duplicate same-scope transport generation detected' "$out" 2>/dev/null; then
+      saw=1
+      break
+    fi
+    sleep 1
+  done
+
+  [ "$saw" = "1" ] \
+    && pass "join detects duplicate same-scope transport" \
+    || fail "join did not report duplicate transport (stdout=$(cat "$out" 2>/dev/null); stderr=$(cat "$err" 2>/dev/null))"
+
+  if kill -0 "$stale_one" 2>/dev/null || kill -0 "$stale_two" 2>/dev/null; then
+    fail "duplicate formatter processes survived join self-heal"
+  else
+    pass "join reaped duplicate formatter processes"
+  fi
+
+  kill "$join_pid" 2>/dev/null || true
+  wait "$join_pid" 2>/dev/null || true
+  AIRC_HOME="$home" "$AIRC" teardown >/dev/null 2>&1 || true
+  rm -rf "$root"
+  cleanup_all
+}
+
 # ── Scenario: gh_secondary_rate_limit_degraded_startup (#479) ──────────
 # GitHub secondary throttling must not prevent monitor startup. On
 # 2026-05-04 Windows/WSL hit this shape: `gh auth status` tripped the
@@ -4672,6 +4722,7 @@ case "$MODE" in
   attach_starts_background_transport) scenario_attach_starts_background_transport ;;
   attach_spawn_strips_attach_flag) scenario_attach_spawn_strips_attach_flag ;;
   codex_join_detaches_transport) scenario_codex_join_detaches_transport ;;
+  join_reaps_duplicate_scope_transport) scenario_join_reaps_duplicate_scope_transport ;;
   gh_secondary_rate_limit_degraded_startup) scenario_gh_secondary_rate_limit_degraded_startup ;;
   solo_mesh_warns) scenario_solo_mesh_warns ;;
   connect_after_kill_recovers) scenario_connect_after_kill_recovers ;;
@@ -4709,6 +4760,7 @@ case "$MODE" in
     scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope
     scenario_send_dead_monitor_dies; scenario_send_gone_gist_does_not_claim_delivery; scenario_monitor_liveness_process_evidence
     scenario_attach_starts_background_transport; scenario_attach_spawn_strips_attach_flag; scenario_codex_join_detaches_transport
+    scenario_join_reaps_duplicate_scope_transport
     scenario_gh_secondary_rate_limit_degraded_startup
     scenario_solo_mesh_warns
     scenario_connect_after_kill_recovers
@@ -4722,7 +4774,7 @@ case "$MODE" in
     scenario_custom_room_creates_gist
     scenario_invite_human
     ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|send_gone_gist_does_not_claim_delivery|monitor_liveness_process_evidence|gh_secondary_rate_limit_degraded_startup|solo_mesh_warns|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|send_gone_gist_does_not_claim_delivery|monitor_liveness_process_evidence|attach_starts_background_transport|attach_spawn_strips_attach_flag|codex_join_detaches_transport|join_reaps_duplicate_scope_transport|gh_secondary_rate_limit_degraded_startup|solo_mesh_warns|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary
- make `airc join` detect duplicate same-scope transport generations before short-circuiting as already joined
- widen join self-heal restart to reap scope-path-tagged bearer/formatter/handshake children plus their airc wrapper ancestors
- leave UI-only `log_tail` attach streams out of the transport reap set
- add an integration regression for duplicate formatter processes in one scope

## Validation
- `bash -n lib/airc_bash/cmd_connect.sh test/integration.sh`
- `./test/integration.sh join_reaps_duplicate_scope_transport`
- `./test/integration.sh attach_starts_background_transport`
- `./test/integration.sh codex_join_detaches_transport`
- `./test/integration.sh monitor_liveness_process_evidence`
- `./test/integration.sh send_gone_gist_does_not_claim_delivery`

Note: these scenarios are not parallel-safe because the integration harness has global /tmp cleanup; validation was rerun sequentially after a parallel collision exposed that.