### PR TITLE
feat(queue,#1174-airc-side): --allow-cross-repo flag for close-merged

### DIFF
--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -1965,16 +1965,25 @@ _cmd_queue_close_merged() {
   # Auto-close queue cards explicitly completed by a merged PR.
   #
   # Args:
-  #   airc queue close-merged <pr-url|owner/repo#PR> [--merge-sha SHA] [--actor X] [--dry-run]
+  #   airc queue close-merged <pr-url|owner/repo#PR> [--merge-sha SHA] [--actor X] [--allow-cross-repo] [--dry-run]
   #
   # GitHub's native "Closes #N" only triggers when the PR merges into the
   # default branch. AIRC uses canary first, so queue cards need a canary-time
   # close path. Plain mentions ("Refs #N", "See #N") are intentionally not
   # close targets; they may describe related work that remains open.
+  #
+  # Cross-repo close (--allow-cross-repo) requires gh to be authenticated
+  # with a token that has issues:write on the OTHER repo (continuum#1174):
+  # the workflow's auto-issued GITHUB_TOKEN is repo-scoped and can't close
+  # cross-repo refs. Operator supplies a fine-grained PAT or GitHub App
+  # installation token via the workflow's GH_TOKEN env. Without the flag
+  # (default), cross-repo refs are detected + reported but NOT closed —
+  # preserves backward compatibility with existing repo-scoped workflows.
   local pr_url=""
   local merge_sha=""
   local actor=""
   local dry_run=0
+  local allow_cross_repo=0
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -1982,9 +1991,10 @@ _cmd_queue_close_merged() {
         _airc_queue_close_merged_help
         return 0
         ;;
-      --merge-sha) shift; merge_sha="${1:-}" ;;
-      --actor)     shift; actor="${1:-}" ;;
-      --dry-run)   dry_run=1 ;;
+      --merge-sha)        shift; merge_sha="${1:-}" ;;
+      --actor)            shift; actor="${1:-}" ;;
+      --dry-run)          dry_run=1 ;;
+      --allow-cross-repo) allow_cross_repo=1 ;;
       -*) die "queue close-merged: unknown flag: $1" ;;
       *)
         if [ -z "$pr_url" ]; then
@@ -2147,9 +2157,19 @@ PYEOF
     ref_num="${ref##*#}"
 
     if [ "$ref_repo" != "$pr_repo" ]; then
-      printf '  [cross-repo] %s — skipped (workflow GITHUB_TOKEN is repo-scoped)\n' "$ref"
+      if [ "$allow_cross_repo" -eq 0 ]; then
+        printf '  [cross-repo] %s — skipped (--allow-cross-repo not set; default GITHUB_TOKEN is repo-scoped)\n' "$ref"
+        cross_repo_count=$((cross_repo_count + 1))
+        continue
+      fi
+      # Fall through to normal close path. gh's auth context (GH_TOKEN
+      # env or `gh auth login`) decides whether the close actually
+      # succeeds — if the token doesn't have issues:write on $ref_repo,
+      # the close call fails loudly with the gh API error and we count
+      # it as errored (NOT a silent skip). Operator supplies the
+      # broader-scoped token via the workflow's GH_TOKEN secret.
+      printf '  [cross-repo] %s — attempting close (--allow-cross-repo set; relying on gh auth scope)\n' "$ref"
       cross_repo_count=$((cross_repo_count + 1))
-      continue
     fi
 
     local issue_body
@@ -2670,21 +2690,30 @@ _airc_queue_close_merged_help() {
 airc queue close-merged — auto-close queue cards completed by a merged PR
 
 USAGE
-  airc queue close-merged <pr-url> [--merge-sha SHA] [--actor X] [--dry-run]
-  airc queue close-merged owner/repo#PR [--merge-sha SHA] [--actor X] [--dry-run]
+  airc queue close-merged <pr-url> [--merge-sha SHA] [--actor X] [--allow-cross-repo] [--dry-run]
+  airc queue close-merged owner/repo#PR [--merge-sha SHA] [--actor X] [--allow-cross-repo] [--dry-run]
 
 ARGUMENTS
-  <pr-url>           GitHub PR URL (https://github.com/.../pull/N) OR
-                     owner/repo#N short form. PR must already be merged.
+  <pr-url>            GitHub PR URL (https://github.com/.../pull/N) OR
+                      owner/repo#N short form. PR must already be merged.
 
 OPTIONS
-  --merge-sha SHA    Merge commit SHA for the audit trail. If omitted,
-                     pulled from PR metadata (mergeCommit.oid).
-  --actor X          Identity recorded in the status-log entry. Defaults
-                     to current work identity. CI passes
-                     "github-actions" so the audit trail names the system.
-  --dry-run          Show what WOULD be closed; don't mutate or close.
-  -h, --help         This help.
+  --merge-sha SHA     Merge commit SHA for the audit trail. If omitted,
+                      pulled from PR metadata (mergeCommit.oid).
+  --actor X           Identity recorded in the status-log entry. Defaults
+                      to current work identity. CI passes
+                      "github-actions" so the audit trail names the system.
+  --allow-cross-repo  Attempt to close cross-repo queue-card refs (default:
+                      report-only). Requires gh to be authenticated with a
+                      token that has issues:write on the OTHER repo —
+                      typically a fine-grained PAT or GitHub App
+                      installation token, supplied via the workflow's
+                      GH_TOKEN secret. Without this flag, cross-repo refs
+                      are detected + reported but NOT closed (preserves
+                      backward compat with existing repo-scoped workflows).
+                      See continuum#1174 for the design rationale.
+  --dry-run           Show what WOULD be closed; don't mutate or close.
+  -h, --help          This help.
 
 WHAT IT DOES
   1. Fetches the PR body via gh.
@@ -2692,7 +2721,10 @@ WHAT IT DOES
   3. Parses the body for same-repo and cross-repo queue-card closing refs
      with GitHub-style closing keywords (Closes/Fixes/Resolves).
   4. For same-repo queue cards: sets status=merged and closes the issue.
-  5. Cross-repo closing refs are reported but not closed with repo-scoped tokens.
+  5. Cross-repo closing refs are reported. With --allow-cross-repo set,
+     attempts the close (gh's auth scope decides if it actually succeeds —
+     failures count as errored, not silent skips). Without the flag, they
+     are skipped with a count in the summary.
   Plain mentions like "Refs #N" are ignored so doc-only PRs do not close
   implementation cards.
 EOF

--- a/test/test_queue_close_merged.py
+++ b/test/test_queue_close_merged.py
@@ -416,15 +416,16 @@ class CloseMergedRefParserTests(unittest.TestCase):
         self.assertIn("CambrianTech/airc#102", result.stdout)
 
     def test_cross_repo_ref_detected_not_closed(self) -> None:
-        # Cross-repo ref must surface in summary as cross-repo, not closed.
+        # Cross-repo ref must surface in summary as cross-repo, not closed
+        # by default. (--allow-cross-repo flag opt-in is tested separately.)
         body = "Closes CambrianTech/continuum#1130.\n"
         result, _ = self._run_dry(body)
         self.assertEqual(result.returncode, 0)
         self.assertIn("CambrianTech/continuum#1130", result.stdout)
         self.assertIn("[cross-repo]", result.stdout,
                       "cross-repo refs must be marked, not closed")
-        self.assertIn("workflow GITHUB_TOKEN is repo-scoped",
-                      result.stdout)
+        self.assertIn("--allow-cross-repo not set", result.stdout,
+                      "skip message must explain how to enable cross-repo close")
 
     def test_dedup_repeated_ref(self) -> None:
         # Same #N referenced twice → process once.
@@ -594,6 +595,71 @@ class CloseMergedE2ETests(unittest.TestCase):
                          "dry-run MUST NOT call gh issue edit")
         self.assertFalse(close_file.exists(),
                          "dry-run MUST NOT call gh issue close")
+
+
+# ─────────────────────────────────────────────────────────────────
+# Cross-repo close (--allow-cross-repo flag, continuum#1174)
+# ─────────────────────────────────────────────────────────────────
+
+class CloseMergedCrossRepoTests(unittest.TestCase):
+    """The --allow-cross-repo flag opts in to attempting close calls
+    against issues in OTHER repos. Without the flag (default), cross-
+    repo refs are detected + reported but not closed. With the flag,
+    the close call is attempted and gh's auth context decides whether
+    it actually succeeds.
+
+    These tests use --dry-run so no real gh close happens; they verify
+    the dispatch + reporting path differs based on the flag."""
+
+    def _run(self, body: str, extra_args: list[str]
+             ) -> subprocess.CompletedProcess[str]:
+        tmp = tempfile.mkdtemp()
+        env = _fake_gh(tmp, pr_body=body)
+        return run_airc(
+            ["queue", "close-merged",
+             "https://github.com/CambrianTech/airc/pull/574"] + extra_args,
+            env_overrides=env,
+        )
+
+    def test_default_skips_cross_repo_with_recovery_hint(self) -> None:
+        """Default (no flag): cross-repo refs are skipped, message names
+        the flag operators need to enable cross-repo close. Backward-
+        compat with existing repo-scoped workflows."""
+        body = "Closes CambrianTech/continuum#1130.\n"
+        result = self._run(body, ["--dry-run"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("[cross-repo]", result.stdout)
+        self.assertIn("CambrianTech/continuum#1130", result.stdout)
+        self.assertIn("--allow-cross-repo not set", result.stdout,
+                      "skip message must explain how to enable cross-repo")
+        self.assertIn("1 cross-repo", result.stdout,
+                      "summary must count the cross-repo skip")
+
+    def test_allow_cross_repo_attempts_close(self) -> None:
+        """With --allow-cross-repo + --dry-run: cross-repo ref reaches
+        the dry-run [dry-run] line instead of the [cross-repo] skip
+        line. Proves the flag changes the dispatch path."""
+        body = "Closes CambrianTech/continuum#1130.\n"
+        result = self._run(body, ["--allow-cross-repo", "--dry-run"])
+        self.assertEqual(result.returncode, 0,
+                         f"dry-run with --allow-cross-repo must succeed; "
+                         f"stderr={result.stderr}")
+        # The [cross-repo] line still appears (announcing the attempt),
+        # but the ref ALSO reaches the dry-run path (would-close summary).
+        self.assertIn("[cross-repo]", result.stdout,
+                      "cross-repo refs are still announced for visibility")
+        self.assertIn("attempting close", result.stdout,
+                      "with --allow-cross-repo, message must say attempting")
+        self.assertIn("1 cross-repo", result.stdout,
+                      "summary still counts the cross-repo ref")
+
+    def test_unknown_flag_still_rejected(self) -> None:
+        """Smoke: --allow-cross-repo doesn't disable the unknown-flag
+        guard. A typo of the new flag is rejected loudly."""
+        body = "Closes #100.\n"
+        result = self._run(body, ["--allow-x-repo", "--dry-run"])
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unknown flag", result.stdout + result.stderr)
 
 
 # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

PR-1 of continuum#1174 (close-merged flywheel reliability) — airc-side flag enabling cross-repo close attempts.

## Why

continuum#1174 calls out the biggest reliability gap in today's auto-close substrate: a PR in airc that says \"Closes CambrianTech/continuum#1130\" can't actually close the continuum card because the workflow's auto-issued `GITHUB_TOKEN` is repo-scoped. Currently the subcommand DETECTS cross-repo refs but unconditionally skips the close. This PR adds the opt-in flag.

## What lands

`lib/airc_bash/cmd_queue.sh`:
- New `--allow-cross-repo` flag (default off → unchanged behavior).
- When set, cross-repo refs fall through to the normal close path; gh's auth context decides whether the close actually succeeds. Failures count as errored, not silent skips.
- Skip message names the flag so operators know how to enable: `\"--allow-cross-repo not set; default GITHUB_TOKEN is repo-scoped\"`.
- Help text updated with the flag + the auth requirement (fine-grained PAT or GitHub App installation token via workflow `GH_TOKEN` secret).

`test/test_queue_close_merged.py`:
- New `CloseMergedCrossRepoTests` (3 tests): default skips with recovery hint, flag reaches the close path, typo of new flag still rejected.
- Fixed 1 pre-existing test that asserted the old skip message.

## Test plan

- [x] `bash -n` clean
- [x] 29/29 test_queue_close_merged green (was 26; +3 new)
- [x] Default (no flag) preserves existing behavior — backward compat for current workflows
- [ ] Live smoke once continuum-side workflow PR (sequenced follow-up) lands + a real cross-repo card test

## Out of scope (separate PRs)

- **continuum-side workflow update** — pass `--allow-cross-repo` + supply cross-repo PAT secret. Lands as a separate PR in continuum repo, sequenced after this merges so the airc CLI version on canary has the flag.
- **Fine-grained PAT / GitHub App setup docs** for operators.
- **Retry-on-gh-API-blip** for transient network failures — PR-2 of continuum#1174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)