### PR TITLE
feat(airc-rs): move log append and rotate to rust

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -204,6 +204,9 @@ pub enum Command {
     /// Coordinate work lanes over the current room's AIRC substrate.
     Lane(crate::lane_cli::LaneArgs),
 
+    /// Append and rotate legacy messages.jsonl files through Rust.
+    Log(crate::log_cli::LogArgs),
+
     /// Coordinate workspace leases over the current room's AIRC substrate.
     Workspace(crate::workspace_cli::WorkspaceArgs),
 

--- a/crates/airc-cli/src/log_cli.rs
+++ b/crates/airc-cli/src/log_cli.rs
@@ -1,0 +1,37 @@
+//! Clap argument shapes for `airc-rs log ...`.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+pub const DEFAULT_MAX_LINES: usize = 5_000;
+pub const DEFAULT_KEEP_LINES: usize = 2_500;
+
+#[derive(Debug, Args)]
+pub struct LogArgs {
+    #[command(subcommand)]
+    pub action: LogAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LogAction {
+    /// Append one stdin frame unless its JSON `sig` exists in the recent tail.
+    Append {
+        /// messages.jsonl path to append.
+        #[arg(long)]
+        path: PathBuf,
+    },
+
+    /// Trim a messages.jsonl file to its recent tail when over threshold.
+    Rotate {
+        /// messages.jsonl path to rotate.
+        #[arg(long)]
+        path: PathBuf,
+        /// Rotate only when the file has more than this many lines.
+        #[arg(long, default_value_t = DEFAULT_MAX_LINES)]
+        max_lines: usize,
+        /// Number of tail lines to keep after rotation.
+        #[arg(long, default_value_t = DEFAULT_KEEP_LINES)]
+        keep_lines: usize,
+    },
+}

--- a/crates/airc-cli/src/log_commands.rs
+++ b/crates/airc-cli/src/log_commands.rs
@@ -1,0 +1,305 @@
+//! `airc-rs log ...` handlers for legacy shell log paths.
+
+use std::error::Error;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, SystemTime};
+
+use serde_json::Value;
+use uuid::Uuid;
+
+const LOCK_STALE: Duration = Duration::from_secs(30);
+const LOCK_WAIT: Duration = Duration::from_secs(5);
+const LOCK_SLEEP: Duration = Duration::from_millis(50);
+const TAIL_LIMIT: usize = 5_000;
+
+pub fn run_append(path: &Path) -> Result<(), Box<dyn Error>> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    if input.is_empty() {
+        return Ok(());
+    }
+    append_unique_sig(path, &input)?;
+    Ok(())
+}
+
+pub fn run_rotate(path: &Path, max_lines: usize, keep_lines: usize) -> Result<(), Box<dyn Error>> {
+    rotate_if_needed(path, max_lines, keep_lines)?;
+    Ok(())
+}
+
+fn append_unique_sig(path: &Path, line: &str) -> Result<AppendOutcome, Box<dyn Error>> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)?;
+    }
+
+    let framed = if line.ends_with('\n') {
+        line.to_string()
+    } else {
+        format!("{line}\n")
+    };
+    let sig = line_sig(&framed);
+    let lock = LogLock::acquire(path)?;
+    let outcome = if sig
+        .as_deref()
+        .is_some_and(|sig| recent_sigs(path, TAIL_LIMIT).contains(&sig.to_string()))
+    {
+        AppendOutcome::Skipped
+    } else {
+        let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+        file.write_all(framed.as_bytes())?;
+        AppendOutcome::Appended
+    };
+    drop(lock);
+    Ok(outcome)
+}
+
+fn rotate_if_needed(
+    path: &Path,
+    max_lines: usize,
+    keep_lines: usize,
+) -> Result<RotateOutcome, Box<dyn Error>> {
+    if max_lines <= keep_lines {
+        return Err("max-lines must be greater than keep-lines".into());
+    }
+    if !path.is_file() {
+        return Ok(RotateOutcome::Noop);
+    }
+
+    let content = fs::read(path)?;
+    let lines = split_lines(&content);
+    if lines.len() <= max_lines {
+        return Ok(RotateOutcome::Noop);
+    }
+
+    let tmp_path = temp_path_for(path);
+    {
+        let mut tmp = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&tmp_path)?;
+        for line in lines.iter().skip(lines.len() - keep_lines) {
+            tmp.write_all(line)?;
+        }
+    }
+
+    match fs::rename(&tmp_path, path) {
+        Ok(()) => Ok(RotateOutcome::Rotated),
+        Err(first_error) => {
+            if let Err(remove_error) = fs::remove_file(path) {
+                let _ = fs::remove_file(&tmp_path);
+                return Err(format!(
+                    "failed to replace {}: {first_error}; remove failed: {remove_error}",
+                    path.display()
+                )
+                .into());
+            }
+            if let Err(rename_error) = fs::rename(&tmp_path, path) {
+                let _ = fs::remove_file(&tmp_path);
+                return Err(format!(
+                    "failed to replace {} after remove: {rename_error}",
+                    path.display()
+                )
+                .into());
+            }
+            Ok(RotateOutcome::Rotated)
+        }
+    }
+}
+
+fn line_sig(line: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(line).ok()?;
+    value
+        .get("sig")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn recent_sigs(path: &Path, limit: usize) -> Vec<String> {
+    let Ok(content) = fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let mut sigs: Vec<String> = content
+        .lines()
+        .rev()
+        .filter_map(line_sig)
+        .take(limit)
+        .collect();
+    sigs.reverse();
+    sigs
+}
+
+fn split_lines(content: &[u8]) -> Vec<&[u8]> {
+    if content.is_empty() {
+        return Vec::new();
+    }
+
+    let mut start = 0;
+    let mut lines = Vec::new();
+    for (index, byte) in content.iter().enumerate() {
+        if *byte == b'\n' {
+            lines.push(&content[start..=index]);
+            start = index + 1;
+        }
+    }
+    if start < content.len() {
+        lines.push(&content[start..]);
+    }
+    lines
+}
+
+fn temp_path_for(path: &Path) -> PathBuf {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(format!(
+        ".airc-log-{}-{}.tmp",
+        std::process::id(),
+        Uuid::new_v4()
+    ))
+}
+
+struct LogLock {
+    path: PathBuf,
+}
+
+impl LogLock {
+    fn acquire(path: &Path) -> Result<Self, Box<dyn Error>> {
+        let lock_path = path.with_extension(format!(
+            "{}lock",
+            path.extension()
+                .and_then(|extension| extension.to_str())
+                .map(|extension| format!("{extension}."))
+                .unwrap_or_default()
+        ));
+        let started = SystemTime::now();
+
+        loop {
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&lock_path)
+            {
+                Ok(mut file) => {
+                    writeln!(file, "{}", std::process::id())?;
+                    return Ok(Self { path: lock_path });
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                    if is_stale_lock(&lock_path) {
+                        let _ = fs::remove_file(&lock_path);
+                        continue;
+                    }
+                    if started.elapsed().unwrap_or_default() >= LOCK_WAIT {
+                        return Err(format!(
+                            "timed out waiting for log lock: {}",
+                            lock_path.display()
+                        )
+                        .into());
+                    }
+                    thread::sleep(LOCK_SLEEP);
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+}
+
+impl Drop for LogLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn is_stale_lock(path: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+    let Ok(modified) = metadata.modified() else {
+        return false;
+    };
+    modified
+        .elapsed()
+        .map(|elapsed| elapsed > LOCK_STALE)
+        .unwrap_or(false)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AppendOutcome {
+    Appended,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RotateOutcome {
+    Noop,
+    Rotated,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{append_unique_sig, rotate_if_needed, AppendOutcome, RotateOutcome};
+
+    #[test]
+    fn append_skips_duplicate_sig_from_recent_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("messages.jsonl");
+
+        assert_eq!(
+            append_unique_sig(&path, r#"{"sig":"a","msg":"one"}"#).unwrap(),
+            AppendOutcome::Appended
+        );
+        assert_eq!(
+            append_unique_sig(&path, r#"{"sig":"a","msg":"duplicate"}"#).unwrap(),
+            AppendOutcome::Skipped
+        );
+
+        let content = std::fs::read_to_string(path).unwrap();
+        assert!(content.contains("one"));
+        assert!(!content.contains("duplicate"));
+    }
+
+    #[test]
+    fn append_without_sig_always_appends() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("messages.jsonl");
+
+        append_unique_sig(&path, r#"{"msg":"one"}"#).unwrap();
+        append_unique_sig(&path, r#"{"msg":"one"}"#).unwrap();
+
+        assert_eq!(std::fs::read_to_string(path).unwrap().lines().count(), 2);
+    }
+
+    #[test]
+    fn rotate_keeps_tail_when_over_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("messages.jsonl");
+        std::fs::write(&path, "one\ntwo\nthree\nfour\n").unwrap();
+
+        assert_eq!(
+            rotate_if_needed(&path, 3, 2).unwrap(),
+            RotateOutcome::Rotated
+        );
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "three\nfour\n");
+    }
+
+    #[test]
+    fn rotate_noops_under_limit_or_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("messages.jsonl");
+
+        assert_eq!(rotate_if_needed(&path, 3, 2).unwrap(), RotateOutcome::Noop);
+        std::fs::write(&path, "one\ntwo\n").unwrap();
+        assert_eq!(rotate_if_needed(&path, 3, 2).unwrap(), RotateOutcome::Noop);
+    }
+
+    #[test]
+    fn rotate_rejects_non_headroom_thresholds() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("messages.jsonl");
+
+        assert!(rotate_if_needed(&path, 2, 2).is_err());
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -24,6 +24,8 @@ mod events_cli;
 mod events_commands;
 mod lane_cli;
 mod lane_commands;
+mod log_cli;
+mod log_commands;
 mod work_cli;
 mod work_commands;
 mod workspace_cli;
@@ -43,6 +45,7 @@ use cli::{Cli, Command, PeerAction};
 use codex_cli::CodexHookAction;
 use events_cli::EventsAction;
 use lane_cli::{LaneAction, LaneManagerAction};
+use log_cli::LogAction;
 use work_cli::WorkAction;
 use workspace_cli::WorkspaceAction;
 
@@ -207,6 +210,15 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     lane_commands::run_manager_status(&home, limit).await
                 }
             },
+        },
+
+        Command::Log(args) => match args.action {
+            LogAction::Append { path } => log_commands::run_append(&path),
+            LogAction::Rotate {
+                path,
+                max_lines,
+                keep_lines,
+            } => log_commands::run_rotate(&path, max_lines, keep_lines),
         },
 
         Command::Workspace(args) => match args.action {

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -2322,11 +2322,11 @@ JSON
                 printf '%s\n' "$_hb_payload" > "$_hb_tmp"
                 # Rotate the host's messages.jsonl when it exceeds the
                 # AIRC_LOG_MAX_LINES threshold (default 5000). Trims
-                # in-place via airc_core.log; SSH-tail's -F flag detects
+                # in-place via airc-rs log rotate; SSH-tail's -F flag detects
                 # the atomic replace and re-opens. Joiners with offsets
                 # past the new file's line count are caught by #245.
                 # Cheap no-op when under threshold.
-                "$AIRC_PYTHON" -m airc_core.log rotate --path "$_hb_messages" \
+                "$(airc_rs_bin)" log rotate --path "$_hb_messages" \
                   --max-lines "${AIRC_LOG_MAX_LINES:-5000}" \
                   --keep-lines "${AIRC_LOG_KEEP_LINES:-2500}" >/dev/null 2>&1 || true
                 # Capture stderr to a state file (per never-swallow-errors

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -270,7 +270,7 @@ cmd_send() {
   ensure_init
 
   _airc_append_local_signed() {
-    if ! printf '%s\n' "$1" | "$AIRC_PYTHON" -m airc_core.log_append append --path "$MESSAGES" >/dev/null; then
+    if ! printf '%s\n' "$1" | "$(airc_rs_bin)" log append --path "$MESSAGES" >/dev/null; then
       echo "$1" >> "$MESSAGES"
     fi
   }

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -81,6 +81,15 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("airc_core.datetime", body)
         self.assertIn('"$(airc_rs_bin)" iso-to-epoch "$ts"', body)
 
+    def test_log_append_and_rotate_use_airc_rs(self):
+        send = (REPO / "lib/airc_bash/cmd_send.sh").read_text(encoding="utf-8")
+        connect = (REPO / "lib/airc_bash/cmd_connect.sh").read_text(encoding="utf-8")
+
+        self.assertNotIn("airc_core.log_append", send)
+        self.assertIn('"$(airc_rs_bin)" log append --path "$MESSAGES"', send)
+        self.assertNotIn("airc_core.log rotate", connect)
+        self.assertIn('"$(airc_rs_bin)" log rotate --path "$_hb_messages"', connect)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `airc-rs log append` with legacy-compatible duplicate-`sig` suppression and lock-file behavior.
- Add `airc-rs log rotate` with legacy-compatible max/keep line trimming.
- Route shell send-path local append and heartbeat log rotation through Rust with no Python fallback.
- Add cutover guards for the two shell runtime paths.

## Notes
- The Python modules remain for `monitor_formatter` internals; this PR removes the shell runtime dependency only. Monitor internals should be a separate cutover.

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-cli --check`
- `cargo test --manifest-path Cargo.toml -p airc-cli log_commands`
- `cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings`
- `python3 test/test_codex_rust_cutover.py`
- `bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh`
- `printf ... | cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- log append --path /tmp/airc-log-smoke.jsonl`
- `cargo test --manifest-path Cargo.toml --workspace`

## CI
- Linux/macOS/Windows matrix required before merge.
