### PR TITLE
feat(lib): emit PeerDeparted lifecycle events

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -447,6 +447,14 @@ pub enum PeerAction {
         #[arg(long)]
         socket: Option<PathBuf>,
     },
+    /// Remove a peer from local trust.
+    Remove {
+        /// Peer UUID to remove from the trust store.
+        peer_id: String,
+        /// Override the default socket (`<home>/daemon.sock`).
+        #[arg(long)]
+        socket: Option<PathBuf>,
+    },
     /// List enrolled peers from the peer trust store.
     List,
 }

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -24,7 +24,7 @@ use futures::stream::StreamExt;
 
 use airc_daemon::{
     peers_store, run as run_daemon_server, AddPeerRequest, DaemonClient, DaemonState,
-    LocalIdentity, SubscribeRequest,
+    LocalIdentity, RemovePeerRequest, Request, Response, SubscribeRequest,
 };
 use airc_lib::{Airc, Body, Headers, PeerSpec};
 use airc_store::{EventStore, SqliteEventStore};
@@ -696,13 +696,49 @@ pub async fn run_peer_add(
     // fine — it'll pick up the trust store on next start.
     let client = DaemonClient::new(socket);
     match client
-        .add_peer(AddPeerRequest {
-            peer_id,
-            pubkey_b64,
-        })
+        .call_with_timeout(
+            Request::AddPeer(AddPeerRequest {
+                peer_id,
+                pubkey_b64,
+            }),
+            Duration::from_millis(250),
+        )
         .await
     {
-        Ok(()) => println!("daemon: in-memory registry updated."),
+        Ok(Response::Ok) => println!("daemon: in-memory registry updated."),
+        Ok(other) => println!("daemon: skipped in-memory registry sync ({other:?})."),
+        Err(_) => {
+            println!("daemon: not running (trust store updated; daemon will load on next start).")
+        }
+    }
+    Ok(())
+}
+
+/// `peer remove <peer-id>` — remove a peer from durable trust and
+/// update the running daemon's verifier when present.
+pub async fn run_peer_remove(
+    home: &Path,
+    peer_id: airc_core::PeerId,
+    socket: PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let removed = airc.remove_peer(peer_id, "manual").await?;
+    if removed {
+        println!("removed peer_id={peer_id}");
+    } else {
+        println!("peer_id={peer_id} was not enroled");
+    }
+
+    let client = DaemonClient::new(socket);
+    match client
+        .call_with_timeout(
+            Request::RemovePeer(RemovePeerRequest { peer_id }),
+            Duration::from_millis(250),
+        )
+        .await
+    {
+        Ok(Response::Ok) => println!("daemon: in-memory registry updated."),
+        Ok(other) => println!("daemon: skipped in-memory registry sync ({other:?})."),
         Err(_) => {
             println!("daemon: not running (trust store updated; daemon will load on next start).")
         }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -356,6 +356,10 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             PeerAction::Add { spec, socket } => {
                 commands::run_peer_add(&home, spec, default_or(socket, &home)).await
             }
+            PeerAction::Remove { peer_id, socket } => {
+                let peer_id = parse_peer_id(&peer_id)?;
+                commands::run_peer_remove(&home, peer_id, default_or(socket, &home)).await
+            }
             PeerAction::List => commands::run_peer_list(&home).await,
         },
 

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -255,6 +255,51 @@ fn part_without_args_leaves_default_channel() {
     assert!(stdout.contains("parted:  #part-cli"), "{stdout}");
 }
 
+#[test]
+fn peer_remove_deletes_enrolled_peer() {
+    let workspace = TempDir::new().expect("tempdir");
+    let alice_home = workspace.path().join("alice");
+    let bob_home = workspace.path().join("bob");
+    let (bob_id, bob_spec) = run_init(&bob_home);
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(async {
+        let airc = airc_lib::Airc::open(&alice_home).await.unwrap();
+        airc.add_peer(bob_spec.parse().unwrap()).await.unwrap();
+    });
+
+    let mut remove = command_for_home(&alice_home);
+    remove.args([
+        "--home",
+        alice_home.to_str().unwrap(),
+        "peer",
+        "remove",
+        &bob_id,
+    ]);
+    let remove_output = output_with_timeout(remove, Duration::from_secs(10), "airc peer remove");
+    assert!(
+        remove_output.status.success(),
+        "peer remove failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&remove_output.stdout),
+        String::from_utf8_lossy(&remove_output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&remove_output.stdout);
+    assert!(
+        stdout.contains(&format!("removed peer_id={bob_id}")),
+        "{stdout}"
+    );
+
+    let mut list = command_for_home(&alice_home);
+    list.args(["--home", alice_home.to_str().unwrap(), "peer", "list"]);
+    let list_output = output_with_timeout(list, Duration::from_secs(10), "airc peer list");
+    assert!(list_output.status.success());
+    assert!(
+        !String::from_utf8_lossy(&list_output.stdout).contains(&bob_id),
+        "removed peer should not appear in list: {}",
+        String::from_utf8_lossy(&list_output.stdout),
+    );
+}
+
 fn strip_cargo_harness_env(command: &mut Command) {
     command.env_remove("CARGO_PKG_NAME");
     for key in std::env::vars_os()

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -14,7 +14,9 @@ use airc_protocol::{Envelope, Frame, FrameKind, Signature, Subscription};
 use airc_transport::Transport;
 use futures::stream::StreamExt;
 
-use crate::ipc::request::{AddPeerRequest, InboxRequest, Request, SendRequest, SubscribeRequest};
+use crate::ipc::request::{
+    AddPeerRequest, InboxRequest, RemovePeerRequest, Request, SendRequest, SubscribeRequest,
+};
 use crate::ipc::response::{InboxResponse, PeerEntry, PeersResponse, Response, StatusResponse};
 use crate::state::DaemonState;
 
@@ -39,6 +41,7 @@ pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
             message: "attach is a streaming request handled by the server".to_string(),
         },
         Request::AddPeer(add) => handle_add_peer(state, add).await,
+        Request::RemovePeer(remove) => handle_remove_peer(state, remove).await,
         Request::ListPeers => handle_list_peers(state).await,
         Request::Stop => {
             // Don't actually stop here; just signal. The server's
@@ -188,6 +191,19 @@ async fn handle_add_peer(state: Arc<DaemonState>, add: AddPeerRequest) -> Respon
             message: format!("add_peer: enrol: {error}"),
         };
     }
+    Response::Ok
+}
+
+async fn handle_remove_peer(state: Arc<DaemonState>, remove: RemovePeerRequest) -> Response {
+    let mut registry = match state.registry.write() {
+        Ok(guard) => guard,
+        Err(_) => {
+            return Response::Error {
+                message: "remove_peer: registry lock poisoned".to_string(),
+            };
+        }
+    };
+    registry.remove_peer(remove.peer_id);
     Response::Ok
 }
 
@@ -349,6 +365,39 @@ mod tests {
         let frames = dir.path().join("frames.jsonl");
         let contents = std::fs::read_to_string(frames).unwrap();
         assert_eq!(contents.lines().count(), 1);
+    }
+
+    #[tokio::test]
+    async fn remove_peer_updates_in_memory_registry() {
+        let state = test_state();
+        let peer_id = PeerId::from_u128(0xb0b);
+        let keypair = PeerKeypair::generate();
+        let pubkey_b64 = base64::Engine::encode(
+            &base64::engine::general_purpose::URL_SAFE_NO_PAD,
+            keypair.public_bytes(),
+        );
+        assert_eq!(
+            dispatch(
+                state.clone(),
+                Request::AddPeer(AddPeerRequest {
+                    peer_id,
+                    pubkey_b64,
+                }),
+            )
+            .await,
+            Response::Ok
+        );
+        assert!(state.registry.read().unwrap().lookup(peer_id, 0).is_some());
+
+        assert_eq!(
+            dispatch(
+                state.clone(),
+                Request::RemovePeer(RemovePeerRequest { peer_id }),
+            )
+            .await,
+            Response::Ok
+        );
+        assert!(state.registry.read().unwrap().lookup(peer_id, 0).is_none());
     }
 
     // Pull PathBuf into scope so the import isn't unused when only

--- a/crates/airc-daemon/src/ipc/client.rs
+++ b/crates/airc-daemon/src/ipc/client.rs
@@ -18,7 +18,8 @@ use tokio::time::{timeout, Duration};
 use crate::ipc::transport::IpcStream;
 
 use crate::ipc::request::{
-    AddPeerRequest, AttachRequest, InboxRequest, Request, SendRequest, SubscribeRequest,
+    AddPeerRequest, AttachRequest, InboxRequest, RemovePeerRequest, Request, SendRequest,
+    SubscribeRequest,
 };
 use crate::ipc::response::{InboxResponse, PeersResponse, Response, StatusResponse};
 
@@ -215,6 +216,18 @@ impl DaemonClient {
 
     pub async fn add_peer(&self, request: AddPeerRequest) -> Result<(), ClientError> {
         match self.call(Request::AddPeer(request)).await? {
+            Response::Ok => Ok(()),
+            other @ (Response::Pong
+            | Response::Status(_)
+            | Response::Inbox(_)
+            | Response::Event { .. }
+            | Response::Peers(_)
+            | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
+        }
+    }
+
+    pub async fn remove_peer(&self, request: RemovePeerRequest) -> Result<(), ClientError> {
+        match self.call(Request::RemovePeer(request)).await? {
             Response::Ok => Ok(()),
             other @ (Response::Pong
             | Response::Status(_)

--- a/crates/airc-daemon/src/ipc/request.rs
+++ b/crates/airc-daemon/src/ipc/request.rs
@@ -21,6 +21,9 @@ pub enum Request {
     /// trust lives in the store; this op keeps the running daemon's
     /// registry in sync without a restart.
     AddPeer(AddPeerRequest),
+    /// Remove a peer from the daemon's in-memory registry after the
+    /// durable trust store has been updated.
+    RemovePeer(RemovePeerRequest),
     /// Snapshot of currently-enrolled peers (peer_id + pubkey).
     /// Returned via `Response::Peers`.
     ListPeers,
@@ -93,6 +96,12 @@ pub struct AddPeerRequest {
     pub pubkey_b64: String,
 }
 
+/// Parameters for `RemovePeer`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemovePeerRequest {
+    pub peer_id: PeerId,
+}
+
 /// Parameters for `Send`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendRequest {
@@ -120,6 +129,15 @@ mod tests {
         assert_eq!(encoded, r#"{"op":"ping"}"#);
         let decoded: Request = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, Request::Ping);
+    }
+
+    #[test]
+    fn remove_peer_roundtrips_with_peer_id() {
+        let peer_id = PeerId::from_u128(0xabc);
+        let encoded =
+            serde_json::to_string(&Request::RemovePeer(RemovePeerRequest { peer_id })).unwrap();
+        let decoded: Request = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, Request::RemovePeer(RemovePeerRequest { peer_id }));
     }
 
     #[test]

--- a/crates/airc-daemon/src/lib.rs
+++ b/crates/airc-daemon/src/lib.rs
@@ -40,7 +40,8 @@ pub use identity::{IdentityError, LocalIdentity};
 
 pub use ipc::client::{ClientError, DaemonClient};
 pub use ipc::request::{
-    AddPeerRequest, AttachRequest, InboxRequest, Request, SendRequest, SubscribeRequest,
+    AddPeerRequest, AttachRequest, InboxRequest, RemovePeerRequest, Request, SendRequest,
+    SubscribeRequest,
 };
 pub use ipc::response::{InboxResponse, PeersResponse, Response, StatusResponse};
 pub use server::{run, DaemonError};

--- a/crates/airc-daemon/src/peers_store.rs
+++ b/crates/airc-daemon/src/peers_store.rs
@@ -215,6 +215,16 @@ pub async fn add(
         .map_err(Into::into)
 }
 
+/// Remove an enrolled peer from the local trust store. Idempotent:
+/// returns `Ok(None)` when the peer is already absent.
+pub async fn remove(home: &Path, peer_id: PeerId) -> Result<Option<StoredPeer>, PeersStoreError> {
+    open_store(home)
+        .await?
+        .remove_peer_trust(peer_id)
+        .await
+        .map_err(Into::into)
+}
+
 /// Apply a signed trust rotation:
 ///
 /// 1. Verify cryptographic shape (signature against `prev_pubkey`,
@@ -348,6 +358,23 @@ mod tests {
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].peer_id, id);
         assert_eq!(loaded[0].pubkey_bytes().unwrap(), pk);
+    }
+
+    #[tokio::test]
+    async fn remove_deletes_peer_trust_idempotently() {
+        let home = TempDir::new().unwrap();
+        let id = PeerId::new();
+        let pk = fake_pubkey(0xab);
+        add(home.path(), id, pk).await.unwrap();
+
+        let removed = remove(home.path(), id)
+            .await
+            .unwrap()
+            .expect("peer was stored");
+        assert_eq!(removed.peer_id, id);
+        assert_eq!(removed.pubkey_bytes().unwrap(), pk);
+        assert!(load(home.path()).await.unwrap().is_empty());
+        assert!(remove(home.path(), id).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/crates/airc-lib/src/lifecycle.rs
+++ b/crates/airc-lib/src/lifecycle.rs
@@ -93,6 +93,8 @@ impl Airc {
     ///   is persisted.
     /// - `PeerArrived` — fired from `Airc::add_peer` when a new peer
     ///   enters the local trust store.
+    /// - `PeerDeparted` — fired from `Airc::remove_peer` when a peer
+    ///   leaves local trust.
     /// - `WireEstablished` — fired when a new local wire subscriber
     ///   attaches.
     /// - `SubscriptionAdvanced` — fired when a runtime consumer cursor
@@ -101,9 +103,8 @@ impl Airc {
     /// - `RoomParted` — fired from [`Airc::part_channel`] after the
     ///   subscription row is tombstoned and presence is refreshed.
     ///
-    /// Other variants (PeerDeparted, WireLost) have stable body schemas
-    /// defined in this module; their emit points are queued for
-    /// follow-up PRs.
+    /// `WireLost` has a stable body schema defined in this module; its
+    /// emit point is queued for a follow-up PR.
     pub(crate) async fn emit_lifecycle(
         &self,
         kind: TranscriptKind,

--- a/crates/airc-lib/src/peers.rs
+++ b/crates/airc-lib/src/peers.rs
@@ -30,6 +30,44 @@ impl Airc {
         self.add_peer_via(spec, "manual").await
     }
 
+    /// Remove a peer from local durable trust and in-memory
+    /// verification state. Emits `PeerDeparted` only when a stored peer
+    /// was actually removed.
+    pub async fn remove_peer(&self, peer_id: PeerId, reason: &str) -> Result<bool, AircError> {
+        let removed_home = peers_store::remove(&self.inner.home, peer_id).await?;
+        let removed_wire_root = if self.inner.wire_root != self.inner.home {
+            peers_store::remove(&self.inner.wire_root, peer_id).await?
+        } else {
+            None
+        };
+        let removed = removed_home.or(removed_wire_root).is_some();
+
+        {
+            let mut registry = self
+                .inner
+                .registry
+                .write()
+                .map_err(|_| AircError::Crypto("registry lock poisoned".to_string()))?;
+            registry.remove_peer(peer_id);
+        }
+
+        if !removed {
+            return Ok(false);
+        }
+
+        let room_id = self.current_room().await?.channel;
+        let body = airc_core::Body::Json(
+            serde_json::to_value(crate::lifecycle::PeerDepartedBody {
+                peer_id,
+                reason: reason.to_string(),
+            })
+            .map_err(|e| AircError::Crypto(format!("lifecycle body serialize: {e}")))?,
+        );
+        self.emit_lifecycle(airc_core::TranscriptKind::PeerDeparted, room_id, body)
+            .await?;
+        Ok(true)
+    }
+
     /// Internal: enrol a peer and emit `PeerArrived` with the
     /// caller-supplied `via` tag (`"invite"`, `"account_registry"`,
     /// `"manual"`, etc.). Callers that know how the peer was

--- a/crates/airc-lib/tests/lifecycle_events.rs
+++ b/crates/airc-lib/tests/lifecycle_events.rs
@@ -159,6 +159,72 @@ async fn add_peer_is_idempotent_no_duplicate_lifecycle_event() {
 }
 
 #[tokio::test]
+async fn remove_peer_emits_peer_departed_lifecycle_event() {
+    use airc_core::PeerId;
+    use airc_lib::lifecycle::PeerDepartedBody;
+    use airc_lib::PeerSpec;
+    use airc_protocol::PeerKeypair;
+
+    let dir = TempDir::new().expect("tempdir");
+    let home = dir.path().join(".airc");
+    std::fs::create_dir_all(&home).unwrap();
+    let airc = Airc::open(&home).await.expect("open");
+    let _room = airc.join("peer-departed-test").await.expect("join");
+
+    let peer_id = PeerId::new();
+    let peer_keypair = PeerKeypair::generate();
+    airc.add_peer(PeerSpec {
+        peer_id,
+        pubkey: peer_keypair.public_bytes(),
+    })
+    .await
+    .expect("add peer");
+
+    let mut stream = airc.subscribe().await.expect("subscribe");
+    let removed = airc
+        .remove_peer(peer_id, "manual")
+        .await
+        .expect("remove peer");
+    assert!(removed, "known peer should be removed");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    let mut found = None;
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), stream.next()).await {
+            Ok(Some(Ok(event))) => {
+                if event.kind == TranscriptKind::PeerDeparted {
+                    found = Some(event);
+                    break;
+                }
+            }
+            Ok(Some(Err(_))) => continue,
+            Ok(None) => panic!("stream closed before PeerDeparted arrived"),
+            Err(_) => continue,
+        }
+    }
+
+    let event = found.expect("PeerDeparted lifecycle event exists");
+    let body = event.body.as_ref().expect("event has body");
+    let body_json = match body {
+        Body::Json(value) => value.clone(),
+        _ => panic!("PeerDeparted body should be JSON"),
+    };
+    let parsed: PeerDepartedBody =
+        serde_json::from_value(body_json).expect("body parses as PeerDepartedBody");
+    assert_eq!(parsed.peer_id, peer_id);
+    assert_eq!(parsed.reason, "manual");
+    assert!(
+        !airc
+            .peers()
+            .await
+            .expect("peers")
+            .iter()
+            .any(|peer| peer.peer_id == peer_id),
+        "removed peer must not remain in durable peer list"
+    );
+}
+
+#[tokio::test]
 async fn join_emits_wire_established_after_subscriber_attaches() {
     use airc_lib::lifecycle::WireEstablishedBody;
 

--- a/crates/airc-protocol/src/signature.rs
+++ b/crates/airc-protocol/src/signature.rs
@@ -129,6 +129,18 @@ impl PeerKeyRegistry {
         self.keys.get(&(peer, key_id))
     }
 
+    /// Remove every enrolled key for `peer`.
+    ///
+    /// Used when local trust is explicitly revoked. Returns the
+    /// number of key ids removed so callers can distinguish an
+    /// idempotent remove from a real departure.
+    pub fn remove_peer(&mut self, peer: PeerId) -> usize {
+        let before = self.keys.len();
+        self.keys
+            .retain(|(enrolled_peer, _key_id), _key| *enrolled_peer != peer);
+        before - self.keys.len()
+    }
+
     /// Reverse lookup: find which `(peer, key_id)` enrolled a given
     /// pubkey. Used by the lan-tcp TLS verifier — at handshake time
     /// the server receives a client cert but doesn't know which peer
@@ -506,5 +518,26 @@ mod tests {
             &PeerKeyRegistry::new(),
         )
         .is_ok());
+    }
+
+    #[test]
+    fn remove_peer_removes_all_key_ids_for_peer() {
+        use crate::keypair::PeerKeypair;
+
+        let peer = PeerId::from_u128(0xabc);
+        let other = PeerId::from_u128(0xdef);
+        let key_a = PeerKeypair::generate();
+        let key_b = PeerKeypair::generate();
+        let key_other = PeerKeypair::generate();
+        let mut registry = PeerKeyRegistry::new();
+        registry.enrol(peer, 0, key_a.public_bytes()).unwrap();
+        registry.enrol(peer, 1, key_b.public_bytes()).unwrap();
+        registry.enrol(other, 0, key_other.public_bytes()).unwrap();
+
+        assert_eq!(registry.remove_peer(peer), 2);
+        assert!(registry.lookup(peer, 0).is_none());
+        assert!(registry.lookup(peer, 1).is_none());
+        assert!(registry.lookup(other, 0).is_some());
+        assert_eq!(registry.remove_peer(peer), 0);
     }
 }

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -178,6 +178,29 @@ impl SqliteEventStore {
         })
     }
 
+    pub async fn remove_peer_trust(
+        &self,
+        peer_id: PeerId,
+    ) -> Result<Option<StoredPeer>, StoreError> {
+        let txn = self.db.begin().await?;
+        let stored = peer_trust::Entity::find_by_id(peer_id.as_uuid())
+            .one(&txn)
+            .await?;
+        let Some(stored) = stored else {
+            txn.commit().await?;
+            return Ok(None);
+        };
+        peer_trust::Entity::delete_by_id(peer_id.as_uuid())
+            .exec(&txn)
+            .await?;
+        txn.commit().await?;
+        Ok(Some(StoredPeer {
+            peer_id,
+            pubkey_b64: stored.pubkey_b64,
+            added_at_ms: i64_to_u64("peer_trust.added_at_ms", stored.added_at_ms)?,
+        }))
+    }
+
     pub async fn append_peer_rotation_audit(
         &self,
         entry: RotationAuditEntry,

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -171,8 +171,8 @@ Status:
 - `airc-lib` subscription query API landed in #911.
 - Typed lifecycle events landed in #914.
 - Lifecycle emit points are being wired as Phase 2 sub-slices:
-  `RoomJoined`, `PeerArrived`, `WireEstablished`, `RoomParted`, and
-  `SubscriptionAdvanced` now emit durable lifecycle events from
+  `RoomJoined`, `PeerArrived`, `PeerDeparted`, `WireEstablished`,
+  `RoomParted`, and `SubscriptionAdvanced` now emit durable lifecycle events from
   substrate code. Cursor advancement uses
   `Airc::save_runtime_cursor_for_event` where the source event is known
   so advancing past a `SubscriptionAdvanced` lifecycle event stores the
@@ -180,6 +180,9 @@ Status:
   `RoomParted` is emitted by the ORM-backed `Airc::part_channel`
   subscription transition and surfaced through the thin `airc part`
   CLI command.
+  `PeerDeparted` is emitted by the ORM-backed `Airc::remove_peer`
+  trust transition and surfaced through `airc peer remove`, including
+  live daemon verifier sync when a daemon is running.
 - Typed git/PR event contracts are being added in `airc-work`:
   `GitCommitObserved`, `GitBranchMoved`, `GitDirtyStateChanged`,
   `PullRequestCheckSuiteChanged`, `PullRequestReviewSubmitted`, and

--- a/docs/rust-substrate-grievances-and-gaps.md
+++ b/docs/rust-substrate-grievances-and-gaps.md
@@ -873,6 +873,11 @@ Replaces the single-slice "Queue/lane Rust model" line in the First Remediation 
      preserves identity/trust/other rooms, refreshes the account
      presence snapshot, and emits durable `RoomParted`. The public
      `airc part [room]` command is a thin wrapper over that API.
+   - **Phase 2 peer-departure slice.** `airc-lib::Airc::remove_peer`
+     removes durable peer trust through `airc-store`, removes the peer
+     from the live verifier registry, emits durable `PeerDeparted`, and
+     the public `airc peer remove <peer-id>` command syncs a running
+     daemon through a typed RPC instead of waiting for restart.
 7. **PR 7 — Continuum bridge.** Continuum event subsystem consumes AIRC subscriptions directly. Persona inboxes are AIRC channel/header subscriptions plus Continuum-specific projection/RAG assembly.
 
 ### What this replaces in the previous plan


### PR DESCRIPTION
## Roadmap Reference

- Phase / slice: Phase 2 — Substrate Events And Subscription API / PeerDeparted emit point
- Primary doc: `docs/architecture/GRID-SUBSTRATE-AUDIT.md`
- Gap doc: `docs/rust-substrate-grievances-and-gaps.md` PR 6 monitor/hook subscriptions, Phase 2 peer-departure slice
- Acceptance gate advanced: peer trust removal becomes a durable lifecycle event and live verifier update that consumers can observe through subscriptions instead of waiting for daemon restart or parsing CLI output.

## Summary

- add peer removal to the ORM-backed peer trust store
- add daemon `RemovePeer` RPC so live verifier state matches durable trust without restart
- add `Airc::remove_peer` and thin `airc peer remove <peer-id>` CLI
- emit durable `PeerDeparted` lifecycle events on actual trust removal
- update Phase 2 docs

## Verification

- `cargo fmt --manifest-path Cargo.toml -p airc-protocol -p airc-store -p airc-daemon -p airc-lib -p airc-cli`
- `cargo test --manifest-path Cargo.toml -p airc-protocol remove_peer_removes_all_key_ids_for_peer -- --nocapture`
- `cargo test --manifest-path Cargo.toml -p airc-daemon remove_deletes_peer_trust_idempotently -- --nocapture`
- `cargo test --manifest-path Cargo.toml -p airc-daemon remove_peer_updates_in_memory_registry -- --nocapture`
- `cargo test --manifest-path Cargo.toml -p airc-lib --test lifecycle_events remove_peer_emits_peer_departed_lifecycle_event -- --nocapture`
- `cargo test --manifest-path Cargo.toml -p airc-cli --test e2e peer_remove_deletes_enrolled_peer -- --nocapture`
- `cargo clippy --manifest-path Cargo.toml -p airc-protocol -p airc-store -p airc-daemon -p airc-lib -p airc-cli --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml --workspace`
- `cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings`

## Coordination

- Claimed the Phase 2 PeerDeparted lane over AIRC before editing.
- Scope is peer trust removal, daemon live verifier sync, lifecycle emission, and thin CLI only.
