### PR TITLE
test(install): gate public airc shim path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,16 @@ jobs:
 
       - name: airc doctor (must report environment-clean)
         run: |
-          export PATH="$HOME/.airc/src:$PATH"
+          export PATH="$HOME/.local/bin:$PATH"
           which airc
-          test "$(which airc)" = "$HOME/.airc/src/airc"
+          test "$(which airc)" = "$HOME/.local/bin/airc"
+          airc version
+          test ! -e "$HOME/.local/bin/airc-core"
           airc doctor
 
       - name: Smoke — connect --no-room --no-gist + teardown
         run: |
-          export PATH="$HOME/.airc/src:$PATH"
+          export PATH="$HOME/.local/bin:$PATH"
           export AIRC_HOME=/tmp/ci-airc/state
           export AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 AIRC_NO_IDENTITY_PROMPT=1
           mkdir -p /tmp/ci-airc/state
@@ -112,14 +114,16 @@ jobs:
 
       - name: airc doctor (must report environment-clean)
         run: |
-          export PATH="$HOME/.airc/src:$PATH"
+          export PATH="$HOME/.local/bin:$PATH"
           which airc
-          test "$(which airc)" = "$HOME/.airc/src/airc"
+          test "$(which airc)" = "$HOME/.local/bin/airc"
+          airc version
+          test ! -e "$HOME/.local/bin/airc-core"
           airc doctor
 
       - name: Smoke — same as linux (airc.pid based)
         run: |
-          export PATH="$HOME/.airc/src:$PATH"
+          export PATH="$HOME/.local/bin:$PATH"
           export AIRC_HOME=/tmp/ci-airc/state
           export AIRC_NO_DISCOVERY=1 AIRC_NO_GENERAL=1 AIRC_NO_IDENTITY_PROMPT=1
           mkdir -p /tmp/ci-airc/state
@@ -216,7 +220,7 @@ jobs:
 
       - name: Run integration suite
         run: |
-          export PATH="$HOME/.airc/src:$PATH"
+          export PATH="$HOME/.local/bin:$PATH"
           # Tests that need real gists self-skip without gh auth. The
           # remaining ~85% of the suite covers the local-only scenarios
           # that catch the lion's share of regressions.

--- a/.github/workflows/runtime-guards.yml
+++ b/.github/workflows/runtime-guards.yml
@@ -10,21 +10,25 @@ on:
     branches: [rust-rewrite, canary, main]
     paths:
       - "airc"
+      - "airc.shim"
       - "install.sh"
       - "uninstall.sh"
       - "lib/airc_bash/**"
       - "test/rust_cutover_guard.sh"
       - "test/rust_quality_guard.sh"
+      - ".github/workflows/ci.yml"
       - ".github/workflows/runtime-guards.yml"
   push:
     branches: [rust-rewrite, canary, main]
     paths:
       - "airc"
+      - "airc.shim"
       - "install.sh"
       - "uninstall.sh"
       - "lib/airc_bash/**"
       - "test/rust_cutover_guard.sh"
       - "test/rust_quality_guard.sh"
+      - ".github/workflows/ci.yml"
       - ".github/workflows/runtime-guards.yml"
 
 jobs:
@@ -34,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: shell syntax
-        run: bash -n install.sh uninstall.sh airc lib/airc_bash/*.sh
+        run: bash -n install.sh uninstall.sh airc airc.shim lib/airc_bash/*.sh
       - name: Rust cutover guards
         run: bash test/rust_cutover_guard.sh
       - name: Rust quality guards

--- a/docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md
+++ b/docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md
@@ -57,11 +57,12 @@ Forbidden install shapes:
 - wrappers that silently fall back to an older installed binary;
 - test-only environment variables as the normal user path.
 
-The installer may place a tiny PATH shim if the OS requires it, but the shim
-must resolve to the canonical installed source command in `~/.airc/src/airc`
-or the canonical built artifact for that exact source checkout. It must fail
-loudly if resolution is ambiguous. It must not search arbitrary old install
-locations.
+The installer places a tiny PATH shim at the platform's normal user-bin
+location (for example `~/.local/bin/airc` on POSIX). The shim must resolve to
+the canonical installed source command in `~/.airc/src/airc` or the canonical
+built artifact for that exact source checkout. It must fail loudly if
+resolution is ambiguous. It must not copy the full command implementation,
+search arbitrary old install locations, or expose a second product command.
 
 For version 1 there is no legacy runtime surface. Old Python, shell, gist-chat,
 and language-suffixed compatibility paths should be deleted when their Rust


### PR DESCRIPTION
Summary
- update clean-install CI to validate `airc` resolves from the user PATH shim at `~/.local/bin/airc`
- keep the canonical source checkout as the implementation by proving `airc version` dispatches successfully through the shim
- reject stale `~/.local/bin/airc-core` in POSIX clean-install jobs
- include `airc.shim` and clean-install workflow changes in runtime guard triggering
- update the account-mesh install contract to state the shim is the normal public command surface

Verification
- bash -n install.sh uninstall.sh airc airc.shim lib/airc_bash/*.sh
- bash test/rust_cutover_guard.sh
- bash test/rust_quality_guard.sh
- temp-home CI-style install smoke: `which airc == $HOME/.local/bin/airc`, `airc version`, no `$HOME/.local/bin/airc-core`
