### PR TITLE
feat(identity): move rename collision scan to rust

### DIFF
--- a/crates/airc-cli/src/identity_cli.rs
+++ b/crates/airc-cli/src/identity_cli.rs
@@ -43,6 +43,22 @@ pub enum IdentityAction {
         peer_name: String,
     },
 
+    /// Exit 0 when a proposed rename collides with a recent foreign sender.
+    RenameCollision {
+        /// Local messages.jsonl path.
+        #[arg(long)]
+        messages_file: PathBuf,
+        /// Sanitized target name being requested.
+        #[arg(long)]
+        target: String,
+        /// Current local name before the rename.
+        #[arg(long = "old-name")]
+        old_name: String,
+        /// Number of recent log lines to inspect.
+        #[arg(long, default_value_t = 200)]
+        tail_lines: usize,
+    },
+
     /// Sign stdin bytes with the legacy Ed25519 PEM identity.
     SignEd25519 {
         /// Legacy identity directory containing private.pem.

--- a/crates/airc-cli/src/identity_commands.rs
+++ b/crates/airc-cli/src/identity_commands.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeSet, VecDeque};
 use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -77,6 +78,19 @@ pub fn run_peer_ssh_pub(peers_dir: &Path, peer_name: &str) -> Result<(), Box<dyn
         println!("{ssh_pub}");
     }
     Ok(())
+}
+
+pub fn run_rename_collision(
+    messages_file: &Path,
+    target: &str,
+    old_name: &str,
+    tail_lines: usize,
+) -> Result<(), Box<dyn Error>> {
+    if rename_collision(messages_file, target, old_name, tail_lines) {
+        Ok(())
+    } else {
+        Err(NoCollision.into())
+    }
 }
 
 pub fn run_session_file(write_dir: &Path, transport_name: &str) -> Result<(), Box<dyn Error>> {
@@ -292,6 +306,9 @@ fn peer_ssh_pub(peers_dir: &Path, peer_name: &str) -> Option<String> {
 #[derive(Debug)]
 struct NudgeNeeded;
 
+#[derive(Debug)]
+struct NoCollision;
+
 impl std::fmt::Display for NudgeNeeded {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(formatter, "identity nudge needed")
@@ -300,12 +317,82 @@ impl std::fmt::Display for NudgeNeeded {
 
 impl Error for NudgeNeeded {}
 
+impl std::fmt::Display for NoCollision {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "no rename collision")
+    }
+}
+
+impl Error for NoCollision {}
+
 pub fn command_exit_code(error: &(dyn Error + 'static)) -> Option<u8> {
     if error.is::<NudgeNeeded>() {
         Some(2)
+    } else if error.is::<NoCollision>() {
+        Some(1)
     } else {
         None
     }
+}
+
+fn rename_collision(messages_file: &Path, target: &str, old_name: &str, tail_lines: usize) -> bool {
+    let target = target.trim();
+    if target.is_empty() {
+        return false;
+    }
+    let mut seen = BTreeSet::new();
+    let mut my_history = BTreeSet::from([old_name.trim().to_string()]);
+    for line in tail_lines_from_file(messages_file, tail_lines) {
+        let Ok(message) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        if let Some(sender) = message
+            .get("from")
+            .and_then(Value::as_str)
+            .filter(|sender| !sender.is_empty())
+        {
+            seen.insert(sender.to_string());
+        }
+        if let Some((old, new)) = message
+            .get("msg")
+            .and_then(Value::as_str)
+            .and_then(parse_rename_marker)
+        {
+            if my_history.contains(old) || my_history.contains(new) {
+                my_history.insert(old.to_string());
+                my_history.insert(new.to_string());
+            }
+        }
+    }
+    seen.contains(target) && !my_history.contains(target)
+}
+
+fn tail_lines_from_file(path: &Path, limit: usize) -> Vec<String> {
+    if limit == 0 {
+        return Vec::new();
+    }
+    let mut lines = VecDeque::with_capacity(limit);
+    for line in fs::read_to_string(path).unwrap_or_default().lines() {
+        if lines.len() == limit {
+            lines.pop_front();
+        }
+        lines.push_back(line.to_string());
+    }
+    lines.into_iter().collect()
+}
+
+fn parse_rename_marker(message: &str) -> Option<(&str, &str)> {
+    let rest = message.strip_prefix("[rename] ")?;
+    let mut old = None;
+    let mut new = None;
+    for part in rest.split_whitespace() {
+        if let Some(value) = part.strip_prefix("old=") {
+            old = Some(value);
+        } else if let Some(value) = part.strip_prefix("new=") {
+            new = Some(value);
+        }
+    }
+    Some((old?, new?))
 }
 
 fn session_file(write_dir: &Path, transport_name: &str) -> Result<PathBuf, Box<dyn Error>> {
@@ -606,6 +693,42 @@ mod tests {
             Some("ssh-ed25519 AAAAC3Nz alice")
         );
         assert_eq!(peer_ssh_pub(dir.path(), "missing"), None);
+    }
+
+    #[test]
+    fn rename_collision_detects_foreign_recent_sender() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("messages.jsonl");
+        fs::write(
+            &log,
+            r#"{"from":"mine","msg":"hello","ts":"2026-05-20T00:00:00Z"}"#.to_string()
+                + "\n"
+                + r#"{"from":"alice","msg":"hello","ts":"2026-05-20T00:00:01Z"}"#
+                + "\n",
+        )
+        .unwrap();
+
+        assert!(rename_collision(&log, "alice", "mine", 200));
+        assert!(!rename_collision(&log, "bob", "mine", 200));
+    }
+
+    #[test]
+    fn rename_collision_excludes_local_rename_history() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("messages.jsonl");
+        fs::write(
+            &log,
+            r#"{"from":"old","msg":"[rename] old=old new=temp","ts":"2026-05-20T00:00:00Z"}"#
+                .to_string()
+                + "\n"
+                + r#"{"from":"temp","msg":"[rename] old=temp new=old","ts":"2026-05-20T00:00:01Z"}"#
+                + "\n"
+                + r#"{"from":"old","msg":"back","ts":"2026-05-20T00:00:02Z"}"#
+                + "\n",
+        )
+        .unwrap();
+
+        assert!(!rename_collision(&log, "temp", "old", 200));
     }
 
     #[test]

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -380,6 +380,17 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 peers_dir,
                 peer_name,
             } => identity_commands::run_peer_ssh_pub(&peers_dir, &peer_name),
+            IdentityAction::RenameCollision {
+                messages_file,
+                target,
+                old_name,
+                tail_lines,
+            } => identity_commands::run_rename_collision(
+                &messages_file,
+                &target,
+                &old_name,
+                tail_lines,
+            ),
             IdentityAction::SignEd25519 { identity_dir } => {
                 println!("{}", legacy_identity::sign_ed25519_stdin(&identity_dir)?);
                 Ok(())

--- a/lib/airc_bash/cmd_rename.sh
+++ b/lib/airc_bash/cmd_rename.sh
@@ -94,34 +94,11 @@ cmd_rename() {
     # nicks that were US, exclude them from the collision set. The
     # check still blocks renaming TO another peer's nick — original
     # safety property preserved.
-    if tail -200 "$MESSAGES" 2>/dev/null \
-         | AIRC_NEW_NAME="$new_name" AIRC_OLD_NAME="$old_name" "$AIRC_PYTHON" -c "
-import sys, os, json, re
-target = os.environ.get('AIRC_NEW_NAME', '')
-my_current = os.environ.get('AIRC_OLD_NAME', '')
-seen = set()
-my_history = {my_current}  # current nick is always 'mine'
-_rn = re.compile(r'\[rename\] old=([a-z0-9-]+) new=([a-z0-9-]+)')
-for line in sys.stdin:
-    try:
-        m = json.loads(line)
-        fr = m.get('from')
-        msg = m.get('msg', '') or ''
-        if fr:
-            seen.add(fr)
-        # Trace [rename] chain: if either side of a rename was us,
-        # both sides are us. Multi-pass would be more correct, but
-        # the linear pass catches the common case (consecutive renames).
-        mm = _rn.match(msg)
-        if mm:
-            old_n, new_n = mm.group(1), mm.group(2)
-            if old_n in my_history or new_n in my_history:
-                my_history.add(old_n)
-                my_history.add(new_n)
-    except Exception:
-        pass
-sys.exit(0 if (target in seen and target not in my_history) else 1)
-" 2>/dev/null; then
+    if "$(airc_rs_bin)" identity rename-collision \
+         --messages-file "$MESSAGES" \
+         --target "$new_name" \
+         --old-name "$old_name" \
+         --tail-lines 200 >/dev/null 2>&1; then
       die "name collision: '$new_name' has been seen as an active (foreign) peer in this room (use 'airc logs' to verify)"
     fi
   fi

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -231,6 +231,12 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" config set ', combined)
         self.assertIn('"$(airc_rs_bin)" config read-parted', combined)
 
+    def test_rename_collision_scan_uses_airc_rs(self):
+        source = (REPO / "lib/airc_bash/cmd_rename.sh").read_text(encoding="utf-8")
+
+        self.assertNotIn("AIRC_PYTHON", source)
+        self.assertIn('"$(airc_rs_bin)" identity rename-collision', source)
+
     def test_host_block_config_write_uses_airc_rs(self):
         source = (REPO / "lib/airc_bash/cmd_connect.sh").read_text(encoding="utf-8")
         self.assertNotIn("airc_core.config set_host_block", source)


### PR DESCRIPTION
Summary
- add airc-rs identity rename-collision for recent sender collision checks
- route cmd_rename through the Rust collision scanner instead of inline Python
- cover foreign sender collisions and local rename-history exclusions
- add a static cutover guard for cmd_rename

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-cli rename_collision
- bash -n airc lib/airc_bash/*.sh
- python3 test/test_codex_rust_cutover.py
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace