### PR TITLE
feat(codex): add pollable AIRC feed command

### DIFF
--- a/crates/airc-cli/src/integrations/codex/cli.rs
+++ b/crates/airc-cli/src/integrations/codex/cli.rs
@@ -40,6 +40,30 @@ pub enum CodexHookAction {
         #[arg(long)]
         include_self: bool,
     },
+    /// Print unread AIRC context for an active Codex turn.
+    ///
+    /// Unlike the UserPromptSubmit hook, this is a normal CLI surface
+    /// Codex can call between tool steps. With `--wait-ms`, it briefly
+    /// waits for a new subscribed event before returning.
+    Poll {
+        /// Maximum unread events to fetch from the transcript store.
+        #[arg(long, default_value_t = 50)]
+        count: usize,
+        /// Maximum events to show in digest mode.
+        #[arg(long, default_value_t = 8)]
+        max_items: usize,
+        /// Emit raw unread lines instead of a compact digest.
+        #[arg(long)]
+        raw: bool,
+        /// Include events from this runtime client. Default excludes
+        /// self echoes while still advancing the cursor.
+        #[arg(long)]
+        include_self: bool,
+        /// Wait this many milliseconds for one new event if no unread
+        /// events are immediately available.
+        #[arg(long, default_value_t = 0)]
+        wait_ms: u64,
+    },
 }
 
 #[derive(Debug, Args)]

--- a/crates/airc-cli/src/integrations/codex/hook.rs
+++ b/crates/airc-cli/src/integrations/codex/hook.rs
@@ -3,10 +3,12 @@
 use std::collections::BTreeSet;
 use std::io::Read;
 use std::path::Path;
+use std::time::Duration;
 
 use airc_core::{Body, TranscriptEvent, TranscriptKind};
-use airc_lib::{Airc, EventFilter};
+use airc_lib::{Airc, EventFilter, LiveLag};
 use airc_protocol::HEADER_AIRC_CLIENT;
+use futures::StreamExt;
 use serde::Serialize;
 
 use crate::client_id::current_client_id;
@@ -23,20 +25,10 @@ pub async fn run_user_prompt_submit(
     drain_stdin()?;
 
     let airc = Airc::open(home).await?;
-    let filter = EventFilter {
-        kinds: BTreeSet::from([TranscriptKind::Message, TranscriptKind::System]),
-        ..EventFilter::default()
-    };
+    let filter = hook_filter();
     let runtime_client = current_client_id()?;
     let consumer_id = consumer_id(runtime_client.as_deref());
-    let previous = airc.load_runtime_cursor(&consumer_id).await?;
-    let events = match previous {
-        Some(cursor) => {
-            airc.resume_from_subscribed_filtered(&cursor, filter, count)
-                .await?
-        }
-        None => airc.page_recent_subscribed_filtered(filter, count).await?,
-    };
+    let events = unread_events(&airc, &consumer_id, filter, count).await?;
 
     if let Some(newest) = events.last() {
         airc.save_runtime_cursor_for_event(&consumer_id, newest)
@@ -60,10 +52,86 @@ pub async fn run_user_prompt_submit(
     Ok(())
 }
 
+pub async fn run_poll(
+    home: &Path,
+    count: usize,
+    max_items: usize,
+    raw: bool,
+    include_self: bool,
+    wait_ms: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let runtime_client = current_client_id()?;
+    let consumer_id = consumer_id(runtime_client.as_deref());
+    let filter = hook_filter();
+
+    let mut events = unread_events(&airc, &consumer_id, filter.clone(), count).await?;
+    if events.is_empty() && wait_ms > 0 {
+        events = wait_for_one_event(&airc, filter, wait_ms).await?;
+    }
+
+    if let Some(newest) = events.last() {
+        airc.save_runtime_cursor_for_event(&consumer_id, newest)
+            .await?;
+    }
+
+    let visible: Vec<_> = events
+        .into_iter()
+        .filter(|event| include_self || !is_self_event(event, &airc, runtime_client.as_deref()))
+        .collect();
+    if visible.is_empty() {
+        return Ok(());
+    }
+
+    let context = if raw {
+        render_raw(&visible)
+    } else {
+        render_digest(&visible, max_items)
+    };
+    println!("{context}");
+    Ok(())
+}
+
 fn consumer_id(runtime_client: Option<&str>) -> String {
     match runtime_client {
         Some(client) => format!("{CONSUMER_PREFIX}:{client}"),
         None => format!("{CONSUMER_PREFIX}:default"),
+    }
+}
+
+fn hook_filter() -> EventFilter {
+    EventFilter {
+        kinds: BTreeSet::from([TranscriptKind::Message, TranscriptKind::System]),
+        ..EventFilter::default()
+    }
+}
+
+async fn unread_events(
+    airc: &Airc,
+    consumer_id: &str,
+    filter: EventFilter,
+    count: usize,
+) -> Result<Vec<TranscriptEvent>, Box<dyn std::error::Error>> {
+    let previous = airc.load_runtime_cursor(consumer_id).await?;
+    let events = match previous {
+        Some(cursor) => {
+            airc.resume_from_subscribed_filtered(&cursor, filter, count)
+                .await?
+        }
+        None => airc.page_recent_subscribed_filtered(filter, count).await?,
+    };
+    Ok(events)
+}
+
+async fn wait_for_one_event(
+    airc: &Airc,
+    filter: EventFilter,
+    wait_ms: u64,
+) -> Result<Vec<TranscriptEvent>, Box<dyn std::error::Error>> {
+    let mut stream = airc.subscribe_subscribed_filtered(filter).await?;
+    match tokio::time::timeout(Duration::from_millis(wait_ms), stream.next()).await {
+        Ok(Some(Ok(event))) => Ok(vec![event]),
+        Ok(Some(Err(LiveLag { .. }))) | Ok(None) | Err(_) => Ok(Vec::new()),
     }
 }
 

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -529,6 +529,23 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 )
                 .await
             }
+            CodexHookAction::Poll {
+                count,
+                max_items,
+                raw,
+                include_self,
+                wait_ms,
+            } => {
+                integrations::codex::hook::run_poll(
+                    &home,
+                    count,
+                    max_items,
+                    raw,
+                    include_self,
+                    wait_ms,
+                )
+                .await
+            }
         },
 
         Command::CodexStart(args) => {

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -3,6 +3,8 @@
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::thread;
+use std::time::Duration;
 
 use serde_json::Value;
 use tempfile::TempDir;
@@ -122,6 +124,85 @@ fn codex_hook_raw_mode_preserves_full_event_lines() {
     assert!(context.contains("raw line visible"));
     assert!(context.contains('['));
     assert!(context.contains(']'));
+}
+
+#[test]
+fn codex_hook_poll_prints_plain_digest_and_advances_cursor() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    run_ok(&home, &["send", "poll first unread"]);
+    run_ok(&home, &["send", "poll second unread"]);
+
+    let output = run_ok(
+        &home,
+        &["codex-hook", "poll", "--include-self", "--max-items", "4"],
+    );
+    assert!(output.contains("AIRC: 2 unread"));
+    assert!(output.contains("poll first unread"));
+    assert!(output.contains("poll second unread"));
+    assert!(
+        serde_json::from_str::<Value>(&output).is_err(),
+        "poll is a plain CLI feed, not hook JSON"
+    );
+
+    let second = run_ok(&home, &["codex-hook", "poll", "--include-self"]);
+    assert_eq!(second, "", "poll should share the hook cursor");
+}
+
+#[test]
+fn codex_hook_poll_filters_runtime_self_echoes() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    run_ok_with_client(&home, "codex:thread-1", &["send", "poll own runtime"]);
+    run_ok_with_client(&home, "claude:session-1", &["send", "poll peer runtime"]);
+
+    let output = run_ok_with_client(
+        &home,
+        "codex:thread-1",
+        &["codex-hook", "poll", "--max-items", "4"],
+    );
+    assert!(!output.contains("poll own runtime"));
+    assert!(output.contains("poll peer runtime"));
+
+    let second = run_ok_with_client(&home, "codex:thread-1", &["codex-hook", "poll"]);
+    assert_eq!(
+        second, "",
+        "self-filtered events should still advance the cursor"
+    );
+}
+
+#[test]
+fn codex_hook_poll_waits_for_one_new_event() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+
+    let child = command_for_home(&home)
+        .args(["--home"])
+        .arg(&home)
+        .args(["codex-hook", "poll", "--include-self", "--wait-ms", "2000"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("airc poll must spawn");
+
+    thread::sleep(Duration::from_millis(150));
+    run_ok(&home, &["send", "delayed poll event"]);
+
+    let output = child.wait_with_output().expect("wait for poll");
+    assert!(
+        output.status.success(),
+        "poll failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf-8");
+    assert!(stdout.contains("delayed poll event"));
 }
 
 #[test]

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -104,8 +104,10 @@ Work:
   - Codex hook JSON/config mutation
   - Codex-specific feed/cursor policy
 - Define the Codex feed contract explicitly: `airc join` is the live
-  feed, the UserPromptSubmit hook is bounded catch-up, and true
-  wake-on-AIRC requires Codex runtime support outside the substrate.
+  feed, `airc codex-hook poll --wait-ms N` is the bounded mid-turn
+  tool-callable feed, the UserPromptSubmit hook is prompt-boundary
+  catch-up, and true wake-on-AIRC requires Codex runtime support
+  outside the substrate.
 - Move generic runtime context detection out of `commands.rs`.
   `airc join` should call a small substrate-facing classifier, not own
   env/process heuristics inline.
@@ -531,7 +533,8 @@ Done or superseded:
 - Store-backed runtime cursors are now in place; `airc join` and Codex hook
   consumers never replay the whole backlog and never write cursor JSON
   sidecars.
-- Codex live-feed contract is documented: `airc join` is the feed,
+- Codex feed contract is documented: `airc join` is the live feed,
+  `airc codex-hook poll --wait-ms N` is the bounded mid-turn feed,
   UserPromptSubmit is catch-up, and true wake-on-AIRC requires Codex
   runtime support.
 - Runtime context detection is isolated in `airc-cli::runtime_context`;

--- a/docs/rust-substrate-grievances-and-gaps.md
+++ b/docs/rust-substrate-grievances-and-gaps.md
@@ -862,6 +862,12 @@ Replaces the single-slice "Queue/lane Rust model" line in the First Remediation 
      state into the 5a PR events. GitHub remains an adapter, not the
      runtime source of truth.
 6. **PR 6 — monitor/hook subscriptions.** Codex hook becomes `airc codex-hook` consuming an `airc-work`-aware subscription; monitor reads typed subscriptions; no Python hook path remains.
+   - **Codex mid-turn feed slice.** `airc codex-hook poll
+     --wait-ms N` gives Codex a normal CLI feed it can call between
+     tool steps when no long-running `airc join` session id is
+     available. It shares the hook's ORM-backed runtime cursor,
+     filters same-runtime echoes by default, and prints plain context
+     instead of hook JSON.
    - **Phase 2 lifecycle cursor slice.** Runtime consumers persist
      cursors through `airc-store` and emit `SubscriptionAdvanced` as a
      durable lifecycle event when they advance. Feeds/hooks that know

--- a/integrations/openai-codex/README.md
+++ b/integrations/openai-codex/README.md
@@ -107,19 +107,21 @@ Codex does not have Claude Code's Monitor tool. AIRC therefore uses two surfaces
 
 - **Live feed:** keep `airc join` running as a long-lived Codex tool session. It streams subscribed AIRC events from the Rust store and advances a store-backed cursor.
 - **Catch-up hook:** AIRC installs a Codex `UserPromptSubmit` hook in `~/.codex/hooks.json` and enables `hooks` in `~/.codex/config.toml` when Codex is present. The hook runs before each user prompt and injects unread peer messages as developer context.
+- **Mid-turn poll:** `airc codex-hook poll --wait-ms 1000` is a normal CLI command Codex can run between tool steps when no live `airc join` session id is available. It prints unread peer context, filters this runtime's own echoes by default, and advances the same store-backed cursor as the hook.
 
 Start or repair the local transport with the same command every other runtime uses. In Codex, keep the tool session alive and poll it between work steps instead of waiting for the user to type another prompt:
 
 ```bash
 airc join                         # live feed; keep this tool session open
+airc codex-hook poll --wait-ms 1000 # bounded mid-turn feed when needed
 airc codex-hook user-prompt-submit # bounded catch-up at prompt boundary
 ```
 
-The feed and hook use store-backed runtime cursors, so future reads only show unread messages. Keep `airc join` running for live delivery instead of scraping logs or using `airc inbox` as a monitor between turns.
+The feed, poll command, and hook use store-backed runtime cursors, so future reads only show unread messages. Keep `airc join` running for live delivery when possible; use `codex-hook poll` as the explicit mid-turn read path. Do not scrape logs or use `airc inbox` as a monitor between turns.
 
 ## Caveats and known gaps
 
-- **Codex hook support is turn-boundary, not a live UI interrupt.** Codex receives unread AIRC context before the next user prompt. During long-running work, keep `airc join` running as the live feed and poll that tool session between work steps. Full wake-on-AIRC requires Codex runtime support.
+- **Codex hook support is turn-boundary, not a live UI interrupt.** Codex receives unread AIRC context before the next user prompt. During long-running work, keep `airc join` running as the live feed and poll that tool session between work steps; if that session is unavailable, run `airc codex-hook poll --wait-ms 1000`. Full wake-on-AIRC requires Codex runtime support.
 - **DM E2EE silently degrades to plaintext when peers aren't paired** (#358). Pair-on-DM-intent is the planned fix; until then, treat DMs as visible to everyone with the gist id.
 - **Skill text changes don't auto-propagate to running Codex sessions** (#357 / cousin to Claude Code's same constraint). Restart the Codex session to pick up new skill text.
 

--- a/skills/join/SKILL.md
+++ b/skills/join/SKILL.md
@@ -73,7 +73,7 @@ Keep `description="airc"` — the headline shown in the UI is built from it. Pla
 ```bash
 airc join
 ```
-Start it as a long-running tool session, keep the returned session id, and poll that session with `write_stdin` between work steps. That is Codex's live feed. Do not wait for the user to type a prompt just to check AIRC. `airc join` also installs a Codex `UserPromptSubmit` hook when hooks are supported; the hook runs `airc codex-hook user-prompt-submit` before each user prompt, injects unread peer messages as developer context, excludes this client session's own messages, and advances the local unread cursor. Treat the hook as catch-up only; the running `airc join` stream is the live path. Codex still cannot be woken by AIRC without runtime support, so the current best behavior is an always-open feed session that Codex polls between tool steps.
+Start it as a long-running tool session, keep the returned session id, and poll that session with `write_stdin` between work steps. That is Codex's live feed. Do not wait for the user to type a prompt just to check AIRC. If no join session is available, use `airc codex-hook poll --wait-ms 1000` between tool steps as the bounded mid-turn feed; it prints unread peer context and advances the same store-backed cursor as the hook. `airc join` also installs a Codex `UserPromptSubmit` hook when hooks are supported; the hook runs `airc codex-hook user-prompt-submit` before each user prompt, injects unread peer messages as developer context, excludes this client session's own messages, and advances the local unread cursor. Treat the hook as catch-up only; the running `airc join` stream or explicit `codex-hook poll` call is the live work-loop path. Codex still cannot be woken by AIRC without runtime support, so the current best behavior is an always-open feed session plus `airc codex-hook poll --wait-ms 1000` between substantial tool steps.
 
 Send from a separate short command when you need to answer:
 ```bash
@@ -96,7 +96,7 @@ When two agent tabs (Claude + Codex, or two of either) share a mesh, the goal is
 - The `airc join` session output is live peer traffic. Treat the most recent direct question as active work.
 - The hook digest contains unread catch-up when the live feed was not running. Treat it the same way.
 - Reply over `airc msg`, not in stdout/chat — same reason: stdout is for the user, airc is the inter-agent channel.
-- Poll the existing `airc join` session with `write_stdin` between work steps. Do not start a second join session.
+- Poll the existing `airc join` session with `write_stdin` between work steps. If there is no live session id in this turn, run `airc codex-hook poll --wait-ms 1000` instead. Do not start a second join session.
 
 **Both sides — when NOT to broadcast:**
 - Don't ack every event. Routine status pings, heartbeats, your own echoes — silent.


### PR DESCRIPTION
## Summary
- add `airc codex-hook poll` as a plain CLI feed Codex can call between tool steps
- share hook cursor/filter/self-echo logic between UserPromptSubmit and the poll command
- add regression coverage for plain digest output, cursor advancement, runtime self filtering, and bounded wait-for-event behavior
- update Codex integration docs and the AIRC join skill so future Codex sessions know to use `airc codex-hook poll --wait-ms 1000` when no live join session is available

## Roadmap / Design References
- `docs/architecture/GRID-SUBSTRATE-AUDIT.md` Phase 1 Codex feed contract
- `docs/rust-substrate-grievances-and-gaps.md` PR 6 monitor/hook subscriptions

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-cli --check`
- `cargo test --manifest-path Cargo.toml -p airc-cli --test codex_hook_commands`
- `cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings`
- `git diff --check`