### PR TITLE
feat(lib): discover local route health

### DIFF
--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -40,9 +40,9 @@ pub use peers::EnrolledPeer;
 pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use room::Room;
 pub use route::{
-    InviteBeacon, RouteClass, RouteDecision, RouteEndpoint, RoutePolicy, TransportCandidate,
-    TransportHealthSample, TransportHealthState, TransportHealthTable, TransportKind,
-    TransportResolver, TransportRole, TransportRoute,
+    InviteBeacon, RouteClass, RouteDecision, RouteDiscoverySnapshot, RouteEndpoint, RoutePolicy,
+    TransportCandidate, TransportHealthSample, TransportHealthState, TransportHealthTable,
+    TransportKind, TransportResolver, TransportRole, TransportRoute,
 };
 pub use stream::{EventFilter, EventStream, FilteredEventStream, LiveLag};
 pub use work::{

--- a/crates/airc-lib/src/route/discovery.rs
+++ b/crates/airc-lib/src/route/discovery.rs
@@ -1,0 +1,72 @@
+//! Route discovery and health ingestion.
+//!
+//! Discovery reads substrate-owned state and turns it into route
+//! health/endpoints. Consumers should not hand-edit route health just
+//! to make normal local/LAN operation work.
+
+use airc_core::PeerId;
+
+use crate::error::AircError;
+use crate::route::health::TransportHealthSample;
+use crate::route::invite::RouteEndpoint;
+use crate::route::policy::TransportKind;
+use crate::Airc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteDiscoverySnapshot {
+    pub health: Vec<TransportHealthSample>,
+    pub endpoints: Vec<RouteEndpoint>,
+    pub connected_lan_peers: Vec<PeerId>,
+}
+
+impl Airc {
+    /// Refresh route health from substrate-owned discovery state.
+    ///
+    /// This does not invent Tailscale, relay, UDP, or WebRTC routes.
+    /// Those adapters feed this table when their discovery/probes
+    /// exist. Today it ingests:
+    ///
+    /// - local-fs: always healthy for the current local store/wire path
+    /// - LAN-TCP: healthy when there is a bound LAN endpoint or an
+    ///   active LAN peer connection
+    pub async fn refresh_route_discovery(&self) -> Result<RouteDiscoverySnapshot, AircError> {
+        self.upsert_transport_health(TransportHealthSample::healthy_direct(
+            TransportKind::LocalFs,
+        ))?;
+
+        let endpoints = self.route_endpoints()?;
+        let lan_has_endpoint = endpoints
+            .iter()
+            .any(|endpoint| matches!(endpoint, RouteEndpoint::LanTcp { .. }));
+        let connected_lan_peers = self.connected_lan_peers().await;
+        if lan_has_endpoint || !connected_lan_peers.is_empty() {
+            self.upsert_transport_health(TransportHealthSample::healthy_direct(
+                TransportKind::LanTcp,
+            ))?;
+        }
+
+        Ok(RouteDiscoverySnapshot {
+            health: self.transport_health()?,
+            endpoints,
+            connected_lan_peers,
+        })
+    }
+
+    /// Snapshot the last known discovery state without mutating
+    /// route health.
+    pub async fn route_discovery_snapshot(&self) -> Result<RouteDiscoverySnapshot, AircError> {
+        Ok(RouteDiscoverySnapshot {
+            health: self.transport_health()?,
+            endpoints: self.route_endpoints()?,
+            connected_lan_peers: self.connected_lan_peers().await,
+        })
+    }
+
+    async fn connected_lan_peers(&self) -> Vec<PeerId> {
+        let adapter = self.inner.lan_tcp.lock().await.clone();
+        match adapter {
+            Some(adapter) => adapter.connected_peers().await,
+            None => Vec::new(),
+        }
+    }
+}

--- a/crates/airc-lib/src/route/mod.rs
+++ b/crates/airc-lib/src/route/mod.rs
@@ -5,6 +5,7 @@
 //! routes. App and CLI layers consume this through `Airc`; they do
 //! not construct transport adapters or route frames themselves.
 
+pub mod discovery;
 pub mod health;
 pub mod invite;
 pub mod policy;
@@ -12,6 +13,7 @@ pub mod resolver;
 
 pub(crate) mod execution;
 
+pub use discovery::RouteDiscoverySnapshot;
 pub use health::{TransportHealthSample, TransportHealthState, TransportHealthTable};
 pub use invite::{InviteBeacon, RouteEndpoint};
 pub use policy::{

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -280,6 +280,37 @@ async fn lan_listen_feeds_health_and_invite_endpoint_without_tailscale() {
 }
 
 #[tokio::test]
+async fn discovery_refresh_is_local_first_without_github_or_tailscale() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+
+    airc.replace_transport_health([]).unwrap();
+    let snapshot = airc.refresh_route_discovery().await.unwrap();
+
+    assert!(
+        snapshot
+            .health
+            .iter()
+            .any(|sample| sample.kind == TransportKind::LocalFs),
+        "local-fs must be discovered without GitHub"
+    );
+    assert!(
+        snapshot
+            .health
+            .iter()
+            .all(|sample| sample.kind != TransportKind::GhGist),
+        "GitHub must not appear in local discovery"
+    );
+    assert!(
+        snapshot
+            .health
+            .iter()
+            .all(|sample| sample.kind != TransportKind::Tailscale),
+        "Tailscale is optional reachability, not a local dependency"
+    );
+}
+
+#[tokio::test]
 async fn filtered_event_queries_match_kind_and_headers_without_body_parse() {
     let home = TempDir::new().unwrap();
     let airc = Airc::open(home.path()).await.unwrap();


### PR DESCRIPTION
## Summary
- add route::discovery with RouteDiscoverySnapshot
- add Airc::refresh_route_discovery and Airc::route_discovery_snapshot
- ingest local-fs health without manual overrides, GitHub, or Tailscale
- ingest LAN health from existing bound endpoints / active LAN peers
- add embedding proof that local discovery is GitHub-free and Tailscale-free

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib
- cargo test --manifest-path Cargo.toml -p airc-lib --test embedding_smoke -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-lib route -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-lib --lib -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm
- cargo test --manifest-path Cargo.toml -p airc-lib
- git diff --check