### PR TITLE
feat: add hygiene policy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,40 @@ Operational rules:
   the current owner before taking over.
 - Use `airc queue release` when you stop working so the card returns to the
   pool.
+- Use `airc hygiene report` when disk pressure appears. Multi-agent lanes
+  create rebuildable caches quickly; AIRC policy should own cleanup instead of
+  relying on each agent to remember ad hoc commands.
 
 The queue is deliberately GitHub-native. It survives local process restarts,
 works across machines, and remains readable to humans in the repository UI.
 Static queue boards in [`widgets/`](widgets/) render the same issue envelope;
 they do not introduce a second source of truth.
+
+## Workspace Hygiene
+
+`airc hygiene` keeps many-agent workspaces from filling the machine. The
+default policy file is `<repo>/.airc-policy.json`: commit it when a project
+needs shared behavior, keep private mesh state in `.airc/config.json`.
+
+```bash
+airc hygiene init
+airc hygiene report
+airc hygiene clean --dry-run
+airc hygiene clean --yes
+```
+
+The default clean action removes only rebuildable lane caches under
+`~/.airc-worktrees`: Rust `src/workers/target` and `src/node_modules`.
+Main checkout caches and Docker prune are policy-gated and off by default.
+The JSON shape is intentionally serde-friendly so the Rust AIRC rewrite can
+preserve the same command contract.
+
+Reports include disk, CPU load, memory availability, GPU hook status, and
+optional `report_paths`. This is meant to become an automatic sanitation loop:
+lane create/remove, queue metronome, doctor, and low-resource monitors can all
+call the same policy engine instead of relying on agents to remember cleanup.
+See [`docs/hygiene-policy.md`](docs/hygiene-policy.md) for the policy shape and
+default values.
 
 ## Rooms And Scope
 
@@ -321,6 +350,8 @@ airc queue release <issue-url> --reason "<why>"
 airc queue stale <owner/repo>
 airc queue nudge <issue-url|owner/repo>
 airc lane create <issue-ref> --branch <branch> --base canary
+airc hygiene report
+airc hygiene clean --dry-run
 ```
 
 ## Updating

--- a/airc
+++ b/airc
@@ -2581,6 +2581,15 @@ else
   exit 1
 fi
 
+# cmd_hygiene — project cache/worktree cleanup policy for many-agent lanes.
+if [ -n "${_airc_lib_dir:-}" ] && [ -f "$_airc_lib_dir/airc_bash/cmd_hygiene.sh" ]; then
+  # shellcheck source=lib/airc_bash/cmd_hygiene.sh
+  source "$_airc_lib_dir/airc_bash/cmd_hygiene.sh"
+else
+  echo "ERROR: airc_bash/cmd_hygiene.sh not found via lib-dir resolver." >&2
+  exit 1
+fi
+
 
 # ── Dispatch ────────────────────────────────────────────────────────────
 
@@ -2641,6 +2650,7 @@ case "${1:-help}" in
   decrypt-approval) shift; cmd_decrypt_approval "$@" ;;
   queue)     shift; cmd_queue "$@" ;;
   lane|lanes|worktree|worktrees) shift; cmd_lane "$@" ;;
+  hygiene|clean|cleanup) shift; cmd_hygiene "$@" ;;
   rooms|list|ls) shift; cmd_rooms "$@" ;;
   part) shift; cmd_part "$@" ;;
   version|--version|-v) shift; cmd_version "$@" ;;
@@ -2706,6 +2716,8 @@ case "${1:-help}" in
     echo "  airc queue availability <owner/repo> [--since 30m]       Show peer/activity + stale-claim summary"
     echo "  airc queue adopt <issue-url> [card-fields…]              Convert an existing issue into a queue card"
     echo "  airc lane create <issue-ref> [--base canary]             Create isolated worktree lane"
+    echo "  airc hygiene report                                      Show rebuildable worktree cache pressure"
+    echo "  airc hygiene clean --yes                                 Remove safe per-lane caches"
     echo "  airc msg / send <text>          Broadcast to the default channel"
     echo "  airc msg / send @<peer> <text>  DM a peer (still in the shared log)"
     echo "  airc msg / send @a @b <text>    DM multiple peers (also: @a,b,c)"

--- a/docs/hygiene-policy.md
+++ b/docs/hygiene-policy.md
@@ -1,0 +1,61 @@
+# AIRC Hygiene Policy
+
+`airc hygiene` uses a project policy file to keep many-agent workspaces from
+filling a machine. The default path is:
+
+```text
+<repo>/.airc-policy.json
+```
+
+The file is optional. If it does not exist, AIRC uses built-in defaults. Run
+`airc hygiene init` to write the default file for a project.
+
+The policy is intentionally JSON and non-secret so the same shape can move to
+Rust with `serde` without changing the command contract.
+
+## Default Policy
+
+```json
+{
+  "block_free_gb": 15.0,
+  "clean_docker_build_cache": false,
+  "clean_main_rust_target": false,
+  "clean_worktree_node_modules": true,
+  "clean_worktree_rust_targets": true,
+  "hooks": [],
+  "report_paths": [],
+  "warn_free_gb": 50.0,
+  "workspace_root": "~/.airc-worktrees"
+}
+```
+
+## Behavior
+
+`airc hygiene report` shows:
+
+- free disk under the workspace filesystem
+- CPU 1-minute load average
+- available memory when the host OS exposes it
+- GPU status placeholder for project hooks
+- configured report paths
+- safe cleanup candidates
+
+`airc hygiene clean --yes` removes only rebuildable lane caches by default:
+
+- `~/.airc-worktrees/*/src/workers/target`
+- `~/.airc-worktrees/*/src/node_modules`
+
+Main checkout caches and Docker prune are off by default. Projects can opt in
+when they know the tradeoff is acceptable.
+
+## Future Hooks
+
+The `hooks` array is reserved for automatic project-specific checks and cleanup
+actions. The intended flow is:
+
+- lane create/remove calls the policy engine
+- queue metronome warns or cleans when thresholds are crossed
+- doctor includes policy status
+- low-resource monitors trigger safe cleanup without waiting for a human
+- project hooks add GPU, Docker, simulator, model cache, or persona sandbox
+  reporting without changing the core command shape

--- a/lib/airc_bash/cmd_hygiene.sh
+++ b/lib/airc_bash/cmd_hygiene.sh
@@ -1,0 +1,47 @@
+# Sourced by airc. cmd_hygiene — workspace/cache policy for many-agent lanes.
+
+cmd_hygiene() {
+  local subcmd="${1:-report}"
+  case "$subcmd" in
+    -h|--help)
+      _airc_hygiene_help
+      return 0
+      ;;
+    init|report|clean)
+      "$AIRC_PYTHON" -m airc_core.hygiene "$@"
+      ;;
+    *)
+      die "hygiene: unknown subcommand: $subcmd (try: init, report, clean)"
+      ;;
+  esac
+}
+
+_airc_hygiene_help() {
+  cat <<'EOF'
+airc hygiene — project workspace/cache hygiene for multi-agent lanes
+
+USAGE
+  airc hygiene init [--force]
+  airc hygiene report [--json]
+  airc hygiene clean --dry-run
+  airc hygiene clean --yes
+
+POLICY
+  Default policy path is <repo>/.airc-policy.json. It is intentionally
+  non-secret and serde-friendly so the Rust AIRC rewrite can keep the same
+  shape. Runtime identity/mesh state stays in private .airc/config.json.
+
+RESOURCE REPORTING
+  report includes disk, CPU load, memory availability, GPU hook status, and
+  optional policy.report_paths. This is the manual surface that future
+  automatic triggers can call from lane create/remove, queue metronome, doctor,
+  and low-resource monitors.
+
+SAFE CLEANUP
+  By default, clean only removes rebuildable per-lane caches:
+    - ~/.airc-worktrees/*/src/workers/target
+    - ~/.airc-worktrees/*/src/node_modules
+
+  Main checkout caches and Docker prune are policy-gated and off by default.
+EOF
+}

--- a/lib/airc_core/hygiene.py
+++ b/lib/airc_core/hygiene.py
@@ -1,0 +1,332 @@
+"""Workspace hygiene policy and cleanup for multi-agent AIRC lanes.
+
+This module is intentionally small and data-oriented so it can move to Rust
+without changing the command contract. The policy file is JSON: serde-friendly,
+dependency-free, and safe to commit when it contains no secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+DEFAULT_POLICY_FILE = ".airc-policy.json"
+
+
+@dataclass(frozen=True)
+class HygienePolicy:
+    workspace_root: str = "~/.airc-worktrees"
+    report_paths: list[str] = field(default_factory=list)
+    hooks: list[str] = field(default_factory=list)
+    warn_free_gb: float = 50.0
+    block_free_gb: float = 15.0
+    clean_worktree_rust_targets: bool = True
+    clean_worktree_node_modules: bool = True
+    clean_main_rust_target: bool = False
+    clean_docker_build_cache: bool = False
+
+
+@dataclass(frozen=True)
+class CleanupCandidate:
+    kind: str
+    path: str
+    bytes: int
+
+
+def _repo_root(start: str | None = None) -> Path:
+    cwd = Path(start or os.getcwd()).resolve()
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(cwd),
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        if out:
+            return Path(out).resolve()
+    except (OSError, subprocess.CalledProcessError):
+        pass
+    return cwd
+
+
+def _policy_path(args: argparse.Namespace) -> Path:
+    if args.policy:
+        return Path(args.policy).expanduser().resolve()
+    return _repo_root() / DEFAULT_POLICY_FILE
+
+
+def load_policy(path: Path) -> HygienePolicy:
+    if not path.exists():
+        return HygienePolicy()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise SystemExit(f"hygiene: cannot read policy {path}: {exc}") from exc
+    allowed = set(HygienePolicy.__dataclass_fields__)
+    unknown = sorted(set(data) - allowed)
+    if unknown:
+        raise SystemExit(
+            f"hygiene: unknown policy key(s) in {path}: {', '.join(unknown)}"
+        )
+    return HygienePolicy(**data)
+
+
+def write_policy(path: Path, policy: HygienePolicy) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(asdict(policy), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _path_size(path: Path) -> int:
+    if not path.exists():
+        return 0
+    if path.is_file() or path.is_symlink():
+        try:
+            return path.lstat().st_size
+        except OSError:
+            return 0
+    total = 0
+    for root, dirs, files in os.walk(path, topdown=True):
+        # Do not follow symlinked directory trees.
+        dirs[:] = [d for d in dirs if not (Path(root) / d).is_symlink()]
+        for name in files:
+            p = Path(root) / name
+            try:
+                total += p.lstat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def _gb(bytes_value: int) -> float:
+    return bytes_value / (1024 ** 3)
+
+
+def _fmt_size(bytes_value: int) -> str:
+    value = float(bytes_value)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024 or unit == "TiB":
+            if unit == "B":
+                return f"{int(value)} {unit}"
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} TiB"
+
+
+def _find_dirs(root: Path, suffix_parts: tuple[str, ...]) -> Iterable[Path]:
+    if not root.exists():
+        return []
+    suffix = os.sep.join(suffix_parts)
+    matches: list[Path] = []
+    for dirpath, dirnames, _filenames in os.walk(root):
+        path = Path(dirpath)
+        if str(path).endswith(suffix):
+            matches.append(path)
+            dirnames[:] = []
+            continue
+        if path.name in {".git", "dist", ".continuum"}:
+            dirnames[:] = [d for d in dirnames if d not in {"target", "node_modules"}]
+    return matches
+
+
+def collect_candidates(policy: HygienePolicy, repo_root: Path) -> list[CleanupCandidate]:
+    candidates: list[CleanupCandidate] = []
+    workspace_root = Path(policy.workspace_root).expanduser()
+
+    if policy.clean_worktree_rust_targets:
+        for path in _find_dirs(workspace_root, ("src", "workers", "target")):
+            candidates.append(CleanupCandidate("worktree-rust-target", str(path), _path_size(path)))
+
+    if policy.clean_worktree_node_modules:
+        for path in _find_dirs(workspace_root, ("src", "node_modules")):
+            candidates.append(CleanupCandidate("worktree-node-modules", str(path), _path_size(path)))
+
+    if policy.clean_main_rust_target:
+        path = repo_root / "src" / "workers" / "target"
+        if path.exists():
+            candidates.append(CleanupCandidate("main-rust-target", str(path), _path_size(path)))
+
+    return sorted(candidates, key=lambda c: c.bytes, reverse=True)
+
+
+def _free_disk_gb(path: Path) -> float:
+    usage = shutil.disk_usage(path if path.exists() else path.parent)
+    return _gb(usage.free)
+
+
+def _memory_available_gb() -> float | None:
+    meminfo = Path("/proc/meminfo")
+    if meminfo.exists():
+        for line in meminfo.read_text(encoding="utf-8", errors="ignore").splitlines():
+            if line.startswith("MemAvailable:"):
+                parts = line.split()
+                if len(parts) >= 2:
+                    return int(parts[1]) / (1024 ** 2)
+    try:
+        out = subprocess.check_output(["vm_stat"], text=True, stderr=subprocess.DEVNULL)
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    page_size = 4096
+    free_pages = 0
+    for line in out.splitlines():
+        if "page size of" in line:
+            try:
+                page_size = int(line.split("page size of", 1)[1].split("bytes", 1)[0].strip())
+            except (IndexError, ValueError):
+                page_size = 4096
+        if line.startswith(("Pages free:", "Pages inactive:", "Pages speculative:")):
+            try:
+                free_pages += int(line.split(":", 1)[1].strip().rstrip("."))
+            except (IndexError, ValueError):
+                continue
+    return _gb(free_pages * page_size) if free_pages else None
+
+
+def resource_snapshot(policy: HygienePolicy) -> dict[str, object]:
+    load = None
+    try:
+        load = os.getloadavg()[0]
+    except (AttributeError, OSError):
+        pass
+    paths = []
+    for raw in policy.report_paths:
+        path = Path(raw).expanduser()
+        if path.exists():
+            paths.append({
+                "path": str(path),
+                "bytes": _path_size(path),
+            })
+    return {
+        "free_disk_gb": _free_disk_gb(Path(policy.workspace_root).expanduser()),
+        "cpu_load_1m": load,
+        "memory_available_gb": _memory_available_gb(),
+        "gpu": "hook-required",
+        "paths": paths,
+        "hooks_configured": len(policy.hooks),
+    }
+
+
+def _print_report(policy_path: Path, policy: HygienePolicy, candidates: list[CleanupCandidate]) -> None:
+    snapshot = resource_snapshot(policy)
+    free_gb = float(snapshot["free_disk_gb"])
+    print("# airc hygiene report")
+    print(f"policy: {policy_path}")
+    print(f"workspace_root: {Path(policy.workspace_root).expanduser()}")
+    print(f"free_disk: {free_gb:.1f} GiB")
+    if snapshot["cpu_load_1m"] is not None:
+        print(f"cpu_load_1m: {float(snapshot['cpu_load_1m']):.2f}")
+    if snapshot["memory_available_gb"] is not None:
+        print(f"memory_available: {float(snapshot['memory_available_gb']):.1f} GiB")
+    print(f"gpu: {snapshot['gpu']}")
+    print(f"hooks_configured: {snapshot['hooks_configured']}")
+    if free_gb < policy.block_free_gb:
+        print(f"status: BLOCK ({free_gb:.1f} GiB < {policy.block_free_gb:.1f} GiB)")
+    elif free_gb < policy.warn_free_gb:
+        print(f"status: WARN ({free_gb:.1f} GiB < {policy.warn_free_gb:.1f} GiB)")
+    else:
+        print("status: OK")
+    print()
+    if not candidates:
+        print("No safe cleanup candidates found.")
+    else:
+        total = sum(c.bytes for c in candidates)
+        print(f"safe_cleanup_candidates: {len(candidates)} ({_fmt_size(total)})")
+        for candidate in candidates[:80]:
+            print(f"- {candidate.kind}: {_fmt_size(candidate.bytes)}  {candidate.path}")
+        if len(candidates) > 80:
+            print(f"... {len(candidates) - 80} more")
+    if policy.report_paths:
+        print()
+        print("reported_paths:")
+        for item in snapshot["paths"]:
+            print(f"- {_fmt_size(int(item['bytes']))}  {item['path']}")
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    path = _policy_path(args)
+    if path.exists() and not args.force:
+        print(f"hygiene: policy already exists: {path}", file=sys.stderr)
+        print("use --force to overwrite", file=sys.stderr)
+        return 1
+    write_policy(path, HygienePolicy())
+    print(f"Wrote hygiene policy: {path}")
+    return 0
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    path = _policy_path(args)
+    policy = load_policy(path)
+    candidates = collect_candidates(policy, _repo_root())
+    if args.json:
+        snapshot = resource_snapshot(policy)
+        print(json.dumps({
+            "policy": str(path),
+            **snapshot,
+            "candidates": [asdict(c) for c in candidates],
+        }, indent=2, sort_keys=True))
+    else:
+        _print_report(path, policy, candidates)
+    return 0
+
+
+def cmd_clean(args: argparse.Namespace) -> int:
+    path = _policy_path(args)
+    policy = load_policy(path)
+    candidates = collect_candidates(policy, _repo_root())
+    if not candidates:
+        print("No safe cleanup candidates found.")
+        return 0
+    if not args.yes and not args.dry_run:
+        print("hygiene clean: refusing to delete without --yes or --dry-run", file=sys.stderr)
+        return 1
+    total = sum(c.bytes for c in candidates)
+    verb = "would remove" if args.dry_run else "removing"
+    print(f"{verb} {len(candidates)} safe cleanup candidate(s), {_fmt_size(total)}")
+    for candidate in candidates:
+        print(f"- {candidate.kind}: {_fmt_size(candidate.bytes)}  {candidate.path}")
+        if not args.dry_run:
+            shutil.rmtree(candidate.path, ignore_errors=True)
+    if policy.clean_docker_build_cache:
+        if args.dry_run:
+            print("- docker: would run docker system prune -af")
+        else:
+            subprocess.run(["docker", "system", "prune", "-af"], check=False)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="airc_core.hygiene")
+    parser.add_argument("--policy", default="", help="policy path (default: repo .airc-policy.json)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    init = sub.add_parser("init", help="write default project hygiene policy")
+    init.add_argument("--force", action="store_true")
+    init.set_defaults(func=cmd_init)
+
+    report = sub.add_parser("report", help="show cleanup candidates")
+    report.add_argument("--json", action="store_true")
+    report.set_defaults(func=cmd_report)
+
+    clean = sub.add_parser("clean", help="remove safe rebuildable caches")
+    clean.add_argument("--dry-run", action="store_true")
+    clean.add_argument("--yes", action="store_true")
+    clean.set_defaults(func=cmd_clean)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_hygiene.py
+++ b/test/test_hygiene.py
@@ -1,0 +1,133 @@
+"""Tests for `airc hygiene` workspace cache policy."""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+AIRC_BIN = REPO_ROOT / "airc"
+
+
+def run_airc(
+    args: list[str],
+    env: dict[str, str],
+    cwd: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(AIRC_BIN), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=cwd,
+        timeout=20,
+    )
+
+
+def isolated_env(tmp: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update({
+        "HOME": tmp,
+        "AIRC_HOME": str(pathlib.Path(tmp) / ".airc"),
+        "AIRC_NO_IDENTITY_PROMPT": "1",
+    })
+    return env
+
+
+def make_git_repo(tmp: str) -> pathlib.Path:
+    repo = pathlib.Path(tmp) / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "airc-test@example.invalid"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "AIRC Test"], cwd=repo, check=True)
+    (repo / "README.md").write_text("test\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    return repo
+
+
+class HygieneCommandTests(unittest.TestCase):
+    def test_init_writes_serde_friendly_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_git_repo(tmp)
+            result = run_airc(["hygiene", "init"], isolated_env(tmp), str(repo))
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            policy_path = repo / ".airc-policy.json"
+            self.assertTrue(policy_path.exists())
+            policy = json.loads(policy_path.read_text(encoding="utf-8"))
+            self.assertEqual(policy["workspace_root"], "~/.airc-worktrees")
+            self.assertTrue(policy["clean_worktree_rust_targets"])
+            self.assertTrue(policy["clean_worktree_node_modules"])
+            self.assertFalse(policy["clean_main_rust_target"])
+
+    def test_report_lists_only_policy_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_git_repo(tmp)
+            workspace = pathlib.Path(tmp) / "lanes"
+            target = workspace / "repo-card-agent" / "src" / "workers" / "target"
+            modules = workspace / "repo-card-agent" / "src" / "node_modules"
+            protected = repo / "src" / "workers" / "target"
+            for path in (target, modules, protected):
+                path.mkdir(parents=True)
+                (path / "sentinel").write_text("cache\n", encoding="utf-8")
+            (repo / ".airc-policy.json").write_text(
+                json.dumps({"workspace_root": str(workspace)}, indent=2),
+                encoding="utf-8",
+            )
+
+            result = run_airc(["hygiene", "report"], isolated_env(tmp), str(repo))
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("worktree-rust-target", result.stdout)
+            self.assertIn("worktree-node-modules", result.stdout)
+            self.assertIn(str(target), result.stdout)
+            self.assertIn(str(modules), result.stdout)
+            self.assertNotIn(str(protected), result.stdout)
+
+    def test_clean_requires_yes_or_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_git_repo(tmp)
+            workspace = pathlib.Path(tmp) / "lanes"
+            target = workspace / "repo-card-agent" / "src" / "workers" / "target"
+            target.mkdir(parents=True)
+            (target / "sentinel").write_text("cache\n", encoding="utf-8")
+            (repo / ".airc-policy.json").write_text(
+                json.dumps({"workspace_root": str(workspace)}, indent=2),
+                encoding="utf-8",
+            )
+
+            result = run_airc(["hygiene", "clean"], isolated_env(tmp), str(repo))
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertTrue(target.exists())
+            self.assertIn("--yes or --dry-run", result.stderr)
+
+    def test_clean_yes_removes_rebuildable_worktree_caches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_git_repo(tmp)
+            workspace = pathlib.Path(tmp) / "lanes"
+            target = workspace / "repo-card-agent" / "src" / "workers" / "target"
+            modules = workspace / "repo-card-agent" / "src" / "node_modules"
+            for path in (target, modules):
+                path.mkdir(parents=True)
+                (path / "sentinel").write_text("cache\n", encoding="utf-8")
+            (repo / ".airc-policy.json").write_text(
+                json.dumps({"workspace_root": str(workspace)}, indent=2),
+                encoding="utf-8",
+            )
+
+            result = run_airc(["hygiene", "clean", "--yes"], isolated_env(tmp), str(repo))
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(target.exists())
+            self.assertFalse(modules.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- adds `airc hygiene init/report/clean` for multi-agent workspace sanitation
- introduces serde-friendly `.airc-policy.json` defaults for rebuildable lane cache cleanup
- reports disk, CPU load, memory availability, GPU hook status, report paths, and cleanup candidates
- documents the policy shape and future automatic hook points

## Verification
- `python3 -m compileall -q lib/airc_core/hygiene.py`
- `python3 -m unittest discover -s test -p test_hygiene.py`
- `python3 -m unittest discover -s test -p test_lane.py`
- `./airc hygiene report --json | python3 -m json.tool`

## Follow-up
- filed #631 for the Rust-native automatic sanitation loop: lane lifecycle, queue metronome, doctor, low-resource monitors, Docker/model/GPU/project hooks

Refs #631