### PR TITLE
feat(work): heartbeat claims and surface stale owners

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -573,6 +573,11 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             WorkAction::Claim { card_id, ttl_ms } => {
                 work_commands::run_claim(&home, card_id, ttl_ms).await
             }
+            WorkAction::Heartbeat {
+                card_id,
+                claim_id,
+                ttl_ms,
+            } => work_commands::run_heartbeat(&home, card_id, claim_id, ttl_ms).await,
             WorkAction::Release {
                 card_id,
                 claim_id,

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -36,6 +36,16 @@ pub enum WorkAction {
         #[arg(long, default_value_t = 600_000)]
         ttl_ms: u64,
     },
+    /// Extend this peer's claim lease on a work card.
+    Heartbeat {
+        /// Work card UUID.
+        card_id: String,
+        /// Claim UUID returned by `work claim`.
+        claim_id: String,
+        /// New lease duration from this heartbeat.
+        #[arg(long, default_value_t = 600_000)]
+        ttl_ms: u64,
+    },
     /// Release this peer's claim on a work card.
     Release {
         /// Work card UUID.

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -1,9 +1,11 @@
 //! `airc work ...` handlers.
 //!
 //! The CLI stays intentionally thin: it parses human input, calls the
-//! consumer-facing `airc_lib::Airc` work API, and prints stable lines
-//! that other tools can scrape. Work-domain validation and event
-//! construction live in `airc-lib` / `airc-work`.
+//! consumer-facing `airc_lib::Airc` work API, and renders terminal
+//! output for humans. Integrations should call `airc-lib` / daemon IPC
+//! / ORM projections directly rather than parsing CLI output.
+//! Work-domain validation and event construction live in `airc-lib` /
+//! `airc-work`.
 
 use std::path::Path;
 
@@ -69,6 +71,23 @@ pub async fn run_release(
     Ok(())
 }
 
+pub async fn run_heartbeat(
+    home: &Path,
+    card_id: String,
+    claim_id: String,
+    ttl_ms: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    airc.heartbeat_work_claim(airc_lib::HeartbeatWorkClaim {
+        card_id: parse_work_card_id(&card_id)?,
+        claim_id: parse_claim_id(&claim_id)?,
+        ttl_ms,
+    })
+    .await?;
+    println!("claim_heartbeat: card_id={card_id} claim_id={claim_id} ttl_ms={ttl_ms}");
+    Ok(())
+}
+
 pub async fn run_board(home: &Path, limit: usize) -> Result<(), Box<dyn std::error::Error>> {
     let airc = Airc::open(home).await?;
     let board = airc.work_board(limit).await?;
@@ -82,6 +101,7 @@ fn print_board(board: &WorkBoardProjection) {
         println!("(no work cards)");
         return;
     }
+    let stale_claims = board.stale_claims(now_ms());
 
     println!("work cards: {}", snapshot.cards.len());
     for card in &snapshot.cards {
@@ -102,6 +122,26 @@ fn print_board(board: &WorkBoardProjection) {
             title = card.title,
         );
     }
+    if !stale_claims.is_empty() {
+        println!();
+        println!("stale claims: {}", stale_claims.len());
+        for claim in stale_claims {
+            println!(
+                "{card_id}  owner={owner}  claim={claim_id}  expired_at_ms={expired_at_ms}",
+                card_id = claim.card_id,
+                owner = claim.owner,
+                claim_id = claim.claim_id,
+                expired_at_ms = claim.expired_at_ms,
+            );
+        }
+    }
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
 }
 
 fn parse_work_card_id(input: &str) -> Result<WorkCardId, Box<dyn std::error::Error>> {

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -53,6 +53,12 @@ fn work_create_claim_release_projects_on_board() {
     assert!(claimed_board.contains(claim_id));
     assert!(claimed_board.contains("Claimed"));
 
+    let heartbeat = run_ok(
+        &home,
+        &["work", "heartbeat", card_id, claim_id, "--ttl-ms", "60000"],
+    );
+    assert!(heartbeat.contains("claim_heartbeat"));
+
     run_ok(
         &home,
         &[
@@ -69,6 +75,35 @@ fn work_create_claim_release_projects_on_board() {
     assert!(released_board.contains(card_id));
     assert!(released_board.contains("Open"));
     assert!(released_board.contains("claim=-"));
+}
+
+#[test]
+fn work_board_surfaces_stale_claims() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let create = run_ok(
+        &home,
+        &[
+            "work",
+            "create",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "do not let abandoned claims idle-lock a lane",
+        ],
+    );
+    let card_id = extract_field(&create, "card_id:").expect("create prints card_id");
+
+    let claim = run_ok(&home, &["work", "claim", card_id, "--ttl-ms", "1"]);
+    let claim_id = extract_field(&claim, "claim_id:").expect("claim prints claim_id");
+    std::thread::sleep(std::time::Duration::from_millis(5));
+
+    let stale_board = run_ok(&home, &["work", "board"]);
+    assert!(stale_board.contains("stale claims: 1"), "{stale_board}");
+    assert!(stale_board.contains(card_id), "{stale_board}");
+    assert!(stale_board.contains(claim_id), "{stale_board}");
 }
 
 #[test]

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -107,9 +107,9 @@ pub use webrtc_media::{
 };
 pub use work::{
     AllocateWorkspace, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard, CreateWorkCard,
-    CreateWorkLane, HeartbeatWorkspace, ObserveLocalGitWorkspace, ObservePullRequests,
-    ObservedLocalGitWorkspace, ObservedPullRequests, ReleaseManagerHat, ReleaseWorkClaim,
-    ReleaseWorkspace, RequestWorkspace,
+    CreateWorkLane, HeartbeatWorkClaim, HeartbeatWorkspace, ObserveLocalGitWorkspace,
+    ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests, ReleaseManagerHat,
+    ReleaseWorkClaim, ReleaseWorkspace, RequestWorkspace,
 };
 
 // Convenience re-exports so consumers don't need to pull airc-core

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -4,11 +4,11 @@ use airc_core::EventId;
 use airc_protocol::FrameKind;
 use airc_work::{
     encode_work_event, local_git_events_since, pull_request_events_since, BranchName, CardCreated,
-    ClaimId, ClaimReleased, CommandGitRunner, LaneCreated, LaneId, LaneState, LaneStateChanged,
-    LocalGitObserver, LocalGitSnapshot, LocalGitWorkspace, ManagerHatClaimed, ManagerHatReleased,
-    Priority, PullRequestObserver, PullRequestSource, RepoId, RepoPullRequestSnapshot,
-    WorkBoardProjection, WorkCardClaimed, WorkCardId, WorkEvent, WorkspaceAllocated,
-    WorkspaceHeartbeat, WorkspaceId, WorkspaceReleased, WorkspaceRequested,
+    ClaimHeartbeat, ClaimId, ClaimReleased, CommandGitRunner, LaneCreated, LaneId, LaneState,
+    LaneStateChanged, LocalGitObserver, LocalGitSnapshot, LocalGitWorkspace, ManagerHatClaimed,
+    ManagerHatReleased, Priority, PullRequestObserver, PullRequestSource, RepoId,
+    RepoPullRequestSnapshot, WorkBoardProjection, WorkCardClaimed, WorkCardId, WorkEvent,
+    WorkspaceAllocated, WorkspaceHeartbeat, WorkspaceId, WorkspaceReleased, WorkspaceRequested,
 };
 use airc_work_store::WorkEventStore;
 
@@ -35,6 +35,13 @@ pub struct ReleaseWorkClaim {
     pub card_id: WorkCardId,
     pub claim_id: ClaimId,
     pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HeartbeatWorkClaim {
+    pub card_id: WorkCardId,
+    pub claim_id: ClaimId,
+    pub ttl_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -159,6 +166,21 @@ impl Airc {
             owner: self.peer_id(),
             reason: request.reason,
             released_at_ms: now_ms()?,
+        });
+        self.publish_work_event(&event).await?;
+        Ok(())
+    }
+
+    /// Extend this peer's claim lease for a work card. Agents should
+    /// heartbeat long-running work so stale claims become visible when
+    /// a tab goes idle or dies instead of locking a lane indefinitely.
+    pub async fn heartbeat_work_claim(&self, request: HeartbeatWorkClaim) -> Result<(), AircError> {
+        let event = WorkEvent::ClaimHeartbeat(ClaimHeartbeat {
+            card_id: request.card_id,
+            claim_id: request.claim_id,
+            owner: self.peer_id(),
+            ttl_ms: request.ttl_ms,
+            heartbeat_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(())


### PR DESCRIPTION
## Summary
- add `Airc::heartbeat_work_claim` and export `HeartbeatWorkClaim` for typed claim lease renewal
- add `airc work heartbeat <card_id> <claim_id>` as the human CLI wrapper over the Rust API
- make `airc work board` surface expired/stale claims so abandoned work cannot silently idle-lock lanes
- update work CLI comments to state integrations use `airc-lib`/IPC/ORM projections, not CLI output parsing

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-cli --test work_commands
- cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings