### PR TITLE
feat(airc-transport): LanTcpAdapter — TLS-wrapped TCP with peer-pinned mTLS

### DIFF
--- a/crates/airc-transport/src/error.rs
+++ b/crates/airc-transport/src/error.rs
@@ -1,90 +1,12 @@
 //! Transport-level errors.
 //!
-//! Each adapter declares its own `Error` associated type, but they share
-//! the same general failure modes (I/O failed, serialization failed,
-//! the wire isn't ready). This module gives `LocalFsAdapter` a typed
-//! error; other adapters will follow the same pattern.
+//! Each adapter declares its own `Error` associated type so callers can
+//! discriminate failure modes per adapter without a one-size-fits-all
+//! enum. This module hosts the local-fs adapter's error type; the
+//! lan-tcp adapter's error lives alongside that adapter in
+//! `lan_tcp/adapter.rs`.
 
 use std::fmt;
-
-/// What can go wrong inside the lan-tcp adapter.
-///
-/// LAN-TCP is **DEV-PREVIEW** until PR-4 wires rustls peer pinning +
-/// real Ed25519 verification. The error variants below include the
-/// security-guard refusal cases so the substrate fails closed rather
-/// than silently exposing a plaintext wire on the LAN.
-#[derive(Debug)]
-pub enum LanTcpError {
-    /// File or socket I/O failed.
-    Io(std::io::Error),
-
-    /// A peer sent bytes that didn't parse as a `Frame`. The substrate
-    /// refuses rather than silently dropping — possibly a protocol
-    /// mismatch, a hostile peer, or a wire corruption.
-    Json(serde_json::Error),
-
-    /// The caller asked to bind a non-loopback address without
-    /// threading `unsafe_allow_public_bind()`. Default refuses — the
-    /// LAN adapter is DEV-PREVIEW and must not be exposed on a real
-    /// network without explicit opt-in.
-    PublicBindNotAllowed(std::net::SocketAddr),
-
-    /// The builder was driven to `.build()` without a bind address.
-    MissingBindAddr,
-
-    /// A peer sent a length-prefix exceeding the per-frame limit.
-    /// Substrate caps frame size to defend against OOM from a hostile
-    /// peer. Honest senders stay well under via the body-lift policy.
-    FrameTooLarge { announced: u64, limit: u64 },
-}
-
-impl fmt::Display for LanTcpError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            LanTcpError::Io(error) => write!(f, "lan-tcp transport I/O: {error}"),
-            LanTcpError::Json(error) => write!(f, "lan-tcp transport frame parse: {error}"),
-            LanTcpError::PublicBindNotAllowed(addr) => write!(
-                f,
-                "lan-tcp refused to bind non-loopback address {addr} \
-                 — adapter is DEV-PREVIEW (no transport encryption, \
-                 no Ed25519 verification wired); thread \
-                 unsafe_allow_public_bind() to override"
-            ),
-            LanTcpError::MissingBindAddr => write!(
-                f,
-                "lan-tcp builder missing bind address — call .bind(addr) before .build()"
-            ),
-            LanTcpError::FrameTooLarge { announced, limit } => write!(
-                f,
-                "lan-tcp refused frame with announced size {announced} bytes \
-                 (limit {limit}) — bodies above limit must be lifted to \
-                 airc-blobs and carried as MediaRef"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for LanTcpError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            LanTcpError::Io(error) => Some(error),
-            LanTcpError::Json(error) => Some(error),
-            _ => None,
-        }
-    }
-}
-
-impl From<std::io::Error> for LanTcpError {
-    fn from(error: std::io::Error) -> Self {
-        LanTcpError::Io(error)
-    }
-}
-
-impl From<serde_json::Error> for LanTcpError {
-    fn from(error: serde_json::Error) -> Self {
-        LanTcpError::Json(error)
-    }
-}
 
 /// What can go wrong inside the local-fs adapter.
 #[derive(Debug)]

--- a/crates/airc-transport/src/lan_tcp/adapter.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter.rs
@@ -1,0 +1,679 @@
+//! `LanTcpAdapter` — secure same-LAN wire over TLS-wrapped TCP.
+//!
+//! MVP scope (PR-3c):
+//!   - Point-to-peer: one active connection per adapter (either
+//!     accepted-from listener or dialed via connect). PR-3d expands
+//!     to N-peer fan-out.
+//!   - Multi-subscriber fan-out (one adapter, many local
+//!     `Transport::subscribe` callers).
+//!   - Length-prefixed JSON frames over TLS.
+//!   - FrameKind delivery split inherited from the Transport trait:
+//!     Message/Control durable+backpressure, Event lossy.
+//!   - Mutual TLS via `tls_config` builders; peer identity bound
+//!     post-handshake by reading the peer cert and looking up via
+//!     `PeerKeyRegistry::find_peer`.
+//!
+//! What's deferred to follow-ups:
+//!   - Multi-peer concurrent connections (PR-3d).
+//!   - mDNS/discovery (separate concern).
+//!   - Reconnect / retry logic (robustness PR).
+//!   - Per-frame ack/replay-cursor (PR-3e or bridge layer).
+
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::sync::RwLock;
+
+use async_trait::async_trait;
+use futures::stream::Stream;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{mpsc, Mutex};
+use tokio_rustls::client::TlsStream as ClientTlsStream;
+use tokio_rustls::server::TlsStream as ServerTlsStream;
+use tokio_rustls::{TlsAcceptor, TlsConnector};
+
+use airc_core::PeerId;
+use airc_protocol::{Frame, FrameKind, PeerKeyRegistry, PeerKeypair, Subscription};
+
+use crate::lan_tcp::cert::extract_ed25519_pubkey;
+use crate::lan_tcp::tls_config::{build_client_config, build_server_config, TlsConfigError};
+use crate::transport::{FrameStream, Transport};
+
+/// Per-frame payload size limit. Defense against a malicious or
+/// misconfigured peer sending an absurd length prefix. Honest senders
+/// stay well under via the body-lift policy (default 16 KiB ceiling).
+const MAX_FRAME_BYTES: u32 = 16 * 1024 * 1024;
+
+/// Outbound channel depth per connection. Slow remote → senders
+/// applying backpressure pile up here before the Transport's
+/// kind-aware dispatch kicks in.
+const OUTBOUND_CHANNEL_DEPTH: usize = 256;
+
+/// Subscriber inbound channel depth — matches local-fs.
+const SUBSCRIBER_CHANNEL_DEPTH: usize = 64;
+
+/// LAN transport errors.
+#[derive(Debug)]
+pub enum LanTcpError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    TlsConfig(TlsConfigError),
+    TlsHandshake(std::io::Error),
+    /// Post-handshake peer-id binding failed: cert presented didn't
+    /// resolve to a known peer.
+    PeerNotInRegistry,
+    /// Length prefix exceeded `MAX_FRAME_BYTES` — likely hostile or
+    /// misconfigured.
+    FrameTooLarge {
+        announced: u32,
+        limit: u32,
+    },
+    /// `send()` called with no connection established.
+    NotConnected,
+    /// `connect()` or `listen()` called twice on the same adapter.
+    AlreadyHasConnection,
+}
+
+impl std::fmt::Display for LanTcpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LanTcpError::Io(error) => write!(f, "lan-tcp I/O: {error}"),
+            LanTcpError::Json(error) => write!(f, "lan-tcp frame parse: {error}"),
+            LanTcpError::TlsConfig(error) => write!(f, "lan-tcp TLS config: {error}"),
+            LanTcpError::TlsHandshake(error) => write!(f, "lan-tcp TLS handshake: {error}"),
+            LanTcpError::PeerNotInRegistry => write!(
+                f,
+                "post-handshake: peer cert pubkey is not in the registry (this should have been caught at handshake)"
+            ),
+            LanTcpError::FrameTooLarge { announced, limit } => write!(
+                f,
+                "lan-tcp refused frame with announced size {announced} bytes (limit {limit})"
+            ),
+            LanTcpError::NotConnected => {
+                write!(f, "lan-tcp adapter has no active connection")
+            }
+            LanTcpError::AlreadyHasConnection => write!(
+                f,
+                "lan-tcp adapter already has an active connection — point-to-peer for MVP, PR-3d adds multi-peer"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LanTcpError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            LanTcpError::Io(error) | LanTcpError::TlsHandshake(error) => Some(error),
+            LanTcpError::Json(error) => Some(error),
+            LanTcpError::TlsConfig(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for LanTcpError {
+    fn from(error: std::io::Error) -> Self {
+        LanTcpError::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for LanTcpError {
+    fn from(error: serde_json::Error) -> Self {
+        LanTcpError::Json(error)
+    }
+}
+
+impl From<TlsConfigError> for LanTcpError {
+    fn from(error: TlsConfigError) -> Self {
+        LanTcpError::TlsConfig(error)
+    }
+}
+
+/// Active connection's sender half — write-task receives Frames from
+/// this and pushes them onto the TLS stream.
+type OutboundTx = mpsc::Sender<Frame>;
+
+/// One subscriber's filtered inbound channel + matching predicate.
+struct SubscriberHandle {
+    id: u64,
+    subscription: Subscription,
+    tx: mpsc::Sender<Result<Frame, LanTcpError>>,
+}
+
+struct Inner {
+    self_peer_id: PeerId,
+    keypair: PeerKeypair,
+    registry: Arc<RwLock<PeerKeyRegistry>>,
+    server_config: Arc<rustls::ServerConfig>,
+    /// At most one active connection per adapter in MVP. PR-3d
+    /// promotes this to `HashMap<PeerId, OutboundTx>`.
+    connection: Mutex<Option<OutboundTx>>,
+    subscribers: Mutex<Vec<SubscriberHandle>>,
+    next_sub_id: AtomicU64,
+}
+
+/// Secure same-LAN adapter.
+pub struct LanTcpAdapter {
+    inner: Arc<Inner>,
+}
+
+impl LanTcpAdapter {
+    /// Construct an adapter. No network activity yet — call
+    /// `listen()` or `connect()` to establish a connection.
+    pub fn new(
+        self_peer_id: PeerId,
+        keypair: PeerKeypair,
+        registry: Arc<RwLock<PeerKeyRegistry>>,
+    ) -> Result<Self, LanTcpError> {
+        let server_config = build_server_config(self_peer_id, &keypair, registry.clone())?;
+        Ok(Self {
+            inner: Arc::new(Inner {
+                self_peer_id,
+                keypair,
+                registry,
+                server_config,
+                connection: Mutex::new(None),
+                subscribers: Mutex::new(Vec::new()),
+                next_sub_id: AtomicU64::new(0),
+            }),
+        })
+    }
+
+    /// Bind a TCP listener and accept ONE incoming connection. The
+    /// returned `SocketAddr` is the actual bound address (useful when
+    /// `bind_addr.port() == 0` and the OS assigns).
+    ///
+    /// Internally spawns the accept loop + post-handshake read/write
+    /// tasks. Returns after the listener is bound, NOT after a peer
+    /// has connected — callers await delivery via `subscribe`.
+    pub async fn listen(&self, bind_addr: SocketAddr) -> Result<SocketAddr, LanTcpError> {
+        // Refuse if already connected; MVP is point-to-peer.
+        {
+            let conn = self.inner.connection.lock().await;
+            if conn.is_some() {
+                return Err(LanTcpError::AlreadyHasConnection);
+            }
+        }
+
+        let listener = TcpListener::bind(bind_addr).await?;
+        let actual = listener.local_addr()?;
+        let inner = self.inner.clone();
+
+        tokio::spawn(async move {
+            // Accept ONE connection; subsequent attempts ignored in
+            // MVP. PR-3d turns this into a multi-accept loop.
+            match listener.accept().await {
+                Ok((tcp_stream, _peer_addr)) => {
+                    let acceptor = TlsAcceptor::from(inner.server_config.clone());
+                    match acceptor.accept(tcp_stream).await {
+                        Ok(tls_stream) => {
+                            handle_server_connection(inner, tls_stream).await;
+                        }
+                        Err(_error) => {
+                            // Handshake rejected (e.g. unenrolled
+                            // client cert). The pinned client
+                            // verifier already refused; no further
+                            // action needed.
+                        }
+                    }
+                }
+                Err(_error) => {
+                    // Listener failed — no recovery in MVP.
+                }
+            }
+        });
+
+        Ok(actual)
+    }
+
+    /// Dial a peer over TLS. Returns after the TLS handshake completes
+    /// successfully (or fails). Frames flow once subscribe + send are
+    /// in use.
+    pub async fn connect(
+        &self,
+        peer_addr: SocketAddr,
+        expected_peer: PeerId,
+    ) -> Result<(), LanTcpError> {
+        {
+            let conn = self.inner.connection.lock().await;
+            if conn.is_some() {
+                return Err(LanTcpError::AlreadyHasConnection);
+            }
+        }
+
+        let client_config = build_client_config(
+            self.inner.self_peer_id,
+            &self.inner.keypair,
+            expected_peer,
+            self.inner.registry.clone(),
+        )?;
+        let connector = TlsConnector::from(client_config);
+
+        let tcp_stream = TcpStream::connect(peer_addr).await?;
+
+        // ServerName for SNI — uses the expected_peer's UUID string.
+        // The pinned verifier ignores the server_name argument, so
+        // this is purely for the protocol-level SNI extension.
+        let server_name = rustls_pki_types::ServerName::try_from(expected_peer.to_string())
+            .map_err(|e| {
+                LanTcpError::TlsHandshake(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    e.to_string(),
+                ))
+            })?;
+
+        let tls_stream = connector
+            .connect(server_name, tcp_stream)
+            .await
+            .map_err(LanTcpError::TlsHandshake)?;
+
+        let inner = self.inner.clone();
+        tokio::spawn(async move {
+            handle_client_connection(inner, tls_stream).await;
+        });
+
+        Ok(())
+    }
+}
+
+/// Post-handshake server-side connection handler: bind the peer
+/// identity from the cert, spawn read + write loops.
+async fn handle_server_connection(inner: Arc<Inner>, tls_stream: ServerTlsStream<TcpStream>) {
+    let peer_id = match resolve_peer_from_server_stream(&inner, &tls_stream) {
+        Some(peer) => peer,
+        None => return, // verifier should have caught this; bail.
+    };
+    let (read_half, write_half) = tokio::io::split(tls_stream);
+    spawn_connection_loops(inner, peer_id, read_half, write_half);
+}
+
+/// Post-handshake client-side connection handler.
+async fn handle_client_connection(inner: Arc<Inner>, tls_stream: ClientTlsStream<TcpStream>) {
+    let peer_id = match resolve_peer_from_client_stream(&inner, &tls_stream) {
+        Some(peer) => peer,
+        None => return,
+    };
+    let (read_half, write_half) = tokio::io::split(tls_stream);
+    spawn_connection_loops(inner, peer_id, read_half, write_half);
+}
+
+fn resolve_peer_from_server_stream(
+    inner: &Arc<Inner>,
+    tls_stream: &ServerTlsStream<TcpStream>,
+) -> Option<PeerId> {
+    let certs = tls_stream.get_ref().1.peer_certificates()?;
+    let cert = certs.first()?;
+    let pubkey = extract_ed25519_pubkey(cert).ok()?;
+    let registry = inner.registry.read().ok()?;
+    registry.find_peer(&pubkey).map(|(peer, _key_id)| peer)
+}
+
+fn resolve_peer_from_client_stream(
+    inner: &Arc<Inner>,
+    tls_stream: &ClientTlsStream<TcpStream>,
+) -> Option<PeerId> {
+    let certs = tls_stream.get_ref().1.peer_certificates()?;
+    let cert = certs.first()?;
+    let pubkey = extract_ed25519_pubkey(cert).ok()?;
+    let registry = inner.registry.read().ok()?;
+    registry.find_peer(&pubkey).map(|(peer, _key_id)| peer)
+}
+
+fn spawn_connection_loops<R, W>(inner: Arc<Inner>, peer_id: PeerId, read_half: R, write_half: W)
+where
+    R: tokio::io::AsyncRead + Send + Unpin + 'static,
+    W: tokio::io::AsyncWrite + Send + Unpin + 'static,
+{
+    let (outbound_tx, outbound_rx) = mpsc::channel::<Frame>(OUTBOUND_CHANNEL_DEPTH);
+
+    // Install this as THE connection. Replaces any prior (shouldn't
+    // happen in MVP because we check before spawning).
+    let inner_for_install = inner.clone();
+    tokio::spawn(async move {
+        *inner_for_install.connection.lock().await = Some(outbound_tx);
+    });
+
+    // Spawn write loop.
+    tokio::spawn(write_loop(write_half, outbound_rx));
+
+    // Spawn read loop with peer binding.
+    tokio::spawn(read_loop(inner, peer_id, read_half));
+}
+
+/// Read loop: pull length-prefixed JSON frames off the TLS stream
+/// and fan out to subscribers per the Transport trait's lag policy.
+async fn read_loop<R>(inner: Arc<Inner>, _peer_id: PeerId, mut read_half: R)
+where
+    R: tokio::io::AsyncRead + Send + Unpin + 'static,
+{
+    loop {
+        // Read 4-byte BE length prefix.
+        let mut len_bytes = [0u8; 4];
+        if read_half.read_exact(&mut len_bytes).await.is_err() {
+            // Connection closed (clean EOF or error). Drop the
+            // outbound channel so senders see "not connected."
+            *inner.connection.lock().await = None;
+            return;
+        }
+        let len = u32::from_be_bytes(len_bytes);
+        if len > MAX_FRAME_BYTES {
+            // Hostile or misconfigured peer — drop the connection.
+            *inner.connection.lock().await = None;
+            return;
+        }
+        let mut payload = vec![0u8; len as usize];
+        if read_half.read_exact(&mut payload).await.is_err() {
+            *inner.connection.lock().await = None;
+            return;
+        }
+
+        let frame: Frame = match serde_json::from_slice(&payload) {
+            Ok(frame) => frame,
+            Err(_error) => {
+                // Malformed payload — drop the connection rather
+                // than silently skipping.
+                *inner.connection.lock().await = None;
+                return;
+            }
+        };
+
+        // Fan out to subscribers; same lag policy as local-fs.
+        dispatch_to_subscribers(&inner, frame).await;
+    }
+}
+
+async fn dispatch_to_subscribers(inner: &Arc<Inner>, frame: Frame) {
+    let mut dead_ids: Vec<u64> = Vec::new();
+    {
+        let subs = inner.subscribers.lock().await;
+        for sub in subs.iter() {
+            if !subscription_matches_with_cursor(&sub.subscription, &frame) {
+                continue;
+            }
+            let send_result = match frame.kind {
+                FrameKind::Message | FrameKind::Control => {
+                    // Backpressure-bearing — block on slow consumer.
+                    sub.tx.send(Ok(frame.clone())).await.map_err(|_| ())
+                }
+                FrameKind::Event => {
+                    // Lossy — drop on full subscriber buffer.
+                    match sub.tx.try_send(Ok(frame.clone())) {
+                        Ok(()) => Ok(()),
+                        Err(mpsc::error::TrySendError::Full(_)) => Ok(()),
+                        Err(mpsc::error::TrySendError::Closed(_)) => Err(()),
+                    }
+                }
+            };
+            if send_result.is_err() {
+                dead_ids.push(sub.id);
+            }
+        }
+    }
+    if !dead_ids.is_empty() {
+        let mut subs = inner.subscribers.lock().await;
+        subs.retain(|sub| !dead_ids.contains(&sub.id));
+    }
+}
+
+/// Cursor predicate (mirrors local-fs's check) — frames at or before
+/// the cursor are skipped for replay subscribers.
+fn subscription_matches_with_cursor(sub: &Subscription, frame: &Frame) -> bool {
+    if !sub.matches(frame) {
+        return false;
+    }
+    if let Some(cursor) = &sub.from_cursor {
+        let envelope = &frame.envelope;
+        let after = envelope.lamport > cursor.lamport
+            || (envelope.lamport == cursor.lamport
+                && envelope.event_id.as_uuid() > cursor.event_id.as_uuid());
+        if !after {
+            return false;
+        }
+    }
+    true
+}
+
+/// Write loop: drain the outbound channel, write framed bytes to TLS.
+async fn write_loop<W>(mut write_half: W, mut outbound_rx: mpsc::Receiver<Frame>)
+where
+    W: tokio::io::AsyncWrite + Send + Unpin + 'static,
+{
+    while let Some(frame) = outbound_rx.recv().await {
+        let payload = match serde_json::to_vec(&frame) {
+            Ok(bytes) => bytes,
+            Err(_) => continue, // skip malformed frame
+        };
+        if payload.len() > MAX_FRAME_BYTES as usize {
+            // Drop oversized frames — caller should be lifting bodies.
+            continue;
+        }
+        let len = (payload.len() as u32).to_be_bytes();
+        if write_half.write_all(&len).await.is_err() {
+            return;
+        }
+        if write_half.write_all(&payload).await.is_err() {
+            return;
+        }
+        if write_half.flush().await.is_err() {
+            return;
+        }
+    }
+}
+
+#[async_trait]
+impl Transport for LanTcpAdapter {
+    type Error = LanTcpError;
+
+    async fn send(&self, frame: Frame) -> Result<(), Self::Error> {
+        let conn = self.inner.connection.lock().await;
+        let tx = conn.as_ref().ok_or(LanTcpError::NotConnected)?;
+        tx.send(frame).await.map_err(|_| LanTcpError::NotConnected)
+    }
+
+    async fn subscribe(
+        &self,
+        subscription: Subscription,
+    ) -> Result<FrameStream<Self::Error>, Self::Error> {
+        let (tx, rx) = mpsc::channel(SUBSCRIBER_CHANNEL_DEPTH);
+        let id = self.inner.next_sub_id.fetch_add(1, Ordering::Relaxed);
+        {
+            let mut subs = self.inner.subscribers.lock().await;
+            subs.push(SubscriberHandle {
+                id,
+                subscription,
+                tx,
+            });
+        }
+        let stream = futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        });
+        Ok(Box::pin(stream) as Pin<Box<dyn Stream<Item = _> + Send>>)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::{
+        headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, PeerId, RoomId,
+    };
+    use airc_protocol::{ChannelId, Envelope, Frame, FrameKind, Signature, Subscription};
+    use futures::stream::StreamExt;
+    use std::time::Duration;
+
+    fn ensure_crypto_provider() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    fn frame_at(lamport: u64, channel: ChannelId, body: &str) -> Frame {
+        Frame {
+            kind: FrameKind::Message,
+            envelope: Envelope {
+                event_id: EventId::from_u128(lamport as u128),
+                sender: PeerId::from_u128(0xa1),
+                sender_client: ClientId::from_u128(0xc1),
+                channel,
+                target: MentionTarget::All,
+                lamport,
+                occurred_at_ms: 1_700_000_000_000 + lamport,
+                reply_to: None,
+                headers: Headers::new(),
+                body: Some(Body::text(body)),
+                media: Vec::new(),
+                signature: Signature::Unsigned,
+            },
+        }
+    }
+
+    /// Build (Alice, Bob) — two peers, each with a keypair, both
+    /// enrolled in a shared registry. Returns (peer_id_a, adapter_a,
+    /// peer_id_b, adapter_b).
+    fn make_paired_adapters() -> (PeerId, LanTcpAdapter, PeerId, LanTcpAdapter) {
+        ensure_crypto_provider();
+        let alice_id = PeerId::from_u128(0xa1);
+        let bob_id = PeerId::from_u128(0xb2);
+        let alice_kp = PeerKeypair::generate();
+        let bob_kp = PeerKeypair::generate();
+
+        let mut registry = PeerKeyRegistry::new();
+        registry
+            .enrol(alice_id, 0, alice_kp.public_bytes())
+            .unwrap();
+        registry.enrol(bob_id, 0, bob_kp.public_bytes()).unwrap();
+        let registry = Arc::new(RwLock::new(registry));
+
+        let alice = LanTcpAdapter::new(alice_id, alice_kp, registry.clone()).unwrap();
+        let bob = LanTcpAdapter::new(bob_id, bob_kp, registry).unwrap();
+        (alice_id, alice, bob_id, bob)
+    }
+
+    #[tokio::test]
+    async fn two_paired_peers_round_trip_a_message() {
+        // The core e2e test: Alice listens, Bob dials. TLS handshake
+        // succeeds (both enrolled). Alice sends a Message frame; Bob
+        // receives it via subscribe.
+        let (alice_id, alice, _bob_id, bob) = make_paired_adapters();
+
+        let loopback = SocketAddr::from(([127, 0, 0, 1], 0));
+        let bound = alice.listen(loopback).await.unwrap();
+
+        // Bob subscribes BEFORE the connection completes so the
+        // arrival is observable.
+        let mut bob_stream = bob
+            .subscribe(Subscription {
+                channel: None,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        bob.connect(bound, alice_id).await.unwrap();
+
+        // Give the post-handshake spawn tasks a moment to install
+        // the connection handle on Alice's side.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let channel = RoomId::from_u128(0xc0ffee);
+        alice
+            .send(frame_at(1, channel, "hello from alice"))
+            .await
+            .unwrap();
+
+        let received = tokio::time::timeout(Duration::from_secs(3), bob_stream.next())
+            .await
+            .expect("must yield within 3s")
+            .expect("stream must yield Some")
+            .expect("frame must parse");
+        assert_eq!(received.envelope.lamport, 1);
+        assert_eq!(
+            received
+                .envelope
+                .body
+                .as_ref()
+                .and_then(Body::as_text)
+                .unwrap(),
+            "hello from alice"
+        );
+    }
+
+    #[tokio::test]
+    async fn unenrolled_peer_cannot_handshake() {
+        // The security guard: an unenrolled peer's dial is rejected
+        // at the TLS handshake — no frames can ever flow.
+        ensure_crypto_provider();
+        let alice_id = PeerId::from_u128(0xa1);
+        let alice_kp = PeerKeypair::generate();
+        // Alice's registry has ONLY herself enrolled.
+        let mut alice_registry = PeerKeyRegistry::new();
+        alice_registry
+            .enrol(alice_id, 0, alice_kp.public_bytes())
+            .unwrap();
+        let alice_registry = Arc::new(RwLock::new(alice_registry));
+        let alice = LanTcpAdapter::new(alice_id, alice_kp, alice_registry).unwrap();
+
+        // Stranger: not in Alice's registry. Has Alice in HER
+        // registry though (otherwise she couldn't verify Alice's
+        // server cert).
+        let stranger_id = PeerId::from_u128(0xdeadbeef);
+        let stranger_kp = PeerKeypair::generate();
+        // Stranger needs Alice's pubkey to verify Alice's server cert;
+        // we extract it directly here. The reverse direction — Alice
+        // accepting stranger — is what this test actually pins.
+        let alice_pub_for_stranger: [u8; 32] = {
+            use crate::lan_tcp::cert::{extract_ed25519_pubkey, generate_self_signed_cert};
+            let (cert, _) = generate_self_signed_cert(
+                &PeerKeypair::from_secret_bytes(&alice.inner.keypair.secret_bytes()),
+                alice_id,
+            )
+            .unwrap();
+            extract_ed25519_pubkey(&cert).unwrap()
+        };
+        let mut stranger_registry = PeerKeyRegistry::new();
+        stranger_registry
+            .enrol(alice_id, 0, alice_pub_for_stranger)
+            .unwrap();
+        stranger_registry
+            .enrol(stranger_id, 0, stranger_kp.public_bytes())
+            .unwrap();
+        let stranger_registry = Arc::new(RwLock::new(stranger_registry));
+        let stranger = LanTcpAdapter::new(stranger_id, stranger_kp, stranger_registry).unwrap();
+
+        let bound = alice
+            .listen(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+
+        // Stranger dials Alice. Alice's `PinnedClientVerifier` rejects
+        // the stranger's cert (unenrolled). Note that the *client's*
+        // `connect()` may return `Ok` because the TLS handshake
+        // completes from the client side before the server's
+        // CertVerify rejection is fully propagated — that's a TLS
+        // protocol property, not a substrate bug. The substrate
+        // guarantee is that no frames can flow: Alice never installs
+        // a connection, so a subsequent `alice.send()` MUST fail with
+        // `NotConnected`.
+        let _ = stranger.connect(bound, alice_id).await;
+        // Give the server side a moment to observe the rejected
+        // handshake and tear the connection down.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let channel = RoomId::from_u128(0xc0ffee);
+        let send_result = alice.send(frame_at(1, channel, "should never arrive")).await;
+        assert!(
+            matches!(send_result, Err(LanTcpError::NotConnected)),
+            "Alice must have no installed connection after refusing stranger's handshake; got {send_result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_without_connection_returns_not_connected() {
+        // Sending before listen/connect should surface a typed error,
+        // not panic or block forever.
+        let (_alice_id, alice, _bob_id, _bob) = make_paired_adapters();
+        let channel = RoomId::from_u128(0xc0ffee);
+        let result = alice.send(frame_at(1, channel, "into the void")).await;
+        assert!(matches!(result, Err(LanTcpError::NotConnected)));
+    }
+}

--- a/crates/airc-transport/src/lan_tcp/mod.rs
+++ b/crates/airc-transport/src/lan_tcp/mod.rs
@@ -16,15 +16,18 @@
 //!     reject.
 //!   - Cert decode failure / wrong SPKI algorithm → reject.
 //!
-//! This module owns the cryptographic *infrastructure* — cert
-//! generation and pinning verifiers. The `LanTcpAdapter` (a
-//! `Transport` impl that uses these verifiers to wrap real TCP
-//! connections in TLS) lands in PR-3c; this PR pins the security
-//! foundation independently so it's reviewable and testable in
-//! isolation.
+//! Module layout:
+//!   - `cert` — bidirectional cert ↔ Ed25519 pubkey bridge
+//!   - `verifier` — rustls verifiers pinned to enrolled keys
+//!   - `tls_config` — composes cert + verifier into rustls configs
+//!   - `adapter` — `LanTcpAdapter` (the `Transport` impl)
 
+pub mod adapter;
 pub mod cert;
+pub mod tls_config;
 pub mod verifier;
 
+pub use adapter::{LanTcpAdapter, LanTcpError};
 pub use cert::{extract_ed25519_pubkey, generate_self_signed_cert, CertGenError, CertParseError};
+pub use tls_config::{build_client_config, build_server_config, TlsConfigError};
 pub use verifier::{PinnedClientVerifier, PinnedServerVerifier};

--- a/crates/airc-transport/src/lan_tcp/tls_config.rs
+++ b/crates/airc-transport/src/lan_tcp/tls_config.rs
@@ -1,0 +1,149 @@
+//! Build rustls `ServerConfig` and `ClientConfig` wired to the
+//! substrate's peer-pinning verifiers.
+//!
+//! Both configs are TLS 1.3 only, Ed25519 only, mutual-auth. The
+//! standard CA path is replaced by `PinnedServerVerifier` /
+//! `PinnedClientVerifier` from this module — there is no fall-back to
+//! standard PKI, and the configs refuse to be built without a registry
+//! reference.
+
+use std::sync::Arc;
+use std::sync::RwLock;
+
+use rustls::{ClientConfig, ServerConfig};
+
+use airc_core::PeerId;
+use airc_protocol::{PeerKeyRegistry, PeerKeypair};
+
+use crate::lan_tcp::cert::{generate_self_signed_cert, CertGenError};
+use crate::lan_tcp::verifier::{PinnedClientVerifier, PinnedServerVerifier};
+
+/// What can go wrong configuring the TLS layer.
+#[derive(Debug)]
+pub enum TlsConfigError {
+    /// Cert generation from the peer keypair failed.
+    CertGen(CertGenError),
+
+    /// rustls rejected the config — usually a misconfigured cipher
+    /// suite, key/cert mismatch, or missing crypto provider.
+    Rustls(rustls::Error),
+}
+
+impl std::fmt::Display for TlsConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TlsConfigError::CertGen(error) => write!(f, "TLS cert generation: {error}"),
+            TlsConfigError::Rustls(error) => write!(f, "rustls config: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for TlsConfigError {}
+
+impl From<CertGenError> for TlsConfigError {
+    fn from(error: CertGenError) -> Self {
+        TlsConfigError::CertGen(error)
+    }
+}
+
+impl From<rustls::Error> for TlsConfigError {
+    fn from(error: rustls::Error) -> Self {
+        TlsConfigError::Rustls(error)
+    }
+}
+
+/// Build a TLS `ServerConfig` that presents the peer's self-signed
+/// Ed25519-bound cert and verifies incoming client certs against the
+/// registry via `PinnedClientVerifier`.
+///
+/// `peer_id` is THIS peer's id (used as the cert subject CN).
+/// `keypair` is THIS peer's signing key (used to sign the cert).
+/// `registry` is the trust anchor (must contain the peers expected to
+/// connect; an empty registry means the server refuses every client).
+pub fn build_server_config(
+    peer_id: PeerId,
+    keypair: &PeerKeypair,
+    registry: Arc<RwLock<PeerKeyRegistry>>,
+) -> Result<Arc<ServerConfig>, TlsConfigError> {
+    let (cert, key) = generate_self_signed_cert(keypair, peer_id)?;
+
+    let verifier = Arc::new(PinnedClientVerifier::new(registry));
+
+    let config = ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+        .with_client_cert_verifier(verifier)
+        .with_single_cert(vec![cert], key)?;
+
+    Ok(Arc::new(config))
+}
+
+/// Build a TLS `ClientConfig` that presents the peer's cert and pins
+/// the server side to `expected_peer`'s enrolled Ed25519 pubkey.
+///
+/// Construct a fresh `ClientConfig` per `connect(...)` call when the
+/// expected peer differs — the verifier is baked in at config build
+/// time, not selectable per-connection.
+pub fn build_client_config(
+    self_peer_id: PeerId,
+    keypair: &PeerKeypair,
+    expected_peer: PeerId,
+    registry: Arc<RwLock<PeerKeyRegistry>>,
+) -> Result<Arc<ClientConfig>, TlsConfigError> {
+    let (cert, key) = generate_self_signed_cert(keypair, self_peer_id)?;
+
+    let verifier = Arc::new(PinnedServerVerifier::new(expected_peer, registry));
+
+    let config = ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+        .dangerous()
+        .with_custom_certificate_verifier(verifier)
+        .with_client_auth_cert(vec![cert], key)?;
+
+    Ok(Arc::new(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ensure_crypto_provider() {
+        // rustls 0.23 requires a CryptoProvider to be installed before
+        // building configs. We install ring once per test process;
+        // ignore the duplicate-installation error since tests can run
+        // in any order.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    #[test]
+    fn server_config_builds_for_enrolled_peer() {
+        ensure_crypto_provider();
+        let peer = PeerId::from_u128(0xa1);
+        let keypair = PeerKeypair::generate();
+
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
+        let registry = Arc::new(RwLock::new(registry));
+
+        let config = build_server_config(peer, &keypair, registry);
+        assert!(config.is_ok(), "expected Ok, got {config:?}");
+    }
+
+    #[test]
+    fn client_config_builds_for_expected_peer() {
+        ensure_crypto_provider();
+        let self_peer = PeerId::from_u128(0xa1);
+        let other_peer = PeerId::from_u128(0xb2);
+        let self_kp = PeerKeypair::generate();
+        let other_kp = PeerKeypair::generate();
+
+        let mut registry = PeerKeyRegistry::new();
+        registry
+            .enrol(self_peer, 0, self_kp.public_bytes())
+            .unwrap();
+        registry
+            .enrol(other_peer, 0, other_kp.public_bytes())
+            .unwrap();
+        let registry = Arc::new(RwLock::new(registry));
+
+        let config = build_client_config(self_peer, &self_kp, other_peer, registry);
+        assert!(config.is_ok(), "expected Ok, got {config:?}");
+    }
+}

--- a/crates/airc-transport/src/lib.rs
+++ b/crates/airc-transport/src/lib.rs
@@ -27,8 +27,9 @@ pub mod transport;
 // Re-exports — stable public surface.
 pub use error::LocalFsError;
 pub use lan_tcp::{
-    extract_ed25519_pubkey, generate_self_signed_cert, CertGenError, CertParseError,
-    PinnedClientVerifier, PinnedServerVerifier,
+    build_client_config, build_server_config, extract_ed25519_pubkey, generate_self_signed_cert,
+    CertGenError, CertParseError, LanTcpAdapter, LanTcpError, PinnedClientVerifier,
+    PinnedServerVerifier, TlsConfigError,
 };
 pub use local_fs::LocalFsAdapter;
 pub use transport::{FrameStream, Transport};


### PR DESCRIPTION
## Summary

PR-3c lands the `Transport` impl that uses PR-3b's cert + verifier infrastructure (PR #670). **Two AI peers on the same LAN can now talk over mutual-TLS-authenticated TCP** with no plaintext path, no CA, no fallback.

This is the e2e "two AI peers on different machines (same LAN) chat without burning a single gh request" milestone.

## MVP scope

- **Point-to-peer**: one active connection per adapter. PR-3d expands to N-peer fan-out.
- **Multi-subscriber fan-out**: one adapter, many `Transport::subscribe` callers.
- **Length-prefixed JSON frames**: u32 BE prefix + payload, 16 MB per-frame cap.
- **Mutual TLS 1.3 only** via `tls_config` builders. Ed25519 only.
- **Post-handshake peer-id binding**: cert subject pubkey → `PeerKeyRegistry::find_peer` → `PeerId`. Cert that doesn't resolve = reject (server-side; verifier already refused at handshake time, this is a sanity check).
- **FrameKind delivery split** inherited from the trait: Message/Control durable+backpressure, Event lossy.

## New: `crates/airc-transport/src/lan_tcp/`

- **`tls_config.rs`** — `build_server_config` / `build_client_config`. Composes the substrate's `PeerKeypair` (via PKCS#8 DER → rcgen) with the pinning verifiers into rustls configs.
- **`adapter.rs`** — `LanTcpAdapter`:
  - `new(self_peer_id, keypair, registry)` → adapter
  - `listen(bind_addr)` → spawns accept loop, accepts ONE peer
  - `connect(addr, expected_peer)` → dials + completes mTLS
  - `Transport::send` → broadcasts to the (single MVP) connection
  - `Transport::subscribe(Subscription)` → registers a handle, returns filtered FrameStream
  - Read loop dispatches per kind-aware lag policy; dead subscribers GCd by next dispatch pass

## Removed (refactor)

`error.rs` previously had a stub `LanTcpError` from the pre-pivot "DEV-PREVIEW with unsafe_allow_public_bind" plan. Deleted. The real `LanTcpError` now lives in `adapter.rs` with appropriate variants:

```rust
pub enum LanTcpError {
    Io, Json, TlsConfig, TlsHandshake,
    PeerNotInRegistry,
    FrameTooLarge { announced, limit },
    NotConnected,
    AlreadyHasConnection,
}
```

## Test plan

- [x] `cargo fmt -p airc-transport` — clean
- [x] `cargo clippy -p airc-transport --all-targets -- -D warnings` — clean
- [x] `cargo test -p airc-transport` — **29 pass / 0 fail**

Key new tests:

| Test | Pins |
|------|------|
| `two_paired_peers_round_trip_a_message` | Full e2e: Alice listens, Bob dials, both enrolled. Bob receives Alice's Message frame via subscribe within 3 s. |
| `unenrolled_peer_cannot_handshake` | Stranger NOT in Alice's registry tries to connect; Alice's `PinnedClientVerifier` rejects; Alice never installs a connection; `alice.send` returns `NotConnected`. **Pins the security guarantee: handshake rejection ⇒ zero frames flow.** |
| `send_without_connection_returns_not_connected` | Typed error before listen/connect. |
| `server_config_builds_for_enrolled_peer` | TLS config builder works. |
| `client_config_builds_for_expected_peer` | TLS config builder works. |

## Deferred (per "robustness next" cue)

- Multi-peer concurrent connections (PR-3d)
- Reconnect / retry logic
- Per-frame Ed25519 signing on the send path (`PeerKeypair::sign_envelope` is ready; the wiring through `LanTcpAdapter::send` is the next signing step)
- mDNS / discovery (separate concern from the wire layer)

## Stack

Stacked on `feat/airc-transport-tls-pinning` (PR #670). Once all of #664–#671 merge, two Rust-substrate AI peers can talk over a real LAN with no gh polling and no plaintext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)