### PR TITLE
fix(workspace): keep lane roots under airc home

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ airc hygiene clean --dry-run
 airc hygiene clean --yes
 ```
 
-The default clean action removes only rebuildable lane caches under `~/.airc-worktrees`: Rust `src/workers/target` and `src/node_modules`. Main checkout caches and Docker prune are policy-gated and off by default. The Rust `airc-work` events (`DrainCandidateCategory { RebuildableCache, GeneratedArtifact, DownloadedDependency, DockerLayer, ModelCache, TraceArtifact, Unknown }`) make the policy decision pattern-matchable; `safe_by_default()` is conservative — only rebuildable and downloaded categories drain without explicit opt-in.
+The default clean action removes only rebuildable lane caches under `~/.airc/worktrees`: Rust `src/workers/target` and `src/node_modules`. Main checkout caches and Docker prune are policy-gated and off by default. The Rust `airc-work` events (`DrainCandidateCategory { RebuildableCache, GeneratedArtifact, DownloadedDependency, DockerLayer, ModelCache, TraceArtifact, Unknown }`) make the policy decision pattern-matchable; `safe_by_default()` is conservative — only rebuildable and downloaded categories drain without explicit opt-in.
 
 ## Rooms And Scope
 

--- a/crates/airc-cli/src/hygiene_commands.rs
+++ b/crates/airc-cli/src/hygiene_commands.rs
@@ -29,7 +29,7 @@ struct HygienePolicy {
 impl Default for HygienePolicy {
     fn default() -> Self {
         Self {
-            workspace_root: "~/.airc-worktrees".to_string(),
+            workspace_root: "~/.airc/worktrees".to_string(),
             report_paths: Vec::new(),
             hooks: Vec::new(),
             warn_free_gb: 50.0,
@@ -530,6 +530,11 @@ mod tests {
         write_policy(&path, &HygienePolicy::default()).unwrap();
 
         assert_eq!(load_policy(&path).unwrap(), HygienePolicy::default());
+    }
+
+    #[test]
+    fn default_workspace_root_lives_under_airc_home() {
+        assert_eq!(HygienePolicy::default().workspace_root, "~/.airc/worktrees");
     }
 
     #[test]

--- a/crates/airc-cli/src/worktree_lane_commands.rs
+++ b/crates/airc-cli/src/worktree_lane_commands.rs
@@ -113,11 +113,20 @@ fn abs_path(path: &str) -> Result<PathBuf, Box<dyn Error>> {
     } else {
         PathBuf::from(path)
     };
-    if expanded.is_absolute() {
-        Ok(expanded)
+    let absolute = if expanded.is_absolute() {
+        expanded
     } else {
-        Ok(std::env::current_dir()?.join(expanded))
+        std::env::current_dir()?.join(expanded)
+    };
+    if absolute.exists() {
+        return Ok(fs::canonicalize(absolute)?);
     }
+    if let (Some(parent), Some(file_name)) = (absolute.parent(), absolute.file_name()) {
+        if parent.exists() {
+            return Ok(fs::canonicalize(parent)?.join(file_name));
+        }
+    }
+    Ok(absolute)
 }
 
 fn home_dir() -> Option<PathBuf> {
@@ -175,6 +184,17 @@ mod tests {
         assert_eq!(slug("#1234: Rust Lane!"), "1234-rust-lane");
         assert_eq!(slug(""), "lane");
         assert_eq!(slug("A_B.C-D"), "a_b.c-d");
+    }
+
+    #[test]
+    fn abs_path_canonicalizes_existing_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let with_dot = dir.path().join(".");
+
+        assert_eq!(
+            abs_path(&with_dot.to_string_lossy()).unwrap(),
+            fs::canonicalize(dir.path()).unwrap()
+        );
     }
 
     #[test]

--- a/docs/hygiene-policy.md
+++ b/docs/hygiene-policy.md
@@ -25,7 +25,7 @@ Rust with `serde` without changing the command contract.
   "hooks": [],
   "report_paths": [],
   "warn_free_gb": 50.0,
-  "workspace_root": "~/.airc-worktrees"
+  "workspace_root": "~/.airc/worktrees"
 }
 ```
 
@@ -42,8 +42,8 @@ Rust with `serde` without changing the command contract.
 
 `airc hygiene clean --yes` removes only rebuildable lane caches by default:
 
-- `~/.airc-worktrees/*/src/workers/target`
-- `~/.airc-worktrees/*/src/node_modules`
+- `~/.airc/worktrees/*/src/workers/target`
+- `~/.airc/worktrees/*/src/node_modules`
 
 Main checkout caches and Docker prune are off by default. Projects can opt in
 when they know the tradeoff is acceptable.

--- a/lib/airc_bash/cmd_hygiene.sh
+++ b/lib/airc_bash/cmd_hygiene.sh
@@ -39,8 +39,8 @@ RESOURCE REPORTING
 
 SAFE CLEANUP
   By default, clean only removes rebuildable per-lane caches:
-    - ~/.airc-worktrees/*/src/workers/target
-    - ~/.airc-worktrees/*/src/node_modules
+    - ~/.airc/worktrees/*/src/workers/target
+    - ~/.airc/worktrees/*/src/node_modules
 
   Main checkout caches and Docker prune are policy-gated and off by default.
 EOF

--- a/lib/airc_bash/cmd_lane.sh
+++ b/lib/airc_bash/cmd_lane.sh
@@ -88,7 +88,7 @@ _cmd_lane_create() {
   fi
 
   if [ -z "$lane_dir" ]; then
-    lane_dir="$HOME/.airc-worktrees/${repo_name}-${issue_token}-${owner_token}"
+    lane_dir="$HOME/.airc/worktrees/${repo_name}-${issue_token}-${owner_token}"
   fi
   lane_dir=$(_airc_lane_abs_path "$lane_dir")
 
@@ -294,7 +294,7 @@ OPTIONS
   --repo PATH       Source checkout. Default: current git repo.
   --branch NAME     Lane branch. Default: feat/<issue>-<owner>.
   --base NAME       Branch/ref to base from. Default: canary.
-  --dir PATH        Worktree directory. Default: ~/.airc-worktrees/<repo>-<issue>-<owner>.
+  --dir PATH        Worktree directory. Default: ~/.airc/worktrees/<repo>-<issue>-<owner>.
   --owner HANDLE    Lane owner. Default: current AIRC identity.
   --dry-run         Print without creating the worktree.
 EOF


### PR DESCRIPTION
Summary
- move default lane worktree root from ~/.airc-worktrees to ~/.airc/worktrees
- align hygiene policy defaults, shell help, and docs with the AIRC-owned workspace root
- add a Rust regression test pinning the default under ~/.airc

Verification
- bash -n airc lib/airc_bash/cmd_lane.sh lib/airc_bash/cmd_hygiene.sh
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli hygiene -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- ./airc lane create CambrianTech/airc#999 --repo . --base HEAD --owner codex --dry-run