### PR TITLE
feat(join): explicit scope + mesh-kind in output

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -87,6 +87,7 @@ pub async fn run_join(home: &Path, room: Option<String>) -> Result<(), Box<dyn s
             println!("joined:  #{}", joined.name);
             println!("wire:    {}", joined.wire.display());
             println!("channel: {}", joined.channel);
+            print_scope_context(home, &joined.wire);
         }
         None => {
             let cwd = std::env::current_dir()?;
@@ -98,9 +99,49 @@ pub async fn run_join(home: &Path, room: Option<String>) -> Result<(), Box<dyn s
             }
             println!("default: #{}", current.name);
             println!("wire:    {}", current.wire.display());
+            print_scope_context(home, &current.wire);
         }
     }
     Ok(())
+}
+
+/// Tell the operator which scope they actually joined and whether
+/// it's sharing the machine-account wire or running isolated. The
+/// substrate already routes correctly; this is purely diagnostic so
+/// `airc join` from a project dir doesn't leave anyone wondering
+/// "am I on the same mesh as my HOME tabs?"
+///
+/// Codex's criterion #2: "airc join from a project scope must
+/// converge onto the same usable account mesh or clearly show which
+/// scope it is using."
+fn print_scope_context(home: &Path, wire: &Path) {
+    // wire = <wire_root>/wires/<channel> → wire_root is two parents up.
+    let wire_root = wire
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.to_path_buf());
+    let scope = home.canonicalize().unwrap_or_else(|_| home.to_path_buf());
+    let wire_root_canon = wire_root
+        .as_ref()
+        .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()));
+    println!("scope:   {}", scope.display());
+    match &wire_root_canon {
+        Some(root) if root == &scope => {
+            println!(
+                "mesh:    project-local (this scope's identity AND wire live in `{}` — sends are isolated to this dir)",
+                scope.display()
+            );
+        }
+        Some(root) => {
+            println!(
+                "mesh:    machine-account (this scope shares wire at `{}` with every other scope on this user's machine)",
+                root.display()
+            );
+        }
+        None => {
+            println!("mesh:    unknown (could not resolve wire root)");
+        }
+    }
 }
 
 /// `send` — local-fs single-shot send to the current room. Routes


### PR DESCRIPTION
## Criterion #2 of Codex's reliability list

> "airc join from a project scope must converge onto the same usable account mesh or clearly show which scope it is using."

\`airc join\` previously printed channels + wire path but left the operator to mentally parse \`/Users/x/.airc/wires/general\` vs \`/path/to/project/.airc/wires/general\` to know whether they were on the machine-account mesh or isolated.

## Fix

Two extra output lines:

\`\`\`
under-$HOME scope:
  scope:   /Users/x/Development/foo/.airc
  mesh:    machine-account (this scope shares wire at
           `/Users/x/.airc` with every other scope on this user's
           machine)

outside-$HOME scope (tempdir / CI):
  scope:   /tmp/foo/.airc
  mesh:    project-local (this scope's identity AND wire live in
           `/tmp/foo/.airc` — sends are isolated to this dir)
\`\`\`

Resolution: derive \`wire_root\` from \`current.wire\` (\`<root>/wires/<channel>\`, parent twice), canonicalize both. wire_root == scope → project-local; otherwise machine-account.

## Smoke

Both branches verified live with the dev build — tempdir scope reports project-local, project-under-\$HOME scope reports machine-account with the shared wire path.

## Test plan

- [x] \`cargo test -p airc-cli\` — all green
- [x] \`cargo clippy -p airc-cli --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] Smoke from tempdir → project-local mesh reported
- [x] Smoke from \$HOME subdir → machine-account mesh reported with \`~/.airc\` wire path

## Remaining criteria

- #1 status counts Rust peers → #858
- #3 send/msg receipt honesty → #859
- #4 public-install both-ways live receipt → smoke test after these three merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)