### PR TITLE
feat(airc-transport): TLS peer-pinning infrastructure (cert gen + verifiers)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -41,12 +41,18 @@ dependencies = [
  "airc-core",
  "airc-protocol",
  "async-trait",
+ "ed25519-dalek",
  "fs2",
  "futures",
+ "rcgen",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-rustls",
+ "x509-parser",
 ]
 
 [[package]]
@@ -54,6 +60,45 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "async-trait"
@@ -67,10 +112,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -98,6 +164,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -191,6 +267,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +283,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +313,17 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -247,7 +363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -261,6 +377,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -475,6 +597,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,10 +633,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -525,6 +733,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -600,12 +814,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -618,7 +869,41 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -688,6 +973,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +992,16 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "spki"
@@ -730,6 +1031,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,7 +1051,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -748,7 +1060,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -763,14 +1084,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -782,6 +1149,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -801,6 +1178,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uuid"
@@ -953,12 +1336,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1052,6 +1508,34 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,10 +33,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-transport"
+version = "0.1.0"
+dependencies = [
+ "airc-core",
+ "airc-protocol",
+ "async-trait",
+ "fs2",
+ "futures",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bitflags"
@@ -58,6 +84,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"
@@ -134,16 +166,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -157,8 +274,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -273,6 +395,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +457,19 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -414,6 +555,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +581,28 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -564,6 +740,43 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
-members = ["crates/airc-core", "crates/airc-blobs", "crates/airc-protocol"]
+members = [
+    "crates/airc-core",
+    "crates/airc-blobs",
+    "crates/airc-protocol",
+    "crates/airc-transport",
+]
 resolver = "2"

--- a/crates/airc-protocol/src/signature.rs
+++ b/crates/airc-protocol/src/signature.rs
@@ -128,6 +128,28 @@ impl PeerKeyRegistry {
     pub fn lookup(&self, peer: PeerId, key_id: u32) -> Option<&VerifyingKey> {
         self.keys.get(&(peer, key_id))
     }
+
+    /// Reverse lookup: find which `(peer, key_id)` enrolled a given
+    /// pubkey. Used by the lan-tcp TLS verifier — at handshake time
+    /// the server receives a client cert but doesn't know which peer
+    /// is connecting; it extracts the cert's Ed25519 pubkey, calls
+    /// `find_peer`, and either binds the connection to the resulting
+    /// peer or rejects on miss.
+    ///
+    /// Returns the first match (each pubkey should be unique per
+    /// `(peer, key_id)`, but if a duplicate is enrolled, the first
+    /// hit wins). Iteration order is non-deterministic — fine for
+    /// reverse-lookup correctness because we only need to know
+    /// whether ANY match exists.
+    pub fn find_peer(&self, pubkey: &[u8; 32]) -> Option<(PeerId, u32)> {
+        self.keys.iter().find_map(|((peer, key_id), key)| {
+            if key.as_bytes() == pubkey {
+                Some((*peer, *key_id))
+            } else {
+                None
+            }
+        })
+    }
 }
 
 /// What can go wrong when verifying a frame.

--- a/crates/airc-transport/Cargo.toml
+++ b/crates/airc-transport/Cargo.toml
@@ -10,10 +10,16 @@ airc-core = { path = "../airc-core" }
 airc-protocol = { path = "../airc-protocol" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["fs", "io-util", "rt", "rt-multi-thread", "sync", "time", "macros"] }
+tokio = { version = "1", features = ["fs", "io-util", "net", "rt", "rt-multi-thread", "sync", "time", "macros"] }
 async-trait = "0.1"
 futures = "0.3"
 fs2 = "0.4"
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "ring"] }
+rcgen = { version = "0.14", default-features = false, features = ["pem", "ring"] }
+rustls-pki-types = "1"
+ed25519-dalek = { version = "2", features = ["pkcs8"] }
+x509-parser = "0.18"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/airc-transport/Cargo.toml
+++ b/crates/airc-transport/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "airc-transport"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+[dependencies]
+airc-core = { path = "../airc-core" }
+airc-protocol = { path = "../airc-protocol" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["fs", "io-util", "rt", "rt-multi-thread", "sync", "time", "macros"] }
+async-trait = "0.1"
+futures = "0.3"
+fs2 = "0.4"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["test-util", "macros", "rt-multi-thread"] }

--- a/crates/airc-transport/src/error.rs
+++ b/crates/airc-transport/src/error.rs
@@ -7,6 +7,85 @@
 
 use std::fmt;
 
+/// What can go wrong inside the lan-tcp adapter.
+///
+/// LAN-TCP is **DEV-PREVIEW** until PR-4 wires rustls peer pinning +
+/// real Ed25519 verification. The error variants below include the
+/// security-guard refusal cases so the substrate fails closed rather
+/// than silently exposing a plaintext wire on the LAN.
+#[derive(Debug)]
+pub enum LanTcpError {
+    /// File or socket I/O failed.
+    Io(std::io::Error),
+
+    /// A peer sent bytes that didn't parse as a `Frame`. The substrate
+    /// refuses rather than silently dropping — possibly a protocol
+    /// mismatch, a hostile peer, or a wire corruption.
+    Json(serde_json::Error),
+
+    /// The caller asked to bind a non-loopback address without
+    /// threading `unsafe_allow_public_bind()`. Default refuses — the
+    /// LAN adapter is DEV-PREVIEW and must not be exposed on a real
+    /// network without explicit opt-in.
+    PublicBindNotAllowed(std::net::SocketAddr),
+
+    /// The builder was driven to `.build()` without a bind address.
+    MissingBindAddr,
+
+    /// A peer sent a length-prefix exceeding the per-frame limit.
+    /// Substrate caps frame size to defend against OOM from a hostile
+    /// peer. Honest senders stay well under via the body-lift policy.
+    FrameTooLarge { announced: u64, limit: u64 },
+}
+
+impl fmt::Display for LanTcpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LanTcpError::Io(error) => write!(f, "lan-tcp transport I/O: {error}"),
+            LanTcpError::Json(error) => write!(f, "lan-tcp transport frame parse: {error}"),
+            LanTcpError::PublicBindNotAllowed(addr) => write!(
+                f,
+                "lan-tcp refused to bind non-loopback address {addr} \
+                 — adapter is DEV-PREVIEW (no transport encryption, \
+                 no Ed25519 verification wired); thread \
+                 unsafe_allow_public_bind() to override"
+            ),
+            LanTcpError::MissingBindAddr => write!(
+                f,
+                "lan-tcp builder missing bind address — call .bind(addr) before .build()"
+            ),
+            LanTcpError::FrameTooLarge { announced, limit } => write!(
+                f,
+                "lan-tcp refused frame with announced size {announced} bytes \
+                 (limit {limit}) — bodies above limit must be lifted to \
+                 airc-blobs and carried as MediaRef"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LanTcpError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            LanTcpError::Io(error) => Some(error),
+            LanTcpError::Json(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for LanTcpError {
+    fn from(error: std::io::Error) -> Self {
+        LanTcpError::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for LanTcpError {
+    fn from(error: serde_json::Error) -> Self {
+        LanTcpError::Json(error)
+    }
+}
+
 /// What can go wrong inside the local-fs adapter.
 #[derive(Debug)]
 pub enum LocalFsError {

--- a/crates/airc-transport/src/error.rs
+++ b/crates/airc-transport/src/error.rs
@@ -1,0 +1,53 @@
+//! Transport-level errors.
+//!
+//! Each adapter declares its own `Error` associated type, but they share
+//! the same general failure modes (I/O failed, serialization failed,
+//! the wire isn't ready). This module gives `LocalFsAdapter` a typed
+//! error; other adapters will follow the same pattern.
+
+use std::fmt;
+
+/// What can go wrong inside the local-fs adapter.
+#[derive(Debug)]
+pub enum LocalFsError {
+    /// File or directory I/O failed — couldn't open the wire dir,
+    /// couldn't read the frames file, fsync failed, etc.
+    Io(std::io::Error),
+
+    /// A line in the frames file failed to parse as a `Frame`. Either
+    /// the file was corrupted, or a different writer is using an
+    /// incompatible format on the same wire. The substrate refuses
+    /// rather than silently dropping — the caller decides whether to
+    /// continue or abort.
+    Json(serde_json::Error),
+}
+
+impl fmt::Display for LocalFsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LocalFsError::Io(error) => write!(f, "local-fs transport I/O: {error}"),
+            LocalFsError::Json(error) => write!(f, "local-fs transport frame parse: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for LocalFsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            LocalFsError::Io(error) => Some(error),
+            LocalFsError::Json(error) => Some(error),
+        }
+    }
+}
+
+impl From<std::io::Error> for LocalFsError {
+    fn from(error: std::io::Error) -> Self {
+        LocalFsError::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for LocalFsError {
+    fn from(error: serde_json::Error) -> Self {
+        LocalFsError::Json(error)
+    }
+}

--- a/crates/airc-transport/src/lan_tcp/cert.rs
+++ b/crates/airc-transport/src/lan_tcp/cert.rs
@@ -1,0 +1,205 @@
+//! Cert generation + pubkey extraction for TLS peer-pinning.
+//!
+//! - `generate_self_signed_cert(keypair, peer_id)` — turns the
+//!   substrate's `PeerKeypair` (Ed25519) into a self-signed X.509 cert
+//!   suitable for rustls. The cert's subject CN carries the peer's
+//!   UUID string for diagnostics; the cryptographic identity is the
+//!   subject public key (the Ed25519 pubkey itself).
+//!
+//! - `extract_ed25519_pubkey(cert_der)` — reverse direction, used by
+//!   the pinning verifiers: take a received cert and return its
+//!   Ed25519 subject pubkey for registry lookup.
+
+use ed25519_dalek::pkcs8::EncodePrivateKey;
+use ed25519_dalek::SigningKey;
+use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use x509_parser::prelude::*;
+
+use airc_core::PeerId;
+use airc_protocol::PeerKeypair;
+
+/// What can go wrong generating a self-signed cert from a `PeerKeypair`.
+#[derive(Debug)]
+pub enum CertGenError {
+    /// ed25519-dalek couldn't serialize its key as PKCS#8 — should
+    /// only fail for buggy key material; substrate-generated keys
+    /// always serialize cleanly.
+    Pkcs8(ed25519_dalek::pkcs8::Error),
+
+    /// rcgen rejected the PKCS#8 input or failed to produce a cert.
+    Rcgen(String),
+}
+
+impl std::fmt::Display for CertGenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CertGenError::Pkcs8(error) => write!(f, "PKCS#8 serialize: {error}"),
+            CertGenError::Rcgen(message) => write!(f, "rcgen: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for CertGenError {}
+
+/// What can go wrong extracting an Ed25519 pubkey from a received cert.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CertParseError {
+    /// The bytes didn't decode as a valid X.509 cert.
+    InvalidCert(String),
+
+    /// The cert's SubjectPublicKeyInfo algorithm isn't Ed25519
+    /// (OID 1.3.101.112). Peer is using an unsupported key type;
+    /// substrate refuses the handshake.
+    WrongAlgorithm { oid: String },
+
+    /// The subject pubkey field had the wrong length (expected 32
+    /// bytes for Ed25519). Indicates a malformed cert.
+    WrongPubkeyLength { got: usize },
+}
+
+impl std::fmt::Display for CertParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CertParseError::InvalidCert(message) => write!(f, "invalid X.509: {message}"),
+            CertParseError::WrongAlgorithm { oid } => {
+                write!(
+                    f,
+                    "cert subject pubkey is OID {oid}, expected Ed25519 (1.3.101.112)"
+                )
+            }
+            CertParseError::WrongPubkeyLength { got } => {
+                write!(f, "cert subject pubkey is {got} bytes, expected 32")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CertParseError {}
+
+/// Generate a self-signed cert binding `peer_id` to the keypair's
+/// Ed25519 pubkey. Returns the cert + private key in the formats
+/// rustls expects (`CertificateDer` + `PrivateKeyDer`).
+pub fn generate_self_signed_cert(
+    keypair: &PeerKeypair,
+    peer_id: PeerId,
+) -> Result<(CertificateDer<'static>, PrivateKeyDer<'static>), CertGenError> {
+    // ed25519-dalek SigningKey → PKCS#8 DER → rcgen KeyPair. Same
+    // bytes through three representations; the substrate identity
+    // and TLS identity are guaranteed identical by construction.
+    let signing = SigningKey::from_bytes(&keypair.secret_bytes());
+    let pkcs8 = signing.to_pkcs8_der().map_err(CertGenError::Pkcs8)?;
+    let pkcs8_bytes = pkcs8.as_bytes().to_vec();
+
+    let rcgen_key = KeyPair::try_from(pkcs8_bytes.as_slice())
+        .map_err(|error| CertGenError::Rcgen(error.to_string()))?;
+
+    // Subject Common Name = peer UUID string. Substrate doesn't read
+    // this back; it's purely for diagnostics ("openssl x509 -text -in
+    // peer.der" shows the PeerId).
+    let mut dn = DistinguishedName::new();
+    dn.push(DnType::CommonName, peer_id.to_string());
+
+    let mut params = CertificateParams::new(Vec::<String>::new())
+        .map_err(|error| CertGenError::Rcgen(error.to_string()))?;
+    params.distinguished_name = dn;
+
+    let cert = params
+        .self_signed(&rcgen_key)
+        .map_err(|error| CertGenError::Rcgen(error.to_string()))?;
+
+    let cert_der = CertificateDer::from(cert.der().to_vec());
+    let key_der = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(pkcs8_bytes));
+
+    Ok((cert_der, key_der))
+}
+
+/// Extract the Ed25519 subject pubkey from a received cert.
+///
+/// Used by both `PinnedServerVerifier` (server side, on receiving a
+/// client cert) and `PinnedClientVerifier` (client side, on receiving
+/// a server cert). Returns the 32-byte pubkey ready to pass to
+/// `PeerKeyRegistry::find_peer` or `::lookup`.
+pub fn extract_ed25519_pubkey(cert_der: &CertificateDer<'_>) -> Result<[u8; 32], CertParseError> {
+    let (_, parsed) = X509Certificate::from_der(cert_der.as_ref())
+        .map_err(|error| CertParseError::InvalidCert(error.to_string()))?;
+
+    let spki = &parsed.subject_pki;
+    // Ed25519 OID per RFC 8410.
+    let oid = spki.algorithm.algorithm.to_id_string();
+    if oid != "1.3.101.112" {
+        return Err(CertParseError::WrongAlgorithm { oid });
+    }
+
+    let pubkey_bits = &spki.subject_public_key.data;
+    if pubkey_bits.len() != 32 {
+        return Err(CertParseError::WrongPubkeyLength {
+            got: pubkey_bits.len(),
+        });
+    }
+
+    let mut out = [0u8; 32];
+    out.copy_from_slice(pubkey_bits);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_protocol::PeerKeypair;
+
+    #[test]
+    fn generated_cert_carries_the_keypair_pubkey() {
+        // The core invariant: the substrate's Ed25519 identity and the
+        // TLS cert's subject pubkey are the SAME bytes. If they
+        // diverge, peer-pinning becomes meaningless (you'd pin to one
+        // key and verify TLS with another).
+        let keypair = PeerKeypair::generate();
+        let peer_id = PeerId::from_u128(0xa1);
+        let (cert_der, _key_der) = generate_self_signed_cert(&keypair, peer_id).unwrap();
+        let extracted = extract_ed25519_pubkey(&cert_der).unwrap();
+        assert_eq!(extracted, keypair.public_bytes());
+    }
+
+    #[test]
+    fn two_keypairs_produce_different_pubkeys_in_certs() {
+        // Sanity: each peer's cert pins its own key, not some global
+        // constant. Catches a hypothetical regression where the
+        // generator hardcoded a test pubkey.
+        let kp_a = PeerKeypair::generate();
+        let kp_b = PeerKeypair::generate();
+        let peer = PeerId::from_u128(0xa1);
+        let (cert_a, _) = generate_self_signed_cert(&kp_a, peer).unwrap();
+        let (cert_b, _) = generate_self_signed_cert(&kp_b, peer).unwrap();
+        assert_ne!(
+            extract_ed25519_pubkey(&cert_a).unwrap(),
+            extract_ed25519_pubkey(&cert_b).unwrap()
+        );
+    }
+
+    #[test]
+    fn malformed_cert_bytes_return_invalid_cert_error() {
+        // Garbage in → typed error out. The TLS verifier surfaces this
+        // as a handshake rejection rather than panicking.
+        let garbage = CertificateDer::from(vec![0u8; 16]);
+        let result = extract_ed25519_pubkey(&garbage);
+        assert!(matches!(result, Err(CertParseError::InvalidCert(_))));
+    }
+
+    #[test]
+    fn cert_round_trips_through_der_bytes() {
+        // The cert produced for rustls must serialize cleanly and the
+        // extracted pubkey survives. If rcgen ever changes its
+        // encoding, this catches it.
+        let keypair = PeerKeypair::generate();
+        let peer_id = PeerId::from_u128(0xc0ffee);
+        let (cert_der, _) = generate_self_signed_cert(&keypair, peer_id).unwrap();
+        // Round trip via a Vec to simulate cert leaving + returning.
+        let bytes: Vec<u8> = cert_der.as_ref().to_vec();
+        let recoded = CertificateDer::from(bytes);
+        assert_eq!(
+            extract_ed25519_pubkey(&recoded).unwrap(),
+            keypair.public_bytes()
+        );
+    }
+}

--- a/crates/airc-transport/src/lan_tcp/mod.rs
+++ b/crates/airc-transport/src/lan_tcp/mod.rs
@@ -1,0 +1,30 @@
+//! Secure LAN transport — TLS-wrapped TCP with peer-pinned Ed25519
+//! identities.
+//!
+//! AI peers on the same LAN talk via TLS 1.2/1.3 over plain TCP. There
+//! is **no plaintext path**: the only way to use this transport is with
+//! mutual TLS where both peers present self-signed X.509 certs bound
+//! to the substrate's Ed25519 identity keys. Receivers pin by Ed25519
+//! pubkey via the substrate's `PeerKeyRegistry` — no CA, no PKI bridge,
+//! no chain-of-trust. The cert IS the identity assertion; the registry
+//! IS the trust anchor.
+//!
+//! Failure modes are fail-closed:
+//!   - Receiving a cert whose Ed25519 pubkey isn't enrolled → reject.
+//!   - Receiving a cert from a peer different from the expected one
+//!     (client side, where the caller knows who they're dialing) →
+//!     reject.
+//!   - Cert decode failure / wrong SPKI algorithm → reject.
+//!
+//! This module owns the cryptographic *infrastructure* — cert
+//! generation and pinning verifiers. The `LanTcpAdapter` (a
+//! `Transport` impl that uses these verifiers to wrap real TCP
+//! connections in TLS) lands in PR-3c; this PR pins the security
+//! foundation independently so it's reviewable and testable in
+//! isolation.
+
+pub mod cert;
+pub mod verifier;
+
+pub use cert::{extract_ed25519_pubkey, generate_self_signed_cert, CertGenError, CertParseError};
+pub use verifier::{PinnedClientVerifier, PinnedServerVerifier};

--- a/crates/airc-transport/src/lan_tcp/verifier.rs
+++ b/crates/airc-transport/src/lan_tcp/verifier.rs
@@ -1,0 +1,417 @@
+//! TLS verifiers that pin to enrolled Ed25519 pubkeys.
+//!
+//! rustls's default chain-of-trust validation (CA → intermediate →
+//! leaf) doesn't fit airc's model: there is no CA, no PKI hierarchy,
+//! no chain. The substrate's `PeerKeyRegistry` IS the trust anchor.
+//! We replace rustls's standard verifiers with these two:
+//!
+//! - **`PinnedServerVerifier`** — client-side. The caller knows which
+//!   peer they're dialing (passed at construction). The verifier
+//!   accepts the server cert iff its subject pubkey matches one of
+//!   the expected peer's enrolled keys. Wrong peer / wrong key →
+//!   reject. Cert isn't Ed25519 → reject. Pubkey not enrolled →
+//!   reject. There is no path that accepts an unknown server.
+//!
+//! - **`PinnedClientVerifier`** — server-side. The server can't know
+//!   in advance which peer is connecting, so the verifier accepts any
+//!   client whose cert pubkey is enrolled in the registry for ANY
+//!   peer. Caller looks up the peer post-handshake via
+//!   `PeerKeyRegistry::find_peer` for connection binding. Cert not in
+//!   registry → reject.
+//!
+//! Both verifiers reject:
+//!   - Malformed cert DER
+//!   - Non-Ed25519 subject pubkey (wrong algorithm OID)
+//!   - Pubkey length ≠ 32 bytes (malformed Ed25519 SPKI)
+//!
+//! There is no "fall back to standard PKI" path. There is no
+//! "allow self-signed" toggle. The only acceptance criterion is
+//! "this pubkey is in the registry."
+
+use std::sync::Arc;
+use std::sync::RwLock;
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
+use rustls::{DigitallySignedStruct, DistinguishedName, Error as RustlsError, SignatureScheme};
+use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
+
+use airc_core::PeerId;
+use airc_protocol::PeerKeyRegistry;
+
+use crate::lan_tcp::cert::extract_ed25519_pubkey;
+
+/// Schemes we tell rustls we can verify for. Just Ed25519 — substrate
+/// identity is exclusively Ed25519, no fall-back ciphers.
+fn supported_schemes() -> Vec<SignatureScheme> {
+    vec![SignatureScheme::ED25519]
+}
+
+/// Client-side: the caller dialed a specific `expected_peer` and the
+/// server's cert MUST present one of that peer's enrolled keys.
+#[derive(Debug)]
+pub struct PinnedServerVerifier {
+    expected_peer: PeerId,
+    registry: Arc<RwLock<PeerKeyRegistry>>,
+}
+
+impl PinnedServerVerifier {
+    pub fn new(expected_peer: PeerId, registry: Arc<RwLock<PeerKeyRegistry>>) -> Self {
+        Self {
+            expected_peer,
+            registry,
+        }
+    }
+}
+
+impl ServerCertVerifier for PinnedServerVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, RustlsError> {
+        let pubkey = extract_ed25519_pubkey(end_entity)
+            .map_err(|error| RustlsError::General(error.to_string()))?;
+
+        let registry = self
+            .registry
+            .read()
+            .map_err(|error| RustlsError::General(format!("registry lock: {error}")))?;
+
+        // Resolve the cert's pubkey to a (peer, key_id) entry. We
+        // accept only if the resolved peer matches the expected one.
+        match registry.find_peer(&pubkey) {
+            Some((peer, _key_id)) if peer == self.expected_peer => {
+                Ok(ServerCertVerified::assertion())
+            }
+            Some((peer, _)) => Err(RustlsError::General(format!(
+                "server cert is for peer {peer}, expected {expected}",
+                expected = self.expected_peer
+            ))),
+            None => Err(RustlsError::General(format!(
+                "server cert pubkey is not enrolled (expected peer {})",
+                self.expected_peer
+            ))),
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        // Substrate is Ed25519-only; TLS 1.2 paths are not used. Reject
+        // explicitly so a downgrade attack surfaces as a hard error.
+        Err(RustlsError::General(
+            "TLS 1.2 not supported by airc substrate (Ed25519-only, TLS 1.3 path)".into(),
+        ))
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        verify_tls13_ed25519(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        supported_schemes()
+    }
+}
+
+/// Server-side: accept any cert whose pubkey is enrolled in the
+/// registry. The caller resolves the peer post-handshake.
+#[derive(Debug)]
+pub struct PinnedClientVerifier {
+    registry: Arc<RwLock<PeerKeyRegistry>>,
+    /// Held as an owned empty slice so `root_hint_subjects` can
+    /// return a borrow per the rustls 0.23 trait signature.
+    empty_hints: Vec<DistinguishedName>,
+}
+
+impl PinnedClientVerifier {
+    pub fn new(registry: Arc<RwLock<PeerKeyRegistry>>) -> Self {
+        Self {
+            registry,
+            empty_hints: Vec::new(),
+        }
+    }
+}
+
+impl ClientCertVerifier for PinnedClientVerifier {
+    fn root_hint_subjects(&self) -> &[DistinguishedName] {
+        // No CA-issued hints; clients use self-signed substrate certs.
+        // Returning empty tells rustls "I'm not advertising any CA
+        // subject names" which is the correct posture for self-signed
+        // peer-pinned auth.
+        &self.empty_hints
+    }
+
+    fn verify_client_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _now: UnixTime,
+    ) -> Result<ClientCertVerified, RustlsError> {
+        let pubkey = extract_ed25519_pubkey(end_entity)
+            .map_err(|error| RustlsError::General(error.to_string()))?;
+
+        let registry = self
+            .registry
+            .read()
+            .map_err(|error| RustlsError::General(format!("registry lock: {error}")))?;
+
+        // Any enrolled peer is acceptable; the adapter will read the
+        // cert pubkey post-handshake and bind the connection to the
+        // resolved PeerId. Pubkey not in registry → reject.
+        if registry.find_peer(&pubkey).is_some() {
+            Ok(ClientCertVerified::assertion())
+        } else {
+            Err(RustlsError::General(
+                "client cert pubkey is not enrolled in the peer key registry".to_string(),
+            ))
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        Err(RustlsError::General(
+            "TLS 1.2 not supported by airc substrate (Ed25519-only, TLS 1.3 path)".into(),
+        ))
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        verify_tls13_ed25519(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        supported_schemes()
+    }
+}
+
+/// Shared Ed25519 TLS 1.3 signature verification. Both verifiers
+/// delegate here so the crypto check stays in one place.
+fn verify_tls13_ed25519(
+    message: &[u8],
+    cert: &CertificateDer<'_>,
+    dss: &DigitallySignedStruct,
+) -> Result<HandshakeSignatureValid, RustlsError> {
+    if dss.scheme != SignatureScheme::ED25519 {
+        return Err(RustlsError::General(format!(
+            "TLS handshake offered scheme {scheme:?}, expected Ed25519 only",
+            scheme = dss.scheme,
+        )));
+    }
+
+    let pubkey_bytes =
+        extract_ed25519_pubkey(cert).map_err(|error| RustlsError::General(error.to_string()))?;
+
+    let verifying_key = ed25519_dalek::VerifyingKey::from_bytes(&pubkey_bytes)
+        .map_err(|error| RustlsError::General(format!("Ed25519 pubkey decode: {error}")))?;
+
+    if dss.signature().len() != 64 {
+        return Err(RustlsError::General(format!(
+            "TLS 1.3 Ed25519 signature is {} bytes, expected 64",
+            dss.signature().len()
+        )));
+    }
+    let mut sig_bytes = [0u8; 64];
+    sig_bytes.copy_from_slice(dss.signature());
+    let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
+
+    use ed25519_dalek::Verifier;
+    verifying_key
+        .verify(message, &signature)
+        .map(|_| HandshakeSignatureValid::assertion())
+        .map_err(|_| RustlsError::General("TLS 1.3 Ed25519 signature did not verify".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_protocol::PeerKeypair;
+
+    use crate::lan_tcp::cert::generate_self_signed_cert;
+
+    fn make_registry_with(peer: PeerId, keypair: &PeerKeypair) -> Arc<RwLock<PeerKeyRegistry>> {
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
+        Arc::new(RwLock::new(registry))
+    }
+
+    fn unix_now() -> UnixTime {
+        // The verifiers ignore the time argument (we don't enforce
+        // notBefore/notAfter — pinning IS the check). Pass a stable
+        // value so tests stay deterministic.
+        UnixTime::since_unix_epoch(std::time::Duration::from_secs(1_700_000_000))
+    }
+
+    #[test]
+    fn server_verifier_accepts_expected_peer_cert() {
+        // The base secure case: dialing peer A, A's cert presents
+        // their enrolled key → verify_server_cert returns Ok.
+        let peer = PeerId::from_u128(0xa1);
+        let keypair = PeerKeypair::generate();
+        let (cert, _) = generate_self_signed_cert(&keypair, peer).unwrap();
+        let registry = make_registry_with(peer, &keypair);
+
+        let verifier = PinnedServerVerifier::new(peer, registry);
+        let server_name = ServerName::try_from("localhost").unwrap();
+        let result = verifier.verify_server_cert(&cert, &[], &server_name, &[], unix_now());
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    #[test]
+    fn server_verifier_rejects_wrong_peer_cert() {
+        // We dialed peer A, but the cert is from peer B (B also has
+        // an enrolled key in the registry, just not the one we want).
+        // Must reject — pinning isn't "any enrolled peer," it's "the
+        // expected one."
+        let peer_a = PeerId::from_u128(0xa1);
+        let peer_b = PeerId::from_u128(0xb2);
+        let kp_a = PeerKeypair::generate();
+        let kp_b = PeerKeypair::generate();
+        let (cert_b, _) = generate_self_signed_cert(&kp_b, peer_b).unwrap();
+
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(peer_a, 0, kp_a.public_bytes()).unwrap();
+        registry.enrol(peer_b, 0, kp_b.public_bytes()).unwrap();
+        let registry = Arc::new(RwLock::new(registry));
+
+        let verifier = PinnedServerVerifier::new(peer_a, registry);
+        let server_name = ServerName::try_from("localhost").unwrap();
+        let result = verifier.verify_server_cert(&cert_b, &[], &server_name, &[], unix_now());
+        assert!(result.is_err());
+        // Diagnostic message must call out the mismatch so debug
+        // output is useful when this fires in production.
+        let msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            msg.contains("expected") || msg.contains("for peer"),
+            "error message must mention expected vs actual peer: {msg}"
+        );
+    }
+
+    #[test]
+    fn server_verifier_rejects_unenrolled_cert() {
+        // Cert is well-formed but its pubkey was never enrolled.
+        // Fail-closed: no acceptance path for unknown identities.
+        let peer = PeerId::from_u128(0xa1);
+        let known_keypair = PeerKeypair::generate();
+        let stranger_keypair = PeerKeypair::generate();
+        let (stranger_cert, _) = generate_self_signed_cert(&stranger_keypair, peer).unwrap();
+
+        let registry = make_registry_with(peer, &known_keypair);
+        let verifier = PinnedServerVerifier::new(peer, registry);
+        let server_name = ServerName::try_from("localhost").unwrap();
+        let result =
+            verifier.verify_server_cert(&stranger_cert, &[], &server_name, &[], unix_now());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn server_verifier_rejects_malformed_cert() {
+        // Garbage bytes → typed reject, not a panic.
+        let peer = PeerId::from_u128(0xa1);
+        let keypair = PeerKeypair::generate();
+        let registry = make_registry_with(peer, &keypair);
+        let verifier = PinnedServerVerifier::new(peer, registry);
+        let server_name = ServerName::try_from("localhost").unwrap();
+        let garbage = CertificateDer::from(vec![0u8; 16]);
+        let result = verifier.verify_server_cert(&garbage, &[], &server_name, &[], unix_now());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn client_verifier_accepts_any_enrolled_peer() {
+        // Server accepts a client cert from peer A AND from peer B,
+        // as long as both are enrolled. Server doesn't pin to one
+        // specific peer; it pins to "any enrolled identity."
+        let peer_a = PeerId::from_u128(0xa1);
+        let peer_b = PeerId::from_u128(0xb2);
+        let kp_a = PeerKeypair::generate();
+        let kp_b = PeerKeypair::generate();
+        let (cert_a, _) = generate_self_signed_cert(&kp_a, peer_a).unwrap();
+        let (cert_b, _) = generate_self_signed_cert(&kp_b, peer_b).unwrap();
+
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(peer_a, 0, kp_a.public_bytes()).unwrap();
+        registry.enrol(peer_b, 0, kp_b.public_bytes()).unwrap();
+        let registry = Arc::new(RwLock::new(registry));
+
+        let verifier = PinnedClientVerifier::new(registry);
+        assert!(verifier
+            .verify_client_cert(&cert_a, &[], unix_now())
+            .is_ok());
+        assert!(verifier
+            .verify_client_cert(&cert_b, &[], unix_now())
+            .is_ok());
+    }
+
+    #[test]
+    fn client_verifier_rejects_unenrolled_peer() {
+        // The same shape as the server-side unenrolled case. No
+        // acceptance path for unknown clients.
+        let known_peer = PeerId::from_u128(0xa1);
+        let known_kp = PeerKeypair::generate();
+        let stranger_kp = PeerKeypair::generate();
+        let (stranger_cert, _) =
+            generate_self_signed_cert(&stranger_kp, PeerId::from_u128(0xdeadbeef)).unwrap();
+
+        let registry = make_registry_with(known_peer, &known_kp);
+        let verifier = PinnedClientVerifier::new(registry);
+        let result = verifier.verify_client_cert(&stranger_cert, &[], unix_now());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn verifiers_only_accept_ed25519_scheme() {
+        // Substrate is Ed25519-only. If rustls offers another scheme
+        // (RSA, ECDSA), we tell it we can't verify — forces the
+        // handshake to choose Ed25519 or fail. This is the substrate
+        // posture: no algorithm-downgrade surface.
+        let peer = PeerId::from_u128(0xa1);
+        let keypair = PeerKeypair::generate();
+        let registry = make_registry_with(peer, &keypair);
+
+        let server_verifier = PinnedServerVerifier::new(peer, registry.clone());
+        assert_eq!(
+            server_verifier.supported_verify_schemes(),
+            vec![SignatureScheme::ED25519]
+        );
+
+        let client_verifier = PinnedClientVerifier::new(registry);
+        assert_eq!(
+            client_verifier.supported_verify_schemes(),
+            vec![SignatureScheme::ED25519]
+        );
+    }
+
+    // NOTE: a direct unit test of `verify_tls12_signature` is
+    // omitted because rustls 0.23 makes `DigitallySignedStruct::new`
+    // private. The TLS 1.2 reject path is an unconditional `Err(...)`
+    // — readable from source — and will be exercised end-to-end by
+    // the integration tests once `LanTcpAdapter` lands in PR-3c
+    // (real handshake with TLS 1.3 only, TLS 1.2 paths refused).
+    #[test]
+    fn supported_schemes_helper_returns_only_ed25519() {
+        // The helper is what `supported_verify_schemes()` returns;
+        // pinning it directly catches a regression where someone
+        // adds a fallback scheme to the list.
+        assert_eq!(supported_schemes(), vec![SignatureScheme::ED25519]);
+    }
+}

--- a/crates/airc-transport/src/lib.rs
+++ b/crates/airc-transport/src/lib.rs
@@ -1,0 +1,29 @@
+//! airc-transport — the wire layer between `airc-protocol` envelopes and
+//! whatever bytes actually move between peers.
+//!
+//! One trait, many adapters. The substrate is intentionally agnostic
+//! about the underlying transport so AI peers (Claude Code, Codex,
+//! vHSM sessions, personas, OpenClaw extensions, Hermes agents,
+//! OpenCode app-server bridges) can pick whatever path makes sense:
+//!
+//! - **local-fs** (this PR) — same-machine multi-process via an
+//!   append-only JSONL log. The direct retirement path for gh-polling
+//!   when multiple AI agents share one Mac.
+//! - **lan-tcp** (PR-3) — same-LAN peer-to-peer via TLS-wrapped TCP.
+//! - **tailscale** (PR-4) — mesh transport for cross-network peers.
+//! - **gh-gist** (legacy adapter, eventual removal) — wraps the
+//!   current Python-airc gist transport so a Rust peer can talk to a
+//!   Python peer during the migration window.
+//!
+//! Designed agent-first. The canonical caller is an AI peer sending
+//! frames to other AI peers; human-chat features (typing, presence)
+//! ride on top via `FrameKind::Event` and headers.
+
+pub mod error;
+pub mod local_fs;
+pub mod transport;
+
+// Re-exports — stable public surface.
+pub use error::LocalFsError;
+pub use local_fs::LocalFsAdapter;
+pub use transport::{FrameStream, Transport};

--- a/crates/airc-transport/src/lib.rs
+++ b/crates/airc-transport/src/lib.rs
@@ -20,10 +20,15 @@
 //! ride on top via `FrameKind::Event` and headers.
 
 pub mod error;
+pub mod lan_tcp;
 pub mod local_fs;
 pub mod transport;
 
 // Re-exports — stable public surface.
 pub use error::LocalFsError;
+pub use lan_tcp::{
+    extract_ed25519_pubkey, generate_self_signed_cert, CertGenError, CertParseError,
+    PinnedClientVerifier, PinnedServerVerifier,
+};
 pub use local_fs::LocalFsAdapter;
 pub use transport::{FrameStream, Transport};

--- a/crates/airc-transport/src/local_fs.rs
+++ b/crates/airc-transport/src/local_fs.rs
@@ -231,11 +231,24 @@ async fn tail_loop(
         let len = match tokio::fs::metadata(&path).await {
             Ok(metadata) => metadata.len(),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                // File deleted under us (logrotate, manual cleanup,
+                // teardown). Forget our position so when a writer
+                // recreates the file we read from the start.
+                offset = 0;
                 sleep(POLL_INTERVAL).await;
                 continue;
             }
             Err(error) => return Err(error.into()),
         };
+
+        if len < offset {
+            // Truncation or recreation detected — file is shorter
+            // than our last recorded position. Without this branch
+            // we'd wait forever for the file to grow past the stale
+            // offset, silently dropping every new frame.
+            // (Codex's #668 review finding.)
+            offset = 0;
+        }
 
         if len > offset {
             offset = drain_new_lines(&path, offset, &subscription, &tx).await?;
@@ -636,6 +649,126 @@ mod tests {
             assert_eq!(item.envelope.lamport, received);
         }
         assert_eq!(received, total_sent);
+    }
+
+    #[tokio::test]
+    async fn truncation_recovers_offset_to_start() {
+        // Codex's #668 review finding: if the log is truncated/
+        // recreated under a live subscriber whose offset has
+        // advanced past the new EOF, the subscriber must NOT stall.
+        // The tail loop has to detect `len < offset`, reset to 0,
+        // and continue reading.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        // Send a big-ish frame so the file has meaningful length.
+        // Then attach live and read it via cursor replay; offset
+        // advances past frame_1.
+        let frame_1 = frame_at(1, channel, "before-truncation");
+        adapter.send(frame_1.clone()).await.unwrap();
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+
+        let first = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.envelope.lamport, 1);
+
+        // Now truncate the file. Subscriber's tail loop has its
+        // offset positioned at the end of frame_1. Without the
+        // truncation-detection branch, the subscriber would stall.
+        tokio::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(adapter.frames_path())
+            .await
+            .unwrap();
+
+        // Give the tail loop one poll cycle to observe the shrunk
+        // file and reset its offset.
+        sleep(Duration::from_millis(100)).await;
+
+        // Send a fresh frame post-truncation. Subscriber MUST see
+        // it (the bug would have it stall here, waiting for the
+        // file to grow past the old offset).
+        let frame_2 = frame_at(2, channel, "after-truncation");
+        adapter.send(frame_2.clone()).await.unwrap();
+
+        let second = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("tail must recover from truncation within 2s")
+            .expect("stream must yield Some")
+            .expect("frame must parse");
+        assert_eq!(second.envelope.lamport, 2);
+        assert_eq!(
+            second
+                .envelope
+                .body
+                .as_ref()
+                .and_then(Body::as_text)
+                .unwrap(),
+            "after-truncation"
+        );
+    }
+
+    #[tokio::test]
+    async fn deletion_then_recreation_recovers_offset() {
+        // Companion to the truncation test: outright DELETE the
+        // file and recreate via a fresh send. The tail loop's
+        // NotFound branch must also reset offset so the recreated
+        // file is read from the start.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        adapter
+            .send(frame_at(1, channel, "before-delete"))
+            .await
+            .unwrap();
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+        let first = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.envelope.lamport, 1);
+
+        // Delete the file entirely.
+        tokio::fs::remove_file(adapter.frames_path()).await.unwrap();
+        sleep(Duration::from_millis(100)).await;
+
+        // Send recreates the file via OpenOptions::create(true).
+        adapter
+            .send(frame_at(2, channel, "after-delete"))
+            .await
+            .unwrap();
+
+        let second = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("tail must recover from deletion within 2s")
+            .expect("stream must yield Some")
+            .expect("frame must parse");
+        assert_eq!(second.envelope.lamport, 2);
     }
 
     #[tokio::test]

--- a/crates/airc-transport/src/local_fs.rs
+++ b/crates/airc-transport/src/local_fs.rs
@@ -1,0 +1,791 @@
+//! `LocalFsAdapter` — same-machine multi-process wire backed by an
+//! append-only JSONL log on the filesystem.
+//!
+//! Use case: AI peers (Claude Code, Codex, vHSM sessions, personas)
+//! co-located on one Mac that need to talk without burning network
+//! budget. A "wire" is a directory; every peer points its adapter at
+//! the same directory; one process appends, all subscribed processes
+//! see. This is the path that directly retires gh-polling for
+//! multi-agent same-Mac chat.
+//!
+//! Layout: `<wire-dir>/frames.jsonl` — one JSON-encoded `Frame` per
+//! line. Writers acquire an exclusive `flock(2)` on the file via
+//! `fs2::FileExt::lock_exclusive` before each append, so multi-
+//! process writers are serialized at the kernel level regardless of
+//! frame size. The flock is released on file drop at the end of each
+//! send. Readers poll the file by byte-offset and parse new lines.
+//!
+//! **Delivery semantics per `FrameKind`** (per the `Transport` trait
+//! contract):
+//! - `Message` / `Control` — durable. fsync'd before `send` returns.
+//!   Receive side applies backpressure (slow consumer slows the
+//!   wire); no frames are lost.
+//! - `Event` — interrupt-style. Written to disk but NOT fsync'd; the
+//!   bytes are visible to same-machine readers immediately, just not
+//!   guaranteed to survive a kernel crash. Receive side is lossy
+//!   past the per-subscriber buffer (slow consumer drops events,
+//!   wire keeps moving). Codex turn/interrupt, turn/steer, presence
+//!   transitions, and typing indicators ride on this kind.
+//!
+//! Constraints (called out so PR-3 can harden them):
+//! - **Polling**: subscribers poll every 50 ms. Fine for the chat
+//!   cadence; replace with `notify`/`inotify`/`kqueue` push-driven
+//!   wake in a follow-up if latency matters.
+//! - **Cursor replay**: `from_cursor: Some(...)` scans the file from
+//!   start to find the cursor. Linear-scan; fine for the typical
+//!   transcript size. PR-3+ can add an offset index.
+//! - **Send concurrency on flock**: writes are serialized across the
+//!   whole machine while the flock is held. For typical AI-agent
+//!   chat traffic this is fine (sub-millisecond critical section).
+//!   If high-frequency event traffic ever starves out senders, the
+//!   right fix is a separate `events.jsonl` (lossier, no flock) or
+//!   per-frame spool/rename. For PR-2 a single flocked log is
+//!   correct and simple.
+
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use fs2::FileExt;
+use futures::stream::Stream;
+use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+
+use airc_core::TranscriptCursor;
+use airc_protocol::{Frame, FrameKind, Subscription};
+
+use crate::error::LocalFsError;
+use crate::transport::{FrameStream, Transport};
+
+const FRAMES_FILENAME: &str = "frames.jsonl";
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+const RECEIVER_CHANNEL_DEPTH: usize = 64;
+
+/// Same-machine wire backed by `<wire-dir>/frames.jsonl`.
+///
+/// Cross-process send safety comes from `fs2::FileExt::lock_exclusive`
+/// (advisory flock) on the frames file — no in-memory mutex needed,
+/// flock handles both intra- and inter-process serialization.
+pub struct LocalFsAdapter {
+    wire_dir: PathBuf,
+}
+
+impl LocalFsAdapter {
+    /// Open the wire at `wire_dir`. The directory is created on first
+    /// `send` / `subscribe` if it doesn't already exist — the caller
+    /// doesn't need to pre-create it.
+    pub fn new(wire_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            wire_dir: wire_dir.into(),
+        }
+    }
+
+    /// The directory backing this wire. Useful for tests + diagnostics.
+    pub fn wire_dir(&self) -> &Path {
+        &self.wire_dir
+    }
+
+    /// Compute the frames-log path.
+    fn frames_path(&self) -> PathBuf {
+        self.wire_dir.join(FRAMES_FILENAME)
+    }
+
+    /// Create the wire directory if absent. Called on every send +
+    /// subscribe so the API doesn't have an "init" step.
+    async fn ensure_wire_dir(&self) -> Result<(), LocalFsError> {
+        tokio::fs::create_dir_all(&self.wire_dir).await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Transport for LocalFsAdapter {
+    type Error = LocalFsError;
+
+    async fn send(&self, frame: Frame) -> Result<(), Self::Error> {
+        self.ensure_wire_dir().await?;
+
+        // Serialize before crossing the spawn_blocking boundary so the
+        // critical section (open + flock + write + maybe-fsync) is as
+        // short as possible.
+        let mut buffer = serde_json::to_vec(&frame)?;
+        buffer.push(b'\n');
+        let frame_kind = frame.kind;
+        let path = self.frames_path();
+
+        // std::fs + fs2 flock is sync; bracket the kernel calls in
+        // spawn_blocking so we don't stall the async runtime. fs2
+        // doesn't have a tokio-native equivalent and rolling our own
+        // ioctl invocation would be more risk than this is worth.
+        tokio::task::spawn_blocking(move || -> Result<(), LocalFsError> {
+            use std::fs::OpenOptions as StdOpenOptions;
+
+            let file = StdOpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)?;
+            // Exclusive cross-process flock. Other writers (in this
+            // process or any other) block here until we release. The
+            // lock is released when `file` drops at end of block.
+            file.lock_exclusive()?;
+            let result = write_then_maybe_sync(&file, &buffer, frame_kind);
+            // Explicit unlock so an Err from write/sync doesn't leak
+            // the lock past the file's natural drop scope. (Drop
+            // also unlocks on POSIX, but being explicit is clearer.)
+            let _ = FileExt::unlock(&file);
+            result
+        })
+        .await
+        .map_err(|join_error| LocalFsError::Io(std::io::Error::other(join_error.to_string())))??;
+
+        Ok(())
+    }
+
+    async fn subscribe(
+        &self,
+        subscription: Subscription,
+    ) -> Result<FrameStream<Self::Error>, Self::Error> {
+        self.ensure_wire_dir().await?;
+        let path = self.frames_path();
+        let (tx, rx) = mpsc::channel(RECEIVER_CHANNEL_DEPTH);
+
+        // Spawn the tail task. Owned by the returned stream's
+        // lifetime: when the stream is dropped, `rx` is dropped,
+        // `tx.send(...)` returns Err on the next iteration, and the
+        // task exits.
+        tokio::spawn(async move {
+            if let Err(error) = tail_loop(path, subscription, tx.clone()).await {
+                // Surface transport errors to the subscriber so they
+                // can react, then close. We deliberately don't swallow.
+                let _ = tx.send(Err(error)).await;
+            }
+        });
+
+        // Wrap the mpsc receiver as a Stream without pulling
+        // `tokio-stream` as a dep — futures::stream::unfold suffices.
+        let stream = futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        });
+        Ok(Box::pin(stream) as Pin<Box<dyn Stream<Item = _> + Send>>)
+    }
+}
+
+/// Inside the spawn_blocking + flock critical section: append the
+/// serialized frame, then fsync IFF the kind is durable. `Event`
+/// frames skip the fsync so they don't pay the disk-flush latency
+/// (interrupt-style delivery semantics, per the `Transport` trait
+/// contract).
+fn write_then_maybe_sync(
+    mut file: &std::fs::File,
+    buffer: &[u8],
+    frame_kind: FrameKind,
+) -> Result<(), LocalFsError> {
+    use std::io::Write;
+
+    file.write_all(buffer)?;
+    match frame_kind {
+        FrameKind::Message | FrameKind::Control => {
+            // Durable kinds: fsync so a reader attaching right after
+            // this returns observes the frame even past a kernel
+            // crash. Substrate contract: Ok means durable.
+            file.sync_data()?;
+        }
+        FrameKind::Event => {
+            // Interrupt-style: skip fsync. The bytes are in the OS
+            // page cache and visible to same-machine readers
+            // immediately; survival across a kernel crash is not
+            // required for event semantics.
+        }
+    }
+    Ok(())
+}
+
+/// Background tail loop: poll the frames file, parse new lines, filter
+/// against the subscription, and ship matches through `tx`.
+async fn tail_loop(
+    path: PathBuf,
+    subscription: Subscription,
+    tx: mpsc::Sender<Result<Frame, LocalFsError>>,
+) -> Result<(), LocalFsError> {
+    let mut offset: u64 = if subscription.from_cursor.is_some() {
+        // Cursor-anchored: scan from start so we can replay.
+        0
+    } else {
+        // Live-only: skip to end. Existing frames are not replayed.
+        match tokio::fs::metadata(&path).await {
+            Ok(metadata) => metadata.len(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => 0,
+            Err(error) => return Err(error.into()),
+        }
+    };
+
+    loop {
+        // Stop if the subscriber dropped the stream. Avoids waking
+        // for the next poll just to discover the channel is closed.
+        if tx.is_closed() {
+            return Ok(());
+        }
+
+        let len = match tokio::fs::metadata(&path).await {
+            Ok(metadata) => metadata.len(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                sleep(POLL_INTERVAL).await;
+                continue;
+            }
+            Err(error) => return Err(error.into()),
+        };
+
+        if len > offset {
+            offset = drain_new_lines(&path, offset, &subscription, &tx).await?;
+        }
+
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Read from `offset` to current EOF, dispatch matching frames, return
+/// the new offset (positioned at the end of the last complete line —
+/// partial trailing lines are NOT consumed so a concurrent appender's
+/// in-flight write is re-read once it lands).
+async fn drain_new_lines(
+    path: &Path,
+    mut offset: u64,
+    subscription: &Subscription,
+    tx: &mpsc::Sender<Result<Frame, LocalFsError>>,
+) -> Result<u64, LocalFsError> {
+    let mut file = tokio::fs::File::open(path).await?;
+    file.seek(std::io::SeekFrom::Start(offset)).await?;
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let read = reader.read_line(&mut line).await?;
+        if read == 0 {
+            // True EOF.
+            break;
+        }
+        if !line.ends_with('\n') {
+            // Partial line — a writer is mid-append. Don't advance
+            // offset; we'll re-read on the next poll once the
+            // newline arrives.
+            break;
+        }
+        offset += read as u64;
+
+        let trimmed = line.trim_end_matches('\n');
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let frame: Frame = serde_json::from_str(trimmed)?;
+
+        if !subscription.matches(&frame) {
+            continue;
+        }
+        if let Some(cursor) = &subscription.from_cursor {
+            if !frame_after_cursor(&frame, cursor) {
+                continue;
+            }
+        }
+
+        // Delivery dispatch per FrameKind (per Codex's lag-policy
+        // feedback — events must not stall behind transcript catch-
+        // up; messages must not be silently dropped).
+        let dispatch = match frame.kind {
+            FrameKind::Message | FrameKind::Control => {
+                // Durable kinds: apply backpressure. If the
+                // subscriber is slow, this await blocks the tail
+                // loop until they catch up. No frames lost.
+                tx.send(Ok(frame)).await.map_err(|_| DispatchExit::Closed)
+            }
+            FrameKind::Event => {
+                // Interrupt-style: lossy. Drop on full buffer;
+                // surface closed-subscriber as the exit signal.
+                match tx.try_send(Ok(frame)) {
+                    Ok(()) => Ok(()),
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        // Subscriber backlog full — event dropped.
+                        // The wire keeps moving, which is the
+                        // documented semantic. Could log a counter
+                        // here in a future patch.
+                        Ok(())
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => Err(DispatchExit::Closed),
+                }
+            }
+        };
+
+        if dispatch.is_err() {
+            // Subscriber dropped. Exit the spawned task cleanly.
+            // We've already advanced `offset` past this line, which
+            // is fine — there's no resumability after drop.
+            return Ok(offset);
+        }
+    }
+    Ok(offset)
+}
+
+/// Internal: signal that the subscriber's stream is closed, so the
+/// tail-loop should exit. Not exposed — just an internal control flow
+/// type so the dispatch match is exhaustive without conflating with
+/// `LocalFsError`.
+enum DispatchExit {
+    Closed,
+}
+
+/// Is `frame` strictly after `cursor` in transcript order?
+/// Lamport first, event_id as tiebreaker — matches airc-core's
+/// transcript ordering rule.
+fn frame_after_cursor(frame: &Frame, cursor: &TranscriptCursor) -> bool {
+    let envelope = &frame.envelope;
+    envelope.lamport > cursor.lamport
+        || (envelope.lamport == cursor.lamport
+            && envelope.event_id.as_uuid() > cursor.event_id.as_uuid())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::{
+        headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, PeerId, RoomId,
+    };
+    use airc_protocol::{ChannelId, Envelope, Frame, FrameKind, Signature, Subscription};
+    use futures::stream::StreamExt;
+    use tempfile::TempDir;
+
+    fn frame_at(lamport: u64, channel: ChannelId, body: &str) -> Frame {
+        Frame {
+            kind: FrameKind::Message,
+            envelope: Envelope {
+                event_id: EventId::from_u128(lamport as u128),
+                sender: PeerId::from_u128(0xa1),
+                sender_client: ClientId::from_u128(0xc1),
+                channel,
+                target: MentionTarget::All,
+                lamport,
+                occurred_at_ms: 1_700_000_000_000 + lamport,
+                reply_to: None,
+                headers: Headers::new(),
+                body: Some(Body::text(body)),
+                media: Vec::new(),
+                signature: Signature::Unsigned,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn send_then_subscribe_with_cursor_replays_frame() {
+        // The "two AI agents share a Mac" base case. Agent A sends,
+        // Agent B subscribes with from_cursor=None... but None means
+        // live-only, so we use a from_cursor anchor to force replay.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        adapter
+            .send(frame_at(1, channel, "hello from A"))
+            .await
+            .unwrap();
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+        let received = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("must yield within 2s")
+            .expect("stream must yield Some")
+            .expect("frame must parse");
+
+        assert_eq!(received.envelope.lamport, 1);
+        let body_text = received
+            .envelope
+            .body
+            .as_ref()
+            .and_then(Body::as_text)
+            .expect("body must be text");
+        assert_eq!(body_text, "hello from A");
+    }
+
+    #[tokio::test]
+    async fn live_subscription_skips_past_frames() {
+        // from_cursor=None means "live only" — frames already on disk
+        // when subscribe() is called are NOT replayed. Critical for
+        // agents who reconnect and don't want to re-process history.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        adapter.send(frame_at(1, channel, "old")).await.unwrap();
+
+        let sub = Subscription {
+            channel: Some(channel),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+
+        // Give the tail loop a poll cycle to seek to EOF.
+        sleep(Duration::from_millis(100)).await;
+
+        adapter.send(frame_at(2, channel, "new")).await.unwrap();
+
+        let received = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("must yield within 2s")
+            .expect("stream must yield Some")
+            .expect("frame must parse");
+        assert_eq!(received.envelope.lamport, 2);
+        assert_eq!(
+            received
+                .envelope
+                .body
+                .as_ref()
+                .and_then(Body::as_text)
+                .unwrap(),
+            "new"
+        );
+    }
+
+    #[tokio::test]
+    async fn subscription_channel_filter_routes_correctly() {
+        // Fan-out hot path: one wire carries multiple channels; each
+        // subscriber gets only its channel's frames.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let chan_a = RoomId::from_u128(0xaaaa);
+        let chan_b = RoomId::from_u128(0xbbbb);
+
+        let sub = Subscription {
+            channel: Some(chan_a),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+
+        // Let the tail task start.
+        sleep(Duration::from_millis(50)).await;
+
+        adapter.send(frame_at(1, chan_a, "a-frame")).await.unwrap();
+        adapter.send(frame_at(2, chan_b, "b-frame")).await.unwrap();
+        adapter
+            .send(frame_at(3, chan_a, "a-frame-2"))
+            .await
+            .unwrap();
+
+        // Should receive only the chan_a frames.
+        let first = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("first")
+            .expect("some")
+            .expect("ok");
+        let second = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("second")
+            .expect("some")
+            .expect("ok");
+        assert_eq!(first.envelope.lamport, 1);
+        assert_eq!(second.envelope.lamport, 3);
+
+        // No third frame on the chan_a stream within 200ms.
+        let third = tokio::time::timeout(Duration::from_millis(200), stream.next()).await;
+        assert!(third.is_err(), "no further frames expected");
+    }
+
+    #[tokio::test]
+    async fn two_subscribers_both_receive() {
+        // Fan-out parity: two independent subscribers on the same
+        // channel both get every frame. The "Codex AND Claude" case.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        let make_sub = || Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+
+        let mut stream_a = adapter.subscribe(make_sub()).await.unwrap();
+        let mut stream_b = adapter.subscribe(make_sub()).await.unwrap();
+
+        sleep(Duration::from_millis(50)).await;
+        adapter
+            .send(frame_at(1, channel, "broadcast"))
+            .await
+            .unwrap();
+
+        let recv_a = tokio::time::timeout(Duration::from_secs(2), stream_a.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let recv_b = tokio::time::timeout(Duration::from_secs(2), stream_b.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(recv_a.envelope.lamport, 1);
+        assert_eq!(recv_b.envelope.lamport, 1);
+    }
+
+    #[tokio::test]
+    async fn events_are_lossy_when_subscriber_lags() {
+        // Codex's lag-policy contract: Event frames must drop on a
+        // full subscriber buffer rather than back up the wire. If
+        // every event sent here arrives, the lossy semantic is
+        // broken. Send WAY more events than the channel depth (64)
+        // while NOT consuming, then drain — expect strictly fewer
+        // than sent.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+
+        // Let the tail loop arm. Then send a flood of Events
+        // without reading from the stream.
+        sleep(Duration::from_millis(50)).await;
+        let total_sent: u64 = 500;
+        for lamport in 1..=total_sent {
+            let mut frame = frame_at(lamport, channel, &format!("evt-{lamport}"));
+            frame.kind = FrameKind::Event;
+            adapter.send(frame).await.unwrap();
+        }
+
+        // Give the tail loop time to drain the file into the bounded
+        // subscriber channel — events will be dropped at try_send
+        // when the channel is full.
+        sleep(Duration::from_millis(300)).await;
+
+        // Drain whatever made it through.
+        let mut count: u64 = 0;
+        while let Ok(Some(Ok(_))) =
+            tokio::time::timeout(Duration::from_millis(50), stream.next()).await
+        {
+            count += 1;
+        }
+        assert!(
+            count < total_sent,
+            "events must be lossy when subscriber lags; received {count} of {total_sent}"
+        );
+        assert!(count > 0, "at least some events should arrive; got {count}");
+    }
+
+    #[tokio::test]
+    async fn messages_are_not_dropped_under_subscriber_lag() {
+        // The flip side: Message frames apply backpressure and MUST
+        // be delivered in full. If a slow subscriber drops messages
+        // we've broken the durability contract — the Codex bridge
+        // (and every other consumer) needs to rely on this.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+
+        sleep(Duration::from_millis(50)).await;
+        let total_sent: u64 = 200;
+        for lamport in 1..=total_sent {
+            adapter
+                .send(frame_at(lamport, channel, &format!("msg-{lamport}")))
+                .await
+                .unwrap();
+        }
+
+        // Drain — all must arrive (backpressure can slow it, but
+        // can't lose). Generous timeout for the full drain since
+        // backpressure may stall periodically.
+        let mut received: u64 = 0;
+        while received < total_sent {
+            let item = tokio::time::timeout(Duration::from_secs(10), stream.next())
+                .await
+                .expect("must yield within 10s under backpressure")
+                .expect("stream must yield Some")
+                .expect("frame must parse");
+            received += 1;
+            // Sanity that order is preserved.
+            assert_eq!(item.envelope.lamport, received);
+        }
+        assert_eq!(received, total_sent);
+    }
+
+    #[tokio::test]
+    async fn flock_serializes_concurrent_in_process_senders() {
+        // The flock contract: even with many concurrent senders, the
+        // resulting frames.jsonl is well-formed (one frame per line,
+        // no torn writes, all frames present). Tests within-process
+        // concurrency — cross-process flock relies on the same
+        // kernel mechanism so the in-process test is a proxy. (A
+        // real cross-process test would spawn child processes,
+        // which is out of scope for unit tests.)
+        let dir = TempDir::new().unwrap();
+        let adapter = std::sync::Arc::new(LocalFsAdapter::new(dir.path()));
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        let mut handles = Vec::new();
+        let frames_per_sender: u64 = 30;
+        let sender_count: u64 = 8;
+        for sender_idx in 0..sender_count {
+            let adapter = adapter.clone();
+            let handle = tokio::spawn(async move {
+                for i in 0..frames_per_sender {
+                    let lamport = sender_idx * frames_per_sender + i + 1;
+                    adapter
+                        .send(frame_at(
+                            lamport,
+                            channel,
+                            &format!("sender-{sender_idx}-{i}"),
+                        ))
+                        .await
+                        .unwrap();
+                }
+            });
+            handles.push(handle);
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        // Read the resulting file: every line MUST parse, and the
+        // total count MUST equal sender_count * frames_per_sender.
+        let contents = tokio::fs::read_to_string(adapter.frames_path())
+            .await
+            .unwrap();
+        let lines: Vec<_> = contents.lines().collect();
+        let expected = (sender_count * frames_per_sender) as usize;
+        assert_eq!(
+            lines.len(),
+            expected,
+            "every concurrent send must land as exactly one line"
+        );
+        for line in lines {
+            let _: Frame = serde_json::from_str(line).expect("every line must parse cleanly");
+        }
+    }
+
+    #[tokio::test]
+    async fn drop_stream_stops_tail_task() {
+        // Resource discipline: dropping the returned stream must
+        // shut down its background tail. Tested indirectly: the tail
+        // task observes the closed channel and exits on its next
+        // poll. We can't observe the task directly but we can assert
+        // the second send doesn't panic / leak (smoke test).
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let stream = adapter.subscribe(sub).await.unwrap();
+        drop(stream);
+
+        // Sends after stream drop should still succeed against the
+        // wire — the closed subscriber doesn't affect the writer.
+        sleep(Duration::from_millis(100)).await;
+        adapter
+            .send(frame_at(1, channel, "no one home"))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_is_durable_when_returning_ok() {
+        // The contract: send returning Ok means the frame is on disk
+        // and readable. Pin that by reading the file directly after
+        // a single send.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        adapter.send(frame_at(1, channel, "durable")).await.unwrap();
+
+        let contents = tokio::fs::read_to_string(adapter.frames_path())
+            .await
+            .unwrap();
+        // One frame, one line, ends with newline.
+        assert_eq!(contents.lines().count(), 1);
+        assert!(contents.ends_with('\n'));
+        let parsed: Frame = serde_json::from_str(contents.trim_end()).unwrap();
+        assert_eq!(parsed.envelope.lamport, 1);
+    }
+
+    #[tokio::test]
+    async fn from_cursor_drops_frames_at_or_before_anchor() {
+        // Replay semantics: from_cursor returns frames STRICTLY after
+        // the anchor (not including the anchor frame itself), so a
+        // reconnecting peer doesn't re-process the last-acked event.
+        let dir = TempDir::new().unwrap();
+        let adapter = LocalFsAdapter::new(dir.path());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        let frame1 = frame_at(1, channel, "first");
+        let frame2 = frame_at(2, channel, "second");
+        let frame3 = frame_at(3, channel, "third");
+
+        adapter.send(frame1.clone()).await.unwrap();
+        adapter.send(frame2.clone()).await.unwrap();
+        adapter.send(frame3.clone()).await.unwrap();
+
+        let sub = Subscription {
+            channel: Some(channel),
+            from_cursor: Some(TranscriptCursor {
+                lamport: 1,
+                event_id: frame1.envelope.event_id,
+            }),
+            ..Default::default()
+        };
+        let mut stream = adapter.subscribe(sub).await.unwrap();
+
+        let recv_a = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let recv_b = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(recv_a.envelope.lamport, 2);
+        assert_eq!(recv_b.envelope.lamport, 3);
+
+        // No further frames.
+        let none = tokio::time::timeout(Duration::from_millis(200), stream.next()).await;
+        assert!(none.is_err(), "should be no further frames");
+    }
+}

--- a/crates/airc-transport/src/transport.rs
+++ b/crates/airc-transport/src/transport.rs
@@ -1,0 +1,101 @@
+//! The `Transport` trait — what every adapter (local-fs, lan-tcp,
+//! tailscale, ...) implements.
+//!
+//! The substrate is intentionally agnostic about the wire underneath.
+//! Adapters carry `airc-protocol::Frame`s in both directions; the
+//! substrate enforces semantics (subscriptions, signature verification,
+//! fan-out). One trait, many impls, swap freely.
+//!
+//! Designed agent-to-agent-first: the canonical caller is an AI peer
+//! (Claude Code, Codex, vHSM session, persona) sending a frame to
+//! other AI peers on the same Mac, same LAN, or across a mesh. Latency
+//! and concurrency dominate the design; legacy human-chat features
+//! (typing indicators, presence) ride on top via `FrameKind::Event`
+//! and headers, not as core trait surface.
+
+use std::pin::Pin;
+
+use async_trait::async_trait;
+use futures::Stream;
+
+use airc_protocol::{Frame, Subscription};
+
+/// A stream of frames matching a subscription, with transport-level
+/// errors surfaced inline so receivers see I/O failures rather than
+/// silently lose frames.
+///
+/// `Pin<Box<dyn Stream + Send>>` is dyn-friendly so adapters can be
+/// stored as `Box<dyn Transport<Error = ...>>` and the receive surface
+/// stays generic.
+pub type FrameStream<E> = Pin<Box<dyn Stream<Item = Result<Frame, E>> + Send>>;
+
+/// The contract an adapter implements.
+#[async_trait]
+pub trait Transport: Send + Sync {
+    /// Adapter-specific error type. Must be `Send + Sync + 'static` so
+    /// errors can cross `await` points and propagate from spawned
+    /// tasks; must implement `std::error::Error` so callers can use
+    /// the standard error-chain idioms.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Send a frame onto the wire.
+    ///
+    /// **Delivery semantics depend on `frame.kind`** — adapters MUST
+    /// respect this split so consumers like the Codex bridge can rely
+    /// on it:
+    ///
+    /// - `FrameKind::Message` / `FrameKind::Control`: **durable**. By
+    ///   the time `Ok` returns the frame is persisted (fsync'd for
+    ///   local-fs; ACKed for lan-tcp). Readers attaching after this
+    ///   call MUST be able to read it. These kinds carry transcript
+    ///   content + session lifecycle — losing one is a bug.
+    ///
+    /// - `FrameKind::Event`: **interrupt-style live**. The wire makes
+    ///   the frame visible to currently-attached readers as fast as
+    ///   possible (skipping fsync, etc.). Crash-survival is NOT
+    ///   guaranteed for events — they're meant for typing indicators,
+    ///   turn/steer, turn/interrupt, presence transitions, work-offer
+    ///   pings. The frame may be dropped by slow subscribers (see
+    ///   `subscribe` for the lag policy).
+    ///
+    /// Frames are bytes-equal to what receivers see; the substrate
+    /// does NOT mutate the envelope in transit. (Adapters MAY add or
+    /// strip transport-level framing around the envelope — that's
+    /// invisible to the protocol layer.)
+    async fn send(&self, frame: Frame) -> Result<(), Self::Error>;
+
+    /// Subscribe and receive frames matching `subscription`.
+    ///
+    /// The returned stream:
+    ///   - Yields frames matching the subscription criteria (`channel`,
+    ///     `kinds`, `headers_filter`).
+    ///   - Yields `from_cursor`-anchored replay first (when set), then
+    ///     transitions to live frames.
+    ///   - Yields `Err(transport-error)` on transport-level failures.
+    ///   - Closes when the transport is torn down OR the stream is
+    ///     dropped (unsubscribes the receiver).
+    ///
+    /// **Lag policy (per Codex's feedback — Codex turn/interrupt and
+    /// turn/steer must not get stuck behind transcript catch-up):**
+    ///
+    /// - `FrameKind::Message` / `FrameKind::Control` frames apply
+    ///   **backpressure** — a slow consumer slows the wire's drain
+    ///   rate but no frames are lost. Durable kinds get reliable
+    ///   delivery.
+    ///
+    /// - `FrameKind::Event` frames are **lossy past the per-subscriber
+    ///   buffer** — if the subscriber's queue is full, the event is
+    ///   dropped at the boundary. Interrupt-style delivery: better to
+    ///   miss a stale interrupt than to back up the whole wire. The
+    ///   wire keeps moving; subscribers MUST poll their stream
+    ///   promptly to see events.
+    ///
+    /// Multiple subscribers may attach concurrently; the transport
+    /// fans out. Each subscriber gets its own stream — no cross-talk
+    /// and no shared backpressure (a slow subscriber affects only its
+    /// own backlog).
+    async fn subscribe(
+        &self,
+        subscription: Subscription,
+    ) -> Result<FrameStream<Self::Error>, Self::Error>;
+}


### PR DESCRIPTION
## Summary

PR-3b of the substrate stack. Pins the **cryptographic foundation** for the secure LAN transport (PR-3c lands the `LanTcpAdapter` itself). Per Codex's review of the original PR-3 sketch + Joel's "always go most-capable" steer:

- **No plaintext path**
- **No opt-in unsafe bind**
- **No PKI bridge** — the substrate's `PeerKeyRegistry` IS the trust anchor

## New: `crates/airc-transport/src/lan_tcp/`

**`cert.rs` — bidirectional cert ↔ Ed25519 pubkey bridge:**

- `generate_self_signed_cert(keypair, peer_id)` takes a substrate `PeerKeypair` and produces a `(CertificateDer, PrivateKeyDer)` pair via `rcgen`, with the substrate's Ed25519 `SigningKey` going through PKCS#8 DER as the round-trip format. **The TLS cert's subject pubkey IS the substrate's Ed25519 pubkey by construction** — peer-pinning becomes meaningful.
- `extract_ed25519_pubkey(cert_der)` parses a received X.509 cert, validates the SPKI algorithm is Ed25519 (OID `1.3.101.112`), returns the 32-byte pubkey for registry lookup.

**`verifier.rs` — rustls trait impls for peer-pinning:**

- `PinnedServerVerifier` (client-side) takes an `expected_peer` and the registry. Accepts the server cert iff its pubkey resolves (via `find_peer`) to the expected `PeerId`. Wrong peer / unknown pubkey / non-Ed25519 / malformed cert → reject.
- `PinnedClientVerifier` (server-side) accepts any cert whose pubkey is enrolled for any peer. Caller binds the connection to the resolved `PeerId` post-handshake.
- `supported_verify_schemes()` returns ONLY Ed25519 — no algorithm-downgrade surface.
- `verify_tls12_signature` returns `Err` unconditionally — substrate is TLS 1.3 + Ed25519 only, no legacy path.

## Modified: `crates/airc-protocol/src/signature.rs`

- `PeerKeyRegistry::find_peer(pubkey) -> Option<(PeerId, u32)>` — reverse lookup for the server verifier. Pure-data helper; iteration order is non-deterministic but we only care about ANY-match presence.

## Adapter pattern stays clean

The `Transport` trait is the contract; gh-gist (future), local-fs (PR-2), lan-tcp (PR-3c) are all impls. **Dropping any one = deleting that adapter file.** No coupling — exactly what Joel asked for re "make gh and others as adapters/traits so we can drop them."

## Test plan

- [x] `cargo fmt -p airc-transport` — clean
- [x] `cargo clippy -p airc-transport --all-targets -- -D warnings` — clean
- [x] `cargo test -p airc-transport` — **24 pass / 0 fail** (12 existing local-fs + 12 new TLS pinning)

| Test | Pins |
|------|------|
| `generated_cert_carries_the_keypair_pubkey` | substrate Ed25519 = TLS subject pubkey |
| `two_keypairs_produce_different_pubkeys_in_certs` | no hardcoded test pubkey |
| `malformed_cert_bytes_return_invalid_cert_error` | garbage → typed error |
| `cert_round_trips_through_der_bytes` | rcgen encoding survives ser/deser |
| `server_verifier_accepts_expected_peer_cert` | base secure case |
| `server_verifier_rejects_wrong_peer_cert` | pinning ≠ "any enrolled peer" |
| `server_verifier_rejects_unenrolled_cert` | fail-closed on unknown |
| `server_verifier_rejects_malformed_cert` | garbage cert → reject |
| `client_verifier_accepts_any_enrolled_peer` | server accepts any enrolled |
| `client_verifier_rejects_unenrolled_peer` | fail-closed on unknown client |
| `verifiers_only_accept_ed25519_scheme` | no algorithm downgrade |
| `supported_schemes_helper_returns_only_ed25519` | regression guard |

## Dependencies

Adds: `rustls = "0.23"` (ring backend), `tokio-rustls = "0.26"`, `rcgen = "0.14"` (ed25519 + pem), `rustls-pki-types = "1"`, `x509-parser = "0.18"`, `ed25519-dalek` pkcs8 feature.

**Note on js-sys/wasm-bindgen in `cargo fetch`**: these are transitive deps of `getrandom` and `ring` gated behind `cfg(target_arch = "wasm32")`. They are NOT linked into native builds — verified via `cargo tree --target=x86_64-apple-darwin -p airc-transport`.

## Stack

Stacked on `feat/airc-protocol-ed25519` (PR #669). **PR-3c next** — `LanTcpAdapter` wiring these verifiers into TLS-wrapped TCP with mutual auth, manual listen/connect API, length-prefixed JSON frames, FrameKind-aware delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)