### PR TITLE
fix(airc-transport): LAN-TCP send pre-validates payload, no silent drops

### DIFF
--- a/crates/airc-transport/src/lan_tcp/adapter/connection.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/connection.rs
@@ -87,7 +87,7 @@ async fn install_and_spawn_loops<R, W>(
     R: tokio::io::AsyncRead + Send + Unpin + 'static,
     W: tokio::io::AsyncWrite + Send + Unpin + 'static,
 {
-    let (outbound_tx, outbound_rx) = mpsc::channel::<Frame>(OUTBOUND_CHANNEL_DEPTH);
+    let (outbound_tx, outbound_rx) = mpsc::channel::<Vec<u8>>(OUTBOUND_CHANNEL_DEPTH);
     // Install synchronously — when this function returns, the
     // connection IS ready to receive sends.
     inner.connections.lock().await.insert(peer_id, outbound_tx);
@@ -138,20 +138,28 @@ where
     }
 }
 
-/// Write loop: drain the outbound channel, write framed bytes to TLS.
-async fn write_loop<W>(mut write_half: W, mut outbound_rx: mpsc::Receiver<Frame>)
+/// Write loop: drain the outbound channel, length-prefix the
+/// already-validated payload, write framed bytes to TLS.
+///
+/// The payload is pre-serialized and size-checked by
+/// `LanTcpAdapter::send` before it lands in the channel — by the
+/// time it reaches this loop the bytes are known-valid, so the
+/// only failure mode is a dead socket (which terminates the loop).
+/// No silent drops.
+async fn write_loop<W>(mut write_half: W, mut outbound_rx: mpsc::Receiver<Vec<u8>>)
 where
     W: tokio::io::AsyncWrite + Send + Unpin + 'static,
 {
-    while let Some(frame) = outbound_rx.recv().await {
-        let payload = match serde_json::to_vec(&frame) {
-            Ok(bytes) => bytes,
-            Err(_) => continue, // skip malformed frame
-        };
-        if payload.len() > MAX_FRAME_BYTES as usize {
-            // Drop oversized frames — caller should be lifting bodies.
-            continue;
-        }
+    while let Some(payload) = outbound_rx.recv().await {
+        // Defense-in-depth assertion: the sender already enforced
+        // this, but if a future regression bypasses pre-validation
+        // we'd rather fail loudly here than silently truncate.
+        debug_assert!(
+            payload.len() <= MAX_FRAME_BYTES as usize,
+            "write_loop received oversized payload ({} bytes, limit {})",
+            payload.len(),
+            MAX_FRAME_BYTES
+        );
         let len = (payload.len() as u32).to_be_bytes();
         if write_half.write_all(&len).await.is_err() {
             return;

--- a/crates/airc-transport/src/lan_tcp/adapter/inner.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/inner.rs
@@ -31,9 +31,15 @@ pub(super) const OUTBOUND_CHANNEL_DEPTH: usize = 256;
 /// Subscriber inbound channel depth — matches local-fs.
 pub(super) const SUBSCRIBER_CHANNEL_DEPTH: usize = 64;
 
-/// Active connection's sender half — write-task receives Frames from
-/// this and pushes them onto the TLS stream.
-pub(super) type OutboundTx = mpsc::Sender<Frame>;
+/// Active connection's sender half — write-task receives the
+/// serialized payload (no length prefix; the write loop adds it)
+/// from this and pushes the framed bytes onto the TLS stream.
+/// Carrying pre-validated bytes rather than `Frame` ensures
+/// `send()` can return synchronously if the frame is oversized or
+/// unserializable — no post-acceptance silent drops in the write
+/// loop. (Closes grievance §9 "Silent drop after acceptance is not
+/// acceptable" / Codex audit 2026-05-19.)
+pub(super) type OutboundTx = mpsc::Sender<Vec<u8>>;
 
 /// One subscriber's filtered inbound channel + matching predicate.
 pub(super) struct SubscriberHandle {

--- a/crates/airc-transport/src/lan_tcp/adapter/mod.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/mod.rs
@@ -54,7 +54,7 @@ use airc_protocol::{Frame, PeerKeyRegistry, PeerKeypair, Subscription};
 
 use crate::lan_tcp::adapter::connection::{handle_client_connection, handle_server_connection};
 use crate::lan_tcp::adapter::inner::{
-    Inner, OutboundTx, SubscriberHandle, SUBSCRIBER_CHANNEL_DEPTH,
+    Inner, OutboundTx, SubscriberHandle, MAX_FRAME_BYTES, SUBSCRIBER_CHANNEL_DEPTH,
 };
 use crate::lan_tcp::tls_config::{build_client_config, build_server_config};
 use crate::transport::{FrameStream, Transport};
@@ -200,6 +200,19 @@ impl Transport for LanTcpAdapter {
     type Error = LanTcpError;
 
     async fn send(&self, frame: Frame) -> Result<(), Self::Error> {
+        // Pre-validate BEFORE enqueueing so any failure (serialize
+        // error, oversized payload) returns synchronously rather
+        // than being silently dropped by the write loop after the
+        // caller already saw Ok. Grievance §9: `send()` must mean
+        // something measurable.
+        let payload = serde_json::to_vec(&frame)?;
+        if payload.len() > MAX_FRAME_BYTES as usize {
+            return Err(LanTcpError::FrameTooLarge {
+                announced: u32::try_from(payload.len()).unwrap_or(u32::MAX),
+                limit: MAX_FRAME_BYTES,
+            });
+        }
+
         // Snapshot under lock, drop, dispatch — never hold the
         // connections mutex across awaits.
         let targets: Vec<(PeerId, OutboundTx)> = {
@@ -220,7 +233,7 @@ impl Transport for LanTcpAdapter {
         let mut delivered_any = false;
         let mut last_error: Option<LanTcpError> = None;
         for (_peer, tx) in targets {
-            match tx.send(frame.clone()).await {
+            match tx.send(payload.clone()).await {
                 Ok(()) => delivered_any = true,
                 Err(_closed) => {
                     last_error = Some(LanTcpError::NoActivePeers);
@@ -503,5 +516,52 @@ mod tests {
         let channel = RoomId::from_u128(0xc0ffee);
         let result = alice.send(frame_at(1, channel, "into the void")).await;
         assert!(matches!(result, Err(LanTcpError::NoActivePeers)));
+    }
+
+    #[tokio::test]
+    async fn send_oversized_frame_returns_err_synchronously_without_dispatch() {
+        // The defensible proof for grievance §9 / "no post-acceptance
+        // silent drops": when the frame's serialized form exceeds the
+        // per-frame size cap, `send()` must surface `FrameTooLarge`
+        // *before* enqueueing — so the caller learns about the
+        // failure rather than seeing Ok and never observing the drop
+        // on the wire. The bob-side never receives the frame.
+        let (alice_id, alice, bob_id, bob) = make_paired_adapters();
+        let bound = alice
+            .listen(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+        bob.connect(bound, alice_id).await.unwrap();
+
+        let mut bob_stream = bob.subscribe(Subscription::default()).await.unwrap();
+
+        // Build a frame whose serialized JSON is guaranteed past the
+        // 16 MiB cap: a 17 MiB ASCII body alone exceeds the limit.
+        let oversized_body = "a".repeat((MAX_FRAME_BYTES as usize) + 1024 * 1024);
+        let channel = RoomId::from_u128(0xc0ffee);
+        let huge_frame = frame_at(1, channel, &oversized_body);
+
+        let send_result = alice.send(huge_frame).await;
+        assert!(
+            matches!(
+                send_result,
+                Err(LanTcpError::FrameTooLarge { announced, limit })
+                    if announced > limit && limit == MAX_FRAME_BYTES
+            ),
+            "expected FrameTooLarge with announced > limit, got {send_result:?}"
+        );
+
+        // Cross-check: bob's subscriber must not see the frame
+        // (because send() rejected it before enqueueing). Give the
+        // network a generous tick to surface anything in flight.
+        let bob_saw = tokio::time::timeout(Duration::from_millis(200), bob_stream.next()).await;
+        assert!(
+            bob_saw.is_err(),
+            "bob must not have received an oversized frame on the wire — got {bob_saw:?}"
+        );
+
+        // peer_id parameter is otherwise unused but the assertion is
+        // here to make the test's intent obvious in the diff.
+        let _ = bob_id;
     }
 }


### PR DESCRIPTION
## Work intake (per operating control board)

- **Grievance:** §9 — LAN-TCP Still Has Delivery Gaps (\"write loop can drop oversized/serialization-failed frames after \`send()\` accepted them into the channel\")
- **Gap:** Rust Runtime Gaps — \"measurable send outcome\" / \"no silent fallback policy\"
- **Acceptance gate:** Gate 1 (Rust Hot Path) — \`send()\` semantics
- **Python/shell impact:** untouched
- **Branch:** \`feat/lan-tcp-send-correctness\` off \`rust-rewrite\`, short-lived
- **Proof:** \`send_oversized_frame_returns_err_synchronously_without_dispatch\` — builds a 17 MiB-body frame, asserts \`send()\` returns \`Err(FrameTooLarge)\` synchronously AND the subscriber never observes the frame on the wire.

## What changed

- Outbound channel type: \`mpsc::Sender<Frame>\` → \`mpsc::Sender<Vec<u8>>\`. Pre-serialized, pre-validated bytes only.
- \`LanTcpAdapter::send\`: serializes once, checks against \`MAX_FRAME_BYTES\` (16 MiB), returns \`Err\` synchronously on oversize or serialization failure. Then enqueues the bytes.
- Write loop: receives bytes, length-prefixes, writes. No \`continue\` on validation failure (validation is upstream now). \`debug_assert!\` guards against future regression.
- Error variants reused: existing \`LanTcpError::FrameTooLarge { announced, limit }\` (previously used only on inbound length-prefix check) now also surfaces oversize sends. \`LanTcpError::Json\` covers serialization failure.

## Test plan

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --workspace --all-features\` — airc-transport 36 (was 35, +1 new), all other crates unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)