### PR TITLE
feat(queue): nudge verb — surface card to peers (airc#562 PR-3)

### DIFF
--- a/airc
+++ b/airc
@@ -2637,6 +2637,7 @@ case "${1:-help}" in
     echo "  airc queue claim <issue-url> [--owner X]                 Take ownership (status=in-progress)"
     echo "  airc queue release <issue-url> [--reason \"…\"]            Clear ownership (back to pool)"
     echo "  airc queue set-status <issue-url> <state>                Change card status field"
+    echo "  airc queue nudge <issue-url> [--peer @handle]            Surface a queue card to peers"
     echo "  airc msg / send <text>          Broadcast to the default channel"
     echo "  airc msg / send @<peer> <text>  DM a peer (still in the shared log)"
     echo "  airc msg / send @a @b <text>    DM multiple peers (also: @a,b,c)"

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -65,8 +65,11 @@ cmd_queue() {
     set-status)
       _cmd_queue_set_status "$@"
       ;;
+    nudge)
+      _cmd_queue_nudge "$@"
+      ;;
     *)
-      die "queue: unknown subcommand: $subcmd (try: add, list, claim, release, set-status)"
+      die "queue: unknown subcommand: $subcmd (try: add, list, claim, release, set-status, nudge)"
       ;;
   esac
 }
@@ -342,6 +345,7 @@ USAGE
   airc queue claim <issue-url> [--owner X] [--status Y]
   airc queue release <issue-url> [--reason "..."] [--status claimed|blocked]
   airc queue set-status <issue-url> <state>
+  airc queue nudge <issue-url> [--peer @handle] [--message "..."]
 
 DESCRIPTION
   Adds, lists, or mutates queue cards (GitHub issues with airc-queue
@@ -350,8 +354,8 @@ DESCRIPTION
 
 VERB SCOPE
   add / list                   PR-1 (airc#566, merged)
-  claim / release / set-status PR-2 (this PR)
-  nudge                        PR-3 (deferred)
+  claim / release / set-status PR-2 (airc#568, merged)
+  nudge                        PR-3 (this PR)
   heartbeat / stall detection  PR-4 (deferred)
 
 EOF
@@ -665,6 +669,180 @@ _cmd_queue_set_status() {
     --set "status=$new_status"
 }
 
+_cmd_queue_nudge() {
+  # Surface a queue card to peers via airc msg (broadcast or DM), and
+  # annotate the card's status log with the nudge event. NO status mutation.
+  #
+  # Args:
+  #   airc queue nudge <issue-url> [--peer @handle] [--message "..."] [--dry-run]
+  #
+  # The nudge IS an action, not a WHO-is-idle decision. Recipients filter +
+  # decide whether to claim. Heartbeat/stall-driven auto-pickup stays out of
+  # scope for PR-3 (PR-4 territory per airc#562).
+
+  local issue_url=""
+  local target_peer=""
+  local extra_message=""
+  local dry_run=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -h|--help)
+        _airc_queue_nudge_help
+        return 0
+        ;;
+      --peer)     shift; target_peer="${1:-}" ;;
+      --message)  shift; extra_message="${1:-}" ;;
+      --dry-run)  dry_run=1 ;;
+      -*) die "queue nudge: unknown flag: $1" ;;
+      *)
+        if [ -z "$issue_url" ]; then
+          issue_url="$1"
+        else
+          die "queue nudge: too many positional args (use: queue nudge <url> [--peer @h] [--message ...])"
+        fi
+        ;;
+    esac
+    shift || true
+  done
+
+  if [ -z "$issue_url" ]; then
+    _airc_queue_nudge_help >&2
+    return 1
+  fi
+
+  # Normalize --peer: strip a single leading '@' if present, validate non-empty.
+  # Joel's protocol-not-client + handle convention: peers identified by AIRC
+  # whois name (claude-tab-#1, codex, continuum-8e97, etc.). NOT gh login.
+  if [ -n "$target_peer" ]; then
+    target_peer="${target_peer#@}"
+    if [ -z "$target_peer" ]; then
+      die "queue nudge: --peer expects a handle (got empty after stripping @)"
+    fi
+  fi
+
+  local parsed_issue repo issue_num
+  if ! parsed_issue=$(_airc_queue_parse_issue_url "$issue_url"); then
+    die "queue nudge: <issue-url> must be a GitHub issue URL or owner/repo#N (got: $issue_url)"
+  fi
+  repo="${parsed_issue%#*}"
+  issue_num="${parsed_issue##*#}"
+
+  if ! command -v gh >/dev/null 2>&1; then
+    die "queue nudge: 'gh' CLI is required."
+  fi
+
+  # Verify the issue exists + has a kind=airc-queue-card-v1 envelope. Pull
+  # title + current status for the broadcast text. Use temp file to dodge
+  # stdin contention with the python heredoc (standard idiom in this module
+  # per Codex's review fixes on PR-1+PR-2).
+  local issue_blob
+  if ! issue_blob=$(gh issue view "$issue_num" --repo "$repo" --json title,body 2>&1); then
+    die "queue nudge: gh issue view failed for $repo#$issue_num: $issue_blob"
+  fi
+
+  local issue_file
+  issue_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-nudge-issue.XXXXXX") || die "queue nudge: mktemp failed"
+  printf '%s' "$issue_blob" >"$issue_file"
+
+  local card_meta
+  if ! card_meta=$("$AIRC_PYTHON" - "$issue_file" <<'PYEOF'
+import json, re, sys
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    issue = json.load(f)
+title = issue.get("title", "(no title)")
+body = issue.get("body", "") or ""
+CARD_BLOCK_RE = re.compile(r'```json\s*\n(.*?)\n\s*```', re.DOTALL)
+card = None
+for m in CARD_BLOCK_RE.finditer(body):
+    try:
+        parsed = json.loads(m.group(1).strip())
+    except Exception:
+        continue
+    if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
+        card = parsed
+        break
+if card is None:
+    print("ERR:no-envelope", file=sys.stderr)
+    sys.exit(2)
+status = (card.get("status") or "").strip() or "unknown"
+owner = (card.get("owner") or "").strip()
+# Tab-separated for shell-friendly parse.
+print(f"{title}\t{status}\t{owner}")
+PYEOF
+  ); then
+    rm -f "$issue_file"
+    die "queue nudge: $repo#$issue_num is not a valid airc-queue-card-v1 envelope"
+  fi
+  rm -f "$issue_file"
+
+  local card_title card_status card_owner
+  card_title=$(printf '%s' "$card_meta" | awk -F'\t' '{print $1}')
+  card_status=$(printf '%s' "$card_meta" | awk -F'\t' '{print $2}')
+  card_owner=$(printf '%s' "$card_meta" | awk -F'\t' '{print $3}')
+
+  local actor
+  actor=$(_airc_queue_resolve_name)
+
+  # Compose nudge broadcast text. One-line, prefixed with "nudge:" so peers
+  # can filter (per QUEUE.md broadcast hooks in continuum#1110 .airc/).
+  local nudge_text
+  if [ -n "$target_peer" ]; then
+    nudge_text="nudge: ${repo}#${issue_num} → @${target_peer} — ${card_title} (status=${card_status}"
+  else
+    nudge_text="nudge: ${repo}#${issue_num} — ${card_title} (status=${card_status}"
+  fi
+  if [ -n "$card_owner" ]; then
+    nudge_text="${nudge_text}, owner=${card_owner}"
+  fi
+  nudge_text="${nudge_text})"
+  if [ -n "$extra_message" ]; then
+    nudge_text="${nudge_text} — ${extra_message}"
+  fi
+  nudge_text="${nudge_text} — claim with: airc queue claim ${repo}#${issue_num}"
+
+  # Status log message for the card body annotation.
+  local log_msg
+  if [ -n "$target_peer" ]; then
+    log_msg="$actor nudged @${target_peer}"
+  else
+    log_msg="$actor nudged (broadcast)"
+  fi
+  if [ -n "$extra_message" ]; then
+    log_msg="${log_msg}: ${extra_message}"
+  fi
+
+  if [ "$dry_run" = "1" ]; then
+    echo "  [dry-run] would broadcast: ${nudge_text}"
+    echo "  [dry-run] would annotate ${repo}#${issue_num} status log: ${log_msg}"
+    return 0
+  fi
+
+  # Send the nudge. DM if --peer set, broadcast otherwise. Use --internal so
+  # the nudge doesn't trigger the post-send-poll loop on the sender's side
+  # (Codex/non-Monitor runtimes already have their own inbox poll cadence;
+  # we don't want every nudge to also dump the sender's inbox to stdout).
+  # Actually NOT --internal — recipients should see the broadcast in their
+  # inbox stream like normal traffic. The post-send-poll fires on sender
+  # side, not on receiver side, so it's a sender-side ergonomic that
+  # nudge senders probably want. Leave it as a normal send.
+  if [ -n "$target_peer" ]; then
+    if ! cmd_send "@${target_peer}" "$nudge_text"; then
+      die "queue nudge: cmd_send to @${target_peer} failed"
+    fi
+  else
+    if ! cmd_send "$nudge_text"; then
+      die "queue nudge: cmd_send broadcast failed"
+    fi
+  fi
+
+  # Annotate the card body via the same mutate path used by claim/release/
+  # set-status. NO actual field changes — log_msg-only entry to the status
+  # log. The mutate helper appends the entry; absence of --set/--clear
+  # leaves field values untouched.
+  _airc_queue_mutate_card "$issue_url" 0 "$log_msg"
+}
+
 _airc_queue_mutate_card() {
   # Update an existing card body in place.
   # Args: <issue_url> <dry_run> <log_msg> [--set field=value | --clear field]...
@@ -889,5 +1067,47 @@ OPTIONS
 NOTES
   - Does NOT close the issue automatically when set to merged. Operators
     close manually so the queue tracks closure events explicitly.
+EOF
+}
+
+_airc_queue_nudge_help() {
+  cat <<'EOF'
+airc queue nudge — surface a queue card to peers (broadcast or DM)
+
+USAGE
+  airc queue nudge <issue-url> [--peer @handle] [--message "..."] [--dry-run]
+  airc queue nudge owner/repo#N [--peer @handle] [--message "..."] [--dry-run]
+
+ARGUMENTS
+  <issue-url>        GitHub issue URL OR owner/repo#N reference. The issue
+                     must contain a valid kind=airc-queue-card-v1 envelope.
+
+OPTIONS
+  --peer @handle     DM the nudge to a specific peer. Default: broadcast to
+                     the current scope's room.
+  --message "..."    Optional one-line explanation appended to the nudge
+                     ("nudge: #1125 — pickup needed before EOD" etc.).
+  --dry-run          Print the broadcast text + status-log entry that
+                     WOULD be written; don't send or edit.
+  -h, --help         This help.
+
+WHAT IT DOES
+  1. Verifies the issue is a real airc-queue card (envelope exists).
+  2. Composes a one-line nudge: "nudge:<repo>#<N> [→ @peer] — <title> (<status>)
+     [— <message>]"
+  3. Sends via airc msg (broadcast OR DM if --peer), so peers see it in
+     their inbox stream alongside other AIRC traffic.
+  4. Appends a status-log entry to the card body recording who nudged + when
+     + target peer (if any). Same _airc_queue_mutate_card path as
+     claim/release/set-status — no new wire format.
+
+NOTES
+  - Nudge is the ACTION; the WHO-is-idle decision lives upstream. Peers
+    receiving a nudge decide for themselves whether to claim the card.
+  - Heartbeat / stall-detection (auto-pickup of cards whose owner went
+    silent) is intentionally out of scope here — see airc#562 PR-4
+    backlog and `.airc/ASSEMBLY-LINE.md` in continuum#1110.
+  - Status field is NOT changed by nudge. Use airc queue set-status if you
+    need to mark the card differently.
 EOF
 }

--- a/test/test_queue_nudge.py
+++ b/test/test_queue_nudge.py
@@ -136,6 +136,12 @@ class QueueNudgeDispatchTests(unittest.TestCase):
         self.assertIn("nudge", result.stdout,
                       "top-level help must list 'nudge' verb")
 
+    def test_global_help_lists_nudge_verb(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(["help"], env_overrides=_isolated_env(tmp))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("airc queue nudge", result.stdout)
+
 
 class QueueNudgeValidationTests(unittest.TestCase):
     def test_missing_url_fails(self) -> None:

--- a/test/test_queue_nudge.py
+++ b/test/test_queue_nudge.py
@@ -1,0 +1,286 @@
+"""Tests for `airc queue nudge` (airc#562 PR-3).
+
+Coverage:
+  - dispatch: nudge reaches _cmd_queue_nudge + --help
+  - top-level help lists nudge
+  - validation: missing URL / malformed URL / non-card body fails
+  - dry-run prints expected broadcast text + status-log entry, no gh call
+  - dry-run with --peer @h emits DM-style text + per-peer log entry
+  - dry-run with --message "..." appends the message
+  - --peer strips leading @ correctly
+  - empty --peer (just "@") fails fast
+  - title + status pulled from card envelope into broadcast
+  - nudge does NOT mutate status (no --set/--clear in mutate-card call)
+  - non-airc-card body rejected before any send
+
+Real `cmd_send` + `gh issue edit` aren't exercised — dry-run path covers
+the full envelope-parse + broadcast-text-shape + log-entry-shape end-to-end
+without hitting transport.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+AIRC_BIN = REPO_ROOT / "airc"
+
+
+def run_airc(args: list[str], env_overrides: dict[str, str] | None = None,
+             cwd: str | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [str(AIRC_BIN), *args],
+        capture_output=True, text=True, env=env,
+        cwd=cwd or str(REPO_ROOT), timeout=15,
+    )
+
+
+def _isolated_env(tmp: str) -> dict[str, str]:
+    return {
+        "HOME": tmp,
+        "AIRC_HOME": str(pathlib.Path(tmp) / ".airc"),
+        "AIRC_NO_IDENTITY_PROMPT": "1",
+        "PATH": "/usr/bin:/bin",
+    }
+
+
+VALID_CARD_BODY = '''**airc-queue card**
+
+Sample card for nudge tests.
+
+```json
+{
+  "kind": "airc-queue-card-v1",
+  "owner": "claude-tab-1",
+  "status": "in-progress",
+  "branch": "feat/nudge-test"
+}
+```
+
+Close this issue when the work is done.
+'''
+
+NON_CARD_BODY = '''Plain issue body with no airc-queue-card-v1 envelope.
+
+Just markdown, no JSON code block matching the kind we want.
+'''
+
+
+def _isolated_env_with_fake_gh(tmp: str, body_response: str | None = None) -> dict[str, str]:
+    """Stub `gh` so issue-view returns a chosen body and issue-edit no-ops.
+    Same shape as test_queue_claim's helper — non-dry-run path would call
+    gh to fetch + edit the body, dry-run still calls gh issue view to
+    verify the card exists before declining to send/mutate."""
+    fakebin = pathlib.Path(tmp) / "bin"
+    fakebin.mkdir(exist_ok=True)
+    body = body_response if body_response is not None else VALID_CARD_BODY
+    body_file = pathlib.Path(tmp) / "fake_body.txt"
+    body_file.write_text(body, encoding="utf-8")
+    # Wrap in a JSON envelope so `gh issue view --json title,body` returns
+    # a parseable shape — _cmd_queue_nudge consumes title+body together.
+    import json
+    issue_blob = json.dumps({
+        "title": "Sample card for nudge tests",
+        "body": body,
+    })
+    issue_file = pathlib.Path(tmp) / "fake_issue.json"
+    issue_file.write_text(issue_blob, encoding="utf-8")
+    gh_script = (
+        "#!/bin/sh\n"
+        f'ISSUE_FILE="{issue_file}"\n'
+        f'BODY_FILE="{body_file}"\n'
+        "case \"$1 $2\" in\n"
+        "  'issue view')\n"
+        # If --json present (nudge calls), return the issue blob; else body.
+        "    case \" $* \" in\n"
+        "      *' --json '*) cat \"$ISSUE_FILE\" ;;\n"
+        "      *) cat \"$BODY_FILE\" ;;\n"
+        "    esac\n"
+        "    ;;\n"
+        "  'issue edit') exit 0 ;;\n"
+        "  *) echo '[]' ;;\n"
+        "esac\n"
+    )
+    gh = fakebin / "gh"
+    gh.write_text(gh_script, encoding="utf-8")
+    gh.chmod(0o755)
+    env = _isolated_env(tmp)
+    env["PATH"] = f"{fakebin}:/usr/bin:/bin"
+    env["AIRC_GH_BIN"] = str(gh)
+    return env
+
+
+class QueueNudgeDispatchTests(unittest.TestCase):
+    def test_nudge_help_returns_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(["queue", "nudge", "--help"],
+                              env_overrides=_isolated_env(tmp))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--peer", result.stdout)
+        self.assertIn("--message", result.stdout)
+        self.assertIn("--dry-run", result.stdout)
+
+    def test_top_help_lists_nudge_verb(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(["queue", "--help"],
+                              env_overrides=_isolated_env(tmp))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("nudge", result.stdout,
+                      "top-level help must list 'nudge' verb")
+
+
+class QueueNudgeValidationTests(unittest.TestCase):
+    def test_missing_url_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(["queue", "nudge"],
+                              env_overrides=_isolated_env(tmp))
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_malformed_url_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(["queue", "nudge", "not-a-url"],
+                              env_overrides=_isolated_env_with_fake_gh(tmp))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("owner/repo", result.stdout + result.stderr)
+
+    def test_non_card_body_rejected_before_send(self) -> None:
+        # nudge must verify the issue is a real airc-queue card BEFORE
+        # broadcasting — otherwise random issues could spam the room.
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "nudge", "owner/repo#1", "--dry-run"],
+                env_overrides=_isolated_env_with_fake_gh(tmp, body_response=NON_CARD_BODY),
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("airc-queue-card-v1", result.stdout + result.stderr)
+
+    def test_empty_peer_after_at_strip_fails(self) -> None:
+        # --peer "@" alone (just the @ with no handle) must fail fast.
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "nudge", "owner/repo#1", "--peer", "@", "--dry-run"],
+                env_overrides=_isolated_env_with_fake_gh(tmp),
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--peer", result.stdout + result.stderr)
+
+
+class QueueNudgeDryRunTests(unittest.TestCase):
+    def test_dry_run_broadcast_includes_card_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "nudge", "owner/repo#1", "--dry-run"],
+                env_overrides=_isolated_env_with_fake_gh(tmp),
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        out = result.stdout
+        # Broadcast text contains card title + status + claim hint
+        self.assertIn("nudge:", out)
+        self.assertIn("owner/repo#1", out)
+        self.assertIn("Sample card for nudge tests", out)
+        self.assertIn("status=in-progress", out)
+        self.assertIn("airc queue claim", out)
+
+    def test_dry_run_includes_owner_when_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "nudge", "owner/repo#1", "--dry-run"],
+                env_overrides=_isolated_env_with_fake_gh(tmp),
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        # Card has owner=claude-tab-1; broadcast surfaces it
+        self.assertIn("owner=claude-tab-1", result.stdout)
+
+    def test_dry_run_with_peer_renders_dm_style(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "nudge", "owner/repo#1",
+                 "--peer", "@codex", "--dry-run"],
+                env_overrides=_isolated_env_with_fake_gh(tmp),
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        out = result.stdout
+        # @ strip happened; DM target appears in broadcast text
+        self.assertIn("→ @codex", out)
+        # Status log line names the target peer
+        self.assertIn("nudged @codex", out)
+
+    def test_dry_run_with_peer_no_at_prefix_works(self) -> None:
+        # Operators can pass "codex" or "@codex" — both should work.
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "nudge", "owner/repo#1",
+                 "--peer", "codex", "--dry-run"],
+                env_overrides=_isolated_env_with_fake_gh(tmp),
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        # Same DM rendering whether @ was supplied or not
+        self.assertIn("→ @codex", result.stdout)
+
+    def test_dry_run_without_peer_renders_broadcast_style(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "nudge", "owner/repo#1", "--dry-run"],
+                env_overrides=_isolated_env_with_fake_gh(tmp),
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        out = result.stdout
+        # No "→ @" arrow when no --peer specified
+        self.assertNotIn("→ @", out)
+        # Status log marks it as broadcast
+        self.assertIn("nudged (broadcast)", out)
+
+    def test_dry_run_with_message_appends_text(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "nudge", "owner/repo#1",
+                 "--message", "needs eyes before EOD",
+                 "--dry-run"],
+                env_overrides=_isolated_env_with_fake_gh(tmp),
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        out = result.stdout
+        # Message appears in broadcast text
+        self.assertIn("needs eyes before EOD", out)
+
+    def test_dry_run_does_not_mutate_card_status(self) -> None:
+        # nudge MUST NOT change the status field (status mutation goes
+        # through set-status, not nudge).
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "nudge", "owner/repo#1", "--dry-run"],
+                env_overrides=_isolated_env_with_fake_gh(tmp),
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        out = result.stdout
+        # The dry-run preview names the log entry but should NOT contain
+        # any "set status=" or "would set: status=" affordance.
+        # (Card status is RENDERED in the broadcast text — that's the
+        # current value being communicated, not a mutation.)
+        # Sanity: our log_msg doesn't include "set:" tokens.
+        self.assertNotIn("would set: status", out)
+        self.assertNotIn("set:status=", out)
+
+    def test_short_issue_ref_parses_on_macos_bash3(self) -> None:
+        # Same regression check claude tab #2's PR-2 had — reuses the
+        # _airc_queue_parse_issue_url helper which had the bash 3 local -n bug.
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "nudge", "owner/repo#1", "--dry-run"],
+                env_overrides=_isolated_env_with_fake_gh(tmp),
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("owner/repo#1", result.stdout)
+        self.assertNotIn("local: -n", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR-3 of the airc#562 queue verb series. Adds \`airc queue nudge\` — surface a queue card to peers via broadcast or DM, with status-log annotation. Continues claude tab #2's series after PR-1 (#566 add/list, merged) and PR-2 (#568 claim/release/set-status, merged); claude tab #2 explicitly yielded this PR-3 to me on AIRC.

## What lands

\`\`\`bash
airc queue nudge <issue-url> [--peer @handle] [--message "..."] [--dry-run]
\`\`\`

- Verifies the issue is a real \`airc-queue-card-v1\` envelope (rejects random non-card issues BEFORE any send — prevents spam vector)
- Composes a one-line nudge: \`nudge: <repo>#<N> [→ @peer] — <title> (status=..., owner=...) — claim with: airc queue claim <repo>#<N>\`
- Sends via \`cmd_send\` (broadcast OR DM if \`--peer\`)
- Annotates the card body status log via the same \`_airc_queue_mutate_card\` path used by claim/release/set-status — no new wire format
- **NOTHING ELSE**: no status change, no ownership change, no heartbeat/stall logic. Nudge is the action; recipients filter + decide whether to claim.

## What's NOT in scope

- **Idle detection** — WHO-is-idle is a separate concern; nudge is fire-and-forget.
- **Heartbeat / stall-driven auto-pickup** — stays as PR-4 (claude tab #1's 7-req design from earlier today + the 30min cadence in continuum/.airc/ASSEMBLY-LINE.md).
- **Cognition-aware routing intelligence** — airc#572 is the layer above; nudge stays dumb broadcast/DM. Routing can be advisory on top, not central.

## Conventions followed

- \`--peer\` accepts handle with or without leading \`@\`; both normalized. Empty after strip (\`@\` alone) fails fast.
- Per Joel's protocol-not-client + handle-not-gh-login conventions: \`--peer\` addresses AIRC whois identity (claude-tab-1, codex, continuum-8e97), NOT a github account.
- Status-log entry shape mirrors PR-2 idiom.
- Empty mutations (just log_msg, no \`--set\`/\`--clear\`) is a supported use of \`_airc_queue_mutate_card\` — empty mutations_raw loop is no-op, log entry still appends.
- Top-level help updated: nudge listed in USAGE + VERB SCOPE section now shows PR-1/PR-2 merged, PR-3 (this PR), PR-4 deferred.

## Test plan

- [x] **New test/test_queue_nudge.py: 14/14 PASS**
  - Dispatch: nudge --help + top-level help lists nudge
  - Validation: missing URL / malformed URL / non-card body rejected BEFORE send / empty --peer after @ strip rejected
  - Dry-run: broadcast text contains card title + status + claim hint + owner; --peer renders DM-style with → arrow + targeted log entry; no --peer renders broadcast log entry; --message appends; @ prefix optional on --peer; bash 3 macOS regression on issue-url parser
  - Crucially: nudge does NOT mutate card status (no \`set:status=\` tokens in dry-run output)
- [x] test_queue.py: 16/16 PASS (no PR-1 regression)
- [x] test_queue_claim.py: 17/17 PASS (no PR-2 regression)
- [x] \`bash -n\` clean on \`airc\` + \`lib/airc_bash/cmd_queue.sh\`
- [x] Secrets audit clean

## Coordination history

Claude tab #2 (claimed PR-1 + PR-2 in same session) explicitly yielded PR-3: *"YIELDING airc#562 PR-3 (nudge) to sibling tab #1 — go ahead. Your scoped spec is right."* No race risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)