### PR TITLE
test(examples): prove agent dogfood consumer path

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -21,6 +21,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::RwLock;
 
@@ -78,6 +79,7 @@ pub(crate) struct AircInner {
     pub(crate) route_health: RwLock<TransportHealthTable>,
     pub(crate) route_endpoints: RwLock<RouteEndpointTable>,
     pub(crate) imported_invites: RwLock<ImportedInviteTable>,
+    pub(crate) lamport_clock: AtomicU64,
     pub(crate) lan_tcp: Mutex<Option<LanTcpAdapter>>,
     pub(crate) lan_subscriber: Mutex<Option<FrameSubscriber>>,
     /// Per-wire background subscriber tasks. Spawned lazily on first
@@ -159,6 +161,7 @@ impl Airc {
                 route_health: RwLock::new(TransportHealthTable::local_default()),
                 route_endpoints: RwLock::new(RouteEndpointTable::default()),
                 imported_invites: RwLock::new(ImportedInviteTable::default()),
+                lamport_clock: AtomicU64::new(0),
                 lan_tcp: Mutex::new(None),
                 lan_subscriber: Mutex::new(None),
                 subscribers: Mutex::new(HashMap::new()),
@@ -197,6 +200,7 @@ impl Airc {
             route_health: RwLock::new(TransportHealthTable::local_default()),
             route_endpoints: RwLock::new(RouteEndpointTable::default()),
             imported_invites: RwLock::new(ImportedInviteTable::default()),
+            lamport_clock: AtomicU64::new(self.inner.lamport_clock.load(Ordering::Relaxed)),
             lan_tcp: Mutex::new(None),
             lan_subscriber: Mutex::new(None),
             subscribers: Mutex::new(HashMap::new()),
@@ -280,5 +284,21 @@ impl Airc {
 
     pub(crate) fn event_store(&self) -> &dyn EventStore {
         self.inner.store.as_ref()
+    }
+
+    pub(crate) fn next_lamport(&self, wall_ms: u64) -> u64 {
+        let mut current = self.inner.lamport_clock.load(Ordering::Relaxed);
+        loop {
+            let next = wall_ms.max(current.saturating_add(1));
+            match self.inner.lamport_clock.compare_exchange(
+                current,
+                next,
+                Ordering::SeqCst,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return next,
+                Err(observed) => current = observed,
+            }
+        }
     }
 }

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -33,6 +33,7 @@ impl Airc {
         let route = self.resolve_send_route(kind)?;
         let event_id = EventId::new();
         let occurred_at_ms = now_ms()?;
+        let lamport = self.next_lamport(occurred_at_ms);
         let mut frame = Frame {
             kind,
             envelope: Envelope {
@@ -41,7 +42,7 @@ impl Airc {
                 sender_client: self.inner.identity.client_id,
                 channel: room.channel,
                 target: MentionTarget::All,
-                lamport: occurred_at_ms,
+                lamport,
                 occurred_at_ms,
                 reply_to: None,
                 headers,

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -217,6 +217,22 @@ async fn workspace_lifecycle_projects_from_store() {
         .await
         .unwrap();
 
+    let events = airc.page_recent(128).await.unwrap();
+    let lamports: Vec<u64> = events
+        .iter()
+        .filter(|event| {
+            event
+                .headers
+                .get("forge.body_hint")
+                .is_some_and(|hint| hint == "airc.work.event")
+        })
+        .map(|event| event.lamport)
+        .collect();
+    assert!(
+        lamports.windows(2).all(|pair| pair[0] < pair[1]),
+        "work events emitted by one Airc handle must be strictly lamport ordered: {lamports:?}"
+    );
+
     let board = airc.work_board(128).await.unwrap();
     let workspace = board.workspace(workspace_id).unwrap();
     assert_eq!(workspace.lease.status, WorkspaceStatus::Released);

--- a/crates/examples/embedded_consumer_smoke/Cargo.toml
+++ b/crates/examples/embedded_consumer_smoke/Cargo.toml
@@ -10,15 +10,15 @@ description = "Consumer-embedding proof: a downstream crate that links airc-lib 
 workspace = true
 
 [dependencies]
-# This crate consumes airc-lib like any external embedder would.
-# It deliberately depends ONLY on airc-lib for the SDK surface, not
-# on the lower-level airc-core / airc-protocol / airc-store / etc.
-# That constraint is what proves the API is genuinely consumable
-# without reaching into substrate internals.
+# This crate consumes airc-lib like any external embedder would. Its
+# only AIRC dependency is airc-lib, not the lower-level airc-core /
+# airc-protocol / airc-store / etc. That constraint is what proves
+# the API is genuinely consumable without reaching into substrate
+# internals.
 airc-lib = { path = "../../airc-lib" }
+futures = "0.3"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
 
 [dev-dependencies]
-futures = "0.3"
 tempfile = "3"
 tokio = { version = "1", features = ["test-util", "macros", "rt-multi-thread", "time"] }

--- a/crates/examples/embedded_consumer_smoke/src/agent.rs
+++ b/crates/examples/embedded_consumer_smoke/src/agent.rs
@@ -1,0 +1,166 @@
+//! Agent-consumer shape used by Codex/Claude-style runtimes.
+//!
+//! This is deliberately tiny product-adjacent code: it models what an
+//! agent runtime needs from AIRC without importing substrate crates or
+//! shelling out to the CLI.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use airc_lib::{
+    Airc, AircError, Body, EventFilter, FilteredEventStream, HeaderFilter, Headers, PeerSpec,
+    TranscriptCursor, TranscriptEvent, TranscriptKind,
+};
+use futures::StreamExt;
+
+pub const HEADER_AGENT_KIND: &str = "airc.agent.kind";
+pub const HEADER_AGENT_NAME: &str = "airc.agent.name";
+pub const HEADER_AGENT_RUN_ID: &str = "airc.agent.run_id";
+
+pub const AGENT_KIND_PROMPT: &str = "prompt";
+pub const AGENT_KIND_STATUS: &str = "status";
+
+#[derive(Debug, Clone)]
+pub struct AgentProfile {
+    pub name: String,
+    pub run_id: String,
+}
+
+impl AgentProfile {
+    pub fn new(name: impl Into<String>, run_id: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            run_id: run_id.into(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AgentConsumer {
+    airc: Airc,
+    profile: AgentProfile,
+}
+
+impl AgentConsumer {
+    pub async fn open(home: impl Into<PathBuf>, profile: AgentProfile) -> Result<Self, AircError> {
+        Ok(Self {
+            airc: Airc::open(home).await?,
+            profile,
+        })
+    }
+
+    pub fn airc(&self) -> &Airc {
+        &self.airc
+    }
+
+    pub fn peer_spec(&self) -> String {
+        self.airc.peer_spec()
+    }
+
+    pub async fn trust_peer_spec(&self, spec: &str) -> Result<(), AircError> {
+        let peer: PeerSpec = spec.parse()?;
+        self.airc.add_peer(peer).await
+    }
+
+    pub async fn join_shared_wire(
+        &self,
+        room: &str,
+        wire: impl AsRef<Path>,
+    ) -> Result<(), AircError> {
+        self.airc
+            .join_with_wire(room, wire.as_ref().to_path_buf())
+            .await?;
+        Ok(())
+    }
+
+    pub async fn send_prompt(&self, text: &str) -> Result<(), AircError> {
+        self.send_agent_event(AGENT_KIND_PROMPT, text).await
+    }
+
+    pub async fn send_status(&self, text: &str) -> Result<(), AircError> {
+        self.send_agent_event(AGENT_KIND_STATUS, text).await
+    }
+
+    pub async fn subscribe_prompts(&self) -> Result<AgentInbox, AircError> {
+        let mut kinds = std::collections::BTreeSet::new();
+        kinds.insert(TranscriptKind::Message);
+        let filter = EventFilter {
+            channel: None,
+            kinds,
+            headers_filter: HeaderFilter::Exact {
+                key: HEADER_AGENT_KIND.to_string(),
+                value: AGENT_KIND_PROMPT.to_string(),
+            },
+        };
+        Ok(AgentInbox {
+            owner: self.clone(),
+            stream: self.airc.subscribe_filtered(filter).await?,
+        })
+    }
+
+    pub async fn resume_prompts_after(
+        &self,
+        cursor: &TranscriptCursor,
+        limit: usize,
+    ) -> Result<Vec<TranscriptEvent>, AircError> {
+        let mut kinds = std::collections::BTreeSet::new();
+        kinds.insert(TranscriptKind::Message);
+        let filter = EventFilter {
+            channel: None,
+            kinds,
+            headers_filter: HeaderFilter::Exact {
+                key: HEADER_AGENT_KIND.to_string(),
+                value: AGENT_KIND_PROMPT.to_string(),
+            },
+        };
+        Ok(self
+            .airc
+            .resume_from_filtered(cursor, filter, limit)
+            .await?
+            .into_iter()
+            .filter(|event| !self.is_own_event(event))
+            .collect())
+    }
+
+    fn is_own_event(&self, event: &TranscriptEvent) -> bool {
+        event.peer_id == self.airc.peer_id() && event.client_id == self.airc.client_id()
+    }
+
+    async fn send_agent_event(&self, kind: &str, text: &str) -> Result<(), AircError> {
+        let mut headers = Headers::new();
+        headers.insert(HEADER_AGENT_KIND.to_string(), kind.to_string());
+        headers.insert(HEADER_AGENT_NAME.to_string(), self.profile.name.clone());
+        headers.insert(HEADER_AGENT_RUN_ID.to_string(), self.profile.run_id.clone());
+        self.airc.send(Body::text(text), headers).await?;
+        Ok(())
+    }
+}
+
+pub struct AgentInbox {
+    owner: AgentConsumer,
+    stream: FilteredEventStream,
+}
+
+impl AgentInbox {
+    pub async fn next_inbound(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<Option<TranscriptEvent>, AircError> {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return Ok(None);
+            }
+            let remaining = deadline.saturating_duration_since(now);
+            let event = tokio::time::timeout(remaining, self.stream.next()).await;
+            match event {
+                Ok(Some(Ok(event))) if self.owner.is_own_event(&event) => continue,
+                Ok(Some(Ok(event))) => return Ok(Some(event)),
+                Ok(Some(Err(lag))) => return Err(AircError::Route(lag.to_string())),
+                Ok(None) => return Ok(None),
+                Err(_) => return Ok(None),
+            }
+        }
+    }
+}

--- a/crates/examples/embedded_consumer_smoke/src/lib.rs
+++ b/crates/examples/embedded_consumer_smoke/src/lib.rs
@@ -19,7 +19,9 @@
 //! identity bridge, Hermes agent contracts, etc.) — this crate is the
 //! foundation those build on.
 //!
-//! Constraint: this crate depends ONLY on `airc-lib`. If a future
-//! change forces a substrate-internal import in here, that's a
-//! signal `airc-lib` is missing a re-export, not a sign this crate
-//! should grow more imports.
+//! Constraint: this crate's only AIRC dependency is `airc-lib`. If a
+//! future change forces a substrate-internal AIRC import in here,
+//! that's a signal `airc-lib` is missing a re-export, not a sign this
+//! crate should grow more substrate imports.
+
+pub mod agent;

--- a/crates/examples/embedded_consumer_smoke/tests/agent_dogfood.rs
+++ b/crates/examples/embedded_consumer_smoke/tests/agent_dogfood.rs
@@ -1,0 +1,121 @@
+//! Dogfood proof for Codex/Claude-style agent runtimes.
+//!
+//! The consumer here behaves like an agent hook/monitor loop: subscribe
+//! first, receive inbound typed events live, persist a cursor, and
+//! resume after restart without processing its own sends as inbound
+//! work. It depends only on `embedded_consumer_smoke`, whose runtime
+//! AIRC dependency is only `airc-lib`.
+
+use std::time::Duration;
+
+use airc_lib::Body;
+use embedded_consumer_smoke::agent::{
+    AgentConsumer, AgentProfile, HEADER_AGENT_KIND, HEADER_AGENT_NAME,
+};
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn codex_and_claude_style_agents_exchange_without_self_echo_or_polling() {
+    let codex_home = TempDir::new().unwrap();
+    let claude_home = TempDir::new().unwrap();
+    let wire_dir = TempDir::new().unwrap();
+    let wire = wire_dir.path().join("agent-wire.jsonl");
+
+    let codex = AgentConsumer::open(
+        codex_home.path(),
+        AgentProfile::new("codex", "codex-run-001"),
+    )
+    .await
+    .unwrap();
+    let claude = AgentConsumer::open(
+        claude_home.path(),
+        AgentProfile::new("claude", "claude-run-001"),
+    )
+    .await
+    .unwrap();
+
+    codex.trust_peer_spec(&claude.peer_spec()).await.unwrap();
+    claude.trust_peer_spec(&codex.peer_spec()).await.unwrap();
+
+    codex
+        .join_shared_wire("agent-dogfood", &wire)
+        .await
+        .unwrap();
+    claude
+        .join_shared_wire("agent-dogfood", &wire)
+        .await
+        .unwrap();
+
+    let mut codex_inbox = codex.subscribe_prompts().await.unwrap();
+    let mut claude_inbox = claude.subscribe_prompts().await.unwrap();
+
+    codex
+        .send_prompt("codex -> claude: can you see this through airc-lib?")
+        .await
+        .unwrap();
+
+    let claude_seen = claude_inbox
+        .next_inbound(Duration::from_secs(3))
+        .await
+        .unwrap()
+        .expect("claude must receive codex prompt live");
+    assert_eq!(
+        claude_seen.body.as_ref().and_then(Body::as_text),
+        Some("codex -> claude: can you see this through airc-lib?")
+    );
+    assert_eq!(
+        claude_seen
+            .headers
+            .get(HEADER_AGENT_KIND)
+            .map(String::as_str),
+        Some("prompt")
+    );
+    assert_eq!(
+        claude_seen
+            .headers
+            .get(HEADER_AGENT_NAME)
+            .map(String::as_str),
+        Some("codex")
+    );
+
+    let codex_self_echo = codex_inbox
+        .next_inbound(Duration::from_millis(150))
+        .await
+        .unwrap();
+    assert!(
+        codex_self_echo.is_none(),
+        "an agent monitor must not process its own send as inbound work"
+    );
+
+    let cursor_after_first = claude_seen.cursor();
+
+    claude
+        .send_prompt("claude -> codex: yes, live subscribe works")
+        .await
+        .unwrap();
+
+    let codex_seen = codex_inbox
+        .next_inbound(Duration::from_secs(3))
+        .await
+        .unwrap()
+        .expect("codex must receive claude prompt live");
+    assert_eq!(
+        codex_seen.body.as_ref().and_then(Body::as_text),
+        Some("claude -> codex: yes, live subscribe works")
+    );
+
+    let resumed = claude
+        .resume_prompts_after(&cursor_after_first, 16)
+        .await
+        .unwrap();
+    assert!(
+        resumed
+            .iter()
+            .all(|event| event.event_id != cursor_after_first.event_id),
+        "cursor resume must not return the event at the cursor"
+    );
+    assert!(
+        resumed.is_empty(),
+        "claude's own prompt after the cursor is filtered from inbound replay"
+    );
+}


### PR DESCRIPTION
Summary
- add a small agent-consumer layer over airc-lib for Codex/Claude-style runtimes
- prove two separate agent homes exchange typed prompt events through live subscribe, not CLI polling
- prove self-sends are skipped as inbound work and cursor replay does not duplicate already-seen events
- keep the example crate's only AIRC dependency as airc-lib

Verification
- cargo fmt --manifest-path Cargo.toml --all --check
- cargo clippy --manifest-path Cargo.toml -p embedded-consumer-smoke --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p embedded-consumer-smoke
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace