### PR TITLE
feat(airc-rs): parse doctor rate-limit json in rust

### DIFF
--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -459,8 +459,8 @@ _doctor_health() {
     local rate_json
     if rate_json=$(airc_gh_rate_limit_json_cached); then
       local core_remaining core_limit
-      core_remaining=$(echo "$rate_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['resources']['core']['remaining'])" 2>/dev/null || echo "")
-      core_limit=$(echo "$rate_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['resources']['core']['limit'])" 2>/dev/null || echo "")
+      core_remaining=$(printf '%s' "$rate_json" | "$(airc_rs_bin)" gist get .resources.core.remaining 2>/dev/null || echo "")
+      core_limit=$(printf '%s' "$rate_json" | "$(airc_rs_bin)" gist get .resources.core.limit 2>/dev/null || echo "")
       if [ -n "$core_remaining" ] && [ -n "$core_limit" ]; then
         if [ "$core_remaining" -lt 100 ]; then
           printf "  [WARN] gh core rate-limit: %s/%s remaining — bus may stall soon\n" "$core_remaining" "$core_limit"

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -163,6 +163,16 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("python3 -c", body)
         self.assertIn('"$(airc_rs_bin)" daemon-scope-id "$target_scope"', body)
 
+    def test_doctor_rate_limit_json_uses_airc_rs(self):
+        source = (REPO / "lib/airc_bash/cmd_doctor.sh").read_text(encoding="utf-8")
+        start = source.index("airc doctor --health -- live bus health")
+        end = source.index("# ── gh request governor", start)
+        body = source[start:end]
+
+        self.assertNotIn("python3 -c", body)
+        self.assertIn('"$(airc_rs_bin)" gist get .resources.core.remaining', body)
+        self.assertIn('"$(airc_rs_bin)" gist get .resources.core.limit', body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary
- route doctor GitHub rate-limit JSON field reads through airc-rs gist get
- remove the python3 -c JSON parsing from the live health path
- add a cutover guard for the doctor rate-limit block

Verification
- python3 test/test_codex_rust_cutover.py
- bash -n airc install.sh uninstall.sh lib/airc_bash/*.sh
- printf sample JSON | cargo run -q -p airc-cli -- gist get .resources.core.remaining
- printf sample JSON | cargo run -q -p airc-cli -- gist get .resources.core.limit
- cargo fmt -p airc-cli --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace