### PR TITLE
feat(airc-cli): move pair handshake to Rust

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -23,6 +23,7 @@ use crate::config_cli::ConfigArgs;
 use crate::envelope_cli::EnvelopeArgs;
 use crate::gh_cli::GhArgs;
 use crate::gist_cli::GistArgs;
+use crate::handshake_cli::HandshakeArgs;
 use crate::identity_cli::IdentityArgs;
 use crate::message_cli::MessageArgs;
 use crate::pending_cli::PendingArgs;
@@ -238,6 +239,9 @@ pub enum Command {
 
     /// Shared GitHub request governor.
     Gh(GhArgs),
+
+    /// TCP pairing handshake during Rust cutover.
+    Handshake(HandshakeArgs),
 
     /// Pending-queue routing helpers during Rust cutover.
     Pending(PendingArgs),

--- a/crates/airc-cli/src/handshake_cli.rs
+++ b/crates/airc-cli/src/handshake_cli.rs
@@ -1,0 +1,54 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct HandshakeArgs {
+    #[command(subcommand)]
+    pub action: HandshakeAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum HandshakeAction {
+    /// Joiner-side TCP pair request.
+    Send {
+        host: String,
+        port: u16,
+        #[arg(long, default_value = "")]
+        my_name: String,
+        #[arg(long, default_value = "")]
+        my_host: String,
+        #[arg(long, default_value = "")]
+        my_ssh_pub: String,
+        #[arg(long, default_value = "")]
+        my_sign_pub: String,
+        #[arg(long, default_value = "")]
+        my_x25519_pub: String,
+        #[arg(long, default_value = "")]
+        my_airc_home: String,
+        #[arg(long, default_value = "{}")]
+        my_identity_json: String,
+    },
+
+    /// Host-side TCP listener; accepts and records one peer.
+    AcceptOne {
+        #[arg(long, default_value_t = 7547)]
+        host_port: u16,
+        #[arg(long)]
+        peers_dir: PathBuf,
+        #[arg(long)]
+        identity_dir: PathBuf,
+        #[arg(long)]
+        config: PathBuf,
+        #[arg(long)]
+        host_name: String,
+        #[arg(long, default_value_t = 300)]
+        reminder_interval: u64,
+        #[arg(long)]
+        airc_home: PathBuf,
+        #[arg(long)]
+        messages: PathBuf,
+        #[arg(long, default_value_t = 0)]
+        watch_pid: u32,
+    },
+}

--- a/crates/airc-cli/src/handshake_commands.rs
+++ b/crates/airc-cli/src/handshake_commands.rs
@@ -1,0 +1,312 @@
+use std::error::Error;
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::legacy_identity;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PairRequest {
+    name: String,
+    host: String,
+    ssh_pub: String,
+    sign_pub: String,
+    x25519_pub: String,
+    airc_home: String,
+    identity: Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PairResponse {
+    ssh_pub: String,
+    x25519_pub: String,
+    name: String,
+    reminder: u64,
+    airc_home: String,
+    identity: Value,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn run_send(
+    host: &str,
+    port: u16,
+    my_name: &str,
+    my_host: &str,
+    my_ssh_pub: &str,
+    my_sign_pub: &str,
+    my_x25519_pub: &str,
+    my_airc_home: &str,
+    my_identity_json: &str,
+) -> Result<(), Box<dyn Error>> {
+    let identity = serde_json::from_str::<Value>(my_identity_json).unwrap_or_else(|_| json!({}));
+    let request = PairRequest {
+        name: my_name.to_string(),
+        host: my_host.to_string(),
+        ssh_pub: my_ssh_pub.to_string(),
+        sign_pub: my_sign_pub.to_string(),
+        x25519_pub: my_x25519_pub.to_string(),
+        airc_home: my_airc_home.to_string(),
+        identity,
+    };
+    let mut stream = TcpStream::connect((host, port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+    stream.write_all(serde_json::to_string(&request)?.as_bytes())?;
+    stream.write_all(b"\n")?;
+    stream.shutdown(std::net::Shutdown::Write)?;
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+    println!("{}", response.trim());
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn run_accept_one(
+    host_port: u16,
+    peers_dir: &Path,
+    identity_dir: &Path,
+    config: &Path,
+    host_name: &str,
+    reminder_interval: u64,
+    airc_home: &Path,
+    messages: &Path,
+    watch_pid: u32,
+) -> Result<(), Box<dyn Error>> {
+    let listener = TcpListener::bind(("0.0.0.0", host_port))?;
+    listener.set_nonblocking(true)?;
+    let (mut stream, _) = accept_with_watch(&listener, watch_pid)?;
+    let request = read_request(&mut stream)?;
+
+    authorize_ssh_key(&request.ssh_pub)?;
+    write_peer_record(peers_dir, &request)?;
+    let response = PairResponse {
+        ssh_pub: fs::read_to_string(identity_dir.join("ssh_key.pub"))?
+            .trim()
+            .to_string(),
+        x25519_pub: legacy_identity::load_x25519_public(identity_dir).unwrap_or_default(),
+        name: host_name.to_string(),
+        reminder: reminder_interval,
+        airc_home: airc_home.display().to_string(),
+        identity: load_identity(config),
+    };
+    stream.write_all(serde_json::to_string(&response)?.as_bytes())?;
+    stream.write_all(b"\n")?;
+    append_join_event(messages, airc_home, &request.name)?;
+    println!("  Peer joined: {}", request.name);
+    Ok(())
+}
+
+fn accept_with_watch(
+    listener: &TcpListener,
+    watch_pid: u32,
+) -> Result<(TcpStream, std::net::SocketAddr), Box<dyn Error>> {
+    loop {
+        match listener.accept() {
+            Ok(pair) => return Ok(pair),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                if watch_pid != 0 && !pid_is_alive(watch_pid) {
+                    std::process::exit(0);
+                }
+                thread::sleep(Duration::from_millis(200));
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+}
+
+fn read_request(stream: &mut TcpStream) -> Result<PairRequest, Box<dyn Error>> {
+    let mut data = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        let read = stream.read(&mut buf)?;
+        if read == 0 {
+            break;
+        }
+        data.extend_from_slice(&buf[..read]);
+        if data.contains(&b'\n') {
+            break;
+        }
+    }
+    let line = String::from_utf8(data)?;
+    Ok(serde_json::from_str(line.trim())?)
+}
+
+fn write_peer_record(peers_dir: &Path, request: &PairRequest) -> Result<(), Box<dyn Error>> {
+    fs::create_dir_all(peers_dir)?;
+    remove_stale_peer_records(peers_dir, request)?;
+    let mut record = json!({
+        "name": request.name,
+        "host": request.host,
+        "airc_home": request.airc_home,
+        "paired": timestamp(),
+        "ssh_pub": request.ssh_pub,
+        "identity": request.identity,
+    });
+    if !request.x25519_pub.is_empty() {
+        record["x25519_pub"] = Value::String(request.x25519_pub.clone());
+    }
+    fs::write(
+        peers_dir.join(format!("{}.json", request.name)),
+        serde_json::to_string_pretty(&record)?,
+    )?;
+    if !request.sign_pub.is_empty() {
+        fs::write(
+            peers_dir.join(format!("{}.pub", request.name)),
+            &request.sign_pub,
+        )?;
+    }
+    Ok(())
+}
+
+fn remove_stale_peer_records(
+    peers_dir: &Path,
+    request: &PairRequest,
+) -> Result<(), Box<dyn Error>> {
+    for entry in fs::read_dir(peers_dir)? {
+        let path = entry?.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        if path.file_stem().and_then(|value| value.to_str()) == Some(request.name.as_str()) {
+            continue;
+        }
+        let stale = fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+            .is_some_and(|value| same_peer(&value, request));
+        if stale {
+            let _ = fs::remove_file(&path);
+            let _ = fs::remove_file(path.with_extension("pub"));
+        }
+    }
+    Ok(())
+}
+
+fn same_peer(value: &Value, request: &PairRequest) -> bool {
+    if !request.x25519_pub.is_empty()
+        && value.get("x25519_pub").and_then(Value::as_str) == Some(request.x25519_pub.as_str())
+    {
+        return true;
+    }
+    !request.host.is_empty()
+        && !request.airc_home.is_empty()
+        && value.get("host").and_then(Value::as_str) == Some(request.host.as_str())
+        && value.get("airc_home").and_then(Value::as_str) == Some(request.airc_home.as_str())
+}
+
+fn authorize_ssh_key(ssh_key: &str) -> Result<(), Box<dyn Error>> {
+    if ssh_key.trim().is_empty() {
+        return Ok(());
+    }
+    let Some(home) = home_dir() else {
+        return Ok(());
+    };
+    let ssh_dir = home.join(".ssh");
+    fs::create_dir_all(&ssh_dir)?;
+    let authorized_keys = ssh_dir.join("authorized_keys");
+    let existing = fs::read_to_string(&authorized_keys).unwrap_or_default();
+    if !existing.contains(ssh_key.trim()) {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&authorized_keys)?;
+        writeln!(file, "{}", ssh_key.trim())?;
+    }
+    set_private_permissions(&ssh_dir, &authorized_keys);
+    Ok(())
+}
+
+fn append_join_event(messages: &Path, airc_home: &Path, name: &str) -> Result<(), Box<dyn Error>> {
+    let room_name = fs::read_to_string(airc_home.join("room_name"))
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "general".to_string());
+    let event = json!({
+        "ts": timestamp(),
+        "from": "airc",
+        "to": "all",
+        "channel": room_name,
+        "msg": format!("{name} joined #{room_name}"),
+    });
+    if let Some(parent) = messages.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(messages)?;
+    writeln!(file, "{}", serde_json::to_string(&event)?)?;
+    Ok(())
+}
+
+fn load_identity(config: &Path) -> Value {
+    fs::read_to_string(config)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .and_then(|value| value.get("identity").cloned())
+        .unwrap_or_else(|| json!({}))
+}
+
+fn timestamp() -> String {
+    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
+}
+
+#[cfg(unix)]
+fn set_private_permissions(ssh_dir: &Path, authorized_keys: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = fs::set_permissions(ssh_dir, fs::Permissions::from_mode(0o700));
+    let _ = fs::set_permissions(authorized_keys, fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn set_private_permissions(_ssh_dir: &Path, _authorized_keys: &Path) {}
+
+#[cfg(unix)]
+fn pid_is_alive(pid: u32) -> bool {
+    // SAFETY: `kill(pid, 0)` does not send a signal; it checks process existence.
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn pid_is_alive(_pid: u32) -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_match_prefers_x25519_identity() {
+        let request = PairRequest {
+            name: "new".into(),
+            host: "user@host".into(),
+            ssh_pub: String::new(),
+            sign_pub: String::new(),
+            x25519_pub: "pub".into(),
+            airc_home: "/new".into(),
+            identity: json!({}),
+        };
+        assert!(same_peer(
+            &json!({"host":"other","x25519_pub":"pub"}),
+            &request
+        ));
+        assert!(!same_peer(
+            &json!({"host":"user@host","airc_home":"/old"}),
+            &request
+        ));
+    }
+}

--- a/crates/airc-cli/src/legacy_identity.rs
+++ b/crates/airc-cli/src/legacy_identity.rs
@@ -98,6 +98,13 @@ pub fn load_x25519_private(identity_dir: &Path) -> Result<[u8; 32], Box<dyn Erro
     read_exact_32(&identity_dir.join(X25519_PRIV), "X25519 private key")
 }
 
+pub fn load_x25519_public(identity_dir: &Path) -> Result<String, Box<dyn Error>> {
+    Ok(b64_url_no_pad(&read_exact_32(
+        &identity_dir.join(X25519_PUB),
+        "X25519 public key",
+    )?))
+}
+
 fn x25519_paths(identity_dir: &Path) -> (PathBuf, PathBuf) {
     (
         identity_dir.join(X25519_PRIV),

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -35,6 +35,8 @@ mod gh_commands;
 mod gh_state;
 mod gist_cli;
 mod gist_commands;
+mod handshake_cli;
+mod handshake_commands;
 mod identity_cli;
 mod identity_commands;
 mod lane_cli;
@@ -76,6 +78,7 @@ use envelope_cli::EnvelopeAction;
 use events_cli::EventsAction;
 use gh_cli::GhAction;
 use gist_cli::GistAction;
+use handshake_cli::HandshakeAction;
 use identity_cli::IdentityAction;
 use lane_cli::{LaneAction, LaneManagerAction};
 use log_cli::LogAction;
@@ -447,6 +450,51 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 clear_audit,
             } => gh_commands::run_audit(count, summary, reset, clear_audit),
             GhAction::Doctor { count } => gh_commands::run_doctor(count),
+        },
+
+        Command::Handshake(args) => match args.action {
+            HandshakeAction::Send {
+                host,
+                port,
+                my_name,
+                my_host,
+                my_ssh_pub,
+                my_sign_pub,
+                my_x25519_pub,
+                my_airc_home,
+                my_identity_json,
+            } => handshake_commands::run_send(
+                &host,
+                port,
+                &my_name,
+                &my_host,
+                &my_ssh_pub,
+                &my_sign_pub,
+                &my_x25519_pub,
+                &my_airc_home,
+                &my_identity_json,
+            ),
+            HandshakeAction::AcceptOne {
+                host_port,
+                peers_dir,
+                identity_dir,
+                config,
+                host_name,
+                reminder_interval,
+                airc_home,
+                messages,
+                watch_pid,
+            } => handshake_commands::run_accept_one(
+                host_port,
+                &peers_dir,
+                &identity_dir,
+                &config,
+                &host_name,
+                reminder_interval,
+                &airc_home,
+                &messages,
+                watch_pid,
+            ),
         },
 
         Command::Pending(args) => match args.action {

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -271,7 +271,7 @@ _join_restart_scope_processes() {
     kill -0 "$_candidate" 2>/dev/null || continue
     _candidate_cmd=$(proc_cmdline "$_candidate" 2>/dev/null || true)
     case "$_candidate_cmd" in
-      *airc_core.bearer_cli*recv*|*airc-rs*monitor*format*|*airc-rs*monitor*attach*|*airc_core.monitor_formatter*|*airc_core.handshake*|*airc_core.log_tail*) ;;
+      *airc_core.bearer_cli*recv*|*airc-rs*monitor*format*|*airc-rs*monitor*attach*|*airc-rs*handshake*) ;;
       *airc[[:space:]]connect*|*airc[[:space:]]join*|*/airc[[:space:]]*) ;;
       *) continue ;;
     esac
@@ -300,10 +300,10 @@ _join_restart_scope_processes() {
 
 _join_scope_transport_pids() {
   # Scope-path catch-all for `airc join` self-heal. Pidfiles are not
-  # enough after Monitor restarts: old bearer_cli / monitor_formatter
+  # enough after Monitor restarts: old bearer/formatter
   # children can be reparented to init and keep serving the same scope
   # while the new generation also runs. Match only transport/process
-  # owners for THIS scope; leave UI-only log_tail attach streams alone.
+  # owners for THIS scope; leave UI-only attach streams alone.
   local _pids=""
   local _pid _cmd _scope_variant
   while IFS= read -r _scope_variant; do
@@ -314,8 +314,8 @@ _join_scope_transport_pids() {
       [ "$_pid" = "$PPID" ] && continue
       _cmd=$(proc_cmdline "$_pid" || true)
       case "$_cmd" in
-        *airc_core.log_tail*|*airc-rs*monitor*attach*) continue ;;
-        *airc_core.bearer_cli*recv*|*airc-rs*monitor*format*|*airc_core.monitor_formatter*|*airc_core.handshake*accept_one*)
+        *airc-rs*monitor*attach*) continue ;;
+        *airc_core.bearer_cli*recv*|*airc-rs*monitor*format*|*airc-rs*handshake*accept-one*)
           _pids="$_pids $_pid"
           ;;
         *) continue ;;
@@ -1724,14 +1724,7 @@ cmd_connect() {
 
     local response
     local _pair_ok=1
-    # Migrated to airc_core.handshake send with proper --flags (not env
-    # vars). MSYS path-translation on Git Bash silently mangles env-var
-    # values that look like Unix paths (/Users/... → C:/Program
-    # Files/Git/Users/...) when they cross to a Windows-binary subprocess.
-    # argparse --flags are per-arg-predictable (callers can //-prefix
-    # or set MSYS2_ARG_CONV_EXCL targeted-ly). Continuum-b69f 2026-04-27
-    # traced the env-var path-mangling class.
-    response=$("$AIRC_PYTHON" -m airc_core.handshake send "$peer_host_only" "$peer_port" \
+    response=$("$(airc_rs_bin)" handshake send "$peer_host_only" "$peer_port" \
                   --my-name "$my_name" \
                   --my-host "$(whoami)@$(get_host)" \
                   --my-ssh-pub "$my_ssh_pub" \
@@ -2447,25 +2440,21 @@ JSON
     # Parent-watch (#132): the loop exits when its own parent disappears
     # (PPID=1 = reparented to init = airc parent bash died). Without
     # this, the loop survives terminal close / Monitor tool teardown /
-    # kill of the parent, keeps spawning fresh python listeners, and
+    # kill of the parent, keeps spawning fresh listeners, and
     # every joiner that hits the cached port gets a real-looking pair
-    # handshake against a ghost host. Pair-listener Python has its own
-    # 1s parent-watch thread (see airc_core.handshake._start_parent_watch)
-    # to catch the in-flight-handshake case; this loop check covers the
-    # between-iterations case before the next python is spawned.
+    # handshake against a ghost host. The Rust listener also receives
+    # --watch-pid, so in-flight accepts exit when the parent dies.
     _orphan_parent_pid=$$
     (
       # Loop while the airc parent bash is still alive. kill -0 is the
       # cheapest "is PID still running" probe (no signal sent, just an
       # error if the process is gone). When the parent dies, this exits
-      # before the next iteration so no fresh python is spawned.
+      # before the next iteration so no fresh listener is spawned.
       #
-      # --watch-pid hands the same PID to the python listener, which
-      # spawns a 1s polling thread that os._exit()s mid-accept the
-      # moment the parent dies — covering the in-flight handshake
-      # case that the bash between-iterations check can't see.
+      # --watch-pid hands the same PID to the Rust listener, which exits
+      # during accept polling the moment the parent dies.
       while kill -0 "$_orphan_parent_pid" 2>/dev/null; do
-        "$AIRC_PYTHON" -m airc_core.handshake accept_one \
+        "$(airc_rs_bin)" handshake accept-one \
           --host-port "$host_port" \
           --peers-dir "$PEERS_DIR" \
           --identity-dir "$IDENTITY_DIR" \

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -319,6 +319,14 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$_airc_rs" --home "$AIRC_WRITE_DIR" monitor attach', body)
         self.assertIn("airc-rs is required for monitor attach", body)
 
+    def test_handshake_runtime_paths_use_airc_rs(self):
+        source = (REPO / "lib/airc_bash/cmd_connect.sh").read_text(encoding="utf-8")
+
+        self.assertNotIn("airc_core.handshake send", source)
+        self.assertNotIn("airc_core.handshake accept_one", source)
+        self.assertIn('"$(airc_rs_bin)" handshake send', source)
+        self.assertIn('"$(airc_rs_bin)" handshake accept-one', source)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary
- add airc-rs handshake send and accept-one for TCP pair handshakes
- persist accepted peer records, signature pub files, host response metadata, and join events from Rust
- route joiner send and host accept loop through airc-rs instead of airc_core.handshake
- add cutover guard blocking handshake send/accept runtime paths from returning to Python

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-cli
- python3 test/test_codex_rust_cutover.py
- bash -n lib/airc_bash/cmd_connect.sh
- smoke: airc-rs handshake accept-one + airc-rs handshake send round-tripped over localhost, wrote peer record, and appended join event