### PR TITLE
ci: rust quality gates — fmt + clippy (deny warnings) + test on every Rust PR

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,91 @@
+name: rust
+
+# Quality gates for the airc-rust workspace (anything under `crates/`).
+#
+# Three jobs on every PR + push touching Rust:
+#   fmt      — `cargo fmt --check` (no formatter drift)
+#   clippy   — `cargo clippy --all-targets --all-features -- -D warnings`
+#              (zero clippy warnings, treat all as errors)
+#   test     — `cargo test --all-features` (every test green)
+#
+# Per Joel's direction (2026-05-18): "use rust conventions and obsession
+# with tests. clippy, fmt etc." These three gates are the substrate-quality
+# bar every airc-rust PR clears before merge.
+#
+# The clean-install / install.sh smoke jobs in ci.yml continue to validate
+# the Python+bash install path; this workflow specifically gates the
+# Rust workspace as it grows.
+
+on:
+  pull_request:
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/rust.yml"
+  push:
+    branches: [canary, main, rust-rewrite]
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/rust.yml"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  fmt:
+    name: cargo fmt --check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: install rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup component add rustfmt
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: cargo clippy (deny warnings)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: install rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup component add clippy
+      - name: cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-clippy-
+      - name: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: install rust toolchain
+        run: rustup toolchain install stable --profile minimal
+      - name: cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+      - name: cargo test --workspace --all-features
+        run: cargo test --workspace --all-features


### PR DESCRIPTION
## Summary

Per Joel (2026-05-18): *"use rust conventions and obsession with tests. clippy, fmt etc."*

Adds \`.github/workflows/rust.yml\` enforcing three quality gates on every PR + push that touches \`crates/**\`, \`Cargo.toml\`, \`Cargo.lock\`, or the workflow itself:

| Job | Command | Gate |
|---|---|---|
| **fmt** | \`cargo fmt --all -- --check\` | No formatter drift |
| **clippy** | \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` | Zero clippy warnings; all treated as errors |
| **test** | \`cargo test --workspace --all-features\` | Every test green |

\`RUSTFLAGS=-D warnings\` at env level so even non-clippy build warnings fail the build.

Path-filtered so Python+bash-only changes don't trigger cargo runs (the existing \`ci.yml\` continues to gate that path).

Cargo cache on clippy/test jobs for fast iteration; fmt is fast enough without the cache.

## Why now

Current airc-core is clean against this bar (\`cargo fmt --check\` has 0 diffs, \`cargo clippy -D warnings\` has 0 warnings). Locking the bar in BEFORE more code lands prevents drift — the same craft discipline as the Lane F ratchet in continuum: codify the standard at the gate, not after the fact.

## Test plan

- [x] cargo fmt --check on current workspace: 0 diffs
- [x] cargo clippy --all-targets --all-features -- -D warnings on current workspace: 0 warnings
- [x] cargo test on current workspace: 16/16 pass (airc-core) + 35/35 pass (airc-blobs after #660)

🤖 Generated with [Claude Code](https://claude.com/claude-code)