### PR TITLE
fix(airc): make join own daemon live delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "airc-transport",
  "async-trait",
  "base64",
+ "fs2",
  "futures",
  "serde",
  "serde_json",

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -91,6 +91,21 @@ fn git_toplevel(cwd: &Path) -> Option<PathBuf> {
 
 /// Default Unix socket path inside `home`.
 pub fn default_socket_path_in(home: &std::path::Path) -> PathBuf {
+    #[cfg(unix)]
+    {
+        use sha2::{Digest, Sha256};
+        let canonical = home.canonicalize().unwrap_or_else(|_| home.to_path_buf());
+        let mut hasher = Sha256::new();
+        hasher.update(canonical.to_string_lossy().as_bytes());
+        let digest = hasher.finalize();
+        let hex = digest
+            .iter()
+            .take(12)
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        std::env::temp_dir().join(format!("airc-{hex}.sock"))
+    }
+    #[cfg(not(unix))]
     home.join("daemon.sock")
 }
 

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -13,15 +13,18 @@
 //! `VerificationPolicy::Strict` is the only policy used in CLI paths.
 
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::sync::RwLock;
+use std::time::{Duration, Instant};
 
 use airc_core::{ClientId, EventId, PeerId, TranscriptCursor};
 use airc_protocol::{PeerKeyRegistry, VerificationPolicy, HEADER_AIRC_CLIENT};
 use futures::stream::StreamExt;
 
 use airc_daemon::{
-    peers_store, run as run_daemon_server, AddPeerRequest, DaemonClient, DaemonState, LocalIdentity,
+    peers_store, run as run_daemon_server, AddPeerRequest, DaemonClient, DaemonState,
+    LocalIdentity, SubscribeRequest,
 };
 use airc_lib::{Airc, Body, Headers, PeerSpec};
 use airc_store::{EventStore, SqliteEventStore};
@@ -101,6 +104,139 @@ pub async fn run_join(home: &Path, room: Option<String>) -> Result<(), Box<dyn s
             println!("wire:    {}", current.wire.display());
             print_scope_context(home, &current.wire);
         }
+    }
+    let socket = crate::cli::default_socket_path_in(home);
+    ensure_daemon_running(home, socket.clone(), Vec::new()).await?;
+    subscribe_daemon_to_current_rooms(home, socket).await?;
+    Ok(())
+}
+
+pub async fn ensure_daemon_running(
+    home: &Path,
+    socket: PathBuf,
+    _peers: Vec<PeerSpec>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = DaemonClient::new(socket.clone());
+    if client
+        .ping_with_timeout(Duration::from_millis(250))
+        .await
+        .is_ok()
+    {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(home)?;
+    let log = home.join("airc-daemon.log");
+    let stdout = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log)?;
+    let stderr = stdout.try_clone()?;
+    let exe = std::env::current_exe()?;
+    let mut command = Command::new(exe);
+    command
+        .arg("--home")
+        .arg(home)
+        .arg("daemon")
+        .arg("--socket")
+        .arg(&socket)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+    detach_daemon(&mut command);
+    command.spawn()?;
+
+    let client = DaemonClient::new(socket);
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if client
+            .ping_with_timeout(Duration::from_millis(250))
+            .await
+            .is_ok()
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    Err(format!("daemon did not become ready; see {}", log.display()).into())
+}
+
+#[cfg(unix)]
+fn detach_daemon(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    // SAFETY: this closure runs in the child just before exec and
+    // only calls setsid, which is async-signal-safe.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
+#[cfg(windows)]
+fn detach_daemon(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+    const DETACHED_PROCESS: u32 = 0x00000008;
+    const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+    command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+}
+
+async fn subscribe_daemon_to_current_rooms(
+    home: &Path,
+    socket: PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let client = DaemonClient::new(socket);
+    let set = airc.subscription_set().await?;
+    sync_daemon_peers(&client, home, &set).await?;
+    for subscription in set.all() {
+        client
+            .subscribe(SubscribeRequest {
+                wire: subscription.as_room().wire,
+            })
+            .await?;
+    }
+    Ok(())
+}
+
+async fn sync_daemon_peers(
+    client: &DaemonClient,
+    home: &Path,
+    set: &airc_lib::SubscriptionSet,
+) -> Result<(), Box<dyn std::error::Error>> {
+    sync_daemon_peers_from_store(client, home).await?;
+    for subscription in set.all() {
+        if let Some(wire_root) = subscription
+            .as_room()
+            .wire
+            .parent()
+            .and_then(|path| path.parent())
+        {
+            if wire_root != home {
+                sync_daemon_peers_from_store(client, wire_root).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn sync_daemon_peers_from_store(
+    client: &DaemonClient,
+    home: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for peer in peers_store::load(home)? {
+        client
+            .add_peer(AddPeerRequest {
+                peer_id: peer.peer_id,
+                pubkey_b64: peer.pubkey_b64,
+            })
+            .await?;
     }
     Ok(())
 }
@@ -350,6 +486,8 @@ pub async fn run_msg(
     socket: PathBuf,
     text: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    ensure_daemon_running(home, socket.clone(), Vec::new()).await?;
+    subscribe_daemon_to_current_rooms(home, socket.clone()).await?;
     let airc = Airc::attach(home, socket).await?;
     let current = airc.current_room().await?;
     airc.say_with_headers(text, runtime_headers()?).await?;

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -840,7 +840,11 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             MonitorAction::Format { peers_dir, my_name } => {
                 monitor::run_format(&peers_dir, &my_name)
             }
-            MonitorAction::Attach { my_name } => monitor::run_attach(&home, &my_name).await,
+            MonitorAction::Attach { my_name } => {
+                let socket = default_or(None, &home);
+                commands::ensure_daemon_running(&home, socket.clone(), parsed.peers).await?;
+                monitor::run_attach(&home, &my_name).await
+            }
         },
 
         Command::Workspace(args) => match args.action {

--- a/crates/airc-cli/src/monitor/attach.rs
+++ b/crates/airc-cli/src/monitor/attach.rs
@@ -1,11 +1,11 @@
-use std::collections::BTreeSet;
 use std::error::Error;
 use std::path::Path;
 
 use airc_core::{Body, MentionTarget, TranscriptEvent, TranscriptKind};
-use airc_lib::{Airc, EventFilter};
+use airc_daemon::{AttachRequest, DaemonClient, Response, SubscribeRequest};
+use airc_lib::Airc;
 use airc_protocol::HEADER_AIRC_CLIENT;
-use futures::StreamExt;
+use tokio::io::{AsyncBufReadExt, BufReader};
 
 use super::render::{normalize_channel, xml_escape, Sandbox};
 use crate::client_id::current_client_id;
@@ -13,22 +13,39 @@ use crate::client_id::current_client_id;
 pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error>> {
     let airc = Airc::open(home).await?;
     let client_id = current_client_id().ok().flatten();
-    let mut stream = airc
-        .subscribe_subscribed_filtered(EventFilter {
-            kinds: BTreeSet::from([TranscriptKind::Message, TranscriptKind::System]),
-            ..EventFilter::default()
-        })
-        .await?;
+    let socket = crate::cli::default_socket_path_in(home);
+    let client = DaemonClient::new(socket);
+    let set = airc.subscription_set().await?;
+    for subscription in set.all() {
+        client
+            .subscribe(SubscribeRequest {
+                wire: subscription.as_room().wire,
+            })
+            .await?;
+    }
+    let stream = client.attach(AttachRequest::default()).await?;
+    let mut reader = BufReader::new(stream);
     let mut sandbox = Sandbox::new();
 
     println!("airc: attached to Rust event stream for subscribed channels");
-    while let Some(item) = stream.next().await {
-        match item {
-            Ok(event) => render_event(&event, client_id.as_deref(), &mut sandbox),
-            Err(lag) => eprintln!("airc: monitor lagged; {lag}"),
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).await? == 0 {
+            return Ok(());
+        }
+        let response: Response = serde_json::from_str(line.trim_end_matches('\n'))?;
+        match response {
+            Response::Ok => {}
+            Response::Event { event } => {
+                if matches!(event.kind, TranscriptKind::Message | TranscriptKind::System) {
+                    render_event(event.as_ref(), client_id.as_deref(), &mut sandbox);
+                }
+            }
+            Response::Error { message } => return Err(message.into()),
+            Response::Pong | Response::Status(_) | Response::Inbox(_) | Response::Peers(_) => {}
         }
     }
-    Ok(())
 }
 
 fn render_event(event: &TranscriptEvent, client_id: Option<&str>, sandbox: &mut Sandbox) {

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -153,19 +153,12 @@ fn join_without_args_uses_default_account_context() {
     create_repo_with_origin(&repo, "https://github.com/CambrianTech/continuum.git");
     seed_mesh_identity(&home, "joelteply");
 
-    let output = Command::new(airc_core())
-        .env("HOME", machine.path())
-        // Tests run with the operator's real `gh` auth. The gh-gist
-        // account-registry sync (#862) would iterate the real user's
-        // gist list (`gh api /gists --paginate`), which hangs the
-        // test for high-gist-count accounts. Disable for hermetic
-        // testing; PR 1 of the architecture plan moves this sync to
-        // a background daemon tick.
+    let mut join = Command::new(airc_core());
+    join.env("HOME", machine.path())
         .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
         .args(["--home", home.to_str().unwrap(), "join"])
-        .current_dir(&repo)
-        .output()
-        .expect("airc-core join must spawn");
+        .current_dir(&repo);
+    let output = output_with_timeout(join, Duration::from_secs(10), "airc join");
     assert!(
         output.status.success(),
         "join failed: stdout={} stderr={}",
@@ -197,6 +190,63 @@ fn join_without_args_uses_default_account_context() {
             .join("wires")
             .join("cambriantech")
     );
+
+    let mut stop_command = Command::new(airc_core());
+    stop_command
+        .env("HOME", machine.path())
+        .args(["--home", home.to_str().unwrap(), "stop"]);
+    let stop = output_with_timeout(stop_command, Duration::from_secs(10), "airc stop");
+    assert!(
+        stop.status.success(),
+        "stop failed after join proof: stdout={} stderr={}",
+        String::from_utf8_lossy(&stop.stdout),
+        String::from_utf8_lossy(&stop.stderr),
+    );
+}
+
+fn output_with_timeout(
+    mut command: Command,
+    timeout: Duration,
+    label: &str,
+) -> std::process::Output {
+    let log_dir = TempDir::new().expect("command log tempdir");
+    let stdout_path = log_dir.path().join("stdout.log");
+    let stderr_path = log_dir.path().join("stderr.log");
+    let stdout = std::fs::File::create(&stdout_path).expect("stdout log");
+    let stderr = std::fs::File::create(&stderr_path).expect("stderr log");
+    command
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+    let mut child = command.spawn().unwrap_or_else(|error| {
+        panic!("{label} must spawn: {error}");
+    });
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {}
+            Err(error) => panic!("{label} wait failed: {error}"),
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            let stdout = std::fs::read(&stdout_path).unwrap_or_default();
+            let stderr = std::fs::read(&stderr_path).unwrap_or_default();
+            panic!(
+                "{label} timed out after {timeout:?}: stdout={} stderr={}",
+                String::from_utf8_lossy(&stdout),
+                String::from_utf8_lossy(&stderr),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    let stdout = std::fs::read(&stdout_path).unwrap_or_default();
+    let stderr = std::fs::read(&stderr_path).unwrap_or_default();
+    std::process::Output {
+        status,
+        stdout,
+        stderr,
+    }
 }
 
 fn create_repo_with_origin(path: &Path, origin: &str) {

--- a/crates/airc-cli/tests/operational_dogfood.rs
+++ b/crates/airc-cli/tests/operational_dogfood.rs
@@ -164,6 +164,7 @@ fn monitor_attach_streams_rust_events_without_legacy_log() {
 
     let _ = claude_monitor.kill();
     let _ = claude_monitor.wait();
+    installed_stop(&claude_user_home);
 }
 
 struct InitOutput {
@@ -263,6 +264,19 @@ fn installed_inbox(user_home: &Path) -> String {
         String::from_utf8_lossy(&output.stderr)
     );
     String::from_utf8(output.stdout).expect("inbox stdout utf-8")
+}
+
+fn installed_stop(user_home: &Path) {
+    let output = installed_command(user_home)
+        .arg("stop")
+        .output()
+        .expect("airc stop must spawn");
+    assert!(
+        output.status.success(),
+        "stop failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 fn installed_command(user_home: &Path) -> Command {

--- a/crates/airc-daemon/Cargo.toml
+++ b/crates/airc-daemon/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"
 futures = "0.3"
+fs2 = "0.4"
 uuid = { version = "1", features = ["v4", "v5"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "signal", "net", "io-util", "sync"] }
 

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -35,6 +35,9 @@ pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
         Request::Send(send) => handle_send(state, send).await,
         Request::Subscribe(sub) => handle_subscribe(state, sub).await,
         Request::Inbox(inbox) => handle_inbox(state, inbox).await,
+        Request::Attach(_) => Response::Error {
+            message: "attach is a streaming request handled by the server".to_string(),
+        },
         Request::AddPeer(add) => handle_add_peer(state, add).await,
         Request::ListPeers => handle_list_peers(state).await,
         Request::Stop => {
@@ -80,18 +83,27 @@ async fn handle_subscribe(state: Arc<DaemonState>, sub: SubscribeRequest) -> Res
             match item {
                 Ok(frame) => {
                     let event = frame.into_transcript_event();
-                    if let Err(err) = store.append(event).await {
-                        // Persistence failures are loud. Most likely
-                        // a duplicate replay (DuplicateEventId), which
-                        // is benign for replay-style subscriptions.
-                        // Anything else (Database, Migration, Codec)
-                        // surfaces here so the operator sees it.
-                        eprintln!("daemon subscriber: store append failed: {err}");
+                    let event_id = event.event_id;
+                    match store.append(event.clone()).await {
+                        Ok(()) | Err(airc_store::StoreError::DuplicateEventId(_)) => {
+                            let _ = state.live_tx.send(event);
+                        }
+                        Err(err) => {
+                            // Persistence failures are loud. Most likely
+                            // a duplicate replay (DuplicateEventId), which
+                            // is benign for replay-style subscriptions.
+                            // Anything else (Database, Migration, Codec)
+                            // surfaces here so the operator sees it.
+                            eprintln!(
+                                "daemon subscriber: store append failed for {event_id}: {err}"
+                            );
+                        }
                     }
                 }
-                Err(_verify_error) => {
+                Err(verify_error) => {
                     // Verification failure — don't persist.
                     // Future: surface a counter in Status response.
+                    eprintln!("daemon subscriber: frame verification failed: {verify_error}");
                 }
             }
         }

--- a/crates/airc-daemon/src/ipc/client.rs
+++ b/crates/airc-daemon/src/ipc/client.rs
@@ -13,11 +13,16 @@
 use std::path::PathBuf;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::time::{timeout, Duration};
 
 use crate::ipc::transport::IpcStream;
 
-use crate::ipc::request::{AddPeerRequest, InboxRequest, Request, SendRequest, SubscribeRequest};
+use crate::ipc::request::{
+    AddPeerRequest, AttachRequest, InboxRequest, Request, SendRequest, SubscribeRequest,
+};
 use crate::ipc::response::{InboxResponse, PeersResponse, Response, StatusResponse};
+
+const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Reasons a daemon RPC fails.
 #[derive(Debug)]
@@ -28,6 +33,9 @@ pub enum ClientError {
     Io(std::io::Error),
     /// Request or response failed to serialize/deserialize.
     Codec(serde_json::Error),
+    /// The daemon accepted or was contacted, but did not complete
+    /// the request inside the RPC deadline.
+    Timeout,
     /// Daemon returned `Response::Error { message }`.
     Daemon(String),
     /// Daemon returned a response variant inconsistent with the
@@ -44,6 +52,7 @@ impl std::fmt::Display for ClientError {
             }
             ClientError::Io(error) => write!(f, "daemon RPC I/O: {error}"),
             ClientError::Codec(error) => write!(f, "daemon RPC codec: {error}"),
+            ClientError::Timeout => write!(f, "daemon RPC timed out"),
             ClientError::Daemon(message) => write!(f, "daemon error: {message}"),
             ClientError::UnexpectedResponse(response) => {
                 write!(f, "daemon returned unexpected response: {response:?}")
@@ -57,7 +66,9 @@ impl std::error::Error for ClientError {
         match self {
             ClientError::NotConnected(error) | ClientError::Io(error) => Some(error),
             ClientError::Codec(error) => Some(error),
-            ClientError::Daemon(_) | ClientError::UnexpectedResponse(_) => None,
+            ClientError::Timeout | ClientError::Daemon(_) | ClientError::UnexpectedResponse(_) => {
+                None
+            }
         }
     }
 }
@@ -83,6 +94,20 @@ impl DaemonClient {
     /// Unix sockets support `shutdown` half-close but named pipes
     /// don't. Both sides read until `\n`, parse, drop.
     pub async fn call(&self, request: Request) -> Result<Response, ClientError> {
+        self.call_with_timeout(request, DEFAULT_RPC_TIMEOUT).await
+    }
+
+    pub async fn call_with_timeout(
+        &self,
+        request: Request,
+        deadline: Duration,
+    ) -> Result<Response, ClientError> {
+        timeout(deadline, self.call_inner(request))
+            .await
+            .map_err(|_| ClientError::Timeout)?
+    }
+
+    async fn call_inner(&self, request: Request) -> Result<Response, ClientError> {
         let stream = IpcStream::connect(&self.socket_path)
             .await
             .map_err(ClientError::NotConnected)?;
@@ -106,16 +131,22 @@ impl DaemonClient {
             other @ (Response::Pong
             | Response::Status(_)
             | Response::Inbox(_)
+            | Response::Event { .. }
             | Response::Peers(_)
             | Response::Ok) => Ok(other),
         }
     }
 
     pub async fn ping(&self) -> Result<(), ClientError> {
-        match self.call(Request::Ping).await? {
+        self.ping_with_timeout(DEFAULT_RPC_TIMEOUT).await
+    }
+
+    pub async fn ping_with_timeout(&self, deadline: Duration) -> Result<(), ClientError> {
+        match self.call_with_timeout(Request::Ping, deadline).await? {
             Response::Pong => Ok(()),
             other @ (Response::Status(_)
             | Response::Inbox(_)
+            | Response::Event { .. }
             | Response::Peers(_)
             | Response::Ok
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
@@ -127,6 +158,7 @@ impl DaemonClient {
             Response::Status(status) => Ok(status),
             other @ (Response::Pong
             | Response::Inbox(_)
+            | Response::Event { .. }
             | Response::Peers(_)
             | Response::Ok
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
@@ -139,6 +171,7 @@ impl DaemonClient {
             other @ (Response::Pong
             | Response::Status(_)
             | Response::Inbox(_)
+            | Response::Event { .. }
             | Response::Peers(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
@@ -150,6 +183,7 @@ impl DaemonClient {
             other @ (Response::Pong
             | Response::Status(_)
             | Response::Inbox(_)
+            | Response::Event { .. }
             | Response::Peers(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
@@ -160,6 +194,7 @@ impl DaemonClient {
             Response::Inbox(response) => Ok(response),
             other @ (Response::Pong
             | Response::Status(_)
+            | Response::Event { .. }
             | Response::Peers(_)
             | Response::Ok
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
@@ -172,6 +207,7 @@ impl DaemonClient {
             other @ (Response::Pong
             | Response::Status(_)
             | Response::Inbox(_)
+            | Response::Event { .. }
             | Response::Peers(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
@@ -183,6 +219,7 @@ impl DaemonClient {
             other @ (Response::Pong
             | Response::Status(_)
             | Response::Inbox(_)
+            | Response::Event { .. }
             | Response::Peers(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
@@ -198,8 +235,26 @@ impl DaemonClient {
             other @ (Response::Pong
             | Response::Status(_)
             | Response::Inbox(_)
+            | Response::Event { .. }
             | Response::Ok
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
+    }
+
+    pub async fn attach(&self, request: AttachRequest) -> Result<IpcStream, ClientError> {
+        timeout(Duration::from_secs(5), self.attach_inner(request))
+            .await
+            .map_err(|_| ClientError::Timeout)?
+    }
+
+    async fn attach_inner(&self, request: AttachRequest) -> Result<IpcStream, ClientError> {
+        let mut stream = IpcStream::connect(&self.socket_path)
+            .await
+            .map_err(ClientError::NotConnected)?;
+        let mut buffer = serde_json::to_vec(&Request::Attach(request))?;
+        buffer.push(b'\n');
+        stream.write_all(&buffer).await.map_err(ClientError::Io)?;
+        stream.flush().await.map_err(ClientError::Io)?;
+        Ok(stream)
     }
 }

--- a/crates/airc-daemon/src/ipc/request.rs
+++ b/crates/airc-daemon/src/ipc/request.rs
@@ -37,6 +37,10 @@ pub enum Request {
     /// filtered to a single channel. Pass back the response's
     /// `newest` cursor on the next call for consume-once streaming.
     Inbox(InboxRequest),
+    /// Attach to the daemon's live event stream. This is a long-lived
+    /// request: after an initial `Response::Ok`, the daemon writes
+    /// `Response::Event` lines until the client disconnects.
+    Attach(AttachRequest),
     /// Graceful shutdown. Daemon completes in-flight requests, then
     /// stops accepting new connections + exits.
     Stop,
@@ -69,6 +73,15 @@ pub struct InboxRequest {
     /// reasonable cap (32) so a slow client doesn't pull megabytes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,
+}
+
+/// Parameters for `Attach`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AttachRequest {
+    /// Restrict live events to this channel. `None` streams all
+    /// subscribed daemon events.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<airc_core::RoomId>,
 }
 
 /// Parameters for `AddPeer`. `pubkey_b64` is the URL-safe-no-padding

--- a/crates/airc-daemon/src/ipc/response.rs
+++ b/crates/airc-daemon/src/ipc/response.rs
@@ -17,6 +17,10 @@ pub enum Response {
     /// caller threads back on the next call to keep the stream
     /// consume-once.
     Inbox(InboxResponse),
+    /// One live event emitted by an `Attach` stream.
+    Event {
+        event: Box<airc_core::TranscriptEvent>,
+    },
     /// Response to `ListPeers` — the daemon's currently-enrolled
     /// peers (peer_id + URL-safe-no-padding base64 pubkey).
     Peers(PeersResponse),
@@ -98,5 +102,35 @@ mod tests {
         assert!(encoded.contains("boom"));
         let decoded: Response = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, error);
+    }
+
+    #[test]
+    fn event_response_wraps_transcript_without_tag_collision() {
+        use airc_core::{
+            Body, ClientId, EventId, Headers, MentionTarget, RoomId, TranscriptEvent,
+            TranscriptKind,
+        };
+
+        let response = Response::Event {
+            event: Box::new(TranscriptEvent {
+                event_id: EventId::new(),
+                room_id: RoomId::new(),
+                peer_id: PeerId::new(),
+                client_id: ClientId::new(),
+                kind: TranscriptKind::Message,
+                occurred_at_ms: 1,
+                lamport: 1,
+                target: MentionTarget::All,
+                headers: Headers::new(),
+                body: Some(Body::text("hello")),
+                attachment: None,
+                receipt: None,
+                metadata: serde_json::Value::Null,
+            }),
+        };
+
+        let encoded = serde_json::to_string(&response).unwrap();
+        let decoded: Response = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, response);
     }
 }

--- a/crates/airc-daemon/src/ipc/transport.rs
+++ b/crates/airc-daemon/src/ipc/transport.rs
@@ -52,9 +52,21 @@ impl IpcStream {
         #[cfg(windows)]
         {
             let pipe_name = resolve_pipe_name(path);
-            tokio::net::windows::named_pipe::ClientOptions::new()
-                .open(&pipe_name)
-                .map(IpcStream::WindowsClient)
+            let client = tokio::time::timeout(
+                std::time::Duration::from_millis(250),
+                tokio::task::spawn_blocking(move || {
+                    tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name)
+                }),
+            )
+            .await
+            .map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "timed out opening daemon named pipe",
+                )
+            })?
+            .map_err(|error| std::io::Error::other(format!("named-pipe open task: {error}")))??;
+            Ok(IpcStream::WindowsClient(client))
         }
     }
 }

--- a/crates/airc-daemon/src/lib.rs
+++ b/crates/airc-daemon/src/lib.rs
@@ -39,7 +39,9 @@ pub mod state;
 pub use identity::{IdentityError, LocalIdentity};
 
 pub use ipc::client::{ClientError, DaemonClient};
-pub use ipc::request::{AddPeerRequest, InboxRequest, Request, SendRequest, SubscribeRequest};
+pub use ipc::request::{
+    AddPeerRequest, AttachRequest, InboxRequest, Request, SendRequest, SubscribeRequest,
+};
 pub use ipc::response::{InboxResponse, PeersResponse, Response, StatusResponse};
 pub use server::{run, DaemonError};
 pub use state::DaemonState;

--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -15,10 +15,12 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use fs2::FileExt;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use uuid::Uuid;
 
 use crate::handlers::dispatch;
-use crate::ipc::request::Request;
+use crate::ipc::request::{AttachRequest, Request};
 use crate::ipc::response::Response;
 use crate::ipc::transport::{IpcListener, IpcStream};
 use crate::state::DaemonState;
@@ -26,6 +28,8 @@ use crate::state::DaemonState;
 /// What can go wrong running the daemon.
 #[derive(Debug)]
 pub enum DaemonError {
+    /// Another daemon already owns this IPC endpoint.
+    AlreadyRunning(PathBuf),
     /// Socket bind / accept I/O failure.
     Io(std::io::Error),
     /// Could not remove a stale socket file from a prior daemon
@@ -36,6 +40,9 @@ pub enum DaemonError {
 impl std::fmt::Display for DaemonError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            DaemonError::AlreadyRunning(path) => {
+                write!(f, "daemon already running on {}", path.display())
+            }
             DaemonError::Io(error) => write!(f, "daemon I/O: {error}"),
             DaemonError::StaleSocket(error) => {
                 write!(f, "stale socket cleanup: {error}")
@@ -47,6 +54,7 @@ impl std::fmt::Display for DaemonError {
 impl std::error::Error for DaemonError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            DaemonError::AlreadyRunning(_) => None,
             DaemonError::Io(error) | DaemonError::StaleSocket(error) => Some(error),
         }
     }
@@ -62,6 +70,7 @@ impl From<std::io::Error> for DaemonError {
 /// shutdown. Returns when the shutdown notifier fires (typically from
 /// a Stop request handler) or the listener errors.
 pub async fn run(state: Arc<DaemonState>, socket_path: PathBuf) -> Result<(), DaemonError> {
+    let _guard = DaemonBindGuard::acquire(&socket_path)?;
     cleanup_stale_socket(&socket_path).map_err(DaemonError::StaleSocket)?;
     let listener = IpcListener::bind(&socket_path).await?;
 
@@ -88,6 +97,52 @@ pub async fn run(state: Arc<DaemonState>, socket_path: PathBuf) -> Result<(), Da
     // close, so the call is a no-op.
     listener.cleanup();
     Ok(())
+}
+
+struct DaemonBindGuard {
+    file: std::fs::File,
+}
+
+impl DaemonBindGuard {
+    fn acquire(socket_path: &Path) -> Result<Self, DaemonError> {
+        let lock_dir = std::env::temp_dir().join("airc-daemon-locks");
+        std::fs::create_dir_all(&lock_dir)?;
+        let lock_path = lock_dir.join(format!("{}.lock", socket_lock_id(socket_path)));
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(lock_path)?;
+        if let Err(error) = file.try_lock_exclusive() {
+            if is_lock_contended(&error) {
+                return Err(DaemonError::AlreadyRunning(socket_path.to_path_buf()));
+            }
+            return Err(DaemonError::Io(error));
+        }
+        Ok(Self { file })
+    }
+}
+
+fn is_lock_contended(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::PermissionDenied
+    ) || error.raw_os_error() == Some(33)
+}
+
+impl Drop for DaemonBindGuard {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
+
+fn socket_lock_id(socket_path: &Path) -> Uuid {
+    const LOCK_NAMESPACE: Uuid = Uuid::from_bytes([
+        0xa1, 0xc2, 0x70, 0x1b, 0xe0, 0x05, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x03,
+    ]);
+    Uuid::new_v5(&LOCK_NAMESPACE, socket_path.to_string_lossy().as_bytes())
 }
 
 /// If the previous daemon left a stale socket file behind, unlink
@@ -151,11 +206,47 @@ async fn handle_connection(stream: IpcStream, state: Arc<DaemonState>) -> Result
         }
     };
 
+    if let Request::Attach(attach) = request {
+        return stream_attach(writer, state, attach).await;
+    }
+
     let response = dispatch(state, request).await;
     write_response(&mut writer, &response).await?;
     // Drop reader+writer (and thus the underlying stream) so the
     // client's read sees EOF promptly.
     Ok(())
+}
+
+async fn stream_attach<W>(
+    mut writer: W,
+    state: Arc<DaemonState>,
+    attach: AttachRequest,
+) -> Result<(), DaemonError>
+where
+    W: AsyncWriteExt + Unpin,
+{
+    write_response(&mut writer, &Response::Ok).await?;
+    let mut rx = state.live_tx.subscribe();
+    loop {
+        let event = match rx.recv().await {
+            Ok(event) => event,
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => return Ok(()),
+        };
+        if attach
+            .channel
+            .is_some_and(|channel| event.room_id != channel)
+        {
+            continue;
+        }
+        write_response(
+            &mut writer,
+            &Response::Event {
+                event: Box::new(event),
+            },
+        )
+        .await?;
+    }
 }
 
 async fn write_response<W>(writer: &mut W, response: &Response) -> Result<(), DaemonError>
@@ -357,19 +448,9 @@ mod tests {
 
     #[tokio::test]
     async fn second_daemon_refuses_to_steal_live_socket() {
-        // Pin the cleanup_stale_socket / first_pipe_instance contract:
-        // if a daemon is already live on the path, a second run() must
-        // refuse rather than silently take over. The exact error kind
-        // differs by platform:
-        //   - Unix: cleanup_stale_socket returns DaemonError::StaleSocket
-        //     wrapping AddrInUse (we synthesised the kind when probing
-        //     the live socket).
-        //   - Windows: ServerOptions::first_pipe_instance(true) surfaces
-        //     duplicate-binder via DaemonError::Io with PermissionDenied
-        //     (os error 5 / ERROR_ACCESS_DENIED). The OS chose that error
-        //     code; we honour it rather than fabricate equivalence.
-        // Either error variant constitutes "refused" — the test asserts
-        // refusal, not a specific error shape.
+        // A second daemon must fail before binding the endpoint. The
+        // bind guard normalizes platform lock errors into the daemon
+        // contract so callers do not need OS-specific error matching.
         let state = fresh_state();
         let socket = unique_socket();
         let first = state.clone();
@@ -377,16 +458,12 @@ mod tests {
         let first_handle = tokio::spawn(async move { run(first, socket_for_first).await });
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let second_result = run(fresh_state(), socket.clone()).await;
-        let refused = match &second_result {
-            Err(DaemonError::StaleSocket(_)) => true,
-            Err(DaemonError::Io(io)) if io.kind() == std::io::ErrorKind::PermissionDenied => {
-                cfg!(windows)
-            }
-            _ => false,
-        };
+        let second_result =
+            tokio::time::timeout(Duration::from_secs(2), run(fresh_state(), socket.clone()))
+                .await
+                .expect("second daemon bind attempt must return promptly");
         assert!(
-            refused,
+            matches!(second_result, Err(DaemonError::AlreadyRunning(_))),
             "second daemon must refuse to steal a live socket; got {second_result:?}"
         );
 

--- a/crates/airc-daemon/src/state.rs
+++ b/crates/airc-daemon/src/state.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Instant;
 
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::{broadcast, Mutex, Notify};
 
 use airc_core::PeerId;
 use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
@@ -50,6 +50,8 @@ pub struct DaemonState {
     /// is idempotent — repeated calls find the wire here and skip
     /// the spawn.
     pub subscribed_wires: Mutex<HashMap<PathBuf, ()>>,
+    /// Authoritative live fan-out for daemon consumers.
+    pub live_tx: broadcast::Sender<airc_core::TranscriptEvent>,
     /// Notified when the daemon should stop accepting + exit cleanly.
     pub shutdown: Notify,
 }
@@ -67,6 +69,7 @@ impl DaemonState {
         home: PathBuf,
         event_store: Arc<dyn EventStore>,
     ) -> Self {
+        let (live_tx, _) = broadcast::channel(1024);
         Self {
             peer_id,
             keypair,
@@ -77,6 +80,7 @@ impl DaemonState {
             local_fs_transports: Mutex::new(HashMap::new()),
             event_store,
             subscribed_wires: Mutex::new(HashMap::new()),
+            live_tx,
             shutdown: Notify::new(),
         }
     }

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -429,16 +429,11 @@ impl Airc {
     /// Subscribe to every channel in `context`, set its default, and
     /// start local subscribers for the resulting wires.
     ///
-    /// When the local `gh` is authenticated against GitHub, this
-    /// also publishes the scope's account-registry document to a
-    /// per-machine gist and refreshes from any other matching gists
-    /// on the same account — that's the cross-machine bootstrap.
-    /// Both operations are best-effort: if `gh` is missing,
-    /// unauthenticated, rate-limited, or the user has deleted the
-    /// gist out-of-band, the join still completes locally and the
-    /// failure is surfaced via stderr. Cross-machine convergence
-    /// just won't happen until gh recovers — the local mesh
-    /// continues to work.
+    /// Network bootstrap is intentionally not in this critical path:
+    /// `airc join` is the local, deterministic act of entering the
+    /// account mesh. Cross-machine publication/refresh belongs to a
+    /// bounded coordinator task so gh/network latency can never make
+    /// the public join command hang.
     pub async fn ensure_join_context(&self, context: JoinContext) -> Result<Vec<Room>, AircError> {
         let identity = self.mesh_identity()?;
         let mut set = subscriptions::load_or_init(&self.inner.home)?;
@@ -463,60 +458,6 @@ impl Airc {
             self.ensure_wire_subscriber(&room.wire).await?;
         }
 
-        // Cross-machine bootstrap: publish + refresh through gh-gist
-        // if gh is authenticated. Best-effort with a hard deadline so
-        // the join command never blocks indefinitely on slow gh API
-        // (e.g., `gh api /gists --paginate` over a user's full gist
-        // list, which can take minutes for high-gist-count accounts).
-        // Tests and headless flows can skip entirely with
-        // `AIRC_DISABLE_ACCOUNT_REGISTRY=1`.
-        //
-        // Local mesh still works regardless; cross-machine
-        // convergence just doesn't happen on this join. The daemon
-        // (PR 1 of the architecture plan) will own this sync on a
-        // periodic background tick so the CLI never waits on it.
-        let registry_disabled = std::env::var_os("AIRC_DISABLE_ACCOUNT_REGISTRY")
-            .map(|v| v != "0" && !v.is_empty())
-            .unwrap_or(false);
-        if !registry_disabled {
-            let timeout_secs: u64 = std::env::var("AIRC_REGISTRY_TIMEOUT_SECS")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(5);
-            let timeout = std::time::Duration::from_secs(timeout_secs);
-            let registry_future = async {
-                if crate::gh_account_registry::gh_auth_ready(None).await {
-                    let store = crate::gh_account_registry::GhAccountRegistryStore::new(
-                        self.inner.wire_root.clone(),
-                    );
-                    if let Err(error) = self.publish_account_registry(&store).await {
-                        eprintln!(
-                            "airc: cross-machine registry publish failed (local mesh still works): {error}"
-                        );
-                    }
-                    match self.refresh_account_registry(&store).await {
-                        Ok(Some(_doc)) => {}
-                        Ok(None) => {}
-                        Err(error) => {
-                            eprintln!(
-                                "airc: cross-machine registry refresh failed (local mesh still works): {error}"
-                            );
-                        }
-                    }
-                }
-            };
-            if tokio::time::timeout(timeout, registry_future)
-                .await
-                .is_err()
-            {
-                eprintln!(
-                    "airc: cross-machine registry sync exceeded {timeout_secs}s — \
-                     continuing without it (local mesh still works). \
-                     Set AIRC_REGISTRY_TIMEOUT_SECS=<n> to extend or \
-                     AIRC_DISABLE_ACCOUNT_REGISTRY=1 to skip entirely."
-                );
-            }
-        }
         Ok(rooms)
     }
 

--- a/crates/airc-lib/src/gh_account_registry.rs
+++ b/crates/airc-lib/src/gh_account_registry.rs
@@ -46,6 +46,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
+use tokio::time::{timeout, Duration};
 
 use crate::account_registry::{
     AccountRegistryDocument, AccountRegistryError, AccountRegistryStore,
@@ -313,15 +314,22 @@ fn extract_gist_id(stdout: &str) -> Option<String> {
 /// cleanly when the operator isn't logged in.
 pub async fn gh_auth_ready(gh_bin: Option<&Path>) -> bool {
     let bin = gh_bin.unwrap_or_else(|| Path::new("gh"));
-    match Command::new(bin)
+    let mut child = match Command::new(bin)
         .args(["auth", "status"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .status()
-        .await
+        .spawn()
     {
-        Ok(status) => status.success(),
-        Err(_) => false,
+        Ok(child) => child,
+        Err(_) => return false,
+    };
+    match timeout(Duration::from_millis(750), child.wait()).await {
+        Ok(Ok(status)) => status.success(),
+        Ok(Err(_)) => false,
+        Err(_) => {
+            let _ = child.kill().await;
+            false
+        }
     }
 }
 

--- a/test/public_installed_runtime_proof.sh
+++ b/test/public_installed_runtime_proof.sh
@@ -14,14 +14,8 @@ set -euo pipefail
 # `--no-gist` / `--channel` / `--attach` / env-var flags don't
 # apply; those were wrapper concerns.
 #
-# Coverage that defers to later architecture PRs:
-#   - msg/attach/monitor live narration → PR 1 (daemon auto-start)
-#                                       + PR 2 (`airc attach` subcommand)
-#   - Codex hook injection              → PR 3 (hook reads daemon socket)
-#
-# Until those land, this proof verifies what the substrate CAN
-# verify today through the public command: subscription set,
-# RoomId derivation, machine-account wire promotion.
+# The proof intentionally exercises the public Rust command, not an
+# internal target/debug path and not the removed shell wrapper.
 
 fail() {
   echo "public installed runtime proof failed: $*" >&2
@@ -50,13 +44,23 @@ fi
 case "$(uname -s 2>/dev/null)" in
   MINGW*|MSYS*|CYGWIN*) ;;
   *)
-    [ ! -e "$(dirname "$AIRC_BIN")/airc-core" ] \
-      || fail "POSIX install must not expose stale airc-core on PATH"
+    if [ -z "${AIRC_EXPECT_BIN:-}" ]; then
+      [ ! -e "$(dirname "$AIRC_BIN")/airc-core" ] \
+        || fail "POSIX install must not expose stale airc-core on PATH"
+    fi
     ;;
 esac
 
 ROOT="$(mktemp -d "${TMPDIR:-/tmp}/airc-public-proof.XXXXXX")"
 cleanup() {
+  if [ -n "${MONITOR_PID:-}" ]; then
+    kill "$MONITOR_PID" 2>/dev/null || true
+  fi
+  for scope in "$CONTINUUM_SCOPE" "$OPENCLAW_SCOPE"; do
+    if [ -d "$scope" ]; then
+      "$AIRC_BIN" --home "$scope" stop >/dev/null 2>&1 || true
+    fi
+  done
   rm -rf "$ROOT"
 }
 trap cleanup EXIT INT TERM
@@ -117,6 +121,17 @@ run_join_for_scope() {
   }
   [ -s "$scope/subscriptions.json" ] \
     || fail "airc join did not create subscriptions.json for $scope"
+  (
+    cd "$repo" || exit 1
+    HOME="$MACHINE_HOME" AIRC_HOME="$scope" \
+      "$AIRC_BIN" --home "$scope" ping >"$out.ping" 2>"$err.ping"
+  ) || {
+    echo "--- ping stdout ---" >&2
+    cat "$out.ping" >&2 || true
+    echo "--- ping stderr ---" >&2
+    cat "$err.ping" >&2 || true
+    fail "airc join did not leave daemon alive for $scope"
+  }
 }
 
 json_channel_field() {
@@ -175,4 +190,147 @@ openclaw_general_wire="$(json_channel_field "$OPENCLAW_SCOPE/subscriptions.json"
 [ "$continuum_general_wire" = "$MACHINE_HOME_REAL/.airc/wires/general" ] \
   || fail "#general wire must be account-home scoped, got $continuum_general_wire"
 
-log "all checks passed"
+wait_for_file_text() {
+  local file="$1"
+  local needle="$2"
+  local deadline=$((SECONDS + 30))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    [ -f "$file" ] && grep -q "$needle" "$file" && return 0
+    sleep 1
+  done
+  return 1
+}
+
+wait_for_message() {
+  local repo="$1"
+  local scope="$2"
+  local message="$3"
+  local out="$4"
+  local err="$5"
+  local deadline=$((SECONDS + 12))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    (
+      cd "$repo" || exit 1
+      HOME="$MACHINE_HOME" AIRC_HOME="$scope" \
+        "$AIRC_BIN" --home "$scope" events list --kind message --limit 32
+    ) >"$out" 2>"$err" || return 1
+    grep -q "$message" "$out" && return 0
+    sleep 1
+  done
+  return 1
+}
+
+send_general_from_continuum() {
+  local message="$1"
+  local out="$2"
+  local err="$3"
+  (
+    cd "$CONTINUUM_REPO" || exit 1
+    HOME="$MACHINE_HOME" AIRC_HOME="$CONTINUUM_SCOPE" \
+      "$AIRC_BIN" --home "$CONTINUUM_SCOPE" join general >/dev/null
+    HOME="$MACHINE_HOME" AIRC_HOME="$CONTINUUM_SCOPE" AIRC_CLIENT_ID="continuum-proof-sender" \
+      "$AIRC_BIN" --home "$CONTINUUM_SCOPE" msg "$message" >"$out" 2>"$err"
+  ) || {
+    echo "--- msg stdout ---" >&2
+    cat "$out" >&2 || true
+    echo "--- msg stderr ---" >&2
+    cat "$err" >&2 || true
+    fail "public airc msg failed"
+  }
+}
+
+PROOF_MESSAGE="public installed runtime proof $(date +%s)"
+send_general_from_continuum "$PROOF_MESSAGE" "$ROOT/msg.out" "$ROOT/msg.err"
+
+if ! wait_for_message \
+  "$OPENCLAW_REPO" \
+  "$OPENCLAW_SCOPE" \
+  "$PROOF_MESSAGE" \
+  "$ROOT/events.out" \
+  "$ROOT/events.err"; then
+  echo "--- events stdout ---" >&2
+  cat "$ROOT/events.out" >&2 || true
+  echo "--- events stderr ---" >&2
+  cat "$ROOT/events.err" >&2 || true
+  fail "second fresh scope did not read public airc msg from account wire"
+fi
+
+MONITOR_PID=""
+start_monitor_for_scope() {
+  local repo="$1"
+  local scope="$2"
+  local out="$3"
+  local err="$4"
+  (
+    cd "$repo" || exit 1
+    HOME="$MACHINE_HOME" AIRC_HOME="$scope" AIRC_CLIENT_ID="openclaw-proof-monitor" \
+      "$AIRC_BIN" --home "$scope" monitor attach --my-name "airc" >"$out" 2>"$err"
+  ) &
+  MONITOR_PID=$!
+  if ! wait_for_file_text "$out" "attached to Rust event stream"; then
+    echo "--- monitor stdout ---" >&2
+    cat "$out" >&2 || true
+    echo "--- monitor stderr ---" >&2
+    cat "$err" >&2 || true
+    fail "public airc monitor attach did not attach to Rust event stream"
+  fi
+}
+
+MONITOR_MESSAGE="monitor public proof $(date +%s)"
+start_monitor_for_scope "$OPENCLAW_REPO" "$OPENCLAW_SCOPE" "$ROOT/monitor.out" "$ROOT/monitor.err"
+send_general_from_continuum "$MONITOR_MESSAGE" "$ROOT/monitor-msg.out" "$ROOT/monitor-msg.err"
+
+if ! wait_for_file_text "$ROOT/monitor.out" "$MONITOR_MESSAGE"; then
+  echo "--- monitor stdout ---" >&2
+  cat "$ROOT/monitor.out" >&2 || true
+  echo "--- monitor stderr ---" >&2
+  cat "$ROOT/monitor.err" >&2 || true
+  fail "public airc monitor attach did not render inbound peer message"
+fi
+
+kill "$MONITOR_PID" 2>/dev/null || true
+MONITOR_PID=""
+
+HOOK_MESSAGE="codex hook public proof $(date +%s)"
+send_general_from_continuum "$HOOK_MESSAGE" "$ROOT/hook-msg.out" "$ROOT/hook-msg.err"
+
+if ! wait_for_message \
+  "$OPENCLAW_REPO" \
+  "$OPENCLAW_SCOPE" \
+  "$HOOK_MESSAGE" \
+  "$ROOT/hook-events.out" \
+  "$ROOT/hook-events.err"; then
+  echo "--- hook warmup events stdout ---" >&2
+  cat "$ROOT/hook-events.out" >&2 || true
+  echo "--- hook warmup events stderr ---" >&2
+  cat "$ROOT/hook-events.err" >&2 || true
+  fail "second fresh scope did not persist hook proof message before codex-hook"
+fi
+
+(
+  cd "$OPENCLAW_REPO" || exit 1
+  HOME="$MACHINE_HOME" AIRC_HOME="$OPENCLAW_SCOPE" \
+    "$AIRC_BIN" --home "$OPENCLAW_SCOPE" join general >/dev/null
+  printf '{"hook_event_name":"UserPromptSubmit"}' | \
+    HOME="$MACHINE_HOME" AIRC_HOME="$OPENCLAW_SCOPE" AIRC_CLIENT_ID="openclaw-proof-hook" \
+    "$AIRC_BIN" --home "$OPENCLAW_SCOPE" codex-hook user-prompt-submit \
+      --cursor-file "$ROOT/codex-hook-cursor.json" \
+      --count 64 \
+      --raw
+) >"$ROOT/codex-hook.out" 2>"$ROOT/codex-hook.err" || {
+  echo "--- codex-hook stdout ---" >&2
+  cat "$ROOT/codex-hook.out" >&2 || true
+  echo "--- codex-hook stderr ---" >&2
+  cat "$ROOT/codex-hook.err" >&2 || true
+  fail "public airc codex-hook user-prompt-submit failed"
+}
+
+if ! grep -q "$HOOK_MESSAGE" "$ROOT/codex-hook.out"; then
+  echo "--- codex-hook stdout ---" >&2
+  cat "$ROOT/codex-hook.out" >&2 || true
+  echo "--- codex-hook stderr ---" >&2
+  cat "$ROOT/codex-hook.err" >&2 || true
+  fail "public airc codex-hook did not include inbound Rust event context"
+fi
+
+log "public airc command, account-room derivation, same-machine #general wire, message delivery, monitor attach, and codex-hook are coherent"


### PR DESCRIPTION
Summary
- make `airc join` start the scope daemon and subscribe it to all joined channels
- add daemon Attach streaming over typed IPC and route Monitor attach through that daemon stream
- route public `airc msg` through daemon send, keep no-arg `airc ping` as daemon health
- use short hashed daemon socket paths on Unix so project scopes do not hit socket path limits
- strengthen public installed proof so two fresh project scopes join, share #general, deliver live Monitor events, and feed the Codex hook

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-daemon -p airc-cli
- cargo clippy --manifest-path Cargo.toml -p airc-daemon -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-daemon -p airc-cli
- AIRC_BIN=/Users/joelteply/Development/cambrian/airc/airc AIRC_EXPECT_BIN=/Users/joelteply/Development/cambrian/airc/airc test/public_installed_runtime_proof.sh
- test/rust_cutover_guard.sh