### PR TITLE
fix(install): remove rust suffix from airc surface

### DIFF
--- a/.github/workflows/auto-close-queue-cards.yml
+++ b/.github/workflows/auto-close-queue-cards.yml
@@ -24,7 +24,8 @@ name: auto-close-queue-cards
 #
 #   Runs `airc queue close-merged` from the checkout — no install
 #   step required because the `./airc` dispatcher works from a clone
-#   when gh + bash + airc-rs are present (all on ubuntu-latest).
+#   when gh + bash + the AIRC implementation binary are present (all on
+#   ubuntu-latest).
 #
 # Scope:
 #   - Same-repo only. Cross-repo refs (e.g. airc PR closing

--- a/airc
+++ b/airc
@@ -61,16 +61,6 @@ _airc_resolve_lib_dir() {
 }
 _airc_lib_dir=$(_airc_resolve_lib_dir)
 
-# One-time migration from pre-rename ~/.agent-relay → ~/.airc. Fires when user
-# is on vanilla defaults, the old dir exists as a real dir (not a symlink we
-# already left), and ~/.airc doesn't. Leaves a symlink ~/.agent-relay → ~/.airc
-# so running monitors + tails pointing at the old path keep working.
-if [ -z "${AIRC_HOME:-}" ] && [ -d "$HOME/.agent-relay" ] && [ ! -L "$HOME/.agent-relay" ] && [ ! -e "$HOME/.airc" ]; then
-  mv "$HOME/.agent-relay" "$HOME/.airc" 2>/dev/null && \
-    ln -s "$HOME/.airc" "$HOME/.agent-relay" 2>/dev/null && \
-    echo "  Migrated $HOME/.agent-relay → $HOME/.airc (symlink left for back-compat)" >&2
-fi
-
 # Scope = $PWD/.airc. Your identity is tied to where you are.
 #
 # Run `airc` from the same cwd each time for a persistent identity in that
@@ -329,7 +319,7 @@ fi
 # their own adapter until those transports are deleted.
 if [ -n "$_gh_resolved" ] || command -v gh >/dev/null 2>&1; then
   gh() {
-    "$(airc_rs_bin)" gh run -- "$@"
+    "$(airc_core_bin)" gh run -- "$@"
   }
 fi
 unset _gh_resolved
@@ -480,11 +470,11 @@ _airc_scope_monitor_formatter_pids() {
   local scope_dir="${1:-}"
   [ -n "$scope_dir" ] || return 0
   local p cmd
-  proc_airc_pids_matching 'airc-rs.*monitor.*format' 2>/dev/null | while IFS= read -r p; do
+  proc_airc_pids_matching 'airc-core.*monitor.*format' 2>/dev/null | while IFS= read -r p; do
     case "$p" in ''|*[!0-9]*) continue ;; esac
     cmd=$(proc_cmdline "$p" 2>/dev/null || true)
     case "$cmd" in
-      *airc-rs*monitor*format*) ;;
+      *airc-core*monitor*format*) ;;
       *) continue ;;
     esac
     _airc_cmdline_mentions_scope "$cmd" "$scope_dir/peers" || continue
@@ -636,7 +626,7 @@ _validate_peer_name() {
 ensure_init() {
   if [ -d "$AIRC_WRITE_DIR" ]; then
     local _repair_out
-    if _repair_out=$("$(airc_rs_bin)" --home "$AIRC_WRITE_DIR" scope repair-config \
+    if _repair_out=$("$(airc_core_bin)" --home "$AIRC_WRITE_DIR" scope repair-config \
         --config "$CONFIG" \
         --default-name "$(derive_name)" \
         --host "$(get_host)" 2>&1); then
@@ -648,15 +638,15 @@ ensure_init() {
   die "Not initialized ($AIRC_WRITE_DIR). Run: airc join"
 }
 
-# config CRUD via airc-rs — proper clap --flags so paths are
+# config CRUD via airc-core — proper clap --flags so paths are
 # per-arg-predictable across MSYS path-translation. Each call passes
 # `--config <path>` explicitly.
 get_name() {
-  "$(airc_rs_bin)" config get-name --home "$AIRC_WRITE_DIR" --config "$CONFIG" 2>/dev/null || echo "unknown"
+  "$(airc_core_bin)" config get-name --home "$AIRC_WRITE_DIR" --config "$CONFIG" 2>/dev/null || echo "unknown"
 }
 
 get_config_val() {
-  "$(airc_rs_bin)" config get --home "$AIRC_WRITE_DIR" --config "$CONFIG" "$1" "${2:-}" 2>/dev/null || echo "${2:-}"
+  "$(airc_core_bin)" config get --home "$AIRC_WRITE_DIR" --config "$CONFIG" "$1" "${2:-}" 2>/dev/null || echo "${2:-}"
 }
 set_config_val()   {
   # Empty $2 must reach argparse as the value of --value. The plain
@@ -670,74 +660,74 @@ set_config_val()   {
   # Repro on Windows 11 + WSL2 Ubuntu (issue #511 trace):
   #   set_config_val host "$(get_host)"   # get_host -> ""
   #   → exit 2 + "argument --value: expected one argument"
-  "$(airc_rs_bin)" config set --home "$AIRC_WRITE_DIR" --config "$CONFIG" --key "$1" --value="${2-}"
+  "$(airc_core_bin)" config set --home "$AIRC_WRITE_DIR" --config "$CONFIG" --key "$1" --value="${2-}"
 }
 unset_config_keys() {
-  "$(airc_rs_bin)" config unset-keys --home "$AIRC_WRITE_DIR" --config "$CONFIG" "$@"
+  "$(airc_core_bin)" config unset-keys --home "$AIRC_WRITE_DIR" --config "$CONFIG" "$@"
 }
 
-airc_rs_bin() {
+airc_core_bin() {
   local _root; _root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  if [ -n "${AIRC_RS_BIN:-}" ]; then
-    [ -x "$AIRC_RS_BIN" ] && { printf '%s\n' "$AIRC_RS_BIN"; return 0; }
-    die "AIRC_RS_BIN is set but not executable: $AIRC_RS_BIN"
+  if [ -n "${AIRC_CORE_BIN:-}" ]; then
+    [ -x "$AIRC_CORE_BIN" ] && { printf '%s\n' "$AIRC_CORE_BIN"; return 0; }
+    die "AIRC_CORE_BIN is set but not executable: $AIRC_CORE_BIN"
   fi
 
   # In a dev checkout, prefer the binary built from this tree so cutover
-  # tests do not accidentally exercise an older installed airc-rs.
-  for _candidate in "$_root/target/debug/airc-rs" "$_root/target/release/airc-rs"; do
+  # tests do not accidentally exercise an older installed airc-core.
+  for _candidate in "$_root/target/debug/airc-core" "$_root/target/release/airc-core"; do
     [ -x "$_candidate" ] && { printf '%s\n' "$_candidate"; return 0; }
   done
 
-  if command -v airc-rs >/dev/null 2>&1; then
-    command -v airc-rs
+  if command -v airc-core >/dev/null 2>&1; then
+    command -v airc-core
     return 0
   fi
-  die "airc-rs is required; run install.sh or cargo build --manifest-path \"$_root/Cargo.toml\" -p airc-cli"
+  die "airc-core is required; run install.sh or cargo build --manifest-path \"$_root/Cargo.toml\" -p airc-cli"
 }
 
 airc_client_id() {
-  "$(airc_rs_bin)" client-id 2>/dev/null
+  "$(airc_core_bin)" client-id 2>/dev/null
 }
 
 airc_config_read_channels() {
   local cfg="${1:-$CONFIG}"
-  "$(airc_rs_bin)" config read-channels --home "$AIRC_WRITE_DIR" --config "$cfg" 2>/dev/null
+  "$(airc_core_bin)" config read-channels --home "$AIRC_WRITE_DIR" --config "$cfg" 2>/dev/null
 }
 
 airc_config_default_channel() {
   local cfg="${1:-$CONFIG}"
-  "$(airc_rs_bin)" config default-channel --home "$AIRC_WRITE_DIR" --config "$cfg" 2>/dev/null
+  "$(airc_core_bin)" config default-channel --home "$AIRC_WRITE_DIR" --config "$cfg" 2>/dev/null
 }
 
 airc_config_get_channel_gist() {
   local channel="$1" cfg="${2:-$CONFIG}"
-  "$(airc_rs_bin)" config get-channel-gist --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel" 2>/dev/null
+  "$(airc_core_bin)" config get-channel-gist --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel" 2>/dev/null
 }
 
 airc_config_list_channel_gists() {
   local cfg="${1:-$CONFIG}"
-  "$(airc_rs_bin)" config list-channel-gists --home "$AIRC_WRITE_DIR" --config "$cfg" 2>/dev/null
+  "$(airc_core_bin)" config list-channel-gists --home "$AIRC_WRITE_DIR" --config "$cfg" 2>/dev/null
 }
 
 airc_config_subscribe() {
   local channel="$1" cfg="${2:-$CONFIG}" first="${3:-0}"
   if [ "$first" = "1" ]; then
-    "$(airc_rs_bin)" config subscribe --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel" --first
+    "$(airc_core_bin)" config subscribe --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel" --first
   else
-    "$(airc_rs_bin)" config subscribe --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel"
+    "$(airc_core_bin)" config subscribe --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel"
   fi
 }
 
 airc_config_unsubscribe() {
   local channel="$1" cfg="${2:-$CONFIG}"
-  "$(airc_rs_bin)" config unsubscribe --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel"
+  "$(airc_core_bin)" config unsubscribe --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel"
 }
 
 airc_config_set_channel_gist() {
   local channel="$1" gist_id="${2-}" cfg="${3:-$CONFIG}"
-  "$(airc_rs_bin)" config set-channel-gist --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel" --gist-id="$gist_id"
+  "$(airc_core_bin)" config set-channel-gist --home "$AIRC_WRITE_DIR" --config "$cfg" --channel "$channel" --gist-id="$gist_id"
 }
 
 # Same as get_config_val but reads from an arbitrary config.json path.
@@ -745,7 +735,7 @@ airc_config_set_channel_gist() {
 # that need to read sibling-scope state without changing $CONFIG.
 get_config_val_in() {
   local cfg="$1" key="$2" default="${3:-}"
-  "$(airc_rs_bin)" config get --home "$AIRC_WRITE_DIR" --config "$cfg" "$key" "$default" 2>/dev/null || echo "$default"
+  "$(airc_core_bin)" config get --home "$AIRC_WRITE_DIR" --config "$cfg" "$key" "$default" 2>/dev/null || echo "$default"
 }
 
 get_host() {
@@ -766,7 +756,7 @@ get_host() {
   # LAN. Returns 127.0.0.1 if no internet route is available — which we
   # treat as "no LAN" and fall through to hostname.
   local lan_ip
-  lan_ip=$("$(airc_rs_bin)" lan-ip 2>/dev/null || true)
+  lan_ip=$("$(airc_core_bin)" lan-ip 2>/dev/null || true)
   if [ -n "$lan_ip" ]; then
     # Sanity: must look like an IPv4 address (skip exotic surprises).
     case "$lan_ip" in
@@ -978,14 +968,14 @@ peer_pick_address() {
   local addresses_json="${1:-}" host_machine="${2:-}"
   [ -z "$addresses_json" ] || [ "$addresses_json" = "null" ] && return 0
 
-  # Parse through airc-rs instead of jq/Python so routing decisions stay
+  # Parse through airc-core instead of jq/Python so routing decisions stay
   # on the Rust cutover path.
 
   # Same machine: use localhost.
   local my_machine; my_machine=$(host_machine_id)
   if [ -n "$host_machine" ] && [ "$host_machine" = "$my_machine" ]; then
     local pick; pick=$(printf '%s' "$addresses_json" \
-      | "$(airc_rs_bin)" gist pick-addr localhost 2>/dev/null)
+      | "$(airc_core_bin)" gist pick-addr localhost 2>/dev/null)
     if [ -n "$pick" ]; then printf '%s' "$pick"; return 0; fi
   fi
 
@@ -996,13 +986,13 @@ peer_pick_address() {
   if [ -n "$my_lan_ips" ]; then
     local lan_entries
     lan_entries=$(printf '%s' "$addresses_json" \
-      | "$(airc_rs_bin)" gist list-lan-entries 2>/dev/null)
+      | "$(airc_core_bin)" gist list-lan-entries 2>/dev/null)
     if [ -n "$lan_entries" ]; then
       while IFS= read -r entry; do
         [ -z "$entry" ] && continue
-        local subnet; subnet=$(printf '%s' "$entry" | "$(airc_rs_bin)" gist get .subnet 2>/dev/null)
-        local addr;   addr=$(printf '%s' "$entry"   | "$(airc_rs_bin)" gist get .addr 2>/dev/null)
-        local port;   port=$(printf '%s' "$entry"   | "$(airc_rs_bin)" gist get .port 2>/dev/null)
+        local subnet; subnet=$(printf '%s' "$entry" | "$(airc_core_bin)" gist get .subnet 2>/dev/null)
+        local addr;   addr=$(printf '%s' "$entry"   | "$(airc_core_bin)" gist get .addr 2>/dev/null)
+        local port;   port=$(printf '%s' "$entry"   | "$(airc_core_bin)" gist get .port 2>/dev/null)
         # subnet is like "192.168.1.0/24" — match the /24 prefix against my IPs.
         if [ -n "$subnet" ]; then
           local prefix="${subnet%/*}"   # 192.168.1.0
@@ -1032,7 +1022,7 @@ peer_pick_address() {
   # tailscale up but want airc to skip it for routing decisions).
   if [ "${AIRC_NO_TAILSCALE:-0}" != "1" ] && _have_tailscale_locally; then
     local pick; pick=$(printf '%s' "$addresses_json" \
-      | "$(airc_rs_bin)" gist pick-addr tailscale 2>/dev/null)
+      | "$(airc_core_bin)" gist pick-addr tailscale 2>/dev/null)
     if [ -n "$pick" ]; then printf '%s' "$pick"; return 0; fi
   fi
 
@@ -1049,7 +1039,7 @@ peer_pick_address() {
   # gh-bearer-only routing (broadcast still works; direct pair
   # skipped).
   printf '%s' "$addresses_json" \
-    | "$(airc_rs_bin)" gist pick-addr-excluding localhost tailscale 2>/dev/null
+    | "$(airc_core_bin)" gist pick-addr-excluding localhost tailscale 2>/dev/null
 }
 
 # _have_tailscale_locally: do WE currently have a Tailscale interface
@@ -1106,11 +1096,11 @@ _have_tailscale_locally() {
 humanhash() {
   local input="${1:-}"
   [ -z "$input" ] && return 1
-  "$(airc_rs_bin)" humanhash "$input"
+  "$(airc_core_bin)" humanhash "$input"
 }
 
 sign_message() {
-  printf '%s' "$1" | "$(airc_rs_bin)" identity sign-ed25519 --home "$AIRC_WRITE_DIR" --dir "$IDENTITY_DIR"
+  printf '%s' "$1" | "$(airc_core_bin)" identity sign-ed25519 --home "$AIRC_WRITE_DIR" --dir "$IDENTITY_DIR"
 }
 
 # ── Platform adapters ───────────────────────────────────────────────────
@@ -1235,10 +1225,10 @@ _primary_scope_for() {
 }
 
 # parted_rooms helpers (#136 sticky /part) — thin wrappers; mutation
-# logic lives in airc-rs config.
-_read_parted_rooms()  { [ -f "$1/config.json" ] && "$(airc_rs_bin)" config read-parted --home "$1" --config "$1/config.json" 2>/dev/null; }
-_record_parted_room() { [ -f "$1/config.json" ] && "$(airc_rs_bin)" config record-parted --home "$1" --config "$1/config.json" --room "$2" 2>/dev/null || true; }
-_clear_parted_room()  { [ -f "$1/config.json" ] && "$(airc_rs_bin)" config clear-parted --home "$1" --config "$1/config.json" --room "$2" 2>/dev/null || true; }
+# logic lives in airc-core config.
+_read_parted_rooms()  { [ -f "$1/config.json" ] && "$(airc_core_bin)" config read-parted --home "$1" --config "$1/config.json" 2>/dev/null; }
+_record_parted_room() { [ -f "$1/config.json" ] && "$(airc_core_bin)" config record-parted --home "$1" --config "$1/config.json" --room "$2" 2>/dev/null || true; }
+_clear_parted_room()  { [ -f "$1/config.json" ] && "$(airc_core_bin)" config clear-parted --home "$1" --config "$1/config.json" --room "$2" 2>/dev/null || true; }
 
 # Spawn the #general sidecar (issue #121) — a parallel `airc join`
 # in a sibling scope (.general suffix) so the primary tab is in BOTH
@@ -1319,7 +1309,7 @@ init_identity() {
   # PEM format the openssl path produced, so existing scopes upgrade
   # in place without rotating keys.
   if [ ! -f "$IDENTITY_DIR/private.pem" ]; then
-    if ! "$(airc_rs_bin)" identity bootstrap-ed25519 --home "$AIRC_WRITE_DIR" --dir "$IDENTITY_DIR"; then
+    if ! "$(airc_core_bin)" identity bootstrap-ed25519 --home "$AIRC_WRITE_DIR" --dir "$IDENTITY_DIR"; then
       die "Ed25519 identity bootstrap failed"
     fi
   fi
@@ -1333,7 +1323,7 @@ init_identity() {
     }
   fi
   # Phase E.2: bootstrap X25519 keypair for envelope encryption.
-  "$(airc_rs_bin)" identity bootstrap --home "$AIRC_WRITE_DIR" --dir "$IDENTITY_DIR" >/dev/null
+  "$(airc_core_bin)" identity bootstrap --home "$AIRC_WRITE_DIR" --dir "$IDENTITY_DIR" >/dev/null
   touch "$MESSAGES"
 }
 
@@ -1347,7 +1337,7 @@ _monitor_multi_channel() {
   # writes to the parent's stdout interleave at line boundaries.
   #
   # Args: my_name, TAB-separated "channel<TAB>gist_id" lines (one per
-  # subscribed channel, from airc-rs config list-channel-gists).
+  # subscribed channel, from airc-core config list-channel-gists).
   local my_name="$1"
   local channel_map="$2"
 
@@ -1387,12 +1377,12 @@ _monitor_multi_channel() {
         local ch="$1" gid="$2"
         [ -z "$ch" ] && return 0
         [ -z "$gid" ] && return 0
-        # airc-rs bearer recv stderr → per-channel log file (CLAUDE.md
+        # airc-core bearer recv stderr → per-channel log file (CLAUDE.md
         # "never swallow errors"). The previous 2>/dev/null hid every
         # transient gh failure, leaving "monitor's fine but no events"
         # undebuggable. Append-mode so a tail of the log shows the
         # actual cause when a channel dies.
-        "$(airc_rs_bin)" bearer recv "self" \
+        "$(airc_core_bin)" bearer recv "self" \
           --room-gist-id "$gid" \
           --offset-file "$AIRC_WRITE_DIR/monitor_offset.${ch}" \
           --state-file "$AIRC_WRITE_DIR/bearer_state.${ch}.json" \
@@ -1466,7 +1456,7 @@ _monitor_multi_channel() {
             gid=$(airc_config_list_channel_gists "$CONFIG" | awk -F '\t' -v c="$ch" '$1 == c {print $2; exit}')
             if [ -n "$gid" ]; then
               sleep 3
-              "$(airc_rs_bin)" bearer recv "self" \
+              "$(airc_core_bin)" bearer recv "self" \
                 --room-gist-id "$gid" \
                 --offset-file "$AIRC_WRITE_DIR/monitor_offset.${ch}" \
                 --state-file "$AIRC_WRITE_DIR/bearer_state.${ch}.json" \
@@ -1648,7 +1638,7 @@ monitor() {
     local consecutive_timeouts=0
     local ESCALATE_AFTER=4
     while true; do
-      "$(airc_rs_bin)" bearer recv "self" \
+      "$(airc_core_bin)" bearer recv "self" \
         --room-gist-id "$room_gist_id" \
         --offset-file "$offset_file" \
         --state-file "$AIRC_WRITE_DIR/bearer_state.json" \
@@ -1704,19 +1694,19 @@ monitor() {
 # Handles [rename] protocol by updating peer records on disk.
 # Read JSONL from stdin, emit one human-readable line per message.
 # Rust monitor formatter. Same stdin/stdout contract as the retired
-# formatter, but live receive formatting now stays on airc-rs.
+# formatter, but live receive formatting now stays on airc-core.
 monitor_formatter() {
   local my_name="$1"
   local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
-  local _airc_rs; _airc_rs=$(airc_rs_bin 2>/dev/null || true)
-  if [ -z "$_airc_rs" ]; then
-    echo "airc: airc-rs is required for monitor format" >&2
+  local _airc_core; _airc_core=$(airc_core_bin 2>/dev/null || true)
+  if [ -z "$_airc_core" ]; then
+    echo "airc: airc-core is required for monitor format" >&2
     return 127
   fi
   if [ -n "$_client_id" ]; then
-    AIRC_CLIENT_ID="$_client_id" "$_airc_rs" monitor format --peers-dir "$PEERS_DIR" --my-name "$my_name"
+    AIRC_CLIENT_ID="$_client_id" "$_airc_core" monitor format --peers-dir "$PEERS_DIR" --my-name "$my_name"
   else
-    "$_airc_rs" monitor format --peers-dir "$PEERS_DIR" --my-name "$my_name"
+    "$_airc_core" monitor format --peers-dir "$PEERS_DIR" --my-name "$my_name"
   fi
 }
 
@@ -1764,7 +1754,7 @@ flush_pending_loop() {
     rhome=$(remote_home)
 
     local _gh_wait=0
-    _gh_wait=$("$(airc_rs_bin)" gh wait-seconds 2>/dev/null || echo 0)
+    _gh_wait=$("$(airc_core_bin)" gh wait-seconds 2>/dev/null || echo 0)
     if [ "${_gh_wait:-0}" -gt 0 ] 2>/dev/null; then
       [ "$_gh_wait" -gt 60 ] 2>/dev/null && _gh_wait=60
       sleep "$_gh_wait"
@@ -1863,7 +1853,7 @@ flush_pending_host_loop() {
     [ -s "$pending" ] || continue
 
     local _gh_wait=0
-    _gh_wait=$("$(airc_rs_bin)" gh wait-seconds 2>/dev/null || echo 0)
+    _gh_wait=$("$(airc_core_bin)" gh wait-seconds 2>/dev/null || echo 0)
     if [ "${_gh_wait:-0}" -gt 0 ] 2>/dev/null; then
       [ "$_gh_wait" -gt 60 ] 2>/dev/null && _gh_wait=60
       sleep "$_gh_wait"
@@ -1880,16 +1870,16 @@ flush_pending_host_loop() {
     local _fallback_gist=""
     [ -f "$AIRC_WRITE_DIR/room_gist_id" ] && _fallback_gist=$(cat "$AIRC_WRITE_DIR/room_gist_id" 2>/dev/null || true)
     local _batch_route _batch_ok _batch_channel _batch_gist _batch_count
-    _batch_route=$("$(airc_rs_bin)" pending host-broadcast-route \
+    _batch_route=$("$(airc_core_bin)" pending host-broadcast-route \
       --snapshot "$snapshot" --config "$CONFIG" --fallback-gist "$_fallback_gist" 2>/dev/null || true)
     IFS="$(printf '\t')" read -r _batch_ok _batch_channel _batch_gist _batch_count <<EOF
 $_batch_route
 EOF
     if [ "$_batch_ok" = "ok" ] && [ -n "$_batch_gist" ]; then
       local _batch_outcome _batch_kind
-      _batch_outcome=$(cat "$snapshot" | "$(airc_rs_bin)" bearer send-batch \
+      _batch_outcome=$(cat "$snapshot" | "$(airc_core_bin)" bearer send-batch \
         all "$_batch_channel" --room-gist-id "$_batch_gist" 2>/dev/null || echo '{"kind":"transient_failure"}')
-      _batch_kind=$(printf '%s' "$_batch_outcome" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
+      _batch_kind=$(printf '%s' "$_batch_outcome" | "$(airc_core_bin)" gist get .kind 2>/dev/null)
       if [ "$_batch_kind" = "delivered" ]; then
         cat "$snapshot" >> "$MESSAGES"
         delivered=${_batch_count:-0}
@@ -1908,7 +1898,7 @@ EOF
       # never the wrapped envelope — cmd_send queues pre-wrap so the
       # drain can re-resolve recipient pubkey at retry time).
       local _line_channel
-      _line_channel=$(printf '%s\n' "$line" | "$(airc_rs_bin)" gist get .channel 2>/dev/null)
+      _line_channel=$(printf '%s\n' "$line" | "$(airc_core_bin)" gist get .channel 2>/dev/null)
 
       # Resolve channel → gist. Fall back to legacy room_gist_id only
       # when the line carries no channel (older queued lines may pre-date
@@ -1931,24 +1921,24 @@ EOF
       # Re-resolve recipient pubkey at drain time. Pre-pair queued lines
       # shipped plaintext; post-pair drain wraps them with the new pubkey.
       local _line_to
-      _line_to=$(printf '%s\n' "$line" | "$(airc_rs_bin)" gist get .to 2>/dev/null)
+      _line_to=$(printf '%s\n' "$line" | "$(airc_core_bin)" gist get .to 2>/dev/null)
       local _line_pub=""
       if [ -n "$_line_to" ] && [ "$_line_to" != "all" ]; then
-        _line_pub=$("$(airc_rs_bin)" identity peer-pub --home "$AIRC_WRITE_DIR" \
+        _line_pub=$("$(airc_core_bin)" identity peer-pub --home "$AIRC_WRITE_DIR" \
           --peers-dir "$PEERS_DIR" --peer-name "$_line_to" 2>/dev/null || true)
       fi
       local _wire="$line"
       if [ -n "$_line_pub" ]; then
-        _wire=$(printf '%s' "$line" | "$(airc_rs_bin)" envelope wrap --home "$AIRC_WRITE_DIR" \
+        _wire=$(printf '%s' "$line" | "$(airc_core_bin)" envelope wrap --home "$AIRC_WRITE_DIR" \
           --recipient-pub="$_line_pub" \
           --identity-dir "$IDENTITY_DIR" 2>/dev/null || printf '%s' "$line")
       fi
 
       local _outcome _kind
-      _outcome=$(printf '%s' "$_wire" | "$(airc_rs_bin)" bearer send \
+      _outcome=$(printf '%s' "$_wire" | "$(airc_core_bin)" bearer send \
         "${_line_to:-all}" "$_line_channel" \
         --room-gist-id "$_line_gist" 2>/dev/null || echo '{"kind":"transient_failure"}')
-      _kind=$(printf '%s' "$_outcome" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
+      _kind=$(printf '%s' "$_outcome" | "$(airc_core_bin)" gist get .kind 2>/dev/null)
 
       case "$_kind" in
         delivered)
@@ -2114,7 +2104,7 @@ reminder_timer_loop() {
               my_name=$(_airc_queue_resolve_name 2>/dev/null || echo "")
             fi
             local roster
-            roster=$("$(airc_rs_bin)" recent-senders \
+            roster=$("$(airc_core_bin)" recent-senders \
               --messages-log "$messages_log" \
               --window-seconds "$qm_roster_window" \
               --exclude-name "$my_name" 2>/dev/null || true)
@@ -2198,7 +2188,7 @@ reminder_timer_loop() {
         sub="${sub#\#}"
         local sf_path="$AIRC_WRITE_DIR/bearer_state.${sub}.json"
         subs_file_glob="${subs_file_glob}${sf_path}|"
-      done < <("$(airc_rs_bin)" config read-channels --home "$AIRC_WRITE_DIR" --config "$CONFIG" 2>/dev/null)
+      done < <("$(airc_core_bin)" config read-channels --home "$AIRC_WRITE_DIR" --config "$CONFIG" 2>/dev/null)
 
       for sf in "$AIRC_WRITE_DIR"/bearer_state*.json; do
         [ -f "$sf" ] || continue
@@ -2214,7 +2204,7 @@ reminder_timer_loop() {
         fi
         has_any_state=1
         local ts
-        ts=$("$(airc_rs_bin)" bearer-state "$sf" 2>/dev/null | awk '{print $1}')
+        ts=$("$(airc_core_bin)" bearer-state "$sf" 2>/dev/null | awk '{print $1}')
         if [ -n "$ts" ] && [ "$ts" -gt "$freshest_recv" ] 2>/dev/null; then
           freshest_recv="$ts"
         fi
@@ -2370,7 +2360,7 @@ EOF
     # command lines. Match on that to scope the kill to OUR children
     # only — multi-scope safety, same principle as cmd_teardown's
     # scope-isolation guarantee.
-    pkill -f "airc-rs bearer recv.*${AIRC_WRITE_DIR}" 2>/dev/null || true
+    pkill -f "airc-core bearer recv.*${AIRC_WRITE_DIR}" 2>/dev/null || true
   done
 }
 
@@ -2626,7 +2616,7 @@ case "${1:-help}" in
   codex-poll) shift; AIRC_INBOX_QUIET_EMPTY=1 AIRC_INBOX_EXCLUDE_SELF=1 cmd_inbox --count 50 "$@" ;;
   codex-start) shift; cmd_codex_start "$@" ;;
   codex-hook) shift; cmd_codex_hook "$@" ;;
-  gh-audit) shift; "$(airc_rs_bin)" gh audit "$@" ;;
+  gh-audit) shift; "$(airc_core_bin)" gh audit "$@" ;;
   status)    shift; cmd_status "$@" ;;
   doctor)            shift; cmd_doctor "$@" ;;
   tests|test)        shift; _doctor_run_tests "$@" ;;

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 workspace = true
 
 [[bin]]
-name = "airc-rs"
+name = "airc-core"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -58,15 +58,14 @@ pub fn default_socket_path_in(home: &std::path::Path) -> PathBuf {
     home.join("daemon.sock")
 }
 
-/// airc-rs — Rust substrate CLI. Replaces the Python `airc` step by
-/// step; each subcommand exercises one slice of the substrate.
+/// AIRC substrate CLI.
 #[derive(Debug, Parser)]
 #[command(
-    name = "airc-rs",
+    name = "airc",
     version,
-    about = "AIRC substrate CLI (Rust)",
+    about = "AIRC substrate CLI",
     long_about = "Cross-process / cross-machine AI chat over the airc substrate. \
-                  Replaces the Python airc CLI as the Rust path matures."
+                  Provides the public AIRC command surface."
 )]
 pub struct Cli {
     /// State directory for persisted identity + IPC socket. Default
@@ -77,7 +76,7 @@ pub struct Cli {
 
     /// Ad-hoc peers to enrol for this invocation only, repeatable.
     /// Format: `<uuid>:<base64-pubkey-no-padding>`. Persistent peers
-    /// come from `<home>/peers.json` (managed via `airc-rs peer add`);
+    /// come from `<home>/peers.json` (managed via `airc peer add`);
     /// this flag unions on top for one-shot use.
     #[arg(long = "peer", value_name = "SPEC", global = true)]
     pub peers: Vec<PeerSpec>,
@@ -139,7 +138,7 @@ pub enum Command {
 
     /// Send a single text Message frame to the current room and exit.
     /// The current room lives in `<home>/room.json`; switch with
-    /// `airc-rs room <name>`.
+    /// `airc room <name>`.
     Send {
         /// Message body.
         text: String,
@@ -233,7 +232,7 @@ pub enum Command {
     /// Print or switch the current room. With no name, prints the
     /// current room's name + wire + channel. With a name, derives a
     /// deterministic `(wire, channel)` from the name and sets it as
-    /// the current room — two peers who run `airc-rs room project-x`
+    /// the current room — two peers who run `airc room project-x`
     /// land in the same channel without sharing the UUID.
     Room {
         /// Room name. Omit to just print the current room.
@@ -349,7 +348,7 @@ pub enum PeerAction {
     /// registry stays in sync — no daemon restart required.
     Add {
         /// Peer spec: `<uuid>:<base64-pubkey-no-padding>` (the
-        /// `peer_spec:` line from the other side's `airc-rs init`).
+        /// `peer_spec:` line from the other side's `airc init`).
         spec: PeerSpec,
         /// Override the default socket (`<home>/daemon.sock`).
         #[arg(long)]

--- a/crates/airc-cli/src/codex_commands.rs
+++ b/crates/airc-cli/src/codex_commands.rs
@@ -1,4 +1,4 @@
-//! `airc-rs codex-hook ...` handlers.
+//! `airc codex-hook ...` handlers.
 
 use std::collections::BTreeSet;
 use std::io::Read;
@@ -166,7 +166,7 @@ fn render_digest(events: &[TranscriptEvent], max_items: usize) -> String {
         ));
     }
     if hidden > 0 {
-        lines.push("more: airc-rs codex-hook user-prompt-submit --raw".to_string());
+        lines.push("more: airc codex-hook user-prompt-submit --raw".to_string());
     }
     lines.join("\n")
 }

--- a/crates/airc-cli/src/codex_hooks_json.rs
+++ b/crates/airc-cli/src/codex_hooks_json.rs
@@ -1,22 +1,19 @@
 //! Codex hooks.json mutation for AIRC hook installation.
 
-use std::path::Path;
-use std::path::PathBuf;
-
 use serde_json::{json, Value};
+use std::path::Path;
 
-const RUST_HOOK_COMMAND: &str = "airc-rs codex-hook user-prompt-submit";
 const HOOK_COMMAND_SUFFIX: &str = "codex-hook user-prompt-submit";
-const LEGACY_HOOK_COMMAND: &str = "airc codex-hook user-prompt-submit";
+const HOOK_COMMAND: &str = "airc codex-hook user-prompt-submit";
 const HOOK_STATUS: &str = "Checking AIRC inbox";
 
-pub fn install(path: &Path, airc_rs: &Path) -> Result<bool, Box<dyn std::error::Error>> {
+pub fn install(path: &Path, _airc_core: &Path) -> Result<bool, Box<dyn std::error::Error>> {
     let original = read_json(path)?;
     let mut data = ensure_root_object(original);
     let user_prompt = ensure_user_prompt_array(&mut data)?;
     let before = user_prompt.clone();
     remove_managed_hook_entries(user_prompt);
-    user_prompt.push(hook_group(&hook_command(airc_rs)));
+    user_prompt.push(hook_group(HOOK_COMMAND));
 
     let changed = *user_prompt != before;
     if changed {
@@ -89,9 +86,7 @@ fn is_managed_hook_command(command: Option<&str>) -> bool {
     let Some(command) = command else {
         return false;
     };
-    command == RUST_HOOK_COMMAND
-        || command == LEGACY_HOOK_COMMAND
-        || command.ends_with(HOOK_COMMAND_SUFFIX)
+    command == HOOK_COMMAND || command.ends_with(HOOK_COMMAND_SUFFIX)
 }
 
 fn hook_group(command: &str) -> Value {
@@ -103,25 +98,6 @@ fn hook_group(command: &str) -> Value {
             "statusMessage": HOOK_STATUS
         }]
     })
-}
-
-fn hook_command(airc_rs: &Path) -> String {
-    format!("{} {HOOK_COMMAND_SUFFIX}", shell_quote_path(airc_rs))
-}
-
-fn shell_quote_path(path: &Path) -> String {
-    let raw = path_to_string(path);
-    if raw
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-'))
-    {
-        return raw;
-    }
-    format!("'{}'", raw.replace('\'', "'\\''"))
-}
-
-fn path_to_string(path: &Path) -> String {
-    PathBuf::from(path).to_string_lossy().into_owned()
 }
 
 fn read_json(path: &Path) -> Result<Value, Box<dyn std::error::Error>> {

--- a/crates/airc-cli/src/codex_install.rs
+++ b/crates/airc-cli/src/codex_install.rs
@@ -20,8 +20,8 @@ pub async fn run_install_hooks(
             config.display()
         );
     }
-    let airc_rs = std::env::current_exe()?;
-    if codex_hooks_json::install(&hooks_json, &airc_rs)? {
+    let airc_core = std::env::current_exe()?;
+    if codex_hooks_json::install(&hooks_json, &airc_core)? {
         println!(
             "installed AIRC UserPromptSubmit hook in {}",
             hooks_json.display()

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -33,7 +33,7 @@ use airc_store::{EventStore, SqliteEventStore};
 pub async fn run_init(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let airc = Airc::open(home).await?;
     // Auto-join "default" room on first init so subsequent
-    // `airc-rs msg` / `say` work without explicit room selection.
+    // `airc msg` / `say` work without explicit room selection.
     if airc.current_room().await?.name != "default" {
         // load_or_default returns the synthesised default when
         // room.json is missing; if a different room name comes back
@@ -49,8 +49,8 @@ pub async fn run_init(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
     println!("peer_spec:   {}", airc.peer_spec());
     println!();
     println!(
-        "Share peer_spec with peers; enrol theirs via `airc-rs peer add <spec>`. \
-         Use `airc-rs room <name>` to switch rooms; `airc-rs msg \"hi\"` sends \
+        "Share peer_spec with peers; enrol theirs via `airc peer add <spec>`. \
+         Use `airc room <name>` to switch rooms; `airc msg \"hi\"` sends \
          to the current room."
     );
     Ok(())
@@ -204,12 +204,12 @@ pub async fn run_daemon(
         store,
     ));
     println!(
-        "airc-rs daemon: peer_id={} listening on {}",
+        "airc daemon: peer_id={} listening on {}",
         identity.peer_id,
         socket.display()
     );
     run_daemon_server(state, socket).await?;
-    println!("airc-rs daemon: stopped.");
+    println!("airc daemon: stopped.");
     Ok(())
 }
 
@@ -408,7 +408,7 @@ pub async fn run_peer_list(home: &Path) -> Result<(), Box<dyn std::error::Error>
     let airc = Airc::open(home).await?;
     let peers = airc.peers().await?;
     if peers.is_empty() {
-        println!("(no enroled peers — use `airc-rs peer add <spec>` to enrol)");
+        println!("(no enroled peers — use `airc peer add <spec>` to enrol)");
         return Ok(());
     }
     for peer in &peers {

--- a/crates/airc-cli/src/events_cli.rs
+++ b/crates/airc-cli/src/events_cli.rs
@@ -1,4 +1,4 @@
-//! Clap argument shapes for `airc-rs events ...`.
+//! Clap argument shapes for `airc events ...`.
 
 use clap::{Args, Subcommand, ValueEnum};
 

--- a/crates/airc-cli/src/events_commands.rs
+++ b/crates/airc-cli/src/events_commands.rs
@@ -1,4 +1,4 @@
-//! `airc-rs events ...` handlers.
+//! `airc events ...` handlers.
 
 use std::path::Path;
 

--- a/crates/airc-cli/src/handshake_cli.rs
+++ b/crates/airc-cli/src/handshake_cli.rs
@@ -63,7 +63,7 @@ mod tests {
     fn send_accepts_multiline_hyphen_leading_public_keys() {
         let pem = "-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----";
         let cli = Cli::try_parse_from([
-            "airc-rs",
+            "airc-core",
             "handshake",
             "send",
             "127.0.0.1",

--- a/crates/airc-cli/src/lane_cli.rs
+++ b/crates/airc-cli/src/lane_cli.rs
@@ -1,4 +1,4 @@
-//! Clap argument shapes for `airc-rs lane ...`.
+//! Clap argument shapes for `airc lane ...`.
 
 use clap::{Args, Subcommand, ValueEnum};
 

--- a/crates/airc-cli/src/lane_commands.rs
+++ b/crates/airc-cli/src/lane_commands.rs
@@ -1,4 +1,4 @@
-//! `airc-rs lane ...` handlers.
+//! `airc lane ...` handlers.
 
 use std::path::Path;
 

--- a/crates/airc-cli/src/log_cli.rs
+++ b/crates/airc-cli/src/log_cli.rs
@@ -1,4 +1,4 @@
-//! Clap argument shapes for `airc-rs log ...`.
+//! Clap argument shapes for `airc log ...`.
 
 use std::path::PathBuf;
 

--- a/crates/airc-cli/src/log_commands.rs
+++ b/crates/airc-cli/src/log_commands.rs
@@ -1,4 +1,4 @@
-//! `airc-rs log ...` handlers for legacy shell log paths.
+//! `airc log ...` handlers for legacy shell log paths.
 
 use std::error::Error;
 use std::fs::{self, File, OpenOptions};

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -1,4 +1,4 @@
-//! airc-rs — Rust substrate CLI binary.
+//! airc — Rust substrate CLI.
 //!
 //! State lives under `<home>` (default `$HOME/.airc`):
 //!   - `identity.key`   — 32-byte Ed25519 secret (0600)
@@ -6,7 +6,7 @@
 //!   - `daemon.sock`    — IPC socket
 //!   - `peers.json`     — (next PR) persisted peer registry
 //!
-//! `airc-rs init` is the only command that creates the identity from
+//! `airc init` is the only command that creates the identity from
 //! nothing. All others load `<home>/identity.{key,json}` (auto-
 //! generating if absent). `VerificationPolicy::Strict` is the only
 //! policy used in CLI paths — no `AllowUnsigned` opt-in.
@@ -128,19 +128,19 @@ fn main() -> ExitCode {
     #[cfg(windows)]
     {
         return match std::thread::Builder::new()
-            .name("airc-rs-main".to_string())
+            .name("airc-main".to_string())
             .stack_size(WINDOWS_MAIN_STACK_BYTES)
             .spawn(run_main)
         {
             Ok(handle) => match handle.join() {
                 Ok(code) => code,
                 Err(_) => {
-                    eprintln!("airc-rs: main thread panicked");
+                    eprintln!("airc: main thread panicked");
                     ExitCode::FAILURE
                 }
             },
             Err(error) => {
-                eprintln!("airc-rs: failed to start main thread: {error}");
+                eprintln!("airc: failed to start main thread: {error}");
                 ExitCode::FAILURE
             }
         };
@@ -157,7 +157,7 @@ fn run_main() -> ExitCode {
     {
         Ok(runtime) => runtime,
         Err(error) => {
-            eprintln!("airc-rs: failed to start tokio runtime: {error}");
+            eprintln!("airc: failed to start tokio runtime: {error}");
             return ExitCode::FAILURE;
         }
     };
@@ -180,7 +180,7 @@ async fn async_main() -> ExitCode {
             if let Some(code) = identity_commands::command_exit_code(error.as_ref()) {
                 return ExitCode::from(code);
             }
-            eprintln!("airc-rs: {error}");
+            eprintln!("airc: {error}");
             ExitCode::FAILURE
         }
     }

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -1,4 +1,4 @@
-//! Clap argument shapes for `airc-rs work ...`.
+//! Clap argument shapes for `airc work ...`.
 
 use clap::{Args, Subcommand, ValueEnum};
 

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -1,4 +1,4 @@
-//! `airc-rs work ...` handlers.
+//! `airc work ...` handlers.
 //!
 //! The CLI stays intentionally thin: it parses human input, calls the
 //! consumer-facing `airc_lib::Airc` work API, and prints stable lines

--- a/crates/airc-cli/src/workspace_cli.rs
+++ b/crates/airc-cli/src/workspace_cli.rs
@@ -1,4 +1,4 @@
-//! Clap argument shapes for `airc-rs workspace ...`.
+//! Clap argument shapes for `airc workspace ...`.
 
 use clap::{Args, Subcommand};
 

--- a/crates/airc-cli/src/workspace_commands.rs
+++ b/crates/airc-cli/src/workspace_commands.rs
@@ -1,4 +1,4 @@
-//! `airc-rs workspace ...` handlers.
+//! `airc workspace ...` handlers.
 
 use std::path::Path;
 

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -1,4 +1,4 @@
-//! End-to-end coverage for `airc-rs codex-hook ...`.
+//! End-to-end coverage for `airc-core codex-hook ...`.
 
 use std::io::Write;
 use std::path::Path;
@@ -7,8 +7,8 @@ use std::process::{Command, Stdio};
 use serde_json::Value;
 use tempfile::TempDir;
 
-fn airc_rs() -> &'static str {
-    env!("CARGO_BIN_EXE_airc-rs")
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-core")
 }
 
 #[test]
@@ -103,7 +103,7 @@ fn codex_hook_raw_mode_preserves_full_event_lines() {
 }
 
 #[test]
-fn codex_hook_installer_replaces_legacy_python_hook() {
+fn codex_hook_installer_replaces_existing_managed_hook() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("airc");
     let codex_home = workspace.path().join("codex");
@@ -143,17 +143,19 @@ fn codex_hook_installer_replaces_legacy_python_hook() {
         commands
             .iter()
             .any(|command| command.ends_with("codex-hook user-prompt-submit")),
-        "installer must add a Rust hook command, got {commands:?}"
+        "installer must add the public hook command, got {commands:?}"
     );
-    assert!(
-        !commands.contains(&"airc-rs codex-hook user-prompt-submit".to_string()),
-        "installer should pin the resolved airc-rs executable instead of relying on PATH"
+    assert_eq!(
+        commands
+            .iter()
+            .filter(|command| command.as_str() == "airc codex-hook user-prompt-submit")
+            .count(),
+        1
     );
-    assert!(!commands.contains(&"airc codex-hook user-prompt-submit".to_string()));
 }
 
 #[test]
-fn codex_hook_installer_replaces_prior_absolute_rust_hook() {
+fn codex_hook_installer_replaces_existing_managed_hook_command() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("airc");
     let codex_home = workspace.path().join("codex");
@@ -162,7 +164,7 @@ fn codex_hook_installer_replaces_prior_absolute_rust_hook() {
         .expect("write config");
     std::fs::write(
         codex_home.join("hooks.json"),
-        r#"{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"/old/install/bin/airc-rs codex-hook user-prompt-submit"}]}]}}"#,
+        r#"{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"airc codex-hook user-prompt-submit"}]}]}}"#,
     )
     .expect("write hooks");
 
@@ -186,17 +188,16 @@ fn codex_hook_installer_replaces_prior_absolute_rust_hook() {
             .filter(|command| command.ends_with("codex-hook user-prompt-submit"))
             .count(),
         1,
-        "install must replace older managed hook commands, got {commands:?}"
+        "install must replace existing managed hook commands, got {commands:?}"
     );
-    assert!(
-        commands[0].contains(env!("CARGO_BIN_EXE_airc-rs")),
-        "hook command should pin current executable, got {:?}",
-        commands
+    assert_eq!(
+        commands,
+        vec!["airc codex-hook user-prompt-submit".to_string()]
     );
 }
 
 #[test]
-fn codex_hook_installer_removes_stale_filesystem_profile() {
+fn codex_hook_installer_removes_managed_filesystem_profile() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("airc");
     let codex_home = workspace.path().join("codex");
@@ -250,7 +251,7 @@ fn codex_hook_uninstaller_removes_managed_hooks_only() {
     .expect("write config");
     std::fs::write(
         codex_home.join("hooks.json"),
-        r#"{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"echo existing"},{"type":"command","command":"airc-rs codex-hook user-prompt-submit"}]}]}}"#,
+        r#"{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"echo existing"},{"type":"command","command":"airc-core codex-hook user-prompt-submit"}]}]}}"#,
     )
     .expect("write hooks");
 
@@ -273,19 +274,19 @@ fn codex_hook_uninstaller_removes_managed_hooks_only() {
             .expect("hooks json");
     let commands = hook_commands(&hooks);
     assert!(commands.contains(&"echo existing".to_string()));
-    assert!(!commands.contains(&"airc-rs codex-hook user-prompt-submit".to_string()));
+    assert!(!commands.contains(&"airc-core codex-hook user-prompt-submit".to_string()));
 }
 
 fn run_ok(home: &Path, args: &[&str]) -> String {
-    let output = Command::new(airc_rs())
+    let output = Command::new(airc_core())
         .arg("--home")
         .arg(home)
         .args(args)
         .output()
-        .expect("airc-rs command must spawn");
+        .expect("airc-core command must spawn");
     assert!(
         output.status.success(),
-        "airc-rs {:?} failed: stdout={} stderr={}",
+        "airc-core {:?} failed: stdout={} stderr={}",
         args,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
@@ -294,7 +295,7 @@ fn run_ok(home: &Path, args: &[&str]) -> String {
 }
 
 fn run_hook(home: &Path, args: &[&str], stdin: &str) -> String {
-    let mut child = Command::new(airc_rs())
+    let mut child = Command::new(airc_core())
         .arg("--home")
         .arg(home)
         .args(args)
@@ -302,7 +303,7 @@ fn run_hook(home: &Path, args: &[&str], stdin: &str) -> String {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .expect("airc-rs hook must spawn");
+        .expect("airc-core hook must spawn");
     child
         .stdin
         .as_mut()
@@ -312,7 +313,7 @@ fn run_hook(home: &Path, args: &[&str], stdin: &str) -> String {
     let output = child.wait_with_output().expect("wait for hook");
     assert!(
         output.status.success(),
-        "airc-rs {:?} failed: stdout={} stderr={}",
+        "airc-core {:?} failed: stdout={} stderr={}",
         args,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),

--- a/crates/airc-cli/tests/config_commands.rs
+++ b/crates/airc-cli/tests/config_commands.rs
@@ -1,4 +1,4 @@
-//! End-to-end coverage for `airc-rs config ...`.
+//! End-to-end coverage for `airc-core config ...`.
 
 use std::fs;
 use std::path::Path;
@@ -6,8 +6,8 @@ use std::process::Command;
 
 use tempfile::TempDir;
 
-fn airc_rs() -> &'static str {
-    env!("CARGO_BIN_EXE_airc-rs")
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-core")
 }
 
 #[test]
@@ -246,15 +246,15 @@ fn config_set_host_block_writes_handshake_fields() {
 }
 
 fn run_ok(home: &Path, args: &[&str]) -> String {
-    let output = Command::new(airc_rs())
+    let output = Command::new(airc_core())
         .arg("--home")
         .arg(home)
         .args(args)
         .output()
-        .expect("airc-rs command must spawn");
+        .expect("airc-core command must spawn");
     assert!(
         output.status.success(),
-        "airc-rs {:?} failed: stdout={} stderr={}",
+        "airc-core {:?} failed: stdout={} stderr={}",
         args,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),

--- a/crates/airc-cli/tests/daemon_scope_commands.rs
+++ b/crates/airc-cli/tests/daemon_scope_commands.rs
@@ -1,15 +1,15 @@
 use std::process::Command;
 
-fn airc_rs() -> &'static str {
-    env!("CARGO_BIN_EXE_airc-rs")
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-core")
 }
 
 #[test]
 fn daemon_scope_id_matches_legacy_sha1_prefix() {
-    let output = Command::new(airc_rs())
+    let output = Command::new(airc_core())
         .args(["daemon-scope-id", "/tmp/airc"])
         .output()
-        .expect("airc-rs daemon-scope-id must spawn");
+        .expect("airc-core daemon-scope-id must spawn");
 
     assert!(
         output.status.success(),

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -1,4 +1,4 @@
-//! End-to-end integration test for the `airc-rs` binary.
+//! End-to-end integration test for the `airc-core` binary.
 //!
 //! Spawns two real subprocesses (Alice + Bob), has them chat over the
 //! Rust substrate, and asserts the message arrives. No Python anywhere.
@@ -14,19 +14,19 @@ use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 
-fn airc_rs() -> &'static str {
-    env!("CARGO_BIN_EXE_airc-rs")
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-core")
 }
 
-/// Run `airc-rs --home <dir> init` and parse the printed `peer_id:`
+/// Run `airc-core --home <dir> init` and parse the printed `peer_id:`
 /// and `peer_spec:` lines from stdout.
 fn run_init(home: &Path) -> (String, String) {
-    let output = Command::new(airc_rs())
+    let output = Command::new(airc_core())
         .arg("--home")
         .arg(home)
         .arg("init")
         .output()
-        .expect("airc-rs init must spawn");
+        .expect("airc-core init must spawn");
     assert!(
         output.status.success(),
         "init failed: stdout={} stderr={}",
@@ -49,8 +49,8 @@ fn extract_field<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
 }
 
 #[test]
-fn two_airc_rs_processes_chat_over_local_fs() {
-    // Alice runs `airc-rs listen`; Bob runs `airc-rs send`; Alice's
+fn two_airc_core_processes_chat_over_local_fs() {
+    // Alice runs `airc-core listen`; Bob runs `airc-core send`; Alice's
     // stdout MUST contain the message body within a few seconds. No
     // Python anywhere.
     let workspace = TempDir::new().expect("tempdir");
@@ -68,7 +68,7 @@ fn two_airc_rs_processes_chat_over_local_fs() {
     run_room(&alice_home, "e2e", &wire);
     run_room(&bob_home, "e2e", &wire);
 
-    let mut alice = Command::new(airc_rs())
+    let mut alice = Command::new(airc_core())
         .args([
             "--home",
             alice_home.to_str().unwrap(),
@@ -84,7 +84,7 @@ fn two_airc_rs_processes_chat_over_local_fs() {
 
     std::thread::sleep(Duration::from_millis(300));
 
-    let bob_send = Command::new(airc_rs())
+    let bob_send = Command::new(airc_core())
         .args([
             "--home",
             bob_home.to_str().unwrap(),
@@ -117,10 +117,10 @@ fn two_airc_rs_processes_chat_over_local_fs() {
     );
 }
 
-/// Run `airc-rs --home <dir> room <name> --wire <wire>`. Used by
+/// Run `airc-core --home <dir> room <name> --wire <wire>`. Used by
 /// tests to pin two peers to the same shared-wire room.
 fn run_room(home: &Path, name: &str, wire: &Path) {
-    let output = Command::new(airc_rs())
+    let output = Command::new(airc_core())
         .args([
             "--home",
             home.to_str().unwrap(),
@@ -130,7 +130,7 @@ fn run_room(home: &Path, name: &str, wire: &Path) {
             wire.to_str().unwrap(),
         ])
         .output()
-        .expect("airc-rs room must spawn");
+        .expect("airc-core room must spawn");
     assert!(
         output.status.success(),
         "room setup failed: stderr={}",
@@ -156,7 +156,7 @@ fn listen_rejects_unenrolled_signer() {
     run_room(&alice_home, "e2e", &wire);
     run_room(&mallory_home, "e2e", &wire);
 
-    let mut alice = Command::new(airc_rs())
+    let mut alice = Command::new(airc_core())
         .args(["--home", alice_home.to_str().unwrap(), "listen", "--replay"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -167,7 +167,7 @@ fn listen_rejects_unenrolled_signer() {
 
     // Mallory passes herself as `--peer` so her own registry is
     // non-empty; her CLI signs the frame under her own identity.
-    let _mallory_send = Command::new(airc_rs())
+    let _mallory_send = Command::new(airc_core())
         .args([
             "--home",
             mallory_home.to_str().unwrap(),
@@ -193,7 +193,7 @@ fn listen_rejects_unenrolled_signer() {
 }
 
 #[test]
-fn two_airc_rs_processes_chat_over_lan_via_sdk_route() {
+fn two_airc_core_processes_chat_over_lan_via_sdk_route() {
     // The LAN CLI commands must be thin wrappers over airc-lib. This
     // test spawns real processes and uses `lan-listen` / `lan-send`
     // without a shared local-fs wire.
@@ -204,7 +204,7 @@ fn two_airc_rs_processes_chat_over_lan_via_sdk_route() {
     let (alice_id, alice_spec) = run_init(&alice_home);
     let (_bob_id, bob_spec) = run_init(&bob_home);
 
-    let mut alice = Command::new(airc_rs())
+    let mut alice = Command::new(airc_core())
         .args([
             "--home",
             alice_home.to_str().unwrap(),
@@ -226,7 +226,7 @@ fn two_airc_rs_processes_chat_over_lan_via_sdk_route() {
             .expect("alice must print bound LAN address");
     let bound_addr = parse_listening_addr(&listen_line);
 
-    let bob_send = Command::new(airc_rs())
+    let bob_send = Command::new(airc_core())
         .args([
             "--home",
             bob_home.to_str().unwrap(),
@@ -268,7 +268,7 @@ fn daemon_msg_and_inbox_use_sdk_attach_path() {
     let socket = workspace.path().join("daemon.sock");
     run_init(&home);
 
-    let mut daemon = Command::new(airc_rs())
+    let mut daemon = Command::new(airc_core())
         .args([
             "--home",
             home.to_str().unwrap(),
@@ -287,7 +287,7 @@ fn daemon_msg_and_inbox_use_sdk_attach_path() {
         Duration::from_secs(6),
     );
 
-    let msg = Command::new(airc_rs())
+    let msg = Command::new(airc_core())
         .args([
             "--home",
             home.to_str().unwrap(),
@@ -316,7 +316,7 @@ fn daemon_msg_and_inbox_use_sdk_attach_path() {
         "inbox did not print daemon-sent message through SDK attach path"
     );
 
-    let stop = Command::new(airc_rs())
+    let stop = Command::new(airc_core())
         .args([
             "--home",
             home.to_str().unwrap(),
@@ -336,7 +336,7 @@ fn inbox_without_socket_reads_in_process_store() {
     let home = workspace.path().join("agent");
     run_init(&home);
 
-    let send = Command::new(airc_rs())
+    let send = Command::new(airc_core())
         .args([
             "--home",
             home.to_str().unwrap(),
@@ -352,7 +352,7 @@ fn inbox_without_socket_reads_in_process_store() {
         String::from_utf8_lossy(&send.stderr),
     );
 
-    let inbox = Command::new(airc_rs())
+    let inbox = Command::new(airc_core())
         .args(["--home", home.to_str().unwrap(), "inbox", "--limit", "16"])
         .output()
         .expect("inbox must spawn");
@@ -371,7 +371,7 @@ fn inbox_without_socket_reads_in_process_store() {
 
 #[test]
 fn rerun_init_returns_same_peer_id() {
-    // The persistence pin: `airc-rs init` must be idempotent. The
+    // The persistence pin: `airc-core init` must be idempotent. The
     // second run reuses the on-disk identity rather than minting a
     // new peer_id.
     let workspace = TempDir::new().expect("tempdir");
@@ -393,7 +393,7 @@ fn wait_for_command_stdout_contains(
 ) -> bool {
     let deadline = Instant::now() + timeout;
     loop {
-        let output = Command::new(airc_rs())
+        let output = Command::new(airc_core())
             .args([
                 "--home",
                 home.to_str().unwrap(),

--- a/crates/airc-cli/tests/events_commands.rs
+++ b/crates/airc-cli/tests/events_commands.rs
@@ -1,12 +1,12 @@
-//! End-to-end coverage for `airc-rs events ...`.
+//! End-to-end coverage for `airc-core events ...`.
 
 use std::path::Path;
 use std::process::Command;
 
 use tempfile::TempDir;
 
-fn airc_rs() -> &'static str {
-    env!("CARGO_BIN_EXE_airc-rs")
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-core")
 }
 
 #[test]
@@ -47,15 +47,15 @@ fn events_list_filters_by_kind_and_header_prefix() {
 }
 
 fn run_ok(home: &Path, args: &[&str]) -> String {
-    let output = Command::new(airc_rs())
+    let output = Command::new(airc_core())
         .arg("--home")
         .arg(home)
         .args(args)
         .output()
-        .expect("airc-rs command must spawn");
+        .expect("airc-core command must spawn");
     assert!(
         output.status.success(),
-        "airc-rs {:?} failed: stdout={} stderr={}",
+        "airc-core {:?} failed: stdout={} stderr={}",
         args,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),

--- a/crates/airc-cli/tests/identity_commands.rs
+++ b/crates/airc-cli/tests/identity_commands.rs
@@ -3,13 +3,13 @@ use std::process::Command;
 use base64::{engine::general_purpose, Engine};
 use tempfile::TempDir;
 
-fn airc_rs() -> &'static str {
-    env!("CARGO_BIN_EXE_airc-rs")
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-core")
 }
 
 #[test]
 fn identity_pretty_matches_whois_shape() {
-    let output = Command::new(airc_rs())
+    let output = Command::new(airc_core())
         .args([
             "identity",
             "pretty",
@@ -21,7 +21,7 @@ fn identity_pretty_matches_whois_shape() {
             "alice.local",
         ])
         .output()
-        .expect("airc-rs identity pretty must spawn");
+        .expect("airc-core identity pretty must spawn");
 
     assert!(
         output.status.success(),
@@ -46,10 +46,10 @@ fn identity_pretty_matches_whois_shape() {
 
 #[test]
 fn identity_pretty_defaults_unset_fields() {
-    let output = Command::new(airc_rs())
+    let output = Command::new(airc_core())
         .args(["identity", "pretty", "--name", "alice"])
         .output()
-        .expect("airc-rs identity pretty must spawn");
+        .expect("airc-core identity pretty must spawn");
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -178,7 +178,7 @@ fn legacy_envelope_wrap_encrypts_message_field() {
 
 fn run_ok(home: &std::path::Path, args: &[&str], stdin: &str) -> String {
     use std::io::Write;
-    let mut child = Command::new(airc_rs())
+    let mut child = Command::new(airc_core())
         .arg("--home")
         .arg(home)
         .args(args)
@@ -186,17 +186,17 @@ fn run_ok(home: &std::path::Path, args: &[&str], stdin: &str) -> String {
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .expect("airc-rs must spawn");
+        .expect("airc-core must spawn");
     child
         .stdin
         .as_mut()
         .expect("stdin")
         .write_all(stdin.as_bytes())
         .unwrap();
-    let output = child.wait_with_output().expect("airc-rs must exit");
+    let output = child.wait_with_output().expect("airc-core must exit");
     assert!(
         output.status.success(),
-        "airc-rs failed: stdout={} stderr={}",
+        "airc-core failed: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );

--- a/crates/airc-cli/tests/message_commands.rs
+++ b/crates/airc-cli/tests/message_commands.rs
@@ -1,11 +1,11 @@
-//! End-to-end coverage for `airc-rs message ...`.
+//! End-to-end coverage for `airc-core message ...`.
 
 use std::process::Command;
 
 use serde_json::Value;
 
-fn airc_rs() -> &'static str {
-    env!("CARGO_BIN_EXE_airc-rs")
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-core")
 }
 
 #[test]
@@ -23,7 +23,7 @@ fn message_build_legacy_alias_matches_build_output() {
 }
 
 fn run_ok(prefix: &[&str]) -> String {
-    let output = Command::new(airc_rs())
+    let output = Command::new(airc_core())
         .args(prefix)
         .args([
             "--from",
@@ -42,7 +42,7 @@ fn run_ok(prefix: &[&str]) -> String {
             "chat",
         ])
         .output()
-        .expect("run airc-rs");
+        .expect("run airc-core");
 
     assert!(
         output.status.success(),

--- a/crates/airc-cli/tests/operational_dogfood.rs
+++ b/crates/airc-cli/tests/operational_dogfood.rs
@@ -2,7 +2,7 @@
 //!
 //! This test intentionally does NOT pass `--home` and does NOT pass
 //! ad-hoc `--peer` flags to listen/send. Each subprocess receives a
-//! distinct fake user HOME, so `airc-rs` resolves state through the
+//! distinct fake user HOME, so `airc-core` resolves state through the
 //! default installed path: `<HOME>/.airc`.
 //!
 //! The proof shape mirrors the real Codex/Claude target:
@@ -22,8 +22,8 @@ use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 
-fn airc_rs() -> &'static str {
-    env!("CARGO_BIN_EXE_airc-rs")
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-core")
 }
 
 #[test]
@@ -170,7 +170,7 @@ fn installed_init(user_home: &Path) -> InitOutput {
     let output = installed_command(user_home)
         .arg("init")
         .output()
-        .expect("airc-rs init must spawn");
+        .expect("airc-core init must spawn");
     assert!(
         output.status.success(),
         "init failed: stdout={} stderr={}",
@@ -194,7 +194,7 @@ fn installed_peer_add(user_home: &Path, peer_spec: &str) {
     let output = installed_command(user_home)
         .args(["peer", "add", peer_spec])
         .output()
-        .expect("airc-rs peer add must spawn");
+        .expect("airc-core peer add must spawn");
     assert!(
         output.status.success(),
         "peer add failed: stdout={} stderr={}",
@@ -207,7 +207,7 @@ fn installed_room(user_home: &Path, room: &str, wire: &Path) {
     let output = installed_command(user_home)
         .args(["room", room, "--wire", wire.to_str().expect("wire utf-8")])
         .output()
-        .expect("airc-rs room must spawn");
+        .expect("airc-core room must spawn");
     assert!(
         output.status.success(),
         "room failed: stdout={} stderr={}",
@@ -222,7 +222,7 @@ fn installed_listen(user_home: &Path) -> std::process::Child {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .expect("airc-rs listen must spawn")
+        .expect("airc-core listen must spawn")
 }
 
 fn installed_monitor_attach(user_home: &Path) -> std::process::Child {
@@ -238,7 +238,7 @@ fn installed_send(user_home: &Path, text: &str) {
     let output = installed_command(user_home)
         .args(["send", text])
         .output()
-        .expect("airc-rs send must spawn");
+        .expect("airc-core send must spawn");
     assert!(
         output.status.success(),
         "send failed: stdout={} stderr={}",
@@ -251,7 +251,7 @@ fn installed_inbox(user_home: &Path) -> String {
     let output = installed_command(user_home)
         .args(["inbox", "--limit", "16"])
         .output()
-        .expect("airc-rs inbox must spawn");
+        .expect("airc-core inbox must spawn");
     assert!(
         output.status.success(),
         "inbox failed: stdout={} stderr={}",
@@ -262,7 +262,7 @@ fn installed_inbox(user_home: &Path) -> String {
 }
 
 fn installed_command(user_home: &Path) -> Command {
-    let mut command = Command::new(airc_rs());
+    let mut command = Command::new(airc_core());
     command.env("HOME", user_home);
     command.env("USERPROFILE", user_home);
     command

--- a/crates/airc-cli/tests/route_commands.rs
+++ b/crates/airc-cli/tests/route_commands.rs
@@ -1,9 +1,9 @@
-//! End-to-end coverage for `airc-rs route ...`.
+//! End-to-end coverage for `airc-core route ...`.
 
 use std::process::Command;
 
-fn airc_rs() -> &'static str {
-    env!("CARGO_BIN_EXE_airc-rs")
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-core")
 }
 
 #[test]
@@ -51,13 +51,13 @@ fn route_status_down_override_removes_candidate() {
 }
 
 fn run_ok(args: &[&str]) -> String {
-    let output = Command::new(airc_rs())
+    let output = Command::new(airc_core())
         .args(args)
         .output()
-        .expect("airc-rs command must spawn");
+        .expect("airc-core command must spawn");
     assert!(
         output.status.success(),
-        "airc-rs {:?} failed: stdout={} stderr={}",
+        "airc-core {:?} failed: stdout={} stderr={}",
         args,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),

--- a/crates/airc-cli/tests/transport_commands.rs
+++ b/crates/airc-cli/tests/transport_commands.rs
@@ -1,4 +1,4 @@
-//! End-to-end coverage for `airc-rs transport ...`.
+//! End-to-end coverage for `airc-core transport ...`.
 
 use std::fs;
 use std::path::Path;
@@ -6,8 +6,8 @@ use std::process::Command;
 
 use tempfile::TempDir;
 
-fn airc_rs() -> &'static str {
-    env!("CARGO_BIN_EXE_airc-rs")
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-core")
 }
 
 #[test]
@@ -104,7 +104,7 @@ fn run_ok(home: &Path, args: &[&str]) -> String {
     let output = run_raw(home, args);
     assert!(
         output.status.success(),
-        "airc-rs {:?} failed: stdout={} stderr={}",
+        "airc-core {:?} failed: stdout={} stderr={}",
         args,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
@@ -113,12 +113,12 @@ fn run_ok(home: &Path, args: &[&str]) -> String {
 }
 
 fn run_raw(home: &Path, args: &[&str]) -> std::process::Output {
-    Command::new(airc_rs())
+    Command::new(airc_core())
         .arg("--home")
         .arg(home)
         .args(args)
         .output()
-        .expect("airc-rs command must spawn")
+        .expect("airc-core command must spawn")
 }
 
 fn now_seconds() -> u64 {

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -1,4 +1,4 @@
-//! End-to-end coverage for `airc-rs work ...`.
+//! End-to-end coverage for `airc-core work ...`.
 //!
 //! These tests execute the binary as a consumer would. The command
 //! path must stay a thin wrapper over `airc-lib`, but the proof needs
@@ -10,8 +10,8 @@ use std::process::Command;
 
 use tempfile::TempDir;
 
-fn airc_rs() -> &'static str {
-    env!("CARGO_BIN_EXE_airc-rs")
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-core")
 }
 
 #[test]
@@ -171,15 +171,15 @@ fn work_board_empty_state_is_explicit() {
 }
 
 fn run_ok(home: &Path, args: &[&str]) -> String {
-    let output = Command::new(airc_rs())
+    let output = Command::new(airc_core())
         .arg("--home")
         .arg(home)
         .args(args)
         .output()
-        .expect("airc-rs command must spawn");
+        .expect("airc-core command must spawn");
     assert!(
         output.status.success(),
-        "airc-rs {:?} failed: stdout={} stderr={}",
+        "airc-core {:?} failed: stdout={} stderr={}",
         args,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),

--- a/crates/airc-cli/tests/workspace_commands.rs
+++ b/crates/airc-cli/tests/workspace_commands.rs
@@ -1,12 +1,12 @@
-//! End-to-end coverage for `airc-rs workspace ...`.
+//! End-to-end coverage for `airc-core workspace ...`.
 
 use std::path::Path;
 use std::process::Command;
 
 use tempfile::TempDir;
 
-fn airc_rs() -> &'static str {
-    env!("CARGO_BIN_EXE_airc-rs")
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-core")
 }
 
 #[test]
@@ -80,15 +80,15 @@ fn workspace_request_allocate_heartbeat_release_projects_on_list() {
 }
 
 fn run_ok(home: &Path, args: &[&str]) -> String {
-    let output = Command::new(airc_rs())
+    let output = Command::new(airc_core())
         .arg("--home")
         .arg(home)
         .args(args)
         .output()
-        .expect("airc-rs command must spawn");
+        .expect("airc-core command must spawn");
     assert!(
         output.status.success(),
-        "airc-rs {:?} failed: stdout={} stderr={}",
+        "airc-core {:?} failed: stdout={} stderr={}",
         args,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),

--- a/crates/airc-cli/tests/worktree_lane_commands.rs
+++ b/crates/airc-cli/tests/worktree_lane_commands.rs
@@ -1,4 +1,4 @@
-//! End-to-end coverage for `airc-rs worktree-lane ...`.
+//! End-to-end coverage for `airc-core worktree-lane ...`.
 
 use std::path::Path;
 use std::process::Command;
@@ -6,8 +6,8 @@ use std::process::Command;
 use serde_json::Value;
 use tempfile::TempDir;
 
-fn airc_rs() -> &'static str {
-    env!("CARGO_BIN_EXE_airc-rs")
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc-core")
 }
 
 #[test]
@@ -84,15 +84,15 @@ fn worktree_lane_slug_and_abs_path_match_shell_contract() {
 }
 
 fn run_ok(args: &[&str], cwd: Option<&Path>) -> String {
-    let mut command = Command::new(airc_rs());
+    let mut command = Command::new(airc_core());
     command.args(args);
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }
-    let output = command.output().expect("airc-rs command must spawn");
+    let output = command.output().expect("airc-core command must spawn");
     assert!(
         output.status.success(),
-        "airc-rs {:?} failed: stdout={} stderr={}",
+        "airc-core {:?} failed: stdout={} stderr={}",
         args,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),

--- a/crates/airc-daemon/src/identity.rs
+++ b/crates/airc-daemon/src/identity.rs
@@ -33,7 +33,7 @@ const IDENTITY_STATE_VERSION: u32 = 1;
 const IDENTITY_KEY_FILENAME: &str = "identity.key";
 const IDENTITY_STATE_FILENAME: &str = "identity.json";
 
-/// Persisted-state bundle: stable identity for this airc-rs install.
+/// Persisted-state bundle: stable identity for this airc-core install.
 #[derive(Debug, Clone)]
 pub struct LocalIdentity {
     pub keypair: PeerKeypair,

--- a/crates/airc-daemon/src/ipc/client.rs
+++ b/crates/airc-daemon/src/ipc/client.rs
@@ -190,7 +190,7 @@ impl DaemonClient {
 
     // Reserved for future CLI surfaces that want the daemon's
     // authoritative in-memory view (rather than reading peers.json
-    // directly). The current `airc-rs peer list` reads the file.
+    // directly). The current `airc peer list` reads the file.
     #[allow(dead_code)]
     pub async fn list_peers(&self) -> Result<PeersResponse, ClientError> {
         match self.call(Request::ListPeers).await? {

--- a/crates/airc-daemon/src/ipc/mod.rs
+++ b/crates/airc-daemon/src/ipc/mod.rs
@@ -1,8 +1,8 @@
-//! IPC between the `airc-rs` CLI and the running daemon.
+//! IPC between the `airc-core` CLI and the running daemon.
 //!
 //! Wire protocol = newline-delimited JSON over a local IPC primitive.
 //! On Unix that's a Unix-domain socket at `<home>/daemon.sock`. On
-//! Windows it's a named pipe (`\\.\pipe\airc-rs-<home>`). The
+//! Windows it's a named pipe (`\\.\pipe\airc-core-<home>`). The
 //! `transport` module abstracts both behind one `IpcListener` /
 //! `IpcStream` API; everything above (request/response types,
 //! dispatch, handlers) stays platform-agnostic.

--- a/crates/airc-daemon/src/ipc/transport.rs
+++ b/crates/airc-daemon/src/ipc/transport.rs
@@ -259,7 +259,7 @@ fn resolve_pipe_name(path: &Path) -> String {
 ///      socket file already exists (the common steady-state case for
 ///      a client connecting to a running daemon).
 ///   2. If that fails, canonicalise just the parent dir (which exists
-///      after `airc-rs init`) and re-join the file basename.
+///      after `airc init`) and re-join the file basename.
 ///   3. If that also fails, fall back to a string-level normalisation:
 ///      backslashes → forward slashes, lowercase. On Windows this
 ///      handles separator + case equivalence; on Unix the function

--- a/crates/airc-daemon/src/lib.rs
+++ b/crates/airc-daemon/src/lib.rs
@@ -5,7 +5,7 @@
 //! CLI invocations; each connection is one request/response round-
 //! trip dispatched against the typed [`Request`] enum. The daemon
 //! owns the peer keypair, registry, and any open transports;
-//! subsequent CLI commands (`airc-rs msg`, `airc-rs status`) become
+//! subsequent CLI commands (`airc msg`, `airc status`) become
 //! cheap RPCs that don't re-load identity or re-handshake transports.
 //!
 //! Module layout (one concern per file):

--- a/crates/airc-daemon/src/peers_store.rs
+++ b/crates/airc-daemon/src/peers_store.rs
@@ -2,7 +2,7 @@
 //!
 //! Saves enrolled peers across CLI / daemon restarts so `--peer
 //! <spec>` flags disappear from daily use. Two writers:
-//!   - `airc-rs peer add <spec>` — appends to the file
+//!   - `airc peer add <spec>` — appends to the file
 //!   - The daemon's `AddPeer` handler — appends + reloads its
 //!     in-memory `PeerKeyRegistry`
 //!

--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -6,7 +6,7 @@
 //!
 //! Transport varies by platform via `IpcListener`:
 //!   - Unix: Unix-domain socket at `<home>/daemon.sock`
-//!   - Windows: named pipe at `\\.\pipe\airc-rs-<home>`
+//!   - Windows: named pipe at `\\.\pipe\airc-core-<home>`
 //!
 //! Shutdown: the state's `shutdown` notifier wakes the accept loop;
 //! the loop runs the transport's `cleanup` (unlinks the socket file

--- a/crates/airc-lib/src/room.rs
+++ b/crates/airc-lib/src/room.rs
@@ -1,10 +1,10 @@
 //! Current-room persistence — the default `(wire, channel)` for
-//! short-shape commands like `airc-rs msg "hi"` and `airc-rs inbox`.
+//! short-shape commands like `airc msg "hi"` and `airc inbox`.
 //!
 //! AI peers (and humans) shouldn't have to type `--wire <path>
 //! --channel <uuid>` on every call. Joining a room writes
 //! `<home>/room.json` once; every subsequent command reads it.
-//! `airc-rs join <name>` switches.
+//! `airc join <name>` switches.
 //!
 //! A "room" is a name. The substrate primitives it expands to are
 //! deterministic:
@@ -12,7 +12,7 @@
 //!   - channel = UUIDv5(namespace=oid, name)
 //!
 //! Same name → same channel UUID across machines, so two peers who
-//! both `airc-rs join project-x` land in the same room without
+//! both `airc join project-x` land in the same room without
 //! exchanging the channel UUID.
 
 use std::path::{Path, PathBuf};
@@ -27,7 +27,7 @@ const ROOM_VERSION: u32 = 1;
 const DEFAULT_ROOM_NAME: &str = "default";
 
 /// Namespace UUID for deriving channel UUIDs from room names.
-/// Stable across all airc-rs installs so `airc-rs join project-x`
+/// Stable across all airc installs so `airc join project-x`
 /// on different machines produces the same channel.
 const ROOM_NAMESPACE: Uuid = Uuid::from_bytes([
     0xa1, 0xc2, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
@@ -89,7 +89,7 @@ impl From<std::time::SystemTimeError> for RoomError {
     }
 }
 
-/// The current room — what `airc-rs msg` / `inbox` / `send` /
+/// The current room — what `airc msg` / `inbox` / `send` /
 /// `listen` default to.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Room {
@@ -121,7 +121,7 @@ impl Room {
         })
     }
 
-    /// Default room — auto-created on `airc-rs init`. Name "default",
+    /// Default room — auto-created on `airc init`. Name "default",
     /// derived per `from_name`.
     pub fn default_for(home: &Path) -> Result<Self, RoomError> {
         Self::from_name(home, DEFAULT_ROOM_NAME)

--- a/crates/airc-transport/src/lan_tcp/adapter/mod.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/mod.rs
@@ -89,7 +89,7 @@ impl LanTcpAdapter {
     }
 
     /// Snapshot of currently-connected peers. Useful for diagnostics
-    /// (`airc-rs peers`) + tests.
+    /// (`airc-core peers`) + tests.
     pub async fn connected_peers(&self) -> Vec<PeerId> {
         self.inner
             .connections

--- a/crates/examples/embedded_consumer_smoke/src/lib.rs
+++ b/crates/examples/embedded_consumer_smoke/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate has no runtime code. Its purpose is to PROVE — by being
 //! a downstream consumer of `airc-lib` — that a small consumer app
 //! can embed AIRC without reaching into substrate internals or
-//! shelling out to the `airc-rs` CLI.
+//! shelling out to the `airc-core` CLI.
 //!
 //! That's the audit's [Gate 4](Consumer Embedding) and grievance §13
 //! ("Consumer Integration Is Not Proven"):

--- a/docs/architecture/ROBUSTNESS-INTEGRATION-PLAN.md
+++ b/docs/architecture/ROBUSTNESS-INTEGRATION-PLAN.md
@@ -401,7 +401,7 @@ failed. No hidden success.
 ### PR 5: Presence Projection
 
 - Add endpoint presence events and a projection API.
-- Add `airc-rs presence list` and `airc-lib` presence calls.
+- Add `airc presence list` and `airc-lib` presence calls.
 - Stop rendering configured peers as "online" unless a fresh endpoint
   says so.
 
@@ -438,7 +438,7 @@ failed. No hidden success.
 ## Stop Doing
 
 - Do not add new runtime behavior to Python or shell.
-- Do not make consumers shell out to `airc-rs` as their integration
+- Do not make consumers shell out to `airc` as their integration
   path.
 - Do not add a consumer-specific field to the AIRC envelope when a
   namespaced header will do.

--- a/docs/rust-substrate-grievances-and-gaps.md
+++ b/docs/rust-substrate-grievances-and-gaps.md
@@ -240,7 +240,7 @@ That is acceptable for a first CLI, but not as the integration surface for Conti
 
 Needed split:
 
-- `airc-core`: IDs, identity, headers, basic types;
+- `airc-core` crate: IDs, identity, headers, basic types;
 - `airc-protocol`: envelopes, frames, signatures, subscriptions;
 - `airc-transport`: adapters and resolver;
 - `airc-store`: durable event/projection store;
@@ -794,11 +794,14 @@ Disk hygiene, stale-branch cleanup, and "who is doing what" all derive from the 
 
 Workspace sanitation is not optional polish. A machine may host 20+ local agents, each with lanes, worktrees, Rust targets, Docker layers, model caches, browser traces, and project sandboxes. AIRC must know what it allocated and provide a drain path for anything rebuildable. The feature shape:
 
+- AIRC-created git worktrees live under the single home root `~/.airc/worktrees/<repo>/<lease-or-branch>` by default. Repo-local `.airc/` remains project scope state; ad hoc sibling roots such as `~/Development/.../airc-worktrees` are not the convention.
+- every workspace allocation records its root path, repo, branch, owner peer, lease id, created timestamp, heartbeat timestamp, and expected PR/issue links;
+- worktree drains are policy-backed: merged/closed PRs, released leases, expired heartbeats, and clean git status may be deleted automatically; dirty or unknown worktrees are report-only until an explicit policy admits them;
 - every workspace lease records disk usage and cache roots it owns;
 - every drain candidate is typed as `RebuildableCache`, `GeneratedArtifact`, `DownloadedDependency`, `DockerLayer`, `ModelCache`, `TraceArtifact`, or `Unknown`;
 - default policy may drain only safe rebuildable caches;
 - destructive or ambiguous drains require explicit policy opt-in;
-- `airc-rs workspace report` and `airc-rs hygiene report` expose the same projection;
+- `airc workspace report` and `airc hygiene report` expose the same projection;
 - low-space pressure emits `WorkspacePressureReported`, then policy may emit `WorkspaceDrainRequested`;
 - completed cleanup records bytes reclaimed, paths touched, and policy rule id;
 - dry-run and record/replay are required so cleanup decisions can be inspected after the fact.
@@ -839,9 +842,9 @@ Replaces the single-slice "Queue/lane Rust model" line in the First Remediation 
    - **Sub-PR 3a — drain typing (this PR).** Typed events: `WorkspacePressureReported`, `WorkspaceDrainRequested`, `WorkspaceDrainCompleted`. Typed model: `DrainCandidateCategory` (closed enum incl. `Unknown`), `DrainCandidate`, `PressureLevel`, `DrainOutcome`. Projection extends `WorkBoardProjection` with `workspace_pressure`, `pending_drains`, `drain_history` — all keyed by `WorkspaceId` independent of the card+claim lease flow so peers without leases can participate in hygiene. Codec roundtrip + projection sequence tests. No runtime detector or executor; that's the next sub-PR.
    - **Sub-PR 3b — workspace lease decoupling (follow-up).** Today's `WorkspaceLease` requires `card_id` + `claim_id`. Peers that allocate workspaces outside the card flow can emit pressure/drain events but cannot register the workspace itself. Needed: a lightweight workspace registration event without card/claim, plus a `WorkspaceStatus::External` (or equivalent) variant. Out of scope for 3a — it's a wider model change with downstream impact on `WorkspaceRequested`.
    - **Sub-PR 3c — pressure detector + drain executor.** Runtime that probes disk, emits `WorkspacePressureReported`, evaluates policy (default = `RebuildableCache` + `DownloadedDependency`), and executes `WorkspaceDrainRequested` → `WorkspaceDrainCompleted`. Dry-run path lands first.
-4. **PR 4 — CLI thin wrapper.** `airc-rs work list`, `airc-rs work claim`, `airc-rs lane status`, `airc-rs workspace list`, `airc-rs workspace report`, `airc-rs hygiene report`, `airc-rs hygiene clean --dry-run` — all backed by `airc-work`, no Python touched.
+4. **PR 4 — CLI thin wrapper.** `airc work list`, `airc work claim`, `airc lane status`, `airc workspace list`, `airc workspace report`, `airc hygiene report`, `airc hygiene clean --dry-run` — all backed by `airc-work`, no Python touched.
 5. **PR 5 — GitHub adapter.** Mirror card state to issues/PRs; reconcile PR status into events; GitHub is adapter-only.
-6. **PR 6 — monitor/hook subscriptions.** Codex hook becomes `airc-rs codex-hook` consuming an `airc-work`-aware subscription; monitor reads typed subscriptions; no Python hook path remains.
+6. **PR 6 — monitor/hook subscriptions.** Codex hook becomes `airc codex-hook` consuming an `airc-work`-aware subscription; monitor reads typed subscriptions; no Python hook path remains.
 7. **PR 7 — Continuum bridge.** Continuum event subsystem consumes AIRC subscriptions directly. Persona inboxes are AIRC channel/header subscriptions plus Continuum-specific projection/RAG assembly.
 
 ### What this replaces in the previous plan

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #
 # curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 #
-# Clones the repo, puts `airc` on PATH, symlinks skills into ~/.claude/skills/
+# Clones the repo, puts `airc` on PATH, and installs AIRC skills.
 
 set -euo pipefail
 
@@ -12,10 +12,7 @@ REPO_URL="https://github.com/CambrianTech/airc.git"
 CLONE_DIR="${AIRC_DIR:-$HOME/.airc-src}"
 # BIN_DIR + SKILLS_TARGET respect env-var overrides so test harnesses
 # (and packagers, distros, etc.) can point install.sh at a sandbox
-# instead of stomping ~/.local/bin and ~/.claude/skills. Pre-fix, a
-# test passing BIN_DIR=/tmp/foo would be silently ignored and the
-# real ~/.local/bin/airc symlink would get rewritten to point at the
-# test dir — caught when our own canary test corrupted the real install.
+# instead of stomping ~/.local/bin and ~/.claude/skills.
 BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
 SKILLS_TARGET="${SKILLS_TARGET:-$HOME/.claude/skills}"
 
@@ -342,7 +339,7 @@ ensure_prereqs
 
 # ── Clone or update ─────────────────────────────────────────────────────
 
-if [ -d "$CLONE_DIR/.git" ]; then
+if [ -d "$CLONE_DIR/.git" ] || [ -f "$CLONE_DIR/.git" ]; then
   # AIRC_INSTALL_NO_PULL=1: trust CLONE_DIR's checked-out tree exactly
   # as-is — no branch switch, no pull. CI uses this when it has already
   # staged the PR's tree at $CLONE_DIR via `cp -r .` and wants the
@@ -440,68 +437,63 @@ fi
 
 # ── airc on PATH ───────────────────────────────────────────────────────
 
+_write_airc_forwarder() {
+  local target="$1"
+  mkdir -p "$(dirname "$target")"
+  cat > "$target" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+export AIRC_DIR="$CLONE_DIR"
+exec "$CLONE_DIR/airc" "\$@"
+SH
+  chmod +x "$target"
+  ok "Installed command: $target"
+}
+
 mkdir -p "$BIN_DIR"
-# Single-source rule (#543/#544 follow-up): on real Linux/macOS the
-# symlink is fine — the kernel resolves it to $CLONE_DIR/airc each
-# invocation, so `airc update` propagates instantly. On Git Bash for
-# Windows (MINGW), `ln -sf` falls back to a literal COPY because
-# Developer Mode is off by default; that copy goes stale the moment
-# `airc update` (run from WSL) refreshes the canonical clone, and
-# Claude Code's Monitor running this stale copy was the root cause
-# of months of "Windows runs old code while airc version reports new
-# SHA" diagnoses. Use the polyglot shim on Windows instead — it
-# delegates to whichever live install (WSL canonical, then native)
-# is present at runtime. No copies, no drift.
+# Install exactly one public Unix command: `airc`. It is a stable
+# forwarder into the clone, not a symlink and not a copied implementation
+# script. That keeps `airc update` and clean-room reinstalls honest.
 case "$(uname -s 2>/dev/null)" in
   MINGW*|MSYS*|CYGWIN*)
     if [ -f "$CLONE_DIR/airc.shim" ]; then
-      # Replace any pre-existing full-script copy that earlier installs
-      # might have left in PATH. Failing soft is fine — best-effort
-      # cleanup is enough to fix dual-install drift.
       [ -f "$BIN_DIR/airc" ] && rm -f "$BIN_DIR/airc" 2>/dev/null || true
-      [ -f "$BIN_DIR/relay" ] && rm -f "$BIN_DIR/relay" 2>/dev/null || true
       cp -f "$CLONE_DIR/airc.shim" "$BIN_DIR/airc"
-      cp -f "$CLONE_DIR/airc.shim" "$BIN_DIR/relay"
-      chmod +x "$BIN_DIR/airc" "$BIN_DIR/relay" 2>/dev/null || true
+      chmod +x "$BIN_DIR/airc" 2>/dev/null || true
     else
-      # Repo predates the shim (transitional). Symlink-or-copy the full
-      # script as before; clean the duplicate next install.
-      ln -sf "$CLONE_DIR/airc" "$BIN_DIR/airc"
-      ln -sf "$CLONE_DIR/airc" "$BIN_DIR/relay"
+      _write_airc_forwarder "$BIN_DIR/airc"
     fi
     [ -f "$CLONE_DIR/airc.cmd" ] && cp -f "$CLONE_DIR/airc.cmd" "$BIN_DIR/airc.cmd"
     [ -f "$CLONE_DIR/airc.ps1" ] && cp -f "$CLONE_DIR/airc.ps1" "$BIN_DIR/airc.ps1"
     ;;
   *)
-    # Real Linux/macOS: symlink is right.
-    ln -sf "$CLONE_DIR/airc" "$BIN_DIR/airc"
-    # Back-compat: `relay` still works for muscle-memory and stale docs.
-    ln -sf "$CLONE_DIR/airc" "$BIN_DIR/relay"
+    _write_airc_forwarder "$BIN_DIR/airc"
     ;;
 esac
 
-_install_airc_rs_binary() {
-  [ "${AIRC_SKIP_RUST_BUILD:-0}" = "1" ] && { info "AIRC_SKIP_RUST_BUILD=1 -- skipping airc-rs build"; return 0; }
+_install_airc_core_binary() {
+  [ "${AIRC_SKIP_RUST_BUILD:-0}" = "1" ] && { info "AIRC_SKIP_RUST_BUILD=1 -- skipping airc-core build"; return 0; }
   if ! command -v cargo >/dev/null 2>&1; then
-    fail "cargo is required to build airc-rs. Install Rust, then re-run install.sh."
+    fail "cargo is required to build airc-core. Install Rust, then re-run install.sh."
   fi
-  info "Building Rust CLI: airc-rs"
+  info "Building Rust CLI: airc-core"
   (cd "$CLONE_DIR" && cargo build --release -p airc-cli)
-  local built="$CLONE_DIR/target/release/airc-rs"
-  [ -x "$built" ] || fail "airc-rs build completed but binary is missing: $built"
+  local built="$CLONE_DIR/target/release/airc-core"
+  [ -x "$built" ] || fail "airc-core build completed but binary is missing: $built"
   case "$(uname -s 2>/dev/null)" in
     MINGW*|MSYS*|CYGWIN*)
-      cp -f "$built" "$BIN_DIR/airc-rs.exe"
-      ok "Installed airc-rs: $BIN_DIR/airc-rs.exe"
+      cp -f "$built" "$BIN_DIR/airc-core.exe"
+      ok "Installed airc-core: $BIN_DIR/airc-core.exe"
       ;;
     *)
-      ln -sf "$built" "$BIN_DIR/airc-rs"
-      ok "Installed airc-rs: $BIN_DIR/airc-rs"
+      cp -f "$built" "$BIN_DIR/airc-core"
+      chmod +x "$BIN_DIR/airc-core"
+      ok "Installed airc-core: $BIN_DIR/airc-core"
       ;;
   esac
 }
 
-_install_airc_rs_binary
+_install_airc_core_binary
 
 if ! echo "$PATH" | tr ':' '\n' | grep -qx "$BIN_DIR"; then
   for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
@@ -534,28 +526,14 @@ _install_airc_skills_into() {
   [ -d "$CLONE_DIR/skills" ] || return 0
   mkdir -p "$skills_target"
 
-  # Clean up old symlinks from previous installs.
-  # Includes the airc-classic skill names (connect/send/rename/disconnect) that
-  # were renamed to IRC-canonical (join/msg/nick/quit) — leaving the old symlinks
-  # in place would shadow the new skills with stale content. (`uninstall` was
-  # previously listed here when the skill didn't exist; now that we ship a real
-  # /uninstall skill, the per-skill symlink loop below recreates it cleanly and
-  # this list omits it.)
-  local old
-  for old in "$skills_target"/relay-* "$skills_target"/monitor "$skills_target"/setup \
-             "$skills_target"/connect "$skills_target"/send "$skills_target"/rename "$skills_target"/disconnect \
-             "$skills_target"/inbox "$skills_target"/tests; do
-    [ -L "$old" ] && rm "$old" 2>/dev/null
-  done
-
   local skill_dir skill_name target
   for skill_dir in "$CLONE_DIR"/skills/*/; do
     [ -d "$skill_dir" ] || continue
     [ -f "$skill_dir/SKILL.md" ] || continue
     skill_name="$(basename "$skill_dir")"
     target="$skills_target/$skill_name"
-    # If the target is a real directory (from a pre-rename hand-install
-    # or an old copy-based installer), it shadows the new symlink. Nuke it.
+    # If the target is a real directory, it shadows the current skill
+    # link. Remove it and install the current skill.
     if [ -d "$target" ] && [ ! -L "$target" ]; then
       rm -rf "$target"
     elif [ -L "$target" ]; then
@@ -641,7 +619,7 @@ TOML
   # When Codex's runtime supports outside-workspace filesystem profiles,
   # restore the block (history at git log -- install.sh).
 
-  # Cleanup for stale [permissions.airc.filesystem] blocks lives in the
+  # Cleanup for managed [permissions.airc.filesystem] blocks lives in the
   # Rust Codex hook installer below. Keep this profile function focused
   # on the network profile it owns.
 
@@ -696,14 +674,13 @@ _install_airc_codex_developer_instructions() {
 
   if grep -qE '^[[:space:]]*(hooks|codex_hooks)[[:space:]]*=[[:space:]]*true' "$config" 2>/dev/null \
      && [ -f "$hooks_json" ] \
-     && { grep -qF 'airc-rs codex-hook user-prompt-submit' "$hooks_json" 2>/dev/null \
-          || grep -qF 'airc codex-hook user-prompt-submit' "$hooks_json" 2>/dev/null; }; then
+     && grep -qF 'airc codex-hook user-prompt-submit' "$hooks_json" 2>/dev/null; then
     if grep -qF 'AIRC-CODEX-INSTRUCTIONS-START' "$config" 2>/dev/null; then
       local _tmp; _tmp=$(mktemp)
       sed '/^# AIRC-CODEX-INSTRUCTIONS-START/,/^# AIRC-CODEX-INSTRUCTIONS-END/d' "$config" > "$_tmp"
       mv "$_tmp" "$config"
     fi
-    info "  Codex AIRC hook already installed; skipping legacy developer_instructions polling contract"
+    info "  Codex AIRC hook already installed; skipping developer_instructions polling contract"
     return 0
   fi
 
@@ -754,20 +731,20 @@ _install_airc_codex_hooks() {
   [ "${AIRC_SKIP_CODEX_HOOKS:-0}" = "1" ] && return 0
   [ -f "$HOME/.codex/config.toml" ] || return 0
 
-  local _airc_rs=""
-  if command -v airc-rs >/dev/null 2>&1; then
-    _airc_rs=$(command -v airc-rs)
-  elif [ -x "$CLONE_DIR/target/release/airc-rs" ]; then
-    _airc_rs="$CLONE_DIR/target/release/airc-rs"
-  elif [ -x "$CLONE_DIR/target/debug/airc-rs" ]; then
-    _airc_rs="$CLONE_DIR/target/debug/airc-rs"
+  local _airc_core=""
+  if [ -x "$CLONE_DIR/target/release/airc-core" ]; then
+    _airc_core="$CLONE_DIR/target/release/airc-core"
+  elif [ -x "$CLONE_DIR/target/debug/airc-core" ]; then
+    _airc_core="$CLONE_DIR/target/debug/airc-core"
+  elif command -v airc-core >/dev/null 2>&1; then
+    _airc_core=$(command -v airc-core)
   else
-    warn "Could not install Codex AIRC hook: airc-rs not found"
+    warn "Could not install Codex AIRC hook: airc-core not found"
     return 0
   fi
 
   local out
-  if out=$("$_airc_rs" codex-hook install-hooks --codex-home "$HOME/.codex" 2>&1); then
+  if out=$("$_airc_core" codex-hook install-hooks --codex-home "$HOME/.codex" 2>&1); then
     if [ -n "$out" ]; then
       printf '%s\n' "$out" | while IFS= read -r line; do
         ok "Codex AIRC hook: $line"

--- a/lib/airc_bash/cmd_approve.sh
+++ b/lib/airc_bash/cmd_approve.sh
@@ -11,7 +11,7 @@
 #                            print the join string. Manual handoff for
 #                            now; PR-2c automates this via state.
 #
-# External cross-references (resolved at call time): die, airc_rs_bin,
+# External cross-references (resolved at call time): die, airc_core_bin,
 # `gh` CLI.
 #
 # Crypto contract: per-knock + per-approval X25519 ephemerals → ECDH +
@@ -114,7 +114,7 @@ cmd_approve() {
   # The helper generates a per-approval ephemeral keypair internally,
   # runs ECDH, and emits {ver, approver_pub, nonce, ciphertext} JSON.
   local approval_json
-  if ! approval_json=$("$(airc_rs_bin)" knock encrypt-for-knocker \
+  if ! approval_json=$("$(airc_core_bin)" knock encrypt-for-knocker \
         --knocker-pub "$knocker_pub" \
         --plaintext "$invite_string" 2>&1); then
     die "approve: encryption failed: $approval_json"
@@ -234,15 +234,15 @@ cmd_decrypt_approval() {
   fi
 
   local approver_pub nonce ciphertext
-  approver_pub=$("$(airc_rs_bin)" knock approval-field --field approver_pub <<< "$approval_json")
-  nonce=$("$(airc_rs_bin)" knock approval-field --field nonce <<< "$approval_json")
-  ciphertext=$("$(airc_rs_bin)" knock approval-field --field ciphertext <<< "$approval_json")
+  approver_pub=$("$(airc_core_bin)" knock approval-field --field approver_pub <<< "$approval_json")
+  nonce=$("$(airc_core_bin)" knock approval-field --field nonce <<< "$approval_json")
+  ciphertext=$("$(airc_core_bin)" knock approval-field --field ciphertext <<< "$approval_json")
 
   if [ -z "$approver_pub" ] || [ -z "$nonce" ] || [ -z "$ciphertext" ]; then
     die "decrypt-approval: malformed approval envelope (missing approver_pub/nonce/ciphertext)"
   fi
 
-  if ! "$(airc_rs_bin)" knock decrypt-from-approver \
+  if ! "$(airc_core_bin)" knock decrypt-from-approver \
         --knocker-priv "$knocker_priv" \
         --approver-pub "$approver_pub" \
         --nonce "$nonce" \
@@ -313,7 +313,7 @@ _airc_approve_extract_knocker_pub() {
   # Body comes in via $1 as raw markdown; we look for the first JSON
   # block with a "knocker_pub" field.
   local body="$1"
-  "$(airc_rs_bin)" knock extract-knocker-pub <<< "$body" 2>/dev/null || true
+  "$(airc_core_bin)" knock extract-knocker-pub <<< "$body" 2>/dev/null || true
 }
 
 _airc_decrypt_extract_approval() {
@@ -321,7 +321,7 @@ _airc_decrypt_extract_approval() {
   # Returns the most recent envelope (last comment with one), so a
   # repost or correction wins over the original.
   local comments_json="$1"
-  "$(airc_rs_bin)" knock extract-approval <<< "$comments_json" 2>/dev/null || true
+  "$(airc_core_bin)" knock extract-approval <<< "$comments_json" 2>/dev/null || true
 }
 
 _airc_approve_default_invite() {

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -86,7 +86,7 @@ _join_phase_done() {
 #      --first: prepend (sets the scope's default channel).
 #      default: append.
 #   2. Resolve-or-create the canonical gist for the channel on the
-#      user's gh account (airc-rs channel-gist resolve
+#      user's gh account (airc-core channel-gist resolve
 #      --create-if-missing). Idempotent across runs.
 #   3. Persist the channel→gist mapping in channel_gists{} so cmd_send's
 #      route-by-channel and the multi-channel monitor's per-channel
@@ -150,7 +150,7 @@ ensure_channel_subscribed_with_gist() {
     _gid=""
   fi
   if [ -z "$_gid" ]; then
-    _gid=$("$(airc_rs_bin)" channel-gist resolve \
+    _gid=$("$(airc_core_bin)" channel-gist resolve \
            --channel "$channel" --create-if-missing 2>"$_err")
   fi
   if [ -z "$_gid" ]; then
@@ -184,12 +184,12 @@ _join_show_status_and_inbox() {
 _join_transport_health_ok() {
   [ -f "$CONFIG" ] || return 1
   local _channels
-  _channels=$("$(airc_rs_bin)" config read-channels --home "$AIRC_WRITE_DIR" --config "$CONFIG" 2>/dev/null || true)
+  _channels=$("$(airc_core_bin)" config read-channels --home "$AIRC_WRITE_DIR" --config "$CONFIG" 2>/dev/null || true)
   # Legacy/no-room mode has no gist bearer to heartbeat. If the caller
   # already proved the scope owner is alive, transport_health has no
   # channel rows to evaluate and must not force a duplicate restart.
   [ -n "$_channels" ] || return 0
-  "$(airc_rs_bin)" transport health \
+  "$(airc_core_bin)" transport health \
     --home "$AIRC_WRITE_DIR" \
     --config "$CONFIG" \
     --quiet \
@@ -256,7 +256,7 @@ _join_restart_scope_processes() {
   # Filter rules:
   #   - drop non-numeric / empty entries (already a no-op)
   #   - drop $$ and $PPID (case 1)
-  #   - drop any PID whose cmdline doesn't look like airc/airc-rs
+  #   - drop any PID whose cmdline doesn't look like airc/airc-core
   #     (case 2). Same regex shape as the stale-pidfile check at
   #     ~line 971 and cmd_teardown's parent-chain reaper.
   local _self_filtered_pids="" _candidate _candidate_cmd
@@ -271,7 +271,7 @@ _join_restart_scope_processes() {
     kill -0 "$_candidate" 2>/dev/null || continue
     _candidate_cmd=$(proc_cmdline "$_candidate" 2>/dev/null || true)
     case "$_candidate_cmd" in
-      *airc-rs*monitor*format*|*airc-rs*monitor*attach*|*airc-rs*handshake*|*airc-rs*bearer*recv*) ;;
+      *airc-core*monitor*format*|*airc-core*monitor*attach*|*airc-core*handshake*|*airc-core*bearer*recv*) ;;
       *airc[[:space:]]connect*|*airc[[:space:]]join*|*/airc[[:space:]]*) ;;
       *) continue ;;
     esac
@@ -314,8 +314,8 @@ _join_scope_transport_pids() {
       [ "$_pid" = "$PPID" ] && continue
       _cmd=$(proc_cmdline "$_pid" || true)
       case "$_cmd" in
-        *airc-rs*monitor*attach*) continue ;;
-        *airc-rs*monitor*format*|*airc-rs*handshake*accept-one*|*airc-rs*bearer*recv*)
+        *airc-core*monitor*attach*) continue ;;
+        *airc-core*monitor*format*|*airc-core*handshake*accept-one*|*airc-core*bearer*recv*)
           _pids="$_pids $_pid"
           ;;
         *) continue ;;
@@ -366,7 +366,7 @@ _join_scope_has_duplicate_transport() {
   fi
 
   local _seen_gists="" _pid _cmd _gid
-  for _pid in $(proc_airc_pids_matching 'airc-rs.*bearer[[:space:]]+recv' 2>/dev/null | sort -un || true); do
+  for _pid in $(proc_airc_pids_matching 'airc-core.*bearer[[:space:]]+recv' 2>/dev/null | sort -un || true); do
     _cmd=$(proc_cmdline "$_pid" || true)
     _airc_cmdline_mentions_scope "$_cmd" "$AIRC_WRITE_DIR" || continue
     _gid=$(printf '%s\n' "$_cmd" | awk '{
@@ -392,15 +392,15 @@ _join_attach_local_stream() {
   echo "  Background AIRC owns transport; this process only displays new peer messages."
   local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
   local _tail_name; _tail_name=$(get_name 2>/dev/null || echo "airc")
-  local _airc_rs; _airc_rs=$(airc_rs_bin 2>/dev/null || true)
-  if [ -z "$_airc_rs" ]; then
-    echo "airc: airc-rs is required for monitor attach" >&2
+  local _airc_core; _airc_core=$(airc_core_bin 2>/dev/null || true)
+  if [ -z "$_airc_core" ]; then
+    echo "airc: airc-core is required for monitor attach" >&2
     return 127
   fi
   if [ -n "$_client_id" ]; then
-    AIRC_CLIENT_ID="$_client_id" exec "$_airc_rs" --home "$AIRC_WRITE_DIR" monitor attach --my-name "$_tail_name"
+    AIRC_CLIENT_ID="$_client_id" exec "$_airc_core" --home "$AIRC_WRITE_DIR" monitor attach --my-name "$_tail_name"
   else
-    exec "$_airc_rs" --home "$AIRC_WRITE_DIR" monitor attach --my-name "$_tail_name"
+    exec "$_airc_core" --home "$AIRC_WRITE_DIR" monitor attach --my-name "$_tail_name"
   fi
 }
 
@@ -781,7 +781,7 @@ cmd_connect() {
       airc_config_subscribe "$room_name" "$CONFIG" 0 2>/dev/null || true
       # Resolve --create-if-missing: returns the gist id (find existing
       # or create new gist named "airc room: #<channel>").
-      local _new_gist; _new_gist=$("$(airc_rs_bin)" channel-gist resolve \
+      local _new_gist; _new_gist=$("$(airc_core_bin)" channel-gist resolve \
           --channel "$room_name" --create-if-missing 2>&1)
       if [ -n "$_new_gist" ] && printf '%s' "$_new_gist" | grep -qE '^[0-9a-f]{32}$'; then
         # Save the channel→gist mapping in config so cmd_send can route to it.
@@ -831,7 +831,7 @@ cmd_connect() {
       sleep 1
     else
       local _health_out _health_rc=0
-      _health_out=$("$(airc_rs_bin)" transport health \
+      _health_out=$("$(airc_core_bin)" transport health \
         --home "$AIRC_WRITE_DIR" \
         --config "$CONFIG" \
         --fail 2>/dev/null) || _health_rc=$?
@@ -1321,13 +1321,13 @@ cmd_connect() {
       # malformed JSON `"invite": "..."` line (quotes and all), pair
       # handshake failed on garbage host info, and self-heal didn't fire
       # because resolved_room_name was never extracted via the jq path.
-      # gh api → airc-rs extracts
+      # gh api → airc-core extracts
       # the first file's content. This is the rest-API path; it's preferred
       # over the gh gist view --raw path because the latter prepends the
       # gist description as a header line that we'd then have to strip.
       if command -v gh >/dev/null 2>&1; then
         raw_content=$( (gh api "gists/$gist_id" 2>/dev/null \
-                        | "$(airc_rs_bin)" gist gist-content --channel "$room_name" 2>/dev/null) || true )
+                        | "$(airc_core_bin)" gist gist-content --channel "$room_name" 2>/dev/null) || true )
       fi
       # Fallback path 1: gh raw view (description leak handled by the
       # awk strip below at "head -c 1 | grep '{'" cleanup).
@@ -1362,7 +1362,7 @@ cmd_connect() {
       # without gh OR git. Last resort. (#188 — was curl + jq.)
       if [ -z "$raw_content" ] && command -v curl >/dev/null 2>&1; then
         raw_content=$( (curl -fsSL "https://api.github.com/gists/$gist_id" 2>/dev/null \
-                        | "$(airc_rs_bin)" gist gist-content --channel "$room_name" 2>/dev/null) || true )
+                        | "$(airc_core_bin)" gist gist-content --channel "$room_name" 2>/dev/null) || true )
       fi
       # Last-resort cleanup: if raw_content still has the description-header
       # leak from a degraded gh-view path, strip lines before the first '{'
@@ -1384,8 +1384,8 @@ cmd_connect() {
       # #188: was `if command -v jq`; now Python is the truth-layer
       # (always available since #152 Phase 0). Drop the jq gate.
       local airc_ver kind
-      airc_ver=$(printf '%s' "$raw_content" | "$(airc_rs_bin)" gist get .airc 2>/dev/null)
-      kind=$(printf '%s' "$raw_content" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
+      airc_ver=$(printf '%s' "$raw_content" | "$(airc_core_bin)" gist get .airc 2>/dev/null)
+      kind=$(printf '%s' "$raw_content" | "$(airc_core_bin)" gist get .kind 2>/dev/null)
       if [ -n "$airc_ver" ]; then
           # Versioned envelope — dispatch on kind.
           case "$kind" in
@@ -1393,7 +1393,7 @@ cmd_connect() {
               # Single-pair invite (legacy + --no-general flow). Gist is
               # ephemeral; host deletes after pair.
               resolved=$(printf '%s' "$raw_content" \
-                         | "$(airc_rs_bin)" gist get .invite 2>/dev/null \
+                         | "$(airc_core_bin)" gist get .invite 2>/dev/null \
                          | head -1 | tr -d '\r\n ')
               ;;
             mesh|room)
@@ -1405,21 +1405,21 @@ cmd_connect() {
               # yet (joiner can read either). The .invite field carries
               # today's name@user@host:port#pubkey string.
               resolved=$(printf '%s' "$raw_content" \
-                         | "$(airc_rs_bin)" gist get .invite 2>/dev/null \
+                         | "$(airc_core_bin)" gist get .invite 2>/dev/null \
                          | head -1 | tr -d '\r\n ')
               # New mesh shape: .channels[]; legacy room shape: .name.
               # Prefer channels[0] if present; fall back to .name.
               resolved_room_name=$(printf '%s' "$raw_content" \
-                         | "$(airc_rs_bin)" gist get-first-of '.channels[0]' '.name' 2>/dev/null)
+                         | "$(airc_core_bin)" gist get-first-of '.channels[0]' '.name' 2>/dev/null)
               # Multi-address: capture host.addresses[] + host.machine_id
               # for the joiner's address-picker (peer_pick_address). Empty
               # if the host published a pre-multi-address envelope; in
               # that case JOIN MODE falls back to the parsed-from-invite
               # host:port (legacy single-address path).
               _resolved_addresses_json=$(printf '%s' "$raw_content" \
-                         | "$(airc_rs_bin)" gist get-json .host.addresses 2>/dev/null)
+                         | "$(airc_core_bin)" gist get-json .host.addresses 2>/dev/null)
               _resolved_host_machine_id=$(printf '%s' "$raw_content" \
-                         | "$(airc_rs_bin)" gist get .host.machine_id 2>/dev/null)
+                         | "$(airc_core_bin)" gist get .host.machine_id 2>/dev/null)
 
               # Heartbeat freshness check — the structural fix for
               # orphan-gist class. Hosts update last_heartbeat every
@@ -1432,7 +1432,7 @@ cmd_connect() {
               # compat; their hosts will get caught by the existing
               # SSH-failure self-heal path at line ~1850.
               local _hb_iso _hb_ts _now_ts _hb_stale_sec
-              _hb_iso=$(printf '%s' "$raw_content" | "$(airc_rs_bin)" gist get .last_heartbeat 2>/dev/null)
+              _hb_iso=$(printf '%s' "$raw_content" | "$(airc_core_bin)" gist get .last_heartbeat 2>/dev/null)
               _hb_stale_sec="${AIRC_HEARTBEAT_STALE:-90}"
               if [ -n "$_hb_iso" ]; then
                 # Cross-platform ISO→epoch via the iso_to_epoch adapter.
@@ -1715,16 +1715,16 @@ cmd_connect() {
     # bootstrap is idempotent (no-ops if keypair exists). Empty value
     # if cryptography isn't installed — handshake stays compatible
     # with peers running pre-Phase-E airc.
-    my_x25519_pub=$("$(airc_rs_bin)" identity bootstrap --home "$AIRC_WRITE_DIR" --dir "$IDENTITY_DIR" 2>/dev/null || echo "")
+    my_x25519_pub=$("$(airc_core_bin)" identity bootstrap --home "$AIRC_WRITE_DIR" --dir "$IDENTITY_DIR" 2>/dev/null || echo "")
 
     # Read own identity blob to send in handshake (issue #34 v2 — peers
     # cache each other's identity at pair-time so airc whois works fast).
-    local my_identity_json; my_identity_json=$("$(airc_rs_bin)" config get --home "$AIRC_WRITE_DIR" --config "$CONFIG" identity "{}" 2>/dev/null || echo "{}")
+    local my_identity_json; my_identity_json=$("$(airc_core_bin)" config get --home "$AIRC_WRITE_DIR" --config "$CONFIG" identity "{}" 2>/dev/null || echo "{}")
     [ -z "$my_identity_json" ] && my_identity_json="{}"
 
     local response
     local _pair_ok=1
-    response=$("$(airc_rs_bin)" handshake send "$peer_host_only" "$peer_port" \
+    response=$("$(airc_core_bin)" handshake send "$peer_host_only" "$peer_port" \
                   --my-name "$my_name" \
                   --my-host "$(whoami)@$(get_host)" \
                   --my-ssh-pub "$my_ssh_pub" \
@@ -1780,7 +1780,7 @@ cmd_connect() {
     # targeted ssh-keygen -R when a PRIOR real-sshd host key in known_hosts
     # is known stale (e.g. the server rotated sshd host keys).
     local host_ssh_pub
-    host_ssh_pub=$(printf '%s' "$response" | "$(airc_rs_bin)" gist get .ssh_pub 2>/dev/null || true)
+    host_ssh_pub=$(printf '%s' "$response" | "$(airc_core_bin)" gist get .ssh_pub 2>/dev/null || true)
     if [ -n "$host_ssh_pub" ]; then
       mkdir -p "$HOME/.ssh" && chmod 700 "$HOME/.ssh"
       grep -qF "$host_ssh_pub" "$HOME/.ssh/authorized_keys" 2>/dev/null || {
@@ -1799,11 +1799,11 @@ cmd_connect() {
     # Drop any existing peer records with the same host first — stale names
     # from a prior rename chain must not linger alongside the current one.
     local host_airc_home host_x25519_pub
-    host_airc_home=$(printf '%s' "$response" | "$(airc_rs_bin)" gist get .airc_home 2>/dev/null || true)
+    host_airc_home=$(printf '%s' "$response" | "$(airc_core_bin)" gist get .airc_home 2>/dev/null || true)
     # Phase E.2: capture host's X25519 pubkey from handshake response
     # so cmd_send can encrypt envelopes destined for this peer.
-    host_x25519_pub=$(printf '%s' "$response" | "$(airc_rs_bin)" gist get .x25519_pub 2>/dev/null || true)
-    "$(airc_rs_bin)" identity write-peer-record --home "$AIRC_WRITE_DIR" \
+    host_x25519_pub=$(printf '%s' "$response" | "$(airc_core_bin)" gist get .x25519_pub 2>/dev/null || true)
+    "$(airc_core_bin)" identity write-peer-record --home "$AIRC_WRITE_DIR" \
         --peers-dir "$PEERS_DIR" \
         --peer-name "$peer_name" \
         --host "$ssh_target" \
@@ -1829,7 +1829,7 @@ cmd_connect() {
     # the join string for onward sharing without a fresh handshake. Also
     # cache the host's identity blob from the handshake response so
     # `airc whois <host-name>` works locally (issue #34 v2).
-    local host_identity_json; host_identity_json=$(printf '%s' "$response" | "$(airc_rs_bin)" gist get .identity "{}" 2>/dev/null || echo "{}")
+    local host_identity_json; host_identity_json=$(printf '%s' "$response" | "$(airc_core_bin)" gist get .identity "{}" 2>/dev/null || echo "{}")
     [ -z "$host_identity_json" ] && host_identity_json="{}"
     # Pass values as env vars instead of bash-substituted into the
     # python heredoc body. PR #164 retest 2026-04-27
@@ -1842,7 +1842,7 @@ cmd_connect() {
     # to env-var pass — python reads from os.environ; bash never
     # touches the python source. Also emit stderr to surface failures
     # for the future debugger (not /dev/null).
-    "$(airc_rs_bin)" config set-host-block --home "$AIRC_WRITE_DIR" \
+    "$(airc_core_bin)" config set-host-block --home "$AIRC_WRITE_DIR" \
         --config "$CONFIG" \
         --host-airc-home "$host_airc_home" \
         --host-name "$peer_name" \
@@ -1853,7 +1853,7 @@ cmd_connect() {
 
     # Pick up reminder setting from host
     local host_reminder
-    host_reminder=$(printf '%s' "$response" | "$(airc_rs_bin)" gist get .reminder 300 2>/dev/null || echo "300")
+    host_reminder=$(printf '%s' "$response" | "$(airc_core_bin)" gist get .reminder 300 2>/dev/null || echo "300")
     if [ "$host_reminder" -gt 0 ] 2>/dev/null; then
       echo "$host_reminder" > "$AIRC_WRITE_DIR/reminder"
       date +%s > "$AIRC_WRITE_DIR/last_sent"
@@ -2030,13 +2030,13 @@ cmd_connect() {
             local _configured_gid
             _configured_gid=$(airc_config_get_channel_gist "$room_name" "$CONFIG" || true)
             if [ -n "$_configured_gid" ] && [ ! -f "$AIRC_WRITE_DIR/room_gist_id" ]; then
-              _existing_room_gid=$("$(airc_rs_bin)" channel-gist find \
+              _existing_room_gid=$("$(airc_core_bin)" channel-gist find \
                                    --channel "$room_name" 2>/dev/null || true)
             fi
           fi
           if [ -z "$_existing_room_gid" ] && [ "${AIRC_NO_DISCOVERY:-0}" != "1" ]; then
             local _host_preflight_rc=0
-            _existing_room_gid=$("$(airc_rs_bin)" channel-gist host-preflight \
+            _existing_room_gid=$("$(airc_core_bin)" channel-gist host-preflight \
                                  --channel "$room_name" --config "$CONFIG" 2>/dev/null) || _host_preflight_rc=$?
             if [ "${_host_preflight_rc:-0}" = "2" ]; then
               die "GitHub room discovery is unavailable for #${room_name}; refusing to create a new solo room. Retry after the GitHub backoff clears."
@@ -2155,7 +2155,7 @@ JSON
         fi
         local _gist_url=""
         if [ -n "${_existing_room_gid:-}" ] && [ "$use_room" = "1" ]; then
-          if "$(airc_rs_bin)" gh patch-gist-file \
+          if "$(airc_core_bin)" gh patch-gist-file \
                --gist-id "$_existing_room_gid" \
                --filename "airc-room-${room_name}.json" \
                --content-file "$_gist_tmp" >/dev/null 2>/dev/null \
@@ -2169,7 +2169,7 @@ JSON
           local _gist_id="${_gist_url##*/}"
           local _hh; _hh=$(humanhash "$_gist_id" 2>/dev/null)
           if [ "$use_room" = "1" ]; then
-            "$(airc_rs_bin)" channel-gist remember-created \
+            "$(airc_core_bin)" channel-gist remember-created \
               --channel "$room_name" \
               --gist-id "$_gist_id" \
               --description "$_gist_desc" \
@@ -2280,11 +2280,11 @@ JSON
                 printf '%s\n' "$_hb_payload" > "$_hb_tmp"
                 # Rotate the host's messages.jsonl when it exceeds the
                 # AIRC_LOG_MAX_LINES threshold (default 5000). Trims
-                # in-place via airc-rs log rotate; SSH-tail's -F flag detects
+                # in-place via airc-core log rotate; SSH-tail's -F flag detects
                 # the atomic replace and re-opens. Joiners with offsets
                 # past the new file's line count are caught by #245.
                 # Cheap no-op when under threshold.
-                "$(airc_rs_bin)" log rotate --path "$_hb_messages" \
+                "$(airc_core_bin)" log rotate --path "$_hb_messages" \
                   --max-lines "${AIRC_LOG_MAX_LINES:-5000}" \
                   --keep-lines "${AIRC_LOG_KEEP_LINES:-2500}" >/dev/null 2>&1 || true
                 # Capture stderr to a state file (per never-swallow-errors
@@ -2295,7 +2295,7 @@ JSON
                 # consecutive failures: after N in a row, detect
                 # active-host-evicted (#224) and self-heal.
                 _hb_tried_add=0
-                if "$(airc_rs_bin)" gh patch-gist-file \
+                if "$(airc_core_bin)" gh patch-gist-file \
                      --gist-id "$_gist_id" \
                      --filename "airc-room-${_hb_room}.json" \
                      --content-file "$_hb_tmp" >/dev/null 2>"$_hb_stderr"; then
@@ -2458,7 +2458,7 @@ JSON
       # --watch-pid hands the same PID to the Rust listener, which exits
       # during accept polling the moment the parent dies.
       while kill -0 "$_orphan_parent_pid" 2>/dev/null; do
-        "$(airc_rs_bin)" handshake accept-one \
+        "$(airc_core_bin)" handshake accept-one \
           --host-port "$host_port" \
           --peers-dir "$PEERS_DIR" \
           --identity-dir "$IDENTITY_DIR" \

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -402,8 +402,8 @@ _doctor_health() {
     local rate_json
     if rate_json=$(airc_gh_rate_limit_json_cached); then
       local core_remaining core_limit
-      core_remaining=$(printf '%s' "$rate_json" | "$(airc_rs_bin)" gist get .resources.core.remaining 2>/dev/null || echo "")
-      core_limit=$(printf '%s' "$rate_json" | "$(airc_rs_bin)" gist get .resources.core.limit 2>/dev/null || echo "")
+      core_remaining=$(printf '%s' "$rate_json" | "$(airc_core_bin)" gist get .resources.core.remaining 2>/dev/null || echo "")
+      core_limit=$(printf '%s' "$rate_json" | "$(airc_core_bin)" gist get .resources.core.limit 2>/dev/null || echo "")
       if [ -n "$core_remaining" ] && [ -n "$core_limit" ]; then
         if [ "$core_remaining" -lt 100 ]; then
           printf "  [WARN] gh core rate-limit: %s/%s remaining — bus may stall soon\n" "$core_remaining" "$core_limit"
@@ -428,7 +428,7 @@ _doctor_health() {
   # never make same-machine or LAN chat look down when bearer/local health
   # proves the live bus is still moving.
   local _gov_rc=0 _gov_out
-  _gov_out=$("$(airc_rs_bin)" gh doctor --count 80 2>&1) || _gov_rc=$?
+  _gov_out=$("$(airc_core_bin)" gh doctor --count 80 2>&1) || _gov_rc=$?
   printf '%s\n' "$_gov_out"
   case "$_gov_out" in
     *"[BLOCKED]"*) warns=$((warns+1)) ;;
@@ -479,7 +479,7 @@ _doctor_health() {
       fi
       found_state=1
       local state_ts last_recv_ts last_heartbeat_ts heartbeat_age
-      state_ts=$("$(airc_rs_bin)" bearer-state "$state_file" 2>/dev/null || echo "0 0")
+      state_ts=$("$(airc_core_bin)" bearer-state "$state_file" 2>/dev/null || echo "0 0")
       last_recv_ts=${state_ts%% *}
       last_heartbeat_ts=${state_ts#* }
       [ "$last_recv_ts" = "$state_ts" ] && last_heartbeat_ts=0
@@ -533,7 +533,7 @@ _doctor_health() {
   if [ "${peer_count:-0}" -eq 0 ] 2>/dev/null; then
     local _collab_rc=0
     local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
-    "$(airc_rs_bin)" collaboration doctor \
+    "$(airc_core_bin)" collaboration doctor \
       --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" --client-id "$_client_id" || _collab_rc=$?
     case "$_collab_rc" in
       1) warns=$((warns+1)) ;;

--- a/lib/airc_bash/cmd_hygiene.sh
+++ b/lib/airc_bash/cmd_hygiene.sh
@@ -8,7 +8,7 @@ cmd_hygiene() {
       return 0
       ;;
     init|report|clean)
-      "$(airc_rs_bin)" hygiene "$@"
+      "$(airc_core_bin)" hygiene "$@"
       ;;
     *)
       die "hygiene: unknown subcommand: $subcmd (try: init, report, clean)"

--- a/lib/airc_bash/cmd_identity.sh
+++ b/lib/airc_bash/cmd_identity.sh
@@ -17,7 +17,7 @@
 #     adapters for continuum (the only platform implemented today).
 #
 # External cross-references (call-time): die, ensure_init, get_config_val,
-# set_config_val, resolve_name, airc_rs_bin, AIRC_HOME, CONFIG, plus the
+# set_config_val, resolve_name, airc_core_bin, AIRC_HOME, CONFIG, plus the
 # continuum CLI on PATH for import/push.
 #
 # Extracted from airc as part of #152 Phase 3 file split. The bundle is
@@ -103,25 +103,25 @@ _identity_session_file() {
   local transport_name="${1:-}"
   [ -z "$transport_name" ] && transport_name="anonymous"
   mkdir -p "$AIRC_WRITE_DIR/sessions" 2>/dev/null || true
-  "$(airc_rs_bin)" identity session-file --write-dir "$AIRC_WRITE_DIR" --transport-name "$transport_name"
+  "$(airc_core_bin)" identity session-file --write-dir "$AIRC_WRITE_DIR" --transport-name "$transport_name"
 }
 
 _identity_default_work_name() {
   local transport_name="${1:-anonymous}"
   local session_file="${2:-}"
-  "$(airc_rs_bin)" identity default-work-name --transport-name "$transport_name" --session-file "$session_file"
+  "$(airc_core_bin)" identity default-work-name --transport-name "$transport_name" --session-file "$session_file"
 }
 
 _identity_read_work_name() {
   local session_file="$1"
   [ -f "$session_file" ] || return 1
-  "$(airc_rs_bin)" identity read-work-name --session-file "$session_file"
+  "$(airc_core_bin)" identity read-work-name --session-file "$session_file"
 }
 
 _identity_write_work_session() {
   local session_file="$1" name="$2" transport_name="$3"
   _validate_peer_name "$name"
-  "$(airc_rs_bin)" identity write-work-session --session-file "$session_file" --name "$name" --transport-name "$transport_name"
+  "$(airc_core_bin)" identity write-work-session --session-file "$session_file" --name "$name" --transport-name "$transport_name"
 }
 
 _identity_resolve_work_name() {
@@ -204,7 +204,7 @@ _identity_register() {
 _identity_bootstrap_nudge_if_unset() {
   local nudge_file="$AIRC_WRITE_DIR/.identity_nudged_v1"
   [ -f "$nudge_file" ] && return 0
-  "$(airc_rs_bin)" identity nudge-needed --config "$CONFIG"
+  "$(airc_core_bin)" identity nudge-needed --config "$CONFIG"
   local nudge_status=$?
   if [ "$nudge_status" = "2" ]; then
     echo ""
@@ -219,7 +219,7 @@ _identity_bootstrap_nudge_if_unset() {
 }
 
 _identity_show() {
-  "$(airc_rs_bin)" identity show-config --config "$CONFIG"
+  "$(airc_core_bin)" identity show-config --config "$CONFIG"
 }
 
 _identity_set() {
@@ -261,13 +261,13 @@ _identity_set() {
   [ "$set_role" = 1 ] && args+=(--role "$role")
   [ "$set_bio" = 1 ] && args+=(--bio "$bio")
   [ "$set_status" = 1 ] && args+=(--status "$status")
-  "$(airc_rs_bin)" "${args[@]}"
+  "$(airc_core_bin)" "${args[@]}"
 }
 
 _identity_link() {
   local platform="${1:-}" handle="${2:-}"
   [ -z "$platform" ] && die "Usage: airc identity link <platform> [handle] (omit/blank handle to unlink)"
-  "$(airc_rs_bin)" identity link-config --config "$CONFIG" --platform "$platform" --handle "$handle"
+  "$(airc_core_bin)" identity link-config --config "$CONFIG" --platform "$platform" --handle "$handle"
 }
 
 # WHOIS: prints identity for self, host, paired peer, or other peer of
@@ -322,7 +322,7 @@ cmd_whois() {
     return 0
   fi
   local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
-  if "$(airc_rs_bin)" collaboration observed-whois \
+  if "$(airc_core_bin)" collaboration observed-whois \
       --home "$AIRC_WRITE_DIR" --my-name "$my_name" --peer-name "$target" --client-id "$_client_id"; then
     return 0
   fi
@@ -340,7 +340,7 @@ _whois_in_scope() {
   [ -f "$scope_config" ] || return 1
 
   # All scope-local config + peer file reads route through
-  # get_config_val_in / airc-rs config. Pre-migration
+  # get_config_val_in / airc-core config. Pre-migration
   # this function had six inline JSON snippets reading individual
   # JSON fields — each a silent-fail vector with bash-substituted
   # SCOPE_CONFIG / PEER_FILE env vars. Now: one CLI per read.
@@ -375,8 +375,8 @@ _whois_in_scope() {
     local remote_blob
     remote_blob=$(IDENTITY_DIR="$scope/identity" relay_ssh "$host_target_addr" "cat $host_airc_home/peers/$target.json 2>/dev/null" 2>/dev/null || true)
     if [ -n "$remote_blob" ]; then
-      local peer_id; peer_id=$(printf '%s' "$remote_blob" | "$(airc_rs_bin)" gist get .identity "{}" 2>/dev/null || echo "{}")
-      local peer_host; peer_host=$(printf '%s' "$remote_blob" | "$(airc_rs_bin)" gist get .host 2>/dev/null || echo "")
+      local peer_id; peer_id=$(printf '%s' "$remote_blob" | "$(airc_core_bin)" gist get .identity "{}" 2>/dev/null || echo "{}")
+      local peer_host; peer_host=$(printf '%s' "$remote_blob" | "$(airc_core_bin)" gist get .host 2>/dev/null || echo "")
       _whois_pretty "$target" "$peer_id" "$peer_host"
       return 0
     fi
@@ -389,7 +389,7 @@ _whois_in_scope() {
 # Args: name, identity-json, host (any may be empty).
 _whois_pretty() {
   local name="$1" blob="${2:-{\}}" host="${3:-}"
-  "$(airc_rs_bin)" identity pretty --name "$name" --identity-json "$blob" --host "$host"
+  "$(airc_core_bin)" identity pretty --name "$name" --identity-json "$blob" --host "$host"
 }
 
 # cmd_kick extracted to lib/airc_bash/cmd_kick.sh
@@ -474,14 +474,14 @@ _identity_import_continuum() {
   fi
   # Parse the JSON; merge into our identity. Empty fields skip; existing
   # fields get overwritten (the user's intent: "I want to BE this persona").
-  "$(airc_rs_bin)" identity import-continuum --config "$CONFIG" --blob "$blob"
+  "$(airc_core_bin)" identity import-continuum --config "$CONFIG" --blob "$blob"
 }
 
 _identity_push_continuum() {
   if ! command -v continuum >/dev/null 2>&1; then
     die "continuum CLI not on PATH — install continuum before pushing."
   fi
-  local handle; handle=$("$(airc_rs_bin)" identity continuum-handle --config "$CONFIG" 2>/dev/null)
+  local handle; handle=$("$(airc_core_bin)" identity continuum-handle --config "$CONFIG" 2>/dev/null)
   [ -z "$handle" ] && die "No continuum handle linked. Run: airc identity link continuum <name>"
-  "$(airc_rs_bin)" identity push-continuum --config "$CONFIG" --handle "$handle"
+  "$(airc_core_bin)" identity push-continuum --config "$CONFIG" --handle "$handle"
 }

--- a/lib/airc_bash/cmd_kick.sh
+++ b/lib/airc_bash/cmd_kick.sh
@@ -59,7 +59,7 @@ cmd_kick() {
   # peer could keep authenticating despite the "kick" — caught by
   # Copilot review on PR #73.
   local peer_ssh_pub
-  peer_ssh_pub=$("$(airc_rs_bin)" identity peer-ssh-pub \
+  peer_ssh_pub=$("$(airc_core_bin)" identity peer-ssh-pub \
     --peers-dir "$PEERS_DIR" \
     --peer-name "$target" 2>/dev/null || echo "")
 

--- a/lib/airc_bash/cmd_knock.sh
+++ b/lib/airc_bash/cmd_knock.sh
@@ -123,8 +123,8 @@ cmd_knock() {
   local knock_keys_json knocker_pub knocker_priv
   knock_keys_json=$(_airc_knock_gen_keys 2>/dev/null || echo "")
   if [ -n "$knock_keys_json" ]; then
-    knocker_pub=$("$(airc_rs_bin)" knock approval-field --field pub <<< "$knock_keys_json" 2>/dev/null || echo "")
-    knocker_priv=$("$(airc_rs_bin)" knock approval-field --field priv <<< "$knock_keys_json" 2>/dev/null || echo "")
+    knocker_pub=$("$(airc_core_bin)" knock approval-field --field pub <<< "$knock_keys_json" 2>/dev/null || echo "")
+    knocker_priv=$("$(airc_core_bin)" knock approval-field --field priv <<< "$knock_keys_json" 2>/dev/null || echo "")
   else
     # Crypto path unavailable. Knock
     # still posts but without an approval pubkey — cmd_approve will
@@ -228,7 +228,7 @@ _airc_knock_identity_json() {
   # name-only envelope if state is missing — knock should work even on
   # a fresh install where identity wasn't populated yet.
   local name="$1"
-  "$(airc_rs_bin)" knock identity-json \
+  "$(airc_core_bin)" knock identity-json \
     --name "$name" \
     --state-dir "$AIRC_WRITE_DIR" 2>/dev/null || _airc_knock_identity_fallback "$name"
 }
@@ -254,7 +254,7 @@ _airc_knock_gen_keys() {
   # Returns JSON {"priv": "<hex>", "pub": "<hex>"} on stdout.
   # Returns non-zero (caller falls back to no-pubkey envelope) when the
   # Rust binary isn't available.
-  "$(airc_rs_bin)" knock gen-keys
+  "$(airc_core_bin)" knock gen-keys
 }
 
 _airc_knock_issue_body() {

--- a/lib/airc_bash/cmd_lane.sh
+++ b/lib/airc_bash/cmd_lane.sh
@@ -167,11 +167,11 @@ _cmd_lane_list() {
   touch "$registry"
 
   if [ "$output_json" -eq 1 ]; then
-    "$(airc_rs_bin)" worktree-lane list --registry "$registry" --json
+    "$(airc_core_bin)" worktree-lane list --registry "$registry" --json
     return
   fi
 
-  "$(airc_rs_bin)" worktree-lane list --registry "$registry"
+  "$(airc_core_bin)" worktree-lane list --registry "$registry"
 }
 
 _cmd_lane_remove() {
@@ -203,12 +203,12 @@ _cmd_lane_remove() {
 
   local registry
   registry=$(_airc_lane_registry)
-  "$(airc_rs_bin)" worktree-lane find --registry "$registry" "$target" >/dev/null \
+  "$(airc_core_bin)" worktree-lane find --registry "$registry" "$target" >/dev/null \
     || die "lane remove: no recorded lane matches: $target"
 
   local repo_root lane_dir
-  repo_root=$("$(airc_rs_bin)" worktree-lane find --registry "$registry" "$target" --field repo)
-  lane_dir=$("$(airc_rs_bin)" worktree-lane find --registry "$registry" "$target" --field dir)
+  repo_root=$("$(airc_core_bin)" worktree-lane find --registry "$registry" "$target" --field repo)
+  lane_dir=$("$(airc_core_bin)" worktree-lane find --registry "$registry" "$target" --field dir)
 
   case "$lane_dir" in
     "$repo_root"|"$repo_root"/*)
@@ -234,11 +234,11 @@ _airc_lane_registry() {
 }
 
 _airc_lane_abs_path() {
-  "$(airc_rs_bin)" worktree-lane abs-path "$1"
+  "$(airc_core_bin)" worktree-lane abs-path "$1"
 }
 
 _airc_lane_slug() {
-  "$(airc_rs_bin)" worktree-lane slug "$1"
+  "$(airc_core_bin)" worktree-lane slug "$1"
 }
 
 _airc_lane_resolve_base() {
@@ -258,7 +258,7 @@ _airc_lane_record() {
   local registry
   registry=$(_airc_lane_registry)
   mkdir -p "$(dirname "$registry")"
-  "$(airc_rs_bin)" worktree-lane record \
+  "$(airc_core_bin)" worktree-lane record \
     --registry "$registry" \
     --issue "$issue_ref" \
     --repo "$repo_root" \

--- a/lib/airc_bash/cmd_queue.sh
+++ b/lib/airc_bash/cmd_queue.sh
@@ -46,7 +46,7 @@
 # contract field names yet. PR-3/PR-4 will tighten as needed.
 #
 # External cross-references (resolved at call time):
-#   die, resolve_name, airc_rs_bin; `gh` CLI.
+#   die, resolve_name, airc_core_bin; `gh` CLI.
 
 # Help text is split out so cmd_queue.sh keeps behavior logic readable.
 if [ -n "${_airc_lib_dir:-}" ] && [ -f "$_airc_lib_dir/airc_bash/cmd_queue_help.sh" ]; then
@@ -330,7 +330,7 @@ EOF
   # Read the JSON from a tempfile (not stdin) because the heredoc carrying
   # the python source uses fd 0; can't redirect stdin twice.
   local dm_text
-  dm_text=$("$(airc_rs_bin)" queue-card dispatch-message \
+  dm_text=$("$(airc_core_bin)" queue-card dispatch-message \
     --target-agent "$target_agent" \
     --extra-message "$extra_message" \
     --next-json-file "$next_json_file")
@@ -546,7 +546,7 @@ _cmd_queue_list() {
 
   local list_args=(queue-card list --repo "$target_repo" --owner "$filter_owner" --status "$filter_status" --raw-json-file "$raw_json_file")
   [ "$output_json" -eq 1 ] && list_args+=(--json)
-  "$(airc_rs_bin)" "${list_args[@]}"
+  "$(airc_core_bin)" "${list_args[@]}"
   local py_status=$?
   rm -f "$raw_json_file"
   if [ "$py_status" -eq 0 ] && [ "$output_json" -eq 0 ] && [ "$check_staleness" -eq 1 ]; then
@@ -593,7 +593,7 @@ _airc_queue_list_staleness_sweep() {
   refs_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-list-stale-refs.XXXXXX") || { rm -f "$raw_json_file"; return 1; }
   printf '%s' "$raw_json" >"$raw_json_file"
 
-  "$(airc_rs_bin)" queue-card review-refs --repo "$target_repo" --raw-json-file "$raw_json_file" >"$refs_file"
+  "$(airc_core_bin)" queue-card review-refs --repo "$target_repo" --raw-json-file "$raw_json_file" >"$refs_file"
 
   if [ -s "$refs_file" ]; then
     printf '\n# staleness sweep — review cards\n'
@@ -667,7 +667,7 @@ _airc_queue_card_body() {
   local blockers="$5" env="$6" evidence="$7"
   local next_action="$8" last_heartbeat="$9"
 
-  "$(airc_rs_bin)" queue-card body \
+  "$(airc_core_bin)" queue-card body \
     --id "$id" \
     --branch "$branch" \
     --owner "$owner" \
@@ -790,7 +790,7 @@ _airc_queue_claim_guard() {
   printf '%s' "$current_body" >"$body_file"
 
   local fields
-  if ! fields=$("$(airc_rs_bin)" queue-card claim-fields --body-file "$body_file"); then
+  if ! fields=$("$(airc_core_bin)" queue-card claim-fields --body-file "$body_file"); then
     rm -f "$body_file"
     die "$fields"
   fi
@@ -1032,7 +1032,7 @@ _cmd_queue_stale() {
 
   local stale_args=(queue-card stale --repo "$target_repo" --stale-after "$stale_after" --raw-json-file "$raw_json_file")
   [ "$output_json" -eq 1 ] && stale_args+=(--json)
-  "$(airc_rs_bin)" "${stale_args[@]}"
+  "$(airc_core_bin)" "${stale_args[@]}"
   local py_status=$?
   rm -f "$raw_json_file"
   return "$py_status"
@@ -1116,7 +1116,7 @@ _cmd_queue_next() {
 
   local next_args=(queue-card next --repo "$target_repo" --owner "$owner" --base "$base" --repo-root "$repo_root" --raw-json-file "$raw_json_file")
   [ "$output_json" -eq 1 ] && next_args+=(--json)
-  "$(airc_rs_bin)" "${next_args[@]}"
+  "$(airc_core_bin)" "${next_args[@]}"
   local py_status=$?
   rm -f "$raw_json_file"
   if [ "$py_status" -ne 0 ]; then
@@ -1402,7 +1402,7 @@ _cmd_queue_adopt() {
   local adopted_body
   local adopt_args=(queue-card adopt-body --issue-json-file "$issue_json_file" --queue-body-file "$body_file")
   [ "$force" = "1" ] && adopt_args+=(--force)
-  adopted_body=$("$(airc_rs_bin)" "${adopt_args[@]}")
+  adopted_body=$("$(airc_core_bin)" "${adopt_args[@]}")
   local adopt_rc=$?
   if [ "$adopt_rc" -ne 0 ]; then
     rm -f "$issue_json_file" "$body_file"
@@ -1545,7 +1545,7 @@ _cmd_queue_nudge_repo() {
   printf '%s' "$raw_json" >"$raw_json_file"
 
   local summary
-  if ! summary=$("$(airc_rs_bin)" queue-card nudge-summary --raw-json-file "$raw_json_file"); then
+  if ! summary=$("$(airc_core_bin)" queue-card nudge-summary --raw-json-file "$raw_json_file"); then
     rm -f "$raw_json_file"
     die "queue nudge: could not summarize queue cards for $target_repo"
   fi
@@ -1610,7 +1610,7 @@ _cmd_queue_nudge_card() {
   printf '%s' "$issue_blob" >"$issue_file"
 
   local card_meta
-  if ! card_meta=$("$(airc_rs_bin)" queue-card nudge-card-meta --issue-file "$issue_file"); then
+  if ! card_meta=$("$(airc_core_bin)" queue-card nudge-card-meta --issue-file "$issue_file"); then
     rm -f "$issue_file"
     die "queue nudge: $repo#$issue_num is not a valid airc-queue-card-v1 envelope"
   fi
@@ -1753,7 +1753,7 @@ _cmd_queue_pongs() {
 
   local pongs_args=(queue-card pongs --repo "$target_repo" --sweep-id "$sweep_id" --since "$since" --cards-file "$cards_file" --messages-file "$messages_file")
   [ "$output_json" -eq 1 ] && pongs_args+=(--json)
-  "$(airc_rs_bin)" "${pongs_args[@]}"
+  "$(airc_core_bin)" "${pongs_args[@]}"
   local py_status=$?
   rm -f "$cards_file" "$messages_file"
   return "$py_status"
@@ -1841,7 +1841,7 @@ _cmd_queue_availability() {
 
   local availability_args=(queue-card availability --repo "$target_repo" --sweep-id "$sweep_id" --since "$since" --stale-after "$stale_after" --cards-file "$cards_file" --messages-file "$messages_file")
   [ "$output_json" -eq 1 ] && availability_args+=(--json)
-  "$(airc_rs_bin)" "${availability_args[@]}"
+  "$(airc_core_bin)" "${availability_args[@]}"
   local py_status=$?
   rm -f "$cards_file" "$messages_file"
   return "$py_status"
@@ -1928,7 +1928,7 @@ _cmd_queue_staleness() {
     local pr_file pr_meta
     pr_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-staleness-pr.XXXXXX") || die "queue staleness: mktemp failed"
     printf '%s' "$pr_blob" >"$pr_file"
-    if ! pr_meta=$("$(airc_rs_bin)" queue-card pr-meta --pr-file "$pr_file"); then
+    if ! pr_meta=$("$(airc_core_bin)" queue-card pr-meta --pr-file "$pr_file"); then
       rm -f "$pr_file"
       die "queue staleness: PR JSON parse failed"
     fi
@@ -2006,7 +2006,7 @@ _cmd_queue_staleness() {
     --base-new-file "$base_new_file"
   )
   [ "$output_json" -eq 1 ] && analyze_args+=(--json)
-  "$(airc_rs_bin)" "${analyze_args[@]}"
+  "$(airc_core_bin)" "${analyze_args[@]}"
   local analyze_status=$?
   rm -f "$files_file" "$diff_file" "$base_new_file"
   return "$analyze_status"

--- a/lib/airc_bash/cmd_queue_card.sh
+++ b/lib/airc_bash/cmd_queue_card.sh
@@ -60,7 +60,7 @@ _airc_queue_mutate_card() {
   timestamp=$(date -u +"%Y-%m-%dT%H:%MZ")
 
   local new_body
-  if ! new_body=$("$(airc_rs_bin)" queue-card mutate-body \
+  if ! new_body=$("$(airc_core_bin)" queue-card mutate-body \
     --body-file "$body_file" \
     --mutations-file "$mut_file" \
     --log-msg "$log_msg" \

--- a/lib/airc_bash/cmd_queue_close_merged.sh
+++ b/lib/airc_bash/cmd_queue_close_merged.sh
@@ -76,7 +76,7 @@ _cmd_queue_close_merged() {
   printf '%s' "$pr_blob" >"$pr_file"
 
   local pr_meta
-  if ! pr_meta=$("$(airc_rs_bin)" queue-card close-merged-meta --pr-file "$pr_file"); then
+  if ! pr_meta=$("$(airc_core_bin)" queue-card close-merged-meta --pr-file "$pr_file"); then
     rm -f "$pr_file"
     die "queue close-merged: PR JSON parse failed"
   fi
@@ -108,7 +108,7 @@ _cmd_queue_close_merged() {
 
   local refs_file
   refs_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-refs.XXXXXX") || die "queue close-merged: mktemp failed"
-  if ! "$(airc_rs_bin)" queue-card close-merged-refs --pr-file "$pr_file" --repo "$pr_repo" >"$refs_file"; then
+  if ! "$(airc_core_bin)" queue-card close-merged-refs --pr-file "$pr_file" --repo "$pr_repo" >"$refs_file"; then
     rm -f "$pr_file" "$refs_file"
     die "queue close-merged: ref-parser failed"
   fi
@@ -162,7 +162,7 @@ _cmd_queue_close_merged() {
     local issue_body_file envelope_status
     issue_body_file=$(mktemp "${TMPDIR:-/tmp}/airc-queue-issue.XXXXXX") || die "queue close-merged: mktemp failed"
     printf '%s' "$issue_body" >"$issue_body_file"
-    envelope_status=$("$(airc_rs_bin)" queue-card card-status --body-file "$issue_body_file")
+    envelope_status=$("$(airc_core_bin)" queue-card card-status --body-file "$issue_body_file")
     rm -f "$issue_body_file"
 
     case "$envelope_status" in

--- a/lib/airc_bash/cmd_queue_plan.sh
+++ b/lib/airc_bash/cmd_queue_plan.sh
@@ -84,7 +84,7 @@ _cmd_queue_plan() {
     plan_args+=(--json)
   fi
 
-  "$(airc_rs_bin)" "${plan_args[@]}"
+  "$(airc_core_bin)" "${plan_args[@]}"
   local plan_status=$?
   rm -f "$raw_json_file"
   return "$plan_status"

--- a/lib/airc_bash/cmd_queue_steward.sh
+++ b/lib/airc_bash/cmd_queue_steward.sh
@@ -80,7 +80,7 @@ _cmd_queue_steward() {
     steward_args+=(--json)
   fi
 
-  "$(airc_rs_bin)" "${steward_args[@]}"
+  "$(airc_core_bin)" "${steward_args[@]}"
   local steward_status=$?
   rm -f "$raw_json_file"
   return "$steward_status"

--- a/lib/airc_bash/cmd_rename.sh
+++ b/lib/airc_bash/cmd_rename.sh
@@ -94,7 +94,7 @@ cmd_rename() {
     # nicks that were US, exclude them from the collision set. The
     # check still blocks renaming TO another peer's nick — original
     # safety property preserved.
-    if "$(airc_rs_bin)" identity rename-collision \
+    if "$(airc_core_bin)" identity rename-collision \
          --messages-file "$MESSAGES" \
          --target "$new_name" \
          --old-name "$old_name" \
@@ -104,7 +104,7 @@ cmd_rename() {
   fi
 
   # Phase 1: write the new name into THIS scope's config (the truth-
-  # layer effect for this scope). Goes through airc-rs config rather
+  # layer effect for this scope). Goes through airc-core config rather
   # than an inline-python heredoc — the heredoc was quoting-fragile
   # (would have broken on a name containing a single quote — currently
   # safe because the sanitizer keeps names in [a-z0-9-], but a sharp

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -398,7 +398,7 @@ _cmd_invite_human() {
   local primary_chan primary_gid
   primary_chan=$(airc_config_default_channel "$CONFIG" || true)
   if [ -n "$primary_chan" ]; then
-    primary_gid=$("$(airc_rs_bin)" config get-channel-gist \
+    primary_gid=$("$(airc_core_bin)" config get-channel-gist \
       --home "$AIRC_WRITE_DIR" \
       --config "$CONFIG" \
       --channel "$primary_chan" 2>/dev/null || true)
@@ -515,7 +515,7 @@ cmd_peers() {
   # newer record (cruft left from rename chain-breaks before the stable-host
   # matching logic landed).
   if [ "${1:-}" = "--prune" ]; then
-    "$(airc_rs_bin)" collaboration prune-peers \
+    "$(airc_core_bin)" collaboration prune-peers \
       --home "$AIRC_WRITE_DIR" \
       --my-name "$(get_name)" \
       --client-id "$(airc_client_id 2>/dev/null || true)"
@@ -534,7 +534,7 @@ cmd_peers() {
   # is what was missing when "5 peers earlier today, 1 now" looked
   # identical to "5 peers, all silent for 30 min" in the listing —
   # silent records persist on disk regardless of liveness.
-  "$(airc_rs_bin)" collaboration peers \
+  "$(airc_core_bin)" collaboration peers \
     --home "$AIRC_WRITE_DIR" \
     --my-name "$(get_name)" \
     --client-id "$(airc_client_id 2>/dev/null || true)"

--- a/lib/airc_bash/cmd_send.sh
+++ b/lib/airc_bash/cmd_send.sh
@@ -11,7 +11,7 @@
 #
 # External cross-references (resolved at call time): die, ensure_init,
 # get_config_val, set_config_val, relay_ssh, AIRC_HOME, MESSAGES,
-# resolve_name, get_host, _hash, and airc-rs helpers for envelope
+# resolve_name, get_host, _hash, and airc-core helpers for envelope
 # construction and transport calls.
 #
 # Extracted from airc as part of #152 Phase 3 file split. Joel 2026-04-27:
@@ -252,7 +252,7 @@ cmd_send() {
   ensure_init
 
   _airc_append_local_signed() {
-    if ! printf '%s\n' "$1" | "$(airc_rs_bin)" log append --path "$MESSAGES" >/dev/null; then
+    if ! printf '%s\n' "$1" | "$(airc_core_bin)" log append --path "$MESSAGES" >/dev/null; then
       echo "$1" >> "$MESSAGES"
     fi
   }
@@ -277,14 +277,14 @@ cmd_send() {
     # Shell is no longer allowed to route ordinary chat through gh. The
     # Rust SDK owns the local substrate path; this shell wrapper only
     # preserves the legacy CLI spelling while typed DM/system/heartbeat
-    # surfaces finish moving into airc-rs.
+    # surfaces finish moving into airc-core.
     [ "$peer_name" = "all" ] || return 1
     [ "$internal" = "0" ] || return 1
     [ "$system_event" = "0" ] || return 1
     [ "$heartbeat" = "0" ] || return 1
     [ "$plaintext" = "0" ] || return 1
 
-    local _rs; _rs=$(airc_rs_bin)
+    local _rs; _rs=$(airc_core_bin)
     "$_rs" --home "$AIRC_WRITE_DIR" room "$active_channel" >/dev/null \
       || die "rust message route failed to select #${active_channel}"
     if "$_rs" --home "$AIRC_WRITE_DIR" ping >/dev/null 2>&1; then
@@ -332,7 +332,7 @@ cmd_send() {
   local message_kind=""
   [ "$heartbeat" = "1" ] && message_kind="heartbeat"
   local payload
-  payload=$("$(airc_rs_bin)" message build \
+  payload=$("$(airc_core_bin)" message build \
       --from "$from_name" \
       --to "$peer_name" \
       --ts "$ts_val" \
@@ -361,7 +361,7 @@ cmd_send() {
     # this send; they are never converted into plaintext wire traffic.
     local recipient_pub=""
     if [ "$peer_name" != "all" ] && [ "$plaintext" != "1" ]; then
-      recipient_pub=$("$(airc_rs_bin)" identity peer-pub --home "$AIRC_WRITE_DIR" \
+      recipient_pub=$("$(airc_core_bin)" identity peer-pub --home "$AIRC_WRITE_DIR" \
         --peers-dir "$PEERS_DIR" --peer-name "$peer_name" 2>/dev/null || true)
     fi
     local wire_msg="$full_msg"
@@ -369,7 +369,7 @@ cmd_send() {
       die "missing X25519 key for '$peer_name' — refusing plaintext DM"
     fi
     if [ -n "$recipient_pub" ]; then
-      wire_msg=$(printf '%s' "$full_msg" | "$(airc_rs_bin)" envelope wrap --home "$AIRC_WRITE_DIR" \
+      wire_msg=$(printf '%s' "$full_msg" | "$(airc_core_bin)" envelope wrap --home "$AIRC_WRITE_DIR" \
         --recipient-pub="$recipient_pub" \
         --identity-dir "$IDENTITY_DIR")
       if [ -n "${AIRC_E2E_DEBUG:-}" ]; then
@@ -395,14 +395,14 @@ cmd_send() {
     fi
 
     local outcome
-    outcome=$(printf '%s' "$wire_msg" | "$(airc_rs_bin)" bearer send \
+    outcome=$(printf '%s' "$wire_msg" | "$(airc_core_bin)" bearer send \
       "$peer_name" "$active_channel" \
       --host-target "$host_target" \
       --remote-home "$rhome" \
       --room-gist-id "$room_gist_id")
     local kind detail
-    kind=$(printf '%s' "$outcome" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
-    detail=$(printf '%s' "$outcome" | "$(airc_rs_bin)" gist get .detail 2>/dev/null)
+    kind=$(printf '%s' "$outcome" | "$(airc_core_bin)" gist get .kind 2>/dev/null)
+    detail=$(printf '%s' "$outcome" | "$(airc_core_bin)" gist get .detail 2>/dev/null)
 
     case "$kind" in
       delivered)
@@ -438,13 +438,13 @@ cmd_send() {
           # set -euo pipefail). Re-invoke the same bearer_cli pipeline
           # the initial send used (lines ~316-320) so the retry path is
           # exactly the original send path replayed against fresh auth.
-          retry_outcome=$(printf '%s' "$wire_msg" | "$(airc_rs_bin)" bearer send \
+          retry_outcome=$(printf '%s' "$wire_msg" | "$(airc_core_bin)" bearer send \
             "$peer_name" "$active_channel" \
             --host-target "$host_target" \
             --remote-home "$rhome" \
             --room-gist-id "$room_gist_id" 2>&1) || true
-          retry_kind=$(printf '%s' "$retry_outcome" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
-          retry_detail=$(printf '%s' "$retry_outcome" | "$(airc_rs_bin)" gist get .detail 2>/dev/null)
+          retry_kind=$(printf '%s' "$retry_outcome" | "$(airc_core_bin)" gist get .kind 2>/dev/null)
+          retry_detail=$(printf '%s' "$retry_outcome" | "$(airc_core_bin)" gist get .detail 2>/dev/null)
           if [ "$retry_kind" = "delivered" ]; then
             echo "  ✓ Sent post-heal." >&2
             return 0
@@ -580,7 +580,7 @@ cmd_send() {
     # group encryption is a separate protocol, not an implicit fallback.
     local _host_recipient_pub=""
     if [ "$peer_name" != "all" ] && [ "$plaintext" != "1" ]; then
-      _host_recipient_pub=$("$(airc_rs_bin)" identity peer-pub --home "$AIRC_WRITE_DIR" \
+      _host_recipient_pub=$("$(airc_core_bin)" identity peer-pub --home "$AIRC_WRITE_DIR" \
         --peers-dir "$PEERS_DIR" --peer-name "$peer_name" 2>/dev/null || true)
     fi
     local _host_wire_msg="$full_msg"
@@ -588,7 +588,7 @@ cmd_send() {
       die "missing X25519 key for '$peer_name' — refusing plaintext DM"
     fi
     if [ -n "$_host_recipient_pub" ]; then
-      _host_wire_msg=$(printf '%s' "$full_msg" | "$(airc_rs_bin)" envelope wrap --home "$AIRC_WRITE_DIR" \
+      _host_wire_msg=$(printf '%s' "$full_msg" | "$(airc_core_bin)" envelope wrap --home "$AIRC_WRITE_DIR" \
         --recipient-pub="$_host_recipient_pub" \
         --identity-dir "$IDENTITY_DIR")
     fi
@@ -603,12 +603,12 @@ cmd_send() {
 
     if [ -n "$_host_room_gist_id" ]; then
       local _host_outcome
-      _host_outcome=$(printf '%s' "$_host_wire_msg" | "$(airc_rs_bin)" bearer send \
+      _host_outcome=$(printf '%s' "$_host_wire_msg" | "$(airc_core_bin)" bearer send \
         "$peer_name" "$active_channel" \
         --room-gist-id "$_host_room_gist_id")
       local _host_kind _host_detail
-      _host_kind=$(printf '%s' "$_host_outcome" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
-      _host_detail=$(printf '%s' "$_host_outcome" | "$(airc_rs_bin)" gist get .detail 2>/dev/null)
+      _host_kind=$(printf '%s' "$_host_outcome" | "$(airc_core_bin)" gist get .kind 2>/dev/null)
+      _host_detail=$(printf '%s' "$_host_outcome" | "$(airc_core_bin)" gist get .detail 2>/dev/null)
       case "$_host_kind" in
         delivered)
           # Append to local audit log only on confirmed delivery. Pre-fix
@@ -750,7 +750,7 @@ cmd_send() {
     fi
     if [ "${_peer_count:-0}" -eq 0 ] 2>/dev/null; then
       local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
-      "$(airc_rs_bin)" collaboration send-warning \
+      "$(airc_core_bin)" collaboration send-warning \
         --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" --client-id "$_client_id" 2>/dev/null || true
     fi
     _airc_codex_poll_after_user_send
@@ -806,7 +806,7 @@ cmd_ping() {
   ensure_init
 
   local ping_id
-  ping_id=$("$(airc_rs_bin)" uuid-v4)
+  ping_id=$("$(airc_core_bin)" uuid-v4)
 
   local start_time
   start_time=$(date +%s)

--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -17,7 +17,7 @@ _airc_monitor_health_report() {
   local mode="${1:-all}"
   local args=(transport health --home "$AIRC_WRITE_DIR" --config "$CONFIG")
   [ "$mode" = "degraded-only" ] && args+=(--degraded-only)
-  "$(airc_rs_bin)" "${args[@]}" 2>/dev/null | sed 's/^/  /' || true
+  "$(airc_core_bin)" "${args[@]}" 2>/dev/null | sed 's/^/  /' || true
 }
 
 _airc_collaboration_health_report() {
@@ -25,17 +25,17 @@ _airc_collaboration_health_report() {
   # self-healed host can have fresh bearer heartbeats while nobody else is
   # paired to this mesh. Surface that split-brain shape explicitly.
   local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
-  "$(airc_rs_bin)" collaboration status \
+  "$(airc_core_bin)" collaboration status \
     --home "$AIRC_WRITE_DIR" --my-name "$(get_name)" --client-id "$_client_id"
 }
 
 _airc_rust_local_status_report() {
   local _rs
-  _rs=$(airc_rs_bin)
+  _rs=$(airc_core_bin)
 
   local _room_out
   if ! _room_out=$("$_rs" --home "$AIRC_WRITE_DIR" room 2>/dev/null); then
-    echo "  data-plane:  rust-local unavailable (run: airc-rs init)"
+    echo "  data-plane:  rust-local unavailable (run: airc-core init)"
     return 0
   fi
 
@@ -97,7 +97,7 @@ cmd_status() {
   # is config.json's subscribed_channels; first element is the default
   # channel that cmd_send stamps. Display the list with a marker for
   # the default.
-  local _channels; _channels=$("$(airc_rs_bin)" config read-channels --home "$AIRC_WRITE_DIR" --config "$CONFIG" 2>/dev/null)
+  local _channels; _channels=$("$(airc_core_bin)" config read-channels --home "$AIRC_WRITE_DIR" --config "$CONFIG" 2>/dev/null)
   if [ -n "$_channels" ]; then
     local _default; _default=$(echo "$_channels" | head -1)
     local _rest; _rest=$(echo "$_channels" | tail -n +2 | tr '\n' ',' | sed 's/,$//' | sed 's/,/, #/g')
@@ -194,7 +194,7 @@ cmd_status() {
   local bearer_state="$AIRC_WRITE_DIR/bearer_state.json"
   if [ -f "$bearer_state" ]; then
     local _bs_summary
-    _bs_summary=$("$(airc_rs_bin)" bearer-state --summary "$bearer_state" 2>/dev/null)
+    _bs_summary=$("$(airc_core_bin)" bearer-state --summary "$bearer_state" 2>/dev/null)
     echo "  bearer:      ${_bs_summary:-unreadable} (legacy gh invite/remote)"
   elif [ -n "$host_target" ]; then
     echo "  bearer:      no state file ($AIRC_WRITE_DIR/bearer_state.json) — legacy gh invite/remote not yet streaming"
@@ -236,7 +236,7 @@ cmd_status() {
   [ -f "$pending" ] && pending_count=$(grep -c '^.' "$pending" 2>/dev/null || echo 0)
   if [ "$pending_count" -gt 0 ]; then
     local _gh_wait=0
-    _gh_wait=$("$(airc_rs_bin)" gh wait-seconds 2>/dev/null || echo 0)
+    _gh_wait=$("$(airc_core_bin)" gh wait-seconds 2>/dev/null || echo 0)
     if [ "${_gh_wait:-0}" -gt 0 ] 2>/dev/null; then
       echo "  queue:       ${pending_count} pending legacy gh item(s) (paused for ${_gh_wait}s; rust-local unaffected)"
     else
@@ -319,7 +319,7 @@ cmd_logs() {
   if [ "$output_json" -eq 1 ]; then
     set -- "$@" --json
   fi
-  echo "$raw" | "$(airc_rs_bin)" log "$@"
+  echo "$raw" | "$(airc_core_bin)" log "$@"
 }
 
 cmd_inbox() {
@@ -351,7 +351,7 @@ cmd_inbox() {
       --exclude-self)
         exclude_self=1; shift ;;
       --reset)
-        "$(airc_rs_bin)" log inbox-reset \
+        "$(airc_core_bin)" log inbox-reset \
           --home "$AIRC_WRITE_DIR" --cursor-file "$cursor_file"
         return 0 ;;
       -h|--help)
@@ -394,7 +394,7 @@ cmd_inbox() {
     fi
 
     local rust_out
-    if ! rust_out=$("$(airc_rs_bin)" "${rust_args[@]}" 2>&1); then
+    if ! rust_out=$("$(airc_core_bin)" "${rust_args[@]}" 2>&1); then
       printf '%s\n' "$rust_out" >&2
       return 2
     fi
@@ -434,7 +434,7 @@ cmd_inbox() {
     local _client_id; _client_id=$(airc_client_id 2>/dev/null || true)
     inbox_args+=(--exclude-self --my-name "$(get_name)" --client-id "$_client_id")
   fi
-  if ! out=$("$(airc_rs_bin)" "${inbox_args[@]}" 2>&1); then
+  if ! out=$("$(airc_core_bin)" "${inbox_args[@]}" 2>&1); then
     printf '%s\n' "$out" >&2
     return 1
   fi
@@ -446,10 +446,10 @@ cmd_inbox() {
 cmd_codex_hook() {
   ensure_init
 
-  local _airc_rs
-  _airc_rs=$(command -v airc-rs 2>/dev/null || true)
-  if [ -z "$_airc_rs" ]; then
-    die "airc-rs is required for codex-hook; build/install the Rust CLI first"
+  local _airc_core
+  _airc_core=$(command -v airc-core 2>/dev/null || true)
+  if [ -z "$_airc_core" ]; then
+    die "airc-core is required for codex-hook; build/install the Rust CLI first"
   fi
 
   local sub="${1:-}"
@@ -464,15 +464,15 @@ cmd_codex_hook() {
         esac
       done
       if [ "$_has_cursor_file" = "1" ]; then
-        "$_airc_rs" --home "$AIRC_WRITE_DIR" codex-hook user-prompt-submit "$@"
+        "$_airc_core" --home "$AIRC_WRITE_DIR" codex-hook user-prompt-submit "$@"
       else
-        "$_airc_rs" --home "$AIRC_WRITE_DIR" codex-hook user-prompt-submit \
+        "$_airc_core" --home "$AIRC_WRITE_DIR" codex-hook user-prompt-submit \
           --cursor-file "$AIRC_WRITE_DIR/codex_hook_cursor.json" \
           "$@"
       fi
       ;;
     install-hooks|uninstall-hooks)
-      "$_airc_rs" codex-hook "$sub" "$@"
+      "$_airc_core" codex-hook "$sub" "$@"
       ;;
     -h|--help|'')
       echo "Usage: airc codex-hook {user-prompt-submit|install-hooks|uninstall-hooks}"
@@ -503,12 +503,12 @@ cmd_codex_start() {
 
   local _started_at
   _started_at=$(date +%s)
-  local _airc_rs
-  _airc_rs=$(command -v airc-rs 2>/dev/null || true)
-  if [ -z "$_airc_rs" ]; then
-    die "airc-rs is required for codex-start; build/install the Rust CLI first"
+  local _airc_core
+  _airc_core=$(command -v airc-core 2>/dev/null || true)
+  if [ -z "$_airc_core" ]; then
+    die "airc-core is required for codex-start; build/install the Rust CLI first"
   fi
-  "$_airc_rs" codex-start \
+  "$_airc_core" codex-start \
     --airc "$0" \
     --home "$AIRC_WRITE_DIR" \
     --log "$_log" \

--- a/lib/airc_bash/cmd_teardown.sh
+++ b/lib/airc_bash/cmd_teardown.sh
@@ -25,7 +25,7 @@ _airc_teardown_is_live_airc_pid() {
 
   local cmd
   cmd=$(proc_cmdline "$pid" || true)
-  echo "$cmd" | grep -Eq '(^|[[:space:]])([^[:space:]]*/)?airc([[:space:]]+(join|connect)|$)|(^|[[:space:]])([^[:space:]]*/)?airc-rs([[:space:]]|$)'
+  echo "$cmd" | grep -Eq '(^|[[:space:]])([^[:space:]]*/)?airc([[:space:]]+(join|connect)|$)|(^|[[:space:]])([^[:space:]]*/)?airc-core([[:space:]]|$)'
 }
 
 _airc_teardown_live_only() {
@@ -495,7 +495,7 @@ cmd_disconnect() {
   esac
   cmd_teardown >/dev/null 2>&1 || true
   if [ -f "$CONFIG" ]; then
-    "$(airc_rs_bin)" config unset-keys --home "$AIRC_WRITE_DIR" --config "$CONFIG" \
+    "$(airc_core_bin)" config unset-keys --home "$AIRC_WRITE_DIR" --config "$CONFIG" \
       host_target host_name host_airc_home host_port host_ssh_pub >/dev/null 2>&1 || true
   fi
   echo "  Disconnected. Identity preserved. Next 'airc join' starts fresh."

--- a/lib/airc_bash/lib_daemon_detect.sh
+++ b/lib/airc_bash/lib_daemon_detect.sh
@@ -24,10 +24,10 @@ airc_daemon_scope_id() {
   local target_scope="${1:-}"
   [ -n "$target_scope" ] || target_scope="${AIRC_HOME:-$HOME/.airc}"
   local id=""
-  if command -v airc_rs_bin >/dev/null 2>&1; then
-    id=$("$(airc_rs_bin)" daemon-scope-id "$target_scope" 2>/dev/null || true)
-  elif command -v airc-rs >/dev/null 2>&1; then
-    id=$(airc-rs daemon-scope-id "$target_scope" 2>/dev/null || true)
+  if command -v airc_core_bin >/dev/null 2>&1; then
+    id=$("$(airc_core_bin)" daemon-scope-id "$target_scope" 2>/dev/null || true)
+  elif command -v airc-core >/dev/null 2>&1; then
+    id=$(airc-core daemon-scope-id "$target_scope" 2>/dev/null || true)
   fi
   if [ -z "$id" ] && command -v sha1sum >/dev/null 2>&1; then
     id=$(printf '%s' "$target_scope" | sha1sum 2>/dev/null | awk '{print substr($1,1,12)}')

--- a/lib/airc_bash/mesh.sh
+++ b/lib/airc_bash/mesh.sh
@@ -40,7 +40,7 @@ _mesh_desc() {
 # Production invariant: the gist envelope content is the source of
 # truth, not the human description. Pre-fix this matched only gists
 # whose description was exactly "airc mesh"; meanwhile
-# airc-rs channel-gist discovery found older "airc room: ..." gists
+# airc-core channel-gist discovery found older "airc room: ..." gists
 # by envelope content. Two discovery systems, two answers, split-brain.
 #
 # Delegate lookup to channel_gist.find_existing so connect, subscribe,
@@ -62,7 +62,7 @@ _mesh_find() {
       return 0
     fi
   fi
-  "$(airc_rs_bin)" channel-gist find --channel "$channel" --require-invite 2>/dev/null || true
+  "$(airc_core_bin)" channel-gist find --channel "$channel" --require-invite 2>/dev/null || true
 }
 
 # Find the canonical channel gist whether or not it currently has a host
@@ -84,7 +84,7 @@ _mesh_find_any() {
       return 0
     fi
   fi
-  "$(airc_rs_bin)" channel-gist find --channel "$channel" 2>/dev/null || true
+  "$(airc_core_bin)" channel-gist find --channel "$channel" 2>/dev/null || true
 }
 
 # Publish a new mesh gist. Echoes the new gist id, or empty on failure.
@@ -130,13 +130,13 @@ _mesh_age_secs() {
   local content
   if [ -n "$channel" ]; then
     content=$(gh api "gists/$gist_id" 2>/dev/null \
-      | "$(airc_rs_bin)" gist gist-content --channel "$channel" 2>/dev/null || true)
+      | "$(airc_core_bin)" gist gist-content --channel "$channel" 2>/dev/null || true)
   else
     content=$(gh api "gists/$gist_id" 2>/dev/null \
-      | "$(airc_rs_bin)" gist gist-content 2>/dev/null || true)
+      | "$(airc_core_bin)" gist gist-content 2>/dev/null || true)
   fi
   [ -z "$content" ] && return 0
-  local hb; hb=$(printf '%s' "$content" | "$(airc_rs_bin)" gist get .last_heartbeat 2>/dev/null || true)
+  local hb; hb=$(printf '%s' "$content" | "$(airc_core_bin)" gist get .last_heartbeat 2>/dev/null || true)
   [ -z "$hb" ] && return 0
   local hb_epoch; hb_epoch=$(iso_to_epoch "$hb")
   [ -z "$hb_epoch" ] && return 0

--- a/lib/airc_bash/platform_adapters.sh
+++ b/lib/airc_bash/platform_adapters.sh
@@ -180,7 +180,7 @@ detect_platform() {
 iso_to_epoch() {
   local ts="${1:-}"
   [ -z "$ts" ] && return 0
-  "$(airc_rs_bin)" iso-to-epoch "$ts" 2>/dev/null || true
+  "$(airc_core_bin)" iso-to-epoch "$ts" 2>/dev/null || true
 }
 
 # MSYS / Git Bash path conversion. Six callsites in airc + three in

--- a/skills/repair/SKILL.md
+++ b/skills/repair/SKILL.md
@@ -19,10 +19,10 @@ If `$ARGUMENTS` contains an invite string (looks like `name@user@host[:port]#<ba
 ```bash
 # Grab the pieces the host wrote into config during the last pair.
 SCOPE=$(airc debug-scope)
-HOST_NAME=$(airc-rs config get --config "$SCOPE/config.json" host_name 2>/dev/null || true)
-HOST_TARGET=$(airc-rs config get --config "$SCOPE/config.json" host_target 2>/dev/null || true)
-HOST_PORT=$(airc-rs config get --config "$SCOPE/config.json" host_port 7547 2>/dev/null || true)
-HOST_PUB=$(airc-rs config get --config "$SCOPE/config.json" host_ssh_pub 2>/dev/null || true)
+HOST_NAME=$(airc config get --config "$SCOPE/config.json" host_name 2>/dev/null || true)
+HOST_TARGET=$(airc config get --config "$SCOPE/config.json" host_target 2>/dev/null || true)
+HOST_PORT=$(airc config get --config "$SCOPE/config.json" host_port 7547 2>/dev/null || true)
+HOST_PUB=$(airc config get --config "$SCOPE/config.json" host_ssh_pub 2>/dev/null || true)
 PUB_B64=$(printf '%s\n' "$HOST_PUB" | base64 | tr -d '\n')
 
 if [ -n "$HOST_NAME" ] && [ -n "$HOST_TARGET" ] && [ -n "$HOST_PUB" ]; then

--- a/skills/uninstall/SKILL.md
+++ b/skills/uninstall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airc:uninstall
-description: Fully remove airc from this machine — stops processes, removes legacy background registrations if present, deletes the clone, drops binary + skill symlinks. Confirm with the user before running; this is destructive.
+description: Fully remove airc from this machine — stops processes, deletes the clone, drops binary + skill files. Confirm with the user before running; this is destructive.
 user-invocable: true
 allowed-tools: Bash
 argument-hint: "[--yes] [--purge]"
@@ -14,7 +14,7 @@ argument-hint: "[--yes] [--purge]"
 
 - The user says "uninstall airc" / "remove airc" / "I'm done with airc."
 - The user is reinstalling from scratch and wants a clean slate first.
-- A botched install left stale symlinks or a clone in a weird state, and `/repair` isn't enough.
+- A botched install left a clone in a weird state, and `/repair` isn't enough.
 
 ## What it does
 
@@ -25,8 +25,8 @@ airc uninstall
 Walks the full removal in order:
 
 1. `airc teardown --all` — stops every running airc process across all scopes on this machine
-2. Removes any legacy background registration if present
-3. Removes binary forwarders: `~/.local/bin/{airc, relay, airc.cmd, airc.ps1}`
+2. Removes daemon registrations if present
+3. Removes binary files: `~/.local/bin/{airc, airc-core, airc-core.exe, airc.cmd, airc.ps1}`
 4. Removes airc skill symlinks under `~/.claude/skills/`
 5. Removes the clone dir (`~/.airc-src` or `$AIRC_DIR`)
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -20,16 +20,16 @@ AIRC="${AIRC:-$(cd "$(dirname "$0")/.." && pwd)/airc}"
 [ -x "$AIRC" ] || { echo "FATAL: $AIRC not executable"; exit 2; }
 AIRC_REPO_ROOT="$(cd "$(dirname "$AIRC")" && pwd)"
 
-airc_rs_bin() {
-  if [ -n "${AIRC_RS_BIN:-}" ]; then
-    [ -x "$AIRC_RS_BIN" ] && { printf '%s\n' "$AIRC_RS_BIN"; return 0; }
+airc_core_bin() {
+  if [ -n "${AIRC_CORE_BIN:-}" ]; then
+    [ -x "$AIRC_CORE_BIN" ] && { printf '%s\n' "$AIRC_CORE_BIN"; return 0; }
     return 1
   fi
-  if command -v airc-rs >/dev/null 2>&1; then
-    command -v airc-rs
+  if command -v airc-core >/dev/null 2>&1; then
+    command -v airc-core
     return 0
   fi
-  for candidate in "$AIRC_REPO_ROOT/target/release/airc-rs" "$AIRC_REPO_ROOT/target/debug/airc-rs"; do
+  for candidate in "$AIRC_REPO_ROOT/target/release/airc-core" "$AIRC_REPO_ROOT/target/debug/airc-core"; do
     if [ -x "$candidate" ]; then
       printf '%s\n' "$candidate"
       return 0
@@ -171,7 +171,7 @@ requires_local_pair_bearer_or_skip() {
   local _scn="$1"
   if [ -z "$_airc_have_local_bearer" ]; then
     local _kinds
-    _kinds=$("$(airc_rs_bin)" bearer kinds 2>/dev/null | tr '\n' ' ' || echo "")
+    _kinds=$("$(airc_core_bin)" bearer kinds 2>/dev/null | tr '\n' ' ' || echo "")
     case " $_kinds " in
       *" local "*|*" ssh "*) _airc_have_local_bearer="yes" ;;
       *)                     _airc_have_local_bearer="no" ;;
@@ -291,7 +291,7 @@ scaffold_identity() {
     ssh-keygen -t ed25519 -f "$identity_dir/ssh_key" -N '' -q -C "$name" 2>/dev/null
   fi
   if [ ! -f "$identity_dir/private.pem" ]; then
-    "$(airc_rs_bin)" identity bootstrap-ed25519 --dir "$identity_dir"
+    "$(airc_core_bin)" identity bootstrap-ed25519 --dir "$identity_dir"
   fi
 }
 
@@ -366,8 +366,8 @@ scenario_tabs() {
   cp /tmp/airc-it-j/state/identity/* "$fake_home/state/identity/" 2>/dev/null
   cp /tmp/airc-it-j/state/config.json "$fake_home/state/config.json"
   # Point host_target at an unreachable host
-  "$(airc_rs_bin)" config set --config "$fake_home/state/config.json" --key host_target --value nobody@198.51.100.99
-  "$(airc_rs_bin)" config set --config "$fake_home/state/config.json" --key host_airc_home --value /tmp/nowhere
+  "$(airc_core_bin)" config set --config "$fake_home/state/config.json" --key host_target --value nobody@198.51.100.99
+  "$(airc_core_bin)" config set --config "$fake_home/state/config.json" --key host_airc_home --value /tmp/nowhere
   # Write a fake peer so resolution doesn't fail
   echo '{"name":"ghost","host":"nobody@198.51.100.99","airc_home":"/tmp/nowhere"}' > "$fake_home/state/peers/ghost.json"
   AIRC_HOME=$fake_home/state "$AIRC" send @ghost "this-should-fail-but-still-mirror" >/dev/null 2>&1
@@ -417,7 +417,7 @@ scenario_tabs() {
   [ -f "$peer_file" ] && pass "peer record for renamed peer is on disk" \
                       || fail "no peer record for gamma (rename didn't persist)"
   local peer_home
-  peer_home=$("$(airc_rs_bin)" config get --config "$peer_file" airc_home)
+  peer_home=$("$(airc_core_bin)" config get --config "$peer_file" airc_home)
   [ -n "$peer_home" ] && pass "peer record has non-empty airc_home ($peer_home)" \
                       || fail "peer record airc_home is empty — remote_home() fallback would misroute sends"
 
@@ -753,10 +753,10 @@ scenario_queue() {
 
   # Snapshot the real host_target, then flip to an unreachable address.
   local real_target
-  real_target=$("$(airc_rs_bin)" config get --config /tmp/airc-it-q-j/state/config.json host_target)
+  real_target=$("$(airc_core_bin)" config get --config /tmp/airc-it-q-j/state/config.json host_target)
   [ -n "$real_target" ] || { fail "no host_target recorded in joiner config"; return; }
 
-  "$(airc_rs_bin)" config set --config /tmp/airc-it-q-j/state/config.json \
+  "$(airc_core_bin)" config set --config /tmp/airc-it-q-j/state/config.json \
     --key host_target --value nobody@198.51.100.99
   # Also fake the peer record so resolution doesn't fail on @qhost
   echo '{"name":"qhost","host":"nobody@198.51.100.99","airc_home":"/tmp/nowhere"}' \
@@ -779,7 +779,7 @@ scenario_queue() {
     || fail "send during outage: no [QUEUED] marker in local messages.jsonl"
 
   # ── Recovery: restore real host_target, wait for flush loop ─────────
-  "$(airc_rs_bin)" config set --config /tmp/airc-it-q-j/state/config.json \
+  "$(airc_core_bin)" config set --config /tmp/airc-it-q-j/state/config.json \
     --key host_target --value "$real_target"
   pass "joiner: host_target restored (recovery simulation)"
 
@@ -853,9 +853,9 @@ scenario_status() {
   # Pending queue: simulate an outage by flipping host_target and sending, then assert queue size.
   # Reuse the same fake-target pattern as scenario_queue.
   local real_target
-  real_target=$("$(airc_rs_bin)" config get --config /tmp/airc-it-s-j/state/config.json host_target)
-  "$(airc_rs_bin)" config set --config /tmp/airc-it-s-j/state/config.json --key _real_host_target --value "$real_target"
-  "$(airc_rs_bin)" config set --config /tmp/airc-it-s-j/state/config.json --key host_target --value nobody@198.51.100.99
+  real_target=$("$(airc_core_bin)" config get --config /tmp/airc-it-s-j/state/config.json host_target)
+  "$(airc_core_bin)" config set --config /tmp/airc-it-s-j/state/config.json --key _real_host_target --value "$real_target"
+  "$(airc_core_bin)" config set --config /tmp/airc-it-s-j/state/config.json --key host_target --value nobody@198.51.100.99
   echo '{"name":"shost","host":"nobody@198.51.100.99","airc_home":"/tmp/nowhere"}' > /tmp/airc-it-s-j/state/peers/shost.json
   AIRC_HOME=/tmp/airc-it-s-j/state "$AIRC" send @shost "status-queue-probe" >/dev/null 2>&1 || true
   local j_out3; j_out3=$(AIRC_HOME=/tmp/airc-it-s-j/state "$AIRC" status 2>&1)
@@ -1121,10 +1121,10 @@ scenario_events() {
     local event_ok=0 line
     while IFS= read -r line; do
       [ -n "$line" ] || continue
-      [ "$(printf '%s' "$line" | "$(airc_rs_bin)" gist get .from 2>/dev/null)" = "airc" ] || continue
-      printf '%s' "$(printf '%s' "$line" | "$(airc_rs_bin)" gist get .msg 2>/dev/null)" | grep -q 'beta joined' || continue
-      [ "$(printf '%s' "$line" | "$(airc_rs_bin)" gist get .to 2>/dev/null)" = "all" ] || continue
-      [ -n "$(printf '%s' "$line" | "$(airc_rs_bin)" gist get .ts 2>/dev/null)" ] || continue
+      [ "$(printf '%s' "$line" | "$(airc_core_bin)" gist get .from 2>/dev/null)" = "airc" ] || continue
+      printf '%s' "$(printf '%s' "$line" | "$(airc_core_bin)" gist get .msg 2>/dev/null)" | grep -q 'beta joined' || continue
+      [ "$(printf '%s' "$line" | "$(airc_core_bin)" gist get .to 2>/dev/null)" = "all" ] || continue
+      [ -n "$(printf '%s' "$line" | "$(airc_core_bin)" gist get .ts 2>/dev/null)" ] || continue
       event_ok=1
       break
     done < /tmp/airc-it-h/state/messages.jsonl
@@ -1358,7 +1358,7 @@ scenario_identity() {
   # nick that would have triggered the bug and asserting the stored
   # name has no leading dash.
   AIRC_HOME="$home/state" "$AIRC" nick ".dottyname" >/dev/null 2>&1 || true
-  local renamed; renamed=$("$(airc_rs_bin)" config get --config "$home/state/config.json" name)
+  local renamed; renamed=$("$(airc_core_bin)" config get --config "$home/state/config.json" name)
   case "$renamed" in
     -*) fail "airc nick produced leading-dash name '$renamed' — sanitization regression" ;;
     "") fail "airc nick wrote empty name — sanitization regression" ;;
@@ -1662,7 +1662,7 @@ scenario_heartbeat() {
   # Original gist must still exist and now advertise beta as host.
   local recovered_name
   recovered_name=$(gh api "gists/$gist_id" --jq ".files[\"airc-room-${rname}.json\"].content" 2>/dev/null \
-    | "$(airc_rs_bin)" gist get .host.name 2>/dev/null || true)
+    | "$(airc_core_bin)" gist get .host.name 2>/dev/null || true)
   if [ "$recovered_name" = "beta" ]; then
     pass "original gist preserved and host lease updated to beta"
   else
@@ -2011,9 +2011,9 @@ JSON
   local sent_ok=0
   while IFS= read -r line; do
     [ -n "$line" ] || continue
-    [ "$(printf '%s' "$line" | "$(airc_rs_bin)" gist get .msg 2>/dev/null)" = "live monitor probe ascii" ] || continue
-    [ -n "$(printf '%s' "$line" | "$(airc_rs_bin)" gist get .client_id 2>/dev/null)" ] || continue
-    [ -n "$(printf '%s' "$line" | "$(airc_rs_bin)" gist get .sig 2>/dev/null)" ] || continue
+    [ "$(printf '%s' "$line" | "$(airc_core_bin)" gist get .msg 2>/dev/null)" = "live monitor probe ascii" ] || continue
+    [ -n "$(printf '%s' "$line" | "$(airc_core_bin)" gist get .client_id 2>/dev/null)" ] || continue
+    [ -n "$(printf '%s' "$line" | "$(airc_core_bin)" gist get .sig 2>/dev/null)" ] || continue
     sent_ok=1
     break
   done < "$home/messages.jsonl"
@@ -2097,8 +2097,8 @@ JSON
     && pass "status reports recv-side 404 as degraded despite fresh heartbeat" \
     || fail "status treated recv-side 404 as healthy (got: $status_out)"
 
-  local real_airc_rs; real_airc_rs=$(airc_rs_bin)
-  cat > "$fakebin/airc-rs" <<SH
+  local real_airc_core; real_airc_core=$(airc_core_bin)
+  cat > "$fakebin/airc-core" <<SH
 #!/bin/bash
 if [ "\${1:-}" = "bearer" ] && [ "\${2:-}" = "send" ]; then
   cat >/dev/null
@@ -2113,14 +2113,14 @@ if [ "\${1:-}" = "bearer" ] && [ "\${2:-}" = "send" ]; then
       ;;
   esac
 fi
-exec "$real_airc_rs" "\$@"
+exec "$real_airc_core" "\$@"
 SH
-  chmod +x "$fakebin/airc-rs"
+  chmod +x "$fakebin/airc-core"
 
   local out err rc
   out=$(mktemp -t airc-gone-out.XXXXXX)
   err=$(mktemp -t airc-gone-err.XXXXXX)
-  AIRC_HOME="$home" AIRC_RS_BIN="$fakebin/airc-rs" "$AIRC" msg @ghost "lost forever" >"$out" 2>"$err"
+  AIRC_HOME="$home" AIRC_CORE_BIN="$fakebin/airc-core" "$AIRC" msg @ghost "lost forever" >"$out" 2>"$err"
   rc=$?
 
   [ "$rc" -ne 0 ] \
@@ -2138,13 +2138,13 @@ SH
   fi
 
   local mapping
-  mapping=$(AIRC_HOME="$home" "$real_airc_rs" config get-channel-gist \
+  mapping=$(AIRC_HOME="$home" "$real_airc_core" config get-channel-gist \
     --config "$home/config.json" --channel general 2>/dev/null || true)
   [ -z "$mapping" ] \
     && pass "stale channel gist mapping cleared" \
     || fail "stale channel gist mapping still present: $mapping"
 
-  AIRC_FAKE_BEARER_KIND=transient_failure AIRC_HOME="$home" AIRC_RS_BIN="$fakebin/airc-rs" \
+  AIRC_FAKE_BEARER_KIND=transient_failure AIRC_HOME="$home" AIRC_CORE_BIN="$fakebin/airc-core" \
     "$AIRC" msg @ghost "retry later" >"$out" 2>"$err"
   rc=$?
   [ "$rc" -eq 0 ] \
@@ -2222,7 +2222,7 @@ JSON
     && pass "fresh bearer_state alone does not satisfy AIRC process liveness" \
     || fail "fresh bearer_state falsely satisfied AIRC process liveness (got: $status_out)"
 
-  ( exec -a "airc-rs monitor format --peers-dir $other/peers --my-name foreign" sleep 60 ) &
+  ( exec -a "airc-core monitor format --peers-dir $other/peers --my-name foreign" sleep 60 ) &
   local foreign_pid=$!
   sleep 1
   status_out=$(AIRC_HOME="$home" "$AIRC" status 2>&1)
@@ -2232,7 +2232,7 @@ JSON
   kill "$foreign_pid" 2>/dev/null || true
   wait "$foreign_pid" 2>/dev/null || true
 
-  ( exec -a "airc-rs monitor format --peers-dir $home/peers --my-name local" sleep 60 ) &
+  ( exec -a "airc-core monitor format --peers-dir $home/peers --my-name local" sleep 60 ) &
   local local_pid=$!
   local seen=0 i
   for i in $(seq 1 10); do
@@ -2684,9 +2684,9 @@ scenario_codex_join_waits_for_duplicate_repair() {
   mkdir -p "$home/peers"
 
   echo "99999" > "$home/airc.pid"
-  ( exec -a "airc-rs monitor format --peers-dir $home/peers --my-name stale-one" sleep 60 ) &
+  ( exec -a "airc-core monitor format --peers-dir $home/peers --my-name stale-one" sleep 60 ) &
   local stale_one=$!
-  ( exec -a "airc-rs monitor format --peers-dir $home/peers --my-name stale-two" sleep 60 ) &
+  ( exec -a "airc-core monitor format --peers-dir $home/peers --my-name stale-two" sleep 60 ) &
   local stale_two=$!
 
   CODEX_THREAD_ID=airc-it-codex-dup AIRC_CODEX_START_WAIT_SEC=25 \
@@ -2730,9 +2730,9 @@ scenario_join_reaps_duplicate_scope_transport() {
   mkdir -p "$home/peers" "$root"
 
   echo "99999" > "$home/airc.pid"
-  ( exec -a "airc-rs monitor format --peers-dir $home/peers --my-name stale-one" sleep 60 ) &
+  ( exec -a "airc-core monitor format --peers-dir $home/peers --my-name stale-one" sleep 60 ) &
   local stale_one=$!
-  ( exec -a "airc-rs monitor format --peers-dir $home/peers --my-name stale-two" sleep 60 ) &
+  ( exec -a "airc-core monitor format --peers-dir $home/peers --my-name stale-two" sleep 60 ) &
   local stale_two=$!
 
   AIRC_HOME="$home" AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 AIRC_NO_CODEX_DETACH=1 \
@@ -3103,7 +3103,7 @@ scenario_general_sidecar_default() {
     [ -f "$home1/config.json" ] && grep -q 'subscribed_channels' "$home1/config.json" && break
   done
 
-  if [ -f "$home1/config.json" ] && "$(airc_rs_bin)" config read-channels --config "$home1/config.json" | grep -qx "general"; then
+  if [ -f "$home1/config.json" ] && "$(airc_core_bin)" config read-channels --config "$home1/config.json" | grep -qx "general"; then
     pass "subscribed_channels includes 'general'"
   else
     fail "subscribed_channels missing 'general' (config: $(cat "$home1/config.json" 2>/dev/null))"
@@ -3202,7 +3202,7 @@ JSON
 
   # ── Set away with message ──
   AIRC_HOME="$home" "$AIRC" away "in a meeting til 3pm" >/dev/null 2>&1
-  local status; status=$("$(airc_rs_bin)" config get-path --config "$home/config.json" .identity.status)
+  local status; status=$("$(airc_core_bin)" config get-path --config "$home/config.json" .identity.status)
   [ "$status" = "in a meeting til 3pm" ] \
     && pass "away <msg> sets status field" \
     || fail "away didn't set status (got: '$status')"
@@ -3215,14 +3215,14 @@ JSON
 
   # ── Multi-word message via positional args ──
   AIRC_HOME="$home" "$AIRC" away getting coffee >/dev/null 2>&1
-  status=$("$(airc_rs_bin)" config get-path --config "$home/config.json" .identity.status)
+  status=$("$(airc_core_bin)" config get-path --config "$home/config.json" .identity.status)
   [ "$status" = "getting coffee" ] \
     && pass "away with multi-word arg joins with spaces" \
     || fail "multi-word away dropped tokens (got: '$status')"
 
   # ── airc back (no args) clears status ──
   AIRC_HOME="$home" "$AIRC" away >/dev/null 2>&1
-  status=$("$(airc_rs_bin)" config get-path --config "$home/config.json" .identity.status "(absent)")
+  status=$("$(airc_core_bin)" config get-path --config "$home/config.json" .identity.status "(absent)")
   [ "$status" = "(absent)" ] \
     && pass "away (no arg) clears status field (back)" \
     || fail "away no-arg didn't clear status (got: '$status')"
@@ -3230,7 +3230,7 @@ JSON
   # ── 'back' alias (IRC convention shortcut) ──
   AIRC_HOME="$home" "$AIRC" away "afk" >/dev/null 2>&1
   AIRC_HOME="$home" "$AIRC" back >/dev/null 2>&1
-  status=$("$(airc_rs_bin)" config get-path --config "$home/config.json" .identity.status "(absent)")
+  status=$("$(airc_core_bin)" config get-path --config "$home/config.json" .identity.status "(absent)")
   [ "$status" = "(absent)" ] \
     && pass "back alias also clears status" \
     || fail "back alias didn't clear (got: '$status')"
@@ -3320,10 +3320,10 @@ JSON
 
   # Identity preserved
   local name pronouns role bio
-  name=$("$(airc_rs_bin)" config get --config "$home/config.json" name)
-  pronouns=$("$(airc_rs_bin)" config get-path --config "$home/config.json" .identity.pronouns)
-  role=$("$(airc_rs_bin)" config get-path --config "$home/config.json" .identity.role)
-  bio=$("$(airc_rs_bin)" config get-path --config "$home/config.json" .identity.bio)
+  name=$("$(airc_core_bin)" config get --config "$home/config.json" name)
+  pronouns=$("$(airc_core_bin)" config get-path --config "$home/config.json" .identity.pronouns)
+  role=$("$(airc_core_bin)" config get-path --config "$home/config.json" .identity.role)
+  bio=$("$(airc_core_bin)" config get-path --config "$home/config.json" .identity.bio)
   [ "$name" = "alpha" ] && pass "name survives quit" || fail "name lost (got: '$name')"
   [ "$pronouns" = "they" ] && pass "pronouns survive quit" || fail "pronouns lost (got: '$pronouns')"
   [ "$role" = "agent" ] && pass "role survives quit" || fail "role lost (got: '$role')"
@@ -3331,8 +3331,8 @@ JSON
 
   # Host-pairing fields cleared
   local has_target has_name
-  has_target=$("$(airc_rs_bin)" config has-key --config "$home/config.json" host_target)
-  has_name=$("$(airc_rs_bin)" config has-key --config "$home/config.json" host_name)
+  has_target=$("$(airc_core_bin)" config has-key --config "$home/config.json" host_target)
+  has_name=$("$(airc_core_bin)" config has-key --config "$home/config.json" host_name)
   [ "$has_target" = "false" ] && pass "host_target cleared by quit" || fail "host_target still present"
   [ "$has_name" = "false" ] && pass "host_name cleared by quit" || fail "host_name still present"
 
@@ -3348,7 +3348,7 @@ JSON
 }
 JSON
   AIRC_HOME="$home" "$AIRC" disconnect >/dev/null 2>&1
-  has_target=$("$(airc_rs_bin)" config has-key --config "$home/config.json" host_target)
+  has_target=$("$(airc_core_bin)" config has-key --config "$home/config.json" host_target)
   [ "$has_target" = "false" ] && pass "disconnect alias clears pairing too" || fail "disconnect alias didn't clear"
 
   rm -rf /tmp/airc-it-q-quit
@@ -3406,8 +3406,8 @@ scenario_platform_adapters() {
     return
   fi
   _adapter_call() {
-    local _rs; _rs=$(airc_rs_bin) || return 1
-    AIRC_RS_BIN="$_rs" bash -c "airc_rs_bin() { printf '%s\n' \"\$AIRC_RS_BIN\"; }; source '$_adapters_file'; $*"
+    local _rs; _rs=$(airc_core_bin) || return 1
+    AIRC_CORE_BIN="$_rs" bash -c "airc_core_bin() { printf '%s\n' \"\$AIRC_CORE_BIN\"; }; source '$_adapters_file'; $*"
   }
 
   # ── proc_children ──
@@ -3630,8 +3630,8 @@ scenario_bearer_ssh_send() {
   # Pull the joiner's host_target + remote_home from its config; identity
   # key is at a known path on disk.
   local jstate=/tmp/airc-it-bs-j/state
-  local host_target; host_target=$("$(airc_rs_bin)" config get --config "$jstate/config.json" host_target)
-  local rhome;       rhome=$("$(airc_rs_bin)" config get --config "$jstate/config.json" host_airc_home "$HOME/.airc")
+  local host_target; host_target=$("$(airc_core_bin)" config get --config "$jstate/config.json" host_target)
+  local rhome;       rhome=$("$(airc_core_bin)" config get --config "$jstate/config.json" host_airc_home "$HOME/.airc")
   # NOTE on port: airc's host_target field stores `user@host` WITHOUT port
   # because the actual SSH messaging goes through the system sshd at port 22
   # (the airc port is only used for the pairing handshake). The bearer's
@@ -3646,7 +3646,7 @@ scenario_bearer_ssh_send() {
   local payload='{"from":"gamma","to":"all","ts":"2026-04-29T00:00:00Z","channel":"general","msg":"bearer-test-payload-78a8c","sig":"x"}'
 
   local outcome
-  outcome=$(printf '%s' "$payload" | "$(airc_rs_bin)" bearer send \
+  outcome=$(printf '%s' "$payload" | "$(airc_core_bin)" bearer send \
     "alpha" "general" \
     --host-target "$host_target" \
     --identity-key "$ikey" \
@@ -3687,8 +3687,8 @@ scenario_bearer_ssh_recv() {
   pass "joiner delta paired with alpha"
 
   local jstate=/tmp/airc-it-br-j/state
-  local host_target; host_target=$("$(airc_rs_bin)" config get --config "$jstate/config.json" host_target)
-  local rhome;       rhome=$("$(airc_rs_bin)" config get --config "$jstate/config.json" host_airc_home "$HOME/.airc")
+  local host_target; host_target=$("$(airc_core_bin)" config get --config "$jstate/config.json" host_target)
+  local rhome;       rhome=$("$(airc_core_bin)" config get --config "$jstate/config.json" host_airc_home "$HOME/.airc")
   # NOTE on port: airc's host_target field stores `user@host` WITHOUT port
   # because the actual SSH messaging goes through the system sshd at port 22
   # (the airc port is only used for the pairing handshake). The bearer's
@@ -3709,7 +3709,7 @@ scenario_bearer_ssh_recv() {
 
   # Run the recv driver in the background. It writes "FOUND" to recv_out
   # when it sees the marker, then exits.
-  "$(airc_rs_bin)" bearer recv alpha \
+  "$(airc_core_bin)" bearer recv alpha \
     --host-target "$host_target" \
     --identity-key "$ikey" \
     --remote-home "$rhome" \
@@ -3744,7 +3744,7 @@ scenario_bearer_ssh_recv() {
 }
 
 scenario_bearer_cli_recv() {
-  # Phase 2b: prove `airc-rs bearer recv` emits one line per envelope,
+  # Phase 2b: prove `airc-core bearer recv` emits one line per envelope,
   # payload-bytes verbatim, suitable for piping straight
   # into monitor_formatter. If this scenario passes but the monitor still
   # misses messages, the bug is in the formatter or in the watchdog —
@@ -3763,8 +3763,8 @@ scenario_bearer_cli_recv() {
   pass "joiner delta paired with alpha"
 
   local jstate=/tmp/airc-it-cli-j/state
-  local host_target; host_target=$("$(airc_rs_bin)" config get --config "$jstate/config.json" host_target)
-  local rhome;       rhome=$("$(airc_rs_bin)" config get --config "$jstate/config.json" host_airc_home "$HOME/.airc")
+  local host_target; host_target=$("$(airc_core_bin)" config get --config "$jstate/config.json" host_target)
+  local rhome;       rhome=$("$(airc_core_bin)" config get --config "$jstate/config.json" host_airc_home "$HOME/.airc")
   local ikey="$jstate/identity/ssh_key"
   local hstate=/tmp/airc-it-cli-h/state
 
@@ -3773,10 +3773,10 @@ scenario_bearer_cli_recv() {
   local cli_out; cli_out=$(mktemp -t airc-it-cli-recv.XXXXXX)
   local cli_err; cli_err=$(mktemp -t airc-it-cli-err.XXXXXX)
 
-  # Run airc-rs bearer recv in the background, captured to a file. Different
+  # Run airc-core bearer recv in the background, captured to a file. Different
   # offset_file path per invocation so we don't fight the live joiner.
   local off_file; off_file=$(mktemp -t airc-it-cli-off.XXXXXX); rm -f "$off_file"
-  "$(airc_rs_bin)" bearer recv alpha \
+  "$(airc_core_bin)" bearer recv alpha \
     --host-target "$host_target" \
     --identity-key "$ikey" \
     --remote-home "$rhome" \
@@ -3813,7 +3813,7 @@ scenario_bearer_cli_recv() {
   local parsed_found=0
   while IFS= read -r line; do
     [ -n "$line" ] || continue
-    [ "$(printf '%s' "$line" | "$(airc_rs_bin)" gist get .msg 2>/dev/null)" = "$marker" ] && parsed_found=1 && break
+    [ "$(printf '%s' "$line" | "$(airc_core_bin)" gist get .msg 2>/dev/null)" = "$marker" ] && parsed_found=1 && break
   done < "$cli_out"
   if [ $found -eq 1 ] && [ "$parsed_found" = "1" ]; then
     pass "bearer_cli recv output is parseable JSONL"
@@ -3886,8 +3886,8 @@ scenario_gh_send_creates_messages_jsonl() {
   local marker="tdd-first-send-marker-$(date +%s%N)"
   local probe='{"from":"alpha","to":"all","ts":"2026-04-29T00:00:00Z","channel":"general","msg":"'"$marker"'","sig":"x"}'
   local outcome
-  outcome=$(printf '%s' "$probe" | "$(airc_rs_bin)" bearer send all general --room-gist-id "$gist_id" 2>&1)
-  local kind; kind=$(printf '%s' "$outcome" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
+  outcome=$(printf '%s' "$probe" | "$(airc_core_bin)" bearer send all general --room-gist-id "$gist_id" 2>&1)
+  local kind; kind=$(printf '%s' "$outcome" | "$(airc_core_bin)" gist get .kind 2>/dev/null)
 
   if [ "$kind" = "delivered" ]; then
     pass "bearer_cli send returned 'delivered'"
@@ -4146,9 +4146,9 @@ scenario_gist_rotates_under_size_limit() {
   local probe='{"from":"alpha","to":"all","ts":"2026-04-29T00:00:00Z","channel":"rotation-test","msg":"'"$marker"'","sig":"x"}'
   local send_out
   send_out=$(AIRC_DISABLE_LOCAL_BUS=1 AIRC_GIST_MAX_BYTES=2000 AIRC_GIST_KEEP_LINES=10 \
-    "$(airc_rs_bin)" bearer send all rotation-test \
+    "$(airc_core_bin)" bearer send all rotation-test \
       --room-gist-id "$gist_id" <<< "$probe" 2>&1)
-  local send_kind; send_kind=$(printf '%s' "$send_out" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
+  local send_kind; send_kind=$(printf '%s' "$send_out" | "$(airc_core_bin)" gist get .kind 2>/dev/null)
   if [ "$send_kind" = "secondary_rate_limit" ]; then
     echo "  (skipped — gh secondary rate limit/backoff active; local bus disabled so rotation is not falsely accepted)"
     trap - EXIT
@@ -4230,7 +4230,7 @@ JSON
   # about to create.)
   sleep 1
   local single_gid
-  single_gid=$("$(airc_rs_bin)" channel-gist resolve --channel lobby-target --create-if-missing 2>/dev/null)
+  single_gid=$("$(airc_core_bin)" channel-gist resolve --channel lobby-target --create-if-missing 2>/dev/null)
 
   if [ -z "$single_gid" ]; then
     fail "channel_gist resolve returned empty"
@@ -4250,7 +4250,7 @@ JSON
   # The new single_gid should be a canonical single-channel gist.
   local single_channels
   single_channels=$(gh api "gists/$single_gid" --jq '.files | to_entries[0].value.content' 2>/dev/null \
-    | "$(airc_rs_bin)" gist get .channels 2>/dev/null)
+    | "$(airc_core_bin)" gist get .channels 2>/dev/null)
   if [ "$single_channels" = '["lobby-target"]' ]; then
     pass "single-channel gist envelope has channels=['lobby-target'] (post-3c canonical shape)"
   else
@@ -4262,7 +4262,7 @@ JSON
   # the legacy. This is the real production scenario where Peer B
   # resolves AFTER Peer A already published the canonical single-channel.
   local second_resolve
-  second_resolve=$("$(airc_rs_bin)" channel-gist resolve --channel lobby-target 2>/dev/null)
+  second_resolve=$("$(airc_core_bin)" channel-gist resolve --channel lobby-target 2>/dev/null)
   if [ "$second_resolve" = "$single_gid" ]; then
     pass "second resolve returns the canonical single-channel gist (substrate converges)"
   else
@@ -4320,7 +4320,7 @@ scenario_general_has_shared_gist() {
   pass "host published project room gist: $proj_gid (for #$rname)"
 
   trap "gh gist delete '$proj_gid' --yes 2>/dev/null || true; \
-        general_gid=\$(\"$(airc_rs_bin)\" config get-channel-gist --config /tmp/airc-it-tdd283-h/state/config.json --channel general 2>/dev/null); \
+        general_gid=\$(\"$(airc_core_bin)\" config get-channel-gist --config /tmp/airc-it-tdd283-h/state/config.json --channel general 2>/dev/null); \
         [ -n \"\$general_gid\" ] && [ \"\$general_gid\" != \"$proj_gid\" ] && gh gist delete \"\$general_gid\" --yes 2>/dev/null || true" EXIT
 
   # Sleep a moment so the sidecar code has had a chance to also resolve
@@ -4330,7 +4330,7 @@ scenario_general_has_shared_gist() {
   # Critical assertion 1: config.json must have a channel_gists map
   # with "general" pointing at a gist id distinct from the project room.
   local general_gid
-  general_gid=$("$(airc_rs_bin)" config get-channel-gist --config /tmp/airc-it-tdd283-h/state/config.json --channel general 2>/dev/null)
+  general_gid=$("$(airc_core_bin)" config get-channel-gist --config /tmp/airc-it-tdd283-h/state/config.json --channel general 2>/dev/null)
 
   if [ -n "$general_gid" ]; then
     pass "config.channel_gists['general'] resolved to: $general_gid"
@@ -4397,7 +4397,7 @@ scenario_custom_room_creates_gist() {
   for i in $(seq 1 30); do
     sleep 1
     [ -f "$home/state/config.json" ] || continue
-    gid=$("$(airc_rs_bin)" config get-channel-gist --config "$home/state/config.json" --channel "$rname" 2>/dev/null)
+    gid=$("$(airc_core_bin)" config get-channel-gist --config "$home/state/config.json" --channel "$rname" 2>/dev/null)
     [ -n "$gid" ] && break
   done
   trap "[ -n '$gid' ] && gh gist delete '$gid' --yes 2>/dev/null || true" EXIT
@@ -4456,7 +4456,7 @@ scenario_invite_human() {
   for i in $(seq 1 60); do
     sleep 1
     [ -f "$home_h/state/config.json" ] || continue
-    host_gid=$("$(airc_rs_bin)" config get-channel-gist --config "$home_h/state/config.json" --channel "$rname" 2>/dev/null)
+    host_gid=$("$(airc_core_bin)" config get-channel-gist --config "$home_h/state/config.json" --channel "$rname" 2>/dev/null)
     [ -n "$host_gid" ] && break
   done
 
@@ -4581,10 +4581,10 @@ scenario_bearer_gh() {
 
   # Send via the Rust bearer CLI. This is the same gh path airc msg uses.
   local send_out
-  send_out=$(printf '%s' "$probe" | AIRC_DISABLE_LOCAL_BUS=1 "$(airc_rs_bin)" bearer send all general --room-gist-id "$gist_id" 2>&1)
-  local send_kind; send_kind=$(printf '%s' "$send_out" | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
+  send_out=$(printf '%s' "$probe" | AIRC_DISABLE_LOCAL_BUS=1 "$(airc_core_bin)" bearer send all general --room-gist-id "$gist_id" 2>&1)
+  local send_kind; send_kind=$(printf '%s' "$send_out" | "$(airc_core_bin)" gist get .kind 2>/dev/null)
 
-  if "$(airc_rs_bin)" bearer kinds | grep -qx 'gh'; then
+  if "$(airc_core_bin)" bearer kinds | grep -qx 'gh'; then
     pass "Rust bearer registry exposes gh"
   else
     fail "Rust bearer registry missing gh"
@@ -4597,15 +4597,15 @@ scenario_bearer_gh() {
     cleanup_all
     return
   elif [ "$send_kind" = "delivered" ]; then
-    pass "airc-rs bearer send returns delivered"
+    pass "airc-core bearer send returns delivered"
   else
-    fail "airc-rs bearer send did not deliver (got: $send_out)"
+    fail "airc-core bearer send did not deliver (got: $send_out)"
     return
   fi
 
   # Verify the marker actually landed in the gist.
   local content; content=$(gh api "gists/$gist_id" 2>/dev/null \
-    | "$(airc_rs_bin)" gist file-content --filename messages.jsonl 2>/dev/null)
+    | "$(airc_core_bin)" gist file-content --filename messages.jsonl 2>/dev/null)
   if printf '%s' "$content" | grep -q "$marker"; then
     pass "payload visible in gist's messages.jsonl"
   else
@@ -4614,7 +4614,7 @@ scenario_bearer_gh() {
   fi
 
   # Now exercise recv: append a SECOND probe to the gist via gh CLI
-  # directly (simulating another peer's send), then verify airc-rs
+  # directly (simulating another peer's send), then verify airc-core
   # bearer recv picks it up. Use poll_interval=1 to keep the test fast
   # — production default is 15s.
   local marker2="gh-bearer-recv-marker-$(date +%s%N)"
@@ -4623,7 +4623,7 @@ scenario_bearer_gh() {
   local recv_err; recv_err=$(mktemp -t airc-it-bg-recv-err.XXXXXX)
   local recv_state; recv_state=$(mktemp -t airc-it-bg-state.XXXXXX)
   local recv_offset; recv_offset=$(mktemp -t airc-it-bg-offset.XXXXXX); rm -f "$recv_offset"
-  AIRC_DISABLE_LOCAL_BUS=1 AIRC_GH_POLL_INTERVAL=1 "$(airc_rs_bin)" bearer recv alpha \
+  AIRC_DISABLE_LOCAL_BUS=1 AIRC_GH_POLL_INTERVAL=1 "$(airc_core_bin)" bearer recv alpha \
     --room-gist-id "$gist_id" \
     --offset-file "$recv_offset" \
     --state-file "$recv_state" \
@@ -4638,7 +4638,7 @@ scenario_bearer_gh() {
   # wholesale, so reconstruct the full content.
   sleep 2
   local prior_content; prior_content=$(gh api "gists/$gist_id" 2>/dev/null \
-    | "$(airc_rs_bin)" gist file-content --filename messages.jsonl 2>/dev/null)
+    | "$(airc_core_bin)" gist file-content --filename messages.jsonl 2>/dev/null)
   local seed2; seed2=$(mktemp -d -t airc-it-bg-seed2.XXXXXX)
   {
     printf '%s' "$prior_content"
@@ -4661,18 +4661,18 @@ scenario_bearer_gh() {
   wait "$recv_pid" 2>/dev/null || true
 
   if grep -q "$marker2" "$recv_out" 2>/dev/null; then
-    pass "airc-rs bearer recv picked up the appended marker"
+    pass "airc-core bearer recv picked up the appended marker"
   else
-    fail "airc-rs bearer recv did NOT see the marker (out: $(cat "$recv_out" 2>/dev/null) | err: $(cat "$recv_err" 2>/dev/null))"
+    fail "airc-core bearer recv did NOT see the marker (out: $(cat "$recv_out" 2>/dev/null) | err: $(cat "$recv_err" 2>/dev/null))"
   fi
-  local recv_kind; recv_kind=$(cat "$recv_state" 2>/dev/null | "$(airc_rs_bin)" gist get .kind 2>/dev/null)
-  local recv_sender; recv_sender=$(cat "$recv_state" 2>/dev/null | "$(airc_rs_bin)" gist get .last_sender 2>/dev/null)
-  local recv_ts; recv_ts=$(cat "$recv_state" 2>/dev/null | "$(airc_rs_bin)" gist get .last_recv_ts 2>/dev/null)
+  local recv_kind; recv_kind=$(cat "$recv_state" 2>/dev/null | "$(airc_core_bin)" gist get .kind 2>/dev/null)
+  local recv_sender; recv_sender=$(cat "$recv_state" 2>/dev/null | "$(airc_core_bin)" gist get .last_sender 2>/dev/null)
+  local recv_ts; recv_ts=$(cat "$recv_state" 2>/dev/null | "$(airc_core_bin)" gist get .last_recv_ts 2>/dev/null)
   if [ "$recv_kind" = "gh" ] && [ "$recv_sender" = "beta" ] && \
      awk "BEGIN { exit !(($recv_ts > 0) && ($(date +%s) - $recv_ts < 30)) }" 2>/dev/null; then
-    pass "airc-rs bearer state reports fresh gh recv event"
+    pass "airc-core bearer state reports fresh gh recv event"
   else
-    fail "airc-rs bearer state not fresh (state: $(cat "$recv_state" 2>/dev/null))"
+    fail "airc-core bearer state not fresh (state: $(cat "$recv_state" 2>/dev/null))"
   fi
 
   rm -f "$recv_out" "$recv_err" "$recv_state" "$recv_offset" "$recv_offset.local.bytes"
@@ -4695,7 +4695,7 @@ scenario_shell_msg_rust_local() {
 { "name": "rust-shell", "subscribed_channels": ["airc"] }
 JSON
 
-  if AIRC_HOME="$home" AIRC_RS_BIN="$(airc_rs_bin)" "$AIRC" msg "$marker" >"$out" 2>"$err"; then
+  if AIRC_HOME="$home" AIRC_CORE_BIN="$(airc_core_bin)" "$AIRC" msg "$marker" >"$out" 2>"$err"; then
     pass "airc msg returned success through Rust local route"
   else
     fail "airc msg failed (out: $(cat "$out" 2>/dev/null); err: $(cat "$err" 2>/dev/null))"
@@ -4714,14 +4714,14 @@ JSON
     fail "airc msg leaked into gh bearer path (out: $(cat "$out" 2>/dev/null); err: $(cat "$err" 2>/dev/null); pending: $(cat "$home/pending.jsonl" 2>/dev/null))"
   fi
 
-  if AIRC_HOME="$home" AIRC_RS_BIN="$(airc_rs_bin)" "$AIRC" inbox --count 5 >"$out" 2>"$err" \
+  if AIRC_HOME="$home" AIRC_CORE_BIN="$(airc_core_bin)" "$AIRC" inbox --count 5 >"$out" 2>"$err" \
       && grep -q "$marker" "$out"; then
     pass "airc inbox reads Rust local transcript"
   else
     fail "airc inbox did not read Rust local transcript (out: $(cat "$out" 2>/dev/null); err: $(cat "$err" 2>/dev/null))"
   fi
 
-  if AIRC_HOME="$home" AIRC_RS_BIN="$(airc_rs_bin)" "$AIRC" status >"$out" 2>"$err" \
+  if AIRC_HOME="$home" AIRC_CORE_BIN="$(airc_core_bin)" "$AIRC" status >"$out" 2>"$err" \
       && grep -q 'data-plane:  rust-local active (#airc' "$out" \
       && grep -q 'gh auth:.*rust-local unaffected' "$out"; then
     pass "airc status reports Rust local data-plane before gh health"
@@ -4730,7 +4730,7 @@ JSON
   fi
 
   local explicit_cursor="$home/explicit-codex-hook-cursor.json"
-  if printf '{"hook_event_name":"UserPromptSubmit"}' | AIRC_HOME="$home" AIRC_RS_BIN="$(airc_rs_bin)" "$AIRC" codex-hook user-prompt-submit --cursor-file "$explicit_cursor" --include-self >"$out" 2>"$err" \
+  if printf '{"hook_event_name":"UserPromptSubmit"}' | AIRC_HOME="$home" AIRC_CORE_BIN="$(airc_core_bin)" "$AIRC" codex-hook user-prompt-submit --cursor-file "$explicit_cursor" --include-self >"$out" 2>"$err" \
       && grep -q "$marker" "$out" \
       && [ -f "$explicit_cursor" ]; then
     pass "codex-hook wrapper respects explicit cursor file on Rust event stream"

--- a/test/rust_cutover_guard.sh
+++ b/test/rust_cutover_guard.sh
@@ -25,3 +25,15 @@ for path in install.sh uninstall.sh airc lib/airc_bash skills integrations READM
     fail "live path still references Python runtime: $path"
   fi
 done
+
+if git grep -nE 'airc-rs|airc_rs|AIRC_RS' -- . ':!test/rust_cutover_guard.sh'; then
+  fail "old Rust-language command suffix remains"
+fi
+
+if git grep -nE 'ln -s[f]?[[:space:]].*BIN_DIR.*/airc|ln -s[f]?[[:space:]].*CLONE_DIR.*/airc' -- install.sh; then
+  fail "install.sh must install the public airc command as a forwarder file, not a symlink"
+fi
+
+if git grep -nE 'BIN_DIR.*/relay|for f in airc relay|[,{]airc,relay|relay-[*]' -- install.sh uninstall.sh skills; then
+  fail "relay command alias install/uninstall surface remains"
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -9,7 +9,7 @@
 # What it removes:
 #   - running airc processes (via airc teardown --all, if airc is on PATH)
 #   - daemon (launchd / systemd-user / Task Scheduler) via airc daemon uninstall
-#   - ~/.local/bin/{airc, relay, airc.cmd, airc.ps1}
+#   - ~/.local/bin/{airc, airc-core, airc-core.exe, airc.cmd, airc.ps1}
 #   - skill symlinks under ~/.claude/skills/ pointing into the clone
 #   - the clone itself (~/.airc-src or $AIRC_DIR)
 #
@@ -58,7 +58,7 @@ cd "$HOME" 2>/dev/null || cd /
 
 cat <<EOF
 This will remove airc from this machine:
-  binary symlinks   $BIN_DIR/{airc,relay,airc.cmd,airc.ps1}
+  binary files      $BIN_DIR/{airc,airc-core,airc-core.exe,airc.cmd,airc.ps1}
   skill symlinks    $SKILLS_TARGET/<airc-skills>/ + ~/.codex/skills/<airc-skills>/ (if Codex installed)
   install dir       $CLONE_DIR
   daemon            launchd / systemd-user / Task Scheduler unit (if installed)
@@ -98,8 +98,7 @@ if command -v airc >/dev/null 2>&1; then
 fi
 
 # 3. Skill symlinks. Walk every entry in the skills dir and drop any
-# symlink that resolves into the clone — covers both current names and
-# any stale ones from prior installs (relay-*, etc.). install.sh writes
+# symlink that resolves into the clone. install.sh writes
 # into both ~/.claude/skills (Claude Code) and ~/.codex/skills (Codex)
 # when both agents are present, so we walk both on uninstall.
 _remove_clone_owned_skill_symlinks() {
@@ -139,30 +138,30 @@ if [ -f "$codex_config" ]; then
     mv "$_tmp" "$codex_config"
     ok "Removed airc command-rules pre-approval from $codex_config"
   fi
-  _airc_rs=""
-  if command -v airc-rs >/dev/null 2>&1; then
-    _airc_rs=$(command -v airc-rs)
-  elif [ -x "$CLONE_DIR/target/release/airc-rs" ]; then
-    _airc_rs="$CLONE_DIR/target/release/airc-rs"
-  elif [ -x "$CLONE_DIR/target/debug/airc-rs" ]; then
-    _airc_rs="$CLONE_DIR/target/debug/airc-rs"
+  _airc_core=""
+  if command -v airc-core >/dev/null 2>&1; then
+    _airc_core=$(command -v airc-core)
+  elif [ -x "$CLONE_DIR/target/release/airc-core" ]; then
+    _airc_core="$CLONE_DIR/target/release/airc-core"
+  elif [ -x "$CLONE_DIR/target/debug/airc-core" ]; then
+    _airc_core="$CLONE_DIR/target/debug/airc-core"
   fi
-  if [ -n "$_airc_rs" ]; then
-    if out=$("$_airc_rs" codex-hook uninstall-hooks --codex-home "$HOME/.codex" 2>&1); then
+  if [ -n "$_airc_core" ]; then
+    if out=$("$_airc_core" codex-hook uninstall-hooks --codex-home "$HOME/.codex" 2>&1); then
       if [ -n "$out" ]; then
         printf '%s\n' "$out" | while IFS= read -r line; do
           ok "Codex AIRC hook: $line"
         done
       fi
     else
-      warn "Could not uninstall Codex AIRC hook through airc-rs: $out"
+      warn "Could not uninstall Codex AIRC hook through airc-core: $out"
     fi
   fi
 fi
 
 # 4. Binary forwarders on PATH.
 removed_bins=0
-for f in airc relay airc.cmd airc.ps1; do
+for f in airc airc-core airc-core.exe airc.cmd airc.ps1; do
   if [ -L "$BIN_DIR/$f" ] || [ -f "$BIN_DIR/$f" ]; then
     # Symlinks: drop unconditionally (we own them).
     # Real files (airc.cmd / airc.ps1 on Windows): drop only if their


### PR DESCRIPTION
## Summary
- rename the Cargo implementation binary from `airc-rs` to `airc-core` and remove the old Rust-language suffix from the repo surface
- install `airc` as a stable forwarder file instead of a symlink, and stop installing the `relay` command alias
- install Codex hooks through the public `airc codex-hook user-prompt-submit` command
- make install.sh recognize git worktrees where `.git` is a file
- add cutover guards for old suffixes, public-command symlinks, and relay alias surfaces
- document the canonical `~/.airc/worktrees` workspace convention and drain requirements

## Verification
- bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh test/integration.sh
- bash test/rust_cutover_guard.sh
- sandbox install-shape proof: `airc` exists, is executable, is not a symlink, and `relay` is not created
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli codex_hook -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-cli