### PR TITLE
feat(queue): adopt existing issues into queue cards

### DIFF
--- a/airc
+++ b/airc
@@ -2652,6 +2652,7 @@ case "${1:-help}" in
     echo "  airc queue release <issue-url> [--reason \"…\"]            Clear ownership (back to pool)"
     echo "  airc queue set-status <issue-url> <state>                Change card status field"
     echo "  airc queue nudge <issue-url|owner/repo> [--peer @handle] Surface a card or repo status sweep"
+    echo "  airc queue adopt <issue-url> [card-fields…]              Convert an existing issue into a queue card"
     echo "  airc msg / send <text>          Broadcast to the default channel"
     echo "  airc msg / send @<peer> <text>  DM a peer (still in the shared log)"
     echo "  airc msg / send @a @b <text>    DM multiple peers (also: @a,b,c)"

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -8,6 +8,7 @@
 #                 release    — clear owner (back to claimable pool).                     [PR-2]
 #                 set-status — change status field with enum validation.                 [PR-2]
 #                 nudge      — surface a card OR repo-scoped status sweep.                [PR-3+]
+#                 adopt      — convert an existing issue into a queue card.
 #
 # Verbs deferred to later PRs under airc#562:
 #   - heartbeat + stall detection (PR-4)
@@ -68,8 +69,11 @@ cmd_queue() {
     nudge)
       _cmd_queue_nudge "$@"
       ;;
+    adopt|import)
+      _cmd_queue_adopt "$@"
+      ;;
     *)
-      die "queue: unknown subcommand: $subcmd (try: add, list, claim, release, set-status, nudge)"
+      die "queue: unknown subcommand: $subcmd (try: add, list, claim, release, set-status, nudge, adopt)"
       ;;
   esac
 }
@@ -347,6 +351,7 @@ USAGE
   airc queue set-status <issue-url> <state>
   airc queue nudge <issue-url> [--peer @handle] [--message "..."]
   airc queue nudge <owner/repo> [--message "..."] [--limit N]
+  airc queue adopt <issue-url> [card-fields...] [--force]
 
 DESCRIPTION
   Adds, lists, or mutates queue cards (GitHub issues with airc-queue
@@ -357,6 +362,7 @@ VERB SCOPE
   add / list                   PR-1 (airc#566, merged)
   claim / release / set-status PR-2 (airc#568, merged)
   nudge                        PR-3 (card) + PR-4a (repo ping/pong sweep)
+  adopt / import               Backlog migration (airc#575)
   heartbeat / stall detection  PR-4 (deferred)
 
 EOF
@@ -668,6 +674,168 @@ _cmd_queue_set_status() {
   _airc_queue_mutate_card "$issue_url" "$dry_run" \
     "$actor -> status=$new_status" \
     --set "status=$new_status"
+}
+
+_cmd_queue_adopt() {
+  # Convert an existing GitHub issue into an airc-queue card in place.
+  # This is the backlog migration path: no duplicate card, no lost issue
+  # context. The queue envelope is prepended and the original body is kept
+  # under a details block for humans and future tooling.
+  local issue_url=""
+  local card_id=""
+  local card_branch=""
+  local card_owner=""
+  local card_status="claimed"
+  local card_blockers=""
+  local card_env=""
+  local card_evidence=""
+  local card_next_action=""
+  local card_last_heartbeat=""
+  local dry_run=0
+  local force=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -h|--help)
+        _airc_queue_adopt_help
+        return 0
+        ;;
+      --id)             shift; card_id="${1:-}" ;;
+      --branch)         shift; card_branch="${1:-}" ;;
+      --owner)          shift; card_owner="${1:-}" ;;
+      --status)         shift; card_status="${1:-}" ;;
+      --blockers)       shift; card_blockers="${1:-}" ;;
+      --env)            shift; card_env="${1:-}" ;;
+      --evidence)       shift; card_evidence="${1:-}" ;;
+      --next-action)    shift; card_next_action="${1:-}" ;;
+      --last-heartbeat) shift; card_last_heartbeat="${1:-}" ;;
+      --force)          force=1 ;;
+      --dry-run)        dry_run=1 ;;
+      -*) die "queue adopt: unknown flag: $1" ;;
+      *)
+        if [ -z "$issue_url" ]; then
+          issue_url="$1"
+        else
+          die "queue adopt: too many positional args. Got extra: $1"
+        fi
+        ;;
+    esac
+    shift || true
+  done
+
+  if [ -z "$issue_url" ]; then
+    _airc_queue_adopt_help >&2
+    return 1
+  fi
+
+  case "$card_status" in
+    claimed|in-progress|blocked|review|merged) : ;;
+    *) die "queue adopt: --status must be one of: claimed, in-progress, blocked, review, merged (got: $card_status)" ;;
+  esac
+
+  local parsed_issue repo issue_num
+  if ! parsed_issue=$(_airc_queue_parse_issue_url "$issue_url"); then
+    die "queue adopt: <issue-url> must be a GitHub issue URL or owner/repo#N (got: $issue_url)"
+  fi
+  repo="${parsed_issue%#*}"
+  issue_num="${parsed_issue##*#}"
+
+  if [ -z "$card_id" ]; then
+    card_id="#$issue_num"
+  fi
+  if [ -z "$card_owner" ]; then
+    card_owner=$(_airc_queue_resolve_name)
+  fi
+  if [ -z "$card_evidence" ]; then
+    card_evidence="Adopted existing GitHub issue into airc queue."
+  fi
+  if [ -z "$card_next_action" ]; then
+    card_next_action="Triage, claim, or close this adopted backlog card."
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    die "queue adopt: 'gh' CLI is required."
+  fi
+
+  local issue_json
+  if ! issue_json=$(gh issue view "$issue_num" --repo "$repo" --json title,body 2>&1); then
+    die "queue adopt: gh issue view failed for $repo#$issue_num: $issue_json"
+  fi
+
+  local issue_json_file body_file
+  issue_json_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-adopt-json.XXXXXX") || die "queue adopt: mktemp failed"
+  body_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-adopt-body.XXXXXX") || die "queue adopt: mktemp failed"
+  printf '%s' "$issue_json" >"$issue_json_file"
+
+  local queue_body
+  queue_body=$(_airc_queue_card_body \
+    "$card_id" "$card_branch" "$card_owner" "$card_status" \
+    "$card_blockers" "$card_env" "$card_evidence" \
+    "$card_next_action" "$card_last_heartbeat")
+  printf '%s' "$queue_body" >"$body_file"
+
+  local adopted_body
+  adopted_body=$("$AIRC_PYTHON" - "$issue_json_file" "$body_file" "$force" <<'PYEOF'
+import json, re, sys
+issue_json_path, queue_body_path, force_raw = sys.argv[1:4]
+force = force_raw == "1"
+
+with open(issue_json_path, "r", encoding="utf-8") as f:
+    issue = json.loads(f.read())
+with open(queue_body_path, "r", encoding="utf-8") as f:
+    queue_body = f.read().rstrip()
+
+old_body = issue.get("body") or ""
+CARD_BLOCK_RE = re.compile(r'```json\s*\n(.*?)\n\s*```', re.DOTALL)
+for m in CARD_BLOCK_RE.finditer(old_body):
+    try:
+        parsed = json.loads(m.group(1).strip())
+    except Exception:
+        continue
+    if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
+        if not force:
+            print("queue adopt: issue already has an airc-queue-card-v1 envelope; pass --force to rewrite", file=sys.stderr)
+            sys.exit(3)
+        break
+
+if old_body.strip():
+    original = "\n\n## Original issue body\n\n<details>\n<summary>Pre-adoption body</summary>\n\n" + old_body.rstrip() + "\n\n</details>\n"
+else:
+    original = "\n\n## Original issue body\n\n_No pre-adoption body._\n"
+
+print(queue_body + original, end="")
+PYEOF
+)
+  local adopt_rc=$?
+  if [ "$adopt_rc" -ne 0 ]; then
+    rm -f "$issue_json_file" "$body_file"
+    printf '%s\n' "$adopted_body" >&2
+    return "$adopt_rc"
+  fi
+  rm -f "$issue_json_file" "$body_file"
+
+  if [ "$dry_run" -eq 1 ]; then
+    printf 'DRY RUN — would adopt %s#%s into airc queue:\n' "$repo" "$issue_num"
+    printf '  id:      %s\n' "$card_id"
+    printf '  owner:   %s\n' "$card_owner"
+    printf '  status:  %s\n' "$card_status"
+    printf '  new body:\n'
+    printf '%s\n' "$adopted_body" | sed 's/^/    /'
+    return 0
+  fi
+
+  local edit_out
+  if ! edit_out=$(_airc_gh_safe_body "$adopted_body" issue edit "$issue_num" \
+    --repo "$repo"); then
+    die "queue adopt: gh issue edit failed for $repo#$issue_num: $edit_out"
+  fi
+
+  local label_out
+  if ! label_out=$(gh issue edit "$issue_num" --repo "$repo" --add-label "airc-queue" 2>&1); then
+    printf 'note: could not add "airc-queue" label to %s#%s: %s\n' "$repo" "$issue_num" "$label_out" >&2
+  fi
+
+  printf 'Adopted %s#%s into airc queue.\n' "$repo" "$issue_num"
 }
 
 _cmd_queue_nudge() {
@@ -1199,6 +1367,46 @@ OPTIONS
 NOTES
   - Does NOT close the issue automatically when set to merged. Operators
     close manually so the queue tracks closure events explicitly.
+EOF
+}
+
+_airc_queue_adopt_help() {
+  cat <<'EOF'
+airc queue adopt — convert an existing issue into a queue card
+
+USAGE
+  airc queue adopt <issue-url> [card-fields...] [--force] [--dry-run]
+  airc queue adopt owner/repo#N [card-fields...] [--force] [--dry-run]
+
+DESCRIPTION
+  Prepends the standard airc-queue JSON envelope to an existing GitHub issue,
+  preserves the original issue body under "Original issue body", and applies
+  the airc-queue label when possible. This is the backlog migration path:
+  existing issues become queue-managed cards without creating duplicates.
+
+CARD FIELDS (all optional; defaults shown)
+  --id <ref>             Issue/PR this card coordinates (default: #N)
+  --branch <name>        Branch name, if known.
+  --owner <handle>       AIRC handle (default: this scope's resolve_name)
+  --status <state>       claimed | in-progress | blocked | review | merged
+                         (default: claimed)
+  --blockers <list>      Comma-separated blockers.
+  --env <tag>            Environment/capability tag.
+  --evidence <text>      Why this was adopted or what proof exists.
+  --next-action <text>   One sentence on the next step.
+  --last-heartbeat <ts>  ISO timestamp + sha, if known.
+
+OPTIONS
+  --force                Rewrite even if a queue envelope already exists.
+  --dry-run              Print the adopted body that WOULD be posted.
+  -h, --help             This help.
+
+EXAMPLES
+  airc queue adopt CambrianTech/continuum#914 \\
+    --owner codex \\
+    --status claimed \\
+    --env ui/browser \\
+    --next-action "Decide whether this stale UI issue still applies."
 EOF
 }
 

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -68,6 +68,57 @@ def _isolated_env_with_fake_gh(tmp: str) -> dict[str, str]:
     return env
 
 
+def _isolated_env_with_adopt_fake_gh(
+    tmp: str, issue: dict[str, object]
+) -> tuple[dict[str, str], pathlib.Path]:
+    fakebin = pathlib.Path(tmp) / "bin"
+    fakebin.mkdir()
+    record_dir = pathlib.Path(tmp) / "gh-record"
+    record_dir.mkdir()
+    issue_json = record_dir / "issue.json"
+    issue_json.write_text(json.dumps(issue), encoding="utf-8")
+    gh = fakebin / "gh"
+    gh.write_text(
+        "#!/bin/sh\n"
+        f'ISSUE_JSON="{issue_json}"\n'
+        f'RECORD_DIR="{record_dir}"\n'
+        'if [ "$1 $2" = "issue view" ]; then\n'
+        '  cat "$ISSUE_JSON"\n'
+        '  exit 0\n'
+        'fi\n'
+        'for a in "$@"; do printf "%s\\n" "$a"; done > "$RECORD_DIR/argv.txt"\n'
+        'if [ "$1 $2" = "issue edit" ]; then\n'
+        '  saw_body=0\n'
+        '  saw_label=0\n'
+        '  while [ $# -gt 0 ]; do\n'
+        '    case "$1" in\n'
+        '      --body-file)\n'
+        '        shift\n'
+        '        cp "$1" "$RECORD_DIR/edited-body.txt"\n'
+        '        saw_body=1\n'
+        '        ;;\n'
+        '      --add-label)\n'
+        '        saw_label=1\n'
+        '        ;;\n'
+        '    esac\n'
+        '    shift || true\n'
+        '  done\n'
+        '  if [ "$saw_body" = "1" ]; then cp "$RECORD_DIR/argv.txt" "$RECORD_DIR/body-edit-argv.txt"; fi\n'
+        '  if [ "$saw_label" = "1" ]; then cp "$RECORD_DIR/argv.txt" "$RECORD_DIR/label-edit-argv.txt"; fi\n'
+        "  printf '%s\\n' 'ok'\n"
+        '  exit 0\n'
+        'fi\n'
+        "printf '%s\\n' 'unexpected gh call' >&2\n"
+        "exit 2\n",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    env = _isolated_env(tmp)
+    env["PATH"] = f"{fakebin}:/usr/bin:/bin"
+    env["AIRC_GH_BIN"] = str(gh)
+    return env, record_dir
+
+
 class QueueDispatchTests(unittest.TestCase):
     def test_queue_no_subcommand_prints_help(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -97,6 +148,13 @@ class QueueDispatchTests(unittest.TestCase):
                               env_overrides=_isolated_env(tmp))
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("--owner", result.stdout)
+
+    def test_queue_adopt_help_returns_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(["queue", "adopt", "--help"],
+                              env_overrides=_isolated_env(tmp))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Original issue body", result.stdout)
 
     def test_unknown_subcommand_fails_loudly(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -255,6 +313,76 @@ class QueueListAutoDetectTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("now_utc:", result.stdout)
         self.assertIn("No open airc-queue cards", result.stdout)
+
+
+class QueueAdoptTests(unittest.TestCase):
+    def test_adopt_dry_run_prepends_queue_envelope_and_preserves_body(self) -> None:
+        issue = {
+            "title": "old backlog item",
+            "body": "Existing issue text with `markdown` and $(literal).",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            env, _record_dir = _isolated_env_with_adopt_fake_gh(tmp, issue)
+            result = run_airc(
+                ["queue", "adopt", "owner/repo#7",
+                 "--owner", "codex",
+                 "--env", "triage",
+                 "--next-action", "Decide whether this stale issue still applies.",
+                 "--dry-run"],
+                env_overrides=env,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("DRY RUN", result.stdout)
+        self.assertIn("Original issue body", result.stdout)
+        self.assertIn("Existing issue text", result.stdout)
+        match = re.search(r'```json\s*\n\s*(\{.*?\})\s*\n\s*```',
+                          result.stdout, re.DOTALL)
+        self.assertIsNotNone(match)
+        card = json.loads(match.group(1))  # type: ignore[union-attr]
+        self.assertEqual(card["kind"], "airc-queue-card-v1")
+        self.assertEqual(card["id"], "#7")
+        self.assertEqual(card["owner"], "codex")
+        self.assertEqual(card["status"], "claimed")
+        self.assertEqual(card["env"], "triage")
+
+    def test_adopt_posts_body_via_body_file_and_adds_label(self) -> None:
+        issue = {"title": "old backlog item", "body": "Original body"}
+        with tempfile.TemporaryDirectory() as tmp:
+            env, record_dir = _isolated_env_with_adopt_fake_gh(tmp, issue)
+            result = run_airc(
+                ["queue", "adopt", "owner/repo#7",
+                 "--owner", "codex",
+                 "--next-action", "Pick this up."],
+                env_overrides=env,
+            )
+            edited_body = (record_dir / "edited-body.txt").read_text(encoding="utf-8")
+            body_argv = (record_dir / "body-edit-argv.txt").read_text(encoding="utf-8").splitlines()
+            label_argv = (record_dir / "label-edit-argv.txt").read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Adopted owner/repo#7", result.stdout)
+        self.assertIn("--body-file", body_argv)
+        self.assertNotIn("--body", body_argv)
+        self.assertIn("--add-label", label_argv)
+        self.assertIn("airc-queue-card-v1", edited_body)
+        self.assertIn("Original body", edited_body)
+
+    def test_adopt_rejects_existing_queue_card_without_force(self) -> None:
+        issue = {
+            "title": "already adopted",
+            "body": "```json\n{\"kind\":\"airc-queue-card-v1\"}\n```",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            env, _record_dir = _isolated_env_with_adopt_fake_gh(tmp, issue)
+            result = run_airc(
+                ["queue", "adopt", "owner/repo#7", "--dry-run"],
+                env_overrides=env,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("already has an airc-queue-card-v1 envelope",
+                      result.stdout + result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `airc queue adopt` / `airc queue import` to convert an existing issue into an airc-queue card in place
- preserve the original issue body under an `Original issue body` details block so backlog migration does not lose context
- use the safe GitHub body-file path for the issue rewrite and apply the `airc-queue` label when available
- reject already-adopted issues unless `--force` is passed

Fixes #575.

## Validation
- `python3 test/test_queue.py`
- `python3 test/test_queue_claim.py`
- `python3 test/test_queue_nudge.py`
- `python3 test/test_gh_safe_body.py`
- `bash -n airc`
- `bash -n lib/airc_bash/cmd_queue.sh`
- `git diff --check`
