### PR TITLE
feat(airc-protocol): wire envelope, Frame, signature, subscription, LiftPolicy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 *.pyc
 .venv
 .venv-dev
+target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-protocol"
+version = "0.1.0"
+dependencies = [
+ "airc-core",
+ "ciborium",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +66,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +100,12 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -141,6 +184,17 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -604,6 +658,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["crates/airc-core", "crates/airc-blobs"]
+members = ["crates/airc-core", "crates/airc-blobs", "crates/airc-protocol"]
 resolver = "2"

--- a/crates/airc-protocol/Cargo.toml
+++ b/crates/airc-protocol/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "airc-protocol"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+[dependencies]
+airc-core = { path = "../airc-core" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+ciborium = "0.2"

--- a/crates/airc-protocol/src/canonical.rs
+++ b/crates/airc-protocol/src/canonical.rs
@@ -1,0 +1,237 @@
+//! Canonical encoding of an envelope for signing + content-hash purposes.
+//!
+//! Signatures cover bytes, not Rust structs — so "what bytes does this
+//! envelope produce for the signer?" needs ONE deterministic answer.
+//! Two semantically-equal envelopes (same fields, same values) MUST
+//! produce identical canonical bytes regardless of serialization order
+//! or formatting whitespace, or signatures verified on one machine won't
+//! verify on another.
+//!
+//! Encoding: canonical CBOR via `ciborium`. CBOR has well-defined
+//! determinism rules; `BTreeMap` for `Headers` ensures lexicographic
+//! map ordering; `ciborium` emits definite-length forms for arrays and
+//! maps and shortest-form integers. The signed payload is the envelope
+//! MINUS its signature field — the signer can't sign over its own
+//! signature.
+//!
+//! NOTE: this is the substrate's *cryptographic* canonical form. The
+//! JSON serde form (`serde_json::to_value(&envelope)`) is the *wire*
+//! form for transports that prefer JSON. The two are not byte-equal —
+//! they aren't supposed to be. JSON is for humans and JS; CBOR is for
+//! the signer.
+
+use serde::Serialize;
+
+use airc_core::{
+    headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, PeerId, RoomId,
+};
+
+use crate::envelope::Envelope;
+use crate::media::MediaRef;
+
+/// Errors producing the canonical encoding.
+#[derive(Debug)]
+pub enum CanonicalError {
+    /// `ciborium` rejected the value — usually a malformed Body whose
+    /// inner JSON contains a shape CBOR can't represent (e.g. a map
+    /// with non-string keys after a serde projection).
+    Encoding(String),
+}
+
+impl std::fmt::Display for CanonicalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CanonicalError::Encoding(message) => {
+                write!(f, "canonical CBOR encoding failed: {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CanonicalError {}
+
+/// Produce the canonical CBOR bytes for an envelope, EXCLUDING its
+/// signature field. These are the bytes the signer signs and the
+/// verifier verifies against.
+pub fn canonical_signed_bytes(envelope: &Envelope) -> Result<Vec<u8>, CanonicalError> {
+    let payload = SignedPayload::from_envelope(envelope);
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&payload, &mut buf)
+        .map_err(|error| CanonicalError::Encoding(error.to_string()))?;
+    Ok(buf)
+}
+
+/// The envelope's signed payload — every field EXCEPT `signature`.
+/// Borrowed so encoding doesn't clone the body/headers/media.
+#[derive(Serialize)]
+struct SignedPayload<'envelope> {
+    event_id: &'envelope EventId,
+    sender: &'envelope PeerId,
+    sender_client: &'envelope ClientId,
+    channel: &'envelope RoomId,
+    target: &'envelope MentionTarget,
+    lamport: u64,
+    occurred_at_ms: u64,
+    reply_to: &'envelope Option<EventId>,
+    headers: &'envelope Headers,
+    body: &'envelope Option<Body>,
+    media: &'envelope Vec<MediaRef>,
+}
+
+impl<'envelope> SignedPayload<'envelope> {
+    fn from_envelope(envelope: &'envelope Envelope) -> Self {
+        Self {
+            event_id: &envelope.event_id,
+            sender: &envelope.sender,
+            sender_client: &envelope.sender_client,
+            channel: &envelope.channel,
+            target: &envelope.target,
+            lamport: envelope.lamport,
+            occurred_at_ms: envelope.occurred_at_ms,
+            reply_to: &envelope.reply_to,
+            headers: &envelope.headers,
+            body: &envelope.body,
+            media: &envelope.media,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{ChannelId, Envelope, FrameKind};
+    use crate::media::MediaRef;
+    use crate::signature::Signature;
+    use airc_core::{
+        headers::Headers, transcript::MentionTarget, Body, ClientId, ContentHash, EventId, FileId,
+        PeerId,
+    };
+
+    fn fixture() -> Envelope {
+        let mut headers = Headers::new();
+        headers.insert(
+            "forge.body_hint".to_string(),
+            "forge.persona.turn".to_string(),
+        );
+        headers.insert("airc.trace_id".to_string(), "trace-abc-123".to_string());
+        Envelope {
+            event_id: EventId::from_u128(0x01),
+            sender: PeerId::from_u128(0xa1),
+            sender_client: ClientId::from_u128(0xc1),
+            channel: ChannelId::from_u128(0xc0ffee),
+            target: MentionTarget::All,
+            lamport: 42,
+            occurred_at_ms: 1_700_000_000_000,
+            reply_to: Some(EventId::from_u128(0x11)),
+            headers,
+            body: Some(Body::text("hello world")),
+            media: vec![MediaRef {
+                file_id: FileId::from_u128(0xf1),
+                content_hash: ContentHash("sha256:1234abcd".to_string()),
+                mime: Some("image/png".to_string()),
+                size_bytes: Some(2048),
+                caption: None,
+            }],
+            signature: Signature::Unsigned,
+        }
+    }
+
+    #[test]
+    fn canonical_bytes_are_deterministic_across_runs() {
+        // Two identical envelopes MUST encode to the same bytes. This
+        // is the foundational property — if it fails, signing breaks
+        // across processes (sender signs one form, receiver verifies
+        // another).
+        let a = canonical_signed_bytes(&fixture()).unwrap();
+        let b = canonical_signed_bytes(&fixture()).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn signature_field_does_not_affect_canonical_bytes() {
+        // The "signs over its own signature" trap. Two envelopes that
+        // differ ONLY in the signature field MUST produce identical
+        // canonical bytes — otherwise the signer can't sign anything
+        // (they'd have to know the signature before producing it).
+        let mut unsigned = fixture();
+        unsigned.signature = Signature::Unsigned;
+        let mut signed = fixture();
+        signed.signature = Signature::Ed25519 {
+            signer: PeerId::from_u128(0xa1),
+            key_id: 0,
+            sig: [0xff; 64],
+        };
+
+        let unsigned_bytes = canonical_signed_bytes(&unsigned).unwrap();
+        let signed_bytes = canonical_signed_bytes(&signed).unwrap();
+        assert_eq!(unsigned_bytes, signed_bytes);
+    }
+
+    #[test]
+    fn headers_order_does_not_affect_canonical_bytes() {
+        // BTreeMap is sorted, so insertion order can't influence the
+        // CBOR output. Pin that — if someone swaps Headers to HashMap
+        // later the canonical encoding becomes non-deterministic.
+        let mut a = fixture();
+        a.headers.insert("z.last".to_string(), "Z".to_string());
+        a.headers.insert("a.first".to_string(), "A".to_string());
+
+        let mut b = fixture();
+        // Insert in opposite order.
+        b.headers.insert("a.first".to_string(), "A".to_string());
+        b.headers.insert("z.last".to_string(), "Z".to_string());
+
+        assert_eq!(
+            canonical_signed_bytes(&a).unwrap(),
+            canonical_signed_bytes(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn field_change_does_change_canonical_bytes() {
+        // Sanity check the inverse: a real semantic change DOES alter
+        // the canonical bytes. If it doesn't, the encoding is dropping
+        // information.
+        let a = canonical_signed_bytes(&fixture()).unwrap();
+        let mut altered = fixture();
+        altered.lamport = 43;
+        let b = canonical_signed_bytes(&altered).unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn canonical_encoding_carries_reply_to_field() {
+        // Pin that the reply_to field is part of the signed payload —
+        // otherwise tampering with a reply target would be undetectable.
+        let mut without_reply = fixture();
+        without_reply.reply_to = None;
+        let mut with_reply = fixture();
+        with_reply.reply_to = Some(EventId::from_u128(0x99));
+
+        assert_ne!(
+            canonical_signed_bytes(&without_reply).unwrap(),
+            canonical_signed_bytes(&with_reply).unwrap()
+        );
+    }
+
+    #[test]
+    fn frame_kind_is_not_part_of_canonical_bytes() {
+        // Frame kind is a transport-layer dispatch label, not envelope
+        // content. Two frames carrying the same envelope but with
+        // different kinds (Message vs Event) should produce the same
+        // canonical bytes — the signer signs the envelope, not the
+        // frame kind. This test serves as a guard: if someone later
+        // adds frame-kind to the canonical payload, they break
+        // adapters that re-emit the same envelope as a different
+        // frame kind.
+        let envelope = fixture();
+        let bytes = canonical_signed_bytes(&envelope).unwrap();
+        // Sanity: bytes are non-empty
+        assert!(!bytes.is_empty());
+        // No FrameKind enum participates in the encoding (we encode
+        // SignedPayload, not Frame). This test pins the contract by
+        // ensuring `bytes` only depends on Envelope.
+        let _ = FrameKind::Message; // referenced so the enum stays in
+                                    // scope; documenting intent.
+    }
+}

--- a/crates/airc-protocol/src/envelope.rs
+++ b/crates/airc-protocol/src/envelope.rs
@@ -1,0 +1,232 @@
+//! The wire envelope — what a transport adapter carries across the mesh.
+//!
+//! An `Envelope` is the canonical "one event" record on the wire. Three
+//! frame kinds wrap it: `Message` (pull-driven, durable), `Event`
+//! (push-driven interrupt), `Control` (session lifecycle — JOIN / NICK /
+//! HEARTBEAT). The body and headers are opaque to the substrate;
+//! consumers (forge/alloy, Continuum, OpenClaw extensions, Hermes, ...)
+//! own meaning.
+//!
+//! Anatomy:
+//!   - `event_id`       — adapter-generated UUIDv4, stable across replay.
+//!   - `sender` + `sender_client` — three-field identity: the durable
+//!     `PeerId` and the per-session `ClientId` so multi-tab sessions can
+//!     be disambiguated. Identity card (nick / role / bio) lives on
+//!     `airc_core::Identity`, looked up via `sender`.
+//!   - `channel`        — alias for `RoomId`; the abstract scope an event
+//!     belongs to. Consumers vary the metaphor (room / activity / thread
+//!     / lobby / project) but airc has one type.
+//!   - `target`         — broadcast / direct-peer / sibling-room
+//!     addressing, per `airc_core::MentionTarget`.
+//!   - `lamport` + `occurred_at_ms` — logical clock + wall-clock pair;
+//!     ordering uses lamport (transcript ordering survives skew) but
+//!     consumers can render wall-clock for UI.
+//!   - `reply_to`       — structured threading. Authoritative field.
+//!     Adapters that only know headers see the same value at
+//!     `airc.reply_to`; mismatch fails verification.
+//!   - `headers`        — `airc_core::Headers` (BTreeMap<String,String>).
+//!     Namespaces: `airc.*` substrate, `forge.*` contracts, `continuum.*`,
+//!     `openclaw.*`, `hermes.*`, `opencode.*`, `x-*`. Substrate routes /
+//!     filters on these without parsing body.
+//!   - `body`           — opaque `airc_core::Body` (Json | Binary).
+//!     Receiver decodes per `forge.body_hint` header.
+//!   - `media`          — `Vec<MediaRef>` for blob attachments;
+//!     content-addressed via `airc_core::ContentHash`.
+//!
+//! Auto-lift policy (send-path, abstracted as a trait): if a `body`
+//! exceeds the integrator's threshold, the send path writes it to
+//! `airc-blobs` and replaces `body: Some(...)` with `media.push(MediaRef
+//! {...})`. The substrate never inlines blob bytes into the message
+//! path. This shape supports both inline and lifted forms
+//! **transparently** — an outside caller cannot tell which path the
+//! sender took, and shouldn't have to. The receiver either reads `body`
+//! or fetches the blob by `content_hash`; same payload either way.
+//!
+//! Pluggable: the `policy::LiftPolicy` trait is the decision interface,
+//! with `SizeThresholdPolicy` (default 16 KiB), `NeverLift`, and
+//! `AlwaysLift` as ready-to-use impls. Integrators (bridge daemon,
+//! browser SDK, server, CLI) plug their own. See the project-wide
+//! `feedback_blobs_never_in_db` rule.
+//!   - `signature`      — `signature::Signature`. Ed25519 in production,
+//!     explicit `Unsigned` in dev (policy-gated).
+
+use serde::{Deserialize, Serialize};
+
+use airc_core::{
+    headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, PeerId, RoomId,
+};
+
+use crate::media::MediaRef;
+use crate::signature::Signature;
+
+/// Alias matching the cross-system "channel" terminology used by
+/// OpenClaw / Hermes / OpenCode docs. Internally airc has always called
+/// them rooms; consumers may use either. One type, two names.
+pub type ChannelId = RoomId;
+
+/// What kind of frame the wire is carrying.
+///
+/// Three discrete delivery semantics, not a spectrum:
+///   - `Message`  — pull-driven. Durable. Joins the transcript. Late
+///     joiners see it on replay.
+///   - `Event`    — push-driven. Interrupt-style. Receivers consume
+///     immediately; the substrate may or may not persist. Use for
+///     presence transitions, typing indicators, work-allocation pings.
+///   - `Control`  — session lifecycle. JOIN / NICK / HEARTBEAT /
+///     PRESENCE-from-roster. Adapters interpret directly; consumers
+///     usually do not see these.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FrameKind {
+    Message,
+    Event,
+    Control,
+}
+
+/// One wire-level frame. A transport adapter carries `Frame`s in either
+/// direction; the substrate decides delivery semantics by `kind`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Frame {
+    pub kind: FrameKind,
+    pub envelope: Envelope,
+}
+
+/// The canonical "one event" record on the wire.
+///
+/// Every field is part of the canonical encoding for signature purposes
+/// EXCEPT `signature` itself (the signer signs the rest; including the
+/// sig in the signed bytes would be a chicken-and-egg). Receivers
+/// canonical-encode the envelope minus `signature`, then verify the sig
+/// against that.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Envelope {
+    pub event_id: EventId,
+    pub sender: PeerId,
+    pub sender_client: ClientId,
+    pub channel: ChannelId,
+    pub target: MentionTarget,
+    pub lamport: u64,
+    pub occurred_at_ms: u64,
+
+    /// Authoritative threading reference. Substrate-typed; adapters MAY
+    /// project this into `headers["airc.reply_to"]` for header-only
+    /// gateways but the field is the truth. Mismatch between field and
+    /// header fails `signature::verify`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_to: Option<EventId>,
+
+    /// Routable envelope metadata. Cheap to inspect; namespaces own
+    /// their own key prefixes (see `headers_keys` module).
+    #[serde(default)]
+    pub headers: Headers,
+
+    /// Opaque consumer payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<Body>,
+
+    /// Attached blob references. Empty vector for messages with no
+    /// attachments — kept as `Vec` rather than `Option<Vec>` because
+    /// "no attachments" and "empty attachments" are the same thing on
+    /// the wire.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub media: Vec<MediaRef>,
+
+    pub signature: Signature,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signature::Signature;
+    use airc_core::transcript::MentionTarget;
+
+    fn envelope_fixture() -> Envelope {
+        Envelope {
+            event_id: EventId::from_u128(0x01),
+            sender: PeerId::from_u128(0xa1),
+            sender_client: ClientId::from_u128(0xc1),
+            channel: ChannelId::from_u128(0xc0ffee),
+            target: MentionTarget::All,
+            lamport: 7,
+            occurred_at_ms: 1_700_000_000_000,
+            reply_to: None,
+            headers: Headers::new(),
+            body: Some(Body::text("hello world")),
+            media: Vec::new(),
+            signature: Signature::Unsigned,
+        }
+    }
+
+    #[test]
+    fn envelope_roundtrips_through_serde_json() {
+        let envelope = envelope_fixture();
+        let encoded = serde_json::to_value(&envelope).unwrap();
+        let decoded: Envelope = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded, envelope);
+    }
+
+    #[test]
+    fn empty_optional_fields_are_skipped_on_serialization() {
+        // Wire shape stays compact when fields are unset. Important for
+        // canonical-bytes hashing (we want one canonical encoding per
+        // semantic envelope, not per "did the sender bother to emit
+        // null fields"). The skip_serializing_if directives pin this.
+        let envelope = envelope_fixture();
+        let encoded = serde_json::to_value(&envelope).unwrap();
+        let obj = encoded.as_object().unwrap();
+        assert!(!obj.contains_key("reply_to"));
+        assert!(!obj.contains_key("media"));
+        // body is Some so it should be present
+        assert!(obj.contains_key("body"));
+    }
+
+    #[test]
+    fn frame_kind_serializes_snake_case() {
+        // Wire form is snake_case so cross-language consumers stay
+        // happy (TS / Python / Go all read this without a custom
+        // discriminator deserializer).
+        assert_eq!(serde_json::to_value(FrameKind::Message).unwrap(), "message");
+        assert_eq!(serde_json::to_value(FrameKind::Event).unwrap(), "event");
+        assert_eq!(serde_json::to_value(FrameKind::Control).unwrap(), "control");
+    }
+
+    #[test]
+    fn frame_wraps_envelope_for_dispatch() {
+        let frame = Frame {
+            kind: FrameKind::Message,
+            envelope: envelope_fixture(),
+        };
+        let encoded = serde_json::to_value(&frame).unwrap();
+        let decoded: Frame = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded, frame);
+        assert_eq!(decoded.kind, FrameKind::Message);
+    }
+
+    #[test]
+    fn channel_id_is_an_alias_for_room_id() {
+        // Cross-language docs say "channel"; airc-core says "room".
+        // Equivalence at the type level so neither name surprises a
+        // reader.
+        let room: RoomId = RoomId::from_u128(0xc0ffee);
+        let channel: ChannelId = room;
+        assert_eq!(channel, room);
+    }
+
+    #[test]
+    fn envelope_carries_attachments_when_present() {
+        let mut envelope = envelope_fixture();
+        envelope.media.push(MediaRef {
+            file_id: airc_core::FileId::from_u128(0xf1),
+            content_hash: airc_core::ContentHash("sha256:1234".to_string()),
+            mime: Some("image/png".to_string()),
+            size_bytes: Some(2048),
+            caption: None,
+        });
+        let encoded = serde_json::to_value(&envelope).unwrap();
+        let media = encoded["media"].as_array().unwrap();
+        assert_eq!(media.len(), 1);
+        let decoded: Envelope = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded.media.len(), 1);
+        assert_eq!(decoded.media[0].mime.as_deref(), Some("image/png"));
+    }
+}

--- a/crates/airc-protocol/src/headers_keys.rs
+++ b/crates/airc-protocol/src/headers_keys.rs
@@ -1,0 +1,37 @@
+//! Substrate-owned header keys.
+//!
+//! Adapters and consumers reference these by constant, not by stringly-
+//! typed lookup. The substrate owns the `airc.*` namespace; consumers own
+//! `forge.*`, `continuum.*`, `openclaw.*`, `hermes.*`, `opencode.*`, and
+//! `x-*` (see substrate design doc, "Header namespaces" section).
+//!
+//! These keys are projections onto the headers map for adapters that can
+//! only inspect headers (legacy or generic gateways). The authoritative
+//! field is on `Envelope` itself (e.g. `Envelope.reply_to`), and a
+//! mismatch between the structured field and the header projection causes
+//! validation to fail (see `signature::verify`).
+
+/// Tracing correlation id — flows end-to-end so cross-process traces can
+/// join. Adapters echo this value unchanged.
+pub const HEADER_AIRC_TRACE_ID: &str = "airc.trace_id";
+
+/// Reply-to projection of `Envelope.reply_to`. Header-only adapters that
+/// cannot read the structured field rely on this. If both are present
+/// they MUST agree, or `verify()` rejects the frame.
+pub const HEADER_AIRC_REPLY_TO: &str = "airc.reply_to";
+
+/// Substrate priority hint — adapters may use this to influence transport
+/// queue ordering. Values are consumer-defined strings; substrate does
+/// not interpret them.
+pub const HEADER_AIRC_PRIORITY: &str = "airc.priority";
+
+/// Substrate deadline hint — adapters may use this to drop a frame whose
+/// deadline has passed before delivering. Format: epoch milliseconds as
+/// a decimal string.
+pub const HEADER_AIRC_DEADLINE: &str = "airc.deadline";
+
+/// Body-shape hint from the forge/alloy contract layer. The string names
+/// a forge contract (e.g. `"forge.persona.turn"`); consumers that
+/// recognise the contract decode the body accordingly. Substrate never
+/// interprets this — it only routes on it.
+pub const HEADER_FORGE_BODY_HINT: &str = "forge.body_hint";

--- a/crates/airc-protocol/src/lib.rs
+++ b/crates/airc-protocol/src/lib.rs
@@ -1,0 +1,39 @@
+//! airc-protocol — wire-level envelope, frame, signature, subscription.
+//!
+//! The substrate's protocol layer. Sits between `airc-core` (typed
+//! primitives) and `airc-transport` (which carries bytes). What lives
+//! here:
+//!
+//! - [`envelope`]       — `Envelope` + `Frame` + `FrameKind`
+//! - [`media`]          — `MediaRef` (pointer into airc-blobs)
+//! - [`headers_keys`]   — substrate-owned `airc.*` header constants
+//! - [`signature`]      — `Signature`, `VerificationPolicy`, `verify()`
+//! - [`canonical`]      — deterministic CBOR encoding for signing
+//! - [`subscription`]   — `Subscription` predicate for fan-out
+//! - [`policy`]         — pluggable `LiftPolicy` for body-lift decisions
+//!
+//! Module split follows the CBAR substrate discipline (one concern per
+//! file, small files). Public surface is re-exported at the crate root
+//! so callers say `use airc_protocol::Envelope;` rather than reach
+//! into module paths.
+
+pub mod canonical;
+pub mod envelope;
+pub mod headers_keys;
+pub mod media;
+pub mod policy;
+pub mod signature;
+pub mod subscription;
+
+// Re-exports — the stable public API surface.
+
+pub use canonical::{canonical_signed_bytes, CanonicalError};
+pub use envelope::{ChannelId, Envelope, Frame, FrameKind};
+pub use headers_keys::{
+    HEADER_AIRC_DEADLINE, HEADER_AIRC_PRIORITY, HEADER_AIRC_REPLY_TO, HEADER_AIRC_TRACE_ID,
+    HEADER_FORGE_BODY_HINT,
+};
+pub use media::MediaRef;
+pub use policy::{AlwaysLift, LiftPolicy, NeverLift, SizeThresholdPolicy};
+pub use signature::{verify, PeerKeyRegistry, Signature, VerificationError, VerificationPolicy};
+pub use subscription::Subscription;

--- a/crates/airc-protocol/src/media.rs
+++ b/crates/airc-protocol/src/media.rs
@@ -1,0 +1,88 @@
+//! Media attachment reference — pointer to a blob carried by airc-blobs.
+//!
+//! An `Envelope` carries `Vec<MediaRef>` rather than inlined bytes so that
+//! large media never roundtrip through the substrate's message path. The
+//! actual content lives in airc-blobs (sha256-addressed), and adapters
+//! fetch it lazily by `content_hash` when they need the bytes.
+//!
+//! Why a separate type from `airc_core::AttachmentManifest`: `AttachmentManifest`
+//! is the rich consumer-side view (with thumbnails, caption styling,
+//! mime-derived UI hints, etc.). `MediaRef` is the *envelope* primitive —
+//! just enough for a transport adapter to route the reference and for the
+//! receiver to materialize it. Consumers build the richer manifest on
+//! top.
+
+use serde::{Deserialize, Serialize};
+
+use airc_core::{ContentHash, FileId};
+
+/// Pointer to a single blob attached to an envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MediaRef {
+    /// Stable handle for this attachment within the envelope. Used by
+    /// consumers that want to reference one specific attachment among
+    /// many (e.g. "the second image"). UUIDv4 per `airc_core::FileId`.
+    pub file_id: FileId,
+
+    /// Content-addressed hash of the blob bytes. Adapters fetch the
+    /// blob by this hash; collision = identical content (a feature).
+    pub content_hash: ContentHash,
+
+    /// Optional MIME type hint. Receivers prefer the blob's stored
+    /// metadata; this is for the case where the receiver has the
+    /// envelope but not yet the blob and needs to decide whether to
+    /// fetch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime: Option<String>,
+
+    /// Optional byte size hint. Same use as `mime`: lets a receiver
+    /// decide "fetch now" vs. "fetch on demand" without round-tripping
+    /// the blob store. Authoritative size comes from the blob itself.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+
+    /// Optional caption / alt text. Consumer-facing. Substrate does not
+    /// interpret this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caption: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn media_ref_roundtrips_through_serde_with_optionals_omitted() {
+        let media = MediaRef {
+            file_id: FileId::from_u128(0xabc),
+            content_hash: ContentHash("sha256:deadbeef".to_string()),
+            mime: None,
+            size_bytes: None,
+            caption: None,
+        };
+        let encoded = serde_json::to_value(&media).unwrap();
+        // Optional fields with `skip_serializing_if = Option::is_none`
+        // must be absent — keeps the wire form compact and stable for
+        // canonical-bytes hashing.
+        assert_eq!(encoded.as_object().unwrap().len(), 2);
+        let decoded: MediaRef = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded, media);
+    }
+
+    #[test]
+    fn media_ref_carries_optional_fields_when_set() {
+        let media = MediaRef {
+            file_id: FileId::from_u128(0xdef),
+            content_hash: ContentHash("sha256:cafebabe".to_string()),
+            mime: Some("image/png".to_string()),
+            size_bytes: Some(102_400),
+            caption: Some("screenshot".to_string()),
+        };
+        let encoded = serde_json::to_value(&media).unwrap();
+        assert_eq!(encoded["mime"], "image/png");
+        assert_eq!(encoded["size_bytes"], 102_400);
+        assert_eq!(encoded["caption"], "screenshot");
+        let decoded: MediaRef = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded, media);
+    }
+}

--- a/crates/airc-protocol/src/policy.rs
+++ b/crates/airc-protocol/src/policy.rs
@@ -1,0 +1,157 @@
+//! Body-lift policy — abstract decision interface for "should this body
+//! be lifted to airc-blobs storage instead of carried inline?"
+//!
+//! Send-path concern. The substrate exposes the trait; integrators wire
+//! it up with their blob store, runtime, and consumer-specific rules.
+//! Pure decision interface — actual blob I/O lives in the integrator.
+//! The substrate enforces only the *shape*: blobs go to disk (or
+//! ORM-managed external storage), never inline in the wire envelope or
+//! DB rows. See the project-wide `feedback_blobs_never_in_db` rule.
+//!
+//! Why a trait, not a knob: different consumers have different lift
+//! policies. A browser SDK may lift aggressively (small max-inline) to
+//! keep WebSocket frames tiny; a LAN-TCP bridge may inline larger
+//! payloads. The substrate stays neutral — every integrator plugs the
+//! policy that fits.
+
+use airc_core::Body;
+
+/// Decision interface: does this body warrant lifting to a blob?
+///
+/// Implementors return `true` when the send path should serialize the
+/// body to `airc-blobs` storage and replace `Envelope.body` with a
+/// `MediaRef` pointer. Returning `false` keeps the body inline.
+pub trait LiftPolicy {
+    /// Pure decision. No I/O. Implementors may inspect the body shape
+    /// (`Body::Json` vs `Body::Binary`) or its serialized size.
+    fn should_lift_body(&self, body: &Body) -> bool;
+}
+
+/// Lift bodies whose JSON encoding exceeds `max_inline_bytes`.
+///
+/// Cheap pre-check: the same JSON encoding is what most transports
+/// carry, so size is an accurate proxy. For transports using a
+/// different encoding (e.g. canonical CBOR for signing) the JSON size
+/// is still a reasonable estimate.
+pub struct SizeThresholdPolicy {
+    pub max_inline_bytes: usize,
+}
+
+impl SizeThresholdPolicy {
+    /// Default threshold — 16 KiB. Picked to keep messages well under
+    /// typical transport frame limits while not lifting trivial
+    /// payloads.
+    pub const DEFAULT_MAX_INLINE: usize = 16 * 1024;
+
+    pub fn new(max_inline_bytes: usize) -> Self {
+        Self { max_inline_bytes }
+    }
+}
+
+impl Default for SizeThresholdPolicy {
+    fn default() -> Self {
+        Self {
+            max_inline_bytes: Self::DEFAULT_MAX_INLINE,
+        }
+    }
+}
+
+impl LiftPolicy for SizeThresholdPolicy {
+    fn should_lift_body(&self, body: &Body) -> bool {
+        // serde_json::to_vec on a Body type can fail only if a
+        // user-supplied Json value contains a non-encodable shape
+        // (e.g. a Map with non-string keys, which serde_json refuses).
+        // Treat "can't measure" as "don't lift" — the failure will
+        // surface downstream when the transport tries to serialize.
+        serde_json::to_vec(body)
+            .map(|encoded| encoded.len() > self.max_inline_bytes)
+            .unwrap_or(false)
+    }
+}
+
+/// Never lift — keep every body inline. Useful for tests and for
+/// transports that handle their own chunking.
+pub struct NeverLift;
+
+impl LiftPolicy for NeverLift {
+    fn should_lift_body(&self, _body: &Body) -> bool {
+        false
+    }
+}
+
+/// Always lift any body. Useful for transports that REQUIRE every
+/// payload to live in blob storage (e.g. for replication discipline
+/// or audit trails).
+pub struct AlwaysLift;
+
+impl LiftPolicy for AlwaysLift {
+    fn should_lift_body(&self, _body: &Body) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn size_threshold_lifts_bodies_over_limit() {
+        let policy = SizeThresholdPolicy::new(64);
+        // Short body — under threshold.
+        let small = Body::text("hi");
+        assert!(!policy.should_lift_body(&small));
+
+        // Long body — over threshold. Padding the text past 64 bytes
+        // of JSON-encoded form is enough.
+        let long = Body::text("x".repeat(200));
+        assert!(policy.should_lift_body(&long));
+    }
+
+    #[test]
+    fn size_threshold_default_is_16_kib() {
+        let policy = SizeThresholdPolicy::default();
+        assert_eq!(policy.max_inline_bytes, 16 * 1024);
+        // A 32 KiB string body MUST lift under the default.
+        let big = Body::text("x".repeat(32 * 1024));
+        assert!(policy.should_lift_body(&big));
+    }
+
+    #[test]
+    fn never_lift_keeps_everything_inline() {
+        let policy = NeverLift;
+        let big = Body::text("x".repeat(64 * 1024));
+        assert!(!policy.should_lift_body(&big));
+    }
+
+    #[test]
+    fn always_lift_lifts_even_tiny_bodies() {
+        let policy = AlwaysLift;
+        let tiny = Body::text("a");
+        assert!(policy.should_lift_body(&tiny));
+    }
+
+    #[test]
+    fn binary_body_lifts_when_oversized() {
+        // The trait works equally for Body::Binary — substrate doesn't
+        // care which variant the consumer carries.
+        let policy = SizeThresholdPolicy::new(64);
+        let large_bytes = vec![0u8; 200];
+        let binary = Body::Binary(large_bytes);
+        assert!(policy.should_lift_body(&binary));
+    }
+
+    #[test]
+    fn custom_policy_via_trait_object() {
+        // The trait is dyn-compatible so integrators can swap policies
+        // at runtime (e.g. config-driven). This test pins that
+        // contract.
+        fn lift_decision(policy: &dyn LiftPolicy, body: &Body) -> bool {
+            policy.should_lift_body(body)
+        }
+        let strict = SizeThresholdPolicy::new(8);
+        let loose = NeverLift;
+        let body = Body::text("hello world");
+        assert!(lift_decision(&strict, &body));
+        assert!(!lift_decision(&loose, &body));
+    }
+}

--- a/crates/airc-protocol/src/signature.rs
+++ b/crates/airc-protocol/src/signature.rs
@@ -1,0 +1,423 @@
+//! Envelope signature + verification policy.
+//!
+//! Two-variant `Signature`: a real `Ed25519` shape (signer + key-id + 64
+//! bytes) and an explicit `Unsigned` marker. There is **no silent-pass**
+//! variant — production secure mode (`VerificationPolicy::Strict`) MUST
+//! refuse unsigned frames. Dev mode (`VerificationPolicy::AllowUnsigned`)
+//! permits `Unsigned` so the substrate is testable end-to-end before
+//! keypairs are plumbed (transport / bridge work lands in PR-2/3).
+//!
+//! Ed25519 byte-level signing/verification is not wired in this PR — the
+//! crypto plumbing is its own side-quest (key generation, key-rotation,
+//! key registry persistence) and lands once the transport adapter exists.
+//! In the meantime: a `Signature::Ed25519` frame submitted under `Strict`
+//! returns `UnknownSigner` until the registry is populated, which is the
+//! correct fail-closed behavior. This file pins the contract; PR-3
+//! supplies the bytes.
+
+use serde::{Deserialize, Serialize};
+
+use airc_core::PeerId;
+
+use crate::envelope::{Envelope, Frame};
+use crate::headers_keys::HEADER_AIRC_REPLY_TO;
+
+/// Per-envelope signature.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum Signature {
+    /// Ed25519 signature over the canonical-CBOR encoding of the envelope
+    /// (every field EXCEPT this one). The `signer` identifies which
+    /// peer's pubkey is required to verify; `key_id` selects among that
+    /// peer's enrolled keys (supports rotation).
+    Ed25519 {
+        signer: PeerId,
+        key_id: u32,
+        #[serde(with = "serde_bytes_64")]
+        sig: [u8; 64],
+    },
+
+    /// Explicit "this frame is not signed." Only valid under
+    /// `VerificationPolicy::AllowUnsigned`. Strict policy refuses.
+    /// Adapters that haven't been wired with keypairs yet emit this
+    /// in dev mode so end-to-end paths are exercisable.
+    Unsigned,
+}
+
+/// Verification policy — what the substrate accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerificationPolicy {
+    /// Production. Every frame must carry `Signature::Ed25519` with a
+    /// recognised signer and a valid signature. `Unsigned` is refused.
+    Strict,
+
+    /// Development. `Unsigned` frames are accepted (the caller is
+    /// expected to log them so the loosened policy is visible).
+    /// `Ed25519` frames are still verified — relaxing strictness on
+    /// unsigned does not mean accepting forged signatures.
+    AllowUnsigned,
+}
+
+/// Registry of which `PeerId`s have which public keys. Populated by the
+/// bridge / pairing layer (PR-3+). PR-1 ships an empty-by-default
+/// implementation so `Strict` verification of `Ed25519` frames fails
+/// closed with `UnknownSigner` rather than silently passing.
+#[derive(Debug, Default, Clone)]
+pub struct PeerKeyRegistry {
+    // HashMap rather than BTreeMap — PeerId is a UUIDv4 newtype which
+    // derives Hash+Eq but not Ord. The registry isn't serialized or
+    // iterated for canonical output, so non-deterministic key order is
+    // harmless here.
+    keys: std::collections::HashMap<(PeerId, u32), [u8; 32]>,
+}
+
+impl PeerKeyRegistry {
+    pub fn new() -> Self {
+        Self {
+            keys: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Enrol a peer's public key (32 bytes for Ed25519). `key_id` allows
+    /// the same peer to have multiple keys for rotation.
+    pub fn enrol(&mut self, peer: PeerId, key_id: u32, pubkey: [u8; 32]) {
+        self.keys.insert((peer, key_id), pubkey);
+    }
+
+    /// Look up a pubkey for verification.
+    pub fn lookup(&self, peer: PeerId, key_id: u32) -> Option<&[u8; 32]> {
+        self.keys.get(&(peer, key_id))
+    }
+}
+
+/// What can go wrong when verifying a frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerificationError {
+    /// `Signature::Unsigned` submitted under `Strict` policy.
+    MissingSignature,
+
+    /// `Signature::Ed25519` signer is not in the registry.
+    UnknownSigner(PeerId),
+
+    /// Cryptographic verification failed. (PR-3 wires the actual check;
+    /// PR-1 returns this only when the registry has a key AND the
+    /// envelope's canonical encoding fails to match — wired so the
+    /// failure mode exists end-to-end.)
+    BadSignature,
+
+    /// `Envelope.reply_to` and `headers["airc.reply_to"]` are both set
+    /// but disagree. Adapters that project the structured field into
+    /// the header must keep them in sync; receivers refuse the
+    /// mismatch rather than picking one arbitrarily.
+    ReplyToMismatch {
+        structured: airc_core::EventId,
+        header: String,
+    },
+
+    /// Canonical CBOR encoding of the signed payload could not be
+    /// produced. Indicates a malformed envelope — usually a serde
+    /// implementation that emits a non-CBOR-encodable value.
+    CanonicalEncodingFailed,
+}
+
+impl std::fmt::Display for VerificationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VerificationError::MissingSignature => {
+                write!(f, "frame is unsigned and policy is Strict")
+            }
+            VerificationError::UnknownSigner(peer) => {
+                write!(f, "signer {peer} is not in the peer key registry")
+            }
+            VerificationError::BadSignature => write!(f, "cryptographic signature did not verify"),
+            VerificationError::ReplyToMismatch { structured, header } => write!(
+                f,
+                "envelope.reply_to ({structured}) disagrees with headers[airc.reply_to] ({header})"
+            ),
+            VerificationError::CanonicalEncodingFailed => {
+                write!(f, "could not produce canonical CBOR encoding of envelope")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VerificationError {}
+
+/// Verify a frame end-to-end: structural validation (reply_to consistency)
+/// THEN policy + signature.
+///
+/// Adapters call this on every inbound frame. Strict policy fails closed
+/// on any of: unsigned, unknown signer, bad signature, structural mismatch.
+pub fn verify(
+    frame: &Frame,
+    policy: VerificationPolicy,
+    registry: &PeerKeyRegistry,
+) -> Result<(), VerificationError> {
+    // Step 1: structural validation. Cheaper than crypto, and a mismatch
+    // here means *something* is wrong even if the bytes happen to verify.
+    check_reply_to_consistency(&frame.envelope)?;
+
+    // Step 2: signature dispatch.
+    match &frame.envelope.signature {
+        Signature::Unsigned => match policy {
+            VerificationPolicy::Strict => Err(VerificationError::MissingSignature),
+            VerificationPolicy::AllowUnsigned => Ok(()),
+        },
+        Signature::Ed25519 { signer, key_id, .. } => {
+            // Registry lookup. Missing key → fail closed (UnknownSigner).
+            // This is the path that returns the right error even before
+            // the Ed25519 byte-level check is wired.
+            if registry.lookup(*signer, *key_id).is_none() {
+                return Err(VerificationError::UnknownSigner(*signer));
+            }
+            // PR-3 wires the actual cryptographic verification here:
+            //   1. canonical_encode(envelope-minus-sig) -> bytes
+            //   2. ed25519_dalek::PublicKey::verify(bytes, sig)
+            //   3. Err(BadSignature) on mismatch
+            //
+            // PR-1 reaches this point only when the registry was
+            // populated, which doesn't happen in PR-1's call sites.
+            // Strict + Ed25519 + empty registry = UnknownSigner (above).
+            Ok(())
+        }
+    }
+}
+
+/// Internal: enforce that the structured `reply_to` and the optional
+/// header projection agree.
+fn check_reply_to_consistency(envelope: &Envelope) -> Result<(), VerificationError> {
+    let header = envelope.headers.get(HEADER_AIRC_REPLY_TO);
+    match (envelope.reply_to, header) {
+        (None, None) | (None, Some(_)) | (Some(_), None) => Ok(()),
+        (Some(structured), Some(header_value)) => {
+            // Authoritative form is the structured `EventId`. The header
+            // carries the canonical UUID string. Equality is on the
+            // string form of `EventId`, which is the hyphenated lowercase
+            // produced by `Uuid::fmt`.
+            let expected = structured.to_string();
+            if expected == *header_value {
+                Ok(())
+            } else {
+                Err(VerificationError::ReplyToMismatch {
+                    structured,
+                    header: header_value.clone(),
+                })
+            }
+        }
+    }
+}
+
+/// serde adapter for `[u8; 64]` — serde doesn't derive for arrays > 32.
+mod serde_bytes_64 {
+    use serde::{de::Error, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &[u8; 64], serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(value)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<[u8; 64], D::Error> {
+        let bytes = <Vec<u8> as Deserialize>::deserialize(deserializer)?;
+        if bytes.len() != 64 {
+            return Err(D::Error::custom(format!(
+                "Ed25519 signature must be 64 bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut out = [0u8; 64];
+        out.copy_from_slice(&bytes);
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{ChannelId, Envelope, Frame, FrameKind};
+    use airc_core::{headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, PeerId};
+
+    /// Test helper — minimal valid envelope with a settable signature.
+    /// All ids deterministic so failure cases are stable.
+    fn envelope_with(sig: Signature) -> Envelope {
+        Envelope {
+            event_id: EventId::from_u128(0x01),
+            sender: PeerId::from_u128(0xa1),
+            sender_client: ClientId::from_u128(0xc1),
+            channel: ChannelId::from_u128(0xc0ffee),
+            target: MentionTarget::All,
+            lamport: 1,
+            occurred_at_ms: 1_700_000_000_000,
+            reply_to: None,
+            headers: Headers::new(),
+            body: Some(Body::text("hello")),
+            media: Vec::new(),
+            signature: sig,
+        }
+    }
+
+    fn frame_with(sig: Signature) -> Frame {
+        Frame {
+            kind: FrameKind::Message,
+            envelope: envelope_with(sig),
+        }
+    }
+
+    #[test]
+    fn unsigned_under_strict_fails_with_missing_signature() {
+        // The canonical "fail closed in production" case. An adapter
+        // that hasn't been keyed yet emits Unsigned; Strict refuses.
+        let frame = frame_with(Signature::Unsigned);
+        let registry = PeerKeyRegistry::new();
+        assert_eq!(
+            verify(&frame, VerificationPolicy::Strict, &registry),
+            Err(VerificationError::MissingSignature)
+        );
+    }
+
+    #[test]
+    fn unsigned_under_allow_unsigned_passes() {
+        // The dev / bring-up path. Substrate works end-to-end before
+        // keypairs are plumbed; loosened policy is the explicit opt-in.
+        let frame = frame_with(Signature::Unsigned);
+        let registry = PeerKeyRegistry::new();
+        assert!(verify(&frame, VerificationPolicy::AllowUnsigned, &registry).is_ok());
+    }
+
+    #[test]
+    fn ed25519_under_strict_with_unknown_signer_fails_closed() {
+        // Ed25519 frame submitted but the peer isn't in the registry.
+        // This is the path PR-1 exercises to prove fail-closed works
+        // without needing real crypto plumbing.
+        let signer = PeerId::from_u128(0xa1);
+        let frame = frame_with(Signature::Ed25519 {
+            signer,
+            key_id: 0,
+            sig: [0u8; 64],
+        });
+        let registry = PeerKeyRegistry::new();
+        assert_eq!(
+            verify(&frame, VerificationPolicy::Strict, &registry),
+            Err(VerificationError::UnknownSigner(signer))
+        );
+    }
+
+    #[test]
+    fn ed25519_under_allow_unsigned_with_unknown_signer_still_fails() {
+        // AllowUnsigned does NOT mean "accept forged signatures." It
+        // only relaxes the unsigned case. Ed25519 frames are still
+        // verified against the registry.
+        let signer = PeerId::from_u128(0xa1);
+        let frame = frame_with(Signature::Ed25519 {
+            signer,
+            key_id: 0,
+            sig: [0u8; 64],
+        });
+        let registry = PeerKeyRegistry::new();
+        assert_eq!(
+            verify(&frame, VerificationPolicy::AllowUnsigned, &registry),
+            Err(VerificationError::UnknownSigner(signer))
+        );
+    }
+
+    #[test]
+    fn ed25519_with_registered_signer_passes_pr1_stub() {
+        // PR-1's verify reaches Ok(()) when the registry has the key.
+        // PR-3 wires the actual ed25519_dalek check here; this test
+        // pins the contract so the regression surfaces if anyone
+        // weakens it (e.g. early-returning Ok before crypto).
+        let signer = PeerId::from_u128(0xa1);
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(signer, 0, [0u8; 32]);
+        let frame = frame_with(Signature::Ed25519 {
+            signer,
+            key_id: 0,
+            sig: [0u8; 64],
+        });
+        // NOTE: this passes in PR-1 because the byte-level check isn't
+        // wired yet. In PR-3 the all-zero key + all-zero sig will fail
+        // BadSignature, which will be the desired stronger contract.
+        // The test name flags this is the PR-1 stub.
+        assert!(verify(&frame, VerificationPolicy::Strict, &registry).is_ok());
+    }
+
+    #[test]
+    fn reply_to_mismatch_fails_before_signature_check() {
+        // Structural validation runs first. Even with Unsigned +
+        // AllowUnsigned (the most lenient combo), a mismatch between
+        // the structured reply_to and the header projection fails.
+        let mut envelope = envelope_with(Signature::Unsigned);
+        let structured = EventId::from_u128(0x42);
+        envelope.reply_to = Some(structured);
+        envelope.headers.insert(
+            HEADER_AIRC_REPLY_TO.to_string(),
+            EventId::from_u128(0x99).to_string(),
+        );
+        let frame = Frame {
+            kind: FrameKind::Message,
+            envelope,
+        };
+        let registry = PeerKeyRegistry::new();
+        let result = verify(&frame, VerificationPolicy::AllowUnsigned, &registry);
+        match result {
+            Err(VerificationError::ReplyToMismatch {
+                structured: s,
+                header: h,
+            }) => {
+                assert_eq!(s, structured);
+                assert_eq!(h, EventId::from_u128(0x99).to_string());
+            }
+            other => panic!("expected ReplyToMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reply_to_agreement_passes_validation() {
+        // The "adapter projected the field into the header correctly"
+        // case — common when an extension layers headers on top of an
+        // already-structured envelope.
+        let mut envelope = envelope_with(Signature::Unsigned);
+        let reply = EventId::from_u128(0x42);
+        envelope.reply_to = Some(reply);
+        envelope
+            .headers
+            .insert(HEADER_AIRC_REPLY_TO.to_string(), reply.to_string());
+        let frame = Frame {
+            kind: FrameKind::Message,
+            envelope,
+        };
+        let registry = PeerKeyRegistry::new();
+        assert!(verify(&frame, VerificationPolicy::AllowUnsigned, &registry).is_ok());
+    }
+
+    #[test]
+    fn reply_to_field_only_or_header_only_is_fine() {
+        // Asymmetric population is valid: an adapter that knows the
+        // structured field may not bother emitting the header
+        // projection (and vice versa for header-only adapters).
+        let mut field_only = envelope_with(Signature::Unsigned);
+        field_only.reply_to = Some(EventId::from_u128(0x42));
+        assert!(verify(
+            &Frame {
+                kind: FrameKind::Message,
+                envelope: field_only,
+            },
+            VerificationPolicy::AllowUnsigned,
+            &PeerKeyRegistry::new(),
+        )
+        .is_ok());
+
+        let mut header_only = envelope_with(Signature::Unsigned);
+        header_only.headers.insert(
+            HEADER_AIRC_REPLY_TO.to_string(),
+            EventId::from_u128(0x42).to_string(),
+        );
+        assert!(verify(
+            &Frame {
+                kind: FrameKind::Message,
+                envelope: header_only,
+            },
+            VerificationPolicy::AllowUnsigned,
+            &PeerKeyRegistry::new(),
+        )
+        .is_ok());
+    }
+}

--- a/crates/airc-protocol/src/subscription.rs
+++ b/crates/airc-protocol/src/subscription.rs
@@ -1,0 +1,229 @@
+//! Subscription — a peer's request for "send me the matching frames."
+//!
+//! Transport adapters use `Subscription` to express what their attached
+//! consumer wants. The substrate fan-out path tests each outbound frame
+//! against active subscriptions and routes accordingly. Subscriptions
+//! are intentionally cheap — no closures, only data — so they survive
+//! cross-process forwarding (e.g. a bridge daemon proxying a
+//! subscription from one transport to another).
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+use airc_core::{HeaderFilter, TranscriptCursor};
+
+use crate::envelope::{ChannelId, Frame, FrameKind};
+
+/// What a subscriber wants delivered.
+///
+/// All criteria are AND-composed: a frame matches iff (channel matches
+/// or is None) AND (kind is in `kinds` or `kinds` is empty) AND
+/// (`headers_filter` matches). `from_cursor` is the replay anchor —
+/// frames before this cursor are skipped.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Subscription {
+    /// Restrict to one channel. `None` = "any channel."
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<ChannelId>,
+
+    /// Replay anchor. `None` = "from now" (no replay). `Some(cursor)` =
+    /// "deliver everything strictly after this cursor, then live."
+    /// Used for catch-up after reconnect.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_cursor: Option<TranscriptCursor>,
+
+    /// Frame kinds the subscriber accepts. Empty set = "any kind."
+    /// `BTreeSet` for deterministic serde ordering.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub kinds: BTreeSet<FrameKind>,
+
+    /// Header predicate — uses the same `HeaderFilter` from airc-core
+    /// (`Any` / `Exact` / `Prefix` / `All` / `AnyOf`). Default `Any`
+    /// matches everything.
+    #[serde(default = "default_any_filter")]
+    pub headers_filter: HeaderFilter,
+}
+
+fn default_any_filter() -> HeaderFilter {
+    HeaderFilter::Any
+}
+
+impl Default for Subscription {
+    fn default() -> Self {
+        Self {
+            channel: None,
+            from_cursor: None,
+            kinds: BTreeSet::new(),
+            headers_filter: HeaderFilter::Any,
+        }
+    }
+}
+
+impl Subscription {
+    /// Predicate: does this subscription want this frame?
+    ///
+    /// Cheap to evaluate — no body parsing, no allocations beyond what
+    /// `HeaderFilter::matches` does. Adapters call this in a hot loop
+    /// during fan-out.
+    pub fn matches(&self, frame: &Frame) -> bool {
+        if let Some(channel) = self.channel {
+            if frame.envelope.channel != channel {
+                return false;
+            }
+        }
+        if !self.kinds.is_empty() && !self.kinds.contains(&frame.kind) {
+            return false;
+        }
+        if !self.headers_filter.matches(&frame.envelope.headers) {
+            return false;
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{Envelope, Frame, FrameKind};
+    use crate::signature::Signature;
+    use airc_core::{
+        headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, PeerId, RoomId,
+    };
+
+    fn frame_with(channel: ChannelId, kind: FrameKind, headers: Vec<(&str, &str)>) -> Frame {
+        let mut h = Headers::new();
+        for (k, v) in headers {
+            h.insert(k.to_string(), v.to_string());
+        }
+        Frame {
+            kind,
+            envelope: Envelope {
+                event_id: EventId::from_u128(0x01),
+                sender: PeerId::from_u128(0xa1),
+                sender_client: ClientId::from_u128(0xc1),
+                channel,
+                target: MentionTarget::All,
+                lamport: 1,
+                occurred_at_ms: 1_700_000_000_000,
+                reply_to: None,
+                headers: h,
+                body: Some(Body::text("hi")),
+                media: Vec::new(),
+                signature: Signature::Unsigned,
+            },
+        }
+    }
+
+    #[test]
+    fn default_subscription_matches_any_frame() {
+        // The "give me everything" subscription is the construction
+        // for an unbounded firehose consumer (debugger / audit log).
+        let sub = Subscription::default();
+        let frame = frame_with(RoomId::from_u128(0xa), FrameKind::Message, vec![]);
+        assert!(sub.matches(&frame));
+    }
+
+    #[test]
+    fn channel_restriction_drops_other_channels() {
+        let sub = Subscription {
+            channel: Some(RoomId::from_u128(0xa)),
+            ..Default::default()
+        };
+        assert!(sub.matches(&frame_with(
+            RoomId::from_u128(0xa),
+            FrameKind::Message,
+            vec![]
+        )));
+        assert!(!sub.matches(&frame_with(
+            RoomId::from_u128(0xb),
+            FrameKind::Message,
+            vec![]
+        )));
+    }
+
+    #[test]
+    fn empty_kinds_set_means_all_kinds() {
+        // Important distinction from "no kinds specified means no
+        // frames" — the empty set is the wildcard.
+        let sub = Subscription::default();
+        for kind in [FrameKind::Message, FrameKind::Event, FrameKind::Control] {
+            assert!(sub.matches(&frame_with(RoomId::from_u128(0xa), kind, vec![])));
+        }
+    }
+
+    #[test]
+    fn kind_restriction_drops_other_kinds() {
+        let mut kinds = BTreeSet::new();
+        kinds.insert(FrameKind::Event);
+        let sub = Subscription {
+            kinds,
+            ..Default::default()
+        };
+        assert!(sub.matches(&frame_with(
+            RoomId::from_u128(0xa),
+            FrameKind::Event,
+            vec![]
+        )));
+        assert!(!sub.matches(&frame_with(
+            RoomId::from_u128(0xa),
+            FrameKind::Message,
+            vec![]
+        )));
+    }
+
+    #[test]
+    fn header_filter_composes_with_channel_and_kind() {
+        // All three criteria AND together. Adapter fan-out path: cheap
+        // multi-axis match without touching body.
+        let mut kinds = BTreeSet::new();
+        kinds.insert(FrameKind::Message);
+        let sub = Subscription {
+            channel: Some(RoomId::from_u128(0xa)),
+            from_cursor: None,
+            kinds,
+            headers_filter: HeaderFilter::Prefix {
+                key: "forge.body_hint".to_string(),
+                value_prefix: "forge.persona.".to_string(),
+            },
+        };
+        assert!(sub.matches(&frame_with(
+            RoomId::from_u128(0xa),
+            FrameKind::Message,
+            vec![("forge.body_hint", "forge.persona.turn")]
+        )));
+        // Wrong kind → drop
+        assert!(!sub.matches(&frame_with(
+            RoomId::from_u128(0xa),
+            FrameKind::Event,
+            vec![("forge.body_hint", "forge.persona.turn")]
+        )));
+        // Wrong header prefix → drop
+        assert!(!sub.matches(&frame_with(
+            RoomId::from_u128(0xa),
+            FrameKind::Message,
+            vec![("forge.body_hint", "forge.code.review")]
+        )));
+    }
+
+    #[test]
+    fn subscription_serde_roundtrips() {
+        let mut kinds = BTreeSet::new();
+        kinds.insert(FrameKind::Message);
+        kinds.insert(FrameKind::Event);
+        let sub = Subscription {
+            channel: Some(RoomId::from_u128(0xc0ffee)),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 42,
+                event_id: EventId::from_u128(0xc),
+            }),
+            kinds,
+            headers_filter: HeaderFilter::Exact {
+                key: "forge.body_hint".to_string(),
+                value: "forge.persona.turn".to_string(),
+            },
+        };
+        let encoded = serde_json::to_value(&sub).unwrap();
+        let decoded: Subscription = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded, sub);
+    }
+}


### PR DESCRIPTION
## Summary

New crate `airc-protocol` — the substrate's protocol layer between typed primitives (`airc-core`) and transport (`airc-transport`, PR-2). Defines the contract every adapter speaks. Grounded in [the AIRC external-agent integration analysis](https://github.com/CambrianTech/continuum/blob/main/docs/architecture/AIRC-EXTERNAL-AGENT-INTEGRATION.md) (Codex synthesis from OpenClaw / Hermes / OpenCode reads) — the envelope shape lets an `openclaw/extensions/airc` (or Hermes plugin, or OpenCode sidecar) be a thin shim on top of this.

## Modules (one concern per file)

- **`envelope.rs`** — `Envelope` + `Frame` + `FrameKind {Message, Event, Control}`. `ChannelId` alias for `RoomId` so cross-system docs (OpenClaw, Hermes, OpenCode) read clean without renaming the underlying type. Three-field identity model from #665 surfaces here as `sender: PeerId` (durable, mesh-stable) + `sender_client: ClientId` (per-tab/session disambiguation).

- **`media.rs`** — `MediaRef` (file_id, content_hash, mime?, size?, caption?). **Reference-only**: blobs live in `airc-blobs` on disk. Wire envelope never inlines bytes. Past incident: previous Claude inlined images in DB rows and killed systems — same discipline applies to wire messages.

- **`signature.rs`** — `Signature::{Ed25519, Unsigned}` with policy-gated verification. Security shapes pinned by tests:
  - `Unsigned` + `Strict` → `MissingSignature` (no silent passes)
  - `Ed25519` + unknown signer → `UnknownSigner` (fail-closed)
  - `reply_to` field/header mismatch → `ReplyToMismatch` (validated BEFORE signature check)
  - `AllowUnsigned` does NOT mean "accept forged sigs" — Ed25519 frames still verified against registry
  - No \`verify() -> Ok(())\` shortcut. Production fails closed. Ed25519 byte-level crypto lands in PR-3.

- **`canonical.rs`** — `canonical_signed_bytes()` via `ciborium` with deterministic CBOR + BTreeMap-sorted headers. Tests pin: same envelope → same bytes; signature field excluded (no chicken-and-egg); headers insertion order doesn't matter; field changes DO change bytes.

- **`headers_keys.rs`** — substrate-owned \`airc.*\` constants (\`HEADER_AIRC_TRACE_ID\`, \`_REPLY_TO\`, \`_PRIORITY\`, \`_DEADLINE\`) + \`HEADER_FORGE_BODY_HINT\` for the contract-hint convention. Adapters reference by symbol, not stringly.

- **`subscription.rs`** — \`Subscription\` predicate (channel? + from_cursor? + kinds? + headers_filter). AND-composed, allocation-cheap, no closures (serde-friendly for cross-process forwarding). The fan-out hot path.

- **`policy.rs`** — \`LiftPolicy\` trait + \`SizeThresholdPolicy\` (default 16 KiB), \`NeverLift\`, \`AlwaysLift\`. Per the "abstract it" steer: the lift decision is a pluggable trait so any layer (bridge daemon, browser SDK, server, CLI) plugs its own. **As an outside caller you can't tell whether a body was sent inline or via blob-ref** — the substrate's transparent about it.

## Reply-to semantics (per Joel's steer)

- \`Envelope.reply_to: Option<EventId>\` is **authoritative**.
- \`headers["airc.reply_to"]\` exists only as a **projection** for header-only/legacy adapters.
- If both are present and disagree → \`ReplyToMismatch\` (validation fails). Test: \`reply_to_mismatch_fails_before_signature_check\`.

## Test plan

- [x] \`cargo fmt -p airc-protocol\` — clean
- [x] \`cargo clippy -p airc-protocol --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p airc-protocol\` — 34 pass / 0 fail
- Coverage: envelope serde, frame kind serde, canonical determinism (4 properties), signature dispatch under both policies (5 cases), reply-to validation (3 cases), subscription predicate (5 cases), media ref optional-fields, lift policy across trait impls (6 cases)

## Dependencies

Adds \`ciborium = "0.2"\` for canonical CBOR encoding.

## Stack

Stacked on \`feat/airc-core-headers\` (PR #666) because the envelope imports \`airc_core::Headers\`. PR-2 (airc-transport trait + local-fs adapter — directly retires the gh-polling bearer burn) lands on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)