### PR TITLE
fix(work): schedule from complete work projection

### DIFF
--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -537,14 +537,30 @@ impl Airc {
     }
 
     /// Rebuild the current room's work board from persisted work
-    /// events. `limit` is the transcript page size; callers that need
-    /// complete history should pass a sufficiently high limit until a
-    /// dedicated paged board API lands.
+    /// events. `limit` is the transcript page size for interactive
+    /// board views; scheduling code should use
+    /// [`Airc::work_board_complete`] instead.
     pub async fn work_board(&self, limit: usize) -> Result<WorkBoardProjection, AircError> {
         let room = self.current_room().await?;
         self.ensure_room_subscriber(&room).await?;
         let store = WorkEventStore::new(self.event_store());
         Ok(store.project_recent(Some(room.channel), limit).await?)
+    }
+
+    /// Rebuild the current room's complete work board in bounded store
+    /// pages. Scheduling and mutation paths use this so old active
+    /// cards do not disappear just because chat/status traffic pushed
+    /// their creation event outside a recent transcript window.
+    pub async fn work_board_complete(
+        &self,
+        page_size: usize,
+    ) -> Result<WorkBoardProjection, AircError> {
+        let room = self.current_room().await?;
+        self.ensure_room_subscriber(&room).await?;
+        let store = WorkEventStore::new(self.event_store());
+        Ok(store
+            .project_complete(Some(room.channel), page_size)
+            .await?)
     }
 
     /// Return work cards this peer could reasonably take next. This
@@ -565,7 +581,7 @@ impl Airc {
         &self,
         query: WorkQueueStatusQuery,
     ) -> Result<WorkQueueStatus, AircError> {
-        let board = self.work_board(query.event_limit).await?;
+        let board = self.work_board_complete(query.event_limit).await?;
         let now_ms = now_ms()?;
         let stale_claims = board.stale_claims(now_ms);
         let snapshot = board.snapshot();

--- a/crates/airc-lib/src/work_roster.rs
+++ b/crates/airc-lib/src/work_roster.rs
@@ -102,7 +102,7 @@ impl Airc {
         &self,
         query: WorkRosterQuery,
     ) -> Result<WorkRosterStatus, AircError> {
-        let board = self.work_board(query.event_limit).await?;
+        let board = self.work_board_complete(query.event_limit).await?;
         let snapshot = board.snapshot();
         let now_ms = now_ms()?;
         let active_agents = self

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -249,6 +249,57 @@ async fn work_card_mutations_find_cards_beyond_small_recent_window() {
 }
 
 #[tokio::test]
+async fn scheduling_finds_claimable_cards_beyond_small_recent_window() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("work-scheduling-complete-board").await.unwrap();
+
+    let card_id = airc
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            title: "old claimable work".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+        })
+        .await
+        .unwrap();
+    wait_for_card(&airc, card_id).await;
+
+    for idx in 0..600 {
+        airc.say(&format!("non-work scheduling noise {idx}"))
+            .await
+            .unwrap();
+    }
+
+    assert!(
+        airc.work_board(512).await.unwrap().card(card_id).is_none(),
+        "interactive recent board no longer contains the old card"
+    );
+
+    let claimable = airc
+        .claimable_work(ClaimableWorkQuery {
+            event_limit: 128,
+            ..ClaimableWorkQuery::default()
+        })
+        .await
+        .unwrap();
+    assert!(
+        claimable.iter().any(|item| item.card.card_id == card_id),
+        "scheduler must use complete projection, not the recent board window"
+    );
+
+    let roster = airc
+        .work_roster_status(WorkRosterQuery {
+            event_limit: 128,
+            ..WorkRosterQuery::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(roster.claimable_count, 1);
+}
+
+#[tokio::test]
 async fn duplicate_work_card_claims_fail_before_poisoning_projection() {
     let home = TempDir::new().unwrap();
     let airc = Airc::open(home.path()).await.unwrap();

--- a/crates/airc-work-store/src/lib.rs
+++ b/crates/airc-work-store/src/lib.rs
@@ -107,7 +107,7 @@ where
             }
         }
 
-        Ok(WorkBoardProjection::replay(events)?)
+        Ok(WorkBoardProjection::replay_window(events)?)
     }
 }
 

--- a/crates/airc-work-store/src/tests.rs
+++ b/crates/airc-work-store/src/tests.rs
@@ -189,6 +189,35 @@ async fn project_complete_pages_from_start_without_recent_window_loss() {
 }
 
 #[tokio::test]
+async fn project_complete_tolerates_orphaned_work_events() {
+    let store = InMemoryEventStore::new();
+    let room = RoomId::from_u128(10);
+    let orphan_card = WorkCardId::from_u128(19);
+    let valid_card = WorkCardId::from_u128(20);
+
+    store
+        .append(work_transcript(
+            1,
+            room,
+            1,
+            &card_state_changed(orphan_card),
+        ))
+        .await
+        .unwrap();
+    store
+        .append(work_transcript(2, room, 2, &card_created(valid_card)))
+        .await
+        .unwrap();
+
+    let complete = WorkEventStore::new(&store)
+        .project_complete(Some(room), 1)
+        .await
+        .unwrap();
+    assert!(complete.card(orphan_card).is_none());
+    assert!(complete.card(valid_card).is_some());
+}
+
+#[tokio::test]
 async fn resume_from_uses_store_cursor_contract() {
     let store = InMemoryEventStore::new();
     let room = RoomId::from_u128(10);


### PR DESCRIPTION
## Summary
- add Airc::work_board_complete for bounded complete work projection
- use complete projection for work_queue_status / claimable_work and roster claimable counts
- add a regression where an old open card falls outside the 512-event recent board window but remains schedulable

## Why
The mutation bug is fixed, but manager/scheduler paths still used recent transcript windows. That can recreate idle lock: agents see no work even though old open cards still exist in the room.

## Verification
- cargo test --manifest-path Cargo.toml -p airc-lib --test work_api scheduling_finds_claimable_cards_beyond_small_recent_window
- cargo test --manifest-path Cargo.toml -p airc-lib work_manager
- cargo clippy --manifest-path Cargo.toml -p airc-lib --all-targets -- -D warnings