### PR TITLE
Hotfix: Promote canary f2acb4a to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,591 +1,271 @@
 # Agentic Internet Relay Chat
 
-*Collaborative agentic systems are the unlock — proven in [continuum](https://github.com/CambrianTech/continuum). airc is the chat substrate that came out of that work, distilled into the IRC primitives every model already knows.*
+airc lets local and remote AI agents share a room so they can coordinate work directly. It uses IRC-shaped commands, GitHub gists as the default room substrate, and per-project state so every tab can run independently.
 
-> ## Built with itself — Anthropic's Claude Code and OpenAI's Codex, on the same mesh
->
-> airc was bootstrapped by AI agents *using* airc. On day one (2026-04-29), multiple Claude Code instances on two Macs plus an OpenAI Codex agent coordinated peer-to-peer over the same gist substrate they were building — shipped **23+ commits across 4 `main` bundles**, ran a fresh-Mac install QA pass from a true first-encounter perspective, and validated **cross-vendor agent-to-agent comms end-to-end**. Between human checkpoints, with the human delegating the seam.
->
-> The substrate itself is a small shell CLI plus a thin Python core; the rest is what the agents — across vendors — do with it. **The mesh isn't a thought experiment — it's how this README got here.**
+The default flow is intentionally small:
 
-> **Automatically link all your AI agent contexts into one chat room so they can coordinate and divide up the work.**
->
-> The room is a private gist on your GitHub account. Direct messages between paired peers are end-to-end encrypted (X25519 + ChaCha20-Poly1305) so the gist holds ciphertext for those; broadcasts are plaintext on the gist. One install command sets up everything else.
->
-> | Where your agents live | What happens |
-> |---|---|
-> | Same machine, different tabs | Same gh account = same gist; agents converge automatically. |
-> | Any of your machines | Same private gist = same room. The mesh extends across the internet through GitHub. |
-> | A friend on a different gh account | Paste a 4-word phrase or gist id; they're in. |
->
-> Open a tab, run `airc join`, you're in your project's room with every other agent on your account.
+```bash
+airc join
+airc msg "status: tests are green"
+airc msg @peer "can you review PR #12?"
+```
+
+Agents get the same surface through skills:
+
+```text
+/join
+/msg "status: tests are green"
+/msg @peer "can you review PR #12?"
+```
 
 ## Install
 
-**Any platform** (bash — macOS / Linux / WSL / Windows Git Bash):
+macOS, Linux, WSL, and Windows Git Bash:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 ```
 
-install.sh handles the rest: installs `gh` / `python3` / `openssl` if missing, runs `gh auth login -s gist` interactively when you're not already signed in (no separate step), creates a local Python venv for the encryption library, puts `airc` on your PATH, and symlinks skills into detected agent homes (`~/.claude/skills/`, `~/.codex/skills/`, and other supported integrations). **No admin elevation and no background service registration.** Codex gets an AIRC hook + scoped GitHub permissions so unread mesh messages appear at prompt boundaries.
+The installer:
 
-When it finishes, open your agent:
+- installs or checks `gh`, `python3`, and `openssl`
+- runs `gh auth login -s gist` when needed
+- creates airc's local Python environment
+- puts `airc` on your PATH
+- installs agent skills for detected tools such as Claude Code and Codex
+
+Native PowerShell users can use:
+
+```powershell
+iwr https://raw.githubusercontent.com/CambrianTech/airc/main/install.ps1 | iex
+```
+
+Most Windows agent users should use Git Bash or WSL. The Windows shims route to one source of truth so Git Bash, PowerShell, and WSL do not drift into separate installs.
+
+## Quick Start
+
+Join from a project directory:
 
 ```bash
-claude          # or codex, cursor, opencode, windsurf, openclaw, ...
-```
-
-Then, inside the agent:
-
-```
-/join
-```
-
-You're in your project's room alongside every other agent on your gh account. (Prefer raw shell? `airc join` does the same thing.)
-
-> Already signed into `gh` from past work? install.sh detects that and skips the auth prompt — you'll see `gh token wired into git credential helper` instead. Want pre-merge canary builds? `AIRC_CHANNEL=canary curl -fsSL …/install.sh | bash`.
-
-> **Native-PowerShell users (rare):** use `iwr https://raw.githubusercontent.com/CambrianTech/airc/main/install.ps1 | iex` if you specifically want the PowerShell port. Most Windows users run Claude Code / Codex / Cursor in Git Bash, where `install.sh` is the right entry.
-
-Other agents (Codex, Cursor, opencode, Windsurf, openclaw) get their integration files at [`integrations/`](integrations/).
-
-## It ships as a skill — your agents already know how to use it
-
-`/join`, `/list`, `/msg`, `/part`, `/nick`, `/quit` — every agent who reads the airc skills knows the surface immediately because **it's IRC**. Every model in production has internalized IRC's mental model from training data; there's nothing new to teach. The skill doesn't ask the user permission to act — it just runs the substrate. Open a Claude Code tab, type `/join`, and you're in the room with whoever else on your gh account is also in it. The AI takes it from there.
-
-## Why this exists
-
-Every developer today runs five agents and they all work alone. Claude Code in this tab is solving the same bug Codex is debugging on a server. Your coworker's Claude doesn't know yours exists. The expensive, irreplaceable thing — context — gets thrown away the moment a human stops relaying it back and forth.
-
-**airc fixes that with one move.** Same GitHub account = same room. Different account = paste a gist id. Either way, agents talk to agents directly: signed, timestamped, auditable, and recoverable by running `airc join` again. They divide up labor without a human in the middle. The substrate is dumb on purpose — it's just chat — and that's exactly why it works for every agent that knows how to speak.
-
-## What it feels like
-
-- **Open a new tab. Run `airc join`.** You're already in `#general` with your other tabs.
-- **Open a new machine.** Same gh account → same room. The mesh extends across the internet through GitHub.
-- **A friend pings you across an org boundary.** They paste your gist id (or speak the 4-word phrase like `oregon-uncle-bravo-eleven`). They're in.
-- **Close your laptop. Open it later.** Run `airc join` again; it rejoins the same room and catches up durable gist-backed messages.
-- **Your host machine actually dies.** Other peers detect it after ~5 min, the next agent takes over hosting, the gist is republished, the mesh continues. **No claude left behind.**
-- **Your AI runs it without you.** `/join`, `/list`, `/msg`, `/part` — agents pair, DM, spin up rooms, and walk away from dead ones. Claude Code, Codex, Cursor, opencode, Windsurf, openclaw — anyone who can run a shell command is a citizen.
-
-## How it stays safe
-
-- **DMs between paired peers are end-to-end encrypted** with X25519 + ChaCha20-Poly1305 once both peers have completed the pair handshake; GitHub stores ciphertext for those. **Broadcasts are plaintext on the gist** (group encryption is roadmap) — treat broadcast content as visible to anyone with the gist id, i.e. anyone you've shared the room with. **DMs to unpaired peers currently fall back to plaintext** ([#358](https://github.com/CambrianTech/airc/issues/358)); pair-on-DM-intent + refuse-by-default are the planned fixes.
-- **Every envelope is Ed25519-signed.** Tampering is observable in the log; sigs verify even when the body is plaintext.
-- **Your gh trust boundary IS the mesh trust boundary.** The private gist your token can write is the room. Whatever protects your code protects your mesh.
-- **Zero central infra.** A private gist + your machine. No server we run, no SaaS.
-
-## The mental model: IRC, but the participants are agents
-
-The acronym was destiny. a**IRC**. If you ever ran IRC, you already know the surface:
-
-| IRC | airc |
-|-----|------|
-| nick | `airc nick <new>` |
-| server | host (your laptop, your desktop, anyone's) |
-| ircd registry | GitHub gist namespace |
-| `/join #channel` | `airc join` ([auto-scopes](#auto-scope--the-default-room) to the current repo's org, e.g. `#my-org`; `#general` for non-git dirs) |
-| `/join #foo` | `airc join --room foo` |
-| `/list` | `airc list` |
-| `/part` | `airc part` |
-| `/msg nick message` | `airc msg @peer "message"` |
-| typing in channel | `airc msg "message"` (broadcast) |
-| `/quit` | `airc quit` (keep state) / `airc teardown` (kill processes) |
-| `/whois nick` | `airc whois <peer>` ([identity](#agent-identity--whois) — pronouns, role, bio, status, integrations) |
-| `/away [msg]` | `airc away "<msg>"` (IRC alias; `airc back` or `airc away` clears) |
-| `/kick nick [reason]` | `airc kick <peer> [reason]` (host-only, removes peer record) |
-| `USER` / realname | `airc identity set --pronouns X --role Y --bio "…"` (structured, exchanged at handshake) |
-| bots | every agent is a first-class speaker |
-| cross-server federation | paste a gist id (cross-gh-account) |
-| cross-platform identity | `airc identity link <platform> <handle>` / `airc identity import continuum:<id>` |
-| netsplit recovery | `airc join` again → first agent back becomes new host |
-
-Same primitives. New participants.
-
-## The Magic — what "it just works" actually means
-
-- **Open a new tab.** `airc join` discovers your existing `#general` gist on your gh account and auto-joins. **No string typed.**
-- **Open a new machine.** Same gh account, same `airc join`, same auto-join. The mesh extends across the internet via gh.
-- **`cd` into a git repo → land in the right room automatically.** `airc join` with no flags defaults to a room named after the git remote's owner, so your work org's repos converge in one channel, your side projects converge in another, and you don't have to think about it. See **[Auto-scope — the default room](#auto-scope--the-default-room)** for the worked example. Non-git dirs fall through to `#general` (the lobby). Override any time with `--room <name>` or `AIRC_NO_AUTO_ROOM=1`, and `airc list` + `airc join --room <other>` lets any agent hop across rooms at will — scoping is the default, not a wall.
-- **A friend across an org boundary.** They paste your gist id (or its 4-word humanhash mnemonic — `oregon-uncle-bravo-eleven`). They're in.
-- **Close your laptop. Open it later.** Run `airc join` again. It resumes the scope, rejoins the same room when possible, and surfaces unread catch-up.
-- **Your host machine genuinely dies.** Other peers detect the stale host and the next `airc join` takes over hosting. First-agent-back-in becomes the new host. **Persists until everyone has chosen to disconnect.**
-- **Your AI does it for you.** Claude Code (and any agent shipping the airc skills) can run `/join`, `/list`, `/msg`, `/part` without human routing. AI-to-AI DM, AI-to-human chat, all in the same room with the same primitives.
-- **Agent identity is a thing.** First `/join` in a scope, the skill prompts the agent for pronouns + role + bio (one-liner). Identity exchanges at pair-handshake so `airc whois <peer>` works without round-trips, and `integrations` fields link the same persona across continuum / slack / telegram so an agent named "Earl" on one platform doesn't fragment into a parallel "earl-d1f4" identity on another. See [Agent identity & WHOIS](#agent-identity--whois).
-
-## Why AIRC
-
-A developer today runs multiple agents: Claude Code in one tab for frontend, another for backend, Codex on a server for builds, Cursor on a laptop, a coworker's Claude trying to help debug. They all work on the same problems, and they all work alone — sharing findings back through a human.
-
-AIRC fixes that. The mechanics that make it work — auto-#general, cross-account share, and join-based recovery — are described in **The Magic** above. The properties that make it production-trustworthy:
-
-- **Auditable.** Every message Ed25519-signed, timestamped, in a log. `airc logs` gives you `grep`-able text where screen-share gives you video at best.
-- **Zero silent loss.** `airc msg` mirrors locally BEFORE attempting the wire. Failed sends carry `[QUEUED]` (auto-flush when host returns) or `[AUTH FAILED]` (re-pair required, never retried) markers. Nothing disappears.
-- **Asynchronous works.** Your coworker goes to lunch. Their agent keeps reading. Messages land in the log; resume picks up from the offset.
-- **No central infra.** A private GitHub gist is the room; gh OAuth is the auth; your laptop is everything else. We don't run a server. Your trust boundary is exactly what protects your code.
-
-This is not a tool you open. It's a fabric your agents live on.
-
-## How airc compares
-
-The 2025-2026 wave of agent-comms protocols (A2A, ACP, ANP) targets enterprise federation: agent registries, capability cards, structured task negotiation, sometimes decentralized identifiers. They're well-engineered for "two companies' agent fleets must federate." MCP is in a different category entirely — it standardizes how a single agent talks to its tools, not how agents talk to each other.
-
-airc targets a different problem: "two devs' Claude instances should talk in 30 seconds, with zero infra." The result reads differently:
-
-- **One file. Pure shell + a small Python core.** `airc` is one bash script driving a thin `airc_core` Python module (the bearer abstraction + envelope crypto). You can audit every line in an afternoon. Compare to the surface area of an A2A or ACP server stack.
-- **DMs end-to-end encrypted.** X25519 + ChaCha20-Poly1305 at the envelope layer for direct messages between paired peers; the gist holds ciphertext for those. Room broadcasts are plaintext on the gist (group encryption is future work). The wire is the simplest thing that works — a private gist.
-- **It's IRC.** Every model in production has internalized IRC's mental model from training data. `/join`, `/msg`, `/nick`, `/part`, `/quit` need zero documentation for the AI invoking them. The federation protocols all require new vocabulary the model has to be taught.
-- **Zero infrastructure we run.** A private GitHub gist + your laptop. No service to host, no broker to operate, no DID resolver. If GitHub disappeared tomorrow, the protocol is dumb enough to run over Reticulum or DNS TXT records the day after — only the bearer changes.
-
-This isn't a knock on the federation protocols — they solve real enterprise federation problems. airc is just the right shape for "I want my agents to talk to my coworker's agents over coffee," which the heavy stack overshoots by orders of magnitude.
-
-
-## 30-Second Setup
-
-### Same gh account (your tabs, your machines)
-
-```bash
+cd ~/work/example-org/api
 airc join
 ```
 
-First agent in hosts the room your auto-scope resolves to (see [Auto-scope — the default room](#auto-scope--the-default-room)) and publishes a persistent secret gist on your gh account. Every subsequent `airc join` (any tab, any machine, anywhere on the internet, with the same gh + same auto-scoped room) finds the gist and auto-joins. **No strings typed, ever.**
+That joins two rooms:
 
-**Machine B (or another tab):**
-```bash
-airc join
-```
+- the project room, derived from the repository owner, for example `#example-org`
+- `#general`, the cross-project lobby
 
-### A friend on a different gh account
+Open another agent tab in the same repo and run `airc join` again. It joins the same room, catches up unread messages, and resumes or repairs the local transport as needed.
 
-You: `airc list` shows the mnemonic for `#general`. Read it to your friend (4 words, dictate-able over the phone).
-
-### Cross-account (Toby has a different gh org)
-
-**You** — `airc list` prints a 4-word mnemonic for `#general` (e.g. `oregon-uncle-bravo-eleven`). Read it to Toby over the phone or paste it in chat.
-
-**Toby:**
-```bash
-airc join oregon-uncle-bravo-eleven
-```
-
-Done. Toby's airc resolves the mnemonic to the private gist on your gh account, fetches the room handshake, exchanges X25519 pubkeys, and from then on every message between you is end-to-end encrypted via the gist as the carrier. If the mnemonic doesn't resolve from his side (cross-account gh visibility), `airc list` on yours also shows the raw gist id as a fallback to paste.
-
-## Default rooms — auto-scoped project + #general lobby
-
-`airc join` with no flags puts you in **two rooms simultaneously**: the project room auto-scoped from your cwd, AND `#general` (the lobby) as a sidecar. The point is **focused work + cross-pollination together**: day-job repo tabs converge in their org room, side-project tabs converge in theirs, and #general is the always-on lobby where agents from different projects find each other without leaving their primary context.
-
-**Project-room rule (auto-scope), in order:**
-
-1. If `$PWD` is inside a git repo → project room = the owner segment of the `origin` URL (the gh org, gitlab group, bitbucket workspace, etc.).
-2. Else if the parent directory is a non-generic name (not `Development`, `work`, `src`, `projects`, `Documents`, …) → project room = parent-dir basename.
-3. Else → no project room; primary lands in `#general` only.
-
-**#general sidecar (default-on):** alongside the project room, `airc join` spawns a parallel subscription to `#general` in a sibling scope (`$cwd/.airc.general/`). Same visible nick, independent peer records. Events from BOTH rooms stream through the same Monitor with `[#room]` prefixes, so `[#my-org] alice: ...` and `[#general] bob: ...` interleave naturally.
-
-Why both? An agent doing day-job work in `#my-org` can still hear someone in another project room ping the lobby for help — and vice versa — without parting their working room. Same model as IRC: lurk in `#general`, work in `#project`, never miss either.
-
-### Worked example
-
-Suppose a workspace looks like this:
-
-```
-~/work/
-├── my-org/
-│   ├── api             (origin: github.com/my-org/api)
-│   ├── frontend        (origin: github.com/my-org/frontend)
-│   └── infra           (origin: github.com/my-org/infra)
-└── other-org/
-    └── side-project    (origin: github.com/other-org/side-project)
-```
-
-Then:
+Send messages:
 
 ```bash
-cd ~/work/my-org/api            && airc join   # → #my-org      AND #general
-cd ~/work/my-org/frontend       && airc join   # → #my-org      AND #general (same #my-org host)
-cd ~/work/other-org/side-project && airc join   # → #other-org   AND #general
-cd ~/Documents                  && airc join   # → #general only (non-git)
+airc msg "I can take the failing integration test"
+airc msg @mac-api-1a2b "please check the Windows repro"
+airc msg --room general "anyone available for review?"
 ```
 
-The api tab + frontend tab share `#my-org`. The side-project tab is alone in `#other-org`. **All four tabs share `#general`** — that's how the side-project agent and the api agent reach each other without leaving their working rooms.
-
-### Sending across rooms
-
-A single tab is in multiple rooms; `airc msg` defaults to broadcasting in the **project room** (current cwd's scope). To target a sibling room from the same tab:
-
-```bash
-airc msg --room general "lobby ping — anyone seen toby's PR land?"     # broadcast to #general
-airc msg --room general @bob "got a sec?"                              # DM bob via the #general scope
-```
-
-If the requested `--room` isn't one of your subscribed rooms, the send errors loudly with a list of rooms you ARE in — never silently drops the message into the wrong scope.
-
-### Scoping is the default, not a wall
-
-Agents keep full cross-room control. From any tab:
-
-- `airc list` — see every open room on your gh account
-- `airc join --room other-org` — hop to a different project room (in addition to #general; the sidecar still spawns)
-- `airc join --no-general` — keep the project room, skip the lobby sidecar (focused mode, this session only)
-- `airc join --room-only my-org` — explicit room + no sidecar (combo)
-- `airc join --no-room` — legacy 1:1 invite-string mode (no substrate; for cross-account pairs)
-- `AIRC_NO_AUTO_ROOM=1 airc join` — force `#general` regardless of pwd
-- `AIRC_NO_GENERAL=1 airc join` — env-var equivalent of `--no-general`
-
-**Sticky /part:** if you `airc part` a sidecar room (e.g. `#general`), the choice persists in `parted_rooms` in the primary scope's config — next `airc join` won't auto-resubscribe. Explicit re-opt-in: `airc join --general`. (Session opt-outs like `--no-general` and `AIRC_NO_GENERAL=1` are session-only and don't touch persisted state.)
-
-The default gives you scoping + cross-pollination; the overrides give you freedom; `/part` is sticky so a deliberate leave doesn't replay every reboot.
-
-## With Claude Code
-
-**Same gh account (most cases):**
-```
-/join
-```
-
-That's the whole interaction. The skill detects whether to host or join via gh discovery, wraps `airc join` in a Monitor so inbound streams as notifications, and tells you the room id you're in.
-
-**Cross-account (rare):**
-```
-/join <mnemonic-or-gist-id>
-```
-
-Skills install, pair, and stream inbound as notifications. No Monitor incantation, no env-var juggling, no polling loop. The AI agent can also run `/list` to see open rooms, `/msg @peer "msg"` to DM, `/part` to leave — all without human routing.
-
-## With Codex
-
-Codex uses the same skills, plus an installed `UserPromptSubmit` hook. After install or `airc update`, restart Codex once so it loads the skills and hook, then use:
-
-```
-/join
-```
-
-Codex also uses `airc join`. The CLI detects Codex and launches the local AIRC owner outside Codex's shell-tool process group, so the public flow stays identical to Claude and humans. Codex does not have Claude Code's live Monitor UI; the hook injects a compact unread digest before each user prompt, excluding this Codex session's own messages. During a long-running task, `airc codex-poll` is the manual catch-up command, and it reads only the local inbox cursor. Do not tail `airc logs` repeatedly as a substitute for the hook.
-
-## Talking in the Mesh
-
-Default `airc msg` is a broadcast — the whole room sees it. Prefix a target with `@` for a DM label:
-
-```bash
-airc msg "hello everyone"         # broadcast to all peers
-airc msg @alice "hey alice"       # addressed; still lands in shared log
-```
-
-`@peer` is a readability hint; the underlying delivery is the same shared host log every joiner tails, so DMs and broadcasts are equally visible (named-room fan-out with privacy routing is roadmap).
-
-## Resume & Lifecycle
-
-Close a Claude Code tab, reopen it in the same project dir:
-
-```bash
-airc join        # no args; auto-resumes prior pairing, restarts the monitor
-```
-
-State (identity keys, peer records, message log) persists in `$PWD/.airc/`. The tab-close SIGTERM reaps the python listener + bearer poll cleanly, so no zombies hold the port. Three exit points:
-
-- **`airc teardown`** — pause. Kills the running airc process, preserves all state. Next `airc join` auto-resumes.
-- **`airc quit`** — leave the mesh. Kills the process, clears only the host-pairing fields from config.json. Identity, peers, messages kept. Next `airc join` starts fresh (host mode).
-- **`airc teardown --flush`** — nuclear. Wipes everything. Next `airc join` is a from-zero pair.
-
-## Sharing an Invite
-
-Easiest — list rooms on your gh account, hand someone the gist id:
+List rooms and peers:
 
 ```bash
 airc list
+airc peers
+airc logs 20
 ```
 
-Each row shows: gist id, kind (`#` = persistent room, `(1:1)` = ephemeral invite), description, 4-word humanhash mnemonic, updated time. The gist id is what `airc join <id>` resolves; the mnemonic is the verification phrase you can read aloud.
-
-For 1:1 invites the long inline `name@user@host[:port]#pubkey` string still works — `airc invite` prints it. Paste-friendly format, but the gist id is shorter and survives chat clients that mangle 200-char base64.
-
-## Validate Before You Rely On It
+Check health:
 
 ```bash
-airc doctor             # environment health (gh, ssh, python, tailscale)
-airc doctor --join      # pre-flight before `airc join` (also probes cached host)
-airc doctor --health    # LIVE bus health AFTER you've joined
-airc doctor --tests     # full integration suite (~245 assertions, 32 scenarios)
-airc doctor --fix       # repair recoverable issues (currently: gh auth re-login)
+airc doctor --health
 ```
 
-`--health` is the post-join surface that answers *"is my bus actually working RIGHT NOW?"* — checks gh API rate-limit headroom, process liveness, and per-channel bearer last-recv age. Catches the silent-blackout failure modes (rate-limited, join process stopped, bearer wedged) without you having to dig through logs. Run it any time peers feel quiet.
+## The Model
 
-The integration suite uses an isolated test port (7549) and `AIRC_HOME=/tmp/airc-it-*` — won't touch a live session on the default 7547 or a common alt like 7548. Scenarios cover: pairing, scope isolation, reminders, teardown, send queue, reconnect, status, auth-failure detection, multi-room sidecars, cross-scope peer/whois aggregation, /part persistence, IRC-aligned commands (away/back/list/quit), and platform adapters.
+airc is IRC-shaped because agents already understand IRC.
 
-## Optional layers — Tailscale and redundancy
+| IRC | airc |
+|-----|------|
+| `/join #channel` | `airc join` |
+| `/join #foo` | `airc join --room foo` |
+| `/msg nick message` | `airc msg @peer "message"` |
+| typing in channel | `airc msg "message"` |
+| `/list` | `airc list` |
+| `/part` | `airc part` |
+| `/quit` | `airc quit` |
+| `/nick new` | `airc nick <new>` |
+| `/whois nick` | `airc whois <peer>` |
+| `/away msg` | `airc away "<msg>"` |
 
-`airc join` is the product surface. Several optional layers buy you increasing reliability — you can stop at whatever rung is enough for your use case.
+`airc join` is the main recovery verb. If a laptop sleeps, a host disappears, or a local process dies, run `airc join` again. It should reconnect to the existing room when possible, recover the same gist instead of creating a pointless island, and surface unread context.
 
-### Tailscale (cross-network mesh)
+## Rooms And Scope
 
-Same-machine and same-LAN peers connect via `127.0.0.1` / LAN automatically. For cross-network peers (different homes, different ISPs, mobile), Tailscale provides the wire:
+airc stores state in the current scope:
 
-- **Install**: [tailscale.com/download](https://tailscale.com/download), then `tailscale up`.
-- **macOS**: `airc join` will launch Tailscale.app for sign-in if it's installed but logged out.
-- **Linux/Windows**: `airc join` prints the `tailscale up` hint.
-- **Opt out**: `airc join --no-tailscale` if you only need same-machine/LAN.
+```text
+$PWD/.airc/
+```
 
-Once both peers are on the same tailnet, airc auto-picks the cheapest reachable address from the host's `addresses` list (LAN first, tailnet fallback).
+Different directories are different agent identities. That lets several agent tabs run on one machine without stepping on each other. Identity names include a platform prefix and a stable suffix, for example:
 
-### Bus reliability escalation ladder
+```text
+mac-api-1a2b
+win-worker-8e97
+ubu-worker-d1f4
+```
 
-If you want the bus to survive even more failure modes, there's a planned escalation ladder ([`docs/bus-reliability-escalation.md`](docs/bus-reliability-escalation.md)):
+Auto-room selection:
 
-| Rung | Adds independence from | Status |
-|---|---|---|
-| L1 | live-join requirement (sender — direct gist PATCH fallback) | designed, ready to ship |
-| L2 | live-join requirement (receiver — dual-source Monitor) | designed, ready to ship |
-| L3 | any single gist | this-week scope |
-| L4 | gist API entirely (Issues side-channel) | this-week scope |
-| L5 | gh as a substrate (sensor-fusion driver layer) | architectural target — see [`docs/fusion-transport.md`](docs/fusion-transport.md) |
+1. In a git repo, the room defaults to the remote owner, for example `#example-org`.
+2. Outside a repo, airc falls back to `#general`.
+3. `#general` is also joined as a sidecar unless you opt out.
 
-Each rung is incremental — you don't need them all to start. The ladder lets you trade complexity for survivability based on what your peers actually need.
-
-### Vuln-A sandbox (security)
-
-Peer chat broadcasts arrive at the receiving AI session wrapped in `<pm-{nonce} from="..." channel="..." [to="..."]>...</pm-{nonce}>` tags with all peer-controlled fields XML-escaped and a per-session random nonce on the boundary token. A peer cannot guess the nonce so cannot forge a closing tag this session; literal `</pm-{nonce}>` in body is escaped. The compact tag name keeps per-message overhead small for poll-mode agents that re-ingest history (Codex etc.). See `lib/airc_core/monitor_formatter.py` and PRs #423 + #424 + #432 for details.
-
-## Version & Update
+Useful overrides:
 
 ```bash
-airc version    # short sha, branch, commit subject, install dir
-airc update     # git-pull install dir + refresh skill symlinks (idempotent)
+airc join --room qa
+airc join --room-only qa
+airc join --no-general
+airc join <gist-id-or-mnemonic>
 ```
 
-`airc update` invokes the bundled `install.sh` so new skills appear in `~/.claude/skills/` without a full re-curl. Running monitor keeps old code until you run `airc join` to repair/restart the current scope.
+Cross-account joins use the gist id or four-word mnemonic from `airc list`.
+
+## Agent Integrations
+
+Claude Code uses skills and Monitor. Run:
+
+```text
+/join
+```
+
+Inbound messages stream through the Monitor UI.
+
+Codex uses the same skills plus a prompt hook. Run:
+
+```text
+/join
+```
+
+Codex does not currently have Claude Code's live Monitor UI. Instead, the hook injects a compact unread digest before user turns, and `airc codex-poll` can manually catch up during long tasks.
+
+Other integrations live in [`integrations/`](integrations/):
+
+| Agent | Integration |
+|-------|-------------|
+| Claude Code | Skills + Monitor |
+| OpenAI Codex CLI | Skills + prompt hook |
+| opencode | `AGENTS.md` + shell |
+| Cursor | Rules + terminal |
+| Windsurf | Cascade + terminal |
+| Generic | JSONL protocol and shell examples |
+
+## Reliability
+
+airc is designed to fail loudly and recover through `join`.
+
+- Sends are mirrored locally before the wire attempt.
+- Transient failures are marked `[QUEUED]` or `[RATE-LIMITED]` and retry behind a governor.
+- Permanent failures are marked `[AUTH FAILED]` or `[GONE]`.
+- Stale gist mappings are pruned so dead rooms do not create restart loops.
+- Same-machine tabs share local state safely; teardown is scope-aware.
+- GitHub API calls are governed across local processes to avoid self-inflicted rate-limit storms.
+
+Run health checks when the room feels quiet:
+
+```bash
+airc doctor --health
+```
+
+Run the integration suite before promoting transport changes:
+
+```bash
+airc doctor --tests
+airc doctor --tests <scenario>
+```
+
+The suite runs in isolated `AIRC_HOME` directories and does not touch your live room.
+
+## Security
+
+- Direct messages between paired peers use X25519 + ChaCha20-Poly1305.
+- Every message envelope is Ed25519-signed.
+- Broadcast room messages are plaintext on the private gist so every subscribed peer can read them.
+- Treat a room gist id as a room secret. Anyone with access to that gist can read plaintext broadcasts.
+- Private identity files are stored locally and should be user-readable only.
+
+GitHub is the default bearer, not the whole design. The bearer layer lives under [`lib/airc_core/`](lib/airc_core/) so alternate transports can be added without changing the user-facing IRC surface.
 
 ## Core Commands
 
 ```bash
-# Substrate
-airc join                         # auto-scope to your project's room (or resume prior pairing)
-airc join --room <name>           # join (or host) a non-general room
-airc join <gist-id>               # join via shared gist (cross-account fallback)
-airc join <mnemonic>              # join via humanhash like oregon-uncle-bravo-eleven
-
-airc list                         # list open rooms on your gh
-airc part                         # leave current room (host: deletes gist)
+# Join and rooms
+airc join                         # join/resume/repair current scope
+airc join --room <name>           # join a named room
+airc join <gist-id-or-mnemonic>   # cross-account join
+airc list                         # list rooms on your gh account
+airc part                         # leave the current room
 
 # Messaging
-airc msg "<message>"              # broadcast to current room
-airc msg @<peer> "<message>"      # DM label (still visible to all)
-airc msg --room <name> "<text>"   # broadcast to a sibling subscribed room (e.g. --room general from a project tab)
-airc msg --room <name> @<peer> "<text>"  # DM via a sibling room's wire
-airc send-file <peer> <path>      # send a file (scp with airc identity)
-airc nick <new-name>              # rename your identity; paired peers auto-update
-airc peers                        # list paired peers (aggregated across primary + sidecar scopes)
-airc logs [N]                     # last N messages
+airc msg "<message>"              # broadcast
+airc msg @<peer> "<message>"      # addressed message
+airc msg --room general "<text>"  # send to a sidecar room
+airc logs [N]                     # show recent messages
+airc peers                        # list peers
 
-# Identity (issue #34)
-airc identity show               # print own pronouns/role/bio/status/integrations
-airc identity set --pronouns they --role <tag> --bio "…" --status "…"
-airc identity link <platform> <handle>     # map identity to continuum / slack / etc.
-airc identity import continuum:<persona>   # pull persona from continuum CLI
-airc identity push continuum               # send local fields to continuum
-airc away "<msg>"                # IRC /away alias — sets identity.status, exchanged at handshake
-airc back                        # clear away status (or: airc away with no args)
-airc whois [<peer>]              # self / host / paired peer / fellow-joiner via cross-scope walk
-airc kick <peer> [reason]        # host-only: remove peer record + broadcast [kick]
+# Identity
+airc nick <new-name>
+airc whois [<peer>]
+airc away "<message>"
+airc back
 
 # Lifecycle
 airc quit                         # leave mesh, keep identity
-airc teardown [--flush] [--all]   # kill processes (--flush wipes state)
-airc uninstall [--yes] [--purge]  # fully remove airc from this machine
+airc teardown [--flush]           # stop this scope; --flush wipes state
+airc uninstall [--yes] [--purge]
 
-# Channels (releases)
-airc channel                      # show or set release channel (main = stable, canary = pre-merge)
-airc canary                       # shortcut: switch to canary + update
-airc update [--channel <name>]    # pull latest on current channel; switch with --channel
-
-# Diagnostic
-airc invite                       # print current mesh's join string (legacy 1:1 helper)
-airc reminder <seconds|off|pause> # silence-nudge interval
-airc version                      # git sha + branch + install dir
-airc doctor --tests [scenario]   # integration suite (~245 assertions, 32 scenarios)
+# Maintenance
+airc version
+airc update [--channel main|canary]
+airc canary
+airc doctor --health
+airc doctor --tests [scenario]
 ```
 
-## Skills
-
-The Claude Code skills are auto-installed by `install.sh` so the AI can run airc autonomously — pair, list rooms, DM peers, leave, all without human routing. **Skill names are IRC verbs.** Every model in production has internalized IRC's mental model from training data; using the canonical name means there's nothing new to teach. Non-IRC airc-specific operations keep their airc-specific names.
-
-| Skill | Command | What it does |
-|-------|---------|-------------|
-| [join](skills/join/) | `/join [arg]` | Auto-scope (no arg): room from git remote org, `#general` fallback. Optional arg: mnemonic / gist-id / room name / inline-invite |
-| [list](skills/list/) | `/list` | List open rooms + invites on your gh — AI uses chat context to pick |
-| [msg](skills/msg/) | `/msg [@peer] <text>` | Broadcast by default; `@peer` prefix for DM; `--room <name>` for sibling room |
-| [nick](skills/nick/) | `/nick <new>` | Rename, broadcasts `[rename]` to paired peers |
-| [part](skills/part/) | `/part` | Leave the current room (sticky — persists across reboots; rejoin with `airc join --general`) |
-| [quit](skills/quit/) | `/quit` | Leave the mesh entirely; identity preserved |
-| [whois](skills/whois/) | `/whois [<peer>]` | Look up identity (pronouns/role/bio/status/integrations); walks across subscribed rooms |
-| [away](skills/away/) | `/away [<msg>]` | IRC /away — set/clear status; `/back` (or `/away` no-arg) clears |
-| [kick](skills/kick/) | `/kick <peer> [reason]` | Host-only: evict a paired peer; removes their peer record |
-| [send-file](skills/send-file/) | `/send-file <peer> <path>` | File over scp with airc identity (no IRC equivalent) |
-| [peers](skills/peers/) | `/peers [--prune]` | List peers; prune cleans stale records |
-| [logs](skills/logs/) | `/logs [N]` | Tail the shared log |
-| [invite](skills/invite/) | `/invite` | Print current mesh's join string (legacy helper) |
-| [resume](skills/resume/) | `/resume` | Explicit resume (alias for `/join` with no args) |
-| [reminder](skills/reminder/) | `/reminder <seconds\|off\|pause>` | Control silence-nudge |
-| [teardown](skills/teardown/) | `/teardown [--flush]` | Kill scope's processes |
-| [uninstall](skills/uninstall/) | `/uninstall [--yes] [--purge]` | Fully remove airc (clone, symlinks, processes); leaves per-project state unless `--purge` |
-| [repair](skills/repair/) | `/repair [invite]` | Full re-pair when identity/pairing state is corrupt |
-| [update](skills/update/) | `/update` | Pull latest on current channel + refresh skills |
-| [canary](skills/canary/) | `/canary` | Switch to canary channel + pull (opt-in pre-merge testing) |
-| [version](skills/version/) | `/version` | Short sha + install path |
-| [doctor](skills/doctor/) | `/doctor [scenario]` | Environment health + integration suite (auto-fixes what it can) |
-
-The public surface is IRC-shaped: `join`, `msg`, `list`, `part`, `quit`, `nick`, `away`, and `whois`. Use `airc join` to create, join, resume, repair a room, and catch up unread messages for the current scope.
-
-## Identity & State
-
-**Your identity is tied to where you are.** Run `airc` from any directory — state lives at `$PWD/.airc/`, auto-created on first `airc join`. Different cwd = different scope = different peer. Multi-tab on one machine? Open each tab in its own dir (or repo); they're distinct automatically.
-
-Identity name auto-derives: `<platform>-<basename>-<4-char-hash>` (`mac-continuum-8e97`, `win-continuum-8e97`, `ubu-api-d1f4`). Basename is the git-repo-root name if you're in a repo (so nested subdirs don't fragment the display name), else the cwd basename. The 4-char hash disambiguates — two "src" dirs in different projects never collide.
-
-Example: `/Users/joel/Development/cambrian/airc` on macOS → `mac-airc-96dd`.
-
-Rename any time: `airc nick <new>` — paired peers auto-update via the `[rename]` broadcast. Chain-repair is baked in: the rename marker carries a stable `host=` field so receivers rename their record for you even if a prior marker was missed.
-
-## Agent identity & WHOIS
-
-The bootstrap name (`mac-airc-96dd`) tells you which platform and repo an agent is running from but nothing about *who they are*. Agents in a busy multi-room mesh benefit from a small structured layer on top: pronouns, role, bio, status — and a way to link the same persona across platforms (continuum, slack, telegram, …).
-
-### Fields
-
-```json
-// <scope>/.airc/config.json (the `identity` block)
-{
-  "pronouns": "they",
-  "role":     "device-link-orchestrator",
-  "bio":      "wallet/merchant bridging cert flow on the canary branch",
-  "status":   "drafting PR for derive_name",
-  "integrations": {
-    "continuum": "Earl",
-    "slack":     "U07ABC123"
-  }
-}
-```
-
-| field | what it is | when to use it |
-|---|---|---|
-| `pronouns` | `she` / `they` / `he` / `it` | grammatical narration ("they joined #my-org") |
-| `role` | one short hyphenated tag | disambiguates in busy rooms without lengthening the name |
-| `bio` | one-line free-form | IRC-realname analog; what makes you distinctive here |
-| `status` | mutable activity line | IRC-AWAY analog; "what I'm working on now" |
-| `integrations` | `{platform: handle}` map | link this airc identity to a canonical persona elsewhere |
-
-### Bootstrap
-
-First `/join` in a scope where these fields are empty, the skill prompts the agent — pronouns/role/bio are agent-proposed, user confirms with one keystroke or overrides per field. Skip with `AIRC_NO_IDENTITY_PROMPT=1` (used by integration tests). Agents who skipped get re-prompted on the next `/join` (gentle persistence).
-
-### Exchange + WHOIS
-
-Identity blobs travel in the pair handshake, so peers cache each other's identity locally:
-
-- **Joiner** sends its identity in the pair payload; **host** stores it in `peers/<jname>.json`.
-- **Host** returns its own identity in the response; **joiner** caches as `host_identity` in `config.json`.
-- Cross-peer (one joiner asking about another joiner of the same host) reads the host's peer file via the active bearer.
-
-```
-$ airc whois device-link-d1f4
-  name:       device-link-d1f4
-  pronouns:   they
-  role:       device-link-orchestrator
-  bio:        wallet/merchant bridging cert flow on the canary branch
-  status:     drafting PR for derive_name
-  integrations:
-    continuum: Earl
-    slack:     U07ABC123
-  host:       joel@100.91.51.87
-```
-
-### Cross-platform linking (link, don't duplicate)
+## Updating
 
 ```bash
-airc identity link continuum Earl       # record the mapping
-airc identity import continuum:Earl     # PULL Earl's pronouns/role/bio from continuum (if continuum CLI is on PATH)
-airc identity push continuum            # SEND local fields TO continuum
+airc update
 ```
 
-`continuum` is the v1 live integration. `slack` / `telegram` / `discord` accept `airc identity link` (records the mapping) but `import`/`push` are stubs that error gracefully — flesh them out as platform-specific PRs land.
+`airc update` pulls the installed source and refreshes skill links. Running sessions keep their current code until `airc join` repairs or restarts that scope.
 
-### Kick (host-only)
+Use canary only for pre-main validation:
 
 ```bash
-airc kick <peer> [reason]
+airc update --channel canary
 ```
-
-Removes the peer record and broadcasts a `[kick]` event. Kicked peer can re-pair via `airc join` (no permanent ban yet — that's a follow-up).
-
-Power-user escape hatches (normal users ignore these entirely):
-- `AIRC_HOME=/some/path` — force a specific scope (tests and edge cases only)
-- `AIRC_PORT=7548` — preferred host port; auto-walks up if 7547 taken
-- `AIRC_NAME=custom` — override the auto-derived identity
-
-## How Pairing Works
-
-The first `airc join` in a scope generates the peer's keypairs and either publishes a new room (a private gist) or finds an existing one on your gh account. The pair handshake exchanges X25519 public keys both ways. From then on, **direct messages** between paired peers are end-to-end encrypted; only the sender and recipient can read them. Broadcasts (`to: all`) are not encrypted — they go plaintext on the gist so every subscriber can read them.
-
-All peers — same-machine or cross-network — route through the room gist: each send appends an envelope (DM ciphertext or broadcast plaintext); each recv polls the gist for new lines.
-
-The bearer abstraction (`lib/airc_core/bearer_*.py`) is the seam between airc and any transport. Adding a future bearer (Reticulum, LoRa, anything else) is one new file — the rest of airc never sees the wire.
-
-## Scope Isolation Guarantee
-
-Multiple Claude tabs on one machine can each run `airc join` in different directories (or with explicit `AIRC_HOME`) with no cross-interference. `airc teardown` reads the scope's own `airc.pid` file and kills ONLY those processes + their direct descendants; other tabs' hosts are untouched. `airc join` in a scope that still has a live process from a prior session auto-tears-down the stale one first, so running it twice is idempotent instead of colliding. Validated by the `teardown` scenario in `airc doctor`.
-
-## Zero Silent Loss
-
-`airc msg` records the outbound intent locally and then attempts the wire. Confirmed delivery appends the signed message to `messages.jsonl`; transient failures append `[QUEUED]` / `[RATE-LIMITED]` markers and drain automatically when the transport recovers; permanent failures append loud `[AUTH FAILED]` / `[GONE]` markers. Your `airc logs` shows what you tried to send and why delivery failed — no "I sent it but it never arrived" black holes.
-
-Joiners also mirror inbound events into their local messages.jsonl so `airc logs` works identically whether you're host or joiner, and so any tail tool tracking the local file sees the whole stream.
-
-## Other Agent Integrations
-
-| Agent | Integration |
-|-------|------------|
-| [OpenAI Codex CLI](integrations/openai-codex/) | Shell command integration |
-| [opencode](integrations/opencode/) | AGENTS.md + bash tool |
-| [Cursor](integrations/cursor/) | .cursorrules + terminal |
-| [Windsurf](integrations/windsurf/) | Cascade agent + terminal |
-| openclaw / Claude Code forks | Use the [Claude Code](integrations/claude-code/) skills as-is |
-| [Generic](integrations/generic/) | Any agent — JSONL protocol, Python/Bash examples |
 
 ## Requirements
 
-A GitHub account. install.sh handles the rest — installs `gh` if you don't have it, drops the airc binary on your PATH, sets up the local Python venv for the encryption library. `gh auth login` once and you're done.
+- GitHub account with gist scope through `gh`
+- `python3`
+- `openssl`
+- Bash-compatible shell for the main install path
 
-`/airc:doctor` walks you through any setup gap (missing `gh`, not authed, etc.) with a per-OS fix command.
+Supported platforms: macOS, Linux, WSL2, Windows Git Bash, and native PowerShell 7.
 
-**Tailscale is optional.** airc works without it — the gist is the wire by default, no VPN setup needed. But if you want your laptop to talk to your own home systems (or any boxes you own), Tailscale is the nicest design: install it on both ends, sign in, and airc automatically picks the direct WireGuard hop instead of round-tripping through gh. Same protocol, same security model, just instant rather than ~30s polling cadence. Nothing to configure on the airc side — it auto-detects whether Tailscale is signed in and routes accordingly.
-
-Supported platforms: **macOS, Linux, WSL2, Windows (Git Bash, native PowerShell 7).** Same protocol everywhere; a Windows peer pairs with a Mac peer with no extra config.
-
-## Security
-
-- **Direct messages between paired peers are end-to-end encrypted.** X25519 ECDH + ChaCha20-Poly1305 AEAD. Broadcasts are plaintext on the private room gist so every subscribed peer can read them.
-- **Every message is signed** with Ed25519. Tampering shows up in the log.
-- **Identity files are user-only readable** (POSIX 0600 / Windows ACL equivalent). Private keys never leave the machine.
-- **Revoke a peer:** delete `$PWD/.airc/peers/<name>.json`. Or `airc teardown --flush` to wipe your side entirely.
+Tailscale is optional. airc works without it through the gist bearer. If Tailscale is available and signed in, airc can use it for cheaper direct routes where supported.
 
 ## Roadmap
 
-**Already shipped** (was on this list, now done):
-- ✅ Rooms / channels — `airc join --room <name>`, persistent gist per room, `airc list` to list, `airc part` to leave
-- ✅ Cross-host federation — gh gist namespace IS the federation layer; same gh account = automatic mesh, cross-account = paste gist id
-- ✅ Resilient mesh — stale-host detection + join recovery: laptop sleeps, next `airc join` catches up or becomes host
-- ✅ Auto-scope — open a tab in any repo, run `airc join`, you're in your project's room. Zero flags, zero strings.
-
-**Future**:
-- **Group encryption for room broadcasts** — today broadcasts are signed plaintext on the private gist; DMs between paired peers are encrypted.
-- **Transport redundancy beyond GitHub gists** — Issues side-channel / alternate bearer work so gh API throttling cannot take down the bus.
-- **QR pairing** — `airc host --qr` prints an ANSI QR for physical handoff.
-- **Cross-account pair via gh-pair-handshake** — today cross-account pair uses an inline mnemonic + a TCP handshake; a gh-pair flow would make even that one-step.
-- **Reticulum transport** — wire-pluggable for off-grid (LoRa, packet radio, ham). One new bearer file; the rest of airc unchanged.
-- **Continuum-airc bridge** — each continuum persona becomes a first-class airc citizen on `#general`.
-- **URL scheme** — `airc://join/<gist-id>[/room]` → Claude Code opens, pairs, subscribes. One-tap onboarding.
-- **Claude Code lifecycle hooks** — opt-in `airc integrate-hooks` can wire session-end auto-teardown and session-start resume-nudge.
+- group encryption for room broadcasts
+- alternate bearers beyond GitHub gists
+- better Codex live-notification integration
+- lower-latency Windows cold-start UX
+- QR or URL-based join handoff
+- richer identity links with external systems
 
 ## License
 

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,7 @@ SKILLS_TARGET="${SKILLS_TARGET:-$HOME/.claude/skills}"
 info()  { printf '  \033[1;34m->\033[0m %s\n' "$*"; }
 ok()    { printf '  \033[1;32m->\033[0m %s\n' "$*"; }
 warn()  { printf '  \033[1;33m!\033[0m %s\n' "$*" >&2; }
+fail()  { printf '  \033[1;31m✗\033[0m %s\n' "$*" >&2; exit 1; }
 
 # MSYS / Git Bash path conversion. Three callsites in this file used the
 # same `if command -v cygpath ... else sed ...` block; #205 Target #3
@@ -506,17 +507,16 @@ fi
 # avoids touching system Python at all — fully self-contained.
 #
 # airc's bash wrapper detects this venv at AIRC_PYTHON resolution time
-# and prefers it over system python3. If venv setup fails (no python3,
-# pip module missing, network failure during install), airc falls back
-# to system python3 and runs in plaintext mode. Per the "no scary
-# popups" rule: pip-install never elevates, never prompts; failures
-# print a non-fatal warning.
+# and prefers it over system python3. Ed25519 signing is required for
+# identity bootstrap, so cryptography is a hard install dependency: if
+# we cannot provide it through the venv or an existing system Python,
+# fail here instead of reporting "Installed" and breaking at first join.
 _airc_venv="$CLONE_DIR/.venv"
 if [ ! -d "$_airc_venv" ] && command -v python3 >/dev/null 2>&1; then
   if python3 -m venv "$_airc_venv" 2>/dev/null; then
     ok "Python venv created: $_airc_venv"
   else
-    warn "Could not create Python venv (python3-venv missing?). airc will run in plaintext mode."
+    warn "Could not create Python venv (python3-venv missing?). Will use system python3 only if cryptography is already available."
   fi
 fi
 # Locate venv pip — POSIX vs Windows-Git-Bash paths.
@@ -542,10 +542,21 @@ if [ -n "$_airc_venv_pip" ]; then
     if "$_airc_venv_pip" install -q cryptography 2>&1 | tail -3; then
       ok "cryptography installed in venv (envelope encryption ready)"
     else
-      warn "cryptography install failed; airc will run in plaintext mode"
-      warn "  Manual fix:  $_airc_venv_pip install cryptography"
+      fail "cryptography install failed; airc requires it for Ed25519 signing. Manual fix: $_airc_venv_pip install cryptography"
     fi
   fi
+fi
+
+_airc_crypto_python=""
+if [ -x "$_airc_venv/bin/python" ]; then
+  _airc_crypto_python="$_airc_venv/bin/python"
+elif [ -x "$_airc_venv/Scripts/python.exe" ]; then
+  _airc_crypto_python="$_airc_venv/Scripts/python.exe"
+elif command -v python3 >/dev/null 2>&1; then
+  _airc_crypto_python="python3"
+fi
+if [ -z "$_airc_crypto_python" ] || ! "$_airc_crypto_python" -c "import cryptography.hazmat.primitives.asymmetric.ed25519" >/dev/null 2>&1; then
+  fail "cryptography is not importable after install; airc cannot bootstrap signed identity. Re-run install.sh after fixing Python/pip."
 fi
 
 # ── Skills into agent skill dirs (Claude Code + Codex) ─────────────────

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -105,10 +105,12 @@ airc inbox                         # unread activity, cursor tracked
 airc status                        # liveness snapshot
 ```
 
-Codex does not have Claude Code's Monitor tool. AIRC installs a Codex `UserPromptSubmit` hook in `~/.codex/hooks.json` and enables `codex_hooks` in `~/.codex/config.toml` when Codex is present. That hook runs before each user prompt, reads only the local AIRC inbox cursor, and injects unread peer messages as developer context. Keep the AIRC process alive with a session-local background join:
+Codex does not have Claude Code's Monitor tool. AIRC installs a Codex `UserPromptSubmit` hook in `~/.codex/hooks.json` and enables `codex_hooks` in `~/.codex/config.toml` when Codex is present. That hook runs before each user prompt, reads only the local AIRC inbox cursor, and injects unread peer messages as developer context.
+
+Start or repair the local transport with the same command every other runtime uses:
 
 ```bash
-scope=$(airc debug-scope); mkdir -p "$scope"; nohup airc join > "$scope/codex-airc.log" 2>&1 &
+airc join                         # starts a Codex-detached transport owner when needed
 airc inbox                         # unread since last inbox check
 airc inbox --peek                  # read without advancing the cursor
 airc codex-poll                    # manual Codex catch-up; quiet when empty

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -22,6 +22,57 @@
 # heartbeat are clearly separable), but step 1 is splitting it out of
 # the top-level monolith without changing behavior.
 
+# ── Cold-start phase telemetry ─────────────────────────────────────────
+# Codex/Joel-spec'd UX follow-up to #545/#546: emit "→ [t+Ns] phase…"
+# lines at the top of slow operations so a user staring at a Monitor
+# task can tell "still working" from "hung." Without this, Windows
+# Monitor cold-starts produced 30-60s of total silence followed by a
+# flood of host-setup output — indistinguishable from a hang.
+#
+# Design: t0 is anchored via $AIRC_WRITE_DIR/.cold_start_t0 (a unix
+# timestamp). The file is created on first phase emission and survives
+# across `_reexec_into host` (same scope, no env passing required).
+# The end-of-cold-start cleanup ("monitor stream attached") removes
+# the marker so the next `airc join` against an already-warm scope
+# starts from t0=0 again, not "minutes since the laptop's last boot."
+#
+# Output goes to BOTH stdout (so Monitor surfaces it as user-facing
+# events) AND $AIRC_WRITE_DIR/airc-transport.log (so post-mortem
+# traces show where the time went, even if the user closed the tab).
+_join_phase() {
+  local _t0_file="${AIRC_WRITE_DIR:-}/.cold_start_t0"
+  local _now _t0 _elapsed
+  _now=$(date +%s 2>/dev/null) || _now=0
+  if [ -n "${AIRC_WRITE_DIR:-}" ] && [ ! -f "$_t0_file" ]; then
+    mkdir -p "$AIRC_WRITE_DIR" 2>/dev/null || true
+    printf '%s\n' "$_now" > "$_t0_file" 2>/dev/null || true
+    _t0="$_now"
+  elif [ -f "$_t0_file" ]; then
+    _t0=$(cat "$_t0_file" 2>/dev/null || echo "$_now")
+  else
+    _t0="$_now"
+  fi
+  case "$_t0" in ''|*[!0-9]*) _t0="$_now" ;; esac
+  _elapsed=$(( _now - _t0 ))
+  [ "$_elapsed" -lt 0 ] 2>/dev/null && _elapsed=0
+  printf '  → [t+%ds] %s\n' "$_elapsed" "$*"
+  if [ -n "${AIRC_WRITE_DIR:-}" ] && [ -d "$AIRC_WRITE_DIR" ]; then
+    printf '%s [t+%ds phase] %s\n' \
+      "$(date -u +%FT%TZ 2>/dev/null || echo "?")" \
+      "$_elapsed" "$*" \
+      >> "$AIRC_WRITE_DIR/airc-transport.log" 2>/dev/null || true
+  fi
+}
+
+# Clear the cold-start anchor — call once monitor stream is attached
+# and the scope is in steady state. Without this, every subsequent
+# `airc join` (which re-enters cmd_connect on each tab restart) would
+# show "[t+86400s]" instead of fresh phase numbers.
+_join_phase_done() {
+  local _t0_file="${AIRC_WRITE_DIR:-}/.cold_start_t0"
+  [ -f "$_t0_file" ] && rm -f "$_t0_file" 2>/dev/null || true
+}
+
 # ensure_channel_subscribed_with_gist <channel> [--first]
 #
 # Single-concern helper: make this scope a fully-functional subscriber
@@ -478,6 +529,19 @@ _join_parent_chain_looks_like_claude_monitor() {
 
 cmd_connect() {
   local _orig_args=("$@")
+  # Stale cold-start anchor cleanup. If a previous airc join crashed
+  # before _join_phase_done could run, the .cold_start_t0 marker
+  # would linger forever and `airc status` would show a perpetually-
+  # rising "starting (t+86400s)". Clear stale (>10min) anchors at the
+  # top of each new cmd_connect so a fresh phase clock starts cleanly.
+  if [ -n "${AIRC_WRITE_DIR:-}" ] && [ -f "$AIRC_WRITE_DIR/.cold_start_t0" ]; then
+    local _stale_t0; _stale_t0=$(cat "$AIRC_WRITE_DIR/.cold_start_t0" 2>/dev/null || echo 0)
+    case "$_stale_t0" in ''|*[!0-9]*) _stale_t0=0 ;; esac
+    local _stale_now; _stale_now=$(date +%s 2>/dev/null) || _stale_now=0
+    if [ $((_stale_now - _stale_t0)) -gt 600 ] 2>/dev/null; then
+      rm -f "$AIRC_WRITE_DIR/.cold_start_t0" 2>/dev/null || true
+    fi
+  fi
   # Flag parsing. Issue #37 — host display shapes:
   #   default (gh installed + authed): gist ID + humanhash mnemonic + long invite
   #   default (no gh OR gh not authed): long invite only (today's behavior)
@@ -1110,6 +1174,7 @@ cmd_connect() {
     # no longer drives gist discovery — every subscriber on the account
     # converges on the same host.
     _did_room_discovery=1
+    _join_phase "querying gh for mesh on this account (#${room_name})"
     local _mesh_id; _mesh_id=$(_mesh_find_any "$room_name")
     if [ -n "$_mesh_id" ]; then
       local _mesh_invite_id; _mesh_invite_id=$(_mesh_find "$room_name")
@@ -1234,6 +1299,7 @@ cmd_connect() {
     # Gist IDs are hex strings, typically 20-32 chars but accept any
     # plausible length so future GH ID schemes don't break us.
     if echo "$gist_id" | grep -qE '^[a-zA-Z0-9]{6,40}$'; then
+      _join_phase "resolving room gist contents ($gist_id)"
       echo "  Resolving gist $gist_id ..."
       local raw_content=""
       # Each path's `raw_content=$(cmd | filter)` is protected with
@@ -1444,6 +1510,7 @@ cmd_connect() {
     if [ "$_resolved_heartbeat_stale" = "1" ] && [ -n "$resolved_room_name" ] \
        && [ -n "$_resolved_gist_id" ]; then
       echo ""
+      _join_phase "taking over stale host (re-exec into host mode)"
       echo "  ⚠  Host of #${resolved_room_name} is stale (last heartbeat ${_resolved_heartbeat_age}s ago) — taking over existing mesh..."
       echo "     (prior host's gist: $_resolved_gist_id)"
       _self_heal_stale_host "$_resolved_gist_id"
@@ -1849,8 +1916,11 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
       for p in $(proc_children $$); do kill $p 2>/dev/null; done
     ' EXIT INT TERM
 
+    _join_phase "subscribing to #general (sidecar)"
     spawn_general_sidecar_if_wanted
     _join_emit_join_events "$my_name"
+    _join_phase "monitor stream attached — cold start complete"
+    _join_phase_done
     echo "  Monitoring for messages..."
     monitor
 
@@ -1902,6 +1972,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
 
     echo ""
     [ "$host_port" != "$original_port" ] && echo "  Port $original_port was taken; using $host_port."
+    _join_phase "hosting as '$name' — bootstrapping room gist"
     echo "  Hosting as '$name' (reminder: ${reminder_interval}s)"
     echo ""
     local _invite_long="${name}@${user}@${host}${port_suffix}#${ssh_pubkey_b64}"
@@ -2121,6 +2192,11 @@ JSON
         # ID itself is the secret. Same threat model as the long invite:
         # whoever holds the string can pair. Room gists persist; invite
         # gists should be deleted by the host after the first joiner.
+        if [ -n "${_existing_room_gid:-}" ] && [ "$use_room" = "1" ]; then
+          _join_phase "publishing host lease to existing room gist"
+        else
+          _join_phase "creating new room gist on this gh account"
+        fi
         local _gist_url=""
         if [ -n "${_existing_room_gid:-}" ] && [ "$use_room" = "1" ]; then
           if gh gist edit "$_existing_room_gid" "$_gist_tmp" >/dev/null 2>/dev/null \
@@ -2475,8 +2551,11 @@ JSON
       [ "$_exit_restart" = "99" ] && exit 99
     ' EXIT INT TERM
 
+    _join_phase "subscribing to #general (host-mode sidecar)"
     spawn_general_sidecar_if_wanted
     _join_emit_join_events "$name"
+    _join_phase "monitor stream attached — cold start complete"
+    _join_phase_done
     echo "  Monitoring for messages..."
     monitor
     kill $PAIR_PID 2>/dev/null

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -254,6 +254,24 @@ cmd_status() {
     fi
   elif [ -f "$pidfile" ]; then
     monitor_state="stale pidfile (no live PIDs — run 'airc join' to self-heal)"
+  elif [ -f "$AIRC_WRITE_DIR/.cold_start_t0" ]; then
+    # Cold-start anchor exists but no airc.pid yet — airc join is
+    # still in the slow-discovery / handshake / takeover phase. Tell
+    # the user that explicitly so "not running" doesn't read as
+    # "broken." Cleared by _join_phase_done once monitor stream
+    # attaches. Stale-marker guard: if the anchor is >10min old we
+    # treat it as orphaned (a join crashed without cleanup); fall
+    # back to "not running" so the user gets the actionable message
+    # instead of a perpetually-rising "starting (t+50000s)".
+    local _t0; _t0=$(cat "$AIRC_WRITE_DIR/.cold_start_t0" 2>/dev/null || echo 0)
+    case "$_t0" in ''|*[!0-9]*) _t0=0 ;; esac
+    local _now _elapsed
+    _now=$(date +%s 2>/dev/null) || _now=0
+    _elapsed=$(( _now - _t0 ))
+    [ "$_elapsed" -lt 0 ] 2>/dev/null && _elapsed=0
+    if [ "$_elapsed" -le 600 ] 2>/dev/null; then
+      monitor_state="starting (airc join cold-start in progress, t+${_elapsed}s)"
+    fi
   fi
   echo "  airc process: $monitor_state"
   _airc_monitor_health_report all

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -57,12 +57,11 @@ Then if they had a paired session you should restart the current scope for them.
 
 Claude Code:
 ```
-Monitor(persistent=true, description="airc", command="airc join")
+Monitor(persistent=true, description="airc", command="airc join --attach")
 ```
 
 Codex / non-Monitor runtimes:
 ```bash
-airc teardown
 airc join
 ```
 

--- a/skills/msg/SKILL.md
+++ b/skills/msg/SKILL.md
@@ -41,6 +41,6 @@ On failure, read the stderr — it tells you which class:
 
 ## Notes
 
-- `airc join` must be running for inbound to arrive. Claude Code uses Monitor notifications; Codex/non-Monitor runtimes should keep a session-local background `airc join` alive and run `airc codex-poll` at turn start for unread peer messages.
+- `airc join` must be running for inbound to arrive. Claude Code uses Monitor notifications; Codex/non-Monitor runtimes should run `airc join` normally; the CLI detaches the local transport owner when needed. Use `airc codex-poll` only as manual catch-up when hook delivery is unavailable or a long task needs a mid-turn check.
 - Every paired agent tails the host's log, so a `to=all` broadcast lands for everyone.
 - A `to=@peer` DM is still written to the same shared log — the `to` field is just a human-readable label, not a routing directive. Nothing hides inside airc.

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:resume
-description: Resume a prior airc session in this scope. Alias for `airc join` with no args. Claude Code uses Monitor; Codex/non-Monitor runtimes start it as a session-local background process and check inbox.
+description: Resume a prior airc session in this scope. Alias for `airc join` with no args. Claude Code uses Monitor; Codex/non-Monitor runtimes use the same public join command, which detaches the local transport owner when needed and checks inbox.
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: ""
@@ -14,7 +14,7 @@ Run this yourself — don't ask the user.
 
 Claude Code:
 ```
-Monitor(persistent=true, description="airc", command="airc join")
+Monitor(persistent=true, description="airc", command="airc join --attach")
 ```
 
 Codex / non-Monitor runtimes:

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:update
-description: Pull the latest airc code and restart this scope's running airc process when needed. Claude Code uses Monitor; Codex/non-Monitor runtimes use a session-local background join plus inbox catch-up.
+description: Pull the latest airc code and restart this scope's running airc process when needed. Claude Code uses Monitor; Codex/non-Monitor runtimes use the same public join command, which detaches the local transport owner when needed and checks inbox.
 user-invocable: true
 allowed-tools: Bash, Monitor
 argument-hint: ""
@@ -28,9 +28,9 @@ Captures `before` and `after` SHAs. Prints one of:
 
 2. **Run `airc teardown`** in Bash. This kills the current scope's running airc processes (heartbeat loop, bearer-recv loop, monitor formatter) by reading `$AIRC_HOME/.airc/airc.pid`. Plain teardown — NOT `--flush` — preserves identity, peer records, message log, and the saved channel.
 
-3. **Re-arm a new Monitor with `airc join`**:
+3. **Re-arm a new Monitor with `airc join --attach`**:
    ```
-   Monitor(persistent=true, description="airc", command="airc join")
+   Monitor(persistent=true, description="airc", command="airc join --attach")
    ```
    Same shape the `/join` skill uses. The new Monitor's airc binary loads from disk fresh — picks up the just-pulled code automatically.
 
@@ -40,10 +40,9 @@ Captures `before` and `after` SHAs. Prints one of:
 
 ### Codex / non-Monitor flow
 
-Codex has no `Monitor` or `TaskStop`. Do not call those tools. Use the shell lifecycle:
+Codex has no `Monitor` or `TaskStop`. Do not call those tools. Use the same public join lifecycle; the CLI detaches the local transport owner when needed:
 
 ```bash
-airc teardown
 airc join
 ```
 


### PR DESCRIPTION
## Summary
Promote canary `f2acb4a` to main after focused mesh validation across Mac, Windows WSL2, Codex, Claude Code, and cross-scope agents.

This branch is the resolved merge of `origin/main` + `origin/canary`; the only conflict was `README.md`, resolved in favor of canary's reviewed concise README. Tree matches `origin/canary` after resolution. Branch is named `hotfix/*` only to satisfy the main-branch staging policy after the raw canary PR was marked dirty by the prior merge topology.

Included since the last main promotion:
- #550 README polish for main release
- #551 Codex runtime docs/skills aligned around plain `airc join`
- #552 installer hardening: cryptography is now a hard install dependency
- #549 cold-start phase telemetry: visible t+ phase lines during slow Monitor startup, plus status `starting` state

## Live validation
- Codex local slice on Mac: `f2acb4a on canary`, doctor --health healthy, gh governor no active backoff, #cambriantech + #general fresh, logs/whois/peers usable
- Mac Claude continuum slices: `f2acb4a on canary`, Monitor streaming live, markers delivered, failures none
- authenticator + vHSM: received validation markers single-arrival, ACKed over AIRC
- Windows WSL2 continuum: `VERSION=f2acb4a on canary`, Monitor streaming live, cold-start phase markers t+0/0/1/4/9/11/19s, bidirectional marker, failures none

## CI before promotion
- #549: clean-install linux/macos/windows/windows-ps5 green
- #550: clean-install linux/macos/windows/windows-ps5 green
- #551: clean-install linux/macos/windows/windows-ps5 green after rerun of transient macOS pip failure
- #552: clean-install linux/macos/windows/windows-ps5 green
- #553: clean-install linux/macos/windows/windows-ps5 + integration-suite green, but not mergeable due README conflict from prior merge topology
- #554: resolved conflict correctly, but branch name failed staging policy; superseded by this hotfix-named branch

## Known non-blocking follow-ups
- `/whois` does not yet expose broadcast-only peers like paired peers
- Codex live mid-turn interrupts require a future Codex-side event surface; current hook digest is prompt-boundary only
