### PR TITLE
test(command-bus): prove request reply over LAN

### DIFF
--- a/crates/airc-lib/tests/command_bus_round_trip.rs
+++ b/crates/airc-lib/tests/command_bus_round_trip.rs
@@ -10,6 +10,7 @@
 //! can build typed request/reply on top of `Airc::request` +
 //! `Airc::reply` + `Airc::await_reply`.
 
+use std::net::SocketAddr;
 use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
@@ -34,6 +35,108 @@ fn request_and_reply_round_trip_via_shared_wire() {
         runtime.block_on(async {
             round_trip_inner(machine.path()).await;
         });
+    });
+}
+
+#[test]
+fn request_and_reply_round_trip_over_lan_without_github() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(async {
+        let alice_home = TempDir::new().expect("alice home");
+        let bob_home = TempDir::new().expect("bob home");
+
+        let alice = Airc::open(alice_home.path()).await.expect("alice opens");
+        let bob = Airc::open(bob_home.path()).await.expect("bob opens");
+
+        let alice_spec = alice.peer_spec().parse().expect("alice peer spec");
+        let bob_spec = bob.peer_spec().parse().expect("bob peer spec");
+        alice.add_peer(bob_spec).await.expect("alice trusts bob");
+        bob.add_peer(alice_spec).await.expect("bob trusts alice");
+
+        alice.join("command-bus-lan-test").await.unwrap();
+        bob.join("command-bus-lan-test").await.unwrap();
+
+        let bob_addr = bob
+            .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .expect("bob listens on LAN");
+        alice
+            .connect_lan(bob_addr, bob.peer_id())
+            .await
+            .expect("alice connects to bob over LAN");
+
+        let bob_handle = bob.clone();
+        let handler = tokio::spawn(async move {
+            let mut stream = bob_handle.subscribe().await.unwrap();
+            loop {
+                match stream.next().await {
+                    Some(Ok(event)) => {
+                        let Some(correlation) = event.headers.get(HEADER_AIRC_CORRELATION_ID)
+                        else {
+                            continue;
+                        };
+                        let Some(reply_to) = event.headers.get(HEADER_AIRC_REPLY_TO) else {
+                            continue;
+                        };
+                        if event.peer_id == bob_handle.peer_id() {
+                            continue;
+                        }
+                        let correlation_id =
+                            Uuid::parse_str(correlation).expect("valid correlation uuid");
+                        let reply_to_peer = PeerId::from_uuid(
+                            Uuid::parse_str(reply_to).expect("valid reply_to uuid"),
+                        );
+                        let mut headers = Headers::new();
+                        headers.insert("forge.body_hint".into(), "test.lan.result".into());
+                        bob_handle
+                            .reply(
+                                reply_to_peer,
+                                correlation_id,
+                                headers,
+                                Body::text("lan-pong"),
+                            )
+                            .await
+                            .expect("bob replies over LAN");
+                        return;
+                    }
+                    Some(Err(_)) => continue,
+                    None => return,
+                }
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut headers = Headers::new();
+        headers.insert("airc.command_kind".into(), "test.lan.ping".into());
+        let pending = alice
+            .request(
+                MentionTarget::All,
+                headers,
+                Body::text("lan-ping"),
+                Duration::from_secs(3),
+            )
+            .await
+            .expect("alice issues LAN request");
+        let correlation_id = pending.correlation_id;
+
+        let reply = alice.await_reply(pending).await.expect("alice gets reply");
+        assert_eq!(
+            reply.target,
+            MentionTarget::Peer(alice.peer_id()),
+            "LAN reply must be directed at the requester"
+        );
+        assert_eq!(
+            reply.headers.get(HEADER_AIRC_CORRELATION_ID),
+            Some(&correlation_id.to_string()),
+            "LAN reply must preserve the correlation id"
+        );
+        assert_eq!(
+            reply.body.as_ref().and_then(Body::as_text),
+            Some("lan-pong")
+        );
+
+        handler.await.expect("handler completes");
     });
 }
 

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -535,18 +535,21 @@ context.
   reading stdout until the attach marker, terminating the child, and
   asserting on the captured stream. This proves the actual attach +
   stream path instead of only the setup return.
-- **Open: cross-machine fixture is not yet emulated under CI.** Today
-  cross-machine routing relies on operator-side manual verify.
-  Phase 2 lifecycle events + Phase 4 command-bus need
-  multi-machine CI to genuinely prove they work end-to-end.
+- **Closed for LAN-shaped command traffic: cross-machine fixture is
+  emulated under CI with separate homes and no shared local-fs data
+  plane.** `airc-lib` now proves command-bus request/reply over the
+  LAN-TCP route (`request_and_reply_round_trip_over_lan_without_github`).
+  Remaining broader proof: tailnet/relay across real machines before
+  promoting the rewrite beyond local/LAN confidence.
 
 ## Immediate PR Queue
 
-1. Add lifecycle event types.
-2. Add the git/PR/kanban event adapter skeleton so agents can
+1. Add the git/PR/kanban event adapter skeleton so agents can
    subscribe to work-state changes instead of polling.
-3. Add cross-machine CI fixture shape that proves local/LAN/tailnet
-   routing without relying on GitHub for routine traffic.
+2. Add tailnet/relay CI fixture shape that proves non-LAN routing
+   without relying on GitHub for routine traffic.
+3. Promote the LAN command-bus proof into the Continuum/OpenClaw/Hermes
+   integration fixture once those consumers bind to command-bus APIs.
 
 Done or superseded:
 
@@ -566,6 +569,8 @@ Done or superseded:
   joined channels, default room, and cursors without parsing CLI prose.
 - Command-bus request/reply helpers are in `airc-lib`, with directed
   envelope targets and correlation/deadline headers.
+- Command-bus request/reply is proven over LAN-TCP with separate homes
+  and no GitHub/shared-fs data plane.
 - The e2e join harness now emulates a Monitor-shaped streaming
   consumer instead of disabling attach with `AIRC_NO_ATTACH`.
 


### PR DESCRIPTION
## Summary
- add a LAN-TCP command-bus proof: two separate homes trust each other, connect over LAN, exchange `Airc::request` / `Airc::reply`, and preserve correlation headers
- update `GRID-SUBSTRATE-AUDIT.md` so the immediate queue reflects completed lifecycle work and the new LAN command-bus proof
- leave tailnet/relay and consumer fixture promotion as the remaining broader proof work

## Verification
- `cargo test -p airc-lib --test command_bus_round_trip request_and_reply_round_trip_over_lan_without_github -- --nocapture`
- `cargo test -p airc-lib --test command_bus_round_trip`
- `cargo test -p airc-lib --test embedding_smoke two_embedded_handles_chat_over_lan_without_cli`
- `cargo test -p airc-cli --test e2e two_airc_core_processes_chat_over_lan_via_sdk_route`
- `cargo clippy -p airc-lib --test command_bus_round_trip --all-features -- -D warnings`
- `cargo fmt --all --check`
