### PR TITLE
feat(gist): extract named file content through rust

### DIFF
--- a/crates/airc-cli/src/gist_cli.rs
+++ b/crates/airc-cli/src/gist_cli.rs
@@ -45,4 +45,11 @@ pub enum GistAction {
         #[arg(long, default_value = "")]
         channel: String,
     },
+
+    /// Extract a named file's content from a GitHub gist API response.
+    FileContent {
+        /// Exact gist filename, for example messages.jsonl.
+        #[arg(long)]
+        filename: String,
+    },
 }

--- a/crates/airc-cli/src/gist_commands.rs
+++ b/crates/airc-cli/src/gist_commands.rs
@@ -106,6 +106,16 @@ pub fn run_gist_content(channel: &str) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+pub fn run_file_content(filename: &str) -> Result<(), Box<dyn Error>> {
+    let Some(json) = read_stdin_json() else {
+        return Ok(());
+    };
+    if let Some(content) = file_content(&json, filename) {
+        print!("{content}");
+    }
+    Ok(())
+}
+
 fn read_stdin_json() -> Option<Value> {
     let mut raw = String::new();
     io::stdin().read_to_string(&mut raw).ok()?;
@@ -152,6 +162,15 @@ fn gist_content(json: &Value, channel: &str) -> Option<String> {
     files
         .values()
         .find_map(|entry| entry.get("content").and_then(Value::as_str))
+        .map(ToOwned::to_owned)
+}
+
+fn file_content(json: &Value, filename: &str) -> Option<String> {
+    json.get("files")?
+        .as_object()?
+        .get(filename)?
+        .get("content")?
+        .as_str()
         .map(ToOwned::to_owned)
 }
 
@@ -242,6 +261,22 @@ mod tests {
         let content = gist_content(&gist, "acme").unwrap();
         let parsed: Value = serde_json::from_str(&content).unwrap();
         assert_eq!(parsed["invite"], "fresh-host@example");
+    }
+
+    #[test]
+    fn file_content_extracts_exact_filename_with_dot() {
+        let gist = json!({
+            "files": {
+                "messages.jsonl": {"content": "line one\nline two\n"},
+                "airc-room-general.json": {"content": "{}"}
+            }
+        });
+
+        assert_eq!(
+            file_content(&gist, "messages.jsonl").as_deref(),
+            Some("line one\nline two\n")
+        );
+        assert!(file_content(&gist, "missing.jsonl").is_none());
     }
 
     #[test]

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -600,6 +600,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             }
             GistAction::ListLanEntries => gist_commands::run_list_lan_entries(),
             GistAction::GistContent { channel } => gist_commands::run_gist_content(&channel),
+            GistAction::FileContent { filename } => gist_commands::run_file_content(&filename),
         },
 
         Command::Message(args) => match args.action {

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -4767,7 +4767,7 @@ bearer.close()
 
   # Verify the marker actually landed in the gist.
   local content; content=$(gh api "gists/$gist_id" 2>/dev/null \
-    | python3 -c "import sys, json; print(json.load(sys.stdin)['files']['messages.jsonl']['content'])" 2>/dev/null)
+    | "$(airc_rs_bin)" gist file-content --filename messages.jsonl 2>/dev/null)
   if printf '%s' "$content" | grep -q "$marker"; then
     pass "payload visible in gist's messages.jsonl"
   else
@@ -4819,7 +4819,7 @@ finally:
   # wholesale, so reconstruct the full content.
   sleep 2
   local prior_content; prior_content=$(gh api "gists/$gist_id" 2>/dev/null \
-    | python3 -c "import sys, json; print(json.load(sys.stdin)['files']['messages.jsonl']['content'], end='')" 2>/dev/null)
+    | "$(airc_rs_bin)" gist file-content --filename messages.jsonl 2>/dev/null)
   local seed2; seed2=$(mktemp -d -t airc-it-bg-seed2.XXXXXX)
   {
     printf '%s' "$prior_content"

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -171,6 +171,16 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("json.load(sys.stdin).get(\"kind\"", body)
         self.assertNotIn("| python3 -c", body)
 
+    def test_integration_bearer_gist_file_content_uses_airc_rs(self):
+        source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
+        start = source.index("scenario_bearer_gh()")
+        end = source.index("scenario_e2e_encryption()", start)
+        body = source[start:end]
+
+        self.assertIn('"$(airc_rs_bin)" gist file-content --filename messages.jsonl', body)
+        self.assertNotIn("json.load(sys.stdin)['files']['messages.jsonl']['content']", body)
+        self.assertNotIn("| python3 -c", body)
+
     def test_integration_heartbeat_gist_probe_uses_airc_rs(self):
         source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
         start = source.index("scenario_heartbeat()")


### PR DESCRIPTION
Summary
- add airc-rs gist file-content for exact gist filenames such as messages.jsonl
- route bearer_gh messages.jsonl extraction through the Rust CLI
- add Rust unit coverage and static cutover guards for the file-content path

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli file_content
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- python3 test/test_codex_rust_cutover.py
- bash -n test/integration.sh install.sh uninstall.sh airc lib/airc_bash/*.sh
- git diff --check
- printf '{"files":{"messages.jsonl":{"content":"hello\nworld\n"}}}' | cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- gist file-content --filename messages.jsonl
- cargo test --manifest-path Cargo.toml --workspace