### PR TITLE
feat(airc-cli): move local identity state to Rust

### DIFF
--- a/crates/airc-cli/src/identity_cli.rs
+++ b/crates/airc-cli/src/identity_cli.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Subcommand};
+use std::path::PathBuf;
 
 #[derive(Debug, Args)]
 pub struct IdentityArgs {
@@ -82,5 +83,95 @@ pub enum IdentityAction {
         /// Pair timestamp.
         #[arg(long)]
         paired: String,
+    },
+
+    /// Print the session state path for a transport identity.
+    SessionFile {
+        #[arg(long)]
+        write_dir: PathBuf,
+        #[arg(long, default_value = "anonymous")]
+        transport_name: String,
+    },
+
+    /// Print the default work identity for a transport + session.
+    DefaultWorkName {
+        #[arg(long, default_value = "anonymous")]
+        transport_name: String,
+        #[arg(long)]
+        session_file: PathBuf,
+    },
+
+    /// Read the saved work identity from a session file.
+    ReadWorkName {
+        #[arg(long)]
+        session_file: PathBuf,
+    },
+
+    /// Write the saved work identity for a session.
+    WriteWorkSession {
+        #[arg(long)]
+        session_file: PathBuf,
+        #[arg(long)]
+        name: String,
+        #[arg(long, default_value = "anonymous")]
+        transport_name: String,
+    },
+
+    /// Print local identity from config.json.
+    ShowConfig {
+        #[arg(long)]
+        config: PathBuf,
+    },
+
+    /// Update local identity fields in config.json.
+    SetConfig {
+        #[arg(long)]
+        config: PathBuf,
+        #[arg(long)]
+        pronouns: Option<String>,
+        #[arg(long)]
+        role: Option<String>,
+        #[arg(long)]
+        bio: Option<String>,
+        #[arg(long)]
+        status: Option<String>,
+    },
+
+    /// Link or unlink a platform handle in config.json.
+    LinkConfig {
+        #[arg(long)]
+        config: PathBuf,
+        #[arg(long)]
+        platform: String,
+        #[arg(long, default_value = "")]
+        handle: String,
+    },
+
+    /// Exit 2 when config identity should show the first-run nudge.
+    NudgeNeeded {
+        #[arg(long)]
+        config: PathBuf,
+    },
+
+    /// Merge a continuum persona JSON blob into config.json.
+    ImportContinuum {
+        #[arg(long)]
+        config: PathBuf,
+        #[arg(long)]
+        blob: String,
+    },
+
+    /// Print linked continuum handle from config.json.
+    ContinuumHandle {
+        #[arg(long)]
+        config: PathBuf,
+    },
+
+    /// Push local identity fields to a linked continuum persona.
+    PushContinuum {
+        #[arg(long)]
+        config: PathBuf,
+        #[arg(long)]
+        handle: String,
     },
 }

--- a/crates/airc-cli/src/identity_commands.rs
+++ b/crates/airc-cli/src/identity_commands.rs
@@ -1,10 +1,16 @@
 use std::error::Error;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
+use chrono::{SecondsFormat, Utc};
 use serde_json::{json, Value};
 
 const IDENTITY_FIELDS: &[&str] = &["pronouns", "role", "bio", "status"];
+const PRONOUNS_MAX: usize = 64;
+const ROLE_MAX: usize = 128;
+const BIO_MAX: usize = 512;
+const STATUS_MAX: usize = 256;
 
 pub fn run_pretty(name: &str, identity_json: &str, host: &str) -> Result<(), Box<dyn Error>> {
     let identity: Value =
@@ -73,6 +79,202 @@ pub fn run_peer_ssh_pub(peers_dir: &Path, peer_name: &str) -> Result<(), Box<dyn
     Ok(())
 }
 
+pub fn run_session_file(write_dir: &Path, transport_name: &str) -> Result<(), Box<dyn Error>> {
+    let session_file = session_file(write_dir, transport_name)?;
+    println!("{}", session_file.display());
+    Ok(())
+}
+
+pub fn run_default_work_name(
+    transport_name: &str,
+    session_file: &Path,
+) -> Result<(), Box<dyn Error>> {
+    println!("{}", default_work_name(transport_name, session_file));
+    Ok(())
+}
+
+pub fn run_read_work_name(session_file: &Path) -> Result<(), Box<dyn Error>> {
+    let Some(name) = read_work_name(session_file) else {
+        return Err("no saved work identity".into());
+    };
+    println!("{name}");
+    Ok(())
+}
+
+pub fn run_write_work_session(
+    session_file: &Path,
+    name: &str,
+    transport_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    write_work_session(session_file, name, transport_name)
+}
+
+pub fn run_show_config(config: &Path) -> Result<(), Box<dyn Error>> {
+    let Some(root) = load_config_opt(config) else {
+        println!("  (no config — run airc join)");
+        return Ok(());
+    };
+    print_config_identity(&root);
+    Ok(())
+}
+
+pub fn run_set_config(
+    config: &Path,
+    pronouns: Option<String>,
+    role: Option<String>,
+    bio: Option<String>,
+    status: Option<String>,
+) -> Result<(), Box<dyn Error>> {
+    if pronouns.is_none() && role.is_none() && bio.is_none() && status.is_none() {
+        return Err("Pass at least one of --pronouns / --role / --bio / --status".into());
+    }
+    validate_len("pronouns", pronouns.as_deref(), PRONOUNS_MAX)?;
+    validate_len("role", role.as_deref(), ROLE_MAX)?;
+    validate_len("bio", bio.as_deref(), BIO_MAX)?;
+    validate_len("status", status.as_deref(), STATUS_MAX)?;
+
+    let mut root = load_config_required(config)?;
+    let ident = object_field_mut(&mut root, "identity");
+    set_optional_string(ident, "pronouns", pronouns);
+    set_optional_string(ident, "role", role);
+    set_optional_string(ident, "bio", bio);
+    set_optional_string(ident, "status", status);
+    save_config(config, &root)?;
+    println!("  identity updated.");
+    Ok(())
+}
+
+pub fn run_link_config(config: &Path, platform: &str, handle: &str) -> Result<(), Box<dyn Error>> {
+    let mut root = load_config_required(config)?;
+    let ident = object_field_mut(&mut root, "identity");
+    let integrations = object_map_field_mut(ident, "integrations");
+    let previous = integrations
+        .get(platform)
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    if handle.trim().is_empty() {
+        integrations.remove(platform);
+    } else {
+        integrations.insert(
+            platform.to_string(),
+            Value::String(handle.trim().to_string()),
+        );
+    }
+    save_config(config, &root)?;
+
+    match (handle.trim().is_empty(), previous) {
+        (false, Some(prev)) if prev != handle.trim() => {
+            println!("  linked: {platform} -> {} (was: {prev})", handle.trim())
+        }
+        (false, _) => println!("  linked: {platform} -> {}", handle.trim()),
+        (true, Some(prev)) => {
+            println!("  unlinked: {platform} (was: {prev}; pass a handle to (re)link)")
+        }
+        (true, None) => println!(
+            "  no {platform} integration to unlink. Pass a handle to link: airc identity link {platform} <handle>"
+        ),
+    }
+    Ok(())
+}
+
+pub fn run_nudge_needed(config: &Path) -> Result<(), Box<dyn Error>> {
+    let Some(root) = load_config_opt(config) else {
+        return Ok(());
+    };
+    let ident = root.get("identity").and_then(Value::as_object);
+    let all_unset = ["pronouns", "role", "bio"].iter().all(|field| {
+        ident
+            .and_then(|items| items.get(*field))
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .is_none()
+    });
+    if all_unset {
+        return Err(NudgeNeeded.into());
+    }
+    Ok(())
+}
+
+pub fn run_import_continuum(config: &Path, blob: &str) -> Result<(), Box<dyn Error>> {
+    let source: Value = serde_json::from_str(blob).unwrap_or(Value::Null);
+    let mut root = load_config_required(config)?;
+    let ident = object_field_mut(&mut root, "identity");
+    for key in ["pronouns", "role", "bio"] {
+        if let Some(value) = source
+            .get(key)
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+        {
+            ident.insert(key.to_string(), Value::String(value.to_string()));
+        }
+    }
+    let name = source
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let integrations = object_map_field_mut(ident, "integrations");
+    integrations.insert("continuum".to_string(), Value::String(name.clone()));
+    save_config(config, &root)?;
+    println!(
+        "  imported continuum:{} -> pronouns={} role={} bio set={}",
+        if name.is_empty() { "?" } else { &name },
+        source.get("pronouns").and_then(Value::as_str).unwrap_or(""),
+        source.get("role").and_then(Value::as_str).unwrap_or(""),
+        source
+            .get("bio")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .is_some()
+    );
+    Ok(())
+}
+
+pub fn run_continuum_handle(config: &Path) -> Result<(), Box<dyn Error>> {
+    let root = load_config_required(config)?;
+    if let Some(handle) = root
+        .get("identity")
+        .and_then(|identity| identity.get("integrations"))
+        .and_then(|integrations| integrations.get("continuum"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    {
+        println!("{handle}");
+    }
+    Ok(())
+}
+
+pub fn run_push_continuum(config: &Path, handle: &str) -> Result<(), Box<dyn Error>> {
+    let root = load_config_required(config)?;
+    let identity = root.get("identity").unwrap_or(&Value::Null);
+    let mut args = vec![
+        "persona".to_string(),
+        "update".to_string(),
+        handle.to_string(),
+    ];
+    for key in ["pronouns", "role", "bio"] {
+        if let Some(value) = identity
+            .get(key)
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+        {
+            args.push(format!("--{key}"));
+            args.push(value.to_string());
+        }
+    }
+    let output = Command::new("continuum").args(&args).output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = stderr.trim();
+        let stdout = stdout.trim();
+        let message = if stderr.is_empty() { stdout } else { stderr };
+        return Err(format!("  continuum push failed: {}", message).into());
+    }
+    println!("  pushed local identity to continuum:{handle}");
+    Ok(())
+}
+
 fn peer_ssh_pub(peers_dir: &Path, peer_name: &str) -> Option<String> {
     let path = peers_dir.join(format!("{peer_name}.json"));
     let value = fs::read_to_string(path)
@@ -85,6 +287,247 @@ fn peer_ssh_pub(peers_dir: &Path, peer_name: &str) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_owned)
+}
+
+#[derive(Debug)]
+struct NudgeNeeded;
+
+impl std::fmt::Display for NudgeNeeded {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "identity nudge needed")
+    }
+}
+
+impl Error for NudgeNeeded {}
+
+pub fn command_exit_code(error: &(dyn Error + 'static)) -> Option<u8> {
+    if error.is::<NudgeNeeded>() {
+        Some(2)
+    } else {
+        None
+    }
+}
+
+fn session_file(write_dir: &Path, transport_name: &str) -> Result<PathBuf, Box<dyn Error>> {
+    let (source, value) = session_source();
+    let digest = sha256_hex(format!("{source}:{value}").as_bytes());
+    let _ = transport_name;
+    Ok(write_dir
+        .join("sessions")
+        .join(format!("{}.json", &digest[..16])))
+}
+
+fn default_work_name(transport_name: &str, session_file: &Path) -> String {
+    let digest = sha256_hex(session_file.display().to_string().as_bytes());
+    format!("{}-{}", slug(transport_name), &digest[..4])
+}
+
+fn read_work_name(session_file: &Path) -> Option<String> {
+    fs::read_to_string(session_file)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .and_then(|value| {
+            value
+                .get("name")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+        })
+}
+
+fn write_work_session(
+    session_file: &Path,
+    name: &str,
+    transport_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    if let Some(parent) = session_file.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let (source, value) = session_source();
+    let mut root = fs::read_to_string(session_file)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .unwrap_or_else(|| Value::Object(Default::default()));
+    let object = root
+        .as_object_mut()
+        .ok_or("session file root must be a JSON object")?;
+    object.insert("name".to_string(), Value::String(name.to_string()));
+    object.insert(
+        "transport_name".to_string(),
+        Value::String(transport_name.to_string()),
+    );
+    object.insert("session_source".to_string(), Value::String(source));
+    object.insert("session_hint".to_string(), Value::String(value));
+    object.insert(
+        "updated_at".to_string(),
+        Value::String(Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)),
+    );
+    fs::write(session_file, serde_json::to_string_pretty(&root)?)?;
+    Ok(())
+}
+
+fn session_source() -> (String, String) {
+    for key in [
+        "AIRC_SESSION_ID",
+        "CODEX_THREAD_ID",
+        "CLAUDE_SESSION_ID",
+        "CLAUDE_CODE_SESSION_ID",
+        "TERM_SESSION_ID",
+        "TMUX_PANE",
+    ] {
+        if let Ok(value) = std::env::var(key) {
+            let value = value.trim();
+            if !value.is_empty() {
+                return (key.to_string(), value.to_string());
+            }
+        }
+    }
+    ("cwd".to_string(), current_dir_string())
+}
+
+fn current_dir_string() -> String {
+    std::env::current_dir()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| ".".to_string())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn slug(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut last_dash = false;
+    for ch in value.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() || ch == '-' {
+            out.push(ch);
+            last_dash = false;
+        } else if !last_dash {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    let out = out.trim_matches('-');
+    if out.is_empty() {
+        "agent".to_string()
+    } else {
+        out.to_string()
+    }
+}
+
+fn load_config_opt(config: &Path) -> Option<Value> {
+    fs::read_to_string(config)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+}
+
+fn load_config_required(config: &Path) -> Result<Value, Box<dyn Error>> {
+    let root = load_config_opt(config).ok_or("config JSON is missing or malformed")?;
+    if !root.is_object() {
+        return Err("config JSON root must be an object".into());
+    }
+    Ok(root)
+}
+
+fn save_config(config: &Path, root: &Value) -> Result<(), Box<dyn Error>> {
+    fs::write(config, serde_json::to_string_pretty(root)?)?;
+    Ok(())
+}
+
+fn object_field_mut<'a>(root: &'a mut Value, key: &str) -> &'a mut serde_json::Map<String, Value> {
+    let object = root
+        .as_object_mut()
+        .expect("load_config_required validates config root object");
+    if !object.get(key).is_some_and(Value::is_object) {
+        object.insert(key.to_string(), Value::Object(Default::default()));
+    }
+    object.get_mut(key).unwrap().as_object_mut().unwrap()
+}
+
+fn object_map_field_mut<'a>(
+    object: &'a mut serde_json::Map<String, Value>,
+    key: &str,
+) -> &'a mut serde_json::Map<String, Value> {
+    if !object.get(key).is_some_and(Value::is_object) {
+        object.insert(key.to_string(), Value::Object(Default::default()));
+    }
+    object.get_mut(key).unwrap().as_object_mut().unwrap()
+}
+
+fn set_optional_string(
+    object: &mut serde_json::Map<String, Value>,
+    key: &str,
+    value: Option<String>,
+) {
+    if let Some(value) = value {
+        let value = value.trim();
+        if value.is_empty() {
+            object.remove(key);
+        } else {
+            object.insert(key.to_string(), Value::String(value.to_string()));
+        }
+    }
+}
+
+fn validate_len(name: &str, value: Option<&str>, max: usize) -> Result<(), Box<dyn Error>> {
+    if let Some(value) = value.filter(|value| value.len() > max) {
+        return Err(format!("{name} too long ({} chars; max {max})", value.len()).into());
+    }
+    Ok(())
+}
+
+fn print_config_identity(root: &Value) {
+    let identity = root.get("identity").unwrap_or(&Value::Null);
+    let name = root.get("name").and_then(Value::as_str).unwrap_or("?");
+    print_identity_value("name", name, "");
+    print_identity_field(identity, "pronouns", PRONOUNS_MAX, "(unset)");
+    print_identity_field(identity, "role", ROLE_MAX, "(unset)");
+    print_identity_field(identity, "bio", BIO_MAX, "(unset)");
+    print_identity_field(
+        identity,
+        "status",
+        STATUS_MAX,
+        "(unset; airc away <msg> to set)",
+    );
+    if let Some(integrations) = identity
+        .get("integrations")
+        .and_then(Value::as_object)
+        .filter(|items| !items.is_empty())
+    {
+        println!("  integrations:");
+        for (key, value) in integrations {
+            let text = value
+                .as_str()
+                .map_or_else(|| value.to_string(), str::to_string);
+            println!("    {key}: {text}");
+        }
+    } else {
+        println!("  integrations: (none)");
+    }
+}
+
+fn print_identity_field(identity: &Value, key: &str, max: usize, fallback: &str) {
+    let value = truncated(identity, key, max).unwrap_or_default();
+    print_identity_value(key, &value, fallback);
+}
+
+fn print_identity_value(key: &str, value: &str, fallback: &str) {
+    let label = format!("{key}:");
+    let display = if value.is_empty() { fallback } else { value };
+    println!("  {label:<11} {display}");
+}
+
+fn truncated(identity: &Value, key: &str, max: usize) -> Option<String> {
+    let value = identity.get(key)?.as_str()?.to_string();
+    if value.chars().count() <= max {
+        Some(value)
+    } else {
+        let prefix: String = value.chars().take(max.saturating_sub(3)).collect();
+        Some(format!("{prefix}..."))
+    }
 }
 
 fn remove_stale_host_records(
@@ -163,5 +606,90 @@ mod tests {
             Some("ssh-ed25519 AAAAC3Nz alice")
         );
         assert_eq!(peer_ssh_pub(dir.path(), "missing"), None);
+    }
+
+    #[test]
+    fn work_session_round_trips_saved_name() {
+        temp_env::with_var("AIRC_SESSION_ID", Some("thread-123"), || {
+            let dir = tempfile::tempdir().unwrap();
+            let session = session_file(dir.path(), "Codex Agent").unwrap();
+
+            assert!(session.ends_with("sessions/1700b5a26accf9e8.json"));
+            assert!(default_work_name("Codex Agent", &session).starts_with("codex-agent-"));
+            assert_eq!(read_work_name(&session), None);
+
+            write_work_session(&session, "codex-tab-1", "Codex Agent").unwrap();
+
+            assert_eq!(read_work_name(&session).as_deref(), Some("codex-tab-1"));
+            let saved: Value = serde_json::from_str(&fs::read_to_string(session).unwrap()).unwrap();
+            assert_eq!(saved["transport_name"], "Codex Agent");
+            assert_eq!(saved["session_source"], "AIRC_SESSION_ID");
+            assert_eq!(saved["session_hint"], "thread-123");
+        });
+    }
+
+    #[test]
+    fn set_and_link_config_updates_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config.json");
+        fs::write(&config, r#"{"name":"codex","identity":{}}"#).unwrap();
+
+        run_set_config(
+            &config,
+            Some("they".to_string()),
+            Some("rust-cutter".to_string()),
+            Some("Moves runtime identity state into Rust.".to_string()),
+            None,
+        )
+        .unwrap();
+        run_link_config(&config, "continuum", "clio").unwrap();
+
+        let saved: Value = serde_json::from_str(&fs::read_to_string(&config).unwrap()).unwrap();
+        assert_eq!(saved["identity"]["pronouns"], "they");
+        assert_eq!(saved["identity"]["role"], "rust-cutter");
+        assert_eq!(
+            saved["identity"]["bio"],
+            "Moves runtime identity state into Rust."
+        );
+        assert_eq!(saved["identity"]["integrations"]["continuum"], "clio");
+
+        run_link_config(&config, "continuum", "").unwrap();
+        let saved: Value = serde_json::from_str(&fs::read_to_string(config).unwrap()).unwrap();
+        assert!(saved["identity"]["integrations"]
+            .as_object()
+            .unwrap()
+            .get("continuum")
+            .is_none());
+    }
+
+    #[test]
+    fn import_continuum_merges_identity_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config.json");
+        fs::write(
+            &config,
+            r#"{"name":"codex","identity":{"status":"reviewing"}}"#,
+        )
+        .unwrap();
+
+        run_import_continuum(
+            &config,
+            r#"{"name":"clio","pronouns":"she/they","role":"memory-architect","bio":"Builds recall."}"#,
+        )
+        .unwrap();
+
+        let saved: Value = serde_json::from_str(&fs::read_to_string(config).unwrap()).unwrap();
+        assert_eq!(saved["identity"]["pronouns"], "she/they");
+        assert_eq!(saved["identity"]["role"], "memory-architect");
+        assert_eq!(saved["identity"]["bio"], "Builds recall.");
+        assert_eq!(saved["identity"]["status"], "reviewing");
+        assert_eq!(saved["identity"]["integrations"]["continuum"], "clio");
+    }
+
+    #[test]
+    fn truncated_preserves_utf8_boundary() {
+        let value = json!({"bio":"ééééé"});
+
+        assert_eq!(truncated(&value, "bio", 4).as_deref(), Some("é..."));
     }
 }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -124,6 +124,9 @@ async fn main() -> ExitCode {
             if let Some(code) = collaboration_commands::command_exit_code(error.as_ref()) {
                 return ExitCode::from(code);
             }
+            if let Some(code) = identity_commands::command_exit_code(error.as_ref()) {
+                return ExitCode::from(code);
+            }
             eprintln!("airc-rs: {error}");
             ExitCode::FAILURE
         }
@@ -341,6 +344,45 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 &x25519_pub,
                 &paired,
             ),
+            IdentityAction::SessionFile {
+                write_dir,
+                transport_name,
+            } => identity_commands::run_session_file(&write_dir, &transport_name),
+            IdentityAction::DefaultWorkName {
+                transport_name,
+                session_file,
+            } => identity_commands::run_default_work_name(&transport_name, &session_file),
+            IdentityAction::ReadWorkName { session_file } => {
+                identity_commands::run_read_work_name(&session_file)
+            }
+            IdentityAction::WriteWorkSession {
+                session_file,
+                name,
+                transport_name,
+            } => identity_commands::run_write_work_session(&session_file, &name, &transport_name),
+            IdentityAction::ShowConfig { config } => identity_commands::run_show_config(&config),
+            IdentityAction::SetConfig {
+                config,
+                pronouns,
+                role,
+                bio,
+                status,
+            } => identity_commands::run_set_config(&config, pronouns, role, bio, status),
+            IdentityAction::LinkConfig {
+                config,
+                platform,
+                handle,
+            } => identity_commands::run_link_config(&config, &platform, &handle),
+            IdentityAction::NudgeNeeded { config } => identity_commands::run_nudge_needed(&config),
+            IdentityAction::ImportContinuum { config, blob } => {
+                identity_commands::run_import_continuum(&config, &blob)
+            }
+            IdentityAction::ContinuumHandle { config } => {
+                identity_commands::run_continuum_handle(&config)
+            }
+            IdentityAction::PushContinuum { config, handle } => {
+                identity_commands::run_push_continuum(&config, &handle)
+            }
         },
 
         Command::Envelope(args) => match args.action {

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -17,7 +17,7 @@
 #     adapters for continuum (the only platform implemented today).
 #
 # External cross-references (call-time): die, ensure_init, get_config_val,
-# set_config_val, resolve_name, AIRC_HOME, AIRC_PYTHON, CONFIG, plus the
+# set_config_val, resolve_name, airc_rs_bin, AIRC_HOME, CONFIG, plus the
 # continuum CLI on PATH for import/push.
 #
 # Extracted from airc as part of #152 Phase 3 file split. The bundle is
@@ -103,116 +103,25 @@ _identity_session_file() {
   local transport_name="${1:-}"
   [ -z "$transport_name" ] && transport_name="anonymous"
   mkdir -p "$AIRC_WRITE_DIR/sessions" 2>/dev/null || true
-  AIRC_WRITE_DIR="$AIRC_WRITE_DIR" \
-    TRANSPORT_NAME="$transport_name" \
-    "$AIRC_PYTHON" -c '
-import hashlib, os, pathlib, re, subprocess
-
-def first_env(*names):
-    for name in names:
-        value = os.environ.get(name, "").strip()
-        if value:
-            return name, value
-    return "", ""
-
-source, value = first_env(
-    "AIRC_SESSION_ID",
-    "CODEX_THREAD_ID",
-    "CLAUDE_SESSION_ID",
-    "CLAUDE_CODE_SESSION_ID",
-    "TERM_SESSION_ID",
-    "TMUX_PANE",
-)
-if not value:
-    tty = ""
-    try:
-        tty = subprocess.check_output(["tty"], text=True, stderr=subprocess.DEVNULL).strip()
-    except Exception:
-        tty = ""
-    if tty and tty != "not a tty":
-        source, value = "tty", tty
-if not value:
-    source = "cwd"
-    value = os.getcwd()
-
-raw = f"{source}:{value}"
-digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
-base = os.environ["AIRC_WRITE_DIR"]
-path = pathlib.Path(base) / "sessions" / f"{digest}.json"
-print(path)
-'
+  "$(airc_rs_bin)" identity session-file --write-dir "$AIRC_WRITE_DIR" --transport-name "$transport_name"
 }
 
 _identity_default_work_name() {
   local transport_name="${1:-anonymous}"
   local session_file="${2:-}"
-  SESSION_FILE="$session_file" TRANSPORT_NAME="$transport_name" "$AIRC_PYTHON" -c '
-import hashlib, os, re
-name = os.environ.get("TRANSPORT_NAME", "anonymous") or "anonymous"
-session_file = os.environ.get("SESSION_FILE", "")
-suffix = hashlib.sha256(session_file.encode("utf-8")).hexdigest()[:4]
-base = re.sub(r"[^a-z0-9-]+", "-", name.lower()).strip("-") or "agent"
-print(f"{base}-{suffix}")
-'
+  "$(airc_rs_bin)" identity default-work-name --transport-name "$transport_name" --session-file "$session_file"
 }
 
 _identity_read_work_name() {
   local session_file="$1"
   [ -f "$session_file" ] || return 1
-  SESSION_FILE="$session_file" "$AIRC_PYTHON" -c '
-import json, os, sys
-try:
-    data = json.load(open(os.environ["SESSION_FILE"]))
-except Exception:
-    sys.exit(1)
-name = str(data.get("name", "")).strip()
-if not name:
-    sys.exit(1)
-print(name)
-'
+  "$(airc_rs_bin)" identity read-work-name --session-file "$session_file"
 }
 
 _identity_write_work_session() {
   local session_file="$1" name="$2" transport_name="$3"
   _validate_peer_name "$name"
-  SESSION_FILE="$session_file" \
-    NAME="$name" \
-    TRANSPORT_NAME="$transport_name" \
-    "$AIRC_PYTHON" -c '
-import json, os, pathlib, subprocess, time
-path = pathlib.Path(os.environ["SESSION_FILE"])
-path.parent.mkdir(parents=True, exist_ok=True)
-source = ""
-value = ""
-for key in ("AIRC_SESSION_ID", "CODEX_THREAD_ID", "CLAUDE_SESSION_ID", "CLAUDE_CODE_SESSION_ID", "TERM_SESSION_ID", "TMUX_PANE"):
-    candidate = os.environ.get(key, "").strip()
-    if candidate:
-        source, value = key, candidate
-        break
-if not value:
-    try:
-        tty = subprocess.check_output(["tty"], text=True, stderr=subprocess.DEVNULL).strip()
-    except Exception:
-        tty = ""
-    if tty and tty != "not a tty":
-        source, value = "tty", tty
-if not value:
-    source, value = "cwd", os.getcwd()
-data = {}
-if path.exists():
-    try:
-        data = json.load(open(path))
-    except Exception:
-        data = {}
-data.update({
-    "name": os.environ["NAME"],
-    "transport_name": os.environ.get("TRANSPORT_NAME", ""),
-    "session_source": source,
-    "session_hint": value,
-    "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-})
-json.dump(data, open(path, "w"), indent=2, sort_keys=True)
-'
+  "$(airc_rs_bin)" identity write-work-session --session-file "$session_file" --name "$name" --transport-name "$transport_name"
 }
 
 _identity_resolve_work_name() {
@@ -295,63 +204,22 @@ _identity_register() {
 _identity_bootstrap_nudge_if_unset() {
   local nudge_file="$AIRC_WRITE_DIR/.identity_nudged_v1"
   [ -f "$nudge_file" ] && return 0
-  CONFIG="$CONFIG" "$AIRC_PYTHON" -c '
-import json, os, sys
-try:
-    c = json.load(open(os.environ["CONFIG"]))
-except Exception:
-    sys.exit(0)
-ident = c.get("identity", {}) or {}
-unset = [k for k in ("pronouns", "role", "bio") if not ident.get(k)]
-if len(unset) == 3:
-    sys.exit(2)  # all three unset → nudge
-sys.exit(0)
-' || {
-    if [ "$?" = "2" ]; then
-      echo ""
-      echo "  Tip: set your identity so peers know who they are talking to. One-line example:"
-      echo "    airc identity set --pronouns they --role 'your role' --bio 'one-sentence bio'"
-      echo "  Done? Suppress this nudge: touch $nudge_file"
-      echo ""
-    fi
-  }
+  "$(airc_rs_bin)" identity nudge-needed --config "$CONFIG"
+  local nudge_status=$?
+  if [ "$nudge_status" = "2" ]; then
+    echo ""
+    echo "  Tip: set your identity so peers know who they are talking to. One-line example:"
+    echo "    airc identity set --pronouns they --role 'your role' --bio 'one-sentence bio'"
+    echo "  Done? Suppress this nudge: touch $nudge_file"
+    echo ""
+  elif [ "$nudge_status" != "0" ]; then
+    return "$nudge_status"
+  fi
   : > "$nudge_file" 2>/dev/null || true
 }
 
 _identity_show() {
-  CONFIG="$CONFIG" "$AIRC_PYTHON" -c '
-import json, os
-try:
-    c = json.load(open(os.environ["CONFIG"]))
-except Exception:
-    print("  (no config — run airc join)"); raise SystemExit(0)
-ident = c.get("identity", {}) or {}
-# Render-time truncation. Peer records from before the write-side
-# length caps (#328) may have multi-KB bios that would clutter
-# screens / break terminal rendering. Truncate to the same caps used
-# at write time, with an ellipsis to signal it happened.
-def _trunc(v, cap):
-    s = str(v or "")
-    return s if len(s) <= cap else s[: cap - 1] + "…"
-fields = [
-    ("name",     c.get("name", "?"),                         ""),
-    ("pronouns", _trunc(ident.get("pronouns", ""), 64),      "(unset)"),
-    ("role",     _trunc(ident.get("role", ""), 128),         "(unset)"),
-    ("bio",      _trunc(ident.get("bio", ""), 512),          "(unset)"),
-    ("status",   _trunc(ident.get("status", ""), 256),       "(unset; airc away <msg> to set)"),
-]
-for k, v, fallback in fields:
-    label = k + ":"
-    value = v if v else fallback
-    print(f"  {label:<11} {value}")
-ints = ident.get("integrations", {}) or {}
-if ints:
-    print("  integrations:")
-    for k, v in ints.items():
-        print(f"    {k}: {v}")
-else:
-    print("  integrations: (none)")
-'
+  "$(airc_rs_bin)" identity show-config --config "$CONFIG"
 }
 
 _identity_set() {
@@ -388,58 +256,18 @@ _identity_set() {
   if [ "$set_status" = 1 ] && [ "${#status}" -gt "$_max_status" ]; then
     die "status too long (${#status} chars; max $_max_status)"
   fi
-  CONFIG="$CONFIG" \
-    SET_PRONOUNS="$set_pronouns" PRONOUNS="$pronouns" \
-    SET_ROLE="$set_role"         ROLE="$role" \
-    SET_BIO="$set_bio"           BIO="$bio" \
-    SET_STATUS="$set_status"     STATUS="$status" \
-    "$AIRC_PYTHON" -c '
-import json, os
-c = json.load(open(os.environ["CONFIG"]))
-ident = c.setdefault("identity", {})
-for key, env_set, env_val in [
-    ("pronouns", "SET_PRONOUNS", "PRONOUNS"),
-    ("role",     "SET_ROLE",     "ROLE"),
-    ("bio",      "SET_BIO",      "BIO"),
-    ("status",   "SET_STATUS",   "STATUS"),
-]:
-    if os.environ.get(env_set) == "1":
-        v = os.environ.get(env_val, "").strip()
-        if v:
-            ident[key] = v
-        else:
-            ident.pop(key, None)
-json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
-print("  identity updated.")
-'
+  local args=(identity set-config --config "$CONFIG")
+  [ "$set_pronouns" = 1 ] && args+=(--pronouns "$pronouns")
+  [ "$set_role" = 1 ] && args+=(--role "$role")
+  [ "$set_bio" = 1 ] && args+=(--bio "$bio")
+  [ "$set_status" = 1 ] && args+=(--status "$status")
+  "$(airc_rs_bin)" "${args[@]}"
 }
 
 _identity_link() {
   local platform="${1:-}" handle="${2:-}"
   [ -z "$platform" ] && die "Usage: airc identity link <platform> [handle] (omit/blank handle to unlink)"
-  CONFIG="$CONFIG" PLATFORM="$platform" HANDLE="$handle" "$AIRC_PYTHON" -c '
-import json, os
-c = json.load(open(os.environ["CONFIG"]))
-ints = c.setdefault("identity", {}).setdefault("integrations", {})
-platform = os.environ["PLATFORM"]
-handle = os.environ.get("HANDLE", "").strip()
-prev = ints.get(platform)
-if handle:
-    ints[platform] = handle
-    if prev and prev != handle:
-        print(f"  linked: {platform} -> {handle} (was: {prev})")
-    else:
-        print(f"  linked: {platform} -> {handle}")
-elif prev:
-    # QA-pass clarification 2026-04-28: be explicit about "you said
-    # link but I unlinked" — happens when user omits the handle.
-    ints.pop(platform, None)
-    print(f"  unlinked: {platform} (was: {prev}; pass a handle to (re)link)")
-else:
-    # Nothing was linked. Be explicit instead of saying "unlinked" for a no-op.
-    print(f"  no {platform} integration to unlink. Pass a handle to link: airc identity link {platform} <handle>")
-json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
-'
+  "$(airc_rs_bin)" identity link-config --config "$CONFIG" --platform "$platform" --handle "$handle"
 }
 
 # WHOIS: prints identity for self, host, paired peer, or other peer of
@@ -513,7 +341,7 @@ _whois_in_scope() {
 
   # All scope-local config + peer file reads route through
   # get_config_val_in / airc-rs config. Pre-migration
-  # this function had six inline python heredocs reading individual
+  # this function had six inline JSON snippets reading individual
   # JSON fields — each a silent-fail vector with bash-substituted
   # SCOPE_CONFIG / PEER_FILE env vars. Now: one CLI per read.
   #
@@ -646,49 +474,14 @@ _identity_import_continuum() {
   fi
   # Parse the JSON; merge into our identity. Empty fields skip; existing
   # fields get overwritten (the user's intent: "I want to BE this persona").
-  BLOB="$blob" CONFIG="$CONFIG" "$AIRC_PYTHON" -c '
-import json, os
-try:
-    src = json.loads(os.environ["BLOB"])
-except Exception:
-    src = {}
-c = json.load(open(os.environ["CONFIG"]))
-ident = c.setdefault("identity", {})
-for k in ("pronouns", "role", "bio"):
-    v = src.get(k)
-    if v:
-        ident[k] = v
-ints = ident.setdefault("integrations", {})
-ints["continuum"] = src.get("name", "")
-json.dump(c, open(os.environ["CONFIG"], "w"), indent=2)
-print(f"  imported continuum:{src.get(\"name\", \"?\")} → pronouns={src.get(\"pronouns\", \"\")} role={src.get(\"role\", \"\")} bio set={bool(src.get(\"bio\"))}")
-'
+  "$(airc_rs_bin)" identity import-continuum --config "$CONFIG" --blob "$blob"
 }
 
 _identity_push_continuum() {
   if ! command -v continuum >/dev/null 2>&1; then
     die "continuum CLI not on PATH — install continuum before pushing."
   fi
-  local handle; handle=$(CONFIG="$CONFIG" "$AIRC_PYTHON" -c '
-import json, os
-c = json.load(open(os.environ["CONFIG"]))
-print(c.get("identity", {}).get("integrations", {}).get("continuum", ""))
-' 2>/dev/null)
+  local handle; handle=$("$(airc_rs_bin)" identity continuum-handle --config "$CONFIG" 2>/dev/null)
   [ -z "$handle" ] && die "No continuum handle linked. Run: airc identity link continuum <name>"
-  CONFIG="$CONFIG" HANDLE="$handle" "$AIRC_PYTHON" -c '
-import json, os, subprocess
-c = json.load(open(os.environ["CONFIG"]))
-ident = c.get("identity", {})
-handle = os.environ["HANDLE"]
-args = ["continuum", "persona", "update", handle]
-for k in ("pronouns", "role", "bio"):
-    v = ident.get(k)
-    if v:
-        args += [f"--{k}", v]
-res = subprocess.run(args, capture_output=True, text=True)
-if res.returncode != 0:
-    print(f"  continuum push failed: {res.stderr.strip() or res.stdout.strip()}")
-    raise SystemExit(1)
-print(f"  pushed local identity to continuum:{handle}")
-'
+  "$(airc_rs_bin)" identity push-continuum --config "$CONFIG" --handle "$handle"
 }

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -254,6 +254,22 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("AIRC_PYTHON", source)
         self.assertIn('"$(airc_rs_bin)" identity peer-ssh-pub', source)
 
+    def test_identity_local_state_uses_airc_rs(self):
+        source = (REPO / "lib/airc_bash/cmd_identity.sh").read_text(encoding="utf-8")
+
+        self.assertNotIn("AIRC_PYTHON", source)
+        self.assertIn('"$(airc_rs_bin)" identity session-file', source)
+        self.assertIn('"$(airc_rs_bin)" identity default-work-name', source)
+        self.assertIn('"$(airc_rs_bin)" identity read-work-name', source)
+        self.assertIn('"$(airc_rs_bin)" identity write-work-session', source)
+        self.assertIn('"$(airc_rs_bin)" identity nudge-needed', source)
+        self.assertIn('"$(airc_rs_bin)" identity show-config', source)
+        self.assertIn("identity set-config --config", source)
+        self.assertIn('"$(airc_rs_bin)" identity link-config', source)
+        self.assertIn('"$(airc_rs_bin)" identity import-continuum', source)
+        self.assertIn('"$(airc_rs_bin)" identity continuum-handle', source)
+        self.assertIn('"$(airc_rs_bin)" identity push-continuum', source)
+
     def test_lane_registry_uses_airc_rs(self):
         source = (REPO / "lib/airc_bash/cmd_lane.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Summary
- add typed airc-rs identity commands for session files, work identity state, local config identity, Continuum import/push helpers, and first-run nudge detection
- route cmd_identity.sh local/session/config behavior through airc-rs with no Python fallback
- add Rust tests for session state, config set/link, Continuum import, UTF-8 truncation, plus a cutover guard banning AIRC_PYTHON from cmd_identity.sh

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli identity_commands
- python3 test/test_codex_rust_cutover.py
- bash -n airc lib/airc_bash/*.sh
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- identity set-config/link-config/show-config smoke
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace