### PR TITLE
feat(routes): enforce invite-only gist admission

### DIFF
--- a/crates/airc-cli/src/route_cli.rs
+++ b/crates/airc-cli/src/route_cli.rs
@@ -22,12 +22,16 @@ pub struct RouteStatusArgs {
     #[arg(long = "relay", value_enum)]
     pub relay: Vec<RouteTransport>,
 
-    /// Add a healthy bootstrap-only transport candidate.
-    #[arg(long = "bootstrap", value_enum)]
-    pub bootstrap: Vec<RouteTransport>,
+    /// Add a healthy peer rendezvous transport candidate.
+    #[arg(long = "rendezvous", value_enum)]
+    pub rendezvous: Vec<RouteTransport>,
+
+    /// Add a healthy invite beacon transport candidate.
+    #[arg(long = "invite", value_enum)]
+    pub invite: Vec<RouteTransport>,
 
     /// Mark a transport down. Format: `<transport>:<role>`, e.g.
-    /// `lan-tcp:direct` or `gh-gist:bootstrap-only`.
+    /// `lan-tcp:direct` or `gh-gist:rendezvous`.
     #[arg(long = "down")]
     pub down: Vec<RouteHealthOverride>,
 }
@@ -37,8 +41,11 @@ pub enum RouteTransport {
     LocalFs,
     LanTcp,
     Tailscale,
+    Udp,
+    WebRtcDataChannel,
     Reticulum,
     Relay,
+    Ssh,
     GhGist,
 }
 
@@ -52,7 +59,9 @@ pub struct RouteHealthOverride {
 pub enum RouteRole {
     Direct,
     Relay,
-    BootstrapOnly,
+    InviteBeacon,
+    Rendezvous,
+    Admin,
 }
 
 impl std::str::FromStr for RouteHealthOverride {

--- a/crates/airc-cli/src/route_commands.rs
+++ b/crates/airc-cli/src/route_commands.rs
@@ -1,5 +1,5 @@
 use airc_lib::{
-    RouteDecision, RoutePurpose, TransportHealthSample, TransportHealthState, TransportKind,
+    RouteClass, RouteDecision, TransportHealthSample, TransportHealthState, TransportKind,
     TransportResolver, TransportRole,
 };
 
@@ -20,19 +20,19 @@ pub fn run_status(args: RouteStatusArgs) -> Result<(), Box<dyn std::error::Error
     }
 
     println!("route decisions:");
-    for purpose in [
-        RoutePurpose::Data,
-        RoutePurpose::LiveEvent,
-        RoutePurpose::Bootstrap,
+    for class in [
+        RouteClass::InviteAdvertise,
+        RouteClass::PeerRendezvous,
+        RouteClass::ControlInteractive,
+        RouteClass::DataInteractive,
+        RouteClass::DataBulk,
+        RouteClass::MediaSignaling,
+        RouteClass::PresenceEphemeral,
     ] {
-        match resolver.resolve(purpose) {
-            Ok(route) => println!(
-                "- {} -> {}",
-                format_purpose(purpose),
-                format_kind(route.kind)
-            ),
+        match resolver.resolve(class) {
+            Ok(route) => println!("- {} -> {}", format_class(class), format_kind(route.kind)),
             Err(RouteDecision::NoRoute { .. }) => {
-                println!("- {} -> no-route", format_purpose(purpose));
+                println!("- {} -> no-route", format_class(class));
             }
             Err(RouteDecision::Selected(_)) => unreachable!("selected routes are returned as Ok"),
         }
@@ -46,7 +46,8 @@ fn health_samples(args: RouteStatusArgs) -> Vec<TransportHealthSample> {
 
     if args.direct.is_empty()
         && args.relay.is_empty()
-        && args.bootstrap.is_empty()
+        && args.rendezvous.is_empty()
+        && args.invite.is_empty()
         && args.down.is_empty()
     {
         samples.push(TransportHealthSample::healthy_direct(
@@ -66,9 +67,14 @@ fn health_samples(args: RouteStatusArgs) -> Vec<TransportHealthSample> {
             .map(|transport| healthy(transport, RouteRole::Relay)),
     );
     samples.extend(
-        args.bootstrap
+        args.rendezvous
             .into_iter()
-            .map(|transport| healthy(transport, RouteRole::BootstrapOnly)),
+            .map(|transport| healthy(transport, RouteRole::Rendezvous)),
+    );
+    samples.extend(
+        args.invite
+            .into_iter()
+            .map(|transport| healthy(transport, RouteRole::InviteBeacon)),
     );
     samples.extend(args.down.into_iter().map(down));
     samples
@@ -88,11 +94,15 @@ fn down(override_: RouteHealthOverride) -> TransportHealthSample {
     TransportHealthSample::down(override_.transport.into(), override_.role.into())
 }
 
-fn format_purpose(purpose: RoutePurpose) -> &'static str {
-    match purpose {
-        RoutePurpose::Data => "data",
-        RoutePurpose::LiveEvent => "live-event",
-        RoutePurpose::Bootstrap => "bootstrap",
+fn format_class(class: RouteClass) -> &'static str {
+    match class {
+        RouteClass::InviteAdvertise => "invite-advertise",
+        RouteClass::PeerRendezvous => "peer-rendezvous",
+        RouteClass::ControlInteractive => "control-interactive",
+        RouteClass::DataInteractive => "data-interactive",
+        RouteClass::DataBulk => "data-bulk",
+        RouteClass::MediaSignaling => "media-signaling",
+        RouteClass::PresenceEphemeral => "presence-ephemeral",
     }
 }
 
@@ -101,8 +111,11 @@ fn format_kind(kind: TransportKind) -> &'static str {
         TransportKind::LocalFs => "local-fs",
         TransportKind::LanTcp => "lan-tcp",
         TransportKind::Tailscale => "tailscale",
+        TransportKind::Udp => "udp",
+        TransportKind::WebRtcDataChannel => "webrtc-data-channel",
         TransportKind::Reticulum => "reticulum",
         TransportKind::Relay => "relay",
+        TransportKind::Ssh => "ssh",
         TransportKind::GhGist => "gh-gist",
     }
 }
@@ -111,7 +124,9 @@ fn format_role(role: TransportRole) -> &'static str {
     match role {
         TransportRole::Direct => "direct",
         TransportRole::Relay => "relay",
-        TransportRole::BootstrapOnly => "bootstrap-only",
+        TransportRole::InviteBeacon => "invite-beacon",
+        TransportRole::Rendezvous => "rendezvous",
+        TransportRole::Admin => "admin",
     }
 }
 
@@ -129,8 +144,11 @@ impl From<RouteTransport> for TransportKind {
             RouteTransport::LocalFs => Self::LocalFs,
             RouteTransport::LanTcp => Self::LanTcp,
             RouteTransport::Tailscale => Self::Tailscale,
+            RouteTransport::Udp => Self::Udp,
+            RouteTransport::WebRtcDataChannel => Self::WebRtcDataChannel,
             RouteTransport::Reticulum => Self::Reticulum,
             RouteTransport::Relay => Self::Relay,
+            RouteTransport::Ssh => Self::Ssh,
             RouteTransport::GhGist => Self::GhGist,
         }
     }
@@ -141,7 +159,9 @@ impl From<RouteRole> for TransportRole {
         match value {
             RouteRole::Direct => Self::Direct,
             RouteRole::Relay => Self::Relay,
-            RouteRole::BootstrapOnly => Self::BootstrapOnly,
+            RouteRole::InviteBeacon => Self::InviteBeacon,
+            RouteRole::Rendezvous => Self::Rendezvous,
+            RouteRole::Admin => Self::Admin,
         }
     }
 }

--- a/crates/airc-cli/tests/route_commands.rs
+++ b/crates/airc-cli/tests/route_commands.rs
@@ -11,35 +11,35 @@ fn route_status_defaults_to_local_runtime_route() {
     let output = run_ok(&["route", "status"]);
 
     assert!(output.contains("- local-fs role=direct state=healthy"));
-    assert!(output.contains("- data -> local-fs"));
-    assert!(output.contains("- live-event -> local-fs"));
+    assert!(output.contains("- data-interactive -> local-fs"));
+    assert!(output.contains("- presence-ephemeral -> local-fs"));
     assert!(!output.contains("gh-gist"));
 }
 
 #[test]
-fn route_status_keeps_github_bootstrap_only() {
-    let output = run_ok(&["route", "status", "--bootstrap", "gh-gist"]);
+fn route_status_keeps_github_invite_only() {
+    let output = run_ok(&["route", "status", "--invite", "gh-gist"]);
 
-    assert!(output.contains("- gh-gist role=bootstrap-only state=healthy"));
-    assert!(output.contains("- data -> no-route"));
-    assert!(output.contains("- live-event -> no-route"));
-    assert!(output.contains("- bootstrap -> gh-gist"));
+    assert!(output.contains("- gh-gist role=invite-beacon state=healthy"));
+    assert!(output.contains("- invite-advertise -> gh-gist"));
+    assert!(output.contains("- data-interactive -> no-route"));
+    assert!(output.contains("- presence-ephemeral -> no-route"));
     assert!(!output.contains("migration"));
 }
 
 #[test]
-fn route_status_prefers_direct_route_over_bootstrap_github() {
+fn route_status_prefers_direct_route_over_rendezvous_github() {
     let output = run_ok(&[
         "route",
         "status",
-        "--bootstrap",
+        "--rendezvous",
         "gh-gist",
         "--direct",
         "reticulum",
     ]);
 
-    assert!(output.contains("- data -> reticulum"));
-    assert!(output.contains("- bootstrap -> reticulum"));
+    assert!(output.contains("- peer-rendezvous -> reticulum"));
+    assert!(output.contains("- data-interactive -> reticulum"));
 }
 
 #[test]
@@ -47,7 +47,7 @@ fn route_status_down_override_removes_candidate() {
     let output = run_ok(&["route", "status", "--down", "local-fs:direct"]);
 
     assert!(output.contains("- local-fs role=direct state=down"));
-    assert!(output.contains("- data -> no-route"));
+    assert!(output.contains("- data-interactive -> no-route"));
 }
 
 fn run_ok(args: &[&str]) -> String {

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -42,7 +42,7 @@ pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use room::Room;
 pub use route_health::{TransportHealthSample, TransportHealthState};
 pub use route_policy::{
-    RouteDecision, RoutePolicy, RoutePurpose, TransportCandidate, TransportKind, TransportRole,
+    RouteClass, RouteDecision, RoutePolicy, TransportCandidate, TransportKind, TransportRole,
 };
 pub use route_resolver::{TransportResolver, TransportRoute};
 pub use stream::{EventFilter, EventStream, FilteredEventStream, LiveLag};

--- a/crates/airc-lib/src/route_policy.rs
+++ b/crates/airc-lib/src/route_policy.rs
@@ -1,18 +1,27 @@
 //! Transport route policy for consumer-facing AIRC embeddings.
 //!
 //! The important invariant is negative: GitHub is not a transparent
-//! runtime fallback. It can carry bootstrap/rendezvous frames when a caller
-//! explicitly chooses that purpose, but normal chat/data routing must use
-//! direct transports or fail loudly.
+//! runtime fallback. Gists can carry invite/rendezvous beacons when a
+//! caller explicitly chooses that route class, but normal chat, event,
+//! media-signaling, and bulk routing must use admitted live transports
+//! or fail loudly.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum RoutePurpose {
-    /// Normal durable conversation / work traffic.
-    Data,
-    /// Interrupt-style live events such as presence or turn steering.
-    LiveEvent,
-    /// Initial peer discovery / rendezvous metadata.
-    Bootstrap,
+pub enum RouteClass {
+    /// Publish a shareable invite beacon.
+    InviteAdvertise,
+    /// Find or refresh candidate routes for a peer.
+    PeerRendezvous,
+    /// Durable low-latency control traffic.
+    ControlInteractive,
+    /// Durable chat/work traffic.
+    DataInteractive,
+    /// Larger payload handoff metadata.
+    DataBulk,
+    /// WebRTC/LiveKit/game session signaling.
+    MediaSignaling,
+    /// Typing/thinking/presence-style ephemeral state.
+    PresenceEphemeral,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -20,8 +29,11 @@ pub enum TransportKind {
     LocalFs,
     LanTcp,
     Tailscale,
+    Udp,
+    WebRtcDataChannel,
     Reticulum,
     Relay,
+    Ssh,
     GhGist,
 }
 
@@ -29,7 +41,9 @@ pub enum TransportKind {
 pub enum TransportRole {
     Direct,
     Relay,
-    BootstrapOnly,
+    InviteBeacon,
+    Rendezvous,
+    Admin,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -42,7 +56,7 @@ pub struct TransportCandidate {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RouteDecision {
     Selected(TransportKind),
-    NoRoute { purpose: RoutePurpose },
+    NoRoute { class: RouteClass },
 }
 
 #[derive(Debug, Clone, Default)]
@@ -51,49 +65,120 @@ pub struct RoutePolicy;
 impl RoutePolicy {
     pub fn choose(
         &self,
-        purpose: RoutePurpose,
+        class: RouteClass,
         candidates: impl IntoIterator<Item = TransportCandidate>,
     ) -> RouteDecision {
         candidates
             .into_iter()
             .filter(|candidate| candidate.healthy)
-            .filter(|candidate| allows(purpose, *candidate))
-            .min_by_key(|candidate| priority(purpose, candidate.kind))
+            .filter(|candidate| allows(class, *candidate))
+            .min_by_key(|candidate| priority(class, candidate.kind, candidate.role))
             .map(|candidate| RouteDecision::Selected(candidate.kind))
-            .unwrap_or(RouteDecision::NoRoute { purpose })
+            .unwrap_or(RouteDecision::NoRoute { class })
     }
 }
 
-fn allows(purpose: RoutePurpose, candidate: TransportCandidate) -> bool {
+fn allows(class: RouteClass, candidate: TransportCandidate) -> bool {
     match candidate.kind {
-        TransportKind::GhGist => {
-            purpose == RoutePurpose::Bootstrap && candidate.role == TransportRole::BootstrapOnly
+        TransportKind::GhGist => matches!(
+            (class, candidate.role),
+            (RouteClass::InviteAdvertise, TransportRole::InviteBeacon)
+                | (RouteClass::PeerRendezvous, TransportRole::Rendezvous)
+        ),
+        TransportKind::LocalFs | TransportKind::LanTcp | TransportKind::Tailscale => {
+            candidate.role == TransportRole::Direct
+                && (is_live_class(class) || class == RouteClass::PeerRendezvous)
         }
-        TransportKind::LocalFs
-        | TransportKind::LanTcp
-        | TransportKind::Tailscale
-        | TransportKind::Reticulum => candidate.role == TransportRole::Direct,
-        TransportKind::Relay => candidate.role == TransportRole::Relay,
+        TransportKind::Udp | TransportKind::WebRtcDataChannel => {
+            candidate.role == TransportRole::Direct
+                && matches!(
+                    class,
+                    RouteClass::ControlInteractive
+                        | RouteClass::DataInteractive
+                        | RouteClass::MediaSignaling
+                        | RouteClass::PresenceEphemeral
+                )
+        }
+        TransportKind::Reticulum => {
+            (candidate.role == TransportRole::Direct
+                && (is_live_class(class) || class == RouteClass::PeerRendezvous))
+                || matches!(
+                    (class, candidate.role),
+                    (RouteClass::PeerRendezvous, TransportRole::Rendezvous)
+                )
+        }
+        TransportKind::Relay => {
+            (candidate.role == TransportRole::Relay && is_live_class(class))
+                || matches!(
+                    (class, candidate.role),
+                    (RouteClass::InviteAdvertise, TransportRole::InviteBeacon)
+                        | (RouteClass::PeerRendezvous, TransportRole::Rendezvous)
+                )
+        }
+        TransportKind::Ssh => false,
     }
 }
 
-fn priority(purpose: RoutePurpose, kind: TransportKind) -> u8 {
-    match purpose {
-        RoutePurpose::Data | RoutePurpose::LiveEvent => match kind {
+fn is_live_class(class: RouteClass) -> bool {
+    matches!(
+        class,
+        RouteClass::ControlInteractive
+            | RouteClass::DataInteractive
+            | RouteClass::DataBulk
+            | RouteClass::MediaSignaling
+            | RouteClass::PresenceEphemeral
+    )
+}
+
+fn priority(class: RouteClass, kind: TransportKind, role: TransportRole) -> u8 {
+    match class {
+        RouteClass::ControlInteractive
+        | RouteClass::DataInteractive
+        | RouteClass::PresenceEphemeral => match kind {
             TransportKind::LocalFs => 0,
             TransportKind::LanTcp => 1,
             TransportKind::Tailscale => 2,
-            TransportKind::Reticulum => 3,
-            TransportKind::Relay => 4,
-            TransportKind::GhGist => 255,
+            TransportKind::Udp => 3,
+            TransportKind::WebRtcDataChannel => 4,
+            TransportKind::Reticulum => 5,
+            TransportKind::Relay => 6,
+            TransportKind::Ssh | TransportKind::GhGist => 255,
         },
-        RoutePurpose::Bootstrap => match kind {
+        RouteClass::MediaSignaling => match kind {
+            TransportKind::LocalFs => 0,
+            TransportKind::Udp => 1,
+            TransportKind::WebRtcDataChannel => 2,
+            TransportKind::LanTcp => 3,
+            TransportKind::Tailscale => 4,
+            TransportKind::Reticulum => 5,
+            TransportKind::Relay => 6,
+            TransportKind::Ssh | TransportKind::GhGist => 255,
+        },
+        RouteClass::DataBulk => match kind {
             TransportKind::LocalFs => 0,
             TransportKind::LanTcp => 1,
             TransportKind::Tailscale => 2,
             TransportKind::Reticulum => 3,
             TransportKind::Relay => 4,
-            TransportKind::GhGist => 5,
+            TransportKind::Udp
+            | TransportKind::WebRtcDataChannel
+            | TransportKind::Ssh
+            | TransportKind::GhGist => 255,
+        },
+        RouteClass::PeerRendezvous => match (kind, role) {
+            (TransportKind::LocalFs, TransportRole::Direct) => 0,
+            (TransportKind::LanTcp, TransportRole::Direct) => 1,
+            (TransportKind::Tailscale, TransportRole::Direct) => 2,
+            (TransportKind::Reticulum, TransportRole::Direct) => 3,
+            (TransportKind::Reticulum, TransportRole::Rendezvous) => 4,
+            (TransportKind::Relay, TransportRole::Rendezvous) => 5,
+            (TransportKind::GhGist, TransportRole::Rendezvous) => 6,
+            _ => 255,
+        },
+        RouteClass::InviteAdvertise => match (kind, role) {
+            (TransportKind::Relay, TransportRole::InviteBeacon) => 0,
+            (TransportKind::GhGist, TransportRole::InviteBeacon) => 1,
+            _ => 255,
         },
     }
 }
@@ -111,32 +196,36 @@ mod tests {
     }
 
     #[test]
-    fn data_routes_never_select_github_as_fallback() {
+    fn live_routes_never_select_github_as_fallback() {
         let policy = RoutePolicy;
-        let decision = policy.choose(
-            RoutePurpose::Data,
-            [candidate(
-                TransportKind::GhGist,
-                TransportRole::BootstrapOnly,
-            )],
-        );
-
-        assert_eq!(
-            decision,
-            RouteDecision::NoRoute {
-                purpose: RoutePurpose::Data
-            }
-        );
+        for class in [
+            RouteClass::ControlInteractive,
+            RouteClass::DataInteractive,
+            RouteClass::DataBulk,
+            RouteClass::MediaSignaling,
+            RouteClass::PresenceEphemeral,
+        ] {
+            assert_eq!(
+                policy.choose(
+                    class,
+                    [
+                        candidate(TransportKind::GhGist, TransportRole::InviteBeacon),
+                        candidate(TransportKind::GhGist, TransportRole::Rendezvous),
+                    ],
+                ),
+                RouteDecision::NoRoute { class }
+            );
+        }
     }
 
     #[test]
-    fn bootstrap_can_use_github_when_no_direct_route_exists() {
+    fn invite_advertise_can_use_github_when_no_relay_beacon_exists() {
         let policy = RoutePolicy;
         let decision = policy.choose(
-            RoutePurpose::Bootstrap,
+            RouteClass::InviteAdvertise,
             [candidate(
                 TransportKind::GhGist,
-                TransportRole::BootstrapOnly,
+                TransportRole::InviteBeacon,
             )],
         );
 
@@ -144,12 +233,23 @@ mod tests {
     }
 
     #[test]
-    fn direct_routes_beat_github_even_for_bootstrap() {
+    fn peer_rendezvous_can_use_github_when_no_better_route_exists() {
         let policy = RoutePolicy;
         let decision = policy.choose(
-            RoutePurpose::Bootstrap,
+            RouteClass::PeerRendezvous,
+            [candidate(TransportKind::GhGist, TransportRole::Rendezvous)],
+        );
+
+        assert_eq!(decision, RouteDecision::Selected(TransportKind::GhGist));
+    }
+
+    #[test]
+    fn direct_routes_beat_github_for_peer_rendezvous() {
+        let policy = RoutePolicy;
+        let decision = policy.choose(
+            RouteClass::PeerRendezvous,
             [
-                candidate(TransportKind::GhGist, TransportRole::BootstrapOnly),
+                candidate(TransportKind::GhGist, TransportRole::Rendezvous),
                 candidate(TransportKind::LanTcp, TransportRole::Direct),
             ],
         );
@@ -158,10 +258,24 @@ mod tests {
     }
 
     #[test]
+    fn relay_beacon_beats_github_invite() {
+        let policy = RoutePolicy;
+        let decision = policy.choose(
+            RouteClass::InviteAdvertise,
+            [
+                candidate(TransportKind::GhGist, TransportRole::InviteBeacon),
+                candidate(TransportKind::Relay, TransportRole::InviteBeacon),
+            ],
+        );
+
+        assert_eq!(decision, RouteDecision::Selected(TransportKind::Relay));
+    }
+
+    #[test]
     fn unhealthy_candidates_are_ignored() {
         let policy = RoutePolicy;
         let decision = policy.choose(
-            RoutePurpose::Data,
+            RouteClass::DataInteractive,
             [
                 TransportCandidate {
                     kind: TransportKind::LocalFs,
@@ -179,13 +293,51 @@ mod tests {
     fn reticulum_is_a_direct_transport_not_a_github_fallback() {
         let policy = RoutePolicy;
         let decision = policy.choose(
-            RoutePurpose::Data,
+            RouteClass::DataInteractive,
             [
-                candidate(TransportKind::GhGist, TransportRole::BootstrapOnly),
+                candidate(TransportKind::GhGist, TransportRole::Rendezvous),
                 candidate(TransportKind::Reticulum, TransportRole::Direct),
             ],
         );
 
         assert_eq!(decision, RouteDecision::Selected(TransportKind::Reticulum));
+    }
+
+    #[test]
+    fn ssh_is_not_admissible_for_product_delivery() {
+        let policy = RoutePolicy;
+        let decision = policy.choose(
+            RouteClass::DataInteractive,
+            [candidate(TransportKind::Ssh, TransportRole::Admin)],
+        );
+
+        assert_eq!(
+            decision,
+            RouteDecision::NoRoute {
+                class: RouteClass::DataInteractive
+            }
+        );
+    }
+
+    #[test]
+    fn udp_is_interactive_not_bulk() {
+        let policy = RoutePolicy;
+
+        assert_eq!(
+            policy.choose(
+                RouteClass::MediaSignaling,
+                [candidate(TransportKind::Udp, TransportRole::Direct)],
+            ),
+            RouteDecision::Selected(TransportKind::Udp)
+        );
+        assert_eq!(
+            policy.choose(
+                RouteClass::DataBulk,
+                [candidate(TransportKind::Udp, TransportRole::Direct)],
+            ),
+            RouteDecision::NoRoute {
+                class: RouteClass::DataBulk
+            }
+        );
     }
 }

--- a/crates/airc-lib/src/route_resolver.rs
+++ b/crates/airc-lib/src/route_resolver.rs
@@ -4,11 +4,11 @@
 //! It does not open sockets, poll GitHub, or probe Reticulum. It
 //! accepts measured candidates and applies [`RoutePolicy`]. Later
 //! slices can add health probes/discovery without changing the rule
-//! that GitHub is bootstrap/rendezvous only.
+//! that GitHub is invite/rendezvous only.
 
 use crate::route_health::TransportHealthSample;
 use crate::route_policy::{
-    RouteDecision, RoutePolicy, RoutePurpose, TransportCandidate, TransportKind,
+    RouteClass, RouteDecision, RoutePolicy, TransportCandidate, TransportKind,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -46,8 +46,8 @@ impl TransportResolver {
         self.replace_candidates(samples.into_iter().map(TransportHealthSample::candidate));
     }
 
-    pub fn resolve(&self, purpose: RoutePurpose) -> Result<TransportRoute, RouteDecision> {
-        match self.policy.choose(purpose, self.candidates.iter().copied()) {
+    pub fn resolve(&self, class: RouteClass) -> Result<TransportRoute, RouteDecision> {
+        match self.policy.choose(class, self.candidates.iter().copied()) {
             RouteDecision::Selected(kind) => Ok(TransportRoute { kind }),
             decision @ RouteDecision::NoRoute { .. } => Err(decision),
         }
@@ -70,22 +70,22 @@ mod tests {
 
     #[test]
     fn resolver_rejects_github_for_runtime_data() {
-        let resolver = TransportResolver::new([candidate(GhGist, TransportRole::BootstrapOnly)]);
+        let resolver = TransportResolver::new([candidate(GhGist, TransportRole::Rendezvous)]);
 
         assert_eq!(
-            resolver.resolve(RoutePurpose::Data),
+            resolver.resolve(RouteClass::DataInteractive),
             Err(RouteDecision::NoRoute {
-                purpose: RoutePurpose::Data
+                class: RouteClass::DataInteractive
             })
         );
     }
 
     #[test]
-    fn resolver_allows_github_for_bootstrap_only() {
-        let resolver = TransportResolver::new([candidate(GhGist, TransportRole::BootstrapOnly)]);
+    fn resolver_allows_github_for_invite_only() {
+        let resolver = TransportResolver::new([candidate(GhGist, TransportRole::InviteBeacon)]);
 
         assert_eq!(
-            resolver.resolve(RoutePurpose::Bootstrap),
+            resolver.resolve(RouteClass::InviteAdvertise),
             Ok(TransportRoute { kind: GhGist })
         );
     }
@@ -93,12 +93,12 @@ mod tests {
     #[test]
     fn resolver_selects_reticulum_for_runtime_data() {
         let resolver = TransportResolver::new([
-            candidate(GhGist, TransportRole::BootstrapOnly),
+            candidate(GhGist, TransportRole::Rendezvous),
             candidate(Reticulum, TransportRole::Direct),
         ]);
 
         assert_eq!(
-            resolver.resolve(RoutePurpose::Data),
+            resolver.resolve(RouteClass::DataInteractive),
             Ok(TransportRoute { kind: Reticulum })
         );
     }
@@ -108,14 +108,14 @@ mod tests {
         let mut resolver = TransportResolver::new([candidate(LanTcp, TransportRole::Direct)]);
 
         assert_eq!(
-            resolver.resolve(RoutePurpose::Data),
+            resolver.resolve(RouteClass::DataInteractive),
             Ok(TransportRoute { kind: LanTcp })
         );
 
         resolver.replace_candidates([candidate(Reticulum, TransportRole::Direct)]);
 
         assert_eq!(
-            resolver.resolve(RoutePurpose::Data),
+            resolver.resolve(RouteClass::DataInteractive),
             Ok(TransportRoute { kind: Reticulum })
         );
     }
@@ -134,8 +134,22 @@ mod tests {
         ]);
 
         assert_eq!(
-            resolver.resolve(RoutePurpose::Data),
+            resolver.resolve(RouteClass::DataInteractive),
             Ok(TransportRoute { kind: Reticulum })
+        );
+    }
+
+    #[test]
+    fn resolver_selects_udp_for_interactive_data_when_available() {
+        let resolver = TransportResolver::new([
+            candidate(GhGist, TransportRole::Rendezvous),
+            candidate(Udp, TransportRole::Direct),
+            candidate(Relay, TransportRole::Relay),
+        ]);
+
+        assert_eq!(
+            resolver.resolve(RouteClass::DataInteractive),
+            Ok(TransportRoute { kind: Udp })
         );
     }
 }

--- a/crates/airc-transport/src/lib.rs
+++ b/crates/airc-transport/src/lib.rs
@@ -11,6 +11,7 @@
 //!   when multiple AI agents share one Mac.
 //! - **lan-tcp** (PR-3) — same-LAN peer-to-peer via TLS-wrapped TCP.
 //! - **tailscale** (PR-4) — mesh transport for cross-network peers.
+//! - **udp** — future low-latency realtime/game/live control path.
 //! - **gh-gist** — bootstrap/rendezvous adapter only. It must not become
 //!   a primary runtime path; GitHub is acceptable for identity exchange,
 //!   address publication, and invitations, not sustained chat transport.

--- a/docs/architecture/AIRC-RUST-SUBSTRATE.md
+++ b/docs/architecture/AIRC-RUST-SUBSTRATE.md
@@ -62,7 +62,7 @@ APIs; route resolution sits below them.
    directly. No shell-out from runtime code.
 4. **Persist** durably with proper cursors, archive drain, and SQLite/
    Postgres backends via SeaORM.
-5. **Multi-transport** — same-host, same-LAN, Tailscale, relay,
+5. **Multi-transport** — same-host, same-LAN, Tailscale, UDP, relay,
    WebRTC datachannel, Reticulum, and gh-gist invite/rendezvous.
    Pluggable, capability-resolved.
 6. **Be more secure** than today's airc: per-message forward secrecy,
@@ -340,7 +340,7 @@ The transport layer is a control plane, not a pile of special-case
 adapters. Local and remote delivery are the same product behavior:
 the caller submits one signed envelope, gets one delivery contract,
 and observes one transcript/replay model. Whether the bytes moved
-through local filesystem, LAN-TCP, Tailscale, Reticulum, a relay, or
+through local filesystem, LAN-TCP, Tailscale, UDP, Reticulum, a relay, or
 WebRTC datachannel is invisible above the substrate boundary.
 
 This is the telecom shape: separate the service contract from the
@@ -577,8 +577,8 @@ pub trait TransportHandle: Send + Sync {
 ```
 
 There is no adapter-specific caller API. A local-fs adapter, LAN-TCP
-adapter, Tailscale adapter, Reticulum adapter, relay adapter, and WebRTC
-datachannel adapter all implement the same contract. Adapter-specific
+adapter, Tailscale adapter, UDP adapter, Reticulum adapter, relay adapter,
+and WebRTC datachannel adapter all implement the same contract. Adapter-specific
 configuration lives below `open`; adapter-specific errors are normalized
 into scheduler states above it.
 
@@ -625,6 +625,8 @@ In the doc as anchors; not all in the v1 ship:
 - `local-fs` — same-host, same-scope. Ship v1.
 - `lan-tcp` — same-LAN direct. Ship v1.
 - `tailscale` — same-tailnet cross-network mesh. Ship v1.
+- `udp` — low-latency control/game/live packets where policy admits
+  unordered or partially ordered delivery. Future plugin.
 - `gh-gist-invite` — public invite/rendezvous beacon only. Ship v1.
   Not admissible for live chat/event data-plane classes.
 - `airc-relay` — own-hosted cross-network store-and-forward. Future

--- a/docs/architecture/INVITE-ROUTING-ARCHITECTURE.md
+++ b/docs/architecture/INVITE-ROUTING-ARCHITECTURE.md
@@ -19,8 +19,8 @@ A gist can publish enough signed information for a peer to join a mesh:
 - revocation or rotation notices
 
 After that, live frames move through AIRC transports selected by the route
-resolver: same-process, same-host local-fs/IPC, LAN/Tailscale TCP, relay,
-WebRTC datachannel, Reticulum, or future adapters. Consumers publish and
+resolver: same-process, same-host local-fs/IPC, LAN/Tailscale TCP, UDP,
+relay, WebRTC datachannel, Reticulum, or future adapters. Consumers publish and
 subscribe to events; they do not know or care which transport carried a frame.
 
 ## Why
@@ -49,7 +49,7 @@ route resolver
   chooses admissible route set from health, capabilities, policy, and scope
 
 transport adapters
-  local-fs/IPC, LAN/Tailscale TCP, relay, WebRTC datachannel, Reticulum, gh-gist invite
+  local-fs/IPC, LAN/Tailscale TCP, UDP, relay, WebRTC datachannel, Reticulum, gh-gist invite
 
 invite store
   signed beacons for bootstrap and rendezvous only
@@ -83,11 +83,11 @@ Initial admissibility:
 | --- | --- |
 | `InviteAdvertise` | gh-gist, static file, QR/text export, future public relay |
 | `PeerRendezvous` | gh-gist, relay, Reticulum announce, mDNS/LAN discovery |
-| `ControlInteractive` | local, LAN/Tailscale, relay, WebRTC datachannel, Reticulum |
-| `DataInteractive` | local, LAN/Tailscale, relay, WebRTC datachannel, Reticulum |
+| `ControlInteractive` | local, LAN/Tailscale, UDP, relay, WebRTC datachannel, Reticulum |
+| `DataInteractive` | local, LAN/Tailscale, UDP, relay, WebRTC datachannel, Reticulum |
 | `DataBulk` | local, LAN/Tailscale, relay, Reticulum, blob store handoff |
-| `MediaSignaling` | local, LAN/Tailscale, relay, WebRTC datachannel, Reticulum |
-| `PresenceEphemeral` | local, LAN/Tailscale, relay, WebRTC datachannel, Reticulum |
+| `MediaSignaling` | local, LAN/Tailscale, UDP, relay, WebRTC datachannel, Reticulum |
+| `PresenceEphemeral` | local, LAN/Tailscale, UDP, relay, WebRTC datachannel, Reticulum |
 
 `gh-gist` is not admissible for `ControlInteractive`, `DataInteractive`,
 `DataBulk`, `MediaSignaling`, or `PresenceEphemeral` unless a future explicit
@@ -106,7 +106,7 @@ requiring SSHD:
 | Same LAN | TLS-pinned LAN-TCP | Direct, signed, OS-neutral Rust. No Windows SSHD setup. |
 | Same Tailscale tailnet | TLS-pinned TCP over Tailscale address | Same route contract as LAN; Tailscale is reachability, not identity. |
 | Different tailnets / NAT boundary | `airc-relay` store-and-forward, then WebRTC/Reticulum where possible | Relay is the dependable baseline; direct routes can be promoted after discovery. |
-| Browser / live-mode control | WebRTC datachannel with relay/TURN when needed | AIRC carries signaling and control events, not media frames. |
+| Browser / live-mode control | UDP or WebRTC datachannel with relay/TURN when needed | AIRC carries signaling and control events, not media frames. |
 | Offline or intermittent mesh | Reticulum or relay-backed queue | Route state is explicit: queued until an admissible route exists. |
 
 SSH can exist as a future adapter for admin workflows, but it is not a required
@@ -180,7 +180,7 @@ pub trait EventBus {
 Subscriptions filter by channel, peer, frame kind, and headers. They do not
 filter by transport. A Continuum room, OpenClaw chat bridge, Hermes agent, or
 Codex monitor receives the same envelopes whether the bytes arrived over
-local-fs, Tailscale, relay, WebRTC, or Reticulum.
+local-fs, Tailscale, UDP, relay, WebRTC, or Reticulum.
 
 This is the boundary Continuum needs:
 
@@ -194,7 +194,7 @@ This is the boundary Continuum needs:
 ## GitHub Governor Semantics
 
 The GitHub governor only gates GitHub-backed invite and rendezvous operations.
-It must not mark local, LAN, Tailscale, relay, WebRTC, or Reticulum delivery as
+It must not mark local, LAN, Tailscale, UDP, relay, WebRTC, or Reticulum delivery as
 degraded.
 
 Allowed governor effects:


### PR DESCRIPTION
Summary
- replace coarse route purposes with explicit route classes: invite, rendezvous, control, interactive data, bulk, media signaling, presence
- add UDP, WebRTC datachannel, SSH/admin, invite-beacon, and rendezvous route modeling
- enforce gh-gist as invite/rendezvous only; live data/event/media classes return no-route instead of selecting GitHub
- update route status CLI and tests to show the route-class decisions
- update architecture docs to include UDP and the refined route boundary

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib -p airc-cli --check
- cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-lib route_ -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli route -- --nocapture
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- route status --invite gh-gist --rendezvous gh-gist --direct udp --relay relay
- bash test/rust_quality_guard.sh
- bash test/rust_cutover_guard.sh
- git diff --check