### PR TITLE
feat(work): close completed cards

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -585,6 +585,10 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 claim_id,
                 reason,
             } => work_commands::run_release(&home, card_id, claim_id, reason).await,
+            WorkAction::State { card_id, state } => {
+                work_commands::run_state(&home, card_id, state).await
+            }
+            WorkAction::Close { card_id } => work_commands::run_close(&home, card_id).await,
             WorkAction::Board { limit } => work_commands::run_board(&home, limit).await,
             WorkAction::Next {
                 repo,

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -56,6 +56,19 @@ pub enum WorkAction {
         #[arg(long)]
         reason: Option<String>,
     },
+    /// Change a work card's lifecycle state.
+    State {
+        /// Work card UUID.
+        card_id: String,
+        /// New lifecycle state.
+        #[arg(value_enum)]
+        state: CliCardState,
+    },
+    /// Mark a work card closed so it no longer appears as claimable.
+    Close {
+        /// Work card UUID.
+        card_id: String,
+    },
     /// Print the current room's projected work board.
     Board {
         /// Recent transcript events to replay into the projection.
@@ -112,4 +125,16 @@ pub enum CliAvailabilityState {
     Ready,
     Busy,
     Away,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum CliCardState {
+    Open,
+    Claimed,
+    InProgress,
+    Blocked,
+    Review,
+    Merged,
+    Closed,
 }

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -12,11 +12,11 @@ use std::path::Path;
 use uuid::Uuid;
 
 use airc_lib::{
-    AgentAvailabilityState, Airc, ClaimId, ClaimWorkCard, CreateWorkCard, LaneId, Priority,
-    ReleaseWorkClaim, RepoId, WorkBoardProjection, WorkCardId,
+    AgentAvailabilityState, Airc, CardState, ChangeWorkCardState, ClaimId, ClaimWorkCard,
+    CreateWorkCard, LaneId, Priority, ReleaseWorkClaim, RepoId, WorkBoardProjection, WorkCardId,
 };
 
-use crate::work_cli::{CliAvailabilityState, CliPriority};
+use crate::work_cli::{CliAvailabilityState, CliCardState, CliPriority};
 
 pub async fn run_create(
     home: &Path,
@@ -86,6 +86,24 @@ pub async fn run_heartbeat(
     .await?;
     println!("claim_heartbeat: card_id={card_id} claim_id={claim_id} ttl_ms={ttl_ms}");
     Ok(())
+}
+
+pub async fn run_state(
+    home: &Path,
+    card_id: String,
+    state: CliCardState,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let card_id = parse_work_card_id(&card_id)?;
+    let state = CardState::from(state);
+    airc.change_work_card_state(ChangeWorkCardState { card_id, state })
+        .await?;
+    println!("card_state_changed: card_id={card_id} state={state:?}");
+    Ok(())
+}
+
+pub async fn run_close(home: &Path, card_id: String) -> Result<(), Box<dyn std::error::Error>> {
+    run_state(home, card_id, CliCardState::Closed).await
 }
 
 pub async fn run_board(home: &Path, limit: usize) -> Result<(), Box<dyn std::error::Error>> {
@@ -262,6 +280,20 @@ impl From<CliAvailabilityState> for AgentAvailabilityState {
             CliAvailabilityState::Ready => Self::Ready,
             CliAvailabilityState::Busy => Self::Busy,
             CliAvailabilityState::Away => Self::Away,
+        }
+    }
+}
+
+impl From<CliCardState> for CardState {
+    fn from(value: CliCardState) -> Self {
+        match value {
+            CliCardState::Open => Self::Open,
+            CliCardState::Claimed => Self::Claimed,
+            CliCardState::InProgress => Self::InProgress,
+            CliCardState::Blocked => Self::Blocked,
+            CliCardState::Review => Self::Review,
+            CliCardState::Merged => Self::Merged,
+            CliCardState::Closed => Self::Closed,
         }
     }
 }

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -183,6 +183,39 @@ fn work_next_suggests_claimable_priority_cards() {
 }
 
 #[test]
+fn work_close_removes_card_from_claimable_next() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let create = run_ok(
+        &home,
+        &[
+            "work",
+            "create",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "done work should not stay claimable",
+            "--priority",
+            "p0",
+        ],
+    );
+    let card_id = extract_field(&create, "card_id:").expect("card id");
+
+    let close = run_ok(&home, &["work", "close", card_id]);
+    assert!(close.contains("card_state_changed"), "{close}");
+    assert!(close.contains("Closed"), "{close}");
+
+    let board = run_ok(&home, &["work", "board"]);
+    assert!(board.contains(card_id), "{board}");
+    assert!(board.contains("Closed"), "{board}");
+
+    let next = run_ok(&home, &["work", "next", "--event-limit", "128"]);
+    assert!(!next.contains(card_id), "{next}");
+}
+
+#[test]
 fn lane_create_status_and_state_drive_work_projection() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -116,11 +116,11 @@ pub use webrtc_media::{
     OutgoingSampleTrack, OutgoingVideoTrack, WebRtcConnectionBuilder, WebRtcMediaCodec,
 };
 pub use work::{
-    AllocateWorkspace, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard, ClaimableWorkItem,
-    ClaimableWorkQuery, CreateWorkCard, CreateWorkLane, HeartbeatWorkClaim, HeartbeatWorkspace,
-    ObserveLocalGitWorkspace, ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests,
-    ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace, ReportAgentAvailability,
-    RequestWorkspace,
+    AllocateWorkspace, ChangeWorkCardState, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard,
+    ClaimableWorkItem, ClaimableWorkQuery, CreateWorkCard, CreateWorkLane, HeartbeatWorkClaim,
+    HeartbeatWorkspace, ObserveLocalGitWorkspace, ObservePullRequests, ObservedLocalGitWorkspace,
+    ObservedPullRequests, ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace,
+    ReportAgentAvailability, RequestWorkspace,
 };
 
 // Convenience re-exports so consumers don't need to pull airc-core

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -4,12 +4,13 @@ use airc_core::EventId;
 use airc_protocol::FrameKind;
 use airc_work::{
     encode_work_event, local_git_events_since, pull_request_events_since,
-    AgentAvailabilityReported, AgentAvailabilityState, BranchName, CardCreated, ClaimHeartbeat,
-    ClaimId, ClaimReleased, CommandGitRunner, LaneCreated, LaneId, LaneState, LaneStateChanged,
-    LocalGitObserver, LocalGitSnapshot, LocalGitWorkspace, ManagerHatClaimed, ManagerHatReleased,
-    Priority, PullRequestObserver, PullRequestSource, RepoId, RepoPullRequestSnapshot, StaleClaim,
-    WorkBoardProjection, WorkCard, WorkCardClaimed, WorkCardId, WorkEvent, WorkspaceAllocated,
-    WorkspaceHeartbeat, WorkspaceId, WorkspaceReleased, WorkspaceRequested,
+    AgentAvailabilityReported, AgentAvailabilityState, BranchName, CardCreated, CardState,
+    CardStateChanged, ClaimHeartbeat, ClaimId, ClaimReleased, CommandGitRunner, LaneCreated,
+    LaneId, LaneState, LaneStateChanged, LocalGitObserver, LocalGitSnapshot, LocalGitWorkspace,
+    ManagerHatClaimed, ManagerHatReleased, Priority, PullRequestObserver, PullRequestSource,
+    RepoId, RepoPullRequestSnapshot, StaleClaim, WorkBoardProjection, WorkCard, WorkCardClaimed,
+    WorkCardId, WorkEvent, WorkspaceAllocated, WorkspaceHeartbeat, WorkspaceId, WorkspaceReleased,
+    WorkspaceRequested,
 };
 use airc_work_store::WorkEventStore;
 
@@ -36,6 +37,12 @@ pub struct ReleaseWorkClaim {
     pub card_id: WorkCardId,
     pub claim_id: ClaimId,
     pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangeWorkCardState {
+    pub card_id: WorkCardId,
+    pub state: CardState,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -208,6 +215,23 @@ impl Airc {
             owner: self.peer_id(),
             reason: request.reason,
             released_at_ms: now_ms()?,
+        });
+        self.publish_work_event(&event).await?;
+        Ok(())
+    }
+
+    /// Change a work card's lifecycle state through the work event
+    /// stream. This is the queue hygiene path agents use to stop
+    /// completed work from remaining claimable.
+    pub async fn change_work_card_state(
+        &self,
+        request: ChangeWorkCardState,
+    ) -> Result<(), AircError> {
+        let event = WorkEvent::CardStateChanged(CardStateChanged {
+            card_id: request.card_id,
+            state: request.state,
+            changed_by: self.peer_id(),
+            changed_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(())


### PR DESCRIPTION
## Summary
- add typed Airc::change_work_card_state for card lifecycle transitions
- add airc work state and airc work close thin CLI wrappers
- cover that closed cards remain on the board but no longer appear in claimable next suggestions

## Verification
- cargo test --manifest-path Cargo.toml -p airc-cli --test work_commands work_close_removes_card_from_claimable_next
- cargo test --manifest-path Cargo.toml -p airc-cli --test work_commands
- cargo test --manifest-path Cargo.toml -p airc-lib --test work_api
- cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings
- git diff --check