### PR TITLE
fix(work): tolerate bounded board replay windows

### DIFF
--- a/crates/airc-work-store/src/lib.rs
+++ b/crates/airc-work-store/src/lib.rs
@@ -68,7 +68,7 @@ where
         limit: usize,
     ) -> Result<WorkBoardProjection, WorkStoreError> {
         let page = self.page_recent(channel, limit).await?;
-        Ok(WorkBoardProjection::replay(page.events)?)
+        Ok(WorkBoardProjection::replay_window(page.events)?)
     }
 
     pub async fn project_from(

--- a/crates/airc-work-store/src/tests.rs
+++ b/crates/airc-work-store/src/tests.rs
@@ -124,6 +124,36 @@ async fn project_recent_rebuilds_board_from_persisted_events() {
 }
 
 #[tokio::test]
+async fn project_recent_skips_events_whose_anchor_is_outside_window() {
+    let store = InMemoryEventStore::new();
+    let room = RoomId::from_u128(10);
+    let old_card = WorkCardId::from_u128(20);
+    let visible_card = WorkCardId::from_u128(21);
+
+    store
+        .append(work_transcript(1, room, 1, &card_created(old_card)))
+        .await
+        .unwrap();
+    store
+        .append(work_transcript(2, room, 2, &card_state_changed(old_card)))
+        .await
+        .unwrap();
+    store
+        .append(work_transcript(3, room, 3, &card_created(visible_card)))
+        .await
+        .unwrap();
+
+    let projection = WorkEventStore::new(&store)
+        .project_recent(Some(room), 2)
+        .await
+        .unwrap();
+
+    assert!(projection.card(old_card).is_none());
+    let card = projection.card(visible_card).unwrap();
+    assert_eq!(card.state, CardState::Open);
+}
+
+#[tokio::test]
 async fn resume_from_uses_store_cursor_contract() {
     let store = InMemoryEventStore::new();
     let room = RoomId::from_u128(10);

--- a/crates/airc-work/src/projection.rs
+++ b/crates/airc-work/src/projection.rs
@@ -241,5 +241,14 @@ pub enum ProjectionError {
     },
 }
 
+impl ProjectionError {
+    pub fn is_missing_window_anchor(&self) -> bool {
+        matches!(
+            self,
+            Self::UnknownCard(_) | Self::UnknownLane(_) | Self::UnknownWorkspace(_)
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/airc-work/src/projection/apply.rs
+++ b/crates/airc-work/src/projection/apply.rs
@@ -72,6 +72,23 @@ impl WorkBoardProjection {
         Ok(projection)
     }
 
+    /// Replay a bounded transcript window. Events whose anchor entity
+    /// was created before the window are skipped; structural errors
+    /// inside the window still fail.
+    pub fn replay_window(
+        events: impl IntoIterator<Item = WorkEvent>,
+    ) -> Result<Self, ProjectionError> {
+        let mut projection = Self::new();
+        for event in events {
+            match projection.apply(&event) {
+                Ok(()) => {}
+                Err(error) if error.is_missing_window_anchor() => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(projection)
+    }
+
     pub fn snapshot(&self) -> BoardSnapshot {
         BoardSnapshot {
             cards: self.cards.values().cloned().collect(),


### PR DESCRIPTION
## Summary
- add explicit bounded-window replay semantics for recent work-board projections
- keep full `WorkBoardProjection::replay` strict while `project_recent` skips events whose anchor was created outside the requested window
- add a regression test and prove the current queue works with `work board --limit 64`

## Verification
- cargo test --manifest-path Cargo.toml -p airc-work
- cargo test --manifest-path Cargo.toml -p airc-work-store
- cargo test --manifest-path Cargo.toml -p airc-cli --test work_commands work_board_empty_state_is_explicit
- cargo build --manifest-path Cargo.toml -p airc-cli
- target/debug/airc work board --limit 64
- cargo clippy --manifest-path Cargo.toml -p airc-work -p airc-work-store -p airc-lib -p airc-cli --all-targets -- -D warnings
- git diff --check

Refs docs/architecture/GRID-SUBSTRATE-AUDIT.md work queue reliability: bounded board views must not fail when the requested replay window omits old anchor events.