### PR TITLE
fix(#576): detect queue refs in PR titles

### DIFF
--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -1423,7 +1423,7 @@ _cmd_queue_close_merged() {
   fi
 
   local pr_blob
-  if ! pr_blob=$(gh pr view "$pr_num" --repo "$pr_repo" --json body,mergedAt,mergeCommit,baseRefName,url 2>&1); then
+  if ! pr_blob=$(gh pr view "$pr_num" --repo "$pr_repo" --json title,body,mergedAt,mergeCommit,baseRefName,url 2>&1); then
     die "queue close-merged: gh pr view failed for $pr_repo#$pr_num: $pr_blob"
   fi
 
@@ -1441,20 +1441,22 @@ base_ref = pr.get("baseRefName") or ""
 merge_commit = pr.get("mergeCommit") or {}
 sha = (merge_commit.get("oid") if isinstance(merge_commit, dict) else "") or ""
 body = pr.get("body") or ""
+title = pr.get("title") or ""
 url = pr.get("url") or ""
-print(f"{merged_at}\t{base_ref}\t{sha}\t{url}\t{len(body)}")
+print(f"{merged_at}\t{base_ref}\t{sha}\t{url}\t{len(title)}\t{len(body)}")
 PYEOF
   ); then
     rm -f "$pr_file"
     die "queue close-merged: PR JSON parse failed"
   fi
 
-  local pr_merged_at pr_base_ref pr_sha pr_canonical_url pr_body_len
+  local pr_merged_at pr_base_ref pr_sha pr_canonical_url pr_title_len pr_body_len
   pr_merged_at=$(printf '%s' "$pr_meta" | awk -F'\t' '{print $1}')
   pr_base_ref=$(printf '%s' "$pr_meta" | awk -F'\t' '{print $2}')
   pr_sha=$(printf '%s' "$pr_meta" | awk -F'\t' '{print $3}')
   pr_canonical_url=$(printf '%s' "$pr_meta" | awk -F'\t' '{print $4}')
-  pr_body_len=$(printf '%s' "$pr_meta" | awk -F'\t' '{print $5}')
+  pr_title_len=$(printf '%s' "$pr_meta" | awk -F'\t' '{print $5}')
+  pr_body_len=$(printf '%s' "$pr_meta" | awk -F'\t' '{print $6}')
 
   if [ -z "$pr_merged_at" ]; then
     rm -f "$pr_file"
@@ -1481,18 +1483,20 @@ with open(sys.argv[1], "r", encoding="utf-8") as f:
     pr = json.load(f)
 default_repo = sys.argv[2]
 body = pr.get("body") or ""
+title = pr.get("title") or ""
+text = f"{title}\n{body}"
 
 CROSS_RE = re.compile(r'\b([A-Za-z0-9][A-Za-z0-9._-]*)/([A-Za-z0-9][A-Za-z0-9._-]*)#(\d+)\b')
 SAME_RE = re.compile(r'(?<![A-Za-z0-9_/])#(\d+)\b')
 
 seen = set()
-for m in CROSS_RE.finditer(body):
+for m in CROSS_RE.finditer(text):
     owner, repo, num = m.group(1), m.group(2), m.group(3)
     key = f"{owner}/{repo}#{num}"
     if key not in seen:
         seen.add(key)
         print(key)
-for m in SAME_RE.finditer(body):
+for m in SAME_RE.finditer(text):
     num = m.group(1)
     key = f"{default_repo}#{num}"
     if key not in seen:
@@ -1514,10 +1518,10 @@ PYEOF
   rm -f "$refs_file"
 
   printf 'queue close-merged: PR %s merged into %s @ %s\n' "$pr_canonical_url" "$pr_base_ref" "${merge_sha:0:8}"
-  printf 'queue close-merged: scanned %d body refs (PR body %d chars)\n' "${#refs[@]}" "$pr_body_len"
+  printf 'queue close-merged: scanned %d title/body refs (PR title %d chars, body %d chars)\n' "${#refs[@]}" "$pr_title_len" "$pr_body_len"
 
   if [ "${#refs[@]}" -eq 0 ]; then
-    printf 'queue close-merged: no queue-card refs in PR body — nothing to close.\n'
+    printf 'queue close-merged: no queue-card refs in PR title/body — nothing to close.\n'
     return 0
   fi
 

--- a/test/test_queue_close_merged.py
+++ b/test/test_queue_close_merged.py
@@ -52,6 +52,7 @@ def _isolated_env(tmp: str) -> dict[str, str]:
 
 
 def _fake_gh(tmp: str,
+             pr_title: str = "",
              pr_body: str = "",
              pr_merged_at: str = "2026-05-13T20:00:00Z",
              pr_base_ref: str = "canary",
@@ -75,6 +76,7 @@ def _fake_gh(tmp: str,
 
     # PR JSON file the fake gh streams on `gh pr view`.
     pr_json = {
+        "title": pr_title,
         "body": pr_body,
         "mergedAt": pr_merged_at,
         "mergeCommit": {"oid": pr_merge_sha} if pr_merge_sha else None,
@@ -309,6 +311,28 @@ class CloseMergedRefParserTests(unittest.TestCase):
             env_overrides=env,
         )
         return result, pathlib.Path(tmp)
+
+    def test_title_ref_detected(self) -> None:
+        tmp = tempfile.mkdtemp()
+        env = _fake_gh(
+            tmp,
+            pr_title="feat(#576): auto-close queue cards when PRs merge into canary",
+            pr_body="Body has unrelated #561.\n",
+            issue_bodies={
+                "576": _card_body(),
+                "561": "Plain issue, not a queue card.\n",
+            },
+        )
+        result = run_airc(
+            ["queue", "close-merged",
+             "https://github.com/CambrianTech/airc/pull/581",
+             "--dry-run"],
+            env_overrides=env,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("title/body refs", result.stdout)
+        self.assertIn("CambrianTech/airc#576", result.stdout)
+        self.assertIn("[dry-run]", result.stdout)
 
     def test_no_refs_clean_exit(self) -> None:
         body = "Just a PR body with no issue refs.\n"


### PR DESCRIPTION
## Summary
- parse queue-card references from PR title plus body in `airc queue close-merged`
- report title/body scan counts in workflow logs
- add regression coverage for `feat(#576): ...` style titles

## Proof
- `python3 -m unittest test_queue_close_merged`
- `python3 test/test_queue.py`
- `python3 test/test_gh_safe_body.py`
- `bash -n airc lib/airc_bash/cmd_queue.sh`
- dry-run against merged PR #581 now sees airc#576 from the title and would close it