### PR TITLE
Fix collaboration health for same-nick peers

### DIFF
--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -589,8 +589,9 @@ _doctor_health() {
   fi
   if [ "${peer_count:-0}" -eq 0 ] 2>/dev/null; then
     local _collab_rc=0
+    local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
     "$AIRC_PYTHON" -m airc_core.collaboration doctor \
-      --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" || _collab_rc=$?
+      --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" --client-id "$_client_id" || _collab_rc=$?
     case "$_collab_rc" in
       1) warns=$((warns+1)) ;;
       2) issues=$((issues+1)) ;;

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -493,8 +493,9 @@ cmd_whois() {
   if _whois_in_scope "$AIRC_WRITE_DIR" "$target"; then
     return 0
   fi
+  local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
   if "$AIRC_PYTHON" -m airc_core.collaboration whois-fallback \
-      --home "$AIRC_WRITE_DIR" --my-name "$my_name" --peer-name "$target"; then
+      --home "$AIRC_WRITE_DIR" --my-name "$my_name" --peer-name "$target" --client-id "$_client_id"; then
     return 0
   fi
 

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -571,8 +571,9 @@ else:
   # identical to "5 peers, all silent for 30 min" in the listing —
   # silent records persist on disk regardless of liveness.
   if ! find "$PEERS_DIR" -maxdepth 1 -name '*.json' -type f 2>/dev/null | grep -q .; then
+    local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
     "$AIRC_PYTHON" -m airc_core.collaboration peers-fallback \
-      --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" && return
+      --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" --client-id "$_client_id" && return
     echo "  No peers yet."
     return
   fi

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -739,8 +739,9 @@ cmd_send() {
       _peer_count=$(find "$PEERS_DIR" -maxdepth 1 -name '*.json' -type f 2>/dev/null | wc -l | tr -d ' ')
     fi
     if [ "${_peer_count:-0}" -eq 0 ] 2>/dev/null; then
+      local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
       "$AIRC_PYTHON" -m airc_core.collaboration send-warning \
-        --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" 2>/dev/null || true
+        --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" --client-id "$_client_id" 2>/dev/null || true
     fi
     _airc_codex_poll_after_user_send
   fi

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -178,8 +178,9 @@ _airc_collaboration_health_report() {
   # Local transport health is not the same as collaboration health. A
   # self-healed host can have fresh bearer heartbeats while nobody else is
   # paired to this mesh. Surface that split-brain shape explicitly.
+  local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
   "$AIRC_PYTHON" -m airc_core.collaboration status \
-    --home "$AIRC_WRITE_DIR" --my-name "$(get_name)"
+    --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" --client-id "$_client_id"
 }
 
 cmd_status() {

--- a/lib/airc_core/collaboration.py
+++ b/lib/airc_core/collaboration.py
@@ -16,6 +16,8 @@ import time
 from dataclasses import dataclass
 from typing import Optional
 
+from airc_core.client_id import current_client_id
+
 
 RECENT_REMOTE_WINDOW_SEC = 600
 
@@ -24,6 +26,74 @@ RECENT_REMOTE_WINDOW_SEC = 600
 class RemoteActivity:
     name: str
     ts: int
+    client_id: str = ""
+
+
+@dataclass(frozen=True)
+class MessageActivity:
+    name: str
+    ts: int
+    client_id: str
+
+
+@dataclass(frozen=True)
+class CollaborationEvidence:
+    recent_speakers: dict[str, int]
+    recent_activity: Optional[RemoteActivity]
+    any_activity: Optional[RemoteActivity]
+
+
+def _display_name(sender: object, client_id: str, my_name: str) -> str:
+    name = str(sender)
+    if client_id and name == my_name:
+        return f"{name} [{client_id}]"
+    return name
+
+
+def _is_self_message(msg: dict, my_name: str, my_client_id: str) -> bool:
+    sender = msg.get("from")
+    if not sender or sender == "airc":
+        return True
+    msg_client_id = str(msg.get("client_id") or "")
+    if my_client_id and msg_client_id:
+        return msg_client_id == my_client_id
+    if sender != my_name:
+        return False
+    # Legacy messages did not carry client_id; same nick still means self.
+    # Modern multi-agent rooms may reuse a nick, so same nick plus client_id
+    # is peer evidence when this process lacks a local client_id.
+    return not msg_client_id
+
+
+def _remote_messages(
+    home: str,
+    my_name: str,
+    window_sec: Optional[int],
+    my_client_id: str,
+) -> list[MessageActivity]:
+    messages_log = os.path.join(home, "messages.jsonl")
+    now = int(time.time())
+    found: list[MessageActivity] = []
+    try:
+        with open(messages_log, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    msg = json.loads(line)
+                except Exception:
+                    continue
+                if _is_self_message(msg, my_name, my_client_id):
+                    continue
+                ts = _epoch(msg.get("ts"))
+                if ts is None:
+                    continue
+                if window_sec is not None and now - ts >= window_sec:
+                    continue
+                sender = msg.get("from")
+                client_id = str(msg.get("client_id") or "")
+                found.append(MessageActivity(_display_name(sender, client_id, my_name), ts, client_id))
+    except OSError:
+        pass
+    return found
 
 
 def _epoch(ts: object) -> Optional[int]:
@@ -67,68 +137,69 @@ def peer_record_count(home: str) -> int:
     return count
 
 
-def recent_remote_activity(home: str, my_name: str, window_sec: int = RECENT_REMOTE_WINDOW_SEC) -> Optional[RemoteActivity]:
-    return _remote_activity(home, my_name, window_sec=window_sec)
+def recent_remote_activity(
+    home: str,
+    my_name: str,
+    window_sec: int = RECENT_REMOTE_WINDOW_SEC,
+    my_client_id: str = "",
+) -> Optional[RemoteActivity]:
+    return _remote_activity(home, my_name, window_sec=window_sec, my_client_id=my_client_id)
 
 
-def any_remote_activity(home: str, my_name: str) -> Optional[RemoteActivity]:
-    return _remote_activity(home, my_name, window_sec=None)
+def any_remote_activity(home: str, my_name: str, my_client_id: str = "") -> Optional[RemoteActivity]:
+    return _remote_activity(home, my_name, window_sec=None, my_client_id=my_client_id)
 
 
-def _remote_activity(home: str, my_name: str, window_sec: Optional[int]) -> Optional[RemoteActivity]:
-    messages_log = os.path.join(home, "messages.jsonl")
+def _remote_activity(
+    home: str,
+    my_name: str,
+    window_sec: Optional[int],
+    my_client_id: str = "",
+) -> Optional[RemoteActivity]:
+    last = max(
+        _remote_messages(home, my_name, window_sec=window_sec, my_client_id=my_client_id),
+        key=lambda activity: activity.ts,
+        default=None,
+    )
+    if last is None:
+        return None
+    return RemoteActivity(last.name, last.ts, last.client_id)
+
+
+def collaboration_evidence(home: str, my_name: str, my_client_id: str = "") -> CollaborationEvidence:
+    any_messages = _remote_messages(home, my_name, window_sec=None, my_client_id=my_client_id)
     now = int(time.time())
-    last: Optional[RemoteActivity] = None
-    try:
-        with open(messages_log, encoding="utf-8") as f:
-            for line in f:
-                try:
-                    msg = json.loads(line)
-                except Exception:
-                    continue
-                sender = msg.get("from")
-                if not sender or sender in (my_name, "airc"):
-                    continue
-                ts = _epoch(msg.get("ts"))
-                if ts is None:
-                    continue
-                if window_sec is not None and now - ts >= window_sec:
-                    continue
-                if last is None or ts > last.ts:
-                    last = RemoteActivity(str(sender), ts)
-    except OSError:
-        pass
-    return last
+    recent_speakers: dict[str, int] = {}
+    recent_activity: Optional[RemoteActivity] = None
+    any_activity: Optional[RemoteActivity] = None
+    for activity in any_messages:
+        if any_activity is None or activity.ts > any_activity.ts:
+            any_activity = RemoteActivity(activity.name, activity.ts, activity.client_id)
+        if now - activity.ts >= RECENT_REMOTE_WINDOW_SEC:
+            continue
+        recent_speakers[activity.name] = max(recent_speakers.get(activity.name, 0), activity.ts)
+        if recent_activity is None or activity.ts > recent_activity.ts:
+            recent_activity = RemoteActivity(activity.name, activity.ts, activity.client_id)
+    return CollaborationEvidence(recent_speakers, recent_activity, any_activity)
 
 
-def recent_remote_speakers(home: str, my_name: str, window_sec: int = RECENT_REMOTE_WINDOW_SEC) -> dict[str, int]:
-    messages_log = os.path.join(home, "messages.jsonl")
-    now = int(time.time())
+def recent_remote_speakers(
+    home: str,
+    my_name: str,
+    window_sec: int = RECENT_REMOTE_WINDOW_SEC,
+    my_client_id: str = "",
+) -> dict[str, int]:
     speakers: dict[str, int] = {}
-    try:
-        with open(messages_log, encoding="utf-8") as f:
-            for line in f:
-                try:
-                    msg = json.loads(line)
-                except Exception:
-                    continue
-                sender = msg.get("from")
-                if not sender or sender in (my_name, "airc"):
-                    continue
-                ts = _epoch(msg.get("ts"))
-                if ts is None or now - ts >= window_sec:
-                    continue
-                speakers[str(sender)] = max(speakers.get(str(sender), 0), ts)
-    except OSError:
-        pass
+    for activity in _remote_messages(home, my_name, window_sec=window_sec, my_client_id=my_client_id):
+        speakers[activity.name] = max(speakers.get(activity.name, 0), activity.ts)
     return speakers
 
 
 def cmd_status(args: argparse.Namespace) -> int:
     count = peer_record_count(args.home)
-    speakers = recent_remote_speakers(args.home, args.my_name)
-    recent = recent_remote_activity(args.home, args.my_name)
-    any_recent = recent if recent is not None else any_remote_activity(args.home, args.my_name)
+    evidence = collaboration_evidence(args.home, args.my_name, args.client_id)
+    speakers = evidence.recent_speakers
+    any_recent = evidence.recent_activity if evidence.recent_activity is not None else evidence.any_activity
     now = int(time.time())
     if any_recent is None:
         remote_desc = "no remote messages recorded"
@@ -153,9 +224,10 @@ def cmd_status(args: argparse.Namespace) -> int:
 
 def cmd_doctor(args: argparse.Namespace) -> int:
     count = peer_record_count(args.home)
-    speakers = recent_remote_speakers(args.home, args.my_name)
-    recent = recent_remote_activity(args.home, args.my_name)
-    any_recent = recent if recent is not None else any_remote_activity(args.home, args.my_name)
+    evidence = collaboration_evidence(args.home, args.my_name, args.client_id)
+    speakers = evidence.recent_speakers
+    recent = evidence.recent_activity
+    any_recent = evidence.any_activity
     now = int(time.time())
     if count > 0:
         print(f"  [ok] collaboration mesh has {count} peer record(s)")
@@ -190,7 +262,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 def cmd_send_warning(args: argparse.Namespace) -> int:
     if peer_record_count(args.home) > 0:
         return 0
-    if not recent_remote_speakers(args.home, args.my_name):
+    if not recent_remote_speakers(args.home, args.my_name, my_client_id=args.client_id):
         print(
             "  WARN: collaboration has no direct peer records or recent broadcast peers. "
             "Run 'airc peers' and verify others joined this gist.",
@@ -200,7 +272,7 @@ def cmd_send_warning(args: argparse.Namespace) -> int:
 
 
 def cmd_peers_fallback(args: argparse.Namespace) -> int:
-    speakers = recent_remote_speakers(args.home, args.my_name)
+    speakers = recent_remote_speakers(args.home, args.my_name, my_client_id=args.client_id)
     if not speakers:
         return 1
     print("  Recent broadcast peers:")
@@ -210,7 +282,7 @@ def cmd_peers_fallback(args: argparse.Namespace) -> int:
 
 
 def cmd_whois_fallback(args: argparse.Namespace) -> int:
-    speakers = recent_remote_speakers(args.home, args.my_name)
+    speakers = recent_remote_speakers(args.home, args.my_name, my_client_id=args.client_id)
     ts = speakers.get(args.peer_name)
     if ts is None:
         return 1
@@ -231,9 +303,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         p = sub.add_parser(name)
         p.add_argument("--home", required=True)
         p.add_argument("--my-name", default="")
+        p.add_argument("--client-id", default=current_client_id())
     p = sub.add_parser("whois-fallback")
     p.add_argument("--home", required=True)
     p.add_argument("--my-name", default="")
+    p.add_argument("--client-id", default=current_client_id())
     p.add_argument("--peer-name", required=True)
     args = parser.parse_args(argv)
     if args.cmd == "status":

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2935,6 +2935,23 @@ JSON
     && pass "airc peers falls back to recent broadcast-only traffic" \
     || fail "airc peers hid recent remote traffic when peer records were empty ($peers_out)"
 
+  printf '{"from":"solo-host","to":"all","ts":"%s","channel":"general","msg":"same nick remote proof","client_id":"agent:other"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$home/messages.jsonl"
+  status_out=$(AIRC_CLIENT_ID="agent:self" AIRC_HOME="$home" "$AIRC" status 2>&1)
+  echo "$status_out" | grep -q 'solo-host \[agent:other\]' \
+    && pass "status distinguishes same-nick peers by client_id" \
+    || fail "status treated same-nick peer traffic as self ($status_out)"
+  doctor_out=$(AIRC_CLIENT_ID="agent:self" AIRC_HOME="$home" "$AIRC" doctor --health 2>&1)
+  echo "$doctor_out" | grep -q 'recent broadcast peer' \
+    && pass "doctor distinguishes same-nick peers by client_id" \
+    || fail "doctor treated same-nick peer traffic as self ($doctor_out)"
+  peers_out=$(AIRC_CLIENT_ID="agent:self" AIRC_HOME="$home" "$AIRC" peers 2>&1)
+  echo "$peers_out" | grep -q 'solo-host \[agent:other\] → broadcast room' \
+    && pass "airc peers lists same-nick broadcast peer by client_id" \
+    || fail "airc peers hid same-nick broadcast peer ($peers_out)"
+
+  printf '{"from":"remote-agent","to":"all","ts":"%s","channel":"general","msg":"recent remote proof"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$home/messages.jsonl"
   local whois_out
   whois_out=$(AIRC_HOME="$home" "$AIRC" whois remote-agent 2>&1)
   echo "$whois_out" | grep -q 'role: *broadcast peer' \

--- a/test/test_collaboration.py
+++ b/test/test_collaboration.py
@@ -28,13 +28,18 @@ class CollaborationHealthTests(unittest.TestCase):
         (home / "peers").mkdir()
         return tmp, home
 
-    def _remote_line(self, sender="remote-agent"):
-        return json.dumps({
+    def _remote_line(self, sender="remote-agent", client_id=None):
+        msg = {
             "from": sender,
             "to": "all",
             "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "channel": "general",
             "msg": "hello",
+        }
+        if client_id is not None:
+            msg["client_id"] = client_id
+        return json.dumps({
+            **msg,
         }) + "\n"
 
     def test_status_waiting_without_records_or_remote_traffic(self):
@@ -85,6 +90,45 @@ class CollaborationHealthTests(unittest.TestCase):
             self.assertIn("Presence is derived", text)
             self.assertNotIn("collaboration: SOLO", text)
 
+    def test_status_ok_when_same_name_different_client_id_exists(self):
+        tmp, home = self._scope()
+        with tmp:
+            (home / "messages.jsonl").write_text(
+                self._remote_line(sender="me", client_id="agent:other"),
+                encoding="utf-8",
+            )
+            out = io.StringIO()
+            with redirect_stdout(out):
+                rc = collaboration.main([
+                    "status",
+                    "--home", str(home),
+                    "--my-name", "me",
+                    "--client-id", "agent:self",
+                ])
+            self.assertEqual(rc, 0)
+            text = out.getvalue()
+            self.assertIn("collaboration: ok (1 broadcast peer", text)
+            self.assertIn("me [agent:other]", text)
+            self.assertNotIn("collaboration: SOLO", text)
+
+    def test_status_ignores_same_client_id_as_self(self):
+        tmp, home = self._scope()
+        with tmp:
+            (home / "messages.jsonl").write_text(
+                self._remote_line(sender="me", client_id="agent:self"),
+                encoding="utf-8",
+            )
+            out = io.StringIO()
+            with redirect_stdout(out):
+                rc = collaboration.main([
+                    "status",
+                    "--home", str(home),
+                    "--my-name", "me",
+                    "--client-id", "agent:self",
+                ])
+            self.assertEqual(rc, 0)
+            self.assertIn("collaboration: waiting for peers", out.getvalue())
+
     def test_doctor_ok_when_recent_remote_traffic_exists(self):
         tmp, home = self._scope()
         with tmp:
@@ -115,6 +159,26 @@ class CollaborationHealthTests(unittest.TestCase):
                 rc = collaboration.main(["peers-fallback", "--home", str(home), "--my-name", "me"])
             self.assertEqual(rc, 0)
             self.assertIn("remote-agent", out.getvalue())
+            self.assertIn("broadcast room", out.getvalue())
+
+    def test_peers_fallback_lists_same_name_broadcast_speaker_by_client_id(self):
+        tmp, home = self._scope()
+        with tmp:
+            os.rmdir(home / "peers")
+            (home / "messages.jsonl").write_text(
+                self._remote_line(sender="me", client_id="agent:other"),
+                encoding="utf-8",
+            )
+            out = io.StringIO()
+            with redirect_stdout(out):
+                rc = collaboration.main([
+                    "peers-fallback",
+                    "--home", str(home),
+                    "--my-name", "me",
+                    "--client-id", "agent:self",
+                ])
+            self.assertEqual(rc, 0)
+            self.assertIn("me [agent:other]", out.getvalue())
             self.assertIn("broadcast room", out.getvalue())
 
     def test_whois_fallback_describes_recent_broadcast_speaker(self):


### PR DESCRIPTION
## Summary
- classify collaboration traffic by runtime client_id before falling back to nickname
- pass airc_client_id into status, doctor, peers, whois, and send-warning health paths
- add unit and integration coverage for same-nick/different-client_id broadcast peers

## Tests
- python3 test/test_collaboration.py
- bash -n test/integration.sh lib/airc_bash/cmd_status.sh lib/airc_bash/cmd_doctor.sh lib/airc_bash/cmd_rooms.sh lib/airc_bash/cmd_send.sh lib/airc_bash/cmd_identity.sh
- ./test/integration.sh solo_mesh_warns

Fixes #355