### PR TITLE
perf(lib): use set-backed event dedup

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -19,7 +19,7 @@
 //! # Ok(()) }
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -32,6 +32,7 @@ use airc_store::{EventStore, SqliteEventStore};
 use airc_transport::LanTcpAdapter;
 use tokio::sync::{broadcast, Mutex};
 
+use crate::broadcast_deduper::BroadcastDeduper;
 use crate::error::AircError;
 use crate::join_context::JoinContext;
 use crate::mesh_identity;
@@ -143,7 +144,7 @@ pub(crate) struct AircInner {
     /// local identity row, so two processes on the same AIRC_HOME
     /// share it and the equality check would (incorrectly) suppress
     /// the cross-process peer's frames as "our own."
-    pub(crate) recently_broadcast: std::sync::Mutex<std::collections::VecDeque<airc_core::EventId>>,
+    pub(crate) recently_broadcast: std::sync::Mutex<BroadcastDeduper>,
 }
 
 /// Capacity of the recently-broadcast ring. Sized to a multiple of
@@ -206,12 +207,11 @@ impl Airc {
         registry
             .enrol(identity.peer_id, 0, identity.keypair.public_bytes())
             .map_err(|e| AircError::Crypto(e.to_string()))?;
-        let mut enrolled = vec![identity.peer_id];
+        let mut enrolled = HashSet::from([identity.peer_id]);
         for stored in load_peer_registries(&home, &wire_root).await? {
-            if enrolled.contains(&stored.peer_id) {
+            if !enrolled.insert(stored.peer_id) {
                 continue;
             }
-            enrolled.push(stored.peer_id);
             registry
                 .enrol(
                     stored.peer_id,
@@ -243,9 +243,9 @@ impl Airc {
                 lan_subscriber: Mutex::new(None),
                 subscribers: Mutex::new(HashMap::new()),
                 live_tx,
-                recently_broadcast: std::sync::Mutex::new(
-                    std::collections::VecDeque::with_capacity(RECENTLY_BROADCAST_CAPACITY),
-                ),
+                recently_broadcast: std::sync::Mutex::new(BroadcastDeduper::with_capacity(
+                    RECENTLY_BROADCAST_CAPACITY,
+                )),
             }),
         })
     }
@@ -258,14 +258,7 @@ impl Airc {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        if ring.contains(&event_id) {
-            return false;
-        }
-        if ring.len() >= RECENTLY_BROADCAST_CAPACITY {
-            ring.pop_front();
-        }
-        ring.push_back(event_id);
-        true
+        ring.mark(event_id)
     }
 
     /// Return the home directory backing this handle.
@@ -305,7 +298,7 @@ impl Airc {
             lan_subscriber: Mutex::new(None),
             subscribers: Mutex::new(HashMap::new()),
             live_tx: self.inner.live_tx.clone(),
-            recently_broadcast: std::sync::Mutex::new(std::collections::VecDeque::with_capacity(
+            recently_broadcast: std::sync::Mutex::new(BroadcastDeduper::with_capacity(
                 RECENTLY_BROADCAST_CAPACITY,
             )),
         };

--- a/crates/airc-lib/src/broadcast_deduper.rs
+++ b/crates/airc-lib/src/broadcast_deduper.rs
@@ -1,0 +1,63 @@
+use std::collections::{HashSet, VecDeque};
+
+use airc_core::EventId;
+
+/// Bounded O(1) duplicate guard for events already fanned out by this process.
+pub(crate) struct BroadcastDeduper {
+    capacity: usize,
+    order: VecDeque<EventId>,
+    seen: HashSet<EventId>,
+}
+
+impl BroadcastDeduper {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            capacity,
+            order: VecDeque::with_capacity(capacity),
+            seen: HashSet::with_capacity(capacity),
+        }
+    }
+
+    /// Mark `event_id` as seen. Returns true only for the first mark.
+    pub(crate) fn mark(&mut self, event_id: EventId) -> bool {
+        if self.seen.contains(&event_id) {
+            return false;
+        }
+        if self.capacity == 0 {
+            return true;
+        }
+        if self.order.len() >= self.capacity {
+            if let Some(expired) = self.order.pop_front() {
+                self.seen.remove(&expired);
+            }
+        }
+        self.order.push_back(event_id);
+        self.seen.insert(event_id);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duplicate_marks_are_rejected() {
+        let event = EventId::from_u128(1);
+        let mut deduper = BroadcastDeduper::with_capacity(4);
+
+        assert!(deduper.mark(event));
+        assert!(!deduper.mark(event));
+    }
+
+    #[test]
+    fn expired_marks_can_be_seen_again() {
+        let first = EventId::from_u128(1);
+        let mut deduper = BroadcastDeduper::with_capacity(2);
+
+        assert!(deduper.mark(first));
+        assert!(deduper.mark(EventId::from_u128(2)));
+        assert!(deduper.mark(EventId::from_u128(3)));
+        assert!(deduper.mark(first));
+    }
+}

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -36,6 +36,7 @@
 
 pub mod account_registry;
 pub mod airc;
+mod broadcast_deduper;
 pub mod command_bus;
 pub mod coordinator;
 mod daemon;

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -330,10 +330,11 @@ five concrete hotpaths and seven kill-list patterns.
    With N=50 subscribers, ~10 µs/event in clones alone. Subsumed
    by Top #2 once events go through Arc.
 
-5. **Linear peer dedup at startup** — `airc.rs:204-209`.
-   `enrolled.contains()` on a `Vec` is O(N²) during init. At N=500
-   peers (large org grid), ~250 µs per Airc::open. Fix: HashSet,
-   not Vec.
+5. **Linear peer dedup at startup** — closed by the set-backed dedup
+   cut. `Airc::open` uses a `HashSet` while loading peer trust rows,
+   and the live broadcast duplicate guard uses `BroadcastDeduper`
+   (`VecDeque` eviction + `HashSet` membership) instead of scanning
+   the whole recent-event ring on every ingest.
 
 ### Substrate-wide patterns to kill (priority order)
 


### PR DESCRIPTION
## Summary
- add an explicit BroadcastDeduper with FIFO eviction plus HashSet membership
- replace Airc::open peer enrollment Vec scan with HashSet dedup
- update docs/architecture/GRID-SUBSTRATE-AUDIT.md Phase 3.6 to mark linear dedup addressed

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib
- cargo test --manifest-path Cargo.toml -p airc-lib broadcast_deduper -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-lib cross_instance_send_reaches_receiver_subscribe_stream -- --nocapture
- cargo test --manifest-path Cargo.toml --workspace
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings