### PR TITLE
feat(airc-lib): active-agent heartbeat events

### DIFF
--- a/crates/airc-lib/src/agent_heartbeat.rs
+++ b/crates/airc-lib/src/agent_heartbeat.rs
@@ -1,0 +1,340 @@
+//! Active-agent heartbeat events.
+//!
+//! Closes GRID-SUBSTRATE-AUDIT flaw #6 from #964: "the active-agent
+//! loop is not yet self-managing." Before this module, observers had
+//! to read inbox prose ("claude-tab-1 back online") to know which
+//! agents were alive. After this module, agents emit typed
+//! heartbeats on an interval and any observer can query
+//! [`Airc::active_agents(within)`] to get a current liveness view.
+//!
+//! Headers (filterable without body decode):
+//! - `airc.heartbeat.kind` = `"alive"` (reserved space for future
+//!   kinds: `"leaving"`, `"degraded"`).
+//! - `airc.heartbeat.runtime` = caller-supplied runtime label
+//!   (e.g. `"claude"`, `"codex"`, `"interactive"`).
+//!
+//! Frame kind is `Event` (durable — same trade-off the audit's flaw
+//! #4 flags). 60s default emit interval keeps noise bounded. The
+//! ephemeral-vs-durable substrate split is the right long-term fix
+//! and is its own follow-up.
+//!
+//! Scope cut: this module ships the typed event + emit task + query.
+//! It does **not** ship:
+//! - Automatic stop when the process exits (caller owns the handle's
+//!   lifecycle; dropping aborts the task).
+//! - Cross-room scoping (heartbeats go to the current default room).
+//! - A `"leaving"` event on graceful shutdown (caller can emit one
+//!   manually via [`Airc::emit_agent_heartbeat`] with a custom kind
+//!   if needed; the typed shape is reserved for it).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use airc_core::headers::Headers;
+use airc_core::transcript::MentionTarget;
+use airc_core::{Body, PeerId, TranscriptEvent};
+use airc_protocol::FrameKind;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+use crate::error::AircError;
+use crate::time::now_ms;
+use crate::Airc;
+
+pub const HEADER_HEARTBEAT_KIND: &str = "airc.heartbeat.kind";
+pub const HEADER_HEARTBEAT_RUNTIME: &str = "airc.heartbeat.runtime";
+
+/// Default 60s emit cadence. Tuned so a peer that hasn't beat in
+/// 3× the default is unambiguously stale, while keeping heartbeat
+/// noise low on a busy inbox.
+pub const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
+
+/// What the heartbeat is asserting. Reserved space for future kinds
+/// (`Leaving`, `Degraded`) so observers can switch on this string
+/// rather than parsing free-text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HeartbeatKind {
+    /// Periodic "I'm still here" beat.
+    Alive,
+    /// Caller is shutting down gracefully — observers should mark
+    /// this peer offline immediately, not wait for staleness.
+    Leaving,
+}
+
+impl HeartbeatKind {
+    pub fn header_value(self) -> &'static str {
+        match self {
+            HeartbeatKind::Alive => "alive",
+            HeartbeatKind::Leaving => "leaving",
+        }
+    }
+}
+
+/// One typed heartbeat record. Body of the durable event; substrate
+/// headers `airc.heartbeat.kind` / `runtime` carry the same values
+/// so observers can filter without decoding the body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentHeartbeat {
+    pub kind: HeartbeatKind,
+    pub peer: PeerId,
+    /// Caller-supplied runtime label. Convention: lowercase identifier
+    /// (`"claude"`, `"codex"`, `"interactive"`, `"automation"`).
+    pub runtime: String,
+    /// Optional caller-supplied scope label. Useful when one agent
+    /// runs from multiple project worktrees and observers want to
+    /// distinguish them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    pub emitted_at_ms: u64,
+}
+
+/// Summary of one currently-alive agent. Returned by
+/// [`Airc::active_agents`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentLiveness {
+    pub peer: PeerId,
+    pub runtime: String,
+    pub scope: Option<String>,
+    pub last_seen_ms: u64,
+}
+
+/// Handle to a running heartbeat emit task. Dropping or calling
+/// [`HeartbeatTask::stop`] aborts the task.
+pub struct HeartbeatTask {
+    inner: Arc<Mutex<Option<JoinHandle<()>>>>,
+}
+
+impl HeartbeatTask {
+    fn new(handle: JoinHandle<()>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Some(handle))),
+        }
+    }
+
+    /// Stop the heartbeat task. Aborts the spawned tokio task; no
+    /// `Leaving` event is emitted. Callers that want a graceful
+    /// "I'm leaving" signal should call
+    /// [`Airc::emit_agent_heartbeat`] with [`HeartbeatKind::Leaving`]
+    /// before dropping the handle.
+    pub async fn stop(self) {
+        if let Some(handle) = self.inner.lock().await.take() {
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for HeartbeatTask {
+    fn drop(&mut self) {
+        let inner = self.inner.clone();
+        // Best-effort abort on drop. We can't await from Drop, so
+        // spawn a tiny task that takes the handle and aborts.
+        // Skipped if a runtime isn't available (unusual outside of
+        // tests).
+        if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::spawn(async move {
+                if let Some(handle) = inner.lock().await.take() {
+                    handle.abort();
+                }
+            });
+        }
+    }
+}
+
+impl Airc {
+    /// Emit a single heartbeat. Useful for ad-hoc beats (e.g.
+    /// `Leaving` on graceful shutdown) outside the periodic task.
+    pub async fn emit_agent_heartbeat(
+        &self,
+        kind: HeartbeatKind,
+        runtime: impl Into<String>,
+        scope: Option<String>,
+    ) -> Result<(), AircError> {
+        let runtime = runtime.into();
+        let heartbeat = AgentHeartbeat {
+            kind,
+            peer: self.peer_id(),
+            runtime: runtime.clone(),
+            scope,
+            emitted_at_ms: now_ms()?,
+        };
+        let body = serde_json::to_value(&heartbeat)
+            .map_err(|error| AircError::Crypto(format!("agent heartbeat encode: {error}")))?;
+        let mut headers = Headers::new();
+        headers.insert(
+            HEADER_HEARTBEAT_KIND.into(),
+            kind.header_value().to_string(),
+        );
+        headers.insert(HEADER_HEARTBEAT_RUNTIME.into(), runtime);
+        self.send_frame_to(
+            FrameKind::Event,
+            MentionTarget::All,
+            Body::Json(body),
+            headers,
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Spawn a background task that emits `Alive` heartbeats every
+    /// `interval`. Returns a handle that aborts the task when
+    /// dropped or [`HeartbeatTask::stop`]ed.
+    ///
+    /// Pass [`DEFAULT_HEARTBEAT_INTERVAL`] for the standard 60s
+    /// cadence. Shorter intervals are useful in tests; longer
+    /// intervals are useful for low-traffic agents that don't need
+    /// fine-grained liveness.
+    pub async fn start_agent_heartbeat(
+        &self,
+        runtime: impl Into<String>,
+        scope: Option<String>,
+        interval: Duration,
+    ) -> Result<HeartbeatTask, AircError> {
+        let runtime = runtime.into();
+        // Emit one beat synchronously so observers see the agent
+        // alive immediately, before the first interval tick.
+        self.emit_agent_heartbeat(HeartbeatKind::Alive, runtime.clone(), scope.clone())
+            .await?;
+
+        let airc = self.clone();
+        let handle = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            // Skip the first tick since we already emitted above.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                if let Err(error) = airc
+                    .emit_agent_heartbeat(HeartbeatKind::Alive, runtime.clone(), scope.clone())
+                    .await
+                {
+                    eprintln!("agent heartbeat emit failed: {error}");
+                }
+            }
+        });
+        Ok(HeartbeatTask::new(handle))
+    }
+
+    /// Return the agents whose most recent heartbeat falls within
+    /// `within` of the current wall-clock time. Walks the recent
+    /// transcript page (`window` events) and reduces to one entry
+    /// per peer (latest-wins).
+    ///
+    /// Excludes peers whose latest heartbeat was [`HeartbeatKind::
+    /// Leaving`] — that's a deliberate offline signal.
+    pub async fn active_agents(
+        &self,
+        within: Duration,
+        window: usize,
+    ) -> Result<Vec<AgentLiveness>, AircError> {
+        let now = now_ms()?;
+        let cutoff = now.saturating_sub(within.as_millis() as u64);
+        let recent = self.page_recent(window).await?;
+        let mut latest: std::collections::HashMap<PeerId, AgentHeartbeat> =
+            std::collections::HashMap::new();
+        for event in &recent {
+            let Some(beat) = parse_heartbeat(event) else {
+                continue;
+            };
+            if beat.emitted_at_ms < cutoff {
+                continue;
+            }
+            // Keep the highest emitted_at_ms per peer.
+            latest
+                .entry(beat.peer)
+                .and_modify(|existing| {
+                    if beat.emitted_at_ms > existing.emitted_at_ms {
+                        *existing = beat.clone();
+                    }
+                })
+                .or_insert(beat);
+        }
+        let mut alive: Vec<AgentLiveness> = latest
+            .into_values()
+            .filter(|beat| beat.kind == HeartbeatKind::Alive)
+            .map(|beat| AgentLiveness {
+                peer: beat.peer,
+                runtime: beat.runtime,
+                scope: beat.scope,
+                last_seen_ms: beat.emitted_at_ms,
+            })
+            .collect();
+        alive.sort_by_key(|liveness| liveness.peer.to_string());
+        Ok(alive)
+    }
+}
+
+fn parse_heartbeat(event: &TranscriptEvent) -> Option<AgentHeartbeat> {
+    let _ = event.headers.get(HEADER_HEARTBEAT_KIND)?;
+    let body = event.body.as_ref()?;
+    let value = match body {
+        Body::Json(value) => value.clone(),
+        _ => return None,
+    };
+    serde_json::from_value(value).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_alive() -> AgentHeartbeat {
+        AgentHeartbeat {
+            kind: HeartbeatKind::Alive,
+            peer: PeerId::new(),
+            runtime: "claude".to_string(),
+            scope: Some("/work/airc".to_string()),
+            emitted_at_ms: 1_700_000_000_000,
+        }
+    }
+
+    fn sample_leaving() -> AgentHeartbeat {
+        AgentHeartbeat {
+            kind: HeartbeatKind::Leaving,
+            peer: PeerId::new(),
+            runtime: "codex".to_string(),
+            scope: None,
+            emitted_at_ms: 1_700_000_001_000,
+        }
+    }
+
+    #[test]
+    fn alive_heartbeat_round_trips_through_json() {
+        let beat = sample_alive();
+        let json = serde_json::to_string(&beat).expect("encode");
+        let decoded: AgentHeartbeat = serde_json::from_str(&json).expect("decode");
+        assert_eq!(decoded, beat);
+    }
+
+    #[test]
+    fn leaving_heartbeat_round_trips_through_json() {
+        let beat = sample_leaving();
+        let json = serde_json::to_string(&beat).expect("encode");
+        let decoded: AgentHeartbeat = serde_json::from_str(&json).expect("decode");
+        assert_eq!(decoded, beat);
+    }
+
+    #[test]
+    fn header_values_stable() {
+        assert_eq!(HeartbeatKind::Alive.header_value(), "alive");
+        assert_eq!(HeartbeatKind::Leaving.header_value(), "leaving");
+    }
+
+    #[test]
+    fn scope_is_optional_in_json() {
+        let beat = AgentHeartbeat {
+            kind: HeartbeatKind::Alive,
+            peer: PeerId::new(),
+            runtime: "interactive".to_string(),
+            scope: None,
+            emitted_at_ms: 0,
+        };
+        let json = serde_json::to_string(&beat).expect("encode");
+        // `serde(skip_serializing_if = "Option::is_none")` should
+        // omit the scope key entirely when None.
+        assert!(!json.contains("\"scope\""));
+        let decoded: AgentHeartbeat = serde_json::from_str(&json).expect("decode");
+        assert_eq!(decoded.scope, None);
+    }
+}

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -35,6 +35,7 @@
 #![deny(unsafe_code)]
 
 pub mod account_registry;
+pub mod agent_heartbeat;
 pub mod airc;
 mod broadcast_deduper;
 pub mod command_bus;
@@ -66,6 +67,10 @@ pub mod work;
 pub use account_registry::{
     AccountPeerBeacon, AccountRegistryDocument, AccountRegistryError, AccountRegistryStore,
     SqliteAccountRegistryStore, ACCOUNT_REGISTRY_SCHEMA_VERSION,
+};
+pub use agent_heartbeat::{
+    AgentHeartbeat, AgentLiveness, HeartbeatKind, HeartbeatTask, DEFAULT_HEARTBEAT_INTERVAL,
+    HEADER_HEARTBEAT_KIND, HEADER_HEARTBEAT_RUNTIME,
 };
 pub use airc::Airc;
 pub use command_bus::PendingCommand;

--- a/crates/airc-lib/tests/agent_heartbeat_round_trip.rs
+++ b/crates/airc-lib/tests/agent_heartbeat_round_trip.rs
@@ -1,0 +1,156 @@
+//! Integration: agent-heartbeat events round-trip between two Airc
+//! instances over a shared local-fs wire.
+//!
+//! Proves GRID-SUBSTRATE-AUDIT flaw #6 substrate primitive. Alice
+//! spawns a heartbeat task; Bob queries `active_agents` from his
+//! side and sees Alice as live with the correct runtime/scope. Then
+//! Alice emits an explicit `Leaving` beat; Bob's next query
+//! excludes Alice. Bob never has to read inbox prose — typed
+//! liveness with stable headers, queryable from any subscribed
+//! peer.
+
+use std::time::Duration;
+
+use airc_lib::{Airc, HeartbeatKind, PeerSpec};
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn heartbeat_task_is_visible_via_active_agents_query() {
+    let alice_home = TempDir::new().expect("alice home");
+    let bob_home = TempDir::new().expect("bob home");
+    let wire_dir = TempDir::new().expect("shared wire dir");
+    let wire_path = wire_dir.path().join("wire.jsonl");
+
+    let alice = Airc::open(alice_home.path()).await.expect("alice opens");
+    let bob = Airc::open(bob_home.path()).await.expect("bob opens");
+
+    let alice_spec: PeerSpec = alice.peer_spec().parse().expect("alice peer spec");
+    let bob_spec: PeerSpec = bob.peer_spec().parse().expect("bob peer spec");
+    alice.add_peer(bob_spec).await.expect("alice trusts bob");
+    bob.add_peer(alice_spec.clone())
+        .await
+        .expect("bob trusts alice");
+
+    alice
+        .join_with_wire("heartbeat-test", wire_path.clone())
+        .await
+        .expect("alice joins");
+    bob.join_with_wire("heartbeat-test", wire_path)
+        .await
+        .expect("bob joins");
+
+    // Alice starts emitting heartbeats. Short interval so the test
+    // doesn't have to wait for a 60s tick; the first beat is
+    // emitted synchronously inside start_agent_heartbeat so we don't
+    // need to wait for any tick either.
+    let heartbeat = alice
+        .start_agent_heartbeat(
+            "claude",
+            Some("/work/airc".to_string()),
+            Duration::from_secs(60),
+        )
+        .await
+        .expect("alice starts heartbeat");
+
+    // Give the wire-share subscriber time to ingest the synchronous
+    // first beat.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let alive = bob
+        .active_agents(Duration::from_secs(120), 64)
+        .await
+        .expect("bob queries active agents");
+    assert!(
+        alive
+            .iter()
+            .any(|liveness| liveness.peer == alice_spec.peer_id),
+        "alice should appear as alive after her first heartbeat; got {alive:?}"
+    );
+    let alice_view = alive
+        .iter()
+        .find(|liveness| liveness.peer == alice_spec.peer_id)
+        .expect("alice view present");
+    assert_eq!(alice_view.runtime, "claude");
+    assert_eq!(alice_view.scope.as_deref(), Some("/work/airc"));
+
+    // Alice explicitly leaves.
+    alice
+        .emit_agent_heartbeat(
+            HeartbeatKind::Leaving,
+            "claude",
+            Some("/work/airc".to_string()),
+        )
+        .await
+        .expect("alice emits leaving");
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let alive = bob
+        .active_agents(Duration::from_secs(120), 64)
+        .await
+        .expect("bob queries after leaving");
+    assert!(
+        !alive
+            .iter()
+            .any(|liveness| liveness.peer == alice_spec.peer_id),
+        "alice should no longer appear after Leaving; got {alive:?}"
+    );
+
+    heartbeat.stop().await;
+}
+
+#[tokio::test]
+async fn stale_heartbeats_are_filtered_by_within_window() {
+    let alice_home = TempDir::new().expect("alice home");
+    let bob_home = TempDir::new().expect("bob home");
+    let wire_dir = TempDir::new().expect("shared wire dir");
+    let wire_path = wire_dir.path().join("wire.jsonl");
+
+    let alice = Airc::open(alice_home.path()).await.expect("alice opens");
+    let bob = Airc::open(bob_home.path()).await.expect("bob opens");
+    let alice_spec: PeerSpec = alice.peer_spec().parse().expect("alice peer spec");
+    let bob_spec: PeerSpec = bob.peer_spec().parse().expect("bob peer spec");
+    alice.add_peer(bob_spec).await.expect("trust");
+    bob.add_peer(alice_spec.clone()).await.expect("trust");
+
+    alice
+        .join_with_wire("heartbeat-staleness", wire_path.clone())
+        .await
+        .expect("alice joins");
+    bob.join_with_wire("heartbeat-staleness", wire_path)
+        .await
+        .expect("bob joins");
+
+    // Alice emits a single beat.
+    alice
+        .emit_agent_heartbeat(HeartbeatKind::Alive, "claude", None)
+        .await
+        .expect("alice emits");
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Query with a 1ms window — Alice's beat is older than that, so
+    // she should be filtered out. Sleep a bit to make sure the
+    // timestamp on the beat is comfortably outside the 1ms window.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let alive = bob
+        .active_agents(Duration::from_millis(1), 64)
+        .await
+        .expect("bob queries with 1ms window");
+    assert!(
+        !alive.iter().any(|liveness| liveness.peer == alice_spec.peer_id),
+        "alice's beat is older than the 1ms staleness window — should be filtered out; got {alive:?}"
+    );
+
+    // Same data, generous window — alice should appear.
+    let alive = bob
+        .active_agents(Duration::from_secs(60), 64)
+        .await
+        .expect("bob queries with 60s window");
+    assert!(
+        alive
+            .iter()
+            .any(|liveness| liveness.peer == alice_spec.peer_id),
+        "alice's beat falls within 60s — should appear; got {alive:?}"
+    );
+}

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -146,6 +146,21 @@ theoretical architecture concerns; they showed up in normal use.
    state, missed heartbeats expire leases, and peers can query "who can
    take work now?" without reading recent chat.
 
+   **Substrate primitive landed** via `airc-lib::agent_heartbeat`:
+   typed `AgentHeartbeat` event (kind ∈ Alive/Leaving, peer, runtime,
+   optional scope, emitted_at_ms), `airc.heartbeat.kind` / `runtime`
+   headers, `Airc::start_agent_heartbeat(runtime, scope, interval)`
+   that spawns a periodic emit task returning a stop-handle, and
+   `Airc::active_agents(within, window)` that reduces recent
+   transcript to the current liveness view (filters stale, excludes
+   `Leaving`-terminated peers). 60s default cadence trades durability
+   noise for query simplicity. Open follow-ups: ephemeral
+   (non-durable) frame kind so heartbeats don't accumulate in the
+   transcript store (composes with flaw #4 lifecycle noise);
+   ready/busy/claimed state machine on top of this (composes with
+   flaw #3 lane coordination); CLI surface (`airc agents` /
+   `airc whois --live`).
+
 7. **Dirty checkout protection is operational, not enforced.** The
    Continuum checkout was already heavily dirty, so the correct behavior
    was to use `~/.airc/worktrees`. That convention exists in docs and


### PR DESCRIPTION
## Summary
Closes flaw #6 from GRID-SUBSTRATE-AUDIT (#964): "active-agent loop not yet self-managing." Pair to my #965 (typed lane coordination) — together they replace prose-only agent coordination with typed substrate primitives.

## API
- `Airc::start_agent_heartbeat(runtime, scope, interval)` — periodic emit task. First beat synchronous so observers see the agent live immediately.
- `Airc::emit_agent_heartbeat(kind, runtime, scope)` — single-shot (useful for `Leaving` on shutdown).
- `Airc::active_agents(within, window)` — current liveness view, reduces recent transcript, filters stale + `Leaving`.
- `HeartbeatTask::stop()` — graceful task abort.

## Headers (filterable without body decode)
- `airc.heartbeat.kind` = `"alive" | "leaving"`
- `airc.heartbeat.runtime` = lowercase identifier (`"claude"`, `"codex"`, etc.)

## Test plan
- [x] 4 unit tests — round-trip on each `HeartbeatKind`, header value stability, optional-scope JSON
- [x] 2 integration tests on two Airc instances over a shared wire: heartbeat visible via `active_agents` + `Leaving` removes peer; staleness window filters correctly
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

## Scope cuts (audit doc notes follow-ups)
- Heartbeats are durable `FrameKind::Event` — same flaw #4 noise trade-off; ephemeral frame kind is the right long-term fix.
- No ready/busy/claimed state machine; composes with #965 lane coordination as separate lane.
- No CLI (`airc agents` / `airc whois --live`).
- No automatic Leaving on process exit; caller owns handle lifecycle.

## Pairing with #965
Together, #965 (typed lane claims) + #967 (this — typed liveness) give us: "who's alive, what are they working on, when was their last beat?" — all queryable from typed substrate state, no inbox-prose grepping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)