### PR TITLE
feat(lib): organize route discovery and health

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -33,8 +33,9 @@ use tokio::sync::{broadcast, Mutex};
 
 use crate::error::AircError;
 use crate::room::{self, Room};
-use crate::route_health::TransportHealthSample;
-use crate::route_policy::TransportKind;
+use crate::route::health::TransportHealthTable;
+use crate::route::invite::RouteEndpointTable;
+use crate::route::TransportHealthSample;
 use crate::transport::{FrameSubscriber, WireSubscriber};
 
 const EVENTS_DB_FILENAME: &str = "events.sqlite";
@@ -73,7 +74,8 @@ pub(crate) struct AircInner {
     pub(crate) store: Arc<dyn EventStore>,
     pub(crate) registry: Arc<RwLock<PeerKeyRegistry>>,
     pub(crate) policy: VerificationPolicy,
-    pub(crate) route_health: RwLock<Vec<TransportHealthSample>>,
+    pub(crate) route_health: RwLock<TransportHealthTable>,
+    pub(crate) route_endpoints: RwLock<RouteEndpointTable>,
     pub(crate) lan_tcp: Mutex<Option<LanTcpAdapter>>,
     pub(crate) lan_subscriber: Mutex<Option<FrameSubscriber>>,
     /// Per-wire background subscriber tasks. Spawned lazily on first
@@ -139,9 +141,8 @@ impl Airc {
                 store,
                 registry,
                 policy,
-                route_health: RwLock::new(vec![TransportHealthSample::healthy_direct(
-                    TransportKind::LocalFs,
-                )]),
+                route_health: RwLock::new(TransportHealthTable::local_default()),
+                route_endpoints: RwLock::new(RouteEndpointTable::default()),
                 lan_tcp: Mutex::new(None),
                 lan_subscriber: Mutex::new(None),
                 subscribers: Mutex::new(HashMap::new()),
@@ -165,9 +166,10 @@ impl Airc {
         self.inner.identity.client_id
     }
 
-    /// Replace the route-health view consumed by the resolver. Discovery
-    /// and transport probes own this in production; tests and embedded
-    /// harnesses can pin samples to prove route admission behavior.
+    /// Replace the route-health view consumed by the resolver.
+    /// Discovery and transport probes own this in production; tests
+    /// and embedded harnesses can pin samples to prove route
+    /// admission behavior.
     pub fn replace_transport_health(
         &self,
         samples: impl IntoIterator<Item = TransportHealthSample>,
@@ -177,7 +179,30 @@ impl Airc {
             .route_health
             .write()
             .map_err(|_| AircError::Route("route health lock poisoned".to_string()))?;
-        *route_health = samples.into_iter().collect();
+        route_health.replace(samples);
+        Ok(())
+    }
+
+    /// Snapshot the current route-health samples. Consumers can use
+    /// this for diagnostics without reaching into resolver internals.
+    pub fn transport_health(&self) -> Result<Vec<TransportHealthSample>, AircError> {
+        self.inner
+            .route_health
+            .read()
+            .map_err(|_| AircError::Route("route health lock poisoned".to_string()))
+            .map(|table| table.samples())
+    }
+
+    pub(crate) fn upsert_transport_health(
+        &self,
+        sample: TransportHealthSample,
+    ) -> Result<(), AircError> {
+        let mut route_health = self
+            .inner
+            .route_health
+            .write()
+            .map_err(|_| AircError::Route("route health lock poisoned".to_string()))?;
+        route_health.upsert(sample);
         Ok(())
     }
 

--- a/crates/airc-lib/src/lan.rs
+++ b/crates/airc-lib/src/lan.rs
@@ -10,8 +10,7 @@ use airc_core::PeerId;
 use airc_transport::LanTcpAdapter;
 
 use crate::error::AircError;
-use crate::route_health::TransportHealthSample;
-use crate::route_policy::TransportKind;
+use crate::route::{RouteEndpoint, TransportHealthSample, TransportKind};
 use crate::Airc;
 
 impl Airc {
@@ -24,9 +23,8 @@ impl Airc {
             .await
             .map_err(|error| AircError::Transport(error.to_string()))?;
         self.ensure_lan_subscriber().await?;
-        self.replace_transport_health([TransportHealthSample::healthy_direct(
-            TransportKind::LanTcp,
-        )])?;
+        self.upsert_transport_health(TransportHealthSample::healthy_direct(TransportKind::LanTcp))?;
+        self.upsert_route_endpoint(RouteEndpoint::LanTcp { addr: actual })?;
         Ok(actual)
     }
 
@@ -43,9 +41,7 @@ impl Airc {
             .await
             .map_err(|error| AircError::Transport(error.to_string()))?;
         self.ensure_lan_subscriber().await?;
-        self.replace_transport_health([TransportHealthSample::healthy_direct(
-            TransportKind::LanTcp,
-        )])?;
+        self.upsert_transport_health(TransportHealthSample::healthy_direct(TransportKind::LanTcp))?;
         Ok(())
     }
 

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -28,10 +28,7 @@ mod messaging;
 mod peers;
 pub mod registry;
 pub mod room;
-mod route_execution;
-pub mod route_health;
-pub mod route_policy;
-pub mod route_resolver;
+pub mod route;
 mod stream;
 mod time;
 mod transport;
@@ -42,11 +39,11 @@ pub use error::AircError;
 pub use peers::EnrolledPeer;
 pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use room::Room;
-pub use route_health::{TransportHealthSample, TransportHealthState};
-pub use route_policy::{
-    RouteClass, RouteDecision, RoutePolicy, TransportCandidate, TransportKind, TransportRole,
+pub use route::{
+    InviteBeacon, RouteClass, RouteDecision, RouteEndpoint, RoutePolicy, TransportCandidate,
+    TransportHealthSample, TransportHealthState, TransportHealthTable, TransportKind,
+    TransportResolver, TransportRole, TransportRoute,
 };
-pub use route_resolver::{TransportResolver, TransportRoute};
 pub use stream::{EventFilter, EventStream, FilteredEventStream, LiveLag};
 pub use work::{
     AllocateWorkspace, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard, CreateWorkCard,

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -3,8 +3,7 @@ use airc_protocol::{Envelope, Frame, FrameKind, Signature};
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::error::AircError;
-use crate::route_policy::{RouteClass, RouteDecision};
-use crate::route_resolver::TransportResolver;
+use crate::route::{RouteClass, RouteDecision, TransportResolver, TransportRoute};
 use crate::stream::{EventFilter, EventStream, FilteredEventStream};
 use crate::time::now_ms;
 use crate::Airc;
@@ -59,14 +58,14 @@ impl Airc {
         Ok(event_id)
     }
 
-    fn resolve_send_route(&self, kind: FrameKind) -> Result<crate::TransportRoute, AircError> {
+    fn resolve_send_route(&self, kind: FrameKind) -> Result<TransportRoute, AircError> {
         let class = route_class_for_frame(kind);
         let samples = self
             .inner
             .route_health
             .read()
             .map_err(|_| AircError::Route("route health lock poisoned".to_string()))?
-            .clone();
+            .samples();
         TransportResolver::from_health(samples)
             .resolve(class)
             .map_err(format_route_refusal)

--- a/crates/airc-lib/src/registry.rs
+++ b/crates/airc-lib/src/registry.rs
@@ -12,6 +12,7 @@ use std::sync::RwLock;
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use airc_core::PeerId;
@@ -50,7 +51,7 @@ impl std::fmt::Display for PeerSpecError {
 impl std::error::Error for PeerSpecError {}
 
 /// A parsed peer spec: which peer it identifies + their 32-byte pubkey.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PeerSpec {
     pub peer_id: PeerId,
     pub pubkey: [u8; 32],

--- a/crates/airc-lib/src/route/execution.rs
+++ b/crates/airc-lib/src/route/execution.rs
@@ -9,7 +9,7 @@ use airc_protocol::Frame;
 use airc_transport::{LocalFsAdapter, Transport};
 
 use crate::error::AircError;
-use crate::route_policy::TransportKind;
+use crate::route::policy::TransportKind;
 use crate::{Airc, Room};
 
 impl Airc {

--- a/crates/airc-lib/src/route/health.rs
+++ b/crates/airc-lib/src/route/health.rs
@@ -4,7 +4,7 @@
 //! candidates. Keeping the conversion explicit prevents "transport
 //! exists" from being confused with "transport is usable now."
 
-use crate::route_policy::{TransportCandidate, TransportKind, TransportRole};
+use crate::route::policy::{TransportCandidate, TransportKind, TransportRole};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TransportHealthState {
@@ -55,6 +55,40 @@ impl TransportHealthSample {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransportHealthTable {
+    samples: Vec<TransportHealthSample>,
+}
+
+impl TransportHealthTable {
+    pub fn local_default() -> Self {
+        Self {
+            samples: vec![TransportHealthSample::healthy_direct(
+                TransportKind::LocalFs,
+            )],
+        }
+    }
+
+    pub fn replace(&mut self, samples: impl IntoIterator<Item = TransportHealthSample>) {
+        self.samples = samples.into_iter().collect();
+    }
+
+    pub fn upsert(&mut self, sample: TransportHealthSample) {
+        match self
+            .samples
+            .iter_mut()
+            .find(|existing| existing.kind == sample.kind && existing.role == sample.role)
+        {
+            Some(existing) => *existing = sample,
+            None => self.samples.push(sample),
+        }
+    }
+
+    pub fn samples(&self) -> Vec<TransportHealthSample> {
+        self.samples.clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,5 +121,25 @@ mod tests {
         .candidate();
 
         assert!(!candidate.healthy);
+    }
+
+    #[test]
+    fn health_table_upsert_replaces_same_kind_and_role() {
+        let mut table = TransportHealthTable::local_default();
+        table.upsert(TransportHealthSample::healthy_direct(TransportKind::LanTcp));
+        table.upsert(TransportHealthSample::down(
+            TransportKind::LanTcp,
+            TransportRole::Direct,
+        ));
+
+        let samples = table.samples();
+        assert_eq!(samples.len(), 2);
+        assert_eq!(
+            samples
+                .iter()
+                .find(|sample| sample.kind == TransportKind::LanTcp)
+                .map(|sample| sample.state),
+            Some(TransportHealthState::Down)
+        );
     }
 }

--- a/crates/airc-lib/src/route/invite.rs
+++ b/crates/airc-lib/src/route/invite.rs
@@ -1,0 +1,165 @@
+//! Invite/rendezvous payloads.
+//!
+//! Gists and other public rendezvous mechanisms should publish this
+//! kind of connection metadata, not runtime messages. Runtime traffic
+//! moves over admitted live transports after a peer consumes the
+//! invite.
+
+use std::net::SocketAddr;
+
+use airc_core::PeerId;
+use serde::{Deserialize, Serialize};
+
+use crate::error::AircError;
+use crate::registry::PeerSpec;
+use crate::Airc;
+
+pub const INVITE_BEACON_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RouteEndpoint {
+    LanTcp { addr: SocketAddr },
+    TailscaleTcp { addr: SocketAddr },
+    Relay { url: String },
+    Reticulum { destination: String },
+    WebRtcSignaling { url: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InviteBeacon {
+    pub schema_version: u16,
+    pub peer_id: PeerId,
+    pub peer_spec: PeerSpec,
+    pub endpoints: Vec<RouteEndpoint>,
+}
+
+impl InviteBeacon {
+    pub fn new(peer_id: PeerId, peer_spec: PeerSpec, endpoints: Vec<RouteEndpoint>) -> Self {
+        Self {
+            schema_version: INVITE_BEACON_SCHEMA_VERSION,
+            peer_id,
+            peer_spec,
+            endpoints,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RouteEndpointTable {
+    endpoints: Vec<RouteEndpoint>,
+}
+
+impl RouteEndpointTable {
+    pub fn upsert(&mut self, endpoint: RouteEndpoint) {
+        match self
+            .endpoints
+            .iter_mut()
+            .find(|existing| same_endpoint_kind(existing, &endpoint))
+        {
+            Some(existing) => *existing = endpoint,
+            None => self.endpoints.push(endpoint),
+        }
+    }
+
+    pub fn endpoints(&self) -> Vec<RouteEndpoint> {
+        self.endpoints.clone()
+    }
+}
+
+impl Airc {
+    pub fn route_endpoints(&self) -> Result<Vec<RouteEndpoint>, AircError> {
+        self.inner
+            .route_endpoints
+            .read()
+            .map_err(|_| AircError::Route("route endpoints lock poisoned".to_string()))
+            .map(|table| table.endpoints())
+    }
+
+    pub fn invite_beacon(&self) -> Result<InviteBeacon, AircError> {
+        Ok(InviteBeacon::new(
+            self.inner.identity.peer_id,
+            PeerSpec {
+                peer_id: self.inner.identity.peer_id,
+                pubkey: self.inner.identity.keypair.public_bytes(),
+            },
+            self.route_endpoints()?,
+        ))
+    }
+
+    pub(crate) fn upsert_route_endpoint(&self, endpoint: RouteEndpoint) -> Result<(), AircError> {
+        let mut endpoints = self
+            .inner
+            .route_endpoints
+            .write()
+            .map_err(|_| AircError::Route("route endpoints lock poisoned".to_string()))?;
+        endpoints.upsert(endpoint);
+        Ok(())
+    }
+}
+
+fn same_endpoint_kind(left: &RouteEndpoint, right: &RouteEndpoint) -> bool {
+    matches!(
+        (left, right),
+        (RouteEndpoint::LanTcp { .. }, RouteEndpoint::LanTcp { .. })
+            | (
+                RouteEndpoint::TailscaleTcp { .. },
+                RouteEndpoint::TailscaleTcp { .. }
+            )
+            | (RouteEndpoint::Relay { .. }, RouteEndpoint::Relay { .. })
+            | (
+                RouteEndpoint::Reticulum { .. },
+                RouteEndpoint::Reticulum { .. }
+            )
+            | (
+                RouteEndpoint::WebRtcSignaling { .. },
+                RouteEndpoint::WebRtcSignaling { .. }
+            )
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_protocol::PeerKeypair;
+
+    #[test]
+    fn invite_beacon_serializes_connection_metadata_without_messages() {
+        let keypair = PeerKeypair::generate();
+        let peer_id = PeerId::new();
+        let beacon = InviteBeacon::new(
+            peer_id,
+            PeerSpec {
+                peer_id,
+                pubkey: keypair.public_bytes(),
+            },
+            vec![RouteEndpoint::LanTcp {
+                addr: SocketAddr::from(([127, 0, 0, 1], 7474)),
+            }],
+        );
+
+        let json = serde_json::to_string(&beacon).expect("beacon json");
+
+        assert!(json.contains("lan_tcp"));
+        assert!(json.contains("127.0.0.1:7474"));
+        assert!(!json.contains("message"));
+    }
+
+    #[test]
+    fn endpoint_table_replaces_same_transport_kind() {
+        let mut table = RouteEndpointTable::default();
+        table.upsert(RouteEndpoint::LanTcp {
+            addr: SocketAddr::from(([127, 0, 0, 1], 1000)),
+        });
+        table.upsert(RouteEndpoint::LanTcp {
+            addr: SocketAddr::from(([127, 0, 0, 1], 2000)),
+        });
+
+        assert_eq!(
+            table.endpoints(),
+            vec![RouteEndpoint::LanTcp {
+                addr: SocketAddr::from(([127, 0, 0, 1], 2000))
+            }]
+        );
+    }
+}

--- a/crates/airc-lib/src/route/mod.rs
+++ b/crates/airc-lib/src/route/mod.rs
@@ -1,0 +1,20 @@
+//! Routing, discovery, and invite/rendezvous model.
+//!
+//! This subsystem owns route policy, health, endpoint discovery,
+//! invite beacons, resolver selection, and execution of selected
+//! routes. App and CLI layers consume this through `Airc`; they do
+//! not construct transport adapters or route frames themselves.
+
+pub mod health;
+pub mod invite;
+pub mod policy;
+pub mod resolver;
+
+pub(crate) mod execution;
+
+pub use health::{TransportHealthSample, TransportHealthState, TransportHealthTable};
+pub use invite::{InviteBeacon, RouteEndpoint};
+pub use policy::{
+    RouteClass, RouteDecision, RoutePolicy, TransportCandidate, TransportKind, TransportRole,
+};
+pub use resolver::{TransportResolver, TransportRoute};

--- a/crates/airc-lib/src/route/policy.rs
+++ b/crates/airc-lib/src/route/policy.rs
@@ -135,8 +135,8 @@ fn priority(class: RouteClass, kind: TransportKind, role: TransportRole) -> u8 {
         RouteClass::ControlInteractive
         | RouteClass::DataInteractive
         | RouteClass::PresenceEphemeral => match kind {
-            TransportKind::LocalFs => 0,
-            TransportKind::LanTcp => 1,
+            TransportKind::LanTcp => 0,
+            TransportKind::LocalFs => 1,
             TransportKind::Tailscale => 2,
             TransportKind::Udp => 3,
             TransportKind::WebRtcDataChannel => 4,
@@ -155,8 +155,8 @@ fn priority(class: RouteClass, kind: TransportKind, role: TransportRole) -> u8 {
             TransportKind::Ssh | TransportKind::GhGist => 255,
         },
         RouteClass::DataBulk => match kind {
-            TransportKind::LocalFs => 0,
-            TransportKind::LanTcp => 1,
+            TransportKind::LanTcp => 0,
+            TransportKind::LocalFs => 1,
             TransportKind::Tailscale => 2,
             TransportKind::Reticulum => 3,
             TransportKind::Relay => 4,
@@ -166,8 +166,8 @@ fn priority(class: RouteClass, kind: TransportKind, role: TransportRole) -> u8 {
             | TransportKind::GhGist => 255,
         },
         RouteClass::PeerRendezvous => match (kind, role) {
-            (TransportKind::LocalFs, TransportRole::Direct) => 0,
-            (TransportKind::LanTcp, TransportRole::Direct) => 1,
+            (TransportKind::LanTcp, TransportRole::Direct) => 0,
+            (TransportKind::LocalFs, TransportRole::Direct) => 1,
             (TransportKind::Tailscale, TransportRole::Direct) => 2,
             (TransportKind::Reticulum, TransportRole::Direct) => 3,
             (TransportKind::Reticulum, TransportRole::Rendezvous) => 4,
@@ -250,6 +250,20 @@ mod tests {
             RouteClass::PeerRendezvous,
             [
                 candidate(TransportKind::GhGist, TransportRole::Rendezvous),
+                candidate(TransportKind::LanTcp, TransportRole::Direct),
+            ],
+        );
+
+        assert_eq!(decision, RouteDecision::Selected(TransportKind::LanTcp));
+    }
+
+    #[test]
+    fn live_peer_delivery_prefers_lan_over_local_storage_when_both_are_healthy() {
+        let policy = RoutePolicy;
+        let decision = policy.choose(
+            RouteClass::DataInteractive,
+            [
+                candidate(TransportKind::LocalFs, TransportRole::Direct),
                 candidate(TransportKind::LanTcp, TransportRole::Direct),
             ],
         );

--- a/crates/airc-lib/src/route/resolver.rs
+++ b/crates/airc-lib/src/route/resolver.rs
@@ -6,8 +6,8 @@
 //! slices can add health probes/discovery without changing the rule
 //! that GitHub is invite/rendezvous only.
 
-use crate::route_health::TransportHealthSample;
-use crate::route_policy::{
+use crate::route::health::TransportHealthSample;
+use crate::route::policy::{
     RouteClass, RouteDecision, RoutePolicy, TransportCandidate, TransportKind,
 };
 
@@ -57,8 +57,8 @@ impl TransportResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::route_health::{TransportHealthSample, TransportHealthState};
-    use crate::route_policy::{TransportKind::*, TransportRole};
+    use crate::route::health::{TransportHealthSample, TransportHealthState};
+    use crate::route::policy::{TransportKind::*, TransportRole};
 
     fn candidate(kind: TransportKind, role: TransportRole) -> TransportCandidate {
         TransportCandidate {

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -10,7 +10,7 @@
 use std::{net::SocketAddr, time::Duration};
 
 use airc_lib::{
-    Airc, Body, EventFilter, HeaderFilter, Headers, PeerSpec, TranscriptKind,
+    Airc, Body, EventFilter, HeaderFilter, Headers, PeerSpec, RouteEndpoint, TranscriptKind,
     TransportHealthSample, TransportKind, TransportRole,
 };
 use futures::stream::StreamExt;
@@ -235,6 +235,48 @@ async fn two_embedded_handles_chat_over_lan_without_cli() {
         .filter_map(|event| event.body.as_ref().and_then(Body::as_text))
         .collect();
     assert_eq!(bodies, vec!["hello over sdk lan"]);
+}
+
+#[tokio::test]
+async fn lan_listen_feeds_health_and_invite_endpoint_without_tailscale() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+
+    let bound = airc
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+
+    let health = airc.transport_health().unwrap();
+    assert!(
+        health
+            .iter()
+            .any(|sample| sample.kind == TransportKind::LocalFs),
+        "local route remains present"
+    );
+    assert!(
+        health.iter().any(|sample| {
+            sample.kind == TransportKind::LanTcp
+                && sample.state == airc_lib::TransportHealthState::Healthy
+        }),
+        "LAN listen must feed route health"
+    );
+
+    let beacon = airc.invite_beacon().unwrap();
+    assert_eq!(beacon.peer_id, airc.peer_id());
+    assert!(
+        beacon
+            .endpoints
+            .contains(&RouteEndpoint::LanTcp { addr: bound }),
+        "invite beacon publishes connection metadata"
+    );
+    assert!(
+        beacon
+            .endpoints
+            .iter()
+            .all(|endpoint| !matches!(endpoint, RouteEndpoint::TailscaleTcp { .. })),
+        "Tailscale must not be invented for local LAN operation"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- move route policy/resolver/execution/health/invite into a single route subsystem
- add TransportHealthTable so health updates are named state instead of raw Vec replacement
- have LAN listen/connect feed route health automatically while preserving local operation without Tailscale
- add InviteBeacon + RouteEndpoint metadata so gist/rendezvous can publish connection info, not messages
- prefer healthy LAN over local-fs for live peer delivery when both routes are available

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib
- cargo test --manifest-path Cargo.toml -p airc-lib --test embedding_smoke -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-lib route -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-lib --lib -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm
- cargo test --manifest-path Cargo.toml -p airc-lib
- cargo test --manifest-path Cargo.toml -p airc-cli --test e2e -- --nocapture
- cargo fmt --manifest-path Cargo.toml --all --check
- git diff --check