### PR TITLE
perf(lib): shorten subscriber setup locks

### DIFF
--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -60,10 +60,13 @@ impl Airc {
     }
 
     pub(crate) async fn ensure_wire_subscriber(&self, wire: &Path) -> Result<(), AircError> {
-        let mut subs = self.inner.subscribers.lock().await;
-        if subs.contains_key(wire) {
-            return Ok(());
+        {
+            let subs = self.inner.subscribers.lock().await;
+            if subs.contains_key(wire) {
+                return Ok(());
+            }
         }
+
         self.sync_account_peer_registry().await?;
         let transport = SignedTransport::new(
             LocalFsAdapter::new(wire),
@@ -83,6 +86,11 @@ impl Airc {
             .subscribe(subscription)
             .await
             .map_err(|e| AircError::Transport(e.to_string()))?;
+
+        let mut subs = self.inner.subscribers.lock().await;
+        if subs.contains_key(wire) {
+            return Ok(());
+        }
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let task = self.spawn_frame_ingest(stream, Some(wire.to_path_buf()), Some(shutdown_rx));
@@ -169,10 +177,13 @@ impl Airc {
     }
 
     pub(crate) async fn ensure_lan_subscriber(&self) -> Result<(), AircError> {
-        let mut subscriber = self.inner.lan_subscriber.lock().await;
-        if subscriber.is_some() {
-            return Ok(());
+        {
+            let subscriber = self.inner.lan_subscriber.lock().await;
+            if subscriber.is_some() {
+                return Ok(());
+            }
         }
+
         let adapter = self.lan_adapter().await?;
         let transport = SignedTransport::new(
             adapter,
@@ -189,6 +200,12 @@ impl Airc {
             .subscribe(subscription)
             .await
             .map_err(|e| AircError::Transport(e.to_string()))?;
+
+        let mut subscriber = self.inner.lan_subscriber.lock().await;
+        if subscriber.is_some() {
+            return Ok(());
+        }
+
         let task = self.spawn_frame_ingest(stream, None, None);
         *subscriber = Some(FrameSubscriber { _task: task });
         Ok(())

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -348,8 +348,10 @@ five concrete hotpaths and seven kill-list patterns.
    PeerKeyRegistry and the route resolver tables. Route health,
    advertised endpoints, and imported invites now own internal
    `DashMap` storage and are held by `Arc<Table>` at the SDK boundary.
-   Remaining global maps should follow the same internally concurrent
-   table pattern rather than exposing outer locks to callers.
+   Remaining lifecycle maps should avoid holding locks across async
+   I/O; wire/LAN subscriber setup now checks under lock, performs
+   transport setup outside the critical section, then re-checks before
+   insertion.
 3. **Full JSON file rewrites on every mutate** — removed from peer
    trust, subscriptions/default-room, account registry, and
    coordinator beacons. Keep pushing remaining config/install helpers


### PR DESCRIPTION
## Summary
- avoid holding the wire subscriber map mutex across peer-registry sync and transport subscribe awaits
- avoid holding the LAN subscriber mutex across LAN adapter and transport subscribe awaits
- re-check under lock before insertion to preserve idempotent single-subscriber behavior
- update GRID-SUBSTRATE-AUDIT Phase 3.6 lock guidance

## Verification
- cargo fmt --manifest-path Cargo.toml --all --check
- cargo test --manifest-path Cargo.toml -p airc-lib --test lifecycle_events -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-lib --test embedding_smoke two_embedded_handles_chat_over_lan_without_cli -- --nocapture
- cargo test --manifest-path Cargo.toml --workspace
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings