### PR TITLE
feat(logs): add json transcript pages

### DIFF
--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -416,22 +416,26 @@ cmd_logs() {
   # and O(delta) per-turn — Codex hit context exhaustion 2026-05-02
   # because polling `logs 50` every turn re-injected ~7K tokens.
   local since=""
+  local output_json=0
   local positional=()
   while [ $# -gt 0 ]; do
     case "$1" in
+      --json)
+        output_json=1; shift ;;
       --since)
         [ -n "${2:-}" ] || die "--since requires an argument (ISO timestamp or relative like 60s/5m/1h)"
         since="$2"; shift 2 ;;
       --since=*)
         since="${1#--since=}"; shift ;;
       -h|--help)
-        echo "Usage: airc logs [N] [--since <ts|Ns|Nm|Nh>]"
+        echo "Usage: airc logs [N] [--since <ts|Ns|Nm|Nh>] [--json]"
         echo "  N           tail this many recent messages (default 20)"
         echo "  --since X   filter to messages newer than X. X can be:"
         echo "              ISO timestamp (2026-05-02T19:30:00Z)"
         echo "              relative offset (60s, 5m, 1h, 2d)"
         echo "              For incremental polling — re-poll using the"
         echo "              ts of the last message you saw."
+        echo "  --json      emit now_utc, since, count, and event objects."
         return 0 ;;
       *) positional+=("$1"); shift ;;
     esac
@@ -456,51 +460,14 @@ cmd_logs() {
   else
     raw=$(tail -"$count" "$MESSAGES" 2>/dev/null) || true
   fi
-  # Pass --since as env var (not bash-interpolated into Python) so empty
-  # value doesn't produce malformed Python like `since_arg = or ''`.
-  AIRC_LOGS_SINCE="$since" echo "$raw" | AIRC_LOGS_SINCE="$since" "$AIRC_PYTHON" -c "
-import sys, json, re, os
-from datetime import datetime, timezone, timedelta
-
-since_arg = os.environ.get('AIRC_LOGS_SINCE', '')
-since_dt = None
-if since_arg:
-    # Relative offset: <N><unit> where unit is s|m|h|d
-    m = re.fullmatch(r'(\d+)([smhd])', since_arg)
-    if m:
-        n, unit = int(m.group(1)), m.group(2)
-        delta = {'s': timedelta(seconds=n), 'm': timedelta(minutes=n),
-                 'h': timedelta(hours=n),   'd': timedelta(days=n)}[unit]
-        since_dt = datetime.now(timezone.utc) - delta
-    else:
-        # ISO timestamp — accept Z suffix or +00:00
-        try:
-            since_dt = datetime.fromisoformat(since_arg.replace('Z', '+00:00'))
-            if since_dt.tzinfo is None:
-                since_dt = since_dt.replace(tzinfo=timezone.utc)
-        except ValueError:
-            sys.stderr.write(f\"airc logs --since: cannot parse '{since_arg}' (use ISO timestamp or 60s/5m/1h/2d)\n\")
-            sys.exit(2)
-
-for line in sys.stdin:
-    try:
-        m = json.loads(line.strip())
-        if since_dt is not None:
-            ts = m.get('ts', '')
-            if not ts:
-                continue
-            try:
-                msg_dt = datetime.fromisoformat(ts.replace('Z', '+00:00'))
-                if msg_dt.tzinfo is None:
-                    msg_dt = msg_dt.replace(tzinfo=timezone.utc)
-            except ValueError:
-                continue
-            if msg_dt <= since_dt:
-                continue
-        print(f\"[{m.get('ts','')}] {m.get('from','?')}: {m.get('msg','')}\")
-    except Exception:
-        pass
-"
+  local json_flag=()
+  if [ "$output_json" -eq 1 ]; then
+    json_flag=(--json)
+  fi
+  echo "$raw" | "$AIRC_PYTHON" -m airc_core.logs render \
+    --since "$since" \
+    --count "$count" \
+    "${json_flag[@]}"
 }
 
 cmd_inbox() {

--- a/lib/airc_core/logs.py
+++ b/lib/airc_core/logs.py
@@ -1,0 +1,140 @@
+"""Machine-readable rendering for AIRC message logs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class LogEvent:
+    id: str
+    ts: str
+    sender: str
+    recipient: str
+    channel: str
+    msg: str
+    client_id: str
+    raw: dict
+
+
+def parse_since(value: str) -> datetime | None:
+    if not value:
+        return None
+    match = re.fullmatch(r"(\d+)([smhd])", value)
+    if match:
+        amount = int(match.group(1))
+        unit = match.group(2)
+        delta = {
+            "s": timedelta(seconds=amount),
+            "m": timedelta(minutes=amount),
+            "h": timedelta(hours=amount),
+            "d": timedelta(days=amount),
+        }[unit]
+        return datetime.now(timezone.utc) - delta
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            f"cannot parse '{value}' (use ISO timestamp or 60s/5m/1h/2d)"
+        ) from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _parse_ts(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def events_from_lines(lines: Iterable[str], since: datetime | None = None) -> list[LogEvent]:
+    events: list[LogEvent] = []
+    for line in lines:
+        try:
+            obj = json.loads(line.strip())
+        except Exception:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        ts = obj.get("ts", "")
+        if not isinstance(ts, str):
+            ts = ""
+        if since is not None:
+            event_dt = _parse_ts(ts)
+            if event_dt is None or event_dt <= since:
+                continue
+        sender = obj.get("from", "?")
+        recipient = obj.get("to", "")
+        channel = obj.get("channel", "")
+        msg = obj.get("msg", "")
+        client_id = obj.get("client_id", obj.get("clientId", ""))
+        sig = obj.get("sig", obj.get("id", ""))
+        events.append(
+            LogEvent(
+                id=sig if isinstance(sig, str) else "",
+                ts=ts,
+                sender=sender if isinstance(sender, str) else "?",
+                recipient=recipient if isinstance(recipient, str) else "",
+                channel=channel if isinstance(channel, str) else "",
+                msg=msg if isinstance(msg, str) else str(msg),
+                client_id=client_id if isinstance(client_id, str) else "",
+                raw=obj,
+            )
+        )
+    return events
+
+
+def render_human(events: Iterable[LogEvent]) -> str:
+    return "".join(f"[{event.ts}] {event.sender}: {event.msg}\n" for event in events)
+
+
+def render_json(events: list[LogEvent], since_arg: str, count: int) -> str:
+    payload = {
+        "now_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "since": since_arg,
+        "count": count,
+        "events": [asdict(event) for event in events],
+    }
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="airc_core.logs")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    render = sub.add_parser("render")
+    render.add_argument("--since", default="")
+    render.add_argument("--count", type=int, required=True)
+    render.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        since = parse_since(args.since)
+    except ValueError as exc:
+        print(f"airc logs --since: {exc}", file=sys.stderr)
+        return 2
+    events = events_from_lines(sys.stdin, since)
+    if args.json:
+        sys.stdout.write(render_json(events, args.since, args.count))
+    else:
+        sys.stdout.write(render_human(events))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/logs/SKILL.md
+++ b/skills/logs/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: airc:logs
-description: Show the last N messages in the mesh's shared log (default 20). Human-readable format — timestamp + sender + message.
+description: Show the last N messages in the mesh's shared log (default 20), either human-readable or JSON for tooling.
 user-invocable: true
 allowed-tools: Bash
-argument-hint: "[N]"
+argument-hint: "[N] [--since <ts|offset>] [--json]"
 ---
 
 # airc logs
@@ -17,10 +17,12 @@ airc logs                  # last 20
 airc logs 50               # last 50
 airc logs --since 5m       # incremental poll for recent messages
 airc logs --since 2026-05-03T15:30:00Z
+airc logs 50 --json       # machine-readable page for tooling
 airc join                  # prints status + unread catch-up when the scope is already active
 ```
 
 Prints one line per message: `[ts] from: msg`. Reads this scope's local message log, which the running bearer keeps synced from the channel gist.
+With `--json`, prints `now_utc`, `since`, `count`, and an `events` array with stable fields plus the raw envelope.
 
 ## When to use
 

--- a/test/test_logs.py
+++ b/test/test_logs.py
@@ -1,0 +1,80 @@
+"""Tests for machine-readable `airc logs` rendering."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+from airc_core import logs  # noqa: E402
+
+
+class LogsRenderTests(unittest.TestCase):
+    def line(self, **fields: object) -> str:
+        return json.dumps(fields) + "\n"
+
+    def test_human_render_preserves_existing_shape(self) -> None:
+        events = logs.events_from_lines([
+            self.line(ts="2026-05-16T01:00:00Z", **{"from": "agent"}, msg="ready")
+        ])
+
+        self.assertEqual(logs.render_human(events), "[2026-05-16T01:00:00Z] agent: ready\n")
+
+    def test_json_render_exposes_stable_event_fields(self) -> None:
+        events = logs.events_from_lines([
+            self.line(
+                sig="sig-1",
+                ts="2026-05-16T01:00:00Z",
+                **{"from": "agent", "to": "all"},
+                channel="general",
+                msg="ready",
+                client_id="client-a",
+            )
+        ])
+
+        payload = json.loads(logs.render_json(events, since_arg="", count=20))
+
+        self.assertEqual(payload["count"], 20)
+        self.assertEqual(payload["events"][0]["id"], "sig-1")
+        self.assertEqual(payload["events"][0]["sender"], "agent")
+        self.assertEqual(payload["events"][0]["recipient"], "all")
+        self.assertEqual(payload["events"][0]["channel"], "general")
+        self.assertEqual(payload["events"][0]["client_id"], "client-a")
+        self.assertEqual(payload["events"][0]["raw"]["msg"], "ready")
+
+    def test_since_filters_by_message_timestamp(self) -> None:
+        since = datetime(2026, 5, 16, 1, 0, 0, tzinfo=timezone.utc)
+
+        events = logs.events_from_lines(
+            [
+                self.line(ts="2026-05-16T00:59:59Z", **{"from": "agent"}, msg="old"),
+                self.line(ts="2026-05-16T01:00:01Z", **{"from": "agent"}, msg="new"),
+            ],
+            since=since,
+        )
+
+        self.assertEqual([event.msg for event in events], ["new"])
+
+    def test_cli_json_mode(self) -> None:
+        stdin = io.StringIO(self.line(sig="sig-1", ts="2026-05-16T01:00:00Z", **{"from": "agent"}, msg="ready"))
+        stdout = io.StringIO()
+
+        with patch("sys.stdin", stdin), redirect_stdout(stdout):
+            code = logs.main(["render", "--count", "20", "--json"])
+
+        self.assertEqual(code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["events"][0]["id"], "sig-1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an airc_core.logs renderer for human and JSON log pages
- support airc logs --json alongside existing --since/count behavior
- document the JSON shape for tooling consumers

## Verification
- python3 -m unittest discover -s test -p 'test_logs.py'
- python3 -m unittest discover -s test -p 'test_*.py' (440 tests, 53 skipped)
- bash -n lib/airc_bash/cmd_status.sh
- cargo test
- git diff --check
- isolated smoke: AIRC_HOME=<temp> ./airc logs 20 --json