### PR TITLE
fix(store): persist subscriptions through ORM

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -187,9 +187,8 @@ pub enum Command {
     /// Legacy envelope encryption helpers during Rust cutover.
     Envelope(EnvelopeArgs),
 
-    /// Send a single text Message frame to the current room and exit.
-    /// The current room lives in `<home>/room.json`; switch with
-    /// `airc room <name>`.
+    /// Send a single text Message frame to the default subscribed
+    /// room and exit. The default channel lives in the ORM store.
     Send {
         /// Message body.
         text: String,

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -170,25 +170,9 @@ fn join_without_args_uses_default_account_context() {
     assert!(stdout.contains("#cambriantech"), "{stdout}");
     assert!(stdout.contains("default: #cambriantech"), "{stdout}");
 
-    let subscriptions = std::fs::read_to_string(home.join("subscriptions.json")).unwrap();
-    assert!(subscriptions.contains("\"general\""), "{subscriptions}");
     assert!(
-        subscriptions.contains("\"cambriantech\""),
-        "{subscriptions}"
-    );
-    let json: serde_json::Value = serde_json::from_str(&subscriptions).unwrap();
-    let wire = json["subscribed"]["cambriantech"]["wire"]
-        .as_str()
-        .expect("cambriantech wire");
-    assert_eq!(
-        std::path::PathBuf::from(wire),
-        machine
-            .path()
-            .canonicalize()
-            .unwrap()
-            .join(".airc")
-            .join("wires")
-            .join("cambriantech")
+        !home.join("subscriptions.json").exists(),
+        "join must not recreate subscriptions.json; subscriptions are ORM-backed"
     );
 
     let mut stop_command = Command::new(airc_core());

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -400,11 +400,11 @@ impl Airc {
     pub async fn join(&self, name: &str) -> Result<Room, AircError> {
         let channel = ChannelName::new(name)?;
         let identity = self.mesh_identity()?;
-        let mut set = subscriptions::load_or_init(&self.inner.home)?;
+        let mut set = subscriptions::load_or_init(self.event_store()).await?;
         let subscription =
             set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
         set.set_default(channel)?;
-        subscriptions::save(&self.inner.home, &set)?;
+        subscriptions::save(self.event_store(), &set).await?;
         self.publish_presence(&identity, &set)?;
         let room = subscription.as_room();
         self.ensure_wire_subscriber(&room.wire).await?;
@@ -437,7 +437,7 @@ impl Airc {
     /// the public join command hang.
     pub async fn ensure_join_context(&self, context: JoinContext) -> Result<Vec<Room>, AircError> {
         let identity = self.mesh_identity()?;
-        let mut set = subscriptions::load_or_init(&self.inner.home)?;
+        let mut set = subscriptions::load_or_init(self.event_store()).await?;
         let mut rooms = Vec::new();
 
         for channel in context.channels {
@@ -452,7 +452,7 @@ impl Airc {
         if set.subscribed.contains_key(&context.default) {
             set.set_default(context.default)?;
         }
-        subscriptions::save(&self.inner.home, &set)?;
+        subscriptions::save(self.event_store(), &set).await?;
         self.publish_presence(&identity, &set)?;
 
         for room in &rooms {
@@ -469,12 +469,12 @@ impl Airc {
     pub async fn join_with_wire(&self, name: &str, wire: PathBuf) -> Result<Room, AircError> {
         let channel = ChannelName::new(name)?;
         let identity = self.mesh_identity()?;
-        let mut set = subscriptions::load_or_init(&self.inner.home)?;
+        let mut set = subscriptions::load_or_init(self.event_store()).await?;
         let subscription = Subscription::with_wire(&identity, channel.clone(), wire)?;
         set.parted.remove(&channel);
         set.subscribed.insert(channel.clone(), subscription.clone());
         set.set_default(channel)?;
-        subscriptions::save(&self.inner.home, &set)?;
+        subscriptions::save(self.event_store(), &set).await?;
         self.publish_presence(&identity, &set)?;
         let room = subscription.as_room();
         self.ensure_wire_subscriber(&room.wire).await?;
@@ -485,7 +485,7 @@ impl Airc {
     /// `#general` through the subscription set, using the resolved
     /// mesh identity so the `RoomId` is stable per Git/GitHub user.
     pub async fn current_room(&self) -> Result<Room, AircError> {
-        let mut set = subscriptions::load_or_init(&self.inner.home)?;
+        let mut set = subscriptions::load_or_init(self.event_store()).await?;
         if let Some(subscription) = set.default_subscription() {
             return Ok(subscription.as_room());
         }
@@ -495,7 +495,7 @@ impl Airc {
         let subscription =
             set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
         set.set_default(channel)?;
-        subscriptions::save(&self.inner.home, &set)?;
+        subscriptions::save(self.event_store(), &set).await?;
         self.publish_presence(&identity, &set)?;
         Ok(subscription.as_room())
     }

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -21,11 +21,13 @@
 //!
 //! ## Storage
 //!
-//! Persisted to `<home>/subscriptions.json`. Schema version 1.
+//! Persisted through `airc-store` ORM tables. There is no JSON
+//! sidecar for subscription/default-channel state.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
+use airc_store::{EventStore, StoredSubscription};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -36,7 +38,6 @@ use crate::room::Room;
 use crate::stream::EventFilter;
 use crate::Airc;
 
-const SUBSCRIPTIONS_FILENAME: &str = "subscriptions.json";
 const SUBSCRIPTIONS_VERSION: u32 = 1;
 
 /// Namespace UUID for deriving channel UUIDs from
@@ -48,22 +49,16 @@ const SUBSCRIPTIONS_NAMESPACE: Uuid = Uuid::from_bytes([
 /// What can go wrong loading or saving the subscription set.
 #[derive(Debug)]
 pub enum SubscriptionError {
-    Io(std::io::Error),
-    Json(serde_json::Error),
+    Store(airc_store::StoreError),
     Clock(std::time::SystemTimeError),
-    SchemaVersionMismatch { found: u32, expected: u32 },
     InvalidChannelName(ChannelNameError),
 }
 
 impl std::fmt::Display for SubscriptionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Io(error) => write!(f, "subscriptions I/O: {error}"),
-            Self::Json(error) => write!(f, "subscriptions JSON: {error}"),
+            Self::Store(error) => write!(f, "subscriptions store: {error}"),
             Self::Clock(error) => write!(f, "subscriptions clock: {error}"),
-            Self::SchemaVersionMismatch { found, expected } => {
-                write!(f, "subscriptions.json version {found}, expected {expected}")
-            }
             Self::InvalidChannelName(error) => write!(f, "invalid channel name: {error}"),
         }
     }
@@ -72,24 +67,16 @@ impl std::fmt::Display for SubscriptionError {
 impl std::error::Error for SubscriptionError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::Io(error) => Some(error),
-            Self::Json(error) => Some(error),
+            Self::Store(error) => Some(error),
             Self::Clock(error) => Some(error),
-            Self::SchemaVersionMismatch { .. } => None,
             Self::InvalidChannelName(error) => Some(error),
         }
     }
 }
 
-impl From<std::io::Error> for SubscriptionError {
-    fn from(value: std::io::Error) -> Self {
-        Self::Io(value)
-    }
-}
-
-impl From<serde_json::Error> for SubscriptionError {
-    fn from(value: serde_json::Error) -> Self {
-        Self::Json(value)
+impl From<airc_store::StoreError> for SubscriptionError {
+    fn from(value: airc_store::StoreError) -> Self {
+        Self::Store(value)
     }
 }
 
@@ -178,7 +165,6 @@ impl Serialize for ChannelName {
     where
         S: serde::Serializer,
     {
-        // Serialize without `#` so on-disk JSON is the normalized form.
         serializer.serialize_str(&self.0)
     }
 }
@@ -243,7 +229,7 @@ pub fn derive_room_id(identity: &MeshIdentity, channel: &ChannelName) -> RoomId 
 }
 
 /// One channel this scope is subscribed to.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Subscription {
     pub name: ChannelName,
     pub room_id: RoomId,
@@ -306,7 +292,7 @@ impl Subscription {
 /// pointer for short-shape commands and the parted set so re-running
 /// [`Airc::join_default_context`](crate::Airc::join_default_context)
 /// doesn't auto-restore a channel the user left.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubscriptionSet {
     pub version: u32,
     pub subscribed: BTreeMap<ChannelName, Subscription>,
@@ -424,46 +410,71 @@ impl SubscriptionSet {
     }
 }
 
-/// On-disk path for the subscription set.
-pub fn path_in(home: &Path) -> PathBuf {
-    home.join(SUBSCRIPTIONS_FILENAME)
+/// Load the subscription set from the durable store. If no rows exist
+/// yet, return an empty set; callers decide how to seed it.
+pub async fn load_or_init(store: &dyn EventStore) -> Result<SubscriptionSet, SubscriptionError> {
+    let mut set = SubscriptionSet::empty();
+    for row in store.load_subscriptions().await? {
+        let name = ChannelName::new(&row.channel_name)?;
+        if row.parted {
+            set.parted.insert(name);
+            continue;
+        }
+        let subscription = Subscription {
+            name: name.clone(),
+            room_id: row.room_id,
+            wire: PathBuf::from(row.wire),
+            joined_at_ms: row.joined_at_ms,
+        };
+        if row.is_default {
+            set.default = Some(name.clone());
+        }
+        set.subscribed.insert(name, subscription);
+    }
+    if set
+        .default
+        .as_ref()
+        .is_some_and(|name| !set.subscribed.contains_key(name))
+    {
+        set.default = set.subscribed.keys().next().cloned();
+    }
+    Ok(set)
 }
 
-/// Load the subscription set. If it does not exist yet, return an
-/// empty set; callers decide how to seed it.
-pub fn load_or_init(home: &Path) -> Result<SubscriptionSet, SubscriptionError> {
-    let path = path_in(home);
-    if path.exists() {
-        let text = std::fs::read_to_string(&path)?;
-        let set: SubscriptionSet = serde_json::from_str(&text)?;
-        if set.version != SUBSCRIPTIONS_VERSION {
-            return Err(SubscriptionError::SchemaVersionMismatch {
-                found: set.version,
-                expected: SUBSCRIPTIONS_VERSION,
+/// Save the subscription set through the durable store. This is the
+/// only persistence path for subscriptions/default channel state.
+pub async fn save(store: &dyn EventStore, set: &SubscriptionSet) -> Result<(), SubscriptionError> {
+    let mut rows = Vec::new();
+    for subscription in set.all() {
+        rows.push(StoredSubscription {
+            channel_name: subscription.name.as_str().to_string(),
+            room_id: subscription.room_id,
+            wire: subscription.wire.to_string_lossy().into_owned(),
+            joined_at_ms: subscription.joined_at_ms,
+            is_default: set.default.as_ref() == Some(&subscription.name),
+            parted: false,
+        });
+    }
+    for channel in &set.parted {
+        if !set.subscribed.contains_key(channel) {
+            rows.push(StoredSubscription {
+                channel_name: channel.as_str().to_string(),
+                room_id: derive_room_id(&MeshIdentity::unset(), channel),
+                wire: String::new(),
+                joined_at_ms: 0,
+                is_default: false,
+                parted: true,
             });
         }
-        return Ok(set);
     }
-
-    Ok(SubscriptionSet::empty())
-}
-
-/// Save the subscription set to disk. Always writes the canonical
-/// shape; round-trip-safe (load_or_init → save → load_or_init yields
-/// the same set).
-pub fn save(home: &Path, set: &SubscriptionSet) -> Result<(), SubscriptionError> {
-    std::fs::create_dir_all(home)?;
-    let path = path_in(home);
-    let text = serde_json::to_string_pretty(set)?;
-    std::fs::write(&path, text)?;
-    set_owner_only_permissions(&path)?;
+    store.replace_subscriptions(rows).await?;
     Ok(())
 }
 
 impl Airc {
     /// Load this scope's subscription set for consumer surfaces.
     pub async fn subscription_set(&self) -> Result<SubscriptionSet, AircError> {
-        Ok(load_or_init(&self.inner.home)?)
+        Ok(load_or_init(self.event_store()).await?)
     }
 
     pub(crate) async fn subscribed_event_filter(
@@ -540,19 +551,6 @@ fn push_unique_path(items: &mut Vec<PathBuf>, item: PathBuf) {
     }
 }
 
-#[cfg(unix)]
-fn set_owner_only_permissions(path: &Path) -> std::io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    let mut perms = std::fs::metadata(path)?.permissions();
-    perms.set_mode(0o600);
-    std::fs::set_permissions(path, perms)
-}
-
-#[cfg(not(unix))]
-fn set_owner_only_permissions(_path: &Path) -> std::io::Result<()> {
-    Ok(())
-}
-
 fn now_ms() -> Result<u64, std::time::SystemTimeError> {
     Ok(std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)?
@@ -562,6 +560,7 @@ fn now_ms() -> Result<u64, std::time::SystemTimeError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use airc_store::InMemoryEventStore;
     use tempfile::tempdir;
 
     #[test]
@@ -601,16 +600,6 @@ mod tests {
         let c = ChannelName::new("general").unwrap();
         assert_eq!(c.to_string(), "#general");
         assert_eq!(c.display_with_hash(), "#general");
-    }
-
-    #[test]
-    fn channel_name_serde_round_trip() {
-        let original = ChannelName::new("#general").unwrap();
-        let json = serde_json::to_string(&original).unwrap();
-        // Stored without `#` to keep the normalized form on disk.
-        assert_eq!(json, "\"general\"");
-        let back: ChannelName = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, original);
     }
 
     #[test]
@@ -802,26 +791,27 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[test]
-    fn save_load_round_trip_preserves_set() {
+    #[tokio::test]
+    async fn save_load_round_trip_preserves_set() {
         let dir = tempdir().unwrap();
         let home = dir.path();
+        let store = InMemoryEventStore::new();
         let id = MeshIdentity::new("joelteply");
         let mut set = SubscriptionSet::empty();
         set.subscribe(home, &id, ChannelName::new("general").unwrap())
             .unwrap();
         set.subscribe(home, &id, ChannelName::new("cambriantech").unwrap())
             .unwrap();
-        save(home, &set).unwrap();
+        save(&store, &set).await.unwrap();
 
-        let loaded = load_or_init(home).unwrap();
+        let loaded = load_or_init(&store).await.unwrap();
         assert_eq!(loaded, set);
     }
 
-    #[test]
-    fn empty_set_when_neither_file_exists() {
-        let dir = tempdir().unwrap();
-        let set = load_or_init(dir.path()).unwrap();
+    #[tokio::test]
+    async fn empty_set_when_store_has_no_rows() {
+        let store = InMemoryEventStore::new();
+        let set = load_or_init(&store).await.unwrap();
         assert!(set.subscribed.is_empty());
         assert!(set.default.is_none());
         assert!(set.parted.is_empty());

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -11,10 +11,9 @@ use std::{net::SocketAddr, time::Duration};
 
 use airc_daemon::{DaemonState, LocalIdentity};
 use airc_lib::{
-    coordinator_snapshot, resolve_mesh_identity_with, subscriptions, Airc, Body, ChannelName,
-    CoordinatorConfig, EventFilter, HeaderFilter, Headers, MeshIdentity, MeshIdentitySource,
-    PeerSpec, RouteEndpoint, SubscriptionSet, TranscriptKind, TransportHealthSample, TransportKind,
-    TransportRole,
+    coordinator_snapshot, resolve_mesh_identity_with, Airc, Body, ChannelName, CoordinatorConfig,
+    EventFilter, HeaderFilter, Headers, MeshIdentity, MeshIdentitySource, PeerSpec, RouteEndpoint,
+    TranscriptKind, TransportHealthSample, TransportKind, TransportRole,
 };
 use airc_protocol::{PeerKeyRegistry, VerificationPolicy};
 use airc_store::{EventStore, SqliteEventStore};
@@ -709,19 +708,6 @@ async fn filtered_event_queries_match_kind_and_headers_without_body_parse() {
 #[tokio::test]
 async fn subscribed_filter_reads_all_configured_channels_not_current_room_only() {
     let home = TempDir::new().unwrap();
-    let identity = MeshIdentity::unset();
-    let mut subscription_set = SubscriptionSet::empty();
-    subscription_set
-        .subscribe(home.path(), &identity, ChannelName::new("general").unwrap())
-        .unwrap();
-    subscription_set
-        .subscribe(
-            home.path(),
-            &identity,
-            ChannelName::new("cambriantech").unwrap(),
-        )
-        .unwrap();
-    subscriptions::save(home.path(), &subscription_set).unwrap();
     let airc = Airc::open(home.path()).await.unwrap();
 
     airc.join("general").await.unwrap();

--- a/crates/airc-store/src/entities/mod.rs
+++ b/crates/airc-store/src/entities/mod.rs
@@ -8,8 +8,10 @@
 //!   - `runtime_cursors` — per-consumer replay cursors.
 //!   - `peer_trust` / `peer_rotation_audit` — trust anchors and
 //!     signed key-rotation audit rows.
+//!   - `subscriptions` — joined channel/default-channel state.
 
 pub mod event;
 pub mod peer_rotation_audit;
 pub mod peer_trust;
 pub mod runtime_cursor;
+pub mod subscription;

--- a/crates/airc-store/src/entities/subscription.rs
+++ b/crates/airc-store/src/entities/subscription.rs
@@ -1,0 +1,23 @@
+//! `subscriptions` table — joined channels and default-channel state.
+//!
+//! Subscriptions are runtime state. They belong in the store with
+//! cursors, transcript replay, and trust anchors, not in sidecar JSON.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "subscriptions")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub channel_name: String,
+    pub room_id: Uuid,
+    pub wire: String,
+    pub joined_at_ms: i64,
+    pub is_default: bool,
+    pub parted: bool,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/airc-store/src/lib.rs
+++ b/crates/airc-store/src/lib.rs
@@ -36,9 +36,11 @@ pub mod migration;
 pub mod peer_trust;
 pub mod sqlite;
 pub mod store;
+pub mod subscriptions;
 
 pub use error::StoreError;
 pub use memory::InMemoryEventStore;
 pub use peer_trust::{RotationAuditEntry, StoredPeer};
 pub use sqlite::SqliteEventStore;
 pub use store::EventStore;
+pub use subscriptions::StoredSubscription;

--- a/crates/airc-store/src/memory.rs
+++ b/crates/airc-store/src/memory.rs
@@ -10,10 +10,12 @@ use airc_core::{RoomId, TranscriptCursor, TranscriptEvent};
 
 use crate::error::StoreError;
 use crate::store::EventStore;
+use crate::subscriptions::StoredSubscription;
 
 pub struct InMemoryEventStore {
     events: Mutex<Vec<TranscriptEvent>>,
     runtime_cursors: Mutex<BTreeMap<String, TranscriptCursor>>,
+    subscriptions: Mutex<Vec<StoredSubscription>>,
 }
 
 impl InMemoryEventStore {
@@ -21,6 +23,7 @@ impl InMemoryEventStore {
         Self {
             events: Mutex::new(Vec::new()),
             runtime_cursors: Mutex::new(BTreeMap::new()),
+            subscriptions: Mutex::new(Vec::new()),
         }
     }
 }
@@ -113,6 +116,23 @@ impl EventStore for InMemoryEventStore {
             .lock()
             .map_err(|_| StoreError::LockPoisoned)?;
         cursors.insert(consumer_id.to_string(), cursor.clone());
+        Ok(())
+    }
+
+    async fn load_subscriptions(&self) -> Result<Vec<StoredSubscription>, StoreError> {
+        let subscriptions = self
+            .subscriptions
+            .lock()
+            .map_err(|_| StoreError::LockPoisoned)?;
+        Ok(subscriptions.clone())
+    }
+
+    async fn replace_subscriptions(&self, rows: Vec<StoredSubscription>) -> Result<(), StoreError> {
+        let mut subscriptions = self
+            .subscriptions
+            .lock()
+            .map_err(|_| StoreError::LockPoisoned)?;
+        *subscriptions = rows;
         Ok(())
     }
 }

--- a/crates/airc-store/src/migration/m20260522_000004_create_subscriptions.rs
+++ b/crates/airc-store/src/migration/m20260522_000004_create_subscriptions.rs
@@ -1,0 +1,68 @@
+//! Add ORM-owned subscription/default-channel state.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Subscriptions::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Subscriptions::ChannelName)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Subscriptions::RoomId).uuid().not_null())
+                    .col(ColumnDef::new(Subscriptions::Wire).string().not_null())
+                    .col(
+                        ColumnDef::new(Subscriptions::JoinedAtMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(Subscriptions::IsDefault)
+                            .boolean()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(Subscriptions::Parted).boolean().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_subscriptions_default")
+                    .table(Subscriptions::Table)
+                    .col(Subscriptions::IsDefault)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(Subscriptions::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Subscriptions {
+    Table,
+    ChannelName,
+    RoomId,
+    Wire,
+    JoinedAtMs,
+    IsDefault,
+    Parted,
+}

--- a/crates/airc-store/src/migration/mod.rs
+++ b/crates/airc-store/src/migration/mod.rs
@@ -10,6 +10,7 @@ use sea_orm_migration::prelude::*;
 mod m20260519_000001_create_events;
 mod m20260522_000002_create_runtime_cursors;
 mod m20260522_000003_create_peer_trust;
+mod m20260522_000004_create_subscriptions;
 
 pub struct Migrator;
 
@@ -20,6 +21,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260519_000001_create_events::Migration),
             Box::new(m20260522_000002_create_runtime_cursors::Migration),
             Box::new(m20260522_000003_create_peer_trust::Migration),
+            Box::new(m20260522_000004_create_subscriptions::Migration),
         ]
     }
 }

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use sea_orm::{
     sea_query::{Expr, OnConflict},
     ActiveValue, ColumnTrait, ConnectOptions, Database, DatabaseConnection, EntityTrait,
-    QueryFilter, QueryOrder, QuerySelect, Set,
+    QueryFilter, QueryOrder, QuerySelect, Set, TransactionTrait,
 };
 use sea_orm_migration::MigratorTrait;
 use serde_json::Value as JsonValue;
@@ -29,11 +29,12 @@ use airc_core::{
     Body, ClientId, EventId, Headers, PeerId, RoomId, TranscriptCursor, TranscriptEvent,
 };
 
-use crate::entities::{event, peer_rotation_audit, peer_trust, runtime_cursor};
+use crate::entities::{event, peer_rotation_audit, peer_trust, runtime_cursor, subscription};
 use crate::error::StoreError;
 use crate::migration::Migrator;
 use crate::peer_trust::{RotationAuditEntry, StoredPeer};
 use crate::store::EventStore;
+use crate::subscriptions::StoredSubscription;
 
 pub struct SqliteEventStore {
     db: DatabaseConnection,
@@ -397,6 +398,46 @@ impl EventStore for SqliteEventStore {
             .await?;
         Ok(())
     }
+
+    async fn load_subscriptions(&self) -> Result<Vec<StoredSubscription>, StoreError> {
+        let rows = subscription::Entity::find()
+            .order_by_asc(subscription::Column::ChannelName)
+            .all(&self.db)
+            .await?;
+        rows.into_iter()
+            .map(|row| {
+                Ok(StoredSubscription {
+                    channel_name: row.channel_name,
+                    room_id: RoomId::from_uuid(row.room_id),
+                    wire: row.wire,
+                    joined_at_ms: i64_to_u64("subscriptions.joined_at_ms", row.joined_at_ms)?,
+                    is_default: row.is_default,
+                    parted: row.parted,
+                })
+            })
+            .collect()
+    }
+
+    async fn replace_subscriptions(&self, rows: Vec<StoredSubscription>) -> Result<(), StoreError> {
+        let txn = self.db.begin().await?;
+        subscription::Entity::delete_many().exec(&txn).await?;
+        for row in rows {
+            let active = subscription::ActiveModel {
+                channel_name: ActiveValue::Set(row.channel_name),
+                room_id: ActiveValue::Set(row.room_id.as_uuid()),
+                wire: ActiveValue::Set(row.wire),
+                joined_at_ms: ActiveValue::Set(u64_to_i64(
+                    "subscriptions.joined_at_ms",
+                    row.joined_at_ms,
+                )?),
+                is_default: ActiveValue::Set(row.is_default),
+                parted: ActiveValue::Set(row.parted),
+            };
+            subscription::Entity::insert(active).exec(&txn).await?;
+        }
+        txn.commit().await?;
+        Ok(())
+    }
 }
 
 fn to_active_model(ev: &TranscriptEvent) -> Result<event::ActiveModel, StoreError> {
@@ -714,6 +755,72 @@ mod tests {
                 .unwrap(),
             Some(join)
         );
+    }
+
+    #[tokio::test]
+    async fn subscriptions_round_trip_through_orm_table() {
+        let store = SqliteEventStore::in_memory().await.unwrap();
+        let rows = vec![
+            StoredSubscription {
+                channel_name: "general".to_string(),
+                room_id: RoomId::from_u128(0x100),
+                wire: "/tmp/airc/wires/general".to_string(),
+                joined_at_ms: 1_700_000_000_000,
+                is_default: false,
+                parted: false,
+            },
+            StoredSubscription {
+                channel_name: "cambriantech".to_string(),
+                room_id: RoomId::from_u128(0x101),
+                wire: "/tmp/airc/wires/cambriantech".to_string(),
+                joined_at_ms: 1_700_000_000_010,
+                is_default: true,
+                parted: false,
+            },
+            StoredSubscription {
+                channel_name: "old-room".to_string(),
+                room_id: RoomId::from_u128(0x102),
+                wire: String::new(),
+                joined_at_ms: 0,
+                is_default: false,
+                parted: true,
+            },
+        ];
+
+        let mut expected = rows.clone();
+        expected.sort_by(|a, b| a.channel_name.cmp(&b.channel_name));
+        store.replace_subscriptions(rows).await.unwrap();
+
+        assert_eq!(store.load_subscriptions().await.unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn subscriptions_persist_across_store_handles() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.sqlite");
+        let rows = vec![StoredSubscription {
+            channel_name: "general".to_string(),
+            room_id: RoomId::from_u128(0x200),
+            wire: dir
+                .path()
+                .join("wires")
+                .join("general")
+                .display()
+                .to_string(),
+            joined_at_ms: 1_700_000_000_000,
+            is_default: true,
+            parted: false,
+        }];
+
+        SqliteEventStore::open_path(&path)
+            .await
+            .unwrap()
+            .replace_subscriptions(rows.clone())
+            .await
+            .unwrap();
+
+        let reopened = SqliteEventStore::open_path(&path).await.unwrap();
+        assert_eq!(reopened.load_subscriptions().await.unwrap(), rows);
     }
 
     #[tokio::test]

--- a/crates/airc-store/src/store.rs
+++ b/crates/airc-store/src/store.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use airc_core::{RoomId, TranscriptCursor, TranscriptEvent};
 
 use crate::error::StoreError;
+use crate::subscriptions::StoredSubscription;
 
 /// Durable transcript event store.
 ///
@@ -73,4 +74,14 @@ pub trait EventStore: Send + Sync {
         cursor: &TranscriptCursor,
         updated_at_ms: u64,
     ) -> Result<(), StoreError>;
+
+    /// Load joined-channel/default-channel state.
+    async fn load_subscriptions(&self) -> Result<Vec<StoredSubscription>, StoreError>;
+
+    /// Replace joined-channel/default-channel state with `rows`.
+    ///
+    /// Callers pass the complete subscription projection; the store
+    /// owns the durable table and never mirrors this into sidecar
+    /// files.
+    async fn replace_subscriptions(&self, rows: Vec<StoredSubscription>) -> Result<(), StoreError>;
 }

--- a/crates/airc-store/src/subscriptions.rs
+++ b/crates/airc-store/src/subscriptions.rs
@@ -1,0 +1,13 @@
+//! Subscription store types.
+
+use airc_core::RoomId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredSubscription {
+    pub channel_name: String,
+    pub room_id: RoomId,
+    pub wire: String,
+    pub joined_at_ms: u64,
+    pub is_default: bool,
+    pub parted: bool,
+}

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -194,9 +194,9 @@ Move to SeaORM entities (one row, one table, one transaction):
 
 | Today (JSON file + temp-rename) | Phase 3.5 (SeaORM table) |
 |---|---|
-| `peers.json` | `peers` (FK from events.peer_id) |
-| `subscriptions.json` | `subscriptions` (FK to rooms) |
-| `room.json` (current room marker) | `rooms` table + `default` flag |
+| `peers.json` | `peer_trust` + `peer_rotation_audit` (done in #883) |
+| `subscriptions.json` | `subscriptions` table (done in store-backed subscriptions cut) |
+| `room.json` (current room marker) | `subscriptions.is_default` (done in store-backed subscriptions cut) |
 | `identity.json` (singleton) | `identity` table (singleton row) |
 | `mesh_identity` cache file | `mesh_identity` table (or column on identity) |
 | `account_registry/*.json` | `account_registry` table |
@@ -240,10 +240,11 @@ five concrete hotpaths and seven kill-list patterns.
 ### Top 5 perf problems (worst first)
 
 1. **Synchronous file I/O on every CLI/subscribe call** —
-   `peers_store.rs:217`, `subscriptions.rs:437-458`. Every subscribe,
-   send, or join re-reads `peers.json` + `subscriptions.json` from
-   disk. ~5–15ms per JSON read × every invocation. Phase 3.5 (move
-   to SeaORM) kills this.
+   peer trust moved to SeaORM in #883 and subscriptions/default-room
+   moved to the `subscriptions` table in the store-backed
+   subscriptions cut. Remaining file-backed runtime state is
+   identity, mesh-identity cache, account registry, and coordinator
+   beacons.
 
 2. **Double clone of `TranscriptEvent` on every ingest** —
    `messaging.rs:110`, `transport.rs:124`. Each event is cloned
@@ -268,14 +269,16 @@ five concrete hotpaths and seven kill-list patterns.
 
 ### Substrate-wide patterns to kill (priority order)
 
-1. **Synchronous file I/O in async functions** — peers.json,
-   subscriptions.json reads on event path. (Phase 3.5 deletes
-   these files entirely.)
+1. **Synchronous file I/O in async functions** — identity,
+   mesh-identity cache, account registry, and coordinator beacon
+   reads still need SeaORM cuts. Peer trust and subscriptions are now
+   store-backed.
 2. **`RwLock<HashMap>` at global granularity** — PeerKeyRegistry,
    route_health, route_endpoints, imported_invites. Switch to
    `DashMap` or sharded RwLock for N-reader scale.
-3. **Full JSON file rewrites on every mutate** — `peers_store`
-   save, `subscriptions` save. Phase 3.5 kills these.
+3. **Full JSON file rewrites on every mutate** — remaining registry
+   and coordinator saves. Peer trust and subscriptions/default-room
+   are no longer JSON-backed.
 4. **`event.clone()` on broadcast hot path** — `Arc<TranscriptEvent>`
    internally; broadcast is `Arc::clone`.
 5. **Linear scans for dedup** — `enrolled.contains`, subscriptions


### PR DESCRIPTION
## Summary
- add an ORM-backed `subscriptions` table and store DTO for joined-channel/default-channel state
- route `airc-lib` subscription load/save through the `EventStore` trait instead of `subscriptions.json`
- update join/default-context tests so `airc join` does not recreate subscription JSON sidecars
- update the grid substrate audit with the completed subscription/default-room ORM cut

## Verification
- cargo fmt --all
- cargo test -p airc-store subscriptions
- cargo test -p airc-lib subscriptions
- cargo test -p airc-cli join_without_args_uses_default_account_context
- cargo clippy -p airc-store -p airc-lib -p airc-cli --all-targets -- -D warnings
- cargo test --workspace