### PR TITLE
feat(airc-rs): move iso timestamp parsing to rust

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -218,6 +218,12 @@ pub enum Command {
 
     /// Print this runtime process's client id, if one can be derived.
     ClientId,
+
+    /// Convert a canonical UTC timestamp to Unix epoch seconds.
+    IsoToEpoch {
+        /// Timestamp in `YYYY-MM-DDTHH:MM:SSZ` form.
+        timestamp: String,
+    },
 }
 
 #[derive(Debug, Args)]

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -244,6 +244,11 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             println!("{value}");
             Ok(())
         }
+
+        Command::IsoToEpoch { timestamp } => {
+            println!("{}", airc_core::iso_to_epoch(&timestamp)?);
+            Ok(())
+        }
     }
 }
 

--- a/crates/airc-core/src/datetime.rs
+++ b/crates/airc-core/src/datetime.rs
@@ -1,0 +1,139 @@
+//! UTC timestamp helpers used by shell compatibility adapters.
+
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DateTimeError {
+    InvalidFormat,
+    InvalidDate,
+    InvalidTime,
+}
+
+impl fmt::Display for DateTimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidFormat => f.write_str("timestamp must match YYYY-MM-DDTHH:MM:SSZ"),
+            Self::InvalidDate => f.write_str("timestamp date is invalid"),
+            Self::InvalidTime => f.write_str("timestamp time is invalid"),
+        }
+    }
+}
+
+impl Error for DateTimeError {}
+
+pub fn iso_to_epoch(timestamp: &str) -> Result<i64, DateTimeError> {
+    if timestamp.len() != 20
+        || timestamp.as_bytes()[4] != b'-'
+        || timestamp.as_bytes()[7] != b'-'
+        || timestamp.as_bytes()[10] != b'T'
+        || timestamp.as_bytes()[13] != b':'
+        || timestamp.as_bytes()[16] != b':'
+        || timestamp.as_bytes()[19] != b'Z'
+    {
+        return Err(DateTimeError::InvalidFormat);
+    }
+
+    let year = parse_i32(&timestamp[0..4])?;
+    let month = parse_u32(&timestamp[5..7])?;
+    let day = parse_u32(&timestamp[8..10])?;
+    let hour = parse_u32(&timestamp[11..13])?;
+    let minute = parse_u32(&timestamp[14..16])?;
+    let second = parse_u32(&timestamp[17..19])?;
+
+    if hour > 23 || minute > 59 || second > 59 {
+        return Err(DateTimeError::InvalidTime);
+    }
+    if month == 0 || month > 12 {
+        return Err(DateTimeError::InvalidDate);
+    }
+    let month_days = days_in_month(year, month);
+    if day == 0 || day > month_days {
+        return Err(DateTimeError::InvalidDate);
+    }
+
+    let days = days_from_civil(year, month, day);
+    Ok(days * 86_400 + i64::from(hour * 3_600 + minute * 60 + second))
+}
+
+fn parse_i32(value: &str) -> Result<i32, DateTimeError> {
+    parse_digits(value)
+        .and_then(|parsed| i32::try_from(parsed).map_err(|_| DateTimeError::InvalidFormat))
+}
+
+fn parse_u32(value: &str) -> Result<u32, DateTimeError> {
+    parse_digits(value)
+        .and_then(|parsed| u32::try_from(parsed).map_err(|_| DateTimeError::InvalidFormat))
+}
+
+fn parse_digits(value: &str) -> Result<u64, DateTimeError> {
+    value.bytes().try_fold(0u64, |acc, byte| match byte {
+        b'0'..=b'9' => Ok(acc * 10 + u64::from(byte - b'0')),
+        _ => Err(DateTimeError::InvalidFormat),
+    })
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+fn days_from_civil(year: i32, month: u32, day: u32) -> i64 {
+    let year = year - i32::from(month <= 2);
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let month = month as i32;
+    let day_of_year = (153 * (month + if month > 2 { -3 } else { 9 }) + 2) / 5 + day as i32 - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    i64::from(era * 146_097 + day_of_era - 719_468)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{iso_to_epoch, DateTimeError};
+
+    #[test]
+    fn known_timestamp_matches_legacy_python() {
+        assert_eq!(iso_to_epoch("2026-01-15T12:34:56Z").unwrap(), 1_768_480_496);
+    }
+
+    #[test]
+    fn unix_epoch_round_trips_to_zero() {
+        assert_eq!(iso_to_epoch("1970-01-01T00:00:00Z").unwrap(), 0);
+    }
+
+    #[test]
+    fn leap_day_is_valid_only_in_leap_year() {
+        assert_eq!(iso_to_epoch("2024-02-29T00:00:00Z").unwrap(), 1_709_164_800);
+        assert_eq!(
+            iso_to_epoch("2023-02-29T00:00:00Z"),
+            Err(DateTimeError::InvalidDate)
+        );
+    }
+
+    #[test]
+    fn malformed_timestamps_fail_without_epoch() {
+        assert_eq!(iso_to_epoch(""), Err(DateTimeError::InvalidFormat));
+        assert_eq!(
+            iso_to_epoch("not-a-timestamp"),
+            Err(DateTimeError::InvalidFormat)
+        );
+        assert_eq!(
+            iso_to_epoch("2026-01-15 12:34:56Z"),
+            Err(DateTimeError::InvalidFormat)
+        );
+        assert_eq!(
+            iso_to_epoch("2026-01-15T25:34:56Z"),
+            Err(DateTimeError::InvalidTime)
+        );
+    }
+}

--- a/crates/airc-core/src/lib.rs
+++ b/crates/airc-core/src/lib.rs
@@ -15,6 +15,7 @@
 //! - [`body`]       — opaque payload (Json | Binary) consumers carry
 //! - [`transcript`] — TranscriptEvent + TranscriptKind + MentionTarget
 //! - [`cursor`]     — cursor + paging primitives for transcript fetch
+//! - [`datetime`]   — fixed-format UTC timestamp parsing
 //! - [`receipt`]    — delivered/read/applied acknowledgments
 //! - [`attachment`] — file-attachment manifest (consumer-side richer view)
 //! - [`filter`]     — self-echo filtering for multi-tab consumers
@@ -27,6 +28,7 @@
 pub mod attachment;
 pub mod body;
 pub mod cursor;
+pub mod datetime;
 pub mod filter;
 pub mod headers;
 pub mod humanhash;
@@ -42,6 +44,7 @@ pub mod transcript;
 pub use attachment::AttachmentManifest;
 pub use body::Body;
 pub use cursor::{page_before, page_recent, TranscriptCursor, TranscriptPage};
+pub use datetime::{iso_to_epoch, DateTimeError};
 pub use filter::{filter_self_echoes, SelfFilter};
 pub use headers::{HeaderFilter, Headers};
 pub use humanhash::{humanhash, HumanhashError};

--- a/lib/airc_bash/mesh.sh
+++ b/lib/airc_bash/mesh.sh
@@ -144,7 +144,7 @@ except Exception:
     pass
 ' 2>/dev/null || true)
   [ -z "$hb" ] && return 0
-  local hb_epoch; hb_epoch=$("$AIRC_PYTHON" -m airc_core.datetime iso_to_epoch "$hb" 2>/dev/null || true)
+  local hb_epoch; hb_epoch=$(iso_to_epoch "$hb")
   [ -z "$hb_epoch" ] && return 0
   local now_epoch; now_epoch=$(date -u +%s)
   echo $(( now_epoch - hb_epoch ))

--- a/lib/airc_bash/platform_adapters.sh
+++ b/lib/airc_bash/platform_adapters.sh
@@ -175,17 +175,12 @@ detect_platform() {
 # Convert an ISO 8601 UTC timestamp to a Unix epoch (seconds since 1970).
 # Echoes the epoch on success, empty on failure.
 #
-# Migrated to airc_core.datetime as Phase 0a of the Python truth-layer
-# (#152 architecture). Pre-migration this was a 3-fallback adapter
-# chain inline in bash (BSD date / GNU date / python3 heredoc).
-# Post-migration the bash function is a one-line call into the
-# Python module — same contract, same stdout shape, but the logic
-# lives in a testable Python file with no bash → python heredoc
-# substitution risk. First migration; pattern for the rest.
+# Runtime path is Rust-owned; invalid input keeps the legacy empty-output
+# contract for bash callers.
 iso_to_epoch() {
   local ts="${1:-}"
   [ -z "$ts" ] && return 0
-  "$AIRC_PYTHON" -m airc_core.datetime iso_to_epoch "$ts" 2>/dev/null
+  "$(airc_rs_bin)" iso-to-epoch "$ts" 2>/dev/null || true
 }
 
 # MSYS / Git Bash path conversion. Six callsites in airc + three in

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -72,6 +72,15 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" client-id', body)
         self.assertIn('"$(airc_rs_bin)" humanhash "$input"', body)
 
+    def test_iso_to_epoch_uses_airc_rs(self):
+        source = (REPO / "lib/airc_bash/platform_adapters.sh").read_text(encoding="utf-8")
+        start = source.index("iso_to_epoch()")
+        end = source.index("# MSYS / Git Bash path conversion", start)
+        body = source[start:end]
+
+        self.assertNotIn("airc_core.datetime", body)
+        self.assertIn('"$(airc_rs_bin)" iso-to-epoch "$ts"', body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `airc_core::iso_to_epoch` for fixed UTC `YYYY-MM-DDTHH:MM:SSZ` parsing.
- Add `airc-rs iso-to-epoch` for shell compatibility paths.
- Route the bash `iso_to_epoch` adapter through Rust with no Python fallback.
- Remove the direct mesh call to `airc_core.datetime` so callers share the Rust adapter.
- Add a cutover guard preventing this helper from drifting back to Python.

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-core -p airc-cli --check`
- `cargo test --manifest-path Cargo.toml -p airc-core datetime`
- `cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- iso-to-epoch 2026-01-15T12:34:56Z`
- `cargo clippy --manifest-path Cargo.toml -p airc-core -p airc-cli --all-targets -- -D warnings`
- `python3 test/test_codex_rust_cutover.py`
- `bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh`
- `cargo test --manifest-path Cargo.toml --workspace`

## CI
- Linux/macOS/Windows matrix required before merge.
