### PR TITLE
feat(airc-cli): add Rust Codex hook context

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -16,6 +16,7 @@ use clap::{Args, Parser, Subcommand};
 
 use airc_lib::PeerSpec;
 
+use crate::codex_cli::CodexHookArgs;
 use crate::work_cli::WorkArgs;
 
 /// Default home directory for persisted identity + IPC state.
@@ -190,6 +191,9 @@ pub enum Command {
 
     /// Inspect persisted events through subscription-style filters.
     Events(crate::events_cli::EventsArgs),
+
+    /// Codex lifecycle hook adapters backed by Rust AIRC events.
+    CodexHook(CodexHookArgs),
 
     /// Coordinate work cards over the current room's AIRC substrate.
     Work(WorkArgs),

--- a/crates/airc-cli/src/codex_cli.rs
+++ b/crates/airc-cli/src/codex_cli.rs
@@ -1,0 +1,34 @@
+//! Codex integration CLI definitions.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct CodexHookArgs {
+    #[command(subcommand)]
+    pub action: CodexHookAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum CodexHookAction {
+    /// Emit Codex UserPromptSubmit JSON with unread AIRC context.
+    UserPromptSubmit {
+        /// Cursor file. Defaults to `<home>/codex_hook_cursor.json`.
+        #[arg(long)]
+        cursor_file: Option<PathBuf>,
+        /// Maximum unread events to fetch from the transcript store.
+        #[arg(long, default_value_t = 50)]
+        count: usize,
+        /// Maximum events to show in digest mode.
+        #[arg(long, default_value_t = 8)]
+        max_items: usize,
+        /// Emit raw unread lines instead of a compact digest.
+        #[arg(long)]
+        raw: bool,
+        /// Include events from this peer. Default excludes same-peer
+        /// self echoes so Codex does not re-inject its own sends.
+        #[arg(long)]
+        include_self: bool,
+    },
+}

--- a/crates/airc-cli/src/codex_commands.rs
+++ b/crates/airc-cli/src/codex_commands.rs
@@ -1,0 +1,216 @@
+//! `airc-rs codex-hook ...` handlers.
+
+use std::collections::BTreeSet;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use airc_core::{Body, TranscriptCursor, TranscriptEvent, TranscriptKind};
+use airc_lib::{Airc, EventFilter};
+use serde::Serialize;
+
+const DEFAULT_CURSOR_FILENAME: &str = "codex_hook_cursor.json";
+
+pub async fn run_user_prompt_submit(
+    home: &Path,
+    cursor_file: Option<PathBuf>,
+    count: usize,
+    max_items: usize,
+    raw: bool,
+    include_self: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    drain_stdin()?;
+
+    let airc = Airc::open(home).await?;
+    let cursor_path = cursor_file.unwrap_or_else(|| home.join(DEFAULT_CURSOR_FILENAME));
+    let filter = EventFilter {
+        kinds: BTreeSet::from([TranscriptKind::Message, TranscriptKind::System]),
+        ..EventFilter::current_room()
+    };
+    let previous = read_cursor_if_present(&cursor_path)?;
+    let events = match previous {
+        Some(cursor) => airc.resume_from_filtered(&cursor, filter, count).await?,
+        None => airc.page_recent_filtered(filter, count).await?,
+    };
+
+    if let Some(newest) = events.last().map(TranscriptEvent::cursor) {
+        write_cursor(&cursor_path, &newest)?;
+    }
+
+    let visible: Vec<_> = events
+        .into_iter()
+        .filter(|event| include_self || event.peer_id != airc.peer_id())
+        .collect();
+    if visible.is_empty() {
+        return Ok(());
+    }
+
+    let context = if raw {
+        render_raw(&visible)
+    } else {
+        render_digest(&visible, max_items)
+    };
+    print_hook_payload(&context)?;
+    Ok(())
+}
+
+fn drain_stdin() -> Result<(), Box<dyn std::error::Error>> {
+    let mut raw = String::new();
+    std::io::stdin().read_to_string(&mut raw)?;
+    if raw.trim().is_empty() {
+        return Ok(());
+    }
+    let value: serde_json::Value = serde_json::from_str(&raw)?;
+    if !value.is_object() {
+        return Err("Codex hook stdin must be a JSON object".into());
+    }
+    Ok(())
+}
+
+fn read_cursor_if_present(
+    path: &Path,
+) -> Result<Option<TranscriptCursor>, Box<dyn std::error::Error>> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => Ok(Some(serde_json::from_str(&text)?)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn write_cursor(path: &Path, cursor: &TranscriptCursor) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, serde_json::to_vec(cursor)?)?;
+    std::fs::rename(tmp, path)?;
+    Ok(())
+}
+
+fn print_hook_payload(context: &str) -> Result<(), Box<dyn std::error::Error>> {
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct HookPayload<'a> {
+        hook_specific_output: HookSpecificOutput<'a>,
+    }
+
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct HookSpecificOutput<'a> {
+        hook_event_name: &'a str,
+        additional_context: &'a str,
+    }
+
+    let payload = HookPayload {
+        hook_specific_output: HookSpecificOutput {
+            hook_event_name: "UserPromptSubmit",
+            additional_context: context,
+        },
+    };
+    println!("{}", serde_json::to_string(&payload)?);
+    Ok(())
+}
+
+fn render_raw(events: &[TranscriptEvent]) -> String {
+    events
+        .iter()
+        .map(|event| {
+            format!(
+                "[{}] {}: {}",
+                event.occurred_at_ms,
+                event.peer_id,
+                summarize_body(event)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn render_digest(events: &[TranscriptEvent], max_items: usize) -> String {
+    let messages = dedupe(events);
+    if messages.is_empty() {
+        return String::new();
+    }
+
+    let max_items = max_items.max(1);
+    let hidden = messages.len().saturating_sub(max_items);
+    let shown = &messages[messages.len().saturating_sub(max_items)..];
+    let mut peers = Vec::new();
+    for message in &messages {
+        if !peers.contains(&message.peer) {
+            peers.push(message.peer.clone());
+        }
+    }
+
+    let mut lines = Vec::new();
+    let mut first = format!("AIRC: {} unread", messages.len());
+    if !peers.is_empty() {
+        let shown_peers = peers.iter().take(3).cloned().collect::<Vec<_>>().join(", ");
+        first.push_str(" from ");
+        first.push_str(&shown_peers);
+        if peers.len() > 3 {
+            first.push_str(&format!(" +{}", peers.len() - 3));
+        }
+    }
+    lines.push(first);
+    if hidden > 0 {
+        lines.push(format!(
+            "latest {} shown; {hidden} older omitted",
+            shown.len()
+        ));
+    }
+    for message in shown {
+        lines.push(format!(
+            "- {}: {}",
+            message.peer,
+            summarize_text(&message.body, 120)
+        ));
+    }
+    if hidden > 0 {
+        lines.push("more: airc-rs codex-hook user-prompt-submit --raw".to_string());
+    }
+    lines.join("\n")
+}
+
+#[derive(Clone)]
+struct DigestMessage {
+    peer: String,
+    body: String,
+}
+
+fn dedupe(events: &[TranscriptEvent]) -> Vec<DigestMessage> {
+    let mut seen = BTreeSet::new();
+    let mut messages = Vec::new();
+    for event in events {
+        let peer = event.peer_id.to_string();
+        let body = summarize_body(event);
+        if seen.insert((peer.clone(), body.clone())) {
+            messages.push(DigestMessage { peer, body });
+        }
+    }
+    messages
+}
+
+fn summarize_body(event: &TranscriptEvent) -> String {
+    match &event.body {
+        Some(body) => format_body(body),
+        None => "<empty body>".to_string(),
+    }
+}
+
+fn format_body(body: &Body) -> String {
+    if let Some(text) = body.as_text() {
+        return text.to_string();
+    }
+    match body {
+        Body::Json(value) => value.to_string(),
+        Body::Binary(bytes) => format!("<binary {} bytes>", bytes.len()),
+    }
+}
+
+fn summarize_text(value: &str, max_len: usize) -> String {
+    let one_line = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if one_line.len() <= max_len {
+        return one_line;
+    }
+    format!("{}...", one_line[..max_len.saturating_sub(3)].trim_end())
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -12,6 +12,8 @@
 //! policy used in CLI paths — no `AllowUnsigned` opt-in.
 
 mod cli;
+mod codex_cli;
+mod codex_commands;
 mod commands;
 mod events_cli;
 mod events_commands;
@@ -33,6 +35,7 @@ use airc_core::PeerId;
 
 use airc_daemon::LocalIdentity;
 use cli::{Cli, Command, PeerAction};
+use codex_cli::CodexHookAction;
 use events_cli::EventsAction;
 use lane_cli::{LaneAction, LaneManagerAction};
 use work_cli::WorkAction;
@@ -129,6 +132,26 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 header_prefix,
                 limit,
             } => events_commands::run_list(&home, kind, header, header_prefix, limit).await,
+        },
+
+        Command::CodexHook(args) => match args.action {
+            CodexHookAction::UserPromptSubmit {
+                cursor_file,
+                count,
+                max_items,
+                raw,
+                include_self,
+            } => {
+                codex_commands::run_user_prompt_submit(
+                    &home,
+                    cursor_file,
+                    count,
+                    max_items,
+                    raw,
+                    include_self,
+                )
+                .await
+            }
         },
 
         Command::Work(args) => match args.action {

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -1,0 +1,155 @@
+//! End-to-end coverage for `airc-rs codex-hook ...`.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn airc_rs() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-rs")
+}
+
+#[test]
+fn codex_hook_emits_context_and_advances_cursor() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+    let cursor = workspace.path().join("cursor.json");
+
+    run_ok(&home, &["init"]);
+    run_ok(&home, &["send", "first unread"]);
+    run_ok(&home, &["send", "second unread"]);
+
+    let output = run_hook(
+        &home,
+        &[
+            "codex-hook",
+            "user-prompt-submit",
+            "--cursor-file",
+            cursor.to_str().unwrap(),
+            "--include-self",
+        ],
+        "{}",
+    );
+    let context = additional_context(&output);
+    assert!(context.contains("AIRC: 2 unread"));
+    assert!(context.contains("first unread"));
+    assert!(context.contains("second unread"));
+    assert!(cursor.exists(), "hook must persist its transcript cursor");
+
+    let second = run_hook(
+        &home,
+        &[
+            "codex-hook",
+            "user-prompt-submit",
+            "--cursor-file",
+            cursor.to_str().unwrap(),
+            "--include-self",
+        ],
+        "{}",
+    );
+    assert_eq!(
+        second, "",
+        "second hook call should be silent after cursor advance"
+    );
+}
+
+#[test]
+fn codex_hook_excludes_self_echoes_but_still_advances_cursor() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+    let cursor = workspace.path().join("cursor.json");
+
+    run_ok(&home, &["init"]);
+    run_ok(&home, &["send", "own message"]);
+
+    let output = run_hook(
+        &home,
+        &[
+            "codex-hook",
+            "user-prompt-submit",
+            "--cursor-file",
+            cursor.to_str().unwrap(),
+        ],
+        r#"{"hook_event_name":"UserPromptSubmit"}"#,
+    );
+    assert_eq!(output, "");
+    assert!(cursor.exists(), "self echoes should not replay forever");
+}
+
+#[test]
+fn codex_hook_raw_mode_preserves_full_event_lines() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    run_ok(&home, &["send", "raw line visible"]);
+
+    let output = run_hook(
+        &home,
+        &[
+            "codex-hook",
+            "user-prompt-submit",
+            "--raw",
+            "--include-self",
+        ],
+        "{}",
+    );
+    let context = additional_context(&output);
+    assert!(context.contains("raw line visible"));
+    assert!(context.contains('['));
+    assert!(context.contains(']'));
+}
+
+fn run_ok(home: &Path, args: &[&str]) -> String {
+    let output = Command::new(airc_rs())
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .output()
+        .expect("airc-rs command must spawn");
+    assert!(
+        output.status.success(),
+        "airc-rs {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout utf-8")
+}
+
+fn run_hook(home: &Path, args: &[&str], stdin: &str) -> String {
+    let mut child = Command::new(airc_rs())
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("airc-rs hook must spawn");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin pipe")
+        .write_all(stdin.as_bytes())
+        .expect("write hook stdin");
+    let output = child.wait_with_output().expect("wait for hook");
+    assert!(
+        output.status.success(),
+        "airc-rs {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout utf-8")
+}
+
+fn additional_context(output: &str) -> String {
+    let value: Value = serde_json::from_str(output).expect("hook JSON");
+    value["hookSpecificOutput"]["additionalContext"]
+        .as_str()
+        .expect("additionalContext string")
+        .to_string()
+}


### PR DESCRIPTION
## Summary
- add `airc-rs codex-hook user-prompt-submit` backed by the Rust event store
- persist a typed transcript cursor so hook context is replayable and does not re-inject old events
- emit Codex UserPromptSubmit JSON directly from Rust, with digest/raw modes and self-echo suppression

## Tests
- `cargo test --manifest-path Cargo.toml -p airc-cli --test codex_hook_commands -- --nocapture`
- `cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml --workspace`