### PR TITLE
feat(airc-cli): install Codex hooks from Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml_edit",
  "uuid",
 ]
 
@@ -2733,6 +2734,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3239,6 +3264,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "signal", "net", "io-util", "sync"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml_edit = "0.22"
 base64 = "0.22"
 futures = "0.3"
 uuid = { version = "1", features = ["v4", "v5"] }

--- a/crates/airc-cli/src/codex_cli.rs
+++ b/crates/airc-cli/src/codex_cli.rs
@@ -12,6 +12,18 @@ pub struct CodexHookArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum CodexHookAction {
+    /// Install the Rust UserPromptSubmit hook into Codex config.
+    InstallHooks {
+        /// Codex home directory. Defaults to `$HOME/.codex`.
+        #[arg(long)]
+        codex_home: Option<PathBuf>,
+    },
+    /// Remove AIRC-managed UserPromptSubmit hooks from Codex config.
+    UninstallHooks {
+        /// Codex home directory. Defaults to `$HOME/.codex`.
+        #[arg(long)]
+        codex_home: Option<PathBuf>,
+    },
     /// Emit Codex UserPromptSubmit JSON with unread AIRC context.
     UserPromptSubmit {
         /// Cursor file. Defaults to `<home>/codex_hook_cursor.json`.

--- a/crates/airc-cli/src/codex_config.rs
+++ b/crates/airc-cli/src/codex_config.rs
@@ -1,0 +1,120 @@
+//! Codex TOML config mutation for AIRC hook installation.
+
+use std::path::Path;
+
+use toml_edit::{value, DocumentMut, Item, Table};
+
+const INSTRUCTIONS_START: &str = "# AIRC-CODEX-INSTRUCTIONS-START";
+const INSTRUCTIONS_END: &str = "# AIRC-CODEX-INSTRUCTIONS-END";
+
+pub fn enable_hooks_feature(path: &Path) -> Result<bool, Box<dyn std::error::Error>> {
+    let original = read_text(path)?;
+    let without_legacy = remove_legacy_codex_hooks_key(&original)?;
+    let mut doc = parse_toml_document(&without_legacy)?;
+    let features = ensure_table(&mut doc, "features")?;
+    let already_enabled = features
+        .get("hooks")
+        .and_then(Item::as_bool)
+        .unwrap_or(false);
+    if !already_enabled {
+        features["hooks"] = value(true);
+    }
+    let rendered = doc.to_string();
+    if rendered != original {
+        write_text(path, &rendered)?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+pub fn disable_managed_hooks_feature(path: &Path) -> Result<bool, Box<dyn std::error::Error>> {
+    let original = read_text(path)?;
+    if original.is_empty() {
+        return Ok(false);
+    }
+    let mut doc = parse_toml_document(&original)?;
+    if let Some(features) = doc.get_mut("features").and_then(Item::as_table_mut) {
+        features.remove("hooks");
+        features.remove("codex_hooks");
+        if features.is_empty() {
+            doc.as_table_mut().remove("features");
+        }
+    }
+    let rendered = doc.to_string();
+    if rendered != original {
+        write_text(path, &rendered)?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+pub fn remove_managed_developer_instructions(
+    path: &Path,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let original = read_text(path)?;
+    if !original.contains(INSTRUCTIONS_START) {
+        return Ok(false);
+    }
+    let mut out = Vec::new();
+    let mut skipping = false;
+    for line in original.lines() {
+        if line.starts_with(INSTRUCTIONS_START) {
+            skipping = true;
+            continue;
+        }
+        if skipping {
+            if line.starts_with(INSTRUCTIONS_END) {
+                skipping = false;
+            }
+            continue;
+        }
+        out.push(line);
+    }
+    let rendered = out.join("\n").trim().to_string();
+    write_text(path, &(rendered + "\n"))?;
+    Ok(true)
+}
+
+fn parse_toml_document(text: &str) -> Result<DocumentMut, Box<dyn std::error::Error>> {
+    if text.trim().is_empty() {
+        return Ok(DocumentMut::new());
+    }
+    Ok(text.parse::<DocumentMut>()?)
+}
+
+fn ensure_table<'a>(
+    doc: &'a mut DocumentMut,
+    key: &str,
+) -> Result<&'a mut Table, Box<dyn std::error::Error>> {
+    let table = doc
+        .as_table_mut()
+        .entry(key)
+        .or_insert_with(|| Item::Table(Table::new()));
+    table
+        .as_table_mut()
+        .ok_or_else(|| format!("{key} exists but is not a table").into())
+}
+
+fn remove_legacy_codex_hooks_key(text: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let mut doc = parse_toml_document(text)?;
+    if let Some(features) = doc.get_mut("features").and_then(Item::as_table_mut) {
+        features.remove("codex_hooks");
+    }
+    Ok(doc.to_string())
+}
+
+fn read_text(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => Ok(text),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn write_text(path: &Path, text: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, text)?;
+    Ok(())
+}

--- a/crates/airc-cli/src/codex_hooks_json.rs
+++ b/crates/airc-cli/src/codex_hooks_json.rs
@@ -1,0 +1,112 @@
+//! Codex hooks.json mutation for AIRC hook installation.
+
+use std::path::Path;
+
+use serde_json::{json, Value};
+
+const RUST_HOOK_COMMAND: &str = "airc-rs codex-hook user-prompt-submit";
+const LEGACY_HOOK_COMMAND: &str = "airc codex-hook user-prompt-submit";
+const HOOK_STATUS: &str = "Checking AIRC inbox";
+
+pub fn install(path: &Path) -> Result<bool, Box<dyn std::error::Error>> {
+    let original = read_json(path)?;
+    let mut data = ensure_root_object(original);
+    let user_prompt = ensure_user_prompt_array(&mut data)?;
+    let before = user_prompt.clone();
+    remove_managed_hook_entries(user_prompt);
+    user_prompt.push(hook_group());
+
+    let changed = *user_prompt != before;
+    if changed {
+        write_json(path, &data)?;
+    }
+    Ok(changed)
+}
+
+pub fn uninstall(path: &Path) -> Result<bool, Box<dyn std::error::Error>> {
+    let original = read_json(path)?;
+    let mut data = ensure_root_object(original);
+    let Some(user_prompt) = data
+        .pointer_mut("/hooks/UserPromptSubmit")
+        .and_then(Value::as_array_mut)
+    else {
+        return Ok(false);
+    };
+    let before = user_prompt.clone();
+    remove_managed_hook_entries(user_prompt);
+    let changed = *user_prompt != before;
+    if changed {
+        write_json(path, &data)?;
+    }
+    Ok(changed)
+}
+
+fn ensure_root_object(value: Value) -> Value {
+    if value.is_object() {
+        value
+    } else {
+        json!({})
+    }
+}
+
+fn ensure_user_prompt_array(
+    data: &mut Value,
+) -> Result<&mut Vec<Value>, Box<dyn std::error::Error>> {
+    if !data.is_object() {
+        *data = json!({});
+    }
+    if data.get("hooks").and_then(Value::as_object).is_none() {
+        data["hooks"] = json!({});
+    }
+    if data["hooks"]
+        .get("UserPromptSubmit")
+        .and_then(Value::as_array)
+        .is_none()
+    {
+        data["hooks"]["UserPromptSubmit"] = json!([]);
+    }
+    data["hooks"]["UserPromptSubmit"]
+        .as_array_mut()
+        .ok_or_else(|| "hooks.UserPromptSubmit is not an array".into())
+}
+
+fn remove_managed_hook_entries(groups: &mut Vec<Value>) {
+    groups.retain_mut(|group| {
+        let Some(hooks) = group.get_mut("hooks").and_then(Value::as_array_mut) else {
+            return true;
+        };
+        hooks.retain(|hook| {
+            let command = hook.get("command").and_then(Value::as_str);
+            command != Some(RUST_HOOK_COMMAND) && command != Some(LEGACY_HOOK_COMMAND)
+        });
+        !hooks.is_empty()
+    });
+}
+
+fn hook_group() -> Value {
+    json!({
+        "hooks": [{
+            "type": "command",
+            "command": RUST_HOOK_COMMAND,
+            "timeout": 5,
+            "statusMessage": HOOK_STATUS
+        }]
+    })
+}
+
+fn read_json(path: &Path) -> Result<Value, Box<dyn std::error::Error>> {
+    match std::fs::read_to_string(path) {
+        Ok(text) if text.trim().is_empty() => Ok(json!({})),
+        Ok(text) => Ok(serde_json::from_str(&text)?),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(json!({})),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn write_json(path: &Path, value: &Value) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, format!("{}\n", serde_json::to_string_pretty(value)?))?;
+    Ok(())
+}

--- a/crates/airc-cli/src/codex_install.rs
+++ b/crates/airc-cli/src/codex_install.rs
@@ -1,0 +1,63 @@
+//! Codex hook installer command orchestration.
+
+use std::path::PathBuf;
+
+use crate::{codex_config, codex_hooks_json};
+
+pub async fn run_install_hooks(
+    codex_home: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let codex_home = codex_home.unwrap_or_else(default_codex_home);
+    let config = codex_home.join("config.toml");
+    let hooks_json = codex_home.join("hooks.json");
+
+    if codex_config::enable_hooks_feature(&config)? {
+        println!("enabled hooks in {}", config.display());
+    }
+    if codex_hooks_json::install(&hooks_json)? {
+        println!(
+            "installed AIRC UserPromptSubmit hook in {}",
+            hooks_json.display()
+        );
+    }
+    if codex_config::remove_managed_developer_instructions(&config)? {
+        println!(
+            "removed legacy AIRC Codex polling instructions from {}",
+            config.display()
+        );
+    }
+    Ok(())
+}
+
+pub async fn run_uninstall_hooks(
+    codex_home: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let codex_home = codex_home.unwrap_or_else(default_codex_home);
+    let config = codex_home.join("config.toml");
+    let hooks_json = codex_home.join("hooks.json");
+
+    if codex_config::disable_managed_hooks_feature(&config)? {
+        println!(
+            "removed airc-managed hooks feature from {}",
+            config.display()
+        );
+    }
+    if codex_hooks_json::uninstall(&hooks_json)? {
+        println!(
+            "removed AIRC UserPromptSubmit hook from {}",
+            hooks_json.display()
+        );
+    }
+    Ok(())
+}
+
+fn default_codex_home() -> PathBuf {
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home).join(".codex");
+    }
+    #[cfg(windows)]
+    if let Some(userprofile) = std::env::var_os("USERPROFILE") {
+        return PathBuf::from(userprofile).join(".codex");
+    }
+    PathBuf::from(".codex")
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -14,6 +14,9 @@
 mod cli;
 mod codex_cli;
 mod codex_commands;
+mod codex_config;
+mod codex_hooks_json;
+mod codex_install;
 mod commands;
 mod events_cli;
 mod events_commands;
@@ -135,6 +138,12 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         },
 
         Command::CodexHook(args) => match args.action {
+            CodexHookAction::InstallHooks { codex_home } => {
+                codex_install::run_install_hooks(codex_home).await
+            }
+            CodexHookAction::UninstallHooks { codex_home } => {
+                codex_install::run_uninstall_hooks(codex_home).await
+            }
             CodexHookAction::UserPromptSubmit {
                 cursor_file,
                 count,

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -102,6 +102,86 @@ fn codex_hook_raw_mode_preserves_full_event_lines() {
     assert!(context.contains(']'));
 }
 
+#[test]
+fn codex_hook_installer_replaces_legacy_python_hook() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("airc");
+    let codex_home = workspace.path().join("codex");
+    std::fs::create_dir_all(&codex_home).expect("codex home");
+    std::fs::write(
+        codex_home.join("config.toml"),
+        "[features]\ncodex_hooks = true\nother = true\n",
+    )
+    .expect("write config");
+    std::fs::write(
+        codex_home.join("hooks.json"),
+        r#"{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"echo existing"},{"type":"command","command":"airc codex-hook user-prompt-submit"}]}]}}"#,
+    )
+    .expect("write hooks");
+
+    run_ok(
+        &home,
+        &[
+            "codex-hook",
+            "install-hooks",
+            "--codex-home",
+            codex_home.to_str().unwrap(),
+        ],
+    );
+
+    let config = std::fs::read_to_string(codex_home.join("config.toml")).expect("read config");
+    assert!(config.contains("hooks = true"));
+    assert!(config.contains("other = true"));
+    assert!(!config.contains("codex_hooks"));
+
+    let hooks: Value =
+        serde_json::from_str(&std::fs::read_to_string(codex_home.join("hooks.json")).unwrap())
+            .expect("hooks json");
+    let commands = hook_commands(&hooks);
+    assert!(commands.contains(&"echo existing".to_string()));
+    assert!(commands.contains(&"airc-rs codex-hook user-prompt-submit".to_string()));
+    assert!(!commands.contains(&"airc codex-hook user-prompt-submit".to_string()));
+}
+
+#[test]
+fn codex_hook_uninstaller_removes_managed_hooks_only() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("airc");
+    let codex_home = workspace.path().join("codex");
+    std::fs::create_dir_all(&codex_home).expect("codex home");
+    std::fs::write(
+        codex_home.join("config.toml"),
+        "[features]\nhooks = true\nother = true\n",
+    )
+    .expect("write config");
+    std::fs::write(
+        codex_home.join("hooks.json"),
+        r#"{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"echo existing"},{"type":"command","command":"airc-rs codex-hook user-prompt-submit"}]}]}}"#,
+    )
+    .expect("write hooks");
+
+    run_ok(
+        &home,
+        &[
+            "codex-hook",
+            "uninstall-hooks",
+            "--codex-home",
+            codex_home.to_str().unwrap(),
+        ],
+    );
+
+    let config = std::fs::read_to_string(codex_home.join("config.toml")).expect("read config");
+    assert!(!config.contains("hooks = true"));
+    assert!(config.contains("other = true"));
+
+    let hooks: Value =
+        serde_json::from_str(&std::fs::read_to_string(codex_home.join("hooks.json")).unwrap())
+            .expect("hooks json");
+    let commands = hook_commands(&hooks);
+    assert!(commands.contains(&"echo existing".to_string()));
+    assert!(!commands.contains(&"airc-rs codex-hook user-prompt-submit".to_string()));
+}
+
 fn run_ok(home: &Path, args: &[&str]) -> String {
     let output = Command::new(airc_rs())
         .arg("--home")
@@ -152,4 +232,14 @@ fn additional_context(output: &str) -> String {
         .as_str()
         .expect("additionalContext string")
         .to_string()
+}
+
+fn hook_commands(hooks: &Value) -> Vec<String> {
+    hooks["hooks"]["UserPromptSubmit"]
+        .as_array()
+        .expect("UserPromptSubmit array")
+        .iter()
+        .flat_map(|group| group["hooks"].as_array().into_iter().flatten())
+        .filter_map(|hook| hook["command"].as_str().map(ToString::to_string))
+        .collect()
 }


### PR DESCRIPTION
## Summary
- add `airc-rs codex-hook install-hooks` and `uninstall-hooks`
- replace legacy `airc codex-hook user-prompt-submit` hook entries with the Rust `airc-rs` hook command
- split Codex TOML config, hooks.json mutation, and command orchestration into separate modules

## Tests
- `cargo test --manifest-path Cargo.toml -p airc-cli --test codex_hook_commands -- --nocapture`
- `cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml --workspace`