### PR TITLE
feat(airc-transport): add realtime UDP adapter

### DIFF
--- a/crates/airc-lib/src/route/invite.rs
+++ b/crates/airc-lib/src/route/invite.rs
@@ -22,6 +22,7 @@ pub const INVITE_BEACON_SCHEMA_VERSION: u16 = 1;
 pub enum RouteEndpoint {
     LanTcp { addr: SocketAddr },
     TailscaleTcp { addr: SocketAddr },
+    Udp { addr: SocketAddr },
     Relay { url: String },
     Reticulum { destination: String },
     WebRtcSignaling { url: String },
@@ -183,6 +184,7 @@ fn same_endpoint_kind(left: &RouteEndpoint, right: &RouteEndpoint) -> bool {
                 RouteEndpoint::TailscaleTcp { .. },
                 RouteEndpoint::TailscaleTcp { .. }
             )
+            | (RouteEndpoint::Udp { .. }, RouteEndpoint::Udp { .. })
             | (RouteEndpoint::Relay { .. }, RouteEndpoint::Relay { .. })
             | (
                 RouteEndpoint::Reticulum { .. },
@@ -237,6 +239,29 @@ mod tests {
             vec![RouteEndpoint::LanTcp {
                 addr: SocketAddr::from(([127, 0, 0, 1], 2000))
             }]
+        );
+    }
+
+    #[test]
+    fn endpoint_table_tracks_udp_separately_from_lan_tcp() {
+        let mut table = RouteEndpointTable::default();
+        table.upsert(RouteEndpoint::LanTcp {
+            addr: SocketAddr::from(([127, 0, 0, 1], 1000)),
+        });
+        table.upsert(RouteEndpoint::Udp {
+            addr: SocketAddr::from(([127, 0, 0, 1], 1000)),
+        });
+
+        assert_eq!(
+            table.endpoints(),
+            vec![
+                RouteEndpoint::LanTcp {
+                    addr: SocketAddr::from(([127, 0, 0, 1], 1000))
+                },
+                RouteEndpoint::Udp {
+                    addr: SocketAddr::from(([127, 0, 0, 1], 1000))
+                }
+            ]
         );
     }
 

--- a/crates/airc-lib/src/route/policy.rs
+++ b/crates/airc-lib/src/route/policy.rs
@@ -94,7 +94,6 @@ fn allows(class: RouteClass, candidate: TransportCandidate) -> bool {
                 && matches!(
                     class,
                     RouteClass::ControlInteractive
-                        | RouteClass::DataInteractive
                         | RouteClass::MediaSignaling
                         | RouteClass::PresenceEphemeral
                 )
@@ -132,9 +131,7 @@ fn is_live_class(class: RouteClass) -> bool {
 
 fn priority(class: RouteClass, kind: TransportKind, role: TransportRole) -> u8 {
     match class {
-        RouteClass::ControlInteractive
-        | RouteClass::DataInteractive
-        | RouteClass::PresenceEphemeral => match kind {
+        RouteClass::ControlInteractive | RouteClass::PresenceEphemeral => match kind {
             TransportKind::LanTcp => 0,
             TransportKind::LocalFs => 1,
             TransportKind::Tailscale => 2,
@@ -143,6 +140,17 @@ fn priority(class: RouteClass, kind: TransportKind, role: TransportRole) -> u8 {
             TransportKind::Reticulum => 5,
             TransportKind::Relay => 6,
             TransportKind::Ssh | TransportKind::GhGist => 255,
+        },
+        RouteClass::DataInteractive => match kind {
+            TransportKind::LanTcp => 0,
+            TransportKind::LocalFs => 1,
+            TransportKind::Tailscale => 2,
+            TransportKind::Reticulum => 3,
+            TransportKind::Relay => 4,
+            TransportKind::Udp
+            | TransportKind::WebRtcDataChannel
+            | TransportKind::Ssh
+            | TransportKind::GhGist => 255,
         },
         RouteClass::MediaSignaling => match kind {
             TransportKind::LocalFs => 0,
@@ -334,9 +342,16 @@ mod tests {
     }
 
     #[test]
-    fn udp_is_interactive_not_bulk() {
+    fn udp_is_realtime_not_durable_data() {
         let policy = RoutePolicy;
 
+        assert_eq!(
+            policy.choose(
+                RouteClass::ControlInteractive,
+                [candidate(TransportKind::Udp, TransportRole::Direct)],
+            ),
+            RouteDecision::Selected(TransportKind::Udp)
+        );
         assert_eq!(
             policy.choose(
                 RouteClass::MediaSignaling,
@@ -351,6 +366,15 @@ mod tests {
             ),
             RouteDecision::NoRoute {
                 class: RouteClass::DataBulk
+            }
+        );
+        assert_eq!(
+            policy.choose(
+                RouteClass::DataInteractive,
+                [candidate(TransportKind::Udp, TransportRole::Direct)],
+            ),
+            RouteDecision::NoRoute {
+                class: RouteClass::DataInteractive
             }
         );
     }

--- a/crates/airc-lib/src/route/resolver.rs
+++ b/crates/airc-lib/src/route/resolver.rs
@@ -140,7 +140,7 @@ mod tests {
     }
 
     #[test]
-    fn resolver_selects_udp_for_interactive_data_when_available() {
+    fn resolver_selects_udp_for_interactive_control_when_available() {
         let resolver = TransportResolver::new([
             candidate(GhGist, TransportRole::Rendezvous),
             candidate(Udp, TransportRole::Direct),
@@ -148,8 +148,12 @@ mod tests {
         ]);
 
         assert_eq!(
-            resolver.resolve(RouteClass::DataInteractive),
+            resolver.resolve(RouteClass::ControlInteractive),
             Ok(TransportRoute { kind: Udp })
+        );
+        assert_eq!(
+            resolver.resolve(RouteClass::DataInteractive),
+            Ok(TransportRoute { kind: Relay })
         );
     }
 }

--- a/crates/airc-transport/src/lib.rs
+++ b/crates/airc-transport/src/lib.rs
@@ -27,6 +27,7 @@ pub mod local_fs;
 pub mod relay;
 pub mod signed;
 pub mod transport;
+pub mod udp;
 
 // Re-exports — stable public surface.
 pub use error::LocalFsError;
@@ -39,3 +40,4 @@ pub use lan_tcp::{
 pub use local_fs::LocalFsAdapter;
 pub use signed::{SignedError, SignedTransport};
 pub use transport::{FrameStream, Transport};
+pub use udp::{UdpAdapter, UdpConfig, UdpError};

--- a/crates/airc-transport/src/udp/adapter.rs
+++ b/crates/airc-transport/src/udp/adapter.rs
@@ -1,0 +1,222 @@
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::stream::Stream;
+use tokio::net::UdpSocket;
+use tokio::sync::{mpsc, Mutex, RwLock};
+
+use airc_core::transcript::MentionTarget;
+use airc_protocol::{Frame, FrameKind, Subscription};
+
+use crate::transport::{FrameStream, Transport};
+use crate::udp::config::UdpConfig;
+use crate::udp::error::UdpError;
+
+const MAX_DATAGRAM_BYTES: usize = 60 * 1024;
+const SUBSCRIBER_CHANNEL_DEPTH: usize = 64;
+
+struct SubscriberHandle {
+    #[allow(dead_code)]
+    id: u64,
+    subscription: Subscription,
+    tx: mpsc::Sender<Result<Frame, UdpError>>,
+}
+
+struct Inner {
+    config: UdpConfig,
+    socket: RwLock<Option<Arc<UdpSocket>>>,
+    subscribers: Mutex<Vec<SubscriberHandle>>,
+    next_sub_id: AtomicU64,
+}
+
+/// Low-latency UDP frame adapter.
+#[derive(Clone)]
+pub struct UdpAdapter {
+    inner: Arc<Inner>,
+}
+
+impl UdpAdapter {
+    pub fn new(config: UdpConfig) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                config,
+                socket: RwLock::new(None),
+                subscribers: Mutex::new(Vec::new()),
+                next_sub_id: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    /// Bind the UDP socket and spawn the receive loop. Returns the
+    /// actual local address, including the OS-assigned port when the
+    /// configured port is 0.
+    pub async fn bind(&self) -> Result<SocketAddr, UdpError> {
+        {
+            let guard = self.inner.socket.read().await;
+            if guard.is_some() {
+                return Err(UdpError::AlreadyBound);
+            }
+        }
+
+        let socket = Arc::new(UdpSocket::bind(self.inner.config.bind_addr).await?);
+        let local_addr = socket.local_addr()?;
+
+        {
+            let mut guard = self.inner.socket.write().await;
+            if guard.is_some() {
+                return Err(UdpError::AlreadyBound);
+            }
+            *guard = Some(Arc::clone(&socket));
+        }
+
+        tokio::spawn(read_loop(Arc::clone(&self.inner), socket));
+        Ok(local_addr)
+    }
+
+    pub async fn local_addr(&self) -> Result<SocketAddr, UdpError> {
+        let socket = self.bound_socket().await?;
+        Ok(socket.local_addr()?)
+    }
+
+    async fn bound_socket(&self) -> Result<Arc<UdpSocket>, UdpError> {
+        self.inner
+            .socket
+            .read()
+            .await
+            .as_ref()
+            .cloned()
+            .ok_or(UdpError::NotBound)
+    }
+
+    fn destinations(&self, frame: &Frame) -> Result<Vec<SocketAddr>, UdpError> {
+        match frame.envelope.target {
+            MentionTarget::Peer(peer_id) => self
+                .inner
+                .config
+                .peer_endpoints
+                .get(&peer_id)
+                .copied()
+                .map(|addr| vec![addr])
+                .ok_or(UdpError::UnknownPeerEndpoint(peer_id)),
+            MentionTarget::All | MentionTarget::Room(_) => {
+                let endpoints: Vec<SocketAddr> =
+                    self.inner.config.peer_endpoints.values().copied().collect();
+                if endpoints.is_empty() {
+                    Err(UdpError::NoPeerEndpoints)
+                } else {
+                    Ok(endpoints)
+                }
+            }
+        }
+    }
+}
+
+async fn read_loop(inner: Arc<Inner>, socket: Arc<UdpSocket>) {
+    let mut buffer = vec![0u8; MAX_DATAGRAM_BYTES];
+    loop {
+        let (len, _source) = match socket.recv_from(&mut buffer).await {
+            Ok(received) => received,
+            Err(error) => {
+                dispatch_error(&inner, UdpError::Io(error)).await;
+                return;
+            }
+        };
+        let frame = match serde_json::from_slice::<Frame>(&buffer[..len]) {
+            Ok(frame) => frame,
+            Err(error) => {
+                dispatch_error(&inner, UdpError::Json(error)).await;
+                continue;
+            }
+        };
+        dispatch_frame(&inner, frame).await;
+    }
+}
+
+async fn dispatch_frame(inner: &Arc<Inner>, frame: Frame) {
+    let subscribers = {
+        let subscribers = inner.subscribers.lock().await;
+        subscribers
+            .iter()
+            .filter(|subscriber| subscriber.subscription.matches(&frame))
+            .map(|subscriber| subscriber.tx.clone())
+            .collect::<Vec<_>>()
+    };
+
+    for tx in subscribers {
+        let _ = tx.try_send(Ok(frame.clone()));
+    }
+}
+
+async fn dispatch_error(inner: &Arc<Inner>, error: UdpError) {
+    let subscribers = {
+        let subscribers = inner.subscribers.lock().await;
+        subscribers
+            .iter()
+            .map(|subscriber| subscriber.tx.clone())
+            .collect::<Vec<_>>()
+    };
+
+    for tx in subscribers {
+        let _ = tx.try_send(Err(match &error {
+            UdpError::Io(io) => UdpError::Io(std::io::Error::new(io.kind(), io.to_string())),
+            UdpError::Json(json) => UdpError::Json(serde_json::Error::io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                json.to_string(),
+            ))),
+            UdpError::FrameTooLarge { actual, limit } => UdpError::FrameTooLarge {
+                actual: *actual,
+                limit: *limit,
+            },
+            UdpError::UnsupportedDurableKind(kind) => UdpError::UnsupportedDurableKind(*kind),
+            UdpError::UnknownPeerEndpoint(peer) => UdpError::UnknownPeerEndpoint(*peer),
+            UdpError::NoPeerEndpoints => UdpError::NoPeerEndpoints,
+            UdpError::AlreadyBound => UdpError::AlreadyBound,
+            UdpError::NotBound => UdpError::NotBound,
+        }));
+    }
+}
+
+#[async_trait]
+impl Transport for UdpAdapter {
+    type Error = UdpError;
+
+    async fn send(&self, frame: Frame) -> Result<(), Self::Error> {
+        if !matches!(frame.kind, FrameKind::Event) {
+            return Err(UdpError::UnsupportedDurableKind(frame.kind));
+        }
+
+        let payload = serde_json::to_vec(&frame)?;
+        if payload.len() > MAX_DATAGRAM_BYTES {
+            return Err(UdpError::FrameTooLarge {
+                actual: payload.len(),
+                limit: MAX_DATAGRAM_BYTES,
+            });
+        }
+
+        let socket = self.bound_socket().await?;
+        for destination in self.destinations(&frame)? {
+            socket.send_to(&payload, destination).await?;
+        }
+        Ok(())
+    }
+
+    async fn subscribe(
+        &self,
+        subscription: Subscription,
+    ) -> Result<FrameStream<Self::Error>, Self::Error> {
+        let (tx, rx) = mpsc::channel(SUBSCRIBER_CHANNEL_DEPTH);
+        let id = self.inner.next_sub_id.fetch_add(1, Ordering::Relaxed);
+        self.inner.subscribers.lock().await.push(SubscriberHandle {
+            id,
+            subscription,
+            tx,
+        });
+        let stream = futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        });
+        Ok(Box::pin(stream) as Pin<Box<dyn Stream<Item = _> + Send>>)
+    }
+}

--- a/crates/airc-transport/src/udp/config.rs
+++ b/crates/airc-transport/src/udp/config.rs
@@ -1,0 +1,29 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
+
+use airc_core::PeerId;
+
+/// UDP adapter configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UdpConfig {
+    /// Local bind address. Use port 0 in tests or embedded callers
+    /// that want the OS to allocate an ephemeral port.
+    pub bind_addr: SocketAddr,
+    /// Known peer endpoints. Broadcast sends go to all endpoints;
+    /// direct-peer sends require the target peer to be present here.
+    pub peer_endpoints: HashMap<PeerId, SocketAddr>,
+}
+
+impl UdpConfig {
+    pub fn new(bind_addr: SocketAddr) -> Self {
+        Self {
+            bind_addr,
+            peer_endpoints: HashMap::new(),
+        }
+    }
+
+    pub fn with_peer(mut self, peer_id: PeerId, addr: SocketAddr) -> Self {
+        self.peer_endpoints.insert(peer_id, addr);
+        self
+    }
+}

--- a/crates/airc-transport/src/udp/error.rs
+++ b/crates/airc-transport/src/udp/error.rs
@@ -1,0 +1,73 @@
+use airc_core::PeerId;
+use airc_protocol::FrameKind;
+
+/// UDP transport errors.
+#[derive(Debug)]
+pub enum UdpError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    /// UDP datagrams are bounded. The adapter refuses oversized
+    /// frames before send instead of truncating or fragmenting.
+    FrameTooLarge {
+        actual: usize,
+        limit: usize,
+    },
+    /// UDP is not a durable transcript route.
+    UnsupportedDurableKind(FrameKind),
+    /// No endpoint is known for a direct peer target.
+    UnknownPeerEndpoint(PeerId),
+    /// Broadcast send requested with no configured peer endpoints.
+    NoPeerEndpoints,
+    /// `bind()` called twice on one adapter.
+    AlreadyBound,
+    /// `send()`/`subscribe()` called before `bind()`.
+    NotBound,
+}
+
+impl std::fmt::Display for UdpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "udp I/O: {error}"),
+            Self::Json(error) => write!(f, "udp frame parse: {error}"),
+            Self::FrameTooLarge { actual, limit } => {
+                write!(f, "udp frame size {actual} exceeds datagram limit {limit}")
+            }
+            Self::UnsupportedDurableKind(kind) => {
+                write!(f, "udp does not support durable frame kind {kind:?}")
+            }
+            Self::UnknownPeerEndpoint(peer) => {
+                write!(f, "udp has no endpoint for peer {peer}")
+            }
+            Self::NoPeerEndpoints => f.write_str("udp has no configured peer endpoints"),
+            Self::AlreadyBound => f.write_str("udp adapter is already bound"),
+            Self::NotBound => f.write_str("udp adapter is not bound"),
+        }
+    }
+}
+
+impl std::error::Error for UdpError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::Json(error) => Some(error),
+            Self::FrameTooLarge { .. }
+            | Self::UnsupportedDurableKind(_)
+            | Self::UnknownPeerEndpoint(_)
+            | Self::NoPeerEndpoints
+            | Self::AlreadyBound
+            | Self::NotBound => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for UdpError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for UdpError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}

--- a/crates/airc-transport/src/udp/mod.rs
+++ b/crates/airc-transport/src/udp/mod.rs
@@ -1,0 +1,25 @@
+//! `UdpAdapter` — low-latency datagram transport for interrupt-style
+//! AIRC frames.
+//!
+//! UDP is intentionally narrower than `local_fs`, `lan_tcp`, or
+//! `relay`: it is for event/control signaling where stale data should
+//! be dropped rather than queued. It does NOT claim durable transcript
+//! delivery. `Transport::send` therefore rejects `FrameKind::Message`
+//! and `FrameKind::Control` explicitly. Durable traffic must use a
+//! durable route.
+//!
+//! Security boundary: UDP does not authenticate peers at the socket
+//! layer. Production callers wrap this adapter with `SignedTransport`
+//! so frame signatures are verified at the substrate boundary. The
+//! adapter does not degrade to unsigned trust.
+
+mod adapter;
+mod config;
+mod error;
+
+pub use adapter::UdpAdapter;
+pub use config::UdpConfig;
+pub use error::UdpError;
+
+#[cfg(test)]
+mod tests;

--- a/crates/airc-transport/src/udp/tests.rs
+++ b/crates/airc-transport/src/udp/tests.rs
@@ -1,0 +1,148 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use airc_core::{
+    headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, PeerId, RoomId,
+};
+use airc_protocol::{ChannelId, Envelope, Frame, FrameKind, Signature, Subscription};
+use futures::StreamExt;
+
+use crate::transport::Transport;
+use crate::udp::{UdpAdapter, UdpConfig, UdpError};
+
+fn frame(kind: FrameKind, lamport: u64, target: MentionTarget, body: &str) -> Frame {
+    Frame {
+        kind,
+        envelope: Envelope {
+            event_id: EventId::from_u128(lamport as u128),
+            sender: PeerId::from_u128(0xa1),
+            sender_client: ClientId::from_u128(0xc1),
+            channel: ChannelId::from_u128(0xc0ffee),
+            target,
+            lamport,
+            occurred_at_ms: 1_700_000_000_000 + lamport,
+            reply_to: None,
+            headers: Headers::new(),
+            body: Some(Body::text(body)),
+            media: Vec::new(),
+            signature: Signature::Unsigned,
+        },
+    }
+}
+
+async fn bound_adapter(peers: HashMap<PeerId, SocketAddr>) -> (UdpAdapter, SocketAddr) {
+    let adapter = UdpAdapter::new(UdpConfig {
+        bind_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+        peer_endpoints: peers,
+    });
+    let addr = adapter.bind().await.unwrap();
+    (adapter, addr)
+}
+
+#[tokio::test]
+async fn event_round_trips_between_two_udp_adapters() {
+    let alice_id = PeerId::from_u128(0xa1);
+    let bob_id = PeerId::from_u128(0xb2);
+
+    let (bob, bob_addr) = bound_adapter(HashMap::new()).await;
+    let mut alice_peers = HashMap::new();
+    alice_peers.insert(bob_id, bob_addr);
+    let (alice, _alice_addr) = bound_adapter(alice_peers).await;
+
+    let mut bob_stream = bob.subscribe(Subscription::default()).await.unwrap();
+    let outbound = frame(
+        FrameKind::Event,
+        1,
+        MentionTarget::Peer(bob_id),
+        "udp hello",
+    );
+
+    alice.send(outbound.clone()).await.unwrap();
+
+    let received = tokio::time::timeout(Duration::from_secs(2), bob_stream.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(received, outbound);
+    assert_eq!(received.envelope.sender, alice_id);
+}
+
+#[tokio::test]
+async fn channel_subscription_filters_udp_events() {
+    let wanted = RoomId::from_u128(0x11);
+    let other = RoomId::from_u128(0x22);
+    let bob_id = PeerId::from_u128(0xb2);
+
+    let (bob, bob_addr) = bound_adapter(HashMap::new()).await;
+    let mut alice_peers = HashMap::new();
+    alice_peers.insert(bob_id, bob_addr);
+    let (alice, _alice_addr) = bound_adapter(alice_peers).await;
+
+    let mut stream = bob
+        .subscribe(Subscription {
+            channel: Some(wanted),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let mut wrong = frame(FrameKind::Event, 1, MentionTarget::Peer(bob_id), "wrong");
+    wrong.envelope.channel = other;
+    let mut right = frame(FrameKind::Event, 2, MentionTarget::Peer(bob_id), "right");
+    right.envelope.channel = wanted;
+
+    alice.send(wrong).await.unwrap();
+    alice.send(right.clone()).await.unwrap();
+
+    let received = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(received, right);
+}
+
+#[tokio::test]
+async fn durable_frames_fail_closed_on_udp() {
+    let bob_id = PeerId::from_u128(0xb2);
+    let mut peers = HashMap::new();
+    peers.insert(bob_id, SocketAddr::from(([127, 0, 0, 1], 5555)));
+    let (alice, _alice_addr) = bound_adapter(peers).await;
+
+    let error = alice
+        .send(frame(
+            FrameKind::Message,
+            1,
+            MentionTarget::Peer(bob_id),
+            "must not silently send",
+        ))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        UdpError::UnsupportedDurableKind(FrameKind::Message)
+    ));
+}
+
+#[tokio::test]
+async fn unknown_direct_peer_fails_before_socket_send() {
+    let (alice, _alice_addr) = bound_adapter(HashMap::new()).await;
+    let missing = PeerId::from_u128(0x99);
+
+    let error = alice
+        .send(frame(
+            FrameKind::Event,
+            1,
+            MentionTarget::Peer(missing),
+            "missing peer",
+        ))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, UdpError::UnknownPeerEndpoint(peer) if peer == missing));
+}


### PR DESCRIPTION
## Summary
- add `airc_transport::udp` with `UdpAdapter`, `UdpConfig`, and typed fail-closed errors
- support low-latency `FrameKind::Event` datagrams with subscription fan-out and channel filtering
- reject durable `Message`/`Control` frames on UDP instead of pretending they are reliable
- add `RouteEndpoint::Udp` and tighten route policy so UDP is realtime/control/signaling only, not durable data/chat

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-transport -p airc-lib --check`
- `cargo clippy --manifest-path Cargo.toml -p airc-transport -p airc-lib --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml -p airc-transport -p airc-lib`

## Coordination
- PR-F in isolated worktree: `/Users/joelteply/Development/cambrian/airc-worktrees/udp-adapter`
- Disjoint from Claude PR-H peer trust rotation work