### PR TITLE
feat(airc-rs): move bearer state reads to rust

### DIFF
--- a/crates/airc-cli/src/bearer_state.rs
+++ b/crates/airc-cli/src/bearer_state.rs
@@ -1,0 +1,66 @@
+//! Helpers for reading legacy bearer state JSON from shell commands.
+
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+pub fn run(path: &Path) -> Result<(), Box<dyn Error>> {
+    let state = read_state(path)?;
+    println!(
+        "{} {}",
+        int_timestamp(state.get("last_recv_ts")),
+        int_timestamp(state.get("last_heartbeat_ts"))
+    );
+    Ok(())
+}
+
+fn read_state(path: &Path) -> Result<Value, Box<dyn Error>> {
+    let raw = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&raw)?)
+}
+
+fn int_timestamp(value: Option<&Value>) -> u64 {
+    let Some(value) = value else {
+        return 0;
+    };
+    let parsed = match value {
+        Value::Number(number) => number.as_f64(),
+        Value::String(text) => text.parse::<f64>().ok(),
+        _ => None,
+    };
+    parsed
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .map(|value| value as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{int_timestamp, read_state};
+    use serde_json::json;
+
+    #[test]
+    fn timestamp_accepts_numbers_and_numeric_strings() {
+        assert_eq!(int_timestamp(Some(&json!(123.9))), 123);
+        assert_eq!(int_timestamp(Some(&json!("456.7"))), 456);
+    }
+
+    #[test]
+    fn timestamp_rejects_missing_negative_and_non_numeric_values() {
+        assert_eq!(int_timestamp(None), 0);
+        assert_eq!(int_timestamp(Some(&json!(-1))), 0);
+        assert_eq!(int_timestamp(Some(&json!("nope"))), 0);
+        assert_eq!(int_timestamp(Some(&json!({}))), 0);
+    }
+
+    #[test]
+    fn read_state_parses_json_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        std::fs::write(&path, r#"{"last_recv_ts": 10}"#).unwrap();
+
+        assert_eq!(read_state(&path).unwrap()["last_recv_ts"], 10);
+    }
+}

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -78,6 +78,12 @@ pub enum Command {
     /// peer_id.
     Init,
 
+    /// Print legacy bearer state timestamps as `last_recv last_heartbeat`.
+    BearerState {
+        /// bearer_state.<channel>.json path to read.
+        path: PathBuf,
+    },
+
     /// Send a single text Message frame to the current room and exit.
     /// The current room lives in `<home>/room.json`; switch with
     /// `airc-rs room <name>`.

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -11,6 +11,7 @@
 //! generating if absent). `VerificationPolicy::Strict` is the only
 //! policy used in CLI paths — no `AllowUnsigned` opt-in.
 
+mod bearer_state;
 mod cli;
 mod client_id;
 mod codex_cli;
@@ -74,6 +75,8 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
     match parsed.command {
         Command::Init => commands::run_init(&home).await,
+
+        Command::BearerState { path } => bearer_state::run(&path),
 
         Command::Send { text } => commands::run_send(&home, parsed.peers, &text).await,
 

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -536,7 +536,7 @@ _doctor_health() {
       fi
       found_state=1
       local state_ts last_recv_ts last_heartbeat_ts heartbeat_age
-      state_ts=$("$AIRC_PYTHON" -m airc_core.bearer_state "$state_file" 2>/dev/null || echo "0 0")
+      state_ts=$("$(airc_rs_bin)" bearer-state "$state_file" 2>/dev/null || echo "0 0")
       last_recv_ts=${state_ts%% *}
       last_heartbeat_ts=${state_ts#* }
       [ "$last_recv_ts" = "$state_ts" ] && last_heartbeat_ts=0

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -90,6 +90,12 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("airc_core.log rotate", connect)
         self.assertIn('"$(airc_rs_bin)" log rotate --path "$_hb_messages"', connect)
 
+    def test_bearer_state_uses_airc_rs(self):
+        source = (REPO / "lib/airc_bash/cmd_doctor.sh").read_text(encoding="utf-8")
+
+        self.assertNotIn("airc_core.bearer_state", source)
+        self.assertIn('"$(airc_rs_bin)" bearer-state "$state_file"', source)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `airc-rs bearer-state <path>` for legacy bearer timestamp reads.
- Route doctor health checks through Rust with no Python fallback.
- Add a cutover guard so `cmd_doctor.sh` cannot drift back to `airc_core.bearer_state`.

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-cli --check`
- `cargo test --manifest-path Cargo.toml -p airc-cli bearer_state`
- `cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings`
- `python3 test/test_codex_rust_cutover.py`
- `bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh`
- `cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- bearer-state <tmp-state>`
- `cargo test --manifest-path Cargo.toml --workspace`

## CI
- Linux/macOS/Windows matrix required before merge.
