### PR TITLE
fix(invite): read channel gist through rust config

### DIFF
--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -398,14 +398,10 @@ _cmd_invite_human() {
   local primary_chan primary_gid
   primary_chan=$(airc_config_default_channel "$CONFIG" || true)
   if [ -n "$primary_chan" ]; then
-    primary_gid=$("$AIRC_PYTHON" -c "
-import json, sys
-try:
-    c = json.load(open('$CONFIG'))
-    print(c.get('channel_gists', {}).get('$primary_chan', ''))
-except Exception:
-    pass
-" 2>/dev/null)
+    primary_gid=$("$(airc_rs_bin)" config get-channel-gist \
+      --home "$AIRC_WRITE_DIR" \
+      --config "$CONFIG" \
+      --channel "$primary_chan" 2>/dev/null || true)
   fi
   # Fallback: legacy room_gist_id file (pre-channel-gists installs).
   if [ -z "$primary_gid" ] && [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -116,6 +116,12 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("AIRC_PYTHON", body)
         self.assertNotIn("python", body.lower())
 
+        invite_start = rooms.index("_cmd_invite_human()")
+        invite_end = rooms.index("cmd_invite()", invite_start)
+        invite_body = rooms[invite_start:invite_end]
+        self.assertIn("config get-channel-gist", invite_body)
+        self.assertNotIn("AIRC_PYTHON", invite_body)
+
     def test_inbox_uses_airc_rs(self):
         source = (REPO / "lib/airc_bash/cmd_status.sh").read_text(encoding="utf-8")
         start = source.index("cmd_inbox()")


### PR DESCRIPTION
Summary
- route human invite channel-gist lookup through airc-rs config get-channel-gist
- remove the inline Python JSON parser from _cmd_invite_human
- add a cutover guard for the invite helper

Verification
- bash -n airc lib/airc_bash/*.sh
- python3 test/test_codex_rust_cutover.py
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings