### PR TITLE
feat(airc-cli): persisted identity state — stable peer_id + client_id

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -1,4 +1,13 @@
 //! Command-line interface definitions (clap derive).
+//!
+//! All commands default to the persisted state at `<home>` (default
+//! `$HOME/.airc-rs`), which contains:
+//!   - `identity.key`   — 32-byte Ed25519 secret (0600 on Unix)
+//!   - `identity.json`  — stable peer_id + client_id (0600)
+//!   - `daemon.sock`    — IPC socket for the daemon
+//!   - `peers.json`     — (future) persisted peer registry
+//!
+//! The `--home` flag overrides for testing / multi-identity setups.
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -7,15 +16,20 @@ use clap::{Parser, Subcommand};
 
 use crate::registry::PeerSpec;
 
-/// Default Unix socket path for the daemon. Overridable per-command
-/// via `--socket`.
-pub fn default_socket_path() -> PathBuf {
-    // ~/.airc-rs/daemon.sock if HOME is set; otherwise /tmp.
+/// Default home directory for persisted identity + IPC state.
+pub fn default_home_dir() -> PathBuf {
     if let Some(home) = std::env::var_os("HOME") {
-        PathBuf::from(home).join(".airc-rs").join("daemon.sock")
+        PathBuf::from(home).join(".airc-rs")
     } else {
-        PathBuf::from("/tmp").join("airc-rs-daemon.sock")
+        // No HOME — fall back to a clearly-scoped path under /tmp so
+        // accidents don't clobber real homes.
+        PathBuf::from("/tmp").join("airc-rs")
     }
+}
+
+/// Default Unix socket path inside `home`.
+pub fn default_socket_path_in(home: &std::path::Path) -> PathBuf {
+    home.join("daemon.sock")
 }
 
 /// airc-rs — Rust substrate CLI. Replaces the Python `airc` step by
@@ -29,20 +43,18 @@ pub fn default_socket_path() -> PathBuf {
                   Replaces the Python airc CLI as the Rust path matures."
 )]
 pub struct Cli {
-    /// Path to the 32-byte Ed25519 identity file. Created on first
-    /// use if absent.
-    #[arg(long, env = "AIRC_RS_IDENTITY", global = true)]
-    pub identity_file: Option<PathBuf>,
-
-    /// This peer's UUID. Generated and printed on first `init`;
-    /// pass it back on subsequent commands.
-    #[arg(long, env = "AIRC_RS_PEER_ID", global = true)]
-    pub peer_id: Option<String>,
+    /// State directory for persisted identity + IPC socket. Default
+    /// `$HOME/.airc-rs`. Override for tests or multi-identity setups.
+    #[arg(long, env = "AIRC_RS_HOME", global = true)]
+    pub home: Option<PathBuf>,
 
     /// Peers to enrol in the local registry, repeatable.
     /// Format: `<uuid>:<base64-pubkey-no-padding>`. Obtain by
     /// running `airc-rs init` on the peer side and copying its
     /// printed spec.
+    ///
+    /// (Will be replaced by a persisted `peers.json` in the next
+    /// PR; flag stays as an override.)
     #[arg(long = "peer", value_name = "SPEC", global = true)]
     pub peers: Vec<PeerSpec>,
 
@@ -52,8 +64,10 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
-    /// Create or load an identity, then print this peer's spec for
-    /// out-of-band sharing.
+    /// Create or load the persisted identity (`<home>/identity.key` +
+    /// `<home>/identity.json`), then print this peer's spec for
+    /// out-of-band sharing. Idempotent — repeat runs return the same
+    /// peer_id.
     Init,
 
     /// Send a single text Message frame and exit.
@@ -97,8 +111,8 @@ pub enum Command {
         text: String,
     },
 
-    /// Same-LAN secure listen: bind a TLS server, accept ONE peer
-    /// (MVP), print received frames.
+    /// Same-LAN secure listen: bind a TLS server, accept peers,
+    /// print received frames.
     LanListen {
         /// Bind address (e.g. `127.0.0.1:7474` or `0.0.0.0:7474`).
         #[arg(long)]
@@ -112,8 +126,7 @@ pub enum Command {
     /// subsequent short-lived CLI calls (`ping`, `msg`, `status`)
     /// don't re-load identity or re-handshake.
     Daemon {
-        /// Override the default socket path
-        /// (`$HOME/.airc-rs/daemon.sock`).
+        /// Override the default socket path (`<home>/daemon.sock`).
         #[arg(long)]
         socket: Option<PathBuf>,
     },
@@ -153,20 +166,15 @@ pub enum Command {
 
     /// Pull buffered frames from the daemon's inbox for a wire.
     /// On first call for a wire, the daemon starts subscribing
-    /// (idempotent — repeat calls reuse the same subscription).
-    /// Pass `--since-lamport` to consume only new frames since the
-    /// last call.
+    /// (idempotent). Pass `--since-lamport` for consume-once cursor.
     Inbox {
         #[arg(long)]
         socket: Option<PathBuf>,
         /// Wire directory.
         #[arg(long)]
         wire: PathBuf,
-        /// Return frames with lamport > this value (consume-once
-        /// cursor). Defaults to 0 = everything in the buffer.
         #[arg(long)]
         since_lamport: Option<u64>,
-        /// Max frames in one batch.
         #[arg(long)]
         limit: Option<usize>,
     },

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1,5 +1,9 @@
 //! Subcommand handlers — keep them small and direct. Each function
-//! takes the parsed CLI context and runs.
+//! takes a `LocalIdentity` (loaded once per invocation by `main`) +
+//! command-specific args.
+//!
+//! `VerificationPolicy::Strict` is the only policy used in CLI paths.
+//! There is no opt-in for `AllowUnsigned` here — production rules.
 
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -15,50 +19,49 @@ use futures::stream::StreamExt;
 use uuid::Uuid;
 
 use crate::daemon::{run as run_daemon_server, DaemonState};
-use crate::identity::load_or_generate;
+use crate::identity::LocalIdentity;
 use crate::ipc::request::{InboxRequest, SubscribeRequest};
 use crate::ipc::{DaemonClient, SendRequest};
 use crate::registry::{build_registry, format_peer_spec, PeerSpec};
 
-/// `init` — load or generate the identity, print the peer spec.
-pub fn run_init(identity_file: &Path, peer_id: Option<PeerId>) -> std::io::Result<()> {
-    let keypair = load_or_generate(identity_file)?;
-    let peer_id = peer_id.unwrap_or_default();
-    println!("identity_file: {}", identity_file.display());
-    println!("peer_id:       {peer_id}");
+/// `init` — create or load the persisted identity under `<home>`,
+/// then print the peer spec for out-of-band sharing.
+pub fn run_init(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let identity = LocalIdentity::load_or_generate(home)?;
+    println!("home:        {}", home.display());
+    println!("peer_id:     {}", identity.peer_id);
+    println!("client_id:   {}", identity.client_id);
     println!(
-        "peer_spec:     {}",
-        format_peer_spec(peer_id, &keypair.public_bytes())
+        "peer_spec:   {}",
+        format_peer_spec(identity.peer_id, &identity.keypair.public_bytes())
     );
     println!();
-    println!("Share `peer_spec` with the other side, and pass it back as");
-    println!("`--peer <spec>` plus `--peer-id {peer_id}` on subsequent commands.");
+    println!(
+        "Share peer_spec with other peers and pass it back as --peer <spec>. \
+         (Persistent peers.json coming in the next PR.)"
+    );
     Ok(())
 }
 
 /// `send` — local-fs single-shot send, signed under Strict.
 pub async fn run_send(
-    identity_file: &Path,
-    peer_id: PeerId,
+    identity: &LocalIdentity,
     peers: Vec<PeerSpec>,
     wire: &Path,
     channel: &str,
     text: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let keypair = load_or_generate(identity_file)?;
-    let registry = build_registry(peer_id, keypair.public_bytes(), &peers)?;
-
+    let registry = build_registry(identity.peer_id, identity.keypair.public_bytes(), &peers)?;
     let inner = LocalFsAdapter::new(wire);
     let transport = SignedTransport::new(
         inner,
-        keypair,
-        peer_id,
+        identity.keypair.clone(),
+        identity.peer_id,
         registry,
         VerificationPolicy::Strict,
     );
-
     let channel_id = parse_channel(channel)?;
-    let frame = build_message_frame(peer_id, channel_id, text);
+    let frame = build_message_frame(identity, channel_id, text);
     transport.send(frame).await?;
     println!("sent.");
     Ok(())
@@ -66,93 +69,187 @@ pub async fn run_send(
 
 /// `listen` — local-fs subscribe loop. Prints frames until Ctrl-C.
 pub async fn run_listen(
-    identity_file: &Path,
-    peer_id: PeerId,
+    identity: &LocalIdentity,
     peers: Vec<PeerSpec>,
     wire: &Path,
     channel: Option<String>,
     replay: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let keypair = load_or_generate(identity_file)?;
-    let registry = build_registry(peer_id, keypair.public_bytes(), &peers)?;
-
+    let registry = build_registry(identity.peer_id, identity.keypair.public_bytes(), &peers)?;
     let inner = LocalFsAdapter::new(wire);
     let transport = SignedTransport::new(
         inner,
-        keypair,
-        peer_id,
+        identity.keypair.clone(),
+        identity.peer_id,
         registry,
         VerificationPolicy::Strict,
     );
-
     let subscription = subscription_for(channel.as_deref(), replay)?;
     let mut stream = transport.subscribe(subscription).await?;
 
-    println!("listening on {} (peer_id {peer_id}) …", wire.display());
+    println!(
+        "listening on {} (peer_id {}) …",
+        wire.display(),
+        identity.peer_id
+    );
     print_until_signal(&mut stream).await
 }
 
 /// `lan-send` — TLS-wrapped single-shot send to a remote peer.
 pub async fn run_lan_send(
-    identity_file: &Path,
-    peer_id: PeerId,
+    identity: &LocalIdentity,
     peers: Vec<PeerSpec>,
     to: std::net::SocketAddr,
     expected_peer: PeerId,
     channel: &str,
     text: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let keypair = load_or_generate(identity_file)?;
-    let registry = build_registry(peer_id, keypair.public_bytes(), &peers)?;
-
-    let inner = LanTcpAdapter::new(peer_id, keypair.clone(), registry.clone())?;
+    let registry = build_registry(identity.peer_id, identity.keypair.public_bytes(), &peers)?;
+    let inner = LanTcpAdapter::new(identity.peer_id, identity.keypair.clone(), registry.clone())?;
     inner.connect(to, expected_peer).await?;
-
-    // `connect()` now installs the outbound channel synchronously
-    // before returning (Codex's #671 readiness-race fix), so no
-    // sleep needed before sending.
     let transport = SignedTransport::new(
         inner,
-        keypair,
-        peer_id,
+        identity.keypair.clone(),
+        identity.peer_id,
         registry,
         VerificationPolicy::Strict,
     );
-
     let channel_id = parse_channel(channel)?;
-    let frame = build_message_frame(peer_id, channel_id, text);
+    let frame = build_message_frame(identity, channel_id, text);
     transport.send(frame).await?;
     println!("sent over lan-tcp.");
     Ok(())
 }
 
-/// `lan-listen` — bind a TLS server, accept ONE peer, print frames.
+/// `lan-listen` — bind a TLS server, accept peers, print frames.
 pub async fn run_lan_listen(
-    identity_file: &Path,
-    peer_id: PeerId,
+    identity: &LocalIdentity,
     peers: Vec<PeerSpec>,
     bind: std::net::SocketAddr,
     replay: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let keypair = load_or_generate(identity_file)?;
-    let registry = build_registry(peer_id, keypair.public_bytes(), &peers)?;
-
-    let inner = LanTcpAdapter::new(peer_id, keypair.clone(), registry.clone())?;
+    let registry = build_registry(identity.peer_id, identity.keypair.public_bytes(), &peers)?;
+    let inner = LanTcpAdapter::new(identity.peer_id, identity.keypair.clone(), registry.clone())?;
     let actual = inner.listen(bind).await?;
-    println!("listening on {actual} (peer_id {peer_id}) …");
-
+    println!("listening on {actual} (peer_id {}) …", identity.peer_id);
     let transport = SignedTransport::new(
         inner,
-        keypair,
-        peer_id,
+        identity.keypair.clone(),
+        identity.peer_id,
         registry,
         VerificationPolicy::Strict,
     );
-
     let subscription = subscription_for(None, replay)?;
     let mut stream = transport.subscribe(subscription).await?;
     print_until_signal(&mut stream).await
 }
+
+/// `daemon` — run the long-lived daemon process on the given socket.
+pub async fn run_daemon(
+    identity: LocalIdentity,
+    peers: Vec<PeerSpec>,
+    socket: PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let registry = build_registry(identity.peer_id, identity.keypair.public_bytes(), &peers)?;
+
+    if let Some(parent) = socket.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+
+    let state = Arc::new(DaemonState::new(
+        identity.peer_id,
+        identity.keypair,
+        registry,
+        VerificationPolicy::Strict,
+    ));
+    println!(
+        "airc-rs daemon: peer_id={} listening on {}",
+        identity.peer_id,
+        socket.display()
+    );
+    run_daemon_server(state, socket).await?;
+    println!("airc-rs daemon: stopped.");
+    Ok(())
+}
+
+// ---- Daemon-client commands (no identity load needed) ---------------
+
+pub async fn run_ping(socket: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let client = DaemonClient::new(socket);
+    client.ping().await?;
+    println!("pong");
+    Ok(())
+}
+
+pub async fn run_status(socket: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let client = DaemonClient::new(socket);
+    let status = client.status().await?;
+    println!("peer_id:        {}", status.peer_id);
+    println!("uptime_seconds: {}", status.uptime_seconds);
+    Ok(())
+}
+
+pub async fn run_stop(socket: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let client = DaemonClient::new(socket);
+    client.stop().await?;
+    println!("daemon: stop requested.");
+    Ok(())
+}
+
+pub async fn run_msg(
+    socket: PathBuf,
+    wire: PathBuf,
+    channel: &str,
+    text: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let channel_uuid = Uuid::from_str(channel)?;
+    let client = DaemonClient::new(socket);
+    client
+        .send(SendRequest {
+            wire,
+            channel: channel_uuid,
+            text: text.to_string(),
+        })
+        .await?;
+    println!("sent.");
+    Ok(())
+}
+
+pub async fn run_inbox(
+    socket: PathBuf,
+    wire: PathBuf,
+    since_lamport: Option<u64>,
+    limit: Option<usize>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = DaemonClient::new(socket);
+    client
+        .subscribe(SubscribeRequest { wire: wire.clone() })
+        .await?;
+    let inbox = client
+        .inbox(InboxRequest {
+            wire,
+            since_lamport,
+            limit,
+        })
+        .await?;
+    if inbox.frames.is_empty() {
+        println!("(no new frames; newest_lamport={})", inbox.newest_lamport);
+        return Ok(());
+    }
+    for frame in &inbox.frames {
+        print_frame(frame);
+    }
+    println!();
+    println!(
+        "newest_lamport={} — pass as --since-lamport on the next call",
+        inbox.newest_lamport
+    );
+    Ok(())
+}
+
+// ---- Shared helpers -------------------------------------------------
 
 fn parse_channel(channel: &str) -> Result<RoomId, uuid::Error> {
     let uuid = Uuid::from_str(channel)?;
@@ -182,7 +279,7 @@ fn subscription_for(
     })
 }
 
-fn build_message_frame(sender: PeerId, channel: RoomId, text: &str) -> Frame {
+fn build_message_frame(identity: &LocalIdentity, channel: RoomId, text: &str) -> Frame {
     let lamport = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
@@ -191,8 +288,10 @@ fn build_message_frame(sender: PeerId, channel: RoomId, text: &str) -> Frame {
         kind: FrameKind::Message,
         envelope: Envelope {
             event_id: EventId::new(),
-            sender,
-            sender_client: ClientId::new(),
+            sender: identity.peer_id,
+            // Stable ClientId from the persisted identity — multi-tab
+            // disambiguation, replay records cite this.
+            sender_client: identity.client_id,
             channel,
             target: MentionTarget::All,
             lamport,
@@ -200,8 +299,9 @@ fn build_message_frame(sender: PeerId, channel: RoomId, text: &str) -> Frame {
             reply_to: None,
             headers: Headers::new(),
             body: Some(Body::text(text)),
-            media: Vec::new(),
+            // SignedTransport replaces this with Ed25519 on the way out.
             signature: Signature::Unsigned,
+            media: Vec::new(),
         },
     }
 }
@@ -235,121 +335,6 @@ where
     }
 }
 
-/// `daemon` — run the long-lived daemon process on the given socket.
-pub async fn run_daemon(
-    identity_file: &Path,
-    peer_id: PeerId,
-    peers: Vec<PeerSpec>,
-    socket: PathBuf,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let keypair = load_or_generate(identity_file)?;
-    let registry = build_registry(peer_id, keypair.public_bytes(), &peers)?;
-
-    // Ensure the socket's parent directory exists; the daemon won't
-    // create it for the user.
-    if let Some(parent) = socket.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)?;
-        }
-    }
-
-    let state = Arc::new(DaemonState::new(
-        peer_id,
-        keypair,
-        registry,
-        VerificationPolicy::Strict,
-    ));
-    println!(
-        "airc-rs daemon: peer_id={peer_id} listening on {}",
-        socket.display()
-    );
-    run_daemon_server(state, socket).await?;
-    println!("airc-rs daemon: stopped.");
-    Ok(())
-}
-
-/// `ping` — RPC the daemon. Prints "pong" on success.
-pub async fn run_ping(socket: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
-    let client = DaemonClient::new(socket);
-    client.ping().await?;
-    println!("pong");
-    Ok(())
-}
-
-/// `status` — fetch daemon's health snapshot.
-pub async fn run_status(socket: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
-    let client = DaemonClient::new(socket);
-    let status = client.status().await?;
-    println!("peer_id:        {}", status.peer_id);
-    println!("uptime_seconds: {}", status.uptime_seconds);
-    Ok(())
-}
-
-/// `stop` — ask the daemon to shut down gracefully.
-pub async fn run_stop(socket: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
-    let client = DaemonClient::new(socket);
-    client.stop().await?;
-    println!("daemon: stop requested.");
-    Ok(())
-}
-
-/// `inbox` — Subscribe-then-Inbox via the daemon. Prints any
-/// buffered frames newer than `since_lamport`. The first call for a
-/// wire kicks off the daemon's subscription; subsequent calls are
-/// pure reads.
-pub async fn run_inbox(
-    socket: PathBuf,
-    wire: PathBuf,
-    since_lamport: Option<u64>,
-    limit: Option<usize>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let client = DaemonClient::new(socket);
-    // Idempotent — daemon ignores duplicate subscribes for the wire.
-    client
-        .subscribe(SubscribeRequest { wire: wire.clone() })
-        .await?;
-    let inbox = client
-        .inbox(InboxRequest {
-            wire,
-            since_lamport,
-            limit,
-        })
-        .await?;
-    if inbox.frames.is_empty() {
-        println!("(no new frames; newest_lamport={})", inbox.newest_lamport);
-        return Ok(());
-    }
-    for frame in &inbox.frames {
-        print_frame(frame);
-    }
-    println!();
-    println!(
-        "newest_lamport={} — pass as --since-lamport on the next call",
-        inbox.newest_lamport
-    );
-    Ok(())
-}
-
-/// `msg` — send via the daemon.
-pub async fn run_msg(
-    socket: PathBuf,
-    wire: PathBuf,
-    channel: &str,
-    text: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let channel_uuid = Uuid::from_str(channel)?;
-    let client = DaemonClient::new(socket);
-    client
-        .send(SendRequest {
-            wire,
-            channel: channel_uuid,
-            text: text.to_string(),
-        })
-        .await?;
-    println!("sent.");
-    Ok(())
-}
-
 fn print_frame(frame: &Frame) {
     let text = frame
         .envelope
@@ -364,3 +349,10 @@ fn print_frame(frame: &Frame) {
         channel = frame.envelope.channel,
     );
 }
+
+// Silence the unused-import warning for `ClientId`: it's used
+// transitively through `LocalIdentity::client_id` (which is the
+// `airc_core::ClientId` newtype) but not referenced by name in this
+// file. Keeping the import explicit keeps the dep graph readable.
+#[allow(dead_code)]
+fn _client_id_kept_in_scope(_: ClientId) {}

--- a/crates/airc-cli/src/identity.rs
+++ b/crates/airc-cli/src/identity.rs
@@ -1,71 +1,251 @@
-//! Identity persistence — load + save a `PeerKeypair` to a file.
+//! Persisted local identity — `LocalIdentity` bundles the keypair + a
+//! stable `peer_id` + `client_id` so the substrate's identity survives
+//! across CLI invocations and across daemon restarts.
 //!
-//! MVP storage: raw 32-byte Ed25519 secret in a file at `--identity-file
-//! <path>`. The file is created with 0600 (owner-only) permissions
-//! when the runtime is on Unix.
+//! Layout on disk (under `<home>/`, default `$HOME/.airc-rs/`):
 //!
-//! NOT for production secrets: a real implementation belongs behind
-//! SQLCipher, an OS keychain, or a hardware enclave (see the substrate
-//! `feedback_blobs_never_in_db` rule + the storage discussion in
-//! `airc-protocol::keypair`'s docs). The CLI's MVP file-storage is
-//! adequate for cross-process e2e demos but flagged as such.
+//!   - `identity.key`  — raw 32-byte Ed25519 secret (0600)
+//!   - `identity.json` — `{ peer_id, client_id, version, created_at_ms }` (0600)
+//!
+//! The two files are paired. `load_or_generate` treats them as one
+//! unit: either both exist (load), or both are absent (generate +
+//! save). One present + one absent is an error — we refuse to recover
+//! ambiguously because losing either half changes peer identity.
+//!
+//! Storage caveat: this is plain on-disk material. A production
+//! deployment belongs behind SQLCipher / OS keychain / hardware
+//! enclave per the substrate `feedback_blobs_never_in_db` rule. The
+//! CLI's file storage is adequate for cross-process demos + the
+//! current daemon use case; it's deliberately replaceable.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
+
+use airc_core::{ClientId, PeerId};
 use airc_protocol::PeerKeypair;
 
-pub fn load_or_generate(path: &Path) -> std::io::Result<PeerKeypair> {
-    if path.exists() {
-        load(path)
-    } else {
-        let keypair = PeerKeypair::generate();
-        save(path, &keypair)?;
-        Ok(keypair)
-    }
+/// On-disk schema version for `identity.json`. Bump when the file
+/// shape changes incompatibly.
+const IDENTITY_STATE_VERSION: u32 = 1;
+
+/// Sibling metadata file alongside `identity.key`.
+const IDENTITY_KEY_FILENAME: &str = "identity.key";
+const IDENTITY_STATE_FILENAME: &str = "identity.json";
+
+/// Persisted-state bundle: stable identity for this airc-rs install.
+#[derive(Debug, Clone)]
+pub struct LocalIdentity {
+    pub keypair: PeerKeypair,
+    pub peer_id: PeerId,
+    pub client_id: ClientId,
 }
 
-pub fn load(path: &Path) -> std::io::Result<PeerKeypair> {
-    let bytes = std::fs::read(path)?;
-    if bytes.len() != 32 {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!(
-                "identity file {} has {} bytes, expected 32 (raw Ed25519 secret)",
-                path.display(),
-                bytes.len()
+#[derive(Debug, Serialize, Deserialize)]
+struct IdentityState {
+    version: u32,
+    peer_id: PeerId,
+    client_id: ClientId,
+    created_at_ms: u64,
+}
+
+#[derive(Debug)]
+pub enum IdentityError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    /// Identity-state file's `version` doesn't match what this build
+    /// knows how to read. Refuse to load rather than silently
+    /// reinterpret.
+    SchemaVersionMismatch {
+        found: u32,
+        expected: u32,
+    },
+    /// `identity.key` exists but the sibling `identity.json` doesn't
+    /// (or vice versa). The pair is required to disambiguate
+    /// identity — refusing rather than regenerating prevents silent
+    /// peer-id rotation.
+    PartialState {
+        key_exists: bool,
+        state_exists: bool,
+    },
+    /// `identity.key` exists but isn't the expected 32 bytes.
+    BadKeyLength(usize),
+}
+
+impl std::fmt::Display for IdentityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IdentityError::Io(error) => write!(f, "identity I/O: {error}"),
+            IdentityError::Json(error) => write!(f, "identity state JSON: {error}"),
+            IdentityError::SchemaVersionMismatch { found, expected } => {
+                write!(
+                    f,
+                    "identity.json schema version {found}, this build expects {expected}"
+                )
+            }
+            IdentityError::PartialState {
+                key_exists,
+                state_exists,
+            } => write!(
+                f,
+                "identity is half-initialised: key={} state={}. \
+                 Either remove both files to regenerate, or restore the missing one — \
+                 the substrate refuses to invent a new peer_id over an existing key.",
+                key_exists, state_exists
             ),
-        ));
+            IdentityError::BadKeyLength(got) => write!(
+                f,
+                "identity.key is {got} bytes, expected 32 (raw Ed25519 secret)"
+            ),
+        }
     }
-    let mut secret = [0u8; 32];
-    secret.copy_from_slice(&bytes);
-    Ok(PeerKeypair::from_secret_bytes(&secret))
 }
 
-pub fn save(path: &Path, keypair: &PeerKeypair) -> std::io::Result<()> {
+impl std::error::Error for IdentityError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            IdentityError::Io(error) => Some(error),
+            IdentityError::Json(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for IdentityError {
+    fn from(error: std::io::Error) -> Self {
+        IdentityError::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for IdentityError {
+    fn from(error: serde_json::Error) -> Self {
+        IdentityError::Json(error)
+    }
+}
+
+impl LocalIdentity {
+    /// Path to the secret key file inside `home`.
+    pub fn key_path(home: &Path) -> PathBuf {
+        home.join(IDENTITY_KEY_FILENAME)
+    }
+
+    /// Path to the state file inside `home`.
+    pub fn state_path(home: &Path) -> PathBuf {
+        home.join(IDENTITY_STATE_FILENAME)
+    }
+
+    /// Load the existing identity from `home`, or generate a fresh
+    /// one (writing both files) if neither exists. Refuses to
+    /// recover from a half-initialised state.
+    pub fn load_or_generate(home: &Path) -> Result<Self, IdentityError> {
+        let key_path = Self::key_path(home);
+        let state_path = Self::state_path(home);
+        let key_exists = key_path.exists();
+        let state_exists = state_path.exists();
+        match (key_exists, state_exists) {
+            (true, true) => Self::load(home),
+            (false, false) => Self::generate_and_save(home),
+            (key, state) => Err(IdentityError::PartialState {
+                key_exists: key,
+                state_exists: state,
+            }),
+        }
+    }
+
+    /// Load an existing identity (both files must exist).
+    pub fn load(home: &Path) -> Result<Self, IdentityError> {
+        let key_bytes = std::fs::read(Self::key_path(home))?;
+        if key_bytes.len() != 32 {
+            return Err(IdentityError::BadKeyLength(key_bytes.len()));
+        }
+        let mut secret = [0u8; 32];
+        secret.copy_from_slice(&key_bytes);
+        let keypair = PeerKeypair::from_secret_bytes(&secret);
+
+        let state_text = std::fs::read_to_string(Self::state_path(home))?;
+        let state: IdentityState = serde_json::from_str(&state_text)?;
+        if state.version != IDENTITY_STATE_VERSION {
+            return Err(IdentityError::SchemaVersionMismatch {
+                found: state.version,
+                expected: IDENTITY_STATE_VERSION,
+            });
+        }
+        Ok(Self {
+            keypair,
+            peer_id: state.peer_id,
+            client_id: state.client_id,
+        })
+    }
+
+    /// Generate a fresh identity + persist it under `home`. Returns
+    /// the same `LocalIdentity` a subsequent `load(home)` would
+    /// produce.
+    pub fn generate_and_save(home: &Path) -> Result<Self, IdentityError> {
+        ensure_home_dir(home)?;
+        let keypair = PeerKeypair::generate();
+        let peer_id = PeerId::new();
+        let client_id = ClientId::new();
+        let created_at_ms = now_ms();
+
+        write_owner_only(&Self::key_path(home), &keypair.secret_bytes())?;
+
+        let state = IdentityState {
+            version: IDENTITY_STATE_VERSION,
+            peer_id,
+            client_id,
+            created_at_ms,
+        };
+        let state_text = serde_json::to_string_pretty(&state)?;
+        write_owner_only(&Self::state_path(home), state_text.as_bytes())?;
+
+        Ok(Self {
+            keypair,
+            peer_id,
+            client_id,
+        })
+    }
+}
+
+/// Create `home` if missing; on Unix, restrict to 0700 (owner-only)
+/// so the secret + state files aren't even discoverable by other
+/// users on the same machine.
+fn ensure_home_dir(home: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(home)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(home)?.permissions();
+        perms.set_mode(0o700);
+        std::fs::set_permissions(home, perms)?;
+    }
+    Ok(())
+}
+
+/// Write a file with 0600 (owner-only) permissions on Unix. Windows
+/// inherits the user-profile ACL — call out as a known cross-platform
+/// gap for the production-hardening pass.
+fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             std::fs::create_dir_all(parent)?;
         }
     }
-    std::fs::write(path, keypair.secret_bytes())?;
-    set_owner_only_permissions(path)?;
+    std::fs::write(path, bytes)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(path)?.permissions();
+        perms.set_mode(0o600);
+        std::fs::set_permissions(path, perms)?;
+    }
     Ok(())
 }
 
-#[cfg(unix)]
-fn set_owner_only_permissions(path: &Path) -> std::io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    let mut perms = std::fs::metadata(path)?.permissions();
-    perms.set_mode(0o600);
-    std::fs::set_permissions(path, perms)
-}
-
-#[cfg(not(unix))]
-fn set_owner_only_permissions(_path: &Path) -> std::io::Result<()> {
-    // Windows: rely on default user-profile ACLs for the directory.
-    // A real cross-platform implementation would set Windows ACLs to
-    // restrict to current user only — out of scope for MVP.
-    Ok(())
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -74,33 +254,96 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn round_trip_through_disk() {
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("test.key");
-        let original = PeerKeypair::generate();
-        save(&path, &original).unwrap();
-        let loaded = load(&path).unwrap();
-        assert_eq!(loaded.secret_bytes(), original.secret_bytes());
+    fn load_or_generate_creates_both_files_and_reuses_them() {
+        let home = TempDir::new().unwrap();
+        let first = LocalIdentity::load_or_generate(home.path()).unwrap();
+        assert!(LocalIdentity::key_path(home.path()).exists());
+        assert!(LocalIdentity::state_path(home.path()).exists());
+
+        let second = LocalIdentity::load_or_generate(home.path()).unwrap();
+        // The crucial invariant: same key, same peer_id across runs.
+        assert_eq!(first.keypair.secret_bytes(), second.keypair.secret_bytes());
+        assert_eq!(first.peer_id, second.peer_id);
+        assert_eq!(first.client_id, second.client_id);
     }
 
     #[test]
-    fn load_or_generate_creates_then_reuses() {
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("auto.key");
-        let first = load_or_generate(&path).unwrap();
-        let second = load_or_generate(&path).unwrap();
-        // The second call must read what the first wrote, not
-        // generate a fresh key — otherwise a CLI rerun would
-        // change identity.
-        assert_eq!(first.secret_bytes(), second.secret_bytes());
+    fn refuses_partial_state_when_only_key_exists() {
+        // Key without state would silently regenerate a fresh peer_id
+        // if we tolerated it — that would break every prior peer
+        // who'd already enrolled the old peer_id. Refuse.
+        let home = TempDir::new().unwrap();
+        write_owner_only(&LocalIdentity::key_path(home.path()), &[0u8; 32]).unwrap();
+        let result = LocalIdentity::load_or_generate(home.path());
+        assert!(matches!(
+            result,
+            Err(IdentityError::PartialState {
+                key_exists: true,
+                state_exists: false,
+            })
+        ));
     }
 
     #[test]
-    fn rejects_wrong_size_identity_file() {
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("bad.key");
-        std::fs::write(&path, [0u8; 20]).unwrap();
-        let result = load(&path);
-        assert!(result.is_err());
+    fn refuses_partial_state_when_only_json_exists() {
+        let home = TempDir::new().unwrap();
+        std::fs::create_dir_all(home.path()).unwrap();
+        std::fs::write(LocalIdentity::state_path(home.path()), "{}").unwrap();
+        let result = LocalIdentity::load_or_generate(home.path());
+        assert!(matches!(
+            result,
+            Err(IdentityError::PartialState {
+                key_exists: false,
+                state_exists: true,
+            })
+        ));
+    }
+
+    #[test]
+    fn refuses_bad_key_length() {
+        let home = TempDir::new().unwrap();
+        let identity = LocalIdentity::generate_and_save(home.path()).unwrap();
+        // Corrupt the key file.
+        std::fs::write(LocalIdentity::key_path(home.path()), b"too short").unwrap();
+        let result = LocalIdentity::load(home.path());
+        assert!(matches!(result, Err(IdentityError::BadKeyLength(_))));
+        // The valid identity we generated above is still good — pin
+        // that load failure doesn't corrupt the in-memory copy.
+        assert_eq!(identity.peer_id.to_string().len(), 36);
+    }
+
+    #[test]
+    fn refuses_unknown_schema_version() {
+        let home = TempDir::new().unwrap();
+        LocalIdentity::generate_and_save(home.path()).unwrap();
+        std::fs::write(
+            LocalIdentity::state_path(home.path()),
+            r#"{"version":999,"peer_id":"00000000-0000-0000-0000-000000000001","client_id":"00000000-0000-0000-0000-000000000002","created_at_ms":0}"#,
+        )
+        .unwrap();
+        let result = LocalIdentity::load(home.path());
+        assert!(matches!(
+            result,
+            Err(IdentityError::SchemaVersionMismatch {
+                found: 999,
+                expected: IDENTITY_STATE_VERSION,
+            })
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn key_and_state_files_are_owner_only_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+        let home = TempDir::new().unwrap();
+        LocalIdentity::generate_and_save(home.path()).unwrap();
+        for file in [
+            LocalIdentity::key_path(home.path()),
+            LocalIdentity::state_path(home.path()),
+        ] {
+            let mode = std::fs::metadata(&file).unwrap().permissions().mode();
+            // Strip the file-type bits, keep just the perm bits.
+            assert_eq!(mode & 0o777, 0o600, "{} not 0600", file.display());
+        }
     }
 }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -1,20 +1,15 @@
 //! airc-rs — Rust substrate CLI binary.
 //!
-//! Wires the substrate crates (`airc-core`, `airc-protocol`,
-//! `airc-transport`) into a small command-line tool that proves the
-//! Rust substrate works end-to-end without any Python. Two terminals
-//! can chat over local-fs or LAN-TCP via this binary.
+//! State lives under `<home>` (default `$HOME/.airc-rs`):
+//!   - `identity.key`   — 32-byte Ed25519 secret (0600)
+//!   - `identity.json`  — stable peer_id + client_id (0600)
+//!   - `daemon.sock`    — IPC socket
+//!   - `peers.json`     — (next PR) persisted peer registry
 //!
-//! MVP scope:
-//!   - `init` — generate / load identity, print peer spec.
-//!   - `send` / `listen` — local-fs (same-Mac multi-process).
-//!   - `lan-send` / `lan-listen` — TLS-wrapped TCP (same-LAN secure).
-//!
-//! What's deferred:
-//!   - Persistent registry (for now, peers are passed via repeated
-//!     `--peer` flags on each command).
-//!   - A bridge daemon that holds state for short-lived CLI calls.
-//!   - Cross-platform polish (Windows ACLs, etc.).
+//! `airc-rs init` is the only command that creates the identity from
+//! nothing. All others load `<home>/identity.{key,json}` (auto-
+//! generating if absent). `VerificationPolicy::Strict` is the only
+//! policy used in CLI paths — no `AllowUnsigned` opt-in.
 
 mod cli;
 mod commands;
@@ -23,7 +18,9 @@ mod identity;
 mod ipc;
 mod registry;
 
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::str::FromStr;
 
 use clap::Parser;
 use uuid::Uuid;
@@ -31,18 +28,16 @@ use uuid::Uuid;
 use airc_core::PeerId;
 
 use cli::{Cli, Command};
+use identity::LocalIdentity;
 
 fn parse_peer_id(input: &str) -> Result<PeerId, Box<dyn std::error::Error>> {
-    let uuid = Uuid::parse_str(input)
-        .map_err(|error| format!("--peer-id {input:?} is not a valid UUID: {error}"))?;
+    let uuid = Uuid::from_str(input)
+        .map_err(|error| format!("--expected-peer {input:?} is not a valid UUID: {error}"))?;
     Ok(PeerId::from_uuid(uuid))
 }
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    // Install the rustls crypto provider once at process start so all
-    // TLS paths Just Work. Ignore the duplicate-install error in case
-    // a test harness installed it first.
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     let parsed = Cli::parse();
@@ -56,107 +51,73 @@ async fn main() -> ExitCode {
 }
 
 async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
-    let identity_file = parsed
-        .identity_file
-        .clone()
-        .ok_or("--identity-file or AIRC_RS_IDENTITY env var is required")?;
-
-    let parsed_peer_id = match parsed.peer_id.as_deref() {
-        Some(input) => Some(parse_peer_id(input)?),
-        None => None,
-    };
+    let home = parsed.home.clone().unwrap_or_else(cli::default_home_dir);
 
     match parsed.command {
-        Command::Init => commands::run_init(&identity_file, parsed_peer_id).map_err(Into::into),
+        Command::Init => commands::run_init(&home),
+
         Command::Send {
             wire,
             channel,
             text,
         } => {
-            let peer_id = parsed_peer_id.ok_or("--peer-id is required for send")?;
-            commands::run_send(
-                &identity_file,
-                peer_id,
-                parsed.peers,
-                &wire,
-                &channel,
-                &text,
-            )
-            .await
+            let identity = LocalIdentity::load_or_generate(&home)?;
+            commands::run_send(&identity, parsed.peers, &wire, &channel, &text).await
         }
+
         Command::Listen {
             wire,
             channel,
             replay,
         } => {
-            let peer_id = parsed_peer_id.ok_or("--peer-id is required for listen")?;
-            commands::run_listen(
-                &identity_file,
-                peer_id,
-                parsed.peers,
-                &wire,
-                channel,
-                replay,
-            )
-            .await
+            let identity = LocalIdentity::load_or_generate(&home)?;
+            commands::run_listen(&identity, parsed.peers, &wire, channel, replay).await
         }
+
         Command::LanSend {
             to,
             expected_peer,
             channel,
             text,
         } => {
-            let peer_id = parsed_peer_id.ok_or("--peer-id is required for lan-send")?;
+            let identity = LocalIdentity::load_or_generate(&home)?;
             let expected = parse_peer_id(&expected_peer)?;
-            commands::run_lan_send(
-                &identity_file,
-                peer_id,
-                parsed.peers,
-                to,
-                expected,
-                &channel,
-                &text,
-            )
-            .await
+            commands::run_lan_send(&identity, parsed.peers, to, expected, &channel, &text).await
         }
+
         Command::LanListen { bind, replay } => {
-            let peer_id = parsed_peer_id.ok_or("--peer-id is required for lan-listen")?;
-            commands::run_lan_listen(&identity_file, peer_id, parsed.peers, bind, replay).await
+            let identity = LocalIdentity::load_or_generate(&home)?;
+            commands::run_lan_listen(&identity, parsed.peers, bind, replay).await
         }
+
         Command::Daemon { socket } => {
-            let peer_id = parsed_peer_id.ok_or("--peer-id is required for daemon")?;
-            let socket = socket.unwrap_or_else(cli::default_socket_path);
-            commands::run_daemon(&identity_file, peer_id, parsed.peers, socket).await
+            let identity = LocalIdentity::load_or_generate(&home)?;
+            let socket = default_or(socket, &home);
+            commands::run_daemon(identity, parsed.peers, socket).await
         }
-        Command::Ping { socket } => {
-            let socket = socket.unwrap_or_else(cli::default_socket_path);
-            commands::run_ping(socket).await
-        }
-        Command::Status { socket } => {
-            let socket = socket.unwrap_or_else(cli::default_socket_path);
-            commands::run_status(socket).await
-        }
-        Command::Stop { socket } => {
-            let socket = socket.unwrap_or_else(cli::default_socket_path);
-            commands::run_stop(socket).await
-        }
+
+        Command::Ping { socket } => commands::run_ping(default_or(socket, &home)).await,
+        Command::Status { socket } => commands::run_status(default_or(socket, &home)).await,
+        Command::Stop { socket } => commands::run_stop(default_or(socket, &home)).await,
+
         Command::Msg {
             socket,
             wire,
             channel,
             text,
-        } => {
-            let socket = socket.unwrap_or_else(cli::default_socket_path);
-            commands::run_msg(socket, wire, &channel, &text).await
-        }
+        } => commands::run_msg(default_or(socket, &home), wire, &channel, &text).await,
+
         Command::Inbox {
             socket,
             wire,
             since_lamport,
             limit,
-        } => {
-            let socket = socket.unwrap_or_else(cli::default_socket_path);
-            commands::run_inbox(socket, wire, since_lamport, limit).await
-        }
+        } => commands::run_inbox(default_or(socket, &home), wire, since_lamport, limit).await,
     }
+}
+
+/// Resolve `--socket` override to its value, falling back to the
+/// home-derived default.
+fn default_or(explicit: Option<PathBuf>, home: &Path) -> PathBuf {
+    explicit.unwrap_or_else(|| cli::default_socket_path_in(home))
 }

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -1,10 +1,10 @@
 //! End-to-end integration test for the `airc-rs` binary.
 //!
 //! Spawns two real subprocesses (Alice + Bob), has them chat over the
-//! Rust substrate, and asserts the message arrives. This is the proof
-//! of life: no Python anywhere in the loop. If this test passes,
-//! Python `airc` has a fully functional Rust replacement for the
-//! basic chat use case.
+//! Rust substrate, and asserts the message arrives. No Python anywhere.
+//!
+//! Each subprocess uses its own `--home <dir>` so the identity state
+//! is isolated per-test and per-peer.
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
@@ -13,17 +13,16 @@ use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 
-/// Returns the path to the `airc-rs` binary cargo built for this test.
 fn airc_rs() -> &'static str {
     env!("CARGO_BIN_EXE_airc-rs")
 }
 
-/// Run `airc-rs init` and parse the printed `peer_id:` and
-/// `peer_spec:` lines from stdout.
-fn run_init(identity_file: &Path) -> (String, String) {
+/// Run `airc-rs --home <dir> init` and parse the printed `peer_id:`
+/// and `peer_spec:` lines from stdout.
+fn run_init(home: &Path) -> (String, String) {
     let output = Command::new(airc_rs())
-        .arg("--identity-file")
-        .arg(identity_file)
+        .arg("--home")
+        .arg(home)
         .arg("init")
         .output()
         .expect("airc-rs init must spawn");
@@ -50,28 +49,23 @@ fn extract_field<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
 
 #[test]
 fn two_airc_rs_processes_chat_over_local_fs() {
-    // The headline test: Alice runs `airc-rs listen`; Bob runs
-    // `airc-rs send`; Alice's stdout MUST contain the message body
-    // within a few seconds. No Python anywhere.
-    let dir = TempDir::new().expect("tempdir");
-    let alice_key = dir.path().join("alice.key");
-    let bob_key = dir.path().join("bob.key");
-    let wire = dir.path().join("wire");
+    // Alice runs `airc-rs listen`; Bob runs `airc-rs send`; Alice's
+    // stdout MUST contain the message body within a few seconds. No
+    // Python anywhere.
+    let workspace = TempDir::new().expect("tempdir");
+    let alice_home = workspace.path().join("alice");
+    let bob_home = workspace.path().join("bob");
+    let wire = workspace.path().join("wire");
 
-    let (alice_id, alice_spec) = run_init(&alice_key);
-    let (bob_id, bob_spec) = run_init(&bob_key);
+    let (_alice_id, alice_spec) = run_init(&alice_home);
+    let (_bob_id, bob_spec) = run_init(&bob_home);
 
-    // Fixed channel UUID so both sides agree.
     let channel = "11111111-2222-3333-4444-555555555555";
 
-    // Spawn Alice's listener with --replay so she sees messages sent
-    // even slightly before her subscribe completes (race-safe).
     let mut alice = Command::new(airc_rs())
         .args([
-            "--identity-file",
-            alice_key.to_str().unwrap(),
-            "--peer-id",
-            &alice_id,
+            "--home",
+            alice_home.to_str().unwrap(),
             "--peer",
             &bob_spec,
             "listen",
@@ -86,16 +80,12 @@ fn two_airc_rs_processes_chat_over_local_fs() {
         .spawn()
         .expect("alice must spawn");
 
-    // Give the listener a moment to start the tail loop.
     std::thread::sleep(Duration::from_millis(300));
 
-    // Bob sends.
     let bob_send = Command::new(airc_rs())
         .args([
-            "--identity-file",
-            bob_key.to_str().unwrap(),
-            "--peer-id",
-            &bob_id,
+            "--home",
+            bob_home.to_str().unwrap(),
             "--peer",
             &alice_spec,
             "send",
@@ -113,7 +103,6 @@ fn two_airc_rs_processes_chat_over_local_fs() {
         String::from_utf8_lossy(&bob_send.stderr)
     );
 
-    // Read Alice's stdout until we see the message or hit the timeout.
     let alice_stdout = alice.stdout.take().expect("alice stdout");
     let body_arrived = wait_for_line_contains(
         alice_stdout,
@@ -121,7 +110,6 @@ fn two_airc_rs_processes_chat_over_local_fs() {
         Duration::from_secs(6),
     );
 
-    // Clean up: kill the listener.
     let _ = alice.kill();
     let _ = alice.wait();
 
@@ -133,28 +121,24 @@ fn two_airc_rs_processes_chat_over_local_fs() {
 
 #[test]
 fn listen_rejects_unenrolled_signer() {
-    // Security guarantee through the CLI: Mallory (not in Alice's
-    // peer list) writes a signed frame to the wire. Alice's listen
-    // process should NOT print it as a happy message; instead it
-    // surfaces "verification failed" via stderr.
-    let dir = TempDir::new().expect("tempdir");
-    let alice_key = dir.path().join("alice.key");
-    let mallory_key = dir.path().join("mallory.key");
-    let wire = dir.path().join("wire");
+    // Mallory's signed frame must be rejected by Alice's listen — she
+    // isn't in Alice's peer registry. Stderr surfaces a verification
+    // failure; stdout never prints it as a happy message.
+    let workspace = TempDir::new().expect("tempdir");
+    let alice_home = workspace.path().join("alice");
+    let mallory_home = workspace.path().join("mallory");
+    let wire = workspace.path().join("wire");
 
-    let (alice_id, _alice_spec) = run_init(&alice_key);
-    let (mallory_id, mallory_spec) = run_init(&mallory_key);
+    let (_alice_id, _alice_spec) = run_init(&alice_home);
+    let (_mallory_id, mallory_spec) = run_init(&mallory_home);
 
     let channel = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 
     // Alice's peer list does NOT include Mallory.
-    // No `--peer` flags passed at all.
     let mut alice = Command::new(airc_rs())
         .args([
-            "--identity-file",
-            alice_key.to_str().unwrap(),
-            "--peer-id",
-            &alice_id,
+            "--home",
+            alice_home.to_str().unwrap(),
             "listen",
             "--wire",
             wire.to_str().unwrap(),
@@ -169,19 +153,13 @@ fn listen_rejects_unenrolled_signer() {
 
     std::thread::sleep(Duration::from_millis(300));
 
-    // Mallory sends; Mallory's registry only contains herself + Alice
-    // (so she CAN sign), but Alice's registry doesn't contain her.
+    // Mallory passes herself as `--peer` so her own registry is
+    // non-empty; her CLI signs the frame under her own identity.
     let _mallory_send = Command::new(airc_rs())
         .args([
-            "--identity-file",
-            mallory_key.to_str().unwrap(),
-            "--peer-id",
-            &mallory_id,
+            "--home",
+            mallory_home.to_str().unwrap(),
             "--peer",
-            // Mallory needs Alice in HER registry to sign — but the
-            // CLI's send only needs the sender's own identity to be
-            // enrolled (we enrol self automatically). We still pass
-            // Alice as a peer so the registry is non-empty.
             &mallory_spec,
             "send",
             "--wire",
@@ -193,9 +171,6 @@ fn listen_rejects_unenrolled_signer() {
         .output()
         .expect("mallory send must spawn");
 
-    // Read Alice's stderr — we expect a "verification failed" line.
-    // (Stdout might be empty because the listen never accepts the
-    // frame as a valid message.)
     let alice_stderr = alice.stderr.take().expect("alice stderr");
     let saw_rejection =
         wait_for_line_contains(alice_stderr, "verification failed", Duration::from_secs(6));
@@ -209,10 +184,24 @@ fn listen_rejects_unenrolled_signer() {
     );
 }
 
+#[test]
+fn rerun_init_returns_same_peer_id() {
+    // The persistence pin: `airc-rs init` must be idempotent. The
+    // second run reuses the on-disk identity rather than minting a
+    // new peer_id.
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("alice");
+    let (first_id, first_spec) = run_init(&home);
+    let (second_id, second_spec) = run_init(&home);
+    assert_eq!(first_id, second_id, "peer_id must persist across init runs");
+    assert_eq!(
+        first_spec, second_spec,
+        "peer_spec must persist across init runs"
+    );
+}
+
 /// Block until `reader` yields a line containing `needle`, or the
-/// deadline elapses. Reads byte-by-byte so we don't have to predict
-/// line boundaries; this matters because the airc-rs output is
-/// line-oriented but the test's view of stdout/stderr is a stream.
+/// deadline elapses.
 fn wait_for_line_contains<R: Read + Send + 'static>(
     reader: R,
     needle: &str,
@@ -242,10 +231,8 @@ fn wait_for_line_contains<R: Read + Send + 'static>(
     }
 }
 
-// Linker stub: silences an unused-import lint when `Write` is only
-// pulled in for trait usage. (`Write` is used implicitly by `tx.send`
-// via the channel impl; this trait import is here in case future
-// tests need it directly.)
+// Trait keepalive for `Write` — silences unused-import lints if the
+// import is otherwise only needed transitively.
 #[allow(dead_code)]
 fn _trait_keepalive(mut w: impl Write) {
     let _ = w.write(&[]);


### PR DESCRIPTION
## Summary

\`airc-rs init\` now creates a persistent identity under \`<home>\` (default \`\$HOME/.airc-rs\`). Subsequent CLI calls load it automatically. **No more \`--peer-id\` flag, no more \`--identity-file\` flag, no nil-Uuid default ambiguity.**

Per Codex's framing: persisted identity state, not just nicer flags.

## On-disk layout

```
<home>/
├── identity.key   (32-byte Ed25519 secret, 0600 on Unix)
├── identity.json  (version + peer_id + client_id + created_at_ms, 0600)
├── daemon.sock    (IPC)
└── peers.json     (next PR — persisted registry)
```

## Surface change

- **Removed:** \`--identity-file\`, \`--peer-id\`
- **Added:** \`--home <dir>\` (env \`AIRC_RS_HOME\`), default \`\$HOME/.airc-rs\`
- Socket default: \`<home>/daemon.sock\`
- Frames carry the **persisted** \`client_id\` (was: freshly generated per CLI call — broke multi-tab disambiguation)

\`VerificationPolicy::Strict\` is the only policy in CLI paths — no \`AllowUnsigned\` opt-in remains.

## Safety: refuses partial state

If \`identity.key\` exists but \`identity.json\` doesn't (or vice versa), \`load_or_generate\` returns \`IdentityError::PartialState\` rather than minting a fresh \`peer_id\` over the existing key. Silent peer-id rotation would break every peer that's already enrolled the old key.

## Test plan

- [x] \`cargo fmt -p airc-cli\` — clean
- [x] \`cargo clippy -p airc-cli --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p airc-cli\` — **25 unit + 3 e2e pass**

New tests:
- \`identity::tests::load_or_generate_creates_both_files_and_reuses_them\` — peer_id persistence
- \`identity::tests::refuses_partial_state_*\` (×2) — silent rotation prevented
- \`identity::tests::refuses_bad_key_length\` / \`refuses_unknown_schema_version\` — typed refusals
- \`identity::tests::key_and_state_files_are_owner_only_on_unix\` — 0600 pinned
- \`e2e::rerun_init_returns_same_peer_id\` — persistence at the binary surface

## Next

Persistent \`peers.json\` so \`--peer\` flags disappear too. Then mDNS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)