### PR TITLE
docs(architecture): airc-rust substrate design — generic messaging/event/network layer (DRAFT)

### DIFF
--- a/docs/architecture/AIRC-RUST-SUBSTRATE.md
+++ b/docs/architecture/AIRC-RUST-SUBSTRATE.md
@@ -225,7 +225,12 @@ remain valid; scrollback queries that hit pre-drain ranges
 transparently consult the archive partition. Active DB stays
 bounded → constant query performance.
 
-## Transport resolver
+## Transport resolver (adapter pattern, replaceable mid-life)
+
+Same adapter discipline used everywhere else in our stack — inference
+providers in continuum, model registry candidates in Lane A, storage
+adapters in zsm-server, FFI surfaces in vHSM. airc-transport is
+another instance of the same craft.
 
 `airc-transport::Resolver` picks a transport per recipient by
 capability + reachability:
@@ -239,11 +244,71 @@ capability + reachability:
 
 Same-host peers **never round-trip through gh**. Today's "gh-only
 post-Phase-3c" decision is reverted with a proper bearer registry.
-gh-gist stays as a legacy bridge for cross-network peers who haven't
-paired via Tailscale yet, but it's not the only transport.
+gh-gist stays as a legacy bearer for cross-network peers who haven't
+paired via Tailscale yet, but it's not the only one.
 
-Each transport is a `Transport` trait impl exposing `send(envelope)`
-and `receive() -> Stream<Envelope>`. The resolver multiplexes.
+### Trait shape
+
+```rust
+pub trait Transport: Send + Sync {
+    fn id(&self) -> TransportId;
+    fn capabilities(&self) -> TransportCapabilities;
+    async fn send(&self, env: Envelope) -> Result<()>;
+    fn receive(&self) -> BoxStream<'static, Envelope>;
+    async fn health(&self) -> TransportHealth;
+}
+
+pub trait Bearer: Transport {
+    // Bearer-specific: durable cross-network store-and-forward.
+    // gh-gist is a Bearer; lan-tcp is a Transport but not a Bearer.
+    async fn fetch_since(&self, channel: ChannelId, cursor: Cursor)
+        -> Result<Vec<Envelope>>;
+    async fn ack(&self, sig: Signature) -> Result<()>;
+}
+```
+
+Transports register at runtime via a registry. The resolver multiplexes;
+each peer pair holds a list of viable transports sorted by preference.
+
+### Resilient to bearer changes
+
+The point: when gh-gist stops being viable (rate limits get worse,
+GitHub deprecates gists, our trust assumptions shift, whatever) —
+we **don't get stuck**. Adapter design means:
+
+- Roll a new bearer (custom HTTP relay, NATS, MQTT broker, IPFS pubsub,
+  our own continuum-hosted store-and-forward) — implement the `Bearer`
+  trait, register it. Existing peer pairings auto-discover the new
+  bearer via the registry handshake.
+- Offer multiple bearers simultaneously — peers pick by health +
+  policy. Bearer-A goes down, traffic shifts to Bearer-B without
+  consumer involvement.
+- Deprecate a bearer gradually — mark it `deprecated_after_ts`; new
+  pairings prefer alternatives; existing pairings get a structured
+  "your transport is sunsetting" event so consumers can re-pair.
+- Hot-swap mid-life — the resolver re-evaluates on every send; a
+  bearer added at runtime is usable immediately, no restart.
+
+Same pride as the rest of the stack. No transport is a hard
+dependency. Whatever ships first is replaceable later.
+
+### Planned bearers / transports
+
+In the doc as anchors; not all in the v1 ship:
+
+- `local-fs` — same-host, same-scope. Ship v1.
+- `lan-tcp` — same-LAN direct. Ship v1.
+- `tailscale` — cross-network mesh. Ship v1.
+- `gh-gist` — legacy bridge. Ship v1 (for migration); deprecate
+  when we have a non-gh cross-network bearer.
+- `airc-relay` — own-hosted cross-network store-and-forward. Future
+  ship; the gh-gist replacement.
+- `reticulum` — Mark Qvist's mesh networking stack. Future plugin.
+  Useful for unreliable / radio / off-grid mesh.
+- `nats` or `mqtt` — for ops integration where consumers already run
+  a broker. Future plugin.
+- `webrtc-data-channel` — direct browser ↔ desktop without TURN.
+  Future plugin.
 
 ## Names + identity (no env-var hacks)
 
@@ -301,34 +366,163 @@ Consumers define their own payload schemas (commands, recipes,
 typed events, replay records, telemetry, whatever) inside the body.
 airc has no opinion.
 
-## WebRTC efficiency (airc as network-substrate)
+## Fast UDP (airc as network-substrate, not just chat)
 
-WebRTC needs efficient UDP across the same boundary airc already owns
-(peer addressing, NAT traversal, encryption keys). Punting that to
-consumers means every consumer that wants real-time A/V re-implements
-ICE candidate gathering, TURN fallback, STUN reachability. That's
-substrate-level work; airc handles it.
+A generic fast-UDP path is substrate-level work. WebRTC needs it
+(real-time A/V across NATs), game servers need it (Call-of-Duty-style
+match-state sync at 60 Hz), multiplayer simulations need it (player
+position, projectile state), some IoT meshes need it. Every one of
+those consumers re-implementing ICE candidate gathering, NAT traversal,
+TURN fallback, STUN reachability, and UDP multiplexing is the wrong
+factoring. airc owns the network primitive once; consumers ride it.
 
-`airc-rtc` crate ships:
-- ICE candidate gathering reusing airc's transport reachability data
-  (we already know which peers are LAN-direct vs Tailscale vs
-  gh-bridge; ICE candidates derive from the same probe)
-- UDP socket multiplexing alongside airc control traffic
-- STUN/TURN integration (consumer can provide their own TURN server
-  or use a default airc-supplied one for the mesh)
-- webrtc-rs as the underlying media-engine integration
-- Per-stream key derivation from the airc identity ratchet (same
-  forward-secrecy properties as airc messages)
+`airc-rtc` crate (rename pending — the WebRTC-flavored name oversells
+it) ships:
+- **UDP socket multiplexing** alongside airc control traffic on the
+  same bound port. Connectionless. Low latency.
+- **ICE candidate gathering** reusing airc's transport reachability
+  data (we already know which peers are LAN-direct vs Tailscale vs
+  gh-bridge; the candidate list derives from the same probe).
+- **STUN/TURN integration** for cross-NAT reachability. Consumer can
+  provide its own TURN server or use a default airc-supplied one for
+  the mesh.
+- **NAT traversal + hole-punching** as a peer pair handshake. Same
+  primitive whether the packets are WebRTC SRTP, Call-of-Duty match
+  state, or anything else.
+- **Per-stream key derivation** from the airc identity ratchet (same
+  forward-secrecy properties as airc messages — and consistent
+  across all fast-UDP consumers).
+- **webrtc-rs** as one integration option for consumers that want
+  the full WebRTC stack. Game servers wanting raw UDP-with-sequence
+  use the lower-level API directly.
 
-Consumers hand `airc-rtc` media tracks (audio/video frames or pre-
-encoded media); it handles peer-direct UDP where possible, falls back
-to TURN-relay when NATs require it. The signaling (SDP/ICE) flows as
-airc events alongside; airc-rtc and the consumer's signaling handler
-share the same envelope substrate.
+Consumers hand `airc-rtc` either media tracks (audio/video frames)
+or raw UDP messages (game-state diffs, multiplayer events). It
+handles peer-direct UDP where possible, falls back to TURN-relay
+when NATs require it. The signaling (SDP/ICE for WebRTC; lobby/match
+state for games) flows as airc events alongside on the regular
+TCP/gh/local channels.
 
-This is what "network related and fine" means for WebRTC: the
-substrate owns the network primitive even though the application
-owns what the media bytes represent.
+This is what "network related and fine" means: the substrate owns
+the network primitive even though the application owns what the
+bytes represent.
+
+## Reliability + connection health
+
+The substrate is operational infrastructure. It must keep connections
+alive, detect failures fast, reestablish without manual intervention.
+
+Built-in primitives:
+
+- **Keep-alive heartbeats** at the transport layer, separate from
+  application heartbeats. Configurable cadence per transport (more
+  frequent for UDP/RTC paths, slower for gh-gist).
+- **Dead-host detection**: if N consecutive heartbeats fail, the
+  peer is marked degraded; if N+M, marked dead. Subscribers get an
+  event; consumer can decide whether to fail-over to backup peers.
+- **Auto-reconnect with backoff**: when a transport reports failure,
+  airc-transport retries with exponential backoff. State (cursors,
+  subscriptions, pending sends) survives the reconnect.
+- **Self-healing host migration**: when the channel host evicts
+  (today's `[HOST EVICTED]` flow), airc-rust formalizes the
+  re-host election. Cursors and pending sends migrate to the new
+  host transparently; consumers see a structured event, not a
+  protocol fault.
+- **Message durability across reconnect**: pending sends queue in
+  `airc-store`; the daemon retries on reconnect. Loss is loud (event
+  + audit-log entry) not silent.
+- **Health probes**: `airc doctor --health` returns structured
+  status: per-transport state, last-recv timestamps, peer
+  reachability matrix, queue depths. The same data is queryable
+  programmatically by consumers.
+
+**Reticulum alignment**: Mark Qvist's [Reticulum Network Stack](https://reticulum.network)
+solves a similar shape — distributed network substrate, identity-
+addressable, transport-agnostic, designed for unreliable links.
+airc-rust's transport layer is structured to allow `airc-transport-
+reticulum` as a future plugin. When it lands, the airc-substrate API
+doesn't change — Reticulum just becomes another transport the
+resolver can pick, with its own reachability properties (e.g.
+"reticulum: works over LoRa / amateur radio when other transports
+have no path").
+
+## Security
+
+Beyond per-message encryption (handled by the double-ratchet section
+above), the substrate enforces operational safety:
+
+- **Identity attestation**: pairing produces a signed envelope
+  binding pubkey → nick → role → first-seen ts → paired-with-pubkey.
+  Re-pair under the same pubkey is a non-event; re-pair under a
+  DIFFERENT pubkey for the same nick surfaces an "identity changed"
+  warning event so consumers can re-verify.
+- **Allowlist / blocklist** on the peer registry. Untrusted peers
+  get sandboxed: their messages land in a quarantine channel
+  consumers explicitly opt into.
+- **Rate limiting** per peer per channel. Misbehaving peers (flood,
+  burst, malformed envelopes) get throttled by the receiving daemon;
+  events fan out so subscribers can decide policy.
+- **Untrusted-payload handling**: airc never executes a payload.
+  Body interpretation is consumer-level. The substrate guarantees
+  delivery integrity (signature verified, AEAD intact, hop authentic)
+  but makes no claim about payload safety. Consumers that process
+  untrusted payloads (RPC handlers, code execution, etc.) own
+  sandboxing.
+- **No-PII guarantee**: airc-store doesn't index on body content.
+  Consumers can opt into a per-message PII flag that triggers
+  shorter retention + audit-trail-only access. Default storage is
+  "structured envelope metadata + opaque body" — no body scanning,
+  no body indexing, no body-derived analytics.
+- **Hardware-backed identity** where available: macOS Secure Enclave
+  (Touch ID-protected signing), Windows TPM, Linux TPM2 / fTPM. Key
+  material never leaves the secure element. Pairing flow attests
+  hardware-rooted vs software-only.
+- **Audit log**: every key rotation, pairing, host migration,
+  rate-limit trip, and redaction event lands in an append-only audit
+  table separate from message storage. Operators can query the audit
+  log without touching message content.
+
+The threat model airc-rust defends against:
+- Network attacker (passive or active) reading or tampering with
+  on-wire traffic → defeated by AEAD + ratchet
+- Compromised peer impersonating another peer → defeated by
+  identity attestation; old keys can't replay as new identity
+- Forward-secrecy compromise (long-term key theft) → defeated by
+  double-ratchet per-message keys
+- Malicious peer flooding a channel → mitigated by rate limiting
+- Lost / stolen device → SQLCipher at-rest + Secure-Enclave-bound
+  keys mean local DB + identity remain protected without the
+  device unlocked
+- Malicious payload from an authorized peer → NOT defended at
+  substrate level; consumer responsibility
+
+## Beyond chat: airc-rust as a generic substrate
+
+The protocol primitives (peers, rooms, messages, events, signaling,
+file transfer, fast UDP) are not chat-specific. Consumer patterns
+beyond chat:
+
+- **Game lobby + match coordination**: rooms = lobbies, peers =
+  players, fast-UDP = match state, events = "player joined" / "match
+  starting" / "kill confirmed" / etc. Call-of-Duty-shaped servers
+  fit the same substrate that runs an IRC bot.
+- **Distributed scientific compute**: rooms = experiment cohorts,
+  events = task dispatched / result ready / worker failed, file
+  transfer = result-dataset shipment.
+- **IoT mesh**: rooms = device groups, events = sensor reading
+  bursts, fast-UDP = real-time telemetry, Reticulum transport when
+  links are unreliable.
+- **Multiplayer simulations / virtual worlds**: rooms = world
+  partitions, fast-UDP = entity state sync, events = world events,
+  file transfer = world-asset distribution.
+- **Persona / agent ecosystems**: rooms = team rooms, peers =
+  agents/personas/humans, events = "is thinking" indicators,
+  commands = JSON RPC inside messages.
+
+The chat-shaped consumer (IRC client, automation bot, persona) is
+the simplest case. Game/sim/IoT cases use more of the fast-UDP path
+and less of the durable-scrollback path; both share the same
+substrate primitives.
 
 ## Migration phases
 

--- a/docs/architecture/AIRC-RUST-SUBSTRATE.md
+++ b/docs/architecture/AIRC-RUST-SUBSTRATE.md
@@ -1,0 +1,446 @@
+# airc-rust — Generic Messaging Substrate
+
+**Status**: Draft. Outline + key decisions. Sections marked _stub_
+get fleshed out as peers + Joel iterate.
+
+**Authored by**: claude (vHSM-tab, architecture role)
+**Date**: 2026-05-18
+**Supersedes**: today's Python+bash airc.
+
+## What airc-rust is
+
+airc-rust is a **network substrate that doubles as a messaging layer and
+an event bus**. The elevator-pitch analogy: it's to its consumers what
+Signal Protocol is to its apps — a generic encrypted-messaging primitive
+that applications layer their semantics on top of. Signal facilitates;
+the apps decide what they're saying.
+
+Think IRC for the high-level shape: peers, rooms, messages, events,
+signaling, identity, durable scrollback. Same primitives, modern
+transport, structured storage, no language lock-in to Python or shell.
+
+It is **not** a continuum-specific layer, a coding-agent-specific layer,
+or any one consumer's protocol. Continuum, OpenClaw users, Hermes users,
+IRC-style human chat clients, future AI personas, CLI tools, grid
+routing layers — all join the same rooms as peer types of one primitive.
+None of them is mentioned by name in the core protocol.
+
+The three roles airc-rust plays for consumers:
+- **Network substrate** — the connection layer the multi-machine grid
+  rides on. Peer discovery, addressing, encryption, reachability
+  resolution. (Grid orchestration / routing decisions stay at the
+  consumer level; airc carries the connections those decisions land on.)
+- **Messaging layer** — durable chat-shaped store + scrollback + cursors.
+  The kind of substrate `irssi` would expect.
+- **Event bus** — interrupt-driven fan-out for things consumers need to
+  wake on, not poll for.
+
+## What airc-rust is not
+
+- Not an opinion about what consumers say to each other. Payloads are
+  opaque — JSON, binary, whatever the consumer signs on the body field.
+- Not a media streaming layer. It carries signaling envelopes; actual
+  A/V streams go through webrtc-rs / LiveKit / whatever the consumer
+  picks. The signaling SDP/ICE is just opaque payload to airc.
+- Not a command bus with a fixed opcode catalog. A "command" is an
+  application-level JSON convention consumers register their own
+  handlers for; airc doesn't route by opcode and doesn't validate
+  command shapes.
+
+## Goals
+
+1. **Replace** today's Python+bash airc. Zero Python in the runtime.
+   Shell limited to bootstrap (`install.sh`).
+2. **Stay generic** — IRC-like substrate, not a Continuum extension.
+3. **Embed** as a Rust library (`airc-lib`) any consumer (Continuum,
+   OpenClaw, Hermes, your terminal client, future ones) can link
+   directly. No shell-out from runtime code.
+4. **Persist** durably with proper cursors, archive drain, and SQLite/
+   Postgres backends via SeaORM.
+5. **Multi-transport** — same-host, same-LAN, Tailscale, gh-gist
+   (legacy bridge). Pluggable, capability-resolved.
+6. **Be more secure** than today's airc: per-message forward secrecy,
+   hardware-backed identity keys, at-rest encryption.
+7. **No multimedia in the body** — protocol enforces media-ref
+   pointers; blobs live in companion content-addressed storage.
+
+## The protocol
+
+airc-rust has three primitive kinds of wire frame:
+
+### 1. Messages (encapsulated payload, pull-driven)
+
+The bulk of airc traffic. An envelope wraps an opaque payload. The
+envelope is what airc routes/stores/signs; the payload is what the
+consumer reads.
+
+```rust
+pub struct Message {
+    pub id: Uuid,
+    pub from: PeerId,
+    pub to: Recipient,             // single peer or "all" within channel
+    pub channel: ChannelId,
+    pub ts: Timestamp,
+    pub body: Body,                // opaque to airc
+    pub media_refs: Vec<MediaRef>, // pointers, not bytes
+    pub signature: Signature,      // sender's signature over envelope+body
+}
+
+pub enum Body {
+    Json(serde_json::Value),       // most consumers
+    Binary(Bytes),                 // when JSON overhead is wasted
+}
+```
+
+Storage stores these. Subscribers can request them on a pull (`fetch
+since cursor` / `fetch by channel + range`). They are not pushed
+unless the consumer also wraps them as an event (next kind).
+
+### 2. Events (interrupt-driven push)
+
+When a sender wants subscribers to **wake immediately** instead of
+poll, the envelope carries the `event` flag (or a distinct frame kind
+— TBD). Same shape as Message; difference is delivery semantics. The
+transport fans out to subscribers that registered interest.
+
+Canonical events:
+- "joel is typing" / "claude is thinking" — typing-indicator-shaped
+  ephemeral state that recipients want to render NOW, not on next
+  poll. Body carries the actor + intent ("typing" / "thinking" /
+  "uploading"). May not even persist past TTL.
+- "peer joined room" / "peer dropped" — presence transitions.
+- WebRTC signaling (SDP, ICE) — the receiving peer must wake to
+  answer the offer before timeout.
+- Sentinel-style alerts, kanban-card-state-changed, file-transfer-
+  progress — anything a watcher wants pushed.
+
+```rust
+pub struct Subscription {
+    pub channel: Option<ChannelId>,   // None = any
+    pub from_peer: Option<PeerId>,    // None = any
+    pub body_hint: Option<String>,    // optional payload-kind tag for filtering
+}
+```
+
+Monitor processes (like Claude Code's airc Monitor) subscribe to
+events. Sentinels subscribe to events. WebRTC signaling lands as
+events so the receiving consumer wakes immediately on SDP/ICE.
+
+The `body_hint` is a peer convention (consumers agree on the string,
+e.g. "signaling.webrtc.sdp" or "kanban.card.claimed") — airc doesn't
+interpret it, just lets subscribers filter on it.
+
+Events are still persisted (in the same `messages` table) — replay-
+ability matters. The interrupt-drivenness is purely about wake
+semantics.
+
+### 3. Control frames
+
+Protocol-level plumbing, not application payload:
+
+- `JOIN <channel>` — peer joins a channel
+- `PART <channel>` — peer leaves
+- `IDENTIFY <pubkey> <attestation>` — bind nick to pubkey
+- `NICK <new>` — rename
+- `HEARTBEAT` — keep-alive (filtered from display)
+- `WHO <channel>` — list current peers
+
+These ARE structured at the protocol level because airc has to
+process them. The application body of an application Message can
+embed JSON that looks command-shaped, but that's not the same as a
+Control frame.
+
+## Crate layout
+
+```
+airc-rust/
+├── crates/
+│   ├── airc-core/        # envelope, identity, double-ratchet crypto
+│   ├── airc-protocol/    # frame types, Body, MediaRef, serde
+│   ├── airc-store/       # SeaORM models, migrations, archive drain
+│   ├── airc-transport/
+│   │   ├── local-fs/     # same-host peers via shared FS
+│   │   ├── lan-tcp/      # same-LAN direct peer connection
+│   │   ├── tailscale/    # cross-network via Tailscale
+│   │   └── gh-gist/      # legacy bridge (deprecated)
+│   ├── airc-blobs/       # content-addressed media storage
+│   ├── airc-daemon/      # long-running: workers, drain, fan-out
+│   ├── airc-lib/         # high-level Rust API — consumers depend on this
+│   ├── airc-cli/         # the `airc` binary
+│   ├── airc-claude-hook/ # Claude Code installer hook
+│   └── airc-codex-hook/  # Codex installer hook
+├── migrations/           # sea-orm-cli managed schema
+├── docs/
+└── install.sh            # one-time bootstrap; the only shell that ships
+```
+
+## Storage shape (SeaORM)
+
+Generic. No consumer-specific tables.
+
+| Table | Columns | Purpose |
+|---|---|---|
+| `messages` | id, channel_id, ts, from_pubkey, to (string), body_kind (json/binary), body_blob, body_hint, is_event (bool), signature | The wire log |
+| `media_refs` | message_id, sha256, mime, size, blob_path | Pointers; blobs live in `airc-blobs` |
+| `channels` | id, name, host_pubkey, created_at, archive_partition_id | Rooms |
+| `peers` | pubkey, nick, role_hint, last_seen_at, attest_sig | Identity |
+| `cursors` | peer_pubkey, channel_id, last_read_sig, last_read_ts | Per-peer read state |
+| `subscriptions` | peer_pubkey, channel_id_or_null, from_peer_or_null, body_hint_or_null | Event fan-out registry |
+| `archive_partitions` | id, drained_at, range_start_ts, range_end_ts | Bounded active DB; older messages moved to archive DB |
+| `key_attestations` | pubkey, paired_at, attest_sig, paired_with_pubkey | Identity audit trail |
+
+`messages.body_blob` is opaque to airc. Consumers serialize/deserialize
+their own payload shapes into/out of it. The optional `body_hint` is a
+string convention for routing/filtering — airc never validates it.
+
+**File transfer + media is first-class airc work, not punted to
+consumers.**
+
+`airc-blobs` is a built-in crate, not optional. Native API:
+
+```rust
+let media_ref = airc.send_file("./screenshot.png").await?;
+// or:
+airc.send(channel, body, attachments=vec![path_a, path_b]).await?;
+```
+
+What airc-blobs handles natively (consumers do not):
+- Content-addressing (sha256 → blob path)
+- Encryption-at-rest (same per-peer or per-room key as messages)
+- Chunked transfer for large files over slow transports
+- Integrity verification on download
+- GC after retention window (or pin to keep)
+- Resume-on-reconnect for interrupted transfers
+
+**Hard rule**: a consumer trying to put a blob > N bytes (configurable,
+default 64KB) into `body_blob` gets an error. The blob goes via
+`airc-blobs` instead, and the message carries a `MediaRef` pointing
+to it. airc-store enforces this so consumers can't lazy themselves
+into a bloated DB.
+
+**Archive drain:**
+Background task in `airc-daemon`. Messages older than retention
+window (default 30 days) get moved to a sibling archive DB. Cursors
+remain valid; scrollback queries that hit pre-drain ranges
+transparently consult the archive partition. Active DB stays
+bounded → constant query performance.
+
+## Transport resolver
+
+`airc-transport::Resolver` picks a transport per recipient by
+capability + reachability:
+
+| Recipient location | Preferred transport |
+|---|---|
+| Same host, same scope | `local-fs` (shared `.airc/` dir, file-tail) |
+| Same LAN (mDNS / link-local) | `lan-tcp` (direct connection) |
+| Cross-network via Tailscale tailnet | `tailscale` |
+| Cross-network, no Tailscale | `gh-gist` (legacy bridge — slow, rate-limited) |
+
+Same-host peers **never round-trip through gh**. Today's "gh-only
+post-Phase-3c" decision is reverted with a proper bearer registry.
+gh-gist stays as a legacy bridge for cross-network peers who haven't
+paired via Tailscale yet, but it's not the only transport.
+
+Each transport is a `Transport` trait impl exposing `send(envelope)`
+and `receive() -> Stream<Envelope>`. The resolver multiplexes.
+
+## Names + identity (no env-var hacks)
+
+`get_nick` (Rust port of today's `get_name`) auto-derives based on
+parent-process detection:
+
+- Parent is `claude` → default nick `claude`
+- Parent is `codex` → default nick `codex`
+- Parent is something else → scope-derived nick (today's behavior)
+- Collision detected in scope → auto-suffix (`claude`, `claude-2`,
+  `claude-arch` if role inferable)
+- `airc identity set <name>` overrides explicitly (proper CLI, not
+  env vars). `AIRC_AGENT_NAME` stays as a test-only escape hatch.
+
+Identity material:
+- ed25519 signing keypair
+- X25519 keypair for ECDH ratchet bootstrap
+- Hardware-backed where available: macOS Secure Enclave (Touch ID
+  protected), Windows TPM, Linux TPM2 / fTPM
+- Identity attestation: pairing produces a signed envelope binding
+  pubkey → nick → role → first-seen ts. Re-pair under same pubkey
+  is a non-event; re-pair under DIFFERENT pubkey for the same nick
+  surfaces a warning ("identity changed").
+
+## Security upgrades
+
+- **Double-ratchet** (Signal-protocol-style): per-message forward
+  secrecy on DMs and small-group rooms. Replaces today's per-session
+  ephemeral X25519.
+- **Sender keys** for large rooms (> 8 peers) where pure ratchet
+  gets expensive — same Signal-group-protocol shape.
+- **At-rest encryption**: SQLCipher on the SeaORM SQLite. Postgres
+  backend uses pgcrypto if enabled.
+- **Crypto primitives**: `ring` for X25519/Ed25519/ChaCha20-Poly1305;
+  `signal-protocol` crate (or equivalent) for ratchet state.
+- **No PII assumption in storage**: consumers can tag a body with
+  `pii=true` (via the `body_hint`) which triggers extra retention/
+  redaction policy. Audit log marks redaction events.
+
+## How consumers plug in
+
+Any consumer — Continuum, OpenClaw, Hermes, a CLI client, a CI bot,
+a future persona engine — links `airc-lib` and:
+
+1. Registers identity (creates pubkey, picks initial nick).
+2. Joins channels (`JOIN` control frame).
+3. Sends messages: `airc.send(channel, body, ?to)` — body is whatever
+   JSON/binary the consumer chooses.
+4. Sends events: `airc.send_event(channel, body, ?body_hint, ?to)`.
+5. Subscribes to events: `airc.subscribe(filter, handler)`.
+6. Reads scrollback: `airc.fetch(channel, since)`.
+7. Uploads blobs: `airc.blobs.put(bytes) -> MediaRef`.
+
+Consumers define their own payload schemas (commands, recipes,
+typed events, replay records, telemetry, whatever) inside the body.
+airc has no opinion.
+
+## WebRTC efficiency (airc as network-substrate)
+
+WebRTC needs efficient UDP across the same boundary airc already owns
+(peer addressing, NAT traversal, encryption keys). Punting that to
+consumers means every consumer that wants real-time A/V re-implements
+ICE candidate gathering, TURN fallback, STUN reachability. That's
+substrate-level work; airc handles it.
+
+`airc-rtc` crate ships:
+- ICE candidate gathering reusing airc's transport reachability data
+  (we already know which peers are LAN-direct vs Tailscale vs
+  gh-bridge; ICE candidates derive from the same probe)
+- UDP socket multiplexing alongside airc control traffic
+- STUN/TURN integration (consumer can provide their own TURN server
+  or use a default airc-supplied one for the mesh)
+- webrtc-rs as the underlying media-engine integration
+- Per-stream key derivation from the airc identity ratchet (same
+  forward-secrecy properties as airc messages)
+
+Consumers hand `airc-rtc` media tracks (audio/video frames or pre-
+encoded media); it handles peer-direct UDP where possible, falls back
+to TURN-relay when NATs require it. The signaling (SDP/ICE) flows as
+airc events alongside; airc-rtc and the consumer's signaling handler
+share the same envelope substrate.
+
+This is what "network related and fine" means for WebRTC: the
+substrate owns the network primitive even though the application
+owns what the media bytes represent.
+
+## Migration phases
+
+1. **Phase 1 — Parallel.** Build the airc-rust crates. Today's
+   Python+bash airc continues to run. Rust binary co-exists.
+2. **Phase 2 — Bridge.** A bridge reads from Python-airc and mirrors
+   into airc-store. Existing rooms keep working.
+3. **Phase 3 — Library cutover.** Major consumers move from
+   shell-out / IPC to `airc-lib`. The slow chat paths inside those
+   consumers go away.
+4. **Phase 4 — CLI parity.** The Rust `airc` binary replaces the
+   bash `airc` script. Subcommands behavior-identical at launch.
+5. **Phase 5 — Python/shell deletion.** All `airc_core/*.py` and
+   `cmd_*.sh` deleted. Only `install.sh` remains in shell.
+6. **Phase 6 — Security upgrade.** Double-ratchet + SQLCipher
+   landed once stable. Pairing flows updated to produce attestation.
+
+Each phase reversible until phase 5.
+
+## Open questions
+
+- Vector storage for consumer-side embedding indexes: sqlite-vss
+  (single-binary story) vs. pgvector (Postgres backend only). Both
+  belong in the consumer, not in airc-core, but airc-store could
+  expose an optional capability flag.
+- WebRTC: signaling shape (SDP/ICE JSON content) stays application-
+  level — consumers wrap it in event bodies with `body_hint="rtc.sdp"`
+  or similar. BUT the NETWORK side (UDP, ICE candidate gathering,
+  NAT traversal, the actual efficient media path) IS airc-rust's
+  job because it's network-substrate work. `airc-rtc` crate ships
+  the UDP/ICE machinery via webrtc-rs; consumers hand it media
+  streams and it handles peer-direct UDP-or-TURN-relay efficiently
+  across the same boundary the rest of airc owns. See "WebRTC
+  efficiency" section below.
+- Backward-compat for existing peer pairings established under
+  today's airc identity model: bridge during phase 2, retire at
+  phase 5.
+- Cursor model for archived ranges: do we expose archive query as
+  a different API or just transparent-passthrough on `fetch`?
+
+## Appendix A — Example consumer: a chat client
+
+A bare CLI chat client (think `irssi`) just uses messages:
+
+```rust
+let airc = AircClient::open()?;
+airc.join("#general")?;
+loop {
+    select! {
+        Some(msg) = airc.next_message() => {
+            println!("[{}] <{}> {}", msg.channel, msg.from, msg.body.as_text());
+        }
+        Some(input) = stdin.next_line() => {
+            airc.send("#general", Body::Json(json!({"text": input})), None)?;
+        }
+    }
+}
+```
+
+It doesn't subscribe to events because it doesn't need push wake-up —
+the message loop is already blocking on next-frame.
+
+## Appendix B — Example consumer: a Monitor (sentinel-shaped)
+
+A Monitor process that wakes on every event in a channel:
+
+```rust
+let airc = AircClient::open()?;
+airc.subscribe(Subscription {
+    channel: Some(ch),
+    body_hint: None,
+    from_peer: None,
+}, |envelope| {
+    // wake immediately when an event arrives
+    handle(envelope);
+})?;
+airc.run();  // pumps the transport
+```
+
+This is the shape Claude Code's Monitor uses today. It's interrupt-
+driven by construction.
+
+## Appendix C — Example consumer: an automation engine
+
+An engine that issues RPC-style commands to peers, encoded as JSON
+in the body, with a correlation_id convention:
+
+```rust
+let envelope = airc.send_event(
+    "#cambriantech",
+    Body::Json(json!({
+        "op": "git/pr-create",
+        "args": { "branch": "feat/foo", "title": "..." },
+        "correlation_id": uuid::Uuid::new_v4(),
+    })),
+    Some("rpc.command"),       // body_hint for filtering
+    Some(target_peer),         // direct, not broadcast
+)?;
+// wait for a response event with matching correlation_id
+let resp = airc.await_event_matching(|m|
+    m.body.json_field("correlation_id") == correlation_id
+).await?;
+```
+
+airc doesn't know what `git/pr-create` means. The consumer that
+receives the event recognizes the op string and handles it. Another
+consumer that doesn't recognize it ignores it.
+
+That's it — commands are just JSON payloads with a convention. The
+"command bus" is application-level, not protocol-level.
+
+---
+
+_Draft. Reply with corrections, omissions, or "yes ship it" on the
+PR thread._

--- a/docs/architecture/AIRC-RUST-SUBSTRATE.md
+++ b/docs/architecture/AIRC-RUST-SUBSTRATE.md
@@ -407,6 +407,56 @@ This is what "network related and fine" means: the substrate owns
 the network primitive even though the application owns what the
 bytes represent.
 
+## Roster semantics — three orthogonal peer sets per room
+
+Surfaced as a real design gap by Codex on 2026-05-18: continuum's chat
+header was rendering persistent `room.members` / seeded-capable users
+as if they're active participants. That's misleading and it's a
+substrate-level fix, not a UI fix.
+
+The substrate exposes **three orthogonal peer sets** per room. They are
+distinct API surfaces; consumers compose them as their use case
+requires.
+
+| Set | What it represents | Durability |
+|---|---|---|
+| `membership` | Subscription / capability — peers who CAN be in the room (seeded, invited, allowlisted) | Durable, persisted in `peers` × `channels` join table |
+| `live_presence` | Peers who ARE in the room RIGHT NOW (connected transport, recent activity) | Transient, derived from `last_seen_at` + transport state |
+| `responder_ready` | Peers who are primed to act — model admitted, inbox ready, agent online | Transient + capability-aware; updated by consumer signals |
+
+```rust
+impl Room {
+    pub fn membership(&self) -> &MembershipSet;
+    pub fn live_presence(&self) -> &PresenceSet;
+    pub fn responder_ready(&self) -> &ResponderSet;
+}
+```
+
+The three sets are computed from different sources:
+- `membership` reads from `peers` + `channels` join in airc-store.
+- `live_presence` derives from per-transport keep-alive state + the
+  presence-event stream. A peer that hasn't sent a heartbeat in N
+  seconds drops out of live_presence even if they remain in
+  membership.
+- `responder_ready` is composed: a peer announces readiness via an
+  application-level event (consumer convention, e.g.
+  `body_hint="presence.responder_ready"`). The substrate tracks
+  which peers have most-recently announced ready vs busy/offline.
+
+UI defaults (consumer choice, but the substrate makes the data easy):
+
+| Use case | Default rendering |
+|---|---|
+| Live chat header ("who's here") | `live_presence ∩ responder_ready` |
+| Room admin / capability view | `membership` |
+| Inference dispatch ("who can respond") | `responder_ready` |
+| Quorum / mention resolution | `live_presence` |
+
+The substrate API exposes all three; consumers pick. **The substrate
+never collapses them into a single "users" list** — that collapse is
+exactly the bug Codex caught in continuum today, and it would re-emerge
+in any consumer if the substrate didn't keep them distinct.
+
 ## Reliability + connection health
 
 The substrate is operational infrastructure. It must keep connections


### PR DESCRIPTION
## Draft — design doc for airc Rust rewrite

Authored after a real-time conversation in #cambriantech where Joel + peers landed the requirements. Pushing as a draft so corrections can happen in the PR thread instead of buried in airc scrollback. Still iterating; multiple sections marked _stub_ for next pass; reliability/Reticulum/safety getting folded in follow-up commits to this same branch.

## What this design says

- airc-rust is a **generic messaging/event/network substrate**, IRC-shaped. Not Continuum-specific. Like Signal Protocol is to its apps: a facilitator; consumers layer their semantics on top.
- **Three primitive frame kinds**: messages (encapsulated opaque payload, pull-driven), events (interrupt-driven push — typing indicators, "is thinking", SDP/ICE wake-up, sentinel alerts), control (JOIN/NICK/IDENTIFY/heartbeat).
- **Payload is opaque** to airc. Commands are application JSON conventions, not protocol primitives. Same for "events" semantically — airc only knows the delivery mode (push-fanout vs pull-store).
- **File transfer + media is first-class airc work**. `airc-blobs` crate handles content-addressing, encryption-at-rest, chunked transfer. Hard rule: blobs never in message body, only `MediaRef` pointers.
- **WebRTC**: signaling stays application JSON; UDP/ICE/NAT-traversal IS airc (substrate-level). `airc-rtc` crate wraps webrtc-rs and reuses airc transport reachability data.
- **Multi-transport** resolver: local-fs (same host), lan-tcp, Tailscale, gh-gist (legacy). Same-host peers never round-trip through gh.
- **Names**: parent-process detection auto-derives nicks (\`claude\`, \`codex\`). Auto-suffix on collision. No env-var ceremony for normal use.
- **Storage**: SeaORM. Generic tables — \`messages\` (opaque body + body_hint + is_event flag), \`media_refs\`, \`channels\`, \`peers\`, \`cursors\`, \`subscriptions\`, \`archive_partitions\`. Background drain bounds the active DB.
- **Security**: double-ratchet (Signal-protocol-style), sender-keys for large rooms, SQLCipher at-rest, hardware-backed identity keys, \`ring\` for primitives.
- **Zero Python** in the runtime. Shell limited to \`install.sh\`. All \`airc_core/*.py\` and \`cmd_*.sh\` deleted at migration phase 5.

Three appendices walk through example consumers: a CLI chat client, a Monitor-shaped sentinel, an automation engine doing RPC-style commands via JSON payload conventions. None require airc to know what they're doing.

## Reply on this thread with

- Corrections (where I overspecialized / underspecified)
- Omissions
- "ship it" or "rewrite section X" or specific section critiques

The doc is the contract. Once landed, airc-rust implementation can begin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)