### PR TITLE
feat(connect,status): cold-start phase telemetry (Windows UX)

### DIFF
--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -22,6 +22,57 @@
 # heartbeat are clearly separable), but step 1 is splitting it out of
 # the top-level monolith without changing behavior.
 
+# ── Cold-start phase telemetry ─────────────────────────────────────────
+# Codex/Joel-spec'd UX follow-up to #545/#546: emit "→ [t+Ns] phase…"
+# lines at the top of slow operations so a user staring at a Monitor
+# task can tell "still working" from "hung." Without this, Windows
+# Monitor cold-starts produced 30-60s of total silence followed by a
+# flood of host-setup output — indistinguishable from a hang.
+#
+# Design: t0 is anchored via $AIRC_WRITE_DIR/.cold_start_t0 (a unix
+# timestamp). The file is created on first phase emission and survives
+# across `_reexec_into host` (same scope, no env passing required).
+# The end-of-cold-start cleanup ("monitor stream attached") removes
+# the marker so the next `airc join` against an already-warm scope
+# starts from t0=0 again, not "minutes since the laptop's last boot."
+#
+# Output goes to BOTH stdout (so Monitor surfaces it as user-facing
+# events) AND $AIRC_WRITE_DIR/airc-transport.log (so post-mortem
+# traces show where the time went, even if the user closed the tab).
+_join_phase() {
+  local _t0_file="${AIRC_WRITE_DIR:-}/.cold_start_t0"
+  local _now _t0 _elapsed
+  _now=$(date +%s 2>/dev/null) || _now=0
+  if [ -n "${AIRC_WRITE_DIR:-}" ] && [ ! -f "$_t0_file" ]; then
+    mkdir -p "$AIRC_WRITE_DIR" 2>/dev/null || true
+    printf '%s\n' "$_now" > "$_t0_file" 2>/dev/null || true
+    _t0="$_now"
+  elif [ -f "$_t0_file" ]; then
+    _t0=$(cat "$_t0_file" 2>/dev/null || echo "$_now")
+  else
+    _t0="$_now"
+  fi
+  case "$_t0" in ''|*[!0-9]*) _t0="$_now" ;; esac
+  _elapsed=$(( _now - _t0 ))
+  [ "$_elapsed" -lt 0 ] 2>/dev/null && _elapsed=0
+  printf '  → [t+%ds] %s\n' "$_elapsed" "$*"
+  if [ -n "${AIRC_WRITE_DIR:-}" ] && [ -d "$AIRC_WRITE_DIR" ]; then
+    printf '%s [t+%ds phase] %s\n' \
+      "$(date -u +%FT%TZ 2>/dev/null || echo "?")" \
+      "$_elapsed" "$*" \
+      >> "$AIRC_WRITE_DIR/airc-transport.log" 2>/dev/null || true
+  fi
+}
+
+# Clear the cold-start anchor — call once monitor stream is attached
+# and the scope is in steady state. Without this, every subsequent
+# `airc join` (which re-enters cmd_connect on each tab restart) would
+# show "[t+86400s]" instead of fresh phase numbers.
+_join_phase_done() {
+  local _t0_file="${AIRC_WRITE_DIR:-}/.cold_start_t0"
+  [ -f "$_t0_file" ] && rm -f "$_t0_file" 2>/dev/null || true
+}
+
 # ensure_channel_subscribed_with_gist <channel> [--first]
 #
 # Single-concern helper: make this scope a fully-functional subscriber
@@ -478,6 +529,19 @@ _join_parent_chain_looks_like_claude_monitor() {
 
 cmd_connect() {
   local _orig_args=("$@")
+  # Stale cold-start anchor cleanup. If a previous airc join crashed
+  # before _join_phase_done could run, the .cold_start_t0 marker
+  # would linger forever and `airc status` would show a perpetually-
+  # rising "starting (t+86400s)". Clear stale (>10min) anchors at the
+  # top of each new cmd_connect so a fresh phase clock starts cleanly.
+  if [ -n "${AIRC_WRITE_DIR:-}" ] && [ -f "$AIRC_WRITE_DIR/.cold_start_t0" ]; then
+    local _stale_t0; _stale_t0=$(cat "$AIRC_WRITE_DIR/.cold_start_t0" 2>/dev/null || echo 0)
+    case "$_stale_t0" in ''|*[!0-9]*) _stale_t0=0 ;; esac
+    local _stale_now; _stale_now=$(date +%s 2>/dev/null) || _stale_now=0
+    if [ $((_stale_now - _stale_t0)) -gt 600 ] 2>/dev/null; then
+      rm -f "$AIRC_WRITE_DIR/.cold_start_t0" 2>/dev/null || true
+    fi
+  fi
   # Flag parsing. Issue #37 — host display shapes:
   #   default (gh installed + authed): gist ID + humanhash mnemonic + long invite
   #   default (no gh OR gh not authed): long invite only (today's behavior)
@@ -1110,6 +1174,7 @@ cmd_connect() {
     # no longer drives gist discovery — every subscriber on the account
     # converges on the same host.
     _did_room_discovery=1
+    _join_phase "querying gh for mesh on this account (#${room_name})"
     local _mesh_id; _mesh_id=$(_mesh_find_any "$room_name")
     if [ -n "$_mesh_id" ]; then
       local _mesh_invite_id; _mesh_invite_id=$(_mesh_find "$room_name")
@@ -1234,6 +1299,7 @@ cmd_connect() {
     # Gist IDs are hex strings, typically 20-32 chars but accept any
     # plausible length so future GH ID schemes don't break us.
     if echo "$gist_id" | grep -qE '^[a-zA-Z0-9]{6,40}$'; then
+      _join_phase "resolving room gist contents ($gist_id)"
       echo "  Resolving gist $gist_id ..."
       local raw_content=""
       # Each path's `raw_content=$(cmd | filter)` is protected with
@@ -1444,6 +1510,7 @@ cmd_connect() {
     if [ "$_resolved_heartbeat_stale" = "1" ] && [ -n "$resolved_room_name" ] \
        && [ -n "$_resolved_gist_id" ]; then
       echo ""
+      _join_phase "taking over stale host (re-exec into host mode)"
       echo "  ⚠  Host of #${resolved_room_name} is stale (last heartbeat ${_resolved_heartbeat_age}s ago) — taking over existing mesh..."
       echo "     (prior host's gist: $_resolved_gist_id)"
       _self_heal_stale_host "$_resolved_gist_id"
@@ -1849,8 +1916,11 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
       for p in $(proc_children $$); do kill $p 2>/dev/null; done
     ' EXIT INT TERM
 
+    _join_phase "subscribing to #general (sidecar)"
     spawn_general_sidecar_if_wanted
     _join_emit_join_events "$my_name"
+    _join_phase "monitor stream attached — cold start complete"
+    _join_phase_done
     echo "  Monitoring for messages..."
     monitor
 
@@ -1902,6 +1972,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
 
     echo ""
     [ "$host_port" != "$original_port" ] && echo "  Port $original_port was taken; using $host_port."
+    _join_phase "hosting as '$name' — bootstrapping room gist"
     echo "  Hosting as '$name' (reminder: ${reminder_interval}s)"
     echo ""
     local _invite_long="${name}@${user}@${host}${port_suffix}#${ssh_pubkey_b64}"
@@ -2121,6 +2192,11 @@ JSON
         # ID itself is the secret. Same threat model as the long invite:
         # whoever holds the string can pair. Room gists persist; invite
         # gists should be deleted by the host after the first joiner.
+        if [ -n "${_existing_room_gid:-}" ] && [ "$use_room" = "1" ]; then
+          _join_phase "publishing host lease to existing room gist"
+        else
+          _join_phase "creating new room gist on this gh account"
+        fi
         local _gist_url=""
         if [ -n "${_existing_room_gid:-}" ] && [ "$use_room" = "1" ]; then
           if gh gist edit "$_existing_room_gid" "$_gist_tmp" >/dev/null 2>/dev/null \
@@ -2475,8 +2551,11 @@ JSON
       [ "$_exit_restart" = "99" ] && exit 99
     ' EXIT INT TERM
 
+    _join_phase "subscribing to #general (host-mode sidecar)"
     spawn_general_sidecar_if_wanted
     _join_emit_join_events "$name"
+    _join_phase "monitor stream attached — cold start complete"
+    _join_phase_done
     echo "  Monitoring for messages..."
     monitor
     kill $PAIR_PID 2>/dev/null

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -254,6 +254,24 @@ cmd_status() {
     fi
   elif [ -f "$pidfile" ]; then
     monitor_state="stale pidfile (no live PIDs — run 'airc join' to self-heal)"
+  elif [ -f "$AIRC_WRITE_DIR/.cold_start_t0" ]; then
+    # Cold-start anchor exists but no airc.pid yet — airc join is
+    # still in the slow-discovery / handshake / takeover phase. Tell
+    # the user that explicitly so "not running" doesn't read as
+    # "broken." Cleared by _join_phase_done once monitor stream
+    # attaches. Stale-marker guard: if the anchor is >10min old we
+    # treat it as orphaned (a join crashed without cleanup); fall
+    # back to "not running" so the user gets the actionable message
+    # instead of a perpetually-rising "starting (t+50000s)".
+    local _t0; _t0=$(cat "$AIRC_WRITE_DIR/.cold_start_t0" 2>/dev/null || echo 0)
+    case "$_t0" in ''|*[!0-9]*) _t0=0 ;; esac
+    local _now _elapsed
+    _now=$(date +%s 2>/dev/null) || _now=0
+    _elapsed=$(( _now - _t0 ))
+    [ "$_elapsed" -lt 0 ] 2>/dev/null && _elapsed=0
+    if [ "$_elapsed" -le 600 ] 2>/dev/null; then
+      monitor_state="starting (airc join cold-start in progress, t+${_elapsed}s)"
+    fi
   fi
   echo "  airc process: $monitor_state"
   _airc_monitor_health_report all


### PR DESCRIPTION
## Summary

Codex-spec'd UX follow-up to #545/#546. Without this, Windows Monitor cold-starts produced 30-60s of total silence followed by a flood of host-setup output — indistinguishable from a hang.

Pure observability addition. No control-plane behavior changes. Single-source PATH invariant from #545 preserved.

## Helper: `_join_phase` (in `cmd_connect.sh`)

- t0 anchored via `$AIRC_WRITE_DIR/.cold_start_t0`; survives `_reexec_into host` (same scope, no env passing required)
- Output goes to BOTH stdout (Monitor surfaces it as user-facing event) AND `$AIRC_WRITE_DIR/airc-transport.log` (post-mortem traces show where the time went)
- `_join_phase_done` clears the marker once the monitor stream attaches — next `airc join` against an already-warm scope starts from t0=0 again
- Stale-marker self-cleanup at top of `cmd_connect` for crashed-prior-join anchors >10min old

## Phase markers added at slow points

| Phase | Source op |
|---|---|
| querying gh for mesh on this account (#X) | `_mesh_find_any` (gh gist list) |
| resolving room gist contents (id) | `gh api gists/<id>` |
| taking over stale host | re-exec to host mode |
| hosting as NAME — bootstrapping room gist | host mode entry |
| publishing host lease to existing room gist | `gh gist edit` |
| creating new room gist | `gh gist create` (alt path) |
| subscribing to #general (sidecar) | `spawn_general_sidecar_if_wanted` |
| monitor stream attached — cold start complete | terminal |

## `cmd_status` — distinguish "starting" from "not running"

Pre-fix `airc status` reported `airc process: not running` whether airc was genuinely absent OR mid-cold-start. Post-fix:

- If `.cold_start_t0` exists AND age ≤ 600s → `starting (airc join cold-start in progress, t+Ns)`
- Stale-marker guard: anchors >10min old treated as orphaned, falls back to `not running` so user gets the actionable message

## Live verification

Smoke run on Windows WSL2 (isolated AIRC_HOME, fresh discovery, stale prior host triggering takeover):

```
→ [t+0s]  querying gh for mesh on this account (#general)
→ [t+15s] resolving room gist contents (c68640ec...)
→ [t+17s] taking over stale host (re-exec into host mode)
→ [t+21s] hosting as 'win-continuum-8e97' — bootstrapping room gist
→ [t+25s] publishing host lease to existing room gist
→ [t+25s] subscribing to #general (host-mode sidecar)
→ [t+26s] monitor stream attached — cold start complete
```

`airc-transport.log` (post-mortem):

```
2026-05-07T02:56:44Z [t+0s phase] querying gh for mesh on this account (#general)
2026-05-07T02:56:59Z [t+15s phase] resolving room gist contents (c68640ec...)
2026-05-07T02:57:01Z [t+17s phase] taking over stale host (re-exec into host mode)
2026-05-07T02:57:05Z [t+21s phase] hosting as 'win-continuum-8e97' ...
2026-05-07T02:57:09Z [t+25s phase] publishing host lease to existing room gist
2026-05-07T02:57:09Z [t+25s phase] subscribing to #general (host-mode sidecar)
2026-05-07T02:57:10Z [t+26s phase] monitor stream attached — cold start complete
```

`airc status` mid-cold-start (prior to the done marker clearing):

```
airc process: starting (airc join cold-start in progress, t+34s)
```

## Related — Windows Monitor cold-start surface trail

| PR | Concern |
|---|---|
| #533 | SIGHUP cascade |
| #538 | monitor 404-gone gist |
| #541 | airc.pid+messages.jsonl early-write |
| #542 | airc.cmd direct cmd→bash |
| #543 | dual-clone single-source |
| #544 | airc.cmd args-forwarding |
| #545 | polyglot shim |
| #546 | supervisor self-protect (3-layer) |
| **THIS** | UX/observability for residual cold-start latency |

🤖 Generated with [Claude Code](https://claude.com/claude-code)