### PR TITLE
fix(store): persist account registry through ORM

### DIFF
--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -11,21 +11,22 @@
 //! media, and model payloads are explicitly out of scope.
 
 use std::collections::HashMap;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+
+use airc_store::{SqliteEventStore, StoredAccountRegistry};
 
 use crate::coordinator::{CoordinatorSnapshot, PresenceBeacon};
 use crate::error::AircError;
 use crate::registry::PeerSpec;
 use crate::route::{InviteBeacon, RouteEndpoint};
 use crate::subscriptions::{ChannelName, MeshIdentity};
+use crate::time;
 use crate::Airc;
 
 pub const ACCOUNT_REGISTRY_SCHEMA_VERSION: u16 = 1;
-const REGISTRY_FILENAME: &str = "registry.json";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccountRegistryDocument {
@@ -175,95 +176,72 @@ pub trait AccountRegistryStore: Send + Sync {
     ) -> Result<Option<AccountRegistryDocument>, AccountRegistryError>;
 }
 
-#[derive(Debug, Clone)]
-pub struct FileAccountRegistryStore {
-    root: PathBuf,
+/// Store-backed local cache of account-registry documents.
+///
+/// Replaces the previous on-disk `<root>/<mesh-identity>/registry.json`
+/// sidecar with a row in the `account_registry` SeaORM table. Pairs
+/// well with remote adapters (e.g. `GhAccountRegistryStore`) — those
+/// publish to a remote rendezvous and use this store as the local
+/// cache of "what we last sent/received."
+#[derive(Clone)]
+pub struct SqliteAccountRegistryStore {
+    store: Arc<SqliteEventStore>,
 }
 
-impl FileAccountRegistryStore {
-    pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
-    }
-
-    pub fn root(&self) -> &Path {
-        &self.root
-    }
-
-    fn path_for(&self, mesh_identity: &MeshIdentity) -> PathBuf {
-        self.root
-            .join(safe_component(mesh_identity.as_str()))
-            .join(REGISTRY_FILENAME)
+impl SqliteAccountRegistryStore {
+    pub fn new(store: Arc<SqliteEventStore>) -> Self {
+        Self { store }
     }
 }
 
 #[async_trait]
-impl AccountRegistryStore for FileAccountRegistryStore {
+impl AccountRegistryStore for SqliteAccountRegistryStore {
     async fn publish(
         &self,
         document: &AccountRegistryDocument,
     ) -> Result<(), AccountRegistryError> {
         document.validate()?;
-        let path = self.path_for(&document.mesh_identity);
-        let parent = path
-            .parent()
-            .ok_or_else(|| AccountRegistryError::Adapter("registry path has no parent".into()))?;
-        fs::create_dir_all(parent).map_err(|error| {
-            AccountRegistryError::Adapter(format!(
-                "create registry dir {}: {error}",
-                parent.display()
-            ))
-        })?;
-        let tmp = path.with_extension("json.tmp");
-        let text = serde_json::to_string_pretty(document).map_err(|error| {
+        let document_json = serde_json::to_string(document).map_err(|error| {
             AccountRegistryError::Adapter(format!("serialize registry document: {error}"))
         })?;
-        fs::write(&tmp, text).map_err(|error| {
-            AccountRegistryError::Adapter(format!("write registry tmp {}: {error}", tmp.display()))
+        let now_ms = time::now_ms().map_err(|error| {
+            AccountRegistryError::Adapter(format!("clock for registry save: {error}"))
         })?;
-        fs::rename(&tmp, &path).map_err(|error| {
-            AccountRegistryError::Adapter(format!(
-                "publish registry {} -> {}: {error}",
-                tmp.display(),
-                path.display()
-            ))
-        })?;
-        Ok(())
+        self.store
+            .save_account_registry(StoredAccountRegistry {
+                mesh_identity: document.mesh_identity.as_str().to_string(),
+                schema_version: document.schema_version,
+                generated_at_ms: document.generated_at_ms,
+                document_json,
+                updated_at_ms: now_ms,
+            })
+            .await
+            .map_err(|error| {
+                AccountRegistryError::Adapter(format!("persist registry document: {error}"))
+            })
     }
 
     async fn refresh(
         &self,
         mesh_identity: &MeshIdentity,
     ) -> Result<Option<AccountRegistryDocument>, AccountRegistryError> {
-        let path = self.path_for(mesh_identity);
-        let text = match fs::read_to_string(&path) {
-            Ok(text) => text,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(error) => {
-                return Err(AccountRegistryError::Adapter(format!(
-                    "read registry {}: {error}",
-                    path.display()
-                )));
-            }
+        let row = self
+            .store
+            .load_account_registry(mesh_identity.as_str())
+            .await
+            .map_err(|error| {
+                AccountRegistryError::Adapter(format!("load registry document: {error}"))
+            })?;
+        let Some(stored) = row else {
+            return Ok(None);
         };
-        let document: AccountRegistryDocument = serde_json::from_str(&text).map_err(|error| {
-            AccountRegistryError::Adapter(format!("parse registry {}: {error}", path.display()))
-        })?;
+        let document: AccountRegistryDocument = serde_json::from_str(&stored.document_json)
+            .map_err(|error| {
+                AccountRegistryError::Adapter(format!("parse registry document: {error}"))
+            })?;
         document.validate()?;
         Ok(Some(document))
     }
-}
-
-fn safe_component(value: &str) -> String {
-    value
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
-                c
-            } else {
-                '-'
-            }
-        })
-        .collect()
 }
 
 impl Airc {
@@ -479,10 +457,18 @@ mod tests {
         ));
     }
 
+    async fn sqlite_registry_store_at(dir: &std::path::Path) -> SqliteAccountRegistryStore {
+        let path = dir.join("events.sqlite");
+        let event_store = airc_store::SqliteEventStore::open_path(&path)
+            .await
+            .unwrap();
+        SqliteAccountRegistryStore::new(Arc::new(event_store))
+    }
+
     #[tokio::test]
-    async fn file_registry_store_publishes_and_refreshes_document() {
+    async fn sqlite_registry_store_publishes_and_refreshes_document() {
         let dir = tempdir().unwrap();
-        let store = FileAccountRegistryStore::new(dir.path().join("registry"));
+        let store = sqlite_registry_store_at(&dir.path().join("registry")).await;
         let peer_id = PeerId::new();
         let document = AccountRegistryDocument::new(
             mesh(),
@@ -505,7 +491,6 @@ mod tests {
         let refreshed = store.refresh(&mesh()).await.unwrap().unwrap();
 
         assert_eq!(refreshed, document);
-        assert!(store.root().join("joelteply/registry.json").is_file());
     }
 
     #[tokio::test]
@@ -566,13 +551,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn file_registry_bridges_two_isolated_machine_homes() {
+    async fn sqlite_registry_bridges_two_isolated_machine_homes() {
         let dir = tempdir().unwrap();
         let machine_a = dir.path().join("machine-a/.airc");
         let machine_b = dir.path().join("machine-b/.airc");
         write_identity(&machine_a).await;
         write_identity(&machine_b).await;
-        let store = FileAccountRegistryStore::new(dir.path().join("remote-registry"));
+        let store = sqlite_registry_store_at(&dir.path().join("remote-registry")).await;
 
         let airc_a = Airc::open(&machine_a).await.unwrap();
         airc_a.join("general").await.unwrap();

--- a/crates/airc-lib/src/gh_account_registry.rs
+++ b/crates/airc-lib/src/gh_account_registry.rs
@@ -15,11 +15,11 @@
 //!   gist; gist private)
 //! - **Description marker:** `airc-account-mesh-registry` (used for
 //!   discovery filtering on `gh gist list`)
-//! - **One gist per machine.** The local `airc-registry-gist-id`
-//!   sentinel under `<wire_root>/` records this machine's gist id so
-//!   subsequent publishes update the same gist instead of creating
-//!   duplicates. If the sentinel is missing on first publish, a new
-//!   gist is created and the id is persisted.
+//! - **One gist per machine.** The per-mesh-identity gist-id
+//!   sentinel row in `account_registry_gist_sentinel` records this
+//!   machine's gist id so subsequent publishes update the same gist
+//!   instead of creating duplicates. If the sentinel is missing on
+//!   first publish, a new gist is created and the id is persisted.
 //! - **Refresh merges all matching gists.** A scope joining on a
 //!   third+ machine sees both other machines' beacons without any
 //!   server-side coordination.
@@ -40,6 +40,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -48,10 +49,13 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 use tokio::time::{timeout, Duration};
 
+use airc_store::{SqliteEventStore, StoredAccountRegistryGistSentinel};
+
 use crate::account_registry::{
     AccountRegistryDocument, AccountRegistryError, AccountRegistryStore,
 };
 use crate::subscriptions::MeshIdentity;
+use crate::time;
 
 /// Filename used for the registry blob inside each per-machine gist.
 const REGISTRY_FILENAME: &str = "airc-account-mesh-registry.json";
@@ -59,29 +63,29 @@ const REGISTRY_FILENAME: &str = "airc-account-mesh-registry.json";
 /// across versions — bumping this constant would orphan existing
 /// registries.
 const REGISTRY_DESCRIPTION: &str = "airc-account-mesh-registry";
-/// Local sentinel that records this machine's gist id so subsequent
-/// publishes update the same gist instead of creating duplicates.
-const GIST_ID_FILENAME: &str = "account-registry-gist-id";
 
 /// gh-gist-backed account-registry store.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct GhAccountRegistryStore {
     gh_bin: PathBuf,
-    sentinel_root: PathBuf,
+    store: Arc<SqliteEventStore>,
 }
 
 impl GhAccountRegistryStore {
-    /// Construct a new store. `sentinel_root` is the directory where
-    /// the local-gist-id sentinel will be persisted — typically the
-    /// machine-account home `~/.airc/`.
-    pub fn new(sentinel_root: impl Into<PathBuf>) -> Self {
+    /// Construct a new store. The `store` handle is where this
+    /// adapter persists the per-mesh-identity gist-id sentinel that
+    /// lets subsequent publishes update the same gist rather than
+    /// creating duplicates. Typically the same SqliteEventStore the
+    /// machine-account home (`~/.airc/events.sqlite`) uses, but any
+    /// store with the account_registry tables works.
+    pub fn new(store: Arc<SqliteEventStore>) -> Self {
         Self {
             gh_bin: PathBuf::from(
                 std::env::var_os("AIRC_GH_BIN")
                     .map(|s| s.to_string_lossy().into_owned())
                     .unwrap_or_else(|| "gh".into()),
             ),
-            sentinel_root: sentinel_root.into(),
+            store,
         }
     }
 
@@ -91,25 +95,53 @@ impl GhAccountRegistryStore {
         self
     }
 
-    fn sentinel_path(&self) -> PathBuf {
-        self.sentinel_root.join(GIST_ID_FILENAME)
+    async fn load_gist_id(
+        &self,
+        mesh_identity: &MeshIdentity,
+    ) -> Result<Option<String>, AccountRegistryError> {
+        let row = self
+            .store
+            .load_account_registry_gist_sentinel(mesh_identity.as_str())
+            .await
+            .map_err(|error| {
+                AccountRegistryError::Adapter(format!("load gist sentinel: {error}"))
+            })?;
+        Ok(row.and_then(|s| {
+            let trimmed = s.gist_id.trim().to_string();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        }))
     }
 
-    fn load_gist_id(&self) -> Option<String> {
-        std::fs::read_to_string(self.sentinel_path())
-            .ok()
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-    }
-
-    fn save_gist_id(&self, id: &str) -> Result<(), AccountRegistryError> {
-        std::fs::create_dir_all(&self.sentinel_root).map_err(|error| {
-            AccountRegistryError::Adapter(format!("create sentinel dir: {error}"))
+    async fn save_gist_id(
+        &self,
+        mesh_identity: &MeshIdentity,
+        id: &str,
+    ) -> Result<(), AccountRegistryError> {
+        let now_ms = time::now_ms().map_err(|error| {
+            AccountRegistryError::Adapter(format!("clock for gist sentinel save: {error}"))
         })?;
-        let path = self.sentinel_path();
-        std::fs::write(&path, id).map_err(|error| {
-            AccountRegistryError::Adapter(format!("write sentinel {}: {error}", path.display()))
-        })
+        self.store
+            .save_account_registry_gist_sentinel(StoredAccountRegistryGistSentinel {
+                mesh_identity: mesh_identity.as_str().to_string(),
+                gist_id: id.to_string(),
+                updated_at_ms: now_ms,
+            })
+            .await
+            .map_err(|error| AccountRegistryError::Adapter(format!("save gist sentinel: {error}")))
+    }
+
+    async fn clear_gist_id(
+        &self,
+        mesh_identity: &MeshIdentity,
+    ) -> Result<(), AccountRegistryError> {
+        self.store
+            .clear_account_registry_gist_sentinel(mesh_identity.as_str())
+            .await
+            .map_err(|error| AccountRegistryError::Adapter(format!("clear gist sentinel: {error}")))
     }
 
     async fn gh_run(
@@ -157,7 +189,7 @@ impl AccountRegistryStore for GhAccountRegistryStore {
             AccountRegistryError::Adapter(format!("serialize registry: {error}"))
         })?;
 
-        match self.load_gist_id() {
+        match self.load_gist_id(&document.mesh_identity).await? {
             Some(id) => {
                 // Update existing gist. `gh gist edit <id> --filename
                 // <name> -` reads new content from stdin.
@@ -170,7 +202,7 @@ impl AccountRegistryStore for GhAccountRegistryStore {
                 if !ok {
                     // Probably the recorded gist was deleted out-of-
                     // band. Drop the sentinel and retry as create.
-                    let _ = std::fs::remove_file(self.sentinel_path());
+                    let _ = self.clear_gist_id(&document.mesh_identity).await;
                     return Err(AccountRegistryError::Adapter(format!(
                         "gh gist edit {id} failed; sentinel cleared so next publish will recreate. stderr: {stderr}"
                     )));
@@ -204,7 +236,7 @@ impl AccountRegistryStore for GhAccountRegistryStore {
                         "could not parse gist id from gh output: {stdout}"
                     ))
                 })?;
-                self.save_gist_id(&id)?;
+                self.save_gist_id(&document.mesh_identity, &id).await?;
                 Ok(())
             }
         }
@@ -365,12 +397,22 @@ mod tests {
         assert!(extract_gist_id("https://gist.github.com/joelteply/").is_none());
     }
 
-    #[test]
-    fn save_and_load_gist_id_round_trips() {
+    #[tokio::test]
+    async fn save_and_load_gist_id_round_trips() {
         let dir = tempfile::tempdir().unwrap();
-        let store = GhAccountRegistryStore::new(dir.path());
-        assert!(store.load_gist_id().is_none());
-        store.save_gist_id("abc123").unwrap();
-        assert_eq!(store.load_gist_id().as_deref(), Some("abc123"));
+        let event_store =
+            airc_store::SqliteEventStore::open_path(&dir.path().join("events.sqlite"))
+                .await
+                .unwrap();
+        let store = GhAccountRegistryStore::new(Arc::new(event_store));
+        let mesh = MeshIdentity::new("joelteply");
+        assert!(store.load_gist_id(&mesh).await.unwrap().is_none());
+        store.save_gist_id(&mesh, "abc123").await.unwrap();
+        assert_eq!(
+            store.load_gist_id(&mesh).await.unwrap().as_deref(),
+            Some("abc123")
+        );
+        store.clear_gist_id(&mesh).await.unwrap();
+        assert!(store.load_gist_id(&mesh).await.unwrap().is_none());
     }
 }

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -46,7 +46,7 @@ pub mod work;
 
 pub use account_registry::{
     AccountPeerBeacon, AccountRegistryDocument, AccountRegistryError, AccountRegistryStore,
-    FileAccountRegistryStore, ACCOUNT_REGISTRY_SCHEMA_VERSION,
+    SqliteAccountRegistryStore, ACCOUNT_REGISTRY_SCHEMA_VERSION,
 };
 pub use airc::Airc;
 pub use coordinator::{

--- a/crates/airc-store/src/account_registry.rs
+++ b/crates/airc-store/src/account_registry.rs
@@ -1,0 +1,24 @@
+//! Public DTOs for the `account_registry` + `account_registry_gist_sentinel`
+//! tables. Consumers of `airc-store` interact with these typed shapes;
+//! the entity modules (`entities::account_registry`) stay internal.
+
+/// One cached account-registry row. The `document_json` is the
+/// serialized `AccountRegistryDocument` from `airc-lib`; this crate
+/// stays oblivious to its shape on purpose so the store can carry
+/// future document schema changes without recompiling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredAccountRegistry {
+    pub mesh_identity: String,
+    pub schema_version: u16,
+    pub generated_at_ms: u64,
+    pub document_json: String,
+    pub updated_at_ms: u64,
+}
+
+/// One per-mesh-identity gh-gist sentinel row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredAccountRegistryGistSentinel {
+    pub mesh_identity: String,
+    pub gist_id: String,
+    pub updated_at_ms: u64,
+}

--- a/crates/airc-store/src/entities/account_registry.rs
+++ b/crates/airc-store/src/entities/account_registry.rs
@@ -1,0 +1,74 @@
+//! `account_registry` + `account_registry_gist_sentinel` tables.
+//!
+//! The account registry document is the cross-machine snapshot of a
+//! mesh-identity's published peer + channel state, signed once and
+//! exchanged via the rendezvous adapter (gh-gist by default). The
+//! row stored here is the **local cache** of the most recently
+//! published-or-refreshed document for a given mesh identity, plus
+//! the per-mesh-identity gist-id sentinel that lets the gh adapter
+//! recognize "its own" gist on subsequent publishes.
+//!
+//! Treated as wire-payload encoding per non-negotiable #9: the
+//! document body is opaque JSON (a serialized
+//! `AccountRegistryDocument`) because consumers either fetch the
+//! whole document or don't — there is no in-store query for "peers
+//! across all registries." Live presence/peer/subscription state
+//! lives in their respective dedicated tables; the registry is the
+//! sync snapshot, not the source.
+
+pub mod document {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "account_registry")]
+    pub struct Model {
+        /// Mesh identity string (gh login, git email, or local
+        /// fallback) — the same shape used by the
+        /// `subscriptions::MeshIdentity` newtype.
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub mesh_identity: String,
+        /// Schema version copied from the document at save time.
+        /// Read out for the fast-path version check before parsing
+        /// the body.
+        pub schema_version: i32,
+        /// `generated_at_ms` from the document itself (what the
+        /// sender stamped). Distinct from `updated_at_ms`, which is
+        /// when we last wrote the row.
+        pub generated_at_ms: i64,
+        /// Serialized `AccountRegistryDocument` JSON. Opaque to the
+        /// store; consumers parse on read.
+        pub document_json: String,
+        /// Wall-clock timestamp when we last upserted this row.
+        pub updated_at_ms: i64,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod gist_sentinel {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "account_registry_gist_sentinel")]
+    pub struct Model {
+        /// Mesh identity this sentinel belongs to. A machine may
+        /// own multiple mesh identities (work + personal gh
+        /// accounts); each gets its own sentinel.
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub mesh_identity: String,
+        /// gh-gist id this machine owns for this mesh identity.
+        /// Treated as opaque text by the store; the gh adapter
+        /// interprets it.
+        pub gist_id: String,
+        /// Wall-clock timestamp when we last upserted this row.
+        pub updated_at_ms: i64,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}

--- a/crates/airc-store/src/entities/mod.rs
+++ b/crates/airc-store/src/entities/mod.rs
@@ -14,7 +14,12 @@
 //!     holds the `peer_id` / `client_id` / version / created_at
 //!     bookkeeping that lived in `identity.json` before Phase 3.5.
 //!   - `mesh_identity` — cached account identity for room derivation.
+//!   - `account_registry` + `account_registry_gist_sentinel` — local
+//!     cache of the published cross-machine registry document and the
+//!     per-mesh-identity gist-id sentinel that the gh adapter uses
+//!     to recognize its own gist across publishes.
 
+pub mod account_registry;
 pub mod event;
 pub mod local_identity;
 pub mod mesh_identity;

--- a/crates/airc-store/src/lib.rs
+++ b/crates/airc-store/src/lib.rs
@@ -29,6 +29,7 @@
 // signature has to match verbatim. Opt out at the crate level rather
 // than scattering `#[allow(elided_lifetimes_in_paths)]` per impl.
 
+pub mod account_registry;
 pub mod entities;
 pub mod error;
 pub mod memory;
@@ -39,6 +40,7 @@ pub mod sqlite;
 pub mod store;
 pub mod subscriptions;
 
+pub use account_registry::{StoredAccountRegistry, StoredAccountRegistryGistSentinel};
 pub use error::StoreError;
 pub use memory::InMemoryEventStore;
 pub use mesh_identity::StoredMeshIdentity;

--- a/crates/airc-store/src/migration/m20260522_000007_create_account_registry.rs
+++ b/crates/airc-store/src/migration/m20260522_000007_create_account_registry.rs
@@ -1,0 +1,106 @@
+//! Add ORM-owned account registry document cache + per-mesh-identity
+//! gh-gist sentinel table.
+//!
+//! Pairs the two tables in a single migration because they're the
+//! same feature surface (account_registry storage) and we don't
+//! anticipate adding one without the other.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(AccountRegistry::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(AccountRegistry::MeshIdentity)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(AccountRegistry::SchemaVersion)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AccountRegistry::GeneratedAtMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AccountRegistry::DocumentJson)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AccountRegistry::UpdatedAtMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_table(
+                Table::create()
+                    .table(AccountRegistryGistSentinel::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(AccountRegistryGistSentinel::MeshIdentity)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(AccountRegistryGistSentinel::GistId)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AccountRegistryGistSentinel::UpdatedAtMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(AccountRegistryGistSentinel::Table)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_table(Table::drop().table(AccountRegistry::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum AccountRegistry {
+    Table,
+    MeshIdentity,
+    SchemaVersion,
+    GeneratedAtMs,
+    DocumentJson,
+    UpdatedAtMs,
+}
+
+#[derive(DeriveIden)]
+enum AccountRegistryGistSentinel {
+    Table,
+    MeshIdentity,
+    GistId,
+    UpdatedAtMs,
+}

--- a/crates/airc-store/src/migration/mod.rs
+++ b/crates/airc-store/src/migration/mod.rs
@@ -13,6 +13,7 @@ mod m20260522_000003_create_peer_trust;
 mod m20260522_000004_create_subscriptions;
 mod m20260522_000005_create_local_identity;
 mod m20260522_000006_create_mesh_identity;
+mod m20260522_000007_create_account_registry;
 
 pub struct Migrator;
 
@@ -26,6 +27,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260522_000004_create_subscriptions::Migration),
             Box::new(m20260522_000005_create_local_identity::Migration),
             Box::new(m20260522_000006_create_mesh_identity::Migration),
+            Box::new(m20260522_000007_create_account_registry::Migration),
         ]
     }
 }

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -29,9 +29,10 @@ use airc_core::{
     Body, ClientId, EventId, Headers, PeerId, RoomId, TranscriptCursor, TranscriptEvent,
 };
 
+use crate::account_registry::{StoredAccountRegistry, StoredAccountRegistryGistSentinel};
 use crate::entities::{
-    event, local_identity, mesh_identity, peer_rotation_audit, peer_trust, runtime_cursor,
-    subscription,
+    account_registry, event, local_identity, mesh_identity, peer_rotation_audit, peer_trust,
+    runtime_cursor, subscription,
 };
 use crate::error::StoreError;
 use crate::mesh_identity::StoredMeshIdentity;
@@ -275,6 +276,130 @@ impl SqliteEventStore {
             )?),
         };
         local_identity::Entity::insert(active)
+            .exec(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    /// Load the cached account-registry document for a given mesh
+    /// identity, if any. Returns `Ok(None)` when this scope has
+    /// never published-or-refreshed a document for that identity.
+    pub async fn load_account_registry(
+        &self,
+        mesh_identity: &str,
+    ) -> Result<Option<StoredAccountRegistry>, StoreError> {
+        let row = account_registry::document::Entity::find_by_id(mesh_identity.to_string())
+            .one(&self.db)
+            .await?;
+        row.map(|m| {
+            Ok(StoredAccountRegistry {
+                mesh_identity: m.mesh_identity,
+                schema_version: u16::try_from(m.schema_version).map_err(|_| {
+                    StoreError::InvalidStoredValue {
+                        field: "account_registry.schema_version",
+                        value: m.schema_version as i128,
+                    }
+                })?,
+                generated_at_ms: i64_to_u64("account_registry.generated_at_ms", m.generated_at_ms)?,
+                document_json: m.document_json,
+                updated_at_ms: i64_to_u64("account_registry.updated_at_ms", m.updated_at_ms)?,
+            })
+        })
+        .transpose()
+    }
+
+    /// Upsert the cached account-registry document for a given mesh
+    /// identity. Idempotent on the document body; the `updated_at_ms`
+    /// stamp always reflects the most recent save.
+    pub async fn save_account_registry(
+        &self,
+        document: StoredAccountRegistry,
+    ) -> Result<(), StoreError> {
+        let active = account_registry::document::ActiveModel {
+            mesh_identity: Set(document.mesh_identity.clone()),
+            schema_version: Set(i32::from(document.schema_version)),
+            generated_at_ms: Set(u64_to_i64(
+                "account_registry.generated_at_ms",
+                document.generated_at_ms,
+            )?),
+            document_json: Set(document.document_json),
+            updated_at_ms: Set(u64_to_i64(
+                "account_registry.updated_at_ms",
+                document.updated_at_ms,
+            )?),
+        };
+        account_registry::document::Entity::insert(active)
+            .on_conflict(
+                OnConflict::column(account_registry::document::Column::MeshIdentity)
+                    .update_columns([
+                        account_registry::document::Column::SchemaVersion,
+                        account_registry::document::Column::GeneratedAtMs,
+                        account_registry::document::Column::DocumentJson,
+                        account_registry::document::Column::UpdatedAtMs,
+                    ])
+                    .to_owned(),
+            )
+            .exec(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    /// Load the gh-gist sentinel for a given mesh identity, if any.
+    pub async fn load_account_registry_gist_sentinel(
+        &self,
+        mesh_identity: &str,
+    ) -> Result<Option<StoredAccountRegistryGistSentinel>, StoreError> {
+        let row = account_registry::gist_sentinel::Entity::find_by_id(mesh_identity.to_string())
+            .one(&self.db)
+            .await?;
+        row.map(|m| {
+            Ok(StoredAccountRegistryGistSentinel {
+                mesh_identity: m.mesh_identity,
+                gist_id: m.gist_id,
+                updated_at_ms: i64_to_u64(
+                    "account_registry_gist_sentinel.updated_at_ms",
+                    m.updated_at_ms,
+                )?,
+            })
+        })
+        .transpose()
+    }
+
+    /// Delete the gh-gist sentinel for a given mesh identity.
+    /// Used when the remote gist was edited-or-deleted out of band
+    /// and the local recording is stale.
+    pub async fn clear_account_registry_gist_sentinel(
+        &self,
+        mesh_identity: &str,
+    ) -> Result<(), StoreError> {
+        account_registry::gist_sentinel::Entity::delete_by_id(mesh_identity.to_string())
+            .exec(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    /// Upsert the gh-gist sentinel for a given mesh identity.
+    pub async fn save_account_registry_gist_sentinel(
+        &self,
+        sentinel: StoredAccountRegistryGistSentinel,
+    ) -> Result<(), StoreError> {
+        let active = account_registry::gist_sentinel::ActiveModel {
+            mesh_identity: Set(sentinel.mesh_identity.clone()),
+            gist_id: Set(sentinel.gist_id),
+            updated_at_ms: Set(u64_to_i64(
+                "account_registry_gist_sentinel.updated_at_ms",
+                sentinel.updated_at_ms,
+            )?),
+        };
+        account_registry::gist_sentinel::Entity::insert(active)
+            .on_conflict(
+                OnConflict::column(account_registry::gist_sentinel::Column::MeshIdentity)
+                    .update_columns([
+                        account_registry::gist_sentinel::Column::GistId,
+                        account_registry::gist_sentinel::Column::UpdatedAtMs,
+                    ])
+                    .to_owned(),
+            )
             .exec(&self.db)
             .await?;
         Ok(())


### PR DESCRIPTION
## Summary

Phase 3.5 continuation. Two more JSON sidecars eliminated:

1. **Per-mesh-identity registry document** — used to live at \`<root>/<mesh-identity>/registry.json\`. Now backed by an \`account_registry\` table keyed by mesh_identity, with schema_version + generated_at + the document body as opaque JSON (treated as wire-payload encoding per non-neg #9 — the document is a published snapshot for cross-machine sync; live peer/subscription state lives in their own dedicated tables).

2. **Gh-gist sentinel** — used a per-machine file \`<sentinel_root>/account-registry-gist-id\` (no mesh-identity scoping). Now a row in \`account_registry_gist_sentinel\` keyed by mesh_identity, so a single machine can carry multiple mesh identities without their gist ids colliding.

## Changes

- New entity module \`entities::account_registry\` with two submodules (document, gist_sentinel) sharing one migration.
- Migration #7 \`m20260522_000007_create_account_registry\` (strictly additive; both tables in one file because they're the same feature surface).
- DTOs \`StoredAccountRegistry\`, \`StoredAccountRegistryGistSentinel\` in a small \`account_registry\` module on airc-store.
- \`SqliteEventStore\` gains load/save/clear methods for both rows; save uses ON CONFLICT UPDATE upsert, clear deletes by PK.
- airc-lib:
    - \`FileAccountRegistryStore\` → \`SqliteAccountRegistryStore\`. Wraps an \`Arc<SqliteEventStore>\`. No \`pub use FileAccountRegistryStore\` callers existed outside tests, so the rename is a clean swap.
    - \`GhAccountRegistryStore\` now takes \`Arc<SqliteEventStore>\` instead of \`sentinel_root: PathBuf\`. Sentinel load/save/clear go through the store; no more \`std::fs::*\` on the sentinel path.
    - Tests adjusted to use \`SqliteEventStore::open_path\` for the registry-side store.

## Doctrine alignment

Non-negotiable #9 ("Durable substrate data uses the store/ORM boundary"). The document body remains JSON because it's wire-payload encoding for cross-machine sync — the allowance the non-negotiable carves out for "wire payload encoding ... external invite documents." Per-row identifiers (mesh_identity, gist_id, schema_version) are typed columns with indexes, not JSON-buried fields.

## Verification

- \`cargo test --workspace\` green (35 store tests, 146 lib tests, all suites pass)
- \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- \`cargo fmt --check\` clean

## Remaining Phase 3.5

- Coordinator beacons (the local \`accounts/\` beacon directory under wire_root)
- Codex's lane: hook/feed cursor JSON cleanup (already in flight per their last airc lane claim)

## Test plan

- [x] Workspace tests, clippy, fmt
- [ ] CI: 3-OS tests + runtime guards + public install proof
- [ ] After merge: existing installs that had \`<sentinel_root>/account-registry-gist-id\` will silently lose the gist id on first publish; the gh adapter will create a fresh gist and persist its id to the new sentinel table. The orphaned old gist remains in the user's gh account; can be deleted manually. Consistent backward-compat trade with #883/#884/#885/#886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)