### PR TITLE
feat(work): surface claimable queue suggestions in agent feeds

### DIFF
--- a/crates/airc-cli/src/integrations/codex/hook.rs
+++ b/crates/airc-cli/src/integrations/codex/hook.rs
@@ -12,6 +12,7 @@ use futures::StreamExt;
 use serde::Serialize;
 
 use crate::client_id::current_client_id;
+use crate::work_suggestions::{is_work_queue_event, render_claimable_work};
 
 const CONSUMER_PREFIX: &str = "codex-hook";
 
@@ -35,18 +36,13 @@ pub async fn run_user_prompt_submit(
             .await?;
     }
 
+    let work_context = work_context(&airc, &events).await?;
     let visible: Vec<_> = events
         .into_iter()
         .filter(|event| include_self || !is_self_event(event, &airc, runtime_client.as_deref()))
         .collect();
-    if visible.is_empty() {
+    let Some(context) = render_context(&airc, &visible, max_items, raw, work_context).await? else {
         return Ok(());
-    }
-
-    let context = if raw {
-        render_raw(&visible)
-    } else {
-        render_digest(&visible, max_items)
     };
     print_hook_payload(&context)?;
     Ok(())
@@ -78,21 +74,51 @@ pub async fn run_poll(
             .await?;
     }
 
+    let work_context = work_context(&airc, &events).await?;
     let visible: Vec<_> = events
         .into_iter()
         .filter(|event| include_self || !is_self_event(event, &airc, runtime_client.as_deref()))
         .collect();
-    if visible.is_empty() {
+    let Some(context) = render_context(&airc, &visible, max_items, raw, work_context).await? else {
         return Ok(());
-    }
-
-    let context = if raw {
-        render_raw(&visible)
-    } else {
-        render_digest(&visible, max_items)
     };
     println!("{context}");
     Ok(())
+}
+
+async fn work_context(
+    airc: &Airc,
+    events: &[TranscriptEvent],
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    if events.iter().any(is_work_queue_event) {
+        render_claimable_work(airc).await
+    } else {
+        Ok(None)
+    }
+}
+
+async fn render_context(
+    _airc: &Airc,
+    events: &[TranscriptEvent],
+    max_items: usize,
+    raw: bool,
+    work_context: Option<String>,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let chat_context = if raw {
+        let text = render_raw(events);
+        (!text.is_empty()).then_some(text)
+    } else {
+        let text = render_digest(events, max_items);
+        (!text.is_empty()).then_some(text)
+    };
+    let mut sections = Vec::new();
+    if let Some(context) = chat_context {
+        sections.push(context);
+    }
+    if let Some(context) = work_context {
+        sections.push(context);
+    }
+    Ok((!sections.is_empty()).then(|| sections.join("\n\n")))
 }
 
 fn consumer_id(runtime_client: Option<&str>) -> String {
@@ -273,6 +299,9 @@ fn dedupe(events: &[TranscriptEvent]) -> Vec<DigestMessage> {
     let mut seen = BTreeSet::new();
     let mut messages = Vec::new();
     for event in events {
+        if is_work_queue_event(event) {
+            continue;
+        }
         let peer = event.peer_id.to_string();
         let body = summarize_body(event);
         if seen.insert((peer.clone(), body.clone())) {

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -63,6 +63,7 @@ mod transport_commands;
 mod update_commands;
 mod work_cli;
 mod work_commands;
+mod work_suggestions;
 mod workspace_cli;
 mod workspace_commands;
 mod worktree_lane_cli;

--- a/crates/airc-cli/src/monitor/attach.rs
+++ b/crates/airc-cli/src/monitor/attach.rs
@@ -9,6 +9,7 @@ use airc_protocol::HEADER_AIRC_CLIENT;
 
 use super::render::{normalize_channel, xml_escape, Sandbox};
 use crate::client_id::current_client_id;
+use crate::work_suggestions::render_claimable_work_for_event;
 
 pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error>> {
     let airc = Airc::open(home).await?;
@@ -35,7 +36,10 @@ pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error
         match response {
             Response::Ok => {}
             Response::Event { event } => {
-                if matches!(event.kind, TranscriptKind::Message | TranscriptKind::System) {
+                if let Some(text) = render_claimable_work_for_event(&airc, event.as_ref()).await? {
+                    sandbox.emit_contract_once();
+                    render_text_event(event.as_ref(), client_id.as_deref(), &text, &mut sandbox);
+                } else if matches!(event.kind, TranscriptKind::Message | TranscriptKind::System) {
                     render_event(event.as_ref(), client_id.as_deref(), &mut sandbox);
                 }
             }
@@ -55,6 +59,15 @@ fn render_event(event: &TranscriptEvent, client_id: Option<&str>, sandbox: &mut 
     };
 
     sandbox.emit_contract_once();
+    render_text_event(event, client_id, body, sandbox);
+}
+
+fn render_text_event(
+    event: &TranscriptEvent,
+    _client_id: Option<&str>,
+    body: &str,
+    sandbox: &mut Sandbox,
+) {
     let channel = normalize_channel(&event.room_id.to_string());
     let mut attrs = vec![
         format!("from=\"{}\"", xml_escape(&event.peer_id.to_string())),

--- a/crates/airc-cli/src/work_suggestions.rs
+++ b/crates/airc-cli/src/work_suggestions.rs
@@ -1,0 +1,148 @@
+use airc_core::TranscriptEvent;
+use airc_lib::{
+    Airc, ClaimableWorkItem, ClaimableWorkQuery, RepoId, HEADER_FORGE_WORK_EVENT_KIND,
+    HEADER_FORGE_WORK_REPO,
+};
+
+const DEFAULT_LIMIT: usize = 5;
+
+pub(crate) fn is_work_queue_event(event: &TranscriptEvent) -> bool {
+    matches!(
+        event
+            .headers
+            .get(HEADER_FORGE_WORK_EVENT_KIND)
+            .map(String::as_str),
+        Some("card_created" | "claim_released" | "card_state_changed")
+    )
+}
+
+pub(crate) async fn render_claimable_work(
+    airc: &Airc,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let items = airc
+        .claimable_work(ClaimableWorkQuery {
+            limit: DEFAULT_LIMIT,
+            ..ClaimableWorkQuery::default()
+        })
+        .await?;
+    Ok(render_items(&items))
+}
+
+pub(crate) async fn render_claimable_work_for_event(
+    airc: &Airc,
+    event: &TranscriptEvent,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    if !is_work_queue_event(event) {
+        return Ok(None);
+    }
+    let repo = event
+        .headers
+        .get(HEADER_FORGE_WORK_REPO)
+        .and_then(|value| RepoId::try_from(value.as_str()).ok());
+    let items = airc
+        .claimable_work(ClaimableWorkQuery {
+            repo,
+            limit: DEFAULT_LIMIT,
+            ..ClaimableWorkQuery::default()
+        })
+        .await?;
+    Ok(render_items(&items))
+}
+
+fn render_items(items: &[ClaimableWorkItem]) -> Option<String> {
+    if items.is_empty() {
+        return None;
+    }
+    let mut lines = vec![format!("AIRC work: {} claimable P0/P1", items.len())];
+    for item in items {
+        let card = &item.card;
+        let prefix = if item.is_stale_claim() {
+            "recover"
+        } else {
+            "claim"
+        };
+        lines.push(format!(
+            "- {priority:?} {card_id} {repo}: {title} ({prefix}: airc work claim {card_id})",
+            priority = card.priority,
+            card_id = card.card_id,
+            repo = card.repo,
+            title = card.title
+        ));
+    }
+    Some(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use airc_core::{
+        Body, ClientId, EventId, Headers, MentionTarget, PeerId, RoomId, TranscriptKind,
+    };
+    use airc_lib::{CardState, Priority, WorkCard, WorkCardId};
+
+    use super::*;
+
+    #[test]
+    fn detects_queue_events_only() {
+        let mut event = transcript();
+        event.headers.insert(
+            HEADER_FORGE_WORK_EVENT_KIND.to_string(),
+            "card_created".to_string(),
+        );
+        assert!(is_work_queue_event(&event));
+
+        event.headers.insert(
+            HEADER_FORGE_WORK_EVENT_KIND.to_string(),
+            "claim_heartbeat".to_string(),
+        );
+        assert!(!is_work_queue_event(&event));
+    }
+
+    #[test]
+    fn renders_claimable_items_with_claim_command_hint() {
+        let card_id = WorkCardId::new();
+        let repo = RepoId::try_from("CambrianTech/airc").unwrap();
+        let text = render_items(&[ClaimableWorkItem {
+            card: WorkCard {
+                card_id,
+                repo,
+                title: "wire work suggestions into feed".to_string(),
+                body: None,
+                priority: Priority::P0,
+                lane_id: None,
+                state: CardState::Open,
+                owner: None,
+                claim_id: None,
+                claim_expires_at_ms: None,
+                last_heartbeat_at_ms: None,
+                pull_request: None,
+                created_by: PeerId::new(),
+                created_at_ms: 1,
+                updated_at_ms: 1,
+            },
+            stale_claim: None,
+        }])
+        .unwrap();
+
+        assert!(text.contains("AIRC work: 1 claimable P0/P1"));
+        assert!(text.contains("airc work claim"));
+        assert!(text.contains("wire work suggestions into feed"));
+    }
+
+    fn transcript() -> TranscriptEvent {
+        TranscriptEvent {
+            event_id: EventId::new(),
+            room_id: RoomId::new(),
+            peer_id: PeerId::new(),
+            client_id: ClientId::new(),
+            kind: TranscriptKind::System,
+            occurred_at_ms: 1,
+            lamport: 1,
+            target: MentionTarget::All,
+            headers: Headers::new(),
+            body: Some(Body::Json(serde_json::json!({}))),
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+}

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -103,6 +103,34 @@ fn codex_hook_keeps_stamped_peer_events_when_runtime_client_is_unknown() {
 }
 
 #[test]
+fn codex_hook_suggests_claimable_work_on_work_events() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    run_ok(
+        &home,
+        &[
+            "work",
+            "create",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "wire claimable work into agent feed",
+            "--priority",
+            "p0",
+        ],
+    );
+
+    let output = run_hook(&home, &["codex-hook", "user-prompt-submit"], "{}");
+    let context = additional_context(&output);
+
+    assert!(context.contains("AIRC work: 1 claimable P0/P1"));
+    assert!(context.contains("wire claimable work into agent feed"));
+    assert!(context.contains("airc work claim"));
+}
+
+#[test]
 fn codex_hook_raw_mode_preserves_full_event_lines() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -134,6 +134,7 @@ pub use airc_core::{
 pub use airc_work::{
     AgentAvailabilityRecord, AgentAvailabilityState, BoardSnapshot, BranchName, CardState, ClaimId,
     DirtyState, GitObjectId, LaneId, LaneState, LocalGitSnapshot, ManagerHat, Priority,
-    ProjectionError, RepoId, WorkBoardProjection, WorkCardId, WorkEvent, WorkspaceId,
-    WorkspaceStatus,
+    ProjectionError, RepoId, WorkBoardProjection, WorkCard, WorkCardId, WorkEvent, WorkspaceId,
+    WorkspaceStatus, BODY_HINT_FORGE_WORK_EVENT, HEADER_FORGE_WORK_EVENT_KIND,
+    HEADER_FORGE_WORK_REPO,
 };

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -711,6 +711,12 @@ context.
      and `airc work next` is only a terminal wrapper around that SDK
      call. Default policy surfaces open P0/P1 work; callers can opt
      into stale-claim recovery.
+   - Second slice in flight: Codex hook and Monitor attach detect
+     queue-changing `forge.work.*` events and render claimable-work
+     suggestions from `Airc::claimable_work`, not by parsing
+     `airc work board` prose. Follow-up: make this a reusable
+     subscriber policy so future agent runtimes and Continuum consume
+     the same typed surface.
 3. Add real-machine tailnet/relay proof that exercises the same route
    execution across host boundaries without GitHub routine traffic.
 4. Add a consumer-throughput proof for Continuum-shaped live traffic:


### PR DESCRIPTION
## Summary
- add shared work-suggestion rendering for claimable P0/P1 cards from the typed SDK
- surface suggestions in Codex hook/poll when unread work events change the queue
- surface suggestions in Monitor attach when live work queue events arrive
- update GRID-SUBSTRATE-AUDIT immediate queue notes

## Verification
- cargo test --manifest-path Cargo.toml -p airc-cli --test codex_hook_commands
- cargo test --manifest-path Cargo.toml -p airc-cli monitor::attach
- cargo test --manifest-path Cargo.toml -p airc-cli work_suggestions
- cargo test --manifest-path Cargo.toml -p airc-lib --test work_api claimable_work
- cargo fmt --manifest-path Cargo.toml -p airc-lib -p airc-cli --check
- cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings
- git diff --check