### PR TITLE
test(integration): edit top-level config through rust

### DIFF
--- a/test/integration.sh
+++ b/test/integration.sh
@@ -734,16 +734,11 @@ scenario_queue() {
 
   # Snapshot the real host_target, then flip to an unreachable address.
   local real_target
-  real_target=$(python3 -c "import json; print(json.load(open('/tmp/airc-it-q-j/state/config.json'))['host_target'])")
+  real_target=$("$(airc_rs_bin)" config get --config /tmp/airc-it-q-j/state/config.json host_target)
   [ -n "$real_target" ] || { fail "no host_target recorded in joiner config"; return; }
 
-  python3 -c "
-import json
-p = '/tmp/airc-it-q-j/state/config.json'
-c = json.load(open(p))
-c['host_target'] = 'nobody@198.51.100.99'
-json.dump(c, open(p, 'w'))
-"
+  "$(airc_rs_bin)" config set --config /tmp/airc-it-q-j/state/config.json \
+    --key host_target --value nobody@198.51.100.99
   # Also fake the peer record so resolution doesn't fail on @qhost
   echo '{"name":"qhost","host":"nobody@198.51.100.99","airc_home":"/tmp/nowhere"}' \
     > /tmp/airc-it-q-j/state/peers/qhost.json
@@ -765,13 +760,8 @@ json.dump(c, open(p, 'w'))
     || fail "send during outage: no [QUEUED] marker in local messages.jsonl"
 
   # ── Recovery: restore real host_target, wait for flush loop ─────────
-  python3 -c "
-import json
-p = '/tmp/airc-it-q-j/state/config.json'
-c = json.load(open(p))
-c['host_target'] = '$real_target'
-json.dump(c, open(p, 'w'))
-"
+  "$(airc_rs_bin)" config set --config /tmp/airc-it-q-j/state/config.json \
+    --key host_target --value "$real_target"
   pass "joiner: host_target restored (recovery simulation)"
 
   # Flush loop on joiner polls every ~5s; give up to 25s.
@@ -1355,7 +1345,7 @@ scenario_identity() {
   # nick that would have triggered the bug and asserting the stored
   # name has no leading dash.
   AIRC_HOME="$home/state" "$AIRC" nick ".dottyname" >/dev/null 2>&1 || true
-  local renamed; renamed=$(python3 -c "import json; print(json.load(open('$home/state/config.json')).get('name',''))" 2>/dev/null)
+  local renamed; renamed=$("$(airc_rs_bin)" config get --config "$home/state/config.json" name)
   case "$renamed" in
     -*) fail "airc nick produced leading-dash name '$renamed' — sanitization regression" ;;
     "") fail "airc nick wrote empty name — sanitization regression" ;;

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -85,6 +85,21 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("AIRC_PYTHON", body)
         self.assertNotIn("python3", body)
 
+    def test_integration_top_level_config_edits_use_airc_rs(self):
+        source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
+        queue_start = source.index("scenario_queue()")
+        queue_end = source.index("scenario_status()", queue_start)
+        queue_body = source[queue_start:queue_end]
+        teardown_start = source.index("airc nick post-sanitization")
+        teardown_end = source.index("cleanup_all", teardown_start)
+        teardown_body = source[teardown_start:teardown_end]
+
+        self.assertIn('"$(airc_rs_bin)" config get --config /tmp/airc-it-q-j/state/config.json host_target', queue_body)
+        self.assertIn('"$(airc_rs_bin)" config set --config /tmp/airc-it-q-j/state/config.json', queue_body)
+        self.assertIn('"$(airc_rs_bin)" config get --config "$home/state/config.json" name', teardown_body)
+        self.assertNotIn("python3 -c", queue_body)
+        self.assertNotIn("python3 -c", teardown_body)
+
     def test_uninstaller_uses_rust_codex_hook_uninstaller(self):
         source = (REPO / "uninstall.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Summary
- replace scenario_queue host_target reads/writes with airc-rs config get/set
- replace identity nick sanitization config read with airc-rs config get
- add a cutover guard covering these top-level config edits

Verification
- bash -n test/integration.sh install.sh uninstall.sh airc lib/airc_bash/*.sh
- python3 test/test_codex_rust_cutover.py
- airc-rs config get/set smoke via cargo run