### PR TITLE
feat(airc-cli): move control-plane helpers to Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-clippy-
@@ -92,7 +91,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-test-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ dependencies = [
  "chacha20poly1305",
  "clap",
  "ed25519-dalek",
+ "fs2",
  "futures",
  "hkdf",
  "libc",

--- a/airc
+++ b/airc
@@ -417,12 +417,12 @@ if [ -n "$_gh_resolved" ] && ! command -v gh >/dev/null 2>&1; then
 fi
 
 # Central GitHub request guard. All shell `gh ...` calls below route
-# through the Python adapter so one per-user budget/backoff/audit layer
-# protects every AIRC tab on this machine. Python modules call the same
-# adapter directly via airc_core.gh_backoff.run_gh().
+# through the Rust adapter so one per-user budget/backoff/audit layer
+# protects every AIRC tab on this machine. Legacy Python callers keep
+# their own adapter until those transports are deleted.
 if [ -n "$_gh_resolved" ] || command -v gh >/dev/null 2>&1; then
   gh() {
-    "$AIRC_PYTHON" -m airc_core.gh_backoff run -- "$@"
+    "$(airc_rs_bin)" gh run -- "$@"
   }
 fi
 unset _gh_resolved
@@ -1886,7 +1886,7 @@ flush_pending_loop() {
     rhome=$(remote_home)
 
     local _gh_wait=0
-    _gh_wait=$("$AIRC_PYTHON" -m airc_core.gh_backoff wait-seconds 2>/dev/null || echo 0)
+    _gh_wait=$("$(airc_rs_bin)" gh wait-seconds 2>/dev/null || echo 0)
     if [ "${_gh_wait:-0}" -gt 0 ] 2>/dev/null; then
       [ "$_gh_wait" -gt 60 ] 2>/dev/null && _gh_wait=60
       sleep "$_gh_wait"
@@ -1985,7 +1985,7 @@ flush_pending_host_loop() {
     [ -s "$pending" ] || continue
 
     local _gh_wait=0
-    _gh_wait=$("$AIRC_PYTHON" -m airc_core.gh_backoff wait-seconds 2>/dev/null || echo 0)
+    _gh_wait=$("$(airc_rs_bin)" gh wait-seconds 2>/dev/null || echo 0)
     if [ "${_gh_wait:-0}" -gt 0 ] 2>/dev/null; then
       [ "$_gh_wait" -gt 60 ] 2>/dev/null && _gh_wait=60
       sleep "$_gh_wait"
@@ -2002,7 +2002,7 @@ flush_pending_host_loop() {
     local _fallback_gist=""
     [ -f "$AIRC_WRITE_DIR/room_gist_id" ] && _fallback_gist=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
     local _batch_route _batch_ok _batch_channel _batch_gist _batch_count
-    _batch_route=$("$AIRC_PYTHON" -m airc_core.pending_batch host-broadcast-route \
+    _batch_route=$("$(airc_rs_bin)" pending host-broadcast-route \
       --snapshot "$snapshot" --config "$CONFIG" --fallback-gist "$_fallback_gist" 2>/dev/null || true)
     IFS="$(printf '\t')" read -r _batch_ok _batch_channel _batch_gist _batch_count <<EOF
 $_batch_route
@@ -2808,7 +2808,7 @@ case "${1:-help}" in
   codex-poll) shift; AIRC_INBOX_QUIET_EMPTY=1 AIRC_INBOX_EXCLUDE_SELF=1 cmd_inbox --count 50 "$@" ;;
   codex-start) shift; cmd_codex_start "$@" ;;
   codex-hook) shift; cmd_codex_hook "$@" ;;
-  gh-audit) shift; "$AIRC_PYTHON" -m airc_core.gh_backoff audit "$@" ;;
+  gh-audit) shift; "$(airc_rs_bin)" gh audit "$@" ;;
   status)    shift; cmd_status "$@" ;;
   doctor)            shift; cmd_doctor "$@" ;;
   tests|test)        shift; _doctor_run_tests "$@" ;;

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -32,6 +32,7 @@ x25519-dalek = { version = "2", features = ["static_secrets"] }
 chacha20poly1305 = "0.10"
 hkdf = "0.12"
 rand_core = { version = "0.6", features = ["getrandom"] }
+fs2 = "0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -19,8 +19,10 @@ use airc_lib::PeerSpec;
 use crate::codex_cli::{CodexHookArgs, CodexStartArgs};
 use crate::config_cli::ConfigArgs;
 use crate::envelope_cli::EnvelopeArgs;
+use crate::gh_cli::GhArgs;
 use crate::gist_cli::GistArgs;
 use crate::identity_cli::IdentityArgs;
+use crate::pending_cli::PendingArgs;
 use crate::route_cli::RouteArgs;
 use crate::transport_cli::TransportArgs;
 use crate::work_cli::WorkArgs;
@@ -221,6 +223,12 @@ pub enum Command {
 
     /// Parse legacy GitHub gist envelope JSON.
     Gist(GistArgs),
+
+    /// Shared GitHub request governor.
+    Gh(GhArgs),
+
+    /// Pending-queue routing helpers during Rust cutover.
+    Pending(PendingArgs),
 
     /// Codex lifecycle hook adapters backed by Rust AIRC events.
     CodexHook(CodexHookArgs),

--- a/crates/airc-cli/src/gh_cli.rs
+++ b/crates/airc-cli/src/gh_cli.rs
@@ -1,0 +1,38 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct GhArgs {
+    #[command(subcommand)]
+    pub action: GhAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum GhAction {
+    /// Run `gh` through the shared AIRC request governor.
+    Run {
+        /// Arguments passed to gh. Use `--` before gh flags.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        gh_args: Vec<String>,
+    },
+
+    /// Print current shared backoff wait in seconds.
+    WaitSeconds,
+
+    /// Inspect or clear the local gh governor audit state.
+    Audit {
+        #[arg(long, default_value_t = 50)]
+        count: usize,
+        #[arg(long)]
+        summary: bool,
+        #[arg(long)]
+        reset: bool,
+        #[arg(long)]
+        clear_audit: bool,
+    },
+
+    /// Health report for the local gh governor.
+    Doctor {
+        #[arg(long, default_value_t = 80)]
+        count: usize,
+    },
+}

--- a/crates/airc-cli/src/gh_commands.rs
+++ b/crates/airc-cli/src/gh_commands.rs
@@ -1,0 +1,248 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::process::Command;
+
+use serde_json::{json, Value};
+
+use crate::gh_state::{
+    append_audit, audit_path, backoff_path, backoff_until, budget_path, budget_snapshot,
+    command_class, cwd, guarded_command, now_seconds, recent_events, record_backoff,
+    reserve_guarded_request, safe_args, split_include_output, wait_seconds,
+};
+
+pub fn run_gh(gh_args: Vec<String>) -> Result<(), Box<dyn Error>> {
+    let gh_args = strip_separator(gh_args);
+    let gh = env::var("AIRC_GH_BIN").unwrap_or_else(|_| "gh".to_string());
+
+    if gh_args.len() >= 2
+        && gh_args[0] == "auth"
+        && matches!(gh_args[1].as_str(), "login" | "refresh")
+    {
+        append_audit(&json!({
+            "ts": now_seconds() as i64,
+            "pid": std::process::id(),
+            "cwd": cwd(),
+            "class": command_class(&gh_args),
+            "args": safe_args(&gh_args),
+            "allowed": true,
+            "reason": "interactive-auth",
+        }));
+        let status = Command::new(&gh).args(&gh_args).status()?;
+        return if status.success() {
+            Ok(())
+        } else {
+            Err(format!("gh exited with status {status}").into())
+        };
+    }
+
+    let now = now_seconds();
+    let (allowed, reason) = if env::var("AIRC_GH_GUARD_DISABLE").ok().as_deref() == Some("1")
+        || !guarded_command(&gh_args)
+    {
+        (true, "unguarded".to_string())
+    } else {
+        reserve_guarded_request(&gh_args, now)?
+    };
+
+    let mut event = json!({
+        "ts": now as i64,
+        "pid": std::process::id(),
+        "cwd": cwd(),
+        "class": command_class(&gh_args),
+        "args": safe_args(&gh_args),
+        "allowed": allowed,
+        "reason": reason,
+        "backoff_until": backoff_until() as i64,
+    });
+
+    if !allowed {
+        let msg = format!(
+            "airc gh guard: {}; refusing gh {}\n",
+            reason,
+            safe_args(&gh_args)
+                .into_iter()
+                .take(3)
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        event["rc"] = json!(75);
+        event["outcome"] = json!("blocked");
+        append_audit(&event);
+        eprint!("{msg}");
+        return Err("gh request blocked by governor".into());
+    }
+
+    let output = Command::new(&gh).args(&gh_args).output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    print!("{stdout}");
+    eprint!("{stderr}");
+
+    if output.status.success() {
+        let (headers, _) = split_include_output(&stdout);
+        record_backoff(&headers);
+        event["rc"] = json!(0);
+        event["outcome"] = json!("ok");
+    } else {
+        record_backoff(&format!("{stderr}{stdout}"));
+        event["rc"] = json!(output.status.code().unwrap_or(1));
+        event["outcome"] = json!("error");
+        event["backoff_until"] = json!(backoff_until() as i64);
+        append_audit(&event);
+        return Err(format!("gh exited with status {}", output.status).into());
+    }
+    event["backoff_until"] = json!(backoff_until() as i64);
+    append_audit(&event);
+    Ok(())
+}
+
+pub fn run_wait_seconds() {
+    println!("{}", wait_seconds(now_seconds()));
+}
+
+pub fn run_audit(
+    count: usize,
+    summary: bool,
+    reset: bool,
+    clear_audit: bool,
+) -> Result<(), Box<dyn Error>> {
+    if reset {
+        let mut removed = Vec::new();
+        for path in [backoff_path(), budget_path()] {
+            if fs::remove_file(&path).is_ok() {
+                removed.push(path);
+            }
+        }
+        println!("AIRC gh guard reset: cleared shared backoff/budget state.");
+        for path in removed {
+            println!("  removed {}", path.display());
+        }
+        println!("  audit log retained: {}", audit_path().display());
+        return Ok(());
+    }
+    if clear_audit {
+        let path = audit_path();
+        match fs::remove_file(&path) {
+            Ok(()) => println!("AIRC gh audit cleared: {}", path.display()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                println!("AIRC gh audit already empty: {}", path.display())
+            }
+            Err(error) => return Err(error.into()),
+        }
+        return Ok(());
+    }
+
+    let path = audit_path();
+    let rows = recent_events(count);
+    if !path.exists() {
+        println!("No AIRC gh audit log yet: {}", path.display());
+        return Ok(());
+    }
+
+    if summary {
+        let mut counts = BTreeMap::new();
+        let mut blocked = 0usize;
+        for event in &rows {
+            let class = event
+                .get("class")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            *counts.entry(class.to_string()).or_insert(0usize) += 1;
+            if event.get("allowed").and_then(Value::as_bool) == Some(false) {
+                blocked += 1;
+            }
+        }
+        println!("AIRC gh audit: {}", path.display());
+        println!(
+            "recent events: {}; blocked: {blocked}; shared backoff: {}s",
+            rows.len(),
+            wait_seconds(now_seconds())
+        );
+        let mut counts: Vec<_> = counts.into_iter().collect();
+        counts.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+        for (class, class_count) in counts {
+            println!("  {class_count:4}  {class}");
+        }
+        return Ok(());
+    }
+
+    println!("AIRC gh audit: {}", path.display());
+    for event in rows {
+        let ts = event.get("ts").map_or("?".to_string(), Value::to_string);
+        let class = event
+            .get("class")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let allowed = if event.get("allowed").and_then(Value::as_bool) == Some(false) {
+            "BLOCKED"
+        } else {
+            "ok"
+        };
+        let rc = event.get("rc").map_or(String::new(), Value::to_string);
+        let reason = event.get("reason").and_then(Value::as_str).unwrap_or("");
+        let cwd = event.get("cwd").and_then(Value::as_str).unwrap_or("");
+        println!("{ts} {allowed:7} rc={rc:>7} {class} - {reason} - {cwd}");
+    }
+    Ok(())
+}
+
+pub fn run_doctor(count: usize) -> Result<(), Box<dyn Error>> {
+    let now = now_seconds();
+    let wait = wait_seconds(now);
+    let rows = recent_events(count);
+    let blocked = rows
+        .iter()
+        .filter(|event| event.get("allowed").and_then(Value::as_bool) == Some(false))
+        .count();
+    let (used, limit) = budget_snapshot(now)?;
+
+    println!("  gh governor audit: {}", audit_path().display());
+    if wait > 0 {
+        println!("  [BLOCKED] gh governor shared backoff active for {wait}s");
+    } else if blocked > 0 {
+        println!(
+            "  [WARN] gh governor blocked {blocked}/{} recent guarded request(s)",
+            rows.len()
+        );
+    } else if used >= limit {
+        println!("  [WARN] gh governor local request budget full ({used}/{limit} in 60s)");
+    } else {
+        println!(
+            "  [ok] gh governor: no active backoff; {blocked}/{} blocked; budget {used}/{limit} in 60s",
+            rows.len()
+        );
+    }
+
+    let mut classes = BTreeMap::new();
+    for event in rows {
+        let class = event
+            .get("class")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        *classes.entry(class.to_string()).or_insert(0usize) += 1;
+    }
+    if classes.is_empty() {
+        println!("         no guarded gh requests recorded yet");
+    } else {
+        println!("         recent gh classes:");
+        let mut classes: Vec<_> = classes.into_iter().collect();
+        classes.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+        for (class, class_count) in classes.into_iter().take(5) {
+            println!("           {class_count:4}  {class}");
+        }
+    }
+    if wait > 0 || blocked > 0 || used >= limit {
+        Err("gh governor degraded".into())
+    } else {
+        Ok(())
+    }
+}
+
+fn strip_separator(mut args: Vec<String>) -> Vec<String> {
+    if args.first().map(String::as_str) == Some("--") {
+        args.remove(0);
+    }
+    args
+}

--- a/crates/airc-cli/src/gh_state.rs
+++ b/crates/airc-cli/src/gh_state.rs
@@ -1,0 +1,334 @@
+use std::env;
+use std::error::Error;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use fs2::FileExt;
+use serde_json::Value;
+
+const DEFAULT_MAX_REQUESTS_PER_MIN: usize = 30;
+const LOCAL_THROTTLE_BACKOFF_SEC: f64 = 60.0;
+
+pub(crate) fn reserve_guarded_request(
+    args: &[String],
+    now: f64,
+) -> Result<(bool, String), Box<dyn Error>> {
+    let _lock = GuardLock::acquire()?;
+    let until = backoff_until();
+    if now < until {
+        return Ok((
+            false,
+            format!("shared backoff active for {}s", (until - now) as i64),
+        ));
+    }
+    let count = recent_request_count(now)?;
+    let limit = max_requests_per_min();
+    if count >= limit {
+        write_backoff(now + LOCAL_THROTTLE_BACKOFF_SEC)?;
+        return Ok((
+            false,
+            format!("local request budget exceeded ({count}/{limit} in 60s)"),
+        ));
+    }
+    if guarded_command(args) {
+        record_request(now)?;
+    }
+    Ok((true, "allowed".to_string()))
+}
+
+pub(crate) fn budget_snapshot(now: f64) -> Result<(usize, usize), Box<dyn Error>> {
+    let _lock = GuardLock::acquire()?;
+    Ok((recent_request_count(now)?, max_requests_per_min()))
+}
+
+struct GuardLock(File);
+
+impl GuardLock {
+    fn acquire() -> Result<Self, Box<dyn Error>> {
+        let path = lock_path();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .read(true)
+            .open(path)?;
+        file.lock_exclusive()?;
+        Ok(Self(file))
+    }
+}
+
+impl Drop for GuardLock {
+    fn drop(&mut self) {
+        let _ = self.0.unlock();
+    }
+}
+
+pub(crate) fn wait_seconds(now: f64) -> i64 {
+    (backoff_until() - now).max(0.0) as i64
+}
+
+pub(crate) fn backoff_until() -> f64 {
+    fs::read_to_string(backoff_path())
+        .ok()
+        .and_then(|raw| raw.trim().parse::<f64>().ok())
+        .unwrap_or(0.0)
+}
+
+pub(crate) fn record_backoff(output: &str) {
+    let body = output.to_ascii_lowercase();
+    if body.is_empty() {
+        return;
+    }
+    let now = now_seconds();
+    let mut until = 0.0;
+    if let Some(retry) =
+        header_value(&body, "retry-after").and_then(|value| value.parse::<f64>().ok())
+    {
+        until = now + retry.max(1.0);
+    } else {
+        let remaining = header_value(&body, "x-ratelimit-remaining");
+        let reset =
+            header_value(&body, "x-ratelimit-reset").and_then(|value| value.parse::<f64>().ok());
+        if remaining.as_deref() == Some("0") {
+            if let Some(reset) = reset {
+                until = reset;
+            }
+        } else if body.contains("secondary rate limit")
+            || body.contains("rate limit exceeded")
+            || body.contains("abuse detection")
+        {
+            until = now + 60.0;
+        }
+    }
+    if until > now {
+        let _ = write_backoff(until);
+    }
+}
+
+fn header_value(body: &str, name: &str) -> Option<String> {
+    body.lines().find_map(|line| {
+        let (key, value) = line.split_once(':')?;
+        (key.trim() == name).then(|| value.trim().to_string())
+    })
+}
+
+fn write_backoff(until: f64) -> std::io::Result<()> {
+    if until <= now_seconds() {
+        return Ok(());
+    }
+    let until = until.max(backoff_until());
+    let path = backoff_path();
+    let tmp = path.with_extension(format!("{}.tmp", std::process::id()));
+    fs::write(&tmp, format!("{}", until as i64))?;
+    fs::rename(tmp, path)
+}
+
+fn recent_request_count(now: f64) -> std::io::Result<usize> {
+    let path = budget_path();
+    let cutoff = now - 60.0;
+    let kept: Vec<f64> = fs::read_to_string(&path)
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|line| line.trim().parse::<f64>().ok())
+        .filter(|ts| *ts >= cutoff)
+        .collect();
+    let tmp = path.with_extension(format!("{}.tmp", std::process::id()));
+    let mut file = File::create(&tmp)?;
+    for ts in &kept {
+        writeln!(file, "{ts:.3}")?;
+    }
+    fs::rename(tmp, path)?;
+    Ok(kept.len())
+}
+
+fn record_request(now: f64) -> std::io::Result<()> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(budget_path())?;
+    writeln!(file, "{now:.3}")
+}
+
+fn max_requests_per_min() -> usize {
+    env::var("AIRC_GH_MAX_REQUESTS_PER_MIN")
+        .ok()
+        .and_then(|raw| raw.parse().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_MAX_REQUESTS_PER_MIN)
+}
+
+pub(crate) fn guarded_command(args: &[String]) -> bool {
+    matches!(args.first().map(String::as_str), Some("api" | "gist"))
+        || matches!(
+            (
+                args.first().map(String::as_str),
+                args.get(1).map(String::as_str)
+            ),
+            (Some("auth"), Some("status"))
+        )
+}
+
+pub(crate) fn command_class(args: &[String]) -> String {
+    match args {
+        [] => "unknown".to_string(),
+        [first, rest @ ..] if first == "api" => rest
+            .iter()
+            .find(|part| !part.starts_with('-'))
+            .map(|part| format!("api:{}", part.split('?').next().unwrap_or(part)))
+            .unwrap_or_else(|| "api".to_string()),
+        [first, second, ..] if first == "gist" => format!("gist:{second}"),
+        [first, second, ..] if first == "auth" => format!("auth:{second}"),
+        [first, ..] => first.clone(),
+    }
+}
+
+pub(crate) fn safe_args(args: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut redact_next = false;
+    for arg in args {
+        if redact_next {
+            out.push("<redacted>".to_string());
+            redact_next = false;
+            continue;
+        }
+        if matches!(
+            arg.as_str(),
+            "--input" | "-F" | "--field" | "-f" | "--raw-field"
+        ) {
+            out.push(arg.clone());
+            if arg != "--input" {
+                redact_next = true;
+            }
+            continue;
+        }
+        if arg.to_ascii_lowercase().contains("token")
+            || arg.to_ascii_lowercase().contains("authorization:")
+        {
+            out.push("<redacted>".to_string());
+        } else {
+            out.push(arg.chars().take(180).collect());
+        }
+    }
+    out
+}
+
+pub(crate) fn split_include_output(raw: &str) -> (String, String) {
+    let normalized = raw.replace("\r\n", "\n");
+    if normalized.starts_with("HTTP/") {
+        if let Some(index) = normalized.find("\n\n") {
+            let (headers, body) = normalized.split_at(index);
+            return (headers.to_string(), body.trim_start().to_string());
+        }
+    }
+    (String::new(), raw.to_string())
+}
+
+pub(crate) fn append_audit(event: &Value) {
+    let path = audit_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    if path
+        .metadata()
+        .map(|meta| meta.len() > audit_max_bytes())
+        .unwrap_or(false)
+    {
+        let rotated = path.with_extension("jsonl.1");
+        let _ = fs::remove_file(&rotated);
+        let _ = fs::rename(&path, rotated);
+    }
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(file, "{}", serde_json::to_string(event).unwrap_or_default());
+    }
+}
+
+pub(crate) fn recent_events(count: usize) -> Vec<Value> {
+    let mut rows: Vec<Value> = fs::read_to_string(audit_path())
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .collect();
+    if rows.len() > count {
+        rows.drain(0..rows.len() - count);
+    }
+    rows
+}
+
+fn audit_max_bytes() -> u64 {
+    env::var("AIRC_GH_AUDIT_MAX_BYTES")
+        .ok()
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(262_144)
+}
+
+pub(crate) fn now_seconds() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+pub(crate) fn cwd() -> String {
+    env::current_dir()
+        .map(|path| path.display().to_string())
+        .unwrap_or_default()
+}
+
+fn state_prefix() -> String {
+    #[cfg(unix)]
+    {
+        unsafe { libc::getuid().to_string() }
+    }
+    #[cfg(not(unix))]
+    {
+        env::var("USERNAME").unwrap_or_else(|_| "user".to_string())
+    }
+}
+
+pub(crate) fn backoff_path() -> PathBuf {
+    env::temp_dir().join(format!("airc-gh-backoff-until-{}", state_prefix()))
+}
+
+pub(crate) fn budget_path() -> PathBuf {
+    env::temp_dir().join(format!("airc-gh-budget-{}.jsonl", state_prefix()))
+}
+
+pub(crate) fn audit_path() -> PathBuf {
+    env::var_os("AIRC_GH_AUDIT_LOG")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            env::temp_dir().join(format!("airc-gh-requests-{}.jsonl", state_prefix()))
+        })
+}
+
+fn lock_path() -> PathBuf {
+    env::temp_dir().join(format!("airc-gh-guard-{}.lock", state_prefix()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_classes_match_legacy_shapes() {
+        assert_eq!(
+            command_class(&["api".into(), "/rate_limit".into()]),
+            "api:/rate_limit"
+        );
+        assert_eq!(command_class(&["gist".into(), "edit".into()]), "gist:edit");
+        assert_eq!(
+            command_class(&["auth".into(), "status".into()]),
+            "auth:status"
+        );
+    }
+
+    #[test]
+    fn safe_args_redacts_token_like_values() {
+        let args = safe_args(&["api".into(), "--raw-field".into(), "token=abc".into()]);
+        assert_eq!(args, vec!["api", "--raw-field", "<redacted>"]);
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -27,6 +27,9 @@ mod daemon_scope;
 mod envelope_cli;
 mod events_cli;
 mod events_commands;
+mod gh_cli;
+mod gh_commands;
+mod gh_state;
 mod gist_cli;
 mod gist_commands;
 mod identity_cli;
@@ -37,6 +40,8 @@ mod legacy_envelope;
 mod legacy_identity;
 mod log_cli;
 mod log_commands;
+mod pending_cli;
+mod pending_commands;
 mod route_cli;
 mod route_commands;
 mod transport_cli;
@@ -61,10 +66,12 @@ use codex_cli::CodexHookAction;
 use config_cli::ConfigAction;
 use envelope_cli::EnvelopeAction;
 use events_cli::EventsAction;
+use gh_cli::GhAction;
 use gist_cli::GistAction;
 use identity_cli::IdentityAction;
 use lane_cli::{LaneAction, LaneManagerAction};
 use log_cli::LogAction;
+use pending_cli::PendingAction;
 use route_cli::RouteAction;
 use transport_cli::TransportAction;
 use work_cli::WorkAction;
@@ -303,6 +310,29 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             }
             GistAction::ListLanEntries => gist_commands::run_list_lan_entries(),
             GistAction::GistContent { channel } => gist_commands::run_gist_content(&channel),
+        },
+
+        Command::Gh(args) => match args.action {
+            GhAction::Run { gh_args } => gh_commands::run_gh(gh_args),
+            GhAction::WaitSeconds => {
+                gh_commands::run_wait_seconds();
+                Ok(())
+            }
+            GhAction::Audit {
+                count,
+                summary,
+                reset,
+                clear_audit,
+            } => gh_commands::run_audit(count, summary, reset, clear_audit),
+            GhAction::Doctor { count } => gh_commands::run_doctor(count),
+        },
+
+        Command::Pending(args) => match args.action {
+            PendingAction::HostBroadcastRoute {
+                snapshot,
+                config,
+                fallback_gist,
+            } => pending_commands::run_host_broadcast_route(&snapshot, &config, &fallback_gist),
         },
 
         Command::CodexHook(args) => match args.action {

--- a/crates/airc-cli/src/pending_cli.rs
+++ b/crates/airc-cli/src/pending_cli.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct PendingArgs {
+    #[command(subcommand)]
+    pub action: PendingAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum PendingAction {
+    /// Resolve whether a pending snapshot can be sent as one host broadcast batch.
+    HostBroadcastRoute {
+        #[arg(long)]
+        snapshot: PathBuf,
+        #[arg(long)]
+        config: PathBuf,
+        #[arg(long, default_value = "")]
+        fallback_gist: String,
+    },
+}

--- a/crates/airc-cli/src/pending_commands.rs
+++ b/crates/airc-cli/src/pending_commands.rs
@@ -1,0 +1,95 @@
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Deserialize, Default)]
+struct ConfigFile {
+    #[serde(default)]
+    channel_gists: std::collections::BTreeMap<String, String>,
+}
+
+pub fn run_host_broadcast_route(
+    snapshot: &Path,
+    config: &Path,
+    fallback_gist: &str,
+) -> Result<(), Box<dyn Error>> {
+    let lines = read_lines(snapshot);
+    if lines.is_empty() {
+        println!("no\tempty");
+        return Ok(());
+    }
+
+    let mut channel = String::new();
+    for line in &lines {
+        let Ok(message) = serde_json::from_str::<Value>(line) else {
+            println!("no\tmalformed");
+            return Ok(());
+        };
+        let to = message.get("to").and_then(Value::as_str).unwrap_or("all");
+        if !matches!(to, "" | "all") {
+            println!("no\tdm");
+            return Ok(());
+        }
+        let line_channel = message.get("channel").and_then(Value::as_str).unwrap_or("");
+        if line_channel.is_empty() {
+            println!("no\tmissing-channel");
+            return Ok(());
+        }
+        if !channel.is_empty() && channel != line_channel {
+            println!("no\tmixed-channel");
+            return Ok(());
+        }
+        channel = line_channel.to_string();
+    }
+
+    let config = load_config(config);
+    let gist = config
+        .channel_gists
+        .get(&channel)
+        .map(String::as_str)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(fallback_gist);
+    if gist.is_empty() {
+        println!("no\tmissing-gist");
+        return Ok(());
+    }
+
+    println!("ok\t{channel}\t{gist}\t{}", lines.len());
+    Ok(())
+}
+
+fn read_lines(path: &Path) -> Vec<String> {
+    fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| !line.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn load_config(path: &Path) -> ConfigFile {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_broadcast_route_rejects_dm_batches() {
+        let dir = tempfile::tempdir().unwrap();
+        let snapshot = dir.path().join("pending.jsonl");
+        let config = dir.path().join("config.json");
+        fs::write(&snapshot, r#"{"to":"alice","channel":"general"}"#).unwrap();
+        fs::write(&config, "{}").unwrap();
+
+        run_host_broadcast_route(&snapshot, &config, "fallback").unwrap();
+    }
+}

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1791,7 +1791,7 @@ except Exception:
     # targeted ssh-keygen -R when a PRIOR real-sshd host key in known_hosts
     # is known stale (e.g. the server rotated sshd host keys).
     local host_ssh_pub
-    host_ssh_pub=$(printf '%s' "$response" | "$AIRC_PYTHON" -m airc_core.handshake get_field ssh_pub "" 2>/dev/null || true)
+    host_ssh_pub=$(printf '%s' "$response" | "$(airc_rs_bin)" gist get .ssh_pub 2>/dev/null || true)
     if [ -n "$host_ssh_pub" ]; then
       mkdir -p "$HOME/.ssh" && chmod 700 "$HOME/.ssh"
       grep -qF "$host_ssh_pub" "$HOME/.ssh/authorized_keys" 2>/dev/null || {
@@ -1810,10 +1810,10 @@ except Exception:
     # Drop any existing peer records with the same host first — stale names
     # from a prior rename chain must not linger alongside the current one.
     local host_airc_home host_x25519_pub
-    host_airc_home=$(printf '%s' "$response" | "$AIRC_PYTHON" -m airc_core.handshake get_field airc_home "" 2>/dev/null || true)
+    host_airc_home=$(printf '%s' "$response" | "$(airc_rs_bin)" gist get .airc_home 2>/dev/null || true)
     # Phase E.2: capture host's X25519 pubkey from handshake response
     # so cmd_send can encrypt envelopes destined for this peer.
-    host_x25519_pub=$(printf '%s' "$response" | "$AIRC_PYTHON" -m airc_core.handshake get_field x25519_pub "" 2>/dev/null || true)
+    host_x25519_pub=$(printf '%s' "$response" | "$(airc_rs_bin)" gist get .x25519_pub 2>/dev/null || true)
     HOST_X25519_PUB="$host_x25519_pub" "$AIRC_PYTHON" -c "
 import json, os
 peers_dir = os.path.expanduser('$PEERS_DIR')
@@ -1864,7 +1864,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
     # the join string for onward sharing without a fresh handshake. Also
     # cache the host's identity blob from the handshake response so
     # `airc whois <host-name>` works locally (issue #34 v2).
-    local host_identity_json; host_identity_json=$(printf '%s' "$response" | "$AIRC_PYTHON" -m airc_core.handshake get_field identity "{}" 2>/dev/null || echo "{}")
+    local host_identity_json; host_identity_json=$(printf '%s' "$response" | "$(airc_rs_bin)" gist get .identity "{}" 2>/dev/null || echo "{}")
     [ -z "$host_identity_json" ] && host_identity_json="{}"
     # Pass values as env vars instead of bash-substituted into the
     # python heredoc body. PR #164 retest 2026-04-27
@@ -1888,7 +1888,7 @@ with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
 
     # Pick up reminder setting from host
     local host_reminder
-    host_reminder=$(printf '%s' "$response" | "$AIRC_PYTHON" -m airc_core.handshake get_field reminder 300 2>/dev/null || echo "300")
+    host_reminder=$(printf '%s' "$response" | "$(airc_rs_bin)" gist get .reminder 300 2>/dev/null || echo "300")
     if [ "$host_reminder" -gt 0 ] 2>/dev/null; then
       echo "$host_reminder" > "$AIRC_WRITE_DIR/reminder"
       date +%s > "$AIRC_WRITE_DIR/last_sent"

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -485,11 +485,12 @@ _doctor_health() {
   # per-user cross-process guard. Keep `airc gh-audit` as an advanced
   # escape hatch, but doctor owns the normal diagnosis so users/agents
   # don't need another public verb.
-  local _gov_rc=0
-  "$AIRC_PYTHON" -m airc_core.gh_backoff doctor --count 80 || _gov_rc=$?
-  case "$_gov_rc" in
-    1) warns=$((warns+1)) ;;
-    2) issues=$((issues+1)) ;;
+  local _gov_rc=0 _gov_out
+  _gov_out=$("$(airc_rs_bin)" gh doctor --count 80 2>&1) || _gov_rc=$?
+  printf '%s\n' "$_gov_out"
+  case "$_gov_out" in
+    *"[BLOCKED]"*) issues=$((issues+1)) ;;
+    *) [ "$_gov_rc" -ne 0 ] && warns=$((warns+1)) ;;
   esac
 
   # ── Legacy daemon registration check. Daemon is deprecated; surface

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -547,8 +547,8 @@ _whois_in_scope() {
     local remote_blob
     remote_blob=$(IDENTITY_DIR="$scope/identity" relay_ssh "$host_target_addr" "cat $host_airc_home/peers/$target.json 2>/dev/null" 2>/dev/null || true)
     if [ -n "$remote_blob" ]; then
-      local peer_id; peer_id=$(printf '%s' "$remote_blob" | "$AIRC_PYTHON" -m airc_core.handshake get_field identity "{}" 2>/dev/null || echo "{}")
-      local peer_host; peer_host=$(printf '%s' "$remote_blob" | "$AIRC_PYTHON" -m airc_core.handshake get_field host "" 2>/dev/null || echo "")
+      local peer_id; peer_id=$(printf '%s' "$remote_blob" | "$(airc_rs_bin)" gist get .identity "{}" 2>/dev/null || echo "{}")
+      local peer_host; peer_host=$(printf '%s' "$remote_blob" | "$(airc_rs_bin)" gist get .host 2>/dev/null || echo "")
       _whois_pretty "$target" "$peer_id" "$peer_host"
       return 0
     fi

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -227,7 +227,7 @@ else:
   [ -f "$pending" ] && pending_count=$(grep -c '^.' "$pending" 2>/dev/null || echo 0)
   if [ "$pending_count" -gt 0 ]; then
     local _gh_wait=0
-    _gh_wait=$("$AIRC_PYTHON" -m airc_core.gh_backoff wait-seconds 2>/dev/null || echo 0)
+    _gh_wait=$("$(airc_rs_bin)" gh wait-seconds 2>/dev/null || echo 0)
     if [ "${_gh_wait:-0}" -gt 0 ] 2>/dev/null; then
       echo "  queue:       ${pending_count} pending (paused by gh governor for ${_gh_wait}s)"
     else

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -209,6 +209,34 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" envelope wrap', combined)
         self.assertIn('"$(airc_rs_bin)" gist get .kind', combined)
 
+    def test_control_plane_helpers_use_airc_rs(self):
+        combined = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in [
+                REPO / "airc",
+                REPO / "lib/airc_bash/cmd_connect.sh",
+                REPO / "lib/airc_bash/cmd_doctor.sh",
+                REPO / "lib/airc_bash/cmd_identity.sh",
+                REPO / "lib/airc_bash/cmd_status.sh",
+            ]
+        )
+
+        forbidden = [
+            "airc_core.gh_backoff run",
+            "airc_core.gh_backoff wait-seconds",
+            "airc_core.gh_backoff audit",
+            "airc_core.gh_backoff doctor",
+            "airc_core.pending_batch host-broadcast-route",
+            "airc_core.handshake get_field",
+        ]
+        for needle in forbidden:
+            self.assertNotIn(needle, combined)
+
+        self.assertIn('"$(airc_rs_bin)" gh run', combined)
+        self.assertIn('"$(airc_rs_bin)" gh wait-seconds', combined)
+        self.assertIn('"$(airc_rs_bin)" gh doctor', combined)
+        self.assertIn('"$(airc_rs_bin)" pending host-broadcast-route', combined)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary
- add Rust gh governor commands for run/wait/audit/doctor with shared backoff, budget, locking, and audit output
- add Rust pending host-broadcast route helper
- route gh governor, pending batch routing, and handshake field extraction through airc-rs
- add cutover guard preventing these control-plane helpers from falling back to Python
- split gh command handling from gh state/locking/audit internals to keep the control-plane surface modular

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli --no-fail-fast
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets -- -D warnings
- python3 test/test_codex_rust_cutover.py
- bash -n airc lib/airc_bash/cmd_connect.sh lib/airc_bash/cmd_doctor.sh lib/airc_bash/cmd_identity.sh lib/airc_bash/cmd_status.sh
- cargo test --manifest-path Cargo.toml --workspace --no-fail-fast