### PR TITLE
fix(gh): drain pending sends under governor

### DIFF
--- a/airc
+++ b/airc
@@ -1776,6 +1776,14 @@ flush_pending_loop() {
     [ -z "$host_target" ] && continue
     rhome=$(remote_home)
 
+    local _gh_wait=0
+    _gh_wait=$("$AIRC_PYTHON" -m airc_core.gh_backoff wait-seconds 2>/dev/null || echo 0)
+    if [ "${_gh_wait:-0}" -gt 0 ] 2>/dev/null; then
+      [ "$_gh_wait" -gt 60 ] 2>/dev/null && _gh_wait=60
+      sleep "$_gh_wait"
+      continue
+    fi
+
     local snapshot; snapshot=$(mktemp -t airc-pending-snap.XXXXXX)
     local unsent;   unsent=$(mktemp -t airc-pending-unsent.XXXXXX)
     # Atomic-ish snapshot: mv is atomic on same filesystem, so new sends that
@@ -1867,6 +1875,14 @@ flush_pending_host_loop() {
     fi
     [ -s "$pending" ] || continue
 
+    local _gh_wait=0
+    _gh_wait=$("$AIRC_PYTHON" -m airc_core.gh_backoff wait-seconds 2>/dev/null || echo 0)
+    if [ "${_gh_wait:-0}" -gt 0 ] 2>/dev/null; then
+      [ "$_gh_wait" -gt 60 ] 2>/dev/null && _gh_wait=60
+      sleep "$_gh_wait"
+      continue
+    fi
+
     local snapshot; snapshot=$(mktemp -t airc-pending-host-snap.XXXXXX)
     local unsent;   unsent=$(mktemp -t airc-pending-host-unsent.XXXXXX)
     # Atomic-ish snapshot: mv is atomic on same FS so concurrent cmd_send
@@ -1874,6 +1890,34 @@ flush_pending_host_loop() {
     mv "$pending" "$snapshot" 2>/dev/null || { rm -f "$snapshot" "$unsent"; continue; }
 
     local delivered=0 failed=0
+    local _fallback_gist=""
+    [ -f "$AIRC_WRITE_DIR/room_gist_id" ] && _fallback_gist=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
+    local _batch_route _batch_ok _batch_channel _batch_gist _batch_count
+    _batch_route=$("$AIRC_PYTHON" -m airc_core.pending_batch host-broadcast-route \
+      --snapshot "$snapshot" --config "$CONFIG" --fallback-gist "$_fallback_gist" 2>/dev/null || true)
+    IFS="$(printf '\t')" read -r _batch_ok _batch_channel _batch_gist _batch_count <<EOF
+$_batch_route
+EOF
+    if [ "$_batch_ok" = "ok" ] && [ -n "$_batch_gist" ]; then
+      local _batch_outcome _batch_kind
+      _batch_outcome=$(cat "$snapshot" | "$AIRC_PYTHON" -m airc_core.bearer_cli send-batch \
+        all "$_batch_channel" --room-gist-id "$_batch_gist" 2>/dev/null || echo '{"kind":"transient_failure"}')
+      _batch_kind=$(printf '%s' "$_batch_outcome" | "$AIRC_PYTHON" -c 'import json,sys
+try:
+  print(json.load(sys.stdin).get("kind",""))
+except Exception:
+  print("")' 2>/dev/null)
+      if [ "$_batch_kind" = "delivered" ]; then
+        cat "$snapshot" >> "$MESSAGES"
+        delivered=${_batch_count:-0}
+        : > "$snapshot"
+      else
+        cat "$snapshot" >> "$unsent"
+        failed=${_batch_count:-0}
+        : > "$snapshot"
+      fi
+    fi
+
     while IFS= read -r line; do
       [ -z "$line" ] && continue
 

--- a/lib/airc_core/bearer.py
+++ b/lib/airc_core/bearer.py
@@ -204,6 +204,20 @@ class Bearer(ABC):
         the caller's responsibility, not the bearer's.
         """
 
+    def send_many(self, peer_id: str, channel: str, payloads: list[bytes]) -> SendOutcome:
+        """Deliver multiple payloads to the same peer/channel.
+
+        Default implementation preserves existing bearer semantics by
+        sending in order and stopping at the first non-delivered outcome.
+        Bearers with native append surfaces, such as gh gist, can override
+        this to batch many queued messages into one transport operation.
+        """
+        for payload in payloads:
+            outcome = self.send(peer_id, channel, payload)
+            if outcome.kind != "delivered":
+                return outcome
+        return SendOutcome(kind="delivered", detail=f"{len(payloads)} payload(s)")
+
     @abstractmethod
     def recv_stream(self) -> Iterator[ReceivedMessage]:
         """Yield ReceivedMessage events as they arrive on this bearer.

--- a/lib/airc_core/bearer_cli.py
+++ b/lib/airc_core/bearer_cli.py
@@ -298,6 +298,36 @@ def cmd_send(args) -> int:
     return 0
 
 
+def cmd_send_batch(args) -> int:
+    peer_meta = {
+        "host_target": args.host_target,
+        "remote_home": args.remote_home,
+        "identity_key": args.identity_key,
+        "room_gist_id": getattr(args, "room_gist_id", None),
+    }
+    peer_meta = {k: v for k, v in peer_meta.items() if v}
+
+    try:
+        bearer = resolve(peer_meta)
+    except Exception as e:
+        print(json.dumps({"kind": "transient_failure", "detail": f"resolver error: {e}"}))
+        return 0
+
+    bearer.open(args.peer_id)
+    payloads = [
+        (line if line.endswith(b"\n") else line + b"\n")
+        for line in sys.stdin.buffer.read().splitlines()
+        if line.strip()
+    ]
+    try:
+        outcome = bearer.send_many(args.peer_id, args.channel, payloads)
+    finally:
+        bearer.close()
+
+    print(json.dumps(asdict(outcome)))
+    return 0
+
+
 def cmd_recv(args) -> int:
     """Stream events from the bearer to stdout as raw envelope bytes.
 
@@ -539,6 +569,19 @@ def _build_parser() -> argparse.ArgumentParser:
     send.add_argument("--room-gist-id", default=None,
                       help="gh room gist id for GhBearer routing")
     send.set_defaults(func=cmd_send)
+
+    send_batch = sub.add_parser("send-batch", help="Deliver JSONL payload batch from stdin to peer")
+    send_batch.add_argument("peer_id")
+    send_batch.add_argument("channel")
+    send_batch.add_argument("--host-target", default=None,
+                            help="user@host[:port] for SSH bearer")
+    send_batch.add_argument("--identity-key", default=None,
+                            help="Path to private key file for SSH bearer")
+    send_batch.add_argument("--remote-home", default=None,
+                            help="Remote AIRC_WRITE_DIR path (e.g. '$HOME/.airc')")
+    send_batch.add_argument("--room-gist-id", default=None,
+                            help="gh room gist id for GhBearer routing")
+    send_batch.set_defaults(func=cmd_send_batch)
 
     recv = sub.add_parser("recv", help="Stream inbound events as JSONL on stdout")
     recv.add_argument("peer_id")

--- a/lib/airc_core/bearer_gh.py
+++ b/lib/airc_core/bearer_gh.py
@@ -822,6 +822,100 @@ class GhBearer(Bearer):
             detail=f"concurrent-write conflict after {RETRIES} retries; last: {last_detail}; local bus: {local_detail}",
         )
 
+    def send_many(self, peer_id: str, channel: str, payloads: list[bytes]) -> SendOutcome:
+        """Append a queued batch to the room gist with one GET/PATCH cycle.
+
+        The queue flusher may have many pending lines after a network or
+        GitHub throttle window. Replaying them through send() one at a
+        time turns recovery into another burst of API calls. Gh gist is an
+        append surface, so batch the queued JSONL into a single content
+        update and verify every payload landed.
+        """
+        self._check_alive()
+        if not payloads:
+            return SendOutcome(kind="delivered", detail="0 payload(s)")
+
+        gist_id = self._peer_meta.get("room_gist_id")
+        if not gist_id:
+            raise GhBearerError(
+                f"GhBearer.send_many called for peer_id={peer_id!r} with no room_gist_id"
+            )
+
+        framed_lines: list[str] = []
+        for payload in payloads:
+            framed = payload if payload.endswith(b"\n") else payload + b"\n"
+            try:
+                framed_lines.append(framed.decode("utf-8"))
+            except UnicodeDecodeError:
+                return SendOutcome(
+                    kind="transient_failure",
+                    detail="payload is not utf-8; gh-bearer requires text envelopes",
+                )
+        batch_content = "".join(framed_lines)
+
+        local_ok = True
+        local_detail = ""
+        for line in framed_lines:
+            ok, detail = _local_bus_append(gist_id, line, self._peer_meta)
+            if not ok:
+                local_ok = False
+                local_detail = detail
+
+        RETRIES = 8
+        last_detail = ""
+        for attempt in range(RETRIES):
+            gist, get_kind = _gh_api_get_classified(gist_id)
+            if gist is None:
+                if local_ok and get_kind in ("secondary_rate_limit", "transient_failure", "auth_failure"):
+                    return SendOutcome(
+                        kind="delivered",
+                        detail=f"delivered batch via local bus; gh publish deferred ({get_kind})",
+                    )
+                if get_kind in ("gone", "secondary_rate_limit", "auth_failure"):
+                    return SendOutcome(
+                        kind=get_kind,
+                        detail=f"GET gists/{gist_id} failed: {get_kind}",
+                    )
+                return SendOutcome(
+                    kind="transient_failure",
+                    detail=f"could not fetch gist {gist_id} (network/5xx/timeout)",
+                )
+
+            existing = _read_messages_content(gist)
+            new_content = _rotate_if_needed(_rotate_if_needed(existing) + batch_content)
+
+            ok, detail, patch_kind = _gh_api_patch_classified(gist_id, new_content)
+            if not ok:
+                last_detail = detail
+                if patch_kind == "conflict":
+                    _time.sleep(_jittered_backoff(attempt))
+                    continue
+                if local_ok and patch_kind in ("secondary_rate_limit", "transient_failure", "auth_failure"):
+                    return SendOutcome(
+                        kind="delivered",
+                        detail=f"delivered batch via local bus; gh publish deferred ({patch_kind})",
+                    )
+                return SendOutcome(kind=patch_kind, detail=detail)
+
+            verify, _verify_kind = _gh_api_get_classified(gist_id)
+            if verify is None:
+                return SendOutcome(kind="delivered", detail=f"{len(framed_lines)} payload(s)")
+            content = _read_messages_content(verify)
+            if all(line.rstrip("\n") in content for line in framed_lines):
+                return SendOutcome(kind="delivered", detail=f"{len(framed_lines)} payload(s)")
+            last_detail = "verify-after-write: one or more batch lines missing post-PATCH"
+            _time.sleep(_jittered_backoff(attempt))
+
+        if local_ok:
+            return SendOutcome(
+                kind="delivered",
+                detail=f"delivered batch via local bus; gh conflict after {RETRIES} retries; last: {last_detail}",
+            )
+        return SendOutcome(
+            kind="transient_failure",
+            detail=f"batch conflict after {RETRIES} retries; last: {last_detail}; local bus: {local_detail}",
+        )
+
     def recv_stream(self) -> Iterator[ReceivedMessage]:
         """Poll the room gist on a cadence; yield new envelopes.
 

--- a/lib/airc_core/gh_backoff.py
+++ b/lib/airc_core/gh_backoff.py
@@ -100,6 +100,12 @@ def backoff_active() -> bool:
     return time.time() < backoff_until()
 
 
+def wait_seconds(now: float | None = None) -> int:
+    """Seconds callers should wait before the next guarded gh request."""
+    current = time.time() if now is None else now
+    return max(0, int(backoff_until() - current))
+
+
 def _write_backoff(until: float) -> None:
     if until <= time.time():
         return
@@ -445,9 +451,14 @@ def _main(argv: list[str] | None = None) -> int:
     audit.add_argument("--summary", action="store_true")
     audit.add_argument("--reset", action="store_true", help="clear shared backoff/budget state; keep audit log")
     audit.add_argument("--clear-audit", action="store_true", help="delete the local gh audit log")
+    wait = sub.add_parser("wait-seconds")
+    wait.set_defaults(cmd="wait-seconds")
     args = parser.parse_args(argv)
     if args.cmd == "audit":
         return _cmd_audit(args)
+    if args.cmd == "wait-seconds":
+        print(wait_seconds())
+        return 0
     if args.cmd != "run":
         return 2
 

--- a/lib/airc_core/pending_batch.py
+++ b/lib/airc_core/pending_batch.py
@@ -1,0 +1,81 @@
+"""Helpers for draining pending.jsonl without shell-side JSON parsing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def _load_config(path: str) -> dict:
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return {}
+
+
+def _read_lines(path: str) -> list[str]:
+    try:
+        with open(path, encoding="utf-8") as f:
+            return [line.rstrip("\n") for line in f if line.strip()]
+    except OSError:
+        return []
+
+
+def cmd_host_broadcast_route(args: argparse.Namespace) -> int:
+    lines = _read_lines(args.snapshot)
+    if not lines:
+        print("no\tempty")
+        return 0
+
+    channel = ""
+    for line in lines:
+        try:
+            msg = json.loads(line)
+        except ValueError:
+            print("no\tmalformed")
+            return 0
+        if msg.get("to", "all") not in ("", "all"):
+            print("no\tdm")
+            return 0
+        line_channel = str(msg.get("channel") or "")
+        if not line_channel:
+            print("no\tmissing-channel")
+            return 0
+        if channel and line_channel != channel:
+            print("no\tmixed-channel")
+            return 0
+        channel = line_channel
+
+    config = _load_config(args.config)
+    gist = str((config.get("channel_gists") or {}).get(channel) or "")
+    if not gist:
+        gist = args.fallback_gist or ""
+    if not gist:
+        print("no\tmissing-gist")
+        return 0
+
+    print(f"ok\t{channel}\t{gist}\t{len(lines)}")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="airc_core.pending_batch")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    route = sub.add_parser("host-broadcast-route")
+    route.add_argument("--snapshot", required=True)
+    route.add_argument("--config", required=True)
+    route.add_argument("--fallback-gist", default="")
+    route.set_defaults(func=cmd_host_broadcast_route)
+    return parser
+
+
+def _main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/test/test_bearer.py
+++ b/test/test_bearer.py
@@ -1272,6 +1272,29 @@ class GhBearerSendTests(unittest.TestCase):
 
         self.assertEqual(captured["content"], my_line)
 
+    def test_send_many_batches_payloads_into_one_patch(self):
+        existing = '{"from":"x","msg":"old"}\n'
+        lines = [b'{"from":"a","msg":"one"}', b'{"from":"b","msg":"two"}\n']
+        captured = {}
+
+        def fake_patch(gist_id, content):
+            captured["gist_id"] = gist_id
+            captured["content"] = content
+            return (True, "")
+
+        merged = existing + '{"from":"a","msg":"one"}\n{"from":"b","msg":"two"}\n'
+        gets = [
+            {"files": {"messages.jsonl": {"content": existing}}},
+            {"files": {"messages.jsonl": {"content": merged}}},
+        ]
+        with mock.patch.object(bearer_gh, "_gh_api_get", side_effect=lambda _: gets.pop(0)), \
+             mock.patch.object(bearer_gh, "_gh_api_patch_messages_jsonl", side_effect=fake_patch):
+            outcome = self._bearer().send_many("alice", "general", lines)
+
+        self.assertEqual(outcome.kind, "delivered")
+        self.assertEqual(captured["gist_id"], "abc123")
+        self.assertEqual(captured["content"], merged)
+
     def test_send_transient_when_get_fails(self):
         with mock.patch.object(bearer_gh, "_gh_api_get", return_value=None):
             outcome = self._bearer().send("alice", "general", b'{"x":1}')

--- a/test/test_gh_backoff.py
+++ b/test/test_gh_backoff.py
@@ -65,6 +65,15 @@ class GhGuardTests(unittest.TestCase):
             self.assertEqual(event["class"], "gist:list")
             self.assertFalse(event["allowed"])
 
+    def test_wait_seconds_reports_shared_backoff_remaining(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+             mock.patch.object(tempfile, "gettempdir", return_value=tmp):
+            with mock.patch.object(gh_backoff.time, "time", return_value=900.0):
+                gh_backoff._write_backoff(1000.0)
+
+            self.assertEqual(gh_backoff.wait_seconds(now=940.2), 59)
+            self.assertEqual(gh_backoff.wait_seconds(now=1001.0), 0)
+
     def test_unguarded_command_passes_through(self):
         with tempfile.TemporaryDirectory() as tmp, \
              mock.patch.object(tempfile, "gettempdir", return_value=tmp), \

--- a/test/test_pending_batch.py
+++ b/test/test_pending_batch.py
@@ -1,0 +1,65 @@
+"""pending.jsonl batch classification tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class PendingBatchTests(unittest.TestCase):
+    def run_cli(self, snapshot: Path, config: Path, fallback: str = "") -> str:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "airc_core.pending_batch",
+                "host-broadcast-route",
+                "--snapshot",
+                str(snapshot),
+                "--config",
+                str(config),
+                "--fallback-gist",
+                fallback,
+            ],
+            cwd=str(REPO_ROOT),
+            env={"PYTHONPATH": str(REPO_ROOT / "lib")},
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+
+    def test_broadcast_batch_returns_single_route(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            snapshot = root / "pending.jsonl"
+            config = root / "config.json"
+            snapshot.write_text(
+                '{"to":"all","channel":"general","msg":"one"}\n'
+                '{"channel":"general","msg":"two"}\n',
+                encoding="utf-8",
+            )
+            config.write_text(json.dumps({"channel_gists": {"general": "abc123"}}), encoding="utf-8")
+
+            self.assertEqual(self.run_cli(snapshot, config), "ok\tgeneral\tabc123\t2")
+
+    def test_dm_is_not_batched(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            snapshot = root / "pending.jsonl"
+            config = root / "config.json"
+            snapshot.write_text('{"to":"alice","channel":"general","msg":"secret"}\n', encoding="utf-8")
+            config.write_text(json.dumps({"channel_gists": {"general": "abc123"}}), encoding="utf-8")
+
+            self.assertEqual(self.run_cli(snapshot, config), "no\tdm")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make pending queue flushers honor the shared GitHub backoff window before retrying
- add bearer-level send_many plus gh batching so host broadcast backlog drains with one gist append instead of one append per message
- add pending-batch route helper and tests for backoff wait/batch routing/GhBearer batching

## Validation
- python3 -m py_compile lib/airc_core/gh_backoff.py lib/airc_core/bearer.py lib/airc_core/bearer_cli.py lib/airc_core/bearer_gh.py lib/airc_core/pending_batch.py test/test_gh_backoff.py test/test_bearer.py test/test_pending_batch.py && bash -n airc
- cd test && python3 test_gh_backoff.py && python3 test_pending_batch.py && python3 test_bearer.py
- ./test/integration.sh python_units
- ./test/integration.sh queue
- ./test/integration.sh gh_secondary_rate_limit_degraded_startup

## Notes
This keeps messages in pending.jsonl instead of dropping them, but prevents the drain loop from repeatedly poking gh during an active shared backoff. Broadcast batches are intentionally limited to same-channel non-DM payloads; DMs keep the existing per-line encryption path.