### PR TITLE
feat(airc-cli): add manager hat commands

### DIFF
--- a/crates/airc-cli/src/lane_cli.rs
+++ b/crates/airc-cli/src/lane_cli.rs
@@ -36,6 +36,36 @@ pub enum LaneAction {
         #[arg(long, default_value_t = 128)]
         limit: usize,
     },
+    /// Claim, release, or inspect the manager hat for a repo.
+    Manager {
+        #[command(subcommand)]
+        action: LaneManagerAction,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LaneManagerAction {
+    /// Claim the manager hat lease for a repo.
+    Claim {
+        /// Repository key, e.g. `CambrianTech/airc`.
+        #[arg(long)]
+        repo: String,
+        /// Lease duration in milliseconds.
+        #[arg(long, default_value_t = 900_000)]
+        ttl_ms: u64,
+    },
+    /// Release this peer's manager hat for a repo.
+    Release {
+        /// Repository key, e.g. `CambrianTech/airc`.
+        #[arg(long)]
+        repo: String,
+    },
+    /// Print current manager hats from the board projection.
+    Status {
+        /// Recent transcript events to replay into the projection.
+        #[arg(long, default_value_t = 128)]
+        limit: usize,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/crates/airc-cli/src/lane_commands.rs
+++ b/crates/airc-cli/src/lane_commands.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 use uuid::Uuid;
 
 use airc_lib::{
-    Airc, ChangeWorkLaneState, CreateWorkLane, LaneId, LaneState, RepoId, WorkBoardProjection,
+    Airc, ChangeWorkLaneState, ClaimManagerHat, CreateWorkLane, LaneId, LaneState,
+    ReleaseManagerHat, RepoId, WorkBoardProjection,
 };
 
 use crate::lane_cli::CliLaneState;
@@ -50,6 +51,44 @@ pub async fn run_status(home: &Path, limit: usize) -> Result<(), Box<dyn std::er
     Ok(())
 }
 
+pub async fn run_manager_claim(
+    home: &Path,
+    repo: String,
+    ttl_ms: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let repo = RepoId::new(repo)?;
+    airc.claim_manager_hat(ClaimManagerHat {
+        repo: repo.clone(),
+        ttl_ms,
+    })
+    .await?;
+    println!("manager_hat_claimed: repo={repo} ttl_ms={ttl_ms}");
+    Ok(())
+}
+
+pub async fn run_manager_release(
+    home: &Path,
+    repo: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let repo = RepoId::new(repo)?;
+    airc.release_manager_hat(ReleaseManagerHat { repo: repo.clone() })
+        .await?;
+    println!("manager_hat_released: repo={repo}");
+    Ok(())
+}
+
+pub async fn run_manager_status(
+    home: &Path,
+    limit: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let board = airc.work_board(limit).await?;
+    print_manager_status(&board);
+    Ok(())
+}
+
 fn print_status(board: &WorkBoardProjection) {
     let snapshot = board.snapshot();
     if snapshot.lanes.is_empty() {
@@ -66,6 +105,25 @@ fn print_status(board: &WorkBoardProjection) {
             cards = lane.card_ids.len(),
             repo = lane.repo,
             title = lane.title,
+        );
+    }
+}
+
+fn print_manager_status(board: &WorkBoardProjection) {
+    let snapshot = board.snapshot();
+    if snapshot.manager_hats.is_empty() {
+        println!("(no manager hats)");
+        return;
+    }
+
+    println!("manager hats: {}", snapshot.manager_hats.len());
+    for hat in &snapshot.manager_hats {
+        println!(
+            "{repo}  manager={manager}  claimed_at_ms={claimed_at_ms}  expires_at_ms={expires_at_ms}",
+            repo = hat.repo,
+            manager = hat.manager,
+            claimed_at_ms = hat.claimed_at_ms,
+            expires_at_ms = hat.expires_at_ms,
         );
     }
 }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -31,7 +31,7 @@ use airc_core::PeerId;
 
 use airc_daemon::LocalIdentity;
 use cli::{Cli, Command, PeerAction};
-use lane_cli::LaneAction;
+use lane_cli::{LaneAction, LaneManagerAction};
 use work_cli::WorkAction;
 use workspace_cli::WorkspaceAction;
 
@@ -146,6 +146,17 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 lane_commands::run_state(&home, lane_id, state).await
             }
             LaneAction::Status { limit } => lane_commands::run_status(&home, limit).await,
+            LaneAction::Manager { action } => match action {
+                LaneManagerAction::Claim { repo, ttl_ms } => {
+                    lane_commands::run_manager_claim(&home, repo, ttl_ms).await
+                }
+                LaneManagerAction::Release { repo } => {
+                    lane_commands::run_manager_release(&home, repo).await
+                }
+                LaneManagerAction::Status { limit } => {
+                    lane_commands::run_manager_status(&home, limit).await
+                }
+            },
         },
 
         Command::Workspace(args) => match args.action {

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -121,6 +121,42 @@ fn lane_create_status_and_state_drive_work_projection() {
 }
 
 #[test]
+fn lane_manager_claim_status_and_release_project_from_board() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let claim = run_ok(
+        &home,
+        &[
+            "lane",
+            "manager",
+            "claim",
+            "--repo",
+            "CambrianTech/airc",
+            "--ttl-ms",
+            "60000",
+        ],
+    );
+    assert!(claim.contains("manager_hat_claimed"));
+
+    let status = run_ok(&home, &["lane", "manager", "status"]);
+    assert!(status.contains("manager hats: 1"));
+    assert!(status.contains("CambrianTech/airc"));
+    assert!(status.contains("manager="));
+    assert!(status.contains("expires_at_ms="));
+
+    let release = run_ok(
+        &home,
+        &["lane", "manager", "release", "--repo", "CambrianTech/airc"],
+    );
+    assert!(release.contains("manager_hat_released"));
+
+    let status = run_ok(&home, &["lane", "manager", "status"]);
+    assert!(status.contains("(no manager hats)"));
+}
+
+#[test]
 fn work_board_empty_state_is_explicit() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -39,8 +39,9 @@ pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use room::Room;
 pub use stream::{EventStream, LiveLag};
 pub use work::{
-    AllocateWorkspace, ChangeWorkLaneState, ClaimWorkCard, CreateWorkCard, CreateWorkLane,
-    HeartbeatWorkspace, ReleaseWorkClaim, ReleaseWorkspace, RequestWorkspace,
+    AllocateWorkspace, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard, CreateWorkCard,
+    CreateWorkLane, HeartbeatWorkspace, ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace,
+    RequestWorkspace,
 };
 
 // Convenience re-exports so consumers don't need to pull airc-core
@@ -50,6 +51,7 @@ pub use airc_core::{
     TranscriptCursor, TranscriptEvent,
 };
 pub use airc_work::{
-    BoardSnapshot, BranchName, CardState, ClaimId, LaneId, LaneState, Priority, ProjectionError,
-    RepoId, WorkBoardProjection, WorkCardId, WorkEvent, WorkspaceId, WorkspaceStatus,
+    BoardSnapshot, BranchName, CardState, ClaimId, LaneId, LaneState, ManagerHat, Priority,
+    ProjectionError, RepoId, WorkBoardProjection, WorkCardId, WorkEvent, WorkspaceId,
+    WorkspaceStatus,
 };

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -4,9 +4,9 @@ use airc_core::EventId;
 use airc_protocol::FrameKind;
 use airc_work::{
     encode_work_event, BranchName, CardCreated, ClaimId, ClaimReleased, LaneCreated, LaneId,
-    LaneState, LaneStateChanged, Priority, RepoId, WorkBoardProjection, WorkCardClaimed,
-    WorkCardId, WorkEvent, WorkspaceAllocated, WorkspaceHeartbeat, WorkspaceId, WorkspaceReleased,
-    WorkspaceRequested,
+    LaneState, LaneStateChanged, ManagerHatClaimed, ManagerHatReleased, Priority, RepoId,
+    WorkBoardProjection, WorkCardClaimed, WorkCardId, WorkEvent, WorkspaceAllocated,
+    WorkspaceHeartbeat, WorkspaceId, WorkspaceReleased, WorkspaceRequested,
 };
 use airc_work_store::WorkEventStore;
 
@@ -72,6 +72,17 @@ pub struct HeartbeatWorkspace {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReleaseWorkspace {
     pub workspace_id: WorkspaceId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimManagerHat {
+    pub repo: RepoId,
+    pub ttl_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseManagerHat {
+    pub repo: RepoId,
 }
 
 impl Airc {
@@ -202,6 +213,31 @@ impl Airc {
     pub async fn release_workspace(&self, request: ReleaseWorkspace) -> Result<(), AircError> {
         let event = WorkEvent::WorkspaceReleased(WorkspaceReleased {
             workspace_id: request.workspace_id,
+            released_at_ms: now_ms(),
+        });
+        self.publish_work_event(&event).await?;
+        Ok(())
+    }
+
+    /// Claim the manager hat for a repo in the current room. This is
+    /// a lease, not a permission boundary; peers can see who is
+    /// coordinating and when that claim expires.
+    pub async fn claim_manager_hat(&self, request: ClaimManagerHat) -> Result<(), AircError> {
+        let event = WorkEvent::ManagerHatClaimed(ManagerHatClaimed {
+            repo: request.repo,
+            manager: self.peer_id(),
+            ttl_ms: request.ttl_ms,
+            claimed_at_ms: now_ms(),
+        });
+        self.publish_work_event(&event).await?;
+        Ok(())
+    }
+
+    /// Release this peer's manager hat for a repo.
+    pub async fn release_manager_hat(&self, request: ReleaseManagerHat) -> Result<(), AircError> {
+        let event = WorkEvent::ManagerHatReleased(ManagerHatReleased {
+            repo: request.repo,
+            manager: self.peer_id(),
             released_at_ms: now_ms(),
         });
         self.publish_work_event(&event).await?;

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -1,9 +1,9 @@
 use std::time::{Duration, Instant};
 
 use airc_lib::{
-    Airc, AllocateWorkspace, BranchName, ChangeWorkLaneState, ClaimWorkCard, CreateWorkCard,
-    CreateWorkLane, HeartbeatWorkspace, LaneState, Priority, ReleaseWorkClaim, ReleaseWorkspace,
-    RepoId, RequestWorkspace, WorkCardId, WorkspaceStatus,
+    Airc, AllocateWorkspace, BranchName, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard,
+    CreateWorkCard, CreateWorkLane, HeartbeatWorkspace, LaneState, Priority, ReleaseManagerHat,
+    ReleaseWorkClaim, ReleaseWorkspace, RepoId, RequestWorkspace, WorkCardId, WorkspaceStatus,
 };
 use tempfile::TempDir;
 
@@ -224,4 +224,39 @@ async fn workspace_lifecycle_projects_from_store() {
     assert_eq!(workspace.lease.disk_bytes, Some(4096));
     assert_eq!(workspace.lease.card_id, card_id);
     assert_eq!(workspace.lease.claim_id, claim_id);
+}
+
+#[tokio::test]
+async fn manager_hat_claim_and_release_project_from_store() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("manager-hat-api").await.unwrap();
+    let repo = RepoId::new("CambrianTech/airc").unwrap();
+
+    airc.claim_manager_hat(ClaimManagerHat {
+        repo: repo.clone(),
+        ttl_ms: 60_000,
+    })
+    .await
+    .unwrap();
+
+    let board = airc.work_board(128).await.unwrap();
+    let snapshot = board.snapshot();
+    let hat = snapshot
+        .manager_hats
+        .iter()
+        .find(|hat| hat.repo == repo)
+        .expect("manager hat projects");
+    assert_eq!(hat.manager, airc.peer_id());
+    assert!(hat.expires_at_ms > hat.claimed_at_ms);
+
+    airc.release_manager_hat(ReleaseManagerHat { repo: repo.clone() })
+        .await
+        .unwrap();
+
+    let board = airc.work_board(128).await.unwrap();
+    assert!(
+        board.snapshot().manager_hats.is_empty(),
+        "released manager hat must leave projection"
+    );
 }

--- a/crates/airc-work/src/lib.rs
+++ b/crates/airc-work/src/lib.rs
@@ -30,7 +30,8 @@ pub use model::{
     WorkspaceLease, WorkspaceStatus,
 };
 pub use projection::{
-    BoardSnapshot, LaneRecord, ProjectionError, StaleClaim, WorkBoardProjection, WorkspaceRecord,
+    BoardSnapshot, LaneRecord, ManagerHat, ProjectionError, StaleClaim, WorkBoardProjection,
+    WorkspaceRecord,
 };
 pub use replay::{
     decode_transcript_work_event, project_transcript_work_events, transcript_is_work_event,


### PR DESCRIPTION
## Summary
- add typed `airc-lib` APIs for manager-hat claim/release leases
- add `airc-rs lane manager claim|release|status`
- re-export `ManagerHat` through `airc-work` and `airc-lib`
- add library and CLI subprocess tests for manager-hat projection

## Verification
- `cargo clippy --manifest-path Cargo.toml -p airc-work -p airc-lib -p airc-cli --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml --workspace`
