### PR TITLE
feat(airc-rs): read subscribed channels from rust

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -17,6 +17,7 @@ use clap::{Args, Parser, Subcommand};
 use airc_lib::PeerSpec;
 
 use crate::codex_cli::{CodexHookArgs, CodexStartArgs};
+use crate::config_cli::ConfigArgs;
 use crate::gist_cli::GistArgs;
 use crate::route_cli::RouteArgs;
 use crate::transport_cli::TransportArgs;
@@ -86,6 +87,9 @@ pub enum Command {
         /// bearer_state.<channel>.json path to read.
         path: PathBuf,
     },
+
+    /// Read and update legacy config.json during Rust cutover.
+    Config(ConfigArgs),
 
     /// Send a single text Message frame to the current room and exit.
     /// The current room lives in `<home>/room.json`; switch with

--- a/crates/airc-cli/src/config_cli.rs
+++ b/crates/airc-cli/src/config_cli.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct ConfigArgs {
+    #[command(subcommand)]
+    pub action: ConfigAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ConfigAction {
+    /// Print subscribed channels, one per line.
+    ReadChannels {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+    },
+}

--- a/crates/airc-cli/src/config_commands.rs
+++ b/crates/airc-cli/src/config_commands.rs
@@ -1,0 +1,60 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct ConfigFile {
+    #[serde(default)]
+    subscribed_channels: Vec<String>,
+}
+
+pub fn run_read_channels(
+    home: &Path,
+    config: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let file = load_config(&config);
+    for channel in file.subscribed_channels {
+        println!("{channel}");
+    }
+    Ok(())
+}
+
+fn load_config(path: &Path) -> ConfigFile {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_else(|| ConfigFile {
+            subscribed_channels: Vec::new(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_config_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let config = load_config(&dir.path().join("missing.json"));
+
+        assert!(config.subscribed_channels.is_empty());
+    }
+
+    #[test]
+    fn read_channels_preserves_config_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(
+            &path,
+            r#"{"subscribed_channels":["general","airc","continuum"]}"#,
+        )
+        .unwrap();
+
+        let config = load_config(&path);
+
+        assert_eq!(config.subscribed_channels, ["general", "airc", "continuum"]);
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -21,6 +21,8 @@ mod codex_hooks_json;
 mod codex_install;
 mod codex_start;
 mod commands;
+mod config_cli;
+mod config_commands;
 mod events_cli;
 mod events_commands;
 mod gist_cli;
@@ -50,6 +52,7 @@ use airc_core::PeerId;
 use airc_daemon::LocalIdentity;
 use cli::{Cli, Command, PeerAction};
 use codex_cli::CodexHookAction;
+use config_cli::ConfigAction;
 use events_cli::EventsAction;
 use gist_cli::GistAction;
 use lane_cli::{LaneAction, LaneManagerAction};
@@ -86,6 +89,12 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::Init => commands::run_init(&home).await,
 
         Command::BearerState { path } => bearer_state::run(&path),
+
+        Command::Config(args) => match args.action {
+            ConfigAction::ReadChannels { config } => {
+                config_commands::run_read_channels(&home, config)
+            }
+        },
 
         Command::Send { text } => commands::run_send(&home, parsed.peers, &text).await,
 

--- a/crates/airc-cli/tests/config_commands.rs
+++ b/crates/airc-cli/tests/config_commands.rs
@@ -1,0 +1,52 @@
+//! End-to-end coverage for `airc-rs config ...`.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn airc_rs() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-rs")
+}
+
+#[test]
+fn config_read_channels_preserves_order() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+    fs::write(
+        home.join("config.json"),
+        r#"{"subscribed_channels":["general","airc","continuum"]}"#,
+    )
+    .unwrap();
+
+    let output = run_ok(home, &["config", "read-channels"]);
+
+    assert_eq!(output, "general\nairc\ncontinuum\n");
+}
+
+#[test]
+fn config_read_channels_missing_config_is_empty() {
+    let workspace = TempDir::new().expect("tempdir");
+
+    let output = run_ok(workspace.path(), &["config", "read-channels"]);
+
+    assert!(output.is_empty());
+}
+
+fn run_ok(home: &Path, args: &[&str]) -> String {
+    let output = Command::new(airc_rs())
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .output()
+        .expect("airc-rs command must spawn");
+    assert!(
+        output.status.success(),
+        "airc-rs {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout utf-8")
+}

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -187,7 +187,7 @@ _join_show_status_and_inbox() {
 _join_transport_health_ok() {
   [ -f "$CONFIG" ] || return 1
   local _channels
-  _channels=$("$AIRC_PYTHON" -m airc_core.config read_channels --config "$CONFIG" 2>/dev/null || true)
+  _channels=$("$(airc_rs_bin)" config read-channels --home "$AIRC_WRITE_DIR" --config "$CONFIG" 2>/dev/null || true)
   # Legacy/no-room mode has no gist bearer to heartbeat. If the caller
   # already proved the scope owner is alive, transport_health has no
   # channel rows to evaluate and must not force a duplicate restart.

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -64,7 +64,7 @@ cmd_status() {
   # is config.json's subscribed_channels; first element is the default
   # channel that cmd_send stamps. Display the list with a marker for
   # the default.
-  local _channels; _channels=$("$AIRC_PYTHON" -m airc_core.config read_channels --config "$CONFIG" 2>/dev/null)
+  local _channels; _channels=$("$(airc_rs_bin)" config read-channels --home "$AIRC_WRITE_DIR" --config "$CONFIG" 2>/dev/null)
   if [ -n "$_channels" ]; then
     local _default; _default=$(echo "$_channels" | head -1)
     local _rest; _rest=$(echo "$_channels" | tail -n +2 | tr '\n' ',' | sed 's/,$//' | sed 's/,/, #/g')


### PR DESCRIPTION
Summary
- add airc-rs config read-channels with default <home>/config.json behavior
- preserve subscribed channel ordering and empty-output missing-config behavior
- route join/status read_channels call sites through airc-rs instead of Python

Verification
- cargo fmt -p airc-cli --check
- cargo test -p airc-cli config_
- bash -n airc install.sh uninstall.sh lib/airc_bash/*.sh
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace