### PR TITLE
fix(shell): resolve airc-core from source install

### DIFF
--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -447,7 +447,7 @@ cmd_codex_hook() {
   ensure_init
 
   local _airc_core
-  _airc_core=$(command -v airc-core 2>/dev/null || true)
+  _airc_core=$(airc_core_bin 2>/dev/null || true)
   if [ -z "$_airc_core" ]; then
     die "airc-core is required for codex-hook; build/install the Rust CLI first"
   fi
@@ -504,7 +504,7 @@ cmd_codex_start() {
   local _started_at
   _started_at=$(date +%s)
   local _airc_core
-  _airc_core=$(command -v airc-core 2>/dev/null || true)
+  _airc_core=$(airc_core_bin 2>/dev/null || true)
   if [ -z "$_airc_core" ]; then
     die "airc-core is required for codex-start; build/install the Rust CLI first"
   fi


### PR DESCRIPTION
Summary
- route codex-hook and codex-start through the shared airc_core_bin resolver
- stop assuming airc-core exists on PATH after POSIX installs moved to ~/.airc/src/airc

Verification
- bash -n install.sh uninstall.sh airc bootstrap-airc.sh airc.shim lib/airc_bash/*.sh
- bash test/rust_cutover_guard.sh
- cargo build --manifest-path Cargo.toml --release -p airc-cli
- AIRC_DIR=<branch-source> PATH=<branch-source>:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/Android Studio.app/Contents/jbr/Contents/Home/bin:/Users/joelteply/Library/Android/sdk/platform-tools:/Users/joelteply/Library/Android/sdk/cmdline-tools/latest/bin:/Users/joelteply/Library/Android/sdk/emulator:/Users/joelteply/.rd/bin:/Applications/Rancher Desktop.app/Contents/Resources/resources/darwin/bin:/Users/joelteply/.codex/tmp/arg0/codex-arg0MFrcCx:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/joelteply/.local/bin:/Users/joelteply/.cargo/bin airc join from HOME starts the Codex-detached transport without ~/.local/bin/airc-core