### PR TITLE
refactor(cli): route daemon msg and inbox through SDK

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -6,8 +6,9 @@
 //! grievance §5 / Codex audit finding #4.
 //!
 //! Daemon-host commands construct daemon state directly because they
-//! host the service. Daemon-client commands (`ping`, `status`, `stop`,
-//! `msg`, `inbox`) use `airc_daemon::DaemonClient` directly.
+//! host the service. CLI commands that consume daemon-backed messaging
+//! go through `airc_lib::Airc::attach` so apps and CLI share the same
+//! SDK surface.
 //!
 //! `VerificationPolicy::Strict` is the only policy used in CLI paths.
 
@@ -20,10 +21,9 @@ use airc_protocol::{PeerKeyRegistry, VerificationPolicy};
 use futures::stream::StreamExt;
 
 use airc_daemon::{
-    peers_store, run as run_daemon_server, AddPeerRequest, DaemonClient, DaemonState, InboxRequest,
-    LocalIdentity, SendRequest, SubscribeRequest,
+    peers_store, run as run_daemon_server, AddPeerRequest, DaemonClient, DaemonState, LocalIdentity,
 };
-use airc_lib::{room, Airc, Body, PeerSpec};
+use airc_lib::{Airc, Body, PeerSpec};
 use airc_store::{EventStore, SqliteEventStore};
 
 /// `init` — open the substrate at `<home>`. `Airc::open` loads or
@@ -242,15 +242,9 @@ pub async fn run_msg(
     socket: PathBuf,
     text: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let current = room::load_or_default(home)?;
-    let client = DaemonClient::new(socket);
-    client
-        .send(SendRequest {
-            wire: current.wire,
-            channel: current.channel.as_uuid(),
-            text: text.to_string(),
-        })
-        .await?;
+    let airc = Airc::attach(home, socket).await?;
+    let current = airc.current_room().await?;
+    airc.say(text).await?;
     println!("sent to {} ({}).", current.name, current.channel);
     Ok(())
 }
@@ -262,13 +256,7 @@ pub async fn run_inbox(
     since_event_id: Option<String>,
     limit: Option<usize>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let current = room::load_or_default(home)?;
-    let client = DaemonClient::new(socket);
-    client
-        .subscribe(SubscribeRequest {
-            wire: current.wire.clone(),
-        })
-        .await?;
+    let airc = Airc::attach(home, socket).await?;
     // Both --since-lamport and --since-event-id must be supplied
     // together; the cursor is a tuple per grievance §7.
     let since = match (since_lamport, since_event_id) {
@@ -284,27 +272,19 @@ pub async fn run_inbox(
             );
         }
     };
-    let inbox = client
-        .inbox(InboxRequest {
-            since,
-            channel: Some(current.channel),
-            limit,
-        })
-        .await?;
-    if inbox.events.is_empty() {
-        match &inbox.newest {
-            Some(c) => println!(
-                "(no new events; cursor lamport={} event_id={})",
-                c.lamport, c.event_id
-            ),
-            None => println!("(no events yet — store is empty)"),
-        }
+    let effective_limit = limit.unwrap_or(32);
+    let events = match since {
+        Some(cursor) => airc.resume_from(&cursor, effective_limit).await?,
+        None => airc.page_recent(effective_limit).await?,
+    };
+    if events.is_empty() {
+        println!("(no events)");
         return Ok(());
     }
-    for event in &inbox.events {
+    for event in &events {
         print_event(event);
     }
-    if let Some(cursor) = inbox.newest {
+    if let Some(cursor) = events.last().map(airc_core::TranscriptEvent::cursor) {
         println!();
         println!(
             "cursor: lamport={} event_id={} — pass both as --since-lamport / --since-event-id",

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -262,6 +262,75 @@ fn two_airc_rs_processes_chat_over_lan_via_sdk_route() {
 }
 
 #[test]
+fn daemon_msg_and_inbox_use_sdk_attach_path() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+    let socket = workspace.path().join("daemon.sock");
+    run_init(&home);
+
+    let mut daemon = Command::new(airc_rs())
+        .args([
+            "--home",
+            home.to_str().unwrap(),
+            "daemon",
+            "--socket",
+            socket.to_str().unwrap(),
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("daemon must spawn");
+
+    wait_for_line_contains(
+        daemon.stdout.take().expect("daemon stdout"),
+        "listening on",
+        Duration::from_secs(6),
+    );
+
+    let msg = Command::new(airc_rs())
+        .args([
+            "--home",
+            home.to_str().unwrap(),
+            "msg",
+            "--socket",
+            socket.to_str().unwrap(),
+            "hello through cli attach",
+        ])
+        .output()
+        .expect("msg must spawn");
+    assert!(
+        msg.status.success(),
+        "msg failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&msg.stdout),
+        String::from_utf8_lossy(&msg.stderr),
+    );
+
+    let inbox = wait_for_command_stdout_contains(
+        &home,
+        &socket,
+        "hello through cli attach",
+        Duration::from_secs(6),
+    );
+    assert!(
+        inbox,
+        "inbox did not print daemon-sent message through SDK attach path"
+    );
+
+    let stop = Command::new(airc_rs())
+        .args([
+            "--home",
+            home.to_str().unwrap(),
+            "stop",
+            "--socket",
+            socket.to_str().unwrap(),
+        ])
+        .output()
+        .expect("stop must spawn");
+    assert!(stop.status.success(), "stop failed");
+    let _ = daemon.wait();
+}
+
+#[test]
 fn rerun_init_returns_same_peer_id() {
     // The persistence pin: `airc-rs init` must be idempotent. The
     // second run reuses the on-disk identity rather than minting a
@@ -275,6 +344,36 @@ fn rerun_init_returns_same_peer_id() {
         first_spec, second_spec,
         "peer_spec must persist across init runs"
     );
+}
+
+fn wait_for_command_stdout_contains(
+    home: &Path,
+    socket: &Path,
+    needle: &str,
+    timeout: Duration,
+) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let output = Command::new(airc_rs())
+            .args([
+                "--home",
+                home.to_str().unwrap(),
+                "inbox",
+                "--socket",
+                socket.to_str().unwrap(),
+                "--limit",
+                "16",
+            ])
+            .output()
+            .expect("inbox must spawn");
+        if output.status.success() && String::from_utf8_lossy(&output.stdout).contains(needle) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
 }
 
 fn spawn_line_reader<R: Read + Send + 'static>(reader: R) -> mpsc::Receiver<String> {

--- a/docs/architecture/INVITE-ROUTING-ARCHITECTURE.md
+++ b/docs/architecture/INVITE-ROUTING-ARCHITECTURE.md
@@ -295,7 +295,7 @@ depends on it; parallel work is only clean where write scopes are disjoint.
      stream and store; subscriptions persist outside individual commands.
    - Non-goals: new transport adapters.
 
-4. **PR-D: CLI/user commands through SDK.**
+4. **Current PR-D: CLI/user commands through SDK.**
    - Scope: remaining CLI commands that still construct substrate state directly.
    - Deliverable: command handlers call `airc-lib`/daemon client APIs instead of
      building registries, stores, transports, or route decisions themselves.

--- a/docs/rust-substrate-grievances-and-gaps.md
+++ b/docs/rust-substrate-grievances-and-gaps.md
@@ -626,7 +626,7 @@ Critical remaining gaps:
 
 - The public `airc` product path now routes through Rust for identity, config, bearer, logs, monitor formatting, Codex hooks, queue/work helpers, and install-time setup. Remaining shell should keep shrinking toward install/bootstrap only.
 - `airc-lib` now owns in-process send/subscribe/replay, route selection, local-fs execution, LAN/Tailscale-class TCP execution, route health, invite endpoint metadata, and a daemon-attached SDK path for send/page/resume through typed daemon IPC. Persistent live subscription streams over daemon IPC are still not complete.
-- `airc-cli` is thinner for local and LAN send/listen, but it still owns too much product policy in other commands. Remaining user-facing commands must move onto SDK surfaces instead of constructing substrate state directly.
+- `airc-cli` is thinner for local, LAN, and daemon-backed msg/inbox paths. Remaining user-facing commands must continue moving onto SDK surfaces instead of constructing substrate state directly.
 - Peer trust rotation is still too permissive: `peers_store::add` silently replaces a pubkey for the same `PeerId`. That must become an explicit signed rotation/audit operation.
 - Route resolver basics exist, and LAN listen/connect feed health. Same-host and bound-LAN discovery now populate route health/endpoints without GitHub or Tailscale. Missing: optional Tailscale, relay, UDP/WebRTC, and Reticulum probes without manual flags.
 - Gist is modeled as invite/rendezvous only, and the Rust transport crate now exposes an invite-file store rather than a runtime frame transport. Remaining work: wire user-facing invite commands fully through the SDK path and add signed/audited invite validation.


### PR DESCRIPTION
Summary
- route daemon-backed `msg` through `Airc::attach(...).say(...)` instead of direct `DaemonClient::send`
- route daemon-backed `inbox` through attached SDK page/resume calls instead of direct subscribe/inbox request construction
- add CLI e2e covering daemon startup, `msg`, and `inbox` over the SDK attach path
- update route/gap docs for PR-D status

Verification
- clean worktree: cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- clean worktree: cargo test --manifest-path Cargo.toml -p airc-cli --test e2e daemon_msg_and_inbox_use_sdk_attach_path -- --nocapture
- clean worktree: cargo test --manifest-path Cargo.toml -p airc-cli --test e2e -- --nocapture
- clean worktree: cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings

Note
- Main shared worktree currently has unrelated uncommitted airc-work drain typing edits from parallel PR3 work, so verification was run in a detached clean git worktree at this commit.