### PR TITLE
fix(cli): airc work state review uses Command::current_dir, not gh -C (card a4fe899f)

### DIFF
--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -574,14 +574,17 @@ async fn open_pr_and_link(
     // gh pr create — --fill takes title/body from commits, so a clean
     // workflow (claim → commit → state review) produces a PR titled
     // from the last commit. Head is the worktree's current branch.
+    //
+    // Card a4fe899f: `gh` does NOT accept `-C` (that's git's flag).
+    // The cwd has to be set via `Command::current_dir(...)` so gh's
+    // own repo-resolution (which scans `git remote get-url origin`
+    // from cwd) picks the worktree's branch. Without this, gh
+    // silently ran against whatever the shell's cwd was at invoke
+    // time — usually the wrong repo — and the whole Review-state →
+    // PR-link pipeline failed (best-effort warning was swallowed).
     let create_out = std::process::Command::new("gh")
-        .args([
-            "-C",
-            &worktree_str,
-            "pr",
-            "create",
-            "--fill",
-        ])
+        .current_dir(&worktree_str)
+        .args(["pr", "create", "--fill"])
         .output()?;
     if !create_out.status.success() {
         return Err(format!(
@@ -714,10 +717,12 @@ fn git_rev_parse_branch(worktree: &str) -> Result<String, Box<dyn std::error::Er
 }
 
 fn gh_default_branch(worktree: &str) -> Result<String, Box<dyn std::error::Error>> {
+    // Card a4fe899f: `gh` does NOT accept `-C`; set cwd via
+    // `Command::current_dir(...)` so `gh repo view` resolves the
+    // worktree's origin remote, not the shell cwd's.
     let out = std::process::Command::new("gh")
+        .current_dir(worktree)
         .args([
-            "-C",
-            worktree,
             "repo",
             "view",
             "--json",


### PR DESCRIPTION
## What this fixes

Card 820629e9 shipped `gh -C <worktree> pr create --fill` and `gh -C <worktree> repo view --json defaultBranchRef` in `airc-cli/src/work_commands.rs`. **`gh` does NOT accept `-C`** — that's `git`'s flag. Both invocations failed at parse time.

Because the Review-state → PR pipeline runs as best-effort (warning printed to stderr, state transition not undone), the failures were silently swallowed: no PR opened, `card.pull_request` not populated, and ad7e100b Sub-C's auto-spawn of the sibling review card never fired (it only runs after the link succeeds).

Net effect: every `airc work state X review` since 820629e9 left the card in Review state with no PR, and the agent had no signal the workflow had broken. Both agents' sessions ahead of this commit ran cards through close without ever opening PRs, partly because of this.

## Fix

Replace `gh -C <path>` with `Command::current_dir(...)` on both gh invocations. `gh`'s repo resolver scans `git remote get-url origin` from cwd, so setting cwd correctly is what makes it target the worktree's branch.

Verified by inspection: `git` sites at lines 293/324/704 still use `-C` correctly (that IS git's syntax). Only the two `gh` sites changed.

## Bootstrap exception

This PR is opened **manually** via `gh pr create` from the worktree, NOT via `airc work state review` — because `airc work state review`'s `gh pr create` invocation is exactly what we're fixing. Once this merges, the auto-PR flow works for every subsequent card.

## Substrate-attribution note

Per peer cdff6a9d's card a1b4552a (filed during this fix): the claim for a4fe899f surfaces as attributed to cdff6a9d on the substrate board, because home resolution from inside `~/.airc/worktrees/<short>/` lands at `~/.airc` (machine-account scope) which has cdff6a9d's identity. Git author attribution is Joel's email on both peer scopes so the PR-level author is correct; the substrate-level mis-attribution is tracked as a1b4552a and is a separate fix.

## Validation plan post-merge

Take another card (303f2384 P0 — restrict `--no-lease-required`) using the now-working state-review path. Confirm `gh pr create` fires, the card's `pull_request` field populates via `PullRequestLinked`, and ad7e100b Sub-C auto-spawns the review card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)