### PR TITLE
feat(install): remove python runtime bootstrap

### DIFF
--- a/crates/airc-cli/src/codex_config.rs
+++ b/crates/airc-cli/src/codex_config.rs
@@ -75,6 +75,44 @@ pub fn remove_managed_developer_instructions(
     Ok(true)
 }
 
+pub fn remove_stale_airc_filesystem_permissions(
+    path: &Path,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let original = read_text(path)?;
+    if !original.contains("[permissions.airc.filesystem")
+        && !original.contains("# airc filesystem permissions")
+    {
+        return Ok(false);
+    }
+
+    let mut out = Vec::new();
+    let mut skipping = false;
+    for line in original.lines() {
+        let stripped = line.trim();
+        if stripped.starts_with("# airc filesystem permissions")
+            || stripped.starts_with("[permissions.airc.filesystem")
+        {
+            skipping = true;
+            continue;
+        }
+        if skipping {
+            if stripped.starts_with('[') && !stripped.starts_with("[permissions.airc.filesystem") {
+                skipping = false;
+                out.push(line);
+            }
+            continue;
+        }
+        out.push(line);
+    }
+
+    let rendered = collapse_blank_lines(&out.join("\n"));
+    if rendered == original {
+        return Ok(false);
+    }
+    write_text(path, &rendered)?;
+    Ok(true)
+}
+
 fn parse_toml_document(text: &str) -> Result<DocumentMut, Box<dyn std::error::Error>> {
     if text.trim().is_empty() {
         return Ok(DocumentMut::new());
@@ -101,6 +139,24 @@ fn remove_legacy_codex_hooks_key(text: &str) -> Result<String, Box<dyn std::erro
         features.remove("codex_hooks");
     }
     Ok(doc.to_string())
+}
+
+fn collapse_blank_lines(text: &str) -> String {
+    let mut rendered = String::new();
+    let mut blank_count = 0usize;
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            blank_count += 1;
+            if blank_count <= 2 {
+                rendered.push('\n');
+            }
+            continue;
+        }
+        blank_count = 0;
+        rendered.push_str(line);
+        rendered.push('\n');
+    }
+    rendered
 }
 
 fn read_text(path: &Path) -> Result<String, Box<dyn std::error::Error>> {

--- a/crates/airc-cli/src/codex_install.rs
+++ b/crates/airc-cli/src/codex_install.rs
@@ -14,6 +14,12 @@ pub async fn run_install_hooks(
     if codex_config::enable_hooks_feature(&config)? {
         println!("enabled hooks in {}", config.display());
     }
+    if codex_config::remove_stale_airc_filesystem_permissions(&config)? {
+        println!(
+            "removed stale AIRC filesystem permission profile from {}",
+            config.display()
+        );
+    }
     if codex_hooks_json::install(&hooks_json)? {
         println!(
             "installed AIRC UserPromptSubmit hook in {}",

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -144,6 +144,48 @@ fn codex_hook_installer_replaces_legacy_python_hook() {
 }
 
 #[test]
+fn codex_hook_installer_removes_stale_filesystem_profile() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("airc");
+    let codex_home = workspace.path().join("codex");
+    std::fs::create_dir_all(&codex_home).expect("codex home");
+    std::fs::write(
+        codex_home.join("config.toml"),
+        r#"
+[features]
+codex_hooks = true
+
+# airc filesystem permissions
+[permissions.airc.filesystem]
+enabled = true
+
+[permissions.airc.filesystem.write]
+paths = ["/tmp"]
+
+[permissions.airc.network]
+enabled = true
+"#,
+    )
+    .expect("write config");
+
+    run_ok(
+        &home,
+        &[
+            "codex-hook",
+            "install-hooks",
+            "--codex-home",
+            codex_home.to_str().unwrap(),
+        ],
+    );
+
+    let config = std::fs::read_to_string(codex_home.join("config.toml")).expect("read config");
+    assert!(!config.contains("permissions.airc.filesystem"));
+    assert!(!config.contains("paths = [\"/tmp\"]"));
+    assert!(config.contains("[permissions.airc.network]"));
+    assert!(config.contains("hooks = true"));
+}
+
+#[test]
 fn codex_hook_uninstaller_removes_managed_hooks_only() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("airc");

--- a/install.sh
+++ b/install.sh
@@ -49,12 +49,10 @@ _to_bash_path() {
 # install via the platform's package manager, then verify. Designed for
 # FIRST-TIME users with nothing pre-installed beyond a shell.
 #
-# Required: git, gh, ssh-keygen, python3 (+ cryptography via venv pip),
-# cargo (to build the Rust substrate CLI).
+# Required: git, gh, ssh-keygen, cargo (to build the Rust substrate CLI).
 # Optional: tailscale (only needed for cross-LAN mesh; LAN works without)
-# Deliberately not required: openssl. Issue #341 — identity Ed25519 ops
-# moved to the venv cryptography module so we don't depend on system
-# openssl flavoring (LibreSSL vs OpenSSL etc).
+# Deliberately not required: openssl or Python. Identity, signing, hooks,
+# config, and message parsing are Rust-owned.
 #
 # AIRC_SKIP_PREREQS=1 short-circuits the whole block (CI, dev installs,
 # users who manage their own packages).
@@ -100,12 +98,6 @@ pkgname_for() {
         pacman) echo "openssh" ;;
         apk)    echo "openssh-client" ;;
         winget) echo "" ;;  # OpenSSH ships with modern Windows; nothing to install
-      esac ;;
-    python3)
-      case "$mgr" in
-        pacman) echo "python" ;;
-        winget) echo "Python.Python.3.12" ;;
-        *)      echo "python3" ;;
       esac ;;
     cargo)
       case "$mgr" in
@@ -204,27 +196,17 @@ ensure_prereqs() {
       fi
     else
       warn "Unknown package manager (uname=$(uname -s)). Skipping prereq auto-install."
-      warn "Required prereqs: git, gh, python3 (cryptography via pip), cargo"
+      warn "Required prereqs: git, gh, cargo"
       return 0
     fi
   fi
 
   local missing=() pkgs=() unmappable=()
-  # #188: jq removed — airc's gist envelope parser now uses Python's
-  # stdlib JSON (lib/airc_core/gistparse.py). Python was already a hard
-  # dep since #152 Phase 0; jq was redundant. Drop the dep + the
-  # winget step that would install it.
-  # Issue #341 follow-up: openssl removed from the prereq list. airc
-  # no longer shells out to it for Ed25519 — identity gen + signing
-  # both route through the venv cryptography module (which is already
-  # a hard dep, pip-installed below). LibreSSL on macOS used to make
-  # this an ordeal; now it's a non-issue at the source.
-  for cmd in git gh ssh-keygen python3 cargo; do
+  # jq, openssl, and Python are not install prereqs. JSON handling,
+  # Ed25519 identity/signing, hooks, and config mutation are Rust-owned.
+  for cmd in git gh ssh-keygen cargo; do
     # Strict probe: presence on PATH AND a successful --version invocation.
-    # Used selectively: python3 needs the strict variant because Windows
-    # Store's python3.exe alias is on PATH but exits 49 with a Store-
-    # redirect (2026-04-27). git/gh all
-    # support --version cleanly. ssh-keygen does NOT have a version
+    # git/gh/cargo support --version cleanly. ssh-keygen does NOT have a version
     # flag at all (different from `ssh -V`); calling `ssh-keygen
     # --version` exits non-zero on every install, so the strict probe
     # produces false positives — Joel 2026-04-28 saw "ssh-keygen needs
@@ -272,10 +254,9 @@ ensure_prereqs() {
   else
     ok "All required prereqs present"
   fi
-  # Issue #341 follow-up: openssl Ed25519-capability probe + brew
-  # install dance removed. Identity gen + signing live in the venv
-  # cryptography module now; the system openssl version (LibreSSL or
-  # otherwise) is irrelevant to airc.
+  # Issue #341 follow-up: openssl/Python crypto bootstrap removed.
+  # Identity gen + signing live in Rust, so system OpenSSL and Python
+  # package state are irrelevant to airc install correctness.
 
   # Post-3c: sshd setup + Tailscale install fully removed. Cross-network
   # messaging routes through gh-as-bearer (envelope-encrypted gist),
@@ -533,66 +514,6 @@ if ! echo "$PATH" | tr ':' '\n' | grep -qx "$BIN_DIR"; then
   export PATH="$BIN_DIR:$PATH"
 fi
 
-# ── Python venv with crypto deps (Phase E: envelope encryption) ────────
-# airc's envelope-layer end-to-end encryption needs the cryptography
-# package. We create a venv inside the install dir and pip-install
-# there because PEP 668 makes `pip install --user` fail on managed
-# Pythons (homebrew, system Python on Debian/Ubuntu/etc). The venv
-# avoids touching system Python at all — fully self-contained.
-#
-# airc's bash wrapper detects this venv at AIRC_PYTHON resolution time
-# and prefers it over system python3. Ed25519 signing is required for
-# identity bootstrap, so cryptography is a hard install dependency: if
-# we cannot provide it through the venv or an existing system Python,
-# fail here instead of reporting "Installed" and breaking at first join.
-_airc_venv="$CLONE_DIR/.venv"
-if [ ! -d "$_airc_venv" ] && command -v python3 >/dev/null 2>&1; then
-  if python3 -m venv "$_airc_venv" 2>/dev/null; then
-    ok "Python venv created: $_airc_venv"
-  else
-    warn "Could not create Python venv (python3-venv missing?). Will use system python3 only if cryptography is already available."
-  fi
-fi
-# Locate venv pip — POSIX vs Windows-Git-Bash paths.
-_airc_venv_pip=""
-if [ -x "$_airc_venv/bin/pip" ]; then
-  _airc_venv_pip="$_airc_venv/bin/pip"
-elif [ -x "$_airc_venv/Scripts/pip.exe" ]; then
-  _airc_venv_pip="$_airc_venv/Scripts/pip.exe"
-fi
-if [ -n "$_airc_venv_pip" ]; then
-  # Check if cryptography is already installed (idempotent install).
-  _airc_venv_python_bin=""
-  if [ -x "$_airc_venv/bin/python" ]; then
-    _airc_venv_python_bin="$_airc_venv/bin/python"
-  elif [ -x "$_airc_venv/Scripts/python.exe" ]; then
-    _airc_venv_python_bin="$_airc_venv/Scripts/python.exe"
-  fi
-  if [ -n "$_airc_venv_python_bin" ] && \
-     "$_airc_venv_python_bin" -c "import cryptography" >/dev/null 2>&1; then
-    : # already installed; skip
-  else
-    if "$_airc_venv_pip" install -q --upgrade pip >/dev/null 2>&1; then : ; fi
-    if "$_airc_venv_pip" install -q cryptography 2>&1 | tail -3; then
-      ok "cryptography installed in venv (envelope encryption ready)"
-    else
-      fail "cryptography install failed; airc requires it for Ed25519 signing. Manual fix: $_airc_venv_pip install cryptography"
-    fi
-  fi
-fi
-
-_airc_crypto_python=""
-if [ -x "$_airc_venv/bin/python" ]; then
-  _airc_crypto_python="$_airc_venv/bin/python"
-elif [ -x "$_airc_venv/Scripts/python.exe" ]; then
-  _airc_crypto_python="$_airc_venv/Scripts/python.exe"
-elif command -v python3 >/dev/null 2>&1; then
-  _airc_crypto_python="python3"
-fi
-if [ -z "$_airc_crypto_python" ] || ! "$_airc_crypto_python" -c "import cryptography.hazmat.primitives.asymmetric.ed25519" >/dev/null 2>&1; then
-  fail "cryptography is not importable after install; airc cannot bootstrap signed identity. Re-run install.sh after fixing Python/pip."
-fi
-
 # ── Skills into agent skill dirs (Claude Code + Codex) ─────────────────
 #
 # Both Claude Code and OpenAI Codex use the same on-disk skill format:
@@ -720,51 +641,9 @@ TOML
   # When Codex's runtime supports outside-workspace filesystem profiles,
   # restore the block (history at git log -- install.sh).
 
-  # Cleanup: machines that ran the buggy intermediate (3b20369..c1)
-  # still have the [permissions.airc.filesystem] block in their
-  # config.toml and Codex won't start. Detect and strip it on every
-  # install.sh run so Codex starts cleanly without the user having
-  # to hand-edit their config.
-  if grep -q '^\[permissions\.airc\.filesystem\]' "$config" 2>/dev/null; then
-    info "Removing stale [permissions.airc.filesystem] block from ~/.codex/config.toml (Codex 0.125 doesn't support outside-workspace filesystem profiles; was breaking session startup)..."
-    "${AIRC_PYTHON:-python3}" - "$config" <<'PY'
-import sys, re
-path = sys.argv[1]
-with open(path) as f:
-    text = f.read()
-# Strip from any '# airc filesystem permissions' header (or bare
-# [permissions.airc.filesystem] header) through end of that section
-# and any [permissions.airc.filesystem.<sub>] children. Section ends
-# at the next top-level header that is NOT under [permissions.airc.filesystem].
-lines = text.splitlines(keepends=True)
-out = []
-in_airc_fs = False
-for line in lines:
-    stripped = line.strip()
-    if stripped.startswith('# airc filesystem permissions'):
-        # Drop the leading comment block too (cohesive with the section)
-        in_airc_fs = True
-        continue
-    if stripped.startswith('[permissions.airc.filesystem'):
-        in_airc_fs = True
-        continue
-    if in_airc_fs:
-        # Continue dropping comment lines and key=value lines until we
-        # hit a new section header that isn't airc.filesystem.
-        if stripped.startswith('[') and not stripped.startswith('[permissions.airc.filesystem'):
-            in_airc_fs = False
-            out.append(line)
-        # else: drop (comment, blank, or key=value within the section)
-        continue
-    out.append(line)
-# Collapse runs of >2 blank lines that the strip might have left.
-result = ''.join(out)
-result = re.sub(r'\n{3,}', '\n\n', result)
-with open(path, 'w') as f:
-    f.write(result)
-PY
-    _changed=1
-  fi
+  # Cleanup for stale [permissions.airc.filesystem] blocks lives in the
+  # Rust Codex hook installer below. Keep this profile function focused
+  # on the network profile it owns.
 
   # Set default_permissions = "airc" at the file's top level, but only if
   # no default is currently set. A pre-existing default belongs to the

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -54,8 +54,6 @@ cmd_doctor() {
   _doctor_probe_gh_auth                                             || issues=$((issues+1))
   _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"     || issues=$((issues+1))
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"     || issues=$((issues+1))
-  _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"    || issues=$((issues+1))
-  _doctor_probe_cryptography                                            || issues=$((issues+1))
   # sshd probe removed post-3c: the gist IS the wire for ALL peers; airc no
   # longer ssh's into the host's airc_home. ssh-keygen above stays (identity
   # key generation), ssh client stays (occasional manual diagnostic + future
@@ -118,11 +116,6 @@ _doctor_install_cmd_for() {
         pacman) pkg="openssh" ;;
         apk)    pkg="openssh-client" ;;
       esac ;;
-    python3)
-      case "$mgr" in
-        pacman) pkg="python" ;;
-        *)      pkg="python3" ;;
-      esac ;;
     *) pkg="$prereq" ;;
   esac
   case "$mgr" in
@@ -139,44 +132,15 @@ _doctor_install_cmd_for() {
 
 _doctor_probe() {
   local cmd="$1" mgr="$2" purpose="$3"
-  # Strict-probe ONLY the binaries that have known shadow-aliases on
-  # Windows. PR #153's blanket strict-probe broke on macOS BSD utilities
-  # — `ssh-keygen --version` exits 1 ("illegal option") because BSD
-  # doesn't accept --version, and there's no portable single-flag that
-  # discriminates "real ssh-keygen" from "stub" anyway. Only the
-  # Microsoft Store {python.exe, python3.exe} aliases need defense
-  # against; everything else is uniquely shipped by the user's package
-  # manager (no shadowing ambiguity), so bare `command -v` is correct.
-  case "$cmd" in
-    python|python3)
-      if command -v "$cmd" >/dev/null 2>&1 && "$cmd" --version >/dev/null 2>&1; then
-        printf "  [ok] %s\n" "$cmd"
-        return 0
-      fi
-      ;;
-    *)
-      if command -v "$cmd" >/dev/null 2>&1; then
-        printf "  [ok] %s\n" "$cmd"
-        return 0
-      fi
-      ;;
-  esac
-  # Distinguish "absent" from "stub on PATH" so the fix hint is correct.
-  local fix
   if command -v "$cmd" >/dev/null 2>&1; then
-    # Present but non-functional — almost certainly a stub.
-    printf "  [BROKEN] %s -- %s\n" "$cmd" "$purpose"
-    printf "         '%s' is on PATH but '%s --version' fails. " "$cmd" "$cmd"
-    printf "Likely a Microsoft Store alias on Windows.\n"
-    printf "         Disable: Settings -> Apps -> Advanced app settings -> App execution aliases\n"
-    printf "         Or PATH-prepend a real install ahead of WindowsApps/.\n"
-    fix=$(_doctor_install_cmd_for "$mgr" "$cmd")
-    printf "         Or install fresh: %s\n" "$fix"
-  else
-    fix=$(_doctor_install_cmd_for "$mgr" "$cmd")
-    printf "  [MISSING] %s -- %s\n" "$cmd" "$purpose"
-    printf "         Fix: %s\n" "$fix"
+    printf "  [ok] %s\n" "$cmd"
+    return 0
   fi
+
+  local fix
+  fix=$(_doctor_install_cmd_for "$mgr" "$cmd")
+  printf "  [MISSING] %s -- %s\n" "$cmd" "$purpose"
+  printf "         Fix: %s\n" "$fix"
   return 1
 }
 
@@ -207,26 +171,6 @@ _doctor_probe_gh_auth() {
       return 1
       ;;
   esac
-}
-
-# Probe the venv cryptography package — issue #341 follow-up. airc's
-# Ed25519 identity gen + signing now route through python-cryptography;
-# without it init_identity / sign_message hard-fail. install.sh's venv
-# step pip-installs it, so the failure surface here is "venv setup
-# didn't complete cleanly" or "the system python the resolver picked
-# differs from the venv one". Either way: surface clearly so doctor
-# tells the user to re-run install.sh.
-_doctor_probe_cryptography() {
-  if ! command -v "${AIRC_PYTHON:-python3}" >/dev/null 2>&1; then
-    return 0  # already reported missing by the python3 probe
-  fi
-  if "${AIRC_PYTHON:-python3}" -c "import cryptography.hazmat.primitives.asymmetric.ed25519" >/dev/null 2>&1; then
-    printf "  [ok] cryptography (Ed25519 identity gen + signing)\n"
-    return 0
-  fi
-  printf "  [MISSING] cryptography (Python package, used for Ed25519 identity)\n"
-  printf "         Fix: re-run install.sh (sets up the venv with cryptography)\n"
-  return 1
 }
 
 _doctor_probe_tailscale() {
@@ -280,8 +224,6 @@ _doctor_connect_preflight() {
   _doctor_probe "git"          "$mgr" "VCS for clone/update"           || issues=$((issues+1))
   _doctor_probe "ssh"          "$mgr" "OpenSSH client for the wire"    || issues=$((issues+1))
   _doctor_probe "ssh-keygen"   "$mgr" "Identity keypair generation"    || issues=$((issues+1))
-  _doctor_probe "python3"      "$mgr" "Monitor formatter + heredocs"   || issues=$((issues+1))
-  _doctor_probe_cryptography                                           || issues=$((issues+1))
   # sshd probe removed post-3c — see cmd_doctor() in this file for rationale.
 
   # ── gh chain: installed → authed → gist scope → gists API reachable.

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -43,6 +43,21 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('ln -sf "$built" "$BIN_DIR/airc-rs"', source)
         self.assertIn('cp -f "$built" "$BIN_DIR/airc-rs.exe"', source)
 
+    def test_installer_no_longer_bootstraps_python_runtime(self):
+        source = (REPO / "install.sh").read_text(encoding="utf-8")
+
+        self.assertNotIn("python3 -m venv", source)
+        self.assertNotIn("pip install", source)
+        self.assertNotIn("cryptography is not importable", source)
+        self.assertNotIn("${AIRC_PYTHON:-python3}", source)
+
+    def test_doctor_no_longer_requires_python_runtime(self):
+        source = (REPO / "lib/airc_bash/cmd_doctor.sh").read_text(encoding="utf-8")
+
+        self.assertNotIn('_doctor_probe "python3"', source)
+        self.assertNotIn("_doctor_probe_cryptography", source)
+        self.assertNotIn("AIRC_PYTHON", source)
+
     def test_uninstaller_uses_rust_codex_hook_uninstaller(self):
         source = (REPO / "uninstall.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Summary
- remove Python/cryptography venv bootstrap from install.sh
- stop doctor from requiring Python or Python cryptography
- move stale Codex filesystem permission cleanup into airc-rs codex-hook install-hooks
- add static and runtime tests guarding the installer/doctor Rust cutover

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-cli codex_hook_installer
- python3 test/test_codex_rust_cutover.py
- bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace