### PR TITLE
docs: CI fidelity as substrate non-negotiable (#10)

### DIFF
--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -64,6 +64,14 @@ Priority order matters:
    for wire payload encoding, install/config bootstrap, and external
    invite documents; it is not acceptable for runtime cursors, trust
    state, subscriptions, presence registries, or replay checkpoints.
+10. CI proves the production path; it does not substitute around it.
+    A test that disables a behavior the production path enables is
+    blind to the bugs that behavior creates. Emulate the production
+    shape (Monitor-style streaming consumer, daemon-attached send,
+    cross-machine route resolution) under test; reach for
+    `AIRC_NO_ATTACH` or similar disable-flags only when the test is
+    explicitly proving the script/setup-only path. If we can't
+    emulate it cheaply, that's a substrate gap, not a test cheat.
 
 ## Current Drift
 
@@ -441,6 +449,29 @@ Acceptance gates:
 - No proof depends on GitHub for routine same-machine traffic.
 - Every proof has replay data suitable for debugging without the
   original UI or runtime process.
+- Per non-negotiable #10, proofs emulate the production shape they
+  are validating. A "setup-only" join test still has to prove
+  setup; a "monitor stream" test still has to prove the stream.
+  Disable-flags (`AIRC_NO_ATTACH`, `AIRC_DISABLE_ACCOUNT_REGISTRY`,
+  etc.) are admissible only when the proof is explicitly about
+  the disabled-path behavior.
+
+### Known emulation gaps (Phase 5 follow-ups)
+
+These are places CI currently disables a production behavior
+instead of emulating it. Each is a substrate bug to file once the
+companion phase work lands:
+
+- **e2e join harness sets `AIRC_NO_ATTACH=1` for setup-only
+  subprocesses** (patched alongside #911). Right next move:
+  replace the disable-flag path with a Monitor-shaped consumer
+  that reads stdout until a known marker line, SIGTERMs the
+  child, asserts on captured stream. Proves the actual attach
+  + stream path, not just the setup return.
+- **Cross-machine fixture is not yet emulated under CI.** Today
+  cross-machine routing relies on operator-side manual verify.
+  Phase 2 lifecycle events + Phase 4 command-bus need
+  multi-machine CI to genuinely prove they work end-to-end.
 
 ## Immediate PR Queue
 


### PR DESCRIPTION
## Summary

Joel: \"CI should resemble the real deal as much as we can allow for it. Otherwise we are blind to bugs.\"

Codifies that as audit non-negotiable #10. Triggered by Codex's #911 Windows fix where setup-only e2e join subprocesses set \`AIRC_NO_ATTACH=1\` to dodge streaming. The fix is correct for proving setup; the disable-flag means we no longer have a CI assertion on the actual stream path.

## Changes

1. **Non-negotiable #10** in \`GRID-SUBSTRATE-AUDIT.md\`:
   > CI proves the production path; it does not substitute around it. A test that disables a behavior the production path enables is blind to the bugs that behavior creates. Emulate the production shape; reach for \`AIRC_NO_ATTACH\` or similar disable-flags only when the test is explicitly proving the disabled-path behavior. If we can't emulate it cheaply, that's a substrate gap, not a test cheat.

2. **Phase 5 follow-ups — Known emulation gaps** subsection catalogues current disable-flag sites as filed substrate work:
   - e2e join harness setting \`AIRC_NO_ATTACH=1\` for setup-only subprocesses (post-#911). Next: Monitor-shaped consumer that reads stdout, SIGTERMs on marker line, asserts on the captured stream.
   - Cross-machine fixture not yet emulated under CI — Phase 2 lifecycle events + Phase 4 command-bus need multi-machine CI to genuinely prove.

Doc-only; no code change.

## Test plan

- [x] Markdown only; no build/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)