### PR TITLE
feat(lib): typed lifecycle events (Phase 2)

### DIFF
--- a/crates/airc-core/src/transcript.rs
+++ b/crates/airc-core/src/transcript.rs
@@ -18,6 +18,15 @@ use crate::ids::{ClientId, EventId, PeerId, RoomId};
 
 /// The category of a transcript event. Different kinds may carry
 /// different optional fields on `TranscriptEvent`.
+///
+/// The first six kinds are chat-shaped and consumer-authored:
+/// every send is one of these. The remaining "lifecycle" kinds are
+/// **substrate-authored** — emitted by airc itself when state
+/// transitions happen (room joined, peer arrived, wire established,
+/// etc.). They share the same envelope shape so consumers
+/// subscribe with the same `EventFilter` surface, but the substrate
+/// signs them from its own identity, and the `body` carries a
+/// structured JSON payload documented per-variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TranscriptKind {
@@ -27,12 +36,64 @@ pub enum TranscriptKind {
     Attachment,
     /// Delivery / read / applied receipt — `receipt` field populated.
     Receipt,
-    /// Presence transition (join, leave, away).
+    /// Presence transition (join, leave, away) — IRC analog.
+    /// Distinct from the lifecycle kinds below: `Presence` is a
+    /// consumer-authored chat-shaped event ("I am away"), while
+    /// `PeerArrived`/`PeerDeparted` are substrate-authored
+    /// transitions of the local peer registry.
     Presence,
     /// Session-level control envelope (NICK, IDENTIFY, etc.).
     SessionControl,
     /// Substrate-emitted system message (host eviction, error, etc.).
     System,
+
+    // --- Lifecycle kinds (Phase 2 of GRID-SUBSTRATE-AUDIT) ---
+    // Substrate-authored events consumers subscribe to instead of
+    // polling. Each carries a JSON body documented in
+    // `airc-lib::lifecycle`.
+    /// A new peer was enrolled in the local peer-trust registry.
+    /// Body: `{ "peer_id": <uuid>, "via": "<source>" }` where
+    /// `via` is `"invite"` / `"account_registry"` / `"manual"`.
+    PeerArrived,
+    /// A peer was removed from the local trust registry (kick,
+    /// teardown). Body: `{ "peer_id": <uuid>, "reason": "<text>" }`.
+    PeerDeparted,
+    /// A wire (channel transport) became available to the local
+    /// scope — the wire subscriber attached successfully.
+    /// Body: `{ "wire": "<path>", "channel_name": "<name>" }`.
+    WireEstablished,
+    /// A wire subscriber failed or was torn down. Body:
+    /// `{ "wire": "<path>", "reason": "<text>" }`.
+    WireLost,
+    /// This scope joined a room. Body: `{ "channel_name": "<name>",
+    /// "room_id": <uuid>, "wire": "<path>", "is_default": bool }`.
+    RoomJoined,
+    /// This scope parted a room. Body: `{ "channel_name": "<name>",
+    /// "room_id": <uuid> }`.
+    RoomParted,
+    /// A runtime consumer's cursor advanced. Body:
+    /// `{ "consumer_id": "<id>", "lamport": <u64>,
+    ///    "event_id": <uuid> }`. Useful for "I've caught up to
+    /// here" signals between cooperating consumers.
+    SubscriptionAdvanced,
+}
+
+impl TranscriptKind {
+    /// True for substrate-authored lifecycle kinds (the Phase 2
+    /// additions). Consumers that want only chat-shaped events
+    /// filter these out via `EventFilter::kinds`.
+    pub fn is_lifecycle(self) -> bool {
+        matches!(
+            self,
+            TranscriptKind::PeerArrived
+                | TranscriptKind::PeerDeparted
+                | TranscriptKind::WireEstablished
+                | TranscriptKind::WireLost
+                | TranscriptKind::RoomJoined
+                | TranscriptKind::RoomParted
+                | TranscriptKind::SubscriptionAdvanced
+        )
+    }
 }
 
 /// Who a transcript event is addressed to.

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -409,11 +409,32 @@ impl Airc {
         let mut set = subscriptions::load_or_init(self.event_store()).await?;
         let subscription =
             set.subscribe_with_wire_root(&self.inner.wire_root, &identity, channel.clone())?;
-        set.set_default(channel)?;
+        set.set_default(channel.clone())?;
         subscriptions::save(self.event_store(), &set).await?;
         self.publish_presence(&identity, &set).await?;
         let room = subscription.as_room();
         self.ensure_wire_subscriber(&room.wire).await?;
+
+        // Emit the lifecycle event after the subscription is durable
+        // and the wire is up. Failures here are non-fatal — the room
+        // is genuinely joined regardless of whether subscribers are
+        // notified — but we surface the error to logs so operators
+        // notice.
+        let body_json = serde_json::to_value(crate::lifecycle::RoomJoinedBody {
+            channel_name: channel.as_str().to_string(),
+            room_id: room.channel,
+            wire: room.wire.display().to_string(),
+            is_default: true,
+        })
+        .map_err(|e| AircError::Crypto(format!("lifecycle body serialize: {e}")))?;
+        let body = airc_core::Body::Json(body_json);
+        if let Err(error) = self
+            .emit_lifecycle(airc_core::TranscriptKind::RoomJoined, room.channel, body)
+            .await
+        {
+            eprintln!("airc-lib: room_joined lifecycle emit failed: {error}");
+        }
+
         Ok(room)
     }
 

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -45,6 +45,7 @@ mod fs_permissions;
 pub mod gh_account_registry;
 pub mod join_context;
 mod lan;
+pub mod lifecycle;
 pub mod mesh_identity;
 mod messaging;
 mod peers;

--- a/crates/airc-lib/src/lifecycle.rs
+++ b/crates/airc-lib/src/lifecycle.rs
@@ -1,0 +1,186 @@
+//! Substrate-authored lifecycle events.
+//!
+//! Phase 2 of the GRID-SUBSTRATE-AUDIT. The substrate emits these
+//! when state transitions happen (room joined, peer arrived, wire
+//! established, etc.). Consumers subscribe via the existing
+//! `Airc::subscribe`/`subscribe_subscribed_filtered` stream with
+//! an `EventFilter` that includes the lifecycle kinds.
+//!
+//! Each variant has a stable body schema documented inline. The
+//! schema is JSON because that's what the substrate's body format
+//! already is — consumers parse via `serde_json::from_value` or
+//! grab specific fields by key.
+//!
+//! These are **persisted** like any other transcript event so
+//! consumers that reconnect after a disconnect can replay the
+//! lifecycle history from their cursor. Filter them out at
+//! subscription time if you don't want them in the chat stream.
+
+use airc_core::{Body, ClientId, EventId, MentionTarget, PeerId, RoomId, TranscriptKind};
+use serde::{Deserialize, Serialize};
+
+use crate::error::AircError;
+use crate::time::now_ms;
+use crate::Airc;
+
+/// Body for `TranscriptKind::RoomJoined`. The local scope joined
+/// this room (`channel_name` resolves to `room_id` on the local
+/// wire).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoomJoinedBody {
+    pub channel_name: String,
+    pub room_id: RoomId,
+    pub wire: String,
+    pub is_default: bool,
+}
+
+/// Body for `TranscriptKind::RoomParted`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoomPartedBody {
+    pub channel_name: String,
+    pub room_id: RoomId,
+}
+
+/// Body for `TranscriptKind::PeerArrived`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PeerArrivedBody {
+    pub peer_id: PeerId,
+    /// How the peer entered local trust: `"invite"` /
+    /// `"account_registry"` / `"manual"` / `"local_scope"`.
+    pub via: String,
+}
+
+/// Body for `TranscriptKind::PeerDeparted`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PeerDepartedBody {
+    pub peer_id: PeerId,
+    pub reason: String,
+}
+
+/// Body for `TranscriptKind::WireEstablished`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WireEstablishedBody {
+    pub wire: String,
+    pub channel_name: String,
+}
+
+/// Body for `TranscriptKind::WireLost`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WireLostBody {
+    pub wire: String,
+    pub reason: String,
+}
+
+/// Body for `TranscriptKind::SubscriptionAdvanced`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubscriptionAdvancedBody {
+    pub consumer_id: String,
+    pub lamport: u64,
+    pub event_id: EventId,
+}
+
+impl Airc {
+    /// Emit a lifecycle event for the given room transition. Builds
+    /// a [`TranscriptEvent`](airc_core::TranscriptEvent) signed
+    /// from the local identity, persists it to the store, and fans
+    /// it out to live subscribers. Lifecycle events are durable
+    /// (cursor-replayable) so a consumer that reconnects sees the
+    /// transitions it missed.
+    ///
+    /// Currently wired emit points:
+    /// - `RoomJoined` — fired from [`Airc::join`] /
+    ///   [`Airc::ensure_join_context`] after the subscription row
+    ///   is persisted.
+    ///
+    /// Other variants (PeerArrived/Departed, WireEstablished/Lost,
+    /// SubscriptionAdvanced) have stable body schemas defined in
+    /// this module; their emit points are queued for follow-up
+    /// PRs (one substrate slice at a time per audit doctrine).
+    pub(crate) async fn emit_lifecycle(
+        &self,
+        kind: TranscriptKind,
+        room_id: RoomId,
+        body: Body,
+    ) -> Result<(), AircError> {
+        debug_assert!(
+            kind.is_lifecycle(),
+            "emit_lifecycle called with non-lifecycle kind {kind:?}",
+        );
+        let occurred_at_ms = now_ms()?;
+        let lamport = self.next_lamport(occurred_at_ms);
+        let event = airc_core::TranscriptEvent {
+            event_id: EventId::new(),
+            room_id,
+            peer_id: self.inner.identity.peer_id,
+            client_id: ClientId::new(),
+            kind,
+            occurred_at_ms,
+            lamport,
+            target: MentionTarget::All,
+            headers: airc_core::headers::Headers::new(),
+            body: Some(body),
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        };
+        let event_id = event.event_id;
+        let persist_result = self.inner.store.append(event.clone()).await;
+        match persist_result {
+            Ok(()) | Err(airc_store::StoreError::DuplicateEventId(_)) => {
+                if self.mark_broadcast(event_id) {
+                    let _ = self.inner.live_tx.send(event);
+                }
+                Ok(())
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_kinds_round_trip_through_is_lifecycle() {
+        // All seven lifecycle variants must be classifiable as
+        // lifecycle; the chat-shaped kinds must not.
+        for kind in [
+            TranscriptKind::PeerArrived,
+            TranscriptKind::PeerDeparted,
+            TranscriptKind::WireEstablished,
+            TranscriptKind::WireLost,
+            TranscriptKind::RoomJoined,
+            TranscriptKind::RoomParted,
+            TranscriptKind::SubscriptionAdvanced,
+        ] {
+            assert!(
+                kind.is_lifecycle(),
+                "{kind:?} should be classified as lifecycle"
+            );
+        }
+        for kind in [
+            TranscriptKind::Message,
+            TranscriptKind::Attachment,
+            TranscriptKind::Receipt,
+            TranscriptKind::Presence,
+            TranscriptKind::SessionControl,
+            TranscriptKind::System,
+        ] {
+            assert!(!kind.is_lifecycle(), "{kind:?} should NOT be lifecycle");
+        }
+    }
+
+    #[test]
+    fn room_joined_body_round_trips_through_json() {
+        let body = RoomJoinedBody {
+            channel_name: "general".into(),
+            room_id: RoomId::new(),
+            wire: "/tmp/airc/wires/general".into(),
+            is_default: true,
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        let parsed: RoomJoinedBody = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, body);
+    }
+}

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -904,7 +904,12 @@ mod tests {
         let default = airc.default_room().await.unwrap();
         assert_eq!(default.name, "cambriantech");
 
-        let cambriantech_event = make_event(42, default.channel, "cursor proof");
+        let next_lamport = airc
+            .subscription_cursor(&cambriantech)
+            .await
+            .unwrap()
+            .map_or(42, |cursor| cursor.lamport + 1);
+        let cambriantech_event = make_event(next_lamport, default.channel, "cursor proof");
         let expected_cursor = cambriantech_event.cursor();
         airc.append_event(cambriantech_event).await.unwrap();
         assert_eq!(

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -121,8 +121,7 @@ async fn open_join_say_and_replay_round_trips_in_process() {
 
     let _event_id = airc.say("hello, consumer").await.unwrap();
 
-    let page = wait_for_events(&airc, 1, Duration::from_secs(2)).await;
-    assert_eq!(page.len(), 1);
+    let page = wait_for_events(&airc, 2, Duration::from_secs(2)).await;
     let bodies: Vec<&str> = page
         .iter()
         .filter_map(|e| e.body.as_ref().and_then(Body::as_text))
@@ -562,14 +561,22 @@ async fn send_typed_body_with_headers_round_trips() {
         .await
         .unwrap();
 
-    let page = wait_for_events(&airc, 1, Duration::from_secs(2)).await;
-    assert_eq!(page.len(), 1);
+    let page = wait_for_events(&airc, 2, Duration::from_secs(2)).await;
+    let event = page
+        .iter()
+        .find(|event| {
+            event
+                .headers
+                .get("x-test-marker")
+                .is_some_and(|value| value == "round-trip")
+        })
+        .expect("typed event should round-trip with marker header");
     assert_eq!(
-        page[0].headers.get("x-test-marker").map(String::as_str),
+        event.headers.get("x-test-marker").map(String::as_str),
         Some("round-trip")
     );
     assert_eq!(
-        page[0].headers.get("forge.body_hint").map(String::as_str),
+        event.headers.get("forge.body_hint").map(String::as_str),
         Some("application/json")
     );
 }
@@ -618,12 +625,11 @@ async fn two_embedded_handles_chat_over_lan_without_cli() {
 
     bob.say("hello over sdk lan").await.unwrap();
 
-    let page = wait_for_events(&alice, 1, Duration::from_secs(3)).await;
-    let bodies: Vec<&str> = page
-        .iter()
-        .filter_map(|event| event.body.as_ref().and_then(Body::as_text))
-        .collect();
-    assert_eq!(bodies, vec!["hello over sdk lan"]);
+    let event = wait_for_text(&alice, "hello over sdk lan", Duration::from_secs(3)).await;
+    assert_eq!(
+        event.body.as_ref().and_then(Body::as_text),
+        Some("hello over sdk lan")
+    );
 }
 
 #[tokio::test]

--- a/crates/airc-lib/tests/lifecycle_events.rs
+++ b/crates/airc-lib/tests/lifecycle_events.rs
@@ -1,0 +1,96 @@
+//! Lifecycle event emit + subscribe round-trip.
+//!
+//! Phase 2 proof point: a consumer can subscribe to the substrate
+//! stream and receive substrate-authored lifecycle events
+//! (RoomJoined, etc.) without polling state files. Future emit
+//! points (PeerArrived, WireEstablished, ...) extend this same
+//! pattern.
+
+use std::time::Duration;
+
+use airc_core::{Body, TranscriptKind};
+use airc_lib::{lifecycle::RoomJoinedBody, Airc};
+use futures::stream::StreamExt;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn join_emits_room_joined_lifecycle_event() {
+    let dir = TempDir::new().expect("tempdir");
+    let home = dir.path().join(".airc");
+    std::fs::create_dir_all(&home).unwrap();
+    let airc = Airc::open(&home).await.expect("open");
+
+    // Attach BEFORE join so we don't miss the lifecycle event the
+    // join produces. The broadcast channel does have a small buffer
+    // for in-flight delivery but a clean test asserts the stream
+    // sees the live emit.
+    let mut stream = airc.subscribe().await.expect("subscribe");
+
+    let join_task = {
+        let airc = airc.clone();
+        tokio::spawn(async move {
+            // Tiny sleep to let the subscribe attach fully.
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            airc.join("lifecycle-test").await.expect("join")
+        })
+    };
+
+    // Wait up to 2s for the RoomJoined event to surface on the
+    // stream. The test fails loudly if it doesn't — the emit point
+    // wired in airc.rs::join must produce this event.
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    let mut found = None;
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), stream.next()).await {
+            Ok(Some(Ok(event))) => {
+                if event.kind == TranscriptKind::RoomJoined {
+                    found = Some(event);
+                    break;
+                }
+            }
+            Ok(Some(Err(_))) => continue,
+            Ok(None) => panic!("stream closed before RoomJoined arrived"),
+            Err(_) => continue,
+        }
+    }
+    let room = join_task.await.expect("join completes");
+
+    let event = found.expect("RoomJoined should have been emitted by airc.join");
+    assert_eq!(event.kind, TranscriptKind::RoomJoined);
+    let body = event.body.as_ref().expect("event has body");
+    let body_json = match body {
+        Body::Json(value) => value.clone(),
+        _ => panic!("RoomJoined body should be JSON"),
+    };
+    let parsed: RoomJoinedBody =
+        serde_json::from_value(body_json).expect("body parses as RoomJoinedBody");
+    assert_eq!(parsed.channel_name, "lifecycle-test");
+    assert_eq!(parsed.room_id, room.channel);
+    assert!(parsed.is_default, "join sets the channel as default");
+}
+
+#[tokio::test]
+async fn lifecycle_event_is_persisted_for_cursor_replay() {
+    // Lifecycle events must be durable so a consumer that reconnects
+    // can replay the transitions it missed. Confirm by paging
+    // recent events after join.
+    let dir = TempDir::new().expect("tempdir");
+    let home = dir.path().join(".airc");
+    std::fs::create_dir_all(&home).unwrap();
+    let airc = Airc::open(&home).await.expect("open");
+
+    let _room = airc.join("durability-test").await.expect("join");
+
+    // page_recent reads from the store; if the lifecycle event was
+    // persisted, it shows up here.
+    let page = airc.page_recent(16).await.expect("page");
+    let lifecycle_count = page
+        .iter()
+        .filter(|e| e.kind == TranscriptKind::RoomJoined)
+        .count();
+    assert!(
+        lifecycle_count >= 1,
+        "at least one RoomJoined event should be persisted: {lifecycle_count} found in page of {} events",
+        page.len()
+    );
+}

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -862,6 +862,13 @@ fn to_active_model(ev: &TranscriptEvent) -> Result<event::ActiveModel, StoreErro
         TranscriptKind::Presence => "presence",
         TranscriptKind::SessionControl => "session_control",
         TranscriptKind::System => "system",
+        TranscriptKind::PeerArrived => "peer_arrived",
+        TranscriptKind::PeerDeparted => "peer_departed",
+        TranscriptKind::WireEstablished => "wire_established",
+        TranscriptKind::WireLost => "wire_lost",
+        TranscriptKind::RoomJoined => "room_joined",
+        TranscriptKind::RoomParted => "room_parted",
+        TranscriptKind::SubscriptionAdvanced => "subscription_advanced",
     };
     Ok(event::ActiveModel {
         event_id: ActiveValue::Set(ev.event_id.as_uuid()),
@@ -897,6 +904,13 @@ fn from_model(m: event::Model) -> Result<TranscriptEvent, StoreError> {
         "presence" => TranscriptKind::Presence,
         "session_control" => TranscriptKind::SessionControl,
         "system" => TranscriptKind::System,
+        "peer_arrived" => TranscriptKind::PeerArrived,
+        "peer_departed" => TranscriptKind::PeerDeparted,
+        "wire_established" => TranscriptKind::WireEstablished,
+        "wire_lost" => TranscriptKind::WireLost,
+        "room_joined" => TranscriptKind::RoomJoined,
+        "room_parted" => TranscriptKind::RoomParted,
+        "subscription_advanced" => TranscriptKind::SubscriptionAdvanced,
         other => return Err(StoreError::UnknownTranscriptKind(other.to_string())),
     };
     let target: MentionTarget = serde_json::from_value(m.target)?;


### PR DESCRIPTION
## Summary

Phase 2 of GRID-SUBSTRATE-AUDIT. The substrate now emits typed events for state transitions consumers used to have to poll for. Same envelope shape as chat-shaped events; same subscription filter; same cursor-replayable persistence.

Continuum, OpenClaw, Hermes, agent runtimes, future AR consumers subscribe via the existing \`Airc::subscribe\` / \`subscribe_subscribed_filtered\` stream and filter by \`TranscriptKind\`.

## Variants added

\`airc_core::TranscriptKind\` gains seven lifecycle variants:

| Variant | Body schema |
|---|---|
| \`PeerArrived\` | \`{peer_id, via}\` where via ∈ {invite, account_registry, manual, local_scope} |
| \`PeerDeparted\` | \`{peer_id, reason}\` |
| \`WireEstablished\` | \`{wire, channel_name}\` |
| \`WireLost\` | \`{wire, reason}\` |
| \`RoomJoined\` | \`{channel_name, room_id, wire, is_default}\` |
| \`RoomParted\` | \`{channel_name, room_id}\` |
| \`SubscriptionAdvanced\` | \`{consumer_id, lamport, event_id}\` |

Plus \`TranscriptKind::is_lifecycle()\` helper that classifies the seven distinctly from chat-shaped kinds (Message / Attachment / Receipt / Presence / SessionControl / System). Consumers wanting only chat filter via \`EventFilter::kinds\`.

## Emit points wired in this PR

**RoomJoined** — \`Airc::join\` emits this event after the subscription is durable and the wire subscriber is up. Failures are non-fatal but logged (the room is genuinely joined regardless of subscriber visibility).

The other six variants have **stable body schemas defined and documented in \`airc_lib::lifecycle\`**; their emit points (PeerArrived/Departed on peer_trust mutation, Wire* on subscriber lifecycle, SubscriptionAdvanced on cursor save) are queued for follow-up PRs per Phase 2's slice-by-slice cadence.

## Plumbing

- \`airc_core::transcript\` — variant declarations + classification helper + per-variant body schema docs.
- \`airc_store::sqlite\` — both \`to_active_model\` and \`from_model\` extended to map the seven new kinds to/from their snake_case table strings. Round-trip preserved.
- \`airc_lib::lifecycle\` (new) — typed body structs (\`RoomJoinedBody\`, \`PeerArrivedBody\`, etc.) plus the \`pub(crate) Airc::emit_lifecycle\` helper.
- \`airc_lib::airc\` — \`Airc::join\` calls \`emit_lifecycle\` after the durable + wire setup.

## Integration tests (\`crates/airc-lib/tests/lifecycle_events.rs\`)

- \`join_emits_room_joined_lifecycle_event\` — subscribe BEFORE join, call join in a spawned task, assert the RoomJoined event surfaces on the stream with the expected body.
- \`lifecycle_event_is_persisted_for_cursor_replay\` — proves the event is durable in the store so cursor-replay surfaces it for consumers that reconnect.

## Phase 2 acceptance gate

> Continuum can subscribe to room/lifecycle events through airc-lib without shelling out.

This PR makes that true for RoomJoined; the same emit pattern carries forward to the remaining variants in follow-up PRs.

## Verification

- \`cargo test --workspace\` green (all suites)
- \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- \`cargo fmt --check\` clean

## Test plan

- [x] Workspace tests, clippy, fmt
- [ ] CI: 3-OS tests + runtime guards
- [ ] After merge: a Continuum smoke can subscribe with \`EventFilter { kinds: [TranscriptKind::RoomJoined], ... }\` and assert it sees the right events

🤖 Generated with [Claude Code](https://claude.com/claude-code)