### PR TITLE
feat(lib): emit SubscriptionAdvanced on cursor saves

### DIFF
--- a/crates/airc-cli/src/integrations/codex/hook.rs
+++ b/crates/airc-cli/src/integrations/codex/hook.rs
@@ -38,8 +38,9 @@ pub async fn run_user_prompt_submit(
         None => airc.page_recent_subscribed_filtered(filter, count).await?,
     };
 
-    if let Some(newest) = events.last().map(TranscriptEvent::cursor) {
-        airc.save_runtime_cursor(&consumer_id, &newest).await?;
+    if let Some(newest) = events.last() {
+        airc.save_runtime_cursor_for_event(&consumer_id, newest)
+            .await?;
     }
 
     let visible: Vec<_> = events

--- a/crates/airc-cli/src/join_feed.rs
+++ b/crates/airc-cli/src/join_feed.rs
@@ -36,8 +36,9 @@ async fn print_catch_up(
             for event in &events {
                 print_event(event);
             }
-            if let Some(newest) = events.last().map(TranscriptEvent::cursor) {
-                airc.save_runtime_cursor(consumer_id, &newest).await?;
+            if let Some(newest) = events.last() {
+                airc.save_runtime_cursor_for_event(consumer_id, newest)
+                    .await?;
             }
             if events.len() == CATCH_UP_LIMIT {
                 eprintln!(
@@ -47,8 +48,9 @@ async fn print_catch_up(
         }
         None => {
             let events = airc.page_recent_subscribed_filtered(filter, 1).await?;
-            if let Some(newest) = events.last().map(TranscriptEvent::cursor) {
-                airc.save_runtime_cursor(consumer_id, &newest).await?;
+            if let Some(newest) = events.last() {
+                airc.save_runtime_cursor_for_event(consumer_id, newest)
+                    .await?;
             }
         }
     }
@@ -77,7 +79,7 @@ where
                 match next {
                     Some(Ok(event)) => {
                         print_event(&event);
-                        airc.save_runtime_cursor(consumer_id, &event.cursor()).await?;
+                        airc.save_runtime_cursor_for_event(consumer_id, &event).await?;
                     }
                     Some(Err(lag)) => {
                         eprintln!("{lag}");

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -549,10 +549,37 @@ impl Airc {
         consumer_id: &str,
         cursor: &airc_core::TranscriptCursor,
     ) -> Result<(), AircError> {
+        let room = self.current_room().await?;
         self.inner
             .store
             .save_runtime_cursor(consumer_id, cursor, time::now_ms()?)
             .await?;
+        self.emit_subscription_advanced(consumer_id, cursor, room.channel)
+            .await?;
+        Ok(())
+    }
+
+    /// Persist a runtime consumer checkpoint for a concrete event.
+    ///
+    /// This is the preferred path for hooks and live feeds because it
+    /// carries the source event's room and kind. Cursor advancement for
+    /// a `SubscriptionAdvanced` lifecycle event is stored but does not
+    /// emit another `SubscriptionAdvanced`, preventing self-amplifying
+    /// cursor loops.
+    pub async fn save_runtime_cursor_for_event(
+        &self,
+        consumer_id: &str,
+        event: &airc_core::TranscriptEvent,
+    ) -> Result<(), AircError> {
+        let cursor = event.cursor();
+        self.inner
+            .store
+            .save_runtime_cursor(consumer_id, &cursor, time::now_ms()?)
+            .await?;
+        if event.kind != airc_core::TranscriptKind::SubscriptionAdvanced {
+            self.emit_subscription_advanced(consumer_id, &cursor, event.room_id)
+                .await?;
+        }
         Ok(())
     }
 

--- a/crates/airc-lib/src/lifecycle.rs
+++ b/crates/airc-lib/src/lifecycle.rs
@@ -91,11 +91,17 @@ impl Airc {
     /// - `RoomJoined` — fired from [`Airc::join`] /
     ///   [`Airc::ensure_join_context`] after the subscription row
     ///   is persisted.
+    /// - `PeerArrived` — fired from `Airc::add_peer` when a new peer
+    ///   enters the local trust store.
+    /// - `WireEstablished` — fired when a new local wire subscriber
+    ///   attaches.
+    /// - `SubscriptionAdvanced` — fired when a runtime consumer cursor
+    ///   advances, except for cursor advances caused by
+    ///   `SubscriptionAdvanced` itself.
     ///
-    /// Other variants (PeerArrived/Departed, WireEstablished/Lost,
-    /// SubscriptionAdvanced) have stable body schemas defined in
-    /// this module; their emit points are queued for follow-up
-    /// PRs (one substrate slice at a time per audit doctrine).
+    /// Other variants (PeerDeparted, WireLost, RoomParted) have stable
+    /// body schemas defined in this module; their emit points are
+    /// queued for follow-up PRs.
     pub(crate) async fn emit_lifecycle(
         &self,
         kind: TranscriptKind,
@@ -134,6 +140,24 @@ impl Airc {
             }
             Err(error) => Err(error.into()),
         }
+    }
+
+    pub(crate) async fn emit_subscription_advanced(
+        &self,
+        consumer_id: &str,
+        cursor: &airc_core::TranscriptCursor,
+        room_id: RoomId,
+    ) -> Result<(), AircError> {
+        let body = Body::Json(
+            serde_json::to_value(SubscriptionAdvancedBody {
+                consumer_id: consumer_id.to_string(),
+                lamport: cursor.lamport,
+                event_id: cursor.event_id,
+            })
+            .map_err(|e| AircError::Crypto(format!("lifecycle body serialize: {e}")))?,
+        );
+        self.emit_lifecycle(TranscriptKind::SubscriptionAdvanced, room_id, body)
+            .await
     }
 }
 
@@ -181,6 +205,18 @@ mod tests {
         };
         let json = serde_json::to_string(&body).unwrap();
         let parsed: RoomJoinedBody = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, body);
+    }
+
+    #[test]
+    fn subscription_advanced_body_round_trips_through_json() {
+        let body = SubscriptionAdvancedBody {
+            consumer_id: "codex-hook:thread-1".to_string(),
+            lamport: 42,
+            event_id: EventId::from_u128(7),
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        let parsed: SubscriptionAdvancedBody = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, body);
     }
 }

--- a/crates/airc-lib/tests/lifecycle_events.rs
+++ b/crates/airc-lib/tests/lifecycle_events.rs
@@ -217,6 +217,97 @@ async fn wire_established_fires_once_per_wire_idempotent() {
 }
 
 #[tokio::test]
+async fn save_runtime_cursor_emits_subscription_advanced() {
+    use airc_lib::lifecycle::SubscriptionAdvancedBody;
+
+    let dir = TempDir::new().expect("tempdir");
+    let home = dir.path().join(".airc");
+    std::fs::create_dir_all(&home).unwrap();
+    let airc = Airc::open(&home).await.expect("open");
+    let _room = airc.join("subscription-advanced-test").await.expect("join");
+
+    airc.say("cursor source").await.expect("say");
+    let source = airc
+        .page_recent(32)
+        .await
+        .expect("page")
+        .into_iter()
+        .find(|event| event.kind == TranscriptKind::Message)
+        .expect("message event exists");
+    let source_cursor = source.cursor();
+
+    airc.save_runtime_cursor_for_event("test-consumer", &source)
+        .await
+        .expect("save cursor");
+
+    assert_eq!(
+        airc.load_runtime_cursor("test-consumer").await.unwrap(),
+        Some(source_cursor.clone())
+    );
+
+    let page = airc.page_recent(64).await.expect("page");
+    let event = page
+        .iter()
+        .find(|event| event.kind == TranscriptKind::SubscriptionAdvanced)
+        .expect("SubscriptionAdvanced lifecycle event exists");
+    let body = event.body.as_ref().expect("event has body");
+    let body_json = match body {
+        Body::Json(value) => value.clone(),
+        _ => panic!("SubscriptionAdvanced body should be JSON"),
+    };
+    let parsed: SubscriptionAdvancedBody =
+        serde_json::from_value(body_json).expect("body parses as SubscriptionAdvancedBody");
+    assert_eq!(parsed.consumer_id, "test-consumer");
+    assert_eq!(parsed.lamport, source_cursor.lamport);
+    assert_eq!(parsed.event_id, source_cursor.event_id);
+}
+
+#[tokio::test]
+async fn saving_subscription_advanced_cursor_does_not_emit_recursive_event() {
+    let dir = TempDir::new().expect("tempdir");
+    let home = dir.path().join(".airc");
+    std::fs::create_dir_all(&home).unwrap();
+    let airc = Airc::open(&home).await.expect("open");
+    let _room = airc
+        .join("subscription-advanced-loop-test")
+        .await
+        .expect("join");
+
+    airc.say("cursor source").await.expect("say");
+    let source = airc
+        .page_recent(32)
+        .await
+        .expect("page")
+        .into_iter()
+        .find(|event| event.kind == TranscriptKind::Message)
+        .expect("message event exists");
+    airc.save_runtime_cursor_for_event("test-consumer", &source)
+        .await
+        .expect("save source cursor");
+
+    let lifecycle_event = airc
+        .page_recent(64)
+        .await
+        .expect("page")
+        .into_iter()
+        .find(|event| event.kind == TranscriptKind::SubscriptionAdvanced)
+        .expect("SubscriptionAdvanced lifecycle event exists");
+    airc.save_runtime_cursor_for_event("test-consumer", &lifecycle_event)
+        .await
+        .expect("save lifecycle cursor");
+
+    let page = airc.page_recent(128).await.expect("page");
+    let count = page
+        .iter()
+        .filter(|event| event.kind == TranscriptKind::SubscriptionAdvanced)
+        .count();
+    assert_eq!(
+        count, 1,
+        "saving a SubscriptionAdvanced cursor must not emit another SubscriptionAdvanced event"
+    );
+}
+
+#[tokio::test]
 async fn lifecycle_event_is_persisted_for_cursor_replay() {
     // Lifecycle events must be durable so a consumer that reconnects
     // can replay the transitions it missed. Confirm by paging

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -170,6 +170,13 @@ Status:
 
 - `airc-lib` subscription query API landed in #911.
 - Typed lifecycle events landed in #914.
+- Lifecycle emit points are being wired as Phase 2 sub-slices:
+  `RoomJoined`, `PeerArrived`, `WireEstablished`, and
+  `SubscriptionAdvanced` now emit durable lifecycle events from
+  substrate code. Cursor advancement uses
+  `Airc::save_runtime_cursor_for_event` where the source event is known
+  so advancing past a `SubscriptionAdvanced` lifecycle event stores the
+  cursor without recursively emitting another cursor event.
 - Typed git/PR event contracts are being added in `airc-work`:
   `GitCommitObserved`, `GitBranchMoved`, `GitDirtyStateChanged`,
   `PullRequestCheckSuiteChanged`, `PullRequestReviewSubmitted`, and

--- a/docs/rust-substrate-grievances-and-gaps.md
+++ b/docs/rust-substrate-grievances-and-gaps.md
@@ -862,6 +862,12 @@ Replaces the single-slice "Queue/lane Rust model" line in the First Remediation 
      state into the 5a PR events. GitHub remains an adapter, not the
      runtime source of truth.
 6. **PR 6 — monitor/hook subscriptions.** Codex hook becomes `airc codex-hook` consuming an `airc-work`-aware subscription; monitor reads typed subscriptions; no Python hook path remains.
+   - **Phase 2 lifecycle cursor slice.** Runtime consumers persist
+     cursors through `airc-store` and emit `SubscriptionAdvanced` as a
+     durable lifecycle event when they advance. Feeds/hooks that know
+     the source event use `Airc::save_runtime_cursor_for_event` so a
+     cursor advance caused by `SubscriptionAdvanced` is stored without
+     recursively emitting another cursor event.
 7. **PR 7 — Continuum bridge.** Continuum event subsystem consumes AIRC subscriptions directly. Persona inboxes are AIRC channel/header subscriptions plus Continuum-specific projection/RAG assembly.
 
 ### What this replaces in the previous plan


### PR DESCRIPTION
## Roadmap Reference

- Phase / slice: Phase 2 — Substrate Events And Subscription API / SubscriptionAdvanced emit point
- Primary doc: `docs/architecture/GRID-SUBSTRATE-AUDIT.md`
- Gap / grievance doc section, if applicable: `docs/rust-substrate-grievances-and-gaps.md` PR 6 monitor/hook subscriptions and cursor-backed runtime state
- Acceptance gate advanced: Agent monitor/feed code can observe cursor advancement as durable lifecycle events instead of inferring it from sidecar files or hook-specific state

## Summary

- emit `SubscriptionAdvanced` lifecycle events when runtime cursors advance
- add `Airc::save_runtime_cursor_for_event` so hooks/feeds save cursor state with the source event's room/kind
- prevent recursive cursor-event amplification by storing but not re-emitting when the source event is itself `SubscriptionAdvanced`
- route Codex hook and join-feed cursor saves through the source-event API
- update Phase 2 docs with the wired cursor emit point

## Verification

- cargo fmt --manifest-path Cargo.toml -p airc-lib -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-lib --test lifecycle_events -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli codex_hook -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml --workspace
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings

## Coordination

- Target branch: rust-rewrite
- Related PRs / lanes: follows #914 lifecycle schema, #916 PeerArrived, #919 WireEstablished, #921 roadmap guard
- AIRC update sent: yes