### PR TITLE
feat(queue): metronome fan-out across active roster (airc#607, continuum#1192)

### DIFF
--- a/airc
+++ b/airc
@@ -2138,9 +2138,18 @@ reminder_timer_loop() {
     # only says "you have been silent"; metronome says "here are claimable
     # cards and the exact claim/lane commands." It runs on monitor cadence
     # and never exits the monitor if GitHub/network is temporarily down.
+    #
+    # airc#607 / continuum#1192 — when owner=*roster*, fan out to each
+    # recent sender in this scope's messages.jsonl (a single fixed
+    # owner could only ever feed one agent; the rest of the channel
+    # stayed idle because the metronome had nothing to say to them).
+    # Per-recipient dedup state lives under queue_metronome_recent/
+    # so a tight pulse cadence doesn't double-DM the same agent. The
+    # Rust port of this dispatcher lives in airc#628.
     local queue_metronome_file="$AIRC_WRITE_DIR/queue_metronome"
     if [ -f "$queue_metronome_file" ]; then
       local qm_repo="" qm_owner="" qm_interval=300 qm_limit=10 qm_repo_root=""
+      local qm_roster_window=86400
       while IFS='=' read -r key value; do
         case "$key" in
           repo) qm_repo="$value" ;;
@@ -2148,6 +2157,7 @@ reminder_timer_loop() {
           interval) qm_interval="$value" ;;
           limit) qm_limit="$value" ;;
           repo_root) qm_repo_root="$value" ;;
+          roster_window) qm_roster_window="$value" ;;
         esac
       done < "$queue_metronome_file"
       if [ -n "$qm_repo" ] && [ -n "$qm_interval" ] && [ "$qm_interval" -gt 0 ] 2>/dev/null; then
@@ -2157,20 +2167,103 @@ reminder_timer_loop() {
         local qm_elapsed=$(( now - qm_last ))
         if [ "$qm_elapsed" -ge "$qm_interval" ]; then
           printf '%s\n' "$now" > "$qm_last_file"
-          local qm_args
-          if [ -n "$qm_owner" ]; then
-            qm_args=(dispatch "$qm_owner" "$qm_repo" --limit "$qm_limit" --message "metronome: idle hand-out; claim it, heartbeat it, or release it.")
-            if [ -n "$qm_repo_root" ]; then
-              qm_args+=(--repo-root "$qm_repo_root")
+          if [ "$qm_owner" = "*roster*" ]; then
+            # Fan-out across recent senders. Per-recipient dedup window
+            # = qm_interval, so the same agent can't get a second DM
+            # inside the configured pulse cadence even if the monitor
+            # ticks faster for any reason.
+            local recent_dir="$AIRC_WRITE_DIR/queue_metronome_recent"
+            mkdir -p "$recent_dir"
+            local messages_log="$AIRC_WRITE_DIR/messages.jsonl"
+            # Use the same identity primitive the queue verbs use, so we
+            # filter out the same agent name that would receive its own
+            # cmd_send echo. Fall back to empty so the python below just
+            # doesn't filter — the per-recipient dedup will still gate.
+            local my_name=""
+            if declare -F _airc_queue_resolve_name >/dev/null 2>&1; then
+              my_name=$(_airc_queue_resolve_name 2>/dev/null || echo "")
             fi
+            local roster
+            roster=$("$AIRC_PYTHON" - "$messages_log" "$qm_roster_window" "$my_name" <<'PY' 2>/dev/null
+import json, os, sys, time
+log, window_s, me = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+now = time.time()
+seen = {}
+if os.path.exists(log):
+    try:
+        with open(log) as f:
+            for line in f:
+                try:
+                    m = json.loads(line)
+                except Exception:
+                    continue
+                who = m.get('from') or ''
+                if not who or who == 'airc' or who == me:
+                    continue
+                ts = m.get('ts')
+                # ts may be epoch float, epoch-ms int, or ISO string.
+                try:
+                    if isinstance(ts, (int, float)):
+                        t = float(ts)
+                        if t > 1e12:
+                            t = t / 1000.0
+                    else:
+                        from datetime import datetime
+                        t = datetime.fromisoformat(str(ts).replace('Z', '+00:00')).timestamp()
+                except Exception:
+                    continue
+                if now - t > window_s:
+                    continue
+                prev = seen.get(who, 0)
+                if t > prev:
+                    seen[who] = t
+for who in sorted(seen, key=lambda k: seen[k], reverse=True):
+    print(who)
+PY
+)
+            local dispatched=0 skipped=0
+            local agent
+            while IFS= read -r agent; do
+              [ -n "$agent" ] || continue
+              # Per-recipient dedup: skip if pinged within qm_interval.
+              local agent_stamp="$recent_dir/$agent"
+              local last_ping=0
+              [ -f "$agent_stamp" ] && last_ping=$(cat "$agent_stamp" 2>/dev/null)
+              if [ "$(( now - last_ping ))" -lt "$qm_interval" ]; then
+                skipped=$((skipped + 1))
+                continue
+              fi
+              local qm_args=(dispatch "$agent" "$qm_repo" --limit "$qm_limit" --message "metronome (fan-out): idle hand-out; claim it, heartbeat it, or release it.")
+              if [ -n "$qm_repo_root" ]; then
+                qm_args+=(--repo-root "$qm_repo_root")
+              fi
+              if cmd_queue "${qm_args[@]}" >/dev/null 2>&1; then
+                printf '%s\n' "$now" > "$agent_stamp"
+                dispatched=$((dispatched + 1))
+              else
+                # Empty queue for this agent or other dispatch failure
+                # is expected and non-fatal. Stamp anyway so we don't
+                # retry every tick — same dedup window applies.
+                printf '%s\n' "$now" > "$agent_stamp"
+              fi
+            done <<< "$roster"
+            printf '[%s] airc: Queue metronome fan-out pulse for %s — dispatched %d, skipped %d (dedup)\n' "$(timestamp)" "$qm_repo" "$dispatched" "$skipped"
           else
-            qm_args=(next "$qm_repo" --limit "$qm_limit" --idle-ping)
-            if [ -n "$qm_repo_root" ]; then
-              qm_args+=(--repo-root "$qm_repo_root")
+            local qm_args
+            if [ -n "$qm_owner" ]; then
+              qm_args=(dispatch "$qm_owner" "$qm_repo" --limit "$qm_limit" --message "metronome: idle hand-out; claim it, heartbeat it, or release it.")
+              if [ -n "$qm_repo_root" ]; then
+                qm_args+=(--repo-root "$qm_repo_root")
+              fi
+            else
+              qm_args=(next "$qm_repo" --limit "$qm_limit" --idle-ping)
+              if [ -n "$qm_repo_root" ]; then
+                qm_args+=(--repo-root "$qm_repo_root")
+              fi
             fi
+            printf '[%s] airc: Queue metronome pulse — dispatching next work for %s\n' "$(timestamp)" "$qm_repo"
+            cmd_queue "${qm_args[@]}" || printf '[%s] airc: Queue metronome pulse failed; will retry on next interval.\n' "$(timestamp)"
           fi
-          printf '[%s] airc: Queue metronome pulse — dispatching next work for %s\n' "$(timestamp)" "$qm_repo"
-          cmd_queue "${qm_args[@]}" || printf '[%s] airc: Queue metronome pulse failed; will retry on next interval.\n' "$(timestamp)"
         fi
       fi
     fi

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -1519,6 +1519,14 @@ _cmd_queue_metronome() {
   # Configure monitor-loop queue-next pulses. This is the automated half of
   # `queue next`: monitor can periodically call the same primitive and
   # broadcast candidates when an agent/session is quiet.
+  #
+  # airc#607 / continuum#1192 fan-out: when --all is set, the monitor
+  # consumer iterates the active channel roster (recent senders in this
+  # scope's messages.jsonl) and dispatches per agent — closes the gap
+  # where a single-owner metronome could only ever feed one agent and
+  # left the rest of the room idle. The longer-term Rust port lives in
+  # airc#628 (Rust queue-dispatch substrate); this bash branch is the
+  # bridge so the immediate UX bug isn't blocked on that lane.
   local target_repo=""
   local interval=300
   local owner=""
@@ -1526,6 +1534,8 @@ _cmd_queue_metronome() {
   local repo_root=""
   local off=0
   local status=0
+  local all_roster=0
+  local roster_window=86400
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -1539,10 +1549,12 @@ _cmd_queue_metronome() {
       status)
         status=1
         ;;
-      --interval)  shift; interval="${1:-300}" ;;
-      --owner)     shift; owner="${1:-}" ;;
-      --limit)     shift; limit="${1:-10}" ;;
-      --repo-root) shift; repo_root="${1:-}" ;;
+      --interval)       shift; interval="${1:-300}" ;;
+      --owner)          shift; owner="${1:-}" ;;
+      --limit)          shift; limit="${1:-10}" ;;
+      --repo-root)      shift; repo_root="${1:-}" ;;
+      --all|--roster)   all_roster=1 ;;
+      --roster-window)  shift; roster_window="${1:-86400}" ;;
       -*) die "queue metronome: unknown flag: $1" ;;
       *)
         if [ -z "$target_repo" ]; then
@@ -1555,10 +1567,26 @@ _cmd_queue_metronome() {
     shift || true
   done
 
+  # --all is mutually exclusive with --owner: --all means "iterate the
+  # channel roster"; --owner means "always this one agent". Mixing them
+  # is ambiguous and likely an operator mistake (e.g. forgot to clear an
+  # old --owner). Refuse early so the config file never lands in a
+  # contradictory state the monitor would silently resolve one way.
+  if [ "$all_roster" -eq 1 ] && [ -n "$owner" ]; then
+    die "queue metronome: --all is mutually exclusive with --owner (got both: --owner $owner, --all)"
+  fi
+  case "$roster_window" in
+    ''|*[!0-9]*) die "queue metronome: --roster-window must be a positive integer seconds value (got: $roster_window)" ;;
+  esac
+  if [ "$roster_window" -lt 60 ]; then
+    die "queue metronome: --roster-window must be >= 60 seconds (got: $roster_window)"
+  fi
+
   local config_file="$AIRC_WRITE_DIR/queue_metronome"
 
   if [ "$off" -eq 1 ]; then
     rm -f "$config_file" "$AIRC_WRITE_DIR/queue_metronome_last"
+    rm -rf "$AIRC_WRITE_DIR/queue_metronome_recent"
     echo "  Queue metronome off."
     return 0
   fi
@@ -1595,7 +1623,13 @@ _cmd_queue_metronome() {
   if [ "$limit" -lt 1 ]; then
     die "queue metronome: --limit must be >= 1 (got: $limit)"
   fi
-  if [ -z "$owner" ]; then
+  # airc#607: the sentinel owner=*roster* tells the monitor consumer to
+  # enumerate recent senders from messages.jsonl rather than dispatch to
+  # one fixed agent. Operators opt in via --all; default stays single-
+  # agent to preserve existing behaviour for anyone scripting against it.
+  if [ "$all_roster" -eq 1 ]; then
+    owner='*roster*'
+  elif [ -z "$owner" ]; then
     owner=$(_airc_queue_resolve_name)
   fi
 
@@ -1606,11 +1640,22 @@ _cmd_queue_metronome() {
     printf 'owner=%s\n' "$owner"
     printf 'limit=%s\n' "$limit"
     printf 'repo_root=%s\n' "$repo_root"
+    printf 'roster_window=%s\n' "$roster_window"
   } > "$config_file"
   rm -f "$AIRC_WRITE_DIR/queue_metronome_last"
+  # Per-recipient dedup state lives under queue_metronome_recent/<name>.
+  # Wipe on reconfigure so the next pulse starts clean rather than
+  # silently suppressing recipients whose last-ping pre-dates the new
+  # cadence.
+  rm -rf "$AIRC_WRITE_DIR/queue_metronome_recent"
 
-  echo "  Queue metronome every ${interval}s for ${target_repo} as ${owner}."
-  echo "  Monitor will run: airc queue dispatch ${owner} ${target_repo}"
+  if [ "$all_roster" -eq 1 ]; then
+    echo "  Queue metronome every ${interval}s for ${target_repo}, fan-out across active roster (window ${roster_window}s)."
+    echo "  Monitor will run: airc queue dispatch <each-recent-sender> ${target_repo}"
+  else
+    echo "  Queue metronome every ${interval}s for ${target_repo} as ${owner}."
+    echo "  Monitor will run: airc queue dispatch ${owner} ${target_repo}"
+  fi
 }
 
 _cmd_queue_adopt() {

--- a/lib/airc_bash/cmd_queue_help.sh
+++ b/lib/airc_bash/cmd_queue_help.sh
@@ -367,6 +367,7 @@ airc queue metronome — configure automatic queue-next idle pulses
 
 USAGE
   airc queue metronome <owner/repo> [--interval 300] [--owner HANDLE] [--limit N]
+  airc queue metronome <owner/repo> --all [--interval 300] [--roster-window 86400]
   airc queue metronome status
   airc queue metronome off
 
@@ -379,10 +380,24 @@ DESCRIPTION
   That makes claimable work loud and addressed without waiting for a human
   to ask why agents are idle.
 
+  With --all (airc#607 / continuum#1192), the monitor fans the dispatch
+  out across every recent sender it has seen in this scope's message
+  log — closes the gap where a single-owner config could only ever feed
+  one agent while the rest of the room stayed idle.
+
 OPTIONS
   --interval <seconds>   Pulse cadence. Minimum 30s; default 300s.
   --owner <handle>       Agent/work identity used for claim suggestions.
-                         Default: current AIRC work identity.
+                         Default: current AIRC work identity. Mutually
+                         exclusive with --all.
+  --all, --roster        Fan-out mode: every pulse, iterate every recent
+                         sender in this scope's messages.jsonl and DM
+                         each one their next claimable card. Per-recipient
+                         dedup window = pulse interval, so a tight cadence
+                         can't double-ping the same agent.
+  --roster-window <sec>  How far back to look for "recent sender" when
+                         building the fan-out roster. Minimum 60s; default
+                         86400 (24h). Only meaningful with --all.
   --limit <N>            Max queue cards to scan per pulse (default 10).
   --repo-root <path>     Optional repo path for suggested lane commands.
   status                 Show current config.
@@ -394,6 +409,8 @@ NOTES
     exact next commands so agents can claim deliberately.
   - This is intentionally separate from plain `airc reminder`: reminders
     only say "you are silent"; metronome says "here is what to do next."
+  - Long-term, this dispatcher moves to a typed Rust substrate; see
+    airc#628 (Rust queue-dispatch port).
 EOF
 }
 

--- a/test/test_queue_metronome_fanout.py
+++ b/test/test_queue_metronome_fanout.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Test airc#607/continuum#1192: monitor metronome fan-out across the
+active channel roster.
+
+Two layers of coverage:
+
+1. `test_metronome_all_config_write` — drives the real `airc` binary with
+   a temp `AIRC_HOME`, asserts `--all` writes the `*roster*` sentinel and
+   that `--all` + `--owner` is rejected up-front.
+
+2. `test_roster_extraction_logic` — mirrors the embedded Python that the
+   monitor's reminder_timer_loop runs to build the recipient list from
+   messages.jsonl. Drift between this fixture and the real code is the
+   bug-shape we're protecting against: if the monitor logic changes its
+   filter rules without the test catching it, fan-out either over-pings
+   (system noise) or under-pings (idle peers stay idle, regressing 1192).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+
+
+def _repo_root():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.dirname(here)
+
+
+AIRC = os.path.join(_repo_root(), "airc")
+
+
+class MetronomeAllConfigWrite(unittest.TestCase):
+    """Driving the real airc binary — proves the CLI surface."""
+
+    def test_all_writes_roster_sentinel(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {**os.environ, "AIRC_HOME": tmp, "AIRC_NO_GENERAL": "1"}
+            r = subprocess.run(
+                [AIRC, "queue", "metronome", "CambrianTech/airc",
+                 "--all", "--interval", "60", "--roster-window", "3600"],
+                cwd="/tmp", env=env, capture_output=True, text=True,
+            )
+            self.assertEqual(r.returncode, 0, msg=r.stderr)
+            cfg_path = os.path.join(tmp, "queue_metronome")
+            self.assertTrue(os.path.exists(cfg_path),
+                            f"config not written; stderr={r.stderr!r}")
+            with open(cfg_path) as f:
+                cfg = dict(line.strip().split("=", 1)
+                           for line in f if "=" in line)
+            self.assertEqual(cfg.get("owner"), "*roster*")
+            self.assertEqual(cfg.get("roster_window"), "3600")
+            self.assertEqual(cfg.get("interval"), "60")
+            self.assertEqual(cfg.get("repo"), "CambrianTech/airc")
+
+    def test_all_rejects_owner_combo(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {**os.environ, "AIRC_HOME": tmp, "AIRC_NO_GENERAL": "1"}
+            r = subprocess.run(
+                [AIRC, "queue", "metronome", "CambrianTech/airc",
+                 "--all", "--owner", "joel"],
+                cwd="/tmp", env=env, capture_output=True, text=True,
+            )
+            self.assertNotEqual(r.returncode, 0,
+                                "expected refusal when --all + --owner combined")
+            self.assertIn("mutually exclusive", r.stderr.lower(),
+                          f"expected mutex error; got: {r.stderr!r}")
+
+    def test_roster_window_validation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {**os.environ, "AIRC_HOME": tmp, "AIRC_NO_GENERAL": "1"}
+            r = subprocess.run(
+                [AIRC, "queue", "metronome", "CambrianTech/airc",
+                 "--all", "--roster-window", "10"],
+                cwd="/tmp", env=env, capture_output=True, text=True,
+            )
+            self.assertNotEqual(r.returncode, 0,
+                                "expected refusal for sub-minimum window")
+            self.assertIn("roster-window", r.stderr.lower())
+
+
+# Roster extraction logic copied verbatim from `airc` monitor loop
+# (reminder_timer_loop). Keep in sync — divergence is the bug surface.
+def _extract_roster(messages_path, window_s, me):
+    now = time.time()
+    seen = {}
+    if os.path.exists(messages_path):
+        with open(messages_path) as f:
+            for line in f:
+                try:
+                    m = json.loads(line)
+                except Exception:
+                    continue
+                who = m.get("from") or ""
+                if not who or who == "airc" or who == me:
+                    continue
+                ts = m.get("ts")
+                try:
+                    if isinstance(ts, (int, float)):
+                        t = float(ts)
+                        if t > 1e12:
+                            t = t / 1000.0
+                    else:
+                        t = datetime.fromisoformat(
+                            str(ts).replace("Z", "+00:00")
+                        ).timestamp()
+                except Exception:
+                    continue
+                if now - t > window_s:
+                    continue
+                if t > seen.get(who, 0):
+                    seen[who] = t
+    return [who for who in sorted(seen, key=lambda k: seen[k], reverse=True)]
+
+
+class RosterExtraction(unittest.TestCase):
+    """Unit tests for the python embedded in reminder_timer_loop."""
+
+    def _write_fixture(self, path, lines):
+        with open(path, "w") as f:
+            for line in lines:
+                f.write(json.dumps(line) + "\n")
+
+    def test_recent_senders_listed_newest_first(self):
+        now = time.time()
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, "messages.jsonl")
+            self._write_fixture(log, [
+                {"from": "alice", "ts": now - 60, "to": "all", "msg": "hi"},
+                {"from": "bob",   "ts": now - 30, "to": "all", "msg": "hey"},
+                {"from": "carol", "ts": now - 5,  "to": "all", "msg": "yo"},
+            ])
+            roster = _extract_roster(log, window_s=3600, me="")
+            self.assertEqual(roster, ["carol", "bob", "alice"])
+
+    def test_filters_self_and_airc_system_sender(self):
+        now = time.time()
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, "messages.jsonl")
+            self._write_fixture(log, [
+                {"from": "airc",       "ts": now - 10, "to": "all", "msg": "boot"},
+                {"from": "claude-tab", "ts": now - 5,  "to": "all", "msg": "yo"},
+                {"from": "alice",      "ts": now - 20, "to": "all", "msg": "hi"},
+            ])
+            roster = _extract_roster(log, window_s=3600, me="claude-tab")
+            self.assertEqual(roster, ["alice"])
+
+    def test_drops_anyone_outside_window(self):
+        now = time.time()
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, "messages.jsonl")
+            self._write_fixture(log, [
+                {"from": "ancient", "ts": now - 90000, "to": "all", "msg": "old"},
+                {"from": "fresh",   "ts": now - 30,    "to": "all", "msg": "new"},
+            ])
+            roster = _extract_roster(log, window_s=86400, me="")
+            self.assertEqual(roster, ["fresh"])
+
+    def test_handles_iso_string_timestamps(self):
+        now_iso = datetime.now(timezone.utc).isoformat()
+        old_iso = "2020-01-01T00:00:00Z"
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, "messages.jsonl")
+            self._write_fixture(log, [
+                {"from": "alice", "ts": now_iso, "to": "all", "msg": "hi"},
+                {"from": "old",   "ts": old_iso, "to": "all", "msg": "ancient"},
+            ])
+            roster = _extract_roster(log, window_s=3600, me="")
+            self.assertEqual(roster, ["alice"])
+
+    def test_handles_epoch_milliseconds(self):
+        now_ms = int(time.time() * 1000)
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, "messages.jsonl")
+            self._write_fixture(log, [
+                {"from": "alice", "ts": now_ms, "to": "all", "msg": "hi"},
+            ])
+            roster = _extract_roster(log, window_s=3600, me="")
+            self.assertEqual(roster, ["alice"])
+
+    def test_dedupes_by_latest_timestamp(self):
+        now = time.time()
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, "messages.jsonl")
+            self._write_fixture(log, [
+                {"from": "alice", "ts": now - 600, "to": "all", "msg": "old hi"},
+                {"from": "alice", "ts": now - 5,   "to": "all", "msg": "recent hi"},
+                {"from": "alice", "ts": now - 300, "to": "all", "msg": "middle"},
+            ])
+            roster = _extract_roster(log, window_s=3600, me="")
+            self.assertEqual(roster, ["alice"])  # one entry, not three
+
+    def test_empty_log_returns_empty_roster(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, "messages.jsonl")
+            open(log, "w").close()
+            self.assertEqual(_extract_roster(log, window_s=3600, me=""), [])
+
+    def test_missing_log_returns_empty_roster(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, "messages.jsonl")  # never created
+            self.assertEqual(_extract_roster(log, window_s=3600, me=""), [])
+
+    def test_malformed_lines_are_skipped_not_fatal(self):
+        now = time.time()
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, "messages.jsonl")
+            with open(log, "w") as f:
+                f.write("not json\n")
+                f.write(json.dumps({"from": "alice", "ts": now - 5}) + "\n")
+                f.write("{broken\n")
+            self.assertEqual(_extract_roster(log, window_s=3600, me=""),
+                             ["alice"])
+
+
+if __name__ == "__main__":
+    if not os.path.exists(AIRC) or not os.access(AIRC, os.X_OK):
+        print(f"FATAL: {AIRC} not executable", file=sys.stderr)
+        sys.exit(2)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Metronome `--all` flag fans dispatch out across every recent sender in this scope's `messages.jsonl` instead of being capped at a single fixed owner. Closes the gap where a single-owner config could only ever feed one agent while the rest of the channel stayed idle on top of a non-empty queue.
- Per-recipient dedup (window = pulse interval) so a tight cadence can't double-DM the same agent. State lives under `queue_metronome_recent/`.
- `--all` is mutually exclusive with `--owner` — refuses up-front so the config file can't land in a contradictory state the monitor would silently resolve one way.
- `--roster-window` (default 86400s, min 60s) caps how far back "recent sender" counts.
- 12 new tests: 3 CLI tests against the real `airc` binary + 9 unit tests of the roster extraction logic (recent-only sort, filter self+`airc` system sender, window enforcement, ISO / epoch / epoch-ms timestamps, dedup by latest, empty / missing / malformed log).

## Why bash and not Rust

This is the bridge while airc#628 (Rust queue-dispatch substrate) lands. The embedded python roster extractor and the bash dispatcher loop are intentionally minimal so the Rust port can delete them wholesale rather than re-implement a TS-shaped API.

## Tracking

- Closes airc#607 (monitor idle-pulse)
- Closes continuum#1192 (auto-handout to idle agents)
- Forward link: airc#628 (Rust port)

## Test plan

- [x] `python3 -m unittest test_queue_metronome_fanout` — 12/12 green
- [x] `python3 -m unittest test_queue test_queue_claim test_queue_nudge test_queue_stale` — 102/102 still green
- [x] `bash -n` clean on all three modified shell files
- [x] Manual smoke: `airc queue metronome ... --all` writes correct sentinel; `--all --owner X` refused; `metronome off` clears state including recent dedup dir
- [ ] CI green on this PR
- [ ] Live mesh validation — run `airc queue metronome <repo> --all --interval 60` in a 2+ agent room, verify both agents receive a DM within one interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)