### PR TITLE
fix(join): ensure Codex hook setup

### DIFF
--- a/crates/airc-cli/src/codex_install.rs
+++ b/crates/airc-cli/src/codex_install.rs
@@ -4,35 +4,70 @@ use std::path::PathBuf;
 
 use crate::{codex_config, codex_hooks_json};
 
+#[derive(Debug, Default)]
+pub struct HookInstallReport {
+    pub lines: Vec<String>,
+}
+
+impl HookInstallReport {
+    fn push(&mut self, line: impl Into<String>) {
+        self.lines.push(line.into());
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.lines.is_empty()
+    }
+}
+
 pub async fn run_install_hooks(
     codex_home: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let codex_home = codex_home.unwrap_or_else(default_codex_home);
-    let config = codex_home.join("config.toml");
-    let hooks_json = codex_home.join("hooks.json");
-
-    if codex_config::enable_hooks_feature(&config)? {
-        println!("enabled hooks in {}", config.display());
-    }
-    if codex_config::remove_stale_airc_filesystem_permissions(&config)? {
-        println!(
-            "removed stale AIRC filesystem permission profile from {}",
-            config.display()
-        );
-    }
-    if codex_hooks_json::install(&hooks_json)? {
-        println!(
-            "installed AIRC UserPromptSubmit hook in {}",
-            hooks_json.display()
-        );
-    }
-    if codex_config::remove_managed_developer_instructions(&config)? {
-        println!(
-            "removed legacy AIRC Codex polling instructions from {}",
-            config.display()
-        );
+    let report = install_hooks_at(codex_home)?;
+    for line in report.lines {
+        println!("{line}");
     }
     Ok(())
+}
+
+pub fn install_hooks_at(
+    codex_home: PathBuf,
+) -> Result<HookInstallReport, Box<dyn std::error::Error>> {
+    let config = codex_home.join("config.toml");
+    let hooks_json = codex_home.join("hooks.json");
+    let mut report = HookInstallReport::default();
+
+    if codex_config::enable_hooks_feature(&config)? {
+        report.push(format!("enabled hooks in {}", config.display()));
+    }
+    if codex_config::remove_stale_airc_filesystem_permissions(&config)? {
+        report.push(format!(
+            "removed stale AIRC filesystem permission profile from {}",
+            config.display()
+        ));
+    }
+    if codex_hooks_json::install(&hooks_json)? {
+        report.push(format!(
+            "installed AIRC UserPromptSubmit hook in {}",
+            hooks_json.display()
+        ));
+    }
+    if codex_config::remove_managed_developer_instructions(&config)? {
+        report.push(format!(
+            "removed legacy AIRC Codex polling instructions from {}",
+            config.display()
+        ));
+    }
+    Ok(report)
+}
+
+pub fn install_hooks_for_default_home_if_present(
+) -> Result<HookInstallReport, Box<dyn std::error::Error>> {
+    let codex_home = default_codex_home();
+    if !codex_home.exists() {
+        return Ok(HookInstallReport::default());
+    }
+    install_hooks_at(codex_home)
 }
 
 pub async fn run_uninstall_hooks(
@@ -57,7 +92,7 @@ pub async fn run_uninstall_hooks(
     Ok(())
 }
 
-fn default_codex_home() -> PathBuf {
+pub fn default_codex_home() -> PathBuf {
     if let Some(home) = std::env::var_os("HOME") {
         return PathBuf::from(home).join(".codex");
     }

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -112,6 +112,7 @@ pub async fn run_join(
     let socket = crate::cli::default_socket_path_in(home);
     ensure_daemon_running(home, socket.clone(), Vec::new()).await?;
     subscribe_daemon_to_current_rooms(home, socket).await?;
+    ensure_runtime_integrations();
 
     // `--attach` keeps the foreground process alive and streams the
     // live event broadcast. The skills doc has documented this flag
@@ -125,6 +126,20 @@ pub async fn run_join(
         print_event_stream_until_signal(&mut stream).await?;
     }
     Ok(())
+}
+
+fn ensure_runtime_integrations() {
+    match crate::codex_install::install_hooks_for_default_home_if_present() {
+        Ok(report) if report.is_empty() => {}
+        Ok(report) => {
+            for line in report.lines {
+                println!("runtime: {line}");
+            }
+        }
+        Err(error) => {
+            eprintln!("airc: Codex hook setup skipped: {error}");
+        }
+    }
 }
 
 /// `version` — print package version + install dir. Distinct from

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -204,6 +204,56 @@ fn join_without_args_uses_default_account_context() {
     );
 }
 
+#[test]
+fn join_sets_up_codex_hook_when_codex_home_exists() {
+    let machine = TempDir::new().expect("tempdir");
+    let repo = machine.path().join("continuum");
+    let home = repo.join(".airc");
+    let codex_home = machine.path().join(".codex");
+    create_repo_with_origin(&repo, "https://github.com/CambrianTech/continuum.git");
+    seed_mesh_identity(&home, "joelteply");
+    std::fs::create_dir_all(&codex_home).expect("codex home");
+    std::fs::write(codex_home.join("config.toml"), "[features]\n").expect("codex config");
+
+    let mut join = Command::new(airc_core());
+    join.env("HOME", machine.path())
+        .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
+        .args(["--home", home.to_str().unwrap(), "join"])
+        .current_dir(&repo);
+    let output = output_with_timeout(join, Duration::from_secs(10), "airc join");
+    assert!(
+        output.status.success(),
+        "join failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("runtime: installed AIRC UserPromptSubmit hook"),
+        "{stdout}"
+    );
+
+    let hooks = std::fs::read_to_string(codex_home.join("hooks.json")).expect("hooks.json");
+    assert!(
+        hooks.contains("airc codex-hook user-prompt-submit"),
+        "{hooks}"
+    );
+    let config = std::fs::read_to_string(codex_home.join("config.toml")).expect("config.toml");
+    assert!(config.contains("hooks = true"), "{config}");
+
+    let mut stop_command = Command::new(airc_core());
+    stop_command
+        .env("HOME", machine.path())
+        .args(["--home", home.to_str().unwrap(), "stop"]);
+    let stop = output_with_timeout(stop_command, Duration::from_secs(10), "airc stop");
+    assert!(
+        stop.status.success(),
+        "stop failed after join proof: stdout={} stderr={}",
+        String::from_utf8_lossy(&stop.stdout),
+        String::from_utf8_lossy(&stop.stderr),
+    );
+}
+
 fn output_with_timeout(
     mut command: Command,
     timeout: Duration,


### PR DESCRIPTION
Summary
- make airc join ensure Codex UserPromptSubmit hook setup when ~/.codex exists
- refactor Codex hook installer to return structured changed lines for reuse
- add e2e coverage proving join installs the hook/config without a separate command

Verification
- cargo test --manifest-path Cargo.toml -p airc-cli join_sets_up_codex_hook_when_codex_home_exists -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli join_without_args_uses_default_account_context -- --nocapture
- cargo fmt --manifest-path Cargo.toml -p airc-cli
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- git diff --check