### PR TITLE
fix(airc): restore project scope and runtime hook identity

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -1,7 +1,7 @@
 //! Command-line interface definitions (clap derive).
 //!
 //! All commands default to the persisted state at `<home>` (default
-//! `$HOME/.airc`), which contains:
+//! the current git project's `.airc`), which contains:
 //!   - `identity.key`   — 32-byte Ed25519 secret (0600 on Unix)
 //!   - `identity.json`  — stable peer_id + client_id (0600)
 //!   - `daemon.sock`    — IPC socket for the daemon
@@ -10,7 +10,7 @@
 //! The `--home` flag overrides for testing / multi-identity setups.
 
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::{Args, Parser, Subcommand};
 
@@ -38,19 +38,55 @@ use crate::work_cli::WorkArgs;
 /// Default home directory for persisted identity + IPC state.
 ///
 /// Resolution order:
-///   1. `$HOME` (Unix; also Git Bash on Windows) → `<home>/.airc`
-///   2. `%USERPROFILE%` (native Windows cmd / PowerShell) →
-///      `<userprofile>/.airc`
-///   3. fallback to `./.airc` in the current working dir
+///   1. `$AIRC_HOME` → explicit scope override.
+///   2. First `.airc` ancestor when cwd is inside a scope.
+///   3. Git project root `.airc` when cwd is inside a worktree.
+///   4. `./.airc` in the current working dir.
+///
+/// Account-wide state still lives under the canonical machine account
+/// home (`$HOME/.airc`) inside `airc-lib`; this default is the
+/// consumer/project scope. That preserves the original public contract:
+/// running `airc join` in a repo uses that repo's `.airc`.
 pub fn default_home_dir() -> PathBuf {
-    if let Some(home) = std::env::var_os("HOME") {
-        return PathBuf::from(home).join(".airc");
+    if let Some(home) = std::env::var_os("AIRC_HOME") {
+        return PathBuf::from(home);
     }
-    #[cfg(windows)]
-    if let Some(userprofile) = std::env::var_os("USERPROFILE") {
-        return PathBuf::from(userprofile).join(".airc");
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    default_home_dir_for(&cwd)
+}
+
+fn default_home_dir_for(cwd: &Path) -> PathBuf {
+    for ancestor in cwd.ancestors() {
+        if ancestor
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name == ".airc")
+        {
+            return ancestor.to_path_buf();
+        }
     }
-    PathBuf::from(".airc")
+    git_toplevel(cwd)
+        .map(|root| root.join(".airc"))
+        .unwrap_or_else(|| cwd.join(".airc"))
+}
+
+fn git_toplevel(cwd: &Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    let root = text.trim();
+    if root.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(root))
+    }
 }
 
 /// Default Unix socket path inside `home`.
@@ -68,9 +104,9 @@ pub fn default_socket_path_in(home: &std::path::Path) -> PathBuf {
                   Provides the public AIRC command surface."
 )]
 pub struct Cli {
-    /// State directory for persisted identity + IPC socket. Default
-    /// `$HOME/.airc` (Unix) or `%USERPROFILE%/.airc` (Windows).
-    /// Override for tests or multi-identity setups.
+    /// State directory for persisted identity + IPC socket. Defaults
+    /// to the current git project root's `.airc` unless `$AIRC_HOME`
+    /// is set. Override for tests or multi-identity setups.
     #[arg(long, global = true)]
     pub home: Option<PathBuf>,
 
@@ -341,6 +377,40 @@ pub enum Command {
         /// Scope path. Defaults to `$AIRC_HOME`, then `$HOME/.airc`.
         scope: Option<String>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::default_home_dir_for;
+
+    #[test]
+    fn default_home_uses_enclosing_airc_scope() {
+        let root = tempfile::TempDir::new().unwrap();
+        let scope = root.path().join(".airc");
+        let nested = scope.join("debug");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(default_home_dir_for(&nested), scope);
+    }
+
+    #[test]
+    fn default_home_uses_git_project_root_scope() {
+        let root = tempfile::TempDir::new().unwrap();
+        let repo = root.path().join("repo");
+        let nested = repo.join("src").join("inner");
+        std::fs::create_dir_all(&nested).unwrap();
+        let status = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&repo)
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        assert_eq!(
+            default_home_dir_for(&nested),
+            repo.canonicalize().unwrap().join(".airc")
+        );
+    }
 }
 
 #[derive(Debug, Args)]

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -406,9 +406,12 @@ mod tests {
             .unwrap();
         assert!(status.success());
 
+        let actual = default_home_dir_for(&nested);
+        let expected = repo.join(".airc");
+        std::fs::create_dir_all(&actual).unwrap();
         assert_eq!(
-            default_home_dir_for(&nested),
-            repo.canonicalize().unwrap().join(".airc")
+            actual.canonicalize().unwrap(),
+            expected.canonicalize().unwrap()
         );
     }
 }

--- a/crates/airc-cli/src/codex_commands.rs
+++ b/crates/airc-cli/src/codex_commands.rs
@@ -6,7 +6,10 @@ use std::path::{Path, PathBuf};
 
 use airc_core::{Body, TranscriptCursor, TranscriptEvent, TranscriptKind};
 use airc_lib::{Airc, EventFilter};
+use airc_protocol::HEADER_AIRC_CLIENT;
 use serde::Serialize;
+
+use crate::client_id::current_client_id;
 
 const DEFAULT_CURSOR_FILENAME: &str = "codex_hook_cursor.json";
 
@@ -39,9 +42,10 @@ pub async fn run_user_prompt_submit(
         write_cursor(&cursor_path, &newest)?;
     }
 
+    let runtime_client = current_client_id()?;
     let visible: Vec<_> = events
         .into_iter()
-        .filter(|event| include_self || event.peer_id != airc.peer_id())
+        .filter(|event| include_self || !is_self_event(event, &airc, runtime_client.as_deref()))
         .collect();
     if visible.is_empty() {
         return Ok(());
@@ -54,6 +58,15 @@ pub async fn run_user_prompt_submit(
     };
     print_hook_payload(&context)?;
     Ok(())
+}
+
+fn is_self_event(event: &TranscriptEvent, airc: &Airc, runtime_client: Option<&str>) -> bool {
+    if let Some(runtime_client) = runtime_client {
+        if let Some(event_client) = event.headers.get(HEADER_AIRC_CLIENT) {
+            return event_client == runtime_client;
+        }
+    }
+    event.client_id == airc.client_id() || event.peer_id == airc.peer_id()
 }
 
 fn drain_stdin() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -17,13 +17,13 @@ use std::sync::Arc;
 use std::sync::RwLock;
 
 use airc_core::{ClientId, EventId, PeerId, TranscriptCursor};
-use airc_protocol::{PeerKeyRegistry, VerificationPolicy};
+use airc_protocol::{PeerKeyRegistry, VerificationPolicy, HEADER_AIRC_CLIENT};
 use futures::stream::StreamExt;
 
 use airc_daemon::{
     peers_store, run as run_daemon_server, AddPeerRequest, DaemonClient, DaemonState, LocalIdentity,
 };
-use airc_lib::{Airc, Body, PeerSpec};
+use airc_lib::{Airc, Body, Headers, PeerSpec};
 use airc_store::{EventStore, SqliteEventStore};
 
 /// `init` — open the substrate at `<home>`. `Airc::open` loads or
@@ -182,7 +182,7 @@ pub async fn run_send(
         airc.enrol_volatile_peer(peer)?;
     }
     let current = airc.current_room().await?;
-    airc.say(text).await?;
+    airc.say_with_headers(text, runtime_headers()?).await?;
     let peer_count = airc.peers().await?.len();
     // `Airc::say` returned Ok — the frame is signed, persisted to the
     // local store, and written to the wire. Any scope tailing this
@@ -257,7 +257,7 @@ pub async fn run_lan_send(
     }
     let current = airc.current_room().await?;
     airc.connect_lan(to, expected_peer).await?;
-    airc.say(text).await?;
+    airc.say_with_headers(text, runtime_headers()?).await?;
     println!(
         "sent over lan-tcp to {} ({}).",
         current.name, current.channel
@@ -352,7 +352,7 @@ pub async fn run_msg(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let airc = Airc::attach(home, socket).await?;
     let current = airc.current_room().await?;
-    airc.say(text).await?;
+    airc.say_with_headers(text, runtime_headers()?).await?;
     let peer_count = airc.peers().await?.len();
     // See run_send for the rationale — same message-honesty fix
     // for the daemon-attached send path.
@@ -546,3 +546,11 @@ pub async fn run_peer_list(home: &Path) -> Result<(), Box<dyn std::error::Error>
 // file. Keeping the import explicit makes the dep graph readable.
 #[allow(dead_code)]
 fn _client_id_kept_in_scope(_: ClientId) {}
+
+fn runtime_headers() -> Result<Headers, Box<dyn std::error::Error>> {
+    let mut headers = Headers::new();
+    if let Some(client) = crate::client_id::current_client_id()? {
+        headers.insert(HEADER_AIRC_CLIENT.to_string(), client);
+    }
+    Ok(headers)
+}

--- a/crates/airc-cli/src/monitor/attach.rs
+++ b/crates/airc-cli/src/monitor/attach.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use airc_core::{Body, MentionTarget, TranscriptEvent, TranscriptKind};
 use airc_lib::{Airc, EventFilter};
+use airc_protocol::HEADER_AIRC_CLIENT;
 use futures::StreamExt;
 
 use super::render::{normalize_channel, xml_escape, Sandbox};
@@ -31,7 +32,7 @@ pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error
 }
 
 fn render_event(event: &TranscriptEvent, client_id: Option<&str>, sandbox: &mut Sandbox) {
-    if client_id.is_some_and(|id| event.client_id.to_string() == id) {
+    if is_own_runtime_event(event, client_id) {
         return;
     }
 
@@ -43,7 +44,7 @@ fn render_event(event: &TranscriptEvent, client_id: Option<&str>, sandbox: &mut 
     let channel = normalize_channel(&event.room_id.to_string());
     let mut attrs = vec![
         format!("from=\"{}\"", xml_escape(&event.peer_id.to_string())),
-        format!("client=\"{}\"", xml_escape(&event.client_id.to_string())),
+        format!("client=\"{}\"", xml_escape(&display_client(event))),
         format!("channel=\"{}\"", xml_escape(&channel)),
         format!("ts=\"{}\"", event.occurred_at_ms),
     ];
@@ -63,6 +64,24 @@ fn render_event(event: &TranscriptEvent, client_id: Option<&str>, sandbox: &mut 
         attrs = attrs.join(" "),
         body = xml_escape(body)
     );
+}
+
+fn is_own_runtime_event(event: &TranscriptEvent, client_id: Option<&str>) -> bool {
+    let Some(client_id) = client_id else {
+        return false;
+    };
+    if let Some(event_client) = event.headers.get(HEADER_AIRC_CLIENT) {
+        return event_client == client_id;
+    }
+    event.client_id.to_string() == client_id
+}
+
+fn display_client(event: &TranscriptEvent) -> String {
+    event
+        .headers
+        .get(HEADER_AIRC_CLIENT)
+        .cloned()
+        .unwrap_or_else(|| event.client_id.to_string())
 }
 
 fn body_text(body: &Body) -> Option<&str> {
@@ -90,6 +109,33 @@ mod tests {
         render_event(&event, Some(&event.client_id.to_string()), &mut sandbox);
 
         assert!(!sandbox.has_emitted());
+    }
+
+    #[test]
+    fn render_event_filters_same_runtime_client_header() {
+        let mut event = event("hello");
+        event
+            .headers
+            .insert(HEADER_AIRC_CLIENT.to_string(), "codex:thread-1".to_string());
+        let mut sandbox = Sandbox::new();
+
+        render_event(&event, Some("codex:thread-1"), &mut sandbox);
+
+        assert!(!sandbox.has_emitted());
+    }
+
+    #[test]
+    fn render_event_keeps_different_runtime_client_header() {
+        let mut event = event("hello");
+        event.headers.insert(
+            HEADER_AIRC_CLIENT.to_string(),
+            "claude:session-1".to_string(),
+        );
+        let mut sandbox = Sandbox::new();
+
+        render_event(&event, Some("codex:thread-1"), &mut sandbox);
+
+        assert!(sandbox.has_emitted());
     }
 
     fn event(text: &str) -> TranscriptEvent {

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -79,6 +79,32 @@ fn codex_hook_excludes_self_echoes_but_still_advances_cursor() {
 }
 
 #[test]
+fn codex_hook_filters_by_runtime_client_header_not_persisted_identity() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+    let cursor = workspace.path().join("cursor.json");
+
+    run_ok(&home, &["init"]);
+    run_ok_with_client(&home, "codex:thread-1", &["send", "own runtime"]);
+    run_ok_with_client(&home, "claude:session-1", &["send", "peer runtime"]);
+
+    let output = run_hook_with_client(
+        &home,
+        "codex:thread-1",
+        &[
+            "codex-hook",
+            "user-prompt-submit",
+            "--cursor-file",
+            cursor.to_str().unwrap(),
+        ],
+        "{}",
+    );
+    let context = additional_context(&output);
+    assert!(!context.contains("own runtime"));
+    assert!(context.contains("peer runtime"));
+}
+
+#[test]
 fn codex_hook_raw_mode_preserves_full_event_lines() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");
@@ -286,8 +312,54 @@ fn run_ok(home: &Path, args: &[&str]) -> String {
     String::from_utf8(output.stdout).expect("stdout utf-8")
 }
 
+fn run_ok_with_client(home: &Path, client_id: &str, args: &[&str]) -> String {
+    let output = command_for_home(home)
+        .env("AIRC_CLIENT_ID", client_id)
+        .args(["--home"])
+        .arg(home)
+        .args(args)
+        .output()
+        .expect("airc-core command must spawn");
+    assert!(
+        output.status.success(),
+        "airc-core {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout utf-8")
+}
+
 fn run_hook(home: &Path, args: &[&str], stdin: &str) -> String {
     let mut child = command_for_home(home)
+        .args(["--home"])
+        .arg(home)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("airc-core hook must spawn");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin pipe")
+        .write_all(stdin.as_bytes())
+        .expect("write hook stdin");
+    let output = child.wait_with_output().expect("wait for hook");
+    assert!(
+        output.status.success(),
+        "airc-core {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout utf-8")
+}
+
+fn run_hook_with_client(home: &Path, client_id: &str, args: &[&str], stdin: &str) -> String {
+    let mut child = command_for_home(home)
+        .env("AIRC_CLIENT_ID", client_id)
         .args(["--home"])
         .arg(home)
         .args(args)

--- a/crates/airc-cli/tests/operational_dogfood.rs
+++ b/crates/airc-cli/tests/operational_dogfood.rs
@@ -2,8 +2,8 @@
 //!
 //! This test intentionally does NOT pass `--home` and does NOT pass
 //! ad-hoc `--peer` flags to listen/send. Each subprocess receives a
-//! distinct fake user HOME, so `airc-core` resolves state through the
-//! default installed path: `<HOME>/.airc`.
+//! distinct fake project cwd, so `airc-core` resolves state through the
+//! public default project scope: `<cwd>/.airc`.
 //!
 //! The proof shape mirrors the real Codex/Claude target:
 //!   1. each agent initialises its own installed identity
@@ -35,6 +35,8 @@ fn installed_codex_and_claude_identities_hold_bidirectional_live_room() {
 
     std::fs::create_dir_all(&codex_user_home).expect("codex user home");
     std::fs::create_dir_all(&claude_user_home).expect("claude user home");
+    seed_mesh_identity(&codex_user_home);
+    seed_mesh_identity(&claude_user_home);
 
     let codex_spec = installed_init(&codex_user_home).peer_spec;
     let claude_spec = installed_init(&claude_user_home).peer_spec;
@@ -117,6 +119,8 @@ fn monitor_attach_streams_rust_events_without_legacy_log() {
 
     std::fs::create_dir_all(&codex_user_home).expect("codex user home");
     std::fs::create_dir_all(&claude_user_home).expect("claude user home");
+    seed_mesh_identity(&codex_user_home);
+    seed_mesh_identity(&claude_user_home);
 
     let codex_spec = installed_init(&codex_user_home).peer_spec;
     let claude_spec = installed_init(&claude_user_home).peer_spec;
@@ -263,9 +267,29 @@ fn installed_inbox(user_home: &Path) -> String {
 
 fn installed_command(user_home: &Path) -> Command {
     let mut command = Command::new(airc_core());
+    command.current_dir(user_home);
     command.env("HOME", user_home);
     command.env("USERPROFILE", user_home);
+    command.env("AIRC_CLIENT_ID", test_client_id(user_home));
     command
+}
+
+fn test_client_id(user_home: &Path) -> &'static str {
+    match user_home.file_name().and_then(|name| name.to_str()) {
+        Some(name) if name.contains("claude") => "claude:dogfood",
+        Some(name) if name.contains("codex") => "codex:dogfood",
+        _ => "agent:dogfood",
+    }
+}
+
+fn seed_mesh_identity(user_home: &Path) {
+    let airc_home = user_home.join(".airc");
+    std::fs::create_dir_all(&airc_home).expect("airc home");
+    std::fs::write(
+        airc_home.join("mesh_identity.json"),
+        r#"{"version":1,"identity":"dogfood-account","source":"operator","resolved_at_ms":1,"ttl_ms":86400000}"#,
+    )
+    .expect("write mesh identity");
 }
 
 fn extract_field<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -129,7 +129,7 @@ async fn handle_inbox(state: Arc<DaemonState>, request: InboxRequest) -> Respons
 
 async fn handle_send(state: Arc<DaemonState>, send: SendRequest) -> Response {
     let transport = state.local_fs_for(&send.wire).await;
-    let frame = match build_message_frame(&state, send.channel, &send.text) {
+    let frame = match build_message_frame(&state, send.channel, &send.text, send.headers) {
         Ok(frame) => frame,
         Err(error) => {
             return Response::Error {
@@ -211,6 +211,7 @@ fn build_message_frame(
     state: &DaemonState,
     channel: uuid::Uuid,
     text: &str,
+    headers: Headers,
 ) -> Result<Frame, std::time::SystemTimeError> {
     let lamport = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)?
@@ -226,7 +227,7 @@ fn build_message_frame(
             lamport,
             occurred_at_ms: lamport,
             reply_to: None,
-            headers: Headers::new(),
+            headers,
             body: Some(Body::text(text)),
             media: Vec::new(),
             // Unsigned at this layer — SignedTransport replaces it
@@ -327,6 +328,7 @@ mod tests {
                 wire: dir.path().to_path_buf(),
                 channel: Uuid::nil(),
                 text: "hello".to_string(),
+                headers: Headers::new(),
             }),
         )
         .await;

--- a/crates/airc-daemon/src/ipc/request.rs
+++ b/crates/airc-daemon/src/ipc/request.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use airc_core::PeerId;
+use airc_core::{Headers, PeerId};
 
 /// A single client-issued operation. Wire-tagged by `op`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -89,6 +89,10 @@ pub struct SendRequest {
     pub channel: Uuid,
     /// Body text.
     pub text: String,
+    /// Optional envelope headers supplied by the caller. Used for
+    /// runtime consumer metadata such as `airc.client`.
+    #[serde(default)]
+    pub headers: Headers,
 }
 
 #[cfg(test)]
@@ -111,6 +115,7 @@ mod tests {
             wire: PathBuf::from("/tmp/wire"),
             channel: Uuid::nil(),
             text: "hello".to_string(),
+            headers: Headers::new(),
         });
         let encoded = serde_json::to_string(&original).unwrap();
         let decoded: Request = serde_json::from_str(&encoded).unwrap();

--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -295,6 +295,7 @@ mod tests {
                 wire: wire.clone(),
                 channel,
                 text: "hello from daemon".to_string(),
+                headers: airc_core::Headers::new(),
             })
             .await
             .unwrap();

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -4,7 +4,7 @@
 //! the daemon's typed IPC client instead of making apps construct
 //! daemon requests directly.
 
-use airc_core::{EventId, TranscriptCursor, TranscriptEvent};
+use airc_core::{EventId, Headers, TranscriptCursor, TranscriptEvent};
 use airc_daemon::{InboxRequest, SendRequest, SubscribeRequest};
 
 use crate::error::AircError;
@@ -20,6 +20,7 @@ impl Airc {
         &self,
         room: &Room,
         text: &str,
+        headers: Headers,
     ) -> Result<EventId, AircError> {
         self.daemon_client()
             .ok_or_else(|| AircError::Route("daemon client is not attached".to_string()))?
@@ -27,6 +28,7 @@ impl Airc {
                 wire: room.wire.clone(),
                 channel: room.channel.as_uuid(),
                 text: text.to_string(),
+                headers,
             })
             .await?;
 

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -11,11 +11,20 @@ use crate::Airc;
 impl Airc {
     /// Send a plain-text message to the current room.
     pub async fn say(&self, text: &str) -> Result<EventId, AircError> {
+        self.say_with_headers(text, Headers::new()).await
+    }
+
+    /// Send a plain-text message with envelope headers.
+    pub async fn say_with_headers(
+        &self,
+        text: &str,
+        headers: Headers,
+    ) -> Result<EventId, AircError> {
         if self.is_daemon_attached() {
             let room = self.current_room().await?;
-            return self.daemon_send_text(&room, text).await;
+            return self.daemon_send_text(&room, text, headers).await;
         }
-        self.send(Body::text(text), Headers::new()).await
+        self.send(Body::text(text), headers).await
     }
 
     /// Send a frame with typed body and arbitrary headers.

--- a/crates/airc-protocol/src/headers_keys.rs
+++ b/crates/airc-protocol/src/headers_keys.rs
@@ -30,6 +30,12 @@ pub const HEADER_AIRC_PRIORITY: &str = "airc.priority";
 /// a decimal string.
 pub const HEADER_AIRC_DEADLINE: &str = "airc.deadline";
 
+/// Runtime consumer identity. This is the human/agent process label
+/// (`codex:<thread>`, `claude:<session>`, etc.) used by hooks and
+/// monitors to filter their own sends without conflating every process
+/// that shares the same persisted substrate `ClientId`.
+pub const HEADER_AIRC_CLIENT: &str = "airc.client";
+
 /// Body-shape hint from the forge/alloy contract layer. The string names
 /// a forge contract (e.g. `"forge.persona.turn"`); consumers that
 /// recognise the contract decode the body accordingly. Substrate never

--- a/crates/airc-protocol/src/lib.rs
+++ b/crates/airc-protocol/src/lib.rs
@@ -36,8 +36,8 @@ pub mod trust_rotation;
 pub use canonical::{canonical_signed_bytes, CanonicalError};
 pub use envelope::{ChannelId, Envelope, Frame, FrameKind};
 pub use headers_keys::{
-    HEADER_AIRC_DEADLINE, HEADER_AIRC_PRIORITY, HEADER_AIRC_REPLY_TO, HEADER_AIRC_TRACE_ID,
-    HEADER_FORGE_BODY_HINT,
+    HEADER_AIRC_CLIENT, HEADER_AIRC_DEADLINE, HEADER_AIRC_PRIORITY, HEADER_AIRC_REPLY_TO,
+    HEADER_AIRC_TRACE_ID, HEADER_FORGE_BODY_HINT,
 };
 pub use keypair::PeerKeypair;
 pub use media::MediaRef;


### PR DESCRIPTION
Summary\n- restore Rust CLI default scope to the git project root .airc contract, with AIRC_HOME override and enclosing .airc detection\n- stamp outgoing CLI/daemon messages with the runtime consumer header (airc.client) so Codex/Claude hooks and monitors can distinguish agents sharing one substrate identity\n- make Codex hook and Monitor attach filter self by runtime client header when present, falling back to persisted ids only for older events\n- update operational dogfood coverage so Codex-style and Claude-style agents exchange through live Rust monitor/hook surfaces without manual inbox polling\n\nVerification\n- cargo test --manifest-path Cargo.toml -p airc-cli codex_hook -- --nocapture\n- cargo test --manifest-path Cargo.toml -p airc-cli default_home -- --nocapture\n- cargo test --manifest-path Cargo.toml -p airc-cli render_event -- --nocapture\n- cargo test --manifest-path Cargo.toml -p airc-cli --test operational_dogfood -- --nocapture\n- cargo test --manifest-path Cargo.toml --workspace\n- cargo clippy --manifest-path Cargo.toml -p airc-cli -p airc-lib -p airc-daemon -p airc-protocol --all-targets -- -D warnings