### PR TITLE
fix(store): persist peer trust through ORM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ version = "0.1.0"
 dependencies = [
  "airc-core",
  "async-trait",
+ "base64",
  "sea-orm",
  "sea-orm-migration",
  "serde",

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The Rust route resolver picks among these based on local health + invite metadat
 
 - Every envelope is Ed25519-signed; receivers verify against a local `PeerKeyRegistry`.
 - DMs between paired peers are X25519 + ChaCha20-Poly1305 end-to-end encrypted.
-- Trust changes are **signed explicit operations**, not silent overwrites: a `TrustRotation` event signed by the previous key, sequence-numbered, with an append-only audit log at `<home>/peers_audit.jsonl`. Adding a peer with a different pubkey errors `PubkeyConflict` until a proper rotation is presented.
+- Trust changes are **signed explicit operations**, not silent overwrites: a `TrustRotation` event signed by the previous key, sequence-numbered, with append-only audit rows in the `peer_rotation_audit` table. Adding a peer with a different pubkey errors `PubkeyConflict` until a proper rotation is presented.
 
 ## The Model
 

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -5,7 +5,7 @@
 //!   - `identity.key`   — 32-byte Ed25519 secret (0600 on Unix)
 //!   - `identity.json`  — stable peer_id + client_id (0600)
 //!   - `daemon.sock`    — IPC socket for the daemon
-//!   - `peers.json`     — (future) persisted peer registry
+//!   - `events.sqlite`  — ORM-backed event, cursor, and peer trust store
 //!
 //! The `--home` flag overrides for testing / multi-identity setups.
 
@@ -127,7 +127,7 @@ pub struct Cli {
 
     /// Ad-hoc peers to enrol for this invocation only, repeatable.
     /// Format: `<uuid>:<base64-pubkey-no-padding>`. Persistent peers
-    /// come from `<home>/peers.json` (managed via `airc peer add`);
+    /// come from the peer trust store (managed via `airc peer add`);
     /// this flag unions on top for one-shot use.
     #[arg(long = "peer", value_name = "SPEC", global = true)]
     pub peers: Vec<PeerSpec>,
@@ -295,7 +295,7 @@ pub enum Command {
         wire: Option<PathBuf>,
     },
 
-    /// Manage the persisted peer registry (`<home>/peers.json`).
+    /// Manage the persisted peer trust registry.
     Peer(PeerArgs),
 
     /// Inspect transport route policy and candidate selection.
@@ -461,7 +461,6 @@ pub enum PeerAction {
         #[arg(long)]
         socket: Option<PathBuf>,
     },
-    /// List enrolled peers. Reads from peers.json on disk (the
-    /// daemon writes the same file, so both views agree).
+    /// List enrolled peers from the peer trust store.
     List,
 }

--- a/crates/airc-cli/src/collaboration_commands.rs
+++ b/crates/airc-cli/src/collaboration_commands.rs
@@ -23,9 +23,12 @@ struct CollaborationEvidence {
     any_activity: Option<MessageActivity>,
 }
 
-pub fn run_status(default_home: &Path, args: CollaborationScopeArgs) -> Result<(), Box<dyn Error>> {
+pub async fn run_status(
+    default_home: &Path,
+    args: CollaborationScopeArgs,
+) -> Result<(), Box<dyn Error>> {
     let home = args.home.as_deref().unwrap_or(default_home);
-    let count = peer_record_count(home);
+    let count = peer_record_count(home).await;
     let evidence = collaboration_evidence(home, &args.my_name, &args.client_id);
     let any_recent = evidence
         .recent_activity
@@ -70,9 +73,12 @@ pub fn run_status(default_home: &Path, args: CollaborationScopeArgs) -> Result<(
     Ok(())
 }
 
-pub fn run_doctor(default_home: &Path, args: CollaborationScopeArgs) -> Result<(), Box<dyn Error>> {
+pub async fn run_doctor(
+    default_home: &Path,
+    args: CollaborationScopeArgs,
+) -> Result<(), Box<dyn Error>> {
     let home = args.home.as_deref().unwrap_or(default_home);
-    let count = peer_record_count(home);
+    let count = peer_record_count(home).await;
     let evidence = collaboration_evidence(home, &args.my_name, &args.client_id);
     let now = Utc::now().timestamp();
     if count > 0 {
@@ -125,12 +131,12 @@ pub fn run_doctor(default_home: &Path, args: CollaborationScopeArgs) -> Result<(
     Err(command_exit(2))
 }
 
-pub fn run_send_warning(
+pub async fn run_send_warning(
     default_home: &Path,
     args: CollaborationScopeArgs,
 ) -> Result<(), Box<dyn Error>> {
     let home = args.home.as_deref().unwrap_or(default_home);
-    if peer_record_count(home) == 0
+    if peer_record_count(home).await == 0
         && recent_remote_speakers(home, &args.my_name, &args.client_id).is_empty()
     {
         eprintln!(
@@ -167,8 +173,8 @@ pub fn command_exit_code(error: &(dyn Error + 'static)) -> Option<u8> {
     error.downcast_ref::<CommandExit>().map(|error| error.0)
 }
 
-fn peer_record_count(home: &Path) -> usize {
-    legacy_peer_record_count(home) + rust_peer_record_count(home)
+async fn peer_record_count(home: &Path) -> usize {
+    legacy_peer_record_count(home) + rust_peer_record_count(home).await
 }
 
 /// Count peers from the legacy `<home>/peers/<peer>.json` per-peer
@@ -192,9 +198,9 @@ fn legacy_peer_record_count(home: &Path) -> usize {
 
 /// Count peers in the Rust substrate's peer registry. Two locations
 /// matter:
-///   1. `<home>/peers.json` — per-scope registry written by the
-///      airc-daemon when a peer is enrolled via this scope.
-///   2. `$HOME/.airc/peers.json` — the machine-account registry
+///   1. `<home>/events.sqlite` — per-scope peer trust rows written
+///      when a peer is enrolled via this scope.
+///   2. `$HOME/.airc/events.sqlite` — the machine-account peer trust store
 ///      shared by all scopes on this user's machine. `Airc::open`
 ///      adds every loaded identity to BOTH, so a scope running from
 ///      a project subdir still publishes its peer record into the
@@ -203,12 +209,12 @@ fn legacy_peer_record_count(home: &Path) -> usize {
 /// Without counting the second path, `airc status` says SOLO even
 /// when another scope on the same machine has enrolled, which made
 /// the substrate look broken when it was actually working.
-fn rust_peer_record_count(home: &Path) -> usize {
+async fn rust_peer_record_count(home: &Path) -> usize {
     use std::collections::HashSet;
 
     let mut seen: HashSet<airc_core::PeerId> = HashSet::new();
     for path in rust_peer_registry_paths(home) {
-        if let Ok(peers) = airc_daemon::peers_store::load(&path) {
+        if let Ok(peers) = airc_daemon::peers_store::load(&path).await {
             for peer in peers {
                 seen.insert(peer.peer_id);
             }
@@ -412,14 +418,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn peer_record_count_requires_valid_json_files() {
+    #[tokio::test]
+    async fn peer_record_count_requires_valid_json_files() {
         let dir = tempfile::tempdir().unwrap();
         fs::create_dir(dir.path().join("peers")).unwrap();
         fs::write(dir.path().join("peers").join("alice.json"), "{}").unwrap();
         fs::write(dir.path().join("peers").join("broken.json"), "{").unwrap();
         fs::write(dir.path().join("peers").join("note.txt"), "{}").unwrap();
 
-        assert_eq!(peer_record_count(dir.path()), 1);
+        assert_eq!(peer_record_count(dir.path()).await, 1);
     }
 }

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -377,7 +377,7 @@ async fn sync_daemon_peers_from_store(
     client: &DaemonClient,
     home: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    for peer in peers_store::load(home)? {
+    for peer in peers_store::load(home).await? {
         client
             .add_peer(AddPeerRequest {
                 peer_id: peer.peer_id,
@@ -572,7 +572,7 @@ pub async fn run_daemon(
     peers: Vec<PeerSpec>,
     socket: PathBuf,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let registry = build_combined_registry(home, &identity, &peers)?;
+    let registry = build_combined_registry(home, &identity, &peers).await?;
 
     if let Some(parent) = socket.parent() {
         if !parent.as_os_str().is_empty() {
@@ -755,18 +755,18 @@ fn print_event(event: &airc_core::TranscriptEvent) {
 }
 
 /// Build the runtime `PeerKeyRegistry` from persistent peers
-/// (`<home>/peers.json`) + ad-hoc `--peer` flags. Self is always
+/// (store-backed peer trust) + ad-hoc `--peer` flags. Self is always
 /// enroled. Ad-hoc unions on top of persistent — if the same peer_id
 /// appears in both, the ad-hoc pubkey wins (matches "this invocation
 /// is authoritative" intuition).
-fn build_combined_registry(
+async fn build_combined_registry(
     home: &Path,
     identity: &LocalIdentity,
     adhoc: &[PeerSpec],
 ) -> Result<Arc<RwLock<PeerKeyRegistry>>, Box<dyn std::error::Error>> {
     let mut registry = PeerKeyRegistry::new();
     registry.enrol(identity.peer_id, 0, identity.keypair.public_bytes())?;
-    for stored in peers_store::load(home)? {
+    for stored in peers_store::load(home).await? {
         registry.enrol(stored.peer_id, 0, stored.pubkey_bytes()?)?;
     }
     for spec in adhoc {
@@ -775,7 +775,7 @@ fn build_combined_registry(
     Ok(Arc::new(RwLock::new(registry)))
 }
 
-/// `peer add <spec>` — persist a peer to `<home>/peers.json` via
+/// `peer add <spec>` — persist a peer to the trust store via
 /// `Airc::add_peer`. If a daemon is running on the given socket,
 /// also tells it via the AddPeer RPC so the in-memory registry
 /// stays in sync.
@@ -794,7 +794,7 @@ pub async fn run_peer_add(
     println!("enroled peer_id={peer_id} (pubkey 32 bytes)");
 
     // Best-effort daemon sync. If the daemon isn't running, that's
-    // fine — it'll pick up peers.json on next start.
+    // fine — it'll pick up the trust store on next start.
     let client = DaemonClient::new(socket);
     match client
         .add_peer(AddPeerRequest {
@@ -805,14 +805,14 @@ pub async fn run_peer_add(
     {
         Ok(()) => println!("daemon: in-memory registry updated."),
         Err(_) => {
-            println!("daemon: not running (peers.json updated; daemon will load on next start).")
+            println!("daemon: not running (trust store updated; daemon will load on next start).")
         }
     }
     Ok(())
 }
 
 /// `peer list` — print enroled peers via `Airc::peers`. The daemon
-/// writes the same `<home>/peers.json`, so this view stays
+/// writes the same trust store, so this view stays
 /// consistent whether the daemon is running or not.
 pub async fn run_peer_list(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let airc = Airc::open(home).await?;

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -4,7 +4,7 @@
 //!   - `identity.key`   — 32-byte Ed25519 secret (0600)
 //!   - `identity.json`  — stable peer_id + client_id (0600)
 //!   - `daemon.sock`    — IPC socket
-//!   - `peers.json`     — (next PR) persisted peer registry
+//!   - `events.sqlite`  — ORM-backed event, cursor, and peer trust store
 //!
 //! `airc init` is the only command that creates the identity from
 //! nothing. All others load `<home>/identity.{key,json}` (auto-
@@ -340,10 +340,14 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         },
 
         Command::Collaboration(args) => match args.action {
-            CollaborationAction::Status(args) => collaboration_commands::run_status(&home, args),
-            CollaborationAction::Doctor(args) => collaboration_commands::run_doctor(&home, args),
+            CollaborationAction::Status(args) => {
+                collaboration_commands::run_status(&home, args).await
+            }
+            CollaborationAction::Doctor(args) => {
+                collaboration_commands::run_doctor(&home, args).await
+            }
             CollaborationAction::SendWarning(args) => {
-                collaboration_commands::run_send_warning(&home, args)
+                collaboration_commands::run_send_warning(&home, args).await
             }
             CollaborationAction::Peers(args) => collaboration_peers::run_peers(&home, args),
             CollaborationAction::PrunePeers(args) => {

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -196,9 +196,9 @@ async fn handle_list_peers(state: Arc<DaemonState>) -> Response {
     use base64::Engine;
     // We don't currently expose registry iteration on
     // PeerKeyRegistry (only by-peer lookup + find_peer). Read the
-    // persisted peers.json instead — the source of truth that both
-    // the daemon and CLI write to.
-    let peers = match crate::peers_store::load(&state.home) {
+    // persisted peer trust store instead — the source of truth that
+    // both the daemon and CLI write to.
+    let peers = match crate::peers_store::load(&state.home).await {
         Ok(peers) => peers,
         Err(error) => {
             return Response::Error {
@@ -264,8 +264,8 @@ mod tests {
         let mut registry = PeerKeyRegistry::new();
         registry.enrol(peer_id, 0, keypair.public_bytes()).unwrap();
         let registry = Arc::new(RwLock::new(registry));
-        // Test home is fresh per-call — empty peers.json is fine for
-        // dispatcher tests; no on-disk state required.
+        // Test home is fresh per-call — empty peer trust store is
+        // fine for dispatcher tests; no preexisting state required.
         let home = tempfile::TempDir::new().unwrap();
         let home_path = home.path().to_path_buf();
         // Keep the TempDir alive for the test's lifetime by leaking

--- a/crates/airc-daemon/src/ipc/client.rs
+++ b/crates/airc-daemon/src/ipc/client.rs
@@ -225,9 +225,8 @@ impl DaemonClient {
         }
     }
 
-    // Reserved for future CLI surfaces that want the daemon's
-    // authoritative in-memory view (rather than reading peers.json
-    // directly). The current `airc peer list` reads the file.
+    // Reserved for CLI surfaces that want the daemon's authoritative
+    // in-memory peer view instead of opening the store directly.
     #[allow(dead_code)]
     pub async fn list_peers(&self) -> Result<PeersResponse, ClientError> {
         match self.call(Request::ListPeers).await? {

--- a/crates/airc-daemon/src/ipc/request.rs
+++ b/crates/airc-daemon/src/ipc/request.rs
@@ -17,8 +17,8 @@ pub enum Request {
     Ping,
     /// Snapshot of daemon state (peer id, uptime, …).
     Status,
-    /// Enrol a peer in the daemon's in-memory registry. The CLI
-    /// writes peers.json itself; this op keeps the running daemon's
+    /// Enrol a peer in the daemon's in-memory registry. Durable peer
+    /// trust lives in the store; this op keeps the running daemon's
     /// registry in sync without a restart.
     AddPeer(AddPeerRequest),
     /// Snapshot of currently-enrolled peers (peer_id + pubkey).

--- a/crates/airc-daemon/src/peers_store.rs
+++ b/crates/airc-daemon/src/peers_store.rs
@@ -161,7 +161,14 @@ impl From<StoreError> for PeersStoreError {
             },
             StoreError::WrongPubkeyLength(got) => PeersStoreError::WrongPubkeyLength(got),
             StoreError::Base64(error) => PeersStoreError::Base64(error),
-            other => PeersStoreError::Store(other),
+            StoreError::Io(_)
+            | StoreError::Database(_)
+            | StoreError::LockPoisoned
+            | StoreError::Migration(_)
+            | StoreError::DuplicateEventId(_)
+            | StoreError::UnknownTranscriptKind(_)
+            | StoreError::InvalidStoredValue { .. }
+            | StoreError::Codec(_) => PeersStoreError::Store(error),
         }
     }
 }

--- a/crates/airc-daemon/src/peers_store.rs
+++ b/crates/airc-daemon/src/peers_store.rs
@@ -1,41 +1,26 @@
-//! Persisted peer registry — `<home>/peers.json`.
+//! Persisted peer trust registry.
 //!
-//! Saves enrolled peers across CLI / daemon restarts so `--peer
-//! <spec>` flags disappear from daily use. Two writers:
-//!   - `airc peer add <spec>` — appends to the file
-//!   - The daemon's `AddPeer` handler — appends + reloads its
-//!     in-memory `PeerKeyRegistry`
-//!
-//! Schema is versioned (`version: 1`) so future shape changes don't
-//! silently misread older files.
-//!
-//! Storage caveat: pubkeys are not secret, but the registry IS the
-//! trust anchor — anyone who can write this file can enrol an
-//! impostor. Permissions match the identity files (0600 on Unix).
+//! Peer trust is durable substrate data. It is backed by
+//! `airc-store`/SeaORM tables, not JSON sidecars.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
-use serde::{Deserialize, Serialize};
 
 use airc_core::PeerId;
 use airc_protocol::trust_rotation::{verify_rotation, RotationVerificationError, TrustRotation};
+pub use airc_store::{RotationAuditEntry, StoredPeer};
+use airc_store::{SqliteEventStore, StoreError};
 
-const PEERS_FILENAME: &str = "peers.json";
-const PEERS_AUDIT_FILENAME: &str = "peers_audit.jsonl";
-const PEERS_VERSION: u32 = 1;
+const STORE_DB_FILENAME: &str = "events.sqlite";
 
 #[derive(Debug)]
 pub enum PeersStoreError {
     Io(std::io::Error),
-    Json(serde_json::Error),
     Base64(base64::DecodeError),
     Clock(std::time::SystemTimeError),
-    SchemaVersionMismatch {
-        found: u32,
-        expected: u32,
-    },
+    Store(StoreError),
     WrongPubkeyLength(usize),
     /// Trust gap §8 fix: a peer with this `PeerId` is already in the
     /// store with a different pubkey. To change a stored pubkey, the
@@ -72,15 +57,12 @@ pub enum PeersStoreError {
 impl std::fmt::Display for PeersStoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PeersStoreError::Io(error) => write!(f, "peers.json I/O: {error}"),
-            PeersStoreError::Json(error) => write!(f, "peers.json parse: {error}"),
-            PeersStoreError::Base64(error) => write!(f, "peers.json base64: {error}"),
-            PeersStoreError::Clock(error) => write!(f, "peers.json timestamp clock error: {error}"),
-            PeersStoreError::SchemaVersionMismatch { found, expected } => {
-                write!(f, "peers.json version {found}, expected {expected}")
-            }
+            PeersStoreError::Io(error) => write!(f, "peer trust I/O: {error}"),
+            PeersStoreError::Base64(error) => write!(f, "peer trust base64: {error}"),
+            PeersStoreError::Clock(error) => write!(f, "peer trust timestamp clock error: {error}"),
+            PeersStoreError::Store(error) => write!(f, "peer trust store: {error}"),
             PeersStoreError::WrongPubkeyLength(got) => {
-                write!(f, "peers.json pubkey is {got} bytes, expected 32")
+                write!(f, "peer trust pubkey is {got} bytes, expected 32")
             }
             PeersStoreError::PubkeyConflict {
                 peer_id,
@@ -128,12 +110,11 @@ impl std::error::Error for PeersStoreError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             PeersStoreError::Io(error) => Some(error),
-            PeersStoreError::Json(error) => Some(error),
             PeersStoreError::Base64(error) => Some(error),
             PeersStoreError::Clock(error) => Some(error),
+            PeersStoreError::Store(error) => Some(error),
             PeersStoreError::RotationVerification(error) => Some(error),
-            PeersStoreError::SchemaVersionMismatch { .. }
-            | PeersStoreError::WrongPubkeyLength(_)
+            PeersStoreError::WrongPubkeyLength(_)
             | PeersStoreError::PubkeyConflict { .. }
             | PeersStoreError::PrevPubkeyMismatch { .. }
             | PeersStoreError::SequenceNotMonotonic { .. }
@@ -154,12 +135,6 @@ impl From<std::io::Error> for PeersStoreError {
     }
 }
 
-impl From<serde_json::Error> for PeersStoreError {
-    fn from(error: serde_json::Error) -> Self {
-        PeersStoreError::Json(error)
-    }
-}
-
 impl From<base64::DecodeError> for PeersStoreError {
     fn from(error: base64::DecodeError) -> Self {
         PeersStoreError::Base64(error)
@@ -172,57 +147,41 @@ impl From<std::time::SystemTimeError> for PeersStoreError {
     }
 }
 
-/// One persisted peer entry — what the file holds. `pubkey_b64` is
-/// the URL-safe-no-padding encoding of the 32-byte Ed25519 pubkey
-/// (matches the `peer add <spec>` argument shape).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct StoredPeer {
-    pub peer_id: PeerId,
-    pub pubkey_b64: String,
-    pub added_at_ms: u64,
-}
-
-impl StoredPeer {
-    /// Decode the stored base64 pubkey to its 32-byte form. Used when
-    /// enroling into a `PeerKeyRegistry`.
-    pub fn pubkey_bytes(&self) -> Result<[u8; 32], PeersStoreError> {
-        let bytes = URL_SAFE_NO_PAD.decode(&self.pubkey_b64)?;
-        if bytes.len() != 32 {
-            return Err(PeersStoreError::WrongPubkeyLength(bytes.len()));
+impl From<StoreError> for PeersStoreError {
+    fn from(error: StoreError) -> Self {
+        match error {
+            StoreError::PeerPubkeyConflict {
+                peer_id,
+                stored_pubkey_b64,
+                attempted_pubkey_b64,
+            } => PeersStoreError::PubkeyConflict {
+                peer_id,
+                stored_pubkey_b64,
+                attempted_pubkey_b64,
+            },
+            StoreError::WrongPubkeyLength(got) => PeersStoreError::WrongPubkeyLength(got),
+            StoreError::Base64(error) => PeersStoreError::Base64(error),
+            other => PeersStoreError::Store(other),
         }
-        let mut out = [0u8; 32];
-        out.copy_from_slice(&bytes);
-        Ok(out)
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
-struct PeersFile {
-    version: u32,
-    peers: Vec<StoredPeer>,
+fn store_path(home: &Path) -> std::path::PathBuf {
+    home.join(STORE_DB_FILENAME)
 }
 
-/// Path to peers.json inside `home`.
-pub fn path_in(home: &Path) -> PathBuf {
-    home.join(PEERS_FILENAME)
+async fn open_store(home: &Path) -> Result<SqliteEventStore, PeersStoreError> {
+    Ok(SqliteEventStore::open_path(&store_path(home)).await?)
 }
 
-/// Load the peer list from `home`. Returns an empty list if the file
-/// doesn't exist (this is the normal state for a fresh install).
-pub fn load(home: &Path) -> Result<Vec<StoredPeer>, PeersStoreError> {
-    let path = path_in(home);
-    if !path.exists() {
-        return Ok(Vec::new());
-    }
-    let text = std::fs::read_to_string(&path)?;
-    let file: PeersFile = serde_json::from_str(&text)?;
-    if file.version != PEERS_VERSION {
-        return Err(PeersStoreError::SchemaVersionMismatch {
-            found: file.version,
-            expected: PEERS_VERSION,
-        });
-    }
-    Ok(file.peers)
+/// Load the peer list from `home`. Returns an empty list when no
+/// peer trust rows exist yet (normal for a fresh install).
+pub async fn load(home: &Path) -> Result<Vec<StoredPeer>, PeersStoreError> {
+    open_store(home)
+        .await?
+        .load_peers()
+        .await
+        .map_err(Into::into)
 }
 
 /// Enrol a peer's pubkey for the first time (trust-on-first-use).
@@ -235,44 +194,17 @@ pub fn load(home: &Path) -> Result<Vec<StoredPeer>, PeersStoreError> {
 ///   [`PeersStoreError::PubkeyConflict`]. Changing a stored pubkey
 ///   requires an explicit signed [`rotate`] — silent overwrite was
 ///   the trust-store gap §8 fix removed.
-pub fn add(home: &Path, peer_id: PeerId, pubkey: [u8; 32]) -> Result<StoredPeer, PeersStoreError> {
-    let mut peers = load(home)?;
+pub async fn add(
+    home: &Path,
+    peer_id: PeerId,
+    pubkey: [u8; 32],
+) -> Result<StoredPeer, PeersStoreError> {
     let pubkey_b64 = URL_SAFE_NO_PAD.encode(pubkey);
-
-    if let Some(existing) = peers.iter().find(|p| p.peer_id == peer_id) {
-        if existing.pubkey_b64 == pubkey_b64 {
-            return Ok(existing.clone());
-        }
-        return Err(PeersStoreError::PubkeyConflict {
-            peer_id,
-            stored_pubkey_b64: existing.pubkey_b64.clone(),
-            attempted_pubkey_b64: pubkey_b64,
-        });
-    }
-
-    let entry = StoredPeer {
-        peer_id,
-        pubkey_b64,
-        added_at_ms: now_ms()?,
-    };
-    peers.push(entry.clone());
-    save(home, &peers)?;
-    Ok(entry)
-}
-
-/// Audit-log entry recording one applied rotation. Append-only;
-/// inspectable via [`audit_log`]. Persisted in `peers_audit.jsonl`
-/// adjacent to `peers.json`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RotationAuditEntry {
-    pub peer_id: PeerId,
-    pub prev_pubkey_b64: String,
-    pub next_pubkey_b64: String,
-    pub sequence: u64,
-    /// Producer's `rotated_at_ms` from the rotation event. Audit-only.
-    pub rotated_at_ms: u64,
-    /// Local clock when the rotation was applied to this store.
-    pub applied_at_ms: u64,
+    open_store(home)
+        .await?
+        .add_peer_trust(peer_id, pubkey_b64, now_ms()?)
+        .await
+        .map_err(Into::into)
 }
 
 /// Apply a signed trust rotation:
@@ -284,21 +216,15 @@ pub struct RotationAuditEntry {
 ///    superseded key is rejected.
 /// 3. Check the rotation's `sequence` is strictly greater than the
 ///    last applied sequence for this peer (replay prevention).
-/// 4. Append an [`RotationAuditEntry`] to `peers_audit.jsonl`.
-/// 5. Persist the new pubkey to `peers.json`.
-///
-/// Order matters: audit is appended BEFORE peers.json is rewritten.
-/// If the audit write fails, the store is unchanged — rotation
-/// didn't apply. If peers.json rewrite fails after audit succeeded,
-/// the audit shows an intent that didn't land — `audit_log` and
-/// the on-disk pubkey will disagree and a follow-up reconciliation
-/// pass can detect that. Surfaced as `Io` either way, never silently.
-pub fn rotate(home: &Path, rotation: &TrustRotation) -> Result<StoredPeer, PeersStoreError> {
+/// 4. Insert an audit row into `peer_rotation_audit`.
+/// 5. Persist the new pubkey to `peer_trust`.
+pub async fn rotate(home: &Path, rotation: &TrustRotation) -> Result<StoredPeer, PeersStoreError> {
     // Step 1: crypto.
     verify_rotation(rotation)?;
 
     // Step 2: stored prev_pubkey matches what rotation names.
-    let mut peers = load(home)?;
+    let store = open_store(home).await?;
+    let peers = store.load_peers().await?;
     let stored_idx = peers
         .iter()
         .position(|p| p.peer_id == rotation.peer_id)
@@ -314,7 +240,7 @@ pub fn rotate(home: &Path, rotation: &TrustRotation) -> Result<StoredPeer, Peers
     }
 
     // Step 3: monotonic sequence per peer.
-    let last_seq = last_applied_sequence(home, rotation.peer_id)?;
+    let last_seq = last_applied_sequence(&store, rotation.peer_id).await?;
     if rotation.sequence <= last_seq {
         return Err(PeersStoreError::SequenceNotMonotonic {
             peer_id: rotation.peer_id,
@@ -333,110 +259,44 @@ pub fn rotate(home: &Path, rotation: &TrustRotation) -> Result<StoredPeer, Peers
         rotated_at_ms: rotation.rotated_at_ms,
         applied_at_ms,
     };
-    append_audit(home, &audit_entry)?;
+    store.append_peer_rotation_audit(audit_entry).await?;
 
-    // Step 5: rewrite peers.json with the new pubkey.
-    peers[stored_idx].pubkey_b64 = URL_SAFE_NO_PAD.encode(rotation.next_pubkey);
-    peers[stored_idx].added_at_ms = applied_at_ms;
-    save(home, &peers)?;
-    Ok(peers[stored_idx].clone())
+    // Step 5: replace peer_trust with the new pubkey.
+    store
+        .replace_peer_trust(
+            rotation.peer_id,
+            URL_SAFE_NO_PAD.encode(rotation.next_pubkey),
+            applied_at_ms,
+        )
+        .await
+        .map_err(Into::into)
 }
 
 /// Read all audit entries for `peer_id` in apply-order. Returns an
 /// empty vec if the audit log doesn't exist yet (no rotations have
 /// ever been applied) or the peer has none.
-pub fn audit_log(home: &Path, peer_id: PeerId) -> Result<Vec<RotationAuditEntry>, PeersStoreError> {
-    let path = home.join(PEERS_AUDIT_FILENAME);
-    if !path.exists() {
-        return Ok(Vec::new());
-    }
-    let text = std::fs::read_to_string(&path)?;
-    let mut out = Vec::new();
-    for line in text.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let entry: RotationAuditEntry = serde_json::from_str(trimmed)?;
-        if entry.peer_id == peer_id {
-            out.push(entry);
-        }
-    }
-    Ok(out)
+pub async fn audit_log(
+    home: &Path,
+    peer_id: PeerId,
+) -> Result<Vec<RotationAuditEntry>, PeersStoreError> {
+    open_store(home)
+        .await?
+        .peer_rotation_audit(peer_id)
+        .await
+        .map_err(Into::into)
 }
 
-fn last_applied_sequence(home: &Path, peer_id: PeerId) -> Result<u64, PeersStoreError> {
-    Ok(audit_log(home, peer_id)?
+async fn last_applied_sequence(
+    store: &SqliteEventStore,
+    peer_id: PeerId,
+) -> Result<u64, PeersStoreError> {
+    Ok(store
+        .peer_rotation_audit(peer_id)
+        .await?
         .into_iter()
         .map(|e| e.sequence)
         .max()
         .unwrap_or(0))
-}
-
-fn append_audit(home: &Path, entry: &RotationAuditEntry) -> Result<(), PeersStoreError> {
-    use std::io::Write;
-    std::fs::create_dir_all(home)?;
-    let path = home.join(PEERS_AUDIT_FILENAME);
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)?;
-    let line = serde_json::to_string(entry)?;
-    file.write_all(line.as_bytes())?;
-    file.write_all(b"\n")?;
-    set_owner_only_permissions(&path)?;
-    Ok(())
-}
-
-/// Write the peer list to disk, replacing the existing file.
-pub fn save(home: &Path, peers: &[StoredPeer]) -> Result<(), PeersStoreError> {
-    std::fs::create_dir_all(home)?;
-    let path = path_in(home);
-    let file = PeersFile {
-        version: PEERS_VERSION,
-        peers: peers.to_vec(),
-    };
-    let text = serde_json::to_string_pretty(&file)?;
-    let tmp = home.join(format!(
-        ".{PEERS_FILENAME}.{}.{}.tmp",
-        std::process::id(),
-        PeerId::new()
-    ));
-    std::fs::write(&tmp, text)?;
-    set_owner_only_permissions(&tmp)?;
-    replace_file(&tmp, &path)?;
-    set_owner_only_permissions(&path)?;
-    Ok(())
-}
-
-#[cfg(windows)]
-fn replace_file(tmp: &Path, path: &Path) -> std::io::Result<()> {
-    match std::fs::rename(tmp, path) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            std::fs::remove_file(path)?;
-            std::fs::rename(tmp, path)
-        }
-        Err(error) => Err(error),
-    }
-}
-
-#[cfg(not(windows))]
-fn replace_file(tmp: &Path, path: &Path) -> std::io::Result<()> {
-    std::fs::rename(tmp, path)
-}
-
-#[cfg(unix)]
-fn set_owner_only_permissions(path: &Path) -> std::io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    let mut perms = std::fs::metadata(path)?.permissions();
-    perms.set_mode(0o600);
-    std::fs::set_permissions(path, perms)
-}
-
-#[cfg(not(unix))]
-fn set_owner_only_permissions(_path: &Path) -> std::io::Result<()> {
-    Ok(())
 }
 
 fn now_ms() -> Result<u64, std::time::SystemTimeError> {
@@ -460,44 +320,44 @@ mod tests {
         k
     }
 
-    #[test]
-    fn load_returns_empty_when_file_missing() {
+    #[tokio::test]
+    async fn load_returns_empty_when_store_has_no_peer_rows() {
         let home = TempDir::new().unwrap();
-        let peers = load(home.path()).unwrap();
+        let peers = load(home.path()).await.unwrap();
         assert!(peers.is_empty());
     }
 
-    #[test]
-    fn add_then_load_roundtrips() {
+    #[tokio::test]
+    async fn add_then_load_roundtrips() {
         let home = TempDir::new().unwrap();
         let id = PeerId::new();
         let pk = fake_pubkey(0xaa);
-        let stored = add(home.path(), id, pk).unwrap();
+        let stored = add(home.path(), id, pk).await.unwrap();
         assert_eq!(stored.peer_id, id);
         assert_eq!(stored.pubkey_bytes().unwrap(), pk);
 
-        let loaded = load(home.path()).unwrap();
+        let loaded = load(home.path()).await.unwrap();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].peer_id, id);
         assert_eq!(loaded[0].pubkey_bytes().unwrap(), pk);
     }
 
-    #[test]
-    fn add_is_idempotent_for_same_pubkey() {
+    #[tokio::test]
+    async fn add_is_idempotent_for_same_pubkey() {
         let home = TempDir::new().unwrap();
         let id = PeerId::new();
         let pk = fake_pubkey(0xbb);
-        let first = add(home.path(), id, pk).unwrap();
-        let second = add(home.path(), id, pk).unwrap();
+        let first = add(home.path(), id, pk).await.unwrap();
+        let second = add(home.path(), id, pk).await.unwrap();
         // Same added_at_ms because second call returns the already-
         // stored entry (didn't overwrite).
         assert_eq!(first.added_at_ms, second.added_at_ms);
-        let loaded = load(home.path()).unwrap();
+        let loaded = load(home.path()).await.unwrap();
         assert_eq!(loaded.len(), 1, "duplicate enrolment must be deduped");
     }
 
-    #[test]
-    fn add_refuses_silent_overwrite_on_pubkey_conflict() {
+    #[tokio::test]
+    async fn add_refuses_silent_overwrite_on_pubkey_conflict() {
         // Grievance §8 fix: silent overwrite on second `add` of the
         // same peer_id with a new pubkey is what the rotation path
         // replaces. `add` must now refuse and surface a typed error.
@@ -505,33 +365,33 @@ mod tests {
         let id = PeerId::new();
         let old = fake_pubkey(0xc0);
         let new = fake_pubkey(0xc1);
-        add(home.path(), id, old).unwrap();
-        let result = add(home.path(), id, new);
+        add(home.path(), id, old).await.unwrap();
+        let result = add(home.path(), id, new).await;
         assert!(
             matches!(result, Err(PeersStoreError::PubkeyConflict { peer_id, .. }) if peer_id == id),
             "second add() with a different pubkey must error PubkeyConflict; got {result:?}",
         );
         // Old pubkey must still be stored — no partial-overwrite.
-        let loaded = load(home.path()).unwrap();
+        let loaded = load(home.path()).await.unwrap();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].pubkey_bytes().unwrap(), old);
     }
 
-    #[test]
-    fn add_is_idempotent_for_same_peer_same_pubkey() {
+    #[tokio::test]
+    async fn add_is_idempotent_for_same_peer_same_pubkey() {
         let home = TempDir::new().unwrap();
         let id = PeerId::new();
         let key = fake_pubkey(0x42);
-        let first = add(home.path(), id, key).unwrap();
-        let second = add(home.path(), id, key).unwrap();
+        let first = add(home.path(), id, key).await.unwrap();
+        let second = add(home.path(), id, key).await.unwrap();
         assert_eq!(first.peer_id, second.peer_id);
         assert_eq!(first.pubkey_b64, second.pubkey_b64);
-        let loaded = load(home.path()).unwrap();
+        let loaded = load(home.path()).await.unwrap();
         assert_eq!(loaded.len(), 1);
     }
 
-    #[test]
-    fn signed_rotation_is_accepted_and_audited() {
+    #[tokio::test]
+    async fn signed_rotation_is_accepted_and_audited() {
         use airc_protocol::{sign_rotation, PeerKeypair};
 
         let home = TempDir::new().unwrap();
@@ -539,7 +399,9 @@ mod tests {
         let prev_kp = PeerKeypair::generate();
         let next_kp = PeerKeypair::generate();
 
-        add(home.path(), peer_id, prev_kp.public_bytes()).unwrap();
+        add(home.path(), peer_id, prev_kp.public_bytes())
+            .await
+            .unwrap();
 
         let rotation = sign_rotation(
             &prev_kp,
@@ -550,18 +412,18 @@ mod tests {
         )
         .unwrap();
 
-        let updated = rotate(home.path(), &rotation).unwrap();
+        let updated = rotate(home.path(), &rotation).await.unwrap();
         assert_eq!(updated.pubkey_bytes().unwrap(), next_kp.public_bytes());
 
         // Audit trail visible to consumers.
-        let audit = audit_log(home.path(), peer_id).unwrap();
+        let audit = audit_log(home.path(), peer_id).await.unwrap();
         assert_eq!(audit.len(), 1);
         assert_eq!(audit[0].sequence, 1);
         assert_eq!(audit[0].rotated_at_ms, 1_700_000_000_000);
     }
 
-    #[test]
-    fn rotation_signed_by_wrong_key_is_rejected_before_audit() {
+    #[tokio::test]
+    async fn rotation_signed_by_wrong_key_is_rejected_before_audit() {
         use airc_protocol::{sign_rotation, PeerKeypair, RotationVerificationError};
 
         let home = TempDir::new().unwrap();
@@ -570,7 +432,9 @@ mod tests {
         let next_kp = PeerKeypair::generate();
         let imposter_kp = PeerKeypair::generate();
 
-        add(home.path(), peer_id, prev_kp.public_bytes()).unwrap();
+        add(home.path(), peer_id, prev_kp.public_bytes())
+            .await
+            .unwrap();
 
         // Imposter forges a rotation pretending to be prev, signed by
         // their own key. Crypto verification fails before we touch the
@@ -591,7 +455,7 @@ mod tests {
         })
         .unwrap();
 
-        let result = rotate(home.path(), &bad);
+        let result = rotate(home.path(), &bad).await;
         assert!(
             matches!(
                 result,
@@ -602,13 +466,13 @@ mod tests {
             "wrong-key rotation must fail crypto check before touching store; got {result:?}",
         );
         // Store untouched.
-        let loaded = load(home.path()).unwrap();
+        let loaded = load(home.path()).await.unwrap();
         assert_eq!(loaded[0].pubkey_bytes().unwrap(), prev_kp.public_bytes());
-        assert!(audit_log(home.path(), peer_id).unwrap().is_empty());
+        assert!(audit_log(home.path(), peer_id).await.unwrap().is_empty());
     }
 
-    #[test]
-    fn stale_rotation_against_already_superseded_key_is_rejected() {
+    #[tokio::test]
+    async fn stale_rotation_against_already_superseded_key_is_rejected() {
         use airc_protocol::{sign_rotation, PeerKeypair};
 
         let home = TempDir::new().unwrap();
@@ -617,14 +481,14 @@ mod tests {
         let k1 = PeerKeypair::generate();
         let k2 = PeerKeypair::generate();
 
-        add(home.path(), peer_id, k0.public_bytes()).unwrap();
+        add(home.path(), peer_id, k0.public_bytes()).await.unwrap();
         let r1 = sign_rotation(&k0, peer_id, k1.public_bytes(), 1, 1).unwrap();
-        rotate(home.path(), &r1).unwrap();
+        rotate(home.path(), &r1).await.unwrap();
 
         // Now the stored key is k1. Replay r1 (or any rotation whose
         // prev_pubkey is k0) must be rejected — k0 was superseded.
         let replay = sign_rotation(&k0, peer_id, k2.public_bytes(), 2, 2).unwrap();
-        let result = rotate(home.path(), &replay);
+        let result = rotate(home.path(), &replay).await;
         assert!(
             matches!(
                 result,
@@ -634,8 +498,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn rotation_with_non_monotonic_sequence_is_rejected() {
+    #[tokio::test]
+    async fn rotation_with_non_monotonic_sequence_is_rejected() {
         use airc_protocol::{sign_rotation, PeerKeypair};
 
         let home = TempDir::new().unwrap();
@@ -644,16 +508,16 @@ mod tests {
         let k1 = PeerKeypair::generate();
         let k2 = PeerKeypair::generate();
 
-        add(home.path(), peer_id, k0.public_bytes()).unwrap();
+        add(home.path(), peer_id, k0.public_bytes()).await.unwrap();
         let r1 = sign_rotation(&k0, peer_id, k1.public_bytes(), 5, 100).unwrap();
-        rotate(home.path(), &r1).unwrap();
+        rotate(home.path(), &r1).await.unwrap();
 
         // Try to apply a rotation with sequence == previous (replay) and
         // sequence < previous (out-of-order). Both must fail.
         let same_seq = sign_rotation(&k1, peer_id, k2.public_bytes(), 5, 200).unwrap();
         let lower_seq = sign_rotation(&k1, peer_id, k2.public_bytes(), 3, 200).unwrap();
         assert!(matches!(
-            rotate(home.path(), &same_seq),
+            rotate(home.path(), &same_seq).await,
             Err(PeersStoreError::SequenceNotMonotonic {
                 last_applied: 5,
                 attempted: 5,
@@ -661,7 +525,7 @@ mod tests {
             })
         ));
         assert!(matches!(
-            rotate(home.path(), &lower_seq),
+            rotate(home.path(), &lower_seq).await,
             Err(PeersStoreError::SequenceNotMonotonic {
                 last_applied: 5,
                 attempted: 3,
@@ -670,8 +534,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn rotation_for_unknown_peer_is_rejected() {
+    #[tokio::test]
+    async fn rotation_for_unknown_peer_is_rejected() {
         use airc_protocol::{sign_rotation, PeerKeypair};
 
         let home = TempDir::new().unwrap();
@@ -681,53 +545,27 @@ mod tests {
 
         // Note: NO add() — peer isn't enrolled.
         let rotation = sign_rotation(&prev_kp, peer_id, next_kp.public_bytes(), 1, 0).unwrap();
-        let result = rotate(home.path(), &rotation);
+        let result = rotate(home.path(), &rotation).await;
         assert!(matches!(
             result,
             Err(PeersStoreError::UnknownPeer(p)) if p == peer_id
         ));
     }
 
-    #[test]
-    fn multiple_distinct_peers_accumulate() {
+    #[tokio::test]
+    async fn multiple_distinct_peers_accumulate() {
         let home = TempDir::new().unwrap();
         let a = (PeerId::new(), fake_pubkey(0x01));
         let b = (PeerId::new(), fake_pubkey(0x02));
         let c = (PeerId::new(), fake_pubkey(0x03));
-        add(home.path(), a.0, a.1).unwrap();
-        add(home.path(), b.0, b.1).unwrap();
-        add(home.path(), c.0, c.1).unwrap();
-        let loaded = load(home.path()).unwrap();
+        add(home.path(), a.0, a.1).await.unwrap();
+        add(home.path(), b.0, b.1).await.unwrap();
+        add(home.path(), c.0, c.1).await.unwrap();
+        let loaded = load(home.path()).await.unwrap();
         assert_eq!(loaded.len(), 3);
         let ids: Vec<PeerId> = loaded.iter().map(|p| p.peer_id).collect();
         assert!(ids.contains(&a.0));
         assert!(ids.contains(&b.0));
         assert!(ids.contains(&c.0));
-    }
-
-    #[test]
-    fn rejects_unknown_schema_version() {
-        let home = TempDir::new().unwrap();
-        std::fs::create_dir_all(home.path()).unwrap();
-        std::fs::write(path_in(home.path()), r#"{"version":999,"peers":[]}"#).unwrap();
-        let result = load(home.path());
-        assert!(matches!(
-            result,
-            Err(PeersStoreError::SchemaVersionMismatch { found: 999, .. })
-        ));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn peers_file_is_owner_only_on_unix() {
-        use std::os::unix::fs::PermissionsExt;
-        let home = TempDir::new().unwrap();
-        let id = PeerId::new();
-        add(home.path(), id, fake_pubkey(0x42)).unwrap();
-        let mode = std::fs::metadata(path_in(home.path()))
-            .unwrap()
-            .permissions()
-            .mode();
-        assert_eq!(mode & 0o777, 0o600);
     }
 }

--- a/crates/airc-daemon/src/state.rs
+++ b/crates/airc-daemon/src/state.rs
@@ -34,7 +34,7 @@ pub struct DaemonState {
     pub registry: Arc<RwLock<PeerKeyRegistry>>,
     pub policy: VerificationPolicy,
     /// Home directory the daemon was started against. Lets handlers
-    /// reach `<home>/peers.json` etc. without re-deriving the path.
+    /// reach the store and IPC state without re-deriving the path.
     pub home: PathBuf,
     /// When the daemon started — used for the Status uptime field.
     pub started_at: Instant,

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -267,7 +267,7 @@ fn safe_component(value: &str) -> String {
 }
 
 impl Airc {
-    pub fn account_registry_document(&self) -> Result<AccountRegistryDocument, AircError> {
+    pub async fn account_registry_document(&self) -> Result<AccountRegistryDocument, AircError> {
         let identity = self.mesh_identity()?;
         let snapshot = crate::coordinator::snapshot(
             &self.inner.wire_root,
@@ -279,7 +279,7 @@ impl Airc {
             peer_id: self.inner.identity.peer_id,
             pubkey: self.inner.identity.keypair.public_bytes(),
         }];
-        for stored in airc_daemon::peers_store::load(&self.inner.wire_root)? {
+        for stored in airc_daemon::peers_store::load(&self.inner.wire_root).await? {
             peer_specs.push(PeerSpec {
                 peer_id: stored.peer_id,
                 pubkey: stored.pubkey_bytes()?,
@@ -298,7 +298,7 @@ impl Airc {
         &self,
         store: &dyn AccountRegistryStore,
     ) -> Result<AccountRegistryDocument, AircError> {
-        let document = self.account_registry_document()?;
+        let document = self.account_registry_document().await?;
         store.publish(&document).await?;
         Ok(document)
     }
@@ -329,7 +329,8 @@ impl Airc {
                 &self.inner.wire_root,
                 peer.peer_spec.peer_id,
                 peer.peer_spec.pubkey,
-            )?;
+            )
+            .await?;
             self.enrol_volatile_peer(&peer.peer_spec)?;
             crate::coordinator::publish(
                 &self.inner.wire_root,
@@ -338,7 +339,7 @@ impl Airc {
             )?;
             self.import_invite_beacon(peer.invite_beacon()).await?;
         }
-        self.sync_account_peer_registry()?;
+        self.sync_account_peer_registry().await?;
         Ok(())
     }
 }
@@ -539,7 +540,9 @@ mod tests {
             .await
             .unwrap();
 
-        let peers = airc_daemon::peers_store::load(&airc.inner.wire_root).unwrap();
+        let peers = airc_daemon::peers_store::load(&airc.inner.wire_root)
+            .await
+            .unwrap();
         assert!(peers.iter().any(|peer| peer.peer_id == spec.peer_id));
         let snapshot = crate::coordinator::snapshot(
             &airc.inner.wire_root,
@@ -577,7 +580,9 @@ mod tests {
         let refreshed = airc_b.refresh_account_registry(&store).await.unwrap();
 
         assert!(refreshed.is_some());
-        let peers = airc_daemon::peers_store::load(&airc_b.inner.wire_root).unwrap();
+        let peers = airc_daemon::peers_store::load(&airc_b.inner.wire_root)
+            .await
+            .unwrap();
         assert!(peers.iter().any(|peer| peer.peer_id == airc_a.peer_id()));
         let snapshot = crate::coordinator::snapshot(
             &airc_b.inner.wire_root,

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -77,13 +77,13 @@ fn machine_account_home(scope_home: &Path) -> PathBuf {
     scope_home.to_path_buf()
 }
 
-fn load_peer_registries(
+async fn load_peer_registries(
     home: &Path,
     wire_root: &Path,
 ) -> Result<Vec<peers_store::StoredPeer>, AircError> {
-    let mut peers = peers_store::load(home)?;
+    let mut peers = peers_store::load(home).await?;
     if wire_root != home {
-        peers.extend(peers_store::load(wire_root)?);
+        peers.extend(peers_store::load(wire_root).await?);
     }
     Ok(peers)
 }
@@ -155,7 +155,7 @@ impl Airc {
     ///   - Loads `<home>/identity.{key,json}` (generates if missing).
     ///   - Opens `<home>/events.sqlite` and applies any pending
     ///     event-store migrations.
-    ///   - Loads `<home>/peers.json` into the in-memory trust registry.
+    ///   - Loads peer trust rows into the in-memory trust registry.
     ///
     /// Production policy is always `VerificationPolicy::Strict` —
     /// unsigned frames are rejected. Use `open_with_policy` if a
@@ -192,7 +192,8 @@ impl Airc {
             &wire_root,
             identity.peer_id,
             identity.keypair.public_bytes(),
-        )?;
+        )
+        .await?;
 
         let store_path = home.join(EVENTS_DB_FILENAME);
         let store: Arc<dyn EventStore> = Arc::new(SqliteEventStore::open_path(&store_path).await?);
@@ -202,7 +203,7 @@ impl Airc {
             .enrol(identity.peer_id, 0, identity.keypair.public_bytes())
             .map_err(|e| AircError::Crypto(e.to_string()))?;
         let mut enrolled = vec![identity.peer_id];
-        for stored in load_peer_registries(&home, &wire_root)? {
+        for stored in load_peer_registries(&home, &wire_root).await? {
             if enrolled.contains(&stored.peer_id) {
                 continue;
             }
@@ -357,8 +358,8 @@ impl Airc {
         Ok(cached.as_mesh_identity())
     }
 
-    pub(crate) fn sync_account_peer_registry(&self) -> Result<(), AircError> {
-        let peers = load_peer_registries(&self.inner.home, &self.inner.wire_root)?;
+    pub(crate) async fn sync_account_peer_registry(&self) -> Result<(), AircError> {
+        let peers = load_peer_registries(&self.inner.home, &self.inner.wire_root).await?;
         let mut registry = self
             .inner
             .registry

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -38,7 +38,7 @@ impl Airc {
         body: Body,
         headers: Headers,
     ) -> Result<EventId, AircError> {
-        self.sync_account_peer_registry()?;
+        self.sync_account_peer_registry().await?;
         let room = self.current_room().await?;
         let route = self.resolve_send_route(kind)?;
         let event_id = EventId::new();

--- a/crates/airc-lib/src/peers.rs
+++ b/crates/airc-lib/src/peers.rs
@@ -24,14 +24,14 @@ impl Airc {
     }
 
     /// Enrol a peer into the local trust registry and persist it to
-    /// `<home>/peers.json`.
+    /// the peer trust store.
     pub async fn add_peer(&self, spec: PeerSpec) -> Result<(), AircError> {
-        peers_store::add(&self.inner.home, spec.peer_id, spec.pubkey)?;
+        peers_store::add(&self.inner.home, spec.peer_id, spec.pubkey).await?;
         self.enrol_volatile_peer(&spec)
     }
 
     /// Enrol a peer in the in-memory trust registry without writing
-    /// to `peers.json`.
+    /// durable peer trust state.
     pub fn enrol_volatile_peer(&self, spec: &PeerSpec) -> Result<(), AircError> {
         let mut registry = self
             .inner
@@ -46,7 +46,7 @@ impl Airc {
 
     /// Return a list of enrolled peers.
     pub async fn peers(&self) -> Result<Vec<EnrolledPeer>, AircError> {
-        let stored = peers_store::load(&self.inner.home)?;
+        let stored = peers_store::load(&self.inner.home).await?;
         Ok(stored
             .into_iter()
             .filter(|p| p.peer_id != self.inner.identity.peer_id)

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -29,7 +29,7 @@ impl Airc {
         if subs.contains_key(wire) {
             return Ok(());
         }
-        self.sync_account_peer_registry()?;
+        self.sync_account_peer_registry().await?;
         let transport = SignedTransport::new(
             LocalFsAdapter::new(wire),
             self.inner.identity.keypair.clone(),

--- a/crates/airc-lib/src/wire_replay.rs
+++ b/crates/airc-lib/src/wire_replay.rs
@@ -9,7 +9,7 @@ const FRAMES_FILENAME: &str = "frames.jsonl";
 
 impl Airc {
     pub(crate) async fn replay_wire_once(&self, wire: &Path) -> Result<(), AircError> {
-        self.sync_account_peer_registry()?;
+        self.sync_account_peer_registry().await?;
         let path = wire.join(FRAMES_FILENAME);
         let text = match tokio::fs::read_to_string(&path).await {
             Ok(text) => text,

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -258,7 +258,9 @@ fn same_machine_scopes_share_account_wire_and_registry() {
                     .join(".airc/wires/general")
             );
 
-            let peers = airc_daemon::peers_store::load(&machine.path().join(".airc")).unwrap();
+            let peers = airc_daemon::peers_store::load(&machine.path().join(".airc"))
+                .await
+                .unwrap();
             assert_eq!(
                 peers.len(),
                 2,

--- a/crates/airc-store/Cargo.toml
+++ b/crates/airc-store/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 airc-core = { path = "../airc-core" }
 async-trait = "0.1"
+base64 = "0.22"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/airc-store/src/entities/mod.rs
+++ b/crates/airc-store/src/entities/mod.rs
@@ -1,10 +1,15 @@
 //! SeaORM entity definitions.
 //!
-//! Currently one table:
+//! Tables:
 //!   - `events` — the canonical transcript log. One row per persisted
 //!     `TranscriptEvent`. Indexes on `(channel_id, lamport, event_id)`
 //!     keep `page_recent` and `resume_from` O(log n + page) instead
 //!     of O(n).
+//!   - `runtime_cursors` — per-consumer replay cursors.
+//!   - `peer_trust` / `peer_rotation_audit` — trust anchors and
+//!     signed key-rotation audit rows.
 
 pub mod event;
+pub mod peer_rotation_audit;
+pub mod peer_trust;
 pub mod runtime_cursor;

--- a/crates/airc-store/src/entities/peer_rotation_audit.rs
+++ b/crates/airc-store/src/entities/peer_rotation_audit.rs
@@ -1,0 +1,21 @@
+//! `peer_rotation_audit` table — append-only peer key rotations.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "peer_rotation_audit")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub peer_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub sequence: i64,
+    pub prev_pubkey_b64: String,
+    pub next_pubkey_b64: String,
+    pub rotated_at_ms: i64,
+    pub applied_at_ms: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/airc-store/src/entities/peer_trust.rs
+++ b/crates/airc-store/src/entities/peer_trust.rs
@@ -1,0 +1,20 @@
+//! `peer_trust` table — enrolled peer trust anchors.
+//!
+//! A peer's public key is durable substrate state. It belongs in the
+//! store next to transcript/replay state, not in ad-hoc JSON files.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "peer_trust")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub peer_id: Uuid,
+    pub pubkey_b64: String,
+    pub added_at_ms: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/airc-store/src/error.rs
+++ b/crates/airc-store/src/error.rs
@@ -33,6 +33,29 @@ pub enum StoreError {
     #[error("unknown transcript kind: {0}")]
     UnknownTranscriptKind(String),
 
+    /// Stored numeric value is outside the domain accepted by the
+    /// Rust contract. Refuse silent wraparound at the DB boundary.
+    #[error("invalid stored value for {field}: {value}")]
+    InvalidStoredValue { field: &'static str, value: i128 },
+
+    /// Peer trust conflict: a stored peer has a different public key.
+    #[error(
+        "peer {peer_id} is already enrolled with pubkey {stored_pubkey_b64}; cannot replace it with {attempted_pubkey_b64} without signed rotation"
+    )]
+    PeerPubkeyConflict {
+        peer_id: airc_core::PeerId,
+        stored_pubkey_b64: String,
+        attempted_pubkey_b64: String,
+    },
+
+    /// Peer public key data is malformed in the store.
+    #[error("peer pubkey is {0} bytes, expected 32")]
+    WrongPubkeyLength(usize),
+
+    /// Peer public key base64 is malformed in the store.
+    #[error("peer pubkey base64: {0}")]
+    Base64(#[from] base64::DecodeError),
+
     /// JSON encode/decode failure on the stored `metadata` /
     /// `headers` / `body` blob. Wrapped so callers can distinguish
     /// "corrupt persisted state" from a normal append failure.

--- a/crates/airc-store/src/lib.rs
+++ b/crates/airc-store/src/lib.rs
@@ -1,10 +1,11 @@
-//! `airc-store` — durable event store for AIRC transcripts.
+//! `airc-store` — durable ORM store for AIRC runtime data.
 //!
 //! Closes grievance §5 (CLI/Daemon Is Accumulating Policy — the
 //! needed crate split lists `airc-store` as the source of truth for
-//! events) and §7 (Inbox And Replay Need Stronger Cursor Semantics —
-//! the store owns `(lamport, event_id)` cursoring and channel-aware
-//! filtering rather than the per-wire JSONL append in airc-transport).
+//! runtime data) and §7 (Inbox And Replay Need Stronger Cursor
+//! Semantics — the store owns `(lamport, event_id)` cursoring and
+//! channel-aware filtering rather than the per-wire JSONL append in
+//! airc-transport).
 //!
 //! The trait surface ([`EventStore`]) is the consumer-facing API:
 //!   - `append(event)` durably persists a `TranscriptEvent`;
@@ -12,6 +13,8 @@
 //!   - `resume_from(cursor, channel, limit)` returns events strictly
 //!     after the cursor;
 //!   - `latest_cursor(channel)` returns the newest cursor or None.
+//!   - peer trust tables hold enrolled peer keys and signed rotation
+//!     audit rows.
 //!
 //! Two implementations ship in this crate:
 //!   - [`SqliteEventStore`]: SeaORM-backed SQLite. Production target
@@ -30,10 +33,12 @@ pub mod entities;
 pub mod error;
 pub mod memory;
 pub mod migration;
+pub mod peer_trust;
 pub mod sqlite;
 pub mod store;
 
 pub use error::StoreError;
 pub use memory::InMemoryEventStore;
+pub use peer_trust::{RotationAuditEntry, StoredPeer};
 pub use sqlite::SqliteEventStore;
 pub use store::EventStore;

--- a/crates/airc-store/src/migration/m20260522_000003_create_peer_trust.rs
+++ b/crates/airc-store/src/migration/m20260522_000003_create_peer_trust.rs
@@ -1,0 +1,113 @@
+//! Add ORM-owned peer trust and rotation audit tables.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(PeerTrust::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(PeerTrust::PeerId)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(PeerTrust::PubkeyB64).string().not_null())
+                    .col(
+                        ColumnDef::new(PeerTrust::AddedAtMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(PeerRotationAudit::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(PeerRotationAudit::PeerId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(PeerRotationAudit::Sequence)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(PeerRotationAudit::PrevPubkeyB64)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(PeerRotationAudit::NextPubkeyB64)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(PeerRotationAudit::RotatedAtMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(PeerRotationAudit::AppliedAtMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .primary_key(
+                        Index::create()
+                            .col(PeerRotationAudit::PeerId)
+                            .col(PeerRotationAudit::Sequence),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_peer_rotation_audit_peer_sequence")
+                    .table(PeerRotationAudit::Table)
+                    .col(PeerRotationAudit::PeerId)
+                    .col(PeerRotationAudit::Sequence)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(PeerRotationAudit::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(PeerTrust::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum PeerTrust {
+    Table,
+    PeerId,
+    PubkeyB64,
+    AddedAtMs,
+}
+
+#[derive(DeriveIden)]
+enum PeerRotationAudit {
+    Table,
+    PeerId,
+    Sequence,
+    PrevPubkeyB64,
+    NextPubkeyB64,
+    RotatedAtMs,
+    AppliedAtMs,
+}

--- a/crates/airc-store/src/migration/mod.rs
+++ b/crates/airc-store/src/migration/mod.rs
@@ -9,6 +9,7 @@ use sea_orm_migration::prelude::*;
 
 mod m20260519_000001_create_events;
 mod m20260522_000002_create_runtime_cursors;
+mod m20260522_000003_create_peer_trust;
 
 pub struct Migrator;
 
@@ -18,6 +19,7 @@ impl MigratorTrait for Migrator {
         vec![
             Box::new(m20260519_000001_create_events::Migration),
             Box::new(m20260522_000002_create_runtime_cursors::Migration),
+            Box::new(m20260522_000003_create_peer_trust::Migration),
         ]
     }
 }

--- a/crates/airc-store/src/peer_trust.rs
+++ b/crates/airc-store/src/peer_trust.rs
@@ -1,0 +1,36 @@
+//! Peer trust store types.
+
+use airc_core::PeerId;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+
+use crate::StoreError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredPeer {
+    pub peer_id: PeerId,
+    pub pubkey_b64: String,
+    pub added_at_ms: u64,
+}
+
+impl StoredPeer {
+    pub fn pubkey_bytes(&self) -> Result<[u8; 32], StoreError> {
+        let bytes = URL_SAFE_NO_PAD.decode(&self.pubkey_b64)?;
+        if bytes.len() != 32 {
+            return Err(StoreError::WrongPubkeyLength(bytes.len()));
+        }
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&bytes);
+        Ok(out)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RotationAuditEntry {
+    pub peer_id: PeerId,
+    pub prev_pubkey_b64: String,
+    pub next_pubkey_b64: String,
+    pub sequence: u64,
+    pub rotated_at_ms: u64,
+    pub applied_at_ms: u64,
+}

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -238,12 +238,17 @@ fn i64_to_u64(field: &'static str, value: i64) -> Result<u64, StoreError> {
 }
 
 fn sqlite_file_url(path: &Path) -> String {
-    let raw = path.to_string_lossy().replace('\\', "/");
+    let raw = normalise_sqlite_path(path);
     if has_windows_drive_prefix(&raw) {
         format!("sqlite:{raw}?mode=rwc")
     } else {
         format!("sqlite://{raw}?mode=rwc")
     }
+}
+
+fn normalise_sqlite_path(path: &Path) -> String {
+    let raw = path.to_string_lossy().replace('\\', "/");
+    raw.strip_prefix("//?/").unwrap_or(&raw).to_string()
 }
 
 fn has_windows_drive_prefix(path: &str) -> bool {
@@ -762,6 +767,16 @@ mod tests {
     #[test]
     fn sqlite_file_url_uses_uri_slashes_for_windows_paths() {
         let path = Path::new(r"C:\Users\agent\.airc\events.sqlite");
+
+        assert_eq!(
+            sqlite_file_url(path),
+            "sqlite:C:/Users/agent/.airc/events.sqlite?mode=rwc"
+        );
+    }
+
+    #[test]
+    fn sqlite_file_url_strips_windows_verbatim_prefix() {
+        let path = Path::new(r"\\?\C:\Users\agent\.airc\events.sqlite");
 
         assert_eq!(
             sqlite_file_url(path),

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use sea_orm::{
     sea_query::{Expr, OnConflict},
     ActiveValue, ColumnTrait, ConnectOptions, Database, DatabaseConnection, EntityTrait,
-    QueryFilter, QueryOrder, QuerySelect,
+    QueryFilter, QueryOrder, QuerySelect, Set,
 };
 use sea_orm_migration::MigratorTrait;
 use serde_json::Value as JsonValue;
@@ -29,9 +29,10 @@ use airc_core::{
     Body, ClientId, EventId, Headers, PeerId, RoomId, TranscriptCursor, TranscriptEvent,
 };
 
-use crate::entities::{event, runtime_cursor};
+use crate::entities::{event, peer_rotation_audit, peer_trust, runtime_cursor};
 use crate::error::StoreError;
 use crate::migration::Migrator;
+use crate::peer_trust::{RotationAuditEntry, StoredPeer};
 use crate::store::EventStore;
 
 pub struct SqliteEventStore {
@@ -78,6 +79,162 @@ impl SqliteEventStore {
     pub async fn in_memory() -> Result<Self, StoreError> {
         Self::open("sqlite::memory:").await
     }
+
+    pub async fn load_peers(&self) -> Result<Vec<StoredPeer>, StoreError> {
+        let rows = peer_trust::Entity::find()
+            .order_by_asc(peer_trust::Column::AddedAtMs)
+            .order_by_asc(peer_trust::Column::PeerId)
+            .all(&self.db)
+            .await?;
+        rows.into_iter()
+            .map(|row| {
+                Ok(StoredPeer {
+                    peer_id: PeerId::from_uuid(row.peer_id),
+                    pubkey_b64: row.pubkey_b64,
+                    added_at_ms: i64_to_u64("peer_trust.added_at_ms", row.added_at_ms)?,
+                })
+            })
+            .collect()
+    }
+
+    pub async fn add_peer_trust(
+        &self,
+        peer_id: PeerId,
+        pubkey_b64: String,
+        added_at_ms: u64,
+    ) -> Result<StoredPeer, StoreError> {
+        let active = peer_trust::ActiveModel {
+            peer_id: Set(peer_id.as_uuid()),
+            pubkey_b64: Set(pubkey_b64.clone()),
+            added_at_ms: Set(u64_to_i64("peer_trust.added_at_ms", added_at_ms)?),
+        };
+        let insert = peer_trust::Entity::insert(active)
+            .on_conflict(
+                OnConflict::column(peer_trust::Column::PeerId)
+                    .do_nothing()
+                    .to_owned(),
+            )
+            .exec(&self.db)
+            .await;
+        match insert {
+            Ok(_) | Err(sea_orm::DbErr::RecordNotInserted) => {}
+            Err(error) => return Err(StoreError::Database(error)),
+        }
+
+        let stored = peer_trust::Entity::find_by_id(peer_id.as_uuid())
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| {
+                StoreError::Database(sea_orm::DbErr::Custom(
+                    "peer_trust insert returned no stored row".to_string(),
+                ))
+            })?;
+        if stored.pubkey_b64 != pubkey_b64 {
+            return Err(StoreError::PeerPubkeyConflict {
+                peer_id,
+                stored_pubkey_b64: stored.pubkey_b64,
+                attempted_pubkey_b64: pubkey_b64,
+            });
+        }
+        Ok(StoredPeer {
+            peer_id,
+            pubkey_b64: stored.pubkey_b64,
+            added_at_ms: i64_to_u64("peer_trust.added_at_ms", stored.added_at_ms)?,
+        })
+    }
+
+    pub async fn replace_peer_trust(
+        &self,
+        peer_id: PeerId,
+        pubkey_b64: String,
+        added_at_ms: u64,
+    ) -> Result<StoredPeer, StoreError> {
+        let active = peer_trust::ActiveModel {
+            peer_id: Set(peer_id.as_uuid()),
+            pubkey_b64: Set(pubkey_b64.clone()),
+            added_at_ms: Set(u64_to_i64("peer_trust.added_at_ms", added_at_ms)?),
+        };
+        peer_trust::Entity::insert(active)
+            .on_conflict(
+                OnConflict::column(peer_trust::Column::PeerId)
+                    .update_columns([peer_trust::Column::PubkeyB64, peer_trust::Column::AddedAtMs])
+                    .to_owned(),
+            )
+            .exec(&self.db)
+            .await?;
+        Ok(StoredPeer {
+            peer_id,
+            pubkey_b64,
+            added_at_ms,
+        })
+    }
+
+    pub async fn append_peer_rotation_audit(
+        &self,
+        entry: RotationAuditEntry,
+    ) -> Result<(), StoreError> {
+        let active = peer_rotation_audit::ActiveModel {
+            peer_id: Set(entry.peer_id.as_uuid()),
+            sequence: Set(u64_to_i64("peer_rotation_audit.sequence", entry.sequence)?),
+            prev_pubkey_b64: Set(entry.prev_pubkey_b64),
+            next_pubkey_b64: Set(entry.next_pubkey_b64),
+            rotated_at_ms: Set(u64_to_i64(
+                "peer_rotation_audit.rotated_at_ms",
+                entry.rotated_at_ms,
+            )?),
+            applied_at_ms: Set(u64_to_i64(
+                "peer_rotation_audit.applied_at_ms",
+                entry.applied_at_ms,
+            )?),
+        };
+        peer_rotation_audit::Entity::insert(active)
+            .exec(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn peer_rotation_audit(
+        &self,
+        peer_id: PeerId,
+    ) -> Result<Vec<RotationAuditEntry>, StoreError> {
+        let rows = peer_rotation_audit::Entity::find()
+            .filter(peer_rotation_audit::Column::PeerId.eq(peer_id.as_uuid()))
+            .order_by_asc(peer_rotation_audit::Column::Sequence)
+            .all(&self.db)
+            .await?;
+        rows.into_iter()
+            .map(|row| {
+                Ok(RotationAuditEntry {
+                    peer_id: PeerId::from_uuid(row.peer_id),
+                    prev_pubkey_b64: row.prev_pubkey_b64,
+                    next_pubkey_b64: row.next_pubkey_b64,
+                    sequence: i64_to_u64("peer_rotation_audit.sequence", row.sequence)?,
+                    rotated_at_ms: i64_to_u64(
+                        "peer_rotation_audit.rotated_at_ms",
+                        row.rotated_at_ms,
+                    )?,
+                    applied_at_ms: i64_to_u64(
+                        "peer_rotation_audit.applied_at_ms",
+                        row.applied_at_ms,
+                    )?,
+                })
+            })
+            .collect()
+    }
+}
+
+fn u64_to_i64(field: &'static str, value: u64) -> Result<i64, StoreError> {
+    i64::try_from(value).map_err(|_| StoreError::InvalidStoredValue {
+        field,
+        value: value as i128,
+    })
+}
+
+fn i64_to_u64(field: &'static str, value: i64) -> Result<u64, StoreError> {
+    u64::try_from(value).map_err(|_| StoreError::InvalidStoredValue {
+        field,
+        value: value as i128,
+    })
 }
 
 fn sqlite_file_url(path: &Path) -> String {

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -240,7 +240,7 @@ fn i64_to_u64(field: &'static str, value: i64) -> Result<u64, StoreError> {
 fn sqlite_file_url(path: &Path) -> String {
     let raw = path.to_string_lossy().replace('\\', "/");
     if has_windows_drive_prefix(&raw) {
-        format!("sqlite:///{raw}?mode=rwc")
+        format!("sqlite:{raw}?mode=rwc")
     } else {
         format!("sqlite://{raw}?mode=rwc")
     }
@@ -765,7 +765,7 @@ mod tests {
 
         assert_eq!(
             sqlite_file_url(path),
-            "sqlite:///C:/Users/agent/.airc/events.sqlite?mode=rwc"
+            "sqlite:C:/Users/agent/.airc/events.sqlite?mode=rwc"
         );
     }
 


### PR DESCRIPTION
## Summary
- add SeaORM peer_trust and peer_rotation_audit tables to airc-store
- route daemon/lib peer trust and signed rotation audit through the store instead of JSON sidecars
- keep runtime registry sync explicit and async at the store boundary
- update public comments/docs away from peers.json / peers_audit wording

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-store -p airc-daemon -p airc-lib -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-store --no-fail-fast
- cargo test --manifest-path Cargo.toml -p airc-daemon peers_store --no-fail-fast
- cargo test --manifest-path Cargo.toml -p airc-lib account_registry --no-fail-fast
- cargo test --manifest-path Cargo.toml -p airc-cli collaboration --no-fail-fast
- cargo clippy --manifest-path Cargo.toml -p airc-store -p airc-daemon -p airc-lib -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace --no-fail-fast
- AIRC_BIN=\"$PWD/target/debug/airc\" AIRC_EXPECT_BIN=\"$PWD/target/debug/airc\" test/public_installed_runtime_proof.sh