### PR TITLE
fix(heartbeat): patch takeover gist lease deterministically

### DIFF
--- a/airc
+++ b/airc
@@ -371,7 +371,8 @@ _reexec_into() {
   if [ -d "$AIRC_WRITE_DIR" ]; then
     printf '%d:%d\n' "$$" "$(date +%s)" > "$AIRC_WRITE_DIR/airc.reexec-marker" 2>/dev/null || true
   fi
-  local _name; _name=$(get_config_val name "")
+  local _name="${AIRC_NAME:-}"
+  [ -z "$_name" ] && _name=$(get_config_val name "")
   # Preserve user's --room intent across exec when set (see
   # _self_heal_stale_host). Without this, an explicit `airc join --room
   # qa-foo` that triggers stale-host takeover loses --room and
@@ -380,6 +381,9 @@ _reexec_into() {
   if [ "$mode" = "host" ]; then
     exec env AIRC_NO_DISCOVERY=1 \
       ${_name:+AIRC_NAME="$_name"} \
+      ${AIRC_ADOPT_GIST:+AIRC_ADOPT_GIST="$AIRC_ADOPT_GIST"} \
+      ${AIRC_HEARTBEAT_SEC:+AIRC_HEARTBEAT_SEC="$AIRC_HEARTBEAT_SEC"} \
+      ${AIRC_HEARTBEAT_STALE:+AIRC_HEARTBEAT_STALE="$AIRC_HEARTBEAT_STALE"} \
       ${_intent:+AIRC_ROOM_INTENT="$_intent"} \
       "$0" join "$@"
   else

--- a/crates/airc-cli/src/gh_cli.rs
+++ b/crates/airc-cli/src/gh_cli.rs
@@ -15,6 +15,16 @@ pub enum GhAction {
         gh_args: Vec<String>,
     },
 
+    /// Patch one file in a gist using the GitHub API.
+    PatchGistFile {
+        #[arg(long)]
+        gist_id: String,
+        #[arg(long)]
+        filename: String,
+        #[arg(long)]
+        content_file: std::path::PathBuf,
+    },
+
     /// Print current shared backoff wait in seconds.
     WaitSeconds,
 

--- a/crates/airc-cli/src/gh_commands.rs
+++ b/crates/airc-cli/src/gh_commands.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeMap;
 use std::env;
 use std::error::Error;
 use std::fs;
+use std::io::Write;
+use std::path::Path;
 use std::process::Command;
 
 use serde_json::{json, Value};
@@ -14,6 +16,48 @@ use crate::gh_state::{
 
 pub fn run_gh(gh_args: Vec<String>) -> Result<(), Box<dyn Error>> {
     let gh_args = strip_separator(gh_args);
+    run_gh_with_input(gh_args, None)
+}
+
+pub fn run_patch_gist_file(
+    gist_id: &str,
+    filename: &str,
+    content_file: &Path,
+) -> Result<(), Box<dyn Error>> {
+    if gist_id.trim().is_empty() {
+        return Err("gh patch-gist-file: --gist-id is required".into());
+    }
+    if filename.trim().is_empty() {
+        return Err("gh patch-gist-file: --filename is required".into());
+    }
+    let content = fs::read_to_string(content_file)?;
+    let input = patch_gist_file_input(filename, &content);
+    run_gh_with_input(
+        vec![
+            "api".to_string(),
+            "--include".to_string(),
+            "--method".to_string(),
+            "PATCH".to_string(),
+            format!("gists/{gist_id}"),
+            "--input".to_string(),
+            "-".to_string(),
+        ],
+        Some(input),
+    )
+}
+
+fn patch_gist_file_input(filename: &str, content: &str) -> String {
+    json!({
+        "files": {
+            filename: {
+                "content": content
+            }
+        }
+    })
+    .to_string()
+}
+
+fn run_gh_with_input(gh_args: Vec<String>, input: Option<String>) -> Result<(), Box<dyn Error>> {
     let gh = env::var("AIRC_GH_BIN").unwrap_or_else(|_| "gh".to_string());
 
     if gh_args.len() >= 2
@@ -74,7 +118,20 @@ pub fn run_gh(gh_args: Vec<String>) -> Result<(), Box<dyn Error>> {
         return Err("gh request blocked by governor".into());
     }
 
-    let output = Command::new(&gh).args(&gh_args).output()?;
+    let output = if let Some(input) = input {
+        let mut child = Command::new(&gh)
+            .args(&gh_args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()?;
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(input.as_bytes())?;
+        }
+        child.wait_with_output()?
+    } else {
+        Command::new(&gh).args(&gh_args).output()?
+    };
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     print!("{stdout}");
@@ -245,4 +302,22 @@ fn strip_separator(mut args: Vec<String>) -> Vec<String> {
         args.remove(0);
     }
     args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn patch_gist_file_input_targets_exact_filename() {
+        let body =
+            patch_gist_file_input("airc-room-general.json", "{\"host\":{\"name\":\"beta\"}}\n");
+        let parsed: Value = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(
+            parsed["files"]["airc-room-general.json"]["content"],
+            "{\"host\":{\"name\":\"beta\"}}\n"
+        );
+        assert!(parsed["files"]["messages.jsonl"].is_null());
+    }
 }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -618,6 +618,11 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
         Command::Gh(args) => match args.action {
             GhAction::Run { gh_args } => gh_commands::run_gh(gh_args),
+            GhAction::PatchGistFile {
+                gist_id,
+                filename,
+                content_file,
+            } => gh_commands::run_patch_gist_file(&gist_id, &filename, &content_file),
             GhAction::WaitSeconds => {
                 gh_commands::run_wait_seconds();
                 Ok(())

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -2157,7 +2157,10 @@ JSON
         fi
         local _gist_url=""
         if [ -n "${_existing_room_gid:-}" ] && [ "$use_room" = "1" ]; then
-          if gh gist edit "$_existing_room_gid" "$_gist_tmp" >/dev/null 2>/dev/null \
+          if "$(airc_rs_bin)" gh patch-gist-file \
+               --gist-id "$_existing_room_gid" \
+               --filename "airc-room-${room_name}.json" \
+               --content-file "$_gist_tmp" >/dev/null 2>/dev/null \
              || gh gist edit "$_existing_room_gid" -a "$_gist_tmp" >/dev/null 2>/dev/null; then
             _gist_url="https://gist.github.com/$_existing_room_gid"
           fi
@@ -2294,7 +2297,10 @@ JSON
                 # consecutive failures: after N in a row, detect
                 # active-host-evicted (#224) and self-heal.
                 _hb_tried_add=0
-                if gh gist edit "$_gist_id" "$_hb_tmp" >/dev/null 2>"$_hb_stderr"; then
+                if "$(airc_rs_bin)" gh patch-gist-file \
+                     --gist-id "$_gist_id" \
+                     --filename "airc-room-${_hb_room}.json" \
+                     --content-file "$_hb_tmp" >/dev/null 2>"$_hb_stderr"; then
                   _consec_fail=0
                 elif grep -qE 'unsure what file to edit|file does not exist|no such file' "$_hb_stderr" 2>/dev/null \
                      && gh gist edit "$_gist_id" -a "$_hb_tmp" >/dev/null 2>"$_hb_stderr"; then

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -1586,11 +1586,17 @@ scenario_heartbeat() {
   # power-off. Include any recorded child PIDs when present.
   local host_pids host_parent
   host_pids=$(cat /tmp/airc-it-h/state/airc.pid 2>/dev/null || true)
-  host_parent=$(pgrep -f "AIRC_HOME=/tmp/airc-it-h/state.*connect --room $rname" 2>/dev/null | head -1 || true)
+  host_parent=$(pgrep -f "airc connect --room $rname" 2>/dev/null || true)
   [ -n "$host_parent" ] && host_pids="$host_pids $host_parent"
+  host_pids="$host_pids $(pgrep -f "bearer recv .*--room-gist-id $gist_id" 2>/dev/null || true)"
   [ -n "$(printf '%s' "$host_pids" | tr -d '[:space:]')" ] || { fail "no host process found"; gh gist delete "$gist_id" --yes 2>/dev/null; cleanup_all; return; }
   kill -9 $host_pids 2>/dev/null || true
   sleep 1
+  if pgrep -f "airc connect --room $rname" >/dev/null 2>&1; then
+    fail "host process survived kill -9"
+    gh gist delete "$gist_id" --yes 2>/dev/null
+    cleanup_all; return
+  fi
   pass "host kill -9'd ($host_pids)"
 
   # Wait past the stale window. Use the earlier hb2 timestamp as our

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -118,6 +118,24 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" gist get .host.name', body)
         self.assertNotIn("python3 -c", body)
 
+    def test_heartbeat_gist_edits_select_canonical_filename(self):
+        source = (REPO / "lib/airc_bash/cmd_connect.sh").read_text(encoding="utf-8")
+
+        self.assertIn('"$(airc_rs_bin)" gh patch-gist-file', source)
+        self.assertIn('--filename "airc-room-${room_name}.json"', source)
+        self.assertIn('--filename "airc-room-${_hb_room}.json"', source)
+
+    def test_stale_host_reexec_preserves_takeover_env(self):
+        source = (REPO / "airc").read_text(encoding="utf-8")
+        start = source.index("_reexec_into()")
+        end = source.index("# Stale-host self-heal", start)
+        body = source[start:end]
+
+        self.assertIn('local _name="${AIRC_NAME:-}"', body)
+        self.assertIn('${AIRC_ADOPT_GIST:+AIRC_ADOPT_GIST="$AIRC_ADOPT_GIST"}', body)
+        self.assertIn('${AIRC_HEARTBEAT_SEC:+AIRC_HEARTBEAT_SEC="$AIRC_HEARTBEAT_SEC"}', body)
+        self.assertIn('${AIRC_HEARTBEAT_STALE:+AIRC_HEARTBEAT_STALE="$AIRC_HEARTBEAT_STALE"}', body)
+
     def test_integration_quit_config_probes_use_airc_rs(self):
         source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
         start = source.index("scenario_quit()")


### PR DESCRIPTION
Summary
- add airc-rs gh patch-gist-file to PATCH a named gist file through the governed GitHub API path
- use the Rust patch command for host-lease publish and heartbeat refresh instead of ambiguous gh gist edit selection
- preserve AIRC_ADOPT_GIST, AIRC_NAME, and heartbeat timing across stale-host reexec
- make heartbeat e2e kill the full host process set before takeover
- keep the heartbeat gist probe on airc-rs gist get

Verification
- python3 test/test_codex_rust_cutover.py
- bash -n test/integration.sh install.sh uninstall.sh airc lib/airc_bash/*.sh
- git diff --check
- cargo test --manifest-path Cargo.toml -p airc-cli gh_commands::tests -- --nocapture
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace
- AIRC_GH_GUARD_DISABLE=1 bash test/integration.sh heartbeat

Note
- A normal heartbeat run was blocked locally by shared gh-governor backoff from other airc scopes before setup reached the takeover path. With the guard disabled for the proof run, the scenario passed 8/8.