### PR TITLE
fix(queue): require closing keywords for close-merged

### DIFF
--- a/.github/workflows/auto-close-queue-cards.yml
+++ b/.github/workflows/auto-close-queue-cards.yml
@@ -15,10 +15,12 @@ name: auto-close-queue-cards
 #   needed manual `gh issue close` cleanup.
 #
 # What it does:
-#   On PR merge into canary, parses the PR body for queue-card refs
-#   (Closes #N, queue card #N, owner/repo#N, etc.), verifies each is an
-#   airc-queue-card-v1 envelope, sets status=merged with a status-log
-#   line citing this PR + merge SHA, then closes the issue.
+#   On PR merge into canary, parses the PR body for explicit queue-card
+#   closing refs (Closes/Fixes/Resolves #N, or owner/repo#N with the same
+#   closing keywords), verifies each is an airc-queue-card-v1 envelope,
+#   sets status=merged with a status-log line citing this PR + merge SHA,
+#   then closes the issue. Plain mentions ("Refs #N", "See #N") do not
+#   close cards; they may point at follow-up implementation work.
 #
 #   Runs `airc queue close-merged` from the checkout — no install
 #   step required because the `./airc` dispatcher works from a clone

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -1960,14 +1960,15 @@ PYEOF
 }
 
 _cmd_queue_close_merged() {
-  # Auto-close queue cards referenced by a merged PR.
+  # Auto-close queue cards explicitly completed by a merged PR.
   #
   # Args:
   #   airc queue close-merged <pr-url|owner/repo#PR> [--merge-sha SHA] [--actor X] [--dry-run]
   #
   # GitHub's native "Closes #N" only triggers when the PR merges into the
   # default branch. AIRC uses canary first, so queue cards need a canary-time
-  # close path.
+  # close path. Plain mentions ("Refs #N", "See #N") are intentionally not
+  # close targets; they may describe related work that remains open.
   local pr_url=""
   local merge_sha=""
   local actor=""
@@ -2078,22 +2079,42 @@ body = pr.get("body") or ""
 title = pr.get("title") or ""
 text = f"{title}\n{body}"
 
-CROSS_RE = re.compile(r'\b([A-Za-z0-9][A-Za-z0-9._-]*)/([A-Za-z0-9][A-Za-z0-9._-]*)#(\d+)\b')
-SAME_RE = re.compile(r'(?<![A-Za-z0-9_/])#(\d+)\b')
+CLOSING_KEYWORD_RE = re.compile(
+    r'\b(?:close[sd]?|fix(?:e[sd]|ed)?|resolve[sd]?)\b\s*:?\s*',
+    re.IGNORECASE,
+)
+REF_RE = re.compile(
+    r'\b([A-Za-z0-9][A-Za-z0-9._-]*)/([A-Za-z0-9][A-Za-z0-9._-]*)#(\d+)\b'
+    r'|(?<![A-Za-z0-9_/])#(\d+)\b'
+)
 
 seen = set()
-for m in CROSS_RE.finditer(text):
-    owner, repo, num = m.group(1), m.group(2), m.group(3)
-    key = f"{owner}/{repo}#{num}"
-    if key not in seen:
-        seen.add(key)
-        print(key)
-for m in SAME_RE.finditer(text):
-    num = m.group(1)
-    key = f"{default_repo}#{num}"
-    if key not in seen:
-        seen.add(key)
-        print(key)
+for keyword in CLOSING_KEYWORD_RE.finditer(text):
+    # Match GitHub-style close intent. Refs must appear immediately after the
+    # closing keyword, with optional comma/"and" continuations. This avoids
+    # closing cards for prose like "Fix the UI. See #100 for follow-up."
+    pos = keyword.end()
+    first = True
+    while True:
+        tail = text[pos:]
+        if not first:
+            sep = re.match(r'\s*(?:,|and)\s+', tail, re.IGNORECASE)
+            if not sep:
+                break
+            pos += sep.end()
+            tail = text[pos:]
+        ref = REF_RE.match(tail)
+        if not ref:
+            break
+        if ref.group(4):
+            key = f"{default_repo}#{ref.group(4)}"
+        else:
+            key = f"{ref.group(1)}/{ref.group(2)}#{ref.group(3)}"
+        if key not in seen:
+            seen.add(key)
+            print(key)
+        pos += ref.end()
+        first = False
 PYEOF
   then
     rm -f "$pr_file" "$refs_file"
@@ -2110,10 +2131,10 @@ PYEOF
   rm -f "$refs_file"
 
   printf 'queue close-merged: PR %s merged into %s @ %s\n' "$pr_canonical_url" "$pr_base_ref" "${merge_sha:0:8}"
-  printf 'queue close-merged: scanned %d title/body refs (PR title %d chars, body %d chars)\n' "${#refs[@]}" "$pr_title_len" "$pr_body_len"
+  printf 'queue close-merged: scanned %d title/body closing refs (PR title %d chars, body %d chars)\n' "${#refs[@]}" "$pr_title_len" "$pr_body_len"
 
   if [ "${#refs[@]}" -eq 0 ]; then
-    printf 'queue close-merged: no queue-card refs in PR title/body — nothing to close.\n'
+    printf 'queue close-merged: no queue-card closing refs in PR title/body — nothing to close.\n'
     return 0
   fi
 
@@ -2644,7 +2665,7 @@ EOF
 
 _airc_queue_close_merged_help() {
   cat <<'EOF'
-airc queue close-merged — auto-close queue cards referenced by a merged PR
+airc queue close-merged — auto-close queue cards completed by a merged PR
 
 USAGE
   airc queue close-merged <pr-url> [--merge-sha SHA] [--actor X] [--dry-run]
@@ -2666,8 +2687,11 @@ OPTIONS
 WHAT IT DOES
   1. Fetches the PR body via gh.
   2. Validates the PR is actually merged.
-  3. Parses the body for same-repo and cross-repo queue-card refs.
+  3. Parses the body for same-repo and cross-repo queue-card closing refs
+     with GitHub-style closing keywords (Closes/Fixes/Resolves).
   4. For same-repo queue cards: sets status=merged and closes the issue.
-  5. Cross-repo refs are reported but not closed with repo-scoped tokens.
+  5. Cross-repo closing refs are reported but not closed with repo-scoped tokens.
+  Plain mentions like "Refs #N" are ignored so doc-only PRs do not close
+  implementation cards.
 EOF
 }

--- a/test/test_queue_close_merged.py
+++ b/test/test_queue_close_merged.py
@@ -4,7 +4,7 @@ Coverage:
   - dispatch: close-merged subcommand reaches _cmd_queue_close_merged + --help works
   - validation: missing PR url, malformed url, --merge-sha sanity
   - PR-not-merged guard: refuses to close cards from an unmerged PR
-  - ref parsing: same-repo (#N, Closes #N), cross-repo (owner/repo#N)
+  - ref parsing: same-repo and cross-repo refs with explicit close keywords
   - envelope verification: skips non-airc-queue issues silently
   - idempotency: closes open cards already at status=merged
   - cross-repo: detected + reported, NOT closed (workflow token scope)
@@ -312,11 +312,11 @@ class CloseMergedRefParserTests(unittest.TestCase):
         )
         return result, pathlib.Path(tmp)
 
-    def test_title_ref_detected(self) -> None:
+    def test_title_closing_ref_detected(self) -> None:
         tmp = tempfile.mkdtemp()
         env = _fake_gh(
             tmp,
-            pr_title="feat(#576): auto-close queue cards when PRs merge into canary",
+            pr_title="fix: close queue card. Closes #576",
             pr_body="Body has unrelated #561.\n",
             issue_bodies={
                 "576": _card_body(),
@@ -330,9 +330,30 @@ class CloseMergedRefParserTests(unittest.TestCase):
             env_overrides=env,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("title/body refs", result.stdout)
+        self.assertIn("title/body closing refs", result.stdout)
         self.assertIn("CambrianTech/airc#576", result.stdout)
         self.assertIn("[dry-run]", result.stdout)
+
+    def test_title_context_ref_is_not_close_target(self) -> None:
+        tmp = tempfile.mkdtemp()
+        env = _fake_gh(
+            tmp,
+            pr_title="feat(#576): document queue cards",
+            pr_body="Body has unrelated #561.\n",
+            issue_bodies={
+                "576": _card_body(),
+                "561": "Plain issue, not a queue card.\n",
+            },
+        )
+        result = run_airc(
+            ["queue", "close-merged",
+             "https://github.com/CambrianTech/airc/pull/581",
+             "--dry-run"],
+            env_overrides=env,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("nothing to close", result.stdout)
+        self.assertNotIn("CambrianTech/airc#576", result.stdout)
 
     def test_no_refs_clean_exit(self) -> None:
         body = "Just a PR body with no issue refs.\n"
@@ -351,13 +372,48 @@ class CloseMergedRefParserTests(unittest.TestCase):
         self.assertIn("[dry-run]", result.stdout,
                       "dry-run path should mark as would-close")
 
-    def test_bare_hash_n_detected(self) -> None:
-        # #100 (no Closes keyword) — still detected via SAME_RE.
+    def test_bare_hash_n_is_not_a_close_target(self) -> None:
+        # #100 without a closing keyword is context only. It must not close
+        # implementation cards from docs-only PRs that say "Refs #N".
         body = "See #100 for context.\n"
         issue_bodies = {"100": _card_body()}
         result, _ = self._run_dry(body, issue_bodies=issue_bodies)
         self.assertEqual(result.returncode, 0)
+        self.assertIn("nothing to close", result.stdout)
+        self.assertNotIn("CambrianTech/airc#100", result.stdout)
+
+    def test_refs_keyword_is_not_a_close_target(self) -> None:
+        body = "Refs #100.\n"
+        issue_bodies = {"100": _card_body()}
+        result, _ = self._run_dry(body, issue_bodies=issue_bodies)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("nothing to close", result.stdout)
+        self.assertNotIn("CambrianTech/airc#100", result.stdout)
+
+    def test_fixes_keyword_closes_same_repo_ref(self) -> None:
+        body = "Fixes #100.\n"
+        issue_bodies = {"100": _card_body()}
+        result, _ = self._run_dry(body, issue_bodies=issue_bodies)
+        self.assertEqual(result.returncode, 0)
         self.assertIn("CambrianTech/airc#100", result.stdout)
+        self.assertIn("[dry-run]", result.stdout)
+
+    def test_closing_word_prose_does_not_close_later_ref(self) -> None:
+        body = "Fix the queue docs. See #100 for implementation.\n"
+        issue_bodies = {"100": _card_body()}
+        result, _ = self._run_dry(body, issue_bodies=issue_bodies)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("nothing to close", result.stdout)
+        self.assertNotIn("CambrianTech/airc#100", result.stdout)
+
+    def test_closing_keyword_accepts_comma_continuation(self) -> None:
+        body = "Closes #100, #101 and #102.\n"
+        issue_bodies = {"100": _card_body(), "101": _card_body(), "102": _card_body()}
+        result, _ = self._run_dry(body, issue_bodies=issue_bodies)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("CambrianTech/airc#100", result.stdout)
+        self.assertIn("CambrianTech/airc#101", result.stdout)
+        self.assertIn("CambrianTech/airc#102", result.stdout)
 
     def test_cross_repo_ref_detected_not_closed(self) -> None:
         # Cross-repo ref must surface in summary as cross-repo, not closed.


### PR DESCRIPTION
## Summary
- Tighten `airc queue close-merged` so it only closes cards referenced with explicit GitHub-style closing keywords: `Closes`, `Fixes`, or `Resolves`.
- Ignore plain mentions like `Refs #N`, `See #N`, and title context such as `feat(#N)` so docs-only or related-work PRs do not silently close implementation cards.
- Update the auto-close workflow docs and parser tests for the new contract.

Closes #600

## Proof
- `python3 -m unittest discover -s test -p 'test_queue_close_merged.py'` -> 26 OK
- `python3 -m unittest discover -s test` -> 386 OK, 50 skipped
