### PR TITLE
install: stop documenting python runtime setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh |
 
 The installer:
 
-- installs or checks `gh`, `python3`, and `openssl`
+- installs or checks `gh`
 - runs `gh auth login -s gist` when needed
-- creates airc's local Python environment
 - puts `airc` on your PATH
 - installs agent skills for detected tools such as Claude Code and Codex
 
@@ -386,8 +385,6 @@ airc update --channel canary
 ## Requirements
 
 - GitHub account with gist scope through `gh`
-- `python3`
-- `openssl`
 - Bash-compatible shell for the main install path
 
 Supported platforms: macOS, Linux, WSL2, Windows Git Bash, and native PowerShell 7.

--- a/install.ps1
+++ b/install.ps1
@@ -313,50 +313,6 @@ if ($userPath -notlike "*$BIN_TARGET*") {
     Write-Step "Added $BIN_TARGET to user PATH (open a NEW shell to pick up)"
 }
 
-# -- Python venv with crypto deps (Phase E: envelope encryption) --------
-# Mirrors install.sh's venv setup. Per the "no scary popups" rule, this
-# never elevates: pip-install --user is fine, but we use a self-contained
-# venv to avoid PEP 668 issues on managed Pythons. airc's bash wrapper
-# detects this venv at AIRC_PYTHON resolution time. Failure → plaintext
-# fallback (warning, not error).
-$venvDir = Join-Path $CLONE_DIR '.venv'
-if (-not (Test-Path $venvDir)) {
-    $py = (Get-Command python -ErrorAction SilentlyContinue)
-    if (-not $py) { $py = (Get-Command python3 -ErrorAction SilentlyContinue) }
-    if ($py) {
-        try {
-            & $py.Source -m venv $venvDir 2>&1 | Out-Null
-            Write-Ok "Python venv created: $venvDir"
-        } catch {
-            Write-Warn2 "Could not create Python venv. airc will run in plaintext mode: $_"
-        }
-    } else {
-        Write-Warn2 "python not on PATH; skipping venv setup. airc will run in plaintext mode."
-    }
-}
-$venvPip = Join-Path $venvDir 'Scripts\pip.exe'
-$venvPython = Join-Path $venvDir 'Scripts\python.exe'
-if (Test-Path $venvPip) {
-    $hasCrypto = $false
-    if (Test-Path $venvPython) {
-        try { & $venvPython -c "import cryptography" 2>$null; $hasCrypto = ($LASTEXITCODE -eq 0) } catch {}
-    }
-    if (-not $hasCrypto) {
-        try {
-            & $venvPip install -q --upgrade pip 2>&1 | Out-Null
-            & $venvPip install -q cryptography 2>&1 | Out-Null
-            if ($LASTEXITCODE -eq 0) {
-                Write-Ok "cryptography installed in venv (envelope encryption ready)"
-            } else {
-                Write-Warn2 "cryptography install failed; airc will run in plaintext mode"
-                Write-Host "    Manual fix:  $venvPip install cryptography"
-            }
-        } catch {
-            Write-Warn2 "cryptography install threw: $_"
-        }
-    }
-}
-
 # -- Skills wiring -------------------------------------------------------
 # Same as install.sh: each subdir under <repo>/skills becomes a slash
 # command in Claude Code. Symlink when possible (so `git pull` updates

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -10,7 +10,7 @@ The same one-liner used by every other agent:
 curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 ```
 
-install.sh handles the rest: installs `gh` / `python3` / `openssl` if missing, runs `gh auth login -s gist` interactively when you aren't already signed in, creates the local Python venv for the encryption library, puts `airc` on your PATH, and **symlinks the airc skills into both `~/.claude/skills/` (if Claude Code is around) and `~/.codex/skills/` (if Codex is around)**. Detection is automatic — install.sh probes `command -v codex && [ -d ~/.codex ]` and quietly skips Codex if absent. **No admin elevation and no background service registration.**
+install.sh handles the rest: checks `gh`, runs `gh auth login -s gist` interactively when you aren't already signed in, puts `airc` on your PATH, and **symlinks the airc skills into both `~/.claude/skills/` (if Claude Code is around) and `~/.codex/skills/` (if Codex is around)**. Detection is automatic — install.sh probes `command -v codex && [ -d ~/.codex ]` and quietly skips Codex if absent. **No admin elevation and no background service registration.**
 
 When Codex is detected, install.sh ALSO writes a scoped network-permission profile into `~/.codex/config.toml`:
 
@@ -71,7 +71,7 @@ If you've already run install.sh on this machine for Claude Code and THEN instal
 airc doctor
 ```
 
-Expect `All required prereqs present` and `[ok] cryptography (Ed25519 identity gen + signing)`. If anything is `[MISSING]`, follow the per-platform fix line — install.sh + doctor are designed to be self-explanatory.
+Expect `All required prereqs present`. If anything is `[MISSING]`, follow the per-platform fix line — install.sh + doctor are designed to be self-explanatory.
 
 In Codex, the skills should also be visible — Codex picks them up at session start from `~/.codex/skills/<name>/SKILL.md`. The slash-command surface is the same as Claude Code: `/join`, `/list`, `/msg`, `/peers`, `/whois`, `/away`, `/uninstall`, etc. `/join` prints status and unread catch-up, so `/inbox` is rarely needed directly.
 

--- a/skills/uninstall/SKILL.md
+++ b/skills/uninstall/SKILL.md
@@ -28,7 +28,7 @@ Walks the full removal in order:
 2. Removes any legacy background registration if present
 3. Removes binary forwarders: `~/.local/bin/{airc, relay, airc.cmd, airc.ps1}`
 4. Removes airc skill symlinks under `~/.claude/skills/`
-5. Removes the clone dir (`~/.airc-src` or `$AIRC_DIR`), including the `.venv` inside
+5. Removes the clone dir (`~/.airc-src` or `$AIRC_DIR`)
 
 **Confirmation prompt:** asks the user to type `yes` to proceed. If you're invoking from an agent, pass `--yes` only after the user has explicitly confirmed.
 
@@ -40,7 +40,7 @@ Walks the full removal in order:
 ## What it leaves alone
 
 - **Per-project `.airc/` state** — your identity keys, peer records, message logs in every dir you ran `airc join` from. Use `--purge` to get a list of them.
-- **`gh` auth, brew/apt-installed packages** (gh / python3 / openssl) — those aren't airc's to remove.
+- **`gh` auth, brew/apt-installed packages** — those aren't airc's to remove.
 - **Other agents' configs** (Codex, Cursor, opencode, Windsurf) — airc only owns its own integration files.
 
 ## Read the result

--- a/test/test_codex_rust_cutover.py
+++ b/test/test_codex_rust_cutover.py
@@ -44,10 +44,23 @@ class CodexRustCutoverTests(unittest.TestCase):
         self.assertIn('cp -f "$built" "$BIN_DIR/airc-rs.exe"', source)
 
     def test_installer_no_longer_bootstraps_python_runtime(self):
-        source = (REPO / "install.sh").read_text(encoding="utf-8")
+        source = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in [
+                REPO / "install.sh",
+                REPO / "install.ps1",
+                REPO / "README.md",
+                REPO / "integrations/openai-codex/README.md",
+                REPO / "uninstall.sh",
+                REPO / "skills/uninstall/SKILL.md",
+            ]
+        )
 
         self.assertNotIn("python3 -m venv", source)
         self.assertNotIn("pip install", source)
+        self.assertNotIn("Python venv", source)
+        self.assertNotIn(".venv", source)
+        self.assertNotIn("AIRC_PYTHON", source)
         self.assertNotIn("cryptography is not importable", source)
         self.assertNotIn("${AIRC_PYTHON:-python3}", source)
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -11,7 +11,7 @@
 #   - daemon (launchd / systemd-user / Task Scheduler) via airc daemon uninstall
 #   - ~/.local/bin/{airc, relay, airc.cmd, airc.ps1}
 #   - skill symlinks under ~/.claude/skills/ pointing into the clone
-#   - the clone itself (~/.airc-src or $AIRC_DIR), including the .venv inside
+#   - the clone itself (~/.airc-src or $AIRC_DIR)
 #
 # What it leaves:
 #   - per-project .airc/ state in every dir you ran `airc join` from
@@ -60,7 +60,7 @@ cat <<EOF
 This will remove airc from this machine:
   binary symlinks   $BIN_DIR/{airc,relay,airc.cmd,airc.ps1}
   skill symlinks    $SKILLS_TARGET/<airc-skills>/ + ~/.codex/skills/<airc-skills>/ (if Codex installed)
-  install dir       $CLONE_DIR (clone + .venv)
+  install dir       $CLONE_DIR
   daemon            launchd / systemd-user / Task Scheduler unit (if installed)
   running processes airc teardown --all (if airc is on PATH)
 
@@ -179,7 +179,7 @@ for f in airc relay airc.cmd airc.ps1; do
 done
 [ "$removed_bins" -gt 0 ] && ok "Removed $removed_bins binary forwarder(s) from $BIN_DIR"
 
-# 5. Clone dir + venv. Last, since the steps above call into airc + read
+# 5. Clone dir. Last, since the steps above call into airc + read
 # from the clone for the skill walk. Once this runs, `airc` is gone.
 if [ -d "$CLONE_DIR" ]; then
   rm -rf "$CLONE_DIR"


### PR DESCRIPTION
Summary
- delete the PowerShell installer's Python venv / pip / cryptography setup block
- remove Python, OpenSSL, and venv claims from README and Codex integration docs
- remove venv wording from uninstall docs and skill text
- expand the cutover guard so install docs and uninstall docs cannot reintroduce venv/AIRC_PYTHON setup

Verification
- python3 test/test_codex_rust_cutover.py
- bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh test/integration.sh
- git diff --check

Note
- pwsh is not installed on this Mac, so I could not run a local PowerShell parser check for install.ps1.