### PR TITLE
feat(airc-cli): add workspace lease commands

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -193,6 +193,9 @@ pub enum Command {
 
     /// Coordinate work lanes over the current room's AIRC substrate.
     Lane(crate::lane_cli::LaneArgs),
+
+    /// Coordinate workspace leases over the current room's AIRC substrate.
+    Workspace(crate::workspace_cli::WorkspaceArgs),
 }
 
 #[derive(Debug, Args)]

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -17,6 +17,8 @@ mod lane_cli;
 mod lane_commands;
 mod work_cli;
 mod work_commands;
+mod workspace_cli;
+mod workspace_commands;
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -31,6 +33,7 @@ use airc_daemon::LocalIdentity;
 use cli::{Cli, Command, PeerAction};
 use lane_cli::LaneAction;
 use work_cli::WorkAction;
+use workspace_cli::WorkspaceAction;
 
 fn parse_peer_id(input: &str) -> Result<PeerId, Box<dyn std::error::Error>> {
     let uuid = Uuid::from_str(input)
@@ -143,6 +146,29 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 lane_commands::run_state(&home, lane_id, state).await
             }
             LaneAction::Status { limit } => lane_commands::run_status(&home, limit).await,
+        },
+
+        Command::Workspace(args) => match args.action {
+            WorkspaceAction::Request {
+                card_id,
+                claim_id,
+                repo,
+                branch,
+                base,
+            } => {
+                workspace_commands::run_request(&home, card_id, claim_id, repo, branch, base).await
+            }
+            WorkspaceAction::Allocate { workspace_id, path } => {
+                workspace_commands::run_allocate(&home, workspace_id, path).await
+            }
+            WorkspaceAction::Heartbeat {
+                workspace_id,
+                disk_bytes,
+            } => workspace_commands::run_heartbeat(&home, workspace_id, disk_bytes).await,
+            WorkspaceAction::Release { workspace_id } => {
+                workspace_commands::run_release(&home, workspace_id).await
+            }
+            WorkspaceAction::List { limit } => workspace_commands::run_list(&home, limit).await,
         },
     }
 }

--- a/crates/airc-cli/src/workspace_cli.rs
+++ b/crates/airc-cli/src/workspace_cli.rs
@@ -1,0 +1,56 @@
+//! Clap argument shapes for `airc-rs workspace ...`.
+
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct WorkspaceArgs {
+    #[command(subcommand)]
+    pub action: WorkspaceAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WorkspaceAction {
+    /// Request a workspace lease for a claimed work card.
+    Request {
+        /// Work card UUID.
+        card_id: String,
+        /// Claim UUID returned by `work claim`.
+        claim_id: String,
+        /// Repository key, e.g. `CambrianTech/airc`.
+        #[arg(long)]
+        repo: String,
+        /// Workspace branch name.
+        #[arg(long)]
+        branch: String,
+        /// Base branch name.
+        #[arg(long, default_value = "rust-rewrite")]
+        base: String,
+    },
+    /// Mark a requested workspace as allocated at a concrete path.
+    Allocate {
+        /// Workspace UUID returned by `workspace request`.
+        workspace_id: String,
+        /// Filesystem path allocated for the workspace.
+        #[arg(long)]
+        path: String,
+    },
+    /// Heartbeat a workspace lease.
+    Heartbeat {
+        /// Workspace UUID.
+        workspace_id: String,
+        /// Optional disk usage in bytes.
+        #[arg(long)]
+        disk_bytes: Option<u64>,
+    },
+    /// Release a workspace lease.
+    Release {
+        /// Workspace UUID.
+        workspace_id: String,
+    },
+    /// Print the current room's projected workspace leases.
+    List {
+        /// Recent transcript events to replay into the projection.
+        #[arg(long, default_value_t = 128)]
+        limit: usize,
+    },
+}

--- a/crates/airc-cli/src/workspace_commands.rs
+++ b/crates/airc-cli/src/workspace_commands.rs
@@ -1,0 +1,128 @@
+//! `airc-rs workspace ...` handlers.
+
+use std::path::Path;
+
+use uuid::Uuid;
+
+use airc_lib::{
+    Airc, AllocateWorkspace, BranchName, ClaimId, HeartbeatWorkspace, ReleaseWorkspace, RepoId,
+    RequestWorkspace, WorkBoardProjection, WorkCardId, WorkspaceId,
+};
+
+pub async fn run_request(
+    home: &Path,
+    card_id: String,
+    claim_id: String,
+    repo: String,
+    branch: String,
+    base: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let workspace_id = airc
+        .request_workspace(RequestWorkspace {
+            card_id: parse_work_card_id(&card_id)?,
+            claim_id: parse_claim_id(&claim_id)?,
+            repo: RepoId::new(repo)?,
+            branch: BranchName::new(branch)?,
+            base: BranchName::new(base)?,
+        })
+        .await?;
+    println!("workspace_id: {workspace_id}");
+    Ok(())
+}
+
+pub async fn run_allocate(
+    home: &Path,
+    workspace_id: String,
+    path: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    airc.allocate_workspace(AllocateWorkspace {
+        workspace_id: parse_workspace_id(&workspace_id)?,
+        path,
+    })
+    .await?;
+    println!("workspace_allocated: workspace_id={workspace_id}");
+    Ok(())
+}
+
+pub async fn run_heartbeat(
+    home: &Path,
+    workspace_id: String,
+    disk_bytes: Option<u64>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    airc.heartbeat_workspace(HeartbeatWorkspace {
+        workspace_id: parse_workspace_id(&workspace_id)?,
+        disk_bytes,
+    })
+    .await?;
+    println!("workspace_heartbeat: workspace_id={workspace_id}");
+    Ok(())
+}
+
+pub async fn run_release(
+    home: &Path,
+    workspace_id: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    airc.release_workspace(ReleaseWorkspace {
+        workspace_id: parse_workspace_id(&workspace_id)?,
+    })
+    .await?;
+    println!("workspace_released: workspace_id={workspace_id}");
+    Ok(())
+}
+
+pub async fn run_list(home: &Path, limit: usize) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let board = airc.work_board(limit).await?;
+    print_workspaces(&board);
+    Ok(())
+}
+
+fn print_workspaces(board: &WorkBoardProjection) {
+    let snapshot = board.snapshot();
+    if snapshot.workspaces.is_empty() {
+        println!("(no workspaces)");
+        return;
+    }
+
+    println!("workspaces: {}", snapshot.workspaces.len());
+    for record in &snapshot.workspaces {
+        let lease = &record.lease;
+        let disk = lease
+            .disk_bytes
+            .map(|bytes| bytes.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "{workspace_id}  {status:?}  card={card_id}  claim={claim_id}  repo={repo}  branch={branch}  base={base}  path={path}  disk_bytes={disk}",
+            workspace_id = lease.workspace_id,
+            status = lease.status,
+            card_id = lease.card_id,
+            claim_id = lease.claim_id,
+            repo = lease.repo,
+            branch = lease.branch,
+            base = lease.base,
+            path = lease.path,
+        );
+    }
+}
+
+fn parse_work_card_id(input: &str) -> Result<WorkCardId, Box<dyn std::error::Error>> {
+    let uuid = Uuid::parse_str(input)
+        .map_err(|error| format!("work card id {input:?} is not a valid UUID: {error}"))?;
+    Ok(WorkCardId::from_uuid(uuid))
+}
+
+fn parse_claim_id(input: &str) -> Result<ClaimId, Box<dyn std::error::Error>> {
+    let uuid = Uuid::parse_str(input)
+        .map_err(|error| format!("claim id {input:?} is not a valid UUID: {error}"))?;
+    Ok(ClaimId::from_uuid(uuid))
+}
+
+fn parse_workspace_id(input: &str) -> Result<WorkspaceId, Box<dyn std::error::Error>> {
+    let uuid = Uuid::parse_str(input)
+        .map_err(|error| format!("workspace id {input:?} is not a valid UUID: {error}"))?;
+    Ok(WorkspaceId::from_uuid(uuid))
+}

--- a/crates/airc-cli/tests/workspace_commands.rs
+++ b/crates/airc-cli/tests/workspace_commands.rs
@@ -1,0 +1,102 @@
+//! End-to-end coverage for `airc-rs workspace ...`.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn airc_rs() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-rs")
+}
+
+#[test]
+fn workspace_request_allocate_heartbeat_release_projects_on_list() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let card = run_ok(
+        &home,
+        &[
+            "work",
+            "create",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "workspace cli lifecycle",
+        ],
+    );
+    let card_id = extract_field(&card, "card_id:").expect("create prints card_id");
+    let claim = run_ok(&home, &["work", "claim", card_id, "--ttl-ms", "60000"]);
+    let claim_id = extract_field(&claim, "claim_id:").expect("claim prints claim_id");
+
+    let request = run_ok(
+        &home,
+        &[
+            "workspace",
+            "request",
+            card_id,
+            claim_id,
+            "--repo",
+            "CambrianTech/airc",
+            "--branch",
+            "feat/workspace-commands",
+            "--base",
+            "rust-rewrite",
+        ],
+    );
+    let workspace_id =
+        extract_field(&request, "workspace_id:").expect("request prints workspace_id");
+
+    run_ok(
+        &home,
+        &[
+            "workspace",
+            "allocate",
+            workspace_id,
+            "--path",
+            "/tmp/airc/ws",
+        ],
+    );
+    run_ok(
+        &home,
+        &[
+            "workspace",
+            "heartbeat",
+            workspace_id,
+            "--disk-bytes",
+            "4096",
+        ],
+    );
+    let active = run_ok(&home, &["workspace", "list"]);
+    assert!(active.contains(workspace_id));
+    assert!(active.contains("Active"));
+    assert!(active.contains("disk_bytes=4096"));
+    assert!(active.contains("feat/workspace-commands"));
+
+    run_ok(&home, &["workspace", "release", workspace_id]);
+    let released = run_ok(&home, &["workspace", "list"]);
+    assert!(released.contains("Released"));
+}
+
+fn run_ok(home: &Path, args: &[&str]) -> String {
+    let output = Command::new(airc_rs())
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .output()
+        .expect("airc-rs command must spawn");
+    assert!(
+        output.status.success(),
+        "airc-rs {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout utf-8")
+}
+
+fn extract_field<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
+    text.lines()
+        .find_map(|line| line.strip_prefix(prefix).map(str::trim))
+}

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -39,7 +39,8 @@ pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use room::Room;
 pub use stream::{EventStream, LiveLag};
 pub use work::{
-    ChangeWorkLaneState, ClaimWorkCard, CreateWorkCard, CreateWorkLane, ReleaseWorkClaim,
+    AllocateWorkspace, ChangeWorkLaneState, ClaimWorkCard, CreateWorkCard, CreateWorkLane,
+    HeartbeatWorkspace, ReleaseWorkClaim, ReleaseWorkspace, RequestWorkspace,
 };
 
 // Convenience re-exports so consumers don't need to pull airc-core
@@ -50,5 +51,5 @@ pub use airc_core::{
 };
 pub use airc_work::{
     BoardSnapshot, BranchName, CardState, ClaimId, LaneId, LaneState, Priority, ProjectionError,
-    RepoId, WorkBoardProjection, WorkCardId, WorkEvent, WorkspaceId,
+    RepoId, WorkBoardProjection, WorkCardId, WorkEvent, WorkspaceId, WorkspaceStatus,
 };

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -3,9 +3,10 @@
 use airc_core::EventId;
 use airc_protocol::FrameKind;
 use airc_work::{
-    encode_work_event, CardCreated, ClaimId, ClaimReleased, LaneCreated, LaneId, LaneState,
-    LaneStateChanged, Priority, RepoId, WorkBoardProjection, WorkCardClaimed, WorkCardId,
-    WorkEvent,
+    encode_work_event, BranchName, CardCreated, ClaimId, ClaimReleased, LaneCreated, LaneId,
+    LaneState, LaneStateChanged, Priority, RepoId, WorkBoardProjection, WorkCardClaimed,
+    WorkCardId, WorkEvent, WorkspaceAllocated, WorkspaceHeartbeat, WorkspaceId, WorkspaceReleased,
+    WorkspaceRequested,
 };
 use airc_work_store::WorkEventStore;
 
@@ -45,6 +46,32 @@ pub struct CreateWorkLane {
 pub struct ChangeWorkLaneState {
     pub lane_id: LaneId,
     pub state: LaneState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestWorkspace {
+    pub card_id: WorkCardId,
+    pub claim_id: ClaimId,
+    pub repo: RepoId,
+    pub branch: BranchName,
+    pub base: BranchName,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllocateWorkspace {
+    pub workspace_id: WorkspaceId,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HeartbeatWorkspace {
+    pub workspace_id: WorkspaceId,
+    pub disk_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReleaseWorkspace {
+    pub workspace_id: WorkspaceId,
 }
 
 impl Airc {
@@ -122,6 +149,60 @@ impl Airc {
             state: request.state,
             changed_by: self.peer_id(),
             changed_at_ms: now_ms(),
+        });
+        self.publish_work_event(&event).await?;
+        Ok(())
+    }
+
+    /// Request a workspace lease for an already-claimed work card.
+    /// The request is a typed event; actual worktree allocation is a
+    /// later adapter that consumes this event.
+    pub async fn request_workspace(
+        &self,
+        request: RequestWorkspace,
+    ) -> Result<WorkspaceId, AircError> {
+        let workspace_id = WorkspaceId::new();
+        let event = WorkEvent::WorkspaceRequested(WorkspaceRequested {
+            workspace_id,
+            card_id: request.card_id,
+            claim_id: request.claim_id,
+            owner: self.peer_id(),
+            repo: request.repo,
+            branch: request.branch,
+            base: request.base,
+            requested_at_ms: now_ms(),
+        });
+        self.publish_work_event(&event).await?;
+        Ok(workspace_id)
+    }
+
+    /// Mark a requested workspace as allocated at a concrete path.
+    pub async fn allocate_workspace(&self, request: AllocateWorkspace) -> Result<(), AircError> {
+        let event = WorkEvent::WorkspaceAllocated(WorkspaceAllocated {
+            workspace_id: request.workspace_id,
+            path: request.path,
+            allocated_at_ms: now_ms(),
+        });
+        self.publish_work_event(&event).await?;
+        Ok(())
+    }
+
+    /// Heartbeat a workspace lease with optional disk usage.
+    pub async fn heartbeat_workspace(&self, request: HeartbeatWorkspace) -> Result<(), AircError> {
+        let event = WorkEvent::WorkspaceHeartbeat(WorkspaceHeartbeat {
+            workspace_id: request.workspace_id,
+            disk_bytes: request.disk_bytes,
+            heartbeat_at_ms: now_ms(),
+        });
+        self.publish_work_event(&event).await?;
+        Ok(())
+    }
+
+    /// Release a workspace lease.
+    pub async fn release_workspace(&self, request: ReleaseWorkspace) -> Result<(), AircError> {
+        let event = WorkEvent::WorkspaceReleased(WorkspaceReleased {
+            workspace_id: request.workspace_id,
+            released_at_ms: now_ms(),
         });
         self.publish_work_event(&event).await?;
         Ok(())

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -1,8 +1,9 @@
 use std::time::{Duration, Instant};
 
 use airc_lib::{
-    Airc, ChangeWorkLaneState, ClaimWorkCard, CreateWorkCard, CreateWorkLane, LaneState, Priority,
-    ReleaseWorkClaim, RepoId, WorkCardId,
+    Airc, AllocateWorkspace, BranchName, ChangeWorkLaneState, ClaimWorkCard, CreateWorkCard,
+    CreateWorkLane, HeartbeatWorkspace, LaneState, Priority, ReleaseWorkClaim, ReleaseWorkspace,
+    RepoId, RequestWorkspace, WorkCardId, WorkspaceStatus,
 };
 use tempfile::TempDir;
 
@@ -164,4 +165,63 @@ async fn lane_create_attach_card_and_state_change_project_from_store() {
         .find(|lane| lane.lane_id == lane_id)
         .expect("lane remains projected");
     assert_eq!(lane.state, LaneState::Active);
+}
+
+#[tokio::test]
+async fn workspace_lifecycle_projects_from_store() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("workspace-api").await.unwrap();
+
+    let card_id = airc
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            title: "workspace lease lifecycle".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+        })
+        .await
+        .unwrap();
+    let claim_id = airc
+        .claim_work_card(ClaimWorkCard {
+            card_id,
+            ttl_ms: 60_000,
+        })
+        .await
+        .unwrap();
+
+    let workspace_id = airc
+        .request_workspace(RequestWorkspace {
+            card_id,
+            claim_id,
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            branch: BranchName::new("feat/workspace-commands").unwrap(),
+            base: BranchName::new("rust-rewrite").unwrap(),
+        })
+        .await
+        .unwrap();
+    airc.allocate_workspace(AllocateWorkspace {
+        workspace_id,
+        path: "/tmp/airc/ws".to_string(),
+    })
+    .await
+    .unwrap();
+    airc.heartbeat_workspace(HeartbeatWorkspace {
+        workspace_id,
+        disk_bytes: Some(4096),
+    })
+    .await
+    .unwrap();
+    airc.release_workspace(ReleaseWorkspace { workspace_id })
+        .await
+        .unwrap();
+
+    let board = airc.work_board(128).await.unwrap();
+    let workspace = board.workspace(workspace_id).unwrap();
+    assert_eq!(workspace.lease.status, WorkspaceStatus::Released);
+    assert_eq!(workspace.lease.path, "/tmp/airc/ws");
+    assert_eq!(workspace.lease.disk_bytes, Some(4096));
+    assert_eq!(workspace.lease.card_id, card_id);
+    assert_eq!(workspace.lease.claim_id, claim_id);
 }


### PR DESCRIPTION
## Summary
- add typed `airc-lib` APIs for workspace request/allocate/heartbeat/release
- add `airc-rs workspace request|allocate|heartbeat|release|list`
- keep workspace allocation as typed events only; no filesystem worktree side effects in this slice
- add library projection tests and CLI subprocess coverage for the workspace lifecycle

## Verification
- `cargo clippy --manifest-path Cargo.toml -p airc-cli -p airc-lib --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml --workspace`
