### PR TITLE
feat(airc-lib): WireLost emit on stream-end + teardown

### DIFF
--- a/crates/airc-lib/src/lifecycle.rs
+++ b/crates/airc-lib/src/lifecycle.rs
@@ -97,14 +97,17 @@ impl Airc {
     ///   leaves local trust.
     /// - `WireEstablished` — fired when a new local wire subscriber
     ///   attaches.
+    /// - `WireLost` — fired when the wire subscriber task exits,
+    ///   either because the stream ended (`reason="stream_ended"`)
+    ///   or because `Airc::teardown_wire` signalled it
+    ///   (`reason="teardown"`).
     /// - `SubscriptionAdvanced` — fired when a runtime consumer cursor
     ///   advances, except for cursor advances caused by
     ///   `SubscriptionAdvanced` itself.
     /// - `RoomParted` — fired from [`Airc::part_channel`] after the
     ///   subscription row is tombstoned and presence is refreshed.
     ///
-    /// `WireLost` has a stable body schema defined in this module; its
-    /// emit point is queued for a follow-up PR.
+    /// All seven Phase 2 lifecycle variants are now wired.
     pub(crate) async fn emit_lifecycle(
         &self,
         kind: TranscriptKind,

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -1,9 +1,10 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use airc_core::{EventId, TranscriptCursor};
 use airc_protocol::{Frame, Subscription};
 use airc_transport::{LocalFsAdapter, SignedTransport, Transport};
 use futures::stream::StreamExt;
+use tokio::sync::oneshot;
 
 use crate::error::AircError;
 use crate::room::Room;
@@ -12,6 +13,10 @@ use crate::Airc;
 pub(crate) struct WireSubscriber {
     /// Kept alive by ownership of its `JoinHandle`.
     pub(crate) _task: tokio::task::JoinHandle<()>,
+    /// Drop or `take().send(())` to stop the task and trigger the
+    /// `WireLost` emit path with `reason="teardown"`. `None` after
+    /// the sender has been consumed by a teardown call.
+    pub(crate) shutdown: Option<oneshot::Sender<()>>,
 }
 
 pub(crate) struct FrameSubscriber {
@@ -49,14 +54,55 @@ impl Airc {
             .await
             .map_err(|e| AircError::Transport(e.to_string()))?;
 
-        let task = self.spawn_frame_ingest(stream);
-        subs.insert(wire.to_path_buf(), WireSubscriber { _task: task });
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let task = self.spawn_frame_ingest(stream, Some(wire.to_path_buf()), Some(shutdown_rx));
+        subs.insert(
+            wire.to_path_buf(),
+            WireSubscriber {
+                _task: task,
+                shutdown: Some(shutdown_tx),
+            },
+        );
         // Drop the subscribers lock before emitting — the emit
         // path touches the store + broadcast and we don't want
         // to hold the wire subscriber map across an await.
         drop(subs);
 
         self.emit_wire_established(wire).await?;
+        Ok(())
+    }
+
+    /// Test-only public alias for [`Airc::teardown_wire`]. Kept
+    /// behind `#[doc(hidden)]` so it isn't part of the documented
+    /// SDK surface — the eventual public verb is owned by the
+    /// `airc part` / `airc teardown` CLI lanes.
+    #[doc(hidden)]
+    pub async fn teardown_wire_for_test(&self, wire: &Path) -> Result<(), AircError> {
+        self.teardown_wire(wire).await
+    }
+
+    /// Stop tailing `wire`. Drops the local subscriber and emits a
+    /// `WireLost` lifecycle event with `reason="teardown"`. No-op if
+    /// the wire is not currently subscribed.
+    pub(crate) async fn teardown_wire(&self, wire: &Path) -> Result<(), AircError> {
+        let mut subs = self.inner.subscribers.lock().await;
+        let Some(mut subscriber) = subs.remove(wire) else {
+            return Ok(());
+        };
+        let shutdown = subscriber.shutdown.take();
+        // Drop the map lock before awaiting the task — the task may
+        // be mid-emit and needs the broadcast channel.
+        drop(subs);
+        if let Some(tx) = shutdown {
+            // `Err` only fires if the receiver is already gone (task
+            // exited on its own). In that path the task already
+            // emitted WireLost with `reason="stream_ended"`; nothing
+            // more to do here.
+            let _ = tx.send(());
+        }
+        // Wait briefly for the task to finalize its emit. Bounded so
+        // a wedged subscriber can't hang teardown forever.
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), subscriber._task).await;
         Ok(())
     }
 
@@ -110,29 +156,102 @@ impl Airc {
             .subscribe(subscription)
             .await
             .map_err(|e| AircError::Transport(e.to_string()))?;
-        let task = self.spawn_frame_ingest(stream);
+        let task = self.spawn_frame_ingest(stream, None, None);
         *subscriber = Some(FrameSubscriber { _task: task });
         Ok(())
     }
 
+    /// Spawn the ingest task for a subscription stream.
+    ///
+    /// - `wire_for_lifecycle = Some(path)` opts the task into
+    ///   `WireLost` emission when the stream ends or the shutdown
+    ///   signal fires. Pass `None` for streams that don't represent
+    ///   a single wire (LAN sweep), since those have no canonical
+    ///   wire path to attach the lifecycle event to.
+    /// - `shutdown` is consumed; when the corresponding `Sender` is
+    ///   dropped or signalled, the task exits with
+    ///   `reason="teardown"`. Pass `None` for streams without an
+    ///   explicit teardown handle.
     fn spawn_frame_ingest<E>(
         &self,
         mut stream: airc_transport::FrameStream<E>,
+        wire_for_lifecycle: Option<PathBuf>,
+        shutdown: Option<oneshot::Receiver<()>>,
     ) -> tokio::task::JoinHandle<()>
     where
         E: std::fmt::Display + Send + 'static,
     {
         let airc = self.clone();
         tokio::spawn(async move {
-            while let Some(item) = stream.next().await {
-                match item {
-                    Ok(frame) => airc.append_received_frame(frame).await,
-                    Err(verify_err) => {
-                        eprintln!("airc-lib subscriber: frame verification failed: {verify_err}");
+            let reason: &'static str = match shutdown {
+                Some(mut shutdown_rx) => loop {
+                    tokio::select! {
+                        biased;
+                        _ = &mut shutdown_rx => break "teardown",
+                        item = stream.next() => match item {
+                            Some(Ok(frame)) => airc.append_received_frame(frame).await,
+                            Some(Err(verify_err)) => {
+                                eprintln!(
+                                    "airc-lib subscriber: frame verification failed: {verify_err}"
+                                );
+                            }
+                            None => break "stream_ended",
+                        }
                     }
+                },
+                None => loop {
+                    match stream.next().await {
+                        Some(Ok(frame)) => airc.append_received_frame(frame).await,
+                        Some(Err(verify_err)) => {
+                            eprintln!(
+                                "airc-lib subscriber: frame verification failed: {verify_err}"
+                            );
+                        }
+                        None => break "stream_ended",
+                    }
+                },
+            };
+            if let Some(wire) = wire_for_lifecycle {
+                if let Err(err) = airc.emit_wire_lost(&wire, reason).await {
+                    eprintln!(
+                        "airc-lib subscriber: wire_lost emit failed for {} ({reason}): {err}",
+                        wire.display()
+                    );
                 }
             }
         })
+    }
+
+    async fn emit_wire_lost(&self, wire: &Path, reason: &str) -> Result<(), AircError> {
+        // Resolve channel/room_id the same way `emit_wire_established`
+        // does — by matching the wire against the current
+        // subscription set. If the subscription row has already
+        // been removed (e.g. by a future `part` flow that races
+        // teardown), the emit silently no-ops; consumers see only
+        // `WireEstablished` without a matching `WireLost`, which is
+        // correct because no room exists for the event to belong to.
+        let subs = self.subscriptions().await?;
+        let canon = wire.canonicalize().ok();
+        let matched = subs.into_iter().find(|s| {
+            if let Some(canon) = canon.as_ref() {
+                s.wire.canonicalize().ok().as_ref() == Some(canon)
+            } else {
+                s.wire == wire
+            }
+        });
+        let Some(sub) = matched else {
+            return Ok(());
+        };
+        let room_id = sub.room_id;
+        let body = airc_core::Body::Json(
+            serde_json::to_value(crate::lifecycle::WireLostBody {
+                wire: wire.display().to_string(),
+                reason: reason.to_string(),
+            })
+            .map_err(|e| AircError::Crypto(format!("lifecycle body serialize: {e}")))?,
+        );
+        self.emit_lifecycle(airc_core::TranscriptKind::WireLost, room_id, body)
+            .await
     }
 
     pub(crate) async fn append_received_frame(&self, frame: Frame) {

--- a/crates/airc-lib/tests/lifecycle_events.rs
+++ b/crates/airc-lib/tests/lifecycle_events.rs
@@ -426,6 +426,87 @@ async fn saving_subscription_advanced_cursor_does_not_emit_recursive_event() {
 }
 
 #[tokio::test]
+async fn teardown_wire_emits_wire_lost_with_teardown_reason() {
+    use airc_lib::lifecycle::WireLostBody;
+
+    let dir = TempDir::new().expect("tempdir");
+    let home = dir.path().join(".airc");
+    std::fs::create_dir_all(&home).unwrap();
+    let airc = Airc::open(&home).await.expect("open");
+
+    // Join puts a wire subscriber in the map.
+    let room = airc.join("wire-lost-test").await.expect("join");
+
+    // Resolve the wire path the same way the subscriber map keys
+    // are formed — via the room subscription.
+    let subs = airc.subscriptions().await.expect("subscriptions");
+    let sub = subs
+        .iter()
+        .find(|s| s.room_id == room.channel)
+        .expect("subscription row for joined channel");
+    let wire_path = sub.wire.clone();
+
+    airc.teardown_wire_for_test(&wire_path)
+        .await
+        .expect("teardown_wire");
+
+    // Allow the task a moment to flush its emit even though
+    // teardown_wire awaits the JoinHandle.
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    let mut wire_lost_event = None;
+    while std::time::Instant::now() < deadline {
+        let page = airc.page_recent(64).await.expect("page");
+        if let Some(event) = page
+            .into_iter()
+            .find(|e| e.kind == TranscriptKind::WireLost)
+        {
+            wire_lost_event = Some(event);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let event = wire_lost_event.expect("WireLost should be emitted by teardown_wire");
+    let body = event.body.as_ref().expect("event has body");
+    let body_json = match body {
+        Body::Json(value) => value.clone(),
+        _ => panic!("WireLost body should be JSON"),
+    };
+    let parsed: WireLostBody =
+        serde_json::from_value(body_json).expect("body parses as WireLostBody");
+    assert_eq!(
+        parsed.reason, "teardown",
+        "explicit teardown path tags reason=teardown"
+    );
+    assert!(!parsed.wire.is_empty(), "wire path should be set");
+}
+
+#[tokio::test]
+async fn teardown_wire_is_idempotent_no_subscriber_noop() {
+    let dir = TempDir::new().expect("tempdir");
+    let home = dir.path().join(".airc");
+    std::fs::create_dir_all(&home).unwrap();
+    let airc = Airc::open(&home).await.expect("open");
+
+    // Tearing down a wire that was never subscribed must not panic
+    // and must not emit a WireLost event (no room to attach it to).
+    let bogus = home.join("does-not-exist");
+    airc.teardown_wire_for_test(&bogus)
+        .await
+        .expect("teardown_wire on unknown wire is a no-op");
+
+    let page = airc.page_recent(64).await.expect("page");
+    let count = page
+        .iter()
+        .filter(|e| e.kind == TranscriptKind::WireLost)
+        .count();
+    assert_eq!(
+        count, 0,
+        "tearing down an unknown wire must not emit WireLost"
+    );
+}
+
+#[tokio::test]
 async fn lifecycle_event_is_persisted_for_cursor_replay() {
     // Lifecycle events must be durable so a consumer that reconnects
     // can replay the transitions it missed. Confirm by paging


### PR DESCRIPTION
## Roadmap Reference

- Phase / slice: Phase 2 — Substrate Events And Subscription API / WireLost emit point
- Primary doc: `docs/architecture/GRID-SUBSTRATE-AUDIT.md`
- Gap / grievance doc section, if applicable: `docs/rust-substrate-grievances-and-gaps.md` PR 6 monitor/hook subscriptions, Phase 2 lifecycle emit points
- Acceptance gate advanced: wire stream termination and teardown become durable lifecycle events that consumers can observe through subscriptions instead of inferring from missing process state.

## Summary

- Phase 2 lifecycle: 5/7 emit points now wired — adds `WireLost`.
- `spawn_frame_ingest` takes an optional wire-path + shutdown receiver; on stream end or shutdown, the task emits `WireLost { wire, reason }` with `reason` in `{stream_ended, teardown}`.
- Adds `Airc::teardown_wire(path)` as the per-wire teardown verb for the lifecycle proof.
- LAN subscribers opt out of `WireLost` because there is no canonical local wire path to attach to.

## Verification

- `cargo test -p airc-lib --test lifecycle_events`
- `cargo test -p airc-lib`
- `cargo clippy -p airc-lib --all-targets -- -D warnings`
- `cargo build --workspace`
- GitHub Actions: rust matrix green on macOS, Ubuntu, and Windows before the roadmap-body edit

## Coordination

- Target branch: `rust-rewrite`
- Related PRs / lanes: Phase 2 lifecycle emit-point lane; pairs with RoomParted and PeerDeparted slices
- AIRC update sent: pending after merge
