### PR TITLE
fix(store): persist mesh identity through ORM

### DIFF
--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -299,20 +299,19 @@ fn create_repo_with_origin(path: &Path, origin: &str) {
 }
 
 fn seed_mesh_identity(home: &Path, identity: &str) {
-    std::fs::create_dir_all(home).unwrap();
-    std::fs::write(
-        home.join("mesh_identity.json"),
-        format!(
-            r#"{{
-  "version": 1,
-  "identity": "{identity}",
-  "source": "operator",
-  "resolved_at_ms": 1,
-  "ttl_ms": 86400000
-}}"#
-        ),
-    )
-    .unwrap();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(async {
+        let store = airc_store::SqliteEventStore::open_path(&home.join("events.sqlite"))
+            .await
+            .unwrap();
+        airc_lib::resolve_mesh_identity_with(
+            &store,
+            || Some((identity.to_string(), airc_lib::MeshIdentitySource::Operator)),
+            1,
+        )
+        .await
+        .unwrap();
+    });
 }
 
 #[test]

--- a/crates/airc-cli/tests/operational_dogfood.rs
+++ b/crates/airc-cli/tests/operational_dogfood.rs
@@ -298,12 +298,24 @@ fn test_client_id(user_home: &Path) -> &'static str {
 
 fn seed_mesh_identity(user_home: &Path) {
     let airc_home = user_home.join(".airc");
-    std::fs::create_dir_all(&airc_home).expect("airc home");
-    std::fs::write(
-        airc_home.join("mesh_identity.json"),
-        r#"{"version":1,"identity":"dogfood-account","source":"operator","resolved_at_ms":1,"ttl_ms":86400000}"#,
-    )
-    .expect("write mesh identity");
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(async {
+        let store = airc_store::SqliteEventStore::open_path(&airc_home.join("events.sqlite"))
+            .await
+            .unwrap();
+        airc_lib::resolve_mesh_identity_with(
+            &store,
+            || {
+                Some((
+                    "dogfood-account".to_string(),
+                    airc_lib::MeshIdentitySource::Operator,
+                ))
+            },
+            1,
+        )
+        .await
+        .unwrap();
+    });
 }
 
 fn extract_field<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -268,7 +268,7 @@ fn safe_component(value: &str) -> String {
 
 impl Airc {
     pub async fn account_registry_document(&self) -> Result<AccountRegistryDocument, AircError> {
-        let identity = self.mesh_identity()?;
+        let identity = self.mesh_identity().await?;
         let snapshot = crate::coordinator::snapshot(
             &self.inner.wire_root,
             &identity,
@@ -307,7 +307,7 @@ impl Airc {
         &self,
         store: &dyn AccountRegistryStore,
     ) -> Result<Option<AccountRegistryDocument>, AircError> {
-        let identity = self.mesh_identity()?;
+        let identity = self.mesh_identity().await?;
         let Some(document) = store.refresh(&identity).await? else {
             return Ok(None);
         };
@@ -368,19 +368,21 @@ mod tests {
         }
     }
 
-    fn write_identity(home: &std::path::Path) {
-        std::fs::create_dir_all(home).unwrap();
-        std::fs::write(
-            home.join("mesh_identity.json"),
-            r#"{
-  "version": 1,
-  "identity": "joelteply",
-  "source": "operator",
-  "resolved_at_ms": 4102444800000,
-  "ttl_ms": 86400000
-}
-"#,
+    async fn write_identity(home: &std::path::Path) {
+        let store = airc_store::SqliteEventStore::open_path(&home.join("events.sqlite"))
+            .await
+            .unwrap();
+        crate::mesh_identity::resolve_with(
+            &store,
+            || {
+                Some((
+                    "joelteply".to_string(),
+                    crate::mesh_identity::Source::Operator,
+                ))
+            },
+            4_102_444_800_000,
         )
+        .await
         .unwrap();
     }
 
@@ -568,8 +570,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let machine_a = dir.path().join("machine-a/.airc");
         let machine_b = dir.path().join("machine-b/.airc");
-        write_identity(&machine_a);
-        write_identity(&machine_b);
+        write_identity(&machine_a).await;
+        write_identity(&machine_b).await;
         let store = FileAccountRegistryStore::new(dir.path().join("remote-registry"));
 
         let airc_a = Airc::open(&machine_a).await.unwrap();

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -353,8 +353,8 @@ impl Airc {
     /// re-resolves after [`crate::mesh_identity::DEFAULT_TTL_MS`] so
     /// concurrent callers don't hammer `gh`. See the module docs for
     /// the resolver chain.
-    pub(crate) fn mesh_identity(&self) -> Result<MeshIdentity, AircError> {
-        let cached = mesh_identity::resolve(&self.inner.home)?;
+    pub(crate) async fn mesh_identity(&self) -> Result<MeshIdentity, AircError> {
+        let cached = mesh_identity::resolve(self.event_store()).await?;
         Ok(cached.as_mesh_identity())
     }
 
@@ -399,7 +399,7 @@ impl Airc {
     /// short-shape commands.
     pub async fn join(&self, name: &str) -> Result<Room, AircError> {
         let channel = ChannelName::new(name)?;
-        let identity = self.mesh_identity()?;
+        let identity = self.mesh_identity().await?;
         let mut set = subscriptions::load_or_init(self.event_store()).await?;
         let subscription =
             set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
@@ -436,7 +436,7 @@ impl Airc {
     /// bounded coordinator task so gh/network latency can never make
     /// the public join command hang.
     pub async fn ensure_join_context(&self, context: JoinContext) -> Result<Vec<Room>, AircError> {
-        let identity = self.mesh_identity()?;
+        let identity = self.mesh_identity().await?;
         let mut set = subscriptions::load_or_init(self.event_store()).await?;
         let mut rooms = Vec::new();
 
@@ -468,7 +468,7 @@ impl Airc {
     /// Production users want [`join`].
     pub async fn join_with_wire(&self, name: &str, wire: PathBuf) -> Result<Room, AircError> {
         let channel = ChannelName::new(name)?;
-        let identity = self.mesh_identity()?;
+        let identity = self.mesh_identity().await?;
         let mut set = subscriptions::load_or_init(self.event_store()).await?;
         let subscription = Subscription::with_wire(&identity, channel.clone(), wire)?;
         set.parted.remove(&channel);
@@ -490,7 +490,7 @@ impl Airc {
             return Ok(subscription.as_room());
         }
 
-        let identity = self.mesh_identity()?;
+        let identity = self.mesh_identity().await?;
         let channel = ChannelName::new("general")?;
         let subscription =
             set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -61,9 +61,9 @@ pub use error::AircError;
 pub use gh_account_registry::{gh_auth_ready, GhAccountRegistryStore};
 pub use join_context::{JoinContext, GENERAL_CHANNEL};
 pub use mesh_identity::{
-    load_cached as load_cached_mesh_identity, path_in as mesh_identity_path,
-    resolve as resolve_mesh_identity, resolve_with as resolve_mesh_identity_with, CachedIdentity,
-    MeshIdentityError, Source as MeshIdentitySource, DEFAULT_TTL_MS as MESH_IDENTITY_TTL_MS,
+    load_cached as load_cached_mesh_identity, resolve as resolve_mesh_identity,
+    resolve_with as resolve_mesh_identity_with, CachedIdentity, MeshIdentityError,
+    Source as MeshIdentitySource, DEFAULT_TTL_MS as MESH_IDENTITY_TTL_MS,
 };
 pub use peers::EnrolledPeer;
 pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};

--- a/crates/airc-lib/src/mesh_identity.rs
+++ b/crates/airc-lib/src/mesh_identity.rs
@@ -9,7 +9,7 @@
 //!
 //! ## Resolution order
 //!
-//! 1. **Cached value** in `<home>/mesh_identity.json`, if fresh
+//! 1. **Cached value** in the `mesh_identity` ORM table, if fresh
 //!    (`resolved_at_ms` within [`DEFAULT_TTL_MS`]).
 //! 2. **`gh api user --jq .login`** — the canonical GitHub identity
 //!    when `gh` is installed and authenticated.
@@ -21,8 +21,8 @@
 //!
 //! ## Caching
 //!
-//! Persisted to `<home>/mesh_identity.json`. Schema version 1.
-//! Re-resolution kicks in after `DEFAULT_TTL_MS`; cache hits never
+//! Persisted to the `mesh_identity` ORM table. Re-resolution kicks in
+//! after `DEFAULT_TTL_MS`; cache hits never
 //! shell out, so ten local scopes opening at once produce at most
 //! one `gh` call.
 //!
@@ -33,15 +33,14 @@
 //! [`resolve`] which uses the gh+git fallback resolver. Tests pass
 //! a fixed-string closure.
 
-use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use airc_store::{EventStore, StoredMeshIdentity};
 use serde::{Deserialize, Serialize};
 
 use crate::subscriptions::MeshIdentity;
 
-const IDENTITY_FILENAME: &str = "mesh_identity.json";
-const IDENTITY_VERSION: u32 = 1;
+const MESH_IDENTITY_SCOPE: &str = "default";
 /// Default cache TTL: 24h. Re-resolution after this re-checks gh /
 /// git in case the operator switched accounts.
 pub const DEFAULT_TTL_MS: u64 = 24 * 60 * 60 * 1000;
@@ -91,21 +90,17 @@ impl CachedIdentity {
 /// What can go wrong resolving/persisting the identity.
 #[derive(Debug)]
 pub enum MeshIdentityError {
-    Io(std::io::Error),
-    Json(serde_json::Error),
+    Store(airc_store::StoreError),
     Clock(std::time::SystemTimeError),
-    SchemaVersionMismatch { found: u32, expected: u32 },
+    UnknownSource(String),
 }
 
 impl std::fmt::Display for MeshIdentityError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Io(error) => write!(f, "mesh identity I/O: {error}"),
-            Self::Json(error) => write!(f, "mesh identity JSON: {error}"),
+            Self::Store(error) => write!(f, "mesh identity store: {error}"),
             Self::Clock(error) => write!(f, "mesh identity clock: {error}"),
-            Self::SchemaVersionMismatch { found, expected } => {
-                write!(f, "mesh_identity.json version {found}, expected {expected}")
-            }
+            Self::UnknownSource(source) => write!(f, "unknown mesh identity source: {source}"),
         }
     }
 }
@@ -113,23 +108,16 @@ impl std::fmt::Display for MeshIdentityError {
 impl std::error::Error for MeshIdentityError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::Io(error) => Some(error),
-            Self::Json(error) => Some(error),
+            Self::Store(error) => Some(error),
             Self::Clock(error) => Some(error),
-            Self::SchemaVersionMismatch { .. } => None,
+            Self::UnknownSource(_) => None,
         }
     }
 }
 
-impl From<std::io::Error> for MeshIdentityError {
-    fn from(value: std::io::Error) -> Self {
-        Self::Io(value)
-    }
-}
-
-impl From<serde_json::Error> for MeshIdentityError {
-    fn from(value: serde_json::Error) -> Self {
-        Self::Json(value)
+impl From<airc_store::StoreError> for MeshIdentityError {
+    fn from(value: airc_store::StoreError) -> Self {
+        Self::Store(value)
     }
 }
 
@@ -139,15 +127,10 @@ impl From<std::time::SystemTimeError> for MeshIdentityError {
     }
 }
 
-/// On-disk path for the cache.
-pub fn path_in(home: &Path) -> PathBuf {
-    home.join(IDENTITY_FILENAME)
-}
-
 /// Resolve via the default fallback chain (gh → git email → local
 /// hostname/user) and persist. Most callers want this.
-pub fn resolve(home: &Path) -> Result<CachedIdentity, MeshIdentityError> {
-    resolve_with(home, default_resolver, now_ms()?)
+pub async fn resolve(store: &dyn EventStore) -> Result<CachedIdentity, MeshIdentityError> {
+    resolve_with(store, default_resolver, now_ms()?).await
 }
 
 /// Resolve with an injected resolver closure. The closure returns
@@ -156,15 +139,15 @@ pub fn resolve(home: &Path) -> Result<CachedIdentity, MeshIdentityError> {
 ///
 /// Used by tests to bypass `gh` / `git` shell-outs and by production
 /// callers via [`resolve`].
-pub fn resolve_with<F>(
-    home: &Path,
+pub async fn resolve_with<F>(
+    store: &dyn EventStore,
     resolver: F,
     now_ms: u64,
 ) -> Result<CachedIdentity, MeshIdentityError>
 where
     F: FnOnce() -> Option<(String, Source)>,
 {
-    if let Some(cached) = load_cached(home)? {
+    if let Some(cached) = load_cached(store).await? {
         // Operator-source caches are trusted as-is and never expire —
         // they were explicitly set by the user (env var, CLI override,
         // test seed). Treating them as TTL-bounded forces a fall-through
@@ -184,13 +167,13 @@ where
     };
 
     let entry = CachedIdentity {
-        version: IDENTITY_VERSION,
+        version: 1,
         identity,
         source,
         resolved_at_ms: now_ms,
         ttl_ms: DEFAULT_TTL_MS,
     };
-    save(home, &entry)?;
+    save(store, &entry).await?;
     Ok(entry)
 }
 
@@ -198,30 +181,73 @@ where
 /// doesn't exist. Used by code paths that want to know "do we have an
 /// identity?" without triggering a `gh` shell-out (e.g., status
 /// printers).
-pub fn load_cached(home: &Path) -> Result<Option<CachedIdentity>, MeshIdentityError> {
-    let path = path_in(home);
-    if !path.exists() {
-        return Ok(None);
-    }
-    let text = std::fs::read_to_string(&path)?;
-    let entry: CachedIdentity = serde_json::from_str(&text)?;
-    if entry.version != IDENTITY_VERSION {
-        return Err(MeshIdentityError::SchemaVersionMismatch {
-            found: entry.version,
-            expected: IDENTITY_VERSION,
-        });
-    }
-    Ok(Some(entry))
+pub async fn load_cached(
+    store: &dyn EventStore,
+) -> Result<Option<CachedIdentity>, MeshIdentityError> {
+    store
+        .load_mesh_identity(MESH_IDENTITY_SCOPE)
+        .await?
+        .map(CachedIdentity::try_from)
+        .transpose()
 }
 
 /// Persist the cache.
-pub fn save(home: &Path, entry: &CachedIdentity) -> Result<(), MeshIdentityError> {
-    std::fs::create_dir_all(home)?;
-    let path = path_in(home);
-    let text = serde_json::to_string_pretty(entry)?;
-    std::fs::write(&path, text)?;
-    set_owner_only_permissions(&path)?;
+pub async fn save(store: &dyn EventStore, entry: &CachedIdentity) -> Result<(), MeshIdentityError> {
+    store
+        .save_mesh_identity(StoredMeshIdentity::from(entry.clone()))
+        .await?;
     Ok(())
+}
+
+impl Source {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::GhApiUser => "gh_api_user",
+            Self::GitEmail => "git_email",
+            Self::LocalHostUser => "local_host_user",
+            Self::Operator => "operator",
+        }
+    }
+}
+
+impl TryFrom<&str> for Source {
+    type Error = MeshIdentityError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "gh_api_user" => Ok(Self::GhApiUser),
+            "git_email" => Ok(Self::GitEmail),
+            "local_host_user" => Ok(Self::LocalHostUser),
+            "operator" => Ok(Self::Operator),
+            other => Err(MeshIdentityError::UnknownSource(other.to_string())),
+        }
+    }
+}
+
+impl From<CachedIdentity> for StoredMeshIdentity {
+    fn from(value: CachedIdentity) -> Self {
+        Self {
+            scope: MESH_IDENTITY_SCOPE.to_string(),
+            identity: value.identity,
+            source: value.source.as_str().to_string(),
+            resolved_at_ms: value.resolved_at_ms,
+            ttl_ms: value.ttl_ms,
+        }
+    }
+}
+
+impl TryFrom<StoredMeshIdentity> for CachedIdentity {
+    type Error = MeshIdentityError;
+
+    fn try_from(value: StoredMeshIdentity) -> Result<Self, Self::Error> {
+        Ok(Self {
+            version: 1,
+            identity: value.identity,
+            source: Source::try_from(value.source.as_str())?,
+            resolved_at_ms: value.resolved_at_ms,
+            ttl_ms: value.ttl_ms,
+        })
+    }
 }
 
 /// Default resolver: `gh api user --jq .login` then `git config
@@ -302,19 +328,6 @@ fn local_fallback_identity() -> String {
     format!("local:{host}:{user}")
 }
 
-#[cfg(unix)]
-fn set_owner_only_permissions(path: &Path) -> std::io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    let mut perms = std::fs::metadata(path)?.permissions();
-    perms.set_mode(0o600);
-    std::fs::set_permissions(path, perms)
-}
-
-#[cfg(not(unix))]
-fn set_owner_only_permissions(_path: &Path) -> std::io::Result<()> {
-    Ok(())
-}
-
 fn now_ms() -> Result<u64, std::time::SystemTimeError> {
     Ok(std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)?
@@ -324,7 +337,7 @@ fn now_ms() -> Result<u64, std::time::SystemTimeError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::tempdir;
+    use airc_store::InMemoryEventStore;
 
     fn mock_gh(value: &'static str) -> impl FnOnce() -> Option<(String, Source)> {
         move || Some((value.to_string(), Source::GhApiUser))
@@ -334,53 +347,55 @@ mod tests {
         None
     }
 
-    #[test]
-    fn resolve_with_injected_resolver_persists() {
-        let dir = tempdir().unwrap();
-        let entry = resolve_with(dir.path(), mock_gh("joelteply"), 1_000).unwrap();
+    #[tokio::test]
+    async fn resolve_with_injected_resolver_persists() {
+        let store = InMemoryEventStore::new();
+        let entry = resolve_with(&store, mock_gh("joelteply"), 1_000)
+            .await
+            .unwrap();
         assert_eq!(entry.identity, "joelteply");
         assert_eq!(entry.source, Source::GhApiUser);
         assert_eq!(entry.resolved_at_ms, 1_000);
-        assert!(path_in(dir.path()).exists());
+        assert!(load_cached(&store).await.unwrap().is_some());
     }
 
-    #[test]
-    fn resolve_uses_cache_when_fresh() {
-        let dir = tempdir().unwrap();
+    #[tokio::test]
+    async fn resolve_uses_cache_when_fresh() {
+        let store = InMemoryEventStore::new();
         // First resolve writes "alice".
-        resolve_with(dir.path(), mock_gh("alice"), 1_000).unwrap();
+        resolve_with(&store, mock_gh("alice"), 1_000).await.unwrap();
         // Second resolve with a DIFFERENT mock should still see "alice"
         // because the cache is fresh.
-        let entry = resolve_with(dir.path(), mock_gh("bob"), 1_500).unwrap();
+        let entry = resolve_with(&store, mock_gh("bob"), 1_500).await.unwrap();
         assert_eq!(entry.identity, "alice", "cache must short-circuit");
     }
 
-    #[test]
-    fn resolve_re_resolves_after_ttl_expiry() {
-        let dir = tempdir().unwrap();
-        resolve_with(dir.path(), mock_gh("alice"), 1_000).unwrap();
+    #[tokio::test]
+    async fn resolve_re_resolves_after_ttl_expiry() {
+        let store = InMemoryEventStore::new();
+        resolve_with(&store, mock_gh("alice"), 1_000).await.unwrap();
         // 24h + 1ms past resolution.
         let later = 1_000 + DEFAULT_TTL_MS + 1;
-        let entry = resolve_with(dir.path(), mock_gh("bob"), later).unwrap();
+        let entry = resolve_with(&store, mock_gh("bob"), later).await.unwrap();
         assert_eq!(entry.identity, "bob");
     }
 
-    #[test]
-    fn resolve_falls_back_to_local_when_resolver_yields_none() {
-        let dir = tempdir().unwrap();
-        let entry = resolve_with(dir.path(), mock_none, 1_000).unwrap();
+    #[tokio::test]
+    async fn resolve_falls_back_to_local_when_resolver_yields_none() {
+        let store = InMemoryEventStore::new();
+        let entry = resolve_with(&store, mock_none, 1_000).await.unwrap();
         assert_eq!(entry.source, Source::LocalHostUser);
         assert!(entry.identity.starts_with("local:"));
         // Fallback is the SAME on a given machine — second resolve
         // (fresh cache) returns the cached fallback value too.
-        let entry2 = resolve_with(dir.path(), mock_none, 1_100).unwrap();
+        let entry2 = resolve_with(&store, mock_none, 1_100).await.unwrap();
         assert_eq!(entry2.identity, entry.identity);
     }
 
     #[test]
     fn as_mesh_identity_round_trips_to_typed_value() {
         let entry = CachedIdentity {
-            version: IDENTITY_VERSION,
+            version: 1,
             identity: "joelteply".to_string(),
             source: Source::GhApiUser,
             resolved_at_ms: 0,
@@ -389,37 +404,35 @@ mod tests {
         assert_eq!(entry.as_mesh_identity().as_str(), "joelteply");
     }
 
-    #[test]
-    fn load_cached_returns_none_when_file_absent() {
-        let dir = tempdir().unwrap();
-        assert!(load_cached(dir.path()).unwrap().is_none());
+    #[tokio::test]
+    async fn load_cached_returns_none_when_store_has_no_row() {
+        let store = InMemoryEventStore::new();
+        assert!(load_cached(&store).await.unwrap().is_none());
     }
 
-    #[test]
-    fn load_cached_rejects_wrong_schema_version() {
-        let dir = tempdir().unwrap();
-        let bad = serde_json::json!({
-            "version": 999,
-            "identity": "alice",
-            "source": "gh_api_user",
-            "resolved_at_ms": 0,
-            "ttl_ms": DEFAULT_TTL_MS,
-        });
-        std::fs::write(path_in(dir.path()), serde_json::to_string(&bad).unwrap()).unwrap();
-        let err = load_cached(dir.path()).unwrap_err();
-        assert!(matches!(
-            err,
-            MeshIdentityError::SchemaVersionMismatch {
-                found: 999,
-                expected: 1
-            }
-        ));
+    #[tokio::test]
+    async fn load_cached_rejects_unknown_source() {
+        let store = InMemoryEventStore::new();
+        store
+            .save_mesh_identity(StoredMeshIdentity {
+                scope: MESH_IDENTITY_SCOPE.to_string(),
+                identity: "alice".to_string(),
+                source: "surprise".to_string(),
+                resolved_at_ms: 0,
+                ttl_ms: DEFAULT_TTL_MS,
+            })
+            .await
+            .unwrap();
+        let err = load_cached(&store).await.unwrap_err();
+        assert!(
+            matches!(err, MeshIdentityError::UnknownSource(ref source) if source == "surprise")
+        );
     }
 
     #[test]
     fn is_expired_uses_saturating_sub_for_clock_skew() {
         let entry = CachedIdentity {
-            version: IDENTITY_VERSION,
+            version: 1,
             identity: "x".to_string(),
             source: Source::GhApiUser,
             // Future-dated resolved_at — saturating_sub yields 0,
@@ -431,18 +444,18 @@ mod tests {
         assert!(!entry.is_expired(500_000));
     }
 
-    #[test]
-    fn save_load_round_trip_preserves_entry() {
-        let dir = tempdir().unwrap();
+    #[tokio::test]
+    async fn save_load_round_trip_preserves_entry() {
+        let store = InMemoryEventStore::new();
         let entry = CachedIdentity {
-            version: IDENTITY_VERSION,
+            version: 1,
             identity: "joelteply".to_string(),
             source: Source::GhApiUser,
             resolved_at_ms: 42,
             ttl_ms: DEFAULT_TTL_MS,
         };
-        save(dir.path(), &entry).unwrap();
-        let loaded = load_cached(dir.path()).unwrap().unwrap();
+        save(&store, &entry).await.unwrap();
+        let loaded = load_cached(&store).await.unwrap().unwrap();
         assert_eq!(loaded, entry);
     }
 

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -503,7 +503,7 @@ impl Airc {
         }
 
         if room_ids.is_empty() {
-            let identity = self.mesh_identity()?;
+            let identity = self.mesh_identity().await?;
             push_unique(
                 &mut room_ids,
                 Subscription::new_with_wire_root(
@@ -524,7 +524,7 @@ impl Airc {
             push_unique_path(&mut wires, subscription.wire.clone());
         }
         if wires.is_empty() {
-            let identity = self.mesh_identity()?;
+            let identity = self.mesh_identity().await?;
             push_unique_path(
                 &mut wires,
                 Subscription::new_with_wire_root(

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -399,8 +399,8 @@ fn default_join_context_subscribes_general_and_repo_owner_on_shared_account_wire
             let alice_home = alice_repo.join(".airc");
             let bob_home = bob_repo.join(".airc");
 
-            seed_mesh_identity(&alice_home, "joelteply");
-            seed_mesh_identity(&bob_home, "joelteply");
+            seed_mesh_identity(&alice_home, "joelteply").await;
+            seed_mesh_identity(&bob_home, "joelteply").await;
 
             let alice = Airc::open(&alice_home).await.unwrap();
             let bob = Airc::open(&bob_home).await.unwrap();
@@ -500,16 +500,20 @@ fn repo_with_origin(path: &std::path::Path, origin: &str) -> std::path::PathBuf 
     path.to_path_buf()
 }
 
-fn seed_mesh_identity(home: &std::path::Path, identity: &str) {
+async fn seed_mesh_identity(home: &std::path::Path, identity: &str) {
+    let store = SqliteEventStore::open_path(&home.join("events.sqlite"))
+        .await
+        .unwrap();
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_millis() as u64;
     resolve_mesh_identity_with(
-        home,
+        &store,
         || Some((identity.to_string(), MeshIdentitySource::Operator)),
         now_ms,
     )
+    .await
     .unwrap();
 }
 

--- a/crates/airc-store/src/entities/mesh_identity.rs
+++ b/crates/airc-store/src/entities/mesh_identity.rs
@@ -1,0 +1,19 @@
+//! `mesh_identity` table — cached account identity for room derivation.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "mesh_identity")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub scope: String,
+    pub identity: String,
+    pub source: String,
+    pub resolved_at_ms: i64,
+    pub ttl_ms: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/airc-store/src/entities/mod.rs
+++ b/crates/airc-store/src/entities/mod.rs
@@ -13,9 +13,11 @@
 //!     `identity.key`. Secret material stays on disk; this table
 //!     holds the `peer_id` / `client_id` / version / created_at
 //!     bookkeeping that lived in `identity.json` before Phase 3.5.
+//!   - `mesh_identity` — cached account identity for room derivation.
 
 pub mod event;
 pub mod local_identity;
+pub mod mesh_identity;
 pub mod peer_rotation_audit;
 pub mod peer_trust;
 pub mod runtime_cursor;

--- a/crates/airc-store/src/lib.rs
+++ b/crates/airc-store/src/lib.rs
@@ -32,6 +32,7 @@
 pub mod entities;
 pub mod error;
 pub mod memory;
+pub mod mesh_identity;
 pub mod migration;
 pub mod peer_trust;
 pub mod sqlite;
@@ -40,6 +41,7 @@ pub mod subscriptions;
 
 pub use error::StoreError;
 pub use memory::InMemoryEventStore;
+pub use mesh_identity::StoredMeshIdentity;
 pub use peer_trust::{RotationAuditEntry, StoredPeer};
 pub use sqlite::{SqliteEventStore, StoredLocalIdentity};
 pub use store::EventStore;

--- a/crates/airc-store/src/memory.rs
+++ b/crates/airc-store/src/memory.rs
@@ -9,6 +9,7 @@ use std::sync::Mutex;
 use airc_core::{RoomId, TranscriptCursor, TranscriptEvent};
 
 use crate::error::StoreError;
+use crate::mesh_identity::StoredMeshIdentity;
 use crate::store::EventStore;
 use crate::subscriptions::StoredSubscription;
 
@@ -16,6 +17,7 @@ pub struct InMemoryEventStore {
     events: Mutex<Vec<TranscriptEvent>>,
     runtime_cursors: Mutex<BTreeMap<String, TranscriptCursor>>,
     subscriptions: Mutex<Vec<StoredSubscription>>,
+    mesh_identities: Mutex<BTreeMap<String, StoredMeshIdentity>>,
 }
 
 impl InMemoryEventStore {
@@ -24,6 +26,7 @@ impl InMemoryEventStore {
             events: Mutex::new(Vec::new()),
             runtime_cursors: Mutex::new(BTreeMap::new()),
             subscriptions: Mutex::new(Vec::new()),
+            mesh_identities: Mutex::new(BTreeMap::new()),
         }
     }
 }
@@ -133,6 +136,26 @@ impl EventStore for InMemoryEventStore {
             .lock()
             .map_err(|_| StoreError::LockPoisoned)?;
         *subscriptions = rows;
+        Ok(())
+    }
+
+    async fn load_mesh_identity(
+        &self,
+        scope: &str,
+    ) -> Result<Option<StoredMeshIdentity>, StoreError> {
+        let identities = self
+            .mesh_identities
+            .lock()
+            .map_err(|_| StoreError::LockPoisoned)?;
+        Ok(identities.get(scope).cloned())
+    }
+
+    async fn save_mesh_identity(&self, entry: StoredMeshIdentity) -> Result<(), StoreError> {
+        let mut identities = self
+            .mesh_identities
+            .lock()
+            .map_err(|_| StoreError::LockPoisoned)?;
+        identities.insert(entry.scope.clone(), entry);
         Ok(())
     }
 }

--- a/crates/airc-store/src/mesh_identity.rs
+++ b/crates/airc-store/src/mesh_identity.rs
@@ -1,0 +1,10 @@
+//! Mesh identity store types.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredMeshIdentity {
+    pub scope: String,
+    pub identity: String,
+    pub source: String,
+    pub resolved_at_ms: u64,
+    pub ttl_ms: u64,
+}

--- a/crates/airc-store/src/migration/m20260522_000006_create_mesh_identity.rs
+++ b/crates/airc-store/src/migration/m20260522_000006_create_mesh_identity.rs
@@ -1,0 +1,50 @@
+//! Add ORM-owned mesh identity cache.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(MeshIdentity::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(MeshIdentity::Scope)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(MeshIdentity::Identity).string().not_null())
+                    .col(ColumnDef::new(MeshIdentity::Source).string().not_null())
+                    .col(
+                        ColumnDef::new(MeshIdentity::ResolvedAtMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(MeshIdentity::TtlMs).big_integer().not_null())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(MeshIdentity::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum MeshIdentity {
+    Table,
+    Scope,
+    Identity,
+    Source,
+    ResolvedAtMs,
+    TtlMs,
+}

--- a/crates/airc-store/src/migration/mod.rs
+++ b/crates/airc-store/src/migration/mod.rs
@@ -12,6 +12,7 @@ mod m20260522_000002_create_runtime_cursors;
 mod m20260522_000003_create_peer_trust;
 mod m20260522_000004_create_subscriptions;
 mod m20260522_000005_create_local_identity;
+mod m20260522_000006_create_mesh_identity;
 
 pub struct Migrator;
 
@@ -24,6 +25,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260522_000003_create_peer_trust::Migration),
             Box::new(m20260522_000004_create_subscriptions::Migration),
             Box::new(m20260522_000005_create_local_identity::Migration),
+            Box::new(m20260522_000006_create_mesh_identity::Migration),
         ]
     }
 }

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -30,9 +30,11 @@ use airc_core::{
 };
 
 use crate::entities::{
-    event, local_identity, peer_rotation_audit, peer_trust, runtime_cursor, subscription,
+    event, local_identity, mesh_identity, peer_rotation_audit, peer_trust, runtime_cursor,
+    subscription,
 };
 use crate::error::StoreError;
+use crate::mesh_identity::StoredMeshIdentity;
 use crate::migration::Migrator;
 use crate::peer_trust::{RotationAuditEntry, StoredPeer};
 use crate::store::EventStore;
@@ -502,6 +504,52 @@ impl EventStore for SqliteEventStore {
         txn.commit().await?;
         Ok(())
     }
+
+    async fn load_mesh_identity(
+        &self,
+        scope: &str,
+    ) -> Result<Option<StoredMeshIdentity>, StoreError> {
+        let row = mesh_identity::Entity::find_by_id(scope.to_string())
+            .one(&self.db)
+            .await?;
+        row.map(|row| {
+            Ok(StoredMeshIdentity {
+                scope: row.scope,
+                identity: row.identity,
+                source: row.source,
+                resolved_at_ms: i64_to_u64("mesh_identity.resolved_at_ms", row.resolved_at_ms)?,
+                ttl_ms: i64_to_u64("mesh_identity.ttl_ms", row.ttl_ms)?,
+            })
+        })
+        .transpose()
+    }
+
+    async fn save_mesh_identity(&self, entry: StoredMeshIdentity) -> Result<(), StoreError> {
+        let active = mesh_identity::ActiveModel {
+            scope: ActiveValue::Set(entry.scope),
+            identity: ActiveValue::Set(entry.identity),
+            source: ActiveValue::Set(entry.source),
+            resolved_at_ms: ActiveValue::Set(u64_to_i64(
+                "mesh_identity.resolved_at_ms",
+                entry.resolved_at_ms,
+            )?),
+            ttl_ms: ActiveValue::Set(u64_to_i64("mesh_identity.ttl_ms", entry.ttl_ms)?),
+        };
+        mesh_identity::Entity::insert(active)
+            .on_conflict(
+                OnConflict::column(mesh_identity::Column::Scope)
+                    .update_columns([
+                        mesh_identity::Column::Identity,
+                        mesh_identity::Column::Source,
+                        mesh_identity::Column::ResolvedAtMs,
+                        mesh_identity::Column::TtlMs,
+                    ])
+                    .to_owned(),
+            )
+            .exec(&self.db)
+            .await?;
+        Ok(())
+    }
 }
 
 fn to_active_model(ev: &TranscriptEvent) -> Result<event::ActiveModel, StoreError> {
@@ -885,6 +933,35 @@ mod tests {
 
         let reopened = SqliteEventStore::open_path(&path).await.unwrap();
         assert_eq!(reopened.load_subscriptions().await.unwrap(), rows);
+    }
+
+    #[tokio::test]
+    async fn mesh_identity_upserts_and_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.sqlite");
+        let first = StoredMeshIdentity {
+            scope: "default".to_string(),
+            identity: "alice".to_string(),
+            source: "operator".to_string(),
+            resolved_at_ms: 1,
+            ttl_ms: 86_400_000,
+        };
+        let second = StoredMeshIdentity {
+            identity: "bob".to_string(),
+            resolved_at_ms: 2,
+            ..first.clone()
+        };
+
+        let store = SqliteEventStore::open_path(&path).await.unwrap();
+        assert!(store.load_mesh_identity("default").await.unwrap().is_none());
+        store.save_mesh_identity(first).await.unwrap();
+        store.save_mesh_identity(second.clone()).await.unwrap();
+
+        let reopened = SqliteEventStore::open_path(&path).await.unwrap();
+        assert_eq!(
+            reopened.load_mesh_identity("default").await.unwrap(),
+            Some(second)
+        );
     }
 
     #[tokio::test]

--- a/crates/airc-store/src/store.rs
+++ b/crates/airc-store/src/store.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use airc_core::{RoomId, TranscriptCursor, TranscriptEvent};
 
 use crate::error::StoreError;
+use crate::mesh_identity::StoredMeshIdentity;
 use crate::subscriptions::StoredSubscription;
 
 /// Durable transcript event store.
@@ -84,4 +85,13 @@ pub trait EventStore: Send + Sync {
     /// owns the durable table and never mirrors this into sidecar
     /// files.
     async fn replace_subscriptions(&self, rows: Vec<StoredSubscription>) -> Result<(), StoreError>;
+
+    /// Load the cached mesh identity row for `scope`, if present.
+    async fn load_mesh_identity(
+        &self,
+        scope: &str,
+    ) -> Result<Option<StoredMeshIdentity>, StoreError>;
+
+    /// Upsert the cached mesh identity row for its `scope`.
+    async fn save_mesh_identity(&self, entry: StoredMeshIdentity) -> Result<(), StoreError>;
 }

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -198,7 +198,7 @@ Move to SeaORM entities (one row, one table, one transaction):
 | `subscriptions.json` | `subscriptions` table (done in store-backed subscriptions cut) |
 | `room.json` (current room marker) | `subscriptions.is_default` (done in store-backed subscriptions cut) |
 | `identity.json` (singleton) | `identity` table (singleton row) |
-| `mesh_identity` cache file | `mesh_identity` table (or column on identity) |
+| `mesh_identity` cache file | `mesh_identity` table (done in store-backed mesh identity cut) |
 | `account_registry/*.json` | `account_registry` table |
 | `coordinator/*.beacon` | `beacons` table with `ttl_expires_at` |
 | `codex_hook_cursor.json` + `join_feed_cursor.{client}.json` | `cursors` table (per-runtime-client, per-channel) |
@@ -243,8 +243,7 @@ five concrete hotpaths and seven kill-list patterns.
    peer trust moved to SeaORM in #883 and subscriptions/default-room
    moved to the `subscriptions` table in the store-backed
    subscriptions cut. Remaining file-backed runtime state is
-   identity, mesh-identity cache, account registry, and coordinator
-   beacons.
+   identity, account registry, and coordinator beacons.
 
 2. **Double clone of `TranscriptEvent` on every ingest** —
    `messaging.rs:110`, `transport.rs:124`. Each event is cloned
@@ -270,8 +269,8 @@ five concrete hotpaths and seven kill-list patterns.
 ### Substrate-wide patterns to kill (priority order)
 
 1. **Synchronous file I/O in async functions** — identity,
-   mesh-identity cache, account registry, and coordinator beacon
-   reads still need SeaORM cuts. Peer trust and subscriptions are now
+   account registry, and coordinator beacon reads still need SeaORM
+   cuts. Peer trust, subscriptions, and mesh identity are now
    store-backed.
 2. **`RwLock<HashMap>` at global granularity** — PeerKeyRegistry,
    route_health, route_endpoints, imported_invites. Switch to


### PR DESCRIPTION
## Summary
- add an ORM-backed `mesh_identity` table for the account identity cache
- route mesh identity resolution through the `EventStore` trait instead of `mesh_identity.json`
- update `Airc` join/current-room/account-registry paths to await the store-backed resolver
- update tests to seed mesh identity through the store and document the completed ORM cut

## Verification
- cargo fmt --all
- cargo test -p airc-store mesh_identity
- cargo test -p airc-lib mesh_identity
- cargo test -p airc-cli join_without_args_uses_default_account_context
- cargo clippy -p airc-store -p airc-lib -p airc-cli --all-targets -- -D warnings
- cargo test --workspace