### PR TITLE
feat(diagnostics): add typed substrate diagnostic sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ name = "airc-daemon"
 version = "0.1.0"
 dependencies = [
  "airc-core",
+ "airc-diagnostics",
  "airc-identity",
  "airc-ipc",
  "airc-protocol",
@@ -120,6 +121,14 @@ dependencies = [
  "tempfile",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "airc-diagnostics"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -154,6 +163,7 @@ version = "0.1.0"
 dependencies = [
  "airc-core",
  "airc-daemon",
+ "airc-diagnostics",
  "airc-identity",
  "airc-ipc",
  "airc-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/airc-core",
+    "crates/airc-diagnostics",
     "crates/airc-blobs",
     "crates/airc-protocol",
     "crates/airc-transport",

--- a/crates/airc-daemon/Cargo.toml
+++ b/crates/airc-daemon/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 airc-core = { path = "../airc-core" }
+airc-diagnostics = { path = "../airc-diagnostics" }
 airc-identity = { path = "../airc-identity" }
 airc-ipc = { path = "../airc-ipc" }
 airc-protocol = { path = "../airc-protocol" }

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -11,6 +11,9 @@ use std::sync::Arc;
 use airc_core::{
     headers::Headers, transcript::MentionTarget, Body, ClientId, EventId, RoomId, TranscriptCursor,
 };
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
+};
 use airc_ipc::request::{
     AddPeerRequest, InboxRequest, RemovePeerRequest, Request, SendRequest, SubscribeRequest,
 };
@@ -113,21 +116,27 @@ async fn handle_subscribe(state: Arc<DaemonState>, sub: SubscribeRequest) -> Res
                             let _ = state.live_tx.send(event);
                         }
                         Err(err) => {
-                            // Persistence failures are loud. Most likely
-                            // a duplicate replay (DuplicateEventId), which
-                            // is benign for replay-style subscriptions.
-                            // Anything else (Database, Migration, Codec)
-                            // surfaces here so the operator sees it.
-                            eprintln!(
-                                "daemon subscriber: store append failed for {event_id}: {err}"
+                            StderrJsonDiagnosticSink.emit(
+                                DiagnosticEvent::error(
+                                    DiagnosticComponent::Daemon,
+                                    DiagnosticCode::StoreAppendFailed,
+                                    "daemon subscriber store append failed",
+                                )
+                                .with_field("event_id", event_id)
+                                .with_field("error", err),
                             );
                         }
                     }
                 }
                 Err(verify_error) => {
-                    // Verification failure — don't persist.
-                    // Future: surface a counter in Status response.
-                    eprintln!("daemon subscriber: frame verification failed: {verify_error}");
+                    StderrJsonDiagnosticSink.emit(
+                        DiagnosticEvent::warn(
+                            DiagnosticComponent::Daemon,
+                            DiagnosticCode::FrameVerificationFailed,
+                            "daemon subscriber frame verification failed",
+                        )
+                        .with_field("error", verify_error),
+                    );
                 }
             }
         }

--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -20,6 +20,9 @@ use fs2::FileExt;
 use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
 
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
+};
 use airc_ipc::codec::{read_frame, write_frame};
 use airc_ipc::request::{AttachRequest, Request};
 use airc_ipc::response::Response;
@@ -88,7 +91,14 @@ pub async fn run(state: Arc<DaemonState>, socket_path: PathBuf) -> Result<(), Da
                 let state = state.clone();
                 tokio::spawn(async move {
                     if let Err(error) = handle_connection(stream, state).await {
-                        eprintln!("daemon connection error: {error}");
+                        StderrJsonDiagnosticSink.emit(
+                            DiagnosticEvent::error(
+                                DiagnosticComponent::Daemon,
+                                DiagnosticCode::ConnectionError,
+                                "daemon connection error",
+                            )
+                            .with_field("error", error),
+                        );
                     }
                 });
             }

--- a/crates/airc-daemon/src/state.rs
+++ b/crates/airc-daemon/src/state.rs
@@ -20,6 +20,9 @@ use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, Mutex, Notify};
 
 use airc_core::PeerId;
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
+};
 use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
 use airc_store::EventStore;
 use airc_transport::{LocalFsAdapter, SignedTransport};
@@ -165,9 +168,14 @@ impl DaemonState {
                     _ = state.shutdown.notified() => break,
                     _ = tokio::time::sleep(TRUST_REFRESH_INTERVAL) => {
                         if let Err(error) = state.refresh_trust_root(&root).await {
-                            eprintln!(
-                                "daemon trust refresh failed for {}: {error}",
-                                root.display()
+                            StderrJsonDiagnosticSink.emit(
+                                DiagnosticEvent::warn(
+                                    DiagnosticComponent::Daemon,
+                                    DiagnosticCode::TrustRefreshFailed,
+                                    "daemon trust refresh failed",
+                                )
+                                .with_field("root", root.display())
+                                .with_field("error", error),
                             );
                         }
                     }

--- a/crates/airc-diagnostics/Cargo.toml
+++ b/crates/airc-diagnostics/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "airc-diagnostics"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+# Typed operational diagnostics for AIRC substrate components.
+# This crate is the boundary between protocol/runtime state and
+# terminal logging. Libraries emit structured DiagnosticEvents; CLI or
+# daemon hosts decide whether those become stderr JSONL, an ORM row, an
+# AIRC event, or a test assertion.
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/airc-diagnostics/src/lib.rs
+++ b/crates/airc-diagnostics/src/lib.rs
@@ -1,0 +1,194 @@
+//! Typed operational diagnostics for AIRC.
+//!
+//! Diagnostics are not protocol output. Substrate code emits
+//! [`DiagnosticEvent`] values through a [`DiagnosticSink`]; terminal
+//! hosts can render them to stderr, and integrations can route them to
+//! ORM/event projections without parsing CLI text.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticSeverity {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticComponent {
+    Daemon,
+    Monitor,
+    Replay,
+    Subscriber,
+    Transport,
+    WebRtc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticCode {
+    ConnectionError,
+    FrameVerificationFailed,
+    StoreAppendFailed,
+    TrustRefreshFailed,
+    WireLostEmitFailed,
+    MalformedReplayFrameSkipped,
+    UnverifiableReplayFrameSkipped,
+    ReplayFramesSkipped,
+    WebRtcOfferAnswerFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiagnosticEvent {
+    pub severity: DiagnosticSeverity,
+    pub component: DiagnosticComponent,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub fields: BTreeMap<String, String>,
+    pub occurred_at_ms: u64,
+}
+
+impl DiagnosticEvent {
+    pub fn new(
+        severity: DiagnosticSeverity,
+        component: DiagnosticComponent,
+        code: DiagnosticCode,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            severity,
+            component,
+            code,
+            message: message.into(),
+            fields: BTreeMap::new(),
+            occurred_at_ms: now_ms(),
+        }
+    }
+
+    pub fn warn(
+        component: DiagnosticComponent,
+        code: DiagnosticCode,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::new(DiagnosticSeverity::Warn, component, code, message)
+    }
+
+    pub fn error(
+        component: DiagnosticComponent,
+        code: DiagnosticCode,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::new(DiagnosticSeverity::Error, component, code, message)
+    }
+
+    pub fn with_field(mut self, key: impl Into<String>, value: impl ToString) -> Self {
+        self.fields.insert(key.into(), value.to_string());
+        self
+    }
+}
+
+pub trait DiagnosticSink: Send + Sync {
+    fn emit(&self, event: DiagnosticEvent);
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopDiagnosticSink;
+
+impl DiagnosticSink for NoopDiagnosticSink {
+    fn emit(&self, _event: DiagnosticEvent) {}
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StderrJsonDiagnosticSink;
+
+impl DiagnosticSink for StderrJsonDiagnosticSink {
+    fn emit(&self, event: DiagnosticEvent) {
+        let mut stderr = std::io::stderr().lock();
+        let _ = serde_json::to_writer(&mut stderr, &event);
+        let _ = stderr.write_all(b"\n");
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct MemoryDiagnosticSink {
+    events: Arc<Mutex<Vec<DiagnosticEvent>>>,
+}
+
+impl MemoryDiagnosticSink {
+    pub fn events(&self) -> Vec<DiagnosticEvent> {
+        match self.events.lock() {
+            Ok(events) => events.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+}
+
+impl DiagnosticSink for MemoryDiagnosticSink {
+    fn emit(&self, event: DiagnosticEvent) {
+        match self.events.lock() {
+            Ok(mut events) => events.push(event),
+            Err(poisoned) => poisoned.into_inner().push(event),
+        }
+    }
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSeverity, DiagnosticSink,
+        MemoryDiagnosticSink,
+    };
+
+    #[test]
+    fn memory_sink_captures_typed_events() {
+        let sink = MemoryDiagnosticSink::default();
+        sink.emit(
+            DiagnosticEvent::warn(
+                DiagnosticComponent::Replay,
+                DiagnosticCode::UnverifiableReplayFrameSkipped,
+                "skipped unverifiable frame",
+            )
+            .with_field("peer_id", "peer-1"),
+        );
+
+        let events = sink.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].severity, DiagnosticSeverity::Warn);
+        assert_eq!(events[0].component, DiagnosticComponent::Replay);
+        assert_eq!(
+            events[0].code,
+            DiagnosticCode::UnverifiableReplayFrameSkipped
+        );
+        assert_eq!(events[0].fields.get("peer_id"), Some(&"peer-1".to_string()));
+    }
+
+    #[test]
+    fn event_serializes_as_stable_snake_case_json() {
+        let event = DiagnosticEvent::error(
+            DiagnosticComponent::Daemon,
+            DiagnosticCode::ConnectionError,
+            "connection failed",
+        )
+        .with_field("socket", "daemon.sock");
+
+        let value = serde_json::to_value(event).expect("diagnostic json");
+        assert_eq!(value["severity"], "error");
+        assert_eq!(value["component"], "daemon");
+        assert_eq!(value["code"], "connection_error");
+        assert_eq!(value["fields"]["socket"], "daemon.sock");
+    }
+}

--- a/crates/airc-lib/Cargo.toml
+++ b/crates/airc-lib/Cargo.toml
@@ -24,6 +24,7 @@ workspace = true
 
 [dependencies]
 airc-core = { path = "../airc-core" }
+airc-diagnostics = { path = "../airc-diagnostics" }
 airc-identity = { path = "../airc-identity" }
 airc-ipc = { path = "../airc-ipc" }
 airc-protocol = { path = "../airc-protocol" }

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -2,6 +2,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use airc_core::{EventId, TranscriptCursor};
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
+};
 use airc_protocol::{Frame, Subscription};
 use airc_transport::{LocalFsAdapter, SignedTransport, Transport};
 use futures::stream::StreamExt;
@@ -367,9 +370,15 @@ impl Airc {
             };
             if let Some(wire) = wire_for_lifecycle {
                 if let Err(err) = airc.emit_wire_lost(&wire, reason).await {
-                    eprintln!(
-                        "airc-lib subscriber: wire_lost emit failed for {} ({reason}): {err}",
-                        wire.display()
+                    StderrJsonDiagnosticSink.emit(
+                        DiagnosticEvent::warn(
+                            DiagnosticComponent::Subscriber,
+                            DiagnosticCode::WireLostEmitFailed,
+                            "wire_lost lifecycle emit failed",
+                        )
+                        .with_field("wire", wire.display())
+                        .with_field("reason", reason)
+                        .with_field("error", err),
                     );
                 }
             }
@@ -436,7 +445,15 @@ impl Airc {
                 }
             }
             Err(err) => {
-                eprintln!("airc-lib subscriber: store append failed: {err}");
+                StderrJsonDiagnosticSink.emit(
+                    DiagnosticEvent::error(
+                        DiagnosticComponent::Subscriber,
+                        DiagnosticCode::StoreAppendFailed,
+                        "subscriber store append failed",
+                    )
+                    .with_field("event_id", event_id)
+                    .with_field("error", err),
+                );
             }
         }
     }
@@ -444,7 +461,14 @@ impl Airc {
 
 fn warn_frame_verify_failed(error: &impl std::fmt::Display) {
     if std::env::var_os("AIRC_REPLAY_WARN").is_some() {
-        eprintln!("airc-lib subscriber: frame verification failed: {error}");
+        StderrJsonDiagnosticSink.emit(
+            DiagnosticEvent::warn(
+                DiagnosticComponent::Subscriber,
+                DiagnosticCode::FrameVerificationFailed,
+                "subscriber frame verification failed",
+            )
+            .with_field("error", error),
+        );
     }
 }
 

--- a/crates/airc-lib/src/webrtc.rs
+++ b/crates/airc-lib/src/webrtc.rs
@@ -33,6 +33,9 @@ use std::time::Duration;
 
 use airc_core::headers::Headers;
 use airc_core::{Body, PeerId, TranscriptEvent};
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
+};
 use airc_protocol::FrameKind;
 use airc_transport::webrtc_datachannel::WebRtcDataChannelAdapter;
 use futures::StreamExt;
@@ -224,7 +227,16 @@ impl Airc {
                 }
                 let initiator = event.peer_id;
                 if let Err(error) = airc.answer_offer(initiator, session_id, sdp).await {
-                    eprintln!("webrtc accept_offer failed for {initiator}: {error}");
+                    StderrJsonDiagnosticSink.emit(
+                        DiagnosticEvent::warn(
+                            DiagnosticComponent::WebRtc,
+                            DiagnosticCode::WebRtcOfferAnswerFailed,
+                            "WebRTC offer answer failed",
+                        )
+                        .with_field("initiator", initiator)
+                        .with_field("session_id", session_id)
+                        .with_field("error", error),
+                    );
                 }
             }
         });

--- a/crates/airc-lib/src/wire_replay.rs
+++ b/crates/airc-lib/src/wire_replay.rs
@@ -1,5 +1,8 @@
 use std::path::Path;
 
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
+};
 use airc_protocol::{verify, Frame};
 
 use crate::error::AircError;
@@ -36,9 +39,14 @@ impl Airc {
                     // one means losing every later real event too.
                     malformed_count += 1;
                     if replay_warnings_enabled() {
-                        eprintln!(
-                            "airc-lib replay: skipping malformed frame in {}: {error}",
-                            path.display()
+                        StderrJsonDiagnosticSink.emit(
+                            DiagnosticEvent::warn(
+                                DiagnosticComponent::Replay,
+                                DiagnosticCode::MalformedReplayFrameSkipped,
+                                "skipping malformed replay frame",
+                            )
+                            .with_field("wire_file", path.display())
+                            .with_field("error", error),
                         );
                     }
                     continue;
@@ -56,7 +64,15 @@ impl Airc {
                 // scope that touched the wire pre-identity-reset.
                 unverifiable_count += 1;
                 if replay_warnings_enabled() {
-                    eprintln!("airc-lib replay: skipping unverifiable frame: {error}");
+                    StderrJsonDiagnosticSink.emit(
+                        DiagnosticEvent::warn(
+                            DiagnosticComponent::Replay,
+                            DiagnosticCode::UnverifiableReplayFrameSkipped,
+                            "skipping unverifiable replay frame",
+                        )
+                        .with_field("wire_file", path.display())
+                        .with_field("error", error),
+                    );
                 }
                 continue;
             }
@@ -67,9 +83,15 @@ impl Airc {
             }
         }
         if replay_warnings_enabled() && (malformed_count > 0 || unverifiable_count > 0) {
-            eprintln!(
-                "airc-lib replay: skipped {malformed_count} malformed and {unverifiable_count} unverifiable frame(s) in {}",
-                path.display()
+            StderrJsonDiagnosticSink.emit(
+                DiagnosticEvent::warn(
+                    DiagnosticComponent::Replay,
+                    DiagnosticCode::ReplayFramesSkipped,
+                    "replay skipped invalid frame(s)",
+                )
+                .with_field("wire_file", path.display())
+                .with_field("malformed_count", malformed_count)
+                .with_field("unverifiable_count", unverifiable_count),
             );
         }
         Ok(())

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -167,6 +167,14 @@ theoretical architecture concerns; they showed up in normal use.
    channels — `airc-lib`, daemon IPC, ORM-backed projections, and AIRC
    events — not stdout/stderr parsing.
 
+   Status: foundation landed in `airc-diagnostics`: typed severity,
+   component, and code enums plus sink implementations. The first
+   substrate warnings in `airc-lib` replay/subscriber paths and
+   `airc-daemon` subscriber/trust/connection paths now emit structured
+   diagnostics before terminal rendering. Remaining work is to move
+   CLI/monitor/doctor surfaces onto the same sink model and add an ORM
+   sink for consumer-visible diagnostics.
+
 These flaws do not invalidate the substrate path. They identify the
 next product gap: the transport now works well enough that the weak
 point is coordination ergonomics, typed roster/claim state, and stale
@@ -308,8 +316,8 @@ Work:
   - dropped event count where loss is allowed
   - oldest retained cursor
   - per-subscriber cursor age
-- Replace silent ingest warnings with typed diagnostics that can be
-  emitted as events and surfaced in `airc doctor`.
+- Continue replacing silent ingest warnings with typed diagnostics that
+  can be emitted as ORM rows/events and surfaced in `airc doctor`.
 - Audit `Mutex`/lock scopes across `.await`; split or narrow where a
   lock crosses IO.
 - Reduce avoidable `event.clone()` in hot broadcast paths.


### PR DESCRIPTION
## Summary
- add `airc-diagnostics` with typed severity/component/code enums and sink implementations
- route airc-lib replay/subscriber/WebRTC warnings through structured diagnostic events
- route airc-daemon subscriber/trust/connection failures through the same sink
- update `GRID-SUBSTRATE-AUDIT.md` with the diagnostic-sink foundation and remaining ORM/event sink work

## Design note
This does not make stdout/stderr an integration contract. `StderrJsonDiagnosticSink` is only a terminal/host sink. Consumers should use `airc-lib`, daemon IPC, ORM projections, and AIRC events; the next slice can add an ORM/event sink without changing call sites.

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-diagnostics -p airc-lib -p airc-daemon`
- `cargo test --manifest-path Cargo.toml -p airc-diagnostics`
- `cargo test --manifest-path Cargo.toml -p airc-lib wire_replay`
- `cargo clippy --manifest-path Cargo.toml -p airc-diagnostics -p airc-lib -p airc-daemon --all-targets -- -D warnings`
- `git diff --check`