### PR TITLE
feat(airc-lib): expose work coordination API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,8 @@ dependencies = [
  "airc-protocol",
  "airc-store",
  "airc-transport",
+ "airc-work",
+ "airc-work-store",
  "async-trait",
  "base64",
  "futures",

--- a/crates/airc-lib/Cargo.toml
+++ b/crates/airc-lib/Cargo.toml
@@ -23,6 +23,8 @@ airc-protocol = { path = "../airc-protocol" }
 airc-store = { path = "../airc-store" }
 airc-transport = { path = "../airc-transport" }
 airc-daemon = { path = "../airc-daemon" }
+airc-work = { path = "../airc-work" }
+airc-work-store = { path = "../airc-work-store" }
 
 async-trait = "0.1"
 base64 = "0.22"

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -21,28 +21,18 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::RwLock;
-use std::task::{Context, Poll};
 
-use airc_core::{
-    body::Body, headers::Headers, transcript::MentionTarget, ClientId, EventId, PeerId,
-    TranscriptCursor, TranscriptEvent,
-};
+use airc_core::{ClientId, PeerId, TranscriptEvent};
 use airc_daemon::{peers_store, LocalIdentity};
-use airc_protocol::{
-    Envelope, Frame, FrameKind, PeerKeyRegistry, Signature, Subscription, VerificationPolicy,
-};
+use airc_protocol::{PeerKeyRegistry, VerificationPolicy};
 use airc_store::{EventStore, SqliteEventStore};
-use airc_transport::{LocalFsAdapter, SignedTransport, Transport};
-use futures::stream::{Stream, StreamExt};
 use tokio::sync::{broadcast, Mutex};
-use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
 
 use crate::error::AircError;
-use crate::registry::PeerSpec;
 use crate::room::{self, Room};
+use crate::transport::WireSubscriber;
 
 const EVENTS_DB_FILENAME: &str = "events.sqlite";
 
@@ -71,30 +61,23 @@ const LIVE_BROADCAST_CAPACITY: usize = 1024;
 ///     get a `Stream<Item = TranscriptEvent>`.
 #[derive(Clone)]
 pub struct Airc {
-    inner: Arc<AircInner>,
+    pub(crate) inner: Arc<AircInner>,
 }
 
-struct AircInner {
-    home: PathBuf,
-    identity: LocalIdentity,
-    store: Arc<dyn EventStore>,
-    registry: Arc<RwLock<PeerKeyRegistry>>,
-    policy: VerificationPolicy,
+pub(crate) struct AircInner {
+    pub(crate) home: PathBuf,
+    pub(crate) identity: LocalIdentity,
+    pub(crate) store: Arc<dyn EventStore>,
+    pub(crate) registry: Arc<RwLock<PeerKeyRegistry>>,
+    pub(crate) policy: VerificationPolicy,
     /// Per-wire background subscriber tasks. Spawned lazily on first
     /// `say`/`send`/`subscribe`/`page_recent` referencing the wire.
     /// Held in a Mutex so concurrent calls can't double-spawn.
-    subscribers: Mutex<HashMap<PathBuf, WireSubscriber>>,
+    pub(crate) subscribers: Mutex<HashMap<PathBuf, WireSubscriber>>,
     /// Live event fan-out. Every event the subscribers append to the
     /// store is also forwarded here so consumers tailing via
     /// [`Airc::subscribe`] see it immediately.
-    live_tx: broadcast::Sender<TranscriptEvent>,
-}
-
-struct WireSubscriber {
-    /// Kept alive by ownership of its `JoinHandle`. Dropped when
-    /// `Airc` is dropped (since the AircInner holding it goes away),
-    /// which closes the underlying transport subscription.
-    _task: tokio::task::JoinHandle<()>,
+    pub(crate) live_tx: broadcast::Sender<TranscriptEvent>,
 }
 
 impl Airc {
@@ -172,15 +155,6 @@ impl Airc {
         self.inner.identity.client_id
     }
 
-    /// Return the peer-spec string suitable for sharing with another
-    /// peer so they can enrol this identity into their trust registry.
-    pub fn peer_spec(&self) -> String {
-        crate::registry::format_peer_spec(
-            self.inner.identity.peer_id,
-            &self.inner.identity.keypair.public_bytes(),
-        )
-    }
-
     /// Switch the current room to one derived from `name`. Same name
     /// on two peers yields the same channel UUID via UUIDv5, so they
     /// converge without exchanging the UUID out-of-band. Spawns a
@@ -212,308 +186,7 @@ impl Airc {
         Ok(room::load_or_default(&self.inner.home)?)
     }
 
-    /// Send a plain-text message to the current room. Returns the
-    /// event's `EventId` so callers can correlate or filter their
-    /// own echo via [`Airc::subscribe`].
-    pub async fn say(&self, text: &str) -> Result<EventId, AircError> {
-        self.send(Body::text(text), Headers::new()).await
+    pub(crate) fn event_store(&self) -> &dyn EventStore {
+        self.inner.store.as_ref()
     }
-
-    /// Send a frame with typed body and arbitrary headers to the
-    /// current room. Frame is signed under the local identity and
-    /// written through the room's local-fs wire. The room's
-    /// background subscriber will see the frame on the wire,
-    /// convert it to a `TranscriptEvent`, append it to the store,
-    /// and broadcast it to live [`subscribe`](Self::subscribe)
-    /// receivers — so `say(...).await` followed by
-    /// `page_recent(...)` reliably observes the new event.
-    pub async fn send(&self, body: Body, headers: Headers) -> Result<EventId, AircError> {
-        let room = self.current_room().await?;
-        self.ensure_wire_subscriber(&room.wire).await?;
-        let event_id = EventId::new();
-        let frame = Frame {
-            kind: FrameKind::Message,
-            envelope: Envelope {
-                event_id,
-                sender: self.inner.identity.peer_id,
-                sender_client: self.inner.identity.client_id,
-                channel: room.channel,
-                target: MentionTarget::All,
-                lamport: now_ms(),
-                occurred_at_ms: now_ms(),
-                reply_to: None,
-                headers,
-                body: Some(body),
-                media: Vec::new(),
-                signature: Signature::Unsigned,
-            },
-        };
-        let inner = LocalFsAdapter::new(&room.wire);
-        let transport = SignedTransport::new(
-            inner,
-            self.inner.identity.keypair.clone(),
-            self.inner.identity.peer_id,
-            self.inner.registry.clone(),
-            self.inner.policy,
-        );
-        transport
-            .send(frame)
-            .await
-            .map_err(|e| AircError::Transport(e.to_string()))?;
-        Ok(event_id)
-    }
-
-    /// Subscribe to the live event stream. Every event appended to
-    /// the durable store (by this `Airc` handle or by remote peers
-    /// the wire's subscriber sees) is forwarded to all live
-    /// subscribers. Lagged receivers get
-    /// [`broadcast::error::RecvError::Lagged`] rather than silent
-    /// drops — consumers that need durable replay use
-    /// [`Airc::resume_from`].
-    pub async fn subscribe(&self) -> Result<EventStream, AircError> {
-        let room = self.current_room().await?;
-        // Subscribe to the broadcast BEFORE spawning the wire
-        // subscriber, otherwise the wire-tail's replay-on-attach
-        // can fire events into the broadcast before this receiver
-        // exists and they're lost. tokio::broadcast only delivers
-        // events sent AFTER the subscribe call.
-        let rx = self.inner.live_tx.subscribe();
-        self.ensure_wire_subscriber(&room.wire).await?;
-        Ok(EventStream {
-            inner: BroadcastStream::new(rx),
-        })
-    }
-
-    /// Fetch the most recent `limit` events from the durable store,
-    /// filtered to the current room. Returns events in transcript
-    /// order (oldest → newest within the page).
-    pub async fn page_recent(&self, limit: usize) -> Result<Vec<TranscriptEvent>, AircError> {
-        let room = self.current_room().await?;
-        self.ensure_wire_subscriber(&room.wire).await?;
-        Ok(self
-            .inner
-            .store
-            .page_recent(Some(room.channel), limit)
-            .await?)
-    }
-
-    /// Fetch up to `limit` events strictly after `cursor` from the
-    /// current room. Use the cursor of the last event returned to
-    /// page forward.
-    pub async fn resume_from(
-        &self,
-        cursor: &TranscriptCursor,
-        limit: usize,
-    ) -> Result<Vec<TranscriptEvent>, AircError> {
-        let room = self.current_room().await?;
-        Ok(self
-            .inner
-            .store
-            .resume_from(cursor, Some(room.channel), limit)
-            .await?)
-    }
-
-    /// Cursor of the newest event in the current room, or `None` if
-    /// the room has no events yet.
-    pub async fn latest_cursor(&self) -> Result<Option<TranscriptCursor>, AircError> {
-        let room = self.current_room().await?;
-        Ok(self.inner.store.latest_cursor(Some(room.channel)).await?)
-    }
-
-    /// Append a `TranscriptEvent` to the durable store directly. The
-    /// caller is responsible for the event's identity/lamport fields
-    /// being correct. Useful for consumers replaying captured events
-    /// or for tests that want to seed history.
-    pub async fn append_event(&self, event: TranscriptEvent) -> Result<(), AircError> {
-        Ok(self.inner.store.append(event).await?)
-    }
-
-    /// Enrol a peer into the local trust registry and persist it to
-    /// `<home>/peers.json`. Pass the peer-spec the remote produced
-    /// via [`Airc::peer_spec`].
-    pub async fn add_peer(&self, spec: PeerSpec) -> Result<(), AircError> {
-        peers_store::add(&self.inner.home, spec.peer_id, spec.pubkey)?;
-        let mut registry = self
-            .inner
-            .registry
-            .write()
-            .map_err(|_| AircError::Crypto("registry lock poisoned".to_string()))?;
-        registry
-            .enrol(spec.peer_id, 0, spec.pubkey)
-            .map_err(|e| AircError::Crypto(e.to_string()))?;
-        Ok(())
-    }
-
-    /// Enrol a peer in the in-memory trust registry WITHOUT writing
-    /// to `peers.json`. Used by short-lived invocations (the CLI's
-    /// `--peer` flag, one-shot tooling) that want to trust a peer for
-    /// the current process only.
-    ///
-    /// Persistent enrolment goes through [`add_peer`] — this method
-    /// is intentionally volatile.
-    pub fn enrol_volatile_peer(&self, spec: &PeerSpec) -> Result<(), AircError> {
-        let mut registry = self
-            .inner
-            .registry
-            .write()
-            .map_err(|_| AircError::Crypto("registry lock poisoned".to_string()))?;
-        registry
-            .enrol(spec.peer_id, 0, spec.pubkey)
-            .map_err(|e| AircError::Crypto(e.to_string()))?;
-        Ok(())
-    }
-
-    /// Return a list of enrolled peers (read from peers.json — the
-    /// daemon writes the same file, so this view stays consistent).
-    pub async fn peers(&self) -> Result<Vec<EnrolledPeer>, AircError> {
-        let stored = peers_store::load(&self.inner.home)?;
-        Ok(stored
-            .into_iter()
-            .map(|p| EnrolledPeer {
-                peer_id: p.peer_id,
-                pubkey_b64: p.pubkey_b64,
-            })
-            .collect())
-    }
-
-    /// Idempotently spawn a background subscriber on `wire` if one
-    /// isn't already running. The subscriber:
-    ///   1. attaches a SignedTransport<LocalFsAdapter> subscription
-    ///      anchored at the start of the wire (replays existing
-    ///      frames into the store on first attach);
-    ///   2. converts each verified `Frame` into a `TranscriptEvent`
-    ///      via `Frame::into_transcript_event`;
-    ///   3. appends to the durable store;
-    ///   4. fans the event out on `live_tx` for live subscribers.
-    ///
-    /// Verification failures and store errors are surfaced on stderr
-    /// rather than silently swallowed — the operating doc's "errors
-    /// reach a debugger" rule.
-    async fn ensure_wire_subscriber(&self, wire: &Path) -> Result<(), AircError> {
-        let mut subs = self.inner.subscribers.lock().await;
-        if subs.contains_key(wire) {
-            return Ok(());
-        }
-        let transport = SignedTransport::new(
-            LocalFsAdapter::new(wire),
-            self.inner.identity.keypair.clone(),
-            self.inner.identity.peer_id,
-            self.inner.registry.clone(),
-            self.inner.policy,
-        );
-        // Replay-anchored so first attach captures pre-existing
-        // frames on the wire and routes them into the store.
-        let subscription = Subscription {
-            from_cursor: Some(TranscriptCursor {
-                lamport: 0,
-                event_id: EventId::from_u128(0),
-            }),
-            ..Default::default()
-        };
-        let mut stream = transport
-            .subscribe(subscription)
-            .await
-            .map_err(|e| AircError::Transport(e.to_string()))?;
-
-        let store = self.inner.store.clone();
-        let live_tx = self.inner.live_tx.clone();
-        let task = tokio::spawn(async move {
-            while let Some(item) = stream.next().await {
-                match item {
-                    Ok(frame) => {
-                        let event = frame.into_transcript_event();
-                        match store.append(event.clone()).await {
-                            Ok(()) => {
-                                // No active receivers is normal — the
-                                // broadcast send returns Err and we
-                                // don't care; the event is durably in
-                                // the store either way.
-                                let _ = live_tx.send(event);
-                            }
-                            Err(airc_store::StoreError::DuplicateEventId(_)) => {
-                                // Replay-anchored attach re-reads the
-                                // existing wire on every fresh
-                                // Airc::open; the store rejects the
-                                // duplicate, we skip the broadcast.
-                            }
-                            Err(err) => {
-                                eprintln!("airc-lib subscriber: store append failed: {err}");
-                            }
-                        }
-                    }
-                    Err(verify_err) => {
-                        eprintln!("airc-lib subscriber: frame verification failed: {verify_err}");
-                    }
-                }
-            }
-        });
-        subs.insert(wire.to_path_buf(), WireSubscriber { _task: task });
-        Ok(())
-    }
-}
-
-/// Live transcript-event stream returned by [`Airc::subscribe`].
-/// Wraps a broadcast receiver and yields events as they arrive.
-///
-/// Lagged behaviour: if the consumer falls behind the broadcast
-/// capacity, the stream surfaces the lag count and resumes from
-/// the current tip. That's a real signal — consumers that need
-/// durable replay should snapshot a cursor and call
-/// [`Airc::resume_from`] when they catch up. Silent drops are not
-/// part of the API.
-pub struct EventStream {
-    inner: BroadcastStream<TranscriptEvent>,
-}
-
-impl Stream for EventStream {
-    type Item = Result<TranscriptEvent, LiveLag>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-        let inner = Pin::new(&mut this.inner);
-        match inner.poll_next(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Some(Ok(event))) => Poll::Ready(Some(Ok(event))),
-            Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n)))) => {
-                Poll::Ready(Some(Err(LiveLag { skipped: n })))
-            }
-            Poll::Ready(None) => Poll::Ready(None),
-        }
-    }
-}
-
-/// Surfaced when a live stream falls behind the broadcast capacity.
-/// `skipped` is the number of events the consumer missed; recover by
-/// snapshotting a `TranscriptCursor` and calling
-/// [`Airc::resume_from`] to backfill from the store.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LiveLag {
-    pub skipped: u64,
-}
-
-impl std::fmt::Display for LiveLag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "live stream lagged {} events — resume from cursor",
-            self.skipped
-        )
-    }
-}
-
-impl std::error::Error for LiveLag {}
-
-/// One row in [`Airc::peers`]. Mirrors the daemon's `PeerEntry`
-/// without forcing consumers to pull the daemon crate.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EnrolledPeer {
-    pub peer_id: PeerId,
-    pub pubkey_b64: String,
-}
-
-fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
 }

--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -13,6 +13,15 @@ pub enum AircError {
     #[error("event store: {0}")]
     Store(#[from] airc_store::StoreError),
 
+    #[error("work store: {0}")]
+    WorkStore(#[from] airc_work_store::WorkStoreError),
+
+    #[error("work projection: {0}")]
+    WorkProjection(#[from] airc_work::ProjectionError),
+
+    #[error("work event codec: {0}")]
+    WorkCodec(#[from] airc_work::WorkEventCodecError),
+
     #[error("room state: {0}")]
     Room(#[from] crate::room::RoomError),
 

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -23,17 +23,30 @@
 
 pub mod airc;
 pub mod error;
+mod messaging;
+mod peers;
 pub mod registry;
 pub mod room;
+mod stream;
+mod time;
+mod transport;
+pub mod work;
 
-pub use airc::{Airc, EnrolledPeer, EventStream, LiveLag};
+pub use airc::Airc;
 pub use error::AircError;
+pub use peers::EnrolledPeer;
 pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use room::Room;
+pub use stream::{EventStream, LiveLag};
+pub use work::{ClaimWorkCard, CreateWorkCard, ReleaseWorkClaim};
 
 // Convenience re-exports so consumers don't need to pull airc-core
 // just to type the common return values.
 pub use airc_core::{
     body::Body, headers::Headers, transcript::MentionTarget, ClientId, EventId, PeerId, RoomId,
     TranscriptCursor, TranscriptEvent,
+};
+pub use airc_work::{
+    BoardSnapshot, BranchName, CardState, ClaimId, LaneId, Priority, ProjectionError, RepoId,
+    WorkBoardProjection, WorkCardId, WorkEvent, WorkspaceId,
 };

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -1,0 +1,108 @@
+use airc_core::{Body, EventId, Headers, MentionTarget, TranscriptCursor, TranscriptEvent};
+use airc_protocol::{Envelope, Frame, FrameKind, Signature};
+use airc_transport::{LocalFsAdapter, SignedTransport, Transport};
+use tokio_stream::wrappers::BroadcastStream;
+
+use crate::error::AircError;
+use crate::stream::EventStream;
+use crate::time::now_ms;
+use crate::Airc;
+
+impl Airc {
+    /// Send a plain-text message to the current room.
+    pub async fn say(&self, text: &str) -> Result<EventId, AircError> {
+        self.send(Body::text(text), Headers::new()).await
+    }
+
+    /// Send a frame with typed body and arbitrary headers.
+    pub async fn send(&self, body: Body, headers: Headers) -> Result<EventId, AircError> {
+        self.send_frame(FrameKind::Message, body, headers).await
+    }
+
+    pub(crate) async fn send_frame(
+        &self,
+        kind: FrameKind,
+        body: Body,
+        headers: Headers,
+    ) -> Result<EventId, AircError> {
+        let room = self.current_room().await?;
+        self.ensure_wire_subscriber(&room.wire).await?;
+        let event_id = EventId::new();
+        let occurred_at_ms = now_ms();
+        let frame = Frame {
+            kind,
+            envelope: Envelope {
+                event_id,
+                sender: self.inner.identity.peer_id,
+                sender_client: self.inner.identity.client_id,
+                channel: room.channel,
+                target: MentionTarget::All,
+                lamport: occurred_at_ms,
+                occurred_at_ms,
+                reply_to: None,
+                headers,
+                body: Some(body),
+                media: Vec::new(),
+                signature: Signature::Unsigned,
+            },
+        };
+        let transport = SignedTransport::new(
+            LocalFsAdapter::new(&room.wire),
+            self.inner.identity.keypair.clone(),
+            self.inner.identity.peer_id,
+            self.inner.registry.clone(),
+            self.inner.policy,
+        );
+        transport
+            .send(frame)
+            .await
+            .map_err(|e| AircError::Transport(e.to_string()))?;
+        Ok(event_id)
+    }
+
+    /// Subscribe to the live event stream.
+    pub async fn subscribe(&self) -> Result<EventStream, AircError> {
+        let room = self.current_room().await?;
+        let rx = self.inner.live_tx.subscribe();
+        self.ensure_wire_subscriber(&room.wire).await?;
+        Ok(EventStream {
+            inner: BroadcastStream::new(rx),
+        })
+    }
+
+    /// Fetch the most recent `limit` events from the current room.
+    pub async fn page_recent(&self, limit: usize) -> Result<Vec<TranscriptEvent>, AircError> {
+        let room = self.current_room().await?;
+        self.ensure_wire_subscriber(&room.wire).await?;
+        Ok(self
+            .inner
+            .store
+            .page_recent(Some(room.channel), limit)
+            .await?)
+    }
+
+    /// Fetch up to `limit` events strictly after `cursor`.
+    pub async fn resume_from(
+        &self,
+        cursor: &TranscriptCursor,
+        limit: usize,
+    ) -> Result<Vec<TranscriptEvent>, AircError> {
+        let room = self.current_room().await?;
+        Ok(self
+            .inner
+            .store
+            .resume_from(cursor, Some(room.channel), limit)
+            .await?)
+    }
+
+    /// Cursor of the newest event in the current room.
+    pub async fn latest_cursor(&self) -> Result<Option<TranscriptCursor>, AircError> {
+        let room = self.current_room().await?;
+        Ok(self.inner.store.latest_cursor(Some(room.channel)).await?)
+    }
+
+    /// Append a `TranscriptEvent` to the durable store directly.
+    pub async fn append_event(&self, event: TranscriptEvent) -> Result<(), AircError> {
+        Ok(self.inner.store.append(event).await?)
+    }
+}

--- a/crates/airc-lib/src/peers.rs
+++ b/crates/airc-lib/src/peers.rs
@@ -1,0 +1,58 @@
+use airc_core::PeerId;
+use airc_daemon::peers_store;
+
+use crate::error::AircError;
+use crate::registry::PeerSpec;
+use crate::Airc;
+
+/// One row in `Airc::peers`. Mirrors the daemon's `PeerEntry`
+/// without forcing consumers to pull the daemon crate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnrolledPeer {
+    pub peer_id: PeerId,
+    pub pubkey_b64: String,
+}
+
+impl Airc {
+    /// Return the peer-spec string suitable for sharing with another
+    /// peer so they can enrol this identity into their trust registry.
+    pub fn peer_spec(&self) -> String {
+        crate::registry::format_peer_spec(
+            self.inner.identity.peer_id,
+            &self.inner.identity.keypair.public_bytes(),
+        )
+    }
+
+    /// Enrol a peer into the local trust registry and persist it to
+    /// `<home>/peers.json`.
+    pub async fn add_peer(&self, spec: PeerSpec) -> Result<(), AircError> {
+        peers_store::add(&self.inner.home, spec.peer_id, spec.pubkey)?;
+        self.enrol_volatile_peer(&spec)
+    }
+
+    /// Enrol a peer in the in-memory trust registry without writing
+    /// to `peers.json`.
+    pub fn enrol_volatile_peer(&self, spec: &PeerSpec) -> Result<(), AircError> {
+        let mut registry = self
+            .inner
+            .registry
+            .write()
+            .map_err(|_| AircError::Crypto("registry lock poisoned".to_string()))?;
+        registry
+            .enrol(spec.peer_id, 0, spec.pubkey)
+            .map_err(|e| AircError::Crypto(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Return a list of enrolled peers.
+    pub async fn peers(&self) -> Result<Vec<EnrolledPeer>, AircError> {
+        let stored = peers_store::load(&self.inner.home)?;
+        Ok(stored
+            .into_iter()
+            .map(|p| EnrolledPeer {
+                peer_id: p.peer_id,
+                pubkey_b64: p.pubkey_b64,
+            })
+            .collect())
+    }
+}

--- a/crates/airc-lib/src/room.rs
+++ b/crates/airc-lib/src/room.rs
@@ -185,76 +185,9 @@ fn set_owner_only_permissions(_path: &Path) -> std::io::Result<()> {
 fn now_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
+        .expect("system clock before UNIX_EPOCH violates AIRC room timestamp contract")
+        .as_millis() as u64
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-
-    #[test]
-    fn from_name_is_deterministic_across_homes() {
-        // Same room name → same channel UUID across different homes.
-        // Critical for peers joining the same name without sharing
-        // the channel UUID out-of-band.
-        let home_a = TempDir::new().unwrap();
-        let home_b = TempDir::new().unwrap();
-        let a = Room::from_name(home_a.path(), "project-x");
-        let b = Room::from_name(home_b.path(), "project-x");
-        assert_eq!(a.channel, b.channel);
-        // Wire IS different (per-home), but channel matches.
-        assert_ne!(a.wire, b.wire);
-    }
-
-    #[test]
-    fn from_name_differs_per_name() {
-        let home = TempDir::new().unwrap();
-        let a = Room::from_name(home.path(), "general");
-        let b = Room::from_name(home.path(), "private");
-        assert_ne!(a.channel, b.channel);
-        assert_ne!(a.wire, b.wire);
-    }
-
-    #[test]
-    fn load_or_default_returns_default_when_missing() {
-        let home = TempDir::new().unwrap();
-        let room = load_or_default(home.path()).unwrap();
-        assert_eq!(room.name, "default");
-    }
-
-    #[test]
-    fn save_then_load_roundtrips() {
-        let home = TempDir::new().unwrap();
-        let original = Room::from_name(home.path(), "test-room");
-        save(home.path(), &original).unwrap();
-        let loaded = load_or_default(home.path()).unwrap();
-        assert_eq!(loaded.name, original.name);
-        assert_eq!(loaded.channel, original.channel);
-        assert_eq!(loaded.wire, original.wire);
-    }
-
-    #[test]
-    fn sanitise_replaces_path_separators() {
-        // Avoid escaping the wires dir via weird names.
-        assert_eq!(sanitise_name("../etc/passwd"), "---etc-passwd");
-        assert_eq!(sanitise_name("normal-name_42"), "normal-name_42");
-    }
-
-    #[test]
-    fn refuses_unknown_schema_version() {
-        let home = TempDir::new().unwrap();
-        std::fs::create_dir_all(home.path()).unwrap();
-        std::fs::write(
-            path_in(home.path()),
-            r#"{"version":999,"name":"x","wire":"/tmp","channel":"00000000-0000-0000-0000-000000000000","joined_at_ms":0}"#,
-        )
-        .unwrap();
-        let result = load_or_default(home.path());
-        assert!(matches!(
-            result,
-            Err(RoomError::SchemaVersionMismatch { found: 999, .. })
-        ));
-    }
-}
+mod tests;

--- a/crates/airc-lib/src/room/tests.rs
+++ b/crates/airc-lib/src/room/tests.rs
@@ -1,0 +1,61 @@
+use super::*;
+use tempfile::TempDir;
+
+#[test]
+fn from_name_is_deterministic_across_homes() {
+    let home_a = TempDir::new().unwrap();
+    let home_b = TempDir::new().unwrap();
+    let a = Room::from_name(home_a.path(), "project-x");
+    let b = Room::from_name(home_b.path(), "project-x");
+    assert_eq!(a.channel, b.channel);
+    assert_ne!(a.wire, b.wire);
+}
+
+#[test]
+fn from_name_differs_per_name() {
+    let home = TempDir::new().unwrap();
+    let a = Room::from_name(home.path(), "general");
+    let b = Room::from_name(home.path(), "private");
+    assert_ne!(a.channel, b.channel);
+    assert_ne!(a.wire, b.wire);
+}
+
+#[test]
+fn load_or_default_returns_default_when_missing() {
+    let home = TempDir::new().unwrap();
+    let room = load_or_default(home.path()).unwrap();
+    assert_eq!(room.name, "default");
+}
+
+#[test]
+fn save_then_load_roundtrips() {
+    let home = TempDir::new().unwrap();
+    let original = Room::from_name(home.path(), "test-room");
+    save(home.path(), &original).unwrap();
+    let loaded = load_or_default(home.path()).unwrap();
+    assert_eq!(loaded.name, original.name);
+    assert_eq!(loaded.channel, original.channel);
+    assert_eq!(loaded.wire, original.wire);
+}
+
+#[test]
+fn sanitise_replaces_path_separators() {
+    assert_eq!(sanitise_name("../etc/passwd"), "---etc-passwd");
+    assert_eq!(sanitise_name("normal-name_42"), "normal-name_42");
+}
+
+#[test]
+fn refuses_unknown_schema_version() {
+    let home = TempDir::new().unwrap();
+    std::fs::create_dir_all(home.path()).unwrap();
+    std::fs::write(
+        path_in(home.path()),
+        r#"{"version":999,"name":"x","wire":"/tmp","channel":"00000000-0000-0000-0000-000000000000","joined_at_ms":0}"#,
+    )
+    .unwrap();
+    let result = load_or_default(home.path());
+    assert!(matches!(
+        result,
+        Err(RoomError::SchemaVersionMismatch { found: 999, .. })
+    ));
+}

--- a/crates/airc-lib/src/stream.rs
+++ b/crates/airc-lib/src/stream.rs
@@ -1,0 +1,45 @@
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use airc_core::TranscriptEvent;
+use futures::stream::Stream;
+use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
+
+/// Live transcript-event stream returned by `Airc::subscribe`.
+pub struct EventStream {
+    pub(crate) inner: BroadcastStream<TranscriptEvent>,
+}
+
+impl Stream for EventStream {
+    type Item = Result<TranscriptEvent, LiveLag>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        let inner = Pin::new(&mut this.inner);
+        match inner.poll_next(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Some(Ok(event))) => Poll::Ready(Some(Ok(event))),
+            Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n)))) => {
+                Poll::Ready(Some(Err(LiveLag { skipped: n })))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveLag {
+    pub skipped: u64,
+}
+
+impl std::fmt::Display for LiveLag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "live stream lagged {} events; resume from cursor",
+            self.skipped
+        )
+    }
+}
+
+impl std::error::Error for LiveLag {}

--- a/crates/airc-lib/src/time.rs
+++ b/crates/airc-lib/src/time.rs
@@ -1,0 +1,6 @@
+pub(crate) fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX_EPOCH violates AIRC timestamp contract")
+        .as_millis() as u64
+}

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -1,0 +1,72 @@
+use std::path::Path;
+
+use airc_core::{EventId, TranscriptCursor};
+use airc_protocol::Subscription;
+use airc_transport::{LocalFsAdapter, SignedTransport, Transport};
+use futures::stream::StreamExt;
+
+use crate::error::AircError;
+use crate::room::Room;
+use crate::Airc;
+
+pub(crate) struct WireSubscriber {
+    /// Kept alive by ownership of its `JoinHandle`.
+    pub(crate) _task: tokio::task::JoinHandle<()>,
+}
+
+impl Airc {
+    pub(crate) async fn ensure_room_subscriber(&self, room: &Room) -> Result<(), AircError> {
+        self.ensure_wire_subscriber(&room.wire).await
+    }
+
+    pub(crate) async fn ensure_wire_subscriber(&self, wire: &Path) -> Result<(), AircError> {
+        let mut subs = self.inner.subscribers.lock().await;
+        if subs.contains_key(wire) {
+            return Ok(());
+        }
+        let transport = SignedTransport::new(
+            LocalFsAdapter::new(wire),
+            self.inner.identity.keypair.clone(),
+            self.inner.identity.peer_id,
+            self.inner.registry.clone(),
+            self.inner.policy,
+        );
+        let subscription = Subscription {
+            from_cursor: Some(TranscriptCursor {
+                lamport: 0,
+                event_id: EventId::from_u128(0),
+            }),
+            ..Default::default()
+        };
+        let mut stream = transport
+            .subscribe(subscription)
+            .await
+            .map_err(|e| AircError::Transport(e.to_string()))?;
+
+        let store = self.inner.store.clone();
+        let live_tx = self.inner.live_tx.clone();
+        let task = tokio::spawn(async move {
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(frame) => {
+                        let event = frame.into_transcript_event();
+                        match store.append(event.clone()).await {
+                            Ok(()) => {
+                                let _ = live_tx.send(event);
+                            }
+                            Err(airc_store::StoreError::DuplicateEventId(_)) => {}
+                            Err(err) => {
+                                eprintln!("airc-lib subscriber: store append failed: {err}");
+                            }
+                        }
+                    }
+                    Err(verify_err) => {
+                        eprintln!("airc-lib subscriber: frame verification failed: {verify_err}");
+                    }
+                }
+            }
+        });
+        subs.insert(wire.to_path_buf(), WireSubscriber { _task: task });
+        Ok(())
+    }
+}

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -1,0 +1,99 @@
+//! Consumer request structs for the work coordination API.
+
+use airc_core::EventId;
+use airc_protocol::FrameKind;
+use airc_work::{
+    encode_work_event, CardCreated, ClaimId, ClaimReleased, LaneId, Priority, RepoId,
+    WorkBoardProjection, WorkCardClaimed, WorkCardId, WorkEvent,
+};
+use airc_work_store::WorkEventStore;
+
+use crate::time::now_ms;
+use crate::{Airc, AircError};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateWorkCard {
+    pub repo: RepoId,
+    pub title: String,
+    pub body: Option<String>,
+    pub priority: Priority,
+    pub lane_id: Option<LaneId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClaimWorkCard {
+    pub card_id: WorkCardId,
+    pub ttl_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseWorkClaim {
+    pub card_id: WorkCardId,
+    pub claim_id: ClaimId,
+    pub reason: Option<String>,
+}
+
+impl Airc {
+    /// Create a work card in the current room and publish it as a
+    /// signed work-domain event. Returns the UUIDv4 card id generated
+    /// locally for this card.
+    pub async fn create_work_card(&self, request: CreateWorkCard) -> Result<WorkCardId, AircError> {
+        let card_id = WorkCardId::new();
+        let event = WorkEvent::CardCreated(CardCreated {
+            card_id,
+            repo: request.repo,
+            title: request.title,
+            body: request.body,
+            priority: request.priority,
+            lane_id: request.lane_id,
+            created_by: self.peer_id(),
+            created_at_ms: now_ms(),
+        });
+        self.publish_work_event(&event).await?;
+        Ok(card_id)
+    }
+
+    /// Claim a work card for this peer. Returns the UUIDv4 claim id
+    /// generated locally for the lease.
+    pub async fn claim_work_card(&self, request: ClaimWorkCard) -> Result<ClaimId, AircError> {
+        let claim_id = ClaimId::new();
+        let event = WorkEvent::CardClaimed(WorkCardClaimed {
+            card_id: request.card_id,
+            claim_id,
+            owner: self.peer_id(),
+            ttl_ms: request.ttl_ms,
+            claimed_at_ms: now_ms(),
+        });
+        self.publish_work_event(&event).await?;
+        Ok(claim_id)
+    }
+
+    /// Release this peer's work claim.
+    pub async fn release_work_claim(&self, request: ReleaseWorkClaim) -> Result<(), AircError> {
+        let event = WorkEvent::ClaimReleased(ClaimReleased {
+            card_id: request.card_id,
+            claim_id: request.claim_id,
+            owner: self.peer_id(),
+            reason: request.reason,
+            released_at_ms: now_ms(),
+        });
+        self.publish_work_event(&event).await?;
+        Ok(())
+    }
+
+    /// Rebuild the current room's work board from persisted work
+    /// events. `limit` is the transcript page size; callers that need
+    /// complete history should pass a sufficiently high limit until a
+    /// dedicated paged board API lands.
+    pub async fn work_board(&self, limit: usize) -> Result<WorkBoardProjection, AircError> {
+        let room = self.current_room().await?;
+        self.ensure_room_subscriber(&room).await?;
+        let store = WorkEventStore::new(self.event_store());
+        Ok(store.project_recent(Some(room.channel), limit).await?)
+    }
+
+    async fn publish_work_event(&self, event: &WorkEvent) -> Result<EventId, AircError> {
+        let (headers, body) = encode_work_event(event)?;
+        self.send_frame(FrameKind::Event, body, headers).await
+    }
+}

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -1,0 +1,107 @@
+use std::time::{Duration, Instant};
+
+use airc_lib::{
+    Airc, ClaimWorkCard, CreateWorkCard, Priority, ReleaseWorkClaim, RepoId, WorkCardId,
+};
+use tempfile::TempDir;
+
+async fn wait_for_card(airc: &Airc, card_id: WorkCardId) -> airc_lib::WorkBoardProjection {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let board = airc.work_board(128).await.unwrap();
+        if board.card(card_id).is_some() {
+            return board;
+        }
+        if Instant::now() >= deadline {
+            panic!("timed out waiting for work card {card_id}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[tokio::test]
+async fn create_work_card_publishes_and_projects_from_store() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("work-api").await.unwrap();
+
+    let card_id = airc
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            title: "wire work api through airc-lib".to_string(),
+            body: Some("typed work event over signed substrate".to_string()),
+            priority: Priority::P1,
+            lane_id: None,
+        })
+        .await
+        .unwrap();
+
+    let board = wait_for_card(&airc, card_id).await;
+    let card = board.card(card_id).unwrap();
+    assert_eq!(card.title, "wire work api through airc-lib");
+    assert_eq!(card.repo.as_str(), "CambrianTech/airc");
+    assert_eq!(card.created_by, airc.peer_id());
+}
+
+#[tokio::test]
+async fn claim_and_release_work_card_round_trip_through_projection() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("work-claims").await.unwrap();
+
+    let card_id = airc
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            title: "claim via rust api".to_string(),
+            body: None,
+            priority: Priority::P2,
+            lane_id: None,
+        })
+        .await
+        .unwrap();
+    wait_for_card(&airc, card_id).await;
+
+    let claim_id = airc
+        .claim_work_card(ClaimWorkCard {
+            card_id,
+            ttl_ms: 60_000,
+        })
+        .await
+        .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let board = airc.work_board(128).await.unwrap();
+        let card = board.card(card_id).unwrap();
+        if card.claim_id == Some(claim_id) {
+            assert_eq!(card.owner, Some(airc.peer_id()));
+            break;
+        }
+        if Instant::now() >= deadline {
+            panic!("timed out waiting for work claim {claim_id}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    airc.release_work_claim(ReleaseWorkClaim {
+        card_id,
+        claim_id,
+        reason: Some("merged into rust-rewrite".to_string()),
+    })
+    .await
+    .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let board = airc.work_board(128).await.unwrap();
+        let card = board.card(card_id).unwrap();
+        if card.claim_id.is_none() {
+            assert_eq!(card.owner, None);
+            break;
+        }
+        if Instant::now() >= deadline {
+            panic!("timed out waiting for work claim release {claim_id}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}


### PR DESCRIPTION
## Summary
- add airc-lib work API for create/claim/release and persisted board projection
- publish work events through signed AIRC event frames using the work codec
- add embedding tests proving work events round-trip through storage and projection
- split airc-lib facade concerns into messaging, peers, stream, transport, time, and work modules
- remove room timestamp fallback so clock violations fail hard

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test -p airc-lib
- cargo test --workspace --all-features