### PR TITLE
feat(airc-core): envelope Headers dictionary + HeaderFilter

### DIFF
--- a/crates/airc-core/src/cursor.rs
+++ b/crates/airc-core/src/cursor.rs
@@ -108,6 +108,7 @@ mod tests {
             occurred_at_ms: 1_700_000_000_000 + lamport,
             lamport,
             target: MentionTarget::All,
+            headers: Default::default(),
             body: Some(Body::text(format!("message at lamport {lamport}"))),
             attachment: None,
             receipt: None,

--- a/crates/airc-core/src/filter.rs
+++ b/crates/airc-core/src/filter.rs
@@ -60,6 +60,7 @@ mod tests {
             occurred_at_ms: 1_700_000_000_000 + lamport,
             lamport,
             target: MentionTarget::All,
+            headers: Default::default(),
             body: Some(Body::text(format!("message {seed:x}"))),
             attachment: None,
             receipt: None,

--- a/crates/airc-core/src/headers.rs
+++ b/crates/airc-core/src/headers.rs
@@ -1,0 +1,89 @@
+//! Envelope headers — small routable metadata carried beside opaque bodies.
+//!
+//! Headers are the airc equivalent of HTTP headers: optional, deterministic,
+//! cheap to inspect, and independent from the body payload. The substrate may
+//! route, filter, retain, or diagnose using these values without parsing
+//! consumer JSON. Consumers own their own namespaces (`forge.*`,
+//! `openclaw.*`, `hermes.*`, `continuum.*`, `x-*`).
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Deterministically ordered string headers.
+pub type Headers = BTreeMap<String, String>;
+
+/// Match predicate for subscription fan-out.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HeaderFilter {
+    Any,
+    Exact { key: String, value: String },
+    Prefix { key: String, value_prefix: String },
+    All(Vec<HeaderFilter>),
+    AnyOf(Vec<HeaderFilter>),
+}
+
+impl HeaderFilter {
+    pub fn matches(&self, headers: &Headers) -> bool {
+        match self {
+            HeaderFilter::Any => true,
+            HeaderFilter::Exact { key, value } => headers.get(key) == Some(value),
+            HeaderFilter::Prefix { key, value_prefix } => headers
+                .get(key)
+                .is_some_and(|value| value.starts_with(value_prefix)),
+            HeaderFilter::All(filters) => filters.iter().all(|filter| filter.matches(headers)),
+            HeaderFilter::AnyOf(filters) => filters.iter().any(|filter| filter.matches(headers)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn external_agent_headers() -> Headers {
+        Headers::from([
+            (
+                "forge.body_hint".to_string(),
+                "forge.persona.turn".to_string(),
+            ),
+            (
+                "openclaw.channel".to_string(),
+                "discord:continuum-lab".to_string(),
+            ),
+            ("hermes.skill".to_string(), "calendar".to_string()),
+        ])
+    }
+
+    #[test]
+    fn header_filter_matches_exact_and_prefix_without_body_parse() {
+        let headers = external_agent_headers();
+
+        assert!(HeaderFilter::Exact {
+            key: "openclaw.channel".to_string(),
+            value: "discord:continuum-lab".to_string(),
+        }
+        .matches(&headers));
+
+        assert!(HeaderFilter::Prefix {
+            key: "forge.body_hint".to_string(),
+            value_prefix: "forge.persona.".to_string(),
+        }
+        .matches(&headers));
+
+        assert!(!HeaderFilter::Exact {
+            key: "hermes.skill".to_string(),
+            value: "memory".to_string(),
+        }
+        .matches(&headers));
+    }
+
+    #[test]
+    fn namespaced_headers_are_pass_through_and_deterministic() {
+        let headers = external_agent_headers();
+        let encoded = serde_json::to_string(&headers).unwrap();
+
+        assert!(encoded.find("forge.body_hint").unwrap() < encoded.find("hermes.skill").unwrap());
+        assert!(encoded.contains("openclaw.channel"));
+    }
+}

--- a/crates/airc-core/src/lib.rs
+++ b/crates/airc-core/src/lib.rs
@@ -18,6 +18,7 @@
 //! - [`receipt`]    — delivered/read/applied acknowledgments
 //! - [`attachment`] — file-attachment manifest (consumer-side richer view)
 //! - [`filter`]     — self-echo filtering for multi-tab consumers
+//! - [`headers`]    — envelope headers for routing/filtering without body parse
 //!
 //! Every public type a consumer needs is re-exported at the crate root so
 //! `use airc_core::Identity;` works without knowing the module split.
@@ -26,6 +27,7 @@ pub mod attachment;
 pub mod body;
 pub mod cursor;
 pub mod filter;
+pub mod headers;
 pub mod identity;
 pub mod ids;
 pub mod receipt;
@@ -39,6 +41,7 @@ pub use attachment::AttachmentManifest;
 pub use body::Body;
 pub use cursor::{page_before, page_recent, TranscriptCursor, TranscriptPage};
 pub use filter::{filter_self_echoes, SelfFilter};
+pub use headers::{HeaderFilter, Headers};
 pub use identity::Identity;
 pub use ids::{ClientId, ContentHash, EventId, FileId, PeerId, RoomId};
 pub use receipt::{Receipt, ReceiptKind};

--- a/crates/airc-core/src/transcript.rs
+++ b/crates/airc-core/src/transcript.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::body::Body;
 use crate::cursor::TranscriptCursor;
 use crate::filter::SelfFilter;
+use crate::headers::Headers;
 use crate::ids::{ClientId, EventId, PeerId, RoomId};
 
 /// The category of a transcript event. Different kinds may carry
@@ -60,6 +61,9 @@ pub struct TranscriptEvent {
     pub occurred_at_ms: u64,
     pub lamport: u64,
     pub target: MentionTarget,
+    /// Small envelope metadata for routing/filtering without parsing body.
+    #[serde(default)]
+    pub headers: Headers,
     /// Opaque payload — consumer-defined JSON or binary. See [`Body`].
     /// Replaces the legacy `Option<String>` shape; consumers wanting
     /// plain chat text use `Body::text("...")` and recover it via


### PR DESCRIPTION
## Summary

Implements the **HTTP-style headers** primitive the substrate design doc calls for (docs PR: #662). Headers are the airc equivalent of HTTP headers — optional, deterministic, cheap to inspect, independent of the body payload. The substrate may route, filter, retain, or diagnose using them without ever parsing consumer JSON.

- **`headers.rs` (new)**
  - `pub type Headers = BTreeMap<String, String>` — deterministic ordering for stable diffs / cursors / replay records.
  - `HeaderFilter` enum: `Any` / `Exact` / `Prefix` / `All(...)` / `AnyOf(...)` — match predicate consumers can express for subscription fan-out without handing the substrate a closure.
- **`TranscriptEvent.headers: Headers`** field added with `serde(default)` so legacy events without headers deserialize cleanly to an empty map.
- Re-exports at crate root: `use airc_core::{Headers, HeaderFilter};`

## Namespace discipline

Consumers own their namespaces (`forge.*`, `openclaw.*`, `hermes.*`, `continuum.*`, `x-*`). airc never interprets keys — `HeaderFilter::Prefix` lets the substrate route on namespaces without becoming the namespace registry.

## Test plan

- [x] `cargo fmt -p airc-core` — clean
- [x] `cargo clippy -p airc-core --all-targets -- -D warnings` — clean
- [x] `cargo test -p airc-core` — 25 pass / 0 fail
- New tests: `header_filter_matches_exact_and_prefix_without_body_parse`, `namespaced_headers_are_pass_through_and_deterministic`

## Stack

Stacked on `feat/airc-core-uuid-ids` (PR #663). Identity-fields PR (#665) is independent and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)