### PR TITLE
feat(events): add JSON list output

### DIFF
--- a/crates/airc-cli/src/events_cli.rs
+++ b/crates/airc-cli/src/events_cli.rs
@@ -24,6 +24,9 @@ pub enum EventsAction {
         /// Recent events to scan before filtering.
         #[arg(long, default_value_t = 128)]
         limit: usize,
+        /// Emit a machine-readable JSON object instead of human text.
+        #[arg(long)]
+        json: bool,
     },
 }
 

--- a/crates/airc-cli/src/events_commands.rs
+++ b/crates/airc-cli/src/events_commands.rs
@@ -3,8 +3,15 @@
 use std::path::Path;
 
 use airc_lib::{Airc, Body, EventFilter, HeaderFilter, TranscriptEvent, TranscriptKind};
+use serde::Serialize;
 
 use crate::events_cli::CliTranscriptKind;
+
+#[derive(Debug, Serialize)]
+struct EventsListJson<'a> {
+    count: usize,
+    events: &'a [TranscriptEvent],
+}
 
 pub async fn run_list(
     home: &Path,
@@ -12,6 +19,7 @@ pub async fn run_list(
     exact_headers: Vec<String>,
     prefix_headers: Vec<String>,
     limit: usize,
+    as_json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let airc = Airc::open(home).await?;
     let filter = EventFilter {
@@ -20,7 +28,22 @@ pub async fn run_list(
         ..EventFilter::default()
     };
     let events = airc.page_recent_subscribed_filtered(filter, limit).await?;
-    print_events(&events);
+    if as_json {
+        print_events_json(&events)?;
+    } else {
+        print_events(&events);
+    }
+    Ok(())
+}
+
+fn print_events_json(events: &[TranscriptEvent]) -> Result<(), serde_json::Error> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&EventsListJson {
+            count: events.len(),
+            events,
+        })?
+    );
     Ok(())
 }
 

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -402,7 +402,8 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 header,
                 header_prefix,
                 limit,
-            } => events_commands::run_list(&home, kind, header, header_prefix, limit).await,
+                json,
+            } => events_commands::run_list(&home, kind, header, header_prefix, limit, json).await,
         },
 
         Command::Gist(args) => match args.action {

--- a/crates/airc-cli/tests/events_commands.rs
+++ b/crates/airc-cli/tests/events_commands.rs
@@ -1,7 +1,7 @@
 //! End-to-end coverage for `airc-core events ...`.
 
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use tempfile::TempDir;
 
@@ -47,6 +47,60 @@ fn events_list_filters_by_kind_and_header_prefix() {
 }
 
 #[test]
+fn events_list_json_emits_machine_readable_contract() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    run_ok(&home, &["send", "plain chat"]);
+    run_ok(
+        &home,
+        &[
+            "publish",
+            "--kind",
+            "message",
+            "--body-json",
+            "-",
+            "--header",
+            "forge.body_hint=continuum.chat_transcript",
+            "--header",
+            "continuum.trace_id=smoke-trace",
+        ],
+    );
+
+    let output = run_ok(
+        &home,
+        &[
+            "events",
+            "list",
+            "--json",
+            "--kind",
+            "message",
+            "--header",
+            "forge.body_hint=continuum.chat_transcript",
+        ],
+    );
+    let value: serde_json::Value = serde_json::from_str(&output)
+        .unwrap_or_else(|error| panic!("events list --json stdout is not JSON: {error}; {output}"));
+
+    assert_eq!(value["count"], 1);
+    let event = &value["events"][0];
+    assert!(event["event_id"].is_string(), "missing event_id: {event}");
+    assert_eq!(event["kind"], "message");
+    assert_eq!(
+        event["headers"]["forge.body_hint"],
+        "continuum.chat_transcript"
+    );
+    assert_eq!(event["headers"]["continuum.trace_id"], "smoke-trace");
+    assert_eq!(event["body"]["kind"], "json");
+    assert_eq!(event["body"]["value"]["text"], "hello structured");
+    assert!(
+        !output.contains("events: 1"),
+        "json mode must not include human prose"
+    );
+}
+
+#[test]
 fn send_receipt_distinguishes_zero_paired_peers_without_lying_about_delivery() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");
@@ -74,14 +128,31 @@ fn send_receipt_distinguishes_zero_paired_peers_without_lying_about_delivery() {
 
 fn run_ok(home: &Path, args: &[&str]) -> String {
     let account_home = home.parent().unwrap_or(home);
-    let output = Command::new(airc_core())
+    let mut command = Command::new(airc_core());
+    command
         .arg("--home")
         .arg(home)
         .args(args)
         .env("HOME", account_home)
         .env("USERPROFILE", account_home)
-        .output()
-        .expect("airc-core command must spawn");
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let needs_stdin = args.windows(2).any(|w| w == ["--body-json", "-"]);
+    if needs_stdin {
+        command.stdin(Stdio::piped());
+    }
+
+    let mut child = command.spawn().expect("airc-core command must spawn");
+    if needs_stdin {
+        use std::io::Write;
+        let mut stdin = child.stdin.take().expect("piped stdin");
+        stdin
+            .write_all(br#"{"kind":"chat","text":"hello structured"}"#)
+            .expect("write stdin");
+    }
+
+    let output = child.wait_with_output().expect("airc-core command output");
     assert!(
         output.status.success(),
         "airc-core {:?} failed: stdout={} stderr={}",


### PR DESCRIPTION
## Summary
- add `--json` to `airc events list`
- emit a machine-readable `{ count, events }` contract using the existing `TranscriptEvent` serde shape
- keep human output unchanged when `--json` is absent
- add a CLI regression test proving JSON mode is parseable and contains headers/body for structured consumers

References work card `26f61b24-5e25-4545-820e-1d50db2e235f`.

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-cli --check`
- `cargo test --manifest-path Cargo.toml -p airc-cli --test events_commands`
- `cargo clippy --manifest-path Cargo.toml -p airc-cli --all-targets -- -D warnings`
