### PR TITLE
join: expose transport during attach cold start

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -289,10 +289,11 @@ _join_attach_local_stream() {
   echo "  Attaching this terminal to the local AIRC stream."
   echo "  Background AIRC owns transport; this process only displays new peer messages."
   local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
+  local _tail_name; _tail_name=$(get_name 2>/dev/null || echo "airc")
   if [ -n "$_client_id" ]; then
-    AIRC_CLIENT_ID="$_client_id" exec "$AIRC_PYTHON" -u -m airc_core.log_tail --home "$AIRC_WRITE_DIR" --my-name "$(get_name)"
+    AIRC_CLIENT_ID="$_client_id" exec "$AIRC_PYTHON" -u -m airc_core.log_tail --home "$AIRC_WRITE_DIR" --my-name "$_tail_name"
   else
-    exec "$AIRC_PYTHON" -u -m airc_core.log_tail --home "$AIRC_WRITE_DIR" --my-name "$(get_name)"
+    exec "$AIRC_PYTHON" -u -m airc_core.log_tail --home "$AIRC_WRITE_DIR" --my-name "$_tail_name"
   fi
 }
 
@@ -974,6 +975,24 @@ cmd_connect() {
   if [ "$attach" = "1" ] && [ "${AIRC_NO_ATTACH:-0}" != "1" ]; then
     _join_spawn_transport_for_attach ${_orig_args[@]+"${_orig_args[@]}"}
     return $?
+  fi
+
+  # Mark transport ownership before expensive discovery/bootstrap work.
+  # Host/joiner mode rewrites this later with child PIDs once those
+  # loops exist; until then, the parent shell itself is the live
+  # transport startup owner. Without this early marker, attach-mode
+  # launchers can report "not running" for a process that is alive but
+  # still doing gh discovery, stale-state repair, or first-host setup.
+  mkdir -p "$AIRC_WRITE_DIR"
+  : >> "$MESSAGES"
+  echo "$$" > "$AIRC_WRITE_DIR/airc.pid"
+  trap '
+    _airc_startup_rc=$?
+    rm -f "$AIRC_WRITE_DIR/airc.pid" 2>/dev/null
+    exit $_airc_startup_rc
+  ' EXIT INT TERM
+  if [ -n "${AIRC_TEST_STARTUP_DELAY_SEC:-}" ]; then
+    sleep "$AIRC_TEST_STARTUP_DELAY_SEC"
   fi
 
   # No resume code path. (#130, 2026-04-26.)

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2444,6 +2444,46 @@ scenario_attach_spawn_strips_attach_flag() {
   cleanup_all
 }
 
+# ── Scenario: attach_reports_starting_transport ────────────────────────
+# Attach launchers must see a live transport immediately, even while the
+# child is still in slow discovery/bootstrap before the richer host/join
+# pidfile is written. This is the Windows cold-start shape: no airc.pid
+# meant Monitor concluded "not running" while startup was still in-flight.
+scenario_attach_reports_starting_transport() {
+  section "attach_reports_starting_transport: startup owner is visible before bootstrap finishes"
+  cleanup_all
+
+  local root=/tmp/airc-it-attach-starting
+  local home="$root/state"
+  local out="$root/out.log"
+  local err="$root/err.log"
+  mkdir -p "$root"
+
+  AIRC_HOME="$home" AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 AIRC_TEST_STARTUP_DELAY_SEC=5 \
+    "$AIRC" join --attach --no-room --no-gist >"$out" 2>"$err" &
+  local ui_pid=$!
+
+  local attached=0 status_out="" i
+  for i in $(seq 1 3); do
+    status_out=$(AIRC_HOME="$home" "$AIRC" status 2>&1 || true)
+    if grep -q 'airc: attached to local message stream for this scope' "$out" 2>/dev/null; then
+      attached=1
+      break
+    fi
+    sleep 1
+  done
+
+  [ "$attached" = "1" ] \
+    && pass "attach UI attaches while transport is still in startup delay" \
+    || fail "attach UI did not see startup transport promptly (status=$status_out; stdout=$(cat "$out" 2>/dev/null); stderr=$(cat "$err" 2>/dev/null))"
+
+  kill "$ui_pid" 2>/dev/null || true
+  wait "$ui_pid" 2>/dev/null || true
+  AIRC_HOME="$home" "$AIRC" teardown >/dev/null 2>&1 || true
+  rm -rf "$root"
+  cleanup_all
+}
+
 # ── Scenario: join_rejects_unknown_flag ────────────────────────────────
 # Pre-fix `cmd_connect`'s arg loop had a single `*) positional+=("$1")` arm
 # that silently accepted any `--anything` as a positional. That positional
@@ -5050,6 +5090,7 @@ case "$MODE" in
   attach_starts_background_transport) scenario_attach_starts_background_transport ;;
   attach_transport_survives_launcher_hup) scenario_attach_transport_survives_launcher_hup ;;
   attach_spawn_strips_attach_flag) scenario_attach_spawn_strips_attach_flag ;;
+  attach_reports_starting_transport) scenario_attach_reports_starting_transport ;;
   join_rejects_unknown_flag) scenario_join_rejects_unknown_flag ;;
   join_intent_failure_falls_back_to_host) scenario_join_intent_failure_falls_back_to_host ;;
   codex_join_detaches_transport) scenario_codex_join_detaches_transport ;;
@@ -5092,7 +5133,7 @@ case "$MODE" in
     scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat
     scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope
     scenario_send_dead_monitor_dies; scenario_send_gone_gist_does_not_claim_delivery; scenario_monitor_gone_gist_stops_respawn; scenario_monitor_liveness_process_evidence
-    scenario_attach_starts_background_transport; scenario_attach_transport_survives_launcher_hup; scenario_attach_spawn_strips_attach_flag; scenario_join_rejects_unknown_flag; scenario_join_intent_failure_falls_back_to_host; scenario_codex_join_detaches_transport
+    scenario_attach_starts_background_transport; scenario_attach_transport_survives_launcher_hup; scenario_attach_spawn_strips_attach_flag; scenario_attach_reports_starting_transport; scenario_join_rejects_unknown_flag; scenario_join_intent_failure_falls_back_to_host; scenario_codex_join_detaches_transport
     scenario_codex_join_idempotent_when_healthy
     scenario_codex_join_waits_for_duplicate_repair
     scenario_join_reaps_duplicate_scope_transport
@@ -5109,7 +5150,7 @@ case "$MODE" in
     scenario_custom_room_creates_gist
     scenario_invite_human
     ;;
-  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|send_gone_gist_does_not_claim_delivery|monitor_gone_gist_stops_respawn|monitor_liveness_process_evidence|attach_starts_background_transport|attach_transport_survives_launcher_hup|attach_spawn_strips_attach_flag|codex_join_detaches_transport|codex_join_idempotent_when_healthy|codex_join_waits_for_duplicate_repair|join_reaps_duplicate_scope_transport|gh_secondary_rate_limit_degraded_startup|solo_mesh_warns|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
+  *) echo "Usage: $0 [tabs|scope|teardown|reminder|resilience|reconnect|queue|status|auth_failure|room|events|get_host|identity|whois|kick|heartbeat|bounce|two_tab_localhost|auto_scope|send_dead_monitor_dies|send_gone_gist_does_not_claim_delivery|monitor_gone_gist_stops_respawn|monitor_liveness_process_evidence|attach_starts_background_transport|attach_transport_survives_launcher_hup|attach_spawn_strips_attach_flag|attach_reports_starting_transport|codex_join_detaches_transport|codex_join_idempotent_when_healthy|codex_join_waits_for_duplicate_repair|join_reaps_duplicate_scope_transport|gh_secondary_rate_limit_degraded_startup|solo_mesh_warns|connect_after_kill_recovers|general_sidecar_default|away|list|quit|platform_adapters|python_units|bearer_ssh_send|bearer_ssh_recv|inbox|invite_human|all]"; exit 2 ;;
 esac
 
 echo


### PR DESCRIPTION
## Summary
- write startup transport evidence (airc.pid) before slow discovery/bootstrap work
- create messages.jsonl before attach so Monitor/log-tail can attach immediately
- make attach stream tolerate pre-init config by falling back to a generic self name
- add regression for slow attach cold-start before final host/join pidfile rewrite

## Tests
- bash -n airc lib/airc_bash/cmd_connect.sh test/integration.sh
- ./test/integration.sh attach_starts_background_transport
- ./test/integration.sh attach_spawn_strips_attach_flag
- ./test/integration.sh attach_reports_starting_transport
- ./test/integration.sh codex_join_detaches_transport
- ./test/integration.sh codex_join_idempotent_when_healthy
- ./test/integration.sh monitor_gone_gist_stops_respawn
- ./test/integration.sh send_gone_gist_does_not_claim_delivery
- ./test/integration.sh python_units
