### PR TITLE
fix(daemon): refresh wire trust for live ingest

### DIFF
--- a/crates/airc-daemon/Cargo.toml
+++ b/crates/airc-daemon/Cargo.toml
@@ -30,7 +30,7 @@ base64 = "0.22"
 futures = "0.3"
 fs2 = "0.4"
 uuid = { version = "1", features = ["v4", "v5"] }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "signal", "net", "io-util", "sync"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "signal", "net", "io-util", "sync", "time"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -5,6 +5,7 @@
 //! Adding a new op = add Request variant + add arm here. The
 //! compiler enforces exhaustiveness.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use airc_core::{
@@ -54,6 +55,26 @@ pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
 }
 
 async fn handle_subscribe(state: Arc<DaemonState>, sub: SubscribeRequest) -> Response {
+    let trust_root = match trust_root_for_wire(&sub.wire) {
+        Some(root) => root,
+        None => {
+            return Response::Error {
+                message: format!("subscribe: invalid wire path {}", sub.wire.display()),
+            };
+        }
+    };
+    match state.refresh_trust_root(&trust_root).await {
+        Ok(_) => {}
+        Err(error) => {
+            return Response::Error {
+                message: format!("subscribe: trust refresh: {error}"),
+            };
+        }
+    }
+    if state.register_trust_root(&trust_root).await {
+        state.spawn_trust_refresher(trust_root);
+    }
+
     // Idempotent: if a subscriber task is already running for this
     // wire, return Ok without spawning a duplicate.
     if !state.register_subscriber(&sub.wire).await {
@@ -113,6 +134,10 @@ async fn handle_subscribe(state: Arc<DaemonState>, sub: SubscribeRequest) -> Res
     });
 
     Response::Ok
+}
+
+fn trust_root_for_wire(wire: &Path) -> Option<PathBuf> {
+    wire.parent().and_then(Path::parent).map(Path::to_path_buf)
 }
 
 async fn handle_inbox(state: Arc<DaemonState>, request: InboxRequest) -> Response {
@@ -254,7 +279,9 @@ mod tests {
     use super::*;
     use airc_core::PeerId;
     use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
+    use airc_transport::{LocalFsAdapter, SignedTransport};
     use std::path::PathBuf;
+    use std::time::Duration;
     use uuid::Uuid;
 
     fn test_state() -> Arc<DaemonState> {
@@ -348,6 +375,80 @@ mod tests {
         let frames = dir.path().join("frames.jsonl");
         let contents = std::fs::read_to_string(frames).unwrap();
         assert_eq!(contents.lines().count(), 1);
+    }
+
+    #[tokio::test]
+    async fn subscribed_daemon_learns_wire_root_trust_before_ingest() {
+        let root = tempfile::TempDir::new().unwrap();
+        let wire_root = root.path().join(".airc");
+        let wire = wire_root.join("wires").join("general");
+
+        let daemon = test_state();
+        assert_eq!(
+            dispatch(
+                daemon.clone(),
+                Request::Subscribe(SubscribeRequest { wire: wire.clone() }),
+            )
+            .await,
+            Response::Ok
+        );
+
+        let sibling_peer = PeerId::from_u128(0xc1a0de);
+        let sibling_keypair = PeerKeypair::generate();
+        airc_trust::add(&wire_root, sibling_peer, sibling_keypair.public_bytes())
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                if daemon.registry.lookup(sibling_peer, 0).is_some() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("daemon verifier must learn sibling trust from the wire root");
+
+        let sender_registry = Arc::new(PeerKeyRegistry::new());
+        sender_registry
+            .enrol(sibling_peer, 0, sibling_keypair.public_bytes())
+            .unwrap();
+        let sender_state = DaemonState::new(
+            sibling_peer,
+            sibling_keypair.clone(),
+            sender_registry.clone(),
+            VerificationPolicy::Strict,
+            wire_root.clone(),
+            Arc::new(airc_store::InMemoryEventStore::new()),
+        );
+        let sender = SignedTransport::new(
+            LocalFsAdapter::new(&wire),
+            sibling_keypair,
+            sibling_peer,
+            sender_registry,
+            VerificationPolicy::Strict,
+        );
+        let mut live = daemon.live_tx.subscribe();
+
+        sender
+            .send(
+                build_message_frame(
+                    &sender_state,
+                    Uuid::nil(),
+                    "sibling scope frame after trust refresh",
+                    Headers::new(),
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let event = tokio::time::timeout(Duration::from_secs(2), live.recv())
+            .await
+            .expect("daemon live stream must receive refreshed-trust frame")
+            .expect("live sender must remain open");
+        assert_eq!(event.peer_id, sibling_peer);
     }
 
     #[tokio::test]

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -137,7 +137,12 @@ async fn handle_subscribe(state: Arc<DaemonState>, sub: SubscribeRequest) -> Res
 }
 
 fn trust_root_for_wire(wire: &Path) -> Option<PathBuf> {
-    wire.parent().and_then(Path::parent).map(Path::to_path_buf)
+    match wire.parent() {
+        Some(parent) if parent.file_name().is_some_and(|name| name == "wires") => {
+            parent.parent().map(Path::to_path_buf)
+        }
+        _ => Some(wire.to_path_buf()),
+    }
 }
 
 async fn handle_inbox(state: Arc<DaemonState>, request: InboxRequest) -> Response {
@@ -375,6 +380,18 @@ mod tests {
         let frames = dir.path().join("frames.jsonl");
         let contents = std::fs::read_to_string(frames).unwrap();
         assert_eq!(contents.lines().count(), 1);
+    }
+
+    #[test]
+    fn trust_root_prefers_airc_wire_root_but_accepts_raw_wire_dirs() {
+        let airc_wire = PathBuf::from("/tmp/home/.airc/wires/general");
+        assert_eq!(
+            trust_root_for_wire(&airc_wire),
+            Some(PathBuf::from("/tmp/home/.airc"))
+        );
+
+        let raw_wire = PathBuf::from("/tmp/raw-wire-dir");
+        assert_eq!(trust_root_for_wire(&raw_wire), Some(raw_wire));
     }
 
     #[tokio::test]

--- a/crates/airc-daemon/src/lib.rs
+++ b/crates/airc-daemon/src/lib.rs
@@ -12,6 +12,7 @@
 //!   - `server` — IPC listener + accept loop, [`run`].
 //!   - `state` — shared daemon state ([`DaemonState`]).
 //!   - `handlers` — match arms for each `Request` variant.
+//!   - `trust_refresh` — durable peer-trust store -> live verifier sync.
 //!   - `airc-ipc` — wire-protocol types shared by daemon and clients.
 //!
 //! Adding a new operation:
@@ -31,6 +32,7 @@
 pub mod handlers;
 pub mod server;
 pub mod state;
+pub mod trust_refresh;
 
 pub use server::{run, DaemonError};
 pub use state::DaemonState;

--- a/crates/airc-daemon/src/state.rs
+++ b/crates/airc-daemon/src/state.rs
@@ -13,9 +13,9 @@
 //! semantics + no cross-room leakage).
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tokio::sync::{broadcast, Mutex, Notify};
 
@@ -23,6 +23,10 @@ use airc_core::PeerId;
 use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
 use airc_store::EventStore;
 use airc_transport::{LocalFsAdapter, SignedTransport};
+
+use crate::trust_refresh;
+
+const TRUST_REFRESH_INTERVAL: Duration = Duration::from_millis(750);
 
 /// Everything a daemon needs at runtime. Cheap to clone via Arc; the
 /// underlying handles (registry, transports, store) do their own
@@ -49,6 +53,11 @@ pub struct DaemonState {
     /// is idempotent — repeated calls find the wire here and skip
     /// the spawn.
     pub subscribed_wires: Mutex<HashMap<PathBuf, ()>>,
+    /// Trust roots already watched by this daemon. Each root is an
+    /// AIRC home/store whose peer trust rows should feed the live
+    /// verifier. This is separate from `subscribed_wires`: many wires
+    /// can share one root.
+    pub trusted_roots: Mutex<HashMap<PathBuf, ()>>,
     /// Authoritative live fan-out for daemon consumers.
     pub live_tx: broadcast::Sender<airc_core::TranscriptEvent>,
     /// Notified when the daemon should stop accepting + exit cleanly.
@@ -79,6 +88,7 @@ impl DaemonState {
             local_fs_transports: Mutex::new(HashMap::new()),
             event_store,
             subscribed_wires: Mutex::new(HashMap::new()),
+            trusted_roots: Mutex::new(HashMap::new()),
             live_tx,
             shutdown: Notify::new(),
         }
@@ -125,6 +135,45 @@ impl DaemonState {
         let handle = Arc::new(signed);
         transports.insert(key, handle.clone());
         handle
+    }
+
+    /// Start live verifier synchronization for `root` if this daemon
+    /// is not already watching it. Returns true when a new watcher was
+    /// registered. The caller should refresh once before subscribing;
+    /// the watcher keeps later sibling-scope trust additions visible.
+    pub async fn register_trust_root(&self, root: &Path) -> bool {
+        let mut roots = self.trusted_roots.lock().await;
+        if roots.contains_key(root) {
+            return false;
+        }
+        roots.insert(root.to_path_buf(), ());
+        true
+    }
+
+    pub async fn refresh_trust_root(
+        &self,
+        root: &Path,
+    ) -> Result<usize, trust_refresh::TrustRefreshError> {
+        trust_refresh::refresh_root(self.registry.clone(), root).await
+    }
+
+    pub fn spawn_trust_refresher(self: &Arc<Self>, root: PathBuf) {
+        let state = self.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = state.shutdown.notified() => break,
+                    _ = tokio::time::sleep(TRUST_REFRESH_INTERVAL) => {
+                        if let Err(error) = state.refresh_trust_root(&root).await {
+                            eprintln!(
+                                "daemon trust refresh failed for {}: {error}",
+                                root.display()
+                            );
+                        }
+                    }
+                }
+            }
+        });
     }
 
     pub fn uptime_seconds(&self) -> u64 {

--- a/crates/airc-daemon/src/trust_refresh.rs
+++ b/crates/airc-daemon/src/trust_refresh.rs
@@ -1,0 +1,77 @@
+//! Synchronize durable peer trust into the daemon's live verifier.
+//!
+//! The ORM-backed trust store is the source of truth. The daemon's
+//! `PeerKeyRegistry` is the hot-path verifier cache used by signed
+//! transports. This module is the bridge between those layers: small,
+//! explicit, and one-way.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+
+use airc_protocol::{KeyError, PeerKeyRegistry};
+
+#[derive(Debug)]
+pub enum TrustRefreshError {
+    Store(airc_trust::PeersStoreError),
+    PubkeyBase64(base64::DecodeError),
+    WrongPubkeyLength(usize),
+    InvalidPubkey(KeyError),
+}
+
+impl std::fmt::Display for TrustRefreshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TrustRefreshError::Store(error) => write!(f, "trust refresh store: {error}"),
+            TrustRefreshError::PubkeyBase64(error) => {
+                write!(f, "trust refresh pubkey base64: {error}")
+            }
+            TrustRefreshError::WrongPubkeyLength(got) => {
+                write!(f, "trust refresh pubkey is {got} bytes, expected 32")
+            }
+            TrustRefreshError::InvalidPubkey(error) => {
+                write!(f, "trust refresh invalid pubkey: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TrustRefreshError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            TrustRefreshError::Store(error) => Some(error),
+            TrustRefreshError::PubkeyBase64(error) => Some(error),
+            TrustRefreshError::InvalidPubkey(error) => Some(error),
+            TrustRefreshError::WrongPubkeyLength(_) => None,
+        }
+    }
+}
+
+impl From<airc_trust::PeersStoreError> for TrustRefreshError {
+    fn from(error: airc_trust::PeersStoreError) -> Self {
+        TrustRefreshError::Store(error)
+    }
+}
+
+pub async fn refresh_root(
+    registry: Arc<PeerKeyRegistry>,
+    root: &Path,
+) -> Result<usize, TrustRefreshError> {
+    let peers = airc_trust::load(root).await?;
+    let mut enrolled = 0;
+    for peer in peers {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(peer.pubkey_b64.as_bytes())
+            .map_err(TrustRefreshError::PubkeyBase64)?;
+        let pubkey: [u8; 32] = bytes
+            .try_into()
+            .map_err(|bytes: Vec<u8>| TrustRefreshError::WrongPubkeyLength(bytes.len()))?;
+        registry
+            .enrol(peer.peer_id, 0, pubkey)
+            .map_err(TrustRefreshError::InvalidPubkey)?;
+        enrolled += 1;
+    }
+    Ok(enrolled)
+}

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -414,6 +414,13 @@ follow-up.
   socket; `airc join` starts the current daemon on the current endpoint
   and old scoped daemons become drain candidates instead of blocking
   normal use.
+- **Shared account wires can outpace daemon trust** — CLOSED in the
+  daemon trust-refresh cut. A daemon now registers each subscribed
+  wire's root trust store, refreshes the ORM-backed peer rows before
+  subscription, and keeps that verifier cache synchronized while the
+  daemon runs. Sibling project scopes can publish their durable
+  identity into the shared account wire without requiring a restart or
+  a coincidental CLI command to resync the live verifier.
 
 ### SeaORM perf notes (for Phase 3.5)
 
@@ -574,7 +581,13 @@ context.
    transcript stream.
 3. Add real-machine tailnet/relay proof that exercises the same route
    execution across host boundaries without GitHub routine traffic.
-4. Bind the same command-bus request/reply proof in real Continuum,
+4. Add a consumer-throughput proof for Continuum-shaped live traffic:
+   synthetic room producers at configurable Hz, subscribers in separate
+   scopes first and separate Tailnet/LAN hosts next, with p50/p99
+   latency and drop-rate assertions. This is the proof for pose/avatar
+   streams, fast persona room events, and other high-rate consumers;
+   command-bus request/reply tests are not enough.
+5. Bind the same command-bus request/reply proof in real Continuum,
    OpenClaw, and Hermes repos once their adapters depend on `airc-lib`.
 
 Status:


### PR DESCRIPTION
## Summary
- add daemon trust refresh from the ORM-backed wire root into the live PeerKeyRegistry
- refresh before subscribe and keep one bounded background refresher per trust root
- add a regression proving a subscribed daemon learns sibling-scope trust before ingesting signed frames
- update GRID-SUBSTRATE-AUDIT with the closed shared-account wire trust gap and the Continuum-shaped throughput proof roadmap item

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-daemon --check
- cargo test --manifest-path Cargo.toml -p airc-daemon
- cargo clippy --manifest-path Cargo.toml -p airc-daemon --all-targets -- -D warnings
- git diff --check