### PR TITLE
feat(work): add git and PR event contracts

### DIFF
--- a/crates/airc-work/src/codec/headers.rs
+++ b/crates/airc-work/src/codec/headers.rs
@@ -13,6 +13,9 @@ pub const HEADER_FORGE_WORK_LANE_ID: &str = "forge.work.lane_id";
 pub const HEADER_FORGE_WORK_CLAIM_ID: &str = "forge.work.claim_id";
 pub const HEADER_FORGE_WORK_WORKSPACE_ID: &str = "forge.work.workspace_id";
 pub const HEADER_FORGE_WORK_POLICY_RULE_ID: &str = "forge.work.policy_rule_id";
+pub const HEADER_FORGE_WORK_GIT_BRANCH: &str = "forge.work.git_branch";
+pub const HEADER_FORGE_WORK_GIT_COMMIT: &str = "forge.work.git_commit";
+pub const HEADER_FORGE_WORK_PR_NUMBER: &str = "forge.work.pr_number";
 
 pub fn work_event_headers(event: &WorkEvent) -> Headers {
     let mut headers = Headers::new();
@@ -84,11 +87,40 @@ fn project_domain_headers(event: &WorkEvent, headers: &mut Headers) {
                 e.policy_rule_id.clone(),
             );
         }
+        WorkEvent::GitCommitObserved(e) => {
+            headers.insert(HEADER_FORGE_WORK_REPO.to_string(), e.repo.to_string());
+            insert_display_header(headers, HEADER_FORGE_WORK_GIT_COMMIT, &e.commit);
+            if let Some(branch) = &e.branch {
+                insert_display_header(headers, HEADER_FORGE_WORK_GIT_BRANCH, branch);
+            }
+        }
+        WorkEvent::GitBranchMoved(e) => {
+            headers.insert(HEADER_FORGE_WORK_REPO.to_string(), e.repo.to_string());
+            insert_display_header(headers, HEADER_FORGE_WORK_GIT_BRANCH, &e.branch);
+            insert_display_header(headers, HEADER_FORGE_WORK_GIT_COMMIT, &e.new_head);
+        }
+        WorkEvent::GitDirtyStateChanged(e) => {
+            headers.insert(HEADER_FORGE_WORK_REPO.to_string(), e.repo.to_string());
+            if let Some(workspace_id) = e.workspace_id {
+                insert_display_header(headers, HEADER_FORGE_WORK_WORKSPACE_ID, workspace_id);
+            }
+        }
+        WorkEvent::PullRequestCheckSuiteChanged(e) => {
+            project_pull_request(headers, &e.pull_request);
+        }
+        WorkEvent::PullRequestReviewSubmitted(e) => {
+            project_pull_request(headers, &e.pull_request);
+        }
+        WorkEvent::PullRequestMergeStateChanged(e) => {
+            project_pull_request(headers, &e.pull_request);
+        }
         WorkEvent::PullRequestLinked(e) => {
-            project_pull_request(headers, e.card_id, &e.pull_request.repo)
+            insert_display_header(headers, HEADER_FORGE_WORK_CARD_ID, e.card_id);
+            project_pull_request(headers, &e.pull_request);
         }
         WorkEvent::PullRequestMerged(e) => {
-            project_pull_request(headers, e.card_id, &e.pull_request.repo)
+            insert_display_header(headers, HEADER_FORGE_WORK_CARD_ID, e.card_id);
+            project_pull_request(headers, &e.pull_request);
         }
         WorkEvent::HygieneReportRecorded(e) => {
             headers.insert(
@@ -110,9 +142,13 @@ fn project_claim(headers: &mut Headers, card_id: crate::WorkCardId, claim_id: cr
     insert_display_header(headers, HEADER_FORGE_WORK_CLAIM_ID, claim_id);
 }
 
-fn project_pull_request(headers: &mut Headers, card_id: crate::WorkCardId, repo: &crate::RepoId) {
-    insert_display_header(headers, HEADER_FORGE_WORK_CARD_ID, card_id);
-    headers.insert(HEADER_FORGE_WORK_REPO.to_string(), repo.to_string());
+fn project_pull_request(headers: &mut Headers, pull_request: &crate::PullRequestRef) {
+    headers.insert(
+        HEADER_FORGE_WORK_REPO.to_string(),
+        pull_request.repo.to_string(),
+    );
+    insert_display_header(headers, HEADER_FORGE_WORK_PR_NUMBER, pull_request.number);
+    insert_display_header(headers, HEADER_FORGE_WORK_GIT_BRANCH, &pull_request.head);
 }
 
 fn insert_display_header(headers: &mut Headers, key: &str, value: impl std::fmt::Display) {

--- a/crates/airc-work/src/codec/mod.rs
+++ b/crates/airc-work/src/codec/mod.rs
@@ -17,7 +17,8 @@ mod tests;
 
 pub use headers::{
     work_event_headers, HEADER_FORGE_WORK_CARD_ID, HEADER_FORGE_WORK_CLAIM_ID,
-    HEADER_FORGE_WORK_EVENT_KIND, HEADER_FORGE_WORK_LANE_ID, HEADER_FORGE_WORK_POLICY_RULE_ID,
+    HEADER_FORGE_WORK_EVENT_KIND, HEADER_FORGE_WORK_GIT_BRANCH, HEADER_FORGE_WORK_GIT_COMMIT,
+    HEADER_FORGE_WORK_LANE_ID, HEADER_FORGE_WORK_POLICY_RULE_ID, HEADER_FORGE_WORK_PR_NUMBER,
     HEADER_FORGE_WORK_REPO, HEADER_FORGE_WORK_WORKSPACE_ID,
 };
 
@@ -96,6 +97,12 @@ pub(crate) fn event_kind(event: &WorkEvent) -> &'static str {
         WorkEvent::WorkspacePressureReported(_) => "workspace_pressure_reported",
         WorkEvent::WorkspaceDrainRequested(_) => "workspace_drain_requested",
         WorkEvent::WorkspaceDrainCompleted(_) => "workspace_drain_completed",
+        WorkEvent::GitCommitObserved(_) => "git_commit_observed",
+        WorkEvent::GitBranchMoved(_) => "git_branch_moved",
+        WorkEvent::GitDirtyStateChanged(_) => "git_dirty_state_changed",
+        WorkEvent::PullRequestCheckSuiteChanged(_) => "pull_request_check_suite_changed",
+        WorkEvent::PullRequestReviewSubmitted(_) => "pull_request_review_submitted",
+        WorkEvent::PullRequestMergeStateChanged(_) => "pull_request_merge_state_changed",
         WorkEvent::PullRequestLinked(_) => "pull_request_linked",
         WorkEvent::PullRequestMerged(_) => "pull_request_merged",
         WorkEvent::HygieneReportRecorded(_) => "hygiene_report_recorded",

--- a/crates/airc-work/src/codec/tests.rs
+++ b/crates/airc-work/src/codec/tests.rs
@@ -3,9 +3,11 @@ use airc_protocol::{FrameKind, HEADER_FORGE_BODY_HINT};
 
 use super::*;
 use crate::{
-    BranchName, CardCreated, ClaimId, DrainCandidate, DrainCandidateCategory, DrainOutcome, LaneId,
-    PressureLevel, Priority, RepoId, WorkCardId, WorkEvent, WorkspaceDrainCompleted,
-    WorkspaceDrainRequested, WorkspaceId, WorkspacePressureReported, WorkspaceRequested,
+    BranchName, CardCreated, ClaimId, DrainCandidate, DrainCandidateCategory, DrainOutcome,
+    GitBranchMoved, GitObjectId, LaneId, PrCheckState, PressureLevel, Priority,
+    PullRequestCheckSuiteChanged, PullRequestRef, RepoId, WorkCardId, WorkEvent,
+    WorkspaceDrainCompleted, WorkspaceDrainRequested, WorkspaceId, WorkspacePressureReported,
+    WorkspaceRequested,
 };
 
 fn card_created() -> WorkEvent {
@@ -208,5 +210,71 @@ fn workspace_headers_include_workspace_claim_card_and_repo() {
     assert_eq!(
         headers.get(HEADER_FORGE_WORK_REPO).map(String::as_str),
         Some("CambrianTech/continuum")
+    );
+}
+
+#[test]
+fn git_and_pr_events_roundtrip_with_routeable_headers() {
+    let repo = RepoId::new("CambrianTech/airc").unwrap();
+    let branch = BranchName::new("rust-rewrite").unwrap();
+    let commit = GitObjectId::new("abc123").unwrap();
+
+    let git_event = WorkEvent::GitBranchMoved(GitBranchMoved {
+        repo: repo.clone(),
+        branch: branch.clone(),
+        old_head: None,
+        new_head: commit.clone(),
+        moved_by: PeerId::from_u128(1),
+        moved_at_ms: 2,
+    });
+    let (headers, body) = encode_work_event(&git_event).unwrap();
+    assert_eq!(decode_work_event(&headers, Some(&body)).unwrap(), git_event);
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_WORK_EVENT_KIND)
+            .map(String::as_str),
+        Some("git_branch_moved")
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_WORK_GIT_BRANCH)
+            .map(String::as_str),
+        Some("rust-rewrite")
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_WORK_GIT_COMMIT)
+            .map(String::as_str),
+        Some("abc123")
+    );
+
+    let pr_event = WorkEvent::PullRequestCheckSuiteChanged(PullRequestCheckSuiteChanged {
+        pull_request: PullRequestRef {
+            repo,
+            number: 914,
+            head: BranchName::new("feat/lifecycle-events").unwrap(),
+            base: branch,
+        },
+        state: PrCheckState::Passed,
+        changed_by: PeerId::from_u128(3),
+        changed_at_ms: 4,
+    });
+    let (headers, body) = encode_work_event(&pr_event).unwrap();
+    assert_eq!(decode_work_event(&headers, Some(&body)).unwrap(), pr_event);
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_WORK_EVENT_KIND)
+            .map(String::as_str),
+        Some("pull_request_check_suite_changed")
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_WORK_PR_NUMBER).map(String::as_str),
+        Some("914")
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_WORK_GIT_BRANCH)
+            .map(String::as_str),
+        Some("feat/lifecycle-events")
     );
 }

--- a/crates/airc-work/src/event.rs
+++ b/crates/airc-work/src/event.rs
@@ -6,8 +6,8 @@ use airc_core::PeerId;
 
 use crate::ids::{ClaimId, LaneId, RepoId, WorkCardId, WorkspaceId};
 use crate::model::{
-    BranchName, CardState, DrainCandidate, DrainOutcome, HygieneReport, LaneState, PressureLevel,
-    Priority, PullRequestRef,
+    BranchName, CardState, DirtyState, DrainCandidate, DrainOutcome, GitObjectId, HygieneReport,
+    LaneState, PrCheckState, PrMergeState, PrReviewState, PressureLevel, Priority, PullRequestRef,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -27,6 +27,12 @@ pub enum WorkEvent {
     WorkspacePressureReported(WorkspacePressureReported),
     WorkspaceDrainRequested(WorkspaceDrainRequested),
     WorkspaceDrainCompleted(WorkspaceDrainCompleted),
+    GitCommitObserved(GitCommitObserved),
+    GitBranchMoved(GitBranchMoved),
+    GitDirtyStateChanged(GitDirtyStateChanged),
+    PullRequestCheckSuiteChanged(PullRequestCheckSuiteChanged),
+    PullRequestReviewSubmitted(PullRequestReviewSubmitted),
+    PullRequestMergeStateChanged(PullRequestMergeStateChanged),
     PullRequestLinked(PullRequestLinked),
     PullRequestMerged(PullRequestMerged),
     HygieneReportRecorded(HygieneReportRecorded),
@@ -51,6 +57,12 @@ impl WorkEvent {
             WorkEvent::WorkspacePressureReported(e) => e.reported_at_ms,
             WorkEvent::WorkspaceDrainRequested(e) => e.requested_at_ms,
             WorkEvent::WorkspaceDrainCompleted(e) => e.completed_at_ms,
+            WorkEvent::GitCommitObserved(e) => e.observed_at_ms,
+            WorkEvent::GitBranchMoved(e) => e.moved_at_ms,
+            WorkEvent::GitDirtyStateChanged(e) => e.changed_at_ms,
+            WorkEvent::PullRequestCheckSuiteChanged(e) => e.changed_at_ms,
+            WorkEvent::PullRequestReviewSubmitted(e) => e.submitted_at_ms,
+            WorkEvent::PullRequestMergeStateChanged(e) => e.changed_at_ms,
             WorkEvent::PullRequestLinked(e) => e.linked_at_ms,
             WorkEvent::PullRequestMerged(e) => e.merged_at_ms,
             WorkEvent::HygieneReportRecorded(e) => e.report.recorded_at_ms,
@@ -204,6 +216,70 @@ pub struct WorkspaceDrainCompleted {
     pub dry_run: bool,
     pub outcome: DrainOutcome,
     pub completed_at_ms: u64,
+}
+
+/// A commit was observed by a local git adapter, CI adapter, or
+/// external forge adapter. This is an observation event, not a command
+/// to mutate git.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GitCommitObserved {
+    pub repo: RepoId,
+    pub commit: GitObjectId,
+    pub branch: Option<BranchName>,
+    pub summary: Option<String>,
+    pub observed_by: PeerId,
+    pub observed_at_ms: u64,
+}
+
+/// A branch head moved. Consumers can subscribe to this instead of
+/// polling `git fetch && git rev-parse` in every runtime.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GitBranchMoved {
+    pub repo: RepoId,
+    pub branch: BranchName,
+    pub old_head: Option<GitObjectId>,
+    pub new_head: GitObjectId,
+    pub moved_by: PeerId,
+    pub moved_at_ms: u64,
+}
+
+/// Worktree dirty state changed. This is intentionally small and
+/// closed: detailed path inventories belong in a follow-up inventory
+/// event, while this event is what monitors need to wake up.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GitDirtyStateChanged {
+    pub repo: RepoId,
+    pub workspace_id: Option<WorkspaceId>,
+    pub path: String,
+    pub state: DirtyState,
+    pub dirty_paths: u64,
+    pub untracked_paths: u64,
+    pub changed_by: PeerId,
+    pub changed_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestCheckSuiteChanged {
+    pub pull_request: PullRequestRef,
+    pub state: PrCheckState,
+    pub changed_by: PeerId,
+    pub changed_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestReviewSubmitted {
+    pub pull_request: PullRequestRef,
+    pub reviewer: PeerId,
+    pub state: PrReviewState,
+    pub submitted_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestMergeStateChanged {
+    pub pull_request: PullRequestRef,
+    pub state: PrMergeState,
+    pub changed_by: PeerId,
+    pub changed_at_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/airc-work/src/lib.rs
+++ b/crates/airc-work/src/lib.rs
@@ -16,28 +16,31 @@ pub mod replay;
 pub use codec::{
     decode_work_event, encode_work_event, work_event_headers, work_event_subscription,
     WorkEventCodecError, BODY_HINT_FORGE_WORK_EVENT, HEADER_FORGE_WORK_CARD_ID,
-    HEADER_FORGE_WORK_CLAIM_ID, HEADER_FORGE_WORK_EVENT_KIND, HEADER_FORGE_WORK_LANE_ID,
-    HEADER_FORGE_WORK_POLICY_RULE_ID, HEADER_FORGE_WORK_REPO, HEADER_FORGE_WORK_WORKSPACE_ID,
+    HEADER_FORGE_WORK_CLAIM_ID, HEADER_FORGE_WORK_EVENT_KIND, HEADER_FORGE_WORK_GIT_BRANCH,
+    HEADER_FORGE_WORK_GIT_COMMIT, HEADER_FORGE_WORK_LANE_ID, HEADER_FORGE_WORK_POLICY_RULE_ID,
+    HEADER_FORGE_WORK_PR_NUMBER, HEADER_FORGE_WORK_REPO, HEADER_FORGE_WORK_WORKSPACE_ID,
 };
 pub use drain_policy::{
     evaluate as evaluate_drain_policy, AdmitReason, DrainDecision, GitStatusSummary, PolicyConfig,
     PolicyInputs, PrStatus, PrTerminalState, ReportOnlyReason, DEFAULT_HEARTBEAT_STALE_MS,
 };
 pub use event::{
-    CardCreated, CardStateChanged, ClaimHeartbeat, ClaimReleased, HygieneReportRecorded,
-    LaneCreated, LaneStateChanged, ManagerHatClaimed, ManagerHatReleased, PullRequestLinked,
-    PullRequestMerged, WorkCardClaimed, WorkEvent, WorkspaceAllocated, WorkspaceDrainCompleted,
-    WorkspaceDrainRequested, WorkspaceHeartbeat, WorkspacePressureReported, WorkspaceReleased,
-    WorkspaceRequested,
+    CardCreated, CardStateChanged, ClaimHeartbeat, ClaimReleased, GitBranchMoved,
+    GitCommitObserved, GitDirtyStateChanged, HygieneReportRecorded, LaneCreated, LaneStateChanged,
+    ManagerHatClaimed, ManagerHatReleased, PullRequestCheckSuiteChanged, PullRequestLinked,
+    PullRequestMergeStateChanged, PullRequestMerged, PullRequestReviewSubmitted, WorkCardClaimed,
+    WorkEvent, WorkspaceAllocated, WorkspaceDrainCompleted, WorkspaceDrainRequested,
+    WorkspaceHeartbeat, WorkspacePressureReported, WorkspaceReleased, WorkspaceRequested,
 };
 pub use ids::{ClaimId, LaneId, RepoId, WorkCardId, WorkspaceId};
 pub use model::{
-    BranchName, CardState, DrainCandidate, DrainCandidateCategory, DrainOutcome, HygieneReport,
-    LaneState, PressureLevel, Priority, PullRequestRef, WorkCard, WorkspaceLease, WorkspaceStatus,
+    BranchName, CardState, DirtyState, DrainCandidate, DrainCandidateCategory, DrainOutcome,
+    GitObjectId, HygieneReport, LaneState, PrCheckState, PrMergeState, PrReviewState,
+    PressureLevel, Priority, PullRequestRef, WorkCard, WorkspaceLease, WorkspaceStatus,
 };
 pub use projection::{
-    BoardSnapshot, LaneRecord, ManagerHat, ProjectionError, StaleClaim, WorkBoardProjection,
-    WorkspaceRecord,
+    BoardSnapshot, BranchTrackingRecord, LaneRecord, ManagerHat, ProjectionError,
+    PullRequestRecord, RepoTrackingRecord, StaleClaim, WorkBoardProjection, WorkspaceRecord,
 };
 pub use replay::{
     decode_transcript_work_event, project_transcript_work_events, transcript_is_work_event,

--- a/crates/airc-work/src/model.rs
+++ b/crates/airc-work/src/model.rs
@@ -93,6 +93,84 @@ pub struct PullRequestRef {
     pub base: BranchName,
 }
 
+/// Git object id such as a commit SHA. Kept as a string because Git
+/// installations may expose full SHA-1 today and SHA-256 in newer
+/// repositories; validation only enforces a non-empty hexadecimal id.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct GitObjectId(String);
+
+impl GitObjectId {
+    pub fn new(value: impl Into<String>) -> Result<Self, GitObjectIdError> {
+        let value = value.into();
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(GitObjectIdError::Empty);
+        }
+        if !trimmed.chars().all(|ch| ch.is_ascii_hexdigit()) {
+            return Err(GitObjectIdError::NonHex);
+        }
+        Ok(Self(trimmed.to_ascii_lowercase()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for GitObjectId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum GitObjectIdError {
+    #[error("git object id cannot be empty")]
+    Empty,
+    #[error("git object id must be hexadecimal")]
+    NonHex,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DirtyState {
+    Clean,
+    Dirty,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrCheckState {
+    Queued,
+    Running,
+    Passed,
+    Failed,
+    Cancelled,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrReviewState {
+    Requested,
+    Commented,
+    Approved,
+    ChangesRequested,
+    Dismissed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrMergeState {
+    Open,
+    Draft,
+    Ready,
+    Merged,
+    Closed,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkCard {
     pub card_id: WorkCardId,
@@ -241,5 +319,15 @@ mod tests {
             BranchName::new(" feat/good ").unwrap().as_str(),
             "feat/good"
         );
+    }
+
+    #[test]
+    fn git_object_id_normalizes_hex_and_rejects_unknown_shapes() {
+        assert_eq!(GitObjectId::new(" ABCD1234 ").unwrap().as_str(), "abcd1234");
+        assert!(matches!(GitObjectId::new(""), Err(GitObjectIdError::Empty)));
+        assert!(matches!(
+            GitObjectId::new("not-a-sha"),
+            Err(GitObjectIdError::NonHex)
+        ));
     }
 }

--- a/crates/airc-work/src/projection.rs
+++ b/crates/airc-work/src/projection.rs
@@ -6,9 +6,16 @@ use serde::{Deserialize, Serialize};
 
 use airc_core::PeerId;
 
-use crate::event::{WorkspaceDrainCompleted, WorkspaceDrainRequested, WorkspacePressureReported};
+use crate::event::{
+    GitCommitObserved, GitDirtyStateChanged, PullRequestCheckSuiteChanged,
+    PullRequestMergeStateChanged, PullRequestReviewSubmitted, WorkspaceDrainCompleted,
+    WorkspaceDrainRequested, WorkspacePressureReported,
+};
 use crate::ids::{ClaimId, LaneId, RepoId, WorkCardId, WorkspaceId};
-use crate::model::{HygieneReport, LaneState, WorkCard, WorkspaceLease};
+use crate::model::{
+    BranchName, GitObjectId, HygieneReport, LaneState, PrCheckState, PrMergeState, PrReviewState,
+    PullRequestRef, WorkCard, WorkspaceLease,
+};
 
 mod apply;
 
@@ -31,6 +38,8 @@ pub struct WorkBoardProjection {
     /// Append-only history of completed drains across all workspaces.
     /// Consumers paginate / filter by `workspace_id` via accessors.
     pub(super) drain_history: Vec<WorkspaceDrainCompleted>,
+    pub(super) repo_tracking: BTreeMap<RepoId, RepoTrackingRecord>,
+    pub(super) pull_requests: BTreeMap<String, PullRequestRecord>,
     pub(super) manager_hats: BTreeMap<RepoId, ManagerHat>,
     pub(super) hygiene_reports: Vec<HygieneReport>,
 }
@@ -61,6 +70,14 @@ impl WorkBoardProjection {
             .filter(|d| &d.workspace_id == workspace_id)
             .collect()
     }
+
+    pub fn repo_tracking(&self, repo: &RepoId) -> Option<&RepoTrackingRecord> {
+        self.repo_tracking.get(repo)
+    }
+
+    pub fn pull_request(&self, repo: &RepoId, number: u64) -> Option<&PullRequestRecord> {
+        self.pull_requests.get(&pull_request_key(repo, number))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -68,6 +85,8 @@ pub struct BoardSnapshot {
     pub cards: Vec<WorkCard>,
     pub lanes: Vec<LaneRecord>,
     pub workspaces: Vec<WorkspaceRecord>,
+    pub repo_tracking: Vec<RepoTrackingRecord>,
+    pub pull_requests: Vec<PullRequestRecord>,
     pub manager_hats: Vec<ManagerHat>,
     pub hygiene_reports: Vec<HygieneReport>,
 }
@@ -87,6 +106,95 @@ pub struct LaneRecord {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkspaceRecord {
     pub lease: WorkspaceLease,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoTrackingRecord {
+    pub repo: RepoId,
+    pub branches: BTreeMap<BranchName, BranchTrackingRecord>,
+    pub observed_commits: Vec<GitCommitObserved>,
+    pub dirty_states: Vec<GitDirtyStateChanged>,
+}
+
+impl RepoTrackingRecord {
+    fn new(repo: RepoId) -> Self {
+        Self {
+            repo,
+            branches: BTreeMap::new(),
+            observed_commits: Vec::new(),
+            dirty_states: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BranchTrackingRecord {
+    pub branch: BranchName,
+    pub head: GitObjectId,
+    pub updated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestRecord {
+    pub pull_request: PullRequestRef,
+    pub check_state: Option<PrCheckState>,
+    pub review_state: Option<PrReviewState>,
+    pub merge_state: Option<PrMergeState>,
+    pub updated_at_ms: u64,
+}
+
+impl PullRequestRecord {
+    fn from_check(event: &PullRequestCheckSuiteChanged) -> Self {
+        Self {
+            pull_request: event.pull_request.clone(),
+            check_state: Some(event.state),
+            review_state: None,
+            merge_state: None,
+            updated_at_ms: event.changed_at_ms,
+        }
+    }
+
+    fn from_review(event: &PullRequestReviewSubmitted) -> Self {
+        Self {
+            pull_request: event.pull_request.clone(),
+            check_state: None,
+            review_state: Some(event.state),
+            merge_state: None,
+            updated_at_ms: event.submitted_at_ms,
+        }
+    }
+
+    fn from_merge(event: &PullRequestMergeStateChanged) -> Self {
+        Self {
+            pull_request: event.pull_request.clone(),
+            check_state: None,
+            review_state: None,
+            merge_state: Some(event.state),
+            updated_at_ms: event.changed_at_ms,
+        }
+    }
+
+    fn apply_check(&mut self, event: &PullRequestCheckSuiteChanged) {
+        self.pull_request = event.pull_request.clone();
+        self.check_state = Some(event.state);
+        self.updated_at_ms = event.changed_at_ms;
+    }
+
+    fn apply_review(&mut self, event: &PullRequestReviewSubmitted) {
+        self.pull_request = event.pull_request.clone();
+        self.review_state = Some(event.state);
+        self.updated_at_ms = event.submitted_at_ms;
+    }
+
+    fn apply_merge(&mut self, event: &PullRequestMergeStateChanged) {
+        self.pull_request = event.pull_request.clone();
+        self.merge_state = Some(event.state);
+        self.updated_at_ms = event.changed_at_ms;
+    }
+}
+
+pub(super) fn pull_request_key(repo: &RepoId, number: u64) -> String {
+    format!("{repo}#{number}")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/airc-work/src/projection/apply.rs
+++ b/crates/airc-work/src/projection/apply.rs
@@ -1,16 +1,17 @@
 use crate::event::{
-    CardCreated, CardStateChanged, ClaimHeartbeat, ClaimReleased, HygieneReportRecorded,
-    LaneCreated, LaneStateChanged, ManagerHatClaimed, ManagerHatReleased, PullRequestLinked,
-    PullRequestMerged, WorkCardClaimed, WorkEvent, WorkspaceAllocated, WorkspaceDrainCompleted,
-    WorkspaceDrainRequested, WorkspaceHeartbeat, WorkspacePressureReported, WorkspaceReleased,
-    WorkspaceRequested,
+    CardCreated, CardStateChanged, ClaimHeartbeat, ClaimReleased, GitBranchMoved,
+    GitCommitObserved, GitDirtyStateChanged, HygieneReportRecorded, LaneCreated, LaneStateChanged,
+    ManagerHatClaimed, ManagerHatReleased, PullRequestCheckSuiteChanged, PullRequestLinked,
+    PullRequestMergeStateChanged, PullRequestMerged, PullRequestReviewSubmitted, WorkCardClaimed,
+    WorkEvent, WorkspaceAllocated, WorkspaceDrainCompleted, WorkspaceDrainRequested,
+    WorkspaceHeartbeat, WorkspacePressureReported, WorkspaceReleased, WorkspaceRequested,
 };
 use crate::ids::{WorkCardId, WorkspaceId};
 use crate::model::{CardState, WorkCard, WorkspaceLease, WorkspaceStatus};
 
 use super::{
-    BoardSnapshot, LaneRecord, ManagerHat, ProjectionError, StaleClaim, WorkBoardProjection,
-    WorkspaceRecord,
+    pull_request_key, BoardSnapshot, BranchTrackingRecord, LaneRecord, ManagerHat, ProjectionError,
+    PullRequestRecord, RepoTrackingRecord, StaleClaim, WorkBoardProjection, WorkspaceRecord,
 };
 
 impl WorkBoardProjection {
@@ -34,6 +35,21 @@ impl WorkBoardProjection {
             WorkEvent::WorkspacePressureReported(e) => self.apply_workspace_pressure_reported(e),
             WorkEvent::WorkspaceDrainRequested(e) => self.apply_workspace_drain_requested(e),
             WorkEvent::WorkspaceDrainCompleted(e) => self.apply_workspace_drain_completed(e),
+            WorkEvent::GitCommitObserved(e) => self.apply_git_commit_observed(e),
+            WorkEvent::GitBranchMoved(e) => self.apply_git_branch_moved(e),
+            WorkEvent::GitDirtyStateChanged(e) => self.apply_git_dirty_state_changed(e),
+            WorkEvent::PullRequestCheckSuiteChanged(e) => {
+                self.apply_pull_request_check_suite_changed(e);
+                Ok(())
+            }
+            WorkEvent::PullRequestReviewSubmitted(e) => {
+                self.apply_pull_request_review_submitted(e);
+                Ok(())
+            }
+            WorkEvent::PullRequestMergeStateChanged(e) => {
+                self.apply_pull_request_merge_state_changed(e);
+                Ok(())
+            }
             WorkEvent::PullRequestLinked(e) => self.apply_pull_request_linked(e),
             WorkEvent::PullRequestMerged(e) => self.apply_pull_request_merged(e),
             WorkEvent::HygieneReportRecorded(e) => self.apply_hygiene_report_recorded(e),
@@ -55,6 +71,8 @@ impl WorkBoardProjection {
             cards: self.cards.values().cloned().collect(),
             lanes: self.lanes.values().cloned().collect(),
             workspaces: self.workspaces.values().cloned().collect(),
+            repo_tracking: self.repo_tracking.values().cloned().collect(),
+            pull_requests: self.pull_requests.values().cloned().collect(),
             manager_hats: self.manager_hats.values().cloned().collect(),
             hygiene_reports: self.hygiene_reports.clone(),
         }
@@ -267,6 +285,74 @@ impl WorkBoardProjection {
         Ok(())
     }
 
+    fn apply_git_commit_observed(&mut self, e: &GitCommitObserved) -> Result<(), ProjectionError> {
+        let repo = self.repo_tracking_record(e.repo.clone());
+        repo.observed_commits.push(e.clone());
+        if let Some(branch) = &e.branch {
+            repo.branches.insert(
+                branch.clone(),
+                BranchTrackingRecord {
+                    branch: branch.clone(),
+                    head: e.commit.clone(),
+                    updated_at_ms: e.observed_at_ms,
+                },
+            );
+        }
+        Ok(())
+    }
+
+    fn apply_git_branch_moved(&mut self, e: &GitBranchMoved) -> Result<(), ProjectionError> {
+        let repo = self.repo_tracking_record(e.repo.clone());
+        repo.branches.insert(
+            e.branch.clone(),
+            BranchTrackingRecord {
+                branch: e.branch.clone(),
+                head: e.new_head.clone(),
+                updated_at_ms: e.moved_at_ms,
+            },
+        );
+        Ok(())
+    }
+
+    fn apply_git_dirty_state_changed(
+        &mut self,
+        e: &GitDirtyStateChanged,
+    ) -> Result<(), ProjectionError> {
+        let repo = self.repo_tracking_record(e.repo.clone());
+        repo.dirty_states.push(e.clone());
+        Ok(())
+    }
+
+    fn apply_pull_request_check_suite_changed(&mut self, e: &PullRequestCheckSuiteChanged) {
+        self.pull_requests
+            .entry(pull_request_key(
+                &e.pull_request.repo,
+                e.pull_request.number,
+            ))
+            .and_modify(|record| record.apply_check(e))
+            .or_insert_with(|| PullRequestRecord::from_check(e));
+    }
+
+    fn apply_pull_request_review_submitted(&mut self, e: &PullRequestReviewSubmitted) {
+        self.pull_requests
+            .entry(pull_request_key(
+                &e.pull_request.repo,
+                e.pull_request.number,
+            ))
+            .and_modify(|record| record.apply_review(e))
+            .or_insert_with(|| PullRequestRecord::from_review(e));
+    }
+
+    fn apply_pull_request_merge_state_changed(&mut self, e: &PullRequestMergeStateChanged) {
+        self.pull_requests
+            .entry(pull_request_key(
+                &e.pull_request.repo,
+                e.pull_request.number,
+            ))
+            .and_modify(|record| record.apply_merge(e))
+            .or_insert_with(|| PullRequestRecord::from_merge(e));
+    }
+
     fn apply_pull_request_linked(&mut self, e: &PullRequestLinked) -> Result<(), ProjectionError> {
         let card = self.card_mut(e.card_id)?;
         card.pull_request = Some(e.pull_request.clone());
@@ -329,6 +415,12 @@ impl WorkBoardProjection {
         self.workspaces
             .get_mut(&workspace_id)
             .ok_or(ProjectionError::UnknownWorkspace(workspace_id))
+    }
+
+    fn repo_tracking_record(&mut self, repo: crate::RepoId) -> &mut RepoTrackingRecord {
+        self.repo_tracking
+            .entry(repo.clone())
+            .or_insert_with(|| RepoTrackingRecord::new(repo))
     }
 }
 

--- a/crates/airc-work/src/projection/tests.rs
+++ b/crates/airc-work/src/projection/tests.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::event::*;
 use crate::model::{
-    BranchName, CardState, DrainCandidate, DrainCandidateCategory, DrainOutcome, PressureLevel,
-    Priority, PullRequestRef, WorkspaceStatus,
+    BranchName, CardState, DirtyState, DrainCandidate, DrainCandidateCategory, DrainOutcome,
+    GitObjectId, PrCheckState, PrMergeState, PrReviewState, PressureLevel, Priority,
+    PullRequestRef, WorkspaceStatus,
 };
 
 fn repo() -> RepoId {
@@ -297,6 +298,86 @@ fn two_concurrent_drain_requests_for_same_workspace_and_rule_overwrites() {
     let pending = projection.pending_drains_for(&workspace_id);
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].requested_at_ms, 20);
+}
+
+#[test]
+fn git_and_pr_adapter_events_project_without_polling() {
+    let repo = repo();
+    let branch = BranchName::new("rust-rewrite").unwrap();
+    let head = GitObjectId::new("abc123").unwrap();
+    let next = GitObjectId::new("def456").unwrap();
+    let peer = peer(77);
+    let pr = PullRequestRef {
+        repo: repo.clone(),
+        number: 914,
+        head: BranchName::new("feat/lifecycle-events").unwrap(),
+        base: branch.clone(),
+    };
+
+    let projection = WorkBoardProjection::replay(vec![
+        WorkEvent::GitCommitObserved(GitCommitObserved {
+            repo: repo.clone(),
+            commit: head.clone(),
+            branch: Some(branch.clone()),
+            summary: Some("initial rust substrate".to_string()),
+            observed_by: peer,
+            observed_at_ms: 10,
+        }),
+        WorkEvent::GitBranchMoved(GitBranchMoved {
+            repo: repo.clone(),
+            branch: branch.clone(),
+            old_head: Some(head.clone()),
+            new_head: next.clone(),
+            moved_by: peer,
+            moved_at_ms: 20,
+        }),
+        WorkEvent::GitDirtyStateChanged(GitDirtyStateChanged {
+            repo: repo.clone(),
+            workspace_id: Some(WorkspaceId::from_u128(5)),
+            path: "/Users/joelteply/.airc/worktrees/airc/feat".to_string(),
+            state: DirtyState::Dirty,
+            dirty_paths: 2,
+            untracked_paths: 1,
+            changed_by: peer,
+            changed_at_ms: 30,
+        }),
+        WorkEvent::PullRequestCheckSuiteChanged(PullRequestCheckSuiteChanged {
+            pull_request: pr.clone(),
+            state: PrCheckState::Running,
+            changed_by: peer,
+            changed_at_ms: 40,
+        }),
+        WorkEvent::PullRequestReviewSubmitted(PullRequestReviewSubmitted {
+            pull_request: pr.clone(),
+            reviewer: peer,
+            state: PrReviewState::Approved,
+            submitted_at_ms: 50,
+        }),
+        WorkEvent::PullRequestMergeStateChanged(PullRequestMergeStateChanged {
+            pull_request: pr.clone(),
+            state: PrMergeState::Merged,
+            changed_by: peer,
+            changed_at_ms: 60,
+        }),
+    ])
+    .unwrap();
+
+    let repo_tracking = projection.repo_tracking(&repo).unwrap();
+    assert_eq!(repo_tracking.observed_commits.len(), 1);
+    assert_eq!(repo_tracking.dirty_states[0].state, DirtyState::Dirty);
+    assert_eq!(repo_tracking.branches[&branch].head, next);
+    assert_eq!(repo_tracking.branches[&branch].updated_at_ms, 20);
+
+    let pr_record = projection.pull_request(&repo, 914).unwrap();
+    assert_eq!(pr_record.pull_request, pr);
+    assert_eq!(pr_record.check_state, Some(PrCheckState::Running));
+    assert_eq!(pr_record.review_state, Some(PrReviewState::Approved));
+    assert_eq!(pr_record.merge_state, Some(PrMergeState::Merged));
+    assert_eq!(pr_record.updated_at_ms, 60);
+
+    let snapshot = projection.snapshot();
+    assert_eq!(snapshot.repo_tracking.len(), 1);
+    assert_eq!(snapshot.pull_requests.len(), 1);
 }
 
 #[test]

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -166,6 +166,17 @@ Work:
   state changes the same way they receive chat, monitor, and lifecycle
   events.
 
+Status:
+
+- `airc-lib` subscription query API landed in #911.
+- Typed lifecycle events landed in #914.
+- Typed git/PR event contracts are being added in `airc-work`:
+  `GitCommitObserved`, `GitBranchMoved`, `GitDirtyStateChanged`,
+  `PullRequestCheckSuiteChanged`, `PullRequestReviewSubmitted`, and
+  `PullRequestMergeStateChanged`. This is the contract/projection
+  layer only; the GitHub adapter and local git watcher are separate
+  producers that must emit these events instead of polling inline.
+
 Acceptance gates:
 
 - Continuum can subscribe to room/lifecycle events through `airc-lib`

--- a/docs/rust-substrate-grievances-and-gaps.md
+++ b/docs/rust-substrate-grievances-and-gaps.md
@@ -844,6 +844,18 @@ Replaces the single-slice "Queue/lane Rust model" line in the First Remediation 
    - **Sub-PR 3c — pressure detector + drain executor.** Runtime that probes disk, emits `WorkspacePressureReported`, evaluates policy (default = `RebuildableCache` + `DownloadedDependency`), and executes `WorkspaceDrainRequested` → `WorkspaceDrainCompleted`. Dry-run path lands first.
 4. **PR 4 — CLI thin wrapper.** `airc work list`, `airc work claim`, `airc lane status`, `airc workspace list`, `airc workspace report`, `airc hygiene report`, `airc hygiene clean --dry-run` — all backed by `airc-work`, no Python touched.
 5. **PR 5 — GitHub adapter.** Mirror card state to issues/PRs; reconcile PR status into events; GitHub is adapter-only.
+   - **Sub-PR 5a — git/PR event contracts.** Typed events for
+     `GitCommitObserved`, `GitBranchMoved`, `GitDirtyStateChanged`,
+     `PullRequestCheckSuiteChanged`, `PullRequestReviewSubmitted`, and
+     `PullRequestMergeStateChanged`, plus routeable headers and
+     projection records. No `gh` calls and no local git watcher in
+     this slice.
+   - **Sub-PR 5b — local git watcher adapter.** Observe branch head,
+     commit, and dirty-state changes for AIRC-managed workspaces and
+     emit the 5a events.
+   - **Sub-PR 5c — GitHub PR adapter.** Reconcile PR/check/review/merge
+     state into the 5a PR events. GitHub remains an adapter, not the
+     runtime source of truth.
 6. **PR 6 — monitor/hook subscriptions.** Codex hook becomes `airc codex-hook` consuming an `airc-work`-aware subscription; monitor reads typed subscriptions; no Python hook path remains.
 7. **PR 7 — Continuum bridge.** Continuum event subsystem consumes AIRC subscriptions directly. Persona inboxes are AIRC channel/header subscriptions plus Continuum-specific projection/RAG assembly.
 


### PR DESCRIPTION
## Summary
- add typed git observation events for commit observed, branch moved, and dirty state changed
- add typed PR state events for check suite, review, and merge-state changes
- project repo/branch/commit/PR headers for cheap subscription filtering without body parsing
- extend work projections with repo tracking and PR records for future local-git/GitHub adapters
- update substrate audit docs with the 5a/5b/5c adapter split

## Verification
- cargo fmt --manifest-path Cargo.toml --all --check
- cargo test --manifest-path Cargo.toml -p airc-work -p airc-lib -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-work -p airc-lib --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings