### PR TITLE
feat(lib): execute SDK sends over LAN routes

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -28,13 +28,14 @@ use airc_core::{ClientId, PeerId, TranscriptEvent};
 use airc_daemon::{peers_store, LocalIdentity};
 use airc_protocol::{PeerKeyRegistry, VerificationPolicy};
 use airc_store::{EventStore, SqliteEventStore};
+use airc_transport::LanTcpAdapter;
 use tokio::sync::{broadcast, Mutex};
 
 use crate::error::AircError;
 use crate::room::{self, Room};
 use crate::route_health::TransportHealthSample;
 use crate::route_policy::TransportKind;
-use crate::transport::WireSubscriber;
+use crate::transport::{FrameSubscriber, WireSubscriber};
 
 const EVENTS_DB_FILENAME: &str = "events.sqlite";
 
@@ -73,6 +74,8 @@ pub(crate) struct AircInner {
     pub(crate) registry: Arc<RwLock<PeerKeyRegistry>>,
     pub(crate) policy: VerificationPolicy,
     pub(crate) route_health: RwLock<Vec<TransportHealthSample>>,
+    pub(crate) lan_tcp: Mutex<Option<LanTcpAdapter>>,
+    pub(crate) lan_subscriber: Mutex<Option<FrameSubscriber>>,
     /// Per-wire background subscriber tasks. Spawned lazily on first
     /// `say`/`send`/`subscribe`/`page_recent` referencing the wire.
     /// Held in a Mutex so concurrent calls can't double-spawn.
@@ -139,6 +142,8 @@ impl Airc {
                 route_health: RwLock::new(vec![TransportHealthSample::healthy_direct(
                     TransportKind::LocalFs,
                 )]),
+                lan_tcp: Mutex::new(None),
+                lan_subscriber: Mutex::new(None),
                 subscribers: Mutex::new(HashMap::new()),
                 live_tx,
             }),

--- a/crates/airc-lib/src/lan.rs
+++ b/crates/airc-lib/src/lan.rs
@@ -1,0 +1,66 @@
+//! LAN transport binding for embedded AIRC handles.
+//!
+//! LAN is a substrate transport concern. Consumer apps call these SDK
+//! methods; they do not own socket setup, adapter state, route health,
+//! or frame ingestion.
+
+use std::net::SocketAddr;
+
+use airc_core::PeerId;
+use airc_transport::LanTcpAdapter;
+
+use crate::error::AircError;
+use crate::route_health::TransportHealthSample;
+use crate::route_policy::TransportKind;
+use crate::Airc;
+
+impl Airc {
+    /// Bind a TLS-pinned LAN listener and ingest received frames into
+    /// the same store/live stream as local-fs frames.
+    pub async fn listen_lan(&self, bind: SocketAddr) -> Result<SocketAddr, AircError> {
+        let adapter = self.lan_adapter().await?;
+        let actual = adapter
+            .listen(bind)
+            .await
+            .map_err(|error| AircError::Transport(error.to_string()))?;
+        self.ensure_lan_subscriber().await?;
+        self.replace_transport_health([TransportHealthSample::healthy_direct(
+            TransportKind::LanTcp,
+        )])?;
+        Ok(actual)
+    }
+
+    /// Connect to a TLS-pinned LAN peer and make LAN-TCP the active
+    /// direct route for subsequent sends on this handle.
+    pub async fn connect_lan(
+        &self,
+        peer_addr: SocketAddr,
+        expected_peer: PeerId,
+    ) -> Result<(), AircError> {
+        let adapter = self.lan_adapter().await?;
+        adapter
+            .connect(peer_addr, expected_peer)
+            .await
+            .map_err(|error| AircError::Transport(error.to_string()))?;
+        self.ensure_lan_subscriber().await?;
+        self.replace_transport_health([TransportHealthSample::healthy_direct(
+            TransportKind::LanTcp,
+        )])?;
+        Ok(())
+    }
+
+    pub(crate) async fn lan_adapter(&self) -> Result<LanTcpAdapter, AircError> {
+        let mut guard = self.inner.lan_tcp.lock().await;
+        if let Some(adapter) = guard.as_ref() {
+            return Ok(adapter.clone());
+        }
+        let adapter = LanTcpAdapter::new(
+            self.inner.identity.peer_id,
+            self.inner.identity.keypair.clone(),
+            self.inner.registry.clone(),
+        )
+        .map_err(|error| AircError::Transport(error.to_string()))?;
+        *guard = Some(adapter.clone());
+        Ok(adapter)
+    }
+}

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -23,10 +23,12 @@
 
 pub mod airc;
 pub mod error;
+mod lan;
 mod messaging;
 mod peers;
 pub mod registry;
 pub mod room;
+mod route_execution;
 pub mod route_health;
 pub mod route_policy;
 pub mod route_resolver;

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -1,10 +1,9 @@
 use airc_core::{Body, EventId, Headers, MentionTarget, TranscriptCursor, TranscriptEvent};
 use airc_protocol::{Envelope, Frame, FrameKind, Signature};
-use airc_transport::{LocalFsAdapter, Transport};
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::error::AircError;
-use crate::route_policy::{RouteClass, RouteDecision, TransportKind};
+use crate::route_policy::{RouteClass, RouteDecision};
 use crate::route_resolver::TransportResolver;
 use crate::stream::{EventFilter, EventStream, FilteredEventStream};
 use crate::time::now_ms;
@@ -28,8 +27,7 @@ impl Airc {
         headers: Headers,
     ) -> Result<EventId, AircError> {
         let room = self.current_room().await?;
-        self.resolve_send_route(kind)?;
-        self.ensure_wire_subscriber(&room.wire).await?;
+        let route = self.resolve_send_route(kind)?;
         let event_id = EventId::new();
         let occurred_at_ms = now_ms()?;
         let mut frame = Frame {
@@ -55,16 +53,13 @@ impl Airc {
             .keypair
             .sign_envelope(&frame.envelope, self.inner.identity.peer_id, 0)
             .map_err(|error| AircError::Crypto(error.to_string()))?;
-        let transport = LocalFsAdapter::new(&room.wire);
-        transport
-            .send(frame.clone())
-            .await
-            .map_err(|e| AircError::Transport(e.to_string()))?;
+        self.execute_send_route(route.kind, &room, frame.clone())
+            .await?;
         self.append_sent_frame(frame).await?;
         Ok(event_id)
     }
 
-    fn resolve_send_route(&self, kind: FrameKind) -> Result<(), AircError> {
+    fn resolve_send_route(&self, kind: FrameKind) -> Result<crate::TransportRoute, AircError> {
         let class = route_class_for_frame(kind);
         let samples = self
             .inner
@@ -72,22 +67,9 @@ impl Airc {
             .read()
             .map_err(|_| AircError::Route("route health lock poisoned".to_string()))?
             .clone();
-        let route = TransportResolver::from_health(samples)
+        TransportResolver::from_health(samples)
             .resolve(class)
-            .map_err(format_route_refusal)?;
-        match route.kind {
-            TransportKind::LocalFs => Ok(()),
-            other @ (TransportKind::LanTcp
-            | TransportKind::Tailscale
-            | TransportKind::Udp
-            | TransportKind::WebRtcDataChannel
-            | TransportKind::Reticulum
-            | TransportKind::Relay
-            | TransportKind::Ssh
-            | TransportKind::GhGist) => Err(AircError::Route(format!(
-                "{class:?} selected {other:?}, but this sender has only local-fs execution wired"
-            ))),
-        }
+            .map_err(format_route_refusal)
     }
 
     async fn append_sent_frame(&self, frame: Frame) -> Result<(), AircError> {

--- a/crates/airc-lib/src/route_execution.rs
+++ b/crates/airc-lib/src/route_execution.rs
@@ -1,0 +1,52 @@
+//! Execution of resolved transport routes.
+//!
+//! Message construction, route selection, and adapter execution are
+//! deliberately separate concerns. This layer is the bridge from a
+//! selected `TransportKind` to the concrete adapter that can carry a
+//! signed frame.
+
+use airc_protocol::Frame;
+use airc_transport::{LocalFsAdapter, Transport};
+
+use crate::error::AircError;
+use crate::route_policy::TransportKind;
+use crate::{Airc, Room};
+
+impl Airc {
+    pub(crate) async fn execute_send_route(
+        &self,
+        route: TransportKind,
+        room: &Room,
+        frame: Frame,
+    ) -> Result<(), AircError> {
+        match route {
+            TransportKind::LocalFs => {
+                self.ensure_wire_subscriber(&room.wire).await?;
+                LocalFsAdapter::new(&room.wire)
+                    .send(frame)
+                    .await
+                    .map_err(|error| AircError::Transport(error.to_string()))
+            }
+            TransportKind::LanTcp | TransportKind::Tailscale => {
+                self.ensure_lan_subscriber().await?;
+                self.lan_adapter()
+                    .await?
+                    .send(frame)
+                    .await
+                    .map_err(|error| AircError::Transport(error.to_string()))
+            }
+            TransportKind::Udp => Err(unwired_transport_error(route)),
+            TransportKind::WebRtcDataChannel => Err(unwired_transport_error(route)),
+            TransportKind::Reticulum => Err(unwired_transport_error(route)),
+            TransportKind::Relay => Err(unwired_transport_error(route)),
+            TransportKind::Ssh => Err(unwired_transport_error(route)),
+            TransportKind::GhGist => Err(unwired_transport_error(route)),
+        }
+    }
+}
+
+fn unwired_transport_error(kind: TransportKind) -> AircError {
+    AircError::Route(format!(
+        "{kind:?} route selected but no executable adapter is wired"
+    ))
+}

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use airc_core::{EventId, TranscriptCursor};
-use airc_protocol::Subscription;
+use airc_protocol::{Frame, Subscription};
 use airc_transport::{LocalFsAdapter, SignedTransport, Transport};
 use futures::stream::StreamExt;
 
@@ -10,6 +10,11 @@ use crate::room::Room;
 use crate::Airc;
 
 pub(crate) struct WireSubscriber {
+    /// Kept alive by ownership of its `JoinHandle`.
+    pub(crate) _task: tokio::task::JoinHandle<()>,
+}
+
+pub(crate) struct FrameSubscriber {
     /// Kept alive by ownership of its `JoinHandle`.
     pub(crate) _task: tokio::task::JoinHandle<()>,
 }
@@ -38,35 +43,77 @@ impl Airc {
             }),
             ..Default::default()
         };
-        let mut stream = transport
+        let stream = transport
             .subscribe(subscription)
             .await
             .map_err(|e| AircError::Transport(e.to_string()))?;
 
+        let task = self.spawn_frame_ingest(stream);
+        subs.insert(wire.to_path_buf(), WireSubscriber { _task: task });
+        Ok(())
+    }
+
+    pub(crate) async fn ensure_lan_subscriber(&self) -> Result<(), AircError> {
+        let mut subscriber = self.inner.lan_subscriber.lock().await;
+        if subscriber.is_some() {
+            return Ok(());
+        }
+        let adapter = self.lan_adapter().await?;
+        let transport = SignedTransport::new(
+            adapter,
+            self.inner.identity.keypair.clone(),
+            self.inner.identity.peer_id,
+            self.inner.registry.clone(),
+            self.inner.policy,
+        );
+        let subscription = Subscription {
+            from_cursor: None,
+            ..Default::default()
+        };
+        let stream = transport
+            .subscribe(subscription)
+            .await
+            .map_err(|e| AircError::Transport(e.to_string()))?;
+        let task = self.spawn_frame_ingest(stream);
+        *subscriber = Some(FrameSubscriber { _task: task });
+        Ok(())
+    }
+
+    fn spawn_frame_ingest<E>(
+        &self,
+        mut stream: airc_transport::FrameStream<E>,
+    ) -> tokio::task::JoinHandle<()>
+    where
+        E: std::fmt::Display + Send + 'static,
+    {
         let store = self.inner.store.clone();
         let live_tx = self.inner.live_tx.clone();
-        let task = tokio::spawn(async move {
+        tokio::spawn(async move {
             while let Some(item) = stream.next().await {
                 match item {
-                    Ok(frame) => {
-                        let event = frame.into_transcript_event();
-                        match store.append(event.clone()).await {
-                            Ok(()) => {
-                                let _ = live_tx.send(event);
-                            }
-                            Err(airc_store::StoreError::DuplicateEventId(_)) => {}
-                            Err(err) => {
-                                eprintln!("airc-lib subscriber: store append failed: {err}");
-                            }
-                        }
-                    }
+                    Ok(frame) => append_received_frame(frame, store.as_ref(), &live_tx).await,
                     Err(verify_err) => {
                         eprintln!("airc-lib subscriber: frame verification failed: {verify_err}");
                     }
                 }
             }
-        });
-        subs.insert(wire.to_path_buf(), WireSubscriber { _task: task });
-        Ok(())
+        })
+    }
+}
+
+async fn append_received_frame(
+    frame: Frame,
+    store: &dyn airc_store::EventStore,
+    live_tx: &tokio::sync::broadcast::Sender<airc_core::TranscriptEvent>,
+) {
+    let event = frame.into_transcript_event();
+    match store.append(event.clone()).await {
+        Ok(()) => {
+            let _ = live_tx.send(event);
+        }
+        Err(airc_store::StoreError::DuplicateEventId(_)) => {}
+        Err(err) => {
+            eprintln!("airc-lib subscriber: store append failed: {err}");
+        }
     }
 }

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -7,7 +7,7 @@
 //! background subscriber, the store, and the broadcast fan-out.
 //! This is the slice-6b proof point.
 
-use std::time::Duration;
+use std::{net::SocketAddr, time::Duration};
 
 use airc_lib::{
     Airc, Body, EventFilter, HeaderFilter, Headers, PeerSpec, TranscriptKind,
@@ -206,6 +206,35 @@ async fn send_refuses_github_invite_only_route() {
             .contains("DataInteractive has no admissible live route"),
         "unexpected error: {err}"
     );
+}
+
+#[tokio::test]
+async fn two_embedded_handles_chat_over_lan_without_cli() {
+    let alice_home = TempDir::new().unwrap();
+    let bob_home = TempDir::new().unwrap();
+    let alice = Airc::open(alice_home.path()).await.unwrap();
+    let bob = Airc::open(bob_home.path()).await.unwrap();
+
+    let alice_spec: PeerSpec = alice.peer_spec().parse().unwrap();
+    let bob_spec: PeerSpec = bob.peer_spec().parse().unwrap();
+    alice.add_peer(bob_spec).await.unwrap();
+    bob.add_peer(alice_spec).await.unwrap();
+
+    alice.join("lan-room").await.unwrap();
+    bob.join("lan-room").await.unwrap();
+
+    let bind = SocketAddr::from(([127, 0, 0, 1], 0));
+    let alice_addr = alice.listen_lan(bind).await.unwrap();
+    bob.connect_lan(alice_addr, alice.peer_id()).await.unwrap();
+
+    bob.say("hello over sdk lan").await.unwrap();
+
+    let page = wait_for_events(&alice, 1, Duration::from_secs(3)).await;
+    let bodies: Vec<&str> = page
+        .iter()
+        .filter_map(|event| event.body.as_ref().and_then(Body::as_text))
+        .collect();
+    assert_eq!(bodies, vec!["hello over sdk lan"]);
 }
 
 #[tokio::test]

--- a/crates/airc-transport/src/lan_tcp/adapter/mod.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/mod.rs
@@ -60,6 +60,7 @@ use crate::lan_tcp::tls_config::{build_client_config, build_server_config};
 use crate::transport::{FrameStream, Transport};
 
 /// Secure same-LAN adapter.
+#[derive(Clone)]
 pub struct LanTcpAdapter {
     inner: Arc<Inner>,
 }


### PR DESCRIPTION
## Summary
- add SDK LAN listen/connect binding in airc-lib, not CLI/app logic
- route Airc::send through the resolver and execute selected LocalFs/LanTcp/Tailscale routes via adapter dispatch
- share LAN frame ingestion with the existing store/live event stream
- add an embedding smoke test proving two Airc handles chat over TLS LAN without CLI

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib -p airc-transport --check
- cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-transport --lib -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm
- cargo test --manifest-path Cargo.toml -p airc-lib
- cargo test --manifest-path Cargo.toml -p airc-transport
- bash test/rust_quality_guard.sh
- bash test/rust_cutover_guard.sh
- cargo test --manifest-path Cargo.toml --workspace