### PR TITLE
feat(airc-rs): move gist JSON parsing to rust

### DIFF
--- a/airc
+++ b/airc
@@ -1041,15 +1041,14 @@ peer_pick_address() {
   local addresses_json="${1:-}" host_machine="${2:-}"
   [ -z "$addresses_json" ] || [ "$addresses_json" = "null" ] && return 0
 
-  # #188: parse via airc_core.gistparse (Python stdlib JSON) instead of
-  # jq. Eliminates the jq hard dep — Python is already required for the
-  # truth-layer (#152 Phase 0); jq was redundant.
+  # Parse through airc-rs instead of jq/Python so routing decisions stay
+  # on the Rust cutover path.
 
   # Same machine: use localhost.
   local my_machine; my_machine=$(host_machine_id)
   if [ -n "$host_machine" ] && [ "$host_machine" = "$my_machine" ]; then
     local pick; pick=$(printf '%s' "$addresses_json" \
-      | "$AIRC_PYTHON" -m airc_core.gistparse pick_addr localhost 2>/dev/null)
+      | "$(airc_rs_bin)" gist pick-addr localhost 2>/dev/null)
     if [ -n "$pick" ]; then printf '%s' "$pick"; return 0; fi
   fi
 
@@ -1060,13 +1059,13 @@ peer_pick_address() {
   if [ -n "$my_lan_ips" ]; then
     local lan_entries
     lan_entries=$(printf '%s' "$addresses_json" \
-      | "$AIRC_PYTHON" -m airc_core.gistparse list_lan_entries 2>/dev/null)
+      | "$(airc_rs_bin)" gist list-lan-entries 2>/dev/null)
     if [ -n "$lan_entries" ]; then
       while IFS= read -r entry; do
         [ -z "$entry" ] && continue
-        local subnet; subnet=$(printf '%s' "$entry" | "$AIRC_PYTHON" -m airc_core.gistparse get .subnet 2>/dev/null)
-        local addr;   addr=$(printf '%s' "$entry"   | "$AIRC_PYTHON" -m airc_core.gistparse get .addr 2>/dev/null)
-        local port;   port=$(printf '%s' "$entry"   | "$AIRC_PYTHON" -m airc_core.gistparse get .port 2>/dev/null)
+        local subnet; subnet=$(printf '%s' "$entry" | "$(airc_rs_bin)" gist get .subnet 2>/dev/null)
+        local addr;   addr=$(printf '%s' "$entry"   | "$(airc_rs_bin)" gist get .addr 2>/dev/null)
+        local port;   port=$(printf '%s' "$entry"   | "$(airc_rs_bin)" gist get .port 2>/dev/null)
         # subnet is like "192.168.1.0/24" — match the /24 prefix against my IPs.
         if [ -n "$subnet" ]; then
           local prefix="${subnet%/*}"   # 192.168.1.0
@@ -1096,7 +1095,7 @@ peer_pick_address() {
   # tailscale up but want airc to skip it for routing decisions).
   if [ "${AIRC_NO_TAILSCALE:-0}" != "1" ] && _have_tailscale_locally; then
     local pick; pick=$(printf '%s' "$addresses_json" \
-      | "$AIRC_PYTHON" -m airc_core.gistparse pick_addr tailscale 2>/dev/null)
+      | "$(airc_rs_bin)" gist pick-addr tailscale 2>/dev/null)
     if [ -n "$pick" ]; then printf '%s' "$pick"; return 0; fi
   fi
 
@@ -1113,7 +1112,7 @@ peer_pick_address() {
   # gh-bearer-only routing (broadcast still works; direct pair
   # skipped).
   printf '%s' "$addresses_json" \
-    | "$AIRC_PYTHON" -m airc_core.gistparse pick_addr_excluding localhost tailscale 2>/dev/null
+    | "$(airc_rs_bin)" gist pick-addr-excluding localhost tailscale 2>/dev/null
 }
 
 # _have_tailscale_locally: do WE currently have a Tailscale interface

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -17,6 +17,7 @@ use clap::{Args, Parser, Subcommand};
 use airc_lib::PeerSpec;
 
 use crate::codex_cli::{CodexHookArgs, CodexStartArgs};
+use crate::gist_cli::GistArgs;
 use crate::work_cli::WorkArgs;
 
 /// Default home directory for persisted identity + IPC state.
@@ -197,6 +198,9 @@ pub enum Command {
 
     /// Inspect persisted events through subscription-style filters.
     Events(crate::events_cli::EventsArgs),
+
+    /// Parse legacy GitHub gist envelope JSON.
+    Gist(GistArgs),
 
     /// Codex lifecycle hook adapters backed by Rust AIRC events.
     CodexHook(CodexHookArgs),

--- a/crates/airc-cli/src/gist_cli.rs
+++ b/crates/airc-cli/src/gist_cli.rs
@@ -1,0 +1,48 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct GistArgs {
+    #[command(subcommand)]
+    pub action: GistAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum GistAction {
+    /// Read a dotted/indexed path from stdin JSON.
+    Get {
+        path: String,
+        #[arg(long, default_value = "")]
+        default: String,
+    },
+
+    /// Read a dotted/indexed path and emit compact JSON.
+    GetJson { path: String },
+
+    /// Read the first present path from stdin JSON.
+    GetFirstOf {
+        paths: Vec<String>,
+        #[arg(long, default_value = "")]
+        default: String,
+    },
+
+    /// Pick the first address entry matching a scope.
+    PickAddr { scope: String },
+
+    /// Pick the first address entry.
+    PickAddrFirst,
+
+    /// Pick the first non-localhost address entry.
+    PickAddrNonlocalFirst,
+
+    /// Pick the first address entry whose scope is not excluded.
+    PickAddrExcluding { exclude_scopes: Vec<String> },
+
+    /// Emit LAN address entries as compact JSONL.
+    ListLanEntries,
+
+    /// Extract the selected content file from a GitHub gist API response.
+    GistContent {
+        #[arg(long, default_value = "")]
+        channel: String,
+    },
+}

--- a/crates/airc-cli/src/gist_commands.rs
+++ b/crates/airc-cli/src/gist_commands.rs
@@ -1,0 +1,306 @@
+use std::error::Error;
+use std::io::{self, Read};
+
+use serde_json::Value;
+
+pub fn run_get(path: &str, default: &str) -> Result<(), Box<dyn Error>> {
+    let value = read_stdin_json()
+        .and_then(|json| navigate(&json, path).cloned())
+        .unwrap_or(Value::Null);
+    emit_value(&value, default)?;
+    Ok(())
+}
+
+pub fn run_get_json(path: &str) -> Result<(), Box<dyn Error>> {
+    let value = read_stdin_json()
+        .and_then(|json| navigate(&json, path).cloned())
+        .unwrap_or(Value::Null);
+    match value {
+        Value::Null => println!(),
+        other => println!("{}", serde_json::to_string(&other)?),
+    }
+    Ok(())
+}
+
+pub fn run_get_first_of(paths: &[String], default: &str) -> Result<(), Box<dyn Error>> {
+    let Some(json) = read_stdin_json() else {
+        println!("{default}");
+        return Ok(());
+    };
+    for path in paths {
+        if let Some(value) = navigate(&json, path) {
+            emit_value(value, default)?;
+            return Ok(());
+        }
+    }
+    println!("{default}");
+    Ok(())
+}
+
+pub fn run_pick_addr(scope: &str) -> Result<(), Box<dyn Error>> {
+    let Some(json) = read_stdin_json() else {
+        return Ok(());
+    };
+    if let Some(pick) = pick_addr(&json, |entry_scope| entry_scope == scope) {
+        println!("{pick}");
+    }
+    Ok(())
+}
+
+pub fn run_pick_addr_first() -> Result<(), Box<dyn Error>> {
+    let Some(json) = read_stdin_json() else {
+        return Ok(());
+    };
+    if let Some(pick) = pick_addr(&json, |_| true) {
+        println!("{pick}");
+    }
+    Ok(())
+}
+
+pub fn run_pick_addr_nonlocal_first() -> Result<(), Box<dyn Error>> {
+    let Some(json) = read_stdin_json() else {
+        return Ok(());
+    };
+    if let Some(pick) = pick_addr(&json, |scope| scope != "localhost") {
+        println!("{pick}");
+    }
+    Ok(())
+}
+
+pub fn run_pick_addr_excluding(exclude_scopes: &[String]) -> Result<(), Box<dyn Error>> {
+    let Some(json) = read_stdin_json() else {
+        return Ok(());
+    };
+    if let Some(pick) = pick_addr(&json, |scope| {
+        !exclude_scopes.iter().any(|excluded| excluded == scope)
+    }) {
+        println!("{pick}");
+    }
+    Ok(())
+}
+
+pub fn run_list_lan_entries() -> Result<(), Box<dyn Error>> {
+    let Some(json) = read_stdin_json() else {
+        return Ok(());
+    };
+    let Some(entries) = json.as_array() else {
+        return Ok(());
+    };
+    for entry in entries {
+        if entry.get("scope").and_then(Value::as_str) == Some("lan") {
+            println!("{}", serde_json::to_string(entry)?);
+        }
+    }
+    Ok(())
+}
+
+pub fn run_gist_content(channel: &str) -> Result<(), Box<dyn Error>> {
+    let Some(json) = read_stdin_json() else {
+        return Ok(());
+    };
+    if let Some(content) = gist_content(&json, channel) {
+        println!("{content}");
+    }
+    Ok(())
+}
+
+fn read_stdin_json() -> Option<Value> {
+    let mut raw = String::new();
+    io::stdin().read_to_string(&mut raw).ok()?;
+    if raw.trim().is_empty() {
+        return None;
+    }
+    serde_json::from_str(&raw).ok()
+}
+
+fn navigate<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    if path.is_empty() || path == "." {
+        return Some(value);
+    }
+
+    let mut current = value;
+    for segment in path.strip_prefix('.')?.split('.') {
+        if segment.is_empty() {
+            return None;
+        }
+        let (key, index) = parse_segment(segment)?;
+        if !key.is_empty() {
+            current = current.as_object()?.get(key)?;
+        }
+        if let Some(index) = index {
+            current = current.as_array()?.get(index)?;
+        }
+    }
+    Some(current)
+}
+
+fn parse_segment(segment: &str) -> Option<(&str, Option<usize>)> {
+    if segment.starts_with('[') {
+        return Some(("", Some(parse_index(segment)?)));
+    }
+    let Some(open) = segment.find('[') else {
+        return valid_key(segment).then_some((segment, None));
+    };
+    let key = &segment[..open];
+    valid_key(key).then_some((key, Some(parse_index(&segment[open..])?)))
+}
+
+fn valid_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    matches!(chars.next(), Some(first) if first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch == '-' || ch.is_ascii_alphanumeric())
+}
+
+fn parse_index(segment: &str) -> Option<usize> {
+    let inner = segment.strip_prefix('[')?.strip_suffix(']')?;
+    inner.parse().ok()
+}
+
+fn emit_value(value: &Value, default: &str) -> Result<(), Box<dyn Error>> {
+    match value {
+        Value::Null => println!("{default}"),
+        Value::String(text) => println!("{text}"),
+        Value::Bool(true) => println!("true"),
+        Value::Bool(false) => println!("false"),
+        other => println!("{}", serde_json::to_string(other)?),
+    }
+    Ok(())
+}
+
+fn pick_addr<F>(json: &Value, allowed_scope: F) -> Option<String>
+where
+    F: Fn(&str) -> bool,
+{
+    json.as_array()?.iter().find_map(|entry| {
+        let scope = entry.get("scope").and_then(Value::as_str).unwrap_or("");
+        if !allowed_scope(scope) {
+            return None;
+        }
+        let addr = entry.get("addr").and_then(Value::as_str)?;
+        let port = entry.get("port")?;
+        (!addr.is_empty() && !port.is_null()).then(|| format!("{addr}|{}", port_as_text(port)))
+    })
+}
+
+fn port_as_text(value: &Value) -> String {
+    value
+        .as_str()
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| value.to_string())
+}
+
+fn gist_content(json: &Value, channel: &str) -> Option<String> {
+    let files = json.get("files")?.as_object()?;
+    if !channel.is_empty() {
+        let exact_name = format!("airc-room-{channel}.json");
+        if let Some((_, _, content)) = files
+            .iter()
+            .filter_map(|(name, entry)| matching_channel_content(name, entry, channel, &exact_name))
+            .max_by_key(|(heartbeat, exact, _)| (*heartbeat, *exact))
+        {
+            return Some(content);
+        }
+    }
+    files
+        .values()
+        .find_map(|entry| entry.get("content").and_then(Value::as_str))
+        .map(ToOwned::to_owned)
+}
+
+fn matching_channel_content(
+    name: &str,
+    entry: &Value,
+    channel: &str,
+    exact_name: &str,
+) -> Option<(i64, bool, String)> {
+    let content = entry.get("content")?.as_str()?.to_owned();
+    let envelope: Value = serde_json::from_str(&content).ok()?;
+    let channels = envelope.get("channels")?.as_array()?;
+    channels
+        .iter()
+        .any(|item| item.as_str() == Some(channel))
+        .then(|| {
+            (
+                heartbeat_epoch(envelope.get("last_heartbeat")),
+                name == exact_name,
+                content,
+            )
+        })
+}
+
+fn heartbeat_epoch(value: Option<&Value>) -> i64 {
+    let Some(timestamp) = value.and_then(Value::as_str) else {
+        return 0;
+    };
+    let normalized = timestamp
+        .strip_suffix("+00:00")
+        .map_or_else(|| timestamp.to_owned(), |prefix| format!("{prefix}Z"));
+    airc_core::iso_to_epoch(&normalized).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn navigate_reads_paths_and_indexes() {
+        let value = json!({"host":{"addresses":[{"addr":"127.0.0.1"}]}});
+
+        assert_eq!(
+            navigate(&value, ".host.addresses[0].addr").and_then(Value::as_str),
+            Some("127.0.0.1")
+        );
+        assert!(navigate(&value, ".host.addresses[1].addr").is_none());
+    }
+
+    #[test]
+    fn pick_addr_excludes_unreachable_scopes() {
+        let value = json!([
+            {"scope":"localhost","addr":"127.0.0.1","port":"7547"},
+            {"scope":"lan","addr":"192.168.1.42","port":"7547"},
+            {"scope":"tailscale","addr":"100.79.156.3","port":"7547"}
+        ]);
+
+        assert_eq!(
+            pick_addr(&value, |scope| scope != "localhost" && scope != "tailscale"),
+            Some("192.168.1.42|7547".to_string())
+        );
+    }
+
+    #[test]
+    fn gist_content_selects_freshest_matching_channel() {
+        let stale = json!({
+            "airc": 1,
+            "kind": "mesh",
+            "channels": ["general", "acme"],
+            "last_heartbeat": "2026-05-04T12:54:15Z",
+            "invite": "stale-host@example"
+        });
+        let fresh = json!({
+            "airc": 1,
+            "kind": "mesh",
+            "channels": ["acme", "general"],
+            "last_heartbeat": "2026-05-04T17:14:09Z",
+            "invite": "fresh-host@example"
+        });
+        let gist = json!({
+            "files": {
+                "airc-room-acme.json": {"content": stale.to_string()},
+                "airc-room-general.json": {"content": fresh.to_string()}
+            }
+        });
+
+        let content = gist_content(&gist, "acme").unwrap();
+        let parsed: Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(parsed["invite"], "fresh-host@example");
+    }
+
+    #[test]
+    fn heartbeat_parse_accepts_utc_offset() {
+        assert_eq!(
+            heartbeat_epoch(Some(&json!("2026-05-04T17:14:09+00:00"))),
+            heartbeat_epoch(Some(&json!("2026-05-04T17:14:09Z")))
+        );
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -23,6 +23,8 @@ mod codex_start;
 mod commands;
 mod events_cli;
 mod events_commands;
+mod gist_cli;
+mod gist_commands;
 mod lane_cli;
 mod lane_commands;
 mod log_cli;
@@ -45,6 +47,7 @@ use airc_daemon::LocalIdentity;
 use cli::{Cli, Command, PeerAction};
 use codex_cli::CodexHookAction;
 use events_cli::EventsAction;
+use gist_cli::GistAction;
 use lane_cli::{LaneAction, LaneManagerAction};
 use log_cli::LogAction;
 use work_cli::WorkAction;
@@ -143,6 +146,22 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 header_prefix,
                 limit,
             } => events_commands::run_list(&home, kind, header, header_prefix, limit).await,
+        },
+
+        Command::Gist(args) => match args.action {
+            GistAction::Get { path, default } => gist_commands::run_get(&path, &default),
+            GistAction::GetJson { path } => gist_commands::run_get_json(&path),
+            GistAction::GetFirstOf { paths, default } => {
+                gist_commands::run_get_first_of(&paths, &default)
+            }
+            GistAction::PickAddr { scope } => gist_commands::run_pick_addr(&scope),
+            GistAction::PickAddrFirst => gist_commands::run_pick_addr_first(),
+            GistAction::PickAddrNonlocalFirst => gist_commands::run_pick_addr_nonlocal_first(),
+            GistAction::PickAddrExcluding { exclude_scopes } => {
+                gist_commands::run_pick_addr_excluding(&exclude_scopes)
+            }
+            GistAction::ListLanEntries => gist_commands::run_list_lan_entries(),
+            GistAction::GistContent { channel } => gist_commands::run_gist_content(&channel),
         },
 
         Command::CodexHook(args) => match args.action {

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1320,13 +1320,13 @@ cmd_connect() {
       # malformed JSON `"invite": "..."` line (quotes and all), pair
       # handshake failed on garbage host info, and self-heal didn't fire
       # because resolved_room_name was never extracted via the jq path.
-      # #188: Python (stdlib JSON) replaces jq. gh api → gistparse extracts
+      # gh api → airc-rs extracts
       # the first file's content. This is the rest-API path; it's preferred
       # over the gh gist view --raw path because the latter prepends the
       # gist description as a header line that we'd then have to strip.
       if command -v gh >/dev/null 2>&1; then
         raw_content=$( (gh api "gists/$gist_id" 2>/dev/null \
-                        | "$AIRC_PYTHON" -m airc_core.gistparse gist_content --channel "$room_name" 2>/dev/null) || true )
+                        | "$(airc_rs_bin)" gist gist-content --channel "$room_name" 2>/dev/null) || true )
       fi
       # Fallback path 1: gh raw view (description leak handled by the
       # awk strip below at "head -c 1 | grep '{'" cleanup).
@@ -1361,7 +1361,7 @@ cmd_connect() {
       # without gh OR git. Last resort. (#188 — was curl + jq.)
       if [ -z "$raw_content" ] && command -v curl >/dev/null 2>&1; then
         raw_content=$( (curl -fsSL "https://api.github.com/gists/$gist_id" 2>/dev/null \
-                        | "$AIRC_PYTHON" -m airc_core.gistparse gist_content --channel "$room_name" 2>/dev/null) || true )
+                        | "$(airc_rs_bin)" gist gist-content --channel "$room_name" 2>/dev/null) || true )
       fi
       # Last-resort cleanup: if raw_content still has the description-header
       # leak from a degraded gh-view path, strip lines before the first '{'
@@ -1383,8 +1383,8 @@ cmd_connect() {
       # #188: was `if command -v jq`; now Python is the truth-layer
       # (always available since #152 Phase 0). Drop the jq gate.
       local airc_ver kind
-      airc_ver=$(printf '%s' "$raw_content" | "$AIRC_PYTHON" -m airc_core.gistparse get .airc 2>/dev/null)
-      kind=$(printf '%s' "$raw_content" | "$AIRC_PYTHON" -m airc_core.gistparse get .kind 2>/dev/null)
+      airc_ver=$(printf '%s' "$raw_content" | "$(airc_rs_bin)" gist get .airc 2>/dev/null)
+      kind=$(printf '%s' "$raw_content" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
       if [ -n "$airc_ver" ]; then
           # Versioned envelope — dispatch on kind.
           case "$kind" in
@@ -1392,7 +1392,7 @@ cmd_connect() {
               # Single-pair invite (legacy + --no-general flow). Gist is
               # ephemeral; host deletes after pair.
               resolved=$(printf '%s' "$raw_content" \
-                         | "$AIRC_PYTHON" -m airc_core.gistparse get .invite 2>/dev/null \
+                         | "$(airc_rs_bin)" gist get .invite 2>/dev/null \
                          | head -1 | tr -d '\r\n ')
               ;;
             mesh|room)
@@ -1404,21 +1404,21 @@ cmd_connect() {
               # yet (joiner can read either). The .invite field carries
               # today's name@user@host:port#pubkey string.
               resolved=$(printf '%s' "$raw_content" \
-                         | "$AIRC_PYTHON" -m airc_core.gistparse get .invite 2>/dev/null \
+                         | "$(airc_rs_bin)" gist get .invite 2>/dev/null \
                          | head -1 | tr -d '\r\n ')
               # New mesh shape: .channels[]; legacy room shape: .name.
               # Prefer channels[0] if present; fall back to .name.
               resolved_room_name=$(printf '%s' "$raw_content" \
-                         | "$AIRC_PYTHON" -m airc_core.gistparse get_first_of '.channels[0]' '.name' 2>/dev/null)
+                         | "$(airc_rs_bin)" gist get-first-of '.channels[0]' '.name' 2>/dev/null)
               # Multi-address: capture host.addresses[] + host.machine_id
               # for the joiner's address-picker (peer_pick_address). Empty
               # if the host published a pre-multi-address envelope; in
               # that case JOIN MODE falls back to the parsed-from-invite
               # host:port (legacy single-address path).
               _resolved_addresses_json=$(printf '%s' "$raw_content" \
-                         | "$AIRC_PYTHON" -m airc_core.gistparse get_json .host.addresses 2>/dev/null)
+                         | "$(airc_rs_bin)" gist get-json .host.addresses 2>/dev/null)
               _resolved_host_machine_id=$(printf '%s' "$raw_content" \
-                         | "$AIRC_PYTHON" -m airc_core.gistparse get .host.machine_id 2>/dev/null)
+                         | "$(airc_rs_bin)" gist get .host.machine_id 2>/dev/null)
 
               # Heartbeat freshness check — the structural fix for
               # orphan-gist class. Hosts update last_heartbeat every
@@ -1431,7 +1431,7 @@ cmd_connect() {
               # compat; their hosts will get caught by the existing
               # SSH-failure self-heal path at line ~1850.
               local _hb_iso _hb_ts _now_ts _hb_stale_sec
-              _hb_iso=$(printf '%s' "$raw_content" | "$AIRC_PYTHON" -m airc_core.gistparse get .last_heartbeat 2>/dev/null)
+              _hb_iso=$(printf '%s' "$raw_content" | "$(airc_rs_bin)" gist get .last_heartbeat 2>/dev/null)
               _hb_stale_sec="${AIRC_HEARTBEAT_STALE:-90}"
               if [ -n "$_hb_iso" ]; then
                 # Cross-platform ISO→epoch via the iso_to_epoch adapter.

--- a/lib/airc_bash/mesh.sh
+++ b/lib/airc_bash/mesh.sh
@@ -130,10 +130,10 @@ _mesh_age_secs() {
   local content
   if [ -n "$channel" ]; then
     content=$(gh api "gists/$gist_id" 2>/dev/null \
-      | "$AIRC_PYTHON" -m airc_core.gistparse gist_content --channel "$channel" 2>/dev/null || true)
+      | "$(airc_rs_bin)" gist gist-content --channel "$channel" 2>/dev/null || true)
   else
     content=$(gh api "gists/$gist_id" 2>/dev/null \
-      | "$AIRC_PYTHON" -m airc_core.gistparse gist_content 2>/dev/null || true)
+      | "$(airc_rs_bin)" gist gist-content 2>/dev/null || true)
   fi
   [ -z "$content" ] && return 0
   local hb; hb=$(printf '%s' "$content" | "$AIRC_PYTHON" -c '

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -111,6 +111,19 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("airc_core.logs", body)
         self.assertIn('"$(airc_rs_bin)" log "$@"', body)
 
+    def test_gistparse_runtime_paths_use_airc_rs(self):
+        files = [
+            REPO / "airc",
+            REPO / "lib/airc_bash/mesh.sh",
+            REPO / "lib/airc_bash/cmd_connect.sh",
+        ]
+        for path in files:
+            source = path.read_text(encoding="utf-8")
+            self.assertNotIn("airc_core.gistparse", source, path)
+        combined = "\n".join(path.read_text(encoding="utf-8") for path in files)
+        self.assertIn('"$(airc_rs_bin)" gist get .airc', combined)
+        self.assertIn('"$(airc_rs_bin)" gist gist-content', combined)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary
- add `airc-rs gist` parser commands for legacy gist envelope JSON
- route address picking and gist-content extraction through Rust instead of `airc_core.gistparse`
- add parser unit coverage for path navigation, address filtering, channel-aware gist content, and heartbeat ordering
- add cutover guard so shell runtime paths do not reintroduce Python gistparse

Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-cli --check`
- `cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml -p airc-cli gist_commands`
- `python3 test/test_codex_rust_cutover.py`
- `bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh`
- `printf '%s\n' '[{"scope":"localhost","addr":"127.0.0.1","port":"7547"},{"scope":"lan","addr":"192.168.1.42","port":"7547","subnet":"192.168.1.0/24"}]' | cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- gist pick-addr-excluding localhost`
- `printf '%s\n' '{"airc":1,"kind":"mesh","channels":["general"],"host":{"addresses":[{"scope":"lan","addr":"192.168.1.42","port":7547}]}}' | cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- gist get-json .host.addresses`
- `cargo test --manifest-path Cargo.toml --workspace`

Note
This is the parser cutover only. The GitHub gist wire should become a normal `airc-transport` adapter next, so we can remove the remaining shell/Python transport glue instead of extending it.
