### PR TITLE
test(cli): emulate join attach in e2e harness

### DIFF
--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -156,20 +156,17 @@ fn join_without_args_uses_default_account_context() {
     let mut join = Command::new(airc_core());
     join.env("HOME", machine.path())
         .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
-        .env("AIRC_NO_ATTACH", "1")
+        .env("AIRC_CLIENT_ID", "agent:e2e-join")
         .args(["--home", home.to_str().unwrap(), "join"])
-        .current_dir(&repo);
-    let output = output_with_timeout(join, Duration::from_secs(10), "airc join");
-    assert!(
-        output.status.success(),
-        "join failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
-    let stdout = String::from_utf8(output.stdout).unwrap();
+        .current_dir(&repo)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    strip_cargo_harness_env(&mut join);
+    let stdout = run_join_until_attached(join, Duration::from_secs(10)).join("\n");
     assert!(stdout.contains("#general"), "{stdout}");
     assert!(stdout.contains("#cambriantech"), "{stdout}");
     assert!(stdout.contains("default: #cambriantech"), "{stdout}");
+    assert!(stdout.contains("attached"), "{stdout}");
 
     assert!(
         !home.join("subscriptions.json").exists(),
@@ -203,21 +200,18 @@ fn join_sets_up_codex_hook_when_codex_home_exists() {
     let mut join = Command::new(airc_core());
     join.env("HOME", machine.path())
         .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
-        .env("AIRC_NO_ATTACH", "1")
+        .env("AIRC_CLIENT_ID", "agent:e2e-join-codex")
         .args(["--home", home.to_str().unwrap(), "join"])
-        .current_dir(&repo);
-    let output = output_with_timeout(join, Duration::from_secs(10), "airc join");
-    assert!(
-        output.status.success(),
-        "join failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
+        .current_dir(&repo)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    strip_cargo_harness_env(&mut join);
+    let stdout = run_join_until_attached(join, Duration::from_secs(10)).join("\n");
     assert!(
         stdout.contains("runtime: installed AIRC UserPromptSubmit hook"),
         "{stdout}"
     );
+    assert!(stdout.contains("attached"), "{stdout}");
 
     let hooks = std::fs::read_to_string(codex_home.join("hooks.json")).expect("hooks.json");
     assert!(
@@ -238,6 +232,60 @@ fn join_sets_up_codex_hook_when_codex_home_exists() {
         String::from_utf8_lossy(&stop.stdout),
         String::from_utf8_lossy(&stop.stderr),
     );
+}
+
+fn strip_cargo_harness_env(command: &mut Command) {
+    command.env_remove("CARGO_PKG_NAME");
+    for key in std::env::vars_os()
+        .map(|(key, _)| key)
+        .filter(|key| key.to_string_lossy().starts_with("CARGO_BIN_EXE_"))
+    {
+        command.env_remove(key);
+    }
+}
+
+fn run_join_until_attached(mut command: Command, timeout: Duration) -> Vec<String> {
+    let mut child = command.spawn().unwrap_or_else(|error| {
+        panic!("airc join must spawn: {error}");
+    });
+    let stdout = child.stdout.take().expect("join stdout");
+    let stderr = child.stderr.take().expect("join stderr");
+    let stdout_lines = spawn_line_reader(stdout);
+    let stderr_lines = spawn_line_reader(stderr);
+    let mut lines = Vec::new();
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        match stdout_lines.recv_timeout(Duration::from_millis(100)) {
+            Ok(line) => {
+                let attached = line.contains("attached");
+                lines.push(line);
+                if attached {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return lines;
+                }
+            }
+            Err(_) => {
+                if let Ok(Some(status)) = child.try_wait() {
+                    let stderr = stderr_lines.try_iter().collect::<Vec<_>>().join("\n");
+                    panic!(
+                        "airc join exited before attaching: status={status} stdout={} stderr={stderr}",
+                        lines.join("\n"),
+                    );
+                }
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let stderr = stderr_lines.try_iter().collect::<Vec<_>>().join("\n");
+                    panic!(
+                        "airc join did not attach within {timeout:?}: stdout={} stderr={stderr}",
+                        lines.join("\n"),
+                    );
+                }
+            }
+        }
+    }
 }
 
 fn output_with_timeout(

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -471,28 +471,29 @@ Acceptance gates:
 
 ### Known emulation gaps (Phase 5 follow-ups)
 
-These are places CI currently disables a production behavior
-instead of emulating it. Each is a substrate bug to file once the
-companion phase work lands:
+These track places where CI disabled a production behavior instead
+of emulating it. Open items are substrate bugs to file once the
+companion phase work lands; closed items stay here as regression
+context.
 
-- **e2e join harness sets `AIRC_NO_ATTACH=1` for setup-only
-  subprocesses** (patched alongside #911). Right next move:
-  replace the disable-flag path with a Monitor-shaped consumer
-  that reads stdout until a known marker line, SIGTERMs the
-  child, asserts on captured stream. Proves the actual attach
-  + stream path, not just the setup return.
-- **Cross-machine fixture is not yet emulated under CI.** Today
+- **Closed: e2e join harness no longer sets `AIRC_NO_ATTACH=1` for
+  setup-only subprocesses.** It now emulates an agent runtime by
+  removing Cargo harness markers, setting a stable runtime client,
+  reading stdout until the attach marker, terminating the child, and
+  asserting on the captured stream. This proves the actual attach +
+  stream path instead of only the setup return.
+- **Open: cross-machine fixture is not yet emulated under CI.** Today
   cross-machine routing relies on operator-side manual verify.
   Phase 2 lifecycle events + Phase 4 command-bus need
   multi-machine CI to genuinely prove they work end-to-end.
 
 ## Immediate PR Queue
 
-1. In flight: add subscription query API on `airc-lib` so consumers can
-   inspect joined channels/default room/cursors without CLI parsing.
-2. Add lifecycle event types.
-3. Add first command-bus request/reply helper after reviewing
-   Continuum's bus contract.
+1. Add lifecycle event types.
+2. Add the git/PR/kanban event adapter skeleton so agents can
+   subscribe to work-state changes instead of polling.
+3. Add cross-machine CI fixture shape that proves local/LAN/tailnet
+   routing without relying on GitHub for routine traffic.
 
 Done or superseded:
 
@@ -507,6 +508,12 @@ Done or superseded:
 - Codex hook/feed/config/start files live under
   `airc-cli::integrations::codex`; the top-level CLI no longer owns
   Codex-specific implementation modules.
+- Subscription query APIs are in `airc-lib`: consumers can inspect
+  joined channels, default room, and cursors without parsing CLI prose.
+- Command-bus request/reply helpers are in `airc-lib`, with directed
+  envelope targets and correlation/deadline headers.
+- The e2e join harness now emulates a Monitor-shaped streaming
+  consumer instead of disabling attach with `AIRC_NO_ATTACH`.
 
 ## Open Questions
 


### PR DESCRIPTION
Summary
- replace AIRC_NO_ATTACH join e2e shortcuts with a Monitor-shaped streaming harness
- strip Cargo-only harness env from spawned join processes and use stable agent runtime client ids
- update GRID-SUBSTRATE-AUDIT: join attach emulation gap closed; current PR queue refreshed

Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-cli --test e2e -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-cli --test e2e -- -D warnings