### PR TITLE
feat(airc-cli): move kick peer ssh lookup to Rust

### DIFF
--- a/crates/airc-cli/src/identity_cli.rs
+++ b/crates/airc-cli/src/identity_cli.rs
@@ -32,6 +32,16 @@ pub enum IdentityAction {
         peer_name: String,
     },
 
+    /// Print an enrolled peer's SSH public key from its peer record.
+    PeerSshPub {
+        /// Legacy peers directory containing <peer>.json files.
+        #[arg(long)]
+        peers_dir: std::path::PathBuf,
+        /// Peer display/name key.
+        #[arg(long)]
+        peer_name: String,
+    },
+
     /// Sign stdin bytes with the legacy Ed25519 PEM identity.
     SignEd25519 {
         /// Legacy identity directory containing private.pem.

--- a/crates/airc-cli/src/identity_commands.rs
+++ b/crates/airc-cli/src/identity_commands.rs
@@ -66,6 +66,27 @@ pub fn run_write_peer_record(
     Ok(())
 }
 
+pub fn run_peer_ssh_pub(peers_dir: &Path, peer_name: &str) -> Result<(), Box<dyn Error>> {
+    if let Some(ssh_pub) = peer_ssh_pub(peers_dir, peer_name) {
+        println!("{ssh_pub}");
+    }
+    Ok(())
+}
+
+fn peer_ssh_pub(peers_dir: &Path, peer_name: &str) -> Option<String> {
+    let path = peers_dir.join(format!("{peer_name}.json"));
+    let value = fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .unwrap_or(Value::Null);
+    value
+        .get("ssh_pub")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
 fn remove_stale_host_records(
     peers_dir: &Path,
     peer_name: &str,
@@ -126,5 +147,21 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(peers.join("new.json")).unwrap()).unwrap();
         assert_eq!(written["host"], "alice@example");
         assert_eq!(written["x25519_pub"], "xpub");
+    }
+
+    #[test]
+    fn peer_ssh_pub_reads_peer_record() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("alice.json"),
+            r#"{"ssh_pub":"ssh-ed25519 AAAAC3Nz alice"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            peer_ssh_pub(dir.path(), "alice").as_deref(),
+            Some("ssh-ed25519 AAAAC3Nz alice")
+        );
+        assert_eq!(peer_ssh_pub(dir.path(), "missing"), None);
     }
 }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -310,6 +310,10 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 }
                 Ok(())
             }
+            IdentityAction::PeerSshPub {
+                peers_dir,
+                peer_name,
+            } => identity_commands::run_peer_ssh_pub(&peers_dir, &peer_name),
             IdentityAction::SignEd25519 { identity_dir } => {
                 println!("{}", legacy_identity::sign_ed25519_stdin(&identity_dir)?);
                 Ok(())

--- a/lib/airc_bash/cmd_kick.sh
+++ b/lib/airc_bash/cmd_kick.sh
@@ -59,14 +59,9 @@ cmd_kick() {
   # peer could keep authenticating despite the "kick" — caught by
   # Copilot review on PR #73.
   local peer_ssh_pub
-  peer_ssh_pub=$(PEER_FILE="$peer_file" "$AIRC_PYTHON" -c '
-import json, os
-try:
-    p = json.load(open(os.environ["PEER_FILE"]))
-    print((p.get("ssh_pub") or "").strip())
-except Exception:
-    pass
-' 2>/dev/null || echo "")
+  peer_ssh_pub=$("$(airc_rs_bin)" identity peer-ssh-pub \
+    --peers-dir "$PEERS_DIR" \
+    --peer-name "$target" 2>/dev/null || echo "")
 
   if [ -n "$peer_ssh_pub" ] && [ -f "$HOME/.ssh/authorized_keys" ]; then
     # grep -v returns 1 when every line matches (or the file is empty);

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -248,6 +248,12 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("python3 <<", body)
         self.assertIn('"$(airc_rs_bin)" identity pretty', body)
 
+    def test_kick_peer_ssh_pub_uses_airc_rs(self):
+        source = (REPO / "lib/airc_bash/cmd_kick.sh").read_text(encoding="utf-8")
+
+        self.assertNotIn("AIRC_PYTHON", source)
+        self.assertIn('"$(airc_rs_bin)" identity peer-ssh-pub', source)
+
     def test_message_crypto_helpers_use_airc_rs(self):
         combined = "\n".join(
             path.read_text(encoding="utf-8")


### PR DESCRIPTION
Summary
- add airc-rs identity peer-ssh-pub for host moderation peer records
- route airc kick SSH authorized_keys lookup through Rust instead of inline Python
- add cutover guard keeping cmd_kick.sh free of AIRC_PYTHON

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli identity_commands
- python3 test/test_codex_rust_cutover.py
- bash -n airc lib/airc_bash/*.sh
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- smoke: airc-rs identity peer-ssh-pub read ssh_pub from a temp peer record