### PR TITLE
feat(airc-cli): move knock identity JSON to Rust

### DIFF
--- a/crates/airc-cli/src/knock_cli.rs
+++ b/crates/airc-cli/src/knock_cli.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Args, Subcommand};
 
 #[derive(Debug, Args)]
@@ -32,6 +34,13 @@ pub enum KnockAction {
     ApprovalField {
         #[arg(long)]
         field: String,
+    },
+    /// Emit the identity JSON embedded in a public knock issue.
+    IdentityJson {
+        #[arg(long)]
+        name: String,
+        #[arg(long)]
+        state_dir: PathBuf,
     },
     /// Extract knocker_pub from a knock issue markdown body on stdin.
     ExtractKnockerPub,

--- a/crates/airc-cli/src/knock_commands.rs
+++ b/crates/airc-cli/src/knock_commands.rs
@@ -1,5 +1,8 @@
 use std::error::Error;
+use std::fs;
 use std::io::{self, Read, Write};
+use std::path::Path;
+use std::process::Command;
 
 use chacha20poly1305::aead::{Aead, AeadCore, KeyInit, OsRng};
 use chacha20poly1305::ChaCha20Poly1305;
@@ -77,6 +80,12 @@ pub fn run_approval_field(field: &str) -> Result<(), Box<dyn Error>> {
     if let Some(value) = value.get(field).and_then(Value::as_str) {
         println!("{value}");
     }
+    Ok(())
+}
+
+pub fn run_identity_json(name: &str, state_dir: &Path) -> Result<(), Box<dyn Error>> {
+    let identity = load_knock_identity(state_dir, name);
+    println!("{}", serde_json::to_string(&identity)?);
     Ok(())
 }
 
@@ -170,6 +179,49 @@ fn extract_knocker_pub(markdown: &str) -> Option<String> {
                 .filter(|pubkey| !pubkey.is_empty())
                 .map(str::to_owned)
         })
+}
+
+fn load_knock_identity(state_dir: &Path, name: &str) -> Value {
+    let identity_path = state_dir.join("identity.json");
+    let identity = fs::read_to_string(identity_path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .unwrap_or(Value::Null);
+
+    json!({
+        "name": name,
+        "pronouns": string_field(&identity, "pronouns").unwrap_or_default(),
+        "role": string_field(&identity, "role").unwrap_or_default(),
+        "bio": string_field(&identity, "bio").unwrap_or_default(),
+        "gh_login": string_field(&identity, "gh_login")
+            .or_else(query_gh_login)
+            .unwrap_or_default(),
+    })
+}
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn query_gh_login() -> Option<String> {
+    let output = Command::new("gh")
+        .args(["api", "user", "--jq", ".login"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let login = String::from_utf8(output.stdout).ok()?;
+    let login = login.trim();
+    if login.is_empty() {
+        None
+    } else {
+        Some(login.to_owned())
+    }
 }
 
 fn extract_latest_approval(raw_comments_json: &str) -> Result<Option<Value>, Box<dyn Error>> {
@@ -277,6 +329,36 @@ mod tests {
 "#;
 
         assert_eq!(extract_knocker_pub(markdown).as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn identity_json_reads_existing_fields_and_name() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("identity.json"),
+            r#"{"pronouns":"they/them","role":"agent","bio":"works","gh_login":"octo"}"#,
+        )
+        .unwrap();
+
+        let value = load_knock_identity(dir.path(), "clio");
+
+        assert_eq!(value["name"], "clio");
+        assert_eq!(value["pronouns"], "they/them");
+        assert_eq!(value["role"], "agent");
+        assert_eq!(value["bio"], "works");
+        assert_eq!(value["gh_login"], "octo");
+    }
+
+    #[test]
+    fn identity_json_defaults_when_file_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let value = load_knock_identity(dir.path(), "fresh");
+
+        assert_eq!(value["name"], "fresh");
+        assert_eq!(value["pronouns"], "");
+        assert_eq!(value["role"], "");
+        assert_eq!(value["bio"], "");
     }
 
     #[test]

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -553,6 +553,9 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 &ciphertext,
             ),
             KnockAction::ApprovalField { field } => knock_commands::run_approval_field(&field),
+            KnockAction::IdentityJson { name, state_dir } => {
+                knock_commands::run_identity_json(&name, &state_dir)
+            }
             KnockAction::ExtractKnockerPub => knock_commands::run_extract_knocker_pub(),
             KnockAction::ExtractApproval => knock_commands::run_extract_approval(),
         },

--- a/lib/airc_bash/cmd_knock.sh
+++ b/lib/airc_bash/cmd_knock.sh
@@ -21,8 +21,8 @@
 #   - Repo-local `.airc/` discovery manifest (continuum#1109 pilots that)
 #
 # External cross-references (resolved at call time):
-#   die, ensure_init, resolve_name, get_config_val, AIRC_HOME, AIRC_PYTHON,
-#   _airc_lib_dir; `gh` CLI; `airc_core.identity`.
+#   die, ensure_init, resolve_name, get_config_val, AIRC_HOME,
+#   AIRC_WRITE_DIR; `gh` CLI.
 
 cmd_knock() {
   # Public-facing entrypoint. Args:
@@ -224,51 +224,13 @@ EOF
 }
 
 _airc_knock_identity_json() {
-  # Read identity fields if airc_core.identity is reachable. Falls back
-  # to a minimal name-only envelope if it isn't — knock should work
-  # even on a fresh install where identity wasn't populated yet.
+  # Read identity fields through the Rust CLI. Falls back to a minimal
+  # name-only envelope if state is missing — knock should work even on
+  # a fresh install where identity wasn't populated yet.
   local name="$1"
-  if [ -n "${AIRC_PYTHON:-}" ] && [ -d "${_airc_lib_dir:-}" ]; then
-    "$AIRC_PYTHON" - "$name" "$AIRC_WRITE_DIR" <<'PYEOF' 2>/dev/null || _airc_knock_identity_fallback "$name"
-import json, os, sys
-name = sys.argv[1]
-home = sys.argv[2]
-pronouns = ""
-role = ""
-bio = ""
-gh_login = ""
-identity_path = os.path.join(home, "identity.json")
-if os.path.exists(identity_path):
-    try:
-        with open(identity_path) as f:
-            data = json.load(f) or {}
-        pronouns = data.get("pronouns", "")
-        role = data.get("role", "")
-        bio = data.get("bio", "")
-        gh_login = data.get("gh_login", "")
-    except Exception:
-        pass
-# Fall back to gh CLI if gh_login isn't in identity.json.
-if not gh_login:
-    try:
-        import subprocess
-        gh_login = subprocess.run(
-            ["gh", "api", "user", "--jq", ".login"],
-            capture_output=True, text=True, timeout=5
-        ).stdout.strip() or ""
-    except Exception:
-        gh_login = ""
-print(json.dumps({
-    "name": name,
-    "pronouns": pronouns,
-    "role": role,
-    "bio": bio,
-    "gh_login": gh_login,
-}))
-PYEOF
-  else
-    _airc_knock_identity_fallback "$name"
-  fi
+  "$(airc_rs_bin)" knock identity-json \
+    --name "$name" \
+    --state-dir "$AIRC_WRITE_DIR" 2>/dev/null || _airc_knock_identity_fallback "$name"
 }
 
 _airc_knock_identity_fallback() {
@@ -278,10 +240,7 @@ _airc_knock_identity_fallback() {
 }
 
 _airc_knock_json_str() {
-  # Minimal JSON string escaper for the bash fallback path. Real callers
-  # go through the python heredoc which handles edge cases properly.
-  # Escapes backslash, double-quote, newline, tab — sufficient for typical
-  # name/role/bio content. Anything weirder uses the python path.
+  # Minimal JSON string escaper for the bash fallback path.
   local s="$1"
   s="${s//\\/\\\\}"
   s="${s//\"/\\\"}"

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -139,8 +139,10 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" knock encrypt-for-knocker', combined)
         self.assertIn('"$(airc_rs_bin)" knock decrypt-from-approver', combined)
         self.assertIn('"$(airc_rs_bin)" knock approval-field', combined)
+        self.assertIn('"$(airc_rs_bin)" knock identity-json', combined)
         self.assertIn('"$(airc_rs_bin)" knock extract-knocker-pub', combined)
         self.assertIn('"$(airc_rs_bin)" knock extract-approval', combined)
+        self.assertNotIn("AIRC_PYTHON", (REPO / "lib/airc_bash/cmd_knock.sh").read_text(encoding="utf-8"))
 
     def test_iso_to_epoch_uses_airc_rs(self):
         source = (REPO / "lib/airc_bash/platform_adapters.sh").read_text(encoding="utf-8")


### PR DESCRIPTION
Summary
- add airc-rs knock identity-json for the public knock issue identity envelope
- remove the cmd_knock.sh Python heredoc and route identity JSON through Rust
- extend the cutover guard so cmd_knock.sh cannot use AIRC_PYTHON

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli knock_commands
- python3 test/test_codex_rust_cutover.py
- bash -n airc lib/airc_bash/*.sh
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-cli
- smoke: airc-rs knock identity-json emitted the expected identity envelope from a temp state dir