### PR TITLE
docs: define invite-only gist routing architecture

### DIFF
--- a/docs/architecture/AIRC-RUST-SUBSTRATE.md
+++ b/docs/architecture/AIRC-RUST-SUBSTRATE.md
@@ -35,6 +35,11 @@ The three roles airc-rust plays for consumers:
 - **Event bus** — interrupt-driven fan-out for things consumers need to
   wake on, not poll for.
 
+See [`INVITE-ROUTING-ARCHITECTURE.md`](INVITE-ROUTING-ARCHITECTURE.md) for the
+transport boundary: gh-gist is an invite/rendezvous beacon, not the live
+message/event data plane. Consumers see publish, subscribe, replay, and ack
+APIs; route resolution sits below them.
+
 ## What airc-rust is not
 
 - Not an opinion about what consumers say to each other. Payloads are
@@ -57,8 +62,9 @@ The three roles airc-rust plays for consumers:
    directly. No shell-out from runtime code.
 4. **Persist** durably with proper cursors, archive drain, and SQLite/
    Postgres backends via SeaORM.
-5. **Multi-transport** — same-host, same-LAN, Tailscale, gh-gist
-   (legacy bridge). Pluggable, capability-resolved.
+5. **Multi-transport** — same-host, same-LAN, Tailscale, relay,
+   WebRTC datachannel, Reticulum, and gh-gist invite/rendezvous.
+   Pluggable, capability-resolved.
 6. **Be more secure** than today's airc: per-message forward secrecy,
    hardware-backed identity keys, at-rest encryption.
 7. **No multimedia in the body** — protocol enforces media-ref
@@ -264,7 +270,7 @@ airc-rust/
 │   │   ├── local-fs/     # same-host peers via shared FS
 │   │   ├── lan-tcp/      # same-LAN direct peer connection
 │   │   ├── tailscale/    # cross-network via Tailscale
-│   │   └── gh-gist/      # legacy bridge (deprecated)
+│   │   └── gh-gist/      # invite/rendezvous beacon only
 │   ├── airc-blobs/       # content-addressed media storage
 │   ├── airc-daemon/      # long-running: workers, drain, fan-out
 │   ├── airc-lib/         # high-level Rust API — consumers depend on this
@@ -335,7 +341,7 @@ adapters. Local and remote delivery are the same product behavior:
 the caller submits one signed envelope, gets one delivery contract,
 and observes one transcript/replay model. Whether the bytes moved
 through local filesystem, LAN-TCP, Tailscale, Reticulum, a relay, or
-temporary gh-gist is invisible above the substrate boundary.
+WebRTC datachannel is invisible above the substrate boundary.
 
 This is the telecom shape: separate the service contract from the
 bearers underneath it. A room can contain a same-host Codex process,
@@ -571,8 +577,8 @@ pub trait TransportHandle: Send + Sync {
 ```
 
 There is no adapter-specific caller API. A local-fs adapter, LAN-TCP
-adapter, Tailscale adapter, Reticulum adapter, relay adapter, and gh-gist
-migration adapter all implement the same contract. Adapter-specific
+adapter, Tailscale adapter, Reticulum adapter, relay adapter, and WebRTC
+datachannel adapter all implement the same contract. Adapter-specific
 configuration lives below `open`; adapter-specific errors are normalized
 into scheduler states above it.
 
@@ -592,8 +598,8 @@ pub struct TransportCapabilities {
 
 ### Resilient to bearer changes
 
-The point: when gh-gist stops being viable (rate limits get worse,
-GitHub deprecates gists, our trust assumptions shift, whatever) —
+The point: when any bearer stops being viable (rate limits get worse,
+an upstream deprecates an API, our trust assumptions shift, whatever) —
 we **don't get stuck**. Adapter design means:
 
 - Roll a new bearer (custom HTTP relay, NATS, MQTT broker, IPFS pubsub,
@@ -618,17 +624,20 @@ In the doc as anchors; not all in the v1 ship:
 
 - `local-fs` — same-host, same-scope. Ship v1.
 - `lan-tcp` — same-LAN direct. Ship v1.
-- `tailscale` — cross-network mesh. Ship v1.
-- `gh-gist` — legacy bridge. Ship v1 (for migration); deprecate
-  when we have a non-gh cross-network bearer.
+- `tailscale` — same-tailnet cross-network mesh. Ship v1.
+- `gh-gist-invite` — public invite/rendezvous beacon only. Ship v1.
+  Not admissible for live chat/event data-plane classes.
 - `airc-relay` — own-hosted cross-network store-and-forward. Future
-  ship; the gh-gist replacement.
+  ship; the cross-tailnet and NAT-boundary baseline.
 - `reticulum` — Mark Qvist's mesh networking stack. Future plugin.
   Useful for unreliable / radio / off-grid mesh.
 - `nats` or `mqtt` — for ops integration where consumers already run
   a broker. Future plugin.
-- `webrtc-data-channel` — direct browser ↔ desktop without TURN.
-  Future plugin.
+- `webrtc-data-channel` — direct browser, desktop, and live-mode
+  control traffic; TURN/relay when direct ICE fails. Future plugin.
+- `ssh` — optional administrative/debug adapter only. Not required
+  for install, pairing, chat, event delivery, Windows support, or
+  cross-machine operation.
 
 ## Identifiers — UUIDv4 everywhere
 
@@ -930,7 +939,7 @@ Built-in primitives:
 
 - **Keep-alive heartbeats** at the transport layer, separate from
   application heartbeats. Configurable cadence per transport (more
-  frequent for UDP/RTC paths, slower for gh-gist).
+  frequent for UDP/RTC paths, slower for store-and-forward relays).
 - **Dead-host detection**: if N consecutive heartbeats fail, the
   peer is marked impaired; if N+M, marked dead. Subscribers get a
   structured event. The scheduler refuses new admissions on impaired

--- a/docs/architecture/INVITE-ROUTING-ARCHITECTURE.md
+++ b/docs/architecture/INVITE-ROUTING-ARCHITECTURE.md
@@ -1,0 +1,266 @@
+# AIRC Invite And Route Architecture
+
+**Status:** design contract for the rust-rewrite integration branch
+**Date:** 2026-05-20
+**Supersedes:** the parts of `docs/fusion-transport.md` that treated GitHub
+gists as a data-plane fallback
+
+## Decision
+
+GitHub gists are invite beacons. They are not the chat bus, not the event bus,
+not durable transport, and not a fallback data plane.
+
+A gist can publish enough signed information for a peer to join a mesh:
+
+- room identity and invite metadata
+- peer identity keys
+- bootstrap addresses and supported transport candidates
+- short-lived rendezvous hints
+- revocation or rotation notices
+
+After that, live frames move through AIRC transports selected by the route
+resolver: same-process, same-host local-fs/IPC, LAN/Tailscale TCP, relay,
+WebRTC datachannel, Reticulum, or future adapters. Consumers publish and
+subscribe to events; they do not know or care which transport carried a frame.
+
+## Why
+
+The old gist-heavy model made GitHub rate limits look like AIRC outages. That is
+the wrong boundary. GitHub can be unavailable, throttled, or blocked while a
+same-machine or same-LAN mesh is perfectly healthy.
+
+The corrected model is closer to a QR code, Signal contact link, or WebRTC
+offer link: useful for finding and authenticating a peer, then replaced by the
+best live route.
+
+## Layer Model
+
+```text
+consumer
+  Continuum rooms, OpenClaw, Hermes, OpenCode, CLI chat, agents, games
+
+contract
+  forge-alloy schemas, headers, capabilities, permissions, replay semantics
+
+event bus
+  publish, subscribe, replay, cursors, receipts, coalescing, backpressure
+
+route resolver
+  chooses admissible route set from health, capabilities, policy, and scope
+
+transport adapters
+  local-fs/IPC, LAN/Tailscale TCP, relay, WebRTC datachannel, Reticulum, gh-gist invite
+
+invite store
+  signed beacons for bootstrap and rendezvous only
+```
+
+The event bus owns semantics like durable vs ephemeral delivery and replay.
+The route resolver owns "which links are admissible for this frame." Transport
+adapters only move bytes and report health.
+
+## Route Classes
+
+AIRC should avoid the word fallback for production routing. Fallback implies an
+accidental bad path. A route is either admissible for a class of traffic or it is
+not.
+
+```rust
+pub enum RouteClass {
+    InviteAdvertise,
+    PeerRendezvous,
+    ControlInteractive,
+    DataInteractive,
+    DataBulk,
+    MediaSignaling,
+    PresenceEphemeral,
+}
+```
+
+Initial admissibility:
+
+| Route class | Admissible transports |
+| --- | --- |
+| `InviteAdvertise` | gh-gist, static file, QR/text export, future public relay |
+| `PeerRendezvous` | gh-gist, relay, Reticulum announce, mDNS/LAN discovery |
+| `ControlInteractive` | local, LAN/Tailscale, relay, WebRTC datachannel, Reticulum |
+| `DataInteractive` | local, LAN/Tailscale, relay, WebRTC datachannel, Reticulum |
+| `DataBulk` | local, LAN/Tailscale, relay, Reticulum, blob store handoff |
+| `MediaSignaling` | local, LAN/Tailscale, relay, WebRTC datachannel, Reticulum |
+| `PresenceEphemeral` | local, LAN/Tailscale, relay, WebRTC datachannel, Reticulum |
+
+`gh-gist` is not admissible for `ControlInteractive`, `DataInteractive`,
+`DataBulk`, `MediaSignaling`, or `PresenceEphemeral` unless a future explicit
+compatibility mode opts into a slow public bridge. That bridge must be named as
+compatibility mode, not silently selected.
+
+## Reliable Boundary Coverage
+
+The initial reliable set should cover the real deployment boundaries without
+requiring SSHD:
+
+| Boundary | Baseline route | Notes |
+| --- | --- | --- |
+| Same process / embedded consumer | in-memory or daemon IPC | Continuum can link `airc-lib` directly; no shell, Python, or network hop. |
+| Same machine, multiple agents | local-fs or local IPC | Works for many Codex/Claude/persona processes on one host without GitHub. |
+| Same LAN | TLS-pinned LAN-TCP | Direct, signed, OS-neutral Rust. No Windows SSHD setup. |
+| Same Tailscale tailnet | TLS-pinned TCP over Tailscale address | Same route contract as LAN; Tailscale is reachability, not identity. |
+| Different tailnets / NAT boundary | `airc-relay` store-and-forward, then WebRTC/Reticulum where possible | Relay is the dependable baseline; direct routes can be promoted after discovery. |
+| Browser / live-mode control | WebRTC datachannel with relay/TURN when needed | AIRC carries signaling and control events, not media frames. |
+| Offline or intermittent mesh | Reticulum or relay-backed queue | Route state is explicit: queued until an admissible route exists. |
+
+SSH can exist as a future adapter for admin workflows, but it is not a required
+transport and must not be part of install success criteria. The Windows SSHD
+setup experience was evidence that SSH is the wrong baseline for cross-machine
+AIRC.
+
+## Invite Beacon
+
+An invite is a signed, compact, shareable object. It is stable enough to paste
+into a chat, QR encode, publish to a gist, or hand to another AIRC instance.
+
+```rust
+pub struct InviteBeacon {
+    pub invite_id: InviteId,
+    pub room_id: RoomId,
+    pub issuer: PeerId,
+    pub issued_at_ms: u64,
+    pub expires_at_ms: Option<u64>,
+    pub identity_key: PublicKey,
+    pub candidates: Vec<RouteCandidate>,
+    pub headers: Headers,
+    pub signature: Signature,
+}
+
+pub struct RouteCandidate {
+    pub route_id: RouteId,
+    pub kind: TransportKind,
+    pub endpoint: Endpoint,
+    pub scope: RouteScope,
+    pub capabilities: RouteCapabilities,
+    pub priority: RoutePriority,
+    pub expires_at_ms: Option<u64>,
+}
+```
+
+The beacon advertises possibilities. It does not guarantee they work. The route
+resolver probes candidates, verifies identity, and promotes working links into
+the live route set.
+
+## Route Resolver Contract
+
+The resolver is deterministic and policy-driven:
+
+1. collect candidates from invites, local discovery, peer registry, and active
+   transport health
+2. discard candidates whose capabilities do not satisfy the requested
+   `RouteClass`
+3. discard candidates whose security policy is weaker than the room requires
+4. score remaining candidates by health, locality, latency, cost, and deadline
+5. return a route plan: one primary route, optional redundant routes for
+   critical control frames, or a queued state when no route is admissible
+
+No adapter gets to silently impersonate another adapter. If no live data route
+exists, the frame queues with a visible reason. It does not slip into GitHub
+polling because that is how the system becomes slow without telling us.
+
+## Events And Subscriptions
+
+Consumers see a uniform event API:
+
+```rust
+pub trait EventBus {
+    fn publish(&self, request: PublishRequest) -> Result<EventId>;
+    fn subscribe(&self, request: SubscribeRequest) -> Result<Subscription>;
+    fn replay(&self, request: ReplayRequest) -> Result<Vec<StoredEnvelope>>;
+    fn ack(&self, receipt: Receipt) -> Result<()>;
+}
+```
+
+Subscriptions filter by channel, peer, frame kind, and headers. They do not
+filter by transport. A Continuum room, OpenClaw chat bridge, Hermes agent, or
+Codex monitor receives the same envelopes whether the bytes arrived over
+local-fs, Tailscale, relay, WebRTC, or Reticulum.
+
+This is the boundary Continuum needs:
+
+- rooms and activities become AIRC channels plus consumer headers
+- persona inboxes subscribe to headers and replay cursors
+- WebRTC/live video uses AIRC for signaling, not media frames
+- coding agents use AIRC for work events, kanban, interrupts, and transcripts
+- OpenClaw/Hermes/OpenCode adapters translate their native message shapes into
+  alloyed payloads without adding transport logic
+
+## GitHub Governor Semantics
+
+The GitHub governor only gates GitHub-backed invite and rendezvous operations.
+It must not mark local, LAN, Tailscale, relay, WebRTC, or Reticulum delivery as
+degraded.
+
+Allowed governor effects:
+
+- delay publishing a new invite beacon to gist
+- delay refreshing a public rendezvous hint
+- delay compatibility bridge polling if explicitly enabled
+- report GitHub control-plane pressure in health output
+
+Disallowed governor effects:
+
+- blocking local same-machine chat
+- blocking LAN/Tailscale chat
+- marking the whole bus degraded when live routes are healthy
+- causing a consumer to see a different event model
+
+## Health Model
+
+Health is per route, then summarized per route class.
+
+```rust
+pub enum RouteHealthState {
+    Healthy,
+    Degraded(RouteDegradation),
+    Down(RouteDownReason),
+    Unprobed,
+}
+
+pub struct RouteHealthSample {
+    pub route_id: RouteId,
+    pub kind: TransportKind,
+    pub classes: BTreeSet<RouteClass>,
+    pub state: RouteHealthState,
+    pub rtt_ms: Option<u64>,
+    pub last_success_ms: Option<u64>,
+    pub last_failure_ms: Option<u64>,
+}
+```
+
+`airc doctor --health` should answer two separate questions:
+
+- is the live event bus healthy for my subscribed channels?
+- are invite/rendezvous mechanisms healthy enough to add new peers?
+
+Those answers can differ. That is not degraded architecture; that is accurate
+diagnosis.
+
+## Migration Slices
+
+1. **Policy constants:** encode route classes and gh-gist admissibility in Rust.
+2. **Invite beacon type:** move gist payloads to a signed invite structure.
+3. **Resolver gate:** route plans fail closed when no admissible data route
+   exists; no implicit gist data path.
+4. **Doctor split:** expose live bus health separately from invite health.
+5. **Local route proof:** two local agents exchange events without any GitHub
+   call in the publish/subscribe path.
+6. **Tailscale/LAN proof:** same API, remote peer, no consumer changes.
+7. **Continuum integration proof:** one Continuum room uses AIRC subscribe/replay
+   for chat/events while retaining Continuum-owned payload semantics.
+8. **OpenClaw/Hermes adapter proof:** native clients appear as peers/channels
+   through adapter-owned schemas, not transport-specific hacks.
+
+## Non-Goals
+
+- No GitHub data-plane compatibility unless explicitly requested for migration.
+- No consumer-specific route hacks in Continuum, OpenClaw, Hermes, or Codex.
+- No hidden fallback from one route class to another.
+- No media bytes in AIRC envelopes; AIRC carries signaling and metadata.
+- No shell or Python runtime path for routing decisions.

--- a/docs/fusion-transport.md
+++ b/docs/fusion-transport.md
@@ -1,8 +1,16 @@
 # Sensor-Fusion Bearer Layer — Reticulum-Style Multi-Path Routing
 
-**Status:** design proposal, pre-implementation
+**Status:** superseded for rust-rewrite route policy
 **Authors:** continuum-b69f (Joel + Claude on Windows), with continuum-b741 (Joel + Claude on Mac) for cross-review
 **Context:** drafted 2026-05-02, end of a 22-PR airc hardening session that culminated in a transport-architecture conversation with Joel
+
+> Superseded note, 2026-05-20: the sensor-fusion framing remains useful for
+> measuring multiple links, but this document incorrectly treats gh-gist as a
+> possible data-plane fallback. The current rust-rewrite contract is
+> [`architecture/INVITE-ROUTING-ARCHITECTURE.md`](architecture/INVITE-ROUTING-ARCHITECTURE.md):
+> GitHub gists are invite/rendezvous beacons only, like QR-code links, and live
+> messages/events use admissible local, LAN/Tailscale, relay, WebRTC, Reticulum,
+> or future data transports.
 
 ## TL;DR
 


### PR DESCRIPTION
Summary
- define gh-gist as invite/rendezvous only, not live data-plane transport
- add route classes, admissible transports, and reliable boundary coverage
- mark SSH as optional admin/debug transport, not a setup/runtime requirement
- update substrate and fusion docs to point at the corrected routing contract

Verification
- git diff --check