### PR TITLE
perf(lib): use set-backed subscription dedup

### DIFF
--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -24,7 +24,7 @@
 //! Persisted through `airc-store` ORM tables. There is no JSON
 //! sidecar for subscription/default-channel state.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
 use airc_store::{EventStore, StoredSubscription};
@@ -539,57 +539,51 @@ impl Airc {
 
     async fn subscribed_room_ids(&self) -> Result<Vec<RoomId>, AircError> {
         let mut room_ids = Vec::new();
+        let mut seen = HashSet::new();
         let set = self.subscription_set().await?;
         for subscription in set.all() {
-            push_unique(&mut room_ids, subscription.room_id);
+            if seen.insert(subscription.room_id) {
+                room_ids.push(subscription.room_id);
+            }
         }
 
         if room_ids.is_empty() {
             let identity = self.mesh_identity().await?;
-            push_unique(
-                &mut room_ids,
-                Subscription::new_with_wire_root(
-                    &self.inner.wire_root,
-                    &identity,
-                    ChannelName::new("general").map_err(SubscriptionError::from)?,
-                )?
-                .room_id,
-            );
+            let room_id = Subscription::new_with_wire_root(
+                &self.inner.wire_root,
+                &identity,
+                ChannelName::new("general").map_err(SubscriptionError::from)?,
+            )?
+            .room_id;
+            if seen.insert(room_id) {
+                room_ids.push(room_id);
+            }
         }
         Ok(room_ids)
     }
 
     pub(crate) async fn subscribed_wires(&self) -> Result<Vec<PathBuf>, AircError> {
         let mut wires = Vec::new();
+        let mut seen = BTreeSet::new();
         let set = self.subscription_set().await?;
         for subscription in set.all() {
-            push_unique_path(&mut wires, subscription.wire.clone());
+            if seen.insert(subscription.wire.clone()) {
+                wires.push(subscription.wire.clone());
+            }
         }
         if wires.is_empty() {
             let identity = self.mesh_identity().await?;
-            push_unique_path(
-                &mut wires,
-                Subscription::new_with_wire_root(
-                    &self.inner.wire_root,
-                    &identity,
-                    ChannelName::new("general").map_err(SubscriptionError::from)?,
-                )?
-                .wire,
-            );
+            let wire = Subscription::new_with_wire_root(
+                &self.inner.wire_root,
+                &identity,
+                ChannelName::new("general").map_err(SubscriptionError::from)?,
+            )?
+            .wire;
+            if seen.insert(wire.clone()) {
+                wires.push(wire);
+            }
         }
         Ok(wires)
-    }
-}
-
-fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
-    if !items.contains(&item) {
-        items.push(item);
-    }
-}
-
-fn push_unique_path(items: &mut Vec<PathBuf>, item: PathBuf) {
-    if !items.contains(&item) {
-        items.push(item);
     }
 }
 

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -356,8 +356,11 @@ five concrete hotpaths and seven kill-list patterns.
    toward typed store-backed or wire-payload-only boundaries.
 4. **`event.clone()` on broadcast hot path** — `Arc<TranscriptEvent>`
    internally; broadcast is `Arc::clone`.
-5. **Linear scans for dedup** — `enrolled.contains`, subscriptions
-   iteration. HashSet / indexed lookup.
+5. **Linear scans for dedup** — closed for peer startup dedup and
+   subscription room/wire collection. `Airc::open` uses `HashSet` for
+   peer enrollment, and subscription helpers now keep deterministic
+   output order while using set-backed membership instead of
+   `Vec::contains` scans.
 6. **Verification lock held across async I/O** — closed for
    `PeerKeyRegistry`. `signed.rs` verifies against the registry's
    internal concurrent map directly; there is no external lock to hold


### PR DESCRIPTION
## Summary
- replace subscription room-id dedup Vec::contains scans with HashSet-backed membership
- replace subscription wire dedup Vec::contains scans with BTreeSet-backed membership
- preserve deterministic output order from the subscription map iteration
- update GRID-SUBSTRATE-AUDIT Phase 3.6 linear-scan status

## Verification
- cargo test --manifest-path Cargo.toml -p airc-lib subscriptions:: -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-lib --test embedding_smoke subscribed_filter_reads_all_configured_channels_not_current_room_only -- --nocapture
- cargo fmt --manifest-path Cargo.toml --all --check
- cargo test --manifest-path Cargo.toml --workspace
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings