### PR TITLE
chore(runtime): remove python debug path

### DIFF
--- a/airc
+++ b/airc
@@ -2671,11 +2671,6 @@ case "${1:-help}" in
   debug-scope) echo "$AIRC_WRITE_DIR" ;;
   debug-name)  resolve_name ;;
   debug-host)  get_host ;;
-  debug-pythonpath)
-    echo "AIRC_PYTHON=${AIRC_PYTHON:-<unset>}"
-    echo "lib_dir=${_airc_lib_dir:-<not-resolved>}"
-    echo "PYTHONPATH=${PYTHONPATH:-<unset>}"
-    "${AIRC_PYTHON:-python3}" -c "import airc_core; print(f'airc_core import ok: v{airc_core.__version__}')" 2>&1 ;;
   help|--help|-h)
     echo "AIRC — Agentic Internet Relay Chat for AI peers"
     echo "(IRC verbs are the public interface)"

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -18,7 +18,7 @@
 #
 # External cross-references (call-time): die, ensure_init, get_config_val,
 # set_config_val, unset_config_keys, get_host, resolve_name, relay_ssh,
-# remote_home, AIRC_HOME, AIRC_WRITE_DIR, AIRC_PYTHON, plus cmd_teardown
+# remote_home, AIRC_HOME, AIRC_WRITE_DIR, plus cmd_teardown
 # (which cmd_part calls to do the actual local kill).
 #
 # Extracted from airc as part of #152 Phase 3 file split. Bundled because
@@ -152,7 +152,7 @@ cmd_rooms() {
 # Convert an ISO 8601 timestamp into a relative-time string ("12m ago",
 # "3h ago", "2d ago"). Falls back to the raw timestamp on parse failure.
 # Used by cmd_rooms to display gist activity (#82). Date parsing goes
-# through iso_to_epoch so the BSD/GNU/python fallback chain is shared.
+# through iso_to_epoch so date parsing stays centralized.
 _format_relative_time() {
   local ts="${1:-}"
   [ -z "$ts" ] && { echo "(unknown)"; return; }

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -9,7 +9,7 @@
 # Both are read-only introspection and share no helpers, but live in
 # the same conceptual group ("what is happening?"). External cross-
 # references (call-time): die, ensure_init, get_config_val, relay_ssh,
-# remote_home, MESSAGES, AIRC_PYTHON.
+# remote_home, MESSAGES.
 #
 # Extracted from airc as part of #152 Phase 3 file split.
 

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -111,6 +111,13 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("requires a working python", startup)
         self.assertNotIn("python3 --version", startup)
 
+    def test_airc_has_no_python_debug_runtime_path(self):
+        source = (REPO / "airc").read_text(encoding="utf-8")
+
+        self.assertNotIn("debug-pythonpath", source)
+        self.assertNotIn("AIRC_PYTHON", source)
+        self.assertNotIn("python3", source)
+
     def test_quick_message_roster_uses_airc_rs(self):
         source = (REPO / "airc").read_text(encoding="utf-8")
         start = source.index('if [ "$qm_owner" = "*roster*" ]; then')

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -16,7 +16,7 @@
 # What it leaves:
 #   - per-project .airc/ state in every dir you ran `airc join` from
 #     (identity keys, peer records, message logs — your data, not ours)
-#   - gh auth, brew/apt-installed packages (gh / python3 / openssl)
+#   - gh auth, brew/apt-installed packages (gh / cargo / openssh)
 #   - other agents' configs (Codex / Cursor / opencode / etc.)
 #
 # Flags:
@@ -66,7 +66,7 @@ This will remove airc from this machine:
 
 It will NOT remove:
   per-project .airc/ state in every dir you ran 'airc join' from
-  gh auth, brew/apt packages (gh / python3 / openssl)
+  gh auth, brew/apt packages (gh / cargo / openssh)
   other agents' configs
 
 EOF


### PR DESCRIPTION
Summary
- remove the airc debug-pythonpath command and final AIRC_PYTHON wrapper reference
- clean stale Python dependency comments from uninstall/status/rooms shell files
- add a cutover guard proving the airc wrapper contains no Python runtime path

Verification
- python3 test/test_codex_rust_cutover.py
- bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace