### PR TITLE
feat(lib): add account room coordinator

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -265,6 +265,14 @@ pub enum Command {
     /// Build and inspect message envelopes during Rust cutover.
     Message(MessageArgs),
 
+    /// Join the account mesh. With no room, subscribes to #general
+    /// and the inferred repo/org channel. With a room, subscribes to
+    /// that channel and makes it the default.
+    Join {
+        /// Optional channel name to join.
+        room: Option<String>,
+    },
+
     /// Shared GitHub request governor.
     Gh(GhArgs),
 

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -76,6 +76,33 @@ pub async fn run_room(
     Ok(())
 }
 
+/// `join` — account-room coordinator entrypoint. With no explicit
+/// room, subscribe to `#general` plus the inferred Git owner channel.
+/// With a room, join that arbitrary channel and make it default.
+pub async fn run_join(home: &Path, room: Option<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    match room {
+        Some(room) => {
+            let joined = airc.join(&room).await?;
+            println!("joined:  #{}", joined.name);
+            println!("wire:    {}", joined.wire.display());
+            println!("channel: {}", joined.channel);
+        }
+        None => {
+            let cwd = std::env::current_dir()?;
+            let rooms = airc.join_default_context(cwd).await?;
+            let current = airc.current_room().await?;
+            println!("joined default account context:");
+            for room in rooms {
+                println!("  #{} ({})", room.name, room.channel);
+            }
+            println!("default: #{}", current.name);
+            println!("wire:    {}", current.wire.display());
+        }
+    }
+    Ok(())
+}
+
 /// `send` — local-fs single-shot send to the current room. Routes
 /// through `Airc::say`; ad-hoc `--peer` flags are enrolled in the
 /// in-process registry for the duration of the invocation.

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -601,6 +601,8 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             } => message_commands::run_build(&from, &to, &ts, &channel, &msg, &client_id, &kind),
         },
 
+        Command::Join { room } => commands::run_join(&home, room).await,
+
         Command::Gh(args) => match args.action {
             GhAction::Run { gh_args } => gh_commands::run_gh(gh_args),
             GhAction::PatchGistFile {

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -139,6 +139,83 @@ fn run_room(home: &Path, name: &str, wire: &Path) {
 }
 
 #[test]
+fn join_without_args_uses_default_account_context() {
+    let machine = TempDir::new().expect("tempdir");
+    let repo = machine.path().join("continuum");
+    let home = repo.join(".airc");
+    create_repo_with_origin(&repo, "https://github.com/CambrianTech/continuum.git");
+    seed_mesh_identity(&home, "joelteply");
+
+    let output = Command::new(airc_core())
+        .env("HOME", machine.path())
+        .args(["--home", home.to_str().unwrap(), "join"])
+        .current_dir(&repo)
+        .output()
+        .expect("airc-core join must spawn");
+    assert!(
+        output.status.success(),
+        "join failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("#general"), "{stdout}");
+    assert!(stdout.contains("#cambriantech"), "{stdout}");
+    assert!(stdout.contains("default: #cambriantech"), "{stdout}");
+
+    let subscriptions = std::fs::read_to_string(home.join("subscriptions.json")).unwrap();
+    assert!(subscriptions.contains("\"general\""), "{subscriptions}");
+    assert!(
+        subscriptions.contains("\"cambriantech\""),
+        "{subscriptions}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&subscriptions).unwrap();
+    let wire = json["subscribed"]["cambriantech"]["wire"]
+        .as_str()
+        .expect("cambriantech wire");
+    assert_eq!(
+        std::path::PathBuf::from(wire),
+        machine
+            .path()
+            .join(".airc")
+            .join("wires")
+            .join("cambriantech")
+    );
+}
+
+fn create_repo_with_origin(path: &Path, origin: &str) {
+    std::fs::create_dir_all(path.join(".git")).unwrap();
+    std::fs::write(
+        path.join(".git/config"),
+        format!(
+            r#"[core]
+    repositoryformatversion = 0
+[remote "origin"]
+    url = {origin}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+fn seed_mesh_identity(home: &Path, identity: &str) {
+    std::fs::create_dir_all(home).unwrap();
+    std::fs::write(
+        home.join("mesh_identity.json"),
+        format!(
+            r#"{{
+  "version": 1,
+  "identity": "{identity}",
+  "source": "operator",
+  "resolved_at_ms": 1,
+  "ttl_ms": 86400000
+}}"#
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
 fn listen_rejects_unenrolled_signer() {
     // Mallory's signed frame must be rejected by Alice's listen — she
     // isn't in Alice's peer registry. Stderr surfaces a verification

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -33,6 +33,7 @@ use airc_transport::LanTcpAdapter;
 use tokio::sync::{broadcast, Mutex};
 
 use crate::error::AircError;
+use crate::join_context::JoinContext;
 use crate::mesh_identity;
 use crate::room::Room;
 use crate::route::health::TransportHealthTable;
@@ -319,6 +320,49 @@ impl Airc {
         let room = subscription.as_room();
         self.ensure_wire_subscriber(&room.wire).await?;
         Ok(room)
+    }
+
+    /// Subscribe this scope to the default account context:
+    /// `#general` plus the repository owner channel inferred from
+    /// `cwd` when the caller is inside a Git checkout.
+    ///
+    /// This is the Rust substrate for bare `airc join`. It creates
+    /// missing local subscriptions idempotently, preserves arbitrary
+    /// user-created channels, and uses the account-wide local wire so
+    /// scopes on the same OS account converge without manual pairing.
+    pub async fn join_default_context(
+        &self,
+        cwd: impl AsRef<Path>,
+    ) -> Result<Vec<Room>, AircError> {
+        let context = JoinContext::from_cwd(cwd.as_ref());
+        self.ensure_join_context(context).await
+    }
+
+    /// Subscribe to every channel in `context`, set its default, and
+    /// start local subscribers for the resulting wires.
+    pub async fn ensure_join_context(&self, context: JoinContext) -> Result<Vec<Room>, AircError> {
+        let identity = self.mesh_identity()?;
+        let mut set = subscriptions::load_or_init(&self.inner.home)?;
+        let mut rooms = Vec::new();
+
+        for channel in context.channels {
+            if set.parted.contains(&channel) {
+                continue;
+            }
+            let subscription =
+                set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel)?;
+            rooms.push(subscription.as_room());
+        }
+
+        if set.subscribed.contains_key(&context.default) {
+            set.set_default(context.default)?;
+        }
+        subscriptions::save(&self.inner.home, &set)?;
+
+        for room in &rooms {
+            self.ensure_wire_subscriber(&room.wire).await?;
+        }
+        Ok(rooms)
     }
 
     /// Variant of [`join`] that overrides the per-home default wire

--- a/crates/airc-lib/src/join_context.rs
+++ b/crates/airc-lib/src/join_context.rs
@@ -1,0 +1,191 @@
+//! Default account-room join context.
+//!
+//! A fresh `airc join` should not mean "one current room." It means:
+//! subscribe this scope to the account lobby (`#general`) and, when
+//! running inside a Git checkout, the account/org room inferred from
+//! the repository remote.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use crate::subscriptions::ChannelName;
+
+pub const GENERAL_CHANNEL: &str = "general";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JoinContext {
+    pub channels: Vec<ChannelName>,
+    pub default: ChannelName,
+}
+
+impl JoinContext {
+    pub fn from_cwd(cwd: &Path) -> Self {
+        let mut names = BTreeSet::new();
+        names.insert(ChannelName::general());
+        if let Some(org) = infer_repo_owner_channel(cwd) {
+            names.insert(org);
+        }
+
+        let default = names
+            .iter()
+            .find(|name| name.as_str() != GENERAL_CHANNEL)
+            .cloned()
+            .unwrap_or_else(ChannelName::general);
+        Self {
+            channels: names.into_iter().collect(),
+            default,
+        }
+    }
+}
+
+fn infer_repo_owner_channel(cwd: &Path) -> Option<ChannelName> {
+    let config = find_git_config(cwd)?;
+    let remote = origin_remote_url(&std::fs::read_to_string(config).ok()?)?;
+    let owner = remote_owner(&remote)?;
+    ChannelName::new(owner).ok()
+}
+
+fn find_git_config(cwd: &Path) -> Option<PathBuf> {
+    for dir in cwd.ancestors() {
+        let dotgit = dir.join(".git");
+        if dotgit.is_dir() {
+            return Some(dotgit.join("config"));
+        }
+        if dotgit.is_file() {
+            let text = std::fs::read_to_string(&dotgit).ok()?;
+            let gitdir = text.strip_prefix("gitdir:")?.trim();
+            let gitdir = if Path::new(gitdir).is_absolute() {
+                PathBuf::from(gitdir)
+            } else {
+                dir.join(gitdir)
+            };
+            return Some(gitdir.join("config"));
+        }
+    }
+    None
+}
+
+fn origin_remote_url(config: &str) -> Option<String> {
+    let mut in_origin = false;
+    for raw in config.lines() {
+        let line = raw.trim();
+        if line.starts_with('[') && line.ends_with(']') {
+            in_origin = line == r#"[remote "origin"]"#;
+            continue;
+        }
+        if !in_origin {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim() == "url" {
+            return Some(value.trim().to_string());
+        }
+    }
+    None
+}
+
+fn remote_owner(url: &str) -> Option<&str> {
+    let without_suffix = url.strip_suffix(".git").unwrap_or(url);
+    if let Some(rest) = without_suffix.strip_prefix("git@") {
+        let (_, path) = rest.split_once(':')?;
+        return path.split('/').next();
+    }
+    if let Some((_, path)) = without_suffix.split_once("://") {
+        let path = path.split_once('/')?.1;
+        return path.split('/').next();
+    }
+    without_suffix.split('/').next()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn context_without_git_is_general_only() {
+        let dir = TempDir::new().unwrap();
+
+        let context = JoinContext::from_cwd(dir.path());
+
+        assert_eq!(names(&context), vec!["general"]);
+        assert_eq!(context.default.as_str(), "general");
+    }
+
+    #[test]
+    fn context_adds_github_owner_and_defaults_to_it() {
+        let repo = repo_with_origin("https://github.com/CambrianTech/airc.git");
+
+        let context = JoinContext::from_cwd(repo.path());
+
+        assert_eq!(names(&context), vec!["cambriantech", "general"]);
+        assert_eq!(context.default.as_str(), "cambriantech");
+    }
+
+    #[test]
+    fn context_reads_ssh_origin() {
+        let repo = repo_with_origin("git@github.com:UseIdeem/vHSM.git");
+
+        let context = JoinContext::from_cwd(repo.path());
+
+        assert_eq!(names(&context), vec!["general", "useideem"]);
+        assert_eq!(context.default.as_str(), "useideem");
+    }
+
+    #[test]
+    fn context_walks_up_from_nested_dir() {
+        let repo = repo_with_origin("https://github.com/CambrianTech/continuum.git");
+        let nested = repo.path().join("crates/continuum-core/src");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let context = JoinContext::from_cwd(&nested);
+
+        assert_eq!(context.default.as_str(), "cambriantech");
+    }
+
+    #[test]
+    fn context_reads_gitdir_file_for_worktrees() {
+        let checkout = TempDir::new().unwrap();
+        let gitdir = TempDir::new().unwrap();
+        std::fs::write(
+            checkout.path().join(".git"),
+            format!("gitdir: {}\n", gitdir.path().display()),
+        )
+        .unwrap();
+        std::fs::write(
+            gitdir.path().join("config"),
+            r#"[remote "origin"]
+    url = ssh://git@github.com/OpenClaw/openclaw.git
+"#,
+        )
+        .unwrap();
+
+        let context = JoinContext::from_cwd(checkout.path());
+
+        assert_eq!(names(&context), vec!["general", "openclaw"]);
+        assert_eq!(context.default.as_str(), "openclaw");
+    }
+
+    fn repo_with_origin(url: &str) -> TempDir {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join(".git")).unwrap();
+        std::fs::write(
+            dir.path().join(".git/config"),
+            format!(
+                r#"[core]
+    repositoryformatversion = 0
+[remote "origin"]
+    url = {url}
+"#
+            ),
+        )
+        .unwrap();
+        dir
+    }
+
+    fn names(context: &JoinContext) -> Vec<&str> {
+        context.channels.iter().map(ChannelName::as_str).collect()
+    }
+}

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -24,6 +24,7 @@
 pub mod airc;
 mod daemon;
 pub mod error;
+pub mod join_context;
 mod lan;
 pub mod mesh_identity;
 mod messaging;
@@ -39,6 +40,7 @@ pub mod work;
 
 pub use airc::Airc;
 pub use error::AircError;
+pub use join_context::{JoinContext, GENERAL_CHANNEL};
 pub use mesh_identity::{
     load_cached as load_cached_mesh_identity, path_in as mesh_identity_path,
     resolve as resolve_mesh_identity, resolve_with as resolve_mesh_identity_with, CachedIdentity,

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -112,6 +112,10 @@ impl From<ChannelNameError> for SubscriptionError {
 pub struct ChannelName(String);
 
 impl ChannelName {
+    pub(crate) fn general() -> Self {
+        Self("general".to_string())
+    }
+
     /// Construct from any user-supplied string. Strips a leading `#`
     /// if present, trims whitespace, lower-cases ASCII, and rejects
     /// anything that wouldn't be safe as both a path component and a

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -11,9 +11,9 @@ use std::{net::SocketAddr, time::Duration};
 
 use airc_daemon::{DaemonState, LocalIdentity};
 use airc_lib::{
-    subscriptions, Airc, Body, ChannelName, EventFilter, HeaderFilter, Headers, MeshIdentity,
-    PeerSpec, RouteEndpoint, SubscriptionSet, TranscriptKind, TransportHealthSample, TransportKind,
-    TransportRole,
+    resolve_mesh_identity_with, subscriptions, Airc, Body, ChannelName, EventFilter, HeaderFilter,
+    Headers, MeshIdentity, MeshIdentitySource, PeerSpec, RouteEndpoint, SubscriptionSet,
+    TranscriptKind, TransportHealthSample, TransportKind, TransportRole,
 };
 use airc_protocol::{PeerKeyRegistry, VerificationPolicy};
 use airc_store::{EventStore, SqliteEventStore};
@@ -261,6 +261,58 @@ fn same_machine_scopes_share_account_wire_and_registry() {
     });
 }
 
+#[test]
+fn default_join_context_subscribes_general_and_repo_owner_on_shared_account_wire() {
+    let machine = TempDir::new().unwrap();
+
+    temp_env::with_var("HOME", Some(machine.path()), || {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let alice_repo = repo_with_origin(
+                &machine.path().join("alice-continuum"),
+                "https://github.com/CambrianTech/continuum.git",
+            );
+            let bob_repo = repo_with_origin(
+                &machine.path().join("bob-airc"),
+                "git@github.com:CambrianTech/airc.git",
+            );
+            let alice_home = alice_repo.join(".airc");
+            let bob_home = bob_repo.join(".airc");
+
+            seed_mesh_identity(&alice_home, "joelteply");
+            seed_mesh_identity(&bob_home, "joelteply");
+
+            let alice = Airc::open(&alice_home).await.unwrap();
+            let bob = Airc::open(&bob_home).await.unwrap();
+
+            let alice_rooms = alice.join_default_context(&alice_repo).await.unwrap();
+            let bob_rooms = bob.join_default_context(&bob_repo).await.unwrap();
+
+            assert_eq!(room_names(&alice_rooms), vec!["cambriantech", "general"]);
+            assert_eq!(room_names(&bob_rooms), vec!["cambriantech", "general"]);
+            assert_eq!(alice.current_room().await.unwrap().name, "cambriantech");
+            assert_eq!(bob.current_room().await.unwrap().name, "cambriantech");
+            assert_eq!(
+                alice.current_room().await.unwrap().wire,
+                machine.path().join(".airc/wires/cambriantech")
+            );
+            assert_eq!(
+                alice.current_room().await.unwrap().channel,
+                bob.current_room().await.unwrap().channel
+            );
+
+            alice.say("default account context works").await.unwrap();
+            let event = wait_for_text(
+                &bob,
+                "default account context works",
+                Duration::from_secs(3),
+            )
+            .await;
+            assert_eq!(event.peer_id, alice.peer_id());
+        });
+    });
+}
+
 #[tokio::test]
 async fn open_is_idempotent_across_handles() {
     // Two Airc::open calls on the same home recover the same
@@ -271,6 +323,35 @@ async fn open_is_idempotent_across_handles() {
     drop(first);
     let second = Airc::open(home.path()).await.unwrap();
     assert_eq!(second.peer_id(), first_peer);
+}
+
+fn repo_with_origin(path: &std::path::Path, origin: &str) -> std::path::PathBuf {
+    std::fs::create_dir_all(path.join(".git")).unwrap();
+    std::fs::write(
+        path.join(".git/config"),
+        format!(
+            r#"[core]
+    repositoryformatversion = 0
+[remote "origin"]
+    url = {origin}
+"#
+        ),
+    )
+    .unwrap();
+    path.to_path_buf()
+}
+
+fn seed_mesh_identity(home: &std::path::Path, identity: &str) {
+    resolve_mesh_identity_with(
+        home,
+        || Some((identity.to_string(), MeshIdentitySource::Operator)),
+        1,
+    )
+    .unwrap();
+}
+
+fn room_names(rooms: &[airc_lib::Room]) -> Vec<&str> {
+    rooms.iter().map(|room| room.name.as_str()).collect()
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add `airc-lib::JoinContext` to infer the default account room set from cwd without shelling out
- add `Airc::join_default_context` / `ensure_join_context` so bare join subscribes `#general` plus the inferred repo owner channel on the shared account wire
- add a thin `airc-core join [room]` command for default-context join or arbitrary channel join
- add SDK and CLI proofs for two repo scopes converging on the same account wire and exchanging a signed message

## Verification
- cargo fmt --manifest-path Cargo.toml --all -- --check
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo clippy --manifest-path Cargo.toml --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm
- bash test/rust_quality_guard.sh
- cargo test --manifest-path Cargo.toml -p airc-lib join_context -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-lib default_join_context_subscribes_general_and_repo_owner_on_shared_account_wire -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli join_without_args_uses_default_account_context -- --nocapture
- cargo test --manifest-path Cargo.toml --workspace --no-fail-fast