### PR TITLE
test(integration): fake gone gist sends through airc-rs

### DIFF
--- a/test/integration.sh
+++ b/test/integration.sh
@@ -21,6 +21,10 @@ AIRC="${AIRC:-$(cd "$(dirname "$0")/.." && pwd)/airc}"
 AIRC_REPO_ROOT="$(cd "$(dirname "$AIRC")" && pwd)"
 
 airc_rs_bin() {
+  if [ -n "${AIRC_RS_BIN:-}" ]; then
+    [ -x "$AIRC_RS_BIN" ] && { printf '%s\n' "$AIRC_RS_BIN"; return 0; }
+    return 1
+  fi
   if command -v airc-rs >/dev/null 2>&1; then
     command -v airc-rs
     return 0
@@ -2073,10 +2077,10 @@ JSON
     && pass "status reports recv-side 404 as degraded despite fresh heartbeat" \
     || fail "status treated recv-side 404 as healthy (got: $status_out)"
 
-  local real_py="${AIRC_PYTHON:-$(command -v python3)}"
-  cat > "$fakebin/python" <<SH
+  local real_airc_rs; real_airc_rs=$(airc_rs_bin)
+  cat > "$fakebin/airc-rs" <<SH
 #!/bin/bash
-if [ "\${1:-}" = "-m" ] && [ "\${2:-}" = "airc_core.bearer_cli" ] && [ "\${3:-}" = "send" ]; then
+if [ "\${1:-}" = "bearer" ] && [ "\${2:-}" = "send" ]; then
   cat >/dev/null
   case "\${AIRC_FAKE_BEARER_KIND:-gone}" in
     gone)
@@ -2089,14 +2093,14 @@ if [ "\${1:-}" = "-m" ] && [ "\${2:-}" = "airc_core.bearer_cli" ] && [ "\${3:-}"
       ;;
   esac
 fi
-exec "$real_py" "\$@"
+exec "$real_airc_rs" "\$@"
 SH
-  chmod +x "$fakebin/python"
+  chmod +x "$fakebin/airc-rs"
 
   local out err rc
   out=$(mktemp -t airc-gone-out.XXXXXX)
   err=$(mktemp -t airc-gone-err.XXXXXX)
-  AIRC_HOME="$home" AIRC_PYTHON="$fakebin/python" "$AIRC" msg @ghost "lost forever" >"$out" 2>"$err"
+  AIRC_HOME="$home" AIRC_RS_BIN="$fakebin/airc-rs" "$AIRC" msg @ghost "lost forever" >"$out" 2>"$err"
   rc=$?
 
   [ "$rc" -ne 0 ] \
@@ -2114,13 +2118,13 @@ SH
   fi
 
   local mapping
-  mapping=$(AIRC_HOME="$home" "$real_py" -m airc_core.config get_channel_gist \
+  mapping=$(AIRC_HOME="$home" "$real_airc_rs" config get-channel-gist \
     --config "$home/config.json" --channel general 2>/dev/null || true)
   [ -z "$mapping" ] \
     && pass "stale channel gist mapping cleared" \
     || fail "stale channel gist mapping still present: $mapping"
 
-  AIRC_FAKE_BEARER_KIND=transient_failure AIRC_HOME="$home" AIRC_PYTHON="$fakebin/python" \
+  AIRC_FAKE_BEARER_KIND=transient_failure AIRC_HOME="$home" AIRC_RS_BIN="$fakebin/airc-rs" \
     "$AIRC" msg @ghost "retry later" >"$out" 2>"$err"
   rc=$?
   [ "$rc" -eq 0 ] \

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -216,6 +216,20 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertNotIn("python3 - <<", body)
         self.assertNotIn("python3 -c", body)
 
+    def test_integration_gone_gist_fake_uses_airc_rs_not_python(self):
+        source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
+        start = source.index("scenario_send_gone_gist_does_not_claim_delivery()")
+        end = source.index("scenario_monitor_gone_gist_stops_respawn()", start)
+        body = source[start:end]
+
+        self.assertIn('cat > "$fakebin/airc-rs"', body)
+        self.assertIn('AIRC_RS_BIN="$fakebin/airc-rs"', body)
+        self.assertIn('"$real_airc_rs" config get-channel-gist', body)
+        self.assertNotIn("AIRC_PYTHON", body)
+        self.assertNotIn("airc_core.bearer_cli", body)
+        self.assertNotIn("airc_core.config", body)
+        self.assertNotIn("python3", body)
+
     def test_integration_bearer_gist_file_content_uses_airc_rs(self):
         source = (REPO / "test/integration.sh").read_text(encoding="utf-8")
         start = source.index("scenario_bearer_gh()")


### PR DESCRIPTION
Summary
- teach the integration harness airc_rs_bin helper to honor AIRC_RS_BIN overrides
- replace the gone-gist test's fake Python bearer with a fake airc-rs bearer send
- replace the Python config check with airc-rs config get-channel-gist
- add a cutover guard preventing this scenario from regressing to AIRC_PYTHON or airc_core modules

Verification
- python3 test/test_codex_rust_cutover.py
- bash -n test/integration.sh install.sh uninstall.sh airc lib/airc_bash/*.sh
- git diff --check
- bash test/integration.sh send_gone_gist_does_not_claim_delivery