### PR TITLE
feat(airc-work): typed work coordination domain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-work"
+version = "0.1.0"
+dependencies = [
+ "airc-core",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/airc-protocol",
     "crates/airc-transport",
     "crates/airc-store",
+    "crates/airc-work",
     "crates/airc-daemon",
     "crates/airc-lib",
     "crates/airc-cli",

--- a/crates/airc-work/Cargo.toml
+++ b/crates/airc-work/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "airc-work"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+# Typed work/kanban/workspace domain for AIRC. This crate owns the
+# Rust substrate contracts; GitHub, CLI, Codex hooks, and Continuum
+# are adapters on top.
+
+[dependencies]
+airc-core = { path = "../airc-core" }
+serde = { version = "1", features = ["derive"] }
+thiserror = "1"
+uuid = { version = "1", features = ["v4", "serde"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/airc-work/src/event.rs
+++ b/crates/airc-work/src/event.rs
@@ -1,0 +1,207 @@
+//! Append-only work-domain events.
+
+use serde::{Deserialize, Serialize};
+
+use airc_core::PeerId;
+
+use crate::ids::{ClaimId, LaneId, RepoId, WorkCardId, WorkspaceId};
+use crate::model::{BranchName, CardState, HygieneReport, LaneState, Priority, PullRequestRef};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WorkEvent {
+    CardCreated(CardCreated),
+    CardClaimed(WorkCardClaimed),
+    ClaimHeartbeat(ClaimHeartbeat),
+    ClaimReleased(ClaimReleased),
+    CardStateChanged(CardStateChanged),
+    LaneCreated(LaneCreated),
+    LaneStateChanged(LaneStateChanged),
+    WorkspaceRequested(WorkspaceRequested),
+    WorkspaceAllocated(WorkspaceAllocated),
+    WorkspaceHeartbeat(WorkspaceHeartbeat),
+    WorkspaceReleased(WorkspaceReleased),
+    PullRequestLinked(PullRequestLinked),
+    PullRequestMerged(PullRequestMerged),
+    HygieneReportRecorded(HygieneReportRecorded),
+    ManagerHatClaimed(ManagerHatClaimed),
+    ManagerHatReleased(ManagerHatReleased),
+}
+
+impl WorkEvent {
+    pub fn occurred_at_ms(&self) -> u64 {
+        match self {
+            WorkEvent::CardCreated(e) => e.created_at_ms,
+            WorkEvent::CardClaimed(e) => e.claimed_at_ms,
+            WorkEvent::ClaimHeartbeat(e) => e.heartbeat_at_ms,
+            WorkEvent::ClaimReleased(e) => e.released_at_ms,
+            WorkEvent::CardStateChanged(e) => e.changed_at_ms,
+            WorkEvent::LaneCreated(e) => e.created_at_ms,
+            WorkEvent::LaneStateChanged(e) => e.changed_at_ms,
+            WorkEvent::WorkspaceRequested(e) => e.requested_at_ms,
+            WorkEvent::WorkspaceAllocated(e) => e.allocated_at_ms,
+            WorkEvent::WorkspaceHeartbeat(e) => e.heartbeat_at_ms,
+            WorkEvent::WorkspaceReleased(e) => e.released_at_ms,
+            WorkEvent::PullRequestLinked(e) => e.linked_at_ms,
+            WorkEvent::PullRequestMerged(e) => e.merged_at_ms,
+            WorkEvent::HygieneReportRecorded(e) => e.report.recorded_at_ms,
+            WorkEvent::ManagerHatClaimed(e) => e.claimed_at_ms,
+            WorkEvent::ManagerHatReleased(e) => e.released_at_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CardCreated {
+    pub card_id: WorkCardId,
+    pub repo: RepoId,
+    pub title: String,
+    pub body: Option<String>,
+    pub priority: Priority,
+    pub lane_id: Option<LaneId>,
+    pub created_by: PeerId,
+    pub created_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkCardClaimed {
+    pub card_id: WorkCardId,
+    pub claim_id: ClaimId,
+    pub owner: PeerId,
+    pub ttl_ms: u64,
+    pub claimed_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClaimHeartbeat {
+    pub card_id: WorkCardId,
+    pub claim_id: ClaimId,
+    pub owner: PeerId,
+    pub ttl_ms: u64,
+    pub heartbeat_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClaimReleased {
+    pub card_id: WorkCardId,
+    pub claim_id: ClaimId,
+    pub owner: PeerId,
+    pub reason: Option<String>,
+    pub released_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CardStateChanged {
+    pub card_id: WorkCardId,
+    pub state: CardState,
+    pub changed_by: PeerId,
+    pub changed_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaneCreated {
+    pub lane_id: LaneId,
+    pub repo: RepoId,
+    pub title: String,
+    pub state: LaneState,
+    pub created_by: PeerId,
+    pub created_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaneStateChanged {
+    pub lane_id: LaneId,
+    pub state: LaneState,
+    pub changed_by: PeerId,
+    pub changed_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceRequested {
+    pub workspace_id: WorkspaceId,
+    pub card_id: WorkCardId,
+    pub claim_id: ClaimId,
+    pub owner: PeerId,
+    pub repo: RepoId,
+    pub branch: BranchName,
+    pub base: BranchName,
+    pub requested_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceAllocated {
+    pub workspace_id: WorkspaceId,
+    pub path: String,
+    pub allocated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceHeartbeat {
+    pub workspace_id: WorkspaceId,
+    pub disk_bytes: Option<u64>,
+    pub heartbeat_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceReleased {
+    pub workspace_id: WorkspaceId,
+    pub released_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestLinked {
+    pub card_id: WorkCardId,
+    pub pull_request: PullRequestRef,
+    pub linked_by: PeerId,
+    pub linked_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestMerged {
+    pub card_id: WorkCardId,
+    pub pull_request: PullRequestRef,
+    pub merged_by: PeerId,
+    pub merged_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HygieneReportRecorded {
+    pub report: HygieneReport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManagerHatClaimed {
+    pub repo: RepoId,
+    pub manager: PeerId,
+    pub ttl_ms: u64,
+    pub claimed_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManagerHatReleased {
+    pub repo: RepoId,
+    pub manager: PeerId,
+    pub released_at_ms: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn work_event_serializes_with_kind_tag() {
+        let event = WorkEvent::CardCreated(CardCreated {
+            card_id: WorkCardId::from_u128(1),
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            title: "build work domain".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+            created_by: PeerId::from_u128(2),
+            created_at_ms: 10,
+        });
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["kind"], "card_created");
+        assert_eq!(event.occurred_at_ms(), 10);
+    }
+}

--- a/crates/airc-work/src/ids.rs
+++ b/crates/airc-work/src/ids.rs
@@ -1,0 +1,132 @@
+//! Domain identifiers for work coordination.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+macro_rules! uuid_id {
+    ($name:ident) => {
+        #[derive(
+            Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+        )]
+        #[serde(transparent)]
+        pub struct $name(Uuid);
+
+        impl $name {
+            pub fn new() -> Self {
+                Self(Uuid::new_v4())
+            }
+
+            pub fn from_uuid(uuid: Uuid) -> Self {
+                Self(uuid)
+            }
+
+            pub fn from_u128(value: u128) -> Self {
+                Self(Uuid::from_u128(value))
+            }
+
+            pub fn as_uuid(self) -> Uuid {
+                self.0
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+    };
+}
+
+uuid_id!(WorkCardId);
+uuid_id!(LaneId);
+uuid_id!(ClaimId);
+uuid_id!(WorkspaceId);
+
+/// Repository key such as `CambrianTech/continuum`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RepoId(String);
+
+impl RepoId {
+    pub fn new(value: impl Into<String>) -> Result<Self, RepoIdError> {
+        let value = value.into();
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(RepoIdError::Empty);
+        }
+        if trimmed.contains(char::is_whitespace) {
+            return Err(RepoIdError::ContainsWhitespace);
+        }
+        Ok(Self(trimmed.to_string()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for RepoId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl TryFrom<&str> for RepoId {
+    type Error = RepoIdError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum RepoIdError {
+    #[error("repo id cannot be empty")]
+    Empty,
+    #[error("repo id cannot contain whitespace")]
+    ContainsWhitespace,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uuid_ids_are_uuidv4_by_default() {
+        assert_eq!(
+            WorkCardId::new().as_uuid().get_version(),
+            Some(uuid::Version::Random)
+        );
+        assert_eq!(
+            LaneId::new().as_uuid().get_version(),
+            Some(uuid::Version::Random)
+        );
+        assert_eq!(
+            ClaimId::new().as_uuid().get_version(),
+            Some(uuid::Version::Random)
+        );
+        assert_eq!(
+            WorkspaceId::new().as_uuid().get_version(),
+            Some(uuid::Version::Random)
+        );
+    }
+
+    #[test]
+    fn repo_id_rejects_empty_or_whitespace() {
+        assert!(matches!(RepoId::new(""), Err(RepoIdError::Empty)));
+        assert!(matches!(
+            RepoId::new("CambrianTech / continuum"),
+            Err(RepoIdError::ContainsWhitespace)
+        ));
+        assert_eq!(
+            RepoId::new(" CambrianTech/continuum ").unwrap().as_str(),
+            "CambrianTech/continuum"
+        );
+    }
+}

--- a/crates/airc-work/src/lib.rs
+++ b/crates/airc-work/src/lib.rs
@@ -1,0 +1,26 @@
+//! `airc-work` — typed work coordination domain for AIRC.
+//!
+//! This crate is the Rust contract for queue cards, lanes, work claims,
+//! workspaces, PR links, hygiene reports, and manager-hat state. GitHub
+//! issues/PRs are adapters that mirror these events; they are not the
+//! runtime source of truth.
+
+pub mod event;
+pub mod ids;
+pub mod model;
+pub mod projection;
+
+pub use event::{
+    CardCreated, CardStateChanged, ClaimHeartbeat, ClaimReleased, HygieneReportRecorded,
+    LaneCreated, LaneStateChanged, ManagerHatClaimed, ManagerHatReleased, PullRequestLinked,
+    PullRequestMerged, WorkCardClaimed, WorkEvent, WorkspaceAllocated, WorkspaceHeartbeat,
+    WorkspaceReleased, WorkspaceRequested,
+};
+pub use ids::{ClaimId, LaneId, RepoId, WorkCardId, WorkspaceId};
+pub use model::{
+    BranchName, CardState, HygieneReport, LaneState, Priority, PullRequestRef, WorkCard,
+    WorkspaceLease, WorkspaceStatus,
+};
+pub use projection::{
+    BoardSnapshot, LaneRecord, ProjectionError, StaleClaim, WorkBoardProjection, WorkspaceRecord,
+};

--- a/crates/airc-work/src/model.rs
+++ b/crates/airc-work/src/model.rs
@@ -1,0 +1,158 @@
+//! Stable work-domain data models.
+
+use serde::{Deserialize, Serialize};
+
+use airc_core::PeerId;
+
+use crate::ids::{ClaimId, LaneId, RepoId, WorkCardId, WorkspaceId};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Priority {
+    P0,
+    P1,
+    #[default]
+    P2,
+    P3,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CardState {
+    Open,
+    Claimed,
+    InProgress,
+    Blocked,
+    Review,
+    Merged,
+    Closed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LaneState {
+    Planned,
+    Active,
+    Blocked,
+    Landing,
+    Done,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceStatus {
+    Requested,
+    Allocated,
+    Active,
+    Released,
+    Orphaned,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct BranchName(String);
+
+impl BranchName {
+    pub fn new(value: impl Into<String>) -> Result<Self, BranchNameError> {
+        let value = value.into();
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(BranchNameError::Empty);
+        }
+        if trimmed.contains(char::is_whitespace) {
+            return Err(BranchNameError::ContainsWhitespace);
+        }
+        Ok(Self(trimmed.to_string()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for BranchName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum BranchNameError {
+    #[error("branch name cannot be empty")]
+    Empty,
+    #[error("branch name cannot contain whitespace")]
+    ContainsWhitespace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestRef {
+    pub repo: RepoId,
+    pub number: u64,
+    pub head: BranchName,
+    pub base: BranchName,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkCard {
+    pub card_id: WorkCardId,
+    pub repo: RepoId,
+    pub title: String,
+    pub body: Option<String>,
+    pub priority: Priority,
+    pub lane_id: Option<LaneId>,
+    pub state: CardState,
+    pub owner: Option<PeerId>,
+    pub claim_id: Option<ClaimId>,
+    pub claim_expires_at_ms: Option<u64>,
+    pub last_heartbeat_at_ms: Option<u64>,
+    pub pull_request: Option<PullRequestRef>,
+    pub created_by: PeerId,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceLease {
+    pub workspace_id: WorkspaceId,
+    pub card_id: WorkCardId,
+    pub claim_id: ClaimId,
+    pub owner: PeerId,
+    pub repo: RepoId,
+    pub path: String,
+    pub branch: BranchName,
+    pub base: BranchName,
+    pub status: WorkspaceStatus,
+    pub disk_bytes: Option<u64>,
+    pub created_at_ms: u64,
+    pub heartbeat_at_ms: u64,
+    pub released_at_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HygieneReport {
+    pub repo: RepoId,
+    pub reporter: PeerId,
+    pub total_bytes: u64,
+    pub rebuildable_bytes: u64,
+    pub workspace_count: usize,
+    pub recorded_at_ms: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn branch_name_rejects_empty_and_whitespace() {
+        assert!(matches!(BranchName::new(""), Err(BranchNameError::Empty)));
+        assert!(matches!(
+            BranchName::new("feat/bad branch"),
+            Err(BranchNameError::ContainsWhitespace)
+        ));
+        assert_eq!(
+            BranchName::new(" feat/good ").unwrap().as_str(),
+            "feat/good"
+        );
+    }
+}

--- a/crates/airc-work/src/projection.rs
+++ b/crates/airc-work/src/projection.rs
@@ -1,0 +1,86 @@
+//! In-memory projections built by replaying [`WorkEvent`]s.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use airc_core::PeerId;
+
+use crate::ids::{ClaimId, LaneId, RepoId, WorkCardId, WorkspaceId};
+use crate::model::{HygieneReport, LaneState, WorkCard, WorkspaceLease};
+
+mod apply;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkBoardProjection {
+    pub(super) cards: BTreeMap<WorkCardId, WorkCard>,
+    pub(super) lanes: BTreeMap<LaneId, LaneRecord>,
+    pub(super) workspaces: BTreeMap<WorkspaceId, WorkspaceRecord>,
+    pub(super) manager_hats: BTreeMap<RepoId, ManagerHat>,
+    pub(super) hygiene_reports: Vec<HygieneReport>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BoardSnapshot {
+    pub cards: Vec<WorkCard>,
+    pub lanes: Vec<LaneRecord>,
+    pub workspaces: Vec<WorkspaceRecord>,
+    pub manager_hats: Vec<ManagerHat>,
+    pub hygiene_reports: Vec<HygieneReport>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaneRecord {
+    pub lane_id: LaneId,
+    pub repo: RepoId,
+    pub title: String,
+    pub state: LaneState,
+    pub card_ids: Vec<WorkCardId>,
+    pub created_by: PeerId,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceRecord {
+    pub lease: WorkspaceLease,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManagerHat {
+    pub repo: RepoId,
+    pub manager: PeerId,
+    pub expires_at_ms: u64,
+    pub claimed_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StaleClaim {
+    pub card_id: WorkCardId,
+    pub claim_id: ClaimId,
+    pub owner: PeerId,
+    pub expired_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ProjectionError {
+    #[error("duplicate card {0}")]
+    DuplicateCard(WorkCardId),
+    #[error("unknown card {0}")]
+    UnknownCard(WorkCardId),
+    #[error("duplicate lane {0}")]
+    DuplicateLane(LaneId),
+    #[error("unknown lane {0}")]
+    UnknownLane(LaneId),
+    #[error("unknown workspace {0}")]
+    UnknownWorkspace(WorkspaceId),
+    #[error("claim mismatch for card {card_id}: expected {expected:?}, got {got}")]
+    ClaimMismatch {
+        card_id: WorkCardId,
+        expected: Option<ClaimId>,
+        got: ClaimId,
+    },
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/airc-work/src/projection/apply.rs
+++ b/crates/airc-work/src/projection/apply.rs
@@ -1,0 +1,305 @@
+use crate::event::{
+    CardCreated, CardStateChanged, ClaimHeartbeat, ClaimReleased, HygieneReportRecorded,
+    LaneCreated, LaneStateChanged, ManagerHatClaimed, ManagerHatReleased, PullRequestLinked,
+    PullRequestMerged, WorkCardClaimed, WorkEvent, WorkspaceAllocated, WorkspaceHeartbeat,
+    WorkspaceReleased, WorkspaceRequested,
+};
+use crate::ids::{WorkCardId, WorkspaceId};
+use crate::model::{CardState, WorkCard, WorkspaceLease, WorkspaceStatus};
+
+use super::{
+    BoardSnapshot, LaneRecord, ManagerHat, ProjectionError, StaleClaim, WorkBoardProjection,
+    WorkspaceRecord,
+};
+
+impl WorkBoardProjection {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn apply(&mut self, event: &WorkEvent) -> Result<(), ProjectionError> {
+        match event {
+            WorkEvent::CardCreated(e) => self.apply_card_created(e),
+            WorkEvent::CardClaimed(e) => self.apply_card_claimed(e),
+            WorkEvent::ClaimHeartbeat(e) => self.apply_claim_heartbeat(e),
+            WorkEvent::ClaimReleased(e) => self.apply_claim_released(e),
+            WorkEvent::CardStateChanged(e) => self.apply_card_state_changed(e),
+            WorkEvent::LaneCreated(e) => self.apply_lane_created(e),
+            WorkEvent::LaneStateChanged(e) => self.apply_lane_state_changed(e),
+            WorkEvent::WorkspaceRequested(e) => self.apply_workspace_requested(e),
+            WorkEvent::WorkspaceAllocated(e) => self.apply_workspace_allocated(e),
+            WorkEvent::WorkspaceHeartbeat(e) => self.apply_workspace_heartbeat(e),
+            WorkEvent::WorkspaceReleased(e) => self.apply_workspace_released(e),
+            WorkEvent::PullRequestLinked(e) => self.apply_pull_request_linked(e),
+            WorkEvent::PullRequestMerged(e) => self.apply_pull_request_merged(e),
+            WorkEvent::HygieneReportRecorded(e) => self.apply_hygiene_report_recorded(e),
+            WorkEvent::ManagerHatClaimed(e) => self.apply_manager_hat_claimed(e),
+            WorkEvent::ManagerHatReleased(e) => self.apply_manager_hat_released(e),
+        }
+    }
+
+    pub fn replay(events: impl IntoIterator<Item = WorkEvent>) -> Result<Self, ProjectionError> {
+        let mut projection = Self::new();
+        for event in events {
+            projection.apply(&event)?;
+        }
+        Ok(projection)
+    }
+
+    pub fn snapshot(&self) -> BoardSnapshot {
+        BoardSnapshot {
+            cards: self.cards.values().cloned().collect(),
+            lanes: self.lanes.values().cloned().collect(),
+            workspaces: self.workspaces.values().cloned().collect(),
+            manager_hats: self.manager_hats.values().cloned().collect(),
+            hygiene_reports: self.hygiene_reports.clone(),
+        }
+    }
+
+    pub fn card(&self, card_id: WorkCardId) -> Option<&WorkCard> {
+        self.cards.get(&card_id)
+    }
+
+    pub fn workspace(&self, workspace_id: WorkspaceId) -> Option<&WorkspaceRecord> {
+        self.workspaces.get(&workspace_id)
+    }
+
+    pub fn stale_claims(&self, now_ms: u64) -> Vec<StaleClaim> {
+        self.cards
+            .values()
+            .filter_map(|card| {
+                let (owner, claim_id, expires_at_ms) =
+                    (card.owner?, card.claim_id?, card.claim_expires_at_ms?);
+                (expires_at_ms <= now_ms).then_some(StaleClaim {
+                    card_id: card.card_id,
+                    claim_id,
+                    owner,
+                    expired_at_ms: expires_at_ms,
+                })
+            })
+            .collect()
+    }
+
+    fn apply_card_created(&mut self, e: &CardCreated) -> Result<(), ProjectionError> {
+        if self.cards.contains_key(&e.card_id) {
+            return Err(ProjectionError::DuplicateCard(e.card_id));
+        }
+        let card = WorkCard {
+            card_id: e.card_id,
+            repo: e.repo.clone(),
+            title: e.title.clone(),
+            body: e.body.clone(),
+            priority: e.priority,
+            lane_id: e.lane_id,
+            state: CardState::Open,
+            owner: None,
+            claim_id: None,
+            claim_expires_at_ms: None,
+            last_heartbeat_at_ms: None,
+            pull_request: None,
+            created_by: e.created_by,
+            created_at_ms: e.created_at_ms,
+            updated_at_ms: e.created_at_ms,
+        };
+        self.cards.insert(e.card_id, card);
+        if let Some(lane_id) = e.lane_id {
+            if let Some(lane) = self.lanes.get_mut(&lane_id) {
+                lane.card_ids.push(e.card_id);
+            }
+        }
+        Ok(())
+    }
+
+    fn apply_card_claimed(&mut self, e: &WorkCardClaimed) -> Result<(), ProjectionError> {
+        let card = self.card_mut(e.card_id)?;
+        card.state = CardState::Claimed;
+        card.owner = Some(e.owner);
+        card.claim_id = Some(e.claim_id);
+        card.claim_expires_at_ms = Some(e.claimed_at_ms + e.ttl_ms);
+        card.last_heartbeat_at_ms = Some(e.claimed_at_ms);
+        card.updated_at_ms = e.claimed_at_ms;
+        Ok(())
+    }
+
+    fn apply_claim_heartbeat(&mut self, e: &ClaimHeartbeat) -> Result<(), ProjectionError> {
+        let card = self.card_mut(e.card_id)?;
+        ensure_claim(card, e.claim_id)?;
+        card.claim_expires_at_ms = Some(e.heartbeat_at_ms + e.ttl_ms);
+        card.last_heartbeat_at_ms = Some(e.heartbeat_at_ms);
+        card.updated_at_ms = e.heartbeat_at_ms;
+        Ok(())
+    }
+
+    fn apply_claim_released(&mut self, e: &ClaimReleased) -> Result<(), ProjectionError> {
+        let card = self.card_mut(e.card_id)?;
+        ensure_claim(card, e.claim_id)?;
+        card.state = CardState::Open;
+        card.owner = None;
+        card.claim_id = None;
+        card.claim_expires_at_ms = None;
+        card.updated_at_ms = e.released_at_ms;
+        Ok(())
+    }
+
+    fn apply_card_state_changed(&mut self, e: &CardStateChanged) -> Result<(), ProjectionError> {
+        let card = self.card_mut(e.card_id)?;
+        card.state = e.state;
+        card.updated_at_ms = e.changed_at_ms;
+        Ok(())
+    }
+
+    fn apply_lane_created(&mut self, e: &LaneCreated) -> Result<(), ProjectionError> {
+        if self.lanes.contains_key(&e.lane_id) {
+            return Err(ProjectionError::DuplicateLane(e.lane_id));
+        }
+        self.lanes.insert(
+            e.lane_id,
+            LaneRecord {
+                lane_id: e.lane_id,
+                repo: e.repo.clone(),
+                title: e.title.clone(),
+                state: e.state,
+                card_ids: Vec::new(),
+                created_by: e.created_by,
+                created_at_ms: e.created_at_ms,
+                updated_at_ms: e.created_at_ms,
+            },
+        );
+        Ok(())
+    }
+
+    fn apply_lane_state_changed(&mut self, e: &LaneStateChanged) -> Result<(), ProjectionError> {
+        let lane = self
+            .lanes
+            .get_mut(&e.lane_id)
+            .ok_or(ProjectionError::UnknownLane(e.lane_id))?;
+        lane.state = e.state;
+        lane.updated_at_ms = e.changed_at_ms;
+        Ok(())
+    }
+
+    fn apply_workspace_requested(&mut self, e: &WorkspaceRequested) -> Result<(), ProjectionError> {
+        if !self.cards.contains_key(&e.card_id) {
+            return Err(ProjectionError::UnknownCard(e.card_id));
+        }
+        self.workspaces.insert(
+            e.workspace_id,
+            WorkspaceRecord {
+                lease: WorkspaceLease {
+                    workspace_id: e.workspace_id,
+                    card_id: e.card_id,
+                    claim_id: e.claim_id,
+                    owner: e.owner,
+                    repo: e.repo.clone(),
+                    path: String::new(),
+                    branch: e.branch.clone(),
+                    base: e.base.clone(),
+                    status: WorkspaceStatus::Requested,
+                    disk_bytes: None,
+                    created_at_ms: e.requested_at_ms,
+                    heartbeat_at_ms: e.requested_at_ms,
+                    released_at_ms: None,
+                },
+            },
+        );
+        Ok(())
+    }
+
+    fn apply_workspace_allocated(&mut self, e: &WorkspaceAllocated) -> Result<(), ProjectionError> {
+        let workspace = self.workspace_mut(e.workspace_id)?;
+        workspace.lease.path = e.path.clone();
+        workspace.lease.status = WorkspaceStatus::Allocated;
+        workspace.lease.heartbeat_at_ms = e.allocated_at_ms;
+        Ok(())
+    }
+
+    fn apply_workspace_heartbeat(&mut self, e: &WorkspaceHeartbeat) -> Result<(), ProjectionError> {
+        let workspace = self.workspace_mut(e.workspace_id)?;
+        workspace.lease.status = WorkspaceStatus::Active;
+        workspace.lease.disk_bytes = e.disk_bytes;
+        workspace.lease.heartbeat_at_ms = e.heartbeat_at_ms;
+        Ok(())
+    }
+
+    fn apply_workspace_released(&mut self, e: &WorkspaceReleased) -> Result<(), ProjectionError> {
+        let workspace = self.workspace_mut(e.workspace_id)?;
+        workspace.lease.status = WorkspaceStatus::Released;
+        workspace.lease.released_at_ms = Some(e.released_at_ms);
+        Ok(())
+    }
+
+    fn apply_pull_request_linked(&mut self, e: &PullRequestLinked) -> Result<(), ProjectionError> {
+        let card = self.card_mut(e.card_id)?;
+        card.pull_request = Some(e.pull_request.clone());
+        card.state = CardState::Review;
+        card.updated_at_ms = e.linked_at_ms;
+        Ok(())
+    }
+
+    fn apply_pull_request_merged(&mut self, e: &PullRequestMerged) -> Result<(), ProjectionError> {
+        let card = self.card_mut(e.card_id)?;
+        card.pull_request = Some(e.pull_request.clone());
+        card.state = CardState::Merged;
+        card.updated_at_ms = e.merged_at_ms;
+        Ok(())
+    }
+
+    fn apply_hygiene_report_recorded(
+        &mut self,
+        e: &HygieneReportRecorded,
+    ) -> Result<(), ProjectionError> {
+        self.hygiene_reports.push(e.report.clone());
+        Ok(())
+    }
+
+    fn apply_manager_hat_claimed(&mut self, e: &ManagerHatClaimed) -> Result<(), ProjectionError> {
+        self.manager_hats.insert(
+            e.repo.clone(),
+            ManagerHat {
+                repo: e.repo.clone(),
+                manager: e.manager,
+                expires_at_ms: e.claimed_at_ms + e.ttl_ms,
+                claimed_at_ms: e.claimed_at_ms,
+            },
+        );
+        Ok(())
+    }
+
+    fn apply_manager_hat_released(
+        &mut self,
+        e: &ManagerHatReleased,
+    ) -> Result<(), ProjectionError> {
+        if let Some(hat) = self.manager_hats.get(&e.repo) {
+            if hat.manager == e.manager {
+                self.manager_hats.remove(&e.repo);
+            }
+        }
+        Ok(())
+    }
+
+    fn card_mut(&mut self, card_id: WorkCardId) -> Result<&mut WorkCard, ProjectionError> {
+        self.cards
+            .get_mut(&card_id)
+            .ok_or(ProjectionError::UnknownCard(card_id))
+    }
+
+    fn workspace_mut(
+        &mut self,
+        workspace_id: WorkspaceId,
+    ) -> Result<&mut WorkspaceRecord, ProjectionError> {
+        self.workspaces
+            .get_mut(&workspace_id)
+            .ok_or(ProjectionError::UnknownWorkspace(workspace_id))
+    }
+}
+
+fn ensure_claim(card: &WorkCard, got: crate::ids::ClaimId) -> Result<(), ProjectionError> {
+    if card.claim_id == Some(got) {
+        return Ok(());
+    }
+    Err(ProjectionError::ClaimMismatch {
+        card_id: card.card_id,
+        expected: card.claim_id,
+        got,
+    })
+}

--- a/crates/airc-work/src/projection/tests.rs
+++ b/crates/airc-work/src/projection/tests.rs
@@ -1,0 +1,200 @@
+use super::*;
+use crate::event::*;
+use crate::model::{BranchName, CardState, Priority, PullRequestRef, WorkspaceStatus};
+
+fn repo() -> RepoId {
+    RepoId::new("CambrianTech/airc").unwrap()
+}
+
+fn peer(seed: u128) -> PeerId {
+    PeerId::from_u128(seed)
+}
+
+#[test]
+fn card_claim_heartbeat_and_stale_detection_project_from_events() {
+    let card_id = WorkCardId::from_u128(1);
+    let claim_id = ClaimId::from_u128(2);
+    let owner = peer(3);
+    let mut projection = WorkBoardProjection::new();
+
+    projection
+        .apply(&WorkEvent::CardCreated(CardCreated {
+            card_id,
+            repo: repo(),
+            title: "typed work domain".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+            created_by: owner,
+            created_at_ms: 100,
+        }))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::CardClaimed(WorkCardClaimed {
+            card_id,
+            claim_id,
+            owner,
+            ttl_ms: 100,
+            claimed_at_ms: 110,
+        }))
+        .unwrap();
+
+    let card = projection.card(card_id).unwrap();
+    assert_eq!(card.state, CardState::Claimed);
+    assert_eq!(card.claim_expires_at_ms, Some(210));
+    assert!(projection.stale_claims(209).is_empty());
+    assert_eq!(projection.stale_claims(210).len(), 1);
+
+    projection
+        .apply(&WorkEvent::ClaimHeartbeat(ClaimHeartbeat {
+            card_id,
+            claim_id,
+            owner,
+            ttl_ms: 100,
+            heartbeat_at_ms: 200,
+        }))
+        .unwrap();
+    assert!(projection.stale_claims(299).is_empty());
+    assert_eq!(projection.stale_claims(300)[0].claim_id, claim_id);
+}
+
+#[test]
+fn lane_card_and_pr_merge_projection_is_deterministic() {
+    let repo = repo();
+    let lane_id = LaneId::from_u128(10);
+    let card_id = WorkCardId::from_u128(11);
+    let owner = peer(12);
+    let pr = PullRequestRef {
+        repo: repo.clone(),
+        number: 693,
+        head: BranchName::new("feat/airc-work-domain").unwrap(),
+        base: BranchName::new("rust-rewrite").unwrap(),
+    };
+    let projection = WorkBoardProjection::replay(vec![
+        WorkEvent::LaneCreated(LaneCreated {
+            lane_id,
+            repo: repo.clone(),
+            title: "Work coordination domain".to_string(),
+            state: LaneState::Active,
+            created_by: owner,
+            created_at_ms: 1,
+        }),
+        WorkEvent::CardCreated(CardCreated {
+            card_id,
+            repo,
+            title: "Create airc-work".to_string(),
+            body: None,
+            priority: Priority::P0,
+            lane_id: Some(lane_id),
+            created_by: owner,
+            created_at_ms: 2,
+        }),
+        WorkEvent::PullRequestLinked(PullRequestLinked {
+            card_id,
+            pull_request: pr.clone(),
+            linked_by: owner,
+            linked_at_ms: 3,
+        }),
+        WorkEvent::PullRequestMerged(PullRequestMerged {
+            card_id,
+            pull_request: pr.clone(),
+            merged_by: owner,
+            merged_at_ms: 4,
+        }),
+    ])
+    .unwrap();
+
+    let snapshot = projection.snapshot();
+    assert_eq!(snapshot.lanes[0].card_ids, vec![card_id]);
+    let card = projection.card(card_id).unwrap();
+    assert_eq!(card.state, CardState::Merged);
+    assert_eq!(card.pull_request, Some(pr));
+}
+
+#[test]
+fn workspace_lease_lifecycle_projects_status_and_disk() {
+    let card_id = WorkCardId::from_u128(1);
+    let claim_id = ClaimId::from_u128(2);
+    let workspace_id = WorkspaceId::from_u128(3);
+    let owner = peer(4);
+    let repo = repo();
+    let mut projection = WorkBoardProjection::new();
+    projection
+        .apply(&WorkEvent::CardCreated(CardCreated {
+            card_id,
+            repo: repo.clone(),
+            title: "workspace lifecycle".to_string(),
+            body: None,
+            priority: Priority::P2,
+            lane_id: None,
+            created_by: owner,
+            created_at_ms: 1,
+        }))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::WorkspaceRequested(WorkspaceRequested {
+            workspace_id,
+            card_id,
+            claim_id,
+            owner,
+            repo,
+            branch: BranchName::new("feat/workspace").unwrap(),
+            base: BranchName::new("rust-rewrite").unwrap(),
+            requested_at_ms: 2,
+        }))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::WorkspaceAllocated(WorkspaceAllocated {
+            workspace_id,
+            path: "/tmp/airc-worktrees/ws".to_string(),
+            allocated_at_ms: 3,
+        }))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::WorkspaceHeartbeat(WorkspaceHeartbeat {
+            workspace_id,
+            disk_bytes: Some(4096),
+            heartbeat_at_ms: 4,
+        }))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::WorkspaceReleased(WorkspaceReleased {
+            workspace_id,
+            released_at_ms: 5,
+        }))
+        .unwrap();
+
+    let workspace = projection.workspace(workspace_id).unwrap();
+    assert_eq!(workspace.lease.status, WorkspaceStatus::Released);
+    assert_eq!(workspace.lease.disk_bytes, Some(4096));
+    assert_eq!(workspace.lease.released_at_ms, Some(5));
+}
+
+#[test]
+fn mismatched_claim_is_rejected() {
+    let card_id = WorkCardId::from_u128(1);
+    let owner = peer(3);
+    let mut projection = WorkBoardProjection::new();
+    projection
+        .apply(&WorkEvent::CardCreated(CardCreated {
+            card_id,
+            repo: repo(),
+            title: "claim mismatch".to_string(),
+            body: None,
+            priority: Priority::P2,
+            lane_id: None,
+            created_by: owner,
+            created_at_ms: 1,
+        }))
+        .unwrap();
+    let err = projection
+        .apply(&WorkEvent::ClaimHeartbeat(ClaimHeartbeat {
+            card_id,
+            claim_id: ClaimId::from_u128(9),
+            owner,
+            ttl_ms: 1,
+            heartbeat_at_ms: 2,
+        }))
+        .unwrap_err();
+    assert!(matches!(err, ProjectionError::ClaimMismatch { .. }));
+}


### PR DESCRIPTION
## Work intake

- **Slice:** PR1 of Rust work coordination domain
- **Goal:** Define typed queue/lane/workspace events and projections before porting Python queue/lane commands.
- **Python/shell impact:** none; this adds Rust substrate contracts only.
- **Out of scope:** GitHub adapter, CLI commands, daemon subscriptions, hygiene execution.

## Summary

Adds a new `airc-work` crate with:

- UUID-backed `WorkCardId`, `LaneId`, `ClaimId`, `WorkspaceId` and validated `RepoId` / `BranchName` wrappers.
- Typed `WorkEvent` contracts for cards, claims, heartbeats, lanes, workspaces, PR links/merges, hygiene reports, and manager-hat state.
- Stable model types for card state, lane state, workspace leases, PR refs, priorities, and hygiene reports.
- `WorkBoardProjection` in-memory replay surface with stale-claim detection and deterministic board snapshots.
- Unit tests for event serialization, claim TTL/staleness, lane/card/PR projection, workspace lifecycle, and claim mismatch rejection.

## Design boundary

This is deliberately not a port of the Python queue commands. GitHub issues/PRs become adapters later; AIRC owns typed events and projections first.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p airc-work`
- `cargo test --workspace --all-features`
