### PR TITLE
fix(join): seed rust account rooms from wrapper

### DIFF
--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -270,8 +270,8 @@ fn codex_hook_uninstaller_removes_managed_hooks_only() {
 }
 
 fn run_ok(home: &Path, args: &[&str]) -> String {
-    let output = Command::new(airc_core())
-        .arg("--home")
+    let output = command_for_home(home)
+        .args(["--home"])
         .arg(home)
         .args(args)
         .output()
@@ -287,8 +287,8 @@ fn run_ok(home: &Path, args: &[&str]) -> String {
 }
 
 fn run_hook(home: &Path, args: &[&str], stdin: &str) -> String {
-    let mut child = Command::new(airc_core())
-        .arg("--home")
+    let mut child = command_for_home(home)
+        .args(["--home"])
         .arg(home)
         .args(args)
         .stdin(Stdio::piped())
@@ -311,6 +311,14 @@ fn run_hook(home: &Path, args: &[&str], stdin: &str) -> String {
         String::from_utf8_lossy(&output.stderr),
     );
     String::from_utf8(output.stdout).expect("stdout utf-8")
+}
+
+fn command_for_home(home: &Path) -> Command {
+    let mut command = Command::new(airc_core());
+    let account_home = home.parent().unwrap_or(home);
+    command.env("HOME", account_home);
+    command.env("USERPROFILE", account_home);
+    command
 }
 
 fn additional_context(output: &str) -> String {

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -18,10 +18,17 @@ fn airc_core() -> &'static str {
     env!("CARGO_BIN_EXE_airc-core")
 }
 
+fn command_for_home(home: &Path) -> Command {
+    let mut command = Command::new(airc_core());
+    command.env("HOME", home);
+    command.env("USERPROFILE", home);
+    command
+}
+
 /// Run `airc-core --home <dir> init` and parse the printed `peer_id:`
 /// and `peer_spec:` lines from stdout.
 fn run_init(home: &Path) -> (String, String) {
-    let output = Command::new(airc_core())
+    let output = command_for_home(home)
         .arg("--home")
         .arg(home)
         .arg("init")
@@ -68,7 +75,7 @@ fn two_airc_core_processes_chat_over_local_fs() {
     run_room(&alice_home, "e2e", &wire);
     run_room(&bob_home, "e2e", &wire);
 
-    let mut alice = Command::new(airc_core())
+    let mut alice = command_for_home(&alice_home)
         .args([
             "--home",
             alice_home.to_str().unwrap(),
@@ -84,7 +91,7 @@ fn two_airc_core_processes_chat_over_local_fs() {
 
     std::thread::sleep(Duration::from_millis(300));
 
-    let bob_send = Command::new(airc_core())
+    let bob_send = command_for_home(&bob_home)
         .args([
             "--home",
             bob_home.to_str().unwrap(),
@@ -120,7 +127,7 @@ fn two_airc_core_processes_chat_over_local_fs() {
 /// Run `airc-core --home <dir> room <name> --wire <wire>`. Used by
 /// tests to pin two peers to the same shared-wire room.
 fn run_room(home: &Path, name: &str, wire: &Path) {
-    let output = Command::new(airc_core())
+    let output = command_for_home(home)
         .args([
             "--home",
             home.to_str().unwrap(),
@@ -235,7 +242,7 @@ fn listen_rejects_unenrolled_signer() {
     run_room(&alice_home, "e2e", &wire);
     run_room(&mallory_home, "e2e", &wire);
 
-    let mut alice = Command::new(airc_core())
+    let mut alice = command_for_home(&alice_home)
         .args(["--home", alice_home.to_str().unwrap(), "listen", "--replay"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -246,7 +253,7 @@ fn listen_rejects_unenrolled_signer() {
 
     // Mallory passes herself as `--peer` so her own registry is
     // non-empty; her CLI signs the frame under her own identity.
-    let _mallory_send = Command::new(airc_core())
+    let _mallory_send = command_for_home(&mallory_home)
         .args([
             "--home",
             mallory_home.to_str().unwrap(),
@@ -283,7 +290,7 @@ fn two_airc_core_processes_chat_over_lan_via_sdk_route() {
     let (alice_id, alice_spec) = run_init(&alice_home);
     let (_bob_id, bob_spec) = run_init(&bob_home);
 
-    let mut alice = Command::new(airc_core())
+    let mut alice = command_for_home(&alice_home)
         .args([
             "--home",
             alice_home.to_str().unwrap(),
@@ -305,7 +312,7 @@ fn two_airc_core_processes_chat_over_lan_via_sdk_route() {
             .expect("alice must print bound LAN address");
     let bound_addr = parse_listening_addr(&listen_line);
 
-    let bob_send = Command::new(airc_core())
+    let bob_send = command_for_home(&bob_home)
         .args([
             "--home",
             bob_home.to_str().unwrap(),
@@ -347,7 +354,7 @@ fn daemon_msg_and_inbox_use_sdk_attach_path() {
     let socket = workspace.path().join("daemon.sock");
     run_init(&home);
 
-    let mut daemon = Command::new(airc_core())
+    let mut daemon = command_for_home(&home)
         .args([
             "--home",
             home.to_str().unwrap(),
@@ -366,7 +373,7 @@ fn daemon_msg_and_inbox_use_sdk_attach_path() {
         Duration::from_secs(6),
     );
 
-    let msg = Command::new(airc_core())
+    let msg = command_for_home(&home)
         .args([
             "--home",
             home.to_str().unwrap(),
@@ -395,7 +402,7 @@ fn daemon_msg_and_inbox_use_sdk_attach_path() {
         "inbox did not print daemon-sent message through SDK attach path"
     );
 
-    let stop = Command::new(airc_core())
+    let stop = command_for_home(&home)
         .args([
             "--home",
             home.to_str().unwrap(),
@@ -415,7 +422,7 @@ fn inbox_without_socket_reads_in_process_store() {
     let home = workspace.path().join("agent");
     run_init(&home);
 
-    let send = Command::new(airc_core())
+    let send = command_for_home(&home)
         .args([
             "--home",
             home.to_str().unwrap(),
@@ -431,7 +438,7 @@ fn inbox_without_socket_reads_in_process_store() {
         String::from_utf8_lossy(&send.stderr),
     );
 
-    let inbox = Command::new(airc_core())
+    let inbox = command_for_home(&home)
         .args(["--home", home.to_str().unwrap(), "inbox", "--limit", "16"])
         .output()
         .expect("inbox must spawn");
@@ -472,7 +479,7 @@ fn wait_for_command_stdout_contains(
 ) -> bool {
     let deadline = Instant::now() + timeout;
     loop {
-        let output = Command::new(airc_core())
+        let output = command_for_home(home)
             .args([
                 "--home",
                 home.to_str().unwrap(),

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -177,6 +177,8 @@ fn join_without_args_uses_default_account_context() {
         std::path::PathBuf::from(wire),
         machine
             .path()
+            .canonicalize()
+            .unwrap()
             .join(".airc")
             .join("wires")
             .join("cambriantech")

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -54,15 +54,23 @@ const LIVE_BROADCAST_CAPACITY: usize = 1024;
 fn machine_account_home(scope_home: &Path) -> PathBuf {
     if let Some(home) = std::env::var_os("HOME") {
         let home = PathBuf::from(home);
-        if scope_home.starts_with(&home) {
-            return home.join(".airc");
+        let normalized_home = home.canonicalize().unwrap_or(home);
+        let normalized_scope = scope_home
+            .canonicalize()
+            .unwrap_or_else(|_| scope_home.to_path_buf());
+        if normalized_scope.starts_with(&normalized_home) {
+            return normalized_home.join(".airc");
         }
     }
     #[cfg(windows)]
     if let Some(userprofile) = std::env::var_os("USERPROFILE") {
         let userprofile = PathBuf::from(userprofile);
-        if scope_home.starts_with(&userprofile) {
-            return userprofile.join(".airc");
+        let normalized_userprofile = userprofile.canonicalize().unwrap_or(userprofile);
+        let normalized_scope = scope_home
+            .canonicalize()
+            .unwrap_or_else(|_| scope_home.to_path_buf());
+        if normalized_scope.starts_with(&normalized_userprofile) {
+            return normalized_userprofile.join(".airc");
         }
     }
     scope_home.to_path_buf()

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -244,7 +244,14 @@ fn same_machine_scopes_share_account_wire_and_registry() {
             let bob_room = bob.current_room().await.unwrap();
             assert_eq!(alice_room.channel, bob_room.channel);
             assert_eq!(alice_room.wire, bob_room.wire);
-            assert_eq!(alice_room.wire, machine.path().join(".airc/wires/general"));
+            assert_eq!(
+                alice_room.wire,
+                machine
+                    .path()
+                    .canonicalize()
+                    .unwrap()
+                    .join(".airc/wires/general")
+            );
 
             let peers = airc_daemon::peers_store::load(&machine.path().join(".airc")).unwrap();
             assert_eq!(
@@ -294,7 +301,11 @@ fn default_join_context_subscribes_general_and_repo_owner_on_shared_account_wire
             assert_eq!(bob.current_room().await.unwrap().name, "cambriantech");
             assert_eq!(
                 alice.current_room().await.unwrap().wire,
-                machine.path().join(".airc/wires/cambriantech")
+                machine
+                    .path()
+                    .canonicalize()
+                    .unwrap()
+                    .join(".airc/wires/cambriantech")
             );
             assert_eq!(
                 alice.current_room().await.unwrap().channel,

--- a/docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md
+++ b/docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md
@@ -33,8 +33,8 @@ Python/shell/GitHub data plane.
 ### Install And State Layout
 
 AIRC has one public command name: `airc`. The Rust rewrite must not expose a
-parallel `airc-rs` product surface, require users to remember which binary is
-new, or let different wrappers point at different builds.
+parallel language-suffixed product surface, require users to remember which
+binary is new, or let different wrappers point at different builds.
 
 The install layout is:
 
@@ -51,9 +51,9 @@ must not replace the account-wide coordinator under `~/.airc`.
 
 Forbidden install shapes:
 
-- `~/.airc-src` as a second hidden source checkout;
-- `~/.airc-worktrees` as a parallel worktree root;
-- stale `airc-rs` binaries or user-facing symlinks;
+- second hidden source checkouts outside `~/.airc/src`;
+- parallel worktree roots outside `~/.airc/worktrees`;
+- stale language-suffixed binaries or user-facing symlinks;
 - wrappers that silently fall back to an older installed binary;
 - test-only environment variables as the normal user path.
 
@@ -64,7 +64,7 @@ loudly if resolution is ambiguous. It must not search arbitrary old install
 locations.
 
 For version 1 there is no legacy runtime surface. Old Python, shell, gist-chat,
-and `airc-rs` compatibility paths should be deleted when their Rust
+and language-suffixed compatibility paths should be deleted when their Rust
 replacement exists. If a fresh install would never create a file or symlink,
 the runtime should not contain code to keep using it.
 
@@ -227,8 +227,9 @@ The foolproof order is:
 Current rust-rewrite still has account-mesh gaps:
 
 - CLI `room` language says "switch current room";
-- install and wrapper paths have historically allowed stale `airc-rs`,
-  `~/.airc-src`, and symlink resolution to mask the actual binary under test.
+- install and wrapper paths have historically allowed stale language-suffixed
+  binaries, split source roots, and symlink resolution to mask the actual
+  binary under test.
 - `Airc::join_default_context()` is not implemented yet;
 - mesh identity still uses the unset sentinel until the machine-global
   coordinator resolves the authenticated Git/GitHub user identity.
@@ -253,8 +254,8 @@ Required corrections:
 8. Add machine-global coordinator/cache keyed by Git/GitHub user identity, with
    TTL, singleflight, and backoff around all remote registry publishers.
 9. Collapse install/runtime naming to `airc`, with source under `~/.airc/src`,
-   worktrees under `~/.airc/worktrees`, and no stale `airc-rs` or hidden
-   alternate source roots.
+   worktrees under `~/.airc/worktrees`, and no stale language-suffixed binaries
+   or hidden alternate source roots.
 
 ## Acceptance Tests
 
@@ -285,7 +286,7 @@ The rewrite is not correct until these pass:
   refresh at most; the other nine attach through the machine-global coordinator.
 - Monitor and Codex hooks never invoke GitHub while draining subscribed-channel
   events.
-- After deleting `~/.airc`, `~/.airc-src`, `~/.airc-worktrees`, stale `airc-rs`
-  binaries, and old PATH shims, a fresh install produces exactly one public
-  command, `airc`, and `airc version` reports the same source checkout that the
-  command executes.
+- After deleting old AIRC state, stale language-suffixed binaries, split source
+  roots, parallel worktree roots, and old PATH shims, a fresh install produces
+  exactly one public command, `airc`, and `airc version` reports the same
+  source checkout that the command executes.

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -73,6 +73,20 @@ _join_phase_done() {
   [ -f "$_t0_file" ] && rm -f "$_t0_file" 2>/dev/null || true
 }
 
+_join_seed_rust_account_context() {
+  [ "$use_room" = "1" ] || return 0
+  [ -z "${target:-}" ] || return 0
+
+  local _airc_core
+  _airc_core="$(airc_core_bin)" || return 1
+
+  if [ "$room_explicit" = "1" ]; then
+    "$_airc_core" --home "$AIRC_WRITE_DIR" join "$room_name" >/dev/null
+  else
+    "$_airc_core" --home "$AIRC_WRITE_DIR" join >/dev/null
+  fi
+}
+
 # ensure_channel_subscribed_with_gist <channel> [--first]
 #
 # Single-concern helper: make this scope a fully-functional subscriber
@@ -966,6 +980,10 @@ cmd_connect() {
 
   local target="${1:-}"
   local reminder_interval="${AIRC_REMINDER:-${2:-300}}"  # env > positional > 5min default
+
+  if ! _join_seed_rust_account_context; then
+    die "Could not seed Rust account-room subscriptions; refusing to join with broken local state"
+  fi
 
   # ── Notification-sink liveness ─────────────────────────────────────
   # `airc connect` is only useful when a CONSUMER is reading our stdout —

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -2560,6 +2560,115 @@ scenario_join_intent_failure_falls_back_to_host() {
   cleanup_all
 }
 
+scenario_wrapper_join_seeds_rust_account_context() {
+  section "wrapper_join_seeds_rust_account_context: public airc join seeds Rust account rooms"
+  cleanup_all
+
+  local root=/tmp/airc-it-wrapper-join
+  local machine="$root/home"
+  local repo="$machine/continuum"
+  local home="$repo/.airc"
+  local out="$root/out.log"
+  local err="$root/err.log"
+  mkdir -p "$repo/.git" "$home"
+  cat > "$repo/.git/config" <<'EOF'
+[remote "origin"]
+    url = https://github.com/CambrianTech/continuum.git
+EOF
+  cat > "$home/mesh_identity.json" <<'EOF'
+{
+  "version": 1,
+  "identity": "joelteply",
+  "source": "operator",
+  "resolved_at_ms": 1,
+  "ttl_ms": 86400000
+}
+EOF
+
+  (
+    cd "$repo" || exit 1
+    HOME="$machine" AIRC_HOME="$home" AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 \
+      AIRC_BACKGROUND_OK=1 AIRC_NO_ATTACH=1 "$AIRC" join --no-gist >"$out" 2>"$err" &
+    echo $! > "$root/join.pid"
+  )
+  sleep 3
+  if [ -f "$root/join.pid" ]; then
+    kill "$(cat "$root/join.pid")" 2>/dev/null || true
+  fi
+  if [ -f "$home/airc.pid" ]; then
+    local p
+    for p in $(cat "$home/airc.pid" 2>/dev/null); do
+      kill $(pgrep -P "$p" 2>/dev/null) "$p" 2>/dev/null || true
+    done
+  fi
+  sleep 1
+
+  local subs="$home/subscriptions.json"
+  [ -f "$subs" ] \
+    && pass "public wrapper wrote Rust subscriptions.json" \
+    || fail "public wrapper did not write subscriptions.json; out=$(cat "$out" 2>/dev/null); err=$(cat "$err" 2>/dev/null)"
+
+  grep -q '"general"' "$subs" 2>/dev/null \
+    && pass "default join subscribed #general" \
+    || fail "subscriptions missing #general: $(cat "$subs" 2>/dev/null)"
+
+  grep -q '"cambriantech"' "$subs" 2>/dev/null \
+    && pass "default join subscribed inferred #cambriantech" \
+    || fail "subscriptions missing #cambriantech: $(cat "$subs" 2>/dev/null)"
+
+  grep -q '"default":[[:space:]]*"cambriantech"' "$subs" 2>/dev/null \
+    && pass "inferred repo owner is the default channel" \
+    || fail "default channel was not cambriantech: $(cat "$subs" 2>/dev/null)"
+
+  local machine_real
+  machine_real=$(cd "$machine" && pwd -P)
+  grep -q "\"wire\":[[:space:]]*\"$machine_real/.airc/wires/cambriantech\"" "$subs" 2>/dev/null \
+    && pass "wire is account-home scoped, not project scoped" \
+    || fail "wire is not account-home scoped ($machine_real): $(cat "$subs" 2>/dev/null)"
+
+  local custom_root=/tmp/airc-it-wrapper-join-custom
+  local custom_machine="$custom_root/home"
+  local custom_repo="$custom_machine/openclaw"
+  local custom_home="$custom_repo/.airc"
+  mkdir -p "$custom_repo/.git" "$custom_home"
+  cat > "$custom_repo/.git/config" <<'EOF'
+[remote "origin"]
+    url = https://github.com/OpenClaw/openclaw.git
+EOF
+  cat > "$custom_home/mesh_identity.json" <<'EOF'
+{
+  "version": 1,
+  "identity": "joelteply",
+  "source": "operator",
+  "resolved_at_ms": 1,
+  "ttl_ms": 86400000
+}
+EOF
+  (
+    cd "$custom_repo" || exit 1
+    HOME="$custom_machine" AIRC_HOME="$custom_home" AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 \
+      AIRC_BACKGROUND_OK=1 AIRC_NO_ATTACH=1 "$AIRC" join --room continuum-activity-7 --no-gist >"$custom_root/out.log" 2>"$custom_root/err.log" &
+    echo $! > "$custom_root/join.pid"
+  )
+  sleep 3
+  if [ -f "$custom_root/join.pid" ]; then
+    kill "$(cat "$custom_root/join.pid")" 2>/dev/null || true
+  fi
+  if [ -f "$custom_home/airc.pid" ]; then
+    local p
+    for p in $(cat "$custom_home/airc.pid" 2>/dev/null); do
+      kill $(pgrep -P "$p" 2>/dev/null) "$p" 2>/dev/null || true
+    done
+  fi
+  sleep 1
+  local custom_subs="$custom_home/subscriptions.json"
+  grep -q '"continuum-activity-7"' "$custom_subs" 2>/dev/null \
+    && pass "explicit --room joins arbitrary channel through Rust coordinator" \
+    || fail "explicit --room did not seed arbitrary channel: $(cat "$custom_subs" 2>/dev/null)"
+
+  cleanup_all
+}
+
 # ── Scenario: codex_join_detaches_transport ────────────────────────────
 # Public Codex flow is plain `airc join`. The shell dispatch detects Codex
 # and routes through the detach adapter, while the spawned child is guarded
@@ -4771,6 +4880,7 @@ case "$MODE" in
   attach_reports_starting_transport) scenario_attach_reports_starting_transport ;;
   join_rejects_unknown_flag) scenario_join_rejects_unknown_flag ;;
   join_intent_failure_falls_back_to_host) scenario_join_intent_failure_falls_back_to_host ;;
+  wrapper_join_seeds_rust_account_context) scenario_wrapper_join_seeds_rust_account_context ;;
   codex_join_detaches_transport) scenario_codex_join_detaches_transport ;;
   codex_join_idempotent_when_healthy) scenario_codex_join_idempotent_when_healthy ;;
   codex_join_waits_for_duplicate_repair) scenario_codex_join_waits_for_duplicate_repair ;;
@@ -4809,7 +4919,7 @@ case "$MODE" in
     scenario_identity; scenario_whois; scenario_kick; scenario_heartbeat
     scenario_bounce; scenario_two_tab_localhost; scenario_auto_scope
     scenario_send_dead_monitor_dies; scenario_send_gone_gist_does_not_claim_delivery; scenario_monitor_gone_gist_stops_respawn; scenario_monitor_liveness_process_evidence
-    scenario_attach_starts_background_transport; scenario_attach_transport_survives_launcher_hup; scenario_attach_spawn_strips_attach_flag; scenario_attach_reports_starting_transport; scenario_join_rejects_unknown_flag; scenario_join_intent_failure_falls_back_to_host; scenario_codex_join_detaches_transport
+    scenario_attach_starts_background_transport; scenario_attach_transport_survives_launcher_hup; scenario_attach_spawn_strips_attach_flag; scenario_attach_reports_starting_transport; scenario_join_rejects_unknown_flag; scenario_join_intent_failure_falls_back_to_host; scenario_wrapper_join_seeds_rust_account_context; scenario_codex_join_detaches_transport
     scenario_codex_join_idempotent_when_healthy
     scenario_codex_join_waits_for_duplicate_repair
     scenario_join_reaps_duplicate_scope_transport


### PR DESCRIPTION
Summary
- route bare `airc join` through the Rust account-room coordinator before legacy attach/setup continues
- canonicalize same-machine account home paths so `/tmp` and `/private/tmp` scopes share the correct account wire
- add a real wrapper integration scenario for default and explicit room joins, without fake early-exit hooks
- isolate Codex hook and e2e subprocess tests from accidental shared Windows account wires
- clean account-mesh docs so forbidden legacy install names stay out of the repo

Verification
- bash test/integration.sh wrapper_join_seeds_rust_account_context
- bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh
- bash test/rust_cutover_guard.sh
- bash test/rust_quality_guard.sh
- cargo fmt --manifest-path Cargo.toml --all -- --check
- cargo clippy --manifest-path Cargo.toml -p airc-cli --test codex_hook_commands -- -D warnings
- cargo clippy --manifest-path Cargo.toml -p airc-cli --test e2e -- -D warnings
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings
- cargo clippy --manifest-path Cargo.toml --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm
- cargo test --manifest-path Cargo.toml -p airc-cli --test codex_hook_commands
- cargo test --manifest-path Cargo.toml -p airc-cli --test e2e
- cargo test --manifest-path Cargo.toml -p airc-lib same_machine_scopes_share_account_wire_and_registry -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-lib default_join_context_subscribes_general_and_repo_owner_on_shared_account_wire -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli join_without_args_uses_default_account_context -- --nocapture
- cargo test --manifest-path Cargo.toml --workspace --no-fail-fast