### PR TITLE
fix(events): monitor hooks use subscribed channels

### DIFF
--- a/crates/airc-cli/src/codex_commands.rs
+++ b/crates/airc-cli/src/codex_commands.rs
@@ -24,12 +24,15 @@ pub async fn run_user_prompt_submit(
     let cursor_path = cursor_file.unwrap_or_else(|| home.join(DEFAULT_CURSOR_FILENAME));
     let filter = EventFilter {
         kinds: BTreeSet::from([TranscriptKind::Message, TranscriptKind::System]),
-        ..EventFilter::current_room()
+        ..EventFilter::default()
     };
     let previous = read_cursor_if_present(&cursor_path)?;
     let events = match previous {
-        Some(cursor) => airc.resume_from_filtered(&cursor, filter, count).await?,
-        None => airc.page_recent_filtered(filter, count).await?,
+        Some(cursor) => {
+            airc.resume_from_subscribed_filtered(&cursor, filter, count)
+                .await?
+        }
+        None => airc.page_recent_subscribed_filtered(filter, count).await?,
     };
 
     if let Some(newest) = events.last().map(TranscriptEvent::cursor) {

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -32,15 +32,6 @@ use airc_store::{EventStore, SqliteEventStore};
 /// prints the local peer's spec so the user can share it.
 pub async fn run_init(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let airc = Airc::open(home).await?;
-    // Auto-join "default" room on first init so subsequent
-    // `airc msg` / `say` work without explicit room selection.
-    if airc.current_room().await?.name != "default" {
-        // load_or_default returns the synthesised default when
-        // room.json is missing; if a different room name comes back
-        // the user has already joined something — leave it.
-    } else if !airc.home().join("room.json").exists() {
-        airc.join("default").await?;
-    }
     let current = airc.current_room().await?;
     println!("home:        {}", airc.home().display());
     println!("peer_id:     {}", airc.peer_id());

--- a/crates/airc-cli/src/events_commands.rs
+++ b/crates/airc-cli/src/events_commands.rs
@@ -17,9 +17,9 @@ pub async fn run_list(
     let filter = EventFilter {
         kinds: kinds.into_iter().map(TranscriptKind::from).collect(),
         headers_filter: parse_header_filters(exact_headers, prefix_headers)?,
-        ..EventFilter::current_room()
+        ..EventFilter::default()
     };
-    let events = airc.page_recent_filtered(filter, limit).await?;
+    let events = airc.page_recent_subscribed_filtered(filter, limit).await?;
     print_events(&events);
     Ok(())
 }

--- a/crates/airc-cli/src/monitor/attach.rs
+++ b/crates/airc-cli/src/monitor/attach.rs
@@ -13,14 +13,14 @@ pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error
     let airc = Airc::open(home).await?;
     let client_id = current_client_id().ok().flatten();
     let mut stream = airc
-        .subscribe_filtered(EventFilter {
+        .subscribe_subscribed_filtered(EventFilter {
             kinds: BTreeSet::from([TranscriptKind::Message, TranscriptKind::System]),
-            ..EventFilter::current_room()
+            ..EventFilter::default()
         })
         .await?;
     let mut sandbox = Sandbox::new();
 
-    println!("airc: attached to Rust event stream for this scope");
+    println!("airc: attached to Rust event stream for subscribed channels");
     while let Some(item) = stream.next().await {
         match item {
             Ok(event) => render_event(&event, client_id.as_deref(), &mut sandbox),

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -33,10 +33,11 @@ use airc_transport::LanTcpAdapter;
 use tokio::sync::{broadcast, Mutex};
 
 use crate::error::AircError;
-use crate::room::{self, Room};
+use crate::room::Room;
 use crate::route::health::TransportHealthTable;
 use crate::route::invite::{ImportedInviteTable, RouteEndpointTable};
 use crate::route::TransportHealthSample;
+use crate::subscriptions::{self, ChannelName, MeshIdentity, Subscription};
 use crate::transport::{FrameSubscriber, WireSubscriber};
 
 const EVENTS_DB_FILENAME: &str = "events.sqlite";
@@ -251,14 +252,16 @@ impl Airc {
         Ok(())
     }
 
-    /// Switch the current room to one derived from `name`. Same name
-    /// on two peers yields the same channel UUID via UUIDv5, so they
-    /// converge without exchanging the UUID out-of-band. Spawns a
-    /// background subscriber on the new room's wire if one isn't
-    /// already running, so subsequent `say`s land in the store.
+    /// Subscribe to `name` and make it the default channel for
+    /// short-shape commands.
     pub async fn join(&self, name: &str) -> Result<Room, AircError> {
-        let room = Room::from_name(&self.inner.home, name)?;
-        room::save(&self.inner.home, &room)?;
+        let channel = ChannelName::new(name)?;
+        let identity = MeshIdentity::unset();
+        let mut set = subscriptions::load_or_init(&self.inner.home)?;
+        let subscription = set.subscribe(&self.inner.home, &identity, channel.clone())?;
+        set.set_default(channel)?;
+        subscriptions::save(&self.inner.home, &set)?;
+        let room = subscription.as_room();
         self.ensure_wire_subscriber(&room.wire).await?;
         Ok(room)
     }
@@ -268,18 +271,33 @@ impl Airc {
     /// processes on one machine tail the same `frames.jsonl`).
     /// Production users want [`join`].
     pub async fn join_with_wire(&self, name: &str, wire: PathBuf) -> Result<Room, AircError> {
-        let mut room = Room::from_name(&self.inner.home, name)?;
-        room.wire = wire;
-        room::save(&self.inner.home, &room)?;
+        let channel = ChannelName::new(name)?;
+        let identity = MeshIdentity::unset();
+        let mut set = subscriptions::load_or_init(&self.inner.home)?;
+        let subscription = Subscription::with_wire(&identity, channel.clone(), wire)?;
+        set.parted.remove(&channel);
+        set.subscribed.insert(channel.clone(), subscription.clone());
+        set.set_default(channel)?;
+        subscriptions::save(&self.inner.home, &set)?;
+        let room = subscription.as_room();
         self.ensure_wire_subscriber(&room.wire).await?;
         Ok(room)
     }
 
-    /// Read the persisted current room. Returns the default room
-    /// (synthesised on the fly, NOT persisted) if no `room.json`
-    /// has been written yet.
+    /// Read the default subscribed channel. Fresh scopes default to
+    /// `#general` through the subscription set.
     pub async fn current_room(&self) -> Result<Room, AircError> {
-        Ok(room::load_or_default(&self.inner.home)?)
+        let mut set = subscriptions::load_or_init(&self.inner.home)?;
+        if let Some(subscription) = set.default_subscription() {
+            return Ok(subscription.as_room());
+        }
+
+        let identity = MeshIdentity::unset();
+        let channel = ChannelName::new("general")?;
+        let subscription = set.subscribe(&self.inner.home, &identity, channel.clone())?;
+        set.set_default(channel)?;
+        subscriptions::save(&self.inner.home, &set)?;
+        Ok(subscription.as_room())
     }
 
     pub(crate) fn event_store(&self) -> &dyn EventStore {

--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -25,6 +25,12 @@ pub enum AircError {
     #[error("room state: {0}")]
     Room(#[from] crate::room::RoomError),
 
+    #[error("subscription state: {0}")]
+    Subscription(#[from] crate::subscriptions::SubscriptionError),
+
+    #[error("channel name: {0}")]
+    ChannelName(#[from] crate::subscriptions::ChannelNameError),
+
     #[error("system clock before UNIX_EPOCH: {0}")]
     Clock(#[from] std::time::SystemTimeError),
 

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -111,6 +111,23 @@ impl Airc {
         })
     }
 
+    /// Subscribe to live events from all subscribed rooms. This is
+    /// the monitor/hook surface: no hidden narrowing to current room.
+    pub async fn subscribe_subscribed_filtered(
+        &self,
+        filter: EventFilter,
+    ) -> Result<FilteredEventStream, AircError> {
+        let filter = self.subscribed_event_filter(filter).await?;
+        let rx = self.inner.live_tx.subscribe();
+        self.ensure_subscribed_room_subscribers().await?;
+        Ok(FilteredEventStream {
+            inner: EventStream {
+                inner: BroadcastStream::new(rx),
+            },
+            filter,
+        })
+    }
+
     /// Fetch the most recent `limit` events from the current room.
     pub async fn page_recent(&self, limit: usize) -> Result<Vec<TranscriptEvent>, AircError> {
         let room = self.current_room().await?;
@@ -134,6 +151,24 @@ impl Airc {
     ) -> Result<Vec<TranscriptEvent>, AircError> {
         let filter = self.scope_filter_to_current_room(filter).await?;
         self.ensure_current_room_subscriber().await?;
+        Ok(self
+            .inner
+            .store
+            .page_recent(filter.channel, limit)
+            .await?
+            .into_iter()
+            .filter(|event| filter.matches(event))
+            .collect())
+    }
+
+    /// Fetch recent events from the subscribed room set.
+    pub async fn page_recent_subscribed_filtered(
+        &self,
+        filter: EventFilter,
+        limit: usize,
+    ) -> Result<Vec<TranscriptEvent>, AircError> {
+        let filter = self.subscribed_event_filter(filter).await?;
+        self.ensure_subscribed_room_subscribers().await?;
         Ok(self
             .inner
             .store
@@ -171,6 +206,24 @@ impl Airc {
         limit: usize,
     ) -> Result<Vec<TranscriptEvent>, AircError> {
         let filter = self.scope_filter_to_current_room(filter).await?;
+        Ok(self
+            .inner
+            .store
+            .resume_from(cursor, filter.channel, limit)
+            .await?
+            .into_iter()
+            .filter(|event| filter.matches(event))
+            .collect())
+    }
+
+    /// Fetch events strictly after `cursor` from the subscribed room set.
+    pub async fn resume_from_subscribed_filtered(
+        &self,
+        cursor: &TranscriptCursor,
+        filter: EventFilter,
+        limit: usize,
+    ) -> Result<Vec<TranscriptEvent>, AircError> {
+        let filter = self.subscribed_event_filter(filter).await?;
         Ok(self
             .inner
             .store

--- a/crates/airc-lib/src/room.rs
+++ b/crates/airc-lib/src/room.rs
@@ -1,10 +1,5 @@
-//! Current-room persistence — the default `(wire, channel)` for
-//! short-shape commands like `airc msg "hi"` and `airc inbox`.
-//!
-//! AI peers (and humans) shouldn't have to type `--wire <path>
-//! --channel <uuid>` on every call. Joining a room writes
-//! `<home>/room.json` once; every subsequent command reads it.
-//! `airc join <name>` switches.
+//! Room value type — the substrate expansion of a channel name into
+//! a wire path and channel id.
 //!
 //! A "room" is a name. The substrate primitives it expands to are
 //! deterministic:
@@ -22,7 +17,6 @@ use uuid::Uuid;
 
 use airc_core::RoomId;
 
-const ROOM_FILENAME: &str = "room.json";
 const ROOM_VERSION: u32 = 1;
 const DEFAULT_ROOM_NAME: &str = "default";
 
@@ -33,29 +27,16 @@ const ROOM_NAMESPACE: Uuid = Uuid::from_bytes([
     0xa1, 0xc2, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
 ]);
 
-/// What can go wrong loading / saving the current room.
+/// What can go wrong constructing a room value.
 #[derive(Debug)]
 pub enum RoomError {
-    Io(std::io::Error),
-    Json(serde_json::Error),
     Clock(std::time::SystemTimeError),
-    /// Schema version mismatch — refuse to misinterpret old / future
-    /// room files.
-    SchemaVersionMismatch {
-        found: u32,
-        expected: u32,
-    },
 }
 
 impl std::fmt::Display for RoomError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RoomError::Io(error) => write!(f, "room I/O: {error}"),
-            RoomError::Json(error) => write!(f, "room JSON: {error}"),
             RoomError::Clock(error) => write!(f, "room timestamp clock error: {error}"),
-            RoomError::SchemaVersionMismatch { found, expected } => {
-                write!(f, "room.json version {found}, expected {expected}")
-            }
         }
     }
 }
@@ -63,23 +44,8 @@ impl std::fmt::Display for RoomError {
 impl std::error::Error for RoomError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            RoomError::Io(error) => Some(error),
-            RoomError::Json(error) => Some(error),
             RoomError::Clock(error) => Some(error),
-            RoomError::SchemaVersionMismatch { .. } => None,
         }
-    }
-}
-
-impl From<std::io::Error> for RoomError {
-    fn from(error: std::io::Error) -> Self {
-        RoomError::Io(error)
-    }
-}
-
-impl From<serde_json::Error> for RoomError {
-    fn from(error: serde_json::Error) -> Self {
-        RoomError::Json(error)
     }
 }
 
@@ -89,13 +55,12 @@ impl From<std::time::SystemTimeError> for RoomError {
     }
 }
 
-/// The current room — what `airc msg` / `inbox` / `send` /
-/// `listen` default to.
+/// A channel's concrete substrate location.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Room {
     /// Schema version.
     pub version: u32,
-    /// Human-readable room name. `default` on fresh init.
+    /// Human-readable room name.
     pub name: String,
     /// Wire directory for this room.
     pub wire: PathBuf,
@@ -128,40 +93,6 @@ impl Room {
     }
 }
 
-/// Path to `<home>/room.json`.
-pub fn path_in(home: &Path) -> PathBuf {
-    home.join(ROOM_FILENAME)
-}
-
-/// Load the current room. Falls back to the default room (`name =
-/// "default"`) if `<home>/room.json` doesn't exist yet — this is
-/// the normal state for a fresh install.
-pub fn load_or_default(home: &Path) -> Result<Room, RoomError> {
-    let path = path_in(home);
-    if !path.exists() {
-        return Room::default_for(home);
-    }
-    let text = std::fs::read_to_string(&path)?;
-    let room: Room = serde_json::from_str(&text)?;
-    if room.version != ROOM_VERSION {
-        return Err(RoomError::SchemaVersionMismatch {
-            found: room.version,
-            expected: ROOM_VERSION,
-        });
-    }
-    Ok(room)
-}
-
-/// Save the current room (overwriting any previous one).
-pub fn save(home: &Path, room: &Room) -> Result<(), RoomError> {
-    std::fs::create_dir_all(home)?;
-    let path = path_in(home);
-    let text = serde_json::to_string_pretty(room)?;
-    std::fs::write(&path, text)?;
-    set_owner_only_permissions(&path)?;
-    Ok(())
-}
-
 /// Sanitise a room name into a path-safe directory component. ASCII
 /// alphanumerics + `-` + `_` survive; everything else becomes `-`.
 /// Multiple names can collide post-sanitisation (`foo/bar` and
@@ -176,19 +107,6 @@ fn sanitise_name(name: &str) -> String {
             }
         })
         .collect()
-}
-
-#[cfg(unix)]
-fn set_owner_only_permissions(path: &Path) -> std::io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    let mut perms = std::fs::metadata(path)?.permissions();
-    perms.set_mode(0o600);
-    std::fs::set_permissions(path, perms)
-}
-
-#[cfg(not(unix))]
-fn set_owner_only_permissions(_path: &Path) -> std::io::Result<()> {
-    Ok(())
 }
 
 fn now_ms() -> Result<u64, std::time::SystemTimeError> {

--- a/crates/airc-lib/src/room/tests.rs
+++ b/crates/airc-lib/src/room/tests.rs
@@ -21,41 +21,7 @@ fn from_name_differs_per_name() {
 }
 
 #[test]
-fn load_or_default_returns_default_when_missing() {
-    let home = TempDir::new().unwrap();
-    let room = load_or_default(home.path()).unwrap();
-    assert_eq!(room.name, "default");
-}
-
-#[test]
-fn save_then_load_roundtrips() {
-    let home = TempDir::new().unwrap();
-    let original = Room::from_name(home.path(), "test-room").unwrap();
-    save(home.path(), &original).unwrap();
-    let loaded = load_or_default(home.path()).unwrap();
-    assert_eq!(loaded.name, original.name);
-    assert_eq!(loaded.channel, original.channel);
-    assert_eq!(loaded.wire, original.wire);
-}
-
-#[test]
 fn sanitise_replaces_path_separators() {
     assert_eq!(sanitise_name("../etc/passwd"), "---etc-passwd");
     assert_eq!(sanitise_name("normal-name_42"), "normal-name_42");
-}
-
-#[test]
-fn refuses_unknown_schema_version() {
-    let home = TempDir::new().unwrap();
-    std::fs::create_dir_all(home.path()).unwrap();
-    std::fs::write(
-        path_in(home.path()),
-        r#"{"version":999,"name":"x","wire":"/tmp","channel":"00000000-0000-0000-0000-000000000000","joined_at_ms":0}"#,
-    )
-    .unwrap();
-    let result = load_or_default(home.path());
-    assert!(matches!(
-        result,
-        Err(RoomError::SchemaVersionMismatch { found: 999, .. })
-    ));
 }

--- a/crates/airc-lib/src/stream.rs
+++ b/crates/airc-lib/src/stream.rs
@@ -55,6 +55,7 @@ impl std::error::Error for LiveLag {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EventFilter {
     pub channel: Option<RoomId>,
+    pub channels: Vec<RoomId>,
     pub kinds: BTreeSet<TranscriptKind>,
     pub headers_filter: HeaderFilter,
 }
@@ -63,6 +64,7 @@ impl Default for EventFilter {
     fn default() -> Self {
         Self {
             channel: None,
+            channels: Vec::new(),
             kinds: BTreeSet::new(),
             headers_filter: HeaderFilter::Any,
         }
@@ -79,6 +81,9 @@ impl EventFilter {
             if event.room_id != channel {
                 return false;
             }
+        }
+        if !self.channels.is_empty() && !self.channels.contains(&event.room_id) {
+            return false;
         }
         if !self.kinds.is_empty() && !self.kinds.contains(&event.kind) {
             return false;

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -1,15 +1,7 @@
 //! Channel-subscription set — the multi-channel model the account-mesh
 //! join contract requires.
 //!
-//! Replaces (atop, not yet under) the single-room
-//! [`crate::room::Room`] model. The old shape persisted exactly one
-//! `(name, RoomId, wire)` in `<home>/room.json`; switching channels
-//! meant overwriting it, so a scope could only ever see one channel's
-//! traffic. That's wrong for monitors and hooks: a scope subscribed to
-//! `#general` AND `#cambriantech` needs to surface events from both
-//! simultaneously.
-//!
-//! The new shape is the **subscription set** — an ordered list of
+//! The shape is the **subscription set** — an ordered list of
 //! channels this scope is subscribed to, plus a "default" pointer for
 //! short-shape commands (`airc msg "hi"`) and a "parted" set so we
 //! don't auto-resubscribe to a channel the user explicitly left when
@@ -27,18 +19,9 @@
 //! identity is supplied by the caller; a follow-up wires it to
 //! `gh api user --jq .login` via the machine-global coordinator.
 //!
-//! Defaulting `identity = ""` reproduces the pre-existing name-only
-//! derivation in `room::Room::from_name` for back-compat during the
-//! migration window.
-//!
 //! ## Storage
 //!
-//! Persisted to `<home>/subscriptions.json`. Schema version 1. On
-//! first load, if `subscriptions.json` is absent but `room.json`
-//! exists, the legacy single-room file is converted to a one-entry
-//! `SubscriptionSet` and saved alongside it (the room file stays for
-//! callers still using [`crate::Airc::current_room`] until the next
-//! slice removes them).
+//! Persisted to `<home>/subscriptions.json`. Schema version 1.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -48,15 +31,16 @@ use uuid::Uuid;
 
 use airc_core::RoomId;
 
-use crate::room::{self, Room, RoomError};
+use crate::error::AircError;
+use crate::room::Room;
+use crate::stream::EventFilter;
+use crate::Airc;
 
 const SUBSCRIPTIONS_FILENAME: &str = "subscriptions.json";
 const SUBSCRIPTIONS_VERSION: u32 = 1;
 
 /// Namespace UUID for deriving channel UUIDs from
-/// `(mesh_identity, channel_name)`. Distinct from `room::ROOM_NAMESPACE`
-/// (which was name-only) so the new derivation can coexist with legacy
-/// rooms during migration without ambiguous collisions.
+/// `(mesh_identity, channel_name)`.
 const SUBSCRIPTIONS_NAMESPACE: Uuid = Uuid::from_bytes([
     0xa1, 0xc2, 0x00, 0x01, 0x00, 0x00, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
 ]);
@@ -69,7 +53,6 @@ pub enum SubscriptionError {
     Clock(std::time::SystemTimeError),
     SchemaVersionMismatch { found: u32, expected: u32 },
     InvalidChannelName(ChannelNameError),
-    Room(RoomError),
 }
 
 impl std::fmt::Display for SubscriptionError {
@@ -82,7 +65,6 @@ impl std::fmt::Display for SubscriptionError {
                 write!(f, "subscriptions.json version {found}, expected {expected}")
             }
             Self::InvalidChannelName(error) => write!(f, "invalid channel name: {error}"),
-            Self::Room(error) => write!(f, "subscriptions room migration: {error}"),
         }
     }
 }
@@ -95,7 +77,6 @@ impl std::error::Error for SubscriptionError {
             Self::Clock(error) => Some(error),
             Self::SchemaVersionMismatch { .. } => None,
             Self::InvalidChannelName(error) => Some(error),
-            Self::Room(error) => Some(error),
         }
     }
 }
@@ -121,12 +102,6 @@ impl From<std::time::SystemTimeError> for SubscriptionError {
 impl From<ChannelNameError> for SubscriptionError {
     fn from(value: ChannelNameError) -> Self {
         Self::InvalidChannelName(value)
-    }
-}
-
-impl From<RoomError> for SubscriptionError {
-    fn from(value: RoomError) -> Self {
-        Self::Room(value)
     }
 }
 
@@ -224,8 +199,7 @@ impl MeshIdentity {
         &self.0
     }
 
-    /// Sentinel for callers that don't yet have a real identity (e.g.,
-    /// unit tests, the migration path during the transition window).
+    /// Sentinel for callers that don't yet have a real identity.
     /// Returns a deterministic empty identity.
     pub fn unset() -> Self {
         Self(String::new())
@@ -264,6 +238,14 @@ impl Subscription {
         name: ChannelName,
     ) -> Result<Self, SubscriptionError> {
         let wire = home.join("wires").join(name.as_str());
+        Self::with_wire(identity, name, wire)
+    }
+
+    pub fn with_wire(
+        identity: &MeshIdentity,
+        name: ChannelName,
+        wire: PathBuf,
+    ) -> Result<Self, SubscriptionError> {
         let room_id = derive_room_id(identity, &name);
         Ok(Self {
             name,
@@ -271,6 +253,16 @@ impl Subscription {
             wire,
             joined_at_ms: now_ms()?,
         })
+    }
+
+    pub fn as_room(&self) -> Room {
+        Room {
+            version: 1,
+            name: self.name.as_str().to_string(),
+            wire: self.wire.clone(),
+            channel: self.room_id,
+            joined_at_ms: self.joined_at_ms,
+        }
     }
 }
 
@@ -381,11 +373,8 @@ pub fn path_in(home: &Path) -> PathBuf {
     home.join(SUBSCRIPTIONS_FILENAME)
 }
 
-/// Load the subscription set. If `subscriptions.json` is missing but
-/// `room.json` exists, migrate the single legacy room into a
-/// one-entry subscription set and persist. If neither exists, return
-/// an empty set (not persisted — caller decides whether to seed via
-/// `join_default_context`).
+/// Load the subscription set. If it does not exist yet, return an
+/// empty set; callers decide how to seed it.
 pub fn load_or_init(home: &Path) -> Result<SubscriptionSet, SubscriptionError> {
     let path = path_in(home);
     if path.exists() {
@@ -397,15 +386,6 @@ pub fn load_or_init(home: &Path) -> Result<SubscriptionSet, SubscriptionError> {
                 expected: SUBSCRIPTIONS_VERSION,
             });
         }
-        return Ok(set);
-    }
-
-    // Migration path: legacy room.json present, no subscriptions.json.
-    let room_path = room::path_in(home);
-    if room_path.exists() {
-        let legacy = room::load_or_default(home)?;
-        let set = from_legacy_room(&legacy)?;
-        save(home, &set)?;
         return Ok(set);
     }
 
@@ -424,31 +404,82 @@ pub fn save(home: &Path, set: &SubscriptionSet) -> Result<(), SubscriptionError>
     Ok(())
 }
 
-/// Convert a legacy `Room` into a single-entry `SubscriptionSet`.
-/// The legacy room is preserved verbatim (same wire path and
-/// `joined_at_ms`); only the `RoomId` is re-derived via the new
-/// `(MeshIdentity::unset(), name)` derivation so the migrated entry
-/// is observable by the new derivation path. Old name-only `RoomId`s
-/// from `Room::from_name` won't equal the new ones — which is the
-/// point: the new derivation namespaces by identity, so legacy single-
-/// room scopes get a fresh per-identity `RoomId` on migration. The
-/// transition window's existing in-flight events still live under the
-/// legacy `RoomId`; new sends route to the new one. Joel acknowledged
-/// this discontinuity is acceptable — the rewrite is a clean break.
-pub fn from_legacy_room(legacy: &Room) -> Result<SubscriptionSet, SubscriptionError> {
-    let name = ChannelName::new(&legacy.name)?;
-    let identity = MeshIdentity::unset();
-    let room_id = derive_room_id(&identity, &name);
-    let sub = Subscription {
-        name: name.clone(),
-        room_id,
-        wire: legacy.wire.clone(),
-        joined_at_ms: legacy.joined_at_ms,
-    };
-    let mut set = SubscriptionSet::empty();
-    set.subscribed.insert(name.clone(), sub);
-    set.default = Some(name);
-    Ok(set)
+impl Airc {
+    /// Load this scope's subscription set for consumer surfaces.
+    pub async fn subscription_set(&self) -> Result<SubscriptionSet, AircError> {
+        Ok(load_or_init(&self.inner.home)?)
+    }
+
+    pub(crate) async fn subscribed_event_filter(
+        &self,
+        mut filter: EventFilter,
+    ) -> Result<EventFilter, AircError> {
+        if filter.channel.is_some() || !filter.channels.is_empty() {
+            return Ok(filter);
+        }
+        filter.channels = self.subscribed_room_ids().await?;
+        Ok(filter)
+    }
+
+    pub(crate) async fn ensure_subscribed_room_subscribers(&self) -> Result<(), AircError> {
+        for wire in self.subscribed_wires().await? {
+            self.ensure_wire_subscriber(&wire).await?;
+        }
+        Ok(())
+    }
+
+    async fn subscribed_room_ids(&self) -> Result<Vec<RoomId>, AircError> {
+        let mut room_ids = Vec::new();
+        let set = self.subscription_set().await?;
+        for subscription in set.all() {
+            push_unique(&mut room_ids, subscription.room_id);
+        }
+
+        if room_ids.is_empty() {
+            push_unique(
+                &mut room_ids,
+                Subscription::new(
+                    &self.inner.home,
+                    &MeshIdentity::unset(),
+                    ChannelName::new("general").map_err(SubscriptionError::from)?,
+                )?
+                .room_id,
+            );
+        }
+        Ok(room_ids)
+    }
+
+    async fn subscribed_wires(&self) -> Result<Vec<PathBuf>, AircError> {
+        let mut wires = Vec::new();
+        let set = self.subscription_set().await?;
+        for subscription in set.all() {
+            push_unique_path(&mut wires, subscription.wire.clone());
+        }
+        if wires.is_empty() {
+            push_unique_path(
+                &mut wires,
+                Subscription::new(
+                    &self.inner.home,
+                    &MeshIdentity::unset(),
+                    ChannelName::new("general").map_err(SubscriptionError::from)?,
+                )?
+                .wire,
+            );
+        }
+        Ok(wires)
+    }
+}
+
+fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
+    if !items.contains(&item) {
+        items.push(item);
+    }
+}
+
+fn push_unique_path(items: &mut Vec<PathBuf>, item: PathBuf) {
+    if !items.contains(&item) {
+        items.push(item);
+    }
 }
 
 #[cfg(unix)]
@@ -608,6 +639,35 @@ mod tests {
     }
 
     #[test]
+    fn subscribe_accepts_arbitrary_user_and_domain_channels() {
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+        let id = MeshIdentity::new("joelteply");
+        let mut set = SubscriptionSet::empty();
+
+        for name in [
+            "continuum-activity-7",
+            "openclaw-workspace_alpha",
+            "useideem",
+            "friend-general",
+            "forge-lora-slots",
+        ] {
+            set.subscribe(home, &id, ChannelName::new(name).unwrap())
+                .unwrap();
+        }
+
+        let names = set
+            .channel_names()
+            .map(ChannelName::as_str)
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"continuum-activity-7"));
+        assert!(names.contains(&"openclaw-workspace_alpha"));
+        assert!(names.contains(&"useideem"));
+        assert!(names.contains(&"friend-general"));
+        assert!(names.contains(&"forge-lora-slots"));
+    }
+
+    #[test]
     fn unsubscribe_marks_parted_and_falls_back_default() {
         let dir = tempdir().unwrap();
         let home = dir.path();
@@ -669,27 +729,6 @@ mod tests {
 
         let loaded = load_or_init(home).unwrap();
         assert_eq!(loaded, set);
-    }
-
-    #[test]
-    fn migrate_from_legacy_room_when_subscriptions_absent() {
-        let dir = tempdir().unwrap();
-        let home = dir.path();
-
-        // Seed the legacy room.json directly.
-        let legacy = Room::from_name(home, "default").unwrap();
-        room::save(home, &legacy).unwrap();
-        assert!(room::path_in(home).exists());
-        assert!(!path_in(home).exists());
-
-        let set = load_or_init(home).unwrap();
-        assert!(path_in(home).exists(), "migration must persist the set");
-        assert_eq!(set.subscribed.len(), 1);
-        let migrated = set.subscribed.values().next().unwrap();
-        assert_eq!(migrated.name.as_str(), "default");
-        assert_eq!(migrated.wire, legacy.wire);
-        assert_eq!(migrated.joined_at_ms, legacy.joined_at_ms);
-        assert_eq!(set.default.as_ref().unwrap().as_str(), "default");
     }
 
     #[test]

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -11,8 +11,9 @@ use std::{net::SocketAddr, time::Duration};
 
 use airc_daemon::{DaemonState, LocalIdentity};
 use airc_lib::{
-    Airc, Body, EventFilter, HeaderFilter, Headers, PeerSpec, RouteEndpoint, TranscriptKind,
-    TransportHealthSample, TransportKind, TransportRole,
+    subscriptions, Airc, Body, ChannelName, EventFilter, HeaderFilter, Headers, MeshIdentity,
+    PeerSpec, RouteEndpoint, SubscriptionSet, TranscriptKind, TransportHealthSample, TransportKind,
+    TransportRole,
 };
 use airc_protocol::{PeerKeyRegistry, VerificationPolicy};
 use airc_store::{EventStore, SqliteEventStore};
@@ -110,7 +111,10 @@ async fn open_join_say_and_replay_round_trips_in_process() {
     let room = airc.join("project-x").await.unwrap();
     assert_eq!(room.name, "project-x");
     let current = airc.current_room().await.unwrap();
-    assert_eq!(current.channel, room.channel, "join persisted to room.json");
+    assert_eq!(
+        current.channel, room.channel,
+        "join persisted to the subscription set"
+    );
 
     let _event_id = airc.say("hello, consumer").await.unwrap();
 
@@ -221,7 +225,7 @@ async fn peer_spec_round_trips_via_add_peer() {
 #[tokio::test]
 async fn open_is_idempotent_across_handles() {
     // Two Airc::open calls on the same home recover the same
-    // identity (and the same DB without migration conflicts).
+    // identity and event store.
     let home = TempDir::new().unwrap();
     let first = Airc::open(home.path()).await.unwrap();
     let first_peer = first.peer_id();
@@ -416,4 +420,47 @@ async fn filtered_event_queries_match_kind_and_headers_without_body_parse() {
         matches[0].body.as_ref().and_then(Body::as_text),
         Some("persona turn payload")
     );
+}
+
+#[tokio::test]
+async fn subscribed_filter_reads_all_configured_channels_not_current_room_only() {
+    let home = TempDir::new().unwrap();
+    let identity = MeshIdentity::unset();
+    let mut subscription_set = SubscriptionSet::empty();
+    subscription_set
+        .subscribe(home.path(), &identity, ChannelName::new("general").unwrap())
+        .unwrap();
+    subscription_set
+        .subscribe(
+            home.path(),
+            &identity,
+            ChannelName::new("cambriantech").unwrap(),
+        )
+        .unwrap();
+    subscriptions::save(home.path(), &subscription_set).unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+
+    airc.join("general").await.unwrap();
+    airc.say("general lobby message").await.unwrap();
+    wait_for_text(&airc, "general lobby message", Duration::from_secs(2)).await;
+
+    airc.join("cambriantech").await.unwrap();
+    airc.say("project room message").await.unwrap();
+    wait_for_text(&airc, "project room message", Duration::from_secs(2)).await;
+
+    let filter = EventFilter {
+        kinds: std::collections::BTreeSet::from([TranscriptKind::Message]),
+        ..EventFilter::default()
+    };
+    let events = airc
+        .page_recent_subscribed_filtered(filter, 32)
+        .await
+        .unwrap();
+    let texts = events
+        .iter()
+        .filter_map(|event| event.body.as_ref().and_then(Body::as_text))
+        .collect::<Vec<_>>();
+
+    assert!(texts.contains(&"general lobby message"));
+    assert!(texts.contains(&"project room message"));
 }

--- a/crates/examples/consumer_shapes/src/continuum.rs
+++ b/crates/examples/consumer_shapes/src/continuum.rs
@@ -208,6 +208,7 @@ pub fn decode_persona_event(
 pub fn any_persona_event_filter() -> EventFilter {
     EventFilter {
         channel: None,
+        channels: Vec::new(),
         kinds: BTreeSet::new(),
         headers_filter: HeaderFilter::Exact {
             key: HEADER_FORGE_BODY_HINT.to_string(),
@@ -221,6 +222,7 @@ pub fn any_persona_event_filter() -> EventFilter {
 pub fn activity_event_filter(activity_id: &str) -> EventFilter {
     EventFilter {
         channel: None,
+        channels: Vec::new(),
         kinds: BTreeSet::new(),
         headers_filter: HeaderFilter::All(vec![
             HeaderFilter::Exact {

--- a/crates/examples/consumer_shapes/src/hermes.rs
+++ b/crates/examples/consumer_shapes/src/hermes.rs
@@ -171,6 +171,7 @@ pub fn decode_hermes_event(
 pub fn any_hermes_event_filter() -> EventFilter {
     EventFilter {
         channel: None,
+        channels: Vec::new(),
         kinds: BTreeSet::new(),
         headers_filter: HeaderFilter::Exact {
             key: HEADER_FORGE_BODY_HINT.to_string(),
@@ -185,6 +186,7 @@ pub fn any_hermes_event_filter() -> EventFilter {
 pub fn agent_event_filter(agent_id: &str) -> EventFilter {
     EventFilter {
         channel: None,
+        channels: Vec::new(),
         kinds: BTreeSet::new(),
         headers_filter: HeaderFilter::All(vec![
             HeaderFilter::Exact {

--- a/crates/examples/consumer_shapes/src/openclaw.rs
+++ b/crates/examples/consumer_shapes/src/openclaw.rs
@@ -172,6 +172,7 @@ pub fn decode_openclaw_event(
 pub fn any_openclaw_event_filter() -> EventFilter {
     EventFilter {
         channel: None,
+        channels: Vec::new(),
         kinds: BTreeSet::new(),
         headers_filter: HeaderFilter::Exact {
             key: HEADER_FORGE_BODY_HINT.to_string(),
@@ -184,6 +185,7 @@ pub fn any_openclaw_event_filter() -> EventFilter {
 pub fn workspace_event_filter(workspace_id: &str) -> EventFilter {
     EventFilter {
         channel: None,
+        channels: Vec::new(),
         kinds: BTreeSet::new(),
         headers_filter: HeaderFilter::All(vec![
             HeaderFilter::Exact {

--- a/crates/examples/embedded_consumer_smoke/src/agent.rs
+++ b/crates/examples/embedded_consumer_smoke/src/agent.rs
@@ -86,6 +86,7 @@ impl AgentConsumer {
         kinds.insert(TranscriptKind::Message);
         let filter = EventFilter {
             channel: None,
+            channels: Vec::new(),
             kinds,
             headers_filter: HeaderFilter::Exact {
                 key: HEADER_AGENT_KIND.to_string(),
@@ -107,6 +108,7 @@ impl AgentConsumer {
         kinds.insert(TranscriptKind::Message);
         let filter = EventFilter {
             channel: None,
+            channels: Vec::new(),
             kinds,
             headers_filter: HeaderFilter::Exact {
                 key: HEADER_AGENT_KIND.to_string(),

--- a/docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md
+++ b/docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md
@@ -1,0 +1,291 @@
+# AIRC Account Mesh Join Contract
+
+**Status:** required contract for rust-rewrite
+**Date:** 2026-05-20
+
+## Decision
+
+`airc join` means: enter the account-wide mesh for the current Git/GitHub user
+identity, then subscribe this scope to the default channels for the current
+context.
+
+It does not mean "join one isolated local room." It does not require a user to
+paste an invite when another agent on the same Git/GitHub user account already
+has a live mesh. It does not make `#general` and the project channel mutually
+exclusive.
+
+The old system's useful behavior was:
+
+- every agent, tab, terminal, and machine on Joel's Git/GitHub account could
+  meet in the same `#general`;
+- every CambrianTech repo on any of Joel's machines joined the same
+  `#cambriantech` room;
+- every Ideem repo on any of Joel's machines joined the same `#ideem` room;
+- the account identity, not the machine, was the room namespace;
+- a single running monitor could surface traffic from all subscribed channels;
+- `airc join` was the normal recovery and convergence verb.
+
+The Rust rewrite must preserve that contract while replacing the brittle
+Python/shell/GitHub data plane.
+
+## Concepts
+
+### Install And State Layout
+
+AIRC has one public command name: `airc`. The Rust rewrite must not expose a
+parallel `airc-rs` product surface, require users to remember which binary is
+new, or let different wrappers point at different builds.
+
+The install layout is:
+
+```text
+~/.airc/
+  src/                 source checkout for the installed AIRC build
+  worktrees/           managed agent/development worktrees and leases
+  accounts/            account-mesh coordinator/cache state
+  scopes/              optional per-scope runtime state when needed
+```
+
+Project-local `.airc/` directories may exist for project scope state, but they
+must not replace the account-wide coordinator under `~/.airc`.
+
+Forbidden install shapes:
+
+- `~/.airc-src` as a second hidden source checkout;
+- `~/.airc-worktrees` as a parallel worktree root;
+- stale `airc-rs` binaries or user-facing symlinks;
+- wrappers that silently fall back to an older installed binary;
+- test-only environment variables as the normal user path.
+
+The installer may place a tiny PATH shim if the OS requires it, but the shim
+must resolve to the canonical installed source command in `~/.airc/src/airc`
+or the canonical built artifact for that exact source checkout. It must fail
+loudly if resolution is ambiguous. It must not search arbitrary old install
+locations.
+
+For version 1 there is no legacy runtime surface. Old Python, shell, gist-chat,
+and `airc-rs` compatibility paths should be deleted when their Rust
+replacement exists. If a fresh install would never create a file or symlink,
+the runtime should not contain code to keep using it.
+
+### Account Mesh
+
+An account mesh is the discovery namespace shared by all machines, tabs,
+terminals, and agents authenticated as the same Git/GitHub user identity. In
+the old implementation, GitHub gists accidentally provided this namespace:
+"same GitHub account" meant "same canonical channel registry."
+
+Rust must make this explicit. A mesh registry maps:
+
+```text
+git user identity + channel name -> channel beacon / route candidates / trust data
+```
+
+GitHub may publish that registry for remote bootstrap across the user's
+machines. Local state, LAN discovery, Tailscale, relay, WebRTC, Reticulum, and
+future adapters may publish or mirror the same registry. Consumers do not see
+different semantics per transport.
+
+### Machine-Global Coordinator
+
+Every machine needs one local coordinator/cache per Git/GitHub user identity.
+It is the machine's shared memory for account-mesh discovery.
+
+The first tab/terminal/agent on a machine that runs `airc join` may need to pay
+the rare remote-registry cost: refresh the GitHub-published account mesh,
+publish this machine's signed beacon, and probe direct routes. After that, the
+result is machine-global state under `~/.airc`; other local scopes attach to
+the coordinator/cache and must not independently hammer GitHub.
+
+This is the hierarchy:
+
+1. in-process state;
+2. machine-global coordinator/cache for this Git user identity;
+3. direct route health: local, LAN, Tailscale, relay, WebRTC, Reticulum;
+4. rare GitHub registry refresh/publish when the machine cache is stale,
+   missing, or explicitly repaired.
+
+The coordinator owns debounce/singleflight/backoff. Ten local agents starting
+at once should produce at most one remote registry refresh, then all ten attach
+to the same machine-local truth.
+
+### Channels
+
+Channels are logical subscriptions inside the account mesh. `#general` is the
+common account lobby across all of the user's machines. The inferred org/project
+channel, for example `#cambriantech` or `#ideem`, is the work channel shared by
+all repos in that organization/project namespace.
+
+A scope can be in many channels at once. The channel set is first-class state,
+not a side effect of a "current room" file.
+
+The current/default channel is only the target for short commands like
+`airc msg "hi"` when the caller does not specify a channel. It must not be the
+only channel the monitor, hooks, or event subsystem can see.
+
+### Join
+
+Bare `airc join` should:
+
+1. Load or create the local identity for this scope.
+2. Ask the machine-global coordinator for the current Git/GitHub user
+   identity's account mesh. The coordinator uses cached local truth when fresh
+   and performs at most one rare remote registry refresh when stale.
+3. Infer the project/org channel from the current repository.
+4. Subscribe to both:
+   - `#general`, unless the user explicitly parted it;
+   - the inferred org/project channel, when one exists.
+5. Start or attach to the scope's event stream.
+6. Monitor all subscribed channels.
+
+`airc join --room X` adds or promotes `#X` as a subscription. It must not make
+the process deaf to the other subscribed channels.
+
+`airc part` removes a channel subscription. It does not delete identity or
+destroy the whole account mesh.
+
+## Monitor And Hooks
+
+Monitor and hook delivery must consume the same Rust event-subscription
+surface:
+
+```text
+subscribe(scope, filter = subscribed_channels + event/header filters)
+resume_from(scope, cursor, filter = subscribed_channels + event/header filters)
+page_recent(scope, filter = subscribed_channels + event/header filters)
+```
+
+Using `current_room` as the implicit filter is wrong for monitor and hook
+surfaces. It hides `#general` when the current channel is `#cambriantech`, and
+it hides project traffic when the current channel is `#general`.
+
+For Continuum, OpenClaw, Hermes, and other consumers, this is the same model:
+an activity or room is a channel subscription over the account/grid mesh; typed
+events flow through the same replayable event bus.
+
+## Gist Boundary
+
+Gists were never valuable because they were a good chat data plane. They were
+valuable because they gave the old system a shared account-level registry that
+worked across all of Joel's machines under the same Git/GitHub account.
+
+The Rust boundary is:
+
+- GitHub gist may advertise signed channel beacons and route candidates.
+- GitHub gist may help any of the user's machines find the same account mesh.
+- GitHub gist must not be required for same-machine traffic.
+- GitHub gist must not silently become the live data plane for chat/events.
+- GitHub gist must be accessed through the machine-global coordinator, with
+  TTL, singleflight, and backoff. Individual tabs, monitors, hooks, and message
+  sends do not call GitHub directly.
+
+If GitHub is unavailable, local agents on one machine and peers with already
+known direct routes should still communicate. Remote first-contact may wait for
+another registry publisher or explicit invite, but that is a discovery problem,
+not a different chat model.
+
+Rare GitHub access is allowed for:
+
+- first join on a machine with no fresh account-mesh cache;
+- publishing or rotating this machine's signed beacon;
+- conservative lease refresh;
+- explicit user commands such as invite/list/repair;
+- discovering remote machines when no local/LAN/Tailscale/relay path is already
+  known.
+
+GitHub access is forbidden for:
+
+- routine chat/event frames;
+- monitor polling;
+- hook execution;
+- per-message delivery;
+- status loops;
+- every tab independently checking the same registry.
+
+## Tailscale Boundary
+
+Tailscale is a first-class remote-route candidate for the user's own machines.
+When `airc join` needs a remote route and Tailscale is installed but logged out
+or down, AIRC should trigger or clearly guide `tailscale up` instead of silently
+pretending only local routes exist.
+
+Tailscale is reachability, not identity. Peers still authenticate with AIRC
+identity keys and trust rotation. Tailscale only gives the route resolver a
+direct address between machines in the same tailnet.
+
+The foolproof order is:
+
+1. same process / daemon IPC;
+2. same machine local transport;
+3. same LAN;
+4. Tailscale, with login/up flow if the route is needed;
+5. relay / WebRTC / Reticulum for non-tailnet or NAT boundaries;
+6. GitHub gist only to publish or discover the account mesh and route beacons.
+
+## Rust Gaps To Close
+
+Current rust-rewrite still has account-mesh gaps:
+
+- CLI `room` language says "switch current room";
+- install and wrapper paths have historically allowed stale `airc-rs`,
+  `~/.airc-src`, and symlink resolution to mask the actual binary under test.
+- `Airc::join_default_context()` is not implemented yet;
+- mesh identity still uses the unset sentinel until the machine-global
+  coordinator resolves the authenticated Git/GitHub user identity.
+
+Required corrections:
+
+1. Keep `SubscriptionSet` as the runtime source of truth:
+   subscribed channels, default channel, parted channels, and stable
+   `(mesh identity, channel name) -> RoomId` derivation.
+2. Make `Airc::join_default_context()` or equivalent subscribe to `general`
+   plus inferred org/project channel.
+3. Make `Airc::join_channel(name)` add/promote a channel without removing the
+   rest.
+4. Make monitor and hooks default to all subscribed channels, not current room.
+5. Add account-mesh registry abstraction for `git user identity + channel ->
+   beacon`.
+6. Keep the data plane selected by route policy: local, LAN, relay, WebRTC,
+   Reticulum, etc. Gist remains registry/bootstrap.
+7. Add Rust Tailscale discovery/login health: detect installed/down/logged-out,
+   surface `tailscale up`, and publish Tailscale route candidates when signed
+   in.
+8. Add machine-global coordinator/cache keyed by Git/GitHub user identity, with
+   TTL, singleflight, and backoff around all remote registry publishers.
+9. Collapse install/runtime naming to `airc`, with source under `~/.airc/src`,
+   worktrees under `~/.airc/worktrees`, and no stale `airc-rs` or hidden
+   alternate source roots.
+
+## Acceptance Tests
+
+The rewrite is not correct until these pass:
+
+- Two fresh agents on any two of Joel's machines, authenticated as the same
+  Git/GitHub user, run `airc join` with no pasted invite and both see the same
+  `#general`.
+- Two agents in CambrianTech repos on any of Joel's machines run `airc join`
+  and both see the same `#cambriantech` and `#general`.
+- Two agents in Ideem repos on any of Joel's machines run `airc join` and both
+  see the same `#ideem` and `#general`.
+- One agent sends to `#general`; another whose current/default channel is
+  `#cambriantech` receives it through monitor.
+- One agent sends to `#cambriantech`; another whose current/default channel is
+  `#general` receives it through monitor.
+- Codex hook context includes new events from all subscribed channels, with one
+  cursor/replay contract.
+- Every machine on the same Git/GitHub user account can discover the same
+  canonical channel registry through a remote publisher without changing
+  channel semantics.
+- If Tailscale is needed for a same-account remote machine and is installed but
+  down, `airc join` reports or triggers the login/up path before giving up on
+  that route.
+- If GitHub is rate-limited, same-machine agents with local route discovery
+  still communicate.
+- Ten local agents starting `airc join` concurrently cause one remote registry
+  refresh at most; the other nine attach through the machine-global coordinator.
+- Monitor and Codex hooks never invoke GitHub while draining subscribed-channel
+  events.
+- After deleting `~/.airc`, `~/.airc-src`, `~/.airc-worktrees`, stale `airc-rs`
+  binaries, and old PATH shims, a fresh install produces exactly one public
+  command, `airc`, and `airc version` reports the same source checkout that the
+  command executes.

--- a/docs/architecture/AIRC-RUST-SUBSTRATE.md
+++ b/docs/architecture/AIRC-RUST-SUBSTRATE.md
@@ -40,6 +40,12 @@ transport boundary: gh-gist is an invite/rendezvous beacon, not the live
 message/event data plane. Consumers see publish, subscribe, replay, and ack
 APIs; route resolution sits below them.
 
+See [`ACCOUNT-MESH-JOIN-CONTRACT.md`](ACCOUNT-MESH-JOIN-CONTRACT.md) for the
+join/subscription contract the Rust rewrite must preserve from the working
+system: bare `airc join` enters the account mesh and subscribes the scope to
+`#general` plus the inferred org/project channel. Channels are subscriptions
+on the mesh, not isolated one-room pairing worlds.
+
 ## What airc-rust is not
 
 - Not an opinion about what consumers say to each other. Payloads are


### PR DESCRIPTION
Summary
- document account-mesh join semantics and clean install/state layout
- add airc-lib subscription-set reader from existing subscribed_channels config
- route monitor attach, events list, and Codex hook replay through subscribed-channel filters instead of current_room
- preserve persisted room wire fallback so installed/shared-wire monitor tests still work

Verification
- cargo fmt --manifest-path Cargo.toml --all --check
- cargo check --manifest-path Cargo.toml --workspace
- cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-lib subscriptions
- cargo test --manifest-path Cargo.toml -p airc-lib subscribed_filter_reads_all_configured_channels_not_current_room_only
- cargo test --manifest-path Cargo.toml -p airc-cli monitor_attach_streams_rust_events_without_legacy_log
- cargo test --manifest-path Cargo.toml -p airc-cli codex
- cargo test --manifest-path Cargo.toml -p airc-cli events
- git diff --check