### PR TITLE
test(integration): probe status outage through rust

### DIFF
--- a/test/integration.sh
+++ b/test/integration.sh
@@ -828,14 +828,10 @@ scenario_status() {
 
   # Pending queue: simulate an outage by flipping host_target and sending, then assert queue size.
   # Reuse the same fake-target pattern as scenario_queue.
-  python3 -c "
-import json
-p = '/tmp/airc-it-s-j/state/config.json'
-c = json.load(open(p))
-c['_real_host_target'] = c['host_target']
-c['host_target'] = 'nobody@198.51.100.99'
-json.dump(c, open(p, 'w'))
-"
+  local real_target
+  real_target=$("$(airc_rs_bin)" config get --config /tmp/airc-it-s-j/state/config.json host_target)
+  "$(airc_rs_bin)" config set --config /tmp/airc-it-s-j/state/config.json --key _real_host_target --value "$real_target"
+  "$(airc_rs_bin)" config set --config /tmp/airc-it-s-j/state/config.json --key host_target --value nobody@198.51.100.99
   echo '{"name":"shost","host":"nobody@198.51.100.99","airc_home":"/tmp/nowhere"}' > /tmp/airc-it-s-j/state/peers/shost.json
   AIRC_HOME=/tmp/airc-it-s-j/state "$AIRC" send @shost "status-queue-probe" >/dev/null 2>&1 || true
   local j_out3; j_out3=$(AIRC_HOME=/tmp/airc-it-s-j/state "$AIRC" status 2>&1)

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -109,6 +109,16 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" config get --config "$peer_file" airc_home', body)
         self.assertNotIn("python3 -c", body)
 
+    def test_integration_status_outage_probe_uses_airc_rs(self):
+        source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
+        start = source.index("scenario_status()")
+        end = source.index("scenario_auth_failure()", start)
+        body = source[start:end]
+
+        self.assertIn('"$(airc_rs_bin)" config get --config /tmp/airc-it-s-j/state/config.json host_target', body)
+        self.assertIn('"$(airc_rs_bin)" config set --config /tmp/airc-it-s-j/state/config.json --key host_target', body)
+        self.assertNotIn("python3 -c", body)
+
     def test_integration_heartbeat_gist_probe_uses_airc_rs(self):
         source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
         start = source.index("scenario_heartbeat()")


### PR DESCRIPTION
Summary
- route scenario_status outage fixture mutation through airc-rs config get/set
- remove python3 -c from the status scenario
- add a static cutover guard for the status scenario

Verification
- python3 test/test_codex_rust_cutover.py
- bash -n test/integration.sh install.sh uninstall.sh airc lib/airc_bash/*.sh
- git diff --check
- bash test/integration.sh status