### PR TITLE
feat(cli): airc doctor — install + identity + scope self-diagnosis

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -301,12 +301,12 @@ pub enum Command {
     /// Walks the install/identity/daemon/route checklist that
     /// `skills/doctor/SKILL.md` documents agents calling. Default
     /// mode is the env probe (fast, local). `--health` adds live
-    /// route/process state. `--fix` applies safe auto-recovery for
-    /// detected issues (PartialState identity, stale daemon
-    /// socket).
+    /// route/process state. `--fix` applies only safe auto-recovery
+    /// for detected issues (currently stale daemon sockets).
     Doctor {
-        /// After diagnosing, apply auto-recovery for detected
-        /// issues (PartialState identity wipe, stale daemon stop).
+        /// After diagnosing, apply safe auto-recovery. Identity
+        /// partial states are reported with manual fix commands;
+        /// doctor does not wipe identity/trust state automatically.
         /// Without `--fix`, doctor only reports.
         #[arg(long)]
         fix: bool,

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -296,6 +296,27 @@ pub enum Command {
     /// package version.)
     Version,
 
+    /// Self-diagnose the airc install + scope state.
+    ///
+    /// Walks the install/identity/daemon/route checklist that
+    /// `skills/doctor/SKILL.md` documents agents calling. Default
+    /// mode is the env probe (fast, local). `--health` adds live
+    /// route/process state. `--fix` applies safe auto-recovery for
+    /// detected issues (PartialState identity, stale daemon
+    /// socket).
+    Doctor {
+        /// After diagnosing, apply auto-recovery for detected
+        /// issues (PartialState identity wipe, stale daemon stop).
+        /// Without `--fix`, doctor only reports.
+        #[arg(long)]
+        fix: bool,
+
+        /// Include live route/process health (calls into the
+        /// route resolver + daemon status).
+        #[arg(long)]
+        health: bool,
+    },
+
     /// Shared GitHub request governor.
     Gh(GhArgs),
 

--- a/crates/airc-cli/src/doctor.rs
+++ b/crates/airc-cli/src/doctor.rs
@@ -10,9 +10,9 @@
 //! Diagnostic surface (in priority order):
 //!
 //! 1. **Identity** — `identity.key` + `local_identity` row pairing.
-//!    Detects PartialState (most common new-machine friction).
-//!    Auto-fix on `--fix`: wipe + regenerate when both halves are
-//!    safe to discard (no remote pairings on the orphan id).
+//!    Detects partial state (most common new-machine friction).
+//!    Identity repair is intentionally manual because wiping a
+//!    peer_id discards remote trust enrolled against that id.
 //!
 //! 2. **Daemon liveness** — is a daemon process answering the IPC
 //!    socket for this scope? Stale socket vs missing entirely.

--- a/crates/airc-cli/src/doctor.rs
+++ b/crates/airc-cli/src/doctor.rs
@@ -1,0 +1,400 @@
+//! `airc doctor` — install + identity + scope self-diagnosis with
+//! optional auto-recovery.
+//!
+//! The skill documents agents calling this; the binary owns the
+//! diagnostic walk. Each check returns a [`Finding`] with a status
+//! (`Ok`, `Info`, `Warn`, `Blocked`) plus the exact one-liner fix
+//! the operator (or agent) should run. With `--fix`, doctor applies
+//! the safe auto-recoveries inline.
+//!
+//! Diagnostic surface (in priority order):
+//!
+//! 1. **Identity** — `identity.key` + `local_identity` row pairing.
+//!    Detects PartialState (most common new-machine friction).
+//!    Auto-fix on `--fix`: wipe + regenerate when both halves are
+//!    safe to discard (no remote pairings on the orphan id).
+//!
+//! 2. **Daemon liveness** — is a daemon process answering the IPC
+//!    socket for this scope? Stale socket vs missing entirely.
+//!    Auto-fix on `--fix`: remove a stale socket file.
+//!
+//! 3. **Binary freshness** — does the installed binary match the
+//!    source tree, if a source tree is detectable? Surfaces "old
+//!    binary on PATH" — the symptom I (claude) hit when running
+//!    pre-#885 binary against post-#885 schema.
+//!
+//! 4. **Route + transport health** (with `--health`) — calls into
+//!    `Airc::refresh_route_discovery` for the typed transport
+//!    health snapshot and renders it.
+//!
+//! Each Finding maps to either a single-line stdout report
+//! (default mode) or an action (fix mode). The skill markdown can
+//! be the AI-side narration layer over this binary.
+
+use std::path::Path;
+
+use airc_daemon::{DaemonClient, LocalIdentity};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    Ok,
+    Info,
+    Warn,
+    Blocked,
+}
+
+impl Status {
+    fn label(self) -> &'static str {
+        match self {
+            Status::Ok => "[ok]",
+            Status::Info => "[info]",
+            Status::Warn => "[WARN]",
+            Status::Blocked => "[BLOCKED]",
+        }
+    }
+}
+
+pub struct Finding {
+    pub status: Status,
+    pub check: &'static str,
+    pub detail: String,
+    pub fix: Option<String>,
+}
+
+impl Finding {
+    fn ok(check: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            status: Status::Ok,
+            check,
+            detail: detail.into(),
+            fix: None,
+        }
+    }
+    fn info(check: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            status: Status::Info,
+            check,
+            detail: detail.into(),
+            fix: None,
+        }
+    }
+    fn warn(check: &'static str, detail: impl Into<String>, fix: impl Into<String>) -> Self {
+        Self {
+            status: Status::Warn,
+            check,
+            detail: detail.into(),
+            fix: Some(fix.into()),
+        }
+    }
+    fn blocked(check: &'static str, detail: impl Into<String>, fix: impl Into<String>) -> Self {
+        Self {
+            status: Status::Blocked,
+            check,
+            detail: detail.into(),
+            fix: Some(fix.into()),
+        }
+    }
+}
+
+pub async fn run(home: &Path, fix: bool, health: bool) -> Result<(), Box<dyn std::error::Error>> {
+    println!("airc doctor — scope: {}", home.display());
+    println!();
+
+    let mut applied = Vec::new();
+    let mut findings = Vec::new();
+
+    findings.extend(check_identity(home).await);
+    findings.extend(check_daemon(home).await);
+    findings.extend(check_binary_freshness());
+
+    if health {
+        findings.extend(check_health(home).await);
+    }
+
+    for finding in &findings {
+        println!(
+            "{} {}: {}",
+            finding.status.label(),
+            finding.check,
+            finding.detail
+        );
+        if let Some(fix_cmd) = &finding.fix {
+            println!("    Fix: {fix_cmd}");
+        }
+    }
+
+    println!();
+
+    if fix {
+        applied.extend(apply_fixes(home, &findings).await?);
+    }
+
+    let degraded = findings
+        .iter()
+        .filter(|f| matches!(f.status, Status::Warn | Status::Blocked))
+        .count();
+
+    if applied.is_empty() {
+        if degraded == 0 {
+            println!("airc doctor: ok ({} check(s) clean)", findings.len());
+        } else {
+            println!(
+                "airc doctor: {degraded} of {} check(s) need attention. Re-run with --fix to apply safe auto-recovery.",
+                findings.len()
+            );
+        }
+    } else {
+        println!("airc doctor: applied {} fix(es):", applied.len());
+        for action in &applied {
+            println!("  • {action}");
+        }
+        println!("Re-run `airc doctor` to verify.");
+    }
+
+    Ok(())
+}
+
+/// Identity check — the most common new-machine friction. Walks the
+/// same partial-state logic `LocalIdentity::load_or_generate` does
+/// but reports rather than fails.
+async fn check_identity(home: &Path) -> Vec<Finding> {
+    let key_path = LocalIdentity::key_path(home);
+    let key_exists = key_path.exists();
+    // Probe legacy json so a half-migrated install is named for what
+    // it is, not just "row missing".
+    let legacy_json = home.join("identity.json").exists();
+
+    // Open the store to ask about the singleton row. If the store
+    // itself can't open, surface that instead — that's a different
+    // class of breakage (disk full, permissions, db corruption).
+    let store = match airc_store::SqliteEventStore::open_path(&home.join("events.sqlite")).await {
+        Ok(store) => store,
+        Err(error) => {
+            return vec![Finding::blocked(
+                "identity store",
+                format!("can't open events.sqlite: {error}"),
+                "check disk/permissions; if corrupted, `airc teardown --flush` and re-join (loses scope state)",
+            )];
+        }
+    };
+    let row = match store.load_local_identity().await {
+        Ok(opt) => opt,
+        Err(error) => {
+            return vec![Finding::blocked(
+                "identity row",
+                format!("can't query local_identity: {error}"),
+                "schema may be from an older binary; `airc update` or rebuild",
+            )];
+        }
+    };
+
+    match (key_exists, row.is_some(), legacy_json) {
+        (true, true, _) => vec![Finding::ok(
+            "identity",
+            "key + ORM row both present",
+        )],
+        (false, false, false) => vec![Finding::info(
+            "identity",
+            "no identity material (fresh scope; `airc join` will generate)",
+        )],
+        (false, false, true) => vec![Finding::warn(
+            "identity",
+            "legacy identity.json present without identity.key — orphan metadata",
+            "`rm <home>/identity.json` then `airc join` to regenerate identity cleanly",
+        )],
+        (true, false, true) => vec![Finding::warn(
+            "identity",
+            "key present + legacy identity.json present, no ORM row — pre-#902 install",
+            "`airc join` will auto-migrate (post-#902 logic; identity.json gets consumed)",
+        )],
+        (true, false, false) => vec![Finding::blocked(
+            "identity",
+            "key present but no ORM row and no legacy json — orphan key, no recovery without backup",
+            "`airc teardown --flush` to wipe (loses peer_id), then `airc join` to regenerate",
+        )],
+        (false, true, _) => vec![Finding::blocked(
+            "identity",
+            "ORM row present but key file missing — can't sign without the secret",
+            "restore <home>/identity.key from backup, OR `airc teardown --flush` and re-join (loses peer_id)",
+        )],
+    }
+}
+
+async fn check_daemon(home: &Path) -> Vec<Finding> {
+    let socket = crate::cli::default_socket_path_in(home);
+    let client = DaemonClient::new(socket.clone());
+    match client
+        .ping_with_timeout(std::time::Duration::from_millis(250))
+        .await
+    {
+        Ok(_) => vec![Finding::ok(
+            "daemon",
+            format!("responding on {}", socket.display()),
+        )],
+        Err(_) if socket.exists() => vec![Finding::warn(
+            "daemon",
+            format!(
+                "socket exists at {} but no process answers",
+                socket.display()
+            ),
+            format!(
+                "stale socket from prior crash; remove with `rm {}` then `airc join`",
+                socket.display()
+            ),
+        )],
+        Err(_) => vec![Finding::info(
+            "daemon",
+            "not running (`airc join` will spawn it)",
+        )],
+    }
+}
+
+fn check_binary_freshness() -> Vec<Finding> {
+    let exe = match std::env::current_exe() {
+        Ok(exe) => exe,
+        Err(_) => return vec![Finding::info("binary", "couldn't resolve current exe path")],
+    };
+    let canonical = exe.canonicalize().unwrap_or_else(|_| exe.clone());
+
+    // If the binary lives under a known source-tree layout, mention
+    // that — helps operators notice when the installed binary is
+    // pointing at a stale `~/.airc/src/target/...` from a different
+    // checkout. We don't have a reliable way to compare to a
+    // canonical "current" build here without baking commit metadata
+    // into the binary (TODO), so just surface the location.
+    let detail = format!("install: {}", canonical.display());
+    vec![Finding::info("binary", detail)]
+}
+
+async fn check_health(home: &Path) -> Vec<Finding> {
+    use airc_lib::{Airc, TransportHealthState};
+
+    let airc = match Airc::open(home).await {
+        Ok(airc) => airc,
+        Err(error) => {
+            return vec![Finding::blocked(
+                "route health",
+                format!("can't open substrate: {error}"),
+                "address the identity/store errors above first",
+            )];
+        }
+    };
+    let snapshot = match airc.refresh_route_discovery().await {
+        Ok(s) => s,
+        Err(error) => {
+            return vec![Finding::warn(
+                "route health",
+                format!("route refresh failed: {error}"),
+                "run `airc transport health` for the underlying detail",
+            )];
+        }
+    };
+    let total = snapshot.health.len();
+    let degraded = snapshot
+        .health
+        .iter()
+        .filter(|sample| sample.state != TransportHealthState::Healthy)
+        .count();
+    if degraded == 0 {
+        vec![Finding::ok(
+            "route health",
+            format!("{total} route(s) healthy"),
+        )]
+    } else {
+        vec![Finding::warn(
+            "route health",
+            format!("{degraded} of {total} route(s) degraded"),
+            "run `airc transport health` to see the row-level detail",
+        )]
+    }
+}
+
+async fn apply_fixes(
+    home: &Path,
+    findings: &[Finding],
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let mut applied = Vec::new();
+    for finding in findings {
+        if finding.check == "daemon" && finding.status == Status::Warn {
+            // Stale socket case. Identity PartialState recovery is
+            // intentionally NOT automatic — wiping a peer_id
+            // discards trust enrolled by remote peers; surface the
+            // manual one-liner instead.
+            let socket = crate::cli::default_socket_path_in(home);
+            if socket.exists() {
+                match std::fs::remove_file(&socket) {
+                    Ok(()) => {
+                        applied.push(format!(
+                            "removed stale daemon socket at {}",
+                            socket.display()
+                        ));
+                    }
+                    Err(error) => {
+                        eprintln!(
+                            "doctor: couldn't remove stale socket {}: {error}",
+                            socket.display()
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(applied)
+}
+
+// Re-export the run signature behind a simpler module path used by
+// the dispatch site in main.rs.
+pub async fn run_doctor(
+    home: &Path,
+    fix: bool,
+    health: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    run(home, fix, health).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_labels_match_skill_doc() {
+        // The skill markdown uses [ok] [info] [WARN] [BLOCKED] —
+        // pin those literally so future-doctor renderings don't
+        // drift from operator-readable docs.
+        assert_eq!(Status::Ok.label(), "[ok]");
+        assert_eq!(Status::Info.label(), "[info]");
+        assert_eq!(Status::Warn.label(), "[WARN]");
+        assert_eq!(Status::Blocked.label(), "[BLOCKED]");
+    }
+
+    #[tokio::test]
+    async fn fresh_scope_reports_no_identity_material() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let findings = check_identity(dir.path()).await;
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].status, Status::Info);
+        assert!(findings[0].detail.contains("no identity material"));
+    }
+
+    #[tokio::test]
+    async fn key_without_row_is_blocked_with_clear_fix() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("identity.key"), [7u8; 32]).unwrap();
+        let findings = check_identity(dir.path()).await;
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].status, Status::Blocked);
+        let fix = findings[0].fix.as_ref().unwrap();
+        assert!(fix.contains("teardown --flush"));
+    }
+
+    #[tokio::test]
+    async fn key_plus_legacy_json_reports_pre_902_install() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("identity.key"), [7u8; 32]).unwrap();
+        std::fs::write(dir.path().join("identity.json"), "{}").unwrap();
+        let findings = check_identity(dir.path()).await;
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].status, Status::Warn);
+        assert!(findings[0].detail.contains("pre-#902"));
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -20,6 +20,7 @@ mod collaboration_commands;
 mod collaboration_peers;
 mod commands;
 mod daemon_scope;
+mod doctor;
 mod envelope_cli;
 mod events_cli;
 mod events_commands;
@@ -397,6 +398,8 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::Join { room } => commands::run_join(&home, room).await,
 
         Command::Version => commands::run_version(),
+
+        Command::Doctor { fix, health } => doctor::run_doctor(&home, fix, health).await,
 
         Command::Gh(args) => match args.action {
             GhAction::Run { gh_args } => gh_commands::run_gh(gh_args),


### PR DESCRIPTION
## Summary

Skill `skills/doctor/SKILL.md` documented agents calling `airc doctor` / `--health` / `--fix`. None of those subcommands actually existed on the Rust binary. This PR makes the skill contract real.

The onboarding-friction floor for new machines coming online (M1, Intel Mac 2017, Windows boxes). When something doesn't work post-install, `airc doctor` gives the operator (or the AI agent on their behalf) the exact one-liner fix instead of a generic error.

## Diagnostic walk

| Check | Reports |
|---|---|
| **Identity** | `identity.key` + `local_identity` row pairing — covers every partial-state case I (claude) lived through this weekend |
| **Daemon** | Pings IPC socket; distinguishes "not running" from "stale socket from prior crash" |
| **Binary freshness** | Surfaces install dir so operators notice old-binary-on-PATH symptoms |
| **Route health** (with `--health`) | Calls into `Airc::refresh_route_discovery` + typed `TransportHealthSample` snapshot |

Status labels use the literal `[ok]` `[info]` `[WARN]` `[BLOCKED]` strings from the skill markdown so the AI narration layer stays aligned with the binary output. Regression-guarded by `status_labels_match_skill_doc`.

## Identity matrix

| key | row | json | Status | Fix one-liner |
|---|---|---|---|---|
| ✓ | ✓ | — | `[ok]` | — |
| — | — | — | `[info]` | `airc join` |
| ✓ | — | ✓ | `[WARN]` | `airc join` auto-migrates via #902 |
| — | — | ✓ | `[WARN]` | `rm <home>/identity.json` then `airc join` |
| ✓ | — | — | `[BLOCKED]` | `airc teardown --flush` then `airc join` (loses peer_id) |
| — | ✓ | — | `[BLOCKED]` | restore identity.key OR `airc teardown --flush` |

## --fix scope

Applies only **safe** auto-recoveries: stale daemon socket removal. Identity partial-state is intentionally NOT auto-recovered because wiping a peer_id discards remote-peer trust enrolled on the orphan id. The manual one-liner is surfaced; the human stays in the loop.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- 4 doctor tests + full workspace test suite green
- Live-tested on HOME scope: identity ok, daemon not running, binary install dir surfaced

## Test plan

- [x] Workspace tests, clippy, fmt
- [ ] CI: 3-OS tests + runtime guards + public install proof
- [ ] After merge: verify on new machines as they come online

🤖 Generated with [Claude Code](https://claude.com/claude-code)