### PR TITLE
fix(cli): restore IRC-shaped peers and whois commands

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -282,6 +282,21 @@ pub enum Command {
     /// Manage the persisted peer trust registry.
     Peer(PeerArgs),
 
+    /// List enrolled peers in the current scope.
+    ///
+    /// IRC-shaped public command. Equivalent to `airc peer list`,
+    /// kept as the low-friction human / agent coordination surface.
+    Peers,
+
+    /// Show identity information for self or an enrolled peer.
+    ///
+    /// With no target, prints this scope's identity card. With a peer
+    /// id or prefix, prints the enrolled trust entry for that peer.
+    Whois {
+        /// Optional peer UUID or unambiguous UUID prefix.
+        peer: Option<String>,
+    },
+
     /// Inspect transport route policy and candidate selection.
     Route(RouteArgs),
 

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -766,6 +766,50 @@ pub async fn run_peer_list(home: &Path) -> Result<(), Box<dyn std::error::Error>
     Ok(())
 }
 
+/// `whois <peer>` — print the trust entry for an enrolled peer.
+///
+/// Rich peer identity cards are a roster-layer follow-up. This command
+/// is intentionally honest today: it resolves the peer trust entry that
+/// controls message verification instead of pretending to have profile
+/// metadata that is not yet published on the substrate.
+pub async fn run_whois_peer(home: &Path, target: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let peers = airc.peers().await?;
+    let matches = peers
+        .iter()
+        .filter(|peer| peer.peer_id.to_string().starts_with(target))
+        .collect::<Vec<_>>();
+
+    match matches.as_slice() {
+        [] => {
+            println!("peer not found: {target}");
+            if peers.is_empty() {
+                println!("(no enroled peers — use `airc peer add <spec>` to enrol)");
+            } else {
+                println!("known peers:");
+                for peer in peers {
+                    println!("  {}  {}", peer.peer_id, peer.pubkey_b64);
+                }
+            }
+            Err("peer not found".into())
+        }
+        [peer] => {
+            println!("  peer_id:   {}", peer.peer_id);
+            println!("  pubkey:    {}", peer.pubkey_b64);
+            println!("  identity:  not published yet");
+            println!("  source:    peer trust store");
+            Ok(())
+        }
+        _ => {
+            println!("ambiguous peer prefix: {target}");
+            for peer in matches {
+                println!("  {}  {}", peer.peer_id, peer.pubkey_b64);
+            }
+            Err("ambiguous peer prefix".into())
+        }
+    }
+}
+
 // Silence the unused-import warning for `ClientId`: it's used
 // transitively through `LocalIdentity::client_id` (the
 // `airc_core::ClientId` newtype) but not referenced by name in this

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -364,6 +364,13 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             PeerAction::List => commands::run_peer_list(&home).await,
         },
 
+        Command::Peers => commands::run_peer_list(&home).await,
+
+        Command::Whois { peer } => match peer {
+            Some(peer) => commands::run_whois_peer(&home, &peer).await,
+            None => identity_commands::run_show(&home).await,
+        },
+
         Command::Route(args) => match args.action {
             RouteAction::Status(args) => route_commands::run_status(args),
         },

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -292,14 +292,71 @@ fn peer_remove_deletes_enrolled_peer() {
     );
 
     let mut list = command_for_home(&alice_home);
-    list.args(["--home", alice_home.to_str().unwrap(), "peer", "list"]);
-    let list_output = output_with_timeout(list, Duration::from_secs(10), "airc peer list");
+    list.args(["--home", alice_home.to_str().unwrap(), "peers"]);
+    let list_output = output_with_timeout(list, Duration::from_secs(10), "airc peers");
     assert!(list_output.status.success());
     assert!(
         !String::from_utf8_lossy(&list_output.stdout).contains(&bob_id),
         "removed peer should not appear in list: {}",
         String::from_utf8_lossy(&list_output.stdout),
     );
+}
+
+#[test]
+fn irc_shaped_peers_and_whois_commands_are_available() {
+    let workspace = TempDir::new().expect("tempdir");
+    let alice_home = workspace.path().join("alice");
+    let bob_home = workspace.path().join("bob");
+    let (bob_id, bob_spec) = run_init(&bob_home);
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(async {
+        let airc = airc_lib::Airc::open(&alice_home).await.unwrap();
+        airc.add_peer(bob_spec.parse().unwrap()).await.unwrap();
+    });
+
+    let mut peers = command_for_home(&alice_home);
+    peers.args(["--home", alice_home.to_str().unwrap(), "peers"]);
+    let peers_output = output_with_timeout(peers, Duration::from_secs(10), "airc peers");
+    assert!(
+        peers_output.status.success(),
+        "peers failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&peers_output.stdout),
+        String::from_utf8_lossy(&peers_output.stderr),
+    );
+    let peers_stdout = String::from_utf8_lossy(&peers_output.stdout);
+    assert!(peers_stdout.contains(&bob_id), "{peers_stdout}");
+
+    let prefix = &bob_id[..8];
+    let mut whois_peer = command_for_home(&alice_home);
+    whois_peer.args(["--home", alice_home.to_str().unwrap(), "whois", prefix]);
+    let whois_peer_output =
+        output_with_timeout(whois_peer, Duration::from_secs(10), "airc whois <peer>");
+    assert!(
+        whois_peer_output.status.success(),
+        "whois peer failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&whois_peer_output.stdout),
+        String::from_utf8_lossy(&whois_peer_output.stderr),
+    );
+    let whois_peer_stdout = String::from_utf8_lossy(&whois_peer_output.stdout);
+    assert!(whois_peer_stdout.contains(&bob_id), "{whois_peer_stdout}");
+    assert!(
+        whois_peer_stdout.contains("source:    peer trust store"),
+        "{whois_peer_stdout}"
+    );
+
+    let mut whois_self = command_for_home(&alice_home);
+    whois_self.args(["--home", alice_home.to_str().unwrap(), "whois"]);
+    let whois_self_output = output_with_timeout(whois_self, Duration::from_secs(10), "airc whois");
+    assert!(
+        whois_self_output.status.success(),
+        "whois self failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&whois_self_output.stdout),
+        String::from_utf8_lossy(&whois_self_output.stderr),
+    );
+    let whois_self_stdout = String::from_utf8_lossy(&whois_self_output.stdout);
+    assert!(whois_self_stdout.contains("name:"), "{whois_self_stdout}");
+    assert!(whois_self_stdout.contains("role:"), "{whois_self_stdout}");
 }
 
 fn strip_cargo_harness_env(command: &mut Command) {

--- a/docs/DATA-MODEL-REFERENCE.md
+++ b/docs/DATA-MODEL-REFERENCE.md
@@ -149,7 +149,7 @@ clears `is_default` if applicable; the row stays for replay
 fidelity.
 
 **Owner**: `airc join` / `airc room`. **Readers**: every send/recv
-path, `airc peer list`, `airc status`.
+path, `airc peers`, `airc status`.
 
 ---
 

--- a/docs/PHASE-3.5-MIGRATION.md
+++ b/docs/PHASE-3.5-MIGRATION.md
@@ -50,7 +50,7 @@ The first `airc join` after upgrade:
 5. Reads the wire to backfill any unseen events into the
    `events` table.
 
-What you'll see if it worked: `airc peer list` shows enrolled
+What you'll see if it worked: `airc peers` shows enrolled
 peers (post-#903 it reads from the account-mesh union, so HOME
 peers + scope peers both show up); `airc msg "..."` reports
 "N paired peer(s)" with N > 0.
@@ -118,7 +118,7 @@ What it means: pre-#903 bug where `Airc::peers()` loaded scope-local
 trust instead of the account-mesh union. Fixed in #903.
 
 Recovery: upgrade to a post-#903 binary. If you're already there,
-verify with `airc peer list` (should show HOME + per-scope peers).
+verify with `airc peers` (should show HOME + per-scope peers).
 
 ## What you should clean up by hand
 

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -97,14 +97,16 @@ agents coordinated Continuum integration over AIRC. They are not
 theoretical architecture concerns; they showed up in normal use.
 
 1. **Runtime skill/docs drift from the installed CLI.** The installed
-   Codex skills still referenced `airc peers` and `airc whois`, while
-   the current command surface exposes `airc peer list` and has no
-   `whois` command. This makes agents trust stale instructions and
-   burns time on nonexistent commands. Skills must be generated or
-   verified from the installed CLI contract during `airc update`.
+   Codex skills referenced the correct IRC-shaped public verbs
+   (`airc peers`, `airc whois`), while the Rust CLI exposed only a
+   lower-level `airc peer list` path and no top-level `whois` command.
+   This makes agents trust stale instructions and burns time on
+   nonexistent commands. Skills must be generated or verified from the
+   installed CLI contract during `airc update`, and IRC-shaped verbs
+   should remain the public surface when they match the product model.
 
 2. **Peer roster is too low-level for human/agent coordination.**
-   `airc peer list` prints peer IDs and public keys only. It does not
+   `airc peers` prints peer IDs and public keys only. It does not
    show nick, runtime kind, project scope, room subscriptions,
    last-seen timestamp, or live/stale status. With several Claude
    agents plus Codex online, this forced manual inference from inbox
@@ -151,6 +153,19 @@ theoretical architecture concerns; they showed up in normal use.
    worktrees or prevent accidental edits in a dirty main checkout.
    Worktree leases should become the default for claimed work, with
    status/drain commands showing ownership and cleanup eligibility.
+
+8. **Operational logging is mixed into stdout/stderr command output.**
+   Several user-facing commands print lifecycle, debug, install, and
+   coordination status directly to stdout/stderr. That makes the CLI
+   brittle when it is mistaken for an integration surface: hooks,
+   monitors, scripts, and consumer SDKs cannot reliably distinguish
+   protocol state from incidental diagnostics. AIRC needs a
+   logging/event abstraction with explicit sinks and levels. Even when
+   debug output ultimately lands on stdout/stderr for a terminal, it
+   must be emitted through that diagnostic abstraction, not scattered
+   `println!`/`eprintln!` calls. Integration contracts must use real
+   channels — `airc-lib`, daemon IPC, ORM-backed projections, and AIRC
+   events — not stdout/stderr parsing.
 
 These flaws do not invalidate the substrate path. They identify the
 next product gap: the transport now works well enough that the weak

--- a/skills/peers/SKILL.md
+++ b/skills/peers/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: airc:peers
-description: List paired peers in this scope. Add --prune to clean stale records (same-host duplicates left over from rename chain-breaks before stable-host matching landed).
+description: List enrolled peers in this scope.
 user-invocable: true
 allowed-tools: Bash
-argument-hint: "[--prune]"
+argument-hint: ""
 ---
 
 # airc peers
@@ -16,21 +16,19 @@ Run this yourself — don't ask the user.
 airc peers
 ```
 
-Prints one line per paired peer: `<name> → <ssh-target>`.
-
-```bash
-airc peers --prune
-```
-
-Removes stale peer records whose `host` matches a newer record (cruft from rename chain-breaks before stable-host identity landed). Prints `pruned: <name> -> <host>` per removal, or `No stale records to prune.` if clean.
+Prints one line per paired peer. Current Rust output is the verification
+truth: `<peer-id> <public-key>`.
+Rich names, runtime kind, project scope, last-seen status, and live/stale
+readiness belong to the roster projection follow-up.
 
 ## When to use
 
 - Before sending — confirm the peer name you want is actually paired.
-- After a host rename burst or multi-reconnect session, to spot duplicate records (same host, different names).
+- When coordinating work, confirm the peer identity you expect is enrolled.
 - Debugging "who am I actually talking to?"
 
 ## Notes
 
-- `--prune` is safe: it only removes records whose host matches another record's host (same machine+user, different name). Keeps the most-recently-paired one.
-- Peer records are pulled fresh from disk each call; no caching.
+- This is the IRC-shaped public command. `airc peer list` is the lower-level structured equivalent.
+- Peer trust rows are loaded from the ORM-backed trust store each call.
+- Cleanup belongs to typed drain/roster workflows, not ad hoc `--prune` behavior.

--- a/skills/whois/SKILL.md
+++ b/skills/whois/SKILL.md
@@ -1,26 +1,26 @@
 ---
 name: airc:whois
-description: Look up identity (name, pronouns, role, bio, status, integrations) for self / host / paired peer / fellow joiner across all subscribed rooms. IRC /whois analog.
+description: Look up this scope's identity, or inspect an enrolled peer trust entry. IRC /whois analog.
 user-invocable: true
 allowed-tools: Bash
-argument-hint: "[<peer-name>]"
+argument-hint: "[<peer-id-or-prefix>]"
 ---
 
-# /whois — Look up identity for a peer
+# /whois — Look up identity / peer trust
 
 Run this yourself — don't ask the user.
 
 ## Execute
 
 ```bash
-airc whois <peer-name>
+airc whois <peer-id-or-prefix>
 ```
 
 ```bash
-airc whois         # prints YOUR own identity (self)
+airc whois         # prints this scope's own identity card
 ```
 
-Output is a structured block:
+Self output is a structured identity block:
 
 ```
   name:      build-d1f4
@@ -29,19 +29,20 @@ Output is a structured block:
   bio:       CI and release coordination for the current project
   status:    in a meeting til 3pm
   integrations: (none)
-  host:      joelteply@100.91.51.87
 ```
 
-## Resolution order (per scope)
+Peer output is the enrolled trust entry:
 
-For each subscribed scope (primary first, then sidecars):
+```
+  peer_id:   543c0bf7-15a3-48be-bc9b-876a7b586926
+  pubkey:    <base64-url-public-key>
+  identity:  not published yet
+  source:    peer trust store
+```
 
-1. **Self** — short-circuits, prints your own identity.
-2. **Host** — when target name matches the scope's `host_name`, reads `host_identity` cached at handshake.
-3. **Local peer file** — `<scope>/peers/<target>.json` if you've paired with the target directly.
-4. **Cross-peer-via-host** — single SSH read of host's `peers/<target>.json` for fellow joiners in the same room.
-
-If primary scope misses, sibling sidecar scopes are walked (issue #134) — so a peer who's only in your `#general` sidecar resolves cleanly from a project-scope cwd.
+Rich peer names, roles, room subscriptions, live/stale status, and
+published identity cards belong to the roster projection follow-up.
+Do not pretend that data exists before the roster layer publishes it.
 
 ## When to use
 
@@ -51,14 +52,12 @@ If primary scope misses, sibling sidecar scopes are walked (issue #134) — so a
 
 ## When the lookup will 404
 
-- Target hasn't published identity yet (peer file exists but identity blob is empty → fields show `(unset)`).
-- Target is in a room you're not subscribed to (no scope to walk).
-- Target name is misspelled — names are lowercase alphanumeric + `-`.
+- Target peer id/prefix is not enrolled in this scope's trust store.
+- Target prefix matches more than one enrolled peer.
 
 The error message lists `airc peers` as a hint so the user can list valid names.
 
 ## Notes
 
 - Whois is a one-shot command. Doesn't require a running monitor. Safe to call any time.
-- Cross-scope walk runs at most one SSH per scope. Cheap.
-- Identity is cached at pair-handshake time — no live propagation if the peer changes their `identity` mid-session. They re-pair (or you do) to refresh.
+- This is the public IRC-shaped command. `airc identity show` is the lower-level self-only equivalent.


### PR DESCRIPTION
## Summary
- restore top-level IRC-shaped `airc peers` and `airc whois` commands in the Rust CLI
- keep `airc peer list` as the lower-level structured equivalent, but stop teaching it as the primary public verb
- update skills/docs to match the public command surface and record the diagnostic-channel flaw in the grid audit
- add e2e coverage for `airc peers`, `airc whois`, and `airc whois <peer-prefix>`

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-cli irc_shaped_peers_and_whois_commands_are_available
- cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-cli --test e2e peer_remove_deletes_enrolled_peer
- bash test/rust_quality_guard.sh
- bash test/rust_cutover_guard.sh
- git diff --check
- cargo test --manifest-path Cargo.toml -p airc-cli