### PR TITLE
feat(airc-cli): move queue staleness metadata to Rust

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -60,6 +60,7 @@ mod queue_card_cli;
 mod queue_card_commands;
 mod queue_card_projection;
 mod queue_card_runtime;
+mod queue_card_staleness;
 mod route_cli;
 mod route_commands;
 mod scope_cli;
@@ -907,6 +908,11 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 &cards_file,
                 &messages_file,
             ),
+            QueueCardAction::ReviewRefs {
+                repo,
+                raw_json_file,
+            } => queue_card_staleness::run_review_refs(&repo, &raw_json_file),
+            QueueCardAction::PrMeta { pr_file } => queue_card_staleness::run_pr_meta(&pr_file),
         },
 
         Command::Humanhash { hex_input, words } => {

--- a/crates/airc-cli/src/queue_card_cli.rs
+++ b/crates/airc-cli/src/queue_card_cli.rs
@@ -157,4 +157,18 @@ pub enum QueueCardAction {
         #[arg(long)]
         messages_file: PathBuf,
     },
+
+    /// Extract PR refs from review-status queue cards for staleness sweeps.
+    ReviewRefs {
+        #[arg(long)]
+        repo: String,
+        #[arg(long)]
+        raw_json_file: PathBuf,
+    },
+
+    /// Print base/head/url metadata from gh pr view JSON.
+    PrMeta {
+        #[arg(long)]
+        pr_file: PathBuf,
+    },
 }

--- a/crates/airc-cli/src/queue_card_staleness.rs
+++ b/crates/airc-cli/src/queue_card_staleness.rs
@@ -1,0 +1,164 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::queue_card_commands::{parse_card, read_json, string_field};
+
+pub fn run_review_refs(repo: &str, raw_json_file: &Path) -> Result<(), Box<dyn Error>> {
+    let issues = read_json(raw_json_file)?;
+    let issues = issues
+        .as_array()
+        .ok_or("queue staleness refs: issue JSON must be an array")?;
+    for issue in issues {
+        let Some(card) = issue
+            .get("body")
+            .and_then(Value::as_str)
+            .and_then(parse_card)
+        else {
+            continue;
+        };
+        let card_value = Value::Object(card);
+        if string_field(&card_value, "status") != "review" {
+            continue;
+        }
+        let text = [
+            string_field(issue, "title"),
+            string_field(issue, "body"),
+            string_field(&card_value, "next_action"),
+            string_field(&card_value, "evidence"),
+        ]
+        .join("\n");
+        if let Some(reference) = first_ref(repo, &text) {
+            println!("{reference}");
+        }
+    }
+    Ok(())
+}
+
+pub fn run_pr_meta(pr_file: &Path) -> Result<(), Box<dyn Error>> {
+    let pr = read_json(pr_file)?;
+    println!(
+        "{}\t{}\t{}",
+        string_field(&pr, "baseRefName"),
+        string_field(&pr, "headRefName"),
+        string_field(&pr, "url")
+    );
+    Ok(())
+}
+
+fn first_ref(repo: &str, text: &str) -> Option<String> {
+    extract_refs(repo, text).into_iter().next()
+}
+
+fn extract_refs(repo: &str, text: &str) -> BTreeSet<String> {
+    let mut refs = BTreeSet::new();
+    for raw in text.split(|ch: char| {
+        ch.is_whitespace() || matches!(ch, '`' | '"' | '\'' | '<' | '>' | '(' | ')' | '[' | ']')
+    }) {
+        let token = raw.trim_matches(|ch: char| matches!(ch, ',' | '.' | ':' | ';' | '!' | '?'));
+        if token.is_empty() {
+            continue;
+        }
+        if let Some(reference) = github_url_ref(token) {
+            refs.insert(reference);
+            continue;
+        }
+        if let Some(reference) = owner_repo_ref(token) {
+            refs.insert(reference);
+            continue;
+        }
+        if let Some(number) = local_issue_ref(token) {
+            refs.insert(format!("{repo}#{number}"));
+        }
+    }
+    refs
+}
+
+fn github_url_ref(token: &str) -> Option<String> {
+    let path = token.strip_prefix("https://github.com/")?;
+    let parts = path.split('/').collect::<Vec<_>>();
+    if parts.len() < 4 || !matches!(parts[2], "pull" | "pulls") || !is_digits(parts[3]) {
+        return None;
+    }
+    Some(format!("{}/{}#{}", parts[0], parts[1], parts[3]))
+}
+
+fn owner_repo_ref(token: &str) -> Option<String> {
+    let (repo, number) = token.split_once('#')?;
+    let (owner, name) = repo.split_once('/')?;
+    if owner.is_empty() || name.is_empty() || !is_digits(number) {
+        return None;
+    }
+    if !owner.chars().all(is_repo_char) || !name.chars().all(is_repo_char) {
+        return None;
+    }
+    Some(format!("{owner}/{name}#{number}"))
+}
+
+fn local_issue_ref(token: &str) -> Option<&str> {
+    let number = token.strip_prefix('#')?;
+    is_digits(number).then_some(number)
+}
+
+fn is_repo_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-')
+}
+
+fn is_digits(value: &str) -> bool {
+    !value.is_empty() && value.chars().all(|ch| ch.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::fs;
+
+    #[test]
+    fn refs_extract_github_url_repo_ref_and_local_ref() {
+        let refs = extract_refs(
+            "CambrianTech/airc",
+            "see https://github.com/CambrianTech/airc/pull/755, other/repo#12 and #9",
+        );
+
+        assert!(refs.contains("CambrianTech/airc#755"));
+        assert!(refs.contains("other/repo#12"));
+        assert!(refs.contains("CambrianTech/airc#9"));
+    }
+
+    #[test]
+    fn review_refs_only_prints_review_cards() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("issues.json");
+        fs::write(
+            &file,
+            json!([
+                {"title":"A #1","body":"```json\n{\"kind\":\"airc-queue-card-v1\",\"status\":\"claimed\"}\n```"},
+                {"title":"B #2","body":"```json\n{\"kind\":\"airc-queue-card-v1\",\"status\":\"review\"}\n```"}
+            ])
+            .to_string(),
+        )
+        .unwrap();
+
+        let issues = read_json(&file).unwrap();
+        let refs = issues
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|issue| {
+                let card = issue
+                    .get("body")
+                    .and_then(Value::as_str)
+                    .and_then(parse_card)?;
+                let card_value = Value::Object(card);
+                (string_field(&card_value, "status") == "review")
+                    .then(|| first_ref("CambrianTech/airc", &string_field(issue, "title")))
+                    .flatten()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(refs, vec!["CambrianTech/airc#2"]);
+    }
+}

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -593,42 +593,7 @@ _airc_queue_list_staleness_sweep() {
   refs_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-list-stale-refs.XXXXXX") || { rm -f "$raw_json_file"; return 1; }
   printf '%s' "$raw_json" >"$raw_json_file"
 
-  "$AIRC_PYTHON" - "$target_repo" "$raw_json_file" >"$refs_file" <<'PYEOF'
-import json, re, sys
-repo, path = sys.argv[1:3]
-with open(path, "r", encoding="utf-8") as f:
-    issues = json.load(f)
-card_re = re.compile(r'```json\s*\n(.*?)\n\s*```', re.DOTALL)
-for issue in issues:
-    card = {}
-    for m in card_re.finditer(issue.get("body", "") or ""):
-        try:
-            parsed = json.loads(m.group(1).strip())
-        except Exception:
-            continue
-        if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
-            card = parsed
-            break
-    if (card.get("status") or "").strip() != "review":
-        continue
-    text = "\n".join([
-        str(issue.get("title") or ""),
-        str(issue.get("body") or ""),
-        str(card.get("next_action") or ""),
-        str(card.get("evidence") or ""),
-    ])
-    refs = []
-    for m in re.finditer(r'https://github\.com/([^/]+/[^/]+)/(?:pull|pulls)/(\d+)|\b([A-Za-z0-9][A-Za-z0-9._-]*)/([A-Za-z0-9][A-Za-z0-9._-]*)#(\d+)\b|(?<![A-Za-z0-9_/])#(\d+)\b', text):
-        if m.group(1):
-            refs.append(f"{m.group(1)}#{m.group(2)}")
-        elif m.group(3):
-            refs.append(f"{m.group(3)}/{m.group(4)}#{m.group(5)}")
-        elif m.group(6):
-            refs.append(f"{repo}#{m.group(6)}")
-    for ref in dict.fromkeys(refs):
-        print(ref)
-        break
-PYEOF
+  "$(airc_rs_bin)" queue-card review-refs --repo "$target_repo" --raw-json-file "$raw_json_file" >"$refs_file"
 
   if [ -s "$refs_file" ]; then
     printf '\n# staleness sweep — review cards\n'
@@ -1963,13 +1928,7 @@ _cmd_queue_staleness() {
     local pr_file pr_meta
     pr_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-staleness-pr.XXXXXX") || die "queue staleness: mktemp failed"
     printf '%s' "$pr_blob" >"$pr_file"
-    if ! pr_meta=$("$AIRC_PYTHON" - "$pr_file" <<'PYEOF'
-import json, sys
-with open(sys.argv[1], "r", encoding="utf-8") as f:
-    pr = json.load(f)
-print(f"{pr.get('baseRefName') or ''}\t{pr.get('headRefName') or ''}\t{pr.get('url') or ''}")
-PYEOF
-    ); then
+    if ! pr_meta=$("$(airc_rs_bin)" queue-card pr-meta --pr-file "$pr_file"); then
       rm -f "$pr_file"
       die "queue staleness: PR JSON parse failed"
     fi

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -305,6 +305,8 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn("queue-card next", combined)
         self.assertIn("queue-card pongs", combined)
         self.assertIn("queue-card availability", combined)
+        self.assertIn("queue-card review-refs", combined)
+        self.assertIn("queue-card pr-meta", combined)
 
     def test_message_crypto_helpers_use_airc_rs(self):
         combined = "\n".join(


### PR DESCRIPTION
Summary
- add Rust queue-card review-refs and pr-meta helpers
- route review-card staleness ref extraction and PR metadata parsing through airc-rs
- leave only the full staleness diff analyzer on the remaining Python path
- extend cutover guard for the new staleness metadata Rust paths

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli queue_card_staleness
- python3 test/test_codex_rust_cutover.py
- bash -n lib/airc_bash/cmd_queue.sh
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-cli
- cargo test --manifest-path Cargo.toml --workspace