### PR TITLE
feat(lib): emit WireEstablished lifecycle event (Phase 2 cont.)

### DIFF
--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -51,7 +51,47 @@ impl Airc {
 
         let task = self.spawn_frame_ingest(stream);
         subs.insert(wire.to_path_buf(), WireSubscriber { _task: task });
+        // Drop the subscribers lock before emitting — the emit
+        // path touches the store + broadcast and we don't want
+        // to hold the wire subscriber map across an await.
+        drop(subs);
+
+        self.emit_wire_established(wire).await?;
         Ok(())
+    }
+
+    async fn emit_wire_established(&self, wire: &Path) -> Result<(), AircError> {
+        // Resolve channel_name + room_id by matching the wire path
+        // against the current subscription set. Best-effort: if no
+        // matching subscription is found (e.g. shared-wire test
+        // setups, lan subscriber spinning up before any join), emit
+        // with the wire path alone and let consumers correlate.
+        let (channel_name, room_id) = match self.subscriptions().await {
+            Ok(subs) => {
+                let canon = wire.canonicalize().ok();
+                let matched = subs.into_iter().find(|s| {
+                    if let Some(canon) = canon.as_ref() {
+                        s.wire.canonicalize().ok().as_ref() == Some(canon)
+                    } else {
+                        s.wire == wire
+                    }
+                });
+                match matched {
+                    Some(sub) => (sub.name.as_str().to_string(), sub.room_id),
+                    None => return Ok(()),
+                }
+            }
+            Err(_) => return Ok(()),
+        };
+        let body = airc_core::Body::Json(
+            serde_json::to_value(crate::lifecycle::WireEstablishedBody {
+                wire: wire.display().to_string(),
+                channel_name,
+            })
+            .map_err(|e| AircError::Crypto(format!("lifecycle body serialize: {e}")))?,
+        );
+        self.emit_lifecycle(airc_core::TranscriptKind::WireEstablished, room_id, body)
+            .await
     }
 
     pub(crate) async fn ensure_lan_subscriber(&self) -> Result<(), AircError> {

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -62,27 +62,22 @@ impl Airc {
 
     async fn emit_wire_established(&self, wire: &Path) -> Result<(), AircError> {
         // Resolve channel_name + room_id by matching the wire path
-        // against the current subscription set. Best-effort: if no
-        // matching subscription is found (e.g. shared-wire test
-        // setups, lan subscriber spinning up before any join), emit
-        // with the wire path alone and let consumers correlate.
-        let (channel_name, room_id) = match self.subscriptions().await {
-            Ok(subs) => {
-                let canon = wire.canonicalize().ok();
-                let matched = subs.into_iter().find(|s| {
-                    if let Some(canon) = canon.as_ref() {
-                        s.wire.canonicalize().ok().as_ref() == Some(canon)
-                    } else {
-                        s.wire == wire
-                    }
-                });
-                match matched {
-                    Some(sub) => (sub.name.as_str().to_string(), sub.room_id),
-                    None => return Ok(()),
-                }
+        // against the current subscription set. Missing match is a
+        // legitimate no-op for shared-wire test setups; failure to
+        // read the subscription set propagates.
+        let subs = self.subscriptions().await?;
+        let canon = wire.canonicalize().ok();
+        let matched = subs.into_iter().find(|s| {
+            if let Some(canon) = canon.as_ref() {
+                s.wire.canonicalize().ok().as_ref() == Some(canon)
+            } else {
+                s.wire == wire
             }
-            Err(_) => return Ok(()),
+        });
+        let Some(sub) = matched else {
+            return Ok(());
         };
+        let (channel_name, room_id) = (sub.name.as_str().to_string(), sub.room_id);
         let body = airc_core::Body::Json(
             serde_json::to_value(crate::lifecycle::WireEstablishedBody {
                 wire: wire.display().to_string(),

--- a/crates/airc-lib/tests/lifecycle_events.rs
+++ b/crates/airc-lib/tests/lifecycle_events.rs
@@ -159,6 +159,64 @@ async fn add_peer_is_idempotent_no_duplicate_lifecycle_event() {
 }
 
 #[tokio::test]
+async fn join_emits_wire_established_after_subscriber_attaches() {
+    use airc_lib::lifecycle::WireEstablishedBody;
+
+    let dir = TempDir::new().expect("tempdir");
+    let home = dir.path().join(".airc");
+    std::fs::create_dir_all(&home).unwrap();
+    let airc = Airc::open(&home).await.expect("open");
+
+    // join() drives ensure_wire_subscriber which emits the event.
+    let _room = airc.join("wire-established-test").await.expect("join");
+
+    // Page recent events; both RoomJoined and WireEstablished
+    // should land. The order between them is implementation
+    // detail (current order: RoomJoined fires inside join() after
+    // ensure_wire_subscriber returns, so WireEstablished is first
+    // in the lamport sequence — but the test asserts presence,
+    // not order).
+    let page = airc.page_recent(64).await.expect("page");
+    let wire_event = page
+        .iter()
+        .find(|e| e.kind == TranscriptKind::WireEstablished)
+        .expect("WireEstablished should be emitted when the wire subscriber attaches");
+    let body = wire_event.body.as_ref().expect("event has body");
+    let body_json = match body {
+        Body::Json(value) => value.clone(),
+        _ => panic!("WireEstablished body should be JSON"),
+    };
+    let parsed: WireEstablishedBody =
+        serde_json::from_value(body_json).expect("body parses as WireEstablishedBody");
+    assert_eq!(parsed.channel_name, "wire-established-test");
+    assert!(!parsed.wire.is_empty(), "wire path should be set");
+}
+
+#[tokio::test]
+async fn wire_established_fires_once_per_wire_idempotent() {
+    let dir = TempDir::new().expect("tempdir");
+    let home = dir.path().join(".airc");
+    std::fs::create_dir_all(&home).unwrap();
+    let airc = Airc::open(&home).await.expect("open");
+
+    let _room = airc.join("idempotent-wire").await.expect("first join");
+    // Second join() to the same channel — should hit the
+    // contains_key short-circuit in ensure_wire_subscriber. No
+    // duplicate WireEstablished.
+    let _room2 = airc.join("idempotent-wire").await.expect("second join");
+
+    let page = airc.page_recent(64).await.expect("page");
+    let count = page
+        .iter()
+        .filter(|e| e.kind == TranscriptKind::WireEstablished)
+        .count();
+    assert_eq!(
+        count, 1,
+        "ensure_wire_subscriber must short-circuit on the second call; only one WireEstablished expected"
+    );
+}
+
+#[tokio::test]
 async fn lifecycle_event_is_persisted_for_cursor_replay() {
     // Lifecycle events must be durable so a consumer that reconnects
     // can replay the transitions it missed. Confirm by paging


### PR DESCRIPTION
## Roadmap Reference
- Implements `docs/architecture/GRID-SUBSTRATE-AUDIT.md` Phase 2 / lifecycle emit-point wiring.
- Tracks `docs/rust-substrate-grievances-and-gaps.md` lifecycle/event-subscription gaps: typed substrate lifecycle events must be durable, replayable, and emitted by the runtime instead of inferred by shell/monitor code.

## Summary

Phase 2 emit-point wiring continues — WireEstablished now fires when a wire subscriber first attaches (the local-fs adapter starts tailing frames.jsonl for a channel). Idempotent per wire via the existing `ensure_wire_subscriber` short-circuit.

## Body resolution

Looks up `channel_name` + `room_id` by matching the wire path against the current subscription set (`Airc::subscriptions()` introduced in #911). Path canonicalised on both sides to tolerate symlinks + .. components. If no matching subscription is found (LAN subscriber spinning up without a join, shared-wire test setups), the emit is skipped. Subscription load errors propagate.

## Lock hygiene

The `subscribers` map lock is explicitly dropped before the `emit_lifecycle` call. Holding it across an await that hits the store + broadcast would serialise all future `ensure_wire_subscriber` calls behind the emit — wrong for the multi-room attach case.

## Failure semantics

`?` propagation, matching the fail-loud posture Codex landed for RoomJoined / PeerArrived in 1cafeab + 2f01433. Lifecycle emission is part of the substrate contract; silently logging hides regressions.

## Tests

- `join_emits_wire_established_after_subscriber_attaches` — asserts the event surfaces after a join() with the expected channel_name + non-empty wire path.
- `wire_established_fires_once_per_wire_idempotent` — second join() for the same channel must not emit a duplicate.

## Verification

- `cargo fmt --manifest-path Cargo.toml -p airc-lib --check`
- `cargo test --manifest-path Cargo.toml -p airc-lib --test lifecycle_events -- --nocapture`
- `cargo clippy --manifest-path Cargo.toml -p airc-lib --all-targets -- -D warnings`
- CI pending after Codex fail-loud patch

## Remaining Phase 2 emit points (next slices)

- WireLost — needs task-lifecycle reshape so the spawned ingest task can signal back when its stream ends
- PeerArrived from account_registry import (multi-store flow design)
- PeerDeparted (no removal API yet)
- RoomParted (needs `Airc::part` API first)
- SubscriptionAdvanced on cursor save

Doesn't touch Codex's airc-work lane (#918 local git watcher, merged as Sub-PR 5b).