### PR TITLE
feat(airc-cli): build legacy message JSON in Rust

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -22,6 +22,7 @@ use crate::envelope_cli::EnvelopeArgs;
 use crate::gh_cli::GhArgs;
 use crate::gist_cli::GistArgs;
 use crate::identity_cli::IdentityArgs;
+use crate::message_cli::MessageArgs;
 use crate::pending_cli::PendingArgs;
 use crate::route_cli::RouteArgs;
 use crate::transport_cli::TransportArgs;
@@ -224,6 +225,9 @@ pub enum Command {
     /// Parse legacy GitHub gist envelope JSON.
     Gist(GistArgs),
 
+    /// Build and inspect message envelopes during Rust cutover.
+    Message(MessageArgs),
+
     /// Shared GitHub request governor.
     Gh(GhArgs),
 
@@ -259,6 +263,9 @@ pub enum Command {
 
     /// Print this runtime process's client id, if one can be derived.
     ClientId,
+
+    /// Generate a UUIDv4.
+    UuidV4,
 
     /// Convert a canonical UTC timestamp to Unix epoch seconds.
     IsoToEpoch {

--- a/crates/airc-cli/src/identity_cli.rs
+++ b/crates/airc-cli/src/identity_cli.rs
@@ -51,4 +51,26 @@ pub enum IdentityAction {
         #[arg(long, default_value = "")]
         host: String,
     },
+
+    /// Write a legacy peer record learned from the join handshake.
+    WritePeerRecord {
+        /// Legacy peers directory containing <peer>.json files.
+        #[arg(long)]
+        peers_dir: std::path::PathBuf,
+        /// Peer display/name key.
+        #[arg(long)]
+        peer_name: String,
+        /// SSH target for the peer.
+        #[arg(long)]
+        host: String,
+        /// Peer airc home path.
+        #[arg(long, default_value = "")]
+        airc_home: String,
+        /// Optional X25519 public key for envelope encryption.
+        #[arg(long, default_value = "")]
+        x25519_pub: String,
+        /// Pair timestamp.
+        #[arg(long)]
+        paired: String,
+    },
 }

--- a/crates/airc-cli/src/identity_commands.rs
+++ b/crates/airc-cli/src/identity_commands.rs
@@ -1,6 +1,8 @@
 use std::error::Error;
+use std::fs;
+use std::path::Path;
 
-use serde_json::Value;
+use serde_json::{json, Value};
 
 const IDENTITY_FIELDS: &[&str] = &["pronouns", "role", "bio", "status"];
 
@@ -38,6 +40,64 @@ pub fn run_pretty(name: &str, identity_json: &str, host: &str) -> Result<(), Box
     Ok(())
 }
 
+pub fn run_write_peer_record(
+    peers_dir: &Path,
+    peer_name: &str,
+    host: &str,
+    airc_home: &str,
+    x25519_pub: &str,
+    paired: &str,
+) -> Result<(), Box<dyn Error>> {
+    fs::create_dir_all(peers_dir)?;
+    remove_stale_host_records(peers_dir, peer_name, host)?;
+
+    let mut record = json!({
+        "name": peer_name,
+        "host": host,
+        "airc_home": airc_home,
+        "paired": paired,
+    });
+    if !x25519_pub.is_empty() {
+        record["x25519_pub"] = Value::String(x25519_pub.to_string());
+    }
+
+    let path = peers_dir.join(format!("{peer_name}.json"));
+    fs::write(path, serde_json::to_string_pretty(&record)?)?;
+    Ok(())
+}
+
+fn remove_stale_host_records(
+    peers_dir: &Path,
+    peer_name: &str,
+    host: &str,
+) -> Result<(), Box<dyn Error>> {
+    for entry in fs::read_dir(peers_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        if path.file_stem().and_then(|value| value.to_str()) == Some(peer_name) {
+            continue;
+        }
+        let stale = fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+            .and_then(|value| {
+                value
+                    .get("host")
+                    .and_then(Value::as_str)
+                    .map(|stored_host| stored_host == host)
+            })
+            .unwrap_or(false);
+        if stale {
+            let _ = fs::remove_file(&path);
+            let _ = fs::remove_file(path.with_extension("pub"));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -45,5 +105,26 @@ mod tests {
     #[test]
     fn malformed_identity_is_treated_as_empty() {
         assert!(run_pretty("alice", "not-json", "").is_ok());
+    }
+
+    #[test]
+    fn write_peer_record_removes_stale_records_for_same_host() {
+        let dir = tempfile::tempdir().unwrap();
+        let peers = dir.path();
+        fs::write(
+            peers.join("old.json"),
+            r#"{"name":"old","host":"alice@example","airc_home":"/old"}"#,
+        )
+        .unwrap();
+        fs::write(peers.join("old.pub"), "legacy").unwrap();
+
+        run_write_peer_record(peers, "new", "alice@example", "/airc", "xpub", "now").unwrap();
+
+        assert!(!peers.join("old.json").exists());
+        assert!(!peers.join("old.pub").exists());
+        let written: Value =
+            serde_json::from_str(&fs::read_to_string(peers.join("new.json")).unwrap()).unwrap();
+        assert_eq!(written["host"], "alice@example");
+        assert_eq!(written["x25519_pub"], "xpub");
     }
 }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -40,6 +40,8 @@ mod legacy_envelope;
 mod legacy_identity;
 mod log_cli;
 mod log_commands;
+mod message_cli;
+mod message_commands;
 mod pending_cli;
 mod pending_commands;
 mod route_cli;
@@ -71,6 +73,7 @@ use gist_cli::GistAction;
 use identity_cli::IdentityAction;
 use lane_cli::{LaneAction, LaneManagerAction};
 use log_cli::LogAction;
+use message_cli::MessageAction;
 use pending_cli::PendingAction;
 use route_cli::RouteAction;
 use transport_cli::TransportAction;
@@ -199,6 +202,21 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 identity_json,
                 host,
             } => identity_commands::run_pretty(&name, &identity_json, &host),
+            IdentityAction::WritePeerRecord {
+                peers_dir,
+                peer_name,
+                host,
+                airc_home,
+                x25519_pub,
+                paired,
+            } => identity_commands::run_write_peer_record(
+                &peers_dir,
+                &peer_name,
+                &host,
+                &airc_home,
+                &x25519_pub,
+                &paired,
+            ),
         },
 
         Command::Envelope(args) => match args.action {
@@ -310,6 +328,20 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             }
             GistAction::ListLanEntries => gist_commands::run_list_lan_entries(),
             GistAction::GistContent { channel } => gist_commands::run_gist_content(&channel),
+        },
+
+        Command::Message(args) => match args.action {
+            MessageAction::BuildLegacy {
+                from,
+                to,
+                ts,
+                channel,
+                msg,
+                client_id,
+                kind,
+            } => message_commands::run_build_legacy(
+                &from, &to, &ts, &channel, &msg, &client_id, &kind,
+            ),
         },
 
         Command::Gh(args) => match args.action {
@@ -450,6 +482,11 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 return Err("client id is unavailable".into());
             };
             println!("{value}");
+            Ok(())
+        }
+
+        Command::UuidV4 => {
+            println!("{}", uuid::Uuid::new_v4());
             Ok(())
         }
 

--- a/crates/airc-cli/src/message_cli.rs
+++ b/crates/airc-cli/src/message_cli.rs
@@ -1,0 +1,28 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct MessageArgs {
+    #[command(subcommand)]
+    pub action: MessageAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum MessageAction {
+    /// Build a legacy messages.jsonl chat envelope as JSON.
+    BuildLegacy {
+        #[arg(long)]
+        from: String,
+        #[arg(long)]
+        to: String,
+        #[arg(long)]
+        ts: String,
+        #[arg(long)]
+        channel: String,
+        #[arg(long)]
+        msg: String,
+        #[arg(long, default_value = "")]
+        client_id: String,
+        #[arg(long, default_value = "")]
+        kind: String,
+    },
+}

--- a/crates/airc-cli/src/message_commands.rs
+++ b/crates/airc-cli/src/message_commands.rs
@@ -1,0 +1,68 @@
+use std::error::Error;
+
+use serde_json::{json, Value};
+
+pub fn run_build_legacy(
+    from: &str,
+    to: &str,
+    ts: &str,
+    channel: &str,
+    msg: &str,
+    client_id: &str,
+    kind: &str,
+) -> Result<(), Box<dyn Error>> {
+    let mut payload = json!({
+        "from": from,
+        "to": to,
+        "ts": ts,
+        "channel": channel,
+        "msg": msg,
+    });
+    let object = payload
+        .as_object_mut()
+        .expect("json object literal is an object");
+    if !client_id.is_empty() {
+        object.insert(
+            "client_id".to_string(),
+            Value::String(client_id.to_string()),
+        );
+    }
+    if !kind.is_empty() {
+        object.insert("kind".to_string(), Value::String(kind.to_string()));
+    }
+    println!("{}", serde_json::to_string(&payload)?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_legacy_owns_json_serialization() {
+        let mut out = Vec::new();
+        let payload = json!({
+            "from": "alice",
+            "to": "all",
+            "ts": "2026-05-19T00:00:00Z",
+            "channel": "general",
+            "msg": "line\nquote \" slash \\",
+            "client_id": "client",
+            "kind": "heartbeat",
+        });
+        serde_json::to_writer(&mut out, &payload).unwrap();
+        let parsed: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(parsed["msg"], "line\nquote \" slash \\");
+
+        run_build_legacy(
+            "alice",
+            "all",
+            "2026-05-19T00:00:00Z",
+            "general",
+            "line\nquote \" slash \\",
+            "client",
+            "heartbeat",
+        )
+        .unwrap();
+    }
+}

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -1714,14 +1714,7 @@ cmd_connect() {
 
     # Read own identity blob to send in handshake (issue #34 v2 — peers
     # cache each other's identity at pair-time so airc whois works fast).
-    local my_identity_json; my_identity_json=$(CONFIG="$CONFIG" "$AIRC_PYTHON" -c '
-import json, os
-try:
-    c = json.load(open(os.environ["CONFIG"]))
-    print(json.dumps(c.get("identity", {})))
-except Exception:
-    print("{}")
-' 2>/dev/null)
+    local my_identity_json; my_identity_json=$("$(airc_rs_bin)" config get --home "$AIRC_WRITE_DIR" --config "$CONFIG" identity "{}" 2>/dev/null || echo "{}")
     [ -z "$my_identity_json" ] && my_identity_json="{}"
 
     local response
@@ -1814,38 +1807,14 @@ except Exception:
     # Phase E.2: capture host's X25519 pubkey from handshake response
     # so cmd_send can encrypt envelopes destined for this peer.
     host_x25519_pub=$(printf '%s' "$response" | "$(airc_rs_bin)" gist get .x25519_pub 2>/dev/null || true)
-    HOST_X25519_PUB="$host_x25519_pub" "$AIRC_PYTHON" -c "
-import json, os
-peers_dir = os.path.expanduser('$PEERS_DIR')
-os.makedirs(peers_dir, exist_ok=True)
-peer_name = '$peer_name'
-ssh_target = '$ssh_target'
-if os.path.isdir(peers_dir):
-    for entry in os.listdir(peers_dir):
-        if not entry.endswith('.json'): continue
-        if entry == peer_name + '.json': continue
-        try:
-            d = json.load(open(os.path.join(peers_dir, entry)))
-        except Exception:
-            continue
-        if d.get('host') == ssh_target:
-            for ext in ('.json', '.pub'):
-                p = os.path.join(peers_dir, entry[:-5] + ext)
-                if os.path.isfile(p):
-                    try: os.remove(p)
-                    except Exception: pass
-record = {
-    'name': peer_name,
-    'host': ssh_target,
-    'airc_home': '$host_airc_home',
-    'paired': '$(timestamp)'
-}
-host_x = os.environ.get('HOST_X25519_PUB', '')
-if host_x:
-    record['x25519_pub'] = host_x
-with open(os.path.join(peers_dir, peer_name + '.json'), 'w') as f:
-    json.dump(record, f, indent=2)
-" 2>/dev/null || true
+    "$(airc_rs_bin)" identity write-peer-record --home "$AIRC_WRITE_DIR" \
+        --peers-dir "$PEERS_DIR" \
+        --peer-name "$peer_name" \
+        --host "$ssh_target" \
+        --airc-home "$host_airc_home" \
+        --x25519-pub "$host_x25519_pub" \
+        --paired "$(timestamp)" \
+        2>/dev/null || true
 
     # If we resolved this pair via gist discovery (vs. inline-invite),
     # persist the gist id so resume-time freshness checks can detect a

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -296,13 +296,6 @@ cmd_send() {
   ts_val=$(timestamp)
   local client_id; client_id=$(airc_client_id 2>/dev/null || true)
 
-  local escaped_msg
-  escaped_msg=$(printf '%s' "$msg" | "$AIRC_PYTHON" -c "import sys,json; print(json.dumps(sys.stdin.read())[1:-1])")
-  local escaped_client_id=""
-  if [ -n "$client_id" ]; then
-    escaped_client_id=$(printf '%s' "$client_id" | "$AIRC_PYTHON" -c "import sys,json; print(json.dumps(sys.stdin.read())[1:-1])")
-  fi
-
   # Channel: stamp every outbound envelope with the active channel so the
   # monitor display can route by channel uniformly (Phase 2 mesh
   # substrate). Resolution priority (Phase 2B.1):
@@ -325,14 +318,21 @@ cmd_send() {
 
   local from_name="$my_name"
   [ "$system_event" = "1" ] && from_name="airc"
-  local payload="{\"from\":\"$from_name\",\"to\":\"$peer_name\",\"ts\":\"$ts_val\",\"channel\":\"$active_channel\",\"msg\":\"$escaped_msg\""
-  [ -n "$escaped_client_id" ] && payload="${payload},\"client_id\":\"$escaped_client_id\""
   # airc#644 PR-2: stamp kind=heartbeat when --heartbeat was passed so
   # cmd_peers can track separately + monitor_formatter can filter from
   # UI. Default kind (chat) is implicit — pre-#644 peers don't emit kind
   # and downstream code treats absent kind as chat for back-compat.
-  [ "$heartbeat" = "1" ] && payload="${payload},\"kind\":\"heartbeat\""
-  payload="${payload}}"
+  local message_kind=""
+  [ "$heartbeat" = "1" ] && message_kind="heartbeat"
+  local payload
+  payload=$("$(airc_rs_bin)" message build-legacy \
+      --from "$from_name" \
+      --to "$peer_name" \
+      --ts "$ts_val" \
+      --channel "$active_channel" \
+      --msg "$msg" \
+      --client-id "$client_id" \
+      --kind "$message_kind")
   local sig; sig=$(sign_message "$payload")
   local full_msg="${payload%?}"
   full_msg="${full_msg},\"sig\":\"$sig\"}"
@@ -825,9 +825,8 @@ cmd_ping() {
   esac
   ensure_init
 
-  # uuid from python for format consistency with the regex in monitor_formatter.
   local ping_id
-  ping_id=$("$AIRC_PYTHON" -c "import uuid; print(uuid.uuid4())")
+  ping_id=$("$(airc_rs_bin)" uuid-v4)
 
   local start_time
   start_time=$(date +%s)

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -237,6 +237,29 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" gh doctor', combined)
         self.assertIn('"$(airc_rs_bin)" pending host-broadcast-route', combined)
 
+    def test_message_json_glue_uses_airc_rs(self):
+        combined = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in [
+                REPO / "lib/airc_bash/cmd_send.sh",
+                REPO / "lib/airc_bash/cmd_connect.sh",
+            ]
+        )
+
+        forbidden = [
+            "json.dumps(sys.stdin.read())",
+            "uuid.uuid4()",
+            "HOST_X25519_PUB",
+            "json.dump(record",
+        ]
+        for needle in forbidden:
+            self.assertNotIn(needle, combined)
+
+        self.assertIn('"$(airc_rs_bin)" message build-legacy', combined)
+        self.assertIn('"$(airc_rs_bin)" uuid-v4', combined)
+        self.assertIn('"$(airc_rs_bin)" config get --home "$AIRC_WRITE_DIR"', combined)
+        self.assertIn('"$(airc_rs_bin)" identity write-peer-record', combined)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary
- add `airc-rs message build-legacy` so Rust owns outbound messages.jsonl JSON serialization instead of shell string-splicing/escaping
- add `airc-rs uuid-v4` for ping ids
- add `airc-rs identity write-peer-record` for join handshake peer records and stale same-host cleanup
- route join identity blob extraction through existing Rust config reader
- add cutover guard for these message/join JSON glue paths

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli --no-fail-fast
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets -- -D warnings
- python3 test/test_codex_rust_cutover.py
- bash -n lib/airc_bash/cmd_send.sh lib/airc_bash/cmd_connect.sh
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- message build-legacy --from 'a\"b' --to all --ts 2026-05-19T00:00:00Z --channel general --msg $'line\nquote \" slash \\' --client-id client --kind heartbeat | cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- gist get .msg
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- uuid-v4
- cargo test --manifest-path Cargo.toml --workspace --no-fail-fast