### PR TITLE
fix(repair): preserve gone channel pruning

### DIFF
--- a/airc
+++ b/airc
@@ -1459,9 +1459,13 @@ _monitor_multi_channel() {
             fi
             if [ -s "$AIRC_WRITE_DIR/bearer_recv.${ch}.log" ] \
                && tail -20 "$AIRC_WRITE_DIR/bearer_recv.${ch}.log" | grep -qE 'returned 404|\(gone\)|GET gists/.* failed: gone'; then
+              local _gone_gid
+              _gone_gid=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
+                --config "$CONFIG" --channel "$ch" 2>/dev/null || true)
               "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
                 --config "$CONFIG" --channel "$ch" --gist-id "" \
                 >/dev/null 2>&1 || true
+              [ -n "$_gone_gid" ] && printf '%s\n' "$_gone_gid" > "$AIRC_WRITE_DIR/gone_channel_gist.${ch}" 2>/dev/null || true
               printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[GONE: room gist 404 — channel #%s dissolved. Monitor stopped respawning this channel; re-host with: airc join --room %s]"}\n' \
                 "$(timestamp)" "$ch" "$ch" "$ch" >> "$MESSAGES"
               echo "airc: #${ch} gist returned 404 (gone); cleared stale channel_gists[${ch}] and stopped respawning that channel" >&2

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -433,6 +433,7 @@ cmd_send() {
         "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
           --config "$CONFIG" --channel "$active_channel" --gist-id "" \
           >/dev/null 2>&1 || true
+        [ -n "${room_gist_id:-}" ] && printf '%s\n' "$room_gist_id" > "$AIRC_WRITE_DIR/gone_channel_gist.${active_channel}" 2>/dev/null || true
         local gone_marker; gone_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[GONE: room gist 404 — channel #%s dissolved, message NOT delivered. Re-host with: airc join --room %s] %s"}' \
           "$(timestamp)" "$active_channel" "$active_channel" "$active_channel" "${detail:-no detail}")
         echo "$gone_marker" >> "$MESSAGES"
@@ -630,6 +631,7 @@ cmd_send() {
           "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
             --config "$CONFIG" --channel "$active_channel" --gist-id "" \
             >/dev/null 2>&1 || true
+          [ -n "${_host_room_gist_id:-}" ] && printf '%s\n' "$_host_room_gist_id" > "$AIRC_WRITE_DIR/gone_channel_gist.${active_channel}" 2>/dev/null || true
           local _host_gone_marker; _host_gone_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[GONE: room gist 404 — channel #%s dissolved, message NOT delivered. Re-host with: airc join --room %s] %s"}' \
             "$(timestamp)" "$active_channel" "$active_channel" "$active_channel" "${_host_detail:-no detail}")
           echo "$_host_gone_marker" >> "$MESSAGES"

--- a/lib/airc_core/scope_repair.py
+++ b/lib/airc_core/scope_repair.py
@@ -51,6 +51,11 @@ def _gist_from_bearer_log(home: Path, channel: str) -> str:
     return ""
 
 
+def _gone_channel_gist(home: Path, channel: str) -> str:
+    gid = _read(home / f"gone_channel_gist.{channel}")
+    return gid if GIST_RE.match(gid) else ""
+
+
 def _name_from_messages(home: Path) -> str:
     try:
         lines = (home / "messages.jsonl").read_text(encoding="utf-8").splitlines()[-500:]
@@ -94,9 +99,14 @@ def infer_config(home: Path, default_name: str, host: str, existing: dict | None
         channels = [room_name] + [ch for ch in channels if ch != room_name]
 
     channel_gists: dict[str, str] = dict(existing.get("channel_gists", {}) or {})
-    if room_name and GIST_RE.match(room_gist):
+    if room_name and GIST_RE.match(room_gist) and _gone_channel_gist(home, room_name) != room_gist:
         channel_gists[room_name] = room_gist
     for channel in channels:
+        gone_gist = _gone_channel_gist(home, channel)
+        if gone_gist:
+            if channel_gists.get(channel) == gone_gist:
+                channel_gists.pop(channel, None)
+            continue
         log_gist = _gist_from_bearer_log(home, channel)
         if GIST_RE.match(log_gist):
             channel_gists[channel] = log_gist

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2204,6 +2204,10 @@ scenario_monitor_gone_gist_stops_respawn() {
     && pass "monitor clears dissolved channel gist mapping" \
     || fail "monitor does not clear dissolved channel gist mapping"
 
+  grep -q 'gone_channel_gist' "$src" \
+    && pass "monitor persists gone channel marker for scope repair" \
+    || fail "monitor does not persist gone channel marker for scope repair"
+
   grep -q "no channel_gists mappings remain" "$src" \
     && pass "empty refreshed channel map is treated as authoritative" \
     || fail "empty refreshed channel map still falls back to stale startup map"

--- a/test/test_scope_repair.py
+++ b/test/test_scope_repair.py
@@ -108,6 +108,37 @@ class ScopeRepairTests(unittest.TestCase):
             self.assertEqual(data["subscribed_channels"], ["cambriantech", "general"])
             self.assertEqual(data["channel_gists"]["cambriantech"], "df40c8ae6c90f8e14009426fd6e16e22")
 
+    def test_gone_marker_prevents_repair_from_restoring_dead_gist(self):
+        tmp = tempfile.TemporaryDirectory()
+        with tmp:
+            home = Path(tmp.name)
+            config = home / "config.json"
+            dead = "a2bb8d168e50c05a47b726378624a4a9"
+            config.write_text(
+                json.dumps(
+                    {
+                        "name": "continuum-8e97",
+                        "subscribed_channels": ["cambriantech", "qa-test-b69f"],
+                        "channel_gists": {"cambriantech": "df40c8ae6c90f8e14009426fd6e16e22"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (home / "bearer_state.qa-test-b69f.json").write_text("{}\n", encoding="utf-8")
+            (home / "bearer_recv.qa-test-b69f.log").write_text(
+                f"[airc:bearer_gh] _gh_api_get({dead}): gh api exit=1: Not Found (HTTP 404)\n"
+                f"bearer recv: stream failed: room gist {dead} returned 404 (gone)\n",
+                encoding="utf-8",
+            )
+            (home / "gone_channel_gist.qa-test-b69f").write_text(dead + "\n", encoding="utf-8")
+
+            rc = scope_repair.main(["repair-config", "--home", str(home), "--config", str(config)])
+
+            self.assertEqual(rc, 0)
+            data = json.loads(config.read_text(encoding="utf-8"))
+            self.assertEqual(data["subscribed_channels"], ["cambriantech", "qa-test-b69f"])
+            self.assertNotIn("qa-test-b69f", data.get("channel_gists", {}))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- persist a `gone_channel_gist.<channel>` marker when monitor recv or send sees a terminal gist 404
- make `scope_repair repair-config` honor that marker so it cannot restore a dead channel mapping from stale bearer logs or durable room state
- extend the monitor-gone scenario to require the durable marker
- add a scope-repair unit test for Windows' observed loop: #538 prunes a dead channel, then repair previously restored it

## Why
Windows validated #538 pruned `qa-test-b69f`, then found `airc msg`/ensure-init repaired the config and reintroduced the dead gist from historical bearer logs. That made #538 repeat the same prune every join instead of permanently healing.

## Validation
- `bash -n airc lib/airc_bash/cmd_send.sh test/integration.sh`
- `python3 -m py_compile lib/airc_core/scope_repair.py test/test_scope_repair.py`
- `python3 test/test_scope_repair.py`
- `./test/integration.sh monitor_gone_gist_stops_respawn`
- `./test/integration.sh send_gone_gist_does_not_claim_delivery`
- `./test/integration.sh python_units`