### PR TITLE
feat(airc-core): Body enum (Json | Binary) — opaque payload primitive

### DIFF
--- a/crates/airc-core/src/body.rs
+++ b/crates/airc-core/src/body.rs
@@ -1,0 +1,147 @@
+//! Message body — the opaque payload airc carries on behalf of consumers.
+//!
+//! Per the airc-rust substrate design doc, a body is intentionally opaque
+//! to airc: consumers serialize their own structured payloads (chat text,
+//! command JSON, event JSON, signaling SDP, etc.) into either a JSON value
+//! or raw binary bytes, and airc routes/persists the result without
+//! interpretation.
+//!
+//! The previous shape (`body: Option<String>`) was text-only and forced
+//! consumers to base64-encode binary data inside a string. The `Body` enum
+//! enables first-class binary payloads for game-state diffs, WebRTC
+//! signaling, custom binary command formats, and any consumer that needs
+//! to avoid JSON overhead.
+//!
+//! Tagged enum (`{"kind": "json", "value": ...}` / `{"kind": "binary",
+//! "value": [...]}`) so both variants round-trip through any serde
+//! format. Zero airc-rust users means we don't need the legacy bare-
+//! string backward-compat; the Python+bash airc keeps its own shape
+//! until cutover, and airc-rust starts with the correct primitive.
+
+use serde::{Deserialize, Serialize};
+
+/// Opaque message body. Consumers pick the shape; airc routes/persists.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum Body {
+    /// Structured JSON payload — the common case (chat text wrapped in a
+    /// `{"text":"..."}` object, typed events, RPC commands with
+    /// correlation IDs, etc.).
+    Json(serde_json::Value),
+    /// Raw binary bytes — for consumers that need to avoid JSON overhead
+    /// (game-state diffs at high tick rate, pre-encoded media frames,
+    /// custom wire formats). Always distinguishable from Json on the
+    /// wire via the `"kind": "binary"` discriminator.
+    Binary(Vec<u8>),
+}
+
+impl Body {
+    /// Wrap a chat-style text string into a `Body::Json` with the
+    /// canonical `{"text": "..."}` shape consumers conventionally use
+    /// for plain chat.
+    pub fn text(s: impl Into<String>) -> Self {
+        Body::Json(serde_json::json!({ "text": s.into() }))
+    }
+
+    /// Extract chat-style text from a body, if the body is a JSON
+    /// object with a `text` field of string type. Returns `None` for
+    /// any other shape (binary, JSON without text field, etc.).
+    pub fn as_text(&self) -> Option<&str> {
+        match self {
+            Body::Json(serde_json::Value::Object(map)) => {
+                map.get("text").and_then(|v| v.as_str())
+            }
+            Body::Json(serde_json::Value::String(s)) => {
+                // Backward-compat: legacy bare-string payloads still
+                // surface as text.
+                Some(s.as_str())
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_body_roundtrips_through_serde() {
+        let body = Body::Json(serde_json::json!({
+            "text": "hello world",
+            "lang": "en"
+        }));
+        let encoded = serde_json::to_value(&body).unwrap();
+        let decoded: Body = serde_json::from_value(encoded.clone()).unwrap();
+        assert_eq!(decoded, body);
+        // Tagged: encoding carries the discriminator + content fields.
+        assert_eq!(encoded["kind"], "json");
+        assert_eq!(encoded["value"]["text"], "hello world");
+        assert_eq!(encoded["value"]["lang"], "en");
+    }
+
+    #[test]
+    fn binary_body_roundtrips_through_serde() {
+        let body = Body::Binary(vec![0x00, 0xff, 0xde, 0xad, 0xbe, 0xef]);
+        let encoded = serde_json::to_value(&body).unwrap();
+        let decoded: Body = serde_json::from_value(encoded.clone()).unwrap();
+        assert_eq!(decoded, body);
+        // Tagged form distinguishes Binary from a Json(Array) of the
+        // same numbers — no more "indistinguishable after roundtrip"
+        // edge case the untagged shape had.
+        assert_eq!(encoded["kind"], "binary");
+        assert!(encoded["value"].is_array());
+    }
+
+    #[test]
+    fn text_helper_constructs_canonical_chat_shape() {
+        let body = Body::text("hi");
+        match &body {
+            Body::Json(serde_json::Value::Object(m)) => {
+                assert_eq!(m["text"], "hi");
+                assert_eq!(m.len(), 1, "text helper produces exactly {{text: ...}}");
+            }
+            _ => panic!("text() should produce Body::Json with object shape"),
+        }
+        assert_eq!(body.as_text(), Some("hi"));
+    }
+
+    #[test]
+    fn as_text_returns_none_for_binary_body() {
+        let body = Body::Binary(vec![1, 2, 3]);
+        assert_eq!(body.as_text(), None);
+    }
+
+    #[test]
+    fn as_text_returns_none_for_json_without_text_field() {
+        let body = Body::Json(serde_json::json!({"op": "kanban/create", "args": []}));
+        assert_eq!(body.as_text(), None);
+    }
+
+    #[test]
+    fn json_array_of_ints_stays_json_not_binary() {
+        // Edge: a JSON array of small ints would have been confused with
+        // Binary under untagged serde. Tagged form makes the
+        // disambiguation explicit — without "kind": "binary", it's Json.
+        let body = Body::Json(serde_json::json!([1, 2, 3]));
+        let encoded = serde_json::to_value(&body).unwrap();
+        assert_eq!(encoded["kind"], "json");
+        let decoded: Body = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded, body);
+    }
+
+    #[test]
+    fn missing_kind_discriminator_is_a_parse_error() {
+        // A wire envelope that drops the `kind` discriminator (e.g. a
+        // bug in a non-Rust consumer that wrote a bare JSON value
+        // instead of a tagged Body) should fail loud at parse time,
+        // not silently default to Json. Tagged enums enforce this.
+        let bare = serde_json::json!({"text": "hi"});
+        let result: Result<Body, _> = serde_json::from_value(bare);
+        assert!(
+            result.is_err(),
+            "untagged body without 'kind' must fail parse, got: {:?}",
+            result
+        );
+    }
+}

--- a/crates/airc-core/src/cursor.rs
+++ b/crates/airc-core/src/cursor.rs
@@ -98,6 +98,7 @@ pub(crate) fn event_order(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::body::Body;
     use crate::filter::SelfFilter;
     use crate::ids::{ClientId, PeerId};
     use crate::transcript::{MentionTarget, TranscriptKind};
@@ -112,7 +113,7 @@ mod tests {
             occurred_at_ms: 1_700_000_000_000 + lamport,
             lamport,
             target: MentionTarget::All,
-            body: Some(format!("message {id}")),
+            body: Some(Body::text(format!("message {id}"))),
             attachment: None,
             receipt: None,
             metadata: serde_json::json!({}),

--- a/crates/airc-core/src/filter.rs
+++ b/crates/airc-core/src/filter.rs
@@ -44,6 +44,7 @@ pub fn filter_self_echoes(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::body::Body;
     use crate::ids::{EventId, RoomId};
     use crate::transcript::{MentionTarget, TranscriptKind};
 
@@ -57,7 +58,7 @@ mod tests {
             occurred_at_ms: 1_700_000_000_000 + lamport,
             lamport,
             target: MentionTarget::All,
-            body: Some(format!("message {id}")),
+            body: Some(Body::text(format!("message {id}"))),
             attachment: None,
             receipt: None,
             metadata: serde_json::json!({}),

--- a/crates/airc-core/src/lib.rs
+++ b/crates/airc-core/src/lib.rs
@@ -12,6 +12,7 @@
 //!
 //! - [`ids`]        — newtype wrappers for identifier strings
 //! - [`identity`]   — the per-peer Identity card (the user/account abstraction)
+//! - [`body`]       — opaque payload (Json | Binary) consumers carry
 //! - [`transcript`] — TranscriptEvent + TranscriptKind + MentionTarget
 //! - [`cursor`]     — cursor + paging primitives for transcript fetch
 //! - [`receipt`]    — delivered/read/applied acknowledgments
@@ -22,6 +23,7 @@
 //! `use airc_core::Identity;` works without knowing the module split.
 
 pub mod attachment;
+pub mod body;
 pub mod cursor;
 pub mod filter;
 pub mod identity;
@@ -34,6 +36,7 @@ pub mod transcript;
 // module paths so refactors stay clear.
 
 pub use attachment::AttachmentManifest;
+pub use body::Body;
 pub use cursor::{page_before, page_recent, TranscriptCursor, TranscriptPage};
 pub use filter::{filter_self_echoes, SelfFilter};
 pub use identity::Identity;

--- a/crates/airc-core/src/transcript.rs
+++ b/crates/airc-core/src/transcript.rs
@@ -10,6 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::body::Body;
 use crate::cursor::TranscriptCursor;
 use crate::filter::SelfFilter;
 use crate::ids::{ClientId, EventId, PeerId, RoomId};
@@ -59,7 +60,11 @@ pub struct TranscriptEvent {
     pub occurred_at_ms: u64,
     pub lamport: u64,
     pub target: MentionTarget,
-    pub body: Option<String>,
+    /// Opaque payload — consumer-defined JSON or binary. See [`Body`].
+    /// Replaces the legacy `Option<String>` shape; consumers wanting
+    /// plain chat text use `Body::text("...")` and recover it via
+    /// `body.as_ref().and_then(Body::as_text)`.
+    pub body: Option<Body>,
     pub attachment: Option<crate::attachment::AttachmentManifest>,
     pub receipt: Option<crate::receipt::Receipt>,
     pub metadata: serde_json::Value,


### PR DESCRIPTION
## Summary

PR-2 of the airc-core refactor stack. Stacks on **#654** (Identity + modular split). Adds the typed \`Body\` enum to replace \`TranscriptEvent.body\`'s text-only \`Option<String>\` shape.

### The two variants

- **\`Body::Json(serde_json::Value)\`** — the bulk of traffic. Chat text wrapped as \`{"text": "..."}\`, typed events, RPC commands with correlation IDs, signaling envelopes, anything structured.
- **\`Body::Binary(Vec<u8>)\`** — for consumers that avoid JSON overhead. Game-state diffs at high tick rate, pre-encoded media frames, custom binary command formats, future fast-UDP consumers.

### Tagged, not untagged

\`{"kind": "json", "value": ...}\` / \`{"kind": "binary", "value": [...]}\` — both variants round-trip cleanly through any serde format. Zero airc-rust users means we don't need the legacy bare-string backward-compat; the Python+bash airc keeps its shape until cutover, and airc-rust starts with the correct primitive.

### TDD cadence visible

- Initially designed as untagged enum
- Red test caught the "Binary array indistinguishable from Json(Array)" edge case
- Pivoted to tagged enum per "build correctly / zero users" direction — accept loss of legacy compat for protocol correctness
- All 7 Body tests pass; full airc-core suite **16/16** (9 from #654 + 7 new)

## What changed

| File | Change |
|---|---|
| \`crates/airc-core/src/body.rs\` | NEW. Body enum + helpers + 7 tests. |
| \`crates/airc-core/src/transcript.rs\` | \`body: Option<String>\` → \`body: Option<Body>\` |
| \`crates/airc-core/src/cursor.rs\` | test helper uses \`Body::text(...)\` |
| \`crates/airc-core/src/filter.rs\` | test helper uses \`Body::text(...)\` |
| \`crates/airc-core/src/lib.rs\` | module declaration + re-export |

## Test plan

- [x] 7 new Body tests pass: json round-trip, binary round-trip, text helper, as_text behavior, JSON-array-stays-json edge case, missing-discriminator fail-loud
- [x] All 16 airc-core tests pass (\`cargo test -p airc-core\`)
- [x] Helpers documented: \`Body::text(s)\`, \`body.as_text()\`

## What this does NOT add

Next in the audit stack: EventFrame distinction (push-fanout vs pull-store), MediaRef split (waits for #653+#655 airc-blobs land), Subscription filter type, Control frame variants, body_hint field, Signature wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)