### PR TITLE
fix(msg): distinguish local store from peer delivery

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -99,7 +99,18 @@ pub async fn run_send(
     }
     let current = airc.current_room().await?;
     airc.say(text).await?;
-    println!("sent to {} ({}).", current.name, current.channel);
+    let peer_count = airc.peers().await?.len();
+    if peer_count == 0 {
+        println!(
+            "stored locally in {} ({}) - no enrolled peers; not delivered to another agent.",
+            current.name, current.channel
+        );
+    } else {
+        println!(
+            "sent to {} ({}) for {peer_count} enrolled peer(s).",
+            current.name, current.channel
+        );
+    }
     Ok(())
 }
 
@@ -245,7 +256,18 @@ pub async fn run_msg(
     let airc = Airc::attach(home, socket).await?;
     let current = airc.current_room().await?;
     airc.say(text).await?;
-    println!("sent to {} ({}).", current.name, current.channel);
+    let peer_count = airc.peers().await?.len();
+    if peer_count == 0 {
+        println!(
+            "stored locally in {} ({}) - no enrolled peers; not delivered to another agent.",
+            current.name, current.channel
+        );
+    } else {
+        println!(
+            "sent to {} ({}) for {peer_count} enrolled peer(s).",
+            current.name, current.channel
+        );
+    }
     Ok(())
 }
 

--- a/crates/airc-cli/tests/events_commands.rs
+++ b/crates/airc-cli/tests/events_commands.rs
@@ -46,6 +46,19 @@ fn events_list_filters_by_kind_and_header_prefix() {
     assert!(!output.contains("plain chat"));
 }
 
+#[test]
+fn send_receipt_distinguishes_local_store_from_peer_delivery() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let output = run_ok(&home, &["send", "not delivered to a peer"]);
+
+    assert!(output.contains("stored locally"));
+    assert!(output.contains("no enrolled peers"));
+    assert!(output.contains("not delivered to another agent"));
+}
+
 fn run_ok(home: &Path, args: &[&str]) -> String {
     let output = Command::new(airc_core())
         .arg("--home")


### PR DESCRIPTION
Summary\n- stop reporting local-only writes as peer sends when no peers are enrolled\n- apply the same receipt semantics to send and msg\n- add a CLI regression test for the no-peer local-store path\n\nVerification\n- cargo fmt --manifest-path Cargo.toml -p airc-cli --check\n- cargo test --manifest-path Cargo.toml -p airc-cli send_receipt_distinguishes_local_store_from_peer_delivery\n- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings