### PR TITLE
feat(shell): read rust local inbox by default

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -251,12 +251,15 @@ pub async fn run_msg(
 
 pub async fn run_inbox(
     home: &Path,
-    socket: PathBuf,
+    socket: Option<PathBuf>,
     since_lamport: Option<u64>,
     since_event_id: Option<String>,
     limit: Option<usize>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let airc = Airc::attach(home, socket).await?;
+    let airc = match socket {
+        Some(socket) => Airc::attach(home, socket).await?,
+        None => Airc::open(home).await?,
+    };
     // Both --since-lamport and --since-event-id must be supplied
     // together; the cursor is a tuple per grievance §7.
     let since = match (since_lamport, since_event_id) {

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -523,16 +523,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             since_lamport,
             since_event_id,
             limit,
-        } => {
-            commands::run_inbox(
-                &home,
-                default_or(socket, &home),
-                since_lamport,
-                since_event_id,
-                limit,
-            )
-            .await
-        }
+        } => commands::run_inbox(&home, socket, since_lamport, since_event_id, limit).await,
 
         Command::Room { name, wire } => commands::run_room(&home, name, wire).await,
 

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -331,6 +331,45 @@ fn daemon_msg_and_inbox_use_sdk_attach_path() {
 }
 
 #[test]
+fn inbox_without_socket_reads_in_process_store() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+    run_init(&home);
+
+    let send = Command::new(airc_rs())
+        .args([
+            "--home",
+            home.to_str().unwrap(),
+            "send",
+            "hello through in-process inbox",
+        ])
+        .output()
+        .expect("send must spawn");
+    assert!(
+        send.status.success(),
+        "send failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&send.stdout),
+        String::from_utf8_lossy(&send.stderr),
+    );
+
+    let inbox = Command::new(airc_rs())
+        .args(["--home", home.to_str().unwrap(), "inbox", "--limit", "16"])
+        .output()
+        .expect("inbox must spawn");
+    assert!(
+        inbox.status.success(),
+        "inbox failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&inbox.stdout),
+        String::from_utf8_lossy(&inbox.stderr),
+    );
+    assert!(
+        String::from_utf8_lossy(&inbox.stdout).contains("hello through in-process inbox"),
+        "inbox stdout missing sent message: {}",
+        String::from_utf8_lossy(&inbox.stdout)
+    );
+}
+
+#[test]
 fn rerun_init_returns_same_peer_id() {
     // The persistence pin: `airc-rs init` must be idempotent. The
     // second run reuses the on-disk identity rather than minting a

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -351,6 +351,56 @@ cmd_inbox() {
     since=""
   fi
 
+  _airc_try_rust_inbox_read() {
+    # Plain inbox reads follow plain msg sends onto the Rust local
+    # substrate. Legacy relative-time/self-filter modes stay on the
+    # old log reader until those filters are represented in the Rust
+    # transcript API.
+    [ -z "$since" ] || return 1
+    [ "$exclude_self" = "0" ] || return 1
+
+    local rust_cursor_file="$AIRC_WRITE_DIR/inbox_cursor.rust"
+    local rust_args=(--home "$AIRC_WRITE_DIR" inbox --limit "$count")
+    if [ -s "$rust_cursor_file" ]; then
+      local cursor_lamport cursor_event_id
+      read -r cursor_lamport cursor_event_id < "$rust_cursor_file" || true
+      if [ -n "${cursor_lamport:-}" ] && [ -n "${cursor_event_id:-}" ]; then
+        rust_args+=(--since-lamport "$cursor_lamport" --since-event-id "$cursor_event_id")
+      fi
+    fi
+
+    local rust_out
+    if ! rust_out=$("$(airc_rs_bin)" "${rust_args[@]}" 2>&1); then
+      printf '%s\n' "$rust_out" >&2
+      return 2
+    fi
+
+    local cursor_line
+    cursor_line=$(printf '%s\n' "$rust_out" | grep '^cursor: lamport=' | tail -1 || true)
+    if [ "$peek" -eq 0 ] && [ -n "$cursor_line" ]; then
+      local next_lamport next_event_id
+      next_lamport=$(printf '%s\n' "$cursor_line" | sed -n 's/^cursor: lamport=\([0-9][0-9]*\) event_id=.*/\1/p')
+      next_event_id=$(printf '%s\n' "$cursor_line" | sed -n 's/^cursor: lamport=[0-9][0-9]* event_id=\([^ ]*\).*/\1/p')
+      if [ -n "$next_lamport" ] && [ -n "$next_event_id" ]; then
+        printf '%s %s\n' "$next_lamport" "$next_event_id" > "$rust_cursor_file"
+      fi
+    fi
+
+    if [ "$quiet_empty" = "1" ] && [ "$rust_out" = "(no events)" ]; then
+      return 0
+    fi
+    printf '%s\n' "$rust_out" | sed '/^cursor: lamport=/d'
+    return 0
+  }
+
+  local _rust_inbox_rc=0
+  _airc_try_rust_inbox_read || _rust_inbox_rc=$?
+  if [ "$_rust_inbox_rc" -eq 0 ]; then
+    return 0
+  elif [ "$_rust_inbox_rc" -eq 2 ]; then
+    return 1
+  fi
+
   local out
   local inbox_args=(log inbox-read --home "$AIRC_WRITE_DIR" --cursor-file "$cursor_file" --count "$count")
   [ -n "$since" ] && inbox_args+=(--since "$since")

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -4695,6 +4695,13 @@ JSON
     fail "airc msg leaked into gh bearer path (out: $(cat "$out" 2>/dev/null); err: $(cat "$err" 2>/dev/null); pending: $(cat "$home/pending.jsonl" 2>/dev/null))"
   fi
 
+  if AIRC_HOME="$home" AIRC_RS_BIN="$(airc_rs_bin)" "$AIRC" inbox --count 5 >"$out" 2>"$err" \
+      && grep -q "$marker" "$out"; then
+    pass "airc inbox reads Rust local transcript"
+  else
+    fail "airc inbox did not read Rust local transcript (out: $(cat "$out" 2>/dev/null); err: $(cat "$err" 2>/dev/null))"
+  fi
+
   rm -rf "$root"
 }
 


### PR DESCRIPTION
Summary
- make `airc-rs inbox` use the embedded SDK/store when no socket is explicitly passed
- keep daemon-attached inbox behavior when `--socket` is supplied
- route default shell `airc inbox` reads through the Rust local transcript cursor
- extend the shell integration scenario to prove `airc msg` then `airc inbox` works without gh bearer queueing

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-cli --test e2e
- bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh test/integration.sh
- bash test/rust_cutover_guard.sh
- bash test/rust_quality_guard.sh
- AIRC_RS_BIN="/Users/joelteply/Development/cambrian/airc/target/debug/airc-rs" bash test/integration.sh shell_msg_rust_local