### PR TITLE
fix(handshake): accept hyphen-leading public key values

### DIFF
--- a/crates/airc-cli/src/handshake_cli.rs
+++ b/crates/airc-cli/src/handshake_cli.rs
@@ -18,11 +18,11 @@ pub enum HandshakeAction {
         my_name: String,
         #[arg(long, default_value = "")]
         my_host: String,
-        #[arg(long, default_value = "")]
+        #[arg(long, default_value = "", allow_hyphen_values = true)]
         my_ssh_pub: String,
-        #[arg(long, default_value = "")]
+        #[arg(long, default_value = "", allow_hyphen_values = true)]
         my_sign_pub: String,
-        #[arg(long, default_value = "")]
+        #[arg(long, default_value = "", allow_hyphen_values = true)]
         my_x25519_pub: String,
         #[arg(long, default_value = "")]
         my_airc_home: String,
@@ -51,4 +51,48 @@ pub enum HandshakeAction {
         #[arg(long, default_value_t = 0)]
         watch_pid: u32,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::cli::{Cli, Command};
+
+    #[test]
+    fn send_accepts_multiline_hyphen_leading_public_keys() {
+        let pem = "-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----";
+        let cli = Cli::try_parse_from([
+            "airc-rs",
+            "handshake",
+            "send",
+            "127.0.0.1",
+            "7549",
+            "--my-name",
+            "joiner",
+            "--my-host",
+            "user@host",
+            "--my-ssh-pub",
+            "ssh-ed25519 AAAA joiner",
+            "--my-sign-pub",
+            pem,
+            "--my-x25519-pub",
+            "-----x25519-hyphen-leading",
+        ])
+        .expect("hyphen-leading public keys should parse as option values");
+
+        let Command::Handshake(args) = cli.command else {
+            panic!("expected handshake command");
+        };
+        let super::HandshakeAction::Send {
+            my_sign_pub,
+            my_x25519_pub,
+            ..
+        } = args.action
+        else {
+            panic!("expected handshake send");
+        };
+        assert_eq!(my_sign_pub, pem);
+        assert_eq!(my_x25519_pub, "-----x25519-hyphen-leading");
+    }
 }


### PR DESCRIPTION
Summary
- allow handshake send public-key option values to begin with hyphens
- add a clap parser regression covering multiline PEM and hyphen-leading key values
- verify the events integration scenario now pairs and records the join event

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli handshake_cli::tests::send_accepts_multiline_hyphen_leading_public_keys
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- bash test/integration.sh events
- python3 test/test_codex_rust_cutover.py
- bash -n test/integration.sh install.sh uninstall.sh airc lib/airc_bash/*.sh
- git diff --check