### PR TITLE
feat(work): enforce lease-zone for work claim + heartbeat diagnostic

### DIFF
--- a/crates/airc-cli/src/lease.rs
+++ b/crates/airc-cli/src/lease.rs
@@ -1,0 +1,187 @@
+//! Worktree-lease ergonomics for the airc CLI.
+//!
+//! Durable rule (Joel, multi-project): `~/.airc/worktrees/` is the
+//! lease zone. Agent lanes do their work inside leases so the main
+//! checkout stays clean and parallel agents don't clobber each
+//! other.
+//!
+//! Closes flaw #7 from GRID-SUBSTRATE-AUDIT #964 (unenforced
+//! worktree leases). This module enforces the rule at the CLI
+//! boundary because cwd is process state — keeping it out of the
+//! substrate preserves the substrate-of-truth/SDK-composes/CLI-
+//! consumes layering.
+//!
+//! Two checks:
+//!
+//! 1. **At claim time** — `airc work claim` refuses when cwd is not
+//!    under `~/.airc/worktrees/`, unless `--no-lease-required`.
+//!    This catches the common mistake of claiming a card while
+//!    sitting in the main checkout.
+//!
+//! 2. **At heartbeat time** — `airc work heartbeat` does NOT refuse
+//!    (the claim was already granted; the heartbeat just renews the
+//!    lease). Instead it emits a typed `WorkspaceLeaseViolation`
+//!    diagnostic so the substrate has a record. Drift away from a
+//!    lease mid-task is worth observing.
+
+use std::path::{Path, PathBuf};
+
+/// The lease zone subdirectory under `$HOME`.
+const LEASE_ZONE_RELATIVE: &str = ".airc/worktrees";
+
+/// Resolve the lease zone path (`~/.airc/worktrees`). Returns
+/// `None` only when neither `$HOME` nor `$USERPROFILE` is set — in
+/// practice this never happens in normal terminal usage, but the
+/// caller decides how to treat that case.
+pub fn lease_root() -> Option<PathBuf> {
+    home_dir().map(|home| home.join(LEASE_ZONE_RELATIVE))
+}
+
+/// Result of checking whether a path lives under the lease zone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeaseCheck {
+    /// The path the caller asked about, canonicalised when possible.
+    pub path: PathBuf,
+    /// The lease zone we compared against, canonicalised when it
+    /// exists on disk.
+    pub lease_root: PathBuf,
+    /// True when `path` is under `lease_root`.
+    pub under_lease: bool,
+}
+
+/// Check whether `path` lives under the configured lease zone.
+///
+/// Reads `$HOME`/`$USERPROFILE` for the lease zone root. For tests
+/// that need a synthetic lease zone, use [`check_path_against`].
+pub fn check_path(path: &Path) -> std::io::Result<LeaseCheck> {
+    let lease_root = lease_root()
+        .ok_or_else(|| std::io::Error::other("HOME/USERPROFILE not set; cannot resolve ~/"))?;
+    Ok(check_path_against(path, &lease_root))
+}
+
+/// Like [`check_path`] but with an explicit lease root, suitable
+/// for tests that build a synthetic lease zone in a tempdir without
+/// mutating process environment.
+pub fn check_path_against(path: &Path, lease_root: &Path) -> LeaseCheck {
+    // Canonicalise both sides so symlinks into the lease zone (and
+    // /var → /private/var on macOS) compare correctly. Fall back to
+    // the raw paths when canonicalisation fails (e.g. the path
+    // doesn't exist yet) — in that case the prefix check still
+    // produces a sensible answer for callers passing real cwds.
+    let canonical_root = lease_root
+        .canonicalize()
+        .unwrap_or_else(|_| lease_root.to_path_buf());
+    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let under_lease = canonical_path.starts_with(&canonical_root);
+    LeaseCheck {
+        path: canonical_path,
+        lease_root: canonical_root,
+        under_lease,
+    }
+}
+
+/// Convenience: check the current working directory.
+pub fn check_current_dir() -> std::io::Result<LeaseCheck> {
+    let cwd = std::env::current_dir()?;
+    check_path(&cwd)
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn path_inside_lease_zone_is_under_lease() {
+        let tmp = TempDir::new().expect("home");
+        let root = tmp.path().join(".airc/worktrees");
+        let leased = root.join("my-lane");
+        std::fs::create_dir_all(&leased).expect("create lane dir");
+
+        let check = check_path_against(&leased, &root);
+        assert!(
+            check.under_lease,
+            "lane dir {:?} should be under lease root {:?}",
+            check.path, check.lease_root
+        );
+    }
+
+    #[test]
+    fn path_outside_lease_zone_is_not_under_lease() {
+        let tmp = TempDir::new().expect("home");
+        let root = tmp.path().join(".airc/worktrees");
+        std::fs::create_dir_all(&root).expect("create lease root");
+        let elsewhere = tmp.path().join("not-a-lease");
+        std::fs::create_dir_all(&elsewhere).expect("create non-lease dir");
+
+        let check = check_path_against(&elsewhere, &root);
+        assert!(
+            !check.under_lease,
+            "non-lease dir {:?} should NOT be under lease root {:?}",
+            check.path, check.lease_root
+        );
+    }
+
+    #[test]
+    fn nonexistent_lease_root_treats_existing_paths_as_not_under_lease() {
+        let tmp = TempDir::new().expect("home");
+        let root = tmp.path().join(".airc/worktrees");
+        // Note: lease root never created.
+        let elsewhere = tmp.path().join("anywhere");
+        std::fs::create_dir_all(&elsewhere).expect("create dir");
+
+        let check = check_path_against(&elsewhere, &root);
+        assert!(!check.under_lease);
+    }
+
+    #[test]
+    fn nested_lane_subdirectory_still_under_lease() {
+        let tmp = TempDir::new().expect("home");
+        let root = tmp.path().join(".airc/worktrees");
+        let deep = root.join("lane/crates/airc-lib/src");
+        std::fs::create_dir_all(&deep).expect("create deep dir");
+
+        let check = check_path_against(&deep, &root);
+        assert!(check.under_lease, "deep path inside a lane must count");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_into_lease_zone_resolves_as_under_lease() {
+        // Canonicalising both sides means a symlink that points into
+        // ~/.airc/worktrees/ still passes — matches user intent
+        // (working in the linked-to location).
+        let tmp = TempDir::new().expect("home");
+        let root = tmp.path().join(".airc/worktrees");
+        let leased = root.join("lane");
+        std::fs::create_dir_all(&leased).expect("create lane");
+        let link = tmp.path().join("shortcut");
+        std::os::unix::fs::symlink(&leased, &link).expect("symlink");
+
+        let check = check_path_against(&link, &root);
+        assert!(check.under_lease, "symlink into lease zone should resolve");
+    }
+
+    #[test]
+    fn unrelated_sibling_path_is_not_under_lease_even_with_prefix_overlap() {
+        // Guard against a naïve string-prefix check that would let
+        // `~/.airc/worktrees-malicious/` match `~/.airc/worktrees/`.
+        let tmp = TempDir::new().expect("home");
+        let root = tmp.path().join(".airc/worktrees");
+        std::fs::create_dir_all(&root).expect("create lease root");
+        let sibling = tmp.path().join(".airc/worktrees-malicious");
+        std::fs::create_dir_all(&sibling).expect("create sibling");
+
+        let check = check_path_against(&sibling, &root);
+        assert!(
+            !check.under_lease,
+            "sibling dir with overlapping prefix must not count as under lease"
+        );
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -43,6 +43,7 @@ mod knock_cli;
 mod knock_commands;
 mod lane_cli;
 mod lane_commands;
+mod lease;
 mod legacy_envelope;
 mod legacy_identity;
 mod monitor;
@@ -572,9 +573,11 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 lane_id,
                 priority,
             } => work_commands::run_create(&home, repo, title, body, lane_id, priority).await,
-            WorkAction::Claim { card_id, ttl_ms } => {
-                work_commands::run_claim(&home, card_id, ttl_ms).await
-            }
+            WorkAction::Claim {
+                card_id,
+                ttl_ms,
+                no_lease_required,
+            } => work_commands::run_claim(&home, card_id, ttl_ms, no_lease_required).await,
             WorkAction::Heartbeat {
                 card_id,
                 claim_id,

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -29,12 +29,21 @@ pub enum WorkAction {
         priority: CliPriority,
     },
     /// Claim an existing work card for this peer.
+    ///
+    /// Refuses when the current directory is not under
+    /// `~/.airc/worktrees/` (the lease zone). Pass
+    /// `--no-lease-required` to override — useful for one-shot
+    /// admin claims from the main checkout.
     Claim {
         /// Work card UUID.
         card_id: String,
         /// Claim lease duration.
         #[arg(long, default_value_t = 600_000)]
         ttl_ms: u64,
+        /// Allow claim from outside `~/.airc/worktrees/`. Default
+        /// behaviour refuses, to keep lane work inside leases.
+        #[arg(long)]
+        no_lease_required: bool,
     },
     /// Extend this peer's claim lease on a work card.
     Heartbeat {

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -9,6 +9,7 @@
 
 use std::path::Path;
 
+use airc_diagnostics::{DiagnosticCode, DiagnosticComponent, DiagnosticEvent};
 use uuid::Uuid;
 
 use airc_lib::{
@@ -17,6 +18,7 @@ use airc_lib::{
     WorkQueueStatus, WorkRosterStatus,
 };
 
+use crate::lease;
 use crate::work_cli::{CliAvailabilityState, CliCardState, CliPriority};
 
 pub async fn run_create(
@@ -45,7 +47,21 @@ pub async fn run_claim(
     home: &Path,
     card_id: String,
     ttl_ms: u64,
+    no_lease_required: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if !no_lease_required {
+        let check = lease::check_current_dir()?;
+        if !check.under_lease {
+            return Err(format!(
+                "refusing to claim work card from {cwd}: not under lease zone {root}.\n\
+                 Allocate a worktree under ~/.airc/worktrees/ first, or pass \
+                 --no-lease-required to override.",
+                cwd = check.path.display(),
+                root = check.lease_root.display(),
+            )
+            .into());
+        }
+    }
     let airc = Airc::open(home).await?;
     let card_id = parse_work_card_id(&card_id)?;
     let claim_id = airc
@@ -79,13 +95,39 @@ pub async fn run_heartbeat(
     ttl_ms: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let airc = Airc::open(home).await?;
+    let card_uuid = parse_work_card_id(&card_id)?;
+    let claim_uuid = parse_claim_id(&claim_id)?;
     airc.heartbeat_work_claim(airc_lib::HeartbeatWorkClaim {
-        card_id: parse_work_card_id(&card_id)?,
-        claim_id: parse_claim_id(&claim_id)?,
+        card_id: card_uuid,
+        claim_id: claim_uuid,
         ttl_ms,
     })
     .await?;
     println!("claim_heartbeat: card_id={card_id} claim_id={claim_id} ttl_ms={ttl_ms}");
+
+    // Heartbeat doesn't refuse on lease drift — the claim was
+    // already granted, and refusing here would just orphan it. But
+    // we DO record the drift as a typed diagnostic so a substrate
+    // observer can see when an agent has wandered out of its lease.
+    if let Ok(check) = lease::check_current_dir() {
+        if !check.under_lease {
+            let diag = DiagnosticEvent::warn(
+                DiagnosticComponent::Work,
+                DiagnosticCode::WorkspaceLeaseViolation,
+                "work heartbeat fired from a path outside the lease zone",
+            )
+            .with_field("card_id", &card_id)
+            .with_field("claim_id", &claim_id)
+            .with_field("cwd", check.path.display())
+            .with_field("lease_root", check.lease_root.display());
+            // Best-effort: a publish failure shouldn't break the
+            // heartbeat from the user's perspective. Surface to
+            // stderr so it isn't silently swallowed.
+            if let Err(error) = airc.publish_diagnostic_event(&diag).await {
+                eprintln!("airc: failed to publish lease-violation diagnostic: {error}");
+            }
+        }
+    }
     Ok(())
 }
 

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -45,7 +45,17 @@ fn work_create_claim_release_projects_on_board() {
     assert!(board.contains("P1"));
     assert!(board.contains("Open"));
 
-    let claim = run_ok(&home, &["work", "claim", card_id, "--ttl-ms", "60000"]);
+    let claim = run_ok(
+        &home,
+        &[
+            "work",
+            "claim",
+            card_id,
+            "--ttl-ms",
+            "60000",
+            "--no-lease-required",
+        ],
+    );
     let claim_id = extract_field(&claim, "claim_id:").expect("claim prints claim_id");
 
     let claimed_board = run_ok(&home, &["work", "board"]);
@@ -96,7 +106,17 @@ fn work_board_surfaces_stale_claims() {
     );
     let card_id = extract_field(&create, "card_id:").expect("create prints card_id");
 
-    let claim = run_ok(&home, &["work", "claim", card_id, "--ttl-ms", "1"]);
+    let claim = run_ok(
+        &home,
+        &[
+            "work",
+            "claim",
+            card_id,
+            "--ttl-ms",
+            "1",
+            "--no-lease-required",
+        ],
+    );
     let claim_id = extract_field(&claim, "claim_id:").expect("claim prints claim_id");
     std::thread::sleep(std::time::Duration::from_millis(5));
 
@@ -206,7 +226,17 @@ fn work_roster_surfaces_availability_and_claims() {
         ],
     );
     let card_id = extract_field(&create, "card_id:").expect("card id");
-    run_ok(&home, &["work", "claim", card_id, "--ttl-ms", "60000"]);
+    run_ok(
+        &home,
+        &[
+            "work",
+            "claim",
+            card_id,
+            "--ttl-ms",
+            "60000",
+            "--no-lease-required",
+        ],
+    );
 
     let roster = run_ok(&home, &["work", "roster", "--event-limit", "128"]);
     assert!(roster.contains("work roster: 1 agent(s)"), "{roster}");
@@ -379,6 +409,60 @@ fn lane_manager_claim_status_and_release_project_from_board() {
 }
 
 #[test]
+fn work_claim_refuses_when_cwd_outside_lease_zone() {
+    // Closes flaw #7 from GRID-SUBSTRATE-AUDIT #964: the CLI must
+    // refuse `work claim` from outside `~/.airc/worktrees/`. The
+    // test fixture's $HOME is a tempdir, and cwd is the source tree
+    // (definitely not inside that tempdir's lease zone), so the
+    // bare claim should fail with a clear refusal.
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let create = run_ok(
+        &home,
+        &[
+            "work",
+            "create",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "refusal test",
+            "--priority",
+            "p2",
+        ],
+    );
+    let card_id = extract_field(&create, "card_id:").expect("card id");
+
+    let stderr = run_expect_failure(&home, &["work", "claim", card_id, "--ttl-ms", "60000"]);
+    assert!(
+        stderr.contains("not under lease zone"),
+        "expected lease-refusal stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--no-lease-required"),
+        "refusal must point at the override flag, got: {stderr}"
+    );
+
+    // With the override the same claim succeeds.
+    let claim = run_ok(
+        &home,
+        &[
+            "work",
+            "claim",
+            card_id,
+            "--ttl-ms",
+            "60000",
+            "--no-lease-required",
+        ],
+    );
+    assert!(
+        extract_field(&claim, "claim_id:").is_some(),
+        "claim with override should print a claim_id, got: {claim}"
+    );
+}
+
+#[test]
 fn work_board_empty_state_is_explicit() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");
@@ -410,6 +494,25 @@ fn run_ok(home: &Path, args: &[&str]) -> String {
         String::from_utf8_lossy(&output.stderr),
     );
     String::from_utf8(output.stdout).expect("stdout utf-8")
+}
+
+fn run_expect_failure(home: &Path, args: &[&str]) -> String {
+    let machine_home = home.parent().unwrap_or(home);
+    let output = Command::new(airc_core())
+        .env("HOME", machine_home)
+        .env("USERPROFILE", machine_home)
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .output()
+        .expect("airc-core command must spawn");
+    assert!(
+        !output.status.success(),
+        "expected airc-core {:?} to fail, but it succeeded: stdout={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+    );
+    String::from_utf8(output.stderr).expect("stderr utf-8")
 }
 
 fn extract_field<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {

--- a/crates/airc-cli/tests/workspace_commands.rs
+++ b/crates/airc-cli/tests/workspace_commands.rs
@@ -27,7 +27,17 @@ fn workspace_request_allocate_heartbeat_release_projects_on_list() {
         ],
     );
     let card_id = extract_field(&card, "card_id:").expect("create prints card_id");
-    let claim = run_ok(&home, &["work", "claim", card_id, "--ttl-ms", "60000"]);
+    let claim = run_ok(
+        &home,
+        &[
+            "work",
+            "claim",
+            card_id,
+            "--ttl-ms",
+            "60000",
+            "--no-lease-required",
+        ],
+    );
     let claim_id = extract_field(&claim, "claim_id:").expect("claim prints claim_id");
 
     let request = run_ok(

--- a/crates/airc-diagnostics/src/lib.rs
+++ b/crates/airc-diagnostics/src/lib.rs
@@ -29,6 +29,7 @@ pub enum DiagnosticComponent {
     Subscriber,
     Transport,
     WebRtc,
+    Work,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -43,6 +44,7 @@ pub enum DiagnosticCode {
     UnverifiableReplayFrameSkipped,
     ReplayFramesSkipped,
     WebRtcOfferAnswerFailed,
+    WorkspaceLeaseViolation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/airc-lib/src/diagnostic_event_sink.rs
+++ b/crates/airc-lib/src/diagnostic_event_sink.rs
@@ -173,6 +173,7 @@ fn component_header_value(component: DiagnosticComponent) -> &'static str {
         DiagnosticComponent::Subscriber => "subscriber",
         DiagnosticComponent::Transport => "transport",
         DiagnosticComponent::WebRtc => "webrtc",
+        DiagnosticComponent::Work => "work",
     }
 }
 
@@ -187,6 +188,7 @@ fn code_header_value(code: DiagnosticCode) -> &'static str {
         DiagnosticCode::UnverifiableReplayFrameSkipped => "unverifiable_replay_frame_skipped",
         DiagnosticCode::ReplayFramesSkipped => "replay_frames_skipped",
         DiagnosticCode::WebRtcOfferAnswerFailed => "webrtc_offer_answer_failed",
+        DiagnosticCode::WorkspaceLeaseViolation => "workspace_lease_violation",
     }
 }
 
@@ -211,6 +213,7 @@ mod tests {
             DiagnosticComponent::Subscriber,
             DiagnosticComponent::Transport,
             DiagnosticComponent::WebRtc,
+            DiagnosticComponent::Work,
         ] {
             let header = component_header_value(component);
             assert!(!header.is_empty(), "{component:?} should map to non-empty");
@@ -229,6 +232,7 @@ mod tests {
             DiagnosticCode::UnverifiableReplayFrameSkipped,
             DiagnosticCode::ReplayFramesSkipped,
             DiagnosticCode::WebRtcOfferAnswerFailed,
+            DiagnosticCode::WorkspaceLeaseViolation,
         ] {
             let header = code_header_value(code);
             assert!(!header.is_empty(), "{code:?} should map to non-empty");


### PR DESCRIPTION
## Summary
Closes work card **7cdffa82** (P1, flaw #7 of GRID-SUBSTRATE-AUDIT #964: \"Enforce lane work happens inside `~/.airc/worktrees/` leases\").

Durable rule across projects: `~/.airc/worktrees/` is the lease zone. Lanes work inside leases so the main checkout stays clean and parallel agents don't clobber each other. Docs + airc messages told agents this; nothing in airc actually *enforced* it. This PR adds enforcement at two specific points.

## Behaviour

1. **`airc work claim` refuses outside the lease zone.** Local check before any substrate call. Pass `--no-lease-required` for legitimate one-shot admin claims from the main checkout (release work, hygiene cards). The refusal stderr points at the override flag.

2. **`airc work heartbeat` emits a typed diagnostic on drift.** Doesn't refuse — the claim was already granted, and refusing would orphan the work. Instead emits a `WorkspaceLeaseViolation` `DiagnosticEvent` with `cwd`, `lease_root`, `card_id`, `claim_id`. Best-effort: publish failure surfaces to stderr rather than being swallowed.

## Layering
- cwd is process state → enforcement lives in `airc-cli`, not the substrate.
- Typed diagnostic variants live in `airc-diagnostics` (closed-set enums extended: `DiagnosticComponent::Work`, `DiagnosticCode::WorkspaceLeaseViolation`).
- `airc-lib::diagnostic_event_sink` string mappings extended; existing stability tests cover them.

## Path comparison safety
- Canonicalises both sides → symlinks into the lease zone (and macOS's `/var → /private/var`) compare correctly.
- `Path::starts_with` is component-aware → sibling dirs like `~/.airc/worktrees-malicious/` are correctly excluded.

## Test plan
- [x] `airc-cli` lease module: 6 unit tests (positive, negative, missing lease root, nested subpaths, symlink resolution, sibling-prefix exclusion).
- [x] `airc-cli` integration: `work_claim_refuses_when_cwd_outside_lease_zone` asserts the refusal stderr AND that `--no-lease-required` recovers.
- [x] Existing integration tests that claim from the source tree (not a lease zone) now pass `--no-lease-required` — they exercise the claim machinery, not lease ergonomics.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all` clean.
- [x] `cargo test --workspace` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)