### PR TITLE
feat(work): render typed agent roster

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -607,6 +607,11 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 )
                 .await
             }
+            WorkAction::Roster {
+                repo,
+                event_limit,
+                active_within_ms,
+            } => work_commands::run_roster(&home, repo, event_limit, active_within_ms).await,
             WorkAction::Availability {
                 repo,
                 state,

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -93,6 +93,18 @@ pub enum WorkAction {
         #[arg(long, default_value_t = 512)]
         event_limit: usize,
     },
+    /// Show agent liveness, availability, and active work claims.
+    Roster {
+        /// Optional repository filter, e.g. `CambrianTech/airc`.
+        #[arg(long)]
+        repo: Option<String>,
+        /// Recent transcript events to replay into the projection.
+        #[arg(long, default_value_t = 512)]
+        event_limit: usize,
+        /// Heartbeat age to consider live.
+        #[arg(long, default_value_t = 180_000)]
+        active_within_ms: u64,
+    },
     /// Publish this agent's availability for a repo.
     Availability {
         /// Repository key, e.g. `CambrianTech/airc`.

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use airc_lib::{
     AgentAvailabilityState, Airc, CardState, ChangeWorkCardState, ClaimId, ClaimWorkCard,
     CreateWorkCard, LaneId, Priority, ReleaseWorkClaim, RepoId, WorkBoardProjection, WorkCardId,
-    WorkQueueStatus,
+    WorkQueueStatus, WorkRosterStatus,
 };
 
 use crate::work_cli::{CliAvailabilityState, CliCardState, CliPriority};
@@ -171,6 +171,24 @@ pub async fn run_next(
     Ok(())
 }
 
+pub async fn run_roster(
+    home: &Path,
+    repo: Option<String>,
+    event_limit: usize,
+    active_within_ms: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let status = airc
+        .work_roster_status(airc_lib::WorkRosterQuery {
+            repo: repo.map(RepoId::new).transpose()?,
+            event_limit,
+            active_within_ms,
+        })
+        .await?;
+    print_work_roster(&status);
+    Ok(())
+}
+
 pub async fn run_availability(
     home: &Path,
     repo: String,
@@ -273,6 +291,68 @@ fn print_work_queue_availability(status: &WorkQueueStatus) {
             peer = availability.report.peer,
             state = availability.report.state,
         );
+    }
+}
+
+fn print_work_roster(status: &WorkRosterStatus) {
+    let now_ms = now_ms();
+    if status.rows.is_empty() {
+        println!("work roster: 0 agent(s)");
+        println!("claimable work: {}", status.claimable_count);
+        return;
+    }
+
+    println!(
+        "work roster: {} agent(s) live={} ready={} busy={} away={} stale_availability={} claimable={}",
+        status.rows.len(),
+        status.alive_count(),
+        status.ready_count(now_ms),
+        status.busy_count(now_ms),
+        status.away_count(now_ms),
+        status.stale_availability_count(now_ms),
+        status.claimable_count
+    );
+    for row in &status.rows {
+        let live = row
+            .liveness
+            .as_ref()
+            .map(|liveness| {
+                format!(
+                    "live runtime={} scope={} last_seen_ms={}",
+                    liveness.runtime,
+                    liveness.scope.as_deref().unwrap_or("-"),
+                    liveness.last_seen_ms
+                )
+            })
+            .unwrap_or_else(|| "live=false".to_string());
+        let availability = row
+            .availability
+            .as_ref()
+            .map(|availability| {
+                format!(
+                    "availability={:?} repo={} stale={} note={}",
+                    availability.report.state,
+                    availability.report.repo,
+                    availability.expires_at_ms <= now_ms,
+                    availability.report.note.as_deref().unwrap_or("-")
+                )
+            })
+            .unwrap_or_else(|| "availability=unknown".to_string());
+        println!(
+            "peer={peer}  {live}  {availability}  claims={claims}",
+            peer = row.peer,
+            claims = row.active_claims.len(),
+        );
+        for card in &row.active_claims {
+            println!(
+                "  claim {card_id}  {priority:?}  {state:?}  repo={repo}  title={title}",
+                card_id = card.card_id,
+                priority = card.priority,
+                state = card.state,
+                repo = card.repo,
+                title = card.title,
+            );
+        }
     }
 }
 

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -172,6 +172,53 @@ fn work_next_surfaces_availability_and_idle_guidance() {
 }
 
 #[test]
+fn work_roster_surfaces_availability_and_claims() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    run_ok(
+        &home,
+        &[
+            "work",
+            "availability",
+            "--repo",
+            "CambrianTech/airc",
+            "--state",
+            "ready",
+            "--note",
+            "ready for roster work",
+            "--ttl-ms",
+            "60000",
+        ],
+    );
+    let create = run_ok(
+        &home,
+        &[
+            "work",
+            "create",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "show who is doing what",
+            "--priority",
+            "p1",
+        ],
+    );
+    let card_id = extract_field(&create, "card_id:").expect("card id");
+    run_ok(&home, &["work", "claim", card_id, "--ttl-ms", "60000"]);
+
+    let roster = run_ok(&home, &["work", "roster", "--event-limit", "128"]);
+    assert!(roster.contains("work roster: 1 agent(s)"), "{roster}");
+    assert!(roster.contains("ready=1"), "{roster}");
+    assert!(roster.contains("availability=Ready"), "{roster}");
+    assert!(roster.contains("ready for roster work"), "{roster}");
+    assert!(roster.contains("claims=1"), "{roster}");
+    assert!(roster.contains(card_id), "{roster}");
+    assert!(roster.contains("show who is doing what"), "{roster}");
+}
+
+#[test]
 fn work_next_suggests_claimable_priority_cards() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -65,6 +65,7 @@ pub mod webrtc_media;
 pub mod webrtc_signaling;
 mod wire_replay;
 pub mod work;
+pub mod work_roster;
 pub mod work_subscription;
 
 pub use account_registry::{
@@ -127,6 +128,7 @@ pub use work::{
     ObservedPullRequests, ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace,
     ReportAgentAvailability, RequestWorkspace, WorkQueueStatus, WorkQueueStatusQuery,
 };
+pub use work_roster::{WorkRosterQuery, WorkRosterRow, WorkRosterStatus};
 pub use work_subscription::{
     WorkEventFilter, HEADER_WORK_CARD_ID, HEADER_WORK_LANE_ID, HEADER_WORK_REPO,
 };

--- a/crates/airc-lib/src/work_roster.rs
+++ b/crates/airc-lib/src/work_roster.rs
@@ -1,0 +1,254 @@
+//! Typed roster projection for agent coordination.
+//!
+//! This module composes the existing work-board projection and
+//! heartbeat query into one SDK object. Terminal commands render this
+//! object for humans; integrations should consume the typed structs
+//! directly.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use airc_core::PeerId;
+use airc_work::{AgentAvailabilityRecord, AgentAvailabilityState, CardState, RepoId, WorkCard};
+
+use crate::agent_heartbeat::AgentLiveness;
+use crate::time::now_ms;
+use crate::{Airc, AircError};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkRosterQuery {
+    pub repo: Option<RepoId>,
+    pub event_limit: usize,
+    pub active_within_ms: u64,
+}
+
+impl Default for WorkRosterQuery {
+    fn default() -> Self {
+        Self {
+            repo: None,
+            event_limit: 512,
+            active_within_ms: 180_000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkRosterStatus {
+    pub rows: Vec<WorkRosterRow>,
+    pub claimable_count: usize,
+}
+
+impl WorkRosterStatus {
+    pub fn ready_count(&self, now_ms: u64) -> usize {
+        self.availability_count(now_ms, AgentAvailabilityState::Ready)
+    }
+
+    pub fn busy_count(&self, now_ms: u64) -> usize {
+        self.availability_count(now_ms, AgentAvailabilityState::Busy)
+    }
+
+    pub fn away_count(&self, now_ms: u64) -> usize {
+        self.availability_count(now_ms, AgentAvailabilityState::Away)
+    }
+
+    pub fn stale_availability_count(&self, now_ms: u64) -> usize {
+        self.rows
+            .iter()
+            .filter(|row| {
+                row.availability
+                    .as_ref()
+                    .is_some_and(|record| record.expires_at_ms <= now_ms)
+            })
+            .count()
+    }
+
+    pub fn alive_count(&self) -> usize {
+        self.rows
+            .iter()
+            .filter(|row| row.liveness.is_some())
+            .count()
+    }
+
+    fn availability_count(&self, now_ms: u64, state: AgentAvailabilityState) -> usize {
+        self.rows
+            .iter()
+            .filter(|row| {
+                row.availability
+                    .as_ref()
+                    .is_some_and(|record| record.expires_at_ms > now_ms)
+                    && row
+                        .availability
+                        .as_ref()
+                        .is_some_and(|record| record.report.state == state)
+            })
+            .count()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkRosterRow {
+    pub peer: PeerId,
+    pub liveness: Option<AgentLiveness>,
+    pub availability: Option<AgentAvailabilityRecord>,
+    pub active_claims: Vec<WorkCard>,
+}
+
+impl Airc {
+    /// Return the typed roster view used by managers, monitors, and
+    /// agent loops: who is alive, who is ready/busy/away, and what
+    /// each peer is already claiming.
+    pub async fn work_roster_status(
+        &self,
+        query: WorkRosterQuery,
+    ) -> Result<WorkRosterStatus, AircError> {
+        let board = self.work_board(query.event_limit).await?;
+        let snapshot = board.snapshot();
+        let now_ms = now_ms()?;
+        let active_agents = self
+            .active_agents(
+                Duration::from_millis(query.active_within_ms),
+                query.event_limit,
+            )
+            .await?;
+
+        let mut rows = RosterRows::new();
+        let mut claimable_count = 0;
+
+        for liveness in active_agents {
+            rows.upsert_liveness(liveness);
+        }
+        for availability in snapshot.agent_availability {
+            if query
+                .repo
+                .as_ref()
+                .is_none_or(|repo| &availability.report.repo == repo)
+            {
+                rows.upsert_availability(availability);
+            }
+        }
+        for card in snapshot.cards {
+            if query.repo.as_ref().is_some_and(|repo| &card.repo != repo) {
+                continue;
+            }
+            if card.state == CardState::Open && card.claim_id.is_none() {
+                claimable_count += 1;
+            } else if is_active_claim(&card, now_ms) {
+                rows.add_active_claim(card);
+            }
+        }
+
+        Ok(WorkRosterStatus {
+            rows: rows.into_sorted_rows(now_ms),
+            claimable_count,
+        })
+    }
+}
+
+struct RosterRows {
+    rows: BTreeMap<String, WorkRosterRow>,
+}
+
+impl RosterRows {
+    fn new() -> Self {
+        Self {
+            rows: BTreeMap::new(),
+        }
+    }
+
+    fn upsert_liveness(&mut self, liveness: AgentLiveness) {
+        let peer = liveness.peer;
+        self.row_mut(peer).liveness = Some(liveness);
+    }
+
+    fn upsert_availability(&mut self, availability: AgentAvailabilityRecord) {
+        let peer = availability.report.peer;
+        self.row_mut(peer).availability = Some(availability);
+    }
+
+    fn add_active_claim(&mut self, card: WorkCard) {
+        let Some(owner) = card.owner else {
+            return;
+        };
+        self.row_mut(owner).active_claims.push(card);
+    }
+
+    fn row_mut(&mut self, peer: PeerId) -> &mut WorkRosterRow {
+        self.rows
+            .entry(peer.to_string())
+            .or_insert_with(|| WorkRosterRow {
+                peer,
+                liveness: None,
+                availability: None,
+                active_claims: Vec::new(),
+            })
+    }
+
+    fn into_sorted_rows(self, now_ms: u64) -> Vec<WorkRosterRow> {
+        let mut rows: Vec<_> = self.rows.into_values().collect();
+        for row in &mut rows {
+            row.active_claims.sort_by(|left, right| {
+                left.priority
+                    .cmp(&right.priority)
+                    .then_with(|| left.updated_at_ms.cmp(&right.updated_at_ms))
+                    .then_with(|| left.card_id.cmp(&right.card_id))
+            });
+        }
+        rows.sort_by(|left, right| {
+            roster_row_rank(left, now_ms)
+                .cmp(&roster_row_rank(right, now_ms))
+                .then_with(|| {
+                    left.availability
+                        .as_ref()
+                        .map(|record| record.report.repo.to_string())
+                        .cmp(
+                            &right
+                                .availability
+                                .as_ref()
+                                .map(|record| record.report.repo.to_string()),
+                        )
+                })
+                .then_with(|| left.peer.to_string().cmp(&right.peer.to_string()))
+        });
+        rows
+    }
+}
+
+fn is_active_claim(card: &WorkCard, now_ms: u64) -> bool {
+    card.owner.is_some()
+        && card.claim_id.is_some()
+        && card
+            .claim_expires_at_ms
+            .is_some_and(|expires_at_ms| expires_at_ms > now_ms)
+        && matches!(
+            card.state,
+            CardState::Claimed | CardState::InProgress | CardState::Blocked | CardState::Review
+        )
+}
+
+fn roster_row_rank(row: &WorkRosterRow, now_ms: u64) -> u8 {
+    if row.liveness.is_some()
+        && row
+            .availability
+            .as_ref()
+            .is_some_and(|record| record.expires_at_ms > now_ms)
+    {
+        row.availability
+            .as_ref()
+            .map(|record| availability_state_rank(record.report.state))
+            .unwrap_or(3)
+    } else if row.liveness.is_some() {
+        3
+    } else if row.availability.is_some() {
+        4
+    } else {
+        5
+    }
+}
+
+fn availability_state_rank(state: AgentAvailabilityState) -> u8 {
+    match state {
+        AgentAvailabilityState::Ready => 0,
+        AgentAvailabilityState::Busy => 1,
+        AgentAvailabilityState::Away => 2,
+    }
+}

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -1,10 +1,11 @@
 use std::time::{Duration, Instant};
 
 use airc_lib::{
-    Airc, AllocateWorkspace, BranchName, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard,
-    ClaimableWorkQuery, CreateWorkCard, CreateWorkLane, DirtyState, HeartbeatWorkspace, LaneState,
-    ObserveLocalGitWorkspace, Priority, ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace,
-    RepoId, RequestWorkspace, WorkCardId, WorkspaceStatus,
+    AgentAvailabilityState, Airc, AllocateWorkspace, BranchName, ChangeWorkLaneState,
+    ClaimManagerHat, ClaimWorkCard, ClaimableWorkQuery, CreateWorkCard, CreateWorkLane, DirtyState,
+    HeartbeatKind, HeartbeatWorkspace, LaneState, ObserveLocalGitWorkspace, Priority,
+    ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace, RepoId, ReportAgentAvailability,
+    RequestWorkspace, WorkCardId, WorkRosterQuery, WorkspaceStatus,
 };
 use tempfile::TempDir;
 
@@ -256,6 +257,72 @@ async fn claimable_work_can_surface_stale_claims_for_recovery() {
         visible[0].stale_claim.as_ref().map(|claim| claim.claim_id),
         Some(claim_id)
     );
+}
+
+#[tokio::test]
+async fn work_roster_status_combines_liveness_availability_and_claims() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("work-roster-api").await.unwrap();
+    let repo = RepoId::new("CambrianTech/airc").unwrap();
+
+    airc.emit_agent_heartbeat(
+        HeartbeatKind::Alive,
+        "codex",
+        Some("airc-worktree".to_string()),
+    )
+    .await
+    .unwrap();
+    airc.report_agent_availability(ReportAgentAvailability {
+        repo: repo.clone(),
+        state: AgentAvailabilityState::Ready,
+        note: Some("can take next card".to_string()),
+        ttl_ms: 60_000,
+    })
+    .await
+    .unwrap();
+
+    let card_id = airc
+        .create_work_card(CreateWorkCard {
+            repo,
+            title: "render typed work roster".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+        })
+        .await
+        .unwrap();
+    let claim_id = airc
+        .claim_work_card(ClaimWorkCard {
+            card_id,
+            ttl_ms: 60_000,
+        })
+        .await
+        .unwrap();
+
+    let roster = airc
+        .work_roster_status(WorkRosterQuery {
+            event_limit: 128,
+            ..WorkRosterQuery::default()
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(roster.rows.len(), 1);
+    assert_eq!(roster.alive_count(), 1);
+    assert_eq!(roster.ready_count(u64::MAX.saturating_sub(1)), 0);
+    assert_eq!(roster.ready_count(0), 1);
+    let row = &roster.rows[0];
+    assert_eq!(row.peer, airc.peer_id());
+    assert_eq!(row.liveness.as_ref().unwrap().runtime, "codex");
+    assert_eq!(
+        row.availability.as_ref().unwrap().report.note.as_deref(),
+        Some("can take next card")
+    );
+    assert_eq!(row.active_claims.len(), 1);
+    assert_eq!(row.active_claims[0].card_id, card_id);
+    assert_eq!(row.active_claims[0].claim_id, Some(claim_id));
+    assert_eq!(roster.claimable_count, 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add a typed airc-lib work roster API that combines agent liveness, availability, active claims, and claimable counts
- add `airc work roster` as a human renderer over that typed API rather than a stdout contract
- cover the SDK roster shape and CLI output with regression tests

## Roadmap / audit
- Advances `docs/architecture/GRID-SUBSTRATE-AUDIT.md` coordination-roadmap work for active-agent visibility, idle-lock prevention, and kanban/work-card operations.

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-lib -p airc-cli --check`
- `cargo test --manifest-path Cargo.toml -p airc-lib work_roster_status -- --nocapture`
- `cargo test --manifest-path Cargo.toml -p airc-cli work_roster_surfaces_availability_and_claims -- --nocapture`
- `cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml -p airc-lib -p airc-cli`
- `git diff --check`