### PR TITLE
docs(webrtc): show Continuum live-room integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ Reference consumer-shape contracts live in [`crates/examples/consumer_shapes/`](
 
 A small embedding proof lives in [`crates/examples/embedded_consumer_smoke/`](crates/examples/embedded_consumer_smoke/). It uses `airc-lib` directly, with two separate consumers exchanging events over a shared wire and replaying by cursor.
 
+Integration notes:
+
+- [Generic agents](integrations/generic/README.md)
+- [Continuum](integrations/continuum/README.md)
+- [OpenClaw](integrations/openclaw/README.md)
+- [Hermes](integrations/hermes/README.md)
+- [WebRTC](integrations/webrtc/README.md)
+
 ## Work Coordination
 
 airc includes typed work-coordination events so multiple agents can divide work without treating GitHub as the runtime bus. GitHub issues and pull requests are adapters and projections; the durable coordination model is the event stream.

--- a/docs/architecture/WEBRTC-MEDIA-TRACKS-PLAN.md
+++ b/docs/architecture/WEBRTC-MEDIA-TRACKS-PLAN.md
@@ -14,6 +14,14 @@ piece (#957) gives those avatars a typed-event control channel. This
 PR extends the same per-peer WebRTC connection with **audio and
 video media tracks** so the avatar can also send/receive AV.
 
+<img src="https://raw.githubusercontent.com/CambrianTech/continuum/main/docs/images/live-session-avatars.png" alt="Continuum live room with one human and AI personas represented as avatars in a shared video conversation" width="100%"/>
+
+The image above is a consumer example, not a substrate dependency.
+AIRC provides the signed channel, peer identity, subscriptions,
+WebRTC signaling, DataChannel control plane, and media-track
+connection lifecycle. Continuum renders the room, owns persona state,
+and decides how avatar audio/video maps to cognition.
+
 Substrate stays generic: it owns the WebRTC connection lifecycle,
 codec negotiation, track attachment, and the inbound-track surface.
 Consumers (Continuum) own:

--- a/integrations/continuum/README.md
+++ b/integrations/continuum/README.md
@@ -2,6 +2,16 @@
 
 Continuum is the capability host in the airc grid model — it owns LLMs, LoRA collections, paging strategy, and persona state. Continuum personas run as airc peers. The integration shape is a typed event vocabulary on the airc wire, not a direct API binding.
 
+<img src="https://raw.githubusercontent.com/CambrianTech/continuum/main/docs/images/live-session-avatars.png" alt="Continuum live room with one human and AI personas represented as avatars in a shared video conversation" width="100%"/>
+
+In a live room, Continuum can use AIRC channels for room presence,
+chat, persona turns, command events, WebRTC signaling, and
+DataChannel control. Audio/video media rides the WebRTC media path;
+AIRC coordinates the signed channel and peer lifecycle around it.
+That same substrate shape can also serve OpenClaw chat surfaces,
+Hermes orchestration, Slack-like bridges, and other consumers without
+making AIRC specific to any one product.
+
 ## How Continuum embeds airc
 
 Continuum links [`airc-lib`](../../crates/airc-lib/) directly. The embedding shape is the one proven by [`embedded_consumer_smoke`](../../crates/examples/embedded_consumer_smoke/) and codified in [`consumer_shapes::continuum`](../../crates/examples/consumer_shapes/src/continuum.rs):

--- a/integrations/webrtc/README.md
+++ b/integrations/webrtc/README.md
@@ -1,0 +1,50 @@
+# WebRTC Integration
+
+AIRC can coordinate WebRTC sessions without becoming a media
+application. The substrate owns identity, signed room events,
+subscriptions, route selection, WebRTC signaling, DataChannel control,
+and the peer connection lifecycle. Consumers own rendering, media
+production, speech, avatar behavior, moderation, and domain policy.
+
+<img src="https://raw.githubusercontent.com/CambrianTech/continuum/main/docs/images/live-session-avatars.png" alt="Continuum live room with one human and AI personas represented as avatars in a shared video conversation" width="100%"/>
+
+Continuum's live avatar room is one concrete consumer: humans and AI
+personas share a room, while AIRC provides the signed channel and
+WebRTC coordination needed for chat, commands, presence, replay,
+DataChannel control, and audio/video track setup. Continuum decides how
+to render avatars, route persona turns, page LoRAs, and interpret
+cognitive state.
+
+The same shape applies to other consumers:
+
+- OpenClaw can present AIRC rooms as user-facing chats and calls.
+- Hermes can orchestrate tools and agents through typed command events.
+- Slack, Discord, Teams, or IRC bridges can map external channels into
+  signed AIRC rooms.
+- Games, VR, and live collaboration tools can use the same signaling
+  and control plane while keeping media/rendering logic outside AIRC.
+
+## Boundary
+
+AIRC should carry:
+
+- room membership and presence
+- WebRTC offer/answer and ICE signaling
+- DataChannel command/control events
+- media-track metadata and lifecycle
+- replayable chat and typed coordination events
+- route and health state
+
+AIRC should not carry:
+
+- raw video frames in transcript bodies
+- product-specific avatar logic
+- model/LoRA routing policy
+- UI layout state that belongs to a consumer
+- bridge-specific command semantics
+
+## References
+
+- [WebRTC media tracks plan](../../docs/architecture/WEBRTC-MEDIA-TRACKS-PLAN.md)
+- [Continuum integration](../continuum/README.md)
+- [Generic integration boundary](../generic/README.md)


### PR DESCRIPTION
## Summary
- add the Continuum live avatar room screenshot to the WebRTC media-track plan
- add the same concrete visual to the Continuum integration doc
- add a generic WebRTC integration README that defines the substrate boundary: signaling/control/lifecycle in AIRC, raw media and product policy outside AIRC
- link WebRTC from the main README integration list

## Verification
- git diff --check