### PR TITLE
feat(airc-cli): move channel gist discovery to Rust

### DIFF
--- a/crates/airc-cli/src/channel_gist_cli.rs
+++ b/crates/airc-cli/src/channel_gist_cli.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct ChannelGistArgs {
+    #[command(subcommand)]
+    pub action: ChannelGistAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ChannelGistAction {
+    /// Find an existing channel gist; never creates.
+    Find {
+        #[arg(long)]
+        channel: String,
+        #[arg(long)]
+        require_invite: bool,
+    },
+
+    /// Host bootstrap decision: existing gist, blocked discovery, or create.
+    HostPreflight {
+        #[arg(long)]
+        channel: String,
+        #[arg(long)]
+        config: Option<PathBuf>,
+    },
+}

--- a/crates/airc-cli/src/channel_gist_commands.rs
+++ b/crates/airc-cli/src/channel_gist_commands.rs
@@ -1,0 +1,418 @@
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+use crate::gh_state::{
+    backoff_until, now_seconds, record_backoff, reserve_guarded_request, split_include_output,
+};
+
+const GIST_LIST_LIMIT: usize = 100;
+
+pub fn run_find(channel: &str, require_invite: bool) -> Result<(), Box<dyn Error>> {
+    if let Some(gist_id) = find_existing(channel, require_invite)? {
+        println!("{gist_id}");
+        Ok(())
+    } else {
+        Err("channel gist not found".into())
+    }
+}
+
+pub fn run_host_preflight(channel: &str, config: Option<&Path>) -> Result<(), Box<dyn Error>> {
+    if let Some(gist_id) = config_channel_gist(config, channel) {
+        println!("{gist_id}");
+        return Ok(());
+    }
+    match find_existing_with_state(channel, false)? {
+        Discovery::Found(gist_id) => {
+            println!("{gist_id}");
+            Ok(())
+        }
+        Discovery::Unavailable => Err(ExitCodeError(2).into()),
+        Discovery::Missing => Err(ExitCodeError(1).into()),
+    }
+}
+
+fn find_existing(channel: &str, require_invite: bool) -> Result<Option<String>, Box<dyn Error>> {
+    Ok(match find_existing_with_state(channel, require_invite)? {
+        Discovery::Found(gist_id) => Some(gist_id),
+        Discovery::Missing | Discovery::Unavailable => None,
+    })
+}
+
+enum Discovery {
+    Found(String),
+    Missing,
+    Unavailable,
+}
+
+fn find_existing_with_state(
+    channel: &str,
+    require_invite: bool,
+) -> Result<Discovery, Box<dyn Error>> {
+    let Some(gists) = list_user_gists()? else {
+        return Ok(Discovery::Unavailable);
+    };
+    let candidates: Vec<Value> = gists
+        .into_iter()
+        .filter(|gist| {
+            let desc = gist
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim();
+            desc.starts_with("airc mesh") || desc.starts_with("airc room:")
+        })
+        .collect();
+
+    if let Some(gist_id) = choose_canonical(
+        candidates
+            .iter()
+            .filter(|gist| is_single_channel_match(gist, channel, require_invite)),
+        channel,
+    ) {
+        return Ok(Discovery::Found(gist_id));
+    }
+
+    let mut deep_canonical = Vec::new();
+    for gist in &candidates {
+        let Some(gist_id) = gist.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        if let Some(mut full) = get_gist(gist_id)? {
+            if is_single_channel_match(&full, channel, require_invite) {
+                carry_timestamp(gist, &mut full);
+                deep_canonical.push(full);
+            }
+        }
+    }
+    if let Some(gist_id) = choose_canonical(deep_canonical.iter(), channel) {
+        return Ok(Discovery::Found(gist_id));
+    }
+
+    if let Some(gist_id) = oldest(
+        candidates
+            .iter()
+            .filter(|gist| gist_describes_channel(gist, channel, require_invite)),
+    ) {
+        return Ok(Discovery::Found(gist_id));
+    }
+
+    let mut deep_legacy = Vec::new();
+    for gist in &candidates {
+        let Some(gist_id) = gist.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        if let Some(mut full) = get_gist(gist_id)? {
+            if gist_describes_channel(&full, channel, require_invite) {
+                carry_timestamp(gist, &mut full);
+                deep_legacy.push(full);
+            }
+        }
+    }
+    if let Some(gist_id) = oldest(deep_legacy.iter()) {
+        return Ok(Discovery::Found(gist_id));
+    }
+    Ok(Discovery::Missing)
+}
+
+fn list_user_gists() -> Result<Option<Vec<Value>>, Box<dyn Error>> {
+    let fresh_sec = env_f64("AIRC_GIST_LIST_CACHE_SEC", 60.0);
+    if let Some(cached) = load_cached_gist_list(fresh_sec) {
+        return Ok(Some(cached));
+    }
+    if backoff_until() > now_seconds() {
+        return Ok(load_cached_gist_list(env_f64(
+            "AIRC_GIST_LIST_STALE_SEC",
+            900.0,
+        )));
+    }
+    let args = vec![
+        "api".to_string(),
+        "--include".to_string(),
+        format!("gists?per_page={GIST_LIST_LIMIT}"),
+    ];
+    let (allowed, _) = reserve_guarded_request(&args, now_seconds())?;
+    if !allowed {
+        return Ok(load_cached_gist_list(env_f64(
+            "AIRC_GIST_LIST_STALE_SEC",
+            900.0,
+        )));
+    }
+    let gh = env::var("AIRC_GH_BIN").unwrap_or_else(|_| "gh".to_string());
+    let Ok(output) = Command::new(gh).args(&args).output() else {
+        return Ok(load_cached_gist_list(env_f64(
+            "AIRC_GIST_LIST_STALE_SEC",
+            900.0,
+        )));
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() {
+        record_backoff(&format!("{stderr}{stdout}"));
+        return Ok(load_cached_gist_list(env_f64(
+            "AIRC_GIST_LIST_STALE_SEC",
+            900.0,
+        )));
+    }
+    let (headers, body) = split_include_output(&stdout);
+    record_backoff(&headers);
+    let loaded: Value = serde_json::from_str(body.trim())?;
+    let Some(items) = loaded.as_array() else {
+        return Ok(None);
+    };
+    let gists = items.clone();
+    save_cached_gist_list(&gists);
+    Ok(Some(gists))
+}
+
+fn get_gist(gist_id: &str) -> Result<Option<Value>, Box<dyn Error>> {
+    if backoff_until() > now_seconds() {
+        return Ok(None);
+    }
+    let args = vec![
+        "api".to_string(),
+        "--include".to_string(),
+        format!("gists/{gist_id}"),
+    ];
+    let (allowed, _) = reserve_guarded_request(&args, now_seconds())?;
+    if !allowed {
+        return Ok(None);
+    }
+    let gh = env::var("AIRC_GH_BIN").unwrap_or_else(|_| "gh".to_string());
+    let Ok(output) = Command::new(gh).args(&args).output() else {
+        return Ok(None);
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() {
+        record_backoff(&format!("{stderr}{stdout}"));
+        return Ok(None);
+    }
+    let (headers, body) = split_include_output(&stdout);
+    record_backoff(&headers);
+    Ok(serde_json::from_str(body.trim()).ok())
+}
+
+fn choose_canonical<'a>(matches: impl Iterator<Item = &'a Value>, channel: &str) -> Option<String> {
+    let matches: Vec<&Value> = matches.collect();
+    let prefix = format!("airc room: #{channel}");
+    oldest(matches.iter().copied().filter(|gist| {
+        gist.get("description")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .starts_with(&prefix)
+    }))
+    .or_else(|| oldest(matches.into_iter()))
+}
+
+fn oldest<'a>(matches: impl Iterator<Item = &'a Value>) -> Option<String> {
+    matches
+        .filter_map(|gist| {
+            let id = gist.get("id")?.as_str()?.to_string();
+            let created = gist
+                .get("created_at")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            Some((created, id))
+        })
+        .min_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)))
+        .map(|(_, id)| id)
+}
+
+fn is_single_channel_match(gist: &Value, channel: &str, require_invite: bool) -> bool {
+    let exact_name = format!("airc-room-{channel}.json");
+    gist.get("files")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flat_map(|files| files.iter())
+        .any(|(name, entry)| {
+            let Some(envelope) = entry
+                .get("content")
+                .and_then(Value::as_str)
+                .and_then(|content| serde_json::from_str::<Value>(content).ok())
+            else {
+                return false;
+            };
+            if require_invite
+                && !envelope
+                    .get("invite")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            {
+                return false;
+            }
+            let channels = envelope.get("channels").and_then(Value::as_array);
+            (name == &exact_name
+                && channels
+                    .into_iter()
+                    .flatten()
+                    .any(|item| item.as_str() == Some(channel)))
+                || channels
+                    .map(|items| items.len() == 1 && items[0].as_str() == Some(channel))
+                    .unwrap_or(false)
+        })
+}
+
+fn gist_describes_channel(gist: &Value, channel: &str, require_invite: bool) -> bool {
+    gist.get("files")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flat_map(|files| files.values())
+        .any(|entry| {
+            let Some(envelope) = entry
+                .get("content")
+                .and_then(Value::as_str)
+                .and_then(|content| serde_json::from_str::<Value>(content).ok())
+            else {
+                return false;
+            };
+            if require_invite
+                && !envelope
+                    .get("invite")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            {
+                return false;
+            }
+            envelope
+                .get("channels")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .any(|item| item.as_str() == Some(channel))
+        })
+}
+
+fn carry_timestamp(source: &Value, target: &mut Value) {
+    if let Some(created_at) = source.get("created_at").cloned() {
+        target["created_at"] = created_at;
+    }
+}
+
+fn config_channel_gist(config: Option<&Path>, channel: &str) -> Option<String> {
+    let path = config?;
+    let raw = fs::read_to_string(path).ok()?;
+    let root: Value = serde_json::from_str(&raw).ok()?;
+    let gist_id = root
+        .get("channel_gists")?
+        .get(channel)?
+        .as_str()?
+        .to_string();
+    valid_gist_id(&gist_id).then_some(gist_id)
+}
+
+fn valid_gist_id(gist_id: &str) -> bool {
+    (8..=64).contains(&gist_id.len()) && gist_id.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+fn cache_path() -> PathBuf {
+    let suffix = state_suffix();
+    env::temp_dir().join(format!("airc-gh-gist-list-{suffix}.json"))
+}
+
+fn state_suffix() -> String {
+    #[cfg(unix)]
+    {
+        unsafe { libc::getuid().to_string() }
+    }
+    #[cfg(not(unix))]
+    {
+        env::var("USERNAME").unwrap_or_else(|_| "user".to_string())
+    }
+}
+
+fn load_cached_gist_list(max_age: f64) -> Option<Vec<Value>> {
+    let path = cache_path();
+    let age = fs::metadata(&path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.elapsed().ok())
+        .map(|elapsed| elapsed.as_secs_f64())?;
+    if age > max_age {
+        return None;
+    }
+    serde_json::from_str::<Vec<Value>>(&fs::read_to_string(path).ok()?).ok()
+}
+
+fn save_cached_gist_list(gists: &[Value]) {
+    let path = cache_path();
+    let tmp = path.with_extension(format!("{}.tmp", std::process::id()));
+    if fs::write(&tmp, serde_json::to_vec(gists).unwrap_or_default()).is_ok() {
+        let _ = fs::rename(tmp, path);
+    }
+}
+
+fn env_f64(name: &str, default: f64) -> f64 {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+#[derive(Debug)]
+struct ExitCodeError(u8);
+
+impl std::fmt::Display for ExitCodeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "exit {}", self.0)
+    }
+}
+
+impl Error for ExitCodeError {}
+
+pub fn command_exit_code(error: &(dyn Error + 'static)) -> Option<u8> {
+    error.downcast_ref::<ExitCodeError>().map(|error| error.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn single_channel_exact_file_matches() {
+        let gist = json!({
+            "files": {
+                "airc-room-general.json": {"content": r#"{"channels":["general"]}"#}
+            }
+        });
+
+        assert!(is_single_channel_match(&gist, "general", false));
+    }
+
+    #[test]
+    fn require_invite_rejects_uninvited_gist() {
+        let gist = json!({
+            "files": {
+                "airc-room-general.json": {"content": r#"{"channels":["general"]}"#}
+            }
+        });
+
+        assert!(!is_single_channel_match(&gist, "general", true));
+    }
+
+    #[test]
+    fn canonical_description_wins_before_oldest_fallback() {
+        let generic = json!({
+            "id": "bbbbbbbb",
+            "description": "airc mesh",
+            "created_at": "2026-01-01T00:00:00Z"
+        });
+        let room = json!({
+            "id": "aaaaaaaa",
+            "description": "airc room: #general",
+            "created_at": "2026-02-01T00:00:00Z"
+        });
+
+        assert_eq!(
+            choose_canonical([generic, room].iter(), "general"),
+            Some("aaaaaaaa".to_string())
+        );
+    }
+}

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -16,6 +16,7 @@ use clap::{Args, Parser, Subcommand};
 
 use airc_lib::PeerSpec;
 
+use crate::channel_gist_cli::ChannelGistArgs;
 use crate::codex_cli::{CodexHookArgs, CodexStartArgs};
 use crate::config_cli::ConfigArgs;
 use crate::envelope_cli::EnvelopeArgs;
@@ -95,6 +96,9 @@ pub enum Command {
 
     /// Read and update legacy config.json during Rust cutover.
     Config(ConfigArgs),
+
+    /// Resolve channel-to-gist discovery state during Rust cutover.
+    ChannelGist(ChannelGistArgs),
 
     /// Identity and whois helpers during Rust cutover.
     Identity(IdentityArgs),

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -12,6 +12,8 @@
 //! policy used in CLI paths — no `AllowUnsigned` opt-in.
 
 mod bearer_state;
+mod channel_gist_cli;
+mod channel_gist_commands;
 mod cli;
 mod client_id;
 mod codex_cli;
@@ -63,6 +65,7 @@ use uuid::Uuid;
 use airc_core::PeerId;
 
 use airc_daemon::LocalIdentity;
+use channel_gist_cli::ChannelGistAction;
 use cli::{Cli, Command, PeerAction};
 use codex_cli::CodexHookAction;
 use config_cli::ConfigAction;
@@ -95,6 +98,9 @@ async fn main() -> ExitCode {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("airc-rs: {error}");
+            if let Some(code) = channel_gist_commands::command_exit_code(error.as_ref()) {
+                return ExitCode::from(code);
+            }
             ExitCode::FAILURE
         }
     }
@@ -174,6 +180,16 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     host_identity_json,
                 },
             ),
+        },
+
+        Command::ChannelGist(args) => match args.action {
+            ChannelGistAction::Find {
+                channel,
+                require_invite,
+            } => channel_gist_commands::run_find(&channel, require_invite),
+            ChannelGistAction::HostPreflight { channel, config } => {
+                channel_gist_commands::run_host_preflight(&channel, config.as_deref())
+            }
         },
 
         Command::Identity(args) => match args.action {

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -2034,13 +2034,13 @@ cmd_connect() {
             local _configured_gid
             _configured_gid=$(airc_config_get_channel_gist "$room_name" "$CONFIG" || true)
             if [ -n "$_configured_gid" ] && [ ! -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
-              _existing_room_gid=$("$AIRC_PYTHON" -m airc_core.channel_gist find \
+              _existing_room_gid=$("$(airc_rs_bin)" channel-gist find \
                                    --channel "$room_name" 2>/dev/null || true)
             fi
           fi
           if [ -z "$_existing_room_gid" ] && [ "${AIRC_NO_DISCOVERY:-0}" != "1" ]; then
             local _host_preflight_rc=0
-            _existing_room_gid=$("$AIRC_PYTHON" -m airc_core.channel_gist host-preflight \
+            _existing_room_gid=$("$(airc_rs_bin)" channel-gist host-preflight \
                                  --channel "$room_name" --config "$CONFIG" 2>/dev/null) || _host_preflight_rc=$?
             if [ "${_host_preflight_rc:-0}" = "2" ]; then
               die "GitHub room discovery is unavailable for #${room_name}; refusing to create a new solo room. Retry after the GitHub backoff clears."

--- a/lib/airc_bash/mesh.sh
+++ b/lib/airc_bash/mesh.sh
@@ -62,7 +62,7 @@ _mesh_find() {
       return 0
     fi
   fi
-  "$AIRC_PYTHON" -m airc_core.channel_gist find --channel "$channel" --require-invite 2>/dev/null || true
+  "$(airc_rs_bin)" channel-gist find --channel "$channel" --require-invite 2>/dev/null || true
 }
 
 # Find the canonical channel gist whether or not it currently has a host
@@ -84,7 +84,7 @@ _mesh_find_any() {
       return 0
     fi
   fi
-  "$AIRC_PYTHON" -m airc_core.channel_gist find --channel "$channel" 2>/dev/null || true
+  "$(airc_rs_bin)" channel-gist find --channel "$channel" 2>/dev/null || true
 }
 
 # Publish a new mesh gist. Echoes the new gist id, or empty on failure.

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -260,6 +260,20 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" config get --home "$AIRC_WRITE_DIR"', combined)
         self.assertIn('"$(airc_rs_bin)" identity write-peer-record', combined)
 
+    def test_channel_gist_find_paths_use_airc_rs(self):
+        combined = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in [
+                REPO / "lib/airc_bash/mesh.sh",
+                REPO / "lib/airc_bash/cmd_connect.sh",
+            ]
+        )
+
+        self.assertNotIn("airc_core.channel_gist find", combined)
+        self.assertNotIn("airc_core.channel_gist host-preflight", combined)
+        self.assertIn('"$(airc_rs_bin)" channel-gist find', combined)
+        self.assertIn('"$(airc_rs_bin)" channel-gist host-preflight', combined)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary
- add `airc-rs channel-gist find` and `host-preflight` for read-only channel gist discovery
- preserve canonical selection rules: exact per-channel room gists before generic mesh matches, oldest for convergence, optional invite requirement
- reuse Rust gh governor state for REST list/get calls and local gist-list cache
- route mesh lookup and host preflight shell paths through airc-rs
- add cutover guard preventing these discovery paths from falling back to Python

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli --no-fail-fast
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets -- -D warnings
- python3 test/test_codex_rust_cutover.py
- bash -n lib/airc_bash/mesh.sh lib/airc_bash/cmd_connect.sh
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- channel-gist host-preflight --channel general --config /tmp/does-not-exist; echo rc=2
- configured-gist host-preflight smoke: rc=0 and printed configured gist id
- cargo test --manifest-path Cargo.toml --workspace --no-fail-fast

Notes
- This intentionally does not port `resolve --create-if-missing` or `remember-created`; gist creation/cache mutation is the next, separate convergence-sensitive slice.