### PR TITLE
refactor(cli): route LAN commands through airc-lib

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -5,10 +5,9 @@
 //! CLI is a thin client of the same API consumers embed. Closes
 //! grievance §5 / Codex audit finding #4.
 //!
-//! LAN-TCP and daemon-host commands construct lower-level handles
-//! (`LanTcpAdapter`, `DaemonState`) directly — they're not in
-//! airc-lib's surface yet. Daemon-client commands (`ping`, `status`,
-//! `stop`, `msg`, `inbox`) use `airc_daemon::DaemonClient` directly.
+//! Daemon-host commands construct daemon state directly because they
+//! host the service. Daemon-client commands (`ping`, `status`, `stop`,
+//! `msg`, `inbox`) use `airc_daemon::DaemonClient` directly.
 //!
 //! `VerificationPolicy::Strict` is the only policy used in CLI paths.
 
@@ -16,14 +15,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::RwLock;
 
-use airc_core::{
-    headers::Headers, transcript::MentionTarget, ClientId, EventId, PeerId, RoomId,
-    TranscriptCursor,
-};
-use airc_protocol::{
-    Envelope, Frame, FrameKind, PeerKeyRegistry, Signature, Subscription, VerificationPolicy,
-};
-use airc_transport::{LanTcpAdapter, SignedTransport, Transport};
+use airc_core::{ClientId, EventId, PeerId, TranscriptCursor};
+use airc_protocol::{PeerKeyRegistry, VerificationPolicy};
 use futures::stream::StreamExt;
 
 use airc_daemon::{
@@ -145,25 +138,18 @@ pub async fn run_listen(
 /// the current room's channel.
 pub async fn run_lan_send(
     home: &Path,
-    identity: &LocalIdentity,
     peers: Vec<PeerSpec>,
     to: std::net::SocketAddr,
     expected_peer: PeerId,
     text: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let current = room::load_or_default(home)?;
-    let registry = build_combined_registry(home, identity, &peers)?;
-    let inner = LanTcpAdapter::new(identity.peer_id, identity.keypair.clone(), registry.clone())?;
-    inner.connect(to, expected_peer).await?;
-    let transport = SignedTransport::new(
-        inner,
-        identity.keypair.clone(),
-        identity.peer_id,
-        registry,
-        VerificationPolicy::Strict,
-    );
-    let frame = build_message_frame(identity, current.channel, text);
-    transport.send(frame).await?;
+    let airc = Airc::open(home).await?;
+    for peer in &peers {
+        airc.enrol_volatile_peer(peer)?;
+    }
+    let current = airc.current_room().await?;
+    airc.connect_lan(to, expected_peer).await?;
+    airc.say(text).await?;
     println!(
         "sent over lan-tcp to {} ({}).",
         current.name, current.channel
@@ -174,34 +160,18 @@ pub async fn run_lan_send(
 /// `lan-listen` — bind a TLS server, accept peers, print frames.
 pub async fn run_lan_listen(
     home: &Path,
-    identity: &LocalIdentity,
     peers: Vec<PeerSpec>,
     bind: std::net::SocketAddr,
-    replay: bool,
+    _replay: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let registry = build_combined_registry(home, identity, &peers)?;
-    let inner = LanTcpAdapter::new(identity.peer_id, identity.keypair.clone(), registry.clone())?;
-    let actual = inner.listen(bind).await?;
-    println!("listening on {actual} (peer_id {}) …", identity.peer_id);
-    let transport = SignedTransport::new(
-        inner,
-        identity.keypair.clone(),
-        identity.peer_id,
-        registry,
-        VerificationPolicy::Strict,
-    );
-    // LAN listen accepts frames on any channel — no filter.
-    let from_cursor = replay.then(|| TranscriptCursor {
-        lamport: 0,
-        event_id: EventId::from_u128(0),
-    });
-    let subscription = Subscription {
-        channel: None,
-        from_cursor,
-        ..Default::default()
-    };
-    let mut stream = transport.subscribe(subscription).await?;
-    print_until_signal(&mut stream).await
+    let airc = Airc::open(home).await?;
+    for peer in &peers {
+        airc.enrol_volatile_peer(peer)?;
+    }
+    let actual = airc.listen_lan(bind).await?;
+    println!("listening on {actual} (peer_id {}) …", airc.peer_id());
+    let mut stream = airc.subscribe().await?;
+    print_event_stream_until_signal(&mut stream).await
 }
 
 /// `daemon` — run the long-lived daemon process on the given socket.
@@ -342,79 +312,6 @@ pub async fn run_inbox(
         );
     }
     Ok(())
-}
-
-// ---- Shared helpers (LAN commands) ---------------------------------
-
-fn build_message_frame(identity: &LocalIdentity, channel: RoomId, text: &str) -> Frame {
-    let lamport = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0);
-    Frame {
-        kind: FrameKind::Message,
-        envelope: Envelope {
-            event_id: EventId::new(),
-            sender: identity.peer_id,
-            // Stable ClientId from the persisted identity — multi-tab
-            // disambiguation, replay records cite this.
-            sender_client: identity.client_id,
-            channel,
-            target: MentionTarget::All,
-            lamport,
-            occurred_at_ms: lamport,
-            reply_to: None,
-            headers: Headers::new(),
-            body: Some(Body::text(text)),
-            // SignedTransport replaces this with Ed25519 on the way out.
-            signature: Signature::Unsigned,
-            media: Vec::new(),
-        },
-    }
-}
-
-async fn print_until_signal<S, E>(stream: &mut S) -> Result<(), Box<dyn std::error::Error>>
-where
-    S: futures::Stream<Item = Result<Frame, E>> + Unpin,
-    E: std::error::Error + Send + Sync + 'static,
-{
-    let sigint = tokio::signal::ctrl_c();
-    let mut sigint = Box::pin(sigint);
-    loop {
-        tokio::select! {
-            biased;
-            _ = &mut sigint => {
-                println!();
-                println!("interrupted; exiting.");
-                return Ok(());
-            }
-            next = stream.next() => {
-                match next {
-                    Some(Ok(frame)) => print_frame(&frame),
-                    Some(Err(error)) => eprintln!("verification failed: {error}"),
-                    None => {
-                        println!("stream closed; exiting.");
-                        return Ok(());
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn print_frame(frame: &Frame) {
-    let text = frame
-        .envelope
-        .body
-        .as_ref()
-        .and_then(Body::as_text)
-        .unwrap_or("<non-text body>");
-    println!(
-        "[{kind:?}] {sender} → {channel}: {text}",
-        kind = frame.kind,
-        sender = frame.envelope.sender,
-        channel = frame.envelope.channel,
-    );
 }
 
 async fn print_event_stream_until_signal(

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -496,14 +496,12 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             expected_peer,
             text,
         } => {
-            let identity = LocalIdentity::load_or_generate(&home)?;
             let expected = parse_peer_id(&expected_peer)?;
-            commands::run_lan_send(&home, &identity, parsed.peers, to, expected, &text).await
+            commands::run_lan_send(&home, parsed.peers, to, expected, &text).await
         }
 
         Command::LanListen { bind, replay } => {
-            let identity = LocalIdentity::load_or_generate(&home)?;
-            commands::run_lan_listen(&home, &identity, parsed.peers, bind, replay).await
+            commands::run_lan_listen(&home, parsed.peers, bind, replay).await
         }
 
         Command::Daemon { socket } => {

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -9,6 +9,7 @@
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
@@ -192,6 +193,75 @@ fn listen_rejects_unenrolled_signer() {
 }
 
 #[test]
+fn two_airc_rs_processes_chat_over_lan_via_sdk_route() {
+    // The LAN CLI commands must be thin wrappers over airc-lib. This
+    // test spawns real processes and uses `lan-listen` / `lan-send`
+    // without a shared local-fs wire.
+    let workspace = TempDir::new().expect("tempdir");
+    let alice_home = workspace.path().join("alice");
+    let bob_home = workspace.path().join("bob");
+
+    let (alice_id, alice_spec) = run_init(&alice_home);
+    let (_bob_id, bob_spec) = run_init(&bob_home);
+
+    let mut alice = Command::new(airc_rs())
+        .args([
+            "--home",
+            alice_home.to_str().unwrap(),
+            "--peer",
+            &bob_spec,
+            "lan-listen",
+            "--bind",
+            "127.0.0.1:0",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("alice lan-listen must spawn");
+
+    let alice_stdout = alice.stdout.take().expect("alice stdout");
+    let lines = spawn_line_reader(alice_stdout);
+    let listen_line =
+        wait_for_channel_line_contains(&lines, "listening on", Duration::from_secs(6))
+            .expect("alice must print bound LAN address");
+    let bound_addr = parse_listening_addr(&listen_line);
+
+    let bob_send = Command::new(airc_rs())
+        .args([
+            "--home",
+            bob_home.to_str().unwrap(),
+            "--peer",
+            &alice_spec,
+            "lan-send",
+            "--to",
+            &bound_addr,
+            "--expected-peer",
+            &alice_id,
+            "hello over cli sdk lan",
+        ])
+        .output()
+        .expect("bob lan-send must spawn");
+    assert!(
+        bob_send.status.success(),
+        "bob lan-send failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&bob_send.stdout),
+        String::from_utf8_lossy(&bob_send.stderr),
+    );
+
+    let body_arrived =
+        wait_for_channel_line_contains(&lines, "hello over cli sdk lan", Duration::from_secs(6))
+            .is_some();
+
+    let _ = alice.kill();
+    let _ = alice.wait();
+
+    assert!(
+        body_arrived,
+        "Alice's LAN listener did not print Bob's message within 6s"
+    );
+}
+
+#[test]
 fn rerun_init_returns_same_peer_id() {
     // The persistence pin: `airc-rs init` must be idempotent. The
     // second run reuses the on-disk identity rather than minting a
@@ -205,6 +275,45 @@ fn rerun_init_returns_same_peer_id() {
         first_spec, second_spec,
         "peer_spec must persist across init runs"
     );
+}
+
+fn spawn_line_reader<R: Read + Send + 'static>(reader: R) -> mpsc::Receiver<String> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let buf = BufReader::new(reader);
+        for line in buf.lines().map_while(Result::ok) {
+            if tx.send(line).is_err() {
+                return;
+            }
+        }
+    });
+    rx
+}
+
+fn wait_for_channel_line_contains(
+    rx: &mpsc::Receiver<String>,
+    needle: &str,
+    timeout: Duration,
+) -> Option<String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(line) if line.contains(needle) => return Some(line),
+            Ok(_) => {}
+            Err(_) => {
+                if Instant::now() >= deadline {
+                    return None;
+                }
+            }
+        }
+    }
+}
+
+fn parse_listening_addr(line: &str) -> String {
+    line.strip_prefix("listening on ")
+        .and_then(|rest| rest.split_whitespace().next())
+        .expect("listening line must contain address")
+        .to_string()
 }
 
 /// Block until `reader` yields a line containing `needle`, or the


### PR DESCRIPTION
## Summary
- remove direct LanTcpAdapter/SignedTransport/frame construction from airc-cli LAN commands
- route lan-send through Airc::connect_lan + Airc::say
- route lan-listen through Airc::listen_lan + Airc::subscribe
- add subprocess e2e proof that two airc-rs processes chat over LAN through the SDK route path, without a shared local-fs wire

## Notes
- Tailscale remains optional reachability, not a local dependency. Local-fs and LAN work without it.
- CLI is thinner here; transport ownership stays in airc-lib/airc-transport.

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli
- cargo check --manifest-path Cargo.toml -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-cli --test e2e -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-cli -p airc-lib --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm
- cargo test --manifest-path Cargo.toml -p airc-cli
- bash test/rust_quality_guard.sh
- git diff --check