### PR TITLE
docs: update route requirements status

### DIFF
--- a/docs/architecture/INVITE-ROUTING-ARCHITECTURE.md
+++ b/docs/architecture/INVITE-ROUTING-ARCHITECTURE.md
@@ -244,18 +244,31 @@ diagnosis.
 
 ## Migration Slices
 
-1. **Policy constants:** encode route classes and gh-gist admissibility in Rust.
-2. **Invite beacon type:** move gist payloads to a signed invite structure.
-3. **Resolver gate:** route plans fail closed when no admissible data route
-   exists; no implicit gist data path.
-4. **Doctor split:** expose live bus health separately from invite health.
-5. **Local route proof:** two local agents exchange events without any GitHub
-   call in the publish/subscribe path.
-6. **Tailscale/LAN proof:** same API, remote peer, no consumer changes.
-7. **Continuum integration proof:** one Continuum room uses AIRC subscribe/replay
-   for chat/events while retaining Continuum-owned payload semantics.
-8. **OpenClaw/Hermes adapter proof:** native clients appear as peers/channels
-   through adapter-owned schemas, not transport-specific hacks.
+1. **Done: policy constants.** Route classes and gh-gist admissibility live in
+   Rust under `airc-lib::route`; gh-gist is invite/rendezvous only.
+2. **Done: resolver gate.** Runtime data fails closed when no admissible live
+   route exists; no implicit gist data path.
+3. **Done: local route proof.** Local-fs and LAN subprocess tests exchange
+   events without GitHub in the publish/subscribe path.
+4. **Done: SDK route execution for LAN/Tailscale-class TCP.** `airc-lib::send`
+   resolves routes and executes local-fs or TLS LAN/Tailscale-class TCP through
+   adapters. Tailscale is optional reachability, not required for local use.
+5. **Done: route subsystem organization.** Health, policy, resolver, execution,
+   and invite metadata live under `crates/airc-lib/src/route/`.
+6. **Partial: route health and invite beacon.** `TransportHealthTable` and
+   `InviteBeacon` exist; LAN listen/connect feed health/endpoints. Gist still
+   needs to publish this invite structure instead of legacy message content.
+7. **Partial: CLI path through SDK.** Local send/listen and LAN send/listen use
+   `airc-lib`; remaining user-facing commands must continue moving onto SDK
+   surfaces instead of owning policy.
+8. **Next: discovery.** Add real local/LAN discovery feeding `TransportHealthTable`
+   and route endpoints without manual peer/address flags.
+9. **Next: relay.** Build `airc-relay` and relay adapter for different tailnets,
+   NAT boundaries, and intermittent peers.
+10. **Next: UDP/WebRTC.** Build UDP and WebRTC datachannel adapters for low-latency
+    control/signaling paths needed before Continuum live-mode integration.
+11. **Next: integration proofs.** Continuum rooms, OpenClaw, Hermes, and opencode
+    must embed AIRC through SDK/contracts with no transport-specific hacks.
 
 ## Non-Goals
 

--- a/docs/rust-substrate-grievances-and-gaps.md
+++ b/docs/rust-substrate-grievances-and-gaps.md
@@ -625,10 +625,13 @@ Verified strengths:
 Critical remaining gaps:
 
 - The public `airc` product path now routes through Rust for identity, config, bearer, logs, monitor formatting, Codex hooks, queue/work helpers, and install-time setup. Remaining shell should keep shrinking toward install/bootstrap only.
-- `airc-lib` does not yet provide a live subscription stream or daemon-attached mode. The embedding smoke test manually appends to the store after `say()` because pure embedding has no background subscriber.
-- `airc-cli` still owns too much policy. The daemon split helped, but command handlers still build registries, manage rooms, open stores, wire transports, and print user semantics.
+- `airc-lib` now owns in-process send/subscribe/replay, route selection, local-fs execution, LAN/Tailscale-class TCP execution, route health, and invite endpoint metadata. Daemon-attached mode and persistent subscription hub are still not complete.
+- `airc-cli` is thinner for local and LAN send/listen, but it still owns too much product policy in other commands. Remaining user-facing commands must move onto SDK surfaces instead of constructing substrate state directly.
 - Peer trust rotation is still too permissive: `peers_store::add` silently replaces a pubkey for the same `PeerId`. That must become an explicit signed rotation/audit operation.
-- There is no transport resolver yet. Local-fs and LAN-TCP exist, but consumers cannot ask for "best route to peer/channel" across same-host, LAN, Tailscale, relay, or migration transports.
+- Route resolver basics exist, and LAN listen/connect feed health. Missing: real discovery/probing that populates route health/endpoints for same-host, LAN, optional Tailscale, relay, UDP/WebRTC, and Reticulum without manual flags.
+- Gist is modeled as invite/rendezvous only, but the actual gist publication flow still needs to publish signed invite/endpoint metadata instead of legacy message content.
+- Relay for different tailnets/NAT is not implemented. This is required before cross-grid and unreliable-network claims are credible.
+- UDP and WebRTC datachannel adapters are modeled but not implemented. They are required before Continuum live-mode, game, and realtime control integration can be considered ready.
 - Presence/live roster/responder-ready state is not implemented as a Rust projection.
 - Queue/lane/workspace/kanban are still legacy operational surfaces, not Rust substrate objects.
 - No Continuum/OpenClaw/Hermes/opencode Rust embedding examples prove future integrations.


### PR DESCRIPTION
## Summary
- mark completed route work: policy, resolver gate, local/LAN proof, SDK LAN execution, route subsystem organization
- record partial work: route health/invite beacon and CLI migration through airc-lib
- list remaining requirements: discovery/probing, gist invite publication, relay, UDP/WebRTC adapters, integration proofs

## Verification
- git diff --check