### PR TITLE
refactor: remove fallback runtime surfaces

### DIFF
--- a/crates/airc-cli/src/collaboration_cli.rs
+++ b/crates/airc-cli/src/collaboration_cli.rs
@@ -16,14 +16,12 @@ pub enum CollaborationAction {
     Doctor(CollaborationScopeArgs),
     /// Warn when sends are likely isolated.
     SendWarning(CollaborationScopeArgs),
-    /// Print recent broadcast peers when peer records are empty.
-    PeersFallback(CollaborationScopeArgs),
     /// Print paired peers plus recent broadcast-only peers.
     Peers(CollaborationScopeArgs),
     /// Remove stale duplicate peer records for the same host.
     PrunePeers(CollaborationScopeArgs),
-    /// Print a broadcast-only whois fallback.
-    WhoisFallback {
+    /// Print identity evidence observed from signed room traffic.
+    ObservedWhois {
         #[command(flatten)]
         scope: CollaborationScopeArgs,
         #[arg(long)]

--- a/crates/airc-cli/src/collaboration_commands.rs
+++ b/crates/airc-cli/src/collaboration_commands.rs
@@ -1,4 +1,3 @@
-use std::cmp::Reverse;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fs;
@@ -141,28 +140,7 @@ pub fn run_send_warning(
     Ok(())
 }
 
-pub fn run_peers_fallback(
-    default_home: &Path,
-    args: CollaborationScopeArgs,
-) -> Result<(), Box<dyn Error>> {
-    let home = args.home.as_deref().unwrap_or(default_home);
-    let speakers = recent_remote_speakers(home, &args.my_name, &args.client_id);
-    if speakers.is_empty() {
-        return Err(command_exit(1));
-    }
-    println!("  Recent broadcast peers:");
-    let mut speaker_entries = speakers.iter().collect::<Vec<_>>();
-    speaker_entries.sort_by_key(|(_, ts)| Reverse(**ts));
-    for (who, ts) in speaker_entries {
-        println!(
-            "  {who} → broadcast room   [(from signed messages.jsonl)]   last seen {}",
-            fmt_age(*ts)
-        );
-    }
-    Ok(())
-}
-
-pub fn run_whois_fallback(
+pub fn run_observed_whois(
     default_home: &Path,
     args: CollaborationScopeArgs,
     peer_name: &str,
@@ -174,11 +152,14 @@ pub fn run_whois_fallback(
     };
     println!("  name:      {peer_name}");
     println!("  pronouns:  (unknown)");
-    println!("  role:      broadcast peer");
+    println!("  role:      observed room participant");
     println!("  bio:       seen in recent signed room traffic");
     println!("  status:    (unknown)");
     println!("  integrations: (none)");
-    println!("  presence:  broadcast-only, last seen {}", fmt_age(*ts));
+    println!(
+        "  presence:  observed from room traffic, last seen {}",
+        fmt_age(*ts)
+    );
     Ok(())
 }
 

--- a/crates/airc-cli/src/envelope_cli.rs
+++ b/crates/airc-cli/src/envelope_cli.rs
@@ -8,22 +8,22 @@ pub struct EnvelopeArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum EnvelopeAction {
-    /// Encrypt the legacy envelope `msg` field for a recipient.
+    /// Encrypt the envelope `msg` field for a recipient.
     Wrap {
         /// Recipient X25519 public key, URL-safe base64 without padding.
-        #[arg(long, default_value = "")]
+        #[arg(long)]
         recipient_pub: String,
-        /// Legacy identity directory containing x25519_priv.
+        /// Identity directory containing x25519_priv.
         #[arg(long)]
         identity_dir: std::path::PathBuf,
     },
 
-    /// Decrypt the legacy envelope `msg` field from a sender.
+    /// Decrypt the envelope `msg` field from a sender.
     Unwrap {
         /// Sender X25519 public key, URL-safe base64 without padding.
-        #[arg(long, default_value = "")]
+        #[arg(long)]
         sender_pub: String,
-        /// Legacy identity directory containing x25519_priv.
+        /// Identity directory containing x25519_priv.
         #[arg(long)]
         identity_dir: std::path::PathBuf,
     },

--- a/crates/airc-cli/src/legacy_envelope.rs
+++ b/crates/airc-cli/src/legacy_envelope.rs
@@ -24,13 +24,9 @@ pub fn wrap_stdin(recipient_pub: &str, identity_dir: &Path) -> Result<(), Box<dy
         return Ok(());
     }
 
-    let Ok(mut envelope) = serde_json::from_str::<Value>(trimmed) else {
-        println!("{trimmed}");
-        return Ok(());
-    };
+    let mut envelope: Value = serde_json::from_str(trimmed)?;
     if recipient_pub.is_empty() {
-        println!("{}", serde_json::to_string(&envelope)?);
-        return Ok(());
+        return Err("envelope wrap requires --recipient-pub".into());
     }
 
     let sender_priv = legacy_identity::load_x25519_private(identity_dir)?;
@@ -60,7 +56,7 @@ pub fn unwrap_stdin(sender_pub: &str, identity_dir: &Path) -> Result<(), Box<dyn
         return Ok(());
     }
     if sender_pub.is_empty() {
-        return Err("legacy envelope unwrap requires --sender-pub for encrypted input".into());
+        return Err("envelope unwrap requires --sender-pub for encrypted input".into());
     }
 
     let recipient_priv = legacy_identity::load_x25519_private(identity_dir)?;
@@ -84,23 +80,23 @@ pub fn unwrap_value(
     let enc = envelope
         .get("enc")
         .and_then(Value::as_str)
-        .ok_or("legacy envelope has no enc field")?;
+        .ok_or("encrypted envelope has no enc field")?;
     if enc != ENC_VERSION {
-        return Err(format!("unsupported legacy envelope enc version: {enc}").into());
+        return Err(format!("unsupported envelope enc version: {enc}").into());
     }
     let ciphertext = envelope
         .get("msg")
         .and_then(Value::as_str)
-        .ok_or("encrypted legacy envelope msg must be a string")?;
+        .ok_or("encrypted envelope msg must be a string")?;
     let nonce = envelope
         .get("nonce")
         .and_then(Value::as_str)
-        .ok_or("encrypted legacy envelope missing nonce")?;
+        .ok_or("encrypted envelope missing nonce")?;
     let ciphertext = legacy_identity::b64_url_decode(ciphertext)?;
     let nonce = legacy_identity::b64_url_decode(nonce)?;
-    let nonce: [u8; 12] = nonce.try_into().map_err(|data: Vec<u8>| {
-        format!("legacy envelope nonce is {} bytes; expected 12", data.len())
-    })?;
+    let nonce: [u8; 12] = nonce
+        .try_into()
+        .map_err(|data: Vec<u8>| format!("envelope nonce is {} bytes; expected 12", data.len()))?;
     let ad = associated_data(envelope)?;
     let key = derive_pairwise_key(recipient_priv, sender_pub)?;
     let cipher = ChaCha20Poly1305::new_from_slice(&key)?;
@@ -112,12 +108,12 @@ pub fn unwrap_value(
                 aad: ad.as_bytes(),
             },
         )
-        .map_err(|_| "legacy envelope decryption failed")?;
+        .map_err(|_| "envelope decryption failed")?;
     let msg = String::from_utf8(plaintext)?;
 
     let object = envelope
         .as_object_mut()
-        .ok_or("legacy envelope must be a JSON object")?;
+        .ok_or("envelope must be a JSON object")?;
     object.insert("msg".to_string(), Value::String(msg));
     object.remove("enc");
     object.remove("nonce");
@@ -153,11 +149,11 @@ fn wrap_value(
                 aad: ad.as_bytes(),
             },
         )
-        .map_err(|_| "legacy envelope encryption failed")?;
+        .map_err(|_| "envelope encryption failed")?;
 
     let object = envelope
         .as_object_mut()
-        .ok_or("legacy envelope must be a JSON object")?;
+        .ok_or("envelope must be a JSON object")?;
     object.insert(
         "msg".to_string(),
         Value::String(b64_url_no_pad(&ciphertext)),

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -344,15 +344,12 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             CollaborationAction::SendWarning(args) => {
                 collaboration_commands::run_send_warning(&home, args)
             }
-            CollaborationAction::PeersFallback(args) => {
-                collaboration_commands::run_peers_fallback(&home, args)
-            }
             CollaborationAction::Peers(args) => collaboration_peers::run_peers(&home, args),
             CollaborationAction::PrunePeers(args) => {
                 collaboration_peers::run_prune_peers(&home, args)
             }
-            CollaborationAction::WhoisFallback { scope, peer_name } => {
-                collaboration_commands::run_whois_fallback(&home, scope, &peer_name)
+            CollaborationAction::ObservedWhois { scope, peer_name } => {
+                collaboration_commands::run_observed_whois(&home, scope, &peer_name)
             }
         },
 
@@ -604,7 +601,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         },
 
         Command::Message(args) => match args.action {
-            MessageAction::BuildLegacy {
+            MessageAction::Build {
                 from,
                 to,
                 ts,
@@ -612,9 +609,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 msg,
                 client_id,
                 kind,
-            } => message_commands::run_build_legacy(
-                &from, &to, &ts, &channel, &msg, &client_id, &kind,
-            ),
+            } => message_commands::run_build(&from, &to, &ts, &channel, &msg, &client_id, &kind),
         },
 
         Command::Gh(args) => match args.action {

--- a/crates/airc-cli/src/message_cli.rs
+++ b/crates/airc-cli/src/message_cli.rs
@@ -8,8 +8,8 @@ pub struct MessageArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum MessageAction {
-    /// Build a legacy messages.jsonl chat envelope as JSON.
-    BuildLegacy {
+    /// Build an outbound chat log envelope as JSON.
+    Build {
         #[arg(long)]
         from: String,
         #[arg(long)]

--- a/crates/airc-cli/src/message_commands.rs
+++ b/crates/airc-cli/src/message_commands.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
-use serde_json::{json, Value};
+use airc_core::ChatLogEnvelope;
 
-pub fn run_build_legacy(
+pub fn run_build(
     from: &str,
     to: &str,
     ts: &str,
@@ -11,25 +11,9 @@ pub fn run_build_legacy(
     client_id: &str,
     kind: &str,
 ) -> Result<(), Box<dyn Error>> {
-    let mut payload = json!({
-        "from": from,
-        "to": to,
-        "ts": ts,
-        "channel": channel,
-        "msg": msg,
-    });
-    let Value::Object(object) = &mut payload else {
-        return Err("legacy message payload must be a JSON object".into());
-    };
-    if !client_id.is_empty() {
-        object.insert(
-            "client_id".to_string(),
-            Value::String(client_id.to_string()),
-        );
-    }
-    if !kind.is_empty() {
-        object.insert("kind".to_string(), Value::String(kind.to_string()));
-    }
+    let payload = ChatLogEnvelope::new(from, to, ts, channel, msg)
+        .with_client_id(client_id)
+        .with_kind(kind);
     println!("{}", serde_json::to_string(&payload)?);
     Ok(())
 }
@@ -37,32 +21,23 @@ pub fn run_build_legacy(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value;
 
     #[test]
-    fn build_legacy_owns_json_serialization() {
-        let mut out = Vec::new();
-        let payload = json!({
-            "from": "alice",
-            "to": "all",
-            "ts": "2026-05-19T00:00:00Z",
-            "channel": "general",
-            "msg": "line\nquote \" slash \\",
-            "client_id": "client",
-            "kind": "heartbeat",
-        });
-        serde_json::to_writer(&mut out, &payload).unwrap();
-        let parsed: Value = serde_json::from_slice(&out).unwrap();
-        assert_eq!(parsed["msg"], "line\nquote \" slash \\");
-
-        run_build_legacy(
-            "alice",
-            "all",
-            "2026-05-19T00:00:00Z",
-            "general",
-            "line\nquote \" slash \\",
-            "client",
-            "heartbeat",
+    fn command_uses_core_chat_log_shape() {
+        let encoded = serde_json::to_string(
+            &ChatLogEnvelope::new(
+                "alice",
+                "all",
+                "2026-05-19T00:00:00Z",
+                "general",
+                "line\nquote \" slash \\",
+            )
+            .with_client_id("client")
+            .with_kind("heartbeat"),
         )
         .unwrap();
+        let parsed: Value = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(parsed["msg"], "line\nquote \" slash \\");
     }
 }

--- a/crates/airc-cli/src/route_commands.rs
+++ b/crates/airc-cli/src/route_commands.rs
@@ -24,7 +24,6 @@ pub fn run_status(args: RouteStatusArgs) -> Result<(), Box<dyn std::error::Error
         RoutePurpose::Data,
         RoutePurpose::LiveEvent,
         RoutePurpose::Bootstrap,
-        RoutePurpose::Migration,
     ] {
         match resolver.resolve(purpose) {
             Ok(route) => println!(
@@ -94,7 +93,6 @@ fn format_purpose(purpose: RoutePurpose) -> &'static str {
         RoutePurpose::Data => "data",
         RoutePurpose::LiveEvent => "live-event",
         RoutePurpose::Bootstrap => "bootstrap",
-        RoutePurpose::Migration => "migration",
     }
 }
 

--- a/crates/airc-cli/tests/route_commands.rs
+++ b/crates/airc-cli/tests/route_commands.rs
@@ -24,7 +24,7 @@ fn route_status_keeps_github_bootstrap_only() {
     assert!(output.contains("- data -> no-route"));
     assert!(output.contains("- live-event -> no-route"));
     assert!(output.contains("- bootstrap -> gh-gist"));
-    assert!(output.contains("- migration -> gh-gist"));
+    assert!(!output.contains("migration"));
 }
 
 #[test]

--- a/crates/airc-core/src/chat_log.rs
+++ b/crates/airc-core/src/chat_log.rs
@@ -1,0 +1,81 @@
+//! Text-chat log envelope used by the current shell boundary.
+//!
+//! This is not a transport adapter. It is the small typed record that the
+//! shell wrapper still appends to `messages.jsonl` while the Rust event bus
+//! takes over. Keeping the shape here prevents command modules, monitors,
+//! and adapters from each hand-rolling the same JSON.
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct ChatLogEnvelope<'a> {
+    pub from: &'a str,
+    pub to: &'a str,
+    pub ts: &'a str,
+    pub channel: &'a str,
+    pub msg: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    pub client_id: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    pub kind: &'a str,
+}
+
+impl<'a> ChatLogEnvelope<'a> {
+    pub fn new(from: &'a str, to: &'a str, ts: &'a str, channel: &'a str, msg: &'a str) -> Self {
+        Self {
+            from,
+            to,
+            ts,
+            channel,
+            msg,
+            client_id: "",
+            kind: "",
+        }
+    }
+
+    pub fn with_client_id(mut self, client_id: &'a str) -> Self {
+        self.client_id = client_id;
+        self
+    }
+
+    pub fn with_kind(mut self, kind: &'a str) -> Self {
+        self.kind = kind;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_required_chat_fields() {
+        let envelope = ChatLogEnvelope::new(
+            "alice",
+            "all",
+            "2026-05-19T00:00:00Z",
+            "general",
+            "line\nquote \" slash \\",
+        )
+        .with_client_id("client")
+        .with_kind("heartbeat");
+
+        let encoded = serde_json::to_value(envelope).unwrap();
+        assert_eq!(encoded["from"], "alice");
+        assert_eq!(encoded["to"], "all");
+        assert_eq!(encoded["channel"], "general");
+        assert_eq!(encoded["msg"], "line\nquote \" slash \\");
+        assert_eq!(encoded["client_id"], "client");
+        assert_eq!(encoded["kind"], "heartbeat");
+    }
+
+    #[test]
+    fn omits_empty_optional_fields() {
+        let envelope =
+            ChatLogEnvelope::new("alice", "all", "2026-05-19T00:00:00Z", "general", "hi");
+
+        let encoded = serde_json::to_value(envelope).unwrap();
+        assert!(encoded.get("client_id").is_none());
+        assert!(encoded.get("kind").is_none());
+    }
+}

--- a/crates/airc-core/src/lib.rs
+++ b/crates/airc-core/src/lib.rs
@@ -13,6 +13,7 @@
 //! - [`ids`]        — newtype wrappers for identifier strings
 //! - [`identity`]   — the per-peer Identity card (the user/account abstraction)
 //! - [`body`]       — opaque payload (Json | Binary) consumers carry
+//! - [`chat_log`]   — current text-chat log envelope at the shell edge
 //! - [`transcript`] — TranscriptEvent + TranscriptKind + MentionTarget
 //! - [`cursor`]     — cursor + paging primitives for transcript fetch
 //! - [`datetime`]   — fixed-format UTC timestamp parsing
@@ -27,6 +28,7 @@
 
 pub mod attachment;
 pub mod body;
+pub mod chat_log;
 pub mod cursor;
 pub mod datetime;
 pub mod filter;
@@ -43,6 +45,7 @@ pub mod transcript;
 
 pub use attachment::AttachmentManifest;
 pub use body::Body;
+pub use chat_log::ChatLogEnvelope;
 pub use cursor::{page_before, page_recent, TranscriptCursor, TranscriptPage};
 pub use datetime::{iso_to_epoch, DateTimeError};
 pub use filter::{filter_self_echoes, SelfFilter};

--- a/crates/airc-lib/src/route_policy.rs
+++ b/crates/airc-lib/src/route_policy.rs
@@ -1,9 +1,9 @@
 //! Transport route policy for consumer-facing AIRC embeddings.
 //!
 //! The important invariant is negative: GitHub is not a transparent
-//! runtime fallback. It can carry rendezvous / migration frames when a
-//! caller explicitly chooses that purpose, but normal chat/data routing
-//! must use direct transports or fail loudly.
+//! runtime fallback. It can carry bootstrap/rendezvous frames when a caller
+//! explicitly chooses that purpose, but normal chat/data routing must use
+//! direct transports or fail loudly.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RoutePurpose {
@@ -13,8 +13,6 @@ pub enum RoutePurpose {
     LiveEvent,
     /// Initial peer discovery / rendezvous metadata.
     Bootstrap,
-    /// Temporary interop with the legacy gist wire during cutover.
-    Migration,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -69,8 +67,7 @@ impl RoutePolicy {
 fn allows(purpose: RoutePurpose, candidate: TransportCandidate) -> bool {
     match candidate.kind {
         TransportKind::GhGist => {
-            matches!(purpose, RoutePurpose::Bootstrap | RoutePurpose::Migration)
-                && candidate.role == TransportRole::BootstrapOnly
+            purpose == RoutePurpose::Bootstrap && candidate.role == TransportRole::BootstrapOnly
         }
         TransportKind::LocalFs
         | TransportKind::LanTcp
@@ -90,7 +87,7 @@ fn priority(purpose: RoutePurpose, kind: TransportKind) -> u8 {
             TransportKind::Relay => 4,
             TransportKind::GhGist => 255,
         },
-        RoutePurpose::Bootstrap | RoutePurpose::Migration => match kind {
+        RoutePurpose::Bootstrap => match kind {
             TransportKind::LocalFs => 0,
             TransportKind::LanTcp => 1,
             TransportKind::Tailscale => 2,

--- a/crates/airc-lib/src/route_resolver.rs
+++ b/crates/airc-lib/src/route_resolver.rs
@@ -4,7 +4,7 @@
 //! It does not open sockets, poll GitHub, or probe Reticulum. It
 //! accepts measured candidates and applies [`RoutePolicy`]. Later
 //! slices can add health probes/discovery without changing the rule
-//! that GitHub is bootstrap/migration only.
+//! that GitHub is bootstrap/rendezvous only.
 
 use crate::route_health::TransportHealthSample;
 use crate::route_policy::{

--- a/crates/airc-transport/src/gh_gist/mod.rs
+++ b/crates/airc-transport/src/gh_gist/mod.rs
@@ -1,4 +1,4 @@
-//! GitHub gist bootstrap/migration transport.
+//! GitHub gist bootstrap/rendezvous transport.
 //!
 //! This adapter exists to contain the old gist-backed message wire
 //! behind the same `Transport` trait while AIRC moves to real peer
@@ -6,7 +6,7 @@
 //! GitHub can help peers discover each other and exchange bootstrap
 //! metadata, then LAN/Tailscale/relay transports should carry the
 //! runtime stream. Nothing in this module is wired as automatic
-//! fallback; consumers must opt into it deliberately for migration or
+//! fallback; consumers must opt into it deliberately for bootstrap or
 //! rendezvous work.
 
 mod adapter;

--- a/crates/airc-transport/src/lib.rs
+++ b/crates/airc-transport/src/lib.rs
@@ -11,10 +11,9 @@
 //!   when multiple AI agents share one Mac.
 //! - **lan-tcp** (PR-3) — same-LAN peer-to-peer via TLS-wrapped TCP.
 //! - **tailscale** (PR-4) — mesh transport for cross-network peers.
-//! - **gh-gist** (legacy migration adapter only) — lets Rust peers
-//!   interoperate with the old gist wire long enough to delete it.
-//!   It must not become a primary runtime path; GitHub is acceptable
-//!   for bootstrap/discovery, not sustained chat transport.
+//! - **gh-gist** — bootstrap/rendezvous adapter only. It must not become
+//!   a primary runtime path; GitHub is acceptable for identity exchange,
+//!   address publication, and invitations, not sustained chat transport.
 //!
 //! Designed agent-first. The canonical caller is an AI peer sending
 //! frames to other AI peers; human-chat features (typing, presence)

--- a/docs/architecture/ROBUSTNESS-INTEGRATION-PLAN.md
+++ b/docs/architecture/ROBUSTNESS-INTEGRATION-PLAN.md
@@ -72,7 +72,7 @@ real system:
   frontend over `airc-lib`/`airc-daemon`, not the place where
   integration semantics accumulate.
 - GitHub still appears as runtime messaging in older docs and paths.
-  It must become bootstrap/mirror/migration only. Same-device and
+  It must become bootstrap/rendezvous only. Same-device and
   same-LAN communication must never depend on GitHub budget.
 - There are remaining runtime defaults that should be reviewed even if
   they compile, especially `unwrap_or(...)` in timestamp, limit, route,

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -322,7 +322,7 @@ cmd_whois() {
     return 0
   fi
   local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
-  if "$(airc_rs_bin)" collaboration whois-fallback \
+  if "$(airc_rs_bin)" collaboration observed-whois \
       --home "$AIRC_WRITE_DIR" --my-name "$my_name" --peer-name "$target" --client-id "$_client_id"; then
     return 0
   fi

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -37,33 +37,17 @@ cmd_send() {
   # message body — exactly the evidence-eating shape the project rejects).
   #
   # Implementation: parse --room here. If it names a sibling sidecar scope
-  # (e.g. ${AIRC_WRITE_DIR}.<name>), re-exec ourselves with AIRC_HOME
-  # pointed at that scope so the rest of the function runs there. Errors
-  # loudly when the requested room isn't in the user's subscription set
-  # — never silently broadcasts to the wrong place.
+  # --room is now an alias for --channel; it stamps the channel field
+  # inside the single active scope.
   local target_room=""
-  # --channel <name> (Phase 2B): post-substrate flag that ONLY stamps
-  # the envelope's channel field; no scope re-exec. Same scope, same
-  # SSH wire, different channel tag. Coexists with --room for now;
-  # Phase 2B.3 deletes --room's re-exec path and makes --room an
-  # alias for --channel.
+  # --channel <name>: stamp the envelope's channel field. The route must
+  # have an exact channel mapping later in this function.
   local channel_override=""
-  # _explicit_channel: user used --room/--channel to target a specific
-  # channel. When set, we MUST find a gist mapping for that channel —
-  # silently falling back to the scope's primary room_gist_id has the
-  # phantom-room failure mode (banner says "→ #qa-experiment", message
-  # actually goes to #general's gist with channel field "qa-experiment",
-  # no new gist ever created). User reported 2026-04-29: "I sent to
-  # #qa-experiment, #qa-sub-room-test, #x — all 'succeeded' with banner,
-  # NONE created a gist."
-  local _explicit_channel=0
   # --internal: best-effort send for internal informational broadcasts
   # ([rename], etc.) where the monitor-down guard is the wrong UX. Append
   # to the local log + return 0 even when the monitor isn't running.
-  # Receivers heal via monitor_formatter's host-fallback / next-traffic
-  # passes, so missing one event in a quiet scope isn't a correctness
-  # issue. Exposed as a flag (not an env var) so call sites are
-  # grep-able and the pattern matches the rest of the airc CLI surface.
+  # Exposed as a flag (not an env var) so call sites are grep-able and
+  # the pattern matches the rest of the airc CLI surface.
   local internal=0
   # --system: protocol/system event. Uses the same send path as chat so
   # peers see lifecycle state on gh/local transports, but stamps from=airc
@@ -106,12 +90,10 @@ cmd_send() {
       --room|-room)
         target_room="${2:-}"
         [ -z "$target_room" ] && die "Usage: airc send --room <name> <message>"
-        _explicit_channel=1
         shift 2 ;;
       --channel|-c)
         channel_override="${2:-}"
         [ -z "$channel_override" ] && die "Usage: airc send --channel <name> <message>"
-        _explicit_channel=1
         shift 2 ;;
       --internal)
         internal=1
@@ -297,13 +279,11 @@ cmd_send() {
   local client_id; client_id=$(airc_client_id 2>/dev/null || true)
 
   # Channel: stamp every outbound envelope with the active channel so the
-  # monitor display can route by channel uniformly (Phase 2 mesh
-  # substrate). Resolution priority (Phase 2B.1):
+  # monitor display can route by channel uniformly.
+  # Resolution order:
   #   1. --channel / -c flag (explicit per-call override)
   #   2. config.json subscribed_channels[0]
-  #      (Phase 2B substrate — replaces sidecar scopes)
-  #   3. legacy room_name file (back-compat for users mid-rollover)
-  #   4. literal "general" fallback
+  #   3. literal "general" default
   local active_channel=""
   if [ -n "$channel_override" ]; then
     active_channel="$channel_override"
@@ -311,21 +291,17 @@ cmd_send() {
   if [ -z "$active_channel" ]; then
     active_channel=$(airc_config_default_channel "$CONFIG" || true)
   fi
-  if [ -z "$active_channel" ] && [ -f "$AIRC_WRITE_DIR/room_name" ]; then
-    active_channel=$(cat "$AIRC_WRITE_DIR/room_name" 2>/dev/null || true)
-  fi
   [ -z "$active_channel" ] && active_channel="general"
 
   local from_name="$my_name"
   [ "$system_event" = "1" ] && from_name="airc"
-  # airc#644 PR-2: stamp kind=heartbeat when --heartbeat was passed so
-  # cmd_peers can track separately + monitor_formatter can filter from
-  # UI. Default kind (chat) is implicit — pre-#644 peers don't emit kind
-  # and downstream code treats absent kind as chat for back-compat.
+  # Stamp kind=heartbeat when --heartbeat was passed so cmd_peers can
+  # track separately and monitor_formatter can filter from UI. Default
+  # chat kind remains implicit on the wire.
   local message_kind=""
   [ "$heartbeat" = "1" ] && message_kind="heartbeat"
   local payload
-  payload=$("$(airc_rs_bin)" message build-legacy \
+  payload=$("$(airc_rs_bin)" message build \
       --from "$from_name" \
       --to "$peer_name" \
       --ts "$ts_val" \
@@ -349,30 +325,22 @@ cmd_send() {
     # encrypted below if the recipient has a stored x25519_pub.
     _airc_append_local_signed "$full_msg"
 
-    # Phase E.3: wrap the wire envelope with envelope-layer encryption
-    # if we have the recipient's X25519 pubkey on file. Empty pubkey =
-    # peer is on pre-Phase-E airc (or never paired with us under E),
-    # in which case the wrap CLI passes through unchanged. Failures
-    # also pass through (loud stderr, no silent encryption skip).
-    # Phase E.3: look up recipient's X25519 pubkey for envelope encryption.
-    # Empty result = peer hasn't paired under E2E (or our cryptography
-    # package isn't installed). The wrap CLI passes through plaintext in
-    # that case, transparently.
+    # Direct messages require an enrolled recipient X25519 key unless
+    # the caller explicitly asked for plaintext. Encryption errors abort
+    # this send; they are never converted into plaintext wire traffic.
     local recipient_pub=""
     if [ "$peer_name" != "all" ] && [ "$plaintext" != "1" ]; then
       recipient_pub=$("$(airc_rs_bin)" identity peer-pub --home "$AIRC_WRITE_DIR" \
         --peers-dir "$PEERS_DIR" --peer-name "$peer_name" 2>/dev/null || true)
     fi
     local wire_msg="$full_msg"
+    if [ "$peer_name" != "all" ] && [ "$plaintext" != "1" ] && [ -z "$recipient_pub" ]; then
+      die "missing X25519 key for '$peer_name' — refusing plaintext DM"
+    fi
     if [ -n "$recipient_pub" ]; then
-      # Stderr unredirected — wrap failures surface loud (CLAUDE.md "never swallow").
       wire_msg=$(printf '%s' "$full_msg" | "$(airc_rs_bin)" envelope wrap --home "$AIRC_WRITE_DIR" \
         --recipient-pub="$recipient_pub" \
-        --identity-dir "$IDENTITY_DIR" || printf '%s' "$full_msg")
-      # Diagnostic: emit the wire shape to stderr so test logs surface
-      # whether encryption actually engaged. Phase E debug aid; remove
-      # once production has verified the path. (Doubles as a sanity
-      # check for `airc doctor`.)
+        --identity-dir "$IDENTITY_DIR")
       if [ -n "${AIRC_E2E_DEBUG:-}" ]; then
         echo "[airc:e2e] wire_msg: $wire_msg" >&2
       fi
@@ -386,24 +354,13 @@ cmd_send() {
     #   4. Branches on the structured SendOutcome.kind
     # Adding a new transport doesn't touch this file — only the
     # resolver registers it. (Phases 1-3 of bearer rewrite; #269 #270.)
-    # Phase 3c+ (#283): route by channel. The active_channel's gist
-    # comes from channel_gists in config (populated at subscribe time).
-    # If the channel has no mapping, fall back to the scope's primary
-    # room_gist_id so single-room scopes keep working unchanged.
+    # Route by channel. The active_channel's gist comes from
+    # channel_gists in config (populated at subscribe time). Missing
+    # mapping is a routing error, not permission to publish elsewhere.
     local room_gist_id=""
     room_gist_id=$(airc_config_get_channel_gist "$active_channel" "$CONFIG" || true)
-    # Phantom-room guard: when --room/--channel was used explicitly,
-    # NEVER fall back to the scope's primary room_gist_id — that publishes
-    # to the wrong gist with the right channel-tag, creating an invisible
-    # mis-route ("phantom success"). Only the no-override path falls back
-    # for back-compat with single-channel scopes.
     if [ -z "$room_gist_id" ]; then
-      if [ "$_explicit_channel" = "1" ]; then
-        die "no gist mapping for channel '$active_channel' — run 'airc join --room $active_channel' first to create the room"
-      fi
-      if [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
-        room_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
-      fi
+      die "no gist mapping for channel '$active_channel' — run 'airc join --room $active_channel' first to create the room"
     fi
 
     local outcome
@@ -558,11 +515,9 @@ cmd_send() {
       # die is appropriate UX for explicit `airc send` — it surfaces
       # "you're broadcasting to nobody" loudly so the user doesn't wait
       # for a reply that can't arrive. For [rename] the broadcast is
-      # informational; receivers heal via monitor_formatter's host-
-      # fallback on next traffic, so noisily failing the rename in any
-      # scope whose monitor isn't running today (a perfectly normal
-      # multi-scope state) would give the rename feature a worse UX
-      # than no-propagation had.
+      # informational, so noisily failing the rename in any scope whose
+      # monitor isn't running today would give the rename feature worse
+      # behavior than no propagation.
       if [ "$internal" = "1" ]; then
         _airc_append_local_signed "$full_msg"
         date +%s > "$AIRC_WRITE_DIR/last_sent" 2>/dev/null
@@ -589,36 +544,30 @@ cmd_send() {
     # — local-only append disappears into a void. Worst silent-loss
     # class until this fix landed.
     #
-    # Same wrap-if-recipient-known logic as the joiner branch above:
-    # encrypt msg field with recipient's X25519 pub when it's a DM and
-    # we have their pubkey on file; broadcasts go plaintext (group
-    # encryption is a future Phase E.4).
+    # Same policy as the joiner branch above: direct messages require
+    # recipient encryption unless --plaintext was explicit. Broadcast
+    # group encryption is a separate protocol, not an implicit fallback.
     local _host_recipient_pub=""
     if [ "$peer_name" != "all" ] && [ "$plaintext" != "1" ]; then
       _host_recipient_pub=$("$(airc_rs_bin)" identity peer-pub --home "$AIRC_WRITE_DIR" \
         --peers-dir "$PEERS_DIR" --peer-name "$peer_name" 2>/dev/null || true)
     fi
     local _host_wire_msg="$full_msg"
+    if [ "$peer_name" != "all" ] && [ "$plaintext" != "1" ] && [ -z "$_host_recipient_pub" ]; then
+      die "missing X25519 key for '$peer_name' — refusing plaintext DM"
+    fi
     if [ -n "$_host_recipient_pub" ]; then
       _host_wire_msg=$(printf '%s' "$full_msg" | "$(airc_rs_bin)" envelope wrap --home "$AIRC_WRITE_DIR" \
         --recipient-pub="$_host_recipient_pub" \
-        --identity-dir "$IDENTITY_DIR" || printf '%s' "$full_msg")
+        --identity-dir "$IDENTITY_DIR")
     fi
 
-    # Route by channel via channel_gists (post-#283); fall back to the
-    # scope's primary room_gist_id so single-room hosts keep working —
-    # but only when the user did NOT explicitly target a different room
-    # (otherwise the fallback turns --room into a phantom success that
-    # silently mis-routes to the primary gist; see _explicit_channel).
+    # Route by channel via channel_gists. Missing mapping is a routing
+    # error, not permission to publish elsewhere.
     local _host_room_gist_id=""
     _host_room_gist_id=$(airc_config_get_channel_gist "$active_channel" "$CONFIG" || true)
     if [ -z "$_host_room_gist_id" ]; then
-      if [ "$_explicit_channel" = "1" ]; then
-        die "no gist mapping for channel '$active_channel' — run 'airc join --room $active_channel' first to create the room"
-      fi
-      if [ -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
-        _host_room_gist_id=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
-      fi
+      die "no gist mapping for channel '$active_channel' — run 'airc join --room $active_channel' first to create the room"
     fi
 
     if [ -n "$_host_room_gist_id" ]; then


### PR DESCRIPTION
## Summary
- add a typed airc-core ChatLogEnvelope and replace the public message build-legacy path with message build
- rename observed collaboration whois projection and remove unused fallback peer command surface
- fail closed on envelope wrap: no invalid-JSON passthrough, no missing-recipient passthrough, and no plaintext DM on encryption failure
- make send routing require exact channel gist mappings instead of falling back to room_gist_id
- remove RoutePurpose::Migration so gh-gist is bootstrap/rendezvous only, not a runtime or migration transport

## Verification
- cargo fmt --manifest-path Cargo.toml --all --check
- cargo clippy --manifest-path Cargo.toml --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh
- cargo test --manifest-path Cargo.toml --workspace
- git diff --check