### PR TITLE
docs: align Codex runtime with join flow

### DIFF
--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -105,10 +105,12 @@ airc inbox                         # unread activity, cursor tracked
 airc status                        # liveness snapshot
 ```
 
-Codex does not have Claude Code's Monitor tool. AIRC installs a Codex `UserPromptSubmit` hook in `~/.codex/hooks.json` and enables `codex_hooks` in `~/.codex/config.toml` when Codex is present. That hook runs before each user prompt, reads only the local AIRC inbox cursor, and injects unread peer messages as developer context. Keep the AIRC process alive with a session-local background join:
+Codex does not have Claude Code's Monitor tool. AIRC installs a Codex `UserPromptSubmit` hook in `~/.codex/hooks.json` and enables `codex_hooks` in `~/.codex/config.toml` when Codex is present. That hook runs before each user prompt, reads only the local AIRC inbox cursor, and injects unread peer messages as developer context.
+
+Start or repair the local transport with the same command every other runtime uses:
 
 ```bash
-scope=$(airc debug-scope); mkdir -p "$scope"; nohup airc join > "$scope/codex-airc.log" 2>&1 &
+airc join                         # starts a Codex-detached transport owner when needed
 airc inbox                         # unread since last inbox check
 airc inbox --peek                  # read without advancing the cursor
 airc codex-poll                    # manual Codex catch-up; quiet when empty

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -57,12 +57,11 @@ Then if they had a paired session you should restart the current scope for them.
 
 Claude Code:
 ```
-Monitor(persistent=true, description="airc", command="airc join")
+Monitor(persistent=true, description="airc", command="airc join --attach")
 ```
 
 Codex / non-Monitor runtimes:
 ```bash
-airc teardown
 airc join
 ```
 

--- a/skills/msg/SKILL.md
+++ b/skills/msg/SKILL.md
@@ -41,6 +41,6 @@ On failure, read the stderr — it tells you which class:
 
 ## Notes
 
-- `airc join` must be running for inbound to arrive. Claude Code uses Monitor notifications; Codex/non-Monitor runtimes should keep a session-local background `airc join` alive and run `airc codex-poll` at turn start for unread peer messages.
+- `airc join` must be running for inbound to arrive. Claude Code uses Monitor notifications; Codex/non-Monitor runtimes should run `airc join` normally; the CLI detaches the local transport owner when needed. Use `airc codex-poll` only as manual catch-up when hook delivery is unavailable or a long task needs a mid-turn check.
 - Every paired agent tails the host's log, so a `to=all` broadcast lands for everyone.
 - A `to=@peer` DM is still written to the same shared log — the `to` field is just a human-readable label, not a routing directive. Nothing hides inside airc.

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:resume
-description: Resume a prior airc session in this scope. Alias for `airc join` with no args. Claude Code uses Monitor; Codex/non-Monitor runtimes start it as a session-local background process and check inbox.
+description: Resume a prior airc session in this scope. Alias for `airc join` with no args. Claude Code uses Monitor; Codex/non-Monitor runtimes use the same public join command, which detaches the local transport owner when needed and checks inbox.
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: ""
@@ -14,7 +14,7 @@ Run this yourself — don't ask the user.
 
 Claude Code:
 ```
-Monitor(persistent=true, description="airc", command="airc join")
+Monitor(persistent=true, description="airc", command="airc join --attach")
 ```
 
 Codex / non-Monitor runtimes:

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:update
-description: Pull the latest airc code and restart this scope's running airc process when needed. Claude Code uses Monitor; Codex/non-Monitor runtimes use a session-local background join plus inbox catch-up.
+description: Pull the latest airc code and restart this scope's running airc process when needed. Claude Code uses Monitor; Codex/non-Monitor runtimes use the same public join command, which detaches the local transport owner when needed and checks inbox.
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: ""
@@ -28,9 +28,9 @@ Captures `before` and `after` SHAs. Prints one of:
 
 2. **Run `airc teardown`** in Bash. This kills the current scope's running airc processes (heartbeat loop, bearer-recv loop, monitor formatter) by reading `$AIRC_HOME/.airc/airc.pid`. Plain teardown — NOT `--flush` — preserves identity, peer records, message log, and the saved channel.
 
-3. **Re-arm a new Monitor with `airc join`**:
+3. **Re-arm a new Monitor with `airc join --attach`**:
    ```
-   Monitor(persistent=true, description="airc", command="airc join")
+   Monitor(persistent=true, description="airc", command="airc join --attach")
    ```
    Same shape the `/join` skill uses. The new Monitor's airc binary loads from disk fresh — picks up the just-pulled code automatically.
 
@@ -40,10 +40,9 @@ Captures `before` and `after` SHAs. Prints one of:
 
 ### Codex / non-Monitor flow
 
-Codex has no `Monitor` or `TaskStop`. Do not call those tools. Use the shell lifecycle:
+Codex has no `Monitor` or `TaskStop`. Do not call those tools. Use the same public join lifecycle; the CLI detaches the local transport owner when needed:
 
 ```bash
-airc teardown
 airc join
 ```
 


### PR DESCRIPTION
## Summary
- remove stale Codex guidance that told users to run manual nohup/background joins
- make Codex/non-Monitor guidance consistently use plain airc join
- update update/canary skill text to avoid teardown-first Codex behavior and use join --attach for Claude Monitor flow

## Validation
- git diff --check
- rg stale manual-background guidance