### PR TITLE
feat(airc-transport): add WebRTC datachannel adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,7 +76,7 @@ dependencies = [
  "futures",
  "hkdf",
  "libc",
- "rand_core",
+ "rand_core 0.6.4",
  "rustls",
  "serde",
  "serde_json",
@@ -122,7 +147,7 @@ dependencies = [
  "airc-core",
  "ciborium",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
 ]
@@ -178,7 +203,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-rustls",
- "x509-parser",
+ "webrtc",
+ "x509-parser 0.18.1",
 ]
 
 [[package]]
@@ -290,11 +316,27 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.6.0",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -302,6 +344,18 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -376,6 +430,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +472,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -429,10 +495,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -447,6 +545,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +561,18 @@ checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "ccm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
 ]
 
 [[package]]
@@ -655,14 +774,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -745,11 +885,25 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -819,6 +973,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,7 +1004,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -850,6 +1018,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -895,6 +1084,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1057,6 +1256,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1072,15 +1272,37 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1088,6 +1310,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "half"
@@ -1339,6 +1572,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -1399,7 +1633,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.5",
@@ -1449,7 +1683,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "serde",
  "winapi",
 ]
@@ -1481,6 +1715,15 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -1506,16 +1749,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -1549,7 +1825,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1592,11 +1868,20 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
 ]
 
 [[package]]
@@ -1648,6 +1933,30 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -1720,6 +2029,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +2079,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +2122,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1842,6 +2178,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,9 +2208,24 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -1863,8 +2234,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1874,7 +2255,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1887,6 +2278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,7 +2296,7 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "time",
- "x509-parser",
+ "x509-parser 0.18.1",
  "yasna",
 ]
 
@@ -1906,7 +2306,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1915,7 +2315,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1948,6 +2348,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,6 +2378,36 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1974,11 +2423,288 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtc"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac1b7092bf69781b30b983d0f2c689f4289a110990ad59c43e561f2ff8fd724"
+dependencies = [
+ "bytes",
+ "hex",
+ "log",
+ "rand 0.9.4",
+ "rcgen",
+ "ring",
+ "rtc-datachannel",
+ "rtc-dtls",
+ "rtc-ice",
+ "rtc-interceptor",
+ "rtc-mdns",
+ "rtc-media",
+ "rtc-rtcp",
+ "rtc-rtp",
+ "rtc-sctp",
+ "rtc-sdp",
+ "rtc-shared",
+ "rtc-srtp",
+ "rtc-stun",
+ "rtc-turn",
+ "rustls",
+ "sansio",
+ "serde",
+ "serde_json",
+ "sha2",
+ "unicase",
+ "url",
+]
+
+[[package]]
+name = "rtc-datachannel"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b532151afaf5f8af7f36b8a57e687dd5ed238117cd29d4bf3a3f68fa8fe035"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-sctp",
+ "rtc-shared",
+ "sansio",
+]
+
+[[package]]
+name = "rtc-dtls"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "067a19d0491fa2b09363bf9fdab2b3889447498844da092f875a1de9968750d0"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "bytecheck",
+ "byteorder",
+ "bytes",
+ "cbc",
+ "ccm",
+ "chacha20poly1305",
+ "der-parser 9.0.0",
+ "hmac",
+ "log",
+ "p256",
+ "p384",
+ "rand 0.9.4",
+ "rand_core 0.6.4",
+ "rcgen",
+ "ring",
+ "rkyv",
+ "rtc-shared",
+ "rustls",
+ "sec1",
+ "sha1",
+ "sha2",
+ "subtle",
+ "x25519-dalek",
+ "x509-parser 0.16.0",
+]
+
+[[package]]
+name = "rtc-ice"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c90a85ecfc2b18ee7697342974afa55d36667d9ca7bec3a5eae63322da997c"
+dependencies = [
+ "bytes",
+ "crc",
+ "log",
+ "rand 0.9.4",
+ "rtc-mdns",
+ "rtc-shared",
+ "rtc-stun",
+ "sansio",
+ "serde",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "rtc-interceptor"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d531f43e290ee72bc782225ecb23d82b38994d69b6c8db9fbdc8eed07ed35e"
+dependencies = [
+ "log",
+ "rand 0.9.4",
+ "rtc-interceptor-derive",
+ "rtc-rtcp",
+ "rtc-rtp",
+ "rtc-shared",
+ "sansio",
+]
+
+[[package]]
+name = "rtc-interceptor-derive"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39d78fc2ae7d5e99881d6604a972e99d97d839e5b3d0668018f82f0faa9bfb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "rtc-mdns"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57deeaa15ece574bf4b6ecd697e4b036aff0bc042e56fb811921eef063a2fdd5"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-shared",
+ "sansio",
+ "socket2 0.5.10",
+]
+
+[[package]]
+name = "rtc-media"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73afea835cfb207f22f4a22952538e3c7cc0ab14dee913b702134178adf2462"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "rand 0.9.4",
+ "rtc-rtp",
+ "rtc-shared",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rtc-rtcp"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b922f475a00c6f853b0c4a3d66c9984fceed368f56dba5fe82af3aff1c77edc7"
+dependencies = [
+ "bytes",
+ "rtc-shared",
+]
+
+[[package]]
+name = "rtc-rtp"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1076beeb0f13d4d38e7fe23c46896de638eeea9a7f2cb13209c31c42d37fe290"
+dependencies = [
+ "bytes",
+ "memchr",
+ "rand 0.9.4",
+ "rtc-shared",
+ "serde",
+]
+
+[[package]]
+name = "rtc-sctp"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d63968f1f8c2c016d04fc16c5a43608772e5b02f9657eed659273dd01b825f7"
+dependencies = [
+ "bytes",
+ "crc",
+ "log",
+ "rand 0.9.4",
+ "rtc-shared",
+ "slab",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rtc-sdp"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8598470804b29e4f3d3486226b43f84db6c0f64311bd1c9e8ec1d9172c3e4c3"
+dependencies = [
+ "rand 0.9.4",
+ "rtc-shared",
+ "url",
+]
+
+[[package]]
+name = "rtc-shared"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b76f42332957719c1922bc9a4ba67ed348d12fca8705c3df171c44058d8f90"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "bitflags 1.3.2",
+ "bytes",
+ "nix 0.26.4",
+ "p256",
+ "rand 0.9.4",
+ "rcgen",
+ "sec1",
+ "serde",
+ "substring",
+ "thiserror 2.0.18",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "rtc-srtp"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91a79f9ac2db5fb54358d6ec6d51dcee64088507f2035b743f28dc9eabac7de5"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "byteorder",
+ "bytes",
+ "ctr",
+ "hmac",
+ "rtc-rtcp",
+ "rtc-rtp",
+ "rtc-shared",
+ "sha1",
+ "subtle",
+]
+
+[[package]]
+name = "rtc-stun"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4492e747d6468f0e69f5e186639b4075cb777a9a983be5c7d51493c2a05245"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.9.4",
+ "ring",
+ "rtc-shared",
+ "sansio",
+ "subtle",
+ "url",
+]
+
+[[package]]
+name = "rtc-turn"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c52c4a3b6d9fea3cb7d1365ff88ee1610ac6c57d0ee126b3b4a26b5debdda6f"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-shared",
+ "rtc-stun",
+ "sansio",
 ]
 
 [[package]]
@@ -2017,7 +2743,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2069,6 +2795,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "sansio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62751faa8bc286982334a082fe125184a29fc89d17775766e4f891b7d726980"
 
 [[package]]
 name = "scopeguard"
@@ -2230,6 +2962,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,8 +3096,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2366,6 +3118,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2493,7 +3255,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "crc",
@@ -2514,7 +3276,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -2536,7 +3298,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "crc",
  "dotenvy",
@@ -2553,7 +3315,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -2625,6 +3387,15 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "subtle"
@@ -2792,7 +3563,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2919,6 +3690,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -3122,7 +3899,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3144,6 +3921,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webrtc"
+version = "0.20.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c747ddba952c11f0847312a6c56fdcec9b89258937e5b5a35c20110d2670304"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "log",
+ "rtc",
+ "tokio",
 ]
 
 [[package]]
@@ -3458,7 +4249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -3501,9 +4292,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "data-encoding",
+ "der-parser 9.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.7.1",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]
@@ -3512,12 +4320,12 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
  "data-encoding",
- "der-parser",
+ "der-parser 10.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.8.1",
  "ring",
  "rusticata-macros",
  "thiserror 2.0.18",

--- a/crates/airc-protocol/src/lib.rs
+++ b/crates/airc-protocol/src/lib.rs
@@ -25,6 +25,7 @@ pub mod headers_keys;
 pub mod keypair;
 pub mod media;
 pub mod policy;
+pub mod rtc_signal;
 pub mod signature;
 pub mod subscription;
 pub mod transcript_conv;
@@ -40,6 +41,7 @@ pub use headers_keys::{
 pub use keypair::PeerKeypair;
 pub use media::MediaRef;
 pub use policy::{AlwaysLift, LiftPolicy, NeverLift, SizeThresholdPolicy};
+pub use rtc_signal::{WebRtcSignal, WebRtcSignalKind, WEBRTC_SIGNAL_BODY_HINT};
 pub use signature::{
     verify, KeyError, PeerKeyRegistry, Signature, VerificationError, VerificationPolicy,
 };

--- a/crates/airc-protocol/src/rtc_signal.rs
+++ b/crates/airc-protocol/src/rtc_signal.rs
@@ -1,0 +1,81 @@
+//! WebRTC signaling payload contract.
+//!
+//! AIRC carries the control plane for WebRTC datachannel routes:
+//! offer/answer/ICE metadata as signed AIRC events. Media bytes and
+//! datachannel bytes stay on WebRTC. Consumers place this payload in a
+//! frame body and set `forge.body_hint = WEBRTC_SIGNAL_BODY_HINT`.
+
+use serde::{Deserialize, Serialize};
+
+use airc_core::{EventId, PeerId, RoomId};
+
+pub const WEBRTC_SIGNAL_BODY_HINT: &str = "forge.webrtc.signal";
+pub const WEBRTC_SIGNAL_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebRtcSignalKind {
+    Offer,
+    Answer,
+    IceCandidate,
+    Teardown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebRtcSignal {
+    pub schema_version: u16,
+    pub session_id: EventId,
+    pub room_id: RoomId,
+    pub from_peer: PeerId,
+    pub to_peer: PeerId,
+    pub kind: WebRtcSignalKind,
+    /// SDP text for offer/answer, ICE candidate JSON for
+    /// `IceCandidate`, or a short machine-readable reason for
+    /// `Teardown`.
+    pub payload: String,
+}
+
+impl WebRtcSignal {
+    pub fn new(
+        session_id: EventId,
+        room_id: RoomId,
+        from_peer: PeerId,
+        to_peer: PeerId,
+        kind: WebRtcSignalKind,
+        payload: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version: WEBRTC_SIGNAL_SCHEMA_VERSION,
+            session_id,
+            room_id,
+            from_peer,
+            to_peer,
+            kind,
+            payload: payload.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signal_contract_round_trips_without_transport_fields() {
+        let signal = WebRtcSignal::new(
+            EventId::from_u128(1),
+            RoomId::from_u128(2),
+            PeerId::from_u128(3),
+            PeerId::from_u128(4),
+            WebRtcSignalKind::Offer,
+            "v=0\r\n",
+        );
+
+        let json = serde_json::to_string(&signal).unwrap();
+        let decoded: WebRtcSignal = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded, signal);
+        assert!(!json.contains("udp_addr"));
+        assert!(!json.contains("transport_kind"));
+    }
+}

--- a/crates/airc-transport/Cargo.toml
+++ b/crates/airc-transport/Cargo.toml
@@ -23,6 +23,7 @@ rcgen = { version = "0.14", default-features = false, features = ["pem", "ring"]
 rustls-pki-types = "1"
 ed25519-dalek = { version = "2", features = ["pkcs8"] }
 x509-parser = "0.18"
+webrtc = { version = "0.20.0-alpha.1", default-features = false, features = ["runtime-tokio"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/airc-transport/src/lib.rs
+++ b/crates/airc-transport/src/lib.rs
@@ -28,6 +28,7 @@ pub mod relay;
 pub mod signed;
 pub mod transport;
 pub mod udp;
+pub mod webrtc_datachannel;
 
 // Re-exports — stable public surface.
 pub use error::LocalFsError;
@@ -41,3 +42,4 @@ pub use local_fs::LocalFsAdapter;
 pub use signed::{SignedError, SignedTransport};
 pub use transport::{FrameStream, Transport};
 pub use udp::{UdpAdapter, UdpConfig, UdpError};
+pub use webrtc_datachannel::{WebRtcDataChannelAdapter, WebRtcDataChannelError};

--- a/crates/airc-transport/src/webrtc_datachannel/adapter.rs
+++ b/crates/airc-transport/src/webrtc_datachannel/adapter.rs
@@ -1,0 +1,184 @@
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::stream::Stream;
+use tokio::sync::{mpsc, Mutex};
+use webrtc::data_channel::{DataChannel, DataChannelEvent};
+
+use airc_protocol::{Frame, FrameKind, Subscription};
+
+use crate::transport::{FrameStream, Transport};
+use crate::webrtc_datachannel::error::WebRtcDataChannelError;
+
+const MAX_DATACHANNEL_FRAME_BYTES: usize = 16 * 1024;
+const SUBSCRIBER_CHANNEL_DEPTH: usize = 64;
+
+struct SubscriberHandle {
+    #[allow(dead_code)]
+    id: u64,
+    subscription: Subscription,
+    tx: mpsc::Sender<Result<Frame, WebRtcDataChannelError>>,
+}
+
+struct Inner {
+    channel: Arc<dyn DataChannel>,
+    is_open: AtomicBool,
+    subscribers: Mutex<Vec<SubscriberHandle>>,
+    next_sub_id: AtomicU64,
+}
+
+#[derive(Clone)]
+pub struct WebRtcDataChannelAdapter {
+    inner: Arc<Inner>,
+}
+
+impl WebRtcDataChannelAdapter {
+    pub fn new(channel: Arc<dyn DataChannel>) -> Self {
+        let adapter = Self {
+            inner: Arc::new(Inner {
+                channel,
+                is_open: AtomicBool::new(false),
+                subscribers: Mutex::new(Vec::new()),
+                next_sub_id: AtomicU64::new(0),
+            }),
+        };
+        adapter.spawn_poll_loop();
+        adapter
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.inner.is_open.load(Ordering::Acquire)
+    }
+
+    fn spawn_poll_loop(&self) {
+        let inner = Arc::clone(&self.inner);
+        tokio::spawn(async move {
+            while let Some(event) = inner.channel.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => {
+                        inner.is_open.store(true, Ordering::Release);
+                    }
+                    DataChannelEvent::OnMessage(message) => {
+                        let frame = serde_json::from_slice::<Frame>(&message.data);
+                        match frame {
+                            Ok(frame) => dispatch_frame(&inner, frame).await,
+                            Err(error) => {
+                                dispatch_error(&inner, WebRtcDataChannelError::Json(error)).await;
+                            }
+                        }
+                    }
+                    DataChannelEvent::OnClose => {
+                        inner.is_open.store(false, Ordering::Release);
+                        return;
+                    }
+                    DataChannelEvent::OnError => {
+                        dispatch_error(
+                            &inner,
+                            WebRtcDataChannelError::WebRtc("datachannel error event".to_string()),
+                        )
+                        .await;
+                    }
+                    DataChannelEvent::OnClosing
+                    | DataChannelEvent::OnBufferedAmountLow
+                    | DataChannelEvent::OnBufferedAmountHigh => {}
+                }
+            }
+            inner.is_open.store(false, Ordering::Release);
+        });
+    }
+}
+
+async fn dispatch_frame(inner: &Arc<Inner>, frame: Frame) {
+    let subscribers = {
+        let subscribers = inner.subscribers.lock().await;
+        subscribers
+            .iter()
+            .filter(|subscriber| subscriber.subscription.matches(&frame))
+            .map(|subscriber| subscriber.tx.clone())
+            .collect::<Vec<_>>()
+    };
+
+    for tx in subscribers {
+        let _ = tx.try_send(Ok(frame.clone()));
+    }
+}
+
+async fn dispatch_error(inner: &Arc<Inner>, error: WebRtcDataChannelError) {
+    let subscribers = {
+        let subscribers = inner.subscribers.lock().await;
+        subscribers
+            .iter()
+            .map(|subscriber| subscriber.tx.clone())
+            .collect::<Vec<_>>()
+    };
+
+    for tx in subscribers {
+        let _ = tx.try_send(Err(match &error {
+            WebRtcDataChannelError::Json(json) => {
+                WebRtcDataChannelError::Json(serde_json::Error::io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    json.to_string(),
+                )))
+            }
+            WebRtcDataChannelError::WebRtc(message) => {
+                WebRtcDataChannelError::WebRtc(message.clone())
+            }
+            WebRtcDataChannelError::NotOpen => WebRtcDataChannelError::NotOpen,
+            WebRtcDataChannelError::FrameTooLarge { actual, limit } => {
+                WebRtcDataChannelError::FrameTooLarge {
+                    actual: *actual,
+                    limit: *limit,
+                }
+            }
+            WebRtcDataChannelError::UnsupportedDurableKind(kind) => {
+                WebRtcDataChannelError::UnsupportedDurableKind(*kind)
+            }
+        }));
+    }
+}
+
+#[async_trait]
+impl Transport for WebRtcDataChannelAdapter {
+    type Error = WebRtcDataChannelError;
+
+    async fn send(&self, frame: Frame) -> Result<(), Self::Error> {
+        if !matches!(frame.kind, FrameKind::Event) {
+            return Err(WebRtcDataChannelError::UnsupportedDurableKind(frame.kind));
+        }
+        if !self.is_open() {
+            return Err(WebRtcDataChannelError::NotOpen);
+        }
+        let payload = serde_json::to_string(&frame)?;
+        if payload.len() > MAX_DATACHANNEL_FRAME_BYTES {
+            return Err(WebRtcDataChannelError::FrameTooLarge {
+                actual: payload.len(),
+                limit: MAX_DATACHANNEL_FRAME_BYTES,
+            });
+        }
+        self.inner
+            .channel
+            .send_text(&payload)
+            .await
+            .map_err(|error| WebRtcDataChannelError::WebRtc(error.to_string()))?;
+        Ok(())
+    }
+
+    async fn subscribe(
+        &self,
+        subscription: Subscription,
+    ) -> Result<FrameStream<Self::Error>, Self::Error> {
+        let (tx, rx) = mpsc::channel(SUBSCRIBER_CHANNEL_DEPTH);
+        let id = self.inner.next_sub_id.fetch_add(1, Ordering::Relaxed);
+        self.inner.subscribers.lock().await.push(SubscriberHandle {
+            id,
+            subscription,
+            tx,
+        });
+        let stream = futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        });
+        Ok(Box::pin(stream) as Pin<Box<dyn Stream<Item = _> + Send>>)
+    }
+}

--- a/crates/airc-transport/src/webrtc_datachannel/error.rs
+++ b/crates/airc-transport/src/webrtc_datachannel/error.rs
@@ -1,0 +1,47 @@
+use airc_protocol::FrameKind;
+
+#[derive(Debug)]
+pub enum WebRtcDataChannelError {
+    Json(serde_json::Error),
+    WebRtc(String),
+    NotOpen,
+    FrameTooLarge { actual: usize, limit: usize },
+    UnsupportedDurableKind(FrameKind),
+}
+
+impl std::fmt::Display for WebRtcDataChannelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Json(error) => write!(f, "webrtc datachannel frame parse: {error}"),
+            Self::WebRtc(error) => write!(f, "webrtc datachannel error: {error}"),
+            Self::NotOpen => f.write_str("webrtc datachannel is not open"),
+            Self::FrameTooLarge { actual, limit } => {
+                write!(
+                    f,
+                    "webrtc datachannel frame size {actual} exceeds limit {limit}"
+                )
+            }
+            Self::UnsupportedDurableKind(kind) => {
+                write!(f, "webrtc datachannel route rejects durable kind {kind:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WebRtcDataChannelError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Json(error) => Some(error),
+            Self::WebRtc(_)
+            | Self::NotOpen
+            | Self::FrameTooLarge { .. }
+            | Self::UnsupportedDurableKind(_) => None,
+        }
+    }
+}
+
+impl From<serde_json::Error> for WebRtcDataChannelError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}

--- a/crates/airc-transport/src/webrtc_datachannel/mod.rs
+++ b/crates/airc-transport/src/webrtc_datachannel/mod.rs
@@ -1,0 +1,15 @@
+//! WebRTC datachannel transport adapter.
+//!
+//! WebRTC signaling travels as signed AIRC events using
+//! `airc_protocol::WebRtcSignal`. Once the selected signaling route
+//! has established a datachannel, this adapter carries realtime AIRC
+//! event frames over that channel. Audio/video media is out of scope.
+
+mod adapter;
+mod error;
+
+pub use adapter::WebRtcDataChannelAdapter;
+pub use error::WebRtcDataChannelError;
+
+#[cfg(test)]
+mod tests;

--- a/crates/airc-transport/src/webrtc_datachannel/tests.rs
+++ b/crates/airc-transport/src/webrtc_datachannel/tests.rs
@@ -1,0 +1,238 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use airc_core::{headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, PeerId};
+use airc_protocol::{ChannelId, Envelope, Frame, FrameKind, Signature, Subscription};
+use futures::StreamExt;
+use tokio::sync::mpsc;
+use webrtc::data_channel::DataChannel;
+use webrtc::peer_connection::{
+    PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler, RTCIceGatheringState,
+    RTCPeerConnectionState,
+};
+use webrtc::runtime::{channel, default_runtime, timeout as rtc_timeout, Sender};
+
+use crate::transport::Transport;
+use crate::webrtc_datachannel::{WebRtcDataChannelAdapter, WebRtcDataChannelError};
+
+struct OffererHandler {
+    gather_complete_tx: Sender<()>,
+    connected_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for OffererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_complete_tx.try_send(());
+        }
+    }
+
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+struct AnswererHandler {
+    gather_complete_tx: Sender<()>,
+    connected_tx: Sender<()>,
+    adapter_tx: mpsc::Sender<WebRtcDataChannelAdapter>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for AnswererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_complete_tx.try_send(());
+        }
+    }
+
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+
+    async fn on_data_channel(&self, channel: Arc<dyn DataChannel>) {
+        let adapter = WebRtcDataChannelAdapter::new(channel);
+        let _ = self.adapter_tx.send(adapter).await;
+    }
+}
+
+fn event_frame(lamport: u64, body: &str) -> Frame {
+    Frame {
+        kind: FrameKind::Event,
+        envelope: Envelope {
+            event_id: EventId::from_u128(lamport as u128),
+            sender: PeerId::from_u128(0xa1),
+            sender_client: ClientId::from_u128(0xc1),
+            channel: ChannelId::from_u128(0xc0ffee),
+            target: MentionTarget::All,
+            lamport,
+            occurred_at_ms: 1_700_000_000_000 + lamport,
+            reply_to: None,
+            headers: Headers::new(),
+            body: Some(Body::text(body)),
+            media: Vec::new(),
+            signature: Signature::Unsigned,
+        },
+    }
+}
+
+fn durable_frame() -> Frame {
+    let mut frame = event_frame(99, "durable");
+    frame.kind = FrameKind::Message;
+    frame
+}
+
+async fn wait_open(adapter: &WebRtcDataChannelAdapter) {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(10) {
+        if adapter.is_open() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("webrtc datachannel did not open within 10s");
+}
+
+async fn established_adapters() -> (
+    WebRtcDataChannelAdapter,
+    WebRtcDataChannelAdapter,
+    Arc<dyn webrtc::peer_connection::PeerConnection>,
+    Arc<dyn webrtc::peer_connection::PeerConnection>,
+) {
+    let runtime = default_runtime().expect("default webrtc runtime");
+
+    let (offerer_gather_tx, mut offerer_gather_rx) = channel::<()>(1);
+    let (offerer_connected_tx, mut offerer_connected_rx) = channel::<()>(1);
+    let (answerer_gather_tx, mut answerer_gather_rx) = channel::<()>(1);
+    let (answerer_connected_tx, mut answerer_connected_rx) = channel::<()>(1);
+    let (answer_adapter_tx, mut answer_adapter_rx) = mpsc::channel(1);
+
+    let offerer_pc = Arc::new(
+        PeerConnectionBuilder::new()
+            .with_handler(Arc::new(OffererHandler {
+                gather_complete_tx: offerer_gather_tx,
+                connected_tx: offerer_connected_tx,
+            }))
+            .with_runtime(runtime.clone())
+            .with_udp_addrs(vec!["127.0.0.1:0"])
+            .build()
+            .await
+            .expect("offerer peer connection"),
+    );
+
+    let offerer_channel = offerer_pc
+        .create_data_channel("airc", None)
+        .await
+        .expect("offerer datachannel");
+    let offerer_adapter = WebRtcDataChannelAdapter::new(offerer_channel);
+
+    let offer = offerer_pc.create_offer(None).await.expect("offer");
+    offerer_pc
+        .set_local_description(offer)
+        .await
+        .expect("set offer local description");
+    let _ = rtc_timeout(Duration::from_secs(5), offerer_gather_rx.recv()).await;
+    let offer_sdp = offerer_pc
+        .local_description()
+        .await
+        .expect("offerer local description");
+
+    let answerer_pc = Arc::new(
+        PeerConnectionBuilder::new()
+            .with_handler(Arc::new(AnswererHandler {
+                gather_complete_tx: answerer_gather_tx,
+                connected_tx: answerer_connected_tx,
+                adapter_tx: answer_adapter_tx,
+            }))
+            .with_runtime(runtime.clone())
+            .with_udp_addrs(vec!["127.0.0.1:0"])
+            .build()
+            .await
+            .expect("answerer peer connection"),
+    );
+
+    answerer_pc
+        .set_remote_description(offer_sdp)
+        .await
+        .expect("answerer remote offer");
+    let answer = answerer_pc.create_answer(None).await.expect("answer");
+    answerer_pc
+        .set_local_description(answer)
+        .await
+        .expect("answerer local description");
+    let _ = rtc_timeout(Duration::from_secs(5), answerer_gather_rx.recv()).await;
+    let answer_sdp = answerer_pc
+        .local_description()
+        .await
+        .expect("answerer local description");
+
+    offerer_pc
+        .set_remote_description(answer_sdp)
+        .await
+        .expect("offerer remote answer");
+
+    rtc_timeout(Duration::from_secs(15), offerer_connected_rx.recv())
+        .await
+        .expect("offerer connected timeout")
+        .expect("offerer connected channel");
+    rtc_timeout(Duration::from_secs(5), answerer_connected_rx.recv())
+        .await
+        .expect("answerer connected timeout")
+        .expect("answerer connected channel");
+
+    let answerer_adapter = tokio::time::timeout(Duration::from_secs(5), answer_adapter_rx.recv())
+        .await
+        .expect("answerer adapter timeout")
+        .expect("answerer adapter");
+
+    wait_open(&offerer_adapter).await;
+    wait_open(&answerer_adapter).await;
+
+    (offerer_adapter, answerer_adapter, offerer_pc, answerer_pc)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn web_rtc_datachannel_adapter_carries_airc_event_frames() {
+    let (offerer_adapter, answerer_adapter, offerer_pc, answerer_pc) = established_adapters().await;
+    let mut answerer_stream = answerer_adapter
+        .subscribe(Subscription::default())
+        .await
+        .expect("subscribe answerer");
+
+    let frame = event_frame(1, "hello through webrtc datachannel");
+    offerer_adapter
+        .send(frame.clone())
+        .await
+        .expect("send frame");
+
+    let received = tokio::time::timeout(Duration::from_secs(5), answerer_stream.next())
+        .await
+        .expect("receive timeout")
+        .expect("stream item")
+        .expect("frame result");
+
+    assert_eq!(received, frame);
+
+    offerer_pc.close().await.expect("close offerer");
+    answerer_pc.close().await.expect("close answerer");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn web_rtc_datachannel_rejects_durable_frames() {
+    let (offerer_adapter, _answerer_adapter, offerer_pc, answerer_pc) =
+        established_adapters().await;
+
+    let error = offerer_adapter.send(durable_frame()).await.unwrap_err();
+    assert!(matches!(
+        error,
+        WebRtcDataChannelError::UnsupportedDurableKind(FrameKind::Message)
+    ));
+
+    offerer_pc.close().await.expect("close offerer");
+    answerer_pc.close().await.expect("close answerer");
+}


### PR DESCRIPTION
## Summary
- add `airc_protocol::WebRtcSignal` as the signed AIRC signaling payload contract (`forge.webrtc.signal`)
- add `airc_transport::WebRtcDataChannelAdapter` over real `webrtc-rs` data channels
- carry AIRC `FrameKind::Event` frames over an established WebRTC datachannel with subscription fan-out
- reject durable `Message`/`Control` frames on the realtime WebRTC route instead of pretending they are durable
- add an e2e test that establishes two local WebRTC peers, opens a datachannel, and sends an AIRC frame through the adapter

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-protocol -p airc-transport --check`
- `cargo test --manifest-path Cargo.toml -p airc-protocol -p airc-transport`
- `cargo clippy --manifest-path Cargo.toml -p airc-protocol -p airc-transport --all-targets -- -D warnings`

## Coordination
- PR-G in isolated worktree: `/Users/joelteply/Development/cambrian/airc-worktrees/webrtc-datachannel`
- Disjoint from Claude PR-H (#819) peer trust rotation