### PR TITLE
fix(reliability): LAN send-flush + lan-listen subscribe order + daemon-shutdown hang

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -521,9 +521,20 @@ pub async fn run_lan_listen(
     for peer in &peers {
         airc.enrol_volatile_peer(peer)?;
     }
+    // Subscribe BEFORE binding the listener. `listen_lan` starts the LAN
+    // frame-ingest task, which fans each received frame into `live_tx`
+    // (see `append_received_frame`). `subscribe()` is a live broadcast
+    // receiver with no backlog for a not-yet-created subscriber, and
+    // `lan-listen` does not replay the store — so a frame that arrives in
+    // the gap between bind and subscribe is fanned out to no receiver and
+    // lost to this consumer (still persisted, just never printed).
+    // Creating the receiver first guarantees it predates any ingested
+    // frame, closing an intermittent CI frame-drop ("listener did not
+    // print the message"). subscribe() does not depend on the listener
+    // being bound.
+    let mut stream = airc.subscribe().await?;
     let actual = airc.listen_lan(bind).await?;
     println!("listening on {actual} (peer_id {}) …", airc.peer_id());
-    let mut stream = airc.subscribe().await?;
     print_event_stream_until_signal(&mut stream).await
 }
 

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -133,7 +133,7 @@ fn two_airc_core_processes_chat_over_local_fs() {
 
     assert!(
         body_arrived,
-        "Alice's stdout did not contain Bob's message within 6s — substrate e2e is broken"
+        "Alice's stdout did not contain Bob's message within the receive timeout — substrate e2e is broken"
     );
 }
 
@@ -776,7 +776,7 @@ fn two_airc_core_processes_chat_over_lan_via_sdk_route() {
 
     assert!(
         body_arrived,
-        "Alice's LAN listener did not print Bob's message within 6s"
+        "Alice's LAN listener did not print Bob's message within the receive timeout"
     );
 }
 

--- a/crates/airc-cli/tests/e2e.rs
+++ b/crates/airc-cli/tests/e2e.rs
@@ -846,7 +846,17 @@ fn daemon_msg_and_inbox_use_sdk_attach_path() {
         .output()
         .expect("stop must spawn");
     assert!(stop.status.success(), "stop failed");
-    let _ = daemon.wait();
+
+    // The daemon MUST exit promptly after a successful `stop`. Bound the
+    // wait: a shutdown regression then fails fast here instead of wedging
+    // the test binary (and CI) until the job timeout — a lost shutdown
+    // notification once hung this for the full 6h ceiling.
+    let exited = wait_for_process_exit(&mut daemon, SPAWN_ROUNDTRIP_TIMEOUT);
+    if !exited {
+        let _ = daemon.kill();
+        let _ = daemon.wait();
+    }
+    assert!(exited, "daemon did not exit after a successful stop");
 }
 
 #[test]
@@ -962,6 +972,26 @@ fn wait_for_channel_line_contains(
                     return None;
                 }
             }
+        }
+    }
+}
+
+/// Poll `child.try_wait()` until the process exits or the deadline
+/// passes; returns true if it exited. Replaces an unbounded `wait()` so
+/// a process that never exits fails the test fast instead of hanging the
+/// whole binary (and CI) indefinitely.
+fn wait_for_process_exit(child: &mut std::process::Child, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    return false;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(_) => return false,
         }
     }
 }

--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -80,10 +80,21 @@ pub async fn run(state: Arc<DaemonState>, socket_path: PathBuf) -> Result<(), Da
     cleanup_stale_socket(&socket_path).map_err(DaemonError::StaleSocket)?;
     let listener = IpcListener::bind(&socket_path).await?;
 
+    // Keep ONE `Notified` future alive across loop iterations. `select!`
+    // otherwise creates and drops a fresh `notified()` each turn, leaving
+    // a window between iterations where no waiter is registered. `Stop`
+    // signals shutdown with `notify_waiters()`, which wakes only the
+    // waiters registered at that instant and stores no permit — so a
+    // notify landing in that window is LOST and the daemon never exits
+    // (`accept()` then blocks forever waiting for a connection that never
+    // comes). A persistently-registered pinned waiter cannot miss it.
+    let shutdown = state.shutdown.notified();
+    tokio::pin!(shutdown);
+
     loop {
         tokio::select! {
             biased;
-            _ = state.shutdown.notified() => {
+            _ = &mut shutdown => {
                 break;
             }
             accept = listener.accept() => {

--- a/crates/airc-daemon/src/state.rs
+++ b/crates/airc-daemon/src/state.rs
@@ -188,9 +188,14 @@ impl DaemonState {
     pub fn spawn_trust_refresher(self: &Arc<Self>, root: PathBuf) {
         let state = self.clone();
         tokio::spawn(async move {
+            // Pin one `Notified` future across iterations so a
+            // `notify_waiters()` shutdown signal can't be lost in the gap
+            // between `select!` turns (see `server::run`).
+            let shutdown = state.shutdown.notified();
+            tokio::pin!(shutdown);
             loop {
                 tokio::select! {
-                    _ = state.shutdown.notified() => break,
+                    _ = &mut shutdown => break,
                     _ = tokio::time::sleep(TRUST_REFRESH_INTERVAL) => {
                         if let Err(error) = state.refresh_trust_root(&root).await {
                             StderrJsonDiagnosticSink.emit(

--- a/crates/airc-transport/src/lan_tcp/adapter/connection.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/connection.rs
@@ -17,7 +17,7 @@ use airc_protocol::Frame;
 
 use crate::lan_tcp::adapter::dispatch::dispatch_to_subscribers;
 use crate::lan_tcp::adapter::error::LanTcpError;
-use crate::lan_tcp::adapter::inner::{Inner, MAX_FRAME_BYTES, OUTBOUND_CHANNEL_DEPTH};
+use crate::lan_tcp::adapter::inner::{Inner, Outbound, MAX_FRAME_BYTES, OUTBOUND_CHANNEL_DEPTH};
 use crate::lan_tcp::cert::extract_ed25519_pubkey;
 
 /// Post-handshake server-side connection handler: bind the peer
@@ -91,7 +91,7 @@ async fn install_and_spawn_loops<R, W>(
     R: tokio::io::AsyncRead + Send + Unpin + 'static,
     W: tokio::io::AsyncWrite + Send + Unpin + 'static,
 {
-    let (outbound_tx, outbound_rx) = mpsc::channel::<Vec<u8>>(OUTBOUND_CHANNEL_DEPTH);
+    let (outbound_tx, outbound_rx) = mpsc::channel::<Outbound>(OUTBOUND_CHANNEL_DEPTH);
     // Install synchronously — when this function returns, the
     // connection IS ready to receive sends.
     inner.connections.lock().await.insert(peer_id, outbound_tx);
@@ -143,18 +143,26 @@ where
 }
 
 /// Write loop: drain the outbound channel, length-prefix the
-/// already-validated payload, write framed bytes to TLS.
+/// already-validated payload, write framed bytes to TLS, then signal
+/// the sender that the frame is flushed to the wire.
 ///
 /// The payload is pre-serialized and size-checked by
 /// `LanTcpAdapter::send` before it lands in the channel — by the
 /// time it reaches this loop the bytes are known-valid, so the
 /// only failure mode is a dead socket (which terminates the loop).
 /// No silent drops.
-async fn write_loop<W>(mut write_half: W, mut outbound_rx: mpsc::Receiver<Vec<u8>>)
+///
+/// The `flushed` signal is fired ONLY after a successful `flush()`, so a
+/// caller awaiting it knows the bytes are in the kernel send buffer and
+/// will survive the caller exiting. On any write/flush error the loop
+/// returns and drops the remaining `flushed` senders — their awaiting
+/// `send()` calls observe the closed channel and report non-delivery
+/// rather than a false success.
+async fn write_loop<W>(mut write_half: W, mut outbound_rx: mpsc::Receiver<Outbound>)
 where
     W: tokio::io::AsyncWrite + Send + Unpin + 'static,
 {
-    while let Some(payload) = outbound_rx.recv().await {
+    while let Some(Outbound { payload, flushed }) = outbound_rx.recv().await {
         // Defense-in-depth assertion: the sender already enforced
         // this, but if a future regression bypasses pre-validation
         // we'd rather fail loudly here than silently truncate.
@@ -174,5 +182,8 @@ where
         if write_half.flush().await.is_err() {
             return;
         }
+        // Flushed to the wire — release the sender. A dropped receiver
+        // (caller no longer waiting) is fine: delivery still happened.
+        let _ = flushed.send(());
     }
 }

--- a/crates/airc-transport/src/lan_tcp/adapter/inner.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/inner.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, oneshot, Mutex};
 
 use airc_core::PeerId;
 use airc_protocol::{Frame, PeerKeyRegistry, PeerKeypair, Subscription};
@@ -30,15 +30,27 @@ pub(super) const OUTBOUND_CHANNEL_DEPTH: usize = 256;
 /// Subscriber inbound channel depth — matches local-fs.
 pub(super) const SUBSCRIBER_CHANNEL_DEPTH: usize = 64;
 
-/// Active connection's sender half — write-task receives the
-/// serialized payload (no length prefix; the write loop adds it)
-/// from this and pushes the framed bytes onto the TLS stream.
-/// Carrying pre-validated bytes rather than `Frame` ensures
-/// `send()` can return synchronously if the frame is oversized or
-/// unserializable — no post-acceptance silent drops in the write
-/// loop. (Closes grievance §9 "Silent drop after acceptance is not
-/// acceptable" / Codex audit 2026-05-19.)
-pub(super) type OutboundTx = mpsc::Sender<Vec<u8>>;
+/// One queued outbound payload plus a completion signal the write loop
+/// fires AFTER it has flushed the bytes to the TLS stream.
+///
+/// `send()` awaits `flushed` so it returns only once the frame is on the
+/// wire (in the kernel send buffer), not merely enqueued. Without this a
+/// one-shot caller — e.g. the `lan-send` CLI — could enqueue, see `Ok`,
+/// print "sent", and exit, aborting the background write task before it
+/// flushed, silently losing the frame. (Enqueue-only `Ok` was a real
+/// intermittent frame drop under load.) The payload is pre-validated
+/// bytes (length-checked + serialized in `send()`), so the write loop
+/// still has no post-acceptance failure mode beyond a dead socket —
+/// grievance §9 / Codex audit 2026-05-19.
+pub(super) struct Outbound {
+    pub(super) payload: Vec<u8>,
+    pub(super) flushed: oneshot::Sender<()>,
+}
+
+/// Active connection's sender half — the write task receives
+/// [`Outbound`] items from this and pushes the framed bytes onto the
+/// TLS stream, signalling `flushed` once each is on the wire.
+pub(super) type OutboundTx = mpsc::Sender<Outbound>;
 
 /// One subscriber's filtered inbound channel + matching predicate.
 pub(super) struct SubscriberHandle {

--- a/crates/airc-transport/src/lan_tcp/adapter/mod.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/mod.rs
@@ -45,7 +45,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::stream::Stream;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio_rustls::{TlsAcceptor, TlsConnector};
 
 use airc_core::PeerId;
@@ -53,7 +53,7 @@ use airc_protocol::{Frame, PeerKeyRegistry, PeerKeypair, Subscription};
 
 use crate::lan_tcp::adapter::connection::{handle_client_connection, handle_server_connection};
 use crate::lan_tcp::adapter::inner::{
-    Inner, OutboundTx, SubscriberHandle, MAX_FRAME_BYTES, SUBSCRIBER_CHANNEL_DEPTH,
+    Inner, Outbound, OutboundTx, SubscriberHandle, MAX_FRAME_BYTES, SUBSCRIBER_CHANNEL_DEPTH,
 };
 use crate::lan_tcp::tls_config::{build_client_config, build_server_config};
 use crate::transport::{FrameStream, Transport};
@@ -226,18 +226,39 @@ impl Transport for LanTcpAdapter {
                 .collect()
         };
 
-        // Broadcast: send to each connected peer. Per-peer failures
-        // tolerated (peer may have dropped between snapshot + send;
-        // the read loop will GC the dead entry). Success if at least
-        // one peer received.
-        let mut delivered_any = false;
+        // Broadcast: enqueue to each connected peer's write loop, each
+        // with a `flushed` oneshot. Per-peer failures tolerated (peer may
+        // have dropped between snapshot + send; the read loop GCs the dead
+        // entry).
+        let mut pending: Vec<oneshot::Receiver<()>> = Vec::new();
         let mut last_error: Option<LanTcpError> = None;
         for (_peer, tx) in targets {
-            match tx.send(payload.clone()).await {
-                Ok(()) => delivered_any = true,
+            let (flushed, flushed_rx) = oneshot::channel();
+            match tx
+                .send(Outbound {
+                    payload: payload.clone(),
+                    flushed,
+                })
+                .await
+            {
+                Ok(()) => pending.push(flushed_rx),
                 Err(_closed) => {
                     last_error = Some(LanTcpError::NoActivePeers);
                 }
+            }
+        }
+
+        // Await flush-to-wire, NOT merely enqueue. `send()` returns only
+        // once at least one peer's write loop confirmed the frame is on
+        // the wire — so a caller that exits immediately after (the
+        // `lan-send` CLI) cannot lose the frame to its own teardown. A
+        // dropped sender (write loop hit a dead socket) resolves to Err
+        // and counts as non-delivery.
+        let mut delivered_any = false;
+        for flushed_rx in pending {
+            match flushed_rx.await {
+                Ok(()) => delivered_any = true,
+                Err(_dropped) => last_error = Some(LanTcpError::NoActivePeers),
             }
         }
         if delivered_any {


### PR DESCRIPTION
Three root-cause concurrency fixes to the substrate, all surfaced while landing the durable tier and chased down with evidence (local stress repro + store probe), not guesses. They land together because the daemon hang (#2) was blocking this PR's own CI, and the LAN fixes aren't yet on `rust-rewrite`, so they can't be validated separately without circular flakiness.

## 1. LAN `send()` returned before flushing to the wire — the real frame-drop *(root cause)*
`LanTcpAdapter::send` enqueued the payload into the per-connection outbound channel and returned `Ok` once **queued** — the TLS write+flush happens later in a background `write_loop` task. So `lan-send` enqueued, saw `Ok`, printed "sent", and **exited** — and process teardown aborted `write_loop` before it flushed, silently dropping the frame. Receiver never saw it (not persisted, no verify error) while the sender reported success.

Diagnosed by reproducing locally under 8×-parallel load (~1 drop in 24) and probing Alice's store on failure: `persisted=false`, Alice stderr empty, Bob "sent" — i.e. the frame never hit the wire, not a receive/verify issue.

**Fix:** each outbound item carries a `flushed` oneshot the write loop fires *after* `flush()`; `send()` awaits it, returning only once the bytes are in the kernel send buffer (which survives the caller exiting). Write/flush error → dropped sender → `send()` reports non-delivery, never a false `Ok`. **Validated: 64/64 parallel-stress round-trips, zero drops** (was ~8 expected without the fix).

## 2. LAN `lan-listen` subscribed after binding *(adjacent latent race, defense-in-depth)*
`run_lan_listen` created its broadcast subscriber *after* `listen_lan`. A frame ingested in that window would be fanned out to a not-yet-created (backlog-free) receiver and lost. Not the cause of the observed flake (that was #1, send-side — this window isn't hit by the test, which sends only after "listening on"), but a real race in live usage. **Fix:** subscribe before binding.

## 3. Daemon shutdown lost-notification hang *(separate real bug)*
`Stop` signals via `Notify::notify_waiters()`, which wakes only waiters registered at that instant and stores no permit. The server accept loop waits in `tokio::select!`, which drops+recreates the `notified()` future each turn — so a notify landing in the between-turns gap is **lost**, `accept()` blocks forever, the daemon never exits. This is the ubuntu job that ran to GitHub's **6h ceiling** (a `cancelled` job, not a test failure). Means `airc stop` can intermittently fail to stop the daemon. **Fix:** pin one `Notified` future outside the loop so the waiter stays registered (same for the trust-refresher loop).

## Plus: test hardening
The e2e daemon test's post-stop `daemon.wait()` was **unbounded** — that's why #3 became a 6h hang instead of a fast failure. Now bounded with a kill fallback + an assertion that the daemon exited. (And the process-spawn e2e waits were already raised 6s→30s via #1020; the now-stale "within 6s" assert strings are corrected here.)

## Verification
Transport adapter tests 46/46 · e2e 13/13 · LAN stress 64/64 · both clippy gates + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
