### PR TITLE
fix(heartbeat): allow empty body when --heartbeat (caught live; airc#644 PR-2 follow-up)

### DIFF
--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -162,7 +162,16 @@ cmd_send() {
   fi
 
   local first="${1:-}"
-  [ -z "$first" ] && die "Usage: airc send <message>  or  airc send @peer <message>"
+  # airc#644 PR-2 follow-up: --heartbeat is the one legitimate empty-body
+  # send. The signal is in the envelope metadata (kind=heartbeat + ts +
+  # from), not the msg body. Skip the usage-check for heartbeats so the
+  # reminder_timer_loop's 'cmd_send --heartbeat --internal ""' actually
+  # reaches the wire. Caught live 2026-05-17: PR-2 shipped but no
+  # heartbeats appeared in messages.jsonl after teardown+rejoin+75s wait
+  # because this usage-check was rejecting the empty body.
+  if [ -z "$first" ] && [ "$heartbeat" != "1" ]; then
+    die "Usage: airc send <message>  or  airc send @peer <message>"
+  fi
 
   # Multi-target DM: collect leading @-tokens (whitespace-separated)
   # and/or comma-separated peers within a single @-token. All forms


### PR DESCRIPTION
## What

PR-2 (#647) shipped \`cmd_send --heartbeat\` + the \`reminder_timer_loop\` hook calling \`cmd_send --heartbeat --internal ""\` every 60s. Locally testing showed zero heartbeats reaching \`messages.jsonl\` — silent emission failure.

Root cause: \`cmd_send\`'s empty-body usage-check (sane default for chat) was rejecting the heartbeat:

\`\`\`
$ airc msg --heartbeat --internal ""
ERROR: Usage: airc send <message>  or  airc send @peer <message>
\`\`\`

This unit tests didn't catch because they're **structural** (grep for the flag's existence) not **behavioural** (actually invoke the send). The reminder-loop's subshell suppressed stdout+stderr so the failure was invisible from logs too.

## Caught Live

Joel: *"have to see if it works."* I did the actual user-surface test:

1. \`airc update --channel canary\` → pulled new code
2. \`airc teardown && airc join\` → restarted with new code
3. Waited 75s (cadence + buffer)
4. \`grep -c '"kind":"heartbeat"' messages.jsonl\` → **0**

The failure was found by running the substrate the way a user would, not by trusting tests.

## Fix

The empty-body check now exempts heartbeats. The signal in a heartbeat IS its envelope metadata (\`kind\` / \`ts\` / \`from\`); body MUST be empty. Other empty-body sends still die loudly per the prior contract.

\`\`\`bash
local first="${1:-}"
if [ -z "$first" ] && [ "$heartbeat" != "1" ]; then
  die "Usage: airc send <message>  or  airc send @peer <message>"
fi
\`\`\`

## Validation

\`bash -n lib/airc_bash/cmd_send.sh\` → ok

After this lands + airc update + restart, the live test should produce:

\`\`\`
$ grep -c '"kind":"heartbeat"' .airc/messages.jsonl
1+   # one per ~60s of process uptime
\`\`\`

## Title Prefix

\`fix:\` per conventional-commits; targets \`canary\` per the merge-to-canary-in-active-loop rule. Closes the regression introduced by #647 in the same active-loop iteration.

## Followup

PR-2's tests should grow a behavioural check that actually invokes \`cmd_send --heartbeat --internal ""\` in a temp-scope and asserts a heartbeat lands in messages.jsonl. Filing as a TODO; the priority right now is fixing the live emission.