### PR TITLE
feat(airc-cli): daemon Subscribe + Inbox — buffered consume-once reads

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -150,4 +150,24 @@ pub enum Command {
         /// Message body.
         text: String,
     },
+
+    /// Pull buffered frames from the daemon's inbox for a wire.
+    /// On first call for a wire, the daemon starts subscribing
+    /// (idempotent — repeat calls reuse the same subscription).
+    /// Pass `--since-lamport` to consume only new frames since the
+    /// last call.
+    Inbox {
+        #[arg(long)]
+        socket: Option<PathBuf>,
+        /// Wire directory.
+        #[arg(long)]
+        wire: PathBuf,
+        /// Return frames with lamport > this value (consume-once
+        /// cursor). Defaults to 0 = everything in the buffer.
+        #[arg(long)]
+        since_lamport: Option<u64>,
+        /// Max frames in one batch.
+        #[arg(long)]
+        limit: Option<usize>,
+    },
 }

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 
 use crate::daemon::{run as run_daemon_server, DaemonState};
 use crate::identity::load_or_generate;
+use crate::ipc::request::{InboxRequest, SubscribeRequest};
 use crate::ipc::{DaemonClient, SendRequest};
 use crate::registry::{build_registry, format_peer_spec, PeerSpec};
 
@@ -289,6 +290,43 @@ pub async fn run_stop(socket: PathBuf) -> Result<(), Box<dyn std::error::Error>>
     let client = DaemonClient::new(socket);
     client.stop().await?;
     println!("daemon: stop requested.");
+    Ok(())
+}
+
+/// `inbox` — Subscribe-then-Inbox via the daemon. Prints any
+/// buffered frames newer than `since_lamport`. The first call for a
+/// wire kicks off the daemon's subscription; subsequent calls are
+/// pure reads.
+pub async fn run_inbox(
+    socket: PathBuf,
+    wire: PathBuf,
+    since_lamport: Option<u64>,
+    limit: Option<usize>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = DaemonClient::new(socket);
+    // Idempotent — daemon ignores duplicate subscribes for the wire.
+    client
+        .subscribe(SubscribeRequest { wire: wire.clone() })
+        .await?;
+    let inbox = client
+        .inbox(InboxRequest {
+            wire,
+            since_lamport,
+            limit,
+        })
+        .await?;
+    if inbox.frames.is_empty() {
+        println!("(no new frames; newest_lamport={})", inbox.newest_lamport);
+        return Ok(());
+    }
+    for frame in &inbox.frames {
+        print_frame(frame);
+    }
+    println!();
+    println!(
+        "newest_lamport={} — pass as --since-lamport on the next call",
+        inbox.newest_lamport
+    );
     Ok(())
 }
 

--- a/crates/airc-cli/src/daemon/handlers.rs
+++ b/crates/airc-cli/src/daemon/handlers.rs
@@ -7,13 +7,20 @@
 
 use std::sync::Arc;
 
-use airc_core::{headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, RoomId};
-use airc_protocol::{Envelope, Frame, FrameKind, Signature};
+use airc_core::{
+    headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, RoomId, TranscriptCursor,
+};
+use airc_protocol::{Envelope, Frame, FrameKind, Signature, Subscription};
 use airc_transport::Transport;
+use futures::stream::StreamExt;
 
 use crate::daemon::state::DaemonState;
-use crate::ipc::request::{Request, SendRequest};
-use crate::ipc::response::{Response, StatusResponse};
+use crate::ipc::request::{InboxRequest, Request, SendRequest, SubscribeRequest};
+use crate::ipc::response::{InboxResponse, Response, StatusResponse};
+
+/// Default `Inbox.limit` when the client doesn't pass one. Caps the
+/// payload size so a slow client doesn't accidentally pull MB.
+const INBOX_DEFAULT_LIMIT: usize = 32;
 
 /// Dispatch one request against the daemon's state. Always returns a
 /// Response — Err paths become `Response::Error { message }` so the
@@ -26,6 +33,8 @@ pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
             uptime_seconds: state.uptime_seconds(),
         }),
         Request::Send(send) => handle_send(state, send).await,
+        Request::Subscribe(sub) => handle_subscribe(state, sub).await,
+        Request::Inbox(inbox) => handle_inbox(state, inbox).await,
         Request::Stop => {
             // Don't actually stop here; just signal. The server's
             // accept loop watches the same notifier and exits after
@@ -34,6 +43,84 @@ pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
             Response::Ok
         }
     }
+}
+
+async fn handle_subscribe(state: Arc<DaemonState>, sub: SubscribeRequest) -> Response {
+    // Idempotent: if the inbox already exists, the subscriber task is
+    // already draining frames into it. Return Ok without spawning a
+    // duplicate.
+    if state.has_inbox(&sub.wire).await {
+        return Response::Ok;
+    }
+
+    // Create the inbox buffer + spawn the drain task.
+    let buffer = state.inbox_for(&sub.wire).await;
+    let transport = state.local_fs_for(&sub.wire).await;
+    let subscription = Subscription {
+        // Replay from the start of the wire — buffer captures
+        // pre-existing frames so an inbox call seconds later still
+        // sees them.
+        from_cursor: Some(TranscriptCursor {
+            lamport: 0,
+            event_id: EventId::from_u128(0),
+        }),
+        ..Default::default()
+    };
+
+    let mut stream = match transport.subscribe(subscription).await {
+        Ok(stream) => stream,
+        Err(error) => {
+            return Response::Error {
+                message: format!("subscribe: {error}"),
+            };
+        }
+    };
+
+    let buffer_for_task = buffer.clone();
+    tokio::spawn(async move {
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(frame) => {
+                    buffer_for_task.lock().await.push(frame);
+                }
+                Err(_verify_error) => {
+                    // Verification failure — don't buffer.
+                    // Future: surface a counter in Status response.
+                }
+            }
+        }
+    });
+
+    Response::Ok
+}
+
+async fn handle_inbox(state: Arc<DaemonState>, request: InboxRequest) -> Response {
+    let Some(buffer) = state.inboxes.lock().await.get(&request.wire).cloned() else {
+        // No subscription on this wire — return empty inbox rather
+        // than an error so clients can call Inbox before Subscribe
+        // without an awkward warmup race.
+        return Response::Inbox(InboxResponse {
+            frames: Vec::new(),
+            newest_lamport: request.since_lamport.unwrap_or(0),
+        });
+    };
+    let buffer = buffer.lock().await;
+    let limit = request.limit.unwrap_or(INBOX_DEFAULT_LIMIT);
+    let frames = buffer.since(request.since_lamport, limit);
+    // newest_lamport in the response is the max we return so the
+    // client can hand it back as since_lamport next time. If we
+    // returned no frames, echo the input cursor so the client doesn't
+    // restart from 0.
+    let newest_lamport = frames
+        .iter()
+        .map(|f| f.envelope.lamport)
+        .max()
+        .or(request.since_lamport)
+        .unwrap_or_else(|| buffer.newest_lamport());
+    Response::Inbox(InboxResponse {
+        frames,
+        newest_lamport,
+    })
 }
 
 async fn handle_send(state: Arc<DaemonState>, send: SendRequest) -> Response {

--- a/crates/airc-cli/src/daemon/server.rs
+++ b/crates/airc-cli/src/daemon/server.rs
@@ -231,6 +231,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn subscribe_then_send_then_inbox_round_trips() {
+        // The big daemon e2e: subscribe to a wire, send a frame
+        // (daemon's own send writes to the wire), inbox returns it.
+        // Proves the daemon's send + buffered-subscribe paths
+        // compose correctly.
+        use crate::ipc::request::{InboxRequest, SendRequest, SubscribeRequest};
+        use tempfile::TempDir;
+
+        let state = fresh_state();
+        let socket = unique_socket();
+        let server_state = state.clone();
+        let server_socket = socket.clone();
+        let server_handle = tokio::spawn(async move { run(server_state, server_socket).await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let dir = TempDir::new().unwrap();
+        let wire = dir.path().to_path_buf();
+        let channel = uuid::Uuid::nil();
+
+        let client = DaemonClient::new(socket);
+        // Subscribe first so the daemon starts the drain task.
+        client
+            .subscribe(SubscribeRequest { wire: wire.clone() })
+            .await
+            .unwrap();
+        // Send through the daemon (daemon signs + writes to the wire).
+        client
+            .send(SendRequest {
+                wire: wire.clone(),
+                channel,
+                text: "hello from daemon".to_string(),
+            })
+            .await
+            .unwrap();
+
+        // Inbox MAY need a brief moment to drain the new frame from
+        // the subscription into the buffer.
+        let mut attempts = 0;
+        let inbox = loop {
+            let response = client
+                .inbox(InboxRequest {
+                    wire: wire.clone(),
+                    since_lamport: None,
+                    limit: None,
+                })
+                .await
+                .unwrap();
+            if !response.frames.is_empty() {
+                break response;
+            }
+            attempts += 1;
+            if attempts > 20 {
+                panic!(
+                    "inbox never saw the sent frame (attempts={attempts}, newest_lamport={})",
+                    response.newest_lamport
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        };
+        assert_eq!(inbox.frames.len(), 1);
+        assert_eq!(
+            inbox.frames[0]
+                .envelope
+                .body
+                .as_ref()
+                .and_then(airc_core::Body::as_text)
+                .unwrap(),
+            "hello from daemon"
+        );
+
+        // newest_lamport should let us "advance past" — second inbox
+        // call returns empty.
+        let after = client
+            .inbox(InboxRequest {
+                wire: wire.clone(),
+                since_lamport: Some(inbox.newest_lamport),
+                limit: None,
+            })
+            .await
+            .unwrap();
+        assert!(
+            after.frames.is_empty(),
+            "after the cursor, inbox must be empty"
+        );
+
+        client.stop().await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(2), server_handle).await;
+    }
+
+    #[tokio::test]
     async fn second_daemon_refuses_to_steal_live_socket() {
         // Pin the cleanup_stale_socket contract: if a daemon is
         // already live on the path, a second run() returns AddrInUse

--- a/crates/airc-cli/src/daemon/state.rs
+++ b/crates/airc-cli/src/daemon/state.rs
@@ -6,7 +6,7 @@
 //! the substrate enforces its own internal locking (e.g.
 //! `PeerKeyRegistry` is wrapped in `Arc<RwLock>`).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -15,8 +15,59 @@ use std::time::Instant;
 use tokio::sync::{Mutex, Notify};
 
 use airc_core::PeerId;
-use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
+use airc_protocol::{Frame, PeerKeyRegistry, PeerKeypair, VerificationPolicy};
 use airc_transport::{LocalFsAdapter, SignedTransport};
+
+/// Default ring-buffer capacity per wire — recent N frames kept in
+/// memory for `Inbox` pulls. Tuned to ~chat-cadence retention; can be
+/// promoted to a config field later.
+pub const DEFAULT_INBOX_CAPACITY: usize = 1024;
+
+/// Bounded ring buffer of recently-received frames for one wire.
+/// Subscribers push into the buffer; `Inbox` requests read from it.
+#[derive(Debug)]
+pub struct InboxBuffer {
+    frames: VecDeque<Frame>,
+    capacity: usize,
+}
+
+impl InboxBuffer {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            frames: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    /// Append a frame, dropping the oldest if at capacity.
+    pub fn push(&mut self, frame: Frame) {
+        if self.frames.len() >= self.capacity {
+            self.frames.pop_front();
+        }
+        self.frames.push_back(frame);
+    }
+
+    /// Return frames with `lamport > since`, lamport-ascending, up
+    /// to `limit`.
+    pub fn since(&self, since: Option<u64>, limit: usize) -> Vec<Frame> {
+        let cutoff = since.unwrap_or(0);
+        self.frames
+            .iter()
+            .filter(|frame| since.is_none() || frame.envelope.lamport > cutoff)
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+
+    /// Largest lamport in the buffer (or 0 if empty).
+    pub fn newest_lamport(&self) -> u64 {
+        self.frames
+            .iter()
+            .map(|f| f.envelope.lamport)
+            .max()
+            .unwrap_or(0)
+    }
+}
 
 /// Everything a daemon needs at runtime. Cheap to clone via Arc; the
 /// underlying handles (registry, transports) do their own interior
@@ -32,6 +83,10 @@ pub struct DaemonState {
     /// opened on first `Send` referencing the wire so daemons that
     /// never send don't allocate state.
     pub local_fs_transports: Mutex<HashMap<PathBuf, Arc<SignedTransport<LocalFsAdapter>>>>,
+    /// One inbox ring buffer per wire — populated by the daemon's
+    /// background subscriber task. `Subscribe` requests create the
+    /// task on first call (idempotent).
+    pub inboxes: Mutex<HashMap<PathBuf, Arc<Mutex<InboxBuffer>>>>,
     /// Notified when the daemon should stop accepting + exit cleanly.
     pub shutdown: Notify,
 }
@@ -50,8 +105,30 @@ impl DaemonState {
             policy,
             started_at: Instant::now(),
             local_fs_transports: Mutex::new(HashMap::new()),
+            inboxes: Mutex::new(HashMap::new()),
             shutdown: Notify::new(),
         }
+    }
+
+    /// Get-or-create the inbox buffer for a wire. The caller is
+    /// responsible for ensuring a subscriber task is pushing into it
+    /// (`ensure_inbox_subscriber`).
+    pub async fn inbox_for(&self, wire: &std::path::Path) -> Arc<Mutex<InboxBuffer>> {
+        let key = wire.to_path_buf();
+        let mut inboxes = self.inboxes.lock().await;
+        if let Some(existing) = inboxes.get(&key) {
+            return existing.clone();
+        }
+        let buffer = Arc::new(Mutex::new(InboxBuffer::new(DEFAULT_INBOX_CAPACITY)));
+        inboxes.insert(key, buffer.clone());
+        buffer
+    }
+
+    /// True if a subscriber task is already running for `wire`.
+    /// The handler uses this to keep `Subscribe` idempotent — repeated
+    /// calls don't spawn additional drain tasks.
+    pub async fn has_inbox(&self, wire: &std::path::Path) -> bool {
+        self.inboxes.lock().await.contains_key(wire)
     }
 
     /// Get-or-create a SignedTransport<LocalFsAdapter> for the given

--- a/crates/airc-cli/src/ipc/client.rs
+++ b/crates/airc-cli/src/ipc/client.rs
@@ -15,8 +15,8 @@ use std::path::PathBuf;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 
-use crate::ipc::request::{Request, SendRequest};
-use crate::ipc::response::{Response, StatusResponse};
+use crate::ipc::request::{InboxRequest, Request, SendRequest, SubscribeRequest};
+use crate::ipc::response::{InboxResponse, Response, StatusResponse};
 
 /// Reasons a daemon RPC fails.
 #[derive(Debug)]
@@ -118,6 +118,20 @@ impl DaemonClient {
     pub async fn send(&self, request: SendRequest) -> Result<(), ClientError> {
         match self.call(Request::Send(request)).await? {
             Response::Ok => Ok(()),
+            other => Err(ClientError::UnexpectedResponse(other)),
+        }
+    }
+
+    pub async fn subscribe(&self, request: SubscribeRequest) -> Result<(), ClientError> {
+        match self.call(Request::Subscribe(request)).await? {
+            Response::Ok => Ok(()),
+            other => Err(ClientError::UnexpectedResponse(other)),
+        }
+    }
+
+    pub async fn inbox(&self, request: InboxRequest) -> Result<InboxResponse, ClientError> {
+        match self.call(Request::Inbox(request)).await? {
+            Response::Inbox(response) => Ok(response),
             other => Err(ClientError::UnexpectedResponse(other)),
         }
     }

--- a/crates/airc-cli/src/ipc/request.rs
+++ b/crates/airc-cli/src/ipc/request.rs
@@ -18,9 +18,42 @@ pub enum Request {
     /// Send a text Message frame. Daemon signs + dispatches via its
     /// owned `SignedTransport`.
     Send(SendRequest),
+    /// Start a subscription on `wire` if one isn't already running.
+    /// Daemon buffers received frames into an in-memory inbox per
+    /// wire. Idempotent — repeated calls return Ok without
+    /// duplicating subscriptions.
+    Subscribe(SubscribeRequest),
+    /// Read buffered frames from the daemon's inbox for `wire`.
+    /// Returns frames strictly after `since_lamport` (if provided),
+    /// up to `limit`. Pass back the response's newest_lamport on the
+    /// next call to keep the stream "consume-once".
+    Inbox(InboxRequest),
     /// Graceful shutdown. Daemon completes in-flight requests, then
     /// stops accepting new connections + exits.
     Stop,
+}
+
+/// Parameters for `Subscribe`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SubscribeRequest {
+    /// Wire directory to subscribe on (creates the local-fs adapter
+    /// + replay-anchored subscription if not already running).
+    pub wire: std::path::PathBuf,
+}
+
+/// Parameters for `Inbox`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InboxRequest {
+    /// Wire directory the daemon should pull buffered frames from.
+    pub wire: std::path::PathBuf,
+    /// Return only frames whose lamport > this value. `None` means
+    /// "everything in the buffer."
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub since_lamport: Option<u64>,
+    /// Max frames to return in this batch. `None` defaults to a
+    /// reasonable cap (32) so a slow client doesn't pull megabytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
 }
 
 /// Parameters for `Send`.

--- a/crates/airc-cli/src/ipc/response.rs
+++ b/crates/airc-cli/src/ipc/response.rs
@@ -3,15 +3,22 @@
 
 use serde::{Deserialize, Serialize};
 
+use airc_protocol::Frame;
+
 /// One response to a `Request`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Response {
     /// Response to `Ping`.
     Pong,
     /// Response to `Status`.
     Status(StatusResponse),
-    /// Generic success for ops that don't return data (`Send`, `Stop`).
+    /// Response to `Inbox` — buffered frames + a "newest cursor" the
+    /// caller threads back on the next call to keep the stream
+    /// consume-once.
+    Inbox(InboxResponse),
+    /// Generic success for ops that don't return data (`Send`,
+    /// `Subscribe`, `Stop`).
     Ok,
     /// Failure — typed message so the client can render it.
     Error { message: String },
@@ -24,6 +31,17 @@ pub struct StatusResponse {
     pub peer_id: String,
     /// Seconds since daemon start.
     pub uptime_seconds: u64,
+}
+
+/// Result of an `Inbox` pull: frames + the lamport to feed back as
+/// `since_lamport` on the next call.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct InboxResponse {
+    /// Up to `limit` frames matching the request, lamport-ascending.
+    pub frames: Vec<Frame>,
+    /// Largest lamport in `frames`, or `since_lamport` echoed back if
+    /// the call returned no frames. Pass this on the next call.
+    pub newest_lamport: u64,
 }
 
 #[cfg(test)]

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -149,5 +149,14 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             let socket = socket.unwrap_or_else(cli::default_socket_path);
             commands::run_msg(socket, wire, &channel, &text).await
         }
+        Command::Inbox {
+            socket,
+            wire,
+            since_lamport,
+            limit,
+        } => {
+            let socket = socket.unwrap_or_else(cli::default_socket_path);
+            commands::run_inbox(socket, wire, since_lamport, limit).await
+        }
     }
 }


### PR DESCRIPTION
## Summary

The receive half of the daemon. Subscribe + Inbox close the loop on Python-replacement: short-lived CLI calls now have a daemon-backed inbox to read from, no per-call substrate setup.

## New ops

| Op | What |
|----|------|
| \`Subscribe { wire }\` | Idempotent. First call spawns a drain task that pulls from \`SignedTransport::subscribe\` + pushes verified frames into the wire's \`InboxBuffer\`. Subsequent calls are no-ops. |
| \`Inbox { wire, since_lamport?, limit? }\` | Return buffered frames with \`lamport > since\` (or everything if since is None), capped at \`limit\` (default 32). Response carries \`newest_lamport\` so the client threads it back next call for consume-once semantics. |

## CLI

```
$ airc-rs inbox --wire /tmp/wire [--since-lamport N] [--limit N]
```

Prints frames + the new cursor to thread back.

## Integration test

\`subscribe_then_send_then_inbox_round_trips\` exercises the full receive path:
1. \`SubscribeRequest{wire}\` → daemon spawns drain task
2. \`SendRequest{wire, channel, text}\` → daemon signs + writes to local-fs
3. Drain task verifies + pushes into the \`InboxBuffer\`
4. \`InboxRequest{wire}\` returns 1 frame; second call with \`since_lamport=newest\` returns 0

## Test plan

- [x] \`cargo fmt -p airc-cli\` — clean
- [x] \`cargo clippy -p airc-cli --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p airc-cli\` — **24 pass / 0 fail** (22 unit + 2 e2e subprocess)

## Targets rust-rewrite

Lands directly on the integration branch — no stacking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)