### PR TITLE
test(integration): probe heartbeat gist through rust

### DIFF
--- a/test/integration.sh
+++ b/test/integration.sh
@@ -1638,7 +1638,7 @@ scenario_heartbeat() {
   # Original gist must still exist and now advertise beta as host.
   local recovered_name
   recovered_name=$(gh api "gists/$gist_id" --jq ".files[\"airc-room-${rname}.json\"].content" 2>/dev/null \
-    | python3 -c 'import json,sys; print(json.load(sys.stdin).get("host",{}).get("name",""))' 2>/dev/null || true)
+    | "$(airc_rs_bin)" gist get .host.name 2>/dev/null || true)
   if [ "$recovered_name" = "beta" ]; then
     pass "original gist preserved and host lease updated to beta"
   else

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -109,6 +109,15 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" config get --config "$peer_file" airc_home', body)
         self.assertNotIn("python3 -c", body)
 
+    def test_integration_heartbeat_gist_probe_uses_airc_rs(self):
+        source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
+        start = source.index("scenario_heartbeat()")
+        end = source.index("scenario_bounce()", start)
+        body = source[start:end]
+
+        self.assertIn('"$(airc_rs_bin)" gist get .host.name', body)
+        self.assertNotIn("python3 -c", body)
+
     def test_integration_quit_config_probes_use_airc_rs(self):
         source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
         start = source.index("scenario_quit()")


### PR DESCRIPTION
Summary
- route the heartbeat orphan-gist host-name probe through airc-rs gist get
- add a static cutover guard keeping scenario_heartbeat free of python3 -c probes

Verification
- python3 test/test_codex_rust_cutover.py
- bash -n test/integration.sh install.sh uninstall.sh airc lib/airc_bash/*.sh
- git diff --check
- printf '{"host":{"name":"beta"}}' | cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- gist get .host.name

Attempted live check
- bash test/integration.sh heartbeat currently fails after takeover: beta adopts the original gist id, but the gist content still advertises host='alpha'. This appears to be an existing heartbeat takeover behavior bug, not a parser-regression from this change.