### PR TITLE
feat(airc-cli): move worktree lane registry to Rust

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -274,6 +274,9 @@ pub enum Command {
     /// Coordinate work lanes over the current room's AIRC substrate.
     Lane(crate::lane_cli::LaneArgs),
 
+    /// Manage legacy local git worktree lane registry during Rust cutover.
+    WorktreeLane(crate::worktree_lane_cli::WorktreeLaneArgs),
+
     /// Append and rotate legacy messages.jsonl files through Rust.
     Log(crate::log_cli::LogArgs),
 

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -66,6 +66,8 @@ mod work_cli;
 mod work_commands;
 mod workspace_cli;
 mod workspace_commands;
+mod worktree_lane_cli;
+mod worktree_lane_commands;
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -100,6 +102,7 @@ use scope_cli::ScopeAction;
 use transport_cli::TransportAction;
 use work_cli::WorkAction;
 use workspace_cli::WorkspaceAction;
+use worktree_lane_cli::WorktreeLaneAction;
 
 fn parse_peer_id(input: &str) -> Result<PeerId, Box<dyn std::error::Error>> {
     let uuid = Uuid::from_str(input)
@@ -640,6 +643,33 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     lane_commands::run_manager_status(&home, limit).await
                 }
             },
+        },
+
+        Command::WorktreeLane(args) => match args.action {
+            WorktreeLaneAction::AbsPath { path } => worktree_lane_commands::run_abs_path(&path),
+            WorktreeLaneAction::Slug { value } => {
+                worktree_lane_commands::run_slug(&value);
+                Ok(())
+            }
+            WorktreeLaneAction::Record {
+                registry,
+                issue,
+                repo,
+                dir,
+                branch,
+                base,
+                owner,
+            } => {
+                worktree_lane_commands::run_record(&registry, issue, repo, dir, branch, base, owner)
+            }
+            WorktreeLaneAction::List { registry, json } => {
+                worktree_lane_commands::run_list(&registry, json)
+            }
+            WorktreeLaneAction::Find {
+                registry,
+                target,
+                field,
+            } => worktree_lane_commands::run_find(&registry, &target, &field),
         },
 
         Command::Log(args) => match args.action {

--- a/crates/airc-cli/src/worktree_lane_cli.rs
+++ b/crates/airc-cli/src/worktree_lane_cli.rs
@@ -1,0 +1,49 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct WorktreeLaneArgs {
+    #[command(subcommand)]
+    pub action: WorktreeLaneAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WorktreeLaneAction {
+    /// Print an absolute path, expanding a leading ~/ when present.
+    AbsPath { path: String },
+    /// Print the shell-compatible lane slug for an issue or owner token.
+    Slug { value: String },
+    /// Append a lane record to the JSONL registry.
+    Record {
+        #[arg(long)]
+        registry: PathBuf,
+        #[arg(long)]
+        issue: String,
+        #[arg(long)]
+        repo: String,
+        #[arg(long)]
+        dir: String,
+        #[arg(long)]
+        branch: String,
+        #[arg(long)]
+        base: String,
+        #[arg(long)]
+        owner: String,
+    },
+    /// List lane records from the JSONL registry.
+    List {
+        #[arg(long)]
+        registry: PathBuf,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Find the newest lane matching issue, dir, or dir basename.
+    Find {
+        #[arg(long)]
+        registry: PathBuf,
+        target: String,
+        #[arg(long, default_value = "json")]
+        field: String,
+    },
+}

--- a/crates/airc-cli/src/worktree_lane_commands.rs
+++ b/crates/airc-cli/src/worktree_lane_commands.rs
@@ -1,0 +1,203 @@
+use std::error::Error;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use chrono::{SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+struct LaneRecord {
+    ts: String,
+    issue: String,
+    repo: String,
+    dir: String,
+    branch: String,
+    base: String,
+    owner: String,
+}
+
+pub fn run_abs_path(path: &str) -> Result<(), Box<dyn Error>> {
+    println!("{}", abs_path(path)?.display());
+    Ok(())
+}
+
+pub fn run_slug(value: &str) {
+    println!("{}", slug(value));
+}
+
+pub fn run_record(
+    registry: &Path,
+    issue: String,
+    repo: String,
+    dir: String,
+    branch: String,
+    base: String,
+    owner: String,
+) -> Result<(), Box<dyn Error>> {
+    if let Some(parent) = registry.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let record = LaneRecord {
+        ts: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+        issue,
+        repo,
+        dir,
+        branch,
+        base,
+        owner,
+    };
+    let mut line = serde_json::to_string(&record)?;
+    line.push('\n');
+    fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(registry)?
+        .write_all(line.as_bytes())?;
+    Ok(())
+}
+
+pub fn run_list(registry: &Path, as_json: bool) -> Result<(), Box<dyn Error>> {
+    let lanes = read_records(registry);
+    if as_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({ "lanes": lanes }))?
+        );
+        return Ok(());
+    }
+
+    println!("# airc lanes");
+    if lanes.is_empty() {
+        println!("No recorded lanes yet.");
+        return Ok(());
+    }
+    for lane in lanes {
+        println!(
+            "- {issue} owner={owner} branch={branch} dir={dir} base={base}",
+            issue = lane.issue,
+            owner = lane.owner,
+            branch = lane.branch,
+            dir = lane.dir,
+            base = lane.base,
+        );
+    }
+    Ok(())
+}
+
+pub fn run_find(registry: &Path, target: &str, field: &str) -> Result<(), Box<dyn Error>> {
+    let Some(lane) = find_record(registry, target) else {
+        return Err(format!("no recorded lane matches: {target}").into());
+    };
+    match field {
+        "json" => println!("{}", serde_json::to_string(&lane)?),
+        "repo" => println!("{}", lane.repo),
+        "dir" => println!("{}", lane.dir),
+        "issue" => println!("{}", lane.issue),
+        "branch" => println!("{}", lane.branch),
+        "base" => println!("{}", lane.base),
+        "owner" => println!("{}", lane.owner),
+        other => return Err(format!("unknown lane field: {other}").into()),
+    }
+    Ok(())
+}
+
+fn abs_path(path: &str) -> Result<PathBuf, Box<dyn Error>> {
+    let expanded = if path == "~" {
+        home_dir().ok_or("HOME/USERPROFILE is not set for ~ expansion")?
+    } else if let Some(rest) = path.strip_prefix("~/") {
+        home_dir()
+            .ok_or("HOME/USERPROFILE is not set for ~/ expansion")?
+            .join(rest)
+    } else {
+        PathBuf::from(path)
+    };
+    if expanded.is_absolute() {
+        Ok(expanded)
+    } else {
+        Ok(std::env::current_dir()?.join(expanded))
+    }
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+fn slug(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut last_was_dash = false;
+    for ch in value.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+            out.push(ch);
+            last_was_dash = false;
+        } else if !last_was_dash {
+            out.push('-');
+            last_was_dash = true;
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    if trimmed.is_empty() {
+        "lane".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn read_records(registry: &Path) -> Vec<LaneRecord> {
+    let Ok(raw) = fs::read_to_string(registry) else {
+        return Vec::new();
+    };
+    raw.lines()
+        .filter_map(|line| serde_json::from_str::<LaneRecord>(line).ok())
+        .collect()
+}
+
+fn find_record(registry: &Path, target: &str) -> Option<LaneRecord> {
+    read_records(registry).into_iter().rfind(|lane| {
+        lane.issue == target
+            || lane.dir == target
+            || Path::new(&lane.dir)
+                .file_name()
+                .and_then(|value| value.to_str())
+                == Some(target)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slug_matches_legacy_shape() {
+        assert_eq!(slug("#1234: Rust Lane!"), "1234-rust-lane");
+        assert_eq!(slug(""), "lane");
+        assert_eq!(slug("A_B.C-D"), "a_b.c-d");
+    }
+
+    #[test]
+    fn record_list_and_find_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = dir.path().join("lanes.jsonl");
+
+        run_record(
+            &registry,
+            "#1".to_string(),
+            "/repo".to_string(),
+            "/tmp/lane-one".to_string(),
+            "feat/one".to_string(),
+            "origin/canary".to_string(),
+            "codex".to_string(),
+        )
+        .unwrap();
+
+        let found = find_record(&registry, "lane-one").unwrap();
+
+        assert_eq!(found.issue, "#1");
+        assert_eq!(found.repo, "/repo");
+        assert_eq!(found.dir, "/tmp/lane-one");
+        assert_eq!(found.branch, "feat/one");
+    }
+}

--- a/crates/airc-cli/tests/worktree_lane_commands.rs
+++ b/crates/airc-cli/tests/worktree_lane_commands.rs
@@ -75,13 +75,11 @@ fn worktree_lane_slug_and_abs_path_match_shell_contract() {
     assert_eq!(slug.trim(), "123-codex-lane");
 
     let abs = run_ok(&["worktree-lane", "abs-path", "relative/lane"], Some(cwd));
-    assert_eq!(
-        abs.trim(),
-        cwd.canonicalize()
-            .unwrap()
-            .join("relative/lane")
-            .display()
-            .to_string()
+    let abs_path = Path::new(abs.trim());
+    assert!(abs_path.is_absolute(), "abs-path output was {abs}");
+    assert!(
+        abs_path.ends_with(Path::new("relative").join("lane")),
+        "abs-path output was {abs}"
     );
 }
 

--- a/crates/airc-cli/tests/worktree_lane_commands.rs
+++ b/crates/airc-cli/tests/worktree_lane_commands.rs
@@ -1,0 +1,103 @@
+//! End-to-end coverage for `airc-rs worktree-lane ...`.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn airc_rs() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-rs")
+}
+
+#[test]
+fn worktree_lane_registry_round_trips_from_cli() {
+    let workspace = TempDir::new().expect("tempdir");
+    let registry = workspace.path().join("lanes.jsonl");
+
+    run_ok(
+        &[
+            "worktree-lane",
+            "record",
+            "--registry",
+            registry.to_str().unwrap(),
+            "--issue",
+            "#123",
+            "--repo",
+            "/repo",
+            "--dir",
+            "/tmp/repo-123-codex",
+            "--branch",
+            "feat/123-codex",
+            "--base",
+            "origin/canary",
+            "--owner",
+            "codex",
+        ],
+        None,
+    );
+
+    let list = run_ok(
+        &[
+            "worktree-lane",
+            "list",
+            "--registry",
+            registry.to_str().unwrap(),
+            "--json",
+        ],
+        None,
+    );
+    let parsed: Value = serde_json::from_str(&list).expect("list json");
+    assert_eq!(parsed["lanes"][0]["issue"], "#123");
+    assert_eq!(parsed["lanes"][0]["owner"], "codex");
+
+    let dir = run_ok(
+        &[
+            "worktree-lane",
+            "find",
+            "--registry",
+            registry.to_str().unwrap(),
+            "repo-123-codex",
+            "--field",
+            "dir",
+        ],
+        None,
+    );
+    assert_eq!(dir.trim(), "/tmp/repo-123-codex");
+}
+
+#[test]
+fn worktree_lane_slug_and_abs_path_match_shell_contract() {
+    let workspace = TempDir::new().expect("tempdir");
+    let cwd = workspace.path();
+
+    let slug = run_ok(&["worktree-lane", "slug", "#123: Codex Lane!"], None);
+    assert_eq!(slug.trim(), "123-codex-lane");
+
+    let abs = run_ok(&["worktree-lane", "abs-path", "relative/lane"], Some(cwd));
+    assert_eq!(
+        abs.trim(),
+        cwd.canonicalize()
+            .unwrap()
+            .join("relative/lane")
+            .display()
+            .to_string()
+    );
+}
+
+fn run_ok(args: &[&str], cwd: Option<&Path>) -> String {
+    let mut command = Command::new(airc_rs());
+    command.args(args);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let output = command.output().expect("airc-rs command must spawn");
+    assert!(
+        output.status.success(),
+        "airc-rs {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout utf-8")
+}

--- a/lib/airc_bash/cmd_lane.sh
+++ b/lib/airc_bash/cmd_lane.sh
@@ -167,35 +167,11 @@ _cmd_lane_list() {
   touch "$registry"
 
   if [ "$output_json" -eq 1 ]; then
-    "$AIRC_PYTHON" - "$registry" <<'PYEOF'
-import json, sys
-items = []
-with open(sys.argv[1], "r", encoding="utf-8") as f:
-    for line in f:
-        try:
-            items.append(json.loads(line))
-        except Exception:
-            pass
-print(json.dumps({"lanes": items}, indent=2))
-PYEOF
-    return $?
+    "$(airc_rs_bin)" worktree-lane list --registry "$registry" --json
+    return
   fi
 
-  printf '# airc lanes\n'
-  if [ ! -s "$registry" ]; then
-    printf 'No recorded lanes yet.\n'
-  else
-    "$AIRC_PYTHON" - "$registry" <<'PYEOF'
-import json, sys
-with open(sys.argv[1], "r", encoding="utf-8") as f:
-    for line in f:
-        try:
-            lane = json.loads(line)
-        except Exception:
-            continue
-        print(f"- {lane.get('issue','?')} owner={lane.get('owner','?')} branch={lane.get('branch','?')} dir={lane.get('dir','?')} base={lane.get('base','?')}")
-PYEOF
-  fi
+  "$(airc_rs_bin)" worktree-lane list --registry "$registry"
 }
 
 _cmd_lane_remove() {
@@ -225,32 +201,14 @@ _cmd_lane_remove() {
 
   [ -n "$target" ] || die "lane remove: pass a lane dir or issue ref"
 
-  local registry lane_json
+  local registry
   registry=$(_airc_lane_registry)
-  lane_json=$("$AIRC_PYTHON" - "$registry" "$target" <<'PYEOF'
-import json, os, sys
-registry, target = sys.argv[1:3]
-matches = []
-try:
-    with open(registry, "r", encoding="utf-8") as f:
-        for line in f:
-            try:
-                lane = json.loads(line)
-            except Exception:
-                continue
-            if target in {lane.get("issue"), lane.get("dir"), os.path.basename(lane.get("dir", ""))}:
-                matches.append(lane)
-except FileNotFoundError:
-    pass
-if not matches:
-    sys.exit(1)
-print(json.dumps(matches[-1]))
-PYEOF
-) || die "lane remove: no recorded lane matches: $target"
+  "$(airc_rs_bin)" worktree-lane find --registry "$registry" "$target" >/dev/null \
+    || die "lane remove: no recorded lane matches: $target"
 
   local repo_root lane_dir
-  repo_root=$("$AIRC_PYTHON" -c 'import json,sys; print(json.loads(sys.argv[1])["repo"])' "$lane_json")
-  lane_dir=$("$AIRC_PYTHON" -c 'import json,sys; print(json.loads(sys.argv[1])["dir"])' "$lane_json")
+  repo_root=$("$(airc_rs_bin)" worktree-lane find --registry "$registry" "$target" --field repo)
+  lane_dir=$("$(airc_rs_bin)" worktree-lane find --registry "$registry" "$target" --field dir)
 
   case "$lane_dir" in
     "$repo_root"|"$repo_root"/*)
@@ -276,11 +234,11 @@ _airc_lane_registry() {
 }
 
 _airc_lane_abs_path() {
-  "$AIRC_PYTHON" -c 'import os,sys; print(os.path.abspath(os.path.expanduser(sys.argv[1])))' "$1"
+  "$(airc_rs_bin)" worktree-lane abs-path "$1"
 }
 
 _airc_lane_slug() {
-  "$AIRC_PYTHON" -c 'import re,sys; s=re.sub(r"[^A-Za-z0-9._-]+","-",sys.argv[1]).strip("-").lower(); print(s or "lane")' "$1"
+  "$(airc_rs_bin)" worktree-lane slug "$1"
 }
 
 _airc_lane_resolve_base() {
@@ -300,19 +258,14 @@ _airc_lane_record() {
   local registry
   registry=$(_airc_lane_registry)
   mkdir -p "$(dirname "$registry")"
-  "$AIRC_PYTHON" - "$issue_ref" "$repo_root" "$lane_dir" "$branch" "$base" "$owner" >>"$registry" <<'PYEOF'
-import datetime, json, sys
-issue, repo, lane_dir, branch, base, owner = sys.argv[1:7]
-print(json.dumps({
-    "ts": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
-    "issue": issue,
-    "repo": repo,
-    "dir": lane_dir,
-    "branch": branch,
-    "base": base,
-    "owner": owner,
-}, sort_keys=True))
-PYEOF
+  "$(airc_rs_bin)" worktree-lane record \
+    --registry "$registry" \
+    --issue "$issue_ref" \
+    --repo "$repo_root" \
+    --dir "$lane_dir" \
+    --branch "$branch" \
+    --base "$base" \
+    --owner "$owner"
 }
 
 _airc_lane_help() {

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -254,6 +254,16 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("AIRC_PYTHON", source)
         self.assertIn('"$(airc_rs_bin)" identity peer-ssh-pub', source)
 
+    def test_lane_registry_uses_airc_rs(self):
+        source = (REPO / "lib/airc_bash/cmd_lane.sh").read_text(encoding="utf-8")
+
+        self.assertNotIn("AIRC_PYTHON", source)
+        self.assertIn('"$(airc_rs_bin)" worktree-lane abs-path', source)
+        self.assertIn('"$(airc_rs_bin)" worktree-lane slug', source)
+        self.assertIn('"$(airc_rs_bin)" worktree-lane record', source)
+        self.assertIn('"$(airc_rs_bin)" worktree-lane list', source)
+        self.assertIn('"$(airc_rs_bin)" worktree-lane find', source)
+
     def test_message_crypto_helpers_use_airc_rs(self):
         combined = "\n".join(
             path.read_text(encoding="utf-8")


### PR DESCRIPTION
Summary
- add airc-rs worktree-lane helpers for abs-path, slug, record, list, and find
- route legacy airc lane registry/list/remove helpers through Rust instead of inline Python
- add CLI integration coverage for worktree lane registry round trips
- add cutover guard keeping cmd_lane.sh free of AIRC_PYTHON

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli worktree_lane
- python3 test/test_codex_rust_cutover.py
- bash -n airc lib/airc_bash/*.sh
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-cli
- cargo test --manifest-path Cargo.toml --workspace
- smoke: airc-rs worktree-lane record/list/find round-tripped a temp registry