### PR TITLE
feat(lib): attach SDK to daemon IPC

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use std::sync::RwLock;
 
 use airc_core::{ClientId, PeerId, TranscriptEvent};
-use airc_daemon::{peers_store, LocalIdentity};
+use airc_daemon::{peers_store, DaemonClient, LocalIdentity};
 use airc_protocol::{PeerKeyRegistry, VerificationPolicy};
 use airc_store::{EventStore, SqliteEventStore};
 use airc_transport::LanTcpAdapter;
@@ -72,6 +72,7 @@ pub(crate) struct AircInner {
     pub(crate) home: PathBuf,
     pub(crate) identity: LocalIdentity,
     pub(crate) store: Arc<dyn EventStore>,
+    pub(crate) daemon_client: Option<Arc<DaemonClient>>,
     pub(crate) registry: Arc<RwLock<PeerKeyRegistry>>,
     pub(crate) policy: VerificationPolicy,
     pub(crate) route_health: RwLock<TransportHealthTable>,
@@ -101,6 +102,18 @@ impl Airc {
     /// test harness needs a different stance.
     pub async fn open(home: impl Into<PathBuf>) -> Result<Self, AircError> {
         Self::open_with_policy(home, VerificationPolicy::Strict).await
+    }
+
+    /// Attach to an already-running daemon. The handle still opens
+    /// local identity/store state so consumers can inspect identity,
+    /// room, and replay state through the same `Airc` facade, but
+    /// send/inbox operations go through daemon IPC.
+    pub async fn attach(
+        home: impl Into<PathBuf>,
+        socket: impl Into<PathBuf>,
+    ) -> Result<Self, AircError> {
+        let airc = Self::open(home).await?;
+        Ok(airc.with_daemon_client(DaemonClient::new(socket.into())))
     }
 
     /// Variant of [`open`] that lets the caller pin the
@@ -140,6 +153,7 @@ impl Airc {
                 home,
                 identity,
                 store,
+                daemon_client: None,
                 registry,
                 policy,
                 route_health: RwLock::new(TransportHealthTable::local_default()),
@@ -166,6 +180,31 @@ impl Airc {
     /// Return the per-session client identifier.
     pub fn client_id(&self) -> ClientId {
         self.inner.identity.client_id
+    }
+
+    pub fn is_daemon_attached(&self) -> bool {
+        self.inner.daemon_client.is_some()
+    }
+
+    fn with_daemon_client(&self, client: DaemonClient) -> Self {
+        let inner = AircInner {
+            home: self.inner.home.clone(),
+            identity: self.inner.identity.clone(),
+            store: self.inner.store.clone(),
+            daemon_client: Some(Arc::new(client)),
+            registry: self.inner.registry.clone(),
+            policy: self.inner.policy,
+            route_health: RwLock::new(TransportHealthTable::local_default()),
+            route_endpoints: RwLock::new(RouteEndpointTable::default()),
+            imported_invites: RwLock::new(ImportedInviteTable::default()),
+            lan_tcp: Mutex::new(None),
+            lan_subscriber: Mutex::new(None),
+            subscribers: Mutex::new(HashMap::new()),
+            live_tx: self.inner.live_tx.clone(),
+        };
+        Self {
+            inner: Arc::new(inner),
+        }
     }
 
     /// Replace the route-health view consumed by the resolver.

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -1,0 +1,86 @@
+//! Daemon-attached SDK mode.
+//!
+//! Consumers still use `Airc`; attach mode routes operations through
+//! the daemon's typed IPC client instead of making apps construct
+//! daemon requests directly.
+
+use airc_core::{EventId, TranscriptCursor, TranscriptEvent};
+use airc_daemon::{InboxRequest, SendRequest, SubscribeRequest};
+
+use crate::error::AircError;
+use crate::room::Room;
+use crate::Airc;
+
+impl Airc {
+    pub(crate) fn daemon_client(&self) -> Option<&airc_daemon::DaemonClient> {
+        self.inner.daemon_client.as_deref()
+    }
+
+    pub(crate) async fn daemon_send_text(
+        &self,
+        room: &Room,
+        text: &str,
+    ) -> Result<EventId, AircError> {
+        self.daemon_client()
+            .ok_or_else(|| AircError::Route("daemon client is not attached".to_string()))?
+            .send(SendRequest {
+                wire: room.wire.clone(),
+                channel: room.channel.as_uuid(),
+                text: text.to_string(),
+            })
+            .await?;
+
+        // Current daemon Send response is an ack-only protocol. Until
+        // the daemon returns the event id, expose a local id so the
+        // API remains fallible/synchronous without inventing a second
+        // response path in the CLI.
+        Ok(EventId::new())
+    }
+
+    pub(crate) async fn daemon_page_recent(
+        &self,
+        room: &Room,
+        limit: usize,
+    ) -> Result<Vec<TranscriptEvent>, AircError> {
+        self.daemon_subscribe_room(room).await?;
+        Ok(self
+            .daemon_client()
+            .ok_or_else(|| AircError::Route("daemon client is not attached".to_string()))?
+            .inbox(InboxRequest {
+                since: None,
+                channel: Some(room.channel),
+                limit: Some(limit),
+            })
+            .await?
+            .events)
+    }
+
+    pub(crate) async fn daemon_resume_from(
+        &self,
+        room: &Room,
+        cursor: &TranscriptCursor,
+        limit: usize,
+    ) -> Result<Vec<TranscriptEvent>, AircError> {
+        self.daemon_subscribe_room(room).await?;
+        Ok(self
+            .daemon_client()
+            .ok_or_else(|| AircError::Route("daemon client is not attached".to_string()))?
+            .inbox(InboxRequest {
+                since: Some(cursor.clone()),
+                channel: Some(room.channel),
+                limit: Some(limit),
+            })
+            .await?
+            .events)
+    }
+
+    pub(crate) async fn daemon_subscribe_room(&self, room: &Room) -> Result<(), AircError> {
+        self.daemon_client()
+            .ok_or_else(|| AircError::Route("daemon client is not attached".to_string()))?
+            .subscribe(SubscribeRequest {
+                wire: room.wire.clone(),
+            })
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -34,6 +34,9 @@ pub enum AircError {
     #[error("peers store: {0}")]
     PeersStore(#[from] airc_daemon::peers_store::PeersStoreError),
 
+    #[error("daemon client: {0}")]
+    DaemonClient(#[from] airc_daemon::ClientError),
+
     /// Transport-side I/O. Stringified because LocalFsAdapter and
     /// LanTcpAdapter return different concrete error types and a
     /// blanket `#[from]` per backend is more weight than it's worth

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -22,6 +22,7 @@
 #![deny(unsafe_code)]
 
 pub mod airc;
+mod daemon;
 pub mod error;
 mod lan;
 mod messaging;

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -11,6 +11,10 @@ use crate::Airc;
 impl Airc {
     /// Send a plain-text message to the current room.
     pub async fn say(&self, text: &str) -> Result<EventId, AircError> {
+        if self.is_daemon_attached() {
+            let room = self.current_room().await?;
+            return self.daemon_send_text(&room, text).await;
+        }
         self.send(Body::text(text), Headers::new()).await
     }
 
@@ -109,6 +113,9 @@ impl Airc {
     /// Fetch the most recent `limit` events from the current room.
     pub async fn page_recent(&self, limit: usize) -> Result<Vec<TranscriptEvent>, AircError> {
         let room = self.current_room().await?;
+        if self.is_daemon_attached() {
+            return self.daemon_page_recent(&room, limit).await;
+        }
         self.ensure_wire_subscriber(&room.wire).await?;
         Ok(self
             .inner
@@ -143,6 +150,9 @@ impl Airc {
         limit: usize,
     ) -> Result<Vec<TranscriptEvent>, AircError> {
         let room = self.current_room().await?;
+        if self.is_daemon_attached() {
+            return self.daemon_resume_from(&room, cursor, limit).await;
+        }
         Ok(self
             .inner
             .store

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -9,10 +9,13 @@
 
 use std::{net::SocketAddr, time::Duration};
 
+use airc_daemon::{DaemonState, LocalIdentity};
 use airc_lib::{
     Airc, Body, EventFilter, HeaderFilter, Headers, PeerSpec, RouteEndpoint, TranscriptKind,
     TransportHealthSample, TransportKind, TransportRole,
 };
+use airc_protocol::{PeerKeyRegistry, VerificationPolicy};
+use airc_store::{EventStore, SqliteEventStore};
 use futures::stream::StreamExt;
 use tempfile::TempDir;
 
@@ -44,6 +47,56 @@ async fn wait_for_events(
     }
 }
 
+async fn wait_for_text(airc: &Airc, text: &str, timeout: Duration) -> airc_lib::TranscriptEvent {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let page = airc.page_recent(64).await.unwrap();
+        if let Some(event) = page
+            .into_iter()
+            .find(|event| event.body.as_ref().and_then(Body::as_text) == Some(text))
+        {
+            return event;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("wait_for_text: did not see {text:?} in {timeout:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+fn unique_socket() -> std::path::PathBuf {
+    let suffix = uuid::Uuid::new_v4().as_u128() as u32;
+    std::path::PathBuf::from(format!("/tmp/airclib{:x}.sock", suffix))
+}
+
+async fn spawn_daemon(home: &std::path::Path) -> (tokio::task::JoinHandle<()>, std::path::PathBuf) {
+    let identity = LocalIdentity::load_or_generate(home).unwrap();
+    let mut registry = PeerKeyRegistry::new();
+    registry
+        .enrol(identity.peer_id, 0, identity.keypair.public_bytes())
+        .unwrap();
+    let store: std::sync::Arc<dyn EventStore> = std::sync::Arc::new(
+        SqliteEventStore::open_path(&home.join("events.sqlite"))
+            .await
+            .unwrap(),
+    );
+    let state = std::sync::Arc::new(DaemonState::new(
+        identity.peer_id,
+        identity.keypair,
+        std::sync::Arc::new(std::sync::RwLock::new(registry)),
+        VerificationPolicy::Strict,
+        home.to_path_buf(),
+        store,
+    ));
+    let socket = unique_socket();
+    let server_socket = socket.clone();
+    let handle = tokio::spawn(async move {
+        airc_daemon::run(state, server_socket).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (handle, socket)
+}
+
 #[tokio::test]
 async fn open_join_say_and_replay_round_trips_in_process() {
     // Gate-4 minimum: a consumer can link airc-lib, open the substrate,
@@ -72,6 +125,29 @@ async fn open_join_say_and_replay_round_trips_in_process() {
     let cursor = airc.latest_cursor().await.unwrap().unwrap();
     let after = airc.resume_from(&cursor, 10).await.unwrap();
     assert!(after.is_empty(), "nothing strictly after the latest cursor");
+}
+
+#[tokio::test]
+async fn attached_sdk_sends_and_pages_through_daemon() {
+    let home = TempDir::new().unwrap();
+    let setup = Airc::open(home.path()).await.unwrap();
+    setup.join("daemon-sdk").await.unwrap();
+    drop(setup);
+    let (daemon, socket) = spawn_daemon(home.path()).await;
+    let airc = Airc::attach(home.path(), &socket).await.unwrap();
+
+    assert!(airc.is_daemon_attached());
+    airc.say("hello through attached sdk").await.unwrap();
+
+    let event = wait_for_text(&airc, "hello through attached sdk", Duration::from_secs(3)).await;
+    let after = airc.resume_from(&event.cursor(), 10).await.unwrap();
+    assert!(after.is_empty());
+
+    airc_daemon::DaemonClient::new(socket).stop().await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), daemon)
+        .await
+        .unwrap()
+        .unwrap();
 }
 
 #[tokio::test]

--- a/docs/architecture/INVITE-ROUTING-ARCHITECTURE.md
+++ b/docs/architecture/INVITE-ROUTING-ARCHITECTURE.md
@@ -289,7 +289,7 @@ depends on it; parallel work is only clean where write scopes are disjoint.
      enrol peer/endpoints.
    - Non-goals: gh as data plane, fallback messaging, relay implementation.
 
-3. **PR-C: Persistent subscription hub / daemon-attached SDK.**
+3. **Current PR-C: Persistent subscription hub / daemon-attached SDK.**
    - Scope: daemon + `airc-lib` attach mode.
    - Deliverable: short-lived CLI/app calls attach to the daemon-backed event
      stream and store; subscriptions persist outside individual commands.

--- a/docs/rust-substrate-grievances-and-gaps.md
+++ b/docs/rust-substrate-grievances-and-gaps.md
@@ -625,7 +625,7 @@ Verified strengths:
 Critical remaining gaps:
 
 - The public `airc` product path now routes through Rust for identity, config, bearer, logs, monitor formatting, Codex hooks, queue/work helpers, and install-time setup. Remaining shell should keep shrinking toward install/bootstrap only.
-- `airc-lib` now owns in-process send/subscribe/replay, route selection, local-fs execution, LAN/Tailscale-class TCP execution, route health, and invite endpoint metadata. Daemon-attached mode and persistent subscription hub are still not complete.
+- `airc-lib` now owns in-process send/subscribe/replay, route selection, local-fs execution, LAN/Tailscale-class TCP execution, route health, invite endpoint metadata, and a daemon-attached SDK path for send/page/resume through typed daemon IPC. Persistent live subscription streams over daemon IPC are still not complete.
 - `airc-cli` is thinner for local and LAN send/listen, but it still owns too much product policy in other commands. Remaining user-facing commands must move onto SDK surfaces instead of constructing substrate state directly.
 - Peer trust rotation is still too permissive: `peers_store::add` silently replaces a pubkey for the same `PeerId`. That must become an explicit signed rotation/audit operation.
 - Route resolver basics exist, and LAN listen/connect feed health. Same-host and bound-LAN discovery now populate route health/endpoints without GitHub or Tailscale. Missing: optional Tailscale, relay, UDP/WebRTC, and Reticulum probes without manual flags.


### PR DESCRIPTION
Summary
- add Airc::attach(home, socket) for daemon-backed SDK mode
- route attached say/page_recent/resume_from through typed daemon IPC
- add an embedding smoke test that starts a real daemon, attaches through airc-lib, sends, pages, and resumes by cursor
- update route/gap docs for PR-C status

Verification
- cargo fmt --manifest-path Cargo.toml --all --check
- cargo clippy --manifest-path Cargo.toml -p airc-lib --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-lib
- git diff --check