### PR TITLE
feat(airc-lib): live subscriptions + auto-populate store on say (slice 6b)

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -56,8 +56,12 @@ const LIVE_BROADCAST_CAPACITY: usize = 1024;
 /// In-process AIRC handle. Holds identity, store, per-room
 /// signed-local-fs transports, and a background subscriber per wire
 /// that converts received `Frame`s into `TranscriptEvent`s and
-/// appends them to the durable store. Cheap to clone via inner
-/// `Arc`s.
+/// appends them to the durable store.
+///
+/// `Clone` is cheap (just an Arc bump). Clones share the SAME
+/// subscriber set + live broadcast channel — call `.clone()` to
+/// pass the handle into a spawned task while keeping the parent's
+/// `subscribe()` stream live.
 ///
 /// Lifecycle:
 ///   - `Airc::open` initialises identity + store + peer registry.
@@ -65,6 +69,7 @@ const LIVE_BROADCAST_CAPACITY: usize = 1024;
 ///     subscriber on the room's wire if one isn't already running.
 ///   - Consumers wanting live push call `Airc::subscribe()` and
 ///     get a `Stream<Item = TranscriptEvent>`.
+#[derive(Clone)]
 pub struct Airc {
     inner: Arc<AircInner>,
 }

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -19,18 +19,26 @@
 //! # Ok(()) }
 //! ```
 
+use std::collections::HashMap;
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::RwLock;
+use std::task::{Context, Poll};
 
 use airc_core::{
     body::Body, headers::Headers, transcript::MentionTarget, ClientId, EventId, PeerId,
     TranscriptCursor, TranscriptEvent,
 };
 use airc_daemon::{peers_store, LocalIdentity};
-use airc_protocol::{Envelope, Frame, FrameKind, PeerKeyRegistry, Signature, VerificationPolicy};
+use airc_protocol::{
+    Envelope, Frame, FrameKind, PeerKeyRegistry, Signature, Subscription, VerificationPolicy,
+};
 use airc_store::{EventStore, SqliteEventStore};
 use airc_transport::{LocalFsAdapter, SignedTransport, Transport};
+use futures::stream::{Stream, StreamExt};
+use tokio::sync::{broadcast, Mutex};
 
 use crate::error::AircError;
 use crate::registry::PeerSpec;
@@ -38,15 +46,50 @@ use crate::room::{self, Room};
 
 const EVENTS_DB_FILENAME: &str = "events.sqlite";
 
-/// In-process AIRC handle. Holds identity, store, and per-room
-/// signed-local-fs transports. Wrap in `Arc` if you need to share
-/// across tasks.
+/// Capacity of the live broadcast channel. Each consumer that calls
+/// [`Airc::subscribe`] gets its own receiver; lagged receivers see
+/// `BroadcastStreamRecvError::Lagged(n)` rather than silently miss
+/// events — the operating doc's "no silent fallback" rule. Consumers
+/// that need durable replay use `Airc::resume_from` against the store.
+const LIVE_BROADCAST_CAPACITY: usize = 1024;
+
+/// In-process AIRC handle. Holds identity, store, per-room
+/// signed-local-fs transports, and a background subscriber per wire
+/// that converts received `Frame`s into `TranscriptEvent`s and
+/// appends them to the durable store. Cheap to clone via inner
+/// `Arc`s.
+///
+/// Lifecycle:
+///   - `Airc::open` initialises identity + store + peer registry.
+///   - `Airc::join(name)` / `Airc::say(text)` lazily start a
+///     subscriber on the room's wire if one isn't already running.
+///   - Consumers wanting live push call `Airc::subscribe()` and
+///     get a `Stream<Item = TranscriptEvent>`.
 pub struct Airc {
+    inner: Arc<AircInner>,
+}
+
+struct AircInner {
     home: PathBuf,
     identity: LocalIdentity,
     store: Arc<dyn EventStore>,
     registry: Arc<RwLock<PeerKeyRegistry>>,
     policy: VerificationPolicy,
+    /// Per-wire background subscriber tasks. Spawned lazily on first
+    /// `say`/`send`/`subscribe`/`page_recent` referencing the wire.
+    /// Held in a Mutex so concurrent calls can't double-spawn.
+    subscribers: Mutex<HashMap<PathBuf, WireSubscriber>>,
+    /// Live event fan-out. Every event the subscribers append to the
+    /// store is also forwarded here so consumers tailing via
+    /// [`Airc::subscribe`] see it immediately.
+    live_tx: broadcast::Sender<TranscriptEvent>,
+}
+
+struct WireSubscriber {
+    /// Kept alive by ownership of its `JoinHandle`. Dropped when
+    /// `Airc` is dropped (since the AircInner holding it goes away),
+    /// which closes the underlying transport subscription.
+    _task: tokio::task::JoinHandle<()>,
 }
 
 impl Airc {
@@ -94,46 +137,54 @@ impl Airc {
                 .map_err(|e| AircError::Crypto(e.to_string()))?;
         }
         let registry = Arc::new(RwLock::new(registry));
+        let (live_tx, _) = broadcast::channel(LIVE_BROADCAST_CAPACITY);
 
         Ok(Self {
-            home,
-            identity,
-            store,
-            registry,
-            policy,
+            inner: Arc::new(AircInner {
+                home,
+                identity,
+                store,
+                registry,
+                policy,
+                subscribers: Mutex::new(HashMap::new()),
+                live_tx,
+            }),
         })
     }
 
     /// Return the home directory backing this handle.
     pub fn home(&self) -> &Path {
-        &self.home
+        &self.inner.home
     }
 
     /// Return the local peer's stable identifier.
     pub fn peer_id(&self) -> PeerId {
-        self.identity.peer_id
+        self.inner.identity.peer_id
     }
 
     /// Return the per-session client identifier.
     pub fn client_id(&self) -> ClientId {
-        self.identity.client_id
+        self.inner.identity.client_id
     }
 
     /// Return the peer-spec string suitable for sharing with another
     /// peer so they can enrol this identity into their trust registry.
     pub fn peer_spec(&self) -> String {
         crate::registry::format_peer_spec(
-            self.identity.peer_id,
-            &self.identity.keypair.public_bytes(),
+            self.inner.identity.peer_id,
+            &self.inner.identity.keypair.public_bytes(),
         )
     }
 
     /// Switch the current room to one derived from `name`. Same name
     /// on two peers yields the same channel UUID via UUIDv5, so they
-    /// converge without exchanging the UUID out-of-band.
+    /// converge without exchanging the UUID out-of-band. Spawns a
+    /// background subscriber on the new room's wire if one isn't
+    /// already running, so subsequent `say`s land in the store.
     pub async fn join(&self, name: &str) -> Result<Room, AircError> {
-        let room = Room::from_name(&self.home, name);
-        room::save(&self.home, &room)?;
+        let room = Room::from_name(&self.inner.home, name);
+        room::save(&self.inner.home, &room)?;
+        self.ensure_wire_subscriber(&room.wire).await?;
         Ok(room)
     }
 
@@ -141,28 +192,34 @@ impl Airc {
     /// (synthesised on the fly, NOT persisted) if no `room.json`
     /// has been written yet.
     pub async fn current_room(&self) -> Result<Room, AircError> {
-        Ok(room::load_or_default(&self.home)?)
+        Ok(room::load_or_default(&self.inner.home)?)
     }
 
     /// Send a plain-text message to the current room. Returns the
     /// event's `EventId` so callers can correlate or filter their
-    /// own echo.
+    /// own echo via [`Airc::subscribe`].
     pub async fn say(&self, text: &str) -> Result<EventId, AircError> {
         self.send(Body::text(text), Headers::new()).await
     }
 
     /// Send a frame with typed body and arbitrary headers to the
     /// current room. Frame is signed under the local identity and
-    /// written through the room's local-fs wire.
+    /// written through the room's local-fs wire. The room's
+    /// background subscriber will see the frame on the wire,
+    /// convert it to a `TranscriptEvent`, append it to the store,
+    /// and broadcast it to live [`subscribe`](Self::subscribe)
+    /// receivers — so `say(...).await` followed by
+    /// `page_recent(...)` reliably observes the new event.
     pub async fn send(&self, body: Body, headers: Headers) -> Result<EventId, AircError> {
         let room = self.current_room().await?;
+        self.ensure_wire_subscriber(&room.wire).await?;
         let event_id = EventId::new();
         let frame = Frame {
             kind: FrameKind::Message,
             envelope: Envelope {
                 event_id,
-                sender: self.identity.peer_id,
-                sender_client: self.identity.client_id,
+                sender: self.inner.identity.peer_id,
+                sender_client: self.inner.identity.client_id,
                 channel: room.channel,
                 target: MentionTarget::All,
                 lamport: now_ms(),
@@ -177,10 +234,10 @@ impl Airc {
         let inner = LocalFsAdapter::new(&room.wire);
         let transport = SignedTransport::new(
             inner,
-            self.identity.keypair.clone(),
-            self.identity.peer_id,
-            self.registry.clone(),
-            self.policy,
+            self.inner.identity.keypair.clone(),
+            self.inner.identity.peer_id,
+            self.inner.registry.clone(),
+            self.inner.policy,
         );
         transport
             .send(frame)
@@ -189,12 +246,32 @@ impl Airc {
         Ok(event_id)
     }
 
+    /// Subscribe to the live event stream. Every event appended to
+    /// the durable store (by this `Airc` handle or by remote peers
+    /// the wire's subscriber sees) is forwarded to all live
+    /// subscribers. Lagged receivers get
+    /// [`broadcast::error::RecvError::Lagged`] rather than silent
+    /// drops — consumers that need durable replay use
+    /// [`Airc::resume_from`].
+    pub async fn subscribe(&self) -> Result<EventStream, AircError> {
+        let room = self.current_room().await?;
+        self.ensure_wire_subscriber(&room.wire).await?;
+        Ok(EventStream {
+            rx: self.inner.live_tx.subscribe(),
+        })
+    }
+
     /// Fetch the most recent `limit` events from the durable store,
     /// filtered to the current room. Returns events in transcript
     /// order (oldest → newest within the page).
     pub async fn page_recent(&self, limit: usize) -> Result<Vec<TranscriptEvent>, AircError> {
         let room = self.current_room().await?;
-        Ok(self.store.page_recent(Some(room.channel), limit).await?)
+        self.ensure_wire_subscriber(&room.wire).await?;
+        Ok(self
+            .inner
+            .store
+            .page_recent(Some(room.channel), limit)
+            .await?)
     }
 
     /// Fetch up to `limit` events strictly after `cursor` from the
@@ -207,6 +284,7 @@ impl Airc {
     ) -> Result<Vec<TranscriptEvent>, AircError> {
         let room = self.current_room().await?;
         Ok(self
+            .inner
             .store
             .resume_from(cursor, Some(room.channel), limit)
             .await?)
@@ -216,7 +294,7 @@ impl Airc {
     /// the room has no events yet.
     pub async fn latest_cursor(&self) -> Result<Option<TranscriptCursor>, AircError> {
         let room = self.current_room().await?;
-        Ok(self.store.latest_cursor(Some(room.channel)).await?)
+        Ok(self.inner.store.latest_cursor(Some(room.channel)).await?)
     }
 
     /// Append a `TranscriptEvent` to the durable store directly. The
@@ -224,15 +302,16 @@ impl Airc {
     /// being correct. Useful for consumers replaying captured events
     /// or for tests that want to seed history.
     pub async fn append_event(&self, event: TranscriptEvent) -> Result<(), AircError> {
-        Ok(self.store.append(event).await?)
+        Ok(self.inner.store.append(event).await?)
     }
 
     /// Enrol a peer into the local trust registry and persist it to
     /// `<home>/peers.json`. Pass the peer-spec the remote produced
     /// via [`Airc::peer_spec`].
     pub async fn add_peer(&self, spec: PeerSpec) -> Result<(), AircError> {
-        peers_store::add(&self.home, spec.peer_id, spec.pubkey)?;
+        peers_store::add(&self.inner.home, spec.peer_id, spec.pubkey)?;
         let mut registry = self
+            .inner
             .registry
             .write()
             .map_err(|_| AircError::Crypto("registry lock poisoned".to_string()))?;
@@ -245,7 +324,7 @@ impl Airc {
     /// Return a list of enrolled peers (read from peers.json — the
     /// daemon writes the same file, so this view stays consistent).
     pub async fn peers(&self) -> Result<Vec<EnrolledPeer>, AircError> {
-        let stored = peers_store::load(&self.home)?;
+        let stored = peers_store::load(&self.inner.home)?;
         Ok(stored
             .into_iter()
             .map(|p| EnrolledPeer {
@@ -254,7 +333,136 @@ impl Airc {
             })
             .collect())
     }
+
+    /// Idempotently spawn a background subscriber on `wire` if one
+    /// isn't already running. The subscriber:
+    ///   1. attaches a SignedTransport<LocalFsAdapter> subscription
+    ///      anchored at the start of the wire (replays existing
+    ///      frames into the store on first attach);
+    ///   2. converts each verified `Frame` into a `TranscriptEvent`
+    ///      via `Frame::into_transcript_event`;
+    ///   3. appends to the durable store;
+    ///   4. fans the event out on `live_tx` for live subscribers.
+    ///
+    /// Verification failures and store errors are surfaced on stderr
+    /// rather than silently swallowed — the operating doc's "errors
+    /// reach a debugger" rule.
+    async fn ensure_wire_subscriber(&self, wire: &Path) -> Result<(), AircError> {
+        let mut subs = self.inner.subscribers.lock().await;
+        if subs.contains_key(wire) {
+            return Ok(());
+        }
+        let transport = SignedTransport::new(
+            LocalFsAdapter::new(wire),
+            self.inner.identity.keypair.clone(),
+            self.inner.identity.peer_id,
+            self.inner.registry.clone(),
+            self.inner.policy,
+        );
+        // Replay-anchored so first attach captures pre-existing
+        // frames on the wire and routes them into the store.
+        let subscription = Subscription {
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = transport
+            .subscribe(subscription)
+            .await
+            .map_err(|e| AircError::Transport(e.to_string()))?;
+
+        let store = self.inner.store.clone();
+        let live_tx = self.inner.live_tx.clone();
+        let task = tokio::spawn(async move {
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(frame) => {
+                        let event = frame.into_transcript_event();
+                        match store.append(event.clone()).await {
+                            Ok(()) => {
+                                // No active receivers is normal (no
+                                // one's called `subscribe()` yet) —
+                                // broadcast::send returns Err in that
+                                // case and we don't care.
+                                let _ = live_tx.send(event);
+                            }
+                            Err(airc_store::StoreError::DuplicateEventId(_)) => {
+                                // Replay-anchored attach re-reads
+                                // the existing wire on every fresh
+                                // Airc::open; the store rejects the
+                                // duplicate, we move on without
+                                // fanning out (the live broadcast is
+                                // for genuinely new events).
+                            }
+                            Err(err) => {
+                                eprintln!("airc-lib subscriber: store append failed: {err}");
+                            }
+                        }
+                    }
+                    Err(verify_err) => {
+                        eprintln!("airc-lib subscriber: frame verification failed: {verify_err}");
+                    }
+                }
+            }
+        });
+        subs.insert(wire.to_path_buf(), WireSubscriber { _task: task });
+        Ok(())
+    }
 }
+
+/// Live transcript-event stream returned by [`Airc::subscribe`].
+/// Wraps a broadcast receiver and yields events as they arrive.
+///
+/// Lagged behaviour: if the consumer falls behind the broadcast
+/// capacity, the stream surfaces the lag count and resumes from
+/// the current tip. That's a real signal — consumers that need
+/// durable replay should snapshot a cursor and call
+/// [`Airc::resume_from`] when they catch up. Silent drops are not
+/// part of the API.
+pub struct EventStream {
+    rx: broadcast::Receiver<TranscriptEvent>,
+}
+
+impl Stream for EventStream {
+    type Item = Result<TranscriptEvent, LiveLag>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        let fut = this.rx.recv();
+        futures::pin_mut!(fut);
+        match fut.as_mut().poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(event)) => Poll::Ready(Some(Ok(event))),
+            Poll::Ready(Err(broadcast::error::RecvError::Lagged(n))) => {
+                Poll::Ready(Some(Err(LiveLag { skipped: n })))
+            }
+            Poll::Ready(Err(broadcast::error::RecvError::Closed)) => Poll::Ready(None),
+        }
+    }
+}
+
+/// Surfaced when a live stream falls behind the broadcast capacity.
+/// `skipped` is the number of events the consumer missed; recover by
+/// snapshotting a `TranscriptCursor` and calling
+/// [`Airc::resume_from`] to backfill from the store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveLag {
+    pub skipped: u64,
+}
+
+impl std::fmt::Display for LiveLag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "live stream lagged {} events — resume from cursor",
+            self.skipped
+        )
+    }
+}
+
+impl std::error::Error for LiveLag {}
 
 /// One row in [`Airc::peers`]. Mirrors the daemon's `PeerEntry`
 /// without forcing consumers to pull the daemon crate.

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -82,10 +82,11 @@ async fn subscribe_yields_live_events_in_order() {
 
     let mut stream = airc.subscribe().await.unwrap();
 
-    // Drive three sends from a spawned task. The subscriber on the
-    // wire converts each into a TranscriptEvent and the broadcast
-    // fans out to the stream we're holding.
-    let airc_send = Airc::open(home.path()).await.unwrap();
+    // Drive three sends from a spawned task. Cloning the Airc
+    // handle is critical: a fresh `Airc::open` on the same home
+    // would have its OWN broadcast channel, and the stream we're
+    // holding wouldn't see fan-outs from that handle's subscriber.
+    let airc_send = airc.clone();
     let send_task = tokio::spawn(async move {
         for i in 0..3 {
             airc_send.say(&format!("hi-{i}")).await.unwrap();

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -1,15 +1,53 @@
 //! Embedding smoke test — proves a small consumer can link the lib
 //! and exercise the Gate-4 minimum: open identity, join a room,
-//! send, page_recent, resume_from, peer-spec/peers handling.
+//! send, observe in store via `page_recent`, subscribe to live
+//! events, fetch replay via `resume_from`, peer-spec/peers handling.
 //!
-//! No daemon involvement; the lib's in-process embedding is the
-//! single linkage point. This is the slice-6 proof point.
+//! No daemon involvement; the lib's in-process embedding owns the
+//! background subscriber, the store, and the broadcast fan-out.
+//! This is the slice-6b proof point.
+
+use std::time::Duration;
 
 use airc_lib::{Airc, Body, Headers, PeerSpec};
+use futures::stream::StreamExt;
 use tempfile::TempDir;
+
+/// Poll `page_recent` until it sees at least `expected` events or
+/// the deadline fires. The wire-side tail loop runs in a background
+/// task; first attaches replay from the start of the wire, but the
+/// store append happens asynchronously after the local-fs adapter
+/// observes the new line. A handful of polls keeps the test
+/// deterministic without flaking on slow CI runners.
+async fn wait_for_events(
+    airc: &Airc,
+    expected: usize,
+    timeout: Duration,
+) -> Vec<airc_lib::TranscriptEvent> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let page = airc.page_recent(64).await.unwrap();
+        if page.len() >= expected {
+            return page;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "wait_for_events: expected {expected} got {} in {:?}",
+                page.len(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
 
 #[tokio::test]
 async fn open_join_say_and_replay_round_trips_in_process() {
+    // Gate-4 minimum: a consumer can link airc-lib, open the substrate,
+    // join a room, send, and observe the event via the store — without
+    // manually feeding the store. Before slice 6b this test had to
+    // call `airc.append_event(...)` because `say` only wrote to the
+    // wire; the background subscriber now closes that loop.
     let home = TempDir::new().unwrap();
     let airc = Airc::open(home.path()).await.unwrap();
 
@@ -18,36 +56,10 @@ async fn open_join_say_and_replay_round_trips_in_process() {
     let current = airc.current_room().await.unwrap();
     assert_eq!(current.channel, room.channel, "join persisted to room.json");
 
-    // Direct send via Airc::say. The wire is the room's local-fs
-    // path; the durable store is `<home>/events.sqlite`.
-    let event_id = airc.say("hello, consumer").await.unwrap();
-    let _ = event_id;
+    let _event_id = airc.say("hello, consumer").await.unwrap();
 
-    // The wire-side write doesn't auto-populate the store in
-    // pure-embedding mode (slice 6 deliberately ships without
-    // background subscribers). Mirror the daemon's behaviour by
-    // appending to the store explicitly so the proof shows the
-    // consumer-facing `page_recent` path works end-to-end.
-    let event = airc_lib::TranscriptEvent {
-        event_id,
-        room_id: room.channel,
-        peer_id: airc.peer_id(),
-        client_id: airc.client_id(),
-        kind: airc_core::transcript::TranscriptKind::Message,
-        occurred_at_ms: 1_700_000_000_000,
-        lamport: 1,
-        target: airc_lib::MentionTarget::All,
-        headers: Headers::new(),
-        body: Some(Body::text("hello, consumer")),
-        attachment: None,
-        receipt: None,
-        metadata: serde_json::Value::Null,
-    };
-    airc.append_event(event.clone()).await.unwrap();
-
-    let page = airc.page_recent(10).await.unwrap();
+    let page = wait_for_events(&airc, 1, Duration::from_secs(2)).await;
     assert_eq!(page.len(), 1);
-    assert_eq!(page[0], event);
     let bodies: Vec<&str> = page
         .iter()
         .filter_map(|e| e.body.as_ref().and_then(Body::as_text))
@@ -57,6 +69,52 @@ async fn open_join_say_and_replay_round_trips_in_process() {
     let cursor = airc.latest_cursor().await.unwrap().unwrap();
     let after = airc.resume_from(&cursor, 10).await.unwrap();
     assert!(after.is_empty(), "nothing strictly after the latest cursor");
+}
+
+#[tokio::test]
+async fn subscribe_yields_live_events_in_order() {
+    // The live subscription contract: subscribers see every event
+    // the substrate appends to the store, in transcript order, while
+    // the consumer is connected.
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("live-test").await.unwrap();
+
+    let mut stream = airc.subscribe().await.unwrap();
+
+    // Drive three sends from a spawned task. The subscriber on the
+    // wire converts each into a TranscriptEvent and the broadcast
+    // fans out to the stream we're holding.
+    let airc_send = Airc::open(home.path()).await.unwrap();
+    let send_task = tokio::spawn(async move {
+        for i in 0..3 {
+            airc_send.say(&format!("hi-{i}")).await.unwrap();
+        }
+    });
+
+    let mut received = Vec::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while received.len() < 3 && std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), stream.next()).await {
+            Ok(Some(Ok(event))) => {
+                if let Some(text) = event.body.as_ref().and_then(Body::as_text) {
+                    if text.starts_with("hi-") {
+                        received.push(text.to_string());
+                    }
+                }
+            }
+            Ok(Some(Err(lag))) => panic!("unexpected live-stream lag: {lag}"),
+            Ok(None) => panic!("stream closed unexpectedly"),
+            Err(_) => continue,
+        }
+    }
+    send_task.await.unwrap();
+
+    assert_eq!(
+        received,
+        vec!["hi-0", "hi-1", "hi-2"],
+        "subscriber must observe all three sends in send order"
+    );
 }
 
 #[tokio::test]
@@ -90,4 +148,35 @@ async fn open_is_idempotent_across_handles() {
     drop(first);
     let second = Airc::open(home.path()).await.unwrap();
     assert_eq!(second.peer_id(), first_peer);
+}
+
+#[tokio::test]
+async fn send_typed_body_with_headers_round_trips() {
+    // Gate-4 bullet: "send typed body with headers". The headers
+    // survive the wire boundary and land in the persisted event.
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("typed-test").await.unwrap();
+
+    let mut headers = Headers::new();
+    headers.insert(
+        "forge.body_hint".to_string(),
+        "application/json".to_string(),
+    );
+    headers.insert("x-test-marker".to_string(), "round-trip".to_string());
+    let _event_id = airc
+        .send(Body::text(r#"{"k":"v"}"#), headers.clone())
+        .await
+        .unwrap();
+
+    let page = wait_for_events(&airc, 1, Duration::from_secs(2)).await;
+    assert_eq!(page.len(), 1);
+    assert_eq!(
+        page[0].headers.get("x-test-marker").map(String::as_str),
+        Some("round-trip")
+    );
+    assert_eq!(
+        page[0].headers.get("forge.body_hint").map(String::as_str),
+        Some("application/json")
+    );
 }


### PR DESCRIPTION
## Work intake (per operating control board)

- **Grievance:** §13 (Consumer Integration Is Not Proven) + Codex audit finding #2 (\"airc-lib does not yet provide a live subscription stream or daemon-attached mode\")
- **Gap:** Rust Runtime Gaps — \"persistent subscription hub\" + Consumer Integration Gaps — \"Generic apps: stable airc-lib API, not shell command parsing\"
- **Acceptance gate:** Gate 4 (Consumer Embedding) — closes \"subscribe\" + makes \"send → fetch replay\" work without manual store seeding
- **Python/shell impact:** untouched
- **Branch:** \`feat/airc-lib-live-subscribe\` off \`rust-rewrite\`, short-lived
- **Proof:** \`say()\` lands in \`page_recent()\` without manual \`append_event\` (smoke test simplifies); new \`subscribe_yields_live_events_in_order\` test asserts 3 spawned sends land on a held \`EventStream\` in send order.

## Summary

\`Airc\` now spawns a background subscriber per-wire that converts verified frames into \`TranscriptEvent\`s, appends to the durable store, and fans out on a \`broadcast::Sender<TranscriptEvent>\`. Consumers call \`Airc::subscribe()\` for a \`Stream<Item = Result<TranscriptEvent, LiveLag>>\`. Lag surfaces explicitly via \`LiveLag\` — no silent drops (operating doc non-negotiable).

The previous smoke test had to manually \`append_event(...)\` because pure embedding had no subscriber. That work-around is gone.

## Out of scope (queued)

- Daemon-attached mode (\`Airc::attach(socket_path)\`)
- Header / channel / kind filters on \`subscribe()\`

## Test plan

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --workspace --all-features\` — all crates green; airc-lib integration tests 3 → 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)