### PR TITLE
fix(registry): no --paginate; bound sync with timeout; tests disable

### DIFF
--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -155,6 +155,13 @@ fn join_without_args_uses_default_account_context() {
 
     let output = Command::new(airc_core())
         .env("HOME", machine.path())
+        // Tests run with the operator's real `gh` auth. The gh-gist
+        // account-registry sync (#862) would iterate the real user's
+        // gist list (`gh api /gists --paginate`), which hangs the
+        // test for high-gist-count accounts. Disable for hermetic
+        // testing; PR 1 of the architecture plan moves this sync to
+        // a background daemon tick.
+        .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
         .args(["--home", home.to_str().unwrap(), "join"])
         .current_dir(&repo)
         .output()

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -464,24 +464,57 @@ impl Airc {
         }
 
         // Cross-machine bootstrap: publish + refresh through gh-gist
-        // if gh is authenticated. Best-effort; never fails the join.
-        if crate::gh_account_registry::gh_auth_ready(None).await {
-            let store = crate::gh_account_registry::GhAccountRegistryStore::new(
-                self.inner.wire_root.clone(),
-            );
-            if let Err(error) = self.publish_account_registry(&store).await {
-                eprintln!(
-                    "airc: cross-machine registry publish failed (local mesh still works): {error}"
-                );
-            }
-            match self.refresh_account_registry(&store).await {
-                Ok(Some(_doc)) => {}
-                Ok(None) => {}
-                Err(error) => {
-                    eprintln!(
-                        "airc: cross-machine registry refresh failed (local mesh still works): {error}"
+        // if gh is authenticated. Best-effort with a hard deadline so
+        // the join command never blocks indefinitely on slow gh API
+        // (e.g., `gh api /gists --paginate` over a user's full gist
+        // list, which can take minutes for high-gist-count accounts).
+        // Tests and headless flows can skip entirely with
+        // `AIRC_DISABLE_ACCOUNT_REGISTRY=1`.
+        //
+        // Local mesh still works regardless; cross-machine
+        // convergence just doesn't happen on this join. The daemon
+        // (PR 1 of the architecture plan) will own this sync on a
+        // periodic background tick so the CLI never waits on it.
+        let registry_disabled = std::env::var_os("AIRC_DISABLE_ACCOUNT_REGISTRY")
+            .map(|v| v != "0" && !v.is_empty())
+            .unwrap_or(false);
+        if !registry_disabled {
+            let timeout_secs: u64 = std::env::var("AIRC_REGISTRY_TIMEOUT_SECS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(5);
+            let timeout = std::time::Duration::from_secs(timeout_secs);
+            let registry_future = async {
+                if crate::gh_account_registry::gh_auth_ready(None).await {
+                    let store = crate::gh_account_registry::GhAccountRegistryStore::new(
+                        self.inner.wire_root.clone(),
                     );
+                    if let Err(error) = self.publish_account_registry(&store).await {
+                        eprintln!(
+                            "airc: cross-machine registry publish failed (local mesh still works): {error}"
+                        );
+                    }
+                    match self.refresh_account_registry(&store).await {
+                        Ok(Some(_doc)) => {}
+                        Ok(None) => {}
+                        Err(error) => {
+                            eprintln!(
+                                "airc: cross-machine registry refresh failed (local mesh still works): {error}"
+                            );
+                        }
+                    }
                 }
+            };
+            if tokio::time::timeout(timeout, registry_future)
+                .await
+                .is_err()
+            {
+                eprintln!(
+                    "airc: cross-machine registry sync exceeded {timeout_secs}s — \
+                     continuing without it (local mesh still works). \
+                     Set AIRC_REGISTRY_TIMEOUT_SECS=<n> to extend or \
+                     AIRC_DISABLE_ACCOUNT_REGISTRY=1 to skip entirely."
+                );
             }
         }
         Ok(rooms)

--- a/crates/airc-lib/src/gh_account_registry.rs
+++ b/crates/airc-lib/src/gh_account_registry.rs
@@ -219,12 +219,19 @@ impl AccountRegistryStore for GhAccountRegistryStore {
         // matching the requested mesh_identity. Operator-supplied
         // identity mismatches (e.g., a stale gist from a previous
         // account) are ignored, not surfaced as errors.
+        // Discovery scans only the user's MOST RECENT 100 gists. The
+        // account-mesh-registry beacon is updated on every `airc
+        // join`, so it stays at the top of the user's gist list
+        // sorted by recency — there's no reason to iterate the
+        // entire account's gist history (which can take minutes for
+        // high-gist-count operators). Dropped `--paginate`
+        // deliberately. If an operator legitimately needs deeper
+        // discovery, that's a separate explicit verb later.
         let (ok, stdout, stderr) = self
             .gh_run(
                 &[
                     "api",
                     "/gists?per_page=100",
-                    "--paginate",
                     "--jq",
                     // Filter to gists whose description matches and which
                     // contain our registry filename. Returns one line of


### PR DESCRIPTION
Two fixes to make `airc join` not hang on the gh-gist account-mesh registry sync from #862.

## Root issue

`refresh_account_registry` was `gh api /gists?per_page=100 --paginate` — walked the operator's ENTIRE gist list. Minutes of network traffic per join.

## Fixes

1. **Drop `--paginate`** — beacon stays at the top of recent gists; first 100 is plenty.
2. **5s deadline** around publish + refresh — slow gh can't block the join. Log + continue.
3. **`AIRC_DISABLE_ACCOUNT_REGISTRY=1`** for hermetic tests + headless flows.
4. **`AIRC_REGISTRY_TIMEOUT_SECS=<n>`** operator override.

Permanent fix lands in architecture PR 1 (daemon owns the sync on a background tick; CLI never waits).

## Test plan

- [x] `cargo test join_without_args`: ~1s (was hanging >60s)
- [x] `cargo clippy --all-targets -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] Workspace test sweep — no FAILED

🤖 Generated with [Claude Code](https://claude.com/claude-code)