### PR TITLE
fix(store): persist coordinator beacons through ORM

### DIFF
--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -247,12 +247,13 @@ impl AccountRegistryStore for SqliteAccountRegistryStore {
 impl Airc {
     pub async fn account_registry_document(&self) -> Result<AccountRegistryDocument, AircError> {
         let identity = self.mesh_identity().await?;
-        let snapshot = crate::coordinator::snapshot(
-            &self.inner.wire_root,
+        let snapshot = crate::coordinator::snapshot_store(
+            self.coordinator_store(),
             &identity,
             &crate::coordinator::CoordinatorConfig::default(),
             crate::time::now_ms()?,
-        )?;
+        )
+        .await?;
         let mut peer_specs = vec![PeerSpec {
             peer_id: self.inner.identity.peer_id,
             pubkey: self.inner.identity.keypair.public_bytes(),
@@ -310,11 +311,12 @@ impl Airc {
             )
             .await?;
             self.enrol_volatile_peer(&peer.peer_spec)?;
-            crate::coordinator::publish(
-                &self.inner.wire_root,
+            crate::coordinator::publish_store(
+                self.coordinator_store(),
                 &document.mesh_identity,
                 &peer.presence,
-            )?;
+            )
+            .await?;
             self.import_invite_beacon(peer.invite_beacon()).await?;
         }
         self.sync_account_peer_registry().await?;
@@ -531,12 +533,13 @@ mod tests {
             .await
             .unwrap();
         assert!(peers.iter().any(|peer| peer.peer_id == spec.peer_id));
-        let snapshot = crate::coordinator::snapshot(
-            &airc.inner.wire_root,
+        let snapshot = crate::coordinator::snapshot_store(
+            airc.event_store(),
             &mesh(),
             &Default::default(),
             1_000,
         )
+        .await
         .unwrap();
         assert!(snapshot
             .live
@@ -571,12 +574,13 @@ mod tests {
             .await
             .unwrap();
         assert!(peers.iter().any(|peer| peer.peer_id == airc_a.peer_id()));
-        let snapshot = crate::coordinator::snapshot(
-            &airc_b.inner.wire_root,
+        let snapshot = crate::coordinator::snapshot_store(
+            airc_b.event_store(),
             &mesh(),
             &Default::default(),
             u64::MAX,
         )
+        .await
         .unwrap();
         assert!(snapshot
             .stale

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -534,7 +534,7 @@ mod tests {
             .unwrap();
         assert!(peers.iter().any(|peer| peer.peer_id == spec.peer_id));
         let snapshot = crate::coordinator::snapshot_store(
-            airc.event_store(),
+            airc.coordinator_store(),
             &mesh(),
             &Default::default(),
             1_000,
@@ -575,7 +575,7 @@ mod tests {
             .unwrap();
         assert!(peers.iter().any(|peer| peer.peer_id == airc_a.peer_id()));
         let snapshot = crate::coordinator::snapshot_store(
-            airc_b.event_store(),
+            airc_b.coordinator_store(),
             &mesh(),
             &Default::default(),
             u64::MAX,

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -114,6 +114,7 @@ pub(crate) struct AircInner {
     pub(crate) wire_root: PathBuf,
     pub(crate) identity: LocalIdentity,
     pub(crate) store: Arc<dyn EventStore>,
+    pub(crate) coordinator_store: Arc<dyn EventStore>,
     pub(crate) daemon_client: Option<Arc<DaemonClient>>,
     pub(crate) registry: Arc<RwLock<PeerKeyRegistry>>,
     pub(crate) policy: VerificationPolicy,
@@ -197,6 +198,9 @@ impl Airc {
 
         let store_path = home.join(EVENTS_DB_FILENAME);
         let store: Arc<dyn EventStore> = Arc::new(SqliteEventStore::open_path(&store_path).await?);
+        let coordinator_store_path = wire_root.join(EVENTS_DB_FILENAME);
+        let coordinator_store: Arc<dyn EventStore> =
+            Arc::new(SqliteEventStore::open_path(&coordinator_store_path).await?);
 
         let mut registry = PeerKeyRegistry::new();
         registry
@@ -227,6 +231,7 @@ impl Airc {
                 home,
                 identity,
                 store,
+                coordinator_store,
                 daemon_client: None,
                 registry,
                 policy,
@@ -288,6 +293,7 @@ impl Airc {
             wire_root: self.inner.wire_root.clone(),
             identity: self.inner.identity.clone(),
             store: self.inner.store.clone(),
+            coordinator_store: self.inner.coordinator_store.clone(),
             daemon_client: Some(Arc::new(client)),
             registry: self.inner.registry.clone(),
             policy: self.inner.policy,
@@ -378,7 +384,7 @@ impl Airc {
         Ok(())
     }
 
-    fn publish_presence(
+    async fn publish_presence(
         &self,
         identity: &MeshIdentity,
         set: &subscriptions::SubscriptionSet,
@@ -391,7 +397,7 @@ impl Airc {
             std::process::id(),
             time::now_ms()?,
         );
-        coordinator::publish(&self.inner.wire_root, identity, &beacon)?;
+        coordinator::publish_store(self.coordinator_store(), identity, &beacon).await?;
         Ok(())
     }
 
@@ -405,7 +411,7 @@ impl Airc {
             set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
         set.set_default(channel)?;
         subscriptions::save(self.event_store(), &set).await?;
-        self.publish_presence(&identity, &set)?;
+        self.publish_presence(&identity, &set).await?;
         let room = subscription.as_room();
         self.ensure_wire_subscriber(&room.wire).await?;
         Ok(room)
@@ -453,7 +459,7 @@ impl Airc {
             set.set_default(context.default)?;
         }
         subscriptions::save(self.event_store(), &set).await?;
-        self.publish_presence(&identity, &set)?;
+        self.publish_presence(&identity, &set).await?;
 
         for room in &rooms {
             self.ensure_wire_subscriber(&room.wire).await?;
@@ -475,7 +481,7 @@ impl Airc {
         set.subscribed.insert(channel.clone(), subscription.clone());
         set.set_default(channel)?;
         subscriptions::save(self.event_store(), &set).await?;
-        self.publish_presence(&identity, &set)?;
+        self.publish_presence(&identity, &set).await?;
         let room = subscription.as_room();
         self.ensure_wire_subscriber(&room.wire).await?;
         Ok(room)
@@ -496,12 +502,16 @@ impl Airc {
             set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
         set.set_default(channel)?;
         subscriptions::save(self.event_store(), &set).await?;
-        self.publish_presence(&identity, &set)?;
+        self.publish_presence(&identity, &set).await?;
         Ok(subscription.as_room())
     }
 
     pub(crate) fn event_store(&self) -> &dyn EventStore {
         self.inner.store.as_ref()
+    }
+
+    pub(crate) fn coordinator_store(&self) -> &dyn EventStore {
+        self.inner.coordinator_store.as_ref()
     }
 
     /// Load a named runtime consumer checkpoint from the durable

--- a/crates/airc-lib/src/coordinator.rs
+++ b/crates/airc-lib/src/coordinator.rs
@@ -60,10 +60,11 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use airc_core::PeerId;
+use airc_store::{EventStore, StoreError, StoredBeacon};
 
 use crate::coordinator_lock::RefreshLock;
 use crate::fs_permissions;
-use crate::subscriptions::{ChannelName, MeshIdentity};
+use crate::subscriptions::{ChannelName, ChannelNameError, MeshIdentity};
 
 const BEACON_VERSION: u32 = 1;
 const ACCOUNTS_DIR: &str = "accounts";
@@ -153,6 +154,8 @@ pub struct CoordinatorSnapshot {
 pub enum CoordinatorError {
     Io(std::io::Error),
     Json(serde_json::Error),
+    Store(StoreError),
+    Channel(ChannelNameError),
     /// A beacon file existed but its schema version didn't match. We
     /// surface this rather than silently skip so the operator sees
     /// the foreign-version surface.
@@ -168,6 +171,8 @@ impl std::fmt::Display for CoordinatorError {
         match self {
             Self::Io(error) => write!(f, "coordinator I/O: {error}"),
             Self::Json(error) => write!(f, "coordinator JSON: {error}"),
+            Self::Store(error) => write!(f, "coordinator store: {error}"),
+            Self::Channel(error) => write!(f, "coordinator channel: {error}"),
             Self::SchemaVersionMismatch {
                 path,
                 found,
@@ -186,6 +191,8 @@ impl std::error::Error for CoordinatorError {
         match self {
             Self::Io(error) => Some(error),
             Self::Json(error) => Some(error),
+            Self::Store(error) => Some(error),
+            Self::Channel(error) => Some(error),
             Self::SchemaVersionMismatch { .. } => None,
         }
     }
@@ -200,6 +207,18 @@ impl From<std::io::Error> for CoordinatorError {
 impl From<serde_json::Error> for CoordinatorError {
     fn from(value: serde_json::Error) -> Self {
         Self::Json(value)
+    }
+}
+
+impl From<StoreError> for CoordinatorError {
+    fn from(value: StoreError) -> Self {
+        Self::Store(value)
+    }
+}
+
+impl From<ChannelNameError> for CoordinatorError {
+    fn from(value: ChannelNameError) -> Self {
+        Self::Channel(value)
     }
 }
 
@@ -263,6 +282,17 @@ pub fn publish(
     Ok(())
 }
 
+pub async fn publish_store(
+    store: &dyn EventStore,
+    identity: &MeshIdentity,
+    beacon: &PresenceBeacon,
+) -> Result<(), CoordinatorError> {
+    store
+        .save_beacon(to_stored_beacon(identity, beacon))
+        .await?;
+    Ok(())
+}
+
 /// Read the caller's own beacon, if it exists. `None` distinguishes
 /// "no prior publish" from "publish exists with stale heartbeat" —
 /// the caller computes freshness from the returned beacon's
@@ -278,6 +308,18 @@ pub fn load_own_beacon(
     }
     let beacon = read_beacon(&path)?;
     Ok(Some(beacon))
+}
+
+pub async fn load_own_beacon_store(
+    store: &dyn EventStore,
+    identity: &MeshIdentity,
+    peer_id: PeerId,
+) -> Result<Option<PresenceBeacon>, CoordinatorError> {
+    store
+        .load_beacon(identity.as_str(), peer_id)
+        .await?
+        .map(from_stored_beacon)
+        .transpose()
 }
 
 /// Build a snapshot of all beacons for a mesh identity. Beacons
@@ -330,6 +372,35 @@ pub fn snapshot(
     })
 }
 
+pub async fn snapshot_store(
+    store: &dyn EventStore,
+    identity: &MeshIdentity,
+    config: &CoordinatorConfig,
+    now_ms: u64,
+) -> Result<CoordinatorSnapshot, CoordinatorError> {
+    let mut live = Vec::new();
+    let mut stale = Vec::new();
+    for beacon in store.list_beacons(identity.as_str()).await? {
+        let beacon = from_stored_beacon(beacon)?;
+        if beacon.is_fresh(now_ms, config.heartbeat_ttl_ms) {
+            live.push(beacon);
+        } else {
+            stale.push(beacon);
+        }
+    }
+    live.sort_by_key(|b| b.peer_id.to_string());
+    stale.sort_by_key(|b| b.peer_id.to_string());
+    let live_channels = unique_channels_in(&live);
+    Ok(CoordinatorSnapshot {
+        mesh_identity: identity.clone(),
+        root: PathBuf::from("airc-store://beacons"),
+        live,
+        stale,
+        live_channels,
+        fetched_at_ms: now_ms,
+    })
+}
+
 /// Delete beacon files for all entries currently in
 /// [`CoordinatorSnapshot::stale`]. Best-effort — missing files
 /// (raced with another draining process) aren't an error. Returns
@@ -352,6 +423,19 @@ pub fn drain_stale(
         }
     }
     Ok(removed)
+}
+
+pub async fn drain_stale_store(
+    store: &dyn EventStore,
+    identity: &MeshIdentity,
+    snapshot: &CoordinatorSnapshot,
+) -> Result<usize, CoordinatorError> {
+    let peer_ids = snapshot
+        .stale
+        .iter()
+        .map(|beacon| beacon.peer_id)
+        .collect::<Vec<_>>();
+    Ok(store.delete_beacons(identity.as_str(), &peer_ids).await?)
 }
 
 /// Outcome of attempting to acquire the remote-refresh lock.
@@ -453,6 +537,39 @@ fn unique_channels_in(beacons: &[PresenceBeacon]) -> Vec<ChannelName> {
     out
 }
 
+fn to_stored_beacon(identity: &MeshIdentity, beacon: &PresenceBeacon) -> StoredBeacon {
+    StoredBeacon {
+        mesh_identity: identity.as_str().to_string(),
+        peer_id: beacon.peer_id,
+        scope_home: beacon.scope_home.to_string_lossy().to_string(),
+        subscribed_channels: beacon
+            .subscribed_channels
+            .iter()
+            .map(|channel| channel.as_str().to_string())
+            .collect(),
+        pid: beacon.pid,
+        published_at_ms: beacon.published_at_ms,
+        heartbeat_at_ms: beacon.heartbeat_at_ms,
+    }
+}
+
+fn from_stored_beacon(beacon: StoredBeacon) -> Result<PresenceBeacon, CoordinatorError> {
+    let subscribed_channels = beacon
+        .subscribed_channels
+        .into_iter()
+        .map(ChannelName::new)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(PresenceBeacon {
+        version: BEACON_VERSION,
+        peer_id: beacon.peer_id,
+        scope_home: PathBuf::from(beacon.scope_home),
+        subscribed_channels,
+        pid: beacon.pid,
+        published_at_ms: beacon.published_at_ms,
+        heartbeat_at_ms: beacon.heartbeat_at_ms,
+    })
+}
+
 /// Convenience: construct a presence beacon at a given timestamp.
 /// Most callers compose this themselves; provided so the common case
 /// (publish-now) is one line.
@@ -537,6 +654,47 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(loaded, beacon);
+    }
+
+    #[tokio::test]
+    async fn store_publish_snapshot_and_drain_round_trip() {
+        let store = airc_store::InMemoryEventStore::new();
+        let mesh = id();
+        let cfg = CoordinatorConfig {
+            heartbeat_ttl_ms: 1_000,
+            refresh_interval_ms: 100,
+        };
+        let fresh = make_beacon(950, vec!["general", "cambriantech"]);
+        let stale = make_beacon(0, vec!["ideem"]);
+
+        publish_store(&store, &mesh, &fresh).await.unwrap();
+        publish_store(&store, &mesh, &stale).await.unwrap();
+
+        let loaded = load_own_beacon_store(&store, &mesh, fresh.peer_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded, fresh);
+
+        let snapshot = snapshot_store(&store, &mesh, &cfg, 1_000).await.unwrap();
+        assert_eq!(snapshot.live.len(), 1);
+        assert_eq!(snapshot.stale.len(), 1);
+        assert_eq!(
+            snapshot
+                .live_channels
+                .iter()
+                .map(ChannelName::as_str)
+                .collect::<Vec<_>>(),
+            vec!["cambriantech", "general"]
+        );
+
+        assert_eq!(
+            drain_stale_store(&store, &mesh, &snapshot).await.unwrap(),
+            1
+        );
+        let after = snapshot_store(&store, &mesh, &cfg, 1_000).await.unwrap();
+        assert!(after.stale.is_empty());
+        assert_eq!(after.live.len(), 1);
     }
 
     #[test]

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -51,10 +51,14 @@ pub use account_registry::{
 pub use airc::Airc;
 pub use coordinator::{
     account_root as coordinator_account_root, beacon_now, drain_stale as coordinator_drain_stale,
-    load_own_beacon as coordinator_load_own_beacon, publish as coordinator_publish,
+    drain_stale_store as coordinator_drain_stale_store,
+    load_own_beacon as coordinator_load_own_beacon,
+    load_own_beacon_store as coordinator_load_own_beacon_store, publish as coordinator_publish,
+    publish_store as coordinator_publish_store,
     release_refresh_lock as coordinator_release_refresh_lock, snapshot as coordinator_snapshot,
-    try_acquire_refresh_lock, CoordinatorConfig, CoordinatorError, CoordinatorSnapshot,
-    PresenceBeacon, RefreshLockOutcome, DEFAULT_HEARTBEAT_TTL_MS as COORDINATOR_HEARTBEAT_TTL_MS,
+    snapshot_store as coordinator_snapshot_store, try_acquire_refresh_lock, CoordinatorConfig,
+    CoordinatorError, CoordinatorSnapshot, PresenceBeacon, RefreshLockOutcome,
+    DEFAULT_HEARTBEAT_TTL_MS as COORDINATOR_HEARTBEAT_TTL_MS,
     DEFAULT_REFRESH_INTERVAL_MS as COORDINATOR_REFRESH_INTERVAL_MS,
 };
 pub use error::AircError;

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -11,9 +11,9 @@ use std::{net::SocketAddr, time::Duration};
 
 use airc_daemon::{DaemonState, LocalIdentity};
 use airc_lib::{
-    coordinator_snapshot, resolve_mesh_identity_with, Airc, Body, ChannelName, CoordinatorConfig,
-    EventFilter, HeaderFilter, Headers, MeshIdentity, MeshIdentitySource, PeerSpec, RouteEndpoint,
-    TranscriptKind, TransportHealthSample, TransportKind, TransportRole,
+    coordinator_snapshot_store, resolve_mesh_identity_with, Airc, Body, ChannelName,
+    CoordinatorConfig, EventFilter, HeaderFilter, Headers, MeshIdentity, MeshIdentitySource,
+    PeerSpec, RouteEndpoint, TranscriptKind, TransportHealthSample, TransportKind, TransportRole,
 };
 use airc_protocol::{PeerKeyRegistry, VerificationPolicy};
 use airc_store::{EventStore, SqliteEventStore};
@@ -429,12 +429,17 @@ fn default_join_context_subscribes_general_and_repo_owner_on_shared_account_wire
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_millis() as u64;
-            let snapshot = coordinator_snapshot(
-                &machine.path().join(".airc"),
+            let coordinator_store =
+                SqliteEventStore::open_path(&machine.path().join(".airc/events.sqlite"))
+                    .await
+                    .unwrap();
+            let snapshot = coordinator_snapshot_store(
+                &coordinator_store,
                 &MeshIdentity::new("joelteply"),
                 &CoordinatorConfig::default(),
                 now_ms,
             )
+            .await
             .unwrap();
             assert_eq!(snapshot.live.len(), 2);
             assert_eq!(

--- a/crates/airc-store/src/beacon.rs
+++ b/crates/airc-store/src/beacon.rs
@@ -1,0 +1,18 @@
+//! Store-owned account-mesh presence beacons.
+//!
+//! Beacons are runtime presence state. The library layer may render
+//! them as coordinator snapshots, but the durable source of truth is
+//! the store, not per-peer JSON files.
+
+use airc_core::PeerId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredBeacon {
+    pub mesh_identity: String,
+    pub peer_id: PeerId,
+    pub scope_home: String,
+    pub subscribed_channels: Vec<String>,
+    pub pid: u32,
+    pub published_at_ms: u64,
+    pub heartbeat_at_ms: u64,
+}

--- a/crates/airc-store/src/entities/beacon.rs
+++ b/crates/airc-store/src/entities/beacon.rs
@@ -1,0 +1,21 @@
+//! Account-mesh presence beacon tables.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "beacons")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub mesh_identity: String,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub peer_id: Uuid,
+    pub scope_home: String,
+    pub pid: i64,
+    pub published_at_ms: i64,
+    pub heartbeat_at_ms: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/airc-store/src/entities/beacon_channel.rs
+++ b/crates/airc-store/src/entities/beacon_channel.rs
@@ -1,0 +1,19 @@
+//! Channels attached to account-mesh presence beacons.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "beacon_channels")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub mesh_identity: String,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub peer_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub channel_name: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/airc-store/src/entities/mod.rs
+++ b/crates/airc-store/src/entities/mod.rs
@@ -18,8 +18,10 @@
 //!     cache of the published cross-machine registry document and the
 //!     per-mesh-identity gist-id sentinel that the gh adapter uses
 //!     to recognize its own gist across publishes.
-
+//!   - `beacons` / `beacon_channels` — account-mesh presence.
 pub mod account_registry;
+pub mod beacon;
+pub mod beacon_channel;
 pub mod event;
 pub mod local_identity;
 pub mod mesh_identity;

--- a/crates/airc-store/src/lib.rs
+++ b/crates/airc-store/src/lib.rs
@@ -30,6 +30,7 @@
 // than scattering `#[allow(elided_lifetimes_in_paths)]` per impl.
 
 pub mod account_registry;
+pub mod beacon;
 pub mod entities;
 pub mod error;
 pub mod memory;
@@ -41,6 +42,7 @@ pub mod store;
 pub mod subscriptions;
 
 pub use account_registry::{StoredAccountRegistry, StoredAccountRegistryGistSentinel};
+pub use beacon::StoredBeacon;
 pub use error::StoreError;
 pub use memory::InMemoryEventStore;
 pub use mesh_identity::StoredMeshIdentity;

--- a/crates/airc-store/src/memory.rs
+++ b/crates/airc-store/src/memory.rs
@@ -6,8 +6,10 @@ use async_trait::async_trait;
 use std::collections::BTreeMap;
 use std::sync::Mutex;
 
-use airc_core::{RoomId, TranscriptCursor, TranscriptEvent};
+use airc_core::{PeerId, RoomId, TranscriptCursor, TranscriptEvent};
+use uuid::Uuid;
 
+use crate::beacon::StoredBeacon;
 use crate::error::StoreError;
 use crate::mesh_identity::StoredMeshIdentity;
 use crate::store::EventStore;
@@ -18,6 +20,7 @@ pub struct InMemoryEventStore {
     runtime_cursors: Mutex<BTreeMap<String, TranscriptCursor>>,
     subscriptions: Mutex<Vec<StoredSubscription>>,
     mesh_identities: Mutex<BTreeMap<String, StoredMeshIdentity>>,
+    beacons: Mutex<BTreeMap<(String, Uuid), StoredBeacon>>,
 }
 
 impl InMemoryEventStore {
@@ -27,6 +30,7 @@ impl InMemoryEventStore {
             runtime_cursors: Mutex::new(BTreeMap::new()),
             subscriptions: Mutex::new(Vec::new()),
             mesh_identities: Mutex::new(BTreeMap::new()),
+            beacons: Mutex::new(BTreeMap::new()),
         }
     }
 }
@@ -157,6 +161,55 @@ impl EventStore for InMemoryEventStore {
             .map_err(|_| StoreError::LockPoisoned)?;
         identities.insert(entry.scope.clone(), entry);
         Ok(())
+    }
+
+    async fn load_beacon(
+        &self,
+        mesh_identity: &str,
+        peer_id: PeerId,
+    ) -> Result<Option<StoredBeacon>, StoreError> {
+        let beacons = self.beacons.lock().map_err(|_| StoreError::LockPoisoned)?;
+        Ok(beacons
+            .get(&(mesh_identity.to_string(), peer_id.as_uuid()))
+            .cloned())
+    }
+
+    async fn list_beacons(&self, mesh_identity: &str) -> Result<Vec<StoredBeacon>, StoreError> {
+        let beacons = self.beacons.lock().map_err(|_| StoreError::LockPoisoned)?;
+        let mut rows = beacons
+            .values()
+            .filter(|beacon| beacon.mesh_identity == mesh_identity)
+            .cloned()
+            .collect::<Vec<_>>();
+        rows.sort_by_key(|beacon| beacon.peer_id.to_string());
+        Ok(rows)
+    }
+
+    async fn save_beacon(&self, beacon: StoredBeacon) -> Result<(), StoreError> {
+        let mut beacons = self.beacons.lock().map_err(|_| StoreError::LockPoisoned)?;
+        beacons.insert(
+            (beacon.mesh_identity.clone(), beacon.peer_id.as_uuid()),
+            beacon,
+        );
+        Ok(())
+    }
+
+    async fn delete_beacons(
+        &self,
+        mesh_identity: &str,
+        peer_ids: &[PeerId],
+    ) -> Result<usize, StoreError> {
+        let mut beacons = self.beacons.lock().map_err(|_| StoreError::LockPoisoned)?;
+        let mut removed = 0;
+        for peer_id in peer_ids {
+            if beacons
+                .remove(&(mesh_identity.to_string(), peer_id.as_uuid()))
+                .is_some()
+            {
+                removed += 1;
+            }
+        }
+        Ok(removed)
     }
 }
 

--- a/crates/airc-store/src/migration/m20260522_000008_create_beacons.rs
+++ b/crates/airc-store/src/migration/m20260522_000008_create_beacons.rs
@@ -1,0 +1,106 @@
+//! Add ORM-owned account-mesh presence beacons.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Beacons::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(Beacons::MeshIdentity).string().not_null())
+                    .col(ColumnDef::new(Beacons::PeerId).uuid().not_null())
+                    .col(ColumnDef::new(Beacons::ScopeHome).string().not_null())
+                    .col(ColumnDef::new(Beacons::Pid).big_integer().not_null())
+                    .col(
+                        ColumnDef::new(Beacons::PublishedAtMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(Beacons::HeartbeatAtMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .primary_key(
+                        Index::create()
+                            .col(Beacons::MeshIdentity)
+                            .col(Beacons::PeerId),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(BeaconChannels::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(BeaconChannels::MeshIdentity)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(BeaconChannels::PeerId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(BeaconChannels::ChannelName)
+                            .string()
+                            .not_null(),
+                    )
+                    .primary_key(
+                        Index::create()
+                            .col(BeaconChannels::MeshIdentity)
+                            .col(BeaconChannels::PeerId)
+                            .col(BeaconChannels::ChannelName),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_beacons_mesh_heartbeat")
+                    .table(Beacons::Table)
+                    .col(Beacons::MeshIdentity)
+                    .col(Beacons::HeartbeatAtMs)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(BeaconChannels::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Beacons::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Beacons {
+    Table,
+    MeshIdentity,
+    PeerId,
+    ScopeHome,
+    Pid,
+    PublishedAtMs,
+    HeartbeatAtMs,
+}
+
+#[derive(DeriveIden)]
+enum BeaconChannels {
+    Table,
+    MeshIdentity,
+    PeerId,
+    ChannelName,
+}

--- a/crates/airc-store/src/migration/mod.rs
+++ b/crates/airc-store/src/migration/mod.rs
@@ -14,6 +14,7 @@ mod m20260522_000004_create_subscriptions;
 mod m20260522_000005_create_local_identity;
 mod m20260522_000006_create_mesh_identity;
 mod m20260522_000007_create_account_registry;
+mod m20260522_000008_create_beacons;
 
 pub struct Migrator;
 
@@ -28,6 +29,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260522_000005_create_local_identity::Migration),
             Box::new(m20260522_000006_create_mesh_identity::Migration),
             Box::new(m20260522_000007_create_account_registry::Migration),
+            Box::new(m20260522_000008_create_beacons::Migration),
         ]
     }
 }

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -30,9 +30,10 @@ use airc_core::{
 };
 
 use crate::account_registry::{StoredAccountRegistry, StoredAccountRegistryGistSentinel};
+use crate::beacon::StoredBeacon;
 use crate::entities::{
-    account_registry, event, local_identity, mesh_identity, peer_rotation_audit, peer_trust,
-    runtime_cursor, subscription,
+    account_registry, beacon, beacon_channel, event, local_identity, mesh_identity,
+    peer_rotation_audit, peer_trust, runtime_cursor, subscription,
 };
 use crate::error::StoreError;
 use crate::mesh_identity::StoredMeshIdentity;
@@ -675,6 +676,136 @@ impl EventStore for SqliteEventStore {
             .await?;
         Ok(())
     }
+
+    async fn load_beacon(
+        &self,
+        mesh_identity: &str,
+        peer_id: PeerId,
+    ) -> Result<Option<StoredBeacon>, StoreError> {
+        let row = beacon::Entity::find()
+            .filter(beacon::Column::MeshIdentity.eq(mesh_identity))
+            .filter(beacon::Column::PeerId.eq(peer_id.as_uuid()))
+            .one(&self.db)
+            .await?;
+        match row {
+            Some(row) => Ok(Some(self.beacon_from_model(row).await?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn list_beacons(&self, mesh_identity: &str) -> Result<Vec<StoredBeacon>, StoreError> {
+        let rows = beacon::Entity::find()
+            .filter(beacon::Column::MeshIdentity.eq(mesh_identity))
+            .order_by_asc(beacon::Column::PeerId)
+            .all(&self.db)
+            .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            out.push(self.beacon_from_model(row).await?);
+        }
+        Ok(out)
+    }
+
+    async fn save_beacon(&self, entry: StoredBeacon) -> Result<(), StoreError> {
+        let txn = self.db.begin().await?;
+        let peer_uuid = entry.peer_id.as_uuid();
+        let active = beacon::ActiveModel {
+            mesh_identity: ActiveValue::Set(entry.mesh_identity.clone()),
+            peer_id: ActiveValue::Set(peer_uuid),
+            scope_home: ActiveValue::Set(entry.scope_home),
+            pid: ActiveValue::Set(i64::from(entry.pid)),
+            published_at_ms: ActiveValue::Set(u64_to_i64(
+                "beacons.published_at_ms",
+                entry.published_at_ms,
+            )?),
+            heartbeat_at_ms: ActiveValue::Set(u64_to_i64(
+                "beacons.heartbeat_at_ms",
+                entry.heartbeat_at_ms,
+            )?),
+        };
+        beacon::Entity::insert(active)
+            .on_conflict(
+                OnConflict::columns([beacon::Column::MeshIdentity, beacon::Column::PeerId])
+                    .update_columns([
+                        beacon::Column::ScopeHome,
+                        beacon::Column::Pid,
+                        beacon::Column::PublishedAtMs,
+                        beacon::Column::HeartbeatAtMs,
+                    ])
+                    .to_owned(),
+            )
+            .exec(&txn)
+            .await?;
+        beacon_channel::Entity::delete_many()
+            .filter(beacon_channel::Column::MeshIdentity.eq(&entry.mesh_identity))
+            .filter(beacon_channel::Column::PeerId.eq(peer_uuid))
+            .exec(&txn)
+            .await?;
+        let mut channels = entry.subscribed_channels;
+        channels.sort();
+        channels.dedup();
+        for channel_name in channels {
+            let active = beacon_channel::ActiveModel {
+                mesh_identity: ActiveValue::Set(entry.mesh_identity.clone()),
+                peer_id: ActiveValue::Set(peer_uuid),
+                channel_name: ActiveValue::Set(channel_name),
+            };
+            beacon_channel::Entity::insert(active).exec(&txn).await?;
+        }
+        txn.commit().await?;
+        Ok(())
+    }
+
+    async fn delete_beacons(
+        &self,
+        mesh_identity: &str,
+        peer_ids: &[PeerId],
+    ) -> Result<usize, StoreError> {
+        let txn = self.db.begin().await?;
+        let mut removed = 0;
+        for peer_id in peer_ids {
+            let peer_uuid = peer_id.as_uuid();
+            beacon_channel::Entity::delete_many()
+                .filter(beacon_channel::Column::MeshIdentity.eq(mesh_identity))
+                .filter(beacon_channel::Column::PeerId.eq(peer_uuid))
+                .exec(&txn)
+                .await?;
+            let result = beacon::Entity::delete_many()
+                .filter(beacon::Column::MeshIdentity.eq(mesh_identity))
+                .filter(beacon::Column::PeerId.eq(peer_uuid))
+                .exec(&txn)
+                .await?;
+            removed += result.rows_affected as usize;
+        }
+        txn.commit().await?;
+        Ok(removed)
+    }
+}
+
+impl SqliteEventStore {
+    async fn beacon_from_model(&self, row: beacon::Model) -> Result<StoredBeacon, StoreError> {
+        let channels = beacon_channel::Entity::find()
+            .filter(beacon_channel::Column::MeshIdentity.eq(&row.mesh_identity))
+            .filter(beacon_channel::Column::PeerId.eq(row.peer_id))
+            .order_by_asc(beacon_channel::Column::ChannelName)
+            .all(&self.db)
+            .await?
+            .into_iter()
+            .map(|row| row.channel_name)
+            .collect();
+        Ok(StoredBeacon {
+            mesh_identity: row.mesh_identity,
+            peer_id: PeerId::from_uuid(row.peer_id),
+            scope_home: row.scope_home,
+            subscribed_channels: channels,
+            pid: u32::try_from(row.pid).map_err(|_| StoreError::InvalidStoredValue {
+                field: "beacons.pid",
+                value: row.pid as i128,
+            })?,
+            published_at_ms: i64_to_u64("beacons.published_at_ms", row.published_at_ms)?,
+            heartbeat_at_ms: i64_to_u64("beacons.heartbeat_at_ms", row.heartbeat_at_ms)?,
+        })
+    }
 }
 
 fn to_active_model(ev: &TranscriptEvent) -> Result<event::ActiveModel, StoreError> {
@@ -1086,6 +1217,60 @@ mod tests {
         assert_eq!(
             reopened.load_mesh_identity("default").await.unwrap(),
             Some(second)
+        );
+    }
+
+    #[tokio::test]
+    async fn beacons_replace_channels_and_drain_by_peer() {
+        let store = SqliteEventStore::in_memory().await.unwrap();
+        let peer_a = PeerId::from_u128(0xa);
+        let peer_b = PeerId::from_u128(0xb);
+        let first = StoredBeacon {
+            mesh_identity: "joelteply".to_string(),
+            peer_id: peer_a,
+            scope_home: "/home/joel/.airc".to_string(),
+            subscribed_channels: vec!["general".to_string(), "cambriantech".to_string()],
+            pid: 42,
+            published_at_ms: 1_000,
+            heartbeat_at_ms: 1_000,
+        };
+        let updated = StoredBeacon {
+            subscribed_channels: vec!["general".to_string()],
+            heartbeat_at_ms: 2_000,
+            ..first.clone()
+        };
+        let other = StoredBeacon {
+            mesh_identity: "joelteply".to_string(),
+            peer_id: peer_b,
+            scope_home: "/home/joel/project/.airc".to_string(),
+            subscribed_channels: vec!["ideem".to_string()],
+            pid: 43,
+            published_at_ms: 1_500,
+            heartbeat_at_ms: 1_500,
+        };
+
+        store.save_beacon(first).await.unwrap();
+        store.save_beacon(updated.clone()).await.unwrap();
+        store.save_beacon(other.clone()).await.unwrap();
+
+        assert_eq!(
+            store.load_beacon("joelteply", peer_a).await.unwrap(),
+            Some(updated)
+        );
+        let listed = store.list_beacons("joelteply").await.unwrap();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(
+            store.delete_beacons("joelteply", &[peer_a]).await.unwrap(),
+            1
+        );
+        assert!(store
+            .load_beacon("joelteply", peer_a)
+            .await
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            store.load_beacon("joelteply", peer_b).await.unwrap(),
+            Some(other)
         );
     }
 

--- a/crates/airc-store/src/store.rs
+++ b/crates/airc-store/src/store.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 
 use airc_core::{RoomId, TranscriptCursor, TranscriptEvent};
 
+use crate::beacon::StoredBeacon;
 use crate::error::StoreError;
 use crate::mesh_identity::StoredMeshIdentity;
 use crate::subscriptions::StoredSubscription;
@@ -94,4 +95,26 @@ pub trait EventStore: Send + Sync {
 
     /// Upsert the cached mesh identity row for its `scope`.
     async fn save_mesh_identity(&self, entry: StoredMeshIdentity) -> Result<(), StoreError>;
+
+    /// Load the caller's own account-mesh beacon for `mesh_identity`,
+    /// if present.
+    async fn load_beacon(
+        &self,
+        mesh_identity: &str,
+        peer_id: airc_core::PeerId,
+    ) -> Result<Option<StoredBeacon>, StoreError>;
+
+    /// List all account-mesh beacons for `mesh_identity`.
+    async fn list_beacons(&self, mesh_identity: &str) -> Result<Vec<StoredBeacon>, StoreError>;
+
+    /// Upsert one account-mesh beacon and replace its channel set in
+    /// the same transaction.
+    async fn save_beacon(&self, beacon: StoredBeacon) -> Result<(), StoreError>;
+
+    /// Delete account-mesh beacons for `mesh_identity`.
+    async fn delete_beacons(
+        &self,
+        mesh_identity: &str,
+        peer_ids: &[airc_core::PeerId],
+    ) -> Result<usize, StoreError>;
 }

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -197,11 +197,11 @@ Move to SeaORM entities (one row, one table, one transaction):
 | `peers.json` | `peer_trust` + `peer_rotation_audit` (done in #883) |
 | `subscriptions.json` | `subscriptions` table (done in store-backed subscriptions cut) |
 | `room.json` (current room marker) | `subscriptions.is_default` (done in store-backed subscriptions cut) |
-| `identity.json` (singleton) | `identity` table (singleton row) |
+| `identity.json` (singleton metadata) | `local_identity` table (done in store-backed local identity cut; key material stays in `identity.key`) |
 | `mesh_identity` cache file | `mesh_identity` table (done in store-backed mesh identity cut) |
 | `account_registry/*.json` | `account_registry` table |
-| `coordinator/*.beacon` | `beacons` table with `ttl_expires_at` |
-| `codex_hook_cursor.json` + `join_feed_cursor.{client}.json` | `cursors` table (per-runtime-client, per-channel) |
+| `coordinator/*.beacon` | `beacons` + `beacon_channels` tables (done in store-backed coordinator beacon cut) |
+| `codex_hook_cursor.json` + `join_feed_cursor.{client}.json` | `runtime_cursors` table (done in cursor cut) |
 
 What dies the day this lands:
 - Every `tmp + rename` pattern (DB transaction is atomic).
@@ -240,10 +240,10 @@ five concrete hotpaths and seven kill-list patterns.
 ### Top 5 perf problems (worst first)
 
 1. **Synchronous file I/O on every CLI/subscribe call** —
-   peer trust moved to SeaORM in #883 and subscriptions/default-room
-   moved to the `subscriptions` table in the store-backed
-   subscriptions cut. Remaining file-backed runtime state is
-   identity, account registry, and coordinator beacons.
+   peer trust moved to SeaORM in #883; subscriptions/default-room,
+   local identity metadata, mesh identity, runtime cursors, and
+   coordinator beacons now use store tables. Remaining file-backed
+   runtime state is the account registry document path.
 
 2. **Double clone of `TranscriptEvent` on every ingest** —
    `messaging.rs:110`, `transport.rs:124`. Each event is cloned
@@ -268,10 +268,10 @@ five concrete hotpaths and seven kill-list patterns.
 
 ### Substrate-wide patterns to kill (priority order)
 
-1. **Synchronous file I/O in async functions** — identity,
-   account registry, and coordinator beacon reads still need SeaORM
-   cuts. Peer trust, subscriptions, and mesh identity are now
-   store-backed.
+1. **Synchronous file I/O in async functions** — account registry
+   reads still need a SeaORM cut. Peer trust, subscriptions, local
+   identity metadata, mesh identity, runtime cursors, and coordinator
+   beacons are now store-backed.
 2. **`RwLock<HashMap>` at global granularity** — PeerKeyRegistry,
    route_health, route_endpoints, imported_invites. Switch to
    `DashMap` or sharded RwLock for N-reader scale.


### PR DESCRIPTION
Summary
- add SeaORM beacon and beacon_channel tables for account-mesh presence
- route AIRC join/presence and account-registry snapshots through the machine-account coordinator store
- keep same-machine scopes sharing beacon state via the shared wire_root events.sqlite
- update the grid substrate audit for ORM-backed local identity, runtime cursors, mesh identity, and beacons

Verification
- cargo fmt --all
- cargo test -p airc-store beacons
- cargo test -p airc-lib coordinator
- cargo test -p airc-lib account_registry
- cargo test -p airc-lib default_join_context_subscribes_general_and_repo_owner_on_shared_account_wire
- cargo test -p airc-cli join_without_args_uses_default_account_context
- cargo clippy -p airc-store -p airc-lib -p airc-cli --all-targets -- -D warnings
- cargo test --workspace