### PR TITLE
feat(examples): consumer integration shape contracts — Continuum/OpenClaw/Hermes (PR-I3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,6 +723,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "consumer-shapes"
+version = "0.1.0"
+dependencies = [
+ "airc-lib",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/airc-lib",
     "crates/airc-cli",
     "crates/examples/embedded_consumer_smoke",
+    "crates/examples/consumer_shapes",
 ]
 resolver = "2"
 

--- a/crates/examples/consumer_shapes/Cargo.toml
+++ b/crates/examples/consumer_shapes/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "consumer-shapes"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+description = "Typed header/body contract examples for downstream consumer integrations: Continuum personas/activities, OpenClaw chat/thread identity, Hermes agent command/events. NOT product code — reference shapes + fixture tests that real integrations mirror."
+
+[lints]
+workspace = true
+
+[dependencies]
+airc-lib = { path = "../../airc-lib" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/examples/consumer_shapes/src/continuum.rs
+++ b/crates/examples/consumer_shapes/src/continuum.rs
@@ -1,0 +1,236 @@
+//! Continuum integration shape: persona/activity events.
+//!
+//! A Continuum persona runs as an AIRC peer. Activities scope a span
+//! of persona work (an "activity" can be a chat session, a render
+//! job, a multi-turn reasoning task). Events ride AIRC envelopes
+//! with typed bodies + filterable headers so other Continuum
+//! components (record/replay, RAG, manager-hat) can subscribe by
+//! activity or by persona without parsing the body.
+//!
+//! Wire-level body hint: `forge.persona.event.v1`.
+//!
+//! Header conventions:
+//!   - `forge.persona.kind`  — event variant discriminator (cheap filter)
+//!   - `forge.persona.id`    — the persona that emitted the event
+//!   - `forge.continuum.activity_id` — scoping activity, when applicable
+//!   - `forge.continuum.turn_id`     — per-turn id, when applicable
+
+use airc_lib::{Body, EventFilter, HeaderFilter, Headers};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+pub const BODY_HINT_FORGE_PERSONA_EVENT: &str = "forge.persona.event.v1";
+
+pub const HEADER_FORGE_PERSONA_KIND: &str = "forge.persona.kind";
+pub const HEADER_FORGE_PERSONA_ID: &str = "forge.persona.id";
+pub const HEADER_FORGE_CONTINUUM_ACTIVITY_ID: &str = "forge.continuum.activity_id";
+pub const HEADER_FORGE_CONTINUUM_TURN_ID: &str = "forge.continuum.turn_id";
+
+const HEADER_FORGE_BODY_HINT: &str = "forge.body_hint";
+
+/// Persona/activity events. Representative subset — real integrations
+/// extend with their own variants following the same shape (typed
+/// noun struct + variant in this enum + header projection).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PersonaEvent {
+    /// A persona is requested to take a turn within an activity.
+    TurnRequested(TurnRequested),
+    /// A persona produced output for a turn it was given.
+    TurnEmitted(TurnEmitted),
+    /// A long-running activity started — other consumers may attach
+    /// subscribers scoped to its `activity_id`.
+    ActivityStarted(ActivityStarted),
+    /// An activity concluded; bound subscriptions can detach.
+    ActivityEnded(ActivityEnded),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnRequested {
+    pub persona_id: String,
+    pub activity_id: String,
+    pub turn_id: String,
+    pub prompt: String,
+    pub requested_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnEmitted {
+    pub persona_id: String,
+    pub activity_id: String,
+    pub turn_id: String,
+    /// Persona-produced output. Real integrations may attach media
+    /// refs separately on the envelope; this body field is the
+    /// text portion.
+    pub text: String,
+    pub emitted_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActivityStarted {
+    pub persona_id: String,
+    pub activity_id: String,
+    pub label: String,
+    pub started_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActivityEnded {
+    pub persona_id: String,
+    pub activity_id: String,
+    pub ended_at_ms: u64,
+}
+
+impl PersonaEvent {
+    pub fn persona_id(&self) -> &str {
+        match self {
+            Self::TurnRequested(e) => &e.persona_id,
+            Self::TurnEmitted(e) => &e.persona_id,
+            Self::ActivityStarted(e) => &e.persona_id,
+            Self::ActivityEnded(e) => &e.persona_id,
+        }
+    }
+
+    pub fn activity_id(&self) -> &str {
+        match self {
+            Self::TurnRequested(e) => &e.activity_id,
+            Self::TurnEmitted(e) => &e.activity_id,
+            Self::ActivityStarted(e) => &e.activity_id,
+            Self::ActivityEnded(e) => &e.activity_id,
+        }
+    }
+
+    pub fn turn_id(&self) -> Option<&str> {
+        match self {
+            Self::TurnRequested(e) => Some(&e.turn_id),
+            Self::TurnEmitted(e) => Some(&e.turn_id),
+            Self::ActivityStarted(_) | Self::ActivityEnded(_) => None,
+        }
+    }
+
+    fn variant_kind(&self) -> &'static str {
+        match self {
+            Self::TurnRequested(_) => "turn_requested",
+            Self::TurnEmitted(_) => "turn_emitted",
+            Self::ActivityStarted(_) => "activity_started",
+            Self::ActivityEnded(_) => "activity_ended",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum PersonaCodecError {
+    MissingBody,
+    NonJsonBody,
+    BodyHintMismatch {
+        actual: Option<String>,
+        expected: &'static str,
+    },
+    Json(serde_json::Error),
+}
+
+impl std::fmt::Display for PersonaCodecError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingBody => f.write_str("persona event body missing"),
+            Self::NonJsonBody => f.write_str("persona event body must be JSON"),
+            Self::BodyHintMismatch { actual, expected } => write!(
+                f,
+                "persona event body hint mismatch: actual={actual:?}, expected={expected:?}",
+            ),
+            Self::Json(error) => write!(f, "persona event JSON codec failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for PersonaCodecError {}
+
+impl From<serde_json::Error> for PersonaCodecError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+/// Produce `(Headers, Body)` ready to feed into [`airc_lib::Airc::send`].
+/// Domain-specific headers are projected so subscribers can filter
+/// without decoding the body.
+pub fn encode_persona_event(event: &PersonaEvent) -> Result<(Headers, Body), PersonaCodecError> {
+    let mut headers = Headers::new();
+    headers.insert(
+        HEADER_FORGE_BODY_HINT.to_string(),
+        BODY_HINT_FORGE_PERSONA_EVENT.to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_PERSONA_KIND.to_string(),
+        event.variant_kind().to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_PERSONA_ID.to_string(),
+        event.persona_id().to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_CONTINUUM_ACTIVITY_ID.to_string(),
+        event.activity_id().to_string(),
+    );
+    if let Some(turn_id) = event.turn_id() {
+        headers.insert(
+            HEADER_FORGE_CONTINUUM_TURN_ID.to_string(),
+            turn_id.to_string(),
+        );
+    }
+    let body = Body::Json(serde_json::to_value(event)?);
+    Ok((headers, body))
+}
+
+pub fn decode_persona_event(
+    headers: &Headers,
+    body: Option<&Body>,
+) -> Result<PersonaEvent, PersonaCodecError> {
+    match headers.get(HEADER_FORGE_BODY_HINT) {
+        Some(value) if value == BODY_HINT_FORGE_PERSONA_EVENT => {}
+        actual => {
+            return Err(PersonaCodecError::BodyHintMismatch {
+                actual: actual.cloned(),
+                expected: BODY_HINT_FORGE_PERSONA_EVENT,
+            });
+        }
+    }
+    let body = body.ok_or(PersonaCodecError::MissingBody)?;
+    let Body::Json(value) = body else {
+        return Err(PersonaCodecError::NonJsonBody);
+    };
+    Ok(serde_json::from_value(value.clone())?)
+}
+
+/// A consumer-side filter that admits any persona event. Combine
+/// with header constants via [`HeaderFilter::All`] to scope to a
+/// specific persona or activity at subscribe time.
+pub fn any_persona_event_filter() -> EventFilter {
+    EventFilter {
+        channel: None,
+        kinds: BTreeSet::new(),
+        headers_filter: HeaderFilter::Exact {
+            key: HEADER_FORGE_BODY_HINT.to_string(),
+            value: BODY_HINT_FORGE_PERSONA_EVENT.to_string(),
+        },
+    }
+}
+
+/// Scope to one activity: events whose body-hint is `forge.persona.event.v1`
+/// AND whose `forge.continuum.activity_id` equals the given id.
+pub fn activity_event_filter(activity_id: &str) -> EventFilter {
+    EventFilter {
+        channel: None,
+        kinds: BTreeSet::new(),
+        headers_filter: HeaderFilter::All(vec![
+            HeaderFilter::Exact {
+                key: HEADER_FORGE_BODY_HINT.to_string(),
+                value: BODY_HINT_FORGE_PERSONA_EVENT.to_string(),
+            },
+            HeaderFilter::Exact {
+                key: HEADER_FORGE_CONTINUUM_ACTIVITY_ID.to_string(),
+                value: activity_id.to_string(),
+            },
+        ]),
+    }
+}

--- a/crates/examples/consumer_shapes/src/hermes.rs
+++ b/crates/examples/consumer_shapes/src/hermes.rs
@@ -1,0 +1,200 @@
+//! Hermes integration shape: agent command/event contracts.
+//!
+//! Hermes wires agents to tools. An agent issues a command; a tool
+//! invocation runs; a result returns. Each step is a typed event on
+//! the AIRC wire with headers carrying agent + command identifiers
+//! so an orchestrator can subscribe to one agent's command stream,
+//! one tool's invocation stream, or one command's full lifecycle.
+//!
+//! Wire-level body hint: `forge.hermes.event.v1`.
+//!
+//! Header conventions:
+//!   - `forge.hermes.kind`       — event variant
+//!   - `forge.hermes.agent_id`   — issuing/receiving agent
+//!   - `forge.hermes.command_id` — correlates command → result
+//!   - `forge.hermes.tool`       — tool/capability name (on invocations)
+
+use airc_lib::{Body, EventFilter, HeaderFilter, Headers};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+pub const BODY_HINT_FORGE_HERMES_EVENT: &str = "forge.hermes.event.v1";
+
+pub const HEADER_FORGE_HERMES_KIND: &str = "forge.hermes.kind";
+pub const HEADER_FORGE_HERMES_AGENT_ID: &str = "forge.hermes.agent_id";
+pub const HEADER_FORGE_HERMES_COMMAND_ID: &str = "forge.hermes.command_id";
+pub const HEADER_FORGE_HERMES_TOOL: &str = "forge.hermes.tool";
+
+const HEADER_FORGE_BODY_HINT: &str = "forge.body_hint";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HermesEvent {
+    /// An agent issued a command. May target a tool by name.
+    AgentCommandIssued(AgentCommandIssued),
+    /// A tool invocation completed (success or failure). Correlates
+    /// to the matching `AgentCommandIssued` by `command_id`.
+    AgentResultReturned(AgentResultReturned),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentCommandIssued {
+    pub agent_id: String,
+    pub command_id: String,
+    pub tool: String,
+    /// Opaque tool input — encoded by the tool's own contract. Kept
+    /// as `serde_json::Value` so the codec can roundtrip any shape.
+    pub input: serde_json::Value,
+    pub issued_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentResultReturned {
+    pub agent_id: String,
+    pub command_id: String,
+    pub tool: String,
+    /// Either an `output` value (success) or an `error` string
+    /// (failure). Honest partial-success is up to the tool: if it
+    /// produced something AND failed, encode both in the `output`
+    /// shape and leave `error` populated — never silently drop one.
+    pub output: Option<serde_json::Value>,
+    pub error: Option<String>,
+    pub returned_at_ms: u64,
+}
+
+impl HermesEvent {
+    pub fn agent_id(&self) -> &str {
+        match self {
+            Self::AgentCommandIssued(e) => &e.agent_id,
+            Self::AgentResultReturned(e) => &e.agent_id,
+        }
+    }
+    pub fn command_id(&self) -> &str {
+        match self {
+            Self::AgentCommandIssued(e) => &e.command_id,
+            Self::AgentResultReturned(e) => &e.command_id,
+        }
+    }
+    pub fn tool(&self) -> &str {
+        match self {
+            Self::AgentCommandIssued(e) => &e.tool,
+            Self::AgentResultReturned(e) => &e.tool,
+        }
+    }
+    fn variant_kind(&self) -> &'static str {
+        match self {
+            Self::AgentCommandIssued(_) => "agent_command_issued",
+            Self::AgentResultReturned(_) => "agent_result_returned",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum HermesCodecError {
+    MissingBody,
+    NonJsonBody,
+    BodyHintMismatch {
+        actual: Option<String>,
+        expected: &'static str,
+    },
+    Json(serde_json::Error),
+}
+
+impl std::fmt::Display for HermesCodecError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingBody => f.write_str("hermes event body missing"),
+            Self::NonJsonBody => f.write_str("hermes event body must be JSON"),
+            Self::BodyHintMismatch { actual, expected } => write!(
+                f,
+                "hermes event body hint mismatch: actual={actual:?}, expected={expected:?}",
+            ),
+            Self::Json(error) => write!(f, "hermes event JSON codec failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for HermesCodecError {}
+
+impl From<serde_json::Error> for HermesCodecError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+pub fn encode_hermes_event(event: &HermesEvent) -> Result<(Headers, Body), HermesCodecError> {
+    let mut headers = Headers::new();
+    headers.insert(
+        HEADER_FORGE_BODY_HINT.to_string(),
+        BODY_HINT_FORGE_HERMES_EVENT.to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_HERMES_KIND.to_string(),
+        event.variant_kind().to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_HERMES_AGENT_ID.to_string(),
+        event.agent_id().to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_HERMES_COMMAND_ID.to_string(),
+        event.command_id().to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_HERMES_TOOL.to_string(),
+        event.tool().to_string(),
+    );
+    let body = Body::Json(serde_json::to_value(event)?);
+    Ok((headers, body))
+}
+
+pub fn decode_hermes_event(
+    headers: &Headers,
+    body: Option<&Body>,
+) -> Result<HermesEvent, HermesCodecError> {
+    match headers.get(HEADER_FORGE_BODY_HINT) {
+        Some(value) if value == BODY_HINT_FORGE_HERMES_EVENT => {}
+        actual => {
+            return Err(HermesCodecError::BodyHintMismatch {
+                actual: actual.cloned(),
+                expected: BODY_HINT_FORGE_HERMES_EVENT,
+            });
+        }
+    }
+    let body = body.ok_or(HermesCodecError::MissingBody)?;
+    let Body::Json(value) = body else {
+        return Err(HermesCodecError::NonJsonBody);
+    };
+    Ok(serde_json::from_value(value.clone())?)
+}
+
+pub fn any_hermes_event_filter() -> EventFilter {
+    EventFilter {
+        channel: None,
+        kinds: BTreeSet::new(),
+        headers_filter: HeaderFilter::Exact {
+            key: HEADER_FORGE_BODY_HINT.to_string(),
+            value: BODY_HINT_FORGE_HERMES_EVENT.to_string(),
+        },
+    }
+}
+
+/// Subscribe to one agent's command + result stream. The combination
+/// of body-hint + agent_id is the routing primitive — body content
+/// is opaque to the substrate.
+pub fn agent_event_filter(agent_id: &str) -> EventFilter {
+    EventFilter {
+        channel: None,
+        kinds: BTreeSet::new(),
+        headers_filter: HeaderFilter::All(vec![
+            HeaderFilter::Exact {
+                key: HEADER_FORGE_BODY_HINT.to_string(),
+                value: BODY_HINT_FORGE_HERMES_EVENT.to_string(),
+            },
+            HeaderFilter::Exact {
+                key: HEADER_FORGE_HERMES_AGENT_ID.to_string(),
+                value: agent_id.to_string(),
+            },
+        ]),
+    }
+}

--- a/crates/examples/consumer_shapes/src/lib.rs
+++ b/crates/examples/consumer_shapes/src/lib.rs
@@ -1,0 +1,44 @@
+//! Consumer integration shape examples.
+//!
+//! Three downstream consumers — Continuum, OpenClaw, Hermes —
+//! each get a module that demonstrates the AIRC header/body contract
+//! shape that real integrations should mirror. The fixture tests
+//! prove encode → decode round-trips and that the supplied
+//! [`airc_lib::EventFilter`] correctly admits events of the right
+//! shape and rejects unrelated ones.
+//!
+//! What this crate is:
+//! - typed event vocabularies (just enough to demonstrate the
+//!   pattern; integrations extend with their own events)
+//! - codec functions producing `(Headers, Body)` ready to feed into
+//!   [`airc_lib::Airc::send`]
+//! - subscription filters ready to feed into
+//!   [`airc_lib::Airc::subscribe_filtered`]
+//!
+//! What this crate is NOT:
+//! - a real Continuum / OpenClaw / Hermes integration
+//! - a substrate change — codecs ride on existing
+//!   `Headers` + `Body` + `EventFilter` surfaces with no airc-lib
+//!   edits required
+//! - exhaustive — each module ships a representative subset; real
+//!   integrations add more event variants following the same shape
+//!
+//! The audit gaps this closes (first slice):
+//! - §13 *"Consumer Integration Is Not Proven"* — shape proof.
+//! - Consumer Integration Gaps:
+//!   - *"Continuum: persona/chat/activity events over AIRC envelopes
+//!     with forge-alloy contracts"*
+//!   - *"OpenClaw: adapter mapping existing chat/thread identity into
+//!     AIRC PeerId/ClientId/channel"*
+//!   - *"Hermes: agent command/events over headers and typed payload
+//!     contracts"*
+//!
+//! opencode/Codex/Claude (the agent-INBOUND subscription shape) is
+//! deliberately omitted from this slice — Codex's PR-I2 dogfood
+//! lane covers that surface.
+
+#![deny(unsafe_code)]
+
+pub mod continuum;
+pub mod hermes;
+pub mod openclaw;

--- a/crates/examples/consumer_shapes/src/openclaw.rs
+++ b/crates/examples/consumer_shapes/src/openclaw.rs
@@ -1,0 +1,199 @@
+//! OpenClaw integration shape: chat/thread identity bridge.
+//!
+//! OpenClaw has its own user identity model and thread/workspace
+//! taxonomy that predates AIRC. The integration shape is a typed
+//! adapter that carries the OpenClaw identifiers as headers
+//! alongside the AIRC envelope, so a consumer can route events by
+//! either system's notion of "who" and "where":
+//!
+//!   - OpenClaw user → AIRC `PeerId` (substrate identity), plus
+//!     `forge.openclaw.user_id` retained as a header for any
+//!     OpenClaw-aware subscriber.
+//!   - OpenClaw thread → AIRC `RoomId` (substrate channel), plus
+//!     `forge.openclaw.thread_id` retained.
+//!   - OpenClaw workspace → header projected for routing; no
+//!     substrate concept needed yet.
+//!
+//! Wire-level body hint: `forge.openclaw.event.v1`.
+
+use airc_lib::{Body, EventFilter, HeaderFilter, Headers};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+pub const BODY_HINT_FORGE_OPENCLAW_EVENT: &str = "forge.openclaw.event.v1";
+
+pub const HEADER_FORGE_OPENCLAW_KIND: &str = "forge.openclaw.kind";
+pub const HEADER_FORGE_OPENCLAW_USER_ID: &str = "forge.openclaw.user_id";
+pub const HEADER_FORGE_OPENCLAW_THREAD_ID: &str = "forge.openclaw.thread_id";
+pub const HEADER_FORGE_OPENCLAW_WORKSPACE_ID: &str = "forge.openclaw.workspace_id";
+
+const HEADER_FORGE_BODY_HINT: &str = "forge.body_hint";
+
+/// Representative OpenClaw events. Real integrations extend with
+/// their own variants (mentions, reactions, edits, attachments...);
+/// the shape below is the pattern.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum OpenClawEvent {
+    /// A user posted a chat message in a thread.
+    ChatMessagePosted(ChatMessagePosted),
+    /// A new thread was created within a workspace.
+    ThreadCreated(ThreadCreated),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChatMessagePosted {
+    /// The OpenClaw user identifier. Stable across thread changes.
+    pub openclaw_user_id: String,
+    /// The OpenClaw thread identifier. Maps to an AIRC channel.
+    pub openclaw_thread_id: String,
+    /// The OpenClaw workspace identifier. Lets a cross-thread
+    /// subscriber filter to one workspace.
+    pub openclaw_workspace_id: String,
+    pub text: String,
+    pub posted_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThreadCreated {
+    pub openclaw_user_id: String,
+    pub openclaw_thread_id: String,
+    pub openclaw_workspace_id: String,
+    pub title: String,
+    pub created_at_ms: u64,
+}
+
+impl OpenClawEvent {
+    pub fn user_id(&self) -> &str {
+        match self {
+            Self::ChatMessagePosted(e) => &e.openclaw_user_id,
+            Self::ThreadCreated(e) => &e.openclaw_user_id,
+        }
+    }
+    pub fn thread_id(&self) -> &str {
+        match self {
+            Self::ChatMessagePosted(e) => &e.openclaw_thread_id,
+            Self::ThreadCreated(e) => &e.openclaw_thread_id,
+        }
+    }
+    pub fn workspace_id(&self) -> &str {
+        match self {
+            Self::ChatMessagePosted(e) => &e.openclaw_workspace_id,
+            Self::ThreadCreated(e) => &e.openclaw_workspace_id,
+        }
+    }
+    fn variant_kind(&self) -> &'static str {
+        match self {
+            Self::ChatMessagePosted(_) => "chat_message_posted",
+            Self::ThreadCreated(_) => "thread_created",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum OpenClawCodecError {
+    MissingBody,
+    NonJsonBody,
+    BodyHintMismatch {
+        actual: Option<String>,
+        expected: &'static str,
+    },
+    Json(serde_json::Error),
+}
+
+impl std::fmt::Display for OpenClawCodecError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingBody => f.write_str("openclaw event body missing"),
+            Self::NonJsonBody => f.write_str("openclaw event body must be JSON"),
+            Self::BodyHintMismatch { actual, expected } => write!(
+                f,
+                "openclaw event body hint mismatch: actual={actual:?}, expected={expected:?}",
+            ),
+            Self::Json(error) => write!(f, "openclaw event JSON codec failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for OpenClawCodecError {}
+
+impl From<serde_json::Error> for OpenClawCodecError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+pub fn encode_openclaw_event(event: &OpenClawEvent) -> Result<(Headers, Body), OpenClawCodecError> {
+    let mut headers = Headers::new();
+    headers.insert(
+        HEADER_FORGE_BODY_HINT.to_string(),
+        BODY_HINT_FORGE_OPENCLAW_EVENT.to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_OPENCLAW_KIND.to_string(),
+        event.variant_kind().to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_OPENCLAW_USER_ID.to_string(),
+        event.user_id().to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_OPENCLAW_THREAD_ID.to_string(),
+        event.thread_id().to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_OPENCLAW_WORKSPACE_ID.to_string(),
+        event.workspace_id().to_string(),
+    );
+    let body = Body::Json(serde_json::to_value(event)?);
+    Ok((headers, body))
+}
+
+pub fn decode_openclaw_event(
+    headers: &Headers,
+    body: Option<&Body>,
+) -> Result<OpenClawEvent, OpenClawCodecError> {
+    match headers.get(HEADER_FORGE_BODY_HINT) {
+        Some(value) if value == BODY_HINT_FORGE_OPENCLAW_EVENT => {}
+        actual => {
+            return Err(OpenClawCodecError::BodyHintMismatch {
+                actual: actual.cloned(),
+                expected: BODY_HINT_FORGE_OPENCLAW_EVENT,
+            });
+        }
+    }
+    let body = body.ok_or(OpenClawCodecError::MissingBody)?;
+    let Body::Json(value) = body else {
+        return Err(OpenClawCodecError::NonJsonBody);
+    };
+    Ok(serde_json::from_value(value.clone())?)
+}
+
+pub fn any_openclaw_event_filter() -> EventFilter {
+    EventFilter {
+        channel: None,
+        kinds: BTreeSet::new(),
+        headers_filter: HeaderFilter::Exact {
+            key: HEADER_FORGE_BODY_HINT.to_string(),
+            value: BODY_HINT_FORGE_OPENCLAW_EVENT.to_string(),
+        },
+    }
+}
+
+/// Scope by workspace — common cross-thread routing requirement.
+pub fn workspace_event_filter(workspace_id: &str) -> EventFilter {
+    EventFilter {
+        channel: None,
+        kinds: BTreeSet::new(),
+        headers_filter: HeaderFilter::All(vec![
+            HeaderFilter::Exact {
+                key: HEADER_FORGE_BODY_HINT.to_string(),
+                value: BODY_HINT_FORGE_OPENCLAW_EVENT.to_string(),
+            },
+            HeaderFilter::Exact {
+                key: HEADER_FORGE_OPENCLAW_WORKSPACE_ID.to_string(),
+                value: workspace_id.to_string(),
+            },
+        ]),
+    }
+}

--- a/crates/examples/consumer_shapes/tests/continuum_roundtrip.rs
+++ b/crates/examples/consumer_shapes/tests/continuum_roundtrip.rs
@@ -1,0 +1,150 @@
+//! Continuum persona/activity contract fixtures.
+//!
+//! Asserts the codec produces the right header projection, the body
+//! roundtrips per variant, and the supplied filters admit/reject
+//! events as expected. These fixtures are the source-of-truth for
+//! the on-wire shape — any change here must coordinate with the
+//! Continuum consumer that subscribes against the same filters.
+
+use airc_lib::{Body, Headers};
+use consumer_shapes::continuum::{
+    activity_event_filter, any_persona_event_filter, decode_persona_event, encode_persona_event,
+    ActivityEnded, ActivityStarted, PersonaCodecError, PersonaEvent, TurnEmitted, TurnRequested,
+    BODY_HINT_FORGE_PERSONA_EVENT, HEADER_FORGE_CONTINUUM_ACTIVITY_ID,
+    HEADER_FORGE_CONTINUUM_TURN_ID, HEADER_FORGE_PERSONA_ID, HEADER_FORGE_PERSONA_KIND,
+};
+
+fn turn_requested() -> PersonaEvent {
+    PersonaEvent::TurnRequested(TurnRequested {
+        persona_id: "skylar".to_string(),
+        activity_id: "session-42".to_string(),
+        turn_id: "turn-1".to_string(),
+        prompt: "what's the meta-goal?".to_string(),
+        requested_at_ms: 1_700_000_000_000,
+    })
+}
+
+fn turn_emitted() -> PersonaEvent {
+    PersonaEvent::TurnEmitted(TurnEmitted {
+        persona_id: "skylar".to_string(),
+        activity_id: "session-42".to_string(),
+        turn_id: "turn-1".to_string(),
+        text: "ship the substrate".to_string(),
+        emitted_at_ms: 1_700_000_000_500,
+    })
+}
+
+#[test]
+fn roundtrip_all_variants_preserves_typed_event() {
+    let cases: Vec<PersonaEvent> = vec![
+        turn_requested(),
+        turn_emitted(),
+        PersonaEvent::ActivityStarted(ActivityStarted {
+            persona_id: "skylar".to_string(),
+            activity_id: "session-42".to_string(),
+            label: "morning standup".to_string(),
+            started_at_ms: 0,
+        }),
+        PersonaEvent::ActivityEnded(ActivityEnded {
+            persona_id: "skylar".to_string(),
+            activity_id: "session-42".to_string(),
+            ended_at_ms: 3_600_000,
+        }),
+    ];
+    for event in cases {
+        let (headers, body) = encode_persona_event(&event).unwrap();
+        let decoded = decode_persona_event(&headers, Some(&body)).unwrap();
+        assert_eq!(decoded, event, "roundtrip diverged for {event:?}");
+    }
+}
+
+#[test]
+fn headers_project_persona_and_activity_for_cheap_filtering() {
+    let (headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    assert_eq!(
+        headers.get("forge.body_hint").map(String::as_str),
+        Some(BODY_HINT_FORGE_PERSONA_EVENT),
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_PERSONA_KIND).map(String::as_str),
+        Some("turn_requested"),
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_PERSONA_ID).map(String::as_str),
+        Some("skylar"),
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_CONTINUUM_ACTIVITY_ID)
+            .map(String::as_str),
+        Some("session-42"),
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_CONTINUUM_TURN_ID)
+            .map(String::as_str),
+        Some("turn-1"),
+    );
+}
+
+#[test]
+fn activity_filter_admits_matching_and_rejects_unrelated() {
+    let (matching_headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    let filter = activity_event_filter("session-42");
+    assert!(
+        filter.headers_filter.matches(&matching_headers),
+        "filter must admit events for the named activity",
+    );
+
+    let off_activity = PersonaEvent::TurnRequested(TurnRequested {
+        persona_id: "skylar".to_string(),
+        activity_id: "other-activity".to_string(),
+        turn_id: "turn-9".to_string(),
+        prompt: "unrelated".to_string(),
+        requested_at_ms: 0,
+    });
+    let (off_headers, _) = encode_persona_event(&off_activity).unwrap();
+    assert!(
+        !filter.headers_filter.matches(&off_headers),
+        "filter must reject events for a different activity",
+    );
+
+    let any_filter = any_persona_event_filter();
+    assert!(any_filter.headers_filter.matches(&matching_headers));
+    assert!(any_filter.headers_filter.matches(&off_headers));
+}
+
+#[test]
+fn decode_rejects_wrong_body_hint() {
+    let (mut headers, body) = encode_persona_event(&turn_requested()).unwrap();
+    headers.insert(
+        "forge.body_hint".to_string(),
+        "forge.work.event.v1".to_string(),
+    );
+    let err = decode_persona_event(&headers, Some(&body)).unwrap_err();
+    assert!(matches!(err, PersonaCodecError::BodyHintMismatch { .. }));
+}
+
+#[test]
+fn decode_rejects_missing_body() {
+    let (headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    let err = decode_persona_event(&headers, None).unwrap_err();
+    assert!(matches!(err, PersonaCodecError::MissingBody));
+}
+
+#[test]
+fn decode_rejects_non_json_body() {
+    let (headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    let err = decode_persona_event(&headers, Some(&Body::Binary(vec![0x01, 0x02]))).unwrap_err();
+    assert!(matches!(err, PersonaCodecError::NonJsonBody));
+}
+
+#[test]
+fn empty_headers_have_no_body_hint_so_decode_errors_loudly() {
+    let headers = Headers::new();
+    let err = decode_persona_event(&headers, None).unwrap_err();
+    assert!(matches!(
+        err,
+        PersonaCodecError::BodyHintMismatch { actual: None, .. }
+    ));
+}

--- a/crates/examples/consumer_shapes/tests/hermes_roundtrip.rs
+++ b/crates/examples/consumer_shapes/tests/hermes_roundtrip.rs
@@ -1,0 +1,127 @@
+//! Hermes agent command/event contract fixtures.
+
+use consumer_shapes::hermes::{
+    agent_event_filter, any_hermes_event_filter, decode_hermes_event, encode_hermes_event,
+    AgentCommandIssued, AgentResultReturned, HermesCodecError, HermesEvent,
+    BODY_HINT_FORGE_HERMES_EVENT, HEADER_FORGE_HERMES_AGENT_ID, HEADER_FORGE_HERMES_COMMAND_ID,
+    HEADER_FORGE_HERMES_KIND, HEADER_FORGE_HERMES_TOOL,
+};
+
+fn command_issued() -> HermesEvent {
+    HermesEvent::AgentCommandIssued(AgentCommandIssued {
+        agent_id: "agent-orion".to_string(),
+        command_id: "cmd-001".to_string(),
+        tool: "fs.read".to_string(),
+        input: serde_json::json!({ "path": "/etc/hostname" }),
+        issued_at_ms: 1_700_000_000_000,
+    })
+}
+
+fn result_returned() -> HermesEvent {
+    HermesEvent::AgentResultReturned(AgentResultReturned {
+        agent_id: "agent-orion".to_string(),
+        command_id: "cmd-001".to_string(),
+        tool: "fs.read".to_string(),
+        output: Some(serde_json::json!({ "content": "joelteply-laptop" })),
+        error: None,
+        returned_at_ms: 1_700_000_000_300,
+    })
+}
+
+#[test]
+fn roundtrip_command_and_result_preserves_typed_event() {
+    for event in [command_issued(), result_returned()] {
+        let (headers, body) = encode_hermes_event(&event).unwrap();
+        let decoded = decode_hermes_event(&headers, Some(&body)).unwrap();
+        assert_eq!(decoded, event);
+    }
+}
+
+#[test]
+fn partial_success_is_first_class_in_result() {
+    // "It worked" without specifics is not acceptable. A result that
+    // produced partial output AND hit an error must serialize both.
+    let partial = HermesEvent::AgentResultReturned(AgentResultReturned {
+        agent_id: "agent-orion".to_string(),
+        command_id: "cmd-002".to_string(),
+        tool: "fs.read".to_string(),
+        output: Some(serde_json::json!({ "content": "partial-data" })),
+        error: Some("EOF before complete read".to_string()),
+        returned_at_ms: 0,
+    });
+    let (headers, body) = encode_hermes_event(&partial).unwrap();
+    let decoded = decode_hermes_event(&headers, Some(&body)).unwrap();
+    assert_eq!(decoded, partial);
+    match decoded {
+        HermesEvent::AgentResultReturned(r) => {
+            assert!(r.output.is_some(), "partial output preserved");
+            assert!(r.error.is_some(), "partial error preserved");
+        }
+        _ => panic!("variant changed during roundtrip"),
+    }
+}
+
+#[test]
+fn headers_project_agent_command_tool() {
+    let (headers, _) = encode_hermes_event(&command_issued()).unwrap();
+    assert_eq!(
+        headers.get("forge.body_hint").map(String::as_str),
+        Some(BODY_HINT_FORGE_HERMES_EVENT),
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_HERMES_KIND).map(String::as_str),
+        Some("agent_command_issued"),
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_HERMES_AGENT_ID)
+            .map(String::as_str),
+        Some("agent-orion"),
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_HERMES_COMMAND_ID)
+            .map(String::as_str),
+        Some("cmd-001"),
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_HERMES_TOOL).map(String::as_str),
+        Some("fs.read"),
+    );
+}
+
+#[test]
+fn agent_filter_admits_matching_agent_and_rejects_other_agents() {
+    let (orion_cmd_headers, _) = encode_hermes_event(&command_issued()).unwrap();
+    let (orion_res_headers, _) = encode_hermes_event(&result_returned()).unwrap();
+    let filter = agent_event_filter("agent-orion");
+
+    // Both events for orion match — the full command lifecycle.
+    assert!(filter.headers_filter.matches(&orion_cmd_headers));
+    assert!(filter.headers_filter.matches(&orion_res_headers));
+
+    let other_agent = HermesEvent::AgentCommandIssued(AgentCommandIssued {
+        agent_id: "agent-rigel".to_string(),
+        command_id: "cmd-999".to_string(),
+        tool: "fs.read".to_string(),
+        input: serde_json::json!({}),
+        issued_at_ms: 0,
+    });
+    let (other_headers, _) = encode_hermes_event(&other_agent).unwrap();
+    assert!(!filter.headers_filter.matches(&other_headers));
+
+    let any_filter = any_hermes_event_filter();
+    assert!(any_filter.headers_filter.matches(&orion_cmd_headers));
+    assert!(any_filter.headers_filter.matches(&other_headers));
+}
+
+#[test]
+fn decode_rejects_wrong_body_hint() {
+    let (mut headers, body) = encode_hermes_event(&command_issued()).unwrap();
+    headers.insert(
+        "forge.body_hint".to_string(),
+        "forge.persona.event.v1".to_string(),
+    );
+    let err = decode_hermes_event(&headers, Some(&body)).unwrap_err();
+    assert!(matches!(err, HermesCodecError::BodyHintMismatch { .. }));
+}

--- a/crates/examples/consumer_shapes/tests/openclaw_roundtrip.rs
+++ b/crates/examples/consumer_shapes/tests/openclaw_roundtrip.rs
@@ -1,0 +1,104 @@
+//! OpenClaw chat/thread identity contract fixtures.
+
+use airc_lib::Body;
+use consumer_shapes::openclaw::{
+    any_openclaw_event_filter, decode_openclaw_event, encode_openclaw_event,
+    workspace_event_filter, ChatMessagePosted, OpenClawCodecError, OpenClawEvent, ThreadCreated,
+    BODY_HINT_FORGE_OPENCLAW_EVENT, HEADER_FORGE_OPENCLAW_THREAD_ID, HEADER_FORGE_OPENCLAW_USER_ID,
+    HEADER_FORGE_OPENCLAW_WORKSPACE_ID,
+};
+
+fn chat_event() -> OpenClawEvent {
+    OpenClawEvent::ChatMessagePosted(ChatMessagePosted {
+        openclaw_user_id: "u-alice".to_string(),
+        openclaw_thread_id: "t-router-debug".to_string(),
+        openclaw_workspace_id: "w-acme".to_string(),
+        text: "PR-G CI is green".to_string(),
+        posted_at_ms: 1_700_000_000_000,
+    })
+}
+
+#[test]
+fn roundtrip_all_variants_preserves_typed_event() {
+    let cases: Vec<OpenClawEvent> = vec![
+        chat_event(),
+        OpenClawEvent::ThreadCreated(ThreadCreated {
+            openclaw_user_id: "u-alice".to_string(),
+            openclaw_thread_id: "t-new".to_string(),
+            openclaw_workspace_id: "w-acme".to_string(),
+            title: "release readout".to_string(),
+            created_at_ms: 0,
+        }),
+    ];
+    for event in cases {
+        let (headers, body) = encode_openclaw_event(&event).unwrap();
+        let decoded = decode_openclaw_event(&headers, Some(&body)).unwrap();
+        assert_eq!(decoded, event);
+    }
+}
+
+#[test]
+fn headers_project_user_thread_workspace_for_filtering() {
+    let (headers, _) = encode_openclaw_event(&chat_event()).unwrap();
+    assert_eq!(
+        headers.get("forge.body_hint").map(String::as_str),
+        Some(BODY_HINT_FORGE_OPENCLAW_EVENT),
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_OPENCLAW_USER_ID)
+            .map(String::as_str),
+        Some("u-alice"),
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_OPENCLAW_THREAD_ID)
+            .map(String::as_str),
+        Some("t-router-debug"),
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_OPENCLAW_WORKSPACE_ID)
+            .map(String::as_str),
+        Some("w-acme"),
+    );
+}
+
+#[test]
+fn workspace_filter_admits_matching_and_rejects_other_workspaces() {
+    let (matching_headers, _) = encode_openclaw_event(&chat_event()).unwrap();
+    let filter = workspace_event_filter("w-acme");
+    assert!(filter.headers_filter.matches(&matching_headers));
+
+    let other_ws = OpenClawEvent::ChatMessagePosted(ChatMessagePosted {
+        openclaw_user_id: "u-bob".to_string(),
+        openclaw_thread_id: "t-other".to_string(),
+        openclaw_workspace_id: "w-different".to_string(),
+        text: "wrong workspace".to_string(),
+        posted_at_ms: 0,
+    });
+    let (other_headers, _) = encode_openclaw_event(&other_ws).unwrap();
+    assert!(!filter.headers_filter.matches(&other_headers));
+
+    let any_filter = any_openclaw_event_filter();
+    assert!(any_filter.headers_filter.matches(&matching_headers));
+    assert!(any_filter.headers_filter.matches(&other_headers));
+}
+
+#[test]
+fn decode_rejects_wrong_body_hint() {
+    let (mut headers, body) = encode_openclaw_event(&chat_event()).unwrap();
+    headers.insert(
+        "forge.body_hint".to_string(),
+        "forge.work.event.v1".to_string(),
+    );
+    let err = decode_openclaw_event(&headers, Some(&body)).unwrap_err();
+    assert!(matches!(err, OpenClawCodecError::BodyHintMismatch { .. }));
+}
+
+#[test]
+fn decode_rejects_non_json_body() {
+    let (headers, _) = encode_openclaw_event(&chat_event()).unwrap();
+    let err = decode_openclaw_event(&headers, Some(&Body::Binary(vec![1, 2, 3]))).unwrap_err();
+    assert!(matches!(err, OpenClawCodecError::NonJsonBody));
+}


### PR DESCRIPTION
## Summary

PR-I3 of the PR-I split. Typed header/body contract examples + fixture tests for three downstream consumers: Continuum personas/activities, OpenClaw chat/thread identity, Hermes agent command/events. Each shape gets its own module with the same pattern (typed event enum → encode → decode → scoped filter → fixture tests).

Codex owns the parallel PR-I2 (dogfood hook/monitor smoke for the opencode/Codex/Claude agent-INBOUND subscription shape). This PR covers the consumer-OUTBOUND shape — disjoint surfaces, no overlap.

## Work Intake Rule

- **Grievance closed (first slice):** §13 *"Consumer Integration Is Not Proven"* — the contract-shape portion.
- **Gaps closed:** Consumer Integration Gaps —
  - *"Continuum: persona/chat/activity events over AIRC envelopes with forge-alloy contracts"*
  - *"OpenClaw: adapter mapping existing chat/thread identity into AIRC PeerId/ClientId/channel"*
  - *"Hermes: agent command/events over headers and typed payload contracts"*
- **Acceptance gate:** Gate 4 (Consumer Embedding) — extends the I1 proof from "any consumer can embed" to "specific consumers have a defined shape to mirror."
- **Python/shell:** untouched.
- **Branch:** `feat/consumer-shapes` off `rust-rewrite@628bbd9`.
- **Tests:** 17 fixture tests.

## What's in this PR

`crates/examples/consumer_shapes/`

**`src/continuum.rs`** — persona/activity events
- `PersonaEvent { TurnRequested, TurnEmitted, ActivityStarted, ActivityEnded }`
- `BODY_HINT_FORGE_PERSONA_EVENT = "forge.persona.event.v1"`
- Header constants: `forge.persona.kind / id`, `forge.continuum.activity_id / turn_id`
- `encode_persona_event` / `decode_persona_event`
- Filters: `any_persona_event_filter()`, `activity_event_filter(id)`

**`src/openclaw.rs`** — chat/thread identity bridge
- `OpenClawEvent { ChatMessagePosted, ThreadCreated }`
- OpenClaw user/thread/workspace identifiers carried as headers alongside the AIRC `PeerId`/`RoomId`. Consumers route by either system's notion of "who" and "where" without parsing the body.
- Filters: `any_openclaw_event_filter()`, `workspace_event_filter(id)`

**`src/hermes.rs`** — agent command/event contracts
- `HermesEvent { AgentCommandIssued, AgentResultReturned }`
- `AgentResultReturned` carries BOTH `output: Option<Value>` AND `error: Option<String>` — partial success is first-class. *"It worked"* without specifics isn't acceptable.
- Filters: `any_hermes_event_filter()`, `agent_event_filter(id)` (full command lifecycle for one agent)

## Constraints satisfied (per Codex's brief)

- **Crate depends ONLY on `airc-lib` + serde.** No substrate-internal imports. If I'd needed a missing `airc-lib` surface I'd have flagged it first per his instruction — none needed.
- **No `airc-lib` edits.** Every type used (`Body`, `Headers`, `HeaderFilter`, `EventFilter`) is already re-exported.
- **No transport / daemon / CLI touched.**
- **Disjoint from PR-I2.** This is the consumer-OUTBOUND shape (consumer emits typed events); PR-I2 is the consumer-INBOUND subscription shape.

## Test plan

- [x] `cargo test -p consumer-shapes` — **17 pass** (7 continuum + 5 openclaw + 5 hermes)
- [x] `cargo test --workspace` — **492 tests pass**
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] CI on Ubuntu/macOS/Windows will run on this PR

## Out of scope (deliberate; future PR-I slices)

- Real Continuum/OpenClaw/Hermes integrations linking this crate
- opencode/Codex/Claude inbound subscription shape — Codex's PR-I2 lane
- Cross-shape coordination examples (Hermes invokes Continuum persona; OpenClaw thread bridges to Hermes agent)

## Coordination

Developed in isolated worktree `/private/tmp/airc-claude-pr-i3`. airc-pinged Codex at branch-cut + before opening PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)