### PR TITLE
test(integration): probe bearer config through rust

### DIFF
--- a/test/integration.sh
+++ b/test/integration.sh
@@ -3612,8 +3612,8 @@ scenario_bearer_ssh_send() {
   # Pull the joiner's host_target + remote_home from its config; identity
   # key is at a known path on disk.
   local jstate=/tmp/airc-it-bs-j/state
-  local host_target; host_target=$(python3 -c "import json; print(json.load(open('$jstate/config.json'))['host_target'])" 2>/dev/null)
-  local rhome;       rhome=$(python3 -c "import json; print(json.load(open('$jstate/config.json')).get('host_airc_home','\$HOME/.airc'))" 2>/dev/null)
+  local host_target; host_target=$("$(airc_rs_bin)" config get --config "$jstate/config.json" host_target)
+  local rhome;       rhome=$("$(airc_rs_bin)" config get --config "$jstate/config.json" host_airc_home "$HOME/.airc")
   # NOTE on port: airc's host_target field stores `user@host` WITHOUT port
   # because the actual SSH messaging goes through the system sshd at port 22
   # (the airc port is only used for the pairing handshake). The bearer's
@@ -3671,8 +3671,8 @@ scenario_bearer_ssh_recv() {
   pass "joiner delta paired with alpha"
 
   local jstate=/tmp/airc-it-br-j/state
-  local host_target; host_target=$(python3 -c "import json; print(json.load(open('$jstate/config.json'))['host_target'])" 2>/dev/null)
-  local rhome;       rhome=$(python3 -c "import json; print(json.load(open('$jstate/config.json')).get('host_airc_home','\$HOME/.airc'))" 2>/dev/null)
+  local host_target; host_target=$("$(airc_rs_bin)" config get --config "$jstate/config.json" host_target)
+  local rhome;       rhome=$("$(airc_rs_bin)" config get --config "$jstate/config.json" host_airc_home "$HOME/.airc")
   # NOTE on port: airc's host_target field stores `user@host` WITHOUT port
   # because the actual SSH messaging goes through the system sshd at port 22
   # (the airc port is only used for the pairing handshake). The bearer's
@@ -3773,8 +3773,8 @@ scenario_bearer_cli_recv() {
   pass "joiner delta paired with alpha"
 
   local jstate=/tmp/airc-it-cli-j/state
-  local host_target; host_target=$(python3 -c "import json; print(json.load(open('$jstate/config.json'))['host_target'])" 2>/dev/null)
-  local rhome;       rhome=$(python3 -c "import json; print(json.load(open('$jstate/config.json')).get('host_airc_home','\$HOME/.airc'))" 2>/dev/null)
+  local host_target; host_target=$("$(airc_rs_bin)" config get --config "$jstate/config.json" host_target)
+  local rhome;       rhome=$("$(airc_rs_bin)" config get --config "$jstate/config.json" host_airc_home "$HOME/.airc")
   local ikey="$jstate/identity/ssh_key"
   local _lib_dir; _lib_dir="$(cd "$(dirname "$AIRC")/lib" && pwd)"
   local hstate=/tmp/airc-it-cli-h/state

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -119,6 +119,17 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('"$(airc_rs_bin)" config set --config /tmp/airc-it-s-j/state/config.json --key host_target', body)
         self.assertNotIn("python3 -c", body)
 
+    def test_integration_bearer_config_probes_use_airc_rs(self):
+        source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
+        start = source.index("scenario_bearer_ssh_send()")
+        end = source.index("scenario_bearer_local()", start)
+        body = source[start:end]
+
+        self.assertIn('"$(airc_rs_bin)" config get --config "$jstate/config.json" host_target', body)
+        self.assertIn('"$(airc_rs_bin)" config get --config "$jstate/config.json" host_airc_home "$HOME/.airc"', body)
+        self.assertNotIn("json.load(open('$jstate/config.json'))", body)
+        self.assertNotIn("python3 -c \"import json; print", body)
+
     def test_integration_heartbeat_gist_probe_uses_airc_rs(self):
         source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
         start = source.index("scenario_heartbeat()")


### PR DESCRIPTION
Summary
- route bearer SSH scenario host_target and host_airc_home reads through airc-rs config get
- remove three python3 config probes from bearer integration setup
- add a static cutover guard for these bearer config probes

Verification
- python3 test/test_codex_rust_cutover.py
- bash -n test/integration.sh install.sh uninstall.sh airc lib/airc_bash/*.sh
- git diff --check
- bash test/integration.sh bearer_ssh_send
- bash test/integration.sh bearer_ssh_recv
- bash test/integration.sh bearer_cli_recv