### PR TITLE
refactor(collaboration): remove jsonl presence scans

### DIFF
--- a/crates/airc-cli/src/collaboration_cli.rs
+++ b/crates/airc-cli/src/collaboration_cli.rs
@@ -16,17 +16,10 @@ pub enum CollaborationAction {
     Doctor(CollaborationScopeArgs),
     /// Warn when sends are likely isolated.
     SendWarning(CollaborationScopeArgs),
-    /// Print paired peers plus recent broadcast-only peers.
+    /// Print paired peers from the substrate peer registry.
     Peers(CollaborationScopeArgs),
     /// Remove stale duplicate peer records for the same host.
     PrunePeers(CollaborationScopeArgs),
-    /// Print identity evidence observed from signed room traffic.
-    ObservedWhois {
-        #[command(flatten)]
-        scope: CollaborationScopeArgs,
-        #[arg(long)]
-        peer_name: String,
-    },
 }
 
 #[derive(Debug, Args)]

--- a/crates/airc-cli/src/collaboration_commands.rs
+++ b/crates/airc-cli/src/collaboration_commands.rs
@@ -1,27 +1,10 @@
-use std::collections::BTreeMap;
 use std::error::Error;
 use std::fs;
 use std::path::Path;
 
-use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use serde_json::Value;
 
 use crate::collaboration_cli::CollaborationScopeArgs;
-
-const RECENT_REMOTE_WINDOW_SEC: i64 = 600;
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct MessageActivity {
-    name: String,
-    ts: i64,
-}
-
-#[derive(Debug, Default, Eq, PartialEq)]
-struct CollaborationEvidence {
-    recent_speakers: BTreeMap<String, i64>,
-    recent_activity: Option<MessageActivity>,
-    any_activity: Option<MessageActivity>,
-}
 
 pub async fn run_status(
     default_home: &Path,
@@ -29,46 +12,14 @@ pub async fn run_status(
 ) -> Result<(), Box<dyn Error>> {
     let home = args.home.as_deref().unwrap_or(default_home);
     let count = peer_record_count(home).await;
-    let evidence = collaboration_evidence(home, &args.my_name, &args.client_id);
-    let any_recent = evidence
-        .recent_activity
-        .as_ref()
-        .or(evidence.any_activity.as_ref());
-    let now = Utc::now().timestamp();
-    let remote_desc = match any_recent {
-        Some(activity) => format!(
-            "last remote message {}s ago from {}",
-            (now - activity.ts).max(0),
-            activity.name
-        ),
-        None => "no remote messages recorded".to_string(),
-    };
 
     if count == 0 {
-        if !evidence.recent_speakers.is_empty() {
-            let label = if evidence.recent_speakers.len() == 1 {
-                "broadcast peer"
-            } else {
-                "broadcast peers"
-            };
-            println!(
-                "  collaboration: ok ({} {label}; 0 direct peer records; {remote_desc})",
-                evidence.recent_speakers.len()
-            );
-            println!("    Presence is derived from recent signed room traffic.");
-        } else if any_recent.is_none() {
-            println!("  collaboration: waiting for peers (0 peer records; {remote_desc})");
-            println!(
-                "    First agent in a room is expected to be alone until another agent joins this gist."
-            );
-        } else {
-            println!("  collaboration: SOLO (0 peer records; {remote_desc})");
-            println!(
-                "    Sends may only land in this local/self-hosted gist until another agent joins this exact mesh."
-            );
-        }
+        println!("  collaboration: waiting for peers (0 peer records)");
+        println!(
+            "    First agent in a room is expected to be alone until another agent joins this account mesh."
+        );
     } else {
-        println!("  collaboration: ok ({count} peer record(s); {remote_desc})");
+        println!("  collaboration: ok ({count} peer record(s))");
     }
     Ok(())
 }
@@ -79,56 +30,13 @@ pub async fn run_doctor(
 ) -> Result<(), Box<dyn Error>> {
     let home = args.home.as_deref().unwrap_or(default_home);
     let count = peer_record_count(home).await;
-    let evidence = collaboration_evidence(home, &args.my_name, &args.client_id);
-    let now = Utc::now().timestamp();
     if count > 0 {
         println!("  [ok] collaboration mesh has {count} peer record(s)");
         return Ok(());
     }
-    if let Some(recent) = evidence.recent_activity.as_ref() {
-        if !evidence.recent_speakers.is_empty() {
-            let label = if evidence.recent_speakers.len() == 1 {
-                "broadcast peer"
-            } else {
-                "broadcast peers"
-            };
-            println!(
-                "  [ok] collaboration mesh has {} recent {label} from signed room traffic (0 direct peer records)",
-                evidence.recent_speakers.len()
-            );
-            println!(
-                "       last remote message {}s ago from {}",
-                (now - recent.ts).max(0),
-                recent.name
-            );
-            return Ok(());
-        }
-        println!(
-            "  [WARN] collaboration mesh has 0 peer records, but remote traffic arrived {}s ago from {}",
-            (now - recent.ts).max(0),
-            recent.name
-        );
-        println!(
-            "         Peer metadata is degraded (DMs/whois may fail), but this is NOT a solo island."
-        );
-        return Err(command_exit(1));
-    }
-    let Some(any_recent) = evidence.any_activity.as_ref() else {
-        println!(
-            "  [info] collaboration mesh has 0 peer records and no remote history — waiting for first peer"
-        );
-        println!("         Share the invite or ask another agent to join this room; first-user startup is OK.");
-        return Ok(());
-    };
-    println!(
-        "  [BLOCKED] collaboration mesh has 0 peer records — last remote traffic was {}s ago from {}; this may be a solo island",
-        (now - any_recent.ts).max(0),
-        any_recent.name
-    );
-    println!(
-        "         Check: airc peers; ask peers to run 'airc update --channel canary && airc join <current invite>'"
-    );
-    Err(command_exit(2))
+    println!("  [info] collaboration mesh has 0 peer records — waiting for first peer");
+    println!("         Ask the peer to run `airc join`; first-user startup is OK.");
+    Ok(())
 }
 
 pub async fn run_send_warning(
@@ -136,41 +44,16 @@ pub async fn run_send_warning(
     args: CollaborationScopeArgs,
 ) -> Result<(), Box<dyn Error>> {
     let home = args.home.as_deref().unwrap_or(default_home);
-    if peer_record_count(home).await == 0
-        && recent_remote_speakers(home, &args.my_name, &args.client_id).is_empty()
-    {
+    if peer_record_count(home).await == 0 {
         eprintln!(
-            "  WARN: collaboration has no direct peer records or recent broadcast peers. Run 'airc peers' and verify others joined this gist."
+            "  WARN: collaboration has no peer records. Run `airc peers` and verify others joined this account mesh."
         );
     }
     Ok(())
 }
 
-pub fn run_observed_whois(
-    default_home: &Path,
-    args: CollaborationScopeArgs,
-    peer_name: &str,
-) -> Result<(), Box<dyn Error>> {
-    let home = args.home.as_deref().unwrap_or(default_home);
-    let speakers = recent_remote_speakers(home, &args.my_name, &args.client_id);
-    let Some(ts) = speakers.get(peer_name) else {
-        return Err(command_exit(1));
-    };
-    println!("  name:      {peer_name}");
-    println!("  pronouns:  (unknown)");
-    println!("  role:      observed room participant");
-    println!("  bio:       seen in recent signed room traffic");
-    println!("  status:    (unknown)");
-    println!("  integrations: (none)");
-    println!(
-        "  presence:  observed from room traffic, last seen {}",
-        fmt_age(*ts)
-    );
-    Ok(())
-}
-
-pub fn command_exit_code(error: &(dyn Error + 'static)) -> Option<u8> {
-    error.downcast_ref::<CommandExit>().map(|error| error.0)
+pub fn command_exit_code(_error: &(dyn Error + 'static)) -> Option<u8> {
+    None
 }
 
 async fn peer_record_count(home: &Path) -> usize {
@@ -255,168 +138,9 @@ fn machine_account_home_for(scope_home: &Path) -> Option<std::path::PathBuf> {
     }
 }
 
-fn collaboration_evidence(home: &Path, my_name: &str, my_client_id: &str) -> CollaborationEvidence {
-    let mut evidence = CollaborationEvidence::default();
-    let now = Utc::now().timestamp();
-    for activity in remote_messages(home, my_name, None, my_client_id) {
-        if evidence
-            .any_activity
-            .as_ref()
-            .is_none_or(|current| activity.ts > current.ts)
-        {
-            evidence.any_activity = Some(activity.clone());
-        }
-        if now - activity.ts >= RECENT_REMOTE_WINDOW_SEC {
-            continue;
-        }
-        evidence
-            .recent_speakers
-            .entry(activity.name.clone())
-            .and_modify(|ts| *ts = (*ts).max(activity.ts))
-            .or_insert(activity.ts);
-        if evidence
-            .recent_activity
-            .as_ref()
-            .is_none_or(|current| activity.ts > current.ts)
-        {
-            evidence.recent_activity = Some(activity);
-        }
-    }
-    evidence
-}
-
-fn recent_remote_speakers(home: &Path, my_name: &str, my_client_id: &str) -> BTreeMap<String, i64> {
-    let mut speakers = BTreeMap::new();
-    for activity in remote_messages(home, my_name, Some(RECENT_REMOTE_WINDOW_SEC), my_client_id) {
-        speakers
-            .entry(activity.name)
-            .and_modify(|ts: &mut i64| *ts = (*ts).max(activity.ts))
-            .or_insert(activity.ts);
-    }
-    speakers
-}
-
-fn remote_messages(
-    home: &Path,
-    my_name: &str,
-    window_sec: Option<i64>,
-    my_client_id: &str,
-) -> Vec<MessageActivity> {
-    let now = Utc::now().timestamp();
-    fs::read_to_string(home.join("messages.jsonl"))
-        .unwrap_or_default()
-        .lines()
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
-        .filter(|message| !is_self_message(message, my_name, my_client_id))
-        .filter_map(|message| {
-            let ts = epoch(message.get("ts")?.as_str()?)?;
-            if window_sec.is_some_and(|window| now - ts >= window) {
-                return None;
-            }
-            let sender = message.get("from")?.as_str()?;
-            let client_id = message
-                .get("client_id")
-                .and_then(Value::as_str)
-                .unwrap_or_default();
-            Some(MessageActivity {
-                name: display_name(sender, client_id, my_name),
-                ts,
-            })
-        })
-        .collect()
-}
-
-fn is_self_message(message: &Value, my_name: &str, my_client_id: &str) -> bool {
-    let Some(sender) = message.get("from").and_then(Value::as_str) else {
-        return true;
-    };
-    if sender == "airc" {
-        return true;
-    }
-    let msg_client_id = message
-        .get("client_id")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    if !my_client_id.is_empty() && !msg_client_id.is_empty() {
-        return msg_client_id == my_client_id;
-    }
-    sender == my_name && msg_client_id.is_empty()
-}
-
-fn display_name(sender: &str, client_id: &str, my_name: &str) -> String {
-    if !client_id.is_empty() && sender == my_name {
-        format!("{sender} [{client_id}]")
-    } else {
-        sender.to_string()
-    }
-}
-
-fn epoch(ts: &str) -> Option<i64> {
-    DateTime::parse_from_rfc3339(ts)
-        .map(|value| value.timestamp())
-        .ok()
-        .or_else(|| {
-            NaiveDateTime::parse_from_str(ts.trim_end_matches('Z'), "%Y-%m-%dT%H:%M:%S")
-                .ok()
-                .map(|value| Utc.from_utc_datetime(&value).timestamp())
-        })
-}
-
-fn fmt_age(ts: i64) -> String {
-    let age = (Utc::now().timestamp() - ts).max(0);
-    if age < 60 {
-        format!("{age}s ago")
-    } else if age < 3600 {
-        format!("{}m ago", age / 60)
-    } else if age < 86400 {
-        format!("{}h ago", age / 3600)
-    } else {
-        format!("{}d ago", age / 86400)
-    }
-}
-
-#[derive(Debug)]
-struct CommandExit(u8);
-
-impl std::fmt::Display for CommandExit {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(formatter, "command exited with {}", self.0)
-    }
-}
-
-impl Error for CommandExit {}
-
-fn command_exit(code: u8) -> Box<dyn Error> {
-    Box::new(CommandExit(code))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn recent_speakers_excludes_self_by_client_id() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(
-            dir.path().join("messages.jsonl"),
-            format!(
-                "{}\n{}\n",
-                r#"{"from":"me","client_id":"mine","ts":"2026-05-19T12:00:00Z"}"#,
-                r#"{"from":"me","client_id":"peer-tab","ts":"2026-05-19T12:00:01Z"}"#,
-            ),
-        )
-        .unwrap();
-
-        let messages = remote_messages(dir.path(), "me", None, "mine");
-
-        assert_eq!(
-            messages,
-            vec![MessageActivity {
-                name: "me [peer-tab]".to_string(),
-                ts: 1_779_192_001,
-            }]
-        );
-    }
 
     #[tokio::test]
     async fn peer_record_count_requires_valid_json_files() {

--- a/crates/airc-cli/src/collaboration_peers.rs
+++ b/crates/airc-cli/src/collaboration_peers.rs
@@ -3,14 +3,9 @@ use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use serde_json::Value;
 
 use crate::collaboration_cli::CollaborationScopeArgs;
-
-const HEARTBEAT_KIND: &str = "heartbeat";
-const STALE_HEARTBEAT_SEC: i64 = 120;
-const RECENT_BROADCAST_WINDOW_SEC: i64 = 600;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct PeerRecord {
@@ -20,22 +15,14 @@ struct PeerRecord {
     stem: String,
 }
 
-#[derive(Debug, Default)]
-struct MessagePresence {
-    last_message: BTreeMap<String, i64>,
-    last_heartbeat: BTreeMap<String, i64>,
-}
-
 pub fn run_peers(default_home: &Path, args: CollaborationScopeArgs) -> Result<(), Box<dyn Error>> {
     let home = args.home.as_deref().unwrap_or(default_home);
     let peers = peer_records(home);
-    let presence = message_presence(home, &args.my_name, &args.client_id);
     if peers.is_empty() {
-        print_broadcast_or_empty(&presence, &args.my_name);
+        println!("  No peers yet.");
         return Ok(());
     }
-    print_peer_records(home, &peers, &presence);
-    print_broadcast_only(&presence, &rendered_names(&peers), &args.my_name);
+    print_peer_records(home, &peers);
     Ok(())
 }
 
@@ -122,149 +109,18 @@ fn peer_record_from_path(path: &Path) -> Option<PeerRecord> {
     })
 }
 
-fn message_presence(home: &Path, my_name: &str, my_client_id: &str) -> MessagePresence {
-    let mut presence = MessagePresence::default();
-    let raw = fs::read_to_string(home.join("messages.jsonl")).unwrap_or_default();
-    for message in raw
-        .lines()
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
-    {
-        let Some(who) = message_sender(&message, my_name, my_client_id) else {
-            continue;
-        };
-        let Some(ts) = message.get("ts").and_then(Value::as_str).and_then(epoch) else {
-            continue;
-        };
-        let target = if message.get("kind").and_then(Value::as_str) == Some(HEARTBEAT_KIND) {
-            &mut presence.last_heartbeat
-        } else {
-            &mut presence.last_message
-        };
-        target
-            .entry(who)
-            .and_modify(|current| *current = (*current).max(ts))
-            .or_insert(ts);
-    }
-    presence
-}
-
-fn message_sender(message: &Value, my_name: &str, my_client_id: &str) -> Option<String> {
-    let sender = message.get("from").and_then(Value::as_str)?;
-    let client_id = message
-        .get("client_id")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    if !my_client_id.is_empty() && client_id == my_client_id {
-        return None;
-    }
-    if sender == my_name {
-        if client_id.is_empty() {
-            return None;
-        }
-        return Some(format!("{sender} [{client_id}]"));
-    }
-    Some(sender.to_string())
-}
-
-fn print_peer_records(home: &Path, peers: &[PeerRecord], presence: &MessagePresence) {
+fn print_peer_records(home: &Path, peers: &[PeerRecord]) {
     let room = fs::read_to_string(home.join("room_name"))
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| "(?)".to_string());
-    let last_seen = last_seen(presence);
-    let now = Utc::now().timestamp();
     let mut seen_keys = BTreeSet::new();
     for peer in peers {
         if !seen_keys.insert((peer.name.clone(), peer.host.clone())) {
             continue;
         }
-        let last_ts = last_seen.get(&peer.name).copied();
-        let hb_ts = presence.last_heartbeat.get(&peer.name).copied();
-        println!(
-            "  {} -> {}   [#{}]   last seen {}{}",
-            peer.name,
-            peer.host,
-            room,
-            last_ts.map(fmt_age).unwrap_or_else(|| "never".to_string()),
-            silent_flag(now, last_ts, hb_ts)
-        );
-    }
-}
-
-fn print_broadcast_or_empty(presence: &MessagePresence, my_name: &str) {
-    let rendered = BTreeSet::new();
-    let rows = broadcast_rows(presence, &rendered, my_name);
-    if rows.is_empty() {
-        println!("  No peers yet.");
-        return;
-    }
-    println!("  Recent broadcast peers:");
-    for (who, ts) in rows {
-        println!(
-            "  {who} -> broadcast room   [(from signed messages.jsonl)]   last seen {}",
-            fmt_age(ts)
-        );
-    }
-}
-
-fn print_broadcast_only(presence: &MessagePresence, rendered: &BTreeSet<String>, my_name: &str) {
-    for (who, ts) in broadcast_rows(presence, rendered, my_name) {
-        println!(
-            "  {who} -> broadcast room   [(from signed messages.jsonl)]   last seen {}",
-            fmt_age(ts)
-        );
-    }
-}
-
-fn broadcast_rows(
-    presence: &MessagePresence,
-    rendered: &BTreeSet<String>,
-    my_name: &str,
-) -> Vec<(String, i64)> {
-    let now = Utc::now().timestamp();
-    let mut rows = last_seen(presence)
-        .into_iter()
-        .filter(|(who, ts)| {
-            who != my_name
-                && who != "airc"
-                && !rendered.contains(who)
-                && now - *ts < RECENT_BROADCAST_WINDOW_SEC
-        })
-        .collect::<Vec<_>>();
-    rows.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
-    rows
-}
-
-fn rendered_names(peers: &[PeerRecord]) -> BTreeSet<String> {
-    peers.iter().map(|peer| peer.name.clone()).collect()
-}
-
-fn last_seen(presence: &MessagePresence) -> BTreeMap<String, i64> {
-    let mut seen = presence.last_message.clone();
-    for (who, ts) in &presence.last_heartbeat {
-        seen.entry(who.clone())
-            .and_modify(|current| *current = (*current).max(*ts))
-            .or_insert(*ts);
-    }
-    seen
-}
-
-fn silent_flag(now: i64, last_ts: Option<i64>, hb_ts: Option<i64>) -> &'static str {
-    let Some(last_ts) = last_ts else {
-        return " (no recorded activity)";
-    };
-    let hb_age = hb_ts.map(|ts| now - ts);
-    if now - last_ts > 3600 {
-        match hb_age {
-            None => " (silent)",
-            Some(age) if age <= STALE_HEARTBEAT_SEC => " (silent, heartbeat OK)",
-            Some(_) => " (PROCESS DOWN)",
-        }
-    } else if hb_age.is_some_and(|age| age > STALE_HEARTBEAT_SEC) {
-        " (heartbeat stale)"
-    } else {
-        ""
+        println!("  {} -> {}   [#{}]", peer.name, peer.host, room,);
     }
 }
 
@@ -273,30 +129,6 @@ fn remove_peer_file(peers_dir: &Path, stem: &str, extension: &str) {
     path.push(format!("{stem}.{extension}"));
     if path.is_file() {
         let _ = fs::remove_file(path);
-    }
-}
-
-fn epoch(ts: &str) -> Option<i64> {
-    DateTime::parse_from_rfc3339(ts)
-        .map(|value| value.timestamp())
-        .ok()
-        .or_else(|| {
-            NaiveDateTime::parse_from_str(ts.trim_end_matches('Z'), "%Y-%m-%dT%H:%M:%S")
-                .ok()
-                .map(|value| Utc.from_utc_datetime(&value).timestamp())
-        })
-}
-
-fn fmt_age(ts: i64) -> String {
-    let age = (Utc::now().timestamp() - ts).max(0);
-    if age < 60 {
-        format!("{age}s ago")
-    } else if age < 3600 {
-        format!("{}m ago", age / 60)
-    } else if age < 86400 {
-        format!("{}h ago", age / 3600)
-    } else {
-        format!("{}d ago", age / 86400)
     }
 }
 
@@ -334,37 +166,5 @@ mod tests {
         assert!(!peers.join("old.json").exists());
         assert!(!peers.join("old.pub").exists());
         assert!(peers.join("new.json").exists());
-    }
-
-    #[test]
-    fn broadcast_rows_exclude_rendered_self_and_airc() {
-        let mut presence = MessagePresence::default();
-        let now = Utc::now().timestamp();
-        presence.last_message.insert("alice".to_string(), now);
-        presence.last_message.insert("me".to_string(), now);
-        presence.last_message.insert("airc".to_string(), now);
-        presence.last_message.insert("bob".to_string(), now);
-
-        let rendered = BTreeSet::from(["bob".to_string()]);
-        let rows = broadcast_rows(&presence, &rendered, "me");
-
-        assert_eq!(rows, vec![("alice".to_string(), now)]);
-    }
-
-    #[test]
-    fn message_presence_keeps_same_name_different_client() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(
-            dir.path().join("messages.jsonl"),
-            r#"{"from":"me","client_id":"mine","ts":"2026-05-19T12:00:00Z"}"#.to_string()
-                + "\n"
-                + r#"{"from":"me","client_id":"peer-tab","ts":"2026-05-19T12:00:01Z"}"#,
-        )
-        .unwrap();
-
-        let presence = message_presence(dir.path(), "me", "mine");
-
-        assert!(!presence.last_message.contains_key("me"));
-        assert!(presence.last_message.contains_key("me [peer-tab]"));
     }
 }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -252,9 +252,6 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             CollaborationAction::PrunePeers(args) => {
                 collaboration_peers::run_prune_peers(&home, args)
             }
-            CollaborationAction::ObservedWhois { scope, peer_name } => {
-                collaboration_commands::run_observed_whois(&home, scope, &peer_name)
-            }
         },
 
         Command::ChannelGist(args) => match args.action {


### PR DESCRIPTION
## Summary
- remove collaboration status/doctor/send-warning inference from local `messages.jsonl`
- remove broadcast-only peer rows and `observed-whois`, which were log-derived compatibility surfaces
- keep collaboration peer reporting tied to peer registries instead of local log scraping

## Verification
- cargo fmt --manifest-path Cargo.toml --all --check
- cargo check --manifest-path Cargo.toml -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-cli collaboration -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings