### PR TITLE
fix(queue): close already-merged queue cards

### DIFF
--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -2159,21 +2159,32 @@ print("not-a-card")
         continue
         ;;
       merged)
-        printf '  [skip]       %s — already status=merged (idempotent)\n' "$ref"
-        skipped_count=$((skipped_count + 1))
-        continue
+        # Status mutation is idempotent, but closure is not. A prior
+        # heartbeat/set-status may have moved the card to merged before
+        # close-merged runs; if the GitHub issue is still open, this
+        # command must still close it so merged cards leave the live queue.
         ;;
     esac
 
     local log_msg="merged via PR ${pr_canonical_url} @ ${merge_sha:0:8} (closed by ${actor})"
 
     if [ "$dry_run" -eq 1 ]; then
-      printf '  [dry-run]    %s — would set status=merged + close (was: %s)\n' "$ref" "$envelope_status"
+      if [ "$envelope_status" = "merged" ]; then
+        printf '  [dry-run]    %s — would close already status=merged card\n' "$ref"
+      else
+        printf '  [dry-run]    %s — would set status=merged + close (was: %s)\n' "$ref" "$envelope_status"
+      fi
       closed_count=$((closed_count + 1))
       continue
     fi
 
-    if ! _airc_queue_mutate_card "$ref" 0 "$log_msg" --set "status=merged" >/dev/null 2>&1; then
+    if [ "$envelope_status" = "merged" ]; then
+      if ! _airc_queue_mutate_card "$ref" 0 "$log_msg" >/dev/null 2>&1; then
+        printf '  [error]      %s — status-log mutation failed\n' "$ref"
+        errored_count=$((errored_count + 1))
+        continue
+      fi
+    elif ! _airc_queue_mutate_card "$ref" 0 "$log_msg" --set "status=merged" >/dev/null 2>&1; then
       printf '  [error]      %s — status mutation failed\n' "$ref"
       errored_count=$((errored_count + 1))
       continue
@@ -2186,7 +2197,11 @@ print("not-a-card")
       continue
     fi
 
-    printf '  [closed]     %s — status=merged, issue closed (was: %s)\n' "$ref" "$envelope_status"
+    if [ "$envelope_status" = "merged" ]; then
+      printf '  [closed]     %s — already status=merged, issue closed\n' "$ref"
+    else
+      printf '  [closed]     %s — status=merged, issue closed (was: %s)\n' "$ref" "$envelope_status"
+    fi
     closed_count=$((closed_count + 1))
   done
 

--- a/test/test_queue_close_merged.py
+++ b/test/test_queue_close_merged.py
@@ -6,7 +6,7 @@ Coverage:
   - PR-not-merged guard: refuses to close cards from an unmerged PR
   - ref parsing: same-repo (#N, Closes #N), cross-repo (owner/repo#N)
   - envelope verification: skips non-airc-queue issues silently
-  - idempotency: skips cards already at status=merged
+  - idempotency: closes open cards already at status=merged
   - cross-repo: detected + reported, NOT closed (workflow token scope)
   - dry-run: emits plan without mutating or closing
   - actor flag: shows up in status-log line
@@ -418,15 +418,16 @@ class CloseMergedEnvelopeTests(unittest.TestCase):
         # And the summary should reflect 0 closed.
         self.assertIn("0 closed", result.stdout)
 
-    def test_skips_already_merged_card(self) -> None:
-        # Idempotent: re-running on a card that's already status=merged
-        # is a skip, not an error.
+    def test_dry_run_closes_already_merged_card(self) -> None:
+        # Idempotent status mutation is not the same as issue closure:
+        # if the issue is still open, close-merged must still plan a close.
         body = "Closes #100.\n"
         issue_bodies = {"100": _card_body(status="merged")}
         result = self._run_dry(body, issue_bodies=issue_bodies)
         self.assertEqual(result.returncode, 0)
-        self.assertIn("already status=merged", result.stdout)
-        self.assertIn("[skip]", result.stdout)
+        self.assertIn("would close already status=merged card", result.stdout)
+        self.assertIn("[dry-run]", result.stdout)
+        self.assertIn("1 closed", result.stdout)
 
 
 # ─────────────────────────────────────────────────────────────────
@@ -476,6 +477,42 @@ class CloseMergedE2ETests(unittest.TestCase):
         self.assertIn("https://github.com/CambrianTech/airc/pull/574", edit_body,
                       "status-log entry must include the PR URL for audit")
 
+        self.assertTrue(close_recorded,
+                        "fake gh must have received an issue close call for #100")
+
+    def test_real_close_closes_already_merged_open_card(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _fake_gh(
+                tmp,
+                pr_body="Closes #100.\n",
+                pr_merge_sha="168c666abcdef0123456789",
+                issue_bodies={"100": _card_body(status="merged")},
+            )
+            result = run_airc(
+                ["queue", "close-merged",
+                 "https://github.com/CambrianTech/airc/pull/574",
+                 "--actor", "github-actions[airc#576]"],
+                env_overrides=env,
+            )
+            record_dir = pathlib.Path(tmp) / "gh-record"
+            edit_file = record_dir / "edit-100.txt"
+            close_file = record_dir / "close-100.txt"
+            edit_body = edit_file.read_text(encoding="utf-8") if edit_file.exists() else None
+            close_recorded = close_file.exists()
+
+        self.assertEqual(result.returncode, 0,
+                         f"expected success; stdout={result.stdout} stderr={result.stderr}")
+        self.assertIn("[closed]", result.stdout)
+        self.assertIn("already status=merged, issue closed", result.stdout)
+        self.assertIn("1 closed", result.stdout)
+
+        self.assertIsNotNone(edit_body,
+                             "already-merged close must still append audit log")
+        self.assertIn('"status": "merged"', edit_body,
+                      "status remains merged")
+        self.assertIn("Status log", edit_body)
+        self.assertIn("168c666a", edit_body,
+                      "audit log must include merge SHA prefix")
         self.assertTrue(close_recorded,
                         "fake gh must have received an issue close call for #100")
 


### PR DESCRIPTION
## Summary
- Fix `airc queue close-merged` so `status=merged` is idempotent only for status mutation, not issue closure.
- If a referenced queue card is already `status=merged` but the GitHub issue is still open, append the audit log and close the issue.
- Update dry-run and real-close regression coverage for already-merged cards.

Triggered by Continuum flywheel test in CambrianTech/continuum#1160: merged cards stayed in the open queue after manual status reconciliation.

## Proof
- `python3 -m unittest discover -s test -p 'test_queue_close_merged.py'` -> 21 tests OK
- `python3 -m unittest discover -s test` -> 381 tests OK, 50 skipped
