### PR TITLE
fix(logs): avoid strict-mode crash without json flag

### DIFF
--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -460,14 +460,16 @@ cmd_logs() {
   else
     raw=$(tail -"$count" "$MESSAGES" 2>/dev/null) || true
   fi
-  local json_flag=()
   if [ "$output_json" -eq 1 ]; then
-    json_flag=(--json)
+    echo "$raw" | "$AIRC_PYTHON" -m airc_core.logs render \
+      --since "$since" \
+      --count "$count" \
+      --json
+    return
   fi
   echo "$raw" | "$AIRC_PYTHON" -m airc_core.logs render \
     --since "$since" \
-    --count "$count" \
-    "${json_flag[@]}"
+    --count "$count"
 }
 
 cmd_inbox() {

--- a/test/test_logs.py
+++ b/test/test_logs.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import io
 import json
+import os
+import subprocess
 import sys
+import tempfile
 import unittest
 from contextlib import redirect_stdout
 from datetime import datetime, timezone
@@ -74,6 +77,36 @@ class LogsRenderTests(unittest.TestCase):
         self.assertEqual(code, 0)
         payload = json.loads(stdout.getvalue())
         self.assertEqual(payload["events"][0]["id"], "sig-1")
+
+    def test_airc_logs_human_mode_does_not_require_json_flag(self) -> None:
+        result = self.run_airc_logs("1")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("[2026-05-16T01:00:00Z] agent: ready", result.stdout)
+
+    def test_airc_logs_json_mode_still_emits_machine_readable_page(self) -> None:
+        result = self.run_airc_logs("1", "--json")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout[result.stdout.index("{"):])
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["events"][0]["sender"], "agent")
+
+    def run_airc_logs(self, *args: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as home:
+            Path(home, "messages.jsonl").write_text(
+                self.line(sig="sig-1", ts="2026-05-16T01:00:00Z", **{"from": "agent"}, msg="ready"),
+                encoding="utf-8",
+            )
+            env = {**os.environ, "AIRC_HOME": home}
+            return subprocess.run(
+                [str(REPO_ROOT / "airc"), "logs", *args],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix `airc logs` human mode under strict Bash by avoiding empty optional-array expansion
- keep `--json` mode explicit and unchanged
- add CLI-boundary regressions for human and JSON logs modes

## Verification
- `python3 -m unittest discover -s test -p 'test_logs.py'`
- `python3 -m unittest discover -s test -p 'test_*.py'` (448 tests, 50 skipped)
- `cargo test`
- `bash -n airc lib/airc_bash/cmd_status.sh`
- `git diff --check`
- live smoke: `airc logs 8`, `airc logs 2 --json`