### PR TITLE
feat(lib): emit RoomParted lifecycle events

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -262,6 +262,13 @@ pub enum Command {
         wire: Option<PathBuf>,
     },
 
+    /// Leave a subscribed room without deleting identity or trust.
+    /// With no room, leaves the current default channel.
+    Part {
+        /// Optional channel name to leave.
+        room: Option<String>,
+    },
+
     /// Manage the persisted peer trust registry.
     Peer(PeerArgs),
 

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -79,6 +79,16 @@ pub async fn run_room(
     Ok(())
 }
 
+/// `part` — leave a subscribed room without deleting identity, trust,
+/// or other room subscriptions.
+pub async fn run_part(home: &Path, room: Option<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let parted = airc.part_channel(room.as_deref()).await?;
+    println!("parted:  #{}", parted.name);
+    println!("channel: {}", parted.channel);
+    Ok(())
+}
+
 /// `join` — account-room coordinator entrypoint. With no explicit
 /// room, subscribe to `#general` plus the inferred Git owner channel.
 /// With a room, join that arbitrary channel and make it default.

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -350,6 +350,8 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
         Command::Room { name, wire } => commands::run_room(&home, name, wire).await,
 
+        Command::Part { room } => commands::run_part(&home, room).await,
+
         Command::Peer(args) => match args.action {
             PeerAction::Add { spec, socket } => {
                 commands::run_peer_add(&home, spec, default_or(socket, &home)).await

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -234,6 +234,27 @@ fn join_sets_up_codex_hook_when_codex_home_exists() {
     );
 }
 
+#[test]
+fn part_without_args_leaves_default_channel() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join(".airc");
+    let wire = workspace.path().join("wire");
+
+    run_room(&home, "part-cli", &wire);
+
+    let mut part = command_for_home(&home);
+    part.args(["--home", home.to_str().unwrap(), "part"]);
+    let output = output_with_timeout(part, Duration::from_secs(10), "airc part");
+    assert!(
+        output.status.success(),
+        "part failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("parted:  #part-cli"), "{stdout}");
+}
+
 fn strip_cargo_harness_env(command: &mut Command) {
     command.env_remove("CARGO_PKG_NAME");
     for key in std::env::vars_os()

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -504,6 +504,41 @@ impl Airc {
         Ok(room)
     }
 
+    /// Leave a subscribed channel without deleting identity or trust.
+    ///
+    /// `None` parts the current default channel. The removed channel is
+    /// tombstoned in the subscription set so a later
+    /// [`join_default_context`](Self::join_default_context) does not
+    /// silently re-add a channel the caller explicitly left.
+    pub async fn part_channel(&self, name: Option<&str>) -> Result<Room, AircError> {
+        let identity = self.mesh_identity().await?;
+        let mut set = subscriptions::load_or_init(self.event_store()).await?;
+        let channel = match name {
+            Some(name) => ChannelName::new(name)?,
+            None => set.default.clone().ok_or(AircError::NoCurrentRoom)?,
+        };
+        let removed = set
+            .unsubscribe(&channel)
+            .ok_or_else(|| AircError::NotSubscribed(channel.display_with_hash()))?;
+        subscriptions::save(self.event_store(), &set).await?;
+        self.publish_presence(&identity, &set).await?;
+
+        let room = removed.as_room();
+        let body_json = serde_json::to_value(crate::lifecycle::RoomPartedBody {
+            channel_name: channel.as_str().to_string(),
+            room_id: room.channel,
+        })
+        .map_err(|e| AircError::Crypto(format!("lifecycle body serialize: {e}")))?;
+        self.emit_lifecycle(
+            airc_core::TranscriptKind::RoomParted,
+            room.channel,
+            airc_core::Body::Json(body_json),
+        )
+        .await?;
+
+        Ok(room)
+    }
+
     /// Read the default subscribed channel. Fresh scopes default to
     /// `#general` through the subscription set, using the resolved
     /// mesh identity so the `RoomId` is stable per Git/GitHub user.

--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -72,6 +72,11 @@ pub enum AircError {
     #[error("no current room — call `join` to set one")]
     NoCurrentRoom,
 
+    /// Caller asked to leave a channel that this scope is not
+    /// currently subscribed to.
+    #[error("not subscribed to channel: {0}")]
+    NotSubscribed(String),
+
     /// Caller passed a peer registry operation referencing a peer
     /// not in the local registry.
     #[error("unknown peer: {0}")]

--- a/crates/airc-lib/src/lifecycle.rs
+++ b/crates/airc-lib/src/lifecycle.rs
@@ -98,10 +98,12 @@ impl Airc {
     /// - `SubscriptionAdvanced` — fired when a runtime consumer cursor
     ///   advances, except for cursor advances caused by
     ///   `SubscriptionAdvanced` itself.
+    /// - `RoomParted` — fired from [`Airc::part_channel`] after the
+    ///   subscription row is tombstoned and presence is refreshed.
     ///
-    /// Other variants (PeerDeparted, WireLost, RoomParted) have stable
-    /// body schemas defined in this module; their emit points are
-    /// queued for follow-up PRs.
+    /// Other variants (PeerDeparted, WireLost) have stable body schemas
+    /// defined in this module; their emit points are queued for
+    /// follow-up PRs.
     pub(crate) async fn emit_lifecycle(
         &self,
         kind: TranscriptKind,
@@ -217,6 +219,17 @@ mod tests {
         };
         let json = serde_json::to_string(&body).unwrap();
         let parsed: SubscriptionAdvancedBody = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, body);
+    }
+
+    #[test]
+    fn room_parted_body_round_trips_through_json() {
+        let body = RoomPartedBody {
+            channel_name: "general".to_string(),
+            room_id: RoomId::from_u128(0xabc),
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        let parsed: RoomPartedBody = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, body);
     }
 }

--- a/crates/airc-lib/tests/lifecycle_events.rs
+++ b/crates/airc-lib/tests/lifecycle_events.rs
@@ -263,6 +263,58 @@ async fn save_runtime_cursor_emits_subscription_advanced() {
 }
 
 #[tokio::test]
+async fn part_channel_emits_room_parted_lifecycle_event() {
+    use airc_lib::lifecycle::RoomPartedBody;
+
+    let dir = TempDir::new().expect("tempdir");
+    let home = dir.path().join(".airc");
+    std::fs::create_dir_all(&home).unwrap();
+    let airc = Airc::open(&home).await.expect("open");
+
+    let room = airc.join("part-me").await.expect("join");
+    let mut stream = airc.subscribe().await.expect("subscribe");
+    let parted = airc
+        .part_channel(Some("part-me"))
+        .await
+        .expect("part channel");
+    assert_eq!(parted.channel, room.channel);
+    assert!(
+        !airc
+            .is_subscribed(&airc_lib::ChannelName::new("part-me").unwrap())
+            .await
+            .expect("subscription query"),
+        "parted channel must no longer be subscribed"
+    );
+
+    let mut found = None;
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), stream.next()).await {
+            Ok(Some(Ok(event))) => {
+                if event.kind == TranscriptKind::RoomParted {
+                    found = Some(event);
+                    break;
+                }
+            }
+            Ok(Some(Err(_))) => continue,
+            Ok(None) => panic!("stream closed before RoomParted arrived"),
+            Err(_) => continue,
+        }
+    }
+    let event = found.expect("RoomParted lifecycle event exists");
+    assert_eq!(event.room_id, room.channel);
+    let body = event.body.as_ref().expect("event has body");
+    let body_json = match body {
+        Body::Json(value) => value.clone(),
+        _ => panic!("RoomParted body should be JSON"),
+    };
+    let parsed: RoomPartedBody =
+        serde_json::from_value(body_json).expect("body parses as RoomPartedBody");
+    assert_eq!(parsed.channel_name, "part-me");
+    assert_eq!(parsed.room_id, room.channel);
+}
+
+#[tokio::test]
 async fn saving_subscription_advanced_cursor_does_not_emit_recursive_event() {
     let dir = TempDir::new().expect("tempdir");
     let home = dir.path().join(".airc");

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -171,12 +171,15 @@ Status:
 - `airc-lib` subscription query API landed in #911.
 - Typed lifecycle events landed in #914.
 - Lifecycle emit points are being wired as Phase 2 sub-slices:
-  `RoomJoined`, `PeerArrived`, `WireEstablished`, and
+  `RoomJoined`, `PeerArrived`, `WireEstablished`, `RoomParted`, and
   `SubscriptionAdvanced` now emit durable lifecycle events from
   substrate code. Cursor advancement uses
   `Airc::save_runtime_cursor_for_event` where the source event is known
   so advancing past a `SubscriptionAdvanced` lifecycle event stores the
   cursor without recursively emitting another cursor event.
+  `RoomParted` is emitted by the ORM-backed `Airc::part_channel`
+  subscription transition and surfaced through the thin `airc part`
+  CLI command.
 - Typed git/PR event contracts are being added in `airc-work`:
   `GitCommitObserved`, `GitBranchMoved`, `GitDirtyStateChanged`,
   `PullRequestCheckSuiteChanged`, `PullRequestReviewSubmitted`, and

--- a/docs/rust-substrate-grievances-and-gaps.md
+++ b/docs/rust-substrate-grievances-and-gaps.md
@@ -868,6 +868,11 @@ Replaces the single-slice "Queue/lane Rust model" line in the First Remediation 
      the source event use `Airc::save_runtime_cursor_for_event` so a
      cursor advance caused by `SubscriptionAdvanced` is stored without
      recursively emitting another cursor event.
+   - **Phase 2 room-part slice.** `airc-lib::Airc::part_channel`
+     removes the subscription through the ORM-backed `SubscriptionSet`,
+     preserves identity/trust/other rooms, refreshes the account
+     presence snapshot, and emits durable `RoomParted`. The public
+     `airc part [room]` command is a thin wrapper over that API.
 7. **PR 7 — Continuum bridge.** Continuum event subsystem consumes AIRC subscriptions directly. Persona inboxes are AIRC channel/header subscriptions plus Continuum-specific projection/RAG assembly.
 
 ### What this replaces in the previous plan


### PR DESCRIPTION
## Roadmap Reference

- Phase / slice: Phase 2 — Substrate Events And Subscription API / RoomParted emit point
- Primary doc: `docs/architecture/GRID-SUBSTRATE-AUDIT.md`
- Gap doc: `docs/rust-substrate-grievances-and-gaps.md` PR 6 monitor/hook subscriptions, Phase 2 room-part slice
- Acceptance gate advanced: room membership changes become durable lifecycle events that monitor, hook, Continuum, OpenClaw, and Hermes consumers can observe through subscriptions instead of parsing CLI prose or store side effects.

## Summary

- add `Airc::part_channel` to remove a subscription through the ORM-backed `SubscriptionSet`, preserve identity/trust/other rooms, refresh presence, and emit `RoomParted`
- add thin `airc part [room]` CLI wrapper over the library API
- add lifecycle + CLI tests for room part behavior
- update the audit/grievance docs to mark the RoomParted emit point wired

## Verification

- `cargo fmt --manifest-path Cargo.toml -p airc-lib -p airc-cli`
- `cargo test --manifest-path Cargo.toml -p airc-lib --test lifecycle_events part_channel_emits_room_parted_lifecycle_event -- --nocapture`
- `cargo test --manifest-path Cargo.toml -p airc-cli --test e2e part_without_args_leaves_default_channel -- --nocapture`
- `cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml --workspace`
- `cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings`

## Coordination

- Claimed the Phase 2 RoomParted lane over AIRC before editing.
- Scope intentionally touches `airc-lib` subscription lifecycle and the thin `airc part` CLI only.
