### PR TITLE
feat(work): add local git watcher adapter

### DIFF
--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -22,6 +22,9 @@ pub enum AircError {
     #[error("work event codec: {0}")]
     WorkCodec(#[from] airc_work::WorkEventCodecError),
 
+    #[error("local git observer: {0}")]
+    LocalGit(#[from] airc_work::LocalGitError),
+
     #[error("room state: {0}")]
     Room(#[from] crate::room::RoomError),
 

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -99,8 +99,8 @@ pub use subscriptions::{
 };
 pub use work::{
     AllocateWorkspace, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard, CreateWorkCard,
-    CreateWorkLane, HeartbeatWorkspace, ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace,
-    RequestWorkspace,
+    CreateWorkLane, HeartbeatWorkspace, ObserveLocalGitWorkspace, ObservedLocalGitWorkspace,
+    ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace, RequestWorkspace,
 };
 
 // Convenience re-exports so consumers don't need to pull airc-core
@@ -112,7 +112,7 @@ pub use airc_core::{
     ClientId, EventId, PeerId, RoomId, TranscriptCursor, TranscriptEvent, TranscriptKind,
 };
 pub use airc_work::{
-    BoardSnapshot, BranchName, CardState, ClaimId, LaneId, LaneState, ManagerHat, Priority,
-    ProjectionError, RepoId, WorkBoardProjection, WorkCardId, WorkEvent, WorkspaceId,
-    WorkspaceStatus,
+    BoardSnapshot, BranchName, CardState, ClaimId, DirtyState, GitObjectId, LaneId, LaneState,
+    LocalGitSnapshot, ManagerHat, Priority, ProjectionError, RepoId, WorkBoardProjection,
+    WorkCardId, WorkEvent, WorkspaceId, WorkspaceStatus,
 };

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -3,8 +3,9 @@
 use airc_core::EventId;
 use airc_protocol::FrameKind;
 use airc_work::{
-    encode_work_event, BranchName, CardCreated, ClaimId, ClaimReleased, LaneCreated, LaneId,
-    LaneState, LaneStateChanged, ManagerHatClaimed, ManagerHatReleased, Priority, RepoId,
+    encode_work_event, local_git_events_since, BranchName, CardCreated, ClaimId, ClaimReleased,
+    CommandGitRunner, LaneCreated, LaneId, LaneState, LaneStateChanged, LocalGitObserver,
+    LocalGitSnapshot, LocalGitWorkspace, ManagerHatClaimed, ManagerHatReleased, Priority, RepoId,
     WorkBoardProjection, WorkCardClaimed, WorkCardId, WorkEvent, WorkspaceAllocated,
     WorkspaceHeartbeat, WorkspaceId, WorkspaceReleased, WorkspaceRequested,
 };
@@ -83,6 +84,20 @@ pub struct ClaimManagerHat {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReleaseManagerHat {
     pub repo: RepoId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObserveLocalGitWorkspace {
+    pub repo: RepoId,
+    pub workspace_id: Option<WorkspaceId>,
+    pub path: std::path::PathBuf,
+    pub previous: Option<LocalGitSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObservedLocalGitWorkspace {
+    pub snapshot: LocalGitSnapshot,
+    pub emitted_event_ids: Vec<EventId>,
 }
 
 impl Airc {
@@ -242,6 +257,39 @@ impl Airc {
         });
         self.publish_work_event(&event).await?;
         Ok(())
+    }
+
+    /// Observe a local git worktree and publish typed work-domain
+    /// events for changes since the caller's previous snapshot.
+    ///
+    /// This is the local adapter boundary: it shells out to `git`, but
+    /// only typed `airc-work` events cross the substrate.
+    pub async fn observe_local_git_workspace(
+        &self,
+        request: ObserveLocalGitWorkspace,
+    ) -> Result<ObservedLocalGitWorkspace, AircError> {
+        let workspace = LocalGitWorkspace {
+            repo: request.repo,
+            workspace_id: request.workspace_id,
+            path: request.path,
+        };
+        let snapshot = LocalGitObserver::new(CommandGitRunner).observe(&workspace)?;
+        let events = local_git_events_since(
+            &workspace,
+            request.previous.as_ref(),
+            &snapshot,
+            self.peer_id(),
+            now_ms()?,
+        );
+        let mut emitted_event_ids = Vec::with_capacity(events.len());
+        for event in events {
+            emitted_event_ids.push(self.publish_work_event(&event).await?);
+        }
+
+        Ok(ObservedLocalGitWorkspace {
+            snapshot,
+            emitted_event_ids,
+        })
     }
 
     /// Rebuild the current room's work board from persisted work

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -2,10 +2,39 @@ use std::time::{Duration, Instant};
 
 use airc_lib::{
     Airc, AllocateWorkspace, BranchName, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard,
-    CreateWorkCard, CreateWorkLane, HeartbeatWorkspace, LaneState, Priority, ReleaseManagerHat,
-    ReleaseWorkClaim, ReleaseWorkspace, RepoId, RequestWorkspace, WorkCardId, WorkspaceStatus,
+    CreateWorkCard, CreateWorkLane, DirtyState, HeartbeatWorkspace, LaneState,
+    ObserveLocalGitWorkspace, Priority, ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace,
+    RepoId, RequestWorkspace, WorkCardId, WorkspaceStatus,
 };
 use tempfile::TempDir;
+
+fn git(repo: &std::path::Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn init_git_repo() -> TempDir {
+    let repo = TempDir::new().unwrap();
+    git(repo.path(), &["init", "-b", "main"]);
+    git(
+        repo.path(),
+        &["config", "user.email", "airc@example.invalid"],
+    );
+    git(repo.path(), &["config", "user.name", "AIRC Test"]);
+    std::fs::write(repo.path().join("README.md"), "initial\n").unwrap();
+    git(repo.path(), &["add", "README.md"]);
+    git(repo.path(), &["commit", "-m", "initial"]);
+    repo
+}
 
 async fn wait_for_card(airc: &Airc, card_id: WorkCardId) -> airc_lib::WorkBoardProjection {
     let deadline = Instant::now() + Duration::from_secs(2);
@@ -275,4 +304,73 @@ async fn manager_hat_claim_and_release_project_from_store() {
         board.snapshot().manager_hats.is_empty(),
         "released manager hat must leave projection"
     );
+}
+
+#[tokio::test]
+async fn local_git_observation_publishes_repo_tracking_events() {
+    let home = TempDir::new().unwrap();
+    let git_repo = init_git_repo();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("local-git-api").await.unwrap();
+    let repo = RepoId::new("CambrianTech/airc").unwrap();
+
+    let observed = airc
+        .observe_local_git_workspace(ObserveLocalGitWorkspace {
+            repo: repo.clone(),
+            workspace_id: None,
+            path: git_repo.path().to_path_buf(),
+            previous: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        observed.emitted_event_ids.len(),
+        3,
+        "first observation emits commit, branch, and dirty-state records"
+    );
+    assert_eq!(observed.snapshot.branch.as_str(), "main");
+    assert_eq!(observed.snapshot.dirty_state, DirtyState::Clean);
+
+    let board = airc.work_board(128).await.unwrap();
+    let tracking = board.repo_tracking(&repo).unwrap();
+    assert_eq!(
+        tracking
+            .branches
+            .get(&observed.snapshot.branch)
+            .unwrap()
+            .head,
+        observed.snapshot.head
+    );
+    assert_eq!(tracking.observed_commits.len(), 1);
+    assert_eq!(tracking.dirty_states.len(), 1);
+
+    let unchanged = airc
+        .observe_local_git_workspace(ObserveLocalGitWorkspace {
+            repo: repo.clone(),
+            workspace_id: None,
+            path: git_repo.path().to_path_buf(),
+            previous: Some(observed.snapshot.clone()),
+        })
+        .await
+        .unwrap();
+    assert!(
+        unchanged.emitted_event_ids.is_empty(),
+        "unchanged git state must not spam the work event stream"
+    );
+
+    std::fs::write(git_repo.path().join("README.md"), "changed\n").unwrap();
+    let dirty = airc
+        .observe_local_git_workspace(ObserveLocalGitWorkspace {
+            repo: repo.clone(),
+            workspace_id: None,
+            path: git_repo.path().to_path_buf(),
+            previous: Some(observed.snapshot),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(dirty.emitted_event_ids.len(), 1);
+    assert_eq!(dirty.snapshot.dirty_state, DirtyState::Dirty);
+    assert_eq!(dirty.snapshot.dirty_paths, 1);
 }

--- a/crates/airc-work/src/lib.rs
+++ b/crates/airc-work/src/lib.rs
@@ -9,6 +9,7 @@ pub mod codec;
 pub mod drain_policy;
 pub mod event;
 pub mod ids;
+pub mod local_git;
 pub mod model;
 pub mod projection;
 pub mod replay;
@@ -33,6 +34,10 @@ pub use event::{
     WorkspaceHeartbeat, WorkspacePressureReported, WorkspaceReleased, WorkspaceRequested,
 };
 pub use ids::{ClaimId, LaneId, RepoId, WorkCardId, WorkspaceId};
+pub use local_git::{
+    local_git_events_since, CommandGitRunner, GitCommandRunner, LocalGitError, LocalGitObserver,
+    LocalGitSnapshot, LocalGitWorkspace,
+};
 pub use model::{
     BranchName, CardState, DirtyState, DrainCandidate, DrainCandidateCategory, DrainOutcome,
     GitObjectId, HygieneReport, LaneState, PrCheckState, PrMergeState, PrReviewState,

--- a/crates/airc-work/src/local_git.rs
+++ b/crates/airc-work/src/local_git.rs
@@ -1,0 +1,416 @@
+//! Local git workspace observation adapter.
+//!
+//! This module is deliberately below CLI/monitor concerns: it reads one
+//! git worktree and produces typed work-domain events. Consumers decide
+//! when to call it and how to persist the returned snapshot.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use airc_core::PeerId;
+
+use crate::{
+    BranchName, DirtyState, GitBranchMoved, GitCommitObserved, GitDirtyStateChanged, GitObjectId,
+    RepoId, WorkEvent, WorkspaceId,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalGitWorkspace {
+    pub repo: RepoId,
+    pub workspace_id: Option<WorkspaceId>,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalGitSnapshot {
+    pub branch: BranchName,
+    pub head: GitObjectId,
+    pub summary: Option<String>,
+    pub dirty_state: DirtyState,
+    pub dirty_paths: u64,
+    pub untracked_paths: u64,
+}
+
+pub trait GitCommandRunner {
+    fn run_git(&self, repo_path: &Path, args: &[&str]) -> Result<String, LocalGitError>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CommandGitRunner;
+
+impl GitCommandRunner for CommandGitRunner {
+    fn run_git(&self, repo_path: &Path, args: &[&str]) -> Result<String, LocalGitError> {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo_path)
+            .args(args)
+            .output()
+            .map_err(|source| LocalGitError::GitSpawn {
+                repo_path: repo_path.to_path_buf(),
+                source,
+            })?;
+
+        if !output.status.success() {
+            return Err(LocalGitError::GitCommand {
+                repo_path: repo_path.to_path_buf(),
+                args: args.iter().map(|arg| (*arg).to_string()).collect(),
+                status: output.status.code(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalGitObserver<R = CommandGitRunner> {
+    runner: R,
+}
+
+impl Default for LocalGitObserver<CommandGitRunner> {
+    fn default() -> Self {
+        Self::new(CommandGitRunner)
+    }
+}
+
+impl<R> LocalGitObserver<R>
+where
+    R: GitCommandRunner,
+{
+    pub fn new(runner: R) -> Self {
+        Self { runner }
+    }
+
+    pub fn observe(
+        &self,
+        workspace: &LocalGitWorkspace,
+    ) -> Result<LocalGitSnapshot, LocalGitError> {
+        let branch = parse_branch(
+            self.runner
+                .run_git(&workspace.path, &["rev-parse", "--abbrev-ref", "HEAD"])?,
+        )?;
+        let head = GitObjectId::new(
+            self.runner
+                .run_git(&workspace.path, &["rev-parse", "HEAD"])?,
+        )?;
+        let summary = optional_summary(
+            self.runner
+                .run_git(&workspace.path, &["log", "-1", "--pretty=%s"])?,
+        );
+        let (dirty_state, dirty_paths, untracked_paths) = parse_status_porcelain(
+            &self
+                .runner
+                .run_git(&workspace.path, &["status", "--porcelain=v1"])?,
+        );
+
+        Ok(LocalGitSnapshot {
+            branch,
+            head,
+            summary,
+            dirty_state,
+            dirty_paths,
+            untracked_paths,
+        })
+    }
+}
+
+pub fn local_git_events_since(
+    workspace: &LocalGitWorkspace,
+    previous: Option<&LocalGitSnapshot>,
+    current: &LocalGitSnapshot,
+    observed_by: PeerId,
+    observed_at_ms: u64,
+) -> Vec<WorkEvent> {
+    let mut events = Vec::new();
+
+    if previous.is_none_or(|snapshot| snapshot.head != current.head) {
+        events.push(WorkEvent::GitCommitObserved(GitCommitObserved {
+            repo: workspace.repo.clone(),
+            commit: current.head.clone(),
+            branch: Some(current.branch.clone()),
+            summary: current.summary.clone(),
+            observed_by,
+            observed_at_ms,
+        }));
+    }
+
+    if previous
+        .is_none_or(|snapshot| snapshot.branch != current.branch || snapshot.head != current.head)
+    {
+        events.push(WorkEvent::GitBranchMoved(GitBranchMoved {
+            repo: workspace.repo.clone(),
+            branch: current.branch.clone(),
+            old_head: previous.map(|snapshot| snapshot.head.clone()),
+            new_head: current.head.clone(),
+            moved_by: observed_by,
+            moved_at_ms: observed_at_ms,
+        }));
+    }
+
+    if previous.is_none_or(|snapshot| dirty_changed(snapshot, current)) {
+        events.push(WorkEvent::GitDirtyStateChanged(GitDirtyStateChanged {
+            repo: workspace.repo.clone(),
+            workspace_id: workspace.workspace_id,
+            path: workspace.path.display().to_string(),
+            state: current.dirty_state,
+            dirty_paths: current.dirty_paths,
+            untracked_paths: current.untracked_paths,
+            changed_by: observed_by,
+            changed_at_ms: observed_at_ms,
+        }));
+    }
+
+    events
+}
+
+fn dirty_changed(previous: &LocalGitSnapshot, current: &LocalGitSnapshot) -> bool {
+    previous.dirty_state != current.dirty_state
+        || previous.dirty_paths != current.dirty_paths
+        || previous.untracked_paths != current.untracked_paths
+}
+
+fn parse_branch(value: String) -> Result<BranchName, LocalGitError> {
+    BranchName::new(value).map_err(LocalGitError::BranchName)
+}
+
+fn optional_summary(value: String) -> Option<String> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn parse_status_porcelain(value: &str) -> (DirtyState, u64, u64) {
+    let mut dirty_paths = 0;
+    let mut untracked_paths = 0;
+
+    for line in value.lines().filter(|line| !line.trim().is_empty()) {
+        if line.starts_with("??") {
+            untracked_paths += 1;
+        } else {
+            dirty_paths += 1;
+        }
+    }
+
+    let state = if dirty_paths == 0 && untracked_paths == 0 {
+        DirtyState::Clean
+    } else {
+        DirtyState::Dirty
+    };
+
+    (state, dirty_paths, untracked_paths)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LocalGitError {
+    #[error("failed to spawn git for {repo_path}: {source}")]
+    GitSpawn {
+        repo_path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("git command failed in {repo_path}: git {args:?} exited {status:?}: {stderr}")]
+    GitCommand {
+        repo_path: PathBuf,
+        args: Vec<String>,
+        status: Option<i32>,
+        stderr: String,
+    },
+    #[error(transparent)]
+    BranchName(#[from] crate::model::BranchNameError),
+    #[error(transparent)]
+    GitObjectId(#[from] crate::model::GitObjectIdError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[derive(Default)]
+    struct FakeGitRunner {
+        outputs: BTreeMap<Vec<String>, Result<String, String>>,
+    }
+
+    impl FakeGitRunner {
+        fn with_output(mut self, args: &[&str], output: &str) -> Self {
+            self.outputs.insert(
+                args.iter().map(|arg| (*arg).to_string()).collect(),
+                Ok(output.to_string()),
+            );
+            self
+        }
+
+        fn with_error(mut self, args: &[&str], stderr: &str) -> Self {
+            self.outputs.insert(
+                args.iter().map(|arg| (*arg).to_string()).collect(),
+                Err(stderr.to_string()),
+            );
+            self
+        }
+    }
+
+    impl GitCommandRunner for FakeGitRunner {
+        fn run_git(&self, repo_path: &Path, args: &[&str]) -> Result<String, LocalGitError> {
+            let key: Vec<String> = args.iter().map(|arg| (*arg).to_string()).collect();
+            match self.outputs.get(&key) {
+                Some(Ok(output)) => Ok(output.clone()),
+                Some(Err(stderr)) => Err(LocalGitError::GitCommand {
+                    repo_path: repo_path.to_path_buf(),
+                    args: key,
+                    status: Some(128),
+                    stderr: stderr.clone(),
+                }),
+                None => Err(LocalGitError::GitCommand {
+                    repo_path: repo_path.to_path_buf(),
+                    args: key,
+                    status: Some(1),
+                    stderr: "missing fake output".to_string(),
+                }),
+            }
+        }
+    }
+
+    fn workspace() -> LocalGitWorkspace {
+        LocalGitWorkspace {
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            workspace_id: Some(WorkspaceId::from_u128(7)),
+            path: PathBuf::from("/work/airc"),
+        }
+    }
+
+    fn clean_runner() -> FakeGitRunner {
+        FakeGitRunner::default()
+            .with_output(&["rev-parse", "--abbrev-ref", "HEAD"], "rust-rewrite")
+            .with_output(
+                &["rev-parse", "HEAD"],
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )
+            .with_output(&["log", "-1", "--pretty=%s"], "latest work")
+            .with_output(&["status", "--porcelain=v1"], "")
+    }
+
+    #[test]
+    fn observe_reads_clean_git_snapshot() {
+        let observer = LocalGitObserver::new(clean_runner());
+
+        let snapshot = observer.observe(&workspace()).unwrap();
+
+        assert_eq!(snapshot.branch.as_str(), "rust-rewrite");
+        assert_eq!(
+            snapshot.head.as_str(),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        assert_eq!(snapshot.summary.as_deref(), Some("latest work"));
+        assert_eq!(snapshot.dirty_state, DirtyState::Clean);
+        assert_eq!(snapshot.dirty_paths, 0);
+        assert_eq!(snapshot.untracked_paths, 0);
+    }
+
+    #[test]
+    fn observe_counts_dirty_and_untracked_paths() {
+        let runner = clean_runner().with_output(
+            &["status", "--porcelain=v1"],
+            " M crates/airc-work/src/local_git.rs\n?? docs/new.md\nA  src/lib.rs\n",
+        );
+        let observer = LocalGitObserver::new(runner);
+
+        let snapshot = observer.observe(&workspace()).unwrap();
+
+        assert_eq!(snapshot.dirty_state, DirtyState::Dirty);
+        assert_eq!(snapshot.dirty_paths, 2);
+        assert_eq!(snapshot.untracked_paths, 1);
+    }
+
+    #[test]
+    fn initial_observation_emits_commit_branch_and_dirty_events() {
+        let snapshot = LocalGitObserver::new(clean_runner())
+            .observe(&workspace())
+            .unwrap();
+
+        let events =
+            local_git_events_since(&workspace(), None, &snapshot, PeerId::from_u128(9), 100);
+
+        assert!(matches!(events[0], WorkEvent::GitCommitObserved(_)));
+        assert!(matches!(events[1], WorkEvent::GitBranchMoved(_)));
+        assert!(matches!(events[2], WorkEvent::GitDirtyStateChanged(_)));
+        assert_eq!(events.len(), 3);
+    }
+
+    #[test]
+    fn unchanged_snapshot_emits_no_events() {
+        let snapshot = LocalGitObserver::new(clean_runner())
+            .observe(&workspace())
+            .unwrap();
+
+        let events = local_git_events_since(
+            &workspace(),
+            Some(&snapshot),
+            &snapshot,
+            PeerId::from_u128(9),
+            100,
+        );
+
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn dirty_change_emits_only_dirty_state_event() {
+        let previous = LocalGitObserver::new(clean_runner())
+            .observe(&workspace())
+            .unwrap();
+        let current = LocalGitSnapshot {
+            dirty_state: DirtyState::Dirty,
+            dirty_paths: 1,
+            untracked_paths: 0,
+            ..previous.clone()
+        };
+
+        let events = local_git_events_since(
+            &workspace(),
+            Some(&previous),
+            &current,
+            PeerId::from_u128(9),
+            100,
+        );
+
+        assert!(matches!(events[0], WorkEvent::GitDirtyStateChanged(_)));
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn head_change_emits_commit_and_branch_events() {
+        let previous = LocalGitObserver::new(clean_runner())
+            .observe(&workspace())
+            .unwrap();
+        let current = LocalGitSnapshot {
+            head: GitObjectId::new("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").unwrap(),
+            summary: Some("new head".to_string()),
+            ..previous.clone()
+        };
+
+        let events = local_git_events_since(
+            &workspace(),
+            Some(&previous),
+            &current,
+            PeerId::from_u128(9),
+            100,
+        );
+
+        assert!(matches!(events[0], WorkEvent::GitCommitObserved(_)));
+        assert!(matches!(events[1], WorkEvent::GitBranchMoved(_)));
+        assert_eq!(events.len(), 2);
+    }
+
+    #[test]
+    fn git_command_failure_is_not_converted_to_unknown_state() {
+        let runner =
+            clean_runner().with_error(&["status", "--porcelain=v1"], "not a git repository");
+        let observer = LocalGitObserver::new(runner);
+
+        let err = observer.observe(&workspace()).unwrap_err();
+
+        assert!(matches!(err, LocalGitError::GitCommand { .. }));
+    }
+}

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -176,6 +176,13 @@ Status:
   `PullRequestMergeStateChanged`. This is the contract/projection
   layer only; the GitHub adapter and local git watcher are separate
   producers that must emit these events instead of polling inline.
+- The local producer is `airc-work::local_git`, surfaced through
+  `airc-lib::Airc::observe_local_git_workspace`. It records branch,
+  head commit, commit summary, and dirty/untracked counts as typed
+  events, with duplicate suppression based on an explicit prior
+  snapshot. Monitor, hooks, Continuum, OpenClaw, and Hermes should call
+  this API or subscribe to its events; they should not each poll git and
+  invent their own state model.
 
 Acceptance gates:
 

--- a/docs/rust-substrate-grievances-and-gaps.md
+++ b/docs/rust-substrate-grievances-and-gaps.md
@@ -852,7 +852,12 @@ Replaces the single-slice "Queue/lane Rust model" line in the First Remediation 
      this slice.
    - **Sub-PR 5b — local git watcher adapter.** Observe branch head,
      commit, and dirty-state changes for AIRC-managed workspaces and
-     emit the 5a events.
+     emit the 5a events. Implemented as `airc-work::local_git` plus
+     `airc-lib::Airc::observe_local_git_workspace`: the adapter reads a
+     local git worktree, compares it to the caller's prior snapshot, and
+     publishes only typed work events for actual changes. CLI/monitor
+     surfaces remain consumers of this library API rather than owning
+     git parsing.
    - **Sub-PR 5c — GitHub PR adapter.** Reconcile PR/check/review/merge
      state into the 5a PR events. GitHub remains an adapter, not the
      runtime source of truth.


### PR DESCRIPTION
## Summary
- add `airc-work::local_git` to observe branch/head/summary/dirty state from a local git worktree
- add snapshot diffing so only changed git state emits typed `GitCommitObserved`, `GitBranchMoved`, and `GitDirtyStateChanged` events
- expose `Airc::observe_local_git_workspace` as the SDK-level publisher for consumers/monitors/hooks
- update substrate docs for Sub-PR 5b

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-work -p airc-lib --check
- cargo test --manifest-path Cargo.toml -p airc-work local_git -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-lib local_git_observation_publishes_repo_tracking_events -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-work -p airc-lib --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings