### PR TITLE
feat(airc-transport): add gh gist bootstrap adapter

### DIFF
--- a/crates/airc-transport/Cargo.toml
+++ b/crates/airc-transport/Cargo.toml
@@ -10,7 +10,7 @@ airc-core = { path = "../airc-core" }
 airc-protocol = { path = "../airc-protocol" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["fs", "io-util", "net", "rt", "rt-multi-thread", "sync", "time", "macros"] }
+tokio = { version = "1", features = ["fs", "io-util", "net", "process", "rt", "rt-multi-thread", "sync", "time", "macros"] }
 async-trait = "0.1"
 futures = "0.3"
 fs2 = "0.4"

--- a/crates/airc-transport/src/gh_gist/adapter.rs
+++ b/crates/airc-transport/src/gh_gist/adapter.rs
@@ -1,0 +1,280 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::Stream;
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+
+use airc_core::TranscriptCursor;
+use airc_protocol::{Frame, FrameKind, Subscription};
+
+use crate::transport::{FrameStream, Transport};
+
+use super::client::{GhCliClient, GistClient};
+use super::error::GhGistError;
+
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(15);
+const RECEIVER_CHANNEL_DEPTH: usize = 64;
+
+pub struct GhGistAdapter<C = GhCliClient> {
+    gist_id: String,
+    client: Arc<C>,
+    poll_interval: Duration,
+}
+
+impl GhGistAdapter<GhCliClient> {
+    pub fn new(gist_id: impl Into<String>) -> Self {
+        Self::with_client(gist_id, GhCliClient::new())
+    }
+}
+
+impl<C> GhGistAdapter<C>
+where
+    C: GistClient + 'static,
+{
+    pub fn with_client(gist_id: impl Into<String>, client: C) -> Self {
+        Self {
+            gist_id: gist_id.into(),
+            client: Arc::new(client),
+            poll_interval: DEFAULT_POLL_INTERVAL,
+        }
+    }
+
+    pub fn with_poll_interval(mut self, poll_interval: Duration) -> Self {
+        self.poll_interval = poll_interval;
+        self
+    }
+}
+
+#[async_trait]
+impl<C> Transport for GhGistAdapter<C>
+where
+    C: GistClient + 'static,
+{
+    type Error = GhGistError;
+
+    async fn send(&self, frame: Frame) -> Result<(), Self::Error> {
+        let mut content = self.client.get_messages(&self.gist_id).await?;
+        let serialized = serde_json::to_string(&frame)?;
+        if !content.is_empty() && !content.ends_with('\n') {
+            content.push('\n');
+        }
+        content.push_str(&serialized);
+        content.push('\n');
+        self.client.put_messages(&self.gist_id, &content).await
+    }
+
+    async fn subscribe(
+        &self,
+        subscription: Subscription,
+    ) -> Result<FrameStream<Self::Error>, Self::Error> {
+        let initial_seen = if subscription.from_cursor.is_some() {
+            0
+        } else {
+            self.client
+                .get_messages(&self.gist_id)
+                .await?
+                .lines()
+                .count()
+        };
+        let gist_id = self.gist_id.clone();
+        let client = Arc::clone(&self.client);
+        let poll_interval = self.poll_interval;
+        let (tx, rx) = mpsc::channel(RECEIVER_CHANNEL_DEPTH);
+
+        tokio::spawn(async move {
+            tail_loop(
+                client,
+                gist_id,
+                subscription,
+                initial_seen,
+                poll_interval,
+                tx.clone(),
+            )
+            .await;
+        });
+
+        let stream = futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        });
+        Ok(Box::pin(stream) as Pin<Box<dyn Stream<Item = _> + Send>>)
+    }
+}
+
+async fn tail_loop<C>(
+    client: Arc<C>,
+    gist_id: String,
+    subscription: Subscription,
+    mut seen_lines: usize,
+    poll_interval: Duration,
+    tx: mpsc::Sender<Result<Frame, GhGistError>>,
+) where
+    C: GistClient + 'static,
+{
+    loop {
+        if tx.is_closed() {
+            return;
+        }
+
+        match client.get_messages(&gist_id).await {
+            Ok(content) => {
+                let lines = content.lines().collect::<Vec<_>>();
+                if seen_lines > lines.len() {
+                    seen_lines = 0;
+                }
+                for line in &lines[seen_lines..] {
+                    let frame = match serde_json::from_str::<Frame>(line) {
+                        Ok(frame) => frame,
+                        Err(error) => {
+                            let _ = tx.send(Err(GhGistError::Json(error))).await;
+                            return;
+                        }
+                    };
+                    if !subscription.matches(&frame) {
+                        continue;
+                    }
+                    if let Some(cursor) = &subscription.from_cursor {
+                        if !frame_after_cursor(&frame, cursor) {
+                            continue;
+                        }
+                    }
+                    if dispatch_frame(&tx, frame).await.is_err() {
+                        return;
+                    }
+                }
+                seen_lines = lines.len();
+            }
+            Err(error) => {
+                let _ = tx.send(Err(error)).await;
+                return;
+            }
+        }
+
+        sleep(poll_interval).await;
+    }
+}
+
+async fn dispatch_frame(
+    tx: &mpsc::Sender<Result<Frame, GhGistError>>,
+    frame: Frame,
+) -> Result<(), ()> {
+    match frame.kind {
+        FrameKind::Message | FrameKind::Control => tx.send(Ok(frame)).await.map_err(|_| ()),
+        FrameKind::Event => match tx.try_send(Ok(frame)) {
+            Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => Ok(()),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(()),
+        },
+    }
+}
+
+fn frame_after_cursor(frame: &Frame, cursor: &TranscriptCursor) -> bool {
+    let envelope = &frame.envelope;
+    envelope.lamport > cursor.lamport
+        || (envelope.lamport == cursor.lamport
+            && envelope.event_id.as_uuid() > cursor.event_id.as_uuid())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::EventId;
+    use airc_core::{headers::Headers, transcript::MentionTarget, Body, ClientId, PeerId, RoomId};
+    use airc_protocol::{Envelope, Signature};
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct MemoryGistClient {
+        content: Mutex<String>,
+    }
+
+    #[async_trait]
+    impl GistClient for MemoryGistClient {
+        async fn get_messages(&self, _gist_id: &str) -> Result<String, GhGistError> {
+            Ok(self.content.lock().unwrap().clone())
+        }
+
+        async fn put_messages(&self, _gist_id: &str, content: &str) -> Result<(), GhGistError> {
+            *self.content.lock().unwrap() = content.to_string();
+            Ok(())
+        }
+    }
+
+    fn frame_at(lamport: u64, channel: RoomId, body: &str) -> Frame {
+        Frame {
+            kind: FrameKind::Message,
+            envelope: Envelope {
+                event_id: EventId::from_u128(lamport as u128),
+                sender: PeerId::from_u128(0xa1),
+                sender_client: ClientId::from_u128(0xc1),
+                channel,
+                target: MentionTarget::All,
+                lamport,
+                occurred_at_ms: 1_700_000_000_000 + lamport,
+                reply_to: None,
+                headers: Headers::new(),
+                body: Some(Body::text(body)),
+                media: Vec::new(),
+                signature: Signature::Unsigned,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn send_appends_frame_to_messages_file_content() {
+        let adapter = GhGistAdapter::with_client("gist-a", MemoryGistClient::default());
+        let channel = RoomId::from_u128(0xc0ffee);
+
+        adapter
+            .send(frame_at(1, channel, "hello over gist"))
+            .await
+            .unwrap();
+
+        let content = adapter.client.get_messages("gist-a").await.unwrap();
+        let stored: Frame = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(
+            stored.envelope.body.as_ref().and_then(Body::as_text),
+            Some("hello over gist")
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_replays_from_cursor_and_filters_channel() {
+        let client = MemoryGistClient::default();
+        let adapter = GhGistAdapter::with_client("gist-a", client)
+            .with_poll_interval(Duration::from_millis(5));
+        let channel = RoomId::from_u128(0xc0ffee);
+        let other = RoomId::from_u128(0xbad);
+        adapter
+            .send(frame_at(1, other, "wrong room"))
+            .await
+            .unwrap();
+        adapter
+            .send(frame_at(2, channel, "right room"))
+            .await
+            .unwrap();
+
+        let mut stream = adapter
+            .subscribe(Subscription {
+                channel: Some(channel),
+                from_cursor: Some(TranscriptCursor {
+                    lamport: 0,
+                    event_id: EventId::from_u128(0),
+                }),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let received = tokio::time::timeout(
+            Duration::from_secs(1),
+            futures::StreamExt::next(&mut stream),
+        )
+        .await
+        .expect("must yield")
+        .expect("stream open")
+        .expect("frame ok");
+        assert_eq!(received.envelope.lamport, 2);
+    }
+}

--- a/crates/airc-transport/src/gh_gist/client.rs
+++ b/crates/airc-transport/src/gh_gist/client.rs
@@ -1,0 +1,109 @@
+use async_trait::async_trait;
+use serde_json::Value;
+use std::path::PathBuf;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+use super::error::GhGistError;
+
+const MESSAGES_FILE: &str = "messages.jsonl";
+
+#[async_trait]
+pub trait GistClient: Send + Sync {
+    async fn get_messages(&self, gist_id: &str) -> Result<String, GhGistError>;
+    async fn put_messages(&self, gist_id: &str, content: &str) -> Result<(), GhGistError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct GhCliClient {
+    gh_bin: PathBuf,
+}
+
+impl GhCliClient {
+    pub fn new() -> Self {
+        Self {
+            gh_bin: PathBuf::from("gh"),
+        }
+    }
+
+    pub fn with_bin(gh_bin: impl Into<PathBuf>) -> Self {
+        Self {
+            gh_bin: gh_bin.into(),
+        }
+    }
+}
+
+impl Default for GhCliClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl GistClient for GhCliClient {
+    async fn get_messages(&self, gist_id: &str) -> Result<String, GhGistError> {
+        let output = Command::new(&self.gh_bin)
+            .args(["api", &format!("gists/{gist_id}")])
+            .output()
+            .await
+            .map_err(|error| GhGistError::Client(error.to_string()))?;
+        if !output.status.success() {
+            return Err(GhGistError::Client(
+                String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            ));
+        }
+        let gist: Value = serde_json::from_slice(&output.stdout)?;
+        Ok(gist
+            .get("files")
+            .and_then(|files| files.get(MESSAGES_FILE))
+            .and_then(|file| file.get("content"))
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string())
+    }
+
+    async fn put_messages(&self, gist_id: &str, content: &str) -> Result<(), GhGistError> {
+        let body = serde_json::json!({
+            "files": {
+                MESSAGES_FILE: {
+                    "content": content,
+                }
+            }
+        });
+        let mut child = Command::new(&self.gh_bin)
+            .args([
+                "api",
+                "--method",
+                "PATCH",
+                &format!("gists/{gist_id}"),
+                "--input",
+                "-",
+            ])
+            .stdin(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|error| GhGistError::Client(error.to_string()))?;
+
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| GhGistError::Client("failed to open gh stdin".to_string()))?;
+        stdin
+            .write_all(body.to_string().as_bytes())
+            .await
+            .map_err(|error| GhGistError::Client(error.to_string()))?;
+        drop(stdin);
+
+        let output = child
+            .wait_with_output()
+            .await
+            .map_err(|error| GhGistError::Client(error.to_string()))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(GhGistError::Client(
+                String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            ))
+        }
+    }
+}

--- a/crates/airc-transport/src/gh_gist/error.rs
+++ b/crates/airc-transport/src/gh_gist/error.rs
@@ -1,0 +1,31 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum GhGistError {
+    Client(String),
+    Json(serde_json::Error),
+}
+
+impl fmt::Display for GhGistError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Client(error) => write!(f, "gh-gist transport client: {error}"),
+            Self::Json(error) => write!(f, "gh-gist transport frame parse: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for GhGistError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Client(_) => None,
+            Self::Json(error) => Some(error),
+        }
+    }
+}
+
+impl From<serde_json::Error> for GhGistError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}

--- a/crates/airc-transport/src/gh_gist/mod.rs
+++ b/crates/airc-transport/src/gh_gist/mod.rs
@@ -1,0 +1,18 @@
+//! GitHub gist bootstrap/migration transport.
+//!
+//! This adapter exists to contain the old gist-backed message wire
+//! behind the same `Transport` trait while AIRC moves to real peer
+//! transports. It is not intended as the steady-state chat path:
+//! GitHub can help peers discover each other and exchange bootstrap
+//! metadata, then LAN/Tailscale/relay transports should carry the
+//! runtime stream. Nothing in this module is wired as automatic
+//! fallback; consumers must opt into it deliberately for migration or
+//! rendezvous work.
+
+mod adapter;
+mod client;
+mod error;
+
+pub use adapter::GhGistAdapter;
+pub use client::{GhCliClient, GistClient};
+pub use error::GhGistError;

--- a/crates/airc-transport/src/lib.rs
+++ b/crates/airc-transport/src/lib.rs
@@ -11,15 +11,17 @@
 //!   when multiple AI agents share one Mac.
 //! - **lan-tcp** (PR-3) — same-LAN peer-to-peer via TLS-wrapped TCP.
 //! - **tailscale** (PR-4) — mesh transport for cross-network peers.
-//! - **gh-gist** (legacy adapter, eventual removal) — wraps the
-//!   current Python-airc gist transport so a Rust peer can talk to a
-//!   Python peer during the migration window.
+//! - **gh-gist** (legacy migration adapter only) — lets Rust peers
+//!   interoperate with the old gist wire long enough to delete it.
+//!   It must not become a primary runtime path; GitHub is acceptable
+//!   for bootstrap/discovery, not sustained chat transport.
 //!
 //! Designed agent-first. The canonical caller is an AI peer sending
 //! frames to other AI peers; human-chat features (typing, presence)
 //! ride on top via `FrameKind::Event` and headers.
 
 pub mod error;
+pub mod gh_gist;
 pub mod lan_tcp;
 pub mod local_fs;
 pub mod signed;
@@ -27,6 +29,7 @@ pub mod transport;
 
 // Re-exports — stable public surface.
 pub use error::LocalFsError;
+pub use gh_gist::{GhCliClient, GhGistAdapter, GhGistError, GistClient};
 pub use lan_tcp::{
     build_client_config, build_server_config, extract_ed25519_pubkey, generate_self_signed_cert,
     CertGenError, CertParseError, LanTcpAdapter, LanTcpError, PinnedClientVerifier,


### PR DESCRIPTION
Summary
- add a `gh_gist` transport module behind the existing `Transport` trait
- isolate GitHub CLI access behind a small `GistClient` trait so the adapter contract is testable without gh/network
- document GitHub gist as bootstrap/migration only, not automatic fallback or sustained chat transport
- add in-memory transport tests for append/send and cursor replay/channel filtering

Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-transport --check`
- `cargo clippy --manifest-path Cargo.toml -p airc-transport --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml -p airc-transport gh_gist`
- `cargo test --manifest-path Cargo.toml --workspace`

Boundary
This does not wire GitHub as a default runtime path. It contains the legacy gist wire under the transport contract so resolver policy can explicitly restrict it to rendezvous / migration, then delete it once LAN/Tailscale/relay bootstrap is proven.
