### PR TITLE
style(airc-blobs): apply current rustfmt rules

### DIFF
--- a/crates/airc-blobs/src/fs.rs
+++ b/crates/airc-blobs/src/fs.rs
@@ -40,7 +40,8 @@ impl FsStore {
     /// dirs lazily.
     pub fn new<P: AsRef<Path>>(root: P) -> Result<Self, BlobError> {
         let root = root.as_ref().to_path_buf();
-        fs::create_dir_all(&root).map_err(|e| BlobError::Io(format!("create_dir_all {root:?}: {e}")))?;
+        fs::create_dir_all(&root)
+            .map_err(|e| BlobError::Io(format!("create_dir_all {root:?}: {e}")))?;
         Ok(Self { root })
     }
 
@@ -67,9 +68,8 @@ impl ContentAddressedStore for FsStore {
 
         // Ensure fan-out dir exists.
         if let Some(parent) = final_path.parent() {
-            fs::create_dir_all(parent).map_err(|e| {
-                BlobError::Io(format!("create_dir_all {parent:?}: {e}"))
-            })?;
+            fs::create_dir_all(parent)
+                .map_err(|e| BlobError::Io(format!("create_dir_all {parent:?}: {e}")))?;
         }
 
         // Write to a sibling .tmp file then rename for atomicity.
@@ -156,11 +156,7 @@ mod tests {
     fn fresh_root() -> PathBuf {
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let n = COUNTER.fetch_add(1, Ordering::SeqCst);
-        let p = std::env::temp_dir().join(format!(
-            "airc-blobs-test-{}-{}",
-            std::process::id(),
-            n
-        ));
+        let p = std::env::temp_dir().join(format!("airc-blobs-test-{}-{}", std::process::id(), n));
         // Remove any leftover from a prior crashed test.
         let _ = fs::remove_dir_all(&p);
         p
@@ -270,11 +266,15 @@ mod tests {
         let root = fresh_root();
         let store = FsStore::new(&root).expect("new");
         let absent = ContentHash::from_bytes(b"never_stored");
-        store.delete(&absent).expect("delete of absent should be Ok");
+        store
+            .delete(&absent)
+            .expect("delete of absent should be Ok");
         // Double-delete also fine
         let hash = store.put(b"x").expect("put");
         store.delete(&hash).expect("first delete");
-        store.delete(&hash).expect("second delete should also be Ok");
+        store
+            .delete(&hash)
+            .expect("second delete should also be Ok");
     }
 
     /// What this catches: `get` re-verifies on-disk bytes against the
@@ -344,7 +344,11 @@ mod tests {
             }
             by_prefix.insert(prefix, bytes);
         }
-        assert_eq!(blobs.len(), 2, "should find two blobs sharing a fan-out prefix within 10000 iterations");
+        assert_eq!(
+            blobs.len(),
+            2,
+            "should find two blobs sharing a fan-out prefix within 10000 iterations"
+        );
 
         let h1 = store.put(&blobs[0]).expect("put 1");
         let h2 = store.put(&blobs[1]).expect("put 2");

--- a/crates/airc-blobs/src/gc.rs
+++ b/crates/airc-blobs/src/gc.rs
@@ -73,8 +73,8 @@ pub fn run<P: AsRef<Path>>(root: P, policy: &RetentionPolicy) -> Result<GcReport
             continue;
         }
         // Inner dir contains the blob files for this fan-out bucket.
-        let inner = fs::read_dir(&path)
-            .map_err(|e| BlobError::Io(format!("read_dir {path:?}: {e}")))?;
+        let inner =
+            fs::read_dir(&path).map_err(|e| BlobError::Io(format!("read_dir {path:?}: {e}")))?;
         for blob_entry in inner {
             let blob_entry = blob_entry.map_err(|e| BlobError::Io(format!("dir entry: {e}")))?;
             let blob_path = blob_entry.path();
@@ -97,7 +97,9 @@ pub fn run<P: AsRef<Path>>(root: P, policy: &RetentionPolicy) -> Result<GcReport
 
     // Phase 2: age-based deletion.
     if let Some(max_age) = policy.max_age {
-        let cutoff = SystemTime::now().checked_sub(max_age).unwrap_or(SystemTime::UNIX_EPOCH);
+        let cutoff = SystemTime::now()
+            .checked_sub(max_age)
+            .unwrap_or(SystemTime::UNIX_EPOCH);
         all_blobs.retain(|b| {
             if b.mtime < cutoff {
                 if delete_one(&b.path, &mut report) {
@@ -168,11 +170,8 @@ mod tests {
     fn fresh_root() -> PathBuf {
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let n = COUNTER.fetch_add(1, Ordering::SeqCst);
-        let p = std::env::temp_dir().join(format!(
-            "airc-blobs-gc-test-{}-{}",
-            std::process::id(),
-            n
-        ));
+        let p =
+            std::env::temp_dir().join(format!("airc-blobs-gc-test-{}-{}", std::process::id(), n));
         let _ = fs::remove_dir_all(&p);
         p
     }
@@ -224,7 +223,9 @@ mod tests {
         let new_hash = store.put(b"new content").expect("put new");
 
         // Mark "old" blob as 1 hour ago, "new" stays fresh
-        let old_path = root.join("0d").join("28cab5c3713c80acab15d18180f5b5d317b66ddc3f9d8a92f859ea29a89a01.blob");
+        let old_path = root
+            .join("0d")
+            .join("28cab5c3713c80acab15d18180f5b5d317b66ddc3f9d8a92f859ea29a89a01.blob");
         // Actually compute paths
         let old_path = store_path_for(&root, &old_hash);
         let new_path = store_path_for(&root, &new_hash);

--- a/crates/airc-blobs/src/hash.rs
+++ b/crates/airc-blobs/src/hash.rs
@@ -196,7 +196,9 @@ mod tests {
             display,
             "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
         );
-        assert!(display.chars().all(|c| c.is_ascii_digit() || c.is_ascii_lowercase()));
+        assert!(display
+            .chars()
+            .all(|c| c.is_ascii_digit() || c.is_ascii_lowercase()));
     }
 
     /// What this catches: serde round-trip via JSON preserves the hash.

--- a/crates/airc-blobs/src/lib.rs
+++ b/crates/airc-blobs/src/lib.rs
@@ -161,7 +161,10 @@ mod tests {
             mime: None,
         };
         let json = serde_json::to_string(&media_ref).expect("serialize");
-        assert!(!json.contains("mime"), "None mime should be omitted; got: {json}");
+        assert!(
+            !json.contains("mime"),
+            "None mime should be omitted; got: {json}"
+        );
     }
 
     /// In-memory fake backend used to exercise the default `exists`
@@ -196,9 +199,7 @@ mod tests {
                 .unwrap()
                 .get(hash)
                 .cloned()
-                .ok_or_else(|| BlobError::NotFound {
-                    hash: hash.clone(),
-                })
+                .ok_or_else(|| BlobError::NotFound { hash: hash.clone() })
         }
 
         fn delete(&self, hash: &ContentHash) -> Result<(), BlobError> {
@@ -251,9 +252,7 @@ mod tests {
     #[test]
     fn blob_error_display_includes_context() {
         let hash = ContentHash::from_bytes(b"x");
-        let not_found = BlobError::NotFound {
-            hash: hash.clone(),
-        };
+        let not_found = BlobError::NotFound { hash: hash.clone() };
         let display = format!("{not_found}");
         assert!(display.contains(&hash.to_string()));
 


### PR DESCRIPTION
Pre-existing fmt drift from when #653/#655/#660 landed. \`cargo fmt -p airc-blobs\` reformats 4 files (whitespace only — no semantic change).

Catching here so the workspace stays \`cargo fmt -- --check\` clean and future PRs don't surface the noise.

- [x] \`cargo test -p airc-blobs\` — passes (no test changes)
- [x] \`cargo fmt --check -p airc-blobs\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)