### PR TITLE
feat(airc-rs): move channel gist config reads to rust

### DIFF
--- a/airc
+++ b/airc
@@ -786,6 +786,26 @@ airc_client_id() {
   "$(airc_rs_bin)" client-id 2>/dev/null
 }
 
+airc_config_read_channels() {
+  local cfg="${1:-$CONFIG}"
+  "$(airc_rs_bin)" config read-channels --home "$AIRC_WRITE_DIR" --config "$cfg" 2>/dev/null
+}
+
+airc_config_default_channel() {
+  local cfg="${1:-$CONFIG}"
+  "$(airc_rs_bin)" config default-channel --home "$AIRC_WRITE_DIR" --config "$cfg" 2>/dev/null
+}
+
+airc_config_get_channel_gist() {
+  local channel="$1" cfg="${2:-$CONFIG}"
+  "$(airc_rs_bin)" config get-channel-gist --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel" 2>/dev/null
+}
+
+airc_config_list_channel_gists() {
+  local cfg="${1:-$CONFIG}"
+  "$(airc_rs_bin)" config list-channel-gists --home "$AIRC_WRITE_DIR" --config "$cfg" 2>/dev/null
+}
+
 # Same as get_config_val but reads from an arbitrary config.json path.
 # Used by _whois_in_scope (#134 cross-scope walk) and other places
 # that need to read sibling-scope state without changing $CONFIG.
@@ -1437,8 +1457,7 @@ _monitor_multi_channel() {
     # required. Empty is meaningful: it means no channel currently has
     # a viable wire, so do not fall back to the stale startup map.
     local _refreshed_map
-    _refreshed_map=$("$AIRC_PYTHON" -m airc_core.config list_channel_gists \
-      --config "$CONFIG" 2>/dev/null || true)
+    _refreshed_map=$(airc_config_list_channel_gists "$CONFIG" || true)
     channel_map="$_refreshed_map"
     if [ -z "$channel_map" ]; then
       echo "airc: no channel_gists mappings remain; monitor waiting for 'airc join --room <channel>' to re-host" >&2
@@ -1526,8 +1545,7 @@ _monitor_multi_channel() {
             if [ -s "$AIRC_WRITE_DIR/bearer_recv.${ch}.log" ] \
                && tail -20 "$AIRC_WRITE_DIR/bearer_recv.${ch}.log" | grep -qE 'returned 404|\(gone\)|GET gists/.* failed: gone'; then
               local _gone_gid
-              _gone_gid=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
-                --config "$CONFIG" --channel "$ch" 2>/dev/null || true)
+              _gone_gid=$(airc_config_get_channel_gist "$ch" "$CONFIG" || true)
               "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
                 --config "$CONFIG" --channel "$ch" --gist-id "" \
                 >/dev/null 2>&1 || true
@@ -1543,8 +1561,7 @@ _monitor_multi_channel() {
             # mapping disappeared, leave this channel down; healthy
             # channels keep flowing and the next outer cycle/config
             # refresh can pick it up again.
-            gid=$("$AIRC_PYTHON" -m airc_core.config list_channel_gists \
-              --config "$CONFIG" 2>/dev/null | awk -F '\t' -v c="$ch" '$1 == c {print $2; exit}')
+            gid=$(airc_config_list_channel_gists "$CONFIG" | awk -F '\t' -v c="$ch" '$1 == c {print $2; exit}')
             if [ -n "$gid" ]; then
               sleep 3
               "$AIRC_PYTHON" -u -m airc_core.bearer_cli recv "self" \
@@ -1568,8 +1585,7 @@ _monitor_multi_channel() {
         # stop removed channels in-place while the formatter pipe stays
         # alive.
         local _current_map
-        _current_map=$("$AIRC_PYTHON" -m airc_core.config list_channel_gists \
-          --config "$CONFIG" 2>/dev/null || true)
+        _current_map=$(airc_config_list_channel_gists "$CONFIG" || true)
         if [ -n "$_current_map" ]; then
           local _kept=()
           for entry in "${_pids[@]}"; do
@@ -1682,7 +1698,7 @@ monitor() {
     # publishable route (channel_gists OR legacy room_gist_id), otherwise
     # the subshell exits immediately and airc.pid lists a dead PID.
     local _has_pub=0
-    if "$AIRC_PYTHON" -m airc_core.config list_channel_gists --config "$CONFIG" 2>/dev/null | grep -q .; then
+    if airc_config_list_channel_gists "$CONFIG" | grep -q .; then
       _has_pub=1
     fi
     if [ "$_has_pub" = "0" ] && [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
@@ -1713,8 +1729,7 @@ monitor() {
   #      that haven't been re-bootstrapped to populate channel_gists)
   #   3. neither → local-tail mode (standalone tests, --no-room --no-gist)
   local channel_map
-  channel_map=$("$AIRC_PYTHON" -m airc_core.config list_channel_gists \
-    --config "$CONFIG" 2>/dev/null || true)
+  channel_map=$(airc_config_list_channel_gists "$CONFIG" || true)
 
   if [ -n "$channel_map" ]; then
     _monitor_multi_channel "$my_name" "$channel_map"
@@ -1937,7 +1952,7 @@ flush_pending_host_loop() {
   # at startup so the spawn site can rely on a quick return when nothing
   # to do, mirroring the joiner-side host_target gate.
   local _has_route=0
-  if "$AIRC_PYTHON" -m airc_core.config list_channel_gists --config "$CONFIG" 2>/dev/null | grep -q .; then
+  if airc_config_list_channel_gists "$CONFIG" | grep -q .; then
     _has_route=1
   fi
   if [ "$_has_route" = "0" ] && [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
@@ -2018,8 +2033,7 @@ except Exception:
       # the channel field).
       local _line_gist=""
       if [ -n "$_line_channel" ]; then
-        _line_gist=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
-          --config "$CONFIG" --channel "$_line_channel" 2>/dev/null || true)
+        _line_gist=$(airc_config_get_channel_gist "$_line_channel" "$CONFIG" || true)
       fi
       if [ -z "$_line_gist" ] && [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
         _line_gist=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
@@ -2481,9 +2495,7 @@ _mesh_rediscover_loop() {
     # channel implies host rotation.
     local current_ch current_gist
     read -r current_ch current_gist <<EOF
-$("$AIRC_PYTHON" -m airc_core.config list_channel_gists \
-      --config "$CONFIG" 2>/dev/null \
-      | awk -F'\t' 'NR==1 {print $1, $2}')
+$(airc_config_list_channel_gists "$CONFIG" | awk -F'\t' 'NR==1 {print $1, $2}')
 EOF
     [ -n "$current_gist" ] || continue
     # Same-gist host lease check. Rotation is not the only failure
@@ -2514,9 +2526,7 @@ EOF
     # stderr) so the AI's Monitor wakes and the user sees what
     # happened, even if the bearer respawn that follows is invisible.
     local channels
-    channels=$("$AIRC_PYTHON" -m airc_core.config list_channel_gists \
-      --config "$CONFIG" 2>/dev/null \
-      | awk -F'\t' '{print $1}')
+    channels=$(airc_config_list_channel_gists "$CONFIG" | awk -F'\t' '{print $1}')
     while IFS= read -r ch; do
       [ -z "$ch" ] && continue
       # The CLI flag is --gist-id (see lib/airc_core/config.py:325).

--- a/crates/airc-cli/src/config_cli.rs
+++ b/crates/airc-cli/src/config_cli.rs
@@ -16,4 +16,28 @@ pub enum ConfigAction {
         #[arg(long)]
         config: Option<PathBuf>,
     },
+
+    /// Print the default subscribed channel.
+    DefaultChannel {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+    },
+
+    /// Print the gist id mapped to a channel.
+    GetChannelGist {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Channel name.
+        #[arg(long)]
+        channel: String,
+    },
+
+    /// Print channel-to-gist mappings as tab-separated lines.
+    ListChannelGists {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+    },
 }

--- a/crates/airc-cli/src/config_commands.rs
+++ b/crates/airc-cli/src/config_commands.rs
@@ -7,6 +7,8 @@ use serde::Deserialize;
 struct ConfigFile {
     #[serde(default)]
     subscribed_channels: Vec<String>,
+    #[serde(default)]
+    channel_gists: std::collections::BTreeMap<String, String>,
 }
 
 pub fn run_read_channels(
@@ -21,12 +23,58 @@ pub fn run_read_channels(
     Ok(())
 }
 
+pub fn run_default_channel(
+    home: &Path,
+    config: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let file = load_config(&config);
+    if let Some(channel) = file.subscribed_channels.first() {
+        println!("{channel}");
+    }
+    Ok(())
+}
+
+pub fn run_get_channel_gist(
+    home: &Path,
+    config: Option<PathBuf>,
+    channel: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let file = load_config(&config);
+    if let Some(gist) = file
+        .channel_gists
+        .get(channel)
+        .filter(|gist| !gist.is_empty())
+    {
+        println!("{gist}");
+    }
+    Ok(())
+}
+
+pub fn run_list_channel_gists(
+    home: &Path,
+    config: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let file = load_config(&config);
+    for (channel, gist) in file
+        .channel_gists
+        .into_iter()
+        .filter(|(channel, gist)| !channel.is_empty() && !gist.is_empty())
+    {
+        println!("{channel}\t{gist}");
+    }
+    Ok(())
+}
+
 fn load_config(path: &Path) -> ConfigFile {
     fs::read_to_string(path)
         .ok()
         .and_then(|raw| serde_json::from_str(&raw).ok())
         .unwrap_or_else(|| ConfigFile {
             subscribed_channels: Vec::new(),
+            channel_gists: std::collections::BTreeMap::new(),
         })
 }
 
@@ -41,6 +89,7 @@ mod tests {
         let config = load_config(&dir.path().join("missing.json"));
 
         assert!(config.subscribed_channels.is_empty());
+        assert!(config.channel_gists.is_empty());
     }
 
     #[test]
@@ -56,5 +105,21 @@ mod tests {
         let config = load_config(&path);
 
         assert_eq!(config.subscribed_channels, ["general", "airc", "continuum"]);
+    }
+
+    #[test]
+    fn reads_channel_gist_mapping() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(
+            &path,
+            r#"{"channel_gists":{"general":"gist-general","airc":"gist-airc"}}"#,
+        )
+        .unwrap();
+
+        let config = load_config(&path);
+
+        assert_eq!(config.channel_gists.get("general").unwrap(), "gist-general");
+        assert_eq!(config.channel_gists.get("airc").unwrap(), "gist-airc");
     }
 }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -94,6 +94,15 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             ConfigAction::ReadChannels { config } => {
                 config_commands::run_read_channels(&home, config)
             }
+            ConfigAction::DefaultChannel { config } => {
+                config_commands::run_default_channel(&home, config)
+            }
+            ConfigAction::GetChannelGist { config, channel } => {
+                config_commands::run_get_channel_gist(&home, config, &channel)
+            }
+            ConfigAction::ListChannelGists { config } => {
+                config_commands::run_list_channel_gists(&home, config)
+            }
         },
 
         Command::Send { text } => commands::run_send(&home, parsed.peers, &text).await,

--- a/crates/airc-cli/tests/config_commands.rs
+++ b/crates/airc-cli/tests/config_commands.rs
@@ -34,6 +34,51 @@ fn config_read_channels_missing_config_is_empty() {
     assert!(output.is_empty());
 }
 
+#[test]
+fn config_default_channel_prints_first_channel() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+    fs::write(
+        home.join("config.json"),
+        r#"{"subscribed_channels":["general","airc"]}"#,
+    )
+    .unwrap();
+
+    let output = run_ok(home, &["config", "default-channel"]);
+
+    assert_eq!(output, "general\n");
+}
+
+#[test]
+fn config_get_channel_gist_prints_mapping() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+    fs::write(
+        home.join("config.json"),
+        r#"{"channel_gists":{"general":"gist-general","airc":"gist-airc"}}"#,
+    )
+    .unwrap();
+
+    let output = run_ok(home, &["config", "get-channel-gist", "--channel", "airc"]);
+
+    assert_eq!(output, "gist-airc\n");
+}
+
+#[test]
+fn config_list_channel_gists_prints_tab_separated_mappings() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+    fs::write(
+        home.join("config.json"),
+        r#"{"channel_gists":{"airc":"gist-airc","general":"gist-general"}}"#,
+    )
+    .unwrap();
+
+    let output = run_ok(home, &["config", "list-channel-gists"]);
+
+    assert_eq!(output, "airc\tgist-airc\ngeneral\tgist-general\n");
+}
+
 fn run_ok(home: &Path, args: &[&str]) -> String {
     let output = Command::new(airc_rs())
         .arg("--home")

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -139,8 +139,7 @@ ensure_channel_subscribed_with_gist() {
     fi
   fi
   if [ -z "$_gid" ]; then
-    _gid=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
-           --config "$CONFIG" --channel "$channel" 2>/dev/null || true)
+    _gid=$(airc_config_get_channel_gist "$channel" "$CONFIG" || true)
   fi
   if [ -n "$_gid" ] && [ "${AIRC_NO_DISCOVERY:-0}" = "1" ] && [ ! -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
     # AIRC_NO_DISCOVERY is a host-election guard, not permission to
@@ -407,12 +406,12 @@ _join_emit_join_events() {
   [ -z "$_name" ] && return 0
   [ -f "$CONFIG" ] || return 0
   local _channels _ch
-  _channels=$("$AIRC_PYTHON" -m airc_core.config read_channels --config "$CONFIG" 2>/dev/null || true)
+  _channels=$(airc_config_read_channels "$CONFIG" || true)
   [ -z "$_channels" ] && return 0
   while IFS= read -r _ch; do
     [ -z "$_ch" ] && continue
     local _gid
-    _gid=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist --config "$CONFIG" --channel "$_ch" 2>/dev/null || true)
+    _gid=$(airc_config_get_channel_gist "$_ch" "$CONFIG" || true)
     [ -z "$_gid" ] && continue
     cmd_send --internal --system --channel "$_ch" "$_name joined #$_ch" >/dev/null 2>&1 || true
   done <<< "$_channels"
@@ -765,7 +764,7 @@ cmd_connect() {
     # the subscribe path so it gets added.
     local _add_subscription=0
     if [ "$room_explicit" = "1" ] && [ -n "$room_name" ] && [ -f "$CONFIG" ]; then
-      local _existing_subs; _existing_subs=$("$AIRC_PYTHON" -m airc_core.config read_channels --config "$CONFIG" 2>/dev/null || true)
+      local _existing_subs; _existing_subs=$(airc_config_read_channels "$CONFIG" || true)
       if ! printf '%s\n' "$_existing_subs" | grep -qFx "$room_name"; then
         _add_subscription=1
       fi
@@ -808,8 +807,7 @@ cmd_connect() {
     local _repair_running_monitor=0
     if [ -f "$CONFIG" ] && command -v gh >/dev/null 2>&1; then
       local _map_lines _line _ch _gid _canonical_gid
-      _map_lines=$("$AIRC_PYTHON" -m airc_core.config list_channel_gists \
-        --config "$CONFIG" 2>/dev/null || true)
+      _map_lines=$(airc_config_list_channel_gists "$CONFIG" || true)
       while IFS=$'\t' read -r _ch _gid; do
         [ -z "$_ch" ] && continue
         [ -z "$_gid" ] && continue
@@ -2072,8 +2070,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
           # early mesh-find gate at line ~568.
           if [ -z "$_existing_room_gid" ] && [ "${AIRC_NO_DISCOVERY:-0}" = "1" ]; then
             local _configured_gid
-            _configured_gid=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
-                              --config "$CONFIG" --channel "$room_name" 2>/dev/null || true)
+            _configured_gid=$(airc_config_get_channel_gist "$room_name" "$CONFIG" || true)
             if [ -n "$_configured_gid" ] && [ ! -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
               _existing_room_gid=$("$AIRC_PYTHON" -m airc_core.channel_gist find \
                                    --channel "$room_name" 2>/dev/null || true)

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -520,7 +520,7 @@ _doctor_health() {
   # principle as bearer scoping in the receive-silence beacon.
   local _subs=""
   if [ -f "$CONFIG" ] && command -v "$AIRC_PYTHON" >/dev/null 2>&1; then
-    _subs=$("$AIRC_PYTHON" -m airc_core.config read_channels --config "$CONFIG" 2>/dev/null || true)
+    _subs=$(airc_config_read_channels "$CONFIG" || true)
   fi
   local found_state=0
   if [ -d "$AIRC_WRITE_DIR" ]; then

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -239,8 +239,7 @@ cmd_part() {
     # Default-room path below (no arg or matching arg) handles the
     # primary scope teardown; this path JUST removes the named room
     # without touching primary scope state.
-    local _ch_gist; _ch_gist=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
-        --config "$CONFIG" --channel "$arg_room" 2>/dev/null || true)
+    local _ch_gist; _ch_gist=$(airc_config_get_channel_gist "$arg_room" "$CONFIG" || true)
     if [ -z "$_ch_gist" ]; then
       die "Not subscribed to #${arg_room} (no channel_gists mapping). Use 'airc list' to see open rooms; 'airc status' for your subscriptions."
     fi
@@ -398,7 +397,7 @@ _cmd_invite_human() {
   # (Copilot's review of #454 flagged the previous comment as
   # mis-describing this; comment now matches actual behavior.)
   local primary_chan primary_gid
-  primary_chan=$("$AIRC_PYTHON" -m airc_core.config default_channel --config "$CONFIG" 2>/dev/null || true)
+  primary_chan=$(airc_config_default_channel "$CONFIG" || true)
   if [ -n "$primary_chan" ]; then
     primary_gid=$("$AIRC_PYTHON" -c "
 import json, sys

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -316,7 +316,7 @@ cmd_send() {
     active_channel="$channel_override"
   fi
   if [ -z "$active_channel" ]; then
-    active_channel=$("$AIRC_PYTHON" -m airc_core.config default_channel --config "$CONFIG" 2>/dev/null || true)
+    active_channel=$(airc_config_default_channel "$CONFIG" || true)
   fi
   if [ -z "$active_channel" ] && [ -f "$AIRC_WRITE_DIR/room_name" ]; then
     active_channel=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null || true)
@@ -391,8 +391,7 @@ cmd_send() {
     # If the channel has no mapping, fall back to the scope's primary
     # room_gist_id so single-room scopes keep working unchanged.
     local room_gist_id=""
-    room_gist_id=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
-      --config "$CONFIG" --channel "$active_channel" 2>/dev/null || true)
+    room_gist_id=$(airc_config_get_channel_gist "$active_channel" "$CONFIG" || true)
     # Phantom-room guard: when --room/--channel was used explicitly,
     # NEVER fall back to the scope's primary room_gist_id — that publishes
     # to the wrong gist with the right channel-tag, creating an invisible
@@ -614,8 +613,7 @@ cmd_send() {
     # (otherwise the fallback turns --room into a phantom success that
     # silently mis-routes to the primary gist; see _explicit_channel).
     local _host_room_gist_id=""
-    _host_room_gist_id=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist \
-      --config "$CONFIG" --channel "$active_channel" 2>/dev/null || true)
+    _host_room_gist_id=$(airc_config_get_channel_gist "$active_channel" "$CONFIG" || true)
     if [ -z "$_host_room_gist_id" ]; then
       if [ "$_explicit_channel" = "1" ]; then
         die "no gist mapping for channel '$active_channel' — run 'airc join --room $active_channel' first to create the room"

--- a/lib/airc_bash/mesh.sh
+++ b/lib/airc_bash/mesh.sh
@@ -51,12 +51,12 @@ _mesh_find() {
   command -v gh >/dev/null 2>&1 || return 0
   local channel="${1:-${room_name:-}}"
   if [ -z "$channel" ] && [ -n "${CONFIG:-}" ] && [ -f "$CONFIG" ]; then
-    channel=$("$AIRC_PYTHON" -m airc_core.config default_channel --config "$CONFIG" 2>/dev/null || true)
+    channel=$(airc_config_default_channel "$CONFIG" || true)
   fi
   [ -z "$channel" ] && channel="general"
   if [ -n "${CONFIG:-}" ] && [ -f "$CONFIG" ]; then
     local configured
-    configured=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist --config "$CONFIG" --channel "$channel" 2>/dev/null || true)
+    configured=$(airc_config_get_channel_gist "$channel" "$CONFIG" || true)
     if [ -n "$configured" ]; then
       printf '%s\n' "$configured"
       return 0
@@ -73,12 +73,12 @@ _mesh_find_any() {
   command -v gh >/dev/null 2>&1 || return 0
   local channel="${1:-${room_name:-}}"
   if [ -z "$channel" ] && [ -n "${CONFIG:-}" ] && [ -f "$CONFIG" ]; then
-    channel=$("$AIRC_PYTHON" -m airc_core.config default_channel --config "$CONFIG" 2>/dev/null || true)
+    channel=$(airc_config_default_channel "$CONFIG" || true)
   fi
   [ -z "$channel" ] && channel="general"
   if [ -n "${CONFIG:-}" ] && [ -f "$CONFIG" ]; then
     local configured
-    configured=$("$AIRC_PYTHON" -m airc_core.config get_channel_gist --config "$CONFIG" --channel "$channel" 2>/dev/null || true)
+    configured=$(airc_config_get_channel_gist "$channel" "$CONFIG" || true)
     if [ -n "$configured" ]; then
       printf '%s\n' "$configured"
       return 0


### PR DESCRIPTION
Summary
- add airc-rs config default-channel, get-channel-gist, and list-channel-gists
- add central shell wrappers for read-only channel config access
- route mesh/send/connect/status room reads through Rust instead of airc_core.config

Verification
- cargo fmt -p airc-cli --check
- cargo test -p airc-cli config_
- bash -n airc install.sh uninstall.sh lib/airc_bash/*.sh
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace