### PR TITLE
feat(airc-daemon): wire airc-store as the inbox backing (slice 5b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "airc-core",
  "airc-daemon",
  "airc-protocol",
+ "airc-store",
  "airc-transport",
  "base64",
  "clap",
@@ -56,6 +57,7 @@ version = "0.1.0"
 dependencies = [
  "airc-core",
  "airc-protocol",
+ "airc-store",
  "airc-transport",
  "async-trait",
  "base64",

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -14,6 +14,7 @@ airc-core = { path = "../airc-core" }
 airc-protocol = { path = "../airc-protocol" }
 airc-transport = { path = "../airc-transport" }
 airc-daemon = { path = "../airc-daemon" }
+airc-store = { path = "../airc-store" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "signal", "net", "io-util", "sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -156,8 +156,14 @@ pub enum Command {
     Inbox {
         #[arg(long)]
         socket: Option<PathBuf>,
-        #[arg(long)]
+        /// Cursor lamport — pair with `--since-event-id`. The cursor
+        /// is `(lamport, event_id)`; both halves required when paging
+        /// from a specific point.
+        #[arg(long, requires = "since_event_id")]
         since_lamport: Option<u64>,
+        /// Cursor event_id (UUID) — pair with `--since-lamport`.
+        #[arg(long, requires = "since_lamport")]
+        since_event_id: Option<String>,
         #[arg(long)]
         limit: Option<usize>,
     },

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -23,6 +23,7 @@ use airc_daemon::{
     peers_store, run as run_daemon_server, AddPeerRequest, DaemonClient, DaemonState, InboxRequest,
     SendRequest, SubscribeRequest,
 };
+use airc_store::{EventStore, SqliteEventStore};
 
 use crate::identity::LocalIdentity;
 use crate::registry::{format_peer_spec, PeerSpec};
@@ -219,12 +220,20 @@ pub async fn run_daemon(
         }
     }
 
+    // The durable event store lives under `<home>/events.sqlite`.
+    // Migrations are applied on open; consumers that subscribed
+    // before the daemon was last restarted can resume from the
+    // same `(lamport, event_id)` cursor on next boot.
+    let store_path = home.join("events.sqlite");
+    let store_url = format!("sqlite://{}?mode=rwc", store_path.display());
+    let store: Arc<dyn EventStore> = Arc::new(SqliteEventStore::open(&store_url).await?);
     let state = Arc::new(DaemonState::new(
         identity.peer_id,
         identity.keypair,
         registry,
         VerificationPolicy::Strict,
         home.to_path_buf(),
+        store,
     ));
     println!(
         "airc-rs daemon: peer_id={} listening on {}",
@@ -282,6 +291,7 @@ pub async fn run_inbox(
     home: &Path,
     socket: PathBuf,
     since_lamport: Option<u64>,
+    since_event_id: Option<String>,
     limit: Option<usize>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let current = room::load_or_default(home)?;
@@ -291,25 +301,48 @@ pub async fn run_inbox(
             wire: current.wire.clone(),
         })
         .await?;
+    // Both --since-lamport and --since-event-id must be supplied
+    // together; the cursor is a tuple per grievance §7.
+    let since = match (since_lamport, since_event_id) {
+        (Some(lamport), Some(ref ev)) => Some(TranscriptCursor {
+            lamport,
+            event_id: EventId::from_uuid(uuid::Uuid::parse_str(ev)?),
+        }),
+        (None, None) => None,
+        _ => {
+            return Err(
+                "--since-lamport and --since-event-id must be passed together (cursor is a tuple)"
+                    .into(),
+            );
+        }
+    };
     let inbox = client
         .inbox(InboxRequest {
-            wire: current.wire,
-            since_lamport,
+            since,
+            channel: Some(current.channel),
             limit,
         })
         .await?;
-    if inbox.frames.is_empty() {
-        println!("(no new frames; newest_lamport={})", inbox.newest_lamport);
+    if inbox.events.is_empty() {
+        match &inbox.newest {
+            Some(c) => println!(
+                "(no new events; cursor lamport={} event_id={})",
+                c.lamport, c.event_id
+            ),
+            None => println!("(no events yet — store is empty)"),
+        }
         return Ok(());
     }
-    for frame in &inbox.frames {
-        print_frame(frame);
+    for event in &inbox.events {
+        print_event(event);
     }
-    println!();
-    println!(
-        "newest_lamport={} — pass as --since-lamport on the next call",
-        inbox.newest_lamport
-    );
+    if let Some(cursor) = inbox.newest {
+        println!();
+        println!(
+            "cursor: lamport={} event_id={} — pass both as --since-lamport / --since-event-id",
+            cursor.lamport, cursor.event_id
+        );
+    }
     Ok(())
 }
 
@@ -395,6 +428,20 @@ fn print_frame(frame: &Frame) {
         kind = frame.kind,
         sender = frame.envelope.sender,
         channel = frame.envelope.channel,
+    );
+}
+
+fn print_event(event: &airc_core::TranscriptEvent) {
+    let text = event
+        .body
+        .as_ref()
+        .and_then(Body::as_text)
+        .unwrap_or("<non-text body>");
+    println!(
+        "[{kind:?}] {sender} → {channel}: {text}",
+        kind = event.kind,
+        sender = event.peer_id,
+        channel = event.room_id,
     );
 }
 

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -97,8 +97,18 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::Inbox {
             socket,
             since_lamport,
+            since_event_id,
             limit,
-        } => commands::run_inbox(&home, default_or(socket, &home), since_lamport, limit).await,
+        } => {
+            commands::run_inbox(
+                &home,
+                default_or(socket, &home),
+                since_lamport,
+                since_event_id,
+                limit,
+            )
+            .await
+        }
 
         Command::Room { name, wire } => commands::run_room(&home, name, wire),
 

--- a/crates/airc-daemon/Cargo.toml
+++ b/crates/airc-daemon/Cargo.toml
@@ -18,6 +18,7 @@ publish = false
 [dependencies]
 airc-core = { path = "../airc-core" }
 airc-protocol = { path = "../airc-protocol" }
+airc-store = { path = "../airc-store" }
 airc-transport = { path = "../airc-transport" }
 
 async-trait = "0.1"

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -48,20 +48,16 @@ pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
 }
 
 async fn handle_subscribe(state: Arc<DaemonState>, sub: SubscribeRequest) -> Response {
-    // Idempotent: if the inbox already exists, the subscriber task is
-    // already draining frames into it. Return Ok without spawning a
-    // duplicate.
-    if state.has_inbox(&sub.wire).await {
+    // Idempotent: if a subscriber task is already running for this
+    // wire, return Ok without spawning a duplicate.
+    if !state.register_subscriber(&sub.wire).await {
         return Response::Ok;
     }
 
-    // Create the inbox buffer + spawn the drain task.
-    let buffer = state.inbox_for(&sub.wire).await;
     let transport = state.local_fs_for(&sub.wire).await;
     let subscription = Subscription {
-        // Replay from the start of the wire — buffer captures
-        // pre-existing frames so an inbox call seconds later still
-        // sees them.
+        // Replay from the start of the wire — late `Inbox` calls
+        // still see pre-existing frames via the store.
         from_cursor: Some(TranscriptCursor {
             lamport: 0,
             event_id: EventId::from_u128(0),
@@ -78,15 +74,23 @@ async fn handle_subscribe(state: Arc<DaemonState>, sub: SubscribeRequest) -> Res
         }
     };
 
-    let buffer_for_task = buffer.clone();
+    let store = state.event_store.clone();
     tokio::spawn(async move {
         while let Some(item) = stream.next().await {
             match item {
                 Ok(frame) => {
-                    buffer_for_task.lock().await.push(frame);
+                    let event = frame.into_transcript_event();
+                    if let Err(err) = store.append(event).await {
+                        // Persistence failures are loud. Most likely
+                        // a duplicate replay (DuplicateEventId), which
+                        // is benign for replay-style subscriptions.
+                        // Anything else (Database, Migration, Codec)
+                        // surfaces here so the operator sees it.
+                        eprintln!("daemon subscriber: store append failed: {err}");
+                    }
                 }
                 Err(_verify_error) => {
-                    // Verification failure — don't buffer.
+                    // Verification failure — don't persist.
                     // Future: surface a counter in Status response.
                 }
             }
@@ -97,32 +101,30 @@ async fn handle_subscribe(state: Arc<DaemonState>, sub: SubscribeRequest) -> Res
 }
 
 async fn handle_inbox(state: Arc<DaemonState>, request: InboxRequest) -> Response {
-    let Some(buffer) = state.inboxes.lock().await.get(&request.wire).cloned() else {
-        // No subscription on this wire — return empty inbox rather
-        // than an error so clients can call Inbox before Subscribe
-        // without an awkward warmup race.
-        return Response::Inbox(InboxResponse {
-            frames: Vec::new(),
-            newest_lamport: request.since_lamport.unwrap_or(0),
-        });
-    };
-    let buffer = buffer.lock().await;
     let limit = request.limit.unwrap_or(INBOX_DEFAULT_LIMIT);
-    let frames = buffer.since(request.since_lamport, limit);
-    // newest_lamport in the response is the max we return so the
-    // client can hand it back as since_lamport next time. If we
-    // returned no frames, echo the input cursor so the client doesn't
-    // restart from 0.
-    let newest_lamport = frames
-        .iter()
-        .map(|f| f.envelope.lamport)
-        .max()
-        .or(request.since_lamport)
-        .unwrap_or_else(|| buffer.newest_lamport());
-    Response::Inbox(InboxResponse {
-        frames,
-        newest_lamport,
-    })
+    let events = match request.since.as_ref() {
+        Some(cursor) => {
+            state
+                .event_store
+                .resume_from(cursor, request.channel, limit)
+                .await
+        }
+        None => state.event_store.page_recent(request.channel, limit).await,
+    };
+    let events = match events {
+        Ok(events) => events,
+        Err(err) => {
+            return Response::Error {
+                message: format!("inbox: {err}"),
+            };
+        }
+    };
+    // Newest cursor in the response is the cursor of the last event
+    // returned, so the client can hand it back as `since` next time.
+    // Empty page: return None so the caller knows to keep its existing
+    // cursor rather than reset to 0.
+    let newest = events.last().map(|e| e.cursor());
+    Response::Inbox(InboxResponse { events, newest })
 }
 
 async fn handle_send(state: Arc<DaemonState>, send: SendRequest) -> Response {
@@ -246,12 +248,15 @@ mod tests {
         // Keep the TempDir alive for the test's lifetime by leaking
         // it. (This is a unit-test pattern: cheap, predictable.)
         std::mem::forget(home);
+        let store: Arc<dyn airc_store::EventStore> =
+            Arc::new(airc_store::InMemoryEventStore::new());
         Arc::new(DaemonState::new(
             peer_id,
             keypair,
             registry,
             VerificationPolicy::Strict,
             home_path,
+            store,
         ))
     }
 

--- a/crates/airc-daemon/src/ipc/request.rs
+++ b/crates/airc-daemon/src/ipc/request.rs
@@ -32,10 +32,10 @@ pub enum Request {
     /// wire. Idempotent — repeated calls return Ok without
     /// duplicating subscriptions.
     Subscribe(SubscribeRequest),
-    /// Read buffered frames from the daemon's inbox for `wire`.
-    /// Returns frames strictly after `since_lamport` (if provided),
-    /// up to `limit`. Pass back the response's newest_lamport on the
-    /// next call to keep the stream "consume-once".
+    /// Read events from the daemon's durable event store, strictly
+    /// after `since` (a `(lamport, event_id)` cursor) and optionally
+    /// filtered to a single channel. Pass back the response's
+    /// `newest` cursor on the next call for consume-once streaming.
     Inbox(InboxRequest),
     /// Graceful shutdown. Daemon completes in-flight requests, then
     /// stops accepting new connections + exits.
@@ -53,13 +53,19 @@ pub struct SubscribeRequest {
 /// Parameters for `Inbox`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InboxRequest {
-    /// Wire directory the daemon should pull buffered frames from.
-    pub wire: std::path::PathBuf,
-    /// Return only frames whose lamport > this value. `None` means
-    /// "everything in the buffer."
+    /// Return only events strictly after this cursor. `None` means
+    /// "give me the most recent events available."
+    ///
+    /// Cursor is `(lamport, event_id)` per grievance §7 — lamport is
+    /// the primary order, event_id is the deterministic tiebreaker.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub since_lamport: Option<u64>,
-    /// Max frames to return in this batch. `None` defaults to a
+    pub since: Option<airc_core::TranscriptCursor>,
+    /// Restrict to events on this channel (room). `None` means "any
+    /// channel" — used when the caller wants global tail rather than
+    /// per-room paging.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<airc_core::RoomId>,
+    /// Max events to return in this batch. `None` defaults to a
     /// reasonable cap (32) so a slow client doesn't pull megabytes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,

--- a/crates/airc-daemon/src/ipc/response.rs
+++ b/crates/airc-daemon/src/ipc/response.rs
@@ -4,7 +4,6 @@
 use serde::{Deserialize, Serialize};
 
 use airc_core::PeerId;
-use airc_protocol::Frame;
 
 /// One response to a `Request`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -52,15 +51,19 @@ pub struct PeersResponse {
     pub peers: Vec<PeerEntry>,
 }
 
-/// Result of an `Inbox` pull: frames + the lamport to feed back as
-/// `since_lamport` on the next call.
+/// Result of an `Inbox` pull: events + the cursor to feed back as
+/// `since` on the next call. Returned events are oldest → newest
+/// within the page.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InboxResponse {
-    /// Up to `limit` frames matching the request, lamport-ascending.
-    pub frames: Vec<Frame>,
-    /// Largest lamport in `frames`, or `since_lamport` echoed back if
-    /// the call returned no frames. Pass this on the next call.
-    pub newest_lamport: u64,
+    /// Up to `limit` events matching the request, in transcript
+    /// order `(lamport asc, event_id asc)`.
+    pub events: Vec<airc_core::TranscriptEvent>,
+    /// Cursor of the newest event in `events`. `None` when the page
+    /// was empty — in that case the caller's `since` is still the
+    /// authoritative position to feed back on the next poll.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub newest: Option<airc_core::TranscriptCursor>,
 }
 
 #[cfg(test)]

--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -193,12 +193,15 @@ mod tests {
         let home = tempfile::TempDir::new().unwrap();
         let home_path = home.path().to_path_buf();
         std::mem::forget(home);
+        let store: Arc<dyn airc_store::EventStore> =
+            Arc::new(airc_store::InMemoryEventStore::new());
         Arc::new(DaemonState::new(
             peer_id,
             keypair,
             registry,
             VerificationPolicy::Strict,
             home_path,
+            store,
         ))
     }
 
@@ -296,34 +299,34 @@ mod tests {
             .await
             .unwrap();
 
-        // Inbox MAY need a brief moment to drain the new frame from
-        // the subscription into the buffer.
+        // Inbox MAY need a brief moment for the subscriber task to
+        // drain the new frame from the wire's tail loop into the
+        // event store.
         let mut attempts = 0;
         let inbox = loop {
             let response = client
                 .inbox(InboxRequest {
-                    wire: wire.clone(),
-                    since_lamport: None,
+                    since: None,
+                    channel: None,
                     limit: None,
                 })
                 .await
                 .unwrap();
-            if !response.frames.is_empty() {
+            if !response.events.is_empty() {
                 break response;
             }
             attempts += 1;
             if attempts > 20 {
                 panic!(
-                    "inbox never saw the sent frame (attempts={attempts}, newest_lamport={})",
-                    response.newest_lamport
+                    "inbox never saw the sent event (attempts={attempts}, newest={:?})",
+                    response.newest
                 );
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         };
-        assert_eq!(inbox.frames.len(), 1);
+        assert_eq!(inbox.events.len(), 1);
         assert_eq!(
-            inbox.frames[0]
-                .envelope
+            inbox.events[0]
                 .body
                 .as_ref()
                 .and_then(airc_core::Body::as_text)
@@ -331,18 +334,19 @@ mod tests {
             "hello from daemon"
         );
 
-        // newest_lamport should let us "advance past" — second inbox
-        // call returns empty.
+        // `newest` cursor should let us "advance past" — second
+        // inbox call returns empty.
+        let cursor = inbox.newest.clone().unwrap();
         let after = client
             .inbox(InboxRequest {
-                wire: wire.clone(),
-                since_lamport: Some(inbox.newest_lamport),
+                since: Some(cursor),
+                channel: None,
                 limit: None,
             })
             .await
             .unwrap();
         assert!(
-            after.frames.is_empty(),
+            after.events.is_empty(),
             "after the cursor, inbox must be empty"
         );
 

--- a/crates/airc-daemon/src/state.rs
+++ b/crates/airc-daemon/src/state.rs
@@ -1,12 +1,18 @@
 //! Daemon's shared state — peer identity, registry, owned transports,
-//! shutdown notifier.
+//! event store, shutdown notifier.
 //!
 //! `DaemonState` is constructed once at startup and passed (via Arc)
 //! to every per-connection handler. Handlers read fields directly;
 //! the substrate enforces its own internal locking (e.g.
 //! `PeerKeyRegistry` is wrapped in `Arc<RwLock>`).
+//!
+//! Slice 5b: the per-wire `InboxBuffer` ring is gone. Subscribers now
+//! convert each received `Frame` into a `TranscriptEvent` and append
+//! to the shared [`EventStore`]; `Inbox` requests query the store via
+//! cursor + channel filter. Closes grievance §7 (stronger cursor
+//! semantics + no cross-room leakage).
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -15,63 +21,13 @@ use std::time::Instant;
 use tokio::sync::{Mutex, Notify};
 
 use airc_core::PeerId;
-use airc_protocol::{Frame, PeerKeyRegistry, PeerKeypair, VerificationPolicy};
+use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
+use airc_store::EventStore;
 use airc_transport::{LocalFsAdapter, SignedTransport};
 
-/// Default ring-buffer capacity per wire — recent N frames kept in
-/// memory for `Inbox` pulls. Tuned to ~chat-cadence retention; can be
-/// promoted to a config field later.
-pub const DEFAULT_INBOX_CAPACITY: usize = 1024;
-
-/// Bounded ring buffer of recently-received frames for one wire.
-/// Subscribers push into the buffer; `Inbox` requests read from it.
-#[derive(Debug)]
-pub struct InboxBuffer {
-    frames: VecDeque<Frame>,
-    capacity: usize,
-}
-
-impl InboxBuffer {
-    pub fn new(capacity: usize) -> Self {
-        Self {
-            frames: VecDeque::with_capacity(capacity),
-            capacity,
-        }
-    }
-
-    /// Append a frame, dropping the oldest if at capacity.
-    pub fn push(&mut self, frame: Frame) {
-        if self.frames.len() >= self.capacity {
-            self.frames.pop_front();
-        }
-        self.frames.push_back(frame);
-    }
-
-    /// Return frames with `lamport > since`, lamport-ascending, up
-    /// to `limit`.
-    pub fn since(&self, since: Option<u64>, limit: usize) -> Vec<Frame> {
-        let cutoff = since.unwrap_or(0);
-        self.frames
-            .iter()
-            .filter(|frame| since.is_none() || frame.envelope.lamport > cutoff)
-            .take(limit)
-            .cloned()
-            .collect()
-    }
-
-    /// Largest lamport in the buffer (or 0 if empty).
-    pub fn newest_lamport(&self) -> u64 {
-        self.frames
-            .iter()
-            .map(|f| f.envelope.lamport)
-            .max()
-            .unwrap_or(0)
-    }
-}
-
 /// Everything a daemon needs at runtime. Cheap to clone via Arc; the
-/// underlying handles (registry, transports) do their own interior
-/// locking.
+/// underlying handles (registry, transports, store) do their own
+/// interior locking.
 pub struct DaemonState {
     pub peer_id: PeerId,
     pub keypair: PeerKeypair,
@@ -86,21 +42,30 @@ pub struct DaemonState {
     /// opened on first `Send` referencing the wire so daemons that
     /// never send don't allocate state.
     pub local_fs_transports: Mutex<HashMap<PathBuf, Arc<SignedTransport<LocalFsAdapter>>>>,
-    /// One inbox ring buffer per wire — populated by the daemon's
-    /// background subscriber task. `Subscribe` requests create the
-    /// task on first call (idempotent).
-    pub inboxes: Mutex<HashMap<PathBuf, Arc<Mutex<InboxBuffer>>>>,
+    /// Durable event store backing `Inbox` queries. Subscribers
+    /// convert received frames to `TranscriptEvent` and append here;
+    /// handlers query via `resume_from(cursor)` with channel filter.
+    pub event_store: Arc<dyn EventStore>,
+    /// Tracks which wires have an active subscriber task. `Subscribe`
+    /// is idempotent — repeated calls find the wire here and skip
+    /// the spawn.
+    pub subscribed_wires: Mutex<HashMap<PathBuf, ()>>,
     /// Notified when the daemon should stop accepting + exit cleanly.
     pub shutdown: Notify,
 }
 
 impl DaemonState {
+    /// Construct a state with the given event store. The store is the
+    /// durable backing for transcript reads; callers that don't need
+    /// persistence (in-process tests) can pass an
+    /// `airc_store::InMemoryEventStore`.
     pub fn new(
         peer_id: PeerId,
         keypair: PeerKeypair,
         registry: Arc<RwLock<PeerKeyRegistry>>,
         policy: VerificationPolicy,
         home: PathBuf,
+        event_store: Arc<dyn EventStore>,
     ) -> Self {
         Self {
             peer_id,
@@ -110,30 +75,29 @@ impl DaemonState {
             home,
             started_at: Instant::now(),
             local_fs_transports: Mutex::new(HashMap::new()),
-            inboxes: Mutex::new(HashMap::new()),
+            event_store,
+            subscribed_wires: Mutex::new(HashMap::new()),
             shutdown: Notify::new(),
         }
     }
 
-    /// Get-or-create the inbox buffer for a wire. The caller is
-    /// responsible for ensuring a subscriber task is pushing into it
-    /// (`ensure_inbox_subscriber`).
-    pub async fn inbox_for(&self, wire: &std::path::Path) -> Arc<Mutex<InboxBuffer>> {
-        let key = wire.to_path_buf();
-        let mut inboxes = self.inboxes.lock().await;
-        if let Some(existing) = inboxes.get(&key) {
-            return existing.clone();
-        }
-        let buffer = Arc::new(Mutex::new(InboxBuffer::new(DEFAULT_INBOX_CAPACITY)));
-        inboxes.insert(key, buffer.clone());
-        buffer
+    /// True if a subscriber task is already running for `wire`. The
+    /// `Subscribe` handler uses this to keep the call idempotent —
+    /// repeated subscribes don't spawn duplicate drain tasks.
+    pub async fn has_subscriber(&self, wire: &std::path::Path) -> bool {
+        self.subscribed_wires.lock().await.contains_key(wire)
     }
 
-    /// True if a subscriber task is already running for `wire`.
-    /// The handler uses this to keep `Subscribe` idempotent — repeated
-    /// calls don't spawn additional drain tasks.
-    pub async fn has_inbox(&self, wire: &std::path::Path) -> bool {
-        self.inboxes.lock().await.contains_key(wire)
+    /// Mark a wire as having an active subscriber task. Returns true
+    /// if this call was the first to claim the wire, false if a task
+    /// was already registered.
+    pub async fn register_subscriber(&self, wire: &std::path::Path) -> bool {
+        let mut subs = self.subscribed_wires.lock().await;
+        if subs.contains_key(wire) {
+            return false;
+        }
+        subs.insert(wire.to_path_buf(), ());
+        true
     }
 
     /// Get-or-create a SignedTransport<LocalFsAdapter> for the given

--- a/crates/airc-protocol/src/lib.rs
+++ b/crates/airc-protocol/src/lib.rs
@@ -27,6 +27,7 @@ pub mod media;
 pub mod policy;
 pub mod signature;
 pub mod subscription;
+pub mod transcript_conv;
 
 // Re-exports — the stable public API surface.
 

--- a/crates/airc-protocol/src/transcript_conv.rs
+++ b/crates/airc-protocol/src/transcript_conv.rs
@@ -1,0 +1,175 @@
+//! Convert a wire-level `Frame` into the canonical `TranscriptEvent`.
+//!
+//! This is the substrate's persistence boundary: `Frame` is what the
+//! transport carries; `TranscriptEvent` is what gets durably stored
+//! and replayed via the event store. The conversion is total — every
+//! Frame can be turned into a TranscriptEvent — but it deliberately
+//! drops signatures (verified upstream by `SignedTransport`; not part
+//! of the durable record) and reply-to (re-projected into headers if
+//! callers need it).
+//!
+//! Lives in airc-protocol rather than airc-core because the function
+//! body touches `Frame`, and Frame lives here.
+
+use airc_core::transcript::{TranscriptEvent, TranscriptKind};
+use serde_json::Value as JsonValue;
+
+use crate::envelope::{Frame, FrameKind};
+
+impl Frame {
+    /// Convert this frame into a `TranscriptEvent` for durable storage.
+    ///
+    /// Mapping rules:
+    ///   - `event_id`, `sender → peer_id`, `sender_client → client_id`,
+    ///     `channel → room_id`, `target`, `lamport`, `occurred_at_ms`,
+    ///     `headers`, `body` are 1:1.
+    ///   - `FrameKind::Message → TranscriptKind::Message`.
+    ///   - `FrameKind::Event → TranscriptKind::System` (no direct
+    ///     transcript equivalent; system-kind preserves it as an
+    ///     auditable record without claiming it's a chat message).
+    ///   - `FrameKind::Control → TranscriptKind::SessionControl`.
+    ///   - `signature` is dropped — verified before persistence; the
+    ///     store doesn't need it again.
+    ///   - `reply_to` is projected into `metadata["airc.reply_to"]`
+    ///     so consumers can recover it without losing data.
+    ///   - `media` is preserved in `metadata["airc.media"]` as a JSON
+    ///     array (full attachment carry-through is a follow-up; we
+    ///     don't drop the data, we just don't promote it to the
+    ///     `attachment` field yet).
+    pub fn into_transcript_event(self) -> TranscriptEvent {
+        let Frame { kind, envelope } = self;
+        let kind = match kind {
+            FrameKind::Message => TranscriptKind::Message,
+            FrameKind::Event => TranscriptKind::System,
+            FrameKind::Control => TranscriptKind::SessionControl,
+        };
+
+        let mut metadata = serde_json::Map::new();
+        if let Some(reply_to) = envelope.reply_to {
+            metadata.insert(
+                "airc.reply_to".to_string(),
+                serde_json::to_value(reply_to).unwrap_or(JsonValue::Null),
+            );
+        }
+        if !envelope.media.is_empty() {
+            metadata.insert(
+                "airc.media".to_string(),
+                serde_json::to_value(&envelope.media).unwrap_or(JsonValue::Null),
+            );
+        }
+
+        TranscriptEvent {
+            event_id: envelope.event_id,
+            room_id: envelope.channel,
+            peer_id: envelope.sender,
+            client_id: envelope.sender_client,
+            kind,
+            occurred_at_ms: envelope.occurred_at_ms,
+            lamport: envelope.lamport,
+            target: envelope.target,
+            headers: envelope.headers,
+            body: envelope.body,
+            attachment: None,
+            receipt: None,
+            metadata: JsonValue::Object(metadata),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{Envelope, FrameKind};
+    use crate::signature::Signature;
+    use airc_core::{
+        body::Body, headers::Headers, transcript::MentionTarget, ClientId, EventId, PeerId, RoomId,
+    };
+
+    fn message_frame() -> Frame {
+        Frame {
+            kind: FrameKind::Message,
+            envelope: Envelope {
+                event_id: EventId::from_u128(0x01),
+                sender: PeerId::from_u128(0xa1),
+                sender_client: ClientId::from_u128(0xc1),
+                channel: RoomId::from_u128(0xc0ffee),
+                target: MentionTarget::All,
+                lamport: 7,
+                occurred_at_ms: 1_700_000_000_000,
+                reply_to: None,
+                headers: Headers::new(),
+                body: Some(Body::text("hi")),
+                media: Vec::new(),
+                signature: Signature::Unsigned,
+            },
+        }
+    }
+
+    #[test]
+    fn message_frame_round_trips_into_transcript_event() {
+        // The minimum-viable contract: all identity, ordering, and
+        // body fields survive the boundary.
+        let frame = message_frame();
+        let expected = frame.envelope.clone();
+        let event = frame.into_transcript_event();
+        assert_eq!(event.event_id, expected.event_id);
+        assert_eq!(event.peer_id, expected.sender);
+        assert_eq!(event.client_id, expected.sender_client);
+        assert_eq!(event.room_id, expected.channel);
+        assert_eq!(event.lamport, expected.lamport);
+        assert_eq!(event.occurred_at_ms, expected.occurred_at_ms);
+        assert_eq!(event.target, expected.target);
+        assert_eq!(event.headers, expected.headers);
+        assert_eq!(event.body, expected.body);
+        assert_eq!(event.kind, TranscriptKind::Message);
+    }
+
+    #[test]
+    fn frame_kind_maps_to_transcript_kind() {
+        let mut frame = message_frame();
+        frame.kind = FrameKind::Event;
+        assert_eq!(
+            frame.into_transcript_event().kind,
+            TranscriptKind::System,
+            "event-kind preserves as system rather than message"
+        );
+
+        let mut frame = message_frame();
+        frame.kind = FrameKind::Control;
+        assert_eq!(
+            frame.into_transcript_event().kind,
+            TranscriptKind::SessionControl
+        );
+    }
+
+    #[test]
+    fn reply_to_is_projected_into_metadata() {
+        // Substrate contract: dropping reply_to silently would lose
+        // threading info. The conversion projects it into metadata
+        // under the substrate-owned key so consumers can recover it.
+        let mut frame = message_frame();
+        let reply_target = EventId::from_u128(0xabc);
+        frame.envelope.reply_to = Some(reply_target);
+        let event = frame.into_transcript_event();
+        let recovered: Option<EventId> = event
+            .metadata
+            .get("airc.reply_to")
+            .and_then(|v| serde_json::from_value(v.clone()).ok());
+        assert_eq!(recovered, Some(reply_target));
+    }
+
+    #[test]
+    fn signature_does_not_appear_in_stored_event() {
+        // Signatures are verified at the transport boundary; the
+        // durable record is the canonical TranscriptEvent and has no
+        // signature field. This test is structural — if a future
+        // refactor accidentally adds a `signature` field to
+        // TranscriptEvent, the call below stops compiling.
+        let event: TranscriptEvent = message_frame().into_transcript_event();
+        let json = serde_json::to_value(&event).unwrap();
+        assert!(
+            json.get("signature").is_none(),
+            "TranscriptEvent must not carry a signature field"
+        );
+    }
+}


### PR DESCRIPTION
## Work intake (per operating control board)

- **Grievance:** §7 — Inbox And Replay Need Stronger Cursor Semantics
- **Gap:** Rust Runtime Gaps — *\"cursor = (lamport, event_id) or stronger event-store cursor\"*; *\"channel-aware inbox filtering\"*; *\"no cross-room leakage when wires are shared\"*
- **Acceptance gate:** Gate 1 (Rust hot path replay)
- **Python/shell impact:** untouched
- **Branch:** \`feat/daemon-store-wiring\` off \`rust-rewrite\`, short-lived
- **Proof:** 4 new \`airc-protocol\` tests on Frame → TranscriptEvent + the existing \`subscribe_then_send_then_inbox_round_trips\` rewritten to assert on the new InboxResponse shape (write → tail → store → resume_from)

## Summary

The daemon's per-wire in-memory \`InboxBuffer\` is gone. Subscriber tasks now convert each received \`Frame\` into a \`TranscriptEvent\` and append to the shared \`EventStore\`. \`Inbox\` requests query the store via \`(lamport, event_id)\` cursor with a per-channel filter.

For local dev: daemon mode opens \`<home>/events.sqlite\` and applies migrations on open, so cursors survive daemon restarts.

## Wire-protocol impact

\`InboxRequest\` (\`since: Option<TranscriptCursor>\`, \`channel: Option<RoomId>\`, \`limit\`) and \`InboxResponse\` (\`events: Vec<TranscriptEvent>\`, \`newest: Option<TranscriptCursor>\`) shapes changed. Daemon and CLI ship together; no external consumers depend on these types yet. Slice 6 (airc-lib) is where the versioned public surface gets locked.

## Test plan

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --workspace --all-features\` — airc-protocol 44 → 48 (+4 conversion), all other crates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)