### PR TITLE
feat(airc-rs): move host config block to rust

### DIFF
--- a/airc
+++ b/airc
@@ -1466,7 +1466,7 @@ _monitor_multi_channel() {
   # writes to the parent's stdout interleave at line boundaries.
   #
   # Args: my_name, TAB-separated "channel<TAB>gist_id" lines (one per
-  # subscribed channel, from airc_core.config list_channel_gists).
+  # subscribed channel, from airc-rs config list-channel-gists).
   local my_name="$1"
   local channel_map="$2"
 

--- a/crates/airc-cli/src/config_cli.rs
+++ b/crates/airc-cli/src/config_cli.rs
@@ -154,4 +154,26 @@ pub enum ConfigAction {
         #[arg(long, default_value = "")]
         gist_id: String,
     },
+
+    /// Persist host fields learned from a pairing handshake.
+    SetHostBlock {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Host airc home path.
+        #[arg(long, default_value = "")]
+        host_airc_home: String,
+        /// Host display name.
+        #[arg(long, default_value = "")]
+        host_name: String,
+        /// Host TCP port.
+        #[arg(long, default_value = "7547")]
+        host_port: String,
+        /// Host SSH public key.
+        #[arg(long, default_value = "")]
+        host_ssh_pub: String,
+        /// Host identity JSON blob.
+        #[arg(long, default_value = "{}")]
+        host_identity_json: String,
+    },
 }

--- a/crates/airc-cli/src/config_commands.rs
+++ b/crates/airc-cli/src/config_commands.rs
@@ -209,6 +209,49 @@ pub fn run_set_channel_gist(
     save_value(&config, &root)
 }
 
+#[derive(Debug)]
+pub struct HostBlockUpdate {
+    pub host_airc_home: String,
+    pub host_name: String,
+    pub host_port: String,
+    pub host_ssh_pub: String,
+    pub host_identity_json: String,
+}
+
+impl HostBlockUpdate {
+    fn parsed_port(&self) -> u16 {
+        self.host_port.parse().unwrap_or(7547)
+    }
+
+    fn parsed_identity(&self) -> Value {
+        serde_json::from_str(&self.host_identity_json).unwrap_or_else(|_| Value::Object(Map::new()))
+    }
+}
+
+pub fn run_set_host_block(
+    home: &Path,
+    config: Option<PathBuf>,
+    update: HostBlockUpdate,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let host_port = update.parsed_port();
+    let host_identity = update.parsed_identity();
+    let mut root = load_value(&config);
+    let object = object_mut(&mut root);
+    object.insert(
+        "host_airc_home".to_string(),
+        Value::String(update.host_airc_home),
+    );
+    object.insert("host_name".to_string(), Value::String(update.host_name));
+    object.insert("host_port".to_string(), Value::Number(host_port.into()));
+    object.insert(
+        "host_ssh_pub".to_string(),
+        Value::String(update.host_ssh_pub),
+    );
+    object.insert("host_identity".to_string(), host_identity);
+    save_value(&config, &root)
+}
+
 fn load_config(path: &Path) -> ConfigFile {
     fs::read_to_string(path)
         .ok()
@@ -445,5 +488,56 @@ mod tests {
 
         run_set_channel_gist(dir.path(), Some(path.clone()), "general", "").unwrap();
         assert!(!load_config(&path).channel_gists.contains_key("general"));
+    }
+
+    #[test]
+    fn set_host_block_writes_typed_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(&path, r#"{"name":"joiner"}"#).unwrap();
+
+        run_set_host_block(
+            dir.path(),
+            Some(path.clone()),
+            HostBlockUpdate {
+                host_airc_home: "/tmp/airc".to_string(),
+                host_name: "host".to_string(),
+                host_port: "7550".to_string(),
+                host_ssh_pub: "ssh-ed25519 AAA".to_string(),
+                host_identity_json: r#"{"role":"host"}"#.to_string(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(config_value(&path, "name", ""), "joiner");
+        assert_eq!(config_value(&path, "host_airc_home", ""), "/tmp/airc");
+        assert_eq!(config_value(&path, "host_name", ""), "host");
+        assert_eq!(config_value(&path, "host_port", ""), "7550");
+        assert_eq!(
+            config_value(&path, "host_identity", "{}"),
+            r#"{"role":"host"}"#
+        );
+    }
+
+    #[test]
+    fn set_host_block_defaults_bad_port_and_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+
+        run_set_host_block(
+            dir.path(),
+            Some(path.clone()),
+            HostBlockUpdate {
+                host_airc_home: String::new(),
+                host_name: String::new(),
+                host_port: "not-a-port".to_string(),
+                host_ssh_pub: String::new(),
+                host_identity_json: "not-json".to_string(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(config_value(&path, "host_port", ""), "7547");
+        assert_eq!(config_value(&path, "host_identity", ""), "{}");
     }
 }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -138,6 +138,24 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 channel,
                 gist_id,
             } => config_commands::run_set_channel_gist(&home, config, &channel, &gist_id),
+            ConfigAction::SetHostBlock {
+                config,
+                host_airc_home,
+                host_name,
+                host_port,
+                host_ssh_pub,
+                host_identity_json,
+            } => config_commands::run_set_host_block(
+                &home,
+                config,
+                config_commands::HostBlockUpdate {
+                    host_airc_home,
+                    host_name,
+                    host_port,
+                    host_ssh_pub,
+                    host_identity_json,
+                },
+            ),
         },
 
         Command::Send { text } => commands::run_send(&home, parsed.peers, &text).await,

--- a/crates/airc-cli/tests/config_commands.rs
+++ b/crates/airc-cli/tests/config_commands.rs
@@ -208,6 +208,43 @@ fn config_parted_rooms_are_idempotent() {
     assert_eq!(run_ok(home, &["config", "read-parted"]), "airc\n");
 }
 
+#[test]
+fn config_set_host_block_writes_handshake_fields() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+    fs::write(home.join("config.json"), r#"{"name":"joiner"}"#).unwrap();
+
+    run_ok(
+        home,
+        &[
+            "config",
+            "set-host-block",
+            "--host-airc-home",
+            "/tmp/host airc",
+            "--host-name",
+            "host",
+            "--host-port",
+            "7551",
+            "--host-ssh-pub",
+            "ssh-ed25519 AAA host",
+            "--host-identity-json",
+            r#"{"role":"host"}"#,
+        ],
+    );
+
+    assert_eq!(
+        run_ok(home, &["config", "get", "host_airc_home"]),
+        "/tmp/host airc\n"
+    );
+    assert_eq!(run_ok(home, &["config", "get", "host_name"]), "host\n");
+    assert_eq!(run_ok(home, &["config", "get", "host_port"]), "7551\n");
+    assert_eq!(
+        run_ok(home, &["config", "get", "host_identity", "{}"]),
+        "{\"role\":\"host\"}\n"
+    );
+    assert_eq!(run_ok(home, &["config", "get-name"]), "joiner\n");
+}
+
 fn run_ok(home: &Path, args: &[&str]) -> String {
     let output = Command::new(airc_rs())
         .arg("--home")

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1877,7 +1877,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
     # to env-var pass — python reads from os.environ; bash never
     # touches the python source. Also emit stderr to surface failures
     # for the future debugger (not /dev/null).
-    "$AIRC_PYTHON" -m airc_core.config set_host_block \
+    "$(airc_rs_bin)" config set-host-block --home "$AIRC_WRITE_DIR" \
         --config "$CONFIG" \
         --host-airc-home "$host_airc_home" \
         --host-name "$peer_name" \

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -512,7 +512,7 @@ _whois_in_scope() {
   [ -f "$scope_config" ] || return 1
 
   # All scope-local config + peer file reads route through
-  # get_config_val_in / airc_core.config (#152 Phase 1). Pre-migration
+  # get_config_val_in / airc-rs config. Pre-migration
   # this function had six inline python heredocs reading individual
   # JSON fields — each a silent-fail vector with bash-substituted
   # SCOPE_CONFIG / PEER_FILE env vars. Now: one CLI per read.

--- a/lib/airc_bash/cmd_rename.sh
+++ b/lib/airc_bash/cmd_rename.sh
@@ -127,7 +127,7 @@ sys.exit(0 if (target in seen and target not in my_history) else 1)
   fi
 
   # Phase 1: write the new name into THIS scope's config (the truth-
-  # layer effect for this scope). Goes through airc_core.config rather
+  # layer effect for this scope). Goes through airc-rs config rather
   # than an inline-python heredoc — the heredoc was quoting-fragile
   # (would have broken on a name containing a single quote — currently
   # safe because the sanitizer keeps names in [a-z0-9-], but a sharp

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -140,6 +140,7 @@ class CodexRustCutoverTests(unittest.TestCase):
             "airc_core.config read_parted",
             "airc_core.config record_parted",
             "airc_core.config clear_parted",
+            "airc_core.config set_host_block",
         ]
         for needle in forbidden:
             self.assertNotIn(needle, combined)
@@ -147,6 +148,11 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" config get-name', combined)
         self.assertIn('"$(airc_rs_bin)" config set ', combined)
         self.assertIn('"$(airc_rs_bin)" config read-parted', combined)
+
+    def test_host_block_config_write_uses_airc_rs(self):
+        source = (REPO / "lib/airc_bash/cmd_connect.sh").read_text(encoding="utf-8")
+        self.assertNotIn("airc_core.config set_host_block", source)
+        self.assertIn('"$(airc_rs_bin)" config set-host-block', source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- add airc-rs config set-host-block with a typed HostBlockUpdate
- preserve legacy host_port and host_identity fallback behavior in Rust
- route join-time host config writes through airc-rs
- add CLI tests and cutover guard for the host-block path

Verification
- cargo fmt -p airc-cli
- cargo test -p airc-cli config_
- python3 test/test_codex_rust_cutover.py
- bash -n airc install.sh uninstall.sh lib/airc_bash/*.sh
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace