### PR TITLE
fix(work): make duplicate claim release idempotent

### DIFF
--- a/crates/airc-work/src/projection/apply.rs
+++ b/crates/airc-work/src/projection/apply.rs
@@ -178,6 +178,9 @@ impl WorkBoardProjection {
 
     fn apply_claim_released(&mut self, e: &ClaimReleased) -> Result<(), ProjectionError> {
         let card = self.card_mut(e.card_id)?;
+        if card.claim_id.is_none() {
+            return Ok(());
+        }
         ensure_claim(card, e.claim_id)?;
         card.state = match card.state {
             CardState::Claimed | CardState::InProgress | CardState::Blocked => CardState::Open,

--- a/crates/airc-work/src/projection/tests.rs
+++ b/crates/airc-work/src/projection/tests.rs
@@ -109,6 +109,53 @@ fn releasing_claim_clears_owner_without_reopening_closed_card() {
 }
 
 #[test]
+fn duplicate_claim_release_is_idempotent_after_claim_is_already_clear() {
+    let card_id = WorkCardId::from_u128(13);
+    let claim_id = ClaimId::from_u128(14);
+    let owner = peer(15);
+
+    let projection = WorkBoardProjection::replay(vec![
+        WorkEvent::CardCreated(CardCreated {
+            card_id,
+            repo: repo(),
+            title: "duplicate release".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+            created_by: owner,
+            created_at_ms: 100,
+        }),
+        WorkEvent::CardClaimed(WorkCardClaimed {
+            card_id,
+            claim_id,
+            owner,
+            ttl_ms: 100,
+            claimed_at_ms: 110,
+        }),
+        WorkEvent::ClaimReleased(ClaimReleased {
+            card_id,
+            claim_id,
+            owner,
+            reason: Some("first release".to_string()),
+            released_at_ms: 120,
+        }),
+        WorkEvent::ClaimReleased(ClaimReleased {
+            card_id,
+            claim_id,
+            owner,
+            reason: Some("duplicate release".to_string()),
+            released_at_ms: 130,
+        }),
+    ])
+    .unwrap();
+
+    let card = projection.card(card_id).unwrap();
+    assert_eq!(card.state, CardState::Open);
+    assert_eq!(card.owner, None);
+    assert_eq!(card.claim_id, None);
+}
+
+#[test]
 fn availability_projection_keeps_latest_peer_state_per_repo() {
     let repo = repo();
     let other_repo = RepoId::new("CambrianTech/continuum").unwrap();


### PR DESCRIPTION
## Summary
- make claim release replay idempotent when a card already has no active claim
- keep active-claim mismatch rejection intact for wrong claim ids
- add a regression test for duplicate releases so one repeated cleanup event cannot poison the whole work queue

## Why
Closing the roster card exposed a replay poison: a duplicate/reordered release event made every future `airc work next` fail with a projection claim mismatch. This keeps durable work replay resilient without accepting mismatches against another active claim.

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-work --check`
- `cargo test --manifest-path Cargo.toml -p airc-work duplicate_claim_release_is_idempotent_after_claim_is_already_clear -- --nocapture`
- `cargo test --manifest-path Cargo.toml -p airc-work mismatched_claim_is_rejected -- --nocapture`
- `cargo clippy --manifest-path Cargo.toml -p airc-work --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml -p airc-cli work_next_surfaces_availability_and_idle_guidance -- --nocapture`
- `target/debug/airc work next --event-limit 4096 --limit 12`