### PR TITLE
feat(inbox): --json flag for machine-readable output

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -283,6 +283,13 @@ pub enum Command {
         since_event_id: Option<String>,
         #[arg(long)]
         limit: Option<usize>,
+        /// Emit a single JSON document on stdout instead of
+        /// human-readable text. Shape mirrors `airc events list
+        /// --json` and `airc publish` for machine consumers
+        /// (continuum's CliAircRealtimeStore, shell scripts, CI
+        /// smoke tests).
+        #[arg(long)]
+        json: bool,
     },
 
     /// Print or switch the current room. With no name, prints the

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -648,6 +648,7 @@ pub async fn run_inbox(
     since_lamport: Option<u64>,
     since_event_id: Option<String>,
     limit: Option<usize>,
+    as_json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let airc = match socket {
         Some(socket) => Airc::attach(home, socket).await?,
@@ -673,6 +674,10 @@ pub async fn run_inbox(
         Some(cursor) => airc.resume_from(&cursor, effective_limit).await?,
         None => airc.page_recent(effective_limit).await?,
     };
+    if as_json {
+        print_inbox_json(&events)?;
+        return Ok(());
+    }
     if events.is_empty() {
         println!("(no events)");
         return Ok(());
@@ -687,6 +692,45 @@ pub async fn run_inbox(
             cursor.lamport, cursor.event_id
         );
     }
+    Ok(())
+}
+
+/// Emit a single JSON document for `airc inbox --json`.
+///
+/// Shape: `{ count, events, cursor: {lamport, event_id} | null }`.
+/// The cursor is the paging hint pointing at the newest event in
+/// this page; pass both halves back as `--since-lamport` /
+/// `--since-event-id` for the next call. Mirrors `airc events
+/// list --json` for the `{count, events}` shape and extends it
+/// with the paging tuple inbox callers need.
+fn print_inbox_json(events: &[airc_core::TranscriptEvent]) -> Result<(), serde_json::Error> {
+    #[derive(serde::Serialize)]
+    struct InboxJson<'a> {
+        count: usize,
+        events: &'a [airc_core::TranscriptEvent],
+        cursor: Option<InboxCursorJson>,
+    }
+    #[derive(serde::Serialize)]
+    struct InboxCursorJson {
+        lamport: u64,
+        event_id: String,
+    }
+
+    let cursor = events
+        .last()
+        .map(airc_core::TranscriptEvent::cursor)
+        .map(|cursor| InboxCursorJson {
+            lamport: cursor.lamport,
+            event_id: cursor.event_id.to_string(),
+        });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&InboxJson {
+            count: events.len(),
+            events,
+            cursor,
+        })?
+    );
     Ok(())
 }
 

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -359,7 +359,8 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             since_lamport,
             since_event_id,
             limit,
-        } => commands::run_inbox(&home, socket, since_lamport, since_event_id, limit).await,
+            json,
+        } => commands::run_inbox(&home, socket, since_lamport, since_event_id, limit, json).await,
 
         Command::Room { name, wire } => commands::run_room(&home, name, wire).await,
 

--- a/crates/airc-cli/tests/inbox_json.rs
+++ b/crates/airc-cli/tests/inbox_json.rs
@@ -1,0 +1,105 @@
+//! End-to-end coverage for `airc inbox --json`.
+//!
+//! Closes work card 3a069fab: machine consumers can't reliably
+//! parse `airc inbox`'s human text output. The `--json` flag
+//! gives them a stable shape that `jq` parses without surprises.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc")
+}
+
+#[test]
+fn inbox_json_returns_count_events_cursor_shape() {
+    // Just asserts the shape — the bare `airc init` flow may
+    // emit lifecycle events (RoomJoined, presence beacons)
+    // that land in inbox, so we don't pin a specific count.
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let stdout = run_ok(&home, &["inbox", "--json"]);
+    let value: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout must be JSON");
+
+    assert!(value["count"].is_number(), "count missing: {value}");
+    assert!(value["events"].is_array(), "events array missing: {value}");
+
+    let count = value["count"].as_u64().expect("count is number");
+    let events_len = value["events"].as_array().expect("events array").len() as u64;
+    assert_eq!(count, events_len, "count must equal events.len()");
+
+    // Cursor present iff at least one event. JSON null vs object
+    // is the discriminator — never absent.
+    if count == 0 {
+        assert!(
+            value["cursor"].is_null(),
+            "empty inbox must have null cursor"
+        );
+    } else {
+        let cursor = &value["cursor"];
+        assert!(cursor.is_object(), "non-empty cursor must be an object");
+        assert!(cursor["lamport"].is_number());
+        assert!(cursor["event_id"].is_string());
+    }
+}
+
+#[test]
+fn inbox_json_carries_events_plus_paging_cursor() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    // Generate some events. `airc send` lands a Message in the
+    // default room which inbox will surface.
+    run_ok(&home, &["send", "hello-1"]);
+    run_ok(&home, &["send", "hello-2"]);
+    run_ok(&home, &["send", "hello-3"]);
+
+    let stdout = run_ok(&home, &["inbox", "--json"]);
+    let value: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout must be JSON");
+
+    let count = value["count"].as_u64().expect("count number");
+    assert!(count >= 3, "expected >=3 events, got {count}: {value}");
+
+    let events = value["events"].as_array().expect("events array");
+    assert_eq!(
+        events.len(),
+        count as usize,
+        "count must match events.len()"
+    );
+
+    // Cursor shape: {lamport, event_id}.
+    let cursor = &value["cursor"];
+    assert!(cursor.is_object(), "cursor must be object, got {cursor}");
+    assert!(cursor["lamport"].is_number(), "cursor.lamport must exist");
+    assert!(
+        cursor["event_id"].is_string(),
+        "cursor.event_id must be a string UUID"
+    );
+}
+
+fn run_ok(home: &Path, args: &[&str]) -> String {
+    let account_home = home.parent().unwrap_or(home);
+    let output = Command::new(airc_core())
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .env("HOME", account_home)
+        .env("USERPROFILE", account_home)
+        .output()
+        .expect("airc-core command must spawn");
+    assert!(
+        output.status.success(),
+        "airc-core {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout utf-8")
+}


### PR DESCRIPTION
## Summary
Closes work card **3a069fab** (P1, "airc inbox --json flag for machine-readable output").

\`airc inbox\` previously emitted human-readable text (\"(no events)\", \"[System] <peer> -> ...\"); machine consumers can't parse it reliably. This PR adds a \`--json\` flag mirroring the shape conventions of \`airc events list --json\` (#991) and \`airc publish\` (#990).

## Shape

\`\`\`json
{
  \"count\": 3,
  \"events\": [...],
  \"cursor\": { \"lamport\": 42, \"event_id\": \"uuid...\" }
}
\`\`\`

- \`cursor\` is \`null\` on empty inbox and \`{lamport, event_id}\` otherwise — never absent. Callers pass both halves back as \`--since-lamport\` / \`--since-event-id\` for the next page.
- \`count\` always equals \`events.len()\` (invariant tested).

## Test plan
- [x] \`inbox_json_returns_count_events_cursor_shape\` — shape is stable; cursor null vs object discriminator works.
- [x] \`inbox_json_carries_events_plus_paging_cursor\` — three \`send\` events surface, cursor is a typed object.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all\` clean.
- [x] \`cargo test --workspace\` green.

## Downstream
Continuum's \`CliAircRealtimeStore\` (alternative path to the direct \`airc-ipc\` dep) consumes this; shell scripts and CI smoke tests as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)