### PR TITLE
feat(codex): route hooks through Rust CLI

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -783,7 +783,8 @@ _install_airc_codex_developer_instructions() {
 
   if grep -qE '^[[:space:]]*(hooks|codex_hooks)[[:space:]]*=[[:space:]]*true' "$config" 2>/dev/null \
      && [ -f "$hooks_json" ] \
-     && grep -qF 'airc codex-hook user-prompt-submit' "$hooks_json" 2>/dev/null; then
+     && { grep -qF 'airc-rs codex-hook user-prompt-submit' "$hooks_json" 2>/dev/null \
+          || grep -qF 'airc codex-hook user-prompt-submit' "$hooks_json" 2>/dev/null; }; then
     if grep -qF 'AIRC-CODEX-INSTRUCTIONS-START' "$config" 2>/dev/null; then
       local _tmp; _tmp=$(mktemp)
       sed '/^# AIRC-CODEX-INSTRUCTIONS-START/,/^# AIRC-CODEX-INSTRUCTIONS-END/d' "$config" > "$_tmp"
@@ -840,20 +841,20 @@ _install_airc_codex_hooks() {
   [ "${AIRC_SKIP_CODEX_HOOKS:-0}" = "1" ] && return 0
   [ -f "$HOME/.codex/config.toml" ] || return 0
 
-  local _python="${_airc_venv_python_bin:-}"
-  if [ -z "$_python" ]; then
-    if command -v python3 >/dev/null 2>&1; then
-      _python=python3
-    elif command -v python >/dev/null 2>&1; then
-      _python=python
-    else
-      warn "Could not install Codex AIRC hook: python not found"
-      return 0
-    fi
+  local _airc_rs=""
+  if command -v airc-rs >/dev/null 2>&1; then
+    _airc_rs=$(command -v airc-rs)
+  elif [ -x "$CLONE_DIR/target/release/airc-rs" ]; then
+    _airc_rs="$CLONE_DIR/target/release/airc-rs"
+  elif [ -x "$CLONE_DIR/target/debug/airc-rs" ]; then
+    _airc_rs="$CLONE_DIR/target/debug/airc-rs"
+  else
+    warn "Could not install Codex AIRC hook: airc-rs not found"
+    return 0
   fi
 
   local out
-  if out=$(PYTHONPATH="$CLONE_DIR/lib${PYTHONPATH:+:$PYTHONPATH}" "$_python" -m airc_core.codex_install --codex-home "$HOME/.codex" install-hooks 2>&1); then
+  if out=$("$_airc_rs" codex-hook install-hooks --codex-home "$HOME/.codex" 2>&1); then
     if [ -n "$out" ]; then
       printf '%s\n' "$out" | while IFS= read -r line; do
         ok "Codex AIRC hook: $line"

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -541,21 +541,26 @@ cmd_inbox() {
 cmd_codex_hook() {
   ensure_init
 
+  local _airc_rs
+  _airc_rs=$(command -v airc-rs 2>/dev/null || true)
+  if [ -z "$_airc_rs" ]; then
+    die "airc-rs is required for codex-hook; build/install the Rust CLI first"
+  fi
+
   local sub="${1:-}"
   shift || true
   case "$sub" in
     user-prompt-submit)
-      local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
-      "$AIRC_PYTHON" -m airc_core.codex_hook user-prompt-submit \
-        --home "$AIRC_WRITE_DIR" \
-        --cursor-file "$AIRC_WRITE_DIR/inbox_cursor" \
-        --my-name "$(get_name)" \
-        --client-id "$_client_id" \
+      "$_airc_rs" --home "$AIRC_WRITE_DIR" codex-hook user-prompt-submit \
+        --cursor-file "$AIRC_WRITE_DIR/codex_hook_cursor.json" \
         "$@"
       ;;
+    install-hooks|uninstall-hooks)
+      "$_airc_rs" codex-hook "$sub" "$@"
+      ;;
     -h|--help|'')
-      echo "Usage: airc codex-hook user-prompt-submit"
-      echo "  Codex lifecycle hook adapter. Emits UserPromptSubmit JSON context for unread local airc messages."
+      echo "Usage: airc codex-hook {user-prompt-submit|install-hooks|uninstall-hooks}"
+      echo "  Codex lifecycle hook adapter backed by the Rust AIRC event store."
       ;;
     *)
       die "Unknown codex-hook command: $sub" ;;

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -1,0 +1,38 @@
+"""Codex hook cutover guards.
+
+These are intentionally static: the failure mode was shell entry points
+quietly routing Codex hooks back through Python after the Rust hook
+existed. The contract here is simple enough to pin directly.
+"""
+
+from pathlib import Path
+import unittest
+
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+class CodexRustCutoverTests(unittest.TestCase):
+    def test_runtime_codex_hook_dispatches_to_airc_rs_not_python(self):
+        source = (REPO / "lib/airc_bash/cmd_status.sh").read_text(encoding="utf-8")
+        start = source.index("cmd_codex_hook()")
+        end = source.index("cmd_codex_start()", start)
+        body = source[start:end]
+
+        self.assertNotIn("airc_core.codex_hook", body)
+        self.assertIn("airc-rs is required for codex-hook", body)
+        self.assertIn("codex-hook user-prompt-submit", body)
+
+    def test_installer_uses_rust_codex_hook_installer(self):
+        source = (REPO / "install.sh").read_text(encoding="utf-8")
+        start = source.index("_install_airc_codex_hooks()")
+        end = source.index("if command -v codex", start)
+        body = source[start:end]
+
+        self.assertNotIn("airc_core.codex_install", body)
+        self.assertIn('codex-hook install-hooks --codex-home "$HOME/.codex"', body)
+        self.assertIn("airc-rs not found", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- route `airc codex-hook user-prompt-submit` through `airc-rs` instead of Python
- route Codex hook installation through `airc-rs codex-hook install-hooks`
- add guard tests that prevent shell entry points from drifting back to `airc_core.codex_hook` / `airc_core.codex_install`

## Tests
- `bash -n install.sh airc lib/airc_bash/cmd_status.sh`
- `python3 test/test_codex_rust_cutover.py`
- `cargo test --manifest-path Cargo.toml --workspace`