### PR TITLE
feat(airc-lib): typed lane-coordination events

### DIFF
--- a/crates/airc-lib/src/lane_coordination.rs
+++ b/crates/airc-lib/src/lane_coordination.rs
@@ -1,0 +1,409 @@
+//! Typed lane-coordination events.
+//!
+//! Closes GRID-SUBSTRATE-AUDIT flaw #3 (#964): "prose-only lane
+//! claims." Before this module, when one agent took a lane the only
+//! way another agent learned about it was a free-text chat message
+//! like "taking AIRC flaw #3 from #964" that the receiving agent had
+//! to grep through inbox prose to discover.
+//!
+//! After this module, an agent calls
+//! [`Airc::claim_lane`]/[`Airc::release_lane`]/[`Airc::complete_lane`]/
+//! [`Airc::block_on_lane`] and the substrate emits a signed event
+//! with stable headers any subscriber can filter on:
+//!
+//! - `airc.coord.kind` = `"claim" | "release" | "complete" | "block_on"`
+//! - `airc.coord.lane_id` = caller-supplied stable id
+//! - `airc.coord.pr` = optional PR number this lane became / blocks on
+//!
+//! Body is JSON-encoded [`LaneCoordinationEvent`]. Frame kind is
+//! `Event` so the route policy treats this as control-class traffic
+//! (the same class WebRTC signaling and other coordination metadata
+//! use).
+//!
+//! Scope cut: this module ships the *contract* — typed events + a
+//! query that returns the latest event per lane_id by replaying the
+//! transcript. It does **not** ship automatic enforcement
+//! ("can't double-claim", "must release before complete"), a
+//! scheduler ("auto-assign me an unclaimed lane"), or a CLI surface
+//! (`airc lane claim ...`). Each of those is its own follow-up
+//! discussed in the PR description.
+
+use std::sync::Arc;
+
+use airc_core::headers::Headers;
+use airc_core::transcript::MentionTarget;
+use airc_core::{Body, PeerId, TranscriptEvent};
+use airc_protocol::FrameKind;
+use futures::stream::StreamExt;
+use serde::{Deserialize, Serialize};
+
+use crate::error::AircError;
+use crate::Airc;
+
+/// Header carrying the lane-action kind. Stable string so subscribers
+/// can filter without parsing the body.
+pub const HEADER_COORD_KIND: &str = "airc.coord.kind";
+/// Header carrying the caller-supplied lane identifier.
+pub const HEADER_COORD_LANE_ID: &str = "airc.coord.lane_id";
+/// Header carrying an associated PR number (optional). Useful when a
+/// claim resolves into a real PR — observers can join claim →
+/// completion events to a concrete artifact.
+pub const HEADER_COORD_PR: &str = "airc.coord.pr";
+
+/// What an agent is asserting about a coordination lane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LaneAction {
+    /// "I am taking this lane and intend to ship it." Other agents
+    /// should avoid duplicating effort.
+    Claim,
+    /// "I am abandoning this lane (handing back)." Cleans up after a
+    /// claim if the original owner can no longer ship it.
+    Release,
+    /// "Lane is shipped." Emit alongside the resulting PR number so
+    /// observers can close it off the active list.
+    Complete,
+    /// "I am blocked on another lane / PR." Useful when an agent
+    /// can't progress until something else lands; surfaces the
+    /// dependency to scheduling logic later.
+    BlockOn,
+}
+
+impl LaneAction {
+    pub fn header_value(self) -> &'static str {
+        match self {
+            LaneAction::Claim => "claim",
+            LaneAction::Release => "release",
+            LaneAction::Complete => "complete",
+            LaneAction::BlockOn => "block_on",
+        }
+    }
+}
+
+/// One typed coordination message. Body of the event; the substrate
+/// header `airc.coord.lane_id` carries the same `lane_id` so
+/// subscribers can filter without decoding the body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaneCoordinationEvent {
+    pub action: LaneAction,
+    pub lane_id: String,
+    pub owner: PeerId,
+    /// Free-text reason. Kept short — this is metadata, not a chat
+    /// transcript.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rationale: Option<String>,
+    /// PR this lane will become or is blocked on. Optional because
+    /// claims are typically emitted before the PR exists.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u64>,
+    /// Lane this claim depends on. Only meaningful for
+    /// `LaneAction::BlockOn`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocked_on_lane_id: Option<String>,
+}
+
+impl LaneCoordinationEvent {
+    pub fn matches_lane(&self, lane_id: &str) -> bool {
+        self.lane_id == lane_id
+    }
+}
+
+/// What the substrate knows about a lane based on the transcript so
+/// far. Returned by [`Airc::lane_status`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaneStatus {
+    /// The latest event seen for this lane, by lamport. `None` if the
+    /// lane has never appeared.
+    pub latest: Option<LaneCoordinationEvent>,
+    /// Full history (oldest → newest) for the lane in this query
+    /// window.
+    pub history: Vec<LaneCoordinationEvent>,
+}
+
+impl LaneStatus {
+    pub fn is_claimed(&self) -> bool {
+        matches!(
+            self.latest.as_ref().map(|event| event.action),
+            Some(LaneAction::Claim) | Some(LaneAction::BlockOn)
+        )
+    }
+
+    pub fn is_complete(&self) -> bool {
+        matches!(
+            self.latest.as_ref().map(|event| event.action),
+            Some(LaneAction::Complete)
+        )
+    }
+
+    pub fn current_owner(&self) -> Option<PeerId> {
+        self.latest.as_ref().map(|event| event.owner)
+    }
+}
+
+impl Airc {
+    /// Publish a "claim" coordination event for `lane_id`. Other
+    /// agents subscribed to the substrate stream see the typed
+    /// event; their scheduling logic (or the human watching the
+    /// inbox) avoids double-taking the lane.
+    pub async fn claim_lane(
+        &self,
+        lane_id: impl Into<String>,
+        rationale: Option<String>,
+    ) -> Result<(), AircError> {
+        self.publish_lane_event(LaneCoordinationEvent {
+            action: LaneAction::Claim,
+            lane_id: lane_id.into(),
+            owner: self.peer_id(),
+            rationale,
+            pr_number: None,
+            blocked_on_lane_id: None,
+        })
+        .await
+    }
+
+    pub async fn release_lane(
+        &self,
+        lane_id: impl Into<String>,
+        rationale: Option<String>,
+    ) -> Result<(), AircError> {
+        self.publish_lane_event(LaneCoordinationEvent {
+            action: LaneAction::Release,
+            lane_id: lane_id.into(),
+            owner: self.peer_id(),
+            rationale,
+            pr_number: None,
+            blocked_on_lane_id: None,
+        })
+        .await
+    }
+
+    pub async fn complete_lane(
+        &self,
+        lane_id: impl Into<String>,
+        pr_number: u64,
+    ) -> Result<(), AircError> {
+        self.publish_lane_event(LaneCoordinationEvent {
+            action: LaneAction::Complete,
+            lane_id: lane_id.into(),
+            owner: self.peer_id(),
+            rationale: None,
+            pr_number: Some(pr_number),
+            blocked_on_lane_id: None,
+        })
+        .await
+    }
+
+    pub async fn block_on_lane(
+        &self,
+        lane_id: impl Into<String>,
+        blocked_on_lane_id: impl Into<String>,
+        rationale: Option<String>,
+    ) -> Result<(), AircError> {
+        self.publish_lane_event(LaneCoordinationEvent {
+            action: LaneAction::BlockOn,
+            lane_id: lane_id.into(),
+            owner: self.peer_id(),
+            rationale,
+            pr_number: None,
+            blocked_on_lane_id: Some(blocked_on_lane_id.into()),
+        })
+        .await
+    }
+
+    /// Walk recent transcript history for coordination events on
+    /// `lane_id` and return the latest plus the full ordered history.
+    ///
+    /// `window` is the number of recent events to scan; pass a
+    /// generous value (e.g. 512) for lanes that may have been
+    /// claimed early in a session. Callers wanting the absolute full
+    /// history should page through the store directly — this is the
+    /// convenience query for "what's the current state of this
+    /// lane?"
+    pub async fn lane_status(&self, lane_id: &str, window: usize) -> Result<LaneStatus, AircError> {
+        let recent = self.page_recent(window).await?;
+        let mut history: Vec<(u64, LaneCoordinationEvent)> = Vec::new();
+        for event in &recent {
+            let Some(parsed) = parse_lane_event(event) else {
+                continue;
+            };
+            if parsed.lane_id != lane_id {
+                continue;
+            }
+            history.push((event.lamport, parsed));
+        }
+        history.sort_by_key(|(lamport, _)| *lamport);
+        let latest = history.last().map(|(_, event)| event.clone());
+        let history = history.into_iter().map(|(_, event)| event).collect();
+        Ok(LaneStatus { latest, history })
+    }
+
+    /// Subscribe to coordination events. Wraps the substrate stream
+    /// with a filter that only yields `LaneCoordinationEvent`s, so
+    /// schedulers and dashboards don't need to know the header /
+    /// body format.
+    pub async fn subscribe_lane_coordination(
+        &self,
+    ) -> Result<
+        impl futures::stream::Stream<Item = (Arc<TranscriptEvent>, LaneCoordinationEvent)>,
+        AircError,
+    > {
+        let inner = self.subscribe().await?;
+        Ok(inner.filter_map(|item| async move {
+            let event = item.ok()?;
+            let parsed = parse_lane_event(&event)?;
+            Some((event, parsed))
+        }))
+    }
+
+    async fn publish_lane_event(&self, event: LaneCoordinationEvent) -> Result<(), AircError> {
+        let kind = event.action.header_value();
+        let lane_id = event.lane_id.clone();
+        let pr_number = event.pr_number;
+        let body = serde_json::to_value(&event)
+            .map_err(|error| AircError::Crypto(format!("lane coordination encode: {error}")))?;
+
+        let mut headers = Headers::new();
+        headers.insert(HEADER_COORD_KIND.into(), kind.to_string());
+        headers.insert(HEADER_COORD_LANE_ID.into(), lane_id);
+        if let Some(pr) = pr_number {
+            headers.insert(HEADER_COORD_PR.into(), pr.to_string());
+        }
+
+        self.send_frame_to(
+            FrameKind::Event,
+            MentionTarget::All,
+            Body::Json(body),
+            headers,
+        )
+        .await?;
+        Ok(())
+    }
+}
+
+fn parse_lane_event(event: &TranscriptEvent) -> Option<LaneCoordinationEvent> {
+    // The header filter is the cheap path. Bodies are only decoded
+    // when the header indicates this is a coordination event.
+    let _ = event.headers.get(HEADER_COORD_KIND)?;
+    let body = event.body.as_ref()?;
+    let value = match body {
+        Body::Json(value) => value.clone(),
+        _ => return None,
+    };
+    serde_json::from_value(value).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_claim() -> LaneCoordinationEvent {
+        LaneCoordinationEvent {
+            action: LaneAction::Claim,
+            lane_id: "audit:#964:flaw-3".to_string(),
+            owner: PeerId::new(),
+            rationale: Some("test claim".to_string()),
+            pr_number: None,
+            blocked_on_lane_id: None,
+        }
+    }
+
+    fn sample_complete(pr: u64) -> LaneCoordinationEvent {
+        LaneCoordinationEvent {
+            action: LaneAction::Complete,
+            lane_id: "audit:#964:flaw-3".to_string(),
+            owner: PeerId::new(),
+            rationale: None,
+            pr_number: Some(pr),
+            blocked_on_lane_id: None,
+        }
+    }
+
+    #[test]
+    fn claim_event_round_trips_through_json() {
+        let event = sample_claim();
+        let json = serde_json::to_string(&event).expect("encode");
+        let decoded: LaneCoordinationEvent = serde_json::from_str(&json).expect("decode");
+        assert_eq!(decoded, event);
+    }
+
+    #[test]
+    fn release_event_round_trips_through_json() {
+        let event = LaneCoordinationEvent {
+            action: LaneAction::Release,
+            lane_id: "lane-x".to_string(),
+            owner: PeerId::new(),
+            rationale: Some("handing back".to_string()),
+            pr_number: None,
+            blocked_on_lane_id: None,
+        };
+        let json = serde_json::to_string(&event).expect("encode");
+        let decoded: LaneCoordinationEvent = serde_json::from_str(&json).expect("decode");
+        assert_eq!(decoded, event);
+    }
+
+    #[test]
+    fn complete_event_round_trips_through_json() {
+        let event = sample_complete(957);
+        let json = serde_json::to_string(&event).expect("encode");
+        let decoded: LaneCoordinationEvent = serde_json::from_str(&json).expect("decode");
+        assert_eq!(decoded, event);
+        assert_eq!(decoded.pr_number, Some(957));
+    }
+
+    #[test]
+    fn block_on_event_round_trips_with_dependency() {
+        let event = LaneCoordinationEvent {
+            action: LaneAction::BlockOn,
+            lane_id: "lane-y".to_string(),
+            owner: PeerId::new(),
+            rationale: Some("needs upstream change".to_string()),
+            pr_number: None,
+            blocked_on_lane_id: Some("lane-z".to_string()),
+        };
+        let json = serde_json::to_string(&event).expect("encode");
+        let decoded: LaneCoordinationEvent = serde_json::from_str(&json).expect("decode");
+        assert_eq!(decoded, event);
+        assert_eq!(decoded.blocked_on_lane_id.as_deref(), Some("lane-z"));
+    }
+
+    #[test]
+    fn header_values_are_stable() {
+        assert_eq!(LaneAction::Claim.header_value(), "claim");
+        assert_eq!(LaneAction::Release.header_value(), "release");
+        assert_eq!(LaneAction::Complete.header_value(), "complete");
+        assert_eq!(LaneAction::BlockOn.header_value(), "block_on");
+    }
+
+    #[test]
+    fn lane_status_is_claimed_after_claim_only() {
+        let status = LaneStatus {
+            latest: Some(sample_claim()),
+            history: vec![sample_claim()],
+        };
+        assert!(status.is_claimed());
+        assert!(!status.is_complete());
+    }
+
+    #[test]
+    fn lane_status_is_complete_after_complete_supersedes_claim() {
+        let claim = sample_claim();
+        let complete = sample_complete(957);
+        let status = LaneStatus {
+            latest: Some(complete.clone()),
+            history: vec![claim, complete],
+        };
+        assert!(!status.is_claimed());
+        assert!(status.is_complete());
+    }
+
+    #[test]
+    fn lane_status_empty_history_reads_unclaimed() {
+        let status = LaneStatus {
+            latest: None,
+            history: Vec::new(),
+        };
+        assert!(!status.is_claimed());
+        assert!(!status.is_complete());
+        assert!(status.current_owner().is_none());
+    }
+}

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -44,6 +44,7 @@ pub mod error;
 pub mod gh_account_registry;
 pub mod join_context;
 mod lan;
+pub mod lane_coordination;
 pub mod lifecycle;
 pub mod mesh_identity;
 mod messaging;
@@ -83,6 +84,10 @@ pub use coordinator::{
 pub use error::AircError;
 pub use gh_account_registry::{gh_auth_ready, GhAccountRegistryStore};
 pub use join_context::{JoinContext, GENERAL_CHANNEL};
+pub use lane_coordination::{
+    LaneAction, LaneCoordinationEvent, LaneStatus, HEADER_COORD_KIND, HEADER_COORD_LANE_ID,
+    HEADER_COORD_PR,
+};
 pub use mesh_identity::{
     load_cached as load_cached_mesh_identity, resolve as resolve_mesh_identity,
     resolve_with as resolve_mesh_identity_with, CachedIdentity, MeshIdentityError,

--- a/crates/airc-lib/tests/lane_coordination_round_trip.rs
+++ b/crates/airc-lib/tests/lane_coordination_round_trip.rs
@@ -1,0 +1,133 @@
+//! Integration: typed lane-coordination events round-trip between
+//! two Airc instances over a shared local-fs wire.
+//!
+//! Proves the substrate primitive for GRID-SUBSTRATE-AUDIT flaw #3.
+//! Alice claims a lane; Bob queries the lane status from his side
+//! and sees the claim. Then Alice completes the lane with a PR
+//! number; Bob's next query reads the completion as the latest
+//! event. Bob never has to parse free-text chat — the events are
+//! signed substrate primitives with stable headers.
+
+use std::time::Duration;
+
+use airc_lib::{Airc, LaneAction, PeerSpec};
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn lane_claim_and_complete_round_trip_between_two_airc_instances() {
+    let alice_home = TempDir::new().expect("alice home");
+    let bob_home = TempDir::new().expect("bob home");
+    let wire_dir = TempDir::new().expect("shared wire dir");
+    let wire_path = wire_dir.path().join("wire.jsonl");
+
+    let alice = Airc::open(alice_home.path()).await.expect("alice opens");
+    let bob = Airc::open(bob_home.path()).await.expect("bob opens");
+
+    let alice_spec: PeerSpec = alice.peer_spec().parse().expect("alice peer spec");
+    let bob_spec: PeerSpec = bob.peer_spec().parse().expect("bob peer spec");
+    alice
+        .add_peer(bob_spec.clone())
+        .await
+        .expect("alice trusts bob");
+    bob.add_peer(alice_spec.clone())
+        .await
+        .expect("bob trusts alice");
+
+    alice
+        .join_with_wire("lane-coord-test", wire_path.clone())
+        .await
+        .expect("alice joins");
+    bob.join_with_wire("lane-coord-test", wire_path)
+        .await
+        .expect("bob joins");
+
+    // Alice claims the lane.
+    let lane = "audit:#964:flaw-3";
+    alice
+        .claim_lane(lane, Some("typed coordination skeleton".to_string()))
+        .await
+        .expect("alice publishes claim");
+
+    // Allow the shared-wire subscriber a moment to ingest.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Bob queries the lane status — should see Alice's claim as the
+    // latest event with the expected owner.
+    let status = bob.lane_status(lane, 64).await.expect("bob queries status");
+    assert!(
+        status.is_claimed(),
+        "lane should read as claimed after Alice's claim"
+    );
+    assert!(!status.is_complete(), "lane should not yet be complete");
+    let latest = status.latest.expect("latest claim present");
+    assert_eq!(latest.lane_id, lane);
+    assert_eq!(latest.action, LaneAction::Claim);
+    assert_eq!(latest.owner, alice_spec.peer_id);
+    assert_eq!(
+        latest.rationale.as_deref(),
+        Some("typed coordination skeleton")
+    );
+
+    // Alice completes the lane with a fictional PR number.
+    alice
+        .complete_lane(lane, 999)
+        .await
+        .expect("alice publishes completion");
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let status = bob
+        .lane_status(lane, 64)
+        .await
+        .expect("bob queries status after completion");
+    assert!(!status.is_claimed(), "completion supersedes the claim");
+    assert!(status.is_complete(), "lane should read complete");
+    let latest = status.latest.expect("latest event present");
+    assert_eq!(latest.action, LaneAction::Complete);
+    assert_eq!(latest.pr_number, Some(999));
+    assert_eq!(
+        status.history.len(),
+        2,
+        "history should contain both the claim and the completion"
+    );
+}
+
+#[tokio::test]
+async fn unrelated_lane_does_not_pollute_status() {
+    let alice_home = TempDir::new().expect("alice home");
+    let bob_home = TempDir::new().expect("bob home");
+    let wire_dir = TempDir::new().expect("shared wire dir");
+    let wire_path = wire_dir.path().join("wire.jsonl");
+
+    let alice = Airc::open(alice_home.path()).await.expect("alice opens");
+    let bob = Airc::open(bob_home.path()).await.expect("bob opens");
+
+    let alice_spec: PeerSpec = alice.peer_spec().parse().expect("alice peer spec");
+    let bob_spec: PeerSpec = bob.peer_spec().parse().expect("bob peer spec");
+    alice.add_peer(bob_spec).await.expect("trust");
+    bob.add_peer(alice_spec).await.expect("trust");
+    alice
+        .join_with_wire("lane-coord-isolation", wire_path.clone())
+        .await
+        .expect("alice joins");
+    bob.join_with_wire("lane-coord-isolation", wire_path)
+        .await
+        .expect("bob joins");
+
+    // Alice claims lane X.
+    alice.claim_lane("lane-x", None).await.expect("claim x");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // Bob queries lane Y — should see nothing for Y, even though X is
+    // visible on the same wire.
+    let status_y = bob.lane_status("lane-y", 64).await.expect("query y");
+    assert!(
+        status_y.latest.is_none(),
+        "unrelated lane must read empty even when other lanes are active"
+    );
+    assert!(status_y.history.is_empty());
+
+    // And lane X reads correctly.
+    let status_x = bob.lane_status("lane-x", 64).await.expect("query x");
+    assert!(status_x.is_claimed());
+}

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -120,6 +120,18 @@ theoretical architecture concerns; they showed up in normal use.
    wired into normal agent coordination so "claim lane C2" becomes an
    event/projection, not just a sentence.
 
+   **Substrate primitive landed** via `airc-lib::lane_coordination`:
+   `LaneCoordinationEvent` (action ∈ Claim/Release/Complete/BlockOn,
+   lane_id, owner peer, optional pr_number/blocked_on_lane_id),
+   stable headers (`airc.coord.kind` / `lane_id` / `pr`), publish
+   helpers (`Airc::claim_lane` / `release_lane` / `complete_lane` /
+   `block_on_lane`), query (`Airc::lane_status(lane_id, window)`),
+   and a filtered stream (`Airc::subscribe_lane_coordination`).
+   Closed the typed-primitive half. Open follow-ups: roster UI that
+   renders active claims (overlaps with flaw #2), scheduler that
+   auto-assigns unclaimed lanes, and enforcement (refuse second claim
+   while first is open).
+
 4. **System lifecycle noise pollutes normal inbox reads.**
    `WireEstablished` and `SubscriptionAdvanced` events are valuable, but
    raw `airc inbox` interleaves them with human/agent chat. During


### PR DESCRIPTION
## Summary
Closes flaw #3 from GRID-SUBSTRATE-AUDIT (#964): "prose-only lane claims." Lane ownership is now a typed substrate event, not a free-text chat string other agents have to grep through inbox prose to discover.

## API
- `Airc::claim_lane(lane_id, rationale)`
- `Airc::release_lane(lane_id, rationale)`
- `Airc::complete_lane(lane_id, pr_number)`
- `Airc::block_on_lane(lane_id, blocked_on_lane_id, rationale)`
- `Airc::lane_status(lane_id, window) -> LaneStatus` (latest event + ordered history)
- `Airc::subscribe_lane_coordination()` — filtered stream yielding only coord events

## Headers (filterable without body decode)
- `airc.coord.kind` = `"claim" | "release" | "complete" | "block_on"`
- `airc.coord.lane_id`
- `airc.coord.pr` (optional)

Body is JSON-encoded `LaneCoordinationEvent`. FrameKind::Event so route policy treats this as ControlInteractive — same class as WebRTC signaling.

## Test plan
- [x] 8 unit tests — round-trip on each LaneAction, header stability, LaneStatus state transitions
- [x] 2 integration tests on two Airc instances over a shared local-fs wire: claim+complete round-trip; lane isolation (lane Y returns empty even when X is active on the same wire)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

## Scope cuts (explicit non-goals)
- No automatic enforcement ("refuse second claim while first open"). Substrate ships the contract; scheduler is separate.
- No scheduler / auto-assignment.
- No CLI surface (`airc lane claim ...`). Add when agents need shell access.
- Roster UI rendering active claims overlaps with flaw #2 — natural follow-up, lives above this primitive.

## Roadmap reference
`docs/architecture/GRID-SUBSTRATE-AUDIT.md` § Observed Flaws #3 — status entry added marking the typed-primitive half closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)