### PR TITLE
fix(cli): default_home_dir skips machine-account ~/.airc + resolves to main working tree from a worktree (card a1b4552a)

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -53,18 +53,82 @@ pub fn default_home_dir() -> PathBuf {
 }
 
 fn default_home_dir_for(cwd: &Path) -> PathBuf {
+    let machine_account = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(|h| PathBuf::from(h).join(".airc"));
+    default_home_dir_for_with(cwd, machine_account.as_deref(), &git_main_working_tree)
+}
+
+/// Card a1b4552a — pure-function half of the resolution so tests can
+/// drive it with synthetic paths instead of needing a real `$HOME`
+/// + git repo. `machine_account_home` is the path we MUST NOT resolve
+/// to (typically `$HOME/.airc`); `git_main_working_tree_fn` resolves
+/// the main working tree of a git checkout from any of its
+/// worktrees (production: shells `git rev-parse --git-common-dir`).
+fn default_home_dir_for_with(
+    cwd: &Path,
+    machine_account_home: Option<&Path>,
+    git_main_working_tree_fn: &dyn Fn(&Path) -> Option<PathBuf>,
+) -> PathBuf {
     for ancestor in cwd.ancestors() {
-        if ancestor
+        let matches_dotairc = ancestor
             .file_name()
             .and_then(|name| name.to_str())
-            .is_some_and(|name| name == ".airc")
-        {
-            return ancestor.to_path_buf();
+            .is_some_and(|name| name == ".airc");
+        if !matches_dotairc {
+            continue;
         }
+        // Card a1b4552a: SKIP the machine-account home itself when
+        // walking ancestors. `~/.airc` is a SYSTEM-LEVEL airc state
+        // directory holding the singleton machine-account identity +
+        // the daemon socket — not a per-project agent scope. Agents
+        // who `cd ~/.airc/worktrees/<short>/` (the d1b2798d auto-spawn
+        // workflow) would otherwise resolve home here and silently
+        // borrow the machine-account's identity, attributing their
+        // actions to whoever owns the singleton row. Reproducibly
+        // observed today: peer 9bb24964 claiming cards from a
+        // spawned worktree → board shows the claims under peer
+        // cdff6a9d (machine-account-owner) instead.
+        if Some(ancestor) == machine_account_home {
+            continue;
+        }
+        return ancestor.to_path_buf();
     }
-    git_toplevel(cwd)
+    // Card a1b4552a: when cwd is inside a git worktree spawned by
+    // `airc work claim` (worktrees live under `~/.airc/worktrees/`),
+    // the canonical project scope is the MAIN repo's `.airc`, not
+    // the worktree's own (worktrees rarely contain their own `.airc`).
+    // `git rev-parse --git-common-dir` points at the MAIN repo's
+    // `.git/` for any worktree; its parent is the main working tree.
+    git_main_working_tree_fn(cwd)
         .map(|root| root.join(".airc"))
+        .or_else(|| git_toplevel(cwd).map(|root| root.join(".airc")))
         .unwrap_or_else(|| cwd.join(".airc"))
+}
+
+fn git_main_working_tree(cwd: &Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    let common_dir = text.trim();
+    if common_dir.is_empty() {
+        return None;
+    }
+    let common_path = PathBuf::from(common_dir);
+    let abs = if common_path.is_absolute() {
+        common_path
+    } else {
+        cwd.join(common_path).canonicalize().ok()?
+    };
+    // common dir is `<main-working-tree>/.git`; parent is the main
+    // working tree.
+    abs.parent().map(|p| p.to_path_buf())
 }
 
 fn git_toplevel(cwd: &Path) -> Option<PathBuf> {
@@ -478,6 +542,64 @@ mod tests {
             actual.canonicalize().unwrap(),
             expected.canonicalize().unwrap()
         );
+    }
+
+    #[test]
+    fn default_home_skips_machine_account_home_when_inside_worktrees_subdir() {
+        // Card a1b4552a — the leak we caught live today. Without this
+        // guard an agent who `cd ~/.airc/worktrees/<short>/` per the
+        // d1b2798d auto-spawn workflow would resolve home to ~/.airc
+        // and borrow the machine-account identity. Test pins that
+        // ancestor walk SKIPS the machine-account ~/.airc and falls
+        // through to git_main_working_tree (the main repo's .airc).
+        use super::default_home_dir_for_with;
+        use std::path::{Path, PathBuf};
+        let machine_account = PathBuf::from("/Users/test/.airc");
+        let cwd = machine_account.join("worktrees").join("abc12345");
+        // Stub git_main_working_tree_fn to a known main repo working tree.
+        let main_repo = PathBuf::from("/Users/test/Development/airc");
+        let stub = |_: &Path| -> Option<PathBuf> { Some(main_repo.clone()) };
+        let resolved =
+            default_home_dir_for_with(&cwd, Some(machine_account.as_path()), &stub);
+        assert_eq!(
+            resolved,
+            main_repo.join(".airc"),
+            "must NOT resolve to machine-account ~/.airc when cwd is under its worktrees dir",
+        );
+    }
+
+    #[test]
+    fn default_home_still_resolves_project_scope_when_not_under_machine_account() {
+        // Sanity: a nested cwd that has an enclosing project .airc that
+        // is NOT the machine-account home resolves correctly (regression
+        // guard — we don't want the fix above to skip legitimate
+        // project scopes too).
+        use super::default_home_dir_for_with;
+        use std::path::{Path, PathBuf};
+        let machine_account = PathBuf::from("/Users/test/.airc");
+        let root = tempfile::TempDir::new().unwrap();
+        let scope = root.path().join(".airc");
+        let nested = scope.join("debug");
+        std::fs::create_dir_all(&nested).unwrap();
+        let stub = |_: &Path| -> Option<PathBuf> { None };
+        let resolved =
+            default_home_dir_for_with(&nested, Some(machine_account.as_path()), &stub);
+        assert_eq!(resolved, scope);
+    }
+
+    #[test]
+    fn default_home_falls_through_to_cwd_airc_when_nothing_else_resolves() {
+        // Final fallback: no ancestor .airc, no git context — cwd's
+        // own .airc is the answer. Pre-existing behaviour, pinned so
+        // the refactor preserves it.
+        use super::default_home_dir_for_with;
+        use std::path::{Path, PathBuf};
+        let root = tempfile::TempDir::new().unwrap();
+        let cwd = root.path().join("standalone");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let stub = |_: &Path| -> Option<PathBuf> { None };
+        let resolved = default_home_dir_for_with(&cwd, None, &stub);
+        assert_eq!(resolved, cwd.join(".airc"));
     }
 
     #[test]


### PR DESCRIPTION
Closes card a1b4552a — the home-resolution leak caught live 3 times in one session.

Peer 9bb24964 claiming cards from spawned worktrees under ~/.airc/worktrees/<short>/ had their claims silently attributed to peer cdff6a9d (machine-account-owner) because default_home_dir_for() walked ancestors, found ~/.airc, and returned it as the project scope. ~/.airc is system-level (singleton machine-account identity + daemon socket), not a per-project agent scope.

Two layered fixes:
1. Ancestor walk skips the machine-account home itself.
2. When cwd is inside a git worktree, use `git rev-parse --git-common-dir` parent as the main working tree, so the airc scope resolves to the main repo's .airc (which has the agent's identity).

Refactored pure resolution into default_home_dir_for_with() so tests don't need real $HOME/git context. 3 new unit tests + 2 existing pin the leak fix, project-scope regression, and the fall-through baseline.

After this lands, multi-agent-per-project worktree workflows attribute correctly. Sister to 8384cc18 (multi-identity-per-scope) and 14b4ce5e (universal handle binding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)