### PR TITLE
ci: enforce PR roadmap references

### DIFF
--- a/.github/workflows/pr-roadmap-reference.yml
+++ b/.github/workflows/pr-roadmap-reference.yml
@@ -1,0 +1,58 @@
+name: pr-roadmap-reference
+
+# Every implementation PR must name the design phase it advances.
+# The PR template creates the shape; this workflow makes the shape
+# enforceable so roadmap linkage is not a memory exercise.
+
+on:
+  pull_request:
+    branches: [rust-rewrite, canary, main]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+jobs:
+  require-roadmap-reference:
+    name: require roadmap reference
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR body roadmap reference
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          require_present() {
+            local label="$1"
+            local pattern="$2"
+            if ! printf '%s\n' "$PR_BODY" | grep -qE "$pattern"; then
+              echo "::error::PR body must include: $label"
+              exit 1
+            fi
+          }
+
+          require_nonempty_field() {
+            local field="$1"
+            local line
+            line="$(printf '%s\n' "$PR_BODY" | grep -E "^- ${field}:" | head -1 || true)"
+            if [ -z "$line" ]; then
+              echo "::error::PR body is missing '- ${field}: ...'"
+              exit 1
+            fi
+            local value="${line#*:}"
+            value="$(printf '%s' "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+            if [ -z "$value" ]; then
+              echo "::error::PR body field '- ${field}:' must not be empty"
+              exit 1
+            fi
+          }
+
+          require_present "## Roadmap Reference heading" '^## Roadmap Reference[[:space:]]*$'
+          require_nonempty_field "Phase / slice"
+          require_present \
+            "Primary doc: docs/architecture/GRID-SUBSTRATE-AUDIT.md" \
+            '^- Primary doc:.*docs/architecture/GRID-SUBSTRATE-AUDIT\.md'
+          require_nonempty_field "Acceptance gate advanced"
+          require_present "## Summary heading" '^## Summary[[:space:]]*$'
+          require_present "## Verification heading" '^## Verification[[:space:]]*$'
+          require_present "## Coordination heading" '^## Coordination[[:space:]]*$'
+
+          echo "PR roadmap reference is present."


### PR DESCRIPTION
## Roadmap Reference

- Phase / slice: Process guard / PR roadmap references
- Primary doc: `docs/architecture/GRID-SUBSTRATE-AUDIT.md`
- Gap / grievance doc section, if applicable: `docs/rust-substrate-grievances-and-gaps.md` process discipline for keeping implementation PRs tied to the phase/gap plan
- Acceptance gate advanced: PRs must name the design phase, acceptance gate, and coordination context they advance

## Summary

- add `pr-roadmap-reference` workflow for PRs targeting rust-rewrite/canary/main
- require a non-empty `Phase / slice` and `Acceptance gate advanced`
- require explicit reference to `docs/architecture/GRID-SUBSTRATE-AUDIT.md`
- require Summary, Verification, and Coordination sections

## Verification

- ruby YAML parse of `.github/workflows/pr-roadmap-reference.yml`
- extracted workflow bash script passes a valid PR body
- extracted workflow bash script rejects a body without `Roadmap Reference`

## Coordination

- Target branch: rust-rewrite
- Related PRs / lanes: follows #920 PR template and user's requirement that PRs reference phase docs
- AIRC update sent: yes