### PR TITLE
feat(airc-work-store): project persisted work events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-work-store"
+version = "0.1.0"
+dependencies = [
+ "airc-core",
+ "airc-store",
+ "airc-work",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/airc-transport",
     "crates/airc-store",
     "crates/airc-work",
+    "crates/airc-work-store",
     "crates/airc-daemon",
     "crates/airc-lib",
     "crates/airc-cli",

--- a/crates/airc-work-store/Cargo.toml
+++ b/crates/airc-work-store/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "airc-work-store"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+# Store bridge for the work coordination domain. Keeps airc-work pure
+# and lets CLI/hooks/Continuum query persisted work state through the
+# generic EventStore contract.
+
+[dependencies]
+airc-core = { path = "../airc-core" }
+airc-store = { path = "../airc-store" }
+airc-work = { path = "../airc-work" }
+thiserror = "1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "macros"] }
+serde_json = "1"

--- a/crates/airc-work-store/src/lib.rs
+++ b/crates/airc-work-store/src/lib.rs
@@ -1,0 +1,104 @@
+//! `airc-work-store` — projection queries over persisted AIRC events.
+//!
+//! This crate is deliberately thin: it depends on the generic
+//! `airc-store::EventStore` trait, decodes recorded work-domain
+//! transcripts through `airc-work`, and returns deterministic board
+//! projections. No SQL, GitHub, CLI, hook, or Continuum policy lives
+//! here.
+
+#![deny(unsafe_code)]
+
+use airc_core::{RoomId, TranscriptCursor, TranscriptEvent};
+use airc_store::{EventStore, StoreError};
+use airc_work::{
+    decode_transcript_work_event, transcript_is_work_event, ProjectionError, WorkBoardProjection,
+    WorkEvent, WorkReplayError,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct WorkEventPage {
+    pub events: Vec<WorkEvent>,
+    pub newest_cursor: Option<TranscriptCursor>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WorkStoreError {
+    #[error("event store failed: {0}")]
+    Store(#[from] StoreError),
+    #[error("work replay failed: {0}")]
+    Replay(#[from] WorkReplayError),
+    #[error("work projection failed: {0}")]
+    Projection(#[from] ProjectionError),
+}
+
+pub struct WorkEventStore<'store, S: ?Sized> {
+    store: &'store S,
+}
+
+impl<'store, S> WorkEventStore<'store, S>
+where
+    S: EventStore + ?Sized,
+{
+    pub fn new(store: &'store S) -> Self {
+        Self { store }
+    }
+
+    pub async fn page_recent(
+        &self,
+        channel: Option<RoomId>,
+        limit: usize,
+    ) -> Result<WorkEventPage, WorkStoreError> {
+        let transcripts = self.store.page_recent(channel, limit).await?;
+        decode_page(transcripts)
+    }
+
+    pub async fn resume_from(
+        &self,
+        cursor: &TranscriptCursor,
+        channel: Option<RoomId>,
+        limit: usize,
+    ) -> Result<WorkEventPage, WorkStoreError> {
+        let transcripts = self.store.resume_from(cursor, channel, limit).await?;
+        decode_page(transcripts)
+    }
+
+    pub async fn project_recent(
+        &self,
+        channel: Option<RoomId>,
+        limit: usize,
+    ) -> Result<WorkBoardProjection, WorkStoreError> {
+        let page = self.page_recent(channel, limit).await?;
+        Ok(WorkBoardProjection::replay(page.events)?)
+    }
+
+    pub async fn project_from(
+        &self,
+        cursor: &TranscriptCursor,
+        channel: Option<RoomId>,
+        limit: usize,
+    ) -> Result<WorkBoardProjection, WorkStoreError> {
+        let page = self.resume_from(cursor, channel, limit).await?;
+        Ok(WorkBoardProjection::replay(page.events)?)
+    }
+}
+
+fn decode_page(transcripts: Vec<TranscriptEvent>) -> Result<WorkEventPage, WorkStoreError> {
+    let newest_cursor = transcripts.last().map(TranscriptEvent::cursor);
+    let mut events = Vec::new();
+
+    for transcript in transcripts {
+        if !transcript_is_work_event(&transcript) {
+            continue;
+        }
+        let item = decode_transcript_work_event(&transcript)?;
+        events.push(item.event);
+    }
+
+    Ok(WorkEventPage {
+        events,
+        newest_cursor,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/airc-work-store/src/tests.rs
+++ b/crates/airc-work-store/src/tests.rs
@@ -1,0 +1,148 @@
+use airc_core::{
+    Body, ClientId, EventId, Headers, MentionTarget, PeerId, RoomId, TranscriptEvent,
+    TranscriptKind,
+};
+use airc_store::{EventStore, InMemoryEventStore};
+use airc_work::{
+    encode_work_event, CardCreated, CardState, CardStateChanged, Priority, RepoId, WorkCardId,
+    WorkEvent,
+};
+
+use super::*;
+
+fn card_created(card_id: WorkCardId) -> WorkEvent {
+    WorkEvent::CardCreated(CardCreated {
+        card_id,
+        repo: RepoId::new("CambrianTech/airc").unwrap(),
+        title: "persisted work card".to_string(),
+        body: None,
+        priority: Priority::P1,
+        lane_id: None,
+        created_by: PeerId::from_u128(200),
+        created_at_ms: 1000,
+    })
+}
+
+fn card_state_changed(card_id: WorkCardId) -> WorkEvent {
+    WorkEvent::CardStateChanged(CardStateChanged {
+        card_id,
+        state: CardState::Review,
+        changed_by: PeerId::from_u128(201),
+        changed_at_ms: 2000,
+    })
+}
+
+fn work_transcript(
+    event_id: u128,
+    room_id: RoomId,
+    lamport: u64,
+    event: &WorkEvent,
+) -> TranscriptEvent {
+    let (headers, body) = encode_work_event(event).unwrap();
+    TranscriptEvent {
+        event_id: EventId::from_u128(event_id),
+        room_id,
+        peer_id: PeerId::from_u128(2),
+        client_id: ClientId::from_u128(3),
+        kind: TranscriptKind::System,
+        occurred_at_ms: event.occurred_at_ms(),
+        lamport,
+        target: MentionTarget::All,
+        headers,
+        body: Some(body),
+        attachment: None,
+        receipt: None,
+        metadata: serde_json::Value::Null,
+    }
+}
+
+fn chat_transcript(event_id: u128, room_id: RoomId, lamport: u64) -> TranscriptEvent {
+    TranscriptEvent {
+        event_id: EventId::from_u128(event_id),
+        room_id,
+        peer_id: PeerId::from_u128(2),
+        client_id: ClientId::from_u128(3),
+        kind: TranscriptKind::Message,
+        occurred_at_ms: 1000 + lamport,
+        lamport,
+        target: MentionTarget::All,
+        headers: Headers::new(),
+        body: Some(Body::text("plain chat")),
+        attachment: None,
+        receipt: None,
+        metadata: serde_json::Value::Null,
+    }
+}
+
+#[tokio::test]
+async fn page_recent_returns_only_decoded_work_events_and_latest_cursor() {
+    let store = InMemoryEventStore::new();
+    let room = RoomId::from_u128(10);
+    let card_id = WorkCardId::from_u128(20);
+
+    store
+        .append(work_transcript(1, room, 1, &card_created(card_id)))
+        .await
+        .unwrap();
+    store.append(chat_transcript(2, room, 2)).await.unwrap();
+    store
+        .append(work_transcript(3, room, 3, &card_state_changed(card_id)))
+        .await
+        .unwrap();
+
+    let work_store = WorkEventStore::new(&store);
+    let page = work_store.page_recent(Some(room), 10).await.unwrap();
+
+    assert_eq!(page.events.len(), 2);
+    assert_eq!(page.newest_cursor.unwrap().event_id, EventId::from_u128(3));
+}
+
+#[tokio::test]
+async fn project_recent_rebuilds_board_from_persisted_events() {
+    let store = InMemoryEventStore::new();
+    let room = RoomId::from_u128(10);
+    let card_id = WorkCardId::from_u128(20);
+
+    store
+        .append(work_transcript(1, room, 1, &card_created(card_id)))
+        .await
+        .unwrap();
+    store
+        .append(work_transcript(2, room, 2, &card_state_changed(card_id)))
+        .await
+        .unwrap();
+
+    let projection = WorkEventStore::new(&store)
+        .project_recent(Some(room), 10)
+        .await
+        .unwrap();
+
+    let card = projection.card(card_id).unwrap();
+    assert_eq!(card.state, CardState::Review);
+}
+
+#[tokio::test]
+async fn resume_from_uses_store_cursor_contract() {
+    let store = InMemoryEventStore::new();
+    let room = RoomId::from_u128(10);
+    let card_a = WorkCardId::from_u128(20);
+    let card_b = WorkCardId::from_u128(21);
+
+    store
+        .append(work_transcript(1, room, 1, &card_created(card_a)))
+        .await
+        .unwrap();
+    let cursor = store.latest_cursor(Some(room)).await.unwrap().unwrap();
+    store
+        .append(work_transcript(2, room, 2, &card_created(card_b)))
+        .await
+        .unwrap();
+
+    let page = WorkEventStore::new(&store)
+        .resume_from(&cursor, Some(room), 10)
+        .await
+        .unwrap();
+
+    assert_eq!(page.events, vec![card_created(card_b)]);
+    assert_eq!(page.newest_cursor.unwrap().event_id, EventId::from_u128(2));
+}


### PR DESCRIPTION
## Summary
- add airc-work-store bridge crate over the generic EventStore trait
- expose page/resume APIs that decode persisted work-domain transcript events
- expose projection helpers that rebuild WorkBoardProjection from stored work events
- keep storage policy out of airc-work and avoid SQL in this domain bridge

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test -p airc-work-store
- cargo test --workspace --all-features