### PR TITLE
docs: AR/Cambrian/grid framing + data-model + Phase 3.5 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# airc — Agentic Internet Relay Chat
+# airc — Cambrian's Backbone Bus
 
-A Rust grid substrate that lets local and remote AI agents share signed, typed events across machines. The user-facing surface is IRC-shaped because agents already understand IRC, but the wire underneath is the Rust substrate — signed envelopes, header-filterable subscriptions, durable store + cursor replay, and pluggable transports (same-host, LAN, relay, UDP, WebRTC). Consumers above the substrate (Continuum, Hermes, OpenClaw, opencode/Codex/Claude) speak typed `forge.*` contracts on the same wire without the substrate having to know what those headers mean.
+A Rust grid substrate that carries every Cambrian internal system on one signed, typed event wire — AR pose streams (60–90Hz, sub-25ms p99 on Tailnet/LAN), distributed-inference command/reply traffic, persona event buses, agent coordination, fleet presence, and IRC-shaped human/agent chat as one consumer profile among many. The substrate is layered so AR-rate workloads and chat-shaped consumers can ride the same envelopes without compromising either.
+
+Three primitives at the core: **signed envelopes** (Ed25519 + ChaCha20-Poly1305 for DMs), **header-filterable multi-room subscriptions**, and a **route resolver** that picks among local-fs / LAN-TCP / Tailscale / relay / WebRTC / Reticulum transports based on per-frame route-class hints + per-route health. Consumers above the substrate (Continuum, OpenClaw, Hermes, agent-relay, forge-alloy, sentinel-ai, AI agents) speak typed `forge.*` / `continuum.*` / `openclaw.*` contracts on the same wire without the substrate having to know what those headers mean. See [`docs/architecture/CAMBRIAN-CONSUMER-INTEGRATION-MATRIX.md`](docs/architecture/CAMBRIAN-CONSUMER-INTEGRATION-MATRIX.md) for the full consumer roster.
 
 The default flow is intentionally small:
 
@@ -86,7 +88,7 @@ Three layers, sharp boundaries:
 | **SDK** (`airc-lib`) | typed ergonomic API: `Airc::open`, `join_with_wire`, `send`, `subscribe_filtered`, `page_recent`, `resume_from`, `add_peer`, `rotate_peer` | reimplement substrate primitives; reach around the substrate to a different store |
 | **Consumers** (Continuum, Hermes, OpenClaw, opencode/Codex/Claude, your app) | typed `forge.*` event vocabularies, capability projections that map "I want model X" to a peer who advertised it, agent policy | reach into substrate internals; embed substrate state in their own; bypass `airc-lib` for performance |
 
-The substrate's only routing primitive is **"deliver events whose headers match this filter to subscribers of that filter."** It does not know that `forge.hermes.tool="continuum.lora.invoke"` should land on a peer with a loaded LoRA capability. That mapping — tool-name → capability-bearing-peer — is policy that lives in the consumer layer, not in airc. If airc started ranking peers by VRAM × latency × model-match, the next request would be for airc to UNDERSTAND models, which dissolves the layer.
+The substrate's core routing primitives are (1) **header-filtered subscription delivery** — events whose headers match a subscriber's filter fan out to that subscriber, multi-room by default; and (2) the **route resolver** — for each send, pick among local-fs / LAN / Tailscale / relay / WebRTC / Reticulum based on per-route health + an optional `airc.route_class` hint from the sender (AR consumers pin `local-only` or `lan-allowed`). The substrate does not know that `forge.hermes.tool="continuum.lora.invoke"` should land on a peer with a loaded LoRA capability. That mapping — tool-name → capability-bearing-peer — is policy that lives in the consumer layer, not in airc. If airc started ranking peers by VRAM × latency × model-match, the next request would be for airc to UNDERSTAND models, which dissolves the layer.
 
 ### Transports (pick automatically, fail loudly)
 
@@ -109,7 +111,9 @@ The Rust route resolver picks among these based on local health + invite metadat
 
 ## The Model
 
-airc is IRC-shaped because agents already understand IRC.
+The substrate is **envelope-shaped, not chat-shaped**: every send is a signed typed event with headers and an opaque body. Chat-shaped consumers get an IRC-friendly surface on top of those envelopes because agents and humans already understand IRC; AR pose streams, command/reply traffic, capability advertisements, and other non-chat consumers ride the same envelopes with different headers and don't see (or need) the IRC layer at all.
+
+When you're consuming chat through the CLI or a Claude/Codex skill, the IRC mapping below is what you interact with. When you're embedding airc as Continuum's pose-sync bus, you see typed events through `airc-lib`, not `/join`.
 
 | IRC | airc |
 |-----|------|

--- a/REFCONTRACT.md
+++ b/REFCONTRACT.md
@@ -1,5 +1,18 @@
 # airc reference contract
 
+**STATUS: LEGACY — HISTORICAL SPEC ONLY.** This contract describes
+the shell/Python+gist implementation of airc that the Rust rewrite
+supersedes. Current substrate specs live in
+`docs/architecture/AIRC-RUST-SUBSTRATE.md`,
+`docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md`,
+`docs/architecture/INVITE-ROUTING-ARCHITECTURE.md`, and
+`docs/DATA-MODEL-REFERENCE.md`. The bearer/gist-as-data-plane code
+referenced below was removed in #899 + #900; `messages.jsonl` is
+no longer on the wire post-Phase 3.5. Read this doc only for
+historical context on how the original shell airc worked.
+
+---
+
 The trunk is this document. The leaves are `airc` (bash) and `airc.ps1` (PowerShell). Both implementations must conform to the function names, argument shapes, return shapes, preconditions, and postconditions specified here. Implementation details (how bash spawns a background loop vs how PS does it; how each language reads/writes the gist) are leaf concerns.
 
 A bug is one of:

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -1,23 +1,36 @@
 //! `airc-lib` — consumer-facing AIRC API.
 //!
-//! Closes grievance §5 (CLI/Daemon Accumulating Policy — the needed
-//! crate split lists `airc-lib` as the consumer-facing surface) and
-//! advances Gate 4 (Consumer Embedding) of the operating doc:
+//! This crate composes the lower-level substrate crates
+//! (`airc-core`, `airc-protocol`, `airc-store`, `airc-transport`,
+//! `airc-daemon`) into one `Airc` facade so consumers (Continuum,
+//! OpenClaw, Hermes, agent runtimes, the CLI itself) don't have to
+//! reconstruct the wiring on every embedding.
+//!
+//! Two ways to use it:
+//!
+//! 1. **In-process embedding** via [`Airc::open(home)`]. The handle
+//!    owns its identity + store + transports directly; no daemon
+//!    involved. Consumers that want their own substrate instance in
+//!    the same process.
+//!
+//! 2. **Daemon-attached** via [`Airc::attach(home, socket)`]. The
+//!    handle talks to a long-running daemon process over the IPC
+//!    socket; suitable for CLI subcommands and short-lived consumers
+//!    that want to share state with persistent runtime processes.
+//!
+//! Closes grievance §5 (CLI/Daemon Accumulating Policy) and Gate 4
+//! (Consumer Embedding) of the operating doc:
 //!
 //! > Pass when a small consumer app can link `airc-lib` and:
 //! > create/load identity; join a channel; send typed body with
 //! > headers; subscribe by header/channel/kind; fetch replay; use
 //! > blobs; never shell out.
 //!
-//! This crate composes the lower-level substrate crates
-//! (`airc-core`, `airc-protocol`, `airc-store`, `airc-transport`,
-//! `airc-daemon`) into one `Airc` facade so consumers don't
-//! reconstruct the wiring on every embedding.
-//!
-//! Scope of this slice (slice 6): in-process embedding. The handle
-//! owns its identity + store + transports directly; no daemon IPC
-//! involved. Daemon-attached mode (`Airc::attach(socket)`) is queued
-//! for slice 6b along with the subscribe-stream surface.
+//! Both shapes are now shipped. The doctrine framework is in
+//! [`docs/architecture/AIRC-RUST-SUBSTRATE.md`](../../docs/architecture/AIRC-RUST-SUBSTRATE.md)
+//! and the consumer roster + table schemas are in
+//! [`docs/architecture/CAMBRIAN-CONSUMER-INTEGRATION-MATRIX.md`](../../docs/architecture/CAMBRIAN-CONSUMER-INTEGRATION-MATRIX.md)
+//! and [`docs/DATA-MODEL-REFERENCE.md`](../../docs/DATA-MODEL-REFERENCE.md).
 
 #![deny(unsafe_code)]
 

--- a/docs/DATA-MODEL-REFERENCE.md
+++ b/docs/DATA-MODEL-REFERENCE.md
@@ -1,0 +1,355 @@
+# airc Data Model Reference
+
+**Status**: Source of truth for every persistent table in the airc
+substrate. Generated from the SeaORM entities at
+`crates/airc-store/src/entities/`. If this doc disagrees with the
+code, the code is right — file an issue.
+
+**Scope**: This is the schema reference, not the access-pattern
+reference. For owner/reader maps and TTL/drain policies, see the
+right-hand columns; for the API surface (which `SqliteEventStore`
+methods touch each table), see `crates/airc-store/src/sqlite.rs`.
+
+## Storage layout
+
+One SQLite file per scope, opened with WAL mode:
+
+```
+<scope-home>/events.sqlite
+```
+
+For machine-account-shared state (the wire-root home, default
+`~/.airc/`), the same file lives under that root and is opened
+read-write by every scope on the same user account. SQLite's WAL
+journaling handles the multi-writer-one-machine case; cross-machine
+sync is the account-registry document's job, not SQLite's.
+
+Migration runner: `Migrator::up` in
+`crates/airc-store/src/migration/mod.rs`. Applied automatically on
+`SqliteEventStore::open`. Migrations are strictly additive — new
+table or new column only, never destructive.
+
+## Tables
+
+### `events` — canonical transcript log
+
+Migration `m20260519_000001_create_events`. The append log every
+consumer reads from. One row per persisted `TranscriptEvent`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `event_id` | UUIDv4 PK | Globally unique. |
+| `room_id` | UUID | Channel the event landed in. |
+| `peer_id` | UUID | Author. |
+| `client_id` | UUID | Runtime client tag (Claude/Codex/etc). |
+| `kind` | TEXT | `TranscriptKind` as snake_case; readable in a DB browse. |
+| `occurred_at_ms` | INTEGER | Wall-clock at send. |
+| `lamport` | INTEGER | Sender's monotonic counter; **primary ordering key**. |
+| `target` | JSON | `MentionTarget`. |
+| `headers` | JSON | Header map (`airc.client`, `airc.correlation_id`, etc.). |
+| `body` | JSON, NULLable | Wire payload. JSON shape is consumer-owned. |
+| `attachment` | JSON, NULLable | `AttachmentManifest`. |
+| `receipt` | JSON, NULLable | Delivery receipt. |
+| `metadata` | JSON | Free-form consumer metadata. |
+
+**Indexes**: composite `(room_id, lamport, event_id)` for
+`page_recent` / `resume_from` O(log n + page). See migration.
+
+**Retention**: never auto-purged. Truncation is a separate operator
+verb; transcripts are durable.
+
+**Owner**: `SqliteEventStore::append`. **Readers**: every consumer
+via `page_recent` / `resume_from` / `latest_cursor`.
+
+---
+
+### `runtime_cursors` — per-consumer replay checkpoints
+
+Migration `m20260522_000002_create_runtime_cursors`. Replaces the
+sidecar JSON cursor files (`codex_hook_cursor.json`,
+`join_feed_cursor.*.json`) that Phase 3.5 deleted.
+
+| Column | Type | Notes |
+|---|---|---|
+| `consumer_id` | TEXT PK | Stable consumer tag, e.g. `join-feed:codex:thread-abc`, `codex-hook:default`. |
+| `lamport` | INTEGER | Saved cursor `lamport`. |
+| `event_id` | UUID | Saved cursor `event_id`. |
+| `updated_at_ms` | INTEGER | Wall-clock at last save. |
+
+**Retention**: rows persist until the consumer explicitly clears or
+a future stale-cursor drain runs. No automatic eviction yet.
+
+**Owner**: any consumer that wants resumable replay. **Readers**:
+same.
+
+---
+
+### `peer_trust` — enrolled peer public keys
+
+Migration `m20260522_000003_create_peer_trust`. Replaces the
+deleted `peers.json` sidecar.
+
+| Column | Type | Notes |
+|---|---|---|
+| `peer_id` | UUID PK | Foreign-key-equivalent to `events.peer_id`. |
+| `pubkey_b64` | TEXT | URL-safe base64 (no pad). |
+| `added_at_ms` | INTEGER | First enrolment timestamp. |
+
+**Retention**: durable until explicit removal (`airc kick` /
+`airc peer remove` / future).
+
+**Owner**: pairing flows (`airc.import_invite`, account registry
+import). **Readers**: signed-transport verification, `airc peers`,
+account registry publishing.
+
+---
+
+### `peer_rotation_audit` — append-only rotation log
+
+Migration `m20260522_000003_create_peer_trust` (same migration as
+`peer_trust`).
+
+| Column | Type | Notes |
+|---|---|---|
+| `peer_id` | UUID, composite PK | The rotating peer. |
+| `sequence` | INTEGER, composite PK | Monotonic per-peer. Crypto-enforced. |
+| `prev_pubkey_b64` | TEXT | Key being rotated out. |
+| `next_pubkey_b64` | TEXT | Key being rotated in. |
+| `rotated_at_ms` | INTEGER | When the rotation was signed. |
+| `applied_at_ms` | INTEGER | When this scope verified + applied it. |
+
+**Retention**: append-only forever. Trust history must be
+auditable.
+
+**Owner**: `peers_store::rotate`. **Readers**: trust audit tools,
+incident response.
+
+---
+
+### `subscriptions` — joined channels + default-channel state
+
+Migration `m20260522_000004_create_subscriptions`. Replaces the
+deleted `subscriptions.json` and `room.json` sidecars.
+
+| Column | Type | Notes |
+|---|---|---|
+| `channel_name` | TEXT PK | Human-readable channel name. |
+| `room_id` | UUID | Deterministic from name + mesh identity. |
+| `wire` | TEXT | Filesystem path to the wire directory. |
+| `joined_at_ms` | INTEGER | First-join timestamp. |
+| `is_default` | BOOLEAN | Exactly one row should have this true. |
+| `parted` | BOOLEAN | Tombstone; never deleted, just flagged. |
+
+**Per-scope**: this table is scoped — each `events.sqlite` has its
+own. Joel's vHSM scope has different subscriptions than his
+continuum scope.
+
+**Retention**: durable. `airc part` flips `parted` to true and
+clears `is_default` if applicable; the row stays for replay
+fidelity.
+
+**Owner**: `airc join` / `airc room`. **Readers**: every send/recv
+path, `airc peer list`, `airc status`.
+
+---
+
+### `local_identity` — singleton install metadata
+
+Migration `m20260522_000005_create_local_identity` (base) +
+`m20260522_000009` (identity-card columns). Replaces the deleted
+`identity.json` sidecar. The secret keypair stays on disk in
+`identity.key` (0600); see [Identity & secrets](#identity--secrets).
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | INTEGER PK | Always 1. CHECK constraint enforces singleton. |
+| `peer_id` | UUID | Stable across CLI invocations. |
+| `client_id` | UUID | Runtime client default. |
+| `version` | INTEGER | Schema version of this row's shape. |
+| `created_at_ms` | INTEGER | First-generate timestamp. |
+| `name` | TEXT | Identity card field; default `""`. |
+| `pronouns` | TEXT | Identity card field; default `""`. |
+| `role` | TEXT | Identity card field; default `""`. |
+| `bio` | TEXT | Identity card field; default `""`. |
+| `status` | TEXT | Away/back; default `""`. |
+| `fingerprint` | TEXT | Cached identity fingerprint; default `""`. |
+| `integrations_json` | JSON | Per-integration profile data; default `{}`. |
+
+**Per-scope**: yes. Each scope has its own singleton row paired
+with its own `identity.key`.
+
+**Retention**: durable.
+
+**Owner**: `airc-daemon::LocalIdentity::load_or_generate`.
+**Readers**: every command that needs `peer_id` / `client_id`;
+`airc identity show`.
+
+---
+
+### `mesh_identity` — cached account identity for room derivation
+
+Migration `m20260522_000006_create_mesh_identity`. Replaces the
+deleted `mesh_identity.json` sidecar.
+
+| Column | Type | Notes |
+|---|---|---|
+| `scope` | TEXT PK | Scope home this cache entry belongs to. |
+| `identity` | TEXT | Resolved identity string (`gh login`, git email, or local fallback). |
+| `source` | TEXT | `GhApiUser` / `GitEmail` / `LocalHostUser` / `Operator`. |
+| `resolved_at_ms` | INTEGER | When the resolver ran. |
+| `ttl_ms` | INTEGER | How long this cache entry is fresh. |
+
+**Retention**: replaced on re-resolution; `Operator`-source entries
+never expire (per #868).
+
+**Owner**: `mesh_identity::resolve` / `resolve_with`. **Readers**:
+RoomId derivation, account registry document generation,
+`airc whois`.
+
+---
+
+### `account_registry` — local cache of the published cross-machine document
+
+Migration `m20260522_000007_create_account_registry`. Replaces the
+deleted `account_registry/<mesh-identity>/registry.json` sidecar.
+
+| Column | Type | Notes |
+|---|---|---|
+| `mesh_identity` | TEXT PK | The mesh this document represents. |
+| `schema_version` | INTEGER | Copied from the document. |
+| `generated_at_ms` | INTEGER | When the sender stamped it. |
+| `document_json` | TEXT | Serialized `AccountRegistryDocument`. Wire payload. |
+| `updated_at_ms` | INTEGER | When we last wrote the row. |
+
+**Treatment**: per non-negotiable #9, the document body is opaque
+JSON because it's wire payload encoding. Indexed-queryable
+identifiers are typed columns.
+
+**Retention**: upserted on every publish-or-refresh.
+
+**Owner**: `SqliteAccountRegistryStore::publish` /
+`GhAccountRegistryStore`. **Readers**: import flows on other
+machines.
+
+---
+
+### `account_registry_gist_sentinel` — per-mesh-identity gist id
+
+Migration `m20260522_000007_create_account_registry` (same migration).
+Replaces the deleted
+`<sentinel_root>/account-registry-gist-id` sidecar.
+
+| Column | Type | Notes |
+|---|---|---|
+| `mesh_identity` | TEXT PK | One sentinel per mesh on this machine. |
+| `gist_id` | TEXT | Opaque to the store; gh adapter interprets. |
+| `updated_at_ms` | INTEGER | Last-saved timestamp. |
+
+**Retention**: cleared by `clear_account_registry_gist_sentinel`
+when the remote gist is detected as gone (out-of-band delete).
+
+**Owner**: `GhAccountRegistryStore::save_gist_id` /
+`clear_gist_id`. **Readers**: every `publish` to decide
+edit-existing vs create-new.
+
+---
+
+### `beacons` — account-mesh presence beacons
+
+Migration `m20260522_000008_create_beacons`. Replaces the deleted
+`accounts/<mesh-identity>/beacons/<peer-id>.json` sidecar tree.
+
+| Column | Type | Notes |
+|---|---|---|
+| `mesh_identity` | TEXT, composite PK | Which mesh this beacon belongs to. |
+| `peer_id` | UUID, composite PK | Which peer is announcing. |
+| `scope_home` | TEXT | Absolute path of the scope this beacon comes from. |
+| `pid` | INTEGER | Process ID (for diagnostics; not load-bearing). |
+| `published_at_ms` | INTEGER | When the beacon was first written. |
+| `heartbeat_at_ms` | INTEGER | Last freshness ping. Used for live/stale partitioning. |
+
+**Live vs stale**: a row is "live" when
+`now - heartbeat_at_ms < CoordinatorConfig::heartbeat_ttl_ms`.
+Drain via `drain_stale_store`. Drains are caller-driven; no
+automatic eviction yet (audit TODO).
+
+**Owner**: `coordinator::publish_store`. **Readers**:
+`coordinator::snapshot_store`, account registry document
+generation, peer list, status display.
+
+---
+
+### `beacon_channels` — channels-per-beacon many-to-many
+
+Migration `m20260522_000008_create_beacons` (same migration).
+
+| Column | Type | Notes |
+|---|---|---|
+| `mesh_identity` | TEXT, composite PK | Tied to a beacon row. |
+| `peer_id` | UUID, composite PK | Tied to a beacon row. |
+| `channel_name` | TEXT, composite PK | One row per channel the beacon advertised. |
+
+**Owner**: `coordinator::publish_store` (atomic replace alongside
+the beacon row). **Readers**:
+`coordinator::snapshot_store::live_channels` aggregation.
+
+## Identity & secrets
+
+The 32-byte Ed25519 secret stays in `<scope>/identity.key` (0600 on
+Unix). It is NOT in the database. The doctrine: blobs go to disk
+or to OS-protected key storage (filesystem perms today; SQLCipher /
+keychain / hardware enclave in production-hardened deployments).
+Per non-negotiable #9, this is the deliberate exception to "durable
+substrate data uses the ORM."
+
+`local_identity.row` and `identity.key` are paired:
+- Both exist → load.
+- Both missing → generate.
+- One missing → `PartialState` error (refuse to invent a new peer_id
+  over an existing key). Recovery: see
+  [PHASE-3.5-MIGRATION.md](PHASE-3.5-MIGRATION.md) (TODO).
+
+## Cross-table invariants
+
+- `events.peer_id` must have a `peer_trust` row (or be the local
+  identity) for `VerificationPolicy::Strict` to accept the frame.
+  Replay handles unknown signers via skip-and-warn (#905).
+- `beacons.peer_id` similarly must be in `peer_trust` (or local) for
+  the coordinator to trust it.
+- `subscriptions.room_id` is deterministically derived from
+  `(mesh_identity, channel_name)` via UUIDv5 — two peers that
+  resolve to the same `mesh_identity` will collide on `room_id` for
+  the same `channel_name`, which is how account-scoped rooms
+  auto-converge.
+
+## What's NOT in the database
+
+- Wire transcript files (`<wire-root>/wires/<channel>/frames.jsonl`)
+  — these are the **transport layer**, separate from the durable
+  store. They exist so a fresh scope can replay the channel without
+  needing to import a sqlite snapshot. The store is the source of
+  truth for what THIS scope has seen; the wire is what it observed
+  on the bus.
+- Refresh-lock sentinels (`accounts/<mesh-identity>/refresh.lock`)
+  — coordinator singleflight primitive. Filesystem-locked because
+  the lock semantics depend on POSIX atomic rename, which SQLite
+  can't model cleanly.
+- The Ed25519 secret (see above).
+
+## When to add a new table
+
+Read non-negotiable #9 in
+[GRID-SUBSTRATE-AUDIT.md](architecture/GRID-SUBSTRATE-AUDIT.md):
+
+> Durable substrate data uses the store/ORM boundary. JSON is
+> allowed for wire payload encoding, install/config bootstrap, and
+> external invite documents; it is not acceptable for runtime
+> cursors, trust state, subscriptions, presence registries, or
+> replay checkpoints.
+
+If your feature owns "durable substrate data" that doesn't fit any
+table above, add a migration. Migration numbering is monotonic
+(`m20260522_000010_*` etc.); ordering matters for the up()
+sequence. Tables are strictly additive — never delete or alter
+column types in an existing migration; ship a new migration that
+adds a column or a sibling table instead.

--- a/docs/PEER-DISCOVERY-SCALABILITY.md
+++ b/docs/PEER-DISCOVERY-SCALABILITY.md
@@ -1,0 +1,155 @@
+# Peer Discovery Scalability
+
+**Status**: Current-state reference + open architectural questions
+for scaling discovery beyond same-machine + one-operator-fleet
+topologies.
+
+## Current model (post-Phase 3.5)
+
+airc's discovery has three layers, each addressing a different
+peer-count regime:
+
+### Layer 1: same-machine (proven, fast)
+
+All scopes on one user's machine share the wire root at
+`~/.airc/wires/<channel>/`. The local-fs adapter writes frames to
+`frames.jsonl`; every scope's wire subscriber tails the file.
+Discovery is implicit — peer rows in the shared `peer_trust` table
+under `~/.airc/events.sqlite` are visible to every scope on the
+account.
+
+Beacons under `beacons` + `beacon_channels` advertise per-scope
+presence with TTL-based live/stale partitioning
+(`CoordinatorConfig::heartbeat_ttl_ms`, default ~30s).
+
+**Scale ceiling**: hundreds of scopes per machine, bounded by
+SQLite-WAL concurrent-reader limits and tail-loop CPU. Not a
+production concern.
+
+### Layer 2: per-operator-fleet (in-flight, partially proven)
+
+Two-plus machines on the same gh account converge through the
+account registry adapter (`GhAccountRegistryStore`):
+
+1. Each machine publishes its `AccountRegistryDocument` to a
+   private gh-gist with the marker description
+   `airc-account-mesh-registry`. The gist id is recorded
+   per-`mesh_identity` in `account_registry_gist_sentinel`.
+2. On `airc join`, every machine lists the operator's gists,
+   filters by marker, fetches each, merges into local
+   `peer_trust` / `subscriptions` / `beacons` state.
+3. Routine traffic does **not** flow through gists — gh is
+   rendezvous metadata only, per doctrine non-negotiable #2. The
+   actual data plane uses local-fs (same machine) or LAN-TCP
+   (same Tailnet/LAN).
+
+**Scale ceiling**: bounded by `gh api /gists?per_page=100` —
+discovery scans only the user's 100 most recent gists. PR #867
+dropped `--paginate` to keep refresh bounded; the assumption is
+the registry beacon is updated on every `airc join`, so it stays
+near the top of the recency list. For operators with high
+gist-churn for unrelated work, this assumption could break.
+
+**Open question**: when does the 100-gist window stop being
+enough? Joel's fleet currently small (M1, Intel Mac 2017, two
+Windows boxes); not an immediate concern. Becomes one for
+multi-team Cambrian deployments.
+
+### Layer 3: grid-to-grid (planned, not yet built)
+
+Multi-human Continuum/OpenClaw grids — different gh accounts,
+different operators, deliberate peer exchange. Out of scope for
+Phase 3.5 and 3.6.
+
+The substrate as currently shipped does NOT have:
+- Public discovery (no DHT, no rendezvous server).
+- Federation between operator fleets.
+- Invite-mediated cross-operator pairing at scale (the existing
+  `airc invite` is one-shot human-paste, not a primitive that
+  scales to N peers).
+
+See `ROBUSTNESS-INTEGRATION-PLAN.md` for the route graph (LAN /
+Tailscale / relay / WebRTC / Reticulum) which is the data-plane
+companion to whatever discovery layer 3 ends up using.
+
+## Beacon TTL strategy
+
+Beacons live in the ORM (post-#888). Per scope per mesh identity:
+
+| Cadence | Default | Sets |
+|---|---|---|
+| `heartbeat_ttl_ms` | 30000 | how stale a beacon may be before partitioning into `CoordinatorSnapshot::stale` |
+| Heartbeat republish | configurable, ~10s typical | how often each scope rewrites its own beacon |
+| Drain frequency | caller-driven | `coordinator::drain_stale_store` is opt-in, not background |
+
+**Drain risk** (called out in GRID-SUBSTRATE-AUDIT.md Phase 3.6):
+no background task currently calls `drain_stale_store`. Stale rows
+accumulate until a caller explicitly invokes the drain. This is
+fine while scope counts are low. For a Cambrian-scale fleet (10+
+machines × multiple scopes each), a background drain job is the
+right next move — flag as a follow-up.
+
+## Account registry refresh policy
+
+Codex's coordinator work (#850, #888) introduced singleflight via
+a filesystem lock at
+`<scope>/coordinator/accounts/<mesh-identity>/refresh.lock`. Only
+one scope per machine fetches at a time; others read the local
+`account_registry` cache. Default refresh interval is bounded by
+`CoordinatorConfig::refresh_interval_ms`.
+
+The 5s timeout around the gh-gist publish + refresh (PR #867)
+keeps a slow GitHub response from blocking a join indefinitely.
+
+**Tradeoff**: aggressive refresh = fresher peer state but more gh
+API quota burn. Current default trades on the conservative side.
+For real-time AR / pose-sync use cases this doesn't matter (those
+go peer-to-peer over LAN/Tailnet after initial pairing); for
+chat-shaped consumers it's fine.
+
+## Open architectural questions
+
+These need answers before the substrate can carry Cambrian's grid
+work at scale:
+
+1. **What replaces the 100-gist discovery window?** Options:
+   - Move the per-operator registry to a single well-known gist id
+     pinned in account metadata (less recency-dependent).
+   - Add an explicit `airc registry list-all` verb that does
+     `--paginate` for operators who genuinely need it.
+   - Push the registry to a non-gh store (S3, IPFS, Reticulum
+     namespace) as an alternative `AccountRegistryStore` impl.
+
+2. **What's the cross-operator pairing primitive?** Today: one-shot
+   `airc invite`. Need: scaled multi-peer onboarding. Sketch
+   options:
+   - Signed mesh-membership tokens (capability-based, time-bound,
+     revocable).
+   - WebAuthn-style ceremony for first pairing, mesh-replicated
+     trust thereafter.
+
+3. **Does beacon drain get a background task?** Currently
+   caller-driven; for fleet-scale operation an opt-in background
+   task (configurable interval) is the right shape. Owner: a future
+   PR on `coordinator::DrainTask`.
+
+4. **Does the gh-gist adapter need a rate-limit backoff?** PR #867
+   added a 5s timeout but no retry policy. Sustained gh API rate
+   limiting could starve refresh.
+
+5. **How does discovery interact with the route resolver?**
+   Currently independent — discovery says "peer X exists," the
+   route resolver picks how to reach them (local-fs, LAN, relay).
+   Future: a peer who's reachable only over a specific route might
+   need to advertise that as part of the registry document.
+
+## See also
+
+- [ACCOUNT-MESH-JOIN-CONTRACT.md](architecture/ACCOUNT-MESH-JOIN-CONTRACT.md)
+  — the join + convergence contract.
+- [INVITE-ROUTING-ARCHITECTURE.md](architecture/INVITE-ROUTING-ARCHITECTURE.md)
+  — gh as invite/rendezvous, not data plane.
+- [DATA-MODEL-REFERENCE.md](DATA-MODEL-REFERENCE.md) — `beacons`,
+  `beacon_channels`, `account_registry`, `peer_trust` schema.
+- [ROBUSTNESS-INTEGRATION-PLAN.md](architecture/ROBUSTNESS-INTEGRATION-PLAN.md)
+  — route resolver (data-plane companion).

--- a/docs/PHASE-3.5-MIGRATION.md
+++ b/docs/PHASE-3.5-MIGRATION.md
@@ -1,0 +1,182 @@
+# Phase 3.5 Migration Playbook
+
+**Status**: Operator + integrator reference. Applies to any
+production install that was on a pre-Phase-3.5 airc build (anything
+older than `rust-rewrite` at `eeb163e`, May 2026).
+
+Phase 3.5 moved every durable substrate sidecar JSON file into
+SeaORM tables inside `<scope>/events.sqlite`. This doc covers (1)
+what migrates automatically, (2) what you should delete by hand,
+(3) how to recover from a half-migrated state.
+
+## Quick reference
+
+| Old sidecar | New table | Auto-migrates? |
+|---|---|---|
+| `<scope>/identity.json` | `local_identity` (singleton row) | Yes — #902 |
+| `<scope>/identity.key` | unchanged, stays as 0600 file | n/a (kept on disk for secrets-at-rest) |
+| `<scope>/subscriptions.json` | `subscriptions` | No — wiped on fresh-open; re-`join` to rebuild |
+| `<scope>/room.json` | `subscriptions.is_default` flag | No — re-`join` rebuilds |
+| `<machine-home>/peers.json` | `peer_trust` | No — relies on re-pairing (or import via account registry) |
+| `<machine-home>/peers_audit.jsonl` | `peer_rotation_audit` | No — historical audit lost (acceptable) |
+| `<machine-home>/mesh_identity.json` | `mesh_identity` | No — re-resolves on next open |
+| `<scope>/coordinator/accounts/<id>/beacons/*.json` | `beacons` + `beacon_channels` | No — beacons are presence; stale on restart anyway |
+| `<scope>/coordinator/accounts/<id>/account_registry/*.json` | `account_registry` | No — re-fetched on next `gh` refresh |
+| `<machine-home>/account-registry-gist-id` | `account_registry_gist_sentinel` | No — gh adapter creates new gist if missing |
+| `<scope>/codex_hook_cursor.json` | `runtime_cursors` (consumer `codex-hook:*`) | No — first hook fire after upgrade re-anchors at latest |
+| `<scope>/join_feed_cursor.*.json` | `runtime_cursors` (consumer `join-feed:*`) | No — first attach re-anchors at latest |
+| `<scope>/config.json` | n/a — public `airc config` command deleted in #890 | No-op |
+| `<scope>/bearer_state.*.json` | n/a — bearer transport deleted in #899 | No-op |
+
+## Upgrade procedure
+
+### Same-machine, already-running install
+
+```
+cd ~/.airc/src    # or wherever your dev checkout lives
+git fetch && git checkout rust-rewrite && git pull
+AIRC_INSTALL_NO_PULL=1 ./install.sh
+airc stop          # tear down old daemon
+airc join          # re-bootstrap from current scope
+```
+
+The first `airc join` after upgrade:
+1. Opens `events.sqlite`, runs any pending migrations.
+2. `LocalIdentity::load_or_generate` finds `identity.key` + no
+   `local_identity` row, scans for legacy `identity.json`, parses
+   it, inserts the singleton row, deletes the JSON file (#902).
+3. Re-subscribes the scope's default channels via `airc join`.
+4. Re-publishes the local beacon into the `beacons` table.
+5. Reads the wire to backfill any unseen events into the
+   `events` table.
+
+What you'll see if it worked: `airc peer list` shows enrolled
+peers (post-#903 it reads from the account-mesh union, so HOME
+peers + scope peers both show up); `airc msg "..."` reports
+"N paired peer(s)" with N > 0.
+
+### Fresh machine, never had airc
+
+```
+curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/rust-rewrite/install.sh | bash
+airc join
+```
+
+Identity is generated fresh; no migration needed.
+
+### Multiple machines on one gh account (Cambrian fleet)
+
+After each machine has run `airc join` cleanly, they auto-converge
+on the same account-mesh rooms via the gh-gist account registry.
+Cross-machine pairing is currently in proof-of-concept; see
+[ACCOUNT-MESH-JOIN-CONTRACT.md](architecture/ACCOUNT-MESH-JOIN-CONTRACT.md)
+for the contract and limitations.
+
+## Recovering from a half-migrated state
+
+### `identity is half-initialised: key=true state=false`
+
+What it means: `<scope>/identity.key` exists but `local_identity`
+table has no row, AND there's no legacy `identity.json` to migrate
+from (e.g. you deleted it manually, or migrated on an old binary
+that didn't have #902 yet).
+
+Recovery:
+1. **If you have an off-disk backup of `identity.json`** — restore
+   it next to `identity.key` and re-run `airc join`. #902 will
+   migrate it.
+2. **If you don't** — `airc teardown --flush` wipes the scope's
+   identity (key file + ORM row). Next `airc join` regenerates.
+   You lose your `peer_id` and any pairings that were anchored on
+   it; peers will need to re-pair.
+
+### `identity is half-initialised: key=false state=true`
+
+What it means: ORM row exists but `identity.key` is missing.
+Probably accidental file deletion or a permissions issue (key
+needs 0600 + owner read).
+
+Recovery:
+1. **If you have the key bytes backed up** — restore the file to
+   `<scope>/identity.key` with 0600 perms.
+2. **If you don't** — the signing key for this identity is gone;
+   no recovery. `airc teardown --flush` and start over.
+
+### `airc inbox` / `airc join` exits with `crypto: signer X is not in the peer key registry`
+
+What it means: an orphan frame on the wire is signed by a peer your
+local registry doesn't trust. Pre-#905 this aborted the whole
+replay; post-#905 it's logged + skipped.
+
+Recovery: upgrade to a post-#905 binary
+(`rust-rewrite @ eeb163e` or later). The orphan frame is harmless
+once replay skips it.
+
+### `airc msg` reports `0 paired remote peers`
+
+What it means: pre-#903 bug where `Airc::peers()` loaded scope-local
+trust instead of the account-mesh union. Fixed in #903.
+
+Recovery: upgrade to a post-#903 binary. If you're already there,
+verify with `airc peer list` (should show HOME + per-scope peers).
+
+## What you should clean up by hand
+
+After a successful upgrade + first `airc join`, the following
+files are dead weight and safe to remove. They're not auto-deleted
+because that's destructive — operators should sanity-check first.
+
+```
+# Per-scope sidecars (under each scope's home, e.g. ~/.airc, vHSM/.airc, …)
+identity.json                          # deleted by #902 if present at migration; otherwise safe to rm
+subscriptions.json
+room.json
+mesh_identity.json
+codex_hook_cursor.json
+join_feed_cursor.*.json
+config.json
+bearer_state.*.json
+
+# Machine-account-shared (under ~/.airc by default)
+peers.json
+peers_audit.jsonl
+account-registry-gist-id
+
+# Coordinator presence directory (under each scope)
+coordinator/accounts/*/beacons/*.json
+coordinator/accounts/*/account_registry/*.json
+```
+
+Keep:
+- `identity.key` (the secret).
+- `events.sqlite` (the new ORM store).
+- `wires/<channel>/frames.jsonl` (wire transport; not in ORM scope).
+- `coordinator/accounts/*/refresh.lock` if present (filesystem
+  singleflight; not in ORM scope).
+
+A future `airc doctor --fix` will offer to delete the migrated
+sidecars after verifying the ORM rows are present. Until then, hand
+cleanup is the only path.
+
+## What WON'T be migrated
+
+- **Old peer trust** (`peers.json`). Phase 3.5 deliberately doesn't
+  migrate this because the format predates the rotation-audit
+  schema. Re-pair with each peer manually, or rely on the account
+  registry to re-import them.
+- **Old account-registry documents** (`accounts/<id>/registry.json`).
+  These get re-fetched from the gh-gist on next refresh — there's
+  no value in preserving a stale local cache.
+- **Old `messages.jsonl`** (legacy gh bearer transport, deleted in
+  #899). If your scope still has this file on disk, it's truly
+  dead — `rm` it. Production traffic has used local-fs / LAN-TCP
+  transport since the bearer chapter closed.
+
+## See also
+
+- [GRID-SUBSTRATE-AUDIT.md](architecture/GRID-SUBSTRATE-AUDIT.md)
+  — the Phase 3.5 doctrine and migration history.
+- [DATA-MODEL-REFERENCE.md](DATA-MODEL-REFERENCE.md) — the
+  authoritative schema for every table this migration creates.
+- [ACCOUNT-MESH-JOIN-CONTRACT.md](architecture/ACCOUNT-MESH-JOIN-CONTRACT.md)
+  — how scopes converge on the same rooms post-migration.

--- a/docs/architecture/AIRC-RUST-SUBSTRATE.md
+++ b/docs/architecture/AIRC-RUST-SUBSTRATE.md
@@ -1,39 +1,63 @@
-# airc-rust — Generic Messaging Substrate
+# airc-rust — Backbone Bus for Cambrian AR, Continuum/OpenClaw/Hermes, and the p2p Grid
 
-**Status**: Draft. Outline + key decisions. Sections marked _stub_
-get fleshed out as peers + Joel iterate.
+**Status**: Living doctrine doc. Sections evolve as the substrate
+ships; non-negotiables in
+[`GRID-SUBSTRATE-AUDIT.md`](GRID-SUBSTRATE-AUDIT.md) lock the
+invariants.
 
 **Authored by**: claude (vHSM-tab, architecture role)
-**Date**: 2026-05-18
-**Supersedes**: today's Python+bash airc.
+**Date**: 2026-05-18, updated 2026-05-23 to widen the consumer
+framing past chat-only.
+**Supersedes**: original Python+bash airc.
 
 ## What airc-rust is
 
-airc-rust is a **network substrate that doubles as a messaging layer and
-an event bus**. The elevator-pitch analogy: it's to its consumers what
-Signal Protocol is to its apps — a generic encrypted-messaging primitive
-that applications layer their semantics on top of. Signal facilitates;
-the apps decide what they're saying.
+airc-rust is **Cambrian's backbone bus** — the substrate every
+internal system rides on for coordination, presence, event
+delivery, and command routing. Three consumer-classes drive the
+design pressure, in decreasing latency-sensitivity:
 
-Think IRC for the high-level shape: peers, rooms, messages, events,
-signaling, identity, durable scrollback. Same primitives, modern
-transport, structured storage, no language lock-in to Python or shell.
+1. **AR systems** — Continuum's headset/edge pose sync, shared
+   spatial anchors, AR event/command streams. 60–90Hz steady
+   state, sub-25ms p99 e2e on Tailnet/LAN, sub-8ms p99
+   same-machine. Highest-latency-sensitivity consumer; see
+   [AR-LATENCY-CONTRACT.md](AR-LATENCY-CONTRACT.md) for budgets.
+2. **All Cambrian internal coordination** — Continuum, OpenClaw,
+   Hermes, agent-relay, forge-alloy, sentinel-ai, plus
+   AI-agent runtimes (Claude Code, Codex, Cursor, opencode,
+   Windsurf). Different vocabularies, one substrate. See
+   [CAMBRIAN-CONSUMER-INTEGRATION-MATRIX.md](CAMBRIAN-CONSUMER-INTEGRATION-MATRIX.md).
+3. **The p2p grid** — Continuum's distributed compute + model
+   serving, multi-operator mesh, capability leasing. Same-machine,
+   then Tailnet/LAN, then grid-to-grid in priority order. See
+   [PEER-DISCOVERY-SCALABILITY.md](../PEER-DISCOVERY-SCALABILITY.md).
 
-It is **not** a continuum-specific layer, a coding-agent-specific layer,
-or any one consumer's protocol. Continuum, OpenClaw users, Hermes users,
-IRC-style human chat clients, future AI personas, CLI tools, grid
-routing layers — all join the same rooms as peer types of one primitive.
-None of them is mentioned by name in the core protocol.
+The elevator pitch: airc is to its consumers what Signal Protocol
+is to its apps — a generic encrypted-event primitive that
+applications layer their semantics on top of. Signal facilitates;
+the apps decide what they're saying. We add presence, multi-room
+subscriptions, durable transcript, and a route resolver across
+local-fs / LAN / Tailscale / relay / WebRTC / Reticulum.
+
+It is **not** chat-shaped at heart, even though chat is one of
+its consumer profiles. Pose streams at 60Hz, command/reply traffic
+with deadlines, ephemeral telemetry, and durable chat all ride the
+same envelope shape. None of them is mentioned by name in the
+core protocol.
 
 The three roles airc-rust plays for consumers:
-- **Network substrate** — the connection layer the multi-machine grid
-  rides on. Peer discovery, addressing, encryption, reachability
-  resolution. (Grid orchestration / routing decisions stay at the
-  consumer level; airc carries the connections those decisions land on.)
-- **Messaging layer** — durable chat-shaped store + scrollback + cursors.
-  The kind of substrate `irssi` would expect.
-- **Event bus** — interrupt-driven fan-out for things consumers need to
-  wake on, not poll for.
+- **Network substrate** — the connection layer the multi-machine
+  grid rides on. Peer discovery, addressing, encryption,
+  reachability resolution. Routine same-machine traffic never
+  depends on GitHub; gh is rendezvous metadata only
+  (non-negotiable #2).
+- **Event bus** — interrupt-driven fan-out for everything
+  consumers need to wake on, not poll for. Subscription by header
+  filter, multi-room by default, replay via cursor.
+- **Command plane** (Phase 4, in flight) — typed request/reply
+  primitive with correlation, deadline, cancellation. Consumers
+  own the command vocabulary; airc owns delivery + correlation
+  matching.
 
 See [`INVITE-ROUTING-ARCHITECTURE.md`](INVITE-ROUTING-ARCHITECTURE.md) for the
 transport boundary: gh-gist is an invite/rendezvous beacon, not the live

--- a/docs/architecture/AR-LATENCY-CONTRACT.md
+++ b/docs/architecture/AR-LATENCY-CONTRACT.md
@@ -1,0 +1,179 @@
+# AR Latency Contract
+
+**Status**: Draft contract for the AR-consumer slice of airc. The
+substrate has to carry Continuum's AR pose/spatial state alongside
+chat-shaped traffic without making either suffer. Numbers below are
+target budgets; actual measurement is pending instrumentation
+(Phase 3.6 benchmarks). All TBD lines are explicit and need
+Continuum-side measurement to lock down.
+
+## Why this exists
+
+airc was designed as a generic event substrate. AR is the
+highest-latency-sensitivity consumer we know about — sub-frame
+spatial sync at 60–90Hz, per-headset pose streams, optionally
+multi-user shared anchors. If the bus can carry AR cleanly, it
+trivially carries chat / commands / events. The reverse is not
+true.
+
+This doc pins the contract AR consumers can rely on, and what they
+must not assume.
+
+## Consumer profiles
+
+Different AR workloads hit the substrate differently. The contract
+distinguishes:
+
+### Profile A: per-headset pose stream
+
+- **Cadence**: 60–90Hz steady state; bursts to ~120Hz acceptable.
+- **Payload**: tens of bytes per frame (pose + timestamp + a few
+  flags). Strict upper bound: 512 bytes including envelope.
+- **Topology**: many-to-one or many-to-few — one headset's pose
+  emitted to whichever peers render the scene.
+- **Loss tolerance**: high. A dropped frame is invisible at 60Hz;
+  even a 100ms gap is recoverable. Ordering matters; reordering
+  doesn't (timestamps determine display).
+- **Latency budget**: e2e < 25ms p99 within Tailnet/LAN; < 8ms p99
+  same-machine.
+
+### Profile B: shared spatial anchor / world state
+
+- **Cadence**: bursty. ~5–20Hz steady, spikes to 60Hz during
+  active manipulation.
+- **Payload**: hundreds of bytes to a few KB. Anchors carry
+  position + orientation + version + manipulating peer.
+- **Topology**: full mesh among participants in the same scene.
+- **Loss tolerance**: low. Lost anchor updates manifest as visible
+  desync; must be retried or merged-via-CRDT.
+- **Latency budget**: < 80ms p99 same-fleet; visible drift above.
+
+### Profile C: AR event/command stream
+
+- **Cadence**: sparse, event-driven. Mode changes, button presses,
+  AI commands.
+- **Payload**: a few hundred bytes, occasionally larger (a
+  tool-call argument).
+- **Topology**: request/reply, typically with correlation IDs.
+- **Loss tolerance**: zero — these are commands.
+- **Latency budget**: < 200ms p95 for human-perceptible
+  interactivity.
+
+## What airc provides today
+
+| Need | Status | Mechanism |
+|---|---|---|
+| Local-fs same-machine fan-out | shipped | `local-fs` adapter; tail-loop CPU bounded by SQLite WAL |
+| Signed envelopes (Ed25519) | shipped | per-frame `Signature::Ed25519` |
+| Per-channel ordering | shipped | Lamport clocks + event_id tiebreak |
+| Multi-room subscription | shipped | `subscribe_subscribed_filtered` (#876) |
+| Replay on attach | shipped | `replay_wire_once` (post-#905 skip-and-warn) |
+| LAN-TCP transport | shipped | `lan-send` / `lan-listen` |
+| Route resolution (LAN / Tailnet / relay / etc.) | partial | route graph + resolver; some routes still planning per ROBUSTNESS-INTEGRATION-PLAN |
+
+## What AR consumers need that isn't there yet
+
+These are the gaps. Each is a follow-up phase, not a Phase 3.5
+deliverable.
+
+### Bounded broadcast capacity for high-cadence streams
+
+The broadcast channel is fixed at 1024 events (LiveLag surfaces
+lag). At 60Hz with 5 concurrent subscribers, 1024 events ≈ 3.4
+seconds of slack — fine for chat, marginal for sustained AR pose
+streams.
+
+**Open**: dedicated high-rate broadcast lane per profile, OR a
+per-subscriber backpressure signal so AR consumers can rate-limit
+their publish.
+
+### Latency-class headers
+
+The route resolver currently picks routes by health. AR pose
+streams want "local-fs or LAN-TCP only, never relay." Today the
+consumer can't express that.
+
+**Proposed**: `airc.route_class` header (`local-only`,
+`lan-allowed`, `any`). Resolver respects the class; falls back
+within the allowed set.
+
+### Per-stream priority
+
+If chat + AR pose share the same wire, a flood of chat shouldn't
+delay pose frames. Need a priority lane on the broadcast channel
+OR per-channel cadence isolation.
+
+**Open**: priority is consumer-hint or substrate-policy?
+
+### Payload-size budget enforcement
+
+A buggy consumer could send a 10MB blob on a pose channel. The
+substrate doesn't enforce per-channel size limits. AR profiles
+need this hard-capped.
+
+**Proposed**: `airc.max_payload_bytes` channel metadata read at
+join. Send-side rejection if exceeded.
+
+### Drop policy
+
+AR Profile A explicitly accepts loss. Today every event is
+durable in `events` table. For pose streams, durable persistence
+is overkill (and a write-rate concern at 60Hz × N peers).
+
+**Proposed**: `TranscriptKind::Ephemeral` variant that broadcasts
+without persisting. Subscribers see it live; replay never sees it.
+
+## Measurement requirements (before locking targets)
+
+The numbers above are target budgets. To lock down a real
+contract, AR consumers + airc need:
+
+1. **End-to-end latency histogram** at each route — local-fs / LAN /
+   Tailnet / relay — at 1Hz / 10Hz / 60Hz / 120Hz cadences.
+2. **Memory pressure at sustained 60Hz × N=10 subscribers** — does
+   the broadcast Arc-clone work, or does `event.clone()` (audit
+   Phase 3.6 hotpath #2) bite?
+3. **Tail-loop CPU** during sustained AR-rate publishes — is the
+   SQLite-WAL writer the bottleneck?
+
+Benchmarks live in `crates/airc-lib/benches/` (new in Phase 3.6).
+Numbers feed back into PERF-BASELINES.md (TODO).
+
+## Doctrine notes for AR consumers
+
+- **Same-machine first, same-fleet second, public p2p last.** The
+  doctrine non-negotiable #3 (local route wins) maps directly to AR
+  latency requirements. Building an AR product on relay-only routes
+  is not supported.
+- **gh-gist is never on the AR data plane.** Per non-negotiable #2,
+  routine traffic doesn't depend on GitHub. AR is routine traffic
+  at scale; gh exists for invite/rendezvous only.
+- **Headers, not payload, carry routing intent.** AR consumers
+  should set `airc.route_class`, `airc.priority`, `airc.deadline_ms`
+  on the envelope. The substrate routes on headers; it doesn't
+  parse payloads.
+
+## Open questions for Continuum
+
+To finalize this contract:
+
+1. What's the actual pose-stream cadence? 60? 90? 120? (Affects
+   broadcast-capacity sizing.)
+2. What's the actual payload envelope size? (Affects
+   max-payload-bytes constant.)
+3. Multi-user shared anchors — how many concurrent participants in
+   one scene before degradation? (Affects mesh fan-out cost.)
+4. Drop tolerance per profile — is the ephemeral-kind proposal
+   correct, or does Profile A still want durable replay for
+   debugging?
+5. What's the failure mode when latency budget is missed? Drop the
+   frame, queue it, surface the lag to the application?
+
+## See also
+
+- [GRID-SUBSTRATE-AUDIT.md](GRID-SUBSTRATE-AUDIT.md) — Phase 3.6
+  perf hotpaths that block AR-scale workloads.
+- [ROBUSTNESS-INTEGRATION-PLAN.md](ROBUSTNESS-INTEGRATION-PLAN.md)
+  — route graph (LAN / Tailnet / relay) data-plane companion.
+- [DATA-MODEL-REFERENCE.md](../DATA-MODEL-REFERENCE.md) — `events`
+  table schema; relevant for ephemeral-kind discussion.

--- a/docs/architecture/CAMBRIAN-CONSUMER-INTEGRATION-MATRIX.md
+++ b/docs/architecture/CAMBRIAN-CONSUMER-INTEGRATION-MATRIX.md
@@ -1,0 +1,128 @@
+# Cambrian Consumer Integration Matrix
+
+**Status**: Map of which Cambrian projects plug into airc and how.
+The substrate is generic — what makes it Cambrian-shaped is the
+set of consumers riding on it. This doc is the canonical roster.
+
+If you're adding a new consumer, add a row + integration README.
+
+## Why this exists
+
+airc is the backbone bus for all Cambrian work coordination — AR,
+distributed inference, agent workflows, tool chains, fleet
+operations. Each consumer plugs in differently: some are pure
+event subscribers, some publish presence, some need request/reply,
+some run on the data plane at AR cadence. This matrix is the
+single read for "who uses what."
+
+## Matrix
+
+| Consumer | Role | Profile | Headers used | Tables read | Tables written | Integration README |
+|---|---|---|---|---|---|---|
+| **Continuum** | AR pose + spatial sync, persona event bus, distributed inference orchestration | A (pose) + B (anchors) + C (commands) | `forge.persona.*`, `continuum.lora.invoke`, `airc.route_class` (TBD) | `events`, `subscriptions`, `peer_trust`, `beacons` | `events` (broadcasts), `subscriptions` (joins) | `integrations/continuum/README.md` |
+| **OpenClaw** | Workspace UI surface (threads, users, presence, render targets) | C (event-driven UI) | `openclaw.thread.*`, `openclaw.user.*` | `events`, `subscriptions`, `peer_trust`, `local_identity` | `events`, `subscriptions` | `integrations/openclaw/README.md` |
+| **Hermes** | Command/orchestration plane for agent workflows | C (request/reply) | `forge.hermes.agent_command`, `airc.correlation_id` (TBD Phase 4) | `events`, `peer_trust` | `events` | TODO — placeholder needed |
+| **Claude Code** | AI agent runtime (Monitor stream + skill bindings) | C (chat + commands) | `airc.client=claude:*`, `airc.correlation_id` (TBD) | `events`, `subscriptions`, `runtime_cursors`, `peer_trust`, `local_identity` | `events`, `subscriptions`, `runtime_cursors` | `integrations/claude-code/README.md` |
+| **OpenAI Codex** | AI agent runtime (UserPromptSubmit hook + persistent join session) | C (chat + commands) | `airc.client=codex:*`, `airc.correlation_id` (TBD) | `events`, `subscriptions`, `runtime_cursors`, `peer_trust`, `local_identity` | `events`, `subscriptions`, `runtime_cursors` | `integrations/openai-codex/README.md` |
+| **Cursor / opencode / Windsurf** | IDE-resident agent surfaces | C | `airc.client=<runtime>:*` | same as Claude/Codex | same as Claude/Codex | placeholders in `integrations/`; READMEs missing until those integrations ship |
+| **agent-relay** | Cross-runtime coordination broker (Cambrian internal) | TBD — scope: bridge between heterogeneous agent runtimes? | TBD | TBD | TBD | TODO |
+| **forge-alloy** | Cambrian internal — see Cambrian workspace | TBD | TBD | TBD | TBD | TODO |
+| **sentinel-ai** | Cambrian internal monitoring/alerting | C (events) | `sentinel.alert.*` (TBD) | `events` | possibly `events` for alert publish | TODO |
+| **Generic** | Reference IDE/CLI consumer for protocol stability | C | `airc.client=generic:*` | demonstrative | demonstrative | `integrations/generic/README.md` |
+
+## Headers convention
+
+The substrate routes on headers; it does not interpret payloads.
+Consumers should follow:
+
+- `airc.client` — runtime tag, e.g. `claude:<session>`, `codex:<thread>`, `continuum:<scope>`.
+  Used for self-filter on shared HOME (post-#869).
+- `airc.correlation_id` (Phase 4) — request/reply correlation. Set
+  by request emitter, echoed by reply.
+- `airc.reply_to` (Phase 4) — where to direct the reply (usually
+  the requesting peer_id; can be a different channel).
+- `airc.deadline_ms` (Phase 4) — request expiry; receivers may drop
+  past-deadline requests.
+- `airc.route_class` (proposed, AR) — `local-only` / `lan-allowed`
+  / `any`. Resolver respects.
+- `airc.priority` (proposed, AR) — `low` / `default` / `high`.
+
+Consumer-specific headers use a consumer-prefixed namespace:
+`forge.persona.*`, `openclaw.thread.*`, `continuum.lora.*`. The
+substrate sees them as opaque routing keys.
+
+## Table-access conventions
+
+Per non-negotiable #6 ("Consumer integrations must be thin"),
+consumers SHOULD:
+
+- Read state through `airc-lib` typed APIs (`Airc::peers`,
+  `Airc::subscriptions`, etc.), not direct SQL.
+- Write state through `airc.say` / `airc.send` and the typed
+  primitives that emit events, not direct table inserts.
+
+Consumers SHOULD NOT:
+
+- Open `events.sqlite` for direct read — the schema is internal,
+  not API-stable.
+- Modify any table — substrate-side invariants depend on
+  controlled-write paths.
+- Reach into wire files (`<wire-root>/wires/<channel>/frames.jsonl`)
+  unless they have explicit substrate-team approval.
+
+The exception: tooling docs / `airc doctor` / debug tools may read
+from the ORM directly for inspection. Production consumers go
+through the SDK.
+
+## Per-consumer onboarding
+
+Each consumer's integration README should answer:
+
+1. Which subset of the matrix above (headers / tables) applies.
+2. The lifecycle hooks the consumer needs (presence updates,
+   peer joins, room subscriptions changing).
+3. The failure modes the consumer must handle (peer not in
+   registry — see #905 skip-and-warn; route degraded — see
+   transport health; persistent failure — see
+   `airc doctor`).
+4. The acceptable cadence / payload-size envelope (see
+   [AR-LATENCY-CONTRACT.md](AR-LATENCY-CONTRACT.md) for Profile A/B/C).
+
+## Gaps and TODOs
+
+These consumers don't have integration READMEs yet. Each blocks a
+production deployment of that consumer:
+
+- **Hermes** — referenced in `README.md` as `forge.hermes.*` but
+  no `integrations/hermes/README.md`. Needed before Hermes embeds.
+- **agent-relay** — Cambrian-internal scope unknown to substrate
+  docs. Owner: Cambrian team. Needs the matrix row above filled in.
+- **forge-alloy** — same.
+- **sentinel-ai** — referenced as monitoring/alerting; need scope
+  doc for alert publish, ack contract.
+- **Cursor / opencode / Windsurf** — listed in `README.md` IDE
+  table but no READMEs. Should land before each shipping
+  integration.
+
+## Adding a new consumer
+
+1. Pick a vocabulary prefix (e.g. `myproject.*`). Document it in
+   the integration README.
+2. Decide your profile (A AR / B anchors / C events). Set
+   `airc.route_class` + `airc.priority` if not Profile C.
+3. Stamp `airc.client=<runtime>:<instance>` on every send so the
+   self-filter works on shared HOME.
+4. Subscribe via `Airc::subscribe_subscribed_filtered(filter)` —
+   the multi-room surface, not the current-room narrow one.
+5. Use `runtime_cursors` for resumable replay; don't invent a
+   sidecar.
+6. Add a row to the matrix above; add `integrations/<name>/README.md`.
+
+## See also
+
+- [GRID-SUBSTRATE-AUDIT.md](GRID-SUBSTRATE-AUDIT.md) — substrate
+  doctrine, non-negotiables, phase progress.
+- [AR-LATENCY-CONTRACT.md](AR-LATENCY-CONTRACT.md) — cadence /
+  latency budgets for AR consumers (Profile A/B).
+- [DATA-MODEL-REFERENCE.md](../DATA-MODEL-REFERENCE.md) — table
+  schemas for the read/write columns above.

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -299,20 +299,31 @@ five concrete hotpaths and seven kill-list patterns.
 
 ### Layering rot (architectural)
 
+**Status after Phase 3.5**: peer-trust + identity ORM cuts
+(#883/#885/#902) softened the `airc-lib`/`airc-daemon` interface
+— the `peers_store` is now a thin shim over `airc-store`
+methods, not a parallel JSON store. The deeper issue (lib
+naming daemon types) is still present and worth a separate
+follow-up.
+
 - **`airc-lib` imports `airc-daemon::peers_store` + `DaemonClient`**
-  (`airc-lib/src/airc.rs:29-30`). The library reaches into the
-  daemon crate's internals. Clean shape: trait
-  `PersistentStore { async fn load_peers(...) }` and the daemon
-  provides an impl. Library never names daemon types.
+  (`airc-lib/src/airc.rs:29-30`) — STILL OPEN post-Phase 3.5. The
+  library reaches into the daemon crate's internals. Clean shape:
+  trait `PersistentStore { async fn load_peers(...) }` and the
+  daemon provides an impl. Library never names daemon types.
+  Tracked for the post-3.6 cleanup phase.
 - **`airc-transport::signed` holds an `Arc<RwLock<PeerKeyRegistry>>`**
-  (`transport/signed.rs:129-146`) but doesn't own its lifecycle.
-  Key rotation invalidates lib's registry but transport has a stale
-  reference. Fix: verification is a pure function or a delegate
-  passed per frame; transport does not own crypto state.
+  (`transport/signed.rs:129-146`) — STILL OPEN. Key rotation
+  invalidates lib's registry but transport has a stale reference.
+  Fix: verification is a pure function or a delegate passed per
+  frame; transport does not own crypto state. (Note: #905 made
+  unverifiable replay frames skip-and-warn instead of fail-closed,
+  which masks one symptom of this rot but doesn't fix the cause.)
 - **Daemon IPC is line-delimited JSON without length-framing**
-  (implied from `airc-daemon/src/ipc/request.rs`). A newline in a
-  message body breaks the parser. No backpressure framing. Fix:
-  length-prefixed CBOR/protobuf, or proper RPC codec (tonic).
+  (implied from `airc-daemon/src/ipc/request.rs`) — STILL OPEN. A
+  newline in a message body breaks the parser. No backpressure
+  framing. Fix: length-prefixed CBOR/protobuf, or proper RPC
+  codec (tonic).
 
 ### SeaORM perf notes (for Phase 3.5)
 


### PR DESCRIPTION
## Summary

Follow-up to the GRID-SUBSTRATE-AUDIT (#879/#881). Widens the doctrine docs from agent-chat-only framing to the backbone-bus reality Joel defined: airc carries Cambrian's AR pose streams (60–90Hz, sub-25ms p99), all internal coordination (Continuum, OpenClaw, Hermes, agent-relay, forge-alloy, sentinel-ai, AI agents), and the p2p grid Continuum is building. IRC-shaped chat is one consumer profile among many, not the substrate's center.

Adds 5 new docs, reframes 4 existing ones, marks Phase 3.5 closure state on a fifth.

## New docs

### `docs/DATA-MODEL-REFERENCE.md`
Authoritative schema for every persistent table in the airc substrate (events, runtime_cursors, peer_trust, peer_rotation_audit, subscriptions, local_identity, mesh_identity, account_registry, account_registry_gist_sentinel, beacons, beacon_channels). One row per table with columns, ownership/readers, retention, indexes, cross-table invariants. Explicit list of what is NOT in the database (wire transcript files, refresh-lock sentinels, Ed25519 secret) and the doctrine for adding new tables.

### `docs/PHASE-3.5-MIGRATION.md`
Operator playbook for production installs upgrading off the sidecar JSONs. Quick-reference table of which JSONs migrate automatically (only identity.json via #902) vs which are wiped + rebuilt by re-join. Recovery procedures for half-initialised states (PartialState errors, orphan signer, "0 paired remote peers"). Hand-cleanup list. Maps directly to the new-machine onboarding the Cambrian fleet will hit.

### `docs/PEER-DISCOVERY-SCALABILITY.md`
Current three-layer discovery model (same-machine via shared HOME, per-operator-fleet via account-registry gist, grid-to-grid pending). Beacon TTL strategy, refresh policy. Open architectural questions: 100-gist discovery window ceiling, cross-operator pairing primitive, background beacon drain, route-resolver / discovery integration.

### `docs/architecture/AR-LATENCY-CONTRACT.md`
First-cut AR consumer contract for Continuum. Profile A (60–90Hz pose), Profile B (5–20Hz shared anchors), Profile C (sparse commands). Targets for cadence, payload, e2e latency. What airc provides today vs what AR consumers still need (latency-class headers, per-stream priority, payload-size budget enforcement, ephemeral kind for non-durable streams). Measurement requirements before final numbers lock down — marked TBD-pending-Continuum-measurement.

### `docs/architecture/CAMBRIAN-CONSUMER-INTEGRATION-MATRIX.md`
Canonical roster of consumers + headers + table-access conventions. Covers Continuum, OpenClaw, Hermes, Claude Code, OpenAI Codex, Cursor, opencode, Windsurf, agent-relay (TBD), forge-alloy (TBD), sentinel-ai (TBD), Generic. Headers convention (\`airc.client\`, \`airc.correlation_id\`, \`airc.route_class\`). Onboarding checklist for new consumers.

## Framing updates

### `docs/architecture/AIRC-RUST-SUBSTRATE.md`
Title changed to **"Backbone Bus for Cambrian AR, Continuum/OpenClaw/Hermes, and the p2p Grid"**. Opening rewritten to lead with three consumer-classes (AR / Cambrian internal / grid) in decreasing latency-sensitivity. The three-roles section adds **command plane** (Phase 4) alongside network substrate + event bus, drops the "messaging layer" framing.

### `README.md`
Title changed to **"Cambrian's Backbone Bus"**. Opening rewritten to lead with AR pose streams + non-chat consumers. Clarifies routing primitives are (1) header-filtered subscription delivery + (2) the route resolver (LAN / Tailscale / relay / WebRTC / Reticulum) with optional \`airc.route_class\` hint. The IRC-shaped model section reframed as one consumer profile rather than the substrate's center.

### `docs/architecture/GRID-SUBSTRATE-AUDIT.md`
Phase 3.6 layering-rot section now distinguishes which findings have been softened by Phase 3.5 (peers_store is now a shim post-#883/#885/#902) vs which are still OPEN (lib naming daemon types, transport-owns-crypto-state, line-delimited JSON IPC).

### `crates/airc-lib/src/lib.rs`
Module doc updated to reflect reality: in-process AND daemon-attached modes both ship. Previous text said daemon mode was "queued for slice 6b" but \`Airc::attach\` has been live for months. Links to the new doctrine + consumer + data-model docs.

### `REFCONTRACT.md`
Labeled **LEGACY HISTORICAL SPEC ONLY** at the top. Bearer/gist-as-data-plane code referenced inside was deleted in #899/#900; current substrate specs live in docs/architecture/*. Readers landing on REFCONTRACT first were getting the pre-rewrite picture without realizing it.

## Test plan

- [x] All changes are docs-only — no code, no test impact
- [x] Build still clean (\`cargo build -p airc-lib\`)
- [ ] Read pass from Codex (he's heads-down on #906 Codex live-feed lane)
- [ ] After merge: docs anchor before Joel's machine transition this weekend, so new boxes (M1 / Intel Mac 2017 / 2 Windows rigs) onboard against a stable spec

## See also

- The Codex live-feed lane (#906) is parallel — no overlap.
- Cross-machine smoke + onboarding-friction PRs are queued for after the audit anchor lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)