### PR TITLE
feat(airc-rs): move generic config state to rust

### DIFF
--- a/airc
+++ b/airc
@@ -737,14 +737,16 @@ ensure_init() {
   die "Not initialized ($AIRC_WRITE_DIR). Run: airc join"
 }
 
-# config CRUD via airc_core.config — proper argparse --flags so paths
-# are per-arg-predictable across MSYS path-translation. Each call passes
+# config CRUD via airc-rs — proper clap --flags so paths are
+# per-arg-predictable across MSYS path-translation. Each call passes
 # `--config <path>` explicitly.
 get_name() {
-  "$AIRC_PYTHON" -m airc_core.config get_name --config "$CONFIG" 2>/dev/null || echo "unknown"
+  "$(airc_rs_bin)" config get-name --home "$AIRC_WRITE_DIR" --config "$CONFIG" 2>/dev/null || echo "unknown"
 }
 
-get_config_val()   { "$AIRC_PYTHON" -m airc_core.config get --config "$CONFIG" "$1" "${2:-}" 2>/dev/null || echo "${2:-}"; }
+get_config_val() {
+  "$(airc_rs_bin)" config get --home "$AIRC_WRITE_DIR" --config "$CONFIG" "$1" "${2:-}" 2>/dev/null || echo "${2:-}"
+}
 set_config_val()   {
   # Empty $2 must reach argparse as the value of --value. The plain
   # `--value "$2"` form fails on Windows when bash invocations cross
@@ -757,9 +759,11 @@ set_config_val()   {
   # Repro on Windows 11 + WSL2 Ubuntu (issue #511 trace):
   #   set_config_val host "$(get_host)"   # get_host -> ""
   #   → exit 2 + "argument --value: expected one argument"
-  "$AIRC_PYTHON" -m airc_core.config set --config "$CONFIG" --key "$1" --value="${2-}"
+  "$(airc_rs_bin)" config set --home "$AIRC_WRITE_DIR" --config "$CONFIG" --key "$1" --value="${2-}"
 }
-unset_config_keys() { "$AIRC_PYTHON" -m airc_core.config unset_keys --config "$CONFIG" "$@"; }
+unset_config_keys() {
+  "$(airc_rs_bin)" config unset-keys --home "$AIRC_WRITE_DIR" --config "$CONFIG" "$@"
+}
 
 airc_rs_bin() {
   local _root; _root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -830,7 +834,7 @@ airc_config_set_channel_gist() {
 # that need to read sibling-scope state without changing $CONFIG.
 get_config_val_in() {
   local cfg="$1" key="$2" default="${3:-}"
-  "$AIRC_PYTHON" -m airc_core.config get --config "$cfg" "$key" "$default" 2>/dev/null || echo "$default"
+  "$(airc_rs_bin)" config get --home "$AIRC_WRITE_DIR" --config "$cfg" "$key" "$default" 2>/dev/null || echo "$default"
 }
 
 get_host() {
@@ -1344,10 +1348,10 @@ _primary_scope_for() {
 }
 
 # parted_rooms helpers (#136 sticky /part) — thin wrappers; mutation
-# logic lives in airc_core.config (#205 target 6).
-_read_parted_rooms()  { [ -f "$1/config.json" ] && "$AIRC_PYTHON" -m airc_core.config read_parted --config "$1/config.json" 2>/dev/null; }
-_record_parted_room() { [ -f "$1/config.json" ] && "$AIRC_PYTHON" -m airc_core.config record_parted --config "$1/config.json" --room "$2" 2>/dev/null || true; }
-_clear_parted_room()  { [ -f "$1/config.json" ] && "$AIRC_PYTHON" -m airc_core.config clear_parted --config "$1/config.json" --room "$2" 2>/dev/null || true; }
+# logic lives in airc-rs config.
+_read_parted_rooms()  { [ -f "$1/config.json" ] && "$(airc_rs_bin)" config read-parted --home "$1" --config "$1/config.json" 2>/dev/null; }
+_record_parted_room() { [ -f "$1/config.json" ] && "$(airc_rs_bin)" config record-parted --home "$1" --config "$1/config.json" --room "$2" 2>/dev/null || true; }
+_clear_parted_room()  { [ -f "$1/config.json" ] && "$(airc_rs_bin)" config clear-parted --home "$1" --config "$1/config.json" --room "$2" 2>/dev/null || true; }
 
 # Spawn the #general sidecar (issue #121) — a parallel `airc join`
 # in a sibling scope (.general suffix) so the primary tab is in BOTH

--- a/crates/airc-cli/src/config_cli.rs
+++ b/crates/airc-cli/src/config_cli.rs
@@ -10,6 +10,84 @@ pub struct ConfigArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum ConfigAction {
+    /// Print a config value, or a default when missing/empty.
+    Get {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Config key.
+        key: String,
+        /// Value printed when the key is missing or empty.
+        #[arg(default_value = "")]
+        default: String,
+    },
+
+    /// Print the configured identity name.
+    GetName {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+    },
+
+    /// Set a config string value.
+    Set {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Config key.
+        #[arg(long)]
+        key: String,
+        /// Config value. Empty values are valid.
+        #[arg(long, default_value = "")]
+        value: String,
+    },
+
+    /// Set the configured identity name.
+    SetName {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Identity name.
+        #[arg(long)]
+        name: String,
+    },
+
+    /// Remove config keys.
+    UnsetKeys {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Keys to remove.
+        keys: Vec<String>,
+    },
+
+    /// Print parted rooms, one per line.
+    ReadParted {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+    },
+
+    /// Add a room to parted_rooms.
+    RecordParted {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Room name.
+        #[arg(long)]
+        room: String,
+    },
+
+    /// Remove a room from parted_rooms.
+    ClearParted {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Room name.
+        #[arg(long)]
+        room: String,
+    },
+
     /// Print subscribed channels, one per line.
     ReadChannels {
         /// Config file. Defaults to `<home>/config.json`.

--- a/crates/airc-cli/src/config_commands.rs
+++ b/crates/airc-cli/src/config_commands.rs
@@ -7,9 +7,102 @@ use serde_json::{Map, Value};
 #[derive(Debug, Deserialize)]
 struct ConfigFile {
     #[serde(default)]
+    parted_rooms: Vec<String>,
+    #[serde(default)]
     subscribed_channels: Vec<String>,
     #[serde(default)]
     channel_gists: std::collections::BTreeMap<String, String>,
+}
+
+pub fn run_get(
+    home: &Path,
+    config: Option<PathBuf>,
+    key: &str,
+    default: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    println!("{}", config_value(&config, key, default));
+    Ok(())
+}
+
+pub fn run_get_name(
+    home: &Path,
+    config: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    println!("{}", config_value(&config, "name", "unknown"));
+    Ok(())
+}
+
+pub fn run_set(
+    home: &Path,
+    config: Option<PathBuf>,
+    key: &str,
+    value: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let mut root = load_value(&config);
+    object_mut(&mut root).insert(key.to_string(), Value::String(value.to_string()));
+    save_value(&config, &root)
+}
+
+pub fn run_set_name(
+    home: &Path,
+    config: Option<PathBuf>,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    run_set(home, config, "name", name)
+}
+
+pub fn run_unset_keys(
+    home: &Path,
+    config: Option<PathBuf>,
+    keys: &[String],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let mut root = load_value(&config);
+    let object = object_mut(&mut root);
+    for key in keys {
+        object.remove(key);
+    }
+    save_value(&config, &root)
+}
+
+pub fn run_read_parted(
+    home: &Path,
+    config: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let file = load_config(&config);
+    for room in file.parted_rooms {
+        println!("{room}");
+    }
+    Ok(())
+}
+
+pub fn run_record_parted(
+    home: &Path,
+    config: Option<PathBuf>,
+    room: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let mut root = load_value(&config);
+    let rooms = parted_rooms_mut(&mut root);
+    if !rooms.iter().any(|value| value.as_str() == Some(room)) {
+        rooms.push(Value::String(room.to_string()));
+    }
+    save_value(&config, &root)
+}
+
+pub fn run_clear_parted(
+    home: &Path,
+    config: Option<PathBuf>,
+    room: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let mut root = load_value(&config);
+    parted_rooms_mut(&mut root).retain(|value| value.as_str() != Some(room));
+    save_value(&config, &root)
 }
 
 pub fn run_read_channels(
@@ -121,6 +214,7 @@ fn load_config(path: &Path) -> ConfigFile {
         .ok()
         .and_then(|raw| serde_json::from_str(&raw).ok())
         .unwrap_or_else(|| ConfigFile {
+            parted_rooms: Vec::new(),
             subscribed_channels: Vec::new(),
             channel_gists: std::collections::BTreeMap::new(),
         })
@@ -178,6 +272,32 @@ fn channel_gists_mut(value: &mut Value) -> &mut Map<String, Value> {
         .expect("entry was converted to object")
 }
 
+fn parted_rooms_mut(value: &mut Value) -> &mut Vec<Value> {
+    let object = object_mut(value);
+    let entry = object
+        .entry("parted_rooms")
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if !entry.is_array() {
+        *entry = Value::Array(Vec::new());
+    }
+    entry.as_array_mut().expect("entry was converted to array")
+}
+
+fn config_value(path: &Path, key: &str, default: &str) -> String {
+    let root = load_value(path);
+    match root.get(key) {
+        Some(Value::Null) | None => default.to_string(),
+        Some(Value::String(value)) if value.is_empty() => default.to_string(),
+        Some(Value::String(value)) => value.clone(),
+        Some(Value::Bool(value)) => value.to_string(),
+        Some(Value::Number(value)) => value.to_string(),
+        Some(Value::Array(_)) | Some(Value::Object(_)) => {
+            serde_json::to_string(root.get(key).expect("matched value exists"))
+                .unwrap_or_else(|_| default.to_string())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,6 +310,58 @@ mod tests {
 
         assert!(config.subscribed_channels.is_empty());
         assert!(config.channel_gists.is_empty());
+        assert!(config.parted_rooms.is_empty());
+    }
+
+    #[test]
+    fn get_returns_default_for_missing_or_empty_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(&path, r#"{"empty":"","name":"alice"}"#).unwrap();
+
+        assert_eq!(config_value(&path, "name", "unknown"), "alice");
+        assert_eq!(config_value(&path, "empty", "fallback"), "fallback");
+        assert_eq!(config_value(&path, "missing", "fallback"), "fallback");
+    }
+
+    #[test]
+    fn get_serializes_structured_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(
+            &path,
+            r#"{"identity":{"role":"agent"},"rooms":["general"]}"#,
+        )
+        .unwrap();
+
+        assert_eq!(config_value(&path, "identity", "{}"), r#"{"role":"agent"}"#);
+        assert_eq!(config_value(&path, "rooms", "[]"), r#"["general"]"#);
+    }
+
+    #[test]
+    fn set_and_unset_preserve_unrelated_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(&path, r#"{"name":"alice","host":"localhost"}"#).unwrap();
+
+        run_set(dir.path(), Some(path.clone()), "name", "bob").unwrap();
+        run_unset_keys(dir.path(), Some(path.clone()), &["host".to_string()]).unwrap();
+
+        assert_eq!(config_value(&path, "name", ""), "bob");
+        assert_eq!(config_value(&path, "host", "missing"), "missing");
+    }
+
+    #[test]
+    fn parted_rooms_are_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+
+        run_record_parted(dir.path(), Some(path.clone()), "general").unwrap();
+        run_record_parted(dir.path(), Some(path.clone()), "general").unwrap();
+        assert_eq!(load_config(&path).parted_rooms, ["general"]);
+
+        run_clear_parted(dir.path(), Some(path.clone()), "general").unwrap();
+        assert!(load_config(&path).parted_rooms.is_empty());
     }
 
     #[test]

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -91,6 +91,28 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::BearerState { path } => bearer_state::run(&path),
 
         Command::Config(args) => match args.action {
+            ConfigAction::Get {
+                config,
+                key,
+                default,
+            } => config_commands::run_get(&home, config, &key, &default),
+            ConfigAction::GetName { config } => config_commands::run_get_name(&home, config),
+            ConfigAction::Set { config, key, value } => {
+                config_commands::run_set(&home, config, &key, &value)
+            }
+            ConfigAction::SetName { config, name } => {
+                config_commands::run_set_name(&home, config, &name)
+            }
+            ConfigAction::UnsetKeys { config, keys } => {
+                config_commands::run_unset_keys(&home, config, &keys)
+            }
+            ConfigAction::ReadParted { config } => config_commands::run_read_parted(&home, config),
+            ConfigAction::RecordParted { config, room } => {
+                config_commands::run_record_parted(&home, config, &room)
+            }
+            ConfigAction::ClearParted { config, room } => {
+                config_commands::run_clear_parted(&home, config, &room)
+            }
             ConfigAction::ReadChannels { config } => {
                 config_commands::run_read_channels(&home, config)
             }

--- a/crates/airc-cli/tests/config_commands.rs
+++ b/crates/airc-cli/tests/config_commands.rs
@@ -158,6 +158,56 @@ fn config_set_channel_gist_sets_and_clears_mapping() {
     );
 }
 
+#[test]
+fn config_get_set_unset_round_trips() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+    fs::write(
+        home.join("config.json"),
+        r#"{"name":"alice","host":"localhost","identity":{"role":"agent"}}"#,
+    )
+    .unwrap();
+
+    assert_eq!(run_ok(home, &["config", "get-name"]), "alice\n");
+    assert_eq!(
+        run_ok(home, &["config", "get", "identity", "{}"]),
+        "{\"role\":\"agent\"}\n"
+    );
+
+    run_ok(home, &["config", "set", "--key", "name", "--value", "bob"]);
+    assert_eq!(run_ok(home, &["config", "get-name"]), "bob\n");
+
+    run_ok(home, &["config", "unset-keys", "host"]);
+    assert_eq!(
+        run_ok(home, &["config", "get", "host", "missing"]),
+        "missing\n"
+    );
+}
+
+#[test]
+fn config_set_name_matches_legacy_command() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+
+    run_ok(home, &["config", "set-name", "--name", "codex-tab"]);
+
+    assert_eq!(run_ok(home, &["config", "get-name"]), "codex-tab\n");
+}
+
+#[test]
+fn config_parted_rooms_are_idempotent() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+
+    run_ok(home, &["config", "record-parted", "--room", "general"]);
+    run_ok(home, &["config", "record-parted", "--room", "general"]);
+    run_ok(home, &["config", "record-parted", "--room", "airc"]);
+    assert_eq!(run_ok(home, &["config", "read-parted"]), "general\nairc\n");
+
+    run_ok(home, &["config", "clear-parted", "--room", "general"]);
+    assert_eq!(run_ok(home, &["config", "read-parted"]), "airc\n");
+}
+
 fn run_ok(home: &Path, args: &[&str]) -> String {
     let output = Command::new(airc_rs())
         .arg("--home")

--- a/lib/airc_bash/cmd_rename.sh
+++ b/lib/airc_bash/cmd_rename.sh
@@ -132,7 +132,7 @@ sys.exit(0 if (target in seen and target not in my_history) else 1)
   # (would have broken on a name containing a single quote — currently
   # safe because the sanitizer keeps names in [a-z0-9-], but a sharp
   # edge in code that's about to recurse).
-  "$AIRC_PYTHON" -m airc_core.config set_name --config "$CONFIG" --name "$new_name"
+  set_config_val name "$new_name"
   echo "  Renamed: $old_name → $new_name"
 
   # Phase 2: propagate the config write to sibling scopes BEFORE

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -124,6 +124,30 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" gist get .airc', combined)
         self.assertIn('"$(airc_rs_bin)" gist gist-content', combined)
 
+    def test_generic_config_runtime_paths_use_airc_rs(self):
+        files = [
+            REPO / "airc",
+            REPO / "lib/airc_bash/cmd_rename.sh",
+        ]
+        combined = "\n".join(path.read_text(encoding="utf-8") for path in files)
+
+        forbidden = [
+            "airc_core.config get_name",
+            "airc_core.config get ",
+            "airc_core.config set ",
+            "airc_core.config set_name",
+            "airc_core.config unset_keys",
+            "airc_core.config read_parted",
+            "airc_core.config record_parted",
+            "airc_core.config clear_parted",
+        ]
+        for needle in forbidden:
+            self.assertNotIn(needle, combined)
+
+        self.assertIn('"$(airc_rs_bin)" config get-name', combined)
+        self.assertIn('"$(airc_rs_bin)" config set ', combined)
+        self.assertIn('"$(airc_rs_bin)" config read-parted', combined)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary
- add Rust config commands for get/get-name/set/set-name/unset-keys
- add Rust parted-room read/record/clear commands
- route shell generic config helpers and rename through airc-rs
- add cutover guard so these runtime paths do not regress to airc_core.config

Verification
- cargo fmt -p airc-cli
- cargo test -p airc-cli config_
- python3 test/test_codex_rust_cutover.py
- bash -n airc install.sh uninstall.sh lib/airc_bash/*.sh
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace