### PR TITLE
feat(route): add JSON route proof harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "airc-ipc",
  "airc-lib",
  "airc-protocol",
+ "airc-relay",
  "airc-store",
  "airc-transport",
  "airc-trust",

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -18,6 +18,7 @@ airc-diagnostics = { path = "../airc-diagnostics" }
 airc-identity = { path = "../airc-identity" }
 airc-ipc = { path = "../airc-ipc" }
 airc-protocol = { path = "../airc-protocol" }
+airc-relay = { path = "../airc-relay" }
 airc-transport = { path = "../airc-transport" }
 airc-trust = { path = "../airc-trust" }
 airc-daemon = { path = "../airc-daemon" }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -58,6 +58,7 @@ mod queue_card_runtime;
 mod queue_card_staleness;
 mod route_cli;
 mod route_commands;
+mod route_proof_commands;
 mod runtime_context;
 mod transport_cli;
 mod transport_commands;
@@ -376,6 +377,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
         Command::Route(args) => match args.action {
             RouteAction::Status(args) => route_commands::run_status(args),
+            RouteAction::Proof(args) => route_proof_commands::run(args).await,
         },
 
         Command::Transport(args) => match args.action {

--- a/crates/airc-cli/src/route_cli.rs
+++ b/crates/airc-cli/src/route_cli.rs
@@ -10,6 +10,8 @@ pub struct RouteArgs {
 pub enum RouteAction {
     /// Show route candidates and policy decisions.
     Status(RouteStatusArgs),
+    /// Execute a route proof and print a machine-readable JSON report.
+    Proof(RouteProofArgs),
 }
 
 #[derive(Debug, Args)]
@@ -34,6 +36,25 @@ pub struct RouteStatusArgs {
     /// `lan-tcp:direct` or `gh-gist:rendezvous`.
     #[arg(long = "down")]
     pub down: Vec<RouteHealthOverride>,
+}
+
+#[derive(Debug, Args)]
+pub struct RouteProofArgs {
+    /// Which proof to run.
+    #[arg(long, value_enum, default_value_t = RouteProofKind::RelayLoopback)]
+    pub kind: RouteProofKind,
+
+    /// Deadline for the command-bus round trip.
+    #[arg(long, default_value_t = 3000)]
+    pub timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum RouteProofKind {
+    /// Two independent homes exchange a request/reply over TLS LAN-TCP on loopback.
+    LanLoopback,
+    /// Two independent homes exchange a request/reply through a local `airc-relay`.
+    RelayLoopback,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/crates/airc-cli/src/route_proof_commands.rs
+++ b/crates/airc-cli/src/route_proof_commands.rs
@@ -44,6 +44,8 @@ struct RouteProofReport {
 async fn proof_lan_loopback(
     timeout: Duration,
 ) -> Result<RouteProofReport, Box<dyn std::error::Error>> {
+    ensure_crypto_provider();
+
     let proof = ProofHomes::new("lan-loopback")?;
     let alice = Airc::open(&proof.alice_home).await?;
     let bob = Airc::open(&proof.bob_home).await?;

--- a/crates/airc-cli/src/route_proof_commands.rs
+++ b/crates/airc-cli/src/route_proof_commands.rs
@@ -1,0 +1,286 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use airc_core::{Body, Headers, MentionTarget, PeerId};
+use airc_lib::{
+    Airc, PeerSpec, TransportHealthSample, TransportHealthState, TransportKind, TransportRole,
+};
+use airc_protocol::{
+    PeerKeyRegistry, PeerKeypair, HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_REPLY_TO,
+};
+use airc_relay::{RelayServer, RelayServerConfig};
+use futures::StreamExt;
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::route_cli::{RouteProofArgs, RouteProofKind};
+
+pub async fn run(args: RouteProofArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let timeout = Duration::from_millis(args.timeout_ms);
+    let report = match args.kind {
+        RouteProofKind::LanLoopback => proof_lan_loopback(timeout).await?,
+        RouteProofKind::RelayLoopback => proof_relay_loopback(timeout).await?,
+    };
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct RouteProofReport {
+    proof: &'static str,
+    transport: &'static str,
+    status: &'static str,
+    github_routine_traffic: bool,
+    alice_peer_id: String,
+    bob_peer_id: String,
+    relay_peer_id: Option<String>,
+    relay_addr: Option<String>,
+    correlation_id: String,
+    reply_body: String,
+    elapsed_ms: u128,
+}
+
+async fn proof_lan_loopback(
+    timeout: Duration,
+) -> Result<RouteProofReport, Box<dyn std::error::Error>> {
+    let proof = ProofHomes::new("lan-loopback")?;
+    let alice = Airc::open(&proof.alice_home).await?;
+    let bob = Airc::open(&proof.bob_home).await?;
+    enrol_pair(&alice, &bob).await?;
+
+    alice.join("route-proof-lan").await?;
+    bob.join("route-proof-lan").await?;
+
+    let bob_addr = bob
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await?;
+    alice.connect_lan(bob_addr, bob.peer_id()).await?;
+    let handler = spawn_reply_handler(bob.clone(), "route.proof.lan.result");
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let start = Instant::now();
+    let reply = issue_ping(&alice, timeout, "route.proof.lan.ping", "lan-ping").await?;
+    join_reply_handler(handler).await?;
+
+    Ok(RouteProofReport {
+        proof: "lan-loopback",
+        transport: "lan-tcp",
+        status: "ok",
+        github_routine_traffic: false,
+        alice_peer_id: alice.peer_id().to_string(),
+        bob_peer_id: bob.peer_id().to_string(),
+        relay_peer_id: None,
+        relay_addr: Some(bob_addr.to_string()),
+        correlation_id: reply.correlation_id.to_string(),
+        reply_body: reply.body,
+        elapsed_ms: start.elapsed().as_millis(),
+    })
+}
+
+async fn proof_relay_loopback(
+    timeout: Duration,
+) -> Result<RouteProofReport, Box<dyn std::error::Error>> {
+    ensure_crypto_provider();
+
+    let proof = ProofHomes::new("relay-loopback")?;
+    let alice = Airc::open(&proof.alice_home).await?;
+    let bob = Airc::open(&proof.bob_home).await?;
+    let (alice_spec, bob_spec) = enrol_pair(&alice, &bob).await?;
+
+    let relay_peer = PeerId::new();
+    let relay_keypair = PeerKeypair::generate();
+    let relay_spec = PeerSpec {
+        peer_id: relay_peer,
+        pubkey: relay_keypair.public_bytes(),
+    };
+    alice.add_peer(relay_spec.clone()).await?;
+    bob.add_peer(relay_spec).await?;
+
+    alice.join("route-proof-relay").await?;
+    bob.join("route-proof-relay").await?;
+
+    let server_registry = std::sync::Arc::new(PeerKeyRegistry::new());
+    server_registry.enrol(alice_spec.peer_id, 0, alice_spec.pubkey)?;
+    server_registry.enrol(bob_spec.peer_id, 0, bob_spec.pubkey)?;
+    let relay = RelayServer::start(RelayServerConfig {
+        peer_id: relay_peer,
+        keypair: relay_keypair,
+        registry: server_registry,
+        bind: SocketAddr::from(([127, 0, 0, 1], 0)),
+    })
+    .await?;
+    let relay_addr = relay.local_addr();
+
+    alice.connect_relay(relay_addr, relay_peer).await?;
+    bob.connect_relay(relay_addr, relay_peer).await?;
+    wait_for_relay_peers(&relay, &[alice.peer_id(), bob.peer_id()]).await?;
+
+    let relay_only = [TransportHealthSample {
+        kind: TransportKind::Relay,
+        role: TransportRole::Relay,
+        state: TransportHealthState::Healthy,
+        rtt_ms: None,
+        success_ppm: None,
+    }];
+    alice.replace_transport_health(relay_only)?;
+    bob.replace_transport_health(relay_only)?;
+
+    let handler = spawn_reply_handler(bob.clone(), "route.proof.relay.result");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let start = Instant::now();
+    let reply = issue_ping(&alice, timeout, "route.proof.relay.ping", "relay-ping").await?;
+    join_reply_handler(handler).await?;
+    relay.shutdown();
+
+    Ok(RouteProofReport {
+        proof: "relay-loopback",
+        transport: "relay",
+        status: "ok",
+        github_routine_traffic: false,
+        alice_peer_id: alice.peer_id().to_string(),
+        bob_peer_id: bob.peer_id().to_string(),
+        relay_peer_id: Some(relay_peer.to_string()),
+        relay_addr: Some(relay_addr.to_string()),
+        correlation_id: reply.correlation_id.to_string(),
+        reply_body: reply.body,
+        elapsed_ms: start.elapsed().as_millis(),
+    })
+}
+
+struct ProofHomes {
+    root: PathBuf,
+    alice_home: PathBuf,
+    bob_home: PathBuf,
+}
+
+impl ProofHomes {
+    fn new(name: &str) -> Result<Self, std::io::Error> {
+        let root = std::env::temp_dir().join(format!("airc-route-proof-{name}-{}", Uuid::new_v4()));
+        let alice_home = root.join("alice/.airc");
+        let bob_home = root.join("bob/.airc");
+        std::fs::create_dir_all(&alice_home)?;
+        std::fs::create_dir_all(&bob_home)?;
+        Ok(Self {
+            root,
+            alice_home,
+            bob_home,
+        })
+    }
+}
+
+impl Drop for ProofHomes {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+struct ProofReply {
+    correlation_id: Uuid,
+    body: String,
+}
+
+async fn enrol_pair(
+    alice: &Airc,
+    bob: &Airc,
+) -> Result<(PeerSpec, PeerSpec), Box<dyn std::error::Error>> {
+    let alice_spec = alice.peer_spec().parse::<PeerSpec>()?;
+    let bob_spec = bob.peer_spec().parse::<PeerSpec>()?;
+    alice.add_peer(bob_spec.clone()).await?;
+    bob.add_peer(alice_spec.clone()).await?;
+    Ok((alice_spec, bob_spec))
+}
+
+fn spawn_reply_handler(
+    responder: Airc,
+    result_hint: &'static str,
+) -> tokio::task::JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>> {
+    tokio::spawn(async move {
+        let mut stream = responder.subscribe().await?;
+        while let Some(next) = stream.next().await {
+            let event = next?;
+            if event.peer_id == responder.peer_id() {
+                continue;
+            }
+            let Some(correlation) = event.headers.get(HEADER_AIRC_CORRELATION_ID) else {
+                continue;
+            };
+            let Some(reply_to) = event.headers.get(HEADER_AIRC_REPLY_TO) else {
+                continue;
+            };
+            let correlation_id = Uuid::parse_str(correlation)?;
+            let reply_to_peer = PeerId::from_uuid(Uuid::parse_str(reply_to)?);
+            let mut headers = Headers::new();
+            headers.insert("forge.body_hint".into(), result_hint.into());
+            responder
+                .reply(
+                    reply_to_peer,
+                    correlation_id,
+                    headers,
+                    Body::text("route-proof-pong"),
+                )
+                .await?;
+            return Ok(());
+        }
+        Err("reply handler stream ended before request arrived".into())
+    })
+}
+
+async fn join_reply_handler(
+    handler: tokio::task::JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    handler
+        .await
+        .map_err(|error| format!("reply handler join failed: {error}"))?
+        .map_err(|error| error.to_string().into())
+}
+
+async fn issue_ping(
+    requester: &Airc,
+    timeout: Duration,
+    command_kind: &str,
+    body: &str,
+) -> Result<ProofReply, Box<dyn std::error::Error>> {
+    let mut headers = Headers::new();
+    headers.insert("airc.command_kind".into(), command_kind.into());
+    let pending = requester
+        .request(MentionTarget::All, headers, Body::text(body), timeout)
+        .await?;
+    let correlation_id = pending.correlation_id;
+    let reply = requester.await_reply(pending).await?;
+    let body = reply
+        .body
+        .as_ref()
+        .and_then(Body::as_text)
+        .unwrap_or("")
+        .to_string();
+    Ok(ProofReply {
+        correlation_id,
+        body,
+    })
+}
+
+async fn wait_for_relay_peers(
+    relay: &RelayServer,
+    expected: &[PeerId],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let connected = relay.connected_peers().await;
+        if expected.iter().all(|peer| connected.contains(peer)) {
+            return Ok(());
+        }
+        if Instant::now() > deadline {
+            return Err(format!(
+                "timeout waiting for relay peers; expected {expected:?}, connected {connected:?}"
+            )
+            .into());
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+fn ensure_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}

--- a/crates/airc-cli/tests/route_commands.rs
+++ b/crates/airc-cli/tests/route_commands.rs
@@ -2,6 +2,8 @@
 
 use std::process::Command;
 
+use serde_json::Value;
+
 fn airc_core() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
 }
@@ -48,6 +50,53 @@ fn route_status_down_override_removes_candidate() {
 
     assert!(output.contains("- local-fs role=direct state=down"));
     assert!(output.contains("- data-interactive -> no-route"));
+}
+
+#[test]
+fn route_proof_lan_loopback_outputs_machine_readable_report() {
+    let output = run_ok(&[
+        "route",
+        "proof",
+        "--kind",
+        "lan-loopback",
+        "--timeout-ms",
+        "3000",
+    ]);
+    let report: Value = serde_json::from_str(&output).expect("route proof output must be JSON");
+
+    assert_eq!(report["proof"], "lan-loopback");
+    assert_eq!(report["transport"], "lan-tcp");
+    assert_eq!(report["status"], "ok");
+    assert_eq!(report["github_routine_traffic"], false);
+    assert_eq!(report["reply_body"], "route-proof-pong");
+    assert!(report["correlation_id"]
+        .as_str()
+        .is_some_and(|id| !id.is_empty()));
+}
+
+#[test]
+fn route_proof_relay_loopback_outputs_machine_readable_report() {
+    let output = run_ok(&[
+        "route",
+        "proof",
+        "--kind",
+        "relay-loopback",
+        "--timeout-ms",
+        "3000",
+    ]);
+    let report: Value = serde_json::from_str(&output).expect("route proof output must be JSON");
+
+    assert_eq!(report["proof"], "relay-loopback");
+    assert_eq!(report["transport"], "relay");
+    assert_eq!(report["status"], "ok");
+    assert_eq!(report["github_routine_traffic"], false);
+    assert_eq!(report["reply_body"], "route-proof-pong");
+    assert!(report["relay_peer_id"]
+        .as_str()
+        .is_some_and(|id| !id.is_empty()));
+    assert!(report["relay_addr"]
+        .as_str()
+        .is_some_and(|addr| !addr.is_empty()));
 }
 
 fn run_ok(args: &[&str]) -> String {

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -752,8 +752,12 @@ through the command-bus over LAN-TCP without GitHub.
 **Cross-cutting substrate gaps still open**:
 
 - **Real-machine tailnet/relay proof.** Same-machine LAN/relay is
-  proven via the consumer-shapes fixture, but multi-host Tailnet
-  routing is still aspirational. Tracked as work card c877e142.
+  proven via the consumer-shapes fixture. The first route-proof
+  command surface now exists (`airc route proof --kind lan-loopback`
+  and `airc route proof --kind relay-loopback`) and emits structured
+  JSON with `github_routine_traffic=false`, giving CI/agents a stable
+  proof contract that does not parse prose. Multi-host Tailnet
+  execution remains the open field proof for card c877e142.
 - **AR pose-stream contract benchmark.** The WebRTC media stack
   (#955/#957/#960/#961/#962/#963) ships the full transport story.
   The 60-90Hz × sub-25ms p99 *contract benchmark* is partially
@@ -855,6 +859,11 @@ leave actual closure to lane 4d843eda — issue/PR hygiene):
      the same typed surface.
 3. Add real-machine tailnet/relay proof that exercises the same route
    execution across host boundaries without GitHub routine traffic.
+   - First slice: `airc route proof` runs LAN-TCP and relay loopback
+     request/reply proofs from the public CLI and prints JSON only.
+     This gives agents/CI a stable command contract and keeps GitHub
+     out of routine traffic. Follow-up: run the same proof against a
+     second physical/Tailnet host and record the report.
 4. Add a consumer-throughput proof for Continuum-shaped live traffic:
    synthetic room producers at configurable Hz, subscribers in separate
    scopes first and separate Tailnet/LAN hosts next, with p50/p99


### PR DESCRIPTION
## Summary
- add `airc route proof` with LAN-TCP and relay loopback proof modes
- emit structured JSON reports with `github_routine_traffic=false` for agent/CI consumption
- split proof execution into `route_proof_commands` so route status stays small
- update `GRID-SUBSTRATE-AUDIT.md` Phase 5 / Immediate PR Queue with the proof-contract slice and remaining real-host follow-up

Closes part of work card `c877e142` (real-machine Tailnet/relay proof): this PR lands the reusable proof command contract; the remaining step is running the same shape against a second physical/Tailnet host.

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-cli --check`
- `cargo test --manifest-path Cargo.toml -p airc-cli --test route_commands -- --nocapture`
- `cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- route proof --kind lan-loopback`
- `cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- route proof --kind relay-loopback`
- `cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings`
- `git diff --check`