### PR TITLE
feat(work): seed backlog from manager candidates

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -584,6 +584,17 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 lane_id,
                 priority,
             } => work_commands::run_create(&home, repo, title, body, lane_id, priority).await,
+            WorkAction::Seed {
+                repo,
+                title,
+                body,
+                lane_id,
+                priority,
+                evidence_key,
+            } => {
+                work_commands::run_seed(&home, repo, title, body, lane_id, priority, evidence_key)
+                    .await
+            }
             WorkAction::Claim {
                 card_id,
                 ttl_ms,

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -28,6 +28,27 @@ pub enum WorkAction {
         #[arg(long, value_enum, default_value = "p2")]
         priority: CliPriority,
     },
+    /// Idempotently seed a manager/roadmap/RAG candidate into this room.
+    Seed {
+        /// Repository key, e.g. `CambrianTech/airc`.
+        #[arg(long)]
+        repo: String,
+        /// Human-readable card title.
+        #[arg(long)]
+        title: String,
+        /// Optional card body.
+        #[arg(long)]
+        body: Option<String>,
+        /// Optional lane UUID to attach this card to.
+        #[arg(long)]
+        lane_id: Option<String>,
+        /// Scheduling priority.
+        #[arg(long, value_enum, default_value = "p2")]
+        priority: CliPriority,
+        /// Stable source key from a roadmap/RAG/issue adapter.
+        #[arg(long)]
+        evidence_key: Option<String>,
+    },
     /// Claim an existing work card for this peer.
     ///
     /// Refuses when the current directory is not under

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -14,9 +14,9 @@ use uuid::Uuid;
 
 use airc_lib::{
     AgentAvailabilityState, Airc, CardState, ChangeWorkCardState, ClaimId, ClaimWorkCard,
-    CreateWorkCard, LaneId, Priority, ReleaseWorkClaim, RepoId, WorkBoardProjection, WorkCardId,
-    WorkManagerRecommendation, WorkManagerRecommendationKind, WorkManagerStatus, WorkQueueStatus,
-    WorkRosterStatus,
+    CreateWorkCard, LaneId, Priority, ReleaseWorkClaim, RepoId, WorkBacklogSeedCandidate,
+    WorkBacklogSeedOutcome, WorkBoardProjection, WorkCardId, WorkManagerRecommendation,
+    WorkManagerRecommendationKind, WorkManagerStatus, WorkQueueStatus, WorkRosterStatus,
 };
 
 use crate::lease;
@@ -41,6 +41,42 @@ pub async fn run_create(
         })
         .await?;
     println!("card_id: {card_id}");
+    Ok(())
+}
+
+pub async fn run_seed(
+    home: &Path,
+    repo: String,
+    title: String,
+    body: Option<String>,
+    lane_id: Option<String>,
+    priority: CliPriority,
+    evidence_key: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let result = airc
+        .seed_work_backlog(vec![WorkBacklogSeedCandidate {
+            repo: RepoId::new(repo)?,
+            title,
+            body,
+            priority: priority.into(),
+            lane_id: parse_optional_lane_id(lane_id.as_deref())?,
+            evidence_key,
+        }])
+        .await?;
+    for item in result.items {
+        let outcome = match item.outcome {
+            WorkBacklogSeedOutcome::Created => "created",
+            WorkBacklogSeedOutcome::AlreadyRepresented => "already_represented",
+            WorkBacklogSeedOutcome::AlreadyCompleted => "already_completed",
+        };
+        println!(
+            "seeded: outcome={outcome} card_id={card_id} repo={repo} title={title}",
+            card_id = item.card_id,
+            repo = item.candidate.repo,
+            title = item.candidate.title,
+        );
+    }
     Ok(())
 }
 

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -88,6 +88,58 @@ fn work_create_claim_release_projects_on_board() {
 }
 
 #[test]
+fn work_seed_is_idempotent_for_manager_candidates() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let first = run_ok(
+        &home,
+        &[
+            "work",
+            "seed",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "manager generated card",
+            "--priority",
+            "p1",
+            "--body",
+            "evidence from roadmap",
+            "--evidence-key",
+            "roadmap:manager-generated-card",
+        ],
+    );
+    assert!(first.contains("outcome=created"), "{first}");
+    let card_id = extract_seed_card_id(&first).expect("seed prints card id");
+
+    let second = run_ok(
+        &home,
+        &[
+            "work",
+            "seed",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "manager   generated   card",
+            "--priority",
+            "p1",
+            "--evidence-key",
+            "roadmap:wording-changed",
+        ],
+    );
+    assert!(second.contains("outcome=already_represented"), "{second}");
+    assert!(second.contains(card_id), "{second}");
+
+    let board = run_ok(&home, &["work", "board"]);
+    assert_eq!(
+        board.matches("manager generated card").count(),
+        1,
+        "{board}"
+    );
+}
+
+#[test]
 fn work_board_surfaces_stale_claims() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");
@@ -518,4 +570,9 @@ fn run_expect_failure(home: &Path, args: &[&str]) -> String {
 fn extract_field<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
     text.lines()
         .find_map(|line| line.strip_prefix(prefix).map(str::trim))
+}
+
+fn extract_seed_card_id(text: &str) -> Option<&str> {
+    text.split_whitespace()
+        .find_map(|field| field.strip_prefix("card_id="))
 }

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -137,6 +137,7 @@ pub use work::{
     ReportAgentAvailability, RequestWorkspace, WorkQueueStatus, WorkQueueStatusQuery,
 };
 pub use work_manager::{
+    SeededWorkCard, WorkBacklogSeedCandidate, WorkBacklogSeedOutcome, WorkBacklogSeedResult,
     WorkManagerAgent, WorkManagerQuery, WorkManagerReason, WorkManagerRecommendation,
     WorkManagerRecommendationKind, WorkManagerStatus,
 };

--- a/crates/airc-lib/src/work_manager.rs
+++ b/crates/airc-lib/src/work_manager.rs
@@ -5,11 +5,11 @@
 //! scheduling view that agents, monitors, and future manager personas
 //! can consume directly.
 
-use airc_work::{Priority, RepoId, StaleClaim, WorkCard};
+use airc_work::{CardState, LaneId, Priority, RepoId, StaleClaim, WorkCard, WorkCardId};
 
 use crate::time::now_ms;
 use crate::{
-    AgentAvailabilityState, Airc, AircError, WorkQueueStatus, WorkQueueStatusQuery,
+    AgentAvailabilityState, Airc, AircError, CreateWorkCard, WorkQueueStatus, WorkQueueStatusQuery,
     WorkRosterQuery, WorkRosterRow, WorkRosterStatus,
 };
 
@@ -87,6 +87,62 @@ pub struct WorkManagerAgent {
     pub scope: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkBacklogSeedCandidate {
+    pub repo: RepoId,
+    pub title: String,
+    pub body: Option<String>,
+    pub priority: Priority,
+    pub lane_id: Option<LaneId>,
+    /// Stable source identifier supplied by a roadmap/RAG/issue
+    /// adapter. AIRC stores it in the typed result for auditability;
+    /// duplicate suppression remains repo+title+lane so adapters can
+    /// change evidence wording without creating duplicate work.
+    pub evidence_key: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkBacklogSeedResult {
+    pub items: Vec<SeededWorkCard>,
+}
+
+impl WorkBacklogSeedResult {
+    pub fn created_count(&self) -> usize {
+        self.items
+            .iter()
+            .filter(|item| item.outcome == WorkBacklogSeedOutcome::Created)
+            .count()
+    }
+
+    pub fn represented_count(&self) -> usize {
+        self.items
+            .iter()
+            .filter(|item| item.outcome == WorkBacklogSeedOutcome::AlreadyRepresented)
+            .count()
+    }
+
+    pub fn completed_count(&self) -> usize {
+        self.items
+            .iter()
+            .filter(|item| item.outcome == WorkBacklogSeedOutcome::AlreadyCompleted)
+            .count()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SeededWorkCard {
+    pub candidate: WorkBacklogSeedCandidate,
+    pub card_id: WorkCardId,
+    pub outcome: WorkBacklogSeedOutcome,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkBacklogSeedOutcome {
+    Created,
+    AlreadyRepresented,
+    AlreadyCompleted,
+}
+
 impl Airc {
     /// Return a typed manager-loop evaluation. This is the substrate
     /// surface for "why is the room idle?" and "what should happen
@@ -118,6 +174,54 @@ impl Airc {
             roster,
             recommendations,
         })
+    }
+
+    /// Idempotently materialize typed backlog candidates into the
+    /// current room. This is the manager flywheel's write boundary:
+    /// roadmap/RAG/issue adapters propose candidates; AIRC creates
+    /// only the missing cards and treats represented/completed cards
+    /// as the recursion base case.
+    pub async fn seed_work_backlog(
+        &self,
+        candidates: Vec<WorkBacklogSeedCandidate>,
+    ) -> Result<WorkBacklogSeedResult, AircError> {
+        let mut board = self.work_board_complete(512).await?;
+        let mut items = Vec::with_capacity(candidates.len());
+
+        for candidate in candidates {
+            let snapshot = board.snapshot();
+            if let Some(card) = find_seed_match(&snapshot.cards, &candidate) {
+                let outcome = if work_card_is_complete(card.state) {
+                    WorkBacklogSeedOutcome::AlreadyCompleted
+                } else {
+                    WorkBacklogSeedOutcome::AlreadyRepresented
+                };
+                items.push(SeededWorkCard {
+                    candidate,
+                    card_id: card.card_id,
+                    outcome,
+                });
+                continue;
+            }
+
+            let card_id = self
+                .create_work_card(CreateWorkCard {
+                    repo: candidate.repo.clone(),
+                    title: candidate.title.clone(),
+                    body: candidate.body.clone(),
+                    priority: candidate.priority,
+                    lane_id: candidate.lane_id,
+                })
+                .await?;
+            items.push(SeededWorkCard {
+                candidate,
+                card_id,
+                outcome: WorkBacklogSeedOutcome::Created,
+            });
+            board = self.work_board_complete(512).await?;
+        }
+
+        Ok(WorkBacklogSeedResult { items })
     }
 }
 
@@ -236,6 +340,26 @@ fn agent_from_row(row: &WorkRosterRow) -> WorkManagerAgent {
             .as_ref()
             .and_then(|liveness| liveness.scope.clone()),
     }
+}
+
+fn find_seed_match<'a>(
+    cards: &'a [WorkCard],
+    candidate: &WorkBacklogSeedCandidate,
+) -> Option<&'a WorkCard> {
+    let title = normalize_seed_title(&candidate.title);
+    cards.iter().find(|card| {
+        card.repo == candidate.repo
+            && card.lane_id == candidate.lane_id
+            && normalize_seed_title(&card.title) == title
+    })
+}
+
+fn normalize_seed_title(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn work_card_is_complete(state: CardState) -> bool {
+    matches!(state, CardState::Merged | CardState::Closed)
 }
 
 #[cfg(test)]

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -5,8 +5,8 @@ use airc_lib::{
     ChangeWorkCardState, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard, ClaimableWorkQuery,
     CreateWorkCard, CreateWorkLane, DirtyState, HeartbeatKind, HeartbeatWorkspace, LaneState,
     ObserveLocalGitWorkspace, Priority, ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace,
-    RepoId, ReportAgentAvailability, RequestWorkspace, WorkCardId, WorkRosterQuery,
-    WorkspaceStatus,
+    RepoId, ReportAgentAvailability, RequestWorkspace, WorkBacklogSeedCandidate,
+    WorkBacklogSeedOutcome, WorkCardId, WorkRosterQuery, WorkspaceStatus,
 };
 use tempfile::TempDir;
 
@@ -297,6 +297,105 @@ async fn scheduling_finds_claimable_cards_beyond_small_recent_window() {
         .await
         .unwrap();
     assert_eq!(roster.claimable_count, 1);
+}
+
+#[tokio::test]
+async fn manager_seed_backlog_creates_only_missing_room_cards() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("work-manager-seed").await.unwrap();
+
+    let repo = RepoId::new("CambrianTech/airc").unwrap();
+    let first = WorkBacklogSeedCandidate {
+        repo: repo.clone(),
+        title: "Roadmap gap: manager loop".to_string(),
+        body: Some("evidence: roadmap phase 1".to_string()),
+        priority: Priority::P0,
+        lane_id: None,
+        evidence_key: Some("roadmap:manager-loop".to_string()),
+    };
+    let second = WorkBacklogSeedCandidate {
+        repo,
+        title: "Roadmap gap: budgeted context".to_string(),
+        body: Some("evidence: roadmap phase 5".to_string()),
+        priority: Priority::P1,
+        lane_id: None,
+        evidence_key: Some("roadmap:budgeted-context".to_string()),
+    };
+
+    let created = airc
+        .seed_work_backlog(vec![first.clone(), second.clone()])
+        .await
+        .unwrap();
+    assert_eq!(created.created_count(), 2);
+    assert_eq!(created.represented_count(), 0);
+
+    for idx in 0..600 {
+        airc.say(&format!("manager seed noise {idx}"))
+            .await
+            .unwrap();
+    }
+    assert!(
+        airc.work_board(512)
+            .await
+            .unwrap()
+            .card(created.items[0].card_id)
+            .is_none(),
+        "recent board should not be enough to dedupe seed candidates"
+    );
+
+    let repeated = airc
+        .seed_work_backlog(vec![first.clone(), second.clone()])
+        .await
+        .unwrap();
+    assert_eq!(repeated.created_count(), 0);
+    assert_eq!(repeated.represented_count(), 2);
+    assert_eq!(
+        repeated
+            .items
+            .iter()
+            .map(|item| item.outcome)
+            .collect::<Vec<_>>(),
+        vec![
+            WorkBacklogSeedOutcome::AlreadyRepresented,
+            WorkBacklogSeedOutcome::AlreadyRepresented
+        ]
+    );
+}
+
+#[tokio::test]
+async fn manager_seed_backlog_treats_completed_cards_as_base_case() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("work-manager-seed-complete").await.unwrap();
+
+    let candidate = WorkBacklogSeedCandidate {
+        repo: RepoId::new("CambrianTech/airc").unwrap(),
+        title: "Completed roadmap gap".to_string(),
+        body: None,
+        priority: Priority::P1,
+        lane_id: None,
+        evidence_key: Some("roadmap:done".to_string()),
+    };
+
+    let created = airc
+        .seed_work_backlog(vec![candidate.clone()])
+        .await
+        .unwrap();
+    airc.change_work_card_state(ChangeWorkCardState {
+        card_id: created.items[0].card_id,
+        state: CardState::Closed,
+    })
+    .await
+    .unwrap();
+
+    let repeated = airc.seed_work_backlog(vec![candidate]).await.unwrap();
+    assert_eq!(repeated.created_count(), 0);
+    assert_eq!(repeated.completed_count(), 1);
+    assert_eq!(
+        repeated.items[0].outcome,
+        WorkBacklogSeedOutcome::AlreadyCompleted
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add typed WorkBacklogSeedCandidate / WorkBacklogSeedResult to airc-lib
- add Airc::seed_work_backlog for idempotent room-scoped card generation from manager/RAG/roadmap candidates
- add thin `airc work seed` CLI wrapper for one candidate
- treat represented cards and completed cards as recursion base cases so repeated manager sweeps do not duplicate work

## Why
This is the first write-side primitive for card queue starvation: manager/RAG/roadmap adapters can propose evidence-backed candidates, and AIRC creates only missing room cards.

## Verification
- cargo test --manifest-path Cargo.toml -p airc-lib --test work_api manager_seed_backlog
- cargo test --manifest-path Cargo.toml -p airc-cli --test work_commands work_seed_is_idempotent_for_manager_candidates
- cargo clippy --manifest-path Cargo.toml -p airc-lib -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-lib --test work_api
- cargo test --manifest-path Cargo.toml -p airc-cli --test work_commands