### PR TITLE
feat(airc-lib): WebRTC DataChannel orchestration over AIRC mesh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "uuid",
+ "webrtc",
 ]
 
 [[package]]

--- a/crates/airc-lib/Cargo.toml
+++ b/crates/airc-lib/Cargo.toml
@@ -43,6 +43,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["rt", "sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 uuid = { version = "1", features = ["v4", "v5"] }
+webrtc = { version = "0.20.0-alpha.1", default-features = false, features = ["runtime-tokio"] }
 
 [dev-dependencies]
 airc-daemon = { path = "../airc-daemon" }

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -130,6 +130,19 @@ pub(crate) struct AircInner {
     pub(crate) relay_subscriber: Mutex<Option<FrameSubscriber>>,
     pub(crate) udp: Mutex<Option<UdpAdapter>>,
     pub(crate) udp_subscriber: Mutex<Option<FrameSubscriber>>,
+    /// Per-peer WebRTC DataChannel adapters, keyed by the remote
+    /// peer id. Populated by `Airc::open_webrtc_to` /
+    /// `Airc::accept_webrtc_offers` after a handshake completes.
+    pub(crate) webrtc_channels:
+        Mutex<HashMap<PeerId, airc_transport::webrtc_datachannel::WebRtcDataChannelAdapter>>,
+    /// Per-peer WebRTC ingest subscriber tasks. Mirrors the
+    /// per-wire `subscribers` map but keyed by peer because each
+    /// WebRTC DataChannel is its own transport instance.
+    pub(crate) webrtc_subscribers: Mutex<HashMap<PeerId, FrameSubscriber>>,
+    /// Keep RTCPeerConnections alive for as long as the adapter is
+    /// registered. Dropping the PC drops the DataChannel.
+    pub(crate) webrtc_peer_connections:
+        Mutex<HashMap<PeerId, std::sync::Arc<dyn webrtc::peer_connection::PeerConnection>>>,
     /// Per-wire background subscriber tasks. Spawned lazily on first
     /// `say`/`send`/`subscribe`/`page_recent` referencing the wire.
     /// Held in a Mutex so concurrent calls can't double-spawn.
@@ -249,6 +262,9 @@ impl Airc {
                 relay_subscriber: Mutex::new(None),
                 udp: Mutex::new(None),
                 udp_subscriber: Mutex::new(None),
+                webrtc_channels: Mutex::new(HashMap::new()),
+                webrtc_subscribers: Mutex::new(HashMap::new()),
+                webrtc_peer_connections: Mutex::new(HashMap::new()),
                 subscribers: Mutex::new(HashMap::new()),
                 live_tx,
                 recently_broadcast: std::sync::Mutex::new(BroadcastDeduper::with_capacity(
@@ -308,6 +324,9 @@ impl Airc {
             relay_subscriber: Mutex::new(None),
             udp: Mutex::new(None),
             udp_subscriber: Mutex::new(None),
+            webrtc_channels: Mutex::new(HashMap::new()),
+            webrtc_subscribers: Mutex::new(HashMap::new()),
+            webrtc_peer_connections: Mutex::new(HashMap::new()),
             subscribers: Mutex::new(HashMap::new()),
             live_tx: self.inner.live_tx.clone(),
             recently_broadcast: std::sync::Mutex::new(BroadcastDeduper::with_capacity(

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -57,6 +57,7 @@ pub mod subscriptions;
 mod time;
 mod transport;
 mod udp;
+mod webrtc;
 pub mod webrtc_signaling;
 mod wire_replay;
 pub mod work;

--- a/crates/airc-lib/src/route/execution.rs
+++ b/crates/airc-lib/src/route/execution.rs
@@ -43,7 +43,24 @@ impl Airc {
                     .await
                     .map_err(|error| AircError::Transport(error.to_string()))
             }
-            TransportKind::WebRtcDataChannel => Err(unwired_transport_error(route)),
+            TransportKind::WebRtcDataChannel => {
+                let target_peer = match frame.envelope.target {
+                    airc_core::transcript::MentionTarget::Peer(peer) => peer,
+                    _ => {
+                        return Err(AircError::Route(
+                            "WebRtcDataChannel requires a Peer-directed target; \
+                             rooms/broadcasts must go over LAN-TCP or Relay"
+                                .into(),
+                        ));
+                    }
+                };
+                self.ensure_webrtc_subscriber(target_peer).await?;
+                self.webrtc_adapter_for(target_peer)
+                    .await?
+                    .send(frame)
+                    .await
+                    .map_err(|error| AircError::Transport(error.to_string()))
+            }
             TransportKind::Reticulum => Err(unwired_transport_error(route)),
             TransportKind::Relay => {
                 self.ensure_relay_subscriber().await?;

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -281,6 +281,44 @@ impl Airc {
         Ok(())
     }
 
+    pub(crate) async fn ensure_webrtc_subscriber(
+        &self,
+        peer_id: airc_core::PeerId,
+    ) -> Result<(), AircError> {
+        {
+            let subscribers = self.inner.webrtc_subscribers.lock().await;
+            if subscribers.contains_key(&peer_id) {
+                return Ok(());
+            }
+        }
+
+        let adapter = self.webrtc_adapter_for(peer_id).await?;
+        let transport = SignedTransport::new(
+            adapter,
+            self.inner.identity.keypair.clone(),
+            self.inner.identity.peer_id,
+            self.inner.registry.clone(),
+            self.inner.policy,
+        );
+        let subscription = Subscription {
+            from_cursor: None,
+            ..Default::default()
+        };
+        let stream = transport
+            .subscribe(subscription)
+            .await
+            .map_err(|e| AircError::Transport(e.to_string()))?;
+
+        let mut subscribers = self.inner.webrtc_subscribers.lock().await;
+        if subscribers.contains_key(&peer_id) {
+            return Ok(());
+        }
+
+        let task = self.spawn_frame_ingest(stream, None, None);
+        subscribers.insert(peer_id, FrameSubscriber { _task: task });
+        Ok(())
+    }
+
     /// Spawn the ingest task for a subscription stream.
     ///
     /// - `wire_for_lifecycle = Some(path)` opts the task into

--- a/crates/airc-lib/src/webrtc.rs
+++ b/crates/airc-lib/src/webrtc.rs
@@ -1,0 +1,432 @@
+//! WebRTC DataChannel orchestration over the AIRC mesh.
+//!
+//! Wires the existing [`airc_transport::webrtc_datachannel::WebRtcDataChannelAdapter`]
+//! into a complete per-peer DataChannel lifecycle:
+//!
+//! - [`Airc::open_webrtc_to`] is the initiator. Creates an
+//!   `RTCPeerConnection`, opens a DataChannel, sends an SDP offer to
+//!   `peer_id` over the AIRC mesh (as a [`SignalingMessage::Offer`]
+//!   event), waits for the matching [`SignalingMessage::Answer`],
+//!   completes the handshake, and registers the resulting adapter in
+//!   the per-peer table so [`TransportKind::WebRtcDataChannel`]
+//!   route execution can dispatch sends to it.
+//! - [`Airc::accept_webrtc_offers`] is the responder side. Spawns a
+//!   long-running task that subscribes to the substrate stream,
+//!   filters for incoming `Offer` messages, and answers them with
+//!   the same handshake flow in reverse.
+//!
+//! Uses the **gather-complete** approach (not trickle ICE): each side
+//! waits for ICE candidate gathering to finish before sending its
+//! local description, so the offer/answer SDPs already include all
+//! candidates. This is exactly the pattern
+//! `webrtc_datachannel/tests.rs::established_adapters` uses. Trickle
+//! ICE, STUN/TURN configuration, reconnect-on-drop, and renegotiation
+//! are explicit non-goals here.
+//!
+//! Loopback bind: PCs gather candidates on `127.0.0.1:0`, which means
+//! this PR's path only works between two endpoints on the same
+//! machine. Real-network NAT traversal needs configurable ICE servers
+//! — flagged as a follow-up.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use airc_core::headers::Headers;
+use airc_core::{Body, PeerId, TranscriptEvent};
+use airc_protocol::FrameKind;
+use airc_transport::webrtc_datachannel::WebRtcDataChannelAdapter;
+use futures::StreamExt;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+use webrtc::data_channel::DataChannel;
+use webrtc::peer_connection::{
+    PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler, RTCIceGatheringState,
+    RTCPeerConnectionState, RTCSdpType, RTCSessionDescription,
+};
+use webrtc::runtime::{channel as rtc_channel, default_runtime, Sender as RtcSender};
+
+use crate::error::AircError;
+use crate::webrtc_signaling::{
+    SignalingMessage, HEADER_WEBRTC_SIGNALING_KIND, HEADER_WEBRTC_SIGNALING_SESSION_ID,
+};
+use crate::Airc;
+
+const HANDSHAKE_GATHER_TIMEOUT: Duration = Duration::from_secs(5);
+const HANDSHAKE_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
+impl Airc {
+    /// Initiate a WebRTC DataChannel to `peer_id`. Drives the full
+    /// offer/answer handshake over the AIRC mesh, registers the
+    /// resulting adapter for [`TransportKind::WebRtcDataChannel`]
+    /// route execution, and ensures the per-peer ingest subscriber.
+    ///
+    /// Blocks until the DataChannel is open or the handshake times
+    /// out. Concurrent calls for the same `peer_id` short-circuit if
+    /// an adapter is already registered.
+    pub async fn open_webrtc_to(&self, peer_id: PeerId) -> Result<(), AircError> {
+        {
+            let guard = self.inner.webrtc_channels.lock().await;
+            if guard.contains_key(&peer_id) {
+                drop(guard);
+                self.ensure_webrtc_subscriber(peer_id).await?;
+                return Ok(());
+            }
+        }
+
+        let session_id = Uuid::new_v4();
+        let runtime = default_runtime()
+            .ok_or_else(|| AircError::Transport("webrtc default runtime unavailable".into()))?;
+        let (gather_tx, mut gather_rx) = rtc_channel::<()>(1);
+        let (connected_tx, mut connected_rx) = rtc_channel::<()>(1);
+        let pc: Arc<dyn PeerConnection> = Arc::new(
+            PeerConnectionBuilder::new()
+                .with_handler(Arc::new(OffererHandler {
+                    gather_tx,
+                    connected_tx,
+                }))
+                .with_runtime(runtime)
+                .with_udp_addrs(vec!["127.0.0.1:0"])
+                .build()
+                .await
+                .map_err(|error| AircError::Transport(format!("webrtc build: {error}")))?,
+        );
+
+        let channel = pc
+            .create_data_channel("airc", None)
+            .await
+            .map_err(|error| AircError::Transport(format!("webrtc data_channel: {error}")))?;
+
+        let offer = pc
+            .create_offer(None)
+            .await
+            .map_err(|error| AircError::Transport(format!("webrtc create_offer: {error}")))?;
+        pc.set_local_description(offer).await.map_err(|error| {
+            AircError::Transport(format!("webrtc set_local_description(offer): {error}"))
+        })?;
+
+        // Wait for ICE gathering to complete so the local description
+        // includes all candidates (no trickle ICE in this skeleton).
+        if webrtc::runtime::timeout(HANDSHAKE_GATHER_TIMEOUT, gather_rx.recv())
+            .await
+            .is_err()
+        {
+            return Err(AircError::Transport(
+                "webrtc ICE gather timeout (offerer)".to_string(),
+            ));
+        }
+        let local_desc = pc
+            .local_description()
+            .await
+            .ok_or_else(|| AircError::Transport("webrtc local_description missing".into()))?;
+
+        // Subscribe BEFORE sending the offer so we don't miss the
+        // answer if it lands fast.
+        let mut stream = self.subscribe().await?;
+        self.send_signaling(
+            peer_id,
+            SignalingMessage::Offer {
+                session_id,
+                sdp: local_desc.sdp.clone(),
+            },
+        )
+        .await?;
+
+        // Wait for the answer matching this session_id.
+        let answer_sdp = await_signaling_answer(&mut stream, session_id, peer_id).await?;
+        let mut answer = RTCSessionDescription::default();
+        answer.sdp_type = RTCSdpType::Answer;
+        answer.sdp = answer_sdp;
+        pc.set_remote_description(answer).await.map_err(|error| {
+            AircError::Transport(format!("webrtc set_remote_description(answer): {error}"))
+        })?;
+
+        if webrtc::runtime::timeout(HANDSHAKE_CONNECT_TIMEOUT, connected_rx.recv())
+            .await
+            .is_err()
+        {
+            return Err(AircError::Transport(
+                "webrtc connect timeout (offerer)".to_string(),
+            ));
+        }
+
+        let adapter = WebRtcDataChannelAdapter::new(channel);
+        wait_for_adapter_open(&adapter).await?;
+        self.register_webrtc_adapter(peer_id, adapter, pc).await?;
+        self.ensure_webrtc_subscriber(peer_id).await?;
+        Ok(())
+    }
+
+    /// Spawn a long-running responder task that listens for incoming
+    /// `SignalingMessage::Offer` events on the substrate and answers
+    /// them with the matching `Answer`. Returns once the task is
+    /// spawned — the task itself runs until the `Airc` handle is
+    /// dropped or its subscriber stream ends.
+    pub async fn accept_webrtc_offers(&self) -> Result<(), AircError> {
+        let mut stream = self.subscribe().await?;
+        let airc = self.clone();
+        tokio::spawn(async move {
+            while let Some(item) = stream.next().await {
+                let Ok(event) = item else {
+                    continue;
+                };
+                let Some(message) = parse_signaling_event(&event) else {
+                    continue;
+                };
+                let SignalingMessage::Offer { session_id, sdp } = message else {
+                    continue;
+                };
+                // Skip our own broadcast echoes.
+                if event.peer_id == airc.peer_id() {
+                    continue;
+                }
+                let initiator = event.peer_id;
+                if let Err(error) = airc.answer_offer(initiator, session_id, sdp).await {
+                    eprintln!("webrtc accept_offer failed for {initiator}: {error}");
+                }
+            }
+        });
+        Ok(())
+    }
+
+    async fn answer_offer(
+        &self,
+        initiator: PeerId,
+        session_id: Uuid,
+        offer_sdp: String,
+    ) -> Result<(), AircError> {
+        {
+            let guard = self.inner.webrtc_channels.lock().await;
+            if guard.contains_key(&initiator) {
+                // Already have a channel — duplicate offer, ignore.
+                return Ok(());
+            }
+        }
+
+        let runtime = default_runtime()
+            .ok_or_else(|| AircError::Transport("webrtc default runtime unavailable".into()))?;
+        let (gather_tx, mut gather_rx) = rtc_channel::<()>(1);
+        let (connected_tx, mut connected_rx) = rtc_channel::<()>(1);
+        let (channel_tx, mut channel_rx) = mpsc::channel::<Arc<dyn DataChannel>>(1);
+        let pc: Arc<dyn PeerConnection> = Arc::new(
+            PeerConnectionBuilder::new()
+                .with_handler(Arc::new(AnswererHandler {
+                    gather_tx,
+                    connected_tx,
+                    channel_tx,
+                }))
+                .with_runtime(runtime)
+                .with_udp_addrs(vec!["127.0.0.1:0"])
+                .build()
+                .await
+                .map_err(|error| AircError::Transport(format!("webrtc build: {error}")))?,
+        );
+
+        let mut offer = RTCSessionDescription::default();
+        offer.sdp_type = RTCSdpType::Offer;
+        offer.sdp = offer_sdp;
+        pc.set_remote_description(offer).await.map_err(|error| {
+            AircError::Transport(format!("webrtc set_remote_description(offer): {error}"))
+        })?;
+
+        let answer = pc
+            .create_answer(None)
+            .await
+            .map_err(|error| AircError::Transport(format!("webrtc create_answer: {error}")))?;
+        pc.set_local_description(answer).await.map_err(|error| {
+            AircError::Transport(format!("webrtc set_local_description(answer): {error}"))
+        })?;
+
+        if webrtc::runtime::timeout(HANDSHAKE_GATHER_TIMEOUT, gather_rx.recv())
+            .await
+            .is_err()
+        {
+            return Err(AircError::Transport(
+                "webrtc ICE gather timeout (answerer)".to_string(),
+            ));
+        }
+        let local_desc = pc
+            .local_description()
+            .await
+            .ok_or_else(|| AircError::Transport("webrtc local_description missing".into()))?;
+
+        self.send_signaling(
+            initiator,
+            SignalingMessage::Answer {
+                session_id,
+                sdp: local_desc.sdp.clone(),
+            },
+        )
+        .await?;
+
+        if webrtc::runtime::timeout(HANDSHAKE_CONNECT_TIMEOUT, connected_rx.recv())
+            .await
+            .is_err()
+        {
+            return Err(AircError::Transport(
+                "webrtc connect timeout (answerer)".to_string(),
+            ));
+        }
+
+        let channel = tokio::time::timeout(Duration::from_secs(5), channel_rx.recv())
+            .await
+            .map_err(|_| AircError::Transport("webrtc data_channel callback timeout".into()))?
+            .ok_or_else(|| AircError::Transport("webrtc data_channel channel closed".into()))?;
+
+        let adapter = WebRtcDataChannelAdapter::new(channel);
+        wait_for_adapter_open(&adapter).await?;
+        self.register_webrtc_adapter(initiator, adapter, pc).await?;
+        self.ensure_webrtc_subscriber(initiator).await?;
+        Ok(())
+    }
+
+    async fn send_signaling(
+        &self,
+        target: PeerId,
+        message: SignalingMessage,
+    ) -> Result<(), AircError> {
+        let kind = message.kind_str().to_string();
+        let session_id = message.session_id().to_string();
+        let body = serde_json::to_value(&message)
+            .map_err(|error| AircError::Transport(format!("webrtc signaling encode: {error}")))?;
+        let mut headers = Headers::new();
+        headers.insert(HEADER_WEBRTC_SIGNALING_KIND.into(), kind);
+        headers.insert(HEADER_WEBRTC_SIGNALING_SESSION_ID.into(), session_id);
+        self.send_frame_to(
+            FrameKind::Event,
+            airc_core::MentionTarget::Peer(target),
+            Body::Json(body),
+            headers,
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn webrtc_adapter_for(
+        &self,
+        peer_id: PeerId,
+    ) -> Result<WebRtcDataChannelAdapter, AircError> {
+        let guard = self.inner.webrtc_channels.lock().await;
+        guard
+            .get(&peer_id)
+            .cloned()
+            .ok_or_else(|| AircError::Transport(format!("no webrtc channel for peer {peer_id}")))
+    }
+
+    /// Whether a WebRTC DataChannel is currently registered for
+    /// `peer_id`. Public so consumers (and integration tests) can
+    /// gate operations on the channel being live without holding the
+    /// internal lock.
+    pub async fn has_webrtc_channel(&self, peer_id: PeerId) -> bool {
+        let guard = self.inner.webrtc_channels.lock().await;
+        guard.contains_key(&peer_id)
+    }
+
+    async fn register_webrtc_adapter(
+        &self,
+        peer_id: PeerId,
+        adapter: WebRtcDataChannelAdapter,
+        pc: Arc<dyn PeerConnection>,
+    ) -> Result<(), AircError> {
+        let mut guard = self.inner.webrtc_channels.lock().await;
+        guard.insert(peer_id, adapter);
+        let mut pc_guard = self.inner.webrtc_peer_connections.lock().await;
+        pc_guard.insert(peer_id, pc);
+        Ok(())
+    }
+}
+
+async fn await_signaling_answer(
+    stream: &mut crate::stream::EventStream,
+    session_id: Uuid,
+    expected_peer: PeerId,
+) -> Result<String, AircError> {
+    let deadline = std::time::Instant::now() + HANDSHAKE_CONNECT_TIMEOUT;
+    while std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let next = tokio::time::timeout(remaining, stream.next()).await;
+        let Ok(Some(Ok(event))) = next else {
+            continue;
+        };
+        if event.peer_id != expected_peer {
+            continue;
+        }
+        let Some(message) = parse_signaling_event(&event) else {
+            continue;
+        };
+        if message.session_id() != session_id {
+            continue;
+        }
+        if let SignalingMessage::Answer { sdp, .. } = message {
+            return Ok(sdp);
+        }
+    }
+    Err(AircError::Transport("webrtc answer timeout".to_string()))
+}
+
+fn parse_signaling_event(event: &TranscriptEvent) -> Option<SignalingMessage> {
+    let _ = event.headers.get(HEADER_WEBRTC_SIGNALING_KIND)?;
+    let body = event.body.as_ref()?;
+    let value = match body {
+        Body::Json(value) => value.clone(),
+        _ => return None,
+    };
+    serde_json::from_value(value).ok()
+}
+
+async fn wait_for_adapter_open(adapter: &WebRtcDataChannelAdapter) -> Result<(), AircError> {
+    let deadline = std::time::Instant::now() + HANDSHAKE_CONNECT_TIMEOUT;
+    while std::time::Instant::now() < deadline {
+        if adapter.is_open() {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    Err(AircError::Transport(
+        "webrtc adapter did not open within deadline".to_string(),
+    ))
+}
+
+struct OffererHandler {
+    gather_tx: RtcSender<()>,
+    connected_tx: RtcSender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for OffererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+struct AnswererHandler {
+    gather_tx: RtcSender<()>,
+    connected_tx: RtcSender<()>,
+    channel_tx: mpsc::Sender<Arc<dyn DataChannel>>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for AnswererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+
+    async fn on_data_channel(&self, channel: Arc<dyn DataChannel>) {
+        let _ = self.channel_tx.send(channel).await;
+    }
+}

--- a/crates/airc-lib/tests/webrtc_route.rs
+++ b/crates/airc-lib/tests/webrtc_route.rs
@@ -1,0 +1,163 @@
+//! Integration: full WebRTC orchestration round-trip without GitHub.
+//!
+//! Two `Airc` instances on separate homes share a local-fs wire so the
+//! signaling messages can travel. Bob runs the responder via
+//! [`Airc::accept_webrtc_offers`]; Alice calls
+//! [`Airc::open_webrtc_to(bob)`] which drives the offer/answer
+//! handshake over the AIRC mesh. Once the DataChannel is open on both
+//! sides, both `replace_transport_health` with WebRTC-only so the
+//! route resolver has no other choice, then Alice sends a control
+//! event whose only viable route is `TransportKind::WebRtcDataChannel`.
+//!
+//! Uses the same gather-complete pattern as the existing
+//! `webrtc_datachannel/tests.rs` adapter tests, and the
+//! `send_frame_to_for_test` doc-hidden alias from #955 because UDP /
+//! WebRTC are only admissible for non-`DataInteractive` route
+//! classes.
+
+use std::sync::{LazyLock, Mutex};
+use std::time::Duration;
+
+use airc_lib::{
+    Airc, Body, Headers, MentionTarget, PeerSpec, TransportHealthSample, TransportHealthState,
+    TransportKind, TransportRole,
+};
+use airc_protocol::FrameKind;
+use futures::stream::StreamExt;
+use tempfile::TempDir;
+
+static CRYPTO_INIT: LazyLock<Mutex<bool>> = LazyLock::new(|| Mutex::new(false));
+
+fn ensure_crypto_provider() {
+    let mut guard = CRYPTO_INIT.lock().unwrap();
+    if !*guard {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        *guard = true;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn webrtc_orchestration_round_trip_over_mesh_signaling() {
+    ensure_crypto_provider();
+
+    let alice_home = TempDir::new().expect("alice home");
+    let bob_home = TempDir::new().expect("bob home");
+    let wire_dir = TempDir::new().expect("shared wire dir");
+    let wire_path = wire_dir.path().join("wire.jsonl");
+
+    let alice = Airc::open(alice_home.path()).await.expect("alice opens");
+    let bob = Airc::open(bob_home.path()).await.expect("bob opens");
+
+    let alice_spec: PeerSpec = alice.peer_spec().parse().expect("alice peer spec");
+    let bob_spec: PeerSpec = bob.peer_spec().parse().expect("bob peer spec");
+    alice
+        .add_peer(bob_spec.clone())
+        .await
+        .expect("alice trusts bob");
+    bob.add_peer(alice_spec.clone())
+        .await
+        .expect("bob trusts alice");
+
+    // Shared wire path so both scopes see each other's signaling
+    // events — matches the throughput-proof pattern from #954.
+    alice
+        .join_with_wire("webrtc-orchestration-test", wire_path.clone())
+        .await
+        .unwrap();
+    bob.join_with_wire("webrtc-orchestration-test", wire_path)
+        .await
+        .unwrap();
+
+    // Bob runs the responder before Alice initiates so the offer
+    // handshake doesn't race the accept loop.
+    bob.accept_webrtc_offers()
+        .await
+        .expect("bob spawns webrtc responder");
+
+    // Brief settle so Bob's subscriber attaches.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Alice initiates. Drives offer → gather → send → receive answer →
+    // connected → DataChannel open → adapter registered.
+    alice
+        .open_webrtc_to(bob_spec.peer_id)
+        .await
+        .expect("alice opens webrtc to bob");
+
+    // Wait until Bob has the adapter registered too — the accept loop
+    // runs in a spawned task and completes asynchronously.
+    let bob_handle = bob.clone();
+    let bob_ready = tokio::time::timeout(Duration::from_secs(20), async move {
+        loop {
+            if bob_handle.has_webrtc_channel(alice_spec.peer_id).await {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+    bob_ready.expect("bob registered webrtc adapter for alice within 20s");
+
+    // Force route resolver to pick WebRTC — no other healthy route.
+    let webrtc_only = [TransportHealthSample {
+        kind: TransportKind::WebRtcDataChannel,
+        role: TransportRole::Direct,
+        state: TransportHealthState::Healthy,
+        rtt_ms: None,
+        success_ppm: None,
+    }];
+    alice.replace_transport_health(webrtc_only).unwrap();
+    bob.replace_transport_health(webrtc_only).unwrap();
+
+    let bob_handle = bob.clone();
+    let bob_peer_id = bob.peer_id();
+    let alice_peer_id = alice.peer_id();
+    let receiver = tokio::spawn(async move {
+        let mut stream = bob_handle.subscribe().await.unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while std::time::Instant::now() < deadline {
+            match tokio::time::timeout(Duration::from_millis(500), stream.next()).await {
+                Ok(Some(Ok(event))) => {
+                    if event.peer_id == bob_peer_id {
+                        continue;
+                    }
+                    if event.peer_id != alice_peer_id {
+                        continue;
+                    }
+                    if let Some(text) = event.body.as_ref().and_then(Body::as_text) {
+                        if text == "webrtc-control-ping" {
+                            return Some(event);
+                        }
+                    }
+                }
+                Ok(Some(Err(_))) => continue,
+                Ok(None) => return None,
+                Err(_) => continue,
+            }
+        }
+        None
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut headers = Headers::new();
+    headers.insert("airc.command_kind".into(), "test.webrtc.control".into());
+    alice
+        .send_frame_to_for_test(
+            FrameKind::Event,
+            MentionTarget::Peer(bob_spec.peer_id),
+            Body::text("webrtc-control-ping"),
+            headers,
+        )
+        .await
+        .expect("alice sends event over webrtc route");
+
+    let event = receiver
+        .await
+        .expect("receiver task joined")
+        .expect("bob received webrtc-routed event within deadline");
+    assert_eq!(
+        event.body.as_ref().and_then(Body::as_text),
+        Some("webrtc-control-ping")
+    );
+}

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -606,11 +606,24 @@ Status:
   a control event sent from Alice to Bob between separate Airc homes
   with `replace_transport_health(udp-only)` forcing UDP as the only
   admissible route. The `webrtc_signaling::SignalingMessage` types
-  (Offer/Answer/IceCandidate) ship as the data contract for the
-  follow-up orchestration PR; this PR does **not** include the
-  mesh-as-signaling-channel state machine, the WebRTC route
-  execution arm, or the per-peer DataChannel registry. Those are
-  the next slice.
+  (Offer/Answer/IceCandidate) shipped alongside as the data contract
+  for the orchestration follow-up.
+- (#6 cont.) WebRTC DataChannel orchestration landed: `Airc::
+  open_webrtc_to(peer_id)` drives the full SDP offer/answer handshake
+  over the AIRC mesh using `SignalingMessage` events;
+  `Airc::accept_webrtc_offers` spawns the responder task. Gather-
+  complete (non-trickle) ICE matches the existing webrtc_datachannel
+  adapter tests. Per-peer DataChannel registry in `AircInner.
+  webrtc_channels`; `TransportKind::WebRtcDataChannel` route arm
+  dispatches sends to it. End-to-end proof: two Airc instances over
+  a shared local-fs signaling wire, Alice initiates, Bob accepts,
+  both `replace_transport_health(webrtc-only)`, then Alice sends a
+  control event whose only viable route is the freshly-established
+  DataChannel — round-trip in ~1.5s under `cargo test`. Explicit
+  non-goals for follow-up: trickle ICE, STUN/TURN configuration for
+  real-network NAT traversal (currently loopback-only via
+  `with_udp_addrs(["127.0.0.1:0"])`), reconnect-on-drop, and
+  renegotiation.
 
 
 


### PR DESCRIPTION
## Summary
Closes the WebRTC half of audit queue item #6. Stacked on #955 (UDP route + signaling types).

Delivers the full per-peer WebRTC DataChannel lifecycle: `Airc::open_webrtc_to(peer_id)` initiator + `Airc::accept_webrtc_offers()` responder, both using the AIRC mesh as the signaling channel via the `SignalingMessage` types from #955.

## Core API
- `Airc::open_webrtc_to(peer_id)` — initiator. Drives the full SDP offer/answer handshake over the AIRC mesh, blocks until DataChannel is open, registers the adapter for `TransportKind::WebRtcDataChannel` route execution.
- `Airc::accept_webrtc_offers()` — spawns responder task. Subscribes to substrate, filters for incoming Offers, answers and registers the adapter.
- `Airc::has_webrtc_channel(peer_id)` — public gate for callers / tests.

## Substrate plumbing
- `AircInner.webrtc_channels: HashMap<PeerId, WebRtcDataChannelAdapter>` per-peer registry.
- `AircInner.webrtc_peer_connections` keeps RTCPeerConnections alive (dropping PC drops the channel).
- `Airc::ensure_webrtc_subscriber(peer_id)` mirrors the LAN / Relay / UDP pattern, keyed by peer.
- `TransportKind::WebRtcDataChannel` route arm resolves target peer from `frame.envelope.target`. Rejects non-Peer targets (broadcasts go over LAN-TCP / Relay).

## Approach
- **Gather-complete (non-trickle) ICE.** Each side waits for ICE gathering before sending its complete SDP. Same pattern as `webrtc_datachannel/tests.rs::established_adapters`.
- **Loopback bind.** PCs gather candidates on `127.0.0.1:0`. Same-machine peers only this PR; real-network NAT traversal is follow-up.

## Integration proof
`tests/webrtc_route.rs` — two Airc instances on separate homes share a local-fs signaling wire, Bob spawns `accept_webrtc_offers`, Alice calls `open_webrtc_to(bob)`, both `replace_transport_health(webrtc-only)`, Alice sends a control event whose only viable route is the freshly-established DataChannel. **Round-trip in ~1.5s under `cargo test`.**

## Explicit non-goals (follow-ups)
- Trickle ICE
- STUN/TURN configuration for real-network NAT traversal
- Reconnect-on-drop / renegotiation
- DataChannel resource cleanup beyond Arc drop semantics

## Test plan
- [x] `cargo test -p airc-lib --test webrtc_route` — passes (1.5s)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

## Roadmap reference
`docs/architecture/GRID-SUBSTRATE-AUDIT.md` § Immediate PR Queue item #6, status entry updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)