### PR TITLE
feat(airc-lib): typed work-event subscription API

### DIFF
--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -64,6 +64,7 @@ pub mod webrtc_media;
 pub mod webrtc_signaling;
 mod wire_replay;
 pub mod work;
+pub mod work_subscription;
 
 pub use account_registry::{
     AccountPeerBeacon, AccountRegistryDocument, AccountRegistryError, AccountRegistryStore,
@@ -120,6 +121,9 @@ pub use work::{
     CreateWorkLane, HeartbeatWorkClaim, HeartbeatWorkspace, ObserveLocalGitWorkspace,
     ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests, ReleaseManagerHat,
     ReleaseWorkClaim, ReleaseWorkspace, ReportAgentAvailability, RequestWorkspace,
+};
+pub use work_subscription::{
+    WorkEventFilter, HEADER_WORK_CARD_ID, HEADER_WORK_LANE_ID, HEADER_WORK_REPO,
 };
 
 // Convenience re-exports so consumers don't need to pull airc-core

--- a/crates/airc-lib/src/work_subscription.rs
+++ b/crates/airc-lib/src/work_subscription.rs
@@ -1,0 +1,281 @@
+//! Typed work-event subscription surface.
+//!
+//! Closes work card e1f8e2e0 (P0): "Work subscription API: typed
+//! kanban/PR event stream for agents." Before this module, consumers
+//! wanting work-card / claim / PR / availability events had to
+//! subscribe to the raw substrate stream, call
+//! `transcript_is_work_event` on each event, decode the body, then
+//! pattern-match. After this module, consumers call
+//! [`Airc::subscribe_work_events`] / [`Airc::recent_work_events`]
+//! with a [`WorkEventFilter`] and get typed [`WorkEvent`] values.
+//!
+//! The substrate primitives this builds on were already shipped:
+//! - `airc-work::transcript_is_work_event` — header-based discriminator
+//! - `airc-work::decode_transcript_work_event` — decoder
+//! - Headers `forge.work.repo` / `forge.work.lane_id` / `forge.work.card_id`
+//!
+//! This module adds the SDK API on top so consumers (Continuum
+//! managers, agent schedulers, dashboards) don't reinvent the
+//! filter + decode loop.
+
+use std::sync::Arc;
+
+use airc_core::{PeerId, TranscriptEvent};
+use airc_work::{
+    decode_transcript_work_event, transcript_is_work_event, LaneId, RepoId, WorkEvent,
+};
+use futures::stream::{Stream, StreamExt};
+
+use crate::error::AircError;
+use crate::Airc;
+
+/// Header keys for filtering work events without decoding the body.
+pub const HEADER_WORK_REPO: &str = "forge.work.repo";
+pub const HEADER_WORK_LANE_ID: &str = "forge.work.lane_id";
+pub const HEADER_WORK_CARD_ID: &str = "forge.work.card_id";
+
+/// Filter applied at subscribe/query time. All fields are `Option`
+/// — a `None` field matches anything.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WorkEventFilter {
+    /// Restrict to events tagged with this `forge.work.repo`.
+    pub repo: Option<RepoId>,
+    /// Restrict to events tagged with this `forge.work.lane_id`.
+    pub lane_id: Option<LaneId>,
+    /// Restrict to events signed by this peer (the substrate-level
+    /// signer of the transcript event, not the work-event's
+    /// actor/owner field — those vary per variant).
+    pub peer: Option<PeerId>,
+}
+
+impl WorkEventFilter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_repo(mut self, repo: RepoId) -> Self {
+        self.repo = Some(repo);
+        self
+    }
+
+    pub fn with_lane_id(mut self, lane_id: LaneId) -> Self {
+        self.lane_id = Some(lane_id);
+        self
+    }
+
+    pub fn with_peer(mut self, peer: PeerId) -> Self {
+        self.peer = Some(peer);
+        self
+    }
+
+    /// Cheap header-only check; avoids decoding the body if the
+    /// substrate-level filters already rule the event out.
+    pub(crate) fn matches_transcript(&self, event: &TranscriptEvent) -> bool {
+        if let Some(peer) = self.peer {
+            if event.peer_id != peer {
+                return false;
+            }
+        }
+        if let Some(repo) = self.repo.as_ref() {
+            match event.headers.get(HEADER_WORK_REPO) {
+                Some(value) if value == repo.as_str() => {}
+                _ => return false,
+            }
+        }
+        if let Some(lane_id) = self.lane_id.as_ref() {
+            let expected = lane_id.to_string();
+            match event.headers.get(HEADER_WORK_LANE_ID) {
+                Some(value) if *value == expected => {}
+                _ => return false,
+            }
+        }
+        true
+    }
+}
+
+impl Airc {
+    /// Subscribe to typed work events. The returned stream yields
+    /// `(transcript event, decoded WorkEvent)` pairs only for
+    /// events matching `filter`. Subscription is live — events
+    /// emitted after the call surface here; for historical events,
+    /// use [`Airc::recent_work_events`].
+    pub async fn subscribe_work_events(
+        &self,
+        filter: WorkEventFilter,
+    ) -> Result<impl Stream<Item = (Arc<TranscriptEvent>, WorkEvent)>, AircError> {
+        let inner = self.subscribe().await?;
+        Ok(inner.filter_map(move |item| {
+            let filter = filter.clone();
+            async move {
+                let event = item.ok()?;
+                if !transcript_is_work_event(&event) {
+                    return None;
+                }
+                if !filter.matches_transcript(&event) {
+                    return None;
+                }
+                let item = decode_transcript_work_event(&event).ok()?;
+                Some((event, item.event))
+            }
+        }))
+    }
+
+    /// Query recent work events from the persisted transcript.
+    /// Walks the last `window` events, filters, decodes, and returns
+    /// the matching `WorkEvent`s in transcript order (oldest →
+    /// newest). Useful for "current state" queries that don't need
+    /// a live subscription.
+    pub async fn recent_work_events(
+        &self,
+        filter: WorkEventFilter,
+        window: usize,
+    ) -> Result<Vec<WorkEvent>, AircError> {
+        let recent = self.page_recent(window).await?;
+        let mut out = Vec::with_capacity(recent.len().min(window));
+        for transcript_event in recent {
+            if !transcript_is_work_event(&transcript_event) {
+                continue;
+            }
+            if !filter.matches_transcript(&transcript_event) {
+                continue;
+            }
+            if let Ok(item) = decode_transcript_work_event(&transcript_event) {
+                out.push(item.event);
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_work::WorkCardId;
+
+    fn sample_filter() -> WorkEventFilter {
+        WorkEventFilter::new()
+            .with_repo(RepoId::new("test-org/test-repo").unwrap())
+            .with_peer(PeerId::new())
+    }
+
+    #[test]
+    fn empty_filter_matches_everything() {
+        let filter = WorkEventFilter::default();
+        let mut headers = airc_core::headers::Headers::new();
+        headers.insert(
+            crate::work_subscription::HEADER_WORK_REPO.to_string(),
+            "anywhere".to_string(),
+        );
+        let event = TranscriptEvent {
+            event_id: airc_core::EventId::new(),
+            peer_id: PeerId::new(),
+            client_id: airc_core::ClientId::new(),
+            room_id: airc_core::RoomId::new(),
+            kind: airc_core::TranscriptKind::System,
+            occurred_at_ms: 0,
+            lamport: 0,
+            target: airc_core::transcript::MentionTarget::All,
+            headers,
+            body: None,
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        };
+        assert!(filter.matches_transcript(&event));
+    }
+
+    #[test]
+    fn peer_filter_rejects_other_signers() {
+        let target_peer = PeerId::new();
+        let other_peer = PeerId::new();
+        let filter = WorkEventFilter::new().with_peer(target_peer);
+        let event = TranscriptEvent {
+            event_id: airc_core::EventId::new(),
+            peer_id: other_peer,
+            client_id: airc_core::ClientId::new(),
+            room_id: airc_core::RoomId::new(),
+            kind: airc_core::TranscriptKind::System,
+            occurred_at_ms: 0,
+            lamport: 0,
+            target: airc_core::transcript::MentionTarget::All,
+            headers: airc_core::headers::Headers::new(),
+            body: None,
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        };
+        assert!(!filter.matches_transcript(&event));
+    }
+
+    #[test]
+    fn repo_filter_matches_header_value() {
+        let repo = RepoId::new("CambrianTech/airc").unwrap();
+        let filter = WorkEventFilter::new().with_repo(repo);
+        let mut headers = airc_core::headers::Headers::new();
+        headers.insert(
+            HEADER_WORK_REPO.to_string(),
+            "CambrianTech/airc".to_string(),
+        );
+        let event = TranscriptEvent {
+            event_id: airc_core::EventId::new(),
+            peer_id: PeerId::new(),
+            client_id: airc_core::ClientId::new(),
+            room_id: airc_core::RoomId::new(),
+            kind: airc_core::TranscriptKind::System,
+            occurred_at_ms: 0,
+            lamport: 0,
+            target: airc_core::transcript::MentionTarget::All,
+            headers,
+            body: None,
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        };
+        assert!(filter.matches_transcript(&event));
+    }
+
+    #[test]
+    fn repo_filter_rejects_other_repo() {
+        let filter =
+            WorkEventFilter::new().with_repo(RepoId::new("expected-org/expected-repo").unwrap());
+        let mut headers = airc_core::headers::Headers::new();
+        headers.insert(
+            HEADER_WORK_REPO.to_string(),
+            "wrong-org/wrong-repo".to_string(),
+        );
+        let event = TranscriptEvent {
+            event_id: airc_core::EventId::new(),
+            peer_id: PeerId::new(),
+            client_id: airc_core::ClientId::new(),
+            room_id: airc_core::RoomId::new(),
+            kind: airc_core::TranscriptKind::System,
+            occurred_at_ms: 0,
+            lamport: 0,
+            target: airc_core::transcript::MentionTarget::All,
+            headers,
+            body: None,
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        };
+        assert!(!filter.matches_transcript(&event));
+    }
+
+    #[test]
+    fn filter_builder_chains() {
+        let filter = WorkEventFilter::new()
+            .with_repo(RepoId::new("test/repo").unwrap())
+            .with_peer(PeerId::new());
+        assert!(filter.repo.is_some());
+        assert!(filter.peer.is_some());
+        assert!(filter.lane_id.is_none());
+    }
+
+    // Compile-time sanity check that the builder doesn't move the
+    // owner — useful when extending tests later.
+    #[test]
+    fn filter_is_cloneable() {
+        let _ = sample_filter().clone();
+        let _: WorkCardId = WorkCardId::new();
+    }
+}

--- a/crates/airc-lib/tests/work_subscription.rs
+++ b/crates/airc-lib/tests/work_subscription.rs
@@ -1,0 +1,180 @@
+//! Integration: typed work-event subscription stream.
+//!
+//! Proves work card e1f8e2e0: agents subscribe via
+//! `Airc::subscribe_work_events` + `WorkEventFilter` and get typed
+//! `WorkEvent` values without parsing CLI prose.
+//!
+//! Alice creates a work card via the existing `Airc::create_work_card`
+//! SDK call; Bob (separate scope sharing the wire) subscribes with a
+//! peer filter and asserts the `WorkEvent::CardCreated` arrives
+//! decoded. Then Bob runs `recent_work_events` and reads the same
+//! event back from the persisted transcript.
+
+use std::time::Duration;
+
+use airc_lib::{Airc, CreateWorkCard, PeerSpec, Priority, RepoId, WorkEvent, WorkEventFilter};
+use futures::stream::StreamExt;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn subscribe_work_events_yields_typed_card_created_event() {
+    let alice_home = TempDir::new().expect("alice home");
+    let bob_home = TempDir::new().expect("bob home");
+    let wire_dir = TempDir::new().expect("shared wire dir");
+    let wire_path = wire_dir.path().join("wire.jsonl");
+
+    let alice = Airc::open(alice_home.path()).await.expect("alice opens");
+    let bob = Airc::open(bob_home.path()).await.expect("bob opens");
+
+    let alice_spec: PeerSpec = alice.peer_spec().parse().expect("alice peer spec");
+    let bob_spec: PeerSpec = bob.peer_spec().parse().expect("bob peer spec");
+    alice.add_peer(bob_spec).await.expect("trust");
+    bob.add_peer(alice_spec.clone()).await.expect("trust");
+
+    alice
+        .join_with_wire("work-subscription-test", wire_path.clone())
+        .await
+        .expect("alice joins");
+    bob.join_with_wire("work-subscription-test", wire_path)
+        .await
+        .expect("bob joins");
+
+    // Bob subscribes BEFORE alice emits, with a peer filter set to
+    // alice — proves the filter actually applies (not just "first
+    // event wins").
+    let filter = WorkEventFilter::new().with_peer(alice_spec.peer_id);
+    let mut stream = Box::pin(bob.subscribe_work_events(filter).await.expect("subscribe"));
+
+    // Tiny settle so bob's subscriber attaches.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let card_id = alice
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new("test-org/test-repo").unwrap(),
+            title: "test card".to_string(),
+            body: Some("subscription proof".to_string()),
+            priority: Priority::P1,
+            lane_id: None,
+        })
+        .await
+        .expect("alice creates card");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let mut got = None;
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), stream.next()).await {
+            Ok(Some((_transcript_event, work_event))) => {
+                if let WorkEvent::CardCreated(payload) = &work_event {
+                    if payload.card_id == card_id {
+                        got = Some(work_event);
+                        break;
+                    }
+                }
+            }
+            Ok(None) => panic!("subscription closed before our event"),
+            Err(_) => continue,
+        }
+    }
+
+    let event = got.expect("CardCreated should arrive on the subscription");
+    match event {
+        WorkEvent::CardCreated(payload) => {
+            assert_eq!(payload.card_id, card_id);
+            assert_eq!(payload.created_by, alice_spec.peer_id);
+        }
+        other => panic!("expected CardCreated, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn recent_work_events_reads_back_from_transcript() {
+    let alice_home = TempDir::new().expect("alice home");
+    let wire_dir = TempDir::new().expect("shared wire dir");
+    let wire_path = wire_dir.path().join("wire.jsonl");
+
+    let alice = Airc::open(alice_home.path()).await.expect("alice opens");
+    alice
+        .join_with_wire("work-recent-test", wire_path)
+        .await
+        .expect("alice joins");
+
+    let card_id = alice
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new("test-org/test-repo").unwrap(),
+            title: "recent test card".to_string(),
+            body: None,
+            priority: Priority::P2,
+            lane_id: None,
+        })
+        .await
+        .expect("create card");
+
+    // Give the wire subscriber a moment to ingest.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let events = alice
+        .recent_work_events(WorkEventFilter::default(), 64)
+        .await
+        .expect("recent query");
+
+    let found = events.iter().any(|event| match event {
+        WorkEvent::CardCreated(payload) => payload.card_id == card_id,
+        _ => false,
+    });
+    assert!(
+        found,
+        "recent_work_events should include the CardCreated we just emitted; got {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn peer_filter_excludes_other_peers_events() {
+    let alice_home = TempDir::new().expect("alice home");
+    let bob_home = TempDir::new().expect("bob home");
+    let wire_dir = TempDir::new().expect("shared wire dir");
+    let wire_path = wire_dir.path().join("wire.jsonl");
+
+    let alice = Airc::open(alice_home.path()).await.expect("alice opens");
+    let bob = Airc::open(bob_home.path()).await.expect("bob opens");
+
+    let alice_spec: PeerSpec = alice.peer_spec().parse().expect("alice peer spec");
+    let bob_spec: PeerSpec = bob.peer_spec().parse().expect("bob peer spec");
+    alice.add_peer(bob_spec.clone()).await.expect("trust");
+    bob.add_peer(alice_spec).await.expect("trust");
+
+    alice
+        .join_with_wire("work-peer-filter-test", wire_path.clone())
+        .await
+        .expect("alice joins");
+    bob.join_with_wire("work-peer-filter-test", wire_path)
+        .await
+        .expect("bob joins");
+
+    // Alice creates a card. Filter scoped to Bob's peer id — should
+    // exclude Alice's event entirely.
+    alice
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new("test-org/test-repo").unwrap(),
+            title: "alice card".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+        })
+        .await
+        .expect("alice creates card");
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let bob_only = WorkEventFilter::new().with_peer(bob_spec.peer_id);
+    let events = alice
+        .recent_work_events(bob_only, 64)
+        .await
+        .expect("recent query");
+
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, WorkEvent::CardCreated(_))),
+        "filter scoped to bob should not surface alice's CardCreated; got {events:?}"
+    );
+}


### PR DESCRIPTION
## Summary
Closes work card **e1f8e2e0** (P0, "Work subscription API: typed kanban/PR event stream for agents"). Before this PR, consumers had to subscribe to the raw substrate stream, call `transcript_is_work_event`, decode the body, then pattern-match. After this PR, typed SDK helpers do it.

## API
- `Airc::subscribe_work_events(filter)` — live stream of `(Arc<TranscriptEvent>, WorkEvent)` pairs.
- `Airc::recent_work_events(filter, window)` — query recent transcript for matching events.
- `WorkEventFilter` — builder: `with_repo`, `with_lane_id`, `with_peer`. Default matches all.

Filter applies at the substrate header level (`forge.work.repo` / `forge.work.lane_id`) + the substrate signer peer id — cheap; bodies are only decoded when the event passes the filter.

## Test plan
- [x] 6 unit tests on `WorkEventFilter` (empty, peer-only, repo match/reject, builder chain, clone)
- [x] 3 integration tests over two Airc instances on shared wire: subscribe → typed CardCreated arrives; recent_work_events reads back; peer-scoped filter excludes other peers' events
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

## Consumer story
Continuum managers, agent schedulers, and dashboards can now consume work-state changes (CardCreated, CardClaimed, ClaimReleased, PullRequestCheckSuiteChanged, AgentAvailabilityChanged, etc.) via typed SDK helpers — no inbox-prose grepping, no manual filter+decode loops.

## Scope cuts (potential follow-ups)
- Per-variant filter (e.g. "only PR events"). Today the filter is header-based; richer kind-discrimination could be added on top.
- Subscription cursor for "from N events ago" resume — `subscribe_work_events` is live-only, `recent_work_events` is window-based. Cursor resume is a separate substrate primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)