### PR TITLE
refactor(daemon): length-frame ipc with cbor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "airc-transport",
  "async-trait",
  "base64",
+ "ciborium",
  "fs2",
  "futures",
  "serde",

--- a/crates/airc-cli/src/monitor/attach.rs
+++ b/crates/airc-cli/src/monitor/attach.rs
@@ -2,10 +2,11 @@ use std::error::Error;
 use std::path::Path;
 
 use airc_core::{Body, MentionTarget, TranscriptEvent, TranscriptKind};
-use airc_daemon::{AttachRequest, DaemonClient, Response, SubscribeRequest};
+use airc_daemon::{
+    ipc::codec::read_frame, AttachRequest, DaemonClient, Response, SubscribeRequest,
+};
 use airc_lib::Airc;
 use airc_protocol::HEADER_AIRC_CLIENT;
-use tokio::io::{AsyncBufReadExt, BufReader};
 
 use super::render::{normalize_channel, xml_escape, Sandbox};
 use crate::client_id::current_client_id;
@@ -23,18 +24,14 @@ pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error
             })
             .await?;
     }
-    let stream = client.attach(AttachRequest::default()).await?;
-    let mut reader = BufReader::new(stream);
+    let mut stream = client.attach(AttachRequest::default()).await?;
     let mut sandbox = Sandbox::new();
 
     println!("airc: attached to Rust event stream for subscribed channels");
-    let mut line = String::new();
     loop {
-        line.clear();
-        if reader.read_line(&mut line).await? == 0 {
+        let Some(response) = read_frame::<_, Response>(&mut stream).await? else {
             return Ok(());
-        }
-        let response: Response = serde_json::from_str(line.trim_end_matches('\n'))?;
+        };
         match response {
             Response::Ok => {}
             Response::Event { event } => {

--- a/crates/airc-daemon/Cargo.toml
+++ b/crates/airc-daemon/Cargo.toml
@@ -25,6 +25,7 @@ airc-store = { path = "../airc-store" }
 airc-transport = { path = "../airc-transport" }
 
 async-trait = "0.1"
+ciborium = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"

--- a/crates/airc-daemon/src/ipc/client.rs
+++ b/crates/airc-daemon/src/ipc/client.rs
@@ -1,10 +1,9 @@
 //! Typed client used by CLI commands to talk to a running daemon.
 //!
-//! `DaemonClient::call(request)` opens a Unix socket, writes the
-//! request as one newline-delimited JSON line, reads the response,
-//! and parses it. One round-trip per connection — simple to debug
-//! with `socat`, and the daemon's accept loop can spawn each
-//! connection independently.
+//! `DaemonClient::call(request)` opens the local daemon socket, writes
+//! one length-prefixed typed request frame, reads one typed response
+//! frame, and closes. One round-trip per connection keeps the daemon's
+//! accept loop simple while avoiding newline-sensitive parsing.
 //!
 //! Convenience helpers (`ping`, `status`, `send`, `stop`) wrap the
 //! generic `call` and dispatch on response variants so callers don't
@@ -12,9 +11,9 @@
 
 use std::path::PathBuf;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::time::{timeout, Duration};
 
+use crate::ipc::codec::{read_frame, write_frame};
 use crate::ipc::transport::IpcStream;
 
 use crate::ipc::request::{
@@ -89,11 +88,9 @@ impl DaemonClient {
         Self { socket_path }
     }
 
-    /// Generic RPC: writes a single newline-terminated request line,
-    /// reads a single newline-terminated response line. No half-close
-    /// — newline framing avoids the Windows-vs-Unix asymmetry where
-    /// Unix sockets support `shutdown` half-close but named pipes
-    /// don't. Both sides read until `\n`, parse, drop.
+    /// Generic RPC: writes one length-prefixed request frame and reads
+    /// one length-prefixed response frame. No half-close — Unix
+    /// sockets support `shutdown`, but Windows named pipes don't.
     pub async fn call(&self, request: Request) -> Result<Response, ClientError> {
         self.call_with_timeout(request, DEFAULT_RPC_TIMEOUT).await
     }
@@ -113,19 +110,20 @@ impl DaemonClient {
             .await
             .map_err(ClientError::NotConnected)?;
         let (reader, mut writer) = tokio::io::split(stream);
-        let mut reader = BufReader::new(reader);
+        let mut reader = reader;
 
-        let mut buffer = serde_json::to_vec(&request)?;
-        buffer.push(b'\n');
-        writer.write_all(&buffer).await.map_err(ClientError::Io)?;
-        writer.flush().await.map_err(ClientError::Io)?;
-
-        let mut response_line = String::new();
-        reader
-            .read_line(&mut response_line)
+        write_frame(&mut writer, &request)
             .await
             .map_err(ClientError::Io)?;
-        let response: Response = serde_json::from_str(response_line.trim_end_matches('\n'))?;
+        let response: Response = read_frame(&mut reader)
+            .await
+            .map_err(ClientError::Io)?
+            .ok_or_else(|| {
+                ClientError::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "daemon closed before response frame",
+                ))
+            })?;
 
         match response {
             Response::Error { message } => Err(ClientError::Daemon(message)),
@@ -263,10 +261,9 @@ impl DaemonClient {
         let mut stream = IpcStream::connect(&self.socket_path)
             .await
             .map_err(ClientError::NotConnected)?;
-        let mut buffer = serde_json::to_vec(&Request::Attach(request))?;
-        buffer.push(b'\n');
-        stream.write_all(&buffer).await.map_err(ClientError::Io)?;
-        stream.flush().await.map_err(ClientError::Io)?;
+        write_frame(&mut stream, &Request::Attach(request))
+            .await
+            .map_err(ClientError::Io)?;
         Ok(stream)
     }
 }

--- a/crates/airc-daemon/src/ipc/codec.rs
+++ b/crates/airc-daemon/src/ipc/codec.rs
@@ -1,0 +1,116 @@
+//! Length-framed IPC codec for daemon RPC and attach streams.
+//!
+//! Local IPC is a byte stream on Unix sockets and Windows named pipes.
+//! Newline-delimited JSON is not a protocol: any string field may
+//! contain a newline, and a slow reader has no declared frame length.
+//! This codec uses a fixed 4-byte big-endian length prefix followed by
+//! a CBOR payload for the typed request/response enums.
+
+use serde::{de::DeserializeOwned, Serialize};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+/// Maximum IPC frame payload. AIRC daemon requests are local control
+/// messages, not blob transport; media stays content-addressed.
+pub const MAX_FRAME_BYTES: u32 = 16 * 1024 * 1024;
+
+pub async fn write_frame<W, T>(writer: &mut W, value: &T) -> std::io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+    T: Serialize,
+{
+    let mut payload = Vec::new();
+    ciborium::into_writer(value, &mut payload).map_err(invalid_data)?;
+    let len = u32::try_from(payload.len()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "ipc frame too large: {} bytes exceeds {}",
+                payload.len(),
+                MAX_FRAME_BYTES
+            ),
+        )
+    })?;
+    if len > MAX_FRAME_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("ipc frame too large: {len} bytes exceeds {MAX_FRAME_BYTES}"),
+        ));
+    }
+
+    writer.write_all(&len.to_be_bytes()).await?;
+    writer.write_all(&payload).await?;
+    writer.flush().await
+}
+
+pub async fn read_frame<R, T>(reader: &mut R) -> std::io::Result<Option<T>>
+where
+    R: AsyncRead + Unpin,
+    T: DeserializeOwned,
+{
+    let mut len_bytes = [0_u8; 4];
+    match reader.read_exact(&mut len_bytes).await {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(error) => return Err(error),
+    }
+
+    let len = u32::from_be_bytes(len_bytes);
+    if len > MAX_FRAME_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("ipc frame too large: {len} bytes exceeds {MAX_FRAME_BYTES}"),
+        ));
+    }
+
+    let mut payload = vec![0_u8; len as usize];
+    reader.read_exact(&mut payload).await?;
+    ciborium::from_reader(payload.as_slice())
+        .map(Some)
+        .map_err(invalid_data)
+}
+
+fn invalid_data(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ipc::request::Request;
+
+    #[tokio::test]
+    async fn frame_round_trips_newline_bearing_payload() {
+        let mut bytes = Vec::new();
+        let request = Request::Send(crate::ipc::request::SendRequest {
+            wire: "/tmp/airc-wire".into(),
+            channel: uuid::Uuid::nil(),
+            text: "first line\nsecond line".to_string(),
+            headers: airc_core::Headers::new(),
+        });
+
+        write_frame(&mut bytes, &request).await.unwrap();
+        assert!(!bytes.ends_with(b"\n"));
+        let decoded: Request = read_frame(&mut bytes.as_slice()).await.unwrap().unwrap();
+
+        assert_eq!(decoded, request);
+    }
+
+    #[tokio::test]
+    async fn empty_stream_returns_none() {
+        let decoded: Option<Request> = read_frame(&mut [].as_slice()).await.unwrap();
+
+        assert!(decoded.is_none());
+    }
+
+    #[tokio::test]
+    async fn oversized_frame_fails_before_allocating_payload() {
+        let bytes = (MAX_FRAME_BYTES + 1).to_be_bytes().to_vec();
+
+        let error = read_frame::<_, Request>(&mut bytes.as_slice())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("ipc frame too large"));
+    }
+}

--- a/crates/airc-daemon/src/ipc/mod.rs
+++ b/crates/airc-daemon/src/ipc/mod.rs
@@ -1,18 +1,20 @@
 //! IPC between the `airc-core` CLI and the running daemon.
 //!
-//! Wire protocol = newline-delimited JSON over a local IPC primitive.
-//! On Unix that's a Unix-domain socket at `<home>/daemon.sock`. On
-//! Windows it's a named pipe (`\\.\pipe\airc-core-<home>`). The
-//! `transport` module abstracts both behind one `IpcListener` /
-//! `IpcStream` API; everything above (request/response types,
-//! dispatch, handlers) stays platform-agnostic.
+//! Wire protocol = length-prefixed CBOR frames over a local IPC
+//! primitive. On Unix that's a Unix-domain socket at
+//! `<home>/daemon.sock`. On Windows it's a named pipe
+//! (`\\.\pipe\airc-core-<home>`). The `transport` module abstracts
+//! both behind one `IpcListener` / `IpcStream` API; everything above
+//! (request/response types, dispatch, handlers) stays
+//! platform-agnostic.
 //!
 //! Why not gRPC / cap'n proto: this is local-only IPC for a
-//! single-machine daemon. JSON over Unix sockets / named pipes is
-//! the right amount of ceremony — typed in Rust (Request/Response
-//! enums), human-debuggable, zero extra schema toolchain.
+//! single-machine daemon. Typed Rust enums plus one internal codec are
+//! enough; consumer-facing observability remains at the CLI/event
+//! layer rather than the raw daemon byte stream.
 
 pub mod client;
+pub mod codec;
 pub mod request;
 pub mod response;
 pub mod transport;

--- a/crates/airc-daemon/src/ipc/request.rs
+++ b/crates/airc-daemon/src/ipc/request.rs
@@ -42,7 +42,7 @@ pub enum Request {
     Inbox(InboxRequest),
     /// Attach to the daemon's live event stream. This is a long-lived
     /// request: after an initial `Response::Ok`, the daemon writes
-    /// `Response::Event` lines until the client disconnects.
+    /// `Response::Event` frames until the client disconnects.
     Attach(AttachRequest),
     /// Graceful shutdown. Daemon completes in-flight requests, then
     /// stops accepting new connections + exits.

--- a/crates/airc-daemon/src/ipc/transport.rs
+++ b/crates/airc-daemon/src/ipc/transport.rs
@@ -392,9 +392,9 @@ mod tests {
         // each other's messages.
         // Use `read_exact` framing on both sides so the test doesn't
         // depend on `shutdown()` half-close semantics — Windows named
-        // pipes have no half-close, so the daemon protocol switched
-        // to newline framing for the same reason. Here we know each
-        // side writes exactly 6 bytes.
+        // pipes have no half-close, so the daemon protocol uses
+        // explicit length framing for the same reason. Here we know
+        // each side writes exactly 6 bytes.
         let server_a = tokio::spawn(async move {
             let mut stream = listener_a.accept().await.unwrap();
             let mut buf = [0u8; 6];

--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -1,8 +1,9 @@
 //! Cross-platform IPC listener + accept loop.
 //!
 //! Each accepted connection is handled in its own task: read one
-//! request, dispatch, write one response, close. Independent
-//! connections so a slow handler doesn't block the listener.
+//! length-framed request, dispatch, write one length-framed response,
+//! close. Attach streams keep writing response frames on the same
+//! connection.
 //!
 //! Transport varies by platform via `IpcListener`:
 //!   - Unix: Unix-domain socket at `<home>/daemon.sock`
@@ -16,10 +17,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use fs2::FileExt;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
 
 use crate::handlers::dispatch;
+use crate::ipc::codec::{read_frame, write_frame};
 use crate::ipc::request::{AttachRequest, Request};
 use crate::ipc::response::Response;
 use crate::ipc::transport::{IpcListener, IpcStream};
@@ -177,26 +179,17 @@ fn cleanup_stale_socket(_path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Handle one connection: read a single newline-terminated JSON
-/// request line, dispatch, write the JSON response line, drop. No
-/// half-close on the read side — Unix sockets can `shutdown` to
-/// signal EOF, but Windows named pipes have no half-close, so a
-/// protocol that relies on `shutdown` + `read_to_end` hangs on
-/// Windows. Newline-delimited single-line framing works identically
-/// on both transports.
+/// Handle one connection: read one length-framed request, dispatch,
+/// write one length-framed response, drop. No half-close on the read
+/// side — Unix sockets can `shutdown` to signal EOF, but Windows named
+/// pipes have no half-close.
 async fn handle_connection(stream: IpcStream, state: Arc<DaemonState>) -> Result<(), DaemonError> {
     let (reader, mut writer) = tokio::io::split(stream);
-    let mut reader = BufReader::new(reader);
-    let mut request_line = String::new();
-    let bytes_read = reader.read_line(&mut request_line).await?;
-    if bytes_read == 0 {
-        // Client closed without sending a request line. Nothing to
-        // respond to; just drop the connection.
-        return Ok(());
-    }
+    let mut reader = reader;
 
-    let request: Request = match serde_json::from_str(request_line.trim_end_matches('\n')) {
-        Ok(request) => request,
+    let request: Request = match read_frame(&mut reader).await {
+        Ok(Some(request)) => request,
+        Ok(None) => return Ok(()),
         Err(error) => {
             let response = Response::Error {
                 message: format!("could not parse request: {error}"),
@@ -253,16 +246,7 @@ async fn write_response<W>(writer: &mut W, response: &Response) -> Result<(), Da
 where
     W: AsyncWriteExt + Unpin,
 {
-    let mut payload = serde_json::to_vec(response).map_err(|error| {
-        DaemonError::Io(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            error.to_string(),
-        ))
-    })?;
-    payload.push(b'\n');
-    writer.write_all(&payload).await?;
-    writer.flush().await?;
-    Ok(())
+    write_frame(writer, response).await.map_err(DaemonError::Io)
 }
 
 #[cfg(test)]

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -398,11 +398,10 @@ follow-up.
   observe updates without swapping an outer lock guard. A future
   delegate can still narrow ownership further, but the hot-path
   serialization point is gone.
-- **Daemon IPC is line-delimited JSON without length-framing**
-  (implied from `airc-daemon/src/ipc/request.rs`) — STILL OPEN. A
-  newline in a message body breaks the parser. No backpressure
-  framing. Fix: length-prefixed CBOR/protobuf, or proper RPC
-  codec (tonic).
+- **Daemon IPC is line-delimited JSON without length-framing** —
+  CLOSED in the IPC framing cut. `airc-daemon::ipc::codec` now owns a
+  single length-prefixed CBOR frame format for request/response RPC
+  and long-lived attach streams, with a bounded max frame size.
 
 ### SeaORM perf notes (for Phase 3.5)
 


### PR DESCRIPTION
## Summary
- add a single daemon IPC codec: 4-byte length prefix + bounded CBOR payload
- route DaemonClient RPC, daemon server dispatch, and attach stream responses through the codec
- update Monitor attach to read typed IPC frames instead of newline JSON
- update docs/architecture/GRID-SUBSTRATE-AUDIT.md to close the daemon IPC framing gap

## Verification
- cargo test --manifest-path Cargo.toml -p airc-daemon ipc::codec -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-daemon -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli --test operational_dogfood -- --nocapture
- cargo fmt --manifest-path Cargo.toml --all --check
- cargo test --manifest-path Cargo.toml --workspace
- cargo clippy --manifest-path Cargo.toml --workspace --all-targets --all-features -- -D warnings