### PR TITLE
fix(install): use ~/.airc/src as the source root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,11 @@ jobs:
         # Override AIRC_DIR + skip the clone step by pre-populating
         # the source tree, then run install.sh's PATH/skills wiring.
         run: |
-          mkdir -p $HOME/.airc-src
-          cp -r . $HOME/.airc-src/
+          mkdir -p $HOME/.airc/src
+          cp -r . $HOME/.airc/src/
           # Real install — no AIRC_SKIP_PREREQS. install.sh must
           # detect the package manager and install everything missing.
-          AIRC_INSTALL_NO_PULL=1 AIRC_DIR=$HOME/.airc-src bash install.sh
+          AIRC_INSTALL_NO_PULL=1 AIRC_DIR=$HOME/.airc/src bash install.sh
 
       - name: airc doctor (must report environment-clean)
         run: |
@@ -105,9 +105,9 @@ jobs:
 
       - name: Stage install.sh + run (no skip-prereqs — real install path)
         run: |
-          mkdir -p $HOME/.airc-src
-          cp -r . $HOME/.airc-src/
-          AIRC_INSTALL_NO_PULL=1 AIRC_DIR=$HOME/.airc-src bash install.sh
+          mkdir -p $HOME/.airc/src
+          cp -r . $HOME/.airc/src/
+          AIRC_INSTALL_NO_PULL=1 AIRC_DIR=$HOME/.airc/src bash install.sh
 
       - name: airc doctor (must report environment-clean)
         run: |
@@ -156,7 +156,7 @@ jobs:
       - name: Run install.ps1 (no skip — real install path via winget)
         shell: pwsh
         run: |
-          $env:AIRC_DIR = "$env:USERPROFILE\.airc-src"
+          $env:AIRC_DIR = "$env:USERPROFILE\.airc\src"
           New-Item -ItemType Directory -Force -Path $env:AIRC_DIR | Out-Null
           Copy-Item -Recurse -Force * $env:AIRC_DIR
           # install.ps1 must work from default Windows PowerShell 5.1
@@ -189,7 +189,7 @@ jobs:
       - name: Run install.ps1 under Windows PowerShell 5.1 (real install)
         shell: powershell
         run: |
-          $env:AIRC_DIR = "$env:USERPROFILE\.airc-src-ps5"
+          $env:AIRC_DIR = "$env:USERPROFILE\.airc\src-ps5"
           New-Item -ItemType Directory -Force -Path $env:AIRC_DIR | Out-Null
           Copy-Item -Recurse -Force * $env:AIRC_DIR
           & "$env:AIRC_DIR\install.ps1"
@@ -208,9 +208,9 @@ jobs:
 
       - name: Stage + install (real install path)
         run: |
-          mkdir -p $HOME/.airc-src
-          cp -r . $HOME/.airc-src/
-          AIRC_INSTALL_NO_PULL=1 AIRC_DIR=$HOME/.airc-src bash install.sh
+          mkdir -p $HOME/.airc/src
+          cp -r . $HOME/.airc/src/
+          AIRC_INSTALL_NO_PULL=1 AIRC_DIR=$HOME/.airc/src bash install.sh
 
       - name: Run integration suite
         run: |

--- a/airc
+++ b/airc
@@ -39,14 +39,14 @@ export MSYS2_ARG_CONV_EXCL="${MSYS2_ARG_CONV_EXCL:-/Users/;/home/;/root/}"
 # source its remaining bash modules. Three resolution paths, first hit wins:
 #   1. $AIRC_DIR (explicit override / install.sh's working dir)
 #   2. dirname of this script (dev checkout — running from repo)
-#   3. $HOME/.airc-src (install.sh default)
+#   3. $HOME/.airc/src (install.sh default)
 _airc_resolve_lib_dir() {
   local _candidate _abs
   for _candidate in \
       "${AIRC_DIR:-}/lib" \
       "$(dirname "$(readlink "$0" 2>/dev/null || echo "$0")")/lib" \
       "$(dirname "$0")/lib" \
-      "$HOME/.airc-src/lib"; do
+      "$HOME/.airc/src/lib"; do
     if [ -d "$_candidate/airc_bash" ]; then
       # Canonicalize to absolute path so module sourcing stays valid even
       # if cwd changes mid-script. cd +
@@ -1106,7 +1106,7 @@ sign_message() {
 # ── Platform adapters ───────────────────────────────────────────────────
 # Decomposed into lib/airc_bash/platform_adapters.sh (#152 Phase 3 — file
 # split). Sourced via the lib-dir resolver set at the top of airc.
-# Same precedence: AIRC_DIR / readlink / dirname / $HOME/.airc-src.
+# Same precedence: AIRC_DIR / readlink / dirname / $HOME/.airc/src.
 if [ -n "${_airc_lib_dir:-}" ] && [ -f "$_airc_lib_dir/airc_bash/platform_adapters.sh" ]; then
   # shellcheck source=lib/airc_bash/platform_adapters.sh
   source "$_airc_lib_dir/airc_bash/platform_adapters.sh"

--- a/airc.cmd
+++ b/airc.cmd
@@ -14,14 +14,14 @@ setlocal
 
 REM Single-source rule for dual Windows+WSL dev boxes: if the user has a
 REM WSL airc install, run THAT clone. Otherwise Windows Monitor can run
-REM %USERPROFILE%\.airc-src while WSL `airc update` updates
-REM /home/<user>/.airc-src, leaving two drifting implementations.
+REM %USERPROFILE%\.airc\src while WSL `airc update` updates
+REM /home/<user>/.airc/src, leaving two drifting implementations.
 REM Set AIRC_WINDOWS_NATIVE=1 or AIRC_DIR=... to force the native
 REM Windows/Git-Bash clone.
 if not defined AIRC_WINDOWS_NATIVE if not defined AIRC_DIR (
   where wsl.exe >nul 2>nul
   if not errorlevel 1 (
-    wsl.exe bash -lc "test -x \"$HOME/.airc-src/airc\"" >nul 2>nul
+    wsl.exe bash -lc "test -x \"$HOME/.airc/src/airc\"" >nul 2>nul
     if not errorlevel 1 (
       REM Forwarding-args fix (post-#543): the previous shape
       REM    wsl.exe sh -lc "...\"$@\"..." airc %*
@@ -39,14 +39,14 @@ if not defined AIRC_WINDOWS_NATIVE if not defined AIRC_DIR (
       REM so positional args become part of the script string before
       REM wsl.exe sees them. bash (not sh) matches the airc script's
       REM `#!/bin/bash` shebang and avoids subtle sh/dash divergence.
-      wsl.exe bash -lc "exec \"$HOME/.airc-src/airc\" %*"
+      wsl.exe bash -lc "exec \"$HOME/.airc/src/airc\" %*"
       exit /b %ERRORLEVEL%
     )
   )
 )
 
 set "AIRC_SRC=%AIRC_DIR%"
-if not defined AIRC_SRC set "AIRC_SRC=%USERPROFILE%\.airc-src"
+if not defined AIRC_SRC set "AIRC_SRC=%USERPROFILE%\.airc\src"
 set "AIRC_SCRIPT=%AIRC_SRC%\airc"
 
 if not exist "%AIRC_SCRIPT%" (

--- a/airc.ps1
+++ b/airc.ps1
@@ -59,7 +59,7 @@ function Resolve-BashExe {
 # git checkout). Linux/Mac sidesteps this with a symlink at $BIN_DIR/airc;
 # Windows can't symlink reliably, so we resolve via env var instead. The
 # convention matches the bash side: $env:AIRC_DIR overrides, default is
-# $HOME\.airc-src.
+# $HOME\.airc\src.
 #
 # Fallback: if airc.ps1 is invoked directly from a source checkout (rare,
 # usually devs), prefer a sibling `airc` script — that's the dev workflow.
@@ -68,7 +68,8 @@ $siblingAirc = Join-Path $psDir 'airc'
 if (Test-Path -LiteralPath $siblingAirc) {
     $bashAirc = $siblingAirc
 } else {
-    $aircDir = if ($env:AIRC_DIR) { $env:AIRC_DIR } else { Join-Path $env:USERPROFILE '.airc-src' }
+    $defaultAircRoot = Join-Path $env:USERPROFILE '.airc'
+    $aircDir = if ($env:AIRC_DIR) { $env:AIRC_DIR } else { Join-Path $defaultAircRoot 'src' }
     $bashAirc = Join-Path $aircDir 'airc'
     if (-not (Test-Path -LiteralPath $bashAirc)) {
         Write-Error "airc.ps1: cannot find bash 'airc' script at $bashAirc (set `$env:AIRC_DIR or reinstall via install.ps1)."

--- a/airc.shim
+++ b/airc.shim
@@ -1,6 +1,6 @@
 #!/bin/bash
 # airc — polyglot PATH shim. Single source of truth: the canonical
-# bash airc lives at $HOME/.airc-src/airc on the WSL/Linux/macOS host.
+# bash airc lives at $HOME/.airc/src/airc on the WSL/Linux/macOS host.
 # This shim is what gets dropped into Windows-visible PATH locations
 # (e.g. /c/Users/<user>/.local/bin/airc) so Git Bash users get a real
 # command without copying the full script.
@@ -18,9 +18,9 @@
 #   1. AIRC_DIR explicitly set + has airc            → exec that
 #   2. AIRC_WINDOWS_NATIVE=1 + native clone exists   → exec native
 #   3. wsl.exe present + WSL canonical clone exists  → route via wsl.exe
-#   4. Native Windows clone at %USERPROFILE%\.airc-src exists
+#   4. Native Windows clone at %USERPROFILE%\.airc\src exists
 #      (matches install.ps1's CLONE_DIR layout)     → exec native
-#   5. Caller-relative: this shim's dirname/../airc-src/airc (rare)
+#   5. Caller-relative: this shim's dirname/../.airc/src/airc (rare)
 #   6. Fail loud with all paths attempted
 #
 # Override knobs:
@@ -45,8 +45,8 @@ fi
 # back through wsl.exe would be circular and slow; just exec the
 # canonical clone in-place.
 if [ -r /proc/version ] && grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then
-  if [ -x "$HOME/.airc-src/airc" ]; then
-    exec "$HOME/.airc-src/airc" "$@"
+  if [ -x "$HOME/.airc/src/airc" ]; then
+    exec "$HOME/.airc/src/airc" "$@"
   fi
 fi
 
@@ -67,18 +67,18 @@ _airc_quote_args() {
 # 2) AIRC_WINDOWS_NATIVE=1 — skip WSL.
 # 3) Otherwise, prefer the WSL canonical clone if wsl.exe + clone exist.
 if [ -z "${AIRC_WINDOWS_NATIVE:-}" ] && command -v wsl.exe >/dev/null 2>&1; then
-  if wsl.exe bash -lc 'test -x "$HOME/.airc-src/airc"' >/dev/null 2>&1; then
+  if wsl.exe bash -lc 'test -x "$HOME/.airc/src/airc"' >/dev/null 2>&1; then
     _quoted=$(_airc_quote_args "$@")
-    exec wsl.exe bash -lc "exec \"\$HOME/.airc-src/airc\"$_quoted"
+    exec wsl.exe bash -lc "exec \"\$HOME/.airc/src/airc\"$_quoted"
   fi
 fi
 
-# 4) Windows-native fallback at %USERPROFILE%\.airc-src.
+# 4) Windows-native fallback at %USERPROFILE%\.airc\src.
 # Translate USERPROFILE (Windows-style) to a Git Bash path. Pure-bash
 # transform avoids hard-coding /c/Users/... or invoking cygpath.
 _native_dir=""
 if [ -n "${USERPROFILE:-}" ]; then
-  _native_dir=$(printf '%s' "$USERPROFILE" | sed -E 's|\\|/|g; s|^([A-Za-z]):|/\L\1|')/.airc-src
+  _native_dir=$(printf '%s' "$USERPROFILE" | sed -E 's|\\|/|g; s|^([A-Za-z]):|/\L\1|')/.airc/src
 fi
 if [ -n "$_native_dir" ] && [ -x "$_native_dir/airc" ]; then
   exec "$_native_dir/airc" "$@"
@@ -88,9 +88,8 @@ fi
 # checkouts, AIRC_DIR-less custom layouts). Walk up from the shim.
 _shim_self=$(cd "$(dirname "$0")" 2>/dev/null && pwd)
 for _candidate in \
-  "$_shim_self/../.airc-src/airc" \
-  "$_shim_self/../airc-src/airc" \
-  "$_shim_self/../../.airc-src/airc"; do
+  "$_shim_self/../.airc/src/airc" \
+  "$_shim_self/../../.airc/src/airc"; do
   if [ -x "$_candidate" ]; then
     exec "$_candidate" "$@"
   fi
@@ -102,7 +101,7 @@ echo "airc: cannot locate canonical airc bash binary." >&2
 echo "  Tried:" >&2
 echo "    AIRC_DIR              = ${AIRC_DIR:-(unset)}" >&2
 echo "    AIRC_WINDOWS_NATIVE   = ${AIRC_WINDOWS_NATIVE:-(unset)}" >&2
-echo "    WSL clone             = \$HOME/.airc-src/airc (in WSL)" >&2
+echo "    WSL clone             = \$HOME/.airc/src/airc (in WSL)" >&2
 echo "    Windows-native clone  = ${_native_dir:-(no USERPROFILE)}/airc" >&2
 echo "" >&2
 echo "  Reinstall:" >&2

--- a/install.ps1
+++ b/install.ps1
@@ -22,8 +22,8 @@
 #
 # Or clone + run:
 #
-#   git clone https://github.com/CambrianTech/airc.git $HOME\.airc-src
-#   powershell -ExecutionPolicy Bypass -File $HOME\.airc-src\install.ps1
+#   git clone https://github.com/CambrianTech/airc.git $HOME\.airc\src
+#   powershell -ExecutionPolicy Bypass -File $HOME\.airc\src\install.ps1
 #
 # After install: open a NEW shell so PATH refreshes, then `airc join`.
 
@@ -35,7 +35,9 @@ $ErrorActionPreference = 'Stop'
 # airc.cmd / airc.ps1 land (added to user PATH); SKILLS_TARGET is where
 # Claude Code looks for slash-command skills. All three honor env-var
 # overrides for tests + isolated installs (parity with install.sh).
-$CLONE_DIR     = if ($env:AIRC_DIR)      { $env:AIRC_DIR }      else { Join-Path $env:USERPROFILE '.airc-src' }
+$DEFAULT_AIRC_ROOT = Join-Path $env:USERPROFILE '.airc'
+$DEFAULT_CLONE_DIR = Join-Path $DEFAULT_AIRC_ROOT 'src'
+$CLONE_DIR     = if ($env:AIRC_DIR)      { $env:AIRC_DIR }      else { $DEFAULT_CLONE_DIR }
 $BIN_TARGET    = if ($env:BIN_TARGET)    { $env:BIN_TARGET }    else { Join-Path $env:USERPROFILE 'AppData\Local\Programs\airc' }
 $SKILLS_TARGET = if ($env:SKILLS_TARGET) { $env:SKILLS_TARGET } else { Join-Path $env:USERPROFILE '.claude\skills' }
 $REPO_URL      = 'https://github.com/CambrianTech/airc.git'
@@ -274,15 +276,15 @@ setlocal
 if not defined AIRC_WINDOWS_NATIVE if not defined AIRC_DIR (
   where wsl.exe >nul 2>nul
   if not errorlevel 1 (
-    wsl.exe sh -lc "test -x \"$HOME/.airc-src/airc\"" >nul 2>nul
+    wsl.exe sh -lc "test -x \"$HOME/.airc/src/airc\"" >nul 2>nul
     if not errorlevel 1 (
-      wsl.exe sh -lc "exec \"$HOME/.airc-src/airc\" \"$@\"" airc %*
+      wsl.exe sh -lc "exec \"$HOME/.airc/src/airc\" \"$@\"" airc %*
       exit /b %ERRORLEVEL%
     )
   )
 )
 set "AIRC_SRC=%AIRC_DIR%"
-if not defined AIRC_SRC set "AIRC_SRC=%USERPROFILE%\.airc-src"
+if not defined AIRC_SRC set "AIRC_SRC=%USERPROFILE%\.airc\src"
 set "AIRC_SCRIPT=%AIRC_SRC%\airc"
 if not exist "%AIRC_SCRIPT%" (
   echo airc.cmd: cannot find bash airc script at "%AIRC_SCRIPT%" 1>&2

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 REPO_URL="https://github.com/CambrianTech/airc.git"
-CLONE_DIR="${AIRC_DIR:-$HOME/.airc-src}"
+CLONE_DIR="${AIRC_DIR:-$HOME/.airc/src}"
 # BIN_DIR + SKILLS_TARGET respect env-var overrides so test harnesses
 # (and packagers, distros, etc.) can point install.sh at a sandbox
 # instead of stomping ~/.local/bin and ~/.claude/skills.
@@ -606,7 +606,7 @@ TOML
   fi
 
   # Filesystem permissions: NOT WRITTEN. Initially we tried granting writes
-  # to ~/.airc-src/ + ~/.airc/ + ~/.local/bin/airc + a :project_roots
+  # to ~/.airc/src/ + ~/.airc/ + ~/.local/bin/airc + a :project_roots
   # block — Codex's runtime hard-rejected the profile at startup with:
   #   "permissions profile requests filesystem writes outside the
   #   workspace root, which is not supported until the runtime enforces

--- a/lib/airc_bash/cmd_daemon.sh
+++ b/lib/airc_bash/cmd_daemon.sh
@@ -105,8 +105,8 @@ _daemon_airc_path() {
   local airc_link="${HOME}/.local/bin/airc"
   if [ -L "$airc_link" ] || [ -x "$airc_link" ]; then
     echo "$airc_link"
-  elif [ -x "${AIRC_DIR:-$HOME/.airc-src}/airc" ]; then
-    echo "${AIRC_DIR:-$HOME/.airc-src}/airc"
+  elif [ -x "${AIRC_DIR:-$HOME/.airc/src}/airc" ]; then
+    echo "${AIRC_DIR:-$HOME/.airc/src}/airc"
   else
     echo "/usr/local/bin/airc"  # last-resort guess; install will fail loud if wrong
   fi

--- a/lib/airc_bash/cmd_doctor.sh
+++ b/lib/airc_bash/cmd_doctor.sh
@@ -568,7 +568,7 @@ _doctor_run_tests() {
       echo "  airc doctor --tests     same as 'airc tests'"
       return 0 ;;
   esac
-  local script="${AIRC_DIR:-$HOME/.airc-src}/test/integration.sh"
+  local script="${AIRC_DIR:-$HOME/.airc/src}/test/integration.sh"
   if [ ! -x "$script" ]; then
     local self; self="$(realpath "$0" 2>/dev/null || echo "$0")"
     local here; here="$(dirname "$self")"

--- a/lib/airc_bash/cmd_update.sh
+++ b/lib/airc_bash/cmd_update.sh
@@ -30,7 +30,7 @@ cmd_update() {
   #   airc update --channel canary   # switch to canary + update
   #   airc update --channel main     # switch back to main + update
   #   airc channel                   # show current channel without updating
-  local dir="${AIRC_DIR:-$HOME/.airc-src}"
+  local dir="${AIRC_DIR:-$HOME/.airc/src}"
   local channel_file="$dir/.channel"
   local requested_channel=""
   local force=0
@@ -233,7 +233,7 @@ _airc_update_reset_to_origin() {
 #                            `airc update` after to actually switch)
 # Allows the AI / human to inspect + decide before the heavier update.
 cmd_channel() {
-  local dir="${AIRC_DIR:-$HOME/.airc-src}"
+  local dir="${AIRC_DIR:-$HOME/.airc/src}"
   local channel_file="$dir/.channel"
   local current="main"
   [ -f "$channel_file" ] && current=$(cat "$channel_file" 2>/dev/null | tr -d '[:space:]')
@@ -294,8 +294,8 @@ cmd_version() {
   local dir=""
   if [ -d "$here/.git" ]; then
     dir="$here"
-  elif [ -d "${AIRC_DIR:-$HOME/.airc-src}/.git" ]; then
-    dir="${AIRC_DIR:-$HOME/.airc-src}"
+  elif [ -d "${AIRC_DIR:-$HOME/.airc/src}/.git" ]; then
+    dir="${AIRC_DIR:-$HOME/.airc/src}"
   fi
   if [ -z "$dir" ]; then
     echo "  unknown (no git metadata found)"

--- a/lib/airc_bash/lib_daemon_detect.sh
+++ b/lib/airc_bash/lib_daemon_detect.sh
@@ -104,7 +104,7 @@ airc_daemon_is_installed() {
 # (post-disconnect tip, status banner). It returns true even when the
 # registered daemon is wired to a DIFFERENT scope from the one being
 # bootstrapped. b69f 2026-05-02 hit this: installed daemon while in
-# /c/.airc-src, then re-ran AIRC_INSTALL_YES=1 install.sh from
+# /c/.airc/src, then re-ran AIRC_INSTALL_YES=1 install.sh from
 # ~/continuum — install.sh saw "any airc daemon registered" → no-op'd
 # the prompt → ~/continuum had no daemon serving it. The fix is for
 # install.sh to ask scope-aware: "does the registered daemon point at

--- a/skills/uninstall/SKILL.md
+++ b/skills/uninstall/SKILL.md
@@ -28,7 +28,7 @@ Walks the full removal in order:
 2. Removes daemon registrations if present
 3. Removes binary files: `~/.local/bin/{airc, airc-core, airc-core.exe, airc.cmd, airc.ps1}`
 4. Removes airc skill symlinks under `~/.claude/skills/`
-5. Removes the clone dir (`~/.airc-src` or `$AIRC_DIR`)
+5. Removes the clone dir (`~/.airc/src` or `$AIRC_DIR`)
 
 **Confirmation prompt:** asks the user to type `yes` to proceed. If you're invoking from an agent, pass `--yes` only after the user has explicitly confirmed.
 

--- a/skills/version/SKILL.md
+++ b/skills/version/SKILL.md
@@ -19,7 +19,7 @@ airc version
 Prints three lines:
 - `airc <short-sha>[ (dirty)] on <branch>` — git state of the install directory. `dirty` means there are uncommitted local changes to the binary or scripts.
 - the commit subject line (so you can see what that SHA actually shipped).
-- the install directory path (so it's obvious whether you're running the canonical `~/.airc-src` install or a dev checkout).
+- the install directory path (so it's obvious whether you're running the canonical `~/.airc/src` install or a dev checkout).
 
 ## When to use
 
@@ -30,5 +30,5 @@ Prints three lines:
 ## Notes
 
 - airc has no version numbers yet. Short git SHA is the authoritative version — it's stable, unique, and unambiguous about which commit shipped.
-- `install:` points at the dir airc actually ran from. `~/.airc-src` is the canonical install via `install.sh`; a dev checkout will report its own path.
+- `install:` points at the dir airc actually ran from. `~/.airc/src` is the canonical install via `install.sh`; a dev checkout will report its own path.
 - If git metadata is missing (e.g., zip install), prints `unknown`.

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -3561,7 +3561,7 @@ scenario_platform_adapters() {
 
 # ── Scenario: windows_cmd_shim_prefers_wsl_single_source ───────────────
 # Windows Claude Code Monitor invokes `airc` through the .cmd shim. Keep
-# dual Windows+WSL installs single-source: if WSL has ~/.airc-src, route
+# dual Windows+WSL installs single-source: if WSL has ~/.airc/src, route
 # there. Otherwise fall back to the native Git Bash clone.
 scenario_windows_cmd_shim_direct_bash() {
   section "windows_cmd_shim_direct_bash: airc.cmd prefers WSL single-source, then Git Bash"

--- a/test/rust_cutover_guard.sh
+++ b/test/rust_cutover_guard.sh
@@ -30,6 +30,10 @@ if git grep -nE 'airc-rs|airc_rs|AIRC_RS' -- . ':!test/rust_cutover_guard.sh'; t
   fail "old Rust-language command suffix remains"
 fi
 
+if git grep -nE 'airc-src|[.]airc-src' -- . ':!test/rust_cutover_guard.sh'; then
+  fail "old split install clone path remains"
+fi
+
 if git grep -nE 'ln -s[f]?[[:space:]].*BIN_DIR.*/airc|ln -s[f]?[[:space:]].*CLONE_DIR.*/airc' -- install.sh; then
   fail "install.sh must install the public airc command as a forwarder file, not a symlink"
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,7 +2,7 @@
 #
 # AIRC uninstaller — single source of truth for full removal.
 #
-# Direct entry:    bash ~/.airc-src/uninstall.sh
+# Direct entry:    bash ~/.airc/src/uninstall.sh
 # Curl-pipe:       curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/uninstall.sh | bash -s -- --yes
 # Via the verb:    airc uninstall            (preferred; just exec's this script)
 #
@@ -11,7 +11,7 @@
 #   - daemon (launchd / systemd-user / Task Scheduler) via airc daemon uninstall
 #   - ~/.local/bin/{airc, airc-core, airc-core.exe, airc.cmd, airc.ps1}
 #   - skill symlinks under ~/.claude/skills/ pointing into the clone
-#   - the clone itself (~/.airc-src or $AIRC_DIR)
+#   - the clone itself (~/.airc/src or $AIRC_DIR)
 #
 # What it leaves:
 #   - per-project .airc/ state in every dir you ran `airc join` from
@@ -24,11 +24,11 @@
 #   --purge        also print the list of per-project .airc/ dirs to remove manually
 #   --help / -h    this message
 #
-# AIRC_DIR env var overrides the clone location (default $HOME/.airc-src).
+# AIRC_DIR env var overrides the clone location (default $HOME/.airc/src).
 
 set -euo pipefail
 
-CLONE_DIR="${AIRC_DIR:-$HOME/.airc-src}"
+CLONE_DIR="${AIRC_DIR:-$HOME/.airc/src}"
 BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
 SKILLS_TARGET="${SKILLS_TARGET:-$HOME/.claude/skills}"
 


### PR DESCRIPTION
Summary
- move the default installed source clone from ~/.airc-src to ~/.airc/src across POSIX, Windows, wrappers, CI, and docs
- keep AIRC_HOME as the single home root while preserving repo-local .airc project state
- add a cutover guard so airc-src/.airc-src cannot return

Verification
- bash -n install.sh uninstall.sh airc airc.shim lib/airc_bash/*.sh
- bash test/rust_cutover_guard.sh
- cargo fmt --manifest-path Cargo.toml --all --check
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- clean install proof: removed ~/.airc-src and ~/.airc/src, cloned branch into ~/.airc/src, ran install.sh, verified airc reports install: ~/.airc/src, public binaries are regular files, and no relay alias exists