### PR TITLE
feat(airc-lib): feed resolver from transport health

### DIFF
--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -27,6 +27,7 @@ mod messaging;
 mod peers;
 pub mod registry;
 pub mod room;
+pub mod route_health;
 pub mod route_policy;
 pub mod route_resolver;
 mod stream;
@@ -39,6 +40,7 @@ pub use error::AircError;
 pub use peers::EnrolledPeer;
 pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use room::Room;
+pub use route_health::{TransportHealthSample, TransportHealthState};
 pub use route_policy::{
     RouteDecision, RoutePolicy, RoutePurpose, TransportCandidate, TransportKind, TransportRole,
 };

--- a/crates/airc-lib/src/route_health.rs
+++ b/crates/airc-lib/src/route_health.rs
@@ -1,0 +1,94 @@
+//! Health input model for transport resolution.
+//!
+//! Discovery/probe code feeds this layer; the resolver consumes plain
+//! candidates. Keeping the conversion explicit prevents "transport
+//! exists" from being confused with "transport is usable now."
+
+use crate::route_policy::{TransportCandidate, TransportKind, TransportRole};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TransportHealthState {
+    Healthy,
+    Degraded,
+    Down,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TransportHealthSample {
+    pub kind: TransportKind,
+    pub role: TransportRole,
+    pub state: TransportHealthState,
+    /// Optional latency observation. `None` means not measured yet.
+    pub rtt_ms: Option<u32>,
+    /// Optional success rate in parts-per-million. `1_000_000` means
+    /// all recent attempts succeeded.
+    pub success_ppm: Option<u32>,
+}
+
+impl TransportHealthSample {
+    pub fn candidate(self) -> TransportCandidate {
+        TransportCandidate {
+            kind: self.kind,
+            role: self.role,
+            healthy: matches!(
+                self.state,
+                TransportHealthState::Healthy | TransportHealthState::Degraded
+            ),
+        }
+    }
+
+    pub fn healthy_direct(kind: TransportKind) -> Self {
+        Self {
+            kind,
+            role: TransportRole::Direct,
+            state: TransportHealthState::Healthy,
+            rtt_ms: None,
+            success_ppm: None,
+        }
+    }
+
+    pub fn down(kind: TransportKind, role: TransportRole) -> Self {
+        Self {
+            kind,
+            role,
+            state: TransportHealthState::Down,
+            rtt_ms: None,
+            success_ppm: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn down_health_maps_to_unhealthy_candidate() {
+        let candidate =
+            TransportHealthSample::down(TransportKind::Reticulum, TransportRole::Direct)
+                .candidate();
+
+        assert_eq!(
+            candidate,
+            TransportCandidate {
+                kind: TransportKind::Reticulum,
+                role: TransportRole::Direct,
+                healthy: false,
+            }
+        );
+    }
+
+    #[test]
+    fn degraded_health_is_still_candidate_usable() {
+        let candidate = TransportHealthSample {
+            kind: TransportKind::LanTcp,
+            role: TransportRole::Direct,
+            state: TransportHealthState::Degraded,
+            rtt_ms: Some(120),
+            success_ppm: Some(800_000),
+        }
+        .candidate();
+
+        assert!(candidate.healthy);
+    }
+}

--- a/crates/airc-lib/src/route_resolver.rs
+++ b/crates/airc-lib/src/route_resolver.rs
@@ -6,6 +6,7 @@
 //! slices can add health probes/discovery without changing the rule
 //! that GitHub is bootstrap/migration only.
 
+use crate::route_health::TransportHealthSample;
 use crate::route_policy::{
     RouteDecision, RoutePolicy, RoutePurpose, TransportCandidate, TransportKind,
 };
@@ -29,12 +30,20 @@ impl TransportResolver {
         }
     }
 
+    pub fn from_health(samples: impl IntoIterator<Item = TransportHealthSample>) -> Self {
+        Self::new(samples.into_iter().map(TransportHealthSample::candidate))
+    }
+
     pub fn candidates(&self) -> &[TransportCandidate] {
         &self.candidates
     }
 
     pub fn replace_candidates(&mut self, candidates: impl IntoIterator<Item = TransportCandidate>) {
         self.candidates = candidates.into_iter().collect();
+    }
+
+    pub fn replace_health(&mut self, samples: impl IntoIterator<Item = TransportHealthSample>) {
+        self.replace_candidates(samples.into_iter().map(TransportHealthSample::candidate));
     }
 
     pub fn resolve(&self, purpose: RoutePurpose) -> Result<TransportRoute, RouteDecision> {
@@ -48,6 +57,7 @@ impl TransportResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::route_health::{TransportHealthSample, TransportHealthState};
     use crate::route_policy::{TransportKind::*, TransportRole};
 
     fn candidate(kind: TransportKind, role: TransportRole) -> TransportCandidate {
@@ -103,6 +113,25 @@ mod tests {
         );
 
         resolver.replace_candidates([candidate(Reticulum, TransportRole::Direct)]);
+
+        assert_eq!(
+            resolver.resolve(RoutePurpose::Data),
+            Ok(TransportRoute { kind: Reticulum })
+        );
+    }
+
+    #[test]
+    fn resolver_can_build_candidates_from_health_samples() {
+        let resolver = TransportResolver::from_health([
+            TransportHealthSample::down(LanTcp, TransportRole::Direct),
+            TransportHealthSample {
+                kind: Reticulum,
+                role: TransportRole::Direct,
+                state: TransportHealthState::Healthy,
+                rtt_ms: Some(80),
+                success_ppm: Some(1_000_000),
+            },
+        ]);
 
         assert_eq!(
             resolver.resolve(RoutePurpose::Data),


### PR DESCRIPTION
Summary
- add `TransportHealthSample` and `TransportHealthState` for resolver inputs
- let `TransportResolver` build and refresh candidates from measured health samples
- keep route policy separate from health measurement so discovery/probes cannot bypass GitHub bootstrap-only rules
- add tests for down/degraded mapping and Reticulum selection from health inputs

Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-lib --check`
- `cargo clippy --manifest-path Cargo.toml -p airc-lib --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml -p airc-lib route_`
- `cargo test --manifest-path Cargo.toml --workspace`

Boundary
This is still resolver plumbing, not transport probing. Later LAN/Tailscale/Reticulum probes should produce these health samples; the resolver then applies the existing no-silent-GitHub-fallback policy.
