### PR TITLE
feat(queue): add metronome idle pulse

### DIFF
--- a/airc
+++ b/airc
@@ -2134,6 +2134,42 @@ reminder_timer_loop() {
       fi
     fi
 
+    # Queue metronome: action-oriented idle pulse for AI agents. Reminder
+    # only says "you have been silent"; metronome says "here are claimable
+    # cards and the exact claim/lane commands." It runs on monitor cadence
+    # and never exits the monitor if GitHub/network is temporarily down.
+    local queue_metronome_file="$AIRC_WRITE_DIR/queue_metronome"
+    if [ -f "$queue_metronome_file" ]; then
+      local qm_repo="" qm_owner="" qm_interval=300 qm_limit=10 qm_repo_root=""
+      while IFS='=' read -r key value; do
+        case "$key" in
+          repo) qm_repo="$value" ;;
+          owner) qm_owner="$value" ;;
+          interval) qm_interval="$value" ;;
+          limit) qm_limit="$value" ;;
+          repo_root) qm_repo_root="$value" ;;
+        esac
+      done < "$queue_metronome_file"
+      if [ -n "$qm_repo" ] && [ -n "$qm_interval" ] && [ "$qm_interval" -gt 0 ] 2>/dev/null; then
+        local qm_last_file="$AIRC_WRITE_DIR/queue_metronome_last"
+        local qm_last=0
+        [ -f "$qm_last_file" ] && qm_last=$(cat "$qm_last_file" 2>/dev/null)
+        local qm_elapsed=$(( now - qm_last ))
+        if [ "$qm_elapsed" -ge "$qm_interval" ]; then
+          printf '%s\n' "$now" > "$qm_last_file"
+          local qm_args=(next "$qm_repo" --limit "$qm_limit" --idle-ping)
+          if [ -n "$qm_owner" ]; then
+            qm_args+=(--owner "$qm_owner")
+          fi
+          if [ -n "$qm_repo_root" ]; then
+            qm_args+=(--repo-root "$qm_repo_root")
+          fi
+          printf '[%s] airc: Queue metronome pulse — checking next work for %s\n' "$(timestamp)" "$qm_repo"
+          cmd_queue "${qm_args[@]}" || printf '[%s] airc: Queue metronome pulse failed; will retry on next interval.\n' "$(timestamp)"
+        fi
+      fi
+    fi
+
     # Receive-side silence beacon. If we have ANY bearer_state file at
     # all and its last_recv_ts is older than recv_threshold (or null
     # since process start), emit a stdout warning the user's Monitor

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -10,6 +10,7 @@
 #                 heartbeat  — stamp liveness on an owned card.
 #                 stale      — list owned cards with missing/old heartbeats.
 #                 next       — recommend claimable next work for idle agents.
+#                 metronome  — configure automatic queue-next idle pulses.
 #                 nudge      — surface a card OR repo-scoped status sweep.                [PR-3+]
 #                 adopt      — convert an existing issue into a queue card.
 #                 pongs      — summarize repo-nudge pong replies.
@@ -81,6 +82,9 @@ cmd_queue() {
     next|pick)
       _cmd_queue_next "$@"
       ;;
+    metronome|pulse)
+      _cmd_queue_metronome "$@"
+      ;;
     nudge)
       _cmd_queue_nudge "$@"
       ;;
@@ -97,7 +101,7 @@ cmd_queue() {
       _cmd_queue_close_merged "$@"
       ;;
     *)
-      die "queue: unknown subcommand: $subcmd (try: add, list, claim, release, set-status, heartbeat, stale, next, nudge, adopt, pongs, availability, close-merged)"
+      die "queue: unknown subcommand: $subcmd (try: add, list, claim, release, set-status, heartbeat, stale, next, metronome, nudge, adopt, pongs, availability, close-merged)"
       ;;
   esac
 }
@@ -378,6 +382,7 @@ USAGE
   airc queue heartbeat <issue-url> [--owner X] [--status Y] [--note "..."]
   airc queue stale <owner/repo> [--stale-after 30m]
   airc queue next [<owner/repo>] [--limit N] [--json]
+  airc queue metronome <owner/repo> [--interval 300]
   airc queue nudge <issue-url> [--peer @handle] [--message "..."]
   airc queue nudge <owner/repo> [--message "..."] [--limit N]
   airc queue adopt <issue-url> [card-fields...] [--force]
@@ -395,6 +400,7 @@ VERB SCOPE
   claim / release / set-status PR-2 (airc#568, merged)
   heartbeat / stale            Stale-claim liveness primitives (airc#572)
   next / pick                  Idle-agent next-work recommendations
+  metronome / pulse            Automatic queue-next idle pulse config
   nudge                        PR-3 (card) + PR-4a (repo ping/pong sweep)
   adopt / import               Backlog migration (airc#575)
   pongs / pong-summary          Repo-nudge response collection (airc#579)
@@ -1173,6 +1179,104 @@ PYEOF
       die "queue next: idle ping failed"
     fi
   fi
+}
+
+_cmd_queue_metronome() {
+  # Configure monitor-loop queue-next pulses. This is the automated half of
+  # `queue next`: monitor can periodically call the same primitive and
+  # broadcast candidates when an agent/session is quiet.
+  local target_repo=""
+  local interval=300
+  local owner=""
+  local limit=10
+  local repo_root=""
+  local off=0
+  local status=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -h|--help)
+        _airc_queue_metronome_help
+        return 0
+        ;;
+      off|disable)
+        off=1
+        ;;
+      status)
+        status=1
+        ;;
+      --interval)  shift; interval="${1:-300}" ;;
+      --owner)     shift; owner="${1:-}" ;;
+      --limit)     shift; limit="${1:-10}" ;;
+      --repo-root) shift; repo_root="${1:-}" ;;
+      -*) die "queue metronome: unknown flag: $1" ;;
+      *)
+        if [ -z "$target_repo" ]; then
+          target_repo="$1"
+        else
+          die "queue metronome: too many positional args (use: queue metronome <owner/repo>)"
+        fi
+        ;;
+    esac
+    shift || true
+  done
+
+  local config_file="$AIRC_WRITE_DIR/queue_metronome"
+
+  if [ "$off" -eq 1 ]; then
+    rm -f "$config_file" "$AIRC_WRITE_DIR/queue_metronome_last"
+    echo "  Queue metronome off."
+    return 0
+  fi
+
+  if [ "$status" -eq 1 ] || { [ -z "$target_repo" ] && [ -f "$config_file" ]; }; then
+    if [ -f "$config_file" ]; then
+      echo "  Queue metronome on:"
+      sed 's/^/    /' "$config_file"
+    else
+      echo "  Queue metronome off."
+    fi
+    return 0
+  fi
+
+  if [ -z "$target_repo" ]; then
+    target_repo=$(_airc_queue_detect_repo_from_cwd || true)
+  fi
+  if [ -z "$target_repo" ]; then
+    die "queue metronome: pass <owner/repo> or run inside a GitHub-backed checkout"
+  fi
+  case "$target_repo" in
+    */*) : ;;
+    *) die "queue metronome: target must be owner/repo, got: $target_repo" ;;
+  esac
+  case "$interval" in
+    ''|*[!0-9]*) die "queue metronome: --interval must be a positive integer seconds value (got: $interval)" ;;
+  esac
+  case "$limit" in
+    ''|*[!0-9]*) die "queue metronome: --limit must be a positive integer (got: $limit)" ;;
+  esac
+  if [ "$interval" -lt 30 ]; then
+    die "queue metronome: --interval must be >= 30 seconds to avoid spam (got: $interval)"
+  fi
+  if [ "$limit" -lt 1 ]; then
+    die "queue metronome: --limit must be >= 1 (got: $limit)"
+  fi
+  if [ -z "$owner" ]; then
+    owner=$(_airc_queue_resolve_name)
+  fi
+
+  mkdir -p "$AIRC_WRITE_DIR"
+  {
+    printf 'repo=%s\n' "$target_repo"
+    printf 'interval=%s\n' "$interval"
+    printf 'owner=%s\n' "$owner"
+    printf 'limit=%s\n' "$limit"
+    printf 'repo_root=%s\n' "$repo_root"
+  } > "$config_file"
+  rm -f "$AIRC_WRITE_DIR/queue_metronome_last"
+
+  echo "  Queue metronome every ${interval}s for ${target_repo} as ${owner}."
+  echo "  Monitor will run: airc queue next ${target_repo} --owner ${owner} --limit ${limit} --idle-ping"
 }
 
 _cmd_queue_adopt() {
@@ -2772,6 +2876,42 @@ NOTES
     claim/lane commands, then heartbeat while working.
   - Monitor/automation layers should call this after a merge, release, or
     idle timeout; humans should not need to manually wake agents.
+EOF
+}
+
+_airc_queue_metronome_help() {
+  cat <<'EOF'
+airc queue metronome — configure automatic queue-next idle pulses
+
+USAGE
+  airc queue metronome <owner/repo> [--interval 300] [--owner HANDLE] [--limit N]
+  airc queue metronome status
+  airc queue metronome off
+
+DESCRIPTION
+  Stores a monitor-loop metronome config. While `airc join`/monitor is
+  running, the monitor periodically runs:
+
+    airc queue next <owner/repo> --owner <handle> --limit <N> --idle-ping
+
+  That makes claimable work loud without waiting for a human to ask why
+  agents are idle.
+
+OPTIONS
+  --interval <seconds>   Pulse cadence. Minimum 30s; default 300s.
+  --owner <handle>       Agent/work identity used for claim suggestions.
+                         Default: current AIRC work identity.
+  --limit <N>            Max queue cards to scan per pulse (default 10).
+  --repo-root <path>     Optional repo path for suggested lane commands.
+  status                 Show current config.
+  off                    Disable metronome and clear last pulse timestamp.
+  -h, --help             This help.
+
+NOTES
+  - The metronome does not claim work by itself. It publishes exact next
+    commands so agents can claim deliberately.
+  - This is intentionally separate from plain `airc reminder`: reminders
+    only say "you are silent"; metronome says "here is what to do next."
 EOF
 }
 

--- a/test/test_queue_nudge.py
+++ b/test/test_queue_nudge.py
@@ -169,6 +169,14 @@ class QueueNudgeDispatchTests(unittest.TestCase):
         self.assertIn("recommend next claimable work", result.stdout)
         self.assertIn("--idle-ping", result.stdout)
 
+    def test_metronome_help_returns_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(["queue", "metronome", "--help"],
+                              env_overrides=_isolated_env(tmp))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("automatic queue-next idle pulses", result.stdout)
+        self.assertIn("metronome off", result.stdout)
+
     def test_nudge_help_returns_zero(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             result = run_airc(["queue", "nudge", "--help"],
@@ -341,6 +349,48 @@ class QueueNudgeDryRunTests(unittest.TestCase):
 
 
 class QueueRepoNudgeDryRunTests(unittest.TestCase):
+    def test_metronome_writes_actionable_monitor_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _isolated_env(tmp)
+            result = run_airc(
+                ["queue", "metronome", "owner/repo",
+                 "--interval", "60",
+                 "--owner", "codex-main",
+                 "--limit", "7",
+                 "--repo-root", "/work/repo"],
+                env_overrides=env,
+            )
+            config = pathlib.Path(env["AIRC_HOME"]) / "queue_metronome"
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Queue metronome every 60s", result.stdout)
+            text = config.read_text(encoding="utf-8")
+            self.assertIn("repo=owner/repo", text)
+            self.assertIn("interval=60", text)
+            self.assertIn("owner=codex-main", text)
+            self.assertIn("limit=7", text)
+            self.assertIn("repo_root=/work/repo", text)
+
+    def test_metronome_rejects_spammy_interval(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "metronome", "owner/repo", "--interval", "5"],
+                env_overrides=_isolated_env(tmp),
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--interval must be >= 30", result.stdout + result.stderr)
+
+    def test_metronome_off_removes_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _isolated_env(tmp)
+            result = run_airc(
+                ["queue", "metronome", "owner/repo", "--interval", "60"],
+                env_overrides=env,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            result = run_airc(["queue", "metronome", "off"], env_overrides=env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse((pathlib.Path(env["AIRC_HOME"]) / "queue_metronome").exists())
+
     def test_next_recommends_claimable_work_with_exact_commands(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             result = run_airc(


### PR DESCRIPTION
## Summary
- add `airc queue metronome` / `airc queue pulse` config for periodic queue-next idle pulses
- wire monitor reminder loop to run `airc queue next <repo> --owner <agent> --idle-ping` on the configured cadence
- keep the pulse action-oriented: it prints candidates and broadcasts an idle pickup request instead of only saying the agent is silent

Closes #606

## Proof
- `bash -n airc lib/airc_bash/cmd_queue.sh lib/airc_bash/cmd_reminder.sh`
- `python3 -m unittest discover -s test -p 'test_queue_nudge.py'` -> 34 tests OK\n- `python3 -m unittest discover -s test -p 'test_queue*.py'` -> 117 tests OK\n\n## Follow-up\n- post-merge hook should enable/run metronome automatically per agent identity\n- review-state cards should settle automatically so `queue next` does not recommend already-merged work\n- add a server-side scheduler so idle detection survives individual tab loops stopping