### PR TITLE
feat(airc-lib): add filtered event subscriptions

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -188,6 +188,9 @@ pub enum Command {
     /// Manage the persisted peer registry (`<home>/peers.json`).
     Peer(PeerArgs),
 
+    /// Inspect persisted events through subscription-style filters.
+    Events(crate::events_cli::EventsArgs),
+
     /// Coordinate work cards over the current room's AIRC substrate.
     Work(WorkArgs),
 

--- a/crates/airc-cli/src/events_cli.rs
+++ b/crates/airc-cli/src/events_cli.rs
@@ -1,0 +1,39 @@
+//! Clap argument shapes for `airc-rs events ...`.
+
+use clap::{Args, Subcommand, ValueEnum};
+
+#[derive(Debug, Args)]
+pub struct EventsArgs {
+    #[command(subcommand)]
+    pub action: EventsAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum EventsAction {
+    /// List persisted current-room events matching filters.
+    List {
+        /// Restrict to transcript kind. Repeatable.
+        #[arg(long = "kind", value_enum)]
+        kind: Vec<CliTranscriptKind>,
+        /// Exact header match as `key=value`. Repeatable.
+        #[arg(long = "header", value_name = "KEY=VALUE")]
+        header: Vec<String>,
+        /// Header prefix match as `key=prefix`. Repeatable.
+        #[arg(long = "header-prefix", value_name = "KEY=PREFIX")]
+        header_prefix: Vec<String>,
+        /// Recent events to scan before filtering.
+        #[arg(long, default_value_t = 128)]
+        limit: usize,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum CliTranscriptKind {
+    Message,
+    Attachment,
+    Receipt,
+    Presence,
+    SessionControl,
+    System,
+}

--- a/crates/airc-cli/src/events_commands.rs
+++ b/crates/airc-cli/src/events_commands.rs
@@ -1,0 +1,103 @@
+//! `airc-rs events ...` handlers.
+
+use std::path::Path;
+
+use airc_lib::{Airc, Body, EventFilter, HeaderFilter, TranscriptEvent, TranscriptKind};
+
+use crate::events_cli::CliTranscriptKind;
+
+pub async fn run_list(
+    home: &Path,
+    kinds: Vec<CliTranscriptKind>,
+    exact_headers: Vec<String>,
+    prefix_headers: Vec<String>,
+    limit: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let filter = EventFilter {
+        kinds: kinds.into_iter().map(TranscriptKind::from).collect(),
+        headers_filter: parse_header_filters(exact_headers, prefix_headers)?,
+        ..EventFilter::current_room()
+    };
+    let events = airc.page_recent_filtered(filter, limit).await?;
+    print_events(&events);
+    Ok(())
+}
+
+fn print_events(events: &[TranscriptEvent]) {
+    if events.is_empty() {
+        println!("(no matching events)");
+        return;
+    }
+
+    println!("events: {}", events.len());
+    for event in events {
+        let body = event
+            .body
+            .as_ref()
+            .map(format_body)
+            .unwrap_or_else(|| "<empty body>".to_string());
+        println!(
+            "{event_id}  {kind:?}  room={room}  peer={peer}  lamport={lamport}  body={body}",
+            event_id = event.event_id,
+            kind = event.kind,
+            room = event.room_id,
+            peer = event.peer_id,
+            lamport = event.lamport,
+        );
+    }
+}
+
+fn format_body(body: &Body) -> String {
+    if let Some(text) = body.as_text() {
+        return text.to_string();
+    }
+    match body {
+        Body::Json(value) => value.to_string(),
+        Body::Binary(bytes) => format!("<binary {} bytes>", bytes.len()),
+    }
+}
+
+fn parse_header_filters(
+    exact: Vec<String>,
+    prefix: Vec<String>,
+) -> Result<HeaderFilter, Box<dyn std::error::Error>> {
+    let mut filters = Vec::new();
+    for item in exact {
+        let (key, value) = split_header_filter(&item)?;
+        filters.push(HeaderFilter::Exact { key, value });
+    }
+    for item in prefix {
+        let (key, value_prefix) = split_header_filter(&item)?;
+        filters.push(HeaderFilter::Prefix { key, value_prefix });
+    }
+    Ok(match filters.len() {
+        0 => HeaderFilter::Any,
+        1 => filters.remove(0),
+        _ => HeaderFilter::All(filters),
+    })
+}
+
+fn split_header_filter(input: &str) -> Result<(String, String), Box<dyn std::error::Error>> {
+    let (key, value) = input
+        .split_once('=')
+        .ok_or_else(|| format!("header filter {input:?} must be KEY=VALUE"))?;
+    let key = key.trim();
+    if key.is_empty() {
+        return Err(format!("header filter {input:?} has empty key").into());
+    }
+    Ok((key.to_string(), value.to_string()))
+}
+
+impl From<CliTranscriptKind> for TranscriptKind {
+    fn from(value: CliTranscriptKind) -> Self {
+        match value {
+            CliTranscriptKind::Message => Self::Message,
+            CliTranscriptKind::Attachment => Self::Attachment,
+            CliTranscriptKind::Receipt => Self::Receipt,
+            CliTranscriptKind::Presence => Self::Presence,
+            CliTranscriptKind::SessionControl => Self::SessionControl,
+            CliTranscriptKind::System => Self::System,
+        }
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -13,6 +13,8 @@
 
 mod cli;
 mod commands;
+mod events_cli;
+mod events_commands;
 mod lane_cli;
 mod lane_commands;
 mod work_cli;
@@ -31,6 +33,7 @@ use airc_core::PeerId;
 
 use airc_daemon::LocalIdentity;
 use cli::{Cli, Command, PeerAction};
+use events_cli::EventsAction;
 use lane_cli::{LaneAction, LaneManagerAction};
 use work_cli::WorkAction;
 use workspace_cli::WorkspaceAction;
@@ -117,6 +120,15 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 commands::run_peer_add(&home, spec, default_or(socket, &home)).await
             }
             PeerAction::List => commands::run_peer_list(&home).await,
+        },
+
+        Command::Events(args) => match args.action {
+            EventsAction::List {
+                kind,
+                header,
+                header_prefix,
+                limit,
+            } => events_commands::run_list(&home, kind, header, header_prefix, limit).await,
         },
 
         Command::Work(args) => match args.action {

--- a/crates/airc-cli/tests/events_commands.rs
+++ b/crates/airc-cli/tests/events_commands.rs
@@ -1,0 +1,64 @@
+//! End-to-end coverage for `airc-rs events ...`.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn airc_rs() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-rs")
+}
+
+#[test]
+fn events_list_filters_by_kind_and_header_prefix() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    run_ok(&home, &["send", "plain chat"]);
+    run_ok(
+        &home,
+        &[
+            "work",
+            "create",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "subscription filter proof",
+        ],
+    );
+
+    let output = run_ok(
+        &home,
+        &[
+            "events",
+            "list",
+            "--kind",
+            "system",
+            "--header-prefix",
+            "forge.body_hint=forge.work.",
+        ],
+    );
+
+    assert!(output.contains("events: 1"));
+    assert!(output.contains("System"));
+    assert!(output.contains("subscription filter proof"));
+    assert!(!output.contains("plain chat"));
+}
+
+fn run_ok(home: &Path, args: &[&str]) -> String {
+    let output = Command::new(airc_rs())
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .output()
+        .expect("airc-rs command must spawn");
+    assert!(
+        output.status.success(),
+        "airc-rs {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout utf-8")
+}

--- a/crates/airc-core/src/transcript.rs
+++ b/crates/airc-core/src/transcript.rs
@@ -18,7 +18,7 @@ use crate::ids::{ClientId, EventId, PeerId, RoomId};
 
 /// The category of a transcript event. Different kinds may carry
 /// different optional fields on `TranscriptEvent`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TranscriptKind {
     /// Conversational message body — the bulk of chat traffic.

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -37,7 +37,7 @@ pub use error::AircError;
 pub use peers::EnrolledPeer;
 pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use room::Room;
-pub use stream::{EventStream, LiveLag};
+pub use stream::{EventFilter, EventStream, FilteredEventStream, LiveLag};
 pub use work::{
     AllocateWorkspace, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard, CreateWorkCard,
     CreateWorkLane, HeartbeatWorkspace, ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace,
@@ -47,8 +47,10 @@ pub use work::{
 // Convenience re-exports so consumers don't need to pull airc-core
 // just to type the common return values.
 pub use airc_core::{
-    body::Body, headers::Headers, transcript::MentionTarget, ClientId, EventId, PeerId, RoomId,
-    TranscriptCursor, TranscriptEvent,
+    body::Body,
+    headers::{HeaderFilter, Headers},
+    transcript::MentionTarget,
+    ClientId, EventId, PeerId, RoomId, TranscriptCursor, TranscriptEvent, TranscriptKind,
 };
 pub use airc_work::{
     BoardSnapshot, BranchName, CardState, ClaimId, LaneId, LaneState, ManagerHat, Priority,

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -4,7 +4,7 @@ use airc_transport::{LocalFsAdapter, Transport};
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::error::AircError;
-use crate::stream::EventStream;
+use crate::stream::{EventFilter, EventStream, FilteredEventStream};
 use crate::time::now_ms;
 use crate::Airc;
 
@@ -83,6 +83,19 @@ impl Airc {
         })
     }
 
+    /// Subscribe to live events matching `filter`. If the filter does
+    /// not specify a channel, it is scoped to the current room.
+    pub async fn subscribe_filtered(
+        &self,
+        filter: EventFilter,
+    ) -> Result<FilteredEventStream, AircError> {
+        let filter = self.scope_filter_to_current_room(filter).await?;
+        Ok(FilteredEventStream {
+            inner: self.subscribe().await?,
+            filter,
+        })
+    }
+
     /// Fetch the most recent `limit` events from the current room.
     pub async fn page_recent(&self, limit: usize) -> Result<Vec<TranscriptEvent>, AircError> {
         let room = self.current_room().await?;
@@ -92,6 +105,25 @@ impl Airc {
             .store
             .page_recent(Some(room.channel), limit)
             .await?)
+    }
+
+    /// Fetch recent events matching `filter`. If the filter does not
+    /// specify a channel, it is scoped to the current room.
+    pub async fn page_recent_filtered(
+        &self,
+        filter: EventFilter,
+        limit: usize,
+    ) -> Result<Vec<TranscriptEvent>, AircError> {
+        let filter = self.scope_filter_to_current_room(filter).await?;
+        self.ensure_current_room_subscriber().await?;
+        Ok(self
+            .inner
+            .store
+            .page_recent(filter.channel, limit)
+            .await?
+            .into_iter()
+            .filter(|event| filter.matches(event))
+            .collect())
     }
 
     /// Fetch up to `limit` events strictly after `cursor`.
@@ -108,6 +140,26 @@ impl Airc {
             .await?)
     }
 
+    /// Fetch events strictly after `cursor` that match `filter`. If
+    /// the filter does not specify a channel, it is scoped to the
+    /// current room.
+    pub async fn resume_from_filtered(
+        &self,
+        cursor: &TranscriptCursor,
+        filter: EventFilter,
+        limit: usize,
+    ) -> Result<Vec<TranscriptEvent>, AircError> {
+        let filter = self.scope_filter_to_current_room(filter).await?;
+        Ok(self
+            .inner
+            .store
+            .resume_from(cursor, filter.channel, limit)
+            .await?
+            .into_iter()
+            .filter(|event| filter.matches(event))
+            .collect())
+    }
+
     /// Cursor of the newest event in the current room.
     pub async fn latest_cursor(&self) -> Result<Option<TranscriptCursor>, AircError> {
         let room = self.current_room().await?;
@@ -117,5 +169,20 @@ impl Airc {
     /// Append a `TranscriptEvent` to the durable store directly.
     pub async fn append_event(&self, event: TranscriptEvent) -> Result<(), AircError> {
         Ok(self.inner.store.append(event).await?)
+    }
+
+    async fn scope_filter_to_current_room(
+        &self,
+        mut filter: EventFilter,
+    ) -> Result<EventFilter, AircError> {
+        if filter.channel.is_none() {
+            filter.channel = Some(self.current_room().await?.channel);
+        }
+        Ok(filter)
+    }
+
+    async fn ensure_current_room_subscriber(&self) -> Result<(), AircError> {
+        let room = self.current_room().await?;
+        self.ensure_wire_subscriber(&room.wire).await
     }
 }

--- a/crates/airc-lib/src/stream.rs
+++ b/crates/airc-lib/src/stream.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeSet;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use airc_core::TranscriptEvent;
+use airc_core::transcript::TranscriptKind;
+use airc_core::{HeaderFilter, RoomId, TranscriptEvent};
 use futures::stream::Stream;
 use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
 
@@ -43,3 +45,69 @@ impl std::fmt::Display for LiveLag {
 }
 
 impl std::error::Error for LiveLag {}
+
+/// Consumer-facing filter over persisted transcript events.
+///
+/// This intentionally mirrors the wire-level subscription shape but
+/// operates on `TranscriptEvent`, which is what hooks, monitors, and
+/// Continuum consume after signatures have been verified and frames
+/// have crossed into the durable store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventFilter {
+    pub channel: Option<RoomId>,
+    pub kinds: BTreeSet<TranscriptKind>,
+    pub headers_filter: HeaderFilter,
+}
+
+impl Default for EventFilter {
+    fn default() -> Self {
+        Self {
+            channel: None,
+            kinds: BTreeSet::new(),
+            headers_filter: HeaderFilter::Any,
+        }
+    }
+}
+
+impl EventFilter {
+    pub fn current_room() -> Self {
+        Self::default()
+    }
+
+    pub fn matches(&self, event: &TranscriptEvent) -> bool {
+        if let Some(channel) = self.channel {
+            if event.room_id != channel {
+                return false;
+            }
+        }
+        if !self.kinds.is_empty() && !self.kinds.contains(&event.kind) {
+            return false;
+        }
+        self.headers_filter.matches(&event.headers)
+    }
+}
+
+pub struct FilteredEventStream {
+    pub(crate) inner: EventStream,
+    pub(crate) filter: EventFilter,
+}
+
+impl Stream for FilteredEventStream {
+    type Item = Result<TranscriptEvent, LiveLag>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            match Pin::new(&mut this.inner).poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Some(Ok(event))) => {
+                    if this.filter.matches(&event) {
+                        return Poll::Ready(Some(Ok(event)));
+                    }
+                }
+                Poll::Ready(Some(Err(lag))) => return Poll::Ready(Some(Err(lag))),
+                Poll::Ready(None) => return Poll::Ready(None),
+            }
+        }
+    }
+}

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -9,7 +9,7 @@
 
 use std::time::Duration;
 
-use airc_lib::{Airc, Body, Headers, PeerSpec};
+use airc_lib::{Airc, Body, EventFilter, HeaderFilter, Headers, PeerSpec, TranscriptKind};
 use futures::stream::StreamExt;
 use tempfile::TempDir;
 
@@ -179,5 +179,37 @@ async fn send_typed_body_with_headers_round_trips() {
     assert_eq!(
         page[0].headers.get("forge.body_hint").map(String::as_str),
         Some("application/json")
+    );
+}
+
+#[tokio::test]
+async fn filtered_event_queries_match_kind_and_headers_without_body_parse() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("filtered-events").await.unwrap();
+
+    let mut headers = Headers::new();
+    headers.insert(
+        "forge.body_hint".to_string(),
+        "forge.persona.turn".to_string(),
+    );
+    headers.insert("continuum.activity".to_string(), "general".to_string());
+    airc.send(Body::text("persona turn payload"), headers)
+        .await
+        .unwrap();
+    airc.say("plain chat").await.unwrap();
+
+    let mut filter = EventFilter::current_room();
+    filter.kinds.insert(TranscriptKind::Message);
+    filter.headers_filter = HeaderFilter::Prefix {
+        key: "forge.body_hint".to_string(),
+        value_prefix: "forge.persona.".to_string(),
+    };
+
+    let matches = airc.page_recent_filtered(filter, 32).await.unwrap();
+    assert_eq!(matches.len(), 1);
+    assert_eq!(
+        matches[0].body.as_ref().and_then(Body::as_text),
+        Some("persona turn payload")
     );
 }


### PR DESCRIPTION
## Summary
- add `EventFilter` and filtered live stream/page/resume APIs over persisted transcript events
- support channel, transcript-kind, and header filtering without body parsing
- add `airc-rs events list` with kind/header/header-prefix filters as a CLI proof surface
- render structured JSON event bodies in the event listing for debugging hooks and integrations
- add library and subprocess tests for header/kind-filtered event queries

## Verification
- `cargo clippy --manifest-path Cargo.toml -p airc-core -p airc-lib -p airc-cli --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml --workspace`
