### PR TITLE
feat(airc-cli): move knock approval crypto to Rust

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -27,6 +27,7 @@ use crate::gist_cli::GistArgs;
 use crate::handshake_cli::HandshakeArgs;
 use crate::hygiene_cli::HygieneArgs;
 use crate::identity_cli::IdentityArgs;
+use crate::knock_cli::KnockArgs;
 use crate::message_cli::MessageArgs;
 use crate::pending_cli::PendingArgs;
 use crate::route_cli::RouteArgs;
@@ -254,6 +255,9 @@ pub enum Command {
 
     /// Workspace/resource hygiene policy.
     Hygiene(HygieneArgs),
+
+    /// Knock/approve crypto helpers during Rust cutover.
+    Knock(KnockArgs),
 
     /// Pending-queue routing helpers during Rust cutover.
     Pending(PendingArgs),

--- a/crates/airc-cli/src/knock_cli.rs
+++ b/crates/airc-cli/src/knock_cli.rs
@@ -1,0 +1,40 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct KnockArgs {
+    #[command(subcommand)]
+    pub action: KnockAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum KnockAction {
+    /// Emit a fresh X25519 keypair as JSON.
+    GenKeys,
+    /// Encrypt plaintext to a knocker's ephemeral public key.
+    EncryptForKnocker {
+        #[arg(long)]
+        knocker_pub: String,
+        #[arg(long)]
+        plaintext: String,
+    },
+    /// Decrypt approver-posted ciphertext with the knocker's private key.
+    DecryptFromApprover {
+        #[arg(long)]
+        knocker_priv: String,
+        #[arg(long)]
+        approver_pub: String,
+        #[arg(long)]
+        nonce: String,
+        #[arg(long)]
+        ciphertext: String,
+    },
+    /// Read one string field from an approval JSON envelope on stdin.
+    ApprovalField {
+        #[arg(long)]
+        field: String,
+    },
+    /// Extract knocker_pub from a knock issue markdown body on stdin.
+    ExtractKnockerPub,
+    /// Extract the latest approval JSON envelope from gh comments JSON on stdin.
+    ExtractApproval,
+}

--- a/crates/airc-cli/src/knock_commands.rs
+++ b/crates/airc-cli/src/knock_commands.rs
@@ -1,0 +1,298 @@
+use std::error::Error;
+use std::io::{self, Read, Write};
+
+use chacha20poly1305::aead::{Aead, AeadCore, KeyInit, OsRng};
+use chacha20poly1305::ChaCha20Poly1305;
+use hkdf::Hkdf;
+use rand_core::RngCore;
+use serde_json::{json, Value};
+use sha2::Sha256;
+use x25519_dalek::{PublicKey, StaticSecret};
+
+const HKDF_INFO: &[u8] = b"airc-knock-approve-v1";
+const JSON_FENCE_START: &str = "```json";
+const JSON_FENCE_END: &str = "```";
+
+pub fn run_gen_keys() -> Result<(), Box<dyn Error>> {
+    let secret = random_secret();
+    let public = PublicKey::from(&secret);
+    println!(
+        "{}",
+        serde_json::to_string(&json!({
+            "priv": hex_encode(&secret.to_bytes()),
+            "pub": hex_encode(public.as_bytes()),
+        }))?
+    );
+    Ok(())
+}
+
+pub fn run_encrypt_for_knocker(knocker_pub: &str, plaintext: &str) -> Result<(), Box<dyn Error>> {
+    let knocker_pub = hex32("--knocker-pub", knocker_pub)?;
+    let approver_priv = random_secret();
+    let approver_pub = PublicKey::from(&approver_priv);
+    let key = derive_pairwise_key(approver_priv.to_bytes(), knocker_pub)?;
+    let cipher = ChaCha20Poly1305::new_from_slice(&key)?;
+    let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+    let ciphertext = cipher
+        .encrypt(&nonce, plaintext.as_bytes())
+        .map_err(|_| "airc knock encrypt: AEAD encryption failed")?;
+    println!(
+        "{}",
+        serde_json::to_string(&json!({
+            "ver": "v1",
+            "approver_pub": hex_encode(approver_pub.as_bytes()),
+            "nonce": hex_encode(&nonce),
+            "ciphertext": hex_encode(&ciphertext),
+        }))?
+    );
+    Ok(())
+}
+
+pub fn run_decrypt_from_approver(
+    knocker_priv: &str,
+    approver_pub: &str,
+    nonce: &str,
+    ciphertext: &str,
+) -> Result<(), Box<dyn Error>> {
+    let knocker_priv = hex32("--knocker-priv", knocker_priv)?;
+    let approver_pub = hex32("--approver-pub", approver_pub)?;
+    let nonce = hex_exact::<12>("--nonce", nonce)?;
+    let ciphertext = hex_decode("--ciphertext", ciphertext)?;
+    let key = derive_pairwise_key(knocker_priv, approver_pub)?;
+    let cipher = ChaCha20Poly1305::new_from_slice(&key)?;
+    let plaintext = cipher
+        .decrypt(&nonce.into(), ciphertext.as_slice())
+        .map_err(|_| "airc knock decrypt: AEAD authentication failed")?;
+    io::stdout().write_all(&plaintext)?;
+    if !plaintext.ends_with(b"\n") {
+        io::stdout().write_all(b"\n")?;
+    }
+    Ok(())
+}
+
+pub fn run_approval_field(field: &str) -> Result<(), Box<dyn Error>> {
+    let mut raw = String::new();
+    io::stdin().read_to_string(&mut raw)?;
+    let value: Value = serde_json::from_str(&raw)?;
+    if let Some(value) = value.get(field).and_then(Value::as_str) {
+        println!("{value}");
+    }
+    Ok(())
+}
+
+pub fn run_extract_knocker_pub() -> Result<(), Box<dyn Error>> {
+    let mut markdown = String::new();
+    io::stdin().read_to_string(&mut markdown)?;
+    if let Some(pubkey) = extract_knocker_pub(&markdown) {
+        println!("{pubkey}");
+    }
+    Ok(())
+}
+
+pub fn run_extract_approval() -> Result<(), Box<dyn Error>> {
+    let mut raw = String::new();
+    io::stdin().read_to_string(&mut raw)?;
+    if let Some(approval) = extract_latest_approval(&raw)? {
+        println!("{}", serde_json::to_string(&approval)?);
+    }
+    Ok(())
+}
+
+fn random_secret() -> StaticSecret {
+    let mut bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+    StaticSecret::from(bytes)
+}
+
+fn derive_pairwise_key(my_priv: [u8; 32], their_pub: [u8; 32]) -> Result<[u8; 32], Box<dyn Error>> {
+    let secret = StaticSecret::from(my_priv);
+    let public = PublicKey::from(their_pub);
+    let shared = secret.diffie_hellman(&public);
+    let hkdf = Hkdf::<Sha256>::new(None, shared.as_bytes());
+    let mut key = [0u8; 32];
+    hkdf.expand(HKDF_INFO, &mut key)
+        .map_err(|_| "HKDF output length is invalid")?;
+    Ok(key)
+}
+
+fn hex32(name: &str, value: &str) -> Result<[u8; 32], Box<dyn Error>> {
+    let bytes = hex_exact::<32>(name, value)?;
+    Ok(bytes)
+}
+
+fn hex_exact<const N: usize>(name: &str, value: &str) -> Result<[u8; N], Box<dyn Error>> {
+    let bytes = hex_decode(name, value)?;
+    bytes.try_into().map_err(|bytes: Vec<u8>| {
+        format!("{name} must decode to {N} bytes, got {}", bytes.len()).into()
+    })
+}
+
+fn hex_decode(name: &str, value: &str) -> Result<Vec<u8>, Box<dyn Error>> {
+    let value = value.trim();
+    if !value.len().is_multiple_of(2) {
+        return Err(format!("{name}: hex input has odd length").into());
+    }
+    let mut out = Vec::with_capacity(value.len() / 2);
+    for pair in value.as_bytes().chunks_exact(2) {
+        let high = hex_nibble(pair[0]).ok_or_else(|| format!("{name}: not valid hex"))?;
+        let low = hex_nibble(pair[1]).ok_or_else(|| format!("{name}: not valid hex"))?;
+        out.push((high << 4) | low);
+    }
+    Ok(out)
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const CHARS: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(CHARS[(byte >> 4) as usize] as char);
+        out.push(CHARS[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn extract_knocker_pub(markdown: &str) -> Option<String> {
+    json_fences(markdown)
+        .filter_map(|block| serde_json::from_str::<Value>(block).ok())
+        .find_map(|value| {
+            value
+                .get("knocker_pub")
+                .and_then(Value::as_str)
+                .filter(|pubkey| !pubkey.is_empty())
+                .map(str::to_owned)
+        })
+}
+
+fn extract_latest_approval(raw_comments_json: &str) -> Result<Option<Value>, Box<dyn Error>> {
+    let value: Value = serde_json::from_str(raw_comments_json)?;
+    let mut latest = None;
+    if let Some(comments) = value.get("comments").and_then(Value::as_array) {
+        for body in comments
+            .iter()
+            .filter_map(|comment| comment.get("body").and_then(Value::as_str))
+        {
+            for block in json_fences(body) {
+                let Ok(candidate) = serde_json::from_str::<Value>(block) else {
+                    continue;
+                };
+                if is_approval_envelope(&candidate) {
+                    latest = Some(candidate);
+                }
+            }
+        }
+    }
+    Ok(latest)
+}
+
+fn is_approval_envelope(value: &Value) -> bool {
+    value.get("ver").and_then(Value::as_str) == Some("v1")
+        && value.get("approver_pub").and_then(Value::as_str).is_some()
+        && value.get("nonce").and_then(Value::as_str).is_some()
+        && value.get("ciphertext").and_then(Value::as_str).is_some()
+}
+
+fn json_fences(markdown: &str) -> impl Iterator<Item = &str> {
+    markdown.split(JSON_FENCE_START).skip(1).filter_map(|tail| {
+        let content = tail.strip_prefix('\n').unwrap_or(tail);
+        content
+            .split_once(JSON_FENCE_END)
+            .map(|(block, _)| block.trim())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_keys_are_hex_32_byte_pair() {
+        let secret = random_secret();
+        let public = PublicKey::from(&secret);
+
+        assert_eq!(
+            hex_decode("priv", &hex_encode(&secret.to_bytes()))
+                .unwrap()
+                .len(),
+            32
+        );
+        assert_eq!(
+            hex_decode("pub", &hex_encode(public.as_bytes()))
+                .unwrap()
+                .len(),
+            32
+        );
+    }
+
+    #[test]
+    fn ecdh_derives_same_key_for_both_parties() {
+        let a = random_secret();
+        let b = random_secret();
+        let a_pub = PublicKey::from(&a);
+        let b_pub = PublicKey::from(&b);
+
+        assert_eq!(
+            derive_pairwise_key(a.to_bytes(), *b_pub.as_bytes()).unwrap(),
+            derive_pairwise_key(b.to_bytes(), *a_pub.as_bytes()).unwrap()
+        );
+    }
+
+    #[test]
+    fn decrypt_rejects_tampered_ciphertext() {
+        let knocker = random_secret();
+        let knocker_pub = PublicKey::from(&knocker);
+        let approver = random_secret();
+        let approver_pub = PublicKey::from(&approver);
+        let key = derive_pairwise_key(approver.to_bytes(), *knocker_pub.as_bytes()).unwrap();
+        let cipher = ChaCha20Poly1305::new_from_slice(&key).unwrap();
+        let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+        let mut ciphertext = cipher.encrypt(&nonce, b"secret".as_slice()).unwrap();
+        let last = ciphertext.last_mut().unwrap();
+        *last ^= 0x01;
+
+        let result = run_decrypt_from_approver(
+            &hex_encode(&knocker.to_bytes()),
+            &hex_encode(approver_pub.as_bytes()),
+            &hex_encode(&nonce),
+            &hex_encode(&ciphertext),
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extracts_knocker_pub_from_markdown_json_fence() {
+        let markdown = r#"hello
+```json
+{"ver":"v1","knocker_pub":"abc123"}
+```
+"#;
+
+        assert_eq!(extract_knocker_pub(markdown).as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn extracts_latest_approval_from_comments_json() {
+        let comments = json!({
+            "comments": [
+                {"body": "```json\n{\"ver\":\"v1\",\"approver_pub\":\"old\",\"nonce\":\"n1\",\"ciphertext\":\"c1\"}\n```"},
+                {"body": "text\n```json\n{\"ver\":\"v1\",\"approver_pub\":\"new\",\"nonce\":\"n2\",\"ciphertext\":\"c2\"}\n```"}
+            ]
+        })
+        .to_string();
+
+        let approval = extract_latest_approval(&comments).unwrap().unwrap();
+
+        assert_eq!(approval["approver_pub"], "new");
+        assert_eq!(approval["nonce"], "n2");
+        assert_eq!(approval["ciphertext"], "c2");
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -43,6 +43,8 @@ mod hygiene_cli;
 mod hygiene_commands;
 mod identity_cli;
 mod identity_commands;
+mod knock_cli;
+mod knock_commands;
 mod lane_cli;
 mod lane_commands;
 mod legacy_envelope;
@@ -87,6 +89,7 @@ use gh_cli::GhAction;
 use gist_cli::GistAction;
 use handshake_cli::HandshakeAction;
 use identity_cli::IdentityAction;
+use knock_cli::KnockAction;
 use lane_cli::{LaneAction, LaneManagerAction};
 use log_cli::LogAction;
 use message_cli::MessageAction;
@@ -531,6 +534,28 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         },
 
         Command::Hygiene(args) => hygiene_commands::run(args),
+
+        Command::Knock(args) => match args.action {
+            KnockAction::GenKeys => knock_commands::run_gen_keys(),
+            KnockAction::EncryptForKnocker {
+                knocker_pub,
+                plaintext,
+            } => knock_commands::run_encrypt_for_knocker(&knocker_pub, &plaintext),
+            KnockAction::DecryptFromApprover {
+                knocker_priv,
+                approver_pub,
+                nonce,
+                ciphertext,
+            } => knock_commands::run_decrypt_from_approver(
+                &knocker_priv,
+                &approver_pub,
+                &nonce,
+                &ciphertext,
+            ),
+            KnockAction::ApprovalField { field } => knock_commands::run_approval_field(&field),
+            KnockAction::ExtractKnockerPub => knock_commands::run_extract_knocker_pub(),
+            KnockAction::ExtractApproval => knock_commands::run_extract_approval(),
+        },
 
         Command::Pending(args) => match args.action {
             PendingAction::HostBroadcastRoute {

--- a/lib/airc_bash/cmd_approve.sh
+++ b/lib/airc_bash/cmd_approve.sh
@@ -11,8 +11,8 @@
 #                            print the join string. Manual handoff for
 #                            now; PR-2c automates this via state.
 #
-# External cross-references (resolved at call time): die, AIRC_PYTHON,
-# `gh` CLI; airc_core.knock_crypto module.
+# External cross-references (resolved at call time): die, airc_rs_bin,
+# `gh` CLI.
 #
 # Crypto contract: per-knock + per-approval X25519 ephemerals → ECDH +
 # HKDF-SHA256 (info=b"airc-knock-approve-v1") → ChaCha20-Poly1305 AEAD.
@@ -110,11 +110,11 @@ cmd_approve() {
     die "approve: invite string is empty (refusing to send empty approval)."
   fi
 
-  # Encrypt the invite to the knocker's pubkey via the python helper.
+  # Encrypt the invite to the knocker's pubkey via the Rust helper.
   # The helper generates a per-approval ephemeral keypair internally,
   # runs ECDH, and emits {ver, approver_pub, nonce, ciphertext} JSON.
   local approval_json
-  if ! approval_json=$("$AIRC_PYTHON" -m airc_core.knock_crypto encrypt-for-knocker \
+  if ! approval_json=$("$(airc_rs_bin)" knock encrypt-for-knocker \
         --knocker-pub "$knocker_pub" \
         --plaintext "$invite_string" 2>&1); then
     die "approve: encryption failed: $approval_json"
@@ -234,15 +234,15 @@ cmd_decrypt_approval() {
   fi
 
   local approver_pub nonce ciphertext
-  approver_pub=$("$AIRC_PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("approver_pub",""))' <<< "$approval_json")
-  nonce=$("$AIRC_PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("nonce",""))' <<< "$approval_json")
-  ciphertext=$("$AIRC_PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("ciphertext",""))' <<< "$approval_json")
+  approver_pub=$("$(airc_rs_bin)" knock approval-field --field approver_pub <<< "$approval_json")
+  nonce=$("$(airc_rs_bin)" knock approval-field --field nonce <<< "$approval_json")
+  ciphertext=$("$(airc_rs_bin)" knock approval-field --field ciphertext <<< "$approval_json")
 
   if [ -z "$approver_pub" ] || [ -z "$nonce" ] || [ -z "$ciphertext" ]; then
     die "decrypt-approval: malformed approval envelope (missing approver_pub/nonce/ciphertext)"
   fi
 
-  if ! "$AIRC_PYTHON" -m airc_core.knock_crypto decrypt-from-approver \
+  if ! "$(airc_rs_bin)" knock decrypt-from-approver \
         --knocker-priv "$knocker_priv" \
         --approver-pub "$approver_pub" \
         --nonce "$nonce" \
@@ -313,23 +313,7 @@ _airc_approve_extract_knocker_pub() {
   # Body comes in via $1 as raw markdown; we look for the first JSON
   # block with a "knocker_pub" field.
   local body="$1"
-  AIRC_APPROVE_BODY="$body" "$AIRC_PYTHON" - <<'PYEOF' 2>/dev/null
-import json, os, re, sys
-body = os.environ.get("AIRC_APPROVE_BODY", "")
-# Match ```json ... ``` blocks; check each for knocker_pub.
-for match in re.finditer(r'```json\s*\n(.*?)\n```', body, re.DOTALL):
-    blob = match.group(1).strip()
-    try:
-        parsed = json.loads(blob)
-    except Exception:
-        continue
-    if isinstance(parsed, dict) and "knocker_pub" in parsed:
-        pub = parsed.get("knocker_pub", "")
-        if pub:
-            print(pub)
-            sys.exit(0)
-sys.exit(1)
-PYEOF
+  "$(airc_rs_bin)" knock extract-knocker-pub <<< "$body" 2>/dev/null || true
 }
 
 _airc_decrypt_extract_approval() {
@@ -337,27 +321,7 @@ _airc_decrypt_extract_approval() {
   # Returns the most recent envelope (last comment with one), so a
   # repost or correction wins over the original.
   local comments_json="$1"
-  AIRC_APPROVE_COMMENTS_JSON="$comments_json" "$AIRC_PYTHON" - <<'PYEOF' 2>/dev/null
-import json, os, re, sys
-data = json.loads(os.environ.get("AIRC_APPROVE_COMMENTS_JSON", "{}"))
-comments = data.get("comments", [])
-found = None
-for comment in comments:
-    body = comment.get("body", "")
-    for match in re.finditer(r'```json\s*\n(.*?)\n```', body, re.DOTALL):
-        try:
-            parsed = json.loads(match.group(1).strip())
-        except Exception:
-            continue
-        if (isinstance(parsed, dict)
-                and parsed.get("ver") == "v1"
-                and "approver_pub" in parsed
-                and "nonce" in parsed
-                and "ciphertext" in parsed):
-            found = match.group(1).strip()  # keep last; iteration is chronological
-if found:
-    print(found)
-PYEOF
+  "$(airc_rs_bin)" knock extract-approval <<< "$comments_json" 2>/dev/null || true
 }
 
 _airc_approve_default_invite() {

--- a/lib/airc_bash/cmd_knock.sh
+++ b/lib/airc_bash/cmd_knock.sh
@@ -123,10 +123,10 @@ cmd_knock() {
   local knock_keys_json knocker_pub knocker_priv
   knock_keys_json=$(_airc_knock_gen_keys 2>/dev/null || echo "")
   if [ -n "$knock_keys_json" ]; then
-    knocker_pub=$("$AIRC_PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("pub",""))' <<< "$knock_keys_json" 2>/dev/null || echo "")
-    knocker_priv=$("$AIRC_PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("priv",""))' <<< "$knock_keys_json" 2>/dev/null || echo "")
+    knocker_pub=$("$(airc_rs_bin)" knock approval-field --field pub <<< "$knock_keys_json" 2>/dev/null || echo "")
+    knocker_priv=$("$(airc_rs_bin)" knock approval-field --field priv <<< "$knock_keys_json" 2>/dev/null || echo "")
   else
-    # Crypto path unavailable (no python venv with cryptography). Knock
+    # Crypto path unavailable. Knock
     # still posts but without an approval pubkey — cmd_approve will
     # hard-fail with a clear "no knocker pubkey, can't encrypt" error
     # rather than silently shipping plaintext.
@@ -291,15 +291,11 @@ _airc_knock_json_str() {
 }
 
 _airc_knock_gen_keys() {
-  # Generate per-knock ephemeral X25519 keypair via the python venv.
+  # Generate per-knock ephemeral X25519 keypair via the Rust CLI.
   # Returns JSON {"priv": "<hex>", "pub": "<hex>"} on stdout.
   # Returns non-zero (caller falls back to no-pubkey envelope) when the
-  # python crypto path isn't available — typically a fresh checkout
-  # without `pip install cryptography` in the venv.
-  if [ -z "${AIRC_PYTHON:-}" ]; then
-    return 1
-  fi
-  "$AIRC_PYTHON" -m airc_core.knock_crypto gen-knock-keys
+  # Rust binary isn't available.
+  "$(airc_rs_bin)" knock gen-keys
 }
 
 _airc_knock_issue_body() {

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -125,6 +125,23 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("airc_core.hygiene", source)
         self.assertIn('"$(airc_rs_bin)" hygiene "$@"', source)
 
+    def test_knock_crypto_uses_airc_rs(self):
+        combined = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in [
+                REPO / "lib/airc_bash/cmd_knock.sh",
+                REPO / "lib/airc_bash/cmd_approve.sh",
+            ]
+        )
+
+        self.assertNotIn("airc_core.knock_crypto", combined)
+        self.assertIn('"$(airc_rs_bin)" knock gen-keys', combined)
+        self.assertIn('"$(airc_rs_bin)" knock encrypt-for-knocker', combined)
+        self.assertIn('"$(airc_rs_bin)" knock decrypt-from-approver', combined)
+        self.assertIn('"$(airc_rs_bin)" knock approval-field', combined)
+        self.assertIn('"$(airc_rs_bin)" knock extract-knocker-pub', combined)
+        self.assertIn('"$(airc_rs_bin)" knock extract-approval', combined)
+
     def test_iso_to_epoch_uses_airc_rs(self):
         source = (REPO / "lib/airc_bash/platform_adapters.sh").read_text(encoding="utf-8")
         start = source.index("iso_to_epoch()")


### PR DESCRIPTION
Summary
- add airc-rs knock crypto helpers for gen-keys, encrypt-for-knocker, decrypt-from-approver, and approval-field
- add Rust extractors for knock issue pubkeys and approval comment envelopes
- route knock/approve shell flows through airc-rs instead of airc_core.knock_crypto
- add cutover guard to keep knock approval crypto off Python

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli
- python3 test/test_codex_rust_cutover.py
- bash -n airc lib/airc_bash/*.sh
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace
- smoke: airc-rs knock gen-keys/encrypt-for-knocker/approval-field/decrypt-from-approver round-tripped an invite