### PR TITLE
feat(airc-rs): derive daemon scope ids in rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "temp-env",
  "tempfile",

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -26,6 +26,7 @@ futures = "0.3"
 uuid = { version = "1", features = ["v4", "v5"] }
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
 sha2 = "0.10"
+sha1 = "0.10"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -249,6 +249,12 @@ pub enum Command {
         /// Timestamp in `YYYY-MM-DDTHH:MM:SSZ` form.
         timestamp: String,
     },
+
+    /// Print the stable daemon service suffix for an airc scope path.
+    DaemonScopeId {
+        /// Scope path. Defaults to `$AIRC_HOME`, then `$HOME/.airc`.
+        scope: Option<String>,
+    },
 }
 
 #[derive(Debug, Args)]

--- a/crates/airc-cli/src/daemon_scope.rs
+++ b/crates/airc-cli/src/daemon_scope.rs
@@ -1,0 +1,34 @@
+use sha1::{Digest, Sha1};
+
+pub fn default_scope() -> String {
+    if let Some(home) = std::env::var_os("AIRC_HOME") {
+        return home.to_string_lossy().into_owned();
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return format!("{}/.airc", home.to_string_lossy());
+    }
+    ".airc".to_string()
+}
+
+pub fn scope_id(scope: &str) -> String {
+    let mut hasher = Sha1::new();
+    hasher.update(scope.as_bytes());
+    let hex = format!("{:x}", hasher.finalize());
+    hex[..12].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_id_matches_legacy_sha1_prefix() {
+        assert_eq!(scope_id("/tmp/airc"), "dcb77ec809c5");
+    }
+
+    #[test]
+    fn scope_id_is_stable_and_distinguishes_scopes() {
+        assert_eq!(scope_id("/tmp/airc"), scope_id("/tmp/airc"));
+        assert_ne!(scope_id("/tmp/airc"), scope_id("/tmp/airc-other"));
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -23,6 +23,7 @@ mod codex_start;
 mod commands;
 mod config_cli;
 mod config_commands;
+mod daemon_scope;
 mod events_cli;
 mod events_commands;
 mod gist_cli;
@@ -382,6 +383,12 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
         Command::IsoToEpoch { timestamp } => {
             println!("{}", airc_core::iso_to_epoch(&timestamp)?);
+            Ok(())
+        }
+
+        Command::DaemonScopeId { scope } => {
+            let scope = scope.unwrap_or_else(daemon_scope::default_scope);
+            println!("{}", daemon_scope::scope_id(&scope));
             Ok(())
         }
     }

--- a/crates/airc-cli/tests/daemon_scope_commands.rs
+++ b/crates/airc-cli/tests/daemon_scope_commands.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+
+fn airc_rs() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-rs")
+}
+
+#[test]
+fn daemon_scope_id_matches_legacy_sha1_prefix() {
+    let output = Command::new(airc_rs())
+        .args(["daemon-scope-id", "/tmp/airc"])
+        .output()
+        .expect("airc-rs daemon-scope-id must spawn");
+
+    assert!(
+        output.status.success(),
+        "daemon-scope-id failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), "dcb77ec809c5\n");
+}

--- a/lib/airc_bash/lib_daemon_detect.sh
+++ b/lib/airc_bash/lib_daemon_detect.sh
@@ -24,7 +24,11 @@ airc_daemon_scope_id() {
   local target_scope="${1:-}"
   [ -n "$target_scope" ] || target_scope="${AIRC_HOME:-$HOME/.airc}"
   local id=""
-  id=$(python3 -c 'import hashlib,sys; print(hashlib.sha1(sys.argv[1].encode()).hexdigest()[:12])' "$target_scope" 2>/dev/null || true)
+  if command -v airc_rs_bin >/dev/null 2>&1; then
+    id=$("$(airc_rs_bin)" daemon-scope-id "$target_scope" 2>/dev/null || true)
+  elif command -v airc-rs >/dev/null 2>&1; then
+    id=$(airc-rs daemon-scope-id "$target_scope" 2>/dev/null || true)
+  fi
   if [ -z "$id" ] && command -v sha1sum >/dev/null 2>&1; then
     id=$(printf '%s' "$target_scope" | sha1sum 2>/dev/null | awk '{print substr($1,1,12)}')
   fi

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -154,6 +154,15 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("airc_core.config set_host_block", source)
         self.assertIn('"$(airc_rs_bin)" config set-host-block', source)
 
+    def test_daemon_scope_id_does_not_use_python(self):
+        source = (REPO / "lib/airc_bash/lib_daemon_detect.sh").read_text(encoding="utf-8")
+        start = source.index("airc_daemon_scope_id()")
+        end = source.index("airc_daemon_service_name_for_scope()", start)
+        body = source[start:end]
+
+        self.assertNotIn("python3 -c", body)
+        self.assertIn('"$(airc_rs_bin)" daemon-scope-id "$target_scope"', body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary
- add airc-rs daemon-scope-id using the legacy SHA-1/12-char service suffix contract
- route daemon install detection through airc-rs instead of python3 -c
- keep shell hash tools only as bootstrap compatibility when airc-rs is unavailable
- add CLI and cutover guard coverage

Verification
- cargo fmt -p airc-cli
- cargo test -p airc-cli daemon_scope
- python3 test/test_codex_rust_cutover.py
- bash -n airc install.sh uninstall.sh lib/airc_bash/*.sh
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace