### PR TITLE
fix(cmd_connect): reject unknown flags instead of treating as positional name

### DIFF
--- a/airc
+++ b/airc
@@ -2448,8 +2448,23 @@ _airc_should_use_codex_start() {
   [ -n "${AIRC_NO_ATTACH:-}" ] && return 1
 
   local _arg
-  for _arg in "$@"; do
-    [ "$_arg" = "--attach" ] && return 1
+  while [ "$#" -gt 0 ]; do
+    _arg="$1"
+    case "$_arg" in
+      --attach|-attach) return 1 ;;
+      -h|--help|--gist|-gist|--no-gist|-no-gist|--no-room|-no-room|--no-general|-no-general|--general|-general|--takeover|-takeover|--no-tailscale|-no-tailscale)
+        shift ;;
+      --room|-room|--room-only|-room-only)
+        shift 2 ;;
+      -*)
+        # Let cmd_connect's parser reject unknown flags directly. If we
+        # launch Codex-detached first, the child fails in the background
+        # and the foreground parent can mask the real "unknown flag"
+        # with a later "Not initialized" status/inbox check.
+        return 1 ;;
+      *)
+        shift ;;
+    esac
   done
 
   [ -n "${CODEX_THREAD_ID:-}${CODEX_CI:-}${CODEX_MANAGED_BY_NPM:-}" ]

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -571,6 +571,18 @@ cmd_connect() {
         # serves this scope, keep that single transport owner and attach
         # this terminal/Claude Monitor to the local messages log.
         attach=1; shift ;;
+      -*)
+        # Reject any unrecognized flag loudly. Pre-fix the catch-all
+        # arm (now below) silently accepted `--anything` as a positional,
+        # which downstream became `target` → host-mode `name` → config
+        # `name`. Observed in the wild: `airc join --background` set
+        # config.name to literal "--background", surfacing as
+        # "Hosting as '--background'" and corrupting peer identity until
+        # manually edited. See #511 (related: #521 belt for --attach).
+        # Inline invites, gist ids, mnemonics never start with `-`, so
+        # this rejector cannot eat a legitimate positional.
+        echo "ERROR: unknown flag '$1'. See: airc join --help" >&2
+        return 2 ;;
       *) positional+=("$1"); shift ;;
     esac
   done

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2404,6 +2404,52 @@ scenario_attach_spawn_strips_attach_flag() {
   cleanup_all
 }
 
+# ── Scenario: join_rejects_unknown_flag ────────────────────────────────
+# Pre-fix `cmd_connect`'s arg loop had a single `*) positional+=("$1")` arm
+# that silently accepted any `--anything` as a positional. That positional
+# became `target` and then host-mode `name`, written to config.json.
+# Observed in the wild (continuum-8e97 on Windows): `airc join --background`
+# produced "Hosting as '--background'" and persisted the bad name in
+# config.json `name` field. Identity stayed corrupted across restarts
+# until the user manually edited the JSON. Same shape as the original
+# --attach leak in #511/#521, generalized to all unrecognized flags.
+scenario_join_rejects_unknown_flag() {
+  section "join_rejects_unknown_flag: cmd_connect rejects --unknown-flag instead of accepting as positional"
+  cleanup_all
+
+  local home=/tmp/airc-it-unknown-flag/state
+  local out=/tmp/airc-it-unknown-flag/out.log
+  local err=/tmp/airc-it-unknown-flag/err.log
+  mkdir -p /tmp/airc-it-unknown-flag
+
+  AIRC_HOME="$home" AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 \
+    "$AIRC" join --background --no-room --no-gist >"$out" 2>"$err"
+  local rc=$?
+
+  [ "$rc" != "0" ] \
+    && pass "unknown flag rejected with non-zero exit (rc=$rc)" \
+    || fail "unknown flag accepted (rc=$rc); stdout=$(cat "$out" 2>/dev/null); stderr=$(cat "$err" 2>/dev/null)"
+
+  grep -q "unknown flag" "$err" \
+    && pass "stderr names the rejection" \
+    || fail "stderr did not mention 'unknown flag': $(cat "$err" 2>/dev/null)"
+
+  ! grep -q "Hosting as '--background'" "$out" \
+    && pass "host setup never started with the bad name" \
+    || fail "host setup proceeded with --background as identity: $(cat "$out" 2>/dev/null)"
+
+  if [ -f "$home/config.json" ]; then
+    ! grep -q '"name":[[:space:]]*"--background"' "$home/config.json" \
+      && pass "config.json identity not corrupted by rejected flag" \
+      || fail "config.json was poisoned: $(cat "$home/config.json" 2>/dev/null)"
+  else
+    pass "config.json was not written (rejected before init)"
+  fi
+
+  rm -rf /tmp/airc-it-unknown-flag
+  cleanup_all
+}
+
 # ── Scenario: codex_join_detaches_transport ────────────────────────────
 # Public Codex flow is plain `airc join`. The shell dispatch detects Codex
 # and routes through the detach adapter, while the spawned child is guarded
@@ -4905,6 +4951,7 @@ case "$MODE" in
   attach_starts_background_transport) scenario_attach_starts_background_transport ;;
   attach_transport_survives_launcher_hup) scenario_attach_transport_survives_launcher_hup ;;
   attach_spawn_strips_attach_flag) scenario_attach_spawn_strips_attach_flag ;;
+  join_rejects_unknown_flag) scenario_join_rejects_unknown_flag ;;
   codex_join_detaches_transport) scenario_codex_join_detaches_transport ;;
   codex_join_idempotent_when_healthy) scenario_codex_join_idempotent_when_healthy ;;
   codex_join_waits_for_duplicate_repair) scenario_codex_join_waits_for_duplicate_repair ;;
@@ -4945,7 +4992,7 @@ case "$MODE" in
     scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat
     scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope
     scenario_send_dead_monitor_dies; scenario_send_gone_gist_does_not_claim_delivery; scenario_monitor_liveness_process_evidence
-    scenario_attach_starts_background_transport; scenario_attach_transport_survives_launcher_hup; scenario_attach_spawn_strips_attach_flag; scenario_codex_join_detaches_transport
+    scenario_attach_starts_background_transport; scenario_attach_transport_survives_launcher_hup; scenario_attach_spawn_strips_attach_flag; scenario_join_rejects_unknown_flag; scenario_codex_join_detaches_transport
     scenario_codex_join_idempotent_when_healthy
     scenario_codex_join_waits_for_duplicate_repair
     scenario_join_reaps_duplicate_scope_transport


### PR DESCRIPTION
## Summary

`cmd_connect`'s arg loop had a single `*) positional+=("$1")` arm that silently accepted any unrecognized `--<flag>` as a positional. The accepted positional became `target` (line 1733: `local name="${target:-}"`), then host-mode `name`, which got persisted to `config.json` `name` field.

**Observed in the wild today** (2026-05-06): continuum-8e97 on Windows ran `airc join --background` (a documented-as-not-a-flag arg) after `airc teardown` and got:

```
Hosting as '--background' (reminder: 300s)
```

`config.json` then had `"name": "--background"`, and identity stayed corrupted across `airc teardown` + `airc join` cycles. Manual JSON edit was the only recovery — exactly the failure mode #511/#521 fixed for `--attach` specifically.

## Fix

Add an explicit `-*)` arm in `cmd_connect`'s flag loop (`lib/airc_bash/cmd_connect.sh:574`) that rejects unknown flags loudly with `return 2` and a stderr message. Inline invites, gist ids, and humanhash mnemonics never start with `-`, so the rejector cannot eat a legitimate positional. The existing PR #521 belt for encoding-corrupted `--attach` is preserved.

## Tests

Adds `scenario_join_rejects_unknown_flag` to `test/integration.sh` covering:
- Non-zero exit code on `airc join --background --no-room --no-gist`
- stderr says "unknown flag"
- stdout never says "Hosting as '--background'"
- `config.json` is not poisoned

Local run on Windows WSL2 (Ubuntu, canary 2357f7b base):

```
$ bash test/integration.sh join_rejects_unknown_flag
─ join_rejects_unknown_flag: cmd_connect rejects --unknown-flag instead of accepting as positional ─
  ✓ unknown flag rejected with non-zero exit (rc=2)
  ✓ stderr names the rejection
  ✓ host setup never started with the bad name
  ✓ config.json was not written (rejected before init)
4 passed, 0 failed
```

Adjacent regressions also re-checked clean:

```
$ bash test/integration.sh attach_transport_survives_launcher_hup
2 passed, 0 failed

$ bash test/integration.sh attach_spawn_strips_attach_flag
2 passed, 0 failed
```

## Related

- #511 — original `--attach` identity-leak issue
- #521 — first defense (strip `--attach` from positional[])
- #533 — codex's HUP regression test (independent, just merged); this PR runs alongside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)