### PR TITLE
feat(runtime): drop wrapper python startup

### DIFF
--- a/airc
+++ b/airc
@@ -18,75 +18,6 @@ case "$AIRC_SELF" in
 esac
 export AIRC_SELF
 
-# Cross-platform Python invocation. macOS / Linux / WSL all ship `python3`
-# on PATH; Git Bash on Windows typically has `python` only (the launcher
-# from python.org). Resolve once at startup; every `python3 ...` invocation
-# downstream goes through this wrapper. Hard fail if neither is present
-# (we still need Python for the remaining legacy handshake/control slices).
-#
-# AIRC_PYTHON: resolve real Python interpreter once, propagate via env
-# var. Pre-fix (PR #153) used a bash function shim named python3
-# exported via export -f. On Git Bash MINGW, export -f succeeds
-# silently but the function does NOT reliably inherit into command-
-# substitution subshells (the captured-via-dollar-paren pattern).
-# Result: every site that captured python3 -c output through a
-# subshell (45+ callsites) bypassed the shim, hit the Microsoft
-# Store stub, exited 49 with empty stdout. The pipe-to-echo-empty
-# fallbacks on those sites then silently set config values to empty
-# strings — host_target, host_airc_home, name all became empty.
-# cmd_send then took the HOST path (no host_target) and mirrored
-# locally without ever attempting the SSH push. Net: every Win→Mac
-# broadcast silently no-op'd while pretending success. Caught by
-# a cross-Mac/Windows substrate-bypass gist
-# 2026-04-27.
-#
-# Fix: env-var holds the resolved interpreter path. Bash variables
-# propagate to subshells unconditionally — no function-export quirks.
-# Every callsite now invokes "$AIRC_PYTHON" -c instead of the
-# function-shim name; sed replace across the file did the conversion.
-# Phase E.2: prefer the venv python at $AIRC_DIR/.venv (or sibling of
-# the script when running from a dev checkout). install.sh creates this
-# venv and pip-installs cryptography there. If the venv is absent, we
-# fall back to system python and the envelope-encryption path silently
-# disables (callers gate on identity.cryptography_available()).
-_airc_venv_python=""
-for _airc_venv_root in \
-    "${AIRC_DIR:-}" \
-    "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" \
-    "$HOME/.airc-src"; do
-  [ -z "$_airc_venv_root" ] && continue
-  for _candidate in \
-      "$_airc_venv_root/.venv/bin/python" \
-      "$_airc_venv_root/.venv/bin/python3" \
-      "$_airc_venv_root/.venv/Scripts/python.exe"; do
-    if [ -x "$_candidate" ]; then
-      _airc_venv_python="$_candidate"
-      break 2
-    fi
-  done
-done
-
-if [ -n "$_airc_venv_python" ]; then
-  AIRC_PYTHON="$_airc_venv_python"
-elif python3 --version >/dev/null 2>&1; then
-  AIRC_PYTHON=python3
-elif command -v python >/dev/null 2>&1 && python --version >/dev/null 2>&1; then
-  AIRC_PYTHON=python
-else
-  echo "ERROR: airc requires a working python3 (or python on Windows/Git Bash)." >&2
-  echo "  macOS:    brew install python3" >&2
-  echo "  Linux:    apt install python3 / dnf install python3" >&2
-  echo "  Windows:  install from https://www.python.org/downloads/" >&2
-  echo "" >&2
-  echo "  Note for Windows: a 'python3.exe' Store-installer alias on PATH" >&2
-  echo "  is NOT a real Python — disable it under" >&2
-  echo "  Settings → Apps → Advanced app settings → App execution aliases" >&2
-  echo "  (toggle off python.exe and python3.exe), or PATH-prepend your real" >&2
-  echo "  install (e.g. C:\\Users\\<you>\\AppData\\Local\\Programs\\Python\\Python312\\)." >&2
-  exit 1
-fi
-export AIRC_PYTHON
-
 # Issue #341 follow-up: shell openssl is no longer used for Ed25519
 # identity gen / signing. The prior _resolve_openssl + AIRC_OPENSSL +
 # _die helper were #342's loud-failure mitigation; once truth moved to
@@ -107,14 +38,9 @@ export AIRC_PYTHON
 # invocation inherits the same translation policy.
 export MSYS2_ARG_CONV_EXCL="${MSYS2_ARG_CONV_EXCL:-/Users/;/home/;/root/}"
 
-# Force UTF-8 for stdin/stdout/stderr in every airc_core invocation.
-# Windows Python defaults to the local code page (cp1252 on most US/EU
-# installs) which can't encode common Unicode chars like → or em-dashes;
-# write attempts raise UnicodeEncodeError, the formatter's per-line
-# error handler catches it, and the message gets silently dropped from
-# the user's view. PYTHONIOENCODING=utf-8 is the standard remedy —
-# applies to every Python subprocess airc spawns. Honors user override.
-# traced + verified 2026-04-27.
+# Legacy Python modules still exist during cutover, but the wrapper no
+# longer resolves or requires Python at startup. Any remaining legacy
+# command must handle its own dependency until it is deleted or ported.
 export PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}"
 
 # Resolve the airc install dir's lib/ path and prepend to PYTHONPATH so
@@ -2202,50 +2128,17 @@ reminder_timer_loop() {
             local messages_log="$AIRC_WRITE_DIR/messages.jsonl"
             # Use the same identity primitive the queue verbs use, so we
             # filter out the same agent name that would receive its own
-            # cmd_send echo. Fall back to empty so the python below just
-            # doesn't filter — the per-recipient dedup will still gate.
+            # cmd_send echo. Fall back to empty; per-recipient dedup
+            # still gates even if the self-name cannot be resolved.
             local my_name=""
             if declare -F _airc_queue_resolve_name >/dev/null 2>&1; then
               my_name=$(_airc_queue_resolve_name 2>/dev/null || echo "")
             fi
             local roster
-            roster=$("$AIRC_PYTHON" - "$messages_log" "$qm_roster_window" "$my_name" <<'PY' 2>/dev/null
-import json, os, sys, time
-log, window_s, me = sys.argv[1], int(sys.argv[2]), sys.argv[3]
-now = time.time()
-seen = {}
-if os.path.exists(log):
-    try:
-        with open(log) as f:
-            for line in f:
-                try:
-                    m = json.loads(line)
-                except Exception:
-                    continue
-                who = m.get('from') or ''
-                if not who or who == 'airc' or who == me:
-                    continue
-                ts = m.get('ts')
-                # ts may be epoch float, epoch-ms int, or ISO string.
-                try:
-                    if isinstance(ts, (int, float)):
-                        t = float(ts)
-                        if t > 1e12:
-                            t = t / 1000.0
-                    else:
-                        from datetime import datetime
-                        t = datetime.fromisoformat(str(ts).replace('Z', '+00:00')).timestamp()
-                except Exception:
-                    continue
-                if now - t > window_s:
-                    continue
-                prev = seen.get(who, 0)
-                if t > prev:
-                    seen[who] = t
-for who in sorted(seen, key=lambda k: seen[k], reverse=True):
-    print(who)
-PY
-)
+            roster=$("$(airc_rs_bin)" recent-senders \
+              --messages-log "$messages_log" \
+              --window-seconds "$qm_roster_window" \
+              --exclude-name "$my_name" 2>/dev/null || true)
             local dispatched=0 skipped=0
             local agent
             while IFS= read -r agent; do
@@ -2779,10 +2672,10 @@ case "${1:-help}" in
   debug-name)  resolve_name ;;
   debug-host)  get_host ;;
   debug-pythonpath)
-    echo "AIRC_PYTHON=$AIRC_PYTHON"
+    echo "AIRC_PYTHON=${AIRC_PYTHON:-<unset>}"
     echo "lib_dir=${_airc_lib_dir:-<not-resolved>}"
     echo "PYTHONPATH=${PYTHONPATH:-<unset>}"
-    "$AIRC_PYTHON" -c "import airc_core; print(f'airc_core import ok: v{airc_core.__version__}')" 2>&1 ;;
+    "${AIRC_PYTHON:-python3}" -c "import airc_core; print(f'airc_core import ok: v{airc_core.__version__}')" 2>&1 ;;
   help|--help|-h)
     echo "AIRC — Agentic Internet Relay Chat for AI peers"
     echo "(IRC verbs are the public interface)"

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -106,6 +106,19 @@ pub enum Command {
     /// Print the primary non-loopback LAN IPv4 address, if detectable.
     LanIp,
 
+    /// Print recent message senders from a legacy messages.jsonl log.
+    RecentSenders {
+        /// Path to legacy messages.jsonl.
+        #[arg(long)]
+        messages_log: PathBuf,
+        /// Only include senders active within this many seconds.
+        #[arg(long)]
+        window_seconds: u64,
+        /// Sender name to exclude, usually this agent's display name.
+        #[arg(long, default_value = "")]
+        exclude_name: String,
+    },
+
     /// Legacy bearer transport helpers during Rust cutover.
     Bearer(BearerArgs),
 

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -54,6 +54,7 @@ mod log_cli;
 mod log_commands;
 mod message_cli;
 mod message_commands;
+mod metronome_commands;
 mod monitor;
 mod network_commands;
 mod pending_cli;
@@ -199,6 +200,12 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         }
 
         Command::LanIp => network_commands::run_lan_ip(),
+
+        Command::RecentSenders {
+            messages_log,
+            window_seconds,
+            exclude_name,
+        } => metronome_commands::run_recent_senders(&messages_log, window_seconds, &exclude_name),
 
         Command::Bearer(args) => match args.action {
             BearerAction::Send {

--- a/crates/airc-cli/src/metronome_commands.rs
+++ b/crates/airc-cli/src/metronome_commands.rs
@@ -1,0 +1,128 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+pub fn run_recent_senders(
+    messages_log: &Path,
+    window_seconds: u64,
+    exclude_name: &str,
+) -> Result<(), Box<dyn Error>> {
+    for sender in recent_senders(messages_log, window_seconds, exclude_name)? {
+        println!("{sender}");
+    }
+    Ok(())
+}
+
+fn recent_senders(
+    messages_log: &Path,
+    window_seconds: u64,
+    exclude_name: &str,
+) -> Result<Vec<String>, Box<dyn Error>> {
+    let file = match File::open(messages_log) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(Box::new(error)),
+    };
+
+    let now_ms = Utc::now().timestamp_millis();
+    let window_ms = (window_seconds as i64).saturating_mul(1000);
+    let mut seen: HashMap<String, i64> = HashMap::new();
+
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let Ok(message) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        let Some(sender) = message.get("from").and_then(Value::as_str) else {
+            continue;
+        };
+        if sender.is_empty() || sender == "airc" || sender == exclude_name {
+            continue;
+        }
+        let Some(sent_ms) = message.get("ts").and_then(parse_timestamp_ms) else {
+            continue;
+        };
+        if now_ms.saturating_sub(sent_ms) > window_ms {
+            continue;
+        }
+        let entry = seen.entry(sender.to_string()).or_insert(i64::MIN);
+        *entry = (*entry).max(sent_ms);
+    }
+
+    let mut senders: Vec<_> = seen.into_iter().collect();
+    senders.sort_by(|(left_name, left_ts), (right_name, right_ts)| {
+        right_ts
+            .cmp(left_ts)
+            .then_with(|| left_name.cmp(right_name))
+    });
+    Ok(senders.into_iter().map(|(sender, _)| sender).collect())
+}
+
+fn parse_timestamp_ms(value: &Value) -> Option<i64> {
+    if let Some(integer) = value.as_i64() {
+        return Some(epoch_number_to_ms(integer as f64));
+    }
+    if let Some(float) = value.as_f64() {
+        return Some(epoch_number_to_ms(float));
+    }
+    let timestamp = value.as_str()?;
+    DateTime::parse_from_rfc3339(&timestamp.replace('Z', "+00:00"))
+        .ok()
+        .map(|parsed| parsed.timestamp_millis())
+}
+
+fn epoch_number_to_ms(value: f64) -> i64 {
+    if value > 1_000_000_000_000.0 {
+        value as i64
+    } else {
+        (value * 1000.0) as i64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn recent_senders_filters_self_and_orders_by_latest_message() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("messages.jsonl");
+        let mut file = File::create(&path).expect("messages log");
+        let now = Utc::now().timestamp();
+        writeln!(file, r#"{{"from":"alice","ts":{}}}"#, now - 5).expect("write alice");
+        writeln!(file, r#"{{"from":"self","ts":{}}}"#, now - 1).expect("write self");
+        writeln!(file, r#"{{"from":"bob","ts":{}}}"#, now - 3).expect("write bob");
+        writeln!(file, r#"{{"from":"alice","ts":{}}}"#, now - 2).expect("write alice latest");
+        writeln!(file, r#"{{"from":"airc","ts":{}}}"#, now).expect("write airc");
+
+        let senders = recent_senders(&path, 60, "self").expect("recent senders");
+
+        assert_eq!(senders, vec!["alice", "bob"]);
+    }
+
+    #[test]
+    fn recent_senders_accepts_epoch_ms_and_rfc3339() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("messages.jsonl");
+        let mut file = File::create(&path).expect("messages log");
+        let now = Utc::now();
+        writeln!(
+            file,
+            r#"{{"from":"millis","ts":{}}}"#,
+            now.timestamp_millis()
+        )
+        .expect("write ms");
+        writeln!(file, r#"{{"from":"iso","ts":"{}"}}"#, now.to_rfc3339()).expect("write iso");
+
+        let senders = recent_senders(&path, 60, "").expect("recent senders");
+
+        assert_eq!(senders.len(), 2);
+        assert!(senders.contains(&"millis".to_string()));
+        assert!(senders.contains(&"iso".to_string()));
+    }
+}

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -520,7 +520,7 @@ _doctor_health() {
   # fix is to intersect with the current subscribed_channels list — same
   # principle as bearer scoping in the receive-silence beacon.
   local _subs=""
-  if [ -f "$CONFIG" ] && command -v "$AIRC_PYTHON" >/dev/null 2>&1; then
+  if [ -f "$CONFIG" ]; then
     _subs=$(airc_config_read_channels "$CONFIG" || true)
   fi
   local found_state=0

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -88,6 +88,24 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("AIRC_PYTHON", body)
         self.assertNotIn("socket.socket", body)
 
+    def test_airc_startup_does_not_require_python(self):
+        source = (REPO / "airc").read_text(encoding="utf-8")
+        startup = source[: source.index("# Issue #341 follow-up")]
+
+        self.assertNotIn("AIRC_PYTHON", startup)
+        self.assertNotIn("requires a working python", startup)
+        self.assertNotIn("python3 --version", startup)
+
+    def test_quick_message_roster_uses_airc_rs(self):
+        source = (REPO / "airc").read_text(encoding="utf-8")
+        start = source.index('if [ "$qm_owner" = "*roster*" ]; then')
+        end = source.index("local dispatched=0 skipped=0", start)
+        body = source[start:end]
+
+        self.assertIn('"$(airc_rs_bin)" recent-senders', body)
+        self.assertNotIn("AIRC_PYTHON", body)
+        self.assertNotIn("import json", body)
+
     def test_scope_repair_uses_airc_rs(self):
         source = (REPO / "airc").read_text(encoding="utf-8")
         start = source.index("ensure_init()")


### PR DESCRIPTION
Summary
- remove the top-level airc startup Python resolver and hard dependency
- add airc-rs recent-senders for queue metronome roster fan-out
- route quick-message roster parsing through Rust and guard it
- avoid doctor assuming AIRC_PYTHON is exported after startup cutover

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-cli metronome_commands
- bash -n airc lib/airc_bash/*.sh
- python3 test/test_codex_rust_cutover.py
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- recent-senders --messages-log /tmp/airc-recent-senders-test.jsonl --window-seconds 60 --exclude-name self
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace