### PR TITLE
fix(#596): honor per-agent queue owner

### DIFF
--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -411,7 +411,8 @@ REQUIRED
 CARD FIELDS (all optional; defaults shown)
   --id <ref>             Issue/PR this card coordinates (e.g. #1085, airc#562)
   --branch <name>        Branch name (e.g. fix/install-tier-name)
-  --owner <handle>       AIRC handle (default: this scope's resolve_name)
+  --owner <handle>       Queue owner (default: AIRC_QUEUE_OWNER, then
+                         AIRC_AGENT_NAME/AIRC_AGENT_NICK, then this scope)
   --status <state>       claimed | in-progress | blocked | review | merged
                          (default: claimed)
   --blockers <list>      Comma-separated #NNNN (e.g. "#1085, airc#559")
@@ -423,6 +424,10 @@ CARD FIELDS (all optional; defaults shown)
 OPTIONS
   --dry-run              Print the card body that WOULD be posted; don't post.
   -h, --help             This help.
+
+ENVIRONMENT
+  AIRC_QUEUE_OWNER        Per-agent queue identity used when --owner is absent.
+  AIRC_AGENT_NAME/NICK    Secondary per-agent identity fallbacks.
 
 EXAMPLES
   airc queue add CambrianTech/continuum \\
@@ -472,8 +477,24 @@ EOF
 }
 
 _airc_queue_resolve_name() {
-  # Best-effort airc handle for the current scope. Falls back to
-  # "anonymous" if no scope (cmd_queue must work pre-init too —
+  # Best-effort queue owner for the current agent/session. Queue ownership
+  # is not always identical to transport identity: multiple local agents may
+  # share one AIRC scope/room handle while working separate cards. Prefer an
+  # explicit queue/session override, then fall back to the room identity.
+  if [ -n "${AIRC_QUEUE_OWNER:-}" ]; then
+    printf '%s\n' "$AIRC_QUEUE_OWNER"
+    return 0
+  fi
+  if [ -n "${AIRC_AGENT_NAME:-}" ]; then
+    printf '%s\n' "$AIRC_AGENT_NAME"
+    return 0
+  fi
+  if [ -n "${AIRC_AGENT_NICK:-}" ]; then
+    printf '%s\n' "$AIRC_AGENT_NICK"
+    return 0
+  fi
+
+  # Falls back to "anonymous" if no scope (cmd_queue must work pre-init too —
   # outsiders may want to query/add cards before joining).
   if declare -F resolve_name >/dev/null 2>&1; then
     resolve_name
@@ -2362,11 +2383,12 @@ USAGE
 
 DESCRIPTION
   Sets the card's owner field and status to indicate active work. Default
-  owner = current scope's resolve_name; default status = in-progress.
+  owner = AIRC_QUEUE_OWNER, then AIRC_AGENT_NAME/AIRC_AGENT_NICK, then
+  current scope's resolve_name; default status = in-progress.
   Appends a "## Status log" line with timestamp + actor.
 
 OPTIONS
-  --owner <handle>   AIRC handle to set as owner (default: this scope).
+  --owner <handle>   Queue owner to set (default: per-agent env, then scope).
   --status <state>   New status (default: in-progress).
   --dry-run          Print the new body that WOULD be written; don't edit.
   -h, --help         This help.
@@ -2425,12 +2447,12 @@ USAGE
   airc queue heartbeat owner/repo#N [--owner X] [--status Y] [--note "..."] [--dry-run]
 
 DESCRIPTION
-  Sets owner (default: this AIRC identity) and last_heartbeat to the
+  Sets owner (default: per-agent env, then this AIRC identity) and last_heartbeat to the
   current UTC timestamp plus git SHA when available. Optionally updates
   status. Appends a Status log line so humans can see that work is alive.
 
 OPTIONS
-  --owner <handle>   AIRC handle to record (default: this scope).
+  --owner <handle>   Queue owner to record (default: per-agent env, then scope).
   --status <state>   Optional status update: claimed, in-progress, blocked,
                      review, or merged.
   --note "<text>"    Short context appended to the status log.
@@ -2478,7 +2500,8 @@ DESCRIPTION
 CARD FIELDS (all optional; defaults shown)
   --id <ref>             Issue/PR this card coordinates (default: #N)
   --branch <name>        Branch name, if known.
-  --owner <handle>       AIRC handle (default: this scope's resolve_name)
+  --owner <handle>       Queue owner (default: AIRC_QUEUE_OWNER, then
+                         AIRC_AGENT_NAME/AIRC_AGENT_NICK, then this scope)
   --status <state>       claimed | in-progress | blocked | review | merged
                          (default: claimed)
   --blockers <list>      Comma-separated blockers.

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -4,7 +4,7 @@ Coverage:
   - dispatch: subcommand router + add/list reach the right functions + --help paths work
   - validation: missing args / bad status enum / malformed repo all fail loud
   - card body shape: dry-run output embeds a JSON envelope with kind=airc-queue-card-v1
-  - default owner: falls back to resolve_name when --owner omitted
+  - default owner: per-agent env override, then resolve_name when --owner omitted
   - field threading: every --flag ends up in the card JSON
   - auto-detect: queue list with no <owner/repo> uses git remote
   - status enum: only canonical states accepted
@@ -273,6 +273,40 @@ class QueueAddCardBodyTests(unittest.TestCase):
         self.assertIn("owner", card)
         self.assertGreater(len(card["owner"]), 0,
                            "default owner must resolve to SOMETHING")
+
+    def test_dry_run_default_owner_prefers_queue_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _isolated_env(tmp)
+            env["AIRC_QUEUE_OWNER"] = "codex-main"
+            result = run_airc(
+                ["queue", "add", "owner/repo",
+                 "--title", "test card",
+                 "--dry-run"],
+                env_overrides=env,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        match = re.search(r'```json\s*\n\s*(\{.*?\})\s*\n\s*```',
+                          result.stdout, re.DOTALL)
+        self.assertIsNotNone(match)
+        card = json.loads(match.group(1))  # type: ignore[union-attr]
+        self.assertEqual(card["owner"], "codex-main")
+
+    def test_dry_run_default_owner_accepts_agent_name_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _isolated_env(tmp)
+            env["AIRC_AGENT_NAME"] = "claude-tab-2"
+            result = run_airc(
+                ["queue", "add", "owner/repo",
+                 "--title", "test card",
+                 "--dry-run"],
+                env_overrides=env,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        match = re.search(r'```json\s*\n\s*(\{.*?\})\s*\n\s*```',
+                          result.stdout, re.DOTALL)
+        self.assertIsNotNone(match)
+        card = json.loads(match.group(1))  # type: ignore[union-attr]
+        self.assertEqual(card["owner"], "claude-tab-2")
 
 
 class QueueListAutoDetectTests(unittest.TestCase):

--- a/test/test_queue_claim.py
+++ b/test/test_queue_claim.py
@@ -6,7 +6,7 @@ Coverage:
   - mutate-card python helper: applies --set/--clear correctly to a fixture
   - dry-run: prints the would-be body, doesn't call gh
   - status log: appends a chronological entry on every mutation
-  - claim defaults: owner=resolve_name, status=in-progress
+  - claim defaults: per-agent env owner, then resolve_name; status=in-progress
   - claim/heartbeat stamp last_heartbeat
   - release defaults: clears owner, sets status=claimed
   - release --status blocked allowed; in-progress/review/merged rejected
@@ -264,6 +264,18 @@ class QueueMutateBodyShapeTests(unittest.TestCase):
         self.assertIn("## Status log", body)
         self.assertIn("claim by claude-tab-2", body)
 
+    def test_claim_default_owner_prefers_queue_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _isolated_env_with_fake_gh(tmp)
+            env["AIRC_QUEUE_OWNER"] = "codex-main"
+            result = run_airc(
+                ["queue", "claim", "owner/repo#1", "--dry-run"],
+                env_overrides=env,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('"owner": "codex-main"', result.stdout)
+        self.assertIn("claim by codex-main", result.stdout)
+
     def test_heartbeat_sets_owner_and_last_heartbeat(self) -> None:
         body = self._dry_run_extract_body(
             ["queue", "heartbeat", "owner/repo#1",
@@ -277,6 +289,18 @@ class QueueMutateBodyShapeTests(unittest.TestCase):
         self.assertRegex(envelope["last_heartbeat"], r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z")
         self.assertIn("heartbeat by codex", body)
         self.assertIn("still testing", body)
+
+    def test_heartbeat_default_owner_prefers_agent_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _isolated_env_with_fake_gh(tmp)
+            env["AIRC_AGENT_NAME"] = "claude-tab-2"
+            result = run_airc(
+                ["queue", "heartbeat", "owner/repo#1", "--dry-run"],
+                env_overrides=env,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('"owner": "claude-tab-2"', result.stdout)
+        self.assertIn("heartbeat by claude-tab-2", result.stdout)
 
     def test_heartbeat_can_update_status(self) -> None:
         body = self._dry_run_extract_body(


### PR DESCRIPTION
## Summary
- add AIRC_QUEUE_OWNER as the queue-owner override before the shared AIRC scope identity
- accept AIRC_AGENT_NAME / AIRC_AGENT_NICK as secondary per-agent fallbacks
- document the default owner precedence in queue help and cover add/claim/heartbeat regressions

## Proof
- bash -n airc lib/airc_bash/cmd_queue.sh
- python3 test/test_queue.py && python3 test/test_queue_claim.py && python3 test/test_queue_nudge.py
- for f in test/test_*.py; do python3 "" || exit 1; done
- git diff --check
- AIRC_QUEUE_OWNER=codex-main ./airc queue add owner/repo --title "identity override smoke" --dry-run

Closes #596