### PR TITLE
feat(config): probe quit fixtures through rust

### DIFF
--- a/crates/airc-cli/src/config_cli.rs
+++ b/crates/airc-cli/src/config_cli.rs
@@ -22,6 +22,27 @@ pub enum ConfigAction {
         default: String,
     },
 
+    /// Print a dotted config path, or a default when missing/null.
+    GetPath {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Dotted path, for example `.identity.role`.
+        path: String,
+        /// Value printed when the path is missing or null.
+        #[arg(default_value = "")]
+        default: String,
+    },
+
+    /// Print whether a top-level config key exists.
+    HasKey {
+        /// Config file. Defaults to `<home>/config.json`.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Top-level config key.
+        key: String,
+    },
+
     /// Print the configured identity name.
     GetName {
         /// Config file. Defaults to `<home>/config.json`.

--- a/crates/airc-cli/src/config_commands.rs
+++ b/crates/airc-cli/src/config_commands.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 use serde_json::{Map, Value};
 
+use crate::json_path::{emit_value, navigate};
+
 #[derive(Debug, Deserialize)]
 struct ConfigFile {
     #[serde(default)]
@@ -22,6 +24,28 @@ pub fn run_get(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = config.unwrap_or_else(|| home.join("config.json"));
     println!("{}", config_value(&config, key, default));
+    Ok(())
+}
+
+pub fn run_get_path(
+    home: &Path,
+    config: Option<PathBuf>,
+    path: &str,
+    default: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    let root = load_value(&config);
+    let value = navigate(&root, path).unwrap_or(&Value::Null);
+    emit_value(value, default)
+}
+
+pub fn run_has_key(
+    home: &Path,
+    config: Option<PathBuf>,
+    key: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = config.unwrap_or_else(|| home.join("config.json"));
+    println!("{}", config_has_key(&config, key));
     Ok(())
 }
 
@@ -341,6 +365,13 @@ fn config_value(path: &Path, key: &str, default: &str) -> String {
     }
 }
 
+fn config_has_key(path: &Path, key: &str) -> bool {
+    load_value(path)
+        .as_object()
+        .map(|object| object.contains_key(key))
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -379,6 +410,46 @@ mod tests {
 
         assert_eq!(config_value(&path, "identity", "{}"), r#"{"role":"agent"}"#);
         assert_eq!(config_value(&path, "rooms", "[]"), r#"["general"]"#);
+    }
+
+    #[test]
+    fn get_path_reads_nested_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(
+            &path,
+            r#"{"identity":{"role":"agent","enabled":true},"rooms":["general"]}"#,
+        )
+        .unwrap();
+
+        let root = load_value(&path);
+        assert_eq!(
+            navigate(&root, ".identity.role").and_then(Value::as_str),
+            Some("agent")
+        );
+        assert_eq!(
+            navigate(&root, ".identity.enabled").and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            navigate(&root, ".rooms[0]").and_then(Value::as_str),
+            Some("general")
+        );
+    }
+
+    #[test]
+    fn has_key_reports_top_level_presence() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(&path, r#"{"host_target":"","identity":{"role":"agent"}}"#).unwrap();
+
+        assert!(config_has_key(&path, "host_target"));
+        assert!(config_has_key(&path, "identity"));
+        assert!(!config_has_key(&path, "missing"));
+        assert!(!config_has_key(
+            &dir.path().join("missing.json"),
+            "host_target"
+        ));
     }
 
     #[test]

--- a/crates/airc-cli/src/gist_commands.rs
+++ b/crates/airc-cli/src/gist_commands.rs
@@ -3,6 +3,8 @@ use std::io::{self, Read};
 
 use serde_json::Value;
 
+use crate::json_path::{emit_value, navigate};
+
 pub fn run_get(path: &str, default: &str) -> Result<(), Box<dyn Error>> {
     let value = read_stdin_json()
         .and_then(|json| navigate(&json, path).cloned())
@@ -111,60 +113,6 @@ fn read_stdin_json() -> Option<Value> {
         return None;
     }
     serde_json::from_str(&raw).ok()
-}
-
-fn navigate<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
-    if path.is_empty() || path == "." {
-        return Some(value);
-    }
-
-    let mut current = value;
-    for segment in path.strip_prefix('.')?.split('.') {
-        if segment.is_empty() {
-            return None;
-        }
-        let (key, index) = parse_segment(segment)?;
-        if !key.is_empty() {
-            current = current.as_object()?.get(key)?;
-        }
-        if let Some(index) = index {
-            current = current.as_array()?.get(index)?;
-        }
-    }
-    Some(current)
-}
-
-fn parse_segment(segment: &str) -> Option<(&str, Option<usize>)> {
-    if segment.starts_with('[') {
-        return Some(("", Some(parse_index(segment)?)));
-    }
-    let Some(open) = segment.find('[') else {
-        return valid_key(segment).then_some((segment, None));
-    };
-    let key = &segment[..open];
-    valid_key(key).then_some((key, Some(parse_index(&segment[open..])?)))
-}
-
-fn valid_key(key: &str) -> bool {
-    let mut chars = key.chars();
-    matches!(chars.next(), Some(first) if first == '_' || first.is_ascii_alphabetic())
-        && chars.all(|ch| ch == '_' || ch == '-' || ch.is_ascii_alphanumeric())
-}
-
-fn parse_index(segment: &str) -> Option<usize> {
-    let inner = segment.strip_prefix('[')?.strip_suffix(']')?;
-    inner.parse().ok()
-}
-
-fn emit_value(value: &Value, default: &str) -> Result<(), Box<dyn Error>> {
-    match value {
-        Value::Null => println!("{default}"),
-        Value::String(text) => println!("{text}"),
-        Value::Bool(true) => println!("true"),
-        Value::Bool(false) => println!("false"),
-        other => println!("{}", serde_json::to_string(other)?),
-    }
-    Ok(())
 }
 
 fn pick_addr<F>(json: &Value, allowed_scope: F) -> Option<String>

--- a/crates/airc-cli/src/json_path.rs
+++ b/crates/airc-cli/src/json_path.rs
@@ -1,0 +1,83 @@
+use std::error::Error;
+
+use serde_json::Value;
+
+pub fn navigate<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    if path.is_empty() || path == "." {
+        return Some(value);
+    }
+
+    let mut current = value;
+    for segment in path.strip_prefix('.')?.split('.') {
+        if segment.is_empty() {
+            return None;
+        }
+        let (key, index) = parse_segment(segment)?;
+        if !key.is_empty() {
+            current = current.as_object()?.get(key)?;
+        }
+        if let Some(index) = index {
+            current = current.as_array()?.get(index)?;
+        }
+    }
+    Some(current)
+}
+
+pub fn emit_value(value: &Value, default: &str) -> Result<(), Box<dyn Error>> {
+    match value {
+        Value::Null => println!("{default}"),
+        Value::String(text) => println!("{text}"),
+        Value::Bool(true) => println!("true"),
+        Value::Bool(false) => println!("false"),
+        other => println!("{}", serde_json::to_string(other)?),
+    }
+    Ok(())
+}
+
+fn parse_segment(segment: &str) -> Option<(&str, Option<usize>)> {
+    if segment.starts_with('[') {
+        return Some(("", Some(parse_index(segment)?)));
+    }
+    let Some(open) = segment.find('[') else {
+        return valid_key(segment).then_some((segment, None));
+    };
+    let key = &segment[..open];
+    valid_key(key).then_some((key, Some(parse_index(&segment[open..])?)))
+}
+
+fn valid_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    matches!(chars.next(), Some(first) if first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch == '-' || ch.is_ascii_alphanumeric())
+}
+
+fn parse_index(segment: &str) -> Option<usize> {
+    let inner = segment.strip_prefix('[')?.strip_suffix(']')?;
+    inner.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn navigate_reads_paths_and_indexes() {
+        let value = json!({"host":{"addresses":[{"addr":"127.0.0.1"}]}});
+
+        assert_eq!(
+            navigate(&value, ".host.addresses[0].addr").and_then(Value::as_str),
+            Some("127.0.0.1")
+        );
+        assert!(navigate(&value, ".host.addresses[1].addr").is_none());
+    }
+
+    #[test]
+    fn navigate_rejects_invalid_paths() {
+        let value = json!({"host":{"name":"alpha"}});
+
+        assert!(navigate(&value, "host.name").is_none());
+        assert!(navigate(&value, ".host..name").is_none());
+        assert!(navigate(&value, ".host.name[bad]").is_none());
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -44,6 +44,7 @@ mod hygiene_cli;
 mod hygiene_commands;
 mod identity_cli;
 mod identity_commands;
+mod json_path;
 mod knock_cli;
 mod knock_commands;
 mod lane_cli;
@@ -267,6 +268,14 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 key,
                 default,
             } => config_commands::run_get(&home, config, &key, &default),
+            ConfigAction::GetPath {
+                config,
+                path,
+                default,
+            } => config_commands::run_get_path(&home, config, &path, &default),
+            ConfigAction::HasKey { config, key } => {
+                config_commands::run_has_key(&home, config, &key)
+            }
             ConfigAction::GetName { config } => config_commands::run_get_name(&home, config),
             ConfigAction::Set { config, key, value } => {
                 config_commands::run_set(&home, config, &key, &value)

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -3326,10 +3326,10 @@ JSON
 
   # Identity preserved
   local name pronouns role bio
-  name=$(python3 -c "import json; print(json.load(open('$home/config.json')).get('name',''))" 2>/dev/null)
-  pronouns=$(python3 -c "import json; print(json.load(open('$home/config.json')).get('identity',{}).get('pronouns',''))" 2>/dev/null)
-  role=$(python3 -c "import json; print(json.load(open('$home/config.json')).get('identity',{}).get('role',''))" 2>/dev/null)
-  bio=$(python3 -c "import json; print(json.load(open('$home/config.json')).get('identity',{}).get('bio',''))" 2>/dev/null)
+  name=$("$(airc_rs_bin)" config get --config "$home/config.json" name)
+  pronouns=$("$(airc_rs_bin)" config get-path --config "$home/config.json" .identity.pronouns)
+  role=$("$(airc_rs_bin)" config get-path --config "$home/config.json" .identity.role)
+  bio=$("$(airc_rs_bin)" config get-path --config "$home/config.json" .identity.bio)
   [ "$name" = "alpha" ] && pass "name survives quit" || fail "name lost (got: '$name')"
   [ "$pronouns" = "they" ] && pass "pronouns survive quit" || fail "pronouns lost (got: '$pronouns')"
   [ "$role" = "agent" ] && pass "role survives quit" || fail "role lost (got: '$role')"
@@ -3337,10 +3337,10 @@ JSON
 
   # Host-pairing fields cleared
   local has_target has_name
-  has_target=$(python3 -c "import json; print('host_target' in json.load(open('$home/config.json')))" 2>/dev/null)
-  has_name=$(python3 -c "import json; print('host_name' in json.load(open('$home/config.json')))" 2>/dev/null)
-  [ "$has_target" = "False" ] && pass "host_target cleared by quit" || fail "host_target still present"
-  [ "$has_name" = "False" ] && pass "host_name cleared by quit" || fail "host_name still present"
+  has_target=$("$(airc_rs_bin)" config has-key --config "$home/config.json" host_target)
+  has_name=$("$(airc_rs_bin)" config has-key --config "$home/config.json" host_name)
+  [ "$has_target" = "false" ] && pass "host_target cleared by quit" || fail "host_target still present"
+  [ "$has_name" = "false" ] && pass "host_name cleared by quit" || fail "host_name still present"
 
   # SSH key file preserved (identity material)
   [ -f "$home/identity/ssh_key" ] && pass "ssh_key preserved (identity material)" || fail "ssh_key lost"
@@ -3354,8 +3354,8 @@ JSON
 }
 JSON
   AIRC_HOME="$home" "$AIRC" disconnect >/dev/null 2>&1
-  has_target=$(python3 -c "import json; print('host_target' in json.load(open('$home/config.json')))" 2>/dev/null)
-  [ "$has_target" = "False" ] && pass "disconnect alias clears pairing too" || fail "disconnect alias didn't clear"
+  has_target=$("$(airc_rs_bin)" config has-key --config "$home/config.json" host_target)
+  [ "$has_target" = "false" ] && pass "disconnect alias clears pairing too" || fail "disconnect alias didn't clear"
 
   rm -rf /tmp/airc-it-q-quit
   cleanup_all

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -100,6 +100,17 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("python3 -c", queue_body)
         self.assertNotIn("python3 -c", teardown_body)
 
+    def test_integration_quit_config_probes_use_airc_rs(self):
+        source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
+        start = source.index("scenario_quit()")
+        end = source.index("scenario_platform_adapters()", start)
+        body = source[start:end]
+
+        self.assertIn('"$(airc_rs_bin)" config get --config "$home/config.json" name', body)
+        self.assertIn('"$(airc_rs_bin)" config get-path --config "$home/config.json" .identity.pronouns', body)
+        self.assertIn('"$(airc_rs_bin)" config has-key --config "$home/config.json" host_target', body)
+        self.assertNotIn("python3 -c", body)
+
     def test_uninstaller_uses_rust_codex_hook_uninstaller(self):
         source = (REPO / "uninstall.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Summary
- add shared dotted JSON path navigation for airc-rs CLI commands
- add config get-path and config has-key for nested config reads and key-presence probes
- route quit/disconnect integration fixture checks through airc-rs instead of python3 -c
- add a static cutover guard for the quit scenario

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli config_commands::tests -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli json_path::tests -- --nocapture
- python3 test/test_codex_rust_cutover.py
- bash -n test/integration.sh install.sh uninstall.sh airc lib/airc_bash/*.sh
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace
- bash test/integration.sh quit