### PR TITLE
runtime: remove live airc_core references

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ The suite runs in isolated `AIRC_HOME` directories and does not touch your live 
 - Treat a room gist id as a room secret. Anyone with access to that gist can read plaintext broadcasts.
 - Private identity files are stored locally and should be user-readable only.
 
-GitHub is the default bearer, not the whole design. The bearer layer lives under [`lib/airc_core/`](lib/airc_core/) so alternate transports can be added without changing the user-facing IRC surface.
+GitHub is the default bearer, not the whole design. The bearer layer is moving into the Rust substrate so alternate transports can be added without changing the user-facing IRC surface.
 
 ## Core Commands
 

--- a/airc
+++ b/airc
@@ -26,31 +26,20 @@ export AIRC_SELF
 # every supported platform ships a working version.
 
 # MSYS Git Bash on Windows translates argv VALUES that look like
-# Unix-rooted paths when bash invokes a Windows-native binary. So
-# `--host-airc-home /Users/joelteply/.airc` arrives at python.exe as
-# `--host-airc-home C:/Program Files/Git/Users/joelteply/.airc` —
-# silently corrupting paths that the joiner later sends back over SSH
-# to a real Unix host. Traced + fixed 2026-04-27;
+# Unix-rooted paths when bash invokes a Windows-native binary. That
+# used to corrupt cross-platform host paths passed through helper
+# commands; keep the targeted exclude until the shell wrapper is gone.
 # the targeted exclude covers macOS / Linux / root home prefixes
 # without breaking `/tmp/` or `/c/` paths (which DO need translation
 # for `--config "$CONFIG"` where $CONFIG is on the local Windows
-# filesystem). Set once at airc startup, exported, every airc_core
-# invocation inherits the same translation policy.
+# filesystem).
 export MSYS2_ARG_CONV_EXCL="${MSYS2_ARG_CONV_EXCL:-/Users/;/home/;/root/}"
 
-# Legacy Python modules still exist during cutover, but the wrapper no
-# longer resolves or requires Python at startup. Any remaining legacy
-# command must handle its own dependency until it is deleted or ported.
-export PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}"
-
-# Resolve the airc install dir's lib/ path and prepend to PYTHONPATH so
-# Python heredocs + module invocations can import airc_core (the
-# Python truth-layer #152). Three resolution paths, first hit wins:
+# Resolve the airc install dir's lib/ path so the shell wrapper can
+# source its remaining bash modules. Three resolution paths, first hit wins:
 #   1. $AIRC_DIR (explicit override / install.sh's working dir)
 #   2. dirname of this script (dev checkout — running from repo)
 #   3. $HOME/.airc-src (install.sh default)
-# When the lib/ dir doesn't exist (e.g. older install before this PR
-# landed), PYTHONPATH stays unmodified — heredocs still work.
 _airc_resolve_lib_dir() {
   local _candidate _abs
   for _candidate in \
@@ -58,9 +47,9 @@ _airc_resolve_lib_dir() {
       "$(dirname "$(readlink "$0" 2>/dev/null || echo "$0")")/lib" \
       "$(dirname "$0")/lib" \
       "$HOME/.airc-src/lib"; do
-    if [ -d "$_candidate/airc_core" ]; then
-      # Canonicalize to absolute path so PYTHONPATH stays valid even
-      # if cwd changes mid-script (heredocs that cd elsewhere). cd +
+    if [ -d "$_candidate/airc_bash" ]; then
+      # Canonicalize to absolute path so module sourcing stays valid even
+      # if cwd changes mid-script. cd +
       # pwd is the portable canonicalize idiom — `realpath` and
       # `readlink -f` are not available everywhere (BSD readlink
       # lacks -f, busybox lacks realpath).
@@ -71,13 +60,6 @@ _airc_resolve_lib_dir() {
   done
 }
 _airc_lib_dir=$(_airc_resolve_lib_dir)
-if [ -n "${_airc_lib_dir:-}" ]; then
-  if [ -n "${PYTHONPATH:-}" ]; then
-    export PYTHONPATH="$_airc_lib_dir:$PYTHONPATH"
-  else
-    export PYTHONPATH="$_airc_lib_dir"
-  fi
-fi
 
 # One-time migration from pre-rename ~/.agent-relay → ~/.airc. Fires when user
 # is on vanilla defaults, the old dir exists as a real dir (not a symlink we
@@ -498,11 +480,11 @@ _airc_scope_monitor_formatter_pids() {
   local scope_dir="${1:-}"
   [ -n "$scope_dir" ] || return 0
   local p cmd
-  proc_airc_pids_matching 'airc-rs.*monitor.*format|airc_core\.monitor_formatter' 2>/dev/null | while IFS= read -r p; do
+  proc_airc_pids_matching 'airc-rs.*monitor.*format' 2>/dev/null | while IFS= read -r p; do
     case "$p" in ''|*[!0-9]*) continue ;; esac
     cmd=$(proc_cmdline "$p" 2>/dev/null || true)
     case "$cmd" in
-      *airc-rs*monitor*format*|*airc_core.monitor_formatter*) ;;
+      *airc-rs*monitor*format*) ;;
       *) continue ;;
     esac
     _airc_cmdline_mentions_scope "$cmd" "$scope_dir/peers" || continue
@@ -1133,11 +1115,8 @@ sign_message() {
 
 # ── Platform adapters ───────────────────────────────────────────────────
 # Decomposed into lib/airc_bash/platform_adapters.sh (#152 Phase 3 — file
-# split). Sourced via the lib-dir resolver set at the top of airc. The
-# resolver's lib_dir already covers airc_core/ (Python truth-layer);
-# airc_bash/ is the bash-side companion that holds extracted adapters
-# and command files. Same precedence: AIRC_DIR / readlink / dirname /
-# $HOME/.airc-src.
+# split). Sourced via the lib-dir resolver set at the top of airc.
+# Same precedence: AIRC_DIR / readlink / dirname / $HOME/.airc-src.
 if [ -n "${_airc_lib_dir:-}" ] && [ -f "$_airc_lib_dir/airc_bash/platform_adapters.sh" ]; then
   # shellcheck source=lib/airc_bash/platform_adapters.sh
   source "$_airc_lib_dir/airc_bash/platform_adapters.sh"
@@ -1336,10 +1315,7 @@ resolve_name() {
 init_identity() {
   local name="$1"
   mkdir -p "$AIRC_WRITE_DIR" "$IDENTITY_DIR" "$PEERS_DIR"
-  # Ed25519 envelope-signing keypair via the venv cryptography path
-  # (issue #341 — the prior shell openssl path broke on macOS LibreSSL
-  # silently). Idempotent: airc_core.identity.bootstrap_ed25519 returns
-  # cleanly without rewriting if the files already exist. Same on-disk
+  # Ed25519 envelope-signing keypair via the Rust CLI. Same on-disk
   # PEM format the openssl path produced, so existing scopes upgrade
   # in place without rotating keys.
   if [ ! -f "$IDENTITY_DIR/private.pem" ]; then
@@ -2048,8 +2024,7 @@ reminder_timer_loop() {
   # the loop emits a kind=heartbeat broadcast. Peers track these in
   # `airc peers` SEPARATELY from chat — a silent peer with fresh
   # heartbeats is alive but heads-down; a silent peer with stale
-  # heartbeats is process-down. Default 60s matches the constant in
-  # lib/airc_core/heartbeat.py (STALE_HEARTBEAT_SEC = 2x = 120s).
+  # heartbeats is process-down. Default 60s gives a 120s stale threshold.
   #
   # Emission is best-effort via `airc msg --heartbeat`. If the send
   # path fails (no bearer, gh rate-limited, etc.) the silence becomes
@@ -2369,7 +2344,6 @@ EOF
     channels=$(airc_config_list_channel_gists "$CONFIG" | awk -F'\t' '{print $1}')
     while IFS= read -r ch; do
       [ -z "$ch" ] && continue
-      # The CLI flag is --gist-id (see lib/airc_core/config.py:325).
       # Pre-fix this was --gist (silently rejected → rotation self-heal
       # never updated config). Surface non-zero exit to stderr so a
       # subsequent bearer mismatch is debuggable; do NOT swallow with

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -256,7 +256,7 @@ _join_restart_scope_processes() {
   # Filter rules:
   #   - drop non-numeric / empty entries (already a no-op)
   #   - drop $$ and $PPID (case 1)
-  #   - drop any PID whose cmdline doesn't look like airc/airc_core
+  #   - drop any PID whose cmdline doesn't look like airc/airc-rs
   #     (case 2). Same regex shape as the stale-pidfile check at
   #     ~line 971 and cmd_teardown's parent-chain reaper.
   local _self_filtered_pids="" _candidate _candidate_cmd
@@ -271,7 +271,7 @@ _join_restart_scope_processes() {
     kill -0 "$_candidate" 2>/dev/null || continue
     _candidate_cmd=$(proc_cmdline "$_candidate" 2>/dev/null || true)
     case "$_candidate_cmd" in
-      *airc_core.bearer_cli*recv*|*airc-rs*monitor*format*|*airc-rs*monitor*attach*|*airc-rs*handshake*) ;;
+      *airc-rs*monitor*format*|*airc-rs*monitor*attach*|*airc-rs*handshake*|*airc-rs*bearer*recv*) ;;
       *airc[[:space:]]connect*|*airc[[:space:]]join*|*/airc[[:space:]]*) ;;
       *) continue ;;
     esac
@@ -315,7 +315,7 @@ _join_scope_transport_pids() {
       _cmd=$(proc_cmdline "$_pid" || true)
       case "$_cmd" in
         *airc-rs*monitor*attach*) continue ;;
-        *airc_core.bearer_cli*recv*|*airc-rs*monitor*format*|*airc-rs*handshake*accept-one*)
+        *airc-rs*monitor*format*|*airc-rs*handshake*accept-one*|*airc-rs*bearer*recv*)
           _pids="$_pids $_pid"
           ;;
         *) continue ;;
@@ -366,7 +366,7 @@ _join_scope_has_duplicate_transport() {
   fi
 
   local _seen_gists="" _pid _cmd _gid
-  for _pid in $(proc_airc_pids_matching 'airc_core\.bearer_cli[[:space:]]+recv' 2>/dev/null | sort -un || true); do
+  for _pid in $(proc_airc_pids_matching 'airc-rs.*bearer[[:space:]]+recv' 2>/dev/null | sort -un || true); do
     _cmd=$(proc_cmdline "$_pid" || true)
     _airc_cmdline_mentions_scope "$_cmd" "$AIRC_WRITE_DIR" || continue
     _gid=$(printf '%s\n' "$_cmd" | awk '{
@@ -1760,10 +1760,8 @@ cmd_connect() {
         echo "" >&2
       fi
       # Either not a room flow, or no gh, or no resolved_room_name → original die.
-      # Surface the captured pair-handshake stderr (2026-04-27:
-      # Windows users got "Can't reach ..." with no clue the real cause was
-      # a Microsoft Store python3.exe stub returning exit 49). Per the
-      # global "never swallow errors" rule — evidence is for the debugger,
+      # Surface the captured pair-handshake stderr. Per the global
+      # "never swallow errors" rule — evidence is for the debugger,
       # not the trash. The handshake captured stderr+stdout via 2>&1 into
       # $response just above, so we have the real error in hand.
       if [ -n "${response:-}" ]; then

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -11,8 +11,8 @@
 #
 # External cross-references (resolved at call time): die, ensure_init,
 # get_config_val, set_config_val, relay_ssh, AIRC_HOME, MESSAGES,
-# resolve_name, get_host, _hash, plus airc_core.* python modules
-# (airc_core.message, airc_core.queue) for envelope construction.
+# resolve_name, get_host, _hash, and airc-rs helpers for envelope
+# construction and transport calls.
 #
 # Extracted from airc as part of #152 Phase 3 file split. Joel 2026-04-27:
 # "1) simplify and modularize 2) build host logic correctly 3) never
@@ -75,7 +75,7 @@ cmd_send() {
   #       to that peer; the whole point is per-peer process-down detection)
   #   (2) the envelope's `kind` field is set to "heartbeat" so the
   #       monitor formatter filters it out of UI rendering and cmd_peers
-  #       tracks it separately from chat (per airc_core.heartbeat)
+  #       tracks it separately from chat.
   # Empty msg body is intended — all the signal is in metadata (from + ts
   # + kind).
   local heartbeat=0
@@ -379,7 +379,7 @@ cmd_send() {
     fi
 
     # Hand the wire to the bearer abstraction. ALL transport-specific
-    # knowledge lives in lib/airc_core/bearer_*.py. cmd_send only:
+    # knowledge lives in the Rust bearer implementation. cmd_send only:
     #   1. Builds the signed envelope (above)
     #   2. Wraps with envelope-layer crypto if recipient supports it
     #   3. Hands payload + peer_meta to bearer_cli

--- a/skills/repair/SKILL.md
+++ b/skills/repair/SKILL.md
@@ -18,10 +18,11 @@ If `$ARGUMENTS` contains an invite string (looks like `name@user@host[:port]#<ba
 
 ```bash
 # Grab the pieces the host wrote into config during the last pair.
-HOST_NAME=$(python3 -c "import json; print(json.load(open('$(airc debug-scope)/config.json')).get('host_name',''))" 2>/dev/null)
-HOST_TARGET=$(python3 -c "import json; print(json.load(open('$(airc debug-scope)/config.json')).get('host_target',''))" 2>/dev/null)
-HOST_PORT=$(python3 -c "import json; print(json.load(open('$(airc debug-scope)/config.json')).get('host_port',7547))" 2>/dev/null)
-HOST_PUB=$(python3 -c "import json; print(json.load(open('$(airc debug-scope)/config.json')).get('host_ssh_pub',''))" 2>/dev/null)
+SCOPE=$(airc debug-scope)
+HOST_NAME=$(airc-rs config get --config "$SCOPE/config.json" host_name 2>/dev/null || true)
+HOST_TARGET=$(airc-rs config get --config "$SCOPE/config.json" host_target 2>/dev/null || true)
+HOST_PORT=$(airc-rs config get --config "$SCOPE/config.json" host_port 7547 2>/dev/null || true)
+HOST_PUB=$(airc-rs config get --config "$SCOPE/config.json" host_ssh_pub 2>/dev/null || true)
 PUB_B64=$(printf '%s\n' "$HOST_PUB" | base64 | tr -d '\n')
 
 if [ -n "$HOST_NAME" ] && [ -n "$HOST_TARGET" ] && [ -n "$HOST_PUB" ]; then


### PR DESCRIPTION
Summary
- remove Python path/bootstrap setup from the airc wrapper
- resolve lib/ by airc_bash modules instead of airc_core
- drop airc_core monitor/bearer process matches in favor of airc-rs patterns
- update stale runtime comments and README references away from lib/airc_core
- convert the repair skill config extraction from python3 JSON reads to airc-rs config reads

Verification
- python3 test/test_codex_rust_cutover.py
- bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh test/integration.sh
- git diff --check
- rg -n airc_core