### PR TITLE
feat(work): publish agent availability state

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ This is a major part of the product, not a side channel. When several agents are
 
 - kanban cards and lane state are projections of typed events
 - claims are leased, visible, and time-bounded
+- agents publish ready/busy/away availability as typed state
 - each agent can take an isolated git worktree for its PR
 - peers can announce PRs, CI state, review requests, and handoffs in-room
 - workspace pressure and drain decisions are modeled instead of left to ad hoc cleanup
@@ -173,6 +174,8 @@ The practical gain is that agents can split one larger task without sharing a di
 The work domain includes queue cards, claims, heartbeats, PR state, workspace leases, and drain events. This supports a plain operating loop:
 
 - claim before editing
+- publish availability before waiting for work
+- heartbeat active claims so stale work is obvious
 - use one worktree per agent per PR, under `~/.airc/worktrees`
 - heartbeat during long work
 - merge completed PRs into the integration branch instead of leaving stale branches

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -584,6 +584,12 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 reason,
             } => work_commands::run_release(&home, card_id, claim_id, reason).await,
             WorkAction::Board { limit } => work_commands::run_board(&home, limit).await,
+            WorkAction::Availability {
+                repo,
+                state,
+                note,
+                ttl_ms,
+            } => work_commands::run_availability(&home, repo, state, note, ttl_ms).await,
         },
 
         Command::Lane(args) => match args.action {

--- a/crates/airc-cli/src/monitor/attach.rs
+++ b/crates/airc-cli/src/monitor/attach.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::io::Write;
 use std::path::Path;
 
 use airc_core::{Body, MentionTarget, TranscriptEvent, TranscriptKind};
@@ -26,6 +27,7 @@ pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error
     let mut sandbox = Sandbox::new();
 
     println!("airc: attached to Rust event stream for subscribed channels");
+    std::io::stdout().flush()?;
     loop {
         let Some(response) = read_frame::<_, Response>(&mut stream).await? else {
             return Ok(());

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -62,6 +62,21 @@ pub enum WorkAction {
         #[arg(long, default_value_t = 128)]
         limit: usize,
     },
+    /// Publish this agent's availability for a repo.
+    Availability {
+        /// Repository key, e.g. `CambrianTech/airc`.
+        #[arg(long)]
+        repo: String,
+        /// Availability state.
+        #[arg(long, value_enum)]
+        state: CliAvailabilityState,
+        /// Optional short note for managers/peers.
+        #[arg(long)]
+        note: Option<String>,
+        /// Availability lease duration.
+        #[arg(long, default_value_t = 600_000)]
+        ttl_ms: u64,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -71,4 +86,12 @@ pub enum CliPriority {
     P1,
     P2,
     P3,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum CliAvailabilityState {
+    Ready,
+    Busy,
+    Away,
 }

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -12,11 +12,11 @@ use std::path::Path;
 use uuid::Uuid;
 
 use airc_lib::{
-    Airc, ClaimId, ClaimWorkCard, CreateWorkCard, LaneId, Priority, ReleaseWorkClaim, RepoId,
-    WorkBoardProjection, WorkCardId,
+    AgentAvailabilityState, Airc, ClaimId, ClaimWorkCard, CreateWorkCard, LaneId, Priority,
+    ReleaseWorkClaim, RepoId, WorkBoardProjection, WorkCardId,
 };
 
-use crate::work_cli::CliPriority;
+use crate::work_cli::{CliAvailabilityState, CliPriority};
 
 pub async fn run_create(
     home: &Path,
@@ -95,15 +95,37 @@ pub async fn run_board(home: &Path, limit: usize) -> Result<(), Box<dyn std::err
     Ok(())
 }
 
+pub async fn run_availability(
+    home: &Path,
+    repo: String,
+    state: CliAvailabilityState,
+    note: Option<String>,
+    ttl_ms: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let repo = RepoId::new(repo)?;
+    airc.report_agent_availability(airc_lib::ReportAgentAvailability {
+        repo: repo.clone(),
+        state: state.into(),
+        note,
+        ttl_ms,
+    })
+    .await?;
+    println!("agent_availability: repo={repo} state={state:?} ttl_ms={ttl_ms}");
+    Ok(())
+}
+
 fn print_board(board: &WorkBoardProjection) {
     let snapshot = board.snapshot();
-    if snapshot.cards.is_empty() {
+    if snapshot.cards.is_empty() && snapshot.agent_availability.is_empty() {
         println!("(no work cards)");
         return;
     }
     let stale_claims = board.stale_claims(now_ms());
 
-    println!("work cards: {}", snapshot.cards.len());
+    if !snapshot.cards.is_empty() {
+        println!("work cards: {}", snapshot.cards.len());
+    }
     for card in &snapshot.cards {
         let owner = card
             .owner
@@ -132,6 +154,21 @@ fn print_board(board: &WorkBoardProjection) {
                 owner = claim.owner,
                 claim_id = claim.claim_id,
                 expired_at_ms = claim.expired_at_ms,
+            );
+        }
+    }
+    if !snapshot.agent_availability.is_empty() {
+        println!();
+        println!("agent availability: {}", snapshot.agent_availability.len());
+        for availability in snapshot.agent_availability {
+            let stale = availability.expires_at_ms <= now_ms();
+            let note = availability.report.note.as_deref().unwrap_or("-");
+            println!(
+                "{repo}  peer={peer}  state={state:?}  stale={stale}  expires_at_ms={expires_at_ms}  note={note}",
+                repo = availability.report.repo,
+                peer = availability.report.peer,
+                state = availability.report.state,
+                expires_at_ms = availability.expires_at_ms,
             );
         }
     }
@@ -175,6 +212,16 @@ impl From<CliPriority> for Priority {
             CliPriority::P1 => Self::P1,
             CliPriority::P2 => Self::P2,
             CliPriority::P3 => Self::P3,
+        }
+    }
+}
+
+impl From<CliAvailabilityState> for AgentAvailabilityState {
+    fn from(value: CliAvailabilityState) -> Self {
+        match value {
+            CliAvailabilityState::Ready => Self::Ready,
+            CliAvailabilityState::Busy => Self::Busy,
+            CliAvailabilityState::Away => Self::Away,
         }
     }
 }

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -107,6 +107,40 @@ fn work_board_surfaces_stale_claims() {
 }
 
 #[test]
+fn work_availability_projects_to_board() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let availability = run_ok(
+        &home,
+        &[
+            "work",
+            "availability",
+            "--repo",
+            "CambrianTech/airc",
+            "--state",
+            "ready",
+            "--note",
+            "can take review",
+            "--ttl-ms",
+            "60000",
+        ],
+    );
+    assert!(
+        availability.contains("agent_availability"),
+        "{availability}"
+    );
+
+    let board = run_ok(&home, &["work", "board"]);
+    assert!(board.contains("agent availability: 1"), "{board}");
+    assert!(board.contains("CambrianTech/airc"), "{board}");
+    assert!(board.contains("state=Ready"), "{board}");
+    assert!(board.contains("stale=false"), "{board}");
+    assert!(board.contains("can take review"), "{board}");
+}
+
+#[test]
 fn lane_create_status_and_state_drive_work_projection() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -109,7 +109,7 @@ pub use work::{
     AllocateWorkspace, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard, CreateWorkCard,
     CreateWorkLane, HeartbeatWorkClaim, HeartbeatWorkspace, ObserveLocalGitWorkspace,
     ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests, ReleaseManagerHat,
-    ReleaseWorkClaim, ReleaseWorkspace, RequestWorkspace,
+    ReleaseWorkClaim, ReleaseWorkspace, ReportAgentAvailability, RequestWorkspace,
 };
 
 // Convenience re-exports so consumers don't need to pull airc-core
@@ -121,7 +121,8 @@ pub use airc_core::{
     ClientId, EventId, PeerId, RoomId, TranscriptCursor, TranscriptEvent, TranscriptKind,
 };
 pub use airc_work::{
-    BoardSnapshot, BranchName, CardState, ClaimId, DirtyState, GitObjectId, LaneId, LaneState,
-    LocalGitSnapshot, ManagerHat, Priority, ProjectionError, RepoId, WorkBoardProjection,
-    WorkCardId, WorkEvent, WorkspaceId, WorkspaceStatus,
+    AgentAvailabilityRecord, AgentAvailabilityState, BoardSnapshot, BranchName, CardState, ClaimId,
+    DirtyState, GitObjectId, LaneId, LaneState, LocalGitSnapshot, ManagerHat, Priority,
+    ProjectionError, RepoId, WorkBoardProjection, WorkCardId, WorkEvent, WorkspaceId,
+    WorkspaceStatus,
 };

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -3,12 +3,13 @@
 use airc_core::EventId;
 use airc_protocol::FrameKind;
 use airc_work::{
-    encode_work_event, local_git_events_since, pull_request_events_since, BranchName, CardCreated,
-    ClaimHeartbeat, ClaimId, ClaimReleased, CommandGitRunner, LaneCreated, LaneId, LaneState,
-    LaneStateChanged, LocalGitObserver, LocalGitSnapshot, LocalGitWorkspace, ManagerHatClaimed,
-    ManagerHatReleased, Priority, PullRequestObserver, PullRequestSource, RepoId,
-    RepoPullRequestSnapshot, WorkBoardProjection, WorkCardClaimed, WorkCardId, WorkEvent,
-    WorkspaceAllocated, WorkspaceHeartbeat, WorkspaceId, WorkspaceReleased, WorkspaceRequested,
+    encode_work_event, local_git_events_since, pull_request_events_since,
+    AgentAvailabilityReported, AgentAvailabilityState, BranchName, CardCreated, ClaimHeartbeat,
+    ClaimId, ClaimReleased, CommandGitRunner, LaneCreated, LaneId, LaneState, LaneStateChanged,
+    LocalGitObserver, LocalGitSnapshot, LocalGitWorkspace, ManagerHatClaimed, ManagerHatReleased,
+    Priority, PullRequestObserver, PullRequestSource, RepoId, RepoPullRequestSnapshot,
+    WorkBoardProjection, WorkCardClaimed, WorkCardId, WorkEvent, WorkspaceAllocated,
+    WorkspaceHeartbeat, WorkspaceId, WorkspaceReleased, WorkspaceRequested,
 };
 use airc_work_store::WorkEventStore;
 
@@ -92,6 +93,14 @@ pub struct ClaimManagerHat {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReleaseManagerHat {
     pub repo: RepoId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReportAgentAvailability {
+    pub repo: RepoId,
+    pub state: AgentAvailabilityState,
+    pub note: Option<String>,
+    pub ttl_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -292,6 +301,26 @@ impl Airc {
             repo: request.repo,
             manager: self.peer_id(),
             released_at_ms: now_ms()?,
+        });
+        self.publish_work_event(&event).await?;
+        Ok(())
+    }
+
+    /// Publish this peer's current availability for a repo. This is a
+    /// coordination signal, not a permission boundary: managers and
+    /// peers use it to avoid idle lock by finding ready responders and
+    /// detecting stale/busy agents without parsing recent chat.
+    pub async fn report_agent_availability(
+        &self,
+        request: ReportAgentAvailability,
+    ) -> Result<(), AircError> {
+        let event = WorkEvent::AgentAvailabilityReported(AgentAvailabilityReported {
+            repo: request.repo,
+            peer: self.peer_id(),
+            state: request.state,
+            note: request.note,
+            ttl_ms: request.ttl_ms,
+            reported_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(())

--- a/crates/airc-work/src/codec/headers.rs
+++ b/crates/airc-work/src/codec/headers.rs
@@ -16,6 +16,7 @@ pub const HEADER_FORGE_WORK_POLICY_RULE_ID: &str = "forge.work.policy_rule_id";
 pub const HEADER_FORGE_WORK_GIT_BRANCH: &str = "forge.work.git_branch";
 pub const HEADER_FORGE_WORK_GIT_COMMIT: &str = "forge.work.git_commit";
 pub const HEADER_FORGE_WORK_PR_NUMBER: &str = "forge.work.pr_number";
+pub const HEADER_FORGE_WORK_STATE: &str = "forge.work.state";
 
 pub fn work_event_headers(event: &WorkEvent) -> Headers {
     let mut headers = Headers::new();
@@ -133,6 +134,13 @@ fn project_domain_headers(event: &WorkEvent, headers: &mut Headers) {
         }
         WorkEvent::ManagerHatReleased(e) => {
             headers.insert(HEADER_FORGE_WORK_REPO.to_string(), e.repo.to_string());
+        }
+        WorkEvent::AgentAvailabilityReported(e) => {
+            headers.insert(HEADER_FORGE_WORK_REPO.to_string(), e.repo.to_string());
+            headers.insert(
+                HEADER_FORGE_WORK_STATE.to_string(),
+                format!("{:?}", e.state).to_ascii_lowercase(),
+            );
         }
     }
 }

--- a/crates/airc-work/src/codec/mod.rs
+++ b/crates/airc-work/src/codec/mod.rs
@@ -19,7 +19,7 @@ pub use headers::{
     work_event_headers, HEADER_FORGE_WORK_CARD_ID, HEADER_FORGE_WORK_CLAIM_ID,
     HEADER_FORGE_WORK_EVENT_KIND, HEADER_FORGE_WORK_GIT_BRANCH, HEADER_FORGE_WORK_GIT_COMMIT,
     HEADER_FORGE_WORK_LANE_ID, HEADER_FORGE_WORK_POLICY_RULE_ID, HEADER_FORGE_WORK_PR_NUMBER,
-    HEADER_FORGE_WORK_REPO, HEADER_FORGE_WORK_WORKSPACE_ID,
+    HEADER_FORGE_WORK_REPO, HEADER_FORGE_WORK_STATE, HEADER_FORGE_WORK_WORKSPACE_ID,
 };
 
 pub const BODY_HINT_FORGE_WORK_EVENT: &str = "forge.work.event.v1";
@@ -108,5 +108,6 @@ pub(crate) fn event_kind(event: &WorkEvent) -> &'static str {
         WorkEvent::HygieneReportRecorded(_) => "hygiene_report_recorded",
         WorkEvent::ManagerHatClaimed(_) => "manager_hat_claimed",
         WorkEvent::ManagerHatReleased(_) => "manager_hat_released",
+        WorkEvent::AgentAvailabilityReported(_) => "agent_availability_reported",
     }
 }

--- a/crates/airc-work/src/codec/tests.rs
+++ b/crates/airc-work/src/codec/tests.rs
@@ -3,11 +3,11 @@ use airc_protocol::{FrameKind, HEADER_FORGE_BODY_HINT};
 
 use super::*;
 use crate::{
-    BranchName, CardCreated, ClaimId, DrainCandidate, DrainCandidateCategory, DrainOutcome,
-    GitBranchMoved, GitObjectId, LaneId, PrCheckState, PressureLevel, Priority,
-    PullRequestCheckSuiteChanged, PullRequestRef, RepoId, WorkCardId, WorkEvent,
-    WorkspaceDrainCompleted, WorkspaceDrainRequested, WorkspaceId, WorkspacePressureReported,
-    WorkspaceRequested,
+    AgentAvailabilityReported, AgentAvailabilityState, BranchName, CardCreated, ClaimId,
+    DrainCandidate, DrainCandidateCategory, DrainOutcome, GitBranchMoved, GitObjectId, LaneId,
+    PrCheckState, PressureLevel, Priority, PullRequestCheckSuiteChanged, PullRequestRef, RepoId,
+    WorkCardId, WorkEvent, WorkspaceDrainCompleted, WorkspaceDrainRequested, WorkspaceId,
+    WorkspacePressureReported, WorkspaceRequested,
 };
 
 fn card_created() -> WorkEvent {
@@ -276,5 +276,34 @@ fn git_and_pr_events_roundtrip_with_routeable_headers() {
             .get(HEADER_FORGE_WORK_GIT_BRANCH)
             .map(String::as_str),
         Some("feat/lifecycle-events")
+    );
+}
+
+#[test]
+fn availability_event_roundtrips_with_repo_and_state_headers() {
+    let event = WorkEvent::AgentAvailabilityReported(AgentAvailabilityReported {
+        repo: RepoId::new("CambrianTech/airc").unwrap(),
+        peer: PeerId::from_u128(42),
+        state: AgentAvailabilityState::Ready,
+        note: Some("can take review".to_string()),
+        ttl_ms: 60_000,
+        reported_at_ms: 7,
+    });
+
+    let (headers, body) = encode_work_event(&event).unwrap();
+    assert_eq!(decode_work_event(&headers, Some(&body)).unwrap(), event);
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_WORK_EVENT_KIND)
+            .map(String::as_str),
+        Some("agent_availability_reported")
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_WORK_REPO).map(String::as_str),
+        Some("CambrianTech/airc")
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_WORK_STATE).map(String::as_str),
+        Some("ready")
     );
 }

--- a/crates/airc-work/src/event.rs
+++ b/crates/airc-work/src/event.rs
@@ -6,8 +6,9 @@ use airc_core::PeerId;
 
 use crate::ids::{ClaimId, LaneId, RepoId, WorkCardId, WorkspaceId};
 use crate::model::{
-    BranchName, CardState, DirtyState, DrainCandidate, DrainOutcome, GitObjectId, HygieneReport,
-    LaneState, PrCheckState, PrMergeState, PrReviewState, PressureLevel, Priority, PullRequestRef,
+    AgentAvailabilityState, BranchName, CardState, DirtyState, DrainCandidate, DrainOutcome,
+    GitObjectId, HygieneReport, LaneState, PrCheckState, PrMergeState, PrReviewState,
+    PressureLevel, Priority, PullRequestRef,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -38,6 +39,7 @@ pub enum WorkEvent {
     HygieneReportRecorded(HygieneReportRecorded),
     ManagerHatClaimed(ManagerHatClaimed),
     ManagerHatReleased(ManagerHatReleased),
+    AgentAvailabilityReported(AgentAvailabilityReported),
 }
 
 impl WorkEvent {
@@ -68,6 +70,7 @@ impl WorkEvent {
             WorkEvent::HygieneReportRecorded(e) => e.report.recorded_at_ms,
             WorkEvent::ManagerHatClaimed(e) => e.claimed_at_ms,
             WorkEvent::ManagerHatReleased(e) => e.released_at_ms,
+            WorkEvent::AgentAvailabilityReported(e) => e.reported_at_ms,
         }
     }
 }
@@ -316,6 +319,16 @@ pub struct ManagerHatReleased {
     pub repo: RepoId,
     pub manager: PeerId,
     pub released_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentAvailabilityReported {
+    pub repo: RepoId,
+    pub peer: PeerId,
+    pub state: AgentAvailabilityState,
+    pub note: Option<String>,
+    pub ttl_ms: u64,
+    pub reported_at_ms: u64,
 }
 
 #[cfg(test)]

--- a/crates/airc-work/src/lib.rs
+++ b/crates/airc-work/src/lib.rs
@@ -27,12 +27,13 @@ pub use drain_policy::{
     PolicyInputs, PrStatus, PrTerminalState, ReportOnlyReason, DEFAULT_HEARTBEAT_STALE_MS,
 };
 pub use event::{
-    CardCreated, CardStateChanged, ClaimHeartbeat, ClaimReleased, GitBranchMoved,
-    GitCommitObserved, GitDirtyStateChanged, HygieneReportRecorded, LaneCreated, LaneStateChanged,
-    ManagerHatClaimed, ManagerHatReleased, PullRequestCheckSuiteChanged, PullRequestLinked,
-    PullRequestMergeStateChanged, PullRequestMerged, PullRequestReviewSubmitted, WorkCardClaimed,
-    WorkEvent, WorkspaceAllocated, WorkspaceDrainCompleted, WorkspaceDrainRequested,
-    WorkspaceHeartbeat, WorkspacePressureReported, WorkspaceReleased, WorkspaceRequested,
+    AgentAvailabilityReported, CardCreated, CardStateChanged, ClaimHeartbeat, ClaimReleased,
+    GitBranchMoved, GitCommitObserved, GitDirtyStateChanged, HygieneReportRecorded, LaneCreated,
+    LaneStateChanged, ManagerHatClaimed, ManagerHatReleased, PullRequestCheckSuiteChanged,
+    PullRequestLinked, PullRequestMergeStateChanged, PullRequestMerged, PullRequestReviewSubmitted,
+    WorkCardClaimed, WorkEvent, WorkspaceAllocated, WorkspaceDrainCompleted,
+    WorkspaceDrainRequested, WorkspaceHeartbeat, WorkspacePressureReported, WorkspaceReleased,
+    WorkspaceRequested,
 };
 pub use ids::{ClaimId, LaneId, RepoId, WorkCardId, WorkspaceId};
 pub use local_git::{
@@ -40,13 +41,15 @@ pub use local_git::{
     LocalGitSnapshot, LocalGitWorkspace,
 };
 pub use model::{
-    BranchName, CardState, DirtyState, DrainCandidate, DrainCandidateCategory, DrainOutcome,
-    GitObjectId, HygieneReport, LaneState, PrCheckState, PrMergeState, PrReviewState,
-    PressureLevel, Priority, PullRequestRef, WorkCard, WorkspaceLease, WorkspaceStatus,
+    AgentAvailabilityState, BranchName, CardState, DirtyState, DrainCandidate,
+    DrainCandidateCategory, DrainOutcome, GitObjectId, HygieneReport, LaneState, PrCheckState,
+    PrMergeState, PrReviewState, PressureLevel, Priority, PullRequestRef, WorkCard, WorkspaceLease,
+    WorkspaceStatus,
 };
 pub use projection::{
-    BoardSnapshot, BranchTrackingRecord, LaneRecord, ManagerHat, ProjectionError,
-    PullRequestRecord, RepoTrackingRecord, StaleClaim, WorkBoardProjection, WorkspaceRecord,
+    AgentAvailabilityRecord, BoardSnapshot, BranchTrackingRecord, LaneRecord, ManagerHat,
+    ProjectionError, PullRequestRecord, RepoTrackingRecord, StaleClaim, WorkBoardProjection,
+    WorkspaceRecord,
 };
 pub use pull_requests::gh::{
     CommandGhRunner, GhCommandRunner, GhPullRequestSource, GhRunnerError, GH_JSON_FIELDS,

--- a/crates/airc-work/src/model.rs
+++ b/crates/airc-work/src/model.rs
@@ -49,6 +49,14 @@ pub enum WorkspaceStatus {
     Failed,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentAvailabilityState {
+    Ready,
+    Busy,
+    Away,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct BranchName(String);

--- a/crates/airc-work/src/projection.rs
+++ b/crates/airc-work/src/projection.rs
@@ -7,9 +7,9 @@ use serde::{Deserialize, Serialize};
 use airc_core::PeerId;
 
 use crate::event::{
-    GitCommitObserved, GitDirtyStateChanged, PullRequestCheckSuiteChanged,
-    PullRequestMergeStateChanged, PullRequestReviewSubmitted, WorkspaceDrainCompleted,
-    WorkspaceDrainRequested, WorkspacePressureReported,
+    AgentAvailabilityReported, GitCommitObserved, GitDirtyStateChanged,
+    PullRequestCheckSuiteChanged, PullRequestMergeStateChanged, PullRequestReviewSubmitted,
+    WorkspaceDrainCompleted, WorkspaceDrainRequested, WorkspacePressureReported,
 };
 use crate::ids::{ClaimId, LaneId, RepoId, WorkCardId, WorkspaceId};
 use crate::model::{
@@ -41,6 +41,7 @@ pub struct WorkBoardProjection {
     pub(super) repo_tracking: BTreeMap<RepoId, RepoTrackingRecord>,
     pub(super) pull_requests: BTreeMap<String, PullRequestRecord>,
     pub(super) manager_hats: BTreeMap<RepoId, ManagerHat>,
+    pub(super) agent_availability: BTreeMap<String, AgentAvailabilityRecord>,
     pub(super) hygiene_reports: Vec<HygieneReport>,
 }
 
@@ -88,6 +89,7 @@ pub struct BoardSnapshot {
     pub repo_tracking: Vec<RepoTrackingRecord>,
     pub pull_requests: Vec<PullRequestRecord>,
     pub manager_hats: Vec<ManagerHat>,
+    pub agent_availability: Vec<AgentAvailabilityRecord>,
     pub hygiene_reports: Vec<HygieneReport>,
 }
 
@@ -203,6 +205,12 @@ pub struct ManagerHat {
     pub manager: PeerId,
     pub expires_at_ms: u64,
     pub claimed_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentAvailabilityRecord {
+    pub report: AgentAvailabilityReported,
+    pub expires_at_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/airc-work/src/projection/apply.rs
+++ b/crates/airc-work/src/projection/apply.rs
@@ -1,17 +1,19 @@
 use crate::event::{
-    CardCreated, CardStateChanged, ClaimHeartbeat, ClaimReleased, GitBranchMoved,
-    GitCommitObserved, GitDirtyStateChanged, HygieneReportRecorded, LaneCreated, LaneStateChanged,
-    ManagerHatClaimed, ManagerHatReleased, PullRequestCheckSuiteChanged, PullRequestLinked,
-    PullRequestMergeStateChanged, PullRequestMerged, PullRequestReviewSubmitted, WorkCardClaimed,
-    WorkEvent, WorkspaceAllocated, WorkspaceDrainCompleted, WorkspaceDrainRequested,
-    WorkspaceHeartbeat, WorkspacePressureReported, WorkspaceReleased, WorkspaceRequested,
+    AgentAvailabilityReported, CardCreated, CardStateChanged, ClaimHeartbeat, ClaimReleased,
+    GitBranchMoved, GitCommitObserved, GitDirtyStateChanged, HygieneReportRecorded, LaneCreated,
+    LaneStateChanged, ManagerHatClaimed, ManagerHatReleased, PullRequestCheckSuiteChanged,
+    PullRequestLinked, PullRequestMergeStateChanged, PullRequestMerged, PullRequestReviewSubmitted,
+    WorkCardClaimed, WorkEvent, WorkspaceAllocated, WorkspaceDrainCompleted,
+    WorkspaceDrainRequested, WorkspaceHeartbeat, WorkspacePressureReported, WorkspaceReleased,
+    WorkspaceRequested,
 };
 use crate::ids::{WorkCardId, WorkspaceId};
 use crate::model::{CardState, WorkCard, WorkspaceLease, WorkspaceStatus};
 
 use super::{
-    pull_request_key, BoardSnapshot, BranchTrackingRecord, LaneRecord, ManagerHat, ProjectionError,
-    PullRequestRecord, RepoTrackingRecord, StaleClaim, WorkBoardProjection, WorkspaceRecord,
+    pull_request_key, AgentAvailabilityRecord, BoardSnapshot, BranchTrackingRecord, LaneRecord,
+    ManagerHat, ProjectionError, PullRequestRecord, RepoTrackingRecord, StaleClaim,
+    WorkBoardProjection, WorkspaceRecord,
 };
 
 impl WorkBoardProjection {
@@ -55,6 +57,10 @@ impl WorkBoardProjection {
             WorkEvent::HygieneReportRecorded(e) => self.apply_hygiene_report_recorded(e),
             WorkEvent::ManagerHatClaimed(e) => self.apply_manager_hat_claimed(e),
             WorkEvent::ManagerHatReleased(e) => self.apply_manager_hat_released(e),
+            WorkEvent::AgentAvailabilityReported(e) => {
+                self.apply_agent_availability_reported(e);
+                Ok(())
+            }
         }
     }
 
@@ -74,6 +80,7 @@ impl WorkBoardProjection {
             repo_tracking: self.repo_tracking.values().cloned().collect(),
             pull_requests: self.pull_requests.values().cloned().collect(),
             manager_hats: self.manager_hats.values().cloned().collect(),
+            agent_availability: self.agent_availability.values().cloned().collect(),
             hygiene_reports: self.hygiene_reports.clone(),
         }
     }
@@ -400,6 +407,16 @@ impl WorkBoardProjection {
             }
         }
         Ok(())
+    }
+
+    fn apply_agent_availability_reported(&mut self, e: &AgentAvailabilityReported) {
+        self.agent_availability.insert(
+            format!("{}:{}", e.repo, e.peer),
+            AgentAvailabilityRecord {
+                report: e.clone(),
+                expires_at_ms: e.reported_at_ms + e.ttl_ms,
+            },
+        );
     }
 
     fn card_mut(&mut self, card_id: WorkCardId) -> Result<&mut WorkCard, ProjectionError> {

--- a/crates/airc-work/src/projection/tests.rs
+++ b/crates/airc-work/src/projection/tests.rs
@@ -1,9 +1,9 @@
 use super::*;
 use crate::event::*;
 use crate::model::{
-    BranchName, CardState, DirtyState, DrainCandidate, DrainCandidateCategory, DrainOutcome,
-    GitObjectId, PrCheckState, PrMergeState, PrReviewState, PressureLevel, Priority,
-    PullRequestRef, WorkspaceStatus,
+    AgentAvailabilityState, BranchName, CardState, DirtyState, DrainCandidate,
+    DrainCandidateCategory, DrainOutcome, GitObjectId, PrCheckState, PrMergeState, PrReviewState,
+    PressureLevel, Priority, PullRequestRef, WorkspaceStatus,
 };
 
 fn repo() -> RepoId {
@@ -60,6 +60,52 @@ fn card_claim_heartbeat_and_stale_detection_project_from_events() {
         .unwrap();
     assert!(projection.stale_claims(299).is_empty());
     assert_eq!(projection.stale_claims(300)[0].claim_id, claim_id);
+}
+
+#[test]
+fn availability_projection_keeps_latest_peer_state_per_repo() {
+    let repo = repo();
+    let other_repo = RepoId::new("CambrianTech/continuum").unwrap();
+    let alice = peer(41);
+
+    let projection = WorkBoardProjection::replay(vec![
+        WorkEvent::AgentAvailabilityReported(AgentAvailabilityReported {
+            repo: repo.clone(),
+            peer: alice,
+            state: AgentAvailabilityState::Ready,
+            note: Some("can review".to_string()),
+            ttl_ms: 100,
+            reported_at_ms: 10,
+        }),
+        WorkEvent::AgentAvailabilityReported(AgentAvailabilityReported {
+            repo: repo.clone(),
+            peer: alice,
+            state: AgentAvailabilityState::Busy,
+            note: Some("taking PR".to_string()),
+            ttl_ms: 50,
+            reported_at_ms: 20,
+        }),
+        WorkEvent::AgentAvailabilityReported(AgentAvailabilityReported {
+            repo: other_repo.clone(),
+            peer: alice,
+            state: AgentAvailabilityState::Ready,
+            note: None,
+            ttl_ms: 100,
+            reported_at_ms: 30,
+        }),
+    ])
+    .unwrap();
+
+    let mut availability = projection.snapshot().agent_availability;
+    availability.sort_by_key(|record| record.report.repo.to_string());
+
+    assert_eq!(availability.len(), 2);
+    assert_eq!(availability[0].report.repo, repo);
+    assert_eq!(availability[0].report.state, AgentAvailabilityState::Busy);
+    assert_eq!(availability[0].expires_at_ms, 70);
+    assert_eq!(availability[1].report.repo, other_repo);
+    assert_eq!(availability[1].report.state, AgentAvailabilityState::Ready);
+    assert_eq!(availability[1].expires_at_ms, 130);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add typed work-domain agent availability events with closed ready/busy/away state
- project latest availability per repo + peer onto the work board
- expose `Airc::report_agent_availability` for embedded consumers
- add thin CLI wrapper `airc work availability --repo ... --state ready|busy|away`
- document the idle-lock loop in README: publish availability, claim work, heartbeat claims

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-work -p airc-lib -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-work availability
- cargo test --manifest-path Cargo.toml -p airc-cli --test work_commands work_availability_projects_to_board
- cargo test --manifest-path Cargo.toml -p airc-work
- cargo test --manifest-path Cargo.toml -p airc-cli --test work_commands
- cargo clippy --manifest-path Cargo.toml -p airc-work -p airc-lib -p airc-cli --all-targets -- -D warnings
- git diff --check