### PR TITLE
fix(send/msg): receipt no longer lies about non-delivery on shared-home wire

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -118,14 +118,27 @@ pub async fn run_send(
     let current = airc.current_room().await?;
     airc.say(text).await?;
     let peer_count = airc.peers().await?.len();
+    // `Airc::say` returned Ok — the frame is signed, persisted to the
+    // local store, and written to the wire. Any scope tailing this
+    // channel's wire will receive it. The peer-registry count
+    // (`peers()`) reflects cryptographically-paired *remote* peers;
+    // a count of 0 does NOT mean "no readers." Two scopes on the
+    // same machine share the wire via the account-home convention
+    // and deliver to each other without any peer enrollment.
+    //
+    // The previous "stored locally — not delivered to another
+    // agent" wording was a lie in exactly that case (caught by
+    // Codex's criterion #3): the message DID deliver to same-
+    // machine same-HOME tailers. Replace with a description that
+    // matches what actually happened.
     if peer_count == 0 {
         println!(
-            "stored locally in {} ({}) - no enrolled peers; not delivered to another agent.",
+            "sent to {} ({}). 0 paired remote peers; any scope tailing this channel on this machine will receive it.",
             current.name, current.channel
         );
     } else {
         println!(
-            "sent to {} ({}) for {peer_count} enrolled peer(s).",
+            "sent to {} ({}) — {peer_count} paired peer(s) + any local scope tailing this channel.",
             current.name, current.channel
         );
     }
@@ -275,14 +288,16 @@ pub async fn run_msg(
     let current = airc.current_room().await?;
     airc.say(text).await?;
     let peer_count = airc.peers().await?.len();
+    // See run_send for the rationale — same message-honesty fix
+    // for the daemon-attached send path.
     if peer_count == 0 {
         println!(
-            "stored locally in {} ({}) - no enrolled peers; not delivered to another agent.",
+            "sent to {} ({}). 0 paired remote peers; any scope tailing this channel on this machine will receive it.",
             current.name, current.channel
         );
     } else {
         println!(
-            "sent to {} ({}) for {peer_count} enrolled peer(s).",
+            "sent to {} ({}) — {peer_count} paired peer(s) + any local scope tailing this channel.",
             current.name, current.channel
         );
     }

--- a/crates/airc-cli/tests/events_commands.rs
+++ b/crates/airc-cli/tests/events_commands.rs
@@ -47,16 +47,29 @@ fn events_list_filters_by_kind_and_header_prefix() {
 }
 
 #[test]
-fn send_receipt_distinguishes_local_store_from_peer_delivery() {
+fn send_receipt_distinguishes_zero_paired_peers_without_lying_about_delivery() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");
 
     run_ok(&home, &["init"]);
-    let output = run_ok(&home, &["send", "not delivered to a peer"]);
+    let output = run_ok(&home, &["send", "wire-only send"]);
 
-    assert!(output.contains("stored locally"));
-    assert!(output.contains("no enrolled peers"));
-    assert!(output.contains("not delivered to another agent"));
+    // With zero paired remote peers, the message IS still delivered
+    // to any same-machine scope tailing the channel (post-#857
+    // cross-process broadcast fix). The receipt must not lie about
+    // non-delivery.
+    assert!(
+        output.contains("sent to"),
+        "receipt must lead with 'sent to' — not the old 'stored locally' wording, got: {output}"
+    );
+    assert!(
+        output.contains("0 paired remote peers"),
+        "receipt must surface zero-paired-remote-peers without claiming non-delivery, got: {output}"
+    );
+    assert!(
+        !output.contains("not delivered"),
+        "receipt must NOT claim non-delivery — same-machine tailers will receive it, got: {output}"
+    );
 }
 
 fn run_ok(home: &Path, args: &[&str]) -> String {


### PR DESCRIPTION
## Criterion #3 of Codex's reliability list

> "airc send/msg must either deliver to enrolled peers or fail loudly with the exact reason."

Pre-#857, "0 paired peers" genuinely meant nobody received the message and the receipt said so. Post-#857 (cross-process broadcast fix), any same-machine same-HOME scope tailing the channel DOES receive the send — so the old "stored locally / not delivered to another agent" wording became a lie in exactly that case. Chat narrates live in Monitor but the send receipt insists nobody got it.

## Fix

Receipt is now fact-based:

\`\`\`
with paired peers:
  sent to <chan> — N paired peer(s) + any local scope tailing this channel.

with no paired peers:
  sent to <chan>. 0 paired remote peers; any scope tailing this channel on this machine will receive it.
\`\`\`

Both true. Neither claims non-delivery. Applied to both \`run_send\` (direct local-fs) and \`run_msg\` (daemon-attached).

## Test plan

- [x] \`send_receipt_distinguishes_zero_paired_peers_without_lying_about_delivery\` updated to assert the new honest wording
- [x] \`cargo test -p airc-cli\`: all green
- [x] \`cargo clippy -p airc-cli --all-targets -- -D warnings\`: clean
- [x] \`cargo fmt --check\`: clean

## Remaining criteria

- #1 status counts Rust peers → #858
- #2 \`airc join\` project-scope clarity → next
- #4 public-install both-ways live receipt proof → after #1+#2+#3 land

🤖 Generated with [Claude Code](https://claude.com/claude-code)