### PR TITLE
feat(approve): forward-secret room-invite handoff (airc#559 PR-2)

### DIFF
--- a/airc
+++ b/airc
@@ -2495,6 +2495,18 @@ else
   exit 1
 fi
 
+# cmd_approve + cmd_decrypt_approval — knock follow-up verbs (airc#559 PR-2).
+# Approver-side: encrypt private-room invite to knocker's per-knock pubkey
+# via per-approval ephemeral ECDH + ChaCha20-Poly1305, post as comment.
+# Knocker-side: decrypt the comment with the saved ephemeral priv key.
+if [ -n "${_airc_lib_dir:-}" ] && [ -f "$_airc_lib_dir/airc_bash/cmd_approve.sh" ]; then
+  # shellcheck source=lib/airc_bash/cmd_approve.sh
+  source "$_airc_lib_dir/airc_bash/cmd_approve.sh"
+else
+  echo "ERROR: airc_bash/cmd_approve.sh not found via lib-dir resolver." >&2
+  exit 1
+fi
+
 
 # ── Dispatch ────────────────────────────────────────────────────────────
 
@@ -2550,6 +2562,8 @@ case "${1:-help}" in
   peers)     shift; cmd_peers "$@" ;;
   invite|share|join-string) shift; cmd_invite "$@" ;;
   knock)     shift; cmd_knock "$@" ;;
+  approve)   shift; cmd_approve "$@" ;;
+  decrypt-approval) shift; cmd_decrypt_approval "$@" ;;
   rooms|list|ls) shift; cmd_rooms "$@" ;;
   part) shift; cmd_part "$@" ;;
   version|--version|-v) shift; cmd_version "$@" ;;
@@ -2600,6 +2614,8 @@ case "${1:-help}" in
     echo "  airc list / rooms / ls          List open rooms + invites on your gh account"
     echo "  airc part                       Leave the current room"
     echo "  airc knock <owner/repo> <msg>   Request collaboration access to a project repo (opens an issue)"
+    echo "  airc approve <issue-url>        Encrypt a private-room invite to the knocker (replies on the issue)"
+    echo "  airc decrypt-approval <url> --knocker-priv <hex>   Decrypt an approval comment (knocker side)"
     echo "  airc msg / send <text>          Broadcast to the default channel"
     echo "  airc msg / send @<peer> <text>  DM a peer (still in the shared log)"
     echo "  airc msg / send @a @b <text>    DM multiple peers (also: @a,b,c)"

--- a/lib/airc_bash/cmd_approve.sh
+++ b/lib/airc_bash/cmd_approve.sh
@@ -1,0 +1,387 @@
+# Sourced by airc. cmd_approve + cmd_decrypt_approval — knock follow-up
+# verbs (airc#559 PR-2).
+#
+# Functions exported back to airc's dispatch:
+#   cmd_approve            — approver-side: read knocker_pub from a knock
+#                            issue, encrypt the private-room invite to
+#                            that pubkey via per-approval ephemeral ECDH,
+#                            post the ciphertext as a comment.
+#   cmd_decrypt_approval   — knocker-side: fetch the approval comment,
+#                            decrypt with the saved ephemeral priv key,
+#                            print the join string. Manual handoff for
+#                            now; PR-2c automates this via state.
+#
+# External cross-references (resolved at call time): die, AIRC_PYTHON,
+# `gh` CLI; airc_core.knock_crypto module.
+#
+# Crypto contract: per-knock + per-approval X25519 ephemerals → ECDH +
+# HKDF-SHA256 (info=b"airc-knock-approve-v1") → ChaCha20-Poly1305 AEAD.
+# Forward-secret: even if a long-term identity key leaks YEARS later,
+# every prior approval's join string is unrecoverable because the
+# ephemerals were never written to disk past one-shot use.
+
+cmd_approve() {
+  # Approver-side. Read the knock issue, encrypt the join string to the
+  # knocker's ephemeral pubkey, post as a comment.
+  #
+  #   airc approve <issue-url> [--invite <string>] [--dry-run]
+  #
+  # When --invite is omitted, the join string defaults to your CURRENT
+  # SCOPE'S invite (via `airc invite`) — convenient for "add this knocker
+  # to the room I'm hosting." When you want to invite to a DIFFERENT
+  # room, pass the invite string explicitly.
+
+  local issue_url=""
+  local invite_string=""
+  local dry_run=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -h|--help)
+        _airc_approve_help
+        return 0
+        ;;
+      --invite)
+        shift
+        invite_string="${1:-}"
+        ;;
+      --dry-run)
+        dry_run=1
+        ;;
+      -*)
+        die "approve: unknown flag: $1"
+        ;;
+      *)
+        if [ -z "$issue_url" ]; then
+          issue_url="$1"
+        else
+          die "approve: too many positional args. Got extra: $1"
+        fi
+        ;;
+    esac
+    shift || true
+  done
+
+  if [ -z "$issue_url" ]; then
+    _airc_approve_help >&2
+    return 1
+  fi
+
+  # Validate URL shape — github.com/owner/repo/issues/N. Accept the
+  # short form `owner/repo#N` too because it's natural to type after
+  # reading `gh issue list` output.
+  local repo issue_num
+  if [[ "$issue_url" =~ ^https://github\.com/([^/]+/[^/]+)/issues/([0-9]+) ]]; then
+    repo="${BASH_REMATCH[1]}"
+    issue_num="${BASH_REMATCH[2]}"
+  elif [[ "$issue_url" =~ ^([^/]+/[^/]+)#([0-9]+)$ ]]; then
+    repo="${BASH_REMATCH[1]}"
+    issue_num="${BASH_REMATCH[2]}"
+  else
+    die "approve: <issue-url> must be a GitHub issue URL or owner/repo#N (got: $issue_url)"
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    die "approve: 'gh' CLI is required. Install: https://cli.github.com/  Then: gh auth login"
+  fi
+
+  # Fetch the issue body via gh — gives us the airc-knock envelope text.
+  local issue_body
+  if ! issue_body=$(gh issue view "$issue_num" --repo "$repo" --json body --jq .body 2>&1); then
+    die "approve: gh issue view failed for $repo#$issue_num: $issue_body"
+  fi
+
+  local knocker_pub
+  knocker_pub=$(_airc_approve_extract_knocker_pub "$issue_body")
+  if [ -z "$knocker_pub" ]; then
+    die "approve: no knocker pubkey found in $repo#$issue_num — is this an airc-knock issue with the Approval crypto block?"
+  fi
+
+  # Default invite: the current scope's invite string (the room the
+  # approver is hosting / joined to). Operators override with --invite
+  # for cross-room invites.
+  if [ -z "$invite_string" ]; then
+    if ! invite_string=$(_airc_approve_default_invite); then
+      die "approve: no --invite given and could not derive one from current scope. Pass --invite \"<string>\" explicitly."
+    fi
+  fi
+
+  if [ -z "$invite_string" ]; then
+    die "approve: invite string is empty (refusing to send empty approval)."
+  fi
+
+  # Encrypt the invite to the knocker's pubkey via the python helper.
+  # The helper generates a per-approval ephemeral keypair internally,
+  # runs ECDH, and emits {ver, approver_pub, nonce, ciphertext} JSON.
+  local approval_json
+  if ! approval_json=$("$AIRC_PYTHON" -m airc_core.knock_crypto encrypt-for-knocker \
+        --knocker-pub "$knocker_pub" \
+        --plaintext "$invite_string" 2>&1); then
+    die "approve: encryption failed: $approval_json"
+  fi
+
+  # Build the comment body. JSON envelope inside a fenced block so
+  # cmd_decrypt_approval can parse it; markdown around it explains
+  # what humans are looking at.
+  #
+  # Avoiding heredoc here: the original heredoc-inside-$() form tripped
+  # bash's parser when the body contained an apostrophe (knocker's).
+  # printf %s with explicit \n is robust + reads cleanly.
+  local approver_name
+  approver_name=$(_airc_approve_resolve_name)
+  local comment_body
+  comment_body=$(printf '**airc-approve from `%s`**\n\n%s\n\n```json\n%s\n```\n\n%s\n\n```\nairc decrypt-approval %s --knocker-priv <your-saved-priv-hex>\n```\n' \
+    "$approver_name" \
+    'The private-room invite is encrypted to the knocker per-knock pubkey (forward-secret per-message ECDH; see [airc#559](https://github.com/CambrianTech/airc/issues/559)). The knocker decrypts with their saved ephemeral private key.' \
+    "$approval_json" \
+    'To decrypt:' \
+    "$issue_url")
+
+  if [ "$dry_run" -eq 1 ]; then
+    printf 'DRY RUN — would post approval comment:\n'
+    printf '  repo:        %s\n' "$repo"
+    printf '  issue:       #%s\n' "$issue_num"
+    printf '  knocker_pub: %s...\n' "${knocker_pub:0:24}"
+    printf '  invite:      %s\n' "$(_airc_approve_redact_invite "$invite_string")"
+    printf '  body preview:\n'
+    printf '%s\n' "$comment_body" | sed 's/^/    /'
+    return 0
+  fi
+
+  local comment_url
+  if ! comment_url=$(gh issue comment "$issue_num" --repo "$repo" --body "$comment_body" 2>&1); then
+    die "approve: gh issue comment failed: $comment_url"
+  fi
+
+  printf 'Approval posted: %s\n' "$comment_url"
+  printf 'Knocker decrypts with: airc decrypt-approval %s --knocker-priv <hex>\n' "$issue_url"
+}
+
+cmd_decrypt_approval() {
+  # Knocker-side. Fetch the approval comment from the issue, decrypt
+  # with the knocker's saved ephemeral priv key, print the join string.
+  #
+  #   airc decrypt-approval <issue-url> --knocker-priv <hex>
+  #
+  # PR-2 keeps state minimal — the knocker manually saves the priv key
+  # output by `airc knock` and passes it back here. PR-2c will manage
+  # state automatically in $AIRC_WRITE_DIR/knock-state/.
+
+  local issue_url=""
+  local knocker_priv=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -h|--help)
+        _airc_decrypt_approval_help
+        return 0
+        ;;
+      --knocker-priv)
+        shift
+        knocker_priv="${1:-}"
+        ;;
+      -*)
+        die "decrypt-approval: unknown flag: $1"
+        ;;
+      *)
+        if [ -z "$issue_url" ]; then
+          issue_url="$1"
+        else
+          die "decrypt-approval: too many positional args. Got extra: $1"
+        fi
+        ;;
+    esac
+    shift || true
+  done
+
+  if [ -z "$issue_url" ] || [ -z "$knocker_priv" ]; then
+    _airc_decrypt_approval_help >&2
+    return 1
+  fi
+
+  local repo issue_num
+  if [[ "$issue_url" =~ ^https://github\.com/([^/]+/[^/]+)/issues/([0-9]+) ]]; then
+    repo="${BASH_REMATCH[1]}"
+    issue_num="${BASH_REMATCH[2]}"
+  elif [[ "$issue_url" =~ ^([^/]+/[^/]+)#([0-9]+)$ ]]; then
+    repo="${BASH_REMATCH[1]}"
+    issue_num="${BASH_REMATCH[2]}"
+  else
+    die "decrypt-approval: <issue-url> must be a GitHub issue URL or owner/repo#N"
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    die "decrypt-approval: 'gh' CLI is required."
+  fi
+
+  # Fetch comments. The approval is the first (or only) comment with an
+  # airc-approve envelope. If multiple approvals are posted, decrypt the
+  # most recent one — operators can override later via --comment-index
+  # if needed (PR-2c).
+  local comments_json
+  if ! comments_json=$(gh issue view "$issue_num" --repo "$repo" --json comments 2>&1); then
+    die "decrypt-approval: gh issue view failed: $comments_json"
+  fi
+
+  local approval_json
+  approval_json=$(_airc_decrypt_extract_approval "$comments_json")
+  if [ -z "$approval_json" ]; then
+    die "decrypt-approval: no airc-approve envelope found in $repo#$issue_num comments. Approval may not have been posted yet."
+  fi
+
+  local approver_pub nonce ciphertext
+  approver_pub=$("$AIRC_PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("approver_pub",""))' <<< "$approval_json")
+  nonce=$("$AIRC_PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("nonce",""))' <<< "$approval_json")
+  ciphertext=$("$AIRC_PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("ciphertext",""))' <<< "$approval_json")
+
+  if [ -z "$approver_pub" ] || [ -z "$nonce" ] || [ -z "$ciphertext" ]; then
+    die "decrypt-approval: malformed approval envelope (missing approver_pub/nonce/ciphertext)"
+  fi
+
+  if ! "$AIRC_PYTHON" -m airc_core.knock_crypto decrypt-from-approver \
+        --knocker-priv "$knocker_priv" \
+        --approver-pub "$approver_pub" \
+        --nonce "$nonce" \
+        --ciphertext "$ciphertext"; then
+    die "decrypt-approval: decryption failed (see error above)"
+  fi
+}
+
+_airc_approve_help() {
+  cat <<'EOF'
+airc approve — encrypt a private-room invite to a knocker (airc#559 PR-2)
+
+USAGE
+  airc approve <issue-url> [--invite "<string>"] [--dry-run]
+  airc approve owner/repo#N  [--invite "<string>"] [--dry-run]
+
+DESCRIPTION
+  Reads the knocker's per-knock ephemeral X25519 pubkey from the
+  airc-knock issue body. Generates a per-approval ephemeral keypair,
+  derives a forward-secret shared key via ECDH+HKDF, AEAD-encrypts the
+  invite, and posts the {approver_pub, nonce, ciphertext} envelope as
+  a comment on the issue.
+
+OPTIONS
+  --invite "<string>"   The private-room join string. If omitted, defaults
+                        to the current scope's invite (the room you're
+                        hosting / joined to).
+  --dry-run             Print what would be posted; don't comment on gh.
+  -h, --help            This help.
+
+NOTES
+  - Both ephemerals are per-message — long-term key compromise YEARS
+    later cannot recover any prior approval's join string.
+  - Public GitHub comments are durable; the join string MUST stay valid
+    only briefly. Per airc#559, room-rotation hooks (PR-3) make leaked
+    old ciphertext unable to reopen access later.
+  - 'gh' CLI must be authenticated. Run 'gh auth login' first.
+EOF
+}
+
+_airc_decrypt_approval_help() {
+  cat <<'EOF'
+airc decrypt-approval — decrypt an approval comment (airc#559 PR-2)
+
+USAGE
+  airc decrypt-approval <issue-url> --knocker-priv <hex>
+  airc decrypt-approval owner/repo#N --knocker-priv <hex>
+
+DESCRIPTION
+  Fetches the airc-approve comment from the knock issue, derives the
+  shared ECDH key with the knocker's saved ephemeral private key, and
+  prints the decrypted invite string to stdout.
+
+OPTIONS
+  --knocker-priv <hex>   Per-knock ephemeral X25519 priv key (hex).
+                         You saved this when running `airc knock`.
+  -h, --help             This help.
+
+NOTES
+  - PR-2 minimal: knocker manually passes the priv key from `airc knock`
+    output. PR-2c will manage state in $AIRC_WRITE_DIR/knock-state/.
+  - 'gh' CLI must be authenticated.
+EOF
+}
+
+_airc_approve_extract_knocker_pub() {
+  # Parse the JSON block under "### Approval crypto" from the issue body.
+  # Body comes in via $1 as raw markdown; we look for the first JSON
+  # block with a "knocker_pub" field.
+  local body="$1"
+  printf '%s' "$body" | "$AIRC_PYTHON" - <<'PYEOF' 2>/dev/null
+import json, re, sys
+body = sys.stdin.read()
+# Match ```json ... ``` blocks; check each for knocker_pub.
+for match in re.finditer(r'```json\s*\n(.*?)\n```', body, re.DOTALL):
+    blob = match.group(1).strip()
+    try:
+        parsed = json.loads(blob)
+    except Exception:
+        continue
+    if isinstance(parsed, dict) and "knocker_pub" in parsed:
+        pub = parsed.get("knocker_pub", "")
+        if pub:
+            print(pub)
+            sys.exit(0)
+sys.exit(1)
+PYEOF
+}
+
+_airc_decrypt_extract_approval() {
+  # Find the airc-approve envelope in the issue's comments JSON.
+  # Returns the most recent envelope (last comment with one), so a
+  # repost or correction wins over the original.
+  local comments_json="$1"
+  printf '%s' "$comments_json" | "$AIRC_PYTHON" - <<'PYEOF' 2>/dev/null
+import json, re, sys
+data = json.loads(sys.stdin.read())
+comments = data.get("comments", [])
+found = None
+for comment in comments:
+    body = comment.get("body", "")
+    for match in re.finditer(r'```json\s*\n(.*?)\n```', body, re.DOTALL):
+        try:
+            parsed = json.loads(match.group(1).strip())
+        except Exception:
+            continue
+        if (isinstance(parsed, dict)
+                and parsed.get("ver") == "v1"
+                and "approver_pub" in parsed
+                and "nonce" in parsed
+                and "ciphertext" in parsed):
+            found = match.group(1).strip()  # keep last; iteration is chronological
+if found:
+    print(found)
+PYEOF
+}
+
+_airc_approve_default_invite() {
+  # Try to derive the current scope's invite string. This is best-effort —
+  # `airc invite` exists for the current scope but the approver may want
+  # to invite to a different room. Operator-override via --invite.
+  if command -v airc >/dev/null 2>&1; then
+    airc invite 2>/dev/null | tail -1 | tr -d '\n' && return 0
+  fi
+  return 1
+}
+
+_airc_approve_resolve_name() {
+  # Best-effort approver name. Falls back to "approver" if no scope.
+  if declare -F resolve_name >/dev/null 2>&1; then
+    resolve_name
+  else
+    echo "approver"
+  fi
+}
+
+_airc_approve_redact_invite() {
+  # Show only the first 24 chars of the invite for dry-run output.
+  # Avoid leaking the full credential into terminal scrollback.
+  local invite="$1"
+  if [ "${#invite}" -le 24 ]; then
+    printf '%s' "$invite"
+  else
+    printf '%s...' "${invite:0:24}"
+  fi
+}

--- a/lib/airc_bash/cmd_approve.sh
+++ b/lib/airc_bash/cmd_approve.sh
@@ -309,9 +309,9 @@ _airc_approve_extract_knocker_pub() {
   # Body comes in via $1 as raw markdown; we look for the first JSON
   # block with a "knocker_pub" field.
   local body="$1"
-  printf '%s' "$body" | "$AIRC_PYTHON" - <<'PYEOF' 2>/dev/null
-import json, re, sys
-body = sys.stdin.read()
+  AIRC_APPROVE_BODY="$body" "$AIRC_PYTHON" - <<'PYEOF' 2>/dev/null
+import json, os, re, sys
+body = os.environ.get("AIRC_APPROVE_BODY", "")
 # Match ```json ... ``` blocks; check each for knocker_pub.
 for match in re.finditer(r'```json\s*\n(.*?)\n```', body, re.DOTALL):
     blob = match.group(1).strip()
@@ -333,9 +333,9 @@ _airc_decrypt_extract_approval() {
   # Returns the most recent envelope (last comment with one), so a
   # repost or correction wins over the original.
   local comments_json="$1"
-  printf '%s' "$comments_json" | "$AIRC_PYTHON" - <<'PYEOF' 2>/dev/null
-import json, re, sys
-data = json.loads(sys.stdin.read())
+  AIRC_APPROVE_COMMENTS_JSON="$comments_json" "$AIRC_PYTHON" - <<'PYEOF' 2>/dev/null
+import json, os, re, sys
+data = json.loads(os.environ.get("AIRC_APPROVE_COMMENTS_JSON", "{}"))
 comments = data.get("comments", [])
 found = None
 for comment in comments:

--- a/lib/airc_bash/cmd_knock.sh
+++ b/lib/airc_bash/cmd_knock.sh
@@ -15,8 +15,7 @@
 #      `airc approve` flow + the kanban work in #559) can read it.
 #   4. `gh` is already a hard dependency for the rest of airc.
 #
-# What this PR does NOT do (later PR-2/PR-3 under airc#559):
-#   - Approval flow (`airc approve <peer>` → sends private-room invite)
+# What this PR does NOT do (later PR-3 under airc#559):
 #   - Private-room rotation when a peer becomes abusive
 #   - Shared sprint/kanban queue primitives
 #   - Repo-local `.airc/` discovery manifest (continuum#1109 pilots that)
@@ -200,8 +199,8 @@ DESCRIPTION
   Opens a GitHub issue on the target repo with title "airc-knock: <msg>"
   and a structured envelope body containing your airc identity (name,
   role, bio) + the message. Repo owners use GitHub's native moderation
-  tools (labels, close, spam, block) and the future `airc approve` flow
-  to send approved peers the private room invite.
+  tools (labels, close, spam, block) and `airc approve` to send approved
+  peers the private room invite.
 
 OPTIONS
   -m, --message <text>   Provide the message via flag (vs trailing args).
@@ -218,8 +217,8 @@ NOTES
   - The 'airc-knock' label is auto-applied if it exists on the target
     repo; otherwise the issue posts without a label and a hint suggests
     creating it.
-  - PR-1 scope (airc#559): just the public entrypoint. Approval flow,
-    private-room handoff, and sprint/kanban queue come in PR-2/PR-3.
+  - Approval handoff uses per-knock crypto. Private-room rotation and
+    sprint/kanban queue primitives come in later airc#559 slices.
 EOF
 }
 
@@ -339,7 +338,7 @@ $identity_json
 ### Next step
 
 Repo owners can:
-- Approve by running \`airc approve $knocker_name\` (Phase 2 of [airc#559](https://github.com/CambrianTech/airc/issues/559)). The approval encrypts the private-room invite to the \`knocker_pub\` above and posts it as a comment on this issue.
+- Approve by running \`airc approve <this issue URL>\` (Phase 2 of [airc#559](https://github.com/CambrianTech/airc/issues/559)). The approval encrypts the private-room invite to the \`knocker_pub\` above and posts it as a comment on this issue.
 - Reject by closing this issue, optionally with a comment.
 - Mark as spam via GitHub's spam tools.
 

--- a/lib/airc_bash/cmd_knock.sh
+++ b/lib/airc_bash/cmd_knock.sh
@@ -111,15 +111,42 @@ cmd_knock() {
   local knocker_identity_json
   knocker_identity_json=$(_airc_knock_identity_json "$knocker_name")
 
+  # Generate a per-knock ephemeral X25519 keypair for the approve flow
+  # (airc#559 PR-2). The approver derives a forward-secret shared key
+  # via ECDH(approver_ephemeral, knocker_ephemeral) and posts the
+  # encrypted private-room invite as a comment. Both ephemerals are
+  # per-message — even if either party's long-term key leaks years
+  # later, every prior approval's join string is unrecoverable.
+  #
+  # The PRIVATE half is printed at the end of the success message so the
+  # operator can save it. PR-2c will manage state automatically; for now
+  # state surface stays minimal.
+  local knock_keys_json knocker_pub knocker_priv
+  knock_keys_json=$(_airc_knock_gen_keys 2>/dev/null || echo "")
+  if [ -n "$knock_keys_json" ]; then
+    knocker_pub=$("$AIRC_PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("pub",""))' <<< "$knock_keys_json" 2>/dev/null || echo "")
+    knocker_priv=$("$AIRC_PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("priv",""))' <<< "$knock_keys_json" 2>/dev/null || echo "")
+  else
+    # Crypto path unavailable (no python venv with cryptography). Knock
+    # still posts but without an approval pubkey — cmd_approve will
+    # hard-fail with a clear "no knocker pubkey, can't encrypt" error
+    # rather than silently shipping plaintext.
+    knocker_pub=""
+    knocker_priv=""
+  fi
+
   local issue_title="airc-knock: $title_slice"
   local issue_body
-  issue_body=$(_airc_knock_issue_body "$knocker_name" "$knocker_identity_json" "$message")
+  issue_body=$(_airc_knock_issue_body "$knocker_name" "$knocker_identity_json" "$message" "$knocker_pub")
 
   if [ "$dry_run" -eq 1 ]; then
     printf 'DRY RUN — would post knock issue:\n'
     printf '  repo:   %s\n' "$target_repo"
     printf '  title:  %s\n' "$issue_title"
     printf '  body:\n%s\n' "$issue_body" | sed 's/^/    /'
+    if [ -n "$knocker_priv" ]; then
+      printf '\n  knocker priv key (SAVE THIS — needed to decrypt approval):\n    %s\n' "$knocker_priv"
+    fi
     return 0
   fi
 
@@ -151,7 +178,13 @@ cmd_knock() {
   fi
 
   printf 'Knock sent: %s\n' "$issue_url"
-  printf 'Awaiting approval. Approved peers receive the private room invite via airc DM (Phase 2 of airc#559).\n'
+  if [ -n "$knocker_priv" ]; then
+    printf '\nSAVE THIS PRIVATE KEY — needed to decrypt the approval comment:\n  %s\n\n' "$knocker_priv"
+    printf 'When approved, run:\n  airc decrypt-approval %s --knocker-priv <the key above>\n' "$issue_url"
+  else
+    printf 'WARNING: no crypto pubkey embedded — cmd_approve cannot encrypt for this knock.\n' >&2
+    printf '         Approval will require an out-of-band channel (DM, email).\n' >&2
+  fi
 }
 
 _airc_knock_help() {
@@ -257,14 +290,33 @@ _airc_knock_json_str() {
   printf '"%s"' "$s"
 }
 
+_airc_knock_gen_keys() {
+  # Generate per-knock ephemeral X25519 keypair via the python venv.
+  # Returns JSON {"priv": "<hex>", "pub": "<hex>"} on stdout.
+  # Returns non-zero (caller falls back to no-pubkey envelope) when the
+  # python crypto path isn't available — typically a fresh checkout
+  # without `pip install cryptography` in the venv.
+  if [ -z "${AIRC_PYTHON:-}" ]; then
+    return 1
+  fi
+  "$AIRC_PYTHON" -m airc_core.knock_crypto gen-knock-keys
+}
+
 _airc_knock_issue_body() {
   local knocker_name="$1"
   local identity_json="$2"
   local message="$3"
+  local knocker_pub="${4:-}"
 
-  # The body is human-readable markdown PLUS a machine-readable JSON
-  # envelope inside a fenced block. Future tooling (`airc approve`,
-  # sprint/kanban) parses the JSON; humans read the markdown.
+  # The body is human-readable markdown PLUS machine-readable JSON
+  # blocks. Future tooling (`airc approve`, sprint/kanban) parses the
+  # JSON; humans read the markdown.
+  #
+  # The Approval crypto block (PR-2) carries the per-knock ephemeral
+  # X25519 pubkey. cmd_approve parses this, generates its own ephemeral,
+  # ECDH-derives a shared key, and posts an encrypted comment. Both
+  # ephemerals are per-message — even a long-term-key leak years later
+  # cannot recover any prior approval's join string.
   cat <<EOF
 **airc knock from \`$knocker_name\`**
 
@@ -278,13 +330,19 @@ $message
 $identity_json
 \`\`\`
 
+### Approval crypto
+
+\`\`\`json
+{"ver":"v1","knocker_pub":"$knocker_pub"}
+\`\`\`
+
 ### Next step
 
 Repo owners can:
-- Approve by running \`airc approve $knocker_name\` (Phase 2 of [airc#559](https://github.com/CambrianTech/airc/issues/559)). The approval sends $knocker_name a private-room invite via airc DM.
+- Approve by running \`airc approve $knocker_name\` (Phase 2 of [airc#559](https://github.com/CambrianTech/airc/issues/559)). The approval encrypts the private-room invite to the \`knocker_pub\` above and posts it as a comment on this issue.
 - Reject by closing this issue, optionally with a comment.
 - Mark as spam via GitHub's spam tools.
 
-This issue was opened by \`airc knock\`. The structured JSON envelope above is parsed by future approval tooling.
+This issue was opened by \`airc knock\`. The structured JSON envelopes above are parsed by future approval tooling.
 EOF
 }

--- a/lib/airc_core/knock_crypto.py
+++ b/lib/airc_core/knock_crypto.py
@@ -1,0 +1,169 @@
+"""Crypto helpers for the airc knock/approve flow (airc#559 PR-2).
+
+Exposes a tiny CLI wrapper around lib/airc_core/crypto.py so the bash
+cmd_knock + cmd_approve + cmd_decrypt-approval functions can do X25519
+ECDH + ChaCha20-Poly1305 AEAD without re-implementing crypto in shell.
+
+Why ephemeral-per-knock + ephemeral-per-approval (forward secrecy):
+
+  Knock posts the knocker's ephemeral pubkey on a public GitHub issue.
+  Approver derives a shared key via ECDH(approver_ephemeral, knocker_ephemeral)
+  and posts the approver's ephemeral pubkey + nonce + ChaCha20-Poly1305
+  ciphertext as a comment.
+
+  Both ephemerals are per-message (not long-term) so even if either
+  party's long-term identity key leaks YEARS later, every prior
+  approval's join string is unrecoverable. The ephemerals are NEVER
+  written to disk after the protocol completes — knocker keeps their
+  priv key only between knock-time and approval-decrypt time.
+
+Verbs:
+
+  gen-knock-keys
+      Emit a fresh X25519 keypair as JSON: {"priv": "<hex>", "pub": "<hex>"}.
+      Knocker generates this per knock; saves priv securely (or stdout
+      one-shot for now); embeds pub in the issue envelope.
+
+  encrypt-for-knocker --knocker-pub <hex> --plaintext <str>
+      Generate per-approval ephemeral keypair, derive shared key via
+      ECDH(approver_priv, knocker_pub), AEAD-encrypt plaintext.
+      Emits JSON: {"ver": "v1", "approver_pub": "<hex>",
+                   "nonce": "<hex>", "ciphertext": "<hex>"}.
+
+  decrypt-from-approver --knocker-priv <hex> --approver-pub <hex>
+                        --nonce <hex> --ciphertext <hex>
+      Derive shared key via ECDH(knocker_priv, approver_pub),
+      AEAD-decrypt. Emits the plaintext to stdout. Exit 1 on auth
+      failure (InvalidTag).
+
+All hex inputs are case-insensitive; outputs lower-case. Hex is used
+(not base64) so the values fit cleanly inside a JSON envelope embedded
+in a markdown fenced block + are easy to eyeball/copy-paste in
+operator UX.
+
+Domain-separated HKDF context: `airc-knock-approve-v1`. Bumping v1→v2
+later signals an incompatible wire format change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+try:
+    from . import crypto as airc_crypto
+except ImportError:
+    # When invoked as a script (python3 -m airc_core.knock_crypto), the
+    # relative import works. When run as a standalone file (rare; tests
+    # may do this), fall back to the absolute import.
+    from airc_core import crypto as airc_crypto
+
+
+HKDF_INFO = b"airc-knock-approve-v1"
+
+
+def _hex_to_bytes(name: str, value: str) -> bytes:
+    try:
+        return bytes.fromhex(value.strip())
+    except ValueError as exc:
+        raise SystemExit(f"{name}: not valid hex: {exc}")
+
+
+def cmd_gen_knock_keys(_args: argparse.Namespace) -> int:
+    priv, pub = airc_crypto.generate_x25519_keypair()
+    print(json.dumps({"priv": priv.hex(), "pub": pub.hex()}))
+    return 0
+
+
+def cmd_encrypt_for_knocker(args: argparse.Namespace) -> int:
+    knocker_pub = _hex_to_bytes("--knocker-pub", args.knocker_pub)
+    if len(knocker_pub) != 32:
+        raise SystemExit("--knocker-pub must decode to 32 bytes")
+
+    approver_priv, approver_pub = airc_crypto.generate_x25519_keypair()
+    shared_key = airc_crypto.derive_pairwise_key(
+        approver_priv, knocker_pub, info=HKDF_INFO
+    )
+    plaintext = args.plaintext.encode("utf-8")
+    nonce, ciphertext = airc_crypto.aead_encrypt(shared_key, plaintext)
+
+    print(json.dumps({
+        "ver": "v1",
+        "approver_pub": approver_pub.hex(),
+        "nonce": nonce.hex(),
+        "ciphertext": ciphertext.hex(),
+    }))
+    return 0
+
+
+def cmd_decrypt_from_approver(args: argparse.Namespace) -> int:
+    knocker_priv = _hex_to_bytes("--knocker-priv", args.knocker_priv)
+    approver_pub = _hex_to_bytes("--approver-pub", args.approver_pub)
+    nonce = _hex_to_bytes("--nonce", args.nonce)
+    ciphertext = _hex_to_bytes("--ciphertext", args.ciphertext)
+
+    if len(knocker_priv) != 32 or len(approver_pub) != 32:
+        raise SystemExit("knocker-priv + approver-pub must each decode to 32 bytes")
+
+    shared_key = airc_crypto.derive_pairwise_key(
+        knocker_priv, approver_pub, info=HKDF_INFO
+    )
+    try:
+        plaintext = airc_crypto.aead_decrypt(shared_key, nonce, ciphertext)
+    except Exception as exc:  # InvalidTag is the expected one; surface anything
+        # InvalidTag means either the wrong key, wrong nonce, or
+        # tampered ciphertext. Per Joel's "never swallow errors" rule,
+        # exit non-zero with the actual exception type so the caller
+        # sees what failed (vs returning empty string).
+        print(f"airc knock decrypt: AEAD authentication failed: {exc}",
+              file=sys.stderr)
+        return 1
+
+    sys.stdout.buffer.write(plaintext)
+    if not plaintext.endswith(b"\n"):
+        sys.stdout.buffer.write(b"\n")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="airc_core.knock_crypto",
+        description="Crypto helpers for airc knock/approve flow.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    gen = sub.add_parser("gen-knock-keys",
+                         help="Emit a fresh X25519 keypair as JSON.")
+    gen.set_defaults(func=cmd_gen_knock_keys)
+
+    enc = sub.add_parser(
+        "encrypt-for-knocker",
+        help="Encrypt plaintext to a knocker's pubkey via ECDH+AEAD.",
+    )
+    enc.add_argument("--knocker-pub", required=True,
+                     help="Knocker's ephemeral X25519 pubkey, hex.")
+    enc.add_argument("--plaintext", required=True,
+                     help="String to encrypt (UTF-8).")
+    enc.set_defaults(func=cmd_encrypt_for_knocker)
+
+    dec = sub.add_parser(
+        "decrypt-from-approver",
+        help="Decrypt approver-posted ciphertext using knocker's priv key.",
+    )
+    dec.add_argument("--knocker-priv", required=True,
+                     help="Knocker's ephemeral X25519 priv key, hex.")
+    dec.add_argument("--approver-pub", required=True,
+                     help="Approver's ephemeral X25519 pubkey from comment, hex.")
+    dec.add_argument("--nonce", required=True,
+                     help="ChaCha20-Poly1305 nonce from comment, hex.")
+    dec.add_argument("--ciphertext", required=True,
+                     help="AEAD ciphertext+tag from comment, hex.")
+    dec.set_defaults(func=cmd_decrypt_from_approver)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_approve.py
+++ b/test/test_approve.py
@@ -1,0 +1,245 @@
+"""Tests for `airc approve` + `airc decrypt-approval` — knock follow-up
+verbs (airc#559 PR-2).
+
+Coverage:
+  - dispatch: both verbs reach the right cmd_ function + --help paths work
+  - validation: malformed issue URLs / missing required args fail loudly
+  - crypto: end-to-end roundtrip via the knock_crypto python helper
+    (gen-knock-keys → encrypt-for-knocker → decrypt-from-approver)
+  - envelope parsing: knocker_pub extracted from a knock issue body
+  - tamper-resistance: ciphertext modification fails AEAD auth
+
+The actual `gh issue comment` invocation is NOT exercised here (would
+require a real GitHub issue + auth). cmd_approve's --dry-run path
+exercises everything UP TO the gh call so the envelope shape is
+verified end-to-end without external dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import subprocess
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+AIRC_BIN = REPO_ROOT / "airc"
+VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python3"
+LIB_DIR = REPO_ROOT / "lib"
+
+
+def _python_with_crypto() -> str:
+    """Find a python3 that has the cryptography package importable.
+
+    Prefers the repo's venv if it exists (covers fresh-checkout test
+    runs); falls back to system python3 (covers CI environments where
+    cryptography is in the system site-packages).
+    """
+    if VENV_PYTHON.exists():
+        return str(VENV_PYTHON)
+    return "python3"
+
+
+def run_airc(args: list[str], env_overrides: dict[str, str] | None = None
+             ) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [str(AIRC_BIN), *args],
+        capture_output=True, text=True, env=env,
+        cwd=str(REPO_ROOT), timeout=15,
+    )
+
+
+def run_knock_crypto(args: list[str], stdin: str = "") -> subprocess.CompletedProcess[str]:
+    """Invoke `python3 -m airc_core.knock_crypto <args>` directly.
+
+    Used by the roundtrip test to drive the crypto layer without
+    spinning up the full airc CLI.
+    """
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(LIB_DIR) + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.run(
+        [_python_with_crypto(), "-m", "airc_core.knock_crypto", *args],
+        input=stdin, capture_output=True, text=True, env=env, timeout=15,
+    )
+
+
+class ApproveDispatchTests(unittest.TestCase):
+    def test_approve_help_returns_zero(self) -> None:
+        result = run_airc(["approve", "--help"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--invite", result.stdout)
+        self.assertIn("airc-knock", result.stdout)
+
+    def test_decrypt_approval_help_returns_zero(self) -> None:
+        result = run_airc(["decrypt-approval", "--help"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--knocker-priv", result.stdout)
+
+
+class ApproveValidationTests(unittest.TestCase):
+    def test_approve_missing_url_fails(self) -> None:
+        result = run_airc(["approve"])
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("issue-url", result.stdout + result.stderr)
+
+    def test_approve_malformed_url_fails_with_clear_message(self) -> None:
+        result = run_airc(["approve", "not-a-url"])
+        self.assertNotEqual(result.returncode, 0)
+        # cmd_approve calls `die` with a specific message; combined
+        # output should contain the validation hint.
+        combined = result.stdout + result.stderr
+        self.assertIn("owner/repo", combined.lower())
+
+    def test_decrypt_approval_missing_priv_fails(self) -> None:
+        result = run_airc(
+            ["decrypt-approval", "https://github.com/owner/repo/issues/1"]
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("knocker-priv", result.stdout + result.stderr)
+
+
+class KnockCryptoRoundtripTests(unittest.TestCase):
+    """End-to-end crypto roundtrip via the python helper.
+
+    Skipped cleanly when cryptography isn't installed in the chosen
+    python (fresh-checkout-no-venv CI case).
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        result = run_knock_crypto(["gen-knock-keys"])
+        if result.returncode != 0:
+            raise unittest.SkipTest(
+                f"knock_crypto unavailable (cryptography not installed?): "
+                f"{result.stderr.strip()}"
+            )
+
+    def test_gen_knock_keys_emits_32_byte_hex_pair(self) -> None:
+        result = run_knock_crypto(["gen-knock-keys"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        keys = json.loads(result.stdout)
+        self.assertEqual(len(bytes.fromhex(keys["priv"])), 32)
+        self.assertEqual(len(bytes.fromhex(keys["pub"])), 32)
+
+    def test_full_roundtrip_recovers_plaintext(self) -> None:
+        # 1. Knocker generates ephemeral keypair.
+        keys = json.loads(run_knock_crypto(["gen-knock-keys"]).stdout)
+        secret = "private-room://abc123#deadbeef"
+        # 2. Approver encrypts to knocker_pub.
+        approval = json.loads(run_knock_crypto([
+            "encrypt-for-knocker",
+            "--knocker-pub", keys["pub"],
+            "--plaintext", secret,
+        ]).stdout)
+        self.assertEqual(approval["ver"], "v1")
+        self.assertEqual(len(bytes.fromhex(approval["approver_pub"])), 32)
+        self.assertEqual(len(bytes.fromhex(approval["nonce"])), 12)
+        self.assertGreater(len(bytes.fromhex(approval["ciphertext"])), 16,
+                           "ciphertext must include AEAD tag (>=16 bytes)")
+        # 3. Knocker decrypts.
+        decrypted = run_knock_crypto([
+            "decrypt-from-approver",
+            "--knocker-priv", keys["priv"],
+            "--approver-pub", approval["approver_pub"],
+            "--nonce", approval["nonce"],
+            "--ciphertext", approval["ciphertext"],
+        ])
+        self.assertEqual(decrypted.returncode, 0, decrypted.stderr)
+        self.assertEqual(decrypted.stdout.rstrip("\n"), secret)
+
+    def test_tampered_ciphertext_fails_aead_auth(self) -> None:
+        keys = json.loads(run_knock_crypto(["gen-knock-keys"]).stdout)
+        approval = json.loads(run_knock_crypto([
+            "encrypt-for-knocker",
+            "--knocker-pub", keys["pub"],
+            "--plaintext", "secret-room",
+        ]).stdout)
+        # Flip one bit in the ciphertext (XOR the last byte with 0x01).
+        ct_bytes = bytearray(bytes.fromhex(approval["ciphertext"]))
+        ct_bytes[-1] ^= 0x01
+        tampered = ct_bytes.hex()
+        result = run_knock_crypto([
+            "decrypt-from-approver",
+            "--knocker-priv", keys["priv"],
+            "--approver-pub", approval["approver_pub"],
+            "--nonce", approval["nonce"],
+            "--ciphertext", tampered,
+        ])
+        # Decryption MUST fail loud — silent corruption would defeat the
+        # whole point of AEAD.
+        self.assertNotEqual(result.returncode, 0,
+                            "tampered ciphertext must fail AEAD auth")
+        self.assertIn("authentication failed", result.stderr.lower())
+
+    def test_wrong_approver_pub_fails(self) -> None:
+        # Two knockers; approver encrypts to A; B tries to decrypt with
+        # A's approver_pub but B's own priv — must fail.
+        keys_a = json.loads(run_knock_crypto(["gen-knock-keys"]).stdout)
+        keys_b = json.loads(run_knock_crypto(["gen-knock-keys"]).stdout)
+        approval = json.loads(run_knock_crypto([
+            "encrypt-for-knocker",
+            "--knocker-pub", keys_a["pub"],
+            "--plaintext", "for-A-only",
+        ]).stdout)
+        result = run_knock_crypto([
+            "decrypt-from-approver",
+            "--knocker-priv", keys_b["priv"],  # wrong knocker!
+            "--approver-pub", approval["approver_pub"],
+            "--nonce", approval["nonce"],
+            "--ciphertext", approval["ciphertext"],
+        ])
+        self.assertNotEqual(result.returncode, 0,
+                            "wrong knocker priv must fail AEAD auth")
+
+
+class KnockEnvelopeShapeTests(unittest.TestCase):
+    """The knock issue body must carry the knocker_pub so cmd_approve
+    can find it. Dry-run output is the canonical reference."""
+
+    def test_knock_dry_run_embeds_knocker_pub_envelope(self) -> None:
+        # Skip if crypto not available — knock falls back to empty pub.
+        if run_knock_crypto(["gen-knock-keys"]).returncode != 0:
+            self.skipTest("knock_crypto unavailable")
+        with __import__('tempfile').TemporaryDirectory() as tmp:
+            env = {
+                "HOME": tmp,
+                "AIRC_HOME": str(pathlib.Path(tmp) / ".airc"),
+                "AIRC_NO_IDENTITY_PROMPT": "1",
+                "PATH": "/usr/bin:/bin",
+            }
+            result = run_airc(
+                ["knock", "owner/repo", "--dry-run", "-m", "test"],
+                env_overrides=env,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        # Find every fenced JSON block and look for one with knocker_pub.
+        blocks = re.findall(r'```json\s*\n\s*(\{.*?\})\s*\n\s*```',
+                            result.stdout, re.DOTALL)
+        knocker_pub_seen = False
+        for blob in blocks:
+            try:
+                parsed = json.loads(blob)
+            except Exception:
+                continue
+            if isinstance(parsed, dict) and "knocker_pub" in parsed:
+                knocker_pub_seen = True
+                # Must be 32-byte hex (64 chars), or empty-string for
+                # the no-crypto fallback path. We're in the crypto-OK
+                # path here (gen-knock-keys succeeded in setUpClass).
+                pub = parsed["knocker_pub"]
+                self.assertEqual(len(pub), 64,
+                                 f"knocker_pub should be 64-char hex; got {len(pub)}")
+                break
+        self.assertTrue(knocker_pub_seen,
+                        f"knock dry-run must embed knocker_pub envelope; "
+                        f"got blocks: {blocks}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_approve.py
+++ b/test/test_approve.py
@@ -241,5 +241,73 @@ class KnockEnvelopeShapeTests(unittest.TestCase):
                         f"got blocks: {blocks}")
 
 
+class ApproveGhParsingTests(unittest.TestCase):
+    """Exercise the shell parser helpers used by the gh-backed paths.
+
+    These catch the shell/heredoc class of bugs where markdown or
+    comments JSON is piped toward Python but the heredoc itself consumes
+    stdin before sys.stdin can read the payload.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        result = run_knock_crypto(["gen-knock-keys"])
+        if result.returncode != 0:
+            raise unittest.SkipTest(
+                f"knock_crypto unavailable (cryptography not installed?): "
+                f"{result.stderr.strip()}"
+            )
+
+    def _run_helper(self, helper: str, payload: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["AIRC_PYTHON"] = _python_with_crypto()
+        return subprocess.run(
+            [
+                "bash",
+                "-c",
+                (
+                    "set -euo pipefail; "
+                    "source lib/airc_bash/cmd_approve.sh; "
+                    f"{helper} \"$PAYLOAD\""
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            env={**env, "PAYLOAD": payload},
+            timeout=15,
+        )
+
+    def test_extract_knocker_pub_reads_issue_body(self) -> None:
+        keys = json.loads(run_knock_crypto(["gen-knock-keys"]).stdout)
+        issue_body = (
+            "**airc knock**\n\n"
+            "```json\n"
+            f"{json.dumps({'ver': 'v1', 'knocker_pub': keys['pub']})}\n"
+            "```\n"
+        )
+        result = self._run_helper("_airc_approve_extract_knocker_pub", issue_body)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.stdout.strip(), keys["pub"])
+
+    def test_extract_approval_reads_latest_approval_from_comments(self) -> None:
+        keys = json.loads(run_knock_crypto(["gen-knock-keys"]).stdout)
+        secret = "private-room://approved"
+        approval = json.loads(run_knock_crypto([
+            "encrypt-for-knocker",
+            "--knocker-pub", keys["pub"],
+            "--plaintext", secret,
+        ]).stdout)
+        comments = {
+            "comments": [
+                {"body": "noise"},
+                {"body": "```json\n" + json.dumps(approval) + "\n```"},
+            ]
+        }
+        result = self._run_helper("_airc_decrypt_extract_approval", json.dumps(comments))
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(json.loads(result.stdout), approval)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Completes the knock → approve → join handoff started in #560. Approver encrypts the private-room invite to the knocker's per-knock ephemeral pubkey via forward-secret per-message ECDH + ChaCha20-Poly1305, posts as a comment on the knock issue. Knocker decrypts with their saved ephemeral private key.

## What lands

- \`airc knock\` now embeds a per-knock ephemeral X25519 pubkey in a new "Approval crypto" envelope block. Private half prints to stdout for operator to save (state mgmt deferred to PR-2c).
- \`airc approve <issue-url>\` reads knocker_pub, generates per-approval ephemeral, ECDH+HKDF+AEAD-encrypts the invite, posts \`{approver_pub, nonce, ciphertext}\` envelope comment.
- \`airc decrypt-approval <issue-url> --knocker-priv <hex>\` fetches the comment, derives shared key, decrypts, prints the join string.
- New \`airc_core.knock_crypto\` python module wraps the airc crypto stack (gen-knock-keys / encrypt-for-knocker / decrypt-from-approver). Keeps bash layer thin.

## Forward secrecy

GitHub comments are durable; even after issue close, the ciphertext stays in history. Per-knock + per-approval ephemerals mean a long-term key compromise YEARS later cannot recover any prior approval — the ephemerals were never written to disk past one-shot use.

Sibling claude tab #1 flagged this on AIRC: raw "encrypt to static pubkey" without FS means a leaked long-term key retroactively decrypts every prior approval. This addresses that head-on.

## Identity binding via airc whois, not gh login

Per Joel's design note (gh-account-can-be-many-agents): trust must key on AIRC peer/session/whois identity. The knocker_pub IS that binding — each agent generates its own ephemeral, so one gh login can knock from N agents without conflating identity.

## Validation

- \`python3 test/test_approve.py\` — **10/10 PASS** (dispatch + validation + crypto roundtrip + tamper-resistance + wrong-knocker-priv-fails + envelope embedding)
- \`python3 test/test_knock.py\` — 7/7 still PASS (no PR-1 regression)
- \`python3 test/test_inbox.py\` — 4/4 still PASS
- \`python3 test/test_codex_hook.py\` — 7/7 still PASS
- \`bash -n airc lib/airc_bash/cmd_knock.sh lib/airc_bash/cmd_approve.sh\` — clean

## Out of scope (deferred)

- **PR-2c**: knocker-side state management at \$AIRC_WRITE_DIR/knock-state/ so priv keys save automatically (vs operator-copy-paste).
- **PR-3**: room-rotation hooks so leaked-old-comment ciphertext can't reopen access.
- **PR-4**: sprint/kanban queue primitives (sibling tab #1's 7-item design spec logged for that PR).

## Crypto detail

- X25519 ECDH → HKDF-SHA256 (info=\`airc-knock-approve-v1\`) → 32-byte ChaCha20-Poly1305 key
- Hex on the wire (not base64) for eyeball-ability + clean JSON-in-markdown embedding
- AEAD nonce: per-message 12 bytes from os.urandom
- Tamper test included: flipping a ciphertext bit → InvalidTag → exit non-zero with clear stderr message (Joel's never-swallow-errors rule)

## Example flow

\`\`\`
knocker$ airc knock CambrianTech/continuum "want to help"
Knock sent: https://github.com/CambrianTech/continuum/issues/N
SAVE THIS PRIVATE KEY — needed to decrypt the approval comment:
  9044a130554fd01ae5a524c1180031057596f6fcb645878666bf78ba4d86d963

approver$ airc approve https://github.com/CambrianTech/continuum/issues/N
Approval posted: <comment-url>

knocker$ airc decrypt-approval https://github.com/CambrianTech/continuum/issues/N --knocker-priv 9044a130...
<the join string>

knocker$ airc join <the join string>
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)