### PR TITLE
fix(#571): route every gh body write through --body-file (lib_gh.sh)

### DIFF
--- a/airc
+++ b/airc
@@ -1218,6 +1218,20 @@ else
   echo "ERROR: airc_bash/lib_daemon_detect.sh not found via lib-dir resolver." >&2
   exit 1
 fi
+
+# ── gh wrapper helpers ──────────────────────────────────────────────────
+# _airc_gh_safe_body — wrap every gh invocation that posts a Markdown
+# body so it goes through --body-file (temp file) instead of --body
+# (argv). See doc-comment in lib_gh.sh for the rationale (airc#571).
+# Sourced unconditionally so cmd_knock / cmd_approve / cmd_queue (and
+# any future module that posts to GitHub) get it for free.
+if [ -n "${_airc_lib_dir:-}" ] && [ -f "$_airc_lib_dir/airc_bash/lib_gh.sh" ]; then
+  # shellcheck source=lib/airc_bash/lib_gh.sh
+  source "$_airc_lib_dir/airc_bash/lib_gh.sh"
+else
+  echo "ERROR: airc_bash/lib_gh.sh not found via lib-dir resolver." >&2
+  exit 1
+fi
 # ── End daemon-installed detector ───────────────────────────────────────
 
 relay_ssh() {

--- a/lib/airc_bash/cmd_approve.sh
+++ b/lib/airc_bash/cmd_approve.sh
@@ -149,7 +149,11 @@ cmd_approve() {
   fi
 
   local comment_url
-  if ! comment_url=$(gh issue comment "$issue_num" --repo "$repo" --body "$comment_body" 2>&1); then
+  # --body-file via lib_gh.sh — approval comments embed an ```json``` AEAD
+  # envelope and prose around it; backticks must NOT trigger command
+  # substitution at any layer (airc#571).
+  if ! comment_url=$(_airc_gh_safe_body "$comment_body" issue comment "$issue_num" \
+    --repo "$repo"); then
     die "approve: gh issue comment failed: $comment_url"
   fi
 

--- a/lib/airc_bash/cmd_knock.sh
+++ b/lib/airc_bash/cmd_knock.sh
@@ -159,16 +159,17 @@ cmd_knock() {
   # doesn't exist, fall back to no-label (still a valid issue, just
   # less filterable).
   local issue_url
-  if issue_url=$(gh issue create \
+  # Body goes via --body-file (lib_gh.sh) so embedded backticks / fenced
+  # code blocks / $-vars in the knock message can't trigger shell
+  # command substitution and can't blow argv length limits (airc#571).
+  if issue_url=$(_airc_gh_safe_body "$issue_body" issue create \
     --repo "$target_repo" \
     --title "$issue_title" \
-    --body "$issue_body" \
-    --label "airc-knock" 2>&1); then
+    --label "airc-knock"); then
     :
-  elif issue_url=$(gh issue create \
+  elif issue_url=$(_airc_gh_safe_body "$issue_body" issue create \
     --repo "$target_repo" \
-    --title "$issue_title" \
-    --body "$issue_body" 2>&1); then
+    --title "$issue_title"); then
     # Owner repo doesn't have the airc-knock label yet — issue still
     # posts. Surface a note so the operator knows to add the label.
     printf 'note: %s does not have an "airc-knock" label yet. The issue posted without one — repo owner may want to add the label for filtering.\n' "$target_repo" >&2

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -166,17 +166,17 @@ _cmd_queue_add() {
 
   # Try with airc-queue label first; fall back to no label if it doesn't
   # exist yet on the target repo (same pattern as cmd_knock).
+  # Body goes via --body-file (lib_gh.sh) — card bodies routinely embed
+  # ```json``` fences and a status log of backticked refs (airc#571).
   local issue_url
-  if issue_url=$(gh issue create \
+  if issue_url=$(_airc_gh_safe_body "$issue_body" issue create \
     --repo "$target_repo" \
     --title "$issue_title" \
-    --body "$issue_body" \
-    --label "airc-queue" 2>&1); then
+    --label "airc-queue"); then
     :
-  elif issue_url=$(gh issue create \
+  elif issue_url=$(_airc_gh_safe_body "$issue_body" issue create \
     --repo "$target_repo" \
-    --title "$issue_title" \
-    --body "$issue_body" 2>&1); then
+    --title "$issue_title"); then
     printf 'note: %s does not have an "airc-queue" label yet. Card posted without one.\n' "$target_repo" >&2
   else
     die "queue add: gh issue create failed: $issue_url"
@@ -806,8 +806,12 @@ PYEOF
     return 0
   fi
 
-  if ! gh issue edit "$issue_num" --repo "$repo" --body "$new_body" >/dev/null 2>&1; then
-    die "queue mutate: gh issue edit failed for $repo#$issue_num"
+  # --body-file via lib_gh.sh — mutated card bodies always contain a
+  # ```json``` fence and a Status log of backticked refs (airc#571).
+  local edit_out
+  if ! edit_out=$(_airc_gh_safe_body "$new_body" issue edit "$issue_num" \
+    --repo "$repo"); then
+    die "queue mutate: gh issue edit failed for $repo#$issue_num: $edit_out"
   fi
 
   printf 'Updated %s#%s: %s\n' "$repo" "$issue_num" "$log_msg"

--- a/lib/airc_bash/lib_gh.sh
+++ b/lib/airc_bash/lib_gh.sh
@@ -1,0 +1,106 @@
+# Sourced by airc. lib_gh — shared helpers for invoking the `gh` CLI safely
+# from airc command modules.
+#
+# Why this exists (airc#571):
+#   GitHub issue/PR/comment bodies are Markdown — they routinely contain
+#   backticks, fenced code blocks, $-vars, and single quotes. Two failure
+#   modes have bitten Codex on canary:
+#
+#     1. Heredoc-construction at variable-build time. If a body is
+#        constructed via $(cat <<EOF ... EOF) where the EOF terminator
+#        isn't single-quoted, embedded backticks/$(...) execute as
+#        command substitution AT VARIABLE-BUILD TIME. The resulting body
+#        is missing the substituted text or contains command output
+#        instead of the literal Markdown.
+#
+#     2. argv-length limit on `--body "$x"`. ARG_MAX on macOS/Linux is
+#        ~256KB. A queue card with a long status log + multiple cards
+#        worth of cross-references can approach that. argv overflow is
+#        silent: gh runs but with truncated body.
+#
+#   The fix here is API-shaped: every gh invocation that takes a body
+#   goes through `_airc_gh_safe_body`, which writes the body to a temp
+#   file and passes it via `--body-file`. That eliminates BOTH classes
+#   in one place — callers can't accidentally use `--body` and miss the
+#   protection (because the helper hides the flag entirely).
+#
+# Companion guidance for callers:
+#   - Build the body string with single-quoted heredoc terminators
+#     (`<<'EOF' ... EOF`) so backticks are inert at construction time.
+#   - Then pass that string as the FIRST arg to _airc_gh_safe_body.
+#     The helper handles the file-and-flag plumbing.
+#
+# Functions exported:
+#   _airc_gh_safe_body — write a body to a temp file and call gh with
+#                        --body-file. See doc-comment on the function.
+# ----------------------------------------------------------------------
+
+_airc_gh_safe_body() {
+  # Invoke `gh` with a long/Markdown body via --body-file, never --body.
+  #
+  # USAGE
+  #   _airc_gh_safe_body <body-string> <gh-args...>
+  #
+  # EXAMPLES
+  #   _airc_gh_safe_body "$issue_body" issue create \
+  #     --repo "$target_repo" --title "$title" --label "airc-knock"
+  #
+  #   _airc_gh_safe_body "$comment_body" issue comment "$issue_num" \
+  #     --repo "$repo"
+  #
+  #   _airc_gh_safe_body "$new_body" issue edit "$issue_num" \
+  #     --repo "$repo"
+  #
+  # CONTRACT (matches the previous `gh ... 2>&1` pattern callers used)
+  #   - Stdout: gh's stdout (URL on success, error text on failure).
+  #   - Stderr: also captured to stdout via 2>&1, mirroring the existing
+  #     idiom so callers can keep `if out=$(_airc_gh_safe_body ...); then`
+  #     unchanged.
+  #   - Return code: 0 on gh success, gh's non-zero exit on failure,
+  #     2 if the temp file couldn't be created (extremely rare).
+  #   - Temp file is removed on every code path including gh failure.
+  #
+  # WHY a temp file (not stdin or process substitution)
+  #   - `--body-file -` would read stdin, but airc's call sites already
+  #     compose other commands via $(...) capture; mixing pipe-stdin
+  #     with capture-stdout is exactly the contention pattern Codex
+  #     caught in cmd_approve.sh / cmd_queue.sh during PR review.
+  #   - Process substitution (`<(printf '%s' "$body")`) requires bash
+  #     features that vary across the airc-supported shell zoo; the
+  #     temp-file path works on bash 3.2 (macOS default) and up.
+  if [ "$#" -lt 2 ]; then
+    printf 'airc: _airc_gh_safe_body needs <body> <gh-args...>\n' >&2
+    return 2
+  fi
+
+  local body="$1"
+  shift
+
+  local body_file
+  if ! body_file=$(mktemp -t airc-gh-body.XXXXXX 2>/dev/null); then
+    # Some BusyBox mktemp variants don't accept -t; fall back to TMPDIR.
+    local tmpdir="${TMPDIR:-/tmp}"
+    body_file="$tmpdir/airc-gh-body.$$.$RANDOM"
+    if ! : > "$body_file" 2>/dev/null; then
+      printf 'airc: _airc_gh_safe_body could not create temp file under %s\n' "$tmpdir" >&2
+      return 2
+    fi
+  fi
+
+  # printf '%s' is intentional: no trailing newline is appended that the
+  # caller didn't already include. Bodies built via heredoc already end
+  # with a newline; bodies built via printf '%s\n' do too. Adding a
+  # second newline here would silently grow every card on every mutate.
+  printf '%s' "$body" > "$body_file"
+
+  local out
+  local rc=0
+  out=$(gh "$@" --body-file "$body_file" 2>&1) || rc=$?
+
+  rm -f "$body_file"
+
+  # Preserve gh's output verbatim. No trailing newline added — same
+  # contract as $(gh ... 2>&1) which the call sites previously used.
+  printf '%s' "$out"
+  return $rc
+}

--- a/test/test_gh_safe_body.py
+++ b/test/test_gh_safe_body.py
@@ -1,0 +1,327 @@
+"""Tests for `_airc_gh_safe_body` — shell-safe gh body writes (airc#571).
+
+Coverage:
+  - helper exists in lib_gh.sh and is sourced unconditionally by `airc`
+  - helper invokes gh with --body-file (NEVER --body) so backticks /
+    fenced code blocks / $-vars in the body can't trigger shell command
+    substitution and can't blow argv length limits
+  - body bytes round-trip exactly (newlines, leading/trailing whitespace,
+    no spurious extra newline appended by the helper)
+  - all three current call-site modules (cmd_knock, cmd_approve,
+    cmd_queue) route through the helper — greppable invariant
+  - error path: gh non-zero exit propagates; temp file is cleaned up
+  - tiny edge: helper rejects missing args (return 2, no gh call)
+
+The fake `gh` here is a recording stub: it captures every --body-file
+content into a known location so the test can assert what got passed to
+gh. Real GitHub auth is never exercised.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+AIRC_BIN = REPO_ROOT / "airc"
+LIB_GH = REPO_ROOT / "lib" / "airc_bash" / "lib_gh.sh"
+
+
+def _isolated_env(tmp: str) -> dict[str, str]:
+    return {
+        "HOME": tmp,
+        "AIRC_HOME": str(pathlib.Path(tmp) / ".airc"),
+        "AIRC_NO_IDENTITY_PROMPT": "1",
+        "PATH": "/usr/bin:/bin",
+    }
+
+
+def _make_recording_gh(tmp: str, exit_code: int = 0,
+                      stdout_text: str = "https://github.com/owner/repo/issues/9999\n",
+                      stderr_text: str = "") -> tuple[pathlib.Path, pathlib.Path]:
+    """Build a fake `gh` script that:
+      - copies every --body-file argument's content to record_dir/body.txt
+      - records every --body argument text to record_dir/body-arg.txt
+        (so the test can assert it's NEVER touched)
+      - records the full argv to record_dir/argv.txt
+      - exits with `exit_code` after printing stdout/stderr
+    Returns (gh_path, record_dir).
+    """
+    fakebin = pathlib.Path(tmp) / "bin"
+    fakebin.mkdir(exist_ok=True)
+    record_dir = pathlib.Path(tmp) / "gh-record"
+    record_dir.mkdir(exist_ok=True)
+    gh = fakebin / "gh"
+    gh.write_text(
+        "#!/bin/sh\n"
+        f'RECORD_DIR="{record_dir}"\n'
+        f'EXIT_CODE={exit_code}\n'
+        # Save full argv (one per line) so the test can grep for --body / --body-file.
+        'for a in "$@"; do printf "%s\\n" "$a"; done > "$RECORD_DIR/argv.txt"\n'
+        'while [ $# -gt 0 ]; do\n'
+        '  case "$1" in\n'
+        '    --body-file)\n'
+        '      shift\n'
+        '      cp "$1" "$RECORD_DIR/body.txt" 2>/dev/null || true\n'
+        '      shift\n'
+        '      ;;\n'
+        '    --body)\n'
+        '      shift\n'
+        '      printf "%s" "$1" > "$RECORD_DIR/body-arg.txt"\n'
+        '      shift\n'
+        '      ;;\n'
+        '    *) shift ;;\n'
+        '  esac\n'
+        'done\n'
+        f'printf "%s" {repr(stdout_text)}\n'
+        + (f'printf "%s" {repr(stderr_text)} >&2\n' if stderr_text else '')
+        + 'exit $EXIT_CODE\n',
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    return gh, record_dir
+
+
+def _run_helper_directly(body: str, gh_args: list[str], tmp: str,
+                         exit_code: int = 0,
+                         stdout_text: str = "https://github.com/owner/repo/issues/9999\n",
+                         stderr_text: str = "",
+                         extra_env: dict[str, str] | None = None
+                         ) -> tuple[subprocess.CompletedProcess[str], pathlib.Path]:
+    """Source lib_gh.sh in a sub-bash and call _airc_gh_safe_body with
+    the supplied body + gh args. Returns (CompletedProcess, record_dir).
+
+    The recording fake-gh is on PATH so the helper invokes IT instead of
+    real gh; the body file content lands in record_dir/body.txt for
+    assertion.
+
+    Body is written to a temp file and read back inside the bash script
+    via `cat` — that way the body bytes are NEVER re-quoted on the
+    bash command line (which is exactly the failure mode we're testing
+    the helper protects against; the test must not become an instance
+    of the bug it's testing).
+    """
+    gh, record_dir = _make_recording_gh(tmp, exit_code=exit_code,
+                                        stdout_text=stdout_text,
+                                        stderr_text=stderr_text)
+    env = _isolated_env(tmp)
+    env["PATH"] = f"{gh.parent}:/usr/bin:/bin"
+    if extra_env:
+        env.update(extra_env)
+
+    # Body via temp file, read back with `cat -- "$BODY_FILE"`.
+    body_file = pathlib.Path(tmp) / "test-body-input.txt"
+    body_file.write_text(body, encoding="utf-8")
+    env["BODY_FILE"] = str(body_file)
+
+    # Args via temp script that literally inlines them — Python's
+    # shlex.quote is the right tool for this job because it produces
+    # POSIX-safe single-quoted argv that bash sees as opaque tokens.
+    import shlex
+    inline_args = " ".join(shlex.quote(a) for a in gh_args)
+
+    bash_script = (
+        f'source "{LIB_GH}"\n'
+        # Read body bytes verbatim from the file (no shell interpretation).
+        'BODY=$(cat -- "$BODY_FILE")\n'
+        # Re-add a trailing newline ONLY if the input file had one — $(cat)
+        # strips trailing newlines per POSIX. Probe via wc + tail.
+        'if [ "$(tail -c 1 -- "$BODY_FILE" | od -An -c | tr -d " ")" = "\\n" ]; then\n'
+        '  BODY="$BODY"$\'\\n\'\n'
+        'fi\n'
+        f'_airc_gh_safe_body "$BODY" {inline_args}\n'
+    )
+    result = subprocess.run(
+        ["bash", "-c", bash_script],
+        capture_output=True, text=True, env=env, timeout=10,
+    )
+    return result, record_dir
+
+
+class HelperRoundtripTests(unittest.TestCase):
+    """Body bytes survive the helper unchanged."""
+
+    def test_plain_body_roundtrips(self) -> None:
+        body = "hello world\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            result, record_dir = _run_helper_directly(
+                body, ["issue", "create", "--repo", "owner/repo", "--title", "T"],
+                tmp,
+            )
+            files = list(record_dir.iterdir())
+            file_names = [f.name for f in files]
+            body_file = record_dir / "body.txt"
+            body_text = body_file.read_text(encoding="utf-8") if body_file.exists() else None
+        self.assertEqual(result.returncode, 0,
+                         f"helper must succeed; stderr={result.stderr!r} stdout={result.stdout!r}")
+        self.assertTrue(body_text is not None,
+                        f"fake gh must have seen --body-file; "
+                        f"record_dir files={file_names}; "
+                        f"stdout={result.stdout!r}; stderr={result.stderr!r}")
+        self.assertEqual(body_text, body,
+                         "body bytes must round-trip exactly")
+
+    def test_backticks_inert_no_command_substitution(self) -> None:
+        # If the helper accidentally evaluated the body, `whoami` would
+        # be replaced by the username. The helper MUST NOT do that.
+        body = "Status: `whoami` should stay literal, not become $(whoami).\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            result, record_dir = _run_helper_directly(
+                body, ["issue", "create", "--repo", "owner/repo", "--title", "T"],
+                tmp,
+            )
+            round_tripped = (record_dir / "body.txt").read_text(encoding="utf-8")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(round_tripped, body)
+        self.assertIn("`whoami`", round_tripped,
+                      "literal backticks must survive — no command substitution")
+        self.assertNotIn(os.environ.get("USER", "should-not-appear-here"),
+                         round_tripped.replace("whoami", ""),
+                         "username must not have leaked into the body")
+
+    def test_fenced_code_block_with_dollar_vars(self) -> None:
+        body = (
+            "Card body:\n"
+            "\n"
+            "```bash\n"
+            "echo $HOME\n"
+            "echo $(date)\n"
+            "echo `pwd`\n"
+            "```\n"
+            "\n"
+            "Done.\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            result, record_dir = _run_helper_directly(
+                body, ["issue", "create", "--repo", "owner/repo", "--title", "T"],
+                tmp,
+            )
+            round_tripped = (record_dir / "body.txt").read_text(encoding="utf-8")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(round_tripped, body,
+                         "fenced code block with $-vars + $() + backticks "
+                         "must survive byte-for-byte")
+
+    def test_no_trailing_newline_added(self) -> None:
+        # Body without trailing \n: helper must not silently grow it.
+        body = "no trailing newline"
+        with tempfile.TemporaryDirectory() as tmp:
+            result, record_dir = _run_helper_directly(
+                body, ["issue", "create", "--repo", "owner/repo", "--title", "T"],
+                tmp,
+            )
+            round_tripped = (record_dir / "body.txt").read_text(encoding="utf-8")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(round_tripped, body, "no trailing newline appended")
+
+
+class HelperFlagDisciplineTests(unittest.TestCase):
+    """The helper must use --body-file, never --body."""
+
+    def test_argv_uses_body_file_not_body(self) -> None:
+        body = "anything"
+        with tempfile.TemporaryDirectory() as tmp:
+            result, record_dir = _run_helper_directly(
+                body, ["issue", "edit", "9", "--repo", "owner/repo"],
+                tmp,
+            )
+            argv = (record_dir / "argv.txt").read_text(encoding="utf-8").splitlines()
+            body_arg_seen = (record_dir / "body-arg.txt").exists()
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("--body-file", argv,
+                      "helper must pass --body-file to gh")
+        self.assertNotIn("--body", argv,
+                         "helper must NEVER pass --body to gh — argv-length "
+                         "limit + future heredoc-construction footgun")
+        self.assertFalse(body_arg_seen,
+                         "fake gh must not have recorded a --body argument")
+
+
+class HelperErrorPathTests(unittest.TestCase):
+    """gh failure propagates; helper rejects bad input."""
+
+    def test_gh_failure_propagates_with_stderr_in_stdout(self) -> None:
+        body = "x"
+        with tempfile.TemporaryDirectory() as tmp:
+            result, _ = _run_helper_directly(
+                body, ["issue", "create", "--repo", "owner/repo", "--title", "T"],
+                tmp, exit_code=1,
+                stdout_text="HTTP 422: validation failed\n",
+                stderr_text="gh stderr text\n",
+            )
+        self.assertEqual(result.returncode, 1,
+                         "helper must propagate gh's non-zero exit")
+        self.assertIn("HTTP 422", result.stdout,
+                      "gh's stdout must reach caller")
+        self.assertIn("gh stderr text", result.stdout,
+                      "gh's stderr must be folded into stdout (2>&1 contract)")
+
+    def test_missing_body_arg_returns_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _isolated_env(tmp)
+            result = subprocess.run(
+                ["bash", "-c",
+                 f'source "{LIB_GH}"; _airc_gh_safe_body'],
+                capture_output=True, text=True, env=env, timeout=5,
+            )
+        self.assertEqual(result.returncode, 2,
+                         "missing args must return 2, not silently call gh")
+        self.assertIn("_airc_gh_safe_body", result.stderr)
+
+
+class CallSiteWiringTests(unittest.TestCase):
+    """All three current modules route gh body writes through the helper.
+
+    Greppable invariant — if a future PR adds a `gh ... --body "$x"`
+    site, this test fails and points the author at the helper.
+    """
+
+    MODULES = (
+        REPO_ROOT / "lib" / "airc_bash" / "cmd_knock.sh",
+        REPO_ROOT / "lib" / "airc_bash" / "cmd_approve.sh",
+        REPO_ROOT / "lib" / "airc_bash" / "cmd_queue.sh",
+    )
+
+    def test_no_module_uses_raw_body_flag(self) -> None:
+        offenders: list[str] = []
+        # Match `--body ` (with trailing space, which is how it's used as
+        # a flag) but NOT `--body-file`. Also exclude `# --body ...` comments.
+        flag_re = re.compile(r'(?<!#)\s--body(?:\s|=)(?!file)')
+        for path in self.MODULES:
+            text = path.read_text(encoding="utf-8")
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                stripped = line.lstrip()
+                if stripped.startswith("#"):
+                    continue
+                if flag_re.search(line):
+                    offenders.append(f"{path.name}:{lineno}: {line.strip()}")
+        self.assertEqual(offenders, [],
+                         "raw `--body` flag found — switch to "
+                         "_airc_gh_safe_body (lib_gh.sh, airc#571):\n"
+                         + "\n".join(offenders))
+
+    def test_helper_sourced_unconditionally_by_airc(self) -> None:
+        # _airc_gh_safe_body must be loaded regardless of which subcommand
+        # dispatches — it's a core safety net, not an opt-in.
+        text = AIRC_BIN.read_text(encoding="utf-8")
+        self.assertIn("airc_bash/lib_gh.sh", text,
+                      "lib_gh.sh must be sourced by the airc dispatcher")
+
+    def test_each_module_calls_helper_at_least_once(self) -> None:
+        # Sanity: every module that posts to gh must actually USE the
+        # helper. If a module stops calling helper entirely, that's a
+        # regression — likely someone replaced it with raw gh.
+        for path in self.MODULES:
+            text = path.read_text(encoding="utf-8")
+            self.assertIn("_airc_gh_safe_body", text,
+                          f"{path.name} must call _airc_gh_safe_body — "
+                          "raw gh body writes were removed in airc#571")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes airc#571 — eliminate shell backtick friction in GitHub body writes.

GitHub bodies are Markdown — backticks, fenced code blocks, `$`-vars, single quotes appear constantly. Two failure modes have bitten Codex on canary:

1. **Heredoc-construction at variable-build time.** `body=$(cat <<EOF ... EOF)` without a single-quoted EOF terminator runs `` `cmd` `` and `$(cmd)` AT BUILD TIME, mangling the body before it ever reaches gh.
2. **argv-length limit on `--body \"\$x\"`.** ARG_MAX ≈ 256KB; a queue card with a long status log can approach that. argv overflow is silent — gh runs but with a truncated body.

Fix is API-shaped: every gh invocation that takes a body goes through `_airc_gh_safe_body`, which writes the body to a temp file and passes via `--body-file`. Eliminates both classes in one place. Callers can't accidentally use `--body` and miss the protection because the helper hides the flag entirely.

## Changes

- **`lib/airc_bash/lib_gh.sh`** (new, ~95 LOC) — `_airc_gh_safe_body` helper. Doc-comment explains why temp-file beats stdin (callers compose with `$(...)` — pipe-stdin + capture-stdout is exactly the contention pattern Codex caught on cmd_approve/cmd_queue reviews). Bash 3.2 compatible (BusyBox mktemp fallback). `2>&1`-equivalent contract preserved so callers keep their `if out=$(_airc_gh_safe_body ...)` patterns unchanged.
- **`airc`** — source `lib_gh.sh` unconditionally near `lib_auth.sh`/`lib_daemon_detect.sh`.
- **`lib/airc_bash/cmd_knock.sh`** — 2 sites (label + fallback) → helper.
- **`lib/airc_bash/cmd_approve.sh`** — 1 site (issue comment with AEAD envelope) → helper.
- **`lib/airc_bash/cmd_queue.sh`** — 3 sites (issue create label + fallback + issue edit on every mutate) → helper.
- **`test/test_gh_safe_body.py`** (new, 10 tests) — helper roundtrip (plain / backticks-inert / fenced code block with `\$vars + \$() + backticks` / no-trailing-newline-added), `--body-file` flag discipline (argv asserted), gh-failure propagation, missing-arg rejection (rc=2), AND a **greppable invariant**: each cmd module must call `_airc_gh_safe_body` AND must not use raw `--body` (catches future regressions).

## Test plan

- [x] `python3 -m unittest test_gh_safe_body` — 10/10 pass
- [x] `python3 -m unittest test_knock test_approve test_queue test_queue_claim` — 52/52 pass (no behavior change for callers)
- [x] Full airc Python suite (21 modules) — clean
- [x] `bash -n` on all touched files
- [x] Live dry-run: `airc queue claim CambrianTech/airc#571 --dry-run` — emits a well-formed body that goes through the new helper path
- [ ] Real-gh smoke: post a card with backticks in evidence/next_action, verify body lands intact (would happen automatically as the canary path drains queue activity)

## Follow-ups (out of scope for this PR)

- **airc#573 (queue nudge)** also writes to gh comments — currently uses its own inline temp-file pattern (correct, but should be refactored onto `_airc_gh_safe_body` once this lands to converge on one idiom). Mechanical follow-up.
- The greppable invariant test (`CallSiteWiringTests.test_no_module_uses_raw_body_flag`) will fail any new `gh ... --body \"\$x\"` site, pointing the author at the helper. Future authors get a free safety net.

## Origin

Codex hit this twice during cmd_approve.sh PR review (PR #561 commit 7bbd0bf) and cmd_queue.sh PR review (PR #566 commit b08d148). Both reviews fixed the immediate symptom locally; this PR fixes it at the seam so it can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)