### PR TITLE
feat(airc-cli): move queue card core to Rust

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -280,6 +280,9 @@ pub enum Command {
     /// Manage legacy local git worktree lane registry during Rust cutover.
     WorktreeLane(crate::worktree_lane_cli::WorktreeLaneArgs),
 
+    /// Queue-card parsing and mutation primitives during Rust cutover.
+    QueueCard(crate::queue_card_cli::QueueCardArgs),
+
     /// Append and rotate legacy messages.jsonl files through Rust.
     Log(crate::log_cli::LogArgs),
 

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -56,6 +56,8 @@ mod message_commands;
 mod monitor;
 mod pending_cli;
 mod pending_commands;
+mod queue_card_cli;
+mod queue_card_commands;
 mod route_cli;
 mod route_commands;
 mod scope_cli;
@@ -97,6 +99,7 @@ use log_cli::LogAction;
 use message_cli::MessageAction;
 use monitor::MonitorAction;
 use pending_cli::PendingAction;
+use queue_card_cli::QueueCardAction;
 use route_cli::RouteAction;
 use scope_cli::ScopeAction;
 use transport_cli::TransportAction;
@@ -784,6 +787,64 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 workspace_commands::run_release(&home, workspace_id).await
             }
             WorkspaceAction::List { limit } => workspace_commands::run_list(&home, limit).await,
+        },
+
+        Command::QueueCard(args) => match args.action {
+            QueueCardAction::Body {
+                id,
+                branch,
+                owner,
+                status,
+                blockers,
+                environment,
+                evidence,
+                next_action,
+                last_heartbeat,
+            } => queue_card_commands::run_body(queue_card_commands::QueueCardInput {
+                id,
+                branch,
+                owner,
+                status,
+                blockers,
+                environment,
+                evidence,
+                next_action,
+                last_heartbeat,
+            }),
+            QueueCardAction::MutateBody {
+                body_file,
+                mutations_file,
+                log_msg,
+                timestamp,
+            } => queue_card_commands::run_mutate_body(
+                &body_file,
+                &mutations_file,
+                &log_msg,
+                &timestamp,
+            ),
+            QueueCardAction::ClaimFields { body_file } => {
+                queue_card_commands::run_claim_fields(&body_file)
+            }
+            QueueCardAction::DispatchMessage {
+                target_agent,
+                extra_message,
+                next_json_file,
+            } => queue_card_commands::run_dispatch_message(
+                &target_agent,
+                &extra_message,
+                &next_json_file,
+            ),
+            QueueCardAction::AdoptBody {
+                issue_json_file,
+                queue_body_file,
+                force,
+            } => queue_card_commands::run_adopt_body(&issue_json_file, &queue_body_file, force),
+            QueueCardAction::NudgeSummary { raw_json_file } => {
+                queue_card_commands::run_nudge_summary(&raw_json_file)
+            }
+            QueueCardAction::NudgeCardMeta { issue_file } => {
+                queue_card_commands::run_nudge_card_meta(&issue_file)
+            }
         },
 
         Command::Humanhash { hex_input, words } => {

--- a/crates/airc-cli/src/queue_card_cli.rs
+++ b/crates/airc-cli/src/queue_card_cli.rs
@@ -1,0 +1,84 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub struct QueueCardArgs {
+    #[command(subcommand)]
+    pub action: QueueCardAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum QueueCardAction {
+    /// Build a queue-card issue body from typed fields.
+    Body {
+        #[arg(long)]
+        id: String,
+        #[arg(long, default_value = "")]
+        branch: String,
+        #[arg(long, default_value = "")]
+        owner: String,
+        #[arg(long, default_value = "")]
+        status: String,
+        #[arg(long, default_value = "")]
+        blockers: String,
+        #[arg(long = "env", default_value = "")]
+        environment: String,
+        #[arg(long, default_value = "")]
+        evidence: String,
+        #[arg(long, default_value = "")]
+        next_action: String,
+        #[arg(long, default_value = "")]
+        last_heartbeat: String,
+    },
+
+    /// Apply set/clear mutations to a queue-card body.
+    MutateBody {
+        #[arg(long)]
+        body_file: PathBuf,
+        #[arg(long)]
+        mutations_file: PathBuf,
+        #[arg(long)]
+        log_msg: String,
+        #[arg(long)]
+        timestamp: String,
+    },
+
+    /// Print owner and status from a queue-card body, one per line.
+    ClaimFields {
+        #[arg(long)]
+        body_file: PathBuf,
+    },
+
+    /// Build the hand-out message for the top queue candidate.
+    DispatchMessage {
+        #[arg(long)]
+        target_agent: String,
+        #[arg(long, default_value = "")]
+        extra_message: String,
+        #[arg(long)]
+        next_json_file: PathBuf,
+    },
+
+    /// Append a queue-card body to an existing issue body.
+    AdoptBody {
+        #[arg(long)]
+        issue_json_file: PathBuf,
+        #[arg(long)]
+        queue_body_file: PathBuf,
+        #[arg(long)]
+        force: bool,
+    },
+
+    /// Summarize queue cards for repo-nudge text.
+    NudgeSummary {
+        #[arg(long)]
+        raw_json_file: PathBuf,
+    },
+
+    /// Print title/status/owner/branch from one issue JSON blob.
+    NudgeCardMeta {
+        #[arg(long)]
+        issue_file: PathBuf,
+    },
+}

--- a/crates/airc-cli/src/queue_card_commands.rs
+++ b/crates/airc-cli/src/queue_card_commands.rs
@@ -1,0 +1,495 @@
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+use serde_json::{Map, Value};
+
+const CARD_KIND: &str = "airc-queue-card-v1";
+const CARD_FENCE_START: &str = "```json";
+const CARD_FENCE_END: &str = "```";
+const STATUS_LOG_HEADER: &str = "## Status log";
+
+#[derive(Debug)]
+pub struct QueueCardInput {
+    pub id: String,
+    pub branch: String,
+    pub owner: String,
+    pub status: String,
+    pub blockers: String,
+    pub environment: String,
+    pub evidence: String,
+    pub next_action: String,
+    pub last_heartbeat: String,
+}
+
+pub fn run_body(input: QueueCardInput) -> Result<(), Box<dyn Error>> {
+    print!("{}", build_body(input)?);
+    Ok(())
+}
+
+pub fn run_mutate_body(
+    body_file: &Path,
+    mutations_file: &Path,
+    log_msg: &str,
+    timestamp: &str,
+) -> Result<(), Box<dyn Error>> {
+    let body = fs::read_to_string(body_file)?;
+    let mutations = fs::read_to_string(mutations_file)?;
+    print!("{}", mutate_body(&body, &mutations, log_msg, timestamp)?);
+    Ok(())
+}
+
+pub fn run_claim_fields(body_file: &Path) -> Result<(), Box<dyn Error>> {
+    let body = fs::read_to_string(body_file)?;
+    let card = parse_card(&body)
+        .ok_or("queue claim: no kind=airc-queue-card-v1 envelope found in body")?;
+    let card_value = Value::Object(card);
+    let mut owner = string_field(&card_value, "owner");
+    if owner == "unclaimed" {
+        owner.clear();
+    }
+    println!("{owner}");
+    println!("{}", string_field(&card_value, "status"));
+    Ok(())
+}
+
+pub fn run_dispatch_message(
+    target_agent: &str,
+    extra_message: &str,
+    next_json_file: &Path,
+) -> Result<(), Box<dyn Error>> {
+    let raw = fs::read_to_string(next_json_file)?;
+    println!("{}", dispatch_message(target_agent, extra_message, &raw)?);
+    Ok(())
+}
+
+pub fn run_adopt_body(
+    issue_json_file: &Path,
+    queue_body_file: &Path,
+    force: bool,
+) -> Result<(), Box<dyn Error>> {
+    let issue = read_json(issue_json_file)?;
+    let queue_body = fs::read_to_string(queue_body_file)?;
+    print!("{}", adopt_body(&issue, &queue_body, force)?);
+    Ok(())
+}
+
+pub fn run_nudge_summary(raw_json_file: &Path) -> Result<(), Box<dyn Error>> {
+    let issues = read_json(raw_json_file)?;
+    println!("{}", nudge_summary(&issues)?);
+    Ok(())
+}
+
+pub fn run_nudge_card_meta(issue_file: &Path) -> Result<(), Box<dyn Error>> {
+    let issue = read_json(issue_file)?;
+    let (title, status, owner, branch) = nudge_card_meta(&issue)?;
+    println!("{title}");
+    println!("{status}");
+    println!("{owner}");
+    println!("{branch}");
+    Ok(())
+}
+
+fn build_body(input: QueueCardInput) -> Result<String, Box<dyn Error>> {
+    let mut card = Map::new();
+    card.insert("kind".to_string(), Value::String(CARD_KIND.to_string()));
+    insert_nonempty(&mut card, "id", &input.id);
+    insert_nonempty(&mut card, "branch", &input.branch);
+    insert_nonempty(&mut card, "owner", &input.owner);
+    insert_nonempty(&mut card, "status", &input.status);
+    insert_nonempty(&mut card, "blockers", &input.blockers);
+    insert_nonempty(&mut card, "env", &input.environment);
+    insert_nonempty(&mut card, "evidence", &input.evidence);
+    insert_nonempty(&mut card, "next_action", &input.next_action);
+    insert_nonempty(&mut card, "last_heartbeat", &input.last_heartbeat);
+    let card_json = serde_json::to_string_pretty(&Value::Object(card))?;
+    Ok(format!(
+        "**airc-queue card**\n\n{}\n\n```json\n{}\n```\n\n{}\n",
+        "Coordinates work via the AIRC queue substrate (airc#562). Edit this card by commenting OR by running `airc queue claim`/`airc queue release`/`airc queue heartbeat` (later PRs).",
+        card_json,
+        "Close this issue when the work is done (status=merged/abandoned).",
+    ))
+}
+
+fn mutate_body(
+    body: &str,
+    mutations: &str,
+    log_msg: &str,
+    timestamp: &str,
+) -> Result<String, Box<dyn Error>> {
+    let found = find_card_block(body)
+        .ok_or("queue mutate: no kind=airc-queue-card-v1 envelope found in body")?;
+    let mut card = found.card;
+    for raw in mutations.lines() {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            continue;
+        }
+        if let Some(keyval) = raw.strip_prefix("set:") {
+            let (key, value) = keyval
+                .split_once('=')
+                .ok_or_else(|| format!("queue mutate: malformed --set: {keyval}"))?;
+            card.insert(
+                key.trim().to_string(),
+                Value::String(value.trim().to_string()),
+            );
+        } else if let Some(key) = raw.strip_prefix("clear:") {
+            card.remove(key.trim());
+        } else {
+            return Err(format!("queue mutate: malformed mutation: {raw}").into());
+        }
+    }
+
+    let new_block = format!(
+        "```json\n{}\n```",
+        serde_json::to_string_pretty(&Value::Object(card))?
+    );
+    let body_with_card = format!(
+        "{}{}{}",
+        &body[..found.start],
+        new_block,
+        &body[found.end..]
+    );
+    let log_line = format!("- {timestamp} — {log_msg}");
+    if body_with_card.contains(STATUS_LOG_HEADER) {
+        Ok(body_with_card.replacen(
+            STATUS_LOG_HEADER,
+            &format!("{STATUS_LOG_HEADER}\n\n{log_line}"),
+            1,
+        ))
+    } else {
+        Ok(format!(
+            "{}\n\n{STATUS_LOG_HEADER}\n\n{log_line}\n",
+            body_with_card.trim_end()
+        ))
+    }
+}
+
+fn dispatch_message(
+    target_agent: &str,
+    extra_message: &str,
+    raw: &str,
+) -> Result<String, Box<dyn Error>> {
+    let data: Value = serde_json::from_str(raw)?;
+    let items: &[Value] = if let Some(items) = data.get("candidates").and_then(Value::as_array) {
+        items.as_slice()
+    } else if let Some(items) = data.get("items").and_then(Value::as_array) {
+        items.as_slice()
+    } else if let Some(items) = data.get("results").and_then(Value::as_array) {
+        items.as_slice()
+    } else if let Some(items) = data.as_array() {
+        items.as_slice()
+    } else {
+        &[]
+    };
+    let top = items.first().ok_or("ERR:no-items")?;
+    let number = top
+        .get("number")
+        .map_or_else(|| "?".to_string(), value_text);
+    let title = truncate_chars(&string_field(top, "title"), 80);
+    let url = string_field(top, "url");
+    let claim = string_field(top, "claim_command");
+    let claim = if claim.is_empty() {
+        string_field(top, "claim")
+    } else {
+        claim
+    };
+    let lane = string_field(top, "lane_command");
+    let lane = if lane.is_empty() {
+        string_field(top, "lane")
+    } else {
+        lane
+    };
+
+    let mut parts = vec![
+        format!("📋 hand-out for @{target_agent}: #{number} — {title}"),
+        nonempty_prefix("   ", &url),
+        nonempty_prefix("   claim: ", &claim),
+        nonempty_prefix("   lane:  ", &lane),
+    ];
+    if !extra_message.trim().is_empty() {
+        parts.push(format!("   note: {}", extra_message.trim()));
+    }
+    parts.retain(|item| !item.is_empty());
+    Ok(parts.join("\n"))
+}
+
+fn adopt_body(issue: &Value, queue_body: &str, force: bool) -> Result<String, Box<dyn Error>> {
+    let old_body = issue.get("body").and_then(Value::as_str).unwrap_or("");
+    if parse_card(old_body).is_some() && !force {
+        return Err("queue adopt: issue already has an airc-queue-card-v1 envelope; pass --force to rewrite".into());
+    }
+    let original = if old_body.trim().is_empty() {
+        "\n\n## Original issue body\n\n_No pre-adoption body._\n".to_string()
+    } else {
+        format!(
+            "\n\n## Original issue body\n\n<details>\n<summary>Pre-adoption body</summary>\n\n{}\n\n</details>\n",
+            old_body.trim_end()
+        )
+    };
+    Ok(format!("{}{}", queue_body.trim_end(), original))
+}
+
+fn nudge_summary(issues: &Value) -> Result<String, Box<dyn Error>> {
+    let issues = issues
+        .as_array()
+        .ok_or("queue nudge: issue JSON must be an array")?;
+    let mut items = Vec::new();
+    for issue in issues {
+        let Some(card) = issue
+            .get("body")
+            .and_then(Value::as_str)
+            .and_then(parse_card)
+        else {
+            continue;
+        };
+        let title = string_field(issue, "title");
+        let title = title
+            .strip_prefix("airc-queue: ")
+            .unwrap_or(&title)
+            .to_string();
+        let status = nonempty_or(
+            &string_field(&Value::Object(card.clone()), "status"),
+            "unknown",
+        );
+        let mut owner = string_field(&Value::Object(card.clone()), "owner");
+        if owner == "unclaimed" {
+            owner.clear();
+        }
+        let branch = string_field(&Value::Object(card), "branch");
+        let mut bit = format!(
+            "#{} {status}",
+            issue
+                .get("number")
+                .map_or_else(|| "?".to_string(), value_text)
+        );
+        if !owner.is_empty() {
+            bit.push_str(&format!(" owner={owner}"));
+        }
+        if !branch.is_empty() {
+            bit.push_str(&format!(" branch={branch}"));
+        }
+        if !title.is_empty() {
+            bit.push_str(&format!(" '{}'", truncate_chars(&title, 60)));
+        }
+        items.push(bit);
+    }
+    if items.is_empty() {
+        Ok("no open queue cards".to_string())
+    } else {
+        Ok(items.into_iter().take(10).collect::<Vec<_>>().join("; "))
+    }
+}
+
+fn nudge_card_meta(issue: &Value) -> Result<(String, String, String, String), Box<dyn Error>> {
+    let title = nonempty_or(&string_field(issue, "title"), "(no title)");
+    let body = string_field(issue, "body");
+    let card = parse_card(&body).ok_or("queue nudge: issue has no airc-queue-card-v1 envelope")?;
+    let card_value = Value::Object(card);
+    Ok((
+        title,
+        nonempty_or(&string_field(&card_value, "status"), "unknown"),
+        string_field(&card_value, "owner"),
+        string_field(&card_value, "branch"),
+    ))
+}
+
+#[derive(Debug)]
+struct FoundCard {
+    start: usize,
+    end: usize,
+    card: Map<String, Value>,
+}
+
+fn parse_card(body: &str) -> Option<Map<String, Value>> {
+    find_card_block(body).map(|found| found.card)
+}
+
+fn find_card_block(body: &str) -> Option<FoundCard> {
+    let mut offset = 0;
+    while let Some(relative_start) = body[offset..].find(CARD_FENCE_START) {
+        let start = offset + relative_start;
+        let after_start = start + CARD_FENCE_START.len();
+        let content_start = body[after_start..]
+            .find('\n')
+            .map(|newline| after_start + newline + 1)
+            .unwrap_or(after_start);
+        let relative_end = body[content_start..].find(CARD_FENCE_END)?;
+        let end = content_start + relative_end;
+        let content = body[content_start..end].trim();
+        if let Ok(Value::Object(card)) = serde_json::from_str::<Value>(content) {
+            if card.get("kind").and_then(Value::as_str) == Some(CARD_KIND) {
+                return Some(FoundCard {
+                    start,
+                    end: end + CARD_FENCE_END.len(),
+                    card,
+                });
+            }
+        }
+        offset = end + CARD_FENCE_END.len();
+    }
+    None
+}
+
+fn read_json(path: &Path) -> Result<Value, Box<dyn Error>> {
+    Ok(serde_json::from_str(&fs::read_to_string(path)?)?)
+}
+
+fn insert_nonempty(card: &mut Map<String, Value>, key: &str, value: &str) {
+    if !value.is_empty() {
+        card.insert(key.to_string(), Value::String(value.to_string()));
+    }
+}
+
+fn string_field(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+fn value_text(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        Value::Number(number) => number.to_string(),
+        Value::Bool(boolean) => boolean.to_string(),
+        Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+fn nonempty_prefix(prefix: &str, value: &str) -> String {
+    if value.is_empty() {
+        String::new()
+    } else {
+        format!("{prefix}{value}")
+    }
+}
+
+fn nonempty_or(value: &str, fallback: &str) -> String {
+    if value.is_empty() {
+        fallback.to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn truncate_chars(value: &str, max: usize) -> String {
+    if value.chars().count() <= max {
+        value.to_string()
+    } else {
+        value.chars().take(max).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn body_builds_markdown_and_card_json() {
+        let body = build_body(QueueCardInput {
+            id: "airc#1".to_string(),
+            branch: "feat/x".to_string(),
+            owner: "codex".to_string(),
+            status: "claimed".to_string(),
+            blockers: String::new(),
+            environment: "mac".to_string(),
+            evidence: "tests pass".to_string(),
+            next_action: "merge".to_string(),
+            last_heartbeat: "2026-05-19T00:00Z".to_string(),
+        })
+        .unwrap();
+
+        let card = parse_card(&body).unwrap();
+        assert_eq!(card["kind"], CARD_KIND);
+        assert_eq!(card["id"], "airc#1");
+        assert_eq!(card["env"], "mac");
+        assert!(!card.contains_key("blockers"));
+    }
+
+    #[test]
+    fn mutate_body_replaces_card_and_adds_log() {
+        let body = "**x**\n\n```json\n{\"kind\":\"airc-queue-card-v1\",\"owner\":\"old\"}\n```\n";
+        let updated =
+            mutate_body(body, "set:owner=new\nclear:missing\n", "claimed", "now").unwrap();
+
+        let card = parse_card(&updated).unwrap();
+        assert_eq!(card["owner"], "new");
+        assert!(updated.contains("## Status log"));
+        assert!(updated.contains("- now — claimed"));
+    }
+
+    #[test]
+    fn claim_fields_treats_unclaimed_as_empty_owner() {
+        let body = "```json\n{\"kind\":\"airc-queue-card-v1\",\"owner\":\"unclaimed\",\"status\":\"claimed\"}\n```";
+        let card = parse_card(body).unwrap();
+        assert_eq!(string_field(&Value::Object(card), "status"), "claimed");
+    }
+
+    #[test]
+    fn dispatch_message_uses_top_candidate() {
+        let raw = json!({
+            "candidates": [{
+                "number": 7,
+                "title": "Fix the queue",
+                "url": "https://example",
+                "claim_command": "airc queue claim",
+                "lane_command": "airc lane"
+            }]
+        })
+        .to_string();
+
+        let text = dispatch_message("claude", "now", &raw).unwrap();
+
+        assert!(text.contains("@claude"));
+        assert!(text.contains("#7"));
+        assert!(text.contains("claim: airc queue claim"));
+        assert!(text.contains("note: now"));
+    }
+
+    #[test]
+    fn adopt_body_refuses_existing_card_without_force() {
+        let issue = json!({"body":"```json\n{\"kind\":\"airc-queue-card-v1\"}\n```"});
+
+        assert!(adopt_body(&issue, "new", false).is_err());
+        assert!(adopt_body(&issue, "new", true)
+            .unwrap()
+            .contains("Pre-adoption body"));
+    }
+
+    #[test]
+    fn nudge_summary_renders_compact_cards() {
+        let issues = json!([{
+            "number": 2,
+            "title": "airc-queue: Build thing",
+            "body": "```json\n{\"kind\":\"airc-queue-card-v1\",\"status\":\"review\",\"owner\":\"codex\",\"branch\":\"feat/x\"}\n```"
+        }]);
+
+        assert_eq!(
+            nudge_summary(&issues).unwrap(),
+            "#2 review owner=codex branch=feat/x 'Build thing'"
+        );
+    }
+
+    #[test]
+    fn nudge_card_meta_requires_queue_card() {
+        let issue = json!({
+            "title": "A",
+            "body": "```json\n{\"kind\":\"airc-queue-card-v1\",\"status\":\"blocked\",\"owner\":\"codex\",\"branch\":\"b\"}\n```"
+        });
+
+        assert_eq!(
+            nudge_card_meta(&issue).unwrap(),
+            (
+                "A".to_string(),
+                "blocked".to_string(),
+                "codex".to_string(),
+                "b".to_string()
+            )
+        );
+    }
+}

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -330,41 +330,10 @@ EOF
   # Read the JSON from a tempfile (not stdin) because the heredoc carrying
   # the python source uses fd 0; can't redirect stdin twice.
   local dm_text
-  dm_text=$("$AIRC_PYTHON" - "$target_agent" "$extra_message" "$next_json_file" <<'PYEOF'
-import json, sys
-target_agent, extra, path = sys.argv[1], sys.argv[2], sys.argv[3]
-try:
-    with open(path) as f:
-        data = json.loads(f.read())
-except json.JSONDecodeError as e:
-    print(f"ERR:json:{e}", file=sys.stderr)
-    sys.exit(2)
-if isinstance(data, dict):
-    items = data.get("candidates") or data.get("items") or data.get("results") or []
-elif isinstance(data, list):
-    items = data
-else:
-    items = []
-if not items:
-    print("ERR:no-items", file=sys.stderr)
-    sys.exit(3)
-top = items[0]
-number = top.get("number") or "?"
-title = (top.get("title") or "").strip()
-url = top.get("url") or ""
-claim = top.get("claim_command") or top.get("claim") or ""
-lane = top.get("lane_command") or top.get("lane") or ""
-parts = [
-    f"📋 hand-out for @{target_agent}: #{number} — {title[:80]}",
-    f"   {url}" if url else "",
-    f"   claim: {claim}" if claim else "",
-    f"   lane:  {lane}" if lane else "",
-]
-if extra:
-    parts.append(f"   note: {extra}")
-print("\n".join(p for p in parts if p))
-PYEOF
-  )
+  dm_text=$("$(airc_rs_bin)" queue-card dispatch-message \
+    --target-agent "$target_agent" \
+    --extra-message "$extra_message" \
+    --next-json-file "$next_json_file")
   rm -f "$next_json_file"
   if [ -z "$dm_text" ]; then
     die "queue dispatch: failed to format hand-out from queue-next output"
@@ -804,29 +773,16 @@ _airc_queue_card_body() {
   local blockers="$5" env="$6" evidence="$7"
   local next_action="$8" last_heartbeat="$9"
 
-  # Build the JSON envelope via python so we get correct escaping for
-  # weird characters in evidence/next_action (operator-supplied free text).
-  local card_json
-  card_json=$("$AIRC_PYTHON" - "$id" "$branch" "$owner" "$status" \
-      "$blockers" "$env" "$evidence" "$next_action" "$last_heartbeat" \
-      <<'PYEOF'
-import json, sys
-keys = ["id","branch","owner","status","blockers","env","evidence","next_action","last_heartbeat"]
-values = sys.argv[1:1+len(keys)]
-card = {"kind": "airc-queue-card-v1"}
-for k, v in zip(keys, values):
-    if v:
-        card[k] = v
-print(json.dumps(card, indent=2))
-PYEOF
-)
-
-  # Body uses printf rather than heredoc to dodge bash heredoc parser
-  # edge cases (apostrophes inside $() — same trap that bit cmd_approve).
-  printf '**airc-queue card**\n\n%s\n\n```json\n%s\n```\n\n%s\n' \
-    'Coordinates work via the AIRC queue substrate (airc#562). Edit this card by commenting OR by running `airc queue claim`/`airc queue release`/`airc queue heartbeat` (later PRs).' \
-    "$card_json" \
-    'Close this issue when the work is done (status=merged/abandoned).'
+  "$(airc_rs_bin)" queue-card body \
+    --id "$id" \
+    --branch "$branch" \
+    --owner "$owner" \
+    --status "$status" \
+    --blockers "$blockers" \
+    --env "$env" \
+    --evidence "$evidence" \
+    --next-action "$next_action" \
+    --last-heartbeat "$last_heartbeat"
 }
 
 # ──────────────────────────────────────────────────────────────────────
@@ -940,33 +896,7 @@ _airc_queue_claim_guard() {
   printf '%s' "$current_body" >"$body_file"
 
   local fields
-  if ! fields=$("$AIRC_PYTHON" - "$body_file" <<'PYEOF'
-import json, re, sys
-
-with open(sys.argv[1], "r", encoding="utf-8") as f:
-    body = f.read()
-
-card = None
-for match in re.finditer(r'```json\s*\n(.*?)\n\s*```', body, re.DOTALL):
-    try:
-        parsed = json.loads(match.group(1).strip())
-    except Exception:
-        continue
-    if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
-        card = parsed
-        break
-
-if card is None:
-    print("queue claim: no kind=airc-queue-card-v1 envelope found in body", file=sys.stderr)
-    sys.exit(2)
-
-owner = (card.get("owner") or "").strip()
-if owner == "unclaimed":
-    owner = ""
-print(owner)
-print((card.get("status") or "").strip())
-PYEOF
-  ); then
+  if ! fields=$("$(airc_rs_bin)" queue-card claim-fields --body-file "$body_file"); then
     rm -f "$body_file"
     die "$fields"
   fi
@@ -1781,37 +1711,9 @@ _cmd_queue_adopt() {
   printf '%s' "$queue_body" >"$body_file"
 
   local adopted_body
-  adopted_body=$("$AIRC_PYTHON" - "$issue_json_file" "$body_file" "$force" <<'PYEOF'
-import json, re, sys
-issue_json_path, queue_body_path, force_raw = sys.argv[1:4]
-force = force_raw == "1"
-
-with open(issue_json_path, "r", encoding="utf-8") as f:
-    issue = json.loads(f.read())
-with open(queue_body_path, "r", encoding="utf-8") as f:
-    queue_body = f.read().rstrip()
-
-old_body = issue.get("body") or ""
-CARD_BLOCK_RE = re.compile(r'```json\s*\n(.*?)\n\s*```', re.DOTALL)
-for m in CARD_BLOCK_RE.finditer(old_body):
-    try:
-        parsed = json.loads(m.group(1).strip())
-    except Exception:
-        continue
-    if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
-        if not force:
-            print("queue adopt: issue already has an airc-queue-card-v1 envelope; pass --force to rewrite", file=sys.stderr)
-            sys.exit(3)
-        break
-
-if old_body.strip():
-    original = "\n\n## Original issue body\n\n<details>\n<summary>Pre-adoption body</summary>\n\n" + old_body.rstrip() + "\n\n</details>\n"
-else:
-    original = "\n\n## Original issue body\n\n_No pre-adoption body._\n"
-
-print(queue_body + original, end="")
-PYEOF
-)
+  local adopt_args=(queue-card adopt-body --issue-json-file "$issue_json_file" --queue-body-file "$body_file")
+  [ "$force" = "1" ] && adopt_args+=(--force)
+  adopted_body=$("$(airc_rs_bin)" "${adopt_args[@]}")
   local adopt_rc=$?
   if [ "$adopt_rc" -ne 0 ]; then
     rm -f "$issue_json_file" "$body_file"
@@ -1954,44 +1856,7 @@ _cmd_queue_nudge_repo() {
   printf '%s' "$raw_json" >"$raw_json_file"
 
   local summary
-  if ! summary=$("$AIRC_PYTHON" - "$raw_json_file" <<'PYEOF'
-import json, re, sys
-with open(sys.argv[1], "r", encoding="utf-8") as f:
-    data = json.load(f)
-CARD_BLOCK_RE = re.compile(r'```json\s*\n(.*?)\n\s*```', re.DOTALL)
-items = []
-for issue in data:
-    card = {}
-    for m in CARD_BLOCK_RE.finditer(issue.get("body", "") or ""):
-        try:
-            parsed = json.loads(m.group(1).strip())
-        except Exception:
-            continue
-        if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
-            card = parsed
-            break
-    if not card:
-        continue
-    title = (issue.get("title", "") or "").replace("airc-queue: ", "", 1)
-    status = (card.get("status") or "unknown").strip()
-    owner = (card.get("owner") or "").strip()
-    if owner == "unclaimed":
-        owner = ""
-    branch = (card.get("branch") or "").strip()
-    bit = f"#{issue.get('number')} {status}"
-    if owner:
-        bit += f" owner={owner}"
-    if branch:
-        bit += f" branch={branch}"
-    if title:
-        bit += f" '{title[:60]}'"
-    items.append(bit)
-if items:
-    print("; ".join(items[:10]))
-else:
-    print("no open queue cards")
-PYEOF
-  ); then
+  if ! summary=$("$(airc_rs_bin)" queue-card nudge-summary --raw-json-file "$raw_json_file"); then
     rm -f "$raw_json_file"
     die "queue nudge: could not summarize queue cards for $target_repo"
   fi
@@ -2056,42 +1921,16 @@ _cmd_queue_nudge_card() {
   printf '%s' "$issue_blob" >"$issue_file"
 
   local card_meta
-  if ! card_meta=$("$AIRC_PYTHON" - "$issue_file" <<'PYEOF'
-import json, re, sys
-with open(sys.argv[1], "r", encoding="utf-8") as f:
-    issue = json.load(f)
-title = issue.get("title", "(no title)")
-body = issue.get("body", "") or ""
-CARD_BLOCK_RE = re.compile(r'```json\s*\n(.*?)\n\s*```', re.DOTALL)
-card = None
-for m in CARD_BLOCK_RE.finditer(body):
-    try:
-        parsed = json.loads(m.group(1).strip())
-    except Exception:
-        continue
-    if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
-        card = parsed
-        break
-if card is None:
-    print("ERR:no-envelope", file=sys.stderr)
-    sys.exit(2)
-status = (card.get("status") or "").strip() or "unknown"
-owner = (card.get("owner") or "").strip()
-if owner == "unclaimed":
-    owner = ""
-# Tab-separated for shell-friendly parse.
-print(f"{title}\t{status}\t{owner}")
-PYEOF
-  ); then
+  if ! card_meta=$("$(airc_rs_bin)" queue-card nudge-card-meta --issue-file "$issue_file"); then
     rm -f "$issue_file"
     die "queue nudge: $repo#$issue_num is not a valid airc-queue-card-v1 envelope"
   fi
   rm -f "$issue_file"
 
   local card_title card_status card_owner
-  card_title=$(printf '%s' "$card_meta" | awk -F'\t' '{print $1}')
-  card_status=$(printf '%s' "$card_meta" | awk -F'\t' '{print $2}')
-  card_owner=$(printf '%s' "$card_meta" | awk -F'\t' '{print $3}')
+  card_title=$(printf '%s\n' "$card_meta" | sed -n '1p')
+  card_status=$(printf '%s\n' "$card_meta" | sed -n '2p')
+  card_owner=$(printf '%s\n' "$card_meta" | sed -n '3p')
 
   local actor
   actor=$(_airc_queue_resolve_name)

--- a/lib/airc_bash/cmd_queue_card.sh
+++ b/lib/airc_bash/cmd_queue_card.sh
@@ -47,10 +47,9 @@ _airc_queue_mutate_card() {
     die "queue: gh issue view failed for $repo#$issue_num: $current_body"
   fi
 
-  # Hand to python: parse envelope, apply mutations, rewrite body with
-  # status-log entry. Python heredoc handles edge cases (escaping, regex)
-  # better than bash here. Body + mutations passed via temp files to
-  # dodge stdin contention with the heredoc.
+  # Hand to Rust: parse envelope, apply mutations, rewrite body with
+  # status-log entry. Body + mutations pass via temp files so shell only
+  # owns process orchestration.
   local body_file mut_file
   body_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-body.XXXXXX") || die "queue: mktemp failed"
   mut_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-muts.XXXXXX") || die "queue: mktemp failed"
@@ -61,75 +60,13 @@ _airc_queue_mutate_card() {
   timestamp=$(date -u +"%Y-%m-%dT%H:%MZ")
 
   local new_body
-  if ! new_body=$("$AIRC_PYTHON" - "$body_file" "$mut_file" "$log_msg" "$timestamp" <<'PYEOF'
-import json, re, sys
-body_path, mut_path, log_msg, timestamp = sys.argv[1:5]
-
-with open(body_path, "r", encoding="utf-8") as f:
-    body = f.read()
-with open(mut_path, "r", encoding="utf-8") as f:
-    mutations_raw = f.read().strip().splitlines()
-
-# Find the kind=airc-queue-card-v1 JSON block.
-CARD_BLOCK_RE = re.compile(r'```json\s*\n(.*?)\n\s*```', re.DOTALL)
-match = None
-for m in CARD_BLOCK_RE.finditer(body):
-    try:
-        parsed = json.loads(m.group(1).strip())
-    except Exception:
-        continue
-    if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
-        match = m
-        card = parsed
-        break
-if match is None:
-    print("queue mutate: no kind=airc-queue-card-v1 envelope found in body", file=sys.stderr)
-    sys.exit(2)
-
-# Apply mutations.
-for raw in mutations_raw:
-    if raw.startswith("set:"):
-        keyval = raw[4:]
-        if "=" not in keyval:
-            print(f"queue mutate: malformed --set: {keyval}", file=sys.stderr)
-            sys.exit(2)
-        k, v = keyval.split("=", 1)
-        card[k.strip()] = v.strip()
-    elif raw.startswith("clear:"):
-        k = raw[6:].strip()
-        if k in card:
-            del card[k]
-    else:
-        # Empty line from trailing newline; ignore.
-        if raw.strip():
-            print(f"queue mutate: malformed mutation: {raw}", file=sys.stderr)
-            sys.exit(2)
-
-new_envelope = json.dumps(card, indent=2)
-new_block = "```json\n" + new_envelope + "\n```"
-
-# Replace the original block with the new one.
-body_with_new_envelope = body[:match.start()] + new_block + body[match.end():]
-
-# Append to ## Status log section. If it doesn't exist yet, create it.
-log_line = f"- {timestamp} — {log_msg}"
-LOG_HEADER = "## Status log"
-if LOG_HEADER in body_with_new_envelope:
-    # Append to existing section: insert after the header line.
-    body_with_log = body_with_new_envelope.replace(
-        LOG_HEADER, LOG_HEADER + "\n\n" + log_line, 1
-    )
-    # Above replaces the FIRST match; entries pile in reverse-chrono
-    # at the top of the section. Newest-first reads better at a glance.
-else:
-    # Create the section at the end of the body.
-    body_with_log = body_with_new_envelope.rstrip() + "\n\n" + LOG_HEADER + "\n\n" + log_line + "\n"
-
-print(body_with_log, end="")
-PYEOF
-); then
+  if ! new_body=$("$(airc_rs_bin)" queue-card mutate-body \
+    --body-file "$body_file" \
+    --mutations-file "$mut_file" \
+    --log-msg "$log_msg" \
+    --timestamp "$timestamp"); then
     rm -f "$body_file" "$mut_file"
-    die "queue mutate: python helper failed: $new_body"
+    die "queue mutate: Rust helper failed: $new_body"
   fi
   rm -f "$body_file" "$mut_file"
 

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -283,6 +283,24 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" worktree-lane list', source)
         self.assertIn('"$(airc_rs_bin)" worktree-lane find', source)
 
+    def test_queue_card_core_uses_airc_rs(self):
+        combined = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in [
+                REPO / "lib/airc_bash/cmd_queue.sh",
+                REPO / "lib/airc_bash/cmd_queue_card.sh",
+            ]
+        )
+
+        self.assertIn('"$(airc_rs_bin)" queue-card body', combined)
+        self.assertIn('"$(airc_rs_bin)" queue-card mutate-body', combined)
+        self.assertIn('"$(airc_rs_bin)" queue-card claim-fields', combined)
+        self.assertIn('"$(airc_rs_bin)" queue-card dispatch-message', combined)
+        self.assertIn("queue-card adopt-body", combined)
+        self.assertIn('"$(airc_rs_bin)" queue-card nudge-summary', combined)
+        self.assertIn('"$(airc_rs_bin)" queue-card nudge-card-meta', combined)
+        self.assertNotIn("AIRC_PYTHON", (REPO / "lib/airc_bash/cmd_queue_card.sh").read_text(encoding="utf-8"))
+
     def test_message_crypto_helpers_use_airc_rs(self):
         combined = "\n".join(
             path.read_text(encoding="utf-8")


### PR DESCRIPTION
Summary
- add typed `airc-rs queue-card` commands for card body generation, mutation, claim-field extraction, dispatch text, adoption, and nudge metadata/summary
- route queue card shell primitives through Rust and remove Python from `cmd_queue_card.sh`
- add focused Rust tests for fenced-card parsing/mutation/rendering and a cutover guard for the new queue-card Rust surface

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli queue_card
- python3 test/test_codex_rust_cutover.py
- bash -n airc lib/airc_bash/*.sh
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- queue-card dispatch-message ...
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- queue-card body ...
- cargo test --manifest-path Cargo.toml -p airc-cli