### PR TITLE
fix(doctor): keep local health independent of GitHub

### DIFF
--- a/crates/airc-cli/src/collaboration_peers.rs
+++ b/crates/airc-cli/src/collaboration_peers.rs
@@ -29,7 +29,7 @@ struct MessagePresence {
 pub fn run_peers(default_home: &Path, args: CollaborationScopeArgs) -> Result<(), Box<dyn Error>> {
     let home = args.home.as_deref().unwrap_or(default_home);
     let peers = peer_records(home);
-    let presence = message_presence(home);
+    let presence = message_presence(home, &args.my_name, &args.client_id);
     if peers.is_empty() {
         print_broadcast_or_empty(&presence, &args.my_name);
         return Ok(());
@@ -122,14 +122,14 @@ fn peer_record_from_path(path: &Path) -> Option<PeerRecord> {
     })
 }
 
-fn message_presence(home: &Path) -> MessagePresence {
+fn message_presence(home: &Path, my_name: &str, my_client_id: &str) -> MessagePresence {
     let mut presence = MessagePresence::default();
     let raw = fs::read_to_string(home.join("messages.jsonl")).unwrap_or_default();
     for message in raw
         .lines()
         .filter_map(|line| serde_json::from_str::<Value>(line).ok())
     {
-        let Some(who) = message.get("from").and_then(Value::as_str) else {
+        let Some(who) = message_sender(&message, my_name, my_client_id) else {
             continue;
         };
         let Some(ts) = message.get("ts").and_then(Value::as_str).and_then(epoch) else {
@@ -141,11 +141,29 @@ fn message_presence(home: &Path) -> MessagePresence {
             &mut presence.last_message
         };
         target
-            .entry(who.to_string())
+            .entry(who)
             .and_modify(|current| *current = (*current).max(ts))
             .or_insert(ts);
     }
     presence
+}
+
+fn message_sender(message: &Value, my_name: &str, my_client_id: &str) -> Option<String> {
+    let sender = message.get("from").and_then(Value::as_str)?;
+    let client_id = message
+        .get("client_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if !my_client_id.is_empty() && client_id == my_client_id {
+        return None;
+    }
+    if sender == my_name {
+        if client_id.is_empty() {
+            return None;
+        }
+        return Some(format!("{sender} [{client_id}]"));
+    }
+    Some(sender.to_string())
 }
 
 fn print_peer_records(home: &Path, peers: &[PeerRecord], presence: &MessagePresence) {
@@ -331,5 +349,22 @@ mod tests {
         let rows = broadcast_rows(&presence, &rendered, "me");
 
         assert_eq!(rows, vec![("alice".to_string(), now)]);
+    }
+
+    #[test]
+    fn message_presence_keeps_same_name_different_client() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("messages.jsonl"),
+            r#"{"from":"me","client_id":"mine","ts":"2026-05-19T12:00:00Z"}"#.to_string()
+                + "\n"
+                + r#"{"from":"me","client_id":"peer-tab","ts":"2026-05-19T12:00:01Z"}"#,
+        )
+        .unwrap();
+
+        let presence = message_presence(dir.path(), "me", "mine");
+
+        assert!(!presence.last_message.contains_key("me"));
+        assert!(presence.last_message.contains_key("me [peer-tab]"));
     }
 }

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -395,8 +395,9 @@ _doctor_health() {
   local issues=0 warns=0
   local now; now=$(date +%s 2>/dev/null || echo 0)
 
-  # ── gh API headroom (rate-limit). Cheap; reveals whether we're near
-  # the cliff that wedged the bus pre-#416/#419.
+  # ── gh API headroom (rate-limit). GitHub is rendezvous/bootstrap
+  # infrastructure, not the live-health source of truth. A local or LAN
+  # mesh must stay healthy while gh is throttled, offline, or backing off.
   if command -v gh >/dev/null 2>&1; then
     local rate_json
     if rate_json=$(airc_gh_rate_limit_json_cached); then
@@ -417,21 +418,20 @@ _doctor_health() {
         printf "  [info] gh rate_limit reachable but parse failed (skipping)\n"
       fi
     else
-      printf "  [BLOCKED] gh API not reachable — can't probe rate-limit\n"
-      printf "         Fix: airc doctor (full env probe will diagnose)\n"
-      issues=$((issues+1))
+      printf "  [WARN] gh API not reachable — GitHub rendezvous/bootstrap unavailable\n"
+      printf "         Live local/LAN transport health is evaluated below\n"
+      warns=$((warns+1))
     fi
   fi
 
-  # ── gh request governor. This is the product-facing surface for the
-  # per-user cross-process guard. Keep `airc gh-audit` as an advanced
-  # escape hatch, but doctor owns the normal diagnosis so users/agents
-  # don't need another public verb.
+  # ── gh request governor. This protects the GitHub adapter only. It must
+  # never make same-machine or LAN chat look down when bearer/local health
+  # proves the live bus is still moving.
   local _gov_rc=0 _gov_out
   _gov_out=$("$(airc_rs_bin)" gh doctor --count 80 2>&1) || _gov_rc=$?
   printf '%s\n' "$_gov_out"
   case "$_gov_out" in
-    *"[BLOCKED]"*) issues=$((issues+1)) ;;
+    *"[BLOCKED]"*) warns=$((warns+1)) ;;
     *) [ "$_gov_rc" -ne 0 ] && warns=$((warns+1)) ;;
   esac
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2883,7 +2883,7 @@ JSON
     || fail "doctor --health did not accept broadcast peer presence ($doctor_out)"
 
   peers_out=$(AIRC_HOME="$home" "$AIRC" peers 2>&1)
-  echo "$peers_out" | grep -q 'remote-agent → broadcast room' \
+  echo "$peers_out" | grep -q 'remote-agent -> broadcast room' \
     && pass "airc peers falls back to recent broadcast-only traffic" \
     || fail "airc peers hid recent remote traffic when peer records were empty ($peers_out)"
 
@@ -2898,7 +2898,7 @@ JSON
     && pass "doctor distinguishes same-nick peers by client_id" \
     || fail "doctor treated same-nick peer traffic as self ($doctor_out)"
   peers_out=$(AIRC_CLIENT_ID="agent:self" AIRC_HOME="$home" "$AIRC" peers 2>&1)
-  echo "$peers_out" | grep -q 'solo-host \[agent:other\] → broadcast room' \
+  echo "$peers_out" | grep -q 'solo-host \[agent:other\] -> broadcast room' \
     && pass "airc peers lists same-nick broadcast peer by client_id" \
     || fail "airc peers hid same-nick broadcast peer ($peers_out)"
 
@@ -2906,7 +2906,7 @@ JSON
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$home/messages.jsonl"
   local whois_out
   whois_out=$(AIRC_HOME="$home" "$AIRC" whois remote-agent 2>&1)
-  echo "$whois_out" | grep -q 'role: *broadcast peer' \
+  echo "$whois_out" | grep -q 'role: *observed room participant' \
     && pass "airc whois returns limited identity for broadcast peer" \
     || fail "airc whois did not resolve broadcast peer ($whois_out)"
 


### PR DESCRIPTION
Summary
- treat GitHub API/governor failures as rendezvous/bootstrap warnings in doctor --health, not live bus blockers
- keep observed same-name peers distinct by client_id in airc peers
- refresh solo_mesh_warns integration assertions for current observed-peer wording

Verification
- bash -n lib/airc_bash/cmd_doctor.sh test/integration.sh
- cargo test --manifest-path Cargo.toml -p airc-cli collaboration_peers
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- bash test/integration.sh solo_mesh_warns
- bash test/rust_quality_guard.sh
- bash test/rust_cutover_guard.sh
- airc doctor --health