### PR TITLE
feat(airc-rs): move client identity mnemonics to rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,8 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "sha2",
+ "temp-env",
  "tempfile",
  "tokio",
  "toml_edit",
@@ -2552,6 +2554,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/airc
+++ b/airc
@@ -761,8 +761,20 @@ set_config_val()   {
 }
 unset_config_keys() { "$AIRC_PYTHON" -m airc_core.config unset_keys --config "$CONFIG" "$@"; }
 
+airc_rs_bin() {
+  if command -v airc-rs >/dev/null 2>&1; then
+    command -v airc-rs
+    return 0
+  fi
+  local _root; _root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  for _candidate in "$_root/target/release/airc-rs" "$_root/target/debug/airc-rs"; do
+    [ -x "$_candidate" ] && { printf '%s\n' "$_candidate"; return 0; }
+  done
+  die "airc-rs is required; run install.sh or cargo build --manifest-path \"$_root/Cargo.toml\" -p airc-cli"
+}
+
 airc_client_id() {
-  "$AIRC_PYTHON" -m airc_core.client_id 2>/dev/null
+  "$(airc_rs_bin)" client-id 2>/dev/null
 }
 
 # Same as get_config_val but reads from an arbitrary config.json path.
@@ -1149,7 +1161,7 @@ _have_tailscale_locally() {
 humanhash() {
   local input="${1:-}"
   [ -z "$input" ] && return 1
-  "$AIRC_PYTHON" -m airc_core.humanhash "$input"
+  "$(airc_rs_bin)" humanhash "$input"
 }
 
 sign_message() {

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -25,9 +25,11 @@ base64 = "0.22"
 futures = "0.3"
 uuid = { version = "1", features = ["v4", "v5"] }
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
+sha2 = "0.10"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
+temp-env = "0.3"

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -206,6 +206,18 @@ pub enum Command {
 
     /// Coordinate workspace leases over the current room's AIRC substrate.
     Workspace(crate::workspace_cli::WorkspaceArgs),
+
+    /// Print the stable mnemonic for a hex digest.
+    Humanhash {
+        /// Hex input to convert into a mnemonic.
+        hex_input: String,
+        /// Number of words to emit.
+        #[arg(long, default_value_t = 4)]
+        words: usize,
+    },
+
+    /// Print this runtime process's client id, if one can be derived.
+    ClientId,
 }
 
 #[derive(Debug, Args)]

--- a/crates/airc-cli/src/client_id.rs
+++ b/crates/airc-cli/src/client_id.rs
@@ -1,0 +1,164 @@
+//! Runtime client identity helpers for shell integration.
+
+use std::env;
+use std::error::Error;
+#[cfg(unix)]
+use std::path::Path;
+#[cfg(unix)]
+use std::process::Command;
+
+#[cfg(any(unix, test))]
+use sha2::{Digest, Sha256};
+
+#[cfg(any(unix, test))]
+use airc_core::humanhash;
+
+#[cfg(any(unix, test))]
+const AGENT_PREFIX: &str = "agent:";
+const CODEX_PREFIX: &str = "codex:";
+const CLAUDE_PREFIX: &str = "claude:";
+#[cfg(unix)]
+const PROCESS_WALK_LIMIT: usize = 16;
+
+pub fn current_client_id() -> Result<Option<String>, Box<dyn Error>> {
+    if let Some(value) = non_empty_env("AIRC_CLIENT_ID") {
+        return Ok(Some(value));
+    }
+    if let Some(value) = non_empty_env("CODEX_THREAD_ID") {
+        return Ok(Some(format!("{CODEX_PREFIX}{value}")));
+    }
+    if let Some(value) = non_empty_env("CLAUDE_CODE_SESSION_ID") {
+        return Ok(Some(format!("{CLAUDE_PREFIX}{value}")));
+    }
+    if let Some(value) = non_empty_env("CLAUDE_SESSION_ID") {
+        return Ok(Some(format!("{CLAUDE_PREFIX}{value}")));
+    }
+
+    agent_process_client_id()
+}
+
+#[cfg(any(unix, test))]
+pub fn agent_label(seed: &str) -> Result<String, Box<dyn Error>> {
+    let mut hasher = Sha256::new();
+    hasher.update(seed.as_bytes());
+    let digest = hasher.finalize();
+    let hex = to_hex(&digest);
+    Ok(format!("{AGENT_PREFIX}{}", humanhash(&hex, 4)?))
+}
+
+#[cfg(unix)]
+fn agent_process_client_id() -> Result<Option<String>, Box<dyn Error>> {
+    let mut pid = std::process::id();
+    for _ in 0..PROCESS_WALK_LIMIT {
+        let Some(process) = read_process(pid)? else {
+            return Ok(None);
+        };
+        if is_agent_command(&process.command) {
+            return Ok(Some(agent_label(&format!("{pid}:{}", process.command))?));
+        }
+        if process.parent_pid <= 1 {
+            return Ok(None);
+        }
+        pid = process.parent_pid;
+    }
+    Ok(None)
+}
+
+#[cfg(not(unix))]
+fn agent_process_client_id() -> Result<Option<String>, Box<dyn Error>> {
+    Ok(None)
+}
+
+#[cfg(unix)]
+struct ProcessRow {
+    parent_pid: u32,
+    command: String,
+}
+
+#[cfg(unix)]
+fn read_process(pid: u32) -> Result<Option<ProcessRow>, Box<dyn Error>> {
+    let output = Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "ppid=,command="])
+        .output()?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let text = String::from_utf8(output.stdout)?;
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let mut parts = trimmed.splitn(2, char::is_whitespace);
+    let parent_pid = parts
+        .next()
+        .ok_or("missing parent pid")?
+        .trim()
+        .parse::<u32>()?;
+    let command = parts.next().unwrap_or("").trim().to_string();
+    Ok(Some(ProcessRow {
+        parent_pid,
+        command,
+    }))
+}
+
+#[cfg(unix)]
+fn is_agent_command(command: &str) -> bool {
+    let argv0 = command.split_whitespace().next().unwrap_or("");
+    let base = Path::new(argv0)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(argv0);
+    matches!(base, "claude" | "codex") || command.contains("/codex/codex")
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+#[cfg(any(unix, test))]
+fn to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{agent_label, current_client_id};
+
+    #[test]
+    fn explicit_env_wins() {
+        temp_env::with_var("AIRC_CLIENT_ID", Some("explicit"), || {
+            temp_env::with_var("CODEX_THREAD_ID", Some("ignored"), || {
+                assert_eq!(current_client_id().unwrap(), Some("explicit".to_string()));
+            });
+        });
+    }
+
+    #[test]
+    fn codex_thread_id_is_namespaced() {
+        temp_env::with_var("AIRC_CLIENT_ID", None::<&str>, || {
+            temp_env::with_var("CODEX_THREAD_ID", Some("thread-1"), || {
+                assert_eq!(
+                    current_client_id().unwrap(),
+                    Some("codex:thread-1".to_string())
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn agent_label_is_mnemonic_not_raw_seed() {
+        let label = agent_label("300:/Users/example/.local/bin/claude --resume").unwrap();
+
+        assert!(label.starts_with("agent:"));
+        assert_eq!(label.split('-').count(), 4);
+        assert!(!label.contains("300"));
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -12,6 +12,7 @@
 //! policy used in CLI paths — no `AllowUnsigned` opt-in.
 
 mod cli;
+mod client_id;
 mod codex_cli;
 mod codex_commands;
 mod codex_config;
@@ -230,6 +231,19 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             }
             WorkspaceAction::List { limit } => workspace_commands::run_list(&home, limit).await,
         },
+
+        Command::Humanhash { hex_input, words } => {
+            println!("{}", airc_core::humanhash(&hex_input, words)?);
+            Ok(())
+        }
+
+        Command::ClientId => {
+            let Some(value) = client_id::current_client_id()? else {
+                return Err("client id is unavailable".into());
+            };
+            println!("{value}");
+            Ok(())
+        }
     }
 }
 

--- a/crates/airc-core/src/humanhash.rs
+++ b/crates/airc-core/src/humanhash.rs
@@ -1,0 +1,367 @@
+//! Human-readable hash mnemonics used by invites and runtime agent labels.
+
+use std::error::Error;
+use std::fmt;
+
+const WORDS: [&str; 256] = [
+    "ack",
+    "alabama",
+    "alanine",
+    "alaska",
+    "alpha",
+    "angel",
+    "apart",
+    "april",
+    "arizona",
+    "arkansas",
+    "artist",
+    "asparagus",
+    "aspen",
+    "august",
+    "autumn",
+    "avocado",
+    "bacon",
+    "bakerloo",
+    "batman",
+    "beer",
+    "berlin",
+    "beryllium",
+    "black",
+    "blossom",
+    "blue",
+    "bluebird",
+    "bravo",
+    "bulldog",
+    "burger",
+    "butter",
+    "california",
+    "carbon",
+    "cardinal",
+    "carolina",
+    "carpet",
+    "cat",
+    "ceiling",
+    "cello",
+    "center",
+    "charlie",
+    "chicken",
+    "coffee",
+    "cola",
+    "cold",
+    "colorado",
+    "comet",
+    "connecticut",
+    "crazy",
+    "cup",
+    "dakota",
+    "december",
+    "delaware",
+    "delta",
+    "diet",
+    "don",
+    "double",
+    "early",
+    "earth",
+    "east",
+    "echo",
+    "edward",
+    "eight",
+    "eighteen",
+    "eleven",
+    "emma",
+    "enemy",
+    "equal",
+    "failed",
+    "fanta",
+    "fillet",
+    "finch",
+    "fish",
+    "five",
+    "fix",
+    "floor",
+    "florida",
+    "football",
+    "four",
+    "fourteen",
+    "foxtrot",
+    "freddie",
+    "friend",
+    "fruit",
+    "gee",
+    "georgia",
+    "glucose",
+    "golf",
+    "green",
+    "grey",
+    "hamper",
+    "happy",
+    "harry",
+    "hawaii",
+    "helium",
+    "high",
+    "hot",
+    "hotel",
+    "hydrogen",
+    "idaho",
+    "illinois",
+    "india",
+    "indigo",
+    "ink",
+    "iowa",
+    "island",
+    "item",
+    "jersey",
+    "jig",
+    "johnny",
+    "juliet",
+    "july",
+    "jupiter",
+    "kansas",
+    "kentucky",
+    "kilo",
+    "king",
+    "kitten",
+    "lactose",
+    "lake",
+    "lamp",
+    "lemon",
+    "leopard",
+    "lima",
+    "lion",
+    "lithium",
+    "london",
+    "louisiana",
+    "low",
+    "magazine",
+    "magnesium",
+    "maine",
+    "mango",
+    "march",
+    "mars",
+    "maryland",
+    "massachusetts",
+    "may",
+    "mexico",
+    "michigan",
+    "mike",
+    "minnesota",
+    "mirror",
+    "missouri",
+    "mobile",
+    "mockingbird",
+    "monkey",
+    "montana",
+    "moon",
+    "mountain",
+    "muppet",
+    "music",
+    "nebraska",
+    "neptune",
+    "network",
+    "nevada",
+    "nine",
+    "nineteen",
+    "nitrogen",
+    "north",
+    "november",
+    "nuts",
+    "october",
+    "ohio",
+    "oklahoma",
+    "one",
+    "orange",
+    "oranges",
+    "oregon",
+    "oscar",
+    "oven",
+    "oxygen",
+    "papa",
+    "paris",
+    "pasta",
+    "pennsylvania",
+    "pip",
+    "pizza",
+    "pluto",
+    "potato",
+    "princess",
+    "purple",
+    "quebec",
+    "queen",
+    "quiet",
+    "red",
+    "river",
+    "robert",
+    "robin",
+    "romeo",
+    "rugby",
+    "sad",
+    "salami",
+    "saturn",
+    "september",
+    "seven",
+    "seventeen",
+    "shade",
+    "sierra",
+    "single",
+    "sink",
+    "six",
+    "sixteen",
+    "skylark",
+    "snake",
+    "social",
+    "sodium",
+    "solar",
+    "south",
+    "spaghetti",
+    "speaker",
+    "spring",
+    "stairway",
+    "steak",
+    "stream",
+    "summer",
+    "sweet",
+    "table",
+    "tango",
+    "ten",
+    "tennessee",
+    "tennis",
+    "texas",
+    "thirteen",
+    "three",
+    "timing",
+    "triple",
+    "twelve",
+    "twenty",
+    "two",
+    "uncle",
+    "undress",
+    "uniform",
+    "uranus",
+    "utah",
+    "vegan",
+    "venus",
+    "vermont",
+    "victor",
+    "video",
+    "violet",
+    "virginia",
+    "washington",
+    "west",
+    "whiskey",
+    "white",
+    "william",
+    "winner",
+    "winter",
+    "wisconsin",
+    "wolfram",
+    "wyoming",
+    "xray",
+    "yankee",
+    "yellow",
+    "zebra",
+    "zulu",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HumanhashError {
+    EmptyInput,
+    EmptyWordCount,
+    InvalidHex,
+}
+
+impl fmt::Display for HumanhashError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyInput => f.write_str("empty input"),
+            Self::EmptyWordCount => f.write_str("word count must be >= 1"),
+            Self::InvalidHex => f.write_str("input must be hex"),
+        }
+    }
+}
+
+impl Error for HumanhashError {}
+
+pub fn humanhash(hex_input: &str, word_count: usize) -> Result<String, HumanhashError> {
+    if hex_input.is_empty() {
+        return Err(HumanhashError::EmptyInput);
+    }
+    if word_count == 0 {
+        return Err(HumanhashError::EmptyWordCount);
+    }
+
+    let mut normalized = String::with_capacity(hex_input.len() + (hex_input.len() % 2));
+    if hex_input.len() % 2 == 1 {
+        normalized.push('0');
+    }
+    normalized.push_str(hex_input);
+
+    let data = decode_hex(&normalized)?;
+    if data.is_empty() {
+        return Err(HumanhashError::EmptyInput);
+    }
+
+    let segment_size = usize::max(data.len() / word_count, 1);
+    let mut output = Vec::with_capacity(word_count);
+    for segment in 0..word_count {
+        let start = segment * segment_size;
+        let end = if segment == word_count - 1 {
+            data.len()
+        } else {
+            start + segment_size
+        };
+        let acc = data
+            .get(start..end)
+            .unwrap_or(&[])
+            .iter()
+            .fold(0u8, |acc, value| acc ^ value);
+        output.push(WORDS[acc as usize]);
+    }
+
+    Ok(output.join("-"))
+}
+
+fn decode_hex(input: &str) -> Result<Vec<u8>, HumanhashError> {
+    input
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = hex_value(pair[0])?;
+            let low = hex_value(pair[1])?;
+            Ok((high << 4) | low)
+        })
+        .collect()
+}
+
+fn hex_value(value: u8) -> Result<u8, HumanhashError> {
+    match value {
+        b'0'..=b'9' => Ok(value - b'0'),
+        b'a'..=b'f' => Ok(value - b'a' + 10),
+        b'A'..=b'F' => Ok(value - b'A' + 10),
+        _ => Err(HumanhashError::InvalidHex),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{humanhash, HumanhashError};
+
+    #[test]
+    fn known_mnemonic_matches_legacy_python() {
+        assert_eq!(
+            humanhash("d7e247c0000000000000000000000000", 4).unwrap(),
+            "potato-ack-ack-ack"
+        );
+    }
+
+    #[test]
+    fn odd_hex_is_left_padded() {
+        assert_eq!(humanhash("abc", 2), humanhash("0abc", 2));
+    }
+
+    #[test]
+    fn invalid_inputs_fail_explicitly() {
+        assert_eq!(humanhash("", 4), Err(HumanhashError::EmptyInput));
+        assert_eq!(humanhash("abcd", 0), Err(HumanhashError::EmptyWordCount));
+        assert_eq!(humanhash("not-hex", 4), Err(HumanhashError::InvalidHex));
+    }
+}

--- a/crates/airc-core/src/lib.rs
+++ b/crates/airc-core/src/lib.rs
@@ -19,6 +19,7 @@
 //! - [`attachment`] — file-attachment manifest (consumer-side richer view)
 //! - [`filter`]     — self-echo filtering for multi-tab consumers
 //! - [`headers`]    — envelope headers for routing/filtering without body parse
+//! - [`humanhash`]  — stable hash mnemonics for invite/client labels
 //!
 //! Every public type a consumer needs is re-exported at the crate root so
 //! `use airc_core::Identity;` works without knowing the module split.
@@ -28,6 +29,7 @@ pub mod body;
 pub mod cursor;
 pub mod filter;
 pub mod headers;
+pub mod humanhash;
 pub mod identity;
 pub mod ids;
 pub mod receipt;
@@ -42,6 +44,7 @@ pub use body::Body;
 pub use cursor::{page_before, page_recent, TranscriptCursor, TranscriptPage};
 pub use filter::{filter_self_echoes, SelfFilter};
 pub use headers::{HeaderFilter, Headers};
+pub use humanhash::{humanhash, HumanhashError};
 pub use identity::Identity;
 pub use ids::{ClientId, ContentHash, EventId, FileId, PeerId, RoomId};
 pub use receipt::{Receipt, ReceiptKind};

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -58,6 +58,20 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$_airc_rs" codex-start', body)
         self.assertIn("airc-rs is required for codex-start", body)
 
+    def test_runtime_identity_helpers_use_airc_rs(self):
+        source = (REPO / "airc").read_text(encoding="utf-8")
+        client_start = source.index("airc_client_id()")
+        client_end = source.index("get_config_val_in()", client_start)
+        human_start = source.index("humanhash()")
+        human_end = source.index("sign_message()", human_start)
+
+        body = source[client_start:client_end] + source[human_start:human_end]
+
+        self.assertNotIn("airc_core.client_id", body)
+        self.assertNotIn("airc_core.humanhash", body)
+        self.assertIn('"$(airc_rs_bin)" client-id', body)
+        self.assertIn('"$(airc_rs_bin)" humanhash "$input"', body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `airc-core::humanhash` with legacy-compatible mnemonic output.
- Add `airc-rs humanhash` and `airc-rs client-id` commands.
- Route shell runtime identity helpers through `airc-rs` with no Python fallback.
- Add a cutover guard covering the `client-id` and `humanhash` shell helpers.

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-core -p airc-cli --check`
- `cargo test --manifest-path Cargo.toml -p airc-core humanhash`
- `cargo test --manifest-path Cargo.toml -p airc-cli client_id`
- `cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- humanhash d7e247c0000000000000000000000000`
- `AIRC_CLIENT_ID=explicit cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- client-id`
- `cargo clippy --manifest-path Cargo.toml -p airc-core -p airc-cli --all-targets -- -D warnings`
- `python3 test/test_codex_rust_cutover.py`
- `bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh`
- `cargo test --manifest-path Cargo.toml --workspace`

## CI
- Linux/macOS/Windows matrix required before merge.
