### PR TITLE
fix(codex-hook): pin rust hook executable and honor cursor overrides

### DIFF
--- a/crates/airc-cli/src/codex_hooks_json.rs
+++ b/crates/airc-cli/src/codex_hooks_json.rs
@@ -1,20 +1,22 @@
 //! Codex hooks.json mutation for AIRC hook installation.
 
 use std::path::Path;
+use std::path::PathBuf;
 
 use serde_json::{json, Value};
 
 const RUST_HOOK_COMMAND: &str = "airc-rs codex-hook user-prompt-submit";
+const HOOK_COMMAND_SUFFIX: &str = "codex-hook user-prompt-submit";
 const LEGACY_HOOK_COMMAND: &str = "airc codex-hook user-prompt-submit";
 const HOOK_STATUS: &str = "Checking AIRC inbox";
 
-pub fn install(path: &Path) -> Result<bool, Box<dyn std::error::Error>> {
+pub fn install(path: &Path, airc_rs: &Path) -> Result<bool, Box<dyn std::error::Error>> {
     let original = read_json(path)?;
     let mut data = ensure_root_object(original);
     let user_prompt = ensure_user_prompt_array(&mut data)?;
     let before = user_prompt.clone();
     remove_managed_hook_entries(user_prompt);
-    user_prompt.push(hook_group());
+    user_prompt.push(hook_group(&hook_command(airc_rs)));
 
     let changed = *user_prompt != before;
     if changed {
@@ -77,21 +79,49 @@ fn remove_managed_hook_entries(groups: &mut Vec<Value>) {
         };
         hooks.retain(|hook| {
             let command = hook.get("command").and_then(Value::as_str);
-            command != Some(RUST_HOOK_COMMAND) && command != Some(LEGACY_HOOK_COMMAND)
+            !is_managed_hook_command(command)
         });
         !hooks.is_empty()
     });
 }
 
-fn hook_group() -> Value {
+fn is_managed_hook_command(command: Option<&str>) -> bool {
+    let Some(command) = command else {
+        return false;
+    };
+    command == RUST_HOOK_COMMAND
+        || command == LEGACY_HOOK_COMMAND
+        || command.ends_with(HOOK_COMMAND_SUFFIX)
+}
+
+fn hook_group(command: &str) -> Value {
     json!({
         "hooks": [{
             "type": "command",
-            "command": RUST_HOOK_COMMAND,
+            "command": command,
             "timeout": 5,
             "statusMessage": HOOK_STATUS
         }]
     })
+}
+
+fn hook_command(airc_rs: &Path) -> String {
+    format!("{} {HOOK_COMMAND_SUFFIX}", shell_quote_path(airc_rs))
+}
+
+fn shell_quote_path(path: &Path) -> String {
+    let raw = path_to_string(path);
+    if raw
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-'))
+    {
+        return raw;
+    }
+    format!("'{}'", raw.replace('\'', "'\\''"))
+}
+
+fn path_to_string(path: &Path) -> String {
+    PathBuf::from(path).to_string_lossy().into_owned()
 }
 
 fn read_json(path: &Path) -> Result<Value, Box<dyn std::error::Error>> {

--- a/crates/airc-cli/src/codex_install.rs
+++ b/crates/airc-cli/src/codex_install.rs
@@ -20,7 +20,8 @@ pub async fn run_install_hooks(
             config.display()
         );
     }
-    if codex_hooks_json::install(&hooks_json)? {
+    let airc_rs = std::env::current_exe()?;
+    if codex_hooks_json::install(&hooks_json, &airc_rs)? {
         println!(
             "installed AIRC UserPromptSubmit hook in {}",
             hooks_json.display()

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -139,8 +139,60 @@ fn codex_hook_installer_replaces_legacy_python_hook() {
             .expect("hooks json");
     let commands = hook_commands(&hooks);
     assert!(commands.contains(&"echo existing".to_string()));
-    assert!(commands.contains(&"airc-rs codex-hook user-prompt-submit".to_string()));
+    assert!(
+        commands
+            .iter()
+            .any(|command| command.ends_with("codex-hook user-prompt-submit")),
+        "installer must add a Rust hook command, got {commands:?}"
+    );
+    assert!(
+        !commands.contains(&"airc-rs codex-hook user-prompt-submit".to_string()),
+        "installer should pin the resolved airc-rs executable instead of relying on PATH"
+    );
     assert!(!commands.contains(&"airc codex-hook user-prompt-submit".to_string()));
+}
+
+#[test]
+fn codex_hook_installer_replaces_prior_absolute_rust_hook() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("airc");
+    let codex_home = workspace.path().join("codex");
+    std::fs::create_dir_all(&codex_home).expect("codex home");
+    std::fs::write(codex_home.join("config.toml"), "[features]\nhooks = true\n")
+        .expect("write config");
+    std::fs::write(
+        codex_home.join("hooks.json"),
+        r#"{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"/old/install/bin/airc-rs codex-hook user-prompt-submit"}]}]}}"#,
+    )
+    .expect("write hooks");
+
+    run_ok(
+        &home,
+        &[
+            "codex-hook",
+            "install-hooks",
+            "--codex-home",
+            codex_home.to_str().unwrap(),
+        ],
+    );
+
+    let hooks: Value =
+        serde_json::from_str(&std::fs::read_to_string(codex_home.join("hooks.json")).unwrap())
+            .expect("hooks json");
+    let commands = hook_commands(&hooks);
+    assert_eq!(
+        commands
+            .iter()
+            .filter(|command| command.ends_with("codex-hook user-prompt-submit"))
+            .count(),
+        1,
+        "install must replace older managed hook commands, got {commands:?}"
+    );
+    assert!(
+        commands[0].contains(env!("CARGO_BIN_EXE_airc-rs")),
+        "hook command should pin current executable, got {:?}",
+        commands
+    );
 }
 
 #[test]

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -456,9 +456,20 @@ cmd_codex_hook() {
   shift || true
   case "$sub" in
     user-prompt-submit)
-      "$_airc_rs" --home "$AIRC_WRITE_DIR" codex-hook user-prompt-submit \
-        --cursor-file "$AIRC_WRITE_DIR/codex_hook_cursor.json" \
-        "$@"
+      local _has_cursor_file=0
+      local _arg
+      for _arg in "$@"; do
+        case "$_arg" in
+          --cursor-file|--cursor-file=*) _has_cursor_file=1 ;;
+        esac
+      done
+      if [ "$_has_cursor_file" = "1" ]; then
+        "$_airc_rs" --home "$AIRC_WRITE_DIR" codex-hook user-prompt-submit "$@"
+      else
+        "$_airc_rs" --home "$AIRC_WRITE_DIR" codex-hook user-prompt-submit \
+          --cursor-file "$AIRC_WRITE_DIR/codex_hook_cursor.json" \
+          "$@"
+      fi
       ;;
     install-hooks|uninstall-hooks)
       "$_airc_rs" codex-hook "$sub" "$@"

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -4710,6 +4710,15 @@ JSON
     fail "airc status did not surface Rust local truth (out: $(cat "$out" 2>/dev/null); err: $(cat "$err" 2>/dev/null))"
   fi
 
+  local explicit_cursor="$home/explicit-codex-hook-cursor.json"
+  if printf '{"hook_event_name":"UserPromptSubmit"}' | AIRC_HOME="$home" AIRC_RS_BIN="$(airc_rs_bin)" "$AIRC" codex-hook user-prompt-submit --cursor-file "$explicit_cursor" --include-self >"$out" 2>"$err" \
+      && grep -q "$marker" "$out" \
+      && [ -f "$explicit_cursor" ]; then
+    pass "codex-hook wrapper respects explicit cursor file on Rust event stream"
+  else
+    fail "codex-hook wrapper explicit cursor failed (out: $(cat "$out" 2>/dev/null); err: $(cat "$err" 2>/dev/null); cursor: $(cat "$explicit_cursor" 2>/dev/null))"
+  fi
+
   rm -rf "$root"
 }
 


### PR DESCRIPTION
Summary
- install Codex UserPromptSubmit hooks with the resolved airc-rs executable path instead of relying on PATH
- replace prior managed hook commands whether they used legacy airc, bare airc-rs, or an older absolute airc-rs path
- make the shell wrapper respect explicit --cursor-file instead of passing it twice
- extend Rust and shell coverage for hook install replacement and Rust-event cursor override behavior

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli codex_hook -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- bash -n airc lib/airc_bash/cmd_status.sh test/integration.sh
- AIRC_RS_BIN=/Users/joelteply/.local/bin/airc-rs ./test/integration.sh shell_msg_rust_local