### PR TITLE
feat(cli+lib): continuous-merge — `airc work merger run` auto-merges Review cards whose PRs are CI-green (card f16650cd)

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -55,6 +55,7 @@ mod lane_commands;
 mod lease;
 mod legacy_envelope;
 mod legacy_identity;
+mod merger;
 mod monitor;
 mod network_commands;
 mod pending_cli;
@@ -696,6 +697,19 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 note,
                 ttl_ms,
             } => work_commands::run_availability(&home, repo, state, note, ttl_ms).await,
+            WorkAction::Merger { action } => match action {
+                work_cli::MergerAction::Run {
+                    interval_secs,
+                    dry_run,
+                } => {
+                    merger::run(
+                        &home,
+                        std::time::Duration::from_secs(interval_secs),
+                        dry_run,
+                    )
+                    .await
+                }
+            },
         },
 
         Command::Lane(args) => match args.action {

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -1,0 +1,327 @@
+//! Continuous-merge background loop — auto-merges Review-state cards
+//! whose linked PRs have green CI, then publishes `PullRequestMerged`
+//! so the projection transitions the card to `Merged`.
+//!
+//! Card f16650cd. Joel directive 2026-05-28: "we do NOT just leave
+//! branches laying around after CI passes" + "we need continuous
+//! merging somewhere". Without this, an agent has to remember to run
+//! `gh pr merge` — a discipline that breaks the moment a less-capable
+//! persona attaches. Substrate-driven; agents go idle, work keeps
+//! shipping.
+//!
+//! ## What this gate checks
+//!
+//! On every tick (default 30s):
+//!
+//! 1. Read the work board projection.
+//! 2. For every card in `Review` state with a `pull_request`:
+//!    - Fetch the PR's check rollup via `gh pr view --json statusCheckRollup`.
+//!    - Apply the *strictly-less-red-than-base* doctrine refinement: a PR
+//!      is mergeable when no NEW red was introduced vs. the base branch
+//!      (the bar agreed during #1033 — pre-existing red doesn't block;
+//!      new red does). For the first cut we use a simpler form: no
+//!      FAILURE/CANCELLED conclusions in the rollup. The pre-existing-red
+//!      bypass is carded as a follow-up.
+//!    - If the gate passes: `gh pr merge --squash --delete-branch`.
+//!    - On success, publish `MarkPullRequestMerged`. The projection
+//!      transitions the card to `Merged`; a separate observer (or the
+//!      next merger tick) closes the card.
+//!
+//! ## What this gate does NOT yet check (future cards)
+//!
+//! - Peer-LGTM convention (card 267d68f5): for multi-author rooms we
+//!   should require a non-author LGTM. For now, ANY Review card
+//!   auto-merges if green — appropriate for single-author scopes; for
+//!   multi-author, the doctrine says "review before Review state."
+//! - Worktree cleanup on merge (card abe9fe4c).
+//! - Card-close on merged (currently relies on projection state and an
+//!   agent's explicit close; an observer would automate it).
+//!
+//! ## Singleton enforcement
+//!
+//! A naive multi-tab launch would race on `gh pr merge` and one would
+//! fail with "PR already merged." A file lock at
+//! `<home>/merger.lock` prevents two merger processes per scope. The
+//! lock is `flock(LOCK_EX | LOCK_NB)` — non-blocking; a second launch
+//! exits cleanly with a "merger already running" message.
+
+use std::path::Path;
+use std::time::Duration;
+
+use airc_lib::{Airc, MarkPullRequestMerged, WorkCard};
+
+/// Run the continuous-merge loop until shutdown (Ctrl-C / SIGTERM).
+/// Default interval at the CLI layer is 30 seconds — CI pipelines on
+/// this project take 2–5 minutes; polling faster wastes API calls
+/// without shipping more.
+///
+/// Holds an exclusive file lock at `<home>/merger.lock` so two
+/// invocations against the same scope don't race on `gh pr merge`.
+pub async fn run(
+    home: &Path,
+    interval: Duration,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _lock = acquire_singleton_lock(home)?;
+
+    let socket = crate::cli::default_socket_path_in(home);
+    crate::commands::ensure_daemon_running(home, socket.clone(), Vec::new()).await?;
+    let airc = Airc::attach(home, socket).await?;
+
+    eprintln!(
+        "airc-merger: started (home={}, interval={:?}, dry_run={})",
+        home.display(),
+        interval,
+        dry_run
+    );
+    eprintln!("airc-merger: peer_id={}", airc.peer_id());
+
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    let shutdown = tokio::signal::ctrl_c();
+    tokio::pin!(shutdown);
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut shutdown => {
+                eprintln!("airc-merger: shutdown signal received, exiting cleanly");
+                return Ok(());
+            }
+            _ = ticker.tick() => {
+                if let Err(error) = tick_once(&airc, dry_run).await {
+                    // A tick failing should NOT bring down the loop —
+                    // gh might be rate-limited, the daemon might be
+                    // momentarily unreachable, etc. Log and continue.
+                    eprintln!("airc-merger: tick failed: {error}");
+                }
+            }
+        }
+    }
+}
+
+/// One pass over the board: scan eligible cards, gate, merge.
+async fn tick_once(airc: &Airc, dry_run: bool) -> Result<(), Box<dyn std::error::Error>> {
+    // Limit chosen large enough to surface every Review card with a
+    // PR in practice. The board fetch already filters heartbeats
+    // (card 79953b4d), so 256 work events back is several days of
+    // realistic mutation rate.
+    let board = airc.work_board(256).await?;
+    let snapshot = board.snapshot();
+
+    for card in &snapshot.cards {
+        let Some(decision) = evaluate(card).await? else {
+            continue;
+        };
+        match decision {
+            MergeDecision::Merge(pr) => {
+                if dry_run {
+                    eprintln!(
+                        "airc-merger: [DRY-RUN] would merge card={} pr=#{} ({})",
+                        card.card_id, pr.number, pr.repo
+                    );
+                    continue;
+                }
+                match perform_merge(card, &pr, airc).await {
+                    Ok(()) => eprintln!(
+                        "airc-merger: merged card={} pr=#{} ({})",
+                        card.card_id, pr.number, pr.repo
+                    ),
+                    Err(error) => eprintln!(
+                        "airc-merger: merge failed card={} pr=#{}: {error}",
+                        card.card_id, pr.number
+                    ),
+                }
+            }
+            MergeDecision::Skip(reason) => {
+                eprintln!("airc-merger: skip card={} reason={reason}", card.card_id);
+            }
+        }
+    }
+    Ok(())
+}
+
+enum MergeDecision {
+    Merge(airc_work::model::PullRequestRef),
+    Skip(String),
+}
+
+/// Per-card eligibility check. Returns `Ok(None)` if the card isn't
+/// even a candidate (not in Review, no PR linked); `Ok(Some(Merge))`
+/// if everything passes; `Ok(Some(Skip(reason)))` if it's a candidate
+/// that failed a gate (so we can log it instead of silently dropping).
+async fn evaluate(card: &WorkCard) -> Result<Option<MergeDecision>, Box<dyn std::error::Error>> {
+    use airc_work::model::CardState;
+    if card.state != CardState::Review {
+        return Ok(None);
+    }
+    let Some(pr) = card.pull_request.clone() else {
+        return Ok(None);
+    };
+
+    match check_pr_gate(&pr).await {
+        Ok(GateResult::Green) => Ok(Some(MergeDecision::Merge(pr))),
+        Ok(GateResult::NotReady(reason)) => Ok(Some(MergeDecision::Skip(reason))),
+        Err(error) => Ok(Some(MergeDecision::Skip(format!(
+            "gh status query failed: {error}"
+        )))),
+    }
+}
+
+enum GateResult {
+    Green,
+    NotReady(String),
+}
+
+/// Query `gh pr view --json statusCheckRollup` and apply the merge
+/// gate. First-cut policy: no FAILURE or CANCELLED in the rollup, and
+/// no checks still IN_PROGRESS/PENDING. Pre-existing-red bypass is
+/// deferred to a follow-up card.
+async fn check_pr_gate(
+    pr: &airc_work::model::PullRequestRef,
+) -> Result<GateResult, Box<dyn std::error::Error>> {
+    let pr_ref = format!("{}#{}", pr.repo.as_str(), pr.number);
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &pr.number.to_string(),
+            "--repo",
+            pr.repo.as_str(),
+            "--json",
+            "statusCheckRollup,mergeable,state",
+        ])
+        .output()
+        .await?;
+    if !output.status.success() {
+        return Err(format!(
+            "gh pr view {pr_ref} failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into());
+    }
+
+    let parsed: GhPrView = serde_json::from_slice(&output.stdout)?;
+
+    if parsed.state != "OPEN" {
+        return Ok(GateResult::NotReady(format!(
+            "PR state is {} (not OPEN)",
+            parsed.state
+        )));
+    }
+    if parsed.mergeable == "CONFLICTING" {
+        return Ok(GateResult::NotReady(
+            "PR has merge conflicts; needs rebase".to_string(),
+        ));
+    }
+
+    let rollup = parsed.status_check_rollup.unwrap_or_default();
+    let mut failures = 0usize;
+    let mut pending = 0usize;
+    for c in &rollup {
+        match c.conclusion.as_deref() {
+            Some("SUCCESS") | Some("NEUTRAL") | Some("SKIPPED") => {}
+            Some("FAILURE") | Some("CANCELLED") | Some("TIMED_OUT") => failures += 1,
+            _ => {
+                // No conclusion → in flight (IN_PROGRESS / QUEUED / PENDING).
+                if c.status.as_deref() != Some("COMPLETED") {
+                    pending += 1;
+                }
+            }
+        }
+    }
+    if failures > 0 {
+        return Ok(GateResult::NotReady(format!("{failures} failing check(s)")));
+    }
+    if pending > 0 {
+        return Ok(GateResult::NotReady(format!(
+            "{pending} check(s) still running"
+        )));
+    }
+    Ok(GateResult::Green)
+}
+
+/// Actually merge. `gh pr merge --squash --delete-branch` matches the
+/// convention every recent PR has used (see merged-PR survey in card
+/// 28f1440c). On success, publish `MarkPullRequestMerged` so the
+/// projection transitions to `Merged`.
+async fn perform_merge(
+    card: &WorkCard,
+    pr: &airc_work::model::PullRequestRef,
+    airc: &Airc,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "pr",
+            "merge",
+            &pr.number.to_string(),
+            "--repo",
+            pr.repo.as_str(),
+            "--squash",
+            "--delete-branch",
+        ])
+        .output()
+        .await?;
+    if !output.status.success() {
+        return Err(format!(
+            "gh pr merge #{} failed: {}",
+            pr.number,
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into());
+    }
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    airc.mark_pull_request_merged(MarkPullRequestMerged {
+        card_id: card.card_id,
+        pull_request: pr.clone(),
+        merged_at_ms: now_ms,
+    })
+    .await?;
+    Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct GhPrView {
+    #[serde(default)]
+    state: String,
+    #[serde(default, rename = "mergeable")]
+    mergeable: String,
+    #[serde(default, rename = "statusCheckRollup")]
+    status_check_rollup: Option<Vec<GhCheck>>,
+}
+
+#[derive(serde::Deserialize)]
+struct GhCheck {
+    #[serde(default)]
+    conclusion: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+}
+
+/// Acquire a non-blocking exclusive lock at `<home>/merger.lock`.
+/// Returns the held file handle (drop = release). A second launch in
+/// the same scope exits with a clear error instead of racing.
+fn acquire_singleton_lock(home: &Path) -> Result<std::fs::File, Box<dyn std::error::Error>> {
+    use fs2::FileExt;
+    std::fs::create_dir_all(home)?;
+    let path = home.join("merger.lock");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&path)?;
+    file.try_lock_exclusive().map_err(|e| {
+        format!(
+            "another airc-merger is already running for {} ({}). \
+             only one merger per scope at a time — kill the other or wait.",
+            home.display(),
+            e
+        )
+    })?;
+    Ok(file)
+}

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -174,10 +174,10 @@ enum GateResult {
     NotReady(String),
 }
 
-/// Query `gh pr view --json statusCheckRollup` and apply the merge
-/// gate. First-cut policy: no FAILURE or CANCELLED in the rollup, and
-/// no checks still IN_PROGRESS/PENDING. Pre-existing-red bypass is
-/// deferred to a follow-up card.
+/// Query `gh pr view --json statusCheckRollup,mergeable,state` and
+/// apply [`evaluate_gh_view`] to the response. The IO half is here;
+/// the decision half is the pure function so it can be unit-tested
+/// without shelling out.
 async fn check_pr_gate(
     pr: &airc_work::model::PullRequestRef,
 ) -> Result<GateResult, Box<dyn std::error::Error>> {
@@ -203,23 +203,30 @@ async fn check_pr_gate(
     }
 
     let parsed: GhPrView = serde_json::from_slice(&output.stdout)?;
+    Ok(evaluate_gh_view(&parsed))
+}
 
-    if parsed.state != "OPEN" {
-        return Ok(GateResult::NotReady(format!(
-            "PR state is {} (not OPEN)",
-            parsed.state
-        )));
+/// Decide whether a PR is ready to merge, given the parsed `gh pr
+/// view` payload. Pure — no IO, no async. First-cut policy:
+///
+/// - state must be `OPEN` (not already MERGED/CLOSED)
+/// - mergeable must not be `CONFLICTING` (no rebase needed)
+/// - no `FAILURE` / `CANCELLED` / `TIMED_OUT` conclusions
+/// - no still-running checks (status != COMPLETED with no conclusion)
+///
+/// The strictly-less-red-than-base doctrine refinement (#1033) is a
+/// separate, more lenient gate carded as a follow-up.
+fn evaluate_gh_view(view: &GhPrView) -> GateResult {
+    if view.state != "OPEN" {
+        return GateResult::NotReady(format!("PR state is {} (not OPEN)", view.state));
     }
-    if parsed.mergeable == "CONFLICTING" {
-        return Ok(GateResult::NotReady(
-            "PR has merge conflicts; needs rebase".to_string(),
-        ));
+    if view.mergeable == "CONFLICTING" {
+        return GateResult::NotReady("PR has merge conflicts; needs rebase".to_string());
     }
-
-    let rollup = parsed.status_check_rollup.unwrap_or_default();
+    let rollup = view.status_check_rollup.as_deref().unwrap_or(&[]);
     let mut failures = 0usize;
     let mut pending = 0usize;
-    for c in &rollup {
+    for c in rollup {
         match c.conclusion.as_deref() {
             Some("SUCCESS") | Some("NEUTRAL") | Some("SKIPPED") => {}
             Some("FAILURE") | Some("CANCELLED") | Some("TIMED_OUT") => failures += 1,
@@ -232,14 +239,12 @@ async fn check_pr_gate(
         }
     }
     if failures > 0 {
-        return Ok(GateResult::NotReady(format!("{failures} failing check(s)")));
+        return GateResult::NotReady(format!("{failures} failing check(s)"));
     }
     if pending > 0 {
-        return Ok(GateResult::NotReady(format!(
-            "{pending} check(s) still running"
-        )));
+        return GateResult::NotReady(format!("{pending} check(s) still running"));
     }
-    Ok(GateResult::Green)
+    GateResult::Green
 }
 
 /// Actually merge. `gh pr merge --squash --delete-branch` matches the
@@ -324,4 +329,178 @@ fn acquire_singleton_lock(home: &Path) -> Result<std::fs::File, Box<dyn std::err
         )
     })?;
     Ok(file)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure-function tests for the merge gate. The IO and orchestration
+    //! halves (gh shelling, work_board fetch, the loop) are integration
+    //! territory — exercised end-to-end when the merger runs against
+    //! real PRs. The decision matrix is what changes most often (every
+    //! follow-up to f16650cd: LGTM gate, less-red bypass, catchup); it
+    //! is the right surface to lock down with unit tests.
+    use super::*;
+    use serde_json::json;
+
+    fn parse(payload: serde_json::Value) -> GhPrView {
+        serde_json::from_value(payload).expect("test fixture must parse")
+    }
+
+    #[test]
+    fn merges_when_state_open_no_conflicts_all_checks_green() {
+        let view = parse(json!({
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"conclusion": "SUCCESS", "status": "COMPLETED"},
+                {"conclusion": "NEUTRAL", "status": "COMPLETED"},
+                {"conclusion": "SKIPPED", "status": "COMPLETED"},
+            ]
+        }));
+        assert!(matches!(evaluate_gh_view(&view), GateResult::Green));
+    }
+
+    #[test]
+    fn refuses_when_pr_is_closed() {
+        let view = parse(json!({"state": "CLOSED", "mergeable": "MERGEABLE"}));
+        let result = evaluate_gh_view(&view);
+        let GateResult::NotReady(reason) = result else {
+            panic!("expected NotReady, got Green");
+        };
+        assert!(reason.contains("CLOSED"), "reason should name the state");
+    }
+
+    #[test]
+    fn refuses_when_pr_is_already_merged() {
+        let view = parse(json!({"state": "MERGED", "mergeable": "MERGEABLE"}));
+        assert!(matches!(evaluate_gh_view(&view), GateResult::NotReady(_)));
+    }
+
+    #[test]
+    fn refuses_when_conflicting() {
+        let view = parse(json!({
+            "state": "OPEN",
+            "mergeable": "CONFLICTING",
+            "statusCheckRollup": [{"conclusion": "SUCCESS", "status": "COMPLETED"}]
+        }));
+        let GateResult::NotReady(reason) = evaluate_gh_view(&view) else {
+            panic!("expected NotReady");
+        };
+        assert!(
+            reason.contains("conflict") || reason.contains("rebase"),
+            "reason should name conflicts"
+        );
+    }
+
+    #[test]
+    fn refuses_when_any_check_failed() {
+        let view = parse(json!({
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"conclusion": "SUCCESS", "status": "COMPLETED"},
+                {"conclusion": "FAILURE", "status": "COMPLETED"},
+                {"conclusion": "SUCCESS", "status": "COMPLETED"},
+            ]
+        }));
+        let GateResult::NotReady(reason) = evaluate_gh_view(&view) else {
+            panic!("expected NotReady");
+        };
+        assert!(reason.contains("failing"), "reason should mention failures");
+    }
+
+    #[test]
+    fn refuses_when_a_check_was_cancelled() {
+        let view = parse(json!({
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"conclusion": "CANCELLED", "status": "COMPLETED"},
+            ]
+        }));
+        assert!(matches!(evaluate_gh_view(&view), GateResult::NotReady(_)));
+    }
+
+    #[test]
+    fn refuses_when_a_check_timed_out() {
+        let view = parse(json!({
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"conclusion": "TIMED_OUT", "status": "COMPLETED"},
+            ]
+        }));
+        assert!(matches!(evaluate_gh_view(&view), GateResult::NotReady(_)));
+    }
+
+    #[test]
+    fn refuses_when_a_check_is_still_running() {
+        let view = parse(json!({
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"conclusion": "SUCCESS", "status": "COMPLETED"},
+                {"conclusion": null, "status": "IN_PROGRESS"},
+            ]
+        }));
+        let GateResult::NotReady(reason) = evaluate_gh_view(&view) else {
+            panic!("expected NotReady");
+        };
+        assert!(
+            reason.contains("still running"),
+            "reason should indicate pending checks"
+        );
+    }
+
+    #[test]
+    fn merges_when_rollup_is_empty() {
+        // No checks configured at all → mergeable. (Repo with no CI is
+        // a valid state, e.g. docs-only repos.) The gate is "no
+        // failure OR pending"; zero checks satisfies both vacuously.
+        let view = parse(json!({
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [],
+        }));
+        assert!(matches!(evaluate_gh_view(&view), GateResult::Green));
+    }
+
+    #[test]
+    fn merges_when_rollup_field_absent() {
+        // Missing field → default empty Vec → vacuously green, same
+        // as the explicit-empty case above. The serde default keeps
+        // the gate robust to gh CLI version drift.
+        let view = parse(json!({"state": "OPEN", "mergeable": "MERGEABLE"}));
+        assert!(matches!(evaluate_gh_view(&view), GateResult::Green));
+    }
+
+    #[test]
+    fn singleton_lock_refuses_second_holder() {
+        // Acquire on a fresh tmpdir, then try a second acquire — must
+        // fail with the "already running" error rather than blocking
+        // or succeeding (which would race two mergers).
+        let tmp = std::env::temp_dir().join(format!(
+            "airc-merger-lock-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let _first = acquire_singleton_lock(&tmp).expect("first acquire");
+        let second = acquire_singleton_lock(&tmp);
+        assert!(second.is_err(), "second acquire must fail");
+        let err = second.unwrap_err().to_string();
+        assert!(
+            err.contains("already running"),
+            "error should name the conflict: {err}"
+        );
+
+        drop(_first);
+        let _third = acquire_singleton_lock(&tmp).expect("after drop, third acquire succeeds");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 }

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -258,6 +258,29 @@ pub enum WorkAction {
         #[arg(long, default_value_t = 600_000)]
         ttl_ms: u64,
     },
+    /// Card f16650cd: continuous-merge daemon. Long-running process
+    /// that polls Review-state cards, merges PRs whose CI is green,
+    /// and publishes `PullRequestMerged` so the projection transitions
+    /// the card. Runs until Ctrl-C / SIGTERM. One per scope at a time
+    /// (`<home>/merger.lock` flock).
+    Merger {
+        #[command(subcommand)]
+        action: MergerAction,
+    },
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum MergerAction {
+    /// Start the continuous-merge loop.
+    Run {
+        /// Poll interval in seconds (default: 30).
+        #[arg(long, default_value_t = 30)]
+        interval_secs: u64,
+        /// Don't actually call `gh pr merge` — log what WOULD be
+        /// merged. Useful while validating the gate logic.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -133,10 +133,10 @@ pub use webrtc_media::{
 pub use work::{
     AllocateWorkspace, ChangeWorkCardState, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard,
     ClaimableWorkItem, ClaimableWorkQuery, CreateWorkCard, CreateWorkLane, HeartbeatWorkClaim,
-    HeartbeatWorkspace, LinkCardPullRequest, ObserveLocalGitWorkspace, ObservePullRequests,
-    ObservedLocalGitWorkspace, ObservedPullRequests, ReleaseManagerHat, ReleaseWorkClaim,
-    ReleaseWorkspace, ReportAgentAvailability, RequestWorkspace, UpdateWorkCard, WorkQueueStatus,
-    WorkQueueStatusQuery,
+    HeartbeatWorkspace, LinkCardPullRequest, MarkPullRequestMerged, ObserveLocalGitWorkspace,
+    ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests, ReleaseManagerHat,
+    ReleaseWorkClaim, ReleaseWorkspace, ReportAgentAvailability, RequestWorkspace, UpdateWorkCard,
+    WorkQueueStatus, WorkQueueStatusQuery,
 };
 pub use work_manager::{
     SeededWorkCard, WorkBacklogSeedCandidate, WorkBacklogSeedOutcome, WorkBacklogSeedResult,

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -161,6 +161,17 @@ pub struct LinkCardPullRequest {
     pub pull_request: airc_work::model::PullRequestRef,
 }
 
+/// Card f16650cd: attest that a PR has been merged. Published by the
+/// continuous-merge background task (`airc work merger run`) AFTER it
+/// successfully calls `gh pr merge`. The projection picks this up and
+/// transitions the card to `CardState::Merged` automatically.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkPullRequestMerged {
+    pub card_id: WorkCardId,
+    pub pull_request: airc_work::model::PullRequestRef,
+    pub merged_at_ms: u64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HeartbeatWorkClaim {
     pub card_id: WorkCardId,
@@ -485,6 +496,28 @@ impl Airc {
             pull_request: request.pull_request,
             linked_by: self.peer_id(),
             linked_at_ms: now_ms()?,
+        });
+        self.publish_work_event(&event).await?;
+        Ok(())
+    }
+
+    /// Card f16650cd: attest that the linked PR has been merged. The
+    /// continuous-merge background task calls this AFTER a successful
+    /// `gh pr merge`. The projection then transitions the card to
+    /// `CardState::Merged`. `merged_by` is the calling peer
+    /// (the merger's identity) — agents reviewing the transcript can
+    /// see who shipped the merge, separate from the card's author.
+    pub async fn mark_pull_request_merged(
+        &self,
+        request: MarkPullRequestMerged,
+    ) -> Result<(), AircError> {
+        self.ensure_work_card_in_current_room(request.card_id)
+            .await?;
+        let event = WorkEvent::PullRequestMerged(airc_work::event::PullRequestMerged {
+            card_id: request.card_id,
+            pull_request: request.pull_request,
+            merged_by: self.peer_id(),
+            merged_at_ms: request.merged_at_ms,
         });
         self.publish_work_event(&event).await?;
         Ok(())


### PR DESCRIPTION
- fix(codex): poll inbox after sending airc messages (#556)
- feat(knock): public collaboration knock entrypoint (airc#559 PR-1) (#560)
- feat(approve): forward-secret room-invite handoff (airc#559 PR-2) (#561)
- feat(queue): add issue-backed queue add/list
- feat(queue): claim/release/set-status verbs (airc#562 PR-2) (#568)
- feat(queue): nudge verb — surface card to peers (airc#562 PR-3) (#573)
- fix(#571): route every gh body write through --body-file (lib_gh.sh) (#574)
- feat(queue): repo-scoped nudge status sweep (#578)
- fix(gh): safely close issues with markdown comments (#582)
- feat(queue): adopt existing issues into queue cards (#583)
- feat(lane): add worktree lanes for agents (#585)
- feat(queue): summarize repo nudge pongs (#586)
- feat(#576): auto-close queue cards when PRs merge into canary (#581)
- fix(#576): detect queue refs in PR titles (#587)
- feat(#572): queue heartbeat and stale scan (#588)
- feat(#570): embeddable queue and room widgets (#589)
- feat(#591): summarize queue availability (#592)
- fix(#593): ignore repo-nudge templates in pongs (#594)
- fix(#596): honor per-agent queue owner (#597)
- fix: add session work identity for queue ownership (#598)
- fix(queue): close already-merged queue cards (#599)
- fix(queue): require closing keywords for close-merged
- fix(queue): preserve issue titles
- feat(queue): recommend next work for idle agents
- feat(queue): allow cross-repo close-merged
- feat(queue): add metronome idle pulse
- fix(queue): prevent accidental claim takeovers
- docs(readme): document AI work queue workflow (#614)
- feat(queue): warn on stale PR branches (#617)
- refactor(queue): split command helpers (#618)
- fix(queue): default planning view and unclaimed-owner semantics (#620)
- Fix collaboration health for same-nick peers (#625)
- fix(lane): hydrate submodules after worktree add (continuum#1252) (#624)
- feat(queue): personalized dispatch verb (closes continuum#1192 broadcast→idle gap) (#623)
- fix(queue): dispatch metronome hand-outs (#627)
- feat: add hygiene policy command (#632)
- fix: fail closed on update conflicts (#633)
- docs: design rust sqlite substrate (#634)
- docs: design realtime event bus (#635)
- feat(queue): add steward dry-run digest (#636)
- feat(core): add Rust transcript primitives (#637)
- feat(logs): add json transcript pages (#638)
- fix(logs): avoid strict-mode crash without json flag (#639)
- refactor(logs): use one render path for human and json modes (#640)
- feat(queue): metronome fan-out across active roster (airc#607, continuum#1192) (#641)
- docs: propose manager-role + lane substrate for airc (#642)
- docs: add lane-kanban-protocol — engineering spec for the lane substrate (#643)
- feat(heartbeat): peer-liveness envelope kind + cmd_peers tracking (airc#644 PR-1) (#645)
- hotfix: cmd_peers Python comment backtick broke airc peers in production (#645 follow-up) (#646)
- feat(heartbeat): wire emission — cmd_send --heartbeat + reminder_timer_loop hook + monitor filter (airc#644 PR-2) (#647)
- fix(heartbeat): allow empty body when --heartbeat (caught live; airc#644 PR-2 follow-up) (#648)
- fix(heartbeat): second empty-body rejection path also needed exemption (airc#644 PR-2 follow-up #2) (#649)
- fix(airc): surface sender client_id on pm-tag so multi-tab agents are distinguishable (#650)
- docs(architecture): airc-rust substrate design — generic messaging/event/network layer (DRAFT) (#651)
- feat(airc-blobs): Phase 1 scaffold — ContentAddressedStore trait + ContentHash + MediaRef (#653)
- feat(airc-blobs): FsStore — filesystem-backed sha256-addressed content store (#655)
- docs(airc-rust): Contract Layer: forge-alloy (substrate vs contract boundary) (#657)
- feat(airc-core): Identity struct + modular split (one concern per file) (#654)
- feat(airc-core): Body enum (Json | Binary) — opaque payload primitive (#656)
- feat(airc-blobs): GC + retention policy — age-based + capacity-based (#660)
- feat(airc-core): convert ID newtypes from String to UUIDv4
- feat(airc-core): envelope Headers dictionary + HeaderFilter predicate
- feat(airc-protocol): wire-level envelope, Frame, signature, subscription, LiftPolicy
- feat(airc-transport): Transport trait + LocalFsAdapter (same-Mac wire)
- fix(airc-transport): tail_loop recovers from frames.jsonl truncation/recreation
- feat(airc-protocol): real Ed25519 signing + verify (closes PR-1 stub)
- feat(airc-transport): TLS peer-pinning infrastructure (cert gen + verifiers)
- feat(airc-transport): LanTcpAdapter — TLS-wrapped TCP with peer-pinned mTLS
- feat(airc-transport): SignedTransport<T> — per-frame Ed25519 sign + verify wrapper
- feat(airc-cli): airc-rs binary — first Rust replacement for Python airc
- test(airc-cli): e2e — two airc-rs subprocesses chat over the substrate
- feat(airc-cli): daemon mode — Unix socket IPC + typed Request/Response
- fix(airc-transport): LAN-TCP readiness race + subscribers-lock-during-await
- feat(airc-cli): daemon Subscribe + Inbox — buffered consume-once reads (#678)
- style(airc-blobs): apply current rustfmt rules (#677)
- feat(airc-transport): multi-peer LanTcpAdapter (#679)
- refactor(airc-transport): split lan_tcp::adapter into module (one concern per file) (#680)
- feat(airc-cli): persisted identity state — stable peer_id + client_id (#681)
- feat(airc-cli): persistent peer registry — peers.json + daemon AddPeer/ListPeers (#682)
- feat(airc-cli): cross-platform daemon — Unix sockets + Windows named pipes (#683)
- ci: rust quality gates — fmt + clippy (deny warnings) + test on every Rust PR (#661)
- docs(airc-rust): replace body_hint with HTTP-style Headers dictionary (reopen of #658) (#662)
- docs(airc-rust): UUIDv4 for every identifier + three-field identity model (reopen of #659) (#663)
- feat(airc-cli): per-user room state — drop --wire/--channel parameter hell (#684)
- fix(airc-cli): Windows pipe-name uniqueness — UUIDv5 over full path (#685)
- fix(codex-hooks): rename TOML key codex_hooks → hooks + auto-migrate (#686)
- fix(airc-transport): LAN-TCP send pre-validates payload, no silent drops (#687)
- feat(airc-store): SeaORM-backed event store crate (slice 4 foundation) (#688)
- refactor: split daemon runtime into airc-daemon crate (slice 5 relocation) (#689)
- feat(airc-daemon): wire airc-store as the inbox backing (slice 5b) (#690)
- feat(airc-lib): consumer-facing facade crate (slice 6) (#691)
- feat(airc-lib): live subscriptions + auto-populate store on say (slice 6b) (#692)
- refactor(airc-cli): commands route through airc_lib::Airc (slice 6c) (#693)
- docs(operating-board): work-coordination domain plan (Codex design) (#694)
- feat(airc-work): typed work coordination domain (#695)
- feat(airc-work): add routable event codec (#696)
- feat(airc-work): replay work events from transcripts (#697)
- feat(airc-work-store): project persisted work events (#698)
- feat(airc-lib): expose work coordination API (#699)
- feat(airc-cli): add work coordination commands (#700)
- feat(airc-cli): add lane coordination commands (#701)
- feat(airc-cli): add workspace lease commands (#702)
- feat(airc-cli): add manager hat commands (#703)
- feat(airc-lib): add filtered event subscriptions (#704)
- feat(airc-cli): add Rust Codex hook context (#705)
- feat(airc-cli): install Codex hooks from Rust (#706)
- feat(codex): route hooks through Rust CLI (#707)
- feat(install): build and install airc-rs (#708)
- refactor(codex): remove Python hook adapters (#709)
- ci: add runtime guard checks for rust-rewrite (#710)
- refactor(codex): move detached start into Rust (#711)
- feat(airc-rs): move client identity mnemonics to rust (#712)
- feat(airc-rs): move iso timestamp parsing to rust (#713)
- feat(airc-rs): move log append and rotate to rust (#714)
- feat(airc-rs): move bearer state reads to rust (#715)
- feat(airc-rs): move logs render to rust (#716)
- feat(airc-rs): move gist JSON parsing to rust (#717)
- feat(airc-transport): add gh gist bootstrap adapter (#718)
- feat(airc-lib): add explicit transport route policy (#719)
- feat(airc-lib): add transport resolver shell (#720)
- feat(airc-lib): feed resolver from transport health (#721)
- feat(airc-rs): expose transport route status (#722)
- feat(airc-rs): move transport health to rust (#723)
- feat(airc-rs): read subscribed channels from rust (#724)
- feat(airc-rs): move channel gist config reads to rust (#725)
- feat(airc-rs): move channel config writes to rust (#726)
- feat(airc-rs): move generic config state to rust (#727)
- feat(airc-rs): move host config block to rust (#728)
- feat(airc-rs): derive daemon scope ids in rust (#729)
- feat(airc-rs): parse doctor rate-limit json in rust (#730)
- feat(airc-rs): render whois identity output in rust (#731)
- feat(airc-cli): move message crypto helpers to Rust (#732)
- feat(airc-cli): move control-plane helpers to Rust (#733)
- feat(airc-cli): build legacy message JSON in Rust (#734)
- feat(airc-cli): move channel gist discovery to Rust (#735)
- feat(airc-cli): move channel gist resolve to Rust (#736)
- feat(airc-cli): move bearer send to Rust (#737)
- refactor(airc-cli): split bearer send modules (#738)
- feat(airc-cli): move bearer recv to Rust (#739)
- feat(airc-cli): move monitor formatter to Rust (#740)
- feat(airc-cli): move local attach tail to Rust (#741)
- feat(airc-cli): move pair handshake to Rust (#742)
- feat(airc-cli): move scope repair to Rust (#743)
- feat(airc-cli): move collaboration health to Rust (#744)
- feat(airc-cli): move inbox cursoring to Rust (#745)
- feat(airc-cli): move hygiene policy to Rust (#746)
- feat(airc-cli): move knock approval crypto to Rust (#747)
- feat(airc-cli): move knock identity JSON to Rust (#748)
- feat(airc-cli): move kick peer ssh lookup to Rust (#749)
- feat(airc-cli): move worktree lane registry to Rust (#750)
- feat(airc-cli): move local identity state to Rust (#751)
- feat(airc-cli): move runtime JSON helpers to Rust (#752)
- feat(airc-cli): move queue card core to Rust (#753)
- feat(airc-cli): move queue projections to Rust (#754)
- feat(airc-cli): move queue runtime summaries to Rust (#755)
- feat(airc-cli): move queue staleness metadata to Rust (#756)
- feat(airc-cli): move queue staleness analyzer to Rust (#757)
- feat(airc-cli): move queue close-merged parsing to Rust (#758)
- feat(queue): move plan and steward projections to rust (#759)
- feat(collaboration): move peers listing to rust (#760)
- fix(invite): read channel gist through rust config (#761)
- feat(identity): move rename collision scan to rust (#762)
- feat(network): move LAN IP probe to rust (#763)
- feat(runtime): drop wrapper python startup (#764)
- feat(install): remove python runtime bootstrap (#765)
- chore(runtime): remove python debug path (#766)
- test(integration): drop legacy python unit gate (#767)
- test(integration): probe bearer kinds through rust (#768)
- test(integration): scaffold ed25519 identity through rust (#769)
- test(integration): edit top-level config through rust (#770)
- feat(config): probe quit fixtures through rust (#771)
- test(integration): probe away status through rust (#772)
- test(integration): probe tabs state through rust (#773)
- test(integration): probe heartbeat gist through rust (#774)
- fix(heartbeat): patch takeover gist lease deterministically (#775)
- test(integration): probe status outage through rust (#776)
- test(integration): probe bearer config through rust (#777)
- test(integration): probe sidecar channels through rust (#778)
- test(integration): probe channel gists through rust (#779)
- test(integration): probe bearer outcome through rust (#780)
- feat(gist): extract named file content through rust (#781)
- test(integration): probe JSON predicates through rust (#782)
- test(integration): route bearer and channel gist through rust (#783)
- test(integration): probe liveness events through rust (#784)
- fix(handshake): accept hyphen-leading public key values (#785)
- test(integration): delete legacy python bearer scenarios (#786)
- test(integration): route gh bearer scenario through rust (#787)
- test(integration): fake gone gist sends through airc-rs (#788)
- test(integration): generate gist rotation seed without python (#789)
- test(integration): remove python from platform adapters scenario (#790)
- install: stop documenting python runtime setup (#791)
- runtime: remove live airc_core references (#792)
- runtime: delete python airc_core layer (#793)
- fix(status): host health ignores joiner bearer pidfiles (#794)
- docs(architecture): transport control plane admission (#795)
- fix: fail closed on production fallback paths (#796)
- docs: define robustness integration plan (#797)
- refactor: remove fallback runtime surfaces (#798)
- ci: enforce Rust quality contracts (#799)
- fix(doctor): keep local health independent of GitHub (#800)
- docs: define invite-only gist routing architecture (#801)
- feat(routes): enforce invite-only gist admission (#802)
- feat(lib): gate sends through route resolver (#803)
- feat(lib): execute SDK sends over LAN routes (#804)
- refactor(cli): route LAN commands through airc-lib (#805)
- feat(lib): organize route discovery and health (#806)
- docs: update route requirements status (#807)
- docs: group route work into PR slices (#808)
- feat(lib): discover local route health (#809)
- feat(route): make gist an invite beacon (#810)
- feat(lib): attach SDK to daemon IPC (#811)
- refactor(cli): route daemon msg and inbox through SDK (#812)
- fix(cli): accept legacy message build command (#814)
- feat(airc-work): drain typing — workspace pressure/drain events + projection (Slice 7 PR 3a) (#813)
- feat(shell): route plain msg through rust local substrate (#815)
- feat(shell): read rust local inbox by default (#817)
- feat(airc-relay): baseline relay server + transport adapter (PR-E) (#816)
- feat(airc-transport): add realtime UDP adapter (#818)
- feat(trust-rotation): signed peer trust rotation contract + daemon application (PR-H) (#819)
- feat(airc-transport): add WebRTC datachannel adapter (#820)
- test(examples): prove SDK consumer embedding path (#821)
- test(examples): prove agent dogfood consumer path (#822)
- feat(examples): consumer integration shape contracts — Continuum/OpenClaw/Hermes (PR-I3) (#823)
- test(cli): prove installed agent identities dogfood live room (#824)
- fix(status): surface rust local data plane before gh bearer (#825)
- fix(codex-hook): pin rust hook executable and honor cursor overrides (#826)
- docs(readme): rework for the post-rewrite substrate (#827)
- fix(workspace): keep lane roots under airc home (#828)
- fix(monitor): attach to Rust event stream (#830)
- fix(teardown): verify live process reaping (#832)
- fix(install): remove rust suffix from airc surface (#833)
- fix(install): use ~/.airc/src as the source root (#835)
- feat(work): drain policy evaluator — pure substrate primitive (#834)
- fix(install): use source command as POSIX entrypoint (#836)
- fix(shell): resolve airc-core from source install (#837)
- fix(status): treat rust-local as routine health (#838)
- fix(install): PATH-augment is newline-safe + strips stale airc lines
- fix(install): rc reconcile no longer short-circuits on in-shell PATH
- fix(codex-hook): install source command path (#839)
- fix(msg): distinguish local store from peer delivery (#840)
- feat(lib): SubscriptionSet + ChannelName + identity-namespaced RoomId (#841)
- fix(events): monitor hooks use subscribed channels (#842)
- feat(lib): mesh identity resolution — replace MeshIdentity::unset() (#843)
- fix(lib): share same-machine account local wire (#844)
- feat(lib): add account room coordinator (#845)
- fix(join): seed rust account rooms from wrapper (#846)
- fix(install): put airc shim on POSIX PATH (#847)
- test(install): gate public airc shim path (#848)
- docs(install): define AI agent install contract (#849)
- test(install): prove public airc account-room runtime (#851)
- feat(lib): machine-global account coordinator (Gap 8) (#850)
- feat(lib): wire account join discovery into local delivery (#852)
- test(install): prove public monitor and hook delivery (#853)
- feat(lib): add account registry bootstrap contract (#854)
- fix(cli): route local join and broadcast through Rust (#855)
- fix(status): show rust command mode after stale startup (#856)
- fix(lib): cross-process chat actually delivers — live_tx fans out on DuplicateEventId (#857)
- fix(status): count Rust-substrate peers, not just legacy peers/ dir (#858)
- fix(send/msg): receipt no longer lies about non-delivery on shared-home wire (#859)
- feat(join): explicit scope + mesh-kind in output (#860)
- fix(join): label canonical HOME scope as machine-account home (#861)
- feat(lib): cross-machine bootstrap via gh-gist account-mesh registry (#862)
- fix(airc): restore project scope and runtime hook identity (#863)
- feat: demolition — bash wrapper deleted, airc IS the Rust binary (#864)
- fix(ci): runtime-guards green post-demolition (#865)
- fix(registry): no --paginate; bound sync with timeout; tests disable (#867)
- fix(mesh-identity): Operator-source cache never expires; bound shell-outs (#868)
- fix(airc): make join own daemon live delivery (#866)
- fix(codex-hook): trust airc.client header on shared-HOME identity (#869)
- feat(cli): restore airc join --attach and airc version subcommand (#870)
- fix(join): ensure Codex hook setup (#871)
- docs(skill): tab-loop semantics for bidirectional agent coordination (#872)
- fix(install): prefer current source tree (#873)
- fix(cli): airc join always streams ALL subscribed rooms; remove --attach (#876)
- test(join): pin runtime attach decision (#877)
- fix(join): detect Codex runtime via client identity (#878)
- docs(architecture): establish grid substrate audit (#879)
- fix(join): persist live feed cursor (#880)
- fix(store): persist runtime cursors through SeaORM (#882)
- docs(architecture): Phase 3.5 ORM end-to-end + Phase 3.6 perf hotpaths (#881)
- fix(store): persist peer trust through ORM (#883)
- fix(store): persist subscriptions through ORM (#884)
- fix(store): persist local identity metadata through ORM (#885)
- fix(store): persist mesh identity through ORM (#886)
- fix(store): persist account registry through ORM (#887)
- fix(store): persist coordinator beacons through ORM (#888)
- cleanup(lib): remove file-backed coordinator beacons (#889)
- cleanup(cli): remove config.json command shim (#890)
- refactor(identity): store-backed identity commands (#891)
- refactor(cli): remove config repair scope command (#892)
- refactor(transport): report substrate route health (#893)
- refactor(cli): remove bearer state command (#894)
- refactor(cli): remove recent senders command (#895)
- refactor(cli): remove legacy log scraping surface (#896)
- refactor(collaboration): remove jsonl presence scans (#897)
- refactor(identity): remove jsonl rename collision helper (#898)
- refactor(cli): remove legacy bearer command (#899)
- refactor(cli): remove jsonl message builder (#900)
- fix(install): copy artifacts instead of symlinking (#901)
- fix(identity): migrate identity json into orm state (#902)
- fix(lib): report peers from account mesh registry (#903)
- fix(cli): agent-runtime attach decision wins over piped-stdout (#904)
- fix(lib): wire replay skips unverifiable frames instead of aborting (#905)
- docs(codex): clarify live feed contract (#906)
- refactor(cli): isolate runtime context classification (#908)
- docs: AR/Cambrian/grid framing + data-model + Phase 3.5 migration (#907)
- refactor(cli): move codex integration behind boundary (#910)
- feat(cli): airc doctor — install + identity + scope self-diagnosis (#909)
- feat(lib): expose subscription query API (#911)
- feat(lib): command-bus primitive (Airc::request / reply / await_reply) (#912)
- docs: CI fidelity as substrate non-negotiable (#10) (#913)
- test(cli): emulate join attach in e2e harness (#915)
- feat(lib): typed lifecycle events (Phase 2) (#914)
- feat(work): add git and PR event contracts (#917)
- feat(lib): emit PeerArrived lifecycle event on add_peer (Phase 2 cont.) (#916)
- feat(work): add local git watcher adapter (#918)
- feat(lib): emit WireEstablished lifecycle event (Phase 2 cont.) (#919)
- docs: require roadmap reference in PR template (#920)
- ci: enforce PR roadmap references (#921)
- feat(lib): emit SubscriptionAdvanced on cursor saves (#922)
- feat(lib): emit RoomParted lifecycle events (#924)
- feat(lib): emit PeerDeparted lifecycle events (#925)
- ci: keep roadmap references as PR template guidance (#926)
- feat(airc-lib): WireLost emit on stream-end + teardown (#923)
- feat(codex): add pollable AIRC feed command (#927)
- test(install): prove Codex poll in public runtime (#928)
- fix(lib): keep routine wire replay quiet (#929)
- feat(cli): add Rust update command (#930)
- refactor(store): move coordinator refresh lock into ORM (#931)
- perf(lib): use set-backed event dedup (#932)
- perf(lib): broadcast live events by arc (#933)
- perf(protocol): remove global peer registry lock (#934)
- perf(lib): remove global route table locks (#935)
- perf(lib): own local ingest task lifecycle (#936)
- perf(lib): use set-backed subscription dedup (#937)
- perf(lib): shorten subscriber setup locks (#938)
- perf(lib): make event filter channels set-backed (#939)
- refactor(daemon): length-frame ipc with cbor (#940)
- fix(cli): restart daemon during update (#941)
- refactor(ipc): split daemon IPC contract into crate (#942)
- refactor(identity): split local identity into crate (#943)
- refactor(trust): split peer trust into crate (#944)
- test(command-bus): prove request reply over LAN (#945)
- feat(airc-lib): execute relay routes through SDK (#946)
- test(consumer-shapes): prove command bus integration (#948)
- feat(airc-work): PR observation adapter skeleton (#947)
- docs(audit): refresh immediate queue after PR adapter (#949)
- feat(airc-work): real gh PullRequestSource over GhCommandRunner (#950)
- docs(readme): restore generic agent IRC framing (#951)
- fix(ipc): version daemon endpoint by protocol (#952)
- fix(daemon): refresh wire trust for live ingest (#953)
- test(airc-lib): prove Continuum-shaped room throughput (#954)
- feat(airc-lib): wire UDP route execution + WebRTC signaling types (#955)
- feat(airc-lib): WebRTC DataChannel orchestration over AIRC mesh (#957)
- docs(webrtc): media tracks plan and implementation split (#959)
- feat(airc-lib): surface incoming WebRTC media tracks (#960)
- feat(airc-lib): add WebRTC media track builder (#961)
- test(airc-lib): prove WebRTC audio and video tracks (#962)
- test(airc-lib): prove WebRTC media and control share a session (#963)
- docs(audit): note observed AIRC coordination flaws (#964)
- fix(cli): restore IRC-shaped peers and whois commands (#966)
- docs(webrtc): show Continuum live-room integration example (#967)
- feat(work): heartbeat claims and surface stale owners (#969)
- feat(work): publish agent availability state (#971)
- feat(diagnostics): add typed substrate diagnostic sink (#973)
- feat(airc-lib): typed lane-coordination events (#965)
- feat(airc-lib): active-agent heartbeat events (#968)
- feat(airc-cli): bake build sha + drift detection in doctor (#972)
- feat(work): suggest claimable cards for agents (#975)
- feat(work): surface claimable queue suggestions in agent feeds (#976)
- feat(airc-lib): typed work-event subscription API (#974)
- feat(work): close completed cards (#977)
- fix(work): tolerate bounded board replay windows (#979)
- feat(airc-lib): AIRC-event diagnostic sink + doctor surface (#978)
- fix(work): preserve terminal state on claim release (#980)
- docs(audit): consumer integration gap audit + follow-up cards (#981)
- docs(audit): roadmap-to-card coverage + missing-card cleanup (#982)
- feat(work): surface agent availability in queue status (#983)
- test(lib): prove Continuum pose fan-out throughput (#984)
- feat(work): render typed agent roster (#986)
- fix(work): make duplicate claim release idempotent (#987)
- feat(airc-lib): external-identity bridge contract (#985)
- feat(work): enforce lease-zone for work claim + heartbeat diagnostic (#988)
- feat(route): add JSON route proof harness (#989)
- feat(publish): structured publish API + airc publish JSON-receipt CLI (#990)
- feat(events): add JSON list output (#991)
- docs: define cooperative coordination training signal (#992)
- fix(work): reject card transitions from wrong room (#993)
- fix(join): replace stale daemon builds from typed status (#994)
- fix(work): tolerate superseded claim release + ghost heartbeat (#996)
- feat(work): publish active-agent roster heartbeats from join (#997)
- fix(work): correlate peer claims to live roster clients (#998)
- feat(work): add typed manager loop evaluation (#999)
- docs(airc): add runtime planning and consumer audit lanes (#1000)
- docs(airc): define autonomous development roadmap (#1001)
- fix(work): find active cards beyond small recent windows (#1004)
- fix(work-store): tolerate orphaned events in complete projection (#1005)
- fix(work): schedule from complete work projection (#1006)
- feat(work): seed backlog from manager candidates (#1008)
- fix(work): make stale claims recoverable by default (#1009)
- feat(ipc): add ResolveWireRequest (channel uuid -> wire path lookup) (#1011)
- feat(inbox): --json flag for machine-readable output (#1010)
- fix(work): exclude terminal cards from stale recovery (#1012)
- fix(identity): resolve mesh identity against machine-global coordinator store (#1014)
- perf(bus): decoupled delivery bus — kill same-machine poll/fsync latency (#1015)
- fix(test): isolate two-machine bridge test via explicit wire roots — repairs Windows CI (#1016)
- docs(arch): airc event-server design — efficient ORM+push routing server (#1017)
- feat(airc-bus): owner-core event router — sharded router + hot ring + generational cursor + zero-copy fan-out (#1018)
- test(e2e): realistic timeout for process-spawn round-trips (fix macOS flake) (#1020)
- fix(reliability): LAN send-flush + lan-listen subscribe order + daemon-shutdown hang (#1021)
- feat(store): SQLite-backed DurableSink — owner-core ORM durable tier (§3.3) (#1019)
- feat(store): persistent EpochStore — generational epoch survives daemon restart (§3.8) (#1022)
- feat(wire): airc-wire — FlatBuffers binary codec for the envelope (zero-copy payload) (#1023)
- feat(work+lib+cli): autonomous-team substrate end-to-end (19 cards) (#1025)
- fix(cli): airc work state review uses Command::current_dir, not gh -C (card a4fe899f) (#1027)
- fix(cli): airc work state X merged refused — only PullRequestMerged event sets Merged (card a1bc62b3) (#1028)
- feat(store): add agent_name column to local_identity (card 8384cc18 Sub-A) (#1030)
- fix(identity): provisional git-email identity self-heals to gh login (one identity per machine) (#1024)
- fix(cli): default_home_dir skips machine-account ~/.airc + resolves to main working tree from a worktree (card a1b4552a) (#1029)
- fix(lib): work_board filters heartbeats out of the projection page (card 79953b4d) (#1031)
- fix(cli): airc work state Closed refuses unless from Merged or pre-work state (card 9656a836) (#1026)
- docs(agents): encode engineering-staff framing — CI-green-before-merge, branch hygiene, monitoring (card 53698eb9) (#1032)
- fix(install): recover from stale Rust toolchain instead of cryptic build abort (#1013)
- ef168afe/airc ci re green rust rewrite accumulate (#1033)
- feat(cli+lib): continuous-merge — `airc work merger run` auto-merges Review cards whose PRs are CI-green (card f16650cd)
