### PR TITLE
feat(airc-cli): move queue close-merged parsing to Rust

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -988,6 +988,15 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     base_new_file: &base_new_file,
                 },
             ),
+            QueueCardAction::CloseMergedMeta { pr_file } => {
+                queue_card_commands::run_close_merged_meta(&pr_file)
+            }
+            QueueCardAction::CloseMergedRefs { pr_file, repo } => {
+                queue_card_commands::run_close_merged_refs(&pr_file, &repo)
+            }
+            QueueCardAction::CardStatus { body_file } => {
+                queue_card_commands::run_card_status(&body_file)
+            }
         },
 
         Command::Humanhash { hex_input, words } => {

--- a/crates/airc-cli/src/queue_card_cli.rs
+++ b/crates/airc-cli/src/queue_card_cli.rs
@@ -203,4 +203,24 @@ pub enum QueueCardAction {
         #[arg(long)]
         base_new_file: PathBuf,
     },
+
+    /// Print close-merged metadata from gh pr view JSON.
+    CloseMergedMeta {
+        #[arg(long)]
+        pr_file: PathBuf,
+    },
+
+    /// Extract close-merged queue refs from gh pr view JSON.
+    CloseMergedRefs {
+        #[arg(long)]
+        pr_file: PathBuf,
+        #[arg(long)]
+        repo: String,
+    },
+
+    /// Print queue-card status from an issue body file.
+    CardStatus {
+        #[arg(long)]
+        body_file: PathBuf,
+    },
 }

--- a/crates/airc-cli/src/queue_card_commands.rs
+++ b/crates/airc-cli/src/queue_card_commands.rs
@@ -90,6 +90,53 @@ pub fn run_nudge_card_meta(issue_file: &Path) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+pub fn run_close_merged_meta(pr_file: &Path) -> Result<(), Box<dyn Error>> {
+    let pr = read_json(pr_file)?;
+    let merge_commit = pr.get("mergeCommit").and_then(Value::as_object);
+    let sha = merge_commit
+        .and_then(|commit| commit.get("oid"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let title = string_field(&pr, "title");
+    let body = string_field(&pr, "body");
+    println!(
+        "{}\t{}\t{}\t{}\t{}\t{}",
+        string_field(&pr, "mergedAt"),
+        string_field(&pr, "baseRefName"),
+        sha,
+        string_field(&pr, "url"),
+        title.chars().count(),
+        body.chars().count()
+    );
+    Ok(())
+}
+
+pub fn run_close_merged_refs(pr_file: &Path, default_repo: &str) -> Result<(), Box<dyn Error>> {
+    let pr = read_json(pr_file)?;
+    let title = string_field(&pr, "title");
+    let body = string_field(&pr, "body");
+    for reference in close_merged_refs(&format!("{title}\n{body}"), default_repo) {
+        println!("{reference}");
+    }
+    Ok(())
+}
+
+pub fn run_card_status(body_file: &Path) -> Result<(), Box<dyn Error>> {
+    let body = fs::read_to_string(body_file)?;
+    match parse_card(&body) {
+        Some(card) => {
+            let status = string_field(&Value::Object(card), "status");
+            if status.is_empty() {
+                println!("unknown");
+            } else {
+                println!("{status}");
+            }
+        }
+        None => println!("not-a-card"),
+    }
+    Ok(())
+}
+
 fn build_body(input: QueueCardInput) -> Result<String, Box<dyn Error>> {
     let mut card = Map::new();
     card.insert("kind".to_string(), Value::String(CARD_KIND.to_string()));
@@ -292,6 +339,180 @@ fn nudge_card_meta(issue: &Value) -> Result<(String, String, String, String), Bo
         string_field(&card_value, "owner"),
         string_field(&card_value, "branch"),
     ))
+}
+
+fn close_merged_refs(text: &str, default_repo: &str) -> Vec<String> {
+    let mut refs = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    let mut cursor = 0;
+    while cursor < text.len() {
+        let Some((keyword_start, keyword_end)) = next_closing_keyword(text, cursor) else {
+            break;
+        };
+        let mut pos = skip_spaces_and_colon(text, keyword_end);
+        let mut first = true;
+        loop {
+            if !first {
+                let Some(next_pos) = skip_ref_separator(text, pos) else {
+                    break;
+                };
+                pos = next_pos;
+            }
+            let Some((reference, end)) = parse_close_ref(text, pos, default_repo) else {
+                break;
+            };
+            if seen.insert(reference.clone()) {
+                refs.push(reference);
+            }
+            pos = end;
+            first = false;
+        }
+        if pos == skip_spaces_and_colon(text, keyword_end) {
+            cursor = keyword_start
+                + text[keyword_start..]
+                    .chars()
+                    .next()
+                    .map_or(1, char::len_utf8);
+        } else {
+            cursor = pos;
+        }
+    }
+    refs
+}
+
+fn next_closing_keyword(text: &str, start: usize) -> Option<(usize, usize)> {
+    let lower = text[start..].to_ascii_lowercase();
+    let keywords = [
+        "closes", "closed", "close", "fixes", "fixed", "fix", "resolves", "resolved", "resolve",
+    ];
+    let mut best: Option<(usize, usize)> = None;
+    for keyword in keywords {
+        let mut search_from = 0;
+        while let Some(relative) = lower[search_from..].find(keyword) {
+            let begin = start + search_from + relative;
+            let end = begin + keyword.len();
+            if is_word_start_boundary(text, begin) && is_word_end_boundary(text, end) {
+                match best {
+                    Some((best_begin, _)) if begin >= best_begin => {}
+                    _ => best = Some((begin, end)),
+                }
+                break;
+            }
+            search_from += relative + keyword.len();
+        }
+    }
+    best
+}
+
+fn is_word_start_boundary(text: &str, index: usize) -> bool {
+    !matches!(
+        text[..index].chars().next_back(),
+        Some(ch) if ch.is_ascii_alphanumeric() || ch == '_'
+    )
+}
+
+fn is_word_end_boundary(text: &str, index: usize) -> bool {
+    !matches!(
+        text[index..].chars().next(),
+        Some(ch) if ch.is_ascii_alphanumeric() || ch == '_'
+    )
+}
+
+fn skip_spaces_and_colon(text: &str, mut pos: usize) -> usize {
+    while let Some(ch) = text[pos..].chars().next() {
+        if ch.is_whitespace() || ch == ':' {
+            pos += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    pos
+}
+
+fn skip_ref_separator(text: &str, mut pos: usize) -> Option<usize> {
+    while let Some(ch) = text[pos..].chars().next() {
+        if ch.is_whitespace() {
+            pos += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    if text[pos..].starts_with(',') {
+        pos += 1;
+        while let Some(ch) = text[pos..].chars().next() {
+            if ch.is_whitespace() {
+                pos += ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+        return Some(pos);
+    }
+    let rest = &text[pos..];
+    if rest.len() >= 3
+        && rest[..3].eq_ignore_ascii_case("and")
+        && is_word_end_boundary(text, pos + 3)
+    {
+        pos += 3;
+        while let Some(ch) = text[pos..].chars().next() {
+            if ch.is_whitespace() {
+                pos += ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+        return Some(pos);
+    }
+    None
+}
+
+fn parse_close_ref(text: &str, pos: usize, default_repo: &str) -> Option<(String, usize)> {
+    if text[pos..].starts_with('#') {
+        let (num, end) = parse_digits(text, pos + 1)?;
+        return Some((format!("{default_repo}#{num}"), end));
+    }
+    let (owner, after_owner) = parse_repo_part(text, pos)?;
+    if !text[after_owner..].starts_with('/') {
+        return None;
+    }
+    let (repo, after_repo) = parse_repo_part(text, after_owner + 1)?;
+    if !text[after_repo..].starts_with('#') {
+        return None;
+    }
+    let (num, end) = parse_digits(text, after_repo + 1)?;
+    Some((format!("{owner}/{repo}#{num}"), end))
+}
+
+fn parse_repo_part(text: &str, mut pos: usize) -> Option<(String, usize)> {
+    let start = pos;
+    while let Some(ch) = text[pos..].chars().next() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+            pos += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    if pos == start {
+        None
+    } else {
+        Some((text[start..pos].to_string(), pos))
+    }
+}
+
+fn parse_digits(text: &str, mut pos: usize) -> Option<(String, usize)> {
+    let start = pos;
+    while let Some(ch) = text[pos..].chars().next() {
+        if ch.is_ascii_digit() {
+            pos += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    if pos == start {
+        None
+    } else {
+        Some((text[start..pos].to_string(), pos))
+    }
 }
 
 #[derive(Debug)]
@@ -499,5 +720,42 @@ mod tests {
                 "b".to_string()
             )
         );
+    }
+
+    #[test]
+    fn close_merged_refs_require_closing_keyword() {
+        let refs = close_merged_refs(
+            "feat(#576): document queue cards\nBody has unrelated #561.",
+            "CambrianTech/airc",
+        );
+
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn close_merged_refs_accept_same_repo_cross_repo_and_continuations() {
+        let refs = close_merged_refs(
+            "Closes #100, CambrianTech/continuum#1130 and #102.",
+            "CambrianTech/airc",
+        );
+
+        assert_eq!(
+            refs,
+            vec![
+                "CambrianTech/airc#100",
+                "CambrianTech/continuum#1130",
+                "CambrianTech/airc#102",
+            ]
+        );
+    }
+
+    #[test]
+    fn close_merged_refs_dedupes_and_ignores_prose_after_keyword() {
+        let refs = close_merged_refs(
+            "Fix the queue docs. See #100.\nFixes #100. Also see #100.",
+            "CambrianTech/airc",
+        );
+
+        assert_eq!(refs, vec!["CambrianTech/airc#100"]);
     }
 }

--- a/lib/airc_bash/cmd_queue_close_merged.sh
+++ b/lib/airc_bash/cmd_queue_close_merged.sh
@@ -76,20 +76,7 @@ _cmd_queue_close_merged() {
   printf '%s' "$pr_blob" >"$pr_file"
 
   local pr_meta
-  if ! pr_meta=$("$AIRC_PYTHON" - "$pr_file" <<'PYEOF'
-import json, sys
-with open(sys.argv[1], "r", encoding="utf-8") as f:
-    pr = json.load(f)
-merged_at = pr.get("mergedAt") or ""
-base_ref = pr.get("baseRefName") or ""
-merge_commit = pr.get("mergeCommit") or {}
-sha = (merge_commit.get("oid") if isinstance(merge_commit, dict) else "") or ""
-body = pr.get("body") or ""
-title = pr.get("title") or ""
-url = pr.get("url") or ""
-print(f"{merged_at}\t{base_ref}\t{sha}\t{url}\t{len(title)}\t{len(body)}")
-PYEOF
-  ); then
+  if ! pr_meta=$("$(airc_rs_bin)" queue-card close-merged-meta --pr-file "$pr_file"); then
     rm -f "$pr_file"
     die "queue close-merged: PR JSON parse failed"
   fi
@@ -121,53 +108,7 @@ PYEOF
 
   local refs_file
   refs_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-refs.XXXXXX") || die "queue close-merged: mktemp failed"
-  if ! "$AIRC_PYTHON" - "$pr_file" "$pr_repo" >"$refs_file" <<'PYEOF'
-import json, re, sys
-with open(sys.argv[1], "r", encoding="utf-8") as f:
-    pr = json.load(f)
-default_repo = sys.argv[2]
-body = pr.get("body") or ""
-title = pr.get("title") or ""
-text = f"{title}\n{body}"
-
-CLOSING_KEYWORD_RE = re.compile(
-    r'\b(?:close[sd]?|fix(?:e[sd]|ed)?|resolve[sd]?)\b\s*:?\s*',
-    re.IGNORECASE,
-)
-REF_RE = re.compile(
-    r'\b([A-Za-z0-9][A-Za-z0-9._-]*)/([A-Za-z0-9][A-Za-z0-9._-]*)#(\d+)\b'
-    r'|(?<![A-Za-z0-9_/])#(\d+)\b'
-)
-
-seen = set()
-for keyword in CLOSING_KEYWORD_RE.finditer(text):
-    # Match GitHub-style close intent. Refs must appear immediately after the
-    # closing keyword, with optional comma/"and" continuations. This avoids
-    # closing cards for prose like "Fix the UI. See #100 for follow-up."
-    pos = keyword.end()
-    first = True
-    while True:
-        tail = text[pos:]
-        if not first:
-            sep = re.match(r'\s*(?:,|and)\s+', tail, re.IGNORECASE)
-            if not sep:
-                break
-            pos += sep.end()
-            tail = text[pos:]
-        ref = REF_RE.match(tail)
-        if not ref:
-            break
-        if ref.group(4):
-            key = f"{default_repo}#{ref.group(4)}"
-        else:
-            key = f"{ref.group(1)}/{ref.group(2)}#{ref.group(3)}"
-        if key not in seen:
-            seen.add(key)
-            print(key)
-        pos += ref.end()
-        first = False
-PYEOF
-  then
+  if ! "$(airc_rs_bin)" queue-card close-merged-refs --pr-file "$pr_file" --repo "$pr_repo" >"$refs_file"; then
     rm -f "$pr_file" "$refs_file"
     die "queue close-merged: ref-parser failed"
   fi
@@ -218,21 +159,11 @@ PYEOF
       continue
     fi
 
-    local envelope_status
-    envelope_status=$(printf '%s' "$issue_body" | "$AIRC_PYTHON" -c '
-import json, re, sys
-body = sys.stdin.read()
-CARD_BLOCK_RE = re.compile(r"```json\s*\n(.*?)\n\s*```", re.DOTALL)
-for m in CARD_BLOCK_RE.finditer(body):
-    try:
-        parsed = json.loads(m.group(1).strip())
-    except Exception:
-        continue
-    if isinstance(parsed, dict) and parsed.get("kind") == "airc-queue-card-v1":
-        print((parsed.get("status") or "").strip() or "unknown")
-        sys.exit(0)
-print("not-a-card")
-')
+    local issue_body_file envelope_status
+    issue_body_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-issue.XXXXXX") || die "queue close-merged: mktemp failed"
+    printf '%s' "$issue_body" >"$issue_body_file"
+    envelope_status=$("$(airc_rs_bin)" queue-card card-status --body-file "$issue_body_file")
+    rm -f "$issue_body_file"
 
     case "$envelope_status" in
       not-a-card)

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -289,6 +289,7 @@ class CodexRustCutoverTests(unittest.TestCase):
             for path in [
                 REPO / "lib/airc_bash/cmd_queue.sh",
                 REPO / "lib/airc_bash/cmd_queue_card.sh",
+                REPO / "lib/airc_bash/cmd_queue_close_merged.sh",
             ]
         )
 
@@ -308,6 +309,9 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn("queue-card review-refs", combined)
         self.assertIn("queue-card pr-meta", combined)
         self.assertIn("queue-card staleness-analyze", combined)
+        self.assertIn("queue-card close-merged-meta", combined)
+        self.assertIn("queue-card close-merged-refs", combined)
+        self.assertIn("queue-card card-status", combined)
 
     def test_message_crypto_helpers_use_airc_rs(self):
         combined = "\n".join(


### PR DESCRIPTION
Summary
- add `queue-card close-merged-meta`, `queue-card close-merged-refs`, and `queue-card card-status`
- route `airc queue close-merged` PR metadata parsing, closing-ref extraction, and queue-card status detection through `airc-rs`
- remove embedded Python from `cmd_queue_close_merged.sh`
- add Rust parser coverage for closing keywords, continuations, cross-repo refs, dedupe, and prose false positives

Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-cli --check`
- `cargo test --manifest-path Cargo.toml -p airc-cli queue_card_commands`
- `python3 test/test_queue_close_merged.py`
- `python3 test/test_codex_rust_cutover.py`
- `bash -n airc lib/airc_bash/*.sh`
- `cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path Cargo.toml --workspace`
- `rg -n "AIRC_PYTHON|python3|python |<<'PY|<<PY" lib/airc_bash/cmd_queue_close_merged.sh` returns no matches
