### PR TITLE
fix(join): canonicalize scope process detection

### DIFF
--- a/airc
+++ b/airc
@@ -190,9 +190,33 @@ fi
 #
 # AIRC_HOME env var overrides, for tests / edge cases. Normal users don't
 # touch it.
+canonical_scope_path() {
+  local p="$1"
+  if [ -d "$p" ]; then
+    (cd "$p" 2>/dev/null && pwd -P) || echo "$p"
+    return
+  fi
+
+  # Scope dirs often do not exist yet on first join. Canonicalize the
+  # existing parent so /tmp/foo/.airc and /private/tmp/foo/.airc still
+  # resolve to one owner on macOS, without requiring non-portable
+  # realpath/readlink -f.
+  local parent base
+  parent="$(dirname "$p")"
+  base="$(basename "$p")"
+  if [ -d "$parent" ]; then
+    local parent_abs
+    parent_abs="$(cd "$parent" 2>/dev/null && pwd -P)" || parent_abs="$parent"
+    echo "$parent_abs/$base"
+    return
+  fi
+
+  echo "$p"
+}
+
 detect_scope() {
   if [ -n "${AIRC_HOME:-}" ]; then
-    echo "$AIRC_HOME"
+    canonical_scope_path "$AIRC_HOME"
     return
   fi
 
@@ -509,9 +533,39 @@ _airc_scope_monitor_formatter_pids() {
     case "$p" in ''|*[!0-9]*) continue ;; esac
     cmd=$(proc_cmdline "$p" 2>/dev/null || true)
     printf '%s\n' "$cmd" | grep -Fq -- 'airc_core.monitor_formatter' || continue
-    printf '%s\n' "$cmd" | grep -Fq -- "--peers-dir $scope_dir/peers" || continue
+    _airc_cmdline_mentions_scope "$cmd" "$scope_dir/peers" || continue
     printf '%s\n' "$p"
   done
+}
+
+_airc_scope_path_variants() {
+  local scope_dir="${1:-}"
+  [ -n "$scope_dir" ] || return 0
+  local canon
+  canon=$(canonical_scope_path "$scope_dir")
+  {
+    printf '%s\n' "$scope_dir"
+    printf '%s\n' "$canon"
+    case "$canon" in
+      /private/tmp/*) printf '/tmp/%s\n' "${canon#/private/tmp/}" ;;
+      /tmp/*)         printf '/private/tmp/%s\n' "${canon#/tmp/}" ;;
+    esac
+  } | sort -u
+}
+
+_airc_cmdline_mentions_scope() {
+  local cmd="${1:-}"
+  local scope_dir="${2:-}"
+  [ -n "$cmd" ] || return 1
+  [ -n "$scope_dir" ] || return 1
+  local variant
+  while IFS= read -r variant; do
+    [ -n "$variant" ] || continue
+    printf '%s\n' "$cmd" | grep -Fq -- "$variant" && return 0
+  done <<EOF
+$(_airc_scope_path_variants "$scope_dir")
+EOF
+  return 1
 }
 
 _airc_cmdline_is_monitor_wrapper() {

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -135,6 +135,12 @@ _join_show_status_and_inbox() {
 
 _join_transport_health_ok() {
   [ -f "$CONFIG" ] || return 1
+  local _channels
+  _channels=$("$AIRC_PYTHON" -m airc_core.config read_channels --config "$CONFIG" 2>/dev/null || true)
+  # Legacy/no-room mode has no gist bearer to heartbeat. If the caller
+  # already proved the scope owner is alive, transport_health has no
+  # channel rows to evaluate and must not force a duplicate restart.
+  [ -n "$_channels" ] || return 0
   "$AIRC_PYTHON" -m airc_core.transport_health check \
     --home "$AIRC_WRITE_DIR" \
     --config "$CONFIG" \
@@ -178,6 +184,15 @@ _join_restart_scope_processes() {
       kill "$_c" 2>/dev/null || true
     done
   done
+  sleep 1
+  for _p in $_pids; do
+    case "$_p" in ''|*[!0-9]*) continue ;; esac
+    kill -0 "$_p" 2>/dev/null || continue
+    kill -9 "$_p" 2>/dev/null || true
+    for _c in $(proc_children "$_p" 2>/dev/null); do
+      kill -9 "$_c" 2>/dev/null || true
+    done
+  done
   rm -f "$AIRC_WRITE_DIR/airc.pid" "$AIRC_WRITE_DIR"/bearer_gist.*.pid 2>/dev/null || true
 }
 
@@ -188,37 +203,42 @@ _join_scope_transport_pids() {
   # while the new generation also runs. Match only transport/process
   # owners for THIS scope; leave UI-only log_tail attach streams alone.
   local _pids=""
-  local _pid _cmd
-  for _pid in $(proc_airc_pids_matching "$AIRC_WRITE_DIR" 2>/dev/null | sort -un || true); do
-    case "$_pid" in ''|*[!0-9]*) continue ;; esac
-    [ "$_pid" = "$$" ] && continue
-    [ "$_pid" = "$PPID" ] && continue
-    _cmd=$(proc_cmdline "$_pid" || true)
-    case "$_cmd" in
-      *airc_core.log_tail*) continue ;;
-      *airc_core.bearer_cli*recv*|*airc_core.monitor_formatter*|*airc_core.handshake*accept_one*)
-        _pids="$_pids $_pid"
-        ;;
-      *) continue ;;
-    esac
+  local _pid _cmd _scope_variant
+  while IFS= read -r _scope_variant; do
+    [ -n "$_scope_variant" ] || continue
+    for _pid in $(proc_airc_pids_matching "$_scope_variant" 2>/dev/null | sort -un || true); do
+      case "$_pid" in ''|*[!0-9]*) continue ;; esac
+      [ "$_pid" = "$$" ] && continue
+      [ "$_pid" = "$PPID" ] && continue
+      _cmd=$(proc_cmdline "$_pid" || true)
+      case "$_cmd" in
+        *airc_core.log_tail*) continue ;;
+        *airc_core.bearer_cli*recv*|*airc_core.monitor_formatter*|*airc_core.handshake*accept_one*)
+          _pids="$_pids $_pid"
+          ;;
+        *) continue ;;
+      esac
 
-    # Reap airc wrapper ancestors too. They often do not include
-    # AIRC_HOME in argv because the scope is in the environment, but if
-    # their Python children are ours, the wrapper is ours.
-    local _ancestor _depth _ancestor_cmd
-    _ancestor=$(proc_parent "$_pid" || true)
-    _depth=0
-    while [ -n "$_ancestor" ] && [ "$_ancestor" != "1" ] && [ "$_depth" -lt 6 ]; do
-      _ancestor_cmd=$(proc_cmdline "$_ancestor" || true)
-      if echo "$_ancestor_cmd" | grep -Eq '(^|[[:space:]])/[^[:space:]]*/airc[[:space:]]+(connect|join)([[:space:]]|$)|(^|[[:space:]])airc[[:space:]]+(connect|join)([[:space:]]|$)|eval .*airc[[:space:]]+(connect|join)'; then
-        _pids="$_pids $_ancestor"
-        _ancestor=$(proc_parent "$_ancestor" || true)
-        _depth=$((_depth + 1))
-      else
-        break
-      fi
+      # Reap airc wrapper ancestors too. They often do not include
+      # AIRC_HOME in argv because the scope is in the environment, but if
+      # their Python children are ours, the wrapper is ours.
+      local _ancestor _depth _ancestor_cmd
+      _ancestor=$(proc_parent "$_pid" || true)
+      _depth=0
+      while [ -n "$_ancestor" ] && [ "$_ancestor" != "1" ] && [ "$_depth" -lt 6 ]; do
+        _ancestor_cmd=$(proc_cmdline "$_ancestor" || true)
+        if echo "$_ancestor_cmd" | grep -Eq '(^|[[:space:]])/[^[:space:]]*/airc[[:space:]]+(connect|join)([[:space:]]|$)|(^|[[:space:]])airc[[:space:]]+(connect|join)([[:space:]]|$)|eval .*airc[[:space:]]+(connect|join)'; then
+          _pids="$_pids $_ancestor"
+          _ancestor=$(proc_parent "$_ancestor" || true)
+          _depth=$((_depth + 1))
+        else
+          break
+        fi
+      done
     done
-  done
+  done <<EOF
+$(_airc_scope_path_variants "$AIRC_WRITE_DIR")
+EOF
 
   # Include direct children of everything we found. This catches short
   # wrapper trees without relying on one pidfile generation being current.
@@ -246,7 +266,7 @@ _join_scope_has_duplicate_transport() {
   local _seen_gists="" _pid _cmd _gid
   for _pid in $(proc_airc_pids_matching 'airc_core\.bearer_cli[[:space:]]+recv' 2>/dev/null | sort -un || true); do
     _cmd=$(proc_cmdline "$_pid" || true)
-    printf '%s\n' "$_cmd" | grep -Fq -- "$AIRC_WRITE_DIR" || continue
+    _airc_cmdline_mentions_scope "$_cmd" "$AIRC_WRITE_DIR" || continue
     _gid=$(printf '%s\n' "$_cmd" | awk '{
       for (i = 1; i <= NF; i++) {
         if ($i == "--room-gist-id" && (i + 1) <= NF) {

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2378,6 +2378,69 @@ scenario_codex_join_detaches_transport() {
   cleanup_all
 }
 
+# ── Scenario: codex_join_idempotent_when_healthy ───────────────────────
+# A healthy Codex scope must treat repeat `airc join` as success without
+# spawning another detached transport. This is the normal "type /join again"
+# recovery habit, so duplicate prevention needs explicit coverage.
+scenario_codex_join_idempotent_when_healthy() {
+  section "codex_join_idempotent_when_healthy: repeat Codex join does not spawn duplicates"
+  cleanup_all
+
+  local root=/tmp/airc-it-codex-idempotent
+  local home="$root/state"
+  local first_out="$root/first.out"
+  local first_err="$root/first.err"
+  local second_out="$root/second.out"
+  local second_err="$root/second.err"
+  mkdir -p "$root"
+
+  CODEX_THREAD_ID=airc-it-codex-idempotent AIRC_HOME="$home" AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 \
+    "$AIRC" join --no-room --no-gist >"$first_out" 2>"$first_err"
+  local first_rc=$?
+
+  [ "$first_rc" = "0" ] \
+    && pass "first codex join returned success" \
+    || fail "first codex join failed rc=$first_rc stdout=$(cat "$first_out" 2>/dev/null) stderr=$(cat "$first_err" 2>/dev/null)"
+
+  local first_status="" first_pid="" i
+  for i in $(seq 1 10); do
+    first_status=$(AIRC_HOME="$home" "$AIRC" status 2>&1 || true)
+    first_pid=$(printf '%s\n' "$first_status" | sed -n 's/.*airc process:.*PID \([0-9][0-9]*\).*/\1/p' | head -1)
+    [ -n "$first_pid" ] && break
+    sleep 1
+  done
+  [ -n "$first_pid" ] \
+    && pass "first codex join left a live transport pid" \
+    || fail "first codex join did not produce a live pid (status=$first_status; stdout=$(cat "$first_out" 2>/dev/null); stderr=$(cat "$first_err" 2>/dev/null))"
+
+  CODEX_THREAD_ID=airc-it-codex-idempotent AIRC_HOME="$home" AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 \
+    "$AIRC" join --no-room --no-gist >"$second_out" 2>"$second_err"
+  local second_rc=$?
+
+  [ "$second_rc" = "0" ] \
+    && pass "repeat codex join returned success" \
+    || fail "repeat codex join failed rc=$second_rc stdout=$(cat "$second_out" 2>/dev/null) stderr=$(cat "$second_err" 2>/dev/null)"
+  grep -q "airc join: already joined in this scope" "$second_out" \
+    && pass "repeat codex join reported already-joined state" \
+    || fail "repeat codex join did not report already-joined state (stdout=$(cat "$second_out" 2>/dev/null); stderr=$(cat "$second_err" 2>/dev/null))"
+  if grep -q "airc join: launched Codex-detached transport" "$second_out"; then
+    fail "repeat codex join launched another detached transport"
+  else
+    pass "repeat codex join did not launch another detached transport"
+  fi
+
+  local second_status="" second_pid=""
+  second_status=$(AIRC_HOME="$home" "$AIRC" status 2>&1 || true)
+  second_pid=$(printf '%s\n' "$second_status" | sed -n 's/.*airc process:.*PID \([0-9][0-9]*\).*/\1/p' | head -1)
+  [ "$second_pid" = "$first_pid" ] \
+    && pass "repeat codex join preserved the running transport pid" \
+    || fail "repeat codex join changed transport pid (before=$first_pid after=$second_pid status=$second_status)"
+
+  AIRC_HOME="$home" "$AIRC" teardown >/dev/null 2>&1 || true
+  rm -rf "$root"
+  cleanup_all
+}
+
 # ── Scenario: codex_join_waits_for_duplicate_repair ────────────────────
 # Codex start returns to the tool after launching a detached transport.
 # If that transport must first reap duplicate same-scope generations,
@@ -2470,9 +2533,11 @@ scenario_join_reaps_duplicate_scope_transport() {
     pass "join reaped duplicate formatter processes"
   fi
 
-  kill "$join_pid" 2>/dev/null || true
-  wait "$join_pid" 2>/dev/null || true
   AIRC_HOME="$home" "$AIRC" teardown >/dev/null 2>&1 || true
+  kill "$join_pid" 2>/dev/null || true
+  sleep 1
+  kill -9 "$join_pid" 2>/dev/null || true
+  wait "$join_pid" 2>/dev/null || true
   rm -rf "$root"
   cleanup_all
 }
@@ -4771,6 +4836,7 @@ case "$MODE" in
   attach_starts_background_transport) scenario_attach_starts_background_transport ;;
   attach_spawn_strips_attach_flag) scenario_attach_spawn_strips_attach_flag ;;
   codex_join_detaches_transport) scenario_codex_join_detaches_transport ;;
+  codex_join_idempotent_when_healthy) scenario_codex_join_idempotent_when_healthy ;;
   codex_join_waits_for_duplicate_repair) scenario_codex_join_waits_for_duplicate_repair ;;
   join_reaps_duplicate_scope_transport) scenario_join_reaps_duplicate_scope_transport ;;
   gh_secondary_rate_limit_degraded_startup) scenario_gh_secondary_rate_limit_degraded_startup ;;
@@ -4810,6 +4876,7 @@ case "$MODE" in
     scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope
     scenario_send_dead_monitor_dies; scenario_send_gone_gist_does_not_claim_delivery; scenario_monitor_liveness_process_evidence
     scenario_attach_starts_background_transport; scenario_attach_spawn_strips_attach_flag; scenario_codex_join_detaches_transport
+    scenario_codex_join_idempotent_when_healthy
     scenario_codex_join_waits_for_duplicate_repair
     scenario_join_reaps_duplicate_scope_transport
     scenario_gh_secondary_rate_limit_degraded_startup
@@ -4825,7 +4892,7 @@ case "$MODE" in
     scenario_custom_room_creates_gist
     scenario_invite_human
     ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|send_gone_gist_does_not_claim_delivery|monitor_liveness_process_evidence|attach_starts_background_transport|attach_spawn_strips_attach_flag|codex_join_detaches_transport|codex_join_waits_for_duplicate_repair|join_reaps_duplicate_scope_transport|gh_secondary_rate_limit_degraded_startup|solo_mesh_warns|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|send_gone_gist_does_not_claim_delivery|monitor_liveness_process_evidence|attach_starts_background_transport|attach_spawn_strips_attach_flag|codex_join_detaches_transport|codex_join_idempotent_when_healthy|codex_join_waits_for_duplicate_repair|join_reaps_duplicate_scope_transport|gh_secondary_rate_limit_degraded_startup|solo_mesh_warns|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary
- canonicalize explicit AIRC_HOME before scope ownership decisions so /tmp and /private/tmp do not split a Mac scope
- match same-scope process evidence across symlink-equivalent paths when detecting/reaping formatter, bearer, and handshake transport processes
- treat alive no-room transports as healthy because there is no gist bearer heartbeat to evaluate
- add a Codex idempotent join regression and harden duplicate-reap cleanup

## Validation
- bash -n airc lib/airc_bash/cmd_connect.sh test/integration.sh
- ./test/integration.sh codex_join_idempotent_when_healthy
- ./test/integration.sh codex_join_detaches_transport
- ./test/integration.sh codex_join_waits_for_duplicate_repair
- ./test/integration.sh join_reaps_duplicate_scope_transport
- live Continuum scope: airc join returned already joined; status transport health ok

## Notes
This addresses a real same-machine failure mode: one tab/process labels the scope as /tmp/... while another sees /private/tmp/..., causing duplicate transport generations or missed repair.