### PR TITLE
test(integration): probe bearer kinds through rust

### DIFF
--- a/crates/airc-cli/src/bearer/cli.rs
+++ b/crates/airc-cli/src/bearer/cli.rs
@@ -8,6 +8,9 @@ pub struct BearerArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum BearerAction {
+    /// Print registered legacy bearer kinds, one per line.
+    Kinds,
+
     /// Deliver one legacy JSONL envelope from stdin.
     Send {
         peer_id: String,

--- a/crates/airc-cli/src/bearer/commands.rs
+++ b/crates/airc-cli/src/bearer/commands.rs
@@ -9,6 +9,14 @@ use super::outcome::{kind_name, SendKind, SendOutcome};
 use super::rotate::rotate_if_needed;
 use crate::gh_state::now_seconds;
 
+const REGISTERED_BEARER_KINDS: &[&str] = &["gh"];
+
+pub fn run_kinds() {
+    for kind in REGISTERED_BEARER_KINDS {
+        println!("{kind}");
+    }
+}
+
 pub fn run_send(
     _peer_id: &str,
     _channel: &str,
@@ -227,6 +235,11 @@ fn sleep_jittered_backoff(attempt: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn registered_bearer_kinds_are_explicit() {
+        assert_eq!(REGISTERED_BEARER_KINDS, &["gh"]);
+    }
 
     #[test]
     fn frame_line_adds_exactly_one_newline() {

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -208,6 +208,10 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         } => metronome_commands::run_recent_senders(&messages_log, window_seconds, &exclude_name),
 
         Command::Bearer(args) => match args.action {
+            BearerAction::Kinds => {
+                bearer::commands::run_kinds();
+                Ok(())
+            }
             BearerAction::Send {
                 peer_id,
                 channel,

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -18,6 +18,21 @@ set -u
 
 AIRC="${AIRC:-$(cd "$(dirname "$0")/.." && pwd)/airc}"
 [ -x "$AIRC" ] || { echo "FATAL: $AIRC not executable"; exit 2; }
+AIRC_REPO_ROOT="$(cd "$(dirname "$AIRC")" && pwd)"
+
+airc_rs_bin() {
+  if command -v airc-rs >/dev/null 2>&1; then
+    command -v airc-rs
+    return 0
+  fi
+  for candidate in "$AIRC_REPO_ROOT/target/release/airc-rs" "$AIRC_REPO_ROOT/target/debug/airc-rs"; do
+    if [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
 
 # Suppress the #general sidecar globally for the test suite (issue #121).
 # Default behavior on canary spawns a sibling .general scope alongside
@@ -152,7 +167,7 @@ requires_local_pair_bearer_or_skip() {
   local _scn="$1"
   if [ -z "$_airc_have_local_bearer" ]; then
     local _kinds
-    _kinds=$(PYTHONPATH="$(dirname "$AIRC")/lib" python3 -c "from airc_core.bearer_resolver import available_kinds; print(' '.join(available_kinds()))" 2>/dev/null || echo "")
+    _kinds=$("$(airc_rs_bin)" bearer kinds 2>/dev/null | tr '\n' ' ' || echo "")
     case " $_kinds " in
       *" local "*|*" ssh "*) _airc_have_local_bearer="yes" ;;
       *)                     _airc_have_local_bearer="no" ;;

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -64,6 +64,16 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("scenario_python_units", source)
         self.assertNotIn("python units:", source)
 
+    def test_integration_local_bearer_probe_uses_airc_rs(self):
+        source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
+        start = source.index("requires_local_pair_bearer_or_skip()")
+        end = source.index("# Reap any orphan room gists", start)
+        body = source[start:end]
+
+        self.assertIn('"$(airc_rs_bin)" bearer kinds', body)
+        self.assertNotIn("airc_core.bearer_resolver", body)
+        self.assertNotIn("python3", body)
+
     def test_uninstaller_uses_rust_codex_hook_uninstaller(self):
         source = (REPO / "uninstall.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Summary
- add airc-rs bearer kinds for the registered legacy bearer list
- use that Rust command for integration local-pair bearer gating
- add a cutover guard preventing the Python bearer resolver probe from returning

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-cli registered_bearer_kinds_are_explicit
- bash -n test/integration.sh install.sh uninstall.sh airc lib/airc_bash/*.sh
- python3 test/test_codex_rust_cutover.py
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- bearer kinds
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace