### PR TITLE
fix(lane): hydrate submodules after worktree add (continuum#1252)

### DIFF
--- a/lib/airc_bash/cmd_lane.sh
+++ b/lib/airc_bash/cmd_lane.sh
@@ -123,6 +123,20 @@ _cmd_lane_create() {
     git -C "$repo_root" worktree add -b "$branch" "$lane_dir" "$resolved_base"
   fi
 
+  # Hydrate submodules in the new lane (continuum#1252).
+  #
+  # `git worktree add` does NOT init submodules in the new working tree,
+  # so any repo with submodule deps (continuum has `vendor/llama.cpp` ~500MB)
+  # has empty submodule directories that fail Rust precommit/prepush hooks
+  # on first commit attempt with cryptic CMake errors. This step makes the
+  # lane self-sufficient: agents shouldn't have to learn the
+  # `git submodule update --init` ritual after every `airc lane create`.
+  #
+  # Fail loud (no `2>/dev/null`, no `|| true`): if submodule init fails the
+  # lane is broken anyway — the user needs to see the error, not have it
+  # swallowed. Repos with no submodules: this is a no-op and exits 0.
+  git -C "$lane_dir" submodule update --init --recursive
+
   _airc_lane_record "$issue_ref" "$repo_root" "$lane_dir" "$branch" "$resolved_base" "$owner"
 
   printf 'Lane created:\n'

--- a/test/test_lane.py
+++ b/test/test_lane.py
@@ -113,6 +113,67 @@ class LaneCommandTests(unittest.TestCase):
             self.assertEqual(removed.returncode, 0, removed.stderr)
             self.assertFalse(lane_dir.exists())
 
+    def test_lane_create_hydrates_submodules_in_new_worktree(self) -> None:
+        """What this catches: regression where `airc lane create` skips
+        `git submodule update --init --recursive`, leaving every submodule
+        path empty in the new lane. continuum has `vendor/llama.cpp`
+        (~500MB CMake project); without hydration the first Rust commit
+        attempt in the lane fails with cryptic CMake errors and the user
+        learns the manual workaround the hard way (continuum#1252).
+
+        Test shape: outer repo embeds a tiny sentinel submodule; after
+        `airc lane create`, the submodule's sentinel file MUST be present
+        in the lane (not just the empty directory)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            # Inner repo to embed as a submodule. Carries a sentinel file
+            # that proves the submodule was actually checked out, not just
+            # registered as an empty path entry.
+            inner = pathlib.Path(tmp) / "inner_origin"
+            inner.mkdir()
+            subprocess.run(["git", "init"], cwd=inner, check=True, capture_output=True)
+            subprocess.run(["git", "config", "user.email", "i@example.invalid"], cwd=inner, check=True)
+            subprocess.run(["git", "config", "user.name", "Inner"], cwd=inner, check=True)
+            (inner / "SENTINEL.txt").write_text("hydrated\n", encoding="utf-8")
+            subprocess.run(["git", "add", "SENTINEL.txt"], cwd=inner, check=True)
+            subprocess.run(["git", "commit", "-m", "init inner"], cwd=inner, check=True, capture_output=True)
+
+            # Outer repo that embeds inner as a submodule at vendor/inner.
+            outer = make_git_repo(tmp)
+            subprocess.run(
+                ["git", "-c", "protocol.file.allow=always",
+                 "submodule", "add", str(inner), "vendor/inner"],
+                cwd=outer, check=True, capture_output=True,
+            )
+            subprocess.run(["git", "commit", "-m", "add submodule"],
+                           cwd=outer, check=True, capture_output=True)
+
+            lane_dir = pathlib.Path(tmp) / "lanes" / "airc-1252-test"
+            env = isolated_env(tmp)
+            # protocol.file.allow=always must propagate through the lane
+            # create's nested git submodule call (file:// submodules are
+            # rejected by default since git 2.38 CVE-2022-39253).
+            env["GIT_CONFIG_COUNT"] = "1"
+            env["GIT_CONFIG_KEY_0"] = "protocol.file.allow"
+            env["GIT_CONFIG_VALUE_0"] = "always"
+
+            result = run_airc(
+                ["lane", "create", "CambrianTech/airc#1252-test",
+                 "--repo", str(outer),
+                 "--dir", str(lane_dir),
+                 "--branch", "test/lane-submodule-hydrate",
+                 "--owner", "claude-tab-1"],
+                env,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            sentinel = lane_dir / "vendor" / "inner" / "SENTINEL.txt"
+            self.assertTrue(
+                sentinel.exists(),
+                f"submodule sentinel must exist after lane create: {sentinel}\n"
+                f"stdout={result.stdout}\nstderr={result.stderr}",
+            )
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "hydrated\n")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes continuum#1252.

## Friction

\`airc lane create\` runs \`git worktree add\` to make the lane, but git worktree add does NOT init submodules in the new working tree. For repos with submodule deps (continuum has \`vendor/llama.cpp\` ~500MB CMake project), this leaves every submodule directory empty. The first Rust commit attempt in the lane fails with cryptic CMake errors:

\`\`\`
CMake Error: The source directory \"<lane>/src/workers/vendor/llama.cpp\"
             does not appear to contain CMakeLists.txt.
build script failed, must exit now
❌ Rust compilation FAILED
❌ PRE-PUSH FAILED
\`\`\`

Surfaced when claude-tab-1 hit it on first work in a freshly-created continuum lane (after Joel's lane-discipline call-out). Workaround was \`git submodule update --init\` manually — fine once you know it, friction every time you forget.

## Fix

Run \`git submodule update --init --recursive\` in the new lane dir right after \`git worktree add\` succeeds. Comment in code explains the rationale.

- Repos with **no submodules**: no-op, exits 0.
- Repos with **broken submodules**: fails LOUD (no \`2>/dev/null\`, no \`|| true\`) so the user sees the real error instead of hitting it later via a confusing CMake/Rust failure. Per the never-suppress-errors discipline.

## Test

- **\`test_lane_create_hydrates_submodules_in_new_worktree\`** — outer repo with a sentinel-file inner submodule; asserts the sentinel exists in the lane's submodule path after \`airc lane create\`. Pre-fix this test would fail (only the empty submodule directory exists); post-fix the file contents are present.
- Test uses \`-c protocol.file.allow=always\` (via GIT_CONFIG_COUNT/KEY/VALUE env-vars to pass through to the nested submodule call) because git 2.38+ rejects file:// submodules by default (CVE-2022-39253) — the env-var path propagates the override into the airc-shell-spawned submodule call.

Full lane suite: **5 passed, 0 failed** (4 existing + 1 new).