### PR TITLE
feat(room-context): budgeted evidence assembly for managers + hooks

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -268,6 +268,22 @@ pub enum Command {
         kind: PublishFrameKind,
     },
 
+    /// Emit a budgeted JSON slice of the current room's evidence
+    /// (recent events, work cards, active claims) for manager
+    /// loops, hooks injecting context at prompt boundaries, and
+    /// RAG-style consumers. Deterministic ordering; ContextTotals
+    /// reports what was seen vs kept so consumers can detect
+    /// truncation.
+    Context {
+        /// Maximum total items across all evidence types.
+        #[arg(long, default_value_t = 64)]
+        max_items: usize,
+        /// Optional age cap in milliseconds; drop evidence older
+        /// than this.
+        #[arg(long)]
+        max_age_ms: Option<u64>,
+    },
+
     /// Pull buffered frames from the daemon's inbox for the current
     /// room's wire.
     Inbox {

--- a/crates/airc-cli/src/context_commands.rs
+++ b/crates/airc-cli/src/context_commands.rs
@@ -1,0 +1,27 @@
+//! `airc context` — emit a budgeted JSON slice of room evidence
+//! for managers, hooks, and RAG consumers.
+//!
+//! Thin pass-through over [`Airc::room_context`]. Output is one
+//! line of JSON suitable for `jq`.
+
+use std::path::Path;
+
+use airc_lib::{Airc, ContextBudget};
+
+pub async fn run_context(
+    home: &Path,
+    max_items: usize,
+    max_age_ms: Option<u64>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let slice = airc
+        .room_context(ContextBudget {
+            max_items,
+            max_age_ms,
+        })
+        .await?;
+    let line = serde_json::to_string(&slice)
+        .map_err(|error| format!("serialize context slice: {error}"))?;
+    println!("{line}");
+    Ok(())
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -20,6 +20,7 @@ mod collaboration_cli;
 mod collaboration_commands;
 mod collaboration_peers;
 mod commands;
+mod context_commands;
 mod daemon_scope;
 mod doctor;
 mod envelope_cli;
@@ -353,6 +354,11 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             headers,
             kind,
         } => publish_commands::run_publish(&home, room, body_text, body_json, headers, kind).await,
+
+        Command::Context {
+            max_items,
+            max_age_ms,
+        } => context_commands::run_context(&home, max_items, max_age_ms).await,
 
         Command::Inbox {
             socket,

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -56,6 +56,7 @@ pub mod publish;
 pub mod registry;
 mod relay;
 pub mod room;
+pub mod room_context;
 pub mod route;
 mod stream;
 pub mod subscriptions;
@@ -115,6 +116,10 @@ pub use peers::EnrolledPeer;
 pub use publish::{PublishReceipt, PublishTarget};
 pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use room::Room;
+pub use room_context::{
+    CardSummary, ClaimSummary, ContextBudget, ContextItem, ContextSlice, ContextTotals,
+    EventSummary,
+};
 pub use route::{
     ImportedInvite, InviteBeacon, RouteClass, RouteDecision, RouteDiscoverySnapshot, RouteEndpoint,
     RoutePolicy, TransportCandidate, TransportHealthSample, TransportHealthState,

--- a/crates/airc-lib/src/room_context.rs
+++ b/crates/airc-lib/src/room_context.rs
@@ -1,0 +1,409 @@
+//! Typed, budgeted room-context assembly for managers, RAG
+//! consumers, and prompt-boundary hooks.
+//!
+//! Closes work card d3930e42 (P1, first slice): "Add budgeted
+//! room-context assembly for manager and RAG consumers".
+//!
+//! Consumers (managers, hooks, RAG processes, Continuum
+//! personas) need to slice the current room's evidence —
+//! recent events, work cards, active claims — into a bounded
+//! payload they can hand to a prompt or a planning loop. Today
+//! they either scrape `airc work board`/`airc events list`
+//! output (the very `stdout parsing` the card forbids) or
+//! re-implement the queries each time.
+//!
+//! This module gives them ONE typed call:
+//!
+//! ```ignore
+//! let slice = airc.room_context(ContextBudget {
+//!     max_items: 64,
+//!     max_age_ms: Some(60 * 60 * 1000),
+//! }).await?;
+//! ```
+//!
+//! `ContextSlice` is JSON-serialisable so the CLI emits it
+//! verbatim for shell/Python consumers, and the in-process
+//! consumers (Continuum/OpenClaw/Hermes per the audits in
+//! #1002 / #1003) link it as a typed value without parsing.
+//!
+//! ## Scope cut (this PR)
+//!
+//! - Evidence types: room events, work cards, active claims.
+//! - Budgets: `max_items` (deterministic fill order) and
+//!   `max_age_ms` (drop everything older).
+//!
+//! ## Explicit non-scope (each is a separate card)
+//!
+//! - Token budget — needs a tokenizer dependency. Consumers
+//!   that care can apply their own tokenizer over the JSON-
+//!   serialised slice for the first iteration.
+//! - PR / CI status integration — waits on the local-git +
+//!   pull-request primitives shipping to airc-lib.
+//! - Roadmap-gap evidence — needs the markdown-sync card
+//!   (fe57c6fa) to land first.
+//! - Capability state — needs the capability advertisement
+//!   shape from the Hermes audit (#1003 follow-ups).
+//! - Hook prompt-boundary consumer wiring — belongs in the
+//!   runtime-planning hooks card (1702d553, already merged
+//!   docs in #1001).
+//!
+//! ## Determinism + ordering
+//!
+//! The slice is deterministic: same store contents + same
+//! budget produce the same slice. Ordering inside the slice:
+//!
+//! 1. Events: newest first (descending `lamport`).
+//! 2. Work cards: priority ascending (P0 first), then state
+//!    bucket (claimable > in-progress > review > closed),
+//!    then `updated_at_ms` descending.
+//! 3. Active claims: `claim_expires_at_ms` ascending (about-
+//!    to-expire surfaces first).
+//!
+//! Items are interleaved in the output by type group in the
+//! order above, fill-stopping when `max_items` is hit. The
+//! `ContextTotals` field on the slice reports what was seen
+//! vs kept so consumers can detect truncation.
+
+use std::collections::BTreeMap;
+
+use airc_core::{EventId, PeerId, RoomId, TranscriptEvent};
+use airc_work::{CardState, ClaimId, Priority, WorkCard, WorkCardId};
+use serde::{Deserialize, Serialize};
+
+use crate::error::AircError;
+use crate::time::now_ms;
+use crate::Airc;
+
+/// How much evidence to keep in a [`ContextSlice`]. Caller-
+/// provided so different consumers (a hook injecting context
+/// at prompt boundary vs a manager-loop replay) can tune
+/// independently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextBudget {
+    /// Total number of items across all evidence types in the
+    /// slice. Hard cap; fill order is documented in the module
+    /// header.
+    pub max_items: usize,
+    /// Drop evidence older than this. `None` means no age
+    /// cap. Measured against `now_ms` at assembly time.
+    pub max_age_ms: Option<u64>,
+}
+
+impl Default for ContextBudget {
+    fn default() -> Self {
+        // 64 items + 1h window — small enough to fit
+        // a model context, big enough to span a typical
+        // multi-agent coordination burst.
+        Self {
+            max_items: 64,
+            max_age_ms: Some(60 * 60 * 1000),
+        }
+    }
+}
+
+/// One piece of room evidence. Tagged so consumers can
+/// pattern-match without re-deriving the type from a field
+/// name.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ContextItem {
+    /// A recent room event, summarised to keep the slice
+    /// bounded. Full transcript still accessible via
+    /// `airc events list`.
+    Event(EventSummary),
+    /// A work card in this room.
+    WorkCard(CardSummary),
+    /// An active (non-expired) claim on a card in this room.
+    ActiveClaim(ClaimSummary),
+}
+
+/// Compact event summary for context slices. Drops the full
+/// body — consumers that need it can re-fetch by `event_id`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventSummary {
+    pub event_id: EventId,
+    pub peer_id: PeerId,
+    pub lamport: u64,
+    pub occurred_at_ms: u64,
+    pub kind: String,
+    /// First few headers (top-level keys only) so consumers
+    /// can filter; bounded so a single event can't blow the
+    /// budget on its own.
+    pub headers: BTreeMap<String, String>,
+}
+
+/// Compact work-card summary. Mirrors `WorkCard` but drops the
+/// body (often long) for slice-size predictability.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CardSummary {
+    pub card_id: WorkCardId,
+    pub repo: String,
+    pub title: String,
+    pub priority: Priority,
+    pub state: CardState,
+    pub owner: Option<PeerId>,
+    pub claim_id: Option<ClaimId>,
+    pub claim_expires_at_ms: Option<u64>,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+}
+
+/// Active-claim summary. About-to-expire claims are
+/// surfaced first because they're the most actionable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaimSummary {
+    pub card_id: WorkCardId,
+    pub claim_id: ClaimId,
+    pub owner: PeerId,
+    pub claim_expires_at_ms: u64,
+    pub last_heartbeat_at_ms: Option<u64>,
+}
+
+/// What was seen vs what fit in the budget. Lets consumers
+/// detect truncation and decide whether to re-query with a
+/// larger budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ContextTotals {
+    pub events_seen: usize,
+    pub events_kept: usize,
+    pub cards_seen: usize,
+    pub cards_kept: usize,
+    pub claims_seen: usize,
+    pub claims_kept: usize,
+}
+
+/// A budgeted snapshot of the current room's evidence.
+///
+/// Deterministic: same store + same budget produces the same
+/// slice. JSON-serialisable so the CLI can emit it verbatim
+/// for shell consumers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextSlice {
+    pub room_id: RoomId,
+    pub room_name: String,
+    /// Unix-ms timestamp captured at assembly start. Reading
+    /// it lets consumers detect a stale slice when comparing
+    /// against `EventSummary.occurred_at_ms`.
+    pub assembled_at_ms: u64,
+    pub budget: ContextBudget,
+    pub items: Vec<ContextItem>,
+    pub totals: ContextTotals,
+}
+
+/// Default per-room event scan window when consumers don't
+/// override. Big enough to cover the typical multi-agent
+/// coordination history, small enough that decode + sort is
+/// fast on every call.
+const DEFAULT_EVENT_SCAN_WINDOW: usize = 1024;
+
+impl Airc {
+    /// Assemble a budgeted slice of the current room's
+    /// evidence. See module docs for fill-order semantics.
+    pub async fn room_context(&self, budget: ContextBudget) -> Result<ContextSlice, AircError> {
+        self.room_context_with_scan_window(budget, DEFAULT_EVENT_SCAN_WINDOW)
+            .await
+    }
+
+    /// Variant of [`Self::room_context`] with an explicit
+    /// per-source scan window. Tests use it to build small
+    /// deterministic transcripts; production callers should
+    /// use [`Self::room_context`].
+    pub async fn room_context_with_scan_window(
+        &self,
+        budget: ContextBudget,
+        event_scan_window: usize,
+    ) -> Result<ContextSlice, AircError> {
+        let room = self.current_room().await?;
+        let assembled_at_ms = now_ms()?;
+        let min_occurred_at_ms = budget
+            .max_age_ms
+            .and_then(|window| assembled_at_ms.checked_sub(window));
+
+        // ----- events -----
+        let recent_events = self.page_recent(event_scan_window).await?;
+        let events_seen = recent_events.len();
+        let mut event_summaries: Vec<EventSummary> = recent_events
+            .into_iter()
+            .filter(|event| min_occurred_at_ms.is_none_or(|min| event.occurred_at_ms >= min))
+            .map(EventSummary::from_transcript)
+            .collect();
+        // Newest first.
+        event_summaries.sort_by_key(|event| std::cmp::Reverse(event.lamport));
+
+        // ----- work cards (already room-scoped projection) -----
+        let board = self.work_board(event_scan_window).await?;
+        let now_ms_for_claims = assembled_at_ms;
+        let board_snapshot = board.snapshot();
+        let cards_seen = board_snapshot.cards.len();
+        let mut card_summaries: Vec<CardSummary> = board_snapshot
+            .cards
+            .iter()
+            .filter(|card| min_occurred_at_ms.is_none_or(|min| card.updated_at_ms >= min))
+            .map(CardSummary::from_work_card)
+            .collect();
+        card_summaries.sort_by(card_priority_then_state_then_recency);
+
+        // ----- active claims -----
+        let mut active_claims: Vec<ClaimSummary> = board_snapshot
+            .cards
+            .iter()
+            .filter(|card| {
+                card.claim_id.is_some()
+                    && card
+                        .claim_expires_at_ms
+                        .is_some_and(|expires| expires > now_ms_for_claims)
+            })
+            .filter_map(ClaimSummary::from_work_card)
+            .collect();
+        let claims_seen = active_claims.len();
+        active_claims.sort_by_key(|claim| claim.claim_expires_at_ms);
+
+        // ----- fill items in declared order until budget hits -----
+        let mut items = Vec::with_capacity(budget.max_items);
+        let mut events_kept = 0usize;
+        let mut cards_kept = 0usize;
+        let mut claims_kept = 0usize;
+        for event in event_summaries {
+            if items.len() >= budget.max_items {
+                break;
+            }
+            items.push(ContextItem::Event(event));
+            events_kept += 1;
+        }
+        for card in card_summaries {
+            if items.len() >= budget.max_items {
+                break;
+            }
+            items.push(ContextItem::WorkCard(card));
+            cards_kept += 1;
+        }
+        for claim in active_claims {
+            if items.len() >= budget.max_items {
+                break;
+            }
+            items.push(ContextItem::ActiveClaim(claim));
+            claims_kept += 1;
+        }
+
+        Ok(ContextSlice {
+            room_id: room.channel,
+            room_name: room.name,
+            assembled_at_ms,
+            budget,
+            items,
+            totals: ContextTotals {
+                events_seen,
+                events_kept,
+                cards_seen,
+                cards_kept,
+                claims_seen,
+                claims_kept,
+            },
+        })
+    }
+}
+
+fn card_priority_then_state_then_recency(
+    left: &CardSummary,
+    right: &CardSummary,
+) -> std::cmp::Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| state_bucket(left.state).cmp(&state_bucket(right.state)))
+        .then_with(|| right.updated_at_ms.cmp(&left.updated_at_ms))
+        .then_with(|| left.card_id.cmp(&right.card_id))
+}
+
+fn state_bucket(state: CardState) -> u8 {
+    match state {
+        CardState::Open => 0,
+        CardState::Claimed | CardState::InProgress => 1,
+        CardState::Blocked => 2,
+        CardState::Review => 3,
+        CardState::Merged => 4,
+        CardState::Closed => 5,
+    }
+}
+
+impl EventSummary {
+    fn from_transcript(event: TranscriptEvent) -> Self {
+        let headers = event
+            .headers
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        Self {
+            event_id: event.event_id,
+            peer_id: event.peer_id,
+            lamport: event.lamport,
+            occurred_at_ms: event.occurred_at_ms,
+            kind: format!("{:?}", event.kind).to_lowercase(),
+            headers,
+        }
+    }
+}
+
+impl CardSummary {
+    fn from_work_card(card: &WorkCard) -> Self {
+        Self {
+            card_id: card.card_id,
+            repo: card.repo.to_string(),
+            title: card.title.clone(),
+            priority: card.priority,
+            state: card.state,
+            owner: card.owner,
+            claim_id: card.claim_id,
+            claim_expires_at_ms: card.claim_expires_at_ms,
+            created_at_ms: card.created_at_ms,
+            updated_at_ms: card.updated_at_ms,
+        }
+    }
+}
+
+impl ClaimSummary {
+    fn from_work_card(card: &WorkCard) -> Option<Self> {
+        Some(Self {
+            card_id: card.card_id,
+            claim_id: card.claim_id?,
+            owner: card.owner?,
+            claim_expires_at_ms: card.claim_expires_at_ms?,
+            last_heartbeat_at_ms: card.last_heartbeat_at_ms,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_budget_default_is_sane() {
+        let budget = ContextBudget::default();
+        assert_eq!(budget.max_items, 64);
+        assert!(budget.max_age_ms.is_some_and(|ms| ms > 0));
+    }
+
+    #[test]
+    fn context_slice_round_trips_as_snake_case_json() {
+        let slice = ContextSlice {
+            room_id: RoomId::from_uuid(uuid::Uuid::nil()),
+            room_name: "test-room".to_string(),
+            assembled_at_ms: 1_700_000_000_000,
+            budget: ContextBudget::default(),
+            items: Vec::new(),
+            totals: ContextTotals::default(),
+        };
+        let value = serde_json::to_value(&slice).expect("encode");
+        assert_eq!(value["room_name"], "test-room");
+        assert_eq!(value["assembled_at_ms"], 1_700_000_000_000_u64);
+        let round_trip: ContextSlice = serde_json::from_value(value).expect("decode");
+        assert_eq!(round_trip.room_name, "test-room");
+    }
+
+    #[test]
+    fn state_bucket_orders_claimable_before_review_before_closed() {
+        assert!(state_bucket(CardState::Open) < state_bucket(CardState::Claimed));
+        assert!(state_bucket(CardState::Claimed) < state_bucket(CardState::Review));
+        assert!(state_bucket(CardState::Review) < state_bucket(CardState::Closed));
+    }
+}

--- a/crates/airc-lib/tests/room_context.rs
+++ b/crates/airc-lib/tests/room_context.rs
@@ -1,0 +1,190 @@
+//! Integration: budgeted room-context assembly produces a
+//! deterministic, bounded slice of room evidence.
+//!
+//! Proves work card d3930e42 (first slice).
+
+use std::time::Duration;
+
+use airc_lib::{Airc, ClaimWorkCard, ContextBudget, ContextItem, CreateWorkCard, Priority, RepoId};
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn room_context_respects_max_items_budget() {
+    let home = TempDir::new().expect("home");
+    let airc = Airc::open(home.path()).await.expect("open");
+    let wire = TempDir::new().expect("wire");
+    airc.join_with_wire("budget-test", wire.path().join("wire.jsonl"))
+        .await
+        .expect("join");
+
+    // Stuff the room with chat messages so the budget kicks in.
+    for i in 0..20u32 {
+        airc.say(&format!("noise #{i}")).await.expect("say");
+    }
+
+    let slice = airc
+        .room_context(ContextBudget {
+            max_items: 5,
+            max_age_ms: None,
+        })
+        .await
+        .expect("room_context");
+
+    assert!(
+        slice.items.len() <= 5,
+        "items must respect max_items, got {}",
+        slice.items.len()
+    );
+    assert_eq!(slice.totals.events_kept, slice.items.len());
+    assert!(
+        slice.totals.events_seen >= 20,
+        "events_seen should report what was scanned, got {}",
+        slice.totals.events_seen
+    );
+}
+
+#[tokio::test]
+async fn room_context_orders_events_newest_first() {
+    let home = TempDir::new().expect("home");
+    let airc = Airc::open(home.path()).await.expect("open");
+    let wire = TempDir::new().expect("wire");
+    airc.join_with_wire("ordering", wire.path().join("wire.jsonl"))
+        .await
+        .expect("join");
+
+    // Need distinguishable timestamps + lamports.
+    for i in 0..3u32 {
+        airc.say(&format!("msg-{i}")).await.expect("say");
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    let slice = airc
+        .room_context(ContextBudget {
+            max_items: 64,
+            max_age_ms: None,
+        })
+        .await
+        .expect("room_context");
+
+    let lamports: Vec<u64> = slice
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            ContextItem::Event(e) => Some(e.lamport),
+            _ => None,
+        })
+        .collect();
+    assert!(!lamports.is_empty(), "should have events");
+    for window in lamports.windows(2) {
+        assert!(
+            window[0] >= window[1],
+            "events should be sorted lamport desc: {window:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn room_context_includes_work_cards_and_active_claims() {
+    let home = TempDir::new().expect("home");
+    let airc = Airc::open(home.path()).await.expect("open");
+    let wire = TempDir::new().expect("wire");
+    airc.join_with_wire("cards", wire.path().join("wire.jsonl"))
+        .await
+        .expect("join");
+
+    let card_id = airc
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new("test-org/test-repo").expect("repo"),
+            title: "context-test card".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+        })
+        .await
+        .expect("create card");
+
+    let _claim_id = airc
+        .claim_work_card(ClaimWorkCard {
+            card_id,
+            ttl_ms: 60_000,
+        })
+        .await
+        .expect("claim");
+
+    let slice = airc
+        .room_context(ContextBudget {
+            max_items: 64,
+            max_age_ms: None,
+        })
+        .await
+        .expect("room_context");
+
+    let saw_card = slice
+        .items
+        .iter()
+        .any(|item| matches!(item, ContextItem::WorkCard(card) if card.card_id == card_id));
+    assert!(
+        saw_card,
+        "context must include the work card we just created"
+    );
+
+    let saw_active_claim = slice
+        .items
+        .iter()
+        .any(|item| matches!(item, ContextItem::ActiveClaim(claim) if claim.card_id == card_id));
+    assert!(
+        saw_active_claim,
+        "context must include the active claim we just created"
+    );
+    assert!(
+        slice.totals.cards_kept >= 1,
+        "totals should account for the kept card: {:?}",
+        slice.totals
+    );
+}
+
+#[tokio::test]
+async fn room_context_max_age_drops_old_events_and_records_seen() {
+    let home = TempDir::new().expect("home");
+    let airc = Airc::open(home.path()).await.expect("open");
+    let wire = TempDir::new().expect("wire");
+    airc.join_with_wire("age-cap", wire.path().join("wire.jsonl"))
+        .await
+        .expect("join");
+
+    // Publish noise BEFORE the budget window opens.
+    for i in 0..5u32 {
+        airc.say(&format!("ancient #{i}")).await.expect("say");
+    }
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Tight max_age_ms: only events emitted in the last 30ms
+    // count. The events above should be older and dropped.
+    let slice = airc
+        .room_context(ContextBudget {
+            max_items: 64,
+            max_age_ms: Some(30),
+        })
+        .await
+        .expect("room_context");
+
+    let kept_events = slice
+        .items
+        .iter()
+        .filter(|item| matches!(item, ContextItem::Event(_)))
+        .count();
+
+    // The slice may still see room-join lifecycle events that
+    // landed during assembly; the invariant we care about is
+    // that the older `say` payloads dropped.
+    assert!(
+        kept_events <= 2,
+        "tight age cap should drop the older chat noise, kept {kept_events}"
+    );
+    assert!(
+        slice.totals.events_seen >= 5,
+        "totals must still report what was scanned ({} seen)",
+        slice.totals.events_seen
+    );
+}

--- a/docs/architecture/ROOM-CONTEXT-ASSEMBLY.md
+++ b/docs/architecture/ROOM-CONTEXT-ASSEMBLY.md
@@ -1,0 +1,117 @@
+# Room context assembly — budgeted evidence for managers, hooks, and RAG consumers
+
+Closes work card **d3930e42** (P1, first slice).
+
+Anchor in the autonomous-development roadmap (`docs/architecture/AUTONOMOUS-DEVELOPMENT-ROADMAP.md`):
+the manager loop and consumer integrations (Continuum,
+OpenClaw, Hermes per #1002 / #1003) need to bundle the
+relevant room evidence into a bounded payload they can hand to
+a prompt, a planner, or a RAG retriever. Doing that against
+the raw event store today requires multi-query stitching and
+no shared budget discipline. This module gives them one typed
+call.
+
+## API
+
+```rust
+use airc_lib::{Airc, ContextBudget};
+
+let slice = airc.room_context(ContextBudget {
+    max_items: 64,
+    max_age_ms: Some(60 * 60 * 1000),
+}).await?;
+```
+
+Types ship from `airc_lib::room_context`:
+
+- `ContextBudget { max_items, max_age_ms }`
+- `ContextSlice { room_id, room_name, assembled_at_ms, budget, items, totals }`
+- `ContextItem::{Event, WorkCard, ActiveClaim}` tagged union.
+- `ContextTotals` reports `*_seen` vs `*_kept` per type so
+  consumers can detect truncation and re-query with a larger
+  budget.
+
+The whole tree is `Serialize + Deserialize` so the CLI
+(`airc context --json`) emits it verbatim for shell/jq
+consumers, and in-process Rust consumers link it as typed
+values without parsing.
+
+## CLI
+
+```
+airc context --max-items 32 --max-age-ms 3600000
+```
+
+Output: one line of JSON, ready for `jq`.
+
+## Determinism
+
+Same store + same budget produces the same slice. Ordering
+within the slice:
+
+1. **Events:** descending `lamport` (newest first).
+2. **Work cards:** ascending `priority` (P0 first), then
+   state bucket (Open → Claimed/InProgress → Blocked →
+   Review → Merged → Closed), then `updated_at_ms`
+   descending, then `card_id` for tie-breaking.
+3. **Active claims:** ascending `claim_expires_at_ms`
+   (about-to-expire first — most actionable for managers).
+
+Items are interleaved in the output by type group in that
+order, fill-stopping when `max_items` is hit. The
+`ContextTotals` field reports what was seen vs kept.
+
+## Scope cut (this PR ships)
+
+- Evidence types: room events, work cards, active claims.
+- Budgets: `max_items` (deterministic fill order) and
+  `max_age_ms` (drop everything older than the window).
+- Deterministic ordering documented + tested.
+- CLI: `airc context --json` for shell consumers.
+- Integration tests cover: budget invariant, lamport
+  ordering, work-card/active-claim inclusion, age cap.
+
+## Explicit non-scope (each is a follow-up card)
+
+- **Token budget.** Needs a tokenizer dependency. Consumers
+  that care can apply their own tokenizer over the JSON-
+  serialised slice for the first iteration. Adding a typed
+  `ContextBudget::max_tokens` is a follow-up once a tokenizer
+  primitive ships.
+- **PR / CI status integration.** Waits on the local-git +
+  pull-request observation primitives (already in
+  `airc-work` but not yet exposed as a room-scoped queryable
+  surface). Add `ContextItem::PullRequest` then.
+- **Roadmap-gap evidence.** Depends on the markdown-sync
+  card (`fe57c6fa`) landing first; once doc anchors map to
+  cards, those cards already surface through the
+  `WorkCard` evidence type.
+- **Capability state.** Depends on the capability
+  advertisement shape from the Hermes audit (#1003
+  follow-ups).
+- **Hook prompt-boundary wiring.** Belongs in the
+  runtime-planning hooks card 1702d553 — `airc context
+  --json` is the surface; wiring it into Codex/Claude
+  hooks is the consumer side.
+
+## How consumers use it
+
+- **Manager loop** (card 878cd7cb) — call `room_context`
+  each tick with a generous budget; inspect cards + claims
+  to decide whether to create/refine/notify/claim.
+- **Codex/Claude hooks** at prompt boundary — call
+  `room_context` with a tight budget and inject the JSON
+  into the system-prompt addendum.
+- **Continuum / OpenClaw / Hermes** — link `airc-lib`
+  directly per the consumer audits; subscribe to live
+  events on top of the slice for delta updates.
+
+## Cross-references
+
+- AIRC structured publish: PR #990 (`airc_lib::publish`).
+- AIRC room-scope mutation guard: PR #993 / #1004.
+- Manager loop card: 878cd7cb (in flight by Codex).
+- OpenClaw consumer audit: PR #1002.
+- Hermes consumer audit: PR #1003.
+- Autonomous roadmap anchor:
+  [`AUTONOMOUS-DEVELOPMENT-ROADMAP.md`](AUTONOMOUS-DEVELOPMENT-ROADMAP.md).


### PR DESCRIPTION
## Summary
Closes work card **d3930e42** (P1, first slice).

Gives the manager loop (878cd7cb), prompt-boundary hooks (1702d553), and consumer integrations (Continuum / OpenClaw / Hermes per #1002 / #1003) one typed call to bundle the current room's evidence — recent events + work cards + active claims — into a bounded, deterministic payload.

## API

\`\`\`rust
pub struct ContextBudget { max_items: usize, max_age_ms: Option<u64> }
pub enum ContextItem { Event(EventSummary), WorkCard(CardSummary), ActiveClaim(ClaimSummary) }
pub struct ContextSlice { room_id, room_name, assembled_at_ms, budget, items, totals }

impl Airc {
    pub async fn room_context(&self, ContextBudget) -> Result<ContextSlice, AircError>;
}
\`\`\`

CLI:

\`\`\`
airc context --max-items 32 --max-age-ms 3600000
\`\`\`

One line of JSON to stdout; jq-friendly. \`ContextTotals\` reports \`*_seen\` vs \`*_kept\` per type so consumers can detect truncation and re-query.

## Determinism + ordering
- Events: descending lamport (newest first).
- Cards: ascending priority → state bucket (Open > Claimed/InProgress > Blocked > Review > Merged > Closed) → updated_at_ms desc → card_id tie-break.
- Active claims: ascending claim_expires_at_ms (about-to-expire first — most actionable for managers).

## Test plan
- [x] 3 unit tests: default budget, ContextSlice snake_case JSON round-trip, state-bucket ordering.
- [x] 4 integration tests: max_items invariant, lamport-desc ordering, work-card + active-claim inclusion, max_age_ms drops old events.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all\` clean.
- [x] \`cargo test --workspace\` green.

## Explicit non-scope (each a follow-up card)
- Token budget (needs tokenizer).
- PR / CI status evidence.
- Roadmap-gap evidence (needs fe57c6fa).
- Capability state (Hermes audit follow-ups, #1003).
- Hook prompt-boundary consumer wiring (consumer side of 1702d553; this PR ships the CLI surface they call).

Doc: \`docs/architecture/ROOM-CONTEXT-ASSEMBLY.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)