### PR TITLE
fix(#593): ignore repo-nudge templates in pongs

### DIFF
--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -1575,6 +1575,8 @@ with open(messages_path, "r", encoding="utf-8") as f:
             if dt <= since_dt:
                 continue
         text = msg.get("msg") or ""
+        if "repo-nudge:" in text and "pong with:" in text:
+            continue
         m = PONG_RE.search(text)
         if not m:
             continue
@@ -1853,6 +1855,8 @@ with open(messages_path, "r", encoding="utf-8") as f:
             if prev is None or ts > prev["ts_dt"]:
                 recent_activity[sender] = {"peer": sender, "ts": ts_raw, "ts_dt": ts, "age": age_label((now - ts).total_seconds())}
         text = msg.get("msg") or ""
+        if "repo-nudge:" in text and "pong with:" in text:
+            continue
         m = PONG_RE.search(text)
         if not m:
             continue

--- a/test/test_queue_nudge.py
+++ b/test/test_queue_nudge.py
@@ -405,6 +405,16 @@ class QueuePongsTests(unittest.TestCase):
             messages.write_text(
                 "\n".join([
                     json.dumps({
+                        "ts": "2099-01-01T00:00:00Z",
+                        "from": "airc-8a5e",
+                        "msg": (
+                            "repo-nudge: owner/repo — sweep=sweep-123 — "
+                            "pong with: pong: owner/repo — sweep=sweep-123 — "
+                            "<nick> — card=<owner/repo#N|idle> "
+                            "state=<idle|coding|testing|reviewing|blocked>"
+                        ),
+                    }),
+                    json.dumps({
                         "ts": "2099-01-01T00:00:01Z",
                         "from": "claude-tab-1",
                         "msg": (
@@ -432,6 +442,7 @@ class QueuePongsTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("responders (1)", result.stdout)
         self.assertIn("claude-tab-1", result.stdout)
+        self.assertNotIn("repo-nudge:", result.stdout)
         self.assertIn("card=owner/repo#1", result.stdout)
         self.assertIn("state=coding", result.stdout)
         self.assertIn("missing owners (1): codex", result.stdout)
@@ -443,6 +454,16 @@ class QueuePongsTests(unittest.TestCase):
             airc_home.mkdir(parents=True, exist_ok=True)
             (airc_home / "messages.jsonl").write_text(
                 "\n".join([
+                    json.dumps({
+                        "ts": "2099-01-01T00:00:00Z",
+                        "from": "airc-8a5e",
+                        "msg": (
+                            "repo-nudge: owner/repo — sweep=sweep-next — "
+                            "pong with: pong: owner/repo — sweep=sweep-next — "
+                            "<nick> — card=<owner/repo#N|idle> "
+                            "state=<idle|coding|testing|reviewing|blocked>"
+                        ),
+                    }),
                     json.dumps({
                         "ts": "2099-01-01T00:00:01Z",
                         "from": "claude-tab-1",
@@ -518,6 +539,7 @@ class QueueAvailabilityTests(unittest.TestCase):
         self.assertIn("# airc-queue availability — owner/repo", out)
         self.assertIn("repo-nudge responders (1)", out)
         self.assertIn("codex: card=owner/repo#2 state=reviewing", out)
+        self.assertNotIn("airc-8a5e: card=owner/repo#N|idle", out)
         self.assertIn("recent room activity (2)", out)
         self.assertIn("claude-tab-1", out)
         self.assertIn("attention needed (2)", out)


### PR DESCRIPTION
## Summary
- filters repo-nudge instruction messages before parsing pong responders
- applies the same filter to `queue pongs` and `queue availability`
- adds regression coverage with a repo-nudge `pong with:` template adjacent to real pongs

## Proof
- `bash -n lib/airc_bash/cmd_queue.sh`
- `python3 test/test_queue_nudge.py`
- live project-room smoke: `airc queue pongs CambrianTech/continuum --sweep-id 20260514T003541Z --since 2h` now reports only the real claude-tab-2 responder, not the repo-nudge template
- `git diff --check`

Closes #593.