### PR TITLE
test(e2e): realistic timeout for process-spawn round-trips (fix macOS flake)

### DIFF
--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -16,6 +16,17 @@ use tempfile::TempDir;
 
 const JOIN_ATTACH_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Deadline for process-spawn round-trips: spawn a real subprocess,
+/// complete the handshake, receive, and print the expected line. The
+/// send is asserted to succeed *before* this wait, so it only bounds the
+/// listener's receive+print — yet at 6s it was the shortest deadline in
+/// the file while being the heaviest path, and flaked intermittently on
+/// loaded macOS CI runners ("did not print within Ns"). These assertions
+/// still require real delivery, so generous headroom removes the
+/// false-negative without weakening the check (matches the 30s the
+/// attach path already uses).
+const SPAWN_ROUNDTRIP_TIMEOUT: Duration = Duration::from_secs(30);
+
 fn airc_core() -> &'static str {
     env!("CARGO_BIN_EXE_airc")
 }
@@ -114,7 +125,7 @@ fn two_airc_core_processes_chat_over_local_fs() {
     let body_arrived = wait_for_line_contains(
         alice_stdout,
         "hello from bob over rust substrate",
-        Duration::from_secs(6),
+        SPAWN_ROUNDTRIP_TIMEOUT,
     );
 
     let _ = alice.kill();
@@ -689,7 +700,7 @@ fn listen_rejects_unenrolled_signer() {
 
     let alice_stderr = alice.stderr.take().expect("alice stderr");
     let saw_rejection =
-        wait_for_line_contains(alice_stderr, "verification failed", Duration::from_secs(6));
+        wait_for_line_contains(alice_stderr, "verification failed", SPAWN_ROUNDTRIP_TIMEOUT);
 
     let _ = alice.kill();
     let _ = alice.wait();
@@ -730,7 +741,7 @@ fn two_airc_core_processes_chat_over_lan_via_sdk_route() {
     let alice_stdout = alice.stdout.take().expect("alice stdout");
     let lines = spawn_line_reader(alice_stdout);
     let listen_line =
-        wait_for_channel_line_contains(&lines, "listening on", Duration::from_secs(6))
+        wait_for_channel_line_contains(&lines, "listening on", SPAWN_ROUNDTRIP_TIMEOUT)
             .expect("alice must print bound LAN address");
     let bound_addr = parse_listening_addr(&listen_line);
 
@@ -757,7 +768,7 @@ fn two_airc_core_processes_chat_over_lan_via_sdk_route() {
     );
 
     let body_arrived =
-        wait_for_channel_line_contains(&lines, "hello over cli sdk lan", Duration::from_secs(6))
+        wait_for_channel_line_contains(&lines, "hello over cli sdk lan", SPAWN_ROUNDTRIP_TIMEOUT)
             .is_some();
 
     let _ = alice.kill();
@@ -792,7 +803,7 @@ fn daemon_msg_and_inbox_use_sdk_attach_path() {
     wait_for_line_contains(
         daemon.stdout.take().expect("daemon stdout"),
         "listening on",
-        Duration::from_secs(6),
+        SPAWN_ROUNDTRIP_TIMEOUT,
     );
 
     let msg = command_for_home(&home)
@@ -817,7 +828,7 @@ fn daemon_msg_and_inbox_use_sdk_attach_path() {
         &home,
         &socket,
         "hello through cli attach",
-        Duration::from_secs(6),
+        SPAWN_ROUNDTRIP_TIMEOUT,
     );
     assert!(
         inbox,


### PR DESCRIPTION
## Why
The process-spawn e2e tests (`crates/airc-cli/tests/e2e.rs`) spawn real subprocesses, perform a send, and wait for the receiver to handshake, receive, and **print** an expected line. The send is asserted to succeed *before* each wait, so the wait only bounds the receiver's receive+print step — yet at **6s** these were the shortest deadlines in the file while being the heaviest paths (full two-process spawn + Ed25519 handshake + receive).

On loaded macOS CI runners that 6s window flakes intermittently. #1019's run hit it on the LAN test:

```
two_airc_core_processes_chat_over_lan_via_sdk_route ... FAILED
panicked at e2e.rs:766: Alice's LAN listener did not print Bob's message within 6s
```

(ubuntu + windows passed in the same run; this is timing/contention, not a logic bug — `bob lan-send` had already succeeded.)

## Fix
Replace the six 6s deadlines (substrate chat, LAN bind + receive, verification-reject, daemon-attach bind + inbox) with a named `SPAWN_ROUNDTRIP_TIMEOUT = 30s` — the same headroom the attach path (`JOIN_ATTACH_TIMEOUT`) already uses.

The assertions still require **real delivery**; a generous deadline only removes the CI-contention false-negative. This is a right-sized deadline, **not** a rerun-paper or a weakened check — if delivery genuinely broke, 30s would still fail.

## Impact
Fixes the latent macOS flake on `rust-rewrite` for **every** subsequent PR (not just #1019). Test-only change; compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
