### PR TITLE
feat(cli): cross-sandbox daemon discovery — sandboxed agents attach to project daemon (card 282850c2)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -107,7 +107,7 @@ pub async fn run_doctrine_publish(
     let version = short_content_hash(body.as_bytes());
 
     let socket = crate::cli::default_socket_path_in(home);
-    ensure_daemon_running(home, socket.clone(), Vec::new()).await?;
+    let socket = ensure_daemon_running(home, socket, Vec::new()).await?;
     let airc = Airc::attach(home, socket).await?;
     airc.publish_room_doctrine(body.clone(), version.clone())
         .await?;
@@ -152,7 +152,7 @@ pub async fn run_join(home: &Path, room: Option<String>) -> Result<(), Box<dyn s
     // Start the machine-singular daemon and attach: join, heartbeat, and
     // the live feed all route through the daemon's router (one path).
     let socket = crate::cli::default_socket_path_in(home);
-    ensure_daemon_running(home, socket.clone(), Vec::new()).await?;
+    let socket = ensure_daemon_running(home, socket, Vec::new()).await?;
     let airc = Airc::attach(home, socket.clone()).await?;
     let runtime_context = crate::runtime_context::RuntimeContext::current();
     match room {
@@ -285,20 +285,58 @@ pub fn run_version() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Make sure a daemon serving `home` is reachable; return the socket
+/// the caller should attach to.
+///
+/// The returned socket is USUALLY equal to `socket` — every agent
+/// resolving the same `home` finds the existing daemon on the same
+/// socket. For sandboxed agents (Codex etc.) whose home-resolved
+/// socket has no daemon, the cross-sandbox discovery directory
+/// (card 282850c2) is consulted and we route to the project's
+/// actual daemon instead of spawning a competing orphan in the
+/// agent's tmpdir. If neither path finds an existing daemon, a fresh
+/// one is spawned at `socket` and announced for future agents.
 pub async fn ensure_daemon_running(
     home: &Path,
     socket: PathBuf,
     _peers: Vec<PeerSpec>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    // 1. Fast path: home-resolved socket already has a current daemon.
     let client = DaemonClient::new(socket.clone());
     if let Ok(status) = client.status_with_timeout(Duration::from_millis(250)).await {
         if daemon_status_is_current(&status) {
-            return Ok(());
+            return Ok(socket);
         }
         let _ = client.stop().await;
         wait_for_daemon_exit(&client, Duration::from_secs(3)).await;
     }
 
+    // 2. Card 282850c2: no daemon at the home-resolved socket. Before
+    // spawning, consult cross-sandbox discovery for a daemon serving
+    // the SAME project root. Sandboxed agents whose `$HOME` was
+    // forced into a tmpdir would otherwise orphan a fresh daemon
+    // every invocation. We only auto-attach when the discovered
+    // daemon's `home` matches ours — different homes mean different
+    // identities, and attaching across them would silently borrow
+    // the wrong agent's keys (card a1b4552a was the prior class of
+    // this kind of attribution leak). In practice the Codex case
+    // DOES match: both agents resolve home from the same project
+    // root, so the home values agree.
+    let project_root = home.parent().map(Path::to_path_buf);
+    if let Some(ref pr) = project_root {
+        if let Some(discovered) = crate::discovery::find_for_project(pr) {
+            if discovered.home == home {
+                let alt = DaemonClient::new(discovered.socket.clone());
+                if let Ok(status) = alt.status_with_timeout(Duration::from_millis(250)).await {
+                    if daemon_status_is_current(&status) {
+                        return Ok(discovered.socket);
+                    }
+                }
+            }
+        }
+    }
+
+    // 3. Spawn a fresh daemon at the home-resolved socket.
     std::fs::create_dir_all(home)?;
     let log = home.join("airc-daemon.log");
     let stdout = std::fs::OpenOptions::new()
@@ -318,9 +356,10 @@ pub async fn ensure_daemon_running(
         .stdout(Stdio::from(stdout))
         .stderr(Stdio::from(stderr));
     detach_daemon(&mut command);
-    command.spawn()?;
+    let child = command.spawn()?;
+    let daemon_pid = child.id();
 
-    let client = DaemonClient::new(socket);
+    let client = DaemonClient::new(socket.clone());
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         if client
@@ -328,7 +367,12 @@ pub async fn ensure_daemon_running(
             .await
             .is_ok()
         {
-            return Ok(());
+            // 4. Card 282850c2: announce so a sandboxed agent
+            // attaching later finds this daemon instead of orphaning
+            // a new one. Best-effort — if the announcement fails,
+            // the normal singleton-per-home model still works.
+            announce_running_daemon(home, &socket, project_root.as_deref(), daemon_pid).await;
+            return Ok(socket);
         }
         if Instant::now() >= deadline {
             break;
@@ -336,6 +380,35 @@ pub async fn ensure_daemon_running(
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
     Err(format!("daemon did not become ready; see {}", log.display()).into())
+}
+
+/// Read `peer_id`/`build` from the freshly-ready daemon and write a
+/// discovery entry. Called from `ensure_daemon_running` after the
+/// readiness ping succeeds; failure is silent.
+async fn announce_running_daemon(
+    home: &Path,
+    socket: &Path,
+    project_root: Option<&Path>,
+    pid: u32,
+) {
+    let client = DaemonClient::new(socket.to_path_buf());
+    let Ok(status) = client.status_with_timeout(Duration::from_millis(250)).await else {
+        return;
+    };
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let entry = crate::discovery::DiscoveredDaemon {
+        socket: socket.to_path_buf(),
+        home: home.to_path_buf(),
+        project_root: project_root.map(Path::to_path_buf),
+        peer_id: status.peer_id,
+        pid,
+        started_at_ms: now_ms,
+        build: status.build_commit.unwrap_or_else(|| "unknown".to_string()),
+    };
+    let _ = crate::discovery::announce(&entry);
 }
 
 fn daemon_status_is_current(status: &airc_ipc::StatusResponse) -> bool {
@@ -504,7 +577,7 @@ fn canonical_machine_account_home() -> Option<PathBuf> {
 /// daemon's router — the only same-machine path (no more `frames.jsonl`).
 pub(crate) async fn attached_airc(home: &Path) -> Result<Airc, Box<dyn std::error::Error>> {
     let socket = crate::cli::default_socket_path_in(home);
-    ensure_daemon_running(home, socket.clone(), Vec::new()).await?;
+    let socket = ensure_daemon_running(home, socket, Vec::new()).await?;
     Ok(Airc::attach(home, socket).await?)
 }
 
@@ -730,7 +803,7 @@ pub async fn run_msg(
     socket: PathBuf,
     text: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    ensure_daemon_running(home, socket.clone(), Vec::new()).await?;
+    let socket = ensure_daemon_running(home, socket, Vec::new()).await?;
     sync_daemon_peers_for_current_rooms(home, socket.clone()).await?;
     let airc = Airc::attach(home, socket).await?;
     let current = airc.current_room().await?;
@@ -762,7 +835,7 @@ pub async fn run_inbox(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let airc = match socket {
         Some(socket) => {
-            ensure_daemon_running(home, socket.clone(), Vec::new()).await?;
+            let socket = ensure_daemon_running(home, socket, Vec::new()).await?;
             Airc::attach(home, socket).await?
         }
         None => attached_airc(home).await?,

--- a/crates/airc-cli/src/discovery.rs
+++ b/crates/airc-cli/src/discovery.rs
@@ -115,7 +115,10 @@ pub fn forget(project_root_or_home: &Path) {
 /// otherwise sets errno (ESRCH for dead, EPERM for live-but-unowned).
 /// We treat EPERM as "alive" because for our purposes a daemon owned
 /// by another OS user is still "running"; the per-UID discovery dir
-/// keeps such daemons out of our view in the first place.
+/// keeps such daemons out of our view in the first place. errno is
+/// read via `std::io::Error::last_os_error().raw_os_error()` for
+/// cross-platform compatibility — direct `libc::__error()` access
+/// is macOS-specific (Linux uses `__errno_location`).
 fn pid_alive(pid: u32) -> bool {
     if pid == 0 {
         return false;
@@ -126,11 +129,7 @@ fn pid_alive(pid: u32) -> bool {
     if res == 0 {
         return true;
     }
-    // errno == EPERM means the process exists but we can't signal it.
-    // SAFETY: errno is a thread-local int; reading it after a libc call
-    // is well-defined.
-    let errno = unsafe { *libc::__error() };
-    errno == libc::EPERM
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
 }
 
 /// Read every `.json` file in the discovery dir, drop the ones whose

--- a/crates/airc-cli/src/discovery.rs
+++ b/crates/airc-cli/src/discovery.rs
@@ -1,0 +1,257 @@
+//! Daemon discovery via a shared `/tmp/airc-discovery-<uid>/` directory.
+//!
+//! Card 282850c2. The daemon socket lives inside `machine_account_home(home)`
+//! — typically `$HOME/.airc/daemon-v5.sock`. That works fine for normal use
+//! (every scope under one user resolves to the same socket, attach is
+//! transparent). But it FAILS for sandboxed agents (Codex, future personas)
+//! whose `$HOME` is a per-invocation tmpdir: each invocation resolves to a
+//! DIFFERENT "machine-account home" → different socket → spawns yet another
+//! orphan daemon → can never join the project's actual room.
+//!
+//! This module adds a second discovery surface that's reachable across
+//! sandbox boundaries: a file in `/tmp/airc-discovery-<uid>/` keyed by the
+//! project root's hash. When a daemon starts it ANNOUNCES itself there;
+//! when `ensure_daemon_running` finds no daemon at the home-resolved
+//! socket, it looks at the discovery dir for a daemon serving the SAME
+//! project root and attaches there instead of spawning a competitor.
+//!
+//! Trust model: the discovery dir is per-UID (file owner matches reader),
+//! so only the same OS user can register/find. Sandboxes that grant `/tmp`
+//! read-through (the common case — most are MORE restrictive on `$HOME`
+//! than on `/tmp`) gain peer-attach for free.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+/// One daemon's announcement — written when it becomes ready, deleted
+/// best-effort on shutdown, and pruned opportunistically when a reader
+/// finds the PID dead. `project_root` is the git working tree the
+/// daemon's home belongs to (when discoverable); other agents in that
+/// project hash to the same key and find this daemon.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DiscoveredDaemon {
+    pub socket: PathBuf,
+    pub home: PathBuf,
+    pub project_root: Option<PathBuf>,
+    /// String form of the daemon's `PeerId` — the agent who owns the
+    /// `local_identity` row for `home`. Informational; not used for
+    /// trust decisions in this module.
+    pub peer_id: String,
+    pub pid: u32,
+    pub started_at_ms: u64,
+    /// Daemon binary's build identifier (`build_info::BUILD`).
+    /// Cross-build attaches still work over the IPC version handshake;
+    /// this is recorded so diagnostics can spot drift.
+    pub build: String,
+}
+
+/// `/tmp/airc-discovery-<uid>/`. Per-UID so the file owner is always the
+/// same OS user, eliminating cross-user collisions on a shared box.
+/// Created if absent. Failure means no discovery — the spawn-or-attach
+/// path falls back to the existing home-resolved socket only.
+fn discovery_dir() -> std::io::Result<PathBuf> {
+    // SAFETY: getuid is async-signal-safe and has no precondition.
+    let uid = unsafe { libc::getuid() };
+    let dir = std::env::temp_dir().join(format!("airc-discovery-{uid}"));
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// 16-char hex prefix of SHA-256(canonical(project_root)). Stable across
+/// runs, so subsequent daemon starts for the same project overwrite
+/// the same file. Collisions are vanishingly unlikely at 64 bits.
+fn project_key(project_root: &Path) -> String {
+    let canon = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
+    let mut h = Sha256::new();
+    h.update(canon.as_os_str().as_encoded_bytes());
+    let digest = h.finalize();
+    // Inline hex of the first 8 bytes — avoids pulling in a `hex` crate
+    // for one call site.
+    let mut s = String::with_capacity(16);
+    for b in &digest[..8] {
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0xf) as usize] as char);
+    }
+    s
+}
+
+const HEX: &[u8; 16] = b"0123456789abcdef";
+
+/// Announce a ready daemon so other agents can find it via the project
+/// root. Called from `ensure_daemon_running` AFTER the readiness ping
+/// succeeds — never before, because a half-started daemon being
+/// announced would race with attaching peers.
+pub fn announce(daemon: &DiscoveredDaemon) -> std::io::Result<()> {
+    let dir = discovery_dir()?;
+    let key_source = daemon.project_root.as_deref().unwrap_or(&daemon.home);
+    let path = dir.join(format!("{}.json", project_key(key_source)));
+    let data = serde_json::to_vec_pretty(daemon).map_err(std::io::Error::other)?;
+    std::fs::write(&path, data)?;
+    Ok(())
+}
+
+/// Delete this project's announcement. Best-effort: called on graceful
+/// shutdown; failure is silent. Crashed daemons are pruned by
+/// `live_daemons()` via the `pid_alive` check.
+///
+/// Not yet wired in — `airc daemon stop` and SIGTERM handling will
+/// call this once those paths exist. Stale-PID detection in
+/// `live_daemons()` keeps the discovery dir self-cleaning in the
+/// meantime, so this is correctness-only, not blocking.
+#[allow(dead_code)]
+pub fn forget(project_root_or_home: &Path) {
+    if let Ok(dir) = discovery_dir() {
+        let path = dir.join(format!("{}.json", project_key(project_root_or_home)));
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// `kill(pid, 0)` — POSIX standard process-existence check. No signal
+/// is delivered; the kernel only validates that the target exists and
+/// the caller has permission to signal it. Returns 0 if alive,
+/// otherwise sets errno (ESRCH for dead, EPERM for live-but-unowned).
+/// We treat EPERM as "alive" because for our purposes a daemon owned
+/// by another OS user is still "running"; the per-UID discovery dir
+/// keeps such daemons out of our view in the first place.
+fn pid_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    // SAFETY: kill(pid, 0) has no side effects beyond errno, and the
+    // signal value 0 is the documented existence-check idiom.
+    let res = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if res == 0 {
+        return true;
+    }
+    // errno == EPERM means the process exists but we can't signal it.
+    // SAFETY: errno is a thread-local int; reading it after a libc call
+    // is well-defined.
+    let errno = unsafe { *libc::__error() };
+    errno == libc::EPERM
+}
+
+/// Read every `.json` file in the discovery dir, drop the ones whose
+/// PID is dead (and best-effort remove the file), return the rest.
+pub fn live_daemons() -> Vec<DiscoveredDaemon> {
+    let Ok(dir) = discovery_dir() else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(&path) else {
+            continue;
+        };
+        let daemon: DiscoveredDaemon = match serde_json::from_slice(&bytes) {
+            Ok(d) => d,
+            Err(_) => {
+                // Malformed file — prune so it doesn't accumulate.
+                let _ = std::fs::remove_file(&path);
+                continue;
+            }
+        };
+        if pid_alive(daemon.pid) {
+            out.push(daemon);
+        } else {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+    out
+}
+
+/// Find a live daemon serving the same project root as `project_root`.
+/// Used by `ensure_daemon_running` when nothing's reachable at the
+/// home-resolved socket: a sandboxed agent whose `$HOME` is a tmpdir
+/// would otherwise spawn yet another orphan; this routes them to the
+/// project's actual daemon instead.
+pub fn find_for_project(project_root: &Path) -> Option<DiscoveredDaemon> {
+    let want = project_key(project_root);
+    live_daemons().into_iter().find(|d| {
+        let key_source = d.project_root.as_deref().unwrap_or(&d.home);
+        project_key(key_source) == want
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_key_is_stable_across_calls() {
+        let a = project_key(Path::new("/Users/joel/Development/airc"));
+        let b = project_key(Path::new("/Users/joel/Development/airc"));
+        assert_eq!(a, b, "same input → same key");
+        assert_eq!(a.len(), 16, "16-char hex key");
+    }
+
+    #[test]
+    fn project_key_distinguishes_paths() {
+        let a = project_key(Path::new("/Users/joel/Development/airc"));
+        let b = project_key(Path::new("/Users/joel/Development/continuum"));
+        assert_ne!(a, b, "different projects → different keys");
+    }
+
+    #[test]
+    fn pid_zero_is_not_alive() {
+        assert!(!pid_alive(0), "pid 0 is never a real process");
+    }
+
+    #[test]
+    fn current_pid_is_alive() {
+        // SAFETY: getpid is async-signal-safe and has no precondition.
+        let me = unsafe { libc::getpid() } as u32;
+        assert!(
+            pid_alive(me),
+            "the current process is, by definition, alive"
+        );
+    }
+
+    #[test]
+    fn announce_then_find_then_forget_roundtrip() {
+        // Use a unique project root so concurrent test invocations don't
+        // collide (cargo test runs each test in its own thread but shares
+        // process state — and we write to a shared dir).
+        let unique = std::env::temp_dir().join(format!(
+            "airc-discovery-test-{}-{}",
+            // SAFETY: getpid is async-signal-safe.
+            unsafe { libc::getpid() },
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&unique).unwrap_or_default();
+
+        // SAFETY: getpid is async-signal-safe.
+        let me = unsafe { libc::getpid() } as u32;
+        let daemon = DiscoveredDaemon {
+            socket: PathBuf::from("/tmp/fake.sock"),
+            home: PathBuf::from("/tmp/fake-home"),
+            project_root: Some(unique.clone()),
+            peer_id: "00000000-0000-0000-0000-000000000000".to_string(),
+            pid: me,
+            started_at_ms: 0,
+            build: "test".to_string(),
+        };
+
+        announce(&daemon).expect("announce writes file");
+        let found = find_for_project(&unique).expect("find_for_project finds it");
+        assert_eq!(found.pid, me);
+        assert_eq!(found.socket, daemon.socket);
+
+        forget(&unique);
+        let gone = find_for_project(&unique);
+        assert!(gone.is_none(), "forget removes the entry");
+
+        let _ = std::fs::remove_dir_all(&unique);
+    }
+}

--- a/crates/airc-cli/src/discovery.rs
+++ b/crates/airc-cli/src/discovery.rs
@@ -46,16 +46,35 @@ pub struct DiscoveredDaemon {
     pub build: String,
 }
 
-/// `/tmp/airc-discovery-<uid>/`. Per-UID so the file owner is always the
-/// same OS user, eliminating cross-user collisions on a shared box.
-/// Created if absent. Failure means no discovery — the spawn-or-attach
+/// `/tmp/airc-discovery-<uid>/` on Unix. Per-UID so the file owner is
+/// always the same OS user, eliminating cross-user collisions on a
+/// shared box. Created if absent.
+///
+/// On Windows the discovery layer is a no-op (`libc::getuid` doesn't
+/// exist; the sandboxed-`$HOME` failure mode discovery addresses is
+/// a Unix sandbox phenomenon — Codex etc. on Windows host their own
+/// user-scoped tmp areas differently). Returning an unreachable
+/// path keeps `live_daemons` / `find_for_project` defensively
+/// returning empty, which is what we want: the spawn-or-attach
 /// path falls back to the existing home-resolved socket only.
+#[cfg(unix)]
 fn discovery_dir() -> std::io::Result<PathBuf> {
     // SAFETY: getuid is async-signal-safe and has no precondition.
     let uid = unsafe { libc::getuid() };
     let dir = std::env::temp_dir().join(format!("airc-discovery-{uid}"));
     std::fs::create_dir_all(&dir)?;
     Ok(dir)
+}
+
+#[cfg(not(unix))]
+fn discovery_dir() -> std::io::Result<PathBuf> {
+    // No-op on non-Unix — return an error so live_daemons() / announce()
+    // short-circuit cleanly.
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "airc daemon discovery is Unix-only (Codex sandbox failure mode \
+         this addresses is a Unix-specific phenomenon)",
+    ))
 }
 
 /// 16-char hex prefix of SHA-256(canonical(project_root)). Stable across
@@ -117,8 +136,13 @@ pub fn forget(project_root_or_home: &Path) {
 /// by another OS user is still "running"; the per-UID discovery dir
 /// keeps such daemons out of our view in the first place. errno is
 /// read via `std::io::Error::last_os_error().raw_os_error()` for
-/// cross-platform compatibility — direct `libc::__error()` access
-/// is macOS-specific (Linux uses `__errno_location`).
+/// cross-platform compatibility (Linux/macOS differ on the errno
+/// accessor symbol).
+///
+/// On Windows discovery is disabled at `discovery_dir()`, so this
+/// function is never called; we stub it to keep the module type-
+/// checked across all targets.
+#[cfg(unix)]
 fn pid_alive(pid: u32) -> bool {
     if pid == 0 {
         return false;
@@ -130,6 +154,13 @@ fn pid_alive(pid: u32) -> bool {
         return true;
     }
     std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+fn pid_alive(_pid: u32) -> bool {
+    // No discovery → no callers; conservatively report not-alive so
+    // any leaked entries get pruned on read.
+    false
 }
 
 /// Read every `.json` file in the discovery dir, drop the ones whose
@@ -204,16 +235,17 @@ mod tests {
         assert!(!pid_alive(0), "pid 0 is never a real process");
     }
 
+    #[cfg(unix)]
     #[test]
     fn current_pid_is_alive() {
-        // SAFETY: getpid is async-signal-safe and has no precondition.
-        let me = unsafe { libc::getpid() } as u32;
+        let me = std::process::id();
         assert!(
             pid_alive(me),
             "the current process is, by definition, alive"
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn announce_then_find_then_forget_roundtrip() {
         // Use a unique project root so concurrent test invocations don't
@@ -221,8 +253,7 @@ mod tests {
         // process state — and we write to a shared dir).
         let unique = std::env::temp_dir().join(format!(
             "airc-discovery-test-{}-{}",
-            // SAFETY: getpid is async-signal-safe.
-            unsafe { libc::getpid() },
+            std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_nanos())
@@ -230,8 +261,7 @@ mod tests {
         ));
         std::fs::create_dir_all(&unique).unwrap_or_default();
 
-        // SAFETY: getpid is async-signal-safe.
-        let me = unsafe { libc::getpid() } as u32;
+        let me = std::process::id();
         let daemon = DiscoveredDaemon {
             socket: PathBuf::from("/tmp/fake.sock"),
             home: PathBuf::from("/tmp/fake-home"),

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -29,6 +29,7 @@ mod collaboration_cli;
 mod collaboration_commands;
 mod collaboration_peers;
 mod commands;
+mod discovery;
 mod doctor;
 mod envelope_cli;
 mod event_render;
@@ -766,7 +767,11 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             }
             MonitorAction::Attach { my_name } => {
                 let socket = default_or(None, &home);
-                commands::ensure_daemon_running(&home, socket.clone(), parsed.peers).await?;
+                // Return-value ignored: this call site only uses the
+                // daemon-side state (monitor::run_attach reads the
+                // store, not the socket). If discovery routes to a
+                // different socket, the home is what matters here.
+                let _socket = commands::ensure_daemon_running(&home, socket, parsed.peers).await?;
                 monitor::run_attach(&home, &my_name).await
             }
         },


### PR DESCRIPTION
- fix(codex): poll inbox after sending airc messages (#556)
- feat(knock): public collaboration knock entrypoint (airc#559 PR-1) (#560)
- feat(approve): forward-secret room-invite handoff (airc#559 PR-2) (#561)
- feat(queue): add issue-backed queue add/list
- feat(queue): claim/release/set-status verbs (airc#562 PR-2) (#568)
- feat(queue): nudge verb — surface card to peers (airc#562 PR-3) (#573)
- fix(#571): route every gh body write through --body-file (lib_gh.sh) (#574)
- feat(queue): repo-scoped nudge status sweep (#578)
- fix(gh): safely close issues with markdown comments (#582)
- feat(queue): adopt existing issues into queue cards (#583)
- feat(lane): add worktree lanes for agents (#585)
- feat(queue): summarize repo nudge pongs (#586)
- feat(#576): auto-close queue cards when PRs merge into canary (#581)
- fix(#576): detect queue refs in PR titles (#587)
- feat(#572): queue heartbeat and stale scan (#588)
- feat(#570): embeddable queue and room widgets (#589)
- feat(#591): summarize queue availability (#592)
- fix(#593): ignore repo-nudge templates in pongs (#594)
- fix(#596): honor per-agent queue owner (#597)
- fix: add session work identity for queue ownership (#598)
- fix(queue): close already-merged queue cards (#599)
- fix(queue): require closing keywords for close-merged
- fix(queue): preserve issue titles
- feat(queue): recommend next work for idle agents
- feat(queue): allow cross-repo close-merged
- feat(queue): add metronome idle pulse
- fix(queue): prevent accidental claim takeovers
- docs(readme): document AI work queue workflow (#614)
- feat(queue): warn on stale PR branches (#617)
- refactor(queue): split command helpers (#618)
- fix(queue): default planning view and unclaimed-owner semantics (#620)
- Fix collaboration health for same-nick peers (#625)
- fix(lane): hydrate submodules after worktree add (continuum#1252) (#624)
- feat(queue): personalized dispatch verb (closes continuum#1192 broadcast→idle gap) (#623)
- fix(queue): dispatch metronome hand-outs (#627)
- feat: add hygiene policy command (#632)
- fix: fail closed on update conflicts (#633)
- docs: design rust sqlite substrate (#634)
- docs: design realtime event bus (#635)
- feat(queue): add steward dry-run digest (#636)
- feat(core): add Rust transcript primitives (#637)
- feat(logs): add json transcript pages (#638)
- fix(logs): avoid strict-mode crash without json flag (#639)
- refactor(logs): use one render path for human and json modes (#640)
- feat(queue): metronome fan-out across active roster (airc#607, continuum#1192) (#641)
- docs: propose manager-role + lane substrate for airc (#642)
- docs: add lane-kanban-protocol — engineering spec for the lane substrate (#643)
- feat(heartbeat): peer-liveness envelope kind + cmd_peers tracking (airc#644 PR-1) (#645)
- hotfix: cmd_peers Python comment backtick broke airc peers in production (#645 follow-up) (#646)
- feat(heartbeat): wire emission — cmd_send --heartbeat + reminder_timer_loop hook + monitor filter (airc#644 PR-2) (#647)
- fix(heartbeat): allow empty body when --heartbeat (caught live; airc#644 PR-2 follow-up) (#648)
- fix(heartbeat): second empty-body rejection path also needed exemption (airc#644 PR-2 follow-up #2) (#649)
- fix(airc): surface sender client_id on pm-tag so multi-tab agents are distinguishable (#650)
- docs(architecture): airc-rust substrate design — generic messaging/event/network layer (DRAFT) (#651)
- feat(airc-blobs): Phase 1 scaffold — ContentAddressedStore trait + ContentHash + MediaRef (#653)
- feat(airc-blobs): FsStore — filesystem-backed sha256-addressed content store (#655)
- docs(airc-rust): Contract Layer: forge-alloy (substrate vs contract boundary) (#657)
- feat(airc-core): Identity struct + modular split (one concern per file) (#654)
- feat(airc-core): Body enum (Json | Binary) — opaque payload primitive (#656)
- feat(airc-blobs): GC + retention policy — age-based + capacity-based (#660)
- feat(airc-core): convert ID newtypes from String to UUIDv4
- feat(airc-core): envelope Headers dictionary + HeaderFilter predicate
- feat(airc-protocol): wire-level envelope, Frame, signature, subscription, LiftPolicy
- feat(airc-transport): Transport trait + LocalFsAdapter (same-Mac wire)
- fix(airc-transport): tail_loop recovers from frames.jsonl truncation/recreation
- feat(airc-protocol): real Ed25519 signing + verify (closes PR-1 stub)
- feat(airc-transport): TLS peer-pinning infrastructure (cert gen + verifiers)
- feat(airc-transport): LanTcpAdapter — TLS-wrapped TCP with peer-pinned mTLS
- feat(airc-transport): SignedTransport<T> — per-frame Ed25519 sign + verify wrapper
- feat(airc-cli): airc-rs binary — first Rust replacement for Python airc
- test(airc-cli): e2e — two airc-rs subprocesses chat over the substrate
- feat(airc-cli): daemon mode — Unix socket IPC + typed Request/Response
- fix(airc-transport): LAN-TCP readiness race + subscribers-lock-during-await
- feat(airc-cli): daemon Subscribe + Inbox — buffered consume-once reads (#678)
- style(airc-blobs): apply current rustfmt rules (#677)
- feat(airc-transport): multi-peer LanTcpAdapter (#679)
- refactor(airc-transport): split lan_tcp::adapter into module (one concern per file) (#680)
- feat(airc-cli): persisted identity state — stable peer_id + client_id (#681)
- feat(airc-cli): persistent peer registry — peers.json + daemon AddPeer/ListPeers (#682)
- feat(airc-cli): cross-platform daemon — Unix sockets + Windows named pipes (#683)
- ci: rust quality gates — fmt + clippy (deny warnings) + test on every Rust PR (#661)
- docs(airc-rust): replace body_hint with HTTP-style Headers dictionary (reopen of #658) (#662)
- docs(airc-rust): UUIDv4 for every identifier + three-field identity model (reopen of #659) (#663)
- feat(airc-cli): per-user room state — drop --wire/--channel parameter hell (#684)
- fix(airc-cli): Windows pipe-name uniqueness — UUIDv5 over full path (#685)
- fix(codex-hooks): rename TOML key codex_hooks → hooks + auto-migrate (#686)
- fix(airc-transport): LAN-TCP send pre-validates payload, no silent drops (#687)
- feat(airc-store): SeaORM-backed event store crate (slice 4 foundation) (#688)
- refactor: split daemon runtime into airc-daemon crate (slice 5 relocation) (#689)
- feat(airc-daemon): wire airc-store as the inbox backing (slice 5b) (#690)
- feat(airc-lib): consumer-facing facade crate (slice 6) (#691)
- feat(airc-lib): live subscriptions + auto-populate store on say (slice 6b) (#692)
- refactor(airc-cli): commands route through airc_lib::Airc (slice 6c) (#693)
- docs(operating-board): work-coordination domain plan (Codex design) (#694)
- feat(airc-work): typed work coordination domain (#695)
- feat(airc-work): add routable event codec (#696)
- feat(airc-work): replay work events from transcripts (#697)
- feat(airc-work-store): project persisted work events (#698)
- feat(airc-lib): expose work coordination API (#699)
- feat(airc-cli): add work coordination commands (#700)
- feat(airc-cli): add lane coordination commands (#701)
- feat(airc-cli): add workspace lease commands (#702)
- feat(airc-cli): add manager hat commands (#703)
- feat(airc-lib): add filtered event subscriptions (#704)
- feat(airc-cli): add Rust Codex hook context (#705)
- feat(airc-cli): install Codex hooks from Rust (#706)
- feat(codex): route hooks through Rust CLI (#707)
- feat(install): build and install airc-rs (#708)
- refactor(codex): remove Python hook adapters (#709)
- ci: add runtime guard checks for rust-rewrite (#710)
- refactor(codex): move detached start into Rust (#711)
- feat(airc-rs): move client identity mnemonics to rust (#712)
- feat(airc-rs): move iso timestamp parsing to rust (#713)
- feat(airc-rs): move log append and rotate to rust (#714)
- feat(airc-rs): move bearer state reads to rust (#715)
- feat(airc-rs): move logs render to rust (#716)
- feat(airc-rs): move gist JSON parsing to rust (#717)
- feat(airc-transport): add gh gist bootstrap adapter (#718)
- feat(airc-lib): add explicit transport route policy (#719)
- feat(airc-lib): add transport resolver shell (#720)
- feat(airc-lib): feed resolver from transport health (#721)
- feat(airc-rs): expose transport route status (#722)
- feat(airc-rs): move transport health to rust (#723)
- feat(airc-rs): read subscribed channels from rust (#724)
- feat(airc-rs): move channel gist config reads to rust (#725)
- feat(airc-rs): move channel config writes to rust (#726)
- feat(airc-rs): move generic config state to rust (#727)
- feat(airc-rs): move host config block to rust (#728)
- feat(airc-rs): derive daemon scope ids in rust (#729)
- feat(airc-rs): parse doctor rate-limit json in rust (#730)
- feat(airc-rs): render whois identity output in rust (#731)
- feat(airc-cli): move message crypto helpers to Rust (#732)
- feat(airc-cli): move control-plane helpers to Rust (#733)
- feat(airc-cli): build legacy message JSON in Rust (#734)
- feat(airc-cli): move channel gist discovery to Rust (#735)
- feat(airc-cli): move channel gist resolve to Rust (#736)
- feat(airc-cli): move bearer send to Rust (#737)
- refactor(airc-cli): split bearer send modules (#738)
- feat(airc-cli): move bearer recv to Rust (#739)
- feat(airc-cli): move monitor formatter to Rust (#740)
- feat(airc-cli): move local attach tail to Rust (#741)
- feat(airc-cli): move pair handshake to Rust (#742)
- feat(airc-cli): move scope repair to Rust (#743)
- feat(airc-cli): move collaboration health to Rust (#744)
- feat(airc-cli): move inbox cursoring to Rust (#745)
- feat(airc-cli): move hygiene policy to Rust (#746)
- feat(airc-cli): move knock approval crypto to Rust (#747)
- feat(airc-cli): move knock identity JSON to Rust (#748)
- feat(airc-cli): move kick peer ssh lookup to Rust (#749)
- feat(airc-cli): move worktree lane registry to Rust (#750)
- feat(airc-cli): move local identity state to Rust (#751)
- feat(airc-cli): move runtime JSON helpers to Rust (#752)
- feat(airc-cli): move queue card core to Rust (#753)
- feat(airc-cli): move queue projections to Rust (#754)
- feat(airc-cli): move queue runtime summaries to Rust (#755)
- feat(airc-cli): move queue staleness metadata to Rust (#756)
- feat(airc-cli): move queue staleness analyzer to Rust (#757)
- feat(airc-cli): move queue close-merged parsing to Rust (#758)
- feat(queue): move plan and steward projections to rust (#759)
- feat(collaboration): move peers listing to rust (#760)
- fix(invite): read channel gist through rust config (#761)
- feat(identity): move rename collision scan to rust (#762)
- feat(network): move LAN IP probe to rust (#763)
- feat(runtime): drop wrapper python startup (#764)
- feat(install): remove python runtime bootstrap (#765)
- chore(runtime): remove python debug path (#766)
- test(integration): drop legacy python unit gate (#767)
- test(integration): probe bearer kinds through rust (#768)
- test(integration): scaffold ed25519 identity through rust (#769)
- test(integration): edit top-level config through rust (#770)
- feat(config): probe quit fixtures through rust (#771)
- test(integration): probe away status through rust (#772)
- test(integration): probe tabs state through rust (#773)
- test(integration): probe heartbeat gist through rust (#774)
- fix(heartbeat): patch takeover gist lease deterministically (#775)
- test(integration): probe status outage through rust (#776)
- test(integration): probe bearer config through rust (#777)
- test(integration): probe sidecar channels through rust (#778)
- test(integration): probe channel gists through rust (#779)
- test(integration): probe bearer outcome through rust (#780)
- feat(gist): extract named file content through rust (#781)
- test(integration): probe JSON predicates through rust (#782)
- test(integration): route bearer and channel gist through rust (#783)
- test(integration): probe liveness events through rust (#784)
- fix(handshake): accept hyphen-leading public key values (#785)
- test(integration): delete legacy python bearer scenarios (#786)
- test(integration): route gh bearer scenario through rust (#787)
- test(integration): fake gone gist sends through airc-rs (#788)
- test(integration): generate gist rotation seed without python (#789)
- test(integration): remove python from platform adapters scenario (#790)
- install: stop documenting python runtime setup (#791)
- runtime: remove live airc_core references (#792)
- runtime: delete python airc_core layer (#793)
- fix(status): host health ignores joiner bearer pidfiles (#794)
- docs(architecture): transport control plane admission (#795)
- fix: fail closed on production fallback paths (#796)
- docs: define robustness integration plan (#797)
- refactor: remove fallback runtime surfaces (#798)
- ci: enforce Rust quality contracts (#799)
- fix(doctor): keep local health independent of GitHub (#800)
- docs: define invite-only gist routing architecture (#801)
- feat(routes): enforce invite-only gist admission (#802)
- feat(lib): gate sends through route resolver (#803)
- feat(lib): execute SDK sends over LAN routes (#804)
- refactor(cli): route LAN commands through airc-lib (#805)
- feat(lib): organize route discovery and health (#806)
- docs: update route requirements status (#807)
- docs: group route work into PR slices (#808)
- feat(lib): discover local route health (#809)
- feat(route): make gist an invite beacon (#810)
- feat(lib): attach SDK to daemon IPC (#811)
- refactor(cli): route daemon msg and inbox through SDK (#812)
- fix(cli): accept legacy message build command (#814)
- feat(airc-work): drain typing — workspace pressure/drain events + projection (Slice 7 PR 3a) (#813)
- feat(shell): route plain msg through rust local substrate (#815)
- feat(shell): read rust local inbox by default (#817)
- feat(airc-relay): baseline relay server + transport adapter (PR-E) (#816)
- feat(airc-transport): add realtime UDP adapter (#818)
- feat(trust-rotation): signed peer trust rotation contract + daemon application (PR-H) (#819)
- feat(airc-transport): add WebRTC datachannel adapter (#820)
- test(examples): prove SDK consumer embedding path (#821)
- test(examples): prove agent dogfood consumer path (#822)
- feat(examples): consumer integration shape contracts — Continuum/OpenClaw/Hermes (PR-I3) (#823)
- test(cli): prove installed agent identities dogfood live room (#824)
- fix(status): surface rust local data plane before gh bearer (#825)
- fix(codex-hook): pin rust hook executable and honor cursor overrides (#826)
- docs(readme): rework for the post-rewrite substrate (#827)
- fix(workspace): keep lane roots under airc home (#828)
- fix(monitor): attach to Rust event stream (#830)
- fix(teardown): verify live process reaping (#832)
- fix(install): remove rust suffix from airc surface (#833)
- fix(install): use ~/.airc/src as the source root (#835)
- feat(work): drain policy evaluator — pure substrate primitive (#834)
- fix(install): use source command as POSIX entrypoint (#836)
- fix(shell): resolve airc-core from source install (#837)
- fix(status): treat rust-local as routine health (#838)
- fix(install): PATH-augment is newline-safe + strips stale airc lines
- fix(install): rc reconcile no longer short-circuits on in-shell PATH
- fix(codex-hook): install source command path (#839)
- fix(msg): distinguish local store from peer delivery (#840)
- feat(lib): SubscriptionSet + ChannelName + identity-namespaced RoomId (#841)
- fix(events): monitor hooks use subscribed channels (#842)
- feat(lib): mesh identity resolution — replace MeshIdentity::unset() (#843)
- fix(lib): share same-machine account local wire (#844)
- feat(lib): add account room coordinator (#845)
- fix(join): seed rust account rooms from wrapper (#846)
- fix(install): put airc shim on POSIX PATH (#847)
- test(install): gate public airc shim path (#848)
- docs(install): define AI agent install contract (#849)
- test(install): prove public airc account-room runtime (#851)
- feat(lib): machine-global account coordinator (Gap 8) (#850)
- feat(lib): wire account join discovery into local delivery (#852)
- test(install): prove public monitor and hook delivery (#853)
- feat(lib): add account registry bootstrap contract (#854)
- fix(cli): route local join and broadcast through Rust (#855)
- fix(status): show rust command mode after stale startup (#856)
- fix(lib): cross-process chat actually delivers — live_tx fans out on DuplicateEventId (#857)
- fix(status): count Rust-substrate peers, not just legacy peers/ dir (#858)
- fix(send/msg): receipt no longer lies about non-delivery on shared-home wire (#859)
- feat(join): explicit scope + mesh-kind in output (#860)
- fix(join): label canonical HOME scope as machine-account home (#861)
- feat(lib): cross-machine bootstrap via gh-gist account-mesh registry (#862)
- fix(airc): restore project scope and runtime hook identity (#863)
- feat: demolition — bash wrapper deleted, airc IS the Rust binary (#864)
- fix(ci): runtime-guards green post-demolition (#865)
- fix(registry): no --paginate; bound sync with timeout; tests disable (#867)
- fix(mesh-identity): Operator-source cache never expires; bound shell-outs (#868)
- fix(airc): make join own daemon live delivery (#866)
- fix(codex-hook): trust airc.client header on shared-HOME identity (#869)
- feat(cli): restore airc join --attach and airc version subcommand (#870)
- fix(join): ensure Codex hook setup (#871)
- docs(skill): tab-loop semantics for bidirectional agent coordination (#872)
- fix(install): prefer current source tree (#873)
- fix(cli): airc join always streams ALL subscribed rooms; remove --attach (#876)
- test(join): pin runtime attach decision (#877)
- fix(join): detect Codex runtime via client identity (#878)
- docs(architecture): establish grid substrate audit (#879)
- fix(join): persist live feed cursor (#880)
- fix(store): persist runtime cursors through SeaORM (#882)
- docs(architecture): Phase 3.5 ORM end-to-end + Phase 3.6 perf hotpaths (#881)
- fix(store): persist peer trust through ORM (#883)
- fix(store): persist subscriptions through ORM (#884)
- fix(store): persist local identity metadata through ORM (#885)
- fix(store): persist mesh identity through ORM (#886)
- fix(store): persist account registry through ORM (#887)
- fix(store): persist coordinator beacons through ORM (#888)
- cleanup(lib): remove file-backed coordinator beacons (#889)
- cleanup(cli): remove config.json command shim (#890)
- refactor(identity): store-backed identity commands (#891)
- refactor(cli): remove config repair scope command (#892)
- refactor(transport): report substrate route health (#893)
- refactor(cli): remove bearer state command (#894)
- refactor(cli): remove recent senders command (#895)
- refactor(cli): remove legacy log scraping surface (#896)
- refactor(collaboration): remove jsonl presence scans (#897)
- refactor(identity): remove jsonl rename collision helper (#898)
- refactor(cli): remove legacy bearer command (#899)
- refactor(cli): remove jsonl message builder (#900)
- fix(install): copy artifacts instead of symlinking (#901)
- fix(identity): migrate identity json into orm state (#902)
- fix(lib): report peers from account mesh registry (#903)
- fix(cli): agent-runtime attach decision wins over piped-stdout (#904)
- fix(lib): wire replay skips unverifiable frames instead of aborting (#905)
- docs(codex): clarify live feed contract (#906)
- refactor(cli): isolate runtime context classification (#908)
- docs: AR/Cambrian/grid framing + data-model + Phase 3.5 migration (#907)
- refactor(cli): move codex integration behind boundary (#910)
- feat(cli): airc doctor — install + identity + scope self-diagnosis (#909)
- feat(lib): expose subscription query API (#911)
- feat(lib): command-bus primitive (Airc::request / reply / await_reply) (#912)
- docs: CI fidelity as substrate non-negotiable (#10) (#913)
- test(cli): emulate join attach in e2e harness (#915)
- feat(lib): typed lifecycle events (Phase 2) (#914)
- feat(work): add git and PR event contracts (#917)
- feat(lib): emit PeerArrived lifecycle event on add_peer (Phase 2 cont.) (#916)
- feat(work): add local git watcher adapter (#918)
- feat(lib): emit WireEstablished lifecycle event (Phase 2 cont.) (#919)
- docs: require roadmap reference in PR template (#920)
- ci: enforce PR roadmap references (#921)
- feat(lib): emit SubscriptionAdvanced on cursor saves (#922)
- feat(lib): emit RoomParted lifecycle events (#924)
- feat(lib): emit PeerDeparted lifecycle events (#925)
- ci: keep roadmap references as PR template guidance (#926)
- feat(airc-lib): WireLost emit on stream-end + teardown (#923)
- feat(codex): add pollable AIRC feed command (#927)
- test(install): prove Codex poll in public runtime (#928)
- fix(lib): keep routine wire replay quiet (#929)
- feat(cli): add Rust update command (#930)
- refactor(store): move coordinator refresh lock into ORM (#931)
- perf(lib): use set-backed event dedup (#932)
- perf(lib): broadcast live events by arc (#933)
- perf(protocol): remove global peer registry lock (#934)
- perf(lib): remove global route table locks (#935)
- perf(lib): own local ingest task lifecycle (#936)
- perf(lib): use set-backed subscription dedup (#937)
- perf(lib): shorten subscriber setup locks (#938)
- perf(lib): make event filter channels set-backed (#939)
- refactor(daemon): length-frame ipc with cbor (#940)
- fix(cli): restart daemon during update (#941)
- refactor(ipc): split daemon IPC contract into crate (#942)
- refactor(identity): split local identity into crate (#943)
- refactor(trust): split peer trust into crate (#944)
- test(command-bus): prove request reply over LAN (#945)
- feat(airc-lib): execute relay routes through SDK (#946)
- test(consumer-shapes): prove command bus integration (#948)
- feat(airc-work): PR observation adapter skeleton (#947)
- docs(audit): refresh immediate queue after PR adapter (#949)
- feat(airc-work): real gh PullRequestSource over GhCommandRunner (#950)
- docs(readme): restore generic agent IRC framing (#951)
- fix(ipc): version daemon endpoint by protocol (#952)
- fix(daemon): refresh wire trust for live ingest (#953)
- test(airc-lib): prove Continuum-shaped room throughput (#954)
- feat(airc-lib): wire UDP route execution + WebRTC signaling types (#955)
- feat(airc-lib): WebRTC DataChannel orchestration over AIRC mesh (#957)
- docs(webrtc): media tracks plan and implementation split (#959)
- feat(airc-lib): surface incoming WebRTC media tracks (#960)
- feat(airc-lib): add WebRTC media track builder (#961)
- test(airc-lib): prove WebRTC audio and video tracks (#962)
- test(airc-lib): prove WebRTC media and control share a session (#963)
- docs(audit): note observed AIRC coordination flaws (#964)
- fix(cli): restore IRC-shaped peers and whois commands (#966)
- docs(webrtc): show Continuum live-room integration example (#967)
- feat(work): heartbeat claims and surface stale owners (#969)
- feat(work): publish agent availability state (#971)
- feat(diagnostics): add typed substrate diagnostic sink (#973)
- feat(airc-lib): typed lane-coordination events (#965)
- feat(airc-lib): active-agent heartbeat events (#968)
- feat(airc-cli): bake build sha + drift detection in doctor (#972)
- feat(work): suggest claimable cards for agents (#975)
- feat(work): surface claimable queue suggestions in agent feeds (#976)
- feat(airc-lib): typed work-event subscription API (#974)
- feat(work): close completed cards (#977)
- fix(work): tolerate bounded board replay windows (#979)
- feat(airc-lib): AIRC-event diagnostic sink + doctor surface (#978)
- fix(work): preserve terminal state on claim release (#980)
- docs(audit): consumer integration gap audit + follow-up cards (#981)
- docs(audit): roadmap-to-card coverage + missing-card cleanup (#982)
- feat(work): surface agent availability in queue status (#983)
- test(lib): prove Continuum pose fan-out throughput (#984)
- feat(work): render typed agent roster (#986)
- fix(work): make duplicate claim release idempotent (#987)
- feat(airc-lib): external-identity bridge contract (#985)
- feat(work): enforce lease-zone for work claim + heartbeat diagnostic (#988)
- feat(route): add JSON route proof harness (#989)
- feat(publish): structured publish API + airc publish JSON-receipt CLI (#990)
- feat(events): add JSON list output (#991)
- docs: define cooperative coordination training signal (#992)
- fix(work): reject card transitions from wrong room (#993)
- fix(join): replace stale daemon builds from typed status (#994)
- fix(work): tolerate superseded claim release + ghost heartbeat (#996)
- feat(work): publish active-agent roster heartbeats from join (#997)
- fix(work): correlate peer claims to live roster clients (#998)
- feat(work): add typed manager loop evaluation (#999)
- docs(airc): add runtime planning and consumer audit lanes (#1000)
- docs(airc): define autonomous development roadmap (#1001)
- fix(work): find active cards beyond small recent windows (#1004)
- fix(work-store): tolerate orphaned events in complete projection (#1005)
- fix(work): schedule from complete work projection (#1006)
- feat(work): seed backlog from manager candidates (#1008)
- fix(work): make stale claims recoverable by default (#1009)
- feat(ipc): add ResolveWireRequest (channel uuid -> wire path lookup) (#1011)
- feat(inbox): --json flag for machine-readable output (#1010)
- fix(work): exclude terminal cards from stale recovery (#1012)
- fix(identity): resolve mesh identity against machine-global coordinator store (#1014)
- perf(bus): decoupled delivery bus — kill same-machine poll/fsync latency (#1015)
- fix(test): isolate two-machine bridge test via explicit wire roots — repairs Windows CI (#1016)
- docs(arch): airc event-server design — efficient ORM+push routing server (#1017)
- feat(airc-bus): owner-core event router — sharded router + hot ring + generational cursor + zero-copy fan-out (#1018)
- test(e2e): realistic timeout for process-spawn round-trips (fix macOS flake) (#1020)
- fix(reliability): LAN send-flush + lan-listen subscribe order + daemon-shutdown hang (#1021)
- feat(store): SQLite-backed DurableSink — owner-core ORM durable tier (§3.3) (#1019)
- feat(store): persistent EpochStore — generational epoch survives daemon restart (§3.8) (#1022)
- feat(wire): airc-wire — FlatBuffers binary codec for the envelope (zero-copy payload) (#1023)
- feat(work+lib+cli): autonomous-team substrate end-to-end (19 cards) (#1025)
- fix(cli): airc work state review uses Command::current_dir, not gh -C (card a4fe899f) (#1027)
- fix(cli): airc work state X merged refused — only PullRequestMerged event sets Merged (card a1bc62b3) (#1028)
- feat(store): add agent_name column to local_identity (card 8384cc18 Sub-A) (#1030)
- fix(identity): provisional git-email identity self-heals to gh login (one identity per machine) (#1024)
- fix(cli): default_home_dir skips machine-account ~/.airc + resolves to main working tree from a worktree (card a1b4552a) (#1029)
- fix(lib): work_board filters heartbeats out of the projection page (card 79953b4d) (#1031)
- fix(cli): airc work state Closed refuses unless from Merged or pre-work state (card 9656a836) (#1026)
- docs(agents): encode engineering-staff framing — CI-green-before-merge, branch hygiene, monitoring (card 53698eb9) (#1032)
- fix(install): recover from stale Rust toolchain instead of cryptic build abort (#1013)
- ef168afe/airc ci re green rust rewrite accumulate (#1033)
- feat(cli): cross-sandbox daemon discovery — sandboxed agents (Codex) attach to project daemon instead of orphaning a fresh one (card 282850c2)
