### PR TITLE
feat(work): surface agent availability in queue status

### DIFF
--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use airc_lib::{
     AgentAvailabilityState, Airc, CardState, ChangeWorkCardState, ClaimId, ClaimWorkCard,
     CreateWorkCard, LaneId, Priority, ReleaseWorkClaim, RepoId, WorkBoardProjection, WorkCardId,
+    WorkQueueStatus,
 };
 
 use crate::work_cli::{CliAvailabilityState, CliCardState, CliPriority};
@@ -122,33 +123,50 @@ pub async fn run_next(
     event_limit: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let airc = Airc::open(home).await?;
-    let query = airc_lib::ClaimableWorkQuery {
+    let query = airc_lib::WorkQueueStatusQuery {
         repo: repo.map(RepoId::new).transpose()?,
         max_priority: max_priority.into(),
         include_stale_claims: include_stale,
         event_limit,
         limit,
     };
-    let items = airc.claimable_work(query).await?;
-    if items.is_empty() {
+    let status = airc.work_queue_status(query).await?;
+    if status.claimable.is_empty() {
         println!("(no claimable work)");
-        return Ok(());
+    } else {
+        println!("claimable work: {}", status.claimable.len());
+        for item in &status.claimable {
+            let stale = item
+                .stale_claim
+                .as_ref()
+                .map(|claim| format!("stale_claim={} owner={}", claim.claim_id, claim.owner))
+                .unwrap_or_else(|| "open".to_string());
+            println!(
+                "{card_id}  {priority:?}  repo={repo}  {stale}  title={title}",
+                card_id = item.card.card_id,
+                priority = item.card.priority,
+                repo = item.card.repo,
+                title = item.card.title,
+            );
+        }
     }
 
-    println!("claimable work: {}", items.len());
-    for item in items {
-        let stale = item
-            .stale_claim
-            .as_ref()
-            .map(|claim| format!("stale_claim={} owner={}", claim.claim_id, claim.owner))
-            .unwrap_or_else(|| "open".to_string());
+    print_work_queue_availability(&status);
+    if !status.active_claims_for_peer.is_empty() {
+        println!();
         println!(
-            "{card_id}  {priority:?}  repo={repo}  {stale}  title={title}",
-            card_id = item.card.card_id,
-            priority = item.card.priority,
-            repo = item.card.repo,
-            title = item.card.title,
+            "your active claims: {}",
+            status.active_claims_for_peer.len()
         );
+        for card in &status.active_claims_for_peer {
+            println!(
+                "{card_id}  {priority:?}  repo={repo}  title={title}",
+                card_id = card.card_id,
+                priority = card.priority,
+                repo = card.repo,
+                title = card.title,
+            );
+        }
     }
     Ok(())
 }
@@ -229,6 +247,32 @@ fn print_board(board: &WorkBoardProjection) {
                 expires_at_ms = availability.expires_at_ms,
             );
         }
+    }
+}
+
+fn print_work_queue_availability(status: &WorkQueueStatus) {
+    if status.agent_availability.is_empty() {
+        return;
+    }
+
+    let now_ms = now_ms();
+    println!();
+    println!(
+        "agent availability: ready={} busy={} away={} stale={}",
+        status.ready_count(now_ms),
+        status.busy_count(now_ms),
+        status.away_count(now_ms),
+        status.stale_availability_count(now_ms)
+    );
+    for availability in &status.agent_availability {
+        let stale = availability.expires_at_ms <= now_ms;
+        let note = availability.report.note.as_deref().unwrap_or("-");
+        println!(
+            "{repo}  peer={peer}  state={state:?}  stale={stale}  note={note}",
+            repo = availability.report.repo,
+            peer = availability.report.peer,
+            state = availability.report.state,
+        );
     }
 }
 

--- a/crates/airc-cli/src/work_suggestions.rs
+++ b/crates/airc-cli/src/work_suggestions.rs
@@ -1,6 +1,6 @@
 use airc_core::TranscriptEvent;
 use airc_lib::{
-    Airc, ClaimableWorkItem, ClaimableWorkQuery, RepoId, HEADER_FORGE_WORK_EVENT_KIND,
+    Airc, RepoId, WorkQueueStatus, WorkQueueStatusQuery, HEADER_FORGE_WORK_EVENT_KIND,
     HEADER_FORGE_WORK_REPO,
 };
 
@@ -12,20 +12,26 @@ pub(crate) fn is_work_queue_event(event: &TranscriptEvent) -> bool {
             .headers
             .get(HEADER_FORGE_WORK_EVENT_KIND)
             .map(String::as_str),
-        Some("card_created" | "claim_released" | "card_state_changed")
+        Some(
+            "card_created"
+                | "card_claimed"
+                | "claim_released"
+                | "card_state_changed"
+                | "agent_availability_reported",
+        )
     )
 }
 
 pub(crate) async fn render_claimable_work(
     airc: &Airc,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
-    let items = airc
-        .claimable_work(ClaimableWorkQuery {
+    let status = airc
+        .work_queue_status(WorkQueueStatusQuery {
             limit: DEFAULT_LIMIT,
-            ..ClaimableWorkQuery::default()
+            ..WorkQueueStatusQuery::default()
         })
         .await?;
-    Ok(render_items(&items))
+    Ok(render_status(&status))
 }
 
 pub(crate) async fn render_claimable_work_for_event(
@@ -39,22 +45,30 @@ pub(crate) async fn render_claimable_work_for_event(
         .headers
         .get(HEADER_FORGE_WORK_REPO)
         .and_then(|value| RepoId::try_from(value.as_str()).ok());
-    let items = airc
-        .claimable_work(ClaimableWorkQuery {
+    let status = airc
+        .work_queue_status(WorkQueueStatusQuery {
             repo,
             limit: DEFAULT_LIMIT,
-            ..ClaimableWorkQuery::default()
+            ..WorkQueueStatusQuery::default()
         })
         .await?;
-    Ok(render_items(&items))
+    Ok(render_status(&status))
 }
 
-fn render_items(items: &[ClaimableWorkItem]) -> Option<String> {
-    if items.is_empty() {
+fn render_status(status: &WorkQueueStatus) -> Option<String> {
+    if status.claimable.is_empty() && status.agent_availability.is_empty() {
         return None;
     }
-    let mut lines = vec![format!("AIRC work: {} claimable P0/P1", items.len())];
-    for item in items {
+    let now_ms = now_ms();
+    let mut lines = vec![format!(
+        "AIRC work: {} claimable P0/P1; availability ready={} busy={} away={} stale={}",
+        status.claimable.len(),
+        status.ready_count(now_ms),
+        status.busy_count(now_ms),
+        status.away_count(now_ms),
+        status.stale_availability_count(now_ms)
+    )];
+    for item in &status.claimable {
         let card = &item.card;
         let prefix = if item.is_stale_claim() {
             "recover"
@@ -69,7 +83,23 @@ fn render_items(items: &[ClaimableWorkItem]) -> Option<String> {
             title = card.title
         ));
     }
+    if status.claimable.is_empty() {
+        lines.push(
+            "no claimable cards; publish ready/busy/away with airc work availability".to_string(),
+        );
+    } else if status.active_claims_for_peer.is_empty() {
+        lines.push(
+            "if idle: claim one, or publish busy/away via airc work availability".to_string(),
+        );
+    }
     Some(lines.join("\n"))
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -77,7 +107,10 @@ mod tests {
     use airc_core::{
         Body, ClientId, EventId, Headers, MentionTarget, PeerId, RoomId, TranscriptKind,
     };
-    use airc_lib::{CardState, Priority, WorkCard, WorkCardId};
+    use airc_lib::{
+        AgentAvailabilityRecord, AgentAvailabilityReported, AgentAvailabilityState, CardState,
+        ClaimableWorkItem, Priority, WorkCard, WorkCardId,
+    };
 
     use super::*;
 
@@ -95,37 +128,76 @@ mod tests {
             "claim_heartbeat".to_string(),
         );
         assert!(!is_work_queue_event(&event));
+
+        event.headers.insert(
+            HEADER_FORGE_WORK_EVENT_KIND.to_string(),
+            "agent_availability_reported".to_string(),
+        );
+        assert!(is_work_queue_event(&event));
     }
 
     #[test]
     fn renders_claimable_items_with_claim_command_hint() {
         let card_id = WorkCardId::new();
         let repo = RepoId::try_from("CambrianTech/airc").unwrap();
-        let text = render_items(&[ClaimableWorkItem {
-            card: WorkCard {
-                card_id,
-                repo,
-                title: "wire work suggestions into feed".to_string(),
-                body: None,
-                priority: Priority::P0,
-                lane_id: None,
-                state: CardState::Open,
-                owner: None,
-                claim_id: None,
-                claim_expires_at_ms: None,
-                last_heartbeat_at_ms: None,
-                pull_request: None,
-                created_by: PeerId::new(),
-                created_at_ms: 1,
-                updated_at_ms: 1,
-            },
-            stale_claim: None,
-        }])
+        let text = render_status(&WorkQueueStatus {
+            claimable: vec![ClaimableWorkItem {
+                card: work_card(card_id, repo),
+                stale_claim: None,
+            }],
+            agent_availability: Vec::new(),
+            active_claims_for_peer: Vec::new(),
+        })
         .unwrap();
 
         assert!(text.contains("AIRC work: 1 claimable P0/P1"));
         assert!(text.contains("airc work claim"));
         assert!(text.contains("wire work suggestions into feed"));
+        assert!(text.contains("publish busy/away"));
+    }
+
+    #[test]
+    fn renders_availability_without_claimable_work() {
+        let repo = RepoId::try_from("CambrianTech/airc").unwrap();
+        let text = render_status(&WorkQueueStatus {
+            claimable: Vec::new(),
+            agent_availability: vec![AgentAvailabilityRecord {
+                report: AgentAvailabilityReported {
+                    repo,
+                    peer: PeerId::new(),
+                    state: AgentAvailabilityState::Ready,
+                    note: Some("available for review".to_string()),
+                    ttl_ms: 60_000,
+                    reported_at_ms: now_ms(),
+                },
+                expires_at_ms: now_ms() + 60_000,
+            }],
+            active_claims_for_peer: Vec::new(),
+        })
+        .unwrap();
+
+        assert!(text.contains("availability ready=1 busy=0 away=0 stale=0"));
+        assert!(text.contains("publish ready/busy/away"));
+    }
+
+    fn work_card(card_id: WorkCardId, repo: RepoId) -> WorkCard {
+        WorkCard {
+            card_id,
+            repo,
+            title: "wire work suggestions into feed".to_string(),
+            body: None,
+            priority: Priority::P0,
+            lane_id: None,
+            state: CardState::Open,
+            owner: None,
+            claim_id: None,
+            claim_expires_at_ms: None,
+            last_heartbeat_at_ms: None,
+            pull_request: None,
+            created_by: PeerId::new(),
+            created_at_ms: 1,
+            updated_at_ms: 1,
+        }
     }
 
     fn transcript() -> TranscriptEvent {

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -131,6 +131,36 @@ fn codex_hook_suggests_claimable_work_on_work_events() {
 }
 
 #[test]
+fn codex_hook_suggests_availability_on_availability_events() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    run_ok(
+        &home,
+        &[
+            "work",
+            "availability",
+            "--repo",
+            "CambrianTech/airc",
+            "--state",
+            "ready",
+            "--note",
+            "available for queue work",
+            "--ttl-ms",
+            "60000",
+        ],
+    );
+
+    let output = run_hook(&home, &["codex-hook", "user-prompt-submit"], "{}");
+    let context = additional_context(&output);
+
+    assert!(context.contains("AIRC work: 0 claimable P0/P1"));
+    assert!(context.contains("availability ready=1 busy=0 away=0 stale=0"));
+    assert!(context.contains("publish ready/busy/away"));
+}
+
+#[test]
 fn codex_hook_raw_mode_preserves_full_event_lines() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -141,6 +141,37 @@ fn work_availability_projects_to_board() {
 }
 
 #[test]
+fn work_next_surfaces_availability_and_idle_guidance() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    run_ok(
+        &home,
+        &[
+            "work",
+            "availability",
+            "--repo",
+            "CambrianTech/airc",
+            "--state",
+            "ready",
+            "--note",
+            "available for P0",
+            "--ttl-ms",
+            "60000",
+        ],
+    );
+
+    let next = run_ok(&home, &["work", "next", "--event-limit", "128"]);
+    assert!(next.contains("(no claimable work)"), "{next}");
+    assert!(
+        next.contains("agent availability: ready=1 busy=0 away=0 stale=0"),
+        "{next}"
+    );
+    assert!(next.contains("available for P0"), "{next}");
+}
+
+#[test]
 fn work_next_suggests_claimable_priority_cards() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -125,7 +125,7 @@ pub use work::{
     ClaimableWorkItem, ClaimableWorkQuery, CreateWorkCard, CreateWorkLane, HeartbeatWorkClaim,
     HeartbeatWorkspace, ObserveLocalGitWorkspace, ObservePullRequests, ObservedLocalGitWorkspace,
     ObservedPullRequests, ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace,
-    ReportAgentAvailability, RequestWorkspace,
+    ReportAgentAvailability, RequestWorkspace, WorkQueueStatus, WorkQueueStatusQuery,
 };
 pub use work_subscription::{
     WorkEventFilter, HEADER_WORK_CARD_ID, HEADER_WORK_LANE_ID, HEADER_WORK_REPO,
@@ -140,9 +140,9 @@ pub use airc_core::{
     ClientId, EventId, PeerId, RoomId, TranscriptCursor, TranscriptEvent, TranscriptKind,
 };
 pub use airc_work::{
-    AgentAvailabilityRecord, AgentAvailabilityState, BoardSnapshot, BranchName, CardState, ClaimId,
-    DirtyState, GitObjectId, LaneId, LaneState, LocalGitSnapshot, ManagerHat, Priority,
-    ProjectionError, RepoId, WorkBoardProjection, WorkCard, WorkCardId, WorkEvent, WorkspaceId,
-    WorkspaceStatus, BODY_HINT_FORGE_WORK_EVENT, HEADER_FORGE_WORK_EVENT_KIND,
-    HEADER_FORGE_WORK_REPO,
+    AgentAvailabilityRecord, AgentAvailabilityReported, AgentAvailabilityState, BoardSnapshot,
+    BranchName, CardState, ClaimId, DirtyState, GitObjectId, LaneId, LaneState, LocalGitSnapshot,
+    ManagerHat, Priority, ProjectionError, RepoId, WorkBoardProjection, WorkCard, WorkCardId,
+    WorkEvent, WorkspaceId, WorkspaceStatus, BODY_HINT_FORGE_WORK_EVENT,
+    HEADER_FORGE_WORK_EVENT_KIND, HEADER_FORGE_WORK_REPO,
 };

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -3,7 +3,7 @@
 use airc_core::EventId;
 use airc_protocol::FrameKind;
 use airc_work::{
-    encode_work_event, local_git_events_since, pull_request_events_since,
+    encode_work_event, local_git_events_since, pull_request_events_since, AgentAvailabilityRecord,
     AgentAvailabilityReported, AgentAvailabilityState, BranchName, CardCreated, CardState,
     CardStateChanged, ClaimHeartbeat, ClaimId, ClaimReleased, CommandGitRunner, LaneCreated,
     LaneId, LaneState, LaneStateChanged, LocalGitObserver, LocalGitSnapshot, LocalGitWorkspace,
@@ -140,6 +140,83 @@ pub struct ClaimableWorkItem {
 impl ClaimableWorkItem {
     pub fn is_stale_claim(&self) -> bool {
         self.stale_claim.is_some()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkQueueStatusQuery {
+    pub repo: Option<RepoId>,
+    pub max_priority: Priority,
+    pub include_stale_claims: bool,
+    pub event_limit: usize,
+    pub limit: usize,
+}
+
+impl Default for WorkQueueStatusQuery {
+    fn default() -> Self {
+        Self {
+            repo: None,
+            max_priority: Priority::P1,
+            include_stale_claims: false,
+            event_limit: 512,
+            limit: 8,
+        }
+    }
+}
+
+impl From<ClaimableWorkQuery> for WorkQueueStatusQuery {
+    fn from(value: ClaimableWorkQuery) -> Self {
+        Self {
+            repo: value.repo,
+            max_priority: value.max_priority,
+            include_stale_claims: value.include_stale_claims,
+            event_limit: value.event_limit,
+            limit: value.limit,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkQueueStatus {
+    pub claimable: Vec<ClaimableWorkItem>,
+    pub agent_availability: Vec<AgentAvailabilityRecord>,
+    pub active_claims_for_peer: Vec<WorkCard>,
+}
+
+impl WorkQueueStatus {
+    pub fn ready_count(&self, now_ms: u64) -> usize {
+        self.agent_availability
+            .iter()
+            .filter(|record| {
+                record.expires_at_ms > now_ms
+                    && record.report.state == AgentAvailabilityState::Ready
+            })
+            .count()
+    }
+
+    pub fn busy_count(&self, now_ms: u64) -> usize {
+        self.agent_availability
+            .iter()
+            .filter(|record| {
+                record.expires_at_ms > now_ms && record.report.state == AgentAvailabilityState::Busy
+            })
+            .count()
+    }
+
+    pub fn away_count(&self, now_ms: u64) -> usize {
+        self.agent_availability
+            .iter()
+            .filter(|record| {
+                record.expires_at_ms > now_ms && record.report.state == AgentAvailabilityState::Away
+            })
+            .count()
+    }
+
+    pub fn stale_availability_count(&self, now_ms: u64) -> usize {
+        self.agent_availability
+            .iter()
+            .filter(|record| record.expires_at_ms <= now_ms)
+            .count()
     }
 }
 
@@ -466,17 +543,39 @@ impl Airc {
         &self,
         query: ClaimableWorkQuery,
     ) -> Result<Vec<ClaimableWorkItem>, AircError> {
+        Ok(self.work_queue_status(query.into()).await?.claimable)
+    }
+
+    /// Return the scheduling view agents need to avoid idle lock:
+    /// claimable cards, current peer claims, and typed ready/busy/away
+    /// availability records. Consumers should use this instead of
+    /// parsing CLI output.
+    pub async fn work_queue_status(
+        &self,
+        query: WorkQueueStatusQuery,
+    ) -> Result<WorkQueueStatus, AircError> {
         let board = self.work_board(query.event_limit).await?;
-        let stale_claims = board.stale_claims(now_ms()?);
+        let now_ms = now_ms()?;
+        let stale_claims = board.stale_claims(now_ms);
         let snapshot = board.snapshot();
+        let peer_id = self.peer_id();
 
         let mut items = Vec::new();
+        let mut active_claims_for_peer = Vec::new();
         for card in snapshot.cards {
             if card.priority > query.max_priority {
                 continue;
             }
             if query.repo.as_ref().is_some_and(|repo| &card.repo != repo) {
                 continue;
+            }
+
+            if card.owner == Some(peer_id)
+                && card
+                    .claim_expires_at_ms
+                    .is_some_and(|expires_at_ms| expires_at_ms > now_ms)
+            {
+                active_claims_for_peer.push(card.clone());
             }
 
             let stale_claim = stale_claims
@@ -501,11 +600,58 @@ impl Airc {
                 .then_with(|| left.card.card_id.cmp(&right.card.card_id))
         });
         items.truncate(query.limit);
-        Ok(items)
+
+        let mut agent_availability: Vec<_> = snapshot
+            .agent_availability
+            .into_iter()
+            .filter(|record| {
+                query
+                    .repo
+                    .as_ref()
+                    .is_none_or(|repo| &record.report.repo == repo)
+            })
+            .collect();
+        agent_availability.sort_by(|left, right| {
+            left.report
+                .repo
+                .cmp(&right.report.repo)
+                .then_with(|| {
+                    availability_state_rank(left.report.state)
+                        .cmp(&availability_state_rank(right.report.state))
+                })
+                .then_with(|| left.expires_at_ms.cmp(&right.expires_at_ms))
+                .then_with(|| {
+                    left.report
+                        .peer
+                        .to_string()
+                        .cmp(&right.report.peer.to_string())
+                })
+        });
+
+        active_claims_for_peer.sort_by(|left, right| {
+            left.priority
+                .cmp(&right.priority)
+                .then_with(|| left.updated_at_ms.cmp(&right.updated_at_ms))
+                .then_with(|| left.card_id.cmp(&right.card_id))
+        });
+
+        Ok(WorkQueueStatus {
+            claimable: items,
+            agent_availability,
+            active_claims_for_peer,
+        })
     }
 
     async fn publish_work_event(&self, event: &WorkEvent) -> Result<EventId, AircError> {
         let (headers, body) = encode_work_event(event)?;
         self.send_frame(FrameKind::Event, body, headers).await
+    }
+}
+
+fn availability_state_rank(state: AgentAvailabilityState) -> u8 {
+    match state {
+        AgentAvailabilityState::Ready => 0,
+        AgentAvailabilityState::Busy => 1,
+        AgentAvailabilityState::Away => 2,
     }
 }


### PR DESCRIPTION
## Summary
- add typed `WorkQueueStatus` to airc-lib with claimable cards, active self-claims, and ready/busy/away availability records
- route `airc work next` and Codex work suggestions through the typed queue-status surface
- trigger work suggestions on availability and claim events so idle agents see the queue state and can claim work or publish busy/away

Closes typed work card c96b8abf-10d5-421b-9f02-9e21c76c3016.

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib -p airc-cli
- cargo test --manifest-path Cargo.toml -p airc-cli work_next_surfaces_availability_and_idle_guidance -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli codex_hook_suggests_availability_on_availability_events -- --nocapture
- cargo test --manifest-path Cargo.toml -p airc-cli work_suggestions -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-lib -p airc-cli
- git diff --check