### PR TITLE
fix(install): copy artifacts instead of symlinking

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -493,12 +493,10 @@ _add_path_entry() {
   fi
 }
 
-# Put a tiny shim on PATH on every platform. Do not copy the full command
-# implementation and do not install a language-suffixed binary here.
 # Build the Rust binary and place it on PATH as `airc`. No shell
 # wrapper, no .shim/.cmd/.ps1 trampolines — the Rust binary is the
-# user surface. Post-demolition (PR D): one binary, one truth, no
-# legacy bash dispatch layer.
+# user surface. Copy the built binary into BIN_DIR so PATH never points
+# at mutable target artifacts inside the source checkout.
 _install_airc_binary() {
   [ "${AIRC_SKIP_RUST_BUILD:-0}" = "1" ] && { info "AIRC_SKIP_RUST_BUILD=1 -- skipping airc build"; return 0; }
   if ! command -v cargo >/dev/null 2>&1; then
@@ -518,13 +516,11 @@ _install_airc_binary() {
     *)
       local built="$CLONE_DIR/target/release/airc"
       [ -x "$built" ] || fail "airc build completed but binary is missing: $built"
-      # Symlink so subsequent `airc update` rebuilds are picked up
-      # without a re-install step. Atomic via rename to avoid a
-      # mid-install window where $BIN_DIR/airc is missing.
       local tmp="$BIN_DIR/.airc.tmp.$$"
-      ln -sf "$built" "$tmp"
+      cp -f "$built" "$tmp"
+      chmod +x "$tmp"
       mv -f "$tmp" "$BIN_DIR/airc"
-      ok "Installed airc: $BIN_DIR/airc -> $built"
+      ok "Installed airc: $BIN_DIR/airc"
       ;;
   esac
 
@@ -552,12 +548,11 @@ _install_airc_binary
 #   Claude Code → ~/.claude/skills/<name>/
 #   Codex       → ~/.codex/skills/<name>/
 #
-# We symlink airc's skills into both whenever the corresponding agent
-# is installed on the machine. Each agent picks up the same skill
-# content; airc's skill text is intentionally written to be agent-
-# generic where the operation is shell-callable (which most airc verbs
-# are). Claude-Code-specific nuances like Monitor invocations are
-# additive — Codex agents fall back to direct shell calls.
+# We copy airc's skills into both whenever the corresponding agent is
+# installed on the machine. Copies avoid symlink resolution differences
+# between shells, agents, Windows Git Bash, and future source checkouts.
+# Each copied skill carries a marker so uninstall can remove only
+# airc-owned skill directories.
 
 _install_airc_skills_into() {
   local skills_target="$1" agent_label="$2"
@@ -570,14 +565,12 @@ _install_airc_skills_into() {
     [ -f "$skill_dir/SKILL.md" ] || continue
     skill_name="$(basename "$skill_dir")"
     target="$skills_target/$skill_name"
-    # If the target is a real directory, it shadows the current skill
-    # link. Remove it and install the current skill.
-    if [ -d "$target" ] && [ ! -L "$target" ]; then
+    if [ -e "$target" ] || [ -L "$target" ]; then
       rm -rf "$target"
-    elif [ -L "$target" ]; then
-      rm "$target"
     fi
-    ln -sf "$skill_dir" "$target"
+    mkdir -p "$target"
+    cp -R "$skill_dir"/. "$target"/
+    printf 'installed-by=airc\nsource=%s\n' "$skill_dir" > "$target/.airc-skill"
     ok "Skill ($agent_label): /$skill_name"
   done
 }
@@ -613,7 +606,7 @@ fi
 # Codex sessions via `codex --profile airc`.
 #
 # Honors AIRC_SKIP_CODEX_CONFIG=1 if a user (or test harness) wants the
-# skill symlinks but NOT the config write.
+# skill install but NOT the config write.
 
 _install_airc_codex_permission_profile() {
   local config="$HOME/.codex/config.toml"

--- a/skills/canary/SKILL.md
+++ b/skills/canary/SKILL.md
@@ -16,7 +16,7 @@ Switches this airc install to the `canary` channel. Under the covers:
 - `git fetch origin canary`
 - `git checkout canary`
 - `git pull --ff-only`
-- Refreshes skills + binary symlinks via `install.sh`
+- Refreshes skills + installed binary via `install.sh`
 - Persists the choice to `$AIRC_DIR/.channel` so subsequent `airc update` (no args) stays on canary
 
 ## Execute

--- a/skills/uninstall/SKILL.md
+++ b/skills/uninstall/SKILL.md
@@ -27,7 +27,7 @@ Walks the full removal in order:
 1. `airc teardown --all` — stops every running airc process across all scopes on this machine
 2. Removes daemon registrations if present
 3. Removes stale POSIX forwarders and Windows shim files under `$BIN_DIR`
-4. Removes airc skill symlinks under `~/.claude/skills/`
+4. Removes airc-owned skill directories under `~/.claude/skills/`
 5. Removes the clone dir (`~/.airc/src` or `$AIRC_DIR`)
 
 **Confirmation prompt:** asks the user to type `yes` to proceed. If you're invoking from an agent, pass `--yes` only after the user has explicitly confirmed.

--- a/test/public_installed_runtime_proof.sh
+++ b/test/public_installed_runtime_proof.sh
@@ -39,14 +39,16 @@ fi
 "$AIRC_BIN" --version >/dev/null || fail "airc --version failed"
 
 # Demolition contract: no stale `airc-core` on PATH next to the
-# real binary. Symlink to source-tree target/release/airc IS the
-# expected shape (legacy "must be a shim file" check was wrapper-era).
+# real binary. The installed `airc` is a copied Rust binary, not a
+# shell wrapper or source-tree symlink.
 case "$(uname -s 2>/dev/null)" in
   MINGW*|MSYS*|CYGWIN*) ;;
   *)
     if [ -z "${AIRC_EXPECT_BIN:-}" ]; then
       [ ! -e "$(dirname "$AIRC_BIN")/airc-core" ] \
         || fail "POSIX install must not expose stale airc-core on PATH"
+      [ ! -L "$AIRC_BIN" ] \
+        || fail "POSIX install must copy the airc binary, not symlink it"
     fi
     ;;
 esac

--- a/test/rust_cutover_guard.sh
+++ b/test/rust_cutover_guard.sh
@@ -38,11 +38,10 @@ if git grep -nE 'messages[.]jsonl|airc bearer|gh-bearer|GH bearer|GitHub bearer|
   fail "old JSONL/bearer message-bus surface remains"
 fi
 
-# Post-demolition contract (PR D): the public `airc` is the Rust
-# binary at $BIN_DIR/airc, installed by install.sh from
-# target/release/airc. No bash wrapper, no .shim/.cmd/.ps1
-# trampolines, no airc-core suffix on the binary. Guards below
-# enforce that the install.sh shape stays consistent with that.
+# Post-demolition contract: the public `airc` is the Rust binary at
+# $BIN_DIR/airc, copied by install.sh from target/release/airc. No
+# bash wrapper, no source-tree symlink, no .shim/.cmd/.ps1
+# trampolines, no airc-core suffix on the binary.
 
 if [ -e airc ] || [ -e airc.shim ] || [ -e airc.cmd ] || [ -e airc.ps1 ]; then
   fail "legacy bash wrapper/trampoline files must not exist in the repo root"
@@ -62,6 +61,10 @@ fi
 
 if git grep -nE 'Installed command shim:|cat > "[$]BIN_DIR/airc" <<' -- install.sh; then
   fail "install.sh must not install a bash wrapper shim — the Rust binary is the user surface"
+fi
+
+if git grep -nE 'ln -sf "[$]built"|Installed airc: [$]BIN_DIR/airc ->|Symlink to source-tree target/release/airc' -- install.sh test ':!test/rust_cutover_guard.sh'; then
+  fail "install.sh must copy the Rust binary into BIN_DIR, not symlink target/release"
 fi
 
 if git grep -nE 'BIN_DIR.*/relay|for f in airc relay|[,{]airc,relay|relay-[*]' -- install.sh uninstall.sh skills; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -10,7 +10,7 @@
 #   - running airc processes (via airc teardown --all, if airc is on PATH)
 #   - daemon (launchd / systemd-user / Task Scheduler) via airc daemon uninstall
 #   - stale POSIX forwarders and Windows shim files under $BIN_DIR
-#   - skill symlinks under ~/.claude/skills/ pointing into the clone
+#   - airc-owned skill directories under ~/.claude/skills/ and ~/.codex/skills/
 #   - the clone itself (~/.airc/src or $AIRC_DIR)
 #
 # What it leaves:
@@ -59,7 +59,7 @@ cd "$HOME" 2>/dev/null || cd /
 cat <<EOF
 This will remove airc from this machine:
   PATH files        $BIN_DIR/{airc,airc.exe} plus legacy $BIN_DIR/{airc-core,airc-core.exe,airc.cmd,airc.ps1}
-  skill symlinks    $SKILLS_TARGET/<airc-skills>/ + ~/.codex/skills/<airc-skills>/ (if Codex installed)
+  skill dirs        $SKILLS_TARGET/<airc-skills>/ + ~/.codex/skills/<airc-skills>/ (if Codex installed)
   install dir       $CLONE_DIR
   daemon            launchd / systemd-user / Task Scheduler unit (if installed)
   running processes airc teardown --all (if airc is on PATH)
@@ -97,29 +97,32 @@ if command -v airc >/dev/null 2>&1; then
   fi
 fi
 
-# 3. Skill symlinks. Walk every entry in the skills dir and drop any
-# symlink that resolves into the clone. install.sh writes
-# into both ~/.claude/skills (Claude Code) and ~/.codex/skills (Codex)
-# when both agents are present, so we walk both on uninstall.
-_remove_clone_owned_skill_symlinks() {
+# 3. Skill dirs. Walk every entry in the skills dir and drop any airc-owned
+# copied skill directory. Also remove older symlinks that resolve into the
+# clone so upgrades converge cleanly.
+_remove_airc_owned_skills() {
   local skills_dir="$1"
   local removed=0 entry target
   [ -d "$skills_dir" ] || { echo 0; return; }
   for entry in "$skills_dir"/*; do
-    [ -L "$entry" ] || continue
-    target="$(readlink "$entry" 2>/dev/null || true)"
-    case "$target" in
-      "$CLONE_DIR"/*|"$CLONE_DIR")
-        rm -f "$entry"
-        removed=$((removed + 1)) ;;
-    esac
+    if [ -L "$entry" ]; then
+      target="$(readlink "$entry" 2>/dev/null || true)"
+      case "$target" in
+        "$CLONE_DIR"/*|"$CLONE_DIR")
+          rm -f "$entry"
+          removed=$((removed + 1)) ;;
+      esac
+    elif [ -d "$entry" ] && [ -f "$entry/.airc-skill" ]; then
+      rm -rf "$entry"
+      removed=$((removed + 1))
+    fi
   done
   echo "$removed"
 }
-removed_skills_claude=$(_remove_clone_owned_skill_symlinks "$SKILLS_TARGET")
-removed_skills_codex=$(_remove_clone_owned_skill_symlinks "${CODEX_SKILLS_TARGET:-$HOME/.codex/skills}")
-[ "$removed_skills_claude" -gt 0 ] && ok "Removed $removed_skills_claude skill symlink(s) from $SKILLS_TARGET"
-[ "$removed_skills_codex"  -gt 0 ] && ok "Removed $removed_skills_codex skill symlink(s) from ${CODEX_SKILLS_TARGET:-$HOME/.codex/skills}"
+removed_skills_claude=$(_remove_airc_owned_skills "$SKILLS_TARGET")
+removed_skills_codex=$(_remove_airc_owned_skills "${CODEX_SKILLS_TARGET:-$HOME/.codex/skills}")
+[ "$removed_skills_claude" -gt 0 ] && ok "Removed $removed_skills_claude airc skill dir(s) from $SKILLS_TARGET"
+[ "$removed_skills_codex"  -gt 0 ] && ok "Removed $removed_skills_codex airc skill dir(s) from ${CODEX_SKILLS_TARGET:-$HOME/.codex/skills}"
 
 # 3b. Codex config.toml cleanup. Strip the airc-managed GH_TOKEN block
 # (and the network-permission profile) if present. Keeps the rest of


### PR DESCRIPTION
## Summary
- install the Rust `airc` binary as a copied executable instead of a symlink to target/release
- copy agent skills with an `.airc-skill` ownership marker instead of symlinking into the source checkout
- update uninstall and cutover/public-runtime guards for the copied-artifact install contract

## Verification
- bash -n install.sh uninstall.sh test/public_installed_runtime_proof.sh test/rust_cutover_guard.sh
- bash test/rust_cutover_guard.sh
- bash test/rust_quality_guard.sh
- AIRC_BIN="$PWD/target/debug/airc" AIRC_EXPECT_BIN="$PWD/target/debug/airc" bash test/public_installed_runtime_proof.sh
- temp-home install proof: `AIRC_INSTALL_NO_PULL=1 bash install.sh`, assert installed `airc` is executable and not a symlink, skill copy has `.airc-skill`, and `airc --version` runs
- cargo fmt --manifest-path Cargo.toml --all --check