### PR TITLE
refactor(transport): report substrate route health

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -458,19 +458,10 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
         Command::Transport(args) => match args.action {
             TransportAction::Health {
-                config,
-                fresh_after,
                 quiet,
                 degraded_only,
                 fail,
-            } => transport_commands::run_health(
-                &home,
-                config,
-                fresh_after,
-                quiet,
-                degraded_only,
-                fail,
-            ),
+            } => transport_commands::run_health(&home, quiet, degraded_only, fail).await,
         },
 
         Command::Events(args) => match args.action {

--- a/crates/airc-cli/src/transport_cli.rs
+++ b/crates/airc-cli/src/transport_cli.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use clap::{Args, Subcommand};
 
 #[derive(Debug, Args)]
@@ -10,21 +8,13 @@ pub struct TransportArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum TransportAction {
-    /// Check scope-local transport heartbeat and pid evidence.
+    /// Inspect substrate route health.
     Health {
-        /// Config file. Defaults to `<home>/config.json`.
-        #[arg(long)]
-        config: Option<PathBuf>,
-
-        /// Maximum acceptable heartbeat age in seconds.
-        #[arg(long, default_value_t = 90)]
-        fresh_after: u64,
-
         /// Suppress output; exit code still reports degraded health.
         #[arg(long)]
         quiet: bool,
 
-        /// Print only degraded channel rows.
+        /// Print only degraded route rows.
         #[arg(long)]
         degraded_only: bool,
 

--- a/crates/airc-cli/src/transport_commands.rs
+++ b/crates/airc-cli/src/transport_commands.rs
@@ -1,88 +1,21 @@
-use std::collections::BTreeMap;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::path::Path;
 
-use serde::Deserialize;
+use airc_lib::{Airc, TransportHealthSample, TransportHealthState, TransportKind, TransportRole};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ChannelHealth {
-    channel: String,
-    status: HealthStatus,
-    age_seconds: Option<u64>,
-    detail: String,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HealthStatus {
-    Ok,
-    Degraded,
-}
-
-impl HealthStatus {
-    fn is_ok(self) -> bool {
-        matches!(self, Self::Ok)
-    }
-
-    fn label(self) -> &'static str {
-        match self {
-            Self::Ok => "ok",
-            Self::Degraded => "DEGRADED",
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct ConfigFile {
-    #[serde(default)]
-    subscribed_channels: Vec<String>,
-    #[serde(default)]
-    channel_gists: BTreeMap<String, String>,
-    #[serde(default)]
-    host_target: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct BearerState {
-    last_heartbeat_ts: Option<JsonNumber>,
-    last_recv_ts: Option<JsonNumber>,
-    last_error: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum JsonNumber {
-    Number(f64),
-    String(String),
-}
-
-impl JsonNumber {
-    fn as_f64(&self) -> Option<f64> {
-        match self {
-            Self::Number(value) => Some(*value),
-            Self::String(value) => value.parse().ok(),
-        }
-    }
-}
-
-pub fn run_health(
+pub async fn run_health(
     home: &Path,
-    config: Option<PathBuf>,
-    fresh_after: u64,
     quiet: bool,
     degraded_only: bool,
     fail: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let config = config.unwrap_or_else(|| home.join("config.json"));
-    let rows = evaluate(home, &config, fresh_after, now_seconds());
-    let degraded = rows
+    let airc = Airc::open(home).await?;
+    let snapshot = airc.refresh_route_discovery().await?;
+    let degraded = snapshot
+        .health
         .iter()
-        .filter(|row| row.status == HealthStatus::Degraded)
+        .filter(|sample| sample.state != TransportHealthState::Healthy)
         .count();
 
-    if rows.is_empty() {
-        return Err("transport health: no channel rows".into());
-    }
     if degraded_only && degraded == 0 {
         return Ok(());
     }
@@ -95,27 +28,33 @@ pub fn run_health(
     }
 
     if degraded == 0 {
-        println!("transport health: ok ({} channel(s) fresh)", rows.len());
+        println!(
+            "transport health: ok ({} route(s) healthy)",
+            snapshot.health.len()
+        );
     } else {
         println!(
-            "transport health: DEGRADED ({degraded}/{} channel(s) need attention)",
-            rows.len()
+            "transport health: DEGRADED ({degraded}/{} route(s) need attention)",
+            snapshot.health.len()
         );
     }
-    for row in rows {
-        if degraded_only && row.status.is_ok() {
+
+    for sample in snapshot.health {
+        if degraded_only && sample.state == TransportHealthState::Healthy {
             continue;
         }
-        let suffix = row
-            .age_seconds
-            .map(|age| format!("{age}s"))
-            .unwrap_or_else(|| "no-signal".to_string());
-        println!(
-            "#{}: {} ({suffix}) - {}",
-            row.channel,
-            row.status.label(),
-            row.detail
-        );
+        print_sample(sample);
+    }
+
+    if snapshot.endpoints.is_empty() {
+        println!("endpoints: none");
+    } else {
+        println!("endpoints: {}", snapshot.endpoints.len());
+    }
+    if snapshot.connected_lan_peers.is_empty() {
+        println!("lan peers: none");
+    } else {
+        println!("lan peers: {}", snapshot.connected_lan_peers.len());
     }
 
     if degraded == 0 || !fail {
@@ -125,342 +64,49 @@ pub fn run_health(
     }
 }
 
-fn evaluate(home: &Path, config: &Path, fresh_after: u64, now: f64) -> Vec<ChannelHealth> {
-    let config = load_config(config);
-    let mut channels = config.subscribed_channels;
-    if channels.is_empty() {
-        channels = config.channel_gists.keys().cloned().collect();
-    }
-
-    channels
-        .into_iter()
-        .map(|channel| {
-            evaluate_channel(
-                home,
-                &config.channel_gists,
-                &channel,
-                fresh_after,
-                now,
-                config.host_target.is_none(),
-            )
-        })
-        .collect()
-}
-
-fn evaluate_channel(
-    home: &Path,
-    gists: &BTreeMap<String, String>,
-    channel: &str,
-    fresh_after: u64,
-    now: f64,
-    is_host: bool,
-) -> ChannelHealth {
-    let gist = gists.get(channel).map(String::as_str).unwrap_or("");
-    let mut issues = Vec::new();
-    let mut age_seconds = None;
-
-    if gist.is_empty() {
-        issues.push("missing channel_gists mapping".to_string());
-    }
-
-    let state_path = home.join(format!("bearer_state.{channel}.json"));
-    let state = load_state(&state_path);
-    if let Some(error) = state.as_ref().and_then(|state| state.last_error.as_deref()) {
-        issues.push(format!("bearer error: {error}"));
-    }
-    let signal = signal_for_gist(home, gists, channel, gist, state.as_ref());
-    let signal_source = signal.as_ref().map(|(_, source)| source.clone());
-    if let Some((signal_ts, _source)) = signal.as_ref() {
-        if now >= *signal_ts {
-            let age = (now - *signal_ts) as u64;
-            age_seconds = Some(age);
-            if age > fresh_after {
-                issues.push(format!("stale heartbeat {age}s"));
-            }
-        } else {
-            issues.push("invalid heartbeat timestamp".to_string());
-        }
-    } else if state.is_some() {
-        match file_age_seconds(&state_path, now) {
-            Some(age) if age <= fresh_after => {
-                age_seconds = Some(age);
-                issues.push("starting; no heartbeat yet".to_string());
-            }
-            Some(_) | None => issues.push("no heartbeat evidence".to_string()),
-        }
-    } else {
-        issues.push("no bearer_state file".to_string());
-    }
-
-    if !is_host {
-        let pid_path = if gist.is_empty() {
-            home.join(format!("bearer_state.{channel}.pid"))
-        } else {
-            home.join(format!("bearer_gist.{}.pid", safe_gist(gist)))
-        };
-        let pid = read_pid(&pid_path);
-        if pid == 0 {
-            issues.push("no bearer pidfile".to_string());
-        } else if !pid_alive(pid) {
-            issues.push(format!("stale bearer pid {pid}"));
-        }
-    }
-
-    ChannelHealth {
-        channel: channel.to_string(),
-        status: if issues.is_empty() {
-            HealthStatus::Ok
-        } else {
-            HealthStatus::Degraded
-        },
-        age_seconds,
-        detail: if issues.is_empty() {
-            if let Some(source) = signal_source.filter(|source| source != channel) {
-                format!("fresh heartbeat via shared gist #{source}")
-            } else {
-                "fresh heartbeat".to_string()
-            }
-        } else {
-            issues.join("; ")
-        },
-    }
-}
-
-fn load_config(path: &Path) -> ConfigFile {
-    fs::read_to_string(path)
-        .ok()
-        .and_then(|raw| serde_json::from_str(&raw).ok())
-        .unwrap_or_else(|| ConfigFile {
-            subscribed_channels: Vec::new(),
-            channel_gists: BTreeMap::new(),
-            host_target: None,
-        })
-}
-
-fn load_state(path: &Path) -> Option<BearerState> {
-    fs::read_to_string(path)
-        .ok()
-        .and_then(|raw| serde_json::from_str(&raw).ok())
-}
-
-fn signal_timestamp(state: &BearerState) -> Option<f64> {
-    state
-        .last_heartbeat_ts
-        .as_ref()
-        .or(state.last_recv_ts.as_ref())
-        .and_then(JsonNumber::as_f64)
-}
-
-fn signal_for_gist(
-    home: &Path,
-    gists: &BTreeMap<String, String>,
-    channel: &str,
-    gist: &str,
-    own_state: Option<&BearerState>,
-) -> Option<(f64, String)> {
-    let mut best = own_state
-        .and_then(signal_timestamp)
-        .map(|ts| (ts, channel.to_string()));
-
-    if gist.is_empty() {
-        return best;
-    }
-
-    for (other, other_gist) in gists {
-        if other == channel || other_gist != gist {
-            continue;
-        }
-        let path = home.join(format!("bearer_state.{other}.json"));
-        let Some(ts) = load_state(&path).as_ref().and_then(signal_timestamp) else {
-            continue;
-        };
-        if best
-            .as_ref()
-            .map(|(best_ts, _)| ts > *best_ts)
-            .unwrap_or(true)
-        {
-            best = Some((ts, other.clone()));
-        }
-    }
-
-    best
-}
-
-fn file_age_seconds(path: &Path, now: f64) -> Option<u64> {
-    let modified = fs::metadata(path).ok()?.modified().ok()?;
-    let modified = modified.duration_since(UNIX_EPOCH).ok()?.as_secs_f64();
-    if now >= modified {
-        Some((now - modified) as u64)
-    } else {
-        None
-    }
-}
-
-fn read_pid(path: &Path) -> u32 {
-    let Ok(raw) = fs::read_to_string(path) else {
-        return 0;
+fn print_sample(sample: TransportHealthSample) {
+    let detail = match (sample.rtt_ms, sample.success_ppm) {
+        (Some(rtt), Some(success)) => format!("{rtt}ms, {:.3}% success", success as f64 / 10_000.0),
+        (Some(rtt), None) => format!("{rtt}ms"),
+        (None, Some(success)) => format!("{:.3}% success", success as f64 / 10_000.0),
+        (None, None) => "not measured".to_string(),
     };
-    raw.trim()
-        .split_once('\t')
-        .map(|(pid, _)| pid)
-        .unwrap_or_else(|| raw.trim())
-        .parse()
-        .unwrap_or(0)
+    println!(
+        "- {} role={} state={} ({detail})",
+        format_kind(sample.kind),
+        format_role(sample.role),
+        format_state(sample.state)
+    );
 }
 
-fn safe_gist(gist: &str) -> String {
-    gist.chars()
-        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
-        .collect()
+fn format_kind(kind: TransportKind) -> &'static str {
+    match kind {
+        TransportKind::LocalFs => "local-fs",
+        TransportKind::LanTcp => "lan-tcp",
+        TransportKind::Tailscale => "tailscale",
+        TransportKind::Udp => "udp",
+        TransportKind::WebRtcDataChannel => "webrtc-data-channel",
+        TransportKind::Reticulum => "reticulum",
+        TransportKind::Relay => "relay",
+        TransportKind::Ssh => "ssh",
+        TransportKind::GhGist => "gh-gist",
+    }
 }
 
-fn now_seconds() -> f64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_secs_f64())
-        .unwrap_or(0.0)
+fn format_role(role: TransportRole) -> &'static str {
+    match role {
+        TransportRole::Direct => "direct",
+        TransportRole::Relay => "relay",
+        TransportRole::InviteBeacon => "invite-beacon",
+        TransportRole::Rendezvous => "rendezvous",
+        TransportRole::Admin => "admin",
+    }
 }
 
-#[cfg(unix)]
-fn pid_alive(pid: u32) -> bool {
-    // SAFETY: `kill(pid, 0)` does not send a signal; it asks the OS to
-    // validate whether the process exists and is visible to this user.
-    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
-}
-
-#[cfg(not(unix))]
-fn pid_alive(pid: u32) -> bool {
-    pid > 0
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::io::Write;
-
-    #[test]
-    fn safe_gist_replaces_non_alphanumeric_chars() {
-        assert_eq!(safe_gist("abc-123/def"), "abc_123_def");
-    }
-
-    #[test]
-    fn read_pid_uses_first_tab_separated_field() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("pid");
-        fs::write(&path, "123\tmetadata\n").unwrap();
-
-        assert_eq!(read_pid(&path), 123);
-    }
-
-    #[test]
-    fn fresh_heartbeat_and_live_pid_is_healthy() {
-        let dir = tempfile::tempdir().unwrap();
-        let home = dir.path();
-        let config = home.join("config.json");
-        let gist = "c68640ec0144b422c16b2d8c83ad5ee5";
-        fs::write(
-            &config,
-            format!(
-                r#"{{"subscribed_channels":["general"],"channel_gists":{{"general":"{gist}"}}}}"#
-            ),
-        )
-        .unwrap();
-        fs::write(
-            home.join("bearer_state.general.json"),
-            r#"{"last_heartbeat_ts":1000}"#,
-        )
-        .unwrap();
-        fs::write(
-            home.join(format!("bearer_gist.{}.pid", safe_gist(gist))),
-            std::process::id().to_string(),
-        )
-        .unwrap();
-
-        let rows = evaluate(home, &config, 90, 1000.0);
-
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].status, HealthStatus::Ok);
-    }
-
-    #[test]
-    fn host_scope_does_not_require_joiner_bearer_pidfile() {
-        let dir = tempfile::tempdir().unwrap();
-        let home = dir.path();
-        let config = home.join("config.json");
-        let gist = "c68640ec0144b422c16b2d8c83ad5ee5";
-        fs::write(
-            &config,
-            format!(
-                r#"{{"subscribed_channels":["general"],"channel_gists":{{"general":"{gist}"}}}}"#
-            ),
-        )
-        .unwrap();
-        fs::write(
-            home.join("bearer_state.general.json"),
-            r#"{"last_heartbeat_ts":1000}"#,
-        )
-        .unwrap();
-
-        let rows = evaluate(home, &config, 90, 1000.0);
-
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].status, HealthStatus::Ok);
-        assert_eq!(rows[0].detail, "fresh heartbeat");
-    }
-
-    #[test]
-    fn joiner_scope_still_requires_bearer_pidfile() {
-        let dir = tempfile::tempdir().unwrap();
-        let home = dir.path();
-        let config = home.join("config.json");
-        let gist = "c68640ec0144b422c16b2d8c83ad5ee5";
-        fs::write(
-            &config,
-            format!(
-                r#"{{"host_target":"joel@example","subscribed_channels":["general"],"channel_gists":{{"general":"{gist}"}}}}"#
-            ),
-        )
-        .unwrap();
-        fs::write(
-            home.join("bearer_state.general.json"),
-            r#"{"last_heartbeat_ts":1000}"#,
-        )
-        .unwrap();
-
-        let rows = evaluate(home, &config, 90, 1000.0);
-
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].status, HealthStatus::Degraded);
-        assert!(rows[0].detail.contains("no bearer pidfile"));
-    }
-
-    #[test]
-    fn stale_heartbeat_and_stale_pid_is_degraded() {
-        let dir = tempfile::tempdir().unwrap();
-        let home = dir.path();
-        let config = home.join("config.json");
-        let gist = "c68640ec0144b422c16b2d8c83ad5ee5";
-        fs::write(
-            &config,
-            format!(
-                r#"{{"host_target":"joel@example","subscribed_channels":["general"],"channel_gists":{{"general":"{gist}"}}}}"#
-            ),
-        )
-        .unwrap();
-        fs::write(
-            home.join("bearer_state.general.json"),
-            r#"{"last_heartbeat_ts":700}"#,
-        )
-        .unwrap();
-        let mut pid_file =
-            fs::File::create(home.join(format!("bearer_gist.{}.pid", safe_gist(gist)))).unwrap();
-        writeln!(pid_file, "999999").unwrap();
-
-        let rows = evaluate(home, &config, 90, 1000.0);
-
-        assert_eq!(rows[0].status, HealthStatus::Degraded);
-        assert!(rows[0].detail.contains("stale heartbeat 300s"));
-        #[cfg(unix)]
-        assert!(rows[0].detail.contains("stale bearer pid 999999"));
+fn format_state(state: TransportHealthState) -> &'static str {
+    match state {
+        TransportHealthState::Healthy => "healthy",
+        TransportHealthState::Degraded => "degraded",
+        TransportHealthState::Down => "down",
     }
 }

--- a/crates/airc-cli/tests/transport_commands.rs
+++ b/crates/airc-cli/tests/transport_commands.rs
@@ -1,110 +1,55 @@
-//! End-to-end coverage for `airc-core transport ...`.
+//! End-to-end coverage for `airc transport ...`.
 
-use std::fs;
-use std::path::Path;
 use std::process::Command;
 
 use tempfile::TempDir;
 
-fn airc_core() -> &'static str {
+fn airc() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
 }
 
 #[test]
-fn transport_health_reports_fresh_heartbeat() {
+fn transport_health_reports_route_snapshot_from_substrate() {
     let workspace = TempDir::new().expect("tempdir");
-    let home = workspace.path();
-    let gist = "c68640ec0144b422c16b2d8c83ad5ee5";
-    write_config(home, gist);
-    fs::write(
-        home.join("bearer_state.general.json"),
-        format!(r#"{{"last_heartbeat_ts":{}}}"#, now_seconds()),
-    )
-    .unwrap();
-    fs::write(
-        home.join(format!("bearer_gist.{gist}.pid")),
-        std::process::id().to_string(),
-    )
-    .unwrap();
 
-    let output = run_ok(home, &["transport", "health"]);
+    let output = run_ok(workspace.path(), &["transport", "health"]);
 
-    assert!(output.contains("transport health: ok (1 channel(s) fresh)"));
-    assert!(output.contains("#general: ok"));
+    assert!(output.contains("transport health: ok (1 route(s) healthy)"));
+    assert!(output.contains("- local-fs role=direct state=healthy"));
+    assert!(output.contains("endpoints: none"));
+    assert!(output.contains("lan peers: none"));
 }
 
 #[test]
-fn transport_health_fail_exits_nonzero_when_degraded() {
+fn transport_health_degraded_only_is_silent_when_routes_are_clean() {
     let workspace = TempDir::new().expect("tempdir");
-    let home = workspace.path();
-    let gist = "c68640ec0144b422c16b2d8c83ad5ee5";
-    write_config(home, gist);
-    fs::write(
-        home.join("bearer_state.general.json"),
-        r#"{"last_heartbeat_ts":700}"#,
-    )
-    .unwrap();
-    fs::write(home.join(format!("bearer_gist.{gist}.pid")), "999999").unwrap();
 
-    let output = run_raw(
-        home,
-        &["transport", "health", "--fresh-after", "90", "--fail"],
+    let output = run_ok(
+        workspace.path(),
+        &["transport", "health", "--degraded-only"],
     );
-
-    assert!(!output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("transport health: DEGRADED"));
-    assert!(stdout.contains("stale heartbeat"));
-}
-
-#[test]
-fn transport_health_default_reports_degraded_without_failing() {
-    let workspace = TempDir::new().expect("tempdir");
-    let home = workspace.path();
-    let gist = "c68640ec0144b422c16b2d8c83ad5ee5";
-    write_config(home, gist);
-
-    let output = run_ok(home, &["transport", "health"]);
-
-    assert!(output.contains("transport health: DEGRADED"));
-    assert!(output.contains("no bearer_state file"));
-}
-
-#[test]
-fn transport_health_degraded_only_is_silent_when_clean() {
-    let workspace = TempDir::new().expect("tempdir");
-    let home = workspace.path();
-    let gist = "c68640ec0144b422c16b2d8c83ad5ee5";
-    write_config(home, gist);
-    fs::write(
-        home.join("bearer_state.general.json"),
-        format!(r#"{{"last_heartbeat_ts":{}}}"#, now_seconds()),
-    )
-    .unwrap();
-    fs::write(
-        home.join(format!("bearer_gist.{gist}.pid")),
-        std::process::id().to_string(),
-    )
-    .unwrap();
-
-    let output = run_ok(home, &["transport", "health", "--degraded-only"]);
 
     assert!(output.trim().is_empty());
 }
 
-fn write_config(home: &Path, gist: &str) {
-    fs::write(
-        home.join("config.json"),
-        format!(r#"{{"subscribed_channels":["general"],"channel_gists":{{"general":"{gist}"}}}}"#),
-    )
-    .unwrap();
+#[test]
+fn transport_health_quiet_succeeds_when_routes_are_clean() {
+    let workspace = TempDir::new().expect("tempdir");
+
+    let output = run_raw(
+        workspace.path(),
+        &["transport", "health", "--quiet", "--fail"],
+    );
+
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
 }
 
-fn run_ok(home: &Path, args: &[&str]) -> String {
+fn run_ok(home: &std::path::Path, args: &[&str]) -> String {
     let output = run_raw(home, args);
     assert!(
         output.status.success(),
-        "airc-core {:?} failed: stdout={} stderr={}",
+        "airc {:?} failed: stdout={} stderr={}",
         args,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
@@ -112,18 +57,11 @@ fn run_ok(home: &Path, args: &[&str]) -> String {
     String::from_utf8(output.stdout).expect("stdout utf-8")
 }
 
-fn run_raw(home: &Path, args: &[&str]) -> std::process::Output {
-    Command::new(airc_core())
+fn run_raw(home: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::new(airc())
         .arg("--home")
         .arg(home)
         .args(args)
         .output()
-        .expect("airc-core command must spawn")
-}
-
-fn now_seconds() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
+        .expect("airc command must spawn")
 }


### PR DESCRIPTION
Summary
- replace config/bearer-file transport health with airc-lib route discovery health
- remove --config and --fresh-after from transport health
- delete heartbeat/pidfile parsing and update public CLI tests around the substrate route snapshot

Verification
- cargo fmt --manifest-path Cargo.toml --all --check
- cargo test --manifest-path Cargo.toml -p airc-cli --test transport_commands -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings