### PR TITLE
test(install): prove public monitor and hook delivery

### DIFF
--- a/.github/workflows/runtime-guards.yml
+++ b/.github/workflows/runtime-guards.yml
@@ -14,6 +14,7 @@ on:
       - "install.sh"
       - "uninstall.sh"
       - "lib/airc_bash/**"
+      - "test/public_installed_runtime_proof.sh"
       - "test/rust_cutover_guard.sh"
       - "test/rust_quality_guard.sh"
       - ".github/workflows/ci.yml"
@@ -26,6 +27,7 @@ on:
       - "install.sh"
       - "uninstall.sh"
       - "lib/airc_bash/**"
+      - "test/public_installed_runtime_proof.sh"
       - "test/rust_cutover_guard.sh"
       - "test/rust_quality_guard.sh"
       - ".github/workflows/ci.yml"
@@ -43,3 +45,7 @@ jobs:
         run: bash test/rust_cutover_guard.sh
       - name: Rust quality guards
         run: bash test/rust_quality_guard.sh
+      - name: Public installed runtime proof
+        run: |
+          cargo build --manifest-path Cargo.toml -p airc-cli
+          AIRC_BIN="$PWD/airc" AIRC_EXPECT_BIN="$PWD/airc" bash test/public_installed_runtime_proof.sh

--- a/docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md
+++ b/docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md
@@ -303,7 +303,8 @@ Already landed in rust-rewrite:
   stale `airc-core`, runs two fresh project scopes through public `airc join`,
   proves they converge on the same account-home `#general` RoomId and wire,
   sends through public `airc msg`, and proves the second scope reads that
-  message through the Rust event surface;
+  message through the Rust event surface, live `airc join --attach` monitor,
+  and `airc codex-hook user-prompt-submit`;
 - machine-global coordinator/cache under `~/.airc/accounts/<identity>/` with
   typed presence beacons, TTL partitioning, and atomic refresh singleflight;
 - `Airc::join` / `Airc::join_default_context()` publish coordinator beacons for
@@ -316,8 +317,6 @@ Current rust-rewrite still has account-mesh gaps:
 
 - CLI `room` language still needs final cleanup so it reads as subscription
   management rather than single-room switching;
-- monitor and hook reliability must be proven through public installed
-  commands using the same coordinator-backed join path;
 - cross-machine account-mesh discovery still needs the rare remote registry
   publisher/refresh path.
 
@@ -348,33 +347,35 @@ Required corrections:
    worktrees under `~/.airc/worktrees`, and no stale language-suffixed binaries
    or hidden alternate source roots.
 
-## Handoff: Monitor And Hook Proof
+## Handoff: Cross-Machine Registry Proof
 
-The coordinator foundation and join wiring are landed. Claude should not
-reimplement `join_default_context`, wrapper seeding, PATH shim, coordinator
-locks, or wire replay. The next slice is the automatic delivery surface.
+The local same-account path is proven through public installed commands:
+`airc join`, `airc msg`, `airc events`, `airc join --attach`, and
+`airc codex-hook user-prompt-submit`. Claude should not reimplement
+`join_default_context`, wrapper seeding, PATH shim, coordinator locks, wire
+replay, monitor attach, or hook reads.
 
 Scope:
 
-- validate `airc join --attach` from a clean installed source, no manual binary
-  copy and no test-only environment override;
-- prove a second fresh scope sends via public `airc msg` and the first scope's
-  monitor emits the inbound event live;
-- prove `airc codex-hook user-prompt-submit` reads the same message through the
-  Rust subscribed event surface;
-- keep all monitor and hook reads scoped to the subscription set, not a
-  single current room;
-- do not add shell log scraping, gist polling, symlink workarounds, or
-  alternate source roots.
+- implement the rare remote registry publisher/refresh path for account mesh
+  discovery;
+- keep GitHub/gist limited to registry/bootstrap metadata, never message
+  delivery;
+- use the coordinator singleflight/backoff so concurrent local joins cause one
+  remote refresh at most;
+- publish route beacons for direct transports (local/LAN/Tailscale/relay/etc.)
+  without changing channel semantics;
+- prove two clean scopes that do not share a local machine account can discover
+  the same account channels through the registry and then use the selected
+  data plane.
 
-Acceptance for the monitor/hook PR:
+Acceptance for the cross-machine PR:
 
-- `test/public_installed_runtime_proof.sh` or a sibling public-install proof
-  starts two fresh scopes, runs bare `airc join`, sends from one, and observes
-  the other through monitor or hook delivery without peer pre-seeding and
-  without GitHub;
-- one-shot event reads remain deterministic through SDK wire replay, not
-  sleeps around background tailers;
+- public installed proof or integration test creates two isolated machine homes
+  for the same mesh identity, runs bare `airc join`, and verifies they derive
+  the same `#general` and inferred org channel without a pasted invite;
+- the test asserts routine chat does not use GitHub as a data plane;
+- same-machine proof remains green without network access;
 - the public command remains `airc`; no hidden language-suffixed runtime path
   or alternate source root is introduced.
 

--- a/lib/airc_bash/cmd_connect.sh
+++ b/lib/airc_bash/cmd_connect.sh
@@ -897,7 +897,9 @@ cmd_connect() {
   if [ "$#" -ge 1 ] && [[ "$1" == *@*@*#* ]]; then
     _looks_like_invite=1
   fi
-  if [ "$use_room" = "1" ] && [ "$_looks_like_invite" = "0" ] \
+  if [ "$use_room" = "1" ] && [ "$use_gist" = "1" ] \
+     && [ "${AIRC_NO_DISCOVERY:-0}" != "1" ] \
+     && [ "$_looks_like_invite" = "0" ] \
      && command -v gh >/dev/null 2>&1; then
     # Pre-flight via the centralized state machine (lib_auth.sh).
     # ok → proceed; rate_limited → proceed degraded so the monitor can

--- a/test/public_installed_runtime_proof.sh
+++ b/test/public_installed_runtime_proof.sh
@@ -42,7 +42,11 @@ case "$(uname -s 2>/dev/null)" in
 esac
 
 ROOT="$(mktemp -d "${TMPDIR:-/tmp}/airc-public-proof.XXXXXX")"
+MONITOR_PID=""
 cleanup() {
+  if [ -n "$MONITOR_PID" ]; then
+    kill "$MONITOR_PID" 2>/dev/null || true
+  fi
   for scope in \
     "$ROOT/home/continuum/.airc" \
     "$ROOT/home/openclaw/.airc"; do
@@ -208,25 +212,35 @@ PROOF_MESSAGE="public installed runtime proof $(date +%s)"
 }
 
 wait_for_message() {
+  local repo="$1"
+  local scope="$2"
+  local message="$3"
+  local out="$4"
+  local err="$5"
   local deadline=$((SECONDS + 12))
   while [ "$SECONDS" -lt "$deadline" ]; do
     (
-      cd "$OPENCLAW_REPO" || exit 1
+      cd "$repo" || exit 1
       HOME="$MACHINE_HOME" \
-        AIRC_HOME="$OPENCLAW_SCOPE" \
+        AIRC_HOME="$scope" \
         AIRC_NO_DISCOVERY=1 \
         AIRC_NO_GENERAL=1 \
         AIRC_BACKGROUND_OK=1 \
         AIRC_NO_ATTACH=1 \
         "$AIRC_BIN" events list --kind message --limit 32
-    ) >"$ROOT/events.out" 2>"$ROOT/events.err" || return 1
-    grep -q "$PROOF_MESSAGE" "$ROOT/events.out" && return 0
+    ) >"$out" 2>"$err" || return 1
+    grep -q "$message" "$out" && return 0
     sleep 1
   done
   return 1
 }
 
-if ! wait_for_message; then
+if ! wait_for_message \
+  "$OPENCLAW_REPO" \
+  "$OPENCLAW_SCOPE" \
+  "$PROOF_MESSAGE" \
+  "$ROOT/events.out" \
+  "$ROOT/events.err"; then
   echo "--- events stdout ---" >&2
   cat "$ROOT/events.out" >&2 || true
   echo "--- events stderr ---" >&2
@@ -234,4 +248,129 @@ if ! wait_for_message; then
   fail "second fresh scope did not read public airc msg from account wire"
 fi
 
-log "public airc command, account-room derivation, same-machine #general wire, and message delivery are coherent"
+wait_for_file_text() {
+  local file="$1"
+  local needle="$2"
+  local deadline=$((SECONDS + 12))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    [ -f "$file" ] && grep -q "$needle" "$file" && return 0
+    sleep 1
+  done
+  return 1
+}
+
+start_monitor_for_scope() {
+  local repo="$1"
+  local scope="$2"
+  local out="$3"
+  local err="$4"
+  (
+    cd "$repo" || exit 1
+    HOME="$MACHINE_HOME" \
+      AIRC_HOME="$scope" \
+      AIRC_NO_DISCOVERY=1 \
+      AIRC_NO_GENERAL=1 \
+      AIRC_BACKGROUND_OK=1 \
+      "$AIRC_BIN" join --attach --no-gist >"$out" 2>"$err"
+  ) &
+  MONITOR_PID=$!
+  if ! wait_for_file_text "$out" "attached to Rust event stream"; then
+    echo "--- monitor stdout ---" >&2
+    cat "$out" >&2 || true
+    echo "--- monitor stderr ---" >&2
+    cat "$err" >&2 || true
+    fail "public airc join --attach did not attach monitor to Rust event stream"
+  fi
+}
+
+MONITOR_MESSAGE="monitor public proof $(date +%s)"
+start_monitor_for_scope "$OPENCLAW_REPO" "$OPENCLAW_SCOPE" "$ROOT/monitor.out" "$ROOT/monitor.err"
+(
+  cd "$CONTINUUM_REPO" || exit 1
+  HOME="$MACHINE_HOME" \
+    AIRC_HOME="$CONTINUUM_SCOPE" \
+    AIRC_NO_DISCOVERY=1 \
+    AIRC_NO_GENERAL=1 \
+    AIRC_BACKGROUND_OK=1 \
+    AIRC_NO_ATTACH=1 \
+    "$AIRC_BIN" msg --channel general "$MONITOR_MESSAGE" >"$ROOT/monitor-msg.out" 2>"$ROOT/monitor-msg.err"
+) || {
+  echo "--- monitor msg stdout ---" >&2
+  cat "$ROOT/monitor-msg.out" >&2 || true
+  echo "--- monitor msg stderr ---" >&2
+  cat "$ROOT/monitor-msg.err" >&2 || true
+  fail "public airc msg for monitor proof failed"
+}
+
+if ! wait_for_file_text "$ROOT/monitor.out" "$MONITOR_MESSAGE"; then
+  echo "--- monitor stdout ---" >&2
+  cat "$ROOT/monitor.out" >&2 || true
+  echo "--- monitor stderr ---" >&2
+  cat "$ROOT/monitor.err" >&2 || true
+  fail "public airc join --attach did not render inbound peer message"
+fi
+
+kill "$MONITOR_PID" 2>/dev/null || true
+MONITOR_PID=""
+
+HOOK_MESSAGE="codex hook public proof $(date +%s)"
+(
+  cd "$CONTINUUM_REPO" || exit 1
+  HOME="$MACHINE_HOME" \
+    AIRC_HOME="$CONTINUUM_SCOPE" \
+    AIRC_NO_DISCOVERY=1 \
+    AIRC_NO_GENERAL=1 \
+    AIRC_BACKGROUND_OK=1 \
+    AIRC_NO_ATTACH=1 \
+    "$AIRC_BIN" msg --channel general "$HOOK_MESSAGE" >"$ROOT/hook-msg.out" 2>"$ROOT/hook-msg.err"
+) || {
+  echo "--- hook msg stdout ---" >&2
+  cat "$ROOT/hook-msg.out" >&2 || true
+  echo "--- hook msg stderr ---" >&2
+  cat "$ROOT/hook-msg.err" >&2 || true
+  fail "public airc msg for codex-hook proof failed"
+}
+
+if ! wait_for_message \
+  "$OPENCLAW_REPO" \
+  "$OPENCLAW_SCOPE" \
+  "$HOOK_MESSAGE" \
+  "$ROOT/hook-events.out" \
+  "$ROOT/hook-events.err"; then
+  echo "--- hook warmup events stdout ---" >&2
+  cat "$ROOT/hook-events.out" >&2 || true
+  echo "--- hook warmup events stderr ---" >&2
+  cat "$ROOT/hook-events.err" >&2 || true
+  fail "second fresh scope did not persist hook proof message before codex-hook"
+fi
+
+(
+  cd "$OPENCLAW_REPO" || exit 1
+  printf '{"hook_event_name":"UserPromptSubmit"}' | \
+    HOME="$MACHINE_HOME" \
+    AIRC_HOME="$OPENCLAW_SCOPE" \
+    AIRC_NO_DISCOVERY=1 \
+    AIRC_NO_GENERAL=1 \
+    AIRC_BACKGROUND_OK=1 \
+    AIRC_NO_ATTACH=1 \
+    "$AIRC_BIN" codex-hook user-prompt-submit \
+      --cursor-file "$ROOT/codex-hook-cursor.json" \
+      --count 64 \
+      --raw
+) >"$ROOT/codex-hook.out" 2>"$ROOT/codex-hook.err" || {
+  echo "--- codex-hook stdout ---" >&2
+  cat "$ROOT/codex-hook.out" >&2 || true
+  echo "--- codex-hook stderr ---" >&2
+  cat "$ROOT/codex-hook.err" >&2 || true
+  fail "public airc codex-hook user-prompt-submit failed"
+}
+
+if ! grep -q "$HOOK_MESSAGE" "$ROOT/codex-hook.out"; then
+  echo "--- codex-hook stdout ---" >&2
+  cat "$ROOT/codex-hook.out" >&2 || true
+  echo "--- codex-hook stderr ---" >&2
+  cat "$ROOT/codex-hook.err" >&2 || true
+  fail "public airc codex-hook did not include inbound Rust event context"
+fi
+
+log "public airc command, account-room derivation, same-machine #general wire, message delivery, monitor attach, and codex-hook are coherent"


### PR DESCRIPTION
## Summary
- extend the public installed runtime proof beyond polling: `airc join --attach` must render a live inbound Rust event
- prove `airc codex-hook user-prompt-submit` reads inbound context from the same Rust subscribed event surface
- update the account-mesh contract: local monitor/hook proof is now covered; next gap is cross-machine registry/bootstrap

## Verification
- bash -n test/public_installed_runtime_proof.sh
- bash test/rust_cutover_guard.sh
- AIRC_BIN="$PWD/airc" AIRC_EXPECT_BIN="$PWD/airc" bash test/public_installed_runtime_proof.sh
- cargo test --manifest-path Cargo.toml -p airc-cli --test operational_dogfood
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings