### PR TITLE
test(airc-lib): prove Continuum-shaped room throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,20 @@ A small embedding proof lives in [`crates/examples/embedded_consumer_smoke/`](cr
 
 airc includes typed work-coordination events so multiple agents can divide work without treating GitHub as the runtime bus. GitHub issues and pull requests are adapters and projections; the durable coordination model is the event stream.
 
+This is a major part of the product, not a side channel. When several agents are active on one machine, airc gives them a shared coordination substrate:
+
+- kanban cards and lane state are projections of typed events
+- claims are leased, visible, and time-bounded
+- each agent can take an isolated git worktree for its PR
+- peers can announce PRs, CI state, review requests, and handoffs in-room
+- workspace pressure and drain decisions are modeled instead of left to ad hoc cleanup
+
+The practical gain is that agents can split one larger task without sharing a dirty checkout or waiting for a human paste-relay. One agent can take a daemon fix, another can take a throughput proof, and both can watch the same room, issue, PR, and workspace state through airc.
+
 The work domain includes queue cards, claims, heartbeats, PR state, workspace leases, and drain events. This supports a plain operating loop:
 
 - claim before editing
-- use one worktree per agent per PR
+- use one worktree per agent per PR, under `~/.airc/worktrees`
 - heartbeat during long work
 - merge completed PRs into the integration branch instead of leaving stale branches
 - drain rebuildable caches through policy, not ad hoc deletion

--- a/crates/airc-lib/tests/consumer_throughput.rs
+++ b/crates/airc-lib/tests/consumer_throughput.rs
@@ -1,0 +1,138 @@
+//! Continuum-shaped consumer throughput proof.
+//!
+//! This is not the final Tailnet/LAN target benchmark. It is the
+//! CI-safe substrate proof: two independent consumers, separate homes,
+//! explicit trust, one shared local wire, live subscription armed
+//! before send, and a sustained room event stream at realtime-ish
+//! cadence. The real-machine proof can tighten latency thresholds
+//! after this shape is stable.
+
+use std::time::{Duration, Instant};
+
+use airc_lib::{Airc, Body, Headers, PeerSpec};
+use futures::StreamExt;
+use tempfile::TempDir;
+
+const EVENT_COUNT: usize = 90;
+const EVENT_HZ: u64 = 60;
+const RECEIVE_TIMEOUT: Duration = Duration::from_secs(8);
+const CI_P99_MAX: Duration = Duration::from_millis(500);
+
+#[derive(Debug)]
+struct PoseEvent {
+    seq: usize,
+    sent_at: Instant,
+}
+
+impl PoseEvent {
+    fn encode(&self) -> String {
+        // `Instant` is intentionally not serialized. This is a local
+        // integration proof, so the receiver gets the sent_at table
+        // out-of-band from the harness.
+        format!("continuum.pose.fixture seq={}", self.seq)
+    }
+}
+
+#[tokio::test]
+async fn continuum_shaped_pose_stream_delivers_at_60hz_without_drop() {
+    let alice_home = TempDir::new().unwrap();
+    let bob_home = TempDir::new().unwrap();
+    let wire_dir = TempDir::new().unwrap();
+    let wire_path = wire_dir.path().join("wire.jsonl");
+
+    let alice = Airc::open(alice_home.path()).await.unwrap();
+    let bob = Airc::open(bob_home.path()).await.unwrap();
+
+    let alice_spec: PeerSpec = alice.peer_spec().parse().unwrap();
+    let bob_spec: PeerSpec = bob.peer_spec().parse().unwrap();
+    alice.add_peer(bob_spec).await.unwrap();
+    bob.add_peer(alice_spec).await.unwrap();
+
+    alice
+        .join_with_wire("continuum-pose-fixture", wire_path.clone())
+        .await
+        .unwrap();
+    bob.join_with_wire("continuum-pose-fixture", wire_path)
+        .await
+        .unwrap();
+
+    let mut stream = bob.subscribe().await.unwrap();
+    let receiver = tokio::spawn(async move {
+        let deadline = Instant::now() + RECEIVE_TIMEOUT;
+        let mut received = Vec::with_capacity(EVENT_COUNT);
+        while received.len() < EVENT_COUNT && Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let Some(next) = tokio::time::timeout(remaining, stream.next())
+                .await
+                .ok()
+                .flatten()
+            else {
+                break;
+            };
+            let event = next.expect("live stream event must decode");
+            let Some(text) = event.body.as_ref().and_then(Body::as_text) else {
+                continue;
+            };
+            let Some(seq) = text.strip_prefix("continuum.pose.fixture seq=") else {
+                continue;
+            };
+            let seq: usize = seq.parse().expect("fixture seq must be numeric");
+            received.push((seq, Instant::now()));
+        }
+        received
+    });
+
+    let interval = Duration::from_nanos(1_000_000_000 / EVENT_HZ);
+    let mut sent = Vec::with_capacity(EVENT_COUNT);
+    for seq in 0..EVENT_COUNT {
+        let pose = PoseEvent {
+            seq,
+            sent_at: Instant::now(),
+        };
+        let mut headers = Headers::new();
+        headers.insert(
+            "forge.contract".to_string(),
+            "continuum.pose.fixture".to_string(),
+        );
+        headers.insert("continuum.fixture.seq".to_string(), seq.to_string());
+        alice
+            .say_with_headers(&pose.encode(), headers)
+            .await
+            .unwrap();
+        sent.push(pose);
+        tokio::time::sleep(interval).await;
+    }
+
+    let received = receiver.await.expect("receiver task must join");
+    assert_eq!(
+        received.len(),
+        EVENT_COUNT,
+        "pose fixture stream dropped events: received {}/{}",
+        received.len(),
+        EVENT_COUNT
+    );
+
+    let mut seen = vec![false; EVENT_COUNT];
+    let mut latencies = Vec::with_capacity(EVENT_COUNT);
+    for (seq, received_at) in received {
+        assert!(seq < EVENT_COUNT, "received out-of-range seq {seq}");
+        assert!(!seen[seq], "duplicate pose event seq {seq}");
+        seen[seq] = true;
+        latencies.push(received_at.duration_since(sent[seq].sent_at));
+    }
+    assert!(seen.into_iter().all(|hit| hit), "missing pose event seq");
+
+    latencies.sort_unstable();
+    let p50 = percentile(&latencies, 50);
+    let p99 = percentile(&latencies, 99);
+    assert!(
+        p99 <= CI_P99_MAX,
+        "CI-safe p99 exceeded: p50={p50:?} p99={p99:?} max={CI_P99_MAX:?}"
+    );
+}
+
+fn percentile(sorted: &[Duration], percentile: usize) -> Duration {
+    assert!(!sorted.is_empty(), "percentile requires samples");
+    let rank = ((sorted.len() - 1) * percentile) / 100;
+    sorted[rank]
+}


### PR DESCRIPTION
## Summary
- add a consumer-throughput integration proof referenced by docs/architecture/GRID-SUBSTRATE-AUDIT.md
- drive 90 Continuum-shaped pose events at 60 Hz through two separate Airc homes over a shared local wire
- assert signed/trusted live delivery with zero drops, duplicate detection, and CI-safe p99 latency ceiling

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib --check
- cargo test --manifest-path Cargo.toml -p airc-lib
- cargo clippy --manifest-path Cargo.toml -p airc-lib --all-targets -- -D warnings
- git diff --check