### PR TITLE
fix(install): use source command as POSIX entrypoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,14 @@ jobs:
 
       - name: airc doctor (must report environment-clean)
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
+          export PATH="$HOME/.airc/src:$PATH"
           which airc
+          test "$(which airc)" = "$HOME/.airc/src/airc"
           airc doctor
 
       - name: Smoke — connect --no-room --no-gist + teardown
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
+          export PATH="$HOME/.airc/src:$PATH"
           export AIRC_HOME=/tmp/ci-airc/state
           export AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 AIRC_NO_IDENTITY_PROMPT=1
           mkdir -p /tmp/ci-airc/state
@@ -111,13 +112,14 @@ jobs:
 
       - name: airc doctor (must report environment-clean)
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
+          export PATH="$HOME/.airc/src:$PATH"
           which airc
+          test "$(which airc)" = "$HOME/.airc/src/airc"
           airc doctor
 
       - name: Smoke — same as linux (airc.pid based)
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
+          export PATH="$HOME/.airc/src:$PATH"
           export AIRC_HOME=/tmp/ci-airc/state
           export AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 AIRC_NO_IDENTITY_PROMPT=1
           mkdir -p /tmp/ci-airc/state
@@ -214,7 +216,7 @@ jobs:
 
       - name: Run integration suite
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
+          export PATH="$HOME/.airc/src:$PATH"
           # Tests that need real gists self-skip without gh auth. The
           # remaining ~85% of the suite covers the local-only scenarios
           # that catch the lion's share of regressions.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The installer:
 
 - installs or checks `gh` (still needed for invite/rendezvous; not the data plane)
 - runs `gh auth login -s gist` when needed
-- puts `airc` on your PATH
+- puts `~/.airc/src/airc` on your PATH
 - installs agent skills for detected tools such as Claude Code and Codex
 
 Native PowerShell users can use:

--- a/bootstrap-airc.sh
+++ b/bootstrap-airc.sh
@@ -9,7 +9,7 @@
 #
 # What it does:
 #   1. Runs install.sh if airc isn't already on PATH (handles prereqs +
-#      symlinks the binary into ~/.local/bin).
+#      puts ~/.airc/src/airc on PATH).
 #   2. Runs `airc doctor --connect` to verify the env can pair (catches
 #      Tailscale-down / gh-missing / network-out before they silently fail).
 #   3. Walks gh auth if not already done.
@@ -38,9 +38,9 @@ if ! command -v airc >/dev/null 2>&1; then
   step "airc not on PATH -- running installer (canary channel)"
   curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/canary/install.sh | bash
   # Pick up the freshly-installed binary in this same session.
-  export PATH="$HOME/.local/bin:$PATH"
+  export PATH="$HOME/.airc/src:$PATH"
   if ! command -v airc >/dev/null 2>&1; then
-    die "airc still not on PATH after install. Add ~/.local/bin to PATH and re-run."
+    die "airc still not on PATH after install. Add ~/.airc/src to PATH and re-run."
   fi
   ok "airc installed: $(command -v airc)"
 else

--- a/install.sh
+++ b/install.sh
@@ -4,15 +4,15 @@
 #
 # curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 #
-# Clones the repo, puts `airc` on PATH, and installs AIRC skills.
+# Clones the repo, puts the source `airc` on PATH, and installs AIRC skills.
 
 set -euo pipefail
 
 REPO_URL="https://github.com/CambrianTech/airc.git"
 CLONE_DIR="${AIRC_DIR:-$HOME/.airc/src}"
-# BIN_DIR + SKILLS_TARGET respect env-var overrides so test harnesses
-# (and packagers, distros, etc.) can point install.sh at a sandbox
-# instead of stomping ~/.local/bin and ~/.claude/skills.
+# BIN_DIR remains for Windows shims. POSIX installs use $CLONE_DIR/airc
+# directly so there is one public command file, not a second POSIX
+# wrapper under BIN_DIR.
 BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
 SKILLS_TARGET="${SKILLS_TARGET:-$HOME/.claude/skills}"
 
@@ -437,37 +437,52 @@ fi
 
 # ── airc on PATH ───────────────────────────────────────────────────────
 
-_write_airc_forwarder() {
-  local target="$1"
-  mkdir -p "$(dirname "$target")"
-  cat > "$target" <<SH
-#!/usr/bin/env bash
-set -euo pipefail
-export AIRC_DIR="$CLONE_DIR"
-exec "$CLONE_DIR/airc" "\$@"
-SH
-  chmod +x "$target"
-  ok "Installed command: $target"
+_add_path_entry() {
+  local path_entry="$1"
+  if echo "$PATH" | tr ':' '\n' | grep -qx "$path_entry"; then
+    return 0
+  fi
+
+  local rc
+  for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
+    [ -f "$rc" ] || continue
+    if ! grep -Fq "$path_entry" "$rc"; then
+      echo "export PATH=\"$path_entry:\$PATH\"  # airc" >> "$rc"
+      ok "Added $path_entry to PATH in $(basename "$rc")"
+    fi
+    break
+  done
+  export PATH="$path_entry:$PATH"
 }
 
-mkdir -p "$BIN_DIR"
-# Install exactly one public Unix command: `airc`. It is a stable
-# forwarder into the clone, not a symlink and not a copied implementation
-# script. That keeps `airc update` and clean-room reinstalls honest.
+# POSIX uses the source command directly: ~/.airc/src/airc. Windows still
+# needs PATH shims because Git Bash / PowerShell / cmd resolve different
+# executable suffixes.
 case "$(uname -s 2>/dev/null)" in
   MINGW*|MSYS*|CYGWIN*)
+    mkdir -p "$BIN_DIR"
     if [ -f "$CLONE_DIR/airc.shim" ]; then
       [ -f "$BIN_DIR/airc" ] && rm -f "$BIN_DIR/airc" 2>/dev/null || true
       cp -f "$CLONE_DIR/airc.shim" "$BIN_DIR/airc"
       chmod +x "$BIN_DIR/airc" 2>/dev/null || true
     else
-      _write_airc_forwarder "$BIN_DIR/airc"
+      cp -f "$CLONE_DIR/airc" "$BIN_DIR/airc"
+      chmod +x "$BIN_DIR/airc" 2>/dev/null || true
     fi
     [ -f "$CLONE_DIR/airc.cmd" ] && cp -f "$CLONE_DIR/airc.cmd" "$BIN_DIR/airc.cmd"
     [ -f "$CLONE_DIR/airc.ps1" ] && cp -f "$CLONE_DIR/airc.ps1" "$BIN_DIR/airc.ps1"
+    _add_path_entry "$BIN_DIR"
     ;;
   *)
-    _write_airc_forwarder "$BIN_DIR/airc"
+    chmod +x "$CLONE_DIR/airc"
+    for stale in "$BIN_DIR/airc" "$BIN_DIR/airc-core"; do
+      if [ -L "$stale" ] || [ -f "$stale" ]; then
+        rm -f "$stale"
+        ok "Removed stale PATH forwarder: $stale"
+      fi
+    done
+    _add_path_entry "$CLONE_DIR"
+    ok "Using command: $CLONE_DIR/airc"
     ;;
 esac
 
@@ -486,25 +501,13 @@ _install_airc_core_binary() {
       ok "Installed airc-core: $BIN_DIR/airc-core.exe"
       ;;
     *)
-      cp -f "$built" "$BIN_DIR/airc-core"
-      chmod +x "$BIN_DIR/airc-core"
-      ok "Installed airc-core: $BIN_DIR/airc-core"
+      chmod +x "$built"
+      ok "Built airc-core: $built"
       ;;
   esac
 }
 
 _install_airc_core_binary
-
-if ! echo "$PATH" | tr ':' '\n' | grep -qx "$BIN_DIR"; then
-  for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
-    if [ -f "$rc" ] && ! grep -q 'airc' "$rc"; then
-      echo 'export PATH="$HOME/.local/bin:$PATH"  # airc' >> "$rc"
-      ok "Added ~/.local/bin to PATH in $(basename "$rc")"
-      break
-    fi
-  done
-  export PATH="$BIN_DIR:$PATH"
-fi
 
 # ── Skills into agent skill dirs (Claude Code + Codex) ─────────────────
 #
@@ -606,7 +609,7 @@ TOML
   fi
 
   # Filesystem permissions: NOT WRITTEN. Initially we tried granting writes
-  # to ~/.airc/src/ + ~/.airc/ + ~/.local/bin/airc + a :project_roots
+  # to ~/.airc/src/ + ~/.airc/ + a :project_roots
   # block — Codex's runtime hard-rejected the profile at startup with:
   #   "permissions profile requests filesystem writes outside the
   #   workspace root, which is not supported until the runtime enforces

--- a/lib/airc_bash/cmd_daemon.sh
+++ b/lib/airc_bash/cmd_daemon.sh
@@ -97,16 +97,14 @@ The OS launchd/systemd/HKCU manages start/stop of registered units automatically
   esac
 }
 
-# Resolve the absolute path to airc binary that should run under the daemon.
-# install.sh symlinks $HOME/.local/bin/airc → $AIRC_DIR/airc; we want the
-# real path so a future `airc update` (which mutates $AIRC_DIR/airc in
-# place) is picked up by launchd/systemd without re-installing the unit.
+# Resolve the absolute path to the airc script that should run under the
+# daemon. POSIX install uses ~/.airc/src/airc directly; Windows may still
+# have shim files under BIN_DIR.
 _daemon_airc_path() {
-  local airc_link="${HOME}/.local/bin/airc"
-  if [ -L "$airc_link" ] || [ -x "$airc_link" ]; then
-    echo "$airc_link"
-  elif [ -x "${AIRC_DIR:-$HOME/.airc/src}/airc" ]; then
+  if [ -x "${AIRC_DIR:-$HOME/.airc/src}/airc" ]; then
     echo "${AIRC_DIR:-$HOME/.airc/src}/airc"
+  elif [ -x "${HOME}/.local/bin/airc" ]; then
+    echo "${HOME}/.local/bin/airc"
   else
     echo "/usr/local/bin/airc"  # last-resort guess; install will fail loud if wrong
   fi

--- a/lib/airc_bash/cmd_rooms.sh
+++ b/lib/airc_bash/cmd_rooms.sh
@@ -427,13 +427,13 @@ _cmd_invite_human() {
 curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 
 # 2) Join my room.
-~/.local/bin/airc join ${primary_gid}
+~/.airc/src/airc join ${primary_gid}
 
 # 3) Say hi so we know you made it.
-~/.local/bin/airc msg "hello, I'm \$(whoami)"
+~/.airc/src/airc msg "hello, I'm \$(whoami)"
 
 # 4) When you're done, leave cleanly.
-#    ~/.local/bin/airc part
+#    ~/.airc/src/airc part
 PASTE
 }
 

--- a/skills/invite/SKILL.md
+++ b/skills/invite/SKILL.md
@@ -52,7 +52,7 @@ airc invite --human
 Prints a multi-line shell-runnable paste-block. The block includes:
 
 1. The canonical curl|bash install one-liner — safe to re-run if they already have airc.
-2. `airc join <gist-id>` using the absolute path `~/.local/bin/airc` (PATH may not include it in the same shell that just installed airc).
+2. `airc join <gist-id>` using the absolute path `~/.airc/src/airc` (PATH may not include it in the same shell that just installed airc).
 3. A "say hi" first-message hint that preserves literal `$(whoami)` so it expands on the receiver's shell, not the host's.
 4. A clean-exit hint (`airc part`).
 

--- a/skills/uninstall/SKILL.md
+++ b/skills/uninstall/SKILL.md
@@ -26,7 +26,7 @@ Walks the full removal in order:
 
 1. `airc teardown --all` — stops every running airc process across all scopes on this machine
 2. Removes daemon registrations if present
-3. Removes binary files: `~/.local/bin/{airc, airc-core, airc-core.exe, airc.cmd, airc.ps1}`
+3. Removes stale POSIX forwarders and Windows shim files under `$BIN_DIR`
 4. Removes airc skill symlinks under `~/.claude/skills/`
 5. Removes the clone dir (`~/.airc/src` or `$AIRC_DIR`)
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -4431,7 +4431,7 @@ scenario_invite_human() {
   # This scenario tests the END-TO-END user flow Joel calls "Toby's
   # case for humans" — friend pastes the block, ends up in the room.
   # We can't actually run the install one-liner in the test (would
-  # touch the real ~/.local/bin/airc and pull from main), but we
+  # touch the real ~/.airc/src/airc and pull from main), but we
   # CAN extract the connect line and execute its substantive part:
   # (1) the paste-block has the right shape, and (2) the connect
   # command in it actually puts a fresh joiner scope into the host's
@@ -4520,12 +4520,12 @@ scenario_invite_human() {
     fail "paste-block gist ($connect_gid) NOT reachable via gh api — the receiver's 'airc connect' would fail"
   fi
 
-  # The paste-block uses absolute paths (~/.local/bin/airc) rather
-  # than bare 'airc'. PATH may not include ~/.local/bin in the same
+  # The paste-block uses absolute paths (~/.airc/src/airc) rather
+  # than bare 'airc'. PATH may not include ~/.airc/src in the same
   # shell that just curl|bash'd install.sh, so bare 'airc' would fail
   # for fresh installs. Absolute paths protect against that.
-  printf '%s\n' "$block" | grep -q "~/.local/bin/airc" \
-    && pass "paste-block uses absolute path (~/.local/bin/airc) so PATH-not-yet-refreshed shells still find airc" \
+  printf '%s\n' "$block" | grep -q "~/.airc/src/airc" \
+    && pass "paste-block uses absolute path (~/.airc/src/airc) so PATH-not-yet-refreshed shells still find airc" \
     || fail "paste-block missing absolute airc path — would fail in a shell that just installed airc"
 
   trap - EXIT

--- a/test/rust_cutover_guard.sh
+++ b/test/rust_cutover_guard.sh
@@ -34,8 +34,12 @@ if git grep -nE 'airc-src|[.]airc-src' -- . ':!test/rust_cutover_guard.sh'; then
   fail "old split install clone path remains"
 fi
 
+if git grep -nE '~[/][.]local/bin/airc|[.]local/bin[:][$]PATH|[$]HOME/[.]local/bin.*airc' -- install.sh README.md skills .github; then
+  fail "POSIX install must use ~/.airc/src/airc directly, not ~/.local/bin/airc"
+fi
+
 if git grep -nE 'ln -s[f]?[[:space:]].*BIN_DIR.*/airc|ln -s[f]?[[:space:]].*CLONE_DIR.*/airc' -- install.sh; then
-  fail "install.sh must install the public airc command as a forwarder file, not a symlink"
+  fail "install.sh must not symlink public airc"
 fi
 
 if git grep -nE 'BIN_DIR.*/relay|for f in airc relay|[,{]airc,relay|relay-[*]' -- install.sh uninstall.sh skills; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -9,7 +9,7 @@
 # What it removes:
 #   - running airc processes (via airc teardown --all, if airc is on PATH)
 #   - daemon (launchd / systemd-user / Task Scheduler) via airc daemon uninstall
-#   - ~/.local/bin/{airc, airc-core, airc-core.exe, airc.cmd, airc.ps1}
+#   - stale POSIX forwarders and Windows shim files under $BIN_DIR
 #   - skill symlinks under ~/.claude/skills/ pointing into the clone
 #   - the clone itself (~/.airc/src or $AIRC_DIR)
 #
@@ -58,7 +58,7 @@ cd "$HOME" 2>/dev/null || cd /
 
 cat <<EOF
 This will remove airc from this machine:
-  binary files      $BIN_DIR/{airc,airc-core,airc-core.exe,airc.cmd,airc.ps1}
+  PATH files        $CLONE_DIR/airc plus stale $BIN_DIR/{airc,airc-core,airc-core.exe,airc.cmd,airc.ps1}
   skill symlinks    $SKILLS_TARGET/<airc-skills>/ + ~/.codex/skills/<airc-skills>/ (if Codex installed)
   install dir       $CLONE_DIR
   daemon            launchd / systemd-user / Task Scheduler unit (if installed)
@@ -159,7 +159,7 @@ if [ -f "$codex_config" ]; then
   fi
 fi
 
-# 4. Binary forwarders on PATH.
+# 4. Stale POSIX forwarders and Windows shim files on PATH.
 removed_bins=0
 for f in airc airc-core airc-core.exe airc.cmd airc.ps1; do
   if [ -L "$BIN_DIR/$f" ] || [ -f "$BIN_DIR/$f" ]; then
@@ -176,7 +176,7 @@ for f in airc airc-core airc-core.exe airc.cmd airc.ps1; do
     fi
   fi
 done
-[ "$removed_bins" -gt 0 ] && ok "Removed $removed_bins binary forwarder(s) from $BIN_DIR"
+[ "$removed_bins" -gt 0 ] && ok "Removed $removed_bins stale PATH file(s) from $BIN_DIR"
 
 # 5. Clone dir. Last, since the steps above call into airc + read
 # from the clone for the skill walk. Once this runs, `airc` is gone.


### PR DESCRIPTION
Summary
- make POSIX installs use ~/.airc/src/airc directly as the public command
- remove stale ~/.local/bin/airc and ~/.local/bin/airc-core on install so they cannot shadow the source
- keep Windows shim files under BIN_DIR, where executable suffixes still require them
- update CI, invite text, bootstrap docs, daemon resolution, and cutover guards for the single-command-path invariant

Verification
- bash -n install.sh uninstall.sh airc bootstrap-airc.sh airc.shim lib/airc_bash/*.sh
- bash test/rust_cutover_guard.sh
- cargo fmt --manifest-path Cargo.toml --all --check
- clean install proof in isolated HOME: cloned this branch into ~/.airc/src, ran install.sh, verified command -v airc == ~/.airc/src/airc, verified no ~/.local/bin/airc or ~/.local/bin/airc-core, verified ~/.airc/src/target/release/airc-core exists, and airc version reports the install source