### PR TITLE
feat(airc-cli): move bearer recv to Rust

### DIFF
--- a/airc
+++ b/airc
@@ -1497,12 +1497,12 @@ _monitor_multi_channel() {
         local ch="$1" gid="$2"
         [ -z "$ch" ] && return 0
         [ -z "$gid" ] && return 0
-        # bearer_cli recv stderr → per-channel log file (CLAUDE.md
+        # airc-rs bearer recv stderr → per-channel log file (CLAUDE.md
         # "never swallow errors"). The previous 2>/dev/null hid every
         # transient gh failure, leaving "monitor's fine but no events"
         # undebuggable. Append-mode so a tail of the log shows the
         # actual cause when a channel dies.
-        "$AIRC_PYTHON" -u -m airc_core.bearer_cli recv "self" \
+        "$(airc_rs_bin)" bearer recv "self" \
           --room-gist-id "$gid" \
           --offset-file "$AIRC_WRITE_DIR/monitor_offset.${ch}" \
           --state-file "$AIRC_WRITE_DIR/bearer_state.${ch}.json" \
@@ -1576,7 +1576,7 @@ _monitor_multi_channel() {
             gid=$(airc_config_list_channel_gists "$CONFIG" | awk -F '\t' -v c="$ch" '$1 == c {print $2; exit}')
             if [ -n "$gid" ]; then
               sleep 3
-              "$AIRC_PYTHON" -u -m airc_core.bearer_cli recv "self" \
+              "$(airc_rs_bin)" bearer recv "self" \
                 --room-gist-id "$gid" \
                 --offset-file "$AIRC_WRITE_DIR/monitor_offset.${ch}" \
                 --state-file "$AIRC_WRITE_DIR/bearer_state.${ch}.json" \
@@ -1758,7 +1758,7 @@ monitor() {
     local consecutive_timeouts=0
     local ESCALATE_AFTER=4
     while true; do
-      "$AIRC_PYTHON" -u -m airc_core.bearer_cli recv "self" \
+      "$(airc_rs_bin)" bearer recv "self" \
         --room-gist-id "$room_gist_id" \
         --offset-file "$offset_file" \
         --state-file "$AIRC_WRITE_DIR/bearer_state.json" \
@@ -2541,18 +2541,18 @@ EOF
     # Force a bearer respawn so the new gist takes effect immediately.
     # _monitor_multi_channel re-reads channel_map at the top of each
     # outer cycle (companion change in this PR), so killing the
-    # bearer_cli children triggers respawn against the freshly-updated
+    # bearer recv children triggers respawn against the freshly-updated
     # config.
     #
-    # SCOPE-SAFE pkill (Copilot review #422 caught this): bearer_cli
+    # SCOPE-SAFE pkill (Copilot review #422 caught this): bearer recv
     # processes from OTHER scopes (different AIRC_HOME) on the same
-    # machine match a bare 'airc_core.bearer_cli recv' pattern. Each
-    # bearer_cli is launched with `--state-file $AIRC_WRITE_DIR/...`
+    # machine match a bare recv pattern. Each bearer recv is launched
+    # with `--state-file $AIRC_WRITE_DIR/...`
     # so AIRC_WRITE_DIR appears uniquely in this scope's process
     # command lines. Match on that to scope the kill to OUR children
     # only — multi-scope safety, same principle as cmd_teardown's
     # scope-isolation guarantee.
-    pkill -f "airc_core.bearer_cli recv.*${AIRC_WRITE_DIR}" 2>/dev/null || true
+    pkill -f "airc-rs bearer recv.*${AIRC_WRITE_DIR}" 2>/dev/null || true
   done
 }
 

--- a/crates/airc-cli/src/bearer/cli.rs
+++ b/crates/airc-cli/src/bearer/cli.rs
@@ -35,4 +35,21 @@ pub enum BearerAction {
         #[arg(long)]
         room_gist_id: Option<String>,
     },
+
+    /// Stream legacy JSONL envelopes to stdout.
+    Recv {
+        peer_id: String,
+        #[arg(long)]
+        host_target: Option<String>,
+        #[arg(long)]
+        identity_key: Option<String>,
+        #[arg(long)]
+        remote_home: Option<String>,
+        #[arg(long)]
+        offset_file: Option<std::path::PathBuf>,
+        #[arg(long)]
+        state_file: Option<std::path::PathBuf>,
+        #[arg(long)]
+        room_gist_id: Option<String>,
+    },
 }

--- a/crates/airc-cli/src/bearer/local_bus.rs
+++ b/crates/airc-cli/src/bearer/local_bus.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 
 const MESSAGES_FILE: &str = "messages.jsonl";
@@ -16,6 +16,35 @@ pub fn append_batch(gist_id: &str, payloads: &[String]) -> (bool, String) {
         }
     }
     (ok, detail)
+}
+
+pub fn read_from(gist_id: &str, mut byte_offset: u64) -> (Vec<String>, u64) {
+    let path = path_for(gist_id);
+    let Ok(mut file) = fs::File::open(path) else {
+        return (Vec::new(), byte_offset);
+    };
+    let size = file.metadata().map(|meta| meta.len()).unwrap_or(0);
+    if byte_offset > size {
+        byte_offset = 0;
+    }
+    if file.seek(SeekFrom::Start(byte_offset)).is_err() {
+        return (Vec::new(), byte_offset);
+    }
+    let mut chunk = Vec::new();
+    if file.read_to_end(&mut chunk).is_err() || chunk.is_empty() {
+        return (Vec::new(), byte_offset);
+    }
+    let Some(last_newline) = chunk.iter().rposition(|byte| *byte == b'\n') else {
+        return (Vec::new(), byte_offset);
+    };
+    let complete = &chunk[..=last_newline];
+    let Ok(text) = String::from_utf8(complete.to_vec()) else {
+        return (Vec::new(), byte_offset);
+    };
+    (
+        text.lines().map(str::to_string).collect(),
+        byte_offset + complete.len() as u64,
+    )
 }
 
 fn append(gist_id: &str, line: &str) -> (bool, String) {

--- a/crates/airc-cli/src/bearer/mod.rs
+++ b/crates/airc-cli/src/bearer/mod.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod commands;
+pub mod recv;
 
 mod gh;
 mod local_bus;

--- a/crates/airc-cli/src/bearer/recv.rs
+++ b/crates/airc-cli/src/bearer/recv.rs
@@ -1,0 +1,335 @@
+use std::collections::{HashSet, VecDeque};
+use std::error::Error;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+use super::gh::{self};
+use super::local_bus;
+use super::outcome::SendKind;
+use crate::gh_state::now_seconds;
+
+const DEFAULT_POLL_INTERVAL: f64 = 15.0;
+const DEFAULT_HEARTBEAT_INTERVAL: f64 = 30.0;
+const SEEN_PAYLOAD_MAX: usize = 5000;
+
+pub fn run_recv(
+    peer_id: &str,
+    _host_target: Option<&str>,
+    _identity_key: Option<&str>,
+    _remote_home: Option<&str>,
+    offset_file: Option<&Path>,
+    state_file: Option<&Path>,
+    room_gist_id: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
+    let Some(gist_id) = room_gist_id.filter(|gist| !gist.trim().is_empty()) else {
+        return Err("bearer recv: no room_gist_id supplied".into());
+    };
+    let mut receiver = GistReceiver::new(peer_id, gist_id, offset_file, state_file);
+    receiver.run()
+}
+
+struct GistReceiver<'a> {
+    peer_id: &'a str,
+    gist_id: &'a str,
+    offset_file: Option<PathBuf>,
+    state_file: Option<PathBuf>,
+    consumed_lines: usize,
+    local_byte_offset: u64,
+    events_total: u64,
+    seen: SeenPayloads,
+    next_heartbeat_at: f64,
+}
+
+impl<'a> GistReceiver<'a> {
+    fn new(
+        peer_id: &'a str,
+        gist_id: &'a str,
+        offset_file: Option<&Path>,
+        state_file: Option<&Path>,
+    ) -> Self {
+        let offset_file = offset_file.map(Path::to_path_buf);
+        let state_file = state_file.map(Path::to_path_buf);
+        let consumed_lines = read_usize_offset(offset_file.as_deref());
+        let local_byte_offset =
+            read_u64_offset(local_offset_file(offset_file.as_deref()).as_deref());
+        Self {
+            peer_id,
+            gist_id,
+            offset_file,
+            state_file,
+            consumed_lines,
+            local_byte_offset,
+            events_total: 0,
+            seen: SeenPayloads::default(),
+            next_heartbeat_at: now_seconds() + heartbeat_interval(),
+        }
+    }
+
+    fn run(&mut self) -> Result<(), Box<dyn Error>> {
+        self.write_state(json!({
+            "kind": "gh",
+            "peer_id": self.peer_id,
+            "last_recv_ts": Value::Null,
+            "last_sender": Value::Null,
+            "events_total": 0,
+            "diag": "bearer open, no events yet",
+        }));
+
+        loop {
+            if !self.drain_local_bus()? {
+                return Ok(());
+            }
+            match gh::get_classified(self.gist_id) {
+                (Some(gist), _) => {
+                    if !self.emit_new_gist_lines(&gist)? {
+                        return Ok(());
+                    }
+                    self.sleep_or_heartbeat(poll_interval())?;
+                }
+                (None, SendKind::Gone) => {
+                    return Err(format!("room gist {} returned 404 (gone)", self.gist_id).into());
+                }
+                (None, SendKind::SecondaryRateLimit) => {
+                    self.sleep_or_heartbeat(poll_interval().max(60.0))?;
+                }
+                (None, _) => {
+                    self.sleep_or_heartbeat(poll_interval())?;
+                }
+            }
+        }
+    }
+
+    fn drain_local_bus(&mut self) -> Result<bool, Box<dyn Error>> {
+        let (lines, new_offset) = local_bus::read_from(self.gist_id, self.local_byte_offset);
+        if new_offset != self.local_byte_offset {
+            self.local_byte_offset = new_offset;
+            write_offset(
+                local_offset_file(self.offset_file.as_deref()).as_deref(),
+                new_offset,
+            );
+        }
+        for line in lines {
+            if !self.emit_line(&line, "local bus")? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn emit_new_gist_lines(&mut self, gist: &Value) -> Result<bool, Box<dyn Error>> {
+        let content = gh::read_messages_content(gist);
+        let lines = content.lines().collect::<Vec<_>>();
+        if self.consumed_lines > lines.len() {
+            self.consumed_lines = lines.len();
+            write_offset(self.offset_file.as_deref(), self.consumed_lines);
+        }
+        for (idx, line) in lines.iter().enumerate().skip(self.consumed_lines) {
+            self.consumed_lines = idx + 1;
+            write_offset(self.offset_file.as_deref(), self.consumed_lines);
+            if !self.emit_line(line, "gh poll")? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn emit_line(&mut self, line: &str, source: &str) -> Result<bool, Box<dyn Error>> {
+        let Some((sender, _channel)) = parse_legacy_envelope(line) else {
+            return Ok(true);
+        };
+        if self.seen.check(line) {
+            return Ok(true);
+        }
+        let mut stdout = io::stdout().lock();
+        if writeln!(stdout, "{line}")
+            .and_then(|_| stdout.flush())
+            .is_err()
+        {
+            return Ok(false);
+        }
+        self.events_total += 1;
+        self.write_state(json!({
+            "kind": "gh",
+            "peer_id": self.peer_id,
+            "last_recv_ts": now_seconds(),
+            "last_sender": sender,
+            "events_total": self.events_total,
+            "diag": format!("last event from {source}"),
+            "last_heartbeat_ts": now_seconds(),
+        }));
+        Ok(true)
+    }
+
+    fn sleep_or_heartbeat(&mut self, seconds: f64) -> Result<(), Box<dyn Error>> {
+        let deadline = now_seconds() + seconds.max(0.0);
+        while now_seconds() < deadline {
+            self.maybe_emit_heartbeat()?;
+            thread::sleep(Duration::from_millis(100));
+        }
+        Ok(())
+    }
+
+    fn maybe_emit_heartbeat(&mut self) -> Result<(), Box<dyn Error>> {
+        let now = now_seconds();
+        if now < self.next_heartbeat_at {
+            return Ok(());
+        }
+        let line = json!({
+            "airc_heartbeat": 1,
+            "ts": now,
+            "channel": self.gist_id,
+        })
+        .to_string();
+        let mut stdout = io::stdout().lock();
+        if writeln!(stdout, "{line}")
+            .and_then(|_| stdout.flush())
+            .is_err()
+        {
+            return Err("stdout closed".into());
+        }
+        self.touch_state_heartbeat(now);
+        self.next_heartbeat_at = now + heartbeat_interval();
+        Ok(())
+    }
+
+    fn write_state(&self, state: Value) {
+        let Some(path) = &self.state_file else {
+            return;
+        };
+        write_json_atomic(path, &state);
+    }
+
+    fn touch_state_heartbeat(&self, ts: f64) {
+        let Some(path) = &self.state_file else {
+            return;
+        };
+        let mut state = fs::read_to_string(path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+            .unwrap_or_else(|| json!({}));
+        state["last_heartbeat_ts"] = json!(ts);
+        write_json_atomic(path, &state);
+    }
+}
+
+#[derive(Default)]
+struct SeenPayloads {
+    values: HashSet<String>,
+    order: VecDeque<String>,
+}
+
+impl SeenPayloads {
+    fn check(&mut self, line: &str) -> bool {
+        if self.values.contains(line) {
+            return true;
+        }
+        let owned = line.to_string();
+        self.values.insert(owned.clone());
+        self.order.push_back(owned);
+        while self.order.len() > SEEN_PAYLOAD_MAX {
+            if let Some(old) = self.order.pop_front() {
+                self.values.remove(&old);
+            }
+        }
+        false
+    }
+}
+
+fn parse_legacy_envelope(line: &str) -> Option<(String, String)> {
+    let env = serde_json::from_str::<Value>(line).ok()?;
+    let sender = env.get("from")?.as_str()?.to_string();
+    let channel = env
+        .get("channel")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    Some((sender, channel))
+}
+
+fn local_offset_file(offset_file: Option<&Path>) -> Option<PathBuf> {
+    offset_file.map(|path| PathBuf::from(format!("{}.local.bytes", path.display())))
+}
+
+fn read_usize_offset(path: Option<&Path>) -> usize {
+    let Some(path) = path else {
+        return 0;
+    };
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .unwrap_or(0)
+}
+
+fn read_u64_offset(path: Option<&Path>) -> u64 {
+    let Some(path) = path else {
+        return 0;
+    };
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(0)
+}
+
+fn write_offset<T: std::fmt::Display>(path: Option<&Path>, value: T) {
+    let Some(path) = path else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::write(path, value.to_string());
+}
+
+fn write_json_atomic(path: &Path, value: &Value) {
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let tmp = path.with_extension(format!("{}.tmp", std::process::id()));
+    if fs::write(&tmp, value.to_string()).is_ok() {
+        let _ = fs::rename(tmp, path);
+    }
+}
+
+fn poll_interval() -> f64 {
+    env_f64("AIRC_GH_POLL_INTERVAL", DEFAULT_POLL_INTERVAL)
+}
+
+fn heartbeat_interval() -> f64 {
+    env_f64("AIRC_BEARER_HEARTBEAT_SEC", DEFAULT_HEARTBEAT_INTERVAL)
+}
+
+fn env_f64(name: &str, default: f64) -> f64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|raw| raw.parse::<f64>().ok())
+        .filter(|value| *value >= 0.0)
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_legacy_envelope_requires_sender() {
+        assert_eq!(
+            parse_legacy_envelope(r#"{"from":"alice","channel":"general"}"#),
+            Some(("alice".to_string(), "general".to_string()))
+        );
+        assert_eq!(parse_legacy_envelope(r#"{"channel":"general"}"#), None);
+        assert_eq!(parse_legacy_envelope("not json"), None);
+    }
+
+    #[test]
+    fn seen_payloads_dedupes_exact_lines() {
+        let mut seen = SeenPayloads::default();
+        assert!(!seen.check("a"));
+        assert!(seen.check("a"));
+        assert!(!seen.check("b"));
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -147,6 +147,23 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 remote_home.as_deref(),
                 room_gist_id.as_deref(),
             ),
+            BearerAction::Recv {
+                peer_id,
+                host_target,
+                identity_key,
+                remote_home,
+                offset_file,
+                state_file,
+                room_gist_id,
+            } => bearer::recv::run_recv(
+                &peer_id,
+                host_target.as_deref(),
+                identity_key.as_deref(),
+                remote_home.as_deref(),
+                offset_file.as_deref(),
+                state_file.as_deref(),
+                room_gist_id.as_deref(),
+            ),
         },
 
         Command::Config(args) => match args.action {

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -292,6 +292,13 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" bearer send ', combined)
         self.assertIn('"$(airc_rs_bin)" bearer send-batch', combined)
 
+    def test_bearer_recv_paths_use_airc_rs(self):
+        source = (REPO / "airc").read_text(encoding="utf-8")
+
+        self.assertNotIn("airc_core.bearer_cli recv", source)
+        self.assertIn('"$(airc_rs_bin)" bearer recv "self"', source)
+        self.assertIn('pkill -f "airc-rs bearer recv.*${AIRC_WRITE_DIR}"', source)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary
- add `airc-rs bearer recv` for gh gist receive loops
- stream legacy JSONL envelopes from gist and local bus with offset tracking, heartbeat output, state-file updates, and deduplication
- route multi-channel and legacy single-gist monitor bearer recv loops through airc-rs
- update scoped bearer restart kill pattern and cutover guard to block Python recv regression

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- bash -n airc
- python3 test/test_codex_rust_cutover.py
- cargo test --manifest-path Cargo.toml -p airc-cli bearer --no-fail-fast
- cargo test --manifest-path Cargo.toml -p airc-cli --no-fail-fast
- cargo test --manifest-path Cargo.toml --workspace --no-fail-fast
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets -- -D warnings