### PR TITLE
feat(airc-cli): cross-platform daemon — Unix sockets + Windows named pipes

### DIFF
--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/main.rs"
 airc-core = { path = "../airc-core" }
 airc-protocol = { path = "../airc-protocol" }
 airc-transport = { path = "../airc-transport" }
-clap = { version = "4", features = ["derive", "env"] }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "signal"] }
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "signal", "net", "io-util", "sync"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -17,14 +17,21 @@ use clap::{Args, Parser, Subcommand};
 use crate::registry::PeerSpec;
 
 /// Default home directory for persisted identity + IPC state.
+///
+/// Resolution order:
+///   1. `$HOME` (Unix; also Git Bash on Windows) → `<home>/.airc-rs`
+///   2. `%USERPROFILE%` (native Windows cmd / PowerShell) →
+///      `<userprofile>/.airc-rs`
+///   3. fallback to `./.airc-rs` in the current working dir
 pub fn default_home_dir() -> PathBuf {
     if let Some(home) = std::env::var_os("HOME") {
-        PathBuf::from(home).join(".airc-rs")
-    } else {
-        // No HOME — fall back to a clearly-scoped path under /tmp so
-        // accidents don't clobber real homes.
-        PathBuf::from("/tmp").join("airc-rs")
+        return PathBuf::from(home).join(".airc-rs");
     }
+    #[cfg(windows)]
+    if let Some(userprofile) = std::env::var_os("USERPROFILE") {
+        return PathBuf::from(userprofile).join(".airc-rs");
+    }
+    PathBuf::from(".airc-rs")
 }
 
 /// Default Unix socket path inside `home`.
@@ -44,8 +51,9 @@ pub fn default_socket_path_in(home: &std::path::Path) -> PathBuf {
 )]
 pub struct Cli {
     /// State directory for persisted identity + IPC socket. Default
-    /// `$HOME/.airc-rs`. Override for tests or multi-identity setups.
-    #[arg(long, env = "AIRC_RS_HOME", global = true)]
+    /// `$HOME/.airc-rs` (Unix) or `%USERPROFILE%/.airc-rs` (Windows).
+    /// Override for tests or multi-identity setups.
+    #[arg(long, global = true)]
     pub home: Option<PathBuf>,
 
     /// Ad-hoc peers to enrol for this invocation only, repeatable.

--- a/crates/airc-cli/src/daemon/server.rs
+++ b/crates/airc-cli/src/daemon/server.rs
@@ -1,23 +1,27 @@
-//! Unix socket listener + accept loop.
+//! Cross-platform IPC listener + accept loop.
 //!
 //! Each accepted connection is handled in its own task: read one
 //! request, dispatch, write one response, close. Independent
 //! connections so a slow handler doesn't block the listener.
 //!
+//! Transport varies by platform via `IpcListener`:
+//!   - Unix: Unix-domain socket at `<home>/daemon.sock`
+//!   - Windows: named pipe at `\\.\pipe\airc-rs-<home>`
+//!
 //! Shutdown: the state's `shutdown` notifier wakes the accept loop;
-//! the loop unbinds the socket file and returns. In-flight handlers
-//! complete normally.
+//! the loop runs the transport's `cleanup` (unlinks the socket file
+//! on Unix; no-op on Windows) and returns.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{UnixListener, UnixStream};
 
 use crate::daemon::handlers::dispatch;
 use crate::daemon::state::DaemonState;
 use crate::ipc::request::Request;
 use crate::ipc::response::Response;
+use crate::ipc::transport::{IpcListener, IpcStream};
 
 /// What can go wrong running the daemon.
 #[derive(Debug)]
@@ -54,12 +58,12 @@ impl From<std::io::Error> for DaemonError {
     }
 }
 
-/// Run the daemon: bind the socket, serve connections until
+/// Run the daemon: bind the IPC listener, serve connections until
 /// shutdown. Returns when the shutdown notifier fires (typically from
 /// a Stop request handler) or the listener errors.
 pub async fn run(state: Arc<DaemonState>, socket_path: PathBuf) -> Result<(), DaemonError> {
     cleanup_stale_socket(&socket_path).map_err(DaemonError::StaleSocket)?;
-    let listener = UnixListener::bind(&socket_path)?;
+    let listener = IpcListener::bind(&socket_path).await?;
 
     loop {
         tokio::select! {
@@ -68,12 +72,10 @@ pub async fn run(state: Arc<DaemonState>, socket_path: PathBuf) -> Result<(), Da
                 break;
             }
             accept = listener.accept() => {
-                let (stream, _addr) = accept?;
+                let stream = accept?;
                 let state = state.clone();
                 tokio::spawn(async move {
                     if let Err(error) = handle_connection(stream, state).await {
-                        // Surface to stderr — a real deployment can
-                        // pipe this to a log. We don't swallow.
                         eprintln!("daemon connection error: {error}");
                     }
                 });
@@ -81,24 +83,25 @@ pub async fn run(state: Arc<DaemonState>, socket_path: PathBuf) -> Result<(), Da
         }
     }
 
-    // Best-effort cleanup. Listener drop unlinks the socket file on
-    // some platforms but not all — call out the path explicitly so
-    // subsequent daemon starts don't trip on a stale file.
-    let _ = std::fs::remove_file(&socket_path);
+    // Best-effort transport cleanup. On Unix this unlinks the
+    // socket file; on Windows named pipes are GCd when handles
+    // close, so the call is a no-op.
+    listener.cleanup();
     Ok(())
 }
 
-/// If a socket file exists from a prior daemon and no process is
-/// holding it, unlink it. If a process IS holding it, the subsequent
-/// `bind` will fail with EADDRINUSE — that error propagates up so the
-/// user sees it instead of us silently stealing the socket.
+/// If the previous daemon left a stale socket file behind, unlink
+/// it. If a process is actively holding it (live daemon), bail with
+/// AddrInUse rather than silently steal the listener.
+///
+/// Unix only — named pipes on Windows don't leave a filesystem
+/// entry, so there's nothing to clean and the OS itself rejects
+/// duplicate binders.
+#[cfg(unix)]
 fn cleanup_stale_socket(path: &Path) -> std::io::Result<()> {
     if !path.exists() {
         return Ok(());
     }
-    // Try connecting; if that succeeds, the daemon is live → don't
-    // touch the file. If it fails with ConnectionRefused, the socket
-    // is stale.
     match std::os::unix::net::UnixStream::connect(path) {
         Ok(_) => Err(std::io::Error::new(
             std::io::ErrorKind::AddrInUse,
@@ -111,10 +114,18 @@ fn cleanup_stale_socket(path: &Path) -> std::io::Result<()> {
     }
 }
 
+#[cfg(not(unix))]
+fn cleanup_stale_socket(_path: &Path) -> std::io::Result<()> {
+    // Windows named pipes self-clean; duplicate-binder protection
+    // comes from `ServerOptions::first_pipe_instance(true)` set in
+    // the transport layer.
+    Ok(())
+}
+
 /// Handle one connection: read a single newline-or-EOF-terminated
 /// JSON request, dispatch, write the JSON response, close.
 async fn handle_connection(
-    mut stream: UnixStream,
+    mut stream: IpcStream,
     state: Arc<DaemonState>,
 ) -> Result<(), DaemonError> {
     let mut request_bytes = Vec::new();
@@ -136,7 +147,7 @@ async fn handle_connection(
     Ok(())
 }
 
-async fn write_response(stream: &mut UnixStream, response: &Response) -> Result<(), DaemonError> {
+async fn write_response(stream: &mut IpcStream, response: &Response) -> Result<(), DaemonError> {
     let mut payload = serde_json::to_vec(response).map_err(|error| {
         DaemonError::Io(std::io::Error::new(
             std::io::ErrorKind::InvalidData,

--- a/crates/airc-cli/src/ipc/client.rs
+++ b/crates/airc-cli/src/ipc/client.rs
@@ -13,7 +13,8 @@
 use std::path::PathBuf;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::UnixStream;
+
+use crate::ipc::transport::IpcStream;
 
 use crate::ipc::request::{AddPeerRequest, InboxRequest, Request, SendRequest, SubscribeRequest};
 use crate::ipc::response::{InboxResponse, PeersResponse, Response, StatusResponse};
@@ -78,7 +79,7 @@ impl DaemonClient {
 
     /// Generic RPC: writes `request`, reads one `Response`.
     pub async fn call(&self, request: Request) -> Result<Response, ClientError> {
-        let mut stream = UnixStream::connect(&self.socket_path)
+        let mut stream = IpcStream::connect(&self.socket_path)
             .await
             .map_err(ClientError::NotConnected)?;
 

--- a/crates/airc-cli/src/ipc/mod.rs
+++ b/crates/airc-cli/src/ipc/mod.rs
@@ -1,22 +1,26 @@
 //! IPC between the `airc-rs` CLI and the running daemon.
 //!
-//! Wire protocol = newline-delimited JSON over a Unix socket. One
-//! request per connection, one response, connection closes. Simple,
-//! debuggable, extensible — adding a new op is one variant in
-//! `Request` + one match arm in the daemon's dispatcher.
+//! Wire protocol = newline-delimited JSON over a local IPC primitive.
+//! On Unix that's a Unix-domain socket at `<home>/daemon.sock`. On
+//! Windows it's a named pipe (`\\.\pipe\airc-rs-<home>`). The
+//! `transport` module abstracts both behind one `IpcListener` /
+//! `IpcStream` API; everything above (request/response types,
+//! dispatch, handlers) stays platform-agnostic.
 //!
-//! Why not gRPC / cap'n proto / mDNS RPC: this is local-only IPC for
-//! a single-machine daemon. JSON over Unix sockets is the right
-//! amount of ceremony — typed in Rust (Request/Response enums),
-//! human-debuggable via `socat - UNIX-CONNECT:...`, and zero extra
-//! schema toolchain.
+//! Why not gRPC / cap'n proto: this is local-only IPC for a
+//! single-machine daemon. JSON over Unix sockets / named pipes is
+//! the right amount of ceremony — typed in Rust (Request/Response
+//! enums), human-debuggable, zero extra schema toolchain.
 
 pub mod client;
 pub mod request;
 pub mod response;
+pub mod transport;
 
 pub use client::DaemonClient;
 pub use request::SendRequest;
+// transport::IpcListener / IpcStream are used by daemon::server and
+// ipc::client directly via their module paths; no top-level re-export.
 
 // `ClientError`, `Request`, `Response`, `StatusResponse` are
 // accessible via their module paths for callers that want them; we

--- a/crates/airc-cli/src/ipc/transport.rs
+++ b/crates/airc-cli/src/ipc/transport.rs
@@ -1,0 +1,296 @@
+//! Cross-platform IPC primitives — Unix sockets on Unix, Windows
+//! named pipes on Windows. The daemon's accept loop and the CLI
+//! client both use `IpcListener` / `IpcStream` so the wire-protocol
+//! code stays platform-agnostic.
+//!
+//! Why typed enums instead of trait objects: tokio's `UnixStream` and
+//! `NamedPipeServer` both implement `AsyncRead + AsyncWrite` but
+//! aren't `dyn`-friendly out of the box (they want concrete reads).
+//! An enum + matching impl gives us a zero-cost dispatch without
+//! `Box<dyn ...>` ceremony, and the platform-specific arms are gated
+//! by `cfg(unix)` / `cfg(windows)` so the binary compiles on both.
+//!
+//! Path conventions:
+//!   - Unix: a filesystem path like `<home>/daemon.sock`.
+//!   - Windows: a named-pipe path like `\\.\pipe\airc-rs-daemon`. If
+//!     the caller passes a plain filesystem path, the resolver
+//!     converts it to a per-home pipe name so multiple homes can
+//!     coexist on one machine.
+
+use std::path::Path;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+/// One IPC connection — read/write the wire bytes, no protocol
+/// knowledge.
+pub enum IpcStream {
+    #[cfg(unix)]
+    Unix(tokio::net::UnixStream),
+    #[cfg(windows)]
+    WindowsServer(tokio::net::windows::named_pipe::NamedPipeServer),
+    #[cfg(windows)]
+    WindowsClient(tokio::net::windows::named_pipe::NamedPipeClient),
+}
+
+impl IpcStream {
+    /// Dial the daemon at the given path.
+    pub async fn connect(path: &Path) -> std::io::Result<Self> {
+        #[cfg(unix)]
+        {
+            tokio::net::UnixStream::connect(path)
+                .await
+                .map(IpcStream::Unix)
+        }
+        #[cfg(windows)]
+        {
+            let pipe_name = resolve_pipe_name(path);
+            tokio::net::windows::named_pipe::ClientOptions::new()
+                .open(&pipe_name)
+                .map(IpcStream::WindowsClient)
+        }
+    }
+}
+
+impl AsyncRead for IpcStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            #[cfg(unix)]
+            IpcStream::Unix(stream) => Pin::new(stream).poll_read(cx, buf),
+            #[cfg(windows)]
+            IpcStream::WindowsServer(stream) => Pin::new(stream).poll_read(cx, buf),
+            #[cfg(windows)]
+            IpcStream::WindowsClient(stream) => Pin::new(stream).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for IpcStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            #[cfg(unix)]
+            IpcStream::Unix(stream) => Pin::new(stream).poll_write(cx, buf),
+            #[cfg(windows)]
+            IpcStream::WindowsServer(stream) => Pin::new(stream).poll_write(cx, buf),
+            #[cfg(windows)]
+            IpcStream::WindowsClient(stream) => Pin::new(stream).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            #[cfg(unix)]
+            IpcStream::Unix(stream) => Pin::new(stream).poll_flush(cx),
+            #[cfg(windows)]
+            IpcStream::WindowsServer(stream) => Pin::new(stream).poll_flush(cx),
+            #[cfg(windows)]
+            IpcStream::WindowsClient(stream) => Pin::new(stream).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            #[cfg(unix)]
+            IpcStream::Unix(stream) => Pin::new(stream).poll_shutdown(cx),
+            #[cfg(windows)]
+            IpcStream::WindowsServer(stream) => Pin::new(stream).poll_shutdown(cx),
+            #[cfg(windows)]
+            IpcStream::WindowsClient(stream) => Pin::new(stream).poll_shutdown(cx),
+        }
+    }
+}
+
+/// Daemon-side listener.
+///
+/// On Unix this wraps a `UnixListener` bound to `<path>`.
+///
+/// On Windows there is no "listener" object in the Unix sense for
+/// named pipes — each call to `NamedPipeServer::create` returns one
+/// pre-allocated server instance that's waiting for a single client
+/// connection. To get accept-loop semantics we keep the bound path
+/// and re-create a fresh server instance per accept call. The first
+/// instance is created with `first_pipe_instance(true)` so two
+/// daemons trying to bind the same name surface as an OS error
+/// (matches the Unix "address in use" behavior).
+pub enum IpcListener {
+    #[cfg(unix)]
+    Unix {
+        listener: tokio::net::UnixListener,
+        path: std::path::PathBuf,
+    },
+    #[cfg(windows)]
+    Windows {
+        pipe_name: String,
+        /// The next server instance, pre-created and ready to
+        /// `.connect().await` for accept. On accept, we move it out,
+        /// `.connect()`, then create a new server instance for the
+        /// NEXT accept call. `first_pipe_instance` is only set on
+        /// the very first creation to fail loudly on duplicate
+        /// daemons.
+        next: tokio::sync::Mutex<Option<tokio::net::windows::named_pipe::NamedPipeServer>>,
+    },
+}
+
+impl IpcListener {
+    /// Bind a listener at `path`. On Unix this `bind(2)`s the socket
+    /// file; on Windows this creates the first named-pipe server
+    /// instance.
+    pub async fn bind(path: &Path) -> std::io::Result<Self> {
+        #[cfg(unix)]
+        {
+            let listener = tokio::net::UnixListener::bind(path)?;
+            Ok(IpcListener::Unix {
+                listener,
+                path: path.to_path_buf(),
+            })
+        }
+        #[cfg(windows)]
+        {
+            let pipe_name = resolve_pipe_name(path);
+            let first = tokio::net::windows::named_pipe::ServerOptions::new()
+                .first_pipe_instance(true)
+                .create(&pipe_name)?;
+            Ok(IpcListener::Windows {
+                pipe_name,
+                next: tokio::sync::Mutex::new(Some(first)),
+            })
+        }
+    }
+
+    /// Accept one connection. Returns an `IpcStream` ready for the
+    /// wire protocol.
+    pub async fn accept(&self) -> std::io::Result<IpcStream> {
+        match self {
+            #[cfg(unix)]
+            IpcListener::Unix { listener, .. } => {
+                let (stream, _addr) = listener.accept().await?;
+                Ok(IpcStream::Unix(stream))
+            }
+            #[cfg(windows)]
+            IpcListener::Windows { pipe_name, next } => {
+                // Take the pre-created server, wait for a client,
+                // then create the next server instance so subsequent
+                // accept() calls find one waiting.
+                let mut guard = next.lock().await;
+                let server = guard.take().ok_or_else(|| {
+                    std::io::Error::other("ipc listener: no next pipe instance prepared")
+                })?;
+                server.connect().await?;
+                // Prepare next instance before returning.
+                *guard =
+                    Some(tokio::net::windows::named_pipe::ServerOptions::new().create(pipe_name)?);
+                Ok(IpcStream::WindowsServer(server))
+            }
+        }
+    }
+
+    /// Best-effort cleanup of the listener's filesystem footprint.
+    /// On Unix this unlinks the socket file. On Windows named pipes
+    /// have no persistent FS entry — no-op.
+    pub fn cleanup(&self) {
+        match self {
+            #[cfg(unix)]
+            IpcListener::Unix { path, .. } => {
+                let _ = std::fs::remove_file(path);
+            }
+            #[cfg(windows)]
+            IpcListener::Windows { .. } => {
+                // Named pipes are GCd when the last handle closes.
+            }
+        }
+    }
+}
+
+/// Convert a filesystem-style path into a Windows named-pipe path.
+///
+/// If the path already looks like a pipe (`\\.\pipe\...`) it's
+/// returned as-is. Otherwise the path's last component is sanitised
+/// and prefixed: `<home>/daemon.sock` → `\\.\pipe\airc-rs-daemon-<home>`.
+/// Multiple homes get distinct pipes so concurrent daemons coexist.
+#[cfg(windows)]
+fn resolve_pipe_name(path: &Path) -> String {
+    let raw = path.to_string_lossy();
+    if raw.starts_with(r"\\.\pipe\") {
+        return raw.into_owned();
+    }
+    // Build a stable per-path pipe name. Use the immediate parent's
+    // basename + the file basename so different homes don't collide.
+    let file = path
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| "daemon".to_string());
+    let parent_tag = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| "default".to_string());
+    let sanitised = sanitise_pipe_token(&format!("{parent_tag}-{file}"));
+    format!(r"\\.\pipe\airc-rs-{sanitised}")
+}
+
+#[cfg(windows)]
+fn sanitise_pipe_token(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unix_round_trip_via_ipc_listener_and_stream() {
+        // Verify the abstraction layer carries bytes correctly on
+        // Unix (where we can actually run a listener in test). On
+        // Windows the same code path applies but isn't exercised
+        // from this CI host — gated CI on a Windows runner would
+        // cover that path.
+        let dir = TempDir::new().unwrap();
+        let socket = dir.path().join("test.sock");
+
+        let listener = IpcListener::bind(&socket).await.unwrap();
+        let socket_clone = socket.clone();
+        let server_task = tokio::spawn(async move {
+            let mut stream = listener.accept().await.unwrap();
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            let mut buf = [0u8; 5];
+            stream.read_exact(&mut buf).await.unwrap();
+            stream.write_all(b"PONG").await.unwrap();
+            stream.shutdown().await.unwrap();
+            buf
+        });
+
+        // Tiny delay for the bind/listen to settle.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let mut client = IpcStream::connect(&socket_clone).await.unwrap();
+        client.write_all(b"PINGX").await.unwrap();
+        client.shutdown().await.unwrap();
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).await.unwrap();
+
+        let received = server_task.await.unwrap();
+        assert_eq!(&received, b"PINGX");
+        assert_eq!(response, b"PONG");
+    }
+}


### PR DESCRIPTION
## Summary

airc-rs now builds + runs the daemon on **Mac, Linux, AND Windows**. The Python airc worked on Windows via Git Bash; the Rust path now runs as a native Windows binary.

## What's new

- \`ipc/transport.rs\` — \`IpcListener\` + \`IpcStream\` enum-based abstraction over Unix sockets vs Windows named pipes. Both arms implement \`AsyncRead + AsyncWrite\` so all higher layers (handlers, dispatch, client) stay platform-agnostic.
- Path conventions:
  - Unix: \`<home>/daemon.sock\`
  - Windows: \`\\.\pipe\airc-rs-<home>\` (multi-home safe via sanitised parent + filename)
- Default home directory now resolves on native Windows too:
  1. \`$HOME\` (Unix + Git Bash)
  2. \`%USERPROFILE%\` (native Windows)
  3. fallback \`./.airc-rs\`
- Cleanup logic is platform-aware: Unix unlinks the stale socket; Windows named pipes self-clean + use \`first_pipe_instance(true)\` to refuse duplicate binders.

## Dropped env-var friction

Per your "env vars are annoying and overkill" note: \`--home\` no longer reads \`AIRC_RS_HOME\`, and the clap \`env\` feature is gone from \`Cargo.toml\`. One less magic knob.

## Test plan

- [x] \`cargo fmt -p airc-cli\` — clean
- [x] \`cargo clippy -p airc-cli --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p airc-cli\` — 33 unit + 3 e2e pass (Mac)
- [x] \`cargo check -p airc-cli --target x86_64-pc-windows-gnu\` — clean (needs \`brew install mingw-w64\` for the cross-linker; not required for native Windows builds)
- [ ] Live Windows run — verified by you on a Windows machine

## Next PR

Room/channel defaults so \`airc-rs msg "hi"\` works with no flags (the parameter-hell fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)