### PR TITLE
feat(lib): gate sends through route resolver

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -166,13 +166,14 @@ impl Airc {
     pub fn replace_transport_health(
         &self,
         samples: impl IntoIterator<Item = TransportHealthSample>,
-    ) {
+    ) -> Result<(), AircError> {
         let mut route_health = self
             .inner
             .route_health
             .write()
-            .expect("route health lock poisoned");
+            .map_err(|_| AircError::Route("route health lock poisoned".to_string()))?;
         *route_health = samples.into_iter().collect();
+        Ok(())
     }
 
     /// Switch the current room to one derived from `name`. Same name

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -32,6 +32,8 @@ use tokio::sync::{broadcast, Mutex};
 
 use crate::error::AircError;
 use crate::room::{self, Room};
+use crate::route_health::TransportHealthSample;
+use crate::route_policy::TransportKind;
 use crate::transport::WireSubscriber;
 
 const EVENTS_DB_FILENAME: &str = "events.sqlite";
@@ -70,6 +72,7 @@ pub(crate) struct AircInner {
     pub(crate) store: Arc<dyn EventStore>,
     pub(crate) registry: Arc<RwLock<PeerKeyRegistry>>,
     pub(crate) policy: VerificationPolicy,
+    pub(crate) route_health: RwLock<Vec<TransportHealthSample>>,
     /// Per-wire background subscriber tasks. Spawned lazily on first
     /// `say`/`send`/`subscribe`/`page_recent` referencing the wire.
     /// Held in a Mutex so concurrent calls can't double-spawn.
@@ -133,6 +136,9 @@ impl Airc {
                 store,
                 registry,
                 policy,
+                route_health: RwLock::new(vec![TransportHealthSample::healthy_direct(
+                    TransportKind::LocalFs,
+                )]),
                 subscribers: Mutex::new(HashMap::new()),
                 live_tx,
             }),
@@ -152,6 +158,21 @@ impl Airc {
     /// Return the per-session client identifier.
     pub fn client_id(&self) -> ClientId {
         self.inner.identity.client_id
+    }
+
+    /// Replace the route-health view consumed by the resolver. Discovery
+    /// and transport probes own this in production; tests and embedded
+    /// harnesses can pin samples to prove route admission behavior.
+    pub fn replace_transport_health(
+        &self,
+        samples: impl IntoIterator<Item = TransportHealthSample>,
+    ) {
+        let mut route_health = self
+            .inner
+            .route_health
+            .write()
+            .expect("route health lock poisoned");
+        *route_health = samples.into_iter().collect();
     }
 
     /// Switch the current room to one derived from `name`. Same name

--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -41,6 +41,11 @@ pub enum AircError {
     #[error("transport: {0}")]
     Transport(String),
 
+    /// Route resolver refused or selected a route the current sender
+    /// cannot execute.
+    #[error("route: {0}")]
+    Route(String),
+
     /// Caller asked for an operation that needs an active room but
     /// the state has none yet. Construct one via `Airc::join`.
     #[error("no current room — call `join` to set one")]

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -4,6 +4,8 @@ use airc_transport::{LocalFsAdapter, Transport};
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::error::AircError;
+use crate::route_policy::{RouteClass, RouteDecision, TransportKind};
+use crate::route_resolver::TransportResolver;
 use crate::stream::{EventFilter, EventStream, FilteredEventStream};
 use crate::time::now_ms;
 use crate::Airc;
@@ -26,6 +28,7 @@ impl Airc {
         headers: Headers,
     ) -> Result<EventId, AircError> {
         let room = self.current_room().await?;
+        self.resolve_send_route(kind)?;
         self.ensure_wire_subscriber(&room.wire).await?;
         let event_id = EventId::new();
         let occurred_at_ms = now_ms()?;
@@ -59,6 +62,25 @@ impl Airc {
             .map_err(|e| AircError::Transport(e.to_string()))?;
         self.append_sent_frame(frame).await?;
         Ok(event_id)
+    }
+
+    fn resolve_send_route(&self, kind: FrameKind) -> Result<(), AircError> {
+        let class = route_class_for_frame(kind);
+        let samples = self
+            .inner
+            .route_health
+            .read()
+            .expect("route health lock poisoned")
+            .clone();
+        let route = TransportResolver::from_health(samples)
+            .resolve(class)
+            .map_err(format_route_refusal)?;
+        match route.kind {
+            TransportKind::LocalFs => Ok(()),
+            other => Err(AircError::Route(format!(
+                "{class:?} selected {other:?}, but this sender has only local-fs execution wired"
+            ))),
+        }
     }
 
     async fn append_sent_frame(&self, frame: Frame) -> Result<(), AircError> {
@@ -184,5 +206,23 @@ impl Airc {
     async fn ensure_current_room_subscriber(&self) -> Result<(), AircError> {
         let room = self.current_room().await?;
         self.ensure_wire_subscriber(&room.wire).await
+    }
+}
+
+fn route_class_for_frame(kind: FrameKind) -> RouteClass {
+    match kind {
+        FrameKind::Message => RouteClass::DataInteractive,
+        FrameKind::Event | FrameKind::Control => RouteClass::ControlInteractive,
+    }
+}
+
+fn format_route_refusal(decision: RouteDecision) -> AircError {
+    match decision {
+        RouteDecision::NoRoute { class } => {
+            AircError::Route(format!("{class:?} has no admissible live route"))
+        }
+        RouteDecision::Selected(kind) => AircError::Route(format!(
+            "unexpected selected route returned as refusal: {kind:?}"
+        )),
     }
 }

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -70,14 +70,21 @@ impl Airc {
             .inner
             .route_health
             .read()
-            .expect("route health lock poisoned")
+            .map_err(|_| AircError::Route("route health lock poisoned".to_string()))?
             .clone();
         let route = TransportResolver::from_health(samples)
             .resolve(class)
             .map_err(format_route_refusal)?;
         match route.kind {
             TransportKind::LocalFs => Ok(()),
-            other => Err(AircError::Route(format!(
+            other @ (TransportKind::LanTcp
+            | TransportKind::Tailscale
+            | TransportKind::Udp
+            | TransportKind::WebRtcDataChannel
+            | TransportKind::Reticulum
+            | TransportKind::Relay
+            | TransportKind::Ssh
+            | TransportKind::GhGist) => Err(AircError::Route(format!(
                 "{class:?} selected {other:?}, but this sender has only local-fs execution wired"
             ))),
         }

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -9,7 +9,10 @@
 
 use std::time::Duration;
 
-use airc_lib::{Airc, Body, EventFilter, HeaderFilter, Headers, PeerSpec, TranscriptKind};
+use airc_lib::{
+    Airc, Body, EventFilter, HeaderFilter, Headers, PeerSpec, TranscriptKind,
+    TransportHealthSample, TransportKind, TransportRole,
+};
 use futures::stream::StreamExt;
 use tempfile::TempDir;
 
@@ -179,6 +182,28 @@ async fn send_typed_body_with_headers_round_trips() {
     assert_eq!(
         page[0].headers.get("forge.body_hint").map(String::as_str),
         Some("application/json")
+    );
+}
+
+#[tokio::test]
+async fn send_refuses_github_invite_only_route() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("route-gate").await.unwrap();
+    airc.replace_transport_health([TransportHealthSample {
+        kind: TransportKind::GhGist,
+        role: TransportRole::InviteBeacon,
+        state: airc_lib::TransportHealthState::Healthy,
+        rtt_ms: None,
+        success_ppm: None,
+    }]);
+
+    let err = airc.say("must not go through gist").await.unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("DataInteractive has no admissible live route"),
+        "unexpected error: {err}"
     );
 }
 

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -196,7 +196,8 @@ async fn send_refuses_github_invite_only_route() {
         state: airc_lib::TransportHealthState::Healthy,
         rtt_ms: None,
         success_ppm: None,
-    }]);
+    }])
+    .unwrap();
 
     let err = airc.say("must not go through gist").await.unwrap_err();
 


### PR DESCRIPTION
Summary
- add route-health state to airc-lib handles, defaulting to local-fs direct
- gate Airc::send/say/send_frame through TransportResolver before opening transport
- fail with a route error when live data has no admissible route, proving gh-gist invite/rendezvous cannot carry chat sends
- add embedding smoke coverage for refusing a GitHub invite-only route

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib -p airc-cli --check
- cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-lib --test embedding_smoke -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-lib route_ -- --nocapture
- bash test/rust_quality_guard.sh
- bash test/rust_cutover_guard.sh
- git diff --check