### PR TITLE
fix(work): make stale claims recoverable by default

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -618,7 +618,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             WorkAction::Next {
                 repo,
                 max_priority,
-                include_stale,
+                exclude_stale,
                 limit,
                 event_limit,
             } => {
@@ -626,7 +626,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     &home,
                     repo,
                     max_priority,
-                    include_stale,
+                    !exclude_stale,
                     limit,
                     event_limit,
                 )
@@ -640,7 +640,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             WorkAction::Manage {
                 repo,
                 max_priority,
-                include_stale,
+                exclude_stale,
                 limit,
                 event_limit,
                 active_within_ms,
@@ -649,7 +649,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     &home,
                     repo,
                     max_priority,
-                    include_stale,
+                    !exclude_stale,
                     limit,
                     event_limit,
                     active_within_ms,

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -584,6 +584,17 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 lane_id,
                 priority,
             } => work_commands::run_create(&home, repo, title, body, lane_id, priority).await,
+            WorkAction::Seed {
+                repo,
+                title,
+                body,
+                lane_id,
+                priority,
+                evidence_key,
+            } => {
+                work_commands::run_seed(&home, repo, title, body, lane_id, priority, evidence_key)
+                    .await
+            }
             WorkAction::Claim {
                 card_id,
                 ttl_ms,

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -113,9 +113,9 @@ pub enum WorkAction {
         /// Highest priority to include.
         #[arg(long, value_enum, default_value = "p1")]
         max_priority: CliPriority,
-        /// Include expired claims as recoverable work.
+        /// Hide expired claims. Normal scheduling treats them as recoverable work.
         #[arg(long)]
-        include_stale: bool,
+        exclude_stale: bool,
         /// Maximum suggestions to print.
         #[arg(long, default_value_t = 8)]
         limit: usize,
@@ -143,9 +143,9 @@ pub enum WorkAction {
         /// Highest priority to include.
         #[arg(long, value_enum, default_value = "p1")]
         max_priority: CliPriority,
-        /// Include expired claims as recoverable work.
+        /// Hide expired claims. Normal scheduling treats them as recoverable work.
         #[arg(long)]
-        include_stale: bool,
+        exclude_stale: bool,
         /// Maximum work suggestions to evaluate.
         #[arg(long, default_value_t = 8)]
         limit: usize,

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -28,6 +28,27 @@ pub enum WorkAction {
         #[arg(long, value_enum, default_value = "p2")]
         priority: CliPriority,
     },
+    /// Idempotently seed a manager/roadmap/RAG candidate into this room.
+    Seed {
+        /// Repository key, e.g. `CambrianTech/airc`.
+        #[arg(long)]
+        repo: String,
+        /// Human-readable card title.
+        #[arg(long)]
+        title: String,
+        /// Optional card body.
+        #[arg(long)]
+        body: Option<String>,
+        /// Optional lane UUID to attach this card to.
+        #[arg(long)]
+        lane_id: Option<String>,
+        /// Scheduling priority.
+        #[arg(long, value_enum, default_value = "p2")]
+        priority: CliPriority,
+        /// Stable source key from a roadmap/RAG/issue adapter.
+        #[arg(long)]
+        evidence_key: Option<String>,
+    },
     /// Claim an existing work card for this peer.
     ///
     /// Refuses when the current directory is not under

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -14,9 +14,9 @@ use uuid::Uuid;
 
 use airc_lib::{
     AgentAvailabilityState, Airc, CardState, ChangeWorkCardState, ClaimId, ClaimWorkCard,
-    CreateWorkCard, LaneId, Priority, ReleaseWorkClaim, RepoId, WorkBoardProjection, WorkCardId,
-    WorkManagerRecommendation, WorkManagerRecommendationKind, WorkManagerStatus, WorkQueueStatus,
-    WorkRosterStatus,
+    CreateWorkCard, LaneId, Priority, ReleaseWorkClaim, RepoId, WorkBacklogSeedCandidate,
+    WorkBacklogSeedOutcome, WorkBoardProjection, WorkCardId, WorkManagerRecommendation,
+    WorkManagerRecommendationKind, WorkManagerStatus, WorkQueueStatus, WorkRosterStatus,
 };
 
 use crate::lease;
@@ -41,6 +41,42 @@ pub async fn run_create(
         })
         .await?;
     println!("card_id: {card_id}");
+    Ok(())
+}
+
+pub async fn run_seed(
+    home: &Path,
+    repo: String,
+    title: String,
+    body: Option<String>,
+    lane_id: Option<String>,
+    priority: CliPriority,
+    evidence_key: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = Airc::open(home).await?;
+    let result = airc
+        .seed_work_backlog(vec![WorkBacklogSeedCandidate {
+            repo: RepoId::new(repo)?,
+            title,
+            body,
+            priority: priority.into(),
+            lane_id: parse_optional_lane_id(lane_id.as_deref())?,
+            evidence_key,
+        }])
+        .await?;
+    for item in result.items {
+        let outcome = match item.outcome {
+            WorkBacklogSeedOutcome::Created => "created",
+            WorkBacklogSeedOutcome::AlreadyRepresented => "already_represented",
+            WorkBacklogSeedOutcome::AlreadyCompleted => "already_completed",
+        };
+        println!(
+            "seeded: outcome={outcome} card_id={card_id} repo={repo} title={title}",
+            card_id = item.card_id,
+            repo = item.candidate.repo,
+            title = item.candidate.title,
+        );
+    }
     Ok(())
 }
 

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -154,6 +154,8 @@ fn work_board_surfaces_stale_claims() {
             "CambrianTech/airc",
             "--title",
             "do not let abandoned claims idle-lock a lane",
+            "--priority",
+            "p1",
         ],
     );
     let card_id = extract_field(&create, "card_id:").expect("create prints card_id");
@@ -176,6 +178,18 @@ fn work_board_surfaces_stale_claims() {
     assert!(stale_board.contains("stale claims: 1"), "{stale_board}");
     assert!(stale_board.contains(card_id), "{stale_board}");
     assert!(stale_board.contains(claim_id), "{stale_board}");
+
+    let next = run_ok(&home, &["work", "next", "--event-limit", "128"]);
+    assert!(next.contains("claimable work: 1"), "{next}");
+    assert!(next.contains("stale_claim="), "{next}");
+    assert!(next.contains(card_id), "{next}");
+
+    let hidden = run_ok(
+        &home,
+        &["work", "next", "--exclude-stale", "--event-limit", "128"],
+    );
+    assert!(hidden.contains("(no claimable work)"), "{hidden}");
+    assert!(!hidden.contains(card_id), "{hidden}");
 }
 
 #[test]

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -88,6 +88,58 @@ fn work_create_claim_release_projects_on_board() {
 }
 
 #[test]
+fn work_seed_is_idempotent_for_manager_candidates() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let first = run_ok(
+        &home,
+        &[
+            "work",
+            "seed",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "manager generated card",
+            "--priority",
+            "p1",
+            "--body",
+            "evidence from roadmap",
+            "--evidence-key",
+            "roadmap:manager-generated-card",
+        ],
+    );
+    assert!(first.contains("outcome=created"), "{first}");
+    let card_id = extract_seed_card_id(&first).expect("seed prints card id");
+
+    let second = run_ok(
+        &home,
+        &[
+            "work",
+            "seed",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "manager   generated   card",
+            "--priority",
+            "p1",
+            "--evidence-key",
+            "roadmap:wording-changed",
+        ],
+    );
+    assert!(second.contains("outcome=already_represented"), "{second}");
+    assert!(second.contains(card_id), "{second}");
+
+    let board = run_ok(&home, &["work", "board"]);
+    assert_eq!(
+        board.matches("manager generated card").count(),
+        1,
+        "{board}"
+    );
+}
+
+#[test]
 fn work_board_surfaces_stale_claims() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");
@@ -518,4 +570,9 @@ fn run_expect_failure(home: &Path, args: &[&str]) -> String {
 fn extract_field<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
     text.lines()
         .find_map(|line| line.strip_prefix(prefix).map(str::trim))
+}
+
+fn extract_seed_card_id(text: &str) -> Option<&str> {
+    text.split_whitespace()
+        .find_map(|field| field.strip_prefix("card_id="))
 }

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -137,6 +137,7 @@ pub use work::{
     ReportAgentAvailability, RequestWorkspace, WorkQueueStatus, WorkQueueStatusQuery,
 };
 pub use work_manager::{
+    SeededWorkCard, WorkBacklogSeedCandidate, WorkBacklogSeedOutcome, WorkBacklogSeedResult,
     WorkManagerAgent, WorkManagerQuery, WorkManagerReason, WorkManagerRecommendation,
     WorkManagerRecommendationKind, WorkManagerStatus,
 };

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -126,7 +126,7 @@ impl Default for ClaimableWorkQuery {
         Self {
             repo: None,
             max_priority: Priority::P1,
-            include_stale_claims: false,
+            include_stale_claims: true,
             event_limit: 512,
             limit: 8,
         }
@@ -159,7 +159,7 @@ impl Default for WorkQueueStatusQuery {
         Self {
             repo: None,
             max_priority: Priority::P1,
-            include_stale_claims: false,
+            include_stale_claims: true,
             event_limit: 512,
             limit: 8,
         }
@@ -705,7 +705,12 @@ impl Airc {
                 room_id: room.channel,
             });
         };
-        if card.claim_id.is_none() {
+        let now_ms = now_ms()?;
+        if card.claim_id.is_none()
+            || card
+                .claim_expires_at_ms
+                .is_some_and(|expires_at_ms| expires_at_ms <= now_ms)
+        {
             return Ok(());
         }
 

--- a/crates/airc-lib/src/work_manager.rs
+++ b/crates/airc-lib/src/work_manager.rs
@@ -5,11 +5,11 @@
 //! scheduling view that agents, monitors, and future manager personas
 //! can consume directly.
 
-use airc_work::{Priority, RepoId, StaleClaim, WorkCard};
+use airc_work::{CardState, LaneId, Priority, RepoId, StaleClaim, WorkCard, WorkCardId};
 
 use crate::time::now_ms;
 use crate::{
-    AgentAvailabilityState, Airc, AircError, WorkQueueStatus, WorkQueueStatusQuery,
+    AgentAvailabilityState, Airc, AircError, CreateWorkCard, WorkQueueStatus, WorkQueueStatusQuery,
     WorkRosterQuery, WorkRosterRow, WorkRosterStatus,
 };
 
@@ -87,6 +87,62 @@ pub struct WorkManagerAgent {
     pub scope: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkBacklogSeedCandidate {
+    pub repo: RepoId,
+    pub title: String,
+    pub body: Option<String>,
+    pub priority: Priority,
+    pub lane_id: Option<LaneId>,
+    /// Stable source identifier supplied by a roadmap/RAG/issue
+    /// adapter. AIRC stores it in the typed result for auditability;
+    /// duplicate suppression remains repo+title+lane so adapters can
+    /// change evidence wording without creating duplicate work.
+    pub evidence_key: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkBacklogSeedResult {
+    pub items: Vec<SeededWorkCard>,
+}
+
+impl WorkBacklogSeedResult {
+    pub fn created_count(&self) -> usize {
+        self.items
+            .iter()
+            .filter(|item| item.outcome == WorkBacklogSeedOutcome::Created)
+            .count()
+    }
+
+    pub fn represented_count(&self) -> usize {
+        self.items
+            .iter()
+            .filter(|item| item.outcome == WorkBacklogSeedOutcome::AlreadyRepresented)
+            .count()
+    }
+
+    pub fn completed_count(&self) -> usize {
+        self.items
+            .iter()
+            .filter(|item| item.outcome == WorkBacklogSeedOutcome::AlreadyCompleted)
+            .count()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SeededWorkCard {
+    pub candidate: WorkBacklogSeedCandidate,
+    pub card_id: WorkCardId,
+    pub outcome: WorkBacklogSeedOutcome,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkBacklogSeedOutcome {
+    Created,
+    AlreadyRepresented,
+    AlreadyCompleted,
+}
+
 impl Airc {
     /// Return a typed manager-loop evaluation. This is the substrate
     /// surface for "why is the room idle?" and "what should happen
@@ -118,6 +174,54 @@ impl Airc {
             roster,
             recommendations,
         })
+    }
+
+    /// Idempotently materialize typed backlog candidates into the
+    /// current room. This is the manager flywheel's write boundary:
+    /// roadmap/RAG/issue adapters propose candidates; AIRC creates
+    /// only the missing cards and treats represented/completed cards
+    /// as the recursion base case.
+    pub async fn seed_work_backlog(
+        &self,
+        candidates: Vec<WorkBacklogSeedCandidate>,
+    ) -> Result<WorkBacklogSeedResult, AircError> {
+        let mut board = self.work_board_complete(512).await?;
+        let mut items = Vec::with_capacity(candidates.len());
+
+        for candidate in candidates {
+            let snapshot = board.snapshot();
+            if let Some(card) = find_seed_match(&snapshot.cards, &candidate) {
+                let outcome = if work_card_is_complete(card.state) {
+                    WorkBacklogSeedOutcome::AlreadyCompleted
+                } else {
+                    WorkBacklogSeedOutcome::AlreadyRepresented
+                };
+                items.push(SeededWorkCard {
+                    candidate,
+                    card_id: card.card_id,
+                    outcome,
+                });
+                continue;
+            }
+
+            let card_id = self
+                .create_work_card(CreateWorkCard {
+                    repo: candidate.repo.clone(),
+                    title: candidate.title.clone(),
+                    body: candidate.body.clone(),
+                    priority: candidate.priority,
+                    lane_id: candidate.lane_id,
+                })
+                .await?;
+            items.push(SeededWorkCard {
+                candidate,
+                card_id,
+                outcome: WorkBacklogSeedOutcome::Created,
+            });
+            board = self.work_board_complete(512).await?;
+        }
+
+        Ok(WorkBacklogSeedResult { items })
     }
 }
 
@@ -236,6 +340,26 @@ fn agent_from_row(row: &WorkRosterRow) -> WorkManagerAgent {
             .as_ref()
             .and_then(|liveness| liveness.scope.clone()),
     }
+}
+
+fn find_seed_match<'a>(
+    cards: &'a [WorkCard],
+    candidate: &WorkBacklogSeedCandidate,
+) -> Option<&'a WorkCard> {
+    let title = normalize_seed_title(&candidate.title);
+    cards.iter().find(|card| {
+        card.repo == candidate.repo
+            && card.lane_id == candidate.lane_id
+            && normalize_seed_title(&card.title) == title
+    })
+}
+
+fn normalize_seed_title(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn work_card_is_complete(state: CardState) -> bool {
+    matches!(state, CardState::Merged | CardState::Closed)
 }
 
 #[cfg(test)]

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -5,8 +5,8 @@ use airc_lib::{
     ChangeWorkCardState, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard, ClaimableWorkQuery,
     CreateWorkCard, CreateWorkLane, DirtyState, HeartbeatKind, HeartbeatWorkspace, LaneState,
     ObserveLocalGitWorkspace, Priority, ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace,
-    RepoId, ReportAgentAvailability, RequestWorkspace, WorkCardId, WorkRosterQuery,
-    WorkspaceStatus,
+    RepoId, ReportAgentAvailability, RequestWorkspace, WorkBacklogSeedCandidate,
+    WorkBacklogSeedOutcome, WorkCardId, WorkRosterQuery, WorkspaceStatus,
 };
 use tempfile::TempDir;
 
@@ -297,6 +297,105 @@ async fn scheduling_finds_claimable_cards_beyond_small_recent_window() {
         .await
         .unwrap();
     assert_eq!(roster.claimable_count, 1);
+}
+
+#[tokio::test]
+async fn manager_seed_backlog_creates_only_missing_room_cards() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("work-manager-seed").await.unwrap();
+
+    let repo = RepoId::new("CambrianTech/airc").unwrap();
+    let first = WorkBacklogSeedCandidate {
+        repo: repo.clone(),
+        title: "Roadmap gap: manager loop".to_string(),
+        body: Some("evidence: roadmap phase 1".to_string()),
+        priority: Priority::P0,
+        lane_id: None,
+        evidence_key: Some("roadmap:manager-loop".to_string()),
+    };
+    let second = WorkBacklogSeedCandidate {
+        repo,
+        title: "Roadmap gap: budgeted context".to_string(),
+        body: Some("evidence: roadmap phase 5".to_string()),
+        priority: Priority::P1,
+        lane_id: None,
+        evidence_key: Some("roadmap:budgeted-context".to_string()),
+    };
+
+    let created = airc
+        .seed_work_backlog(vec![first.clone(), second.clone()])
+        .await
+        .unwrap();
+    assert_eq!(created.created_count(), 2);
+    assert_eq!(created.represented_count(), 0);
+
+    for idx in 0..600 {
+        airc.say(&format!("manager seed noise {idx}"))
+            .await
+            .unwrap();
+    }
+    assert!(
+        airc.work_board(512)
+            .await
+            .unwrap()
+            .card(created.items[0].card_id)
+            .is_none(),
+        "recent board should not be enough to dedupe seed candidates"
+    );
+
+    let repeated = airc
+        .seed_work_backlog(vec![first.clone(), second.clone()])
+        .await
+        .unwrap();
+    assert_eq!(repeated.created_count(), 0);
+    assert_eq!(repeated.represented_count(), 2);
+    assert_eq!(
+        repeated
+            .items
+            .iter()
+            .map(|item| item.outcome)
+            .collect::<Vec<_>>(),
+        vec![
+            WorkBacklogSeedOutcome::AlreadyRepresented,
+            WorkBacklogSeedOutcome::AlreadyRepresented
+        ]
+    );
+}
+
+#[tokio::test]
+async fn manager_seed_backlog_treats_completed_cards_as_base_case() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("work-manager-seed-complete").await.unwrap();
+
+    let candidate = WorkBacklogSeedCandidate {
+        repo: RepoId::new("CambrianTech/airc").unwrap(),
+        title: "Completed roadmap gap".to_string(),
+        body: None,
+        priority: Priority::P1,
+        lane_id: None,
+        evidence_key: Some("roadmap:done".to_string()),
+    };
+
+    let created = airc
+        .seed_work_backlog(vec![candidate.clone()])
+        .await
+        .unwrap();
+    airc.change_work_card_state(ChangeWorkCardState {
+        card_id: created.items[0].card_id,
+        state: CardState::Closed,
+    })
+    .await
+    .unwrap();
+
+    let repeated = airc.seed_work_backlog(vec![candidate]).await.unwrap();
+    assert_eq!(repeated.created_count(), 0);
+    assert_eq!(repeated.completed_count(), 1);
+    assert_eq!(
+        repeated.items[0].outcome,
+        WorkBacklogSeedOutcome::AlreadyCompleted
+    );
 }
 
 #[tokio::test]

--- a/crates/airc-lib/tests/work_api.rs
+++ b/crates/airc-lib/tests/work_api.rs
@@ -569,6 +569,46 @@ async fn claimable_work_can_surface_stale_claims_for_recovery() {
 }
 
 #[tokio::test]
+async fn stale_claim_can_be_reclaimed_by_new_claim() {
+    let home = TempDir::new().unwrap();
+    let airc = Airc::open(home.path()).await.unwrap();
+    airc.join("stale-claim-reclaim-api").await.unwrap();
+
+    let card_id = airc
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            title: "reclaim abandoned work".to_string(),
+            body: None,
+            priority: Priority::P0,
+            lane_id: None,
+        })
+        .await
+        .unwrap();
+    let expired_claim = airc
+        .claim_work_card(ClaimWorkCard { card_id, ttl_ms: 1 })
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let new_claim = airc
+        .claim_work_card(ClaimWorkCard {
+            card_id,
+            ttl_ms: 60_000,
+        })
+        .await
+        .unwrap();
+    assert_ne!(expired_claim, new_claim);
+
+    let board = airc.work_board_complete(128).await.unwrap();
+    let card = board.card(card_id).unwrap();
+    assert_eq!(card.claim_id, Some(new_claim));
+    assert_eq!(card.owner, Some(airc.peer_id()));
+    assert!(card
+        .claim_expires_at_ms
+        .is_some_and(|expires_at_ms| expires_at_ms > 1));
+}
+
+#[tokio::test]
 async fn work_roster_status_combines_liveness_availability_and_claims() {
     let home = TempDir::new().unwrap();
     let airc = Airc::open(home.path()).await.unwrap();

--- a/crates/airc-work/src/projection/apply.rs
+++ b/crates/airc-work/src/projection/apply.rs
@@ -158,7 +158,10 @@ impl WorkBoardProjection {
 
     fn apply_card_claimed(&mut self, e: &WorkCardClaimed) -> Result<(), ProjectionError> {
         let card = self.card_mut(e.card_id)?;
-        if card.claim_id.is_some() {
+        if card
+            .claim_expires_at_ms
+            .is_some_and(|expires_at_ms| expires_at_ms > e.claimed_at_ms)
+        {
             return Ok(());
         }
         card.state = CardState::Claimed;

--- a/crates/airc-work/src/projection/tests.rs
+++ b/crates/airc-work/src/projection/tests.rs
@@ -204,6 +204,49 @@ fn duplicate_active_claim_is_idempotent_and_keeps_original_owner() {
 }
 
 #[test]
+fn expired_claim_can_be_superseded_by_new_claim() {
+    let card_id = WorkCardId::from_u128(21);
+    let expired_claim = ClaimId::from_u128(22);
+    let new_claim = ClaimId::from_u128(23);
+    let expired_owner = peer(24);
+    let new_owner = peer(25);
+
+    let projection = WorkBoardProjection::replay(vec![
+        WorkEvent::CardCreated(CardCreated {
+            card_id,
+            repo: repo(),
+            title: "recover abandoned claim".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+            created_by: expired_owner,
+            created_at_ms: 100,
+        }),
+        WorkEvent::CardClaimed(WorkCardClaimed {
+            card_id,
+            claim_id: expired_claim,
+            owner: expired_owner,
+            ttl_ms: 100,
+            claimed_at_ms: 110,
+        }),
+        WorkEvent::CardClaimed(WorkCardClaimed {
+            card_id,
+            claim_id: new_claim,
+            owner: new_owner,
+            ttl_ms: 100,
+            claimed_at_ms: 210,
+        }),
+    ])
+    .unwrap();
+
+    let card = projection.card(card_id).unwrap();
+    assert_eq!(card.owner, Some(new_owner));
+    assert_eq!(card.claim_id, Some(new_claim));
+    assert_eq!(card.claim_expires_at_ms, Some(310));
+    assert!(projection.stale_claims(309).is_empty());
+}
+
+#[test]
 fn availability_projection_keeps_latest_peer_state_per_repo() {
     let repo = repo();
     let other_repo = RepoId::new("CambrianTech/continuum").unwrap();


### PR DESCRIPTION
## Summary
- treat expired work claims as recoverable by default in typed scheduling queries and CLI work next/manage
- allow a later claim event to supersede an expired claim while keeping active claims first-write-wins
- add regression coverage for stale claim visibility and actual reclaim execution

References the manager/queue starvation roadmap in docs/architecture/GRID-SUBSTRATE-AUDIT.md: stale claims must feed recoverable work instead of hiding cards from idle agents.

## Verification
- cargo fmt --manifest-path Cargo.toml -p airc-work -p airc-lib -p airc-cli --check
- cargo clippy --manifest-path Cargo.toml -p airc-work -p airc-lib -p airc-cli --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml -p airc-work
- cargo test --manifest-path Cargo.toml -p airc-lib --test work_api
- cargo test --manifest-path Cargo.toml -p airc-cli --test work_commands
- target/debug/airc work next --limit 5
- target/debug/airc work manage --repo CambrianTech/airc --limit 5 --event-limit 512