### PR TITLE
feat(store): SQLite-backed DurableSink — owner-core ORM durable tier (§3.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,9 +244,12 @@ dependencies = [
 name = "airc-store"
 version = "0.1.0"
 dependencies = [
+ "airc-bus",
  "airc-core",
  "async-trait",
  "base64",
+ "bytes",
+ "futures",
  "sea-orm",
  "sea-orm-migration",
  "serde",

--- a/crates/airc-store/Cargo.toml
+++ b/crates/airc-store/Cargo.toml
@@ -15,8 +15,13 @@ workspace = true
 
 [dependencies]
 airc-core = { path = "../airc-core" }
+# Lower-level generic owner-core. The durable tier (this crate) implements
+# `airc_bus::DurableSink`, so `airc-store -> airc-bus` is the correct
+# dependency direction; airc-bus must NOT depend on airc-store.
+airc-bus = { path = "../airc-bus" }
 async-trait = "0.1"
 base64 = "0.22"
+bytes = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
@@ -36,5 +41,8 @@ sea-orm-migration = { version = "1", default-features = false, features = [
 tokio = { version = "1", features = ["rt", "macros"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
 tempfile = "3"
+# The owner-core router, exercised against the real SQLite durable tier in
+# the integration proof (deep-replay from disk).
+futures = "0.3"

--- a/crates/airc-store/src/bus_sink.rs
+++ b/crates/airc-store/src/bus_sink.rs
@@ -1,0 +1,543 @@
+//! SQLite-backed [`airc_bus::DurableSink`] — the real ORM durable tier
+//! (§3.3 of `docs/architecture/AIRC-EVENT-SERVER.md`).
+//!
+//! This replaces the in-memory test sink (`airc_bus::InMemoryDurableSink`)
+//! with a SeaORM-backed SQLite store so the owner-core's `Durable`
+//! envelopes persist and replay from disk. The owner daemon is the
+//! **single writer** of this store (§3.3) — there is no write-lock
+//! contention — and the connection runs in **WAL** mode so reads
+//! (deep-replay) never block the writer.
+//!
+//! ## The one sanctioned serialize/deserialize copy
+//!
+//! [`to_active_model`] / [`from_model`] are the ONLY place an
+//! `Envelope` is mapped to/from its persisted row: `headers` → JSON,
+//! `target` → JSON, `payload` → BLOB, `kind`/`delivery` enums → text,
+//! `seq = (epoch, counter)` → two `i64` columns. No other copy of this
+//! mapping exists; the hot path stays zero-copy (§3.1) and only the
+//! durable boundary pays this cost.
+//!
+//! ## Order & paging
+//!
+//! [`DurableSink::page`] returns rows on a channel strictly *after* a
+//! cursor, in the generational total order `(epoch, counter, event_id)`
+//! (§3.5, §3.8 — NOT a single lamport), **bounded by `limit`**, served
+//! by the composite index from a single B-tree range scan (no
+//! full-table scan).
+
+use std::path::Path;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use sea_orm::{
+    sea_query::{Expr, OnConflict},
+    ColumnTrait, ConnectOptions, Database, DatabaseConnection, EntityTrait, QueryFilter,
+    QueryOrder, QuerySelect, Set,
+};
+use sea_orm_migration::MigratorTrait;
+
+use airc_bus::envelope::{Cursor, DeliveryClass, Envelope, Kind, Target};
+use airc_bus::{BusError, DurableSink, Seq};
+use airc_core::{ClientId, EventId, Headers, PeerId, RoomId};
+
+use crate::entities::bus_event;
+use crate::migration::Migrator;
+
+/// SQLite-backed durable tier for the owner-core (§3.3).
+///
+/// Single-writer (the daemon owns it) + WAL — exactly the SQLite shape
+/// that makes the durable tier fast (§3.3): no write-lock contention,
+/// readers never block the writer.
+pub struct SqliteDurableSink {
+    db: DatabaseConnection,
+}
+
+impl SqliteDurableSink {
+    /// Open (or create) a SQLite database at `db_url`, run migrations,
+    /// and put the connection in WAL mode.
+    ///
+    /// For an in-memory store use `"sqlite::memory:"`; for a file store
+    /// use `"sqlite://<path>?mode=rwc"`.
+    pub async fn open(db_url: &str) -> Result<Self, BusError> {
+        let mut opts = ConnectOptions::new(db_url.to_owned());
+        // Single writer (the daemon). One connection avoids SQLite
+        // write-lock contention entirely (§3.3).
+        opts.connect_timeout(std::time::Duration::from_secs(5))
+            .acquire_timeout(std::time::Duration::from_secs(5))
+            .max_connections(1);
+        let db = Database::connect(opts)
+            .await
+            .map_err(|e| BusError::Sink(e.to_string()))?;
+        set_wal(&db).await?;
+        Migrator::up(&db, None)
+            .await
+            .map_err(|e| BusError::Sink(e.to_string()))?;
+        Ok(Self { db })
+    }
+
+    /// Open a file-backed durable tier from a filesystem path. Keeps
+    /// platform path rules (Windows URI slashes) out of consumers.
+    pub async fn open_path(path: &Path) -> Result<Self, BusError> {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).map_err(|e| BusError::Sink(e.to_string()))?;
+            }
+        }
+        Self::open(&sqlite_file_url(path)).await
+    }
+
+    /// Open an ephemeral in-memory durable tier. Convenience for tests.
+    pub async fn in_memory() -> Result<Self, BusError> {
+        Self::open("sqlite::memory:").await
+    }
+}
+
+#[async_trait]
+impl DurableSink for SqliteDurableSink {
+    async fn append(&self, e: &Envelope) -> Result<(), BusError> {
+        // Idempotent insert on `event_id` (§3.3): a replay / re-inject
+        // must not double-store. ON CONFLICT DO NOTHING — a duplicate is
+        // a silent no-op, never an error (the router treats append as
+        // at-least-once).
+        let active = to_active_model(e)?;
+        let res = bus_event::Entity::insert(active)
+            .on_conflict(
+                OnConflict::column(bus_event::Column::EventId)
+                    .do_nothing()
+                    .to_owned(),
+            )
+            .exec(&self.db)
+            .await;
+        match res {
+            Ok(_) => Ok(()),
+            // `RecordNotInserted` is the DO-NOTHING path: the event_id
+            // already exists. Idempotent success, not an error.
+            Err(sea_orm::DbErr::RecordNotInserted) => Ok(()),
+            Err(err) => Err(BusError::Sink(err.to_string())),
+        }
+    }
+
+    async fn page(
+        &self,
+        channel: RoomId,
+        from_cursor: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        // Bounded by `limit`. The trait caller (the router's deep-replay)
+        // may pass a very large limit to mean "the whole tail"; clamp to
+        // `i64::MAX` so the SQL bind never overflows and we never use
+        // `usize::MAX` as a sentinel. The query stays indexed: ORDER BY
+        // rides the composite index, LIMIT only caps the row count.
+        let bounded = u64::try_from(limit)
+            .unwrap_or(u64::MAX)
+            .min(i64::MAX as u64);
+
+        let mut query =
+            bus_event::Entity::find().filter(bus_event::Column::RoomId.eq(channel.as_uuid()));
+
+        // Strictly after the cursor in generational order:
+        //   epoch > c.epoch
+        //   OR (epoch == c.epoch AND counter > c.counter)
+        //   OR (epoch == c.epoch AND counter == c.counter
+        //       AND event_id > c.event_id).
+        // event_id is the deterministic tiebreaker (§3.5); within one
+        // epoch the monotonic counter forbids a tie, but the tiebreak
+        // keeps the order total independent of how `seq` was produced.
+        if let Some(c) = from_cursor {
+            let epoch = c.seq.epoch as i64;
+            let counter = c.seq.counter as i64;
+            let event_id = c.event_id.as_uuid();
+            let strictly_after = Expr::col(bus_event::Column::Epoch)
+                .gt(epoch)
+                .or(Expr::col(bus_event::Column::Epoch)
+                    .eq(epoch)
+                    .and(Expr::col(bus_event::Column::Counter).gt(counter)))
+                .or(Expr::col(bus_event::Column::Epoch)
+                    .eq(epoch)
+                    .and(Expr::col(bus_event::Column::Counter).eq(counter))
+                    .and(Expr::col(bus_event::Column::EventId).gt(event_id)));
+            query = query.filter(strictly_after);
+        }
+
+        let rows = query
+            .order_by_asc(bus_event::Column::Epoch)
+            .order_by_asc(bus_event::Column::Counter)
+            .order_by_asc(bus_event::Column::EventId)
+            .limit(bounded)
+            .all(&self.db)
+            .await
+            .map_err(|e| BusError::Sink(e.to_string()))?;
+
+        rows.into_iter().map(from_model).collect()
+    }
+}
+
+/// Put the connection in WAL journal mode (§3.3). WAL lets the
+/// deep-replay reads run concurrently with the single writer without
+/// blocking it; `synchronous=NORMAL` is the standard WAL durability
+/// trade (an fsync per checkpoint, not per commit) and is safe for the
+/// deliver-first / persist-async contract (§3.3 — the ORM is the source
+/// of truth; a crash loses only the un-flushed tail, replayable from
+/// peers). In-memory databases ignore the pragma.
+async fn set_wal(db: &DatabaseConnection) -> Result<(), BusError> {
+    use sea_orm::{ConnectionTrait, Statement};
+    let backend = db.get_database_backend();
+    for pragma in ["PRAGMA journal_mode=WAL;", "PRAGMA synchronous=NORMAL;"] {
+        db.execute(Statement::from_string(backend, pragma.to_owned()))
+            .await
+            .map_err(|e| BusError::Sink(e.to_string()))?;
+    }
+    Ok(())
+}
+
+/// The ONE sanctioned `Envelope -> row` serialize (§3.3). Lives only
+/// here; no other copy of this mapping exists.
+fn to_active_model(e: &Envelope) -> Result<bus_event::ActiveModel, BusError> {
+    Ok(bus_event::ActiveModel {
+        event_id: Set(e.event_id.as_uuid()),
+        room_id: Set(e.channel.as_uuid()),
+        epoch: Set(u64_to_i64("bus_events.epoch", e.seq.epoch)?),
+        counter: Set(u64_to_i64("bus_events.counter", e.seq.counter)?),
+        kind: Set(kind_to_text(e.kind).to_owned()),
+        delivery: Set(delivery_to_text(e.delivery).to_owned()),
+        target: Set(serde_json::to_value(&e.target).map_err(codec)?),
+        correlation_id: Set(e.correlation_id),
+        coalesce_key: Set(e.coalesce_key.clone()),
+        headers: Set(serde_json::to_value(&e.headers).map_err(codec)?),
+        payload: Set(e.payload.to_vec()),
+        peer_id: Set(e.from.0.as_uuid()),
+        client_id: Set(e.from.1.as_uuid()),
+        occurred_at_ms: Set(u64_to_i64("bus_events.occurred_at_ms", e.occurred_at_ms)?),
+    })
+}
+
+/// The ONE sanctioned `row -> Envelope` deserialize (§3.3). Inverse of
+/// [`to_active_model`].
+fn from_model(m: bus_event::Model) -> Result<Envelope, BusError> {
+    let target: Target = serde_json::from_value(m.target).map_err(codec)?;
+    let headers: Headers = serde_json::from_value(m.headers).map_err(codec)?;
+    Ok(Envelope {
+        event_id: EventId::from_uuid(m.event_id),
+        channel: RoomId::from_uuid(m.room_id),
+        from: (
+            PeerId::from_uuid(m.peer_id),
+            ClientId::from_uuid(m.client_id),
+        ),
+        target,
+        kind: kind_from_text(&m.kind)?,
+        delivery: delivery_from_text(&m.delivery)?,
+        seq: Seq::new(
+            i64_to_u64("bus_events.epoch", m.epoch)?,
+            i64_to_u64("bus_events.counter", m.counter)?,
+        ),
+        occurred_at_ms: i64_to_u64("bus_events.occurred_at_ms", m.occurred_at_ms)?,
+        correlation_id: m.correlation_id,
+        coalesce_key: m.coalesce_key,
+        headers,
+        payload: Bytes::from(m.payload),
+    })
+}
+
+fn kind_to_text(kind: Kind) -> &'static str {
+    match kind {
+        Kind::Message => "message",
+        Kind::Event => "event",
+        Kind::Command => "command",
+        Kind::CommandResult => "command_result",
+        Kind::Signal => "signal",
+        Kind::StreamChunk => "stream_chunk",
+        Kind::Control => "control",
+    }
+}
+
+fn kind_from_text(text: &str) -> Result<Kind, BusError> {
+    match text {
+        "message" => Ok(Kind::Message),
+        "event" => Ok(Kind::Event),
+        "command" => Ok(Kind::Command),
+        "command_result" => Ok(Kind::CommandResult),
+        "signal" => Ok(Kind::Signal),
+        "stream_chunk" => Ok(Kind::StreamChunk),
+        "control" => Ok(Kind::Control),
+        other => Err(BusError::Sink(format!("unknown bus_events.kind: {other}"))),
+    }
+}
+
+fn delivery_to_text(delivery: DeliveryClass) -> &'static str {
+    match delivery {
+        DeliveryClass::Durable => "durable",
+        DeliveryClass::EphemeralLatest => "ephemeral_latest",
+        DeliveryClass::EphemeralWindow => "ephemeral_window",
+        DeliveryClass::RequestResponse => "request_response",
+        DeliveryClass::StreamChunk => "stream_chunk",
+    }
+}
+
+fn delivery_from_text(text: &str) -> Result<DeliveryClass, BusError> {
+    match text {
+        "durable" => Ok(DeliveryClass::Durable),
+        "ephemeral_latest" => Ok(DeliveryClass::EphemeralLatest),
+        "ephemeral_window" => Ok(DeliveryClass::EphemeralWindow),
+        "request_response" => Ok(DeliveryClass::RequestResponse),
+        "stream_chunk" => Ok(DeliveryClass::StreamChunk),
+        other => Err(BusError::Sink(format!(
+            "unknown bus_events.delivery: {other}"
+        ))),
+    }
+}
+
+fn codec(e: serde_json::Error) -> BusError {
+    BusError::Sink(format!("envelope codec error: {e}"))
+}
+
+fn u64_to_i64(field: &'static str, value: u64) -> Result<i64, BusError> {
+    i64::try_from(value).map_err(|_| BusError::Sink(format!("{field} out of i64 range: {value}")))
+}
+
+fn i64_to_u64(field: &'static str, value: i64) -> Result<u64, BusError> {
+    u64::try_from(value).map_err(|_| BusError::Sink(format!("{field} out of u64 range: {value}")))
+}
+
+fn sqlite_file_url(path: &Path) -> String {
+    let raw = normalise_sqlite_path(path);
+    if has_windows_drive_prefix(&raw) {
+        format!("sqlite:{raw}?mode=rwc")
+    } else {
+        format!("sqlite://{raw}?mode=rwc")
+    }
+}
+
+fn normalise_sqlite_path(path: &Path) -> String {
+    let raw = path.to_string_lossy().replace('\\', "/");
+    raw.strip_prefix("//?/").unwrap_or(&raw).to_string()
+}
+
+fn has_windows_drive_prefix(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_bus::envelope::{DeliveryClass, Kind};
+    use airc_core::{ClientId, EventId, PeerId, RoomId};
+    use bytes::Bytes;
+    use uuid::Uuid;
+
+    /// Build a `Durable` envelope at a given `(epoch, counter)` with a
+    /// deterministic `event_id` derived from the position so tests can
+    /// assert exact identity and order. `event_id` is the PK, so (as with
+    /// real random UUIDs) it must be globally unique across channels —
+    /// the channel is mixed into the high half.
+    fn durable_at(channel: RoomId, epoch: u64, counter: u64) -> Envelope {
+        let mut e = Envelope::new(
+            channel,
+            (PeerId::from_u128(0xa1), ClientId::from_u128(0xc1)),
+            Kind::Message,
+            DeliveryClass::Durable,
+            Bytes::from(format!("payload-{epoch}-{counter}")),
+        )
+        .with_event_id(EventId::from_u128(
+            // Distinct per (channel, epoch, counter): channel + epoch in
+            // the high half, counter in the low half, +1 so no id is nil.
+            ((channel.as_uuid().as_u128() ^ (u128::from(epoch) << 16)) << 64)
+                | u128::from(counter).wrapping_add(1),
+        ))
+        .with_header("h", format!("{epoch}:{counter}"));
+        e.seq = Seq::new(epoch, counter);
+        e.occurred_at_ms = 1_700_000_000_000 + counter;
+        e
+    }
+
+    #[tokio::test]
+    async fn append_then_page_round_trips_full_envelope() {
+        // The minimum-viable proof: write one, read it back, every field
+        // (incl. opaque payload + headers + target enum) intact.
+        let sink = SqliteDurableSink::in_memory().await.unwrap();
+        let ch = RoomId::from_u128(0xc0ffee);
+        let e = durable_at(ch, 1, 0)
+            .with_target(Target::Peer(PeerId::from_u128(0x99)))
+            .with_correlation_id(Uuid::from_u128(0x1234))
+            .with_coalesce_key("k");
+        sink.append(&e).await.unwrap();
+
+        let page = sink.page(ch, None, 100).await.unwrap();
+        assert_eq!(page.len(), 1);
+        assert_eq!(page[0], e, "full envelope round-trips through the row");
+    }
+
+    #[tokio::test]
+    async fn page_orders_by_epoch_counter_event_id() {
+        // §3.8 crash-safe order: a post-crash event (higher epoch, lower
+        // counter) sorts strictly AFTER a pre-crash event (lower epoch,
+        // higher counter). Ordering must be (epoch, counter, event_id),
+        // NOT a single lamport — append out of order, expect sorted.
+        let sink = SqliteDurableSink::in_memory().await.unwrap();
+        let ch = RoomId::from_u128(7);
+        // epoch 2 counter 0 appended FIRST but must sort LAST after
+        // epoch 1's counters; epoch 1 counter 2 appended before counter 1.
+        sink.append(&durable_at(ch, 2, 0)).await.unwrap();
+        sink.append(&durable_at(ch, 1, 2)).await.unwrap();
+        sink.append(&durable_at(ch, 1, 0)).await.unwrap();
+        sink.append(&durable_at(ch, 1, 1)).await.unwrap();
+
+        let page = sink.page(ch, None, 100).await.unwrap();
+        let order: Vec<(u64, u64)> = page.iter().map(|e| (e.seq.epoch, e.seq.counter)).collect();
+        assert_eq!(
+            order,
+            vec![(1, 0), (1, 1), (1, 2), (2, 0)],
+            "epoch dominates; post-crash epoch sorts after pre-crash even with lower counter"
+        );
+    }
+
+    #[tokio::test]
+    async fn append_is_idempotent_on_event_id() {
+        // §3.3: a replay / re-inject of the same event_id is a no-op,
+        // never a duplicate row, never an error.
+        let sink = SqliteDurableSink::in_memory().await.unwrap();
+        let ch = RoomId::from_u128(1);
+        let e = durable_at(ch, 1, 0);
+        sink.append(&e).await.unwrap();
+        sink.append(&e).await.unwrap();
+        sink.append(&e).await.unwrap();
+
+        let page = sink.page(ch, None, 100).await.unwrap();
+        assert_eq!(page.len(), 1, "same event_id => exactly one row");
+    }
+
+    #[tokio::test]
+    async fn page_returns_strictly_after_cursor_and_respects_limit() {
+        // Cursor pagination (§3.5): tail then page deeper. Stable, no dup
+        // across pages, respects `limit`.
+        let sink = SqliteDurableSink::in_memory().await.unwrap();
+        let ch = RoomId::from_u128(0x5);
+        for c in 0..10u64 {
+            sink.append(&durable_at(ch, 1, c)).await.unwrap();
+        }
+
+        // First page of 4 from the beginning.
+        let page1 = sink.page(ch, None, 4).await.unwrap();
+        assert_eq!(page1.len(), 4, "limit honored");
+        let c1: Vec<u64> = page1.iter().map(|e| e.seq.counter).collect();
+        assert_eq!(c1, vec![0, 1, 2, 3]);
+
+        // Page deeper from the last cursor of page1 — strictly after, no dup.
+        let cursor = page1[3].cursor();
+        let page2 = sink.page(ch, Some(cursor), 4).await.unwrap();
+        let c2: Vec<u64> = page2.iter().map(|e| e.seq.counter).collect();
+        assert_eq!(c2, vec![4, 5, 6, 7], "strictly after, no dup across pages");
+
+        // Final page exhausts the tail.
+        let cursor = page2[3].cursor();
+        let page3 = sink.page(ch, Some(cursor), 4).await.unwrap();
+        let c3: Vec<u64> = page3.iter().map(|e| e.seq.counter).collect();
+        assert_eq!(c3, vec![8, 9], "tail shorter than limit");
+
+        // No event appears in two pages.
+        let mut all: Vec<u64> = c1.into_iter().chain(c2).chain(c3).collect();
+        all.sort_unstable();
+        all.dedup();
+        assert_eq!(all.len(), 10, "every event delivered exactly once");
+    }
+
+    #[tokio::test]
+    async fn page_strictly_after_at_same_seq_tiebreaks_on_event_id() {
+        // Two events sharing an exact (epoch, counter) page in event_id
+        // order; a cursor at the lower one returns only the higher.
+        let sink = SqliteDurableSink::in_memory().await.unwrap();
+        let ch = RoomId::from_u128(0x1234);
+        let mut lo = durable_at(ch, 5, 5);
+        let mut hi = durable_at(ch, 5, 5);
+        lo = lo.with_event_id(EventId::from_u128(0x1));
+        hi = hi.with_event_id(EventId::from_u128(0x2));
+        sink.append(&lo).await.unwrap();
+        sink.append(&hi).await.unwrap();
+
+        let page = sink.page(ch, None, 10).await.unwrap();
+        assert_eq!(page[0].event_id, lo.event_id);
+        assert_eq!(page[1].event_id, hi.event_id);
+
+        let after = sink.page(ch, Some(lo.cursor()), 10).await.unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].event_id, hi.event_id);
+    }
+
+    #[tokio::test]
+    async fn empty_channel_pages_empty() {
+        let sink = SqliteDurableSink::in_memory().await.unwrap();
+        let empty = RoomId::from_u128(0xdead);
+        assert!(sink.page(empty, None, 100).await.unwrap().is_empty());
+        let cursor = Cursor::new(Seq::new(1, 1), EventId::from_u128(1));
+        assert!(sink
+            .page(empty, Some(cursor), 100)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn page_isolates_channels() {
+        // A page on one channel never leaks another channel's events.
+        let sink = SqliteDurableSink::in_memory().await.unwrap();
+        let a = RoomId::from_u128(0xaaaa);
+        let b = RoomId::from_u128(0xbbbb);
+        sink.append(&durable_at(a, 1, 0)).await.unwrap();
+        sink.append(&durable_at(b, 1, 0)).await.unwrap();
+        sink.append(&durable_at(a, 1, 1)).await.unwrap();
+
+        assert_eq!(sink.page(a, None, 100).await.unwrap().len(), 2);
+        assert_eq!(sink.page(b, None, 100).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn persists_across_handles_on_disk() {
+        // Real durability: append through one handle, reopen the file,
+        // read it back — the WAL-backed row survives.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bus_events.sqlite");
+        let ch = RoomId::from_u128(0x42);
+        let e = durable_at(ch, 1, 0);
+
+        SqliteDurableSink::open_path(&path)
+            .await
+            .unwrap()
+            .append(&e)
+            .await
+            .unwrap();
+
+        let reopened = SqliteDurableSink::open_path(&path).await.unwrap();
+        let page = reopened.page(ch, None, 100).await.unwrap();
+        assert_eq!(page.len(), 1);
+        assert_eq!(page[0], e);
+    }
+
+    #[test]
+    fn kind_and_delivery_text_round_trip_every_variant() {
+        // The enum<->text mapping must cover every variant both ways so a
+        // future variant can't silently corrupt the durable tier.
+        for kind in [
+            Kind::Message,
+            Kind::Event,
+            Kind::Command,
+            Kind::CommandResult,
+            Kind::Signal,
+            Kind::StreamChunk,
+            Kind::Control,
+        ] {
+            assert_eq!(kind_from_text(kind_to_text(kind)).unwrap(), kind);
+        }
+        for delivery in [
+            DeliveryClass::Durable,
+            DeliveryClass::EphemeralLatest,
+            DeliveryClass::EphemeralWindow,
+            DeliveryClass::RequestResponse,
+            DeliveryClass::StreamChunk,
+        ] {
+            assert_eq!(
+                delivery_from_text(delivery_to_text(delivery)).unwrap(),
+                delivery
+            );
+        }
+    }
+}

--- a/crates/airc-store/src/entities/bus_event.rs
+++ b/crates/airc-store/src/entities/bus_event.rs
@@ -1,0 +1,73 @@
+//! `bus_events` table — the durable tier for the owner-core
+//! `airc_bus::Envelope` (§3.3 ORM durable tier of
+//! `docs/architecture/AIRC-EVENT-SERVER.md`).
+//!
+//! This is a CLEAN schema for the generic owner-core envelope — it is
+//! **not** `TranscriptEvent` (`Envelope != TranscriptEvent`). The
+//! `events` table mirrors the chat-shaped `TranscriptEvent`; this one
+//! mirrors the generic envelope (opaque `payload` blob, generational
+//! `seq = (epoch, counter)`, `Target`/`Kind`/`DeliveryClass` enums).
+//!
+//! ## Order key (NOT a single lamport)
+//!
+//! The owner-core total order is the **generational cursor**
+//! `(epoch, counter, event_id)` (§3.5, §3.8) — `epoch` is bumped on
+//! every daemon start so a post-crash event sorts strictly after a
+//! pre-crash one even when the in-memory counter rewinds. The composite
+//! index `idx_bus_events_room_epoch_counter_event_id` covers exactly
+//! that order so `page` is a single indexed B-tree range scan, never a
+//! full-table scan.
+//!
+//! Primary key: `event_id` (a UUIDv4) — append is an idempotent
+//! ON CONFLICT DO NOTHING insert on it (a replay / re-inject must not
+//! double-store, §3.3).
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "bus_events")]
+pub struct Model {
+    /// `event_id` as UUIDv4 — stable across replay, primary key. Append
+    /// is idempotent on this column.
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub event_id: Uuid,
+    /// Channel (room/stream) this envelope belongs to.
+    pub room_id: Uuid,
+    /// Generational order high half (`seq.epoch`). Bumped every daemon
+    /// start so post-crash events sort after pre-crash (§3.8).
+    pub epoch: i64,
+    /// Generational order low half (`seq.counter`) — the in-memory
+    /// monotonic counter within an epoch.
+    pub counter: i64,
+    /// `Kind` serialised as snake_case text (self-documenting; no enum
+    /// mapping table migration when a kind is added).
+    pub kind: String,
+    /// `DeliveryClass` serialised as snake_case text. Only `durable`
+    /// rows ever reach this table (§3.3 efficiency keystone).
+    pub delivery: String,
+    /// `Target` as JSON (`All` / `Endpoint` / `Peer` / `Reply` /
+    /// `Capability`). Stored as TEXT JSON; SQLite is opinion-free.
+    pub target: Json,
+    /// Command ↔ result / request ↔ response correlation (nullable).
+    pub correlation_id: Option<Uuid>,
+    /// Coalescing key for `EphemeralLatest` — carried for completeness;
+    /// `EphemeralLatest` is never persisted, so this is effectively
+    /// always null for `durable` rows (nullable).
+    pub coalesce_key: Option<String>,
+    /// Routable metadata (`Headers` = `BTreeMap<String,String>`) as JSON.
+    pub headers: Json,
+    /// OPAQUE consumer payload bytes. Stored as a BLOB; airc never
+    /// parses it.
+    pub payload: Vec<u8>,
+    /// Sender peer identity.
+    pub peer_id: Uuid,
+    /// Sender session identity.
+    pub client_id: Uuid,
+    /// Owner-stamped wall clock (ms).
+    pub occurred_at_ms: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/airc-store/src/entities/mod.rs
+++ b/crates/airc-store/src/entities/mod.rs
@@ -5,6 +5,11 @@
 //!     `TranscriptEvent`. Indexes on `(channel_id, lamport, event_id)`
 //!     keep `page_recent` and `resume_from` O(log n + page) instead
 //!     of O(n).
+//!   - `bus_events` — the owner-core durable tier (§3.3). One row per
+//!     persisted `airc_bus::Envelope` (a CLEAN schema, NOT
+//!     `TranscriptEvent`). Composite index on
+//!     `(room_id, epoch, counter, event_id)` — the generational cursor
+//!     order — keeps `DurableSink::page` a single indexed range scan.
 //!   - `runtime_cursors` — per-consumer replay cursors.
 //!   - `peer_trust` / `peer_rotation_audit` — trust anchors and
 //!     signed key-rotation audit rows.
@@ -24,6 +29,7 @@
 pub mod account_registry;
 pub mod beacon;
 pub mod beacon_channel;
+pub mod bus_event;
 pub mod event;
 pub mod local_identity;
 pub mod mesh_identity;

--- a/crates/airc-store/src/lib.rs
+++ b/crates/airc-store/src/lib.rs
@@ -21,6 +21,13 @@
 //!     for v1; migrations applied on `open`.
 //!   - [`InMemoryEventStore`]: trait-only test double, no I/O. Use
 //!     in unit tests that don't need durability.
+//!
+//! The owner-core durable tier ships here too: [`SqliteDurableSink`]
+//! is a SeaORM-backed SQLite implementation of `airc_bus::DurableSink`
+//! (§3.3 of `docs/architecture/AIRC-EVENT-SERVER.md`) — the real
+//! persistence behind the bus's `Durable` envelopes, replacing the
+//! in-memory test sink. `airc-store` depends on `airc-bus` (the lower-
+//! level generic crate), never the reverse.
 
 #![deny(unsafe_code)]
 // `rust_2018_idioms` would force `&SchemaManager<'_>` syntax on the
@@ -31,6 +38,7 @@
 
 pub mod account_registry;
 pub mod beacon;
+pub mod bus_sink;
 pub mod entities;
 pub mod error;
 pub mod local_identity;
@@ -45,6 +53,7 @@ pub mod subscriptions;
 
 pub use account_registry::{StoredAccountRegistry, StoredAccountRegistryGistSentinel};
 pub use beacon::StoredBeacon;
+pub use bus_sink::SqliteDurableSink;
 pub use error::StoreError;
 pub use local_identity::StoredLocalIdentity;
 pub use memory::InMemoryEventStore;

--- a/crates/airc-store/src/migration/m20260526_000011_create_bus_events.rs
+++ b/crates/airc-store/src/migration/m20260526_000011_create_bus_events.rs
@@ -1,0 +1,98 @@
+//! Create the `bus_events` table — the owner-core durable tier
+//! (§3.3 ORM durable tier of `docs/architecture/AIRC-EVENT-SERVER.md`).
+//!
+//! One row per persisted `airc_bus::Envelope`. This is a CLEAN schema
+//! for the generic envelope — deliberately NOT `TranscriptEvent`
+//! (`Envelope != TranscriptEvent`): opaque `payload` BLOB, generational
+//! `seq = (epoch, counter)`, `Target`/`Kind`/`DeliveryClass` as text.
+//!
+//! Index strategy:
+//!   - `idx_bus_events_room_epoch_counter_event_id` covers the
+//!     generational cursor order `(room_id, epoch, counter, event_id)`
+//!     used by `DurableSink::page` — the §3.5 bounded deep-replay. It is
+//!     NOT a single lamport: `epoch` leads `counter` so a post-crash
+//!     event sorts strictly after a pre-crash one (§3.8 crash-safe
+//!     order). Leading with `room_id` lets SQLite's planner do one
+//!     B-tree range scan per channel rather than a full-table scan.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(BusEvents::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(BusEvents::EventId)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(BusEvents::RoomId).uuid().not_null())
+                    .col(ColumnDef::new(BusEvents::Epoch).big_integer().not_null())
+                    .col(ColumnDef::new(BusEvents::Counter).big_integer().not_null())
+                    .col(ColumnDef::new(BusEvents::Kind).string().not_null())
+                    .col(ColumnDef::new(BusEvents::Delivery).string().not_null())
+                    .col(ColumnDef::new(BusEvents::Target).json().not_null())
+                    .col(ColumnDef::new(BusEvents::CorrelationId).uuid().null())
+                    .col(ColumnDef::new(BusEvents::CoalesceKey).string().null())
+                    .col(ColumnDef::new(BusEvents::Headers).json().not_null())
+                    .col(ColumnDef::new(BusEvents::Payload).blob().not_null())
+                    .col(ColumnDef::new(BusEvents::PeerId).uuid().not_null())
+                    .col(ColumnDef::new(BusEvents::ClientId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(BusEvents::OccurredAtMs)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_bus_events_room_epoch_counter_event_id")
+                    .table(BusEvents::Table)
+                    .col(BusEvents::RoomId)
+                    .col(BusEvents::Epoch)
+                    .col(BusEvents::Counter)
+                    .col(BusEvents::EventId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(BusEvents::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum BusEvents {
+    Table,
+    EventId,
+    RoomId,
+    Epoch,
+    Counter,
+    Kind,
+    Delivery,
+    Target,
+    CorrelationId,
+    CoalesceKey,
+    Headers,
+    Payload,
+    PeerId,
+    ClientId,
+    OccurredAtMs,
+}

--- a/crates/airc-store/src/migration/mod.rs
+++ b/crates/airc-store/src/migration/mod.rs
@@ -17,6 +17,7 @@ mod m20260522_000007_create_account_registry;
 mod m20260522_000008_create_beacons;
 mod m20260522_000009_add_local_identity_card;
 mod m20260523_000010_create_refresh_locks;
+mod m20260526_000011_create_bus_events;
 
 pub struct Migrator;
 
@@ -34,6 +35,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260522_000008_create_beacons::Migration),
             Box::new(m20260522_000009_add_local_identity_card::Migration),
             Box::new(m20260523_000010_create_refresh_locks::Migration),
+            Box::new(m20260526_000011_create_bus_events::Migration),
         ]
     }
 }

--- a/crates/airc-store/tests/bus_router_durable_tier.rs
+++ b/crates/airc-store/tests/bus_router_durable_tier.rs
@@ -1,0 +1,246 @@
+//! Integration proof — the owner-core `EventRouter` against the REAL
+//! SQLite durable tier (§3.5 / §3.8 of
+//! `docs/architecture/AIRC-EVENT-SERVER.md`).
+//!
+//! This is the airc-bus `no-gap cursor` acceptance scenario
+//! (`evicted_pending_durable_is_served_from_sink_not_skipped`) run with
+//! [`airc_store::SqliteDurableSink`] swapped in for
+//! `InMemoryDurableSink`: publish durables, hold them pinned in the ring
+//! while a gate keeps the sink shut, open the gate so write-behind
+//! persists + unpins them, force ring eviction, then attach-from-start
+//! and assert EVERY event is delivered — the evicted ones now coming
+//! from **real SQLite on disk**. It proves the owner-core works against
+//! the production durable tier, not just the in-memory test sink.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::StreamExt;
+use tokio::sync::Notify;
+
+use airc_bus::envelope::{Cursor, DeliveryClass, Envelope, Kind};
+use airc_bus::{
+    BusError, Clock, DurableSink, EventRouter, Filter, InMemoryEpochStore, ManualClock,
+    RouterConfig, SeqSource,
+};
+use airc_core::{ClientId, EventId, PeerId, RoomId};
+use airc_store::SqliteDurableSink;
+
+/// A [`DurableSink`] decorator that delays `append` until a gate opens,
+/// forwarding everything to a real [`SqliteDurableSink`]. Lets the test
+/// hold `Durable` events "evicted-pending" (pinned in the ring, not yet
+/// on disk), then release them so write-behind persists + unpins — after
+/// which ring-capacity pressure evicts them and a later subscriber's
+/// deep-replay must fetch them from SQLite (§3.8 no-gap).
+struct GatedSqliteSink {
+    inner: Arc<SqliteDurableSink>,
+    open: Notify,
+    is_open: AtomicBool,
+}
+
+impl GatedSqliteSink {
+    fn new(inner: Arc<SqliteDurableSink>) -> Self {
+        Self {
+            inner,
+            open: Notify::new(),
+            is_open: AtomicBool::new(false),
+        }
+    }
+
+    fn open(&self) {
+        self.is_open.store(true, Ordering::SeqCst);
+        self.open.notify_waiters();
+    }
+}
+
+#[async_trait]
+impl DurableSink for GatedSqliteSink {
+    async fn append(&self, e: &Envelope) -> Result<(), BusError> {
+        while !self.is_open.load(Ordering::SeqCst) {
+            self.open.notified().await;
+        }
+        self.inner.append(e).await
+    }
+
+    async fn page(
+        &self,
+        channel: RoomId,
+        from_cursor: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.inner.page(channel, from_cursor, limit).await
+    }
+}
+
+/// Deterministic durable envelope with a stable event_id so replayed
+/// copies compare equal across the ring/sink/live legs.
+fn durable(channel: RoomId, marker: u128, text: &str) -> Envelope {
+    Envelope::new(
+        channel,
+        (PeerId::from_u128(1), ClientId::from_u128(1)),
+        Kind::Message,
+        DeliveryClass::Durable,
+        Bytes::copy_from_slice(text.as_bytes()),
+    )
+    .with_event_id(EventId::from_u128(marker))
+}
+
+/// Drain `n` events with a per-event timeout so a missed event fails loud
+/// (a hang) rather than passing trivially.
+async fn take_n<S>(mut stream: S, n: usize) -> Vec<Arc<Envelope>>
+where
+    S: futures::Stream<Item = Arc<Envelope>> + Unpin,
+{
+    let mut out = Vec::with_capacity(n);
+    for _ in 0..n {
+        let next = tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("timed out waiting for an event — a gap/miss would hang here");
+        out.push(next.expect("stream ended early — missing events"));
+    }
+    out
+}
+
+#[tokio::test]
+async fn evicted_pending_durable_is_served_from_real_sqlite_not_skipped() {
+    // Use a file-backed SQLite so the deep-replay genuinely comes off
+    // disk (WAL), not just process memory.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path: &Path = &dir.path().join("bus_events.sqlite");
+    let real = Arc::new(SqliteDurableSink::open_path(path).await.expect("open sink"));
+    let gated = Arc::new(GatedSqliteSink::new(real.clone()));
+
+    let ch = RoomId::from_u128(0xeee);
+
+    // Build the owner-core router directly against the gated REAL sink,
+    // with a tiny ring so eviction bites once durables are persisted.
+    let epoch_store = InMemoryEpochStore::new();
+    let clock = ManualClock::new(1_700_000_000_000);
+    let seq = Arc::new(SeqSource::start(&epoch_store));
+    let r = EventRouter::new(
+        RouterConfig {
+            ring_capacity: 2,
+            ..Default::default()
+        },
+        Arc::new(clock) as Arc<dyn Clock>,
+        seq,
+        gated.clone(),
+    );
+
+    // Publish 6 durables while the sink gate is SHUT: they fan out + ring
+    // but write-behind blocks on append, so all 6 stay pinned in the ring
+    // (the §3.8 floor — the ring grows past its nominal 2 rather than drop
+    // an unpersisted durable).
+    for i in 1..=6u128 {
+        r.publish(durable(ch, i, &format!("m{i}")))
+            .await
+            .expect("publish");
+    }
+    assert_eq!(
+        r.pinned_in_ring(ch),
+        6,
+        "all unpersisted durables pinned — ring exceeds capacity (§3.8 floor)"
+    );
+
+    // Open the gate: write-behind drains into real SQLite, persists + unpins
+    // all 6, and the ring evicts toward capacity. Wait until the sink holds
+    // all 6 (verified via page) and the ring has shrunk.
+    gated.open();
+    let mut waited = 0;
+    loop {
+        let persisted = real.page(ch, None, 100).await.expect("page").len();
+        if persisted >= 6 && r.ring_len(ch) <= 2 {
+            break;
+        }
+        assert!(
+            waited < 5000,
+            "timed out waiting for persistence + eviction"
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        waited += 5;
+    }
+    assert_eq!(
+        real.page(ch, None, 100).await.expect("page").len(),
+        6,
+        "all durables persisted to real SQLite after gate open"
+    );
+    assert!(
+        r.ring_len(ch) <= 2,
+        "ring evicted the now-persisted durables (so 1..=4 are NOT in RAM)"
+    );
+
+    // Attach from the beginning. Events 1..=4 are gone from the ring; they
+    // MUST be served from the SQLite deep-replay leg or they'd be skipped.
+    let stream = r.subscribe(Filter::channel(ch), None);
+    futures::pin_mut!(stream);
+    let got = take_n(&mut stream, 6).await;
+    let markers: Vec<u128> = got.iter().map(|e| e.event_id.0.as_u128()).collect();
+    assert_eq!(
+        markers,
+        vec![1, 2, 3, 4, 5, 6],
+        "evicted-pending durables come from REAL SQLite — none skipped (§3.8 no-gap)"
+    );
+
+    // No-dup at the seam: no further event should be immediately available.
+    let extra = tokio::time::timeout(Duration::from_millis(200), stream.next()).await;
+    assert!(extra.is_err(), "no duplicate at the replay→live seam");
+}
+
+#[tokio::test]
+async fn router_deep_replay_after_cursor_comes_from_sqlite() {
+    // A leaner proof of the same seam: publish past the ring, let everything
+    // persist, then attach with a mid-stream cursor and assert the tail after
+    // the cursor (held only in SQLite, evicted from the tiny ring) arrives in
+    // order with no gap.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path: &Path = &dir.path().join("bus_events.sqlite");
+    let sink = Arc::new(SqliteDurableSink::open_path(path).await.expect("open sink"));
+
+    let ch = RoomId::from_u128(0xabc);
+    let epoch_store = InMemoryEpochStore::new();
+    let clock = ManualClock::new(1_700_000_000_000);
+    let seq = Arc::new(SeqSource::start(&epoch_store));
+    let r = EventRouter::new(
+        RouterConfig {
+            ring_capacity: 2,
+            ..Default::default()
+        },
+        Arc::new(clock) as Arc<dyn Clock>,
+        seq,
+        sink.clone(),
+    );
+
+    // Publish 8 durables; capture the cursor after the 3rd.
+    let mut cursors = Vec::new();
+    for i in 1..=8u128 {
+        let s = r
+            .publish(durable(ch, i, &format!("m{i}")))
+            .await
+            .expect("publish");
+        cursors.push(Cursor::new(s, EventId::from_u128(i)));
+    }
+
+    // Wait until all 8 are in SQLite (and thus mostly evicted from the ring).
+    let mut waited = 0;
+    while sink.page(ch, None, 100).await.expect("page").len() < 8 {
+        assert!(waited < 5000, "timed out waiting for persistence");
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        waited += 5;
+    }
+
+    // Attach strictly after the 3rd event — expect 4..=8 from SQLite deep-replay.
+    let from = cursors[2];
+    let stream = r.subscribe(Filter::channel(ch), Some(from));
+    futures::pin_mut!(stream);
+    let got = take_n(&mut stream, 5).await;
+    let markers: Vec<u128> = got.iter().map(|e| e.event_id.0.as_u128()).collect();
+    assert_eq!(
+        markers,
+        vec![4, 5, 6, 7, 8],
+        "deep-replay strictly after the cursor, in order, from SQLite"
+    );
+}


### PR DESCRIPTION
Vertical 2 of the airc event server (slice 1): the **ORM durable tier**. The owner-core (#1018) shipped with only an in-memory test sink; this gives it real persistence + bounded deep-replay from disk.

## What this adds
- **`bus_events` schema** (`airc-store` migration + entity) — a CLEAN schema for the generic `Envelope`, deliberately NOT `TranscriptEvent`: opaque `payload` BLOB, generational `seq = (epoch, counter)`, `Kind`/`DeliveryClass`/`Target` as text/JSON. Composite index `(room_id, epoch, counter, event_id)` covers the cursor order exactly → `page` is one indexed B-tree range scan, never a full scan.
- **`SqliteDurableSink`** implementing `airc_bus::DurableSink`:
  - single-writer (`max_connections(1)`) + WAL (`synchronous=NORMAL`) — the daemon-owned shape, no write-lock contention, readers never block the writer.
  - `append`: idempotent `ON CONFLICT(event_id) DO NOTHING` (replay-safe, at-least-once).
  - `page`: strictly-after-cursor in generational order `(epoch, counter, event_id)`, **bounded by `limit`** (the trait's large "whole tail" limit clamps to `i64::MAX` — no `usize::MAX` sentinel).
  - `to_active_model`/`from_model` are the **one sanctioned serialize/deserialize copy** (headers→JSON, payload→BLOB, enums→exhaustive text). The hot path stays zero-copy; only the durable boundary pays.
- **Dependency direction**: `airc-store → airc-bus` (airc-bus never depends on airc-store).

## Tests
Unit (real temp/in-memory SQLite): full-envelope round-trip · `(epoch,counter,event_id)` ordering **across epochs** (post-crash epoch sorts after pre-crash even with lower counter) · idempotent re-append · cursor pagination (no dup across pages, respects limit) · same-seq event_id tiebreak · empty-channel · channel isolation · on-disk persistence across reopened handles · exhaustive enum↔text round-trip.

**Integration proof** (`tests/bus_router_durable_tier.rs`): builds a real `airc_bus::EventRouter` on a file-backed `SqliteDurableSink` (via a gate that holds durables pinned-unpersisted), opens the gate so write-behind persists + the tiny ring evicts, then attaches-from-start and asserts all events arrive — the evicted ones served from **real SQLite on disk**, none skipped (§3.8 no-gap). `take_n` has a per-event timeout so a miss hangs/fails loud rather than passing trivially; no-dup-at-seam asserted.

## Gates
Both clippy gates (incl. the no-silent-fallback production gate) + fmt + tests green locally. Out of scope (follow-ups): router-side `await_durable` blocking path + sink-retry; the stale `airc-bus/sink.rs` doc comment referencing `TranscriptEvent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
