### PR TITLE
docs(architecture): transport control plane admission

### DIFF
--- a/docs/architecture/AIRC-RUST-SUBSTRATE.md
+++ b/docs/architecture/AIRC-RUST-SUBSTRATE.md
@@ -328,50 +328,267 @@ remain valid; scrollback queries that hit pre-drain ranges
 transparently consult the archive partition. Active DB stays
 bounded → constant query performance.
 
-## Transport resolver (adapter pattern, replaceable mid-life)
+## Transport control plane
 
-Same adapter discipline used everywhere else in our stack — inference
-providers in continuum, model registry candidates in Lane A, storage
-adapters in zsm-server, FFI surfaces in vHSM. airc-transport is
-another instance of the same craft.
+The transport layer is a control plane, not a pile of special-case
+adapters. Local and remote delivery are the same product behavior:
+the caller submits one signed envelope, gets one delivery contract,
+and observes one transcript/replay model. Whether the bytes moved
+through local filesystem, LAN-TCP, Tailscale, Reticulum, a relay, or
+temporary gh-gist is invisible above the substrate boundary.
 
-`airc-transport::Resolver` picks a transport per recipient by
-capability + reachability:
+This is the telecom shape: separate the service contract from the
+bearers underneath it. A room can contain a same-host Codex process,
+a LAN Claude, a Tailscale grid node, and an offline OpenClaw client.
+The send path does not switch to "local mode" or "remote mode". The
+control plane decomposes the envelope into delivery work per endpoint,
+leases resources, chooses routes, writes durable queue records where
+needed, and reassembles a single delivery state for observability.
 
-| Recipient location | Preferred transport |
-|---|---|
-| Same host, same scope | `local-fs` (shared `.airc/` dir, file-tail) |
-| Same LAN (mDNS / link-local) | `lan-tcp` (direct connection) |
-| Cross-network via Tailscale tailnet | `tailscale` |
-| Cross-network, no Tailscale | `gh-gist` (legacy bridge — slow, rate-limited) |
+### Layering
 
-Same-host peers **never round-trip through gh**. Today's "gh-only
-post-Phase-3c" decision is reverted with a proper bearer registry.
-gh-gist stays as a legacy bearer for cross-network peers who haven't
-paired via Tailscale yet, but it's not the only one.
+| Layer | Owns | Must not own |
+|---|---|---|
+| Protocol | Envelope, headers, body/media refs, signatures, frame kinds | Reachability, retries, batching, filesystem paths |
+| Identity/presence | Peer identity, client identity, device/session endpoints, capabilities, current leases | Transport implementation details |
+| Route graph | Endpoint-to-endpoint candidate edges, health, cost, priority, redundancy groups | Consumer semantics or body parsing |
+| Delivery scheduler | Durable outbound/inbound queues, batching, deadlines, acks, retry/backoff, resource leases | Adapter-specific protocol code |
+| Transport adapters | One implementation of the common transport contract per bearer | Route policy, admission decisions, consumer-visible behavior |
+| Store/replay | Transcript, delivery journal, cursors, replay fixtures, audit | Live route selection |
+| Consumer API | `Airc::send`, `Airc::subscribe`, `Airc::page_recent`, typed headers | Choosing GH/local/LAN/Tailscale directly |
 
-### Trait shape
+Every adapter is subordinate to the same control plane. The scheduler
+can use many adapters for one logical send, but consumers never call
+different APIs for local vs remote. Redundancy is modeled explicitly
+in route graph edges and delivery journals, never as catch blocks,
+implicit retries into weaker transports, or "try X then silently use Y"
+code.
+
+**Fallbacks are illegal.** The control plane performs admission before
+send. It selects an allowed route from current health, policy, leases,
+and budgets. If no route satisfies the contract, the delivery is
+`Queued` or `NoRoute`; it does not downgrade itself into a slower,
+less secure, or more expensive transport. A route can be re-planned
+later after health or leases change, but that is a new scheduler
+decision with an audit entry, not an exception handler improvising.
+
+**Unknown states are hard failures.** Any route, resource, or adapter
+state that is not represented in a closed Rust enum is not allowed to
+execute. There is no `Unknown => continue`, no "default transport", no
+`unwrap_or(cpu)`, no stringly status that slips through parsing. Unknown
+means `AdmissionRejected { reason: UnknownState }`, a structured event,
+and an audit row. This is the same rule needed for Continuum GPU/CPU
+placement: the system must never silently run on CPU just because GPU
+admission failed or a model/backend status could not be interpreted.
+
+### Endpoint model
+
+Identity is not enough to route. A human/persona/grid node can have
+multiple live endpoints: a laptop tab, a Codex runtime, an OpenClaw
+extension, a Hermes daemon, a render box. The route graph therefore
+routes to `EndpointId`, with `IdentityId` as the durable owner.
 
 ```rust
-pub trait Transport: Send + Sync {
-    fn id(&self) -> TransportId;
-    fn capabilities(&self) -> TransportCapabilities;
-    async fn send(&self, env: Envelope) -> Result<()>;
-    fn receive(&self) -> BoxStream<'static, Envelope>;
-    async fn health(&self) -> TransportHealth;
-}
-
-pub trait Bearer: Transport {
-    // Bearer-specific: durable cross-network store-and-forward.
-    // gh-gist is a Bearer; lan-tcp is a Transport but not a Bearer.
-    async fn fetch_since(&self, channel: ChannelId, cursor: Cursor)
-        -> Result<Vec<Envelope>>;
-    async fn ack(&self, sig: Signature) -> Result<()>;
+pub struct Endpoint {
+    pub endpoint_id: EndpointId,     // UUIDv4, live endpoint/session
+    pub identity_id: IdentityId,     // UUIDv4, durable peer/persona/user
+    pub client_id: ClientId,         // UUIDv4, app/runtime instance
+    pub channels: BTreeSet<ChannelId>,
+    pub capabilities: Capabilities,  // e.g. local-fs, lan-tcp, reticulum
+    pub resource_lease: Option<LeaseId>,
+    pub last_seen: Timestamp,
 }
 ```
 
-Transports register at runtime via a registry. The resolver multiplexes;
-each peer pair holds a list of viable transports sorted by preference.
+Presence updates mutate endpoint state; they do not alter the envelope
+contract. If a peer moves from same-host to Tailscale, the route graph
+changes and the same `Airc::send` call continues to work.
+
+### Route graph
+
+The resolver sees a graph, not a flat adapter list:
+
+```rust
+pub struct RouteEdge {
+    pub from: EndpointId,
+    pub to: EndpointId,
+    pub transport: TransportKind,
+    pub role: TransportRole,         // direct | relay | bootstrap
+    pub health: TransportHealth,
+    pub cost: RouteCost,             // latency, bandwidth, energy, budget
+    pub redundancy_group: Option<RedundancyGroupId>,
+}
+```
+
+Selection is per endpoint and preflighted. In a mixed room, same-host
+recipients get a same-host edge, LAN recipients get LAN, tailnet
+recipients get Tailscale or Reticulum, and offline recipients get queued
+for the next approved store-and-forward edge. This is still one send
+operation at the API boundary. No endpoint can drag another endpoint
+onto a worse transport just because its own best route is unavailable.
+
+### Delivery scheduler
+
+The delivery scheduler is the only layer allowed to decide retry,
+batch, defer, or duplicate-for-redundancy behavior.
+
+```rust
+pub enum DeliveryClass {
+    DurableMessage,      // transcript content; must persist + replay
+    Control,             // join/part/nick/heartbeat; ordered enough
+    LiveEvent,           // interrupt-style; lossy under pressure
+    BlobChunk,           // content-addressed transfer chunk
+}
+
+pub enum DeliveryState {
+    Accepted,
+    Delivered,
+    Acked,
+    Queued,
+    Deferred { reason: DeferReason, retry_after: Timestamp },
+    Failed { reason: FailureReason },
+}
+```
+
+The queue is not a fallback. It is a first-class delivery state chosen
+by policy. If GH is rate-limited, the remote store-and-forward edge is
+deferred and batched. Same-machine or LAN edges keep moving because
+they are separate edges in the same route graph. One remote participant
+must not force all local participants through GH or slow the local path.
+
+The scheduler must record why a route was selected or refused:
+
+```rust
+pub enum RouteRefusal {
+    NoHealthyApprovedEdge,
+    MissingLease,
+    BudgetExceeded,
+    CapabilityMismatch,
+    SecurityPolicyRejected,
+    UnknownState,
+}
+
+pub struct RouteDecisionAudit {
+    pub envelope_id: EventId,
+    pub endpoint_id: EndpointId,
+    pub selected: Option<TransportKind>,
+    pub refusal: Option<RouteRefusal>,
+    pub policy_version: PolicyVersion,
+}
+```
+
+This makes degraded behavior inspectable and replayable. If the system
+starts using GH for runtime data, that is a policy/test failure, not an
+acceptable fallback.
+
+### Closed state machines
+
+All runtime state that can affect performance, correctness, security,
+or cost is a closed enum and must be exhaustively matched:
+
+```rust
+pub enum TransportAdmission {
+    Admitted { edge: RouteEdgeId, lease: LeaseId },
+    Queued { reason: RouteRefusal },
+    Rejected { reason: RouteRefusal },
+}
+
+pub enum ResourceAdmission {
+    Admitted { lease: LeaseId, class: ResourceClass },
+    Queued { reason: ResourceRefusal },
+    Rejected { reason: ResourceRefusal },
+}
+
+pub enum ResourceClass {
+    Cpu,
+    MainMemory,
+    GpuVram,
+    UnifiedMemory,
+    Disk,
+    Network,
+}
+```
+
+Compile-time exhaustiveness is part of the architecture. If a new
+transport health state, resource class, or delivery refusal is added,
+callers must handle it explicitly. Tests must include a "no silent
+unknown" case for every state machine.
+
+Observability is not optional:
+- Every admitted delivery records selected route, endpoint, transport,
+  resource lease, and policy version.
+- Every queued/rejected delivery records the refusal enum.
+- Dashboards and `airc doctor` report route/resource class, not just
+  "slow" or "degraded".
+- Performance harnesses assert that forbidden paths do not appear
+  under normal scenarios, e.g. no GH runtime-data route for local peers
+  and no CPU inference route for GPU-required models.
+
+### Rust covenant
+
+The Rust rewrite exists to make illegal states unrepresentable. That
+requires discipline; merely rewriting Python/bash control flow in Rust
+does not buy safety.
+
+Rules for substrate code:
+- No `unwrap_or(...)` or `unwrap_or_else(...)` for policy, transport,
+  route, resource, model, security, or delivery decisions. Defaults
+  belong in typed config loaded at startup, not in runtime branches.
+- No wildcard match arms (`_ => ...`) on safety-critical enums. Match
+  every variant by name so adding a variant breaks compilation until
+  every caller handles it.
+- No stringly runtime state. Strings are serialization/display at the
+  boundary; internal state is enums/newtypes.
+- No catch-and-continue paths that convert an error into a weaker route
+  or resource class. Errors become refusal/queue/failure states.
+- No CPU/GH/relay substitute path for GPU/direct-required work unless
+  the policy explicitly admitted that exact class before execution.
+- No adapter-specific status leaking above the transport contract.
+  Adapters normalize into closed scheduler states.
+
+The test suite must pin these rules:
+- route policy rejects GH for runtime data
+- route policy rejects unknown/unclassified transport state
+- resource admission rejects GPU-required work without a GPU lease
+- delivery code records the selected route/resource or a refusal enum
+- no implementation can add a new safety-critical enum variant without
+  updating the admission/scheduler tests
+
+### One transport contract
+
+```rust
+pub trait Transport: Send + Sync {
+    fn kind(&self) -> TransportKind;
+    fn capabilities(&self) -> TransportCapabilities;
+    async fn open(&self, endpoint: Endpoint) -> Result<TransportHandle>;
+    async fn health(&self, edge: &RouteEdge) -> TransportHealth;
+}
+
+pub trait TransportHandle: Send + Sync {
+    async fn send(&self, batch: DeliveryBatch) -> Result<DeliveryReceipt>;
+    fn subscribe(&self, sub: Subscription) -> BoxStream<'static, TransportEvent>;
+}
+```
+
+There is no adapter-specific caller API. A local-fs adapter, LAN-TCP
+adapter, Tailscale adapter, Reticulum adapter, relay adapter, and gh-gist
+migration adapter all implement the same contract. Adapter-specific
+configuration lives below `open`; adapter-specific errors are normalized
+into scheduler states above it.
+
+Store-and-forward is a capability, not a separate user-facing mode or
+fallback path:
+
+```rust
+pub struct TransportCapabilities {
+    pub direct: bool,
+    pub store_and_forward: bool,
+    pub ordered: bool,
+    pub durable: bool,
+    pub max_batch_bytes: u64,
+    pub supports_blobs: bool,
+}
+```
 
 ### Resilient to bearer changes
 
@@ -619,7 +836,7 @@ A generic fast-UDP path is substrate-level work. WebRTC needs it
 match-state sync at 60 Hz), multiplayer simulations need it (player
 position, projectile state), some IoT meshes need it. Every one of
 those consumers re-implementing ICE candidate gathering, NAT traversal,
-TURN fallback, STUN reachability, and UDP multiplexing is the wrong
+TURN relay selection, STUN reachability, and UDP multiplexing is the wrong
 factoring. airc owns the network primitive once; consumers ride it.
 
 `airc-rtc` crate (rename pending — the WebRTC-flavored name oversells
@@ -644,10 +861,11 @@ it) ships:
 
 Consumers hand `airc-rtc` either media tracks (audio/video frames)
 or raw UDP messages (game-state diffs, multiplayer events). It
-handles peer-direct UDP where possible, falls back to TURN-relay
-when NATs require it. The signaling (SDP/ICE for WebRTC; lobby/match
-state for games) flows as airc events alongside on the regular
-TCP/gh/local channels.
+handles peer-direct UDP when policy admits that route, or a TURN relay
+when relay is the approved route for that peer pair. TURN is not a
+fallback; it is a selected relay edge with its own lease, cost, and
+audit record. The signaling (SDP/ICE for WebRTC; lobby/match state
+for games) flows as airc events alongside on the regular channels.
 
 This is what "network related and fine" means: the substrate owns
 the network primitive even though the application owns what the
@@ -714,16 +932,20 @@ Built-in primitives:
   application heartbeats. Configurable cadence per transport (more
   frequent for UDP/RTC paths, slower for gh-gist).
 - **Dead-host detection**: if N consecutive heartbeats fail, the
-  peer is marked degraded; if N+M, marked dead. Subscribers get an
-  event; consumer can decide whether to fail-over to backup peers.
-- **Auto-reconnect with backoff**: when a transport reports failure,
-  airc-transport retries with exponential backoff. State (cursors,
-  subscriptions, pending sends) survives the reconnect.
+  peer is marked impaired; if N+M, marked dead. Subscribers get a
+  structured event. The scheduler refuses new admissions on impaired
+  edges unless policy explicitly permits that health state for the
+  delivery class.
+- **Reconnect with backoff**: when a selected transport reports
+  failure, its adapter reconnects within the lease/policy it was
+  granted. State (cursors, subscriptions, pending sends) survives the
+  reconnect. It does not switch to a different transport; route
+  changes are scheduler decisions with audit records.
 - **Self-healing host migration**: when the channel host evicts
   (today's `[HOST EVICTED]` flow), airc-rust formalizes the
-  re-host election. Cursors and pending sends migrate to the new
-  host transparently; consumers see a structured event, not a
-  protocol fault.
+  re-host election. Cursors and pending sends migrate to the newly
+  elected host through an explicit route-graph decision; consumers
+  see a structured event, not a protocol fault.
 - **Message durability across reconnect**: pending sends queue in
   `airc-store`; the daemon retries on reconnect. Loss is loud (event
   + audit-log entry) not silent.


### PR DESCRIPTION
## Summary
- replace adapter-picker framing with a layered transport control plane
- define endpoint route graph, delivery scheduler, queue/admission states, and one transport contract
- make fallbacks illegal: admission selects an approved route or returns queued/no-route with audit
- add Rust covenant for closed enums, no stringly runtime state, no unwrap_or policy paths, and no silent CPU/GH substitutes

## Verification
- git diff --check