### PR TITLE
fix: add session work identity for queue ownership

### DIFF
--- a/airc
+++ b/airc
@@ -2592,7 +2592,8 @@ case "${1:-help}" in
   send-file) shift; cmd_send_file "$@" ;;
   ping)      shift; cmd_ping "$@" ;;
   rename|nick) shift; cmd_rename "$@" ;;
-  identity|whoami) shift; cmd_identity "$@" ;;
+  identity)   shift; cmd_identity "$@" ;;
+  whoami)     shift; cmd_identity whoami "$@" ;;
   away|back) shift; cmd_away "$@" ;;
   whois)     shift; cmd_whois "$@" ;;
   kick)      shift; cmd_kick "$@" ;;

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -71,11 +71,16 @@ cmd_away() {
 }
 
 cmd_identity() {
-  ensure_init
   local sub="${1:-show}"
   shift 2>/dev/null || true
   case "$sub" in
+    whoami|register|adopt|-h|--help|help) ;;
+    *) ensure_init ;;
+  esac
+  case "$sub" in
     show|"") _identity_show ;;
+    whoami)  _identity_whoami ;;
+    register|adopt) _identity_register "$@" ;;
     set)     _identity_set "$@" ;;
     link)    _identity_link "$@" ;;
     import)  _identity_import "$@" ;;
@@ -83,13 +88,201 @@ cmd_identity() {
     -h|--help|help)
       echo "Usage:"
       echo "  airc identity show                            Print own identity"
+      echo "  airc identity whoami                          Print transport + work identity"
+      echo "  airc identity register --name <handle>        Set this session's queue/work identity"
       echo "  airc identity set [--pronouns X] [--role Y] [--bio \"…\"] [--status \"…\"]"
       echo "  airc identity link <platform> [handle]        Map this identity to a platform persona (omit handle to unlink)"
       echo "  airc identity import <platform>:<id>          Pull persona from platform (continuum)"
       echo "  airc identity push <platform>                 Send local fields to platform (continuum)"
       ;;
-    *) die "Unknown identity subcommand: $sub (try: show, set, link, import, push)" ;;
+    *) die "Unknown identity subcommand: $sub (try: show, whoami, register, set, link, import, push)" ;;
   esac
+}
+
+_identity_session_file() {
+  local transport_name="${1:-}"
+  [ -z "$transport_name" ] && transport_name="anonymous"
+  mkdir -p "$AIRC_WRITE_DIR/sessions" 2>/dev/null || true
+  AIRC_WRITE_DIR="$AIRC_WRITE_DIR" \
+    TRANSPORT_NAME="$transport_name" \
+    "$AIRC_PYTHON" -c '
+import hashlib, os, pathlib, re, subprocess
+
+def first_env(*names):
+    for name in names:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return name, value
+    return "", ""
+
+source, value = first_env(
+    "AIRC_SESSION_ID",
+    "CODEX_THREAD_ID",
+    "CLAUDE_SESSION_ID",
+    "CLAUDE_CODE_SESSION_ID",
+    "TERM_SESSION_ID",
+    "TMUX_PANE",
+)
+if not value:
+    tty = ""
+    try:
+        tty = subprocess.check_output(["tty"], text=True, stderr=subprocess.DEVNULL).strip()
+    except Exception:
+        tty = ""
+    if tty and tty != "not a tty":
+        source, value = "tty", tty
+if not value:
+    source = "cwd"
+    value = os.getcwd()
+
+raw = f"{source}:{value}"
+digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+base = os.environ["AIRC_WRITE_DIR"]
+path = pathlib.Path(base) / "sessions" / f"{digest}.json"
+print(path)
+'
+}
+
+_identity_default_work_name() {
+  local transport_name="${1:-anonymous}"
+  local session_file="${2:-}"
+  SESSION_FILE="$session_file" TRANSPORT_NAME="$transport_name" "$AIRC_PYTHON" -c '
+import hashlib, os, re
+name = os.environ.get("TRANSPORT_NAME", "anonymous") or "anonymous"
+session_file = os.environ.get("SESSION_FILE", "")
+suffix = hashlib.sha256(session_file.encode("utf-8")).hexdigest()[:4]
+base = re.sub(r"[^a-z0-9-]+", "-", name.lower()).strip("-") or "agent"
+print(f"{base}-{suffix}")
+'
+}
+
+_identity_read_work_name() {
+  local session_file="$1"
+  [ -f "$session_file" ] || return 1
+  SESSION_FILE="$session_file" "$AIRC_PYTHON" -c '
+import json, os, sys
+try:
+    data = json.load(open(os.environ["SESSION_FILE"]))
+except Exception:
+    sys.exit(1)
+name = str(data.get("name", "")).strip()
+if not name:
+    sys.exit(1)
+print(name)
+'
+}
+
+_identity_write_work_session() {
+  local session_file="$1" name="$2" transport_name="$3"
+  _validate_peer_name "$name"
+  SESSION_FILE="$session_file" \
+    NAME="$name" \
+    TRANSPORT_NAME="$transport_name" \
+    "$AIRC_PYTHON" -c '
+import json, os, pathlib, subprocess, time
+path = pathlib.Path(os.environ["SESSION_FILE"])
+path.parent.mkdir(parents=True, exist_ok=True)
+source = ""
+value = ""
+for key in ("AIRC_SESSION_ID", "CODEX_THREAD_ID", "CLAUDE_SESSION_ID", "CLAUDE_CODE_SESSION_ID", "TERM_SESSION_ID", "TMUX_PANE"):
+    candidate = os.environ.get(key, "").strip()
+    if candidate:
+        source, value = key, candidate
+        break
+if not value:
+    try:
+        tty = subprocess.check_output(["tty"], text=True, stderr=subprocess.DEVNULL).strip()
+    except Exception:
+        tty = ""
+    if tty and tty != "not a tty":
+        source, value = "tty", tty
+if not value:
+    source, value = "cwd", os.getcwd()
+data = {}
+if path.exists():
+    try:
+        data = json.load(open(path))
+    except Exception:
+        data = {}
+data.update({
+    "name": os.environ["NAME"],
+    "transport_name": os.environ.get("TRANSPORT_NAME", ""),
+    "session_source": source,
+    "session_hint": value,
+    "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+})
+json.dump(data, open(path, "w"), indent=2, sort_keys=True)
+'
+}
+
+_identity_resolve_work_name() {
+  local transport_name session_file saved_name default_name
+  if declare -F resolve_name >/dev/null 2>&1; then
+    transport_name=$(resolve_name)
+  else
+    transport_name="anonymous"
+  fi
+
+  session_file=$(_identity_session_file "$transport_name")
+  if saved_name=$(_identity_read_work_name "$session_file" 2>/dev/null); then
+    printf '%s\n' "$saved_name"
+    return 0
+  fi
+
+  # Compatibility shim for existing automation. This is no longer the
+  # product path; first-class session state is written immediately below.
+  if [ -n "${AIRC_QUEUE_OWNER:-}" ]; then
+    _identity_write_work_session "$session_file" "$AIRC_QUEUE_OWNER" "$transport_name"
+    printf '%s\n' "$AIRC_QUEUE_OWNER"
+    return 0
+  fi
+  if [ -n "${AIRC_AGENT_NAME:-}" ]; then
+    _identity_write_work_session "$session_file" "$AIRC_AGENT_NAME" "$transport_name"
+    printf '%s\n' "$AIRC_AGENT_NAME"
+    return 0
+  fi
+  if [ -n "${AIRC_AGENT_NICK:-}" ]; then
+    _identity_write_work_session "$session_file" "$AIRC_AGENT_NICK" "$transport_name"
+    printf '%s\n' "$AIRC_AGENT_NICK"
+    return 0
+  fi
+
+  default_name=$(_identity_default_work_name "$transport_name" "$session_file")
+  _identity_write_work_session "$session_file" "$default_name" "$transport_name"
+  printf '%s\n' "$default_name"
+}
+
+_identity_whoami() {
+  local transport_name session_file work_name
+  transport_name=$(resolve_name)
+  session_file=$(_identity_session_file "$transport_name")
+  work_name=$(_identity_resolve_work_name)
+  printf '  transport:  %s\n' "$transport_name"
+  printf '  work:       %s\n' "$work_name"
+  printf '  session:    %s\n' "$session_file"
+}
+
+_identity_register() {
+  local name=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --name) name="${2:-}"; shift 2 ;;
+      -h|--help)
+        echo "Usage:"
+        echo "  airc identity register --name <handle>"
+        echo "  airc identity adopt <handle>"
+        return 0 ;;
+      --*) die "Unknown flag: $1" ;;
+      *)  name="$1"; shift ;;
+    esac
+  done
+  [ -n "$name" ] || die "Usage: airc identity register --name <handle>"
+  local transport_name session_file
+  transport_name=$(resolve_name)
+  session_file=$(_identity_session_file "$transport_name")
+  _identity_write_work_session "$session_file" "$name" "$transport_name"
+  printf '  work identity: %s\n' "$name"
+  printf '  session: %s\n' "$session_file"
 }
 
 # Identity bootstrap nudge (#146). Called once after a successful

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -411,8 +411,8 @@ REQUIRED
 CARD FIELDS (all optional; defaults shown)
   --id <ref>             Issue/PR this card coordinates (e.g. #1085, airc#562)
   --branch <name>        Branch name (e.g. fix/install-tier-name)
-  --owner <handle>       Queue owner (default: AIRC_QUEUE_OWNER, then
-                         AIRC_AGENT_NAME/AIRC_AGENT_NICK, then this scope)
+  --owner <handle>       Queue owner (default: current work identity from
+                         `airc identity whoami`)
   --status <state>       claimed | in-progress | blocked | review | merged
                          (default: claimed)
   --blockers <list>      Comma-separated #NNNN (e.g. "#1085, airc#559")
@@ -426,8 +426,8 @@ OPTIONS
   -h, --help             This help.
 
 ENVIRONMENT
-  AIRC_QUEUE_OWNER        Per-agent queue identity used when --owner is absent.
-  AIRC_AGENT_NAME/NICK    Secondary per-agent identity fallbacks.
+  AIRC_QUEUE_OWNER        Compatibility fallback for older launchers.
+  AIRC_AGENT_NAME/NICK    Compatibility fallback for older launchers.
 
 EXAMPLES
   airc queue add CambrianTech/continuum \\
@@ -479,18 +479,11 @@ EOF
 _airc_queue_resolve_name() {
   # Best-effort queue owner for the current agent/session. Queue ownership
   # is not always identical to transport identity: multiple local agents may
-  # share one AIRC scope/room handle while working separate cards. Prefer an
-  # explicit queue/session override, then fall back to the room identity.
-  if [ -n "${AIRC_QUEUE_OWNER:-}" ]; then
-    printf '%s\n' "$AIRC_QUEUE_OWNER"
-    return 0
-  fi
-  if [ -n "${AIRC_AGENT_NAME:-}" ]; then
-    printf '%s\n' "$AIRC_AGENT_NAME"
-    return 0
-  fi
-  if [ -n "${AIRC_AGENT_NICK:-}" ]; then
-    printf '%s\n' "$AIRC_AGENT_NICK"
+  # share one AIRC scope/room handle while working separate cards. The
+  # first-class session identity owns product behavior; env names remain
+  # a compatibility path inside the identity resolver.
+  if declare -F _identity_resolve_work_name >/dev/null 2>&1; then
+    _identity_resolve_work_name
     return 0
   fi
 
@@ -2383,12 +2376,11 @@ USAGE
 
 DESCRIPTION
   Sets the card's owner field and status to indicate active work. Default
-  owner = AIRC_QUEUE_OWNER, then AIRC_AGENT_NAME/AIRC_AGENT_NICK, then
-  current scope's resolve_name; default status = in-progress.
+  owner = current work identity from `airc identity whoami`; default status = in-progress.
   Appends a "## Status log" line with timestamp + actor.
 
 OPTIONS
-  --owner <handle>   Queue owner to set (default: per-agent env, then scope).
+  --owner <handle>   Queue owner to set (default: current work identity).
   --status <state>   New status (default: in-progress).
   --dry-run          Print the new body that WOULD be written; don't edit.
   -h, --help         This help.
@@ -2447,12 +2439,12 @@ USAGE
   airc queue heartbeat owner/repo#N [--owner X] [--status Y] [--note "..."] [--dry-run]
 
 DESCRIPTION
-  Sets owner (default: per-agent env, then this AIRC identity) and last_heartbeat to the
+  Sets owner (default: current work identity) and last_heartbeat to the
   current UTC timestamp plus git SHA when available. Optionally updates
   status. Appends a Status log line so humans can see that work is alive.
 
 OPTIONS
-  --owner <handle>   Queue owner to record (default: per-agent env, then scope).
+  --owner <handle>   Queue owner to record (default: current work identity).
   --status <state>   Optional status update: claimed, in-progress, blocked,
                      review, or merged.
   --note "<text>"    Short context appended to the status log.
@@ -2500,8 +2492,7 @@ DESCRIPTION
 CARD FIELDS (all optional; defaults shown)
   --id <ref>             Issue/PR this card coordinates (default: #N)
   --branch <name>        Branch name, if known.
-  --owner <handle>       Queue owner (default: AIRC_QUEUE_OWNER, then
-                         AIRC_AGENT_NAME/AIRC_AGENT_NICK, then this scope)
+  --owner <handle>       Queue owner (default: current work identity)
   --status <state>       claimed | in-progress | blocked | review | merged
                          (default: claimed)
   --blockers <list>      Comma-separated blockers.
@@ -2652,7 +2643,7 @@ OPTIONS
   --merge-sha SHA    Merge commit SHA for the audit trail. If omitted,
                      pulled from PR metadata (mergeCommit.oid).
   --actor X          Identity recorded in the status-log entry. Defaults
-                     to this scope's resolve_name. CI passes
+                     to current work identity. CI passes
                      "github-actions" so the audit trail names the system.
   --dry-run          Show what WOULD be closed; don't mutate or close.
   -h, --help         This help.

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -4,7 +4,7 @@ Coverage:
   - dispatch: subcommand router + add/list reach the right functions + --help paths work
   - validation: missing args / bad status enum / malformed repo all fail loud
   - card body shape: dry-run output embeds a JSON envelope with kind=airc-queue-card-v1
-  - default owner: per-agent env override, then resolve_name when --owner omitted
+  - default owner: session/work identity, then compatibility env fallback
   - field threading: every --flag ends up in the card JSON
   - auto-detect: queue list with no <owner/repo> uses git remote
   - status enum: only canonical states accepted
@@ -263,8 +263,8 @@ class QueueAddCardBodyTests(unittest.TestCase):
                          "queue add must default to status=claimed")
 
     def test_dry_run_default_owner_is_resolved_name(self) -> None:
-        # No --owner → owner field falls back to resolve_name (which
-        # falls back to derive_name → hostname). Must be non-empty.
+        # No --owner → owner field comes from the first-class session/work
+        # identity. Must be non-empty even before `airc join`.
         out = self._dry_run()
         match = re.search(r'```json\s*\n\s*(\{.*?\})\s*\n\s*```',
                           out, re.DOTALL)
@@ -273,6 +273,41 @@ class QueueAddCardBodyTests(unittest.TestCase):
         self.assertIn("owner", card)
         self.assertGreater(len(card["owner"]), 0,
                            "default owner must resolve to SOMETHING")
+
+    def test_dry_run_default_owner_prefers_registered_work_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _isolated_env(tmp)
+            registered = run_airc(
+                ["identity", "register", "--name", "codex-main"],
+                env_overrides=env,
+            )
+            self.assertEqual(registered.returncode, 0, registered.stderr)
+            result = run_airc(
+                ["queue", "add", "owner/repo",
+                 "--title", "test card",
+                 "--dry-run"],
+                env_overrides=env,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        match = re.search(r'```json\s*\n\s*(\{.*?\})\s*\n\s*```',
+                          result.stdout, re.DOTALL)
+        self.assertIsNotNone(match)
+        card = json.loads(match.group(1))  # type: ignore[union-attr]
+        self.assertEqual(card["owner"], "codex-main")
+
+    def test_whoami_prints_transport_and_work_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _isolated_env(tmp)
+            registered = run_airc(
+                ["identity", "register", "--name", "claude-tab-1"],
+                env_overrides=env,
+            )
+            self.assertEqual(registered.returncode, 0, registered.stderr)
+            result = run_airc(["whoami"], env_overrides=env)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("transport:", result.stdout)
+        self.assertIn("work:", result.stdout)
+        self.assertIn("claude-tab-1", result.stdout)
 
     def test_dry_run_default_owner_prefers_queue_env(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/test/test_queue_claim.py
+++ b/test/test_queue_claim.py
@@ -6,7 +6,7 @@ Coverage:
   - mutate-card python helper: applies --set/--clear correctly to a fixture
   - dry-run: prints the would-be body, doesn't call gh
   - status log: appends a chronological entry on every mutation
-  - claim defaults: per-agent env owner, then resolve_name; status=in-progress
+  - claim defaults: session/work identity, then compatibility env fallback; status=in-progress
   - claim/heartbeat stamp last_heartbeat
   - release defaults: clears owner, sets status=claimed
   - release --status blocked allowed; in-progress/review/merged rejected
@@ -275,6 +275,22 @@ class QueueMutateBodyShapeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn('"owner": "codex-main"', result.stdout)
         self.assertIn("claim by codex-main", result.stdout)
+
+    def test_claim_default_owner_prefers_registered_work_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _isolated_env_with_fake_gh(tmp)
+            registered = run_airc(
+                ["identity", "register", "--name", "banach"],
+                env_overrides=env,
+            )
+            self.assertEqual(registered.returncode, 0, registered.stderr)
+            result = run_airc(
+                ["queue", "claim", "owner/repo#1", "--dry-run"],
+                env_overrides=env,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('"owner": "banach"', result.stdout)
+        self.assertIn("claim by banach", result.stdout)
 
     def test_heartbeat_sets_owner_and_last_heartbeat(self) -> None:
         body = self._dry_run_extract_body(


### PR DESCRIPTION
Closes #595

## Summary
- add `airc identity register --name <handle>` and `airc whoami` for first-class local work identity
- persist work identity under the AIRC scope session directory instead of making users manage env vars
- make queue add/claim/heartbeat/adopt default to the current work identity, while keeping env names as compatibility fallback

## Proof
- `bash -n airc lib/airc_bash/cmd_identity.sh lib/airc_bash/cmd_queue.sh`
- `python3 -m unittest discover -s test -p 'test_queue*.py'` -> 99 tests OK\n- `python3 -m unittest discover -s test` -> 380 tests OK, 50 skipped\n- smoke: `./airc identity register --name codex-main`; `./airc whoami`; `./airc queue add CambrianTech/airc --title "session identity smoke" --dry-run` showed owner `codex-main`\n