### PR TITLE
fix(work): find active cards beyond small recent windows

### DIFF
--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -17,7 +17,7 @@ use airc_work_store::WorkEventStore;
 use crate::time::now_ms;
 use crate::{Airc, AircError};
 
-const WORK_MUTATION_LOOKBACK_LIMIT: usize = 4_096;
+const WORK_MUTATION_PAGE_SIZE: usize = 512;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateWorkCard {
@@ -663,7 +663,7 @@ impl Airc {
         self.ensure_room_subscriber(&room).await?;
         let store = WorkEventStore::new(self.event_store());
         let board = store
-            .project_recent(Some(room.channel), WORK_MUTATION_LOOKBACK_LIMIT)
+            .project_complete(Some(room.channel), WORK_MUTATION_PAGE_SIZE)
             .await?;
         if board.card(card_id).is_some() {
             return Ok(());
@@ -680,7 +680,7 @@ impl Airc {
         let room = self.current_room().await?;
         let store = WorkEventStore::new(self.event_store());
         let board = store
-            .project_recent(Some(room.channel), WORK_MUTATION_LOOKBACK_LIMIT)
+            .project_complete(Some(room.channel), WORK_MUTATION_PAGE_SIZE)
             .await?;
         let Some(card) = board.card(card_id) else {
             return Err(AircError::WorkCardNotInCurrentRoom {

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -17,6 +17,8 @@ use airc_work_store::WorkEventStore;
 use crate::time::now_ms;
 use crate::{Airc, AircError};
 
+const WORK_MUTATION_LOOKBACK_LIMIT: usize = 4_096;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateWorkCard {
     pub repo: RepoId,
@@ -660,7 +662,9 @@ impl Airc {
         let room = self.current_room().await?;
         self.ensure_room_subscriber(&room).await?;
         let store = WorkEventStore::new(self.event_store());
-        let board = store.project_recent(Some(room.channel), 512).await?;
+        let board = store
+            .project_recent(Some(room.channel), WORK_MUTATION_LOOKBACK_LIMIT)
+            .await?;
         if board.card(card_id).is_some() {
             return Ok(());
         }
@@ -675,7 +679,9 @@ impl Airc {
     async fn ensure_work_card_unclaimed(&self, card_id: WorkCardId) -> Result<(), AircError> {
         let room = self.current_room().await?;
         let store = WorkEventStore::new(self.event_store());
-        let board = store.project_recent(Some(room.channel), 512).await?;
+        let board = store
+            .project_recent(Some(room.channel), WORK_MUTATION_LOOKBACK_LIMIT)
+            .await?;
         let Some(card) = board.card(card_id) else {
             return Err(AircError::WorkCardNotInCurrentRoom {
                 card_id,

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -209,6 +209,46 @@ async fn work_card_transitions_refuse_cards_from_another_room() {
 }
 
 #[tokio::test]
+async fn work_card_mutations_find_cards_beyond_small_recent_window() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("work-mutation-lookback").await.unwrap();
+
+    let card_id = airc
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            title: "old but active work".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+        })
+        .await
+        .unwrap();
+    wait_for_card(&airc, card_id).await;
+
+    for idx in 0..600 {
+        airc.say(&format!("non-work coordination message {idx}"))
+            .await
+            .unwrap();
+    }
+
+    assert!(
+        airc.work_board(512).await.unwrap().card(card_id).is_none(),
+        "the small recent window reproduces the production failure"
+    );
+
+    airc.change_work_card_state(ChangeWorkCardState {
+        card_id,
+        state: CardState::Closed,
+    })
+    .await
+    .unwrap();
+
+    let board = airc.work_board(1_024).await.unwrap();
+    assert_eq!(board.card(card_id).unwrap().state, CardState::Closed);
+}
+
+#[tokio::test]
 async fn duplicate_work_card_claims_fail_before_poisoning_projection() {
     let home = TempDir::new().unwrap();
     let airc = Airc::open(home.path()).await.unwrap();

--- a/crates/airc-work-store/src/lib.rs
+++ b/crates/airc-work-store/src/lib.rs
@@ -8,7 +8,7 @@
 
 #![deny(unsafe_code)]
 
-use airc_core::{RoomId, TranscriptCursor, TranscriptEvent};
+use airc_core::{EventId, RoomId, TranscriptCursor, TranscriptEvent};
 use airc_store::{EventStore, StoreError};
 use airc_work::{
     decode_transcript_work_event, transcript_is_work_event, ProjectionError, WorkBoardProjection,
@@ -79,6 +79,35 @@ where
     ) -> Result<WorkBoardProjection, WorkStoreError> {
         let page = self.resume_from(cursor, channel, limit).await?;
         Ok(WorkBoardProjection::replay(page.events)?)
+    }
+
+    pub async fn project_complete(
+        &self,
+        channel: Option<RoomId>,
+        page_size: usize,
+    ) -> Result<WorkBoardProjection, WorkStoreError> {
+        let page_size = page_size.max(1);
+        let mut cursor = TranscriptCursor {
+            lamport: 0,
+            event_id: EventId::from_u128(0),
+        };
+        let mut events = Vec::new();
+
+        loop {
+            let transcripts = self.store.resume_from(&cursor, channel, page_size).await?;
+            let transcript_count = transcripts.len();
+            let Some(newest_cursor) = transcripts.last().map(TranscriptEvent::cursor) else {
+                break;
+            };
+            let page = decode_page(transcripts)?;
+            events.extend(page.events);
+            cursor = newest_cursor;
+            if transcript_count < page_size {
+                break;
+            }
+        }
+
+        Ok(WorkBoardProjection::replay(events)?)
     }
 }
 

--- a/crates/airc-work-store/src/tests.rs
+++ b/crates/airc-work-store/src/tests.rs
@@ -154,6 +154,41 @@ async fn project_recent_skips_events_whose_anchor_is_outside_window() {
 }
 
 #[tokio::test]
+async fn project_complete_pages_from_start_without_recent_window_loss() {
+    let store = InMemoryEventStore::new();
+    let room = RoomId::from_u128(10);
+    let old_card = WorkCardId::from_u128(20);
+
+    store
+        .append(work_transcript(1, room, 1, &card_created(old_card)))
+        .await
+        .unwrap();
+    for idx in 0..8 {
+        store
+            .append(chat_transcript(100 + idx, room, 2 + idx as u64))
+            .await
+            .unwrap();
+    }
+    store
+        .append(work_transcript(2, room, 20, &card_state_changed(old_card)))
+        .await
+        .unwrap();
+
+    let recent = WorkEventStore::new(&store)
+        .project_recent(Some(room), 4)
+        .await
+        .unwrap();
+    assert!(recent.card(old_card).is_none());
+
+    let complete = WorkEventStore::new(&store)
+        .project_complete(Some(room), 3)
+        .await
+        .unwrap();
+    let card = complete.card(old_card).unwrap();
+    assert_eq!(card.state, CardState::Review);
+}
+
+#[tokio::test]
 async fn resume_from_uses_store_cursor_contract() {
     let store = InMemoryEventStore::new();
     let room = RoomId::from_u128(10);


### PR DESCRIPTION
## Summary
- add WorkEventStore::project_complete to replay a room work stream from the beginning in bounded pages
- route work-card mutation guards through complete projection instead of an arbitrary recent transcript window
- add regressions for both store-level paging and SDK mutation after chat noise pushes a card outside the small recent board window

## Fixes
- AIRC work card 190a604a-cef8-46bb-90e4-f2f1ff9ece01
- Unblocks closing Continuum card 6b564a9a-ba4f-4bc4-8ba8-c0fe88dd0eaa after continuum#1436 merged

## Verification
- cargo test --manifest-path Cargo.toml -p airc-work-store project_complete_pages_from_start_without_recent_window_loss
- cargo test --manifest-path Cargo.toml -p airc-lib --test work_api work_card_mutations_find_cards_beyond_small_recent_window
- cargo test --manifest-path Cargo.toml -p airc-lib --test work_api
- cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-work-store --all-targets -- -D warnings