### PR TITLE
fix(codex-hook): install source command path

### DIFF
--- a/crates/airc-cli/src/codex_hooks_json.rs
+++ b/crates/airc-cli/src/codex_hooks_json.rs
@@ -1,19 +1,20 @@
 //! Codex hooks.json mutation for AIRC hook installation.
 
 use serde_json::{json, Value};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const HOOK_COMMAND_SUFFIX: &str = "codex-hook user-prompt-submit";
 const HOOK_COMMAND: &str = "airc codex-hook user-prompt-submit";
 const HOOK_STATUS: &str = "Checking AIRC inbox";
 
-pub fn install(path: &Path, _airc_core: &Path) -> Result<bool, Box<dyn std::error::Error>> {
+pub fn install(path: &Path, airc_core: &Path) -> Result<bool, Box<dyn std::error::Error>> {
     let original = read_json(path)?;
     let mut data = ensure_root_object(original);
     let user_prompt = ensure_user_prompt_array(&mut data)?;
     let before = user_prompt.clone();
     remove_managed_hook_entries(user_prompt);
-    user_prompt.push(hook_group(HOOK_COMMAND));
+    let command = hook_command_for(airc_core);
+    user_prompt.push(hook_group(&command));
 
     let changed = *user_prompt != before;
     if changed {
@@ -87,6 +88,49 @@ fn is_managed_hook_command(command: Option<&str>) -> bool {
         return false;
     };
     command == HOOK_COMMAND || command.ends_with(HOOK_COMMAND_SUFFIX)
+}
+
+fn hook_command_for(airc_core: &Path) -> String {
+    source_airc_command_from_core(airc_core)
+        .filter(|airc| airc.is_file())
+        .map(|airc| format!("{} {HOOK_COMMAND_SUFFIX}", shell_quote_path(&airc)))
+        .unwrap_or_else(|| HOOK_COMMAND.to_string())
+}
+
+fn source_airc_command_from_core(airc_core: &Path) -> Option<PathBuf> {
+    // Expected install shape:
+    //   ~/.airc/src/target/release/airc-core
+    //   ~/.airc/src/airc
+    //   ~/.airc/src/airc.cmd        (Windows)
+    //
+    // Cargo test/dev builds use target/debug/airc-core; the same two-level
+    // ascent from target/{profile}/airc-core reaches the source root.
+    let profile_dir = airc_core.parent()?;
+    let target_dir = profile_dir.parent()?;
+    let source_root = target_dir.parent()?;
+    Some(source_root.join(source_airc_filename()))
+}
+
+#[cfg(windows)]
+fn source_airc_filename() -> &'static str {
+    "airc.cmd"
+}
+
+#[cfg(not(windows))]
+fn source_airc_filename() -> &'static str {
+    "airc"
+}
+
+#[cfg(windows)]
+fn shell_quote_path(path: &Path) -> String {
+    let raw = path.display().to_string();
+    format!("\"{}\"", raw.replace('"', "\\\""))
+}
+
+#[cfg(not(windows))]
+fn shell_quote_path(path: &Path) -> String {
+    let raw = path.display().to_string();
+    format!("'{}'", raw.replace('\'', "'\\''"))
 }
 
 fn hook_group(command: &str) -> Value {

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -139,19 +139,13 @@ fn codex_hook_installer_replaces_existing_managed_hook() {
             .expect("hooks json");
     let commands = hook_commands(&hooks);
     assert!(commands.contains(&"echo existing".to_string()));
-    assert!(
-        commands
-            .iter()
-            .any(|command| command.ends_with("codex-hook user-prompt-submit")),
-        "installer must add the public hook command, got {commands:?}"
-    );
+    let managed = managed_hook_commands(&commands);
     assert_eq!(
-        commands
-            .iter()
-            .filter(|command| command.as_str() == "airc codex-hook user-prompt-submit")
-            .count(),
-        1
+        managed.len(),
+        1,
+        "expected one managed hook, got {commands:?}"
     );
+    assert_source_command(&managed[0]);
 }
 
 #[test]
@@ -190,10 +184,8 @@ fn codex_hook_installer_replaces_existing_managed_hook_command() {
         1,
         "install must replace existing managed hook commands, got {commands:?}"
     );
-    assert_eq!(
-        commands,
-        vec!["airc codex-hook user-prompt-submit".to_string()]
-    );
+    assert_eq!(commands.len(), 1, "expected one command, got {commands:?}");
+    assert_source_command(&commands[0]);
 }
 
 #[test]
@@ -337,4 +329,41 @@ fn hook_commands(hooks: &Value) -> Vec<String> {
         .flat_map(|group| group["hooks"].as_array().into_iter().flatten())
         .filter_map(|hook| hook["command"].as_str().map(ToString::to_string))
         .collect()
+}
+
+fn managed_hook_commands(commands: &[String]) -> Vec<String> {
+    commands
+        .iter()
+        .filter(|command| command.ends_with("codex-hook user-prompt-submit"))
+        .cloned()
+        .collect()
+}
+
+fn assert_source_command(command: &str) {
+    assert!(
+        command.ends_with(" codex-hook user-prompt-submit"),
+        "managed hook must call the Codex hook subcommand, got {command:?}"
+    );
+    assert!(
+        command.contains(source_airc_command_fragment()),
+        "managed hook must use the source-installed airc command, got {command:?}"
+    );
+    assert!(
+        !command.starts_with("airc "),
+        "managed hook must not depend on PATH, got {command:?}"
+    );
+    assert!(
+        !command.starts_with("airc-core "),
+        "managed hook must not call airc-core directly, got {command:?}"
+    );
+}
+
+#[cfg(windows)]
+fn source_airc_command_fragment() -> &'static str {
+    "\\airc.cmd\" codex-hook user-prompt-submit"
+}
+
+#[cfg(not(windows))]
+fn source_airc_command_fragment() -> &'static str {
+    "/airc' codex-hook user-prompt-submit"
 }


### PR DESCRIPTION
Summary\n- install Codex hooks with the source-installed airc command instead of PATH-dependent airc\n- resolve airc.cmd on Windows and airc on POSIX from the running airc-core binary\n- tighten installer tests so managed hooks cannot regress to bare airc/airc-core commands\n\nVerification\n- cargo fmt --manifest-path Cargo.toml -p airc-cli --check\n- cargo test --manifest-path Cargo.toml -p airc-cli codex_hook_installer\n- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings