### PR TITLE
feat(airc-cli): bake build sha + drift detection in doctor

### DIFF
--- a/crates/airc-cli/build.rs
+++ b/crates/airc-cli/build.rs
@@ -1,0 +1,60 @@
+//! Bake git commit + branch into the airc binary at compile time.
+//!
+//! Closes work card 38c295b8 (installed runtime convergence)
+//! prerequisite: `airc doctor` / `airc version` need a way to detect
+//! when the installed binary's source matches the current checkout
+//! vs has drifted. The pre-card `doctor.rs` had a TODO comment
+//! noting this exact gap: "we don't have a reliable way to compare
+//! to a canonical 'current' build here without baking commit
+//! metadata into the binary."
+//!
+//! Outputs three compile-time env vars consumable via `env!()`:
+//! - `AIRC_BUILD_COMMIT` — full SHA of `HEAD` at compile time, or
+//!   the literal string `unknown` if git wasn't available.
+//! - `AIRC_BUILD_COMMIT_SHORT` — 12-char short form for display.
+//! - `AIRC_BUILD_BRANCH` — branch name at compile time, or `unknown`.
+//!
+//! The build is **not** re-run when source files change unless the
+//! `.git/HEAD` file does — that's `cargo:rerun-if-changed=.git/HEAD`.
+//! When git isn't present (e.g. building from a release tarball)
+//! the constants fall back to `unknown` rather than failing the
+//! build.
+
+use std::process::Command;
+
+fn main() {
+    let commit = git(["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let commit_short =
+        git(["rev-parse", "--short=12", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let branch =
+        git(["rev-parse", "--abbrev-ref", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=AIRC_BUILD_COMMIT={commit}");
+    println!("cargo:rustc-env=AIRC_BUILD_COMMIT_SHORT={commit_short}");
+    println!("cargo:rustc-env=AIRC_BUILD_BRANCH={branch}");
+    // Re-run when HEAD moves; tells cargo not to rerun on every
+    // source change.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    // .git/HEAD is a single-line file in a normal checkout that
+    // points at refs/heads/<branch>; the branch ref then holds the
+    // commit. Watch both so a commit on the current branch also
+    // triggers a rebuild.
+    println!("cargo:rerun-if-changed=.git/refs/heads/");
+}
+
+fn git<I, S>(args: I) -> Option<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}

--- a/crates/airc-cli/src/build_info.rs
+++ b/crates/airc-cli/src/build_info.rs
@@ -1,0 +1,21 @@
+//! Compile-time build info baked in by `build.rs`.
+//!
+//! These constants are populated by `build.rs` via
+//! `cargo:rustc-env=AIRC_BUILD_*`. When git isn't available at
+//! compile time (e.g. release tarball builds) the constants hold
+//! the literal string `unknown`.
+
+/// Full git commit SHA at compile time, or `unknown`.
+pub const COMMIT: &str = env!("AIRC_BUILD_COMMIT");
+/// 12-char short commit for compact display, or `unknown`.
+pub const COMMIT_SHORT: &str = env!("AIRC_BUILD_COMMIT_SHORT");
+/// Git branch at compile time, or `unknown`.
+pub const BRANCH: &str = env!("AIRC_BUILD_BRANCH");
+/// Cargo package version (semver).
+pub const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Whether build info was actually captured (vs. fell back to
+/// `unknown` because git wasn't available at compile time).
+pub fn is_unknown() -> bool {
+    COMMIT == "unknown"
+}

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -153,8 +153,17 @@ fn ensure_runtime_integrations() {
 pub fn run_version() -> Result<(), Box<dyn std::error::Error>> {
     let exe = std::env::current_exe()?;
     let exe_path = exe.canonicalize().unwrap_or(exe);
-    println!("  airc {}", env!("CARGO_PKG_VERSION"));
+    println!("  airc {}", crate::build_info::PACKAGE_VERSION);
     println!("  install: {}", exe_path.display());
+    if !crate::build_info::is_unknown() {
+        println!(
+            "  build:   {} on {}",
+            crate::build_info::COMMIT_SHORT,
+            crate::build_info::BRANCH
+        );
+    } else {
+        println!("  build:   unknown (git unavailable at compile time)");
+    }
     Ok(())
 }
 

--- a/crates/airc-cli/src/doctor.rs
+++ b/crates/airc-cli/src/doctor.rs
@@ -257,14 +257,72 @@ fn check_binary_freshness() -> Vec<Finding> {
     };
     let canonical = exe.canonicalize().unwrap_or_else(|_| exe.clone());
 
-    // If the binary lives under a known source-tree layout, mention
-    // that — helps operators notice when the installed binary is
-    // pointing at a stale `~/.airc/src/target/...` from a different
-    // checkout. We don't have a reliable way to compare to a
-    // canonical "current" build here without baking commit metadata
-    // into the binary (TODO), so just surface the location.
-    let detail = format!("install: {}", canonical.display());
-    vec![Finding::info("binary", detail)]
+    let mut findings = vec![Finding::info(
+        "binary",
+        format!("install: {}", canonical.display()),
+    )];
+
+    // Compare the baked-in build sha (from build.rs) against the
+    // current HEAD of the install source tree. If they diverge, the
+    // installed binary is stale relative to its source checkout —
+    // running `airc update` reconciles it.
+    if !crate::build_info::is_unknown() {
+        findings.push(Finding::info(
+            "binary",
+            format!(
+                "build: {} on {}",
+                crate::build_info::COMMIT_SHORT,
+                crate::build_info::BRANCH
+            ),
+        ));
+        if let Some(source_head) = source_tree_head() {
+            if source_head == crate::build_info::COMMIT {
+                findings.push(Finding::ok(
+                    "binary",
+                    "installed binary matches source checkout HEAD",
+                ));
+            } else {
+                let short_source = &source_head[..source_head.len().min(12)];
+                findings.push(Finding::warn(
+                    "binary",
+                    format!(
+                        "installed binary drifted from source tree (binary={} source={short_source})",
+                        crate::build_info::COMMIT_SHORT
+                    ),
+                    "run `airc update` to reconcile",
+                ));
+            }
+        }
+    } else {
+        findings.push(Finding::info(
+            "binary",
+            "build sha unknown (git unavailable at compile time); skipping drift check",
+        ));
+    }
+
+    findings
+}
+
+fn source_tree_head() -> Option<String> {
+    // The install source path is conventionally `~/.airc/src` per
+    // install.sh, but we resolve it the same way `update_commands`
+    // does so the two stay aligned.
+    let source = crate::update_commands::install_source_dir().ok()?;
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&source)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
 }
 
 async fn check_health(home: &Path) -> Vec<Finding> {

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -11,6 +11,7 @@
 //! auto-generate missing identity material. `VerificationPolicy::Strict`
 //! is the only policy used in CLI paths — no `AllowUnsigned` opt-in.
 
+mod build_info;
 mod channel_gist_cli;
 mod channel_gist_commands;
 mod cli;

--- a/crates/airc-cli/src/update_commands.rs
+++ b/crates/airc-cli/src/update_commands.rs
@@ -150,7 +150,7 @@ fn detach_daemon(command: &mut Command) {
 #[cfg(not(unix))]
 fn detach_daemon(_command: &mut Command) {}
 
-fn install_source_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
+pub(crate) fn install_source_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
     if let Some(path) = env::var_os("AIRC_DIR").filter(|value| !value.is_empty()) {
         return Ok(PathBuf::from(path));
     }

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -105,6 +105,16 @@ theoretical architecture concerns; they showed up in normal use.
    installed CLI contract during `airc update`, and IRC-shaped verbs
    should remain the public surface when they match the product model.
 
+   **IRC-shaped commands restored** in #966 (`airc peers` / `whois`).
+   The follow-up "installed binary can reject public commands if update
+   lags" surfaced as work card 38c295b8 — closed via the
+   installed-runtime-convergence work: a `build.rs` bakes the git
+   commit + branch into the airc binary at compile time;
+   `airc version` shows the build sha; `airc doctor` compares the
+   baked-in commit against the install-source HEAD and surfaces drift
+   with a `Fix:` directive pointing at `airc update`. Skill/docs
+   generation from the live CLI contract is still open as a follow-up.
+
 2. **Peer roster is too low-level for human/agent coordination.**
    `airc peers` prints peer IDs and public keys only. It does not
    show nick, runtime kind, project scope, room subscriptions,


### PR DESCRIPTION
## Summary
Closes work card **38c295b8** (installed runtime convergence, P1). Before this PR, `airc doctor` had a `TODO` noting "we don't have a reliable way to compare to a canonical 'current' build here without baking commit metadata into the binary." After this PR, drift is detected and operators get a `Fix:` directive.

## Mechanism
- New `crates/airc-cli/build.rs` runs `git rev-parse HEAD` / `--abbrev-ref HEAD` at compile time and emits values via `cargo:rustc-env=AIRC_BUILD_COMMIT*`. Falls back to `unknown` when git isn't available (release tarball builds).
- New `crates/airc-cli/src/build_info.rs` exposes them as `pub const` via `env!()`.
- `airc version` prints build sha + branch alongside the existing version + install path.
- `airc doctor` compares the baked-in commit against the install-source HEAD (via the same `install_source_dir` resolver `airc update` uses) and surfaces drift as `[WARN] binary: ... Fix: run `airc update` to reconcile`.

## Sample output (drift case)
```
airc doctor — scope: /Users/joelteply/.airc

[ok] identity: key + ORM row both present
[ok] daemon: responding on /var/folders/.../airc-ipc-v2-...sock
[info] binary: install: /Users/.../airc-binary
[info] binary: build: 492da8d9a3de on feat/installed-runtime-convergence
[WARN] binary: installed binary drifted from source tree (binary=492da8d9a3de source=8225610ae95d)
    Fix: run `airc update` to reconcile
```

## Sample output (in sync)
```
[ok] binary: installed binary matches source checkout HEAD
```

## Test plan
- [x] `airc version` shows build sha + branch on a built binary
- [x] `airc doctor` surfaces drift when binary commit ≠ source HEAD (reproduced locally — binary built at 492da8d9 vs rust-rewrite head at 8225610)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] build.rs handles the no-git case gracefully (falls back to "unknown")

## Scope cuts (follow-ups)
- **Daemon-side build sha**: a running daemon process could be on a different commit than the binary that started it (e.g. binary updated but daemon not restarted). Daemon IPC method to query the daemon's build sha + comparison in doctor is a natural follow-up.
- **Skill/docs auto-generation**: the audit's flaw #1 also wanted skill generation from the live CLI contract during `airc update`. That's separate scope.

## Roadmap reference
`docs/architecture/GRID-SUBSTRATE-AUDIT.md` § Observed Flaws #1 — status entry updated noting the installed-binary-drift follow-up to #966 is now closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)