### PR TITLE
feat(airc-cli): add lane coordination commands

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -190,6 +190,9 @@ pub enum Command {
 
     /// Coordinate work cards over the current room's AIRC substrate.
     Work(WorkArgs),
+
+    /// Coordinate work lanes over the current room's AIRC substrate.
+    Lane(crate::lane_cli::LaneArgs),
 }
 
 #[derive(Debug, Args)]

--- a/crates/airc-cli/src/lane_cli.rs
+++ b/crates/airc-cli/src/lane_cli.rs
@@ -1,0 +1,49 @@
+//! Clap argument shapes for `airc-rs lane ...`.
+
+use clap::{Args, Subcommand, ValueEnum};
+
+#[derive(Debug, Args)]
+pub struct LaneArgs {
+    #[command(subcommand)]
+    pub action: LaneAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LaneAction {
+    /// Create a typed work lane in the current room.
+    Create {
+        /// Repository key, e.g. `CambrianTech/airc`.
+        #[arg(long)]
+        repo: String,
+        /// Human-readable lane title.
+        #[arg(long)]
+        title: String,
+        /// Initial lane state.
+        #[arg(long, value_enum, default_value = "planned")]
+        state: CliLaneState,
+    },
+    /// Change a lane state.
+    State {
+        /// Lane UUID.
+        lane_id: String,
+        /// New lane state.
+        #[arg(value_enum)]
+        state: CliLaneState,
+    },
+    /// Print the current room's lane projection.
+    Status {
+        /// Recent transcript events to replay into the projection.
+        #[arg(long, default_value_t = 128)]
+        limit: usize,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum CliLaneState {
+    Planned,
+    Active,
+    Blocked,
+    Landing,
+    Done,
+}

--- a/crates/airc-cli/src/lane_commands.rs
+++ b/crates/airc-cli/src/lane_commands.rs
@@ -1,0 +1,89 @@
+//! `airc-rs lane ...` handlers.
+
+use std::path::Path;
+
+use uuid::Uuid;
+
+use airc_lib::{
+    Airc, ChangeWorkLaneState, CreateWorkLane, LaneId, LaneState, RepoId, WorkBoardProjection,
+};
+
+use crate::lane_cli::CliLaneState;
+
+pub async fn run_create(
+    home: &Path,
+    repo: String,
+    title: String,
+    state: CliLaneState,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let lane_id = airc
+        .create_work_lane(CreateWorkLane {
+            repo: RepoId::new(repo)?,
+            title,
+            state: state.into(),
+        })
+        .await?;
+    println!("lane_id: {lane_id}");
+    Ok(())
+}
+
+pub async fn run_state(
+    home: &Path,
+    lane_id: String,
+    state: CliLaneState,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    airc.change_work_lane_state(ChangeWorkLaneState {
+        lane_id: parse_lane_id(&lane_id)?,
+        state: state.into(),
+    })
+    .await?;
+    println!("lane_state: lane_id={lane_id} state={state:?}");
+    Ok(())
+}
+
+pub async fn run_status(home: &Path, limit: usize) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let board = airc.work_board(limit).await?;
+    print_status(&board);
+    Ok(())
+}
+
+fn print_status(board: &WorkBoardProjection) {
+    let snapshot = board.snapshot();
+    if snapshot.lanes.is_empty() {
+        println!("(no work lanes)");
+        return;
+    }
+
+    println!("work lanes: {}", snapshot.lanes.len());
+    for lane in &snapshot.lanes {
+        println!(
+            "{lane_id}  {state:?}  cards={cards}  repo={repo}  title={title}",
+            lane_id = lane.lane_id,
+            state = lane.state,
+            cards = lane.card_ids.len(),
+            repo = lane.repo,
+            title = lane.title,
+        );
+    }
+}
+
+fn parse_lane_id(input: &str) -> Result<LaneId, Box<dyn std::error::Error>> {
+    let uuid = Uuid::parse_str(input)
+        .map_err(|error| format!("lane id {input:?} is not a valid UUID: {error}"))?;
+    Ok(LaneId::from_uuid(uuid))
+}
+
+impl From<CliLaneState> for LaneState {
+    fn from(value: CliLaneState) -> Self {
+        match value {
+            CliLaneState::Planned => Self::Planned,
+            CliLaneState::Active => Self::Active,
+            CliLaneState::Blocked => Self::Blocked,
+            CliLaneState::Landing => Self::Landing,
+            CliLaneState::Done => Self::Done,
+        }
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -13,6 +13,8 @@
 
 mod cli;
 mod commands;
+mod lane_cli;
+mod lane_commands;
 mod work_cli;
 mod work_commands;
 
@@ -27,6 +29,7 @@ use airc_core::PeerId;
 
 use airc_daemon::LocalIdentity;
 use cli::{Cli, Command, PeerAction};
+use lane_cli::LaneAction;
 use work_cli::WorkAction;
 
 fn parse_peer_id(input: &str) -> Result<PeerId, Box<dyn std::error::Error>> {
@@ -118,8 +121,9 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 repo,
                 title,
                 body,
+                lane_id,
                 priority,
-            } => work_commands::run_create(&home, repo, title, body, priority).await,
+            } => work_commands::run_create(&home, repo, title, body, lane_id, priority).await,
             WorkAction::Claim { card_id, ttl_ms } => {
                 work_commands::run_claim(&home, card_id, ttl_ms).await
             }
@@ -129,6 +133,16 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 reason,
             } => work_commands::run_release(&home, card_id, claim_id, reason).await,
             WorkAction::Board { limit } => work_commands::run_board(&home, limit).await,
+        },
+
+        Command::Lane(args) => match args.action {
+            LaneAction::Create { repo, title, state } => {
+                lane_commands::run_create(&home, repo, title, state).await
+            }
+            LaneAction::State { lane_id, state } => {
+                lane_commands::run_state(&home, lane_id, state).await
+            }
+            LaneAction::Status { limit } => lane_commands::run_status(&home, limit).await,
         },
     }
 }

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -21,6 +21,9 @@ pub enum WorkAction {
         /// Optional card body.
         #[arg(long)]
         body: Option<String>,
+        /// Optional lane UUID to attach this card to.
+        #[arg(long)]
+        lane_id: Option<String>,
         /// Scheduling priority.
         #[arg(long, value_enum, default_value = "p2")]
         priority: CliPriority,

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use uuid::Uuid;
 
 use airc_lib::{
-    Airc, ClaimId, ClaimWorkCard, CreateWorkCard, Priority, ReleaseWorkClaim, RepoId,
+    Airc, ClaimId, ClaimWorkCard, CreateWorkCard, LaneId, Priority, ReleaseWorkClaim, RepoId,
     WorkBoardProjection, WorkCardId,
 };
 
@@ -21,6 +21,7 @@ pub async fn run_create(
     repo: String,
     title: String,
     body: Option<String>,
+    lane_id: Option<String>,
     priority: CliPriority,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let airc = Airc::open(home).await?;
@@ -30,7 +31,7 @@ pub async fn run_create(
             title,
             body,
             priority: priority.into(),
-            lane_id: None,
+            lane_id: parse_optional_lane_id(lane_id.as_deref())?,
         })
         .await?;
     println!("card_id: {card_id}");
@@ -113,6 +114,18 @@ fn parse_claim_id(input: &str) -> Result<ClaimId, Box<dyn std::error::Error>> {
     let uuid = Uuid::parse_str(input)
         .map_err(|error| format!("claim id {input:?} is not a valid UUID: {error}"))?;
     Ok(ClaimId::from_uuid(uuid))
+}
+
+fn parse_optional_lane_id(
+    input: Option<&str>,
+) -> Result<Option<LaneId>, Box<dyn std::error::Error>> {
+    input.map(parse_lane_id).transpose()
+}
+
+fn parse_lane_id(input: &str) -> Result<LaneId, Box<dyn std::error::Error>> {
+    let uuid = Uuid::parse_str(input)
+        .map_err(|error| format!("lane id {input:?} is not a valid UUID: {error}"))?;
+    Ok(LaneId::from_uuid(uuid))
 }
 
 impl From<CliPriority> for Priority {

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -72,6 +72,55 @@ fn work_create_claim_release_projects_on_board() {
 }
 
 #[test]
+fn lane_create_status_and_state_drive_work_projection() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+
+    let lane = run_ok(
+        &home,
+        &[
+            "lane",
+            "create",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "rust lane commands",
+            "--state",
+            "planned",
+        ],
+    );
+    let lane_id = extract_field(&lane, "lane_id:").expect("lane create prints lane_id");
+
+    let status = run_ok(&home, &["lane", "status"]);
+    assert!(status.contains(lane_id));
+    assert!(status.contains("Planned"));
+    assert!(status.contains("cards=0"));
+
+    run_ok(
+        &home,
+        &[
+            "work",
+            "create",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "card inside lane",
+            "--lane-id",
+            lane_id,
+        ],
+    );
+
+    let status = run_ok(&home, &["lane", "status"]);
+    assert!(status.contains("cards=1"));
+
+    run_ok(&home, &["lane", "state", lane_id, "active"]);
+    let status = run_ok(&home, &["lane", "status"]);
+    assert!(status.contains("Active"));
+}
+
+#[test]
 fn work_board_empty_state_is_explicit() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -38,7 +38,9 @@ pub use peers::EnrolledPeer;
 pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use room::Room;
 pub use stream::{EventStream, LiveLag};
-pub use work::{ClaimWorkCard, CreateWorkCard, ReleaseWorkClaim};
+pub use work::{
+    ChangeWorkLaneState, ClaimWorkCard, CreateWorkCard, CreateWorkLane, ReleaseWorkClaim,
+};
 
 // Convenience re-exports so consumers don't need to pull airc-core
 // just to type the common return values.
@@ -47,6 +49,6 @@ pub use airc_core::{
     TranscriptCursor, TranscriptEvent,
 };
 pub use airc_work::{
-    BoardSnapshot, BranchName, CardState, ClaimId, LaneId, Priority, ProjectionError, RepoId,
-    WorkBoardProjection, WorkCardId, WorkEvent, WorkspaceId,
+    BoardSnapshot, BranchName, CardState, ClaimId, LaneId, LaneState, Priority, ProjectionError,
+    RepoId, WorkBoardProjection, WorkCardId, WorkEvent, WorkspaceId,
 };

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -3,8 +3,9 @@
 use airc_core::EventId;
 use airc_protocol::FrameKind;
 use airc_work::{
-    encode_work_event, CardCreated, ClaimId, ClaimReleased, LaneId, Priority, RepoId,
-    WorkBoardProjection, WorkCardClaimed, WorkCardId, WorkEvent,
+    encode_work_event, CardCreated, ClaimId, ClaimReleased, LaneCreated, LaneId, LaneState,
+    LaneStateChanged, Priority, RepoId, WorkBoardProjection, WorkCardClaimed, WorkCardId,
+    WorkEvent,
 };
 use airc_work_store::WorkEventStore;
 
@@ -31,6 +32,19 @@ pub struct ReleaseWorkClaim {
     pub card_id: WorkCardId,
     pub claim_id: ClaimId,
     pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateWorkLane {
+    pub repo: RepoId,
+    pub title: String,
+    pub state: LaneState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangeWorkLaneState {
+    pub lane_id: LaneId,
+    pub state: LaneState,
 }
 
 impl Airc {
@@ -76,6 +90,38 @@ impl Airc {
             owner: self.peer_id(),
             reason: request.reason,
             released_at_ms: now_ms(),
+        });
+        self.publish_work_event(&event).await?;
+        Ok(())
+    }
+
+    /// Create a work lane in the current room. Kanban boards are
+    /// projections over lane + card events; this returns the UUIDv4
+    /// lane id generated locally.
+    pub async fn create_work_lane(&self, request: CreateWorkLane) -> Result<LaneId, AircError> {
+        let lane_id = LaneId::new();
+        let event = WorkEvent::LaneCreated(LaneCreated {
+            lane_id,
+            repo: request.repo,
+            title: request.title,
+            state: request.state,
+            created_by: self.peer_id(),
+            created_at_ms: now_ms(),
+        });
+        self.publish_work_event(&event).await?;
+        Ok(lane_id)
+    }
+
+    /// Change a lane's state through the work event stream.
+    pub async fn change_work_lane_state(
+        &self,
+        request: ChangeWorkLaneState,
+    ) -> Result<(), AircError> {
+        let event = WorkEvent::LaneStateChanged(LaneStateChanged {
+            lane_id: request.lane_id,
+            state: request.state,
+            changed_by: self.peer_id(),
+            changed_at_ms: now_ms(),
         });
         self.publish_work_event(&event).await?;
         Ok(())

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -1,7 +1,8 @@
 use std::time::{Duration, Instant};
 
 use airc_lib::{
-    Airc, ClaimWorkCard, CreateWorkCard, Priority, ReleaseWorkClaim, RepoId, WorkCardId,
+    Airc, ChangeWorkLaneState, ClaimWorkCard, CreateWorkCard, CreateWorkLane, LaneState, Priority,
+    ReleaseWorkClaim, RepoId, WorkCardId,
 };
 use tempfile::TempDir;
 
@@ -110,4 +111,57 @@ async fn claim_and_release_work_card_round_trip_through_projection() {
         }
         tokio::time::sleep(Duration::from_millis(25)).await;
     }
+}
+
+#[tokio::test]
+async fn lane_create_attach_card_and_state_change_project_from_store() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("lane-api").await.unwrap();
+
+    let lane_id = airc
+        .create_work_lane(CreateWorkLane {
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            title: "rust lane surface".to_string(),
+            state: LaneState::Planned,
+        })
+        .await
+        .unwrap();
+
+    let card_id = airc
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            title: "attach card to lane".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: Some(lane_id),
+        })
+        .await
+        .unwrap();
+
+    let board = airc.work_board(128).await.unwrap();
+    let snapshot = board.snapshot();
+    let lane = snapshot
+        .lanes
+        .iter()
+        .find(|lane| lane.lane_id == lane_id)
+        .expect("created lane projects");
+    assert_eq!(lane.card_ids, vec![card_id]);
+    assert_eq!(lane.state, LaneState::Planned);
+
+    airc.change_work_lane_state(ChangeWorkLaneState {
+        lane_id,
+        state: LaneState::Active,
+    })
+    .await
+    .unwrap();
+
+    let board = airc.work_board(128).await.unwrap();
+    let lane = board
+        .snapshot()
+        .lanes
+        .into_iter()
+        .find(|lane| lane.lane_id == lane_id)
+        .expect("lane remains projected");
+    assert_eq!(lane.state, LaneState::Active);
 }


### PR DESCRIPTION
## Summary
- add typed `airc-lib` APIs for creating lanes and changing lane state
- add `airc-rs lane create|state|status` as thin wrappers over `airc-lib`
- add `work create --lane-id` so cards can attach to typed lane projections
- add Rust CLI and library tests for lane creation, card membership, and state replay

## Verification
- `cargo clippy --manifest-path Cargo.toml -p airc-cli -p airc-lib --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml --workspace`
