### PR TITLE
feat(lib): expose subscription query API

### DIFF
--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -156,6 +156,7 @@ fn join_without_args_uses_default_account_context() {
     let mut join = Command::new(airc_core());
     join.env("HOME", machine.path())
         .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
+        .env("AIRC_NO_ATTACH", "1")
         .args(["--home", home.to_str().unwrap(), "join"])
         .current_dir(&repo);
     let output = output_with_timeout(join, Duration::from_secs(10), "airc join");
@@ -202,6 +203,7 @@ fn join_sets_up_codex_hook_when_codex_home_exists() {
     let mut join = Command::new(airc_core());
     join.env("HOME", machine.path())
         .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
+        .env("AIRC_NO_ATTACH", "1")
         .args(["--home", home.to_str().unwrap(), "join"])
         .current_dir(&repo);
     let output = output_with_timeout(join, Duration::from_secs(10), "airc join");

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -602,8 +602,27 @@ fn now_ms() -> Result<u64, std::time::SystemTimeError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use airc_core::{Body, ClientId, EventId, Headers, MentionTarget, PeerId, TranscriptEvent};
     use airc_store::InMemoryEventStore;
     use tempfile::tempdir;
+
+    fn make_event(lamport: u64, room_id: RoomId, body: &str) -> TranscriptEvent {
+        TranscriptEvent {
+            event_id: EventId::new(),
+            room_id,
+            peer_id: PeerId::from_u128(0xa1),
+            client_id: ClientId::from_u128(0xc1),
+            kind: airc_core::TranscriptKind::Message,
+            occurred_at_ms: 1_700_000_000_000 + lamport,
+            lamport,
+            target: MentionTarget::All,
+            headers: Headers::new(),
+            body: Some(Body::text(body)),
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
 
     #[test]
     fn channel_name_normalizes() {
@@ -885,18 +904,13 @@ mod tests {
         let default = airc.default_room().await.unwrap();
         assert_eq!(default.name, "cambriantech");
 
-        assert!(airc
-            .subscription_cursor(&cambriantech)
-            .await
-            .unwrap()
-            .is_none());
-        airc.say("cursor proof").await.unwrap();
-        assert!(airc
-            .subscription_cursor(&cambriantech)
-            .await
-            .unwrap()
-            .is_some());
-        assert!(airc.subscription_cursor(&general).await.unwrap().is_none());
+        let cambriantech_event = make_event(42, default.channel, "cursor proof");
+        let expected_cursor = cambriantech_event.cursor();
+        airc.append_event(cambriantech_event).await.unwrap();
+        assert_eq!(
+            airc.subscription_cursor(&cambriantech).await.unwrap(),
+            Some(expected_cursor)
+        );
         assert!(airc.subscription_cursor(&missing).await.unwrap().is_none());
     }
 }

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -477,6 +477,48 @@ impl Airc {
         Ok(load_or_init(self.event_store()).await?)
     }
 
+    /// Return all active channel subscriptions for this scope.
+    ///
+    /// Consumer integrations use this instead of parsing `airc status`
+    /// or reading the store directly. Ordering is deterministic by
+    /// channel name.
+    pub async fn subscriptions(&self) -> Result<Vec<Subscription>, AircError> {
+        let set = self.subscription_set().await?;
+        Ok(set.all().cloned().collect())
+    }
+
+    /// True when this scope is subscribed to `channel`.
+    pub async fn is_subscribed(&self, channel: &ChannelName) -> Result<bool, AircError> {
+        let set = self.subscription_set().await?;
+        Ok(set.subscribed.contains_key(channel))
+    }
+
+    /// Return the default room used by short-shape commands such as
+    /// `airc msg "..."`.
+    pub async fn default_room(&self) -> Result<Room, AircError> {
+        self.current_room().await
+    }
+
+    /// Cursor of the newest event in a subscribed channel.
+    ///
+    /// `None` means either the channel has no events yet or this
+    /// scope is not subscribed to it. Use [`Self::is_subscribed`] when
+    /// callers need to distinguish those cases.
+    pub async fn subscription_cursor(
+        &self,
+        channel: &ChannelName,
+    ) -> Result<Option<airc_core::TranscriptCursor>, AircError> {
+        let set = self.subscription_set().await?;
+        let Some(subscription) = set.subscribed.get(channel) else {
+            return Ok(None);
+        };
+        Ok(self
+            .inner
+            .store
+            .latest_cursor(Some(subscription.room_id))
+            .await?)
+    }
+
     pub(crate) async fn subscribed_event_filter(
         &self,
         mut filter: EventFilter,
@@ -815,5 +857,46 @@ mod tests {
         assert!(set.subscribed.is_empty());
         assert!(set.default.is_none());
         assert!(set.parted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn airc_exposes_subscription_query_api() {
+        let dir = tempdir().unwrap();
+        let airc = Airc::open(dir.path()).await.unwrap();
+
+        airc.join("general").await.unwrap();
+        airc.join("cambriantech").await.unwrap();
+
+        let subscriptions = airc.subscriptions().await.unwrap();
+        let names = subscriptions
+            .iter()
+            .map(|subscription| subscription.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["cambriantech", "general"]);
+
+        let cambriantech = ChannelName::new("cambriantech").unwrap();
+        let general = ChannelName::new("general").unwrap();
+        let missing = ChannelName::new("not-joined").unwrap();
+
+        assert!(airc.is_subscribed(&cambriantech).await.unwrap());
+        assert!(airc.is_subscribed(&general).await.unwrap());
+        assert!(!airc.is_subscribed(&missing).await.unwrap());
+
+        let default = airc.default_room().await.unwrap();
+        assert_eq!(default.name, "cambriantech");
+
+        assert!(airc
+            .subscription_cursor(&cambriantech)
+            .await
+            .unwrap()
+            .is_none());
+        airc.say("cursor proof").await.unwrap();
+        assert!(airc
+            .subscription_cursor(&cambriantech)
+            .await
+            .unwrap()
+            .is_some());
+        assert!(airc.subscription_cursor(&general).await.unwrap().is_none());
+        assert!(airc.subscription_cursor(&missing).await.unwrap().is_none());
     }
 }

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -143,9 +143,20 @@ Work:
   - `Airc::subscriptions()`
   - `Airc::is_subscribed(ChannelName)`
   - `Airc::default_room()`
-  - `Airc::subscription_cursor(SubscriptionId)`
+  - `Airc::subscription_cursor(ChannelName)`
 - Make `Airc::open` accept or derive `RuntimeContext`, so consumers
   do not reimplement runtime identity/client-id logic.
+- Add typed repository/work tracking adapters:
+  - Git events: branch moved, commit observed, worktree leased/drained,
+    dirty state changed.
+  - PR events: check suite queued/running/passed/failed, review
+    requested/submitted, merge state changed.
+  - Kanban/work events: card claimed, card blocked, lane changed,
+    status advanced.
+  These are event producers over the substrate, not ad hoc polling in
+  agent scripts. Agents subscribe by repo/lane/PR headers and receive
+  state changes the same way they receive chat, monitor, and lifecycle
+  events.
 
 Acceptance gates:
 
@@ -153,6 +164,8 @@ Acceptance gates:
   without shelling out.
 - OpenClaw can list joined rooms and presence from typed API calls.
 - Agent monitor/feed code consumes the same lifecycle events.
+- Agents can track CI/PR/kanban state through subscriptions instead of
+  each runtime polling GitHub independently.
 - `airc status` is a renderer over typed state, not an owner of state.
 
 ## Phase 3 — Reliability And Error Shape

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -444,9 +444,9 @@ Acceptance gates:
 
 ## Immediate PR Queue
 
-1. In flight: move Codex hook/feed files behind an integration boundary
-   so `airc-cli` stops owning Codex-specific policy.
-2. Add lifecycle event types and subscription query API.
+1. In flight: add subscription query API on `airc-lib` so consumers can
+   inspect joined channels/default room/cursors without CLI parsing.
+2. Add lifecycle event types.
 3. Add first command-bus request/reply helper after reviewing
    Continuum's bus contract.
 
@@ -460,6 +460,9 @@ Done or superseded:
   runtime support.
 - Runtime context detection is isolated in `airc-cli::runtime_context`;
   `commands.rs` no longer owns join stream/exit heuristics.
+- Codex hook/feed/config/start files live under
+  `airc-cli::integrations::codex`; the top-level CLI no longer owns
+  Codex-specific implementation modules.
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary
- add `Airc::subscriptions()`, `Airc::is_subscribed()`, `Airc::default_room()`, and `Airc::subscription_cursor()` for typed consumer introspection
- keep consumers on `airc-lib` instead of CLI prose or direct store reads
- update `GRID-SUBSTRATE-AUDIT.md` to mark runtime/Codex boundary work done and subscription query API in flight

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib --check
- cargo test --manifest-path Cargo.toml -p airc-lib subscriptions -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-lib --all-targets -- -D warnings