### PR TITLE
feat(airc-cli): add work coordination commands

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -16,6 +16,8 @@ use clap::{Args, Parser, Subcommand};
 
 use airc_lib::PeerSpec;
 
+use crate::work_cli::WorkArgs;
+
 /// Default home directory for persisted identity + IPC state.
 ///
 /// Resolution order:
@@ -185,6 +187,9 @@ pub enum Command {
 
     /// Manage the persisted peer registry (`<home>/peers.json`).
     Peer(PeerArgs),
+
+    /// Coordinate work cards over the current room's AIRC substrate.
+    Work(WorkArgs),
 }
 
 #[derive(Debug, Args)]

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -13,6 +13,8 @@
 
 mod cli;
 mod commands;
+mod work_cli;
+mod work_commands;
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -25,6 +27,7 @@ use airc_core::PeerId;
 
 use airc_daemon::LocalIdentity;
 use cli::{Cli, Command, PeerAction};
+use work_cli::WorkAction;
 
 fn parse_peer_id(input: &str) -> Result<PeerId, Box<dyn std::error::Error>> {
     let uuid = Uuid::from_str(input)
@@ -108,6 +111,24 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 commands::run_peer_add(&home, spec, default_or(socket, &home)).await
             }
             PeerAction::List => commands::run_peer_list(&home).await,
+        },
+
+        Command::Work(args) => match args.action {
+            WorkAction::Create {
+                repo,
+                title,
+                body,
+                priority,
+            } => work_commands::run_create(&home, repo, title, body, priority).await,
+            WorkAction::Claim { card_id, ttl_ms } => {
+                work_commands::run_claim(&home, card_id, ttl_ms).await
+            }
+            WorkAction::Release {
+                card_id,
+                claim_id,
+                reason,
+            } => work_commands::run_release(&home, card_id, claim_id, reason).await,
+            WorkAction::Board { limit } => work_commands::run_board(&home, limit).await,
         },
     }
 }

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -1,0 +1,61 @@
+//! Clap argument shapes for `airc-rs work ...`.
+
+use clap::{Args, Subcommand, ValueEnum};
+
+#[derive(Debug, Args)]
+pub struct WorkArgs {
+    #[command(subcommand)]
+    pub action: WorkAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WorkAction {
+    /// Create a typed work card in the current room.
+    Create {
+        /// Repository key, e.g. `CambrianTech/airc`.
+        #[arg(long)]
+        repo: String,
+        /// Human-readable card title.
+        #[arg(long)]
+        title: String,
+        /// Optional card body.
+        #[arg(long)]
+        body: Option<String>,
+        /// Scheduling priority.
+        #[arg(long, value_enum, default_value = "p2")]
+        priority: CliPriority,
+    },
+    /// Claim an existing work card for this peer.
+    Claim {
+        /// Work card UUID.
+        card_id: String,
+        /// Claim lease duration.
+        #[arg(long, default_value_t = 600_000)]
+        ttl_ms: u64,
+    },
+    /// Release this peer's claim on a work card.
+    Release {
+        /// Work card UUID.
+        card_id: String,
+        /// Claim UUID returned by `work claim`.
+        claim_id: String,
+        /// Optional release reason.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Print the current room's projected work board.
+    Board {
+        /// Recent transcript events to replay into the projection.
+        #[arg(long, default_value_t = 128)]
+        limit: usize,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum CliPriority {
+    P0,
+    P1,
+    P2,
+    P3,
+}

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -1,0 +1,127 @@
+//! `airc-rs work ...` handlers.
+//!
+//! The CLI stays intentionally thin: it parses human input, calls the
+//! consumer-facing `airc_lib::Airc` work API, and prints stable lines
+//! that other tools can scrape. Work-domain validation and event
+//! construction live in `airc-lib` / `airc-work`.
+
+use std::path::Path;
+
+use uuid::Uuid;
+
+use airc_lib::{
+    Airc, ClaimId, ClaimWorkCard, CreateWorkCard, Priority, ReleaseWorkClaim, RepoId,
+    WorkBoardProjection, WorkCardId,
+};
+
+use crate::work_cli::CliPriority;
+
+pub async fn run_create(
+    home: &Path,
+    repo: String,
+    title: String,
+    body: Option<String>,
+    priority: CliPriority,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let card_id = airc
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new(repo)?,
+            title,
+            body,
+            priority: priority.into(),
+            lane_id: None,
+        })
+        .await?;
+    println!("card_id: {card_id}");
+    Ok(())
+}
+
+pub async fn run_claim(
+    home: &Path,
+    card_id: String,
+    ttl_ms: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let card_id = parse_work_card_id(&card_id)?;
+    let claim_id = airc
+        .claim_work_card(ClaimWorkCard { card_id, ttl_ms })
+        .await?;
+    println!("claim_id: {claim_id}");
+    Ok(())
+}
+
+pub async fn run_release(
+    home: &Path,
+    card_id: String,
+    claim_id: String,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    airc.release_work_claim(ReleaseWorkClaim {
+        card_id: parse_work_card_id(&card_id)?,
+        claim_id: parse_claim_id(&claim_id)?,
+        reason,
+    })
+    .await?;
+    println!("released: card_id={card_id} claim_id={claim_id}");
+    Ok(())
+}
+
+pub async fn run_board(home: &Path, limit: usize) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let board = airc.work_board(limit).await?;
+    print_board(&board);
+    Ok(())
+}
+
+fn print_board(board: &WorkBoardProjection) {
+    let snapshot = board.snapshot();
+    if snapshot.cards.is_empty() {
+        println!("(no work cards)");
+        return;
+    }
+
+    println!("work cards: {}", snapshot.cards.len());
+    for card in &snapshot.cards {
+        let owner = card
+            .owner
+            .map(|peer| peer.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let claim = card
+            .claim_id
+            .map(|claim| claim.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "{card_id}  {priority:?}  {state:?}  owner={owner}  claim={claim}  repo={repo}  title={title}",
+            card_id = card.card_id,
+            priority = card.priority,
+            state = card.state,
+            repo = card.repo,
+            title = card.title,
+        );
+    }
+}
+
+fn parse_work_card_id(input: &str) -> Result<WorkCardId, Box<dyn std::error::Error>> {
+    let uuid = Uuid::parse_str(input)
+        .map_err(|error| format!("work card id {input:?} is not a valid UUID: {error}"))?;
+    Ok(WorkCardId::from_uuid(uuid))
+}
+
+fn parse_claim_id(input: &str) -> Result<ClaimId, Box<dyn std::error::Error>> {
+    let uuid = Uuid::parse_str(input)
+        .map_err(|error| format!("claim id {input:?} is not a valid UUID: {error}"))?;
+    Ok(ClaimId::from_uuid(uuid))
+}
+
+impl From<CliPriority> for Priority {
+    fn from(value: CliPriority) -> Self {
+        match value {
+            CliPriority::P0 => Self::P0,
+            CliPriority::P1 => Self::P1,
+            CliPriority::P2 => Self::P2,
+            CliPriority::P3 => Self::P3,
+        }
+    }
+}

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -1,0 +1,108 @@
+//! End-to-end coverage for `airc-rs work ...`.
+//!
+//! These tests execute the binary as a consumer would. The command
+//! path must stay a thin wrapper over `airc-lib`, but the proof needs
+//! to be from the CLI surface because that is what agents will use
+//! while the daemon-attached API is still landing.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn airc_rs() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-rs")
+}
+
+#[test]
+fn work_create_claim_release_projects_on_board() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+
+    let create = run_ok(
+        &home,
+        &[
+            "work",
+            "create",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "wire work commands through airc-lib",
+            "--priority",
+            "p1",
+            "--body",
+            "cli proof against the rust substrate",
+        ],
+    );
+    let card_id = extract_field(&create, "card_id:").expect("create prints card_id");
+
+    let board = run_ok(&home, &["work", "board"]);
+    assert!(board.contains(card_id));
+    assert!(board.contains("CambrianTech/airc"));
+    assert!(board.contains("wire work commands through airc-lib"));
+    assert!(board.contains("P1"));
+    assert!(board.contains("Open"));
+
+    let claim = run_ok(&home, &["work", "claim", card_id, "--ttl-ms", "60000"]);
+    let claim_id = extract_field(&claim, "claim_id:").expect("claim prints claim_id");
+
+    let claimed_board = run_ok(&home, &["work", "board"]);
+    assert!(claimed_board.contains(card_id));
+    assert!(claimed_board.contains(claim_id));
+    assert!(claimed_board.contains("Claimed"));
+
+    run_ok(
+        &home,
+        &[
+            "work",
+            "release",
+            card_id,
+            claim_id,
+            "--reason",
+            "merged into rust-rewrite",
+        ],
+    );
+
+    let released_board = run_ok(&home, &["work", "board"]);
+    assert!(released_board.contains(card_id));
+    assert!(released_board.contains("Open"));
+    assert!(released_board.contains("claim=-"));
+}
+
+#[test]
+fn work_board_empty_state_is_explicit() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let board = run_ok(&home, &["work", "board"]);
+
+    assert!(
+        board.contains("(no work cards)"),
+        "empty board should be explicit, got: {board}"
+    );
+}
+
+fn run_ok(home: &Path, args: &[&str]) -> String {
+    let output = Command::new(airc_rs())
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .output()
+        .expect("airc-rs command must spawn");
+    assert!(
+        output.status.success(),
+        "airc-rs {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout utf-8")
+}
+
+fn extract_field<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
+    text.lines()
+        .find_map(|line| line.strip_prefix(prefix).map(str::trim))
+}

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -1,6 +1,6 @@
 use airc_core::{Body, EventId, Headers, MentionTarget, TranscriptCursor, TranscriptEvent};
 use airc_protocol::{Envelope, Frame, FrameKind, Signature};
-use airc_transport::{LocalFsAdapter, SignedTransport, Transport};
+use airc_transport::{LocalFsAdapter, Transport};
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::error::AircError;
@@ -29,7 +29,7 @@ impl Airc {
         self.ensure_wire_subscriber(&room.wire).await?;
         let event_id = EventId::new();
         let occurred_at_ms = now_ms();
-        let frame = Frame {
+        let mut frame = Frame {
             kind,
             envelope: Envelope {
                 event_id,
@@ -46,18 +46,31 @@ impl Airc {
                 signature: Signature::Unsigned,
             },
         };
-        let transport = SignedTransport::new(
-            LocalFsAdapter::new(&room.wire),
-            self.inner.identity.keypair.clone(),
-            self.inner.identity.peer_id,
-            self.inner.registry.clone(),
-            self.inner.policy,
-        );
+        frame.envelope.signature = self
+            .inner
+            .identity
+            .keypair
+            .sign_envelope(&frame.envelope, self.inner.identity.peer_id, 0)
+            .map_err(|error| AircError::Crypto(error.to_string()))?;
+        let transport = LocalFsAdapter::new(&room.wire);
         transport
-            .send(frame)
+            .send(frame.clone())
             .await
             .map_err(|e| AircError::Transport(e.to_string()))?;
+        self.append_sent_frame(frame).await?;
         Ok(event_id)
+    }
+
+    async fn append_sent_frame(&self, frame: Frame) -> Result<(), AircError> {
+        let event = frame.into_transcript_event();
+        match self.inner.store.append(event.clone()).await {
+            Ok(()) => {
+                let _ = self.inner.live_tx.send(event);
+                Ok(())
+            }
+            Err(airc_store::StoreError::DuplicateEventId(_)) => Ok(()),
+            Err(error) => Err(error.into()),
+        }
     }
 
     /// Subscribe to the live event stream.

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -36,6 +36,12 @@ async fn create_work_card_publishes_and_projects_from_store() {
         .await
         .unwrap();
 
+    let immediate = airc.work_board(128).await.unwrap();
+    assert!(
+        immediate.card(card_id).is_some(),
+        "own work sends must be immediately visible in the local durable store"
+    );
+
     let board = wait_for_card(&airc, card_id).await;
     let card = board.card(card_id).unwrap();
     assert_eq!(card.title, "wire work api through airc-lib");


### PR DESCRIPTION
## Summary
- add `airc-rs work create|claim|release|board` as a thin CLI over `airc-lib` work APIs
- split work-specific clap args and handlers into dedicated modules
- make locally sent frames immediately visible in `airc-lib` durable store after successful transport send
- add CLI subprocess coverage for work create/claim/release/board

## Verification
- `cargo clippy --manifest-path Cargo.toml -p airc-cli -p airc-lib --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml --workspace`
