### PR TITLE
fix(join): replace stale daemon builds from typed status

### DIFF
--- a/crates/airc-cli/src/build_info.rs
+++ b/crates/airc-cli/src/build_info.rs
@@ -19,3 +19,7 @@ pub const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub fn is_unknown() -> bool {
     COMMIT == "unknown"
 }
+
+pub fn is_unknown_or_matches(commit: Option<&str>) -> bool {
+    is_unknown() || commit == Some(COMMIT)
+}

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -21,7 +21,7 @@ use airc_core::{ClientId, EventId, PeerId, TranscriptCursor};
 use airc_protocol::{PeerKeyRegistry, VerificationPolicy, HEADER_AIRC_CLIENT};
 use futures::stream::StreamExt;
 
-use airc_daemon::{run as run_daemon_server, DaemonState};
+use airc_daemon::{run as run_daemon_server, DaemonRuntimeInfo, DaemonState};
 use airc_identity::LocalIdentity;
 use airc_ipc::{
     AddPeerRequest, DaemonClient, RemovePeerRequest, Request, Response, SubscribeRequest,
@@ -173,12 +173,12 @@ pub async fn ensure_daemon_running(
     _peers: Vec<PeerSpec>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let client = DaemonClient::new(socket.clone());
-    if client
-        .ping_with_timeout(Duration::from_millis(250))
-        .await
-        .is_ok()
-    {
-        return Ok(());
+    if let Ok(status) = client.status_with_timeout(Duration::from_millis(250)).await {
+        if daemon_status_is_current(&status) {
+            return Ok(());
+        }
+        let _ = client.stop().await;
+        wait_for_daemon_exit(&client, Duration::from_secs(3)).await;
     }
 
     std::fs::create_dir_all(home)?;
@@ -218,6 +218,25 @@ pub async fn ensure_daemon_running(
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
     Err(format!("daemon did not become ready; see {}", log.display()).into())
+}
+
+fn daemon_status_is_current(status: &airc_ipc::StatusResponse) -> bool {
+    status.ipc_protocol_version == Some(u32::from(airc_ipc::IPC_PROTOCOL_VERSION))
+        && crate::build_info::is_unknown_or_matches(status.build_commit.as_deref())
+}
+
+async fn wait_for_daemon_exit(client: &DaemonClient, max_wait: Duration) {
+    let deadline = Instant::now() + max_wait;
+    while Instant::now() < deadline {
+        if client
+            .ping_with_timeout(Duration::from_millis(150))
+            .await
+            .is_err()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
 }
 
 #[cfg(unix)]
@@ -495,13 +514,14 @@ pub async fn run_daemon(
     // same `(lamport, event_id)` cursor on next boot.
     let store_path = home.join("events.sqlite");
     let store: Arc<dyn EventStore> = Arc::new(SqliteEventStore::open_path(&store_path).await?);
-    let state = Arc::new(DaemonState::new(
+    let state = Arc::new(DaemonState::new_with_runtime(
         identity.peer_id,
         identity.keypair,
         registry,
         VerificationPolicy::Strict,
         home.to_path_buf(),
         store,
+        current_daemon_runtime_info(),
     ));
     println!(
         "airc daemon: peer_id={} listening on {}",
@@ -511,6 +531,17 @@ pub async fn run_daemon(
     run_daemon_server(state, socket).await?;
     println!("airc daemon: stopped.");
     Ok(())
+}
+
+fn current_daemon_runtime_info() -> DaemonRuntimeInfo {
+    DaemonRuntimeInfo {
+        ipc_protocol_version: Some(u32::from(airc_ipc::IPC_PROTOCOL_VERSION)),
+        build_commit: (!crate::build_info::is_unknown()).then(|| crate::build_info::COMMIT.into()),
+        build_branch: (!crate::build_info::is_unknown()).then(|| crate::build_info::BRANCH.into()),
+        executable: std::env::current_exe()
+            .ok()
+            .map(|path| path.display().to_string()),
+    }
 }
 
 // ---- Daemon-client commands (no identity load needed) ---------------
@@ -527,6 +558,19 @@ pub async fn run_status(socket: PathBuf) -> Result<(), Box<dyn std::error::Error
     let status = client.status().await?;
     println!("peer_id:        {}", status.peer_id);
     println!("uptime_seconds: {}", status.uptime_seconds);
+    if let Some(version) = status.ipc_protocol_version {
+        println!("ipc_protocol:   {version}");
+    }
+    if let Some(commit) = status.build_commit.as_deref() {
+        let short = &commit[..commit.len().min(12)];
+        println!("build:          {short}");
+    }
+    if let Some(branch) = status.build_branch.as_deref() {
+        println!("branch:         {branch}");
+    }
+    if let Some(executable) = status.executable.as_deref() {
+        println!("executable:     {executable}");
+    }
     Ok(())
 }
 
@@ -832,4 +876,41 @@ fn runtime_headers() -> Result<Headers, Box<dyn std::error::Error>> {
         headers.insert(HEADER_AIRC_CLIENT.to_string(), client);
     }
     Ok(headers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn status(commit: Option<&str>, protocol: Option<u32>) -> airc_ipc::StatusResponse {
+        airc_ipc::StatusResponse {
+            peer_id: "07e7ad58-ba56-4535-b4e5-a161a110e487".to_string(),
+            uptime_seconds: 1,
+            ipc_protocol_version: protocol,
+            build_commit: commit.map(str::to_string),
+            build_branch: Some("rust-rewrite".to_string()),
+            executable: Some("/tmp/airc".to_string()),
+        }
+    }
+
+    #[test]
+    fn daemon_status_current_requires_matching_protocol_and_build() {
+        assert!(daemon_status_is_current(&status(
+            Some(crate::build_info::COMMIT),
+            Some(u32::from(airc_ipc::IPC_PROTOCOL_VERSION))
+        )));
+        assert!(!daemon_status_is_current(&status(
+            Some("old-build"),
+            Some(u32::from(airc_ipc::IPC_PROTOCOL_VERSION))
+        )));
+        assert!(!daemon_status_is_current(&status(
+            Some(crate::build_info::COMMIT),
+            Some(u32::from(airc_ipc::IPC_PROTOCOL_VERSION) + 1)
+        )));
+    }
+
+    #[test]
+    fn daemon_status_without_metadata_is_stale() {
+        assert!(!daemon_status_is_current(&status(None, None)));
+    }
 }

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -40,6 +40,10 @@ pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
         Request::Status => Response::Status(StatusResponse {
             peer_id: state.peer_id.to_string(),
             uptime_seconds: state.uptime_seconds(),
+            ipc_protocol_version: state.runtime.ipc_protocol_version,
+            build_commit: state.runtime.build_commit.clone(),
+            build_branch: state.runtime.build_branch.clone(),
+            executable: state.runtime.executable.clone(),
         }),
         Request::Send(send) => handle_send(state, send).await,
         Request::Publish(publish) => handle_publish(state, publish).await,

--- a/crates/airc-daemon/src/lib.rs
+++ b/crates/airc-daemon/src/lib.rs
@@ -35,4 +35,4 @@ pub mod state;
 pub mod trust_refresh;
 
 pub use server::{run, DaemonError};
-pub use state::DaemonState;
+pub use state::{DaemonRuntimeInfo, DaemonState};

--- a/crates/airc-daemon/src/state.rs
+++ b/crates/airc-daemon/src/state.rs
@@ -65,6 +65,10 @@ pub struct DaemonState {
     pub live_tx: broadcast::Sender<airc_core::TranscriptEvent>,
     /// Notified when the daemon should stop accepting + exit cleanly.
     pub shutdown: Notify,
+    /// Runtime metadata reported through IPC status so clients can
+    /// replace stale daemons after updates without guessing from
+    /// process lists or socket names.
+    pub runtime: DaemonRuntimeInfo,
 }
 
 impl DaemonState {
@@ -80,6 +84,26 @@ impl DaemonState {
         home: PathBuf,
         event_store: Arc<dyn EventStore>,
     ) -> Self {
+        Self::new_with_runtime(
+            peer_id,
+            keypair,
+            registry,
+            policy,
+            home,
+            event_store,
+            DaemonRuntimeInfo::unknown(),
+        )
+    }
+
+    pub fn new_with_runtime(
+        peer_id: PeerId,
+        keypair: PeerKeypair,
+        registry: Arc<PeerKeyRegistry>,
+        policy: VerificationPolicy,
+        home: PathBuf,
+        event_store: Arc<dyn EventStore>,
+        runtime: DaemonRuntimeInfo,
+    ) -> Self {
         let (live_tx, _) = broadcast::channel(1024);
         Self {
             peer_id,
@@ -94,6 +118,7 @@ impl DaemonState {
             trusted_roots: Mutex::new(HashMap::new()),
             live_tx,
             shutdown: Notify::new(),
+            runtime,
         }
     }
 
@@ -186,5 +211,19 @@ impl DaemonState {
 
     pub fn uptime_seconds(&self) -> u64 {
         self.started_at.elapsed().as_secs()
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DaemonRuntimeInfo {
+    pub ipc_protocol_version: Option<u32>,
+    pub build_commit: Option<String>,
+    pub build_branch: Option<String>,
+    pub executable: Option<String>,
+}
+
+impl DaemonRuntimeInfo {
+    pub fn unknown() -> Self {
+        Self::default()
     }
 }

--- a/crates/airc-ipc/src/client.rs
+++ b/crates/airc-ipc/src/client.rs
@@ -23,6 +23,7 @@ use crate::request::{
 use crate::response::{InboxResponse, PeersResponse, PublishResponse, Response, StatusResponse};
 
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(5);
+const SUBSCRIBE_RPC_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Reasons a daemon RPC fails.
 #[derive(Debug)]
@@ -155,7 +156,14 @@ impl DaemonClient {
     }
 
     pub async fn status(&self) -> Result<StatusResponse, ClientError> {
-        match self.call(Request::Status).await? {
+        self.status_with_timeout(DEFAULT_RPC_TIMEOUT).await
+    }
+
+    pub async fn status_with_timeout(
+        &self,
+        deadline: Duration,
+    ) -> Result<StatusResponse, ClientError> {
+        match self.call_with_timeout(Request::Status, deadline).await? {
             Response::Status(status) => Ok(status),
             other @ (Response::Pong
             | Response::Inbox(_)
@@ -194,7 +202,19 @@ impl DaemonClient {
     }
 
     pub async fn subscribe(&self, request: SubscribeRequest) -> Result<(), ClientError> {
-        match self.call(Request::Subscribe(request)).await? {
+        self.subscribe_with_timeout(request, SUBSCRIBE_RPC_TIMEOUT)
+            .await
+    }
+
+    pub async fn subscribe_with_timeout(
+        &self,
+        request: SubscribeRequest,
+        deadline: Duration,
+    ) -> Result<(), ClientError> {
+        match self
+            .call_with_timeout(Request::Subscribe(request), deadline)
+            .await?
+        {
             Response::Ok => Ok(()),
             other @ (Response::Pong
             | Response::Status(_)

--- a/crates/airc-ipc/src/response.rs
+++ b/crates/airc-ipc/src/response.rs
@@ -40,6 +40,22 @@ pub struct StatusResponse {
     pub peer_id: String,
     /// Seconds since daemon start.
     pub uptime_seconds: u64,
+    /// IPC protocol version spoken by this daemon. Missing means the
+    /// daemon predates status metadata and should be treated as stale
+    /// by lifecycle code.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ipc_protocol_version: Option<u32>,
+    /// Build commit baked into the daemon binary. Missing means
+    /// unknown/old daemon.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_commit: Option<String>,
+    /// Build branch baked into the daemon binary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_branch: Option<String>,
+    /// Executable path of the daemon process. This is diagnostics
+    /// only; lifecycle decisions use protocol + build metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executable: Option<String>,
 }
 
 /// One entry in the `Peers` response. Mirrors `peers_store::StoredPeer`
@@ -98,10 +114,33 @@ mod tests {
         let original = Response::Status(StatusResponse {
             peer_id: "07e7ad58-ba56-4535-b4e5-a161a110e487".to_string(),
             uptime_seconds: 42,
+            ipc_protocol_version: Some(3),
+            build_commit: Some("abc123".to_string()),
+            build_branch: Some("rust-rewrite".to_string()),
+            executable: Some("/tmp/airc".to_string()),
         });
         let encoded = serde_json::to_string(&original).unwrap();
         let decoded: Response = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn status_accepts_pre_metadata_daemon_response() {
+        let decoded: Response = serde_json::from_str(
+            r#"{"kind":"status","peer_id":"07e7ad58-ba56-4535-b4e5-a161a110e487","uptime_seconds":42}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            decoded,
+            Response::Status(StatusResponse {
+                peer_id: "07e7ad58-ba56-4535-b4e5-a161a110e487".to_string(),
+                uptime_seconds: 42,
+                ipc_protocol_version: None,
+                build_commit: None,
+                build_branch: None,
+                executable: None,
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add daemon IPC status metadata for protocol/build/branch/executable
- make join probe daemon status with a short timeout and replace stale daemon builds for the same AIRC_HOME
- render daemon protocol/build metadata in airc status so lifecycle drift is visible
- make daemon subscribe use an explicit longer timeout for Windows cold-start/runtime-load conditions
- add regression coverage for old metadata-free status responses and stale build/protocol detection

Closes work card 9d365956-9978-4ec1-94ca-38af33eb71a9.

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-ipc -p airc-daemon -p airc-cli --check
- cargo test --manifest-path Cargo.toml -p airc-ipc
- cargo test --manifest-path Cargo.toml -p airc-daemon
- cargo test --manifest-path Cargo.toml -p airc-cli
- cargo clippy --manifest-path Cargo.toml -p airc-ipc -p airc-daemon -p airc-cli --all-targets -- -D warnings
- git diff --check