### PR TITLE
feat(trust-rotation): signed peer trust rotation contract + daemon application (PR-H)

### DIFF
--- a/crates/airc-daemon/src/peers_store.rs
+++ b/crates/airc-daemon/src/peers_store.rs
@@ -20,8 +20,10 @@ use base64::Engine;
 use serde::{Deserialize, Serialize};
 
 use airc_core::PeerId;
+use airc_protocol::trust_rotation::{verify_rotation, RotationVerificationError, TrustRotation};
 
 const PEERS_FILENAME: &str = "peers.json";
+const PEERS_AUDIT_FILENAME: &str = "peers_audit.jsonl";
 const PEERS_VERSION: u32 = 1;
 
 #[derive(Debug)]
@@ -30,8 +32,41 @@ pub enum PeersStoreError {
     Json(serde_json::Error),
     Base64(base64::DecodeError),
     Clock(std::time::SystemTimeError),
-    SchemaVersionMismatch { found: u32, expected: u32 },
+    SchemaVersionMismatch {
+        found: u32,
+        expected: u32,
+    },
     WrongPubkeyLength(usize),
+    /// Trust gap §8 fix: a peer with this `PeerId` is already in the
+    /// store with a different pubkey. To change a stored pubkey, the
+    /// caller must use [`rotate`] with a [`TrustRotation`] signed by
+    /// the currently-stored key. Silent overwrite is forbidden.
+    PubkeyConflict {
+        peer_id: PeerId,
+        stored_pubkey_b64: String,
+        attempted_pubkey_b64: String,
+    },
+    /// Crypto-level verification of the rotation failed.
+    RotationVerification(RotationVerificationError),
+    /// Rotation supplied a `prev_pubkey` that doesn't match what's
+    /// currently stored for the target `peer_id`. Either the rotation
+    /// is stale (already superseded) or signed against a different
+    /// trust state than this store has.
+    PrevPubkeyMismatch {
+        peer_id: PeerId,
+        stored_pubkey_b64: String,
+        rotation_prev_pubkey_b64: String,
+    },
+    /// Rotation sequence number is not strictly greater than the
+    /// previously-applied rotation. Either replay or out-of-order.
+    SequenceNotMonotonic {
+        peer_id: PeerId,
+        last_applied: u64,
+        attempted: u64,
+    },
+    /// Trying to rotate a peer that isn't enrolled. The caller must
+    /// `add` first (trust-on-first-use), then `rotate` from then on.
+    UnknownPeer(PeerId),
 }
 
 impl std::fmt::Display for PeersStoreError {
@@ -47,6 +82,44 @@ impl std::fmt::Display for PeersStoreError {
             PeersStoreError::WrongPubkeyLength(got) => {
                 write!(f, "peers.json pubkey is {got} bytes, expected 32")
             }
+            PeersStoreError::PubkeyConflict {
+                peer_id,
+                stored_pubkey_b64,
+                attempted_pubkey_b64,
+            } => write!(
+                f,
+                "peer {peer_id} is already enrolled with pubkey {stored_pubkey_b64}; \
+                 cannot silently overwrite with {attempted_pubkey_b64}. Use `rotate` \
+                 with a TrustRotation signed by the currently-stored key."
+            ),
+            PeersStoreError::RotationVerification(error) => {
+                write!(f, "trust rotation rejected: {error}")
+            }
+            PeersStoreError::PrevPubkeyMismatch {
+                peer_id,
+                stored_pubkey_b64,
+                rotation_prev_pubkey_b64,
+            } => write!(
+                f,
+                "trust rotation for {peer_id} names prev_pubkey {rotation_prev_pubkey_b64} \
+                 but stored pubkey is {stored_pubkey_b64}; rotation is stale or for a \
+                 different trust state."
+            ),
+            PeersStoreError::SequenceNotMonotonic {
+                peer_id,
+                last_applied,
+                attempted,
+            } => write!(
+                f,
+                "trust rotation for {peer_id} has sequence {attempted}, not strictly greater \
+                 than last-applied {last_applied}; possible replay."
+            ),
+            PeersStoreError::UnknownPeer(peer_id) => {
+                write!(
+                    f,
+                    "trust rotation references unknown peer {peer_id}; enrol via add() first"
+                )
+            }
         }
     }
 }
@@ -58,9 +131,20 @@ impl std::error::Error for PeersStoreError {
             PeersStoreError::Json(error) => Some(error),
             PeersStoreError::Base64(error) => Some(error),
             PeersStoreError::Clock(error) => Some(error),
+            PeersStoreError::RotationVerification(error) => Some(error),
             PeersStoreError::SchemaVersionMismatch { .. }
-            | PeersStoreError::WrongPubkeyLength(_) => None,
+            | PeersStoreError::WrongPubkeyLength(_)
+            | PeersStoreError::PubkeyConflict { .. }
+            | PeersStoreError::PrevPubkeyMismatch { .. }
+            | PeersStoreError::SequenceNotMonotonic { .. }
+            | PeersStoreError::UnknownPeer(_) => None,
         }
+    }
+}
+
+impl From<RotationVerificationError> for PeersStoreError {
+    fn from(error: RotationVerificationError) -> Self {
+        PeersStoreError::RotationVerification(error)
     }
 }
 
@@ -141,32 +225,167 @@ pub fn load(home: &Path) -> Result<Vec<StoredPeer>, PeersStoreError> {
     Ok(file.peers)
 }
 
-/// Add a peer to the persisted list. Idempotent — adding a peer
-/// already present (same peer_id + pubkey) is a no-op. Different
-/// pubkey for an existing peer_id REPLACES (treat as rotation).
+/// Enrol a peer's pubkey for the first time (trust-on-first-use).
+///
+/// Behaviour:
+/// - Peer not in store: append, persist, return the new entry.
+/// - Peer in store with the SAME pubkey: idempotent no-op, return
+///   the stored entry.
+/// - Peer in store with a DIFFERENT pubkey: refuses with
+///   [`PeersStoreError::PubkeyConflict`]. Changing a stored pubkey
+///   requires an explicit signed [`rotate`] — silent overwrite was
+///   the trust-store gap §8 fix removed.
 pub fn add(home: &Path, peer_id: PeerId, pubkey: [u8; 32]) -> Result<StoredPeer, PeersStoreError> {
     let mut peers = load(home)?;
     let pubkey_b64 = URL_SAFE_NO_PAD.encode(pubkey);
-    let entry = StoredPeer {
-        peer_id,
-        pubkey_b64: pubkey_b64.clone(),
-        added_at_ms: now_ms()?,
-    };
 
-    // Replace existing entry for this peer_id (rotation) or append.
-    if let Some(existing) = peers.iter_mut().find(|p| p.peer_id == peer_id) {
+    if let Some(existing) = peers.iter().find(|p| p.peer_id == peer_id) {
         if existing.pubkey_b64 == pubkey_b64 {
-            // Identical entry — idempotent no-op, return the
-            // already-stored version.
             return Ok(existing.clone());
         }
-        *existing = entry.clone();
-    } else {
-        peers.push(entry.clone());
+        return Err(PeersStoreError::PubkeyConflict {
+            peer_id,
+            stored_pubkey_b64: existing.pubkey_b64.clone(),
+            attempted_pubkey_b64: pubkey_b64,
+        });
     }
 
+    let entry = StoredPeer {
+        peer_id,
+        pubkey_b64,
+        added_at_ms: now_ms()?,
+    };
+    peers.push(entry.clone());
     save(home, &peers)?;
     Ok(entry)
+}
+
+/// Audit-log entry recording one applied rotation. Append-only;
+/// inspectable via [`audit_log`]. Persisted in `peers_audit.jsonl`
+/// adjacent to `peers.json`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RotationAuditEntry {
+    pub peer_id: PeerId,
+    pub prev_pubkey_b64: String,
+    pub next_pubkey_b64: String,
+    pub sequence: u64,
+    /// Producer's `rotated_at_ms` from the rotation event. Audit-only.
+    pub rotated_at_ms: u64,
+    /// Local clock when the rotation was applied to this store.
+    pub applied_at_ms: u64,
+}
+
+/// Apply a signed trust rotation:
+///
+/// 1. Verify cryptographic shape (signature against `prev_pubkey`,
+///    not a no-op) via [`airc_protocol::trust_rotation::verify_rotation`].
+/// 2. Check the rotation's `prev_pubkey` matches the currently-stored
+///    pubkey for `rotation.peer_id`. A stale rotation against a
+///    superseded key is rejected.
+/// 3. Check the rotation's `sequence` is strictly greater than the
+///    last applied sequence for this peer (replay prevention).
+/// 4. Append an [`RotationAuditEntry`] to `peers_audit.jsonl`.
+/// 5. Persist the new pubkey to `peers.json`.
+///
+/// Order matters: audit is appended BEFORE peers.json is rewritten.
+/// If the audit write fails, the store is unchanged — rotation
+/// didn't apply. If peers.json rewrite fails after audit succeeded,
+/// the audit shows an intent that didn't land — `audit_log` and
+/// the on-disk pubkey will disagree and a follow-up reconciliation
+/// pass can detect that. Surfaced as `Io` either way, never silently.
+pub fn rotate(home: &Path, rotation: &TrustRotation) -> Result<StoredPeer, PeersStoreError> {
+    // Step 1: crypto.
+    verify_rotation(rotation)?;
+
+    // Step 2: stored prev_pubkey matches what rotation names.
+    let mut peers = load(home)?;
+    let stored_idx = peers
+        .iter()
+        .position(|p| p.peer_id == rotation.peer_id)
+        .ok_or(PeersStoreError::UnknownPeer(rotation.peer_id))?;
+    let stored_pubkey_b64 = peers[stored_idx].pubkey_b64.clone();
+    let rotation_prev_pubkey_b64 = URL_SAFE_NO_PAD.encode(rotation.prev_pubkey);
+    if stored_pubkey_b64 != rotation_prev_pubkey_b64 {
+        return Err(PeersStoreError::PrevPubkeyMismatch {
+            peer_id: rotation.peer_id,
+            stored_pubkey_b64,
+            rotation_prev_pubkey_b64,
+        });
+    }
+
+    // Step 3: monotonic sequence per peer.
+    let last_seq = last_applied_sequence(home, rotation.peer_id)?;
+    if rotation.sequence <= last_seq {
+        return Err(PeersStoreError::SequenceNotMonotonic {
+            peer_id: rotation.peer_id,
+            last_applied: last_seq,
+            attempted: rotation.sequence,
+        });
+    }
+
+    // Step 4: append audit entry.
+    let applied_at_ms = now_ms()?;
+    let audit_entry = RotationAuditEntry {
+        peer_id: rotation.peer_id,
+        prev_pubkey_b64: rotation_prev_pubkey_b64,
+        next_pubkey_b64: URL_SAFE_NO_PAD.encode(rotation.next_pubkey),
+        sequence: rotation.sequence,
+        rotated_at_ms: rotation.rotated_at_ms,
+        applied_at_ms,
+    };
+    append_audit(home, &audit_entry)?;
+
+    // Step 5: rewrite peers.json with the new pubkey.
+    peers[stored_idx].pubkey_b64 = URL_SAFE_NO_PAD.encode(rotation.next_pubkey);
+    peers[stored_idx].added_at_ms = applied_at_ms;
+    save(home, &peers)?;
+    Ok(peers[stored_idx].clone())
+}
+
+/// Read all audit entries for `peer_id` in apply-order. Returns an
+/// empty vec if the audit log doesn't exist yet (no rotations have
+/// ever been applied) or the peer has none.
+pub fn audit_log(home: &Path, peer_id: PeerId) -> Result<Vec<RotationAuditEntry>, PeersStoreError> {
+    let path = home.join(PEERS_AUDIT_FILENAME);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let text = std::fs::read_to_string(&path)?;
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let entry: RotationAuditEntry = serde_json::from_str(trimmed)?;
+        if entry.peer_id == peer_id {
+            out.push(entry);
+        }
+    }
+    Ok(out)
+}
+
+fn last_applied_sequence(home: &Path, peer_id: PeerId) -> Result<u64, PeersStoreError> {
+    Ok(audit_log(home, peer_id)?
+        .into_iter()
+        .map(|e| e.sequence)
+        .max()
+        .unwrap_or(0))
+}
+
+fn append_audit(home: &Path, entry: &RotationAuditEntry) -> Result<(), PeersStoreError> {
+    use std::io::Write;
+    std::fs::create_dir_all(home)?;
+    let path = home.join(PEERS_AUDIT_FILENAME);
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    let line = serde_json::to_string(entry)?;
+    file.write_all(line.as_bytes())?;
+    file.write_all(b"\n")?;
+    set_owner_only_permissions(&path)?;
+    Ok(())
 }
 
 /// Write the peer list to disk, replacing the existing file.
@@ -254,21 +473,195 @@ mod tests {
     }
 
     #[test]
-    fn add_replaces_existing_entry_on_pubkey_rotation() {
-        // Rotation case: same peer_id, new pubkey → overwrite.
+    fn add_refuses_silent_overwrite_on_pubkey_conflict() {
+        // Grievance §8 fix: silent overwrite on second `add` of the
+        // same peer_id with a new pubkey is what the rotation path
+        // replaces. `add` must now refuse and surface a typed error.
         let home = TempDir::new().unwrap();
         let id = PeerId::new();
         let old = fake_pubkey(0xc0);
         let new = fake_pubkey(0xc1);
         add(home.path(), id, old).unwrap();
-        add(home.path(), id, new).unwrap();
+        let result = add(home.path(), id, new);
+        assert!(
+            matches!(result, Err(PeersStoreError::PubkeyConflict { peer_id, .. }) if peer_id == id),
+            "second add() with a different pubkey must error PubkeyConflict; got {result:?}",
+        );
+        // Old pubkey must still be stored — no partial-overwrite.
         let loaded = load(home.path()).unwrap();
         assert_eq!(loaded.len(), 1);
-        assert_eq!(
-            loaded[0].pubkey_bytes().unwrap(),
-            new,
-            "later add must overwrite earlier pubkey for the same peer_id"
+        assert_eq!(loaded[0].pubkey_bytes().unwrap(), old);
+    }
+
+    #[test]
+    fn add_is_idempotent_for_same_peer_same_pubkey() {
+        let home = TempDir::new().unwrap();
+        let id = PeerId::new();
+        let key = fake_pubkey(0x42);
+        let first = add(home.path(), id, key).unwrap();
+        let second = add(home.path(), id, key).unwrap();
+        assert_eq!(first.peer_id, second.peer_id);
+        assert_eq!(first.pubkey_b64, second.pubkey_b64);
+        let loaded = load(home.path()).unwrap();
+        assert_eq!(loaded.len(), 1);
+    }
+
+    #[test]
+    fn signed_rotation_is_accepted_and_audited() {
+        use airc_protocol::{sign_rotation, PeerKeypair};
+
+        let home = TempDir::new().unwrap();
+        let peer_id = PeerId::new();
+        let prev_kp = PeerKeypair::generate();
+        let next_kp = PeerKeypair::generate();
+
+        add(home.path(), peer_id, prev_kp.public_bytes()).unwrap();
+
+        let rotation = sign_rotation(
+            &prev_kp,
+            peer_id,
+            next_kp.public_bytes(),
+            1,
+            1_700_000_000_000,
+        )
+        .unwrap();
+
+        let updated = rotate(home.path(), &rotation).unwrap();
+        assert_eq!(updated.pubkey_bytes().unwrap(), next_kp.public_bytes());
+
+        // Audit trail visible to consumers.
+        let audit = audit_log(home.path(), peer_id).unwrap();
+        assert_eq!(audit.len(), 1);
+        assert_eq!(audit[0].sequence, 1);
+        assert_eq!(audit[0].rotated_at_ms, 1_700_000_000_000);
+    }
+
+    #[test]
+    fn rotation_signed_by_wrong_key_is_rejected_before_audit() {
+        use airc_protocol::{sign_rotation, PeerKeypair, RotationVerificationError};
+
+        let home = TempDir::new().unwrap();
+        let peer_id = PeerId::new();
+        let prev_kp = PeerKeypair::generate();
+        let next_kp = PeerKeypair::generate();
+        let imposter_kp = PeerKeypair::generate();
+
+        add(home.path(), peer_id, prev_kp.public_bytes()).unwrap();
+
+        // Imposter forges a rotation pretending to be prev, signed by
+        // their own key. Crypto verification fails before we touch the
+        // store.
+        let bad = sign_rotation(
+            &imposter_kp,
+            peer_id,
+            next_kp.public_bytes(),
+            1,
+            1_700_000_000_000,
+        )
+        .map(|mut r| {
+            // The rotation as signed names imposter as prev_pubkey.
+            // To make the test exercise BadSignature against prev,
+            // forge prev_pubkey post-signing.
+            r.prev_pubkey = prev_kp.public_bytes();
+            r
+        })
+        .unwrap();
+
+        let result = rotate(home.path(), &bad);
+        assert!(
+            matches!(
+                result,
+                Err(PeersStoreError::RotationVerification(
+                    RotationVerificationError::BadSignature
+                ))
+            ),
+            "wrong-key rotation must fail crypto check before touching store; got {result:?}",
         );
+        // Store untouched.
+        let loaded = load(home.path()).unwrap();
+        assert_eq!(loaded[0].pubkey_bytes().unwrap(), prev_kp.public_bytes());
+        assert!(audit_log(home.path(), peer_id).unwrap().is_empty());
+    }
+
+    #[test]
+    fn stale_rotation_against_already_superseded_key_is_rejected() {
+        use airc_protocol::{sign_rotation, PeerKeypair};
+
+        let home = TempDir::new().unwrap();
+        let peer_id = PeerId::new();
+        let k0 = PeerKeypair::generate();
+        let k1 = PeerKeypair::generate();
+        let k2 = PeerKeypair::generate();
+
+        add(home.path(), peer_id, k0.public_bytes()).unwrap();
+        let r1 = sign_rotation(&k0, peer_id, k1.public_bytes(), 1, 1).unwrap();
+        rotate(home.path(), &r1).unwrap();
+
+        // Now the stored key is k1. Replay r1 (or any rotation whose
+        // prev_pubkey is k0) must be rejected — k0 was superseded.
+        let replay = sign_rotation(&k0, peer_id, k2.public_bytes(), 2, 2).unwrap();
+        let result = rotate(home.path(), &replay);
+        assert!(
+            matches!(
+                result,
+                Err(PeersStoreError::PrevPubkeyMismatch { peer_id: p, .. }) if p == peer_id
+            ),
+            "rotation against a superseded prev_pubkey must error PrevPubkeyMismatch; got {result:?}",
+        );
+    }
+
+    #[test]
+    fn rotation_with_non_monotonic_sequence_is_rejected() {
+        use airc_protocol::{sign_rotation, PeerKeypair};
+
+        let home = TempDir::new().unwrap();
+        let peer_id = PeerId::new();
+        let k0 = PeerKeypair::generate();
+        let k1 = PeerKeypair::generate();
+        let k2 = PeerKeypair::generate();
+
+        add(home.path(), peer_id, k0.public_bytes()).unwrap();
+        let r1 = sign_rotation(&k0, peer_id, k1.public_bytes(), 5, 100).unwrap();
+        rotate(home.path(), &r1).unwrap();
+
+        // Try to apply a rotation with sequence == previous (replay) and
+        // sequence < previous (out-of-order). Both must fail.
+        let same_seq = sign_rotation(&k1, peer_id, k2.public_bytes(), 5, 200).unwrap();
+        let lower_seq = sign_rotation(&k1, peer_id, k2.public_bytes(), 3, 200).unwrap();
+        assert!(matches!(
+            rotate(home.path(), &same_seq),
+            Err(PeersStoreError::SequenceNotMonotonic {
+                last_applied: 5,
+                attempted: 5,
+                ..
+            })
+        ));
+        assert!(matches!(
+            rotate(home.path(), &lower_seq),
+            Err(PeersStoreError::SequenceNotMonotonic {
+                last_applied: 5,
+                attempted: 3,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn rotation_for_unknown_peer_is_rejected() {
+        use airc_protocol::{sign_rotation, PeerKeypair};
+
+        let home = TempDir::new().unwrap();
+        let peer_id = PeerId::new();
+        let prev_kp = PeerKeypair::generate();
+        let next_kp = PeerKeypair::generate();
+
+        // Note: NO add() — peer isn't enrolled.
+        let rotation = sign_rotation(&prev_kp, peer_id, next_kp.public_bytes(), 1, 0).unwrap();
+        let result = rotate(home.path(), &rotation);
+        assert!(matches!(
+            result,
+            Err(PeersStoreError::UnknownPeer(p)) if p == peer_id
+        ));
     }
 
     #[test]

--- a/crates/airc-protocol/src/keypair.rs
+++ b/crates/airc-protocol/src/keypair.rs
@@ -89,6 +89,15 @@ impl PeerKeypair {
         self.signing.verifying_key()
     }
 
+    /// Raw Ed25519 signature over arbitrary bytes. Used by typed
+    /// signed-blob features (e.g. `trust_rotation::sign_rotation`)
+    /// that canonical-encode their own body and need a primitive
+    /// signing op. The 64-byte sig matches the Ed25519 contract.
+    pub fn sign_bytes(&self, msg: &[u8]) -> [u8; 64] {
+        use ed25519_dalek::Signer;
+        self.signing.sign(msg).to_bytes()
+    }
+
     /// Sign an envelope: produces a `Signature::Ed25519` carrying the
     /// signer's PeerId, key_id (for rotation), and 64-byte signature
     /// over the envelope's canonical CBOR encoding.

--- a/crates/airc-protocol/src/lib.rs
+++ b/crates/airc-protocol/src/lib.rs
@@ -28,6 +28,7 @@ pub mod policy;
 pub mod signature;
 pub mod subscription;
 pub mod transcript_conv;
+pub mod trust_rotation;
 
 // Re-exports — the stable public API surface.
 
@@ -44,3 +45,7 @@ pub use signature::{
     verify, KeyError, PeerKeyRegistry, Signature, VerificationError, VerificationPolicy,
 };
 pub use subscription::Subscription;
+pub use trust_rotation::{
+    canonical_rotation_bytes, sign_rotation, verify_rotation, RotationVerificationError,
+    TrustRotation,
+};

--- a/crates/airc-protocol/src/signature.rs
+++ b/crates/airc-protocol/src/signature.rs
@@ -291,7 +291,7 @@ fn check_reply_to_consistency(envelope: &Envelope) -> Result<(), VerificationErr
 }
 
 /// serde adapter for `[u8; 64]` — serde doesn't derive for arrays > 32.
-mod serde_bytes_64 {
+pub(crate) mod serde_bytes_64 {
     use serde::{de::Error, Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S: Serializer>(value: &[u8; 64], serializer: S) -> Result<S::Ok, S::Error> {

--- a/crates/airc-protocol/src/trust_rotation.rs
+++ b/crates/airc-protocol/src/trust_rotation.rs
@@ -1,0 +1,257 @@
+//! Signed peer trust rotation — the contract.
+//!
+//! The audit gap this closes:
+//! > "Peer trust rotation is still too permissive: `peers_store::add`
+//! > silently replaces a pubkey for the same `PeerId`. That must
+//! > become an explicit signed rotation/audit operation."
+//!
+//! Shape:
+//!
+//! - A [`TrustRotation`] is the typed envelope. It names the
+//!   peer, the previous pubkey, the new pubkey, a monotonic
+//!   sequence number, and a wall-clock timestamp (audit-only).
+//! - The signature is produced by the previous pubkey's secret
+//!   half. Only the holder of the previous key may authorise a
+//!   rotation to a new key.
+//! - This module verifies the cryptographic shape only:
+//!   signature is valid against `prev_pubkey`, and the rotation
+//!   isn't a no-op (prev != next).
+//! - Anti-replay (sequence > previous-applied) + "prev_pubkey
+//!   matches what's currently stored" live in the daemon's
+//!   `peers_store::rotate` because they require store state.
+//!
+//! Out of scope here: cross-machine propagation, multi-sig
+//! authorisation, recovery from lost-key.
+
+use ed25519_dalek::{Signature as Ed25519Sig, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+
+use airc_core::PeerId;
+
+use crate::PeerKeypair;
+
+/// Signed authorisation that the holder of `prev_pubkey` is rotating
+/// the trust binding for `peer_id` to `next_pubkey`.
+///
+/// The `signature` covers every preceding field of this struct
+/// (everything except `signature` itself) encoded as canonical CBOR.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrustRotation {
+    pub peer_id: PeerId,
+    /// The pubkey the rotation supersedes. The signature must be
+    /// valid against this key.
+    pub prev_pubkey: [u8; 32],
+    /// The pubkey the rotation authorises. Must differ from
+    /// `prev_pubkey` — no-op rotations are rejected.
+    pub next_pubkey: [u8; 32],
+    /// Per-peer monotonic counter. Strictly increasing across all
+    /// rotations applied to this peer. Enforced by the store
+    /// (`peers_store::rotate`), not by this module — replay
+    /// prevention requires knowing the previous applied sequence.
+    pub sequence: u64,
+    /// Producer wall-clock at signing time. Audit-only; the daemon
+    /// does NOT trust this for security decisions because clock skew
+    /// is real and signing machines can lie.
+    pub rotated_at_ms: u64,
+    /// Ed25519 signature over the canonical CBOR encoding of the
+    /// preceding fields, produced by the secret half of `prev_pubkey`.
+    #[serde(with = "crate::signature::serde_bytes_64")]
+    pub signature: [u8; 64],
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum RotationVerificationError {
+    /// `prev_pubkey` was not a valid Ed25519 verifying key.
+    InvalidPrevPubkey,
+    /// Signature did not verify against `prev_pubkey`. Most common
+    /// failure mode — someone produced a rotation request without
+    /// holding the old secret.
+    BadSignature,
+    /// `prev_pubkey == next_pubkey`. Rotation must change something.
+    NoOpRotation,
+    /// Canonical CBOR encoding of the rotation body failed.
+    CanonicalEncodingFailed,
+}
+
+impl std::fmt::Display for RotationVerificationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidPrevPubkey => {
+                f.write_str("trust rotation: prev_pubkey is not a valid Ed25519 verifying key")
+            }
+            Self::BadSignature => {
+                f.write_str("trust rotation: signature did not verify against prev_pubkey")
+            }
+            Self::NoOpRotation => {
+                f.write_str("trust rotation: prev_pubkey == next_pubkey is a no-op")
+            }
+            Self::CanonicalEncodingFailed => {
+                f.write_str("trust rotation: canonical CBOR encoding of body failed")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RotationVerificationError {}
+
+/// Cryptographic verification only. The daemon's `peers_store::rotate`
+/// must ALSO check:
+/// - `rotation.prev_pubkey` matches what's currently stored for
+///   `rotation.peer_id`, and
+/// - `rotation.sequence` is strictly greater than the previously
+///   applied sequence for this peer.
+pub fn verify_rotation(rotation: &TrustRotation) -> Result<(), RotationVerificationError> {
+    if rotation.prev_pubkey == rotation.next_pubkey {
+        return Err(RotationVerificationError::NoOpRotation);
+    }
+    let verifying = VerifyingKey::from_bytes(&rotation.prev_pubkey)
+        .map_err(|_| RotationVerificationError::InvalidPrevPubkey)?;
+    let signed_bytes = canonical_rotation_bytes(rotation)
+        .map_err(|_| RotationVerificationError::CanonicalEncodingFailed)?;
+    let sig = Ed25519Sig::from_bytes(&rotation.signature);
+    verifying
+        .verify(&signed_bytes, &sig)
+        .map_err(|_| RotationVerificationError::BadSignature)
+}
+
+/// Sign a trust rotation. The caller MUST hold the secret half of
+/// `prev_keypair`; this method produces the signature over the
+/// canonical body so the verifier accepts. Callers that do not
+/// hold the previous key cannot produce a passing rotation by
+/// construction.
+pub fn sign_rotation(
+    prev_keypair: &PeerKeypair,
+    peer_id: PeerId,
+    next_pubkey: [u8; 32],
+    sequence: u64,
+    rotated_at_ms: u64,
+) -> Result<TrustRotation, ciborium::ser::Error<std::io::Error>> {
+    let prev_pubkey = prev_keypair.public_bytes();
+    let mut rotation = TrustRotation {
+        peer_id,
+        prev_pubkey,
+        next_pubkey,
+        sequence,
+        rotated_at_ms,
+        signature: [0u8; 64],
+    };
+    let bytes = canonical_rotation_bytes(&rotation)?;
+    rotation.signature = prev_keypair.sign_bytes(&bytes);
+    Ok(rotation)
+}
+
+/// Canonical CBOR bytes of the rotation EXCLUDING the signature.
+/// These are the bytes the prev-key signer signs and the verifier
+/// verifies against.
+pub fn canonical_rotation_bytes(
+    rotation: &TrustRotation,
+) -> Result<Vec<u8>, ciborium::ser::Error<std::io::Error>> {
+    #[derive(Serialize)]
+    struct SignedRotationPayload<'r> {
+        peer_id: &'r PeerId,
+        prev_pubkey: &'r [u8; 32],
+        next_pubkey: &'r [u8; 32],
+        sequence: u64,
+        rotated_at_ms: u64,
+    }
+    let payload = SignedRotationPayload {
+        peer_id: &rotation.peer_id,
+        prev_pubkey: &rotation.prev_pubkey,
+        next_pubkey: &rotation.next_pubkey,
+        sequence: rotation.sequence,
+        rotated_at_ms: rotation.rotated_at_ms,
+    };
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&payload, &mut buf)?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn well_formed_rotation_verifies() {
+        let prev = PeerKeypair::generate();
+        let next = PeerKeypair::generate();
+        let rotation = sign_rotation(
+            &prev,
+            PeerId::from_u128(0xa1),
+            next.public_bytes(),
+            1,
+            1_700_000_000_000,
+        )
+        .unwrap();
+        assert!(verify_rotation(&rotation).is_ok());
+    }
+
+    #[test]
+    fn rotation_signed_by_wrong_key_is_rejected() {
+        // Build a rotation that CLAIMS prev_pubkey is `prev`'s, but
+        // actually sign with `wrong_signer` — a forgery attempt.
+        let prev = PeerKeypair::generate();
+        let wrong_signer = PeerKeypair::generate();
+        let next = PeerKeypair::generate();
+
+        let mut rotation = TrustRotation {
+            peer_id: PeerId::from_u128(0xa1),
+            prev_pubkey: prev.public_bytes(),
+            next_pubkey: next.public_bytes(),
+            sequence: 1,
+            rotated_at_ms: 1_700_000_000_000,
+            signature: [0u8; 64],
+        };
+        let bytes = canonical_rotation_bytes(&rotation).unwrap();
+        rotation.signature = wrong_signer.sign_bytes(&bytes);
+
+        assert_eq!(
+            verify_rotation(&rotation),
+            Err(RotationVerificationError::BadSignature),
+        );
+    }
+
+    #[test]
+    fn tampered_rotation_after_signing_is_rejected() {
+        let prev = PeerKeypair::generate();
+        let next = PeerKeypair::generate();
+        let attacker_target = PeerKeypair::generate();
+        let mut rotation = sign_rotation(
+            &prev,
+            PeerId::from_u128(0xa1),
+            next.public_bytes(),
+            1,
+            1_700_000_000_000,
+        )
+        .unwrap();
+        // Swap next_pubkey after signing — attacker tries to redirect
+        // the rotation to a key they control without re-signing.
+        rotation.next_pubkey = attacker_target.public_bytes();
+        assert_eq!(
+            verify_rotation(&rotation),
+            Err(RotationVerificationError::BadSignature),
+        );
+    }
+
+    #[test]
+    fn no_op_rotation_is_rejected() {
+        let prev = PeerKeypair::generate();
+        let rotation = sign_rotation(
+            &prev,
+            PeerId::from_u128(0xa1),
+            prev.public_bytes(), // same as prev — rotation must change something
+            1,
+            1_700_000_000_000,
+        )
+        .unwrap();
+        assert_eq!(
+            verify_rotation(&rotation),
+            Err(RotationVerificationError::NoOpRotation),
+        );
+    }
+
+    // InvalidPrevPubkey is defensive — dalek 2.x's VerifyingKey decoder
+    // accepts arbitrary 32-byte arrays as valid points, so triggering
+    // this variant deterministically is tricky. The variant stays for
+    // future-proofing (a stricter dalek release would activate it);
+    // BadSignature covers the practical rejection path for bogus keys.
+}


### PR DESCRIPTION
## Summary

Closes the trust-rotation gap. Today `peers_store::add` silently overwrites a stored pubkey when the same `PeerId` is added with a different key — anyone who can write `peers.json` can rotate any peer's trust binding undetected. This PR makes rotation an explicit, signed, audited operation.

## Work Intake Rule

- **Grievance closed:** §8 ("Trust Store Semantics Are Too Loose"). Audit 2026-05-19 line 624.
- **Gap closed:** Security Gaps list — *"explicit key rotation protocol; signed trust changes; audit log for admin/trust/work changes"*.
- **Acceptance gate:** Gate 5 (security).
- **Python/shell:** untouched.
- **Branch:** `feat/peer-trust-rotation` off `rust-rewrite@ae9893b`. Cut from current tip after #818 (UDP) landed.
- **Tests:** 4 protocol-level + 7 daemon-level (1 updated, 6 new).

## Protocol layer (`airc-protocol::trust_rotation`)

- `TrustRotation { peer_id, prev_pubkey, next_pubkey, sequence, rotated_at_ms, signature }` — typed signed event.
- `sign_rotation(prev_keypair, ...)` — produces a rotation signed by the previous key.
- `verify_rotation(&r)` — cryptographic verification only (signature against `prev_pubkey`, not a no-op).
- `canonical_rotation_bytes()` — CBOR-encoded signed payload.
- New `PeerKeypair::sign_bytes(msg) -> [u8; 64]` for typed-signed-blob features; existing `sign_envelope` unchanged.
- `serde_bytes_64` promoted to `pub(crate)` so the new module reuses the same `[u8; 64]` serde adapter.

## Daemon layer (`airc-daemon::peers_store`)

- **`add()` is now fail-closed.** Same peer_id with different pubkey → `PubkeyConflict` error with a clear "use rotate" message. Same-pubkey adds remain idempotent.
- **`rotate(home, rotation)` new:**
  1. `verify_rotation()` (crypto).
  2. Stored `prev_pubkey` for the peer must equal `rotation.prev_pubkey` → rejects stale rotations against superseded keys (`PrevPubkeyMismatch`).
  3. `rotation.sequence` must be strictly greater than last applied per peer (`SequenceNotMonotonic`).
  4. Append `RotationAuditEntry` to `peers_audit.jsonl`.
  5. Rewrite `peers.json` with the new pubkey.
- **`audit_log(home, peer_id)` new** — replays the audit log filtered by peer for inspection.
- **Order matters:** audit append → peers.json rewrite. If rewrite fails after audit succeeded, the audit shows an intent that didn't land — `audit_log()` vs stored pubkey will disagree, surfaced via the existing `Io` error path. No silent partial states.

## Architectural separation

- Crypto-only checks live in `airc-protocol` (substrate contract).
- Store-state checks live in `airc-daemon` (application of the contract).
- Per Codex's tightening note: protocol/trust contract + daemon store application, no CLI, no transport, no hidden migration path.

## Test plan

- [x] `cargo test -p airc-protocol -p airc-daemon` — 13 peers_store + 4 trust_rotation tests pass
- [x] `cargo test --workspace` — **466 tests pass**
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] CI on Ubuntu/macOS/Windows will run on this PR

## Out of scope (deliberate, for follow-up PRs)

- **Cross-machine rotation propagation.** One peer rotating its key needs to reach other peers' stores. Same event-store + projection pattern Slice 7 PR 3 established, but the wire path is its own concern.
- **CLI command** for `airc-rs peer rotate` — Codex's CLI-thinning lane.
- **Multi-sig / threshold rotation.** Single-old-key authorisation is the baseline.

## Coordination

Developed in isolated worktree `/private/tmp/airc-claude-pr-h` per the workspace-isolation convention from earlier today. Codex's PR-F (#818) and his upcoming PR-G (WebRTC) don't touch any of the surfaces this PR modifies (`airc-protocol::trust_rotation`, `airc-daemon::peers_store`). Sent `airc msg` ping with the same scope summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)