### PR TITLE
feat(cli): add Rust update command

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -303,6 +303,11 @@ pub enum Command {
     /// package version.)
     Version,
 
+    /// Fast-forward the installed source checkout and refresh the
+    /// installed `airc` binary + skills from that source.
+    #[command(visible_aliases = ["upgrade", "pull"])]
+    Update,
+
     /// Self-diagnose the airc install + scope state.
     ///
     /// Walks the install/identity/daemon/route checklist that

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -59,6 +59,7 @@ mod route_commands;
 mod runtime_context;
 mod transport_cli;
 mod transport_commands;
+mod update_commands;
 mod work_cli;
 mod work_commands;
 mod workspace_cli;
@@ -404,6 +405,8 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::Join { room } => commands::run_join(&home, room).await,
 
         Command::Version => commands::run_version(),
+
+        Command::Update => update_commands::run_update(),
 
         Command::Doctor { fix, health } => doctor::run_doctor(&home, fix, health).await,
 

--- a/crates/airc-cli/src/update_commands.rs
+++ b/crates/airc-cli/src/update_commands.rs
@@ -1,0 +1,172 @@
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+pub fn run_update() -> Result<(), Box<dyn std::error::Error>> {
+    let source = install_source_dir()?;
+    validate_source_checkout(&source)?;
+
+    let branch = git_text(&source, ["rev-parse", "--abbrev-ref", "HEAD"])?;
+    if branch == "HEAD" || branch.is_empty() {
+        return Err(format!(
+            "install source is detached at {}; check out a branch before updating",
+            source.display()
+        )
+        .into());
+    }
+
+    let before = git_text(&source, ["rev-parse", "--short", "HEAD"])?;
+    run_checked(
+        Command::new("git")
+            .arg("-C")
+            .arg(&source)
+            .arg("fetch")
+            .arg("--quiet")
+            .arg("origin")
+            .arg(&branch),
+        "git fetch",
+    )?;
+    run_checked(
+        Command::new("git")
+            .arg("-C")
+            .arg(&source)
+            .arg("pull")
+            .arg("--ff-only")
+            .arg("--quiet"),
+        "git pull --ff-only",
+    )?;
+    let after = git_text(&source, ["rev-parse", "--short", "HEAD"])?;
+
+    run_installer(&source)?;
+
+    if before == after {
+        println!("Already at {after}.");
+    } else {
+        println!("Updated: {before} -> {after}");
+    }
+    Ok(())
+}
+
+fn install_source_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    if let Some(path) = env::var_os("AIRC_DIR").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(path));
+    }
+    let home = env::var_os("HOME")
+        .or_else(|| env::var_os("USERPROFILE"))
+        .ok_or("HOME is not set; cannot resolve ~/.airc/src")?;
+    Ok(PathBuf::from(home).join(".airc").join("src"))
+}
+
+fn validate_source_checkout(source: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    if !source.join(".git").exists() {
+        return Err(format!(
+            "No git checkout at {}. Reinstall airc from the install script.",
+            source.display()
+        )
+        .into());
+    }
+    if !source.join("install.sh").is_file() {
+        return Err(format!(
+            "install source {} is missing install.sh; reinstall airc from the install script",
+            source.display()
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn run_installer(source: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    run_checked(
+        Command::new("bash")
+            .arg(source.join("install.sh"))
+            .env("AIRC_DIR", source)
+            .env("AIRC_INSTALL_NO_PULL", "1"),
+        "install.sh",
+    )
+}
+
+fn git_text<const N: usize>(
+    source: &Path,
+    args: [&str; N],
+) -> Result<String, Box<dyn std::error::Error>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(source)
+        .args(args)
+        .output()?;
+    if !output.status.success() {
+        return Err(command_error("git", &output).into());
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_string())
+}
+
+fn run_checked(
+    command: &mut Command,
+    label: &'static str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output = command.output()?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(command_error(label, &output).into())
+}
+
+fn command_error(label: &str, output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        format!("exit status {}", output.status)
+    };
+    format!("{label} failed: {detail}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_source_prefers_airc_dir() {
+        temp_env::with_vars(
+            [
+                ("AIRC_DIR", Some("/tmp/custom-airc")),
+                ("HOME", Some("/tmp/home")),
+            ],
+            || {
+                assert_eq!(
+                    install_source_dir().unwrap(),
+                    PathBuf::from("/tmp/custom-airc")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn install_source_defaults_to_home_airc_src() {
+        temp_env::with_vars(
+            [
+                ("AIRC_DIR", None::<&str>),
+                ("HOME", Some("/tmp/home")),
+                ("USERPROFILE", Some("/tmp/userprofile")),
+            ],
+            || {
+                assert_eq!(
+                    install_source_dir().unwrap(),
+                    PathBuf::from("/tmp/home/.airc/src")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn validate_source_requires_git_checkout() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let error = validate_source_checkout(temp.path())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("No git checkout"));
+    }
+}

--- a/install.sh
+++ b/install.sh
@@ -24,10 +24,9 @@ _default_clone_dir() {
 }
 
 CLONE_DIR="${AIRC_DIR:-$(_default_clone_dir)}"
-# BIN_DIR holds a tiny command shim. The shim execs $HOME/.airc/src/airc
-# so the canonical source command remains the single implementation,
-# while agent/non-interactive shells that already have ~/.local/bin on
-# PATH can still run plain `airc` without sourcing shell rc files.
+# BIN_DIR holds the installed Rust binary copied from CLONE_DIR.
+# PATH points at this stable binary, not at mutable source-tree build
+# artifacts and not at a shell wrapper.
 BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
 SKILLS_TARGET="${SKILLS_TARGET:-$HOME/.claude/skills}"
 

--- a/test/public_installed_runtime_proof.sh
+++ b/test/public_installed_runtime_proof.sh
@@ -37,6 +37,8 @@ fi
 
 # Clap exposes the version via `--version`, not a `version` subcommand.
 "$AIRC_BIN" --version >/dev/null || fail "airc --version failed"
+"$AIRC_BIN" update --help >/dev/null \
+  || fail "installed airc missing update command"
 "$AIRC_BIN" codex-hook poll --help >/dev/null \
   || fail "installed airc missing codex mid-turn poll command"
 


### PR DESCRIPTION
## Summary
- add `airc update` with `upgrade`/`pull` aliases to fast-forward the installed source checkout and refresh the installed binary + skills from the same install path
- keep update scoped to the checked-out source tree (`AIRC_DIR` or `~/.airc/src`) with fail-loud errors for detached/non-git installs
- extend the public installed runtime proof so missing `airc update` fails CI
- clean stale installer wording that still described the removed shim model

## Design docs
- `docs/architecture/GRID-SUBSTRATE-AUDIT.md`
- `docs/rust-substrate-grievances-and-gaps.md`

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-cli --check`
- `cargo test --manifest-path Cargo.toml -p airc-cli update_commands`
- `bash -n install.sh test/public_installed_runtime_proof.sh`
- `cargo check --manifest-path Cargo.toml -p airc-cli`
- `cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings`
- `cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- update --help`
- `AIRC_BIN="$PWD/target/debug/airc" AIRC_EXPECT_BIN="$PWD/target/debug/airc" bash test/public_installed_runtime_proof.sh`
- `cargo test --manifest-path Cargo.toml -p airc-cli --test operational_dogfood --test codex_hook_commands`
- `test/rust_cutover_guard.sh`
- `cargo test --manifest-path Cargo.toml --workspace`