### PR TITLE
feat(airc-rs): move channel config writes to rust

### DIFF
--- a/airc
+++ b/airc
@@ -806,6 +806,25 @@ airc_config_list_channel_gists() {
   "$(airc_rs_bin)" config list-channel-gists --home "$AIRC_WRITE_DIR" --config "$cfg" 2>/dev/null
 }
 
+airc_config_subscribe() {
+  local channel="$1" cfg="${2:-$CONFIG}" first="${3:-0}"
+  if [ "$first" = "1" ]; then
+    "$(airc_rs_bin)" config subscribe --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel" --first
+  else
+    "$(airc_rs_bin)" config subscribe --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel"
+  fi
+}
+
+airc_config_unsubscribe() {
+  local channel="$1" cfg="${2:-$CONFIG}"
+  "$(airc_rs_bin)" config unsubscribe --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel"
+}
+
+airc_config_set_channel_gist() {
+  local channel="$1" gist_id="${2-}" cfg="${3:-$CONFIG}"
+  "$(airc_rs_bin)" config set-channel-gist --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel" --gist-id="$gist_id"
+}
+
 # Same as get_config_val but reads from an arbitrary config.json path.
 # Used by _whois_in_scope (#134 cross-scope walk) and other places
 # that need to read sibling-scope state without changing $CONFIG.
@@ -1546,9 +1565,7 @@ _monitor_multi_channel() {
                && tail -20 "$AIRC_WRITE_DIR/bearer_recv.${ch}.log" | grep -qE 'returned 404|\(gone\)|GET gists/.* failed: gone'; then
               local _gone_gid
               _gone_gid=$(airc_config_get_channel_gist "$ch" "$CONFIG" || true)
-              "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
-                --config "$CONFIG" --channel "$ch" --gist-id "" \
-                >/dev/null 2>&1 || true
+              airc_config_set_channel_gist "$ch" "" "$CONFIG" >/dev/null 2>&1 || true
               [ -n "$_gone_gid" ] && printf '%s\n' "$_gone_gid" > "$AIRC_WRITE_DIR/gone_channel_gist.${ch}" 2>/dev/null || true
               printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[GONE: room gist 404 — channel #%s dissolved. Monitor stopped respawning this channel; re-host with: airc join --room %s]"}\n' \
                 "$(timestamp)" "$ch" "$ch" "$ch" >> "$MESSAGES"
@@ -2535,8 +2552,7 @@ EOF
       # subsequent bearer mismatch is debuggable; do NOT swallow with
       # `|| true` — that's the exact silent-failure family this PR set
       # is removing.
-      if ! "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
-            --config "$CONFIG" --channel "$ch" --gist-id "$found_gist" 2>&1; then
+      if ! airc_config_set_channel_gist "$ch" "$found_gist" "$CONFIG" 2>&1; then
         printf '[%s] airc: WARNING — failed to update channel_gists[%s] to %s; rotation self-heal incomplete\n' \
           "$(timestamp)" "$ch" "$found_gist" >&2
       fi

--- a/crates/airc-cli/src/config_cli.rs
+++ b/crates/airc-cli/src/config_cli.rs
@@ -40,4 +40,40 @@ pub enum ConfigAction {
         #[arg(long)]
         config: Option<PathBuf>,
     },
+
+    /// Add a channel to subscribed_channels.
+    Subscribe {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Channel name.
+        #[arg(long)]
+        channel: String,
+        /// Promote this channel to the first/default slot.
+        #[arg(long)]
+        first: bool,
+    },
+
+    /// Remove a channel from subscribed_channels.
+    Unsubscribe {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Channel name.
+        #[arg(long)]
+        channel: String,
+    },
+
+    /// Set or clear a channel_gists mapping.
+    SetChannelGist {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Channel name.
+        #[arg(long)]
+        channel: String,
+        /// Gist id. Empty clears the mapping.
+        #[arg(long, default_value = "")]
+        gist_id: String,
+    },
 }

--- a/crates/airc-cli/src/config_commands.rs
+++ b/crates/airc-cli/src/config_commands.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
+use serde_json::{Map, Value};
 
 #[derive(Debug, Deserialize)]
 struct ConfigFile {
@@ -68,6 +69,53 @@ pub fn run_list_channel_gists(
     Ok(())
 }
 
+pub fn run_subscribe(
+    home: &Path,
+    config: Option<PathBuf>,
+    channel: &str,
+    first: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let mut root = load_value(&config);
+    let channels = subscribed_channels_mut(&mut root);
+    channels.retain(|value| value.as_str() != Some(channel));
+    let value = Value::String(channel.to_string());
+    if first {
+        channels.insert(0, value);
+    } else {
+        channels.push(value);
+    }
+    save_value(&config, &root)
+}
+
+pub fn run_unsubscribe(
+    home: &Path,
+    config: Option<PathBuf>,
+    channel: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let mut root = load_value(&config);
+    subscribed_channels_mut(&mut root).retain(|value| value.as_str() != Some(channel));
+    save_value(&config, &root)
+}
+
+pub fn run_set_channel_gist(
+    home: &Path,
+    config: Option<PathBuf>,
+    channel: &str,
+    gist_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let mut root = load_value(&config);
+    let gists = channel_gists_mut(&mut root);
+    if gist_id.is_empty() {
+        gists.remove(channel);
+    } else {
+        gists.insert(channel.to_string(), Value::String(gist_id.to_string()));
+    }
+    save_value(&config, &root)
+}
+
 fn load_config(path: &Path) -> ConfigFile {
     fs::read_to_string(path)
         .ok()
@@ -76,6 +124,58 @@ fn load_config(path: &Path) -> ConfigFile {
             subscribed_channels: Vec::new(),
             channel_gists: std::collections::BTreeMap::new(),
         })
+}
+
+fn load_value(path: &Path) -> Value {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_else(|| Value::Object(Map::new()))
+}
+
+fn save_value(path: &Path, value: &Value) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)?;
+    }
+    let raw = serde_json::to_string_pretty(value)?;
+    fs::write(path, raw)?;
+    Ok(())
+}
+
+fn object_mut(value: &mut Value) -> &mut Map<String, Value> {
+    if !value.is_object() {
+        *value = Value::Object(Map::new());
+    }
+    value
+        .as_object_mut()
+        .expect("value was converted to object")
+}
+
+fn subscribed_channels_mut(value: &mut Value) -> &mut Vec<Value> {
+    let object = object_mut(value);
+    let entry = object
+        .entry("subscribed_channels")
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if !entry.is_array() {
+        *entry = Value::Array(Vec::new());
+    }
+    entry.as_array_mut().expect("entry was converted to array")
+}
+
+fn channel_gists_mut(value: &mut Value) -> &mut Map<String, Value> {
+    let object = object_mut(value);
+    let entry = object
+        .entry("channel_gists")
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !entry.is_object() {
+        *entry = Value::Object(Map::new());
+    }
+    entry
+        .as_object_mut()
+        .expect("entry was converted to object")
 }
 
 #[cfg(test)]
@@ -121,5 +221,57 @@ mod tests {
 
         assert_eq!(config.channel_gists.get("general").unwrap(), "gist-general");
         assert_eq!(config.channel_gists.get("airc").unwrap(), "gist-airc");
+    }
+
+    #[test]
+    fn subscribe_appends_idempotently() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(&path, r#"{"subscribed_channels":["general"]}"#).unwrap();
+
+        run_subscribe(dir.path(), Some(path.clone()), "airc", false).unwrap();
+        run_subscribe(dir.path(), Some(path.clone()), "airc", false).unwrap();
+
+        let config = load_config(&path);
+        assert_eq!(config.subscribed_channels, ["general", "airc"]);
+    }
+
+    #[test]
+    fn subscribe_first_promotes_channel() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(&path, r#"{"subscribed_channels":["general","airc"]}"#).unwrap();
+
+        run_subscribe(dir.path(), Some(path.clone()), "airc", true).unwrap();
+
+        let config = load_config(&path);
+        assert_eq!(config.subscribed_channels, ["airc", "general"]);
+    }
+
+    #[test]
+    fn unsubscribe_removes_channel() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(&path, r#"{"subscribed_channels":["general","airc"]}"#).unwrap();
+
+        run_unsubscribe(dir.path(), Some(path.clone()), "airc").unwrap();
+
+        let config = load_config(&path);
+        assert_eq!(config.subscribed_channels, ["general"]);
+    }
+
+    #[test]
+    fn set_channel_gist_sets_and_clears_mapping() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+
+        run_set_channel_gist(dir.path(), Some(path.clone()), "general", "gist-general").unwrap();
+        assert_eq!(
+            load_config(&path).channel_gists.get("general").unwrap(),
+            "gist-general"
+        );
+
+        run_set_channel_gist(dir.path(), Some(path.clone()), "general", "").unwrap();
+        assert!(!load_config(&path).channel_gists.contains_key("general"));
     }
 }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -103,6 +103,19 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             ConfigAction::ListChannelGists { config } => {
                 config_commands::run_list_channel_gists(&home, config)
             }
+            ConfigAction::Subscribe {
+                config,
+                channel,
+                first,
+            } => config_commands::run_subscribe(&home, config, &channel, first),
+            ConfigAction::Unsubscribe { config, channel } => {
+                config_commands::run_unsubscribe(&home, config, &channel)
+            }
+            ConfigAction::SetChannelGist {
+                config,
+                channel,
+                gist_id,
+            } => config_commands::run_set_channel_gist(&home, config, &channel, &gist_id),
         },
 
         Command::Send { text } => commands::run_send(&home, parsed.peers, &text).await,

--- a/crates/airc-cli/tests/config_commands.rs
+++ b/crates/airc-cli/tests/config_commands.rs
@@ -79,6 +79,85 @@ fn config_list_channel_gists_prints_tab_separated_mappings() {
     assert_eq!(output, "airc\tgist-airc\ngeneral\tgist-general\n");
 }
 
+#[test]
+fn config_subscribe_unsubscribe_round_trips() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+    fs::write(
+        home.join("config.json"),
+        r#"{"subscribed_channels":["general"]}"#,
+    )
+    .unwrap();
+
+    run_ok(home, &["config", "subscribe", "--channel", "airc"]);
+    run_ok(home, &["config", "subscribe", "--channel", "airc"]);
+    assert_eq!(
+        run_ok(home, &["config", "read-channels"]),
+        "general\nairc\n"
+    );
+
+    run_ok(home, &["config", "unsubscribe", "--channel", "general"]);
+    assert_eq!(run_ok(home, &["config", "read-channels"]), "airc\n");
+}
+
+#[test]
+fn config_subscribe_first_promotes_default_channel() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+    fs::write(
+        home.join("config.json"),
+        r#"{"subscribed_channels":["general","airc"]}"#,
+    )
+    .unwrap();
+
+    run_ok(
+        home,
+        &["config", "subscribe", "--channel", "airc", "--first"],
+    );
+
+    assert_eq!(
+        run_ok(home, &["config", "read-channels"]),
+        "airc\ngeneral\n"
+    );
+}
+
+#[test]
+fn config_set_channel_gist_sets_and_clears_mapping() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+
+    run_ok(
+        home,
+        &[
+            "config",
+            "set-channel-gist",
+            "--channel",
+            "general",
+            "--gist-id",
+            "gist-general",
+        ],
+    );
+    assert_eq!(
+        run_ok(
+            home,
+            &["config", "get-channel-gist", "--channel", "general"]
+        ),
+        "gist-general\n"
+    );
+
+    run_ok(
+        home,
+        &["config", "set-channel-gist", "--channel", "general"],
+    );
+    assert_eq!(
+        run_ok(
+            home,
+            &["config", "get-channel-gist", "--channel", "general"]
+        ),
+        ""
+    );
+}
+
 fn run_ok(home: &Path, args: &[&str]) -> String {
     let output = Command::new(airc_rs())
         .arg("--home")

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -111,10 +111,9 @@ ensure_channel_subscribed_with_gist() {
   trap '[ -n "${_err:-}" ] && rm -f "$_err"' RETURN
 
   # 1. Subscribe in config.
-  local _first_flag=""
-  [ "$mode" = "--first" ] && _first_flag="--first"
-  if ! "$AIRC_PYTHON" -m airc_core.config subscribe \
-       --config "$CONFIG" --channel "$channel" $_first_flag 2>"$_err"; then
+  local _first=0
+  [ "$mode" = "--first" ] && _first=1
+  if ! airc_config_subscribe "$channel" "$CONFIG" "$_first" 2>"$_err"; then
     echo "  ⚠ Could not subscribe to #${channel}:" >&2
     [ -s "$_err" ] && sed 's/^/      /' "$_err" >&2
     return 1
@@ -161,8 +160,7 @@ ensure_channel_subscribed_with_gist() {
   fi
 
   # 3. Persist channel→gist mapping for cmd_send + monitor routing.
-  if ! "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
-       --config "$CONFIG" --channel "$channel" --gist-id "$_gid" 2>"$_err"; then
+  if ! airc_config_set_channel_gist "$channel" "$_gid" "$CONFIG" 2>"$_err"; then
     echo "  ⚠ Could not persist channel→gist mapping for #${channel}:" >&2
     [ -s "$_err" ] && sed 's/^/      /' "$_err" >&2
     return 1
@@ -775,15 +773,14 @@ cmd_connect() {
       # (create if missing). The bearer for this channel will be
       # picked up on the next _monitor_multi_channel cycle (which
       # re-reads channel_map at top of each outer poll).
-      "$AIRC_PYTHON" -m airc_core.config subscribe --config "$CONFIG" --channel "$room_name" 2>/dev/null || true
+      airc_config_subscribe "$room_name" "$CONFIG" 0 2>/dev/null || true
       # Resolve --create-if-missing: returns the gist id (find existing
       # or create new gist named "airc room: #<channel>").
       local _new_gist; _new_gist=$("$AIRC_PYTHON" -m airc_core.channel_gist resolve \
           --channel "$room_name" --create-if-missing 2>&1)
       if [ -n "$_new_gist" ] && printf '%s' "$_new_gist" | grep -qE '^[0-9a-f]{32}$'; then
         # Save the channel→gist mapping in config so cmd_send can route to it.
-        "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
-          --config "$CONFIG" --channel "$room_name" --gist-id "$_new_gist" 2>/dev/null || true
+        airc_config_set_channel_gist "$room_name" "$_new_gist" "$CONFIG" 2>/dev/null || true
         echo "  ✓ Subscribed to #${room_name} (gist $_new_gist). Bearer respawn picks it up within ~30s."
       else
         echo "  ⚠ Subscribed to #${room_name} but gist resolve failed: $_new_gist"
@@ -814,8 +811,7 @@ cmd_connect() {
         _canonical_gid=$(_mesh_find_any "$_ch")
         if [ -n "$_canonical_gid" ] && [ "$_canonical_gid" != "$_gid" ]; then
           echo "  airc join: running monitor is on stale #${_ch} gist $_gid; canonical is $_canonical_gid."
-          "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
-            --config "$CONFIG" --channel "$_ch" --gist-id "$_canonical_gid" 2>/dev/null || true
+          airc_config_set_channel_gist "$_ch" "$_canonical_gid" "$CONFIG" 2>/dev/null || true
           _repair_running_monitor=1
         fi
       done <<< "$_map_lines"
@@ -1647,8 +1643,7 @@ cmd_connect() {
         # does not immediately hit GitHub discovery again during the exact
         # transient/rate-limited condition it is meant to survive.
         if [ -n "${_resolved_gist_id:-}" ]; then
-          "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
-            --config "$CONFIG" --channel "$resolved_room_name" --gist-id "$_resolved_gist_id" 2>/dev/null || true
+          airc_config_set_channel_gist "$resolved_room_name" "$_resolved_gist_id" "$CONFIG" 2>/dev/null || true
         fi
         if [ "${AIRC_TEST_FAIL_ENSURE_CHANNEL:-}" = "$resolved_room_name" ] \
            || ! ensure_channel_subscribed_with_gist "$resolved_room_name" >/dev/null; then
@@ -1861,8 +1856,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
       # #283: also map this channel→gist in channel_gists so the
       # multi-channel monitor polls it and cmd_send routes by channel.
       if [ -n "$resolved_room_name" ]; then
-        "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
-          --config "$CONFIG" --channel "$resolved_room_name" --gist-id "$_resolved_gist_id" 2>/dev/null || true
+        airc_config_set_channel_gist "$resolved_room_name" "$_resolved_gist_id" "$CONFIG" 2>/dev/null || true
       fi
     fi
 
@@ -1998,8 +1992,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
       echo "$room_name" > "$AIRC_WRITE_DIR/room_name"
       # Phase 2B.2: also seed subscribed_channels with our hosted channel
       # so cmd_send + future config-driven consumers see it.
-      "$AIRC_PYTHON" -m airc_core.config subscribe \
-        --config "$CONFIG" --channel "$room_name" --first 2>/dev/null || true
+      airc_config_subscribe "$room_name" "$CONFIG" 1 2>/dev/null || true
       if [ -n "${AIRC_ADOPT_GIST:-}" ]; then
         echo "  Hosting #${room_name} — recovering existing room gist ${AIRC_ADOPT_GIST}."
       else
@@ -2095,8 +2088,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
           # existing gist.
           echo "$_gist_id" > "$AIRC_WRITE_DIR/room_gist_id"
           echo "$room_name" > "$AIRC_WRITE_DIR/room_name"
-          "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
-            --config "$CONFIG" --channel "$room_name" --gist-id "$_gist_id" 2>/dev/null || true
+          airc_config_set_channel_gist "$room_name" "$_gist_id" "$CONFIG" 2>/dev/null || true
           : >"$AIRC_WRITE_DIR/.using_existing_room_gist"
         fi
 
@@ -2225,8 +2217,7 @@ JSON
             # #283: also map this channel→gist in channel_gists so
             # the multi-channel monitor polls it and cmd_send routes
             # by channel.
-            "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
-              --config "$CONFIG" --channel "$room_name" --gist-id "$_gist_id" 2>/dev/null || true
+            airc_config_set_channel_gist "$room_name" "$_gist_id" "$CONFIG" 2>/dev/null || true
 
             # Heartbeat loop: keep last_heartbeat fresh in the gist so
             # joiners can deterministically detect a dead host. Without

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -255,8 +255,8 @@ cmd_part() {
       fi
     fi
     # Remove from subscribed_channels + clear channel_gists mapping.
-    "$AIRC_PYTHON" -m airc_core.config unsubscribe --config "$CONFIG" --channel "$arg_room" 2>/dev/null || true
-    "$AIRC_PYTHON" -m airc_core.config set_channel_gist --config "$CONFIG" --channel "$arg_room" --gist-id "" 2>/dev/null || true
+    airc_config_unsubscribe "$arg_room" "$CONFIG" 2>/dev/null || true
+    airc_config_set_channel_gist "$arg_room" "" "$CONFIG" 2>/dev/null || true
     return 0
   fi
 
@@ -309,8 +309,7 @@ cmd_part() {
   # anymore, the monitor display drops the channel prefix from
   # outbound, and a future cmd_join --room <name> re-adds it.
   if [ "$room_name" != "(unnamed)" ]; then
-    "$AIRC_PYTHON" -m airc_core.config unsubscribe \
-      --config "$CONFIG" --channel "$room_name" 2>/dev/null || true
+    airc_config_unsubscribe "$room_name" "$CONFIG" 2>/dev/null || true
   fi
 
   # IRC `/part` semantics — leave THIS room only; the #general sidecar

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -481,9 +481,7 @@ cmd_send() {
         # clear stale mapping, surface [GONE] marker, do NOT queue
         # (retries would all 404 too). Recovery: airc join --room
         # rediscovers / re-hosts.
-        "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
-          --config "$CONFIG" --channel "$active_channel" --gist-id "" \
-          >/dev/null 2>&1 || true
+        airc_config_set_channel_gist "$active_channel" "" "$CONFIG" >/dev/null 2>&1 || true
         [ -n "${room_gist_id:-}" ] && printf '%s\n' "$room_gist_id" > "$AIRC_WRITE_DIR/gone_channel_gist.${active_channel}" 2>/dev/null || true
         local gone_marker; gone_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[GONE: room gist 404 — channel #%s dissolved, message NOT delivered. Re-host with: airc join --room %s] %s"}' \
           "$(timestamp)" "$active_channel" "$active_channel" "$active_channel" "${detail:-no detail}")
@@ -678,9 +676,7 @@ cmd_send() {
           # API budget for nothing. Drop the message on the floor with
           # loud surface (the [GONE] marker) — same UX as auth_failure
           # but a different remedy.
-          "$AIRC_PYTHON" -m airc_core.config set_channel_gist \
-            --config "$CONFIG" --channel "$active_channel" --gist-id "" \
-            >/dev/null 2>&1 || true
+          airc_config_set_channel_gist "$active_channel" "" "$CONFIG" >/dev/null 2>&1 || true
           [ -n "${_host_room_gist_id:-}" ] && printf '%s\n' "$_host_room_gist_id" > "$AIRC_WRITE_DIR/gone_channel_gist.${active_channel}" 2>/dev/null || true
           local _host_gone_marker; _host_gone_marker=$(printf '{"from":"airc","ts":"%s","channel":"%s","msg":"[GONE: room gist 404 — channel #%s dissolved, message NOT delivered. Re-host with: airc join --room %s] %s"}' \
             "$(timestamp)" "$active_channel" "$active_channel" "$active_channel" "${_host_detail:-no detail}")


### PR DESCRIPTION
Summary
- add Rust config write commands for subscribe, unsubscribe, and channel gist updates
- route shell channel write helpers through airc-rs instead of Python
- preserve unrelated config keys while updating channel state
- cover command behavior with airc-cli config integration tests

Verification
- cargo fmt -p airc-cli
- cargo test -p airc-cli config_
- bash -n airc install.sh uninstall.sh lib/airc_bash/*.sh
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace