### PR TITLE
fix(work): preserve terminal state on claim release

### DIFF
--- a/crates/airc-work/src/projection/apply.rs
+++ b/crates/airc-work/src/projection/apply.rs
@@ -179,7 +179,12 @@ impl WorkBoardProjection {
     fn apply_claim_released(&mut self, e: &ClaimReleased) -> Result<(), ProjectionError> {
         let card = self.card_mut(e.card_id)?;
         ensure_claim(card, e.claim_id)?;
-        card.state = CardState::Open;
+        card.state = match card.state {
+            CardState::Claimed | CardState::InProgress | CardState::Blocked => CardState::Open,
+            CardState::Open | CardState::Review | CardState::Merged | CardState::Closed => {
+                card.state
+            }
+        };
         card.owner = None;
         card.claim_id = None;
         card.claim_expires_at_ms = None;

--- a/crates/airc-work/src/projection/tests.rs
+++ b/crates/airc-work/src/projection/tests.rs
@@ -63,6 +63,52 @@ fn card_claim_heartbeat_and_stale_detection_project_from_events() {
 }
 
 #[test]
+fn releasing_claim_clears_owner_without_reopening_closed_card() {
+    let card_id = WorkCardId::from_u128(10);
+    let claim_id = ClaimId::from_u128(11);
+    let owner = peer(12);
+
+    let projection = WorkBoardProjection::replay(vec![
+        WorkEvent::CardCreated(CardCreated {
+            card_id,
+            repo: repo(),
+            title: "close before release".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+            created_by: owner,
+            created_at_ms: 100,
+        }),
+        WorkEvent::CardClaimed(WorkCardClaimed {
+            card_id,
+            claim_id,
+            owner,
+            ttl_ms: 100,
+            claimed_at_ms: 110,
+        }),
+        WorkEvent::CardStateChanged(CardStateChanged {
+            card_id,
+            state: CardState::Closed,
+            changed_by: owner,
+            changed_at_ms: 120,
+        }),
+        WorkEvent::ClaimReleased(ClaimReleased {
+            card_id,
+            claim_id,
+            owner,
+            reason: Some("merged".to_string()),
+            released_at_ms: 130,
+        }),
+    ])
+    .unwrap();
+
+    let card = projection.card(card_id).unwrap();
+    assert_eq!(card.state, CardState::Closed);
+    assert_eq!(card.owner, None);
+    assert_eq!(card.claim_id, None);
+}
+
+#[test]
 fn availability_projection_keeps_latest_peer_state_per_repo() {
     let repo = repo();
     let other_repo = RepoId::new("CambrianTech/continuum").unwrap();


### PR DESCRIPTION
## Summary
- keep `ClaimReleased` from reopening cards that were already moved to `Closed`, `Merged`, or `Review`
- still clear owner/claim metadata on release
- add regression coverage for close-before-release so completed cards stay out of `work next`

## Verification
- cargo test --manifest-path Cargo.toml -p airc-work releasing_claim_clears_owner_without_reopening_closed_card
- cargo clippy --manifest-path Cargo.toml -p airc-work --all-targets -- -D warnings
- cargo build --manifest-path Cargo.toml -p airc-cli
- target/debug/airc work next --event-limit 2048 --limit 10
- git diff --check

Refs docs/architecture/GRID-SUBSTRATE-AUDIT.md: durable work queue projection must self-prune completed cards and not reintroduce idle work after claim cleanup.