### PR TITLE
feat(airc-cli): daemon mode — Unix socket IPC + typed Request/Response

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -7,6 +7,17 @@ use clap::{Parser, Subcommand};
 
 use crate::registry::PeerSpec;
 
+/// Default Unix socket path for the daemon. Overridable per-command
+/// via `--socket`.
+pub fn default_socket_path() -> PathBuf {
+    // ~/.airc-rs/daemon.sock if HOME is set; otherwise /tmp.
+    if let Some(home) = std::env::var_os("HOME") {
+        PathBuf::from(home).join(".airc-rs").join("daemon.sock")
+    } else {
+        PathBuf::from("/tmp").join("airc-rs-daemon.sock")
+    }
+}
+
 /// airc-rs — Rust substrate CLI. Replaces the Python `airc` step by
 /// step; each subcommand exercises one slice of the substrate.
 #[derive(Debug, Parser)]
@@ -95,5 +106,48 @@ pub enum Command {
         /// Replay-mode subscription (defaults to live-only).
         #[arg(long)]
         replay: bool,
+    },
+
+    /// Start the daemon in the foreground. Holds substrate state so
+    /// subsequent short-lived CLI calls (`ping`, `msg`, `status`)
+    /// don't re-load identity or re-handshake.
+    Daemon {
+        /// Override the default socket path
+        /// (`$HOME/.airc-rs/daemon.sock`).
+        #[arg(long)]
+        socket: Option<PathBuf>,
+    },
+
+    /// Probe the daemon — returns immediately if alive.
+    Ping {
+        #[arg(long)]
+        socket: Option<PathBuf>,
+    },
+
+    /// Daemon health snapshot.
+    Status {
+        #[arg(long)]
+        socket: Option<PathBuf>,
+    },
+
+    /// Ask the daemon to shut down gracefully.
+    Stop {
+        #[arg(long)]
+        socket: Option<PathBuf>,
+    },
+
+    /// Send a text message via the running daemon (fast — no
+    /// per-call substrate setup).
+    Msg {
+        #[arg(long)]
+        socket: Option<PathBuf>,
+        /// Wire directory the daemon should write to.
+        #[arg(long)]
+        wire: PathBuf,
+        /// Channel UUID.
+        #[arg(long)]
+        channel: String,
+        /// Message body.
+        text: String,
     },
 }

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1,8 +1,9 @@
 //! Subcommand handlers — keep them small and direct. Each function
 //! takes the parsed CLI context and runs.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::Arc;
 
 use airc_core::{
     headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, PeerId, RoomId,
@@ -13,7 +14,9 @@ use airc_transport::{LanTcpAdapter, LocalFsAdapter, SignedTransport, Transport};
 use futures::stream::StreamExt;
 use uuid::Uuid;
 
+use crate::daemon::{run as run_daemon_server, DaemonState};
 use crate::identity::load_or_generate;
+use crate::ipc::{DaemonClient, SendRequest};
 use crate::registry::{build_registry, format_peer_spec, PeerSpec};
 
 /// `init` — load or generate the identity, print the peer spec.
@@ -231,6 +234,84 @@ where
             }
         }
     }
+}
+
+/// `daemon` — run the long-lived daemon process on the given socket.
+pub async fn run_daemon(
+    identity_file: &Path,
+    peer_id: PeerId,
+    peers: Vec<PeerSpec>,
+    socket: PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let keypair = load_or_generate(identity_file)?;
+    let registry = build_registry(peer_id, keypair.public_bytes(), &peers)?;
+
+    // Ensure the socket's parent directory exists; the daemon won't
+    // create it for the user.
+    if let Some(parent) = socket.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+
+    let state = Arc::new(DaemonState::new(
+        peer_id,
+        keypair,
+        registry,
+        VerificationPolicy::Strict,
+    ));
+    println!(
+        "airc-rs daemon: peer_id={peer_id} listening on {}",
+        socket.display()
+    );
+    run_daemon_server(state, socket).await?;
+    println!("airc-rs daemon: stopped.");
+    Ok(())
+}
+
+/// `ping` — RPC the daemon. Prints "pong" on success.
+pub async fn run_ping(socket: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let client = DaemonClient::new(socket);
+    client.ping().await?;
+    println!("pong");
+    Ok(())
+}
+
+/// `status` — fetch daemon's health snapshot.
+pub async fn run_status(socket: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let client = DaemonClient::new(socket);
+    let status = client.status().await?;
+    println!("peer_id:        {}", status.peer_id);
+    println!("uptime_seconds: {}", status.uptime_seconds);
+    Ok(())
+}
+
+/// `stop` — ask the daemon to shut down gracefully.
+pub async fn run_stop(socket: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let client = DaemonClient::new(socket);
+    client.stop().await?;
+    println!("daemon: stop requested.");
+    Ok(())
+}
+
+/// `msg` — send via the daemon.
+pub async fn run_msg(
+    socket: PathBuf,
+    wire: PathBuf,
+    channel: &str,
+    text: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let channel_uuid = Uuid::from_str(channel)?;
+    let client = DaemonClient::new(socket);
+    client
+        .send(SendRequest {
+            wire,
+            channel: channel_uuid,
+            text: text.to_string(),
+        })
+        .await?;
+    println!("sent.");
+    Ok(())
 }
 
 fn print_frame(frame: &Frame) {

--- a/crates/airc-cli/src/daemon/handlers.rs
+++ b/crates/airc-cli/src/daemon/handlers.rs
@@ -1,0 +1,170 @@
+//! Dispatch table — one match arm per `Request` variant.
+//!
+//! This is the only file that imports both `Request` and `Response`
+//! types; every other module either produces or consumes one side.
+//! Adding a new op = add Request variant + add arm here. The
+//! compiler enforces exhaustiveness.
+
+use std::sync::Arc;
+
+use airc_core::{headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, RoomId};
+use airc_protocol::{Envelope, Frame, FrameKind, Signature};
+use airc_transport::Transport;
+
+use crate::daemon::state::DaemonState;
+use crate::ipc::request::{Request, SendRequest};
+use crate::ipc::response::{Response, StatusResponse};
+
+/// Dispatch one request against the daemon's state. Always returns a
+/// Response — Err paths become `Response::Error { message }` so the
+/// wire protocol stays uniform.
+pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
+    match request {
+        Request::Ping => Response::Pong,
+        Request::Status => Response::Status(StatusResponse {
+            peer_id: state.peer_id.to_string(),
+            uptime_seconds: state.uptime_seconds(),
+        }),
+        Request::Send(send) => handle_send(state, send).await,
+        Request::Stop => {
+            // Don't actually stop here; just signal. The server's
+            // accept loop watches the same notifier and exits after
+            // sending this response.
+            state.shutdown.notify_waiters();
+            Response::Ok
+        }
+    }
+}
+
+async fn handle_send(state: Arc<DaemonState>, send: SendRequest) -> Response {
+    let transport = state.local_fs_for(&send.wire).await;
+    let frame = build_message_frame(&state, send.channel, &send.text);
+    match transport.send(frame).await {
+        Ok(()) => Response::Ok,
+        Err(error) => Response::Error {
+            message: format!("send: {error}"),
+        },
+    }
+}
+
+fn build_message_frame(state: &DaemonState, channel: uuid::Uuid, text: &str) -> Frame {
+    let lamport = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    Frame {
+        kind: FrameKind::Message,
+        envelope: Envelope {
+            event_id: EventId::new(),
+            sender: state.peer_id,
+            sender_client: ClientId::new(),
+            channel: RoomId::from_uuid(channel),
+            target: MentionTarget::All,
+            lamport,
+            occurred_at_ms: lamport,
+            reply_to: None,
+            headers: Headers::new(),
+            body: Some(Body::text(text)),
+            media: Vec::new(),
+            // Unsigned at this layer — SignedTransport replaces it
+            // with Ed25519 on the way out.
+            signature: Signature::Unsigned,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::PeerId;
+    use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
+    use std::path::PathBuf;
+    use std::sync::RwLock;
+    use uuid::Uuid;
+
+    fn test_state() -> Arc<DaemonState> {
+        let peer_id = PeerId::from_u128(0xa1);
+        let keypair = PeerKeypair::generate();
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(peer_id, 0, keypair.public_bytes()).unwrap();
+        let registry = Arc::new(RwLock::new(registry));
+        Arc::new(DaemonState::new(
+            peer_id,
+            keypair,
+            registry,
+            VerificationPolicy::Strict,
+        ))
+    }
+
+    #[tokio::test]
+    async fn ping_returns_pong() {
+        let state = test_state();
+        let response = dispatch(state, Request::Ping).await;
+        assert_eq!(response, Response::Pong);
+    }
+
+    #[tokio::test]
+    async fn status_carries_peer_id_and_uptime() {
+        let state = test_state();
+        // Sleep so uptime > 0 — pins that the field is wired.
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        let response = dispatch(state.clone(), Request::Status).await;
+        match response {
+            Response::Status(status) => {
+                assert_eq!(status.peer_id, state.peer_id.to_string());
+                assert!(status.uptime_seconds >= 1, "uptime must accumulate");
+            }
+            other => panic!("expected Status, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn stop_signals_shutdown_and_returns_ok() {
+        let state = test_state();
+        // Clone the Arc so we can hand one to dispatch (consumed) and
+        // keep one to subscribe on the shutdown notifier (borrowed).
+        let dispatch_state = state.clone();
+        // Subscribe to the shutdown notifier before dispatching so
+        // notify_waiters wakes us. (Notify drops notifications sent
+        // before any waiter exists; the test pin is that AFTER a
+        // listener is set up, dispatch(Stop) wakes it.)
+        let listener = state.shutdown.notified();
+        tokio::pin!(listener);
+
+        let response = dispatch(dispatch_state, Request::Stop).await;
+        assert_eq!(response, Response::Ok);
+
+        // The notifier should fire promptly — yield once to let the
+        // signal propagate.
+        tokio::time::timeout(std::time::Duration::from_millis(100), &mut listener)
+            .await
+            .expect("shutdown signal must fire after Stop");
+    }
+
+    #[tokio::test]
+    async fn send_dispatches_against_local_fs_transport() {
+        // End-to-end through dispatch: a Send request hits the
+        // (lazily-created) local-fs adapter and Ok comes back.
+        let dir = tempfile::TempDir::new().unwrap();
+        let state = test_state();
+        let response = dispatch(
+            state,
+            Request::Send(SendRequest {
+                wire: dir.path().to_path_buf(),
+                channel: Uuid::nil(),
+                text: "hello".to_string(),
+            }),
+        )
+        .await;
+        assert_eq!(response, Response::Ok);
+        // Frame file should exist with one line.
+        let frames = dir.path().join("frames.jsonl");
+        let contents = std::fs::read_to_string(frames).unwrap();
+        assert_eq!(contents.lines().count(), 1);
+    }
+
+    // Pull PathBuf into scope so the import isn't unused when only
+    // one test references it (silences clippy without #[allow]).
+    #[allow(dead_code)]
+    const _UNUSED_TYPE_KEEPALIVE: Option<PathBuf> = None;
+}

--- a/crates/airc-cli/src/daemon/mod.rs
+++ b/crates/airc-cli/src/daemon/mod.rs
@@ -1,0 +1,33 @@
+//! Long-running daemon that holds substrate state for short-lived
+//! CLI calls.
+//!
+//! Architecture: one Unix socket listener accepts connections from
+//! `airc-rs` CLI invocations; each connection is one
+//! request/response round-trip dispatched against the typed
+//! `Request` enum. The daemon owns the peer keypair, registry, and
+//! any open transports; subsequent CLI commands (`airc-rs msg`,
+//! `airc-rs status`) become cheap RPCs that don't re-load identity
+//! or re-handshake transports.
+//!
+//! Module layout (one concern per file):
+//!   - `server` — Unix socket listener + accept loop
+//!   - `state` — shared daemon state (peer_id, keypair, transports)
+//!   - `handlers` — match arms for each `Request` variant
+//!
+//! Adding a new operation:
+//!
+//!   1. Add a `Request` variant in `ipc::request`
+//!   2. Add a `Response` variant if it returns data
+//!   3. Add a match arm in `handlers::dispatch`
+//!
+//! The compiler enforces exhaustiveness — no silent gaps.
+
+pub mod handlers;
+pub mod server;
+pub mod state;
+
+pub use server::run;
+pub use state::DaemonState;
+// `DaemonError` is reachable via `crate::daemon::server::DaemonError`
+// for callers that need it; not re-exported at this level since the
+// CLI catches it via the Box<dyn Error> path.

--- a/crates/airc-cli/src/daemon/server.rs
+++ b/crates/airc-cli/src/daemon/server.rs
@@ -1,0 +1,256 @@
+//! Unix socket listener + accept loop.
+//!
+//! Each accepted connection is handled in its own task: read one
+//! request, dispatch, write one response, close. Independent
+//! connections so a slow handler doesn't block the listener.
+//!
+//! Shutdown: the state's `shutdown` notifier wakes the accept loop;
+//! the loop unbinds the socket file and returns. In-flight handlers
+//! complete normally.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+
+use crate::daemon::handlers::dispatch;
+use crate::daemon::state::DaemonState;
+use crate::ipc::request::Request;
+use crate::ipc::response::Response;
+
+/// What can go wrong running the daemon.
+#[derive(Debug)]
+pub enum DaemonError {
+    /// Socket bind / accept I/O failure.
+    Io(std::io::Error),
+    /// Could not remove a stale socket file from a prior daemon
+    /// instance.
+    StaleSocket(std::io::Error),
+}
+
+impl std::fmt::Display for DaemonError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DaemonError::Io(error) => write!(f, "daemon I/O: {error}"),
+            DaemonError::StaleSocket(error) => {
+                write!(f, "stale socket cleanup: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DaemonError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            DaemonError::Io(error) | DaemonError::StaleSocket(error) => Some(error),
+        }
+    }
+}
+
+impl From<std::io::Error> for DaemonError {
+    fn from(error: std::io::Error) -> Self {
+        DaemonError::Io(error)
+    }
+}
+
+/// Run the daemon: bind the socket, serve connections until
+/// shutdown. Returns when the shutdown notifier fires (typically from
+/// a Stop request handler) or the listener errors.
+pub async fn run(state: Arc<DaemonState>, socket_path: PathBuf) -> Result<(), DaemonError> {
+    cleanup_stale_socket(&socket_path).map_err(DaemonError::StaleSocket)?;
+    let listener = UnixListener::bind(&socket_path)?;
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = state.shutdown.notified() => {
+                break;
+            }
+            accept = listener.accept() => {
+                let (stream, _addr) = accept?;
+                let state = state.clone();
+                tokio::spawn(async move {
+                    if let Err(error) = handle_connection(stream, state).await {
+                        // Surface to stderr — a real deployment can
+                        // pipe this to a log. We don't swallow.
+                        eprintln!("daemon connection error: {error}");
+                    }
+                });
+            }
+        }
+    }
+
+    // Best-effort cleanup. Listener drop unlinks the socket file on
+    // some platforms but not all — call out the path explicitly so
+    // subsequent daemon starts don't trip on a stale file.
+    let _ = std::fs::remove_file(&socket_path);
+    Ok(())
+}
+
+/// If a socket file exists from a prior daemon and no process is
+/// holding it, unlink it. If a process IS holding it, the subsequent
+/// `bind` will fail with EADDRINUSE — that error propagates up so the
+/// user sees it instead of us silently stealing the socket.
+fn cleanup_stale_socket(path: &Path) -> std::io::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    // Try connecting; if that succeeds, the daemon is live → don't
+    // touch the file. If it fails with ConnectionRefused, the socket
+    // is stale.
+    match std::os::unix::net::UnixStream::connect(path) {
+        Ok(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::AddrInUse,
+            format!("daemon already running on {}", path.display()),
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::ConnectionRefused => {
+            std::fs::remove_file(path)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Handle one connection: read a single newline-or-EOF-terminated
+/// JSON request, dispatch, write the JSON response, close.
+async fn handle_connection(
+    mut stream: UnixStream,
+    state: Arc<DaemonState>,
+) -> Result<(), DaemonError> {
+    let mut request_bytes = Vec::new();
+    stream.read_to_end(&mut request_bytes).await?;
+
+    let request: Request = match serde_json::from_slice(&request_bytes) {
+        Ok(request) => request,
+        Err(error) => {
+            let response = Response::Error {
+                message: format!("could not parse request: {error}"),
+            };
+            write_response(&mut stream, &response).await?;
+            return Ok(());
+        }
+    };
+
+    let response = dispatch(state, request).await;
+    write_response(&mut stream, &response).await?;
+    Ok(())
+}
+
+async fn write_response(stream: &mut UnixStream, response: &Response) -> Result<(), DaemonError> {
+    let mut payload = serde_json::to_vec(response).map_err(|error| {
+        DaemonError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            error.to_string(),
+        ))
+    })?;
+    payload.push(b'\n');
+    stream.write_all(&payload).await?;
+    stream.shutdown().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ipc::client::DaemonClient;
+    use airc_core::PeerId;
+    use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
+    use std::sync::RwLock;
+    use std::time::Duration;
+
+    fn fresh_state() -> Arc<DaemonState> {
+        let peer_id = PeerId::from_u128(0xa1);
+        let keypair = PeerKeypair::generate();
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(peer_id, 0, keypair.public_bytes()).unwrap();
+        let registry = Arc::new(RwLock::new(registry));
+        Arc::new(DaemonState::new(
+            peer_id,
+            keypair,
+            registry,
+            VerificationPolicy::Strict,
+        ))
+    }
+
+    fn unique_socket() -> PathBuf {
+        // /tmp (not env::temp_dir which on macOS resolves to a long
+        // /var/folders/.../T/ path) keeps the path well under SUN_LEN
+        // (104 bytes on macOS). Short suffix from the low bits of a
+        // fresh UUID — collision odds negligible across one test run.
+        let suffix = uuid::Uuid::new_v4().as_u128() as u32;
+        PathBuf::from(format!("/tmp/arc{:x}.sock", suffix))
+    }
+
+    #[tokio::test]
+    async fn client_ping_round_trips_via_real_socket() {
+        // The integration test: spawn a real daemon on a Unix socket
+        // and confirm a DaemonClient::ping completes the round-trip.
+        let state = fresh_state();
+        let socket = unique_socket();
+
+        let server_state = state.clone();
+        let server_socket = socket.clone();
+        let server_handle = tokio::spawn(async move { run(server_state, server_socket).await });
+
+        // Tiny delay for the listener to bind.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let client = DaemonClient::new(socket.clone());
+        client.ping().await.expect("ping must succeed");
+
+        // Shut down the daemon for clean test teardown.
+        client.stop().await.expect("stop must succeed");
+        tokio::time::timeout(Duration::from_secs(2), server_handle)
+            .await
+            .expect("daemon must exit within 2s of stop")
+            .expect("join handle")
+            .expect("daemon must exit Ok");
+    }
+
+    #[tokio::test]
+    async fn status_returns_peer_id() {
+        let state = fresh_state();
+        let expected_peer_id = state.peer_id.to_string();
+        let socket = unique_socket();
+
+        let server_state = state.clone();
+        let server_socket = socket.clone();
+        let server_handle = tokio::spawn(async move { run(server_state, server_socket).await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let client = DaemonClient::new(socket);
+        let status = client.status().await.expect("status must succeed");
+        assert_eq!(status.peer_id, expected_peer_id);
+
+        client.stop().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(2), server_handle)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn second_daemon_refuses_to_steal_live_socket() {
+        // Pin the cleanup_stale_socket contract: if a daemon is
+        // already live on the path, a second run() returns AddrInUse
+        // rather than silently taking over.
+        let state = fresh_state();
+        let socket = unique_socket();
+        let first = state.clone();
+        let socket_for_first = socket.clone();
+        let first_handle = tokio::spawn(async move { run(first, socket_for_first).await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let second_result = run(fresh_state(), socket.clone()).await;
+        assert!(
+            matches!(second_result, Err(DaemonError::StaleSocket(_))),
+            "second daemon must refuse to steal a live socket; got {second_result:?}"
+        );
+
+        // Clean up first daemon.
+        let client = DaemonClient::new(socket);
+        client.stop().await.unwrap();
+        let _ = first_handle.await;
+    }
+}

--- a/crates/airc-cli/src/daemon/state.rs
+++ b/crates/airc-cli/src/daemon/state.rs
@@ -1,0 +1,84 @@
+//! Daemon's shared state — peer identity, registry, owned transports,
+//! shutdown notifier.
+//!
+//! `DaemonState` is constructed once at startup and passed (via Arc)
+//! to every per-connection handler. Handlers read fields directly;
+//! the substrate enforces its own internal locking (e.g.
+//! `PeerKeyRegistry` is wrapped in `Arc<RwLock>`).
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::RwLock;
+use std::time::Instant;
+
+use tokio::sync::{Mutex, Notify};
+
+use airc_core::PeerId;
+use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
+use airc_transport::{LocalFsAdapter, SignedTransport};
+
+/// Everything a daemon needs at runtime. Cheap to clone via Arc; the
+/// underlying handles (registry, transports) do their own interior
+/// locking.
+pub struct DaemonState {
+    pub peer_id: PeerId,
+    pub keypair: PeerKeypair,
+    pub registry: Arc<RwLock<PeerKeyRegistry>>,
+    pub policy: VerificationPolicy,
+    /// When the daemon started — used for the Status uptime field.
+    pub started_at: Instant,
+    /// One signed-local-fs transport per wire directory. Lazily
+    /// opened on first `Send` referencing the wire so daemons that
+    /// never send don't allocate state.
+    pub local_fs_transports: Mutex<HashMap<PathBuf, Arc<SignedTransport<LocalFsAdapter>>>>,
+    /// Notified when the daemon should stop accepting + exit cleanly.
+    pub shutdown: Notify,
+}
+
+impl DaemonState {
+    pub fn new(
+        peer_id: PeerId,
+        keypair: PeerKeypair,
+        registry: Arc<RwLock<PeerKeyRegistry>>,
+        policy: VerificationPolicy,
+    ) -> Self {
+        Self {
+            peer_id,
+            keypair,
+            registry,
+            policy,
+            started_at: Instant::now(),
+            local_fs_transports: Mutex::new(HashMap::new()),
+            shutdown: Notify::new(),
+        }
+    }
+
+    /// Get-or-create a SignedTransport<LocalFsAdapter> for the given
+    /// wire directory. Cached so repeated sends to the same wire
+    /// reuse the same adapter (and its subscribers, eventually).
+    pub async fn local_fs_for(
+        &self,
+        wire: &std::path::Path,
+    ) -> Arc<SignedTransport<LocalFsAdapter>> {
+        let key = wire.to_path_buf();
+        let mut transports = self.local_fs_transports.lock().await;
+        if let Some(existing) = transports.get(&key) {
+            return existing.clone();
+        }
+        let signed = SignedTransport::new(
+            LocalFsAdapter::new(&key),
+            self.keypair.clone(),
+            self.peer_id,
+            self.registry.clone(),
+            self.policy,
+        );
+        let handle = Arc::new(signed);
+        transports.insert(key, handle.clone());
+        handle
+    }
+
+    pub fn uptime_seconds(&self) -> u64 {
+        self.started_at.elapsed().as_secs()
+    }
+}

--- a/crates/airc-cli/src/ipc/client.rs
+++ b/crates/airc-cli/src/ipc/client.rs
@@ -1,0 +1,131 @@
+//! Typed client used by CLI commands to talk to a running daemon.
+//!
+//! `DaemonClient::call(request)` opens a Unix socket, writes the
+//! request as one newline-delimited JSON line, reads the response,
+//! and parses it. One round-trip per connection — simple to debug
+//! with `socat`, and the daemon's accept loop can spawn each
+//! connection independently.
+//!
+//! Convenience helpers (`ping`, `status`, `send`, `stop`) wrap the
+//! generic `call` and dispatch on response variants so callers don't
+//! pattern-match on `Response` themselves.
+
+use std::path::PathBuf;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+use crate::ipc::request::{Request, SendRequest};
+use crate::ipc::response::{Response, StatusResponse};
+
+/// Reasons a daemon RPC fails.
+#[derive(Debug)]
+pub enum ClientError {
+    /// Couldn't connect to the socket — daemon not running.
+    NotConnected(std::io::Error),
+    /// Underlying socket I/O failure mid-call.
+    Io(std::io::Error),
+    /// Request or response failed to serialize/deserialize.
+    Codec(serde_json::Error),
+    /// Daemon returned `Response::Error { message }`.
+    Daemon(String),
+    /// Daemon returned a response variant inconsistent with the
+    /// request (e.g. `Status` returning `Pong`). Indicates a daemon
+    /// bug or a wire-protocol mismatch.
+    UnexpectedResponse(Response),
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClientError::NotConnected(error) => {
+                write!(f, "daemon not reachable: {error}")
+            }
+            ClientError::Io(error) => write!(f, "daemon RPC I/O: {error}"),
+            ClientError::Codec(error) => write!(f, "daemon RPC codec: {error}"),
+            ClientError::Daemon(message) => write!(f, "daemon error: {message}"),
+            ClientError::UnexpectedResponse(response) => {
+                write!(f, "daemon returned unexpected response: {response:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ClientError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ClientError::NotConnected(error) | ClientError::Io(error) => Some(error),
+            ClientError::Codec(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<serde_json::Error> for ClientError {
+    fn from(error: serde_json::Error) -> Self {
+        ClientError::Codec(error)
+    }
+}
+
+pub struct DaemonClient {
+    socket_path: PathBuf,
+}
+
+impl DaemonClient {
+    pub fn new(socket_path: PathBuf) -> Self {
+        Self { socket_path }
+    }
+
+    /// Generic RPC: writes `request`, reads one `Response`.
+    pub async fn call(&self, request: Request) -> Result<Response, ClientError> {
+        let mut stream = UnixStream::connect(&self.socket_path)
+            .await
+            .map_err(ClientError::NotConnected)?;
+
+        let mut buffer = serde_json::to_vec(&request)?;
+        buffer.push(b'\n');
+        stream.write_all(&buffer).await.map_err(ClientError::Io)?;
+        // Signal end of request so the daemon's read-to-end completes.
+        stream.shutdown().await.map_err(ClientError::Io)?;
+
+        let mut response_bytes = Vec::new();
+        stream
+            .read_to_end(&mut response_bytes)
+            .await
+            .map_err(ClientError::Io)?;
+        let response: Response = serde_json::from_slice(&response_bytes)?;
+
+        match response {
+            Response::Error { message } => Err(ClientError::Daemon(message)),
+            other => Ok(other),
+        }
+    }
+
+    pub async fn ping(&self) -> Result<(), ClientError> {
+        match self.call(Request::Ping).await? {
+            Response::Pong => Ok(()),
+            other => Err(ClientError::UnexpectedResponse(other)),
+        }
+    }
+
+    pub async fn status(&self) -> Result<StatusResponse, ClientError> {
+        match self.call(Request::Status).await? {
+            Response::Status(status) => Ok(status),
+            other => Err(ClientError::UnexpectedResponse(other)),
+        }
+    }
+
+    pub async fn send(&self, request: SendRequest) -> Result<(), ClientError> {
+        match self.call(Request::Send(request)).await? {
+            Response::Ok => Ok(()),
+            other => Err(ClientError::UnexpectedResponse(other)),
+        }
+    }
+
+    pub async fn stop(&self) -> Result<(), ClientError> {
+        match self.call(Request::Stop).await? {
+            Response::Ok => Ok(()),
+            other => Err(ClientError::UnexpectedResponse(other)),
+        }
+    }
+}

--- a/crates/airc-cli/src/ipc/mod.rs
+++ b/crates/airc-cli/src/ipc/mod.rs
@@ -1,0 +1,23 @@
+//! IPC between the `airc-rs` CLI and the running daemon.
+//!
+//! Wire protocol = newline-delimited JSON over a Unix socket. One
+//! request per connection, one response, connection closes. Simple,
+//! debuggable, extensible — adding a new op is one variant in
+//! `Request` + one match arm in the daemon's dispatcher.
+//!
+//! Why not gRPC / cap'n proto / mDNS RPC: this is local-only IPC for
+//! a single-machine daemon. JSON over Unix sockets is the right
+//! amount of ceremony — typed in Rust (Request/Response enums),
+//! human-debuggable via `socat - UNIX-CONNECT:...`, and zero extra
+//! schema toolchain.
+
+pub mod client;
+pub mod request;
+pub mod response;
+
+pub use client::DaemonClient;
+pub use request::SendRequest;
+
+// `ClientError`, `Request`, `Response`, `StatusResponse` are
+// accessible via their module paths for callers that want them; we
+// don't re-export them at this level to keep the prelude tight.

--- a/crates/airc-cli/src/ipc/request.rs
+++ b/crates/airc-cli/src/ipc/request.rs
@@ -1,0 +1,70 @@
+//! Client → daemon requests. Add new operations by extending the
+//! `Request` enum; the daemon's dispatcher is exhaustiveness-checked
+//! so the compiler nags you to handle every variant.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// A single client-issued operation. Wire-tagged by `op`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum Request {
+    /// Liveness probe. Returns `Response::Pong`.
+    Ping,
+    /// Snapshot of daemon state (peer id, uptime, …).
+    Status,
+    /// Send a text Message frame. Daemon signs + dispatches via its
+    /// owned `SignedTransport`.
+    Send(SendRequest),
+    /// Graceful shutdown. Daemon completes in-flight requests, then
+    /// stops accepting new connections + exits.
+    Stop,
+}
+
+/// Parameters for `Send`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SendRequest {
+    /// Wire directory the daemon should write to.
+    pub wire: PathBuf,
+    /// Channel UUID. Use a stable value across peers in the same room.
+    pub channel: Uuid,
+    /// Body text.
+    pub text: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ping_serializes_compactly() {
+        // The simplest variant — wire-tag only. Pinned so we catch
+        // accidental unwrapping (e.g. adding fields by mistake).
+        let encoded = serde_json::to_string(&Request::Ping).unwrap();
+        assert_eq!(encoded, r#"{"op":"ping"}"#);
+        let decoded: Request = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, Request::Ping);
+    }
+
+    #[test]
+    fn send_roundtrips_with_typed_fields() {
+        let original = Request::Send(SendRequest {
+            wire: PathBuf::from("/tmp/wire"),
+            channel: Uuid::nil(),
+            text: "hello".to_string(),
+        });
+        let encoded = serde_json::to_string(&original).unwrap();
+        let decoded: Request = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn stop_serializes_compactly() {
+        assert_eq!(
+            serde_json::to_string(&Request::Stop).unwrap(),
+            r#"{"op":"stop"}"#
+        );
+    }
+}

--- a/crates/airc-cli/src/ipc/response.rs
+++ b/crates/airc-cli/src/ipc/response.rs
@@ -1,0 +1,62 @@
+//! Daemon → client responses. Symmetric to `request.rs` — typed
+//! enum, wire-tagged by `kind`.
+
+use serde::{Deserialize, Serialize};
+
+/// One response to a `Request`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Response {
+    /// Response to `Ping`.
+    Pong,
+    /// Response to `Status`.
+    Status(StatusResponse),
+    /// Generic success for ops that don't return data (`Send`, `Stop`).
+    Ok,
+    /// Failure — typed message so the client can render it.
+    Error { message: String },
+}
+
+/// Daemon health/state snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StatusResponse {
+    /// Peer UUID as the hyphenated string form.
+    pub peer_id: String,
+    /// Seconds since daemon start.
+    pub uptime_seconds: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pong_serializes_compactly() {
+        assert_eq!(
+            serde_json::to_string(&Response::Pong).unwrap(),
+            r#"{"kind":"pong"}"#
+        );
+    }
+
+    #[test]
+    fn status_roundtrips() {
+        let original = Response::Status(StatusResponse {
+            peer_id: "07e7ad58-ba56-4535-b4e5-a161a110e487".to_string(),
+            uptime_seconds: 42,
+        });
+        let encoded = serde_json::to_string(&original).unwrap();
+        let decoded: Response = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn error_carries_message() {
+        let error = Response::Error {
+            message: "boom".to_string(),
+        };
+        let encoded = serde_json::to_string(&error).unwrap();
+        assert!(encoded.contains("boom"));
+        let decoded: Response = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, error);
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -18,7 +18,9 @@
 
 mod cli;
 mod commands;
+mod daemon;
 mod identity;
+mod ipc;
 mod registry;
 
 use std::process::ExitCode;
@@ -120,6 +122,32 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::LanListen { bind, replay } => {
             let peer_id = parsed_peer_id.ok_or("--peer-id is required for lan-listen")?;
             commands::run_lan_listen(&identity_file, peer_id, parsed.peers, bind, replay).await
+        }
+        Command::Daemon { socket } => {
+            let peer_id = parsed_peer_id.ok_or("--peer-id is required for daemon")?;
+            let socket = socket.unwrap_or_else(cli::default_socket_path);
+            commands::run_daemon(&identity_file, peer_id, parsed.peers, socket).await
+        }
+        Command::Ping { socket } => {
+            let socket = socket.unwrap_or_else(cli::default_socket_path);
+            commands::run_ping(socket).await
+        }
+        Command::Status { socket } => {
+            let socket = socket.unwrap_or_else(cli::default_socket_path);
+            commands::run_status(socket).await
+        }
+        Command::Stop { socket } => {
+            let socket = socket.unwrap_or_else(cli::default_socket_path);
+            commands::run_stop(socket).await
+        }
+        Command::Msg {
+            socket,
+            wire,
+            channel,
+            text,
+        } => {
+            let socket = socket.unwrap_or_else(cli::default_socket_path);
+            commands::run_msg(socket, wire, &channel, &text).await
         }
     }
 }


### PR DESCRIPTION
## Summary

Long-running daemon that holds substrate state for short-lived CLI calls. Replaces the Python \`airc\` daemon model in Rust. Built per the elegance + extensibility steer: typed wire protocol, one concern per file, composition over inheritance, no silent fallbacks.

## New subcommands

| Command | What |
|---------|------|
| \`daemon\` | Run the daemon (foreground; background-ing is integrator's job: nohup / launchd / systemd) |
| \`ping\` | Liveness probe |
| \`status\` | peer_id + uptime snapshot |
| \`msg\` | Send via daemon (no per-call substrate setup) |
| \`stop\` | Graceful shutdown |

Default socket: \`$HOME/.airc-rs/daemon.sock\` (per-command override via \`--socket\`).

## Wire protocol

Newline-delimited JSON over Unix socket. One request, one response, connection closes. Debuggable with \`socat - UNIX-CONNECT:…\`.

```rust
#[serde(tag = "op", rename_all = "snake_case")]
pub enum Request { Ping, Status, Send(SendRequest), Stop }

#[serde(tag = "kind", rename_all = "snake_case")]
pub enum Response { Pong, Status(StatusResponse), Ok, Error { message } }
```

**Extensibility**: adding an op = add a variant in \`ipc::request\` + add a match arm in \`daemon::handlers::dispatch\`. Compiler enforces exhaustiveness.

## Module layout (one concern per file)

```
ipc/
  ├ mod.rs        — re-exports
  ├ request.rs    — Request enum + tests
  ├ response.rs   — Response enum + tests
  └ client.rs     — DaemonClient + ClientError

daemon/
  ├ mod.rs        — re-exports
  ├ state.rs      — DaemonState (keypair, registry, transport cache, shutdown notifier)
  ├ handlers.rs   — dispatch(Request) → Response
  └ server.rs     — UnixListener + accept loop + connection handlers
```

## Test plan

- [x] \`cargo fmt -p airc-cli\` — clean
- [x] \`cargo clippy -p airc-cli --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p airc-cli\` — **23 pass / 0 fail** (21 unit + 2 e2e subprocess)

Key tests:
- \`ping_returns_pong\`, \`status_carries_peer_id_and_uptime\`, \`stop_signals_shutdown_and_returns_ok\`, \`send_dispatches_against_local_fs_transport\` (handler unit tests)
- \`client_ping_round_trips_via_real_socket\`, \`status_returns_peer_id\` (real Unix socket integration)
- \`second_daemon_refuses_to_steal_live_socket\` — daemon refuses to steal a live socket; returns \`AddrInUse\` instead

## Codex findings on the LAN adapter (separate PR coming)

Codex's review of #671 surfaced two real issues that don't block this PR (daemon uses local-fs, not LAN-TCP) but should land next:
1. \`LanTcpAdapter::connect()\` returns before outbound channel is installed → CLI papers over with \`sleep(150ms)\`. Fix: install synchronously inside \`connect()\`.
2. \`dispatch_to_subscribers\` holds the subscribers mutex during awaits → one slow subscriber blocks dispatch to others. Fix: snapshot under lock, drop, then await.

Filing as a follow-up PR right after this lands.

## Stack

Stacked on \`feat/airc-cli-e2e-integration\` (#674).

🤖 Generated with [Claude Code](https://claude.com/claude-code)