### PR TITLE
fix(work): exclude terminal cards from stale recovery

### DIFF
--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -390,6 +390,56 @@ fn work_close_removes_card_from_claimable_next() {
 }
 
 #[test]
+fn work_next_ignores_stale_claim_after_card_is_closed() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("agent");
+
+    run_ok(&home, &["init"]);
+    let create = run_ok(
+        &home,
+        &[
+            "work",
+            "create",
+            "--repo",
+            "CambrianTech/airc",
+            "--title",
+            "closed stale work should not resurrect",
+            "--priority",
+            "p0",
+        ],
+    );
+    let card_id = extract_field(&create, "card_id:").expect("card id");
+
+    let claim = run_ok(
+        &home,
+        &[
+            "work",
+            "claim",
+            card_id,
+            "--ttl-ms",
+            "1",
+            "--no-lease-required",
+        ],
+    );
+    let claim_id = extract_field(&claim, "claim_id:").expect("claim id");
+    std::thread::sleep(std::time::Duration::from_millis(5));
+
+    let stale_next = run_ok(&home, &["work", "next", "--event-limit", "128"]);
+    assert!(stale_next.contains(card_id), "{stale_next}");
+    assert!(stale_next.contains(claim_id), "{stale_next}");
+
+    run_ok(&home, &["work", "close", card_id]);
+
+    let board = run_ok(&home, &["work", "board"]);
+    assert!(board.contains("Closed"), "{board}");
+    assert!(!board.contains("stale claims: 1"), "{board}");
+
+    let next = run_ok(&home, &["work", "next", "--event-limit", "128"]);
+    assert!(!next.contains(card_id), "{next}");
+    assert!(!next.contains(claim_id), "{next}");
+}
+
+#[test]
 fn lane_create_status_and_state_drive_work_projection() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("agent");

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -610,7 +610,12 @@ impl Airc {
                 .find(|claim| claim.card_id == card.card_id)
                 .cloned();
             let open = card.state == airc_work::CardState::Open && card.claim_id.is_none();
-            let stale_claimable = query.include_stale_claims && stale_claim.is_some();
+            let stale_claimable = query.include_stale_claims
+                && stale_claim.is_some()
+                && !matches!(
+                    card.state,
+                    airc_work::CardState::Merged | airc_work::CardState::Closed
+                );
             if !open && !stale_claimable {
                 continue;
             }

--- a/crates/airc-work/src/projection/apply.rs
+++ b/crates/airc-work/src/projection/apply.rs
@@ -113,6 +113,7 @@ impl WorkBoardProjection {
     pub fn stale_claims(&self, now_ms: u64) -> Vec<StaleClaim> {
         self.cards
             .values()
+            .filter(|card| !matches!(card.state, CardState::Merged | CardState::Closed))
             .filter_map(|card| {
                 let (owner, claim_id, expires_at_ms) =
                     (card.owner?, card.claim_id?, card.claim_expires_at_ms?);

--- a/crates/airc-work/src/projection/tests.rs
+++ b/crates/airc-work/src/projection/tests.rs
@@ -63,6 +63,67 @@ fn card_claim_heartbeat_and_stale_detection_project_from_events() {
 }
 
 #[test]
+fn terminal_cards_do_not_surface_stale_claims() {
+    let owner = peer(6);
+    let merged_card = WorkCardId::from_u128(7);
+    let merged_claim = ClaimId::from_u128(8);
+    let closed_card = WorkCardId::from_u128(9);
+    let closed_claim = ClaimId::from_u128(10);
+
+    let projection = WorkBoardProjection::replay(vec![
+        WorkEvent::CardCreated(CardCreated {
+            card_id: merged_card,
+            repo: repo(),
+            title: "merged stale claim".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+            created_by: owner,
+            created_at_ms: 100,
+        }),
+        WorkEvent::CardClaimed(WorkCardClaimed {
+            card_id: merged_card,
+            claim_id: merged_claim,
+            owner,
+            ttl_ms: 10,
+            claimed_at_ms: 110,
+        }),
+        WorkEvent::CardStateChanged(CardStateChanged {
+            card_id: merged_card,
+            state: CardState::Merged,
+            changed_by: owner,
+            changed_at_ms: 120,
+        }),
+        WorkEvent::CardCreated(CardCreated {
+            card_id: closed_card,
+            repo: repo(),
+            title: "closed stale claim".to_string(),
+            body: None,
+            priority: Priority::P1,
+            lane_id: None,
+            created_by: owner,
+            created_at_ms: 100,
+        }),
+        WorkEvent::CardClaimed(WorkCardClaimed {
+            card_id: closed_card,
+            claim_id: closed_claim,
+            owner,
+            ttl_ms: 10,
+            claimed_at_ms: 110,
+        }),
+        WorkEvent::CardStateChanged(CardStateChanged {
+            card_id: closed_card,
+            state: CardState::Closed,
+            changed_by: owner,
+            changed_at_ms: 120,
+        }),
+    ])
+    .unwrap();
+
+    assert!(projection.stale_claims(121).is_empty());
+}
+
+#[test]
 fn releasing_claim_clears_owner_without_reopening_closed_card() {
     let card_id = WorkCardId::from_u128(10);
     let claim_id = ClaimId::from_u128(11);


### PR DESCRIPTION
Summary
- exclude Closed and Merged work cards from stale-claim recovery at the projection layer
- keep airc-lib work queue selection from resurrecting terminal cards as claimable work
- add projection and CLI regressions for stale claim -> terminal state -> no work-next suggestion

Roadmap / card
- closes AIRC work card 7d0fca25-7764-4031-a47d-4853d8bccd5c

Verification
- cargo fmt --all --check
- cargo test -p airc-work
- cargo test -p airc-cli --test work_commands
- cargo test -p airc-lib work
- cargo clippy -p airc-work -p airc-lib -p airc-cli --all-targets -- -D warnings