### PR TITLE
perf(lib): make event filter channels set-backed

### DIFF
--- a/crates/airc-lib/src/stream.rs
+++ b/crates/airc-lib/src/stream.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -56,7 +56,7 @@ impl std::error::Error for LiveLag {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EventFilter {
     pub channel: Option<RoomId>,
-    pub channels: Vec<RoomId>,
+    pub channels: HashSet<RoomId>,
     pub kinds: BTreeSet<TranscriptKind>,
     pub headers_filter: HeaderFilter,
 }
@@ -65,7 +65,7 @@ impl Default for EventFilter {
     fn default() -> Self {
         Self {
             channel: None,
-            channels: Vec::new(),
+            channels: HashSet::new(),
             kinds: BTreeSet::new(),
             headers_filter: HeaderFilter::Any,
         }
@@ -115,5 +115,47 @@ impl Stream for FilteredEventStream {
                 Poll::Ready(None) => return Poll::Ready(None),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeSet, HashSet};
+
+    use airc_core::{Body, ClientId, EventId, Headers, MentionTarget, PeerId};
+
+    use super::*;
+
+    fn event(room_id: RoomId, kind: TranscriptKind) -> TranscriptEvent {
+        TranscriptEvent {
+            event_id: EventId::new(),
+            room_id,
+            peer_id: PeerId::from_u128(0xa1),
+            client_id: ClientId::from_u128(0xc1),
+            kind,
+            occurred_at_ms: 1,
+            lamport: 1,
+            target: MentionTarget::All,
+            headers: Headers::new(),
+            body: Some(Body::text("test")),
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn event_filter_uses_channel_membership_set() {
+        let admitted = RoomId::from_u128(0x01);
+        let other = RoomId::from_u128(0x02);
+        let filter = EventFilter {
+            channel: None,
+            channels: HashSet::from([admitted]),
+            kinds: BTreeSet::new(),
+            headers_filter: HeaderFilter::Any,
+        };
+
+        assert!(filter.matches(&event(admitted, TranscriptKind::Message)));
+        assert!(!filter.matches(&event(other, TranscriptKind::Message)));
     }
 }

--- a/crates/airc-lib/src/subscriptions.rs
+++ b/crates/airc-lib/src/subscriptions.rs
@@ -526,7 +526,7 @@ impl Airc {
         if filter.channel.is_some() || !filter.channels.is_empty() {
             return Ok(filter);
         }
-        filter.channels = self.subscribed_room_ids().await?;
+        filter.channels = self.subscribed_room_ids().await?.into_iter().collect();
         Ok(filter)
     }
 

--- a/crates/examples/consumer_shapes/src/continuum.rs
+++ b/crates/examples/consumer_shapes/src/continuum.rs
@@ -17,7 +17,7 @@
 
 use airc_lib::{Body, EventFilter, HeaderFilter, Headers};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 
 pub const BODY_HINT_FORGE_PERSONA_EVENT: &str = "forge.persona.event.v1";
 
@@ -208,7 +208,7 @@ pub fn decode_persona_event(
 pub fn any_persona_event_filter() -> EventFilter {
     EventFilter {
         channel: None,
-        channels: Vec::new(),
+        channels: HashSet::new(),
         kinds: BTreeSet::new(),
         headers_filter: HeaderFilter::Exact {
             key: HEADER_FORGE_BODY_HINT.to_string(),
@@ -222,7 +222,7 @@ pub fn any_persona_event_filter() -> EventFilter {
 pub fn activity_event_filter(activity_id: &str) -> EventFilter {
     EventFilter {
         channel: None,
-        channels: Vec::new(),
+        channels: HashSet::new(),
         kinds: BTreeSet::new(),
         headers_filter: HeaderFilter::All(vec![
             HeaderFilter::Exact {

--- a/crates/examples/consumer_shapes/src/hermes.rs
+++ b/crates/examples/consumer_shapes/src/hermes.rs
@@ -16,7 +16,7 @@
 
 use airc_lib::{Body, EventFilter, HeaderFilter, Headers};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 
 pub const BODY_HINT_FORGE_HERMES_EVENT: &str = "forge.hermes.event.v1";
 
@@ -171,7 +171,7 @@ pub fn decode_hermes_event(
 pub fn any_hermes_event_filter() -> EventFilter {
     EventFilter {
         channel: None,
-        channels: Vec::new(),
+        channels: HashSet::new(),
         kinds: BTreeSet::new(),
         headers_filter: HeaderFilter::Exact {
             key: HEADER_FORGE_BODY_HINT.to_string(),
@@ -186,7 +186,7 @@ pub fn any_hermes_event_filter() -> EventFilter {
 pub fn agent_event_filter(agent_id: &str) -> EventFilter {
     EventFilter {
         channel: None,
-        channels: Vec::new(),
+        channels: HashSet::new(),
         kinds: BTreeSet::new(),
         headers_filter: HeaderFilter::All(vec![
             HeaderFilter::Exact {

--- a/crates/examples/consumer_shapes/src/openclaw.rs
+++ b/crates/examples/consumer_shapes/src/openclaw.rs
@@ -18,7 +18,7 @@
 
 use airc_lib::{Body, EventFilter, HeaderFilter, Headers};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 
 pub const BODY_HINT_FORGE_OPENCLAW_EVENT: &str = "forge.openclaw.event.v1";
 
@@ -172,7 +172,7 @@ pub fn decode_openclaw_event(
 pub fn any_openclaw_event_filter() -> EventFilter {
     EventFilter {
         channel: None,
-        channels: Vec::new(),
+        channels: HashSet::new(),
         kinds: BTreeSet::new(),
         headers_filter: HeaderFilter::Exact {
             key: HEADER_FORGE_BODY_HINT.to_string(),
@@ -185,7 +185,7 @@ pub fn any_openclaw_event_filter() -> EventFilter {
 pub fn workspace_event_filter(workspace_id: &str) -> EventFilter {
     EventFilter {
         channel: None,
-        channels: Vec::new(),
+        channels: HashSet::new(),
         kinds: BTreeSet::new(),
         headers_filter: HeaderFilter::All(vec![
             HeaderFilter::Exact {

--- a/crates/examples/embedded_consumer_smoke/src/agent.rs
+++ b/crates/examples/embedded_consumer_smoke/src/agent.rs
@@ -4,6 +4,7 @@
 //! agent runtime needs from AIRC without importing substrate crates or
 //! shelling out to the CLI.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -86,7 +87,7 @@ impl AgentConsumer {
         kinds.insert(TranscriptKind::Message);
         let filter = EventFilter {
             channel: None,
-            channels: Vec::new(),
+            channels: HashSet::new(),
             kinds,
             headers_filter: HeaderFilter::Exact {
                 key: HEADER_AGENT_KIND.to_string(),
@@ -108,7 +109,7 @@ impl AgentConsumer {
         kinds.insert(TranscriptKind::Message);
         let filter = EventFilter {
             channel: None,
-            channels: Vec::new(),
+            channels: HashSet::new(),
             kinds,
             headers_filter: HeaderFilter::Exact {
                 key: HEADER_AGENT_KIND.to_string(),

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -362,7 +362,9 @@ five concrete hotpaths and seven kill-list patterns.
    subscription room/wire collection. `Airc::open` uses `HashSet` for
    peer enrollment, and subscription helpers now keep deterministic
    output order while using set-backed membership instead of
-   `Vec::contains` scans.
+   `Vec::contains` scans. Live/persisted `EventFilter` channel
+   membership is also set-backed, so multi-room monitor/hook/consumer
+   streams do not pay a linear channel scan on every event.
 6. **Verification lock held across async I/O** — closed for
    `PeerKeyRegistry`. `signed.rs` verifies against the registry's
    internal concurrent map directly; there is no external lock to hold


### PR DESCRIPTION
## Summary
- change EventFilter channel membership from Vec<RoomId> to HashSet<RoomId>
- update subscribed filter construction and consumer examples for set-backed membership
- add regression coverage for multi-channel EventFilter matching
- update docs/architecture/GRID-SUBSTRATE-AUDIT.md Phase 3.6 performance notes

## Verification
- cargo test --manifest-path Cargo.toml -p airc-lib stream::tests::event_filter_uses_channel_membership_set -- --nocapture
- cargo test --manifest-path Cargo.toml -p consumer-shapes -- --nocapture
- cargo test --manifest-path Cargo.toml -p embedded-consumer-smoke -- --nocapture
- cargo fmt --manifest-path Cargo.toml --all --check
- cargo test --manifest-path Cargo.toml --workspace
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings