### PR TITLE
fix(queue): dispatch metronome hand-outs

### DIFF
--- a/airc
+++ b/airc
@@ -2157,14 +2157,19 @@ reminder_timer_loop() {
         local qm_elapsed=$(( now - qm_last ))
         if [ "$qm_elapsed" -ge "$qm_interval" ]; then
           printf '%s\n' "$now" > "$qm_last_file"
-          local qm_args=(next "$qm_repo" --limit "$qm_limit" --idle-ping)
+          local qm_args
           if [ -n "$qm_owner" ]; then
-            qm_args+=(--owner "$qm_owner")
+            qm_args=(dispatch "$qm_owner" "$qm_repo" --limit "$qm_limit" --message "metronome: idle hand-out; claim it, heartbeat it, or release it.")
+            if [ -n "$qm_repo_root" ]; then
+              qm_args+=(--repo-root "$qm_repo_root")
+            fi
+          else
+            qm_args=(next "$qm_repo" --limit "$qm_limit" --idle-ping)
+            if [ -n "$qm_repo_root" ]; then
+              qm_args+=(--repo-root "$qm_repo_root")
+            fi
           fi
-          if [ -n "$qm_repo_root" ]; then
-            qm_args+=(--repo-root "$qm_repo_root")
-          fi
-          printf '[%s] airc: Queue metronome pulse — checking next work for %s\n' "$(timestamp)" "$qm_repo"
+          printf '[%s] airc: Queue metronome pulse — dispatching next work for %s\n' "$(timestamp)" "$qm_repo"
           cmd_queue "${qm_args[@]}" || printf '[%s] airc: Queue metronome pulse failed; will retry on next interval.\n' "$(timestamp)"
         fi
       fi

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -171,7 +171,7 @@ cmd_queue() {
 # exact claim + lane commands.
 #
 # Usage:
-#   airc queue dispatch <agent> [<owner/repo>] [--message "..."] [--dry-run]
+#   airc queue dispatch <agent> [<owner/repo>] [--message "..."] [--limit N] [--repo-root PATH] [--dry-run]
 #
 #   <agent>      target peer (with or without leading @)
 #   <owner/repo> defaults to detected from $PWD (same rules as queue next)
@@ -188,6 +188,8 @@ _cmd_queue_dispatch() {
   local target_agent=""
   local target_repo=""
   local extra_message=""
+  local limit=10
+  local repo_root=""
   local dry_run=0
 
   while [ $# -gt 0 ]; do
@@ -197,7 +199,7 @@ _cmd_queue_dispatch() {
 airc queue dispatch — personalized hand-out of next claimable card
 
 USAGE
-  airc queue dispatch <agent> [<owner/repo>] [--message "..."] [--dry-run]
+  airc queue dispatch <agent> [<owner/repo>] [--message "..."] [--limit N] [--repo-root PATH] [--dry-run]
 
 ARGS
   <agent>           target peer name (with or without leading @)
@@ -205,6 +207,8 @@ ARGS
 
 FLAGS
   --message TEXT    extra context to append to the DM
+  --limit N         max queue cards to scan before picking top ranked card
+  --repo-root PATH  include repo path in suggested lane command
   --dry-run         print what would be sent, do not actually DM
 
 DESCRIPTION
@@ -225,6 +229,14 @@ EOF
       --message)
         shift
         extra_message="${1:-}"
+        ;;
+      --limit)
+        shift
+        limit="${1:-10}"
+        ;;
+      --repo-root)
+        shift
+        repo_root="${1:-}"
         ;;
       --dry-run)
         dry_run=1
@@ -265,13 +277,23 @@ EOF
   if ! command -v gh >/dev/null 2>&1; then
     die "queue dispatch: 'gh' CLI is required."
   fi
+  case "$limit" in
+    ''|*[!0-9]*) die "queue dispatch: --limit must be a positive integer (got: $limit)" ;;
+  esac
+  if [ "$limit" -lt 1 ]; then
+    die "queue dispatch: --limit must be >= 1 (got: $limit)"
+  fi
 
   # Pull the top candidate via JSON output of the existing next ranker.
   # Tee to a tempfile so the python parser can read structured input
-  # without having to re-shell to gh again. Use --limit 1 so the ranker
-  # picks the best single match for this agent.
+  # without having to re-shell to gh again. Scan a bounded set, then DM
+  # the first ranked result.
   local next_json
-  if ! next_json=$(_cmd_queue_next "$target_repo" --owner "$target_agent" --limit 1 --json); then
+  local next_args=("$target_repo" --owner "$target_agent" --limit "$limit" --json)
+  if [ -n "$repo_root" ]; then
+    next_args+=(--repo-root "$repo_root")
+  fi
+  if ! next_json=$(_cmd_queue_next "${next_args[@]}"); then
     die "queue dispatch: queue next lookup failed for $target_agent on $target_repo"
   fi
   if [ -z "$next_json" ]; then
@@ -1576,7 +1598,7 @@ _cmd_queue_metronome() {
   rm -f "$AIRC_WRITE_DIR/queue_metronome_last"
 
   echo "  Queue metronome every ${interval}s for ${target_repo} as ${owner}."
-  echo "  Monitor will run: airc queue next ${target_repo} --owner ${owner} --limit ${limit} --idle-ping"
+  echo "  Monitor will run: airc queue dispatch ${owner} ${target_repo}"
 }
 
 _cmd_queue_adopt() {

--- a/lib/airc_bash/cmd_queue_help.sh
+++ b/lib/airc_bash/cmd_queue_help.sh
@@ -342,12 +342,12 @@ USAGE
 
 DESCRIPTION
   Stores a monitor-loop metronome config. While `airc join`/monitor is
-  running, the monitor periodically runs:
+  running, the monitor periodically runs a personalized dispatch:
 
-    airc queue next <owner/repo> --owner <handle> --limit <N> --idle-ping
+    airc queue dispatch <handle> <owner/repo> --limit <N>
 
-  That makes claimable work loud without waiting for a human to ask why
-  agents are idle.
+  That makes claimable work loud and addressed without waiting for a human
+  to ask why agents are idle.
 
 OPTIONS
   --interval <seconds>   Pulse cadence. Minimum 30s; default 300s.
@@ -360,8 +360,8 @@ OPTIONS
   -h, --help             This help.
 
 NOTES
-  - The metronome does not claim work by itself. It publishes exact next
-    commands so agents can claim deliberately.
+  - The metronome does not claim work by itself. It DMs the target agent
+    exact next commands so agents can claim deliberately.
   - This is intentionally separate from plain `airc reminder`: reminders
     only say "you are silent"; metronome says "here is what to do next."
 EOF

--- a/test/test_queue_nudge.py
+++ b/test/test_queue_nudge.py
@@ -175,6 +175,7 @@ class QueueNudgeDispatchTests(unittest.TestCase):
                               env_overrides=_isolated_env(tmp))
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("automatic queue-next idle pulses", result.stdout)
+        self.assertIn("airc queue dispatch", result.stdout)
         self.assertIn("metronome off", result.stdout)
 
     def test_nudge_help_returns_zero(self) -> None:
@@ -369,6 +370,35 @@ class QueueRepoNudgeDryRunTests(unittest.TestCase):
             self.assertIn("owner=codex-main", text)
             self.assertIn("limit=7", text)
             self.assertIn("repo_root=/work/repo", text)
+            self.assertIn("airc queue dispatch codex-main owner/repo", result.stdout)
+
+    def test_dispatch_dry_run_hands_out_top_card_with_repo_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "dispatch", "@codex-main", "owner/repo",
+                 "--limit", "7",
+                 "--repo-root", "/work/repo",
+                 "--message", "idle hand-out",
+                 "--dry-run"],
+                env_overrides=_isolated_env_with_fake_gh(tmp),
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("would DM @codex-main", result.stdout)
+        self.assertIn("hand-out for @codex-main: #2", result.stdout)
+        self.assertIn("airc queue claim 'owner/repo#2' --owner 'codex-main'", result.stdout)
+        self.assertIn("airc lane create 'owner/repo#2' --base 'canary' --branch 'feat/repo-nudge' --repo '/work/repo'", result.stdout)
+        self.assertIn("idle hand-out", result.stdout)
+
+    def test_dispatch_rejects_invalid_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_airc(
+                ["queue", "dispatch", "@codex-main", "owner/repo",
+                 "--limit", "0",
+                 "--dry-run"],
+                env_overrides=_isolated_env_with_fake_gh(tmp),
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--limit must be >= 1", result.stdout + result.stderr)
 
     def test_metronome_rejects_spammy_interval(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- wire queue metronome to personalized `queue dispatch` hand-outs when an owner is configured
- keep broadcast `queue next --idle-ping` only as the ownerless fallback
- add `queue dispatch --limit` and `--repo-root` so dispatch scans a bounded ranked set and preserves lane commands
- update help/tests so the monitor path stays dispatch-first

## Validation
- python3 test/test_queue_nudge.py
- python3 test/test_queue.py
- python3 test/test_queue_claim.py
- airc queue dispatch @codex-main CambrianTech/continuum --limit 10 --dry-run
- airc queue metronome CambrianTech/continuum --interval 60 --owner codex-main --limit 10 --repo-root /Users/joelteply/Development/cambrian/continuum

Continuum: supports CambrianTech/continuum#1192.