### PR TITLE
feat(airc-work): add routable event codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ name = "airc-work"
 version = "0.1.0"
 dependencies = [
  "airc-core",
+ "airc-protocol",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/crates/airc-work/Cargo.toml
+++ b/crates/airc-work/Cargo.toml
@@ -11,9 +11,8 @@ publish = false
 
 [dependencies]
 airc-core = { path = "../airc-core" }
+airc-protocol = { path = "../airc-protocol" }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
-
-[dev-dependencies]
-serde_json = "1"

--- a/crates/airc-work/src/codec/headers.rs
+++ b/crates/airc-work/src/codec/headers.rs
@@ -1,0 +1,99 @@
+//! Header projection for work-domain events.
+
+use airc_core::Headers;
+use airc_protocol::HEADER_FORGE_BODY_HINT;
+
+use crate::codec::{event_kind, BODY_HINT_FORGE_WORK_EVENT};
+use crate::event::WorkEvent;
+
+pub const HEADER_FORGE_WORK_EVENT_KIND: &str = "forge.work.kind";
+pub const HEADER_FORGE_WORK_REPO: &str = "forge.work.repo";
+pub const HEADER_FORGE_WORK_CARD_ID: &str = "forge.work.card_id";
+pub const HEADER_FORGE_WORK_LANE_ID: &str = "forge.work.lane_id";
+pub const HEADER_FORGE_WORK_CLAIM_ID: &str = "forge.work.claim_id";
+pub const HEADER_FORGE_WORK_WORKSPACE_ID: &str = "forge.work.workspace_id";
+
+pub fn work_event_headers(event: &WorkEvent) -> Headers {
+    let mut headers = Headers::new();
+    headers.insert(
+        HEADER_FORGE_BODY_HINT.to_string(),
+        BODY_HINT_FORGE_WORK_EVENT.to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_WORK_EVENT_KIND.to_string(),
+        event_kind(event).to_string(),
+    );
+    project_domain_headers(event, &mut headers);
+    headers
+}
+
+fn project_domain_headers(event: &WorkEvent, headers: &mut Headers) {
+    match event {
+        WorkEvent::CardCreated(e) => {
+            insert_display_header(headers, HEADER_FORGE_WORK_CARD_ID, e.card_id);
+            headers.insert(HEADER_FORGE_WORK_REPO.to_string(), e.repo.to_string());
+            if let Some(lane_id) = e.lane_id {
+                insert_display_header(headers, HEADER_FORGE_WORK_LANE_ID, lane_id);
+            }
+        }
+        WorkEvent::CardClaimed(e) => project_claim(headers, e.card_id, e.claim_id),
+        WorkEvent::ClaimHeartbeat(e) => project_claim(headers, e.card_id, e.claim_id),
+        WorkEvent::ClaimReleased(e) => project_claim(headers, e.card_id, e.claim_id),
+        WorkEvent::CardStateChanged(e) => {
+            insert_display_header(headers, HEADER_FORGE_WORK_CARD_ID, e.card_id);
+        }
+        WorkEvent::LaneCreated(e) => {
+            insert_display_header(headers, HEADER_FORGE_WORK_LANE_ID, e.lane_id);
+            headers.insert(HEADER_FORGE_WORK_REPO.to_string(), e.repo.to_string());
+        }
+        WorkEvent::LaneStateChanged(e) => {
+            insert_display_header(headers, HEADER_FORGE_WORK_LANE_ID, e.lane_id);
+        }
+        WorkEvent::WorkspaceRequested(e) => {
+            insert_display_header(headers, HEADER_FORGE_WORK_WORKSPACE_ID, e.workspace_id);
+            project_claim(headers, e.card_id, e.claim_id);
+            headers.insert(HEADER_FORGE_WORK_REPO.to_string(), e.repo.to_string());
+        }
+        WorkEvent::WorkspaceAllocated(e) => {
+            insert_display_header(headers, HEADER_FORGE_WORK_WORKSPACE_ID, e.workspace_id);
+        }
+        WorkEvent::WorkspaceHeartbeat(e) => {
+            insert_display_header(headers, HEADER_FORGE_WORK_WORKSPACE_ID, e.workspace_id);
+        }
+        WorkEvent::WorkspaceReleased(e) => {
+            insert_display_header(headers, HEADER_FORGE_WORK_WORKSPACE_ID, e.workspace_id);
+        }
+        WorkEvent::PullRequestLinked(e) => {
+            project_pull_request(headers, e.card_id, &e.pull_request.repo)
+        }
+        WorkEvent::PullRequestMerged(e) => {
+            project_pull_request(headers, e.card_id, &e.pull_request.repo)
+        }
+        WorkEvent::HygieneReportRecorded(e) => {
+            headers.insert(
+                HEADER_FORGE_WORK_REPO.to_string(),
+                e.report.repo.to_string(),
+            );
+        }
+        WorkEvent::ManagerHatClaimed(e) => {
+            headers.insert(HEADER_FORGE_WORK_REPO.to_string(), e.repo.to_string());
+        }
+        WorkEvent::ManagerHatReleased(e) => {
+            headers.insert(HEADER_FORGE_WORK_REPO.to_string(), e.repo.to_string());
+        }
+    }
+}
+
+fn project_claim(headers: &mut Headers, card_id: crate::WorkCardId, claim_id: crate::ClaimId) {
+    insert_display_header(headers, HEADER_FORGE_WORK_CARD_ID, card_id);
+    insert_display_header(headers, HEADER_FORGE_WORK_CLAIM_ID, claim_id);
+}
+
+fn project_pull_request(headers: &mut Headers, card_id: crate::WorkCardId, repo: &crate::RepoId) {
+    insert_display_header(headers, HEADER_FORGE_WORK_CARD_ID, card_id);
+    headers.insert(HEADER_FORGE_WORK_REPO.to_string(), repo.to_string());
+}
+
+fn insert_display_header(headers: &mut Headers, key: &str, value: impl std::fmt::Display) {
+    headers.insert(key.to_string(), value.to_string());
+}

--- a/crates/airc-work/src/codec/mod.rs
+++ b/crates/airc-work/src/codec/mod.rs
@@ -1,0 +1,102 @@
+//! Header/body codec for work-domain events.
+//!
+//! AIRC routes on cheap envelope headers. The work event itself stays in
+//! the opaque body so substrate transports do not need to understand
+//! kanban, workspaces, GitHub, Codex, Continuum, OpenClaw, or Hermes.
+
+use std::collections::BTreeSet;
+
+use airc_core::{Body, HeaderFilter, Headers};
+use airc_protocol::{FrameKind, Subscription, HEADER_FORGE_BODY_HINT};
+
+use crate::event::WorkEvent;
+
+mod headers;
+#[cfg(test)]
+mod tests;
+
+pub use headers::{
+    work_event_headers, HEADER_FORGE_WORK_CARD_ID, HEADER_FORGE_WORK_CLAIM_ID,
+    HEADER_FORGE_WORK_EVENT_KIND, HEADER_FORGE_WORK_LANE_ID, HEADER_FORGE_WORK_REPO,
+    HEADER_FORGE_WORK_WORKSPACE_ID,
+};
+
+pub const BODY_HINT_FORGE_WORK_EVENT: &str = "forge.work.event.v1";
+
+#[derive(Debug, thiserror::Error)]
+pub enum WorkEventCodecError {
+    #[error("work event body is missing")]
+    MissingBody,
+    #[error("work event body must be JSON")]
+    NonJsonBody,
+    #[error("work event body uses hint {actual:?}, expected {expected:?}")]
+    BodyHintMismatch {
+        actual: Option<String>,
+        expected: &'static str,
+    },
+    #[error("work event JSON codec failed: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+pub fn encode_work_event(event: &WorkEvent) -> Result<(Headers, Body), WorkEventCodecError> {
+    Ok((
+        work_event_headers(event),
+        Body::Json(serde_json::to_value(event)?),
+    ))
+}
+
+pub fn decode_work_event(
+    headers: &Headers,
+    body: Option<&Body>,
+) -> Result<WorkEvent, WorkEventCodecError> {
+    require_work_event_hint(headers)?;
+    let Some(body) = body else {
+        return Err(WorkEventCodecError::MissingBody);
+    };
+    let Body::Json(value) = body else {
+        return Err(WorkEventCodecError::NonJsonBody);
+    };
+    Ok(serde_json::from_value(value.clone())?)
+}
+
+pub fn work_event_subscription() -> Subscription {
+    Subscription {
+        kinds: BTreeSet::from([FrameKind::Event]),
+        headers_filter: HeaderFilter::Exact {
+            key: HEADER_FORGE_BODY_HINT.to_string(),
+            value: BODY_HINT_FORGE_WORK_EVENT.to_string(),
+        },
+        ..Default::default()
+    }
+}
+
+fn require_work_event_hint(headers: &Headers) -> Result<(), WorkEventCodecError> {
+    match headers.get(HEADER_FORGE_BODY_HINT) {
+        Some(value) if value == BODY_HINT_FORGE_WORK_EVENT => Ok(()),
+        actual => Err(WorkEventCodecError::BodyHintMismatch {
+            actual: actual.cloned(),
+            expected: BODY_HINT_FORGE_WORK_EVENT,
+        }),
+    }
+}
+
+pub(crate) fn event_kind(event: &WorkEvent) -> &'static str {
+    match event {
+        WorkEvent::CardCreated(_) => "card_created",
+        WorkEvent::CardClaimed(_) => "card_claimed",
+        WorkEvent::ClaimHeartbeat(_) => "claim_heartbeat",
+        WorkEvent::ClaimReleased(_) => "claim_released",
+        WorkEvent::CardStateChanged(_) => "card_state_changed",
+        WorkEvent::LaneCreated(_) => "lane_created",
+        WorkEvent::LaneStateChanged(_) => "lane_state_changed",
+        WorkEvent::WorkspaceRequested(_) => "workspace_requested",
+        WorkEvent::WorkspaceAllocated(_) => "workspace_allocated",
+        WorkEvent::WorkspaceHeartbeat(_) => "workspace_heartbeat",
+        WorkEvent::WorkspaceReleased(_) => "workspace_released",
+        WorkEvent::PullRequestLinked(_) => "pull_request_linked",
+        WorkEvent::PullRequestMerged(_) => "pull_request_merged",
+        WorkEvent::HygieneReportRecorded(_) => "hygiene_report_recorded",
+        WorkEvent::ManagerHatClaimed(_) => "manager_hat_claimed",
+        WorkEvent::ManagerHatReleased(_) => "manager_hat_released",
+    }
+}

--- a/crates/airc-work/src/codec/tests.rs
+++ b/crates/airc-work/src/codec/tests.rs
@@ -1,0 +1,118 @@
+use airc_core::{Body, PeerId};
+use airc_protocol::{FrameKind, HEADER_FORGE_BODY_HINT};
+
+use super::*;
+use crate::{
+    BranchName, CardCreated, ClaimId, LaneId, Priority, RepoId, WorkCardId, WorkEvent, WorkspaceId,
+    WorkspaceRequested,
+};
+
+fn card_created() -> WorkEvent {
+    WorkEvent::CardCreated(CardCreated {
+        card_id: WorkCardId::from_u128(1),
+        repo: RepoId::new("CambrianTech/airc").unwrap(),
+        title: "make work events routable".to_string(),
+        body: None,
+        priority: Priority::P1,
+        lane_id: Some(LaneId::from_u128(2)),
+        created_by: PeerId::from_u128(3),
+        created_at_ms: 4,
+    })
+}
+
+#[test]
+fn work_event_roundtrips_through_headers_and_body() {
+    let event = card_created();
+
+    let (headers, body) = encode_work_event(&event).unwrap();
+    let decoded = decode_work_event(&headers, Some(&body)).unwrap();
+
+    assert_eq!(decoded, event);
+    assert_eq!(
+        headers.get(HEADER_FORGE_BODY_HINT).map(String::as_str),
+        Some(BODY_HINT_FORGE_WORK_EVENT)
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_WORK_EVENT_KIND)
+            .map(String::as_str),
+        Some("card_created")
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_WORK_REPO).map(String::as_str),
+        Some("CambrianTech/airc")
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_WORK_CARD_ID).map(String::as_str),
+        Some("00000000-0000-0000-0000-000000000001")
+    );
+}
+
+#[test]
+fn subscription_matches_work_events_without_parsing_body() {
+    let event = card_created();
+    let (headers, _) = encode_work_event(&event).unwrap();
+    let sub = work_event_subscription();
+
+    assert!(sub.headers_filter.matches(&headers));
+    assert!(sub.kinds.contains(&FrameKind::Event));
+}
+
+#[test]
+fn decode_rejects_wrong_hint_and_non_json_body() {
+    let event = card_created();
+    let (mut headers, _) = encode_work_event(&event).unwrap();
+    headers.insert(
+        HEADER_FORGE_BODY_HINT.to_string(),
+        "forge.chat.text".to_string(),
+    );
+
+    assert!(matches!(
+        decode_work_event(&headers, Some(&Body::text("not work"))),
+        Err(WorkEventCodecError::BodyHintMismatch { .. })
+    ));
+
+    headers.insert(
+        HEADER_FORGE_BODY_HINT.to_string(),
+        BODY_HINT_FORGE_WORK_EVENT.to_string(),
+    );
+    assert!(matches!(
+        decode_work_event(&headers, Some(&Body::Binary(vec![1, 2, 3]))),
+        Err(WorkEventCodecError::NonJsonBody)
+    ));
+}
+
+#[test]
+fn workspace_headers_include_workspace_claim_card_and_repo() {
+    let event = WorkEvent::WorkspaceRequested(WorkspaceRequested {
+        workspace_id: WorkspaceId::from_u128(10),
+        card_id: WorkCardId::from_u128(11),
+        claim_id: ClaimId::from_u128(12),
+        owner: PeerId::from_u128(13),
+        repo: RepoId::new("CambrianTech/continuum").unwrap(),
+        branch: BranchName::new("feat/rust-work").unwrap(),
+        base: BranchName::new("rust-rewrite").unwrap(),
+        requested_at_ms: 14,
+    });
+
+    let headers = work_event_headers(&event);
+
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_WORK_WORKSPACE_ID)
+            .map(String::as_str),
+        Some("00000000-0000-0000-0000-00000000000a")
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_WORK_CARD_ID).map(String::as_str),
+        Some("00000000-0000-0000-0000-00000000000b")
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_WORK_CLAIM_ID).map(String::as_str),
+        Some("00000000-0000-0000-0000-00000000000c")
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_WORK_REPO).map(String::as_str),
+        Some("CambrianTech/continuum")
+    );
+}

--- a/crates/airc-work/src/lib.rs
+++ b/crates/airc-work/src/lib.rs
@@ -5,11 +5,18 @@
 //! issues/PRs are adapters that mirror these events; they are not the
 //! runtime source of truth.
 
+pub mod codec;
 pub mod event;
 pub mod ids;
 pub mod model;
 pub mod projection;
 
+pub use codec::{
+    decode_work_event, encode_work_event, work_event_headers, work_event_subscription,
+    WorkEventCodecError, BODY_HINT_FORGE_WORK_EVENT, HEADER_FORGE_WORK_CARD_ID,
+    HEADER_FORGE_WORK_CLAIM_ID, HEADER_FORGE_WORK_EVENT_KIND, HEADER_FORGE_WORK_LANE_ID,
+    HEADER_FORGE_WORK_REPO, HEADER_FORGE_WORK_WORKSPACE_ID,
+};
 pub use event::{
     CardCreated, CardStateChanged, ClaimHeartbeat, ClaimReleased, HygieneReportRecorded,
     LaneCreated, LaneStateChanged, ManagerHatClaimed, ManagerHatReleased, PullRequestLinked,


### PR DESCRIPTION
## Summary
- add work-domain header/body codec for typed WorkEvent payloads
- add forge.work.* header constants for cheap subscription routing by repo/card/lane/claim/workspace
- add work_event_subscription() for monitors, hooks, and consumers to subscribe without body parsing

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test -p airc-work
- cargo test --workspace --all-features