### PR TITLE
feat(airc-core): convert ID newtypes from String to UUIDv4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,11 +3,189 @@
 version = 4
 
 [[package]]
+name = "airc-blobs"
+version = "0.1.0"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "airc-core"
 version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -17,10 +195,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -39,6 +269,24 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -84,6 +332,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,10 +360,251 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/airc-core/Cargo.toml
+++ b/crates/airc-core/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/airc-core/src/attachment.rs
+++ b/crates/airc-core/src/attachment.rs
@@ -53,8 +53,9 @@ mod tests {
 
     #[test]
     fn machine_readable_serde() {
+        let file_id = FileId::from_u128(0x550e8400_e29b_41d4_a716_446655440000);
         let manifest = AttachmentManifest {
-            file_id: FileId("file-1".to_string()),
+            file_id,
             name: "trace.json".to_string(),
             media_type: Some("application/json".to_string()),
             size_bytes: 42,
@@ -65,7 +66,8 @@ mod tests {
 
         let encoded = serde_json::to_value(&manifest).unwrap();
 
-        assert_eq!(encoded["file_id"], "file-1");
+        // file_id serializes as the canonical hyphenated UUID string.
+        assert_eq!(encoded["file_id"], "550e8400-e29b-41d4-a716-446655440000");
         assert_eq!(encoded["content_hash"], "sha256:abc");
         assert_eq!(encoded["size_bytes"], 42);
     }

--- a/crates/airc-core/src/body.rs
+++ b/crates/airc-core/src/body.rs
@@ -48,9 +48,7 @@ impl Body {
     /// any other shape (binary, JSON without text field, etc.).
     pub fn as_text(&self) -> Option<&str> {
         match self {
-            Body::Json(serde_json::Value::Object(map)) => {
-                map.get("text").and_then(|v| v.as_str())
-            }
+            Body::Json(serde_json::Value::Object(map)) => map.get("text").and_then(|v| v.as_str()),
             Body::Json(serde_json::Value::String(s)) => {
                 // Backward-compat: legacy bare-string payloads still
                 // surface as text.

--- a/crates/airc-core/src/cursor.rs
+++ b/crates/airc-core/src/cursor.rs
@@ -33,11 +33,7 @@ pub struct TranscriptPage {
 }
 
 /// Fetch the most recent `limit` events for the room, ordered.
-pub fn page_recent(
-    room_id: RoomId,
-    events: &[TranscriptEvent],
-    limit: usize,
-) -> TranscriptPage {
+pub fn page_recent(room_id: RoomId, events: &[TranscriptEvent], limit: usize) -> TranscriptPage {
     let mut page_events = events.to_vec();
     page_events.sort_by(event_order);
     if page_events.len() > limit {
@@ -86,10 +82,7 @@ fn cursor_before(left: &TranscriptCursor, right: &TranscriptCursor) -> bool {
 /// Total event order: lamport first, then event_id alphabetically.
 /// Public-but-not-API: callers should sort via `page_recent` / `page_before`
 /// rather than reach in here.
-pub(crate) fn event_order(
-    left: &TranscriptEvent,
-    right: &TranscriptEvent,
-) -> std::cmp::Ordering {
+pub(crate) fn event_order(left: &TranscriptEvent, right: &TranscriptEvent) -> std::cmp::Ordering {
     left.lamport
         .cmp(&right.lamport)
         .then_with(|| left.event_id.0.cmp(&right.event_id.0))
@@ -99,78 +92,65 @@ pub(crate) fn event_order(
 mod tests {
     use super::*;
     use crate::body::Body;
-    use crate::filter::SelfFilter;
     use crate::ids::{ClientId, PeerId};
     use crate::transcript::{MentionTarget, TranscriptKind};
 
-    fn event(id: &str, lamport: u64, peer: &str, client: &str) -> TranscriptEvent {
+    /// Test helper: construct a transcript event with deterministic
+    /// UUID ids derived from the lamport. Deterministic so test
+    /// assertions are stable across runs.
+    fn event_at(lamport: u64, peer_seed: u128, client_seed: u128) -> TranscriptEvent {
         TranscriptEvent {
-            event_id: EventId(id.to_string()),
-            room_id: RoomId("general".to_string()),
-            peer_id: PeerId(peer.to_string()),
-            client_id: ClientId(client.to_string()),
+            event_id: EventId::from_u128(lamport as u128),
+            room_id: RoomId::from_u128(0xc0ffee),
+            peer_id: PeerId::from_u128(peer_seed),
+            client_id: ClientId::from_u128(client_seed),
             kind: TranscriptKind::Message,
             occurred_at_ms: 1_700_000_000_000 + lamport,
             lamport,
             target: MentionTarget::All,
-            body: Some(Body::text(format!("message {id}"))),
+            body: Some(Body::text(format!("message at lamport {lamport}"))),
             attachment: None,
             receipt: None,
             metadata: serde_json::json!({}),
         }
     }
 
-    // Suppress unused warning from `SelfFilter` import used by sibling
-    // crate::filter tests but not directly here.
-    #[allow(dead_code)]
-    const _: SelfFilter = SelfFilter::IncludeAll;
-
     #[test]
     fn recent_page_is_ordered_and_cursor_backed() {
-        let events = vec![
-            event("e3", 3, "a", "a1"),
-            event("e1", 1, "a", "a1"),
-            event("e2", 2, "b", "b1"),
-        ];
+        let e1 = event_at(1, 0xaa, 0xa1);
+        let e2 = event_at(2, 0xbb, 0xb1);
+        let e3 = event_at(3, 0xaa, 0xa1);
+        let room = RoomId::from_u128(0xc0ffee);
+        let events = vec![e3.clone(), e1.clone(), e2.clone()];
 
-        let page = page_recent(RoomId("general".to_string()), &events, 2);
+        let page = page_recent(room, &events, 2);
 
-        assert_eq!(
-            page.events
-                .iter()
-                .map(|e| &e.event_id.0)
-                .collect::<Vec<_>>(),
-            vec!["e2", "e3"]
-        );
-        assert_eq!(page.older.unwrap().event_id.0, "e2");
-        assert_eq!(page.newer.unwrap().event_id.0, "e3");
+        let ids: Vec<_> = page.events.iter().map(|e| e.event_id).collect();
+        assert_eq!(ids, vec![e2.event_id, e3.event_id]);
+        assert_eq!(page.older.unwrap().event_id, e2.event_id);
+        assert_eq!(page.newer.unwrap().event_id, e3.event_id);
     }
 
     #[test]
     fn older_page_uses_cursor_not_file_tail() {
-        let events = vec![
-            event("e1", 1, "a", "a1"),
-            event("e2", 2, "b", "b1"),
-            event("e3", 3, "c", "c1"),
-            event("e4", 4, "d", "d1"),
-        ];
+        let e1 = event_at(1, 0xaa, 0xa1);
+        let e2 = event_at(2, 0xbb, 0xb1);
+        let e3 = event_at(3, 0xcc, 0xc1);
+        let e4 = event_at(4, 0xdd, 0xd1);
+        let room = RoomId::from_u128(0xc0ffee);
+        let events = vec![e1, e2.clone(), e3.clone(), e4.clone()];
 
         let page = page_before(
-            RoomId("general".to_string()),
+            room,
             &events,
             &TranscriptCursor {
                 lamport: 4,
-                event_id: EventId("e4".to_string()),
+                event_id: e4.event_id,
             },
             2,
         );
 
-        assert_eq!(
-            page.events
-                .iter()
-                .map(|e| &e.event_id.0)
-                .collect::<Vec<_>>(),
-            vec!["e2", "e3"]
-        );
+        let ids: Vec<_> = page.events.iter().map(|e| e.event_id).collect();
+        assert_eq!(ids, vec![e2.event_id, e3.event_id]);
     }
 }

--- a/crates/airc-core/src/filter.rs
+++ b/crates/airc-core/src/filter.rs
@@ -48,17 +48,19 @@ mod tests {
     use crate::ids::{EventId, RoomId};
     use crate::transcript::{MentionTarget, TranscriptKind};
 
-    fn event(id: &str, lamport: u64, peer: &str, client: &str) -> TranscriptEvent {
+    /// Test helper: deterministic event with caller-supplied peer/client
+    /// UUIDs so assertions can name them.
+    fn event_at(seed: u128, lamport: u64, peer_id: PeerId, client_id: ClientId) -> TranscriptEvent {
         TranscriptEvent {
-            event_id: EventId(id.to_string()),
-            room_id: RoomId("general".to_string()),
-            peer_id: PeerId(peer.to_string()),
-            client_id: ClientId(client.to_string()),
+            event_id: EventId::from_u128(seed),
+            room_id: RoomId::from_u128(0xc0ffee),
+            peer_id,
+            client_id,
             kind: TranscriptKind::Message,
             occurred_at_ms: 1_700_000_000_000 + lamport,
             lamport,
             target: MentionTarget::All,
-            body: Some(Body::text(format!("message {id}"))),
+            body: Some(Body::text(format!("message {seed:x}"))),
             attachment: None,
             receipt: None,
             metadata: serde_json::json!({}),
@@ -67,40 +69,38 @@ mod tests {
 
     #[test]
     fn self_filter_distinguishes_peer_from_client() {
-        let peer = PeerId("agent".to_string());
-        let current_client = ClientId("tab-a".to_string());
+        let agent = PeerId::from_u128(0xa6e7);
+        let reviewer = PeerId::from_u128(0x5e7e);
+        let tab_a = ClientId::from_u128(0xa);
+        let tab_b = ClientId::from_u128(0xb);
+        let tab_c = ClientId::from_u128(0xc);
+
+        let same_client = event_at(0x01, 1, agent, tab_a);
+        let same_peer_other_client = event_at(0x02, 2, agent, tab_b);
+        let other_peer = event_at(0x03, 3, reviewer, tab_c);
         let events = vec![
-            event("same-client", 1, "agent", "tab-a"),
-            event("same-peer-other-client", 2, "agent", "tab-b"),
-            event("other-peer", 3, "reviewer", "tab-c"),
+            same_client.clone(),
+            same_peer_other_client.clone(),
+            other_peer.clone(),
         ];
 
+        // ExcludeSameClient: drop only events from `tab_a`. Same-peer
+        // other-client survives; other-peer survives.
         let client_filtered = filter_self_echoes(
             events.clone(),
-            &peer,
-            &current_client,
+            &agent,
+            &tab_a,
             SelfFilter::ExcludeSameClient,
         );
+        let ids: Vec<_> = client_filtered.iter().map(|e| e.event_id).collect();
         assert_eq!(
-            client_filtered
-                .iter()
-                .map(|e| &e.event_id.0)
-                .collect::<Vec<_>>(),
-            vec!["same-peer-other-client", "other-peer"]
+            ids,
+            vec![same_peer_other_client.event_id, other_peer.event_id]
         );
 
-        let peer_filtered = filter_self_echoes(
-            events,
-            &peer,
-            &current_client,
-            SelfFilter::ExcludeSamePeer,
-        );
-        assert_eq!(
-            peer_filtered
-                .iter()
-                .map(|e| &e.event_id.0)
-                .collect::<Vec<_>>(),
-            vec!["other-peer"]
-        );
+        // ExcludeSamePeer: drop every event from `agent`, regardless of tab.
+        let peer_filtered = filter_self_echoes(events, &agent, &tab_a, SelfFilter::ExcludeSamePeer);
+        let ids: Vec<_> = peer_filtered.iter().map(|e| e.event_id).collect();
+        assert_eq!(ids, vec![other_peer.event_id]);
     }
 }

--- a/crates/airc-core/src/ids.rs
+++ b/crates/airc-core/src/ids.rs
@@ -1,50 +1,188 @@
-//! Newtype-wrapped identifier strings.
+//! Newtype-wrapped identifier types.
 //!
-//! Each id is a thin wrapper around a `String`. The `#[serde(transparent)]`
-//! attribute means the JSON shape is just the raw string — no `{"value": ...}`
-//! envelope — so wire compatibility with the Python+bash airc is preserved.
+//! Every internal id in airc-rust is a UUIDv4 — the right primitive for
+//! a P2P mesh substrate where peers generate ids locally without a
+//! central coordinator. See the substrate design doc, section
+//! "Identifiers — UUIDv4 everywhere," for the full rationale.
 //!
-//! These types intentionally do NOT enforce a specific format (uuid, base64,
-//! human-hash) at the type level. Consumers may pick the encoding they want;
-//! the substrate just routes opaque strings keyed on these ids.
+//! Wire shape: serde encodes `Uuid` as the canonical hyphenated string
+//! (`"550e8400-e29b-41d4-a716-446655440000"`), so JSON envelopes stay
+//! human-readable and cross-language. The `#[serde(transparent)]`
+//! attribute means the JSON shape is just the bare string — no
+//! `{"value": ...}` wrapper.
+//!
+//! Generation: `EventId::new()`, `RoomId::new()`, etc. all delegate to
+//! `Uuid::new_v4()`. Tests that need deterministic ids use
+//! `EventId::from_u128(N)` (also exposed below).
+//!
+//! Exception: `ContentHash` is NOT a UUID — it carries a content-
+//! addressed hash like `"sha256:<hex>"`. Content addressing is the
+//! discipline for blobs; UUIDs are the discipline for runtime
+//! identifiers. They don't overlap.
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
-/// Stable identifier for one transcript event. Persists across host
-/// migrations and replay — two peers receiving the same wire envelope
-/// see the same `EventId`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct EventId(pub String);
+macro_rules! uuid_newtype {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(
+            Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize,
+        )]
+        #[serde(transparent)]
+        pub struct $name(pub Uuid);
 
-/// A room / channel handle. Consumers may pick any naming scheme; airc
-/// does not interpret the inner string.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct RoomId(pub String);
+        impl $name {
+            /// Generate a fresh random UUIDv4.
+            pub fn new() -> Self {
+                Self(Uuid::new_v4())
+            }
 
-/// A peer identifier — the canonical "who is this." Multiple `ClientId`s
-/// may share one `PeerId` (multi-tab same-identity case).
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct PeerId(pub String);
+            /// Construct from a known u128 — for deterministic test ids.
+            /// Production code should use `new()`.
+            pub fn from_u128(value: u128) -> Self {
+                Self(Uuid::from_u128(value))
+            }
 
-/// A per-process / per-tab session identifier under a peer. The pair
-/// `(PeerId, ClientId)` uniquely identifies one running airc consumer
-/// session. Used for self-echo filtering when multiple sessions share
-/// a nick.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct ClientId(pub String);
+            /// Construct from an existing Uuid (e.g. one parsed from
+            /// the wire).
+            pub fn from_uuid(uuid: Uuid) -> Self {
+                Self(uuid)
+            }
 
-/// Stable handle for an attached file or media blob.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct FileId(pub String);
+            /// Access the underlying Uuid.
+            pub fn as_uuid(&self) -> Uuid {
+                self.0
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+    };
+}
+
+uuid_newtype! {
+    /// Stable identifier for one transcript event. Persists across host
+    /// migrations and replay — two peers receiving the same wire envelope
+    /// see the same `EventId`.
+    EventId
+}
+
+uuid_newtype! {
+    /// A room / channel handle. Peers reference rooms internally by
+    /// `RoomId`; display names (`#general`) are mutable handles on top.
+    RoomId
+}
+
+uuid_newtype! {
+    /// A peer identifier — the canonical "who is this." Multiple
+    /// `ClientId`s may share one `PeerId` (multi-tab same-identity case).
+    PeerId
+}
+
+uuid_newtype! {
+    /// A per-process / per-tab session identifier under a peer. The pair
+    /// `(PeerId, ClientId)` uniquely identifies one running airc consumer
+    /// session. Used for self-echo filtering when multiple sessions share
+    /// a nick.
+    ClientId
+}
+
+uuid_newtype! {
+    /// Stable handle for an attached file or media manifest. The blob
+    /// content itself is addressed by `ContentHash` (sha256); this id
+    /// is the manifest handle.
+    FileId
+}
 
 /// Content-addressed hash of a blob. Format-neutral string (typically
 /// `"sha256:<hex>"` but consumers may use other prefixes for other
 /// algorithms — airc just matches strings).
+///
+/// NOT a UUID. Content addressing has different requirements than
+/// runtime identifiers: collision = identical content (a feature, not
+/// a bug), generation = hash of payload bytes (not random). UUIDs
+/// would defeat both properties.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct ContentHash(pub String);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_event_id_is_random_uuidv4() {
+        let a = EventId::new();
+        let b = EventId::new();
+        assert_ne!(a, b, "two new EventIds must differ (collision odds 2^-122)");
+        assert_eq!(
+            a.0.get_version(),
+            Some(uuid::Version::Random),
+            "EventId must be UUIDv4"
+        );
+    }
+
+    #[test]
+    fn from_u128_is_deterministic_for_tests() {
+        let a = EventId::from_u128(0xdead_beef_dead_beef_dead_beef_dead_beef);
+        let b = EventId::from_u128(0xdead_beef_dead_beef_dead_beef_dead_beef);
+        assert_eq!(a, b, "from_u128 with same value must be equal");
+    }
+
+    #[test]
+    fn serde_roundtrips_via_hyphenated_string() {
+        let id = EventId::from_u128(0x550e8400_e29b_41d4_a716_446655440000);
+        let encoded = serde_json::to_value(id).unwrap();
+        // Tagged as a bare string in JSON (serde transparent + Uuid's
+        // own serializer produces hyphenated lowercase).
+        assert_eq!(encoded, "550e8400-e29b-41d4-a716-446655440000");
+        let decoded: EventId = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded, id);
+    }
+
+    #[test]
+    fn display_uses_hyphenated_lowercase() {
+        let id = PeerId::from_u128(0x550e8400_e29b_41d4_a716_446655440000);
+        assert_eq!(format!("{}", id), "550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn malformed_uuid_string_fails_parse() {
+        // Forward-compat safety: if a legacy or hostile wire envelope
+        // sends `"event_id": "not-a-uuid"`, we want a typed parse error,
+        // not a silent String coercion deep in the routing path.
+        let result: Result<EventId, _> = serde_json::from_value(serde_json::json!("not-a-uuid"));
+        assert!(result.is_err(), "malformed UUID must fail to parse");
+    }
+
+    #[test]
+    fn all_id_newtypes_share_the_uuidv4_contract() {
+        // Macro produces identical behavior across all newtype IDs.
+        // This test pins that contract.
+        assert_eq!(EventId::new().0.get_version(), Some(uuid::Version::Random));
+        assert_eq!(RoomId::new().0.get_version(), Some(uuid::Version::Random));
+        assert_eq!(PeerId::new().0.get_version(), Some(uuid::Version::Random));
+        assert_eq!(ClientId::new().0.get_version(), Some(uuid::Version::Random));
+        assert_eq!(FileId::new().0.get_version(), Some(uuid::Version::Random));
+    }
+
+    #[test]
+    fn content_hash_is_not_uuid_typed() {
+        // ContentHash is intentionally a String — content-addressed
+        // hashes have different requirements (deterministic + payload-
+        // derived) than runtime ids. This test pins that distinction.
+        let h = ContentHash("sha256:abc123".to_string());
+        let encoded = serde_json::to_value(&h).unwrap();
+        assert_eq!(encoded, "sha256:abc123");
+    }
+}

--- a/crates/airc-core/src/transcript.rs
+++ b/crates/airc-core/src/transcript.rs
@@ -76,18 +76,13 @@ impl TranscriptEvent {
     pub fn cursor(&self) -> TranscriptCursor {
         TranscriptCursor {
             lamport: self.lamport,
-            event_id: self.event_id.clone(),
+            event_id: self.event_id,
         }
     }
 
     /// Is this event from the receiver's own peer/client (and should be
     /// filtered from display per the filter mode)?
-    pub fn is_self_echo(
-        &self,
-        peer_id: &PeerId,
-        client_id: &ClientId,
-        filter: SelfFilter,
-    ) -> bool {
+    pub fn is_self_echo(&self, peer_id: &PeerId, client_id: &ClientId, filter: SelfFilter) -> bool {
         match filter {
             SelfFilter::IncludeAll => false,
             SelfFilter::ExcludeSameClient => &self.client_id == client_id,


### PR DESCRIPTION
## Summary

Locks the **UUIDv4 mesh-native identifier discipline** at the compile-time level. Every runtime ID in airc-core is now a typed UUID newtype.

Companion to docs PR #663 (which anchors the policy). This PR is the code-side implementation.

## Changes

- \`Cargo.toml\`: add \`uuid = { version = "1", features = ["v4", "serde"] }\`
- \`ids.rs\`: macro-generated UUID newtypes — \`EventId(Uuid)\`, \`RoomId(Uuid)\`, \`PeerId(Uuid)\`, \`ClientId(Uuid)\`, \`FileId(Uuid)\`. Each gets:
  - \`::new()\` → UUIDv4 random
  - \`::from_u128(N)\` → deterministic for tests
  - \`::from_uuid(u)\` → construct from existing
  - \`::as_uuid()\` → access underlying
  - \`Default\`, \`Display\` (hyphenated lowercase)
- \`ContentHash\` stays \`pub struct ContentHash(pub String)\` — content addressing has different requirements than runtime IDs (deterministic + payload-derived). UUIDs would defeat both properties. Discipline distinction pinned by a dedicated test.
- \`transcript.rs\`: \`event_id.clone()\` → \`event_id\` (now Copy)
- \`cursor.rs\` + \`filter.rs\`: test helpers use \`from_u128(N)\` + named locals so assertions reference UUIDs directly instead of string literals
- \`attachment.rs\`: test uses deterministic UUID for FileId; serde assertion updated to expect canonical hyphenated UUID string on the wire

## Wire shape unchanged

serde encodes Uuid as the canonical hyphenated string (\`"550e8400-e29b-41d4-a716-446655440000"\`). JSON envelopes stay human-readable and cross-language parsers work. Backward-compat with Python+bash airc envelopes that happen to carry UUID-shaped strings.

**Fail-loud upgrade**: non-UUID strings (e.g. legacy "e1" test IDs) now fail to parse at envelope deserialize instead of silently coercing into a String. This is the substrate's discipline — malformed identifiers don't reach routing.

## Test plan

- [x] **7 new ids.rs tests** pin the UUIDv4 contract:
  - \`new_event_id_is_random_uuidv4\`
  - \`from_u128_is_deterministic_for_tests\`
  - \`serde_roundtrips_via_hyphenated_string\`
  - \`display_uses_hyphenated_lowercase\`
  - \`malformed_uuid_string_fails_parse\` (fail-loud at envelope deserialize)
  - \`all_id_newtypes_share_the_uuidv4_contract\`
  - \`content_hash_is_not_uuid_typed\` (pins the discipline distinction)
- [x] Full airc-core: **23/23 tests pass** (was 16; +7 new)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`: 0 warnings
- [x] \`cargo fmt --check\`: 0 diffs
- [x] Conforms to the rust.yml gates landing in #661

## What this does NOT add

- Identity struct's \`identity_id: IdentityId\` field per the three-field model in #663 — that's the next PR (\`feat/airc-core-identity-fields\`)
- airc-protocol crate with Envelope/Headers/Body/Subscription types — follow-up PR
- airc-blobs already uses its own ContentHash; not changing in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)