### PR TITLE
test(consumer-shapes): prove command bus integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,8 +779,12 @@ name = "consumer-shapes"
 version = "0.1.0"
 dependencies = [
  "airc-lib",
+ "futures",
  "serde",
  "serde_json",
+ "tempfile",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/airc-lib/src/command_bus.rs
+++ b/crates/airc-lib/src/command_bus.rs
@@ -112,11 +112,11 @@ use futures::stream::StreamExt;
 use uuid::Uuid;
 
 use crate::error::AircError;
+use crate::stream::EventStream;
 use crate::time::now_ms;
 use crate::Airc;
 
 /// One in-flight request awaiting a matching reply.
-#[derive(Debug)]
 pub struct PendingCommand {
     /// The correlation id stamped on the outgoing request event.
     /// The reply event must carry the same value in
@@ -125,6 +125,23 @@ pub struct PendingCommand {
     /// Wall-clock deadline. `await_reply` returns
     /// `AircError::CommandDeadline` past this point.
     pub deadline_at_ms: u64,
+    /// Live reply stream armed before the request is emitted.
+    ///
+    /// Without this, a fast same-process/LAN responder can reply
+    /// before `await_reply` subscribes, and the requester misses its
+    /// own command response. The stream is private so consumers use
+    /// the request/await contract rather than constructing half-armed
+    /// pending commands.
+    reply_stream: Option<EventStream>,
+}
+
+impl std::fmt::Debug for PendingCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PendingCommand")
+            .field("correlation_id", &self.correlation_id)
+            .field("deadline_at_ms", &self.deadline_at_ms)
+            .finish_non_exhaustive()
+    }
 }
 
 impl PendingCommand {
@@ -160,6 +177,7 @@ impl Airc {
     ) -> Result<PendingCommand, AircError> {
         let correlation_id = Uuid::new_v4();
         let deadline_at_ms = now_ms()? + deadline.as_millis() as u64;
+        let reply_stream = self.subscribe().await?;
 
         headers.insert(
             HEADER_AIRC_CORRELATION_ID.into(),
@@ -177,6 +195,7 @@ impl Airc {
         Ok(PendingCommand {
             correlation_id,
             deadline_at_ms,
+            reply_stream: Some(reply_stream),
         })
     }
 
@@ -210,24 +229,26 @@ impl Airc {
     /// headers intact) or [`AircError::CommandDeadline`] if the
     /// deadline elapses first.
     ///
-    /// The substrate subscribes to the live broadcast stream and
-    /// filters by `airc.correlation_id`. If the reply arrived
-    /// before this call (uncommon but possible — the broadcast
-    /// channel has a buffer), the subscribed stream replays it.
+    /// The substrate filters the reply stream armed by
+    /// [`request`](Self::request) before the request frame is sent.
+    /// That ordering is part of the contract: fast local/LAN
+    /// responders cannot win a race against the awaiter.
     pub async fn await_reply(&self, pending: PendingCommand) -> Result<TranscriptEvent, AircError> {
         let correlation = pending.correlation_id.to_string();
-        let mut stream = self.subscribe().await?;
+        let correlation_id = pending.correlation_id;
         let deadline = Instant::now()
             + pending
                 .remaining()
                 .unwrap_or_else(|| Duration::from_secs(0));
+        let mut stream = match pending.reply_stream {
+            Some(stream) => stream,
+            None => self.subscribe().await?,
+        };
 
         loop {
             let timeout = deadline.saturating_duration_since(Instant::now());
             if timeout.is_zero() {
-                return Err(AircError::CommandDeadline {
-                    correlation_id: pending.correlation_id,
-                });
+                return Err(AircError::CommandDeadline { correlation_id });
             }
             match tokio::time::timeout(timeout, stream.next()).await {
                 Ok(Some(Ok(event))) => {
@@ -244,14 +265,10 @@ impl Airc {
                 }
                 Ok(None) => {
                     // Stream closed before any reply arrived.
-                    return Err(AircError::CommandDeadline {
-                        correlation_id: pending.correlation_id,
-                    });
+                    return Err(AircError::CommandDeadline { correlation_id });
                 }
                 Err(_) => {
-                    return Err(AircError::CommandDeadline {
-                        correlation_id: pending.correlation_id,
-                    });
+                    return Err(AircError::CommandDeadline { correlation_id });
                 }
             }
         }
@@ -268,6 +285,7 @@ mod tests {
         let pending = PendingCommand {
             correlation_id: Uuid::new_v4(),
             deadline_at_ms: 1,
+            reply_stream: None,
         };
         assert!(pending.remaining().is_none());
     }
@@ -278,6 +296,7 @@ mod tests {
         let pending = PendingCommand {
             correlation_id: Uuid::new_v4(),
             deadline_at_ms: u64::MAX / 2,
+            reply_stream: None,
         };
         let remaining = pending.remaining().unwrap();
         assert!(remaining.as_millis() > 0);

--- a/crates/examples/consumer_shapes/Cargo.toml
+++ b/crates/examples/consumer_shapes/Cargo.toml
@@ -15,4 +15,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]
+futures = "0.3"
 serde_json = "1"
+tempfile = "3"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
+uuid = { version = "1", features = ["v4"] }

--- a/crates/examples/consumer_shapes/tests/command_bus_integration.rs
+++ b/crates/examples/consumer_shapes/tests/command_bus_integration.rs
@@ -1,0 +1,237 @@
+//! Consumer command-bus integration proof.
+//!
+//! Continuum, OpenClaw, and Hermes shaped payloads are not just codec
+//! fixtures: they can ride the AIRC command-bus request/reply path
+//! over a live transport. This test uses LAN-TCP with separate homes
+//! so it cannot pass through shared local-fs or GitHub.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use airc_lib::{Airc, Body, Headers, MentionTarget, PeerId, TranscriptEvent};
+use consumer_shapes::continuum::{
+    decode_persona_event, encode_persona_event, PersonaEvent, TurnEmitted, TurnRequested,
+    BODY_HINT_FORGE_PERSONA_EVENT,
+};
+use consumer_shapes::hermes::{
+    decode_hermes_event, encode_hermes_event, AgentCommandIssued, AgentResultReturned, HermesEvent,
+    BODY_HINT_FORGE_HERMES_EVENT,
+};
+use consumer_shapes::openclaw::{
+    decode_openclaw_event, encode_openclaw_event, ChatMessagePosted, OpenClawEvent, ThreadCreated,
+    BODY_HINT_FORGE_OPENCLAW_EVENT,
+};
+use futures::StreamExt;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+const HEADER_FORGE_BODY_HINT: &str = "forge.body_hint";
+const HEADER_AIRC_CORRELATION_ID: &str = "airc.correlation_id";
+const HEADER_AIRC_REPLY_TO: &str = "airc.reply_to";
+
+#[tokio::test]
+async fn consumer_contracts_round_trip_over_lan_command_bus() {
+    let alice_home = TempDir::new().expect("alice home");
+    let bob_home = TempDir::new().expect("bob home");
+
+    let alice = Airc::open(alice_home.path()).await.expect("alice opens");
+    let bob = Airc::open(bob_home.path()).await.expect("bob opens");
+
+    let alice_spec = alice.peer_spec().parse().expect("alice peer spec");
+    let bob_spec = bob.peer_spec().parse().expect("bob peer spec");
+    alice.add_peer(bob_spec).await.expect("alice trusts bob");
+    bob.add_peer(alice_spec).await.expect("bob trusts alice");
+
+    alice.join("consumer-command-bus").await.unwrap();
+    bob.join("consumer-command-bus").await.unwrap();
+
+    let bob_addr = bob
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bob listens on LAN");
+    alice
+        .connect_lan(bob_addr, bob.peer_id())
+        .await
+        .expect("alice connects to bob over LAN");
+
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let handler = tokio::spawn(handle_three_consumer_requests(bob.clone(), ready_tx));
+    ready_rx.await.expect("bob subscriber is ready");
+
+    assert_eq!(
+        request_persona_turn(&alice).await,
+        PersonaEvent::TurnEmitted(TurnEmitted {
+            persona_id: "clio".to_string(),
+            activity_id: "activity-chat".to_string(),
+            turn_id: "turn-001".to_string(),
+            text: "continuum turn complete".to_string(),
+            emitted_at_ms: 1_700_000_000_100,
+        })
+    );
+    assert_eq!(
+        request_openclaw_thread(&alice).await,
+        OpenClawEvent::ThreadCreated(ThreadCreated {
+            openclaw_user_id: "u-agent".to_string(),
+            openclaw_thread_id: "t-router-debug".to_string(),
+            openclaw_workspace_id: "w-cambrian".to_string(),
+            title: "AIRC routed thread".to_string(),
+            created_at_ms: 1_700_000_000_200,
+        })
+    );
+    assert_eq!(
+        request_hermes_tool(&alice).await,
+        HermesEvent::AgentResultReturned(AgentResultReturned {
+            agent_id: "hermes-orchestrator".to_string(),
+            command_id: "cmd-lora-001".to_string(),
+            tool: "continuum.lora.invoke".to_string(),
+            output: Some(serde_json::json!({"text": "lora invocation complete"})),
+            error: None,
+            returned_at_ms: 1_700_000_000_300,
+        })
+    );
+
+    handler.await.expect("handler completes");
+}
+
+async fn handle_three_consumer_requests(bob: Airc, ready: tokio::sync::oneshot::Sender<()>) {
+    let mut stream = bob.subscribe().await.unwrap();
+    let _ = ready.send(());
+    let mut handled = 0usize;
+    while handled < 3 {
+        let Some(Ok(event)) = stream.next().await else {
+            continue;
+        };
+        if event.peer_id == bob.peer_id() {
+            continue;
+        }
+        let Some(body_hint) = event
+            .headers
+            .get(HEADER_FORGE_BODY_HINT)
+            .map(String::as_str)
+        else {
+            continue;
+        };
+        match body_hint {
+            BODY_HINT_FORGE_PERSONA_EVENT => {
+                let PersonaEvent::TurnRequested(request) =
+                    decode_persona_event(&event.headers, event.body.as_ref()).unwrap()
+                else {
+                    continue;
+                };
+                let response = PersonaEvent::TurnEmitted(TurnEmitted {
+                    persona_id: request.persona_id,
+                    activity_id: request.activity_id,
+                    turn_id: request.turn_id,
+                    text: "continuum turn complete".to_string(),
+                    emitted_at_ms: 1_700_000_000_100,
+                });
+                reply_with(&bob, &event, encode_persona_event(&response).unwrap()).await;
+                handled += 1;
+            }
+            BODY_HINT_FORGE_OPENCLAW_EVENT => {
+                let OpenClawEvent::ChatMessagePosted(request) =
+                    decode_openclaw_event(&event.headers, event.body.as_ref()).unwrap()
+                else {
+                    continue;
+                };
+                let response = OpenClawEvent::ThreadCreated(ThreadCreated {
+                    openclaw_user_id: "u-agent".to_string(),
+                    openclaw_thread_id: request.openclaw_thread_id,
+                    openclaw_workspace_id: request.openclaw_workspace_id,
+                    title: "AIRC routed thread".to_string(),
+                    created_at_ms: 1_700_000_000_200,
+                });
+                reply_with(&bob, &event, encode_openclaw_event(&response).unwrap()).await;
+                handled += 1;
+            }
+            BODY_HINT_FORGE_HERMES_EVENT => {
+                let HermesEvent::AgentCommandIssued(request) =
+                    decode_hermes_event(&event.headers, event.body.as_ref()).unwrap()
+                else {
+                    continue;
+                };
+                let response = HermesEvent::AgentResultReturned(AgentResultReturned {
+                    agent_id: request.agent_id,
+                    command_id: request.command_id,
+                    tool: request.tool,
+                    output: Some(serde_json::json!({"text": "lora invocation complete"})),
+                    error: None,
+                    returned_at_ms: 1_700_000_000_300,
+                });
+                reply_with(&bob, &event, encode_hermes_event(&response).unwrap()).await;
+                handled += 1;
+            }
+            _ => {}
+        }
+    }
+}
+
+async fn request_persona_turn(alice: &Airc) -> PersonaEvent {
+    let request = PersonaEvent::TurnRequested(TurnRequested {
+        persona_id: "clio".to_string(),
+        activity_id: "activity-chat".to_string(),
+        turn_id: "turn-001".to_string(),
+        prompt: "take a turn".to_string(),
+        requested_at_ms: 1_700_000_000_000,
+    });
+    let reply = request_typed(alice, encode_persona_event(&request).unwrap()).await;
+    decode_persona_event(&reply.headers, reply.body.as_ref()).unwrap()
+}
+
+async fn request_openclaw_thread(alice: &Airc) -> OpenClawEvent {
+    let request = OpenClawEvent::ChatMessagePosted(ChatMessagePosted {
+        openclaw_user_id: "u-human".to_string(),
+        openclaw_thread_id: "t-router-debug".to_string(),
+        openclaw_workspace_id: "w-cambrian".to_string(),
+        text: "please create a routed thread".to_string(),
+        posted_at_ms: 1_700_000_000_010,
+    });
+    let reply = request_typed(alice, encode_openclaw_event(&request).unwrap()).await;
+    decode_openclaw_event(&reply.headers, reply.body.as_ref()).unwrap()
+}
+
+async fn request_hermes_tool(alice: &Airc) -> HermesEvent {
+    let request = HermesEvent::AgentCommandIssued(AgentCommandIssued {
+        agent_id: "hermes-orchestrator".to_string(),
+        command_id: "cmd-lora-001".to_string(),
+        tool: "continuum.lora.invoke".to_string(),
+        input: serde_json::json!({"adapter_id": "lora-clio", "prompt": "summarize"}),
+        issued_at_ms: 1_700_000_000_020,
+    });
+    let reply = request_typed(alice, encode_hermes_event(&request).unwrap()).await;
+    decode_hermes_event(&reply.headers, reply.body.as_ref()).unwrap()
+}
+
+async fn request_typed(alice: &Airc, payload: (Headers, Body)) -> TranscriptEvent {
+    let (headers, body) = payload;
+    let pending = alice
+        .request(MentionTarget::All, headers, body, Duration::from_secs(3))
+        .await
+        .expect("request emits");
+    alice.await_reply(pending).await.expect("reply returns")
+}
+
+async fn reply_with(bob: &Airc, request: &TranscriptEvent, payload: (Headers, Body)) {
+    let (headers, body) = payload;
+    let reply_to_peer = request_peer(request);
+    let correlation_id = request_correlation(request);
+    bob.reply(reply_to_peer, correlation_id, headers, body)
+        .await
+        .expect("reply emits");
+}
+
+fn request_peer(event: &TranscriptEvent) -> PeerId {
+    let value = event
+        .headers
+        .get(HEADER_AIRC_REPLY_TO)
+        .expect("request carries reply peer");
+    PeerId::from_uuid(Uuid::parse_str(value).expect("reply peer is uuid"))
+}
+
+fn request_correlation(event: &TranscriptEvent) -> Uuid {
+    let value = event
+        .headers
+        .get(HEADER_AIRC_CORRELATION_ID)
+        .expect("request carries correlation id");
+    Uuid::parse_str(value).expect("correlation is uuid")
+}

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -544,6 +544,13 @@ context.
   and no GitHub/shared-fs data plane.** `airc-lib` now executes the
   Relay route directly and proves command-bus request/reply over it
   (`request_and_reply_round_trip_over_relay_without_github_or_lan`).
+- **Closed for consumer-shaped command traffic: Continuum, OpenClaw,
+  and Hermes contract payloads now ride the command-bus request/reply
+  primitive over LAN-TCP with separate homes.** The
+  `consumer-shapes` fixture proves typed downstream payloads can use
+  `Airc::request`, `Airc::reply`, and `Airc::await_reply` without
+  parsing CLI prose or depending on GitHub/shared-fs runtime traffic
+  (`consumer_contracts_round_trip_over_lan_command_bus`).
   Remaining broader proof: tailnet/relay across real machines before
   promoting the rewrite beyond local/LAN/relay confidence.
 
@@ -553,8 +560,8 @@ context.
    subscribe to work-state changes instead of polling.
 2. Add real-machine tailnet/relay proof that exercises the same route
    execution across host boundaries without GitHub routine traffic.
-3. Promote the LAN command-bus proof into the Continuum/OpenClaw/Hermes
-   integration fixture once those consumers bind to command-bus APIs.
+3. Bind the same command-bus request/reply proof in real Continuum,
+   OpenClaw, and Hermes repos once their adapters depend on `airc-lib`.
 
 Done or superseded:
 


### PR DESCRIPTION
## Summary
- add a consumer-shapes command-bus integration proof for Continuum, OpenClaw, and Hermes payloads
- run those typed contracts through `Airc::request`, `Airc::reply`, and `Airc::await_reply` over LAN-TCP with separate homes
- update `GRID-SUBSTRATE-AUDIT.md` to mark the example consumer command-bus proof closed and narrow the remaining work to real repo adapter bindings

## Verification
- cargo fmt --all --check
- cargo test -p consumer-shapes --test command_bus_integration -- --nocapture
- cargo test -p consumer-shapes
- cargo clippy -p consumer-shapes --all-targets --all-features -- -D warnings
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings