### PR TITLE
feat(airc-cli): airc-rs binary — first Rust replacement for Python airc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-cli"
+version = "0.1.0"
+dependencies = [
+ "airc-core",
+ "airc-protocol",
+ "airc-transport",
+ "base64",
+ "clap",
+ "futures",
+ "rustls",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "airc-core"
 version = "0.1.0"
 dependencies = [
@@ -53,6 +71,56 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "x509-parser",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -207,6 +275,52 @@ dependencies = [
  "ciborium-io",
  "half",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
@@ -579,6 +693,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +827,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pem"
@@ -979,6 +1105,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1148,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1135,6 +1277,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -1184,6 +1327,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "crates/airc-blobs",
     "crates/airc-protocol",
     "crates/airc-transport",
+    "crates/airc-cli",
 ]
 resolver = "2"

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "airc-cli"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+[[bin]]
+name = "airc-rs"
+path = "src/main.rs"
+
+[dependencies]
+airc-core = { path = "../airc-core" }
+airc-protocol = { path = "../airc-protocol" }
+airc-transport = { path = "../airc-transport" }
+clap = { version = "4", features = ["derive", "env"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "signal"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"
+futures = "0.3"
+uuid = { version = "1", features = ["v4"] }
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -1,0 +1,99 @@
+//! Command-line interface definitions (clap derive).
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+use crate::registry::PeerSpec;
+
+/// airc-rs — Rust substrate CLI. Replaces the Python `airc` step by
+/// step; each subcommand exercises one slice of the substrate.
+#[derive(Debug, Parser)]
+#[command(
+    name = "airc-rs",
+    version,
+    about = "AIRC substrate CLI (Rust)",
+    long_about = "Cross-process / cross-machine AI chat over the airc substrate. \
+                  Replaces the Python airc CLI as the Rust path matures."
+)]
+pub struct Cli {
+    /// Path to the 32-byte Ed25519 identity file. Created on first
+    /// use if absent.
+    #[arg(long, env = "AIRC_RS_IDENTITY", global = true)]
+    pub identity_file: Option<PathBuf>,
+
+    /// This peer's UUID. Generated and printed on first `init`;
+    /// pass it back on subsequent commands.
+    #[arg(long, env = "AIRC_RS_PEER_ID", global = true)]
+    pub peer_id: Option<String>,
+
+    /// Peers to enrol in the local registry, repeatable.
+    /// Format: `<uuid>:<base64-pubkey-no-padding>`. Obtain by
+    /// running `airc-rs init` on the peer side and copying its
+    /// printed spec.
+    #[arg(long = "peer", value_name = "SPEC", global = true)]
+    pub peers: Vec<PeerSpec>,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Create or load an identity, then print this peer's spec for
+    /// out-of-band sharing.
+    Init,
+
+    /// Send a single text Message frame and exit.
+    Send {
+        /// Wire directory (must be the same as the receiver's).
+        #[arg(long)]
+        wire: PathBuf,
+        /// Channel UUID (any unique value shared with the receiver).
+        #[arg(long, value_name = "UUID")]
+        channel: String,
+        /// Message body.
+        text: String,
+    },
+
+    /// Subscribe and print frames until interrupted (Ctrl-C).
+    Listen {
+        /// Wire directory.
+        #[arg(long)]
+        wire: PathBuf,
+        /// Channel filter (optional). If omitted, all channels.
+        #[arg(long, value_name = "UUID")]
+        channel: Option<String>,
+        /// Replay from the start of the wire instead of live-only.
+        #[arg(long)]
+        replay: bool,
+    },
+
+    /// Same-LAN secure send: dial a peer over TLS and send a single
+    /// text frame.
+    LanSend {
+        /// Address of the listening peer (e.g. `127.0.0.1:7474`).
+        #[arg(long)]
+        to: SocketAddr,
+        /// UUID of the listening peer (for cert pinning).
+        #[arg(long)]
+        expected_peer: String,
+        /// Channel UUID.
+        #[arg(long)]
+        channel: String,
+        /// Message body.
+        text: String,
+    },
+
+    /// Same-LAN secure listen: bind a TLS server, accept ONE peer
+    /// (MVP), print received frames.
+    LanListen {
+        /// Bind address (e.g. `127.0.0.1:7474` or `0.0.0.0:7474`).
+        #[arg(long)]
+        bind: SocketAddr,
+        /// Replay-mode subscription (defaults to live-only).
+        #[arg(long)]
+        replay: bool,
+    },
+}

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1,0 +1,249 @@
+//! Subcommand handlers — keep them small and direct. Each function
+//! takes the parsed CLI context and runs.
+
+use std::path::Path;
+use std::str::FromStr;
+
+use airc_core::{
+    headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, PeerId, RoomId,
+    TranscriptCursor,
+};
+use airc_protocol::{Envelope, Frame, FrameKind, Signature, Subscription, VerificationPolicy};
+use airc_transport::{LanTcpAdapter, LocalFsAdapter, SignedTransport, Transport};
+use futures::stream::StreamExt;
+use uuid::Uuid;
+
+use crate::identity::load_or_generate;
+use crate::registry::{build_registry, format_peer_spec, PeerSpec};
+
+/// `init` — load or generate the identity, print the peer spec.
+pub fn run_init(identity_file: &Path, peer_id: Option<PeerId>) -> std::io::Result<()> {
+    let keypair = load_or_generate(identity_file)?;
+    let peer_id = peer_id.unwrap_or_default();
+    println!("identity_file: {}", identity_file.display());
+    println!("peer_id:       {peer_id}");
+    println!(
+        "peer_spec:     {}",
+        format_peer_spec(peer_id, &keypair.public_bytes())
+    );
+    println!();
+    println!("Share `peer_spec` with the other side, and pass it back as");
+    println!("`--peer <spec>` plus `--peer-id {peer_id}` on subsequent commands.");
+    Ok(())
+}
+
+/// `send` — local-fs single-shot send, signed under Strict.
+pub async fn run_send(
+    identity_file: &Path,
+    peer_id: PeerId,
+    peers: Vec<PeerSpec>,
+    wire: &Path,
+    channel: &str,
+    text: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let keypair = load_or_generate(identity_file)?;
+    let registry = build_registry(peer_id, keypair.public_bytes(), &peers)?;
+
+    let inner = LocalFsAdapter::new(wire);
+    let transport = SignedTransport::new(
+        inner,
+        keypair,
+        peer_id,
+        registry,
+        VerificationPolicy::Strict,
+    );
+
+    let channel_id = parse_channel(channel)?;
+    let frame = build_message_frame(peer_id, channel_id, text);
+    transport.send(frame).await?;
+    println!("sent.");
+    Ok(())
+}
+
+/// `listen` — local-fs subscribe loop. Prints frames until Ctrl-C.
+pub async fn run_listen(
+    identity_file: &Path,
+    peer_id: PeerId,
+    peers: Vec<PeerSpec>,
+    wire: &Path,
+    channel: Option<String>,
+    replay: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let keypair = load_or_generate(identity_file)?;
+    let registry = build_registry(peer_id, keypair.public_bytes(), &peers)?;
+
+    let inner = LocalFsAdapter::new(wire);
+    let transport = SignedTransport::new(
+        inner,
+        keypair,
+        peer_id,
+        registry,
+        VerificationPolicy::Strict,
+    );
+
+    let subscription = subscription_for(channel.as_deref(), replay)?;
+    let mut stream = transport.subscribe(subscription).await?;
+
+    println!("listening on {} (peer_id {peer_id}) …", wire.display());
+    print_until_signal(&mut stream).await
+}
+
+/// `lan-send` — TLS-wrapped single-shot send to a remote peer.
+pub async fn run_lan_send(
+    identity_file: &Path,
+    peer_id: PeerId,
+    peers: Vec<PeerSpec>,
+    to: std::net::SocketAddr,
+    expected_peer: PeerId,
+    channel: &str,
+    text: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let keypair = load_or_generate(identity_file)?;
+    let registry = build_registry(peer_id, keypair.public_bytes(), &peers)?;
+
+    let inner = LanTcpAdapter::new(peer_id, keypair.clone(), registry.clone())?;
+    inner.connect(to, expected_peer).await?;
+
+    // SignedTransport wraps the inner once connected.
+    let transport = SignedTransport::new(
+        inner,
+        keypair,
+        peer_id,
+        registry,
+        VerificationPolicy::Strict,
+    );
+
+    // Give the post-handshake spawn task time to install the
+    // outbound channel before send.
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    let channel_id = parse_channel(channel)?;
+    let frame = build_message_frame(peer_id, channel_id, text);
+    transport.send(frame).await?;
+    println!("sent over lan-tcp.");
+    Ok(())
+}
+
+/// `lan-listen` — bind a TLS server, accept ONE peer, print frames.
+pub async fn run_lan_listen(
+    identity_file: &Path,
+    peer_id: PeerId,
+    peers: Vec<PeerSpec>,
+    bind: std::net::SocketAddr,
+    replay: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let keypair = load_or_generate(identity_file)?;
+    let registry = build_registry(peer_id, keypair.public_bytes(), &peers)?;
+
+    let inner = LanTcpAdapter::new(peer_id, keypair.clone(), registry.clone())?;
+    let actual = inner.listen(bind).await?;
+    println!("listening on {actual} (peer_id {peer_id}) …");
+
+    let transport = SignedTransport::new(
+        inner,
+        keypair,
+        peer_id,
+        registry,
+        VerificationPolicy::Strict,
+    );
+
+    let subscription = subscription_for(None, replay)?;
+    let mut stream = transport.subscribe(subscription).await?;
+    print_until_signal(&mut stream).await
+}
+
+fn parse_channel(channel: &str) -> Result<RoomId, uuid::Error> {
+    let uuid = Uuid::from_str(channel)?;
+    Ok(RoomId::from_uuid(uuid))
+}
+
+fn subscription_for(
+    channel: Option<&str>,
+    replay: bool,
+) -> Result<Subscription, Box<dyn std::error::Error>> {
+    let channel_id = match channel {
+        Some(s) => Some(parse_channel(s)?),
+        None => None,
+    };
+    let from_cursor = if replay {
+        Some(TranscriptCursor {
+            lamport: 0,
+            event_id: EventId::from_u128(0),
+        })
+    } else {
+        None
+    };
+    Ok(Subscription {
+        channel: channel_id,
+        from_cursor,
+        ..Default::default()
+    })
+}
+
+fn build_message_frame(sender: PeerId, channel: RoomId, text: &str) -> Frame {
+    let lamport = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    Frame {
+        kind: FrameKind::Message,
+        envelope: Envelope {
+            event_id: EventId::new(),
+            sender,
+            sender_client: ClientId::new(),
+            channel,
+            target: MentionTarget::All,
+            lamport,
+            occurred_at_ms: lamport,
+            reply_to: None,
+            headers: Headers::new(),
+            body: Some(Body::text(text)),
+            media: Vec::new(),
+            signature: Signature::Unsigned,
+        },
+    }
+}
+
+async fn print_until_signal<S, E>(stream: &mut S) -> Result<(), Box<dyn std::error::Error>>
+where
+    S: futures::Stream<Item = Result<Frame, E>> + Unpin,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let sigint = tokio::signal::ctrl_c();
+    let mut sigint = Box::pin(sigint);
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut sigint => {
+                println!();
+                println!("interrupted; exiting.");
+                return Ok(());
+            }
+            next = stream.next() => {
+                match next {
+                    Some(Ok(frame)) => print_frame(&frame),
+                    Some(Err(error)) => eprintln!("verification failed: {error}"),
+                    None => {
+                        println!("stream closed; exiting.");
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn print_frame(frame: &Frame) {
+    let text = frame
+        .envelope
+        .body
+        .as_ref()
+        .and_then(Body::as_text)
+        .unwrap_or("<non-text body>");
+    println!(
+        "[{kind:?}] {sender} → {channel}: {text}",
+        kind = frame.kind,
+        sender = frame.envelope.sender,
+        channel = frame.envelope.channel,
+    );
+}

--- a/crates/airc-cli/src/identity.rs
+++ b/crates/airc-cli/src/identity.rs
@@ -1,0 +1,106 @@
+//! Identity persistence — load + save a `PeerKeypair` to a file.
+//!
+//! MVP storage: raw 32-byte Ed25519 secret in a file at `--identity-file
+//! <path>`. The file is created with 0600 (owner-only) permissions
+//! when the runtime is on Unix.
+//!
+//! NOT for production secrets: a real implementation belongs behind
+//! SQLCipher, an OS keychain, or a hardware enclave (see the substrate
+//! `feedback_blobs_never_in_db` rule + the storage discussion in
+//! `airc-protocol::keypair`'s docs). The CLI's MVP file-storage is
+//! adequate for cross-process e2e demos but flagged as such.
+
+use std::path::Path;
+
+use airc_protocol::PeerKeypair;
+
+pub fn load_or_generate(path: &Path) -> std::io::Result<PeerKeypair> {
+    if path.exists() {
+        load(path)
+    } else {
+        let keypair = PeerKeypair::generate();
+        save(path, &keypair)?;
+        Ok(keypair)
+    }
+}
+
+pub fn load(path: &Path) -> std::io::Result<PeerKeypair> {
+    let bytes = std::fs::read(path)?;
+    if bytes.len() != 32 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "identity file {} has {} bytes, expected 32 (raw Ed25519 secret)",
+                path.display(),
+                bytes.len()
+            ),
+        ));
+    }
+    let mut secret = [0u8; 32];
+    secret.copy_from_slice(&bytes);
+    Ok(PeerKeypair::from_secret_bytes(&secret))
+}
+
+pub fn save(path: &Path, keypair: &PeerKeypair) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    std::fs::write(path, keypair.secret_bytes())?;
+    set_owner_only_permissions(path)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_owner_only_permissions(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o600);
+    std::fs::set_permissions(path, perms)
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_permissions(_path: &Path) -> std::io::Result<()> {
+    // Windows: rely on default user-profile ACLs for the directory.
+    // A real cross-platform implementation would set Windows ACLs to
+    // restrict to current user only — out of scope for MVP.
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn round_trip_through_disk() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.key");
+        let original = PeerKeypair::generate();
+        save(&path, &original).unwrap();
+        let loaded = load(&path).unwrap();
+        assert_eq!(loaded.secret_bytes(), original.secret_bytes());
+    }
+
+    #[test]
+    fn load_or_generate_creates_then_reuses() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("auto.key");
+        let first = load_or_generate(&path).unwrap();
+        let second = load_or_generate(&path).unwrap();
+        // The second call must read what the first wrote, not
+        // generate a fresh key — otherwise a CLI rerun would
+        // change identity.
+        assert_eq!(first.secret_bytes(), second.secret_bytes());
+    }
+
+    #[test]
+    fn rejects_wrong_size_identity_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bad.key");
+        std::fs::write(&path, [0u8; 20]).unwrap();
+        let result = load(&path);
+        assert!(result.is_err());
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -1,0 +1,125 @@
+//! airc-rs — Rust substrate CLI binary.
+//!
+//! Wires the substrate crates (`airc-core`, `airc-protocol`,
+//! `airc-transport`) into a small command-line tool that proves the
+//! Rust substrate works end-to-end without any Python. Two terminals
+//! can chat over local-fs or LAN-TCP via this binary.
+//!
+//! MVP scope:
+//!   - `init` — generate / load identity, print peer spec.
+//!   - `send` / `listen` — local-fs (same-Mac multi-process).
+//!   - `lan-send` / `lan-listen` — TLS-wrapped TCP (same-LAN secure).
+//!
+//! What's deferred:
+//!   - Persistent registry (for now, peers are passed via repeated
+//!     `--peer` flags on each command).
+//!   - A bridge daemon that holds state for short-lived CLI calls.
+//!   - Cross-platform polish (Windows ACLs, etc.).
+
+mod cli;
+mod commands;
+mod identity;
+mod registry;
+
+use std::process::ExitCode;
+
+use clap::Parser;
+use uuid::Uuid;
+
+use airc_core::PeerId;
+
+use cli::{Cli, Command};
+
+fn parse_peer_id(input: &str) -> Result<PeerId, Box<dyn std::error::Error>> {
+    let uuid = Uuid::parse_str(input)
+        .map_err(|error| format!("--peer-id {input:?} is not a valid UUID: {error}"))?;
+    Ok(PeerId::from_uuid(uuid))
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    // Install the rustls crypto provider once at process start so all
+    // TLS paths Just Work. Ignore the duplicate-install error in case
+    // a test harness installed it first.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let parsed = Cli::parse();
+    match dispatch(parsed).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("airc-rs: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
+    let identity_file = parsed
+        .identity_file
+        .clone()
+        .ok_or("--identity-file or AIRC_RS_IDENTITY env var is required")?;
+
+    let parsed_peer_id = match parsed.peer_id.as_deref() {
+        Some(input) => Some(parse_peer_id(input)?),
+        None => None,
+    };
+
+    match parsed.command {
+        Command::Init => commands::run_init(&identity_file, parsed_peer_id).map_err(Into::into),
+        Command::Send {
+            wire,
+            channel,
+            text,
+        } => {
+            let peer_id = parsed_peer_id.ok_or("--peer-id is required for send")?;
+            commands::run_send(
+                &identity_file,
+                peer_id,
+                parsed.peers,
+                &wire,
+                &channel,
+                &text,
+            )
+            .await
+        }
+        Command::Listen {
+            wire,
+            channel,
+            replay,
+        } => {
+            let peer_id = parsed_peer_id.ok_or("--peer-id is required for listen")?;
+            commands::run_listen(
+                &identity_file,
+                peer_id,
+                parsed.peers,
+                &wire,
+                channel,
+                replay,
+            )
+            .await
+        }
+        Command::LanSend {
+            to,
+            expected_peer,
+            channel,
+            text,
+        } => {
+            let peer_id = parsed_peer_id.ok_or("--peer-id is required for lan-send")?;
+            let expected = parse_peer_id(&expected_peer)?;
+            commands::run_lan_send(
+                &identity_file,
+                peer_id,
+                parsed.peers,
+                to,
+                expected,
+                &channel,
+                &text,
+            )
+            .await
+        }
+        Command::LanListen { bind, replay } => {
+            let peer_id = parsed_peer_id.ok_or("--peer-id is required for lan-listen")?;
+            commands::run_lan_listen(&identity_file, peer_id, parsed.peers, bind, replay).await
+        }
+    }
+}

--- a/crates/airc-cli/src/registry.rs
+++ b/crates/airc-cli/src/registry.rs
@@ -1,0 +1,158 @@
+//! Parse `--peer <id>:<pubkey-b64>` arguments into a `PeerKeyRegistry`.
+//!
+//! MVP pairing: peers exchange their (PeerId, pubkey) pair out-of-band
+//! and feed them to the CLI as repeated `--peer` flags. A real airc
+//! deployment will have a pairing flow (QR codes, invite URLs, signed
+//! enrolments via a coordinator). This module is the minimum that
+//! makes cross-process demos work.
+
+use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::RwLock;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use uuid::Uuid;
+
+use airc_core::PeerId;
+use airc_protocol::PeerKeyRegistry;
+
+#[derive(Debug)]
+pub enum PeerSpecError {
+    /// The argument didn't have the form `<peer_id>:<base64_pubkey>`.
+    BadFormat(String),
+    /// The `peer_id` portion wasn't a valid UUID.
+    BadPeerId { input: String, source: uuid::Error },
+    /// Base64 decode failed.
+    BadBase64(String),
+    /// Decoded pubkey wasn't 32 bytes.
+    WrongPubkeyLength(usize),
+}
+
+impl std::fmt::Display for PeerSpecError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PeerSpecError::BadFormat(input) => write!(
+                f,
+                "peer spec {input:?} is not in the form <uuid>:<base64-pubkey>"
+            ),
+            PeerSpecError::BadPeerId { input, source } => {
+                write!(f, "peer id {input:?} is not a valid UUID: {source}")
+            }
+            PeerSpecError::BadBase64(message) => write!(f, "base64 decode failed: {message}"),
+            PeerSpecError::WrongPubkeyLength(got) => {
+                write!(f, "decoded pubkey is {got} bytes, expected 32")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PeerSpecError {}
+
+/// A parsed peer spec: which peer it identifies + their 32-byte pubkey.
+#[derive(Clone, Debug)]
+pub struct PeerSpec {
+    pub peer_id: PeerId,
+    pub pubkey: [u8; 32],
+}
+
+impl FromStr for PeerSpec {
+    type Err = PeerSpecError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (id_part, key_part) = s
+            .split_once(':')
+            .ok_or_else(|| PeerSpecError::BadFormat(s.to_string()))?;
+        let uuid = Uuid::parse_str(id_part).map_err(|source| PeerSpecError::BadPeerId {
+            input: id_part.to_string(),
+            source,
+        })?;
+        let bytes = URL_SAFE_NO_PAD
+            .decode(key_part)
+            .map_err(|error| PeerSpecError::BadBase64(error.to_string()))?;
+        if bytes.len() != 32 {
+            return Err(PeerSpecError::WrongPubkeyLength(bytes.len()));
+        }
+        let mut pubkey = [0u8; 32];
+        pubkey.copy_from_slice(&bytes);
+        Ok(PeerSpec {
+            peer_id: PeerId::from_uuid(uuid),
+            pubkey,
+        })
+    }
+}
+
+/// Build a registry from a list of peer specs. Each spec's pubkey is
+/// enrolled at key_id = 0 (the substrate default).
+pub fn build_registry(
+    self_peer_id: PeerId,
+    self_pubkey: [u8; 32],
+    peer_specs: &[PeerSpec],
+) -> Result<Arc<RwLock<PeerKeyRegistry>>, airc_protocol::KeyError> {
+    let mut registry = PeerKeyRegistry::new();
+    registry.enrol(self_peer_id, 0, self_pubkey)?;
+    for spec in peer_specs {
+        registry.enrol(spec.peer_id, 0, spec.pubkey)?;
+    }
+    Ok(Arc::new(RwLock::new(registry)))
+}
+
+/// Encode a pubkey as a `--peer` argument tail (`<id>:<b64>`), for
+/// printing on `init` so the user can hand it to peers out-of-band.
+pub fn format_peer_spec(peer_id: PeerId, pubkey: &[u8; 32]) -> String {
+    let encoded = URL_SAFE_NO_PAD.encode(pubkey);
+    format!("{peer_id}:{encoded}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_protocol::PeerKeypair;
+
+    #[test]
+    fn round_trip_format_then_parse() {
+        let peer_id = PeerId::new();
+        let keypair = PeerKeypair::generate();
+        let spec_str = format_peer_spec(peer_id, &keypair.public_bytes());
+        let parsed: PeerSpec = spec_str.parse().unwrap();
+        assert_eq!(parsed.peer_id, peer_id);
+        assert_eq!(parsed.pubkey, keypair.public_bytes());
+    }
+
+    #[test]
+    fn rejects_missing_colon() {
+        let result: Result<PeerSpec, _> = "no-colon-here".parse();
+        assert!(matches!(result, Err(PeerSpecError::BadFormat(_))));
+    }
+
+    #[test]
+    fn rejects_bad_uuid() {
+        let result: Result<PeerSpec, _> = "not-a-uuid:AAAA".parse();
+        assert!(matches!(result, Err(PeerSpecError::BadPeerId { .. })));
+    }
+
+    #[test]
+    fn rejects_short_pubkey() {
+        let uuid = PeerId::new();
+        let short_b64 = URL_SAFE_NO_PAD.encode([0u8; 10]);
+        let spec_str = format!("{uuid}:{short_b64}");
+        let result: Result<PeerSpec, _> = spec_str.parse();
+        assert!(matches!(result, Err(PeerSpecError::WrongPubkeyLength(10))));
+    }
+
+    #[test]
+    fn build_registry_with_two_peers() {
+        let self_id = PeerId::new();
+        let self_kp = PeerKeypair::generate();
+        let other_id = PeerId::new();
+        let other_kp = PeerKeypair::generate();
+        let spec = PeerSpec {
+            peer_id: other_id,
+            pubkey: other_kp.public_bytes(),
+        };
+        let registry = build_registry(self_id, self_kp.public_bytes(), &[spec]).unwrap();
+        let registry = registry.read().unwrap();
+        assert!(registry.lookup(self_id, 0).is_some());
+        assert!(registry.lookup(other_id, 0).is_some());
+    }
+}


### PR DESCRIPTION
## Summary

New crate `airc-cli` shipping the `airc-rs` binary. **First Rust replacement for the Python `airc` CLI** — proves the substrate works from a real command line, not just library tests.

## Subcommands

- `init` — generate/load identity, print shareable peer spec
- `send` / `listen` — local-fs same-Mac chat (`LocalFsAdapter` + `SignedTransport` + Strict policy)
- `lan-send` / `lan-listen` — secure LAN chat (`LanTcpAdapter` + `SignedTransport` + TLS 1.3 Ed25519 peer-pinning)

## Live e2e demo

```bash
$ airc-rs --identity-file /tmp/alice.key init
identity_file: /tmp/alice.key
peer_id:       07e7ad58-ba56-4535-b4e5-a161a110e487
peer_spec:     07e7ad58-…:Wi-NZWat3kYD9MhQ7JqMEPZ7i_HKUD-xTi8IIMDF6BY

$ airc-rs --identity-file /tmp/bob.key \
    --peer-id <bob-uuid> --peer <alice-spec> \
    listen --wire /tmp/wire --replay

$ airc-rs --identity-file /tmp/alice.key \
    --peer-id <alice-uuid> --peer <bob-spec> \
    send --wire /tmp/wire --channel <channel-uuid> "hello"
```

Two terminals, **no Python on either side**. Substrate handles signing, verification, delivery, replay.

## Module layout

| File | What |
|------|------|
| `cli.rs` | clap-derive parser, all subcommand args |
| `identity.rs` | `load_or_generate(path) -> PeerKeypair`, owner-only file perms on Unix |
| `registry.rs` | `--peer <uuid>:<base64-pubkey>` parser; `format_peer_spec` for `init` to emit |
| `commands.rs` | Subcommand handlers, all small + direct |
| `main.rs` | clap dispatch + one-time rustls crypto provider install |

## Test plan

- [x] `cargo fmt -p airc-cli` — clean
- [x] `cargo clippy -p airc-cli --all-targets -- -D warnings` — clean
- [x] `cargo test -p airc-cli` — 8 pass (identity round-trip + registry parsing)
- [x] `airc-rs init` smoke-tested live (output above)

## What's deferred

- Persistent registry (peers via repeated `--peer` flags for now)
- Bridge daemon (state holder for short-lived CLI calls)
- Pairing flow (QR / invite URL / signed enrolment)
- Production identity storage (SQLCipher / OS keychain / hardware enclave)
- Windows ACLs for the identity file

## Stack

Stacked on `feat/airc-transport-signed-wrapper` (#672). With this and the substrate stack (#664-#672) merged, two Mac/Linux peers can chat over the Rust substrate from the command line with zero Python involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)