### PR TITLE
fix(status): show rust command mode after stale startup

### DIFF
--- a/lib/airc_bash/cmd_status.sh
+++ b/lib/airc_bash/cmd_status.sh
@@ -164,7 +164,9 @@ cmd_status() {
     if [ "$_elapsed" -le 600 ] 2>/dev/null; then
       monitor_state="starting (airc join cold-start in progress, t+${_elapsed}s)"
     fi
-  elif "$(airc_core_bin)" --home "$AIRC_WRITE_DIR" room >/dev/null 2>&1; then
+  fi
+  if [ "$monitor_state" = "not running" ] \
+      && "$(airc_core_bin)" --home "$AIRC_WRITE_DIR" room >/dev/null 2>&1; then
     monitor_state="not attached (rust-local command mode)"
   fi
   echo "  airc process: $monitor_state"


### PR DESCRIPTION
Summary
- report Rust local command-mode scopes as not attached even when an old cold-start marker is present
- keeps status from looking broken after public Rust join succeeds without a monitor

Verification
- bash -n lib/airc_bash/cmd_status.sh airc
- AIRC_HOME="$HOME/.airc" ./airc status
- AIRC_BIN="$PWD/airc" AIRC_EXPECT_BIN="$PWD/airc" bash test/public_installed_runtime_proof.sh