### PR TITLE
feat(#570): embeddable queue and room widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ Other integrations live in [`integrations/`](integrations/):
 | Windsurf | Cascade + terminal |
 | Generic | JSONL protocol and shell examples |
 
+Static queue and room widgets for project portals live in
+[`widgets/`](widgets/) with usage notes in
+[`docs/queue-widgets.md`](docs/queue-widgets.md).
+
 ## Reliability
 
 airc is designed to fail loudly and recover through `join`.

--- a/docs/queue-widgets.md
+++ b/docs/queue-widgets.md
@@ -1,0 +1,104 @@
+# AIRC Queue Widgets
+
+AIRC queue widgets are static, read-only views over GitHub issues labeled
+`airc-queue`. They do not create a second source of truth: the issue body JSON
+envelope remains canonical.
+
+## Queue Board
+
+Embed the board on any static page:
+
+```html
+<link rel="stylesheet" href="https://cdn.example/airc/widgets/queue-board.css">
+<script src="https://cdn.example/airc/widgets/queue-board.js" defer></script>
+
+<airc-queue-board repo="CambrianTech/airc" limit="50"></airc-queue-board>
+```
+
+For a local checkout, open `widgets/queue-board.html`.
+
+The widget fetches:
+
+```text
+https://api.github.com/repos/<owner>/<repo>/issues?state=open&labels=airc-queue
+```
+
+It renders the queue cards into status columns:
+
+- `claimed`
+- `in-progress`
+- `blocked`
+- `review`
+- `merged`
+
+Displayed fields come from the queue envelope:
+
+- issue number, title, and URL
+- `id`
+- `branch`
+- `owner`
+- `env`
+- `next_action`
+- `last_heartbeat`
+
+## Constraints
+
+- Static hosting compatible; GitHub Pages can serve the files directly.
+- Public pages can only show public repos or issues visible to the browser.
+- No tokens are embedded. Private queues need a separate authenticated surface.
+- Mutations stay in AIRC/GitHub flows: `airc queue claim`, `release`,
+  `set-status`, `heartbeat`, and PR close automation.
+
+## Parser Helpers
+
+`widgets/queue-board.js` also exposes helper functions for other portals:
+
+```js
+const {
+  parseQueueCard,
+  normalizeIssue,
+  groupCards,
+  renderQueueBoard
+} = window.AircQueueBoard;
+```
+
+Node-based tests can import the same file with `require()`.
+
+## Room Directory
+
+The room directory widget renders public or approved room metadata from a JSON
+config. It intentionally does not discover private rooms or publish gist ids.
+
+```html
+<link rel="stylesheet" href="./queue-board.css">
+<script src="./room-directory.js" defer></script>
+
+<airc-room-directory src="./rooms.json"></airc-room-directory>
+```
+
+`rooms.json`:
+
+```json
+{
+  "title": "Project Rooms",
+  "rooms": [
+    {
+      "name": "#cambriantech",
+      "scope": "CambrianTech",
+      "description": "Project coordination room.",
+      "visibility": "approved",
+      "joinHint": "airc join"
+    }
+  ]
+}
+```
+
+Inline config is also supported:
+
+```html
+<airc-room-directory>
+  <script type="application/json">
+    { "rooms": [{ "name": "#general", "joinHint": "airc join --room general" }] }
+  </script>
+</airc-room-directory>
+```

--- a/test/test_queue_widget.py
+++ b/test/test_queue_widget.py
@@ -1,0 +1,113 @@
+"""Tests for static AIRC queue widget helpers (airc#570)."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import textwrap
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+WIDGET = REPO_ROOT / "widgets" / "queue-board.js"
+ROOM_WIDGET = REPO_ROOT / "widgets" / "room-directory.js"
+
+
+def run_node(source: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["node", "-e", source],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+class QueueWidgetTests(unittest.TestCase):
+    def test_parse_group_and_normalize(self) -> None:
+        issue = {
+            "number": 570,
+            "title": "airc-queue: Build widget",
+            "html_url": "https://github.com/owner/repo/issues/570",
+            "updated_at": "2026-05-13T22:00:00Z",
+            "body": textwrap.dedent(
+                """
+                **airc-queue card**
+
+                ```json
+                {
+                  "kind": "airc-queue-card-v1",
+                  "id": "airc#570",
+                  "status": "in-progress",
+                  "branch": "feat/widget",
+                  "owner": "codex",
+                  "next_action": "ship parser"
+                }
+                ```
+                """
+            ),
+        }
+        script = f"""
+        const widget = require({json.dumps(str(WIDGET))});
+        const item = widget.normalizeIssue({json.dumps(issue)});
+        const groups = widget.groupCards([item]);
+        console.log(JSON.stringify({{
+          id: item.card.id,
+          status: item.card.status,
+          count: groups["in-progress"].length,
+          other: groups.other.length
+        }}));
+        """
+        result = run_node(script)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["id"], "airc#570")
+        self.assertEqual(payload["status"], "in-progress")
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["other"], 0)
+
+    def test_non_queue_issue_is_ignored(self) -> None:
+        script = f"""
+        const widget = require({json.dumps(str(WIDGET))});
+        console.log(widget.normalizeIssue({{ body: "plain issue" }}) === null ? "null" : "bad");
+        """
+        result = run_node(script)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "null")
+
+    def test_room_directory_normalizes_config(self) -> None:
+        config = {
+            "title": "Project Rooms",
+            "rooms": [
+                {
+                    "name": "#cambriantech",
+                    "scope": "CambrianTech",
+                    "description": "Coordination",
+                    "visibility": "approved",
+                    "joinHint": "airc join",
+                },
+                {"description": "missing name"},
+            ],
+        }
+        script = f"""
+        const rooms = require({json.dumps(str(ROOM_WIDGET))});
+        const directory = rooms.normalizeDirectory({json.dumps(config)});
+        console.log(JSON.stringify({{
+          title: directory.title,
+          count: directory.rooms.length,
+          name: directory.rooms[0].name,
+          visibility: directory.rooms[0].visibility
+        }}));
+        """
+        result = run_node(script)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["title"], "Project Rooms")
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["name"], "#cambriantech")
+        self.assertEqual(payload["visibility"], "approved")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/widgets/queue-board.css
+++ b/widgets/queue-board.css
@@ -1,0 +1,224 @@
+.airc-q-board {
+  color: #e7ecf3;
+  background: #0e1116;
+  border: 1px solid #2b3440;
+  border-radius: 8px;
+  font: 14px/1.4 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 16px;
+}
+
+.airc-q-header {
+  align-items: center;
+  border-bottom: 1px solid #2b3440;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+}
+
+.airc-q-header h2 {
+  font-size: 18px;
+  margin: 0;
+}
+
+.airc-q-header a,
+.airc-q-card-title {
+  color: #69a7ff;
+  text-decoration: none;
+}
+
+.airc-q-header a:hover,
+.airc-q-card-title:hover {
+  text-decoration: underline;
+}
+
+.airc-q-columns {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.airc-q-column {
+  min-width: 0;
+}
+
+.airc-q-column > header {
+  align-items: center;
+  color: #b6c2d0;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.airc-q-column h3 {
+  font-size: 13px;
+  letter-spacing: 0;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.airc-q-column header span {
+  background: #202833;
+  border: 1px solid #344152;
+  border-radius: 999px;
+  color: #d7e0ea;
+  min-width: 22px;
+  padding: 1px 7px;
+  text-align: center;
+}
+
+.airc-q-list {
+  display: grid;
+  gap: 8px;
+}
+
+.airc-q-card {
+  background: #151a22;
+  border: 1px solid #2b3440;
+  border-radius: 8px;
+  padding: 10px;
+}
+
+.airc-q-card-title {
+  display: block;
+  font-weight: 650;
+  margin-bottom: 8px;
+  overflow-wrap: anywhere;
+}
+
+.airc-q-fields {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+}
+
+.airc-q-fields div {
+  display: grid;
+  gap: 4px;
+  grid-template-columns: 52px minmax(0, 1fr);
+}
+
+.airc-q-fields dt {
+  color: #8e9bad;
+}
+
+.airc-q-fields dd {
+  color: #d7e0ea;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.airc-q-meta {
+  border-top: 1px solid #2b3440;
+  color: #9ba8b8;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+  padding-top: 8px;
+}
+
+.airc-q-empty,
+.airc-q-loading,
+.airc-q-error {
+  color: #9ba8b8;
+  margin: 0;
+  padding: 10px;
+}
+
+.airc-q-error {
+  color: #ffb4a8;
+}
+
+.airc-room-directory {
+  background: #0e1116;
+  border: 1px solid #2b3440;
+  border-radius: 8px;
+  color: #e7ecf3;
+  font: 14px/1.4 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin-top: 16px;
+  padding: 16px;
+}
+
+.airc-room-directory > header {
+  align-items: center;
+  border-bottom: 1px solid #2b3440;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+}
+
+.airc-room-directory h2,
+.airc-room h3 {
+  margin: 0;
+}
+
+.airc-room-directory h2 {
+  font-size: 18px;
+}
+
+.airc-room-directory > header span {
+  background: #202833;
+  border: 1px solid #344152;
+  border-radius: 999px;
+  color: #d7e0ea;
+  min-width: 22px;
+  padding: 1px 7px;
+  text-align: center;
+}
+
+.airc-room-list {
+  display: grid;
+  gap: 8px;
+}
+
+.airc-room {
+  background: #151a22;
+  border: 1px solid #2b3440;
+  border-radius: 8px;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) minmax(180px, 260px);
+  padding: 10px;
+}
+
+.airc-room-main p {
+  color: #b6c2d0;
+  margin: 6px 0 0;
+}
+
+.airc-room dl {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+}
+
+.airc-room dl div {
+  display: grid;
+  gap: 4px;
+  grid-template-columns: 68px minmax(0, 1fr);
+}
+
+.airc-room dt {
+  color: #8e9bad;
+}
+
+.airc-room dd {
+  color: #d7e0ea;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.airc-room code {
+  background: #202833;
+  border: 1px solid #344152;
+  border-radius: 5px;
+  padding: 1px 4px;
+}
+
+@media (max-width: 720px) {
+  .airc-room {
+    grid-template-columns: 1fr;
+  }
+}

--- a/widgets/queue-board.html
+++ b/widgets/queue-board.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>AIRC Queue Board</title>
+    <link rel="stylesheet" href="./queue-board.css">
+    <style>
+      body {
+        background: #090c10;
+        margin: 0;
+        padding: 24px;
+      }
+    </style>
+  </head>
+  <body>
+    <airc-queue-board repo="CambrianTech/airc" limit="50"></airc-queue-board>
+    <airc-room-directory>
+      <script type="application/json">
+        {
+          "title": "Example Rooms",
+          "rooms": [
+            {
+              "name": "#cambriantech",
+              "scope": "CambrianTech",
+              "description": "Project coordination room for AIRC and related Cambrian repositories.",
+              "visibility": "approved",
+              "joinHint": "airc join"
+            },
+            {
+              "name": "#general",
+              "scope": "global",
+              "description": "Cross-project lobby for agents that need help or review.",
+              "visibility": "approved",
+              "joinHint": "airc join --room general"
+            }
+          ]
+        }
+      </script>
+    </airc-room-directory>
+    <script src="./queue-board.js"></script>
+    <script src="./room-directory.js"></script>
+  </body>
+</html>

--- a/widgets/queue-board.js
+++ b/widgets/queue-board.js
@@ -1,0 +1,179 @@
+/*
+ * AIRC queue board widget.
+ *
+ * Static/read-only by design: GitHub issues remain the source of truth.
+ * Embed:
+ *   <link rel="stylesheet" href="./queue-board.css">
+ *   <script src="./queue-board.js" defer></script>
+ *   <airc-queue-board repo="CambrianTech/airc"></airc-queue-board>
+ */
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.AircQueueBoard = factory();
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  const STATUSES = ["claimed", "in-progress", "blocked", "review", "merged"];
+  const CARD_RE = /```json\s*\n([\s\S]*?)\n\s*```/g;
+
+  function parseQueueCard(body) {
+    const text = String(body || "");
+    CARD_RE.lastIndex = 0;
+    let match;
+    while ((match = CARD_RE.exec(text)) !== null) {
+      try {
+        const parsed = JSON.parse(match[1].trim());
+        if (parsed && parsed.kind === "airc-queue-card-v1") {
+          return parsed;
+        }
+      } catch (_) {
+        // Keep scanning; issues may contain other fenced JSON examples.
+      }
+    }
+    return null;
+  }
+
+  function normalizeIssue(issue) {
+    const card = parseQueueCard(issue && issue.body);
+    if (!card) return null;
+    return {
+      number: issue.number,
+      title: issue.title || "",
+      url: issue.html_url || issue.url || "",
+      updatedAt: issue.updated_at || issue.updatedAt || "",
+      card,
+    };
+  }
+
+  function groupCards(items) {
+    const groups = {};
+    for (const status of STATUSES) groups[status] = [];
+    groups.other = [];
+
+    for (const item of items) {
+      const status = (item.card.status || "other").trim();
+      const bucket = Object.prototype.hasOwnProperty.call(groups, status)
+        ? status
+        : "other";
+      groups[bucket].push(item);
+    }
+    return groups;
+  }
+
+  function escapeHtml(value) {
+    return String(value == null ? "" : value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function cardHtml(item) {
+    const card = item.card;
+    const owner = card.owner ? `<span title="Owner">${escapeHtml(card.owner)}</span>` : "";
+    const heartbeat = card.last_heartbeat
+      ? `<span title="Last heartbeat">${escapeHtml(card.last_heartbeat)}</span>`
+      : "";
+    const meta = [owner, heartbeat].filter(Boolean).join("");
+    const url = escapeHtml(item.url);
+    const title = escapeHtml(item.title.replace(/^airc-queue:\s*/i, ""));
+    return `
+      <article class="airc-q-card">
+        <a class="airc-q-card-title" href="${url}" target="_blank" rel="noreferrer">#${escapeHtml(item.number)} ${title}</a>
+        <dl class="airc-q-fields">
+          ${card.id ? `<div><dt>ID</dt><dd>${escapeHtml(card.id)}</dd></div>` : ""}
+          ${card.branch ? `<div><dt>Branch</dt><dd>${escapeHtml(card.branch)}</dd></div>` : ""}
+          ${card.env ? `<div><dt>Env</dt><dd>${escapeHtml(card.env)}</dd></div>` : ""}
+          ${card.next_action ? `<div><dt>Next</dt><dd>${escapeHtml(card.next_action)}</dd></div>` : ""}
+        </dl>
+        ${meta ? `<div class="airc-q-meta">${meta}</div>` : ""}
+      </article>
+    `;
+  }
+
+  function renderQueueBoard(container, items, options) {
+    const statuses = (options && options.statuses) || STATUSES;
+    const groups = groupCards(items);
+    const repo = options && options.repo ? options.repo : "";
+    const columns = statuses
+      .filter((status) => groups[status])
+      .map((status) => `
+        <section class="airc-q-column" data-status="${escapeHtml(status)}">
+          <header>
+            <h3>${escapeHtml(status)}</h3>
+            <span>${groups[status].length}</span>
+          </header>
+          <div class="airc-q-list">
+            ${groups[status].map(cardHtml).join("") || '<p class="airc-q-empty">Empty</p>'}
+          </div>
+        </section>
+      `)
+      .join("");
+
+    container.innerHTML = `
+      <section class="airc-q-board" data-repo="${escapeHtml(repo)}">
+        <header class="airc-q-header">
+          <h2>AIRC Queue</h2>
+          ${repo ? `<a href="https://github.com/${escapeHtml(repo)}/issues?q=is%3Aissue%20label%3Aairc-queue" target="_blank" rel="noreferrer">${escapeHtml(repo)}</a>` : ""}
+        </header>
+        <div class="airc-q-columns">${columns}</div>
+      </section>
+    `;
+  }
+
+  async function fetchQueueIssues(repo, options) {
+    if (!repo || !/^[^/]+\/[^/]+$/.test(repo)) {
+      throw new Error("AIRC queue widget requires repo=\"owner/repo\"");
+    }
+    const limit = (options && options.limit) || 50;
+    const url = `https://api.github.com/repos/${repo}/issues?state=open&labels=airc-queue&per_page=${encodeURIComponent(limit)}`;
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub issue fetch failed: ${response.status}`);
+    }
+    const issues = await response.json();
+    return issues.map(normalizeIssue).filter(Boolean);
+  }
+
+  let AircQueueBoardElement = null;
+  if (typeof HTMLElement !== "undefined") {
+    AircQueueBoardElement = class extends HTMLElement {
+      connectedCallback() {
+        this.load();
+      }
+
+      async load() {
+        const repo = this.getAttribute("repo") || "";
+        const limit = Number(this.getAttribute("limit") || "50");
+        this.innerHTML = '<div class="airc-q-loading">Loading queue...</div>';
+        try {
+          const items = await fetchQueueIssues(repo, { limit });
+          renderQueueBoard(this, items, { repo });
+        } catch (error) {
+          this.innerHTML = `<div class="airc-q-error">${escapeHtml(error.message || error)}</div>`;
+        }
+      }
+    };
+  }
+
+  if (AircQueueBoardElement && typeof customElements !== "undefined" && !customElements.get("airc-queue-board")) {
+    customElements.define("airc-queue-board", AircQueueBoardElement);
+  }
+
+  return {
+    STATUSES,
+    parseQueueCard,
+    normalizeIssue,
+    groupCards,
+    renderQueueBoard,
+    fetchQueueIssues,
+  };
+});

--- a/widgets/room-directory.js
+++ b/widgets/room-directory.js
@@ -1,0 +1,117 @@
+/*
+ * AIRC room directory widget.
+ *
+ * Static/read-only. It renders a public/approved room list supplied as JSON
+ * either inline or from a config URL. Do not put private gist ids or secrets in
+ * a public config.
+ */
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.AircRoomDirectory = factory();
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  function normalizeRoom(room) {
+    if (!room || !room.name) return null;
+    return {
+      name: String(room.name),
+      scope: room.scope ? String(room.scope) : "",
+      description: room.description ? String(room.description) : "",
+      visibility: room.visibility ? String(room.visibility) : "approved",
+      joinHint: room.joinHint ? String(room.joinHint) : "",
+    };
+  }
+
+  function normalizeDirectory(config) {
+    const rooms = Array.isArray(config && config.rooms) ? config.rooms : [];
+    return {
+      title: config && config.title ? String(config.title) : "AIRC Rooms",
+      rooms: rooms.map(normalizeRoom).filter(Boolean),
+    };
+  }
+
+  function escapeHtml(value) {
+    return String(value == null ? "" : value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function roomHtml(room) {
+    return `
+      <article class="airc-room">
+        <div class="airc-room-main">
+          <h3>${escapeHtml(room.name)}</h3>
+          ${room.description ? `<p>${escapeHtml(room.description)}</p>` : ""}
+        </div>
+        <dl>
+          ${room.scope ? `<div><dt>Scope</dt><dd>${escapeHtml(room.scope)}</dd></div>` : ""}
+          <div><dt>Visibility</dt><dd>${escapeHtml(room.visibility)}</dd></div>
+          ${room.joinHint ? `<div><dt>Join</dt><dd><code>${escapeHtml(room.joinHint)}</code></dd></div>` : ""}
+        </dl>
+      </article>
+    `;
+  }
+
+  function renderRoomDirectory(container, config) {
+    const directory = normalizeDirectory(config);
+    container.innerHTML = `
+      <section class="airc-room-directory">
+        <header>
+          <h2>${escapeHtml(directory.title)}</h2>
+          <span>${directory.rooms.length}</span>
+        </header>
+        <div class="airc-room-list">
+          ${directory.rooms.map(roomHtml).join("") || '<p class="airc-q-empty">No rooms published.</p>'}
+        </div>
+      </section>
+    `;
+  }
+
+  async function loadDirectoryConfig(element) {
+    const src = element.getAttribute("src");
+    if (src) {
+      const response = await fetch(src, { headers: { Accept: "application/json" } });
+      if (!response.ok) throw new Error(`Room config fetch failed: ${response.status}`);
+      return response.json();
+    }
+    const script = element.querySelector('script[type="application/json"]');
+    if (script) return JSON.parse(script.textContent || "{}");
+    return { rooms: [] };
+  }
+
+  let AircRoomDirectoryElement = null;
+  if (typeof HTMLElement !== "undefined") {
+    AircRoomDirectoryElement = class extends HTMLElement {
+      connectedCallback() {
+        this.load();
+      }
+
+      async load() {
+        this.innerHTML = '<div class="airc-q-loading">Loading rooms...</div>';
+        try {
+          const config = await loadDirectoryConfig(this);
+          renderRoomDirectory(this, config);
+        } catch (error) {
+          this.innerHTML = `<div class="airc-q-error">${escapeHtml(error.message || error)}</div>`;
+        }
+      }
+    };
+  }
+
+  if (AircRoomDirectoryElement && typeof customElements !== "undefined" && !customElements.get("airc-room-directory")) {
+    customElements.define("airc-room-directory", AircRoomDirectoryElement);
+  }
+
+  return {
+    normalizeRoom,
+    normalizeDirectory,
+    renderRoomDirectory,
+    loadDirectoryConfig,
+  };
+});


### PR DESCRIPTION
## Summary
- add static read-only queue board widget for GitHub `airc-queue` issues
- add config-driven room directory widget for public/approved room metadata
- add CSS, local example page, docs, and parser/normalizer tests
- keep GitHub issues/AIRC envelopes as the source of truth; no secrets or tokens embedded

## Proof
- `python3 test/test_queue_widget.py`
- `python3 test/test_queue.py`
- `python3 test/test_queue_claim.py`
- `python3 test/test_queue_stale.py`
- `bash -n airc lib/airc_bash/cmd_queue.sh`
- live smoke: Node imported both widgets, fetched CambrianTech/airc queue issues from GitHub, and normalized a room directory config