### PR TITLE
feat(airc-protocol): real Ed25519 signing + verify (closes PR-1 stub)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,8 @@ version = "0.1.0"
 dependencies = [
  "airc-core",
  "ciborium",
+ "ed25519-dalek",
+ "rand",
  "serde",
  "serde_json",
 ]
@@ -37,6 +39,12 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -93,6 +101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +132,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,10 +179,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "foldhash"
@@ -171,6 +252,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -297,6 +389,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +440,45 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustversion"
@@ -397,10 +547,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -457,7 +632,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -468,6 +643,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -679,6 +860,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/crates/airc-protocol/Cargo.toml
+++ b/crates/airc-protocol/Cargo.toml
@@ -10,3 +10,5 @@ airc-core = { path = "../airc-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ciborium = "0.2"
+ed25519-dalek = "2"
+rand = "0.8"

--- a/crates/airc-protocol/src/keypair.rs
+++ b/crates/airc-protocol/src/keypair.rs
@@ -1,0 +1,390 @@
+//! Peer keypair — sign envelopes with Ed25519.
+//!
+//! The send-side companion to `signature::verify`. A peer holds a
+//! `PeerKeypair` (their private Ed25519 signing key) and uses it to
+//! sign every outgoing envelope; receivers verify against the peer's
+//! enrolled `VerifyingKey` in their `PeerKeyRegistry`.
+//!
+//! Crypto choice: Ed25519 via `ed25519-dalek`. Picked for the standard
+//! reasons — small key + signature, deterministic signing (same input
+//! always produces same signature, simplifies replay-testing), fast
+//! verify (sub-50µs on modern silicon, fits the per-frame
+//! verification budget), and broad ecosystem support (TLS 1.3 cert
+//! identity, SSH, modern signature ecosystems all converge here).
+//!
+//! Storage: this module holds key material in memory only. Persistent
+//! storage (SQLCipher at-rest, hardware-backed enclaves, etc.) is the
+//! integrator's responsibility — `secret_bytes()` returns the raw 32
+//! bytes for those integrations to handle. Substrate doesn't decide
+//! where keys live; it only signs and verifies with them.
+
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
+use rand::{rngs::OsRng, RngCore};
+
+use airc_core::PeerId;
+
+use crate::canonical::{canonical_signed_bytes, CanonicalError};
+use crate::envelope::Envelope;
+use crate::signature::Signature;
+
+/// A peer's private signing key + derived public key.
+///
+/// Construct with `generate()` (fresh random key) or
+/// `from_secret_bytes(...)` (restore from persisted material). The
+/// underlying `SigningKey` is held in memory only; integrators
+/// arrange persistent storage outside the substrate.
+#[derive(Clone)]
+pub struct PeerKeypair {
+    signing: SigningKey,
+}
+
+impl std::fmt::Debug for PeerKeypair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never debug-print the secret. Pubkey is fine — it's public
+        // by definition and useful for diagnostics.
+        f.debug_struct("PeerKeypair")
+            .field("public_bytes", &self.public_bytes())
+            .field("secret_bytes", &"<redacted>")
+            .finish()
+    }
+}
+
+impl PeerKeypair {
+    /// Generate a fresh random keypair from the OS CSPRNG.
+    ///
+    /// ed25519-dalek 2.x removed the convenience `SigningKey::generate`
+    /// associated function; the substrate-style equivalent is to draw
+    /// 32 bytes from `OsRng` and feed them through `from_bytes`.
+    pub fn generate() -> Self {
+        let mut secret = [0u8; 32];
+        OsRng.fill_bytes(&mut secret);
+        Self {
+            signing: SigningKey::from_bytes(&secret),
+        }
+    }
+
+    /// Restore a keypair from previously-persisted 32 secret bytes.
+    /// Use this to load a key from storage (SQLCipher, keychain, etc.).
+    pub fn from_secret_bytes(secret: &[u8; 32]) -> Self {
+        Self {
+            signing: SigningKey::from_bytes(secret),
+        }
+    }
+
+    /// The 32-byte secret. Hand this to your at-rest storage layer.
+    /// Treat with the discipline you'd apply to any other root secret.
+    pub fn secret_bytes(&self) -> [u8; 32] {
+        self.signing.to_bytes()
+    }
+
+    /// The 32-byte public verifying key. Other peers enrol this in
+    /// their `PeerKeyRegistry` so they can verify your signatures.
+    pub fn public_bytes(&self) -> [u8; 32] {
+        self.signing.verifying_key().to_bytes()
+    }
+
+    /// The parsed `VerifyingKey` — convenience for direct registry
+    /// enrolment without round-tripping through bytes.
+    pub fn verifying_key(&self) -> VerifyingKey {
+        self.signing.verifying_key()
+    }
+
+    /// Sign an envelope: produces a `Signature::Ed25519` carrying the
+    /// signer's PeerId, key_id (for rotation), and 64-byte signature
+    /// over the envelope's canonical CBOR encoding.
+    ///
+    /// The signature covers every envelope field EXCEPT the
+    /// signature itself (see `canonical::canonical_signed_bytes`).
+    pub fn sign_envelope(
+        &self,
+        envelope: &Envelope,
+        signer: PeerId,
+        key_id: u32,
+    ) -> Result<Signature, CanonicalError> {
+        let bytes = canonical_signed_bytes(envelope)?;
+        let sig = self.signing.sign(&bytes);
+        Ok(Signature::Ed25519 {
+            signer,
+            key_id,
+            sig: sig.to_bytes(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::Frame;
+    use crate::envelope::{ChannelId, Envelope, FrameKind};
+    use crate::media::MediaRef;
+    use crate::signature::{verify, PeerKeyRegistry, VerificationError, VerificationPolicy};
+    use airc_core::{
+        headers::Headers, transcript::MentionTarget, Body, ClientId, ContentHash, EventId, FileId,
+        PeerId,
+    };
+
+    fn envelope_fixture(peer: PeerId) -> Envelope {
+        let mut headers = Headers::new();
+        headers.insert(
+            "forge.body_hint".to_string(),
+            "forge.persona.turn".to_string(),
+        );
+        Envelope {
+            event_id: EventId::from_u128(0x01),
+            sender: peer,
+            sender_client: ClientId::from_u128(0xc1),
+            channel: ChannelId::from_u128(0xc0ffee),
+            target: MentionTarget::All,
+            lamport: 7,
+            occurred_at_ms: 1_700_000_000_000,
+            reply_to: None,
+            headers,
+            body: Some(Body::text("hello signed world")),
+            media: vec![MediaRef {
+                file_id: FileId::from_u128(0xf1),
+                content_hash: ContentHash("sha256:abcd".to_string()),
+                mime: Some("image/png".to_string()),
+                size_bytes: Some(2048),
+                caption: None,
+            }],
+            signature: Signature::Unsigned,
+        }
+    }
+
+    #[test]
+    fn sign_then_verify_with_enrolled_key_passes_under_strict() {
+        // The base case: a peer signs an envelope, a receiver with
+        // that peer's pubkey enrolled accepts under Strict policy.
+        // This is the path Strict mode is built for.
+        let peer = PeerId::from_u128(0xa1);
+        let keypair = PeerKeypair::generate();
+        let mut envelope = envelope_fixture(peer);
+        envelope.signature = keypair.sign_envelope(&envelope, peer, 0).unwrap();
+
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
+
+        let frame = Frame {
+            kind: FrameKind::Message,
+            envelope,
+        };
+        assert!(verify(&frame, VerificationPolicy::Strict, &registry).is_ok());
+    }
+
+    #[test]
+    fn tampered_envelope_after_signing_fails_bad_signature() {
+        // The threat model the signature exists for. If anyone in the
+        // middle alters any signed field, verify must reject.
+        let peer = PeerId::from_u128(0xa1);
+        let keypair = PeerKeypair::generate();
+        let mut envelope = envelope_fixture(peer);
+        envelope.signature = keypair.sign_envelope(&envelope, peer, 0).unwrap();
+
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
+
+        // Tamper with the body — substantive content change.
+        envelope.body = Some(Body::text("THIS IS NOT WHAT WAS SIGNED"));
+
+        let frame = Frame {
+            kind: FrameKind::Message,
+            envelope,
+        };
+        assert_eq!(
+            verify(&frame, VerificationPolicy::Strict, &registry),
+            Err(VerificationError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn tampered_lamport_fails_bad_signature() {
+        // Lamport is part of the canonical signed payload — tampering
+        // with it must surface as BadSignature. Pins that ordering
+        // fields are protected from replay-style manipulation.
+        let peer = PeerId::from_u128(0xa1);
+        let keypair = PeerKeypair::generate();
+        let mut envelope = envelope_fixture(peer);
+        envelope.signature = keypair.sign_envelope(&envelope, peer, 0).unwrap();
+        envelope.lamport = 999;
+
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
+
+        let frame = Frame {
+            kind: FrameKind::Message,
+            envelope,
+        };
+        assert_eq!(
+            verify(&frame, VerificationPolicy::Strict, &registry),
+            Err(VerificationError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn tampered_headers_fail_bad_signature() {
+        // Header tampering — even adding a new header that wasn't
+        // present at sign time must invalidate.
+        let peer = PeerId::from_u128(0xa1);
+        let keypair = PeerKeypair::generate();
+        let mut envelope = envelope_fixture(peer);
+        envelope.signature = keypair.sign_envelope(&envelope, peer, 0).unwrap();
+
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
+
+        envelope
+            .headers
+            .insert("x-malicious".to_string(), "injected".to_string());
+
+        let frame = Frame {
+            kind: FrameKind::Message,
+            envelope,
+        };
+        assert_eq!(
+            verify(&frame, VerificationPolicy::Strict, &registry),
+            Err(VerificationError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn tampered_reply_to_fails_bad_signature() {
+        // reply_to is part of the signed payload. Cross-checking with
+        // the structured-vs-header consistency check (PR-1) — both
+        // layers refuse mismatches.
+        let peer = PeerId::from_u128(0xa1);
+        let keypair = PeerKeypair::generate();
+        let mut envelope = envelope_fixture(peer);
+        envelope.signature = keypair.sign_envelope(&envelope, peer, 0).unwrap();
+
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
+
+        envelope.reply_to = Some(EventId::from_u128(0x99));
+
+        let frame = Frame {
+            kind: FrameKind::Message,
+            envelope,
+        };
+        assert_eq!(
+            verify(&frame, VerificationPolicy::Strict, &registry),
+            Err(VerificationError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn wrong_pubkey_in_registry_fails_bad_signature() {
+        // The "evil twin" case: the registry has a key for this
+        // peer, but not the right one. Verify must reject — this is
+        // where the cryptographic check earns its keep.
+        let peer = PeerId::from_u128(0xa1);
+        let real_keypair = PeerKeypair::generate();
+        let imposter_keypair = PeerKeypair::generate();
+        let mut envelope = envelope_fixture(peer);
+        envelope.signature = real_keypair.sign_envelope(&envelope, peer, 0).unwrap();
+
+        let mut registry = PeerKeyRegistry::new();
+        registry
+            .enrol(peer, 0, imposter_keypair.public_bytes())
+            .unwrap();
+
+        let frame = Frame {
+            kind: FrameKind::Message,
+            envelope,
+        };
+        assert_eq!(
+            verify(&frame, VerificationPolicy::Strict, &registry),
+            Err(VerificationError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn unenrolled_signer_fails_unknown_signer() {
+        // Empty registry → fail-closed with UnknownSigner. Pinned
+        // again here because PR-3a wires real crypto on top — make
+        // sure the error type still distinguishes "unknown signer"
+        // from "signature failed."
+        let peer = PeerId::from_u128(0xa1);
+        let keypair = PeerKeypair::generate();
+        let mut envelope = envelope_fixture(peer);
+        envelope.signature = keypair.sign_envelope(&envelope, peer, 0).unwrap();
+
+        let registry = PeerKeyRegistry::new();
+        let frame = Frame {
+            kind: FrameKind::Message,
+            envelope,
+        };
+        assert_eq!(
+            verify(&frame, VerificationPolicy::Strict, &registry),
+            Err(VerificationError::UnknownSigner(peer))
+        );
+    }
+
+    #[test]
+    fn key_rotation_via_key_id_works() {
+        // Same peer, two enrolled keys with different key_ids — both
+        // can sign and both verify. This is how rotation works:
+        // enrol the new key under a new key_id BEFORE retiring the
+        // old one, then transition senders.
+        let peer = PeerId::from_u128(0xa1);
+        let old_keypair = PeerKeypair::generate();
+        let new_keypair = PeerKeypair::generate();
+
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(peer, 0, old_keypair.public_bytes()).unwrap();
+        registry.enrol(peer, 1, new_keypair.public_bytes()).unwrap();
+
+        let mut env_old = envelope_fixture(peer);
+        env_old.signature = old_keypair.sign_envelope(&env_old, peer, 0).unwrap();
+        let frame_old = Frame {
+            kind: FrameKind::Message,
+            envelope: env_old,
+        };
+        assert!(verify(&frame_old, VerificationPolicy::Strict, &registry).is_ok());
+
+        let mut env_new = envelope_fixture(peer);
+        env_new.signature = new_keypair.sign_envelope(&env_new, peer, 1).unwrap();
+        let frame_new = Frame {
+            kind: FrameKind::Message,
+            envelope: env_new,
+        };
+        assert!(verify(&frame_new, VerificationPolicy::Strict, &registry).is_ok());
+    }
+
+    #[test]
+    fn keypair_secret_roundtrips_through_bytes() {
+        // Pin the persistence contract: secret_bytes -> from_secret_bytes
+        // must yield a keypair that signs identically. Otherwise the
+        // at-rest storage path is broken silently.
+        let original = PeerKeypair::generate();
+        let secret = original.secret_bytes();
+        let restored = PeerKeypair::from_secret_bytes(&secret);
+
+        let peer = PeerId::from_u128(0xa1);
+        let envelope = envelope_fixture(peer);
+
+        let sig_a = original.sign_envelope(&envelope, peer, 0).unwrap();
+        let sig_b = restored.sign_envelope(&envelope, peer, 0).unwrap();
+        // Ed25519 is deterministic — same key + same input = same sig.
+        assert_eq!(sig_a, sig_b);
+    }
+
+    #[test]
+    fn debug_redacts_secret() {
+        // Pin that Debug never leaks the secret. If someone adds a
+        // derive(Debug) on PeerKeypair in a refactor, this catches it.
+        let kp = PeerKeypair::generate();
+        let debug_string = format!("{kp:?}");
+        assert!(
+            debug_string.contains("<redacted>"),
+            "Debug output must redact the secret; got: {debug_string}"
+        );
+        // Sanity: the actual 32-byte secret value should not appear
+        // anywhere in the debug output.
+        let secret = kp.secret_bytes();
+        let secret_hex: String = secret.iter().map(|byte| format!("{byte:02x}")).collect();
+        assert!(
+            !debug_string.contains(&secret_hex),
+            "Debug must not contain the secret hex"
+        );
+    }
+}

--- a/crates/airc-protocol/src/lib.rs
+++ b/crates/airc-protocol/src/lib.rs
@@ -8,6 +8,8 @@
 //! - [`media`]          — `MediaRef` (pointer into airc-blobs)
 //! - [`headers_keys`]   — substrate-owned `airc.*` header constants
 //! - [`signature`]      — `Signature`, `VerificationPolicy`, `verify()`
+//!   with real Ed25519 verification
+//! - [`keypair`]        — `PeerKeypair` (Ed25519 signing side)
 //! - [`canonical`]      — deterministic CBOR encoding for signing
 //! - [`subscription`]   — `Subscription` predicate for fan-out
 //! - [`policy`]         — pluggable `LiftPolicy` for body-lift decisions
@@ -20,6 +22,7 @@
 pub mod canonical;
 pub mod envelope;
 pub mod headers_keys;
+pub mod keypair;
 pub mod media;
 pub mod policy;
 pub mod signature;
@@ -33,7 +36,10 @@ pub use headers_keys::{
     HEADER_AIRC_DEADLINE, HEADER_AIRC_PRIORITY, HEADER_AIRC_REPLY_TO, HEADER_AIRC_TRACE_ID,
     HEADER_FORGE_BODY_HINT,
 };
+pub use keypair::PeerKeypair;
 pub use media::MediaRef;
 pub use policy::{AlwaysLift, LiftPolicy, NeverLift, SizeThresholdPolicy};
-pub use signature::{verify, PeerKeyRegistry, Signature, VerificationError, VerificationPolicy};
+pub use signature::{
+    verify, KeyError, PeerKeyRegistry, Signature, VerificationError, VerificationPolicy,
+};
 pub use subscription::Subscription;

--- a/crates/airc-protocol/src/signature.rs
+++ b/crates/airc-protocol/src/signature.rs
@@ -5,20 +5,26 @@
 //! variant — production secure mode (`VerificationPolicy::Strict`) MUST
 //! refuse unsigned frames. Dev mode (`VerificationPolicy::AllowUnsigned`)
 //! permits `Unsigned` so the substrate is testable end-to-end before
-//! keypairs are plumbed (transport / bridge work lands in PR-2/3).
+//! every adapter is keyed.
 //!
-//! Ed25519 byte-level signing/verification is not wired in this PR — the
-//! crypto plumbing is its own side-quest (key generation, key-rotation,
-//! key registry persistence) and lands once the transport adapter exists.
-//! In the meantime: a `Signature::Ed25519` frame submitted under `Strict`
-//! returns `UnknownSigner` until the registry is populated, which is the
-//! correct fail-closed behavior. This file pins the contract; PR-3
-//! supplies the bytes.
+//! PR-3a wired real Ed25519 verification via `ed25519-dalek`. The verify
+//! path:
+//!   1. Structural validation (reply_to consistency).
+//!   2. Policy dispatch on `Signature` variant.
+//!   3. For `Ed25519`: registry lookup (UnknownSigner if missing),
+//!      canonical CBOR encoding, byte-level signature verification.
+//!
+//! No silent passes, no "try secure then plaintext" fallback. Strict
+//! policy fails closed on every failure mode.
+//!
+//! See `keypair` module for the send side (`PeerKeypair`).
 
+use ed25519_dalek::{Signature as Ed25519Sig, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
 
 use airc_core::PeerId;
 
+use crate::canonical::canonical_signed_bytes;
 use crate::envelope::{Envelope, Frame};
 use crate::headers_keys::HEADER_AIRC_REPLY_TO;
 
@@ -58,17 +64,45 @@ pub enum VerificationPolicy {
     AllowUnsigned,
 }
 
-/// Registry of which `PeerId`s have which public keys. Populated by the
-/// bridge / pairing layer (PR-3+). PR-1 ships an empty-by-default
-/// implementation so `Strict` verification of `Ed25519` frames fails
-/// closed with `UnknownSigner` rather than silently passing.
+/// Why enroling a key might fail.
+#[derive(Debug)]
+pub enum KeyError {
+    /// 32-byte pubkey didn't decode as a valid Ed25519 point. Caller
+    /// passed garbage or a key from a different curve.
+    InvalidPublicKey(ed25519_dalek::SignatureError),
+}
+
+impl std::fmt::Display for KeyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KeyError::InvalidPublicKey(error) => {
+                write!(f, "invalid Ed25519 public key: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for KeyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            KeyError::InvalidPublicKey(error) => Some(error),
+        }
+    }
+}
+
+/// Registry of which `PeerId`s have which public keys.
+///
+/// Storage is parsed `VerifyingKey` rather than raw bytes, so verify
+/// doesn't re-parse on every frame (per-frame parsing would burn a
+/// noticeable fraction of the verify budget). `enrol` validates the
+/// bytes once at enrolment time.
 #[derive(Debug, Default, Clone)]
 pub struct PeerKeyRegistry {
     // HashMap rather than BTreeMap — PeerId is a UUIDv4 newtype which
     // derives Hash+Eq but not Ord. The registry isn't serialized or
     // iterated for canonical output, so non-deterministic key order is
     // harmless here.
-    keys: std::collections::HashMap<(PeerId, u32), [u8; 32]>,
+    keys: std::collections::HashMap<(PeerId, u32), VerifyingKey>,
 }
 
 impl PeerKeyRegistry {
@@ -78,14 +112,20 @@ impl PeerKeyRegistry {
         }
     }
 
-    /// Enrol a peer's public key (32 bytes for Ed25519). `key_id` allows
-    /// the same peer to have multiple keys for rotation.
-    pub fn enrol(&mut self, peer: PeerId, key_id: u32, pubkey: [u8; 32]) {
-        self.keys.insert((peer, key_id), pubkey);
+    /// Enrol a peer's public key (32 bytes for Ed25519). `key_id`
+    /// allows the same peer to have multiple keys for rotation.
+    /// Returns `KeyError::InvalidPublicKey` if the bytes don't
+    /// decode as a valid Ed25519 point — substrate refuses garbage
+    /// at enrolment rather than at verify time.
+    pub fn enrol(&mut self, peer: PeerId, key_id: u32, pubkey: [u8; 32]) -> Result<(), KeyError> {
+        let verifying_key =
+            VerifyingKey::from_bytes(&pubkey).map_err(KeyError::InvalidPublicKey)?;
+        self.keys.insert((peer, key_id), verifying_key);
+        Ok(())
     }
 
-    /// Look up a pubkey for verification.
-    pub fn lookup(&self, peer: PeerId, key_id: u32) -> Option<&[u8; 32]> {
+    /// Look up a parsed `VerifyingKey` for verification.
+    pub fn lookup(&self, peer: PeerId, key_id: u32) -> Option<&VerifyingKey> {
         self.keys.get(&(peer, key_id))
     }
 }
@@ -99,10 +139,10 @@ pub enum VerificationError {
     /// `Signature::Ed25519` signer is not in the registry.
     UnknownSigner(PeerId),
 
-    /// Cryptographic verification failed. (PR-3 wires the actual check;
-    /// PR-1 returns this only when the registry has a key AND the
-    /// envelope's canonical encoding fails to match — wired so the
-    /// failure mode exists end-to-end.)
+    /// Cryptographic verification failed — the canonical bytes did
+    /// not verify against the enrolled `VerifyingKey`. Indicates
+    /// tampering, replay with mutated content, or use of the wrong
+    /// key. PR-3a wired this to real Ed25519; PR-1 had it stubbed.
     BadSignature,
 
     /// `Envelope.reply_to` and `headers["airc.reply_to"]` are both set
@@ -163,24 +203,45 @@ pub fn verify(
             VerificationPolicy::Strict => Err(VerificationError::MissingSignature),
             VerificationPolicy::AllowUnsigned => Ok(()),
         },
-        Signature::Ed25519 { signer, key_id, .. } => {
-            // Registry lookup. Missing key → fail closed (UnknownSigner).
-            // This is the path that returns the right error even before
-            // the Ed25519 byte-level check is wired.
-            if registry.lookup(*signer, *key_id).is_none() {
-                return Err(VerificationError::UnknownSigner(*signer));
-            }
-            // PR-3 wires the actual cryptographic verification here:
-            //   1. canonical_encode(envelope-minus-sig) -> bytes
-            //   2. ed25519_dalek::PublicKey::verify(bytes, sig)
-            //   3. Err(BadSignature) on mismatch
-            //
-            // PR-1 reaches this point only when the registry was
-            // populated, which doesn't happen in PR-1's call sites.
-            // Strict + Ed25519 + empty registry = UnknownSigner (above).
-            Ok(())
-        }
+        Signature::Ed25519 {
+            signer,
+            key_id,
+            sig,
+        } => verify_ed25519(&frame.envelope, *signer, *key_id, sig, registry),
     }
+}
+
+/// Crypto-level verification for an Ed25519-signed envelope. Splits
+/// out the lookup + canonical-encode + ed25519 verify steps so the
+/// dispatcher in `verify` stays a clean policy match.
+///
+/// Steps:
+///   1. Look up `(signer, key_id)` in the registry — `None` →
+///      `UnknownSigner` (fail-closed).
+///   2. Canonical-encode the envelope (everything except signature).
+///   3. Ed25519-verify the 64-byte signature over those bytes.
+fn verify_ed25519(
+    envelope: &Envelope,
+    signer: PeerId,
+    key_id: u32,
+    sig_bytes: &[u8; 64],
+    registry: &PeerKeyRegistry,
+) -> Result<(), VerificationError> {
+    let verifying_key = registry
+        .lookup(signer, key_id)
+        .ok_or(VerificationError::UnknownSigner(signer))?;
+
+    let canonical =
+        canonical_signed_bytes(envelope).map_err(|_| VerificationError::CanonicalEncodingFailed)?;
+
+    // `Ed25519Sig::from_bytes` cannot fail for a 64-byte array (the
+    // newer dalek API is infallible-by-length). Any "this is not a
+    // valid signature" comes out of `verify` itself.
+    let signature = Ed25519Sig::from_bytes(sig_bytes);
+
+    verifying_key
+        .verify(&canonical, &signature)
+        .map_err(|_| VerificationError::BadSignature)
 }
 
 /// Internal: enforce that the structured `reply_to` and the optional
@@ -319,24 +380,28 @@ mod tests {
     }
 
     #[test]
-    fn ed25519_with_registered_signer_passes_pr1_stub() {
-        // PR-1's verify reaches Ok(()) when the registry has the key.
-        // PR-3 wires the actual ed25519_dalek check here; this test
-        // pins the contract so the regression surfaces if anyone
-        // weakens it (e.g. early-returning Ok before crypto).
+    fn ed25519_with_garbage_signature_fails_bad_signature() {
+        // PR-3a wired real Ed25519. An all-zero 64-byte signature
+        // can't possibly verify against a real enrolled pubkey —
+        // pin BadSignature as the resulting error. (PR-1 had a stub
+        // that early-returned Ok here; this test replaces that stub
+        // assertion with the correct fail-closed behavior.)
+        use crate::keypair::PeerKeypair;
         let signer = PeerId::from_u128(0xa1);
+        let real_keypair = PeerKeypair::generate();
         let mut registry = PeerKeyRegistry::new();
-        registry.enrol(signer, 0, [0u8; 32]);
+        registry
+            .enrol(signer, 0, real_keypair.public_bytes())
+            .unwrap();
         let frame = frame_with(Signature::Ed25519 {
             signer,
             key_id: 0,
             sig: [0u8; 64],
         });
-        // NOTE: this passes in PR-1 because the byte-level check isn't
-        // wired yet. In PR-3 the all-zero key + all-zero sig will fail
-        // BadSignature, which will be the desired stronger contract.
-        // The test name flags this is the PR-1 stub.
-        assert!(verify(&frame, VerificationPolicy::Strict, &registry).is_ok());
+        assert_eq!(
+            verify(&frame, VerificationPolicy::Strict, &registry),
+            Err(VerificationError::BadSignature)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR-1 (#667) shipped `Signature::Ed25519` + the policy dispatcher but left `verify()` as a stub. This PR wires real `ed25519-dalek` byte-level verify + adds the send side (`PeerKeypair`). Per Codex's PR-3 steer + Joel's \"always go most-capable\" principle:

- **No plaintext production paths**
- **No silent-pass shortcuts** — Strict policy fails closed on every failure mode
- **Crypto choice = Ed25519** (sub-50µs verify, deterministic sign, standard ecosystem, fits the per-frame budget)

## New: `keypair.rs`

```rust
pub struct PeerKeypair { ... }
impl PeerKeypair {
    pub fn generate() -> Self;
    pub fn from_secret_bytes(secret: &[u8; 32]) -> Self;
    pub fn secret_bytes(&self) -> [u8; 32];
    pub fn public_bytes(&self) -> [u8; 32];
    pub fn verifying_key(&self) -> VerifyingKey;
    pub fn sign_envelope(&self, &Envelope, PeerId, u32) -> Result<Signature, CanonicalError>;
}
```

`Debug` redacts the secret (pinned by `debug_redacts_secret` test). Storage is in-memory only; persistence (SQLCipher, keychain, hardware enclave) is the integrator's responsibility.

## Changed: `signature.rs`

- `PeerKeyRegistry` storage: raw `[u8; 32]` → parsed `VerifyingKey`. Pre-validate at enrol time so the verify hot path doesn't re-parse on every frame.
- `enrol()` now returns `Result<(), KeyError>`. Refuses invalid Ed25519 points at enrolment.
- `verify()` dispatches `Signature::Ed25519` to `verify_ed25519`: registry lookup → canonical CBOR encode → `ed25519_dalek::Verifier::verify`. Lookup miss = `UnknownSigner`; crypto mismatch = `BadSignature`.

## Tests (10 new in `keypair.rs`)

- `sign_then_verify_with_enrolled_key_passes_under_strict` — base round-trip
- `tampered_envelope_after_signing_fails_bad_signature` — body tamper
- `tampered_lamport_fails_bad_signature` — ordering field
- `tampered_headers_fail_bad_signature` — header injection
- `tampered_reply_to_fails_bad_signature` — threading field
- `wrong_pubkey_in_registry_fails_bad_signature` — evil-twin pubkey
- `unenrolled_signer_fails_unknown_signer` — fail-closed on empty registry
- `key_rotation_via_key_id_works` — same peer, two keys, both verify
- `keypair_secret_roundtrips_through_bytes` — persistence contract
- `debug_redacts_secret` — no secret in \`Debug\` output

PR-1's stub test (\`ed25519_with_registered_signer_passes_pr1_stub\`) is rewritten as `ed25519_with_garbage_signature_fails_bad_signature` — asserts an all-zero sig against a real pubkey fails BadSignature (the correct stronger contract).

## Test plan

- [x] \`cargo fmt -p airc-protocol\` — clean
- [x] \`cargo clippy -p airc-protocol --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p airc-protocol\` — **44 pass / 0 fail** (was 34 in PR-1)

## Stack

Stacked on \`feat/airc-protocol-envelope\` (#667). **Next: PR-3b** (\`feat/airc-transport-lan-tcp\`) — secure LAN transport (TLS via rustls peer-pinning to these Ed25519 keys). Fails closed when keys/certs are missing.

## Dependencies

Adds: \`ed25519-dalek = \"2\"\`, \`rand = \"0.8\"\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)