### PR TITLE
fix(lib): share same-machine account local wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
+ "temp-env",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/airc-lib/Cargo.toml
+++ b/crates/airc-lib/Cargo.toml
@@ -41,4 +41,5 @@ uuid = { version = "1", features = ["v4", "v5"] }
 
 [dev-dependencies]
 tempfile = "3"
+temp-env = "0.3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -50,6 +50,34 @@ const EVENTS_DB_FILENAME: &str = "events.sqlite";
 /// that need durable replay use `Airc::resume_from` against the store.
 const LIVE_BROADCAST_CAPACITY: usize = 1024;
 
+fn machine_account_home(scope_home: &Path) -> PathBuf {
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        if scope_home.starts_with(&home) {
+            return home.join(".airc");
+        }
+    }
+    #[cfg(windows)]
+    if let Some(userprofile) = std::env::var_os("USERPROFILE") {
+        let userprofile = PathBuf::from(userprofile);
+        if scope_home.starts_with(&userprofile) {
+            return userprofile.join(".airc");
+        }
+    }
+    scope_home.to_path_buf()
+}
+
+fn load_peer_registries(
+    home: &Path,
+    wire_root: &Path,
+) -> Result<Vec<peers_store::StoredPeer>, AircError> {
+    let mut peers = peers_store::load(home)?;
+    if wire_root != home {
+        peers.extend(peers_store::load(wire_root)?);
+    }
+    Ok(peers)
+}
+
 /// In-process AIRC handle. Holds identity, store, per-room
 /// signed-local-fs transports, and a background subscriber per wire
 /// that converts received `Frame`s into `TranscriptEvent`s and
@@ -73,6 +101,7 @@ pub struct Airc {
 
 pub(crate) struct AircInner {
     pub(crate) home: PathBuf,
+    pub(crate) wire_root: PathBuf,
     pub(crate) identity: LocalIdentity,
     pub(crate) store: Arc<dyn EventStore>,
     pub(crate) daemon_client: Option<Arc<DaemonClient>>,
@@ -130,6 +159,13 @@ impl Airc {
         let home: PathBuf = home.into();
         std::fs::create_dir_all(&home).map_err(airc_daemon::IdentityError::Io)?;
         let identity = LocalIdentity::load_or_generate(&home)?;
+        let wire_root = machine_account_home(&home);
+        std::fs::create_dir_all(&wire_root).map_err(airc_daemon::IdentityError::Io)?;
+        peers_store::add(
+            &wire_root,
+            identity.peer_id,
+            identity.keypair.public_bytes(),
+        )?;
 
         let store_path = home.join(EVENTS_DB_FILENAME);
         let store: Arc<dyn EventStore> = Arc::new(SqliteEventStore::open_path(&store_path).await?);
@@ -138,7 +174,12 @@ impl Airc {
         registry
             .enrol(identity.peer_id, 0, identity.keypair.public_bytes())
             .map_err(|e| AircError::Crypto(e.to_string()))?;
-        for stored in peers_store::load(&home)? {
+        let mut enrolled = vec![identity.peer_id];
+        for stored in load_peer_registries(&home, &wire_root)? {
+            if enrolled.contains(&stored.peer_id) {
+                continue;
+            }
+            enrolled.push(stored.peer_id);
             registry
                 .enrol(
                     stored.peer_id,
@@ -154,6 +195,7 @@ impl Airc {
 
         Ok(Self {
             inner: Arc::new(AircInner {
+                wire_root,
                 home,
                 identity,
                 store,
@@ -194,6 +236,7 @@ impl Airc {
     fn with_daemon_client(&self, client: DaemonClient) -> Self {
         let inner = AircInner {
             home: self.inner.home.clone(),
+            wire_root: self.inner.wire_root.clone(),
             identity: self.inner.identity.clone(),
             store: self.inner.store.clone(),
             daemon_client: Some(Arc::new(client)),
@@ -258,7 +301,7 @@ impl Airc {
     /// re-resolves after [`crate::mesh_identity::DEFAULT_TTL_MS`] so
     /// concurrent callers don't hammer `gh`. See the module docs for
     /// the resolver chain.
-    fn mesh_identity(&self) -> Result<MeshIdentity, AircError> {
+    pub(crate) fn mesh_identity(&self) -> Result<MeshIdentity, AircError> {
         let cached = mesh_identity::resolve(&self.inner.home)?;
         Ok(cached.as_mesh_identity())
     }
@@ -269,7 +312,8 @@ impl Airc {
         let channel = ChannelName::new(name)?;
         let identity = self.mesh_identity()?;
         let mut set = subscriptions::load_or_init(&self.inner.home)?;
-        let subscription = set.subscribe(&self.inner.home, &identity, channel.clone())?;
+        let subscription =
+            set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
         set.set_default(channel)?;
         subscriptions::save(&self.inner.home, &set)?;
         let room = subscription.as_room();
@@ -306,7 +350,8 @@ impl Airc {
 
         let identity = self.mesh_identity()?;
         let channel = ChannelName::new("general")?;
-        let subscription = set.subscribe(&self.inner.home, &identity, channel.clone())?;
+        let subscription =
+            set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
         set.set_default(channel)?;
         subscriptions::save(&self.inner.home, &set)?;
         Ok(subscription.as_room())

--- a/crates/airc-lib/src/peers.rs
+++ b/crates/airc-lib/src/peers.rs
@@ -49,6 +49,7 @@ impl Airc {
         let stored = peers_store::load(&self.inner.home)?;
         Ok(stored
             .into_iter()
+            .filter(|p| p.peer_id != self.inner.identity.peer_id)
             .map(|p| EnrolledPeer {
                 peer_id: p.peer_id,
                 pubkey_b64: p.pubkey_b64,

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -241,6 +241,19 @@ impl Subscription {
         Self::with_wire(identity, name, wire)
     }
 
+    /// Construct a subscription whose local-fs wire is rooted at the
+    /// account-wide machine home instead of the caller's scope home.
+    /// This is what makes `~/.airc`, `repo/.airc`, and other scopes on
+    /// the same OS account converge on one local data plane.
+    pub fn new_with_wire_root(
+        wire_root: &Path,
+        identity: &MeshIdentity,
+        name: ChannelName,
+    ) -> Result<Self, SubscriptionError> {
+        let wire = wire_root.join("wires").join(name.as_str());
+        Self::with_wire(identity, name, wire)
+    }
+
     pub fn with_wire(
         identity: &MeshIdentity,
         name: ChannelName,
@@ -313,6 +326,26 @@ impl SubscriptionSet {
             return Ok(existing.clone());
         }
         let sub = Subscription::new(home, identity, name.clone())?;
+        self.subscribed.insert(name.clone(), sub.clone());
+        if self.default.is_none() {
+            self.default = Some(name);
+        }
+        Ok(sub)
+    }
+
+    /// Add or replace a subscription using an account-wide local wire
+    /// root. See [`Subscription::new_with_wire_root`].
+    pub fn subscribe_with_wire_root(
+        &mut self,
+        wire_root: &Path,
+        identity: &MeshIdentity,
+        name: ChannelName,
+    ) -> Result<Subscription, SubscriptionError> {
+        self.parted.remove(&name);
+        if let Some(existing) = self.subscribed.get(&name) {
+            return Ok(existing.clone());
+        }
+        let sub = Subscription::new_with_wire_root(wire_root, identity, name.clone())?;
         self.subscribed.insert(name.clone(), sub.clone());
         if self.default.is_none() {
             self.default = Some(name);
@@ -436,11 +469,12 @@ impl Airc {
         }
 
         if room_ids.is_empty() {
+            let identity = self.mesh_identity()?;
             push_unique(
                 &mut room_ids,
-                Subscription::new(
-                    &self.inner.home,
-                    &MeshIdentity::unset(),
+                Subscription::new_with_wire_root(
+                    &self.inner.wire_root,
+                    &identity,
                     ChannelName::new("general").map_err(SubscriptionError::from)?,
                 )?
                 .room_id,
@@ -456,11 +490,12 @@ impl Airc {
             push_unique_path(&mut wires, subscription.wire.clone());
         }
         if wires.is_empty() {
+            let identity = self.mesh_identity()?;
             push_unique_path(
                 &mut wires,
-                Subscription::new(
-                    &self.inner.home,
-                    &MeshIdentity::unset(),
+                Subscription::new_with_wire_root(
+                    &self.inner.wire_root,
+                    &identity,
                     ChannelName::new("general").map_err(SubscriptionError::from)?,
                 )?
                 .wire,
@@ -636,6 +671,35 @@ mod tests {
         // First subscription stays as default.
         assert_eq!(set.default.as_ref().unwrap().as_str(), "general");
         assert_eq!(set.subscribed.len(), 2);
+    }
+
+    #[test]
+    fn subscribe_with_wire_root_uses_machine_account_wire() {
+        let scope_a = tempdir().unwrap();
+        let scope_b = tempdir().unwrap();
+        let machine_home = tempdir().unwrap();
+        let id = MeshIdentity::new("joelteply");
+        let channel = ChannelName::new("general").unwrap();
+        let mut a = SubscriptionSet::empty();
+        let mut b = SubscriptionSet::empty();
+
+        let a_sub = a
+            .subscribe_with_wire_root(machine_home.path(), &id, channel.clone())
+            .unwrap();
+        let b_sub = b
+            .subscribe_with_wire_root(machine_home.path(), &id, channel)
+            .unwrap();
+
+        assert_eq!(a_sub.room_id, b_sub.room_id);
+        assert_eq!(a_sub.wire, b_sub.wire);
+        assert_eq!(
+            a_sub.wire,
+            machine_home.path().join("wires").join("general")
+        );
+        assert!(
+            !a_sub.wire.starts_with(scope_a.path()) && !b_sub.wire.starts_with(scope_b.path()),
+            "same-machine account mesh must not isolate local data-plane per project scope"
+        );
     }
 
     #[test]

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -222,6 +222,45 @@ async fn peer_spec_round_trips_via_add_peer() {
     );
 }
 
+#[test]
+fn same_machine_scopes_share_account_wire_and_registry() {
+    let machine = TempDir::new().unwrap();
+
+    temp_env::with_var("HOME", Some(machine.path()), || {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let alice_home = machine.path().join("repo-a").join(".airc");
+            let bob_home = machine.path().join("repo-b").join(".airc");
+            std::fs::create_dir_all(alice_home.parent().unwrap()).unwrap();
+            std::fs::create_dir_all(bob_home.parent().unwrap()).unwrap();
+
+            let alice = Airc::open(&alice_home).await.unwrap();
+            alice.join("general").await.unwrap();
+
+            let bob = Airc::open(&bob_home).await.unwrap();
+            bob.join("general").await.unwrap();
+
+            let alice_room = alice.current_room().await.unwrap();
+            let bob_room = bob.current_room().await.unwrap();
+            assert_eq!(alice_room.channel, bob_room.channel);
+            assert_eq!(alice_room.wire, bob_room.wire);
+            assert_eq!(alice_room.wire, machine.path().join(".airc/wires/general"));
+
+            let peers = airc_daemon::peers_store::load(&machine.path().join(".airc")).unwrap();
+            assert_eq!(
+                peers.len(),
+                2,
+                "opening two local scopes must publish both identities into the machine registry"
+            );
+
+            alice.say("same-machine account wire").await.unwrap();
+            let event =
+                wait_for_text(&bob, "same-machine account wire", Duration::from_secs(3)).await;
+            assert_eq!(event.peer_id, alice.peer_id());
+        });
+    });
+}
+
 #[tokio::test]
 async fn open_is_idempotent_across_handles() {
     // Two Airc::open calls on the same home recover the same


### PR DESCRIPTION
## Summary
- root default local-fs wires at the machine account home for scopes under the same HOME/USERPROFILE
- publish each opened local identity into the machine account peer registry and load both scope + account registries under strict verification
- add SDK proof that two fresh project scopes on one account share #general and receive signed frames without manual peer add

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib
- cargo test --manifest-path Cargo.toml -p airc-lib
- cargo clippy --manifest-path Cargo.toml -p airc-lib --all-targets -- -D warnings
- git diff --check