### PR TITLE
feat(airc-rs): render whois identity output in rust

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -19,6 +19,7 @@ use airc_lib::PeerSpec;
 use crate::codex_cli::{CodexHookArgs, CodexStartArgs};
 use crate::config_cli::ConfigArgs;
 use crate::gist_cli::GistArgs;
+use crate::identity_cli::IdentityArgs;
 use crate::route_cli::RouteArgs;
 use crate::transport_cli::TransportArgs;
 use crate::work_cli::WorkArgs;
@@ -90,6 +91,9 @@ pub enum Command {
 
     /// Read and update legacy config.json during Rust cutover.
     Config(ConfigArgs),
+
+    /// Identity and whois helpers during Rust cutover.
+    Identity(IdentityArgs),
 
     /// Send a single text Message frame to the current room and exit.
     /// The current room lives in `<home>/room.json`; switch with

--- a/crates/airc-cli/src/identity_cli.rs
+++ b/crates/airc-cli/src/identity_cli.rs
@@ -1,0 +1,23 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct IdentityArgs {
+    #[command(subcommand)]
+    pub action: IdentityAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum IdentityAction {
+    /// Pretty-print an identity JSON blob for whois output.
+    Pretty {
+        /// Display name to show.
+        #[arg(long)]
+        name: String,
+        /// Identity JSON blob.
+        #[arg(long, default_value = "{}")]
+        identity_json: String,
+        /// Optional host address.
+        #[arg(long, default_value = "")]
+        host: String,
+    },
+}

--- a/crates/airc-cli/src/identity_commands.rs
+++ b/crates/airc-cli/src/identity_commands.rs
@@ -1,0 +1,49 @@
+use std::error::Error;
+
+use serde_json::Value;
+
+const IDENTITY_FIELDS: &[&str] = &["pronouns", "role", "bio", "status"];
+
+pub fn run_pretty(name: &str, identity_json: &str, host: &str) -> Result<(), Box<dyn Error>> {
+    let identity: Value =
+        serde_json::from_str(identity_json).unwrap_or_else(|_| Value::Object(Default::default()));
+
+    println!("  name:      {name}");
+    for field in IDENTITY_FIELDS {
+        let label = format!("{field}:");
+        let value = identity
+            .get(field)
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("(unset)");
+        println!("  {label:<11} {value}");
+    }
+
+    let integrations = identity.get("integrations").and_then(Value::as_object);
+    if let Some(integrations) = integrations.filter(|items| !items.is_empty()) {
+        println!("  integrations:");
+        for (key, value) in integrations {
+            let text = value
+                .as_str()
+                .map_or_else(|| value.to_string(), str::to_string);
+            println!("    {key}: {text}");
+        }
+    } else {
+        println!("  integrations: (none)");
+    }
+
+    if !host.is_empty() {
+        println!("  host:      {host}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn malformed_identity_is_treated_as_empty() {
+        assert!(run_pretty("alice", "not-json", "").is_ok());
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -28,6 +28,8 @@ mod events_cli;
 mod events_commands;
 mod gist_cli;
 mod gist_commands;
+mod identity_cli;
+mod identity_commands;
 mod lane_cli;
 mod lane_commands;
 mod log_cli;
@@ -56,6 +58,7 @@ use codex_cli::CodexHookAction;
 use config_cli::ConfigAction;
 use events_cli::EventsAction;
 use gist_cli::GistAction;
+use identity_cli::IdentityAction;
 use lane_cli::{LaneAction, LaneManagerAction};
 use log_cli::LogAction;
 use route_cli::RouteAction;
@@ -157,6 +160,14 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     host_identity_json,
                 },
             ),
+        },
+
+        Command::Identity(args) => match args.action {
+            IdentityAction::Pretty {
+                name,
+                identity_json,
+                host,
+            } => identity_commands::run_pretty(&name, &identity_json, &host),
         },
 
         Command::Send { text } => commands::run_send(&home, parsed.peers, &text).await,

--- a/crates/airc-cli/tests/identity_commands.rs
+++ b/crates/airc-cli/tests/identity_commands.rs
@@ -1,0 +1,55 @@
+use std::process::Command;
+
+fn airc_rs() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-rs")
+}
+
+#[test]
+fn identity_pretty_matches_whois_shape() {
+    let output = Command::new(airc_rs())
+        .args([
+            "identity",
+            "pretty",
+            "--name",
+            "alice",
+            "--identity-json",
+            r#"{"pronouns":"she","role":"builder","bio":"makes things","status":"away","integrations":{"continuum":"alice-c"}}"#,
+            "--host",
+            "alice.local",
+        ])
+        .output()
+        .expect("airc-rs identity pretty must spawn");
+
+    assert!(
+        output.status.success(),
+        "identity pretty failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        concat!(
+            "  name:      alice\n",
+            "  pronouns:   she\n",
+            "  role:       builder\n",
+            "  bio:        makes things\n",
+            "  status:     away\n",
+            "  integrations:\n",
+            "    continuum: alice-c\n",
+            "  host:      alice.local\n",
+        )
+    );
+}
+
+#[test]
+fn identity_pretty_defaults_unset_fields() {
+    let output = Command::new(airc_rs())
+        .args(["identity", "pretty", "--name", "alice"])
+        .output()
+        .expect("airc-rs identity pretty must spawn");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("  pronouns:   (unset)\n"));
+    assert!(stdout.contains("  integrations: (none)\n"));
+}

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -561,33 +561,7 @@ _whois_in_scope() {
 # Args: name, identity-json, host (any may be empty).
 _whois_pretty() {
   local name="$1" blob="${2:-{\}}" host="${3:-}"
-  NAME="$name" BLOB="$blob" HOST="$host" python3 <<'PYEOF'
-import json, os
-name = os.environ["NAME"]
-host = os.environ.get("HOST", "")
-try:
-    ident = json.loads(os.environ.get("BLOB", "{}") or "{}")
-except Exception:
-    ident = {}
-print(f"  name:      {name}")
-fields = [("pronouns", ident.get("pronouns", "")),
-          ("role",     ident.get("role", "")),
-          ("bio",      ident.get("bio", "")),
-          ("status",   ident.get("status", ""))]
-for k, v in fields:
-    label = k + ":"
-    fallback = "(unset)"
-    print(f"  {label:<11} {v if v else fallback}")
-ints = ident.get("integrations", {}) or {}
-if ints:
-    print("  integrations:")
-    for k, v in ints.items():
-        print(f"    {k}: {v}")
-else:
-    print("  integrations: (none)")
-if host:
-    print(f"  host:      {host}")
-PYEOF
+  "$(airc_rs_bin)" identity pretty --name "$name" --identity-json "$blob" --host "$host"
 }
 
 # cmd_kick extracted to lib/airc_bash/cmd_kick.sh

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -173,6 +173,15 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" gist get .resources.core.remaining', body)
         self.assertIn('"$(airc_rs_bin)" gist get .resources.core.limit', body)
 
+    def test_whois_pretty_uses_airc_rs(self):
+        source = (REPO / "lib/airc_bash/cmd_identity.sh").read_text(encoding="utf-8")
+        start = source.index("_whois_pretty()")
+        end = source.index("# cmd_kick extracted", start)
+        body = source[start:end]
+
+        self.assertNotIn("python3 <<", body)
+        self.assertIn('"$(airc_rs_bin)" identity pretty', body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary
- add airc-rs identity pretty for whois identity rendering
- route _whois_pretty through Rust instead of an inline python heredoc
- add CLI tests for populated and unset identity output
- add a cutover guard for the whois pretty path

Verification
- cargo fmt -p airc-cli
- cargo test -p airc-cli identity
- python3 test/test_codex_rust_cutover.py
- bash -n airc install.sh uninstall.sh lib/airc_bash/*.sh
- cargo fmt -p airc-cli --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace