### PR TITLE
test(integration): probe sidecar channels through rust

### DIFF
--- a/test/integration.sh
+++ b/test/integration.sh
@@ -3089,12 +3089,7 @@ scenario_general_sidecar_default() {
     [ -f "$home1/config.json" ] && grep -q 'subscribed_channels' "$home1/config.json" && break
   done
 
-  if [ -f "$home1/config.json" ] && python3 -c "
-import json,sys
-c=json.load(open('$home1/config.json'))
-chans=c.get('subscribed_channels',[])
-sys.exit(0 if 'general' in chans else 1)
-" 2>/dev/null; then
+  if [ -f "$home1/config.json" ] && "$(airc_rs_bin)" config read-channels --config "$home1/config.json" | grep -qx "general"; then
     pass "subscribed_channels includes 'general'"
   else
     fail "subscribed_channels missing 'general' (config: $(cat "$home1/config.json" 2>/dev/null))"

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -130,6 +130,16 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("json.load(open('$jstate/config.json'))", body)
         self.assertNotIn("python3 -c \"import json; print", body)
 
+    def test_integration_general_sidecar_channels_probe_uses_airc_rs(self):
+        source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
+        start = source.index("scenario_general_sidecar_default()")
+        end = source.index("scenario_away()", start)
+        body = source[start:end]
+
+        self.assertIn('"$(airc_rs_bin)" config read-channels --config "$home1/config.json"', body)
+        self.assertNotIn("subscribed_channels',[]", body)
+        self.assertNotIn("python3 -c", body)
+
     def test_integration_heartbeat_gist_probe_uses_airc_rs(self):
         source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
         start = source.index("scenario_heartbeat()")


### PR DESCRIPTION
Summary
- route the general sidecar subscribed_channels assertion through airc-rs config read-channels
- remove the embedded python3 JSON probe from scenario_general_sidecar_default
- add a static cutover guard for the sidecar channel probe

Verification
- python3 test/test_codex_rust_cutover.py
- bash -n test/integration.sh install.sh uninstall.sh airc lib/airc_bash/*.sh
- git diff --check
- bash test/integration.sh general_sidecar_default