### PR TITLE
fix(install): prefer current source tree

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,21 @@
 set -euo pipefail
 
 REPO_URL="https://github.com/CambrianTech/airc.git"
-CLONE_DIR="${AIRC_DIR:-$HOME/.airc/src}"
+
+_default_clone_dir() {
+  local script="${BASH_SOURCE[0]:-}"
+  local script_dir=""
+  if [ -n "$script" ] && [ -f "$script" ]; then
+    script_dir="$(cd "$(dirname "$script")" && pwd -P)"
+    if [ -f "$script_dir/Cargo.toml" ] && [ -d "$script_dir/crates/airc-cli" ]; then
+      printf '%s\n' "$script_dir"
+      return 0
+    fi
+  fi
+  printf '%s\n' "$HOME/.airc/src"
+}
+
+CLONE_DIR="${AIRC_DIR:-$(_default_clone_dir)}"
 # BIN_DIR holds a tiny command shim. The shim execs $HOME/.airc/src/airc
 # so the canonical source command remains the single implementation,
 # while agent/non-interactive shells that already have ~/.local/bin on

--- a/test/rust_cutover_guard.sh
+++ b/test/rust_cutover_guard.sh
@@ -52,6 +52,10 @@ if ! git grep -q 'Installed airc: [$]BIN_DIR/airc' -- install.sh; then
   fail "install.sh must install the Rust binary at \$BIN_DIR/airc (or .exe on Windows)"
 fi
 
+if ! git grep -q '_default_clone_dir' -- install.sh; then
+  fail "install.sh must resolve a checked-out source tree before defaulting to ~/.airc/src"
+fi
+
 if git grep -nE 'Installed command shim:|cat > "[$]BIN_DIR/airc" <<' -- install.sh; then
   fail "install.sh must not install a bash wrapper shim — the Rust binary is the user surface"
 fi


### PR DESCRIPTION
## Summary
- make ./install.sh build the checked-out source tree it is run from before falling back to ~/.airc/src
- preserve AIRC_DIR as the explicit override for CI/curl installs
- add a cutover guard so the installer cannot regress to stale ~/.airc/src precedence

## Verification
- bash -n install.sh uninstall.sh
- bash test/rust_cutover_guard.sh
- git diff --check
- AIRC_INSTALL_NO_PULL=1 ./install.sh
- airc version