### PR TITLE
feat(work): publish active-agent roster heartbeats from join

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -26,7 +26,7 @@ use airc_identity::LocalIdentity;
 use airc_ipc::{
     AddPeerRequest, DaemonClient, RemovePeerRequest, Request, Response, SubscribeRequest,
 };
-use airc_lib::{Airc, Body, Headers, PeerSpec};
+use airc_lib::{Airc, Body, Headers, HeartbeatTask, PeerSpec, DEFAULT_HEARTBEAT_INTERVAL};
 use airc_store::{EventStore, SqliteEventStore};
 use airc_trust as peers_store;
 
@@ -95,6 +95,7 @@ pub async fn run_part(home: &Path, room: Option<String>) -> Result<(), Box<dyn s
 /// With a room, join that arbitrary channel and make it default.
 pub async fn run_join(home: &Path, room: Option<String>) -> Result<(), Box<dyn std::error::Error>> {
     let airc = Airc::open(home).await?;
+    let runtime_context = crate::runtime_context::RuntimeContext::current();
     match room {
         Some(room) => {
             let joined = airc.join(&room).await?;
@@ -121,10 +122,43 @@ pub async fn run_join(home: &Path, room: Option<String>) -> Result<(), Box<dyn s
     subscribe_daemon_to_current_rooms(home, socket).await?;
     ensure_runtime_integrations();
 
-    if crate::runtime_context::RuntimeContext::current().should_stream_join() {
+    let _heartbeat = if runtime_context.should_stream_join() {
+        Some(start_join_heartbeat(&airc, home, &runtime_context).await?)
+    } else {
+        None
+    };
+
+    if runtime_context.should_stream_join() {
         crate::join_feed::run(&airc).await?;
     }
     Ok(())
+}
+
+async fn start_join_heartbeat(
+    airc: &Airc,
+    home: &Path,
+    runtime_context: &crate::runtime_context::RuntimeContext,
+) -> Result<HeartbeatTask, Box<dyn std::error::Error>> {
+    let scope = join_scope_label(home);
+    let runtime = runtime_context.runtime_label().to_string();
+    let client_id = runtime_context.client_id().map(ToString::to_string);
+    let build = (!crate::build_info::is_unknown()).then(|| crate::build_info::COMMIT_SHORT.into());
+    Ok(airc
+        .start_agent_heartbeat_with_metadata(
+            runtime,
+            client_id,
+            Some(scope),
+            build,
+            DEFAULT_HEARTBEAT_INTERVAL,
+        )
+        .await?)
+}
+
+fn join_scope_label(home: &Path) -> String {
+    match std::env::current_dir() {
+        Ok(cwd) => cwd.display().to_string(),
+        Err(_) => home.display().to_string(),
+    }
 }
 
 fn ensure_runtime_integrations() {

--- a/crates/airc-cli/src/runtime_context.rs
+++ b/crates/airc-cli/src/runtime_context.rs
@@ -56,7 +56,7 @@ impl RuntimeContext {
     pub fn client_id(&self) -> Option<&str> {
         match self {
             Self::Agent { client_id, .. } => client_id.as_deref(),
-            _ => None,
+            Self::InteractiveTerminal | Self::Automation | Self::TestHarness => None,
         }
     }
 }

--- a/crates/airc-cli/src/runtime_context.rs
+++ b/crates/airc-cli/src/runtime_context.rs
@@ -43,6 +43,32 @@ impl RuntimeContext {
     pub fn should_stream_join(&self) -> bool {
         matches!(self, Self::InteractiveTerminal | Self::Agent { .. })
     }
+
+    pub fn runtime_label(&self) -> &'static str {
+        match self {
+            Self::InteractiveTerminal => "interactive",
+            Self::Agent { kind, .. } => kind.label(),
+            Self::Automation => "automation",
+            Self::TestHarness => "test",
+        }
+    }
+
+    pub fn client_id(&self) -> Option<&str> {
+        match self {
+            Self::Agent { client_id, .. } => client_id.as_deref(),
+            _ => None,
+        }
+    }
+}
+
+impl AgentRuntimeKind {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Generic => "agent",
+        }
+    }
 }
 
 fn classify<I, K, V>(env: I, stdout_is_tty: bool, runtime_client: Option<String>) -> RuntimeContext

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -359,10 +359,14 @@ fn print_work_roster(status: &WorkRosterStatus) {
             .liveness
             .as_ref()
             .map(|liveness| {
+                let client = liveness.client_id.as_deref().unwrap_or("-");
+                let build = liveness.build.as_deref().unwrap_or("-");
                 format!(
-                    "live runtime={} scope={} last_seen_ms={}",
+                    "live runtime={} client={} scope={} build={} last_seen_ms={}",
                     liveness.runtime,
+                    client,
                     liveness.scope.as_deref().unwrap_or("-"),
+                    build,
                     liveness.last_seen_ms
                 )
             })

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -189,6 +189,71 @@ fn join_without_args_uses_default_account_context() {
 }
 
 #[test]
+fn join_streaming_agent_publishes_roster_heartbeat() {
+    let machine = TempDir::new().expect("tempdir");
+    let repo = machine.path().join("continuum");
+    let home = repo.join(".airc");
+    create_repo_with_origin(&repo, "https://github.com/CambrianTech/continuum.git");
+    seed_mesh_identity(&home, "joelteply");
+
+    let mut join = Command::new(airc_core());
+    join.env("HOME", machine.path())
+        .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
+        .env("AI_AGENT", "1")
+        .env("AIRC_CLIENT_ID", "agent:e2e-roster")
+        .args(["--home", home.to_str().unwrap(), "join"])
+        .current_dir(&repo)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    strip_cargo_harness_env(&mut join);
+    let stdout = run_join_until_attached(join, JOIN_ATTACH_TIMEOUT).join("\n");
+    assert!(stdout.contains("attached"), "{stdout}");
+
+    let mut roster_command = Command::new(airc_core());
+    roster_command.env("HOME", machine.path()).args([
+        "--home",
+        home.to_str().unwrap(),
+        "work",
+        "roster",
+        "--event-limit",
+        "128",
+    ]);
+    let roster = output_with_timeout(roster_command, Duration::from_secs(10), "airc work roster");
+    assert!(
+        roster.status.success(),
+        "roster failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&roster.stdout),
+        String::from_utf8_lossy(&roster.stderr),
+    );
+    let roster_stdout = String::from_utf8_lossy(&roster.stdout);
+    assert!(
+        roster_stdout.contains("work roster: 1 agent(s)"),
+        "{roster_stdout}"
+    );
+    assert!(roster_stdout.contains("runtime=agent"), "{roster_stdout}");
+    assert!(
+        roster_stdout.contains("client=agent:e2e-roster"),
+        "{roster_stdout}"
+    );
+    assert!(
+        roster_stdout.contains(repo.to_str().unwrap()),
+        "{roster_stdout}"
+    );
+
+    let mut stop_command = Command::new(airc_core());
+    stop_command
+        .env("HOME", machine.path())
+        .args(["--home", home.to_str().unwrap(), "stop"]);
+    let stop = output_with_timeout(stop_command, Duration::from_secs(10), "airc stop");
+    assert!(
+        stop.status.success(),
+        "stop failed after roster heartbeat proof: stdout={} stderr={}",
+        String::from_utf8_lossy(&stop.stdout),
+        String::from_utf8_lossy(&stop.stderr),
+    );
+}
+
+#[test]
 fn join_sets_up_codex_hook_when_codex_home_exists() {
     let machine = TempDir::new().expect("tempdir");
     let repo = machine.path().join("continuum");

--- a/crates/airc-lib/src/agent_heartbeat.rs
+++ b/crates/airc-lib/src/agent_heartbeat.rs
@@ -12,6 +12,8 @@
 //!   kinds: `"leaving"`, `"degraded"`).
 //! - `airc.heartbeat.runtime` = caller-supplied runtime label
 //!   (e.g. `"claude"`, `"codex"`, `"interactive"`).
+//! - `airc.heartbeat.client` = optional runtime client id
+//!   (`"codex:..."`, `"claude:..."`) when known.
 //!
 //! Frame kind is `Event` (durable — same trade-off the audit's flaw
 //! #4 flags). 60s default emit interval keeps noise bounded. The
@@ -44,6 +46,7 @@ use crate::Airc;
 
 pub const HEADER_HEARTBEAT_KIND: &str = "airc.heartbeat.kind";
 pub const HEADER_HEARTBEAT_RUNTIME: &str = "airc.heartbeat.runtime";
+pub const HEADER_HEARTBEAT_CLIENT: &str = "airc.heartbeat.client";
 
 /// Default 60s emit cadence. Tuned so a peer that hasn't beat in
 /// 3× the default is unambiguously stale, while keeping heartbeat
@@ -82,11 +85,19 @@ pub struct AgentHeartbeat {
     /// Caller-supplied runtime label. Convention: lowercase identifier
     /// (`"claude"`, `"codex"`, `"interactive"`, `"automation"`).
     pub runtime: String,
+    /// Optional runtime-client id. This distinguishes multiple tabs
+    /// sharing the same durable peer identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
     /// Optional caller-supplied scope label. Useful when one agent
     /// runs from multiple project worktrees and observers want to
     /// distinguish them.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope: Option<String>,
+    /// Optional build identifier for operators checking whether idle
+    /// or broken agents are on stale code.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build: Option<String>,
     pub emitted_at_ms: u64,
 }
 
@@ -96,7 +107,9 @@ pub struct AgentHeartbeat {
 pub struct AgentLiveness {
     pub peer: PeerId,
     pub runtime: String,
+    pub client_id: Option<String>,
     pub scope: Option<String>,
+    pub build: Option<String>,
     pub last_seen_ms: u64,
 }
 
@@ -152,12 +165,29 @@ impl Airc {
         runtime: impl Into<String>,
         scope: Option<String>,
     ) -> Result<(), AircError> {
+        self.emit_agent_heartbeat_with_metadata(kind, runtime, None, scope, None)
+            .await
+    }
+
+    /// Emit a heartbeat with runtime metadata. CLI `join` uses this
+    /// form so managers can distinguish multiple tabs sharing one
+    /// peer identity and spot stale builds.
+    pub async fn emit_agent_heartbeat_with_metadata(
+        &self,
+        kind: HeartbeatKind,
+        runtime: impl Into<String>,
+        client_id: Option<String>,
+        scope: Option<String>,
+        build: Option<String>,
+    ) -> Result<(), AircError> {
         let runtime = runtime.into();
         let heartbeat = AgentHeartbeat {
             kind,
             peer: self.peer_id(),
             runtime: runtime.clone(),
+            client_id: client_id.clone(),
             scope,
+            build,
             emitted_at_ms: now_ms()?,
         };
         let body = serde_json::to_value(&heartbeat)
@@ -168,6 +198,9 @@ impl Airc {
             kind.header_value().to_string(),
         );
         headers.insert(HEADER_HEARTBEAT_RUNTIME.into(), runtime);
+        if let Some(client_id) = client_id {
+            headers.insert(HEADER_HEARTBEAT_CLIENT.into(), client_id);
+        }
         self.send_frame_to(
             FrameKind::Event,
             MentionTarget::All,
@@ -192,11 +225,30 @@ impl Airc {
         scope: Option<String>,
         interval: Duration,
     ) -> Result<HeartbeatTask, AircError> {
+        self.start_agent_heartbeat_with_metadata(runtime, None, scope, None, interval)
+            .await
+    }
+
+    /// Spawn a heartbeat task with runtime metadata.
+    pub async fn start_agent_heartbeat_with_metadata(
+        &self,
+        runtime: impl Into<String>,
+        client_id: Option<String>,
+        scope: Option<String>,
+        build: Option<String>,
+        interval: Duration,
+    ) -> Result<HeartbeatTask, AircError> {
         let runtime = runtime.into();
         // Emit one beat synchronously so observers see the agent
         // alive immediately, before the first interval tick.
-        self.emit_agent_heartbeat(HeartbeatKind::Alive, runtime.clone(), scope.clone())
-            .await?;
+        self.emit_agent_heartbeat_with_metadata(
+            HeartbeatKind::Alive,
+            runtime.clone(),
+            client_id.clone(),
+            scope.clone(),
+            build.clone(),
+        )
+        .await?;
 
         let airc = self.clone();
         let handle = tokio::spawn(async move {
@@ -206,7 +258,13 @@ impl Airc {
             loop {
                 ticker.tick().await;
                 if let Err(error) = airc
-                    .emit_agent_heartbeat(HeartbeatKind::Alive, runtime.clone(), scope.clone())
+                    .emit_agent_heartbeat_with_metadata(
+                        HeartbeatKind::Alive,
+                        runtime.clone(),
+                        client_id.clone(),
+                        scope.clone(),
+                        build.clone(),
+                    )
                     .await
                 {
                     eprintln!("agent heartbeat emit failed: {error}");
@@ -231,7 +289,7 @@ impl Airc {
         let now = now_ms()?;
         let cutoff = now.saturating_sub(within.as_millis() as u64);
         let recent = self.page_recent(window).await?;
-        let mut latest: std::collections::HashMap<PeerId, AgentHeartbeat> =
+        let mut latest: std::collections::HashMap<AgentHeartbeatKey, AgentHeartbeat> =
             std::collections::HashMap::new();
         for event in &recent {
             let Some(beat) = parse_heartbeat(event) else {
@@ -242,7 +300,7 @@ impl Airc {
             }
             // Keep the highest emitted_at_ms per peer.
             latest
-                .entry(beat.peer)
+                .entry(AgentHeartbeatKey::from(&beat))
                 .and_modify(|existing| {
                     if beat.emitted_at_ms > existing.emitted_at_ms {
                         *existing = beat.clone();
@@ -256,12 +314,35 @@ impl Airc {
             .map(|beat| AgentLiveness {
                 peer: beat.peer,
                 runtime: beat.runtime,
+                client_id: beat.client_id,
                 scope: beat.scope,
+                build: beat.build,
                 last_seen_ms: beat.emitted_at_ms,
             })
             .collect();
-        alive.sort_by_key(|liveness| liveness.peer.to_string());
+        alive.sort_by_key(|liveness| {
+            format!(
+                "{}:{}",
+                liveness.peer,
+                liveness.client_id.as_deref().unwrap_or("")
+            )
+        });
         Ok(alive)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct AgentHeartbeatKey {
+    peer: PeerId,
+    client_id: Option<String>,
+}
+
+impl AgentHeartbeatKey {
+    fn from(beat: &AgentHeartbeat) -> Self {
+        Self {
+            peer: beat.peer,
+            client_id: beat.client_id.clone(),
+        }
     }
 }
 
@@ -284,7 +365,9 @@ mod tests {
             kind: HeartbeatKind::Alive,
             peer: PeerId::new(),
             runtime: "claude".to_string(),
+            client_id: Some("claude:tab-1".to_string()),
             scope: Some("/work/airc".to_string()),
+            build: Some("abc123".to_string()),
             emitted_at_ms: 1_700_000_000_000,
         }
     }
@@ -294,7 +377,9 @@ mod tests {
             kind: HeartbeatKind::Leaving,
             peer: PeerId::new(),
             runtime: "codex".to_string(),
+            client_id: None,
             scope: None,
+            build: None,
             emitted_at_ms: 1_700_000_001_000,
         }
     }
@@ -327,7 +412,9 @@ mod tests {
             kind: HeartbeatKind::Alive,
             peer: PeerId::new(),
             runtime: "interactive".to_string(),
+            client_id: None,
             scope: None,
+            build: None,
             emitted_at_ms: 0,
         };
         let json = serde_json::to_string(&beat).expect("encode");

--- a/crates/airc-lib/src/work_roster.rs
+++ b/crates/airc-lib/src/work_roster.rs
@@ -88,6 +88,7 @@ impl WorkRosterStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkRosterRow {
     pub peer: PeerId,
+    pub client_id: Option<String>,
     pub liveness: Option<AgentLiveness>,
     pub availability: Option<AgentAvailabilityRecord>,
     pub active_claims: Vec<WorkCard>,
@@ -157,7 +158,9 @@ impl RosterRows {
 
     fn upsert_liveness(&mut self, liveness: AgentLiveness) {
         let peer = liveness.peer;
-        self.row_mut(peer).liveness = Some(liveness);
+        let key = row_key(peer, liveness.client_id.as_deref());
+        let client_id = liveness.client_id.clone();
+        self.row_mut_with_key(key, peer, client_id).liveness = Some(liveness);
     }
 
     fn upsert_availability(&mut self, availability: AgentAvailabilityRecord) {
@@ -173,14 +176,22 @@ impl RosterRows {
     }
 
     fn row_mut(&mut self, peer: PeerId) -> &mut WorkRosterRow {
-        self.rows
-            .entry(peer.to_string())
-            .or_insert_with(|| WorkRosterRow {
-                peer,
-                liveness: None,
-                availability: None,
-                active_claims: Vec::new(),
-            })
+        self.row_mut_with_key(row_key(peer, None), peer, None)
+    }
+
+    fn row_mut_with_key(
+        &mut self,
+        key: String,
+        peer: PeerId,
+        client_id: Option<String>,
+    ) -> &mut WorkRosterRow {
+        self.rows.entry(key).or_insert_with(|| WorkRosterRow {
+            peer,
+            client_id,
+            liveness: None,
+            availability: None,
+            active_claims: Vec::new(),
+        })
     }
 
     fn into_sorted_rows(self, now_ms: u64) -> Vec<WorkRosterRow> {
@@ -207,9 +218,22 @@ impl RosterRows {
                                 .map(|record| record.report.repo.to_string()),
                         )
                 })
+                .then_with(|| {
+                    left.client_id
+                        .as_deref()
+                        .unwrap_or("")
+                        .cmp(right.client_id.as_deref().unwrap_or(""))
+                })
                 .then_with(|| left.peer.to_string().cmp(&right.peer.to_string()))
         });
         rows
+    }
+}
+
+fn row_key(peer: PeerId, client_id: Option<&str>) -> String {
+    match client_id {
+        Some(client_id) => format!("{peer}\0{client_id}"),
+        None => peer.to_string(),
     }
 }
 


### PR DESCRIPTION
## Summary
- wire `airc join` live contexts to emit typed active-agent heartbeats automatically
- include runtime client id, scope, and build metadata so roster can distinguish multiple agent tabs instead of flattening by peer
- render heartbeat metadata in `airc work roster`
- add an e2e regression proving `airc join` makes a streaming agent visible in the roster

## Roadmap / Card
- closes work card `e6c377b7-bda4-4776-b99d-911ce299282d` from the manager-loop idle-agent follow-up
- advances `docs/architecture/GRID-SUBSTRATE-AUDIT.md` active-agent liveness / idle-detection path

## Verification
- `cargo fmt --manifest-path Cargo.toml -p airc-lib -p airc-cli --check`
- `cargo test --manifest-path Cargo.toml -p airc-lib agent_heartbeat -- --nocapture`
- `cargo test --manifest-path Cargo.toml -p airc-cli join_streaming_agent_publishes_roster_heartbeat -- --nocapture`
- `cargo test --manifest-path Cargo.toml -p airc-cli work_roster_surfaces_availability_and_claims -- --nocapture`
- `cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings`
- `cargo test --manifest-path Cargo.toml -p airc-lib -p airc-cli`