### PR TITLE
docs: design realtime event bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ queue coordination, realtime subscriptions, and adapter cursors. See
 [`docs/rust-sqlite-substrate.md`](docs/rust-sqlite-substrate.md) for the schema,
 trait, migration, and benchmark contract.
 
+Realtime delivery builds on that store without replacing application schemas.
+AIRC owns subscriptions, replay, receipts, self-filtering, backpressure, and
+transport adapters; consumers such as Continuum keep their canonical
+JTAG/EventBridge/GridFrame/LiveKit payloads. See
+[`docs/realtime-event-bus.md`](docs/realtime-event-bus.md).
+
 ## Rooms And Scope
 
 airc stores state in the current scope:

--- a/docs/realtime-event-bus.md
+++ b/docs/realtime-event-bus.md
@@ -1,0 +1,277 @@
+# Realtime Event Bus
+
+**Status:** design contract for airc#626
+**Builds on:** [`rust-sqlite-substrate.md`](rust-sqlite-substrate.md)
+
+## Goal
+
+AIRC should provide the generic realtime mechanics needed by chat, presence,
+agent coordination, and media control:
+
+- subscribe
+- fan out
+- replay
+- acknowledge
+- filter self echoes
+- coalesce noisy ephemeral state
+- measure latency and dropped events
+- bridge across local, tailnet, GitHub compatibility, and future mesh transports
+
+AIRC should not define Continuum's domain packet hierarchy. Continuum already
+has canonical command/event packages, and AIRC should adapt them.
+
+## Existing Continuum Schemas
+
+The AIRC realtime layer must preserve these package shapes when it carries
+Continuum traffic:
+
+- `JTAGRequest<T>` and `JTAGResponse<T>` in
+  `src/workers/shared/jtag_protocol.rs`
+- `JTAGMessage<T>`, `JTAGEventMessage<T>`, `JTAGRequestMessage<T>`, and
+  `JTAGResponseMessage<T>` in `src/system/core/types/JTAGTypes.ts`
+- `EventBridgePayload` in
+  `src/system/events/shared/EventSystemTypes.ts`
+- `GridFrame` and `GridPayload::{Command, CommandResult, Event, StreamChunk}`
+  in `src/workers/continuum-core/src/modules/grid/frame.rs`
+- `BridgeCommand` and `BridgeEvent` in
+  `src/workers/livekit-protocol/src/lib.rs`
+
+These are payload contracts. AIRC adds transport-neutral delivery mechanics
+around them.
+
+## Layer Split
+
+AIRC owns:
+
+- event append/replay/cursors
+- subscriptions and fanout
+- receipts and acknowledgements
+- self-filtering by `client_id`
+- backpressure, queue depth, retry policy, and dropped-event telemetry
+- ORM-backed SQLite indexes for replayable events
+- bounded memory state for ephemeral presence
+- adapter traits for local IPC, GitHub compatibility, tailnet/grid links, and
+  future transports
+
+Continuum owns:
+
+- command names, event names, persona/media semantics, and UI projection rules
+- JTAG/EventBridge/GridFrame/LiveKit payload definitions
+- when typing, thinking, speaking, or in-call state should be emitted
+- which events become persona memory, room state, activity state, or UI state
+- its own ORM-backed projections; it must not query AIRC SQLite tables directly
+
+The adapter owns:
+
+- mapping a source payload family into AIRC delivery metadata
+- validating enough structure to route safely
+- preserving the original payload bytes or canonical JSON
+- returning the same source payload family to the consumer
+
+## Realtime Envelope
+
+The AIRC envelope is metadata, not a replacement schema:
+
+```rust
+pub struct RealtimeEnvelope<P> {
+    pub event_id: EventId,
+    pub payload_family: PayloadFamily,
+    pub payload: P,
+    pub scope_id: ScopeId,
+    pub room_id: RoomId,
+    pub peer_id: PeerId,
+    pub client_id: ClientId,
+    pub correlation_id: Option<String>,
+    pub delivery: DeliveryClass,
+    pub ttl_ms: Option<u64>,
+    pub coalesce_key: Option<String>,
+    pub occurred_at_ms: u64,
+}
+
+pub enum PayloadFamily {
+    AircNative,
+    ContinuumJtag,
+    ContinuumEventBridge,
+    ContinuumGridFrame,
+    ContinuumLiveKit,
+}
+
+pub enum DeliveryClass {
+    Durable,
+    EphemeralLatest,
+    EphemeralWindow,
+    RequestResponse,
+    StreamChunk,
+}
+```
+
+Examples:
+
+- chat messages: `Durable`
+- receipts: `Durable`
+- typing/thinking/presence: `EphemeralLatest` with a TTL and coalesce key
+- LiveKit room commands and participant events: `Durable` control-plane records
+- audio/video frames: not AIRC payloads; they stay on WebRTC/LiveKit media paths
+- stream progress chunks: `StreamChunk` with bounded replay policy
+
+## Subscription Traits
+
+The Rust core should expose subscription mechanics separately from transport
+adapters:
+
+```rust
+pub trait EventBus {
+    fn publish<P: Serialize>(&self, envelope: NewRealtimeEnvelope<P>) -> Result<EventId>;
+    fn subscribe(&self, request: SubscribeRequest) -> Result<SubscriptionId>;
+    fn poll(&self, subscription: &SubscriptionId, limit: u32) -> Result<Vec<StoredEnvelope>>;
+    fn ack(&self, ack: Receipt) -> Result<()>;
+}
+
+pub trait SubscriptionStore {
+    fn create(&self, request: SubscribeRequest) -> Result<SubscriptionId>;
+    fn resume(&self, subscription: &SubscriptionId) -> Result<SubscriptionCursor>;
+    fn advance(&self, subscription: &SubscriptionId, cursor: SubscriptionCursor) -> Result<()>;
+    fn lag(&self, subscription: &SubscriptionId) -> Result<SubscriptionLag>;
+}
+
+pub trait PresenceStore {
+    fn set_latest(&self, presence: PresenceUpdate) -> Result<()>;
+    fn current(&self, room: &RoomId) -> Result<Vec<PresenceState>>;
+    fn expire_before(&self, now_ms: u64) -> Result<u64>;
+}
+
+pub trait RealtimeTransport {
+    fn send(&self, envelope: &StoredEnvelope) -> Result<TransportSendOutcome>;
+    fn receive(&self, cursor: Option<&str>) -> Result<TransportPollOutcome>;
+    fn health(&self) -> Result<TransportHealth>;
+}
+
+pub trait SchemaAdapter {
+    fn family(&self) -> PayloadFamily;
+    fn validate(&self, payload_json: &[u8]) -> Result<SchemaRoute>;
+    fn correlation_id(&self, payload_json: &[u8]) -> Option<String>;
+    fn coalesce_key(&self, payload_json: &[u8]) -> Option<String>;
+}
+```
+
+`SchemaAdapter` is the boundary that keeps AIRC from duplicating Continuum
+domain logic. It can inspect routing fields, correlation IDs, and event names;
+it must not reinterpret persona/media semantics.
+
+## SQLite Additions
+
+The base substrate already defines `events`, `subscriptions`, `receipts`,
+`outbox`, and `transport_cursors`. Realtime adds small projection tables for
+ephemeral and subscription health.
+
+These tables are ORM migration targets inside AIRC. They are shown to make the
+storage contract reviewable, not to invite application SQL. Consumers use
+`EventBus`, `SubscriptionStore`, `PresenceStore`, and generated payload adapters.
+
+```sql
+CREATE TABLE realtime_latest (
+  scope_id TEXT NOT NULL,
+  room_id TEXT NOT NULL,
+  coalesce_key TEXT NOT NULL,
+  event_id TEXT NOT NULL REFERENCES events(event_id),
+  payload_family TEXT NOT NULL,
+  expires_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY(scope_id, room_id, coalesce_key)
+);
+
+CREATE TABLE subscription_metrics (
+  subscription_id TEXT PRIMARY KEY,
+  delivered_count INTEGER NOT NULL DEFAULT 0,
+  dropped_count INTEGER NOT NULL DEFAULT 0,
+  last_delivery_ms INTEGER,
+  last_ack_ms INTEGER,
+  max_lag_events INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE request_response_index (
+  correlation_id TEXT PRIMARY KEY,
+  request_event_id TEXT NOT NULL REFERENCES events(event_id),
+  response_event_id TEXT REFERENCES events(event_id),
+  status TEXT NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+);
+```
+
+`realtime_latest` can be rebuilt from recent events with TTL still valid. It is
+a projection, not the canonical log.
+
+## Self-Filtering
+
+Every publish path must carry `peer_id` and `client_id`.
+
+Consumers may choose one of three policies:
+
+- `include_all`: diagnostics and transcripts
+- `exclude_same_client`: normal UI/agent echo suppression
+- `exclude_same_peer`: rare cross-tab suppression for workflows that want one
+  visible action per human/agent identity
+
+The default must be `exclude_same_client`, because multiple tabs belonging to
+one peer are independent workers.
+
+## Backpressure And Coalescing
+
+Presence and activity state can be noisy. AIRC should coalesce these by
+`room_id + peer_id + client_id + state_kind + target_id`.
+
+Recommended defaults:
+
+- typing/thinking TTL: 5 seconds
+- speaking/in-call TTL: producer-defined heartbeat, default 10 seconds
+- dropped ephemeral events are counted, not replayed forever
+- durable control events are never silently dropped
+- if a subscriber falls behind a configured window, emit a
+  `system.warning`/lag event and force cursor resume from SQLite
+
+## WebRTC And LiveKit Boundary
+
+AIRC carries control-plane state only:
+
+- room intent
+- participant joined/left
+- agent connected/disconnected
+- cognitive state changes
+- offer/answer/ICE metadata only when needed by the selected adapter
+- reconnect and teardown events
+- health and route diagnostics
+
+AIRC does not carry audio/video frames. Live media stays on WebRTC/LiveKit UDP
+paths. AIRC can coordinate those paths, record control state, and replay enough
+history to recover a session manager.
+
+## Benchmarks And Smoke Tests
+
+Before Continuum integration, the implementation needs:
+
+- two local subscribers exchanging chat plus typing/thinking presence
+- deterministic replay after one subscriber restarts
+- self-filter test with two clients under one peer
+- request/response correlation test for JTAG/GridFrame payloads
+- LiveKit control smoke using `BridgeCommand`/`BridgeEvent` JSON fixtures
+- coalescing test proving 1,000 typing updates become one latest projection
+- fanout benchmark for 4, 8, and 16 subscribers
+- idle CPU benchmark for subscription loops
+- reconnect benchmark measuring cursor replay latency
+
+Initial targets:
+
+- p95 local publish-to-subscriber latency under 20 ms
+- idle subscription loop below 1 percent CPU
+- 1,000 coalesced presence updates produce one latest row and bounded disk writes
+- replay of 1,000 durable events under 50 ms from local SQLite
+
+## Implementation Order
+
+1. Add Rust `airc-core` types for delivery metadata and subscription requests.
+2. Add `SchemaAdapter` fixtures for AIRC-native JSON and Continuum package JSON.
+3. Extend `airc-store` migrations with realtime projection tables.
+4. Implement local in-process publish/poll/ack tests.
+5. Add transport adapter tests with duplicate ingest and self-filtering.
+6. Add CLI smoke commands only after the Rust library behavior is covered.
+7. Wire Continuum through adapters once benchmarks meet the alpha targets.

--- a/docs/rust-sqlite-substrate.md
+++ b/docs/rust-sqlite-substrate.md
@@ -38,6 +38,8 @@ Continuum owns:
 - persona behavior, memory, world/activity semantics, and UI projection policy
 - media-domain meaning for WebRTC/LiveKit sessions
 - application-specific command handlers produced by AIRC events
+- ORM-backed application entities and projections; Continuum must not issue SQL
+  against the AIRC store or depend on AIRC table shapes
 
 Adapters own:
 
@@ -123,10 +125,14 @@ initial set should cover:
 Domain-specific meaning can live above this list, but transport and replay
 semantics must not.
 
-## SQLite Schema
+## Storage Model
 
-Use SQLite WAL mode. The Rust crate owns migrations and enforces invariants
-through transactions.
+Use SQLite WAL mode behind a Rust ORM/entity layer. The Rust crate owns
+migrations and enforces invariants through typed repository methods and
+transactions. Application code talks to Rust traits and generated types, not SQL.
+
+The schema below is a storage and migration contract for the ORM entities. It is
+not a public query API, and Continuum should never bind to it directly.
 
 Suggested pragmas:
 
@@ -282,7 +288,7 @@ CREATE TABLE health_samples (
 Projection tables are caches. They can be rebuilt from `events`. If a projection
 cannot be rebuilt, it is the wrong abstraction.
 
-## Rust Traits
+## Rust Traits And ORM Boundary
 
 The first Rust crate should expose narrow traits that can be tested without a
 daemon:
@@ -321,10 +327,16 @@ pub trait BlobStore {
 }
 ```
 
-Use `rusqlite` for the first implementation unless an async daemon benchmark
-proves `sqlx`/`tokio-rusqlite` is necessary. A single writer connection plus
-reader pool is enough for the near-term command/daemon split and avoids async
-complexity before we have numbers.
+Use a Rust ORM crate for the first implementation, with typed entities,
+migrations, and repository methods. SeaORM is the default candidate because it
+supports SQLite and async service code cleanly; Diesel is acceptable if its
+compile-time schema and sync model fit the first crate better. Raw SQL belongs
+only in migrations, narrowly reviewed performance escapes, or ORM-generated
+code. It must not leak into AIRC command handlers, adapters, or Continuum.
+
+A single writer path plus reader pool is enough for the near-term command/daemon
+split. If benchmarks prove the ORM layer is too slow for a hot path, optimize
+behind the same trait boundary and keep the public API unchanged.
 
 ## Command Contract
 
@@ -336,6 +348,10 @@ The shell/Python layer should become dispatch glue:
   only when its cursor is stale.
 - `airc hygiene report` writes health samples and can trigger policy hooks.
 - monitor/codex-poll subscribe from the store instead of tailing raw JSONL.
+
+Continuum integration should consume Rust/TypeScript types, IPC responses, and
+projection APIs. It should not open the SQLite database, run SQL queries, or
+mirror AIRC's table names into its own domain code.
 
 Logic that must not stay duplicated in shell/Python after Rust owns it:
 
@@ -386,8 +402,8 @@ performance claim must have a reproducible measurement.
 
 ## Migration Plan
 
-1. Add `airc-store` Rust crate with schema, migrations, event ID generation,
-   append/page/resume APIs, and unit tests.
+1. Add `airc-store` Rust crate with ORM entities, migrations, event ID
+   generation, append/page/resume APIs, and unit tests.
 2. Add JSONL import/export so existing `messages.jsonl` rooms are not stranded.
 3. Route `airc logs` through the Rust store behind a feature flag while keeping
    JSONL as compatibility output.

--- a/test/test_realtime_event_bus_docs.py
+++ b/test/test_realtime_event_bus_docs.py
@@ -1,0 +1,69 @@
+"""Contract checks for the realtime event bus design."""
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DOC = REPO_ROOT / "docs" / "realtime-event-bus.md"
+
+
+class RealtimeEventBusDocTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = DOC.read_text(encoding="utf-8")
+
+    def test_reuses_continuum_schema_families(self) -> None:
+        for schema in (
+            "JTAGRequest<T>",
+            "JTAGMessage<T>",
+            "EventBridgePayload",
+            "GridFrame",
+            "BridgeCommand",
+            "BridgeEvent",
+        ):
+            self.assertIn(schema, self.text)
+
+    def test_declares_airc_continuum_adapter_boundaries(self) -> None:
+        for phrase in (
+            "AIRC owns:",
+            "Continuum owns:",
+            "The adapter owns:",
+            "AIRC should not define Continuum's domain packet hierarchy",
+        ):
+            self.assertIn(phrase, self.text)
+
+    def test_traits_cover_subscription_presence_transport_and_schema(self) -> None:
+        for trait_name in (
+            "pub trait EventBus",
+            "pub trait SubscriptionStore",
+            "pub trait PresenceStore",
+            "pub trait RealtimeTransport",
+            "pub trait SchemaAdapter",
+        ):
+            self.assertIn(trait_name, self.text)
+
+    def test_realtime_sql_and_media_boundary_are_explicit(self) -> None:
+        for phrase in (
+            "CREATE TABLE realtime_latest",
+            "CREATE TABLE subscription_metrics",
+            "CREATE TABLE request_response_index",
+            "AIRC does not carry audio/video frames",
+            "exclude_same_client",
+        ):
+            self.assertIn(phrase, self.text)
+
+    def test_realtime_storage_is_internal_orm_not_consumer_sql(self) -> None:
+        for phrase in (
+            "ORM-backed SQLite indexes",
+            "it must not query AIRC SQLite tables directly",
+            "These tables are ORM migration targets inside AIRC",
+            "not to invite application SQL",
+        ):
+            self.assertIn(phrase, self.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_rust_sqlite_substrate_docs.py
+++ b/test/test_rust_sqlite_substrate_docs.py
@@ -46,6 +46,17 @@ class RustSqliteSubstrateDocTests(unittest.TestCase):
         ):
             self.assertIn(trait_name, self.text)
 
+    def test_requires_orm_boundary_not_application_sql(self) -> None:
+        for phrase in (
+            "Use a Rust ORM crate",
+            "SeaORM is the default candidate",
+            "Raw SQL belongs",
+            "only in migrations",
+            "Continuum must not issue SQL",
+            "It should not open the SQLite database, run SQL queries",
+        ):
+            self.assertIn(phrase, self.text)
+
     def test_realtime_and_performance_requirements_are_explicit(self) -> None:
         for phrase in (
             "presence.typing",


### PR DESCRIPTION
## Summary
- define the realtime event-bus contract on top of the Rust SQLite substrate
- preserve Continuum JTAG/EventBridge/GridFrame/LiveKit payloads through schema adapters instead of redefining them
- document subscriptions, presence coalescing, receipts, self-filtering, WebRTC/LiveKit control boundaries, and benchmark targets
- make SQLite explicitly internal to a Rust ORM/entity layer: no Continuum SQL coupling, no app-layer SQL queries
- add doc contract tests for schema families, traits, ORM boundary, SQL projection review text, and media boundary

## Verification
- python3 -m unittest discover -s test -p 'test_realtime_event_bus_docs.py'\n- python3 -m unittest discover -s test -p 'test_rust_sqlite_substrate_docs.py'\n- git diff --check\n\nCloses #626