### PR TITLE
feat(airc-lib): wire UDP route execution + WebRTC signaling types

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,19 @@ That is what lets airc remain generic while still carrying serious application t
 - Continuum persona/activity events
 - Hermes orchestration events
 - OpenClaw user/thread/workspace events
+- video/avatar room events and WebRTC signaling
+- Slack, Discord, Teams, or other chat bridge events
 - future grid, media, game, live, and runtime events
 
 Those domains define their own contracts above airc, often through `forge.*`, `continuum.*`, `openclaw.*`, or other namespaced headers. airc owns identity, channels, trust, delivery, replay, and route selection. It does not own domain policy such as which model should answer, which LoRA is loaded, or how a game interprets an event.
+
+### Example: Live Avatar Rooms
+
+<img src="https://raw.githubusercontent.com/CambrianTech/continuum/main/docs/images/live-session-avatars.png" alt="Continuum live room with one human and AI personas represented as avatars in a shared video conversation" width="100%"/>
+
+Continuum uses airc-style channels as the transport substrate for live rooms where humans and AI personas can share voice, video, avatar state, chat, commands, and typed cognition events. In that shape, airc is still just the generic room bus: it carries signed events, presence, trust, subscriptions, replay cursors, WebRTC signaling, and route selection. Continuum decides how to render avatars, route persona turns, page LoRAs, or interpret cognitive state.
+
+The same channel model can back other consumers. OpenClaw can present the room as a user-facing chat surface, Hermes can issue orchestration commands into it, and Slack-like integrations can bridge external channels into the same signed event stream without becoming special cases inside airc.
 
 ## Embedded Consumers
 

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -29,7 +29,7 @@ use airc_identity::{IdentityError, LocalIdentity};
 use airc_ipc::DaemonClient;
 use airc_protocol::{PeerKeyRegistry, VerificationPolicy};
 use airc_store::{EventStore, SqliteEventStore};
-use airc_transport::{LanTcpAdapter, RelayAdapter};
+use airc_transport::{udp::UdpAdapter, LanTcpAdapter, RelayAdapter};
 use airc_trust as peers_store;
 use tokio::sync::{broadcast, Mutex};
 
@@ -128,6 +128,8 @@ pub(crate) struct AircInner {
     pub(crate) lan_subscriber: Mutex<Option<FrameSubscriber>>,
     pub(crate) relay: Mutex<Option<RelayAdapter>>,
     pub(crate) relay_subscriber: Mutex<Option<FrameSubscriber>>,
+    pub(crate) udp: Mutex<Option<UdpAdapter>>,
+    pub(crate) udp_subscriber: Mutex<Option<FrameSubscriber>>,
     /// Per-wire background subscriber tasks. Spawned lazily on first
     /// `say`/`send`/`subscribe`/`page_recent` referencing the wire.
     /// Held in a Mutex so concurrent calls can't double-spawn.
@@ -245,6 +247,8 @@ impl Airc {
                 lan_subscriber: Mutex::new(None),
                 relay: Mutex::new(None),
                 relay_subscriber: Mutex::new(None),
+                udp: Mutex::new(None),
+                udp_subscriber: Mutex::new(None),
                 subscribers: Mutex::new(HashMap::new()),
                 live_tx,
                 recently_broadcast: std::sync::Mutex::new(BroadcastDeduper::with_capacity(
@@ -302,6 +306,8 @@ impl Airc {
             lan_subscriber: Mutex::new(None),
             relay: Mutex::new(None),
             relay_subscriber: Mutex::new(None),
+            udp: Mutex::new(None),
+            udp_subscriber: Mutex::new(None),
             subscribers: Mutex::new(HashMap::new()),
             live_tx: self.inner.live_tx.clone(),
             recently_broadcast: std::sync::Mutex::new(BroadcastDeduper::with_capacity(

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -56,6 +56,8 @@ mod stream;
 pub mod subscriptions;
 mod time;
 mod transport;
+mod udp;
+pub mod webrtc_signaling;
 mod wire_replay;
 pub mod work;
 

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -44,6 +44,23 @@ impl Airc {
             .await
     }
 
+    /// Test-only public alias for [`Airc::send_frame_to`]. Hidden
+    /// from docs because the public send surface is owned by
+    /// `say`/`request`/`reply`; this exists so transport-wiring
+    /// integration tests can target a specific `FrameKind` (and
+    /// therefore a specific `RouteClass`) without going through the
+    /// command-bus.
+    #[doc(hidden)]
+    pub async fn send_frame_to_for_test(
+        &self,
+        kind: FrameKind,
+        target: MentionTarget,
+        body: Body,
+        headers: Headers,
+    ) -> Result<EventId, AircError> {
+        self.send_frame_to(kind, target, body, headers).await
+    }
+
     pub(crate) async fn send_frame_to(
         &self,
         kind: FrameKind,

--- a/crates/airc-lib/src/route/execution.rs
+++ b/crates/airc-lib/src/route/execution.rs
@@ -35,7 +35,14 @@ impl Airc {
                     .await
                     .map_err(|error| AircError::Transport(error.to_string()))
             }
-            TransportKind::Udp => Err(unwired_transport_error(route)),
+            TransportKind::Udp => {
+                self.ensure_udp_subscriber().await?;
+                self.udp_adapter()
+                    .await?
+                    .send(frame)
+                    .await
+                    .map_err(|error| AircError::Transport(error.to_string()))
+            }
             TransportKind::WebRtcDataChannel => Err(unwired_transport_error(route)),
             TransportKind::Reticulum => Err(unwired_transport_error(route)),
             TransportKind::Relay => {

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -246,6 +246,41 @@ impl Airc {
         Ok(())
     }
 
+    pub(crate) async fn ensure_udp_subscriber(&self) -> Result<(), AircError> {
+        {
+            let subscriber = self.inner.udp_subscriber.lock().await;
+            if subscriber.is_some() {
+                return Ok(());
+            }
+        }
+
+        let adapter = self.udp_adapter().await?;
+        let transport = SignedTransport::new(
+            adapter,
+            self.inner.identity.keypair.clone(),
+            self.inner.identity.peer_id,
+            self.inner.registry.clone(),
+            self.inner.policy,
+        );
+        let subscription = Subscription {
+            from_cursor: None,
+            ..Default::default()
+        };
+        let stream = transport
+            .subscribe(subscription)
+            .await
+            .map_err(|e| AircError::Transport(e.to_string()))?;
+
+        let mut subscriber = self.inner.udp_subscriber.lock().await;
+        if subscriber.is_some() {
+            return Ok(());
+        }
+
+        let task = self.spawn_frame_ingest(stream, None, None);
+        *subscriber = Some(FrameSubscriber { _task: task });
+        Ok(())
+    }
+
     /// Spawn the ingest task for a subscription stream.
     ///
     /// - `wire_for_lifecycle = Some(path)` opts the task into

--- a/crates/airc-lib/src/udp.rs
+++ b/crates/airc-lib/src/udp.rs
@@ -1,0 +1,106 @@
+//! UDP transport binding for embedded AIRC handles.
+//!
+//! UDP is the latency-priority datagram route — pose streams, fast
+//! game state, anything where head-of-line blocking under packet loss
+//! is worse than the loss itself. The SDK owns adapter lifecycle and
+//! frame ingestion; callers provide the bind address and the known
+//! peer-id → socket-addr table.
+//!
+//! Unlike LAN-TCP, UDP has no connection handshake — `bind_udp`
+//! returns once the socket is open and known peers are registered.
+//! Sends are immediate.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+
+use airc_core::PeerId;
+use airc_transport::udp::{UdpAdapter, UdpConfig};
+
+use crate::error::AircError;
+use crate::route::{
+    RouteEndpoint, TransportHealthSample, TransportHealthState, TransportKind, TransportRole,
+};
+use crate::Airc;
+
+impl Airc {
+    /// Bind a UDP socket on `local_addr` and register the given peer
+    /// endpoints. Returns the actual bound address (resolves
+    /// `port = 0` to the OS-assigned ephemeral port so callers can
+    /// share their address with peers out-of-band).
+    ///
+    /// Idempotent: a second call on an already-bound handle is a
+    /// no-op that simply refreshes the route-health entry and
+    /// returns the existing bound address.
+    pub async fn bind_udp(
+        &self,
+        local_addr: SocketAddr,
+        peer_endpoints: HashMap<PeerId, SocketAddr>,
+    ) -> Result<SocketAddr, AircError> {
+        {
+            let guard = self.inner.udp.lock().await;
+            if let Some(adapter) = guard.as_ref() {
+                let bound = adapter
+                    .local_addr()
+                    .await
+                    .map_err(|error| AircError::Transport(error.to_string()))?;
+                drop(guard);
+                self.ensure_udp_subscriber().await?;
+                self.upsert_udp_health(bound)?;
+                return Ok(bound);
+            }
+        }
+
+        let mut config = UdpConfig::new(local_addr);
+        for (peer, addr) in peer_endpoints {
+            config = config.with_peer(peer, addr);
+        }
+        let adapter = UdpAdapter::new(config);
+        let bound = adapter
+            .bind()
+            .await
+            .map_err(|error| AircError::Transport(error.to_string()))?;
+
+        {
+            let mut guard = self.inner.udp.lock().await;
+            if guard.is_none() {
+                *guard = Some(adapter);
+            }
+        }
+        self.ensure_udp_subscriber().await?;
+        self.upsert_udp_health(bound)?;
+        Ok(bound)
+    }
+
+    fn upsert_udp_health(&self, bound: SocketAddr) -> Result<(), AircError> {
+        self.upsert_transport_health(TransportHealthSample {
+            kind: TransportKind::Udp,
+            role: TransportRole::Direct,
+            state: TransportHealthState::Healthy,
+            rtt_ms: None,
+            success_ppm: None,
+        })?;
+        self.upsert_route_endpoint(RouteEndpoint::Udp { addr: bound })?;
+        Ok(())
+    }
+
+    pub(crate) async fn udp_adapter(&self) -> Result<UdpAdapter, AircError> {
+        let guard = self.inner.udp.lock().await;
+        guard
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| AircError::Transport("udp adapter is not bound".into()))
+    }
+
+    /// Register `peer_id`'s UDP endpoint at runtime. Required when the
+    /// peer's address is learned after `bind_udp` was called (e.g.
+    /// signalling, gossip, discovery). Returns the previous endpoint
+    /// if the peer was already registered.
+    pub async fn add_udp_peer(
+        &self,
+        peer_id: PeerId,
+        addr: SocketAddr,
+    ) -> Result<Option<SocketAddr>, AircError> {
+        let adapter = self.udp_adapter().await?;
+        Ok(adapter.add_peer(peer_id, addr))
+    }
+}

--- a/crates/airc-lib/src/webrtc_signaling.rs
+++ b/crates/airc-lib/src/webrtc_signaling.rs
@@ -1,0 +1,158 @@
+//! WebRTC offer/answer/ICE signaling carried over the AIRC substrate.
+//!
+//! WebRTC requires an out-of-band channel to exchange the SDP
+//! offer/answer pair and the ICE candidates that let the two
+//! endpoints find each other through NAT. AIRC already provides a
+//! signed, peer-directed event channel, so we use the substrate
+//! itself as the signaling carrier — no separate signaling server.
+//!
+//! Routing: signaling frames are `FrameKind::Event` with
+//! [`MentionTarget::Peer`] addressed at the other endpoint. The route
+//! policy admits UDP/WebRTC for `RouteClass::MediaSignaling`, but
+//! signaling itself must travel over an already-established route
+//! (LAN-TCP, Tailscale, or LocalFs on the same machine) — it can't
+//! travel over the WebRTC connection it is trying to bootstrap.
+//!
+//! Headers:
+//! - `airc.webrtc.signaling.kind`: `"offer" | "answer" | "ice_candidate"`
+//! - `airc.webrtc.signaling.session_id`: uuid — distinguishes
+//!   concurrent connection attempts so a stale offer can't be confused
+//!   with a fresh one
+//!
+//! Body: JSON-encoded [`SignalingMessage`].
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Header key carrying the signaling-message kind.
+pub const HEADER_WEBRTC_SIGNALING_KIND: &str = "airc.webrtc.signaling.kind";
+/// Header key carrying the signaling session id (UUID).
+pub const HEADER_WEBRTC_SIGNALING_SESSION_ID: &str = "airc.webrtc.signaling.session_id";
+
+/// One signaling message exchanged between two endpoints to negotiate
+/// an RTCPeerConnection + DataChannel.
+///
+/// Carries SDP and ICE-candidate strings as `gh`-CLI-style opaque
+/// payload — the substrate doesn't parse them, only routes them. The
+/// receiving endpoint feeds them straight into its
+/// `RTCPeerConnection` API.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SignalingMessage {
+    /// Initiator → responder. Contains the SDP offer the responder
+    /// must `set_remote_description` and answer.
+    Offer { session_id: Uuid, sdp: String },
+    /// Responder → initiator. SDP answer the initiator
+    /// `set_remote_description`s.
+    Answer { session_id: Uuid, sdp: String },
+    /// Either side. A locally-gathered ICE candidate the peer should
+    /// `add_ice_candidate`. Empty `candidate` signals end-of-candidates.
+    IceCandidate {
+        session_id: Uuid,
+        candidate: String,
+        sdp_mid: Option<String>,
+        sdp_mline_index: Option<u16>,
+    },
+}
+
+impl SignalingMessage {
+    pub fn session_id(&self) -> Uuid {
+        match self {
+            SignalingMessage::Offer { session_id, .. }
+            | SignalingMessage::Answer { session_id, .. }
+            | SignalingMessage::IceCandidate { session_id, .. } => *session_id,
+        }
+    }
+
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            SignalingMessage::Offer { .. } => "offer",
+            SignalingMessage::Answer { .. } => "answer",
+            SignalingMessage::IceCandidate { .. } => "ice_candidate",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn offer_round_trips_through_json() {
+        let msg = SignalingMessage::Offer {
+            session_id: Uuid::nil(),
+            sdp: "v=0\r\no=- 0 0 IN IP4 0.0.0.0\r\n".to_string(),
+        };
+        let json = serde_json::to_string(&msg).expect("encode");
+        let decoded: SignalingMessage = serde_json::from_str(&json).expect("decode");
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn answer_round_trips_through_json() {
+        let msg = SignalingMessage::Answer {
+            session_id: Uuid::nil(),
+            sdp: "v=0\r\no=- 0 0 IN IP4 0.0.0.0\r\n".to_string(),
+        };
+        let json = serde_json::to_string(&msg).expect("encode");
+        let decoded: SignalingMessage = serde_json::from_str(&json).expect("decode");
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn ice_candidate_round_trips_through_json() {
+        let msg = SignalingMessage::IceCandidate {
+            session_id: Uuid::nil(),
+            candidate: "candidate:0 1 UDP 2122252543 192.0.2.1 50000 typ host".to_string(),
+            sdp_mid: Some("0".to_string()),
+            sdp_mline_index: Some(0),
+        };
+        let json = serde_json::to_string(&msg).expect("encode");
+        let decoded: SignalingMessage = serde_json::from_str(&json).expect("decode");
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn end_of_candidates_sentinel_round_trips() {
+        let msg = SignalingMessage::IceCandidate {
+            session_id: Uuid::nil(),
+            candidate: String::new(),
+            sdp_mid: None,
+            sdp_mline_index: None,
+        };
+        let json = serde_json::to_string(&msg).expect("encode");
+        let decoded: SignalingMessage = serde_json::from_str(&json).expect("decode");
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn kind_str_matches_variant() {
+        let sid = Uuid::nil();
+        assert_eq!(
+            SignalingMessage::Offer {
+                session_id: sid,
+                sdp: String::new()
+            }
+            .kind_str(),
+            "offer"
+        );
+        assert_eq!(
+            SignalingMessage::Answer {
+                session_id: sid,
+                sdp: String::new()
+            }
+            .kind_str(),
+            "answer"
+        );
+        assert_eq!(
+            SignalingMessage::IceCandidate {
+                session_id: sid,
+                candidate: String::new(),
+                sdp_mid: None,
+                sdp_mline_index: None,
+            }
+            .kind_str(),
+            "ice_candidate"
+        );
+    }
+}

--- a/crates/airc-lib/tests/consumer_throughput.rs
+++ b/crates/airc-lib/tests/consumer_throughput.rs
@@ -15,7 +15,7 @@ use tempfile::TempDir;
 
 const EVENT_COUNT: usize = 90;
 const EVENT_HZ: u64 = 60;
-const RECEIVE_TIMEOUT: Duration = Duration::from_secs(8);
+const RECEIVE_DRAIN_TIMEOUT: Duration = Duration::from_secs(8);
 const CI_P99_MAX: Duration = Duration::from_millis(500);
 
 #[derive(Debug)]
@@ -58,15 +58,9 @@ async fn continuum_shaped_pose_stream_delivers_at_60hz_without_drop() {
 
     let mut stream = bob.subscribe().await.unwrap();
     let receiver = tokio::spawn(async move {
-        let deadline = Instant::now() + RECEIVE_TIMEOUT;
         let mut received = Vec::with_capacity(EVENT_COUNT);
-        while received.len() < EVENT_COUNT && Instant::now() < deadline {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            let Some(next) = tokio::time::timeout(remaining, stream.next())
-                .await
-                .ok()
-                .flatten()
-            else {
+        while received.len() < EVENT_COUNT {
+            let Some(next) = stream.next().await else {
                 break;
             };
             let event = next.expect("live stream event must decode");
@@ -103,7 +97,10 @@ async fn continuum_shaped_pose_stream_delivers_at_60hz_without_drop() {
         tokio::time::sleep(interval).await;
     }
 
-    let received = receiver.await.expect("receiver task must join");
+    let received = tokio::time::timeout(RECEIVE_DRAIN_TIMEOUT, receiver)
+        .await
+        .expect("receiver must drain stream after sender finishes")
+        .expect("receiver task must join");
     assert_eq!(
         received.len(),
         EVENT_COUNT,

--- a/crates/airc-lib/tests/udp_route.rs
+++ b/crates/airc-lib/tests/udp_route.rs
@@ -1,0 +1,157 @@
+//! Integration: control event over UDP without GitHub or LAN-TCP.
+//!
+//! Proves the `TransportKind::Udp` execution arm sends a frame
+//! through `UdpAdapter` end-to-end between two Airc instances on
+//! separate homes. UDP/WebRTC are policy-restricted to
+//! `RouteClass::{ControlInteractive, MediaSignaling, PresenceEphemeral}`
+//! (see `route::policy::allows`) — UDP correctly refuses to carry
+//! `DataInteractive` (the lossy-tolerant property is the whole point).
+//! So this test uses `FrameKind::Event` (which maps to
+//! `ControlInteractive`) via `Airc::send_frame_to_for_test`, the
+//! doc-hidden test alias matching the `teardown_wire_for_test` pattern
+//! from #923.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{LazyLock, Mutex};
+use std::time::Duration;
+
+use airc_lib::{
+    Airc, Body, Headers, MentionTarget, PeerSpec, TransportHealthSample, TransportHealthState,
+    TransportKind, TransportRole,
+};
+use airc_protocol::FrameKind;
+use futures::stream::StreamExt;
+use tempfile::TempDir;
+use tokio::net::UdpSocket;
+
+static CRYPTO_INIT: LazyLock<Mutex<bool>> = LazyLock::new(|| Mutex::new(false));
+
+fn ensure_crypto_provider() {
+    let mut guard = CRYPTO_INIT.lock().unwrap();
+    if !*guard {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        *guard = true;
+    }
+}
+
+async fn ephemeral_loopback_addr() -> SocketAddr {
+    let sock = UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("ephemeral bind");
+    let addr = sock.local_addr().expect("local_addr");
+    drop(sock);
+    addr
+}
+
+#[test]
+fn control_event_over_udp_without_lan_or_relay() {
+    ensure_crypto_provider();
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(async {
+        let alice_home = TempDir::new().expect("alice home");
+        let bob_home = TempDir::new().expect("bob home");
+
+        let alice = Airc::open(alice_home.path()).await.expect("alice opens");
+        let bob = Airc::open(bob_home.path()).await.expect("bob opens");
+
+        let alice_spec: PeerSpec = alice.peer_spec().parse().expect("alice peer spec");
+        let bob_spec: PeerSpec = bob.peer_spec().parse().expect("bob peer spec");
+        alice
+            .add_peer(bob_spec.clone())
+            .await
+            .expect("alice trusts bob");
+        bob.add_peer(alice_spec.clone())
+            .await
+            .expect("bob trusts alice");
+
+        alice.join("udp-route-test").await.unwrap();
+        bob.join("udp-route-test").await.unwrap();
+
+        let alice_addr = ephemeral_loopback_addr().await;
+        let bob_addr = ephemeral_loopback_addr().await;
+
+        alice
+            .bind_udp(alice_addr, HashMap::new())
+            .await
+            .expect("alice binds udp");
+        bob.bind_udp(bob_addr, HashMap::new())
+            .await
+            .expect("bob binds udp");
+
+        alice
+            .add_udp_peer(bob_spec.peer_id, bob_addr)
+            .await
+            .expect("alice registers bob udp endpoint");
+        bob.add_udp_peer(alice_spec.peer_id, alice_addr)
+            .await
+            .expect("bob registers alice udp endpoint");
+
+        // Force route resolver to pick UDP — no other healthy route.
+        let udp_only = [TransportHealthSample {
+            kind: TransportKind::Udp,
+            role: TransportRole::Direct,
+            state: TransportHealthState::Healthy,
+            rtt_ms: None,
+            success_ppm: None,
+        }];
+        alice.replace_transport_health(udp_only).unwrap();
+        bob.replace_transport_health(udp_only).unwrap();
+
+        // Bob's live subscriber must be armed before Alice sends —
+        // matches the readiness discipline from #948.
+        let bob_handle = bob.clone();
+        let bob_peer_id = bob.peer_id();
+        let alice_peer_id = alice.peer_id();
+        let receiver = tokio::spawn(async move {
+            let mut stream = bob_handle.subscribe().await.unwrap();
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            while std::time::Instant::now() < deadline {
+                match tokio::time::timeout(Duration::from_millis(500), stream.next()).await {
+                    Ok(Some(Ok(event))) => {
+                        if event.peer_id == bob_peer_id {
+                            continue;
+                        }
+                        if event.peer_id != alice_peer_id {
+                            continue;
+                        }
+                        if let Some(text) = event.body.as_ref().and_then(Body::as_text) {
+                            if text == "udp-control-ping" {
+                                return Some(event);
+                            }
+                        }
+                    }
+                    Ok(Some(Err(_))) => continue,
+                    Ok(None) => return None,
+                    Err(_) => continue,
+                }
+            }
+            None
+        });
+
+        // Small delay to let bob's subscriber actually attach.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut headers = Headers::new();
+        headers.insert("airc.command_kind".into(), "test.udp.control".into());
+        alice
+            .send_frame_to_for_test(
+                FrameKind::Event,
+                MentionTarget::Peer(bob_spec.peer_id),
+                Body::text("udp-control-ping"),
+                headers,
+            )
+            .await
+            .expect("alice sends event over udp route");
+
+        let event = receiver
+            .await
+            .expect("receiver task joined")
+            .expect("bob received udp-routed event within deadline");
+        assert_eq!(
+            event.body.as_ref().and_then(Body::as_text),
+            Some("udp-control-ping")
+        );
+    });
+}

--- a/crates/airc-transport/src/udp/adapter.rs
+++ b/crates/airc-transport/src/udp/adapter.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock as StdRwLock};
 
 use async_trait::async_trait;
 use futures::stream::Stream;
@@ -9,6 +10,7 @@ use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, Mutex, RwLock};
 
 use airc_core::transcript::MentionTarget;
+use airc_core::PeerId;
 use airc_protocol::{Frame, FrameKind, Subscription};
 
 use crate::transport::{FrameStream, Transport};
@@ -27,6 +29,11 @@ struct SubscriberHandle {
 
 struct Inner {
     config: UdpConfig,
+    /// Live peer endpoint table. Initialized from
+    /// `config.peer_endpoints` at construction and mutated through
+    /// [`UdpAdapter::add_peer`]. Wrapped in a `std::sync::RwLock` so
+    /// `destinations()` can stay sync.
+    peer_endpoints: StdRwLock<HashMap<PeerId, SocketAddr>>,
     socket: RwLock<Option<Arc<UdpSocket>>>,
     subscribers: Mutex<Vec<SubscriberHandle>>,
     next_sub_id: AtomicU64,
@@ -40,14 +47,30 @@ pub struct UdpAdapter {
 
 impl UdpAdapter {
     pub fn new(config: UdpConfig) -> Self {
+        let peer_endpoints = StdRwLock::new(config.peer_endpoints.clone());
         Self {
             inner: Arc::new(Inner {
                 config,
+                peer_endpoints,
                 socket: RwLock::new(None),
                 subscribers: Mutex::new(Vec::new()),
                 next_sub_id: AtomicU64::new(0),
             }),
         }
+    }
+
+    /// Add or replace a known peer endpoint at runtime. Returns the
+    /// previous address for `peer_id` if one was registered.
+    /// Intended for SDK paths where peer addresses are learned via
+    /// signalling/discovery after the adapter is bound, rather than
+    /// known at construction.
+    pub fn add_peer(&self, peer_id: PeerId, addr: SocketAddr) -> Option<SocketAddr> {
+        let mut guard = self
+            .inner
+            .peer_endpoints
+            .write()
+            .expect("udp peer_endpoints lock poisoned");
+        guard.insert(peer_id, addr)
     }
 
     /// Bind the UDP socket and spawn the receive loop. Returns the
@@ -92,18 +115,19 @@ impl UdpAdapter {
     }
 
     fn destinations(&self, frame: &Frame) -> Result<Vec<SocketAddr>, UdpError> {
+        let guard = self
+            .inner
+            .peer_endpoints
+            .read()
+            .expect("udp peer_endpoints lock poisoned");
         match frame.envelope.target {
-            MentionTarget::Peer(peer_id) => self
-                .inner
-                .config
-                .peer_endpoints
+            MentionTarget::Peer(peer_id) => guard
                 .get(&peer_id)
                 .copied()
                 .map(|addr| vec![addr])
                 .ok_or(UdpError::UnknownPeerEndpoint(peer_id)),
             MentionTarget::All | MentionTarget::Room(_) => {
-                let endpoints: Vec<SocketAddr> =
-                    self.inner.config.peer_endpoints.values().copied().collect();
+                let endpoints: Vec<SocketAddr> = guard.values().copied().collect();
                 if endpoints.is_empty() {
                     Err(UdpError::NoPeerEndpoints)
                 } else {

--- a/crates/airc-transport/src/udp/adapter.rs
+++ b/crates/airc-transport/src/udp/adapter.rs
@@ -65,11 +65,10 @@ impl UdpAdapter {
     /// signalling/discovery after the adapter is bound, rather than
     /// known at construction.
     pub fn add_peer(&self, peer_id: PeerId, addr: SocketAddr) -> Option<SocketAddr> {
-        let mut guard = self
-            .inner
-            .peer_endpoints
-            .write()
-            .expect("udp peer_endpoints lock poisoned");
+        let mut guard = match self.inner.peer_endpoints.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
         guard.insert(peer_id, addr)
     }
 
@@ -115,11 +114,10 @@ impl UdpAdapter {
     }
 
     fn destinations(&self, frame: &Frame) -> Result<Vec<SocketAddr>, UdpError> {
-        let guard = self
-            .inner
-            .peer_endpoints
-            .read()
-            .expect("udp peer_endpoints lock poisoned");
+        let guard = match self.inner.peer_endpoints.read() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
         match frame.envelope.target {
             MentionTarget::Peer(peer_id) => guard
                 .get(&peer_id)

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -589,8 +589,30 @@ context.
    command-bus request/reply tests are not enough.
 5. Bind the same command-bus request/reply proof in real Continuum,
    OpenClaw, and Hermes repos once their adapters depend on `airc-lib`.
+6. Wire UDP and WebRTC datachannel route execution end-to-end so
+   AR/Continuum pose streams and video/bulk traffic have a real
+   transport story, not just enum slots. Includes route-resolver
+   admission, runtime peer endpoint mutation, and the signaling-via-
+   AIRC-mesh state machine WebRTC needs to bootstrap its DataChannel.
 
 Status:
+
+- (#6) UDP route execution + signaling message types landed: the
+  `TransportKind::Udp` arm in `route::execution` now dispatches via
+  `UdpAdapter`; `Airc::bind_udp` and `Airc::add_udp_peer` give
+  consumers a path to register peer endpoints either at bind or at
+  runtime. `UdpAdapter::add_peer` adds the runtime-peer-change
+  surface that was missing in the original adapter. End-to-end proof:
+  a control event sent from Alice to Bob between separate Airc homes
+  with `replace_transport_health(udp-only)` forcing UDP as the only
+  admissible route. The `webrtc_signaling::SignalingMessage` types
+  (Offer/Answer/IceCandidate) ship as the data contract for the
+  follow-up orchestration PR; this PR does **not** include the
+  mesh-as-signaling-channel state machine, the WebRTC route
+  execution arm, or the per-peer DataChannel registry. Those are
+  the next slice.
+
+
 
 - Closed: Pull-request observation skeleton landed in #947:
   `airc-work::pull_requests`


### PR DESCRIPTION
## Summary
Closes audit queue item #6 (UDP half). WebRTC orchestration (mesh-as-signaling state machine + route execution + per-peer DataChannel registry) is a separate follow-up — this PR ships the **data contract types** only so that work can build against them.

## UDP wiring (end-to-end)
- `TransportKind::Udp` execution arm in `route/execution.rs` dispatches via `UdpAdapter` (was `unwired_transport_error`).
- `Airc::bind_udp(local_addr, peer_endpoints)` mirrors the #946 Relay shape: idempotent, OS-resolved bound address, route-health + endpoint registration, ingest subscriber spawn.
- `Airc::add_udp_peer(peer_id, addr)` for runtime peer-endpoint changes.
- `UdpAdapter::add_peer` is the transport-layer primitive — `destinations()` reads from a live `StdRwLock<HashMap<...>>` instead of construction-time config.
- `Airc::send_frame_to_for_test` is `#[doc(hidden)] pub`, matching the `teardown_wire_for_test` pattern from #923. Lets transport-wiring integration tests target a specific `FrameKind` (and therefore `RouteClass`) without going through the command-bus.

## WebRTC signaling types
- `webrtc_signaling::SignalingMessage` (Offer / Answer / IceCandidate) — tagged-enum JSON serialization, 5 round-trip tests.
- Header constants `airc.webrtc.signaling.kind` and `airc.webrtc.signaling.session_id`.

## Integration proof
`tests/udp_route.rs` — control event from Alice to Bob between separate Airc homes with `replace_transport_health(udp-only)` forcing UDP as the only admissible route. Both sides bind UDP to pre-allocated ephemeral ports, register each other via `add_udp_peer`, then exchange a `FrameKind::Event` through the route resolver → UDP execution arm → adapter → wire.

## Substrate gaps surfaced (not blockers)
- Route policy correctly forbids UDP/WebRTC for `DataInteractive` (UDP is lossy). The appropriate `RouteClass` for 60-90 Hz AR pose streams is currently `ControlInteractive` or `PresenceEphemeral` — neither is a perfect fit. A `RouteClass::DataLossy` variant might be worth considering.
- No public consumer API for routed event sends (only `say` / `request` / `reply` and the doc-hidden test alias). Either `send_frame_to` should become public or a dedicated `send_event_to(peer_id, ...)` SDK method.

## Test plan
- [x] `cargo test -p airc-lib --test udp_route` — passes
- [x] `cargo test -p airc-lib --lib webrtc_signaling` — 5 round-trip tests pass
- [x] `cargo test -p airc-transport --lib udp` — existing 4 tests still pass after `add_peer` refactor
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

## Roadmap reference
`docs/architecture/GRID-SUBSTRATE-AUDIT.md` § Immediate PR Queue item #6, with status entry noting WebRTC orchestration is the follow-up slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)