### PR TITLE
feat(ipc): add ResolveWireRequest (channel uuid -> wire path lookup)

### DIFF
--- a/crates/airc-cli/src/monitor/attach.rs
+++ b/crates/airc-cli/src/monitor/attach.rs
@@ -48,7 +48,8 @@ pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error
             | Response::Status(_)
             | Response::Inbox(_)
             | Response::Publish(_)
-            | Response::Peers(_) => {}
+            | Response::Peers(_)
+            | Response::ResolveWire(_) => {}
         }
     }
 }

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -15,11 +15,12 @@ use airc_diagnostics::{
     DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
 };
 use airc_ipc::request::{
-    AddPeerRequest, InboxRequest, PublishRequest, RemovePeerRequest, Request, SendRequest,
-    SubscribeRequest,
+    AddPeerRequest, InboxRequest, PublishRequest, RemovePeerRequest, Request, ResolveWireRequest,
+    SendRequest, SubscribeRequest,
 };
 use airc_ipc::response::{
-    InboxResponse, PeerEntry, PeersResponse, PublishResponse, Response, StatusResponse,
+    InboxResponse, PeerEntry, PeersResponse, PublishResponse, ResolveWireResponse, Response,
+    StatusResponse,
 };
 use airc_protocol::{Envelope, Frame, FrameKind, Signature, Subscription};
 use airc_transport::Transport;
@@ -48,6 +49,7 @@ pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
         Request::Send(send) => handle_send(state, send).await,
         Request::Publish(publish) => handle_publish(state, publish).await,
         Request::Subscribe(sub) => handle_subscribe(state, sub).await,
+        Request::ResolveWire(req) => handle_resolve_wire(state, req).await,
         Request::Inbox(inbox) => handle_inbox(state, inbox).await,
         Request::Attach(_) => Response::Error {
             message: "attach is a streaming request handled by the server".to_string(),
@@ -160,6 +162,32 @@ fn trust_root_for_wire(wire: &Path) -> Option<PathBuf> {
         }
         _ => Some(wire.to_path_buf()),
     }
+}
+
+/// `ResolveWire` handler — answer "what wire path serves this
+/// channel UUID?" from the daemon's subscription store. Returns
+/// `wire: None` when the channel isn't subscribed, so callers
+/// can distinguish "not joined yet" from "lookup failed."
+///
+/// Closes work card 6e525958. Consumer-side callers (continuum's
+/// `DaemonAircRealtimeStore`, OpenClaw/Hermes bridges) use this
+/// to fill `PublishRequest.wire` without having to know the
+/// daemon's filesystem layout.
+async fn handle_resolve_wire(state: Arc<DaemonState>, request: ResolveWireRequest) -> Response {
+    let channel = airc_core::RoomId::from_uuid(request.channel);
+    let subscriptions = match state.event_store.load_subscriptions().await {
+        Ok(rows) => rows,
+        Err(error) => {
+            return Response::Error {
+                message: format!("resolve_wire: load subscriptions: {error}"),
+            };
+        }
+    };
+    let wire = subscriptions
+        .into_iter()
+        .find(|sub| !sub.parted && sub.room_id == channel)
+        .map(|sub| PathBuf::from(sub.wire));
+    Response::ResolveWire(ResolveWireResponse { wire })
 }
 
 async fn handle_inbox(state: Arc<DaemonState>, request: InboxRequest) -> Response {
@@ -393,6 +421,106 @@ mod tests {
                 assert!(status.uptime_seconds >= 1, "uptime must accumulate");
             }
             other => panic!("expected Status, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_wire_returns_none_for_unsubscribed_channel() {
+        // Fresh daemon → no subscriptions → unknown channel
+        // resolves to None (NOT an error — the caller knows to
+        // join first).
+        let state = test_state();
+        let response = dispatch(
+            state,
+            Request::ResolveWire(ResolveWireRequest {
+                channel: Uuid::from_u128(0xdead_beef),
+            }),
+        )
+        .await;
+        match response {
+            Response::ResolveWire(payload) => assert!(
+                payload.wire.is_none(),
+                "unsubscribed channel must resolve to None"
+            ),
+            other => panic!("expected ResolveWire, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_wire_returns_subscription_wire_when_known() {
+        use airc_core::RoomId;
+        use airc_store::StoredSubscription;
+
+        let state = test_state();
+        let room_id = RoomId::new();
+        let wire_path = "/tmp/airc-test/wires/project-x";
+        // Seed the store directly so we don't pull in the full
+        // join lifecycle for a unit test.
+        state
+            .event_store
+            .replace_subscriptions(vec![StoredSubscription {
+                channel_name: "project-x".to_string(),
+                room_id,
+                wire: wire_path.to_string(),
+                joined_at_ms: 0,
+                is_default: true,
+                parted: false,
+            }])
+            .await
+            .expect("seed subscription");
+
+        let response = dispatch(
+            state,
+            Request::ResolveWire(ResolveWireRequest {
+                channel: room_id.as_uuid(),
+            }),
+        )
+        .await;
+        match response {
+            Response::ResolveWire(payload) => assert_eq!(
+                payload.wire,
+                Some(PathBuf::from(wire_path)),
+                "subscribed channel must resolve to its wire path"
+            ),
+            other => panic!("expected ResolveWire, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_wire_skips_parted_subscriptions() {
+        // A parted subscription should NOT be resolvable —
+        // matches the non-auto-rejoin discipline.
+        use airc_core::RoomId;
+        use airc_store::StoredSubscription;
+
+        let state = test_state();
+        let room_id = RoomId::new();
+        state
+            .event_store
+            .replace_subscriptions(vec![StoredSubscription {
+                channel_name: "old-room".to_string(),
+                room_id,
+                wire: "/tmp/airc-test/wires/old-room".to_string(),
+                joined_at_ms: 0,
+                is_default: false,
+                parted: true,
+            }])
+            .await
+            .expect("seed parted subscription");
+
+        let response = dispatch(
+            state,
+            Request::ResolveWire(ResolveWireRequest {
+                channel: room_id.as_uuid(),
+            }),
+        )
+        .await;
+        match response {
+            Response::ResolveWire(payload) => assert!(
+                payload.wire.is_none(),
+                "parted channel must not resolve to a wire"
+            ),
+            other => panic!("expected ResolveWire, got {other:?}"),
         }
     }
 

--- a/crates/airc-ipc/src/client.rs
+++ b/crates/airc-ipc/src/client.rs
@@ -18,9 +18,11 @@ use crate::transport::IpcStream;
 
 use crate::request::{
     AddPeerRequest, AttachRequest, InboxRequest, PublishRequest, RemovePeerRequest, Request,
-    SendRequest, SubscribeRequest,
+    ResolveWireRequest, SendRequest, SubscribeRequest,
 };
-use crate::response::{InboxResponse, PeersResponse, PublishResponse, Response, StatusResponse};
+use crate::response::{
+    InboxResponse, PeersResponse, PublishResponse, ResolveWireResponse, Response, StatusResponse,
+};
 
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(5);
 const SUBSCRIBE_RPC_TIMEOUT: Duration = Duration::from_secs(15);
@@ -134,6 +136,7 @@ impl DaemonClient {
             | Response::Event { .. }
             | Response::Publish(_)
             | Response::Peers(_)
+            | Response::ResolveWire(_)
             | Response::Ok) => Ok(other),
         }
     }
@@ -151,6 +154,7 @@ impl DaemonClient {
             | Response::Publish(_)
             | Response::Peers(_)
             | Response::Ok
+            | Response::ResolveWire(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
@@ -171,6 +175,7 @@ impl DaemonClient {
             | Response::Publish(_)
             | Response::Peers(_)
             | Response::Ok
+            | Response::ResolveWire(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
@@ -184,6 +189,7 @@ impl DaemonClient {
             | Response::Event { .. }
             | Response::Publish(_)
             | Response::Peers(_)
+            | Response::ResolveWire(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
@@ -195,6 +201,28 @@ impl DaemonClient {
             | Response::Status(_)
             | Response::Inbox(_)
             | Response::Event { .. }
+            | Response::Peers(_)
+            | Response::Ok
+            | Response::ResolveWire(_)
+            | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
+        }
+    }
+
+    /// Look up the wire path the daemon uses for a given channel
+    /// UUID. Returns `None` inside [`ResolveWireResponse`] when the
+    /// daemon has not subscribed that channel yet — same non-auto-
+    /// join discipline as [`Airc::publish`](airc-lib's publish API).
+    pub async fn resolve_wire(
+        &self,
+        request: ResolveWireRequest,
+    ) -> Result<ResolveWireResponse, ClientError> {
+        match self.call(Request::ResolveWire(request)).await? {
+            Response::ResolveWire(response) => Ok(response),
+            other @ (Response::Pong
+            | Response::Status(_)
+            | Response::Inbox(_)
+            | Response::Event { .. }
+            | Response::Publish(_)
             | Response::Peers(_)
             | Response::Ok
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
@@ -222,6 +250,7 @@ impl DaemonClient {
             | Response::Event { .. }
             | Response::Publish(_)
             | Response::Peers(_)
+            | Response::ResolveWire(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
@@ -235,6 +264,7 @@ impl DaemonClient {
             | Response::Publish(_)
             | Response::Peers(_)
             | Response::Ok
+            | Response::ResolveWire(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
@@ -248,6 +278,7 @@ impl DaemonClient {
             | Response::Event { .. }
             | Response::Publish(_)
             | Response::Peers(_)
+            | Response::ResolveWire(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
@@ -261,6 +292,7 @@ impl DaemonClient {
             | Response::Event { .. }
             | Response::Publish(_)
             | Response::Peers(_)
+            | Response::ResolveWire(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
@@ -274,6 +306,7 @@ impl DaemonClient {
             | Response::Event { .. }
             | Response::Publish(_)
             | Response::Peers(_)
+            | Response::ResolveWire(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }
@@ -290,6 +323,7 @@ impl DaemonClient {
             | Response::Event { .. }
             | Response::Publish(_)
             | Response::Ok
+            | Response::ResolveWire(_)
             | Response::Error { .. }) => Err(ClientError::UnexpectedResponse(other)),
         }
     }

--- a/crates/airc-ipc/src/lib.rs
+++ b/crates/airc-ipc/src/lib.rs
@@ -25,13 +25,15 @@ pub mod transport;
 /// that an already-running daemon cannot parse. The default CLI socket
 /// includes this value so `airc join` starts a current daemon instead of
 /// connecting to a stale daemon that speaks the previous protocol.
-pub const IPC_PROTOCOL_VERSION: u16 = 3;
+pub const IPC_PROTOCOL_VERSION: u16 = 4;
 
 pub use client::{ClientError, DaemonClient};
 pub use request::{
     AddPeerRequest, AttachRequest, InboxRequest, PublishRequest, RemovePeerRequest, Request,
-    SendRequest, SubscribeRequest,
+    ResolveWireRequest, SendRequest, SubscribeRequest,
 };
-pub use response::{InboxResponse, PeersResponse, PublishResponse, Response, StatusResponse};
+pub use response::{
+    InboxResponse, PeersResponse, PublishResponse, ResolveWireResponse, Response, StatusResponse,
+};
 // IpcListener / IpcStream stay under `transport` because only the
 // daemon host and low-level tests need the raw byte transport.

--- a/crates/airc-ipc/src/request.rs
+++ b/crates/airc-ipc/src/request.rs
@@ -39,6 +39,12 @@ pub enum Request {
     /// wire. Idempotent — repeated calls return Ok without
     /// duplicating subscriptions.
     Subscribe(SubscribeRequest),
+    /// Look up the wire path for a channel UUID. Daemon answers
+    /// from its subscription store so consumer-side code (e.g.
+    /// continuum's `DaemonAircRealtimeStore`) can fill
+    /// `PublishRequest.wire` without knowing the daemon's
+    /// filesystem layout. Closes work card 6e525958.
+    ResolveWire(ResolveWireRequest),
     /// Read events from the daemon's durable event store, strictly
     /// after `since` (a `(lamport, event_id)` cursor) and optionally
     /// filtered to a single channel. Pass back the response's
@@ -59,6 +65,18 @@ pub struct SubscribeRequest {
     /// Wire directory to subscribe on (creates the local-fs adapter
     /// + replay-anchored subscription if not already running).
     pub wire: std::path::PathBuf,
+}
+
+/// Parameters for `ResolveWire`. The daemon answers from its
+/// own subscription store; consumer-side callers (continuum's
+/// `DaemonAircRealtimeStore`, OpenClaw/Hermes bridges) get the
+/// wire path without ever needing to construct it themselves.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolveWireRequest {
+    /// Channel UUID to resolve. Same value the consumer holds
+    /// from prior `Subscribe`, `Publish`, or `airc room`
+    /// interactions.
+    pub channel: Uuid,
 }
 
 /// Parameters for `Inbox`.
@@ -201,5 +219,15 @@ mod tests {
             serde_json::to_string(&Request::Stop).unwrap(),
             r#"{"op":"stop"}"#
         );
+    }
+
+    #[test]
+    fn resolve_wire_roundtrips_with_typed_channel() {
+        let original = Request::ResolveWire(ResolveWireRequest {
+            channel: Uuid::from_u128(0xabcd_1234),
+        });
+        let encoded = serde_json::to_string(&original).unwrap();
+        let decoded: Request = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, original);
     }
 }

--- a/crates/airc-ipc/src/response.rs
+++ b/crates/airc-ipc/src/response.rs
@@ -1,6 +1,8 @@
 //! Daemon → client responses. Symmetric to `request.rs` — typed
 //! enum, wire-tagged by `kind`.
 
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 
 use airc_core::{EventId, PeerId, RoomId};
@@ -23,6 +25,10 @@ pub enum Response {
     },
     /// Response to `Publish`.
     Publish(PublishResponse),
+    /// Response to `ResolveWire`. `wire` is `None` when the
+    /// channel UUID isn't subscribed in this daemon's scope —
+    /// caller must join the channel first.
+    ResolveWire(ResolveWireResponse),
     /// Response to `ListPeers` — the daemon's currently-enrolled
     /// peers (peer_id + URL-safe-no-padding base64 pubkey).
     Peers(PeersResponse),
@@ -97,6 +103,19 @@ pub struct PublishResponse {
     pub channel_id: RoomId,
 }
 
+/// Result of a `ResolveWire` request.
+///
+/// `wire` is `Some(path)` when the daemon's subscription store
+/// has a subscription on the requested channel UUID; `None`
+/// when the daemon has never seen that channel (caller must
+/// join it first — `ResolveWire` does not auto-subscribe, same
+/// non-auto-join discipline as `Airc::publish`'s
+/// `PublishTarget::RoomByName`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolveWireResponse {
+    pub wire: Option<PathBuf>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -162,6 +181,24 @@ mod tests {
             occurred_at_ms: 3,
             channel_id: RoomId::from_u128(4),
         });
+        let encoded = serde_json::to_string(&original).unwrap();
+        let decoded: Response = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn resolve_wire_roundtrips_with_path() {
+        let original = Response::ResolveWire(ResolveWireResponse {
+            wire: Some(PathBuf::from("/var/lib/airc/wires/project-x")),
+        });
+        let encoded = serde_json::to_string(&original).unwrap();
+        let decoded: Response = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn resolve_wire_roundtrips_with_none() {
+        let original = Response::ResolveWire(ResolveWireResponse { wire: None });
         let encoded = serde_json::to_string(&original).unwrap();
         let decoded: Response = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, original);


### PR DESCRIPTION
## Summary
Closes work card **6e525958** (P1).

Per Joel's Q2 call on continuum#1449: consumer-side callers (continuum's \`DaemonAircRealtimeStore\`, OpenClaw/Hermes bridges) should not know the daemon's filesystem layout. The daemon already owns the channel→wire mapping (via its subscription store), so the right shape is a typed IPC op asking the daemon to resolve it.

## Wire protocol

\`\`\`rust
Request::ResolveWire(ResolveWireRequest { channel: Uuid })
Response::ResolveWire(ResolveWireResponse { wire: Option<PathBuf> })
\`\`\`

\`wire = None\` means *\"the daemon has not subscribed that channel yet\"* — not an error. Same non-auto-join discipline as \`Airc::publish\`'s \`PublishTarget::RoomByName\` (#990).

## Protocol version
\`IPC_PROTOCOL_VERSION\` bumped 3 → 4. Adding a new Request variant is wire-incompatible for existing daemons; bumping forces a fresh daemon process onto the new socket per the existing scope-versioned-socket discipline.

## Daemon
\`handle_resolve_wire\` loads subscriptions, finds the one with matching \`room_id\` whose \`parted == false\`, returns its wire path. Parted subscriptions are intentionally invisible (non-auto-rejoin discipline).

## Client helper
\`DaemonClient::resolve_wire(ResolveWireRequest) -> Result<ResolveWireResponse, ClientError>\` — same shape as \`publish\` / \`inbox\` / \`list_peers\`.

## Test plan
- [x] airc-ipc request: roundtrip with typed channel UUID.
- [x] airc-ipc response: roundtrip with \`Some(path)\` AND \`None\`.
- [x] airc-daemon handlers (3): unsubscribed → None; subscribed → path; parted → None.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all\` clean.
- [x] \`cargo test --workspace\` green.

## Downstream
Unblocks continuum#156770cf (\`DaemonAircRealtimeStore\` swap) per the integration-prep status update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)