### PR TITLE
feat(airc-cli): move message crypto helpers to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,9 +43,13 @@ dependencies = [
  "airc-store",
  "airc-transport",
  "base64",
+ "chacha20poly1305",
  "clap",
+ "ed25519-dalek",
  "futures",
+ "hkdf",
  "libc",
+ "rand_core",
  "rustls",
  "serde",
  "serde_json",
@@ -46,6 +60,7 @@ dependencies = [
  "tokio",
  "toml_edit",
  "uuid",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -435,6 +450,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +510,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -592,6 +642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -766,6 +817,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "rand_core",
  "serde",
  "sha2",
  "subtle",
@@ -1263,6 +1315,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1593,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,6 +1732,17 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2857,6 +2935,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3388,6 +3476,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3490,6 +3590,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/airc
+++ b/airc
@@ -89,11 +89,9 @@ fi
 export AIRC_PYTHON
 
 # Issue #341 follow-up: shell openssl is no longer used for Ed25519
-# identity gen / signing. Both paths now route through the venv
-# cryptography module (airc_core.identity bootstrap-ed25519 / sign-
-# ed25519). The prior _resolve_openssl + AIRC_OPENSSL + _die helper
-# were #342's loud-failure mitigation; once truth moved to Python they
-# became dead code and were removed in this commit. ssh-keygen still
+# identity gen / signing. The prior _resolve_openssl + AIRC_OPENSSL +
+# _die helper were #342's loud-failure mitigation; once truth moved to
+# the Rust CLI they became dead code and were removed. ssh-keygen still
 # stays — that's an OpenSSH client tool, separate from libcrypto, and
 # every supported platform ships a working version.
 
@@ -1216,11 +1214,7 @@ humanhash() {
 }
 
 sign_message() {
-  # Sign message bytes via the venv cryptography path (issue #341 — the
-  # prior shell openssl call broke on macOS LibreSSL silently). Identity
-  # module's sign-ed25519 reads from stdin, prints base64 sig matching
-  # the prior `openssl pkeyutl -sign | base64` output byte-for-byte.
-  printf '%s' "$1" | "$AIRC_PYTHON" -m airc_core.identity sign-ed25519 --dir "$IDENTITY_DIR"
+  printf '%s' "$1" | "$(airc_rs_bin)" identity sign-ed25519 --home "$AIRC_WRITE_DIR" --dir "$IDENTITY_DIR"
 }
 
 # ── Platform adapters ───────────────────────────────────────────────────
@@ -1435,8 +1429,8 @@ init_identity() {
   # PEM format the openssl path produced, so existing scopes upgrade
   # in place without rotating keys.
   if [ ! -f "$IDENTITY_DIR/private.pem" ]; then
-    if ! "$AIRC_PYTHON" -m airc_core.identity bootstrap-ed25519 --dir "$IDENTITY_DIR"; then
-      die "Ed25519 identity bootstrap failed — check that the venv has the cryptography package (re-run install.sh)"
+    if ! "$(airc_rs_bin)" identity bootstrap-ed25519 --home "$AIRC_WRITE_DIR" --dir "$IDENTITY_DIR"; then
+      die "Ed25519 identity bootstrap failed"
     fi
   fi
   if [ ! -f "$IDENTITY_DIR/ssh_key" ]; then
@@ -1449,10 +1443,7 @@ init_identity() {
     }
   fi
   # Phase E.2: bootstrap X25519 keypair for envelope encryption.
-  # Idempotent — exits silently if files exist or cryptography isn't
-  # installed (in which case airc gracefully falls back to plaintext
-  # for ALL peers; tests cover both paths).
-  "$AIRC_PYTHON" -m airc_core.identity bootstrap --dir "$IDENTITY_DIR" >/dev/null 2>&1 || true
+  "$(airc_rs_bin)" identity bootstrap --home "$AIRC_WRITE_DIR" --dir "$IDENTITY_DIR" >/dev/null
   touch "$MESSAGES"
 }
 
@@ -2020,11 +2011,7 @@ EOF
       local _batch_outcome _batch_kind
       _batch_outcome=$(cat "$snapshot" | "$AIRC_PYTHON" -m airc_core.bearer_cli send-batch \
         all "$_batch_channel" --room-gist-id "$_batch_gist" 2>/dev/null || echo '{"kind":"transient_failure"}')
-      _batch_kind=$(printf '%s' "$_batch_outcome" | "$AIRC_PYTHON" -c 'import json,sys
-try:
-  print(json.load(sys.stdin).get("kind",""))
-except Exception:
-  print("")' 2>/dev/null)
+      _batch_kind=$(printf '%s' "$_batch_outcome" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
       if [ "$_batch_kind" = "delivered" ]; then
         cat "$snapshot" >> "$MESSAGES"
         delivered=${_batch_count:-0}
@@ -2043,11 +2030,7 @@ except Exception:
       # never the wrapped envelope — cmd_send queues pre-wrap so the
       # drain can re-resolve recipient pubkey at retry time).
       local _line_channel
-      _line_channel=$(printf '%s\n' "$line" | "$AIRC_PYTHON" -c 'import json,sys
-try:
-  print(json.loads(sys.stdin.readline()).get("channel",""))
-except Exception:
-  print("")' 2>/dev/null)
+      _line_channel=$(printf '%s\n' "$line" | "$(airc_rs_bin)" gist get .channel 2>/dev/null)
 
       # Resolve channel → gist. Fall back to legacy room_gist_id only
       # when the line carries no channel (older queued lines may pre-date
@@ -2070,20 +2053,16 @@ except Exception:
       # Re-resolve recipient pubkey at drain time. Pre-pair queued lines
       # shipped plaintext; post-pair drain wraps them with the new pubkey.
       local _line_to
-      _line_to=$(printf '%s\n' "$line" | "$AIRC_PYTHON" -c 'import json,sys
-try:
-  print(json.loads(sys.stdin.readline()).get("to",""))
-except Exception:
-  print("")' 2>/dev/null)
+      _line_to=$(printf '%s\n' "$line" | "$(airc_rs_bin)" gist get .to 2>/dev/null)
       local _line_pub=""
       if [ -n "$_line_to" ] && [ "$_line_to" != "all" ]; then
-        _line_pub=$("$AIRC_PYTHON" -m airc_core.identity peer_pub \
+        _line_pub=$("$(airc_rs_bin)" identity peer-pub --home "$AIRC_WRITE_DIR" \
           --peers-dir "$PEERS_DIR" --peer-name "$_line_to" 2>/dev/null || true)
       fi
       local _wire="$line"
       if [ -n "$_line_pub" ]; then
-        _wire=$(printf '%s' "$line" | "$AIRC_PYTHON" -m airc_core.envelope wrap \
-          --recipient-pub "$_line_pub" \
+        _wire=$(printf '%s' "$line" | "$(airc_rs_bin)" envelope wrap --home "$AIRC_WRITE_DIR" \
+          --recipient-pub="$_line_pub" \
           --identity-dir "$IDENTITY_DIR" 2>/dev/null || printf '%s' "$line")
       fi
 
@@ -2091,11 +2070,7 @@ except Exception:
       _outcome=$(printf '%s' "$_wire" | "$AIRC_PYTHON" -m airc_core.bearer_cli send \
         "${_line_to:-all}" "$_line_channel" \
         --room-gist-id "$_line_gist" 2>/dev/null || echo '{"kind":"transient_failure"}')
-      _kind=$(printf '%s' "$_outcome" | "$AIRC_PYTHON" -c 'import json,sys
-try:
-  print(json.load(sys.stdin).get("kind",""))
-except Exception:
-  print("")' 2>/dev/null)
+      _kind=$(printf '%s' "$_outcome" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
 
       case "$_kind" in
         delivered)

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -27,6 +27,11 @@ uuid = { version = "1", features = ["v4", "v5"] }
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
 sha2 = "0.10"
 sha1 = "0.10"
+ed25519-dalek = { version = "2", features = ["pkcs8", "pem", "rand_core"] }
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+chacha20poly1305 = "0.10"
+hkdf = "0.12"
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -18,6 +18,7 @@ use airc_lib::PeerSpec;
 
 use crate::codex_cli::{CodexHookArgs, CodexStartArgs};
 use crate::config_cli::ConfigArgs;
+use crate::envelope_cli::EnvelopeArgs;
 use crate::gist_cli::GistArgs;
 use crate::identity_cli::IdentityArgs;
 use crate::route_cli::RouteArgs;
@@ -94,6 +95,9 @@ pub enum Command {
 
     /// Identity and whois helpers during Rust cutover.
     Identity(IdentityArgs),
+
+    /// Legacy envelope encryption helpers during Rust cutover.
+    Envelope(EnvelopeArgs),
 
     /// Send a single text Message frame to the current room and exit.
     /// The current room lives in `<home>/room.json`; switch with

--- a/crates/airc-cli/src/envelope_cli.rs
+++ b/crates/airc-cli/src/envelope_cli.rs
@@ -1,0 +1,20 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct EnvelopeArgs {
+    #[command(subcommand)]
+    pub action: EnvelopeAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum EnvelopeAction {
+    /// Encrypt the legacy envelope `msg` field for a recipient.
+    Wrap {
+        /// Recipient X25519 public key, URL-safe base64 without padding.
+        #[arg(long, default_value = "")]
+        recipient_pub: String,
+        /// Legacy identity directory containing x25519_priv.
+        #[arg(long)]
+        identity_dir: std::path::PathBuf,
+    },
+}

--- a/crates/airc-cli/src/identity_cli.rs
+++ b/crates/airc-cli/src/identity_cli.rs
@@ -8,6 +8,37 @@ pub struct IdentityArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum IdentityAction {
+    /// Generate the legacy X25519 keypair if missing and print the pubkey.
+    Bootstrap {
+        /// Legacy identity directory containing x25519_priv/x25519_pub.
+        #[arg(long = "dir")]
+        identity_dir: std::path::PathBuf,
+    },
+
+    /// Generate the legacy Ed25519 PEM keypair if missing.
+    BootstrapEd25519 {
+        /// Legacy identity directory containing private.pem/public.pem.
+        #[arg(long = "dir")]
+        identity_dir: std::path::PathBuf,
+    },
+
+    /// Print an enrolled peer's legacy X25519 public key.
+    PeerPub {
+        /// Legacy peers directory containing <peer>.json files.
+        #[arg(long)]
+        peers_dir: std::path::PathBuf,
+        /// Peer display/name key.
+        #[arg(long)]
+        peer_name: String,
+    },
+
+    /// Sign stdin bytes with the legacy Ed25519 PEM identity.
+    SignEd25519 {
+        /// Legacy identity directory containing private.pem.
+        #[arg(long = "dir")]
+        identity_dir: std::path::PathBuf,
+    },
+
     /// Pretty-print an identity JSON blob for whois output.
     Pretty {
         /// Display name to show.

--- a/crates/airc-cli/src/legacy_envelope.rs
+++ b/crates/airc-cli/src/legacy_envelope.rs
@@ -1,0 +1,150 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::io::{self, Read};
+use std::path::Path;
+
+use base64::{engine::general_purpose, Engine};
+use chacha20poly1305::aead::{Aead, AeadCore, KeyInit, OsRng};
+use chacha20poly1305::ChaCha20Poly1305;
+use hkdf::Hkdf;
+use serde_json::Value;
+use sha2::Sha256;
+use x25519_dalek::{PublicKey, StaticSecret};
+
+use crate::legacy_identity;
+
+const ENC_VERSION: &str = "v1";
+const AEAD_INFO: &[u8] = b"airc-aead-v1";
+
+pub fn wrap_stdin(recipient_pub: &str, identity_dir: &Path) -> Result<(), Box<dyn Error>> {
+    let mut raw = String::new();
+    io::stdin().read_to_string(&mut raw)?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+
+    let Ok(mut envelope) = serde_json::from_str::<Value>(trimmed) else {
+        println!("{trimmed}");
+        return Ok(());
+    };
+    if recipient_pub.is_empty() {
+        println!("{}", serde_json::to_string(&envelope)?);
+        return Ok(());
+    }
+
+    let sender_priv = legacy_identity::load_x25519_private(identity_dir)?;
+    let recipient_pub = legacy_identity::b64_url_decode(recipient_pub)?;
+    let recipient_pub: [u8; 32] = recipient_pub.try_into().map_err(|data: Vec<u8>| {
+        format!(
+            "recipient X25519 public key is {} bytes; expected 32",
+            data.len()
+        )
+    })?;
+    wrap_value(&mut envelope, sender_priv, recipient_pub)?;
+    println!("{}", serde_json::to_string(&envelope)?);
+    Ok(())
+}
+
+fn wrap_value(
+    envelope: &mut Value,
+    sender_priv: [u8; 32],
+    recipient_pub: [u8; 32],
+) -> Result<(), Box<dyn Error>> {
+    let msg = envelope.get("msg").and_then(Value::as_str).map_or_else(
+        || {
+            envelope
+                .get("msg")
+                .map_or_else(String::new, Value::to_string)
+        },
+        str::to_owned,
+    );
+    let ad = associated_data(envelope)?;
+    let key = derive_pairwise_key(sender_priv, recipient_pub)?;
+    let cipher = ChaCha20Poly1305::new_from_slice(&key)?;
+    let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+    let ciphertext = cipher
+        .encrypt(
+            &nonce,
+            chacha20poly1305::aead::Payload {
+                msg: msg.as_bytes(),
+                aad: ad.as_bytes(),
+            },
+        )
+        .map_err(|_| "legacy envelope encryption failed")?;
+
+    let object = envelope
+        .as_object_mut()
+        .ok_or("legacy envelope must be a JSON object")?;
+    object.insert(
+        "msg".to_string(),
+        Value::String(b64_url_no_pad(&ciphertext)),
+    );
+    object.insert("nonce".to_string(), Value::String(b64_url_no_pad(&nonce)));
+    object.insert("enc".to_string(), Value::String(ENC_VERSION.to_string()));
+    Ok(())
+}
+
+fn derive_pairwise_key(
+    sender_priv: [u8; 32],
+    recipient_pub: [u8; 32],
+) -> Result<[u8; 32], Box<dyn Error>> {
+    let secret = StaticSecret::from(sender_priv);
+    let public = PublicKey::from(recipient_pub);
+    let shared = secret.diffie_hellman(&public);
+    let hkdf = Hkdf::<Sha256>::new(None, shared.as_bytes());
+    let mut key = [0u8; 32];
+    hkdf.expand(AEAD_INFO, &mut key)
+        .map_err(|_| "HKDF output length is invalid")?;
+    Ok(key)
+}
+
+fn associated_data(envelope: &Value) -> Result<String, Box<dyn Error>> {
+    let mut fields = BTreeMap::new();
+    fields.insert("channel", string_field(envelope, "channel"));
+    fields.insert("from", string_field(envelope, "from"));
+    let kind = envelope
+        .get("kind")
+        .and_then(Value::as_str)
+        .unwrap_or("chat")
+        .to_string();
+    fields.insert("kind", kind);
+    fields.insert("to", string_field(envelope, "to"));
+    fields.insert("ts", string_field(envelope, "ts"));
+    Ok(serde_json::to_string(&fields)?)
+}
+
+fn string_field(envelope: &Value, key: &str) -> String {
+    envelope
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string()
+}
+
+fn b64_url_no_pad(bytes: &[u8]) -> String {
+    general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn associated_data_matches_legacy_sorted_json() {
+        let envelope = json!({
+            "from": "alice",
+            "to": "bob",
+            "ts": "2026-05-19T00:00:00Z",
+            "channel": "general",
+            "kind": "heartbeat",
+            "msg": "hello"
+        });
+
+        assert_eq!(
+            associated_data(&envelope).unwrap(),
+            r#"{"channel":"general","from":"alice","kind":"heartbeat","to":"bob","ts":"2026-05-19T00:00:00Z"}"#
+        );
+    }
+}

--- a/crates/airc-cli/src/legacy_identity.rs
+++ b/crates/airc-cli/src/legacy_identity.rs
@@ -1,0 +1,166 @@
+use std::error::Error;
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+use base64::{engine::general_purpose, Engine};
+use ed25519_dalek::pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey};
+use ed25519_dalek::{Signer, SigningKey};
+use rand_core::{OsRng, RngCore};
+use serde_json::Value;
+use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret};
+
+const X25519_PRIV: &str = "x25519_priv";
+const X25519_PUB: &str = "x25519_pub";
+const ED25519_PRIV: &str = "private.pem";
+const ED25519_PUB: &str = "public.pem";
+
+pub fn bootstrap_x25519(identity_dir: &Path) -> Result<String, Box<dyn Error>> {
+    let (priv_path, pub_path) = x25519_paths(identity_dir);
+    if priv_path.exists() && pub_path.exists() {
+        return Ok(b64_url_no_pad(&read_exact_32(
+            &pub_path,
+            "X25519 public key",
+        )?));
+    }
+
+    let secret = StaticSecret::random_from_rng(OsRng);
+    let public = X25519PublicKey::from(&secret);
+    atomic_write(&priv_path, secret.to_bytes().as_slice(), private_mode())?;
+    atomic_write(&pub_path, public.as_bytes(), public_mode())?;
+    Ok(b64_url_no_pad(public.as_bytes()))
+}
+
+pub fn bootstrap_ed25519(identity_dir: &Path) -> Result<(), Box<dyn Error>> {
+    let priv_path = identity_dir.join(ED25519_PRIV);
+    let pub_path = identity_dir.join(ED25519_PUB);
+    if priv_path.exists() && pub_path.exists() {
+        return Ok(());
+    }
+
+    let mut seed = [0u8; 32];
+    OsRng.fill_bytes(&mut seed);
+    let signing = SigningKey::from_bytes(&seed);
+    let priv_pem = signing.to_pkcs8_pem(Default::default())?;
+    let pub_pem = signing
+        .verifying_key()
+        .to_public_key_pem(Default::default())?;
+    atomic_write(&priv_path, priv_pem.as_bytes(), private_mode())?;
+    atomic_write(&pub_path, pub_pem.as_bytes(), public_mode())?;
+    Ok(())
+}
+
+pub fn peer_pub(peers_dir: &Path, peer_name: &str) -> Result<Option<String>, Box<dyn Error>> {
+    let path = peers_dir.join(format!("{peer_name}.json"));
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let value: Value = serde_json::from_str(&raw)?;
+    let Some(encoded) = value.get(X25519_PUB).and_then(Value::as_str) else {
+        return Ok(None);
+    };
+    let decoded = b64_url_decode(encoded)?;
+    if decoded.len() != 32 {
+        return Ok(None);
+    }
+    Ok(Some(b64_url_no_pad(&decoded)))
+}
+
+pub fn sign_ed25519_stdin(identity_dir: &Path) -> Result<String, Box<dyn Error>> {
+    let mut data = Vec::new();
+    io::stdin().read_to_end(&mut data)?;
+    let pem = fs::read_to_string(identity_dir.join(ED25519_PRIV))?;
+    let signing = SigningKey::from_pkcs8_pem(&pem)?;
+    let signature = signing.sign(&data);
+    Ok(general_purpose::STANDARD.encode(signature.to_bytes()))
+}
+
+pub fn load_x25519_private(identity_dir: &Path) -> Result<[u8; 32], Box<dyn Error>> {
+    read_exact_32(&identity_dir.join(X25519_PRIV), "X25519 private key")
+}
+
+fn x25519_paths(identity_dir: &Path) -> (PathBuf, PathBuf) {
+    (
+        identity_dir.join(X25519_PRIV),
+        identity_dir.join(X25519_PUB),
+    )
+}
+
+fn read_exact_32(path: &Path, label: &str) -> Result<[u8; 32], Box<dyn Error>> {
+    let raw = fs::read(path)?;
+    let bytes: [u8; 32] = raw.try_into().map_err(|data: Vec<u8>| {
+        format!(
+            "{label} at {} is {} bytes; expected 32",
+            path.display(),
+            data.len()
+        )
+    })?;
+    Ok(bytes)
+}
+
+fn b64_url_no_pad(bytes: &[u8]) -> String {
+    general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+pub fn b64_url_decode(input: &str) -> Result<Vec<u8>, Box<dyn Error>> {
+    Ok(general_purpose::URL_SAFE_NO_PAD.decode(input)?)
+}
+
+fn atomic_write(path: &Path, bytes: &[u8], mode: u32) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+    set_permissions(&tmp, mode)?;
+    fs::rename(tmp, path)
+}
+
+#[cfg(unix)]
+fn set_permissions(path: &Path, mode: u32) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))
+}
+
+#[cfg(not(unix))]
+fn set_permissions(_path: &Path, _mode: u32) -> io::Result<()> {
+    Ok(())
+}
+
+const fn private_mode() -> u32 {
+    0o600
+}
+
+const fn public_mode() -> u32 {
+    0o644
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn x25519_bootstrap_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = bootstrap_x25519(dir.path()).unwrap();
+        let second = bootstrap_x25519(dir.path()).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(b64_url_decode(&first).unwrap().len(), 32);
+    }
+
+    #[test]
+    fn peer_pub_reads_legacy_peer_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let encoded = b64_url_no_pad(&[7u8; 32]);
+        fs::write(
+            dir.path().join("alice.json"),
+            format!(r#"{{"x25519_pub":"{encoded}"}}"#),
+        )
+        .unwrap();
+
+        assert_eq!(peer_pub(dir.path(), "alice").unwrap(), Some(encoded));
+        assert_eq!(peer_pub(dir.path(), "bob").unwrap(), None);
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -24,6 +24,7 @@ mod commands;
 mod config_cli;
 mod config_commands;
 mod daemon_scope;
+mod envelope_cli;
 mod events_cli;
 mod events_commands;
 mod gist_cli;
@@ -32,6 +33,8 @@ mod identity_cli;
 mod identity_commands;
 mod lane_cli;
 mod lane_commands;
+mod legacy_envelope;
+mod legacy_identity;
 mod log_cli;
 mod log_commands;
 mod route_cli;
@@ -56,6 +59,7 @@ use airc_daemon::LocalIdentity;
 use cli::{Cli, Command, PeerAction};
 use codex_cli::CodexHookAction;
 use config_cli::ConfigAction;
+use envelope_cli::EnvelopeAction;
 use events_cli::EventsAction;
 use gist_cli::GistAction;
 use identity_cli::IdentityAction;
@@ -163,11 +167,38 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         },
 
         Command::Identity(args) => match args.action {
+            IdentityAction::Bootstrap { identity_dir } => {
+                println!("{}", legacy_identity::bootstrap_x25519(&identity_dir)?);
+                Ok(())
+            }
+            IdentityAction::BootstrapEd25519 { identity_dir } => {
+                legacy_identity::bootstrap_ed25519(&identity_dir)
+            }
+            IdentityAction::PeerPub {
+                peers_dir,
+                peer_name,
+            } => {
+                if let Some(pubkey) = legacy_identity::peer_pub(&peers_dir, &peer_name)? {
+                    println!("{pubkey}");
+                }
+                Ok(())
+            }
+            IdentityAction::SignEd25519 { identity_dir } => {
+                println!("{}", legacy_identity::sign_ed25519_stdin(&identity_dir)?);
+                Ok(())
+            }
             IdentityAction::Pretty {
                 name,
                 identity_json,
                 host,
             } => identity_commands::run_pretty(&name, &identity_json, &host),
+        },
+
+        Command::Envelope(args) => match args.action {
+            EnvelopeAction::Wrap {
+                recipient_pub,
+                identity_dir,
+            } => legacy_envelope::wrap_stdin(&recipient_pub, &identity_dir),
         },
 
         Command::Send { text } => commands::run_send(&home, parsed.peers, &text).await,

--- a/crates/airc-cli/tests/identity_commands.rs
+++ b/crates/airc-cli/tests/identity_commands.rs
@@ -1,5 +1,8 @@
 use std::process::Command;
 
+use base64::{engine::general_purpose, Engine};
+use tempfile::TempDir;
+
 fn airc_rs() -> &'static str {
     env!("CARGO_BIN_EXE_airc-rs")
 }
@@ -52,4 +55,150 @@ fn identity_pretty_defaults_unset_fields() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("  pronouns:   (unset)\n"));
     assert!(stdout.contains("  integrations: (none)\n"));
+}
+
+#[test]
+fn legacy_identity_commands_bootstrap_lookup_and_sign() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+    let identity_dir = home.join("identity");
+    let peers_dir = home.join("peers");
+    std::fs::create_dir_all(&peers_dir).unwrap();
+
+    let x25519 = run_ok(
+        home,
+        &[
+            "identity",
+            "bootstrap",
+            "--dir",
+            identity_dir.to_str().unwrap(),
+        ],
+        "",
+    );
+    assert_eq!(
+        general_purpose::URL_SAFE_NO_PAD
+            .decode(x25519.trim())
+            .unwrap()
+            .len(),
+        32
+    );
+
+    std::fs::write(
+        peers_dir.join("alice.json"),
+        format!(r#"{{"x25519_pub":"{}"}}"#, x25519.trim()),
+    )
+    .unwrap();
+    assert_eq!(
+        run_ok(
+            home,
+            &[
+                "identity",
+                "peer-pub",
+                "--peers-dir",
+                peers_dir.to_str().unwrap(),
+                "--peer-name",
+                "alice",
+            ],
+            "",
+        ),
+        x25519
+    );
+
+    run_ok(
+        home,
+        &[
+            "identity",
+            "bootstrap-ed25519",
+            "--dir",
+            identity_dir.to_str().unwrap(),
+        ],
+        "",
+    );
+    let signature = run_ok(
+        home,
+        &[
+            "identity",
+            "sign-ed25519",
+            "--dir",
+            identity_dir.to_str().unwrap(),
+        ],
+        "hello",
+    );
+    assert_eq!(
+        general_purpose::STANDARD
+            .decode(signature.trim())
+            .unwrap()
+            .len(),
+        64
+    );
+}
+
+#[test]
+fn legacy_envelope_wrap_encrypts_message_field() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+    let alice = home.join("alice");
+    let bob = home.join("bob");
+    let bob_pub = run_ok(
+        home,
+        &["identity", "bootstrap", "--dir", bob.to_str().unwrap()],
+        "",
+    );
+    run_ok(
+        home,
+        &["identity", "bootstrap", "--dir", alice.to_str().unwrap()],
+        "",
+    );
+
+    let wrapped = run_ok(
+        home,
+        &[
+            "envelope",
+            "wrap",
+            "--identity-dir",
+            alice.to_str().unwrap(),
+            &format!("--recipient-pub={}", bob_pub.trim()),
+        ],
+        r#"{"from":"alice","to":"bob","ts":"2026-05-19T00:00:00Z","channel":"general","msg":"hello"}"#,
+    );
+    let value: serde_json::Value = serde_json::from_str(&wrapped).unwrap();
+    assert_eq!(
+        value.get("enc").and_then(serde_json::Value::as_str),
+        Some("v1")
+    );
+    assert_ne!(
+        value.get("msg").and_then(serde_json::Value::as_str),
+        Some("hello")
+    );
+    assert!(value
+        .get("nonce")
+        .and_then(serde_json::Value::as_str)
+        .is_some());
+}
+
+fn run_ok(home: &std::path::Path, args: &[&str], stdin: &str) -> String {
+    use std::io::Write;
+    let mut child = Command::new(airc_rs())
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("airc-rs must spawn");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().expect("airc-rs must exit");
+    assert!(
+        output.status.success(),
+        "airc-rs failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).unwrap()
 }

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1710,7 +1710,7 @@ cmd_connect() {
     # bootstrap is idempotent (no-ops if keypair exists). Empty value
     # if cryptography isn't installed — handshake stays compatible
     # with peers running pre-Phase-E airc.
-    my_x25519_pub=$("$AIRC_PYTHON" -m airc_core.identity bootstrap --dir "$IDENTITY_DIR" 2>/dev/null || echo "")
+    my_x25519_pub=$("$(airc_rs_bin)" identity bootstrap --home "$AIRC_WRITE_DIR" --dir "$IDENTITY_DIR" 2>/dev/null || echo "")
 
     # Read own identity blob to send in handshake (issue #34 v2 — peers
     # cache each other's identity at pair-time so airc whois works fast).

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -360,14 +360,14 @@ cmd_send() {
     # that case, transparently.
     local recipient_pub=""
     if [ "$peer_name" != "all" ] && [ "$plaintext" != "1" ]; then
-      recipient_pub=$("$AIRC_PYTHON" -m airc_core.identity peer_pub \
+      recipient_pub=$("$(airc_rs_bin)" identity peer-pub --home "$AIRC_WRITE_DIR" \
         --peers-dir "$PEERS_DIR" --peer-name "$peer_name" 2>/dev/null || true)
     fi
     local wire_msg="$full_msg"
     if [ -n "$recipient_pub" ]; then
       # Stderr unredirected — wrap failures surface loud (CLAUDE.md "never swallow").
-      wire_msg=$(printf '%s' "$full_msg" | "$AIRC_PYTHON" -m airc_core.envelope wrap \
-        --recipient-pub "$recipient_pub" \
+      wire_msg=$(printf '%s' "$full_msg" | "$(airc_rs_bin)" envelope wrap --home "$AIRC_WRITE_DIR" \
+        --recipient-pub="$recipient_pub" \
         --identity-dir "$IDENTITY_DIR" || printf '%s' "$full_msg")
       # Diagnostic: emit the wire shape to stderr so test logs surface
       # whether encryption actually engaged. Phase E debug aid; remove
@@ -413,8 +413,8 @@ cmd_send() {
       --remote-home "$rhome" \
       --room-gist-id "$room_gist_id")
     local kind detail
-    kind=$(printf '%s' "$outcome" | "$AIRC_PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("kind",""))' 2>/dev/null)
-    detail=$(printf '%s' "$outcome" | "$AIRC_PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("detail",""))' 2>/dev/null)
+    kind=$(printf '%s' "$outcome" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
+    detail=$(printf '%s' "$outcome" | "$(airc_rs_bin)" gist get .detail 2>/dev/null)
 
     case "$kind" in
       delivered)
@@ -455,8 +455,8 @@ cmd_send() {
             --host-target "$host_target" \
             --remote-home "$rhome" \
             --room-gist-id "$room_gist_id" 2>&1) || true
-          retry_kind=$(printf '%s' "$retry_outcome" | "$AIRC_PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("kind",""))' 2>/dev/null)
-          retry_detail=$(printf '%s' "$retry_outcome" | "$AIRC_PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("detail",""))' 2>/dev/null)
+          retry_kind=$(printf '%s' "$retry_outcome" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
+          retry_detail=$(printf '%s' "$retry_outcome" | "$(airc_rs_bin)" gist get .detail 2>/dev/null)
           if [ "$retry_kind" = "delivered" ]; then
             echo "  ✓ Sent post-heal." >&2
             return 0
@@ -595,13 +595,13 @@ cmd_send() {
     # encryption is a future Phase E.4).
     local _host_recipient_pub=""
     if [ "$peer_name" != "all" ] && [ "$plaintext" != "1" ]; then
-      _host_recipient_pub=$("$AIRC_PYTHON" -m airc_core.identity peer_pub \
+      _host_recipient_pub=$("$(airc_rs_bin)" identity peer-pub --home "$AIRC_WRITE_DIR" \
         --peers-dir "$PEERS_DIR" --peer-name "$peer_name" 2>/dev/null || true)
     fi
     local _host_wire_msg="$full_msg"
     if [ -n "$_host_recipient_pub" ]; then
-      _host_wire_msg=$(printf '%s' "$full_msg" | "$AIRC_PYTHON" -m airc_core.envelope wrap \
-        --recipient-pub "$_host_recipient_pub" \
+      _host_wire_msg=$(printf '%s' "$full_msg" | "$(airc_rs_bin)" envelope wrap --home "$AIRC_WRITE_DIR" \
+        --recipient-pub="$_host_recipient_pub" \
         --identity-dir "$IDENTITY_DIR" || printf '%s' "$full_msg")
     fi
 
@@ -627,8 +627,8 @@ cmd_send() {
         "$peer_name" "$active_channel" \
         --room-gist-id "$_host_room_gist_id")
       local _host_kind _host_detail
-      _host_kind=$(printf '%s' "$_host_outcome" | "$AIRC_PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("kind",""))' 2>/dev/null)
-      _host_detail=$(printf '%s' "$_host_outcome" | "$AIRC_PYTHON" -c 'import json,sys; print(json.load(sys.stdin).get("detail",""))' 2>/dev/null)
+      _host_kind=$(printf '%s' "$_host_outcome" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
+      _host_detail=$(printf '%s' "$_host_outcome" | "$(airc_rs_bin)" gist get .detail 2>/dev/null)
       case "$_host_kind" in
         delivered)
           # Append to local audit log only on confirmed delivery. Pre-fix

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -182,6 +182,33 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("python3 <<", body)
         self.assertIn('"$(airc_rs_bin)" identity pretty', body)
 
+    def test_message_crypto_helpers_use_airc_rs(self):
+        combined = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in [
+                REPO / "airc",
+                REPO / "lib/airc_bash/cmd_send.sh",
+                REPO / "lib/airc_bash/cmd_connect.sh",
+            ]
+        )
+
+        forbidden = [
+            "airc_core.identity sign-ed25519",
+            "airc_core.identity bootstrap-ed25519",
+            "airc_core.identity bootstrap --dir",
+            "airc_core.identity peer_pub",
+            "airc_core.envelope wrap",
+            "json.load(sys.stdin).get(\"kind\"",
+        ]
+        for needle in forbidden:
+            self.assertNotIn(needle, combined)
+
+        self.assertIn('"$(airc_rs_bin)" identity sign-ed25519', combined)
+        self.assertIn('"$(airc_rs_bin)" identity bootstrap-ed25519', combined)
+        self.assertIn('"$(airc_rs_bin)" identity peer-pub', combined)
+        self.assertIn('"$(airc_rs_bin)" envelope wrap', combined)
+        self.assertIn('"$(airc_rs_bin)" gist get .kind', combined)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary
- add Rust legacy identity helpers for X25519 bootstrap, Ed25519 PEM bootstrap/signing, and peer X25519 lookup
- add Rust legacy envelope wrap using X25519 + HKDF-SHA256 + ChaCha20-Poly1305 with the existing v1 JSON envelope shape
- route send, host-drain, and handshake message crypto callsites through airc-rs instead of airc_core Python
- replace remaining send-outcome JSON field extraction in these paths with airc-rs gist get
- add CLI integration tests and static cutover guard for the message crypto path

Verification
- cargo test --manifest-path Cargo.toml -p airc-cli --no-fail-fast
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- python3 test/test_codex_rust_cutover.py
- bash -n airc lib/airc_bash/cmd_send.sh lib/airc_bash/cmd_connect.sh
- cargo test --manifest-path Cargo.toml --workspace --no-fail-fast
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets -- -D warnings