### PR TITLE
fix(lib): keep routine wire replay quiet

### DIFF
--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -433,8 +433,10 @@ fn seed_mesh_identity(home: &Path, identity: &str) {
 #[test]
 fn listen_rejects_unenrolled_signer() {
     // Mallory's signed frame must be rejected by Alice's listen — she
-    // isn't in Alice's peer registry. Stderr surfaces a verification
-    // failure; stdout never prints it as a happy message.
+    // isn't in Alice's peer registry. Routine agent feeds keep stale
+    // verification errors quiet, so this diagnostic test opts into
+    // explicit warnings and asserts stdout never prints it as a happy
+    // message.
     let workspace = TempDir::new().expect("tempdir");
     let alice_home = workspace.path().join("alice");
     let mallory_home = workspace.path().join("mallory");
@@ -449,6 +451,7 @@ fn listen_rejects_unenrolled_signer() {
     run_room(&mallory_home, "e2e", &wire);
 
     let mut alice = command_for_home(&alice_home)
+        .env("AIRC_REPLAY_WARN", "1")
         .args(["--home", alice_home.to_str().unwrap(), "listen", "--replay"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -191,9 +191,7 @@ impl Airc {
                         item = stream.next() => match item {
                             Some(Ok(frame)) => airc.append_received_frame(frame).await,
                             Some(Err(verify_err)) => {
-                                eprintln!(
-                                    "airc-lib subscriber: frame verification failed: {verify_err}"
-                                );
+                                warn_frame_verify_failed(&verify_err);
                             }
                             None => break "stream_ended",
                         }
@@ -203,9 +201,7 @@ impl Airc {
                     match stream.next().await {
                         Some(Ok(frame)) => airc.append_received_frame(frame).await,
                         Some(Err(verify_err)) => {
-                            eprintln!(
-                                "airc-lib subscriber: frame verification failed: {verify_err}"
-                            );
+                            warn_frame_verify_failed(&verify_err);
                         }
                         None => break "stream_ended",
                     }
@@ -285,5 +281,11 @@ impl Airc {
                 eprintln!("airc-lib subscriber: store append failed: {err}");
             }
         }
+    }
+}
+
+fn warn_frame_verify_failed(error: &impl std::fmt::Display) {
+    if std::env::var_os("AIRC_REPLAY_WARN").is_some() {
+        eprintln!("airc-lib subscriber: frame verification failed: {error}");
     }
 }

--- a/crates/airc-lib/src/wire_replay.rs
+++ b/crates/airc-lib/src/wire_replay.rs
@@ -17,6 +17,9 @@ impl Airc {
             Err(error) => return Err(AircError::Transport(error.to_string())),
         };
 
+        let mut malformed_count = 0usize;
+        let mut unverifiable_count = 0usize;
+
         for line in text.lines() {
             let trimmed = line.trim();
             if trimmed.is_empty() {
@@ -31,10 +34,13 @@ impl Airc {
                     // files can carry frames from older builds or
                     // ad-hoc test fixtures; refusing to read past
                     // one means losing every later real event too.
-                    eprintln!(
-                        "airc-lib replay: skipping malformed frame in {}: {error}",
-                        path.display()
-                    );
+                    malformed_count += 1;
+                    if replay_warnings_enabled() {
+                        eprintln!(
+                            "airc-lib replay: skipping malformed frame in {}: {error}",
+                            path.display()
+                        );
+                    }
                     continue;
                 }
             };
@@ -55,7 +61,10 @@ impl Airc {
                 // subsequent legitimate frame in the same file
                 // and breaks `airc inbox` / `airc join` for any
                 // scope that touched the wire pre-identity-reset.
-                eprintln!("airc-lib replay: skipping unverifiable frame: {error}");
+                unverifiable_count += 1;
+                if replay_warnings_enabled() {
+                    eprintln!("airc-lib replay: skipping unverifiable frame: {error}");
+                }
                 continue;
             }
             let event = frame.into_transcript_event();
@@ -63,6 +72,12 @@ impl Airc {
                 Ok(()) | Err(airc_store::StoreError::DuplicateEventId(_)) => {}
                 Err(error) => return Err(error.into()),
             }
+        }
+        if replay_warnings_enabled() && (malformed_count > 0 || unverifiable_count > 0) {
+            eprintln!(
+                "airc-lib replay: skipped {malformed_count} malformed and {unverifiable_count} unverifiable frame(s) in {}",
+                path.display()
+            );
         }
         Ok(())
     }
@@ -72,5 +87,28 @@ impl Airc {
             self.replay_wire_once(&wire).await?;
         }
         Ok(())
+    }
+}
+
+fn replay_warnings_enabled() -> bool {
+    replay_warnings_enabled_from(std::env::var_os("AIRC_REPLAY_WARN"))
+}
+
+fn replay_warnings_enabled_from(value: Option<std::ffi::OsString>) -> bool {
+    value.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::replay_warnings_enabled_from;
+
+    #[test]
+    fn replay_warnings_default_to_quiet() {
+        assert!(!replay_warnings_enabled_from(None));
+    }
+
+    #[test]
+    fn replay_warnings_can_be_enabled_for_diagnostics() {
+        assert!(replay_warnings_enabled_from(Some("1".into())));
     }
 }


### PR DESCRIPTION
## Summary
- stop routine wire replay from printing one warning per stale malformed/unverifiable frame
- stop live subscriber verification failures from spamming normal agent feeds
- keep opt-in diagnostics available with `AIRC_REPLAY_WARN=1`

## Roadmap / Design References
- `docs/architecture/GRID-SUBSTRATE-AUDIT.md` Phase 3 reliability/error shape
- `docs/architecture/AR-LATENCY-CONTRACT.md` replay-on-attach hotpath notes

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-lib`
- `cargo test --manifest-path Cargo.toml -p airc-lib wire_replay`
- `cargo clippy --manifest-path Cargo.toml -p airc-lib --all-targets -- -D warnings`
- `cargo build --manifest-path Cargo.toml -p airc-cli --bin airc`
- `./target/debug/airc codex-hook poll --wait-ms 250 --max-items 4`
- `git diff --check`