### PR TITLE
feat(airc-rs): expose transport route status

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -18,6 +18,7 @@ use airc_lib::PeerSpec;
 
 use crate::codex_cli::{CodexHookArgs, CodexStartArgs};
 use crate::gist_cli::GistArgs;
+use crate::route_cli::RouteArgs;
 use crate::work_cli::WorkArgs;
 
 /// Default home directory for persisted identity + IPC state.
@@ -195,6 +196,9 @@ pub enum Command {
 
     /// Manage the persisted peer registry (`<home>/peers.json`).
     Peer(PeerArgs),
+
+    /// Inspect transport route policy and candidate selection.
+    Route(RouteArgs),
 
     /// Inspect persisted events through subscription-style filters.
     Events(crate::events_cli::EventsArgs),

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -29,6 +29,8 @@ mod lane_cli;
 mod lane_commands;
 mod log_cli;
 mod log_commands;
+mod route_cli;
+mod route_commands;
 mod work_cli;
 mod work_commands;
 mod workspace_cli;
@@ -50,6 +52,7 @@ use events_cli::EventsAction;
 use gist_cli::GistAction;
 use lane_cli::{LaneAction, LaneManagerAction};
 use log_cli::LogAction;
+use route_cli::RouteAction;
 use work_cli::WorkAction;
 use workspace_cli::WorkspaceAction;
 
@@ -137,6 +140,10 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 commands::run_peer_add(&home, spec, default_or(socket, &home)).await
             }
             PeerAction::List => commands::run_peer_list(&home).await,
+        },
+
+        Command::Route(args) => match args.action {
+            RouteAction::Status(args) => route_commands::run_status(args),
         },
 
         Command::Events(args) => match args.action {

--- a/crates/airc-cli/src/route_cli.rs
+++ b/crates/airc-cli/src/route_cli.rs
@@ -1,0 +1,72 @@
+use clap::{Args, Subcommand, ValueEnum};
+
+#[derive(Debug, Args)]
+pub struct RouteArgs {
+    #[command(subcommand)]
+    pub action: RouteAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum RouteAction {
+    /// Show route candidates and policy decisions.
+    Status(RouteStatusArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct RouteStatusArgs {
+    /// Add a healthy direct transport candidate.
+    #[arg(long = "direct", value_enum)]
+    pub direct: Vec<RouteTransport>,
+
+    /// Add a healthy relay transport candidate.
+    #[arg(long = "relay", value_enum)]
+    pub relay: Vec<RouteTransport>,
+
+    /// Add a healthy bootstrap-only transport candidate.
+    #[arg(long = "bootstrap", value_enum)]
+    pub bootstrap: Vec<RouteTransport>,
+
+    /// Mark a transport down. Format: `<transport>:<role>`, e.g.
+    /// `lan-tcp:direct` or `gh-gist:bootstrap-only`.
+    #[arg(long = "down")]
+    pub down: Vec<RouteHealthOverride>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum RouteTransport {
+    LocalFs,
+    LanTcp,
+    Tailscale,
+    Reticulum,
+    Relay,
+    GhGist,
+}
+
+#[derive(Debug, Clone)]
+pub struct RouteHealthOverride {
+    pub transport: RouteTransport,
+    pub role: RouteRole,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum RouteRole {
+    Direct,
+    Relay,
+    BootstrapOnly,
+}
+
+impl std::str::FromStr for RouteHealthOverride {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let Some((transport, role)) = value.split_once(':') else {
+            return Err("expected <transport>:<role>".to_string());
+        };
+
+        Ok(Self {
+            transport: RouteTransport::from_str(transport, true)
+                .map_err(|_| format!("unknown transport {transport:?}"))?,
+            role: RouteRole::from_str(role, true).map_err(|_| format!("unknown role {role:?}"))?,
+        })
+    }
+}

--- a/crates/airc-cli/src/route_commands.rs
+++ b/crates/airc-cli/src/route_commands.rs
@@ -1,0 +1,149 @@
+use airc_lib::{
+    RouteDecision, RoutePurpose, TransportHealthSample, TransportHealthState, TransportKind,
+    TransportResolver, TransportRole,
+};
+
+use crate::route_cli::{RouteHealthOverride, RouteRole, RouteStatusArgs, RouteTransport};
+
+pub fn run_status(args: RouteStatusArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let samples = health_samples(args);
+    let resolver = TransportResolver::from_health(samples.iter().copied());
+
+    println!("route candidates:");
+    for sample in &samples {
+        println!(
+            "- {} role={} state={}",
+            format_kind(sample.kind),
+            format_role(sample.role),
+            format_state(sample.state)
+        );
+    }
+
+    println!("route decisions:");
+    for purpose in [
+        RoutePurpose::Data,
+        RoutePurpose::LiveEvent,
+        RoutePurpose::Bootstrap,
+        RoutePurpose::Migration,
+    ] {
+        match resolver.resolve(purpose) {
+            Ok(route) => println!(
+                "- {} -> {}",
+                format_purpose(purpose),
+                format_kind(route.kind)
+            ),
+            Err(RouteDecision::NoRoute { .. }) => {
+                println!("- {} -> no-route", format_purpose(purpose));
+            }
+            Err(RouteDecision::Selected(_)) => unreachable!("selected routes are returned as Ok"),
+        }
+    }
+
+    Ok(())
+}
+
+fn health_samples(args: RouteStatusArgs) -> Vec<TransportHealthSample> {
+    let mut samples = Vec::new();
+
+    if args.direct.is_empty()
+        && args.relay.is_empty()
+        && args.bootstrap.is_empty()
+        && args.down.is_empty()
+    {
+        samples.push(TransportHealthSample::healthy_direct(
+            TransportKind::LocalFs,
+        ));
+        return samples;
+    }
+
+    samples.extend(
+        args.direct
+            .into_iter()
+            .map(|transport| healthy(transport, RouteRole::Direct)),
+    );
+    samples.extend(
+        args.relay
+            .into_iter()
+            .map(|transport| healthy(transport, RouteRole::Relay)),
+    );
+    samples.extend(
+        args.bootstrap
+            .into_iter()
+            .map(|transport| healthy(transport, RouteRole::BootstrapOnly)),
+    );
+    samples.extend(args.down.into_iter().map(down));
+    samples
+}
+
+fn healthy(transport: RouteTransport, role: RouteRole) -> TransportHealthSample {
+    TransportHealthSample {
+        kind: transport.into(),
+        role: role.into(),
+        state: TransportHealthState::Healthy,
+        rtt_ms: None,
+        success_ppm: None,
+    }
+}
+
+fn down(override_: RouteHealthOverride) -> TransportHealthSample {
+    TransportHealthSample::down(override_.transport.into(), override_.role.into())
+}
+
+fn format_purpose(purpose: RoutePurpose) -> &'static str {
+    match purpose {
+        RoutePurpose::Data => "data",
+        RoutePurpose::LiveEvent => "live-event",
+        RoutePurpose::Bootstrap => "bootstrap",
+        RoutePurpose::Migration => "migration",
+    }
+}
+
+fn format_kind(kind: TransportKind) -> &'static str {
+    match kind {
+        TransportKind::LocalFs => "local-fs",
+        TransportKind::LanTcp => "lan-tcp",
+        TransportKind::Tailscale => "tailscale",
+        TransportKind::Reticulum => "reticulum",
+        TransportKind::Relay => "relay",
+        TransportKind::GhGist => "gh-gist",
+    }
+}
+
+fn format_role(role: TransportRole) -> &'static str {
+    match role {
+        TransportRole::Direct => "direct",
+        TransportRole::Relay => "relay",
+        TransportRole::BootstrapOnly => "bootstrap-only",
+    }
+}
+
+fn format_state(state: TransportHealthState) -> &'static str {
+    match state {
+        TransportHealthState::Healthy => "healthy",
+        TransportHealthState::Degraded => "degraded",
+        TransportHealthState::Down => "down",
+    }
+}
+
+impl From<RouteTransport> for TransportKind {
+    fn from(value: RouteTransport) -> Self {
+        match value {
+            RouteTransport::LocalFs => Self::LocalFs,
+            RouteTransport::LanTcp => Self::LanTcp,
+            RouteTransport::Tailscale => Self::Tailscale,
+            RouteTransport::Reticulum => Self::Reticulum,
+            RouteTransport::Relay => Self::Relay,
+            RouteTransport::GhGist => Self::GhGist,
+        }
+    }
+}
+
+impl From<RouteRole> for TransportRole {
+    fn from(value: RouteRole) -> Self {
+        match value {
+            RouteRole::Direct => Self::Direct,
+            RouteRole::Relay => Self::Relay,
+            RouteRole::BootstrapOnly => Self::BootstrapOnly,
+        }
+    }
+}

--- a/crates/airc-cli/tests/route_commands.rs
+++ b/crates/airc-cli/tests/route_commands.rs
@@ -1,0 +1,66 @@
+//! End-to-end coverage for `airc-rs route ...`.
+
+use std::process::Command;
+
+fn airc_rs() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-rs")
+}
+
+#[test]
+fn route_status_defaults_to_local_runtime_route() {
+    let output = run_ok(&["route", "status"]);
+
+    assert!(output.contains("- local-fs role=direct state=healthy"));
+    assert!(output.contains("- data -> local-fs"));
+    assert!(output.contains("- live-event -> local-fs"));
+    assert!(!output.contains("gh-gist"));
+}
+
+#[test]
+fn route_status_keeps_github_bootstrap_only() {
+    let output = run_ok(&["route", "status", "--bootstrap", "gh-gist"]);
+
+    assert!(output.contains("- gh-gist role=bootstrap-only state=healthy"));
+    assert!(output.contains("- data -> no-route"));
+    assert!(output.contains("- live-event -> no-route"));
+    assert!(output.contains("- bootstrap -> gh-gist"));
+    assert!(output.contains("- migration -> gh-gist"));
+}
+
+#[test]
+fn route_status_prefers_direct_route_over_bootstrap_github() {
+    let output = run_ok(&[
+        "route",
+        "status",
+        "--bootstrap",
+        "gh-gist",
+        "--direct",
+        "reticulum",
+    ]);
+
+    assert!(output.contains("- data -> reticulum"));
+    assert!(output.contains("- bootstrap -> reticulum"));
+}
+
+#[test]
+fn route_status_down_override_removes_candidate() {
+    let output = run_ok(&["route", "status", "--down", "local-fs:direct"]);
+
+    assert!(output.contains("- local-fs role=direct state=down"));
+    assert!(output.contains("- data -> no-route"));
+}
+
+fn run_ok(args: &[&str]) -> String {
+    let output = Command::new(airc_rs())
+        .args(args)
+        .output()
+        .expect("airc-rs command must spawn");
+    assert!(
+        output.status.success(),
+        "airc-rs {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout utf-8")
+}


### PR DESCRIPTION
Summary
- add airc-rs route status for inspecting transport candidates and route decisions
- default no-arg route status to the common local-fs runtime route
- keep gh-gist explicit bootstrap-only and prove direct Reticulum beats it

Verification
- cargo fmt -p airc-cli --check
- cargo test -p airc-cli route_
- cargo clippy -p airc-cli --all-targets -- -D warnings
- cargo test --workspace
- cargo run -q -p airc-cli -- route status
- cargo run -q -p airc-cli -- route status --bootstrap gh-gist --direct reticulum
- cargo clippy --workspace --all-targets -- -D warnings