### PR TITLE
test(join): pin runtime attach decision

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -153,31 +153,56 @@ pub async fn run_join(home: &Path, room: Option<String>) -> Result<(), Box<dyn s
 /// 5. Otherwise — exit cleanly after setup.
 fn should_attach_after_join() -> bool {
     use std::io::IsTerminal;
-    if std::env::var_os("AIRC_NO_ATTACH").is_some() {
+    should_attach_after_join_from(
+        std::env::vars_os().map(|(key, value)| {
+            (
+                key.to_string_lossy().into_owned(),
+                value.to_string_lossy().into_owned(),
+            )
+        }),
+        std::io::stdout().is_terminal(),
+    )
+}
+
+fn should_attach_after_join_from<I, K, V>(env: I, stdout_is_tty: bool) -> bool
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    let mut has_opt_out = false;
+    let mut has_cargo_context = false;
+    let mut has_agent_marker = false;
+    for (key, _value) in env {
+        let key = key.as_ref();
+        if key == "AIRC_NO_ATTACH" {
+            has_opt_out = true;
+        }
+        if key.starts_with("CARGO_BIN_EXE_") || key == "CARGO_PKG_NAME" {
+            has_cargo_context = true;
+        }
+        if matches!(
+            key,
+            "CLAUDECODE"
+                | "CLAUDE_CODE_SESSION_ID"
+                | "AI_AGENT"
+                | "CODEX_AGENT_ID"
+                | "CODEX_SESSION_ID"
+                | "AIRC_CODEX_START_CHILD"
+        ) {
+            has_agent_marker = true;
+        }
+    }
+    if has_opt_out {
         return false;
     }
-    let cargo_context = std::env::vars_os().any(|(k, _)| {
-        let key = k.to_string_lossy();
-        key.starts_with("CARGO_BIN_EXE_") || key == "CARGO_PKG_NAME"
-    });
-    if cargo_context {
+    if has_cargo_context {
         return false;
     }
-    let agent_markers = [
-        "CLAUDECODE",
-        "CLAUDE_CODE_SESSION_ID",
-        "AI_AGENT",
-        "CODEX_AGENT_ID",
-        "CODEX_SESSION_ID",
-        "AIRC_CODEX_START_CHILD",
-    ];
-    if agent_markers
-        .iter()
-        .any(|key| std::env::var_os(key).is_some())
-    {
+    if has_agent_marker {
         return true;
     }
-    std::io::stdout().is_terminal()
+    stdout_is_tty
 }
 
 fn ensure_runtime_integrations() {
@@ -795,4 +820,60 @@ fn runtime_headers() -> Result<Headers, Box<dyn std::error::Error>> {
         headers.insert(HEADER_AIRC_CLIENT.to_string(), client);
     }
     Ok(headers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_attach_after_join_from;
+
+    #[test]
+    fn join_attach_decision_streams_for_codex_agent() {
+        assert!(should_attach_after_join_from(
+            [("CODEX_SESSION_ID", "thread-1")],
+            false
+        ));
+    }
+
+    #[test]
+    fn join_attach_decision_streams_for_claude_agent() {
+        assert!(should_attach_after_join_from(
+            [("CLAUDE_CODE_SESSION_ID", "session-1")],
+            false
+        ));
+    }
+
+    #[test]
+    fn join_attach_decision_streams_for_interactive_tty() {
+        assert!(should_attach_after_join_from(
+            std::iter::empty::<(&str, &str)>(),
+            true
+        ));
+    }
+
+    #[test]
+    fn join_attach_decision_exits_for_cargo_context() {
+        assert!(!should_attach_after_join_from(
+            [
+                ("CLAUDE_CODE_SESSION_ID", "session-1"),
+                ("CARGO_BIN_EXE_airc", "/tmp/airc"),
+            ],
+            true
+        ));
+    }
+
+    #[test]
+    fn join_attach_decision_internal_opt_out_wins() {
+        assert!(!should_attach_after_join_from(
+            [("CODEX_SESSION_ID", "thread-1"), ("AIRC_NO_ATTACH", "1")],
+            true
+        ));
+    }
+
+    #[test]
+    fn join_attach_decision_exits_for_noninteractive_script() {
+        assert!(!should_attach_after_join_from(
+            std::iter::empty::<(&str, &str)>(),
+            false
+        ));
+    }
 }

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -70,12 +70,16 @@ Monitor(persistent=true, description="airc", command="airc join")
 Keep `description="airc"` — the headline shown in the UI is built from it. Plain `airc join` creates the live AIRC stream for the scope.
 
 **Codex / non-Monitor runtimes:** use the same public command. The CLI detects Codex and starts the AIRC owner outside Codex's tool process group; plain `nohup airc join &` can be reaped when the tool call exits.
-```
+```bash
 airc join
+```
+Start it as a long-running tool session, keep the returned session id, and poll that session with `write_stdin` between work steps. That is Codex's live feed. Do not wait for the user to type a prompt just to check AIRC. `airc join` also installs a Codex `UserPromptSubmit` hook when hooks are supported; the hook runs `airc codex-hook user-prompt-submit` before each user prompt, injects unread peer messages as developer context, excludes this client session's own messages, and advances the local unread cursor. Treat the hook as catch-up only; the running `airc join` stream is the live path.
+
+Send from a separate short command when you need to answer:
+```bash
 airc msg "..."                     # broadcast
 airc msg @peer "..."               # DM
 ```
-Codex has no Claude-style Monitor callback, so airc installs a Codex `UserPromptSubmit` hook when hooks are supported. The hook runs `airc codex-hook user-prompt-submit` before each user prompt reaches the model, injects unread peer messages as developer context, excludes this client session's own messages, and advances the local unread cursor. For older sessions started before the hook was installed, run `airc codex-poll` manually at turn start.
 
 Do NOT poll `airc logs N` without `--since` — that re-injects the full tail every turn. Use `airc codex-poll` for manual Codex catch-up; use `airc join` for initial setup and recovery.
 
@@ -88,10 +92,11 @@ When two agent tabs (Claude + Codex, or two of either) share a mesh, the goal is
 - If the message is a lane claim ("I am taking PR X") → ack on airc only if you would otherwise have collided; otherwise silent.
 - Do NOT relay Codex's airc messages back to the user as quotes — the user already sees them too, and quoting creates feedback loops.
 
-**Codex tab — on hook injection at turn start:**
-- The hook digest already contains unread peer messages. Treat the most recent question as the active turn input.
+**Codex tab — on live feed output or hook injection:**
+- The `airc join` session output is live peer traffic. Treat the most recent direct question as active work.
+- The hook digest contains unread catch-up when the live feed was not running. Treat it the same way.
 - Reply over `airc msg`, not in stdout/chat — same reason: stdout is for the user, airc is the inter-agent channel.
-- If you need to poll mid-turn (e.g. coordinating on an in-progress task), call `airc codex-poll` as a tool action between work steps. Bounded, returns immediately, never blocks the turn.
+- Poll the existing `airc join` session with `write_stdin` between work steps. Do not start a second join session.
 
 **Both sides — when NOT to broadcast:**
 - Don't ack every event. Routine status pings, heartbeats, your own echoes — silent.


### PR DESCRIPTION
## Summary
- add focused tests for `airc join` runtime context behavior: Codex/Claude markers stream, cargo/tests exit, internal opt-out wins
- update the Codex join skill to use the existing `airc join` stream as the live feed and the hook as catch-up only
- no new public command or flag

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli join_attach_decision -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli join_without_args_uses_default_account_context -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- git diff --check