### PR TITLE
docs: require roadmap reference in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Roadmap Reference
+
+- Phase / slice:
+- Primary doc: `docs/architecture/GRID-SUBSTRATE-AUDIT.md`
+- Gap / grievance doc section, if applicable: `docs/rust-substrate-grievances-and-gaps.md`
+- Acceptance gate advanced:
+
+## Summary
+
+-
+
+## Verification
+
+-
+
+## Coordination
+
+- Target branch:
+- Related PRs / lanes:
+- AIRC update sent:


### PR DESCRIPTION
## Roadmap Reference
- Process guard for `docs/architecture/GRID-SUBSTRATE-AUDIT.md` and `docs/rust-substrate-grievances-and-gaps.md`.
- Ensures every future PR starts by naming the phase/slice and acceptance gate it advances.

## Summary
- add `.github/pull_request_template.md`
- put `Roadmap Reference` first so implementation PRs do not float away from the phase docs
- include coordination fields for target branch, related lanes, and AIRC update

## Verification
- template-only docs change

## Coordination
- Target branch: rust-rewrite
- Related PRs / lanes: follows #918 and #919 process feedback
- AIRC update sent: yes