### PR TITLE
fix(windows-shim): forward args correctly through wsl.exe

### DIFF
--- a/airc.cmd
+++ b/airc.cmd
@@ -21,9 +21,25 @@ REM Windows/Git-Bash clone.
 if not defined AIRC_WINDOWS_NATIVE if not defined AIRC_DIR (
   where wsl.exe >nul 2>nul
   if not errorlevel 1 (
-    wsl.exe sh -lc "test -x \"$HOME/.airc-src/airc\"" >nul 2>nul
+    wsl.exe bash -lc "test -x \"$HOME/.airc-src/airc\"" >nul 2>nul
     if not errorlevel 1 (
-      wsl.exe sh -lc "exec \"$HOME/.airc-src/airc\" \"$@\"" airc %*
+      REM Forwarding-args fix (post-#543): the previous shape
+      REM    wsl.exe sh -lc "...\"$@\"..." airc %*
+      REM dropped every positional arg silently. wsl.exe does not
+      REM forward args after `-lc <string>` as $0, $1, $2... to the
+      REM inline script — they get consumed by wsl.exe itself — so $@
+      REM inside the script was always empty. `airc.cmd join` ended up
+      REM running `exec airc` (no verb), fell through to the generic
+      REM help banner, and Claude Code's Monitor saw airc print help
+      REM and exit before any transport spawned. The "fresh start"
+      REM banner the Windows trace showed was actually airc's no-args
+      REM idle-host autostart path, not a real takeover.
+      REM
+      REM Fix: inline cmd's %* directly into the bash command string,
+      REM so positional args become part of the script string before
+      REM wsl.exe sees them. bash (not sh) matches the airc script's
+      REM `#!/bin/bash` shebang and avoids subtle sh/dash divergence.
+      wsl.exe bash -lc "exec \"$HOME/.airc-src/airc\" %*"
       exit /b %ERRORLEVEL%
     )
   )


### PR DESCRIPTION
## Summary

`wsl.exe sh -lc "<script>" airc %*` (the routing shape introduced by #543) does **not** forward the positional args to the inline script as `$0`, `$1`, `$@`. `wsl.exe` consumes them itself, so `$@` inside the script was always empty.

`airc.cmd join` ended up running `exec airc` with **no verb**, which falls through to the generic help banner and exits 0. Claude Code's Monitor on Windows saw airc print help and silently terminate — no transport spawned.

## Reproduction

Pre-fix:
```
$ cmd /c airc.cmd version
AIRC — Agentic Internet Relay Chat for AI peers
(IRC verbs are the public interface)
  airc join                       Auto-#general: ...
  ...
```

Post-fix:
```
$ cmd /c airc.cmd version
  airc <sha> on canary
  Merge pull request #543 ...
  install: /home/joel/.airc-src
```

## Root cause

Direct test showed sh sees zero positional args:

```
$ wsl.exe sh -lc 'echo positional: $#  args: $0 $1 $2; echo dollar-at: $@' airc version
positional: 0  args: /bin/bash
dollar-at:
```

So `wsl.exe sh -lc "<script>" airc version` sets `$0=/bin/bash` and drops `airc version` entirely — the script's `\"$@\"` expanded to nothing.

## Fix

1. Inline `cmd`'s `%*` directly into the bash command string, so positional args become part of the script string **before wsl.exe sees them** — bypassing the silent arg-drop.
2. Use `bash -lc` (matches the airc script's `#!/bin/bash` shebang) instead of `sh -lc` (dash on Ubuntu). Avoids subtle sh/dash parser divergence on the same wire shape.

```diff
-    wsl.exe sh -lc "test -x \"$HOME/.airc-src/airc\"" >nul 2>nul
+    wsl.exe bash -lc "test -x \"$HOME/.airc-src/airc\"" >nul 2>nul
     if not errorlevel 1 (
-      wsl.exe sh -lc "exec \"$HOME/.airc-src/airc\" \"$@\"" airc %*
+      wsl.exe bash -lc "exec \"$HOME/.airc-src/airc\" %*"
       exit /b %ERRORLEVEL%
     )
```

## Why this surfaces now

The Windows Monitor cold-start trace (this morning, post-#543 deployment) showed:
- `airc.cmd join` from Monitor → `airc` printed the **help banner** (interpreted as no-args)
- "Hosting #cambriantech — no existing room on your gh account, fresh start" was actually airc's no-args idle host bring-up, not a real takeover
- Monitor exited 1 because airc completed (printed help) and the script returned

Same Windows surface that's been blocking validation of #538 / #541 / #542 / #543 end-to-end.

## Verification

Local Windows + WSL2 (Ubuntu, canary tip + this fix):

```
$ cmd /c airc.cmd version
  airc 4305b8e (dirty) on fix/windows-shim-wsl-arg-forwarding
  Merge pull request #543 from CambrianTech/codex/windows-shim-wsl-single-source
  install: /home/joel/.airc-src
```

Args reach airc; `version` subcommand dispatches correctly; output names the expected install path (WSL clone, not the Windows-side mirror).

## Related

- #542: airc.cmd direct cmd→bash (drop PowerShell hop)
- #543: dual-clone single-source — Windows shim prefers WSL clone
- THIS PR: makes #543's routing actually pass args through

🤖 Generated with [Claude Code](https://claude.com/claude-code)