### PR TITLE
feat(airc-cli): move queue projections to Rust

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -58,6 +58,7 @@ mod pending_cli;
 mod pending_commands;
 mod queue_card_cli;
 mod queue_card_commands;
+mod queue_card_projection;
 mod route_cli;
 mod route_commands;
 mod scope_cli;
@@ -845,6 +846,34 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             QueueCardAction::NudgeCardMeta { issue_file } => {
                 queue_card_commands::run_nudge_card_meta(&issue_file)
             }
+            QueueCardAction::List {
+                repo,
+                owner,
+                status,
+                json,
+                raw_json_file,
+            } => queue_card_projection::run_list(&repo, &owner, &status, json, &raw_json_file),
+            QueueCardAction::Stale {
+                repo,
+                stale_after,
+                json,
+                raw_json_file,
+            } => queue_card_projection::run_stale(&repo, &stale_after, json, &raw_json_file),
+            QueueCardAction::Next {
+                repo,
+                owner,
+                base,
+                repo_root,
+                json,
+                raw_json_file,
+            } => queue_card_projection::run_next(
+                &repo,
+                &owner,
+                &base,
+                &repo_root,
+                json,
+                &raw_json_file,
+            ),
         },
 
         Command::Humanhash { hex_input, words } => {

--- a/crates/airc-cli/src/queue_card_cli.rs
+++ b/crates/airc-cli/src/queue_card_cli.rs
@@ -81,4 +81,46 @@ pub enum QueueCardAction {
         #[arg(long)]
         issue_file: PathBuf,
     },
+
+    /// Render and optionally filter open queue cards.
+    List {
+        #[arg(long)]
+        repo: String,
+        #[arg(long, default_value = "")]
+        owner: String,
+        #[arg(long, default_value = "")]
+        status: String,
+        #[arg(long)]
+        json: bool,
+        #[arg(long)]
+        raw_json_file: PathBuf,
+    },
+
+    /// Render stale owned queue cards.
+    Stale {
+        #[arg(long)]
+        repo: String,
+        #[arg(long, default_value = "30m")]
+        stale_after: String,
+        #[arg(long)]
+        json: bool,
+        #[arg(long)]
+        raw_json_file: PathBuf,
+    },
+
+    /// Rank claimable next queue cards for an owner.
+    Next {
+        #[arg(long)]
+        repo: String,
+        #[arg(long)]
+        owner: String,
+        #[arg(long, default_value = "canary")]
+        base: String,
+        #[arg(long, default_value = "")]
+        repo_root: String,
+        #[arg(long)]
+        json: bool,
+        #[arg(long)]
+        raw_json_file: PathBuf,
+    },
 }

--- a/crates/airc-cli/src/queue_card_commands.rs
+++ b/crates/airc-cli/src/queue_card_commands.rs
@@ -301,7 +301,7 @@ struct FoundCard {
     card: Map<String, Value>,
 }
 
-fn parse_card(body: &str) -> Option<Map<String, Value>> {
+pub(crate) fn parse_card(body: &str) -> Option<Map<String, Value>> {
     find_card_block(body).map(|found| found.card)
 }
 
@@ -331,7 +331,7 @@ fn find_card_block(body: &str) -> Option<FoundCard> {
     None
 }
 
-fn read_json(path: &Path) -> Result<Value, Box<dyn Error>> {
+pub(crate) fn read_json(path: &Path) -> Result<Value, Box<dyn Error>> {
     Ok(serde_json::from_str(&fs::read_to_string(path)?)?)
 }
 
@@ -341,7 +341,7 @@ fn insert_nonempty(card: &mut Map<String, Value>, key: &str, value: &str) {
     }
 }
 
-fn string_field(value: &Value, key: &str) -> String {
+pub(crate) fn string_field(value: &Value, key: &str) -> String {
     value
         .get(key)
         .and_then(Value::as_str)
@@ -350,7 +350,7 @@ fn string_field(value: &Value, key: &str) -> String {
         .to_string()
 }
 
-fn value_text(value: &Value) -> String {
+pub(crate) fn value_text(value: &Value) -> String {
     match value {
         Value::String(text) => text.clone(),
         Value::Number(number) => number.to_string(),
@@ -368,7 +368,7 @@ fn nonempty_prefix(prefix: &str, value: &str) -> String {
     }
 }
 
-fn nonempty_or(value: &str, fallback: &str) -> String {
+pub(crate) fn nonempty_or(value: &str, fallback: &str) -> String {
     if value.is_empty() {
         fallback.to_string()
     } else {
@@ -382,6 +382,14 @@ fn truncate_chars(value: &str, max: usize) -> String {
     } else {
         value.chars().take(max).collect()
     }
+}
+
+pub(crate) fn json_obj<const N: usize>(items: [(&str, Value); N]) -> Value {
+    let mut object = Map::new();
+    for (key, value) in items {
+        object.insert(key.to_string(), value);
+    }
+    Value::Object(object)
 }
 
 #[cfg(test)]

--- a/crates/airc-cli/src/queue_card_projection.rs
+++ b/crates/airc-cli/src/queue_card_projection.rs
@@ -1,0 +1,584 @@
+use std::error::Error;
+use std::path::Path;
+
+use chrono::{DateTime, Duration, NaiveDateTime, Utc};
+use serde_json::{Map, Value};
+
+use crate::queue_card_commands::{
+    json_obj, nonempty_or, parse_card, read_json, string_field, value_text,
+};
+
+pub fn run_list(
+    repo: &str,
+    filter_owner: &str,
+    filter_status: &str,
+    output_json: bool,
+    raw_json_file: &Path,
+) -> Result<(), Box<dyn Error>> {
+    let issues = read_json(raw_json_file)?;
+    let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let cards = list_cards(&issues, filter_owner, filter_status)?;
+    if output_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json_obj([
+                ("now_utc", Value::String(now)),
+                ("repo", Value::String(repo.to_string())),
+                (
+                    "cards",
+                    Value::Array(cards.iter().map(QueueCardListEntry::json).collect())
+                ),
+            ]))?
+        );
+    } else {
+        render_list(repo, &now, filter_owner, filter_status, &cards);
+    }
+    Ok(())
+}
+
+pub fn run_stale(
+    repo: &str,
+    stale_after: &str,
+    output_json: bool,
+    raw_json_file: &Path,
+) -> Result<(), Box<dyn Error>> {
+    let issues = read_json(raw_json_file)?;
+    let threshold = parse_duration(stale_after)?;
+    let now = Utc::now();
+    let rows = stale_cards(&issues, now, threshold)?;
+    let now_text = now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    if output_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json_obj([
+                ("repo", Value::String(repo.to_string())),
+                ("now", Value::String(now_text)),
+                ("stale_after", Value::String(stale_after.to_string())),
+                (
+                    "cards",
+                    Value::Array(rows.iter().map(StaleCard::json).collect())
+                ),
+            ]))?
+        );
+    } else {
+        render_stale(repo, &now_text, stale_after, &rows);
+    }
+    Ok(())
+}
+
+pub fn run_next(
+    repo: &str,
+    owner: &str,
+    base: &str,
+    repo_root: &str,
+    output_json: bool,
+    raw_json_file: &Path,
+) -> Result<(), Box<dyn Error>> {
+    let issues = read_json(raw_json_file)?;
+    let rows = next_cards(&issues, repo, owner, base, repo_root)?;
+    if output_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json_obj([
+                ("repo", Value::String(repo.to_string())),
+                ("owner", Value::String(owner.to_string())),
+                (
+                    "candidates",
+                    Value::Array(rows.iter().map(NextCard::json).collect())
+                ),
+            ]))?
+        );
+    } else {
+        render_next(repo, owner, &rows);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct QueueCardListEntry {
+    number: Value,
+    title: String,
+    url: String,
+    created_at: String,
+    updated_at: String,
+    card: Map<String, Value>,
+}
+
+impl QueueCardListEntry {
+    fn json(&self) -> Value {
+        json_obj([
+            ("number", self.number.clone()),
+            ("title", Value::String(self.title.clone())),
+            ("url", Value::String(self.url.clone())),
+            ("createdAt", Value::String(self.created_at.clone())),
+            ("updatedAt", Value::String(self.updated_at.clone())),
+            ("card", Value::Object(self.card.clone())),
+        ])
+    }
+}
+
+fn list_cards(
+    issues: &Value,
+    filter_owner: &str,
+    filter_status: &str,
+) -> Result<Vec<QueueCardListEntry>, Box<dyn Error>> {
+    let issues = issues
+        .as_array()
+        .ok_or("queue list: issue JSON must be an array")?;
+    let mut cards = Vec::new();
+    for issue in issues {
+        let card = issue
+            .get("body")
+            .and_then(Value::as_str)
+            .and_then(parse_card)
+            .unwrap_or_default();
+        if !filter_owner.is_empty()
+            && card.get("owner").and_then(Value::as_str).unwrap_or("") != filter_owner
+        {
+            continue;
+        }
+        if !filter_status.is_empty()
+            && card.get("status").and_then(Value::as_str).unwrap_or("") != filter_status
+        {
+            continue;
+        }
+        cards.push(QueueCardListEntry {
+            number: issue.get("number").cloned().unwrap_or(Value::Null),
+            title: clean_title(&string_field(issue, "title")),
+            url: string_field(issue, "url"),
+            created_at: string_field(issue, "createdAt"),
+            updated_at: string_field(issue, "updatedAt"),
+            card,
+        });
+    }
+    Ok(cards)
+}
+
+fn render_list(
+    repo: &str,
+    now: &str,
+    filter_owner: &str,
+    filter_status: &str,
+    cards: &[QueueCardListEntry],
+) {
+    if cards.is_empty() {
+        let mut suffix = String::new();
+        if !filter_owner.is_empty() {
+            suffix.push_str(&format!(" owner={filter_owner}"));
+        }
+        if !filter_status.is_empty() {
+            suffix.push_str(&format!(" status={filter_status}"));
+        }
+        println!("# airc-queue — {repo}");
+        println!("now_utc: {now}");
+        println!("No open airc-queue cards on {repo}{suffix}.");
+        return;
+    }
+    println!("# airc-queue — {repo} ({} open)", cards.len());
+    println!("now_utc: {now}");
+    for entry in cards {
+        println!();
+        println!("## #{} — {}", value_text(&entry.number), entry.title);
+        println!("  url:           {}", entry.url);
+        print_card_field(&entry.card, "id", "id");
+        print_card_field(&entry.card, "branch", "branch");
+        print_card_field(&entry.card, "owner", "owner");
+        print_card_field(&entry.card, "status", "status");
+        print_card_field(&entry.card, "blockers", "blockers");
+        print_card_field(&entry.card, "env", "env");
+        print_card_field(&entry.card, "evidence", "evidence");
+        print_card_field(&entry.card, "next_action", "next");
+        print_card_field(&entry.card, "last_heartbeat", "last heartbeat");
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StaleCard {
+    number: Value,
+    title: String,
+    url: String,
+    status: String,
+    owner: String,
+    last_heartbeat: String,
+    age_seconds: Option<i64>,
+    reason: String,
+    next_action: String,
+}
+
+impl StaleCard {
+    fn json(&self) -> Value {
+        let mut object = Map::new();
+        object.insert("number".to_string(), self.number.clone());
+        object.insert("title".to_string(), Value::String(self.title.clone()));
+        object.insert("url".to_string(), Value::String(self.url.clone()));
+        object.insert("status".to_string(), Value::String(self.status.clone()));
+        object.insert("owner".to_string(), Value::String(self.owner.clone()));
+        object.insert(
+            "last_heartbeat".to_string(),
+            Value::String(self.last_heartbeat.clone()),
+        );
+        object.insert(
+            "age_seconds".to_string(),
+            self.age_seconds
+                .map(|value| Value::Number(value.into()))
+                .unwrap_or(Value::Null),
+        );
+        object.insert("reason".to_string(), Value::String(self.reason.clone()));
+        object.insert(
+            "next_action".to_string(),
+            Value::String(self.next_action.clone()),
+        );
+        Value::Object(object)
+    }
+}
+
+fn stale_cards(
+    issues: &Value,
+    now: DateTime<Utc>,
+    threshold: Duration,
+) -> Result<Vec<StaleCard>, Box<dyn Error>> {
+    let issues = issues
+        .as_array()
+        .ok_or("queue stale: issue JSON must be an array")?;
+    let mut rows = Vec::new();
+    for issue in issues {
+        let Some(card) = issue
+            .get("body")
+            .and_then(Value::as_str)
+            .and_then(parse_card)
+        else {
+            continue;
+        };
+        let card_value = Value::Object(card);
+        let status = nonempty_or(&string_field(&card_value, "status"), "unknown");
+        let mut owner = string_field(&card_value, "owner");
+        if owner == "unclaimed" {
+            owner.clear();
+        }
+        if !matches!(status.as_str(), "claimed" | "in-progress" | "review") {
+            continue;
+        }
+        let heartbeat = string_field(&card_value, "last_heartbeat");
+        let hb_dt = parse_heartbeat(&heartbeat);
+        let mut age_seconds = None;
+        let reason = if owner.is_empty() {
+            "missing-owner".to_string()
+        } else if hb_dt.is_none() {
+            "missing-heartbeat".to_string()
+        } else {
+            let age = now - hb_dt.unwrap();
+            age_seconds = Some(age.num_seconds());
+            if age > threshold {
+                "stale-heartbeat".to_string()
+            } else {
+                String::new()
+            }
+        };
+        if reason.is_empty() {
+            continue;
+        }
+        rows.push(StaleCard {
+            number: issue.get("number").cloned().unwrap_or(Value::Null),
+            title: string_field(issue, "title"),
+            url: string_field(issue, "url"),
+            status,
+            owner,
+            last_heartbeat: heartbeat,
+            age_seconds,
+            reason,
+            next_action: string_field(&card_value, "next_action"),
+        });
+    }
+    Ok(rows)
+}
+
+fn render_stale(repo: &str, now: &str, stale_after: &str, rows: &[StaleCard]) {
+    println!("# airc-queue stale — {repo}");
+    println!("now_utc: {now}");
+    println!("stale_after: {stale_after}");
+    if rows.is_empty() {
+        println!("No stale owned cards found.");
+    }
+    for row in rows {
+        println!();
+        println!("## #{} — {}", value_text(&row.number), row.title);
+        println!("  url:            {}", row.url);
+        println!("  status:         {}", row.status);
+        if !row.owner.is_empty() {
+            println!("  owner:          {}", row.owner);
+        }
+        if !row.last_heartbeat.is_empty() {
+            println!("  last heartbeat: {}", row.last_heartbeat);
+        }
+        if let Some(age) = row.age_seconds {
+            println!("  heartbeat age:  {age}s");
+        }
+        println!("  reason:         {}", row.reason);
+        if !row.next_action.is_empty() {
+            println!("  next:           {}", row.next_action);
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct NextCard {
+    rank: i64,
+    number: Value,
+    title: String,
+    url: String,
+    reference: String,
+    status: String,
+    owner: String,
+    branch: String,
+    environment: String,
+    next_action: String,
+    claim_command: String,
+    lane_command: String,
+}
+
+impl NextCard {
+    fn json(&self) -> Value {
+        json_obj([
+            ("rank", Value::Number(self.rank.into())),
+            ("number", self.number.clone()),
+            ("title", Value::String(self.title.clone())),
+            ("url", Value::String(self.url.clone())),
+            ("ref", Value::String(self.reference.clone())),
+            ("status", Value::String(self.status.clone())),
+            ("owner", Value::String(self.owner.clone())),
+            ("branch", Value::String(self.branch.clone())),
+            ("env", Value::String(self.environment.clone())),
+            ("next_action", Value::String(self.next_action.clone())),
+            ("claim_command", Value::String(self.claim_command.clone())),
+            ("lane_command", Value::String(self.lane_command.clone())),
+        ])
+    }
+}
+
+fn next_cards(
+    issues: &Value,
+    repo: &str,
+    owner: &str,
+    base: &str,
+    repo_root: &str,
+) -> Result<Vec<NextCard>, Box<dyn Error>> {
+    let issues = issues
+        .as_array()
+        .ok_or("queue next: issue JSON must be an array")?;
+    let mut rows = Vec::new();
+    for issue in issues {
+        let Some(card) = issue
+            .get("body")
+            .and_then(Value::as_str)
+            .and_then(parse_card)
+        else {
+            continue;
+        };
+        let card_value = Value::Object(card);
+        let status = nonempty_or(&string_field(&card_value, "status"), "claimed");
+        let mut card_owner = string_field(&card_value, "owner");
+        if card_owner == "unclaimed" {
+            card_owner.clear();
+        }
+        let rank = next_score(&status, &card_owner, owner);
+        if rank >= 9 {
+            continue;
+        }
+        let number = issue.get("number").cloned().unwrap_or(Value::Null);
+        let reference = format!("{repo}#{}", value_text(&number));
+        let branch = string_field(&card_value, "branch");
+        let mut lane_cmd = format!(
+            "airc lane create {} --base {}",
+            shquote(&reference),
+            shquote(base)
+        );
+        if !branch.is_empty() {
+            lane_cmd.push_str(&format!(" --branch {}", shquote(&branch)));
+        }
+        if !repo_root.is_empty() {
+            lane_cmd.push_str(&format!(" --repo {}", shquote(repo_root)));
+        }
+        let claim_command = format!(
+            "airc queue claim {} --owner {}",
+            shquote(&reference),
+            shquote(owner)
+        );
+        rows.push(NextCard {
+            rank,
+            number,
+            title: clean_title(&string_field(issue, "title")),
+            url: string_field(issue, "url"),
+            reference,
+            status,
+            owner: card_owner,
+            branch,
+            environment: string_field(&card_value, "env"),
+            next_action: string_field(&card_value, "next_action"),
+            claim_command,
+            lane_command: lane_cmd,
+        });
+    }
+    rows.sort_by(|left, right| {
+        left.rank
+            .cmp(&right.rank)
+            .then(value_text(&left.number).cmp(&value_text(&right.number)))
+    });
+    Ok(rows)
+}
+
+fn render_next(repo: &str, owner: &str, rows: &[NextCard]) {
+    println!("# airc-queue next — {repo}");
+    println!("owner: {owner}");
+    if rows.is_empty() {
+        println!("No claimable queue cards found.");
+        println!("Try: airc queue nudge {repo} --message \"idle agent looking for work\"");
+    }
+    for (idx, row) in rows.iter().take(10).enumerate() {
+        let owner_label = if row.owner.is_empty() {
+            "(unowned)"
+        } else {
+            &row.owner
+        };
+        println!();
+        println!("## {}. {} — {}", idx + 1, row.reference, row.title);
+        println!("  status: {} owner={owner_label}", row.status);
+        if !row.environment.is_empty() {
+            println!("  env:    {}", row.environment);
+        }
+        if !row.branch.is_empty() {
+            println!("  branch: {}", row.branch);
+        }
+        if !row.next_action.is_empty() {
+            println!("  next:   {}", row.next_action);
+        }
+        println!("  claim:  {}", row.claim_command);
+        println!("  lane:   {}", row.lane_command);
+    }
+}
+
+fn clean_title(title: &str) -> String {
+    title
+        .strip_prefix("airc-queue: ")
+        .unwrap_or(title)
+        .to_string()
+}
+
+fn print_card_field(card: &Map<String, Value>, key: &str, label: &str) {
+    let value = card
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty());
+    if let Some(value) = value {
+        let label = format!("{label}:");
+        println!("  {label:<15}{value}");
+    }
+}
+
+fn parse_duration(value: &str) -> Result<Duration, Box<dyn Error>> {
+    let value = value.trim();
+    if value.len() < 2 {
+        return Err(format!("cannot parse duration '{value}' (use 30m, 2h, 1d)").into());
+    }
+    let (amount, unit) = value.split_at(value.len() - 1);
+    let amount: i64 = amount
+        .trim()
+        .parse()
+        .map_err(|_| format!("cannot parse duration '{value}' (use 30m, 2h, 1d)"))?;
+    match unit {
+        "s" => Ok(Duration::seconds(amount)),
+        "m" => Ok(Duration::minutes(amount)),
+        "h" => Ok(Duration::hours(amount)),
+        "d" => Ok(Duration::days(amount)),
+        _ => Err(format!("cannot parse duration '{value}' (use 30m, 2h, 1d)").into()),
+    }
+}
+
+fn parse_heartbeat(value: &str) -> Option<DateTime<Utc>> {
+    let value = value.trim();
+    let start = value.find(|ch: char| ch.is_ascii_digit())?;
+    let tail = &value[start..];
+    for len in [20usize, 17usize] {
+        if tail.len() < len {
+            continue;
+        }
+        let raw = &tail[..len];
+        if len == 20 {
+            if let Ok(dt) = NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H:%M:%SZ") {
+                return Some(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc));
+            }
+        } else if let Ok(dt) = NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H:%MZ") {
+            return Some(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc));
+        }
+    }
+    None
+}
+
+fn next_score(status: &str, card_owner: &str, owner: &str) -> i64 {
+    match (status, card_owner.is_empty(), card_owner == owner) {
+        ("claimed", true, _) => 0,
+        ("claimed", false, _) => 1,
+        ("blocked", true, _) => 2,
+        ("review", _, _) => 3,
+        ("in-progress", _, true) => 4,
+        _ => 9,
+    }
+}
+
+fn shquote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn list_cards_filters_owner_and_status() {
+        let issues = json!([
+            {"number":1,"title":"airc-queue: A","url":"u","body":"```json\n{\"kind\":\"airc-queue-card-v1\",\"owner\":\"codex\",\"status\":\"claimed\"}\n```"},
+            {"number":2,"title":"B","url":"u","body":"```json\n{\"kind\":\"airc-queue-card-v1\",\"owner\":\"other\",\"status\":\"claimed\"}\n```"}
+        ]);
+
+        let cards = list_cards(&issues, "codex", "claimed").unwrap();
+
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].title, "A");
+    }
+
+    #[test]
+    fn stale_cards_detects_missing_heartbeat() {
+        let issues = json!([{
+            "number": 1,
+            "title": "A",
+            "url": "u",
+            "body": "```json\n{\"kind\":\"airc-queue-card-v1\",\"owner\":\"codex\",\"status\":\"in-progress\"}\n```"
+        }]);
+
+        let rows = stale_cards(&issues, Utc::now(), Duration::minutes(30)).unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].reason, "missing-heartbeat");
+    }
+
+    #[test]
+    fn next_cards_ranks_claimable_cards() {
+        let issues = json!([
+            {"number":2,"title":"B","url":"u","body":"```json\n{\"kind\":\"airc-queue-card-v1\",\"owner\":\"codex\",\"status\":\"in-progress\"}\n```"},
+            {"number":1,"title":"A","url":"u","body":"```json\n{\"kind\":\"airc-queue-card-v1\",\"owner\":\"\",\"status\":\"claimed\",\"branch\":\"feat/a\"}\n```"}
+        ]);
+
+        let rows = next_cards(
+            &issues,
+            "CambrianTech/airc",
+            "codex",
+            "rust-rewrite",
+            "/repo",
+        )
+        .unwrap();
+
+        assert_eq!(rows[0].reference, "CambrianTech/airc#1");
+        assert!(rows[0].lane_command.contains("--branch 'feat/a'"));
+        assert!(rows[0].claim_command.contains("--owner 'codex'"));
+    }
+}

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -540,84 +540,13 @@ _cmd_queue_list() {
     die "queue list: gh issue list failed: $raw_json"
   fi
 
-  # Parse + filter + render via python (more robust than bash jq + grep
-  # gymnastics on multi-line bodies). The issue JSON goes through a temp
-  # file because `python - <<'PYEOF'` already consumes stdin for the script.
   local raw_json_file
   raw_json_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-list.XXXXXX") || die "queue list: mktemp failed"
   printf '%s' "$raw_json" >"$raw_json_file"
 
-  "$AIRC_PYTHON" - \
-      "$target_repo" "$filter_owner" "$filter_status" "$output_json" "$raw_json_file" \
-      <<'PYEOF'
-import datetime, json, re, sys
-repo = sys.argv[1]
-filter_owner = sys.argv[2]
-filter_status = sys.argv[3]
-output_json = sys.argv[4] == "1"
-raw_json_file = sys.argv[5]
-now_utc = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
-
-with open(raw_json_file, "r", encoding="utf-8") as f:
-    data = json.loads(f.read())
-
-CARD_BLOCK_RE = re.compile(r'```json\s*\n(.*?)\n\s*```', re.DOTALL)
-
-def parse_card(body: str) -> dict:
-    """Find the first ```json``` block that looks like a queue card."""
-    for match in CARD_BLOCK_RE.finditer(body or ""):
-        try:
-            parsed = json.loads(match.group(1).strip())
-        except Exception:
-            continue
-        if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
-            return parsed
-    return {}
-
-cards = []
-for issue in data:
-    card = parse_card(issue.get("body", ""))
-    if filter_owner and card.get("owner", "") != filter_owner:
-        continue
-    if filter_status and card.get("status", "") != filter_status:
-        continue
-    cards.append({
-        "number": issue.get("number"),
-        "title": issue.get("title", "").replace("airc-queue: ", "", 1),
-        "url": issue.get("url"),
-        "createdAt": issue.get("createdAt"),
-        "updatedAt": issue.get("updatedAt"),
-        "card": card,
-    })
-
-if output_json:
-    print(json.dumps({"now_utc": now_utc, "repo": repo, "cards": cards}, indent=2))
-else:
-    if not cards:
-        suffix = ""
-        if filter_owner: suffix += f" owner={filter_owner}"
-        if filter_status: suffix += f" status={filter_status}"
-        print(f"# airc-queue — {repo}")
-        print(f"now_utc: {now_utc}")
-        print(f"No open airc-queue cards on {repo}{suffix}.")
-        sys.exit(0)
-    print(f"# airc-queue — {repo} ({len(cards)} open)")
-    print(f"now_utc: {now_utc}")
-    for entry in cards:
-        c = entry["card"]
-        print()
-        print(f"## #{entry['number']} — {entry['title']}")
-        print(f"  url:           {entry['url']}")
-        if c.get("id"):              print(f"  id:            {c['id']}")
-        if c.get("branch"):          print(f"  branch:        {c['branch']}")
-        if c.get("owner"):           print(f"  owner:         {c['owner']}")
-        if c.get("status"):          print(f"  status:        {c['status']}")
-        if c.get("blockers"):        print(f"  blockers:      {c['blockers']}")
-        if c.get("env"):             print(f"  env:           {c['env']}")
-        if c.get("evidence"):        print(f"  evidence:      {c['evidence']}")
-        if c.get("next_action"):     print(f"  next:          {c['next_action']}")
-        if c.get("last_heartbeat"):  print(f"  last heartbeat:{c['last_heartbeat']}")
-PYEOF
+  local list_args=(queue-card list --repo "$target_repo" --owner "$filter_owner" --status "$filter_status" --raw-json-file "$raw_json_file")
+  [ "$output_json" -eq 1 ] && list_args+=(--json)
+  "$(airc_rs_bin)" "${list_args[@]}"
   local py_status=$?
   rm -f "$raw_json_file"
   if [ "$py_status" -eq 0 ] && [ "$output_json" -eq 0 ] && [ "$check_staleness" -eq 1 ]; then
@@ -1136,114 +1065,9 @@ _cmd_queue_stale() {
   raw_json_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-stale.XXXXXX") || die "queue stale: mktemp failed"
   printf '%s' "$raw_json" >"$raw_json_file"
 
-  "$AIRC_PYTHON" - "$target_repo" "$stale_after" "$output_json" "$raw_json_file" <<'PYEOF'
-import json, re, sys
-from datetime import datetime, timezone, timedelta
-
-repo, stale_after, output_json_s, path = sys.argv[1:5]
-output_json = output_json_s == "1"
-
-def parse_duration(value: str) -> timedelta:
-    m = re.fullmatch(r"\s*(\d+)\s*([smhd])\s*", value or "")
-    if not m:
-        print(f"queue stale: cannot parse --stale-after '{value}' (use 30m, 2h, 1d)", file=sys.stderr)
-        sys.exit(2)
-    amount = int(m.group(1))
-    unit = m.group(2)
-    if unit == "s":
-        return timedelta(seconds=amount)
-    if unit == "m":
-        return timedelta(minutes=amount)
-    if unit == "h":
-        return timedelta(hours=amount)
-    return timedelta(days=amount)
-
-def parse_card(body: str):
-    for m in re.finditer(r"```json\s*\n(.*?)\n\s*```", body or "", re.DOTALL):
-        try:
-            parsed = json.loads(m.group(1).strip())
-        except Exception:
-            continue
-        if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
-            return parsed
-    return None
-
-def parse_heartbeat(value: str):
-    if not value:
-        return None
-    m = re.search(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?Z)", value)
-    if not m:
-        return None
-    raw = m.group(1)
-    fmt = "%Y-%m-%dT%H:%M:%SZ" if raw.count(":") == 2 else "%Y-%m-%dT%H:%MZ"
-    return datetime.strptime(raw, fmt).replace(tzinfo=timezone.utc)
-
-with open(path, "r", encoding="utf-8") as f:
-    issues = json.load(f)
-
-threshold = parse_duration(stale_after)
-now = datetime.now(timezone.utc)
-rows = []
-for issue in issues:
-    card = parse_card(issue.get("body", ""))
-    if not card:
-        continue
-    status = (card.get("status") or "").strip()
-    owner = (card.get("owner") or "").strip()
-    if owner == "unclaimed":
-        owner = ""
-    if status not in {"claimed", "in-progress", "review"}:
-        continue
-    reason = ""
-    heartbeat = (card.get("last_heartbeat") or "").strip()
-    hb_dt = parse_heartbeat(heartbeat)
-    age_seconds = None
-    if not owner:
-        reason = "missing-owner"
-    elif not hb_dt:
-        reason = "missing-heartbeat"
-    else:
-        age = now - hb_dt
-        age_seconds = int(age.total_seconds())
-        if age > threshold:
-            reason = "stale-heartbeat"
-    if not reason:
-        continue
-    rows.append({
-        "number": issue.get("number"),
-        "title": issue.get("title") or "",
-        "url": issue.get("url") or "",
-        "status": status or "unknown",
-        "owner": owner,
-        "last_heartbeat": heartbeat,
-        "age_seconds": age_seconds,
-        "reason": reason,
-        "next_action": card.get("next_action") or "",
-    })
-
-if output_json:
-    print(json.dumps({"repo": repo, "now": now.isoformat().replace("+00:00", "Z"), "stale_after": stale_after, "cards": rows}, indent=2))
-else:
-    print(f"# airc-queue stale — {repo}")
-    print(f"now_utc: {now.isoformat().replace('+00:00', 'Z')}")
-    print(f"stale_after: {stale_after}")
-    if not rows:
-        print("No stale owned cards found.")
-    for row in rows:
-        print()
-        print(f"## #{row['number']} — {row['title']}")
-        print(f"  url:            {row['url']}")
-        print(f"  status:         {row['status']}")
-        if row["owner"]:
-            print(f"  owner:          {row['owner']}")
-        if row["last_heartbeat"]:
-            print(f"  last heartbeat: {row['last_heartbeat']}")
-        if row["age_seconds"] is not None:
-            print(f"  heartbeat age:  {row['age_seconds']}s")
-        print(f"  reason:         {row['reason']}")
-        if row["next_action"]:
-            print(f"  next:           {row['next_action']}")
-PYEOF
+  local stale_args=(queue-card stale --repo "$target_repo" --stale-after "$stale_after" --raw-json-file "$raw_json_file")
+  [ "$output_json" -eq 1 ] && stale_args+=(--json)
+  "$(airc_rs_bin)" "${stale_args[@]}"
   local py_status=$?
   rm -f "$raw_json_file"
   return "$py_status"
@@ -1325,109 +1149,9 @@ _cmd_queue_next() {
   raw_json_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-next.XXXXXX") || die "queue next: mktemp failed"
   printf '%s' "$raw_json" >"$raw_json_file"
 
-  AIRC_QUEUE_NEXT_OWNER="$owner" \
-  AIRC_QUEUE_NEXT_BASE="$base" \
-  AIRC_QUEUE_NEXT_REPO_ROOT="$repo_root" \
-  "$AIRC_PYTHON" - "$target_repo" "$output_json" "$raw_json_file" <<'PYEOF'
-import json, os, re, sys
-
-repo, output_json_raw, path = sys.argv[1:4]
-output_json = output_json_raw == "1"
-owner = os.environ.get("AIRC_QUEUE_NEXT_OWNER", "anonymous")
-base = os.environ.get("AIRC_QUEUE_NEXT_BASE", "canary")
-repo_root = os.environ.get("AIRC_QUEUE_NEXT_REPO_ROOT", "")
-
-CARD_BLOCK_RE = re.compile(r'```json\s*\n(.*?)\n\s*```', re.DOTALL)
-
-def parse_card(body: str):
-    for m in CARD_BLOCK_RE.finditer(body or ""):
-        try:
-            parsed = json.loads(m.group(1).strip())
-        except Exception:
-            continue
-        if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
-            return parsed
-    return None
-
-def shquote(value: str) -> str:
-    return "'" + value.replace("'", "'\"'\"'") + "'"
-
-def score(status: str, card_owner: str) -> int:
-    if status == "claimed" and not card_owner:
-        return 0
-    if status == "claimed":
-        return 1
-    if status == "blocked" and not card_owner:
-        return 2
-    if status == "review":
-        return 3
-    if status == "in-progress" and card_owner == owner:
-        return 4
-    return 9
-
-with open(path, "r", encoding="utf-8") as f:
-    issues = json.load(f)
-
-rows = []
-for issue in issues:
-    card = parse_card(issue.get("body", "") or "")
-    if not card:
-        continue
-    status = (card.get("status") or "claimed").strip()
-    card_owner = (card.get("owner") or "").strip()
-    if card_owner == "unclaimed":
-        card_owner = ""
-    rank = score(status, card_owner)
-    if rank >= 9:
-        continue
-    ref = f"{repo}#{issue.get('number')}"
-    branch = (card.get("branch") or "").strip()
-    lane_cmd = f"airc lane create {shquote(ref)} --base {shquote(base)}"
-    if branch:
-        lane_cmd += f" --branch {shquote(branch)}"
-    if repo_root:
-        lane_cmd += f" --repo {shquote(repo_root)}"
-    claim_cmd = f"airc queue claim {shquote(ref)} --owner {shquote(owner)}"
-    rows.append({
-        "rank": rank,
-        "number": issue.get("number"),
-        "title": (issue.get("title") or "").replace("airc-queue: ", "", 1),
-        "url": issue.get("url") or "",
-        "ref": ref,
-        "status": status,
-        "owner": card_owner,
-        "branch": branch,
-        "env": card.get("env") or "",
-        "next_action": card.get("next_action") or "",
-        "claim_command": claim_cmd,
-        "lane_command": lane_cmd,
-    })
-
-rows.sort(key=lambda r: (r["rank"], r["number"] or 0))
-payload = {"repo": repo, "owner": owner, "candidates": rows}
-
-if output_json:
-    print(json.dumps(payload, indent=2))
-else:
-    print(f"# airc-queue next — {repo}")
-    print(f"owner: {owner}")
-    if not rows:
-        print("No claimable queue cards found.")
-        print(f"Try: airc queue nudge {repo} --message \"idle agent looking for work\"")
-    for idx, row in enumerate(rows[:10], start=1):
-        owner_label = row["owner"] or "(unowned)"
-        print()
-        print(f"## {idx}. {row['ref']} — {row['title']}")
-        print(f"  status: {row['status']} owner={owner_label}")
-        if row["env"]:
-            print(f"  env:    {row['env']}")
-        if row["branch"]:
-            print(f"  branch: {row['branch']}")
-        if row["next_action"]:
-            print(f"  next:   {row['next_action']}")
-        print(f"  claim:  {row['claim_command']}")
-        print(f"  lane:   {row['lane_command']}")
-PYEOF
+  local next_args=(queue-card next --repo "$target_repo" --owner "$owner" --base "$base" --repo-root "$repo_root" --raw-json-file "$raw_json_file")
+  [ "$output_json" -eq 1 ] && next_args+=(--json)
+  "$(airc_rs_bin)" "${next_args[@]}"
   local py_status=$?
   rm -f "$raw_json_file"
   if [ "$py_status" -ne 0 ]; then

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -300,6 +300,9 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" queue-card nudge-summary', combined)
         self.assertIn('"$(airc_rs_bin)" queue-card nudge-card-meta', combined)
         self.assertNotIn("AIRC_PYTHON", (REPO / "lib/airc_bash/cmd_queue_card.sh").read_text(encoding="utf-8"))
+        self.assertIn("queue-card list", combined)
+        self.assertIn("queue-card stale", combined)
+        self.assertIn("queue-card next", combined)
 
     def test_message_crypto_helpers_use_airc_rs(self):
         combined = "\n".join(


### PR DESCRIPTION
Summary
- add Rust queue-card list/stale/next projections
- route queue list/stale/next shell commands through airc-rs instead of inline Python
- split queue card projections into their own module to keep command files smaller
- extend cutover guard for the new Rust queue projection paths

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli queue_card
- python3 test/test_codex_rust_cutover.py
- bash -n lib/airc_bash/cmd_queue.sh
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-cli
- cargo fmt --manifest-path Cargo.toml --all --check
- bash -n airc lib/airc_bash/*.sh
- cargo test --manifest-path Cargo.toml --workspace
- smoke: airc-rs queue-card list/next/stale with synthetic issue JSON