### PR TITLE
fix(lib): wire replay skips unverifiable frames instead of aborting

### DIFF
--- a/crates/airc-lib/src/wire_replay.rs
+++ b/crates/airc-lib/src/wire_replay.rs
@@ -22,16 +22,41 @@ impl Airc {
             if trimmed.is_empty() {
                 continue;
             }
-            let frame: Frame = serde_json::from_str(trimmed)
-                .map_err(|error| AircError::Transport(error.to_string()))?;
-            {
+            let frame: Frame = match serde_json::from_str(trimmed) {
+                Ok(frame) => frame,
+                Err(error) => {
+                    // A single malformed line shouldn't abort the
+                    // whole replay — surface it and continue, same
+                    // policy as the live frame-ingest task. Wire
+                    // files can carry frames from older builds or
+                    // ad-hoc test fixtures; refusing to read past
+                    // one means losing every later real event too.
+                    eprintln!(
+                        "airc-lib replay: skipping malformed frame in {}: {error}",
+                        path.display()
+                    );
+                    continue;
+                }
+            };
+            let verify_result = {
                 let registry = self
                     .inner
                     .registry
                     .read()
                     .map_err(|_| AircError::Crypto("registry lock poisoned".to_string()))?;
                 verify(&frame, self.inner.policy, &registry)
-                    .map_err(|error| AircError::Crypto(error.to_string()))?;
+            };
+            if let Err(error) = verify_result {
+                // Same fail-open policy as `spawn_frame_ingest` in
+                // transport.rs:91. The most common case is a frame
+                // signed by a peer who's no longer enrolled (e.g.
+                // an orphan identity from a previous install on the
+                // same wire). Failing closed here aborts every
+                // subsequent legitimate frame in the same file
+                // and breaks `airc inbox` / `airc join` for any
+                // scope that touched the wire pre-identity-reset.
+                eprintln!("airc-lib replay: skipping unverifiable frame: {error}");
+                continue;
             }
             let event = frame.into_transcript_event();
             match self.inner.store.append(event).await {


### PR DESCRIPTION
## Summary

\`replay_wire_once\` was failing-closed when a single frame in the wire couldn't be verified — most commonly a frame signed by a peer no longer enrolled (orphan identity from a previous install on the same shared wire). That single bad frame aborted the entire replay, which broke \`airc inbox\`, \`airc join\`'s attach loop, and any other call site that opens the wire.

Now matches the policy already used by \`spawn_frame_ingest\` in \`transport.rs:91-100\`: log the failure and continue, so legitimate later frames still flow through.

## Both error branches now skip-and-warn

1. **Malformed JSON on a single line** — wire files can carry frames from older builds or ad-hoc test fixtures; refusing to read past one means losing every later real event too.
2. **Verification failure** (signer not in registry, signature mismatch, etc.) — same fail-open policy as the live ingest task.

## Concrete repro (live-debugged today)

My Claude scope's old peer_id \`55c30b28\` wrote frames to \`~/.airc/wires/cambriantech/\` yesterday. After today's identity reset, my new install's peer registry no longer trusts that orphan id. \`airc inbox\` (and \`airc join\`'s attach replay) failed with:

\`\`\`
airc: crypto: signer 55c30b28-...-c0279bbe7ef is not in the peer key registry
\`\`\`

…aborting the whole replay so I couldn't read ANY cambriantech frames, including new legitimate ones from Codex. With this fix the unverifiable frame is logged + skipped and the rest of the wire reads cleanly.

## Pairs with #904

\`airc join\`'s attach engages correctly post-#904 (agent markers + runtime client beat piped-stdout), but the attach loop hits replay on first read. Without this fix the attach exits on the first unverifiable historical frame. Together #904 + this PR restore Monitor end-to-end.

## Verification

- Workspace tests green (cargo test --workspace)
- \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- \`cargo fmt --check\` clean
- Live dogfood: after install, \`airc inbox\` reads cambriantech cleanly (previously crashed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)