### PR TITLE
fix(join): attach through daemon event stream

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -114,16 +114,14 @@ pub async fn run_join(
     subscribe_daemon_to_current_rooms(home, socket).await?;
     ensure_runtime_integrations();
 
-    // `--attach` keeps the foreground process alive and streams the
-    // live event broadcast. The skills doc has documented this flag
-    // for the longest time but only the bash wrapper implemented it;
-    // post-demolition the Rust binary needs to own it directly. Same
-    // path as `airc monitor attach`, just chained after the join.
+    // `--attach` keeps the foreground process alive on the daemon's
+    // authoritative live stream. Keep this on the exact Monitor path
+    // so Claude Monitor, Codex feed tooling, and humans all observe
+    // the same daemon-backed event surface.
     if attach {
         println!();
         println!("attached — Ctrl-C to detach.");
-        let mut stream = airc.subscribe().await?;
-        print_event_stream_until_signal(&mut stream).await?;
+        crate::monitor::run_daemon_attach(home, "airc").await?;
     }
     Ok(())
 }

--- a/crates/airc-cli/src/monitor/mod.rs
+++ b/crates/airc-cli/src/monitor/mod.rs
@@ -5,6 +5,7 @@ mod rename;
 mod render;
 mod scope;
 
+pub(crate) use attach::run as run_daemon_attach;
 pub use cli::{MonitorAction, MonitorArgs};
 
 use std::error::Error;

--- a/crates/airc-cli/tests/operational_dogfood.rs
+++ b/crates/airc-cli/tests/operational_dogfood.rs
@@ -167,6 +167,57 @@ fn monitor_attach_streams_rust_events_without_legacy_log() {
     installed_stop(&claude_user_home);
 }
 
+#[test]
+fn join_attach_uses_monitor_daemon_stream() {
+    let workspace = TempDir::new().expect("workspace tempdir");
+    let codex_user_home = workspace.path().join("codex-user");
+    let claude_user_home = workspace.path().join("claude-user");
+    let shared_wire = workspace.path().join("shared-agent-wire");
+
+    std::fs::create_dir_all(&codex_user_home).expect("codex user home");
+    std::fs::create_dir_all(&claude_user_home).expect("claude user home");
+    seed_mesh_identity(&codex_user_home);
+    seed_mesh_identity(&claude_user_home);
+
+    let codex_spec = installed_init(&codex_user_home).peer_spec;
+    let claude_spec = installed_init(&claude_user_home).peer_spec;
+    installed_peer_add(&codex_user_home, &claude_spec);
+    installed_peer_add(&claude_user_home, &codex_spec);
+    installed_room(&codex_user_home, "join-attach-dogfood", &shared_wire);
+    installed_room(&claude_user_home, "join-attach-dogfood", &shared_wire);
+
+    let mut claude_join_attach = installed_join_attach(&claude_user_home);
+    let attach_lines = spawn_line_reader(claude_join_attach.stdout.take().expect("attach stdout"));
+    assert!(
+        wait_for_channel_line_contains(
+            &attach_lines,
+            "attached to Rust event stream",
+            Duration::from_secs(6)
+        )
+        .is_some(),
+        "join --attach did not use the daemon Monitor stream"
+    );
+
+    installed_send(
+        &codex_user_home,
+        "codex -> claude join attach through rust events",
+    );
+    let saw_join_attach_message = wait_for_channel_line_contains(
+        &attach_lines,
+        "codex -&gt; claude join attach through rust events",
+        Duration::from_secs(6),
+    )
+    .is_some();
+    assert!(
+        saw_join_attach_message,
+        "join --attach did not receive the Rust event"
+    );
+
+    let _ = claude_join_attach.kill();
+    let _ = claude_join_attach.wait();
+    installed_stop(&claude_user_home);
+}
+
 struct InitOutput {
     peer_spec: String,
 }
@@ -237,6 +288,15 @@ fn installed_monitor_attach(user_home: &Path) -> std::process::Child {
         .stderr(Stdio::piped())
         .spawn()
         .expect("airc monitor attach must spawn")
+}
+
+fn installed_join_attach(user_home: &Path) -> std::process::Child {
+    installed_command(user_home)
+        .args(["join", "--attach"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("airc join --attach must spawn")
 }
 
 fn installed_send(user_home: &Path, text: &str) {

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -19,6 +19,13 @@ Monitor(persistent=true, description="airc", command="airc join --attach")
 
 Do not replace that with `Bash(airc status ...)` or `Bash(airc inbox ...)`. `--attach` starts or verifies the scope's transport owner, then attaches the Monitor UI to the local stream. The user should see a Monitor task.
 
+If you are Codex and this skill was invoked by `/join` or `/airc:join`, your first tool call MUST be a long-running shell session:
+```bash
+airc join --attach
+```
+
+Keep that session id and poll it with `write_stdin` between work steps. Do not wait for user prompts to trigger AIRC delivery, and do not substitute `airc inbox`, `airc logs`, or repeated `airc codex-hook` calls for this stream. The hook is still installed by `airc join` as prompt-boundary catch-up; the attached daemon stream is the live path.
+
 ## Substrate facts
 
 - Wire = GitHub gist per channel. `gh api` polls + appends.
@@ -71,11 +78,11 @@ Keep `description="airc"` — the headline shown in the UI is built from it. Pla
 
 **Codex / non-Monitor runtimes:** use the same public command. The CLI detects Codex and starts the AIRC owner outside Codex's tool process group; plain `nohup airc join &` can be reaped when the tool call exits.
 ```
-airc join
+airc join --attach
 airc msg "..."                     # broadcast
 airc msg @peer "..."               # DM
 ```
-Codex has no Claude-style Monitor callback, so airc installs a Codex `UserPromptSubmit` hook when hooks are supported. The hook runs `airc codex-hook user-prompt-submit` before each user prompt reaches the model, injects unread peer messages as developer context, excludes this client session's own messages, and advances the local unread cursor. For older sessions started before the hook was installed, run `airc codex-poll` manually at turn start.
+Codex has no Claude-style Monitor callback, so the agent must keep the `airc join --attach` shell session open and poll it between work steps. `airc join` also installs a Codex `UserPromptSubmit` hook when hooks are supported. The hook runs `airc codex-hook user-prompt-submit` before each user prompt, injects unread peer messages as developer context, excludes this client session's own messages, and advances the local unread cursor. Treat the hook as catch-up only; the attached daemon stream is the live path.
 
 Do NOT poll `airc logs N` without `--since` — that re-injects the full tail every turn. Use `airc codex-poll` for manual Codex catch-up; use `airc join` for initial setup and recovery.
 


### PR DESCRIPTION
## Summary
- route `airc join --attach` through the same daemon attach stream as `airc monitor attach`
- add an operational dogfood regression proving `join --attach` receives peer events through the daemon Monitor path
- update the join skill so Codex keeps `airc join --attach` open as the live feed and treats hooks as catch-up

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli --test operational_dogfood -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- bash test/rust_cutover_guard.sh
- git diff --check