### PR TITLE
test(airc-lib): prove WebRTC audio and video tracks

### DIFF
--- a/crates/airc-lib/tests/webrtc_route.rs
+++ b/crates/airc-lib/tests/webrtc_route.rs
@@ -19,8 +19,8 @@ use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
 use airc_lib::{
-    Airc, Body, Headers, MentionTarget, OutgoingAudioTrack, PeerSpec, TransportHealthSample,
-    TransportHealthState, TransportKind, TransportRole,
+    Airc, Body, Headers, MentionTarget, OutgoingAudioTrack, OutgoingVideoTrack, PeerSpec,
+    TransportHealthSample, TransportHealthState, TransportKind, TransportRole,
 };
 use airc_protocol::FrameKind;
 use bytes::Bytes;
@@ -41,7 +41,7 @@ fn ensure_crypto_provider() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn webrtc_builder_negotiates_outgoing_audio_track() {
+async fn webrtc_builder_negotiates_outgoing_media_tracks() {
     ensure_crypto_provider();
 
     let alice_home = TempDir::new().expect("alice home");
@@ -85,19 +85,20 @@ async fn webrtc_builder_negotiates_outgoing_audio_track() {
     let opened = alice
         .webrtc_connection(bob_spec.peer_id)
         .with_audio_track(OutgoingAudioTrack::new("avatar-voice", "avatar-stream"))
+        .with_video_track(OutgoingVideoTrack::new("avatar-video", "avatar-stream"))
         .open()
         .await
         .expect("alice opens media webrtc to bob");
     assert_eq!(opened.outgoing_audio.len(), 1);
-    assert!(opened.outgoing_video.is_empty());
-    let ssrcs = opened.outgoing_audio[0].ssrcs().await;
-    let ssrc = ssrcs
+    assert_eq!(opened.outgoing_video.len(), 1);
+    let audio_ssrcs = opened.outgoing_audio[0].ssrcs().await;
+    let audio_ssrc = audio_ssrcs
         .first()
         .copied()
         .expect("outgoing audio track has an ssrc");
     opened.outgoing_audio[0]
         .write_sample(
-            ssrc,
+            audio_ssrc,
             &Sample {
                 data: Bytes::from_static(&[0xf8, 0xff, 0xfe]),
                 duration: Duration::from_millis(20),
@@ -107,27 +108,59 @@ async fn webrtc_builder_negotiates_outgoing_audio_track() {
         )
         .await
         .expect("alice writes audio sample");
+    let video_ssrcs = opened.outgoing_video[0].ssrcs().await;
+    let video_ssrc = video_ssrcs
+        .first()
+        .copied()
+        .expect("outgoing video track has an ssrc");
+    opened.outgoing_video[0]
+        .write_sample(
+            video_ssrc,
+            &Sample {
+                data: Bytes::from_static(&[
+                    0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a, 0x01, 0x00, 0x01, 0x00,
+                ]),
+                duration: Duration::from_millis(33),
+                ..Default::default()
+            },
+            &[],
+        )
+        .await
+        .expect("alice writes video sample");
 
-    let (remote_peer, track) = tokio::time::timeout(Duration::from_secs(10), async move {
+    let tracks = tokio::time::timeout(Duration::from_secs(10), async move {
+        let mut tracks = Vec::new();
         loop {
             if let Ok(track) = track_rx.try_recv() {
-                return track;
+                tracks.push(track);
+                if tracks.len() == 2 {
+                    return tracks;
+                }
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
     })
     .await
-    .expect("bob receives inbound audio track");
+    .expect("bob receives inbound media tracks");
 
-    assert_eq!(remote_peer, alice_spec.peer_id);
-    assert_eq!(track.kind().await, RtpCodecKind::Audio);
-    assert!(
-        !track.label().await.is_empty(),
-        "remote track should expose a label"
-    );
+    let mut kinds = Vec::new();
+    for (remote_peer, track) in tracks {
+        assert_eq!(remote_peer, alice_spec.peer_id);
+        assert!(
+            !track.label().await.is_empty(),
+            "remote track should expose a label"
+        );
+        kinds.push(track.kind().await);
+    }
+    kinds.sort_by_key(|kind| match kind {
+        RtpCodecKind::Unspecified => 0,
+        RtpCodecKind::Audio => 1,
+        RtpCodecKind::Video => 2,
+    });
+    assert_eq!(kinds, vec![RtpCodecKind::Audio, RtpCodecKind::Video]);
 
     let registered = bob.incoming_tracks_for_peer(alice_spec.peer_id).await;
-    assert_eq!(registered.len(), 1);
+    assert_eq!(registered.len(), 2);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docs/architecture/WEBRTC-MEDIA-TRACKS-PLAN.md
+++ b/docs/architecture/WEBRTC-MEDIA-TRACKS-PLAN.md
@@ -1,9 +1,10 @@
 # WebRTC Media Tracks — API Sketch and Scope
 
-Status: **planning doc, no code yet.** Awaiting Joel's review before
-implementation begins. This is the proposed shape for the
-`airc-lib` media-track SDK that #957's WebRTC orchestration enables
-but doesn't yet expose.
+Status: **baseline implemented.** #960 added inbound media-track
+delivery and the per-peer registry. #961 added the outbound
+connection builder, closed-set Opus/VP8 codec surface, and writable
+sample-track handles. The remaining work is hardening the media path
+for consumer integration, not proving the basic API exists.
 
 ## Goal
 
@@ -24,16 +25,16 @@ Consumers (Continuum) own:
 
 ## Scope cuts (this PR)
 
-**IN:**
+**Baseline now in-tree:**
 - Pre-connect track attachment (tracks added before the offer/answer
   exchange — frozen for the lifetime of the connection)
 - Opinion-ated defaults for the common case: Opus audio, VP8 video
 - Outbound: a sample-writer handle returned to the caller
 - Inbound: a callback or per-peer stream of incoming `TrackRemote`
-- Integration test exercising audio sample round-trip between two
+- Integration test exercising audio/video negotiation between two
   Airc instances on a shared signaling wire
 
-**OUT (deferred to follow-ups):**
+**Still deferred to follow-ups:**
 - **Renegotiation** — adding/removing tracks after the connection is
   established. This needs the signaling state machine to handle
   re-offer events on an existing PC, which is a substantial expansion
@@ -159,20 +160,20 @@ Rationale:
 - Continuum-side avatar rendering can always re-encode if a specific
   hardware encoder is preferred.
 
-## Open questions for Joel
+## Remaining Design Decisions
 
-1. **Codec escape hatch.** Should `OutgoingAudioTrack` /
-   `OutgoingVideoTrack` accept a `with_codec(mime_type)` override
-   for callers that need H264 / AV1 / G.711? Or is opinion-ated-only
-   acceptable for v1?
+1. **Codec expansion.** `WebRtcMediaCodec` is intentionally a
+   closed enum, not a string MIME escape hatch. Add H264 / AV1 /
+   G.711 as explicit variants only when a consumer proof needs them.
 
 2. **Track count limits.** A single PC can carry multiple audio/video
    tracks (e.g. avatar voice + ambient audio). The proposed builder
    accepts a `Vec`. Is unbounded fine, or should there be a sanity
    cap?
 
-3. **Inbound surface shape.** Global callback (proposed) vs per-peer
-   receiver vs both. Recommendation above is global callback first.
+3. **Inbound surface shape.** Global callback and per-peer inspection
+   are in-tree. Per-peer receiver streams remain optional ergonomic
+   sugar if Continuum wants dedicated tasks per peer.
 
 4. **Failure mode when peer doesn't accept the track kinds.** SDP
    negotiation can refuse a codec/track. Surface as an `AircError`
@@ -184,22 +185,35 @@ Rationale:
    declared at session start — they can't go from "voice-only" to
    "voice + video" mid-call without dropping and reconnecting.
 
-## Implementation sketch (rough)
+## Implementation Record
 
-Once the API is approved, the implementation:
+1. #960 added `airc-lib/src/webrtc_media.rs` inbound track types,
+   handler registration, per-peer runtime registry, and `on_track`
+   forwarding from offerer/answerer handlers.
+2. #961 added `WebRtcConnectionBuilder`, `OutgoingAudioTrack`,
+   `OutgoingVideoTrack`, `OpenedWebRtcConnection`, and
+   `OutgoingSampleTrack`.
+3. `Airc::open_webrtc_to(peer_id)` now delegates through the builder
+   so the no-media path and media path share the same connection
+   lifecycle.
+4. The integration proof negotiates tracks over the existing AIRC
+   signaling wire, returns writable local sample handles, and verifies
+   the responder sees inbound `TrackRemote` handles.
 
-1. New module `airc-lib/src/webrtc_media.rs` with `WebRtcConnectionBuilder`,
-   `OutgoingAudioTrack`, `OutgoingVideoTrack`, `OpenedWebRtcConnection`.
-2. Refactor `Airc::open_webrtc_to(peer_id)` internals to delegate to
-   `webrtc_connection(peer_id).open()` so the no-tracks path stays
-   identical.
-3. Update `OffererHandler` and `AnswererHandler` (currently in
-   `webrtc.rs`) to forward `on_track` events to the global inbound
-   handler.
-4. Add `inner.webrtc_incoming_track_handler: Mutex<Option<...>>` to
-   `AircInner`.
-5. Integration test: two Airc instances, audio track only, Alice
-   writes a sample, Bob's handler fires with a matching `TrackRemote`.
+## Next Consumer Proof
+
+The next useful proof is not another substrate type. It is a
+consumer-shaped fixture:
+
+1. A Continuum-like avatar peer opens a WebRTC connection with Opus
+   audio and VP8 video tracks.
+2. A second peer accepts the connection, receives both tracks, and
+   records per-track metadata without parsing AIRC internals.
+3. A control event travels over the DataChannel during the same
+   session, proving media and command/control share the same peer
+   lifecycle without conflating media frames with transcript bodies.
+4. The test asserts no GitHub, no shell, and no consumer-specific
+   code in `airc-lib`.
 
 ## Why this scope is honest
 


### PR DESCRIPTION
## Summary
- extend the WebRTC media integration proof to negotiate both Opus audio and VP8 video tracks
- write one sample to each outgoing track and assert the responder receives both remote track kinds
- update the media-track plan from planning status to implemented baseline + next consumer proof

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib
- cargo test --manifest-path Cargo.toml -p airc-lib --test webrtc_route
- cargo clippy --manifest-path Cargo.toml -p airc-lib --all-targets -- -D warnings
- cargo clippy --manifest-path Cargo.toml --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm
- git diff --check