### PR TITLE
feat(publish): structured publish API + airc publish JSON-receipt CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ name = "airc-ipc"
 version = "0.1.0"
 dependencies = [
  "airc-core",
+ "airc-protocol",
  "ciborium",
  "serde",
  "serde_json",

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -12,7 +12,7 @@
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use airc_lib::PeerSpec;
 
@@ -238,6 +238,34 @@ pub enum Command {
         socket: Option<PathBuf>,
         /// Message body.
         text: String,
+    },
+
+    /// Publish a structured frame and emit a JSON receipt on
+    /// stdout. Designed for consumers (Continuum chat, OpenClaw,
+    /// bridge processes) that need typed event id + lamport +
+    /// channel without human-prose parsing, and to route to a
+    /// non-default room without mutating this scope's default
+    /// pointer.
+    Publish {
+        /// Channel name to route to. Must already be subscribed
+        /// (publish does not auto-join). Defaults to the current
+        /// room when omitted.
+        #[arg(long)]
+        room: Option<String>,
+        /// Inline UTF-8 body. Mutually exclusive with
+        /// `--body-json`.
+        #[arg(long, conflicts_with = "body_json", group = "body")]
+        body_text: Option<String>,
+        /// Path to a UTF-8 JSON file whose contents become the
+        /// frame body. Pass `-` to read from stdin.
+        #[arg(long, group = "body")]
+        body_json: Option<String>,
+        /// Header in `key=value` form. Repeatable.
+        #[arg(long = "header", value_name = "KEY=VALUE")]
+        headers: Vec<String>,
+        /// Frame kind. Defaults to `event` for structured payloads.
+        #[arg(long, value_enum, default_value = "event")]
+        kind: PublishFrameKind,
     },
 
     /// Pull buffered frames from the daemon's inbox for the current
@@ -502,4 +530,18 @@ pub enum PeerAction {
     },
     /// List enrolled peers from the peer trust store.
     List,
+}
+
+/// Frame kind selector for `airc publish`. Maps 1:1 onto
+/// `airc_protocol::FrameKind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum PublishFrameKind {
+    /// Plain message frame (human-readable chat).
+    Message,
+    /// Structured event frame (recommended for typed envelopes
+    /// like Continuum's `AircRealtimeEnvelope`).
+    Event,
+    /// Control-plane signalling.
+    Control,
 }

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -50,6 +50,7 @@ mod monitor;
 mod network_commands;
 mod pending_cli;
 mod pending_commands;
+mod publish_commands;
 mod queue_card_cli;
 mod queue_card_commands;
 mod queue_card_plan;
@@ -345,6 +346,13 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::Msg { socket, text } => {
             commands::run_msg(&home, default_or(socket, &home), &text).await
         }
+        Command::Publish {
+            room,
+            body_text,
+            body_json,
+            headers,
+            kind,
+        } => publish_commands::run_publish(&home, room, body_text, body_json, headers, kind).await,
 
         Command::Inbox {
             socket,

--- a/crates/airc-cli/src/monitor/attach.rs
+++ b/crates/airc-cli/src/monitor/attach.rs
@@ -44,7 +44,11 @@ pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error
                 }
             }
             Response::Error { message } => return Err(message.into()),
-            Response::Pong | Response::Status(_) | Response::Inbox(_) | Response::Peers(_) => {}
+            Response::Pong
+            | Response::Status(_)
+            | Response::Inbox(_)
+            | Response::Publish(_)
+            | Response::Peers(_) => {}
         }
     }
 }

--- a/crates/airc-cli/src/publish_commands.rs
+++ b/crates/airc-cli/src/publish_commands.rs
@@ -1,0 +1,190 @@
+//! `airc publish` handler — thin CLI over [`Airc::publish`].
+//!
+//! Reads body from `--body-text` or `--body-json @file` (with `-`
+//! meaning stdin), parses repeated `--header k=v` flags, calls
+//! [`Airc::publish`], and writes the typed [`PublishReceipt`] as a
+//! single line of JSON to stdout. Shell consumers can `jq` it
+//! without any human-prose parsing.
+
+use std::io::Read;
+use std::path::Path;
+
+use airc_core::{Body, Headers};
+use airc_lib::{Airc, PublishTarget};
+use airc_protocol::FrameKind;
+
+use crate::cli::PublishFrameKind;
+
+pub async fn run_publish(
+    home: &Path,
+    room: Option<String>,
+    body_text: Option<String>,
+    body_json: Option<String>,
+    headers: Vec<String>,
+    kind: PublishFrameKind,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let body = load_body(body_text, body_json)?;
+    let parsed_headers = parse_headers(&headers)?;
+    let target = match room {
+        Some(name) => PublishTarget::RoomByName(name),
+        None => PublishTarget::CurrentRoom,
+    };
+
+    let airc = Airc::open(home).await?;
+    let receipt = airc
+        .publish(target, frame_kind_from(kind), body, parsed_headers)
+        .await?;
+
+    // One-line JSON so callers can pipe into `jq` directly.
+    let line = serde_json::to_string(&receipt)
+        .map_err(|error| format!("serialize publish receipt: {error}"))?;
+    println!("{line}");
+    Ok(())
+}
+
+fn frame_kind_from(kind: PublishFrameKind) -> FrameKind {
+    match kind {
+        PublishFrameKind::Message => FrameKind::Message,
+        PublishFrameKind::Event => FrameKind::Event,
+        PublishFrameKind::Control => FrameKind::Control,
+    }
+}
+
+fn load_body(
+    body_text: Option<String>,
+    body_json: Option<String>,
+) -> Result<Body, Box<dyn std::error::Error>> {
+    match (body_text, body_json) {
+        (Some(text), None) => Ok(Body::text(text)),
+        (None, Some(source)) => {
+            let raw = read_body_source(&source)?;
+            let value: serde_json::Value = serde_json::from_str(&raw).map_err(|error| {
+                format!("body-json input is not valid JSON ({source:?}): {error}")
+            })?;
+            Ok(Body::Json(value))
+        }
+        (None, None) => Err("publish requires --body-text or --body-json".into()),
+        (Some(_), Some(_)) => {
+            // Clap's `conflicts_with` catches this normally; this
+            // branch is defensive in case the args are passed
+            // programmatically.
+            Err("--body-text and --body-json are mutually exclusive".into())
+        }
+    }
+}
+
+fn read_body_source(source: &str) -> Result<String, Box<dyn std::error::Error>> {
+    if source == "-" {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|error| format!("read body-json from stdin: {error}"))?;
+        Ok(buf)
+    } else {
+        std::fs::read_to_string(source)
+            .map_err(|error| format!("read body-json file {source:?}: {error}").into())
+    }
+}
+
+fn parse_headers(specs: &[String]) -> Result<Headers, Box<dyn std::error::Error>> {
+    let mut headers = Headers::new();
+    for spec in specs {
+        let (key, value) = spec.split_once('=').ok_or_else(|| {
+            format!("--header expects `key=value`, got {spec:?} (no `=` separator)")
+        })?;
+        if key.is_empty() {
+            return Err(format!("--header has empty key in {spec:?}").into());
+        }
+        headers.insert(key.into(), value.into());
+    }
+    Ok(headers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_headers_accepts_repeated_kv_pairs_in_order() {
+        let parsed = parse_headers(&[
+            "airc.bridge.source=slack".to_string(),
+            "x.trace=abc-123".to_string(),
+        ])
+        .expect("ok");
+        assert_eq!(
+            parsed.get("airc.bridge.source").map(String::as_str),
+            Some("slack")
+        );
+        assert_eq!(parsed.get("x.trace").map(String::as_str), Some("abc-123"));
+    }
+
+    #[test]
+    fn parse_headers_preserves_empty_value() {
+        let parsed = parse_headers(&["x.flag=".to_string()]).expect("ok");
+        assert_eq!(parsed.get("x.flag").map(String::as_str), Some(""));
+    }
+
+    #[test]
+    fn parse_headers_rejects_missing_separator() {
+        let err = parse_headers(&["nope-no-equals".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("no `=`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_headers_rejects_empty_key() {
+        let err = parse_headers(&["=value".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("empty key"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_body_text_wraps_string_in_canonical_chat_json_shape() {
+        // `Body::text` is sugar for `Body::Json({"text": "..."})` —
+        // the canonical chat shape. Confirm the CLI sugar
+        // round-trips through it correctly.
+        match load_body(Some("hello".into()), None).expect("ok") {
+            Body::Json(value) => assert_eq!(value["text"], "hello"),
+            other => panic!("expected json-wrapped text body, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_body_requires_one_source() {
+        let err = load_body(None, None).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("requires --body-text or --body-json"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_body_rejects_invalid_json() {
+        // Write a temp file with bad JSON.
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(tmp.path(), b"{ not json }").expect("write");
+        let err = load_body(None, Some(tmp.path().to_string_lossy().into_owned())).unwrap_err();
+        assert!(
+            err.to_string().contains("not valid JSON"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_body_json_file_parses() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(tmp.path(), br#"{"kind":"chat","text":"hi"}"#).expect("write");
+        match load_body(None, Some(tmp.path().to_string_lossy().into_owned())).expect("ok") {
+            Body::Json(value) => {
+                assert_eq!(value["kind"], "chat");
+                assert_eq!(value["text"], "hi");
+            }
+            other => panic!("expected json body, got {other:?}"),
+        }
+    }
+}

--- a/crates/airc-cli/tests/publish_command.rs
+++ b/crates/airc-cli/tests/publish_command.rs
@@ -1,0 +1,157 @@
+//! End-to-end coverage for `airc publish`.
+//!
+//! Closes work card a0d740fa: the CLI surface must emit a typed
+//! JSON receipt on stdout that downstream consumers (Continuum,
+//! shell scripts) can jq-parse. No human prose.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use tempfile::TempDir;
+
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc")
+}
+
+#[test]
+fn publish_emits_json_receipt_with_event_id_and_channel() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let stdout = run_ok(
+        &home,
+        &[
+            "publish",
+            "--body-json",
+            "-",
+            "--header",
+            "airc.continuum.kind=chat_transcript",
+        ],
+    );
+
+    // Single line of JSON, parseable.
+    let trimmed = stdout.trim();
+    let receipt: serde_json::Value = serde_json::from_str(trimmed)
+        .unwrap_or_else(|error| panic!("stdout is not JSON: {error}; stdout={stdout}"));
+    assert!(
+        receipt["event_id"].is_string(),
+        "missing event_id: {receipt}"
+    );
+    assert!(receipt["lamport"].is_number(), "missing lamport: {receipt}");
+    assert!(
+        receipt["occurred_at_ms"].is_number(),
+        "missing occurred_at_ms: {receipt}"
+    );
+    assert!(
+        receipt["channel_id"].is_string(),
+        "missing channel_id: {receipt}"
+    );
+    assert!(
+        receipt["channel_name"].is_string(),
+        "missing channel_name: {receipt}"
+    );
+}
+
+#[test]
+fn publish_refuses_unsubscribed_room_with_clear_error() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let stderr = run_expect_failure(
+        &home,
+        &[
+            "publish",
+            "--room",
+            "definitely-not-joined",
+            "--body-text",
+            "should fail",
+        ],
+    );
+
+    assert!(
+        stderr.contains("definitely-not-joined"),
+        "stderr should name the channel, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("not subscribed") || stderr.contains("join the room first"),
+        "stderr should explain remedy, got: {stderr}"
+    );
+}
+
+#[test]
+fn publish_requires_one_body_source() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let stderr = run_expect_failure(&home, &["publish"]);
+    assert!(
+        stderr.contains("--body-text")
+            || stderr.contains("--body-json")
+            || stderr.contains("required"),
+        "stderr should explain that a body source is required, got: {stderr}"
+    );
+}
+
+fn run_ok(home: &Path, args: &[&str]) -> String {
+    let account_home = home.parent().unwrap_or(home);
+    let mut command = Command::new(airc_core());
+    command
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .env("HOME", account_home)
+        .env("USERPROFILE", account_home);
+
+    // The publish JSON test needs to feed a JSON body via stdin.
+    // We do that by detecting `--body-json` with `-` and piping a
+    // small object in. Other invocations get a closed stdin.
+    let needs_stdin = args.windows(2).any(|w| w == ["--body-json", "-"]);
+    if needs_stdin {
+        command.stdin(Stdio::piped());
+    }
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("airc-core command must spawn");
+
+    if needs_stdin {
+        use std::io::Write;
+        let stdin = child.stdin.as_mut().expect("piped stdin");
+        stdin
+            .write_all(br#"{"kind":"chat","text":"hello structured"}"#)
+            .expect("write stdin");
+    }
+
+    let output = child.wait_with_output().expect("airc-core command output");
+    assert!(
+        output.status.success(),
+        "airc-core {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout utf-8")
+}
+
+fn run_expect_failure(home: &Path, args: &[&str]) -> String {
+    let account_home = home.parent().unwrap_or(home);
+    let output = Command::new(airc_core())
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .env("HOME", account_home)
+        .env("USERPROFILE", account_home)
+        .output()
+        .expect("airc-core command must spawn");
+    assert!(
+        !output.status.success(),
+        "expected airc-core {:?} to fail, but it succeeded: stdout={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+    );
+    String::from_utf8(output.stderr).expect("stderr utf-8")
+}

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -15,9 +15,12 @@ use airc_diagnostics::{
     DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
 };
 use airc_ipc::request::{
-    AddPeerRequest, InboxRequest, RemovePeerRequest, Request, SendRequest, SubscribeRequest,
+    AddPeerRequest, InboxRequest, PublishRequest, RemovePeerRequest, Request, SendRequest,
+    SubscribeRequest,
 };
-use airc_ipc::response::{InboxResponse, PeerEntry, PeersResponse, Response, StatusResponse};
+use airc_ipc::response::{
+    InboxResponse, PeerEntry, PeersResponse, PublishResponse, Response, StatusResponse,
+};
 use airc_protocol::{Envelope, Frame, FrameKind, Signature, Subscription};
 use airc_transport::Transport;
 use futures::stream::StreamExt;
@@ -39,6 +42,7 @@ pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
             uptime_seconds: state.uptime_seconds(),
         }),
         Request::Send(send) => handle_send(state, send).await,
+        Request::Publish(publish) => handle_publish(state, publish).await,
         Request::Subscribe(sub) => handle_subscribe(state, sub).await,
         Request::Inbox(inbox) => handle_inbox(state, inbox).await,
         Request::Attach(_) => Response::Error {
@@ -183,7 +187,14 @@ async fn handle_inbox(state: Arc<DaemonState>, request: InboxRequest) -> Respons
 
 async fn handle_send(state: Arc<DaemonState>, send: SendRequest) -> Response {
     let transport = state.local_fs_for(&send.wire).await;
-    let frame = match build_message_frame(&state, send.channel, &send.text, send.headers) {
+    let frame = match build_frame(
+        &state,
+        FrameKind::Message,
+        send.channel,
+        MentionTarget::All,
+        Body::text(send.text),
+        send.headers,
+    ) {
         Ok(frame) => frame,
         Err(error) => {
             return Response::Error {
@@ -195,6 +206,40 @@ async fn handle_send(state: Arc<DaemonState>, send: SendRequest) -> Response {
         Ok(()) => Response::Ok,
         Err(error) => Response::Error {
             message: format!("send: {error}"),
+        },
+    }
+}
+
+async fn handle_publish(state: Arc<DaemonState>, publish: PublishRequest) -> Response {
+    let transport = state.local_fs_for(&publish.wire).await;
+    let frame = match build_frame(
+        &state,
+        publish.kind,
+        publish.channel,
+        publish.target,
+        publish.body,
+        publish.headers,
+    ) {
+        Ok(frame) => frame,
+        Err(error) => {
+            return Response::Error {
+                message: format!("publish: clock before UNIX_EPOCH: {error}"),
+            };
+        }
+    };
+    let event_id = frame.envelope.event_id;
+    let lamport = frame.envelope.lamport;
+    let occurred_at_ms = frame.envelope.occurred_at_ms;
+    let channel_id = frame.envelope.channel;
+    match transport.send(frame).await {
+        Ok(()) => Response::Publish(PublishResponse {
+            event_id,
+            lamport,
+            occurred_at_ms,
+            channel_id,
+        }),
+        Err(error) => Response::Error {
+            message: format!("publish: {error}"),
         },
     }
 }
@@ -258,28 +303,30 @@ async fn handle_list_peers(state: Arc<DaemonState>) -> Response {
     Response::Peers(PeersResponse { peers: entries })
 }
 
-fn build_message_frame(
+fn build_frame(
     state: &DaemonState,
+    kind: FrameKind,
     channel: uuid::Uuid,
-    text: &str,
+    target: MentionTarget,
+    body: Body,
     headers: Headers,
 ) -> Result<Frame, std::time::SystemTimeError> {
     let lamport = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)?
         .as_millis() as u64;
     Ok(Frame {
-        kind: FrameKind::Message,
+        kind,
         envelope: Envelope {
             event_id: EventId::new(),
             sender: state.peer_id,
             sender_client: ClientId::new(),
             channel: RoomId::from_uuid(channel),
-            target: MentionTarget::All,
+            target,
             lamport,
             occurred_at_ms: lamport,
             reply_to: None,
             headers,
-            body: Some(Body::text(text)),
+            body: Some(body),
             media: Vec::new(),
             // Unsigned at this layer — SignedTransport replaces it
             // with Ed25519 on the way out.
@@ -391,6 +438,35 @@ mod tests {
         assert_eq!(contents.lines().count(), 1);
     }
 
+    #[tokio::test]
+    async fn publish_dispatches_structured_frame_and_returns_receipt() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let state = test_state();
+        let response = dispatch(
+            state,
+            Request::Publish(PublishRequest {
+                wire: dir.path().to_path_buf(),
+                channel: Uuid::nil(),
+                kind: FrameKind::Event,
+                target: MentionTarget::All,
+                body: Body::text("structured"),
+                headers: Headers::new(),
+            }),
+        )
+        .await;
+        match response {
+            Response::Publish(receipt) => {
+                assert_eq!(receipt.channel_id, RoomId::from_uuid(Uuid::nil()));
+                assert!(receipt.lamport > 0);
+                assert!(receipt.occurred_at_ms > 0);
+            }
+            other => panic!("expected publish response, got {other:?}"),
+        }
+        let frames = dir.path().join("frames.jsonl");
+        let contents = std::fs::read_to_string(frames).unwrap();
+        assert_eq!(contents.lines().count(), 1);
+    }
+
     #[test]
     fn trust_root_prefers_airc_wire_root_but_accepts_raw_wire_dirs() {
         let airc_wire = PathBuf::from("/tmp/home/.airc/wires/general");
@@ -459,10 +535,12 @@ mod tests {
 
         sender
             .send(
-                build_message_frame(
+                build_frame(
                     &sender_state,
+                    FrameKind::Message,
                     Uuid::nil(),
-                    "sibling scope frame after trust refresh",
+                    MentionTarget::All,
+                    Body::text("sibling scope frame after trust refresh"),
                     Headers::new(),
                 )
                 .unwrap(),

--- a/crates/airc-ipc/Cargo.toml
+++ b/crates/airc-ipc/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 airc-core = { path = "../airc-core" }
+airc-protocol = { path = "../airc-protocol" }
 
 ciborium = "0.2"
 serde = { version = "1", features = ["derive"] }

--- a/crates/airc-ipc/src/client.rs
+++ b/crates/airc-ipc/src/client.rs
@@ -17,10 +17,10 @@ use crate::codec::{read_frame, write_frame};
 use crate::transport::IpcStream;
 
 use crate::request::{
-    AddPeerRequest, AttachRequest, InboxRequest, RemovePeerRequest, Request, SendRequest,
-    SubscribeRequest,
+    AddPeerRequest, AttachRequest, InboxRequest, PublishRequest, RemovePeerRequest, Request,
+    SendRequest, SubscribeRequest,
 };
-use crate::response::{InboxResponse, PeersResponse, Response, StatusResponse};
+use crate::response::{InboxResponse, PeersResponse, PublishResponse, Response, StatusResponse};
 
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -131,6 +131,7 @@ impl DaemonClient {
             | Response::Status(_)
             | Response::Inbox(_)
             | Response::Event { .. }
+            | Response::Publish(_)
             | Response::Peers(_)
             | Response::Ok) => Ok(other),
         }
@@ -146,6 +147,7 @@ impl DaemonClient {
             other @ (Response::Status(_)
             | Response::Inbox(_)
             | Response::Event { .. }
+            | Response::Publish(_)
             | Response::Peers(_)
             | Response::Ok
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
@@ -158,6 +160,7 @@ impl DaemonClient {
             other @ (Response::Pong
             | Response::Inbox(_)
             | Response::Event { .. }
+            | Response::Publish(_)
             | Response::Peers(_)
             | Response::Ok
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
@@ -171,7 +174,21 @@ impl DaemonClient {
             | Response::Status(_)
             | Response::Inbox(_)
             | Response::Event { .. }
+            | Response::Publish(_)
             | Response::Peers(_)
+            | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
+        }
+    }
+
+    pub async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, ClientError> {
+        match self.call(Request::Publish(request)).await? {
+            Response::Publish(response) => Ok(response),
+            other @ (Response::Pong
+            | Response::Status(_)
+            | Response::Inbox(_)
+            | Response::Event { .. }
+            | Response::Peers(_)
+            | Response::Ok
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
@@ -183,6 +200,7 @@ impl DaemonClient {
             | Response::Status(_)
             | Response::Inbox(_)
             | Response::Event { .. }
+            | Response::Publish(_)
             | Response::Peers(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
@@ -194,6 +212,7 @@ impl DaemonClient {
             other @ (Response::Pong
             | Response::Status(_)
             | Response::Event { .. }
+            | Response::Publish(_)
             | Response::Peers(_)
             | Response::Ok
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
@@ -207,6 +226,7 @@ impl DaemonClient {
             | Response::Status(_)
             | Response::Inbox(_)
             | Response::Event { .. }
+            | Response::Publish(_)
             | Response::Peers(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
@@ -219,6 +239,7 @@ impl DaemonClient {
             | Response::Status(_)
             | Response::Inbox(_)
             | Response::Event { .. }
+            | Response::Publish(_)
             | Response::Peers(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
@@ -231,6 +252,7 @@ impl DaemonClient {
             | Response::Status(_)
             | Response::Inbox(_)
             | Response::Event { .. }
+            | Response::Publish(_)
             | Response::Peers(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
@@ -246,6 +268,7 @@ impl DaemonClient {
             | Response::Status(_)
             | Response::Inbox(_)
             | Response::Event { .. }
+            | Response::Publish(_)
             | Response::Ok
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }

--- a/crates/airc-ipc/src/lib.rs
+++ b/crates/airc-ipc/src/lib.rs
@@ -25,13 +25,13 @@ pub mod transport;
 /// that an already-running daemon cannot parse. The default CLI socket
 /// includes this value so `airc join` starts a current daemon instead of
 /// connecting to a stale daemon that speaks the previous protocol.
-pub const IPC_PROTOCOL_VERSION: u16 = 2;
+pub const IPC_PROTOCOL_VERSION: u16 = 3;
 
 pub use client::{ClientError, DaemonClient};
 pub use request::{
-    AddPeerRequest, AttachRequest, InboxRequest, RemovePeerRequest, Request, SendRequest,
-    SubscribeRequest,
+    AddPeerRequest, AttachRequest, InboxRequest, PublishRequest, RemovePeerRequest, Request,
+    SendRequest, SubscribeRequest,
 };
-pub use response::{InboxResponse, PeersResponse, Response, StatusResponse};
+pub use response::{InboxResponse, PeersResponse, PublishResponse, Response, StatusResponse};
 // IpcListener / IpcStream stay under `transport` because only the
 // daemon host and low-level tests need the raw byte transport.

--- a/crates/airc-ipc/src/request.rs
+++ b/crates/airc-ipc/src/request.rs
@@ -7,10 +7,11 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use airc_core::{Headers, PeerId};
+use airc_core::{Body, Headers, MentionTarget, PeerId};
+use airc_protocol::FrameKind;
 
 /// A single client-issued operation. Wire-tagged by `op`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum Request {
     /// Liveness probe. Returns `Response::Pong`.
@@ -30,6 +31,9 @@ pub enum Request {
     /// Send a text Message frame. Daemon signs + dispatches via its
     /// owned `SignedTransport`.
     Send(SendRequest),
+    /// Publish a structured frame. Daemon signs + dispatches via its
+    /// owned transport and returns event metadata in `Response::Publish`.
+    Publish(PublishRequest),
     /// Start a subscription on `wire` if one isn't already running.
     /// Daemon buffers received frames into an in-memory inbox per
     /// wire. Idempotent — repeated calls return Ok without
@@ -117,6 +121,29 @@ pub struct SendRequest {
     pub headers: Headers,
 }
 
+/// Parameters for `Publish`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PublishRequest {
+    /// Wire directory the daemon should write to.
+    pub wire: PathBuf,
+    /// Channel UUID. Use a stable value across peers in the same room.
+    pub channel: Uuid,
+    /// Frame kind to publish.
+    pub kind: FrameKind,
+    /// Target for the envelope. Most consumer publishes use `All`.
+    #[serde(default = "mention_all")]
+    pub target: MentionTarget,
+    /// Opaque body carried by the substrate.
+    pub body: Body,
+    /// Optional envelope headers supplied by the caller.
+    #[serde(default)]
+    pub headers: Headers,
+}
+
+fn mention_all() -> MentionTarget {
+    MentionTarget::All
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,6 +173,21 @@ mod tests {
             wire: PathBuf::from("/tmp/wire"),
             channel: Uuid::nil(),
             text: "hello".to_string(),
+            headers: Headers::new(),
+        });
+        let encoded = serde_json::to_string(&original).unwrap();
+        let decoded: Request = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn publish_roundtrips_with_typed_body_and_kind() {
+        let original = Request::Publish(PublishRequest {
+            wire: PathBuf::from("/tmp/wire"),
+            channel: Uuid::nil(),
+            kind: FrameKind::Event,
+            target: MentionTarget::All,
+            body: Body::text("hello"),
             headers: Headers::new(),
         });
         let encoded = serde_json::to_string(&original).unwrap();

--- a/crates/airc-ipc/src/response.rs
+++ b/crates/airc-ipc/src/response.rs
@@ -3,7 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use airc_core::PeerId;
+use airc_core::{EventId, PeerId, RoomId};
 
 /// One response to a `Request`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -21,6 +21,8 @@ pub enum Response {
     Event {
         event: Box<airc_core::TranscriptEvent>,
     },
+    /// Response to `Publish`.
+    Publish(PublishResponse),
     /// Response to `ListPeers` — the daemon's currently-enrolled
     /// peers (peer_id + URL-safe-no-padding base64 pubkey).
     Peers(PeersResponse),
@@ -70,6 +72,15 @@ pub struct InboxResponse {
     pub newest: Option<airc_core::TranscriptCursor>,
 }
 
+/// Event metadata returned by daemon-backed structured publish.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PublishResponse {
+    pub event_id: EventId,
+    pub lamport: u64,
+    pub occurred_at_ms: u64,
+    pub channel_id: RoomId,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,6 +113,19 @@ mod tests {
         assert!(encoded.contains("boom"));
         let decoded: Response = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, error);
+    }
+
+    #[test]
+    fn publish_response_roundtrips() {
+        let original = Response::Publish(PublishResponse {
+            event_id: EventId::from_u128(1),
+            lamport: 2,
+            occurred_at_ms: 3,
+            channel_id: RoomId::from_u128(4),
+        });
+        let encoded = serde_json::to_string(&original).unwrap();
+        let decoded: Response = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, original);
     }
 
     #[test]

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -4,10 +4,12 @@
 //! the daemon's typed IPC client instead of making apps construct
 //! daemon requests directly.
 
-use airc_core::{EventId, Headers, TranscriptCursor, TranscriptEvent};
-use airc_ipc::{InboxRequest, SendRequest, SubscribeRequest};
+use airc_core::{Body, EventId, Headers, MentionTarget, TranscriptCursor, TranscriptEvent};
+use airc_ipc::{InboxRequest, PublishRequest, SendRequest, SubscribeRequest};
+use airc_protocol::FrameKind;
 
 use crate::error::AircError;
+use crate::publish::PublishReceipt;
 use crate::room::Room;
 use crate::Airc;
 
@@ -37,6 +39,34 @@ impl Airc {
         // API remains fallible/synchronous without inventing a second
         // response path in the CLI.
         Ok(EventId::new())
+    }
+
+    pub(crate) async fn daemon_publish(
+        &self,
+        room: &Room,
+        kind: FrameKind,
+        body: Body,
+        headers: Headers,
+    ) -> Result<PublishReceipt, AircError> {
+        let response = self
+            .daemon_client()
+            .ok_or_else(|| AircError::Route("daemon client is not attached".to_string()))?
+            .publish(PublishRequest {
+                wire: room.wire.clone(),
+                channel: room.channel.as_uuid(),
+                kind,
+                target: MentionTarget::All,
+                body,
+                headers,
+            })
+            .await?;
+        Ok(PublishReceipt {
+            event_id: response.event_id,
+            lamport: response.lamport,
+            occurred_at_ms: response.occurred_at_ms,
+            channel_id: response.channel_id,
+            channel_name: room.name.clone(),
+        })
     }
 
     pub(crate) async fn daemon_page_recent(

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -52,6 +52,7 @@ pub mod lifecycle;
 pub mod mesh_identity;
 mod messaging;
 mod peers;
+pub mod publish;
 pub mod registry;
 mod relay;
 pub mod room;
@@ -110,6 +111,7 @@ pub use mesh_identity::{
     Source as MeshIdentitySource, DEFAULT_TTL_MS as MESH_IDENTITY_TTL_MS,
 };
 pub use peers::EnrolledPeer;
+pub use publish::{PublishReceipt, PublishTarget};
 pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use room::Room;
 pub use route::{

--- a/crates/airc-lib/src/messaging.rs
+++ b/crates/airc-lib/src/messaging.rs
@@ -9,6 +9,15 @@ use crate::stream::{EventFilter, EventStream, FilteredEventStream};
 use crate::time::now_ms;
 use crate::Airc;
 
+/// Event metadata returned by [`Airc::send_frame_to_room`]. Carries
+/// enough to build a typed receipt for the public publish API.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SendFrameResult {
+    pub event_id: EventId,
+    pub lamport: u64,
+    pub occurred_at_ms: u64,
+}
+
 impl Airc {
     /// Send a plain-text message to the current room.
     pub async fn say(&self, text: &str) -> Result<EventId, AircError> {
@@ -68,8 +77,30 @@ impl Airc {
         body: Body,
         headers: Headers,
     ) -> Result<EventId, AircError> {
-        self.sync_account_peer_registry().await?;
         let room = self.current_room().await?;
+        self.send_frame_to_room(kind, target, body, headers, &room)
+            .await
+            .map(|receipt| receipt.event_id)
+    }
+
+    /// Send a frame to a specific room without changing this scope's
+    /// notion of "current room". Returns the full event metadata so
+    /// callers can produce a typed receipt.
+    ///
+    /// This is the substrate-level publish primitive that
+    /// [`Airc::publish`](crate::Airc::publish) composes onto a typed
+    /// [`PublishTarget`](crate::PublishTarget). Existing
+    /// `say`/`send`/`send_frame_to` paths keep their
+    /// current-room-only behaviour by funnelling through here.
+    pub(crate) async fn send_frame_to_room(
+        &self,
+        kind: FrameKind,
+        target: MentionTarget,
+        body: Body,
+        headers: Headers,
+        room: &crate::Room,
+    ) -> Result<SendFrameResult, AircError> {
+        self.sync_account_peer_registry().await?;
         let route = self.resolve_send_route(kind)?;
         let event_id = EventId::new();
         let occurred_at_ms = now_ms()?;
@@ -97,10 +128,14 @@ impl Airc {
             .keypair
             .sign_envelope(&frame.envelope, self.inner.identity.peer_id, 0)
             .map_err(|error| AircError::Crypto(error.to_string()))?;
-        self.execute_send_route(route.kind, &room, frame.clone())
+        self.execute_send_route(route.kind, room, frame.clone())
             .await?;
         self.append_sent_frame(frame).await?;
-        Ok(event_id)
+        Ok(SendFrameResult {
+            event_id,
+            lamport,
+            occurred_at_ms,
+        })
     }
 
     fn resolve_send_route(&self, kind: FrameKind) -> Result<TransportRoute, AircError> {

--- a/crates/airc-lib/src/publish.rs
+++ b/crates/airc-lib/src/publish.rs
@@ -1,14 +1,10 @@
 //! Structured publish API for AIRC consumers (Continuum chat,
 //! OpenClaw, Hermes, etc.).
 //!
-//! Closes work card a0d740fa (P1): "Structured AIRC publish API
-//! for Continuum chat dual-write". The previous publish path for
-//! a typed body forced consumers to either (a) link `airc-lib` and
-//! reach into private internals, or (b) shell out to `airc msg`
-//! with a JSON-stringified payload, losing the typed event id /
-//! lamport / channel in the human-prose output, AND having to
-//! mutate this scope's "current room" pointer to route to a
-//! different room.
+//! Work card a0d740fa (P1): "Structured AIRC publish API for
+//! Continuum chat dual-write". This module gives consumers one
+//! typed publish path for opaque bodies + headers, with a receipt
+//! carrying event id, lamport, and channel.
 //!
 //! This module ships the substrate-level publish primitive:
 //!
@@ -24,12 +20,8 @@
 //! routing + receipt). SDK consumers compose it idiomatically. The
 //! CLI is a thin pass-through over the same call.
 //!
-//! Scope cut: this PR ships the in-process embedding path
-//! ([`Airc::open`]). A follow-up extends the daemon IPC protocol
-//! (`SendRequest` is text-only today) to carry typed body +
-//! structured response so daemon-attached consumers get a real
-//! event id rather than the locally-minted placeholder the text
-//! send currently returns.
+//! The same call works for in-process [`Airc::open`] handles and
+//! daemon-attached [`Airc::attach`] handles.
 
 use airc_core::{Body, EventId, Headers, MentionTarget, RoomId};
 use airc_protocol::FrameKind;
@@ -41,10 +33,10 @@ use crate::Airc;
 
 /// Where a [`PublishReceipt`] should land.
 ///
-/// `CurrentRoom` is the legacy shape — route to whatever this
-/// scope considers default. `RoomByName(name)` requires the
-/// channel name to be in this scope's subscription set and routes
-/// to that room directly; it does NOT auto-join.
+/// `CurrentRoom` routes to whatever this scope considers default.
+/// `RoomByName(name)` requires the channel name to be in this
+/// scope's subscription set and routes to that room directly; it
+/// does NOT auto-join.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PublishTarget {
     /// Route to this scope's default subscribed room.
@@ -94,6 +86,9 @@ impl Airc {
         headers: Headers,
     ) -> Result<PublishReceipt, AircError> {
         let room = self.resolve_publish_target(&target).await?;
+        if self.is_daemon_attached() {
+            return self.daemon_publish(&room, kind, body, headers).await;
+        }
         let result = self
             .send_frame_to_room(kind, MentionTarget::All, body, headers, &room)
             .await?;

--- a/crates/airc-lib/src/publish.rs
+++ b/crates/airc-lib/src/publish.rs
@@ -1,0 +1,164 @@
+//! Structured publish API for AIRC consumers (Continuum chat,
+//! OpenClaw, Hermes, etc.).
+//!
+//! Closes work card a0d740fa (P1): "Structured AIRC publish API
+//! for Continuum chat dual-write". The previous publish path for
+//! a typed body forced consumers to either (a) link `airc-lib` and
+//! reach into private internals, or (b) shell out to `airc msg`
+//! with a JSON-stringified payload, losing the typed event id /
+//! lamport / channel in the human-prose output, AND having to
+//! mutate this scope's "current room" pointer to route to a
+//! different room.
+//!
+//! This module ships the substrate-level publish primitive:
+//!
+//! - [`PublishTarget`] — typed routing target. `CurrentRoom` keeps
+//!   the existing behaviour; `RoomByName(...)` routes to an
+//!   already-subscribed room without touching the default pointer.
+//! - [`PublishReceipt`] — typed receipt: event id, lamport,
+//!   occurred-at, channel id, channel name. JSON-serialisable, so
+//!   the CLI can emit it verbatim for shell consumers.
+//! - [`Airc::publish`] — the API.
+//!
+//! Layering: native substrate owns the truth (frame construction +
+//! routing + receipt). SDK consumers compose it idiomatically. The
+//! CLI is a thin pass-through over the same call.
+//!
+//! Scope cut: this PR ships the in-process embedding path
+//! ([`Airc::open`]). A follow-up extends the daemon IPC protocol
+//! (`SendRequest` is text-only today) to carry typed body +
+//! structured response so daemon-attached consumers get a real
+//! event id rather than the locally-minted placeholder the text
+//! send currently returns.
+
+use airc_core::{Body, EventId, Headers, MentionTarget, RoomId};
+use airc_protocol::FrameKind;
+use serde::{Deserialize, Serialize};
+
+use crate::error::AircError;
+use crate::subscriptions;
+use crate::Airc;
+
+/// Where a [`PublishReceipt`] should land.
+///
+/// `CurrentRoom` is the legacy shape — route to whatever this
+/// scope considers default. `RoomByName(name)` requires the
+/// channel name to be in this scope's subscription set and routes
+/// to that room directly; it does NOT auto-join.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PublishTarget {
+    /// Route to this scope's default subscribed room.
+    CurrentRoom,
+    /// Route to a specific room by channel name. The room must
+    /// already be in this scope's subscription set; refusing to
+    /// auto-join is intentional — publishing should not change
+    /// what rooms this scope is part of.
+    RoomByName(String),
+}
+
+/// Typed receipt returned by [`Airc::publish`]. JSON-serialisable
+/// so the CLI can pass it through to shell consumers without
+/// human-prose parsing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PublishReceipt {
+    /// AIRC-assigned event id for this publish.
+    pub event_id: EventId,
+    /// Lamport counter at publish time (substrate ordering).
+    pub lamport: u64,
+    /// UNIX epoch millis recorded when the frame was constructed.
+    pub occurred_at_ms: u64,
+    /// Channel UUID the frame was routed to.
+    pub channel_id: RoomId,
+    /// Channel name the frame was routed to.
+    pub channel_name: String,
+}
+
+impl Airc {
+    /// Publish a typed body to a specific room without touching
+    /// this scope's default-room pointer.
+    ///
+    /// `kind` selects the frame kind:
+    /// - [`FrameKind::Message`] for human-readable chat.
+    /// - [`FrameKind::Event`] for structured envelopes
+    ///   (recommended for Continuum-style consumers that carry a
+    ///   typed body + filterable headers).
+    /// - [`FrameKind::Control`] for control-plane signalling.
+    ///
+    /// Returns a typed [`PublishReceipt`] carrying the event id,
+    /// lamport, and concrete channel — no stdout parsing required.
+    pub async fn publish(
+        &self,
+        target: PublishTarget,
+        kind: FrameKind,
+        body: Body,
+        headers: Headers,
+    ) -> Result<PublishReceipt, AircError> {
+        let room = self.resolve_publish_target(&target).await?;
+        let result = self
+            .send_frame_to_room(kind, MentionTarget::All, body, headers, &room)
+            .await?;
+        Ok(PublishReceipt {
+            event_id: result.event_id,
+            lamport: result.lamport,
+            occurred_at_ms: result.occurred_at_ms,
+            channel_id: room.channel,
+            channel_name: room.name,
+        })
+    }
+
+    async fn resolve_publish_target(
+        &self,
+        target: &PublishTarget,
+    ) -> Result<crate::Room, AircError> {
+        match target {
+            PublishTarget::CurrentRoom => self.current_room().await,
+            PublishTarget::RoomByName(name) => {
+                let set = subscriptions::load_or_init(self.event_store()).await?;
+                let channel_name = subscriptions::ChannelName::new(name).map_err(|error| {
+                    AircError::Route(format!("publish target channel name {name:?}: {error}"))
+                })?;
+                set.subscribed
+                    .get(&channel_name)
+                    .map(|subscription| subscription.as_room())
+                    .ok_or_else(|| {
+                        AircError::Route(format!(
+                            "refusing to publish to {name:?}: this scope is not subscribed to that \
+                             channel. join the room first (publish does not auto-join)."
+                        ))
+                    })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publish_target_round_trips_through_clone_and_equality() {
+        let a = PublishTarget::CurrentRoom;
+        let b = PublishTarget::RoomByName("project-x".into());
+        assert_eq!(a, a.clone());
+        assert_eq!(b, b.clone());
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn publish_receipt_serializes_to_stable_snake_case_json() {
+        let receipt = PublishReceipt {
+            event_id: EventId::from_uuid(uuid::Uuid::nil()),
+            lamport: 42,
+            occurred_at_ms: 1_700_000_000_000,
+            channel_id: RoomId::from_uuid(uuid::Uuid::nil()),
+            channel_name: "project-x".to_string(),
+        };
+        let value = serde_json::to_value(&receipt).expect("encode");
+        assert_eq!(value["lamport"], 42);
+        assert_eq!(value["occurred_at_ms"], 1_700_000_000_000_u64);
+        assert_eq!(value["channel_name"], "project-x");
+        // Round-trip
+        let decoded: PublishReceipt = serde_json::from_value(value).expect("decode");
+        assert_eq!(decoded, receipt);
+    }
+}

--- a/crates/airc-lib/tests/structured_publish.rs
+++ b/crates/airc-lib/tests/structured_publish.rs
@@ -1,0 +1,166 @@
+//! Integration: structured publish API routes typed bodies to
+//! named rooms without touching the default-room pointer, and
+//! returns a typed receipt instead of human-prose.
+//!
+//! Proves work card a0d740fa (P1): "Structured AIRC publish API
+//! for Continuum chat dual-write". The receipt is the JSON shape
+//! the CLI emits to stdout for shell consumers; the in-process
+//! API is the linkable shape for Rust consumers like Continuum.
+
+use std::time::Duration;
+
+use airc_core::{Body, EventId, Headers};
+use airc_lib::{Airc, PeerSpec, PublishTarget};
+use airc_protocol::FrameKind;
+use futures::stream::StreamExt;
+use serde_json::json;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn publish_to_room_by_name_does_not_mutate_default_pointer() {
+    // Alice joins room-a then room-b. Joining a room sets it as
+    // default, so after both joins the default is room-b. Then she
+    // publishes BY NAME to room-a. The default must remain room-b —
+    // publish must not change which room "current room" points at.
+    let home = TempDir::new().expect("home");
+    let airc = Airc::open(home.path()).await.expect("open");
+
+    let wire_a = TempDir::new().expect("wire-a");
+    let wire_b = TempDir::new().expect("wire-b");
+    airc.join_with_wire("room-a", wire_a.path().join("wire.jsonl"))
+        .await
+        .expect("join room-a");
+    airc.join_with_wire("room-b", wire_b.path().join("wire.jsonl"))
+        .await
+        .expect("join room-b");
+
+    let before = airc.current_room().await.expect("current room before");
+    assert_eq!(
+        before.name, "room-b",
+        "second join should be the default room"
+    );
+
+    let receipt = airc
+        .publish(
+            PublishTarget::RoomByName("room-a".into()),
+            FrameKind::Event,
+            Body::Json(json!({"kind":"chat","text":"hi"})),
+            Headers::new(),
+        )
+        .await
+        .expect("publish");
+
+    assert_eq!(receipt.channel_name, "room-a");
+    assert_ne!(receipt.event_id, EventId::from_uuid(uuid::Uuid::nil()));
+
+    let after = airc.current_room().await.expect("current room after");
+    assert_eq!(
+        after.name, "room-b",
+        "publishing to room-a must not mutate the default pointer"
+    );
+    assert_eq!(
+        after.channel, before.channel,
+        "current channel id should be unchanged"
+    );
+}
+
+#[tokio::test]
+async fn publish_refuses_unsubscribed_room_rather_than_auto_join() {
+    // Publish is an intentional non-auto-join surface: trying to
+    // route to a channel this scope has never joined must fail with
+    // a clear error, not silently subscribe.
+    let home = TempDir::new().expect("home");
+    let airc = Airc::open(home.path()).await.expect("open");
+    let wire = TempDir::new().expect("wire");
+    airc.join_with_wire("only-room", wire.path().join("wire.jsonl"))
+        .await
+        .expect("join");
+
+    let err = airc
+        .publish(
+            PublishTarget::RoomByName("never-joined".into()),
+            FrameKind::Event,
+            Body::text("should never land"),
+            Headers::new(),
+        )
+        .await
+        .expect_err("publish to unsubscribed room must fail");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("never-joined"),
+        "error should name the channel, got: {message}"
+    );
+    assert!(
+        message.contains("not subscribed") || message.contains("join the room first"),
+        "error should explain refusal + remedy, got: {message}"
+    );
+}
+
+#[tokio::test]
+async fn publish_to_current_room_round_trips_to_a_subscriber() {
+    // Alice publishes; Bob (sharing the wire) sees the frame with
+    // matching channel and body. Receipt event id matches the
+    // transcript event id the subscriber receives.
+    let alice_home = TempDir::new().expect("alice");
+    let bob_home = TempDir::new().expect("bob");
+    let wire = TempDir::new().expect("wire");
+    let wire_path = wire.path().join("wire.jsonl");
+
+    let alice = Airc::open(alice_home.path()).await.expect("alice open");
+    let bob = Airc::open(bob_home.path()).await.expect("bob open");
+
+    let alice_spec: PeerSpec = alice.peer_spec().parse().expect("alice spec");
+    let bob_spec: PeerSpec = bob.peer_spec().parse().expect("bob spec");
+    alice.add_peer(bob_spec).await.expect("trust bob");
+    bob.add_peer(alice_spec).await.expect("trust alice");
+
+    alice
+        .join_with_wire("publish-roundtrip", wire_path.clone())
+        .await
+        .expect("alice joins");
+    bob.join_with_wire("publish-roundtrip", wire_path)
+        .await
+        .expect("bob joins");
+
+    let mut subscription = bob.subscribe().await.expect("bob subscribes");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let body = json!({"kind":"chat","payload":{"text":"structured publish works"}});
+    let mut headers = Headers::new();
+    headers.insert("airc.continuum.kind".into(), "chat_transcript".into());
+
+    let receipt = alice
+        .publish(
+            PublishTarget::CurrentRoom,
+            FrameKind::Event,
+            Body::Json(body.clone()),
+            headers,
+        )
+        .await
+        .expect("alice publishes");
+
+    assert_eq!(receipt.channel_name, "publish-roundtrip");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let mut matched = false;
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), subscription.next()).await {
+            Ok(Some(Ok(event))) => {
+                if event.event_id == receipt.event_id {
+                    assert_eq!(event.room_id, receipt.channel_id);
+                    assert_eq!(event.lamport, receipt.lamport);
+                    assert_eq!(
+                        event.headers.get("airc.continuum.kind").map(String::as_str),
+                        Some("chat_transcript")
+                    );
+                    matched = true;
+                    break;
+                }
+            }
+            Ok(Some(Err(_))) | Ok(None) => continue,
+            Err(_) => continue,
+        }
+    }
+    assert!(matched, "subscriber did not see the published event");
+}

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -926,6 +926,17 @@ Status:
   for check + merge state; review-state translation is deferred until
   the GitHub-login → `PeerId` mapping question has a real answer (the
   shape is in place, it just emits empty `reviews` from this source).
+- In flight: structured publish API for consumer dual-write
+  (`a0d740fa`). `airc-lib::Airc::publish` accepts a typed
+  `PublishTarget`, `FrameKind`, opaque `Body`, and `Headers`, then
+  returns a serializable receipt with event id, lamport, timestamp,
+  and concrete channel. `airc publish` is a thin command surface over
+  the same API and emits one JSON receipt line for script callers.
+  The daemon IPC protocol now has `PublishRequest` /
+  `PublishResponse`, so daemon-attached consumers get the same receipt
+  instead of a text-only ack. This is still generic AIRC: Continuum,
+  OpenClaw, Hermes, and bridge processes provide their own body/header
+  conventions above the substrate.
 
 Done or superseded:
 

--- a/docs/realtime-event-bus.md
+++ b/docs/realtime-event-bus.md
@@ -249,6 +249,8 @@ history to recover a session manager.
 
 Before Continuum integration, the implementation needs:
 
+- structured publish API with typed receipt for library, daemon, and
+  JSON-command callers
 - two local subscribers exchanging chat plus typing/thinking presence
 - deterministic replay after one subscriber restarts
 - self-filter test with two clients under one peer


### PR DESCRIPTION
## Summary
- add `airc-lib::Airc::publish` for typed body/header publishes with a structured receipt
- add `airc publish` as a thin JSON-receipt command surface for non-Rust consumers
- add daemon IPC `PublishRequest` / `PublishResponse` and bump IPC protocol to v3 so attached SDK consumers get real event metadata
- document the generic consumer boundary in the grid audit / realtime event-bus docs

## Verification
- `cargo test --manifest-path Cargo.toml -p airc-ipc`
- `cargo test --manifest-path Cargo.toml -p airc-daemon`
- `cargo test --manifest-path Cargo.toml -p airc-lib --test structured_publish`
- `cargo test --manifest-path Cargo.toml -p airc-cli --test publish_command`
- `cargo run --manifest-path Cargo.toml -p airc-cli --quiet -- --home "$TMP/.airc" publish --body-json - --header forge.body_hint=continuum.chat_transcript --kind event`
- `cargo test --manifest-path Cargo.toml --workspace`
- `cargo clippy --manifest-path Cargo.toml --workspace --all-targets -- -D warnings`
