### PR TITLE
feat(airc-transport): Transport trait + LocalFsAdapter (same-Mac wire)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,10 +33,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-transport"
+version = "0.1.0"
+dependencies = [
+ "airc-core",
+ "airc-protocol",
+ "async-trait",
+ "fs2",
+ "futures",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bitflags"
@@ -58,6 +84,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"
@@ -134,16 +166,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -157,8 +274,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -273,6 +395,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +457,19 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -414,6 +555,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +581,28 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -564,6 +740,43 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
-members = ["crates/airc-core", "crates/airc-blobs", "crates/airc-protocol"]
+members = [
+    "crates/airc-core",
+    "crates/airc-blobs",
+    "crates/airc-protocol",
+    "crates/airc-transport",
+]
 resolver = "2"

--- a/crates/airc-transport/Cargo.toml
+++ b/crates/airc-transport/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "airc-transport"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+[dependencies]
+airc-core = { path = "../airc-core" }
+airc-protocol = { path = "../airc-protocol" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["fs", "io-util", "rt", "rt-multi-thread", "sync", "time", "macros"] }
+async-trait = "0.1"
+futures = "0.3"
+fs2 = "0.4"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["test-util", "macros", "rt-multi-thread"] }

--- a/crates/airc-transport/src/error.rs
+++ b/crates/airc-transport/src/error.rs
@@ -1,0 +1,53 @@
+//! Transport-level errors.
+//!
+//! Each adapter declares its own `Error` associated type, but they share
+//! the same general failure modes (I/O failed, serialization failed,
+//! the wire isn't ready). This module gives `LocalFsAdapter` a typed
+//! error; other adapters will follow the same pattern.
+
+use std::fmt;
+
+/// What can go wrong inside the local-fs adapter.
+#[derive(Debug)]
+pub enum LocalFsError {
+    /// File or directory I/O failed — couldn't open the wire dir,
+    /// couldn't read the frames file, fsync failed, etc.
+    Io(std::io::Error),
+
+    /// A line in the frames file failed to parse as a `Frame`. Either
+    /// the file was corrupted, or a different writer is using an
+    /// incompatible format on the same wire. The substrate refuses
+    /// rather than silently dropping — the caller decides whether to
+    /// continue or abort.
+    Json(serde_json::Error),
+}
+
+impl fmt::Display for LocalFsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LocalFsError::Io(error) => write!(f, "local-fs transport I/O: {error}"),
+            LocalFsError::Json(error) => write!(f, "local-fs transport frame parse: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for LocalFsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            LocalFsError::Io(error) => Some(error),
+            LocalFsError::Json(error) => Some(error),
+        }
+    }
+}
+
+impl From<std::io::Error> for LocalFsError {
+    fn from(error: std::io::Error) -> Self {
+        LocalFsError::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for LocalFsError {
+    fn from(error: serde_json::Error) -> Self {
+        LocalFsError::Json(error)
+    }
+}

--- a/crates/airc-transport/src/lib.rs
+++ b/crates/airc-transport/src/lib.rs
@@ -1,0 +1,29 @@
+//! airc-transport — the wire layer between `airc-protocol` envelopes and
+//! whatever bytes actually move between peers.
+//!
+//! One trait, many adapters. The substrate is intentionally agnostic
+//! about the underlying transport so AI peers (Claude Code, Codex,
+//! vHSM sessions, personas, OpenClaw extensions, Hermes agents,
+//! OpenCode app-server bridges) can pick whatever path makes sense:
+//!
+//! - **local-fs** (this PR) — same-machine multi-process via an
+//!   append-only JSONL log. The direct retirement path for gh-polling
+//!   when multiple AI agents share one Mac.
+//! - **lan-tcp** (PR-3) — same-LAN peer-to-peer via TLS-wrapped TCP.
+//! - **tailscale** (PR-4) — mesh transport for cross-network peers.
+//! - **gh-gist** (legacy adapter, eventual removal) — wraps the
+//!   current Python-airc gist transport so a Rust peer can talk to a
+//!   Python peer during the migration window.
+//!
+//! Designed agent-first. The canonical caller is an AI peer sending
+//! frames to other AI peers; human-chat features (typing, presence)
+//! ride on top via `FrameKind::Event` and headers.
+
+pub mod error;
+pub mod local_fs;
+pub mod transport;
+
+// Re-exports — stable public surface.
+pub use error::LocalFsError;
+pub use local_fs::LocalFsAdapter;
+pub use transport::{FrameStream, Transport};

--- a/crates/airc-transport/src/local_fs.rs
+++ b/crates/airc-transport/src/local_fs.rs
@@ -231,11 +231,24 @@ async fn tail_loop(
         let len = match tokio::fs::metadata(&path).await {
             Ok(metadata) => metadata.len(),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                // File deleted under us (logrotate, manual cleanup,
+                // teardown). Forget our position so when a writer
+                // recreates the file we read from the start.
+                offset = 0;
                 sleep(POLL_INTERVAL).await;
                 continue;
             }
             Err(error) => return Err(error.into()),
         };
+
+        if len < offset {
+            // Truncation or recreation detected — file is shorter
+            // than our last recorded position. Without this branch
+            // we'd wait forever for the file to grow past the stale
+            // offset, silently dropping every new frame.
+            // (Codex's #668 review finding.)
+            offset = 0;
+        }
 
         if len > offset {
             offset = drain_new_lines(&path, offset, &subscription, &tx).await?;
@@ -636,6 +649,126 @@ mod tests {
             assert_eq!(item.envelope.lamport, received);
         }
         assert_eq!(received, total_sent);
+    }
+
+    #[tokio::test]
+    async fn truncation_recovers_offset_to_start() {
+        // Codex's #668 review finding: if the log is truncated/
+        // recreated under a live subscriber whose offset has
+        // advanced past the new EOF, the subscriber must NOT stall.
+        // The tail loop has to detect `len < offset`, reset to 0,
+        // and continue reading.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        // Send a big-ish frame so the file has meaningful length.
+        // Then attach live and read it via cursor replay; offset
+        // advances past frame_1.
+        let frame_1 = frame_at(1, channel, "before-truncation");
+        adapter.send(frame_1.clone()).await.unwrap();
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+
+        let first = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.envelope.lamport, 1);
+
+        // Now truncate the file. Subscriber's tail loop has its
+        // offset positioned at the end of frame_1. Without the
+        // truncation-detection branch, the subscriber would stall.
+        tokio::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(adapter.frames_path())
+            .await
+            .unwrap();
+
+        // Give the tail loop one poll cycle to observe the shrunk
+        // file and reset its offset.
+        sleep(Duration::from_millis(100)).await;
+
+        // Send a fresh frame post-truncation. Subscriber MUST see
+        // it (the bug would have it stall here, waiting for the
+        // file to grow past the old offset).
+        let frame_2 = frame_at(2, channel, "after-truncation");
+        adapter.send(frame_2.clone()).await.unwrap();
+
+        let second = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("tail must recover from truncation within 2s")
+            .expect("stream must yield Some")
+            .expect("frame must parse");
+        assert_eq!(second.envelope.lamport, 2);
+        assert_eq!(
+            second
+                .envelope
+                .body
+                .as_ref()
+                .and_then(Body::as_text)
+                .unwrap(),
+            "after-truncation"
+        );
+    }
+
+    #[tokio::test]
+    async fn deletion_then_recreation_recovers_offset() {
+        // Companion to the truncation test: outright DELETE the
+        // file and recreate via a fresh send. The tail loop's
+        // NotFound branch must also reset offset so the recreated
+        // file is read from the start.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        adapter
+            .send(frame_at(1, channel, "before-delete"))
+            .await
+            .unwrap();
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+        let first = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.envelope.lamport, 1);
+
+        // Delete the file entirely.
+        tokio::fs::remove_file(adapter.frames_path()).await.unwrap();
+        sleep(Duration::from_millis(100)).await;
+
+        // Send recreates the file via OpenOptions::create(true).
+        adapter
+            .send(frame_at(2, channel, "after-delete"))
+            .await
+            .unwrap();
+
+        let second = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("tail must recover from deletion within 2s")
+            .expect("stream must yield Some")
+            .expect("frame must parse");
+        assert_eq!(second.envelope.lamport, 2);
     }
 
     #[tokio::test]

--- a/crates/airc-transport/src/local_fs.rs
+++ b/crates/airc-transport/src/local_fs.rs
@@ -1,0 +1,791 @@
+//! `LocalFsAdapter` — same-machine multi-process wire backed by an
+//! append-only JSONL log on the filesystem.
+//!
+//! Use case: AI peers (Claude Code, Codex, vHSM sessions, personas)
+//! co-located on one Mac that need to talk without burning network
+//! budget. A "wire" is a directory; every peer points its adapter at
+//! the same directory; one process appends, all subscribed processes
+//! see. This is the path that directly retires gh-polling for
+//! multi-agent same-Mac chat.
+//!
+//! Layout: `<wire-dir>/frames.jsonl` — one JSON-encoded `Frame` per
+//! line. Writers acquire an exclusive `flock(2)` on the file via
+//! `fs2::FileExt::lock_exclusive` before each append, so multi-
+//! process writers are serialized at the kernel level regardless of
+//! frame size. The flock is released on file drop at the end of each
+//! send. Readers poll the file by byte-offset and parse new lines.
+//!
+//! **Delivery semantics per `FrameKind`** (per the `Transport` trait
+//! contract):
+//! - `Message` / `Control` — durable. fsync'd before `send` returns.
+//!   Receive side applies backpressure (slow consumer slows the
+//!   wire); no frames are lost.
+//! - `Event` — interrupt-style. Written to disk but NOT fsync'd; the
+//!   bytes are visible to same-machine readers immediately, just not
+//!   guaranteed to survive a kernel crash. Receive side is lossy
+//!   past the per-subscriber buffer (slow consumer drops events,
+//!   wire keeps moving). Codex turn/interrupt, turn/steer, presence
+//!   transitions, and typing indicators ride on this kind.
+//!
+//! Constraints (called out so PR-3 can harden them):
+//! - **Polling**: subscribers poll every 50 ms. Fine for the chat
+//!   cadence; replace with `notify`/`inotify`/`kqueue` push-driven
+//!   wake in a follow-up if latency matters.
+//! - **Cursor replay**: `from_cursor: Some(...)` scans the file from
+//!   start to find the cursor. Linear-scan; fine for the typical
+//!   transcript size. PR-3+ can add an offset index.
+//! - **Send concurrency on flock**: writes are serialized across the
+//!   whole machine while the flock is held. For typical AI-agent
+//!   chat traffic this is fine (sub-millisecond critical section).
+//!   If high-frequency event traffic ever starves out senders, the
+//!   right fix is a separate `events.jsonl` (lossier, no flock) or
+//!   per-frame spool/rename. For PR-2 a single flocked log is
+//!   correct and simple.
+
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use fs2::FileExt;
+use futures::stream::Stream;
+use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+
+use airc_core::TranscriptCursor;
+use airc_protocol::{Frame, FrameKind, Subscription};
+
+use crate::error::LocalFsError;
+use crate::transport::{FrameStream, Transport};
+
+const FRAMES_FILENAME: &str = "frames.jsonl";
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+const RECEIVER_CHANNEL_DEPTH: usize = 64;
+
+/// Same-machine wire backed by `<wire-dir>/frames.jsonl`.
+///
+/// Cross-process send safety comes from `fs2::FileExt::lock_exclusive`
+/// (advisory flock) on the frames file — no in-memory mutex needed,
+/// flock handles both intra- and inter-process serialization.
+pub struct LocalFsAdapter {
+    wire_dir: PathBuf,
+}
+
+impl LocalFsAdapter {
+    /// Open the wire at `wire_dir`. The directory is created on first
+    /// `send` / `subscribe` if it doesn't already exist — the caller
+    /// doesn't need to pre-create it.
+    pub fn new(wire_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            wire_dir: wire_dir.into(),
+        }
+    }
+
+    /// The directory backing this wire. Useful for tests + diagnostics.
+    pub fn wire_dir(&self) -> &Path {
+        &self.wire_dir
+    }
+
+    /// Compute the frames-log path.
+    fn frames_path(&self) -> PathBuf {
+        self.wire_dir.join(FRAMES_FILENAME)
+    }
+
+    /// Create the wire directory if absent. Called on every send +
+    /// subscribe so the API doesn't have an "init" step.
+    async fn ensure_wire_dir(&self) -> Result<(), LocalFsError> {
+        tokio::fs::create_dir_all(&self.wire_dir).await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Transport for LocalFsAdapter {
+    type Error = LocalFsError;
+
+    async fn send(&self, frame: Frame) -> Result<(), Self::Error> {
+        self.ensure_wire_dir().await?;
+
+        // Serialize before crossing the spawn_blocking boundary so the
+        // critical section (open + flock + write + maybe-fsync) is as
+        // short as possible.
+        let mut buffer = serde_json::to_vec(&frame)?;
+        buffer.push(b'\n');
+        let frame_kind = frame.kind;
+        let path = self.frames_path();
+
+        // std::fs + fs2 flock is sync; bracket the kernel calls in
+        // spawn_blocking so we don't stall the async runtime. fs2
+        // doesn't have a tokio-native equivalent and rolling our own
+        // ioctl invocation would be more risk than this is worth.
+        tokio::task::spawn_blocking(move || -> Result<(), LocalFsError> {
+            use std::fs::OpenOptions as StdOpenOptions;
+
+            let file = StdOpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)?;
+            // Exclusive cross-process flock. Other writers (in this
+            // process or any other) block here until we release. The
+            // lock is released when `file` drops at end of block.
+            file.lock_exclusive()?;
+            let result = write_then_maybe_sync(&file, &buffer, frame_kind);
+            // Explicit unlock so an Err from write/sync doesn't leak
+            // the lock past the file's natural drop scope. (Drop
+            // also unlocks on POSIX, but being explicit is clearer.)
+            let _ = FileExt::unlock(&file);
+            result
+        })
+        .await
+        .map_err(|join_error| LocalFsError::Io(std::io::Error::other(join_error.to_string())))??;
+
+        Ok(())
+    }
+
+    async fn subscribe(
+        &self,
+        subscription: Subscription,
+    ) -> Result<FrameStream<Self::Error>, Self::Error> {
+        self.ensure_wire_dir().await?;
+        let path = self.frames_path();
+        let (tx, rx) = mpsc::channel(RECEIVER_CHANNEL_DEPTH);
+
+        // Spawn the tail task. Owned by the returned stream's
+        // lifetime: when the stream is dropped, `rx` is dropped,
+        // `tx.send(...)` returns Err on the next iteration, and the
+        // task exits.
+        tokio::spawn(async move {
+            if let Err(error) = tail_loop(path, subscription, tx.clone()).await {
+                // Surface transport errors to the subscriber so they
+                // can react, then close. We deliberately don't swallow.
+                let _ = tx.send(Err(error)).await;
+            }
+        });
+
+        // Wrap the mpsc receiver as a Stream without pulling
+        // `tokio-stream` as a dep — futures::stream::unfold suffices.
+        let stream = futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        });
+        Ok(Box::pin(stream) as Pin<Box<dyn Stream<Item = _> + Send>>)
+    }
+}
+
+/// Inside the spawn_blocking + flock critical section: append the
+/// serialized frame, then fsync IFF the kind is durable. `Event`
+/// frames skip the fsync so they don't pay the disk-flush latency
+/// (interrupt-style delivery semantics, per the `Transport` trait
+/// contract).
+fn write_then_maybe_sync(
+    mut file: &std::fs::File,
+    buffer: &[u8],
+    frame_kind: FrameKind,
+) -> Result<(), LocalFsError> {
+    use std::io::Write;
+
+    file.write_all(buffer)?;
+    match frame_kind {
+        FrameKind::Message | FrameKind::Control => {
+            // Durable kinds: fsync so a reader attaching right after
+            // this returns observes the frame even past a kernel
+            // crash. Substrate contract: Ok means durable.
+            file.sync_data()?;
+        }
+        FrameKind::Event => {
+            // Interrupt-style: skip fsync. The bytes are in the OS
+            // page cache and visible to same-machine readers
+            // immediately; survival across a kernel crash is not
+            // required for event semantics.
+        }
+    }
+    Ok(())
+}
+
+/// Background tail loop: poll the frames file, parse new lines, filter
+/// against the subscription, and ship matches through `tx`.
+async fn tail_loop(
+    path: PathBuf,
+    subscription: Subscription,
+    tx: mpsc::Sender<Result<Frame, LocalFsError>>,
+) -> Result<(), LocalFsError> {
+    let mut offset: u64 = if subscription.from_cursor.is_some() {
+        // Cursor-anchored: scan from start so we can replay.
+        0
+    } else {
+        // Live-only: skip to end. Existing frames are not replayed.
+        match tokio::fs::metadata(&path).await {
+            Ok(metadata) => metadata.len(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => 0,
+            Err(error) => return Err(error.into()),
+        }
+    };
+
+    loop {
+        // Stop if the subscriber dropped the stream. Avoids waking
+        // for the next poll just to discover the channel is closed.
+        if tx.is_closed() {
+            return Ok(());
+        }
+
+        let len = match tokio::fs::metadata(&path).await {
+            Ok(metadata) => metadata.len(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                sleep(POLL_INTERVAL).await;
+                continue;
+            }
+            Err(error) => return Err(error.into()),
+        };
+
+        if len > offset {
+            offset = drain_new_lines(&path, offset, &subscription, &tx).await?;
+        }
+
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Read from `offset` to current EOF, dispatch matching frames, return
+/// the new offset (positioned at the end of the last complete line —
+/// partial trailing lines are NOT consumed so a concurrent appender's
+/// in-flight write is re-read once it lands).
+async fn drain_new_lines(
+    path: &Path,
+    mut offset: u64,
+    subscription: &Subscription,
+    tx: &mpsc::Sender<Result<Frame, LocalFsError>>,
+) -> Result<u64, LocalFsError> {
+    let mut file = tokio::fs::File::open(path).await?;
+    file.seek(std::io::SeekFrom::Start(offset)).await?;
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let read = reader.read_line(&mut line).await?;
+        if read == 0 {
+            // True EOF.
+            break;
+        }
+        if !line.ends_with('\n') {
+            // Partial line — a writer is mid-append. Don't advance
+            // offset; we'll re-read on the next poll once the
+            // newline arrives.
+            break;
+        }
+        offset += read as u64;
+
+        let trimmed = line.trim_end_matches('\n');
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let frame: Frame = serde_json::from_str(trimmed)?;
+
+        if !subscription.matches(&frame) {
+            continue;
+        }
+        if let Some(cursor) = &subscription.from_cursor {
+            if !frame_after_cursor(&frame, cursor) {
+                continue;
+            }
+        }
+
+        // Delivery dispatch per FrameKind (per Codex's lag-policy
+        // feedback — events must not stall behind transcript catch-
+        // up; messages must not be silently dropped).
+        let dispatch = match frame.kind {
+            FrameKind::Message | FrameKind::Control => {
+                // Durable kinds: apply backpressure. If the
+                // subscriber is slow, this await blocks the tail
+                // loop until they catch up. No frames lost.
+                tx.send(Ok(frame)).await.map_err(|_| DispatchExit::Closed)
+            }
+            FrameKind::Event => {
+                // Interrupt-style: lossy. Drop on full buffer;
+                // surface closed-subscriber as the exit signal.
+                match tx.try_send(Ok(frame)) {
+                    Ok(()) => Ok(()),
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        // Subscriber backlog full — event dropped.
+                        // The wire keeps moving, which is the
+                        // documented semantic. Could log a counter
+                        // here in a future patch.
+                        Ok(())
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => Err(DispatchExit::Closed),
+                }
+            }
+        };
+
+        if dispatch.is_err() {
+            // Subscriber dropped. Exit the spawned task cleanly.
+            // We've already advanced `offset` past this line, which
+            // is fine — there's no resumability after drop.
+            return Ok(offset);
+        }
+    }
+    Ok(offset)
+}
+
+/// Internal: signal that the subscriber's stream is closed, so the
+/// tail-loop should exit. Not exposed — just an internal control flow
+/// type so the dispatch match is exhaustive without conflating with
+/// `LocalFsError`.
+enum DispatchExit {
+    Closed,
+}
+
+/// Is `frame` strictly after `cursor` in transcript order?
+/// Lamport first, event_id as tiebreaker — matches airc-core's
+/// transcript ordering rule.
+fn frame_after_cursor(frame: &Frame, cursor: &TranscriptCursor) -> bool {
+    let envelope = &frame.envelope;
+    envelope.lamport > cursor.lamport
+        || (envelope.lamport == cursor.lamport
+            && envelope.event_id.as_uuid() > cursor.event_id.as_uuid())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::{
+        headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, PeerId, RoomId,
+    };
+    use airc_protocol::{ChannelId, Envelope, Frame, FrameKind, Signature, Subscription};
+    use futures::stream::StreamExt;
+    use tempfile::TempDir;
+
+    fn frame_at(lamport: u64, channel: ChannelId, body: &str) -> Frame {
+        Frame {
+            kind: FrameKind::Message,
+            envelope: Envelope {
+                event_id: EventId::from_u128(lamport as u128),
+                sender: PeerId::from_u128(0xa1),
+                sender_client: ClientId::from_u128(0xc1),
+                channel,
+                target: MentionTarget::All,
+                lamport,
+                occurred_at_ms: 1_700_000_000_000 + lamport,
+                reply_to: None,
+                headers: Headers::new(),
+                body: Some(Body::text(body)),
+                media: Vec::new(),
+                signature: Signature::Unsigned,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn send_then_subscribe_with_cursor_replays_frame() {
+        // The "two AI agents share a Mac" base case. Agent A sends,
+        // Agent B subscribes with from_cursor=None... but None means
+        // live-only, so we use a from_cursor anchor to force replay.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        adapter
+            .send(frame_at(1, channel, "hello from A"))
+            .await
+            .unwrap();
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+        let received = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("must yield within 2s")
+            .expect("stream must yield Some")
+            .expect("frame must parse");
+
+        assert_eq!(received.envelope.lamport, 1);
+        let body_text = received
+            .envelope
+            .body
+            .as_ref()
+            .and_then(Body::as_text)
+            .expect("body must be text");
+        assert_eq!(body_text, "hello from A");
+    }
+
+    #[tokio::test]
+    async fn live_subscription_skips_past_frames() {
+        // from_cursor=None means "live only" — frames already on disk
+        // when subscribe() is called are NOT replayed. Critical for
+        // agents who reconnect and don't want to re-process history.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        adapter.send(frame_at(1, channel, "old")).await.unwrap();
+
+        let sub = Subscription {
+            channel: Some(channel),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+
+        // Give the tail loop a poll cycle to seek to EOF.
+        sleep(Duration::from_millis(100)).await;
+
+        adapter.send(frame_at(2, channel, "new")).await.unwrap();
+
+        let received = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("must yield within 2s")
+            .expect("stream must yield Some")
+            .expect("frame must parse");
+        assert_eq!(received.envelope.lamport, 2);
+        assert_eq!(
+            received
+                .envelope
+                .body
+                .as_ref()
+                .and_then(Body::as_text)
+                .unwrap(),
+            "new"
+        );
+    }
+
+    #[tokio::test]
+    async fn subscription_channel_filter_routes_correctly() {
+        // Fan-out hot path: one wire carries multiple channels; each
+        // subscriber gets only its channel's frames.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let chan_a = RoomId::from_u128(0xaaaa);
+        let chan_b = RoomId::from_u128(0xbbbb);
+
+        let sub = Subscription {
+            channel: Some(chan_a),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+
+        // Let the tail task start.
+        sleep(Duration::from_millis(50)).await;
+
+        adapter.send(frame_at(1, chan_a, "a-frame")).await.unwrap();
+        adapter.send(frame_at(2, chan_b, "b-frame")).await.unwrap();
+        adapter
+            .send(frame_at(3, chan_a, "a-frame-2"))
+            .await
+            .unwrap();
+
+        // Should receive only the chan_a frames.
+        let first = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("first")
+            .expect("some")
+            .expect("ok");
+        let second = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("second")
+            .expect("some")
+            .expect("ok");
+        assert_eq!(first.envelope.lamport, 1);
+        assert_eq!(second.envelope.lamport, 3);
+
+        // No third frame on the chan_a stream within 200ms.
+        let third = tokio::time::timeout(Duration::from_millis(200), stream.next()).await;
+        assert!(third.is_err(), "no further frames expected");
+    }
+
+    #[tokio::test]
+    async fn two_subscribers_both_receive() {
+        // Fan-out parity: two independent subscribers on the same
+        // channel both get every frame. The "Codex AND Claude" case.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        let make_sub = || Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+
+        let mut stream_a = adapter.subscribe(make_sub()).await.unwrap();
+        let mut stream_b = adapter.subscribe(make_sub()).await.unwrap();
+
+        sleep(Duration::from_millis(50)).await;
+        adapter
+            .send(frame_at(1, channel, "broadcast"))
+            .await
+            .unwrap();
+
+        let recv_a = tokio::time::timeout(Duration::from_secs(2), stream_a.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let recv_b = tokio::time::timeout(Duration::from_secs(2), stream_b.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(recv_a.envelope.lamport, 1);
+        assert_eq!(recv_b.envelope.lamport, 1);
+    }
+
+    #[tokio::test]
+    async fn events_are_lossy_when_subscriber_lags() {
+        // Codex's lag-policy contract: Event frames must drop on a
+        // full subscriber buffer rather than back up the wire. If
+        // every event sent here arrives, the lossy semantic is
+        // broken. Send WAY more events than the channel depth (64)
+        // while NOT consuming, then drain — expect strictly fewer
+        // than sent.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+
+        // Let the tail loop arm. Then send a flood of Events
+        // without reading from the stream.
+        sleep(Duration::from_millis(50)).await;
+        let total_sent: u64 = 500;
+        for lamport in 1..=total_sent {
+            let mut frame = frame_at(lamport, channel, &format!("evt-{lamport}"));
+            frame.kind = FrameKind::Event;
+            adapter.send(frame).await.unwrap();
+        }
+
+        // Give the tail loop time to drain the file into the bounded
+        // subscriber channel — events will be dropped at try_send
+        // when the channel is full.
+        sleep(Duration::from_millis(300)).await;
+
+        // Drain whatever made it through.
+        let mut count: u64 = 0;
+        while let Ok(Some(Ok(_))) =
+            tokio::time::timeout(Duration::from_millis(50), stream.next()).await
+        {
+            count += 1;
+        }
+        assert!(
+            count < total_sent,
+            "events must be lossy when subscriber lags; received {count} of {total_sent}"
+        );
+        assert!(count > 0, "at least some events should arrive; got {count}");
+    }
+
+    #[tokio::test]
+    async fn messages_are_not_dropped_under_subscriber_lag() {
+        // The flip side: Message frames apply backpressure and MUST
+        // be delivered in full. If a slow subscriber drops messages
+        // we've broken the durability contract — the Codex bridge
+        // (and every other consumer) needs to rely on this.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+
+        sleep(Duration::from_millis(50)).await;
+        let total_sent: u64 = 200;
+        for lamport in 1..=total_sent {
+            adapter
+                .send(frame_at(lamport, channel, &format!("msg-{lamport}")))
+                .await
+                .unwrap();
+        }
+
+        // Drain — all must arrive (backpressure can slow it, but
+        // can't lose). Generous timeout for the full drain since
+        // backpressure may stall periodically.
+        let mut received: u64 = 0;
+        while received < total_sent {
+            let item = tokio::time::timeout(Duration::from_secs(10), stream.next())
+                .await
+                .expect("must yield within 10s under backpressure")
+                .expect("stream must yield Some")
+                .expect("frame must parse");
+            received += 1;
+            // Sanity that order is preserved.
+            assert_eq!(item.envelope.lamport, received);
+        }
+        assert_eq!(received, total_sent);
+    }
+
+    #[tokio::test]
+    async fn flock_serializes_concurrent_in_process_senders() {
+        // The flock contract: even with many concurrent senders, the
+        // resulting frames.jsonl is well-formed (one frame per line,
+        // no torn writes, all frames present). Tests within-process
+        // concurrency — cross-process flock relies on the same
+        // kernel mechanism so the in-process test is a proxy. (A
+        // real cross-process test would spawn child processes,
+        // which is out of scope for unit tests.)
+        let dir = TempDir::new().unwrap();
+        let adapter = std::sync::Arc::new(LocalFsAdapter::new(dir.path()));
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        let mut handles = Vec::new();
+        let frames_per_sender: u64 = 30;
+        let sender_count: u64 = 8;
+        for sender_idx in 0..sender_count {
+            let adapter = adapter.clone();
+            let handle = tokio::spawn(async move {
+                for i in 0..frames_per_sender {
+                    let lamport = sender_idx * frames_per_sender + i + 1;
+                    adapter
+                        .send(frame_at(
+                            lamport,
+                            channel,
+                            &format!("sender-{sender_idx}-{i}"),
+                        ))
+                        .await
+                        .unwrap();
+                }
+            });
+            handles.push(handle);
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        // Read the resulting file: every line MUST parse, and the
+        // total count MUST equal sender_count * frames_per_sender.
+        let contents = tokio::fs::read_to_string(adapter.frames_path())
+            .await
+            .unwrap();
+        let lines: Vec<_> = contents.lines().collect();
+        let expected = (sender_count * frames_per_sender) as usize;
+        assert_eq!(
+            lines.len(),
+            expected,
+            "every concurrent send must land as exactly one line"
+        );
+        for line in lines {
+            let _: Frame = serde_json::from_str(line).expect("every line must parse cleanly");
+        }
+    }
+
+    #[tokio::test]
+    async fn drop_stream_stops_tail_task() {
+        // Resource discipline: dropping the returned stream must
+        // shut down its background tail. Tested indirectly: the tail
+        // task observes the closed channel and exits on its next
+        // poll. We can't observe the task directly but we can assert
+        // the second send doesn't panic / leak (smoke test).
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let stream = adapter.subscribe(sub).await.unwrap();
+        drop(stream);
+
+        // Sends after stream drop should still succeed against the
+        // wire — the closed subscriber doesn't affect the writer.
+        sleep(Duration::from_millis(100)).await;
+        adapter
+            .send(frame_at(1, channel, "no one home"))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_is_durable_when_returning_ok() {
+        // The contract: send returning Ok means the frame is on disk
+        // and readable. Pin that by reading the file directly after
+        // a single send.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        adapter.send(frame_at(1, channel, "durable")).await.unwrap();
+
+        let contents = tokio::fs::read_to_string(adapter.frames_path())
+            .await
+            .unwrap();
+        // One frame, one line, ends with newline.
+        assert_eq!(contents.lines().count(), 1);
+        assert!(contents.ends_with('\n'));
+        let parsed: Frame = serde_json::from_str(contents.trim_end()).unwrap();
+        assert_eq!(parsed.envelope.lamport, 1);
+    }
+
+    #[tokio::test]
+    async fn from_cursor_drops_frames_at_or_before_anchor() {
+        // Replay semantics: from_cursor returns frames STRICTLY after
+        // the anchor (not including the anchor frame itself), so a
+        // reconnecting peer doesn't re-process the last-acked event.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        let frame1 = frame_at(1, channel, "first");
+        let frame2 = frame_at(2, channel, "second");
+        let frame3 = frame_at(3, channel, "third");
+
+        adapter.send(frame1.clone()).await.unwrap();
+        adapter.send(frame2.clone()).await.unwrap();
+        adapter.send(frame3.clone()).await.unwrap();
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 1,
+                event_id: frame1.envelope.event_id,
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+
+        let recv_a = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let recv_b = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(recv_a.envelope.lamport, 2);
+        assert_eq!(recv_b.envelope.lamport, 3);
+
+        // No further frames.
+        let none = tokio::time::timeout(Duration::from_millis(200), stream.next()).await;
+        assert!(none.is_err(), "should be no further frames");
+    }
+}

--- a/crates/airc-transport/src/transport.rs
+++ b/crates/airc-transport/src/transport.rs
@@ -1,0 +1,101 @@
+//! The `Transport` trait — what every adapter (local-fs, lan-tcp,
+//! tailscale, ...) implements.
+//!
+//! The substrate is intentionally agnostic about the wire underneath.
+//! Adapters carry `airc-protocol::Frame`s in both directions; the
+//! substrate enforces semantics (subscriptions, signature verification,
+//! fan-out). One trait, many impls, swap freely.
+//!
+//! Designed agent-to-agent-first: the canonical caller is an AI peer
+//! (Claude Code, Codex, vHSM session, persona) sending a frame to
+//! other AI peers on the same Mac, same LAN, or across a mesh. Latency
+//! and concurrency dominate the design; legacy human-chat features
+//! (typing indicators, presence) ride on top via `FrameKind::Event`
+//! and headers, not as core trait surface.
+
+use std::pin::Pin;
+
+use async_trait::async_trait;
+use futures::Stream;
+
+use airc_protocol::{Frame, Subscription};
+
+/// A stream of frames matching a subscription, with transport-level
+/// errors surfaced inline so receivers see I/O failures rather than
+/// silently lose frames.
+///
+/// `Pin<Box<dyn Stream + Send>>` is dyn-friendly so adapters can be
+/// stored as `Box<dyn Transport<Error = ...>>` and the receive surface
+/// stays generic.
+pub type FrameStream<E> = Pin<Box<dyn Stream<Item = Result<Frame, E>> + Send>>;
+
+/// The contract an adapter implements.
+#[async_trait]
+pub trait Transport: Send + Sync {
+    /// Adapter-specific error type. Must be `Send + Sync + 'static` so
+    /// errors can cross `await` points and propagate from spawned
+    /// tasks; must implement `std::error::Error` so callers can use
+    /// the standard error-chain idioms.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Send a frame onto the wire.
+    ///
+    /// **Delivery semantics depend on `frame.kind`** — adapters MUST
+    /// respect this split so consumers like the Codex bridge can rely
+    /// on it:
+    ///
+    /// - `FrameKind::Message` / `FrameKind::Control`: **durable**. By
+    ///   the time `Ok` returns the frame is persisted (fsync'd for
+    ///   local-fs; ACKed for lan-tcp). Readers attaching after this
+    ///   call MUST be able to read it. These kinds carry transcript
+    ///   content + session lifecycle — losing one is a bug.
+    ///
+    /// - `FrameKind::Event`: **interrupt-style live**. The wire makes
+    ///   the frame visible to currently-attached readers as fast as
+    ///   possible (skipping fsync, etc.). Crash-survival is NOT
+    ///   guaranteed for events — they're meant for typing indicators,
+    ///   turn/steer, turn/interrupt, presence transitions, work-offer
+    ///   pings. The frame may be dropped by slow subscribers (see
+    ///   `subscribe` for the lag policy).
+    ///
+    /// Frames are bytes-equal to what receivers see; the substrate
+    /// does NOT mutate the envelope in transit. (Adapters MAY add or
+    /// strip transport-level framing around the envelope — that's
+    /// invisible to the protocol layer.)
+    async fn send(&self, frame: Frame) -> Result<(), Self::Error>;
+
+    /// Subscribe and receive frames matching `subscription`.
+    ///
+    /// The returned stream:
+    ///   - Yields frames matching the subscription criteria (`channel`,
+    ///     `kinds`, `headers_filter`).
+    ///   - Yields `from_cursor`-anchored replay first (when set), then
+    ///     transitions to live frames.
+    ///   - Yields `Err(transport-error)` on transport-level failures.
+    ///   - Closes when the transport is torn down OR the stream is
+    ///     dropped (unsubscribes the receiver).
+    ///
+    /// **Lag policy (per Codex's feedback — Codex turn/interrupt and
+    /// turn/steer must not get stuck behind transcript catch-up):**
+    ///
+    /// - `FrameKind::Message` / `FrameKind::Control` frames apply
+    ///   **backpressure** — a slow consumer slows the wire's drain
+    ///   rate but no frames are lost. Durable kinds get reliable
+    ///   delivery.
+    ///
+    /// - `FrameKind::Event` frames are **lossy past the per-subscriber
+    ///   buffer** — if the subscriber's queue is full, the event is
+    ///   dropped at the boundary. Interrupt-style delivery: better to
+    ///   miss a stale interrupt than to back up the whole wire. The
+    ///   wire keeps moving; subscribers MUST poll their stream
+    ///   promptly to see events.
+    ///
+    /// Multiple subscribers may attach concurrently; the transport
+    /// fans out. Each subscriber gets its own stream — no cross-talk
+    /// and no shared backpressure (a slow subscriber affects only its
+    /// own backlog).
+    async fn subscribe(
+        &self,
+        subscription: Subscription,
+    ) -> Result<FrameStream<Self::Error>, Self::Error>;
+}


### PR DESCRIPTION
## Summary

New crate `airc-transport` — the wire layer between airc-protocol envelopes and bytes-on-disk-or-wire. First adapter: **`LocalFsAdapter`**, the same-Mac multi-process wire that directly retires gh-polling for multi-agent chat (Codex / Claude Code / vHSM sessions all sharing one directory). Substrate's goal is FAST + portable + AI-first: this is the FAST half landing.

## `Transport` trait

Async, single contract every adapter (local-fs, lan-tcp, tailscale, gh-gist-legacy) implements. Two methods only:

- `send(Frame)` — durability depends on `frame.kind`
- `subscribe(Subscription) -> FrameStream` — fan-out with lag policy

## Delivery semantics (per Codex's feedback)

Formalized so the Codex bridge can rely on them:

- **`Message` / `Control`**: durable. fsync'd on send; receive-side backpressure (slow consumer slows the wire, no frames lost).
- **`Event`**: interrupt-style. Written to disk WITHOUT fsync (visible to same-machine readers immediately, no crash-survival guarantee); receive-side lossy past per-subscriber buffer (drop on full, wire keeps moving). turn/steer, turn/interrupt, presence transitions, typing indicators ride this kind.

## LocalFsAdapter — `<wire-dir>/frames.jsonl`

Append-only log with three correctness properties:

- **Cross-process safety**: `fs2::FileExt::lock_exclusive` (kernel flock) serializes all writers regardless of frame size — replaces the prior O_APPEND/PIPE_BUF gamble per Codex's review. Critical section runs in `spawn_blocking`.
- **Durability branch on FrameKind**: Messages/Control fsync; Events skip (interrupt-style).
- **Reader**: tokio-based byte-offset tail, 50ms poll. Partial in-flight lines NOT consumed; re-read once the newline arrives.

Cursor replay: `from_cursor=None` = "live only" (skip to EOF on attach); `Some(cursor)` replays strictly-after that anchor. Each subscriber gets its own mpsc — no cross-talk, per-subscriber lag isolation.

## Test plan

- [x] `cargo fmt -p airc-transport` — clean
- [x] `cargo clippy -p airc-transport --all-targets -- -D warnings` — clean
- [x] `cargo test -p airc-transport` — 10 pass / 0 fail

| Test | Pins |
|------|------|
| `send_then_subscribe_with_cursor_replays_frame` | base round-trip |
| `live_subscription_skips_past_frames` | `None` cursor = live-only |
| `subscription_channel_filter_routes_correctly` | channel fan-out |
| `two_subscribers_both_receive` | fan-out parity |
| `drop_stream_stops_tail_task` | resource discipline |
| `send_is_durable_when_returning_ok` | durability contract |
| `from_cursor_drops_frames_at_or_before_anchor` | replay semantics |
| `events_are_lossy_when_subscriber_lags` | Codex's lag policy (Events drop on full subscriber buffer) |
| `messages_are_not_dropped_under_subscriber_lag` | Messages survive under backpressure |
| `flock_serializes_concurrent_in_process_senders` | flock correctness (8 senders × 30 frames = 240 lines, all clean) |

## Stack + next

Stacked on `feat/airc-protocol-envelope` (PR #667). **PR-3** (`lan-tcp` adapter — same-LAN AI peers, retires gh as default once it lands) is next.

## Dependencies

Adds: tokio (fs/io/rt/sync/time/macros), async-trait, futures, fs2, tempfile (dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)