### PR TITLE
fix(queue): prevent accidental claim takeovers

### DIFF
--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -606,6 +606,7 @@ _cmd_queue_claim() {
   local new_owner=""
   local new_status="in-progress"
   local dry_run=0
+  local force=0
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -616,6 +617,7 @@ _cmd_queue_claim() {
       --owner)    shift; new_owner="${1:-}" ;;
       --status)   shift; new_status="${1:-}" ;;
       --dry-run)  dry_run=1 ;;
+      --force)    force=1 ;;
       -*) die "queue claim: unknown flag: $1" ;;
       *)
         if [ -z "$issue_url" ]; then
@@ -647,11 +649,78 @@ _cmd_queue_claim() {
   local heartbeat
   heartbeat=$(_airc_queue_heartbeat_value)
 
+  _airc_queue_claim_guard "$issue_url" "$new_owner" "$force"
+
   _airc_queue_mutate_card "$issue_url" "$dry_run" \
     "claim by $new_owner -> status=$new_status" \
     --set "owner=$new_owner" \
     --set "status=$new_status" \
     --set "last_heartbeat=$heartbeat"
+}
+
+_airc_queue_claim_guard() {
+  local issue_url="$1" new_owner="$2" force="$3"
+
+  local parsed_issue repo issue_num
+  if ! parsed_issue=$(_airc_queue_parse_issue_url "$issue_url"); then
+    die "queue: <issue-url> must be a GitHub issue URL or owner/repo#N (got: $issue_url)"
+  fi
+  repo="${parsed_issue%#*}"
+  issue_num="${parsed_issue##*#}"
+
+  if ! command -v gh >/dev/null 2>&1; then
+    die "queue: 'gh' CLI is required."
+  fi
+
+  local current_body
+  if ! current_body=$(gh issue view "$issue_num" --repo "$repo" --json body --jq .body 2>&1); then
+    die "queue: gh issue view failed for $repo#$issue_num: $current_body"
+  fi
+
+  local body_file
+  body_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-claim.XXXXXX") || die "queue: mktemp failed"
+  printf '%s' "$current_body" >"$body_file"
+
+  local fields
+  if ! fields=$("$AIRC_PYTHON" - "$body_file" <<'PYEOF'
+import json, re, sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    body = f.read()
+
+card = None
+for match in re.finditer(r'```json\s*\n(.*?)\n\s*```', body, re.DOTALL):
+    try:
+        parsed = json.loads(match.group(1).strip())
+    except Exception:
+        continue
+    if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
+        card = parsed
+        break
+
+if card is None:
+    print("queue claim: no kind=airc-queue-card-v1 envelope found in body", file=sys.stderr)
+    sys.exit(2)
+
+print((card.get("owner") or "").strip())
+print((card.get("status") or "").strip())
+PYEOF
+  ); then
+    rm -f "$body_file"
+    die "$fields"
+  fi
+  rm -f "$body_file"
+
+  local current_owner current_status
+  current_owner=$(printf '%s\n' "$fields" | sed -n '1p')
+  current_status=$(printf '%s\n' "$fields" | sed -n '2p')
+
+  if [ "$force" -eq 0 ] \
+    && [ -n "$current_owner" ] \
+    && [ "$current_owner" != "$new_owner" ] \
+    && [ "$current_status" != "merged" ]; then
+    die "queue claim: card already claimed by '$current_owner' (status=${current_status:-unknown}). Use --force to take over, or pick a different card via airc queue next."
+  fi
 }
 
 _cmd_queue_release() {
@@ -2733,17 +2802,22 @@ _airc_queue_claim_help() {
 airc queue claim — take ownership of a queue card
 
 USAGE
-  airc queue claim <issue-url> [--owner X] [--status Y] [--dry-run]
-  airc queue claim owner/repo#N [--owner X] [--status Y] [--dry-run]
+  airc queue claim <issue-url> [--owner X] [--status Y] [--force] [--dry-run]
+  airc queue claim owner/repo#N [--owner X] [--status Y] [--force] [--dry-run]
 
 DESCRIPTION
   Sets the card's owner field and status to indicate active work. Default
   owner = current work identity from `airc identity whoami`; default status = in-progress.
   Appends a "## Status log" line with timestamp + actor.
 
+  Collision protection is automatic: claiming a card already owned by a
+  different active owner fails before mutation. Use --force only for an
+  intentional handoff or stale-owner takeover.
+
 OPTIONS
   --owner <handle>   Queue owner to set (default: current work identity).
   --status <state>   New status (default: in-progress).
+  --force            Override a different active owner.
   --dry-run          Print the new body that WOULD be written; don't edit.
   -h, --help         This help.
 EOF

--- a/test/test_queue_claim.py
+++ b/test/test_queue_claim.py
@@ -52,21 +52,26 @@ def _isolated_env(tmp: str) -> dict[str, str]:
     }
 
 
-SYNTHETIC_CARD_BODY = '''**airc-queue card**
+def _card_body(owner: str | None = "previous-owner",
+               status: str = "claimed") -> str:
+    owner_line = f'  "owner": "{owner}",\n' if owner is not None else ""
+    return f'''**airc-queue card**
 
 Coordinates work via the AIRC queue substrate (airc#562). Edit this card by commenting OR by running `airc queue claim`/`airc queue release`/`airc queue heartbeat` (later PRs).
 
 ```json
-{
+{{
   "kind": "airc-queue-card-v1",
-  "owner": "previous-owner",
-  "status": "claimed",
+{owner_line}  "status": "{status}",
   "branch": "feat/x"
-}
+}}
 ```
 
 Close this issue when the work is done (status=merged/abandoned).
 '''
+
+
+SYNTHETIC_CARD_BODY = _card_body()
 
 
 def _isolated_env_with_fake_gh(tmp: str, body_response: str | None = None) -> dict[str, str]:
@@ -155,7 +160,10 @@ class QueueClaimValidationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             result = run_airc(
                 ["queue", "claim", "owner/repo#1", "--owner", "codex", "--dry-run"],
-                env_overrides=_isolated_env_with_fake_gh(tmp),
+                env_overrides=_isolated_env_with_fake_gh(
+                    tmp,
+                    body_response=_card_body(owner=None),
+                ),
             )
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("DRY RUN", result.stdout)
@@ -252,7 +260,7 @@ class QueueMutateBodyShapeTests(unittest.TestCase):
 
     def test_claim_sets_owner_and_status(self) -> None:
         body = self._dry_run_extract_body(
-            ["queue", "claim", "owner/repo#1", "--owner", "claude-tab-2"]
+            ["queue", "claim", "owner/repo#1", "--owner", "claude-tab-2", "--force"]
         )
         envelope = self._extract_envelope(body)
         self.assertEqual(envelope["owner"], "claude-tab-2")
@@ -266,7 +274,7 @@ class QueueMutateBodyShapeTests(unittest.TestCase):
 
     def test_claim_default_owner_prefers_queue_env(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            env = _isolated_env_with_fake_gh(tmp)
+            env = _isolated_env_with_fake_gh(tmp, body_response=_card_body(owner=None))
             env["AIRC_QUEUE_OWNER"] = "codex-main"
             result = run_airc(
                 ["queue", "claim", "owner/repo#1", "--dry-run"],
@@ -278,7 +286,7 @@ class QueueMutateBodyShapeTests(unittest.TestCase):
 
     def test_claim_default_owner_prefers_registered_work_identity(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            env = _isolated_env_with_fake_gh(tmp)
+            env = _isolated_env_with_fake_gh(tmp, body_response=_card_body(owner=None))
             registered = run_airc(
                 ["identity", "register", "--name", "banach"],
                 env_overrides=env,
@@ -291,6 +299,62 @@ class QueueMutateBodyShapeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn('"owner": "banach"', result.stdout)
         self.assertIn("claim by banach", result.stdout)
+
+    def test_claim_rejects_different_active_owner_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _isolated_env_with_fake_gh(
+                tmp,
+                body_response=_card_body(owner="claude-tab-1", status="in-progress"),
+            )
+            result = run_airc(
+                ["queue", "claim", "owner/repo#1", "--owner", "claude-tab-2", "--dry-run"],
+                env_overrides=env,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        combined = result.stdout + result.stderr
+        self.assertIn("already claimed by 'claude-tab-1'", combined)
+        self.assertIn("Use --force", combined)
+        self.assertNotIn("DRY RUN", result.stdout)
+
+    def test_claim_force_allows_handoff_from_different_owner(self) -> None:
+        body = self._dry_run_extract_body(
+            [
+                "queue", "claim", "owner/repo#1",
+                "--owner", "claude-tab-2",
+                "--force",
+            ],
+            body=_card_body(owner="claude-tab-1", status="in-progress"),
+        )
+        envelope = self._extract_envelope(body)
+        self.assertEqual(envelope["owner"], "claude-tab-2")
+        self.assertEqual(envelope["status"], "in-progress")
+
+    def test_claim_allows_same_owner_without_force(self) -> None:
+        body = self._dry_run_extract_body(
+            ["queue", "claim", "owner/repo#1", "--owner", "claude-tab-1"],
+            body=_card_body(owner="claude-tab-1", status="in-progress"),
+        )
+        envelope = self._extract_envelope(body)
+        self.assertEqual(envelope["owner"], "claude-tab-1")
+        self.assertEqual(envelope["status"], "in-progress")
+
+    def test_claim_allows_unclaimed_card_without_force(self) -> None:
+        body = self._dry_run_extract_body(
+            ["queue", "claim", "owner/repo#1", "--owner", "claude-tab-2"],
+            body=_card_body(owner=None, status="claimed"),
+        )
+        envelope = self._extract_envelope(body)
+        self.assertEqual(envelope["owner"], "claude-tab-2")
+        self.assertEqual(envelope["status"], "in-progress")
+
+    def test_claim_allows_merged_card_without_force(self) -> None:
+        body = self._dry_run_extract_body(
+            ["queue", "claim", "owner/repo#1", "--owner", "claude-tab-2"],
+            body=_card_body(owner="claude-tab-1", status="merged"),
+        )
+        envelope = self._extract_envelope(body)
+        self.assertEqual(envelope["owner"], "claude-tab-2")
+        self.assertEqual(envelope["status"], "in-progress")
 
     def test_heartbeat_sets_owner_and_last_heartbeat(self) -> None:
         body = self._dry_run_extract_body(


### PR DESCRIPTION
## Summary
- make queue claim safe by default: an existing active owner blocks takeover before mutation
- add --force as the explicit handoff/stale-owner override
- allow same-owner, unclaimed, and merged-card claims without extra flags
- update claim help so the default path is obvious and low-friction

## Validation
- bash -n lib/airc_bash/cmd_queue.sh
- python3 -m unittest discover -s test -p 'test_queue_claim.py' -v
- python3 -m unittest discover -s test -p 'test_queue*.py'
- git diff --check

Closes #611