### PR TITLE
fix(monitor): stop respawning gone channel gists

### DIFF
--- a/airc
+++ b/airc
@@ -1366,16 +1366,18 @@ _monitor_multi_channel() {
   while true; do
     # Re-read channel_map from config at top of each outer cycle so
     # an in-flight config change (e.g. _mesh_rediscover_loop swapping
-    # the host gist after rotation) takes effect on the next bearer
-    # respawn, no full process restart required. Falls back to the
-    # parameter passed at startup if the re-read returns empty
-    # (transient config-write race or missing list_channel_gists
-    # support on older airc_core).
+    # the host gist after rotation, or a gone-gist prune below) takes
+    # effect on the next bearer respawn, no full process restart
+    # required. Empty is meaningful: it means no channel currently has
+    # a viable wire, so do not fall back to the stale startup map.
     local _refreshed_map
     _refreshed_map=$("$AIRC_PYTHON" -m airc_core.config list_channel_gists \
       --config "$CONFIG" 2>/dev/null || true)
-    if [ -n "$_refreshed_map" ]; then
-      channel_map="$_refreshed_map"
+    channel_map="$_refreshed_map"
+    if [ -z "$channel_map" ]; then
+      echo "airc: no channel_gists mappings remain; monitor waiting for 'airc join --room <channel>' to re-host" >&2
+      sleep 30
+      continue
     fi
     {
       # Per-child PID tracking so we can detect individual deaths.
@@ -1454,6 +1456,16 @@ _monitor_multi_channel() {
             # having to know to read the log file.
             if [ -s "$AIRC_WRITE_DIR/bearer_recv.${ch}.log" ]; then
               tail -3 "$AIRC_WRITE_DIR/bearer_recv.${ch}.log" | sed 's/^/airc:   /' >&2
+            fi
+            if [ -s "$AIRC_WRITE_DIR/bearer_recv.${ch}.log" ] \
+               && tail -20 "$AIRC_WRITE_DIR/bearer_recv.${ch}.log" | grep -qE 'returned 404|\(gone\)|GET gists/.* failed: gone'; then
+              "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
+                --config "$CONFIG" --channel "$ch" --gist-id "" \
+                >/dev/null 2>&1 || true
+              printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[GONE: room gist 404 — channel #%s dissolved. Monitor stopped respawning this channel; re-host with: airc join --room %s]"}\n' \
+                "$(timestamp)" "$ch" "$ch" "$ch" >> "$MESSAGES"
+              echo "airc: #${ch} gist returned 404 (gone); cleared stale channel_gists[${ch}] and stopped respawning that channel" >&2
+              continue
             fi
             # Re-read the channel's gist from config. If the host rotated
             # or send-path self-heal updated channel_gists while this

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2181,6 +2181,36 @@ SH
   cleanup_all
 }
 
+# ── Scenario: monitor_gone_gist_stops_respawn ──────────────────────────
+# Send-path 404 handling already clears stale channel_gists. Recv-path
+# monitor handling must do the same; otherwise a dissolved subscribed
+# channel exits bearer_cli with "room gist ... returned 404 (gone)" and
+# the supervisor respawns it forever, wasting gh budget and flapping the
+# Monitor. This is a structural regression test for that supervisor path.
+scenario_monitor_gone_gist_stops_respawn() {
+  section "monitor_gone_gist_stops_respawn: recv-side 404 clears stale mapping instead of respawning forever"
+  cleanup_all
+
+  local src="$AIRC"
+  grep -q 'GET gists/.* failed: gone' "$src" \
+    && pass "monitor detects gone gist errors from bearer recv logs" \
+    || fail "monitor does not detect gone gist errors from bearer recv logs"
+
+  grep -q 'gist returned 404 (gone); cleared stale channel_gists' "$src" \
+    && pass "monitor surfaces stale channel_gists cleanup" \
+    || fail "monitor does not surface stale channel_gists cleanup"
+
+  grep -q -- '--gist-id ""' "$src" \
+    && pass "monitor clears dissolved channel gist mapping" \
+    || fail "monitor does not clear dissolved channel gist mapping"
+
+  grep -q "no channel_gists mappings remain" "$src" \
+    && pass "empty refreshed channel map is treated as authoritative" \
+    || fail "empty refreshed channel map still falls back to stale startup map"
+
+  cleanup_all
+}
+
 # ── Scenario: monitor_liveness_process_evidence ────────────────────────
 # A project .airc scope can be shared by several Claude/Codex tabs. This
 # scenario keeps monitor liveness honest at the process-evidence layer:
@@ -5005,6 +5035,7 @@ case "$MODE" in
   auto_scope)   scenario_auto_scope ;;
   send_dead_monitor_dies) scenario_send_dead_monitor_dies ;;
   send_gone_gist_does_not_claim_delivery) scenario_send_gone_gist_does_not_claim_delivery ;;
+  monitor_gone_gist_stops_respawn) scenario_monitor_gone_gist_stops_respawn ;;
   monitor_liveness_process_evidence) scenario_monitor_liveness_process_evidence ;;
   attach_starts_background_transport) scenario_attach_starts_background_transport ;;
   attach_transport_survives_launcher_hup) scenario_attach_transport_survives_launcher_hup ;;
@@ -5050,7 +5081,7 @@ case "$MODE" in
     scenario_auth_failure; scenario_room; scenario_events; scenario_get_host
     scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat
     scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope
-    scenario_send_dead_monitor_dies; scenario_send_gone_gist_does_not_claim_delivery; scenario_monitor_liveness_process_evidence
+    scenario_send_dead_monitor_dies; scenario_send_gone_gist_does_not_claim_delivery; scenario_monitor_gone_gist_stops_respawn; scenario_monitor_liveness_process_evidence
     scenario_attach_starts_background_transport; scenario_attach_transport_survives_launcher_hup; scenario_attach_spawn_strips_attach_flag; scenario_join_rejects_unknown_flag; scenario_join_intent_failure_falls_back_to_host; scenario_codex_join_detaches_transport
     scenario_codex_join_idempotent_when_healthy
     scenario_codex_join_waits_for_duplicate_repair
@@ -5068,7 +5099,7 @@ case "$MODE" in
     scenario_custom_room_creates_gist
     scenario_invite_human
     ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|send_gone_gist_does_not_claim_delivery|monitor_liveness_process_evidence|attach_starts_background_transport|attach_transport_survives_launcher_hup|attach_spawn_strips_attach_flag|codex_join_detaches_transport|codex_join_idempotent_when_healthy|codex_join_waits_for_duplicate_repair|join_reaps_duplicate_scope_transport|gh_secondary_rate_limit_degraded_startup|solo_mesh_warns|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|send_gone_gist_does_not_claim_delivery|monitor_gone_gist_stops_respawn|monitor_liveness_process_evidence|attach_starts_background_transport|attach_transport_survives_launcher_hup|attach_spawn_strips_attach_flag|codex_join_detaches_transport|codex_join_idempotent_when_healthy|codex_join_waits_for_duplicate_repair|join_reaps_duplicate_scope_transport|gh_secondary_rate_limit_degraded_startup|solo_mesh_warns|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary
- detect permanent recv-side 404/gone errors in the multi-channel monitor supervisor
- clear the stale `channel_gists[channel]` mapping and stop respawning that dissolved channel
- keep healthy sibling channels running instead of hammering GitHub forever
- treat an empty refreshed channel map as authoritative so the monitor cannot fall back to its stale startup map after pruning the last dead channel

## Why
Windows traced a real monitor death loop: a deleted gist for `#qa-test-b69f` made `bearer_cli recv` exit with 404, and the supervisor restarted it every few seconds. With multiple dead subscribed channels this can hammer GitHub and consume the shared governor budget. Send-path 404 handling already clears stale mappings; recv-path monitor handling needed the same terminal behavior.

## Validation
- `bash -n airc test/integration.sh`
- `./test/integration.sh monitor_gone_gist_stops_respawn`
- `./test/integration.sh send_gone_gist_does_not_claim_delivery`