### PR TITLE
fix(codex-hook): trust airc.client header on shared-HOME identity

### DIFF
--- a/crates/airc-cli/src/codex_commands.rs
+++ b/crates/airc-cli/src/codex_commands.rs
@@ -76,10 +76,16 @@ fn is_self_event(event: &TranscriptEvent, airc: &Airc, runtime_client: Option<&s
     if let Some(event_client) = event.headers.get(HEADER_AIRC_CLIENT) {
         return runtime_client.is_some_and(|rc| event_client == rc);
     }
-    // No header: legacy/unstamped frame. Fall back to identity
-    // equality. Acceptable for the rare unstamped case; current
-    // Rust-emitted frames always stamp the header in send_frame.
-    event.client_id == airc.client_id() || event.peer_id == airc.peer_id()
+    // No header: legacy/unstamped frame. Drop the peer_id check
+    // entirely (Codex's review on PR #869): peer_id is too coarse
+    // for shared-HOME multi-agent operation — every cross-runtime
+    // frame would be suppressed. client_id alone is still subject
+    // to identity-collision on shared HOME, but it's a tighter
+    // signal than peer_id. Current Rust-emitted frames always stamp
+    // the airc.client header in send_frame, so this branch only
+    // fires for legacy/historical frames where false-self
+    // suppression is the lesser harm.
+    event.client_id == airc.client_id()
 }
 
 fn drain_stdin() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/airc-cli/src/codex_commands.rs
+++ b/crates/airc-cli/src/codex_commands.rs
@@ -61,11 +61,24 @@ pub async fn run_user_prompt_submit(
 }
 
 fn is_self_event(event: &TranscriptEvent, airc: &Airc, runtime_client: Option<&str>) -> bool {
-    if let Some(runtime_client) = runtime_client {
-        if let Some(event_client) = event.headers.get(HEADER_AIRC_CLIENT) {
-            return event_client == runtime_client;
-        }
+    // Header-stamped self-detection is the only reliable signal on a
+    // shared HOME. Two scopes (Claude tab + Codex tab) using the
+    // same `~/.airc/` share `identity.json` → share peer_id AND
+    // client_id. The peer_id/client_id equality check would
+    // incorrectly classify EVERY frame from the other runtime as
+    // "self" and filter it out — exactly the symptom that left
+    // Codex's hook silent on Claude's acks.
+    //
+    // Rule: if the event has an `airc.client` header, that IS the
+    // self attestation. Equal to OUR runtime client tag → self.
+    // Different (or our tag absent) → NOT self. Peer_id never
+    // overrides a stamped header on a shared HOME.
+    if let Some(event_client) = event.headers.get(HEADER_AIRC_CLIENT) {
+        return runtime_client.is_some_and(|rc| event_client == rc);
     }
+    // No header: legacy/unstamped frame. Fall back to identity
+    // equality. Acceptable for the rare unstamped case; current
+    // Rust-emitted frames always stamp the header in send_frame.
     event.client_id == airc.client_id() || event.peer_id == airc.peer_id()
 }
 

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -105,6 +105,33 @@ fn codex_hook_filters_by_runtime_client_header_not_persisted_identity() {
 }
 
 #[test]
+fn codex_hook_keeps_stamped_peer_events_when_runtime_client_is_unknown() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+    let cursor = workspace.path().join("cursor.json");
+
+    run_ok(&home, &["init"]);
+    run_ok_with_client(
+        &home,
+        "claude:session-1",
+        &["send", "peer despite shared home"],
+    );
+
+    let output = run_hook(
+        &home,
+        &[
+            "codex-hook",
+            "user-prompt-submit",
+            "--cursor-file",
+            cursor.to_str().unwrap(),
+        ],
+        "{}",
+    );
+    let context = additional_context(&output);
+    assert!(context.contains("peer despite shared home"));
+}
+
+#[test]
 fn codex_hook_raw_mode_preserves_full_event_lines() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");


### PR DESCRIPTION
## The bug

Codex's hook's self-filter falls through to `peer_id` equality when `runtime_client` resolution returns None. On shared HOME (Claude tab + Codex tab both on `~/.airc/`), they have the SAME `peer_id` via shared `identity.json`. The fallback filters out every cross-runtime frame as "self" even though the frames have `airc.client = "claude:..."` headers explicitly marking them.

## The wire proof

```
grep 'claude fresh ack' ~/.airc/wires/cambriantech/frames.jsonl

→ {"sender":"a9aaef9f-...","lamport":1779438083476,
   "headers":{"airc.client":"claude:6f373baf-..."},
   "body":{..."claude fresh ack: saw codex 2026-05-22T08:18:22Z..."}}
```

The frame IS on the wire at lamport 1779438083476 — 180s AFTER Codex's fresh ping at 1779437902491. `airc.client = "claude:6f373baf-..."` distinguishes it from Codex's frames (`airc.client = "codex:..."`). Both have the same `peer_id` because they share HOME identity. Codex's hook saw the frame, runtime_client resolution returned None, fell through to peer_id check, filtered it as self, never injected.

## Fix

If the event has the `airc.client` header, ALWAYS trust it. Don't fall back to peer_id when the header is present.

## Test plan

- [x] cargo test -p airc-cli codex_hook — green
- [x] cargo clippy --all-targets -- -D warnings — clean
- [x] cargo fmt --check — clean
- [x] cargo test --workspace — no FAILED

🤖 Generated with [Claude Code](https://claude.com/claude-code)