### PR TITLE
refactor(logs): use one render path for human and json modes

### DIFF
--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -460,16 +460,11 @@ cmd_logs() {
   else
     raw=$(tail -"$count" "$MESSAGES" 2>/dev/null) || true
   fi
+  set -- render --since "$since" --count "$count"
   if [ "$output_json" -eq 1 ]; then
-    echo "$raw" | "$AIRC_PYTHON" -m airc_core.logs render \
-      --since "$since" \
-      --count "$count" \
-      --json
-    return
+    set -- "$@" --json
   fi
-  echo "$raw" | "$AIRC_PYTHON" -m airc_core.logs render \
-    --since "$since" \
-    --count "$count"
+  echo "$raw" | "$AIRC_PYTHON" -m airc_core.logs "$@"
 }
 
 cmd_inbox() {


### PR DESCRIPTION
## Summary
- remove duplicated human/json render branches from `cmd_logs`
- build renderer argv once and append `--json` when requested
- keeps the strict-mode crash fix from #639 but reduces the shell branching surface

## Verification
- `python3 -m unittest discover -s test -p 'test_logs.py'`
- `bash -n airc lib/airc_bash/cmd_status.sh`
- `git diff --check`
- live smoke: `airc logs 3`, `airc logs 1 --json`

## Follow-up
This is only cleanup around the current Bash wrapper. The architectural direction remains moving AIRC command logic into typed Rust/SQLite-backed command modules and leaving shell as a launcher.