### PR TITLE
feat(airc-lib): add explicit transport route policy

### DIFF
--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -27,6 +27,7 @@ mod messaging;
 mod peers;
 pub mod registry;
 pub mod room;
+pub mod route_policy;
 mod stream;
 mod time;
 mod transport;
@@ -37,6 +38,9 @@ pub use error::AircError;
 pub use peers::EnrolledPeer;
 pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use room::Room;
+pub use route_policy::{
+    RouteDecision, RoutePolicy, RoutePurpose, TransportCandidate, TransportKind, TransportRole,
+};
 pub use stream::{EventFilter, EventStream, FilteredEventStream, LiveLag};
 pub use work::{
     AllocateWorkspace, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard, CreateWorkCard,

--- a/crates/airc-lib/src/route_policy.rs
+++ b/crates/airc-lib/src/route_policy.rs
@@ -1,0 +1,194 @@
+//! Transport route policy for consumer-facing AIRC embeddings.
+//!
+//! The important invariant is negative: GitHub is not a transparent
+//! runtime fallback. It can carry rendezvous / migration frames when a
+//! caller explicitly chooses that purpose, but normal chat/data routing
+//! must use direct transports or fail loudly.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RoutePurpose {
+    /// Normal durable conversation / work traffic.
+    Data,
+    /// Interrupt-style live events such as presence or turn steering.
+    LiveEvent,
+    /// Initial peer discovery / rendezvous metadata.
+    Bootstrap,
+    /// Temporary interop with the legacy gist wire during cutover.
+    Migration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TransportKind {
+    LocalFs,
+    LanTcp,
+    Tailscale,
+    Reticulum,
+    Relay,
+    GhGist,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TransportRole {
+    Direct,
+    Relay,
+    BootstrapOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TransportCandidate {
+    pub kind: TransportKind,
+    pub role: TransportRole,
+    pub healthy: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteDecision {
+    Selected(TransportKind),
+    NoRoute { purpose: RoutePurpose },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RoutePolicy;
+
+impl RoutePolicy {
+    pub fn choose(
+        &self,
+        purpose: RoutePurpose,
+        candidates: impl IntoIterator<Item = TransportCandidate>,
+    ) -> RouteDecision {
+        candidates
+            .into_iter()
+            .filter(|candidate| candidate.healthy)
+            .filter(|candidate| allows(purpose, *candidate))
+            .min_by_key(|candidate| priority(purpose, candidate.kind))
+            .map(|candidate| RouteDecision::Selected(candidate.kind))
+            .unwrap_or(RouteDecision::NoRoute { purpose })
+    }
+}
+
+fn allows(purpose: RoutePurpose, candidate: TransportCandidate) -> bool {
+    match candidate.kind {
+        TransportKind::GhGist => {
+            matches!(purpose, RoutePurpose::Bootstrap | RoutePurpose::Migration)
+                && candidate.role == TransportRole::BootstrapOnly
+        }
+        TransportKind::LocalFs
+        | TransportKind::LanTcp
+        | TransportKind::Tailscale
+        | TransportKind::Reticulum => candidate.role == TransportRole::Direct,
+        TransportKind::Relay => candidate.role == TransportRole::Relay,
+    }
+}
+
+fn priority(purpose: RoutePurpose, kind: TransportKind) -> u8 {
+    match purpose {
+        RoutePurpose::Data | RoutePurpose::LiveEvent => match kind {
+            TransportKind::LocalFs => 0,
+            TransportKind::LanTcp => 1,
+            TransportKind::Tailscale => 2,
+            TransportKind::Reticulum => 3,
+            TransportKind::Relay => 4,
+            TransportKind::GhGist => 255,
+        },
+        RoutePurpose::Bootstrap | RoutePurpose::Migration => match kind {
+            TransportKind::LocalFs => 0,
+            TransportKind::LanTcp => 1,
+            TransportKind::Tailscale => 2,
+            TransportKind::Reticulum => 3,
+            TransportKind::Relay => 4,
+            TransportKind::GhGist => 5,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(kind: TransportKind, role: TransportRole) -> TransportCandidate {
+        TransportCandidate {
+            kind,
+            role,
+            healthy: true,
+        }
+    }
+
+    #[test]
+    fn data_routes_never_select_github_as_fallback() {
+        let policy = RoutePolicy;
+        let decision = policy.choose(
+            RoutePurpose::Data,
+            [candidate(
+                TransportKind::GhGist,
+                TransportRole::BootstrapOnly,
+            )],
+        );
+
+        assert_eq!(
+            decision,
+            RouteDecision::NoRoute {
+                purpose: RoutePurpose::Data
+            }
+        );
+    }
+
+    #[test]
+    fn bootstrap_can_use_github_when_no_direct_route_exists() {
+        let policy = RoutePolicy;
+        let decision = policy.choose(
+            RoutePurpose::Bootstrap,
+            [candidate(
+                TransportKind::GhGist,
+                TransportRole::BootstrapOnly,
+            )],
+        );
+
+        assert_eq!(decision, RouteDecision::Selected(TransportKind::GhGist));
+    }
+
+    #[test]
+    fn direct_routes_beat_github_even_for_bootstrap() {
+        let policy = RoutePolicy;
+        let decision = policy.choose(
+            RoutePurpose::Bootstrap,
+            [
+                candidate(TransportKind::GhGist, TransportRole::BootstrapOnly),
+                candidate(TransportKind::LanTcp, TransportRole::Direct),
+            ],
+        );
+
+        assert_eq!(decision, RouteDecision::Selected(TransportKind::LanTcp));
+    }
+
+    #[test]
+    fn unhealthy_candidates_are_ignored() {
+        let policy = RoutePolicy;
+        let decision = policy.choose(
+            RoutePurpose::Data,
+            [
+                TransportCandidate {
+                    kind: TransportKind::LocalFs,
+                    role: TransportRole::Direct,
+                    healthy: false,
+                },
+                candidate(TransportKind::LanTcp, TransportRole::Direct),
+            ],
+        );
+
+        assert_eq!(decision, RouteDecision::Selected(TransportKind::LanTcp));
+    }
+
+    #[test]
+    fn reticulum_is_a_direct_transport_not_a_github_fallback() {
+        let policy = RoutePolicy;
+        let decision = policy.choose(
+            RoutePurpose::Data,
+            [
+                candidate(TransportKind::GhGist, TransportRole::BootstrapOnly),
+                candidate(TransportKind::Reticulum, TransportRole::Direct),
+            ],
+        );
+
+        assert_eq!(decision, RouteDecision::Selected(TransportKind::Reticulum));
+    }
+}


### PR DESCRIPTION
Summary
- add `airc-lib::route_policy` with typed route purposes, transport kinds, roles, and decisions
- make GitHub gist selectable only for explicit bootstrap/migration purposes
- add Reticulum as a first-class direct transport kind for Continuum planning
- prefer direct transports over GitHub even for bootstrap when direct transport is healthy
- export the route policy types for Continuum/OpenClaw/Hermes/opencode consumers

Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-lib --check`
- `cargo clippy --manifest-path Cargo.toml -p airc-lib --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml -p airc-lib route_policy`
- `cargo test --manifest-path Cargo.toml --workspace`

Boundary
This is policy only. It does not wire a new runtime resolver yet. The point is to make the no-silent-GitHub-fallback rule executable before the resolver starts selecting among local-fs, LAN, Tailscale, Reticulum, relay, and GitHub bootstrap records.
