### PR TITLE
ci: enforce Rust quality contracts

### DIFF
--- a/.github/workflows/runtime-guards.yml
+++ b/.github/workflows/runtime-guards.yml
@@ -14,6 +14,7 @@ on:
       - "uninstall.sh"
       - "lib/airc_bash/**"
       - "test/rust_cutover_guard.sh"
+      - "test/rust_quality_guard.sh"
       - ".github/workflows/runtime-guards.yml"
   push:
     branches: [rust-rewrite, canary, main]
@@ -23,6 +24,7 @@ on:
       - "uninstall.sh"
       - "lib/airc_bash/**"
       - "test/rust_cutover_guard.sh"
+      - "test/rust_quality_guard.sh"
       - ".github/workflows/runtime-guards.yml"
 
 jobs:
@@ -35,3 +37,5 @@ jobs:
         run: bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh
       - name: Rust cutover guards
         run: bash test/rust_cutover_guard.sh
+      - name: Rust quality guards
+        run: bash test/rust_quality_guard.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,8 @@ name: rust
 #              library/binary code cannot use unwrap/expect/panic/todo/
 #              unimplemented or wildcard enum matches.
 #   test     — `cargo test --all-features` (every test green)
+#   quality  — repo policy guard for Rust lint inheritance and banned
+#              fallback/cutover command surfaces
 #
 # Per Joel's direction (2026-05-18): "use rust conventions and obsession
 # with tests. clippy, fmt etc." These three gates are the substrate-quality
@@ -24,6 +26,7 @@ on:
       - "crates/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "test/rust_quality_guard.sh"
       - ".github/workflows/rust.yml"
   push:
     branches: [canary, main, rust-rewrite]
@@ -31,6 +34,7 @@ on:
       - "crates/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "test/rust_quality_guard.sh"
       - ".github/workflows/rust.yml"
 
 env:
@@ -80,6 +84,14 @@ jobs:
           -D clippy::todo
           -D clippy::unimplemented
           -D clippy::wildcard_enum_match_arm
+
+  quality:
+    name: rust quality guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Rust quality guard
+        run: bash test/rust_quality_guard.sh
 
   test:
     # Cross-platform matrix — the substrate must run on Linux, macOS,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ members = [
     "crates/airc-cli",
 ]
 resolver = "2"
+
+[workspace.lints.clippy]
+undocumented_unsafe_blocks = "deny"

--- a/crates/airc-blobs/Cargo.toml
+++ b/crates/airc-blobs/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT"
 publish = false
 description = "Content-addressed blob storage for airc — large bodies live here, frames carry MediaRef pointers."
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license = "MIT"
 publish = false
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "airc-rs"
 path = "src/main.rs"

--- a/crates/airc-cli/src/channel_gist_commands.rs
+++ b/crates/airc-cli/src/channel_gist_commands.rs
@@ -468,6 +468,8 @@ fn cache_path() -> PathBuf {
 fn state_suffix() -> String {
     #[cfg(unix)]
     {
+        // SAFETY: `getuid` has no preconditions, does not dereference pointers,
+        // and returns the numeric user id for the current process.
         unsafe { libc::getuid().to_string() }
     }
     #[cfg(not(unix))]

--- a/crates/airc-cli/src/codex_start.rs
+++ b/crates/airc-cli/src/codex_start.rs
@@ -51,6 +51,9 @@ fn normalize_join_args(args: Vec<String>) -> Vec<String> {
 fn detach(command: &mut Command) {
     use std::os::unix::process::CommandExt;
 
+    // SAFETY: `pre_exec` runs in the child after fork and before exec. The
+    // closure only calls `setsid` and constructs an OS error from errno on
+    // failure; it does not allocate, lock, or touch shared process state.
     unsafe {
         command.pre_exec(|| {
             if libc::setsid() == -1 {

--- a/crates/airc-cli/src/gh_state.rs
+++ b/crates/airc-cli/src/gh_state.rs
@@ -281,6 +281,8 @@ pub(crate) fn cwd() -> String {
 fn state_prefix() -> String {
     #[cfg(unix)]
     {
+        // SAFETY: `getuid` has no preconditions, does not dereference pointers,
+        // and returns the numeric user id for the current process.
         unsafe { libc::getuid().to_string() }
     }
     #[cfg(not(unix))]

--- a/crates/airc-core/Cargo.toml
+++ b/crates/airc-core/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license = "MIT"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/airc-core/src/body.rs
+++ b/crates/airc-core/src/body.rs
@@ -105,7 +105,14 @@ mod tests {
                 assert_eq!(m["text"], "hi");
                 assert_eq!(m.len(), 1, "text helper produces exactly {{text: ...}}");
             }
-            _ => panic!("text() should produce Body::Json with object shape"),
+            Body::Json(
+                serde_json::Value::Null
+                | serde_json::Value::Bool(_)
+                | serde_json::Value::Number(_)
+                | serde_json::Value::String(_)
+                | serde_json::Value::Array(_),
+            )
+            | Body::Binary(_) => panic!("text() should produce Body::Json with object shape"),
         }
         assert_eq!(body.as_text(), Some("hi"));
     }

--- a/crates/airc-daemon/Cargo.toml
+++ b/crates/airc-daemon/Cargo.toml
@@ -15,6 +15,9 @@ publish = false
 # layout (grievance §5: CLI/Daemon Accumulating Policy → airc-cli
 # is the client, airc-daemon is the runtime).
 
+[lints]
+workspace = true
+
 [dependencies]
 airc-core = { path = "../airc-core" }
 airc-protocol = { path = "../airc-protocol" }

--- a/crates/airc-lib/Cargo.toml
+++ b/crates/airc-lib/Cargo.toml
@@ -17,6 +17,9 @@ publish = false
 # `airc.join(room).await`, `airc.say("hi").await`, `airc.page_recent(...)`
 # without shelling out to the CLI or parsing prose.
 
+[lints]
+workspace = true
+
 [dependencies]
 airc-core = { path = "../airc-core" }
 airc-protocol = { path = "../airc-protocol" }

--- a/crates/airc-protocol/Cargo.toml
+++ b/crates/airc-protocol/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license = "MIT"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 airc-core = { path = "../airc-core" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/airc-store/Cargo.toml
+++ b/crates/airc-store/Cargo.toml
@@ -10,6 +10,9 @@ publish = false
 # the first backing; the trait surface is generic enough that
 # Postgres / MySQL drop in via sea-orm's DatabaseBackend.
 
+[lints]
+workspace = true
+
 [dependencies]
 airc-core = { path = "../airc-core" }
 async-trait = "0.1"

--- a/crates/airc-transport/Cargo.toml
+++ b/crates/airc-transport/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license = "MIT"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 airc-core = { path = "../airc-core" }
 airc-protocol = { path = "../airc-protocol" }

--- a/crates/airc-work-store/Cargo.toml
+++ b/crates/airc-work-store/Cargo.toml
@@ -9,6 +9,9 @@ publish = false
 # and lets CLI/hooks/Continuum query persisted work state through the
 # generic EventStore contract.
 
+[lints]
+workspace = true
+
 [dependencies]
 airc-core = { path = "../airc-core" }
 airc-store = { path = "../airc-store" }

--- a/crates/airc-work/Cargo.toml
+++ b/crates/airc-work/Cargo.toml
@@ -9,6 +9,9 @@ publish = false
 # Rust substrate contracts; GitHub, CLI, Codex hooks, and Continuum
 # are adapters on top.
 
+[lints]
+workspace = true
+
 [dependencies]
 airc-core = { path = "../airc-core" }
 airc-protocol = { path = "../airc-protocol" }

--- a/test/rust_quality_guard.sh
+++ b/test/rust_quality_guard.sh
@@ -13,7 +13,7 @@ grep_forbid() {
   local reason="$1"
   local pattern="$2"
   shift 2
-  if git grep -nE "$pattern" -- "$@"; then
+  if git grep -nE "$pattern" -- "$@" ':(exclude)test/rust_quality_guard.sh'; then
     fail "$reason"
   fi
 }

--- a/test/rust_quality_guard.sh
+++ b/test/rust_quality_guard.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+fail() {
+  echo "rust quality guard failed: $*" >&2
+  exit 1
+}
+
+grep_forbid() {
+  local reason="$1"
+  local pattern="$2"
+  shift 2
+  if git grep -nE "$pattern" -- "$@"; then
+    fail "$reason"
+  fi
+}
+
+grep_forbid \
+  "public fallback command names must not return" \
+  'message build-legacy|whois-fallback|peers-fallback|RoutePurpose::Migration' \
+  crates lib/airc_bash airc test
+
+grep_forbid \
+  "envelope encryption failure must not emit the original plaintext payload" \
+  "envelope wrap.*\\|\\|[[:space:]]*printf '%s'.*full_msg|\\|\\|[[:space:]]*printf '%s'.*full_msg" \
+  lib/airc_bash crates/airc-cli/src
+
+grep_forbid \
+  "gh-gist is bootstrap/rendezvous only; do not reintroduce migration route policy" \
+  'RoutePurpose::Migration|Migration => "migration"|migration -> gh-gist|bootstrap/migration' \
+  crates docs/architecture
+
+grep_forbid \
+  "workspace crates must opt into workspace lint policy" \
+  '^unsafe_code[[:space:]]*=' \
+  crates
+
+missing_lints=()
+for manifest in crates/*/Cargo.toml; do
+  if ! awk '
+    /^\[lints\]$/ { in_lints = 1; next }
+    /^\[/ { in_lints = 0 }
+    in_lints && /^workspace[[:space:]]*=[[:space:]]*true$/ { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "$manifest"; then
+    missing_lints+=("$manifest")
+  fi
+done
+
+if [ "${#missing_lints[@]}" -gt 0 ]; then
+  printf '%s\n' "${missing_lints[@]}" >&2
+  fail "crate manifests must inherit [workspace.lints]"
+fi


### PR DESCRIPTION
## Summary
- add workspace lint inheritance across all Rust crates
- deny undocumented unsafe blocks at the workspace lint layer
- document existing Unix unsafe calls and remove a wildcard enum match in a test
- add test/rust_quality_guard.sh for banned fallback/cutover command surfaces and lint inheritance
- run the quality guard from Rust CI and runtime-guards CI

## Verification
- bash test/rust_quality_guard.sh
- bash test/rust_cutover_guard.sh
- bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh test/rust_quality_guard.sh test/rust_cutover_guard.sh
- cargo fmt --manifest-path Cargo.toml --all --check
- cargo clippy --manifest-path Cargo.toml --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace