### PR TITLE
fix: fail closed on production fallback paths

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,8 +4,10 @@ name: rust
 #
 # Three jobs on every PR + push touching Rust:
 #   fmt      — `cargo fmt --check` (no formatter drift)
-#   clippy   — `cargo clippy --all-targets --all-features -- -D warnings`
-#              (zero clippy warnings, treat all as errors)
+#   clippy   — regular all-target warning gate plus a production-only
+#              no-silent-fallback gate. Tests may stay concise, but
+#              library/binary code cannot use unwrap/expect/panic/todo/
+#              unimplemented or wildcard enum matches.
 #   test     — `cargo test --all-features` (every test green)
 #
 # Per Joel's direction (2026-05-18): "use rust conventions and obsession
@@ -68,6 +70,16 @@ jobs:
             ${{ runner.os }}-cargo-clippy-
       - name: cargo clippy --all-targets --all-features -- -D warnings
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: cargo clippy production no-silent-fallback gate
+        run: >
+          cargo clippy --workspace --lib --bins --
+          -D warnings
+          -D clippy::unwrap_used
+          -D clippy::expect_used
+          -D clippy::panic
+          -D clippy::todo
+          -D clippy::unimplemented
+          -D clippy::wildcard_enum_match_arm
 
   test:
     # Cross-platform matrix — the substrate must run on Linux, macOS,

--- a/crates/airc-cli/src/bearer/commands.rs
+++ b/crates/airc-cli/src/bearer/commands.rs
@@ -85,7 +85,7 @@ fn send_payloads(room_gist_id: Option<&str>, payloads: &[String]) -> SendOutcome
     for attempt in 0..retries {
         let (gist, get_kind) = gh::get_classified(gist_id);
         let Some(gist) = gist else {
-            return get_failure_outcome(gist_id, payloads, local_ok, get_kind);
+            return get_failure_outcome(gist_id, get_kind);
         };
 
         let existing = gh::read_messages_content(&gist);
@@ -98,9 +98,6 @@ fn send_payloads(room_gist_id: Option<&str>, payloads: &[String]) -> SendOutcome
                 continue;
             }
             let send_kind = patch_kind.into_send_kind();
-            if let Some(outcome) = local_bus_deferred(payloads, local_ok, send_kind) {
-                return outcome;
-            }
             return SendOutcome::new(send_kind, last_detail);
         }
 
@@ -126,15 +123,7 @@ fn send_payloads(room_gist_id: Option<&str>, payloads: &[String]) -> SendOutcome
     conflict_exhausted_outcome(payloads, local_ok, &local_detail, retries, &last_detail)
 }
 
-fn get_failure_outcome(
-    gist_id: &str,
-    payloads: &[String],
-    local_ok: bool,
-    get_kind: SendKind,
-) -> SendOutcome {
-    if let Some(outcome) = local_bus_deferred(payloads, local_ok, get_kind) {
-        return outcome;
-    }
+fn get_failure_outcome(gist_id: &str, get_kind: SendKind) -> SendOutcome {
     if matches!(
         get_kind,
         SendKind::Gone | SendKind::SecondaryRateLimit | SendKind::AuthFailure
@@ -150,45 +139,13 @@ fn get_failure_outcome(
     )
 }
 
-fn local_bus_deferred(
-    payloads: &[String],
-    local_ok: bool,
-    failure_kind: SendKind,
-) -> Option<SendOutcome> {
-    if !local_ok
-        || !matches!(
-            failure_kind,
-            SendKind::SecondaryRateLimit | SendKind::TransientFailure | SendKind::AuthFailure
-        )
-    {
-        return None;
-    }
-    Some(SendOutcome::new(
-        SendKind::Delivered,
-        format!(
-            "delivered{} via local bus; gh publish deferred ({})",
-            batch_suffix(payloads),
-            kind_name(failure_kind)
-        ),
-    ))
-}
-
 fn conflict_exhausted_outcome(
     payloads: &[String],
-    local_ok: bool,
+    _local_ok: bool,
     local_detail: &str,
     retries: usize,
     last_detail: &str,
 ) -> SendOutcome {
-    if local_ok {
-        return SendOutcome::new(
-            SendKind::Delivered,
-            format!(
-                "delivered{} via local bus; gh conflict after {retries} retries; last: {last_detail}",
-                batch_suffix(payloads)
-            ),
-        );
-    }
     SendOutcome::new(
         SendKind::TransientFailure,
         format!(
@@ -210,14 +167,6 @@ fn delivered_detail(payloads: &[String]) -> SendOutcome {
             SendKind::Delivered,
             format!("{} payload(s)", payloads.len()),
         )
-    }
-}
-
-fn batch_suffix(payloads: &[String]) -> &'static str {
-    if payloads.len() == 1 {
-        ""
-    } else {
-        " batch"
     }
 }
 
@@ -245,5 +194,12 @@ mod tests {
     fn frame_line_adds_exactly_one_newline() {
         assert_eq!(frame_line("abc\n\n"), "abc\n");
         assert_eq!(frame_line("abc"), "abc\n");
+    }
+
+    #[test]
+    fn local_bus_write_does_not_turn_gh_conflict_into_delivered() {
+        let outcome = conflict_exhausted_outcome(&["{}\n".to_string()], true, "", 8, "conflict");
+        let encoded = serde_json::to_value(outcome).unwrap();
+        assert_eq!(encoded["kind"], "transient_failure");
     }
 }

--- a/crates/airc-cli/src/bearer_state.rs
+++ b/crates/airc-cli/src/bearer_state.rs
@@ -55,7 +55,7 @@ fn int_timestamp(value: Option<&Value>) -> u64 {
     let parsed = match value {
         Value::Number(number) => number.as_f64(),
         Value::String(text) => text.parse::<f64>().ok(),
-        _ => None,
+        Value::Null | Value::Bool(_) | Value::Array(_) | Value::Object(_) => None,
     };
     parsed
         .filter(|value| value.is_finite() && *value > 0.0)

--- a/crates/airc-cli/src/config_commands.rs
+++ b/crates/airc-cli/src/config_commands.rs
@@ -66,7 +66,7 @@ pub fn run_set(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = config.unwrap_or_else(|| home.join("config.json"));
     let mut root = load_value(&config);
-    object_mut(&mut root).insert(key.to_string(), Value::String(value.to_string()));
+    object_mut(&mut root)?.insert(key.to_string(), Value::String(value.to_string()));
     save_value(&config, &root)
 }
 
@@ -85,7 +85,7 @@ pub fn run_unset_keys(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = config.unwrap_or_else(|| home.join("config.json"));
     let mut root = load_value(&config);
-    let object = object_mut(&mut root);
+    let object = object_mut(&mut root)?;
     for key in keys {
         object.remove(key);
     }
@@ -111,7 +111,7 @@ pub fn run_record_parted(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = config.unwrap_or_else(|| home.join("config.json"));
     let mut root = load_value(&config);
-    let rooms = parted_rooms_mut(&mut root);
+    let rooms = parted_rooms_mut(&mut root)?;
     if !rooms.iter().any(|value| value.as_str() == Some(room)) {
         rooms.push(Value::String(room.to_string()));
     }
@@ -125,7 +125,7 @@ pub fn run_clear_parted(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = config.unwrap_or_else(|| home.join("config.json"));
     let mut root = load_value(&config);
-    parted_rooms_mut(&mut root).retain(|value| value.as_str() != Some(room));
+    parted_rooms_mut(&mut root)?.retain(|value| value.as_str() != Some(room));
     save_value(&config, &root)
 }
 
@@ -194,7 +194,7 @@ pub fn run_subscribe(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = config.unwrap_or_else(|| home.join("config.json"));
     let mut root = load_value(&config);
-    let channels = subscribed_channels_mut(&mut root);
+    let channels = subscribed_channels_mut(&mut root)?;
     channels.retain(|value| value.as_str() != Some(channel));
     let value = Value::String(channel.to_string());
     if first {
@@ -212,7 +212,7 @@ pub fn run_unsubscribe(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = config.unwrap_or_else(|| home.join("config.json"));
     let mut root = load_value(&config);
-    subscribed_channels_mut(&mut root).retain(|value| value.as_str() != Some(channel));
+    subscribed_channels_mut(&mut root)?.retain(|value| value.as_str() != Some(channel));
     save_value(&config, &root)
 }
 
@@ -224,7 +224,7 @@ pub fn run_set_channel_gist(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = config.unwrap_or_else(|| home.join("config.json"));
     let mut root = load_value(&config);
-    let gists = channel_gists_mut(&mut root);
+    let gists = channel_gists_mut(&mut root)?;
     if gist_id.is_empty() {
         gists.remove(channel);
     } else {
@@ -261,7 +261,7 @@ pub fn run_set_host_block(
     let host_port = update.parsed_port();
     let host_identity = update.parsed_identity();
     let mut root = load_value(&config);
-    let object = object_mut(&mut root);
+    let object = object_mut(&mut root)?;
     object.insert(
         "host_airc_home".to_string(),
         Value::String(update.host_airc_home),
@@ -306,48 +306,68 @@ fn save_value(path: &Path, value: &Value) -> Result<(), Box<dyn std::error::Erro
     Ok(())
 }
 
-fn object_mut(value: &mut Value) -> &mut Map<String, Value> {
-    if !value.is_object() {
+fn object_mut(value: &mut Value) -> Result<&mut Map<String, Value>, Box<dyn std::error::Error>> {
+    if !matches!(value, Value::Object(_)) {
         *value = Value::Object(Map::new());
     }
-    value
-        .as_object_mut()
-        .expect("value was converted to object")
+    match value {
+        Value::Object(object) => Ok(object),
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Array(_) => {
+            Err("failed to initialize config root object".into())
+        }
+    }
 }
 
-fn subscribed_channels_mut(value: &mut Value) -> &mut Vec<Value> {
-    let object = object_mut(value);
+fn subscribed_channels_mut(
+    value: &mut Value,
+) -> Result<&mut Vec<Value>, Box<dyn std::error::Error>> {
+    let object = object_mut(value)?;
     let entry = object
         .entry("subscribed_channels")
         .or_insert_with(|| Value::Array(Vec::new()));
     if !entry.is_array() {
         *entry = Value::Array(Vec::new());
     }
-    entry.as_array_mut().expect("entry was converted to array")
+    match entry {
+        Value::Array(items) => Ok(items),
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Object(_) => {
+            Err("failed to initialize subscribed_channels array".into())
+        }
+    }
 }
 
-fn channel_gists_mut(value: &mut Value) -> &mut Map<String, Value> {
-    let object = object_mut(value);
+fn channel_gists_mut(
+    value: &mut Value,
+) -> Result<&mut Map<String, Value>, Box<dyn std::error::Error>> {
+    let object = object_mut(value)?;
     let entry = object
         .entry("channel_gists")
         .or_insert_with(|| Value::Object(Map::new()));
     if !entry.is_object() {
         *entry = Value::Object(Map::new());
     }
-    entry
-        .as_object_mut()
-        .expect("entry was converted to object")
+    match entry {
+        Value::Object(object) => Ok(object),
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Array(_) => {
+            Err("failed to initialize channel_gists object".into())
+        }
+    }
 }
 
-fn parted_rooms_mut(value: &mut Value) -> &mut Vec<Value> {
-    let object = object_mut(value);
+fn parted_rooms_mut(value: &mut Value) -> Result<&mut Vec<Value>, Box<dyn std::error::Error>> {
+    let object = object_mut(value)?;
     let entry = object
         .entry("parted_rooms")
         .or_insert_with(|| Value::Array(Vec::new()));
     if !entry.is_array() {
         *entry = Value::Array(Vec::new());
     }
-    entry.as_array_mut().expect("entry was converted to array")
+    match entry {
+        Value::Array(items) => Ok(items),
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Object(_) => {
+            Err("failed to initialize parted_rooms array".into())
+        }
+    }
 }
 
 fn config_value(path: &Path, key: &str, default: &str) -> String {
@@ -358,9 +378,11 @@ fn config_value(path: &Path, key: &str, default: &str) -> String {
         Some(Value::String(value)) => value.clone(),
         Some(Value::Bool(value)) => value.to_string(),
         Some(Value::Number(value)) => value.to_string(),
-        Some(Value::Array(_)) | Some(Value::Object(_)) => {
-            serde_json::to_string(root.get(key).expect("matched value exists"))
-                .unwrap_or_else(|_| default.to_string())
+        Some(Value::Array(value)) => {
+            serde_json::to_string(value).unwrap_or_else(|_| default.to_string())
+        }
+        Some(Value::Object(value)) => {
+            serde_json::to_string(value).unwrap_or_else(|_| default.to_string())
         }
     }
 }

--- a/crates/airc-cli/src/gist_commands.rs
+++ b/crates/airc-cli/src/gist_commands.rs
@@ -19,7 +19,11 @@ pub fn run_get_json(path: &str) -> Result<(), Box<dyn Error>> {
         .unwrap_or(Value::Null);
     match value {
         Value::Null => println!(),
-        other => println!("{}", serde_json::to_string(&other)?),
+        other @ (Value::Bool(_)
+        | Value::Number(_)
+        | Value::String(_)
+        | Value::Array(_)
+        | Value::Object(_)) => println!("{}", serde_json::to_string(&other)?),
     }
     Ok(())
 }

--- a/crates/airc-cli/src/hygiene_commands.rs
+++ b/crates/airc-cli/src/hygiene_commands.rs
@@ -402,7 +402,7 @@ impl WalkDecision<'_> {
     fn skips(&self, name: &str) -> bool {
         match self {
             Self::SkipNamed(names) => names.contains(&name),
-            _ => false,
+            Self::Continue | Self::SkipChildren => false,
         }
     }
 }

--- a/crates/airc-cli/src/identity_commands.rs
+++ b/crates/airc-cli/src/identity_commands.rs
@@ -148,7 +148,7 @@ pub fn run_set_config(
     validate_len("status", status.as_deref(), STATUS_MAX)?;
 
     let mut root = load_config_required(config)?;
-    let ident = object_field_mut(&mut root, "identity");
+    let ident = object_field_mut(&mut root, "identity")?;
     set_optional_string(ident, "pronouns", pronouns);
     set_optional_string(ident, "role", role);
     set_optional_string(ident, "bio", bio);
@@ -160,8 +160,8 @@ pub fn run_set_config(
 
 pub fn run_link_config(config: &Path, platform: &str, handle: &str) -> Result<(), Box<dyn Error>> {
     let mut root = load_config_required(config)?;
-    let ident = object_field_mut(&mut root, "identity");
-    let integrations = object_map_field_mut(ident, "integrations");
+    let ident = object_field_mut(&mut root, "identity")?;
+    let integrations = object_map_field_mut(ident, "integrations")?;
     let previous = integrations
         .get(platform)
         .and_then(Value::as_str)
@@ -212,7 +212,7 @@ pub fn run_nudge_needed(config: &Path) -> Result<(), Box<dyn Error>> {
 pub fn run_import_continuum(config: &Path, blob: &str) -> Result<(), Box<dyn Error>> {
     let source: Value = serde_json::from_str(blob).unwrap_or(Value::Null);
     let mut root = load_config_required(config)?;
-    let ident = object_field_mut(&mut root, "identity");
+    let ident = object_field_mut(&mut root, "identity")?;
     for key in ["pronouns", "role", "bio"] {
         if let Some(value) = source
             .get(key)
@@ -227,7 +227,7 @@ pub fn run_import_continuum(config: &Path, blob: &str) -> Result<(), Box<dyn Err
         .and_then(Value::as_str)
         .unwrap_or("")
         .to_string();
-    let integrations = object_map_field_mut(ident, "integrations");
+    let integrations = object_map_field_mut(ident, "integrations")?;
     integrations.insert("continuum".to_string(), Value::String(name.clone()));
     save_config(config, &root)?;
     println!(
@@ -524,24 +524,39 @@ fn save_config(config: &Path, root: &Value) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn object_field_mut<'a>(root: &'a mut Value, key: &str) -> &'a mut serde_json::Map<String, Value> {
-    let object = root
-        .as_object_mut()
-        .expect("load_config_required validates config root object");
+fn object_field_mut<'a>(
+    root: &'a mut Value,
+    key: &str,
+) -> Result<&'a mut serde_json::Map<String, Value>, Box<dyn Error>> {
+    let Value::Object(object) = root else {
+        return Err("config JSON root must be an object".into());
+    };
     if !object.get(key).is_some_and(Value::is_object) {
         object.insert(key.to_string(), Value::Object(Default::default()));
     }
-    object.get_mut(key).unwrap().as_object_mut().unwrap()
+    match object.get_mut(key) {
+        Some(Value::Object(field)) => Ok(field),
+        Some(
+            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Array(_),
+        )
+        | None => Err(format!("failed to initialize {key} object").into()),
+    }
 }
 
 fn object_map_field_mut<'a>(
     object: &'a mut serde_json::Map<String, Value>,
     key: &str,
-) -> &'a mut serde_json::Map<String, Value> {
+) -> Result<&'a mut serde_json::Map<String, Value>, Box<dyn Error>> {
     if !object.get(key).is_some_and(Value::is_object) {
         object.insert(key.to_string(), Value::Object(Default::default()));
     }
-    object.get_mut(key).unwrap().as_object_mut().unwrap()
+    match object.get_mut(key) {
+        Some(Value::Object(field)) => Ok(field),
+        Some(
+            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Array(_),
+        )
+        | None => Err(format!("failed to initialize {key} object").into()),
+    }
 }
 
 fn set_optional_string(

--- a/crates/airc-cli/src/json_path.rs
+++ b/crates/airc-cli/src/json_path.rs
@@ -29,7 +29,9 @@ pub fn emit_value(value: &Value, default: &str) -> Result<(), Box<dyn Error>> {
         Value::String(text) => println!("{text}"),
         Value::Bool(true) => println!("true"),
         Value::Bool(false) => println!("false"),
-        other => println!("{}", serde_json::to_string(other)?),
+        other @ (Value::Number(_) | Value::Array(_) | Value::Object(_)) => {
+            println!("{}", serde_json::to_string(other)?)
+        }
     }
     Ok(())
 }

--- a/crates/airc-cli/src/message_commands.rs
+++ b/crates/airc-cli/src/message_commands.rs
@@ -18,9 +18,9 @@ pub fn run_build_legacy(
         "channel": channel,
         "msg": msg,
     });
-    let object = payload
-        .as_object_mut()
-        .expect("json object literal is an object");
+    let Value::Object(object) = &mut payload else {
+        return Err("legacy message payload must be a JSON object".into());
+    };
     if !client_id.is_empty() {
         object.insert(
             "client_id".to_string(),

--- a/crates/airc-cli/src/network_commands.rs
+++ b/crates/airc-cli/src/network_commands.rs
@@ -13,7 +13,7 @@ fn detect_lan_ip() -> Option<Ipv4Addr> {
     socket.connect((Ipv4Addr::new(8, 8, 8, 8), 80)).ok()?;
     match socket.local_addr().ok()?.ip() {
         IpAddr::V4(ip) if is_routable_lan_ipv4(ip) => Some(ip),
-        _ => None,
+        IpAddr::V4(_) | IpAddr::V6(_) => None,
     }
 }
 

--- a/crates/airc-cli/src/queue_card_commands.rs
+++ b/crates/airc-cli/src/queue_card_commands.rs
@@ -577,7 +577,7 @@ pub(crate) fn value_text(value: &Value) -> String {
         Value::Number(number) => number.to_string(),
         Value::Bool(boolean) => boolean.to_string(),
         Value::Null => String::new(),
-        other => other.to_string(),
+        other @ (Value::Array(_) | Value::Object(_)) => other.to_string(),
     }
 }
 

--- a/crates/airc-cli/src/queue_card_projection.rs
+++ b/crates/airc-cli/src/queue_card_projection.rs
@@ -265,14 +265,16 @@ fn stale_cards(
             "missing-owner".to_string()
         } else if hb_dt.is_none() {
             "missing-heartbeat".to_string()
-        } else {
-            let age = now - hb_dt.unwrap();
+        } else if let Some(heartbeat_at) = hb_dt {
+            let age = now - heartbeat_at;
             age_seconds = Some(age.num_seconds());
             if age > threshold {
                 "stale-heartbeat".to_string()
             } else {
                 String::new()
             }
+        } else {
+            "missing-heartbeat".to_string()
         };
         if reason.is_empty() {
             continue;

--- a/crates/airc-cli/src/queue_card_runtime.rs
+++ b/crates/airc-cli/src/queue_card_runtime.rs
@@ -354,10 +354,14 @@ fn availability_cards(
                 "missing-owner".to_string()
             } else if heartbeat_dt.is_none() {
                 "missing-heartbeat".to_string()
-            } else if now - heartbeat_dt.unwrap() > stale_after {
-                "stale-heartbeat".to_string()
+            } else if let Some(heartbeat_at) = heartbeat_dt {
+                if now - heartbeat_at > stale_after {
+                    "stale-heartbeat".to_string()
+                } else {
+                    String::new()
+                }
             } else {
-                String::new()
+                "missing-heartbeat".to_string()
             }
         } else {
             String::new()

--- a/crates/airc-core/src/body.rs
+++ b/crates/airc-core/src/body.rs
@@ -54,7 +54,13 @@ impl Body {
                 // surface as text.
                 Some(s.as_str())
             }
-            _ => None,
+            Body::Json(
+                serde_json::Value::Null
+                | serde_json::Value::Bool(_)
+                | serde_json::Value::Number(_)
+                | serde_json::Value::Array(_),
+            )
+            | Body::Binary(_) => None,
         }
     }
 }

--- a/crates/airc-daemon/src/identity.rs
+++ b/crates/airc-daemon/src/identity.rs
@@ -106,7 +106,9 @@ impl std::error::Error for IdentityError {
         match self {
             IdentityError::Io(error) => Some(error),
             IdentityError::Json(error) => Some(error),
-            _ => None,
+            IdentityError::SchemaVersionMismatch { .. }
+            | IdentityError::PartialState { .. }
+            | IdentityError::BadKeyLength(_) => None,
         }
     }
 }

--- a/crates/airc-daemon/src/ipc/client.rs
+++ b/crates/airc-daemon/src/ipc/client.rs
@@ -57,7 +57,7 @@ impl std::error::Error for ClientError {
         match self {
             ClientError::NotConnected(error) | ClientError::Io(error) => Some(error),
             ClientError::Codec(error) => Some(error),
-            _ => None,
+            ClientError::Daemon(_) | ClientError::UnexpectedResponse(_) => None,
         }
     }
 }
@@ -103,56 +103,88 @@ impl DaemonClient {
 
         match response {
             Response::Error { message } => Err(ClientError::Daemon(message)),
-            other => Ok(other),
+            other @ (Response::Pong
+            | Response::Status(_)
+            | Response::Inbox(_)
+            | Response::Peers(_)
+            | Response::Ok) => Ok(other),
         }
     }
 
     pub async fn ping(&self) -> Result<(), ClientError> {
         match self.call(Request::Ping).await? {
             Response::Pong => Ok(()),
-            other => Err(ClientError::UnexpectedResponse(other)),
+            other @ (Response::Status(_)
+            | Response::Inbox(_)
+            | Response::Peers(_)
+            | Response::Ok
+            | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
 
     pub async fn status(&self) -> Result<StatusResponse, ClientError> {
         match self.call(Request::Status).await? {
             Response::Status(status) => Ok(status),
-            other => Err(ClientError::UnexpectedResponse(other)),
+            other @ (Response::Pong
+            | Response::Inbox(_)
+            | Response::Peers(_)
+            | Response::Ok
+            | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
 
     pub async fn send(&self, request: SendRequest) -> Result<(), ClientError> {
         match self.call(Request::Send(request)).await? {
             Response::Ok => Ok(()),
-            other => Err(ClientError::UnexpectedResponse(other)),
+            other @ (Response::Pong
+            | Response::Status(_)
+            | Response::Inbox(_)
+            | Response::Peers(_)
+            | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
 
     pub async fn subscribe(&self, request: SubscribeRequest) -> Result<(), ClientError> {
         match self.call(Request::Subscribe(request)).await? {
             Response::Ok => Ok(()),
-            other => Err(ClientError::UnexpectedResponse(other)),
+            other @ (Response::Pong
+            | Response::Status(_)
+            | Response::Inbox(_)
+            | Response::Peers(_)
+            | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
 
     pub async fn inbox(&self, request: InboxRequest) -> Result<InboxResponse, ClientError> {
         match self.call(Request::Inbox(request)).await? {
             Response::Inbox(response) => Ok(response),
-            other => Err(ClientError::UnexpectedResponse(other)),
+            other @ (Response::Pong
+            | Response::Status(_)
+            | Response::Peers(_)
+            | Response::Ok
+            | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
 
     pub async fn stop(&self) -> Result<(), ClientError> {
         match self.call(Request::Stop).await? {
             Response::Ok => Ok(()),
-            other => Err(ClientError::UnexpectedResponse(other)),
+            other @ (Response::Pong
+            | Response::Status(_)
+            | Response::Inbox(_)
+            | Response::Peers(_)
+            | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
 
     pub async fn add_peer(&self, request: AddPeerRequest) -> Result<(), ClientError> {
         match self.call(Request::AddPeer(request)).await? {
             Response::Ok => Ok(()),
-            other => Err(ClientError::UnexpectedResponse(other)),
+            other @ (Response::Pong
+            | Response::Status(_)
+            | Response::Inbox(_)
+            | Response::Peers(_)
+            | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
 
@@ -163,7 +195,11 @@ impl DaemonClient {
     pub async fn list_peers(&self) -> Result<PeersResponse, ClientError> {
         match self.call(Request::ListPeers).await? {
             Response::Peers(response) => Ok(response),
-            other => Err(ClientError::UnexpectedResponse(other)),
+            other @ (Response::Pong
+            | Response::Status(_)
+            | Response::Inbox(_)
+            | Response::Ok
+            | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
 }

--- a/crates/airc-daemon/src/peers_store.rs
+++ b/crates/airc-daemon/src/peers_store.rs
@@ -55,7 +55,8 @@ impl std::error::Error for PeersStoreError {
             PeersStoreError::Io(error) => Some(error),
             PeersStoreError::Json(error) => Some(error),
             PeersStoreError::Base64(error) => Some(error),
-            _ => None,
+            PeersStoreError::SchemaVersionMismatch { .. }
+            | PeersStoreError::WrongPubkeyLength(_) => None,
         }
     }
 }

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -160,7 +160,7 @@ impl Airc {
     /// background subscriber on the new room's wire if one isn't
     /// already running, so subsequent `say`s land in the store.
     pub async fn join(&self, name: &str) -> Result<Room, AircError> {
-        let room = Room::from_name(&self.inner.home, name);
+        let room = Room::from_name(&self.inner.home, name)?;
         room::save(&self.inner.home, &room)?;
         self.ensure_wire_subscriber(&room.wire).await?;
         Ok(room)
@@ -171,7 +171,7 @@ impl Airc {
     /// processes on one machine tail the same `frames.jsonl`).
     /// Production users want [`join`].
     pub async fn join_with_wire(&self, name: &str, wire: PathBuf) -> Result<Room, AircError> {
-        let mut room = Room::from_name(&self.inner.home, name);
+        let mut room = Room::from_name(&self.inner.home, name)?;
         room.wire = wire;
         room::save(&self.inner.home, &room)?;
         self.ensure_wire_subscriber(&room.wire).await?;

--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -25,6 +25,9 @@ pub enum AircError {
     #[error("room state: {0}")]
     Room(#[from] crate::room::RoomError),
 
+    #[error("system clock before UNIX_EPOCH: {0}")]
+    Clock(#[from] std::time::SystemTimeError),
+
     #[error("peer spec: {0}")]
     PeerSpec(#[from] crate::registry::PeerSpecError),
 

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -28,7 +28,7 @@ impl Airc {
         let room = self.current_room().await?;
         self.ensure_wire_subscriber(&room.wire).await?;
         let event_id = EventId::new();
-        let occurred_at_ms = now_ms();
+        let occurred_at_ms = now_ms()?;
         let mut frame = Frame {
             kind,
             envelope: Envelope {

--- a/crates/airc-lib/src/room.rs
+++ b/crates/airc-lib/src/room.rs
@@ -38,6 +38,7 @@ const ROOM_NAMESPACE: Uuid = Uuid::from_bytes([
 pub enum RoomError {
     Io(std::io::Error),
     Json(serde_json::Error),
+    Clock(std::time::SystemTimeError),
     /// Schema version mismatch — refuse to misinterpret old / future
     /// room files.
     SchemaVersionMismatch {
@@ -51,6 +52,7 @@ impl std::fmt::Display for RoomError {
         match self {
             RoomError::Io(error) => write!(f, "room I/O: {error}"),
             RoomError::Json(error) => write!(f, "room JSON: {error}"),
+            RoomError::Clock(error) => write!(f, "room timestamp clock error: {error}"),
             RoomError::SchemaVersionMismatch { found, expected } => {
                 write!(f, "room.json version {found}, expected {expected}")
             }
@@ -63,7 +65,8 @@ impl std::error::Error for RoomError {
         match self {
             RoomError::Io(error) => Some(error),
             RoomError::Json(error) => Some(error),
-            _ => None,
+            RoomError::Clock(error) => Some(error),
+            RoomError::SchemaVersionMismatch { .. } => None,
         }
     }
 }
@@ -77,6 +80,12 @@ impl From<std::io::Error> for RoomError {
 impl From<serde_json::Error> for RoomError {
     fn from(error: serde_json::Error) -> Self {
         RoomError::Json(error)
+    }
+}
+
+impl From<std::time::SystemTimeError> for RoomError {
+    fn from(error: std::time::SystemTimeError) -> Self {
+        RoomError::Clock(error)
     }
 }
 
@@ -100,21 +109,21 @@ impl Room {
     /// Derive a `Room` from a name + home dir. Deterministic — same
     /// (home, name) always produces the same `Room`. Doesn't read
     /// or write disk.
-    pub fn from_name(home: &Path, name: &str) -> Self {
+    pub fn from_name(home: &Path, name: &str) -> Result<Self, RoomError> {
         let wire = home.join("wires").join(sanitise_name(name));
         let channel = RoomId::from_uuid(Uuid::new_v5(&ROOM_NAMESPACE, name.as_bytes()));
-        Self {
+        Ok(Self {
             version: ROOM_VERSION,
             name: name.to_string(),
             wire,
             channel,
-            joined_at_ms: now_ms(),
-        }
+            joined_at_ms: now_ms()?,
+        })
     }
 
     /// Default room — auto-created on `airc-rs init`. Name "default",
     /// derived per `from_name`.
-    pub fn default_for(home: &Path) -> Self {
+    pub fn default_for(home: &Path) -> Result<Self, RoomError> {
         Self::from_name(home, DEFAULT_ROOM_NAME)
     }
 }
@@ -130,7 +139,7 @@ pub fn path_in(home: &Path) -> PathBuf {
 pub fn load_or_default(home: &Path) -> Result<Room, RoomError> {
     let path = path_in(home);
     if !path.exists() {
-        return Ok(Room::default_for(home));
+        return Room::default_for(home);
     }
     let text = std::fs::read_to_string(&path)?;
     let room: Room = serde_json::from_str(&text)?;
@@ -182,11 +191,10 @@ fn set_owner_only_permissions(_path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock before UNIX_EPOCH violates AIRC room timestamp contract")
-        .as_millis() as u64
+fn now_ms() -> Result<u64, std::time::SystemTimeError> {
+    Ok(std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_millis() as u64)
 }
 
 #[cfg(test)]

--- a/crates/airc-lib/src/room/tests.rs
+++ b/crates/airc-lib/src/room/tests.rs
@@ -5,8 +5,8 @@ use tempfile::TempDir;
 fn from_name_is_deterministic_across_homes() {
     let home_a = TempDir::new().unwrap();
     let home_b = TempDir::new().unwrap();
-    let a = Room::from_name(home_a.path(), "project-x");
-    let b = Room::from_name(home_b.path(), "project-x");
+    let a = Room::from_name(home_a.path(), "project-x").unwrap();
+    let b = Room::from_name(home_b.path(), "project-x").unwrap();
     assert_eq!(a.channel, b.channel);
     assert_ne!(a.wire, b.wire);
 }
@@ -14,8 +14,8 @@ fn from_name_is_deterministic_across_homes() {
 #[test]
 fn from_name_differs_per_name() {
     let home = TempDir::new().unwrap();
-    let a = Room::from_name(home.path(), "general");
-    let b = Room::from_name(home.path(), "private");
+    let a = Room::from_name(home.path(), "general").unwrap();
+    let b = Room::from_name(home.path(), "private").unwrap();
     assert_ne!(a.channel, b.channel);
     assert_ne!(a.wire, b.wire);
 }
@@ -30,7 +30,7 @@ fn load_or_default_returns_default_when_missing() {
 #[test]
 fn save_then_load_roundtrips() {
     let home = TempDir::new().unwrap();
-    let original = Room::from_name(home.path(), "test-room");
+    let original = Room::from_name(home.path(), "test-room").unwrap();
     save(home.path(), &original).unwrap();
     let loaded = load_or_default(home.path()).unwrap();
     assert_eq!(loaded.name, original.name);

--- a/crates/airc-lib/src/route_health.rs
+++ b/crates/airc-lib/src/route_health.rs
@@ -30,10 +30,7 @@ impl TransportHealthSample {
         TransportCandidate {
             kind: self.kind,
             role: self.role,
-            healthy: matches!(
-                self.state,
-                TransportHealthState::Healthy | TransportHealthState::Degraded
-            ),
+            healthy: matches!(self.state, TransportHealthState::Healthy),
         }
     }
 
@@ -79,7 +76,7 @@ mod tests {
     }
 
     #[test]
-    fn degraded_health_is_still_candidate_usable() {
+    fn degraded_health_is_not_admissible_by_default() {
         let candidate = TransportHealthSample {
             kind: TransportKind::LanTcp,
             role: TransportRole::Direct,
@@ -89,6 +86,6 @@ mod tests {
         }
         .candidate();
 
-        assert!(candidate.healthy);
+        assert!(!candidate.healthy);
     }
 }

--- a/crates/airc-lib/src/time.rs
+++ b/crates/airc-lib/src/time.rs
@@ -1,6 +1,5 @@
-pub(crate) fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock before UNIX_EPOCH violates AIRC timestamp contract")
-        .as_millis() as u64
+pub(crate) fn now_ms() -> Result<u64, std::time::SystemTimeError> {
+    Ok(std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_millis() as u64)
 }

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -99,7 +99,7 @@ impl Airc {
             priority: request.priority,
             lane_id: request.lane_id,
             created_by: self.peer_id(),
-            created_at_ms: now_ms(),
+            created_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(card_id)
@@ -114,7 +114,7 @@ impl Airc {
             claim_id,
             owner: self.peer_id(),
             ttl_ms: request.ttl_ms,
-            claimed_at_ms: now_ms(),
+            claimed_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(claim_id)
@@ -127,7 +127,7 @@ impl Airc {
             claim_id: request.claim_id,
             owner: self.peer_id(),
             reason: request.reason,
-            released_at_ms: now_ms(),
+            released_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(())
@@ -144,7 +144,7 @@ impl Airc {
             title: request.title,
             state: request.state,
             created_by: self.peer_id(),
-            created_at_ms: now_ms(),
+            created_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(lane_id)
@@ -159,7 +159,7 @@ impl Airc {
             lane_id: request.lane_id,
             state: request.state,
             changed_by: self.peer_id(),
-            changed_at_ms: now_ms(),
+            changed_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(())
@@ -181,7 +181,7 @@ impl Airc {
             repo: request.repo,
             branch: request.branch,
             base: request.base,
-            requested_at_ms: now_ms(),
+            requested_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(workspace_id)
@@ -192,7 +192,7 @@ impl Airc {
         let event = WorkEvent::WorkspaceAllocated(WorkspaceAllocated {
             workspace_id: request.workspace_id,
             path: request.path,
-            allocated_at_ms: now_ms(),
+            allocated_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(())
@@ -203,7 +203,7 @@ impl Airc {
         let event = WorkEvent::WorkspaceHeartbeat(WorkspaceHeartbeat {
             workspace_id: request.workspace_id,
             disk_bytes: request.disk_bytes,
-            heartbeat_at_ms: now_ms(),
+            heartbeat_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(())
@@ -213,7 +213,7 @@ impl Airc {
     pub async fn release_workspace(&self, request: ReleaseWorkspace) -> Result<(), AircError> {
         let event = WorkEvent::WorkspaceReleased(WorkspaceReleased {
             workspace_id: request.workspace_id,
-            released_at_ms: now_ms(),
+            released_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(())
@@ -227,7 +227,7 @@ impl Airc {
             repo: request.repo,
             manager: self.peer_id(),
             ttl_ms: request.ttl_ms,
-            claimed_at_ms: now_ms(),
+            claimed_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(())
@@ -238,7 +238,7 @@ impl Airc {
         let event = WorkEvent::ManagerHatReleased(ManagerHatReleased {
             repo: request.repo,
             manager: self.peer_id(),
-            released_at_ms: now_ms(),
+            released_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(())

--- a/crates/airc-store/src/error.rs
+++ b/crates/airc-store/src/error.rs
@@ -14,6 +14,10 @@ pub enum StoreError {
     #[error("store database error: {0}")]
     Database(#[from] sea_orm::DbErr),
 
+    /// In-memory store lock was poisoned by a panic in another task.
+    #[error("store lock poisoned")]
+    LockPoisoned,
+
     /// Migration error during `open`.
     #[error("store migration error: {0}")]
     Migration(String),
@@ -23,6 +27,11 @@ pub enum StoreError {
     /// generally indicates a replay or a duplicated network frame.
     #[error("duplicate event_id: {0}")]
     DuplicateEventId(uuid::Uuid),
+
+    /// Stored transcript kind is not known to this binary. Refuse to
+    /// reinterpret it as another kind; replay must be exact.
+    #[error("unknown transcript kind: {0}")]
+    UnknownTranscriptKind(String),
 
     /// JSON encode/decode failure on the stored `metadata` /
     /// `headers` / `body` blob. Wrapped so callers can distinguish

--- a/crates/airc-store/src/memory.rs
+++ b/crates/airc-store/src/memory.rs
@@ -31,7 +31,7 @@ impl Default for InMemoryEventStore {
 #[async_trait]
 impl EventStore for InMemoryEventStore {
     async fn append(&self, ev: TranscriptEvent) -> Result<(), StoreError> {
-        let mut events = self.events.lock().unwrap();
+        let mut events = self.events.lock().map_err(|_| StoreError::LockPoisoned)?;
         if events.iter().any(|e| e.event_id == ev.event_id) {
             return Err(StoreError::DuplicateEventId(ev.event_id.as_uuid()));
         }
@@ -44,7 +44,7 @@ impl EventStore for InMemoryEventStore {
         channel: Option<RoomId>,
         limit: usize,
     ) -> Result<Vec<TranscriptEvent>, StoreError> {
-        let events = self.events.lock().unwrap();
+        let events = self.events.lock().map_err(|_| StoreError::LockPoisoned)?;
         let mut filtered: Vec<TranscriptEvent> = events
             .iter()
             .filter(|e| channel.is_none_or(|room| e.room_id == room))
@@ -64,7 +64,7 @@ impl EventStore for InMemoryEventStore {
         channel: Option<RoomId>,
         limit: usize,
     ) -> Result<Vec<TranscriptEvent>, StoreError> {
-        let events = self.events.lock().unwrap();
+        let events = self.events.lock().map_err(|_| StoreError::LockPoisoned)?;
         let mut filtered: Vec<TranscriptEvent> = events
             .iter()
             .filter(|e| channel.is_none_or(|room| e.room_id == room))
@@ -80,7 +80,7 @@ impl EventStore for InMemoryEventStore {
         &self,
         channel: Option<RoomId>,
     ) -> Result<Option<TranscriptCursor>, StoreError> {
-        let events = self.events.lock().unwrap();
+        let events = self.events.lock().map_err(|_| StoreError::LockPoisoned)?;
         let newest = events
             .iter()
             .filter(|e| channel.is_none_or(|room| e.room_id == room))

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -240,11 +240,7 @@ fn from_model(m: event::Model) -> Result<TranscriptEvent, StoreError> {
         "presence" => TranscriptKind::Presence,
         "session_control" => TranscriptKind::SessionControl,
         "system" => TranscriptKind::System,
-        // Unknown kind in a stored row = forward-compat case. Treat
-        // as System rather than failing the page — a future server
-        // version may have written a kind this older binary doesn't
-        // know about, and silently dropping it would lose data.
-        _ => TranscriptKind::System,
+        other => return Err(StoreError::UnknownTranscriptKind(other.to_string())),
     };
     let target: MentionTarget = serde_json::from_value(m.target)?;
     let headers: Headers = serde_json::from_value(m.headers)?;
@@ -286,6 +282,8 @@ fn _json_value_keepalive(_: JsonValue) {}
 mod tests {
     use super::*;
     use airc_core::transcript::MentionTarget;
+    use serde_json::json;
+    use uuid::Uuid;
 
     fn make_event(lamport: u64, room: RoomId, body: &str) -> TranscriptEvent {
         TranscriptEvent {
@@ -303,6 +301,34 @@ mod tests {
             receipt: None,
             metadata: serde_json::Value::Null,
         }
+    }
+
+    fn model_with_kind(kind: &str) -> event::Model {
+        event::Model {
+            event_id: Uuid::new_v4(),
+            room_id: Uuid::new_v4(),
+            peer_id: Uuid::new_v4(),
+            client_id: Uuid::new_v4(),
+            kind: kind.to_string(),
+            occurred_at_ms: 1_700_000_000_000,
+            lamport: 1,
+            target: json!(MentionTarget::All),
+            headers: json!(Headers::new()),
+            body: None,
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn unknown_transcript_kind_fails_closed() {
+        let result = from_model(model_with_kind("future_kind"));
+
+        assert!(
+            matches!(result, Err(StoreError::UnknownTranscriptKind(ref kind)) if kind == "future_kind"),
+            "expected UnknownTranscriptKind, got {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/airc-transport/src/lan_tcp/adapter/error.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/error.rs
@@ -66,7 +66,11 @@ impl std::error::Error for LanTcpError {
             LanTcpError::Io(error) | LanTcpError::TlsHandshake(error) => Some(error),
             LanTcpError::Json(error) => Some(error),
             LanTcpError::TlsConfig(error) => Some(error),
-            _ => None,
+            LanTcpError::PeerNotInRegistry
+            | LanTcpError::FrameTooLarge { .. }
+            | LanTcpError::NoActivePeers
+            | LanTcpError::AlreadyConnectedTo(_)
+            | LanTcpError::AlreadyListening => None,
         }
     }
 }


### PR DESCRIPTION
Summary
- add a production-only Clippy gate that denies unwrap/expect/panic/todo/unimplemented and wildcard enum matches while keeping tests under the normal gate
- make replay/storage fail closed for poisoned locks and unknown transcript kinds instead of silently reinterpreting state
- remove local-bus-as-delivered masking from GH bearer send failures
- convert production timestamp and JSON mutation paths from panic assertions into typed errors/control flow
- make degraded route health non-admissible by default

Verification
- cargo fmt --all
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo clippy --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm
- cargo test --workspace --all-features