### PR TITLE
fix(cli): accept legacy message build command

### DIFF
--- a/crates/airc-cli/src/message_cli.rs
+++ b/crates/airc-cli/src/message_cli.rs
@@ -9,6 +9,7 @@ pub struct MessageArgs {
 #[derive(Debug, Subcommand)]
 pub enum MessageAction {
     /// Build an outbound chat log envelope as JSON.
+    #[command(alias = "build-legacy")]
     Build {
         #[arg(long)]
         from: String,

--- a/crates/airc-cli/tests/message_commands.rs
+++ b/crates/airc-cli/tests/message_commands.rs
@@ -1,0 +1,56 @@
+//! End-to-end coverage for `airc-rs message ...`.
+
+use std::process::Command;
+
+use serde_json::Value;
+
+fn airc_rs() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-rs")
+}
+
+#[test]
+fn message_build_legacy_alias_matches_build_output() {
+    let build = run_ok(&["message", "build"]);
+    let legacy = run_ok(&["message", "build-legacy"]);
+
+    assert_eq!(legacy, build);
+
+    let parsed: Value = serde_json::from_str(&legacy).expect("json payload");
+    assert_eq!(parsed["from"], "codex");
+    assert_eq!(parsed["to"], "all");
+    assert_eq!(parsed["channel"], "airc");
+    assert_eq!(parsed["msg"], "hello from test");
+}
+
+fn run_ok(prefix: &[&str]) -> String {
+    let output = Command::new(airc_rs())
+        .args(prefix)
+        .args([
+            "--from",
+            "codex",
+            "--to",
+            "all",
+            "--ts",
+            "2026-05-20T00:00:00Z",
+            "--channel",
+            "airc",
+            "--msg",
+            "hello from test",
+            "--client-id",
+            "client-1",
+            "--kind",
+            "chat",
+        ])
+        .output()
+        .expect("run airc-rs");
+
+    assert!(
+        output.status.success(),
+        "command failed\nstatus: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    String::from_utf8(output.stdout).expect("utf8 stdout")
+}


### PR DESCRIPTION
Summary
- accept message build-legacy as an alias for message build during wrapper/binary cutover
- add binary-level e2e coverage proving both commands produce the same chat envelope

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli --test message_commands
- cargo test --manifest-path Cargo.toml -p airc-cli message_commands
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- target/debug/airc-rs message build ...
- target/debug/airc-rs message build-legacy ...