### PR TITLE
test(lib): prove Continuum pose fan-out throughput

### DIFF
--- a/crates/airc-lib/tests/consumer_throughput.rs
+++ b/crates/airc-lib/tests/consumer_throughput.rs
@@ -38,7 +38,7 @@ impl PoseEvent {
 }
 
 #[tokio::test]
-async fn continuum_shaped_pose_stream_delivers_at_60hz_without_drop() {
+async fn continuum_shaped_pose_stream_delivers_without_drop() {
     let result = run_pose_stream_fixture(StreamProfile {
         event_count: SINGLE_SUBSCRIBER_EVENT_COUNT,
         event_hz: SINGLE_SUBSCRIBER_EVENT_HZ,
@@ -58,10 +58,7 @@ async fn continuum_shaped_pose_stream_delivers_at_60hz_without_drop() {
         p50 = result.p50,
         p99 = result.p99,
     );
-}
 
-#[tokio::test]
-async fn continuum_shaped_pose_stream_fans_out_to_three_subscribers_at_90hz() {
     let result = run_pose_stream_fixture(StreamProfile {
         event_count: FANOUT_EVENT_COUNT,
         event_hz: FANOUT_EVENT_HZ,

--- a/crates/airc-lib/tests/consumer_throughput.rs
+++ b/crates/airc-lib/tests/consumer_throughput.rs
@@ -13,10 +13,14 @@ use airc_lib::{Airc, Body, Headers, PeerSpec};
 use futures::StreamExt;
 use tempfile::TempDir;
 
-const EVENT_COUNT: usize = 90;
-const EVENT_HZ: u64 = 60;
+const SINGLE_SUBSCRIBER_EVENT_COUNT: usize = 90;
+const SINGLE_SUBSCRIBER_EVENT_HZ: u64 = 60;
+const FANOUT_EVENT_COUNT: usize = 135;
+const FANOUT_EVENT_HZ: u64 = 90;
+const FANOUT_SUBSCRIBERS: usize = 3;
 const RECEIVE_DRAIN_TIMEOUT: Duration = Duration::from_secs(8);
 const CI_P99_MAX: Duration = Duration::from_millis(500);
+const CI_FANOUT_P99_MAX: Duration = Duration::from_millis(750);
 
 #[derive(Debug)]
 struct PoseEvent {
@@ -35,50 +39,108 @@ impl PoseEvent {
 
 #[tokio::test]
 async fn continuum_shaped_pose_stream_delivers_at_60hz_without_drop() {
+    let result = run_pose_stream_fixture(StreamProfile {
+        event_count: SINGLE_SUBSCRIBER_EVENT_COUNT,
+        event_hz: SINGLE_SUBSCRIBER_EVENT_HZ,
+        subscriber_count: 1,
+    })
+    .await;
+
+    assert_eq!(
+        result.received_per_subscriber,
+        vec![SINGLE_SUBSCRIBER_EVENT_COUNT],
+        "pose fixture stream dropped events: received {:?}",
+        result.received_per_subscriber
+    );
+    assert!(
+        result.p99 <= CI_P99_MAX,
+        "CI-safe p99 exceeded: p50={p50:?} p99={p99:?} max={CI_P99_MAX:?}",
+        p50 = result.p50,
+        p99 = result.p99,
+    );
+}
+
+#[tokio::test]
+async fn continuum_shaped_pose_stream_fans_out_to_three_subscribers_at_90hz() {
+    let result = run_pose_stream_fixture(StreamProfile {
+        event_count: FANOUT_EVENT_COUNT,
+        event_hz: FANOUT_EVENT_HZ,
+        subscriber_count: FANOUT_SUBSCRIBERS,
+    })
+    .await;
+
+    assert_eq!(
+        result.received_per_subscriber,
+        vec![FANOUT_EVENT_COUNT; FANOUT_SUBSCRIBERS],
+        "pose fan-out dropped events: received {:?}",
+        result.received_per_subscriber
+    );
+    assert!(
+        result.p99 <= CI_FANOUT_P99_MAX,
+        "CI-safe fan-out p99 exceeded: p50={p50:?} p99={p99:?} max={CI_FANOUT_P99_MAX:?}",
+        p50 = result.p50,
+        p99 = result.p99,
+    );
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StreamProfile {
+    event_count: usize,
+    event_hz: u64,
+    subscriber_count: usize,
+}
+
+#[derive(Debug)]
+struct StreamResult {
+    received_per_subscriber: Vec<usize>,
+    p50: Duration,
+    p99: Duration,
+}
+
+async fn run_pose_stream_fixture(profile: StreamProfile) -> StreamResult {
     let alice_home = TempDir::new().unwrap();
-    let bob_home = TempDir::new().unwrap();
+    let subscriber_homes: Vec<_> = (0..profile.subscriber_count)
+        .map(|_| TempDir::new().unwrap())
+        .collect();
     let wire_dir = TempDir::new().unwrap();
     let wire_path = wire_dir.path().join("wire.jsonl");
 
     let alice = Airc::open(alice_home.path()).await.unwrap();
-    let bob = Airc::open(bob_home.path()).await.unwrap();
+    let mut subscribers = Vec::with_capacity(profile.subscriber_count);
+    for home in &subscriber_homes {
+        subscribers.push(Airc::open(home.path()).await.unwrap());
+    }
 
     let alice_spec: PeerSpec = alice.peer_spec().parse().unwrap();
-    let bob_spec: PeerSpec = bob.peer_spec().parse().unwrap();
-    alice.add_peer(bob_spec).await.unwrap();
-    bob.add_peer(alice_spec).await.unwrap();
+    for subscriber in &subscribers {
+        let subscriber_spec: PeerSpec = subscriber.peer_spec().parse().unwrap();
+        alice.add_peer(subscriber_spec).await.unwrap();
+        subscriber.add_peer(alice_spec.clone()).await.unwrap();
+    }
 
     alice
         .join_with_wire("continuum-pose-fixture", wire_path.clone())
         .await
         .unwrap();
-    bob.join_with_wire("continuum-pose-fixture", wire_path)
-        .await
-        .unwrap();
+    for subscriber in &subscribers {
+        subscriber
+            .join_with_wire("continuum-pose-fixture", wire_path.clone())
+            .await
+            .unwrap();
+    }
 
-    let mut stream = bob.subscribe().await.unwrap();
-    let receiver = tokio::spawn(async move {
-        let mut received = Vec::with_capacity(EVENT_COUNT);
-        while received.len() < EVENT_COUNT {
-            let Some(next) = stream.next().await else {
-                break;
-            };
-            let event = next.expect("live stream event must decode");
-            let Some(text) = event.body.as_ref().and_then(Body::as_text) else {
-                continue;
-            };
-            let Some(seq) = text.strip_prefix("continuum.pose.fixture seq=") else {
-                continue;
-            };
-            let seq: usize = seq.parse().expect("fixture seq must be numeric");
-            received.push((seq, Instant::now()));
-        }
-        received
-    });
+    let mut receivers = Vec::with_capacity(profile.subscriber_count);
+    for subscriber in &subscribers {
+        let stream = subscriber.subscribe().await.unwrap();
+        receivers.push(tokio::spawn(receive_pose_stream(
+            stream,
+            profile.event_count,
+        )));
+    }
 
-    let interval = Duration::from_nanos(1_000_000_000 / EVENT_HZ);
-    let mut sent = Vec::with_capacity(EVENT_COUNT);
-    for seq in 0..EVENT_COUNT {
+    let interval = Duration::from_nanos(1_000_000_000 / profile.event_hz);
+    let mut sent = Vec::with_capacity(profile.event_count);
+    for seq in 0..profile.event_count {
         let pose = PoseEvent {
             seq,
             sent_at: Instant::now(),
@@ -97,35 +159,53 @@ async fn continuum_shaped_pose_stream_delivers_at_60hz_without_drop() {
         tokio::time::sleep(interval).await;
     }
 
-    let received = tokio::time::timeout(RECEIVE_DRAIN_TIMEOUT, receiver)
-        .await
-        .expect("receiver must drain stream after sender finishes")
-        .expect("receiver task must join");
-    assert_eq!(
-        received.len(),
-        EVENT_COUNT,
-        "pose fixture stream dropped events: received {}/{}",
-        received.len(),
-        EVENT_COUNT
-    );
+    let mut received_per_subscriber = Vec::with_capacity(profile.subscriber_count);
+    let mut latencies = Vec::with_capacity(profile.event_count * profile.subscriber_count);
+    for receiver in receivers {
+        let received = tokio::time::timeout(RECEIVE_DRAIN_TIMEOUT, receiver)
+            .await
+            .expect("receiver must drain stream after sender finishes")
+            .expect("receiver task must join");
+        received_per_subscriber.push(received.len());
 
-    let mut seen = vec![false; EVENT_COUNT];
-    let mut latencies = Vec::with_capacity(EVENT_COUNT);
-    for (seq, received_at) in received {
-        assert!(seq < EVENT_COUNT, "received out-of-range seq {seq}");
-        assert!(!seen[seq], "duplicate pose event seq {seq}");
-        seen[seq] = true;
-        latencies.push(received_at.duration_since(sent[seq].sent_at));
+        let mut seen = vec![false; profile.event_count];
+        for (seq, received_at) in received {
+            assert!(seq < profile.event_count, "received out-of-range seq {seq}");
+            assert!(!seen[seq], "duplicate pose event seq {seq}");
+            seen[seq] = true;
+            latencies.push(received_at.duration_since(sent[seq].sent_at));
+        }
+        assert!(seen.into_iter().all(|hit| hit), "missing pose event seq");
     }
-    assert!(seen.into_iter().all(|hit| hit), "missing pose event seq");
 
     latencies.sort_unstable();
-    let p50 = percentile(&latencies, 50);
-    let p99 = percentile(&latencies, 99);
-    assert!(
-        p99 <= CI_P99_MAX,
-        "CI-safe p99 exceeded: p50={p50:?} p99={p99:?} max={CI_P99_MAX:?}"
-    );
+    StreamResult {
+        received_per_subscriber,
+        p50: percentile(&latencies, 50),
+        p99: percentile(&latencies, 99),
+    }
+}
+
+async fn receive_pose_stream(
+    mut stream: airc_lib::EventStream,
+    event_count: usize,
+) -> Vec<(usize, Instant)> {
+    let mut received = Vec::with_capacity(event_count);
+    while received.len() < event_count {
+        let Some(next) = stream.next().await else {
+            break;
+        };
+        let event = next.expect("live stream event must decode");
+        let Some(text) = event.body.as_ref().and_then(Body::as_text) else {
+            continue;
+        };
+        let Some(seq) = text.strip_prefix("continuum.pose.fixture seq=") else {
+            continue;
+        };
+        let seq: usize = seq.parse().expect("fixture seq must be numeric");
+        received.push((seq, Instant::now()));
+    }
+    received
 }
 
 fn percentile(sorted: &[Duration], percentile: usize) -> Duration {

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -757,8 +757,10 @@ through the command-bus over LAN-TCP without GitHub.
 - **AR pose-stream contract benchmark.** The WebRTC media stack
   (#955/#957/#960/#961/#962/#963) ships the full transport story.
   The 60-90Hz × sub-25ms p99 *contract benchmark* is partially
-  proven via #954's local consumer-throughput fixture; the
-  tailnet/multi-machine version is still open. Tracked as work
+  proven via #954's local consumer-throughput fixture; the follow-up
+  local fan-out fixture drives a 90Hz Continuum-shaped pose stream to
+  three independent subscribers with zero-drop and p99 assertions.
+  The tailnet/multi-machine version is still open. Tracked as work
   card 399cef36 (Continuum throughput proof, P0).
 - **Personas-as-rooms mapping.** Audit text mentions personas
   living in rooms; consumer_shapes::continuum.rs models
@@ -795,7 +797,7 @@ against the current work board projection. Findings:
 | 1. PR source adapter | `fdf98f86` | shipped via #947 / #950 — stale Open |
 | 2. Work subscription API | `e1f8e2e0` | shipped via #974 / #975 / #976 — closed |
 | 3. Real-machine tailnet/relay proof | `c877e142` | claimable |
-| 4. Consumer-throughput proof | `399cef36` | partial (#954 local); tailnet still open |
+| 4. Consumer-throughput proof | `399cef36` | local 60Hz + 90Hz fan-out proof; tailnet still open |
 | 5. Bind to Continuum/OpenClaw/Hermes | `d61d7853` | Continuum lane formalized (e9ca8a09 audit); OpenClaw/Hermes blocked on repos in workspace |
 | 6. UDP + WebRTC route execution | (no single card — shipped) | covered by #955/#957/#960/#961/#962/#963 |
 


### PR DESCRIPTION
## Summary
- refactor the Continuum-shaped throughput fixture into reusable stream-profile helpers
- keep the existing 60Hz single-subscriber zero-drop proof
- add a 90Hz pose-stream fan-out proof to three independent subscribers with p99 latency and zero-drop assertions
- update the grid substrate audit to mark local fan-out proven while keeping Tailnet/real-machine proof open

Advances typed work card 399cef36-f735-4a98-93a2-c4c5400d7576.

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-lib --check
- cargo test --manifest-path Cargo.toml -p airc-lib --test consumer_throughput -- --nocapture
- cargo clippy --manifest-path Cargo.toml -p airc-lib --all-targets -- -D warnings
- git diff --check