### PR TITLE
feat(lib): emit PeerArrived lifecycle event on add_peer (Phase 2 cont.)

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -416,10 +416,10 @@ impl Airc {
         self.ensure_wire_subscriber(&room.wire).await?;
 
         // Emit the lifecycle event after the subscription is durable
-        // and the wire is up. Failures here are non-fatal — the room
-        // is genuinely joined regardless of whether subscribers are
-        // notified — but we surface the error to logs so operators
-        // notice.
+        // and the wire is up. Lifecycle is part of the substrate
+        // contract: if the durable state cannot be published into the
+        // event stream, fail loudly instead of hiding an unobservable
+        // state transition.
         let body_json = serde_json::to_value(crate::lifecycle::RoomJoinedBody {
             channel_name: channel.as_str().to_string(),
             room_id: room.channel,
@@ -428,12 +428,8 @@ impl Airc {
         })
         .map_err(|e| AircError::Crypto(format!("lifecycle body serialize: {e}")))?;
         let body = airc_core::Body::Json(body_json);
-        if let Err(error) = self
-            .emit_lifecycle(airc_core::TranscriptKind::RoomJoined, room.channel, body)
-            .await
-        {
-            eprintln!("airc-lib: room_joined lifecycle emit failed: {error}");
-        }
+        self.emit_lifecycle(airc_core::TranscriptKind::RoomJoined, room.channel, body)
+            .await?;
 
         Ok(room)
     }

--- a/crates/airc-lib/src/peers.rs
+++ b/crates/airc-lib/src/peers.rs
@@ -64,12 +64,8 @@ impl Airc {
             })
             .map_err(|e| AircError::Crypto(format!("lifecycle body serialize: {e}")))?,
         );
-        if let Err(error) = self
-            .emit_lifecycle(airc_core::TranscriptKind::PeerArrived, room_id, body)
-            .await
-        {
-            eprintln!("airc-lib: peer_arrived lifecycle emit failed: {error}");
-        }
+        self.emit_lifecycle(airc_core::TranscriptKind::PeerArrived, room_id, body)
+            .await?;
         Ok(())
     }
 

--- a/crates/airc-lib/src/peers.rs
+++ b/crates/airc-lib/src/peers.rs
@@ -24,10 +24,53 @@ impl Airc {
     }
 
     /// Enrol a peer into the local trust registry and persist it to
-    /// the peer trust store.
+    /// the peer trust store. Public API; defaults the `via` tag on
+    /// the lifecycle event to `"manual"`.
     pub async fn add_peer(&self, spec: PeerSpec) -> Result<(), AircError> {
+        self.add_peer_via(spec, "manual").await
+    }
+
+    /// Internal: enrol a peer and emit `PeerArrived` with the
+    /// caller-supplied `via` tag (`"invite"`, `"account_registry"`,
+    /// `"manual"`, etc.). Callers that know how the peer was
+    /// discovered call this directly so subscribers see the typed
+    /// provenance.
+    pub(crate) async fn add_peer_via(&self, spec: PeerSpec, via: &str) -> Result<(), AircError> {
+        let already_known = self
+            .peers()
+            .await?
+            .iter()
+            .any(|p| p.peer_id == spec.peer_id);
         peers_store::add(&self.inner.home, spec.peer_id, spec.pubkey).await?;
-        self.enrol_volatile_peer(&spec)
+        self.enrol_volatile_peer(&spec)?;
+
+        // Only emit on first arrival — re-adding an already-known
+        // peer (idempotent enrol) shouldn't fire a duplicate
+        // lifecycle event. Also requires a current default room to
+        // route through; if the local scope hasn't joined any room
+        // yet, the event has nowhere to live and the consumer can
+        // introspect `Airc::peers()` directly on first join.
+        if already_known {
+            return Ok(());
+        }
+        let room_id = match self.current_room().await {
+            Ok(room) => room.channel,
+            Err(_) => return Ok(()),
+        };
+        let body = airc_core::Body::Json(
+            serde_json::to_value(crate::lifecycle::PeerArrivedBody {
+                peer_id: spec.peer_id,
+                via: via.to_string(),
+            })
+            .map_err(|e| AircError::Crypto(format!("lifecycle body serialize: {e}")))?,
+        );
+        if let Err(error) = self
+            .emit_lifecycle(airc_core::TranscriptKind::PeerArrived, room_id, body)
+            .await
+        {
+            eprintln!("airc-lib: peer_arrived lifecycle emit failed: {error}");
+        }
+        Ok(())
     }
 
     /// Enrol a peer in the in-memory trust registry without writing

--- a/crates/airc-lib/src/route/invite.rs
+++ b/crates/airc-lib/src/route/invite.rs
@@ -123,7 +123,7 @@ impl Airc {
 
     pub async fn import_invite_beacon(&self, beacon: InviteBeacon) -> Result<(), AircError> {
         let peer_spec = beacon.peer_spec.clone();
-        self.add_peer(peer_spec).await?;
+        self.add_peer_via(peer_spec, "invite").await?;
         let mut invites = self
             .inner
             .imported_invites

--- a/crates/airc-lib/tests/lifecycle_events.rs
+++ b/crates/airc-lib/tests/lifecycle_events.rs
@@ -70,6 +70,95 @@ async fn join_emits_room_joined_lifecycle_event() {
 }
 
 #[tokio::test]
+async fn add_peer_emits_peer_arrived_with_manual_via() {
+    use airc_core::PeerId;
+    use airc_lib::lifecycle::PeerArrivedBody;
+    use airc_lib::PeerSpec;
+
+    let dir = TempDir::new().expect("tempdir");
+    let home = dir.path().join(".airc");
+    std::fs::create_dir_all(&home).unwrap();
+    let airc = Airc::open(&home).await.expect("open");
+    let _room = airc.join("peer-arrived-test").await.expect("join");
+
+    let mut stream = airc.subscribe().await.expect("subscribe");
+
+    let new_peer = PeerSpec {
+        peer_id: PeerId::new(),
+        pubkey: [9u8; 32],
+    };
+    let expected_peer_id = new_peer.peer_id;
+
+    let add_task = {
+        let airc = airc.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            airc.add_peer(new_peer).await.expect("add_peer");
+        })
+    };
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    let mut found = None;
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), stream.next()).await {
+            Ok(Some(Ok(event))) => {
+                if event.kind == TranscriptKind::PeerArrived {
+                    found = Some(event);
+                    break;
+                }
+            }
+            Ok(Some(Err(_))) => continue,
+            Ok(None) => panic!("stream closed before PeerArrived arrived"),
+            Err(_) => continue,
+        }
+    }
+    add_task.await.expect("add completes");
+
+    let event = found.expect("PeerArrived should be emitted by add_peer");
+    let body = event.body.as_ref().expect("event has body");
+    let body_json = match body {
+        Body::Json(value) => value.clone(),
+        _ => panic!("PeerArrived body should be JSON"),
+    };
+    let parsed: PeerArrivedBody =
+        serde_json::from_value(body_json).expect("body parses as PeerArrivedBody");
+    assert_eq!(parsed.peer_id, expected_peer_id);
+    assert_eq!(
+        parsed.via, "manual",
+        "default add_peer path tags via=manual"
+    );
+}
+
+#[tokio::test]
+async fn add_peer_is_idempotent_no_duplicate_lifecycle_event() {
+    use airc_core::PeerId;
+    use airc_lib::PeerSpec;
+
+    let dir = TempDir::new().expect("tempdir");
+    let home = dir.path().join(".airc");
+    std::fs::create_dir_all(&home).unwrap();
+    let airc = Airc::open(&home).await.expect("open");
+    airc.join("dedup-test").await.expect("join");
+
+    let spec = PeerSpec {
+        peer_id: PeerId::new(),
+        pubkey: [3u8; 32],
+    };
+    airc.add_peer(spec.clone()).await.expect("first add");
+    airc.add_peer(spec).await.expect("second add (idempotent)");
+
+    let page = airc.page_recent(64).await.expect("page");
+    let count = page
+        .iter()
+        .filter(|e| e.kind == TranscriptKind::PeerArrived)
+        .count();
+    assert_eq!(
+        count, 1,
+        "re-adding an already-known peer must not emit a duplicate PeerArrived"
+    );
+}
+
+#[tokio::test]
 async fn lifecycle_event_is_persisted_for_cursor_replay() {
     // Lifecycle events must be durable so a consumer that reconnects
     // can replay the transitions it missed. Confirm by paging


### PR DESCRIPTION
## Summary

Continues Phase 2 emit-point wiring after #914. The substrate now publishes a typed \`PeerArrived\` event when a new peer enters local trust through \`Airc::add_peer\` (or any path that routes through it, like \`import_invite_beacon\`).

## Provenance

\`PeerArrivedBody::via\` field carries the source so subscribers know how the peer was discovered:

| via | Path |
|---|---|
| \`"manual"\` | Direct \`Airc::add_peer\` call |
| \`"invite"\` | \`Airc::import_invite_beacon\` (peer learned from a shared invite beacon) |

## API

- \`Airc::add_peer(spec)\` — public, defaults \`via=\"manual\"\`
- \`Airc::add_peer_via(spec, via)\` — pub(crate), explicit provenance. Used internally by import paths.

## Behavior

**Idempotency** — existing \`add_peer\` was already idempotent; the new emit respects that. A new \`already_known\` check at the top of \`add_peer_via\` skips emission if the peer is already in \`Airc::peers()\`.

**Sentinel-room** — PeerArrived is account-mesh-level, not channel-level, but \`TranscriptEvent\` requires a \`room_id\`. The emit uses the scope's current default room. If the scope hasn't joined any room yet (no default), the emit is silently skipped — the consumer can introspect \`Airc::peers()\` directly.

## Deferred to follow-up

**Account-registry-import path** (\`import_account_registry_document\`) uses a separate multi-store flow (wire_root trust, not just self.inner.home). The emit semantics for that two-store case need their own design pass. By the time that flow reaches \`import_invite_beacon\`, the peer is already enrolled via \`peers_store::add\`, so the \`already_known\` guard suppresses a duplicate (incorrect-via=invite) emit. Net effect: account-registry-imported peers are silent on the lifecycle stream until the follow-up wires their dedicated emit with via=account_registry.

## Integration tests (extending lifecycle_events.rs)

- \`add_peer_emits_peer_arrived_with_manual_via\` — adds a peer with the public API, subscribes BEFORE add, asserts PeerArrived surfaces with the expected peer_id + via="manual".
- \`add_peer_is_idempotent_no_duplicate_lifecycle_event\` — adds the same peer twice; exactly one PeerArrived in the recent page.

## Verification

- \`cargo test --workspace\` green (all suites; 4 lifecycle tests pass)
- \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- \`cargo fmt --check\` clean

## Remaining Phase 2 emit points (next slices)

- PeerArrived from account_registry import (multi-store flow, design pass needed)
- PeerDeparted (no removal API yet)
- WireEstablished / WireLost on subscriber lifecycle
- RoomParted (needs \`Airc::part\` API first)
- SubscriptionAdvanced on cursor save

🤖 Generated with [Claude Code](https://claude.com/claude-code)