### PR TITLE
fix(install): single-source polyglot shim for Windows PATH

### DIFF
--- a/airc.shim
+++ b/airc.shim
@@ -1,0 +1,110 @@
+#!/bin/bash
+# airc — polyglot PATH shim. Single source of truth: the canonical
+# bash airc lives at $HOME/.airc-src/airc on the WSL/Linux/macOS host.
+# This shim is what gets dropped into Windows-visible PATH locations
+# (e.g. /c/Users/<user>/.local/bin/airc) so Git Bash users get a real
+# command without copying the full script.
+#
+# Why a shim instead of a symlink: install.sh on Git Bash for Windows
+# can't create real symlinks (Developer Mode off by default); ln -sf
+# falls back to a literal copy of the canonical airc, and that copy
+# goes stale the moment `airc update` (run from WSL) refreshes the
+# canonical. Stale copies on PATH made Claude Code Monitor on Windows
+# silently run months-old code while `airc version` reported the new
+# SHA. Per Joel's #543 follow-up: any Windows-visible airc on PATH
+# MUST be a shim — single source of truth, no sync-both-clones.
+#
+# Resolution order:
+#   1. AIRC_DIR explicitly set + has airc            → exec that
+#   2. AIRC_WINDOWS_NATIVE=1 + native clone exists   → exec native
+#   3. wsl.exe present + WSL canonical clone exists  → route via wsl.exe
+#   4. Native Windows clone at %USERPROFILE%\.airc-src exists
+#      (matches install.ps1's CLONE_DIR layout)     → exec native
+#   5. Caller-relative: this shim's dirname/../airc-src/airc (rare)
+#   6. Fail loud with all paths attempted
+#
+# Override knobs:
+#   AIRC_DIR=/path        — force a specific install dir
+#   AIRC_WINDOWS_NATIVE=1 — skip WSL even if available
+#
+# This shim runs under bash on every supported host (Git Bash on
+# Windows, WSL bash, native Linux/macOS bash). It MUST stay tiny and
+# argument-correct — every airc invocation pays its overhead.
+
+set -euo pipefail
+
+# 1) Explicit override.
+if [ -n "${AIRC_DIR:-}" ] && [ -x "$AIRC_DIR/airc" ]; then
+  exec "$AIRC_DIR/airc" "$@"
+fi
+
+# 1.5) If WE are running inside WSL ourselves, prefer the canonical
+# clone in this WSL home directly. Reaches the right place even when
+# the user invoked a Windows-side path like /mnt/c/Users/<u>/.local/
+# bin/airc (Joel: "users could be dumb like me — don't break"). Going
+# back through wsl.exe would be circular and slow; just exec the
+# canonical clone in-place.
+if [ -r /proc/version ] && grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then
+  if [ -x "$HOME/.airc-src/airc" ]; then
+    exec "$HOME/.airc-src/airc" "$@"
+  fi
+fi
+
+# Helpers for the WSL routing path. Building a properly-quoted command
+# string is the only way to get args across the Git Bash → wsl.exe →
+# bash boundary intact: `wsl.exe bash -lc "<cmd>" arg1 arg2` does NOT
+# forward the trailing args to the inline script (wsl.exe consumes
+# them). Inlining via printf %q is what makes `airc.cmd join --room X`
+# actually reach airc with the verb it expects.
+_airc_quote_args() {
+  local a out=""
+  for a in "$@"; do
+    out+=" $(printf '%q' "$a")"
+  done
+  printf '%s' "$out"
+}
+
+# 2) AIRC_WINDOWS_NATIVE=1 — skip WSL.
+# 3) Otherwise, prefer the WSL canonical clone if wsl.exe + clone exist.
+if [ -z "${AIRC_WINDOWS_NATIVE:-}" ] && command -v wsl.exe >/dev/null 2>&1; then
+  if wsl.exe bash -lc 'test -x "$HOME/.airc-src/airc"' >/dev/null 2>&1; then
+    _quoted=$(_airc_quote_args "$@")
+    exec wsl.exe bash -lc "exec \"\$HOME/.airc-src/airc\"$_quoted"
+  fi
+fi
+
+# 4) Windows-native fallback at %USERPROFILE%\.airc-src.
+# Translate USERPROFILE (Windows-style) to a Git Bash path. Pure-bash
+# transform avoids hard-coding /c/Users/... or invoking cygpath.
+_native_dir=""
+if [ -n "${USERPROFILE:-}" ]; then
+  _native_dir=$(printf '%s' "$USERPROFILE" | sed -E 's|\\|/|g; s|^([A-Za-z]):|/\L\1|')/.airc-src
+fi
+if [ -n "$_native_dir" ] && [ -x "$_native_dir/airc" ]; then
+  exec "$_native_dir/airc" "$@"
+fi
+
+# 5) Caller-relative fallback for esoteric installs (developer-tree
+# checkouts, AIRC_DIR-less custom layouts). Walk up from the shim.
+_shim_self=$(cd "$(dirname "$0")" 2>/dev/null && pwd)
+for _candidate in \
+  "$_shim_self/../.airc-src/airc" \
+  "$_shim_self/../airc-src/airc" \
+  "$_shim_self/../../.airc-src/airc"; do
+  if [ -x "$_candidate" ]; then
+    exec "$_candidate" "$@"
+  fi
+done
+
+# 6) Loud failure. No silent help banner — that's the failure mode
+# this shim was written to eliminate.
+echo "airc: cannot locate canonical airc bash binary." >&2
+echo "  Tried:" >&2
+echo "    AIRC_DIR              = ${AIRC_DIR:-(unset)}" >&2
+echo "    AIRC_WINDOWS_NATIVE   = ${AIRC_WINDOWS_NATIVE:-(unset)}" >&2
+echo "    WSL clone             = \$HOME/.airc-src/airc (in WSL)" >&2
+echo "    Windows-native clone  = ${_native_dir:-(no USERPROFILE)}/airc" >&2
+echo "" >&2
+echo "  Reinstall:" >&2
+echo "    curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash" >&2
+exit 1

--- a/install.sh
+++ b/install.sh
@@ -448,23 +448,42 @@ fi
 # ── airc on PATH ───────────────────────────────────────────────────────
 
 mkdir -p "$BIN_DIR"
-ln -sf "$CLONE_DIR/airc" "$BIN_DIR/airc"
-# Back-compat: `relay` still works for muscle-memory and stale docs.
-# The airc binary detects the invocation name and behaves identically.
-ln -sf "$CLONE_DIR/airc" "$BIN_DIR/relay"
-
-# Windows: also place airc.cmd + airc.ps1 forwarders on PATH.
-# Without these, `airc` invoked from native PowerShell or cmd.exe
-# resolves to the bash script, which PowerShell can't execute
-# ("Cannot run a document in the middle of a pipeline"). PR #262
-# made airc.ps1 a thin forwarder to bash, but that's moot if the
-# .ps1 isn't on PATH. cp (not ln -sf) — Windows symlinks are
-# privileged + flaky; copying is universal. Caught by
-# 2026-04-29 (issue #249 PowerShell row).
+# Single-source rule (#543/#544 follow-up): on real Linux/macOS the
+# symlink is fine — the kernel resolves it to $CLONE_DIR/airc each
+# invocation, so `airc update` propagates instantly. On Git Bash for
+# Windows (MINGW), `ln -sf` falls back to a literal COPY because
+# Developer Mode is off by default; that copy goes stale the moment
+# `airc update` (run from WSL) refreshes the canonical clone, and
+# Claude Code's Monitor running this stale copy was the root cause
+# of months of "Windows runs old code while airc version reports new
+# SHA" diagnoses. Use the polyglot shim on Windows instead — it
+# delegates to whichever live install (WSL canonical, then native)
+# is present at runtime. No copies, no drift.
 case "$(uname -s 2>/dev/null)" in
   MINGW*|MSYS*|CYGWIN*)
+    if [ -f "$CLONE_DIR/airc.shim" ]; then
+      # Replace any pre-existing full-script copy that earlier installs
+      # might have left in PATH. Failing soft is fine — best-effort
+      # cleanup is enough to fix dual-install drift.
+      [ -f "$BIN_DIR/airc" ] && rm -f "$BIN_DIR/airc" 2>/dev/null || true
+      [ -f "$BIN_DIR/relay" ] && rm -f "$BIN_DIR/relay" 2>/dev/null || true
+      cp -f "$CLONE_DIR/airc.shim" "$BIN_DIR/airc"
+      cp -f "$CLONE_DIR/airc.shim" "$BIN_DIR/relay"
+      chmod +x "$BIN_DIR/airc" "$BIN_DIR/relay" 2>/dev/null || true
+    else
+      # Repo predates the shim (transitional). Symlink-or-copy the full
+      # script as before; clean the duplicate next install.
+      ln -sf "$CLONE_DIR/airc" "$BIN_DIR/airc"
+      ln -sf "$CLONE_DIR/airc" "$BIN_DIR/relay"
+    fi
     [ -f "$CLONE_DIR/airc.cmd" ] && cp -f "$CLONE_DIR/airc.cmd" "$BIN_DIR/airc.cmd"
     [ -f "$CLONE_DIR/airc.ps1" ] && cp -f "$CLONE_DIR/airc.ps1" "$BIN_DIR/airc.ps1"
+    ;;
+  *)
+    # Real Linux/macOS: symlink is right.
+    ln -sf "$CLONE_DIR/airc" "$BIN_DIR/airc"
+    # Back-compat: `relay` still works for muscle-memory and stale docs.
+    ln -sf "$CLONE_DIR/airc" "$BIN_DIR/relay"
     ;;
 esac
 


### PR DESCRIPTION
## Summary

`install.sh` was symlinking the **full canonical airc bash script** to `$BIN_DIR/airc`. On real Linux/macOS the kernel resolves the symlink each invocation, so `airc update` propagates instantly. On Git Bash for Windows, `ln -sf` is silently a literal **copy** (Developer Mode is off by default), so the Windows PATH copy goes stale the moment `airc update` (run from WSL) refreshes the canonical clone.

That's how a 112KB May-5 copy of the full airc bash script sat at `C:\Users\<user>\.local\bin\airc` for weeks, while `airc version` (going through the `.cmd` shim) reported the up-to-date SHA. Claude Code's Monitor on Windows resolves `airc` via Git Bash's `which`, found the stale copy first, and silently ran months-old code — masking #538 / #541 / #542 / #543 entirely on the Monitor cold-start path.

## Fix

Per Joel's directive ([#543 follow-up](https://github.com/CambrianTech/airc/pull/543#discussion)):

> Any Windows-visible airc on PATH must be a shim, not a copied full bash script. The shim should route to the canonical WSL install when WSL `~/.airc-src/airc` exists. Native Windows fallback remains only when no WSL or `AIRC_WINDOWS_NATIVE=1`.

New file `airc.shim` — polyglot bash routing shim:

| Step | Condition | Action |
|---|---|---|
| 1 | `AIRC_DIR` set + has airc | exec that |
| 2 | We're in WSL ourselves (`/proc/version` says microsoft/wsl) | exec `$HOME/.airc-src/airc` directly (no wsl.exe round-trip) |
| 3 | `AIRC_WINDOWS_NATIVE=1` | skip WSL branch |
| 4 | wsl.exe present + WSL canonical exists | route via `wsl.exe bash -lc "exec ... $quoted_args"` |
| 5 | Native Windows clone at `%USERPROFILE%\.airc-src` | exec that |
| 6 | otherwise | loud failure with all attempted paths |

Step 4 uses `printf %q` to inline args into the bash command string — `wsl.exe bash -lc "<cmd>" arg1 arg2` does NOT forward those args to the inline script (same root-cause as #544; wsl.exe consumes them).

`install.sh` updated: on MINGW/CYGWIN/MSYS hosts, drop the polyglot shim into `$BIN_DIR/airc` + `$BIN_DIR/relay` instead of `ln -sf`'ing the full bash script. Also clean any pre-existing full-script copy left by prior installs (best-effort `rm -f`). Real Linux/macOS keeps the symlink — right tool there.

## Verification

Tested all three invocation contexts on Windows + WSL2:

```
$ cmd /c "C:\Users\green\.local\bin\airc.cmd" version
  airc 4305b8e (dirty) on fix/single-source-windows-shims
  install: /home/joel/.airc-src

$ "C:\Program Files\Git\bin\bash.exe" -lc "which airc; airc version"
/c/Users/green/.local/bin/airc          # the shim
  airc 4305b8e (dirty) on fix/single-source-windows-shims
  install: /home/joel/.airc-src

$ wsl bash -lc "/mnt/c/Users/green/.local/bin/airc version"
  airc 4305b8e (dirty) on fix/single-source-windows-shims
  install: /home/joel/.airc-src
```

All three resolve to the WSL canonical clone. No more dual-clone drift.

## Follow-up (out of scope here)

- `install.ps1` should also drop the polyglot shim at `%USERPROFILE%\.local\bin\airc` so Git Bash users who installed via the Windows-native path get a shim there too. Deferred to a separate PR.
- Add `scenario_windows_install_no_full_script_in_path` integration test that fails if any PATH entry has a full bash airc script (>10KB) instead of a shim. Deferred to a separate PR.
- Reproduced a separate `_join_restart_scope_processes` self-kill bug while testing this PR — when stale heartbeat triggers a restart, the running airc parent gets killed alongside the stale ones. Filing separately; not blocking this PR.

## Related

- #542 airc.cmd direct cmd→bash
- #543 dual-clone single-source for airc.cmd
- #544 airc.cmd args-forwarding (wsl.exe doesn't forward `$@`)
- THIS: extend single-source to ALL Windows-visible PATH copies, not just `airc.cmd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)