### PR TITLE
fix(lib): report peers from account mesh registry

### DIFF
--- a/crates/airc-cli/tests/events_commands.rs
+++ b/crates/airc-cli/tests/events_commands.rs
@@ -73,10 +73,13 @@ fn send_receipt_distinguishes_zero_paired_peers_without_lying_about_delivery() {
 }
 
 fn run_ok(home: &Path, args: &[&str]) -> String {
+    let account_home = home.parent().unwrap_or(home);
     let output = Command::new(airc_core())
         .arg("--home")
         .arg(home)
         .args(args)
+        .env("HOME", account_home)
+        .env("USERPROFILE", account_home)
         .output()
         .expect("airc-core command must spawn");
     assert!(

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -77,7 +77,7 @@ fn machine_account_home(scope_home: &Path) -> PathBuf {
     scope_home.to_path_buf()
 }
 
-async fn load_peer_registries(
+pub(crate) async fn load_peer_registries(
     home: &Path,
     wire_root: &Path,
 ) -> Result<Vec<peers_store::StoredPeer>, AircError> {

--- a/crates/airc-lib/src/peers.rs
+++ b/crates/airc-lib/src/peers.rs
@@ -46,14 +46,18 @@ impl Airc {
 
     /// Return a list of enrolled peers.
     pub async fn peers(&self) -> Result<Vec<EnrolledPeer>, AircError> {
-        let stored = peers_store::load(&self.inner.home).await?;
-        Ok(stored
+        let stored =
+            crate::airc::load_peer_registries(&self.inner.home, &self.inner.wire_root).await?;
+        let mut peers = stored
             .into_iter()
             .filter(|p| p.peer_id != self.inner.identity.peer_id)
             .map(|p| EnrolledPeer {
                 peer_id: p.peer_id,
                 pubkey_b64: p.pubkey_b64,
             })
-            .collect())
+            .collect::<Vec<_>>();
+        peers.sort_by_key(|p| p.peer_id.to_string());
+        peers.dedup_by_key(|p| p.peer_id);
+        Ok(peers)
     }
 }

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -265,6 +265,23 @@ fn same_machine_scopes_share_account_wire_and_registry() {
                 2,
                 "opening two local scopes must publish both identities into the machine registry"
             );
+            assert!(
+                alice
+                    .peers()
+                    .await
+                    .unwrap()
+                    .iter()
+                    .any(|peer| peer.peer_id == bob.peer_id()),
+                "alice's project scope must report peers from the machine-account registry"
+            );
+            assert!(
+                bob.peers()
+                    .await
+                    .unwrap()
+                    .iter()
+                    .any(|peer| peer.peer_id == alice.peer_id()),
+                "bob's project scope must report peers from the machine-account registry"
+            );
 
             alice.say("same-machine account wire").await.unwrap();
             let event =


### PR DESCRIPTION
## Summary
- make Airc::peers report the same project + machine-account trust registry used by runtime verification
- keep project scopes from showing 0 paired peers when the account HOME has enrolled local agents
- extend the same-machine account-wire regression to assert each scope sees the other in the SDK peer view

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib --check
- cargo test --manifest-path Cargo.toml -p airc-lib same_machine_scopes_share_account_wire_and_registry
- cargo clippy --manifest-path Cargo.toml -p airc-lib --all-targets -- -D warnings
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- peer list
- cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- msg "codex local account peer registry check <ts>"