### PR TITLE
feat(airc-lib): AIRC-event diagnostic sink + doctor surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ version = "0.1.0"
 dependencies = [
  "airc-core",
  "airc-daemon",
+ "airc-diagnostics",
  "airc-identity",
  "airc-ipc",
  "airc-lib",

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 airc-core = { path = "../airc-core" }
+airc-diagnostics = { path = "../airc-diagnostics" }
 airc-identity = { path = "../airc-identity" }
 airc-ipc = { path = "../airc-ipc" }
 airc-protocol = { path = "../airc-protocol" }

--- a/crates/airc-cli/src/doctor.rs
+++ b/crates/airc-cli/src/doctor.rs
@@ -367,7 +367,7 @@ async fn check_recent_diagnostics(home: &Path) -> Vec<Finding> {
         match diag.severity {
             DiagnosticSeverity::Error => errors += 1,
             DiagnosticSeverity::Warn => warns += 1,
-            _ => {}
+            DiagnosticSeverity::Info | DiagnosticSeverity::Debug => {}
         }
     }
 

--- a/crates/airc-cli/src/doctor.rs
+++ b/crates/airc-cli/src/doctor.rs
@@ -107,6 +107,7 @@ pub async fn run(home: &Path, fix: bool, health: bool) -> Result<(), Box<dyn std
     findings.extend(check_identity(home).await);
     findings.extend(check_daemon(home).await);
     findings.extend(check_binary_freshness());
+    findings.extend(check_recent_diagnostics(home).await);
 
     if health {
         findings.extend(check_health(home).await);
@@ -322,6 +323,76 @@ fn source_tree_head() -> Option<String> {
         None
     } else {
         Some(value)
+    }
+}
+
+/// Recent diagnostic visibility check. Pulls the last N transcript
+/// events, decodes typed `DiagnosticEvent`s emitted via the AIRC
+/// event sink, and surfaces error/warn counts so operators see
+/// substrate trouble without inspecting the wire by hand.
+async fn check_recent_diagnostics(home: &Path) -> Vec<Finding> {
+    use airc_diagnostics::DiagnosticSeverity;
+    use airc_lib::Airc;
+
+    let airc = match Airc::open(home).await {
+        Ok(airc) => airc,
+        Err(_) => {
+            return vec![Finding::info(
+                "diagnostics",
+                "airc handle unavailable; skipping recent-diagnostic scan",
+            )];
+        }
+    };
+
+    let recent = match airc.recent_diagnostic_events(256).await {
+        Ok(recent) => recent,
+        Err(_) => {
+            return vec![Finding::info(
+                "diagnostics",
+                "couldn't read recent diagnostics from transcript",
+            )];
+        }
+    };
+
+    if recent.is_empty() {
+        return vec![Finding::ok(
+            "diagnostics",
+            "no recent diagnostic events on the wire",
+        )];
+    }
+
+    let mut errors = 0usize;
+    let mut warns = 0usize;
+    for diag in &recent {
+        match diag.severity {
+            DiagnosticSeverity::Error => errors += 1,
+            DiagnosticSeverity::Warn => warns += 1,
+            _ => {}
+        }
+    }
+
+    if errors > 0 {
+        vec![Finding::warn(
+            "diagnostics",
+            format!(
+                "{errors} error / {warns} warn diagnostic(s) in last {} events",
+                recent.len()
+            ),
+            "review with `airc events list --header-prefix airc.diag.severity=`",
+        )]
+    } else if warns > 0 {
+        vec![Finding::info(
+            "diagnostics",
+            format!(
+                "{warns} warn diagnostic(s) in last {} events; no errors",
+                recent.len()
+            ),
+        )]
+    } else {
+        vec![Finding::ok(
+            "diagnostics",
+            format!("{} diagnostic event(s); none at warn/error", recent.len()),
+        )]
     }
 }
 

--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -355,7 +355,6 @@ mod tests {
         // Proves the daemon's send + buffered-subscribe paths
         // compose correctly.
         use airc_ipc::request::{InboxRequest, SendRequest, SubscribeRequest};
-        use tempfile::TempDir;
 
         let state = fresh_state();
         let socket = unique_socket();
@@ -364,11 +363,11 @@ mod tests {
         let server_handle = tokio::spawn(async move { run(server_state, server_socket).await });
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let dir = TempDir::new().unwrap();
-        let wire = dir.path().to_path_buf();
+        let wire = state.home.join("wires").join("daemon-round-trip");
         let channel = uuid::Uuid::nil();
 
         let client = DaemonClient::new(socket);
+        client.ping().await.unwrap();
         // Subscribe first so the daemon starts the drain task.
         client
             .subscribe(SubscribeRequest { wire: wire.clone() })

--- a/crates/airc-lib/src/diagnostic_event_sink.rs
+++ b/crates/airc-lib/src/diagnostic_event_sink.rs
@@ -1,0 +1,237 @@
+//! AIRC-event publication sink for `DiagnosticEvent`s.
+//!
+//! Closes work card 524c7727 (P1, "Diagnostic sink follow-up:
+//! ORM/event sink and doctor surface"). #973 shipped the
+//! `DiagnosticSink` trait + `MemoryDiagnosticSink` /
+//! `StderrJsonDiagnosticSink`. This PR adds the AIRC-event variant:
+//! a sink that publishes each diagnostic as an AIRC Event frame so
+//! integrations on any subscribed peer can decode and act on
+//! diagnostics without parsing stdout/stderr.
+//!
+//! Pairs with a typed subscribe + query API on `Airc` so dashboards,
+//! monitor, and `airc doctor` can read recent diagnostics from the
+//! transcript without screen-scraping any text surface.
+//!
+//! Scope per card: ORM-backed projection is the "or" branch;
+//! AIRC-event publication is the "and" branch this PR takes. The
+//! ORM projection is a perf/durability optimization that can land as
+//! a follow-up once a callsite needs it.
+
+use std::sync::Arc;
+
+use airc_core::headers::Headers;
+use airc_core::transcript::MentionTarget;
+use airc_core::{Body, TranscriptEvent};
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSeverity, DiagnosticSink,
+};
+use airc_protocol::FrameKind;
+use futures::stream::{Stream, StreamExt};
+use tokio::runtime::Handle;
+
+use crate::error::AircError;
+use crate::Airc;
+
+/// Header keys for filtering diagnostics on the wire without
+/// decoding the body. Stable string values (snake_case enum variant
+/// names) so dashboards can match against them directly.
+pub const HEADER_DIAG_SEVERITY: &str = "airc.diag.severity";
+pub const HEADER_DIAG_COMPONENT: &str = "airc.diag.component";
+pub const HEADER_DIAG_CODE: &str = "airc.diag.code";
+
+/// `DiagnosticSink` impl that publishes each event as an AIRC
+/// `FrameKind::Event` frame, tagged with severity/component/code
+/// headers and a JSON-encoded `DiagnosticEvent` body.
+///
+/// The `emit()` callback fires synchronously from any thread; the
+/// publish itself is async, so the sink spawns a tokio task per
+/// event. Best-effort: if no tokio runtime is in scope (callsite
+/// running on a foreign thread), the event is dropped. Diagnostics
+/// must never panic or block the emitter.
+#[derive(Clone)]
+pub struct AircEventDiagnosticSink {
+    airc: Airc,
+}
+
+impl AircEventDiagnosticSink {
+    pub fn new(airc: Airc) -> Self {
+        Self { airc }
+    }
+}
+
+impl DiagnosticSink for AircEventDiagnosticSink {
+    fn emit(&self, event: DiagnosticEvent) {
+        let airc = self.airc.clone();
+        // Sinks can be called from any thread / context. If a tokio
+        // runtime is available, spawn the publish task. If not, the
+        // event drops silently — diagnostics must never block or
+        // panic the caller.
+        if let Ok(handle) = Handle::try_current() {
+            handle.spawn(async move {
+                if let Err(error) = airc.publish_diagnostic_event(&event).await {
+                    // Fall back to stderr only here — this is the
+                    // one allowed eprintln: the publish path itself
+                    // failed, and the sink can't recursively emit
+                    // through itself.
+                    eprintln!("airc diagnostic publish failed: {error}");
+                }
+            });
+        }
+    }
+}
+
+impl Airc {
+    /// Publish a single `DiagnosticEvent` as an AIRC Event frame
+    /// with stable severity/component/code headers. Normally called
+    /// from `AircEventDiagnosticSink::emit`; consumers can also call
+    /// this directly when they have a pre-built event.
+    pub async fn publish_diagnostic_event(&self, event: &DiagnosticEvent) -> Result<(), AircError> {
+        let body = serde_json::to_value(event)
+            .map_err(|error| AircError::Crypto(format!("diagnostic event encode: {error}")))?;
+        let mut headers = Headers::new();
+        headers.insert(
+            HEADER_DIAG_SEVERITY.into(),
+            severity_header_value(event.severity).to_string(),
+        );
+        headers.insert(
+            HEADER_DIAG_COMPONENT.into(),
+            component_header_value(event.component).to_string(),
+        );
+        headers.insert(
+            HEADER_DIAG_CODE.into(),
+            code_header_value(event.code).to_string(),
+        );
+        self.send_frame_to(
+            FrameKind::Event,
+            MentionTarget::All,
+            Body::Json(body),
+            headers,
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Live stream of typed `DiagnosticEvent`s observed on the
+    /// substrate. Filters the raw transcript subscription to events
+    /// carrying the `airc.diag.severity` header and decodes their
+    /// body.
+    pub async fn subscribe_diagnostic_events(
+        &self,
+    ) -> Result<impl Stream<Item = (Arc<TranscriptEvent>, DiagnosticEvent)>, AircError> {
+        let inner = self.subscribe().await?;
+        Ok(inner.filter_map(|item| async move {
+            let event = item.ok()?;
+            let diag = parse_diagnostic_event(&event)?;
+            Some((event, diag))
+        }))
+    }
+
+    /// Query recent diagnostics from the persisted transcript.
+    /// Walks the last `window` events and returns matching
+    /// `DiagnosticEvent`s in transcript order (oldest → newest).
+    /// Useful for `airc doctor` surfacing recent errors without
+    /// holding a live subscription.
+    pub async fn recent_diagnostic_events(
+        &self,
+        window: usize,
+    ) -> Result<Vec<DiagnosticEvent>, AircError> {
+        let recent = self.page_recent(window).await?;
+        let mut out = Vec::with_capacity(recent.len().min(window));
+        for transcript_event in recent {
+            if let Some(diag) = parse_diagnostic_event(&transcript_event) {
+                out.push(diag);
+            }
+        }
+        Ok(out)
+    }
+}
+
+fn parse_diagnostic_event(event: &TranscriptEvent) -> Option<DiagnosticEvent> {
+    let _ = event.headers.get(HEADER_DIAG_SEVERITY)?;
+    let body = event.body.as_ref()?;
+    let value = match body {
+        Body::Json(value) => value.clone(),
+        _ => return None,
+    };
+    serde_json::from_value(value).ok()
+}
+
+fn severity_header_value(severity: DiagnosticSeverity) -> &'static str {
+    match severity {
+        DiagnosticSeverity::Debug => "debug",
+        DiagnosticSeverity::Info => "info",
+        DiagnosticSeverity::Warn => "warn",
+        DiagnosticSeverity::Error => "error",
+    }
+}
+
+fn component_header_value(component: DiagnosticComponent) -> &'static str {
+    match component {
+        DiagnosticComponent::Daemon => "daemon",
+        DiagnosticComponent::Monitor => "monitor",
+        DiagnosticComponent::Replay => "replay",
+        DiagnosticComponent::Subscriber => "subscriber",
+        DiagnosticComponent::Transport => "transport",
+        DiagnosticComponent::WebRtc => "webrtc",
+    }
+}
+
+fn code_header_value(code: DiagnosticCode) -> &'static str {
+    match code {
+        DiagnosticCode::ConnectionError => "connection_error",
+        DiagnosticCode::FrameVerificationFailed => "frame_verification_failed",
+        DiagnosticCode::StoreAppendFailed => "store_append_failed",
+        DiagnosticCode::TrustRefreshFailed => "trust_refresh_failed",
+        DiagnosticCode::WireLostEmitFailed => "wire_lost_emit_failed",
+        DiagnosticCode::MalformedReplayFrameSkipped => "malformed_replay_frame_skipped",
+        DiagnosticCode::UnverifiableReplayFrameSkipped => "unverifiable_replay_frame_skipped",
+        DiagnosticCode::ReplayFramesSkipped => "replay_frames_skipped",
+        DiagnosticCode::WebRtcOfferAnswerFailed => "webrtc_offer_answer_failed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn severity_headers_stable() {
+        assert_eq!(severity_header_value(DiagnosticSeverity::Debug), "debug");
+        assert_eq!(severity_header_value(DiagnosticSeverity::Info), "info");
+        assert_eq!(severity_header_value(DiagnosticSeverity::Warn), "warn");
+        assert_eq!(severity_header_value(DiagnosticSeverity::Error), "error");
+    }
+
+    #[test]
+    fn component_headers_stable() {
+        for component in [
+            DiagnosticComponent::Daemon,
+            DiagnosticComponent::Monitor,
+            DiagnosticComponent::Replay,
+            DiagnosticComponent::Subscriber,
+            DiagnosticComponent::Transport,
+            DiagnosticComponent::WebRtc,
+        ] {
+            let header = component_header_value(component);
+            assert!(!header.is_empty(), "{component:?} should map to non-empty");
+        }
+    }
+
+    #[test]
+    fn code_headers_stable() {
+        for code in [
+            DiagnosticCode::ConnectionError,
+            DiagnosticCode::FrameVerificationFailed,
+            DiagnosticCode::StoreAppendFailed,
+            DiagnosticCode::TrustRefreshFailed,
+            DiagnosticCode::WireLostEmitFailed,
+            DiagnosticCode::MalformedReplayFrameSkipped,
+            DiagnosticCode::UnverifiableReplayFrameSkipped,
+            DiagnosticCode::ReplayFramesSkipped,
+            DiagnosticCode::WebRtcOfferAnswerFailed,
+        ] {
+            let header = code_header_value(code);
+            assert!(!header.is_empty(), "{code:?} should map to non-empty");
+        }
+    }
+}

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -41,6 +41,7 @@ mod broadcast_deduper;
 pub mod command_bus;
 pub mod coordinator;
 mod daemon;
+pub mod diagnostic_event_sink;
 pub mod error;
 pub mod gh_account_registry;
 pub mod join_context;
@@ -86,6 +87,9 @@ pub use coordinator::{
     CoordinatorError, CoordinatorSnapshot, PresenceBeacon, RefreshLockOutcome,
     DEFAULT_HEARTBEAT_TTL_MS as COORDINATOR_HEARTBEAT_TTL_MS,
     DEFAULT_REFRESH_INTERVAL_MS as COORDINATOR_REFRESH_INTERVAL_MS,
+};
+pub use diagnostic_event_sink::{
+    AircEventDiagnosticSink, HEADER_DIAG_CODE, HEADER_DIAG_COMPONENT, HEADER_DIAG_SEVERITY,
 };
 pub use error::AircError;
 pub use gh_account_registry::{gh_auth_ready, GhAccountRegistryStore};

--- a/crates/airc-lib/tests/diagnostic_event_sink.rs
+++ b/crates/airc-lib/tests/diagnostic_event_sink.rs
@@ -1,0 +1,121 @@
+//! Integration: AIRC-event diagnostic sink round-trip.
+//!
+//! Proves work card 524c7727: a substrate emitter publishes a
+//! `DiagnosticEvent` via the AIRC-event sink; a separate Airc
+//! instance subscribed over a shared wire receives it as a typed
+//! `DiagnosticEvent`. No stdout parsing.
+
+use std::time::Duration;
+
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSeverity, DiagnosticSink,
+};
+use airc_lib::{Airc, AircEventDiagnosticSink, PeerSpec};
+use futures::stream::StreamExt;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn diagnostic_event_sink_publishes_to_airc_subscribers() {
+    let alice_home = TempDir::new().expect("alice home");
+    let bob_home = TempDir::new().expect("bob home");
+    let wire_dir = TempDir::new().expect("shared wire");
+    let wire_path = wire_dir.path().join("wire.jsonl");
+
+    let alice = Airc::open(alice_home.path()).await.expect("alice opens");
+    let bob = Airc::open(bob_home.path()).await.expect("bob opens");
+
+    let alice_spec: PeerSpec = alice.peer_spec().parse().expect("alice peer spec");
+    let bob_spec: PeerSpec = bob.peer_spec().parse().expect("bob peer spec");
+    alice.add_peer(bob_spec).await.expect("trust");
+    bob.add_peer(alice_spec).await.expect("trust");
+
+    alice
+        .join_with_wire("diag-sink-test", wire_path.clone())
+        .await
+        .expect("alice joins");
+    bob.join_with_wire("diag-sink-test", wire_path)
+        .await
+        .expect("bob joins");
+
+    // Bob subscribes to typed diagnostic events BEFORE alice emits.
+    let mut stream = Box::pin(
+        bob.subscribe_diagnostic_events()
+            .await
+            .expect("subscribe diagnostics"),
+    );
+
+    // Tiny settle so bob's subscriber attaches.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Alice constructs the AIRC-event sink and emits a real
+    // diagnostic through it. This is the substrate's intended use:
+    // any code that holds a `DiagnosticSink` can emit and observers
+    // receive typed events.
+    let sink = AircEventDiagnosticSink::new(alice.clone());
+    let diag = DiagnosticEvent::warn(
+        DiagnosticComponent::Transport,
+        DiagnosticCode::FrameVerificationFailed,
+        "integration-test diagnostic",
+    )
+    .with_field("scope", "diag-sink-test");
+    sink.emit(diag);
+
+    // Pull until our diagnostic arrives.
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let mut got = None;
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), stream.next()).await {
+            Ok(Some((_transcript_event, diag))) => {
+                if diag.message == "integration-test diagnostic" {
+                    got = Some(diag);
+                    break;
+                }
+            }
+            Ok(None) => panic!("subscription closed before our event"),
+            Err(_) => continue,
+        }
+    }
+
+    let diag = got.expect("diagnostic should arrive at subscriber");
+    assert_eq!(diag.severity, DiagnosticSeverity::Warn);
+    assert_eq!(diag.component, DiagnosticComponent::Transport);
+    assert_eq!(diag.code, DiagnosticCode::FrameVerificationFailed);
+    assert_eq!(diag.message, "integration-test diagnostic");
+    assert_eq!(
+        diag.fields.get("scope").map(String::as_str),
+        Some("diag-sink-test")
+    );
+}
+
+#[tokio::test]
+async fn recent_diagnostic_events_reads_back_from_transcript() {
+    let home = TempDir::new().expect("tempdir");
+    let wire_dir = TempDir::new().expect("wire");
+    let wire_path = wire_dir.path().join("wire.jsonl");
+
+    let airc = Airc::open(home.path()).await.expect("open");
+    airc.join_with_wire("recent-diag-test", wire_path)
+        .await
+        .expect("join");
+
+    let sink = AircEventDiagnosticSink::new(airc.clone());
+    let diag = DiagnosticEvent::error(
+        DiagnosticComponent::WebRtc,
+        DiagnosticCode::WebRtcOfferAnswerFailed,
+        "test recent error",
+    );
+    sink.emit(diag);
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let recent = airc
+        .recent_diagnostic_events(64)
+        .await
+        .expect("recent query");
+    assert!(
+        recent
+            .iter()
+            .any(|d| d.message == "test recent error" && d.severity == DiagnosticSeverity::Error),
+        "recent_diagnostic_events should include our emitted error; got {recent:?}"
+    );
+}


### PR DESCRIPTION
## Summary
Closes work card **524c7727** (P1, "Diagnostic sink follow-up: ORM/event sink and doctor surface"). #973 shipped the `DiagnosticSink` trait + `MemoryDiagnosticSink` / `StderrJsonDiagnosticSink`. This PR adds the AIRC-event variant + a doctor check that reads recent diagnostics from the transcript.

## API
- `AircEventDiagnosticSink::new(airc)` — `DiagnosticSink` impl that publishes each event as an AIRC frame. Non-blocking, non-panicking — best-effort spawn via tokio runtime if available, otherwise drops silently.
- `Airc::publish_diagnostic_event(event)` — direct publish surface.
- `Airc::subscribe_diagnostic_events()` — live typed stream.
- `Airc::recent_diagnostic_events(window)` — query helper used by doctor.

## Headers (filter without body decode)
- `airc.diag.severity` = `"debug" | "info" | "warn" | "error"`
- `airc.diag.component` = `"daemon" | "monitor" | "replay" | "subscriber" | "transport" | "webrtc"`
- `airc.diag.code` = stable per-variant snake_case string

## Doctor surface
New `check_recent_diagnostics` adds these findings:
- `[ok]` no recent diagnostic events
- `[ok]` N events; none at warn/error
- `[info]` N warn(s); no errors
- `[WARN]` N error / M warn — `Fix: review with airc events list --header-prefix airc.diag.severity=`

## Test plan
- [x] 3 unit tests on header value stability
- [x] 2 integration tests over two Airc instances on shared wire — publish via sink + subscribe receives typed event; recent_query reads back from transcript
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

## Scope cut (follow-up)
ORM-backed projection is the "or" branch in the card text — deferred until a callsite needs the perf/durability optimization. AIRC-event publication is the "and" branch this PR takes; doctor reads via `page_recent` which is the same query path.

## Stack
Builds on #973 (`DiagnosticSink` trait + typed enums).

🤖 Generated with [Claude Code](https://claude.com/claude-code)