### PR TITLE
fix(store): persist runtime cursors through SeaORM

### DIFF
--- a/crates/airc-cli/src/codex_cli.rs
+++ b/crates/airc-cli/src/codex_cli.rs
@@ -26,9 +26,6 @@ pub enum CodexHookAction {
     },
     /// Emit Codex UserPromptSubmit JSON with unread AIRC context.
     UserPromptSubmit {
-        /// Cursor file. Defaults to `<home>/codex_hook_cursor.json`.
-        #[arg(long)]
-        cursor_file: Option<PathBuf>,
         /// Maximum unread events to fetch from the transcript store.
         #[arg(long, default_value_t = 50)]
         count: usize,

--- a/crates/airc-cli/src/codex_commands.rs
+++ b/crates/airc-cli/src/codex_commands.rs
@@ -2,20 +2,19 @@
 
 use std::collections::BTreeSet;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-use airc_core::{Body, TranscriptCursor, TranscriptEvent, TranscriptKind};
+use airc_core::{Body, TranscriptEvent, TranscriptKind};
 use airc_lib::{Airc, EventFilter};
 use airc_protocol::HEADER_AIRC_CLIENT;
 use serde::Serialize;
 
 use crate::client_id::current_client_id;
 
-const DEFAULT_CURSOR_FILENAME: &str = "codex_hook_cursor.json";
+const CONSUMER_PREFIX: &str = "codex-hook";
 
 pub async fn run_user_prompt_submit(
     home: &Path,
-    cursor_file: Option<PathBuf>,
     count: usize,
     max_items: usize,
     raw: bool,
@@ -24,12 +23,13 @@ pub async fn run_user_prompt_submit(
     drain_stdin()?;
 
     let airc = Airc::open(home).await?;
-    let cursor_path = cursor_file.unwrap_or_else(|| home.join(DEFAULT_CURSOR_FILENAME));
     let filter = EventFilter {
         kinds: BTreeSet::from([TranscriptKind::Message, TranscriptKind::System]),
         ..EventFilter::default()
     };
-    let previous = read_cursor_if_present(&cursor_path)?;
+    let runtime_client = current_client_id()?;
+    let consumer_id = consumer_id(runtime_client.as_deref());
+    let previous = airc.load_runtime_cursor(&consumer_id).await?;
     let events = match previous {
         Some(cursor) => {
             airc.resume_from_subscribed_filtered(&cursor, filter, count)
@@ -39,10 +39,9 @@ pub async fn run_user_prompt_submit(
     };
 
     if let Some(newest) = events.last().map(TranscriptEvent::cursor) {
-        write_cursor(&cursor_path, &newest)?;
+        airc.save_runtime_cursor(&consumer_id, &newest).await?;
     }
 
-    let runtime_client = current_client_id()?;
     let visible: Vec<_> = events
         .into_iter()
         .filter(|event| include_self || !is_self_event(event, &airc, runtime_client.as_deref()))
@@ -58,6 +57,13 @@ pub async fn run_user_prompt_submit(
     };
     print_hook_payload(&context)?;
     Ok(())
+}
+
+fn consumer_id(runtime_client: Option<&str>) -> String {
+    match runtime_client {
+        Some(client) => format!("{CONSUMER_PREFIX}:{client}"),
+        None => format!("{CONSUMER_PREFIX}:default"),
+    }
 }
 
 fn is_self_event(event: &TranscriptEvent, airc: &Airc, runtime_client: Option<&str>) -> bool {
@@ -98,26 +104,6 @@ fn drain_stdin() -> Result<(), Box<dyn std::error::Error>> {
     if !value.is_object() {
         return Err("Codex hook stdin must be a JSON object".into());
     }
-    Ok(())
-}
-
-fn read_cursor_if_present(
-    path: &Path,
-) -> Result<Option<TranscriptCursor>, Box<dyn std::error::Error>> {
-    match std::fs::read_to_string(path) {
-        Ok(text) => Ok(Some(serde_json::from_str(&text)?)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error.into()),
-    }
-}
-
-fn write_cursor(path: &Path, cursor: &TranscriptCursor) -> Result<(), Box<dyn std::error::Error>> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, serde_json::to_vec(cursor)?)?;
-    std::fs::rename(tmp, path)?;
     Ok(())
 }
 
@@ -248,4 +234,18 @@ fn summarize_text(value: &str, max_len: usize) -> String {
         return one_line;
     }
     format!("{}...", one_line[..max_len.saturating_sub(3)].trim_end())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::consumer_id;
+
+    #[test]
+    fn consumer_id_uses_runtime_client_when_present() {
+        assert_eq!(
+            consumer_id(Some("codex:thread-1")),
+            "codex-hook:codex:thread-1"
+        );
+        assert_eq!(consumer_id(None), "codex-hook:default");
+    }
 }

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -119,16 +119,14 @@ pub async fn run_join(home: &Path, room: Option<String>) -> Result<(), Box<dyn s
     //
     // Agent runtime is detected through explicit env markers OR the
     // same runtime client identity resolver used for event stamping
-    // (`airc client-id`). The cargo signal (`CARGO_BIN_EXE_*` /
-    // `CARGO_PKG_NAME` env vars set on the test binary AND inherited
-    // by spawned children) takes priority — even if Claude Code or
-    // Codex is the parent process, a `cargo test` run inside it
-    // should not hang the test harness.
+    // (`airc client-id`). Noninteractive stdout (pipe/redirect/script)
+    // takes priority so install proofs and automation never hang just
+    // because they inherited a Codex/Claude environment.
     // `AIRC_NO_ATTACH=1` is an explicit internal opt-out for any
     // other script that needs setup-only without inheriting cargo
     // envs.
     if should_attach_after_join() {
-        crate::join_feed::run(&airc, home).await?;
+        crate::join_feed::run(&airc).await?;
     }
     Ok(())
 }
@@ -139,16 +137,17 @@ pub async fn run_join(home: &Path, room: Option<String>) -> Result<(), Box<dyn s
 ///
 /// 1. `AIRC_NO_ATTACH=1` — explicit opt-out (scripts, smokes).
 ///    Highest priority.
-/// 2. Cargo context — `CARGO_BIN_EXE_*` or `CARGO_PKG_NAME` set
+/// 2. Noninteractive stdout — pipe/redirect/script context returns
+///    after setup. This wins over inherited agent markers.
+/// 3. Cargo context — `CARGO_BIN_EXE_*` or `CARGO_PKG_NAME` set
 ///    means we're inside `cargo test` / `cargo run` and must not
-///    hang the harness. This wins over agent-runtime markers
-///    (which may also be set if Claude Code is the parent shell).
-/// 3. Agent runtime markers — Claude Code (`CLAUDECODE`,
+///    hang the harness.
+/// 4. Agent runtime markers — Claude Code (`CLAUDECODE`,
 ///    `CLAUDE_CODE_SESSION_ID`, `AI_AGENT`), Codex
 ///    (`CODEX_AGENT_ID`, `CODEX_SESSION_ID`,
 ///    `AIRC_CODEX_START_CHILD`).
-/// 4. TTY — interactive terminal use.
-/// 5. Otherwise — exit cleanly after setup.
+/// 5. TTY — interactive terminal use.
+/// 6. Otherwise — exit cleanly after setup.
 fn should_attach_after_join() -> bool {
     use std::io::IsTerminal;
     let runtime_client_detected = crate::client_id::current_client_id()
@@ -211,6 +210,9 @@ where
         }
     }
     if has_opt_out {
+        return false;
+    }
+    if !stdout_is_tty {
         return false;
     }
     if has_cargo_context {
@@ -850,7 +852,7 @@ mod tests {
     fn join_attach_decision_streams_for_codex_agent() {
         assert!(should_attach_after_join_from(
             [("CODEX_SESSION_ID", "thread-1")],
-            false
+            true
         ));
     }
 
@@ -858,7 +860,7 @@ mod tests {
     fn join_attach_decision_streams_for_claude_agent() {
         assert!(should_attach_after_join_from(
             [("CLAUDE_CODE_SESSION_ID", "session-1")],
-            false
+            true
         ));
     }
 
@@ -874,6 +876,15 @@ mod tests {
     fn join_attach_decision_streams_for_detected_runtime_client() {
         assert!(should_attach_after_join_with_client(
             std::iter::empty::<(&str, &str)>(),
+            true,
+            true
+        ));
+    }
+
+    #[test]
+    fn join_attach_decision_exits_for_redirected_agent_script() {
+        assert!(!should_attach_after_join_with_client(
+            [("CODEX_SESSION_ID", "thread-1")],
             false,
             true
         ));

--- a/crates/airc-cli/src/join_feed.rs
+++ b/crates/airc-cli/src/join_feed.rs
@@ -2,35 +2,33 @@
 //!
 //! `airc join` is the public recovery/live verb. Agent runtimes keep it
 //! open as their event feed; scripts/tests let it return. This module
-//! keeps the feed usable by storing a per-runtime cursor so each attach
-//! starts at "new since last seen" instead of replaying the full
-//! transcript.
+//! keeps the feed usable by storing a per-runtime cursor in
+//! `airc-store` so each attach starts at "new since last seen" instead
+//! of replaying the full transcript.
 
-use std::path::{Path, PathBuf};
-
-use airc_core::{Body, TranscriptCursor, TranscriptEvent};
+use airc_core::{Body, TranscriptEvent};
 use airc_lib::{Airc, EventFilter, LiveLag};
 use futures::stream::StreamExt;
 
-const CURSOR_PREFIX: &str = "join_feed_cursor";
+const CONSUMER_PREFIX: &str = "join-feed";
 const CATCH_UP_LIMIT: usize = 64;
 
-pub async fn run(airc: &Airc, home: &Path) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run(airc: &Airc) -> Result<(), Box<dyn std::error::Error>> {
     let filter = EventFilter::default();
-    let cursor_path = cursor_path(home)?;
-    print_catch_up(airc, filter.clone(), &cursor_path).await?;
+    let consumer_id = consumer_id()?;
+    print_catch_up(airc, filter.clone(), &consumer_id).await?;
     println!();
     println!("attached — Ctrl-C to detach.");
     let mut stream = airc.subscribe_subscribed_filtered(filter).await?;
-    print_stream_advancing_cursor(&mut stream, &cursor_path).await
+    print_stream_advancing_cursor(airc, &mut stream, &consumer_id).await
 }
 
 async fn print_catch_up(
     airc: &Airc,
     filter: EventFilter,
-    cursor_path: &Path,
+    consumer_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    match read_cursor(cursor_path)? {
+    match airc.load_runtime_cursor(consumer_id).await? {
         Some(cursor) => {
             let events = airc
                 .resume_from_subscribed_filtered(&cursor, filter, CATCH_UP_LIMIT)
@@ -39,7 +37,7 @@ async fn print_catch_up(
                 print_event(event);
             }
             if let Some(newest) = events.last().map(TranscriptEvent::cursor) {
-                write_cursor(cursor_path, &newest)?;
+                airc.save_runtime_cursor(consumer_id, &newest).await?;
             }
             if events.len() == CATCH_UP_LIMIT {
                 eprintln!(
@@ -50,7 +48,7 @@ async fn print_catch_up(
         None => {
             let events = airc.page_recent_subscribed_filtered(filter, 1).await?;
             if let Some(newest) = events.last().map(TranscriptEvent::cursor) {
-                write_cursor(cursor_path, &newest)?;
+                airc.save_runtime_cursor(consumer_id, &newest).await?;
             }
         }
     }
@@ -58,8 +56,9 @@ async fn print_catch_up(
 }
 
 async fn print_stream_advancing_cursor<S>(
+    airc: &Airc,
     stream: &mut S,
-    cursor_path: &Path,
+    consumer_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
     S: futures::stream::Stream<Item = Result<TranscriptEvent, LiveLag>> + Unpin,
@@ -78,7 +77,7 @@ where
                 match next {
                     Some(Ok(event)) => {
                         print_event(&event);
-                        write_cursor(cursor_path, &event.cursor())?;
+                        airc.save_runtime_cursor(consumer_id, &event.cursor()).await?;
                     }
                     Some(Err(lag)) => {
                         eprintln!("{lag}");
@@ -93,47 +92,12 @@ where
     }
 }
 
-fn cursor_path(home: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+fn consumer_id() -> Result<String, Box<dyn std::error::Error>> {
     let suffix = match crate::client_id::current_client_id()? {
-        Some(client_id) => safe_filename_component(&client_id),
+        Some(client_id) => client_id,
         None => "default".to_string(),
     };
-    Ok(home.join(format!("{CURSOR_PREFIX}.{suffix}.json")))
-}
-
-fn read_cursor(path: &Path) -> Result<Option<TranscriptCursor>, Box<dyn std::error::Error>> {
-    match std::fs::read_to_string(path) {
-        Ok(text) => Ok(Some(serde_json::from_str(&text)?)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error.into()),
-    }
-}
-
-fn write_cursor(path: &Path, cursor: &TranscriptCursor) -> Result<(), Box<dyn std::error::Error>> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let tmp = path.with_extension(format!("{}.tmp", std::process::id()));
-    std::fs::write(&tmp, serde_json::to_vec(cursor)?)?;
-    replace_file(&tmp, path)?;
-    Ok(())
-}
-
-#[cfg(windows)]
-fn replace_file(tmp: &Path, path: &Path) -> std::io::Result<()> {
-    match std::fs::rename(tmp, path) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            std::fs::remove_file(path)?;
-            std::fs::rename(tmp, path)
-        }
-        Err(error) => Err(error),
-    }
-}
-
-#[cfg(not(windows))]
-fn replace_file(tmp: &Path, path: &Path) -> std::io::Result<()> {
-    std::fs::rename(tmp, path)
+    Ok(format!("{CONSUMER_PREFIX}:{suffix}"))
 }
 
 fn print_event(event: &TranscriptEvent) {
@@ -150,28 +114,12 @@ fn print_event(event: &TranscriptEvent) {
     );
 }
 
-fn safe_filename_component(value: &str) -> String {
-    value
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
-                ch
-            } else {
-                '-'
-            }
-        })
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
-    use super::safe_filename_component;
+    use super::CONSUMER_PREFIX;
 
     #[test]
-    fn cursor_filename_is_safe_for_runtime_client_ids() {
-        assert_eq!(
-            safe_filename_component("codex:019dea28/with spaces"),
-            "codex-019dea28-with-spaces"
-        );
+    fn consumer_prefix_names_join_feed_checkpoints() {
+        assert_eq!(CONSUMER_PREFIX, "join-feed");
     }
 }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -714,21 +714,13 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 codex_install::run_uninstall_hooks(codex_home).await
             }
             CodexHookAction::UserPromptSubmit {
-                cursor_file,
                 count,
                 max_items,
                 raw,
                 include_self,
             } => {
-                codex_commands::run_user_prompt_submit(
-                    &home,
-                    cursor_file,
-                    count,
-                    max_items,
-                    raw,
-                    include_self,
-                )
-                .await
+                codex_commands::run_user_prompt_submit(&home, count, max_items, raw, include_self)
+                    .await
             }
         },
 

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -15,7 +15,6 @@ fn airc_core() -> &'static str {
 fn codex_hook_emits_context_and_advances_cursor() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");
-    let cursor = workspace.path().join("cursor.json");
 
     run_ok(&home, &["init"]);
     run_ok(&home, &["send", "first unread"]);
@@ -23,30 +22,17 @@ fn codex_hook_emits_context_and_advances_cursor() {
 
     let output = run_hook(
         &home,
-        &[
-            "codex-hook",
-            "user-prompt-submit",
-            "--cursor-file",
-            cursor.to_str().unwrap(),
-            "--include-self",
-        ],
+        &["codex-hook", "user-prompt-submit", "--include-self"],
         "{}",
     );
     let context = additional_context(&output);
     assert!(context.contains("AIRC: 2 unread"));
     assert!(context.contains("first unread"));
     assert!(context.contains("second unread"));
-    assert!(cursor.exists(), "hook must persist its transcript cursor");
 
     let second = run_hook(
         &home,
-        &[
-            "codex-hook",
-            "user-prompt-submit",
-            "--cursor-file",
-            cursor.to_str().unwrap(),
-            "--include-self",
-        ],
+        &["codex-hook", "user-prompt-submit", "--include-self"],
         "{}",
     );
     assert_eq!(
@@ -59,30 +45,28 @@ fn codex_hook_emits_context_and_advances_cursor() {
 fn codex_hook_excludes_self_echoes_but_still_advances_cursor() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");
-    let cursor = workspace.path().join("cursor.json");
 
     run_ok(&home, &["init"]);
     run_ok(&home, &["send", "own message"]);
 
     let output = run_hook(
         &home,
-        &[
-            "codex-hook",
-            "user-prompt-submit",
-            "--cursor-file",
-            cursor.to_str().unwrap(),
-        ],
+        &["codex-hook", "user-prompt-submit"],
         r#"{"hook_event_name":"UserPromptSubmit"}"#,
     );
     assert_eq!(output, "");
-    assert!(cursor.exists(), "self echoes should not replay forever");
+    let second = run_hook(
+        &home,
+        &["codex-hook", "user-prompt-submit"],
+        r#"{"hook_event_name":"UserPromptSubmit"}"#,
+    );
+    assert_eq!(second, "", "self echoes should not replay forever");
 }
 
 #[test]
 fn codex_hook_filters_by_runtime_client_header_not_persisted_identity() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");
-    let cursor = workspace.path().join("cursor.json");
 
     run_ok(&home, &["init"]);
     run_ok_with_client(&home, "codex:thread-1", &["send", "own runtime"]);
@@ -91,12 +75,7 @@ fn codex_hook_filters_by_runtime_client_header_not_persisted_identity() {
     let output = run_hook_with_client(
         &home,
         "codex:thread-1",
-        &[
-            "codex-hook",
-            "user-prompt-submit",
-            "--cursor-file",
-            cursor.to_str().unwrap(),
-        ],
+        &["codex-hook", "user-prompt-submit"],
         "{}",
     );
     let context = additional_context(&output);
@@ -108,7 +87,6 @@ fn codex_hook_filters_by_runtime_client_header_not_persisted_identity() {
 fn codex_hook_keeps_stamped_peer_events_when_runtime_client_is_unknown() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");
-    let cursor = workspace.path().join("cursor.json");
 
     run_ok(&home, &["init"]);
     run_ok_with_client(
@@ -117,16 +95,7 @@ fn codex_hook_keeps_stamped_peer_events_when_runtime_client_is_unknown() {
         &["send", "peer despite shared home"],
     );
 
-    let output = run_hook(
-        &home,
-        &[
-            "codex-hook",
-            "user-prompt-submit",
-            "--cursor-file",
-            cursor.to_str().unwrap(),
-        ],
-        "{}",
-    );
+    let output = run_hook(&home, &["codex-hook", "user-prompt-submit"], "{}");
     let context = additional_context(&output);
     assert!(context.contains("peer despite shared home"));
 }

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -503,6 +503,31 @@ impl Airc {
         self.inner.store.as_ref()
     }
 
+    /// Load a named runtime consumer checkpoint from the durable
+    /// store. This is for hooks/feeds/monitors that need replay
+    /// state; it is intentionally store-backed so runtime delivery
+    /// state does not sprawl into JSON sidecars.
+    pub async fn load_runtime_cursor(
+        &self,
+        consumer_id: &str,
+    ) -> Result<Option<airc_core::TranscriptCursor>, AircError> {
+        Ok(self.inner.store.load_runtime_cursor(consumer_id).await?)
+    }
+
+    /// Persist a named runtime consumer checkpoint in the durable
+    /// store.
+    pub async fn save_runtime_cursor(
+        &self,
+        consumer_id: &str,
+        cursor: &airc_core::TranscriptCursor,
+    ) -> Result<(), AircError> {
+        self.inner
+            .store
+            .save_runtime_cursor(consumer_id, cursor, time::now_ms()?)
+            .await?;
+        Ok(())
+    }
+
     pub(crate) fn next_lamport(&self, wall_ms: u64) -> u64 {
         let mut current = self.inner.lamport_clock.load(Ordering::Relaxed);
         loop {

--- a/crates/airc-store/src/entities/mod.rs
+++ b/crates/airc-store/src/entities/mod.rs
@@ -7,3 +7,4 @@
 //!     of O(n).
 
 pub mod event;
+pub mod runtime_cursor;

--- a/crates/airc-store/src/entities/runtime_cursor.rs
+++ b/crates/airc-store/src/entities/runtime_cursor.rs
@@ -1,0 +1,25 @@
+//! `runtime_cursors` table — durable consumer checkpoints.
+//!
+//! A runtime cursor is not configuration. It is substrate state: a
+//! named consumer's last acknowledged transcript position. Hooks,
+//! joins, monitors, and future Continuum/OpenClaw/Hermes consumers use
+//! this table instead of sidecar JSON cursor files.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "runtime_cursors")]
+pub struct Model {
+    /// Stable consumer identifier, e.g. `join-feed:codex:<thread>` or
+    /// `codex-hook:default`.
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub consumer_id: String,
+    pub lamport: i64,
+    pub event_id: Uuid,
+    pub updated_at_ms: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/airc-store/src/memory.rs
+++ b/crates/airc-store/src/memory.rs
@@ -3,6 +3,7 @@
 //! all state when dropped.
 
 use async_trait::async_trait;
+use std::collections::BTreeMap;
 use std::sync::Mutex;
 
 use airc_core::{RoomId, TranscriptCursor, TranscriptEvent};
@@ -12,12 +13,14 @@ use crate::store::EventStore;
 
 pub struct InMemoryEventStore {
     events: Mutex<Vec<TranscriptEvent>>,
+    runtime_cursors: Mutex<BTreeMap<String, TranscriptCursor>>,
 }
 
 impl InMemoryEventStore {
     pub fn new() -> Self {
         Self {
             events: Mutex::new(Vec::new()),
+            runtime_cursors: Mutex::new(BTreeMap::new()),
         }
     }
 }
@@ -86,6 +89,31 @@ impl EventStore for InMemoryEventStore {
             .filter(|e| channel.is_none_or(|room| e.room_id == room))
             .max_by(|a, b| transcript_order(a, b));
         Ok(newest.map(|e| e.cursor()))
+    }
+
+    async fn load_runtime_cursor(
+        &self,
+        consumer_id: &str,
+    ) -> Result<Option<TranscriptCursor>, StoreError> {
+        let cursors = self
+            .runtime_cursors
+            .lock()
+            .map_err(|_| StoreError::LockPoisoned)?;
+        Ok(cursors.get(consumer_id).cloned())
+    }
+
+    async fn save_runtime_cursor(
+        &self,
+        consumer_id: &str,
+        cursor: &TranscriptCursor,
+        _updated_at_ms: u64,
+    ) -> Result<(), StoreError> {
+        let mut cursors = self
+            .runtime_cursors
+            .lock()
+            .map_err(|_| StoreError::LockPoisoned)?;
+        cursors.insert(consumer_id.to_string(), cursor.clone());
+        Ok(())
     }
 }
 

--- a/crates/airc-store/src/migration/m20260522_000002_create_runtime_cursors.rs
+++ b/crates/airc-store/src/migration/m20260522_000002_create_runtime_cursors.rs
@@ -1,0 +1,56 @@
+//! Add durable runtime cursor checkpoints.
+//!
+//! This replaces ad-hoc JSON cursor sidecars for hook/feed consumers.
+//! The row is keyed by logical consumer id and stores the canonical
+//! transcript cursor `(lamport, event_id)`.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(RuntimeCursors::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(RuntimeCursors::ConsumerId)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(RuntimeCursors::Lamport)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(RuntimeCursors::EventId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(RuntimeCursors::UpdatedAtMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(RuntimeCursors::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum RuntimeCursors {
+    Table,
+    ConsumerId,
+    Lamport,
+    EventId,
+    UpdatedAtMs,
+}

--- a/crates/airc-store/src/migration/mod.rs
+++ b/crates/airc-store/src/migration/mod.rs
@@ -8,12 +8,16 @@
 use sea_orm_migration::prelude::*;
 
 mod m20260519_000001_create_events;
+mod m20260522_000002_create_runtime_cursors;
 
 pub struct Migrator;
 
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20260519_000001_create_events::Migration)]
+        vec![
+            Box::new(m20260519_000001_create_events::Migration),
+            Box::new(m20260522_000002_create_runtime_cursors::Migration),
+        ]
     }
 }

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -29,7 +29,7 @@ use airc_core::{
     Body, ClientId, EventId, Headers, PeerId, RoomId, TranscriptCursor, TranscriptEvent,
 };
 
-use crate::entities::event;
+use crate::entities::{event, runtime_cursor};
 use crate::error::StoreError;
 use crate::migration::Migrator;
 use crate::store::EventStore;
@@ -194,6 +194,46 @@ impl EventStore for SqliteEventStore {
             lamport: m.lamport as u64,
             event_id: EventId::from_uuid(m.event_id),
         }))
+    }
+
+    async fn load_runtime_cursor(
+        &self,
+        consumer_id: &str,
+    ) -> Result<Option<TranscriptCursor>, StoreError> {
+        let row = runtime_cursor::Entity::find_by_id(consumer_id.to_string())
+            .one(&self.db)
+            .await?;
+        Ok(row.map(|m| TranscriptCursor {
+            lamport: m.lamport as u64,
+            event_id: EventId::from_uuid(m.event_id),
+        }))
+    }
+
+    async fn save_runtime_cursor(
+        &self,
+        consumer_id: &str,
+        cursor: &TranscriptCursor,
+        updated_at_ms: u64,
+    ) -> Result<(), StoreError> {
+        let active = runtime_cursor::ActiveModel {
+            consumer_id: ActiveValue::Set(consumer_id.to_string()),
+            lamport: ActiveValue::Set(cursor.lamport as i64),
+            event_id: ActiveValue::Set(cursor.event_id.as_uuid()),
+            updated_at_ms: ActiveValue::Set(updated_at_ms as i64),
+        };
+        runtime_cursor::Entity::insert(active)
+            .on_conflict(
+                OnConflict::column(runtime_cursor::Column::ConsumerId)
+                    .update_columns([
+                        runtime_cursor::Column::Lamport,
+                        runtime_cursor::Column::EventId,
+                        runtime_cursor::Column::UpdatedAtMs,
+                    ])
+                    .to_owned(),
+            )
+            .exec(&self.db)
+            .await?;
+        Ok(())
     }
 }
 
@@ -432,6 +472,86 @@ mod tests {
         assert_eq!(latest_b, b1.cursor());
         let latest_global = store.latest_cursor(None).await.unwrap().unwrap();
         assert_eq!(latest_global, a2.cursor());
+    }
+
+    #[tokio::test]
+    async fn runtime_cursor_upserts_by_consumer_id() {
+        let store = SqliteEventStore::in_memory().await.unwrap();
+        let first = TranscriptCursor {
+            lamport: 7,
+            event_id: EventId::from_u128(0x7),
+        };
+        let second = TranscriptCursor {
+            lamport: 9,
+            event_id: EventId::from_u128(0x9),
+        };
+
+        assert!(store
+            .load_runtime_cursor("codex-hook:default")
+            .await
+            .unwrap()
+            .is_none());
+
+        store
+            .save_runtime_cursor("codex-hook:default", &first, 1_700_000_000_000)
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .load_runtime_cursor("codex-hook:default")
+                .await
+                .unwrap(),
+            Some(first.clone())
+        );
+
+        store
+            .save_runtime_cursor("codex-hook:default", &second, 1_700_000_000_100)
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .load_runtime_cursor("codex-hook:default")
+                .await
+                .unwrap(),
+            Some(second)
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_cursors_are_isolated_by_consumer_id() {
+        let store = SqliteEventStore::in_memory().await.unwrap();
+        let hook = TranscriptCursor {
+            lamport: 3,
+            event_id: EventId::from_u128(0x3),
+        };
+        let join = TranscriptCursor {
+            lamport: 4,
+            event_id: EventId::from_u128(0x4),
+        };
+
+        store
+            .save_runtime_cursor("codex-hook:default", &hook, 1)
+            .await
+            .unwrap();
+        store
+            .save_runtime_cursor("join-feed:codex:thread-1", &join, 2)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store
+                .load_runtime_cursor("codex-hook:default")
+                .await
+                .unwrap(),
+            Some(hook)
+        );
+        assert_eq!(
+            store
+                .load_runtime_cursor("join-feed:codex:thread-1")
+                .await
+                .unwrap(),
+            Some(join)
+        );
     }
 
     #[tokio::test]

--- a/crates/airc-store/src/store.rs
+++ b/crates/airc-store/src/store.rs
@@ -59,4 +59,18 @@ pub trait EventStore: Send + Sync {
         &self,
         channel: Option<RoomId>,
     ) -> Result<Option<TranscriptCursor>, StoreError>;
+
+    /// Return a named runtime consumer's checkpoint.
+    async fn load_runtime_cursor(
+        &self,
+        consumer_id: &str,
+    ) -> Result<Option<TranscriptCursor>, StoreError>;
+
+    /// Persist a named runtime consumer's checkpoint.
+    async fn save_runtime_cursor(
+        &self,
+        consumer_id: &str,
+        cursor: &TranscriptCursor,
+        updated_at_ms: u64,
+    ) -> Result<(), StoreError>;
 }

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -55,6 +55,10 @@ Priority order matters:
 8. Code organization must preserve the substrate boundary. If a file
    starts naming consumers, move that surface into an integration
    crate/module.
+9. Durable substrate data uses the store/ORM boundary. JSON is allowed
+   for wire payload encoding, install/config bootstrap, and external
+   invite documents; it is not acceptable for runtime cursors, trust
+   state, subscriptions, presence registries, or replay checkpoints.
 
 ## Current Drift
 
@@ -80,8 +84,8 @@ Goal: stop making the substrate name Codex/Claude directly.
 Work:
 
 - Add `integrations-common` crate/module for runtime detection,
-  runtime client identity, cursor files, and hook/feed conventions
-  shared by agent integrations.
+  runtime client identity, store-backed cursor ownership, and hook/feed
+  conventions shared by agent integrations.
 - Move Codex-specific surfaces out of `airc-cli`:
   - `codex_*.rs`
   - Codex hook JSON/config mutation
@@ -249,8 +253,9 @@ Acceptance gates:
 
 1. Extract runtime context detection from `airc-cli::commands` into a
    small typed module. Keep behavior identical.
-2. Add cursor-backed join feed so `airc join` does not replay the
-   whole backlog every attach.
+2. Add store-backed runtime cursors so `airc join` and Codex hook
+   consumers never replay the whole backlog and never write cursor JSON
+   sidecars.
 3. Move Codex hook/feed files behind an integration boundary.
 4. Add lifecycle event types and subscription query API.
 5. Add first command-bus request/reply helper after reviewing

--- a/test/public_installed_runtime_proof.sh
+++ b/test/public_installed_runtime_proof.sh
@@ -314,7 +314,6 @@ fi
   printf '{"hook_event_name":"UserPromptSubmit"}' | \
     HOME="$MACHINE_HOME" AIRC_HOME="$OPENCLAW_SCOPE" AIRC_CLIENT_ID="openclaw-proof-hook" \
     "$AIRC_BIN" --home "$OPENCLAW_SCOPE" codex-hook user-prompt-submit \
-      --cursor-file "$ROOT/codex-hook-cursor.json" \
       --count 64 \
       --raw
 ) >"$ROOT/codex-hook.out" 2>"$ROOT/codex-hook.err" || {


### PR DESCRIPTION
## Summary
- add a SeaORM runtime_cursors table and typed EventStore checkpoint API
- move airc join feed and Codex hook cursors off JSON sidecars and into airc-store
- remove the Codex hook --cursor-file surface and update public proof/tests
- fix join attach detection so redirected scripts exit even when they inherit agent runtime markers
- document the ORM boundary as a grid substrate non-negotiable

## Verification
- cargo test --manifest-path Cargo.toml -p airc-store runtime_cursor --no-fail-fast
- cargo test --manifest-path Cargo.toml -p airc-cli codex_hook --no-fail-fast
- cargo test --manifest-path Cargo.toml -p airc-cli join_attach_decision --no-fail-fast
- cargo clippy --manifest-path Cargo.toml -p airc-store -p airc-lib -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace --no-fail-fast
- AIRC_BIN="/Users/joelteply/Development/cambrian/airc/target/debug/airc" AIRC_EXPECT_BIN="/Users/joelteply/Development/cambrian/airc/target/debug/airc" test/public_installed_runtime_proof.sh