### PR TITLE
fix(status): treat rust-local as routine health

### DIFF
--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -15,6 +15,17 @@
 
 _airc_monitor_health_report() {
   local mode="${1:-all}"
+
+  # Rust-local is the routine data-plane. The older transport health
+  # command measures GitHub bearer heartbeat/pidfile state, which is now
+  # invite/remote plumbing. Do not report a missing bearer pidfile as
+  # broken local chat when the Rust room is present.
+  if "$(airc_core_bin)" --home "$AIRC_WRITE_DIR" room >/dev/null 2>&1; then
+    [ "$mode" = "degraded-only" ] && return 0
+    echo "  transport health: ok (rust-local data-plane active)"
+    return 0
+  fi
+
   local args=(transport health --home "$AIRC_WRITE_DIR" --config "$CONFIG")
   [ "$mode" = "degraded-only" ] && args+=(--degraded-only)
   "$(airc_core_bin)" "${args[@]}" 2>/dev/null | sed 's/^/  /' || true


### PR DESCRIPTION
Summary
- stop reporting missing GitHub bearer pidfiles as degraded local transport when the Rust room/data-plane is active
- keep GitHub invite/remote state visible under the separate bearer line instead of poisoning local health

Verification
- bash -n install.sh uninstall.sh airc bootstrap-airc.sh airc.shim lib/airc_bash/*.sh
- bash test/rust_cutover_guard.sh
- AIRC_DIR=<branch-source> AIRC_CORE_BIN=~/.airc/src/target/release/airc-core airc status reports transport health ok for rust-local
- airc inbox no longer emits degraded bearer warnings for local-only operation