### PR TITLE
feat(airc-lib): surface incoming WebRTC media tracks

### DIFF
--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -43,6 +43,7 @@ use crate::route::invite::{ImportedInviteTable, RouteEndpointTable};
 use crate::route::TransportHealthSample;
 use crate::subscriptions::{self, ChannelName, MeshIdentity, Subscription};
 use crate::transport::{FrameSubscriber, WireSubscriber};
+use crate::webrtc_media::{IncomingTrack, IncomingTrackHandler, IncomingTrackRegistry};
 use crate::{coordinator, time};
 
 const EVENTS_DB_FILENAME: &str = "events.sqlite";
@@ -143,6 +144,10 @@ pub(crate) struct AircInner {
     /// registered. Dropping the PC drops the DataChannel.
     pub(crate) webrtc_peer_connections:
         Mutex<HashMap<PeerId, std::sync::Arc<dyn webrtc::peer_connection::PeerConnection>>>,
+    /// Global consumer callback for inbound WebRTC media tracks.
+    pub(crate) webrtc_incoming_track_handler: Mutex<Option<IncomingTrackHandler>>,
+    /// Runtime registry of inbound WebRTC media tracks by peer.
+    pub(crate) webrtc_incoming_tracks: IncomingTrackRegistry,
     /// Per-wire background subscriber tasks. Spawned lazily on first
     /// `say`/`send`/`subscribe`/`page_recent` referencing the wire.
     /// Held in a Mutex so concurrent calls can't double-spawn.
@@ -265,6 +270,8 @@ impl Airc {
                 webrtc_channels: Mutex::new(HashMap::new()),
                 webrtc_subscribers: Mutex::new(HashMap::new()),
                 webrtc_peer_connections: Mutex::new(HashMap::new()),
+                webrtc_incoming_track_handler: Mutex::new(None),
+                webrtc_incoming_tracks: IncomingTrackRegistry::default(),
                 subscribers: Mutex::new(HashMap::new()),
                 live_tx,
                 recently_broadcast: std::sync::Mutex::new(BroadcastDeduper::with_capacity(
@@ -304,6 +311,46 @@ impl Airc {
         self.inner.daemon_client.is_some()
     }
 
+    /// Register the callback invoked when any WebRTC peer connection
+    /// negotiates an inbound media track.
+    ///
+    /// The callback is process-local runtime state. It is not
+    /// persisted because `TrackRemote` handles are live transport
+    /// objects, not replayable transcript data.
+    pub async fn set_incoming_track_handler<F>(&self, handler: F) -> Result<(), AircError>
+    where
+        F: Fn(PeerId, IncomingTrack) + Send + Sync + 'static,
+    {
+        let mut guard = self.inner.webrtc_incoming_track_handler.lock().await;
+        *guard = Some(std::sync::Arc::new(handler));
+        Ok(())
+    }
+
+    /// Return the inbound WebRTC tracks currently registered for a
+    /// peer. This is an inspection surface for consumers and tests;
+    /// media samples themselves are read through the returned
+    /// `TrackRemote` handles.
+    pub async fn incoming_tracks_for_peer(&self, peer_id: PeerId) -> Vec<IncomingTrack> {
+        self.inner
+            .webrtc_incoming_tracks
+            .tracks_for_peer(peer_id)
+            .await
+    }
+
+    pub(crate) async fn handle_incoming_webrtc_track(&self, peer_id: PeerId, track: IncomingTrack) {
+        self.inner
+            .webrtc_incoming_tracks
+            .record(peer_id, track.clone())
+            .await;
+        let handler = {
+            let guard = self.inner.webrtc_incoming_track_handler.lock().await;
+            guard.clone()
+        };
+        if let Some(handler) = handler {
+            handler(peer_id, track);
+        }
+    }
+
     fn with_daemon_client(&self, client: DaemonClient) -> Self {
         let inner = AircInner {
             home: self.inner.home.clone(),
@@ -327,6 +374,8 @@ impl Airc {
             webrtc_channels: Mutex::new(HashMap::new()),
             webrtc_subscribers: Mutex::new(HashMap::new()),
             webrtc_peer_connections: Mutex::new(HashMap::new()),
+            webrtc_incoming_track_handler: Mutex::new(None),
+            webrtc_incoming_tracks: IncomingTrackRegistry::default(),
             subscribers: Mutex::new(HashMap::new()),
             live_tx: self.inner.live_tx.clone(),
             recently_broadcast: std::sync::Mutex::new(BroadcastDeduper::with_capacity(

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -58,6 +58,7 @@ mod time;
 mod transport;
 mod udp;
 mod webrtc;
+pub mod webrtc_media;
 pub mod webrtc_signaling;
 mod wire_replay;
 pub mod work;
@@ -100,6 +101,7 @@ pub use subscriptions::{
     derive_room_id, ChannelName, ChannelNameError, MeshIdentity, Subscription, SubscriptionError,
     SubscriptionSet,
 };
+pub use webrtc_media::{IncomingTrack, IncomingTrackHandler};
 pub use work::{
     AllocateWorkspace, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard, CreateWorkCard,
     CreateWorkLane, HeartbeatWorkspace, ObserveLocalGitWorkspace, ObservePullRequests,

--- a/crates/airc-lib/src/webrtc.rs
+++ b/crates/airc-lib/src/webrtc.rs
@@ -39,6 +39,7 @@ use futures::StreamExt;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 use webrtc::data_channel::DataChannel;
+use webrtc::media_stream::track_remote::TrackRemote;
 use webrtc::peer_connection::{
     PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler, RTCIceGatheringState,
     RTCPeerConnectionState, RTCSdpType, RTCSessionDescription,
@@ -81,6 +82,8 @@ impl Airc {
         let pc: Arc<dyn PeerConnection> = Arc::new(
             PeerConnectionBuilder::new()
                 .with_handler(Arc::new(OffererHandler {
+                    airc: self.clone(),
+                    remote_peer: peer_id,
                     gather_tx,
                     connected_tx,
                 }))
@@ -210,6 +213,8 @@ impl Airc {
         let pc: Arc<dyn PeerConnection> = Arc::new(
             PeerConnectionBuilder::new()
                 .with_handler(Arc::new(AnswererHandler {
+                    airc: self.clone(),
+                    remote_peer: initiator,
                     gather_tx,
                     connected_tx,
                     channel_tx,
@@ -387,6 +392,8 @@ async fn wait_for_adapter_open(adapter: &WebRtcDataChannelAdapter) -> Result<(),
 }
 
 struct OffererHandler {
+    airc: Airc,
+    remote_peer: PeerId,
     gather_tx: RtcSender<()>,
     connected_tx: RtcSender<()>,
 }
@@ -404,9 +411,17 @@ impl PeerConnectionEventHandler for OffererHandler {
             let _ = self.connected_tx.try_send(());
         }
     }
+
+    async fn on_track(&self, track: Arc<dyn TrackRemote>) {
+        self.airc
+            .handle_incoming_webrtc_track(self.remote_peer, track)
+            .await;
+    }
 }
 
 struct AnswererHandler {
+    airc: Airc,
+    remote_peer: PeerId,
     gather_tx: RtcSender<()>,
     connected_tx: RtcSender<()>,
     channel_tx: mpsc::Sender<Arc<dyn DataChannel>>,
@@ -428,5 +443,11 @@ impl PeerConnectionEventHandler for AnswererHandler {
 
     async fn on_data_channel(&self, channel: Arc<dyn DataChannel>) {
         let _ = self.channel_tx.send(channel).await;
+    }
+
+    async fn on_track(&self, track: Arc<dyn TrackRemote>) {
+        self.airc
+            .handle_incoming_webrtc_track(self.remote_peer, track)
+            .await;
     }
 }

--- a/crates/airc-lib/src/webrtc_media.rs
+++ b/crates/airc-lib/src/webrtc_media.rs
@@ -1,0 +1,47 @@
+//! WebRTC media-track consumer surface.
+//!
+//! DataChannel routing lives in [`crate::webrtc`]. This module owns
+//! the generic media-track surface above that connection lifecycle:
+//! inbound track delivery and per-peer inspection. Outbound track
+//! construction lives in a separate implementation lane.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use airc_core::PeerId;
+use tokio::sync::RwLock;
+use webrtc::media_stream::track_remote::TrackRemote;
+
+/// Remote media track delivered by WebRTC.
+pub type IncomingTrack = Arc<dyn TrackRemote>;
+
+/// Global inbound-track callback.
+///
+/// AIRC supplies the peer that negotiated the track and the
+/// `webrtc-rs` remote track object. Consumers decide whether that
+/// track feeds STT, avatar awareness, recording, or another domain
+/// pipeline.
+pub type IncomingTrackHandler = Arc<dyn Fn(PeerId, IncomingTrack) + Send + Sync + 'static>;
+
+/// In-memory per-peer inbound media-track registry.
+///
+/// This is intentionally runtime state rather than event-store state:
+/// WebRTC media tracks are live handles, not replayable transcript
+/// events. Durable metadata can be added later as explicit typed
+/// events if consumers need it.
+#[derive(Clone, Default)]
+pub(crate) struct IncomingTrackRegistry {
+    tracks: Arc<RwLock<HashMap<PeerId, Vec<IncomingTrack>>>>,
+}
+
+impl IncomingTrackRegistry {
+    pub(crate) async fn record(&self, peer_id: PeerId, track: IncomingTrack) {
+        let mut guard = self.tracks.write().await;
+        guard.entry(peer_id).or_default().push(track);
+    }
+
+    pub(crate) async fn tracks_for_peer(&self, peer_id: PeerId) -> Vec<IncomingTrack> {
+        let guard = self.tracks.read().await;
+        guard.get(&peer_id).cloned().unwrap_or_default()
+    }
+}


### PR DESCRIPTION
## Summary
- add `webrtc_media` inbound-track types and per-peer runtime registry
- add `Airc::set_incoming_track_handler` and `Airc::incoming_tracks_for_peer`
- forward `PeerConnectionEventHandler::on_track` from both offerer and answerer paths

## Scope
This is Codex's inbound half from `docs/architecture/WEBRTC-MEDIA-TRACKS-PLAN.md`.

Claude owns the outbound lane: `WebRtcConnectionBuilder`, outgoing audio/video track config, codec defaults, and the `open_webrtc_to` refactor. This PR avoids that surface.

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-lib`
- `cargo test --manifest-path Cargo.toml -p airc-lib --test webrtc_route`
- `cargo clippy --manifest-path Cargo.toml -p airc-lib --all-targets -- -D warnings`
- `cargo clippy --manifest-path Cargo.toml --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm`
- `git diff --check`