### PR TITLE
hotfix: cmd_peers Python comment backtick broke airc peers in production (#645 follow-up)

### DIFF
--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -669,8 +669,15 @@ except OSError:
     pass
 
 # Union: last_seen = max(last_message, last_heartbeat) for the existing
-# `last seen <age>` display column. The NEW columns are additive — they
+# 'last seen <age>' display column. The NEW columns are additive — they
 # show last_message and last_heartbeat distinctly when present.
+#
+# Note: single-quotes (not backticks) on purpose. This Python code is
+# embedded in a bash double-quoted string; bash interprets backticks
+# as command substitution inside double quotes EVEN INSIDE python-quoted
+# regions because bash parses the outer string before python sees it.
+# Caught live on canary install 2026-05-17: PR-1 (#645) shipped with
+# a backtick in this comment which broke airc peers in production.
 last_seen = dict(last_message)
 for who, hb_ts in last_heartbeat.items():
     prev = last_seen.get(who)


### PR DESCRIPTION
## What

PR-1 #645 shipped a backtick inside a Python comment that was embedded in a bash double-quoted string. Bash parses backticks as command substitution inside double quotes **before** Python sees the content, so:

\`\`\`python
# \`last seen <age>\` display column. The NEW columns are additive
\`\`\`

made bash try to execute \`last seen <age>\` as a shell command, with \`<age>\` looking like an input redirect — syntax error, \`airc peers\` broken in production.

## Caught By

Joel: *"have to see if it works."* I updated airc to canary on the test scope and ran \`airc peers\`:

\`\`\`
$ airc peers
/Users/joelteply/.airc-src/lib/airc_bash/cmd_rooms.sh: command substitution: line 581: syntax error near unexpected token \`newline'
/Users/joelteply/.airc-src/lib/airc_bash/cmd_rooms.sh: command substitution: line 581: \`last seen <age>'
  authenticator-448f → joelteply@192.168.1.223   [#general]   last seen 9d ago (silent)
  vhsm-d1f4 → joelteply@192.168.1.112   [#general]   last seen 13h ago (silent)
\`\`\`

Legacy peers still display (the bash error doesn't halt the parent script) but the substitution is broken — peer name + host + tags + age field are all stomped, only the fallback path runs.

This is exactly the testing discipline Joel's been enforcing: code review + unit tests + bash -n syntax check do NOT validate user experience. Run the actual command a user would run, from a fresh install path.

## Fix

Replace backticks with single quotes in the comment. Same meaning, no bash interaction. Adds a guard-comment naming the gotcha so future edits in this Python-in-bash region don't repeat it:

\`\`\`python
# Note: single-quotes (not backticks) on purpose. This Python code is
# embedded in a bash double-quoted string; bash interprets backticks
# as command substitution inside double quotes EVEN INSIDE python-quoted
# regions because bash parses the outer string before python sees it.
\`\`\`

## Validation

\`bash -n lib/airc_bash/cmd_rooms.sh\` passes clean.

## Title Prefix

\`hotfix:\` so the require-canary-or-hotfix policy gate permits direct-to-main path if escalation is needed. Targets canary like the original PR-1.