### PR TITLE
fix(work): tolerate superseded claim release + ghost heartbeat

### DIFF
--- a/crates/airc-work/src/projection.rs
+++ b/crates/airc-work/src/projection.rs
@@ -233,12 +233,6 @@ pub enum ProjectionError {
     UnknownLane(LaneId),
     #[error("unknown workspace {0}")]
     UnknownWorkspace(WorkspaceId),
-    #[error("claim mismatch for card {card_id}: expected {expected:?}, got {got}")]
-    ClaimMismatch {
-        card_id: WorkCardId,
-        expected: Option<ClaimId>,
-        got: ClaimId,
-    },
 }
 
 impl ProjectionError {

--- a/crates/airc-work/src/projection/apply.rs
+++ b/crates/airc-work/src/projection/apply.rs
@@ -172,7 +172,19 @@ impl WorkBoardProjection {
 
     fn apply_claim_heartbeat(&mut self, e: &ClaimHeartbeat) -> Result<(), ProjectionError> {
         let card = self.card_mut(e.card_id)?;
-        ensure_claim(card, e.claim_id)?;
+        // Idempotent-replay tolerance (closes work card c29506b8,
+        // "Work board replay window must not fail on partial
+        // history"): if this heartbeat names a claim that isn't
+        // currently active on the card, drop it silently. The
+        // claim was either never granted (the projection treats
+        // `apply_card_claimed` as first-write-wins, so a racing
+        // second claim is dropped without state change) or was
+        // already superseded by another release. Heartbeating a
+        // ghost claim is a no-op — refusing to project would just
+        // poison the board for every downstream consumer.
+        if card.claim_id != Some(e.claim_id) {
+            return Ok(());
+        }
         card.claim_expires_at_ms = Some(e.heartbeat_at_ms + e.ttl_ms);
         card.last_heartbeat_at_ms = Some(e.heartbeat_at_ms);
         card.updated_at_ms = e.heartbeat_at_ms;
@@ -181,10 +193,25 @@ impl WorkBoardProjection {
 
     fn apply_claim_released(&mut self, e: &ClaimReleased) -> Result<(), ProjectionError> {
         let card = self.card_mut(e.card_id)?;
-        if card.claim_id.is_none() {
+        // Two tolerant-replay branches that converge to the same
+        // no-op (closes work card c29506b8). Both happen in real
+        // distributed runs:
+        //
+        // 1. `claim_id.is_none()` — card already had its active
+        //    claim released; subsequent release events for any
+        //    older claim are idempotent (Codex's #987 fix).
+        //
+        // 2. `claim_id != Some(e.claim_id)` — release names a
+        //    claim that the projection considers superseded
+        //    (e.g. `apply_card_claimed` drops a racing second
+        //    claim, but the second claimant still later emits a
+        //    release for "their" claim id). Treat as no-op
+        //    instead of panicking — refusing here freezes every
+        //    consumer's board until the operator surgically
+        //    rewrites the wire.
+        if card.claim_id != Some(e.claim_id) {
             return Ok(());
         }
-        ensure_claim(card, e.claim_id)?;
         card.state = match card.state {
             CardState::Claimed | CardState::InProgress | CardState::Blocked => CardState::Open,
             CardState::Open | CardState::Review | CardState::Merged | CardState::Closed => {
@@ -467,15 +494,4 @@ impl WorkBoardProjection {
             .entry(repo.clone())
             .or_insert_with(|| RepoTrackingRecord::new(repo))
     }
-}
-
-fn ensure_claim(card: &WorkCard, got: crate::ids::ClaimId) -> Result<(), ProjectionError> {
-    if card.claim_id == Some(got) {
-        return Ok(());
-    }
-    Err(ProjectionError::ClaimMismatch {
-        card_id: card.card_id,
-        expected: card.claim_id,
-        got,
-    })
 }

--- a/crates/airc-work/src/projection/tests.rs
+++ b/crates/airc-work/src/projection/tests.rs
@@ -568,7 +568,13 @@ fn git_and_pr_adapter_events_project_without_polling() {
 }
 
 #[test]
-fn mismatched_claim_is_rejected() {
+fn heartbeat_for_non_active_claim_is_dropped_silently() {
+    // Closes work card c29506b8 ("Work board replay window must
+    // not fail on partial history"). A heartbeat that names a
+    // claim the projection has never observed as active (e.g. a
+    // racing second claimant that lost the first-write-wins
+    // contest in `apply_card_claimed`) must NOT poison the
+    // board — drop the event and let the projection move on.
     let card_id = WorkCardId::from_u128(1);
     let owner = peer(3);
     let mut projection = WorkBoardProjection::new();
@@ -576,7 +582,7 @@ fn mismatched_claim_is_rejected() {
         .apply(&WorkEvent::CardCreated(CardCreated {
             card_id,
             repo: repo(),
-            title: "claim mismatch".to_string(),
+            title: "ghost heartbeat".to_string(),
             body: None,
             priority: Priority::P2,
             lane_id: None,
@@ -584,7 +590,7 @@ fn mismatched_claim_is_rejected() {
             created_at_ms: 1,
         }))
         .unwrap();
-    let err = projection
+    projection
         .apply(&WorkEvent::ClaimHeartbeat(ClaimHeartbeat {
             card_id,
             claim_id: ClaimId::from_u128(9),
@@ -592,6 +598,78 @@ fn mismatched_claim_is_rejected() {
             ttl_ms: 1,
             heartbeat_at_ms: 2,
         }))
-        .unwrap_err();
-    assert!(matches!(err, ProjectionError::ClaimMismatch { .. }));
+        .expect("ghost heartbeat must be tolerated, not panic");
+    let card = projection.card(card_id).expect("card present");
+    assert_eq!(
+        card.claim_id, None,
+        "ghost heartbeat must not invent a claim"
+    );
+}
+
+#[test]
+fn release_for_superseded_claim_does_not_poison_projection() {
+    // Closes work card c29506b8 (the production poison-pill that
+    // motivated this fix). Real wire shape: Create → Claim A →
+    // Claim B (silently dropped by first-write-wins) → Release B.
+    // The release names a claim id the projection never accepted;
+    // refusing it would freeze every consumer's board.
+    let card_id = WorkCardId::from_u128(1);
+    let owner_a = peer(3);
+    let owner_b = peer(4);
+    let claim_a = ClaimId::from_u128(10);
+    let claim_b = ClaimId::from_u128(11);
+    let mut projection = WorkBoardProjection::new();
+
+    projection
+        .apply(&WorkEvent::CardCreated(CardCreated {
+            card_id,
+            repo: repo(),
+            title: "race release".to_string(),
+            body: None,
+            priority: Priority::P2,
+            lane_id: None,
+            created_by: owner_a,
+            created_at_ms: 1,
+        }))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::CardClaimed(WorkCardClaimed {
+            card_id,
+            claim_id: claim_a,
+            owner: owner_a,
+            ttl_ms: 60_000,
+            claimed_at_ms: 2,
+        }))
+        .unwrap();
+    // Second claim — silently ignored by first-write-wins.
+    projection
+        .apply(&WorkEvent::CardClaimed(WorkCardClaimed {
+            card_id,
+            claim_id: claim_b,
+            owner: owner_b,
+            ttl_ms: 60_000,
+            claimed_at_ms: 3,
+        }))
+        .unwrap();
+    // The losing claimant later emits a release for *their* claim
+    // id. Before this fix, this errored with `ClaimMismatch` and
+    // halted every consumer's projection.
+    projection
+        .apply(&WorkEvent::ClaimReleased(ClaimReleased {
+            card_id,
+            claim_id: claim_b,
+            owner: owner_b,
+            reason: None,
+            released_at_ms: 4,
+        }))
+        .expect("release of superseded claim must be tolerated");
+
+    let card = projection.card(card_id).expect("card present");
+    assert_eq!(
+        card.claim_id,
+        Some(claim_a),
+        "first-write claim must still be active after the ghost release"
+    );
+    assert_eq!(card.owner, Some(owner_a));
+    assert_eq!(card.state, CardState::Claimed);
 }


### PR DESCRIPTION
## Summary
Closes work card **c29506b8** (\"Work board replay window must not fail on partial history\").

The work-card projection had two strict paths that — in real distributed runs — poisoned every consumer's board:

1. `apply_claim_heartbeat` required the heartbeat's claim id to match the active claim, errored otherwise.
2. `apply_claim_released` required the release's claim id to match the active claim, errored otherwise.

## Production poison-pill this session

Agents A and B both publish `CardClaimed` for the same card. `apply_card_claimed` already implements first-write-wins (the second claim is silently dropped). The losing claimant later emits `ClaimReleased` for *their* claim id — which the projection never accepted as active. The strict mismatch check errors, and because the projection is used by `airc work claim`/`board`/`next`/`roster`, the **entire work queue becomes unreadable** for every agent until the wire is surgically rewritten.

This stopped a multi-agent session today: Joel called Claude + Codex out for idling, because both saw `airc work next` panic and silently fell back to standing-by. The substrate suggesting *\"no claimable work\"* when it actually means *\"I cannot project the board\"* is precisely the dogfood-finds-fix path #993 was trying to strengthen — this PR completes it.

## Fix
Both `apply_claim_heartbeat` and `apply_claim_released` now drop the event silently when the named claim id doesn't match the projection's active claim. This makes them the third symmetric tolerance branch alongside the two that already exist:

- `apply_card_claimed` already drops racing second claims.
- `apply_claim_released` already drops releases of an already-released claim (Codex's #987 fix).

`ProjectionError::ClaimMismatch` and `ensure_claim` are removed — both producers were the call sites this PR rewrites, both consumers were internal.

## Test plan
- [x] `heartbeat_for_non_active_claim_is_dropped_silently` — heartbeat before any claim must not invent a claim.
- [x] `release_for_superseded_claim_does_not_poison_projection` — recreates the production sequence (Create → Claim A → Claim B silently dropped → Release B) and asserts the projection converges with Claim A still active.
- [x] `cargo test --workspace` green (72 airc-work tests + rest).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)