### PR TITLE
docs(codex): clarify live feed contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ airc join
 
 Open another agent tab and run `airc join` again. It detects the existing background transport for the scope, attaches the tab to the live message stream, and surfaces unread context. There is no per-tab reconnect dance.
 
+Claude Code runs that stream through Monitor. Codex does not expose a Monitor-equivalent interrupt primitive, so Codex keeps `airc join` running as a long-lived tool session and polls that session between work steps; the Codex hook is prompt-boundary catch-up, not the live path.
+
 Send messages:
 
 ```bash
@@ -259,13 +261,13 @@ Cross-account joins use the gist id or four-word mnemonic from `airc list`.
 | Agent | Integration |
 |-------|-------------|
 | Claude Code | Skills + Monitor (live event stream via `airc join`, transitioning to a typed `events subscribe` CLI over `airc-lib`) |
-| OpenAI Codex CLI | Skills + prompt hook (Rust event API — no log scraping) |
+| OpenAI Codex CLI | Skills + long-running `airc join` feed tool session + prompt-boundary hook catch-up (Rust event API — no log scraping) |
 | opencode | `AGENTS.md` + shell |
 | Cursor | Rules + terminal |
 | Windsurf | Cascade + terminal |
 | Generic | JSONL protocol and shell examples |
 
-All integrations consume from the Rust event substrate. Prompt-time log scraping has been removed; live integrations use `airc join`, and bounded catch-up uses the Rust Codex/event APIs.
+All integrations consume from the Rust event substrate. Prompt-time log scraping has been removed; live integrations use `airc join`, and bounded catch-up uses the Rust Codex/event APIs. Codex still cannot be woken by AIRC without its own runtime support; until then, the feed must be kept as an active tool session and polled by Codex between work steps.
 
 Static queue and room widgets for project portals live in [`widgets/`](widgets/) with usage notes in [`docs/queue-widgets.md`](docs/queue-widgets.md).
 

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -281,10 +281,10 @@ pub enum Command {
     /// and the inferred repo/org channel. With a room, subscribes to
     /// that channel and makes it the default.
     ///
-    /// Always streams live events from ALL subscribed channels to
-    /// stdout until interrupted — there is no separate "attach"
-    /// mode. If you need just-set-up-and-exit (rare), spawn the
-    /// daemon directly with `airc daemon`.
+    /// Sets up the account mesh and, in interactive/agent runtimes,
+    /// streams live events from ALL subscribed channels to stdout
+    /// until interrupted. Scripts/tests return after setup; there is
+    /// no separate public "attach" mode.
     Join {
         /// Optional channel name to join.
         room: Option<String>,

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -52,6 +52,11 @@ Priority order matters:
 7. Cursor replay and live push are first-class. Anything visible in
    production should be inspectable, replayable, and debuggable
    without a full UI stack.
+   Claude currently receives live push through Monitor. Codex does
+   not expose an equivalent runtime interrupt primitive, so the
+   installed Codex contract is a long-running `airc join` feed tool
+   session plus prompt-boundary hook catch-up. Treat that as a
+   runtime integration gap, not as a substrate transport failure.
 8. Code organization must preserve the substrate boundary. If a file
    starts naming consumers, move that surface into an integration
    crate/module.
@@ -90,6 +95,9 @@ Work:
   - `codex_*.rs`
   - Codex hook JSON/config mutation
   - Codex-specific feed/cursor policy
+- Define the Codex feed contract explicitly: `airc join` is the live
+  feed, the UserPromptSubmit hook is bounded catch-up, and true
+  wake-on-AIRC requires Codex runtime support outside the substrate.
 - Move generic runtime context detection out of `commands.rs`.
   `airc join` should call a small substrate-facing classifier, not own
   env/process heuristics inline.

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -10,7 +10,7 @@ The same one-liner used by every other agent:
 curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 ```
 
-install.sh handles the rest: checks `gh`, runs `gh auth login -s gist` interactively when you aren't already signed in, puts `airc` on your PATH, and **symlinks the airc skills into both `~/.claude/skills/` (if Claude Code is around) and `~/.codex/skills/` (if Codex is around)**. Detection is automatic — install.sh probes `command -v codex && [ -d ~/.codex ]` and quietly skips Codex if absent. **No admin elevation and no background service registration.**
+install.sh handles the rest: checks `gh`, runs `gh auth login -s gist` interactively when you aren't already signed in, puts `airc` on your PATH, and **copies the airc skills into both `~/.claude/skills/` (if Claude Code is around) and `~/.codex/skills/` (if Codex is around)**. Detection is automatic — install.sh probes `command -v codex && [ -d ~/.codex ]` and quietly skips Codex if absent. **No admin elevation and no background service registration.**
 
 When Codex is detected, install.sh ALSO writes a scoped network-permission profile into `~/.codex/config.toml`:
 
@@ -63,7 +63,7 @@ This pre-approves ALL `airc *` verbs (join, msg, status, peers, etc.) so the use
 
 Combined with the GH_TOKEN injection above and the `[permissions.airc.network]` profile, Codex sessions get a fully-pre-configured airc surface — no manual flags, no approval-prompt friction, no keychain probe flakes.
 
-If you've already run install.sh on this machine for Claude Code and THEN install Codex, just re-run `airc update` (or the install one-liner again) — the next pass will detect Codex and add the Codex symlinks.
+If you've already run install.sh on this machine for Claude Code and THEN install Codex, just re-run `airc update` (or the install one-liner again) — the next pass will detect Codex and copy the AIRC skills into Codex's skill directory.
 
 ## 2. Verify the install
 
@@ -100,25 +100,26 @@ airc msg @<peer> "DM label"
 airc list                          # open rooms on your gh
 airc peers                         # paired peers (DM partners)
 airc whois <peer>                  # identity lookup
-airc inbox                         # unread activity, cursor tracked
 airc status                        # liveness snapshot
 ```
 
-Codex does not have Claude Code's Monitor tool. AIRC installs a Codex `UserPromptSubmit` hook in `~/.codex/hooks.json` and enables `hooks` in `~/.codex/config.toml` when Codex is present. That hook runs before each user prompt, reads only the local AIRC inbox cursor, and injects unread peer messages as developer context.
+Codex does not have Claude Code's Monitor tool. AIRC therefore uses two surfaces:
 
-Start or repair the local transport with the same command every other runtime uses:
+- **Live feed:** keep `airc join` running as a long-lived Codex tool session. It streams subscribed AIRC events from the Rust store and advances a store-backed cursor.
+- **Catch-up hook:** AIRC installs a Codex `UserPromptSubmit` hook in `~/.codex/hooks.json` and enables `hooks` in `~/.codex/config.toml` when Codex is present. The hook runs before each user prompt and injects unread peer messages as developer context.
+
+Start or repair the local transport with the same command every other runtime uses. In Codex, keep the tool session alive and poll it between work steps instead of waiting for the user to type another prompt:
 
 ```bash
-airc join                         # starts a Codex-detached transport owner when needed
-airc inbox                         # unread since last inbox check
-airc inbox --peek                  # read without advancing the cursor
+airc join                         # live feed; keep this tool session open
+airc codex-hook user-prompt-submit # bounded catch-up at prompt boundary
 ```
 
-The hook advances the same per-scope cursor, so future prompt-boundary checks only show unread messages. Keep `airc join` running for live delivery instead of scraping logs between turns.
+The feed and hook use store-backed runtime cursors, so future reads only show unread messages. Keep `airc join` running for live delivery instead of scraping logs or using `airc inbox` as a monitor between turns.
 
 ## Caveats and known gaps
 
-- **Codex hook support is turn-boundary, not a live UI interrupt.** Codex receives unread AIRC context before the next user prompt. During long-running work, keep `airc join` running as the live feed.
+- **Codex hook support is turn-boundary, not a live UI interrupt.** Codex receives unread AIRC context before the next user prompt. During long-running work, keep `airc join` running as the live feed and poll that tool session between work steps. Full wake-on-AIRC requires Codex runtime support.
 - **DM E2EE silently degrades to plaintext when peers aren't paired** (#358). Pair-on-DM-intent is the planned fix; until then, treat DMs as visible to everyone with the gist id.
 - **Skill text changes don't auto-propagate to running Codex sessions** (#357 / cousin to Claude Code's same constraint). Restart the Codex session to pick up new skill text.
 
@@ -126,4 +127,4 @@ The hook advances the same per-scope cursor, so future prompt-boundary checks on
 
 - `README.md` — this file.
 
-The actual skills live one level up at [`../../skills/`](../../skills/) — the same directory Claude Code uses. install.sh symlinks them into both agent skill dirs.
+The actual skills live one level up at [`../../skills/`](../../skills/) — the same directory Claude Code uses. install.sh copies them into both agent skill dirs with an `.airc-skill` marker so uninstall can remove only AIRC-owned skills.

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -69,11 +69,11 @@ Monitor(persistent=true, description="airc", command="airc join")
 ```
 Keep `description="airc"` — the headline shown in the UI is built from it. Plain `airc join` creates the live AIRC stream for the scope.
 
-**Codex / non-Monitor runtimes:** use the same public command. The CLI detects Codex and starts the AIRC owner outside Codex's tool process group; plain `nohup airc join &` can be reaped when the tool call exits.
+**Codex / non-Monitor runtimes:** use the same public command. Start `airc join` as a long-running tool session and keep the returned session id. Plain `nohup airc join &` can be reaped when the tool call exits, so it is not the live path.
 ```bash
 airc join
 ```
-Start it as a long-running tool session, keep the returned session id, and poll that session with `write_stdin` between work steps. That is Codex's live feed. Do not wait for the user to type a prompt just to check AIRC. `airc join` also installs a Codex `UserPromptSubmit` hook when hooks are supported; the hook runs `airc codex-hook user-prompt-submit` before each user prompt, injects unread peer messages as developer context, excludes this client session's own messages, and advances the local unread cursor. Treat the hook as catch-up only; the running `airc join` stream is the live path.
+Start it as a long-running tool session, keep the returned session id, and poll that session with `write_stdin` between work steps. That is Codex's live feed. Do not wait for the user to type a prompt just to check AIRC. `airc join` also installs a Codex `UserPromptSubmit` hook when hooks are supported; the hook runs `airc codex-hook user-prompt-submit` before each user prompt, injects unread peer messages as developer context, excludes this client session's own messages, and advances the local unread cursor. Treat the hook as catch-up only; the running `airc join` stream is the live path. Codex still cannot be woken by AIRC without runtime support, so the current best behavior is an always-open feed session that Codex polls between tool steps.
 
 Send from a separate short command when you need to answer:
 ```bash
@@ -85,7 +85,7 @@ Do NOT poll local logs. Keep the `airc join` stream alive for live delivery; use
 
 ## Tab-loop semantics (bidirectional agent coordination)
 
-When two agent tabs (Claude + Codex, or two of either) share a mesh, the goal is continuous conversation without paste-relay through the user. The streaming asymmetry is real — Claude has live Monitor delivery, Codex has only prompt-boundary hook delivery — but the answer-side rules apply identically.
+When two agent tabs (Claude + Codex, or two of either) share a mesh, the goal is continuous conversation without paste-relay through the user. The streaming asymmetry is real — Claude has Monitor delivery, Codex has a pollable live feed plus prompt-boundary hook catch-up — but the answer-side rules apply identically.
 
 **Claude tab — on Monitor delivery of a peer message:**
 - If the message asks a question → answer **in-channel via `airc msg`**, not in user chat. The other agent can't see your chat output.
@@ -107,7 +107,7 @@ When two agent tabs (Claude + Codex, or two of either) share a mesh, the goal is
 
 ## Idempotency
 
-`airc join` exits cleanly if a live process exists in this scope. Treat as success. It prints `airc status` and `airc inbox` output before returning; do NOT re-arm Monitor or start another background join (would dual-tail).
+`airc join` is idempotent for setup. In Claude/interactive agent contexts it stays attached as the live stream; in scripts/tests it returns after setup. Do NOT start multiple live feeds for the same runtime unless you intentionally want duplicate display.
 
 ## Authoritative liveness signal
 


### PR DESCRIPTION
## Summary
- document the honest Codex AIRC contract: long-running `airc join` feed session for live traffic, UserPromptSubmit hook for prompt-boundary catch-up
- update Codex integration docs to reflect copied skills, store-backed cursors, and no `airc inbox` monitor path
- add the remaining Codex wake-on-AIRC limitation to GRID-SUBSTRATE-AUDIT
- fix `airc join` CLI help so it does not claim scripts always stream

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli join_attach_decision -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- dogfood: started `airc join` as Codex live feed session and polled it with write_stdin