### PR TITLE
perf(protocol): remove global peer registry lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ version = "0.1.0"
 dependencies = [
  "airc-core",
  "ciborium",
+ "dashmap",
  "ed25519-dalek",
  "rand 0.8.6",
  "serde",
@@ -879,6 +880,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1369,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -15,7 +15,6 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
-use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
 use airc_core::{ClientId, EventId, PeerId, TranscriptCursor};
@@ -663,8 +662,8 @@ async fn build_combined_registry(
     home: &Path,
     identity: &LocalIdentity,
     adhoc: &[PeerSpec],
-) -> Result<Arc<RwLock<PeerKeyRegistry>>, Box<dyn std::error::Error>> {
-    let mut registry = PeerKeyRegistry::new();
+) -> Result<Arc<PeerKeyRegistry>, Box<dyn std::error::Error>> {
+    let registry = PeerKeyRegistry::new();
     registry.enrol(identity.peer_id, 0, identity.keypair.public_bytes())?;
     for stored in peers_store::load(home).await? {
         registry.enrol(stored.peer_id, 0, stored.pubkey_bytes()?)?;
@@ -672,7 +671,7 @@ async fn build_combined_registry(
     for spec in adhoc {
         registry.enrol(spec.peer_id, 0, spec.pubkey)?;
     }
-    Ok(Arc::new(RwLock::new(registry)))
+    Ok(Arc::new(registry))
 }
 
 /// `peer add <spec>` — persist a peer to the trust store via

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -14,6 +14,8 @@ use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 
+const JOIN_ATTACH_TIMEOUT: Duration = Duration::from_secs(30);
+
 fn airc_core() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
 }
@@ -162,7 +164,7 @@ fn join_without_args_uses_default_account_context() {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     strip_cargo_harness_env(&mut join);
-    let stdout = run_join_until_attached(join, Duration::from_secs(10)).join("\n");
+    let stdout = run_join_until_attached(join, JOIN_ATTACH_TIMEOUT).join("\n");
     assert!(stdout.contains("#general"), "{stdout}");
     assert!(stdout.contains("#cambriantech"), "{stdout}");
     assert!(stdout.contains("default: #cambriantech"), "{stdout}");
@@ -206,7 +208,7 @@ fn join_sets_up_codex_hook_when_codex_home_exists() {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     strip_cargo_harness_env(&mut join);
-    let stdout = run_join_until_attached(join, Duration::from_secs(10)).join("\n");
+    let stdout = run_join_until_attached(join, JOIN_ATTACH_TIMEOUT).join("\n");
     assert!(
         stdout.contains("runtime: installed AIRC UserPromptSubmit hook"),
         "{stdout}"

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -178,15 +178,7 @@ async fn handle_add_peer(state: Arc<DaemonState>, add: AddPeerRequest) -> Respon
     }
     let mut pubkey = [0u8; 32];
     pubkey.copy_from_slice(&bytes);
-    let mut registry = match state.registry.write() {
-        Ok(guard) => guard,
-        Err(_) => {
-            return Response::Error {
-                message: "add_peer: registry lock poisoned".to_string(),
-            };
-        }
-    };
-    if let Err(error) = registry.enrol(add.peer_id, 0, pubkey) {
+    if let Err(error) = state.registry.enrol(add.peer_id, 0, pubkey) {
         return Response::Error {
             message: format!("add_peer: enrol: {error}"),
         };
@@ -195,15 +187,7 @@ async fn handle_add_peer(state: Arc<DaemonState>, add: AddPeerRequest) -> Respon
 }
 
 async fn handle_remove_peer(state: Arc<DaemonState>, remove: RemovePeerRequest) -> Response {
-    let mut registry = match state.registry.write() {
-        Ok(guard) => guard,
-        Err(_) => {
-            return Response::Error {
-                message: "remove_peer: registry lock poisoned".to_string(),
-            };
-        }
-    };
-    registry.remove_peer(remove.peer_id);
+    state.registry.remove_peer(remove.peer_id);
     Response::Ok
 }
 
@@ -271,15 +255,14 @@ mod tests {
     use airc_core::PeerId;
     use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
     use std::path::PathBuf;
-    use std::sync::RwLock;
     use uuid::Uuid;
 
     fn test_state() -> Arc<DaemonState> {
         let peer_id = PeerId::from_u128(0xa1);
         let keypair = PeerKeypair::generate();
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry.enrol(peer_id, 0, keypair.public_bytes()).unwrap();
-        let registry = Arc::new(RwLock::new(registry));
+        let registry = Arc::new(registry);
         // Test home is fresh per-call — empty peer trust store is
         // fine for dispatcher tests; no preexisting state required.
         let home = tempfile::TempDir::new().unwrap();
@@ -387,7 +370,7 @@ mod tests {
             .await,
             Response::Ok
         );
-        assert!(state.registry.read().unwrap().lookup(peer_id, 0).is_some());
+        assert!(state.registry.lookup(peer_id, 0).is_some());
 
         assert_eq!(
             dispatch(
@@ -397,7 +380,7 @@ mod tests {
             .await,
             Response::Ok
         );
-        assert!(state.registry.read().unwrap().lookup(peer_id, 0).is_none());
+        assert!(state.registry.lookup(peer_id, 0).is_none());
     }
 
     // Pull PathBuf into scope so the import isn't unused when only

--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -271,15 +271,14 @@ mod tests {
     use crate::ipc::client::DaemonClient;
     use airc_core::PeerId;
     use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
-    use std::sync::RwLock;
     use std::time::Duration;
 
     fn fresh_state() -> Arc<DaemonState> {
         let peer_id = PeerId::from_u128(0xa1);
         let keypair = PeerKeypair::generate();
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry.enrol(peer_id, 0, keypair.public_bytes()).unwrap();
-        let registry = Arc::new(RwLock::new(registry));
+        let registry = Arc::new(registry);
         // Test home — leaked so it lives until process exit.
         let home = tempfile::TempDir::new().unwrap();
         let home_path = home.path().to_path_buf();

--- a/crates/airc-daemon/src/state.rs
+++ b/crates/airc-daemon/src/state.rs
@@ -4,7 +4,7 @@
 //! `DaemonState` is constructed once at startup and passed (via Arc)
 //! to every per-connection handler. Handlers read fields directly;
 //! the substrate enforces its own internal locking (e.g.
-//! `PeerKeyRegistry` is wrapped in `Arc<RwLock>`).
+//! `PeerKeyRegistry` owns its own concurrent map).
 //!
 //! Slice 5b: the per-wire `InboxBuffer` ring is gone. Subscribers now
 //! convert each received `Frame` into a `TranscriptEvent` and append
@@ -15,7 +15,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::RwLock;
 use std::time::Instant;
 
 use tokio::sync::{broadcast, Mutex, Notify};
@@ -31,7 +30,7 @@ use airc_transport::{LocalFsAdapter, SignedTransport};
 pub struct DaemonState {
     pub peer_id: PeerId,
     pub keypair: PeerKeypair,
-    pub registry: Arc<RwLock<PeerKeyRegistry>>,
+    pub registry: Arc<PeerKeyRegistry>,
     pub policy: VerificationPolicy,
     /// Home directory the daemon was started against. Lets handlers
     /// reach the store and IPC state without re-deriving the path.
@@ -64,7 +63,7 @@ impl DaemonState {
     pub fn new(
         peer_id: PeerId,
         keypair: PeerKeypair,
-        registry: Arc<RwLock<PeerKeyRegistry>>,
+        registry: Arc<PeerKeyRegistry>,
         policy: VerificationPolicy,
         home: PathBuf,
         event_store: Arc<dyn EventStore>,

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -117,7 +117,7 @@ pub(crate) struct AircInner {
     pub(crate) store: Arc<dyn EventStore>,
     pub(crate) coordinator_store: Arc<dyn EventStore>,
     pub(crate) daemon_client: Option<Arc<DaemonClient>>,
-    pub(crate) registry: Arc<RwLock<PeerKeyRegistry>>,
+    pub(crate) registry: Arc<PeerKeyRegistry>,
     pub(crate) policy: VerificationPolicy,
     pub(crate) route_health: RwLock<TransportHealthTable>,
     pub(crate) route_endpoints: RwLock<RouteEndpointTable>,
@@ -203,7 +203,7 @@ impl Airc {
         let coordinator_store: Arc<dyn EventStore> =
             Arc::new(SqliteEventStore::open_path(&coordinator_store_path).await?);
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = Arc::new(PeerKeyRegistry::new());
         registry
             .enrol(identity.peer_id, 0, identity.keypair.public_bytes())
             .map_err(|e| AircError::Crypto(e.to_string()))?;
@@ -222,7 +222,6 @@ impl Airc {
                 )
                 .map_err(|e| AircError::Crypto(e.to_string()))?;
         }
-        let registry = Arc::new(RwLock::new(registry));
         let (live_tx, _) = broadcast::channel(LIVE_BROADCAST_CAPACITY);
 
         Ok(Self {
@@ -359,13 +358,9 @@ impl Airc {
 
     pub(crate) async fn sync_account_peer_registry(&self) -> Result<(), AircError> {
         let peers = load_peer_registries(&self.inner.home, &self.inner.wire_root).await?;
-        let mut registry = self
-            .inner
-            .registry
-            .write()
-            .map_err(|_| AircError::Crypto("registry lock poisoned".to_string()))?;
         for peer in peers {
-            registry
+            self.inner
+                .registry
                 .enrol(
                     peer.peer_id,
                     0,

--- a/crates/airc-lib/src/peers.rs
+++ b/crates/airc-lib/src/peers.rs
@@ -42,14 +42,7 @@ impl Airc {
         };
         let removed = removed_home.or(removed_wire_root).is_some();
 
-        {
-            let mut registry = self
-                .inner
-                .registry
-                .write()
-                .map_err(|_| AircError::Crypto("registry lock poisoned".to_string()))?;
-            registry.remove_peer(peer_id);
-        }
+        self.inner.registry.remove_peer(peer_id);
 
         if !removed {
             return Ok(false);
@@ -110,12 +103,8 @@ impl Airc {
     /// Enrol a peer in the in-memory trust registry without writing
     /// durable peer trust state.
     pub fn enrol_volatile_peer(&self, spec: &PeerSpec) -> Result<(), AircError> {
-        let mut registry = self
-            .inner
+        self.inner
             .registry
-            .write()
-            .map_err(|_| AircError::Crypto("registry lock poisoned".to_string()))?;
-        registry
             .enrol(spec.peer_id, 0, spec.pubkey)
             .map_err(|e| AircError::Crypto(e.to_string()))?;
         Ok(())

--- a/crates/airc-lib/src/registry.rs
+++ b/crates/airc-lib/src/registry.rs
@@ -8,7 +8,6 @@
 
 use std::str::FromStr;
 use std::sync::Arc;
-use std::sync::RwLock;
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
@@ -93,13 +92,13 @@ pub fn build_registry(
     self_peer_id: PeerId,
     self_pubkey: [u8; 32],
     peer_specs: &[PeerSpec],
-) -> Result<Arc<RwLock<PeerKeyRegistry>>, airc_protocol::KeyError> {
-    let mut registry = PeerKeyRegistry::new();
+) -> Result<Arc<PeerKeyRegistry>, airc_protocol::KeyError> {
+    let registry = PeerKeyRegistry::new();
     registry.enrol(self_peer_id, 0, self_pubkey)?;
     for spec in peer_specs {
         registry.enrol(spec.peer_id, 0, spec.pubkey)?;
     }
-    Ok(Arc::new(RwLock::new(registry)))
+    Ok(Arc::new(registry))
 }
 
 /// Encode a pubkey as a `--peer` argument tail (`<id>:<b64>`), for
@@ -156,7 +155,6 @@ mod tests {
             pubkey: other_kp.public_bytes(),
         };
         let registry = build_registry(self_id, self_kp.public_bytes(), &[spec]).unwrap();
-        let registry = registry.read().unwrap();
         assert!(registry.lookup(self_id, 0).is_some());
         assert!(registry.lookup(other_id, 0).is_some());
     }

--- a/crates/airc-lib/src/wire_replay.rs
+++ b/crates/airc-lib/src/wire_replay.rs
@@ -44,14 +44,7 @@ impl Airc {
                     continue;
                 }
             };
-            let verify_result = {
-                let registry = self
-                    .inner
-                    .registry
-                    .read()
-                    .map_err(|_| AircError::Crypto("registry lock poisoned".to_string()))?;
-                verify(&frame, self.inner.policy, &registry)
-            };
+            let verify_result = verify(&frame, self.inner.policy, self.inner.registry.as_ref());
             if let Err(error) = verify_result {
                 // Same fail-open policy as `spawn_frame_ingest` in
                 // transport.rs:91. The most common case is a frame

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -75,7 +75,7 @@ fn unique_socket() -> std::path::PathBuf {
 
 async fn spawn_daemon(home: &std::path::Path) -> (tokio::task::JoinHandle<()>, std::path::PathBuf) {
     let identity = LocalIdentity::load_or_generate(home).await.unwrap();
-    let mut registry = PeerKeyRegistry::new();
+    let registry = PeerKeyRegistry::new();
     registry
         .enrol(identity.peer_id, 0, identity.keypair.public_bytes())
         .unwrap();
@@ -87,7 +87,7 @@ async fn spawn_daemon(home: &std::path::Path) -> (tokio::task::JoinHandle<()>, s
     let state = std::sync::Arc::new(DaemonState::new(
         identity.peer_id,
         identity.keypair,
-        std::sync::Arc::new(std::sync::RwLock::new(registry)),
+        std::sync::Arc::new(registry),
         VerificationPolicy::Strict,
         home.to_path_buf(),
         store,

--- a/crates/airc-protocol/Cargo.toml
+++ b/crates/airc-protocol/Cargo.toml
@@ -13,5 +13,6 @@ airc-core = { path = "../airc-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ciborium = "0.2"
+dashmap = "6"
 ed25519-dalek = "2"
 rand = "0.8"

--- a/crates/airc-protocol/src/keypair.rs
+++ b/crates/airc-protocol/src/keypair.rs
@@ -170,7 +170,7 @@ mod tests {
         let mut envelope = envelope_fixture(peer);
         envelope.signature = keypair.sign_envelope(&envelope, peer, 0).unwrap();
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
 
         let frame = Frame {
@@ -189,7 +189,7 @@ mod tests {
         let mut envelope = envelope_fixture(peer);
         envelope.signature = keypair.sign_envelope(&envelope, peer, 0).unwrap();
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
 
         // Tamper with the body — substantive content change.
@@ -216,7 +216,7 @@ mod tests {
         envelope.signature = keypair.sign_envelope(&envelope, peer, 0).unwrap();
         envelope.lamport = 999;
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
 
         let frame = Frame {
@@ -238,7 +238,7 @@ mod tests {
         let mut envelope = envelope_fixture(peer);
         envelope.signature = keypair.sign_envelope(&envelope, peer, 0).unwrap();
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
 
         envelope
@@ -265,7 +265,7 @@ mod tests {
         let mut envelope = envelope_fixture(peer);
         envelope.signature = keypair.sign_envelope(&envelope, peer, 0).unwrap();
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
 
         envelope.reply_to = Some(EventId::from_u128(0x99));
@@ -291,7 +291,7 @@ mod tests {
         let mut envelope = envelope_fixture(peer);
         envelope.signature = real_keypair.sign_envelope(&envelope, peer, 0).unwrap();
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry
             .enrol(peer, 0, imposter_keypair.public_bytes())
             .unwrap();
@@ -338,7 +338,7 @@ mod tests {
         let old_keypair = PeerKeypair::generate();
         let new_keypair = PeerKeypair::generate();
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry.enrol(peer, 0, old_keypair.public_bytes()).unwrap();
         registry.enrol(peer, 1, new_keypair.public_bytes()).unwrap();
 

--- a/crates/airc-protocol/src/signature.rs
+++ b/crates/airc-protocol/src/signature.rs
@@ -98,17 +98,16 @@ impl std::error::Error for KeyError {
 /// bytes once at enrolment time.
 #[derive(Debug, Default, Clone)]
 pub struct PeerKeyRegistry {
-    // HashMap rather than BTreeMap — PeerId is a UUIDv4 newtype which
-    // derives Hash+Eq but not Ord. The registry isn't serialized or
-    // iterated for canonical output, so non-deterministic key order is
-    // harmless here.
-    keys: std::collections::HashMap<(PeerId, u32), VerifyingKey>,
+    // Sharded storage keeps verification from taking a process-global
+    // read lock. The registry is not serialized or iterated for
+    // canonical output, so non-deterministic key order is harmless.
+    keys: dashmap::DashMap<(PeerId, u32), VerifyingKey>,
 }
 
 impl PeerKeyRegistry {
     pub fn new() -> Self {
         Self {
-            keys: std::collections::HashMap::new(),
+            keys: dashmap::DashMap::new(),
         }
     }
 
@@ -117,7 +116,7 @@ impl PeerKeyRegistry {
     /// Returns `KeyError::InvalidPublicKey` if the bytes don't
     /// decode as a valid Ed25519 point — substrate refuses garbage
     /// at enrolment rather than at verify time.
-    pub fn enrol(&mut self, peer: PeerId, key_id: u32, pubkey: [u8; 32]) -> Result<(), KeyError> {
+    pub fn enrol(&self, peer: PeerId, key_id: u32, pubkey: [u8; 32]) -> Result<(), KeyError> {
         let verifying_key =
             VerifyingKey::from_bytes(&pubkey).map_err(KeyError::InvalidPublicKey)?;
         self.keys.insert((peer, key_id), verifying_key);
@@ -125,8 +124,8 @@ impl PeerKeyRegistry {
     }
 
     /// Look up a parsed `VerifyingKey` for verification.
-    pub fn lookup(&self, peer: PeerId, key_id: u32) -> Option<&VerifyingKey> {
-        self.keys.get(&(peer, key_id))
+    pub fn lookup(&self, peer: PeerId, key_id: u32) -> Option<VerifyingKey> {
+        self.keys.get(&(peer, key_id)).map(|entry| *entry)
     }
 
     /// Remove every enrolled key for `peer`.
@@ -134,7 +133,7 @@ impl PeerKeyRegistry {
     /// Used when local trust is explicitly revoked. Returns the
     /// number of key ids removed so callers can distinguish an
     /// idempotent remove from a real departure.
-    pub fn remove_peer(&mut self, peer: PeerId) -> usize {
+    pub fn remove_peer(&self, peer: PeerId) -> usize {
         let before = self.keys.len();
         self.keys
             .retain(|(enrolled_peer, _key_id), _key| *enrolled_peer != peer);
@@ -154,7 +153,8 @@ impl PeerKeyRegistry {
     /// reverse-lookup correctness because we only need to know
     /// whether ANY match exists.
     pub fn find_peer(&self, pubkey: &[u8; 32]) -> Option<(PeerId, u32)> {
-        self.keys.iter().find_map(|((peer, key_id), key)| {
+        self.keys.iter().find_map(|entry| {
+            let ((peer, key_id), key) = entry.pair();
             if key.as_bytes() == pubkey {
                 Some((*peer, *key_id))
             } else {
@@ -423,7 +423,7 @@ mod tests {
         use crate::keypair::PeerKeypair;
         let signer = PeerId::from_u128(0xa1);
         let real_keypair = PeerKeypair::generate();
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry
             .enrol(signer, 0, real_keypair.public_bytes())
             .unwrap();
@@ -529,7 +529,7 @@ mod tests {
         let key_a = PeerKeypair::generate();
         let key_b = PeerKeypair::generate();
         let key_other = PeerKeypair::generate();
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry.enrol(peer, 0, key_a.public_bytes()).unwrap();
         registry.enrol(peer, 1, key_b.public_bytes()).unwrap();
         registry.enrol(other, 0, key_other.public_bytes()).unwrap();

--- a/crates/airc-relay/src/connection.rs
+++ b/crates/airc-relay/src/connection.rs
@@ -50,8 +50,8 @@ fn resolve_peer_from_stream(
     let (_, conn) = tls_stream.get_ref();
     let cert = conn.peer_certificates()?.first()?;
     let pubkey = extract_ed25519_pubkey(cert).ok()?;
-    let registry = inner.registry.read().ok()?;
-    registry
+    inner
+        .registry
         .find_peer(&pubkey)
         .map(|(peer_id, _key_version)| peer_id)
 }

--- a/crates/airc-relay/src/main.rs
+++ b/crates/airc-relay/src/main.rs
@@ -6,7 +6,7 @@
 //! that owns persistent identity and a populated `PeerKeyRegistry`.
 
 use std::net::SocketAddr;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use airc_core::PeerId;
 use airc_protocol::{PeerKeyRegistry, PeerKeypair};
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let peer_id = PeerId::new();
     let keypair = PeerKeypair::generate();
-    let registry = Arc::new(RwLock::new(PeerKeyRegistry::new()));
+    let registry = Arc::new(PeerKeyRegistry::new());
 
     let server = RelayServer::start(RelayServerConfig {
         peer_id,

--- a/crates/airc-relay/src/server.rs
+++ b/crates/airc-relay/src/server.rs
@@ -40,7 +40,7 @@ pub struct RelayServerConfig {
     /// Allowlist of clients permitted to connect. mTLS client cert is
     /// resolved to a `PeerId` via `extract_ed25519_pubkey`; only entries
     /// in this registry may connect. Unknown certs fail-closed.
-    pub registry: Arc<std::sync::RwLock<PeerKeyRegistry>>,
+    pub registry: Arc<PeerKeyRegistry>,
     /// Bind address. `0.0.0.0:0` is allowed in tests to let the OS
     /// pick a free port (the actual address is reported by
     /// [`RelayServer::local_addr`]).
@@ -55,7 +55,7 @@ pub(crate) type OutboundTx = mpsc::Sender<Vec<u8>>;
 /// Shared per-server state. Held inside `Arc` and reachable from the
 /// accept loop and every connection task.
 pub(crate) struct Inner {
-    pub(crate) registry: Arc<std::sync::RwLock<PeerKeyRegistry>>,
+    pub(crate) registry: Arc<PeerKeyRegistry>,
     pub(crate) connections: Mutex<HashMap<PeerId, OutboundTx>>,
 }
 

--- a/crates/airc-relay/tests/round_trip.rs
+++ b/crates/airc-relay/tests/round_trip.rs
@@ -6,7 +6,7 @@
 //! stands in for "we can't reach each other directly").
 
 use std::collections::BTreeSet;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 use futures::StreamExt;
@@ -39,13 +39,12 @@ impl TestIdentity {
     }
 }
 
-fn enrolled_registry(identities: &[&TestIdentity]) -> Arc<RwLock<PeerKeyRegistry>> {
-    let registry = Arc::new(RwLock::new(PeerKeyRegistry::new()));
-    {
-        let mut w = registry.write().unwrap();
-        for id in identities {
-            w.enrol(id.peer_id, 1, id.keypair.public_bytes()).unwrap();
-        }
+fn enrolled_registry(identities: &[&TestIdentity]) -> Arc<PeerKeyRegistry> {
+    let registry = Arc::new(PeerKeyRegistry::new());
+    for id in identities {
+        registry
+            .enrol(id.peer_id, 1, id.keypair.public_bytes())
+            .unwrap();
     }
     registry
 }

--- a/crates/airc-transport/src/lan_tcp/adapter/connection.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/connection.rs
@@ -57,8 +57,10 @@ fn resolve_peer_from_server_stream(
     let certs = tls_stream.get_ref().1.peer_certificates()?;
     let cert = certs.first()?;
     let pubkey = extract_ed25519_pubkey(cert).ok()?;
-    let registry = inner.registry.read().ok()?;
-    registry.find_peer(&pubkey).map(|(peer, _key_id)| peer)
+    inner
+        .registry
+        .find_peer(&pubkey)
+        .map(|(peer, _key_id)| peer)
 }
 
 fn resolve_peer_from_client_stream(
@@ -68,8 +70,10 @@ fn resolve_peer_from_client_stream(
     let certs = tls_stream.get_ref().1.peer_certificates()?;
     let cert = certs.first()?;
     let pubkey = extract_ed25519_pubkey(cert).ok()?;
-    let registry = inner.registry.read().ok()?;
-    registry.find_peer(&pubkey).map(|(peer, _key_id)| peer)
+    inner
+        .registry
+        .find_peer(&pubkey)
+        .map(|(peer, _key_id)| peer)
 }
 
 /// Install the outbound channel into `inner` **before** spawning the

--- a/crates/airc-transport/src/lan_tcp/adapter/inner.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/inner.rs
@@ -9,7 +9,6 @@
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
-use std::sync::RwLock;
 
 use tokio::sync::{mpsc, Mutex};
 
@@ -54,7 +53,7 @@ pub(super) struct SubscriberHandle {
 pub(super) struct Inner {
     pub(super) self_peer_id: PeerId,
     pub(super) keypair: PeerKeypair,
-    pub(super) registry: Arc<RwLock<PeerKeyRegistry>>,
+    pub(super) registry: Arc<PeerKeyRegistry>,
     pub(super) server_config: Arc<rustls::ServerConfig>,
     /// Active connections keyed by remote `PeerId`. Filled by both
     /// the accept loop (server-side handshakes) and `connect()`

--- a/crates/airc-transport/src/lan_tcp/adapter/mod.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/mod.rs
@@ -41,7 +41,6 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::sync::RwLock;
 
 use async_trait::async_trait;
 use futures::stream::Stream;
@@ -71,7 +70,7 @@ impl LanTcpAdapter {
     pub fn new(
         self_peer_id: PeerId,
         keypair: PeerKeypair,
-        registry: Arc<RwLock<PeerKeyRegistry>>,
+        registry: Arc<PeerKeyRegistry>,
     ) -> Result<Self, LanTcpError> {
         let server_config = build_server_config(self_peer_id, &keypair, registry.clone())?;
         Ok(Self {
@@ -310,12 +309,12 @@ mod tests {
         let alice_kp = PeerKeypair::generate();
         let bob_kp = PeerKeypair::generate();
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry
             .enrol(alice_id, 0, alice_kp.public_bytes())
             .unwrap();
         registry.enrol(bob_id, 0, bob_kp.public_bytes()).unwrap();
-        let registry = Arc::new(RwLock::new(registry));
+        let registry = Arc::new(registry);
 
         let alice = LanTcpAdapter::new(alice_id, alice_kp, registry.clone()).unwrap();
         let bob = LanTcpAdapter::new(bob_id, bob_kp, registry).unwrap();
@@ -370,11 +369,11 @@ mod tests {
         ensure_crypto_provider();
         let alice_id = PeerId::from_u128(0xa1);
         let alice_kp = PeerKeypair::generate();
-        let mut alice_registry = PeerKeyRegistry::new();
+        let alice_registry = PeerKeyRegistry::new();
         alice_registry
             .enrol(alice_id, 0, alice_kp.public_bytes())
             .unwrap();
-        let alice_registry = Arc::new(RwLock::new(alice_registry));
+        let alice_registry = Arc::new(alice_registry);
         let alice = LanTcpAdapter::new(alice_id, alice_kp, alice_registry).unwrap();
 
         let stranger_id = PeerId::from_u128(0xdeadbeef);
@@ -390,14 +389,14 @@ mod tests {
             .unwrap();
             extract_ed25519_pubkey(&cert).unwrap()
         };
-        let mut stranger_registry = PeerKeyRegistry::new();
+        let stranger_registry = PeerKeyRegistry::new();
         stranger_registry
             .enrol(alice_id, 0, alice_pub_for_stranger)
             .unwrap();
         stranger_registry
             .enrol(stranger_id, 0, stranger_kp.public_bytes())
             .unwrap();
-        let stranger_registry = Arc::new(RwLock::new(stranger_registry));
+        let stranger_registry = Arc::new(stranger_registry);
         let stranger = LanTcpAdapter::new(stranger_id, stranger_kp, stranger_registry).unwrap();
 
         let bound = alice
@@ -433,7 +432,7 @@ mod tests {
         let bob_kp = PeerKeypair::generate();
         let charlie_kp = PeerKeypair::generate();
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry
             .enrol(alice_id, 0, alice_kp.public_bytes())
             .unwrap();
@@ -441,7 +440,7 @@ mod tests {
         registry
             .enrol(charlie_id, 0, charlie_kp.public_bytes())
             .unwrap();
-        let registry = Arc::new(RwLock::new(registry));
+        let registry = Arc::new(registry);
 
         let alice = LanTcpAdapter::new(alice_id, alice_kp, registry.clone()).unwrap();
         let bob = LanTcpAdapter::new(bob_id, bob_kp, registry.clone()).unwrap();

--- a/crates/airc-transport/src/lan_tcp/tls_config.rs
+++ b/crates/airc-transport/src/lan_tcp/tls_config.rs
@@ -8,7 +8,6 @@
 //! reference.
 
 use std::sync::Arc;
-use std::sync::RwLock;
 
 use rustls::{ClientConfig, ServerConfig};
 
@@ -63,7 +62,7 @@ impl From<rustls::Error> for TlsConfigError {
 pub fn build_server_config(
     peer_id: PeerId,
     keypair: &PeerKeypair,
-    registry: Arc<RwLock<PeerKeyRegistry>>,
+    registry: Arc<PeerKeyRegistry>,
 ) -> Result<Arc<ServerConfig>, TlsConfigError> {
     let (cert, key) = generate_self_signed_cert(keypair, peer_id)?;
 
@@ -86,7 +85,7 @@ pub fn build_client_config(
     self_peer_id: PeerId,
     keypair: &PeerKeypair,
     expected_peer: PeerId,
-    registry: Arc<RwLock<PeerKeyRegistry>>,
+    registry: Arc<PeerKeyRegistry>,
 ) -> Result<Arc<ClientConfig>, TlsConfigError> {
     let (cert, key) = generate_self_signed_cert(keypair, self_peer_id)?;
 
@@ -118,9 +117,9 @@ mod tests {
         let peer = PeerId::from_u128(0xa1);
         let keypair = PeerKeypair::generate();
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
-        let registry = Arc::new(RwLock::new(registry));
+        let registry = Arc::new(registry);
 
         let config = build_server_config(peer, &keypair, registry);
         assert!(config.is_ok(), "expected Ok, got {config:?}");
@@ -134,14 +133,14 @@ mod tests {
         let self_kp = PeerKeypair::generate();
         let other_kp = PeerKeypair::generate();
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry
             .enrol(self_peer, 0, self_kp.public_bytes())
             .unwrap();
         registry
             .enrol(other_peer, 0, other_kp.public_bytes())
             .unwrap();
-        let registry = Arc::new(RwLock::new(registry));
+        let registry = Arc::new(registry);
 
         let config = build_client_config(self_peer, &self_kp, other_peer, registry);
         assert!(config.is_ok(), "expected Ok, got {config:?}");

--- a/crates/airc-transport/src/lan_tcp/verifier.rs
+++ b/crates/airc-transport/src/lan_tcp/verifier.rs
@@ -29,7 +29,6 @@
 //! "this pubkey is in the registry."
 
 use std::sync::Arc;
-use std::sync::RwLock;
 
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
@@ -52,11 +51,11 @@ fn supported_schemes() -> Vec<SignatureScheme> {
 #[derive(Debug)]
 pub struct PinnedServerVerifier {
     expected_peer: PeerId,
-    registry: Arc<RwLock<PeerKeyRegistry>>,
+    registry: Arc<PeerKeyRegistry>,
 }
 
 impl PinnedServerVerifier {
-    pub fn new(expected_peer: PeerId, registry: Arc<RwLock<PeerKeyRegistry>>) -> Self {
+    pub fn new(expected_peer: PeerId, registry: Arc<PeerKeyRegistry>) -> Self {
         Self {
             expected_peer,
             registry,
@@ -76,14 +75,9 @@ impl ServerCertVerifier for PinnedServerVerifier {
         let pubkey = extract_ed25519_pubkey(end_entity)
             .map_err(|error| RustlsError::General(error.to_string()))?;
 
-        let registry = self
-            .registry
-            .read()
-            .map_err(|error| RustlsError::General(format!("registry lock: {error}")))?;
-
         // Resolve the cert's pubkey to a (peer, key_id) entry. We
         // accept only if the resolved peer matches the expected one.
-        match registry.find_peer(&pubkey) {
+        match self.registry.find_peer(&pubkey) {
             Some((peer, _key_id)) if peer == self.expected_peer => {
                 Ok(ServerCertVerified::assertion())
             }
@@ -129,14 +123,14 @@ impl ServerCertVerifier for PinnedServerVerifier {
 /// registry. The caller resolves the peer post-handshake.
 #[derive(Debug)]
 pub struct PinnedClientVerifier {
-    registry: Arc<RwLock<PeerKeyRegistry>>,
+    registry: Arc<PeerKeyRegistry>,
     /// Held as an owned empty slice so `root_hint_subjects` can
     /// return a borrow per the rustls 0.23 trait signature.
     empty_hints: Vec<DistinguishedName>,
 }
 
 impl PinnedClientVerifier {
-    pub fn new(registry: Arc<RwLock<PeerKeyRegistry>>) -> Self {
+    pub fn new(registry: Arc<PeerKeyRegistry>) -> Self {
         Self {
             registry,
             empty_hints: Vec::new(),
@@ -162,15 +156,10 @@ impl ClientCertVerifier for PinnedClientVerifier {
         let pubkey = extract_ed25519_pubkey(end_entity)
             .map_err(|error| RustlsError::General(error.to_string()))?;
 
-        let registry = self
-            .registry
-            .read()
-            .map_err(|error| RustlsError::General(format!("registry lock: {error}")))?;
-
         // Any enrolled peer is acceptable; the adapter will read the
         // cert pubkey post-handshake and bind the connection to the
         // resolved PeerId. Pubkey not in registry → reject.
-        if registry.find_peer(&pubkey).is_some() {
+        if self.registry.find_peer(&pubkey).is_some() {
             Ok(ClientCertVerified::assertion())
         } else {
             Err(RustlsError::General(
@@ -248,10 +237,10 @@ mod tests {
 
     use crate::lan_tcp::cert::generate_self_signed_cert;
 
-    fn make_registry_with(peer: PeerId, keypair: &PeerKeypair) -> Arc<RwLock<PeerKeyRegistry>> {
-        let mut registry = PeerKeyRegistry::new();
+    fn make_registry_with(peer: PeerId, keypair: &PeerKeypair) -> Arc<PeerKeyRegistry> {
+        let registry = PeerKeyRegistry::new();
         registry.enrol(peer, 0, keypair.public_bytes()).unwrap();
-        Arc::new(RwLock::new(registry))
+        Arc::new(registry)
     }
 
     fn unix_now() -> UnixTime {
@@ -288,10 +277,10 @@ mod tests {
         let kp_b = PeerKeypair::generate();
         let (cert_b, _) = generate_self_signed_cert(&kp_b, peer_b).unwrap();
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry.enrol(peer_a, 0, kp_a.public_bytes()).unwrap();
         registry.enrol(peer_b, 0, kp_b.public_bytes()).unwrap();
-        let registry = Arc::new(RwLock::new(registry));
+        let registry = Arc::new(registry);
 
         let verifier = PinnedServerVerifier::new(peer_a, registry);
         let server_name = ServerName::try_from("localhost").unwrap();
@@ -348,10 +337,10 @@ mod tests {
         let (cert_a, _) = generate_self_signed_cert(&kp_a, peer_a).unwrap();
         let (cert_b, _) = generate_self_signed_cert(&kp_b, peer_b).unwrap();
 
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry.enrol(peer_a, 0, kp_a.public_bytes()).unwrap();
         registry.enrol(peer_b, 0, kp_b.public_bytes()).unwrap();
-        let registry = Arc::new(RwLock::new(registry));
+        let registry = Arc::new(registry);
 
         let verifier = PinnedClientVerifier::new(registry);
         assert!(verifier

--- a/crates/airc-transport/src/relay/config.rs
+++ b/crates/airc-transport/src/relay/config.rs
@@ -1,7 +1,7 @@
 //! Typed setup for the relay client adapter.
 
 use std::net::SocketAddr;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use airc_core::PeerId;
 use airc_protocol::{PeerKeyRegistry, PeerKeypair};
@@ -27,5 +27,5 @@ pub struct RelayClientConfig {
     /// Shared peer-key registry. MUST contain an enrolled entry for
     /// `relay_peer_id` before [`super::RelayAdapter::connect`] is
     /// called.
-    pub registry: Arc<RwLock<PeerKeyRegistry>>,
+    pub registry: Arc<PeerKeyRegistry>,
 }

--- a/crates/airc-transport/src/relay/tests.rs
+++ b/crates/airc-transport/src/relay/tests.rs
@@ -3,7 +3,7 @@
 //! sides and `airc-relay` already depends on this crate — wiring a
 //! dev-dependency back here would be circular.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use airc_core::{
     headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, PeerId, RoomId,
@@ -41,7 +41,7 @@ fn adapter_without_connect() -> RelayAdapter {
         self_keypair: PeerKeypair::generate(),
         relay_peer_id: PeerId::from_u128(0xff),
         relay_addr: "127.0.0.1:0".parse().unwrap(),
-        registry: Arc::new(RwLock::new(PeerKeyRegistry::new())),
+        registry: Arc::new(PeerKeyRegistry::new()),
     })
 }
 

--- a/crates/airc-transport/src/signed.rs
+++ b/crates/airc-transport/src/signed.rs
@@ -12,7 +12,6 @@
 
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::RwLock;
 
 use async_trait::async_trait;
 use futures::stream::{Stream, StreamExt};
@@ -67,7 +66,7 @@ pub struct SignedTransport<T: Transport> {
     /// Which enrolled key the signer uses. Multiple keys per peer
     /// support rotation; substrate sticks with a single id by default.
     key_id: u32,
-    registry: Arc<RwLock<PeerKeyRegistry>>,
+    registry: Arc<PeerKeyRegistry>,
     policy: VerificationPolicy,
 }
 
@@ -76,7 +75,7 @@ impl<T: Transport> SignedTransport<T> {
         inner: T,
         keypair: PeerKeypair,
         self_peer_id: PeerId,
-        registry: Arc<RwLock<PeerKeyRegistry>>,
+        registry: Arc<PeerKeyRegistry>,
         policy: VerificationPolicy,
     ) -> Self {
         Self {
@@ -131,23 +130,10 @@ where
             async move {
                 match item {
                     Err(error) => Err(SignedError::Inner(error)),
-                    Ok(frame) => {
-                        let registry_guard = match registry.read() {
-                            Ok(g) => g,
-                            Err(_) => {
-                                // Poisoned lock — refuse the frame
-                                // rather than silently passing without
-                                // verification.
-                                return Err(SignedError::Verify(
-                                    VerificationError::CanonicalEncodingFailed,
-                                ));
-                            }
-                        };
-                        match verify(&frame, policy, &registry_guard) {
-                            Ok(()) => Ok(frame),
-                            Err(error) => Err(SignedError::Verify(error)),
-                        }
-                    }
+                    Ok(frame) => match verify(&frame, policy, registry.as_ref()) {
+                        Ok(()) => Ok(frame),
+                        Err(error) => Err(SignedError::Verify(error)),
+                    },
                 }
             }
         });
@@ -199,24 +185,18 @@ mod tests {
         PeerKeypair,
         PeerId,
         PeerKeypair,
-        Arc<RwLock<PeerKeyRegistry>>,
+        Arc<PeerKeyRegistry>,
     ) {
         let alice_id = PeerId::from_u128(0xa1);
         let bob_id = PeerId::from_u128(0xb2);
         let alice_kp = PeerKeypair::generate();
         let bob_kp = PeerKeypair::generate();
-        let mut registry = PeerKeyRegistry::new();
+        let registry = PeerKeyRegistry::new();
         registry
             .enrol(alice_id, 0, alice_kp.public_bytes())
             .unwrap();
         registry.enrol(bob_id, 0, bob_kp.public_bytes()).unwrap();
-        (
-            alice_id,
-            alice_kp,
-            bob_id,
-            bob_kp,
-            Arc::new(RwLock::new(registry)),
-        )
+        (alice_id, alice_kp, bob_id, bob_kp, Arc::new(registry))
     }
 
     fn replay_sub() -> Subscription {
@@ -293,7 +273,7 @@ mod tests {
         // can sign — the wire is shared but registries are not.
         let mallory_id = PeerId::from_u128(0xc4);
         let mallory_kp = PeerKeypair::generate();
-        let mut mallory_registry = PeerKeyRegistry::new();
+        let mallory_registry = PeerKeyRegistry::new();
         mallory_registry
             .enrol(mallory_id, 0, mallory_kp.public_bytes())
             .unwrap();
@@ -302,7 +282,7 @@ mod tests {
         mallory_registry
             .enrol(alice_id, 0, alice_kp.public_bytes())
             .unwrap();
-        let mallory_registry = Arc::new(RwLock::new(mallory_registry));
+        let mallory_registry = Arc::new(mallory_registry);
         let mallory = SignedTransport::new(
             LocalFsAdapter::new(dir.path()),
             mallory_kp,

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -321,10 +321,10 @@ five concrete hotpaths and seven kill-list patterns.
    rather than full event clone.
 
 3. **`RwLock<PeerKeyRegistry>` at process-global granularity** —
-   `airc.rs:118`, `transport/signed.rs:135-145`. Every frame
-   verification acquires a read lock. At 5000 frames/sec on a
-   many-peer grid, that's 5–25 ms/s of contention. Fix: `DashMap`
-   (sharded concurrent map, no global lock).
+   closed by the concurrent peer-registry cut. `PeerKeyRegistry` now
+   owns a sharded `DashMap`; signed transport, TLS verifiers, relay,
+   daemon, and SDK handles hold `Arc<PeerKeyRegistry>` directly. Frame
+   verification no longer serializes on a process-global read lock.
 
 4. **`event.clone()` on broadcast fan-out** — closed with Top #2.
    `EventStream` and `FilteredEventStream` now yield
@@ -344,9 +344,10 @@ five concrete hotpaths and seven kill-list patterns.
    must stay store-backed. Peer trust, subscriptions, local identity
    metadata, mesh identity, account registry, runtime cursors, and
    coordinator beacons are now store-backed.
-2. **`RwLock<HashMap>` at global granularity** — PeerKeyRegistry,
-   route_health, route_endpoints, imported_invites. Switch to
-   `DashMap` or sharded RwLock for N-reader scale.
+2. **`RwLock<HashMap>` at global granularity** — PeerKeyRegistry is
+   closed; route_health, route_endpoints, and imported_invites remain.
+   Switch remaining hot-path registries to `DashMap` or sharded
+   RwLock for N-reader scale.
 3. **Full JSON file rewrites on every mutate** — removed from peer
    trust, subscriptions/default-room, account registry, and
    coordinator beacons. Keep pushing remaining config/install helpers
@@ -355,9 +356,10 @@ five concrete hotpaths and seven kill-list patterns.
    internally; broadcast is `Arc::clone`.
 5. **Linear scans for dedup** — `enrolled.contains`, subscriptions
    iteration. HashSet / indexed lookup.
-6. **Verification lock held across async I/O** — `signed.rs`
-   `registry.read()` during stream processing. Snapshot the
-   registry once or use `try_read()` with fallback.
+6. **Verification lock held across async I/O** — closed for
+   `PeerKeyRegistry`. `signed.rs` verifies against the registry's
+   internal concurrent map directly; there is no external lock to hold
+   while draining the stream.
 7. **Untracked `tokio::spawn` tasks** — `transport.rs:52`
    (`spawn_frame_ingest` at line 91). No cancellation, no shutdown
    signal. Use `JoinSet` + a broadcast shutdown channel; cancel on
@@ -378,13 +380,12 @@ follow-up.
   trait `PersistentStore { async fn load_peers(...) }` and the
   daemon provides an impl. Library never names daemon types.
   Tracked for the post-3.6 cleanup phase.
-- **`airc-transport::signed` holds an `Arc<RwLock<PeerKeyRegistry>>`**
-  (`transport/signed.rs:129-146`) — STILL OPEN. Key rotation
-  invalidates lib's registry but transport has a stale reference.
-  Fix: verification is a pure function or a delegate passed per
-  frame; transport does not own crypto state. (Note: #905 made
-  unverifiable replay frames skip-and-warn instead of fail-closed,
-  which masks one symptom of this rot but doesn't fix the cause.)
+- **`airc-transport::signed` holds peer trust through
+  `Arc<PeerKeyRegistry>`** — CLOSED for global-lock contention. Key
+  rotation mutates the shared registry directly, so transport verifiers
+  observe updates without swapping an outer lock guard. A future
+  delegate can still narrow ownership further, but the hot-path
+  serialization point is gone.
 - **Daemon IPC is line-delimited JSON without length-framing**
   (implied from `airc-daemon/src/ipc/request.rs`) — STILL OPEN. A
   newline in a message body breaks the parser. No backpressure


### PR DESCRIPTION
## Summary
- move PeerKeyRegistry to internal DashMap storage with Arc<PeerKeyRegistry> handles
- remove external Arc<RwLock<PeerKeyRegistry>> from signed transport, LAN-TCP TLS verifiers, relay, daemon, SDK, and CLI
- update GRID-SUBSTRATE-AUDIT Phase 3.6 to close the peer-registry global-lock item

## Verification
- cargo check --manifest-path Cargo.toml -p airc-protocol -p airc-transport -p airc-relay -p airc-daemon -p airc-lib -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-protocol key_rotation_via_key_id_works -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-transport signed -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-relay -- --nocapture
- cargo test --manifest-path Cargo.toml --workspace
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings