### PR TITLE
fix(queue): default planning view and unclaimed-owner semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ coordination record every peer can inspect before starting work.
 Typical flow:
 
 ```bash
+airc queue CambrianTech/example
 airc queue add CambrianTech/example --title "fix websocket reconnect"
 airc queue list CambrianTech/example
 airc queue claim https://github.com/CambrianTech/example/issues/42
@@ -122,6 +123,22 @@ airc queue heartbeat https://github.com/CambrianTech/example/issues/42 \
   --note "tests reproduce; patch in progress"
 airc queue set-status https://github.com/CambrianTech/example/issues/42 review
 ```
+
+`airc queue` is the default planning view. It groups open queue cards into
+strategic lanes, infers P0/P1/P2 priority, shows review and merge candidates,
+active ownership, stale claims, and the next concrete moves. Agents should use
+it as the first command after finishing work or when they suspect the room is
+idle:
+
+```bash
+airc queue
+airc queue CambrianTech/example
+airc queue plan --json
+```
+
+The built-in lanes keep planning consistent across machines and tabs:
+`alpha-gap/rust-runtime`, `perf/resource-control`, `flywheel/automation`,
+`quality/tests-vdd`, `ui/configurator`, and `integration/canary`.
 
 For existing issues, adopt instead of duplicating:
 
@@ -292,6 +309,8 @@ airc doctor --health
 airc doctor --tests [scenario]
 
 # Work queue
+airc queue [<owner/repo>]
+airc queue plan [<owner/repo>]
 airc queue add <owner/repo> --title "<title>"
 airc queue adopt <owner/repo#N>
 airc queue list <owner/repo>

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -1366,6 +1366,13 @@ _cmd_queue_adopt() {
   local card_id=""
   local card_branch=""
   local card_owner=""
+  # Tracks whether --owner was explicitly passed (vs defaulting later to
+  # the current scope's resolve_name). Needed for airc#613: when an
+  # operator explicitly says `--owner unclaimed` for bulk adoption, we
+  # should NOT silently auto-fill the owner with the running agent's
+  # name on top of the unclaimed normalization. Without this flag we
+  # couldn't distinguish "user said no owner" from "user said nothing".
+  local owner_explicit=0
   local card_status="claimed"
   local card_blockers=""
   local card_env=""
@@ -1383,7 +1390,7 @@ _cmd_queue_adopt() {
         ;;
       --id)             shift; card_id="${1:-}" ;;
       --branch)         shift; card_branch="${1:-}" ;;
-      --owner)          shift; card_owner="${1:-}" ;;
+      --owner)          shift; card_owner="${1:-}"; owner_explicit=1 ;;
       --status)         shift; card_status="${1:-}" ;;
       --blockers)       shift; card_blockers="${1:-}" ;;
       --env)            shift; card_env="${1:-}" ;;
@@ -1403,6 +1410,19 @@ _cmd_queue_adopt() {
     esac
     shift || true
   done
+
+  # airc#613 — normalize the "unclaimed" sentinel to no-owner. Operators
+  # use `--owner unclaimed` for bulk-adoption ("this card is available;
+  # someone else will claim it later"), but writing the literal string
+  # into the envelope made the subsequent `airc queue claim` fail
+  # collision protection (airc#612) because owner=unclaimed reads as an
+  # active owner. Treat the sentinel as the absence-of-owner intent the
+  # operator meant. The card body builder skips the owner field
+  # entirely when card_owner is empty, which is the right shape for
+  # "no active owner / available for claim".
+  if [ "$card_owner" = "unclaimed" ]; then
+    card_owner=""
+  fi
 
   if [ -z "$issue_url" ]; then
     _airc_queue_adopt_help >&2
@@ -1424,7 +1444,11 @@ _cmd_queue_adopt() {
   if [ -z "$card_id" ]; then
     card_id="#$issue_num"
   fi
-  if [ -z "$card_owner" ]; then
+  # Auto-fill default owner ONLY if --owner wasn't explicitly given.
+  # An explicit --owner "" or --owner unclaimed (normalized above to "")
+  # signals "no owner / available" and must NOT be silently overwritten
+  # with the running agent's resolve_name. airc#613.
+  if [ -z "$card_owner" ] && [ "$owner_explicit" -eq 0 ]; then
     card_owner=$(_airc_queue_resolve_name)
   fi
   if [ -z "$card_evidence" ]; then

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -75,19 +75,40 @@ else
   return 1 2>/dev/null || exit 1
 fi
 
+# plan is the cohesive queue dashboard: priorities, lanes, active owners,
+# stale claims, and concrete next actions.
+if [ -n "${_airc_lib_dir:-}" ] && [ -f "$_airc_lib_dir/airc_bash/cmd_queue_plan.sh" ]; then
+  # shellcheck source=lib/airc_bash/cmd_queue_plan.sh
+  source "$_airc_lib_dir/airc_bash/cmd_queue_plan.sh"
+else
+  echo "ERROR: airc_bash/cmd_queue_plan.sh not found via lib-dir resolver." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
 cmd_queue() {
   # Top-level router. Validate + dispatch to _cmd_queue_<subcommand>.
   local subcmd="${1:-}"
   shift || true
 
   case "$subcmd" in
-    -h|--help|"")
+    -h|--help)
       _airc_queue_help
-      [ -z "$subcmd" ] && return 1
       return 0
+      ;;
+    "")
+      _cmd_queue_plan "$@"
+      ;;
+    --repo|--limit|--stale-after|--owner|--json)
+      _cmd_queue_plan "$subcmd" "$@"
+      ;;
+    */*)
+      _cmd_queue_plan "$subcmd" "$@"
       ;;
     add)
       _cmd_queue_add "$@"
+      ;;
+    plan|priorities|kanban)
+      _cmd_queue_plan "$@"
       ;;
     list|ls)
       _cmd_queue_list "$@"
@@ -132,7 +153,7 @@ cmd_queue() {
       _cmd_queue_staleness "$@"
       ;;
     *)
-      die "queue: unknown subcommand: $subcmd (try: add, list, claim, release, set-status, heartbeat, stale, next, metronome, nudge, adopt, pongs, availability, close-merged, staleness)"
+      die "queue: unknown subcommand: $subcmd (try: plan, add, list, claim, release, set-status, heartbeat, stale, next, metronome, nudge, adopt, pongs, availability, close-merged, staleness)"
       ;;
   esac
 }
@@ -148,6 +169,7 @@ _cmd_queue_add() {
   local card_id=""
   local card_branch=""
   local card_owner=""
+  local owner_explicit=0
   local card_status="claimed"
   local card_blockers=""
   local card_env=""
@@ -165,7 +187,7 @@ _cmd_queue_add() {
       --title)         shift; title="${1:-}" ;;
       --id)            shift; card_id="${1:-}" ;;
       --branch)        shift; card_branch="${1:-}" ;;
-      --owner)         shift; card_owner="${1:-}" ;;
+      --owner)         shift; card_owner="${1:-}"; owner_explicit=1 ;;
       --status)        shift; card_status="${1:-}" ;;
       --blockers)      shift; card_blockers="${1:-}" ;;
       --env)           shift; card_env="${1:-}" ;;
@@ -205,7 +227,10 @@ _cmd_queue_add() {
   # Default owner = the airc handle running this command. Sub-tab
   # disambiguation belongs to the operator if they share an airc handle
   # across multiple agents (today's pattern: claude tab #1 vs claude tab #2).
-  if [ -z "$card_owner" ]; then
+  if [ "$card_owner" = "unclaimed" ]; then
+    card_owner=""
+  fi
+  if [ -z "$card_owner" ] && [ "$owner_explicit" -eq 0 ]; then
     card_owner=$(_airc_queue_resolve_name)
   fi
 
@@ -711,7 +736,10 @@ if card is None:
     print("queue claim: no kind=airc-queue-card-v1 envelope found in body", file=sys.stderr)
     sys.exit(2)
 
-print((card.get("owner") or "").strip())
+owner = (card.get("owner") or "").strip()
+if owner == "unclaimed":
+    owner = ""
+print(owner)
 print((card.get("status") or "").strip())
 PYEOF
   ); then
@@ -1008,6 +1036,8 @@ for issue in issues:
         continue
     status = (card.get("status") or "").strip()
     owner = (card.get("owner") or "").strip()
+    if owner == "unclaimed":
+        owner = ""
     if status not in {"claimed", "in-progress", "review"}:
         continue
     reason = ""
@@ -1191,6 +1221,8 @@ for issue in issues:
         continue
     status = (card.get("status") or "claimed").strip()
     card_owner = (card.get("owner") or "").strip()
+    if card_owner == "unclaimed":
+        card_owner = ""
     rank = score(status, card_owner)
     if rank >= 9:
         continue
@@ -1674,6 +1706,8 @@ for issue in data:
     title = (issue.get("title", "") or "").replace("airc-queue: ", "", 1)
     status = (card.get("status") or "unknown").strip()
     owner = (card.get("owner") or "").strip()
+    if owner == "unclaimed":
+        owner = ""
     branch = (card.get("branch") or "").strip()
     bit = f"#{issue.get('number')} {status}"
     if owner:
@@ -1774,6 +1808,8 @@ if card is None:
     sys.exit(2)
 status = (card.get("status") or "").strip() or "unknown"
 owner = (card.get("owner") or "").strip()
+if owner == "unclaimed":
+    owner = ""
 # Tab-separated for shell-friendly parse.
 print(f"{title}\t{status}\t{owner}")
 PYEOF
@@ -1971,6 +2007,8 @@ for issue in issues:
     if not card:
         continue
     owner = (card.get("owner") or "").strip()
+    if owner == "unclaimed":
+        owner = ""
     number = issue.get("number")
     if owner:
         owners.setdefault(owner, []).append(f"{repo}#{number}")
@@ -2225,6 +2263,8 @@ for issue in issues:
         continue
     status = (card.get("status") or "unknown").strip()
     owner = (card.get("owner") or "").strip()
+    if owner == "unclaimed":
+        owner = ""
     hb = (card.get("last_heartbeat") or "").strip()
     hb_dt = parse_ts(hb)
     hb_age = int((now - hb_dt).total_seconds()) if hb_dt else None

--- a/lib/airc_bash/cmd_queue_help.sh
+++ b/lib/airc_bash/cmd_queue_help.sh
@@ -6,6 +6,8 @@ _airc_queue_help() {
 airc queue — issue-backed work queue primitives (airc#562)
 
 USAGE
+  airc queue [<owner/repo>] [--limit N] [--json]
+  airc queue plan [<owner/repo>] [--limit N] [--json]
   airc queue add <owner/repo> --title "<one-line>" [card-fields...]
   airc queue list [<owner/repo>] [--owner X] [--status Y] [--limit N] [--json]
   airc queue claim <issue-url> [--owner X] [--status Y]
@@ -24,11 +26,14 @@ USAGE
   airc queue staleness <pr-url|owner/repo#PR> [--repo-root PATH] [--json]
 
 DESCRIPTION
-  Adds, lists, or mutates queue cards (GitHub issues with airc-queue
-  label). Card fields follow the spec in continuum/.airc/QUEUE.md
+  Plans, adds, lists, or mutates queue cards (GitHub issues with
+  airc-queue label). Bare `airc queue` defaults to the cohesive planning
+  view: priorities, lanes, active owners, stale claims, review blockers,
+  and next actions. Card fields follow the spec in continuum/.airc/QUEUE.md
   (sibling claude tab #1's continuum#1110).
 
 VERB SCOPE
+  plan / priorities / kanban  Cohesive prioritized kanban for agents
   add / list                   PR-1 (airc#566, merged)
   claim / release / set-status PR-2 (airc#568, merged)
   heartbeat / stale            Stale-claim liveness primitives (airc#572)
@@ -42,6 +47,47 @@ VERB SCOPE
   staleness / stale-pr          airc#615 — warn on PR branch/base drift
   auto-release policy          Deferred; stale is read-only first
 
+EOF
+}
+
+_airc_queue_plan_help() {
+  cat <<'EOF'
+airc queue plan — cohesive prioritized kanban for agents
+
+USAGE
+  airc queue [<owner/repo>] [--limit N] [--json]
+  airc queue plan [<owner/repo>] [--limit N] [--json]
+  airc queue priorities [<owner/repo>]
+  airc queue kanban [<owner/repo>]
+
+DESCRIPTION
+  One-command coordination view. It fetches open airc-queue cards and
+  automatically groups them into strategic lanes, infers P0/P1/P2 priority,
+  shows review/merge candidates, stale ownership, active owners, and concrete
+  next actions. This is the default agent check-in command; use `--json` for
+  tooling.
+
+OPTIONS
+  --repo <owner/repo>      Alternative way to specify repo.
+  --limit <N>              Max cards to fetch (default 100).
+  --stale-after <dur>      Heartbeat threshold for stale claims: 30m, 2h, 1d
+                           (default: 30m).
+  --owner <handle>         Owner used in generated claim commands.
+  --json                   Emit machine-readable JSON.
+  -h, --help               This help.
+
+LANES
+  alpha-gap/rust-runtime   Rust-owned cognition/runtime, ts-rs, provider/model logic.
+  perf/resource-control    CPU/GPU/memory/docker/throughput/latency work.
+  flywheel/automation      AIRC, queue, kanban, canary, PR/issue automation.
+  quality/tests-vdd        Tests, lint, clippy, VDD/TDD, validation hygiene.
+  ui/configurator          UI/browser/configurator-specific work.
+  integration/canary       Merge/release/install/image integration.
+
+EXAMPLES
+  airc queue
+  airc queue plan CambrianTech/continuum
+  airc queue plan --json | jq '.summary'
 EOF
 }
 

--- a/lib/airc_bash/cmd_queue_plan.sh
+++ b/lib/airc_bash/cmd_queue_plan.sh
@@ -1,0 +1,385 @@
+# shellcheck shell=bash
+# Sourced by cmd_queue.sh. Cohesive queue planning view.
+
+_cmd_queue_plan() {
+  # Print the prioritized kanban state for a repo. This is the "one command"
+  # path for agents: see blockers, reviews, active ownership, stale work,
+  # strategic lanes, and the next concrete actions without stitching
+  # together list/stale/next/availability manually.
+  local target_repo=""
+  local limit=100
+  local output_json=0
+  local stale_after="30m"
+  local owner=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -h|--help)
+        _airc_queue_plan_help
+        return 0
+        ;;
+      --repo)        shift; target_repo="${1:-}" ;;
+      --limit)       shift; limit="${1:-100}" ;;
+      --stale-after) shift; stale_after="${1:-30m}" ;;
+      --owner)       shift; owner="${1:-}" ;;
+      --json)        output_json=1 ;;
+      -*) die "queue plan: unknown flag: $1" ;;
+      *)
+        if [ -z "$target_repo" ]; then
+          target_repo="$1"
+        else
+          die "queue plan: too many positional args (use: queue plan [owner/repo])"
+        fi
+        ;;
+    esac
+    shift || true
+  done
+
+  if [ -z "$target_repo" ]; then
+    target_repo=$(_airc_queue_detect_repo_from_cwd || true)
+  fi
+  if [ -z "$target_repo" ]; then
+    die "queue plan: no <owner/repo> given and could not detect one from \$PWD's git remote. Run inside a GitHub checkout or pass --repo owner/repo."
+  fi
+  case "$target_repo" in
+    */*) : ;;
+    *) die "queue plan: target must be owner/repo, got: $target_repo" ;;
+  esac
+  case "$limit" in
+    ''|*[!0-9]*) die "queue plan: --limit must be a positive integer (got: $limit)" ;;
+  esac
+  if [ "$limit" -lt 1 ]; then
+    die "queue plan: --limit must be >= 1 (got: $limit)"
+  fi
+  if [ -z "$owner" ]; then
+    owner=$(_airc_queue_resolve_name)
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    die "queue plan: 'gh' CLI is required."
+  fi
+
+  local raw_json
+  if ! raw_json=$(gh issue list \
+    --repo "$target_repo" \
+    --label "airc-queue" \
+    --state open \
+    --limit "$limit" \
+    --json number,title,url,body,updatedAt,createdAt 2>&1); then
+    die "queue plan: gh issue list failed for $target_repo: $raw_json"
+  fi
+
+  local raw_json_file
+  raw_json_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-plan.XXXXXX") || die "queue plan: mktemp failed"
+  printf '%s' "$raw_json" >"$raw_json_file"
+
+  AIRC_QUEUE_PLAN_OWNER="$owner" \
+  "$AIRC_PYTHON" - "$target_repo" "$stale_after" "$output_json" "$raw_json_file" <<'PYEOF'
+import datetime as dt
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+
+repo, stale_after_raw, output_json_raw, path = sys.argv[1:5]
+output_json = output_json_raw == "1"
+owner = os.environ.get("AIRC_QUEUE_PLAN_OWNER") or "anonymous"
+
+CARD_BLOCK_RE = re.compile(r'```json\s*\n(.*?)\n\s*```', re.DOTALL)
+
+LANES = [
+    ("alpha-gap/rust-runtime", (
+        "rust", "persona", "cognition", "ts-rs", "runtime", "node",
+        "engram", "prompt", "evaluator", "provider", "model", "ai throughput",
+    )),
+    ("perf/resource-control", (
+        "perf", "speed", "cpu", "memory", "gpu", "docker", "resource",
+        "throughput", "latency", "capacity", "qwen", "cuda", "metal",
+        "vulkan", "livekit", "webrtc", "framebuffer", "texture",
+    )),
+    ("flywheel/automation", (
+        "airc", "queue", "kanban", "automation", "metronome", "nudge",
+        "close-merged", "issue", "pr", "canary", "workflow", "precommit",
+        "collaboration", "owner", "claim",
+    )),
+    ("quality/tests-vdd", (
+        "test", "vdd", "tdd", "lint", "clippy", "baseline", "validation",
+        "smoke", "roundtrip", "hygiene", "ratchet", "determinism",
+    )),
+    ("ui/configurator", (
+        "ui", "browser", "widget", "configurator", "render", "web",
+        "tsx", "react", "adapter",
+    )),
+    ("integration/canary", (
+        "canary", "merge", "release", "install", "image", "main",
+        "pre-push", "prepush", "ci",
+    )),
+]
+
+P0_WORDS = (
+    "broken", "failing", "fail", "regression", "panic", "crash", "blocked",
+    "idle", "flywheel", "canary", "main", "merge", "stale", "wrong",
+)
+P1_WORDS = (
+    "rust", "perf", "speed", "memory", "cpu", "gpu", "resource", "ts-rs",
+    "test", "vdd", "tdd", "cleanup", "refactor", "docker", "qwen",
+)
+
+def parse_duration(value: str) -> dt.timedelta:
+    match = re.fullmatch(r"\s*(\d+)\s*([smhd])\s*", value or "")
+    if not match:
+        print(f"queue plan: cannot parse --stale-after '{value}' (use 30m, 2h, 1d)", file=sys.stderr)
+        sys.exit(2)
+    amount = int(match.group(1))
+    unit = match.group(2)
+    if unit == "s":
+        return dt.timedelta(seconds=amount)
+    if unit == "m":
+        return dt.timedelta(minutes=amount)
+    if unit == "h":
+        return dt.timedelta(hours=amount)
+    return dt.timedelta(days=amount)
+
+def parse_card(body: str) -> dict:
+    for match in CARD_BLOCK_RE.finditer(body or ""):
+        try:
+            parsed = json.loads(match.group(1).strip())
+        except Exception:
+            continue
+        if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
+            return parsed
+    return {}
+
+def parse_time(value: str):
+    if not value:
+        return None
+    match = re.search(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?Z)", value)
+    if not match:
+        return None
+    raw = match.group(1)
+    fmt = "%Y-%m-%dT%H:%M:%SZ" if raw.count(":") == 2 else "%Y-%m-%dT%H:%MZ"
+    return dt.datetime.strptime(raw, fmt).replace(tzinfo=dt.timezone.utc)
+
+def compact_title(title: str) -> str:
+    return (title or "").replace("airc-queue: ", "", 1).strip()
+
+def text_for(issue: dict, card: dict) -> str:
+    return "\n".join([
+        compact_title(issue.get("title", "")),
+        issue.get("body") or "",
+        str(card.get("next_action") or ""),
+        str(card.get("evidence") or ""),
+        str(card.get("env") or ""),
+        str(card.get("branch") or ""),
+    ]).lower()
+
+def lane_for(text: str) -> str:
+    for lane, words in LANES:
+        if any(word in text for word in words):
+            return lane
+    return "backlog/general"
+
+def explicit_priority(card: dict) -> str:
+    value = str(card.get("priority") or card.get("prio") or "").upper().strip()
+    if value in {"P0", "P1", "P2", "P3"}:
+        return value
+    return ""
+
+def priority_for(status: str, text: str, card: dict, stale: bool) -> str:
+    explicit = explicit_priority(card)
+    if explicit:
+        return explicit
+    if status in {"blocked", "review"} or stale or any(word in text for word in P0_WORDS):
+        return "P0"
+    if any(word in text for word in P1_WORDS):
+        return "P1"
+    return "P2"
+
+def shquote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+def short(value: str, limit: int = 96) -> str:
+    value = " ".join((value or "").split())
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1].rstrip() + "..."
+
+with open(path, "r", encoding="utf-8") as f:
+    issues = json.load(f)
+
+now = dt.datetime.now(dt.timezone.utc)
+stale_after = parse_duration(stale_after_raw)
+cards = []
+for issue in issues:
+    card = parse_card(issue.get("body", "") or "")
+    if not card:
+        continue
+    status = (card.get("status") or "claimed").strip() or "claimed"
+    card_owner = (card.get("owner") or "").strip()
+    if card_owner == "unclaimed":
+        card_owner = ""
+    heartbeat = (card.get("last_heartbeat") or "").strip()
+    heartbeat_at = parse_time(heartbeat)
+    stale_reason = ""
+    if status in {"claimed", "in-progress", "review"}:
+        if card_owner and not heartbeat_at:
+            stale_reason = "missing-heartbeat"
+        elif card_owner and heartbeat_at and now - heartbeat_at > stale_after:
+            stale_reason = "stale-heartbeat"
+        elif not card_owner and status in {"in-progress", "review"}:
+            stale_reason = "missing-owner"
+    body_text = text_for(issue, card)
+    lane = lane_for(body_text)
+    priority = priority_for(status, body_text, card, bool(stale_reason))
+    ref = f"{repo}#{issue.get('number')}"
+    cards.append({
+        "number": issue.get("number"),
+        "ref": ref,
+        "title": compact_title(issue.get("title", "")),
+        "url": issue.get("url") or "",
+        "status": status,
+        "owner": card_owner,
+        "lane": lane,
+        "priority": priority,
+        "branch": (card.get("branch") or "").strip(),
+        "env": (card.get("env") or "").strip(),
+        "blockers": (card.get("blockers") or "").strip(),
+        "evidence": (card.get("evidence") or "").strip(),
+        "next_action": (card.get("next_action") or "").strip(),
+        "last_heartbeat": heartbeat,
+        "stale_reason": stale_reason,
+        "updatedAt": issue.get("updatedAt") or "",
+        "claim_command": f"airc queue claim {shquote(ref)} --owner {shquote(owner)}",
+    })
+
+priority_order = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
+status_order = {"review": 0, "blocked": 1, "claimed": 2, "in-progress": 3, "merged": 4}
+cards.sort(key=lambda c: (
+    priority_order.get(c["priority"], 9),
+    status_order.get(c["status"], 9),
+    0 if not c["owner"] else 1,
+    c["number"] or 0,
+))
+
+summary = {
+    "open": len(cards),
+    "priorities": dict(Counter(c["priority"] for c in cards)),
+    "statuses": dict(Counter(c["status"] for c in cards)),
+    "stale": sum(1 for c in cards if c["stale_reason"]),
+    "owned": sum(1 for c in cards if c["owner"]),
+    "unowned": sum(1 for c in cards if not c["owner"]),
+}
+lanes = defaultdict(list)
+owners = defaultdict(list)
+for card in cards:
+    lanes[card["lane"]].append(card)
+    if card["owner"]:
+        owners[card["owner"]].append(card)
+
+payload = {
+    "repo": repo,
+    "owner": owner,
+    "now_utc": now.isoformat().replace("+00:00", "Z"),
+    "stale_after": stale_after_raw,
+    "summary": summary,
+    "cards": cards,
+    "lanes": {lane: [c["ref"] for c in rows] for lane, rows in lanes.items()},
+    "owners": {name: [c["ref"] for c in rows] for name, rows in owners.items()},
+}
+
+if output_json:
+    print(json.dumps(payload, indent=2))
+    sys.exit(0)
+
+def print_card(card: dict, prefix: str = "-") -> None:
+    owner_label = card["owner"] or "unowned"
+    bits = [card["ref"], f"[{card['priority']}]", f"[{card['status']}]", card["lane"], f"owner={owner_label}"]
+    if card["stale_reason"]:
+        bits.append(f"stale={card['stale_reason']}")
+    print(f"{prefix} {' '.join(bits)}")
+    print(f"  title: {short(card['title'])}")
+    if card["next_action"]:
+        print(f"  next:  {short(card['next_action'])}")
+    if card["blockers"]:
+        print(f"  blockers: {short(card['blockers'])}")
+
+print(f"# airc queue plan — {repo}")
+print(f"now_utc: {payload['now_utc']}")
+print(f"owner: {owner}")
+print(
+    "summary: "
+    f"open={summary['open']} "
+    f"P0={summary['priorities'].get('P0', 0)} "
+    f"P1={summary['priorities'].get('P1', 0)} "
+    f"review={summary['statuses'].get('review', 0)} "
+    f"blocked={summary['statuses'].get('blocked', 0)} "
+    f"stale={summary['stale']} "
+    f"unowned={summary['unowned']}"
+)
+
+if not cards:
+    print("No open airc-queue cards.")
+    print(f"next: airc queue add {repo} --title \"Describe the next concrete task\" --status claimed --owner unclaimed")
+    sys.exit(0)
+
+print("\n## P0 now")
+p0_cards = [c for c in cards if c["priority"] == "P0"]
+if p0_cards:
+    for card in p0_cards[:8]:
+        print_card(card)
+else:
+    print("- none")
+
+print("\n## Review / merge candidates")
+review_cards = [c for c in cards if c["status"] == "review"]
+if review_cards:
+    for card in review_cards[:8]:
+        print_card(card)
+else:
+    print("- none")
+
+print("\n## Active ownership")
+if owners:
+    for name in sorted(owners):
+        owned = sorted(owners[name], key=lambda c: (priority_order.get(c["priority"], 9), c["number"] or 0))
+        refs = ", ".join(f"{c['ref']}({c['status']}/{c['priority']})" for c in owned[:8])
+        print(f"- {name}: {refs}")
+else:
+    print("- none")
+
+print("\n## Stale / needs nudge")
+stale_cards = [c for c in cards if c["stale_reason"]]
+if stale_cards:
+    for card in stale_cards[:8]:
+        print_card(card)
+else:
+    print("- none")
+
+print("\n## Strategic lanes")
+lane_names = [lane for lane, _ in LANES] + ["backlog/general"]
+for lane in lane_names:
+    rows = lanes.get(lane, [])
+    if not rows:
+        continue
+    examples = ", ".join(f"{c['ref']}({c['status']}/{c['priority']})" for c in rows[:6])
+    print(f"- {lane}: {len(rows)} open — {examples}")
+
+print("\n## Next actions")
+actions = []
+if review_cards:
+    actions.append(f"Review/merge {review_cards[0]['ref']}: {short(review_cards[0]['title'], 72)}")
+if stale_cards:
+    actions.append(f"Nudge or release stale claim {stale_cards[0]['ref']}: {stale_cards[0]['stale_reason']}")
+claimable = [c for c in cards if c["status"] in {"claimed", "blocked"} and not c["owner"]]
+if claimable:
+    actions.append(f"Claim top ready card: {claimable[0]['claim_command']}")
+if not actions:
+    actions.append("No obvious queue move; create a missing P1/P2 card from the next code smell or test gap.")
+for idx, action in enumerate(actions[:5], start=1):
+    print(f"{idx}. {action}")
+PYEOF
+  local py_status=$?
+  rm -f "$raw_json_file"
+  return "$py_status"
+}

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -68,6 +68,92 @@ def _isolated_env_with_fake_gh(tmp: str) -> dict[str, str]:
     return env
 
 
+def _queue_card_body(**fields: str) -> str:
+    card = {"kind": "airc-queue-card-v1", **fields}
+    return (
+        "**airc-queue card**\n\n"
+        "```json\n"
+        f"{json.dumps(card, indent=2)}\n"
+        "```\n"
+    )
+
+
+def _isolated_env_with_plan_fake_gh(tmp: str) -> dict[str, str]:
+    fakebin = pathlib.Path(tmp) / "bin"
+    fakebin.mkdir()
+    issue_list = [
+        {
+            "number": 11,
+            "title": "Move persona cognition planner into Rust",
+            "url": "https://github.com/owner/repo/issues/11",
+            "body": _queue_card_body(
+                status="claimed",
+                next_action="Define Rust trait boundary and ts-rs export.",
+                env="any",
+            ),
+            "createdAt": "2026-05-14T10:00:00Z",
+            "updatedAt": "2026-05-14T10:05:00Z",
+        },
+        {
+            "number": 12,
+            "title": "Review canary PR for queue automation",
+            "url": "https://github.com/owner/repo/issues/12",
+            "body": _queue_card_body(
+                status="review",
+                owner="claude-tab-2",
+                branch="feat/queue-plan",
+                next_action="Review PR and merge to canary if checks are green.",
+            ),
+            "createdAt": "2026-05-14T10:10:00Z",
+            "updatedAt": "2026-05-14T10:20:00Z",
+        },
+        {
+            "number": 13,
+            "title": "Optimize qwen GPU memory path",
+            "url": "https://github.com/owner/repo/issues/13",
+            "body": _queue_card_body(
+                status="in-progress",
+                owner="codex-main",
+                last_heartbeat="2026-05-14T09:00Z @ abc123",
+                next_action="Measure CPU copies and move feasible path to Metal/CUDA.",
+            ),
+            "createdAt": "2026-05-14T10:15:00Z",
+            "updatedAt": "2026-05-14T10:25:00Z",
+        },
+        {
+            "number": 14,
+            "title": "Available queue card should be claimable",
+            "url": "https://github.com/owner/repo/issues/14",
+            "body": _queue_card_body(
+                status="claimed",
+                owner="unclaimed",
+                next_action="Claim and replace the legacy sentinel owner.",
+            ),
+            "createdAt": "2026-05-14T10:30:00Z",
+            "updatedAt": "2026-05-14T10:35:00Z",
+        },
+    ]
+    issue_list_file = pathlib.Path(tmp) / "fake_issue_list.json"
+    issue_list_file.write_text(json.dumps(issue_list), encoding="utf-8")
+    gh = fakebin / "gh"
+    gh.write_text(
+        "#!/bin/sh\n"
+        f'ISSUE_LIST_FILE="{issue_list_file}"\n'
+        "if [ \"$1 $2\" = \"issue list\" ]; then\n"
+        "  cat \"$ISSUE_LIST_FILE\"\n"
+        "  exit 0\n"
+        "fi\n"
+        "printf '%s\\n' 'unexpected gh call' >&2\n"
+        "exit 2\n",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    env = _isolated_env(tmp)
+    env["PATH"] = f"{fakebin}:/usr/bin:/bin"
+    env["AIRC_GH_BIN"] = str(gh)
+    return env
+
+
 def _isolated_env_with_create_fake_gh(tmp: str) -> tuple[dict[str, str], pathlib.Path]:
     fakebin = pathlib.Path(tmp) / "bin"
     fakebin.mkdir()
@@ -152,19 +238,25 @@ def _isolated_env_with_adopt_fake_gh(
 
 
 class QueueDispatchTests(unittest.TestCase):
-    def test_queue_no_subcommand_prints_help(self) -> None:
+    def test_queue_no_subcommand_defaults_to_plan(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            result = run_airc(["queue"], env_overrides=_isolated_env(tmp))
-        # No subcommand → returncode 1 (caller needed help, didn't ask explicitly).
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("queue add", result.stdout + result.stderr)
-        self.assertIn("queue list", result.stdout + result.stderr)
+            result = run_airc(
+                ["queue", "owner/repo", "--owner", "codex-main"],
+                env_overrides=_isolated_env_with_plan_fake_gh(tmp),
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("# airc queue plan — owner/repo", result.stdout)
+        self.assertIn("summary:", result.stdout)
+        self.assertIn("## Strategic lanes", result.stdout)
+        self.assertIn("alpha-gap/rust-runtime", result.stdout)
+        self.assertIn("perf/resource-control", result.stdout)
 
     def test_queue_help_returns_zero(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             result = run_airc(["queue", "--help"], env_overrides=_isolated_env(tmp))
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("PR-1", result.stdout)
+        self.assertIn("queue plan", result.stdout)
 
     def test_queue_add_help_returns_zero(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -181,6 +273,14 @@ class QueueDispatchTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("--owner", result.stdout)
 
+    def test_queue_plan_help_returns_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(["queue", "plan", "--help"],
+                              env_overrides=_isolated_env(tmp))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("cohesive prioritized kanban", result.stdout)
+        self.assertIn("alpha-gap/rust-runtime", result.stdout)
+
     def test_queue_adopt_help_returns_zero(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             result = run_airc(["queue", "adopt", "--help"],
@@ -194,6 +294,48 @@ class QueueDispatchTests(unittest.TestCase):
                               env_overrides=_isolated_env(tmp))
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("unknown subcommand", result.stdout + result.stderr)
+
+
+class QueuePlanTests(unittest.TestCase):
+    def test_plan_json_groups_lanes_and_priorities(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "plan", "owner/repo", "--owner", "codex-main", "--json"],
+                env_overrides=_isolated_env_with_plan_fake_gh(tmp),
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["repo"], "owner/repo")
+        self.assertEqual(payload["summary"]["open"], 4)
+        self.assertEqual(payload["summary"]["unowned"], 2)
+        self.assertGreaterEqual(payload["summary"]["priorities"]["P0"], 1)
+        self.assertIn("alpha-gap/rust-runtime", payload["lanes"])
+        self.assertIn("perf/resource-control", payload["lanes"])
+        self.assertIn("flywheel/automation", payload["lanes"])
+        self.assertIn("owner/repo#11", payload["lanes"]["alpha-gap/rust-runtime"])
+        self.assertIn("codex-main", payload["owners"])
+        rust_card = next(card for card in payload["cards"] if card["ref"] == "owner/repo#11")
+        self.assertIn("airc queue claim 'owner/repo#11'", rust_card["claim_command"])
+        sentinel_card = next(card for card in payload["cards"] if card["ref"] == "owner/repo#14")
+        self.assertEqual(sentinel_card["owner"], "")
+        self.assertEqual(sentinel_card["stale_reason"], "")
+
+    def test_plan_human_includes_action_sections(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "kanban", "owner/repo", "--owner", "codex-main"],
+                env_overrides=_isolated_env_with_plan_fake_gh(tmp),
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        out = result.stdout
+        self.assertIn("## P0 now", out)
+        self.assertIn("## Review / merge candidates", out)
+        self.assertIn("## Active ownership", out)
+        self.assertIn("## Stale / needs nudge", out)
+        self.assertIn("## Next actions", out)
+        self.assertIn("Review/merge owner/repo#12", out)
 
 
 class QueueAddValidationTests(unittest.TestCase):
@@ -393,6 +535,14 @@ class QueueAddCardBodyTests(unittest.TestCase):
         self.assertIsNotNone(match)
         card = json.loads(match.group(1))  # type: ignore[union-attr]
         self.assertEqual(card["owner"], "claude-tab-2")
+
+    def test_add_with_owner_unclaimed_omits_owner_field(self) -> None:
+        out = self._dry_run("--owner", "unclaimed")
+        match = re.search(r'```json\s*\n\s*(\{.*?\})\s*\n\s*```',
+                          out, re.DOTALL)
+        self.assertIsNotNone(match)
+        card = json.loads(match.group(1))  # type: ignore[union-attr]
+        self.assertNotIn("owner", card)
 
 
 class QueueListAutoDetectTests(unittest.TestCase):

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -504,6 +504,79 @@ class QueueAdoptTests(unittest.TestCase):
         self.assertIn("already has an airc-queue-card-v1 envelope",
                       result.stdout + result.stderr)
 
+    # ─── airc#613 — `--owner unclaimed` sentinel normalization ───────────
+
+    def _adopt_card_dry_run(self, owner_args: list[str]) -> dict:
+        """Run adopt --dry-run with the given --owner args and return the
+        parsed JSON envelope from the output. Helper for the airc#613
+        normalization tests below."""
+        issue = {"title": "fresh backlog", "body": "Plain body."}
+        with tempfile.TemporaryDirectory() as tmp:
+            env, _record_dir = _isolated_env_with_adopt_fake_gh(tmp, issue)
+            result = run_airc(
+                ["queue", "adopt", "owner/repo#42", "--dry-run", *owner_args],
+                env_overrides=env,
+            )
+        self.assertEqual(result.returncode, 0,
+                         f"adopt dry-run must succeed; stderr={result.stderr}")
+        match = re.search(r'```json\s*\n\s*(\{.*?\})\s*\n\s*```',
+                          result.stdout, re.DOTALL)
+        self.assertIsNotNone(match,
+                             f"expected JSON envelope; got:\n{result.stdout}")
+        return json.loads(match.group(1))  # type: ignore[union-attr]
+
+    def test_adopt_with_owner_unclaimed_omits_owner_field(self) -> None:
+        """`--owner unclaimed` is a sentinel meaning "no owner / available
+        for claim" used during bulk adoption. Per airc#613, the sentinel
+        must be normalized to absence-of-owner rather than written as the
+        literal string "unclaimed" — otherwise the subsequent
+        `airc queue claim` fails airc#612 collision protection because
+        owner=unclaimed reads as an active owner.
+
+        Catches: regression where the literal "unclaimed" string ends up
+        in the envelope's owner field, blocking plain claim."""
+        card = self._adopt_card_dry_run(["--owner", "unclaimed"])
+        self.assertNotIn(
+            "owner", card,
+            f"--owner unclaimed should produce no owner field; got: {card}",
+        )
+
+    def test_adopt_with_empty_owner_omits_owner_field(self) -> None:
+        """`--owner ""` is the explicit "no owner" form. Per airc#613, the
+        explicit-empty signal must NOT be silently overwritten with the
+        running agent's resolve_name — that's only the default when
+        --owner wasn't passed at all.
+
+        Catches: regression where the auto-fill fallback fires even when
+        --owner was explicitly set to empty."""
+        card = self._adopt_card_dry_run(["--owner", ""])
+        self.assertNotIn(
+            "owner", card,
+            f'--owner "" should produce no owner field; got: {card}',
+        )
+
+    def test_adopt_default_owner_falls_back_to_resolve_name(self) -> None:
+        """When --owner is NOT passed, owner defaults to the running
+        agent's resolve_name (existing behavior, kept intact). This test
+        guards the fallback so the airc#613 fix doesn't accidentally
+        break the common path of `airc queue adopt <ref>` with no flags.
+
+        Catches: regression where the fallback gets disabled along with
+        the sentinel normalization."""
+        card = self._adopt_card_dry_run([])
+        self.assertIn(
+            "owner", card,
+            f"adopt with no --owner should auto-fill owner; got: {card}",
+        )
+        self.assertNotEqual(
+            card["owner"], "",
+            "auto-filled owner should be a non-empty resolve_name",
+        )
+        self.assertNotEqual(
+            card["owner"], "unclaimed",
+            "auto-filled owner should be a real handle, not the sentinel",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_queue_claim.py
+++ b/test/test_queue_claim.py
@@ -347,6 +347,15 @@ class QueueMutateBodyShapeTests(unittest.TestCase):
         self.assertEqual(envelope["owner"], "claude-tab-2")
         self.assertEqual(envelope["status"], "in-progress")
 
+    def test_claim_allows_legacy_unclaimed_sentinel_without_force(self) -> None:
+        body = self._dry_run_extract_body(
+            ["queue", "claim", "owner/repo#1", "--owner", "claude-tab-2"],
+            body=_card_body(owner="unclaimed", status="claimed"),
+        )
+        envelope = self._extract_envelope(body)
+        self.assertEqual(envelope["owner"], "claude-tab-2")
+        self.assertEqual(envelope["status"], "in-progress")
+
     def test_claim_allows_merged_card_without_force(self) -> None:
         body = self._dry_run_extract_body(
             ["queue", "claim", "owner/repo#1", "--owner", "claude-tab-2"],


### PR DESCRIPTION
## Summary

- make bare `airc queue` / `airc queue <owner/repo>` show a cohesive prioritized planning view
- add `airc queue plan` plus `priorities` / `kanban` aliases with JSON output
- group cards into strategic lanes, surface P0/P1 counts, review candidates, active ownership, stale claims, and concrete next actions
- normalize legacy `owner=unclaimed` as no-owner across add, claim guard, next, stale, nudge, availability, and plan paths
- document the queue planning workflow in README

## Why

AIRC is becoming the coordination layer for agents and a candidate substrate for Continuum chat/coordination. The queue must be easy by default and must not treat `unclaimed` as a real owner, or agents will idle on falsely-owned cards.

## Validation

- `python3 -m unittest discover -s test -p 'test_queue*.py'`\n- `sh test/integration.sh python_units`\n- `bash -n airc lib/airc_bash/cmd_queue.sh lib/airc_bash/cmd_queue_help.sh lib/airc_bash/cmd_queue_plan.sh`\n- `shellcheck -s bash lib/airc_bash/cmd_queue_plan.sh`\n- fresh temp git checkout smoke for bare `airc queue` repo auto-detect\n\n## Follow-up\n\nRust substrate migration is tracked on #563 before Continuum chat/live coordination depends on AIRC as the core runtime.