### PR TITLE
feat(#576): auto-close queue cards when PRs merge into canary

### DIFF
--- a/.github/workflows/auto-close-queue-cards.yml
+++ b/.github/workflows/auto-close-queue-cards.yml
@@ -1,0 +1,84 @@
+name: auto-close-queue-cards
+
+# Auto-close airc-queue cards when their PR merges into canary.
+#
+# Why this exists (airc#576):
+#   GitHub's native "Closes #N" only triggers an issue auto-close when the
+#   PR merges into the DEFAULT branch (main). Our protected workflow
+#   (enforce-canary-staging.yml) requires PRs land in canary FIRST, then
+#   canary→main is promoted as a single integration commit later. That gap
+#   between canary-merge and main-promote leaves queue cards open for
+#   days — they look idle, get nudged, accumulate noise.
+#
+#   Codex called this out as the litter pattern: airc#571, airc#567, and
+#   continuum#1125 all sat open after their PR merged into canary and
+#   needed manual `gh issue close` cleanup.
+#
+# What it does:
+#   On PR merge into canary, parses the PR body for queue-card refs
+#   (Closes #N, queue card #N, owner/repo#N, etc.), verifies each is an
+#   airc-queue-card-v1 envelope, sets status=merged with a status-log
+#   line citing this PR + merge SHA, then closes the issue.
+#
+#   Runs `airc queue close-merged` from the checkout — no install
+#   step required because the `./airc` dispatcher works from a clone
+#   when python3 + gh + bash are present (all on ubuntu-latest).
+#
+# Scope:
+#   - Same-repo only. Cross-repo refs (e.g. airc PR closing
+#     continuum#1130) are detected and reported in the workflow log
+#     but NOT closed — workflow GITHUB_TOKEN is repo-scoped. Cross-repo
+#     auto-close is a follow-up that needs an org-scoped token.
+#   - Idempotent. Already-merged cards skip silently. Cards without
+#     an envelope (loose #N references to non-queue issues) skip
+#     silently. Manual `gh issue close` remains the fallback.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [canary]
+
+# Multiple PRs may close in quick succession; run them serially so
+# status-log entries don't race on the same card (different PRs ideally
+# touch different cards, but a defensive serialize costs nothing).
+concurrency:
+  group: auto-close-queue-cards
+  cancel-in-progress: false
+
+jobs:
+  close-cards:
+    # Only fire on actual merge (not on close-without-merge).
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+      pull-requests: read
+      contents: read
+
+    steps:
+      - name: Checkout (for the airc dispatcher)
+        uses: actions/checkout@v4
+
+      - name: Verify environment (gh + python3 + bash)
+        run: |
+          set -euo pipefail
+          which gh python3 bash
+          gh --version | head -1
+          python3 --version
+          bash --version | head -1
+
+      - name: Run airc queue close-merged
+        env:
+          # gh uses GH_TOKEN; the workflow's GITHUB_TOKEN has issues:write
+          # (granted via the permissions block above) on THIS repo only.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Source identity: the actor field on status-log entries names
+          # the github-actions bot so the audit trail is clear that the
+          # card was closed by automation, not a person/AI.
+          ./airc queue close-merged \
+            "${{ github.event.pull_request.html_url }}" \
+            --merge-sha "${{ github.event.pull_request.merge_commit_sha }}" \
+            --actor "github-actions[airc#576]"

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -2,13 +2,14 @@
 #
 # Function exported back to airc's dispatch:
 #   cmd_queue — subcommand router. Verbs:
-#                 add        — create a new queue card (GitHub issue, airc-queue label). [PR-1]
-#                 list       — list open queue cards on a repo (or auto-detected).       [PR-1]
-#                 claim      — set owner+status on an existing card.                     [PR-2]
-#                 release    — clear owner (back to claimable pool).                     [PR-2]
-#                 set-status — change status field with enum validation.                 [PR-2]
-#                 nudge      — surface a card OR repo-scoped status sweep.                [PR-3+]
-#                 adopt      — convert an existing issue into a queue card.
+#                 add          — create a new queue card (GitHub issue, airc-queue label). [PR-1]
+#                 list         — list open queue cards on a repo (or auto-detected).       [PR-1]
+#                 claim        — set owner+status on an existing card.                     [PR-2]
+#                 release      — clear owner (back to claimable pool).                     [PR-2]
+#                 set-status   — change status field with enum validation.                 [PR-2]
+#                 nudge        — surface a card OR repo-scoped status sweep.               [PR-3+]
+#                 adopt        — convert an existing issue into a queue card.              [#575]
+#                 close-merged — auto-close cards referenced by a merged PR.               [#576]
 #
 # Verbs deferred to later PRs under airc#562:
 #   - heartbeat + stall detection (PR-4)
@@ -72,8 +73,11 @@ cmd_queue() {
     adopt|import)
       _cmd_queue_adopt "$@"
       ;;
+    close-merged)
+      _cmd_queue_close_merged "$@"
+      ;;
     *)
-      die "queue: unknown subcommand: $subcmd (try: add, list, claim, release, set-status, nudge, adopt)"
+      die "queue: unknown subcommand: $subcmd (try: add, list, claim, release, set-status, nudge, adopt, close-merged)"
       ;;
   esac
 }
@@ -352,6 +356,7 @@ USAGE
   airc queue nudge <issue-url> [--peer @handle] [--message "..."]
   airc queue nudge <owner/repo> [--message "..."] [--limit N]
   airc queue adopt <issue-url> [card-fields...] [--force]
+  airc queue close-merged <pr-url> [--merge-sha SHA] [--actor X] [--dry-run]
 
 DESCRIPTION
   Adds, lists, or mutates queue cards (GitHub issues with airc-queue
@@ -361,8 +366,9 @@ DESCRIPTION
 VERB SCOPE
   add / list                   PR-1 (airc#566, merged)
   claim / release / set-status PR-2 (airc#568, merged)
-  nudge                        PR-3 (card) + PR-4a (repo ping/pong sweep)
+  nudge                        PR-3 (card, airc#573) + PR-4a (repo ping/pong sweep, airc#578)
   adopt / import               Backlog migration (airc#575)
+  close-merged                 airc#576 — auto-close on PR merge to canary
   heartbeat / stall detection  PR-4 (deferred)
 
 EOF
@@ -1139,6 +1145,309 @@ PYEOF
   _airc_queue_mutate_card "$issue_url" 0 "$log_msg"
 }
 
+_cmd_queue_close_merged() {
+  # Auto-close queue cards referenced by a merged PR.
+  #
+  # Args:
+  #   airc queue close-merged <pr-url|owner/repo#PR> [--merge-sha SHA] [--actor X] [--dry-run]
+  #
+  # The driver use case is the .github/workflows/auto-close-queue-cards.yml
+  # workflow that fires on pull_request.closed{merged=true,base=canary}.
+  # GitHub's native "Closes #N" only triggers an issue auto-close when the PR
+  # merges into the DEFAULT branch (main). Our protected workflow merges PRs
+  # into canary first, so queue cards stay open until the canary→main bundle
+  # promote — which is too late, and produces the litter Codex called out:
+  # airc#571, airc#567, continuum#1125 all sat open after their PR merged.
+  #
+  # This subcommand runs the close-on-merge cycle at canary-merge time:
+  #   1. Fetch PR body via gh.
+  #   2. Parse for queue-card references — same-repo (#N, Closes #N) and
+  #      cross-repo (owner/repo#N).
+  #   3. For each candidate: verify it's a kind=airc-queue-card-v1 issue,
+  #      skip if already status=merged (idempotent), set status=merged with
+  #      a status-log entry citing the PR + merge SHA, then close the issue.
+  #   4. Print one-line summary: scanned/closed/skipped/errored.
+  #
+  # Same-repo only in this PR — cross-repo close-from-merge needs an
+  # org-scoped token (the workflow's GITHUB_TOKEN can't write to other
+  # repos), and the auth pattern is a follow-up. Cross-repo refs DO get
+  # detected and reported in the summary; they just don't get closed.
+
+  local pr_url=""
+  local merge_sha=""
+  local actor=""
+  local dry_run=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -h|--help)
+        _airc_queue_close_merged_help
+        return 0
+        ;;
+      --merge-sha) shift; merge_sha="${1:-}" ;;
+      --actor)     shift; actor="${1:-}" ;;
+      --dry-run)   dry_run=1 ;;
+      -*) die "queue close-merged: unknown flag: $1" ;;
+      *)
+        if [ -z "$pr_url" ]; then
+          pr_url="$1"
+        else
+          die "queue close-merged: too many positional args (use: queue close-merged <pr-url> [--merge-sha SHA])"
+        fi
+        ;;
+    esac
+    shift || true
+  done
+
+  if [ -z "$pr_url" ]; then
+    _airc_queue_close_merged_help >&2
+    return 1
+  fi
+
+  # Parse PR URL/short-form into repo + number. The existing
+  # _airc_queue_parse_issue_url handles /issues/N + owner/repo#N; we
+  # extend it locally to also accept /pull/N for PR URLs since gh
+  # accepts the number against either subcommand (`gh pr view N` or
+  # `gh issue view N`).
+  local pr_repo pr_num
+  if [[ "$pr_url" =~ ^https://github\.com/([^/]+/[^/]+)/(pull|pulls|issues)/([0-9]+) ]]; then
+    pr_repo="${BASH_REMATCH[1]}"
+    pr_num="${BASH_REMATCH[3]}"
+  elif [[ "$pr_url" =~ ^([^/]+/[^/]+)#([0-9]+)$ ]]; then
+    pr_repo="${BASH_REMATCH[1]}"
+    pr_num="${BASH_REMATCH[2]}"
+  else
+    die "queue close-merged: <pr-url> must be a GitHub PR URL or owner/repo#N (got: $pr_url)"
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    die "queue close-merged: 'gh' CLI is required."
+  fi
+
+  # Fetch PR body + the merge metadata. Authoritative source for both
+  # "what was closed" (body) and the SHA (in case --merge-sha wasn't
+  # passed by the workflow).
+  local pr_blob
+  if ! pr_blob=$(gh pr view "$pr_num" --repo "$pr_repo" --json body,mergedAt,mergeCommit,baseRefName,url 2>&1); then
+    die "queue close-merged: gh pr view failed for $pr_repo#$pr_num: $pr_blob"
+  fi
+
+  local pr_file
+  pr_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-pr.XXXXXX") || die "queue close-merged: mktemp failed"
+  printf '%s' "$pr_blob" >"$pr_file"
+
+  # Extract merged + base ref + sha + body via python (jq variants are
+  # fussy about absent fields).
+  local pr_meta
+  if ! pr_meta=$("$AIRC_PYTHON" - "$pr_file" <<'PYEOF'
+import json, sys
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    pr = json.load(f)
+merged_at = pr.get("mergedAt") or ""
+base_ref = pr.get("baseRefName") or ""
+merge_commit = pr.get("mergeCommit") or {}
+sha = (merge_commit.get("oid") if isinstance(merge_commit, dict) else "") or ""
+body = pr.get("body") or ""
+url = pr.get("url") or ""
+# Tab-separated: merged_at \t base_ref \t sha \t url \t body-len
+# (body itself goes via the same temp file, read again below)
+print(f"{merged_at}\t{base_ref}\t{sha}\t{url}\t{len(body)}")
+PYEOF
+  ); then
+    rm -f "$pr_file"
+    die "queue close-merged: PR JSON parse failed"
+  fi
+
+  local pr_merged_at pr_base_ref pr_sha pr_canonical_url pr_body_len
+  pr_merged_at=$(printf '%s' "$pr_meta" | awk -F'\t' '{print $1}')
+  pr_base_ref=$(printf '%s' "$pr_meta" | awk -F'\t' '{print $2}')
+  pr_sha=$(printf '%s' "$pr_meta" | awk -F'\t' '{print $3}')
+  pr_canonical_url=$(printf '%s' "$pr_meta" | awk -F'\t' '{print $4}')
+  pr_body_len=$(printf '%s' "$pr_meta" | awk -F'\t' '{print $5}')
+
+  # Sanity: PR must be merged. Workflow filters this already but we
+  # guard for the manual-invocation case (developer running close-merged
+  # from a CI re-run, etc.).
+  if [ -z "$pr_merged_at" ]; then
+    rm -f "$pr_file"
+    die "queue close-merged: PR $pr_repo#$pr_num is not merged (mergedAt empty). Refusing to close cards from an unmerged PR."
+  fi
+
+  # Prefer caller-supplied --merge-sha (the workflow passes
+  # github.event.pull_request.merge_commit_sha). Fall back to the
+  # mergeCommit.oid we fetched. If both empty, abort — we'd lose the
+  # audit anchor.
+  if [ -z "$merge_sha" ]; then
+    merge_sha="$pr_sha"
+  fi
+  if [ -z "$merge_sha" ]; then
+    rm -f "$pr_file"
+    die "queue close-merged: no merge SHA available (passed nor in PR metadata). Refusing to close — status-log entry would have no anchor."
+  fi
+
+  # Default actor for the status-log line. CI passes --actor github-actions;
+  # interactive use falls through to the standard resolve_name.
+  if [ -z "$actor" ]; then
+    actor=$(_airc_queue_resolve_name)
+  fi
+
+  # Detect candidate queue-card refs in the PR body. Recognized shapes
+  # (case-insensitive on close-keywords):
+  #   Closes #N / Resolves #N / Fixes #N            (GitHub native)
+  #   Closes owner/repo#N                            (cross-repo native)
+  #   queue card #N / airc-queue: #N                 (airc-specific prose)
+  #   #N at start of line                            (loose mention; gated by envelope-verify)
+  #   owner/repo#N (anywhere)                        (cross-repo loose)
+  local refs_file
+  refs_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-refs.XXXXXX") || die "queue close-merged: mktemp failed"
+  if ! "$AIRC_PYTHON" - "$pr_file" "$pr_repo" >"$refs_file" <<'PYEOF'
+import json, re, sys
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    pr = json.load(f)
+default_repo = sys.argv[2]
+body = pr.get("body") or ""
+
+# Cross-repo: owner/repo#N (matches Closes owner/repo#N and bare mentions).
+CROSS_RE = re.compile(r'\b([A-Za-z0-9][A-Za-z0-9._-]*)/([A-Za-z0-9][A-Za-z0-9._-]*)#(\d+)\b')
+# Same-repo: #N (matches Closes #N, queue card #N, plain #N mentions).
+SAME_RE = re.compile(r'(?<![A-Za-z0-9_/])#(\d+)\b')
+
+seen = set()  # dedupe — body may name the same card twice
+for m in CROSS_RE.finditer(body):
+    owner, repo, num = m.group(1), m.group(2), m.group(3)
+    key = f"{owner}/{repo}#{num}"
+    if key not in seen:
+        seen.add(key)
+        print(key)
+for m in SAME_RE.finditer(body):
+    num = m.group(1)
+    key = f"{default_repo}#{num}"
+    if key not in seen:
+        seen.add(key)
+        print(key)
+PYEOF
+  then
+    rm -f "$pr_file" "$refs_file"
+    die "queue close-merged: ref-parser failed"
+  fi
+  rm -f "$pr_file"
+
+  # Read refs into an array. Empty file = no candidates; that's a valid
+  # outcome (the PR may not reference any queue cards), report it cleanly.
+  local refs=()
+  if [ -s "$refs_file" ]; then
+    while IFS= read -r line; do
+      [ -n "$line" ] && refs+=("$line")
+    done <"$refs_file"
+  fi
+  rm -f "$refs_file"
+
+  printf 'queue close-merged: PR %s merged into %s @ %s\n' "$pr_canonical_url" "$pr_base_ref" "${merge_sha:0:8}"
+  printf 'queue close-merged: scanned %d body refs (PR body %d chars)\n' "${#refs[@]}" "$pr_body_len"
+
+  if [ "${#refs[@]}" -eq 0 ]; then
+    printf 'queue close-merged: no queue-card refs in PR body — nothing to close.\n'
+    return 0
+  fi
+
+  # Process each ref. Track outcomes for the summary.
+  local closed_count=0 skipped_count=0 errored_count=0 cross_repo_count=0
+  local ref ref_repo ref_num
+  for ref in "${refs[@]}"; do
+    ref_repo="${ref%#*}"
+    ref_num="${ref##*#}"
+
+    # Cross-repo refs: report and skip the close (auth scope limitation).
+    # Status-log mutation also requires write access to the OTHER repo's
+    # issues, so we can't even leave a breadcrumb there. PR body itself
+    # serves as the audit trail for cross-repo intent.
+    if [ "$ref_repo" != "$pr_repo" ]; then
+      printf '  [cross-repo] %s — skipped (workflow GITHUB_TOKEN is repo-scoped)\n' "$ref"
+      cross_repo_count=$((cross_repo_count + 1))
+      continue
+    fi
+
+    # Verify this is a queue-card issue (envelope present). Loose
+    # body refs like "see #42" can match arbitrary issues; we only
+    # close real airc-queue cards.
+    local issue_body
+    if ! issue_body=$(gh issue view "$ref_num" --repo "$ref_repo" --json body --jq .body 2>&1); then
+      # Likely the number doesn't exist as an issue (could be a PR ref).
+      printf '  [skip]       %s — gh issue view failed (likely a PR ref, not an issue)\n' "$ref"
+      skipped_count=$((skipped_count + 1))
+      continue
+    fi
+
+    # Inspect envelope: kind, current status. Skip non-cards. Skip
+    # already-merged cards (idempotent re-run protection).
+    local envelope_status
+    envelope_status=$(printf '%s' "$issue_body" | "$AIRC_PYTHON" -c '
+import json, re, sys
+body = sys.stdin.read()
+CARD_BLOCK_RE = re.compile(r"```json\s*\n(.*?)\n\s*```", re.DOTALL)
+for m in CARD_BLOCK_RE.finditer(body):
+    try:
+        parsed = json.loads(m.group(1).strip())
+    except Exception:
+        continue
+    if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
+        print((parsed.get("status") or "").strip() or "unknown")
+        sys.exit(0)
+print("not-a-card")
+')
+
+    case "$envelope_status" in
+      not-a-card)
+        printf '  [skip]       %s — not an airc-queue card (no envelope)\n' "$ref"
+        skipped_count=$((skipped_count + 1))
+        continue
+        ;;
+      merged)
+        printf '  [skip]       %s — already status=merged (idempotent)\n' "$ref"
+        skipped_count=$((skipped_count + 1))
+        continue
+        ;;
+    esac
+
+    # All systems go: set status=merged with audit anchor, then close.
+    local log_msg="merged via PR ${pr_canonical_url} @ ${merge_sha:0:8} (closed by ${actor})"
+
+    if [ "$dry_run" -eq 1 ]; then
+      printf '  [dry-run]    %s — would set status=merged + close (was: %s)\n' "$ref" "$envelope_status"
+      closed_count=$((closed_count + 1))
+      continue
+    fi
+
+    # Mutate first (preserves audit trail even if the close call fails).
+    if ! _airc_queue_mutate_card "$ref" 0 "$log_msg" --set "status=merged" >/dev/null 2>&1; then
+      printf '  [error]      %s — status mutation failed\n' "$ref"
+      errored_count=$((errored_count + 1))
+      continue
+    fi
+
+    # Close the issue. gh exits 0 even if already closed; treat any
+    # non-zero as a real error worth reporting.
+    local close_out
+    if ! close_out=$(gh issue close "$ref_num" --repo "$ref_repo" --reason completed 2>&1); then
+      printf '  [error]      %s — gh issue close failed: %s\n' "$ref" "$close_out"
+      errored_count=$((errored_count + 1))
+      continue
+    fi
+
+    printf '  [closed]     %s — status=merged, issue closed (was: %s)\n' "$ref" "$envelope_status"
+    closed_count=$((closed_count + 1))
+  done
+
+  printf 'queue close-merged: %d closed, %d skipped, %d errored, %d cross-repo (out of %d refs)\n' \
+    "$closed_count" "$skipped_count" "$errored_count" "$cross_repo_count" "${#refs[@]}"
+
+  # Return non-zero if any errors so CI surfaces the failure.
+  if [ "$errored_count" -gt 0 ]; then
+    return 1
+  fi
+  return 0
+}
+
 _airc_queue_mutate_card() {
   # Update an existing card body in place.
   # Args: <issue_url> <dry_run> <log_msg> [--set field=value | --clear field]...
@@ -1459,5 +1768,69 @@ NOTES
     backlog and `.airc/ASSEMBLY-LINE.md` in continuum#1110.
   - Status fields are NOT changed by nudge. Use airc queue set-status if
     you need to mark a card differently.
+EOF
+}
+
+_airc_queue_close_merged_help() {
+  cat <<'EOF'
+airc queue close-merged — auto-close queue cards referenced by a merged PR
+
+USAGE
+  airc queue close-merged <pr-url> [--merge-sha SHA] [--actor X] [--dry-run]
+  airc queue close-merged owner/repo#PR [--merge-sha SHA] [--actor X] [--dry-run]
+
+ARGUMENTS
+  <pr-url>           GitHub PR URL (https://github.com/.../pull/N) OR
+                     owner/repo#N short form. PR must already be merged.
+
+OPTIONS
+  --merge-sha SHA    Merge commit SHA for the audit trail. If omitted,
+                     pulled from PR metadata (mergeCommit.oid).
+  --actor X          Identity recorded in the status-log entry. Defaults
+                     to this scope's resolve_name. CI passes
+                     "github-actions" so the audit trail names the system.
+  --dry-run          Show what WOULD be closed; don't mutate or close.
+  -h, --help         This help.
+
+WHAT IT DOES
+  1. Fetches the PR body via gh.
+  2. Validates the PR is actually merged (mergedAt non-empty).
+  3. Parses the body for queue-card refs:
+       - same-repo: #N, Closes #N, Resolves #N, Fixes #N, queue card #N
+       - cross-repo: owner/repo#N (Closes owner/repo#N etc.)
+  4. For each candidate:
+       - Skips refs that aren't airc-queue cards (no envelope) — silent.
+       - Skips refs that are already status=merged (idempotent re-runs).
+       - Sets status=merged with a status-log line citing the PR URL +
+         merge SHA + actor.
+       - Closes the issue via gh.
+  5. Cross-repo refs are detected and reported in the summary but NOT
+     closed — the workflow's GITHUB_TOKEN is repo-scoped. Cross-repo
+     auto-close is a follow-up (needs an org-scoped token).
+  6. Returns 0 on success, 1 if any card errored. Idempotent — safe to
+     re-run on the same PR.
+
+WHY THIS EXISTS
+  GitHub's native "Closes #N" only auto-closes when a PR merges into the
+  default branch (main). Our protected workflow merges PRs into canary
+  first; the canary→main bundle promote is what triggers GitHub's native
+  close — and that's typically days later. In the meantime, queue cards
+  stay open, get nudged, look idle. Codex called this out as the litter
+  pattern (airc#571, airc#567, continuum#1125 all sat open after merge).
+
+  This subcommand runs the close cycle at canary-merge time so cards
+  close promptly. Manual `gh issue close` remains the fallback for any
+  PR/card the workflow doesn't catch.
+
+EXAMPLES
+  # Manual: close cards from a specific merged PR
+  airc queue close-merged https://github.com/CambrianTech/airc/pull/574
+
+  # Manual with explicit SHA + actor (CI invocation pattern)
+  airc queue close-merged CambrianTech/airc#574 \\
+    --merge-sha 168c666abc1234 --actor github-actions
+
+  # Dry-run: see what would close without touching anything
+  airc queue close-merged https://github.com/CambrianTech/airc/pull/574 --dry-run
 EOF
 }

--- a/test/test_queue_close_merged.py
+++ b/test/test_queue_close_merged.py
@@ -1,0 +1,517 @@
+"""Tests for `airc queue close-merged` (airc#576).
+
+Coverage:
+  - dispatch: close-merged subcommand reaches _cmd_queue_close_merged + --help works
+  - validation: missing PR url, malformed url, --merge-sha sanity
+  - PR-not-merged guard: refuses to close cards from an unmerged PR
+  - ref parsing: same-repo (#N, Closes #N), cross-repo (owner/repo#N)
+  - envelope verification: skips non-airc-queue issues silently
+  - idempotency: skips cards already at status=merged
+  - cross-repo: detected + reported, NOT closed (workflow token scope)
+  - dry-run: emits plan without mutating or closing
+  - actor flag: shows up in status-log line
+  - top-level help advertises close-merged
+
+Real `gh` is never exercised — fake gh wrapper records argv + serves
+canned PR/issue JSON from fixture files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+AIRC_BIN = REPO_ROOT / "airc"
+
+
+def run_airc(args: list[str], env_overrides: dict[str, str] | None = None,
+             cwd: str | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [str(AIRC_BIN), *args],
+        capture_output=True, text=True, env=env,
+        cwd=cwd or str(REPO_ROOT), timeout=20,
+    )
+
+
+def _isolated_env(tmp: str) -> dict[str, str]:
+    return {
+        "HOME": tmp,
+        "AIRC_HOME": str(pathlib.Path(tmp) / ".airc"),
+        "AIRC_NO_IDENTITY_PROMPT": "1",
+        "PATH": "/usr/bin:/bin",
+    }
+
+
+def _fake_gh(tmp: str,
+             pr_body: str = "",
+             pr_merged_at: str = "2026-05-13T20:00:00Z",
+             pr_base_ref: str = "canary",
+             pr_merge_sha: str = "168c666abcdef0123456789",
+             pr_url: str = "https://github.com/CambrianTech/airc/pull/574",
+             issue_bodies: dict[str, str] | None = None,
+             ) -> dict[str, str]:
+    """Build a fake gh that:
+      - 'gh pr view N --repo X --json ...' returns the canned PR JSON.
+      - 'gh issue view N --repo X --json body ...' returns the canned
+        issue body for that issue number (or empty body if not in fixtures).
+      - 'gh issue edit N --repo X --body-file F' records the body to
+        record_dir/edit-<N>.txt and exits 0.
+      - 'gh issue close N --repo X ...' records to record_dir/close-<N>.txt.
+    Returns the env dict ready for run_airc.
+    """
+    fakebin = pathlib.Path(tmp) / "bin"
+    fakebin.mkdir(exist_ok=True)
+    record_dir = pathlib.Path(tmp) / "gh-record"
+    record_dir.mkdir(exist_ok=True)
+
+    # PR JSON file the fake gh streams on `gh pr view`.
+    pr_json = {
+        "body": pr_body,
+        "mergedAt": pr_merged_at,
+        "mergeCommit": {"oid": pr_merge_sha} if pr_merge_sha else None,
+        "baseRefName": pr_base_ref,
+        "url": pr_url,
+    }
+    pr_file = pathlib.Path(tmp) / "pr.json"
+    pr_file.write_text(json.dumps(pr_json), encoding="utf-8")
+
+    # Per-issue body files. Key = "owner/repo#N" or "N" (for repo-less callers).
+    issues_dir = pathlib.Path(tmp) / "issues"
+    issues_dir.mkdir(exist_ok=True)
+    if issue_bodies:
+        for key, body in issue_bodies.items():
+            num = key.rsplit("#", 1)[-1] if "#" in key else key
+            (issues_dir / f"{num}.txt").write_text(body, encoding="utf-8")
+
+    gh = fakebin / "gh"
+    gh.write_text(
+        "#!/bin/sh\n"
+        f'RECORD_DIR="{record_dir}"\n'
+        f'PR_FILE="{pr_file}"\n'
+        f'ISSUES_DIR="{issues_dir}"\n'
+        # Save full argv per-call (multiple calls per test possible).
+        'CALL_ID=$$_$(date +%s%N 2>/dev/null || echo $$)\n'
+        'for a in "$@"; do printf "%s\\n" "$a"; done >> "$RECORD_DIR/argv-$CALL_ID.txt"\n'
+        'verb1="$1"\n'
+        'verb2="$2"\n'
+        'shift 2\n'
+        'case "$verb1 $verb2" in\n'
+        '  "pr view")\n'
+        '    cat "$PR_FILE"\n'
+        '    exit 0\n'
+        '    ;;\n'
+        '  "issue view")\n'
+        # First positional arg is the issue number; rest are flags.
+        # Real gh supports --jq .body to unwrap. Honor that here so the
+        # caller gets the raw body string, matching production behavior.
+        '    num="$1"\n'
+        '    shift\n'
+        '    use_jq=0\n'
+        '    while [ $# -gt 0 ]; do\n'
+        '      case "$1" in\n'
+        '        --jq) use_jq=1; shift; shift ;;\n'
+        '        *) shift ;;\n'
+        '      esac\n'
+        '    done\n'
+        '    body_file="$ISSUES_DIR/$num.txt"\n'
+        '    if [ -f "$body_file" ]; then\n'
+        '      if [ "$use_jq" -eq 1 ]; then\n'
+        '        cat "$body_file"\n'
+        '      else\n'
+        '        printf \'{"body":\'\n'
+        '        python3 -c "import json,sys; print(json.dumps(open(sys.argv[1]).read()))" "$body_file"\n'
+        '        printf \'}\'\n'
+        '      fi\n'
+        '    else\n'
+        '      if [ "$use_jq" -eq 1 ]; then\n'
+        '        :\n'
+        '      else\n'
+        '        printf \'{"body":""}\'\n'
+        '      fi\n'
+        '    fi\n'
+        '    exit 0\n'
+        '    ;;\n'
+        '  "issue edit")\n'
+        '    num="$1"\n'
+        '    while [ $# -gt 0 ]; do\n'
+        '      case "$1" in\n'
+        '        --body-file) shift; cp "$1" "$RECORD_DIR/edit-$num.txt" 2>/dev/null; shift ;;\n'
+        '        *) shift ;;\n'
+        '      esac\n'
+        '    done\n'
+        '    exit 0\n'
+        '    ;;\n'
+        '  "issue close")\n'
+        '    num="$1"\n'
+        '    printf "closed\\n" > "$RECORD_DIR/close-$num.txt"\n'
+        '    exit 0\n'
+        '    ;;\n'
+        '  *)\n'
+        '    printf "[]"\n'
+        '    exit 0\n'
+        '    ;;\n'
+        'esac\n',
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    env = _isolated_env(tmp)
+    env["PATH"] = f"{fakebin}:/usr/bin:/bin"
+    env["AIRC_GH_BIN"] = str(gh)
+    return env
+
+
+def _card_body(status: str = "in-progress",
+               owner: str = "claude-tab-2",
+               extra: str = "") -> str:
+    """Build a synthetic airc-queue-card-v1 body. Used as the issue body
+    a fake gh will return on `gh issue view`."""
+    return f'''**airc-queue card**
+
+```json
+{{
+  "kind": "airc-queue-card-v1",
+  "id": "test-card",
+  "branch": "feat/test",
+  "owner": "{owner}",
+  "status": "{status}"
+}}
+```
+
+{extra}
+'''
+
+
+# ─────────────────────────────────────────────────────────────────
+# Dispatch + validation
+# ─────────────────────────────────────────────────────────────────
+
+class CloseMergedDispatchTests(unittest.TestCase):
+    def test_help_returns_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(["queue", "close-merged", "--help"],
+                              env_overrides=_isolated_env(tmp))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--merge-sha", result.stdout)
+        self.assertIn("--actor", result.stdout)
+        self.assertIn("--dry-run", result.stdout)
+
+    def test_top_level_help_advertises_close_merged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(["queue", "--help"],
+                              env_overrides=_isolated_env(tmp))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("close-merged", result.stdout,
+                      "top-level queue help must list close-merged verb")
+        self.assertIn("airc#576", result.stdout)
+
+    def test_unknown_subcommand_error_lists_close_merged(self) -> None:
+        # Sanity: when someone typos the verb, the error names close-merged
+        # in the available list so they can find it.
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(["queue", "frobnicate"],
+                              env_overrides=_isolated_env(tmp))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("close-merged", result.stdout + result.stderr)
+
+
+class CloseMergedValidationTests(unittest.TestCase):
+    def test_missing_pr_url_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(["queue", "close-merged"],
+                              env_overrides=_isolated_env(tmp))
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_malformed_pr_url_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _fake_gh(tmp)  # gh exists but won't be reached
+            result = run_airc(["queue", "close-merged", "not-a-url"],
+                              env_overrides=env)
+        self.assertNotEqual(result.returncode, 0)
+        combined = result.stdout + result.stderr
+        self.assertIn("owner/repo", combined,
+                      "error must hint at the right url shape")
+
+    def test_unknown_flag_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "close-merged",
+                 "https://github.com/X/Y/pull/1", "--frobnicate"],
+                env_overrides=_isolated_env(tmp),
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unknown flag", result.stdout + result.stderr)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Merged-PR guard
+# ─────────────────────────────────────────────────────────────────
+
+class CloseMergedPRGuardTests(unittest.TestCase):
+    def test_unmerged_pr_refused(self) -> None:
+        # mergedAt empty == PR not merged; refuse to close anything.
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _fake_gh(tmp,
+                           pr_body="Closes #100\n",
+                           pr_merged_at="")  # not merged
+            result = run_airc(
+                ["queue", "close-merged",
+                 "https://github.com/CambrianTech/airc/pull/574"],
+                env_overrides=env,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not merged", result.stdout + result.stderr)
+
+    def test_no_merge_sha_anywhere_refused(self) -> None:
+        # Both --merge-sha unset AND PR metadata mergeCommit absent →
+        # refuse, since the status-log entry would have no audit anchor.
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _fake_gh(tmp,
+                           pr_body="Closes #100\n",
+                           pr_merge_sha="")  # absent
+            result = run_airc(
+                ["queue", "close-merged",
+                 "https://github.com/CambrianTech/airc/pull/574"],
+                env_overrides=env,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("merge SHA", result.stdout + result.stderr)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Body-ref parser
+# ─────────────────────────────────────────────────────────────────
+
+class CloseMergedRefParserTests(unittest.TestCase):
+    """Verifies the dry-run output names every queue ref the parser
+    extracts. Dry-run prints one [...] line per ref (closed/skip/etc),
+    so we count the lines per kind."""
+
+    def _run_dry(self, body: str, env_extras: dict[str, str] | None = None,
+                 issue_bodies: dict[str, str] | None = None
+                 ) -> tuple[subprocess.CompletedProcess[str], pathlib.Path]:
+        tmp = tempfile.mkdtemp()
+        env = _fake_gh(tmp, pr_body=body, issue_bodies=issue_bodies or {})
+        if env_extras:
+            env.update(env_extras)
+        result = run_airc(
+            ["queue", "close-merged",
+             "https://github.com/CambrianTech/airc/pull/574",
+             "--dry-run"],
+            env_overrides=env,
+        )
+        return result, pathlib.Path(tmp)
+
+    def test_no_refs_clean_exit(self) -> None:
+        body = "Just a PR body with no issue refs.\n"
+        result, _ = self._run_dry(body)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("nothing to close", result.stdout)
+
+    def test_same_repo_closes_keyword(self) -> None:
+        # Closes #100 → should detect as a same-repo ref.
+        body = "Body. Closes #100.\n"
+        # Issue 100 is a real airc-queue card.
+        issue_bodies = {"100": _card_body()}
+        result, _ = self._run_dry(body, issue_bodies=issue_bodies)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("CambrianTech/airc#100", result.stdout)
+        self.assertIn("[dry-run]", result.stdout,
+                      "dry-run path should mark as would-close")
+
+    def test_bare_hash_n_detected(self) -> None:
+        # #100 (no Closes keyword) — still detected via SAME_RE.
+        body = "See #100 for context.\n"
+        issue_bodies = {"100": _card_body()}
+        result, _ = self._run_dry(body, issue_bodies=issue_bodies)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("CambrianTech/airc#100", result.stdout)
+
+    def test_cross_repo_ref_detected_not_closed(self) -> None:
+        # Cross-repo ref must surface in summary as cross-repo, not closed.
+        body = "Closes CambrianTech/continuum#1130.\n"
+        result, _ = self._run_dry(body)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("CambrianTech/continuum#1130", result.stdout)
+        self.assertIn("[cross-repo]", result.stdout,
+                      "cross-repo refs must be marked, not closed")
+        self.assertIn("workflow GITHUB_TOKEN is repo-scoped",
+                      result.stdout)
+
+    def test_dedup_repeated_ref(self) -> None:
+        # Same #N referenced twice → process once.
+        body = "Closes #100. Also see #100 above.\n"
+        issue_bodies = {"100": _card_body()}
+        result, _ = self._run_dry(body, issue_bodies=issue_bodies)
+        # Count [dry-run] occurrences for #100 — must be exactly 1.
+        lines_for_100 = [l for l in result.stdout.splitlines()
+                          if "CambrianTech/airc#100" in l and "[dry-run]" in l]
+        self.assertEqual(len(lines_for_100), 1,
+                         f"expected dedup to keep #100 to ONE line; got:\n{result.stdout}")
+
+    def test_no_false_positive_on_arbitrary_text(self) -> None:
+        # Words containing # mid-string should not trigger SAME_RE
+        # (the regex requires word-boundary before #). Issue#100 word.
+        body = "Just text with no# refs and a Issue#100xyz fragment.\n"
+        result, _ = self._run_dry(body)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("nothing to close", result.stdout,
+                      f"bare text must not match #100; got:\n{result.stdout}")
+
+
+# ─────────────────────────────────────────────────────────────────
+# Envelope-verify + idempotency
+# ─────────────────────────────────────────────────────────────────
+
+class CloseMergedEnvelopeTests(unittest.TestCase):
+    def _run_dry(self, body: str, issue_bodies: dict[str, str] | None = None
+                 ) -> subprocess.CompletedProcess[str]:
+        tmp = tempfile.mkdtemp()
+        env = _fake_gh(tmp, pr_body=body, issue_bodies=issue_bodies or {})
+        return run_airc(
+            ["queue", "close-merged",
+             "https://github.com/CambrianTech/airc/pull/574",
+             "--dry-run"],
+            env_overrides=env,
+        )
+
+    def test_skips_non_card_silently(self) -> None:
+        # Issue 100 has a body but NO airc-queue envelope → skip.
+        body = "Closes #100.\n"
+        issue_bodies = {"100": "Random issue body, not a queue card.\n"}
+        result = self._run_dry(body, issue_bodies=issue_bodies)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("[skip]", result.stdout)
+        self.assertIn("not an airc-queue card", result.stdout)
+        # And the summary should reflect 0 closed.
+        self.assertIn("0 closed", result.stdout)
+
+    def test_skips_already_merged_card(self) -> None:
+        # Idempotent: re-running on a card that's already status=merged
+        # is a skip, not an error.
+        body = "Closes #100.\n"
+        issue_bodies = {"100": _card_body(status="merged")}
+        result = self._run_dry(body, issue_bodies=issue_bodies)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("already status=merged", result.stdout)
+        self.assertIn("[skip]", result.stdout)
+
+
+# ─────────────────────────────────────────────────────────────────
+# End-to-end: real mutate + close path through fake gh
+# ─────────────────────────────────────────────────────────────────
+
+class CloseMergedE2ETests(unittest.TestCase):
+    """Non-dry-run path: verify the fake gh recorded both the issue-edit
+    body AND the issue-close call, with the status-log entry reflecting
+    the merge SHA + actor."""
+
+    def test_real_close_writes_edit_and_close_for_card(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _fake_gh(
+                tmp,
+                pr_body="Closes #100.\n",
+                pr_merge_sha="168c666abcdef0123456789",
+                issue_bodies={"100": _card_body(status="in-progress")},
+            )
+            result = run_airc(
+                ["queue", "close-merged",
+                 "https://github.com/CambrianTech/airc/pull/574",
+                 "--actor", "github-actions[airc#576]"],
+                env_overrides=env,
+            )
+            record_dir = pathlib.Path(tmp) / "gh-record"
+            edit_file = record_dir / "edit-100.txt"
+            close_file = record_dir / "close-100.txt"
+            edit_body = edit_file.read_text(encoding="utf-8") if edit_file.exists() else None
+            close_recorded = close_file.exists()
+
+        self.assertEqual(result.returncode, 0,
+                         f"expected success; stdout={result.stdout} stderr={result.stderr}")
+        self.assertIn("[closed]", result.stdout)
+        self.assertIn("1 closed", result.stdout)
+
+        self.assertIsNotNone(edit_body,
+                             "fake gh must have received an edit call for #100")
+        self.assertIn('"status": "merged"', edit_body,
+                      "edit body must show status=merged")
+        # Status-log entry references the PR + sha + actor.
+        self.assertIn("Status log", edit_body)
+        self.assertIn("168c666a", edit_body,
+                      "status-log entry must include the merge SHA prefix")
+        self.assertIn("github-actions[airc#576]", edit_body,
+                      "actor flag must propagate to the status-log entry")
+        self.assertIn("https://github.com/CambrianTech/airc/pull/574", edit_body,
+                      "status-log entry must include the PR URL for audit")
+
+        self.assertTrue(close_recorded,
+                        "fake gh must have received an issue close call for #100")
+
+    def test_no_close_in_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _fake_gh(
+                tmp,
+                pr_body="Closes #100.\n",
+                issue_bodies={"100": _card_body(status="in-progress")},
+            )
+            result = run_airc(
+                ["queue", "close-merged",
+                 "https://github.com/CambrianTech/airc/pull/574",
+                 "--dry-run"],
+                env_overrides=env,
+            )
+            record_dir = pathlib.Path(tmp) / "gh-record"
+            edit_file = record_dir / "edit-100.txt"
+            close_file = record_dir / "close-100.txt"
+
+        self.assertEqual(result.returncode, 0)
+        self.assertFalse(edit_file.exists(),
+                         "dry-run MUST NOT call gh issue edit")
+        self.assertFalse(close_file.exists(),
+                         "dry-run MUST NOT call gh issue close")
+
+
+# ─────────────────────────────────────────────────────────────────
+# CallSiteWiring sanity (catch a future regression where someone
+# adds `--body` raw inside cmd_queue.sh's new code)
+# ─────────────────────────────────────────────────────────────────
+
+class CloseMergedHelperWiringTests(unittest.TestCase):
+    """The implementation must not introduce raw `--body` calls — the
+    airc#571 helper enforced that for every gh body write. This is the
+    same greppable invariant test_gh_safe_body.py runs across the
+    other modules; we extend it to confirm the new code stays clean."""
+
+    def test_no_raw_body_flag_in_close_merged_path(self) -> None:
+        cmd_queue = REPO_ROOT / "lib" / "airc_bash" / "cmd_queue.sh"
+        text = cmd_queue.read_text(encoding="utf-8")
+        # The mutate path uses _airc_gh_safe_body; close call uses
+        # `gh issue close --reason completed` (no body). Anything else
+        # touching gh issue/pr in the new code that takes a body MUST
+        # go through the helper. If a future PR adds raw `--body` here,
+        # this fails.
+        import re
+        flag_re = re.compile(r'(?<!#)\s--body(?:\s|=)(?!file)')
+        offenders = []
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue
+            if flag_re.search(line):
+                offenders.append(f"{cmd_queue.name}:{lineno}: {line.strip()}")
+        self.assertEqual(offenders, [],
+                         "raw `--body` flag found in cmd_queue.sh — "
+                         "use _airc_gh_safe_body (lib_gh.sh, airc#571):\n"
+                         + "\n".join(offenders))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes airc#576 — auto-close airc-queue cards on canary-merge.

GitHub's native `Closes #N` only fires on default-branch (main) merges. Our protected workflow merges PRs into canary first; the canary→main bundle promote happens later. In the gap, queue cards stay open, look idle, get nudged. Codex called this out — airc#571, airc#567, continuum#1125 all sat open after their PR merged and required manual `gh issue close` cleanup.

This PR adds:

1. **`airc queue close-merged <pr-url>`** — new subcommand. Scans a merged PR's body for queue-card refs, verifies each is an `airc-queue-card-v1` envelope, sets status=merged with audit trail, closes the issue. Idempotent + silent on non-card refs.
2. **`.github/workflows/auto-close-queue-cards.yml`** — fires on `pull_request.closed{merged=true,base=canary}`, runs the new subcommand from the checkout. Workflow GITHUB_TOKEN with `issues:write`.
3. **19 tests** covering parsing + envelope-verify + idempotency + cross-repo detection + dry-run + actor-flag propagation + greppable `--body` invariant.

## Live dry-run against airc#574 (the just-merged airc#571 fix)

```
queue close-merged: PR https://github.com/CambrianTech/airc/pull/574 merged into canary @ 168c6666
queue close-merged: scanned 3 body refs (PR body 3544 chars)
  [skip]       CambrianTech/airc#571 — already status=merged (idempotent)
  [skip]       CambrianTech/airc#561 — not an airc-queue card (no envelope)
  [skip]       CambrianTech/airc#566 — not an airc-queue card (no envelope)
queue close-merged: 0 closed, 3 skipped, 0 errored, 0 cross-repo (out of 3 refs)
```

Exact behavior we want: would have closed airc#571 if codex hadn't manually closed it post-merge. Idempotent re-run is safe.

## Test plan

- [x] `python3 -m unittest test_queue_close_merged` — 19/19 pass
- [x] `python3 -m unittest test_knock test_approve test_queue test_queue_claim test_queue_nudge test_gh_safe_body` — 76/76 pass (no regression)
- [x] `bash -n` clean on cmd_queue.sh + airc dispatcher
- [x] Live dry-run against real merged PR (airc#574) shows correct behavior
- [ ] Live workflow trigger on first canary-merge after this lands — that's the proof-of-life. Will broadcast the result on airc.

## Out of scope (follow-ups)

- **Cross-repo close** (airc PR closing continuum#NNN). Workflow GITHUB_TOKEN is repo-scoped; cross-repo refs are detected + reported but NOT closed. Needs an org-scoped token in a follow-up.
- **Closing-comment on the issue** for human visibility. Status-log entry is the audit trail; a top-level comment is duplication. Defer.
- **Continuum-side adoption** — same workflow template lands in continuum as a separate PR.

## Origin

Codex's queue-hygiene observations (airc#571 + airc#567 + continuum#1125 sat open post-merge) and the airc#576 card itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)