### PR TITLE
feat(airc-cli): move runtime JSON helpers to Rust

### DIFF
--- a/airc
+++ b/airc
@@ -2343,15 +2343,7 @@ PY
         sub="${sub#\#}"
         local sf_path="$AIRC_WRITE_DIR/bearer_state.${sub}.json"
         subs_file_glob="${subs_file_glob}${sf_path}|"
-      done < <("$AIRC_PYTHON" -c "
-import json, sys
-try:
-    cfg = json.load(open('$CONFIG'))
-    for c in cfg.get('subscribed_channels') or []:
-        print(c)
-except Exception:
-    pass
-" 2>/dev/null)
+      done < <("$(airc_rs_bin)" config read-channels --home "$AIRC_WRITE_DIR" --config "$CONFIG" 2>/dev/null)
 
       for sf in "$AIRC_WRITE_DIR"/bearer_state*.json; do
         [ -f "$sf" ] || continue
@@ -2366,25 +2358,8 @@ except Exception:
           esac
         fi
         has_any_state=1
-        local ts; ts=$("$AIRC_PYTHON" -c "
-import json, sys, calendar, time
-try:
-    d = json.load(open('$sf'))
-    v = d.get('last_recv_ts')
-    if v is None:
-        print(0)
-    elif isinstance(v, (int, float)):
-        print(int(v))
-    else:
-        # ISO-8601 string — parse to epoch seconds
-        try:
-            t = time.strptime(v.rstrip('Z'), '%Y-%m-%dT%H:%M:%S')
-            print(calendar.timegm(t))
-        except Exception:
-            print(0)
-except Exception:
-    print(0)
-" 2>/dev/null)
+        local ts
+        ts=$("$(airc_rs_bin)" bearer-state "$sf" 2>/dev/null | awk '{print $1}')
         if [ -n "$ts" ] && [ "$ts" -gt "$freshest_recv" ] 2>/dev/null; then
           freshest_recv="$ts"
         fi

--- a/crates/airc-cli/src/bearer_state.rs
+++ b/crates/airc-cli/src/bearer_state.rs
@@ -16,9 +16,36 @@ pub fn run(path: &Path) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+pub fn run_summary(path: &Path) -> Result<(), Box<dyn Error>> {
+    let state = read_state(path)?;
+    println!("{}", state_summary(&state));
+    Ok(())
+}
+
 fn read_state(path: &Path) -> Result<Value, Box<dyn Error>> {
     let raw = fs::read_to_string(path)?;
     Ok(serde_json::from_str(&raw)?)
+}
+
+fn state_summary(state: &Value) -> String {
+    let kind = state
+        .get("kind")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("?");
+    let diag = state.get("diag").and_then(Value::as_str).unwrap_or("");
+    let total = state
+        .get("events_total")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let recv = int_timestamp(state.get("last_recv_ts"));
+    if recv == 0 {
+        format!("awaiting first event (bearer={kind}, {diag})")
+    } else {
+        let now = unix_now();
+        let age = now.saturating_sub(recv);
+        format!("{age}s ago via {kind} ({total} events; {diag})")
+    }
 }
 
 fn int_timestamp(value: Option<&Value>) -> u64 {
@@ -36,9 +63,16 @@ fn int_timestamp(value: Option<&Value>) -> u64 {
         .unwrap_or(0)
 }
 
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{int_timestamp, read_state};
+    use super::{int_timestamp, read_state, state_summary, unix_now};
     use serde_json::json;
 
     #[test]
@@ -62,5 +96,27 @@ mod tests {
         std::fs::write(&path, r#"{"last_recv_ts": 10}"#).unwrap();
 
         assert_eq!(read_state(&path).unwrap()["last_recv_ts"], 10);
+    }
+
+    #[test]
+    fn state_summary_matches_status_shape() {
+        assert_eq!(
+            state_summary(&json!({
+                "last_recv_ts": null,
+                "kind": "gh",
+                "diag": "opened",
+                "events_total": 0
+            })),
+            "awaiting first event (bearer=gh, opened)"
+        );
+
+        let now = unix_now();
+        let summary = state_summary(&json!({
+            "last_recv_ts": now.saturating_sub(3),
+            "kind": "local",
+            "diag": "ok",
+            "events_total": 7
+        }));
+        assert!(summary.ends_with("s ago via local (7 events; ok)"));
     }
 }

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -98,6 +98,9 @@ pub enum Command {
     BearerState {
         /// bearer_state.<channel>.json path to read.
         path: PathBuf,
+        /// Print human-readable receive summary for `airc status`.
+        #[arg(long)]
+        summary: bool,
     },
 
     /// Legacy bearer transport helpers during Rust cutover.

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -139,7 +139,13 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
     match parsed.command {
         Command::Init => commands::run_init(&home).await,
 
-        Command::BearerState { path } => bearer_state::run(&path),
+        Command::BearerState { path, summary } => {
+            if summary {
+                bearer_state::run_summary(&path)
+            } else {
+                bearer_state::run(&path)
+            }
+        }
 
         Command::Bearer(args) => match args.action {
             BearerAction::Send {

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -163,22 +163,7 @@ cmd_status() {
   local bearer_state="$AIRC_WRITE_DIR/bearer_state.json"
   if [ -f "$bearer_state" ]; then
     local _bs_summary
-    _bs_summary=$("$AIRC_PYTHON" -c "
-import json, sys, time
-try:
-    s = json.load(open('$bearer_state'))
-except Exception as e:
-    print(f'unreadable: {e}'); sys.exit(0)
-ts = s.get('last_recv_ts')
-kind = s.get('kind', '?')
-diag = s.get('diag', '')
-total = s.get('events_total', 0)
-if ts is None:
-    print(f'awaiting first event (bearer={kind}, {diag})')
-else:
-    age = int(time.time() - float(ts))
-    print(f'{age}s ago via {kind} ({total} events; {diag})')
-" 2>/dev/null)
+    _bs_summary=$("$(airc_rs_bin)" bearer-state --summary "$bearer_state" 2>/dev/null)
     echo "  bearer:      ${_bs_summary:-unreadable}"
   elif [ -n "$host_target" ]; then
     # Joiner with no bearer state — monitor never came up or hasn't

--- a/lib/airc_bash/cmd_teardown.sh
+++ b/lib/airc_bash/cmd_teardown.sh
@@ -374,16 +374,8 @@ cmd_disconnect() {
   esac
   cmd_teardown >/dev/null 2>&1 || true
   if [ -f "$CONFIG" ]; then
-    "$AIRC_PYTHON" -c "
-import json
-try:
-    c = json.load(open('$CONFIG'))
-    for k in ('host_target', 'host_name', 'host_airc_home', 'host_port', 'host_ssh_pub'):
-        c.pop(k, None)
-    json.dump(c, open('$CONFIG', 'w'), indent=2)
-except Exception:
-    pass
-" 2>/dev/null || true
+    "$(airc_rs_bin)" config unset-keys --home "$AIRC_WRITE_DIR" --config "$CONFIG" \
+      host_target host_name host_airc_home host_port host_ssh_pub >/dev/null 2>&1 || true
   fi
   echo "  Disconnected. Identity preserved. Next 'airc join' starts fresh."
 }

--- a/lib/airc_bash/mesh.sh
+++ b/lib/airc_bash/mesh.sh
@@ -136,13 +136,7 @@ _mesh_age_secs() {
       | "$(airc_rs_bin)" gist gist-content 2>/dev/null || true)
   fi
   [ -z "$content" ] && return 0
-  local hb; hb=$(printf '%s' "$content" | "$AIRC_PYTHON" -c '
-import sys, json
-try:
-    print(json.loads(sys.stdin.read()).get("last_heartbeat", ""))
-except Exception:
-    pass
-' 2>/dev/null || true)
+  local hb; hb=$(printf '%s' "$content" | "$(airc_rs_bin)" gist get .last_heartbeat 2>/dev/null || true)
   [ -z "$hb" ] && return 0
   local hb_epoch; hb_epoch=$(iso_to_epoch "$hb")
   [ -z "$hb_epoch" ] && return 0

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -163,10 +163,12 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" log rotate --path "$_hb_messages"', connect)
 
     def test_bearer_state_uses_airc_rs(self):
-        source = (REPO / "lib/airc_bash/cmd_doctor.sh").read_text(encoding="utf-8")
+        doctor = (REPO / "lib/airc_bash/cmd_doctor.sh").read_text(encoding="utf-8")
+        status = (REPO / "lib/airc_bash/cmd_status.sh").read_text(encoding="utf-8")
 
-        self.assertNotIn("airc_core.bearer_state", source)
-        self.assertIn('"$(airc_rs_bin)" bearer-state "$state_file"', source)
+        self.assertNotIn("airc_core.bearer_state", doctor + status)
+        self.assertIn('"$(airc_rs_bin)" bearer-state "$state_file"', doctor)
+        self.assertIn('"$(airc_rs_bin)" bearer-state --summary "$bearer_state"', status)
 
     def test_logs_render_uses_airc_rs(self):
         source = (REPO / "lib/airc_bash/cmd_status.sh").read_text(encoding="utf-8")
@@ -189,6 +191,7 @@ class CodexRustCutoverTests(unittest.TestCase):
         combined = "\n".join(path.read_text(encoding="utf-8") for path in files)
         self.assertIn('"$(airc_rs_bin)" gist get .airc', combined)
         self.assertIn('"$(airc_rs_bin)" gist gist-content', combined)
+        self.assertIn('"$(airc_rs_bin)" gist get .last_heartbeat', combined)
 
     def test_generic_config_runtime_paths_use_airc_rs(self):
         files = [


### PR DESCRIPTION
Summary
- add `airc-rs bearer-state --summary` for status rendering
- route mesh heartbeat reads, disconnect host-field cleanup, and subscribed-channel scans through airc-rs instead of inline Python
- extend cutover guards for bearer-state status summaries and mesh heartbeat parsing

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli bearer_state
- python3 test/test_codex_rust_cutover.py
- bash -n airc lib/airc_bash/*.sh
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- bearer-state --summary <tmp-state>
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- config read-channels --home <tmp> --config <tmp-config>
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-cli