### PR TITLE
fix(codex): poll inbox after sending airc messages

### DIFF
--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -244,6 +244,22 @@ cmd_send() {
     fi
   }
 
+  _airc_codex_poll_after_user_send() {
+    [ -n "${CODEX_THREAD_ID:-}${CODEX_CI:-}${CODEX_MANAGED_BY_NPM:-}" ] || return 0
+    [ "${AIRC_CODEX_POLL_AFTER_SEND:-1}" != "0" ] || return 0
+
+    local _poll_count="${AIRC_CODEX_SEND_POLL_COUNT:-50}"
+    case "$_poll_count" in
+      ''|*[!0-9]*|0) _poll_count=50 ;;
+    esac
+    local _poll_since="${AIRC_CODEX_SEND_POLL_SINCE:-10m}"
+
+    local _poll_out
+    _poll_out=$(AIRC_INBOX_QUIET_EMPTY=1 AIRC_INBOX_EXCLUDE_SELF=1 cmd_inbox --since "$_poll_since" --count "$_poll_count" 2>&1) || return 0
+    [ -n "$_poll_out" ] && printf '%s\n' "$_poll_out"
+    return 0
+  }
+
   local my_name ts_val
   my_name=$(get_name)
   ts_val=$(timestamp)
@@ -726,6 +742,7 @@ cmd_send() {
       "$AIRC_PYTHON" -m airc_core.collaboration send-warning \
         --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" 2>/dev/null || true
     fi
+    _airc_codex_poll_after_user_send
   fi
 }
 

--- a/lib/airc_core/inbox.py
+++ b/lib/airc_core/inbox.py
@@ -119,9 +119,13 @@ def cmd_read(args: argparse.Namespace) -> int:
                 except Exception:
                     last_offset = next_offset
                     continue
-                if args.exclude_self and args.client_id and line.get("client_id") == args.client_id:
-                    last_offset = next_offset
-                    continue
+                if args.exclude_self:
+                    if args.client_id and line.get("client_id") == args.client_id:
+                        last_offset = next_offset
+                        continue
+                    if not args.client_id and args.my_name and line.get("from") == args.my_name:
+                        last_offset = next_offset
+                        continue
                 if since_dt is not None:
                     dt = _msg_dt(line)
                     if dt is None or dt <= since_dt:

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -4041,6 +4041,45 @@ scenario_inbox() {
     && printf '%s' "$out" | grep -q 'hook-visible' \
     && pass "codex-hook emits UserPromptSubmit context for unread local messages" \
     || fail "codex-hook did not emit expected UserPromptSubmit JSON: $out"
+
+  local send_root=/tmp/airc-it-inbox-send
+  local send_home="$send_root/state"
+  rm -rf "$send_root"
+  mkdir -p "$send_home" "$send_root/bin"
+  echo '{"name":"send-poll-test","subscribed_channels":["general"]}' > "$send_home/config.json"
+  scaffold_identity "$send_home/identity" "send-poll-test" || fail "codex send-poll identity scaffold failed"
+  {
+    printf '%s\n' '{"ts":"2026-05-04T10:04:00Z","from":"peer-test","client_id":"peer-client","msg":"old-backlog-hidden"}'
+    printf '%s\n' '{"ts":"2099-05-04T10:04:00Z","from":"peer-test","client_id":"peer-client","msg":"send-trigger-visible"}'
+  } > "$send_home/messages.jsonl"
+  printf '#!/bin/sh\nsleep 60\n' > "$send_root/bin/airc"
+  chmod +x "$send_root/bin/airc"
+  "$send_root/bin/airc" connect >/dev/null 2>&1 &
+  local dummy_pid=$!
+  echo "$dummy_pid" > "$send_home/airc.pid"
+  out=$(AIRC_CLIENT_ID=test-client CODEX_THREAD_ID=test-thread AIRC_HOME="$send_home" "$AIRC" msg "self send should be filtered" 2>&1)
+  cursor=$(cat "$send_home/inbox_cursor" 2>/dev/null || true)
+  kill "$dummy_pid" 2>/dev/null || true
+  wait "$dummy_pid" 2>/dev/null || true
+  printf '%s' "$out" | grep -q 'send-trigger-visible' \
+    && ! printf '%s' "$out" | grep -q 'self send should be filtered' \
+    && ! printf '%s' "$out" | grep -q 'old-backlog-hidden' \
+    && printf '%s' "$cursor" | grep -q '"offset":[1-9]' \
+    && pass "codex airc msg triggers recent quiet self-filtered inbox poll" \
+    || fail "codex airc msg did not poll unread messages; cursor='$cursor' output: $out"
+
+  "$send_root/bin/airc" connect >/dev/null 2>&1 &
+  dummy_pid=$!
+  echo "$dummy_pid" > "$send_home/airc.pid"
+  if out=$(AIRC_CLIENT_ID=test-client CODEX_THREAD_ID=test-thread AIRC_HOME="$send_home" "$AIRC" msg "second self send should stay quiet" 2>&1); then
+    ! printf '%s' "$out" | grep -q 'second self send should stay quiet' \
+      && pass "codex airc msg exits zero when post-send poll is empty" \
+      || fail "empty post-send poll echoed self message: $out"
+  else
+    fail "codex airc msg returned nonzero when post-send poll was empty: $out"
+  fi
+  kill "$dummy_pid" 2>/dev/null || true
+  wait "$dummy_pid" 2>/dev/null || true
 }
 
 scenario_host_msg_publishes_to_gist() {

--- a/test/test_codex_hook.py
+++ b/test/test_codex_hook.py
@@ -115,6 +115,35 @@ class CodexHookTests(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertEqual(out.getvalue(), "")
 
+    def test_user_prompt_hook_filters_own_rows_when_client_id_missing(self):
+        tmp, home, cursor = self._scope()
+        with tmp:
+            (home / "messages.jsonl").write_text(
+                self._line("me", "2099-05-04T20:00:00Z", "own fallback")
+                + self._line("peer", "2099-05-04T20:00:01Z", "peer visible", "peer-client"),
+                encoding="utf-8",
+            )
+            out = io.StringIO()
+            with patch("sys.stdin", io.StringIO("{}")):
+                with redirect_stdout(out):
+                    rc = codex_hook.main(
+                        [
+                            "user-prompt-submit",
+                            "--home",
+                            str(home),
+                            "--cursor-file",
+                            str(cursor),
+                            "--my-name",
+                            "me",
+                            "--client-id",
+                            "",
+                        ]
+                    )
+            self.assertEqual(rc, 0)
+            context = json.loads(out.getvalue())["hookSpecificOutput"]["additionalContext"]
+            self.assertIn("peer: peer visible", context)
+            self.assertNotIn("me: own fallback", context)
+
     def test_codex_hook_installer_preserves_existing_hooks(self):
         tmp = tempfile.TemporaryDirectory()
         with tmp:

--- a/test/test_inbox.py
+++ b/test/test_inbox.py
@@ -75,6 +75,44 @@ class InboxTests(unittest.TestCase):
             self.assertNotIn("old", text)
             self.assertIn("new", text)
 
+    def test_exclude_self_uses_sender_fallback_only_without_client_id(self):
+        tmp, home, cursor = self._scope()
+        with tmp:
+            log = home / "messages.jsonl"
+            log.write_text(
+                self._line("me", "2099-05-04T20:00:00Z", "legacy self")
+                + self._line("me", "2099-05-04T20:00:01Z", "same-name peer")
+                + self._line("peer", "2099-05-04T20:00:02Z", "visible"),
+                encoding="utf-8",
+            )
+            out = io.StringIO()
+            with redirect_stdout(out):
+                inbox.main(["read", "--home", str(home), "--cursor-file", str(cursor), "--exclude-self", "--my-name", "me"])
+            text = out.getvalue()
+            self.assertNotIn("legacy self", text)
+            self.assertNotIn("same-name peer", text)
+            self.assertIn("visible", text)
+
+            cursor.unlink()
+            out = io.StringIO()
+            with redirect_stdout(out):
+                inbox.main([
+                    "read",
+                    "--home",
+                    str(home),
+                    "--cursor-file",
+                    str(cursor),
+                    "--exclude-self",
+                    "--my-name",
+                    "me",
+                    "--client-id",
+                    "self-client",
+                ])
+            text = out.getvalue()
+            self.assertIn("legacy self", text)
+            self.assertIn("same-name peer", text)
+            self.assertIn("visible", text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- after user-facing airc msg/send in Codex runtimes, run a quiet self-filtered inbox poll so outbound traffic also wakes inbound context
- bound the post-send poll to a recent window to avoid stale backlog floods from delayed local-bus mirroring
- make inbox self-filter fall back to sender name only when the poller has no client id, covering hook environments that lack CODEX_THREAD_ID

## Validation
- ./test/integration.sh inbox
- python3 test/test_inbox.py
- python3 test/test_codex_hook.py
- bash -n airc lib/airc_bash/cmd_send.sh lib/airc_bash/cmd_status.sh test/integration.sh
- git diff --check
- live guinea-pig: patched airc msg initially exposed stale backlog + empty-poll exit bug; both fixed, final live send printed only the normal broadcast arrow and exited 0