### PR TITLE
test(integration): probe bearer outcome through rust

### DIFF
--- a/test/integration.sh
+++ b/test/integration.sh
@@ -3899,7 +3899,7 @@ scenario_gh_send_creates_messages_jsonl() {
   local probe='{"from":"alpha","to":"all","ts":"2026-04-29T00:00:00Z","channel":"general","msg":"'"$marker"'","sig":"x"}'
   local outcome
   outcome=$(printf '%s' "$probe" | PYTHONPATH="$_lib_dir" python3 -m airc_core.bearer_cli send all general --room-gist-id "$gist_id" 2>&1)
-  local kind; kind=$(printf '%s' "$outcome" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("kind",""))' 2>/dev/null)
+  local kind; kind=$(printf '%s' "$outcome" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
 
   if [ "$kind" = "delivered" ]; then
     pass "bearer_cli send returned 'delivered'"

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -161,6 +161,16 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("channel_gists', {}).get", body)
         self.assertNotIn("python3 -c", body)
 
+    def test_integration_bearer_outcome_kind_probe_uses_airc_rs(self):
+        source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
+        start = source.index("scenario_gh_send_creates_messages_jsonl()")
+        end = source.index("scenario_gist_rotates_under_size_limit()", start)
+        body = source[start:end]
+
+        self.assertIn('"$(airc_rs_bin)" gist get .kind', body)
+        self.assertNotIn("json.load(sys.stdin).get(\"kind\"", body)
+        self.assertNotIn("| python3 -c", body)
+
     def test_integration_heartbeat_gist_probe_uses_airc_rs(self):
         source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
         start = source.index("scenario_heartbeat()")


### PR DESCRIPTION
Summary
- route bearer_cli send outcome kind parsing through airc-rs gist get
- remove the python3 JSON parser from scenario_gh_send_creates_messages_jsonl
- add a static cutover guard for the outcome probe

Verification
- python3 test/test_codex_rust_cutover.py
- bash -n test/integration.sh install.sh uninstall.sh airc lib/airc_bash/*.sh
- git diff --check
- printf '{"kind":"delivered"}' | airc-rs gist get .kind