### PR TITLE
feat(network): move LAN IP probe to rust

### DIFF
--- a/airc
+++ b/airc
@@ -853,30 +853,13 @@ get_host() {
   # Returns one of 192.168.*, 10.*, 172.16-31.* on a typical home/office
   # LAN. Returns 127.0.0.1 if no internet route is available — which we
   # treat as "no LAN" and fall through to hostname.
-  if [ -n "${AIRC_PYTHON:-}" ]; then
-    local lan_ip
-    lan_ip=$("$AIRC_PYTHON" -c "
-import socket
-s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-try:
-    s.settimeout(0.5)
-    s.connect(('8.8.8.8', 80))
-    ip = s.getsockname()[0]
-    # Only emit if it looks like a routable LAN address. 127.0.0.1 means
-    # no default route; we want hostname fallback in that case.
-    if ip and not ip.startswith('127.'):
-        print(ip)
-except Exception:
-    pass
-finally:
-    s.close()
-" 2>/dev/null)
-    if [ -n "$lan_ip" ]; then
-      # Sanity: must look like an IPv4 address (skip exotic surprises).
-      case "$lan_ip" in
-        [0-9]*.[0-9]*.[0-9]*.[0-9]*) echo "$lan_ip" && return ;;
-      esac
-    fi
+  local lan_ip
+  lan_ip=$("$(airc_rs_bin)" lan-ip 2>/dev/null || true)
+  if [ -n "$lan_ip" ]; then
+    # Sanity: must look like an IPv4 address (skip exotic surprises).
+    case "$lan_ip" in
+      [0-9]*.[0-9]*.[0-9]*.[0-9]*) echo "$lan_ip" && return ;;
+    esac
   fi
 
   hostname

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -103,6 +103,9 @@ pub enum Command {
         summary: bool,
     },
 
+    /// Print the primary non-loopback LAN IPv4 address, if detectable.
+    LanIp,
+
     /// Legacy bearer transport helpers during Rust cutover.
     Bearer(BearerArgs),
 

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -55,6 +55,7 @@ mod log_commands;
 mod message_cli;
 mod message_commands;
 mod monitor;
+mod network_commands;
 mod pending_cli;
 mod pending_commands;
 mod queue_card_cli;
@@ -196,6 +197,8 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 bearer_state::run(&path)
             }
         }
+
+        Command::LanIp => network_commands::run_lan_ip(),
 
         Command::Bearer(args) => match args.action {
             BearerAction::Send {

--- a/crates/airc-cli/src/network_commands.rs
+++ b/crates/airc-cli/src/network_commands.rs
@@ -1,0 +1,34 @@
+use std::error::Error;
+use std::net::{IpAddr, Ipv4Addr, UdpSocket};
+
+pub fn run_lan_ip() -> Result<(), Box<dyn Error>> {
+    if let Some(ip) = detect_lan_ip() {
+        println!("{ip}");
+    }
+    Ok(())
+}
+
+fn detect_lan_ip() -> Option<Ipv4Addr> {
+    let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).ok()?;
+    socket.connect((Ipv4Addr::new(8, 8, 8, 8), 80)).ok()?;
+    match socket.local_addr().ok()?.ip() {
+        IpAddr::V4(ip) if is_routable_lan_ipv4(ip) => Some(ip),
+        _ => None,
+    }
+}
+
+fn is_routable_lan_ipv4(ip: Ipv4Addr) -> bool {
+    !ip.is_loopback() && !ip.is_unspecified()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn routable_lan_filter_rejects_loopback_and_unspecified() {
+        assert!(!is_routable_lan_ipv4(Ipv4Addr::LOCALHOST));
+        assert!(!is_routable_lan_ipv4(Ipv4Addr::UNSPECIFIED));
+        assert!(is_routable_lan_ipv4(Ipv4Addr::new(192, 168, 1, 2)));
+    }
+}

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -78,6 +78,16 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" client-id', body)
         self.assertIn('"$(airc_rs_bin)" humanhash "$input"', body)
 
+    def test_lan_ip_probe_uses_airc_rs(self):
+        source = (REPO / "airc").read_text(encoding="utf-8")
+        start = source.index("get_host()")
+        end = source.index("resolve_tailscale_bin()", start)
+        body = source[start:end]
+
+        self.assertIn('"$(airc_rs_bin)" lan-ip', body)
+        self.assertNotIn("AIRC_PYTHON", body)
+        self.assertNotIn("socket.socket", body)
+
     def test_scope_repair_uses_airc_rs(self):
         source = (REPO / "airc").read_text(encoding="utf-8")
         start = source.index("ensure_init()")


### PR DESCRIPTION
Summary
- add airc-rs lan-ip backed by Rust UdpSocket route probing
- route get_host LAN IP detection through airc-rs instead of Python socket code
- add cutover guard for the host LAN probe path

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-cli network_commands
- bash -n airc lib/airc_bash/*.sh
- python3 test/test_codex_rust_cutover.py
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- lan-ip
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace