### PR TITLE
test: skip gone-gist send scenario without gh auth

### DIFF
--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2090,6 +2090,7 @@ PY
 # all config, signing, and cmd_send shell behavior stays real.
 scenario_send_gone_gist_does_not_claim_delivery() {
   section "send_gone_gist_does_not_claim_delivery: 404 suppresses delivered banner"
+  requires_gh_auth_or_skip "send_gone_gist_does_not_claim_delivery" || return
   cleanup_all
 
   local root=/tmp/airc-it-gone


### PR DESCRIPTION
## Summary
- gate  behind the existing  helper
- fixes the canary->main promotion CI where the old integration-suite runner has no PAT/GH_TOKEN and hits  instead of the intended 404 path

## Tests
- bash -n test/integration.sh
- ./test/integration.sh send_gone_gist_does_not_claim_delivery