### PR TITLE
feat(lib): wire account join discovery into local delivery

### DIFF
--- a/airc
+++ b/airc
@@ -2613,6 +2613,7 @@ case "${1:-help}" in
   canary) shift; cmd_update --channel canary "$@" ;;
   logs)      shift; cmd_logs "$@" ;;
   inbox|poll) shift; cmd_inbox "$@" ;;
+  events)    shift; "$(airc_core_bin)" --home "$AIRC_WRITE_DIR" events "$@" ;;
   codex-poll) shift; AIRC_INBOX_QUIET_EMPTY=1 AIRC_INBOX_EXCLUDE_SELF=1 cmd_inbox --count 50 "$@" ;;
   codex-start) shift; cmd_codex_start "$@" ;;
   codex-hook) shift; cmd_codex_hook "$@" ;;

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -41,6 +41,7 @@ use crate::route::invite::{ImportedInviteTable, RouteEndpointTable};
 use crate::route::TransportHealthSample;
 use crate::subscriptions::{self, ChannelName, MeshIdentity, Subscription};
 use crate::transport::{FrameSubscriber, WireSubscriber};
+use crate::{coordinator, time};
 
 const EVENTS_DB_FILENAME: &str = "events.sqlite";
 
@@ -315,6 +316,43 @@ impl Airc {
         Ok(cached.as_mesh_identity())
     }
 
+    pub(crate) fn sync_account_peer_registry(&self) -> Result<(), AircError> {
+        let peers = load_peer_registries(&self.inner.home, &self.inner.wire_root)?;
+        let mut registry = self
+            .inner
+            .registry
+            .write()
+            .map_err(|_| AircError::Crypto("registry lock poisoned".to_string()))?;
+        for peer in peers {
+            registry
+                .enrol(
+                    peer.peer_id,
+                    0,
+                    peer.pubkey_bytes()
+                        .map_err(|e| AircError::Crypto(e.to_string()))?,
+                )
+                .map_err(|e| AircError::Crypto(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    fn publish_presence(
+        &self,
+        identity: &MeshIdentity,
+        set: &subscriptions::SubscriptionSet,
+    ) -> Result<(), AircError> {
+        let channels = set.channel_names().cloned().collect();
+        let beacon = coordinator::beacon_now(
+            self.inner.identity.peer_id,
+            self.inner.home.clone(),
+            channels,
+            std::process::id(),
+            time::now_ms()?,
+        );
+        coordinator::publish(&self.inner.wire_root, identity, &beacon)?;
+        Ok(())
+    }
+
     /// Subscribe to `name` and make it the default channel for
     /// short-shape commands.
     pub async fn join(&self, name: &str) -> Result<Room, AircError> {
@@ -325,6 +363,7 @@ impl Airc {
             set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
         set.set_default(channel)?;
         subscriptions::save(&self.inner.home, &set)?;
+        self.publish_presence(&identity, &set)?;
         let room = subscription.as_room();
         self.ensure_wire_subscriber(&room.wire).await?;
         Ok(room)
@@ -366,6 +405,7 @@ impl Airc {
             set.set_default(context.default)?;
         }
         subscriptions::save(&self.inner.home, &set)?;
+        self.publish_presence(&identity, &set)?;
 
         for room in &rooms {
             self.ensure_wire_subscriber(&room.wire).await?;
@@ -386,6 +426,7 @@ impl Airc {
         set.subscribed.insert(channel.clone(), subscription.clone());
         set.set_default(channel)?;
         subscriptions::save(&self.inner.home, &set)?;
+        self.publish_presence(&identity, &set)?;
         let room = subscription.as_room();
         self.ensure_wire_subscriber(&room.wire).await?;
         Ok(room)
@@ -406,6 +447,7 @@ impl Airc {
             set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
         set.set_default(channel)?;
         subscriptions::save(&self.inner.home, &set)?;
+        self.publish_presence(&identity, &set)?;
         Ok(subscription.as_room())
     }
 

--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -34,6 +34,9 @@ pub enum AircError {
     #[error("mesh identity: {0}")]
     MeshIdentity(#[from] crate::mesh_identity::MeshIdentityError),
 
+    #[error("account coordinator: {0}")]
+    Coordinator(#[from] crate::coordinator::CoordinatorError),
+
     #[error("system clock before UNIX_EPOCH: {0}")]
     Clock(#[from] std::time::SystemTimeError),
 

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -39,6 +39,7 @@ mod stream;
 pub mod subscriptions;
 mod time;
 mod transport;
+mod wire_replay;
 pub mod work;
 
 pub use airc::Airc;

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -29,6 +29,7 @@ impl Airc {
         body: Body,
         headers: Headers,
     ) -> Result<EventId, AircError> {
+        self.sync_account_peer_registry()?;
         let room = self.current_room().await?;
         let route = self.resolve_send_route(kind)?;
         let event_id = EventId::new();
@@ -134,6 +135,7 @@ impl Airc {
         if self.is_daemon_attached() {
             return self.daemon_page_recent(&room, limit).await;
         }
+        self.replay_wire_once(&room.wire).await?;
         self.ensure_wire_subscriber(&room.wire).await?;
         Ok(self
             .inner
@@ -150,6 +152,8 @@ impl Airc {
         limit: usize,
     ) -> Result<Vec<TranscriptEvent>, AircError> {
         let filter = self.scope_filter_to_current_room(filter).await?;
+        let room = self.current_room().await?;
+        self.replay_wire_once(&room.wire).await?;
         self.ensure_current_room_subscriber().await?;
         Ok(self
             .inner
@@ -168,6 +172,7 @@ impl Airc {
         limit: usize,
     ) -> Result<Vec<TranscriptEvent>, AircError> {
         let filter = self.subscribed_event_filter(filter).await?;
+        self.replay_subscribed_wires_once().await?;
         self.ensure_subscribed_room_subscribers().await?;
         Ok(self
             .inner
@@ -189,6 +194,7 @@ impl Airc {
         if self.is_daemon_attached() {
             return self.daemon_resume_from(&room, cursor, limit).await;
         }
+        self.replay_wire_once(&room.wire).await?;
         Ok(self
             .inner
             .store
@@ -206,6 +212,8 @@ impl Airc {
         limit: usize,
     ) -> Result<Vec<TranscriptEvent>, AircError> {
         let filter = self.scope_filter_to_current_room(filter).await?;
+        let room = self.current_room().await?;
+        self.replay_wire_once(&room.wire).await?;
         Ok(self
             .inner
             .store
@@ -224,6 +232,7 @@ impl Airc {
         limit: usize,
     ) -> Result<Vec<TranscriptEvent>, AircError> {
         let filter = self.subscribed_event_filter(filter).await?;
+        self.replay_subscribed_wires_once().await?;
         Ok(self
             .inner
             .store

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -487,7 +487,7 @@ impl Airc {
         Ok(room_ids)
     }
 
-    async fn subscribed_wires(&self) -> Result<Vec<PathBuf>, AircError> {
+    pub(crate) async fn subscribed_wires(&self) -> Result<Vec<PathBuf>, AircError> {
         let mut wires = Vec::new();
         let set = self.subscription_set().await?;
         for subscription in set.all() {

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -29,6 +29,7 @@ impl Airc {
         if subs.contains_key(wire) {
             return Ok(());
         }
+        self.sync_account_peer_registry()?;
         let transport = SignedTransport::new(
             LocalFsAdapter::new(wire),
             self.inner.identity.keypair.clone(),

--- a/crates/airc-lib/src/wire_replay.rs
+++ b/crates/airc-lib/src/wire_replay.rs
@@ -1,0 +1,51 @@
+use std::path::Path;
+
+use airc_protocol::{verify, Frame};
+
+use crate::error::AircError;
+use crate::Airc;
+
+const FRAMES_FILENAME: &str = "frames.jsonl";
+
+impl Airc {
+    pub(crate) async fn replay_wire_once(&self, wire: &Path) -> Result<(), AircError> {
+        self.sync_account_peer_registry()?;
+        let path = wire.join(FRAMES_FILENAME);
+        let text = match tokio::fs::read_to_string(&path).await {
+            Ok(text) => text,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(AircError::Transport(error.to_string())),
+        };
+
+        for line in text.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let frame: Frame = serde_json::from_str(trimmed)
+                .map_err(|error| AircError::Transport(error.to_string()))?;
+            {
+                let registry = self
+                    .inner
+                    .registry
+                    .read()
+                    .map_err(|_| AircError::Crypto("registry lock poisoned".to_string()))?;
+                verify(&frame, self.inner.policy, &registry)
+                    .map_err(|error| AircError::Crypto(error.to_string()))?;
+            }
+            let event = frame.into_transcript_event();
+            match self.inner.store.append(event).await {
+                Ok(()) | Err(airc_store::StoreError::DuplicateEventId(_)) => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn replay_subscribed_wires_once(&self) -> Result<(), AircError> {
+        for wire in self.subscribed_wires().await? {
+            self.replay_wire_once(&wire).await?;
+        }
+        Ok(())
+    }
+}

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -21,6 +21,9 @@ use airc_store::{EventStore, SqliteEventStore};
 use futures::stream::StreamExt;
 use tempfile::TempDir;
 
+static HOME_ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
 /// Poll `page_recent` until it sees at least `expected` events or
 /// the deadline fires. The wire-side tail loop runs in a background
 /// task; first attaches replay from the start of the wire, but the
@@ -226,6 +229,7 @@ async fn peer_spec_round_trips_via_add_peer() {
 #[test]
 fn same_machine_scopes_share_account_wire_and_registry() {
     let machine = TempDir::new().unwrap();
+    let _home_env_guard = HOME_ENV_LOCK.lock().unwrap();
 
     temp_env::with_var("HOME", Some(machine.path()), || {
         let runtime = tokio::runtime::Runtime::new().unwrap();
@@ -272,6 +276,7 @@ fn same_machine_scopes_share_account_wire_and_registry() {
 #[test]
 fn default_join_context_subscribes_general_and_repo_owner_on_shared_account_wire() {
     let machine = TempDir::new().unwrap();
+    let _home_env_guard = HOME_ENV_LOCK.lock().unwrap();
 
     temp_env::with_var("HOME", Some(machine.path()), || {
         let runtime = tokio::runtime::Runtime::new().unwrap();

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -11,9 +11,10 @@ use std::{net::SocketAddr, time::Duration};
 
 use airc_daemon::{DaemonState, LocalIdentity};
 use airc_lib::{
-    resolve_mesh_identity_with, subscriptions, Airc, Body, ChannelName, EventFilter, HeaderFilter,
-    Headers, MeshIdentity, MeshIdentitySource, PeerSpec, RouteEndpoint, SubscriptionSet,
-    TranscriptKind, TransportHealthSample, TransportKind, TransportRole,
+    coordinator_snapshot, resolve_mesh_identity_with, subscriptions, Airc, Body, ChannelName,
+    CoordinatorConfig, EventFilter, HeaderFilter, Headers, MeshIdentity, MeshIdentitySource,
+    PeerSpec, RouteEndpoint, SubscriptionSet, TranscriptKind, TransportHealthSample, TransportKind,
+    TransportRole,
 };
 use airc_protocol::{PeerKeyRegistry, VerificationPolicy};
 use airc_store::{EventStore, SqliteEventStore};
@@ -310,6 +311,41 @@ fn default_join_context_subscribes_general_and_repo_owner_on_shared_account_wire
             assert_eq!(
                 alice.current_room().await.unwrap().channel,
                 bob.current_room().await.unwrap().channel
+            );
+
+            let now_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64;
+            let snapshot = coordinator_snapshot(
+                &machine.path().join(".airc"),
+                &MeshIdentity::new("joelteply"),
+                &CoordinatorConfig::default(),
+                now_ms,
+            )
+            .unwrap();
+            assert_eq!(snapshot.live.len(), 2);
+            assert_eq!(
+                snapshot
+                    .live_channels
+                    .iter()
+                    .map(ChannelName::as_str)
+                    .collect::<Vec<_>>(),
+                vec!["cambriantech", "general"]
+            );
+            assert!(
+                snapshot
+                    .live
+                    .iter()
+                    .any(|beacon| beacon.scope_home == alice_home),
+                "join_default_context must publish Alice's scope beacon"
+            );
+            assert!(
+                snapshot
+                    .live
+                    .iter()
+                    .any(|beacon| beacon.scope_home == bob_home),
+                "join_default_context must publish Bob's scope beacon"
             );
 
             alice.say("default account context works").await.unwrap();

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -229,7 +229,7 @@ async fn peer_spec_round_trips_via_add_peer() {
 #[test]
 fn same_machine_scopes_share_account_wire_and_registry() {
     let machine = TempDir::new().unwrap();
-    let _home_env_guard = HOME_ENV_LOCK.lock().unwrap();
+    let _home_env_guard = HOME_ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
 
     temp_env::with_var("HOME", Some(machine.path()), || {
         let runtime = tokio::runtime::Runtime::new().unwrap();
@@ -276,7 +276,7 @@ fn same_machine_scopes_share_account_wire_and_registry() {
 #[test]
 fn default_join_context_subscribes_general_and_repo_owner_on_shared_account_wire() {
     let machine = TempDir::new().unwrap();
-    let _home_env_guard = HOME_ENV_LOCK.lock().unwrap();
+    let _home_env_guard = HOME_ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
 
     temp_env::with_var("HOME", Some(machine.path()), || {
         let runtime = tokio::runtime::Runtime::new().unwrap();
@@ -394,10 +394,14 @@ fn repo_with_origin(path: &std::path::Path, origin: &str) -> std::path::PathBuf 
 }
 
 fn seed_mesh_identity(home: &std::path::Path, identity: &str) {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
     resolve_mesh_identity_with(
         home,
         || Some((identity.to_string(), MeshIdentitySource::Operator)),
-        1,
+        now_ms,
     )
     .unwrap();
 }

--- a/docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md
+++ b/docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md
@@ -301,17 +301,23 @@ Already landed in rust-rewrite:
 - public installed runtime proof for Linux/macOS clean-install CI:
   `test/public_installed_runtime_proof.sh` validates `airc` from PATH, rejects
   stale `airc-core`, runs two fresh project scopes through public `airc join`,
-  and proves they converge on the same account-home `#general` RoomId and wire.
+  proves they converge on the same account-home `#general` RoomId and wire,
+  sends through public `airc msg`, and proves the second scope reads that
+  message through the Rust event surface;
+- machine-global coordinator/cache under `~/.airc/accounts/<identity>/` with
+  typed presence beacons, TTL partitioning, and atomic refresh singleflight;
+- `Airc::join` / `Airc::join_default_context()` publish coordinator beacons for
+  the joined subscription set;
+- durable Rust event reads synchronously replay the local-fs wire into the
+  store before querying, so one-shot commands and hooks do not race a
+  background tailer.
 
 Current rust-rewrite still has account-mesh gaps:
 
 - CLI `room` language still needs final cleanup so it reads as subscription
   management rather than single-room switching;
-- machine-global coordinator/cache is not implemented yet;
-- same-machine peer discovery still relies on peer records being present rather
-  than a coordinator-owned local presence registry;
 - monitor and hook reliability must be proven through public installed
-  commands after coordinator discovery lands;
+  commands using the same coordinator-backed join path;
 - cross-machine account-mesh discovery still needs the rare remote registry
   publisher/refresh path.
 
@@ -326,9 +332,10 @@ Required corrections:
    a channel without removing the rest.
 4. Keep monitor and hooks defaulted to all subscribed channels, not current
    room.
-5. Add machine-global coordinator/cache under `~/.airc/accounts/<identity>/`.
-6. Add account-mesh registry abstraction for `git user identity + channel ->
-   beacon`.
+5. Keep machine-global coordinator/cache under `~/.airc/accounts/<identity>/`
+   as the local source of truth for joined scopes and live channels.
+6. Keep account-mesh registry abstraction for `git user identity + channel ->
+   beacon`, and wire public monitor/hook commands through it.
 7. Keep the data plane selected by route policy: local, LAN, relay, WebRTC,
    Reticulum, etc. Gist remains registry/bootstrap.
 8. Add Rust Tailscale discovery/login health: detect installed/down/logged-out,
@@ -341,43 +348,35 @@ Required corrections:
    worktrees under `~/.airc/worktrees`, and no stale language-suffixed binaries
    or hidden alternate source roots.
 
-## Handoff: Claude Coordinator Slice
+## Handoff: Monitor And Hook Proof
 
-Claude should not reimplement `join_default_context`, wrapper seeding, or the
-PATH shim. Those are already landed. Claude's next slice is the machine-global
-coordinator.
+The coordinator foundation and join wiring are landed. Claude should not
+reimplement `join_default_context`, wrapper seeding, PATH shim, coordinator
+locks, or wire replay. The next slice is the automatic delivery surface.
 
 Scope:
 
-- new coordinator state under `~/.airc/accounts/<mesh-identity>/`;
-- local presence/beacon registry for this machine;
-- channel subscriptions projected into that registry;
-- TTL and singleflight so ten local agents running `airc join` cause at most
-  one remote refresh;
-- same-machine peer discovery before GitHub/gist;
-- no monitor/hook changes in the first coordinator PR unless the coordinator
-  API is already stable.
+- validate `airc join --attach` from a clean installed source, no manual binary
+  copy and no test-only environment override;
+- prove a second fresh scope sends via public `airc msg` and the first scope's
+  monitor emits the inbound event live;
+- prove `airc codex-hook user-prompt-submit` reads the same message through the
+  Rust subscribed event surface;
+- keep all monitor and hook reads scoped to the subscription set, not a
+  single current room;
+- do not add shell log scraping, gist polling, symlink workarounds, or
+  alternate source roots.
 
-Acceptance for Claude's coordinator PR:
+Acceptance for the monitor/hook PR:
 
-- two fresh scopes on the same machine and same mesh identity run public
-  `airc join` and discover the same account channels without an invite;
-- no GitHub access is required for same-machine discovery after the first local
-  coordinator state exists;
-- concurrent joins serialize through the coordinator instead of racing remote
-  registry refresh;
-- coordinator state is typed and inspectable by `airc doctor` / future status
-  commands;
-- no shell-only state machine and no test-only environment variable path.
-
-Codex's parallel proof-gate slice does not implement coordinator behavior. It
-adds the installed-command test harness that coordinator wiring must satisfy.
-When Claude's wiring PR publishes beacons from `Airc::join` and reads the local
-snapshot for same-machine discovery, extend
-`test/public_installed_runtime_proof.sh` rather than adding another ad-hoc
-manual test. The next assertion to add there is: after both fresh scopes join,
-a public `airc msg` from one scope is visible to the other through monitor or
-hook delivery without peer pre-seeding and without GitHub.
+- `test/public_installed_runtime_proof.sh` or a sibling public-install proof
+  starts two fresh scopes, runs bare `airc join`, sends from one, and observes
+  the other through monitor or hook delivery without peer pre-seeding and
+  without GitHub;
+- one-shot event reads remain deterministic through SDK wire replay, not
+  sleeps around background tailers;
+- the public command remains `airc`; no hidden language-suffixed runtime path
+  or alternate source root is introduced.
 
 ## Acceptance Tests
 

--- a/test/public_installed_runtime_proof.sh
+++ b/test/public_installed_runtime_proof.sh
@@ -189,4 +189,49 @@ openclaw_general_wire="$(json_channel_field "$OPENCLAW_SCOPE/subscriptions.json"
 [ "$continuum_general_wire" = "$MACHINE_HOME_REAL/.airc/wires/general" ] \
   || fail "#general wire must be account-home scoped, got $continuum_general_wire"
 
-log "public airc command, account-room derivation, and same-machine #general wire are coherent"
+PROOF_MESSAGE="public installed runtime proof $(date +%s)"
+(
+  cd "$CONTINUUM_REPO" || exit 1
+  HOME="$MACHINE_HOME" \
+    AIRC_HOME="$CONTINUUM_SCOPE" \
+    AIRC_NO_DISCOVERY=1 \
+    AIRC_NO_GENERAL=1 \
+    AIRC_BACKGROUND_OK=1 \
+    AIRC_NO_ATTACH=1 \
+    "$AIRC_BIN" msg --channel general "$PROOF_MESSAGE" >"$ROOT/msg.out" 2>"$ROOT/msg.err"
+) || {
+  echo "--- msg stdout ---" >&2
+  cat "$ROOT/msg.out" >&2 || true
+  echo "--- msg stderr ---" >&2
+  cat "$ROOT/msg.err" >&2 || true
+  fail "public airc msg failed"
+}
+
+wait_for_message() {
+  local deadline=$((SECONDS + 12))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    (
+      cd "$OPENCLAW_REPO" || exit 1
+      HOME="$MACHINE_HOME" \
+        AIRC_HOME="$OPENCLAW_SCOPE" \
+        AIRC_NO_DISCOVERY=1 \
+        AIRC_NO_GENERAL=1 \
+        AIRC_BACKGROUND_OK=1 \
+        AIRC_NO_ATTACH=1 \
+        "$AIRC_BIN" events list --kind message --limit 32
+    ) >"$ROOT/events.out" 2>"$ROOT/events.err" || return 1
+    grep -q "$PROOF_MESSAGE" "$ROOT/events.out" && return 0
+    sleep 1
+  done
+  return 1
+}
+
+if ! wait_for_message; then
+  echo "--- events stdout ---" >&2
+  cat "$ROOT/events.out" >&2 || true
+  echo "--- events stderr ---" >&2
+  cat "$ROOT/events.err" >&2 || true
+  fail "second fresh scope did not read public airc msg from account wire"
+fi
+
+log "public airc command, account-room derivation, same-machine #general wire, and message delivery are coherent"


### PR DESCRIPTION
## Summary
- publish account coordinator beacons from Rust join/current-room paths
- refresh account peer trust before local sends/subscribers
- add deterministic local-fs wire replay before durable event queries so one-shot hooks/commands do not race background tailers
- expose public `airc events` through the Rust CLI and extend the public installed proof to verify real same-machine message delivery
- update the account-mesh contract with the new handoff: monitor/hook live proof is next

## Verification
- cargo test --manifest-path Cargo.toml -p airc-lib
- cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings
- bash -n airc test/public_installed_runtime_proof.sh install.sh uninstall.sh lib/airc_bash/*.sh
- AIRC_BIN="$PWD/airc" AIRC_EXPECT_BIN="$PWD/airc" bash test/public_installed_runtime_proof.sh