### PR TITLE
feat(work): suggest claimable cards for agents

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -585,6 +585,23 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 reason,
             } => work_commands::run_release(&home, card_id, claim_id, reason).await,
             WorkAction::Board { limit } => work_commands::run_board(&home, limit).await,
+            WorkAction::Next {
+                repo,
+                max_priority,
+                include_stale,
+                limit,
+                event_limit,
+            } => {
+                work_commands::run_next(
+                    &home,
+                    repo,
+                    max_priority,
+                    include_stale,
+                    limit,
+                    event_limit,
+                )
+                .await
+            }
             WorkAction::Availability {
                 repo,
                 state,

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -62,6 +62,24 @@ pub enum WorkAction {
         #[arg(long, default_value_t = 128)]
         limit: usize,
     },
+    /// Suggest claimable work for this agent.
+    Next {
+        /// Optional repository filter, e.g. `CambrianTech/airc`.
+        #[arg(long)]
+        repo: Option<String>,
+        /// Highest priority to include.
+        #[arg(long, value_enum, default_value = "p1")]
+        max_priority: CliPriority,
+        /// Include expired claims as recoverable work.
+        #[arg(long)]
+        include_stale: bool,
+        /// Maximum suggestions to print.
+        #[arg(long, default_value_t = 8)]
+        limit: usize,
+        /// Recent transcript events to replay into the projection.
+        #[arg(long, default_value_t = 512)]
+        event_limit: usize,
+    },
     /// Publish this agent's availability for a repo.
     Availability {
         /// Repository key, e.g. `CambrianTech/airc`.

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -95,6 +95,46 @@ pub async fn run_board(home: &Path, limit: usize) -> Result<(), Box<dyn std::err
     Ok(())
 }
 
+pub async fn run_next(
+    home: &Path,
+    repo: Option<String>,
+    max_priority: CliPriority,
+    include_stale: bool,
+    limit: usize,
+    event_limit: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let query = airc_lib::ClaimableWorkQuery {
+        repo: repo.map(RepoId::new).transpose()?,
+        max_priority: max_priority.into(),
+        include_stale_claims: include_stale,
+        event_limit,
+        limit,
+    };
+    let items = airc.claimable_work(query).await?;
+    if items.is_empty() {
+        println!("(no claimable work)");
+        return Ok(());
+    }
+
+    println!("claimable work: {}", items.len());
+    for item in items {
+        let stale = item
+            .stale_claim
+            .as_ref()
+            .map(|claim| format!("stale_claim={} owner={}", claim.claim_id, claim.owner))
+            .unwrap_or_else(|| "open".to_string());
+        println!(
+            "{card_id}  {priority:?}  repo={repo}  {stale}  title={title}",
+            card_id = item.card.card_id,
+            priority = item.card.priority,
+            repo = item.card.repo,
+            title = item.card.title,
+        );
+    }
+    Ok(())
+}
+
 pub async fn run_availability(
     home: &Path,
     repo: String,

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -141,6 +141,48 @@ fn work_availability_projects_to_board() {
 }
 
 #[test]
+fn work_next_suggests_claimable_priority_cards() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let p0 = run_ok(
+        &home,
+        &[
+            "work",
+            "create",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "claimable p0",
+            "--priority",
+            "p0",
+        ],
+    );
+    let p0_id = extract_field(&p0, "card_id:").expect("p0 card id");
+    let p2 = run_ok(
+        &home,
+        &[
+            "work",
+            "create",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "lower p2",
+            "--priority",
+            "p2",
+        ],
+    );
+    let p2_id = extract_field(&p2, "card_id:").expect("p2 card id");
+
+    let next = run_ok(&home, &["work", "next", "--event-limit", "128"]);
+    assert!(next.contains("claimable work: 1"), "{next}");
+    assert!(next.contains(p0_id), "{next}");
+    assert!(next.contains("claimable p0"), "{next}");
+    assert!(!next.contains(p2_id), "{next}");
+}
+
+#[test]
 fn lane_create_status_and_state_drive_work_projection() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -116,10 +116,11 @@ pub use webrtc_media::{
     OutgoingSampleTrack, OutgoingVideoTrack, WebRtcConnectionBuilder, WebRtcMediaCodec,
 };
 pub use work::{
-    AllocateWorkspace, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard, CreateWorkCard,
-    CreateWorkLane, HeartbeatWorkClaim, HeartbeatWorkspace, ObserveLocalGitWorkspace,
-    ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests, ReleaseManagerHat,
-    ReleaseWorkClaim, ReleaseWorkspace, ReportAgentAvailability, RequestWorkspace,
+    AllocateWorkspace, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard, ClaimableWorkItem,
+    ClaimableWorkQuery, CreateWorkCard, CreateWorkLane, HeartbeatWorkClaim, HeartbeatWorkspace,
+    ObserveLocalGitWorkspace, ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests,
+    ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace, ReportAgentAvailability,
+    RequestWorkspace,
 };
 
 // Convenience re-exports so consumers don't need to pull airc-core

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -7,8 +7,8 @@ use airc_work::{
     AgentAvailabilityReported, AgentAvailabilityState, BranchName, CardCreated, ClaimHeartbeat,
     ClaimId, ClaimReleased, CommandGitRunner, LaneCreated, LaneId, LaneState, LaneStateChanged,
     LocalGitObserver, LocalGitSnapshot, LocalGitWorkspace, ManagerHatClaimed, ManagerHatReleased,
-    Priority, PullRequestObserver, PullRequestSource, RepoId, RepoPullRequestSnapshot,
-    WorkBoardProjection, WorkCardClaimed, WorkCardId, WorkEvent, WorkspaceAllocated,
+    Priority, PullRequestObserver, PullRequestSource, RepoId, RepoPullRequestSnapshot, StaleClaim,
+    WorkBoardProjection, WorkCard, WorkCardClaimed, WorkCardId, WorkEvent, WorkspaceAllocated,
     WorkspaceHeartbeat, WorkspaceId, WorkspaceReleased, WorkspaceRequested,
 };
 use airc_work_store::WorkEventStore;
@@ -101,6 +101,39 @@ pub struct ReportAgentAvailability {
     pub state: AgentAvailabilityState,
     pub note: Option<String>,
     pub ttl_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimableWorkQuery {
+    pub repo: Option<RepoId>,
+    pub max_priority: Priority,
+    pub include_stale_claims: bool,
+    pub event_limit: usize,
+    pub limit: usize,
+}
+
+impl Default for ClaimableWorkQuery {
+    fn default() -> Self {
+        Self {
+            repo: None,
+            max_priority: Priority::P1,
+            include_stale_claims: false,
+            event_limit: 512,
+            limit: 8,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimableWorkItem {
+    pub card: WorkCard,
+    pub stale_claim: Option<StaleClaim>,
+}
+
+impl ClaimableWorkItem {
+    pub fn is_stale_claim(&self) -> bool {
+        self.stale_claim.is_some()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -400,6 +433,51 @@ impl Airc {
         self.ensure_room_subscriber(&room).await?;
         let store = WorkEventStore::new(self.event_store());
         Ok(store.project_recent(Some(room.channel), limit).await?)
+    }
+
+    /// Return work cards this peer could reasonably take next. This
+    /// is the typed scheduling surface agents/monitors should use
+    /// instead of scraping `airc work board` output.
+    pub async fn claimable_work(
+        &self,
+        query: ClaimableWorkQuery,
+    ) -> Result<Vec<ClaimableWorkItem>, AircError> {
+        let board = self.work_board(query.event_limit).await?;
+        let stale_claims = board.stale_claims(now_ms()?);
+        let snapshot = board.snapshot();
+
+        let mut items = Vec::new();
+        for card in snapshot.cards {
+            if card.priority > query.max_priority {
+                continue;
+            }
+            if query.repo.as_ref().is_some_and(|repo| &card.repo != repo) {
+                continue;
+            }
+
+            let stale_claim = stale_claims
+                .iter()
+                .find(|claim| claim.card_id == card.card_id)
+                .cloned();
+            let open = card.state == airc_work::CardState::Open && card.claim_id.is_none();
+            let stale_claimable = query.include_stale_claims && stale_claim.is_some();
+            if !open && !stale_claimable {
+                continue;
+            }
+
+            items.push(ClaimableWorkItem { card, stale_claim });
+        }
+
+        items.sort_by(|left, right| {
+            left.card
+                .priority
+                .cmp(&right.card.priority)
+                .then_with(|| right.is_stale_claim().cmp(&left.is_stale_claim()))
+                .then_with(|| left.card.updated_at_ms.cmp(&right.card.updated_at_ms))
+                .then_with(|| left.card.card_id.cmp(&right.card.card_id))
+        });
+        items.truncate(query.limit);
+        Ok(items)
     }
 
     async fn publish_work_event(&self, event: &WorkEvent) -> Result<EventId, AircError> {

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use airc_lib::{
     Airc, AllocateWorkspace, BranchName, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard,
-    CreateWorkCard, CreateWorkLane, DirtyState, HeartbeatWorkspace, LaneState,
+    ClaimableWorkQuery, CreateWorkCard, CreateWorkLane, DirtyState, HeartbeatWorkspace, LaneState,
     ObserveLocalGitWorkspace, Priority, ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace,
     RepoId, RequestWorkspace, WorkCardId, WorkspaceStatus,
 };
@@ -141,6 +141,121 @@ async fn claim_and_release_work_card_round_trip_through_projection() {
         }
         tokio::time::sleep(Duration::from_millis(25)).await;
     }
+}
+
+#[tokio::test]
+async fn claimable_work_suggests_open_priority_cards_without_stdout_parsing() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("claimable-work-api").await.unwrap();
+    let repo = RepoId::new("CambrianTech/airc").unwrap();
+
+    let p0 = airc
+        .create_work_card(CreateWorkCard {
+            repo: repo.clone(),
+            title: "take this first".to_string(),
+            body: None,
+            priority: Priority::P0,
+            lane_id: None,
+        })
+        .await
+        .unwrap();
+    let p1 = airc
+        .create_work_card(CreateWorkCard {
+            repo: repo.clone(),
+            title: "take this second".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+        })
+        .await
+        .unwrap();
+    let p2 = airc
+        .create_work_card(CreateWorkCard {
+            repo,
+            title: "lower priority".to_string(),
+            body: None,
+            priority: Priority::P2,
+            lane_id: None,
+        })
+        .await
+        .unwrap();
+    let claimed = airc
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            title: "already claimed".to_string(),
+            body: None,
+            priority: Priority::P0,
+            lane_id: None,
+        })
+        .await
+        .unwrap();
+    airc.claim_work_card(ClaimWorkCard {
+        card_id: claimed,
+        ttl_ms: 60_000,
+    })
+    .await
+    .unwrap();
+
+    let claimable = airc
+        .claimable_work(ClaimableWorkQuery {
+            event_limit: 128,
+            ..ClaimableWorkQuery::default()
+        })
+        .await
+        .unwrap();
+    let ids: Vec<WorkCardId> = claimable.iter().map(|item| item.card.card_id).collect();
+    assert_eq!(ids, vec![p0, p1]);
+    assert!(!ids.contains(&p2));
+    assert!(!ids.contains(&claimed));
+}
+
+#[tokio::test]
+async fn claimable_work_can_surface_stale_claims_for_recovery() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("claimable-stale-api").await.unwrap();
+
+    let card_id = airc
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            title: "recover stale claim".to_string(),
+            body: None,
+            priority: Priority::P0,
+            lane_id: None,
+        })
+        .await
+        .unwrap();
+    let claim_id = airc
+        .claim_work_card(ClaimWorkCard { card_id, ttl_ms: 1 })
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let hidden = airc
+        .claimable_work(ClaimableWorkQuery {
+            include_stale_claims: false,
+            event_limit: 128,
+            ..ClaimableWorkQuery::default()
+        })
+        .await
+        .unwrap();
+    assert!(hidden.is_empty());
+
+    let visible = airc
+        .claimable_work(ClaimableWorkQuery {
+            include_stale_claims: true,
+            event_limit: 128,
+            ..ClaimableWorkQuery::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(visible.len(), 1);
+    assert_eq!(visible[0].card.card_id, card_id);
+    assert_eq!(
+        visible[0].stale_claim.as_ref().map(|claim| claim.claim_id),
+        Some(claim_id)
+    );
 }
 
 #[tokio::test]

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -706,6 +706,11 @@ context.
    watch work/PR/kanban events through AIRC instead of polling CLI
    prose. This should consume typed `airc-work` events from the
    transcript stream.
+   - First slice landed: `Airc::claimable_work(ClaimableWorkQuery)`
+     returns typed claimable-card suggestions for agents/monitors,
+     and `airc work next` is only a terminal wrapper around that SDK
+     call. Default policy surfaces open P0/P1 work; callers can opt
+     into stale-claim recovery.
 3. Add real-machine tailnet/relay proof that exercises the same route
    execution across host boundaries without GitHub routine traffic.
 4. Add a consumer-throughput proof for Continuum-shaped live traffic:


### PR DESCRIPTION
## Summary
- add `Airc::claimable_work(ClaimableWorkQuery)` as a typed SDK surface for agent work suggestions
- add `ClaimableWorkItem` with optional stale-claim recovery metadata
- add thin `airc work next` terminal wrapper so agents/humans can see claimable work without parsing `work board`
- document this as the first slice of the work subscription surface in `GRID-SUBSTRATE-AUDIT.md`

## Design note
This is not the final interrupt loop by itself. It creates the typed query that Monitor/hooks/feed loops can call when new work events arrive. CLI output remains human-facing only; integrations should call the SDK method or a later daemon IPC equivalent.

## Verification
- `cargo test --manifest-path Cargo.toml -p airc-lib claimable_work`
- `cargo test --manifest-path Cargo.toml -p airc-cli --test work_commands work_next_suggests_claimable_priority_cards`
- `cargo test --manifest-path Cargo.toml -p airc-lib --test work_api`
- `cargo test --manifest-path Cargo.toml -p airc-cli --test work_commands`
- `cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings`
- `git diff --check`