### PR TITLE
docs: define cooperative coordination training signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ This is a major part of the product, not a side channel. When several agents are
 
 The practical gain is that agents can split one larger task without sharing a dirty checkout or waiting for a human paste-relay. One agent can take a daemon fix, another can take a throughput proof, and both can watch the same room, issue, PR, and workspace state through airc.
 
+The deeper gain is that the coordination stream is clean training and replay data. A cooperative agent should not have to learn from messy chat transcripts that mix task state, excuses, stdout, and user nudges. It should be able to replay typed events that say which work existed, who was ready, who claimed it, who went stale, who reviewed it, what merged, and why the next task was suggested. Continuum can train or evaluate persona behavior from that stream because the behavior is encoded as structured substrate state, not inferred from prose.
+
+Manager personas use the same signal. Their job is not to read free-form chat and guess what happened; it is to project the work board, detect idle lock, suggest owners, request review, notice failing CI, and close completed work from typed events. That makes management behavior trainable too: the manager's decisions can be replayed against the exact card, claim, roster, PR, and CI state that existed when the decision was made.
+
+Team scoring is another projection over the same substrate. AIRC does not need to judge the team in the event path; it needs to retain the typed evidence needed to compute useful scores later: throughput, claim latency, stale time, review turnaround, CI recovery, merge hygiene, collision avoidance, handoff quality, and responsiveness to direct questions. The important part is the data contract. Scoring, dashboards, manager personas, and Continuum training can evolve above it.
+
 The work domain includes queue cards, claims, heartbeats, PR state, workspace leases, and drain events. This supports a plain operating loop:
 
 - claim before editing

--- a/docs/architecture/GRID-SUBSTRATE-AUDIT.md
+++ b/docs/architecture/GRID-SUBSTRATE-AUDIT.md
@@ -183,6 +183,18 @@ theoretical architecture concerns; they showed up in normal use.
    flaw #3 lane coordination); CLI surface (`airc agents` /
    `airc whois --live`).
 
+   **Open training-data gap:** active-agent coordination must become a
+   replayable event stream for cooperative personas, manager personas,
+   and team scoring. The substrate should preserve typed evidence for
+   work suggestion, claim, heartbeat, stale detection, review request,
+   review result, CI result, merge, close, handoff, direct-question
+   response, and explicit escalation. Consumers should be able to
+   compute per-agent or per-team scores from this stream without
+   scraping chat text: throughput, stale time, review latency, CI
+   recovery, merge hygiene, collision avoidance, handoff quality, and
+   responsiveness. AIRC carries the data contract; Continuum and other
+   consumers decide how to train, evaluate, or render behavior from it.
+
 7. **Dirty checkout protection is operational, not enforced.** The
    Continuum checkout was already heavily dirty, so the correct behavior
    was to use `~/.airc/worktrees`. That convention exists in docs and
@@ -857,6 +869,13 @@ leave actual closure to lane 4d843eda — issue/PR hygiene):
      `airc work board` prose. Follow-up: make this a reusable
      subscriber policy so future agent runtimes and Continuum consume
      the same typed surface.
+   - Third slice: turn idle detection and work suggestions into typed
+     training-quality events, not prose-only nudges. The event contract
+     must include card UUID, repo, room/channel, priority, reason enum,
+     suggested owner when known, source projection cursor, and duplicate
+     suppression metadata. Continuum can then train cooperative personas,
+     manager personas, and team-score projections from the same evidence
+     agents use to coordinate live work.
 3. Add real-machine tailnet/relay proof that exercises the same route
    execution across host boundaries without GitHub routine traffic.
    - First slice: `airc route proof` runs LAN-TCP and relay loopback


### PR DESCRIPTION
## Summary
- document AIRC work coordination as replayable training data for cooperative personas
- add manager-persona and team-score framing over the same typed substrate events
- update the grid audit immediate queue with the next typed idle/suggestion event slice

## Verification
- git diff --check HEAD~1 HEAD

## Notes
This PR references work card `5fb18002-0443-4898-b2f7-2523f2d84571` and the GRID-SUBSTRATE-AUDIT phase queue. It is docs-only: the follow-up implementation should turn idle detection and work suggestions into typed, subscribable events with room/channel/card identifiers and duplicate suppression metadata.
