### PR TITLE
perf(lib): remove global route table locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "airc-work-store",
  "async-trait",
  "base64",
+ "dashmap",
  "futures",
  "serde",
  "serde_json",

--- a/crates/airc-lib/Cargo.toml
+++ b/crates/airc-lib/Cargo.toml
@@ -31,6 +31,7 @@ airc-work-store = { path = "../airc-work-store" }
 
 async-trait = "0.1"
 base64 = "0.22"
+dashmap = "6"
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -23,7 +23,6 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::sync::RwLock;
 
 use airc_core::{ClientId, PeerId, TranscriptEvent};
 use airc_daemon::{peers_store, DaemonClient, LocalIdentity};
@@ -119,9 +118,9 @@ pub(crate) struct AircInner {
     pub(crate) daemon_client: Option<Arc<DaemonClient>>,
     pub(crate) registry: Arc<PeerKeyRegistry>,
     pub(crate) policy: VerificationPolicy,
-    pub(crate) route_health: RwLock<TransportHealthTable>,
-    pub(crate) route_endpoints: RwLock<RouteEndpointTable>,
-    pub(crate) imported_invites: RwLock<ImportedInviteTable>,
+    pub(crate) route_health: Arc<TransportHealthTable>,
+    pub(crate) route_endpoints: Arc<RouteEndpointTable>,
+    pub(crate) imported_invites: Arc<ImportedInviteTable>,
     pub(crate) lamport_clock: AtomicU64,
     pub(crate) lan_tcp: Mutex<Option<LanTcpAdapter>>,
     pub(crate) lan_subscriber: Mutex<Option<FrameSubscriber>>,
@@ -234,9 +233,9 @@ impl Airc {
                 daemon_client: None,
                 registry,
                 policy,
-                route_health: RwLock::new(TransportHealthTable::local_default()),
-                route_endpoints: RwLock::new(RouteEndpointTable::default()),
-                imported_invites: RwLock::new(ImportedInviteTable::default()),
+                route_health: Arc::new(TransportHealthTable::local_default()),
+                route_endpoints: Arc::new(RouteEndpointTable::default()),
+                imported_invites: Arc::new(ImportedInviteTable::default()),
                 lamport_clock: AtomicU64::new(0),
                 lan_tcp: Mutex::new(None),
                 lan_subscriber: Mutex::new(None),
@@ -289,9 +288,9 @@ impl Airc {
             daemon_client: Some(Arc::new(client)),
             registry: self.inner.registry.clone(),
             policy: self.inner.policy,
-            route_health: RwLock::new(TransportHealthTable::local_default()),
-            route_endpoints: RwLock::new(RouteEndpointTable::default()),
-            imported_invites: RwLock::new(ImportedInviteTable::default()),
+            route_health: Arc::new(TransportHealthTable::local_default()),
+            route_endpoints: Arc::new(RouteEndpointTable::default()),
+            imported_invites: Arc::new(ImportedInviteTable::default()),
             lamport_clock: AtomicU64::new(self.inner.lamport_clock.load(Ordering::Relaxed)),
             lan_tcp: Mutex::new(None),
             lan_subscriber: Mutex::new(None),
@@ -314,35 +313,21 @@ impl Airc {
         &self,
         samples: impl IntoIterator<Item = TransportHealthSample>,
     ) -> Result<(), AircError> {
-        let mut route_health = self
-            .inner
-            .route_health
-            .write()
-            .map_err(|_| AircError::Route("route health lock poisoned".to_string()))?;
-        route_health.replace(samples);
+        self.inner.route_health.replace(samples);
         Ok(())
     }
 
     /// Snapshot the current route-health samples. Consumers can use
     /// this for diagnostics without reaching into resolver internals.
     pub fn transport_health(&self) -> Result<Vec<TransportHealthSample>, AircError> {
-        self.inner
-            .route_health
-            .read()
-            .map_err(|_| AircError::Route("route health lock poisoned".to_string()))
-            .map(|table| table.samples())
+        Ok(self.inner.route_health.samples())
     }
 
     pub(crate) fn upsert_transport_health(
         &self,
         sample: TransportHealthSample,
     ) -> Result<(), AircError> {
-        let mut route_health = self
-            .inner
-            .route_health
-            .write()
-            .map_err(|_| AircError::Route("route health lock poisoned".to_string()))?;
-        route_health.upsert(sample);
+        self.inner.route_health.upsert(sample);
         Ok(())
     }
 

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -88,12 +88,7 @@ impl Airc {
 
     fn resolve_send_route(&self, kind: FrameKind) -> Result<TransportRoute, AircError> {
         let class = route_class_for_frame(kind);
-        let samples = self
-            .inner
-            .route_health
-            .read()
-            .map_err(|_| AircError::Route("route health lock poisoned".to_string()))?
-            .samples();
+        let samples = self.inner.route_health.samples();
         TransportResolver::from_health(samples)
             .resolve(class)
             .map_err(format_route_refusal)

--- a/crates/airc-lib/src/route/health.rs
+++ b/crates/airc-lib/src/route/health.rs
@@ -55,37 +55,76 @@ impl TransportHealthSample {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct TransportHealthTable {
-    samples: Vec<TransportHealthSample>,
+    samples: dashmap::DashMap<(TransportKind, TransportRole), TransportHealthSample>,
 }
 
 impl TransportHealthTable {
     pub fn local_default() -> Self {
-        Self {
-            samples: vec![TransportHealthSample::healthy_direct(
-                TransportKind::LocalFs,
-            )],
+        let table = Self::default();
+        table.upsert(TransportHealthSample::healthy_direct(
+            TransportKind::LocalFs,
+        ));
+        table
+    }
+
+    pub fn replace(&self, samples: impl IntoIterator<Item = TransportHealthSample>) {
+        self.samples.clear();
+        for sample in samples {
+            self.upsert(sample);
         }
     }
 
-    pub fn replace(&mut self, samples: impl IntoIterator<Item = TransportHealthSample>) {
-        self.samples = samples.into_iter().collect();
-    }
-
-    pub fn upsert(&mut self, sample: TransportHealthSample) {
-        match self
-            .samples
-            .iter_mut()
-            .find(|existing| existing.kind == sample.kind && existing.role == sample.role)
-        {
-            Some(existing) => *existing = sample,
-            None => self.samples.push(sample),
-        }
+    pub fn upsert(&self, sample: TransportHealthSample) {
+        self.samples.insert((sample.kind, sample.role), sample);
     }
 
     pub fn samples(&self) -> Vec<TransportHealthSample> {
-        self.samples.clone()
+        let mut samples = self
+            .samples
+            .iter()
+            .map(|entry| *entry.value())
+            .collect::<Vec<_>>();
+        samples.sort_by_key(|sample| {
+            (
+                transport_kind_order(sample.kind),
+                transport_role_order(sample.role),
+            )
+        });
+        samples
+    }
+}
+
+impl Default for TransportHealthTable {
+    fn default() -> Self {
+        Self {
+            samples: dashmap::DashMap::new(),
+        }
+    }
+}
+
+fn transport_kind_order(kind: TransportKind) -> u8 {
+    match kind {
+        TransportKind::LocalFs => 0,
+        TransportKind::LanTcp => 1,
+        TransportKind::Tailscale => 2,
+        TransportKind::Udp => 3,
+        TransportKind::WebRtcDataChannel => 4,
+        TransportKind::Reticulum => 5,
+        TransportKind::Relay => 6,
+        TransportKind::Ssh => 7,
+        TransportKind::GhGist => 8,
+    }
+}
+
+fn transport_role_order(role: TransportRole) -> u8 {
+    match role {
+        TransportRole::Direct => 0,
+        TransportRole::Relay => 1,
+        TransportRole::InviteBeacon => 2,
+        TransportRole::Rendezvous => 3,
+        TransportRole::Admin => 4,
     }
 }
 
@@ -125,7 +164,7 @@ mod tests {
 
     #[test]
     fn health_table_upsert_replaces_same_kind_and_role() {
-        let mut table = TransportHealthTable::local_default();
+        let table = TransportHealthTable::local_default();
         table.upsert(TransportHealthSample::healthy_direct(TransportKind::LanTcp));
         table.upsert(TransportHealthSample::down(
             TransportKind::LanTcp,

--- a/crates/airc-lib/src/route/invite.rs
+++ b/crates/airc-lib/src/route/invite.rs
@@ -47,25 +47,25 @@ impl InviteBeacon {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default)]
 pub struct RouteEndpointTable {
-    endpoints: Vec<RouteEndpoint>,
+    endpoints: dashmap::DashMap<RouteEndpointKind, RouteEndpoint>,
 }
 
 impl RouteEndpointTable {
-    pub fn upsert(&mut self, endpoint: RouteEndpoint) {
-        match self
-            .endpoints
-            .iter_mut()
-            .find(|existing| same_endpoint_kind(existing, &endpoint))
-        {
-            Some(existing) => *existing = endpoint,
-            None => self.endpoints.push(endpoint),
-        }
+    pub fn upsert(&self, endpoint: RouteEndpoint) {
+        self.endpoints
+            .insert(RouteEndpointKind::from(&endpoint), endpoint);
     }
 
     pub fn endpoints(&self) -> Vec<RouteEndpoint> {
-        self.endpoints.clone()
+        let mut endpoints = self
+            .endpoints
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect::<Vec<_>>();
+        endpoints.sort_by_key(|endpoint| RouteEndpointKind::from(endpoint));
+        endpoints
     }
 }
 
@@ -75,39 +75,34 @@ pub struct ImportedInvite {
     pub endpoints: Vec<RouteEndpoint>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default)]
 pub struct ImportedInviteTable {
-    invites: Vec<ImportedInvite>,
+    invites: dashmap::DashMap<PeerId, ImportedInvite>,
 }
 
 impl ImportedInviteTable {
-    pub fn import(&mut self, beacon: InviteBeacon) {
+    pub fn import(&self, beacon: InviteBeacon) {
         let imported = ImportedInvite {
             peer_id: beacon.peer_id,
             endpoints: beacon.endpoints,
         };
-        match self
-            .invites
-            .iter_mut()
-            .find(|existing| existing.peer_id == imported.peer_id)
-        {
-            Some(existing) => *existing = imported,
-            None => self.invites.push(imported),
-        }
+        self.invites.insert(imported.peer_id, imported);
     }
 
     pub fn invites(&self) -> Vec<ImportedInvite> {
-        self.invites.clone()
+        let mut invites = self
+            .invites
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect::<Vec<_>>();
+        invites.sort_by_key(|invite| invite.peer_id.to_string());
+        invites
     }
 }
 
 impl Airc {
     pub fn route_endpoints(&self) -> Result<Vec<RouteEndpoint>, AircError> {
-        self.inner
-            .route_endpoints
-            .read()
-            .map_err(|_| AircError::Route("route endpoints lock poisoned".to_string()))
-            .map(|table| table.endpoints())
+        Ok(self.inner.route_endpoints.endpoints())
     }
 
     pub fn invite_beacon(&self) -> Result<InviteBeacon, AircError> {
@@ -124,21 +119,12 @@ impl Airc {
     pub async fn import_invite_beacon(&self, beacon: InviteBeacon) -> Result<(), AircError> {
         let peer_spec = beacon.peer_spec.clone();
         self.add_peer_via(peer_spec, "invite").await?;
-        let mut invites = self
-            .inner
-            .imported_invites
-            .write()
-            .map_err(|_| AircError::Route("imported invites lock poisoned".to_string()))?;
-        invites.import(beacon);
+        self.inner.imported_invites.import(beacon);
         Ok(())
     }
 
     pub fn imported_invites(&self) -> Result<Vec<ImportedInvite>, AircError> {
-        self.inner
-            .imported_invites
-            .read()
-            .map_err(|_| AircError::Route("imported invites lock poisoned".to_string()))
-            .map(|table| table.invites())
+        Ok(self.inner.imported_invites.invites())
     }
 
     pub async fn publish_gist_invite(&self, gist_id: &str) -> Result<InviteBeacon, AircError> {
@@ -166,35 +152,32 @@ impl Airc {
     }
 
     pub(crate) fn upsert_route_endpoint(&self, endpoint: RouteEndpoint) -> Result<(), AircError> {
-        let mut endpoints = self
-            .inner
-            .route_endpoints
-            .write()
-            .map_err(|_| AircError::Route("route endpoints lock poisoned".to_string()))?;
-        endpoints.upsert(endpoint);
+        self.inner.route_endpoints.upsert(endpoint);
         Ok(())
     }
 }
 
-fn same_endpoint_kind(left: &RouteEndpoint, right: &RouteEndpoint) -> bool {
-    matches!(
-        (left, right),
-        (RouteEndpoint::LanTcp { .. }, RouteEndpoint::LanTcp { .. })
-            | (
-                RouteEndpoint::TailscaleTcp { .. },
-                RouteEndpoint::TailscaleTcp { .. }
-            )
-            | (RouteEndpoint::Udp { .. }, RouteEndpoint::Udp { .. })
-            | (RouteEndpoint::Relay { .. }, RouteEndpoint::Relay { .. })
-            | (
-                RouteEndpoint::Reticulum { .. },
-                RouteEndpoint::Reticulum { .. }
-            )
-            | (
-                RouteEndpoint::WebRtcSignaling { .. },
-                RouteEndpoint::WebRtcSignaling { .. }
-            )
-    )
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+enum RouteEndpointKind {
+    LanTcp,
+    TailscaleTcp,
+    Udp,
+    Relay,
+    Reticulum,
+    WebRtcSignaling,
+}
+
+impl From<&RouteEndpoint> for RouteEndpointKind {
+    fn from(endpoint: &RouteEndpoint) -> Self {
+        match endpoint {
+            RouteEndpoint::LanTcp { .. } => Self::LanTcp,
+            RouteEndpoint::TailscaleTcp { .. } => Self::TailscaleTcp,
+            RouteEndpoint::Udp { .. } => Self::Udp,
+            RouteEndpoint::Relay { .. } => Self::Relay,
+            RouteEndpoint::Reticulum { .. } => Self::Reticulum,
+            RouteEndpoint::WebRtcSignaling { .. } => Self::WebRtcSignaling,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -226,7 +209,7 @@ mod tests {
 
     #[test]
     fn endpoint_table_replaces_same_transport_kind() {
-        let mut table = RouteEndpointTable::default();
+        let table = RouteEndpointTable::default();
         table.upsert(RouteEndpoint::LanTcp {
             addr: SocketAddr::from(([127, 0, 0, 1], 1000)),
         });
@@ -244,7 +227,7 @@ mod tests {
 
     #[test]
     fn endpoint_table_tracks_udp_separately_from_lan_tcp() {
-        let mut table = RouteEndpointTable::default();
+        let table = RouteEndpointTable::default();
         table.upsert(RouteEndpoint::LanTcp {
             addr: SocketAddr::from(([127, 0, 0, 1], 1000)),
         });
@@ -269,7 +252,7 @@ mod tests {
     fn imported_invites_are_remote_not_local_advertised_endpoints() {
         let keypair = PeerKeypair::generate();
         let peer_id = PeerId::new();
-        let mut table = ImportedInviteTable::default();
+        let table = ImportedInviteTable::default();
         table.import(InviteBeacon::new(
             peer_id,
             PeerSpec {

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -344,10 +344,12 @@ five concrete hotpaths and seven kill-list patterns.
    must stay store-backed. Peer trust, subscriptions, local identity
    metadata, mesh identity, account registry, runtime cursors, and
    coordinator beacons are now store-backed.
-2. **`RwLock<HashMap>` at global granularity** — PeerKeyRegistry is
-   closed; route_health, route_endpoints, and imported_invites remain.
-   Switch remaining hot-path registries to `DashMap` or sharded
-   RwLock for N-reader scale.
+2. **`RwLock<HashMap>` at global granularity** — closed for
+   PeerKeyRegistry and the route resolver tables. Route health,
+   advertised endpoints, and imported invites now own internal
+   `DashMap` storage and are held by `Arc<Table>` at the SDK boundary.
+   Remaining global maps should follow the same internally concurrent
+   table pattern rather than exposing outer locks to callers.
 3. **Full JSON file rewrites on every mutate** — removed from peer
    trust, subscriptions/default-room, account registry, and
    coordinator beacons. Keep pushing remaining config/install helpers


### PR DESCRIPTION
## Summary
- move route health, advertised endpoint, and imported invite tables to internal DashMap storage
- replace AircInner outer RwLock route fields with Arc<table> handles
- keep route policy and invite semantics unchanged while updating GRID-SUBSTRATE-AUDIT Phase 3.6

## Verification
- cargo check --manifest-path Cargo.toml -p airc-lib -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-lib route:: -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-lib discovery_refresh_is_local_first_without_github_or_tailscale -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli --test route_commands -- --nocapture
- cargo test --manifest-path Cargo.toml --workspace
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings