### PR TITLE
perf(lib): broadcast live events by arc

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -606,8 +606,9 @@ async fn print_event_stream_until_signal<S>(
     stream: &mut S,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    S: futures::stream::Stream<Item = Result<airc_core::TranscriptEvent, airc_lib::LiveLag>>
-        + Unpin,
+    S: futures::stream::Stream<
+            Item = Result<std::sync::Arc<airc_core::TranscriptEvent>, airc_lib::LiveLag>,
+        > + Unpin,
 {
     let sigint = tokio::signal::ctrl_c();
     let mut sigint = Box::pin(sigint);

--- a/crates/airc-cli/src/integrations/codex/hook.rs
+++ b/crates/airc-cli/src/integrations/codex/hook.rs
@@ -130,7 +130,7 @@ async fn wait_for_one_event(
 ) -> Result<Vec<TranscriptEvent>, Box<dyn std::error::Error>> {
     let mut stream = airc.subscribe_subscribed_filtered(filter).await?;
     match tokio::time::timeout(Duration::from_millis(wait_ms), stream.next()).await {
-        Ok(Some(Ok(event))) => Ok(vec![event]),
+        Ok(Some(Ok(event))) => Ok(vec![event.as_ref().clone()]),
         Ok(Some(Err(LiveLag { .. }))) | Ok(None) | Err(_) => Ok(Vec::new()),
     }
 }

--- a/crates/airc-cli/src/join_feed.rs
+++ b/crates/airc-cli/src/join_feed.rs
@@ -9,6 +9,7 @@
 use airc_core::{Body, TranscriptEvent};
 use airc_lib::{Airc, EventFilter, LiveLag};
 use futures::stream::StreamExt;
+use std::sync::Arc;
 
 const CONSUMER_PREFIX: &str = "join-feed";
 const CATCH_UP_LIMIT: usize = 64;
@@ -63,7 +64,7 @@ async fn print_stream_advancing_cursor<S>(
     consumer_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    S: futures::stream::Stream<Item = Result<TranscriptEvent, LiveLag>> + Unpin,
+    S: futures::stream::Stream<Item = Result<Arc<TranscriptEvent>, LiveLag>> + Unpin,
 {
     let sigint = tokio::signal::ctrl_c();
     let mut sigint = Box::pin(sigint);

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -171,7 +171,10 @@ fn work_board_empty_state_is_explicit() {
 }
 
 fn run_ok(home: &Path, args: &[&str]) -> String {
+    let machine_home = home.parent().unwrap_or(home);
     let output = Command::new(airc_core())
+        .env("HOME", machine_home)
+        .env("USERPROFILE", machine_home)
         .arg("--home")
         .arg(home)
         .args(args)

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -104,7 +104,7 @@ pub(crate) async fn load_peer_registries(
 ///   - `Airc::join(name)` / `Airc::say(text)` lazily start a
 ///     subscriber on the room's wire if one isn't already running.
 ///   - Consumers wanting live push call `Airc::subscribe()` and
-///     get a `Stream<Item = TranscriptEvent>`.
+///     get a `Stream<Item = Arc<TranscriptEvent>>`.
 #[derive(Clone)]
 pub struct Airc {
     pub(crate) inner: Arc<AircInner>,
@@ -132,7 +132,7 @@ pub(crate) struct AircInner {
     /// Live event fan-out. Every event the subscribers append to the
     /// store is also forwarded here so consumers tailing via
     /// [`Airc::subscribe`] see it immediately.
-    pub(crate) live_tx: broadcast::Sender<TranscriptEvent>,
+    pub(crate) live_tx: broadcast::Sender<Arc<TranscriptEvent>>,
     /// Event IDs this Airc instance has already broadcast via
     /// [`live_tx`]. Consulted by the wire subscriber to avoid
     /// double-delivering a send that was already broadcast in-process

--- a/crates/airc-lib/src/command_bus.rs
+++ b/crates/airc-lib/src/command_bus.rs
@@ -234,7 +234,7 @@ impl Airc {
                     if event.headers.get(HEADER_AIRC_CORRELATION_ID) == Some(&correlation)
                         && event.peer_id != self.inner.identity.peer_id
                     {
-                        return Ok(event);
+                        return Ok(event.as_ref().clone());
                     }
                     // Some other event flowed through; keep waiting.
                 }

--- a/crates/airc-lib/src/lifecycle.rs
+++ b/crates/airc-lib/src/lifecycle.rs
@@ -140,7 +140,7 @@ impl Airc {
         match persist_result {
             Ok(()) | Err(airc_store::StoreError::DuplicateEventId(_)) => {
                 if self.mark_broadcast(event_id) {
-                    let _ = self.inner.live_tx.send(event);
+                    let _ = self.inner.live_tx.send(std::sync::Arc::new(event));
                 }
                 Ok(())
             }

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -1,5 +1,6 @@
 use airc_core::{Body, EventId, Headers, MentionTarget, TranscriptCursor, TranscriptEvent};
 use airc_protocol::{Envelope, Frame, FrameKind, Signature};
+use std::sync::Arc;
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::error::AircError;
@@ -123,7 +124,7 @@ impl Airc {
         match persist_result {
             Ok(()) | Err(airc_store::StoreError::DuplicateEventId(_)) => {
                 if self.mark_broadcast(event_id) {
-                    let _ = self.inner.live_tx.send(event);
+                    let _ = self.inner.live_tx.send(Arc::new(event));
                 }
                 Ok(())
             }

--- a/crates/airc-lib/src/stream.rs
+++ b/crates/airc-lib/src/stream.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use airc_core::transcript::TranscriptKind;
@@ -9,11 +10,11 @@ use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
 
 /// Live transcript-event stream returned by `Airc::subscribe`.
 pub struct EventStream {
-    pub(crate) inner: BroadcastStream<TranscriptEvent>,
+    pub(crate) inner: BroadcastStream<Arc<TranscriptEvent>>,
 }
 
 impl Stream for EventStream {
-    type Item = Result<TranscriptEvent, LiveLag>;
+    type Item = Result<Arc<TranscriptEvent>, LiveLag>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -98,7 +99,7 @@ pub struct FilteredEventStream {
 }
 
 impl Stream for FilteredEventStream {
-    type Item = Result<TranscriptEvent, LiveLag>;
+    type Item = Result<Arc<TranscriptEvent>, LiveLag>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -106,7 +107,7 @@ impl Stream for FilteredEventStream {
             match Pin::new(&mut this.inner).poll_next(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Some(Ok(event))) => {
-                    if this.filter.matches(&event) {
+                    if this.filter.matches(event.as_ref()) {
                         return Poll::Ready(Some(Ok(event)));
                     }
                 }

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use airc_core::{EventId, TranscriptCursor};
 use airc_protocol::{Frame, Subscription};
@@ -274,7 +275,7 @@ impl Airc {
         match self.inner.store.append(event.clone()).await {
             Ok(()) | Err(airc_store::StoreError::DuplicateEventId(_)) => {
                 if self.mark_broadcast(event_id) {
-                    let _ = self.inner.live_tx.send(event);
+                    let _ = self.inner.live_tx.send(Arc::new(event));
                 }
             }
             Err(err) => {

--- a/crates/examples/embedded_consumer_smoke/src/agent.rs
+++ b/crates/examples/embedded_consumer_smoke/src/agent.rs
@@ -158,7 +158,7 @@ impl AgentInbox {
             let event = tokio::time::timeout(remaining, self.stream.next()).await;
             match event {
                 Ok(Some(Ok(event))) if self.owner.is_own_event(&event) => continue,
-                Ok(Some(Ok(event))) => return Ok(Some(event)),
+                Ok(Some(Ok(event))) => return Ok(Some(event.as_ref().clone())),
                 Ok(Some(Err(lag))) => return Err(AircError::Route(lag.to_string())),
                 Ok(None) => return Ok(None),
                 Err(_) => return Ok(None),

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -314,11 +314,11 @@ five concrete hotpaths and seven kill-list patterns.
    Remaining file-backed surfaces are install/config compatibility
    helpers and remote wire payloads, not the local runtime truth.
 
-2. **Double clone of `TranscriptEvent` on every ingest** —
-   `messaging.rs:110`, `transport.rs:124`. Each event is cloned
-   for store and again for broadcast. ~100–200 ns × N events/sec,
-   plus allocator churn. Fix: `Arc<TranscriptEvent>` internally;
-   broadcast becomes `Arc::clone` (cheap).
+2. **Double clone of `TranscriptEvent` on every ingest** — closed by
+   the Arc live-event cut. Store append still receives the owned
+   event it persists, but live fan-out now broadcasts
+   `Arc<TranscriptEvent>` so subscriber delivery is pointer clone
+   rather than full event clone.
 
 3. **`RwLock<PeerKeyRegistry>` at process-global granularity** —
    `airc.rs:118`, `transport/signed.rs:135-145`. Every frame
@@ -326,9 +326,11 @@ five concrete hotpaths and seven kill-list patterns.
    many-peer grid, that's 5–25 ms/s of contention. Fix: `DashMap`
    (sharded concurrent map, no global lock).
 
-4. **`event.clone()` on broadcast fan-out** — `messaging.rs:114`.
-   With N=50 subscribers, ~10 µs/event in clones alone. Subsumed
-   by Top #2 once events go through Arc.
+4. **`event.clone()` on broadcast fan-out** — closed with Top #2.
+   `EventStream` and `FilteredEventStream` now yield
+   `Arc<TranscriptEvent>`; owned clones happen only at explicit
+   compatibility boundaries such as command-bus reply return values
+   and hook batch vectors.
 
 5. **Linear peer dedup at startup** — closed by the set-backed dedup
    cut. `Airc::open` uses a `HashSet` while loading peer trust rows,


### PR DESCRIPTION
## Summary
- change live broadcast fan-out to carry Arc<TranscriptEvent> instead of cloning full events per receiver
- keep owned TranscriptEvent clones only at explicit compatibility boundaries such as command-bus replies, hook batches, and embedded consumer inbox return values
- update docs/architecture/GRID-SUBSTRATE-AUDIT.md Phase 3.6 to mark the clone/fan-out hot path addressed

## Verification
- cargo check --manifest-path Cargo.toml -p airc-lib -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-lib subscribe_yields_live_events_in_order -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-lib cross_instance_send_reaches_receiver_subscribe_stream -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-lib request_and_reply_round_trip_via_shared_wire -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli codex_hook_poll_waits_for_one_new_event -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli join_without_args_uses_default_account_context -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli monitor_attach_streams_rust_events_without_legacy_log -- --nocapture
- cargo test --manifest-path Cargo.toml --workspace
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings