### PR TITLE
feat(airc-cli): move collaboration health to Rust

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -19,6 +19,7 @@ use airc_lib::PeerSpec;
 use crate::bearer::cli::BearerArgs;
 use crate::channel_gist_cli::ChannelGistArgs;
 use crate::codex_cli::{CodexHookArgs, CodexStartArgs};
+use crate::collaboration_cli::CollaborationArgs;
 use crate::config_cli::ConfigArgs;
 use crate::envelope_cli::EnvelopeArgs;
 use crate::gh_cli::GhArgs;
@@ -102,6 +103,9 @@ pub enum Command {
 
     /// Read and update legacy config.json during Rust cutover.
     Config(ConfigArgs),
+
+    /// Inspect collaboration health during Rust cutover.
+    Collaboration(CollaborationArgs),
 
     /// Resolve channel-to-gist discovery state during Rust cutover.
     ChannelGist(ChannelGistArgs),

--- a/crates/airc-cli/src/collaboration_cli.rs
+++ b/crates/airc-cli/src/collaboration_cli.rs
@@ -1,0 +1,38 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct CollaborationArgs {
+    #[command(subcommand)]
+    pub action: CollaborationAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum CollaborationAction {
+    /// Print collaboration health for the current scope.
+    Status(CollaborationScopeArgs),
+    /// Print doctor-style collaboration findings.
+    Doctor(CollaborationScopeArgs),
+    /// Warn when sends are likely isolated.
+    SendWarning(CollaborationScopeArgs),
+    /// Print recent broadcast peers when peer records are empty.
+    PeersFallback(CollaborationScopeArgs),
+    /// Print a broadcast-only whois fallback.
+    WhoisFallback {
+        #[command(flatten)]
+        scope: CollaborationScopeArgs,
+        #[arg(long)]
+        peer_name: String,
+    },
+}
+
+#[derive(Debug, Args)]
+pub struct CollaborationScopeArgs {
+    #[arg(long)]
+    pub home: Option<PathBuf>,
+    #[arg(long, default_value = "")]
+    pub my_name: String,
+    #[arg(long, default_value = "")]
+    pub client_id: String,
+}

--- a/crates/airc-cli/src/collaboration_commands.rs
+++ b/crates/airc-cli/src/collaboration_commands.rs
@@ -1,0 +1,379 @@
+use std::cmp::Reverse;
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+use serde_json::Value;
+
+use crate::collaboration_cli::CollaborationScopeArgs;
+
+const RECENT_REMOTE_WINDOW_SEC: i64 = 600;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct MessageActivity {
+    name: String,
+    ts: i64,
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+struct CollaborationEvidence {
+    recent_speakers: BTreeMap<String, i64>,
+    recent_activity: Option<MessageActivity>,
+    any_activity: Option<MessageActivity>,
+}
+
+pub fn run_status(default_home: &Path, args: CollaborationScopeArgs) -> Result<(), Box<dyn Error>> {
+    let home = args.home.as_deref().unwrap_or(default_home);
+    let count = peer_record_count(home);
+    let evidence = collaboration_evidence(home, &args.my_name, &args.client_id);
+    let any_recent = evidence
+        .recent_activity
+        .as_ref()
+        .or(evidence.any_activity.as_ref());
+    let now = Utc::now().timestamp();
+    let remote_desc = match any_recent {
+        Some(activity) => format!(
+            "last remote message {}s ago from {}",
+            (now - activity.ts).max(0),
+            activity.name
+        ),
+        None => "no remote messages recorded".to_string(),
+    };
+
+    if count == 0 {
+        if !evidence.recent_speakers.is_empty() {
+            let label = if evidence.recent_speakers.len() == 1 {
+                "broadcast peer"
+            } else {
+                "broadcast peers"
+            };
+            println!(
+                "  collaboration: ok ({} {label}; 0 direct peer records; {remote_desc})",
+                evidence.recent_speakers.len()
+            );
+            println!("    Presence is derived from recent signed room traffic.");
+        } else if any_recent.is_none() {
+            println!("  collaboration: waiting for peers (0 peer records; {remote_desc})");
+            println!(
+                "    First agent in a room is expected to be alone until another agent joins this gist."
+            );
+        } else {
+            println!("  collaboration: SOLO (0 peer records; {remote_desc})");
+            println!(
+                "    Sends may only land in this local/self-hosted gist until another agent joins this exact mesh."
+            );
+        }
+    } else {
+        println!("  collaboration: ok ({count} peer record(s); {remote_desc})");
+    }
+    Ok(())
+}
+
+pub fn run_doctor(default_home: &Path, args: CollaborationScopeArgs) -> Result<(), Box<dyn Error>> {
+    let home = args.home.as_deref().unwrap_or(default_home);
+    let count = peer_record_count(home);
+    let evidence = collaboration_evidence(home, &args.my_name, &args.client_id);
+    let now = Utc::now().timestamp();
+    if count > 0 {
+        println!("  [ok] collaboration mesh has {count} peer record(s)");
+        return Ok(());
+    }
+    if let Some(recent) = evidence.recent_activity.as_ref() {
+        if !evidence.recent_speakers.is_empty() {
+            let label = if evidence.recent_speakers.len() == 1 {
+                "broadcast peer"
+            } else {
+                "broadcast peers"
+            };
+            println!(
+                "  [ok] collaboration mesh has {} recent {label} from signed room traffic (0 direct peer records)",
+                evidence.recent_speakers.len()
+            );
+            println!(
+                "       last remote message {}s ago from {}",
+                (now - recent.ts).max(0),
+                recent.name
+            );
+            return Ok(());
+        }
+        println!(
+            "  [WARN] collaboration mesh has 0 peer records, but remote traffic arrived {}s ago from {}",
+            (now - recent.ts).max(0),
+            recent.name
+        );
+        println!(
+            "         Peer metadata is degraded (DMs/whois may fail), but this is NOT a solo island."
+        );
+        return Err(command_exit(1));
+    }
+    let Some(any_recent) = evidence.any_activity.as_ref() else {
+        println!(
+            "  [info] collaboration mesh has 0 peer records and no remote history — waiting for first peer"
+        );
+        println!("         Share the invite or ask another agent to join this room; first-user startup is OK.");
+        return Ok(());
+    };
+    println!(
+        "  [BLOCKED] collaboration mesh has 0 peer records — last remote traffic was {}s ago from {}; this may be a solo island",
+        (now - any_recent.ts).max(0),
+        any_recent.name
+    );
+    println!(
+        "         Check: airc peers; ask peers to run 'airc update --channel canary && airc join <current invite>'"
+    );
+    Err(command_exit(2))
+}
+
+pub fn run_send_warning(
+    default_home: &Path,
+    args: CollaborationScopeArgs,
+) -> Result<(), Box<dyn Error>> {
+    let home = args.home.as_deref().unwrap_or(default_home);
+    if peer_record_count(home) == 0
+        && recent_remote_speakers(home, &args.my_name, &args.client_id).is_empty()
+    {
+        eprintln!(
+            "  WARN: collaboration has no direct peer records or recent broadcast peers. Run 'airc peers' and verify others joined this gist."
+        );
+    }
+    Ok(())
+}
+
+pub fn run_peers_fallback(
+    default_home: &Path,
+    args: CollaborationScopeArgs,
+) -> Result<(), Box<dyn Error>> {
+    let home = args.home.as_deref().unwrap_or(default_home);
+    let speakers = recent_remote_speakers(home, &args.my_name, &args.client_id);
+    if speakers.is_empty() {
+        return Err(command_exit(1));
+    }
+    println!("  Recent broadcast peers:");
+    let mut speaker_entries = speakers.iter().collect::<Vec<_>>();
+    speaker_entries.sort_by_key(|(_, ts)| Reverse(**ts));
+    for (who, ts) in speaker_entries {
+        println!(
+            "  {who} → broadcast room   [(from signed messages.jsonl)]   last seen {}",
+            fmt_age(*ts)
+        );
+    }
+    Ok(())
+}
+
+pub fn run_whois_fallback(
+    default_home: &Path,
+    args: CollaborationScopeArgs,
+    peer_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    let home = args.home.as_deref().unwrap_or(default_home);
+    let speakers = recent_remote_speakers(home, &args.my_name, &args.client_id);
+    let Some(ts) = speakers.get(peer_name) else {
+        return Err(command_exit(1));
+    };
+    println!("  name:      {peer_name}");
+    println!("  pronouns:  (unknown)");
+    println!("  role:      broadcast peer");
+    println!("  bio:       seen in recent signed room traffic");
+    println!("  status:    (unknown)");
+    println!("  integrations: (none)");
+    println!("  presence:  broadcast-only, last seen {}", fmt_age(*ts));
+    Ok(())
+}
+
+pub fn command_exit_code(error: &(dyn Error + 'static)) -> Option<u8> {
+    error.downcast_ref::<CommandExit>().map(|error| error.0)
+}
+
+fn peer_record_count(home: &Path) -> usize {
+    let peers_dir = home.join("peers");
+    let Ok(entries) = fs::read_dir(peers_dir) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "json"))
+        .filter(|entry| {
+            fs::read_to_string(entry.path())
+                .ok()
+                .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+                .is_some()
+        })
+        .count()
+}
+
+fn collaboration_evidence(home: &Path, my_name: &str, my_client_id: &str) -> CollaborationEvidence {
+    let mut evidence = CollaborationEvidence::default();
+    let now = Utc::now().timestamp();
+    for activity in remote_messages(home, my_name, None, my_client_id) {
+        if evidence
+            .any_activity
+            .as_ref()
+            .is_none_or(|current| activity.ts > current.ts)
+        {
+            evidence.any_activity = Some(activity.clone());
+        }
+        if now - activity.ts >= RECENT_REMOTE_WINDOW_SEC {
+            continue;
+        }
+        evidence
+            .recent_speakers
+            .entry(activity.name.clone())
+            .and_modify(|ts| *ts = (*ts).max(activity.ts))
+            .or_insert(activity.ts);
+        if evidence
+            .recent_activity
+            .as_ref()
+            .is_none_or(|current| activity.ts > current.ts)
+        {
+            evidence.recent_activity = Some(activity);
+        }
+    }
+    evidence
+}
+
+fn recent_remote_speakers(home: &Path, my_name: &str, my_client_id: &str) -> BTreeMap<String, i64> {
+    let mut speakers = BTreeMap::new();
+    for activity in remote_messages(home, my_name, Some(RECENT_REMOTE_WINDOW_SEC), my_client_id) {
+        speakers
+            .entry(activity.name)
+            .and_modify(|ts: &mut i64| *ts = (*ts).max(activity.ts))
+            .or_insert(activity.ts);
+    }
+    speakers
+}
+
+fn remote_messages(
+    home: &Path,
+    my_name: &str,
+    window_sec: Option<i64>,
+    my_client_id: &str,
+) -> Vec<MessageActivity> {
+    let now = Utc::now().timestamp();
+    fs::read_to_string(home.join("messages.jsonl"))
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|message| !is_self_message(message, my_name, my_client_id))
+        .filter_map(|message| {
+            let ts = epoch(message.get("ts")?.as_str()?)?;
+            if window_sec.is_some_and(|window| now - ts >= window) {
+                return None;
+            }
+            let sender = message.get("from")?.as_str()?;
+            let client_id = message
+                .get("client_id")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            Some(MessageActivity {
+                name: display_name(sender, client_id, my_name),
+                ts,
+            })
+        })
+        .collect()
+}
+
+fn is_self_message(message: &Value, my_name: &str, my_client_id: &str) -> bool {
+    let Some(sender) = message.get("from").and_then(Value::as_str) else {
+        return true;
+    };
+    if sender == "airc" {
+        return true;
+    }
+    let msg_client_id = message
+        .get("client_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if !my_client_id.is_empty() && !msg_client_id.is_empty() {
+        return msg_client_id == my_client_id;
+    }
+    sender == my_name && msg_client_id.is_empty()
+}
+
+fn display_name(sender: &str, client_id: &str, my_name: &str) -> String {
+    if !client_id.is_empty() && sender == my_name {
+        format!("{sender} [{client_id}]")
+    } else {
+        sender.to_string()
+    }
+}
+
+fn epoch(ts: &str) -> Option<i64> {
+    DateTime::parse_from_rfc3339(ts)
+        .map(|value| value.timestamp())
+        .ok()
+        .or_else(|| {
+            NaiveDateTime::parse_from_str(ts.trim_end_matches('Z'), "%Y-%m-%dT%H:%M:%S")
+                .ok()
+                .map(|value| Utc.from_utc_datetime(&value).timestamp())
+        })
+}
+
+fn fmt_age(ts: i64) -> String {
+    let age = (Utc::now().timestamp() - ts).max(0);
+    if age < 60 {
+        format!("{age}s ago")
+    } else if age < 3600 {
+        format!("{}m ago", age / 60)
+    } else if age < 86400 {
+        format!("{}h ago", age / 3600)
+    } else {
+        format!("{}d ago", age / 86400)
+    }
+}
+
+#[derive(Debug)]
+struct CommandExit(u8);
+
+impl std::fmt::Display for CommandExit {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "command exited with {}", self.0)
+    }
+}
+
+impl Error for CommandExit {}
+
+fn command_exit(code: u8) -> Box<dyn Error> {
+    Box::new(CommandExit(code))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recent_speakers_excludes_self_by_client_id() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("messages.jsonl"),
+            format!(
+                "{}\n{}\n",
+                r#"{"from":"me","client_id":"mine","ts":"2026-05-19T12:00:00Z"}"#,
+                r#"{"from":"me","client_id":"peer-tab","ts":"2026-05-19T12:00:01Z"}"#,
+            ),
+        )
+        .unwrap();
+
+        let messages = remote_messages(dir.path(), "me", None, "mine");
+
+        assert_eq!(
+            messages,
+            vec![MessageActivity {
+                name: "me [peer-tab]".to_string(),
+                ts: 1_779_192_001,
+            }]
+        );
+    }
+
+    #[test]
+    fn peer_record_count_requires_valid_json_files() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("peers")).unwrap();
+        fs::write(dir.path().join("peers").join("alice.json"), "{}").unwrap();
+        fs::write(dir.path().join("peers").join("broken.json"), "{").unwrap();
+        fs::write(dir.path().join("peers").join("note.txt"), "{}").unwrap();
+
+        assert_eq!(peer_record_count(dir.path()), 1);
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -23,6 +23,8 @@ mod codex_config;
 mod codex_hooks_json;
 mod codex_install;
 mod codex_start;
+mod collaboration_cli;
+mod collaboration_commands;
 mod commands;
 mod config_cli;
 mod config_commands;
@@ -75,6 +77,7 @@ use bearer::cli::BearerAction;
 use channel_gist_cli::ChannelGistAction;
 use cli::{Cli, Command, PeerAction};
 use codex_cli::CodexHookAction;
+use collaboration_cli::CollaborationAction;
 use config_cli::ConfigAction;
 use envelope_cli::EnvelopeAction;
 use events_cli::EventsAction;
@@ -107,10 +110,13 @@ async fn main() -> ExitCode {
     match dispatch(parsed).await {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
-            eprintln!("airc-rs: {error}");
             if let Some(code) = channel_gist_commands::command_exit_code(error.as_ref()) {
                 return ExitCode::from(code);
             }
+            if let Some(code) = collaboration_commands::command_exit_code(error.as_ref()) {
+                return ExitCode::from(code);
+            }
+            eprintln!("airc-rs: {error}");
             ExitCode::FAILURE
         }
     }
@@ -240,6 +246,20 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     host_identity_json,
                 },
             ),
+        },
+
+        Command::Collaboration(args) => match args.action {
+            CollaborationAction::Status(args) => collaboration_commands::run_status(&home, args),
+            CollaborationAction::Doctor(args) => collaboration_commands::run_doctor(&home, args),
+            CollaborationAction::SendWarning(args) => {
+                collaboration_commands::run_send_warning(&home, args)
+            }
+            CollaborationAction::PeersFallback(args) => {
+                collaboration_commands::run_peers_fallback(&home, args)
+            }
+            CollaborationAction::WhoisFallback { scope, peer_name } => {
+                collaboration_commands::run_whois_fallback(&home, scope, &peer_name)
+            }
         },
 
         Command::ChannelGist(args) => match args.action {

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -591,7 +591,7 @@ _doctor_health() {
   if [ "${peer_count:-0}" -eq 0 ] 2>/dev/null; then
     local _collab_rc=0
     local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
-    "$AIRC_PYTHON" -m airc_core.collaboration doctor \
+    "$(airc_rs_bin)" collaboration doctor \
       --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" --client-id "$_client_id" || _collab_rc=$?
     case "$_collab_rc" in
       1) warns=$((warns+1)) ;;

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -494,7 +494,7 @@ cmd_whois() {
     return 0
   fi
   local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
-  if "$AIRC_PYTHON" -m airc_core.collaboration whois-fallback \
+  if "$(airc_rs_bin)" collaboration whois-fallback \
       --home "$AIRC_WRITE_DIR" --my-name "$my_name" --peer-name "$target" --client-id "$_client_id"; then
     return 0
   fi

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -570,7 +570,7 @@ else:
   # silent records persist on disk regardless of liveness.
   if ! find "$PEERS_DIR" -maxdepth 1 -name '*.json' -type f 2>/dev/null | grep -q .; then
     local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
-    "$AIRC_PYTHON" -m airc_core.collaboration peers-fallback \
+    "$(airc_rs_bin)" collaboration peers-fallback \
       --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" --client-id "$_client_id" && return
     echo "  No peers yet."
     return

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -770,7 +770,7 @@ cmd_send() {
     fi
     if [ "${_peer_count:-0}" -eq 0 ] 2>/dev/null; then
       local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
-      "$AIRC_PYTHON" -m airc_core.collaboration send-warning \
+      "$(airc_rs_bin)" collaboration send-warning \
         --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" --client-id "$_client_id" 2>/dev/null || true
     fi
     _airc_codex_poll_after_user_send

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -25,7 +25,7 @@ _airc_collaboration_health_report() {
   # self-healed host can have fresh bearer heartbeats while nobody else is
   # paired to this mesh. Surface that split-brain shape explicitly.
   local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
-  "$AIRC_PYTHON" -m airc_core.collaboration status \
+  "$(airc_rs_bin)" collaboration status \
     --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" --client-id "$_client_id"
 }
 

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -90,6 +90,25 @@ class CodexRustCutoverTests(unittest.TestCase):
             body,
         )
 
+    def test_collaboration_helpers_use_airc_rs(self):
+        combined = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in [
+                REPO / "lib/airc_bash/cmd_status.sh",
+                REPO / "lib/airc_bash/cmd_send.sh",
+                REPO / "lib/airc_bash/cmd_identity.sh",
+                REPO / "lib/airc_bash/cmd_rooms.sh",
+                REPO / "lib/airc_bash/cmd_doctor.sh",
+            ]
+        )
+
+        self.assertNotIn("airc_core.collaboration", combined)
+        self.assertIn('"$(airc_rs_bin)" collaboration status', combined)
+        self.assertIn('"$(airc_rs_bin)" collaboration send-warning', combined)
+        self.assertIn('"$(airc_rs_bin)" collaboration whois-fallback', combined)
+        self.assertIn('"$(airc_rs_bin)" collaboration peers-fallback', combined)
+        self.assertIn('"$(airc_rs_bin)" collaboration doctor', combined)
+
     def test_iso_to_epoch_uses_airc_rs(self):
         source = (REPO / "lib/airc_bash/platform_adapters.sh").read_text(encoding="utf-8")
         start = source.index("iso_to_epoch()")


### PR DESCRIPTION
Summary
- add airc-rs collaboration commands for status, doctor, send-warning, peers-fallback, and whois-fallback
- route shell collaboration health surfaces through airc-rs instead of airc_core.collaboration
- add cutover guard so collaboration runtime helpers stay off Python

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-cli
- python3 test/test_codex_rust_cutover.py
- bash -n airc lib/airc_bash/*.sh
- smoke: airc-rs collaboration status/peers-fallback/whois-fallback against a temp messages.jsonl scope