### PR TITLE
fix: fail closed on update conflicts

### DIFF
--- a/lib/airc_bash/cmd_update.sh
+++ b/lib/airc_bash/cmd_update.sh
@@ -34,6 +34,7 @@ cmd_update() {
   local channel_file="$dir/.channel"
   local requested_channel=""
   local force=0
+  local reset=0
   while [ $# -gt 0 ]; do
     case "$1" in
       -h|--help)
@@ -43,6 +44,7 @@ cmd_update() {
         echo "  airc update --canary               shortcut for --channel canary"
         echo "  airc update --main                 shortcut for --channel main"
         echo "  airc update --force / -f           auto-stash local mods + pull"
+        echo "  airc update --reset                reset install dir to origin/<channel>"
         return 0 ;;
       --channel|-c)
         requested_channel="${2:-}"
@@ -52,6 +54,7 @@ cmd_update() {
       --canary) requested_channel="canary"; shift ;;
       --main)   requested_channel="main";   shift ;;
       --force|-f) force=1; shift ;;
+      --reset) reset=1; shift ;;
       *) shift ;;
     esac
   done
@@ -69,6 +72,23 @@ cmd_update() {
     [ -z "$channel" ] && channel="main"
   else
     channel="main"
+  fi
+
+  if _airc_update_has_unmerged "$dir"; then
+    if [ "$reset" = "1" ]; then
+      _airc_update_reset_to_origin "$dir" "$channel"
+    else
+      echo "  ❌ Unresolved git merge conflicts in install dir ($dir):" >&2
+      git -C "$dir" status --short 2>&1 | head -20 >&2
+      echo "" >&2
+      echo "  This install checkout cannot safely run airc until conflicts are removed." >&2
+      echo "  Recover with:" >&2
+      echo "    airc update --reset                  # reset install dir to origin/$channel" >&2
+      echo "    git -C $dir status                   # inspect manually" >&2
+      die "refusing to update over unresolved install-dir conflicts"
+    fi
+  elif [ "$reset" = "1" ]; then
+    _airc_update_reset_to_origin "$dir" "$channel"
   fi
 
   # Detect dirty tree BEFORE attempting branch switch / pull. Without this,
@@ -128,6 +148,7 @@ cmd_update() {
   echo "$channel" > "$channel_file"
 
   AIRC_DIR="$dir" bash "$dir/install.sh" || die "install.sh failed."
+  _airc_update_assert_clean_after_install "$dir" "$channel"
 
   local after; after=$(git -C "$dir" rev-parse --short HEAD 2>/dev/null)
   if [ "$before" = "$after" ]; then
@@ -156,6 +177,54 @@ cmd_update() {
       echo ""
     fi
   fi
+}
+
+_airc_update_has_unmerged() {
+  local dir="$1"
+  git -C "$dir" status --porcelain -uall 2>/dev/null | grep -Eq '^(DD|AU|UD|UA|DU|AA|UU) '
+}
+
+_airc_update_has_tracked_changes() {
+  local dir="$1"
+  ! git -C "$dir" diff --quiet 2>/dev/null || ! git -C "$dir" diff --cached --quiet 2>/dev/null
+}
+
+_airc_update_assert_clean_after_install() {
+  local dir="$1"
+  local channel="$2"
+  if _airc_update_has_unmerged "$dir"; then
+    echo "  ❌ install.sh returned but install dir still has unresolved conflicts:" >&2
+    git -C "$dir" status --short 2>&1 | head -20 >&2
+    echo "" >&2
+    echo "  Recover with: airc update --reset  # reset install dir to origin/$channel" >&2
+    die "post-update install dir has unresolved conflicts"
+  fi
+  if _airc_update_has_tracked_changes "$dir"; then
+    echo "  ❌ install.sh returned but install dir has tracked local changes:" >&2
+    git -C "$dir" status --short 2>&1 | head -20 >&2
+    echo "" >&2
+    echo "  Recover with: airc update --reset  # reset install dir to origin/$channel" >&2
+    die "post-update install dir is not clean"
+  fi
+}
+
+_airc_update_reset_to_origin() {
+  local dir="$1"
+  local channel="$2"
+  echo "  ⚠  Resetting install dir to origin/$channel: $dir"
+  git -C "$dir" fetch --quiet origin "$channel" \
+    || die "reset failed: could not fetch origin/$channel"
+  local current_branch
+  current_branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [ "$current_branch" != "$channel" ]; then
+    git -C "$dir" checkout -q "$channel" 2>/dev/null \
+      || git -C "$dir" checkout -q -B "$channel" "origin/$channel" 2>/dev/null \
+      || die "reset failed: could not checkout '$channel'"
+  fi
+  git -C "$dir" reset --hard "origin/$channel" >/dev/null \
+    || die "reset failed: could not reset to origin/$channel"
+  git -C "$dir" clean -fd >/dev/null \
+    || die "reset failed: could not clean untracked files"
 }
 
 # ── cmd_channel: show or set the release channel without pulling ──────

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -1,0 +1,139 @@
+"""Tests for `airc update` install-dir conflict safety."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+AIRC_BIN = REPO_ROOT / "airc"
+
+
+def run_airc(args: list[str], env: dict[str, str], cwd: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(AIRC_BIN), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=cwd,
+        timeout=20,
+    )
+
+
+def _git(repo: pathlib.Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def isolated_env(tmp: str, install_dir: pathlib.Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update({
+        "HOME": tmp,
+        "AIRC_HOME": str(pathlib.Path(tmp) / ".airc"),
+        "AIRC_DIR": str(install_dir),
+        "AIRC_NO_IDENTITY_PROMPT": "1",
+    })
+    return env
+
+
+def make_install_repo(tmp: str) -> tuple[pathlib.Path, pathlib.Path]:
+    origin = pathlib.Path(tmp) / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-b", "canary")
+    _git(origin, "config", "user.email", "airc-test@example.invalid")
+    _git(origin, "config", "user.name", "AIRC Test")
+    (origin / "README.md").write_text("base\n", encoding="utf-8")
+    install = origin / "install.sh"
+    install.write_text(
+        "#!/usr/bin/env bash\n"
+        "cd \"$(dirname \"$0\")\"\n"
+        "[ -n \"${AIRC_UPDATE_TEST_MARKER:-}\" ] && echo ran >> \"$AIRC_UPDATE_TEST_MARKER\"\n"
+        "[ -n \"${AIRC_UPDATE_TEST_DIRTY:-}\" ] && echo dirty > README.md\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    install.chmod(install.stat().st_mode | stat.S_IXUSR)
+    _git(origin, "add", "README.md", "install.sh")
+    _git(origin, "commit", "-m", "base")
+
+    clone = pathlib.Path(tmp) / "install"
+    _git(pathlib.Path(tmp), "clone", str(origin), str(clone))
+    _git(clone, "checkout", "canary")
+    (clone / ".channel").write_text("canary\n", encoding="utf-8")
+    return origin, clone
+
+
+def create_unmerged_conflict(repo: pathlib.Path) -> None:
+    _git(repo, "checkout", "-b", "other")
+    (repo / "README.md").write_text("other\n", encoding="utf-8")
+    _git(repo, "commit", "-am", "other change")
+    _git(repo, "checkout", "canary")
+    (repo / "README.md").write_text("local\n", encoding="utf-8")
+    _git(repo, "commit", "-am", "local change")
+    merge = _git(repo, "merge", "other", check=False)
+    if merge.returncode == 0:
+        raise AssertionError("expected merge conflict")
+
+
+class UpdateConflictTests(unittest.TestCase):
+    def test_update_refuses_existing_unmerged_install_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _origin, install_dir = make_install_repo(tmp)
+            create_unmerged_conflict(install_dir)
+            marker = pathlib.Path(tmp) / "install-ran"
+            env = isolated_env(tmp, install_dir)
+            env["AIRC_UPDATE_TEST_MARKER"] = str(marker)
+
+            result = run_airc(["update"], env, str(REPO_ROOT))
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Unresolved git merge conflicts", result.stderr)
+            self.assertIn("airc update --reset", result.stderr)
+            self.assertFalse(marker.exists(), "install.sh must not run while install dir is conflicted")
+            self.assertIn("UU README.md", _git(install_dir, "status", "--short").stdout)
+
+    def test_update_reset_recovers_conflicted_install_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _origin, install_dir = make_install_repo(tmp)
+            create_unmerged_conflict(install_dir)
+            marker = pathlib.Path(tmp) / "install-ran"
+            env = isolated_env(tmp, install_dir)
+            env["AIRC_UPDATE_TEST_MARKER"] = str(marker)
+
+            result = run_airc(["update", "--reset"], env, str(REPO_ROOT))
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Resetting install dir to origin/canary", result.stdout)
+            self.assertTrue(marker.exists(), "install.sh should run after reset recovery")
+            self.assertEqual(_git(install_dir, "status", "--short", "--untracked-files=no").stdout, "")
+            self.assertEqual((install_dir / "README.md").read_text(encoding="utf-8"), "base\n")
+
+    def test_update_refuses_post_install_tracked_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _origin, install_dir = make_install_repo(tmp)
+            marker = pathlib.Path(tmp) / "install-ran"
+            env = isolated_env(tmp, install_dir)
+            env["AIRC_UPDATE_TEST_MARKER"] = str(marker)
+            env["AIRC_UPDATE_TEST_DIRTY"] = "1"
+
+            result = run_airc(["update"], env, str(REPO_ROOT))
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertTrue(marker.exists(), "install.sh should have run before post-update guard")
+            self.assertIn("install dir has tracked local changes", result.stderr)
+            self.assertIn("airc update --reset", result.stderr)
+            self.assertIn("M README.md", _git(install_dir, "status", "--short").stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- detects unresolved merge conflicts in the AIRC install dir before update proceeds
- adds explicit `airc update --reset` recovery to fetch/reset/clean the install checkout to `origin/<channel>`
- verifies post-install tracked state before printing update success
- adds regression coverage for conflicted install dirs, reset recovery, and post-install dirty state

## Verification
- `python3 -m unittest discover -s test -p test_update.py`
- `python3 -m unittest discover -s test -p test_lane.py`
- `python3 -m unittest discover -s test -p test_queue_nudge.py`
- `bash -n lib/airc_bash/cmd_update.sh`
- `git diff --check`

Closes #619