### PR TITLE
fix(identity): resolve mesh identity against machine-global coordinator store

### DIFF
--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -126,6 +126,95 @@ fn two_airc_core_processes_chat_over_local_fs() {
     );
 }
 
+/// Two scopes (project dirs) on ONE machine account, each running
+/// `join`, must deliver chat to each other over the shared
+/// machine-account wire — with NO explicit `--peer` pairing.
+///
+/// This is the real multi-tab topology (e.g. `…/airc` and
+/// `…/continuum` open at once) and the one the in-process
+/// `external_identity_bridge` tests never exercise: there the two
+/// `Airc` instances live in a single process, so the wire subscriber
+/// runs in the same address space. Here they are two real daemons,
+/// which is where same-machine delivery actually breaks.
+#[test]
+fn two_join_scopes_same_machine_deliver_over_shared_wire() {
+    let machine = TempDir::new().expect("tempdir");
+    let repo_a = machine.path().join("airc");
+    let repo_b = machine.path().join("continuum");
+    let home_a = repo_a.join(".airc");
+    let home_b = repo_b.join(".airc");
+    // Same owner → both auto-scope to #cambriantech, the shared room.
+    create_repo_with_origin(&repo_a, "https://github.com/CambrianTech/airc.git");
+    create_repo_with_origin(&repo_b, "https://github.com/CambrianTech/continuum.git");
+
+    // Reproduce the real-world divergence that fractured #cambriantech:
+    // the two scopes resolved DIFFERENT mesh identities for the same
+    // user — scope A via `git_email` ("joelteply@yahoo.com"), scope B
+    // via `gh_api_user` ("joelteply"). Because the RoomId is derived
+    // from the mesh identity, the same channel name produced two
+    // room_ids and the scopes silently filtered out each other's
+    // frames. We seed each scope's PER-SCOPE store with the divergent
+    // values, and the machine-global COORDINATOR store
+    // (`$HOME/.airc/events.sqlite`) with the canonical one.
+    //
+    // Pre-fix, resolution read the per-scope store → divergent room_ids
+    // → scope B never receives scope A's message (this assertion fails).
+    // Post-fix, resolution reads the coordinator store → both converge
+    // on "joelteply" → delivery works. Deterministic: Operator-source
+    // seeds never expire, so no `gh`/`git` shell-out is involved.
+    let coordinator_home = machine.path().join(".airc");
+    seed_mesh_identity(&coordinator_home, "joelteply");
+    seed_mesh_identity(&home_a, "joelteply@yahoo.com");
+    seed_mesh_identity(&home_b, "joelteply");
+
+    let spawn_join = |home: &Path, repo: &Path, client: &str| {
+        let mut join = Command::new(airc_core());
+        join.env("HOME", machine.path())
+            .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
+            .env("AIRC_CLIENT_ID", client)
+            .args(["--home", home.to_str().unwrap(), "join"])
+            .current_dir(repo)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        strip_cargo_harness_env(&mut join);
+        let mut child = join.spawn().expect("airc join must spawn");
+        let stdout = spawn_line_reader(child.stdout.take().expect("join stdout"));
+        wait_for_channel_line_contains(&stdout, "attached", JOIN_ATTACH_TIMEOUT)
+            .unwrap_or_else(|| panic!("{client} did not attach"));
+        (child, stdout)
+    };
+
+    let (mut child_a, _a_out) = spawn_join(&home_a, &repo_a, "agent:scope-a");
+    let (mut child_b, b_out) = spawn_join(&home_b, &repo_b, "agent:scope-b");
+
+    // Scope A broadcasts to the default shared channel. No --peer.
+    let needle = "hello-from-scope-a-7f3c91";
+    let mut msg = Command::new(airc_core());
+    msg.env("HOME", machine.path())
+        .args(["--home", home_a.to_str().unwrap(), "msg", needle]);
+    let sent = output_with_timeout(msg, Duration::from_secs(10), "airc msg");
+    assert!(
+        sent.status.success(),
+        "scope A msg failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&sent.stdout),
+        String::from_utf8_lossy(&sent.stderr),
+    );
+
+    // Scope B's live feed MUST surface A's message.
+    let got = wait_for_channel_line_contains(&b_out, needle, Duration::from_secs(10));
+
+    let _ = child_a.kill();
+    let _ = child_a.wait();
+    let _ = child_b.kill();
+    let _ = child_b.wait();
+
+    assert!(
+        got.is_some(),
+        "scope B never received scope A's message over the shared machine-account wire — \
+         same-machine cross-process delivery is broken"
+    );
+}
+
 /// Run `airc-core --home <dir> room <name> --wire <wire>`. Used by
 /// tests to pin two peers to the same shared-wire room.
 fn run_room(home: &Path, name: &str, wire: &Path) {

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -418,8 +418,19 @@ impl Airc {
     /// re-resolves after [`crate::mesh_identity::DEFAULT_TTL_MS`] so
     /// concurrent callers don't hammer `gh`. See the module docs for
     /// the resolver chain.
+    ///
+    /// Resolves against the machine-global **coordinator** store
+    /// (`~/.airc/events.sqlite`), NOT the per-scope store. Per
+    /// `docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md`, "the account
+    /// identity, not the machine [scope], is the room namespace." A
+    /// per-scope cache let two scopes on the same machine resolve
+    /// divergent identities (`gh_api_user` "joelteply" vs `git_email`
+    /// "joelteply@yahoo.com"), and since the RoomId is derived from
+    /// the identity, the same channel name fractured into two room_ids
+    /// that silently could not see each other. The coordinator store
+    /// is the machine-global convergence point the contract requires.
     pub(crate) async fn mesh_identity(&self) -> Result<MeshIdentity, AircError> {
-        let cached = mesh_identity::resolve(self.event_store()).await?;
+        let cached = mesh_identity::resolve(self.coordinator_store()).await?;
         Ok(cached.as_mesh_identity())
     }
 

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -429,7 +429,25 @@ impl Airc {
     /// the identity, the same channel name fractured into two room_ids
     /// that silently could not see each other. The coordinator store
     /// is the machine-global convergence point the contract requires.
+    ///
+    /// If the coordinator has no cached identity yet but this scope's
+    /// per-scope store does (older state, or a scope that resolved
+    /// before the coordinator was seeded), adopt the per-scope value
+    /// and promote it into the coordinator — keeping the coordinator
+    /// authoritative while honoring an already-resolved identity. This
+    /// avoids re-running the gh/git resolver and avoids fracturing
+    /// rooms when the coordinator path differs from the scope path —
+    /// e.g. on Windows, where `machine_account_home` collapses temp
+    /// homes that live under `USERPROFILE` onto one coordinator store.
     pub(crate) async fn mesh_identity(&self) -> Result<MeshIdentity, AircError> {
+        if mesh_identity::load_cached(self.coordinator_store())
+            .await?
+            .is_none()
+        {
+            if let Some(local) = mesh_identity::load_cached(self.event_store()).await? {
+                mesh_identity::save(self.coordinator_store(), &local).await?;
+            }
+        }
         let cached = mesh_identity::resolve(self.coordinator_store()).await?;
         Ok(cached.as_mesh_identity())
     }

--- a/crates/airc-lib/tests/embedding_smoke.rs
+++ b/crates/airc-lib/tests/embedding_smoke.rs
@@ -416,6 +416,12 @@ fn default_join_context_subscribes_general_and_repo_owner_on_shared_account_wire
             let alice_home = alice_repo.join(".airc");
             let bob_home = bob_repo.join(".airc");
 
+            // Mesh identity resolves against the machine-global
+            // coordinator store (`$HOME/.airc/events.sqlite`), not the
+            // per-scope store — see `Airc::mesh_identity`. Seed the
+            // coordinator so both scopes converge on "joelteply"
+            // deterministically without a `gh` shell-out.
+            seed_mesh_identity(&machine.path().join(".airc"), "joelteply").await;
             seed_mesh_identity(&alice_home, "joelteply").await;
             seed_mesh_identity(&bob_home, "joelteply").await;
 


### PR DESCRIPTION
## Problem

Two scopes on one machine account silently could not see each other's messages. Each resolved its mesh identity independently against its **own per-scope store**, and they diverged — `gh_api_user` (`joelteply`) in one scope, `git_email` (`joelteply@yahoo.com`) in the other. Because `RoomId` is derived from the mesh identity (`derive_room_id(identity, channel)`), the same channel name (`cambriantech`) produced **two different room_ids**. Both scopes wrote into the shared wire directory, but the subscription filter dropped the other's frames as belonging to a different room. The failure was **silent** (filtered, not rejected), so it presented as "peer offline."

This violated the already-binding `docs/architecture/ACCOUNT-MESH-JOIN-CONTRACT.md`: *"the account identity, not the machine [scope], is the room namespace"* — and its acceptance test *"two CambrianTech repos on one machine see the same #cambriantech."*

## Fix

`Airc::mesh_identity()` now resolves against the **machine-global coordinator store** (`~/.airc/events.sqlite`) instead of the per-scope store — the convergence point the contract's "machine-global coordinator" section already prescribes (resolve once, scopes attach). All scopes on one machine account now converge on one canonical identity and one room_id per channel.

## Work Intake Rule

- **Closes:** account-mesh-join-contract acceptance test (two CambrianTech repos on one machine converge on the same `#cambriantech` room_id). **Advances Gate 1.**
- **Python/shell:** neither removed nor bridged — pure Rust runtime fix.
- **Branch:** `fix/mesh-identity-machine-global-convergence` → `rust-rewrite`.
- **Test:** `e2e::two_join_scopes_same_machine_deliver_over_shared_wire` reproduces the divergence (scope A `git_email`, scope B `gh_api_user`, coordinator canonical). **Proven both ways:** fails without the change with `"scope B never received scope A's message"`, passes with it. Deterministic — Operator-source seeds never expire, so no `gh`/`git` shell-out. `embedding_smoke` seed updated to the coordinator store. **Full workspace suite green: 758 passed, 0 failed.**

## Follow-up (not in this PR)

Cross-*machine* convergence also needs `git_email` → `gh_api_user` source-strength upgrading; held as a follow-up gated on the cross-machine registry path (a documented gap). This PR fixes same-machine convergence — the acute "two tabs can't talk" bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
