### PR TITLE
feat(airc-bus): owner-core event router — sharded router + hot ring + generational cursor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "airc-bus"
+version = "0.1.0"
+dependencies = [
+ "airc-core",
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "futures",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "airc-cli"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/airc-protocol",
     "crates/airc-transport",
     "crates/airc-store",
+    "crates/airc-bus",
     "crates/airc-identity",
     "crates/airc-trust",
     "crates/airc-work",

--- a/crates/airc-bus/Cargo.toml
+++ b/crates/airc-bus/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "airc-bus"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+# Owner-daemon event-server core (slice 1 of AIRC-EVENT-SERVER).
+#
+# This crate is the in-memory, deterministic heart of the owner daemon:
+# the sharded router, per-channel hot ring, coalesced ephemeral cache,
+# cursor engine, and write-behind path to a durable tier. The durable
+# tier is behind the `DurableSink` trait — this crate NEVER depends on
+# airc-store. The ORM-backed `DurableSink` impl lands in a later slice;
+# tests here use an in-memory sink.
+#
+# No IPC wiring, no file-poll deletion: those are separate verticals.
+# Everything here is injectable (Clock + SeqSource + EpochStore) so the
+# acceptance suite is bit-deterministic (§9).
+
+[lints]
+workspace = true
+
+[dependencies]
+airc-core = { path = "../airc-core" }
+
+async-trait = "0.1"
+bytes = "1"
+futures = "0.3"
+async-stream = "0.3"
+thiserror = "1"
+serde = { version = "1", features = ["derive"] }
+uuid = { version = "1", features = ["v4", "serde"] }
+tokio = { version = "1", features = ["rt", "sync", "macros", "time"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
+futures = "0.3"

--- a/crates/airc-bus/src/clock.rs
+++ b/crates/airc-bus/src/clock.rs
@@ -1,0 +1,90 @@
+//! Injectable wall clock (§5, §9).
+//!
+//! `occurred_at_ms` is owner-stamped through a [`Clock`] so tests are
+//! bit-deterministic. Production uses [`SystemClock`]; tests use
+//! [`ManualClock`] and advance it by hand.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Source of wall-clock milliseconds. `Send + Sync` so it lives behind an
+/// `Arc` shared across the router's tasks.
+pub trait Clock: Send + Sync {
+    /// Current time as epoch milliseconds.
+    fn now_ms(&self) -> u64;
+}
+
+/// Real wall clock.
+#[derive(Debug, Default, Clone)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_ms(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0)
+    }
+}
+
+/// Deterministic clock for tests. Starts at a fixed instant; `set`/`advance`
+/// move it explicitly. Cheap to clone — clones share the same time cell.
+#[derive(Debug, Clone)]
+pub struct ManualClock {
+    now: Arc<AtomicU64>,
+}
+
+impl ManualClock {
+    /// Construct a clock reading `start_ms`.
+    pub fn new(start_ms: u64) -> Self {
+        Self {
+            now: Arc::new(AtomicU64::new(start_ms)),
+        }
+    }
+
+    /// Advance the clock by `delta_ms`.
+    pub fn advance(&self, delta_ms: u64) {
+        self.now.fetch_add(delta_ms, Ordering::SeqCst);
+    }
+
+    /// Set the clock to an absolute time.
+    pub fn set(&self, now_ms: u64) {
+        self.now.store(now_ms, Ordering::SeqCst);
+    }
+}
+
+impl Default for ManualClock {
+    fn default() -> Self {
+        Self::new(1_700_000_000_000)
+    }
+}
+
+impl Clock for ManualClock {
+    fn now_ms(&self) -> u64 {
+        self.now.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manual_clock_is_deterministic() {
+        let c = ManualClock::new(1000);
+        assert_eq!(c.now_ms(), 1000);
+        c.advance(50);
+        assert_eq!(c.now_ms(), 1050);
+        c.set(42);
+        assert_eq!(c.now_ms(), 42);
+    }
+
+    #[test]
+    fn manual_clock_clone_shares_time() {
+        let c = ManualClock::new(0);
+        let d = c.clone();
+        c.advance(10);
+        assert_eq!(d.now_ms(), 10, "clones share the underlying time cell");
+    }
+}

--- a/crates/airc-bus/src/envelope.rs
+++ b/crates/airc-bus/src/envelope.rs
@@ -1,0 +1,302 @@
+//! The generic envelope (§2 of AIRC-EVENT-SERVER).
+//!
+//! One primitive carries everything: a chat message, a `data:*` event, a
+//! `screenshot` command, a WebRTC signaling frame. They are distinguished by
+//! [`Kind`] + [`DeliveryClass`], never by living on different buses. The
+//! server routes on `channel` / `target` / `headers` / `delivery` and
+//! **never interprets `payload`** — that opacity keeps it generic across
+//! towers.
+//!
+//! Reuses `airc-core` identity/header types (`RoomId`, `PeerId`, `ClientId`,
+//! `EventId`, `Headers`) so the envelope sits on the same substrate as the
+//! durable `TranscriptEvent`. The durable mapping (`Envelope` ↔
+//! `TranscriptEvent`) is a later-slice concern behind `DurableSink`; this
+//! crate keeps the hot-path type free of ORM shape.
+
+use std::collections::BTreeMap;
+
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use airc_core::{ClientId, EventId, Headers, PeerId, RoomId};
+
+/// Owner-assigned total order = `(epoch, counter)` (§2, §3.8).
+///
+/// `epoch` is persisted and bumped on every daemon start; `counter` is the
+/// in-memory monotonic. Deliver-first (§3.3) can ack a `counter` the ORM has
+/// not flushed yet, so a counter rebuilt from ORM-max after a crash would
+/// *reissue* numbers live subscribers already observed. Bumping `epoch` makes
+/// post-crash events sort strictly after anything pre-crash regardless of
+/// counter rewind. A bare `u64` counter is **not** safe here.
+///
+/// The total order within one owner+channel is `(epoch, counter, event_id)`.
+/// `Ord` derives lexicographically over the field order, which is exactly that
+/// — `epoch` dominates, then `counter`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct Seq {
+    pub epoch: u64,
+    pub counter: u64,
+}
+
+impl Seq {
+    pub fn new(epoch: u64, counter: u64) -> Self {
+        Self { epoch, counter }
+    }
+}
+
+impl std::fmt::Display for Seq {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.epoch, self.counter)
+    }
+}
+
+/// Who an envelope is addressed to (§2).
+///
+/// `Capability` is the 1-to-N capability/query target (§3.9 fan-out /
+/// scatter-gather). Slice 1 carries the variant so the orchestration is not
+/// *precluded*; the grid-router that resolves a capability to a peer set lands
+/// in a later slice. Within slice 1 it routes like `All` (the resolver is
+/// absent), but the shape is here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Target {
+    /// Broadcast to every subscriber on the channel.
+    All,
+    /// A named endpoint address (env/grid scope) — resolved by the router's
+    /// endpoint table in a later slice.
+    Endpoint(String),
+    /// A specific peer.
+    Peer(PeerId),
+    /// The reply leg of a request/response or command/result correlation.
+    Reply(Uuid),
+    /// A capability/query (e.g. `inference:* on a gpu peer`) the grid-router
+    /// resolves to a peer *set* — 1-to-N addressing (§3.9). Slice-1
+    /// placeholder so fan-out/scatter-gather is not precluded.
+    Capability(String),
+}
+
+/// The category of an envelope (§2). Routing/retention keys off this plus
+/// [`DeliveryClass`]; the payload is never parsed to discover it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Kind {
+    Message,
+    Event,
+    Command,
+    CommandResult,
+    Signal,
+    StreamChunk,
+    /// Out-of-band control — e.g. a cancellation addressed to a
+    /// `correlation_id` (§3.9 long-running ops). Slice-1 placeholder.
+    Control,
+}
+
+/// How an envelope is delivered + retained (§2, §3.3, §3.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeliveryClass {
+    /// Becomes an ORM row via the write-behind path; the durability source of
+    /// truth. The only class that reaches [`crate::DurableSink`].
+    Durable,
+    /// Coalesced latest-wins by `(channel, coalesce_key)` in-memory with TTL
+    /// (§3.4). 1000 typing updates → one latest value. **Never** an ORM row.
+    EphemeralLatest,
+    /// A bounded ephemeral window (recent N), in-memory only. Carried for
+    /// completeness; slice-1 treats it as live-fan-out + ring like `Durable`
+    /// minus persistence.
+    EphemeralWindow,
+    /// Request leg of a request/response (§3.9). Routed live; correlated by
+    /// `correlation_id`. Not persisted by default.
+    RequestResponse,
+    /// A chunk of a longer stream (progress, media-control). Routed live; not
+    /// persisted by default.
+    StreamChunk,
+}
+
+impl DeliveryClass {
+    /// True iff an envelope of this class must reach the durable tier.
+    pub fn is_durable(self) -> bool {
+        matches!(self, DeliveryClass::Durable)
+    }
+
+    /// True iff an envelope of this class coalesces latest-wins and must
+    /// **never** reach the durable tier (the firehose keystone, §3.4).
+    pub fn is_ephemeral_latest(self) -> bool {
+        matches!(self, DeliveryClass::EphemeralLatest)
+    }
+}
+
+/// The generic envelope (§2). `payload` is opaque consumer bytes.
+///
+/// `seq` and `occurred_at_ms` are **owner-stamped** — they are assigned by
+/// [`crate::EventRouter::publish`] and are *not* part of the sender's
+/// signature scope (§2 signature scope). A freshly-authored envelope leaves
+/// `seq` unset until publish; the convenience constructors below build the
+/// sender-authored shape and the router fills the rest.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Envelope {
+    /// Stable across replay — two subscribers replaying the same event see the
+    /// same `event_id`.
+    pub event_id: EventId,
+    /// The room/stream this envelope belongs to.
+    pub channel: RoomId,
+    /// Sender identity + session: `(peer, client)`.
+    pub from: (PeerId, ClientId),
+    /// Addressing (§2).
+    pub target: Target,
+    pub kind: Kind,
+    pub delivery: DeliveryClass,
+    /// Owner-assigned order `(epoch, counter)` (§2, §3.8). Assigned at publish.
+    pub seq: Seq,
+    /// Owner-stamped wall clock via an injectable [`crate::Clock`]
+    /// (deterministic tests, §9). Assigned at publish.
+    pub occurred_at_ms: u64,
+    /// Command ↔ result, request ↔ response correlation.
+    pub correlation_id: Option<Uuid>,
+    /// Coalescing key for [`DeliveryClass::EphemeralLatest`] (§3.4).
+    pub coalesce_key: Option<String>,
+    /// Routable metadata; airc routes on these, never parses payload.
+    pub headers: Headers,
+    /// OPAQUE consumer-typed payload.
+    pub payload: Bytes,
+}
+
+impl Envelope {
+    /// Construct a sender-authored envelope. `seq` and `occurred_at_ms` are
+    /// placeholders (`Seq { 0, 0 }` / `0`) — [`crate::EventRouter::publish`]
+    /// overwrites them with owner-stamped values. Use the builder setters for
+    /// the optional fields.
+    pub fn new(
+        channel: RoomId,
+        from: (PeerId, ClientId),
+        kind: Kind,
+        delivery: DeliveryClass,
+        payload: Bytes,
+    ) -> Self {
+        Self {
+            event_id: EventId::new(),
+            channel,
+            from,
+            target: Target::All,
+            kind,
+            delivery,
+            seq: Seq::new(0, 0),
+            occurred_at_ms: 0,
+            correlation_id: None,
+            coalesce_key: None,
+            headers: BTreeMap::new(),
+            payload,
+        }
+    }
+
+    /// Set the addressing target.
+    pub fn with_target(mut self, target: Target) -> Self {
+        self.target = target;
+        self
+    }
+
+    /// Set the coalescing key (for [`DeliveryClass::EphemeralLatest`]).
+    pub fn with_coalesce_key(mut self, key: impl Into<String>) -> Self {
+        self.coalesce_key = Some(key.into());
+        self
+    }
+
+    /// Set the correlation id.
+    pub fn with_correlation_id(mut self, id: Uuid) -> Self {
+        self.correlation_id = Some(id);
+        self
+    }
+
+    /// Set one header.
+    pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.insert(key.into(), value.into());
+        self
+    }
+
+    /// Override the stable `event_id` — used by deterministic tests so a
+    /// replayed event is identity-comparable.
+    pub fn with_event_id(mut self, id: EventId) -> Self {
+        self.event_id = id;
+        self
+    }
+
+    /// The cursor position of this envelope: `(seq, event_id)` (§3.5).
+    pub fn cursor(&self) -> Cursor {
+        Cursor {
+            seq: self.seq,
+            event_id: self.event_id,
+        }
+    }
+}
+
+/// A per-owner-per-channel replay position (§3.5).
+///
+/// Cursor = `(seq, event_id)`, `seq = (epoch, counter)`. A channel's total
+/// order is authoritative only *within one owner daemon* — cross-machine order
+/// of a shared channel is deliberately NOT assumed (§9). Slice 1 must not bake
+/// in a single global authority, so this type is intentionally per-owner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Cursor {
+    pub seq: Seq,
+    pub event_id: EventId,
+}
+
+impl Cursor {
+    pub fn new(seq: Seq, event_id: EventId) -> Self {
+        Self { seq, event_id }
+    }
+
+    /// True iff `self` is strictly before `other` in total order:
+    /// `(epoch, counter)` first, `event_id` as deterministic tiebreaker.
+    ///
+    /// The tiebreaker only ever matters if two events share an exact `seq`,
+    /// which the monotonic counter forbids within one epoch; it is here for
+    /// defense-in-depth and to give `Cursor` a total order independent of how
+    /// `seq` was produced.
+    pub fn is_before(&self, other: &Cursor) -> bool {
+        match self.seq.cmp(&other.seq) {
+            std::cmp::Ordering::Less => true,
+            std::cmp::Ordering::Greater => false,
+            std::cmp::Ordering::Equal => self.event_id.0 < other.event_id.0,
+        }
+    }
+
+    /// True iff an event with this cursor is strictly *after* `gate` — the
+    /// "deliver everything strictly after my cursor" predicate (§3.5).
+    pub fn is_after(&self, gate: &Cursor) -> bool {
+        gate.is_before(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seq_orders_epoch_dominant() {
+        // §3.8: a post-crash event (higher epoch, possibly lower counter)
+        // sorts strictly AFTER a pre-crash event even when the counter rewinds.
+        let pre = Seq::new(1, 1000);
+        let post = Seq::new(2, 0);
+        assert!(post > pre, "higher epoch dominates even with lower counter");
+    }
+
+    #[test]
+    fn cursor_is_after_uses_total_order() {
+        let a = Cursor::new(Seq::new(1, 5), EventId::from_u128(1));
+        let b = Cursor::new(Seq::new(1, 6), EventId::from_u128(2));
+        assert!(b.is_after(&a));
+        assert!(!a.is_after(&b));
+        assert!(!a.is_after(&a), "a cursor is never strictly after itself");
+    }
+
+    #[test]
+    fn cursor_event_id_breaks_seq_ties() {
+        let s = Seq::new(3, 3);
+        let lo = Cursor::new(s, EventId::from_u128(1));
+        let hi = Cursor::new(s, EventId::from_u128(2));
+        assert!(lo.is_before(&hi));
+        assert!(!hi.is_before(&lo));
+    }
+}

--- a/crates/airc-bus/src/ephemeral.rs
+++ b/crates/airc-bus/src/ephemeral.rs
@@ -12,13 +12,14 @@
 //! never holds that lock across `.await`.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::envelope::Envelope;
 
 /// One coalesced entry: the latest envelope for its key, with the wall-clock
 /// time it landed (for TTL).
 struct Entry {
-    env: Envelope,
+    env: Arc<Envelope>,
     stored_at_ms: u64,
 }
 
@@ -42,7 +43,7 @@ impl EphemeralCache {
     /// Coalesce an `EphemeralLatest` envelope: overwrite the entry for its
     /// `coalesce_key`. An envelope without a `coalesce_key` is keyed by its
     /// `event_id` (degenerate — no coalescing, but still bounded by TTL).
-    pub fn coalesce(&mut self, env: Envelope, now_ms: u64) {
+    pub fn coalesce(&mut self, env: Arc<Envelope>, now_ms: u64) {
         let key = env
             .coalesce_key
             .clone()
@@ -57,7 +58,7 @@ impl EphemeralCache {
     }
 
     /// The current latest value for `key`, if present and not TTL-expired.
-    pub fn get(&self, key: &str, now_ms: u64) -> Option<&Envelope> {
+    pub fn get(&self, key: &str, now_ms: u64) -> Option<&Arc<Envelope>> {
         self.latest.get(key).and_then(|e| {
             if self.expired(e, now_ms) {
                 None
@@ -79,12 +80,13 @@ impl EphemeralCache {
     }
 
     /// All currently-live (non-expired) latest values, for replay-on-attach of
-    /// the ephemeral projection.
-    pub fn snapshot(&self, now_ms: u64) -> Vec<Envelope> {
+    /// the ephemeral projection. Each handle is an [`Arc::clone`] — zero deep
+    /// copy.
+    pub fn snapshot(&self, now_ms: u64) -> Vec<Arc<Envelope>> {
         self.latest
             .values()
             .filter(|e| !self.expired(e, now_ms))
-            .map(|e| e.env.clone())
+            .map(|e| Arc::clone(&e.env))
             .collect()
     }
 
@@ -128,7 +130,7 @@ mod tests {
     fn latest_wins_by_coalesce_key() {
         let mut cache = EphemeralCache::new(0);
         for i in 0..1000u32 {
-            cache.coalesce(presence((i % 256) as u8, "typing:alice"), 100);
+            cache.coalesce(Arc::new(presence((i % 256) as u8, "typing:alice")), 100);
         }
         assert_eq!(cache.live_len(100), 1, "1000 updates coalesce to one entry");
         let last = presence((999 % 256) as u8, "typing:alice");
@@ -141,7 +143,7 @@ mod tests {
     #[test]
     fn ttl_expires_entries() {
         let mut cache = EphemeralCache::new(50);
-        cache.coalesce(presence(1, "k"), 1000);
+        cache.coalesce(Arc::new(presence(1, "k")), 1000);
         assert!(cache.get("k", 1049).is_some(), "within TTL");
         assert!(
             cache.get("k", 1050).is_none(),
@@ -154,8 +156,8 @@ mod tests {
     #[test]
     fn distinct_keys_do_not_coalesce() {
         let mut cache = EphemeralCache::new(0);
-        cache.coalesce(presence(1, "typing:alice"), 0);
-        cache.coalesce(presence(2, "typing:bob"), 0);
+        cache.coalesce(Arc::new(presence(1, "typing:alice")), 0);
+        cache.coalesce(Arc::new(presence(2, "typing:bob")), 0);
         assert_eq!(cache.live_len(0), 2);
     }
 }

--- a/crates/airc-bus/src/ephemeral.rs
+++ b/crates/airc-bus/src/ephemeral.rs
@@ -1,0 +1,161 @@
+//! Coalesced ephemeral cache — latest-wins by `(channel, coalesce_key)` (§3.4).
+//!
+//! `EphemeralLatest` traffic (presence, typing, resource-pressure, signaling
+//! churn, avatar pose at 60-90Hz) is coalesced **latest-wins** in an in-memory
+//! map with TTL — *not* one row per update. 1000 typing updates → one latest
+//! value. The firehose that would kill a DB never reaches the durable tier.
+//!
+//! It's a projection, not a log: rebuildable from recent events. Entries
+//! expire after `ttl_ms` measured against an injectable [`crate::Clock`].
+//!
+//! Not internally synchronized — the router owns it behind a shard mutex and
+//! never holds that lock across `.await`.
+
+use std::collections::HashMap;
+
+use crate::envelope::Envelope;
+
+/// One coalesced entry: the latest envelope for its key, with the wall-clock
+/// time it landed (for TTL).
+struct Entry {
+    env: Envelope,
+    stored_at_ms: u64,
+}
+
+/// Latest-wins ephemeral cache for one channel, keyed by `coalesce_key`.
+pub struct EphemeralCache {
+    /// coalesce_key -> latest entry.
+    latest: HashMap<String, Entry>,
+    ttl_ms: u64,
+}
+
+impl EphemeralCache {
+    /// Construct with a TTL in milliseconds. `ttl_ms == 0` means entries never
+    /// expire by time (still latest-wins).
+    pub fn new(ttl_ms: u64) -> Self {
+        Self {
+            latest: HashMap::new(),
+            ttl_ms,
+        }
+    }
+
+    /// Coalesce an `EphemeralLatest` envelope: overwrite the entry for its
+    /// `coalesce_key`. An envelope without a `coalesce_key` is keyed by its
+    /// `event_id` (degenerate — no coalescing, but still bounded by TTL).
+    pub fn coalesce(&mut self, env: Envelope, now_ms: u64) {
+        let key = env
+            .coalesce_key
+            .clone()
+            .unwrap_or_else(|| env.event_id.to_string());
+        self.latest.insert(
+            key,
+            Entry {
+                env,
+                stored_at_ms: now_ms,
+            },
+        );
+    }
+
+    /// The current latest value for `key`, if present and not TTL-expired.
+    pub fn get(&self, key: &str, now_ms: u64) -> Option<&Envelope> {
+        self.latest.get(key).and_then(|e| {
+            if self.expired(e, now_ms) {
+                None
+            } else {
+                Some(&e.env)
+            }
+        })
+    }
+
+    /// Drop TTL-expired entries; return how many were removed. Callers can
+    /// drive this on a cadence; `get`/`snapshot` also honor TTL so a missed
+    /// sweep is never observable.
+    pub fn sweep(&mut self, now_ms: u64) -> usize {
+        let before = self.latest.len();
+        let ttl_ms = self.ttl_ms;
+        self.latest
+            .retain(|_, e| !Self::is_expired(ttl_ms, e.stored_at_ms, now_ms));
+        before - self.latest.len()
+    }
+
+    /// All currently-live (non-expired) latest values, for replay-on-attach of
+    /// the ephemeral projection.
+    pub fn snapshot(&self, now_ms: u64) -> Vec<Envelope> {
+        self.latest
+            .values()
+            .filter(|e| !self.expired(e, now_ms))
+            .map(|e| e.env.clone())
+            .collect()
+    }
+
+    /// Number of live (non-expired) entries.
+    pub fn live_len(&self, now_ms: u64) -> usize {
+        self.latest
+            .values()
+            .filter(|e| !self.expired(e, now_ms))
+            .count()
+    }
+
+    fn expired(&self, e: &Entry, now_ms: u64) -> bool {
+        Self::is_expired(self.ttl_ms, e.stored_at_ms, now_ms)
+    }
+
+    fn is_expired(ttl_ms: u64, stored_at_ms: u64, now_ms: u64) -> bool {
+        ttl_ms != 0 && now_ms.saturating_sub(stored_at_ms) >= ttl_ms
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{DeliveryClass, Kind};
+    use airc_core::{ClientId, EventId, PeerId, RoomId};
+    use bytes::Bytes;
+
+    fn presence(seq_marker: u8, key: &str) -> Envelope {
+        Envelope::new(
+            RoomId::from_u128(1),
+            (PeerId::from_u128(1), ClientId::from_u128(1)),
+            Kind::Signal,
+            DeliveryClass::EphemeralLatest,
+            Bytes::copy_from_slice(&[seq_marker]),
+        )
+        .with_event_id(EventId::from_u128(seq_marker as u128 + 1))
+        .with_coalesce_key(key)
+    }
+
+    #[test]
+    fn latest_wins_by_coalesce_key() {
+        let mut cache = EphemeralCache::new(0);
+        for i in 0..1000u32 {
+            cache.coalesce(presence((i % 256) as u8, "typing:alice"), 100);
+        }
+        assert_eq!(cache.live_len(100), 1, "1000 updates coalesce to one entry");
+        let last = presence((999 % 256) as u8, "typing:alice");
+        assert_eq!(
+            cache.get("typing:alice", 100).unwrap().payload,
+            last.payload
+        );
+    }
+
+    #[test]
+    fn ttl_expires_entries() {
+        let mut cache = EphemeralCache::new(50);
+        cache.coalesce(presence(1, "k"), 1000);
+        assert!(cache.get("k", 1049).is_some(), "within TTL");
+        assert!(
+            cache.get("k", 1050).is_none(),
+            "at/after TTL boundary expires"
+        );
+        let removed = cache.sweep(1050);
+        assert_eq!(removed, 1);
+    }
+
+    #[test]
+    fn distinct_keys_do_not_coalesce() {
+        let mut cache = EphemeralCache::new(0);
+        cache.coalesce(presence(1, "typing:alice"), 0);
+        cache.coalesce(presence(2, "typing:bob"), 0);
+        assert_eq!(cache.live_len(0), 2);
+    }
+}

--- a/crates/airc-bus/src/error.rs
+++ b/crates/airc-bus/src/error.rs
@@ -1,0 +1,27 @@
+//! Error types for the owner-core.
+
+use thiserror::Error;
+
+/// Errors surfaced by the durable tier ([`crate::DurableSink`]) and the
+/// router's write-behind path.
+#[derive(Debug, Error)]
+pub enum BusError {
+    /// The write-behind queue is full and a fire-and-forget durable publish
+    /// was shed rather than block or OOM (§3.8 bounded write-behind). A
+    /// `Durable` publisher that opted into backpressure blocks instead of
+    /// seeing this.
+    #[error("write-behind queue saturated; durable event shed")]
+    WriteBehindSaturated,
+
+    /// The durable tier rejected or failed an append/page.
+    #[error("durable sink error: {0}")]
+    Sink(String),
+
+    /// A subscriber's bounded live channel filled and the subscriber was
+    /// marked lagged (§3.5). Not fatal — the subscriber resumes from the sink.
+    #[error("subscriber lagged behind the live stream")]
+    Lagged,
+}
+
+/// Crate result alias.
+pub type Result<T> = std::result::Result<T, BusError>;

--- a/crates/airc-bus/src/filter.rs
+++ b/crates/airc-bus/src/filter.rs
@@ -1,0 +1,113 @@
+//! Subscription filter — a compiled predicate over the envelope (§3.1).
+//!
+//! A subscription compiles to a predicate so one subscription can span many
+//! rooms (continuum's wildcard/pattern subscriptions). Slice 1 carries the
+//! channel + kind + header dimensions; the predicate is evaluated cheaply on
+//! the hot path after the O(1) channel-index lookup.
+
+use airc_core::{HeaderFilter, RoomId};
+
+use crate::envelope::{DeliveryClass, Envelope, Kind};
+
+/// What a subscriber wants. An empty filter (`Filter::channel(c)`) matches
+/// every envelope on the channel.
+#[derive(Debug, Clone)]
+pub struct Filter {
+    /// The channel to subscribe to. Slice 1 indexes on a single channel; a
+    /// later slice compiles cross-room patterns to a predicate over many.
+    pub channel: RoomId,
+    /// If set, only these kinds match.
+    pub kinds: Option<Vec<Kind>>,
+    /// If set, only these delivery classes match.
+    pub delivery: Option<Vec<DeliveryClass>>,
+    /// Header predicate (`HeaderFilter::Any` = match all).
+    pub headers: HeaderFilter,
+}
+
+impl Filter {
+    /// A filter that matches everything on `channel`.
+    pub fn channel(channel: RoomId) -> Self {
+        Self {
+            channel,
+            kinds: None,
+            delivery: None,
+            headers: HeaderFilter::Any,
+        }
+    }
+
+    /// Restrict to these kinds.
+    pub fn with_kinds(mut self, kinds: Vec<Kind>) -> Self {
+        self.kinds = Some(kinds);
+        self
+    }
+
+    /// Restrict to these delivery classes.
+    pub fn with_delivery(mut self, delivery: Vec<DeliveryClass>) -> Self {
+        self.delivery = Some(delivery);
+        self
+    }
+
+    /// Restrict by header predicate.
+    pub fn with_headers(mut self, headers: HeaderFilter) -> Self {
+        self.headers = headers;
+        self
+    }
+
+    /// Evaluate the predicate against an envelope already known to be on this
+    /// filter's channel.
+    pub fn matches(&self, env: &Envelope) -> bool {
+        if env.channel != self.channel {
+            return false;
+        }
+        if let Some(kinds) = &self.kinds {
+            if !kinds.contains(&env.kind) {
+                return false;
+            }
+        }
+        if let Some(delivery) = &self.delivery {
+            if !delivery.contains(&env.delivery) {
+                return false;
+            }
+        }
+        self.headers.matches(&env.headers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::{ClientId, PeerId};
+    use bytes::Bytes;
+
+    fn env(kind: Kind, delivery: DeliveryClass) -> Envelope {
+        Envelope::new(
+            RoomId::from_u128(1),
+            (PeerId::from_u128(1), ClientId::from_u128(1)),
+            kind,
+            delivery,
+            Bytes::new(),
+        )
+    }
+
+    #[test]
+    fn channel_only_matches_all() {
+        let f = Filter::channel(RoomId::from_u128(1));
+        assert!(f.matches(&env(Kind::Message, DeliveryClass::Durable)));
+    }
+
+    #[test]
+    fn wrong_channel_never_matches() {
+        let f = Filter::channel(RoomId::from_u128(2));
+        assert!(!f.matches(&env(Kind::Message, DeliveryClass::Durable)));
+    }
+
+    #[test]
+    fn kind_and_delivery_restrict() {
+        let f = Filter::channel(RoomId::from_u128(1))
+            .with_kinds(vec![Kind::Message])
+            .with_delivery(vec![DeliveryClass::Durable]);
+        assert!(f.matches(&env(Kind::Message, DeliveryClass::Durable)));
+        assert!(!f.matches(&env(Kind::Signal, DeliveryClass::Durable)));
+        assert!(!f.matches(&env(Kind::Message, DeliveryClass::EphemeralLatest)));
+    }
+}

--- a/crates/airc-bus/src/lib.rs
+++ b/crates/airc-bus/src/lib.rs
@@ -1,0 +1,56 @@
+//! airc-bus — the owner-daemon event-server core (slice 1 of
+//! `docs/architecture/AIRC-EVENT-SERVER.md`).
+//!
+//! This crate is the **in-memory, deterministic heart** of the owner daemon:
+//! the sharded router (§3.1), the per-channel hot ring (§3.2), the coalesced
+//! ephemeral cache (§3.4), the cursor engine (§3.5), and the write-behind path
+//! to a durable tier (§3.3) — with the crash-safety / ordering / backpressure
+//! invariants (§3.8) baked into the types, not assumed away.
+//!
+//! ## What this crate deliberately is NOT
+//!
+//! - **No IPC wiring.** The attach/publish/ack session protocol (§3.6) is a
+//!   later vertical. The public API here is the in-process router.
+//! - **No `airc-store` dependency.** The durable tier (§3.3) is behind the
+//!   [`DurableSink`] trait; the ORM-backed impl lands in a later slice. Tests
+//!   use [`InMemoryDurableSink`].
+//! - **No file-poll deletion.** Removing `frames.jsonl` / `LocalFsAdapter`
+//!   (§7) is a separate vertical and is not touched here.
+//!
+//! Its purpose is to **de-risk the hardest correctness seams** — generational
+//! order (§3.8), the no-gap cursor (§3.5), and the slow-subscriber guarantee
+//! (§3.5) — in pure, deterministic code with injectable [`Clock`] +
+//! [`SeqSource`] (§9), no global mutable state, and no lock held across an
+//! `.await`.
+//!
+//! ## Module layout
+//!
+//! - [`envelope`] — the generic [`Envelope`] (§2), [`Seq`], [`Cursor`],
+//!   [`Target`], [`Kind`], [`DeliveryClass`].
+//! - [`clock`] — injectable [`Clock`] (+ [`ManualClock`] for tests).
+//! - [`seq`] — generational [`SeqSource`] + persisted [`EpochStore`].
+//! - [`sink`] — the [`DurableSink`] trait + [`InMemoryDurableSink`].
+//! - [`ring`] — the per-channel [`HotRing`] (pinned-until-persisted).
+//! - [`ephemeral`] — the coalesced [`EphemeralCache`] (latest-wins + TTL).
+//! - [`filter`] — the subscription [`Filter`] predicate.
+//! - [`router`] — the [`EventRouter`] (publish + subscribe + write-behind).
+
+pub mod clock;
+pub mod envelope;
+pub mod ephemeral;
+pub mod error;
+pub mod filter;
+pub mod ring;
+pub mod router;
+pub mod seq;
+pub mod sink;
+
+pub use clock::{Clock, ManualClock, SystemClock};
+pub use envelope::{Cursor, DeliveryClass, Envelope, Kind, Seq, Target};
+pub use ephemeral::EphemeralCache;
+pub use error::{BusError, Result};
+pub use filter::Filter;
+pub use ring::HotRing;
+pub use router::{EventRouter, LagFlag, RouterConfig};
+pub use seq::{EpochStore, InMemoryEpochStore, SeqSource};
+pub use sink::{DurableSink, InMemoryDurableSink};

--- a/crates/airc-bus/src/ring.rs
+++ b/crates/airc-bus/src/ring.rs
@@ -1,0 +1,193 @@
+//! Per-channel hot ring — recent-event cache (§3.2, §3.8 pinned-until-persisted).
+//!
+//! Each active channel holds a fixed-capacity ring of recent envelopes. It
+//! serves live fan-out and tail-N / recent-replay entirely from RAM; the
+//! durable tier is consulted only for cold/deep replay past the ring (§3.5).
+//!
+//! The correctness teeth (§3.8): a `Durable` ring entry is **pinned** (not
+//! evictable) until the write-behind path confirms it is persisted. This is
+//! the precondition that makes "no gap" true — otherwise a seam replay could
+//! find an event that is neither in the ring nor in the ORM yet. The ring
+//! therefore enforces a **capacity floor ≥ max un-persisted backlog**: if the
+//! oldest entry is still pinned when we need room, the ring grows past nominal
+//! capacity rather than drop an unpersisted `Durable` event.
+//!
+//! This type is **not** internally synchronized — the router owns it behind a
+//! shard mutex and never holds that lock across an `.await`.
+
+use std::collections::VecDeque;
+
+use crate::envelope::{Cursor, Envelope};
+
+/// One slot in the ring.
+struct Slot {
+    env: Envelope,
+    /// A `Durable` slot is pinned until the sink confirms persistence. While
+    /// pinned it cannot be evicted (the no-gap precondition). Non-durable
+    /// slots are never pinned.
+    pinned: bool,
+}
+
+/// A bounded, in-order ring of recent envelopes for one channel.
+pub struct HotRing {
+    slots: VecDeque<Slot>,
+    capacity: usize,
+}
+
+impl HotRing {
+    /// Construct with nominal `capacity`. The ring may temporarily exceed this
+    /// when the oldest entries are pinned (un-persisted `Durable`), preserving
+    /// the §3.8 floor. `capacity` must be ≥ 1.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            slots: VecDeque::with_capacity(capacity.max(1)),
+            capacity: capacity.max(1),
+        }
+    }
+
+    /// Push an envelope, evicting the oldest *unpinned* entries to stay at
+    /// capacity. A `Durable` entry is inserted pinned (must be unpinned via
+    /// [`HotRing::mark_persisted`] before it can be evicted). Returns nothing;
+    /// the ring never drops a pinned entry, so an un-persisted `Durable` is
+    /// always replayable from RAM until it's in the sink.
+    pub fn push(&mut self, env: Envelope) {
+        let pinned = env.delivery.is_durable();
+        self.slots.push_back(Slot { env, pinned });
+        self.evict_to_capacity();
+    }
+
+    /// Mark the entry with this `event_id` as persisted — unpins it so the
+    /// ring may evict it under capacity pressure. Called by the write-behind
+    /// path once [`crate::DurableSink::append`] confirms (§3.8).
+    pub fn mark_persisted(&mut self, event_id: airc_core::EventId) {
+        if let Some(slot) = self.slots.iter_mut().find(|s| s.env.event_id == event_id) {
+            slot.pinned = false;
+        }
+        // Persistence may have unblocked an eviction that capacity pressure
+        // wanted earlier; reclaim now.
+        self.evict_to_capacity();
+    }
+
+    /// Drop oldest entries until at nominal capacity, but **never** evict a
+    /// pinned (un-persisted `Durable`) entry — that would violate the no-gap
+    /// precondition. Eviction stops at the first pinned entry from the front.
+    fn evict_to_capacity(&mut self) {
+        while self.slots.len() > self.capacity {
+            match self.slots.front() {
+                // Front is unpinned -> safe to drop.
+                Some(slot) if !slot.pinned => {
+                    self.slots.pop_front();
+                }
+                // Front is pinned -> floor reached; stop. The ring exceeds
+                // nominal capacity until write-behind confirms (§3.8 floor).
+                _ => break,
+            }
+        }
+    }
+
+    /// Return clones of every entry strictly *after* `from` (the recent leg of
+    /// the cursor replay), in total order. `from == None` returns the whole
+    /// ring. Used at the replay-then-live seam (§3.5).
+    pub fn replay_after(&self, from: Option<Cursor>) -> Vec<Envelope> {
+        self.slots
+            .iter()
+            .filter(|slot| match &from {
+                None => true,
+                Some(c) => slot.env.cursor().is_after(c),
+            })
+            .map(|slot| slot.env.clone())
+            .collect()
+    }
+
+    /// The cursor of the oldest entry currently retained, if any. A
+    /// `from_cursor` older than this means the ring cannot serve the full
+    /// replay and the deep (sink) leg must cover `(from, oldest_in_ring)`.
+    pub fn oldest_cursor(&self) -> Option<Cursor> {
+        self.slots.front().map(|slot| slot.env.cursor())
+    }
+
+    /// Number of entries currently retained (including over-floor pinned).
+    pub fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// True iff the ring holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+
+    /// Count of currently-pinned (un-persisted `Durable`) entries — the live
+    /// un-persisted backlog. Test/diagnostic lever for the §3.8 floor.
+    pub fn pinned_count(&self) -> usize {
+        self.slots.iter().filter(|s| s.pinned).count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{DeliveryClass, Kind};
+    use crate::Seq;
+    use airc_core::{ClientId, EventId, PeerId, RoomId};
+    use bytes::Bytes;
+
+    fn env_at(counter: u64, delivery: DeliveryClass) -> Envelope {
+        let mut e = Envelope::new(
+            RoomId::from_u128(1),
+            (PeerId::from_u128(1), ClientId::from_u128(1)),
+            Kind::Message,
+            delivery,
+            Bytes::from_static(b"x"),
+        )
+        .with_event_id(EventId::from_u128(counter as u128 + 1));
+        e.seq = Seq::new(1, counter);
+        e
+    }
+
+    #[test]
+    fn evicts_unpinned_to_capacity() {
+        let mut ring = HotRing::new(3);
+        for c in 0..5 {
+            ring.push(env_at(c, DeliveryClass::EphemeralWindow));
+        }
+        assert_eq!(ring.len(), 3, "non-durable entries evict to capacity");
+        // oldest retained is counter 2 (0,1 evicted)
+        assert_eq!(ring.oldest_cursor().unwrap().seq.counter, 2);
+    }
+
+    #[test]
+    fn pinned_durable_is_not_evicted_until_persisted() {
+        let mut ring = HotRing::new(2);
+        // Two durable, both unpersisted -> both pinned.
+        ring.push(env_at(0, DeliveryClass::Durable));
+        ring.push(env_at(1, DeliveryClass::Durable));
+        // Third push wants to evict counter 0, but it's pinned -> ring grows.
+        ring.push(env_at(2, DeliveryClass::Durable));
+        assert_eq!(
+            ring.len(),
+            3,
+            "ring exceeds nominal capacity rather than drop an unpersisted Durable (§3.8 floor)"
+        );
+        assert_eq!(ring.pinned_count(), 3);
+
+        // Confirm persistence of the oldest -> now evictable.
+        ring.mark_persisted(EventId::from_u128(1)); // counter 0
+        assert_eq!(ring.len(), 2, "unpinned oldest reclaimed back to capacity");
+        assert_eq!(ring.oldest_cursor().unwrap().seq.counter, 1);
+    }
+
+    #[test]
+    fn replay_after_returns_strictly_newer_in_order() {
+        let mut ring = HotRing::new(10);
+        for c in 0..5 {
+            ring.push(env_at(c, DeliveryClass::Durable));
+        }
+        let from = env_at(1, DeliveryClass::Durable).cursor();
+        let got: Vec<u64> = ring
+            .replay_after(Some(from))
+            .iter()
+            .map(|e| e.seq.counter)
+            .collect();
+        assert_eq!(got, vec![2, 3, 4]);
+    }
+}

--- a/crates/airc-bus/src/ring.rs
+++ b/crates/airc-bus/src/ring.rs
@@ -16,12 +16,13 @@
 //! shard mutex and never holds that lock across an `.await`.
 
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 use crate::envelope::{Cursor, Envelope};
 
 /// One slot in the ring.
 struct Slot {
-    env: Envelope,
+    env: Arc<Envelope>,
     /// A `Durable` slot is pinned until the sink confirms persistence. While
     /// pinned it cannot be evicted (the no-gap precondition). Non-durable
     /// slots are never pinned.
@@ -50,7 +51,7 @@ impl HotRing {
     /// [`HotRing::mark_persisted`] before it can be evicted). Returns nothing;
     /// the ring never drops a pinned entry, so an un-persisted `Durable` is
     /// always replayable from RAM until it's in the sink.
-    pub fn push(&mut self, env: Envelope) {
+    pub fn push(&mut self, env: Arc<Envelope>) {
         let pinned = env.delivery.is_durable();
         self.slots.push_back(Slot { env, pinned });
         self.evict_to_capacity();
@@ -85,17 +86,19 @@ impl HotRing {
         }
     }
 
-    /// Return clones of every entry strictly *after* `from` (the recent leg of
-    /// the cursor replay), in total order. `from == None` returns the whole
-    /// ring. Used at the replay-then-live seam (§3.5).
-    pub fn replay_after(&self, from: Option<Cursor>) -> Vec<Envelope> {
+    /// Return refcount-bumped handles to every entry strictly *after* `from`
+    /// (the recent leg of the cursor replay), in total order. `from == None`
+    /// returns the whole ring. Each handle is an [`Arc::clone`] — zero deep
+    /// copy of the envelope or its headers. Used at the replay-then-live seam
+    /// (§3.5).
+    pub fn replay_after(&self, from: Option<Cursor>) -> Vec<Arc<Envelope>> {
         self.slots
             .iter()
             .filter(|slot| match &from {
                 None => true,
                 Some(c) => slot.env.cursor().is_after(c),
             })
-            .map(|slot| slot.env.clone())
+            .map(|slot| Arc::clone(&slot.env))
             .collect()
     }
 
@@ -148,7 +151,7 @@ mod tests {
     fn evicts_unpinned_to_capacity() {
         let mut ring = HotRing::new(3);
         for c in 0..5 {
-            ring.push(env_at(c, DeliveryClass::EphemeralWindow));
+            ring.push(Arc::new(env_at(c, DeliveryClass::EphemeralWindow)));
         }
         assert_eq!(ring.len(), 3, "non-durable entries evict to capacity");
         // oldest retained is counter 2 (0,1 evicted)
@@ -159,10 +162,10 @@ mod tests {
     fn pinned_durable_is_not_evicted_until_persisted() {
         let mut ring = HotRing::new(2);
         // Two durable, both unpersisted -> both pinned.
-        ring.push(env_at(0, DeliveryClass::Durable));
-        ring.push(env_at(1, DeliveryClass::Durable));
+        ring.push(Arc::new(env_at(0, DeliveryClass::Durable)));
+        ring.push(Arc::new(env_at(1, DeliveryClass::Durable)));
         // Third push wants to evict counter 0, but it's pinned -> ring grows.
-        ring.push(env_at(2, DeliveryClass::Durable));
+        ring.push(Arc::new(env_at(2, DeliveryClass::Durable)));
         assert_eq!(
             ring.len(),
             3,
@@ -180,7 +183,7 @@ mod tests {
     fn replay_after_returns_strictly_newer_in_order() {
         let mut ring = HotRing::new(10);
         for c in 0..5 {
-            ring.push(env_at(c, DeliveryClass::Durable));
+            ring.push(Arc::new(env_at(c, DeliveryClass::Durable)));
         }
         let from = env_at(1, DeliveryClass::Durable).cursor();
         let got: Vec<u64> = ring

--- a/crates/airc-bus/src/router.rs
+++ b/crates/airc-bus/src/router.rs
@@ -1,0 +1,536 @@
+//! The event router — hot-path, in-memory, sharded (§3.1, §3.2, §3.5, §3.8).
+//!
+//! Owns:
+//! - a **sharded** per-channel subscriber index (mutex-striped: unrelated
+//!   rooms never serialize on one lock, §3.1). DashMap was the spec's
+//!   alternative; striped mutexes are chosen here because they keep the hot
+//!   path deterministic and make "no lock across `.await`" a syntactic
+//!   property (every lock is a sync `MutexGuard` in a non-async block).
+//! - a per-channel **hot ring** (bounded, pinned-until-persisted floor, §3.2).
+//! - a per-channel coalesced **ephemeral cache** (latest-wins + TTL, §3.4).
+//! - a bounded **write-behind** path to the [`DurableSink`] (§3.3, §3.8).
+//!
+//! ## The two load-bearing invariants
+//!
+//! **No-gap cursor (§3.5).** `subscribe` registers the live sender *and*
+//! snapshots the ring under the **same** shard lock, so no event slips between
+//! "what replay saw" and "what live delivers." Replay then covers
+//! `(from_cursor, ring.oldest)` from the sink (deep) + the ring snapshot
+//! (recent); live delivery dedups by a replay high-watermark so the seam admits
+//! no miss and no dup. A `Durable` event evicted-pending from the ring is still
+//! in the ring (pinned, §3.8) *or* already in the sink — never neither — so the
+//! deep leg can always cover it.
+//!
+//! **Slow subscriber (§3.5).** Fan-out is `try_send` into each subscriber's
+//! bounded channel. A full channel marks that subscriber **lagged** and drops
+//! the live push — it NEVER blocks the shard or the other subscribers. A lagged
+//! subscriber resumes from the sink via its cursor. No lock is held across the
+//! fan-out (it's all synchronous `try_send`), and certainly none across an
+//! `.await`.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use futures::stream::Stream;
+use tokio::sync::mpsc;
+
+use airc_core::RoomId;
+
+use crate::clock::Clock;
+use crate::envelope::{Cursor, Envelope};
+use crate::ephemeral::EphemeralCache;
+use crate::filter::Filter;
+use crate::ring::HotRing;
+use crate::seq::SeqSource;
+use crate::sink::DurableSink;
+
+/// Tunables for an [`EventRouter`].
+#[derive(Debug, Clone)]
+pub struct RouterConfig {
+    /// Number of shards (mutex stripes). Rooms hash onto a shard; unrelated
+    /// rooms on different shards never serialize.
+    pub shards: usize,
+    /// Nominal per-channel hot-ring capacity. The §3.8 floor means a ring may
+    /// temporarily exceed this while un-persisted `Durable` entries are pinned.
+    pub ring_capacity: usize,
+    /// Bound on each subscriber's live channel. Full = subscriber is lagged.
+    pub subscriber_buffer: usize,
+    /// Bound on the write-behind queue (§3.8 ≥ ring floor).
+    pub write_behind_buffer: usize,
+    /// Ephemeral coalesced-entry TTL in ms (§3.4).
+    pub ephemeral_ttl_ms: u64,
+}
+
+impl Default for RouterConfig {
+    fn default() -> Self {
+        Self {
+            shards: 16,
+            ring_capacity: 256,
+            subscriber_buffer: 1024,
+            write_behind_buffer: 1024,
+            ephemeral_ttl_ms: 30_000,
+        }
+    }
+}
+
+/// A registered subscriber's live delivery handle, held in the channel's
+/// subscriber list.
+struct SubscriberHandle {
+    tx: mpsc::Sender<Envelope>,
+    filter: Filter,
+    /// Set when a `try_send` failed because the bounded channel was full
+    /// (§3.5). Shared with the subscriber's stream so it can observe "I
+    /// lagged, resume from the sink."
+    lagged: Arc<AtomicBool>,
+}
+
+/// Per-channel state: hot ring + ephemeral cache + subscriber list. Lives
+/// inside a shard, behind that shard's mutex.
+struct ChannelState {
+    ring: HotRing,
+    ephemeral: EphemeralCache,
+    subscribers: Vec<SubscriberHandle>,
+}
+
+impl ChannelState {
+    fn new(ring_capacity: usize, ephemeral_ttl_ms: u64) -> Self {
+        Self {
+            ring: HotRing::new(ring_capacity),
+            ephemeral: EphemeralCache::new(ephemeral_ttl_ms),
+            subscribers: Vec::new(),
+        }
+    }
+}
+
+/// One shard: a map of channel -> state, behind one mutex.
+struct Shard {
+    channels: Mutex<HashMap<u128, ChannelState>>,
+}
+
+/// A durable envelope queued for the write-behind task, paired with the shard
+/// index so the task can re-lock and unpin the ring entry on confirmation.
+struct WriteBehindItem {
+    env: Envelope,
+}
+
+/// The owner-core event router (§3).
+///
+/// Cheap to clone via the `Arc` fields; clones share the same router.
+#[derive(Clone)]
+pub struct EventRouter {
+    inner: Arc<RouterInner>,
+}
+
+struct RouterInner {
+    shards: Vec<Shard>,
+    config: RouterConfig,
+    clock: Arc<dyn Clock>,
+    seq: Arc<SeqSource>,
+    sink: Arc<dyn DurableSink>,
+    write_behind_tx: mpsc::Sender<WriteBehindItem>,
+    /// Count of events shed because the write-behind queue was saturated and
+    /// the publisher was fire-and-forget (§3.8). Surfaced for diagnostics.
+    shed_count: AtomicU64,
+    /// Number of channel-state maps that have ever been created (across all
+    /// shards) — the many-rooms test reads this as the allocation proxy.
+    channels_created: AtomicU64,
+}
+
+impl EventRouter {
+    /// Build a router and spawn its write-behind task.
+    ///
+    /// `seq` is built once per daemon start (it has already bumped the epoch).
+    /// `sink` is the durable tier behind the trait. The write-behind task runs
+    /// until the router (and all clones) drop.
+    pub fn new(
+        config: RouterConfig,
+        clock: Arc<dyn Clock>,
+        seq: Arc<SeqSource>,
+        sink: Arc<dyn DurableSink>,
+    ) -> Self {
+        let shards = (0..config.shards.max(1))
+            .map(|_| Shard {
+                channels: Mutex::new(HashMap::new()),
+            })
+            .collect();
+
+        let (write_behind_tx, write_behind_rx) =
+            mpsc::channel::<WriteBehindItem>(config.write_behind_buffer.max(1));
+
+        let inner = Arc::new(RouterInner {
+            shards,
+            config,
+            clock,
+            seq,
+            sink,
+            write_behind_tx,
+            shed_count: AtomicU64::new(0),
+            channels_created: AtomicU64::new(0),
+        });
+
+        // Write-behind task: drains durable envelopes, persists each, then
+        // re-locks the owning shard and unpins the ring entry (§3.8). This is
+        // the ONLY place that holds an `.await` near the durable tier, and it
+        // never holds a shard lock across it.
+        let task_inner = Arc::clone(&inner);
+        tokio::spawn(async move {
+            Self::run_write_behind(task_inner, write_behind_rx).await;
+        });
+
+        Self { inner }
+    }
+
+    fn shard_for(&self, channel: RoomId) -> &Shard {
+        let n = self.inner.shards.len();
+        let idx = (channel.0.as_u128() % n as u128) as usize;
+        &self.inner.shards[idx]
+    }
+
+    /// Publish an envelope (§4 publish-hot). Returns the assigned [`Seq`].
+    ///
+    /// Steps, all synchronous up to the write-behind enqueue:
+    /// 1. Stamp owner metadata: `seq` (generational) + `occurred_at_ms`.
+    /// 2. Under the shard lock: push to the ring (deliver-first), coalesce if
+    ///    `EphemeralLatest`, fan out to matching subscribers via `try_send`
+    ///    (lagging ones marked, never blocking). Release the lock.
+    /// 3. Off the lock: enqueue `Durable` envelopes to write-behind.
+    ///
+    /// [`Seq`]: crate::Seq
+    pub async fn publish(&self, mut env: Envelope) -> crate::Result<crate::Seq> {
+        let seq = self.inner.seq.next();
+        env.seq = seq;
+        env.occurred_at_ms = self.inner.clock.now_ms();
+
+        // --- synchronous hot path: NO await while the shard lock is held ---
+        {
+            let shard = self.shard_for(env.channel);
+            let mut map = shard.channels.lock().expect("shard mutex poisoned");
+            let key = env.channel.0.as_u128();
+            let is_new = !map.contains_key(&key);
+            let state = map.entry(key).or_insert_with(|| {
+                ChannelState::new(
+                    self.inner.config.ring_capacity,
+                    self.inner.config.ephemeral_ttl_ms,
+                )
+            });
+            if is_new {
+                self.inner.channels_created.fetch_add(1, Ordering::SeqCst);
+            }
+
+            if env.delivery.is_ephemeral_latest() {
+                // §3.4: coalesce latest-wins; do NOT ring it (it's a
+                // projection, not a log) and do NOT persist it.
+                state.ephemeral.coalesce(env.clone(), env.occurred_at_ms);
+            } else {
+                // Recent log: ring it (pins if Durable, §3.8).
+                state.ring.push(env.clone());
+            }
+
+            // Fan out live to matching subscribers. try_send only — a slow
+            // subscriber is marked lagged, never blocks the shard (§3.5).
+            state.subscribers.retain(|sub| {
+                if !sub.filter.matches(&env) {
+                    return true; // not for this subscriber, keep it
+                }
+                match sub.tx.try_send(env.clone()) {
+                    Ok(()) => true,
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        // Lagged: drop the live push, flag it; the subscriber
+                        // resumes from the sink via its cursor.
+                        sub.lagged.store(true, Ordering::SeqCst);
+                        true
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                        // Receiver gone -> drop the handle.
+                        false
+                    }
+                }
+            });
+        } // shard lock released here, before any await
+
+        // --- write-behind (durable only), off the hot lock ---
+        if env.delivery.is_durable() {
+            match self
+                .inner
+                .write_behind_tx
+                .try_send(WriteBehindItem { env: env.clone() })
+            {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    // §3.8: bounded write-behind full. Slice-1 fire-and-forget
+                    // policy: shed + surface, never silently drop, never OOM.
+                    // (The `await_durable`/blocking publisher variant is a
+                    // later refinement; the default path sheds with a surfaced
+                    // error so the contract is explicit.)
+                    self.inner.shed_count.fetch_add(1, Ordering::SeqCst);
+                    return Err(crate::BusError::WriteBehindSaturated);
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    return Err(crate::BusError::Sink("write-behind task gone".into()));
+                }
+            }
+        }
+
+        Ok(seq)
+    }
+
+    /// The write-behind drain loop (§3.3 deliver-first / persist-async, §3.8
+    /// ring-pinned-until-persisted). For each durable item: `sink.append` then
+    /// re-lock the shard and `mark_persisted` so the ring may evict it.
+    async fn run_write_behind(inner: Arc<RouterInner>, mut rx: mpsc::Receiver<WriteBehindItem>) {
+        while let Some(item) = rx.recv().await {
+            // append is the only point we touch the durable tier; no shard
+            // lock is held across it.
+            let appended = inner.sink.append(&item.env).await;
+            if appended.is_err() {
+                // Append failed: leave the ring entry pinned so the no-gap
+                // precondition still holds (the event is still in RAM). A real
+                // sink would retry; the in-memory test sink never fails.
+                continue;
+            }
+            // Confirmed persisted -> unpin in the ring.
+            let n = inner.shards.len();
+            let idx = (item.env.channel.0.as_u128() % n as u128) as usize;
+            let shard = &inner.shards[idx];
+            let mut map = shard.channels.lock().expect("shard mutex poisoned");
+            if let Some(state) = map.get_mut(&item.env.channel.0.as_u128()) {
+                state.ring.mark_persisted(item.env.event_id);
+            }
+        }
+    }
+
+    /// Subscribe (§4 subscribe, §3.5 cursor contract).
+    ///
+    /// Returns a stream that yields **every** envelope on the filter strictly
+    /// after `from_cursor`, exactly once, with no gap at the replay→live seam:
+    ///
+    /// 1. Under the shard lock, register the live sender *and* snapshot the
+    ///    ring's replay + oldest cursor atomically. (Registering first means
+    ///    no live event published after this moment can be missed.)
+    /// 2. Off the lock, page the sink for the deep leg `(from_cursor,
+    ///    ring.oldest)` — covering anything older than the ring still retains,
+    ///    including a `Durable` event that was evicted-pending and is now in
+    ///    the sink (§3.8).
+    /// 3. Yield deep replay, then the ring snapshot (historical), tracking the
+    ///    highest cursor emitted.
+    /// 4. Drain the live channel, skipping anything at-or-before the replay
+    ///    high-watermark (dedup) — the seam admits no dup; step-1 ordering
+    ///    admits no miss.
+    pub fn subscribe(
+        &self,
+        filter: Filter,
+        from_cursor: Option<Cursor>,
+    ) -> impl Stream<Item = Envelope> {
+        self.subscribe_with_lag(filter, from_cursor).0
+    }
+
+    /// Like [`EventRouter::subscribe`] but also returns a [`LagFlag`] the
+    /// caller can poll to learn whether the router dropped a live push to this
+    /// subscriber (§3.5 slow-subscriber). When lagged, the caller resumes via
+    /// [`EventRouter::resume_from_cursor`].
+    pub fn subscribe_with_lag(
+        &self,
+        filter: Filter,
+        from_cursor: Option<Cursor>,
+    ) -> (impl Stream<Item = Envelope>, LagFlag) {
+        let inner = Arc::clone(&self.inner);
+        let channel = filter.channel;
+
+        // --- step 1: register live + snapshot ring under one lock ---
+        let lagged = Arc::new(AtomicBool::new(false));
+        let (tx, mut rx) = mpsc::channel::<Envelope>(inner.config.subscriber_buffer.max(1));
+        let (ring_snapshot, ring_oldest) = {
+            let n = inner.shards.len();
+            let idx = (channel.0.as_u128() % n as u128) as usize;
+            let shard = &inner.shards[idx];
+            let mut map = shard.channels.lock().expect("shard mutex poisoned");
+            let key = channel.0.as_u128();
+            let is_new = !map.contains_key(&key);
+            let state = map.entry(key).or_insert_with(|| {
+                ChannelState::new(inner.config.ring_capacity, inner.config.ephemeral_ttl_ms)
+            });
+            if is_new {
+                inner.channels_created.fetch_add(1, Ordering::SeqCst);
+            }
+            state.subscribers.push(SubscriberHandle {
+                tx,
+                filter: filter.clone(),
+                lagged: Arc::clone(&lagged),
+            });
+            // Snapshot recent replay + the oldest cursor still in RAM, while
+            // holding the same lock that gated live registration.
+            (
+                state.ring.replay_after(from_cursor),
+                state.ring.oldest_cursor(),
+            )
+        }; // lock released; now we may await
+
+        let lag_flag = LagFlag(Arc::clone(&lagged));
+        let stream = async_stream::stream! {
+            // --- step 2: deep replay leg from the sink ---
+            // The sink covers `(from_cursor, ring_oldest)`: events older than
+            // the ring still retains. If the ring is non-empty we page the sink
+            // up to (but not including) the ring's oldest; if the ring is empty
+            // we page the whole tail after the cursor.
+            let mut high: Option<Cursor> = from_cursor;
+            let deep = inner
+                .sink
+                .page(channel, from_cursor, usize::MAX)
+                .await
+                .unwrap_or_default();
+            for env in deep {
+                // Only emit sink events strictly before the ring snapshot's
+                // window — the ring snapshot is authoritative for the recent
+                // tail (it may hold un-persisted Durable the sink lacks).
+                let before_ring = match ring_oldest {
+                    Some(o) => env.cursor().is_before(&o),
+                    None => true,
+                };
+                let after_gate = match high {
+                    Some(h) => env.cursor().is_after(&h),
+                    None => true,
+                };
+                if before_ring && after_gate && filter.matches(&env) {
+                    high = Some(env.cursor());
+                    yield env;
+                }
+            }
+
+            // --- step 3: recent replay leg from the ring snapshot ---
+            for env in ring_snapshot {
+                let after_gate = match high {
+                    Some(h) => env.cursor().is_after(&h),
+                    None => true,
+                };
+                if after_gate && filter.matches(&env) {
+                    high = Some(env.cursor());
+                    yield env;
+                }
+            }
+
+            // --- step 4: live, deduped against the replay high-watermark ---
+            while let Some(env) = rx.recv().await {
+                let after_gate = match high {
+                    Some(h) => env.cursor().is_after(&h),
+                    None => true,
+                };
+                if after_gate {
+                    high = Some(env.cursor());
+                    yield env;
+                }
+                // events at-or-before `high` were already delivered by replay;
+                // dropping them is the no-dup half of the seam.
+            }
+        };
+        (stream, lag_flag)
+    }
+
+    /// Deep + recent catch-up for a **lagged** subscriber (§3.5): everything
+    /// strictly after its last cursor, recent-from-ring + deep-from-sink,
+    /// merged in total order with no dup. A lagging `Durable` subscriber calls
+    /// this to resume; fan-out to others was never blocked.
+    pub async fn resume_from_cursor(
+        &self,
+        channel: RoomId,
+        from_cursor: Option<Cursor>,
+    ) -> crate::Result<Vec<Envelope>> {
+        // Recent from ring (snapshot under lock; no await held).
+        let (ring_events, ring_oldest) = {
+            let shard = self.shard_for(channel);
+            let map = shard.channels.lock().expect("shard mutex poisoned");
+            match map.get(&channel.0.as_u128()) {
+                Some(state) => (
+                    state.ring.replay_after(from_cursor),
+                    state.ring.oldest_cursor(),
+                ),
+                None => (Vec::new(), None),
+            }
+        };
+
+        // Deep from sink for the window older than the ring.
+        let deep = self
+            .inner
+            .sink
+            .page(channel, from_cursor, usize::MAX)
+            .await?;
+
+        let mut out: Vec<Envelope> = Vec::new();
+        for env in deep {
+            let before_ring = match ring_oldest {
+                Some(o) => env.cursor().is_before(&o),
+                None => true,
+            };
+            let after_gate = match &from_cursor {
+                Some(h) => env.cursor().is_after(h),
+                None => true,
+            };
+            if before_ring && after_gate {
+                out.push(env);
+            }
+        }
+        out.extend(ring_events);
+        // Total order, dedup by event_id (a Durable may appear in both legs if
+        // it was persisted between the two snapshots).
+        out.sort_by(|a, b| {
+            a.seq
+                .cmp(&b.seq)
+                .then_with(|| a.event_id.0.cmp(&b.event_id.0))
+        });
+        out.dedup_by(|a, b| a.event_id == b.event_id);
+        Ok(out)
+    }
+
+    /// The latest coalesced ephemeral value for `(channel, coalesce_key)`, if
+    /// live (§3.4). Used to seed a freshly-attached subscriber with current
+    /// presence/pose.
+    pub fn ephemeral_latest(&self, channel: RoomId, key: &str) -> Option<Envelope> {
+        let now = self.inner.clock.now_ms();
+        let shard = self.shard_for(channel);
+        let map = shard.channels.lock().expect("shard mutex poisoned");
+        map.get(&channel.0.as_u128())
+            .and_then(|s| s.ephemeral.get(key, now).cloned())
+    }
+
+    /// Number of distinct channels that have ever had state allocated. The
+    /// many-rooms test uses this as the allocation/wakeup proxy: idle channels
+    /// that were merely *named* (never published/subscribed) cost nothing.
+    pub fn channels_created(&self) -> u64 {
+        self.inner.channels_created.load(Ordering::SeqCst)
+    }
+
+    /// Count of fire-and-forget durable events shed under write-behind
+    /// saturation (§3.8). Always counted, never silent.
+    pub fn shed_count(&self) -> u64 {
+        self.inner.shed_count.load(Ordering::SeqCst)
+    }
+
+    /// Test/diagnostic: pinned (un-persisted `Durable`) entries in a channel's
+    /// ring — the live un-persisted backlog (§3.8 floor).
+    pub fn pinned_in_ring(&self, channel: RoomId) -> usize {
+        let shard = self.shard_for(channel);
+        let map = shard.channels.lock().expect("shard mutex poisoned");
+        map.get(&channel.0.as_u128())
+            .map_or(0, |s| s.ring.pinned_count())
+    }
+
+    /// Test/diagnostic: snapshot the count of retained ring entries.
+    pub fn ring_len(&self, channel: RoomId) -> usize {
+        let shard = self.shard_for(channel);
+        let map = shard.channels.lock().expect("shard mutex poisoned");
+        map.get(&channel.0.as_u128()).map_or(0, |s| s.ring.len())
+    }
+}
+
+/// A handle a subscriber polls to learn it has lagged (§3.5). Returned by
+/// [`EventRouter::subscribe_with_lag`] alongside the stream.
+#[derive(Clone)]
+pub struct LagFlag(Arc<AtomicBool>);
+
+impl LagFlag {
+    /// True once the router dropped a live push to this subscriber. The
+    /// subscriber then resumes via [`EventRouter::resume_from_cursor`].
+    pub fn is_lagged(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}

--- a/crates/airc-bus/src/router.rs
+++ b/crates/airc-bus/src/router.rs
@@ -205,7 +205,7 @@ impl EventRouter {
         // --- synchronous hot path: NO await while the shard lock is held ---
         {
             let shard = self.shard_for(env.channel);
-            let mut map = shard.channels.lock().expect("shard mutex poisoned");
+            let mut map = shard.channels.lock().unwrap_or_else(|p| p.into_inner());
             let key = env.channel.0.as_u128();
             let is_new = !map.contains_key(&key);
             let state = map.entry(key).or_insert_with(|| {
@@ -293,7 +293,7 @@ impl EventRouter {
             let n = inner.shards.len();
             let idx = (item.env.channel.0.as_u128() % n as u128) as usize;
             let shard = &inner.shards[idx];
-            let mut map = shard.channels.lock().expect("shard mutex poisoned");
+            let mut map = shard.channels.lock().unwrap_or_else(|p| p.into_inner());
             if let Some(state) = map.get_mut(&item.env.channel.0.as_u128()) {
                 state.ring.mark_persisted(item.env.event_id);
             }
@@ -344,7 +344,7 @@ impl EventRouter {
             let n = inner.shards.len();
             let idx = (channel.0.as_u128() % n as u128) as usize;
             let shard = &inner.shards[idx];
-            let mut map = shard.channels.lock().expect("shard mutex poisoned");
+            let mut map = shard.channels.lock().unwrap_or_else(|p| p.into_inner());
             let key = channel.0.as_u128();
             let is_new = !map.contains_key(&key);
             let state = map.entry(key).or_insert_with(|| {
@@ -438,7 +438,7 @@ impl EventRouter {
         // Recent from ring (snapshot under lock; no await held).
         let (ring_events, ring_oldest) = {
             let shard = self.shard_for(channel);
-            let map = shard.channels.lock().expect("shard mutex poisoned");
+            let map = shard.channels.lock().unwrap_or_else(|p| p.into_inner());
             match map.get(&channel.0.as_u128()) {
                 Some(state) => (
                     state.ring.replay_after(from_cursor),
@@ -487,7 +487,7 @@ impl EventRouter {
     pub fn ephemeral_latest(&self, channel: RoomId, key: &str) -> Option<Envelope> {
         let now = self.inner.clock.now_ms();
         let shard = self.shard_for(channel);
-        let map = shard.channels.lock().expect("shard mutex poisoned");
+        let map = shard.channels.lock().unwrap_or_else(|p| p.into_inner());
         map.get(&channel.0.as_u128())
             .and_then(|s| s.ephemeral.get(key, now).cloned())
     }
@@ -509,7 +509,7 @@ impl EventRouter {
     /// ring — the live un-persisted backlog (§3.8 floor).
     pub fn pinned_in_ring(&self, channel: RoomId) -> usize {
         let shard = self.shard_for(channel);
-        let map = shard.channels.lock().expect("shard mutex poisoned");
+        let map = shard.channels.lock().unwrap_or_else(|p| p.into_inner());
         map.get(&channel.0.as_u128())
             .map_or(0, |s| s.ring.pinned_count())
     }
@@ -517,7 +517,7 @@ impl EventRouter {
     /// Test/diagnostic: snapshot the count of retained ring entries.
     pub fn ring_len(&self, channel: RoomId) -> usize {
         let shard = self.shard_for(channel);
-        let map = shard.channels.lock().expect("shard mutex poisoned");
+        let map = shard.channels.lock().unwrap_or_else(|p| p.into_inner());
         map.get(&channel.0.as_u128()).map_or(0, |s| s.ring.len())
     }
 }

--- a/crates/airc-bus/src/router.rs
+++ b/crates/airc-bus/src/router.rs
@@ -77,7 +77,7 @@ impl Default for RouterConfig {
 /// A registered subscriber's live delivery handle, held in the channel's
 /// subscriber list.
 struct SubscriberHandle {
-    tx: mpsc::Sender<Envelope>,
+    tx: mpsc::Sender<Arc<Envelope>>,
     filter: Filter,
     /// Set when a `try_send` failed because the bounded channel was full
     /// (§3.5). Shared with the subscriber's stream so it can observe "I
@@ -111,7 +111,7 @@ struct Shard {
 /// A durable envelope queued for the write-behind task, paired with the shard
 /// index so the task can re-lock and unpin the ring entry on confirmation.
 struct WriteBehindItem {
-    env: Envelope,
+    env: Arc<Envelope>,
 }
 
 /// The owner-core event router (§3).
@@ -202,6 +202,12 @@ impl EventRouter {
         env.seq = seq;
         env.occurred_at_ms = self.inner.clock.now_ms();
 
+        // Wrap ONCE: from here on every delivery (ring, ephemeral, fan-out,
+        // write-behind) is an `Arc::clone` — a refcount bump, never a deep copy
+        // of the envelope or its `headers` BTreeMap. This is the hot-path
+        // zero-copy keystone: per-subscriber CPU is one atomic increment.
+        let env = Arc::new(env);
+
         // --- synchronous hot path: NO await while the shard lock is held ---
         {
             let shard = self.shard_for(env.channel);
@@ -221,19 +227,22 @@ impl EventRouter {
             if env.delivery.is_ephemeral_latest() {
                 // §3.4: coalesce latest-wins; do NOT ring it (it's a
                 // projection, not a log) and do NOT persist it.
-                state.ephemeral.coalesce(env.clone(), env.occurred_at_ms);
+                state
+                    .ephemeral
+                    .coalesce(Arc::clone(&env), env.occurred_at_ms);
             } else {
                 // Recent log: ring it (pins if Durable, §3.8).
-                state.ring.push(env.clone());
+                state.ring.push(Arc::clone(&env));
             }
 
             // Fan out live to matching subscribers. try_send only — a slow
-            // subscriber is marked lagged, never blocks the shard (§3.5).
+            // subscriber is marked lagged, never blocks the shard (§3.5). Each
+            // send is an `Arc::clone` (refcount bump), NOT a deep copy.
             state.subscribers.retain(|sub| {
                 if !sub.filter.matches(&env) {
                     return true; // not for this subscriber, keep it
                 }
-                match sub.tx.try_send(env.clone()) {
+                match sub.tx.try_send(Arc::clone(&env)) {
                     Ok(()) => true,
                     Err(mpsc::error::TrySendError::Full(_)) => {
                         // Lagged: drop the live push, flag it; the subscriber
@@ -251,11 +260,9 @@ impl EventRouter {
 
         // --- write-behind (durable only), off the hot lock ---
         if env.delivery.is_durable() {
-            match self
-                .inner
-                .write_behind_tx
-                .try_send(WriteBehindItem { env: env.clone() })
-            {
+            match self.inner.write_behind_tx.try_send(WriteBehindItem {
+                env: Arc::clone(&env),
+            }) {
                 Ok(()) => {}
                 Err(mpsc::error::TrySendError::Full(_)) => {
                     // §3.8: bounded write-behind full. Slice-1 fire-and-forget
@@ -321,7 +328,7 @@ impl EventRouter {
         &self,
         filter: Filter,
         from_cursor: Option<Cursor>,
-    ) -> impl Stream<Item = Envelope> {
+    ) -> impl Stream<Item = Arc<Envelope>> {
         self.subscribe_with_lag(filter, from_cursor).0
     }
 
@@ -333,13 +340,13 @@ impl EventRouter {
         &self,
         filter: Filter,
         from_cursor: Option<Cursor>,
-    ) -> (impl Stream<Item = Envelope>, LagFlag) {
+    ) -> (impl Stream<Item = Arc<Envelope>>, LagFlag) {
         let inner = Arc::clone(&self.inner);
         let channel = filter.channel;
 
         // --- step 1: register live + snapshot ring under one lock ---
         let lagged = Arc::new(AtomicBool::new(false));
-        let (tx, mut rx) = mpsc::channel::<Envelope>(inner.config.subscriber_buffer.max(1));
+        let (tx, mut rx) = mpsc::channel::<Arc<Envelope>>(inner.config.subscriber_buffer.max(1));
         let (ring_snapshot, ring_oldest) = {
             let n = inner.shards.len();
             let idx = (channel.0.as_u128() % n as u128) as usize;
@@ -380,6 +387,11 @@ impl EventRouter {
                 .await
                 .unwrap_or_default();
             for env in deep {
+                // The sink (persistence) is a real copy boundary, so the deep
+                // leg arrives as owned `Envelope`s; wrap each once in `Arc` so
+                // the stream item type is uniform with the (already-`Arc`) ring
+                // and live legs and downstream stays zero-copy.
+                let env = Arc::new(env);
                 // Only emit sink events strictly before the ring snapshot's
                 // window — the ring snapshot is authoritative for the recent
                 // tail (it may hold un-persisted Durable the sink lacks).
@@ -434,7 +446,7 @@ impl EventRouter {
         &self,
         channel: RoomId,
         from_cursor: Option<Cursor>,
-    ) -> crate::Result<Vec<Envelope>> {
+    ) -> crate::Result<Vec<Arc<Envelope>>> {
         // Recent from ring (snapshot under lock; no await held).
         let (ring_events, ring_oldest) = {
             let shard = self.shard_for(channel);
@@ -455,8 +467,11 @@ impl EventRouter {
             .page(channel, from_cursor, usize::MAX)
             .await?;
 
-        let mut out: Vec<Envelope> = Vec::new();
+        let mut out: Vec<Arc<Envelope>> = Vec::new();
         for env in deep {
+            // Deep leg is owned `Envelope` from the sink copy boundary; wrap
+            // once so the merged output is uniformly `Arc<Envelope>`.
+            let env = Arc::new(env);
             let before_ring = match ring_oldest {
                 Some(o) => env.cursor().is_before(&o),
                 None => true,
@@ -484,12 +499,12 @@ impl EventRouter {
     /// The latest coalesced ephemeral value for `(channel, coalesce_key)`, if
     /// live (§3.4). Used to seed a freshly-attached subscriber with current
     /// presence/pose.
-    pub fn ephemeral_latest(&self, channel: RoomId, key: &str) -> Option<Envelope> {
+    pub fn ephemeral_latest(&self, channel: RoomId, key: &str) -> Option<Arc<Envelope>> {
         let now = self.inner.clock.now_ms();
         let shard = self.shard_for(channel);
         let map = shard.channels.lock().unwrap_or_else(|p| p.into_inner());
         map.get(&channel.0.as_u128())
-            .and_then(|s| s.ephemeral.get(key, now).cloned())
+            .and_then(|s| s.ephemeral.get(key, now).map(Arc::clone))
     }
 
     /// Number of distinct channels that have ever had state allocated. The

--- a/crates/airc-bus/src/seq.rs
+++ b/crates/airc-bus/src/seq.rs
@@ -1,0 +1,170 @@
+//! Generational sequence assignment (§3.8 generational order).
+//!
+//! `seq = (epoch, counter)`:
+//!
+//! - **`epoch`** is read from a persisted [`EpochStore`] on construction and
+//!   **bumped once per daemon start**. Deliver-first (§3.3) can ack a
+//!   `counter` the ORM hasn't flushed; a crash loses that tail, and a counter
+//!   rebuilt from ORM-max would *reissue* numbers live subscribers already
+//!   saw. Bumping `epoch` makes every post-restart event sort strictly after
+//!   anything pre-restart — even if the counter rewinds.
+//! - **`counter`** is the in-memory monotonic, assigned atomically per
+//!   publish.
+//!
+//! Both are injectable so tests are deterministic (§9). The
+//! [`InMemoryEpochStore`] models the persisted epoch cell; a restart is
+//! modeled by constructing a fresh [`SeqSource`] against the *same*
+//! `InMemoryEpochStore`, which bumps the epoch exactly as a real daemon start
+//! would.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// Persisted home of the `epoch` value. The only piece of [`SeqSource`] that
+/// survives a restart. The ORM-backed impl lands in a later slice; tests use
+/// [`InMemoryEpochStore`].
+///
+/// Contract: [`EpochStore::bump_and_load`] atomically increments the stored
+/// epoch and returns the *new* value. Called exactly once per daemon start.
+pub trait EpochStore: Send + Sync {
+    /// Atomically bump the persisted epoch and return the new value. The first
+    /// ever call on a fresh store returns `1` (epoch `0` is reserved for the
+    /// "never started" sentinel / unstamped envelopes).
+    fn bump_and_load(&self) -> u64;
+}
+
+/// In-memory persisted-epoch model. A clone shares the same underlying cell,
+/// so a "restart" = constructing a new [`SeqSource`] from a clone of this
+/// store. That clone keeps the bumped epoch, exactly like a row that survives
+/// the process.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryEpochStore {
+    epoch: Arc<AtomicU64>,
+}
+
+impl InMemoryEpochStore {
+    /// A store that has never been started (epoch sentinel `0`). The first
+    /// [`SeqSource`] built against it gets epoch `1`.
+    pub fn new() -> Self {
+        Self {
+            epoch: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// The currently-persisted epoch (for test assertions). Not part of the
+    /// hot path.
+    pub fn current(&self) -> u64 {
+        self.epoch.load(Ordering::SeqCst)
+    }
+}
+
+impl EpochStore for InMemoryEpochStore {
+    fn bump_and_load(&self) -> u64 {
+        // fetch_add returns the previous value; the new epoch is +1.
+        self.epoch.fetch_add(1, Ordering::SeqCst) + 1
+    }
+}
+
+/// Assigns `(epoch, counter)` for one daemon lifetime (§3.8).
+///
+/// Built once per daemon start: it bumps the persisted epoch and starts the
+/// in-memory counter from `start_counter` (normally `0`; a restart may seed it
+/// from the durable max, but the bumped epoch dominates regardless so the seed
+/// is an optimization, never a correctness lever — see crash-safe-seq test).
+pub struct SeqSource {
+    epoch: u64,
+    counter: AtomicU64,
+}
+
+impl SeqSource {
+    /// Construct for a new daemon start: bump the persisted epoch, begin the
+    /// counter at `0`.
+    pub fn start(epoch_store: &dyn EpochStore) -> Self {
+        Self::start_at_counter(epoch_store, 0)
+    }
+
+    /// Construct for a new daemon start, seeding the in-memory counter at
+    /// `start_counter`. The bumped epoch still dominates the total order, so
+    /// even a *wrong* seed can never reissue a `(epoch, counter)` pair an
+    /// earlier epoch used — the crash-safety guarantee does not rest on the
+    /// seed (§3.8).
+    pub fn start_at_counter(epoch_store: &dyn EpochStore, start_counter: u64) -> Self {
+        Self {
+            epoch: epoch_store.bump_and_load(),
+            counter: AtomicU64::new(start_counter),
+        }
+    }
+
+    /// The epoch this source stamps. Stable for the source's lifetime.
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    /// Assign the next `(epoch, counter)`. Counter is strictly monotonic
+    /// within the epoch.
+    pub fn next(&self) -> crate::Seq {
+        let counter = self.counter.fetch_add(1, Ordering::SeqCst);
+        crate::Seq::new(self.epoch, counter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_start_gets_epoch_one() {
+        let store = InMemoryEpochStore::new();
+        let src = SeqSource::start(&store);
+        assert_eq!(src.epoch(), 1);
+        assert_eq!(store.current(), 1);
+    }
+
+    #[test]
+    fn restart_bumps_epoch_against_same_store() {
+        let store = InMemoryEpochStore::new();
+        let s1 = SeqSource::start(&store);
+        assert_eq!(s1.epoch(), 1);
+        // "restart": new source, same persisted store.
+        let s2 = SeqSource::start(&store.clone());
+        assert_eq!(s2.epoch(), 2, "every daemon start bumps the epoch");
+    }
+
+    #[test]
+    fn counter_is_monotonic_within_epoch() {
+        let store = InMemoryEpochStore::new();
+        let src = SeqSource::start(&store);
+        let a = src.next();
+        let b = src.next();
+        let c = src.next();
+        assert_eq!(a, crate::Seq::new(1, 0));
+        assert_eq!(b, crate::Seq::new(1, 1));
+        assert_eq!(c, crate::Seq::new(1, 2));
+    }
+
+    #[test]
+    fn post_restart_seq_sorts_after_pre_restart_even_with_rewound_counter() {
+        // The crux of §3.8: pre-crash counter ran high; post-crash counter
+        // (rebuilt from durable max which is lower) rewinds — but epoch+1
+        // makes the post-crash event sort strictly after.
+        let store = InMemoryEpochStore::new();
+        let pre = SeqSource::start(&store);
+        let last_pre = {
+            let mut s = pre.next();
+            for _ in 0..999 {
+                s = pre.next();
+            }
+            s
+        };
+        assert_eq!(last_pre, crate::Seq::new(1, 999));
+
+        // Restart, seed counter low (durable only had a handful flushed).
+        let post = SeqSource::start_at_counter(&store, 10);
+        let first_post = post.next();
+        assert_eq!(first_post, crate::Seq::new(2, 10));
+        assert!(
+            first_post > last_pre,
+            "post-restart seq must sort strictly after pre-restart even though counter rewound"
+        );
+    }
+}

--- a/crates/airc-bus/src/sink.rs
+++ b/crates/airc-bus/src/sink.rs
@@ -70,7 +70,10 @@ impl InMemoryDurableSink {
     /// `ephemeral-off-sink` test asserts this stays `0` for an
     /// `EphemeralLatest` firehose.
     pub fn append_count(&self) -> u64 {
-        self.inner.lock().unwrap_or_else(|p| p.into_inner()).append_count
+        self.inner
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .append_count
     }
 
     /// The total max cursor across all channels, for restart-counter seeding

--- a/crates/airc-bus/src/sink.rs
+++ b/crates/airc-bus/src/sink.rs
@@ -1,0 +1,193 @@
+//! The durable tier seam (§3.3 ORM durable tier, behind a trait).
+//!
+//! This crate is the in-memory hot path; the durable tier (the ORM, §3.3) is
+//! **behind this trait** so `airc-bus` never depends on `airc-store`. The
+//! ORM-backed impl (batched, single-writer, prepared-statement cache) lands in
+//! a later slice and adapts `Envelope` ↔ `TranscriptEvent` there. Tests here
+//! use [`InMemoryDurableSink`].
+//!
+//! Only [`crate::DeliveryClass::Durable`] envelopes ever reach a sink — the
+//! efficiency keystone (§3.3 / §3.4): high-frequency ephemerals never touch
+//! the DB.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use airc_core::RoomId;
+
+use crate::envelope::{Cursor, Envelope};
+use crate::error::Result;
+
+/// The durable event tier. `append` persists one `Durable` envelope; `page`
+/// returns events strictly *after* a cursor for cold/deep replay past the ring
+/// (§3.5). Events come back in total order `(seq, event_id)`.
+#[async_trait]
+pub trait DurableSink: Send + Sync {
+    /// Persist one `Durable` envelope. On success the event is visible to
+    /// every subsequent [`DurableSink::page`] call. The router's write-behind
+    /// task pins the matching ring entry until this resolves (§3.8 ring
+    /// entries pinned until persisted).
+    async fn append(&self, e: &Envelope) -> Result<()>;
+
+    /// Return up to `limit` events on `channel` strictly *after*
+    /// `from_cursor`, in total order. `from_cursor == None` means "from the
+    /// beginning of the channel." This is the deep-replay leg of the cursor
+    /// contract (§3.5).
+    async fn page(
+        &self,
+        channel: RoomId,
+        from_cursor: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>>;
+}
+
+/// In-memory durable tier for tests. Records append count so the
+/// `ephemeral-off-sink` test can assert it was called **zero** times.
+/// Optionally gates appends behind a [`tokio::sync::Notify`]-style barrier so
+/// the `no-gap` test can hold a `Durable` event "evicted-pending" out of the
+/// store while it forces ring eviction.
+#[derive(Default)]
+pub struct InMemoryDurableSink {
+    inner: Mutex<SinkInner>,
+}
+
+#[derive(Default)]
+struct SinkInner {
+    /// channel -> ordered events (kept sorted by cursor on insert).
+    events: BTreeMap<u128, Vec<Envelope>>,
+    /// Total successful appends — the assertion lever for ephemeral-off-sink.
+    append_count: u64,
+}
+
+impl InMemoryDurableSink {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// How many times [`DurableSink::append`] has successfully run. The
+    /// `ephemeral-off-sink` test asserts this stays `0` for an
+    /// `EphemeralLatest` firehose.
+    pub fn append_count(&self) -> u64 {
+        self.inner.lock().expect("sink mutex poisoned").append_count
+    }
+
+    /// The total max cursor across all channels, for restart-counter seeding
+    /// in the crash-safe-seq test (models "rebuild counter from ORM max").
+    pub fn max_counter(&self) -> u64 {
+        let guard = self.inner.lock().expect("sink mutex poisoned");
+        guard
+            .events
+            .values()
+            .flat_map(|v| v.iter())
+            .map(|e| e.seq.counter)
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Snapshot count of persisted events on a channel (test helper).
+    pub fn len(&self, channel: RoomId) -> usize {
+        let guard = self.inner.lock().expect("sink mutex poisoned");
+        guard
+            .events
+            .get(&channel.0.as_u128())
+            .map_or(0, |v| v.len())
+    }
+}
+
+#[async_trait]
+impl DurableSink for InMemoryDurableSink {
+    async fn append(&self, e: &Envelope) -> Result<()> {
+        let mut guard = self.inner.lock().expect("sink mutex poisoned");
+        let bucket = guard.events.entry(e.channel.0.as_u128()).or_default();
+        // Idempotent on event_id — a replay/re-inject must not double-store.
+        if bucket.iter().any(|x| x.event_id == e.event_id) {
+            return Ok(());
+        }
+        bucket.push(e.clone());
+        // Keep the bucket in total order so `page` is a simple scan.
+        bucket.sort_by(|a, b| {
+            a.seq
+                .cmp(&b.seq)
+                .then_with(|| a.event_id.0.cmp(&b.event_id.0))
+        });
+        guard.append_count += 1;
+        Ok(())
+    }
+
+    async fn page(
+        &self,
+        channel: RoomId,
+        from_cursor: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>> {
+        let guard = self.inner.lock().expect("sink mutex poisoned");
+        let Some(bucket) = guard.events.get(&channel.0.as_u128()) else {
+            return Ok(Vec::new());
+        };
+        let out: Vec<Envelope> = bucket
+            .iter()
+            .filter(|e| match &from_cursor {
+                None => true,
+                Some(c) => e.cursor().is_after(c),
+            })
+            .take(limit)
+            .cloned()
+            .collect();
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{DeliveryClass, Kind};
+    use crate::Seq;
+    use airc_core::{ClientId, EventId, PeerId};
+    use bytes::Bytes;
+
+    fn durable_at(channel: RoomId, counter: u64) -> Envelope {
+        let mut e = Envelope::new(
+            channel,
+            (PeerId::from_u128(1), ClientId::from_u128(1)),
+            Kind::Message,
+            DeliveryClass::Durable,
+            Bytes::from_static(b"x"),
+        )
+        .with_event_id(EventId::from_u128(counter as u128 + 1));
+        e.seq = Seq::new(1, counter);
+        e
+    }
+
+    #[tokio::test]
+    async fn append_counts_and_pages_after_cursor() {
+        let sink = InMemoryDurableSink::new();
+        let ch = RoomId::from_u128(7);
+        for c in 0..5 {
+            sink.append(&durable_at(ch, c)).await.unwrap();
+        }
+        assert_eq!(sink.append_count(), 5);
+
+        // strictly after counter 1 -> counters 2,3,4
+        let from = durable_at(ch, 1).cursor();
+        let page = sink.page(ch, Some(from), 100).await.unwrap();
+        let counters: Vec<u64> = page.iter().map(|e| e.seq.counter).collect();
+        assert_eq!(counters, vec![2, 3, 4]);
+    }
+
+    #[tokio::test]
+    async fn append_is_idempotent_on_event_id() {
+        let sink = InMemoryDurableSink::new();
+        let ch = RoomId::from_u128(1);
+        let e = durable_at(ch, 0);
+        sink.append(&e).await.unwrap();
+        sink.append(&e).await.unwrap();
+        assert_eq!(
+            sink.append_count(),
+            1,
+            "re-append of same event_id is a no-op"
+        );
+        assert_eq!(sink.len(ch), 1);
+    }
+}

--- a/crates/airc-bus/src/sink.rs
+++ b/crates/airc-bus/src/sink.rs
@@ -70,13 +70,13 @@ impl InMemoryDurableSink {
     /// `ephemeral-off-sink` test asserts this stays `0` for an
     /// `EphemeralLatest` firehose.
     pub fn append_count(&self) -> u64 {
-        self.inner.lock().expect("sink mutex poisoned").append_count
+        self.inner.lock().unwrap_or_else(|p| p.into_inner()).append_count
     }
 
     /// The total max cursor across all channels, for restart-counter seeding
     /// in the crash-safe-seq test (models "rebuild counter from ORM max").
     pub fn max_counter(&self) -> u64 {
-        let guard = self.inner.lock().expect("sink mutex poisoned");
+        let guard = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         guard
             .events
             .values()
@@ -88,7 +88,7 @@ impl InMemoryDurableSink {
 
     /// Snapshot count of persisted events on a channel (test helper).
     pub fn len(&self, channel: RoomId) -> usize {
-        let guard = self.inner.lock().expect("sink mutex poisoned");
+        let guard = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         guard
             .events
             .get(&channel.0.as_u128())
@@ -99,7 +99,7 @@ impl InMemoryDurableSink {
 #[async_trait]
 impl DurableSink for InMemoryDurableSink {
     async fn append(&self, e: &Envelope) -> Result<()> {
-        let mut guard = self.inner.lock().expect("sink mutex poisoned");
+        let mut guard = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         let bucket = guard.events.entry(e.channel.0.as_u128()).or_default();
         // Idempotent on event_id — a replay/re-inject must not double-store.
         if bucket.iter().any(|x| x.event_id == e.event_id) {
@@ -122,7 +122,7 @@ impl DurableSink for InMemoryDurableSink {
         from_cursor: Option<Cursor>,
         limit: usize,
     ) -> Result<Vec<Envelope>> {
-        let guard = self.inner.lock().expect("sink mutex poisoned");
+        let guard = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         let Some(bucket) = guard.events.get(&channel.0.as_u128()) else {
             return Ok(Vec::new());
         };

--- a/crates/airc-bus/tests/common/mod.rs
+++ b/crates/airc-bus/tests/common/mod.rs
@@ -1,0 +1,139 @@
+//! Shared acceptance-test harness (§11): isolated owner instance, injectable
+//! clock + seq, in-memory durable sink. The test model IS the production model
+//! (§9): no global state, deterministic, explicit lifecycle.
+//!
+//! Each integration-test file is its own crate and pulls this module in, so a
+//! given helper is "unused" from the perspective of any single binary. The
+//! crate-level allow keeps the shared harness warning-free under `-D warnings`.
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+use airc_bus::{
+    Clock, DeliveryClass, Envelope, EventRouter, InMemoryDurableSink, InMemoryEpochStore, Kind,
+    ManualClock, RouterConfig, SeqSource,
+};
+use airc_core::{ClientId, EventId, PeerId, RoomId};
+
+/// A single isolated owner-core instance plus the knobs a test drives.
+pub struct Owner {
+    pub router: EventRouter,
+    pub clock: ManualClock,
+    pub sink: Arc<InMemoryDurableSink>,
+    pub epoch_store: InMemoryEpochStore,
+}
+
+impl Owner {
+    /// Build an owner with the given config and a fresh epoch store / sink.
+    pub fn new(config: RouterConfig) -> Self {
+        let epoch_store = InMemoryEpochStore::new();
+        let sink = Arc::new(InMemoryDurableSink::new());
+        Self::with_parts(config, epoch_store, sink, 0)
+    }
+
+    /// Build an owner reusing a persisted epoch store + sink — models a
+    /// **restart** (the new `SeqSource` bumps the epoch). `start_counter`
+    /// seeds the in-memory counter (e.g. from the sink's durable max).
+    pub fn with_parts(
+        config: RouterConfig,
+        epoch_store: InMemoryEpochStore,
+        sink: Arc<InMemoryDurableSink>,
+        start_counter: u64,
+    ) -> Self {
+        let clock = ManualClock::new(1_700_000_000_000);
+        let seq = Arc::new(SeqSource::start_at_counter(&epoch_store, start_counter));
+        let router = EventRouter::new(
+            config,
+            Arc::new(clock.clone()) as Arc<dyn Clock>,
+            seq,
+            sink.clone(),
+        );
+        Self {
+            router,
+            clock,
+            sink,
+            epoch_store,
+        }
+    }
+}
+
+/// Deterministic durable message envelope with a stable event_id derived from
+/// `marker` so replayed copies compare equal.
+pub fn durable(channel: RoomId, marker: u128, text: &str) -> Envelope {
+    Envelope::new(
+        channel,
+        (PeerId::from_u128(1), ClientId::from_u128(1)),
+        Kind::Message,
+        DeliveryClass::Durable,
+        Bytes::copy_from_slice(text.as_bytes()),
+    )
+    .with_event_id(EventId::from_u128(marker))
+}
+
+/// Deterministic ephemeral-latest envelope coalescing on `key`.
+pub fn ephemeral(channel: RoomId, marker: u128, key: &str, payload: &[u8]) -> Envelope {
+    Envelope::new(
+        channel,
+        (PeerId::from_u128(1), ClientId::from_u128(1)),
+        Kind::Signal,
+        DeliveryClass::EphemeralLatest,
+        Bytes::copy_from_slice(payload),
+    )
+    .with_event_id(EventId::from_u128(marker))
+    .with_coalesce_key(key)
+}
+
+// --- gated durable sink, for the no-gap eviction test ----------------------
+
+use airc_bus::{BusError, Cursor, DurableSink};
+use async_trait::async_trait;
+use tokio::sync::Notify;
+
+/// A [`DurableSink`] decorator that delays `append` until a gate is opened.
+/// Lets a test hold `Durable` events "evicted-pending" (pinned in the ring,
+/// not yet in the store) and then release them so the write-behind path
+/// persists + unpins, after which capacity pressure evicts them — forcing a
+/// later subscriber's deep-replay to fetch them from the sink (§3.8 no-gap).
+pub struct GatedSink {
+    inner: Arc<InMemoryDurableSink>,
+    open: Arc<Notify>,
+    is_open: std::sync::atomic::AtomicBool,
+}
+
+impl GatedSink {
+    pub fn new(inner: Arc<InMemoryDurableSink>) -> Self {
+        Self {
+            inner,
+            open: Arc::new(Notify::new()),
+            is_open: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    /// Open the gate — all pending and future appends proceed.
+    pub fn open(&self) {
+        self.is_open
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.open.notify_waiters();
+    }
+}
+
+#[async_trait]
+impl DurableSink for GatedSink {
+    async fn append(&self, e: &Envelope) -> Result<(), BusError> {
+        while !self.is_open.load(std::sync::atomic::Ordering::SeqCst) {
+            self.open.notified().await;
+        }
+        self.inner.append(e).await
+    }
+
+    async fn page(
+        &self,
+        channel: RoomId,
+        from_cursor: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.inner.page(channel, from_cursor, limit).await
+    }
+}

--- a/crates/airc-bus/tests/crash_safe_seq.rs
+++ b/crates/airc-bus/tests/crash_safe_seq.rs
@@ -1,0 +1,110 @@
+//! Acceptance test 2 — crash-safe seq (§3.8 generational order, §11.1).
+//!
+//! Publish N; simulate a restart (rebuild `SeqSource` with epoch+1, counter
+//! seeded from the sink's durable max — which is < N because some weren't
+//! flushed); publish more. Assert no `seq` is ever reissued and the total
+//! order is monotonic: every post-restart event sorts strictly AFTER every
+//! pre-restart event.
+
+mod common;
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use airc_bus::{RouterConfig, Seq};
+use airc_core::RoomId;
+
+use common::{durable, Owner};
+
+#[tokio::test]
+async fn restart_never_reissues_a_seq_and_order_is_monotonic() {
+    let ch = RoomId::from_u128(0x5e9);
+
+    // --- pre-crash daemon ---
+    let epoch_store = airc_bus::InMemoryEpochStore::new();
+    let sink = Arc::new(airc_bus::InMemoryDurableSink::new());
+
+    let owner1 = Owner::with_parts(
+        RouterConfig::default(),
+        epoch_store.clone(),
+        sink.clone(),
+        0,
+    );
+
+    // Publish N=50; capture the seqs the live subscribers "observed."
+    let mut pre_seqs = Vec::new();
+    for i in 1..=50u128 {
+        let seq = owner1
+            .router
+            .publish(durable(ch, i, &format!("pre{i}")))
+            .await
+            .unwrap();
+        pre_seqs.push(seq);
+    }
+    assert_eq!(owner1.epoch_store.current(), 1, "pre-crash epoch is 1");
+
+    // Only SOME are flushed before the crash — drain only briefly, then drop
+    // the router (== crash). The sink's durable max is < 50.
+    tokio::time::sleep(Duration::from_millis(15)).await;
+    let durable_max = sink.max_counter();
+    // (We don't strictly require it to be < 50, but the test is meaningful
+    // when the counter seed is below the live high-water; assert the seeding
+    // models "rebuild from ORM max" regardless.)
+
+    // "Crash": drop owner1 entirely. Its in-memory counter is gone.
+    drop(owner1);
+
+    // --- restart: same persisted epoch store + same sink, seed counter from
+    // the sink's durable max (the "rebuilt from ORM" counter, which rewinds).
+    let owner2 = Owner::with_parts(
+        RouterConfig::default(),
+        epoch_store.clone(),
+        sink.clone(),
+        durable_max,
+    );
+    assert_eq!(
+        owner2.epoch_store.current(),
+        2,
+        "restart bumped the persisted epoch to 2 (§3.8)"
+    );
+
+    let mut post_seqs = Vec::new();
+    for i in 1..=50u128 {
+        let seq = owner2
+            .router
+            .publish(durable(ch, 1000 + i, &format!("post{i}")))
+            .await
+            .unwrap();
+        post_seqs.push(seq);
+    }
+
+    // (1) No seq is ever reissued across the whole lifetime.
+    let mut all: Vec<Seq> = pre_seqs.iter().chain(post_seqs.iter()).copied().collect();
+    let unique: HashSet<Seq> = all.iter().copied().collect();
+    assert_eq!(
+        unique.len(),
+        all.len(),
+        "no (epoch, counter) pair is reissued across the restart"
+    );
+
+    // (2) Every post-restart event sorts strictly AFTER every pre-restart one.
+    let max_pre = *pre_seqs.iter().max().unwrap();
+    let min_post = *post_seqs.iter().min().unwrap();
+    assert!(
+        min_post > max_pre,
+        "post-restart min {min_post} must exceed pre-restart max {max_pre} \
+         (epoch dominates even though counter rewound: pre counters reached {}, \
+          post counters restart at {durable_max})",
+        max_pre.counter
+    );
+
+    // (3) The total order is globally monotonic when sorted — pre block then
+    // post block, no interleave.
+    all.sort();
+    let split = all.iter().position(|s| s.epoch == 2).unwrap();
+    assert!(
+        all[..split].iter().all(|s| s.epoch == 1) && all[split..].iter().all(|s| s.epoch == 2),
+        "sorted order is all epoch-1 then all epoch-2 — no interleave"
+    );
+}

--- a/crates/airc-bus/tests/ephemeral_off_sink.rs
+++ b/crates/airc-bus/tests/ephemeral_off_sink.rs
@@ -1,0 +1,87 @@
+//! Acceptance test 4 — ephemeral off the sink (§3.4, §11.1 ephemeral-off-ORM).
+//!
+//! 1000 `EphemeralLatest` updates with the same coalesce_key. Assert
+//! `DurableSink::append` was called 0 times and a subscriber sees only the
+//! latest value (TTL respected).
+
+mod common;
+
+use std::time::Duration;
+
+use futures::StreamExt;
+
+use airc_bus::{Filter, RouterConfig};
+use airc_core::RoomId;
+
+use common::{ephemeral, Owner};
+
+#[tokio::test]
+async fn ephemeral_firehose_never_touches_the_sink_and_coalesces() {
+    let ch = RoomId::from_u128(0xef);
+    let owner = Owner::new(RouterConfig {
+        ephemeral_ttl_ms: 10_000,
+        ..Default::default()
+    });
+    let r = &owner.router;
+
+    // 1000 presence/typing updates, all coalescing on one key.
+    for i in 1..=1000u128 {
+        r.publish(ephemeral(ch, i, "typing:alice", &i.to_le_bytes()))
+            .await
+            .unwrap();
+    }
+
+    // Give the (idle) write-behind task a chance to run — it must have nothing
+    // to do, because ephemerals are never enqueued to it.
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    // (1) The sink was NEVER appended to. This is the efficiency keystone:
+    // if ephemerals were (wrongly) enqueued to write-behind, this would be
+    // 1000, not 0.
+    assert_eq!(
+        owner.sink.append_count(),
+        0,
+        "EphemeralLatest must never reach the durable tier (§3.4)"
+    );
+    assert_eq!(
+        owner.sink.len(ch),
+        0,
+        "no durable rows for ephemeral traffic"
+    );
+
+    // (2) The coalesced cache holds exactly the latest value.
+    let latest = r
+        .ephemeral_latest(ch, "typing:alice")
+        .expect("a live coalesced value");
+    assert_eq!(
+        latest.payload.as_ref(),
+        &1000u128.to_le_bytes(),
+        "latest-wins: only the final update survives coalescing"
+    );
+
+    // (3) A subscriber that attaches now and then sees one more update gets
+    // the latest live value (not 1000 separate frames). Attach, publish one
+    // more, observe exactly that one.
+    let stream = r.subscribe(Filter::channel(ch), None);
+    futures::pin_mut!(stream);
+    r.publish(ephemeral(ch, 1001, "typing:alice", &1001u128.to_le_bytes()))
+        .await
+        .unwrap();
+    let next = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("ephemeral live push timed out")
+        .expect("stream ended");
+    assert_eq!(
+        next.payload.as_ref(),
+        &1001u128.to_le_bytes(),
+        "subscriber sees the latest ephemeral live"
+    );
+
+    // (4) TTL respected: advance the clock past the TTL; the cached value
+    // expires.
+    owner.clock.advance(10_000);
+    assert!(
+        r.ephemeral_latest(ch, "typing:alice").is_none(),
+        "ephemeral entry expires after its TTL (§3.4)"
+    );
+}

--- a/crates/airc-bus/tests/many_rooms.rs
+++ b/crates/airc-bus/tests/many_rooms.rs
@@ -1,0 +1,108 @@
+//! Acceptance test 5 — many rooms, idle ones ≈ free (§3.1, §6, §11.1).
+//!
+//! 1000 channels named, 1 active. Idle channels cost ~nothing: no per-channel
+//! task spinning. Tested via two proxies that hold without sampling CPU:
+//!
+//! - **no-allocation-growth:** merely *naming* a channel (constructing a
+//!   `RoomId` + subscribing to it lazily) allocates per-channel state only
+//!   when first touched, and an idle channel never spawns a task or a ring
+//!   that grows. The router exposes `channels_created` — the count of channel
+//!   states ever allocated. We assert it equals the number of channels we
+//!   actually *touched*, not some background-fanned superset.
+//! - **no-wakeups proxy:** idle subscribers produce nothing. We attach a
+//!   subscriber to an idle channel and assert it yields no event within a
+//!   window (a polling/per-room-task design would tick); only the active
+//!   channel's subscriber wakes.
+
+mod common;
+
+use std::time::Duration;
+
+use futures::StreamExt;
+
+use airc_bus::{Filter, RouterConfig};
+use airc_core::RoomId;
+
+use common::{durable, Owner};
+
+#[tokio::test]
+async fn idle_channels_allocate_nothing_and_never_wake() {
+    let owner = Owner::new(RouterConfig::default());
+    let r = &owner.router;
+
+    // Name 1000 channels but touch none yet.
+    let channels: Vec<RoomId> = (0..1000u128).map(RoomId::from_u128).collect();
+
+    // Before touching anything, no channel state exists.
+    assert_eq!(
+        r.channels_created(),
+        0,
+        "naming RoomIds allocates no per-channel state"
+    );
+
+    // Activate exactly ONE channel: subscribe + publish there.
+    let active = channels[500];
+    let active_stream = r.subscribe(Filter::channel(active), None);
+    futures::pin_mut!(active_stream);
+
+    // Attach an idle subscriber to a DIFFERENT channel; it must never wake.
+    let idle = channels[12];
+    let idle_stream = r.subscribe(Filter::channel(idle), None);
+    futures::pin_mut!(idle_stream);
+
+    // Only the two touched channels (active + idle) have state. The other 998
+    // named channels allocated nothing — idle ones are free.
+    assert_eq!(
+        r.channels_created(),
+        2,
+        "only touched channels allocate state; 998 idle ones cost nothing"
+    );
+
+    // Publish on the active channel.
+    r.publish(durable(active, 1, "hello")).await.unwrap();
+
+    // The active subscriber wakes with exactly that event.
+    let got = tokio::time::timeout(Duration::from_secs(5), active_stream.next())
+        .await
+        .expect("active subscriber should wake")
+        .expect("stream ended");
+    assert_eq!(got.event_id.0.as_u128(), 1);
+
+    // The idle subscriber NEVER wakes within the window — no per-room task is
+    // ticking it. (A poll-loop design would produce spurious wakeups here.)
+    let idle_wake = tokio::time::timeout(Duration::from_millis(300), idle_stream.next()).await;
+    assert!(
+        idle_wake.is_err(),
+        "idle channel subscriber must produce no event (no per-channel task/poll)"
+    );
+
+    // Touching the idle channel still didn't spawn anything for the other 998.
+    assert_eq!(
+        r.channels_created(),
+        2,
+        "still only the two touched channels"
+    );
+}
+
+#[tokio::test]
+async fn one_active_room_among_many_does_not_grow_with_room_count() {
+    // Allocation-growth proxy: the per-publish cost is independent of how many
+    // OTHER channels exist. We publish the same workload with the channel set
+    // present vs. absent and assert channel-state count tracks only touched
+    // channels, never the named universe.
+    let owner = Owner::new(RouterConfig::default());
+    let r = &owner.router;
+
+    // Touch a few channels with publishes.
+    for c in [3u128, 7, 11] {
+        r.publish(durable(RoomId::from_u128(c), c, "x"))
+            .await
+            .unwrap();
+    }
+    assert_eq!(
+        r.channels_created(),
+        3,
+        "channel-state allocation tracks only published-to channels, \
+         not the (unbounded) namespace of possible RoomIds"
+    );
+}

--- a/crates/airc-bus/tests/no_gap_cursor.rs
+++ b/crates/airc-bus/tests/no_gap_cursor.rs
@@ -1,0 +1,145 @@
+//! Acceptance test 1 — no-gap cursor (§3.5, §11.1).
+//!
+//! A subscriber attaching mid-stream with a cursor receives EVERY event after
+//! the cursor exactly once, including the replay→live seam, **including** the
+//! case where a `Durable` event was evicted-pending from the ring (small ring
+//! + delayed sink) — it must come from the sink, never be skipped.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+
+use airc_bus::{Clock, Cursor, EventRouter, Filter, InMemoryDurableSink, RouterConfig, SeqSource};
+use airc_core::RoomId;
+
+use common::{durable, GatedSink};
+
+/// Helper: drain `n` events from a stream with a timeout so a missed event
+/// fails loud (a hang) rather than passing trivially.
+async fn take_n<S>(mut stream: S, n: usize) -> Vec<airc_bus::Envelope>
+where
+    S: futures::Stream<Item = airc_bus::Envelope> + Unpin,
+{
+    let mut out = Vec::with_capacity(n);
+    for _ in 0..n {
+        let next = tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("timed out waiting for an event — a gap/miss would hang here");
+        out.push(next.expect("stream ended early — missing events"));
+    }
+    out
+}
+
+#[tokio::test]
+async fn mid_stream_attach_sees_every_event_after_cursor_once() {
+    let ch = RoomId::from_u128(0xabc);
+    let owner = common::Owner::new(RouterConfig {
+        ring_capacity: 1024,
+        ..Default::default()
+    });
+    let r = &owner.router;
+
+    // Publish 5 events; remember the cursor of the 2nd.
+    let mut cursors = Vec::new();
+    for i in 1..=5u128 {
+        let seq = r.publish(durable(ch, i, &format!("m{i}"))).await.unwrap();
+        cursors.push(Cursor::new(seq, airc_core::EventId::from_u128(i)));
+    }
+    let from = cursors[1]; // after the 2nd event
+
+    // Attach mid-stream from `from`. Spawn live publishes that race the
+    // attach/replay so the seam is genuinely exercised.
+    let stream = r.subscribe(Filter::channel(ch), Some(from));
+    futures::pin_mut!(stream);
+
+    // Publish 3 more live, interleaved.
+    for i in 6..=8u128 {
+        r.publish(durable(ch, i, &format!("m{i}"))).await.unwrap();
+    }
+
+    // Expect events 3,4,5 (replay) + 6,7,8 (live) = 6 events, each once.
+    let got = take_n(&mut stream, 6).await;
+    let markers: Vec<u128> = got.iter().map(|e| e.event_id.0.as_u128()).collect();
+    assert_eq!(
+        markers,
+        vec![3, 4, 5, 6, 7, 8],
+        "every event strictly after the cursor, in order, exactly once"
+    );
+
+    // No-dup: assert no further event is immediately available (no replayed
+    // event re-delivered as live).
+    let extra = tokio::time::timeout(Duration::from_millis(200), stream.next()).await;
+    assert!(extra.is_err(), "no duplicate at the seam");
+}
+
+#[tokio::test]
+async fn evicted_pending_durable_is_served_from_sink_not_skipped() {
+    // The §3.8 teeth: small ring + delayed sink. Events stay pinned (not
+    // evictable) while the sink gate is shut; once opened, write-behind
+    // persists + unpins, then capacity pressure evicts them from the ring.
+    // A subscriber attaching from the very start must still get them — now
+    // from the SINK, because the ring no longer holds them.
+    let ch = RoomId::from_u128(0xeee);
+
+    let backing = Arc::new(InMemoryDurableSink::new());
+    let gated = Arc::new(GatedSink::new(backing.clone()));
+
+    // Build a router with a TINY ring directly against the gated sink.
+    let epoch_store = airc_bus::InMemoryEpochStore::new();
+    let clock = airc_bus::ManualClock::new(1_700_000_000_000);
+    let seq = Arc::new(SeqSource::start(&epoch_store));
+    let r = EventRouter::new(
+        RouterConfig {
+            ring_capacity: 2, // tiny: forces eviction once unpinned
+            ..Default::default()
+        },
+        Arc::new(clock) as Arc<dyn Clock>,
+        seq,
+        gated.clone(),
+    );
+
+    // Publish 6 durable events while the sink gate is SHUT. They fan out and
+    // ring, but write-behind blocks on append → all 6 stay pinned in the ring
+    // (the §3.8 floor: ring grows past capacity 2 rather than drop unpersisted
+    // durables).
+    for i in 1..=6u128 {
+        r.publish(durable(ch, i, &format!("m{i}"))).await.unwrap();
+    }
+    assert_eq!(
+        r.pinned_in_ring(ch),
+        6,
+        "all unpersisted durables are pinned — ring exceeds capacity (§3.8 floor)"
+    );
+    assert_eq!(r.ring_len(ch), 6, "ring held all 6 above its nominal 2");
+
+    // Open the gate: write-behind drains, persists all 6, unpins them, and the
+    // ring evicts down toward capacity. Wait until the sink has all 6 and the
+    // ring has shrunk (the eviction we need for the test to mean something).
+    gated.open();
+    let mut waited = 0;
+    while (backing.len(ch) < 6 || r.ring_len(ch) > 2) && waited < 5000 {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        waited += 5;
+    }
+    assert_eq!(backing.len(ch), 6, "all durables persisted after gate open");
+    assert!(
+        r.ring_len(ch) <= 2,
+        "ring evicted the now-persisted durables (so they are NOT in RAM)"
+    );
+
+    // Now attach from the beginning. The early events (1..=4) are gone from
+    // the ring; they MUST be served from the sink. If the deep-replay leg were
+    // removed (or the ring weren't authoritative-then-deep), they'd be skipped.
+    let stream = r.subscribe(Filter::channel(ch), None);
+    futures::pin_mut!(stream);
+    let got = take_n(&mut stream, 6).await;
+    let markers: Vec<u128> = got.iter().map(|e| e.event_id.0.as_u128()).collect();
+    assert_eq!(
+        markers,
+        vec![1, 2, 3, 4, 5, 6],
+        "evicted-pending durables come from the sink — none skipped (§3.8 no-gap)"
+    );
+}

--- a/crates/airc-bus/tests/no_gap_cursor.rs
+++ b/crates/airc-bus/tests/no_gap_cursor.rs
@@ -18,10 +18,11 @@ use airc_core::RoomId;
 use common::{durable, GatedSink};
 
 /// Helper: drain `n` events from a stream with a timeout so a missed event
-/// fails loud (a hang) rather than passing trivially.
-async fn take_n<S>(mut stream: S, n: usize) -> Vec<airc_bus::Envelope>
+/// fails loud (a hang) rather than passing trivially. Items are `Arc<Envelope>`
+/// — the zero-copy fan-out yields refcounted handles, not owned envelopes.
+async fn take_n<S>(mut stream: S, n: usize) -> Vec<Arc<airc_bus::Envelope>>
 where
-    S: futures::Stream<Item = airc_bus::Envelope> + Unpin,
+    S: futures::Stream<Item = Arc<airc_bus::Envelope>> + Unpin,
 {
     let mut out = Vec::with_capacity(n);
     for _ in 0..n {

--- a/crates/airc-bus/tests/slow_subscriber.rs
+++ b/crates/airc-bus/tests/slow_subscriber.rs
@@ -1,0 +1,93 @@
+//! Acceptance test 3 — slow subscriber (§3.5, §5, §11.1).
+//!
+//! Two subscribers, one never drains. The fast one keeps receiving live with
+//! no stall; the slow one is marked lagged and can resume from the sink via
+//! its cursor. Fan-out is NEVER blocked by the slow consumer.
+
+mod common;
+
+use std::time::Duration;
+
+use futures::StreamExt;
+
+use airc_bus::{Filter, RouterConfig};
+use airc_core::RoomId;
+
+use common::{durable, Owner};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn lagging_subscriber_never_stalls_fanout_and_resumes_from_sink() {
+    let ch = RoomId::from_u128(0x10a6);
+
+    // Bounded subscriber buffer: small enough that the never-drained slow
+    // subscriber overflows it (and is marked lagged), large enough that the
+    // continuously-drained fast subscriber's transient backlog stays under it.
+    const BUFFER: usize = 16;
+    const N: u128 = 200;
+    let owner = Owner::new(RouterConfig {
+        subscriber_buffer: BUFFER,
+        ring_capacity: 4096,
+        ..Default::default()
+    });
+    let r = &owner.router;
+
+    // Slow subscriber: attach but NEVER drain it. Its mpsc receiver stays
+    // alive (so the handle isn't dropped) and fills to BUFFER, then overflows.
+    let (_slow_stream, slow_lag) = r.subscribe_with_lag(Filter::channel(ch), None);
+    futures::pin_mut!(_slow_stream);
+
+    // Fast subscriber: drained in lockstep with publishing below.
+    let (fast_stream, _fast_lag) = r.subscribe_with_lag(Filter::channel(ch), None);
+    futures::pin_mut!(fast_stream);
+
+    // Publish N events, draining the fast subscriber after each so it keeps
+    // pace and never overflows its own buffer. Each publish is timeout-guarded:
+    // if fan-out blocked on the slow (undrained) subscriber, publish would
+    // hang and fail here — the core "never stalls the shard" assertion.
+    let mut seen = Vec::new();
+    for i in 1..=N {
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            r.publish(durable(ch, i, &format!("m{i}"))),
+        )
+        .await
+        .expect("publish STALLED — a slow subscriber must never block the shard")
+        .unwrap();
+
+        // Fast subscriber keeps receiving live with no stall.
+        let env = tokio::time::timeout(Duration::from_secs(5), fast_stream.next())
+            .await
+            .expect("fast subscriber STALLED — fan-out was blocked by the slow one")
+            .expect("fast stream ended early");
+        seen.push(env.event_id.0.as_u128());
+    }
+
+    let expected: Vec<u128> = (1..=N).collect();
+    assert_eq!(
+        seen, expected,
+        "fast subscriber got every event live, in order"
+    );
+
+    // The slow subscriber was marked lagged (its bounded channel overflowed
+    // after BUFFER undrained events).
+    assert!(
+        slow_lag.is_lagged(),
+        "the undrained subscriber must be marked lagged (§3.5)"
+    );
+
+    // The slow subscriber can resume from the sink via its cursor. It never
+    // consumed anything, so resuming from None must yield all 200 from the
+    // durable tier (ring may also hold recent, but resume merges + dedups).
+    // Give write-behind a moment to flush everything to the sink.
+    let mut waited = 0;
+    while owner.sink.len(ch) < N as usize && waited < 5000 {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        waited += 5;
+    }
+    let resumed = r.resume_from_cursor(ch, None).await.unwrap();
+    let resumed_markers: Vec<u128> = resumed.iter().map(|e| e.event_id.0.as_u128()).collect();
+    assert_eq!(
+        resumed_markers, expected,
+        "lagged subscriber resumes the full stream from its cursor, no dup, in order"
+    );
+}


### PR DESCRIPTION
**Slice 1 / vertical 1** of the event-server design (`AIRC-EVENT-SERVER.md`, merged in #1017). The in-memory **owner-core** as a new isolated crate `airc-bus` — the heart of the architecture (per-channel router + hot ring + generational cursor), built test-first to the §3.5/§3.8 invariants. No `airc-daemon`/`airc-lib`/`LocalFsAdapter` touched; the durable tier lives entirely behind a `DurableSink` trait (no `airc-store` dep yet).

### What it is
- **Sharded mutex-striped router** — no-lock-across-`.await` is *syntactic* (publish holds a sync guard in a non-async block, released before any await; the write-behind task is the only `.await` near the sink, never under a shard lock).
- **Hot ring, pinned-until-persisted (§3.8)** — an unpersisted `Durable` entry is never evictable, so the no-gap precondition holds; ring grows past nominal capacity rather than drop an unpersisted event.
- **Generational `seq=(epoch,counter)`** — epoch bumped per start, counter rebuilt from sink max; a lost un-flushed tail can never reissue a seq.
- **No-gap cursor** — `subscribe` registers the live sender *and* snapshots the ring under one shard lock (register-first ⇒ no miss); deep-replay (`<ring_oldest`) from the sink, recent from the ring snapshot, live deduped by high-watermark (⇒ no dup).
- **Slow subscriber never stalls** — `try_send`-only fan-out; Full ⇒ mark lagged + drop live + resume-from-cursor; never blocks the shard.
- **`EphemeralLatest` coalesced** latest-wins + TTL; never ringed, never persisted (firehose off the durable tier).
- **Deliver-first / persist-async**; injectable `Clock`+`SeqSource`+`EpochStore` ⇒ deterministic, no global mutable state.

### Tests (§11.1) — each verified fail-without/pass-with
no-gap cursor (incl. **evicted-pending-durable-served-from-sink**), crash-safe seq across simulated restart, slow-subscriber non-blocking + resume, ephemeral-off-sink (1000 updates → 0 sink appends), many-rooms idle. `cargo test -p airc-bus` → **26 green**; `clippy -D warnings` + `fmt` clean (verified by me in the worktree, not just the build report).

### Deferred to vertical 2 (durable tier) — tracked, not blockers for the isolated core
bound the deep-replay page (currently `usize::MAX`, fine for the in-memory sink); the `await_durable` blocking path (slice 1 sheds fire-and-forget with a *surfaced* error, never silent/OOM); sink-append retry/backoff (real ORM sink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
