### PR TITLE
feat(work+cli+merger): peer LGTM convention — non-author approval gates auto-merge (card 267d68f5)

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -710,6 +710,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     .await
                 }
             },
+            WorkAction::Lgtm { card_id } => work_commands::run_lgtm(&home, card_id).await,
         },
 
         Command::Lane(args) => match args.action {

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -48,7 +48,22 @@
 use std::path::Path;
 use std::time::Duration;
 
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
+};
 use airc_lib::{Airc, MarkPullRequestMerged, WorkCard};
+
+/// All merger output goes through here — JSON-structured stderr per
+/// the log-hygiene doctrine (card 8864c548): no `println!` /
+/// `eprintln!` of operational status. Stdout/stderr are reserved for
+/// debug macros; substrate emits structured events the consumer
+/// process (launchd, systemd, Android foreground service, log
+/// aggregator) can filter and route. `StderrJsonDiagnosticSink` is
+/// the same sink the daemon uses; events appear as one JSON object
+/// per line on fd 2.
+fn sink() -> StderrJsonDiagnosticSink {
+    StderrJsonDiagnosticSink
+}
 
 /// Run the continuous-merge loop until shutdown (Ctrl-C / SIGTERM).
 /// Default interval at the CLI layer is 30 seconds — CI pipelines on
@@ -68,13 +83,17 @@ pub async fn run(
     crate::commands::ensure_daemon_running(home, socket.clone(), Vec::new()).await?;
     let airc = Airc::attach(home, socket).await?;
 
-    eprintln!(
-        "airc-merger: started (home={}, interval={:?}, dry_run={})",
-        home.display(),
-        interval,
-        dry_run
+    sink().emit(
+        DiagnosticEvent::info(
+            DiagnosticComponent::Merger,
+            DiagnosticCode::MergerStarted,
+            "continuous-merge loop started",
+        )
+        .with_field("home", home.display())
+        .with_field("interval_ms", interval.as_millis())
+        .with_field("dry_run", dry_run)
+        .with_field("peer_id", airc.peer_id()),
     );
-    eprintln!("airc-merger: peer_id={}", airc.peer_id());
 
     let mut ticker = tokio::time::interval(interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -86,7 +105,11 @@ pub async fn run(
         tokio::select! {
             biased;
             _ = &mut shutdown => {
-                eprintln!("airc-merger: shutdown signal received, exiting cleanly");
+                sink().emit(DiagnosticEvent::info(
+                    DiagnosticComponent::Merger,
+                    DiagnosticCode::MergerShutdown,
+                    "shutdown signal received, exiting cleanly",
+                ));
                 return Ok(());
             }
             _ = ticker.tick() => {
@@ -94,7 +117,14 @@ pub async fn run(
                     // A tick failing should NOT bring down the loop —
                     // gh might be rate-limited, the daemon might be
                     // momentarily unreachable, etc. Log and continue.
-                    eprintln!("airc-merger: tick failed: {error}");
+                    sink().emit(
+                        DiagnosticEvent::warn(
+                            DiagnosticComponent::Merger,
+                            DiagnosticCode::MergerTickFailed,
+                            "merger tick failed",
+                        )
+                        .with_field("error", error),
+                    );
                 }
             }
         }
@@ -109,37 +139,83 @@ async fn tick_once(airc: &Airc, dry_run: bool) -> Result<(), Box<dyn std::error:
     // realistic mutation rate.
     let board = airc.work_board(256).await?;
     let snapshot = board.snapshot();
+    let multi_author = is_multi_author_room(&snapshot);
 
     for card in &snapshot.cards {
-        let Some(decision) = evaluate(card).await? else {
+        let Some(decision) = evaluate(card, &board, multi_author).await? else {
             continue;
         };
         match decision {
             MergeDecision::Merge(pr) => {
                 if dry_run {
-                    eprintln!(
-                        "airc-merger: [DRY-RUN] would merge card={} pr=#{} ({})",
-                        card.card_id, pr.number, pr.repo
+                    sink().emit(
+                        DiagnosticEvent::info(
+                            DiagnosticComponent::Merger,
+                            DiagnosticCode::MergerMerged,
+                            "[dry-run] would merge",
+                        )
+                        .with_field("card_id", card.card_id)
+                        .with_field("pr_number", pr.number)
+                        .with_field("repo", &pr.repo)
+                        .with_field("dry_run", true),
                     );
                     continue;
                 }
                 match perform_merge(card, &pr, airc).await {
-                    Ok(()) => eprintln!(
-                        "airc-merger: merged card={} pr=#{} ({})",
-                        card.card_id, pr.number, pr.repo
+                    Ok(()) => sink().emit(
+                        DiagnosticEvent::info(
+                            DiagnosticComponent::Merger,
+                            DiagnosticCode::MergerMerged,
+                            "merged",
+                        )
+                        .with_field("card_id", card.card_id)
+                        .with_field("pr_number", pr.number)
+                        .with_field("repo", &pr.repo),
                     ),
-                    Err(error) => eprintln!(
-                        "airc-merger: merge failed card={} pr=#{}: {error}",
-                        card.card_id, pr.number
+                    Err(error) => sink().emit(
+                        DiagnosticEvent::error(
+                            DiagnosticComponent::Merger,
+                            DiagnosticCode::MergerMergeFailed,
+                            "merge failed",
+                        )
+                        .with_field("card_id", card.card_id)
+                        .with_field("pr_number", pr.number)
+                        .with_field("error", error),
                     ),
                 }
             }
             MergeDecision::Skip(reason) => {
-                eprintln!("airc-merger: skip card={} reason={reason}", card.card_id);
+                sink().emit(
+                    DiagnosticEvent::info(
+                        DiagnosticComponent::Merger,
+                        DiagnosticCode::MergerSkipped,
+                        "skip",
+                    )
+                    .with_field("card_id", card.card_id)
+                    .with_field("reason", reason),
+                );
             }
         }
     }
     Ok(())
+}
+
+/// Card 267d68f5: multi-author room detection. The merger's LGTM gate
+/// requires a non-author peer LGTM ONLY in multi-author rooms — solo
+/// scopes (one peer ever created any card) merge their own work
+/// without a co-signer. Using `created_by` over `owner` is
+/// deliberate: claims churn (release/reclaim), but author is fixed
+/// at creation. A room with two distinct creators IS multi-author
+/// even if one peer has all current claims.
+fn is_multi_author_room(snapshot: &airc_work::BoardSnapshot) -> bool {
+    let mut creators = std::collections::HashSet::new();
+    for card in &snapshot.cards {
+        creators.insert(card.created_by);
+        if creators.len() > 1 {
+            return true;
+        }
+    }
+    false
 }
 
 enum MergeDecision {
@@ -151,7 +227,11 @@ enum MergeDecision {
 /// even a candidate (not in Review, no PR linked); `Ok(Some(Merge))`
 /// if everything passes; `Ok(Some(Skip(reason)))` if it's a candidate
 /// that failed a gate (so we can log it instead of silently dropping).
-async fn evaluate(card: &WorkCard) -> Result<Option<MergeDecision>, Box<dyn std::error::Error>> {
+async fn evaluate(
+    card: &WorkCard,
+    projection: &airc_work::WorkBoardProjection,
+    multi_author: bool,
+) -> Result<Option<MergeDecision>, Box<dyn std::error::Error>> {
     use airc_work::model::CardState;
     if card.state != CardState::Review {
         return Ok(None);
@@ -159,6 +239,15 @@ async fn evaluate(card: &WorkCard) -> Result<Option<MergeDecision>, Box<dyn std:
     let Some(pr) = card.pull_request.clone() else {
         return Ok(None);
     };
+
+    // Card 267d68f5: peer-LGTM gate. Solo rooms (single creator
+    // ever) bypass; multi-author rooms require a non-author LGTM.
+    if multi_author && !projection.has_non_author_lgtm(card.card_id, &card.created_by) {
+        return Ok(Some(MergeDecision::Skip(format!(
+            "needs peer LGTM (multi-author room, author={})",
+            card.created_by
+        ))));
+    }
 
     match check_pr_gate(&pr).await {
         Ok(GateResult::Green) => Ok(Some(MergeDecision::Merge(pr))),

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -592,4 +592,82 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&tmp);
     }
+
+    // ========================================================================
+    // Card 267d68f5 — multi-author room detection. The merger uses this
+    // ONCE per tick to decide whether the LGTM gate applies; pinning the
+    // semantics with tests so future "improvements" don't accidentally
+    // flip a solo room into LGTM-required (which would deadlock single-
+    // peer scopes that have no co-signer).
+    // ========================================================================
+    use airc_work::model::{CardState, PullRequestRef as PrRef};
+    use airc_work::{BoardSnapshot, RepoId, WorkCard, WorkCardId};
+
+    fn snapshot_with_creators(creators: &[u128]) -> BoardSnapshot {
+        let cards: Vec<WorkCard> = creators
+            .iter()
+            .enumerate()
+            .map(|(i, seed)| WorkCard {
+                card_id: WorkCardId::from_u128((i + 1) as u128),
+                repo: RepoId::new("test/repo").unwrap(),
+                title: format!("card-{i}"),
+                body: None,
+                priority: airc_work::Priority::P1,
+                lane_id: None,
+                state: CardState::Open,
+                owner: None,
+                claim_id: None,
+                claim_expires_at_ms: None,
+                last_heartbeat_at_ms: None,
+                created_by: airc_core::PeerId::from_u128(*seed),
+                created_at_ms: 0,
+                updated_at_ms: 0,
+                pull_request: None,
+                reviews: None,
+            })
+            .collect();
+        BoardSnapshot {
+            cards,
+            lanes: Vec::new(),
+            workspaces: Vec::new(),
+            repo_tracking: Vec::new(),
+            pull_requests: Vec::new(),
+            manager_hats: Vec::new(),
+            agent_availability: Vec::new(),
+            hygiene_reports: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn solo_room_is_not_multi_author() {
+        // One peer, three cards — still solo. The LGTM gate must NOT
+        // apply (sole-author scopes ship their own work).
+        let snapshot = snapshot_with_creators(&[1, 1, 1]);
+        assert!(!is_multi_author_room(&snapshot));
+    }
+
+    #[test]
+    fn two_distinct_creators_make_it_multi_author() {
+        let snapshot = snapshot_with_creators(&[1, 2]);
+        assert!(is_multi_author_room(&snapshot));
+    }
+
+    #[test]
+    fn empty_room_is_not_multi_author() {
+        // No cards yet → no contributors visible → solo bypass. A first-
+        // card scenario shouldn't deadlock on missing peers.
+        let snapshot = snapshot_with_creators(&[]);
+        assert!(!is_multi_author_room(&snapshot));
+    }
+
+    #[test]
+    fn three_distinct_creators_still_multi_author() {
+        let snapshot = snapshot_with_creators(&[1, 2, 3]);
+        assert!(is_multi_author_room(&snapshot));
+    }
+
+    // Silence the unused-import warnings on these `use` lines if a
+    // future refactor drops some of the symbols above.
+    #[allow(dead_code)]
+    fn _silence(_p: PrRef) {}
 }

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -267,6 +267,15 @@ pub enum WorkAction {
         #[command(subcommand)]
         action: MergerAction,
     },
+    /// Card 267d68f5: cast a peer LGTM on a card's PR. Gates the
+    /// continuous-merger's auto-merge for multi-author rooms — the
+    /// merger requires at least one LGTM from a non-author peer
+    /// before shipping. Idempotent (re-voting collapses into one
+    /// entry in the projection's set).
+    Lgtm {
+        /// Card UUID being approved.
+        card_id: String,
+    },
 }
 
 #[derive(Debug, clap::Subcommand)]

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -905,6 +905,23 @@ pub async fn run_close(home: &Path, card_id: String) -> Result<(), Box<dyn std::
     run_state(home, card_id, CliCardState::Closed).await
 }
 
+/// Card 267d68f5: cast a peer LGTM on a card's PR. Publishes a
+/// `WorkLgtmCast` event signed by this peer. Idempotent. The
+/// continuous-merger consults the projection's set on the next tick
+/// to decide whether a Review-state card can auto-merge.
+pub async fn run_lgtm(home: &Path, card_id: String) -> Result<(), Box<dyn std::error::Error>> {
+    use airc_lib::CastWorkLgtm;
+    let card_uuid = parse_work_card_id(&card_id)?;
+    let airc = crate::commands::attached_airc(home).await?;
+    airc.cast_work_lgtm(CastWorkLgtm { card_id: card_uuid })
+        .await?;
+    println!(
+        "work_lgtm_cast: card_id={card_id} voted_by={}",
+        airc.peer_id()
+    );
+    Ok(())
+}
+
 /// Card 9656a836: gate the close transition. Returns `true` when a
 /// card in `state` is allowed to transition to Closed.
 ///

--- a/crates/airc-diagnostics/src/lib.rs
+++ b/crates/airc-diagnostics/src/lib.rs
@@ -24,6 +24,7 @@ pub enum DiagnosticSeverity {
 #[serde(rename_all = "snake_case")]
 pub enum DiagnosticComponent {
     Daemon,
+    Merger,
     Monitor,
     Replay,
     Subscriber,
@@ -45,6 +46,16 @@ pub enum DiagnosticCode {
     ReplayFramesSkipped,
     WebRtcOfferAnswerFailed,
     WorkspaceLeaseViolation,
+    // Card f16650cd + log-hygiene card 8864c548: continuous-merger
+    // emits these from its loop instead of eprintln. Structured
+    // events survive non-tty contexts (launchd, systemd, Android
+    // foreground service) where stdout/stderr would be eaten.
+    MergerStarted,
+    MergerShutdown,
+    MergerTickFailed,
+    MergerSkipped,
+    MergerMerged,
+    MergerMergeFailed,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -72,6 +83,14 @@ impl DiagnosticEvent {
             fields: BTreeMap::new(),
             occurred_at_ms: now_ms(),
         }
+    }
+
+    pub fn info(
+        component: DiagnosticComponent,
+        code: DiagnosticCode,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::new(DiagnosticSeverity::Info, component, code, message)
     }
 
     pub fn warn(

--- a/crates/airc-lib/src/diagnostic_event_sink.rs
+++ b/crates/airc-lib/src/diagnostic_event_sink.rs
@@ -168,6 +168,7 @@ fn severity_header_value(severity: DiagnosticSeverity) -> &'static str {
 fn component_header_value(component: DiagnosticComponent) -> &'static str {
     match component {
         DiagnosticComponent::Daemon => "daemon",
+        DiagnosticComponent::Merger => "merger",
         DiagnosticComponent::Monitor => "monitor",
         DiagnosticComponent::Replay => "replay",
         DiagnosticComponent::Subscriber => "subscriber",
@@ -189,6 +190,12 @@ fn code_header_value(code: DiagnosticCode) -> &'static str {
         DiagnosticCode::ReplayFramesSkipped => "replay_frames_skipped",
         DiagnosticCode::WebRtcOfferAnswerFailed => "webrtc_offer_answer_failed",
         DiagnosticCode::WorkspaceLeaseViolation => "workspace_lease_violation",
+        DiagnosticCode::MergerStarted => "merger_started",
+        DiagnosticCode::MergerShutdown => "merger_shutdown",
+        DiagnosticCode::MergerTickFailed => "merger_tick_failed",
+        DiagnosticCode::MergerSkipped => "merger_skipped",
+        DiagnosticCode::MergerMerged => "merger_merged",
+        DiagnosticCode::MergerMergeFailed => "merger_merge_failed",
     }
 }
 

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -131,12 +131,12 @@ pub use webrtc_media::{
     OutgoingSampleTrack, OutgoingVideoTrack, WebRtcConnectionBuilder, WebRtcMediaCodec,
 };
 pub use work::{
-    AllocateWorkspace, ChangeWorkCardState, ChangeWorkLaneState, ClaimManagerHat, ClaimWorkCard,
-    ClaimableWorkItem, ClaimableWorkQuery, CreateWorkCard, CreateWorkLane, HeartbeatWorkClaim,
-    HeartbeatWorkspace, LinkCardPullRequest, MarkPullRequestMerged, ObserveLocalGitWorkspace,
-    ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests, ReleaseManagerHat,
-    ReleaseWorkClaim, ReleaseWorkspace, ReportAgentAvailability, RequestWorkspace, UpdateWorkCard,
-    WorkQueueStatus, WorkQueueStatusQuery,
+    AllocateWorkspace, CastWorkLgtm, ChangeWorkCardState, ChangeWorkLaneState, ClaimManagerHat,
+    ClaimWorkCard, ClaimableWorkItem, ClaimableWorkQuery, CreateWorkCard, CreateWorkLane,
+    HeartbeatWorkClaim, HeartbeatWorkspace, LinkCardPullRequest, MarkPullRequestMerged,
+    ObserveLocalGitWorkspace, ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests,
+    ReleaseManagerHat, ReleaseWorkClaim, ReleaseWorkspace, ReportAgentAvailability,
+    RequestWorkspace, UpdateWorkCard, WorkQueueStatus, WorkQueueStatusQuery,
 };
 pub use work_manager::{
     SeededWorkCard, WorkBacklogSeedCandidate, WorkBacklogSeedOutcome, WorkBacklogSeedResult,

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -172,6 +172,15 @@ pub struct MarkPullRequestMerged {
     pub merged_at_ms: u64,
 }
 
+/// Card 267d68f5: peer LGTM. A peer (presumed non-author — the
+/// projection enforces author-distinct semantics on consumption)
+/// approves the card's PR for merge. Idempotent: repeated casts by
+/// the same peer collapse into one set entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CastWorkLgtm {
+    pub card_id: WorkCardId,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HeartbeatWorkClaim {
     pub card_id: WorkCardId,
@@ -496,6 +505,23 @@ impl Airc {
             pull_request: request.pull_request,
             linked_by: self.peer_id(),
             linked_at_ms: now_ms()?,
+        });
+        self.publish_work_event(&event).await?;
+        Ok(())
+    }
+
+    /// Card 267d68f5: cast a peer LGTM. The continuous-merger gates
+    /// auto-merge on at least one LGTM from a non-author peer for
+    /// multi-author rooms. Idempotent — voting twice is harmless.
+    /// `voted_by` is the calling peer's id; the projection enforces
+    /// author-distinct semantics, not the publish path.
+    pub async fn cast_work_lgtm(&self, request: CastWorkLgtm) -> Result<(), AircError> {
+        self.ensure_work_card_in_current_room(request.card_id)
+            .await?;
+        let event = WorkEvent::WorkLgtmCast(airc_work::event::WorkLgtmCast {
+            card_id: request.card_id,
+            voted_by: self.peer_id(),
+            voted_at_ms: now_ms()?,
         });
         self.publish_work_event(&event).await?;
         Ok(())

--- a/crates/airc-work/src/codec/headers.rs
+++ b/crates/airc-work/src/codec/headers.rs
@@ -129,6 +129,9 @@ fn project_domain_headers(event: &WorkEvent, headers: &mut Headers) {
             insert_display_header(headers, HEADER_FORGE_WORK_CARD_ID, e.card_id);
             project_pull_request(headers, &e.pull_request);
         }
+        WorkEvent::WorkLgtmCast(e) => {
+            insert_display_header(headers, HEADER_FORGE_WORK_CARD_ID, e.card_id);
+        }
         WorkEvent::HygieneReportRecorded(e) => {
             headers.insert(
                 HEADER_FORGE_WORK_REPO.to_string(),

--- a/crates/airc-work/src/codec/mod.rs
+++ b/crates/airc-work/src/codec/mod.rs
@@ -106,6 +106,7 @@ pub(crate) fn event_kind(event: &WorkEvent) -> &'static str {
         WorkEvent::PullRequestMergeStateChanged(_) => "pull_request_merge_state_changed",
         WorkEvent::PullRequestLinked(_) => "pull_request_linked",
         WorkEvent::PullRequestMerged(_) => "pull_request_merged",
+        WorkEvent::WorkLgtmCast(_) => "work_lgtm_cast",
         WorkEvent::HygieneReportRecorded(_) => "hygiene_report_recorded",
         WorkEvent::ManagerHatClaimed(_) => "manager_hat_claimed",
         WorkEvent::ManagerHatReleased(_) => "manager_hat_released",

--- a/crates/airc-work/src/event.rs
+++ b/crates/airc-work/src/event.rs
@@ -37,6 +37,7 @@ pub enum WorkEvent {
     PullRequestMergeStateChanged(PullRequestMergeStateChanged),
     PullRequestLinked(PullRequestLinked),
     PullRequestMerged(PullRequestMerged),
+    WorkLgtmCast(WorkLgtmCast),
     HygieneReportRecorded(HygieneReportRecorded),
     ManagerHatClaimed(ManagerHatClaimed),
     ManagerHatReleased(ManagerHatReleased),
@@ -69,6 +70,7 @@ impl WorkEvent {
             WorkEvent::PullRequestMergeStateChanged(e) => e.changed_at_ms,
             WorkEvent::PullRequestLinked(e) => e.linked_at_ms,
             WorkEvent::PullRequestMerged(e) => e.merged_at_ms,
+            WorkEvent::WorkLgtmCast(e) => e.voted_at_ms,
             WorkEvent::HygieneReportRecorded(e) => e.report.recorded_at_ms,
             WorkEvent::ManagerHatClaimed(e) => e.claimed_at_ms,
             WorkEvent::ManagerHatReleased(e) => e.released_at_ms,
@@ -369,6 +371,18 @@ pub struct PullRequestMerged {
     pub pull_request: PullRequestRef,
     pub merged_by: PeerId,
     pub merged_at_ms: u64,
+}
+
+/// Card 267d68f5 — peer LGTM: a non-author peer signals the card's
+/// PR is approved for merge. Substrate-native (no GitHub round-trip);
+/// the continuous-merger consults the projection's lgtm voter set
+/// before auto-merging in multi-author rooms. Idempotent: re-voting
+/// is harmless (the projection stores a set, not a list).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkLgtmCast {
+    pub card_id: WorkCardId,
+    pub voted_by: PeerId,
+    pub voted_at_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/airc-work/src/projection.rs
+++ b/crates/airc-work/src/projection.rs
@@ -43,6 +43,33 @@ pub struct WorkBoardProjection {
     pub(super) manager_hats: BTreeMap<RepoId, ManagerHat>,
     pub(super) agent_availability: BTreeMap<String, AgentAvailabilityRecord>,
     pub(super) hygiene_reports: Vec<HygieneReport>,
+    /// Card 267d68f5 — set of peers who've cast LGTM for each card.
+    /// Used by the continuous-merger to gate multi-author rooms: a
+    /// non-author LGTM is required before auto-merge. Idempotent
+    /// across re-votes (set semantics).
+    pub(super) work_lgtm_votes: BTreeMap<WorkCardId, std::collections::HashSet<PeerId>>,
+}
+
+impl WorkBoardProjection {
+    /// Set of peers who've cast LGTM for `card_id`. Empty if none.
+    /// Card 267d68f5 — consumed by the continuous-merger and by
+    /// `airc work board` renderers that want to surface review
+    /// progress (`✓ 1 lgtm`).
+    pub fn lgtm_voters(&self, card_id: WorkCardId) -> impl Iterator<Item = &PeerId> + '_ {
+        self.work_lgtm_votes
+            .get(&card_id)
+            .into_iter()
+            .flat_map(|set| set.iter())
+    }
+
+    /// True when at least one peer DIFFERENT from `author` has cast
+    /// LGTM for `card_id`. The continuous-merger's gate for
+    /// multi-author rooms: an author can't approve their own work.
+    pub fn has_non_author_lgtm(&self, card_id: WorkCardId, author: &PeerId) -> bool {
+        self.work_lgtm_votes
+            .get(&card_id)
+            .is_some_and(|set| set.iter().any(|p| p != author))
+    }
 }
 
 impl WorkBoardProjection {

--- a/crates/airc-work/src/projection/apply.rs
+++ b/crates/airc-work/src/projection/apply.rs
@@ -3,8 +3,8 @@ use crate::event::{
     ClaimReleased, GitBranchMoved, GitCommitObserved, GitDirtyStateChanged, HygieneReportRecorded,
     LaneCreated, LaneStateChanged, ManagerHatClaimed, ManagerHatReleased,
     PullRequestCheckSuiteChanged, PullRequestLinked, PullRequestMergeStateChanged,
-    PullRequestMerged, PullRequestReviewSubmitted, WorkCardClaimed, WorkEvent, WorkspaceAllocated,
-    WorkspaceDrainCompleted, WorkspaceDrainRequested, WorkspaceHeartbeat,
+    PullRequestMerged, PullRequestReviewSubmitted, WorkCardClaimed, WorkEvent, WorkLgtmCast,
+    WorkspaceAllocated, WorkspaceDrainCompleted, WorkspaceDrainRequested, WorkspaceHeartbeat,
     WorkspacePressureReported, WorkspaceReleased, WorkspaceRequested,
 };
 use crate::ids::{WorkCardId, WorkspaceId};
@@ -55,6 +55,10 @@ impl WorkBoardProjection {
             }
             WorkEvent::PullRequestLinked(e) => self.apply_pull_request_linked(e),
             WorkEvent::PullRequestMerged(e) => self.apply_pull_request_merged(e),
+            WorkEvent::WorkLgtmCast(e) => {
+                self.apply_work_lgtm_cast(e);
+                Ok(())
+            }
             WorkEvent::HygieneReportRecorded(e) => self.apply_hygiene_report_recorded(e),
             WorkEvent::ManagerHatClaimed(e) => self.apply_manager_hat_claimed(e),
             WorkEvent::ManagerHatReleased(e) => self.apply_manager_hat_released(e),
@@ -482,6 +486,20 @@ impl WorkBoardProjection {
         card.state = CardState::Merged;
         card.updated_at_ms = e.merged_at_ms;
         Ok(())
+    }
+
+    /// Card 267d68f5 — record a peer's LGTM. Set semantics: re-voting
+    /// is harmless (idempotent). Unlike most apply_* functions this
+    /// doesn't require the card to exist in the projection first; an
+    /// LGTM landing in a transcript window before its CardCreated
+    /// (rare but possible during replay-window scans) still gets
+    /// retained so the `has_non_author_lgtm` check is conservative
+    /// after a CardCreated catches up.
+    fn apply_work_lgtm_cast(&mut self, e: &WorkLgtmCast) {
+        self.work_lgtm_votes
+            .entry(e.card_id)
+            .or_default()
+            .insert(e.voted_by);
     }
 
     fn apply_hygiene_report_recorded(

--- a/crates/airc-work/src/projection/tests.rs
+++ b/crates/airc-work/src/projection/tests.rs
@@ -1378,3 +1378,175 @@ fn card_updated_round_trips_through_serde_with_skip_on_none() {
     let decoded: CardUpdated = serde_json::from_value(json).expect("decode clear");
     assert_eq!(decoded, clear);
 }
+
+// ============================================================================
+// Card 267d68f5 — peer LGTM projection accessors. The merger consults
+// `has_non_author_lgtm(card_id, author)` on every tick in multi-author
+// rooms; these tests pin the contract.
+// ============================================================================
+
+fn card_created(card_id: WorkCardId, author: PeerId, at_ms: u64) -> WorkEvent {
+    WorkEvent::CardCreated(CardCreated {
+        card_id,
+        repo: repo(),
+        title: "lgtm-gated work".to_string(),
+        body: None,
+        priority: Priority::P1,
+        lane_id: None,
+        created_by: author,
+        created_at_ms: at_ms,
+        reviews: None,
+    })
+}
+
+fn lgtm(card_id: WorkCardId, voter: PeerId, at_ms: u64) -> WorkEvent {
+    WorkEvent::WorkLgtmCast(WorkLgtmCast {
+        card_id,
+        voted_by: voter,
+        voted_at_ms: at_ms,
+    })
+}
+
+#[test]
+fn lgtm_cast_records_vote_in_projection() {
+    let card_id = WorkCardId::from_u128(101);
+    let author = peer(1);
+    let voter = peer(2);
+    let mut projection = WorkBoardProjection::new();
+
+    projection
+        .apply(&card_created(card_id, author, 100))
+        .unwrap();
+    projection.apply(&lgtm(card_id, voter, 150)).unwrap();
+
+    let voters: Vec<&PeerId> = projection.lgtm_voters(card_id).collect();
+    assert_eq!(voters.len(), 1, "exactly one voter recorded");
+    assert_eq!(*voters[0], voter, "the recorded voter is the one who voted");
+}
+
+#[test]
+fn lgtm_double_vote_by_same_peer_is_idempotent() {
+    // Set semantics: a peer voting twice doesn't compound. Important
+    // because re-running `airc work lgtm <id>` should be safe.
+    let card_id = WorkCardId::from_u128(102);
+    let author = peer(1);
+    let voter = peer(2);
+    let mut projection = WorkBoardProjection::new();
+
+    projection
+        .apply(&card_created(card_id, author, 100))
+        .unwrap();
+    projection.apply(&lgtm(card_id, voter, 150)).unwrap();
+    projection.apply(&lgtm(card_id, voter, 160)).unwrap();
+    projection.apply(&lgtm(card_id, voter, 170)).unwrap();
+
+    let count = projection.lgtm_voters(card_id).count();
+    assert_eq!(count, 1, "re-voting collapses into one set entry");
+}
+
+#[test]
+fn lgtm_distinct_voters_accumulate() {
+    let card_id = WorkCardId::from_u128(103);
+    let author = peer(1);
+    let voter_a = peer(2);
+    let voter_b = peer(3);
+    let mut projection = WorkBoardProjection::new();
+
+    projection
+        .apply(&card_created(card_id, author, 100))
+        .unwrap();
+    projection.apply(&lgtm(card_id, voter_a, 150)).unwrap();
+    projection.apply(&lgtm(card_id, voter_b, 160)).unwrap();
+
+    let count = projection.lgtm_voters(card_id).count();
+    assert_eq!(count, 2, "two distinct voters yields two set entries");
+}
+
+#[test]
+fn has_non_author_lgtm_false_when_no_votes() {
+    let card_id = WorkCardId::from_u128(104);
+    let author = peer(1);
+    let mut projection = WorkBoardProjection::new();
+    projection
+        .apply(&card_created(card_id, author, 100))
+        .unwrap();
+
+    assert!(
+        !projection.has_non_author_lgtm(card_id, &author),
+        "zero votes → no non-author LGTM"
+    );
+}
+
+#[test]
+fn has_non_author_lgtm_false_when_only_author_voted() {
+    // The merger MUST reject self-approval: an author casting LGTM
+    // on their own card doesn't satisfy the gate. This is the core
+    // safety property of the LGTM convention.
+    let card_id = WorkCardId::from_u128(105);
+    let author = peer(1);
+    let mut projection = WorkBoardProjection::new();
+
+    projection
+        .apply(&card_created(card_id, author, 100))
+        .unwrap();
+    projection.apply(&lgtm(card_id, author, 150)).unwrap();
+
+    assert!(
+        !projection.has_non_author_lgtm(card_id, &author),
+        "author voting for own card does NOT unlock the gate"
+    );
+}
+
+#[test]
+fn has_non_author_lgtm_true_when_peer_voted() {
+    let card_id = WorkCardId::from_u128(106);
+    let author = peer(1);
+    let peer_b = peer(2);
+    let mut projection = WorkBoardProjection::new();
+
+    projection
+        .apply(&card_created(card_id, author, 100))
+        .unwrap();
+    projection.apply(&lgtm(card_id, peer_b, 150)).unwrap();
+
+    assert!(
+        projection.has_non_author_lgtm(card_id, &author),
+        "any peer != author satisfies the gate"
+    );
+}
+
+#[test]
+fn has_non_author_lgtm_true_when_author_also_voted_alongside_peer() {
+    // Author self-LGTM is harmless if a peer ALSO voted — the gate
+    // just needs ONE non-author voter; the author's own vote in the
+    // set doesn't subtract from that.
+    let card_id = WorkCardId::from_u128(107);
+    let author = peer(1);
+    let peer_b = peer(2);
+    let mut projection = WorkBoardProjection::new();
+
+    projection
+        .apply(&card_created(card_id, author, 100))
+        .unwrap();
+    projection.apply(&lgtm(card_id, author, 150)).unwrap();
+    projection.apply(&lgtm(card_id, peer_b, 160)).unwrap();
+
+    assert!(
+        projection.has_non_author_lgtm(card_id, &author),
+        "author + peer voting both → gate open (peer's vote counts)"
+    );
+}
+
+#[test]
+fn lgtm_for_unrecorded_card_does_not_panic() {
+    // Card 267d68f5 has an explicit looseness in apply_work_lgtm_cast:
+    // an LGTM landing in a transcript window before its CardCreated
+    // still gets retained. Verify the projection doesn't error.
+    let card_id = WorkCardId::from_u128(108);
+    let voter = peer(2);
+    let mut projection = WorkBoardProjection::new();
+
+    projection.apply(&lgtm(card_id, voter, 150)).unwrap();
+    let count = projection.lgtm_voters(card_id).count();
+    assert_eq!(count, 1, "vote preserved even without a CardCreated event");
+}


### PR DESCRIPTION
- fix(codex): poll inbox after sending airc messages (#556)
- feat(knock): public collaboration knock entrypoint (airc#559 PR-1) (#560)
- feat(approve): forward-secret room-invite handoff (airc#559 PR-2) (#561)
- feat(queue): add issue-backed queue add/list
- feat(queue): claim/release/set-status verbs (airc#562 PR-2) (#568)
- feat(queue): nudge verb — surface card to peers (airc#562 PR-3) (#573)
- fix(#571): route every gh body write through --body-file (lib_gh.sh) (#574)
- feat(queue): repo-scoped nudge status sweep (#578)
- fix(gh): safely close issues with markdown comments (#582)
- feat(queue): adopt existing issues into queue cards (#583)
- feat(lane): add worktree lanes for agents (#585)
- feat(queue): summarize repo nudge pongs (#586)
- feat(#576): auto-close queue cards when PRs merge into canary (#581)
- fix(#576): detect queue refs in PR titles (#587)
- feat(#572): queue heartbeat and stale scan (#588)
- feat(#570): embeddable queue and room widgets (#589)
- feat(#591): summarize queue availability (#592)
- fix(#593): ignore repo-nudge templates in pongs (#594)
- fix(#596): honor per-agent queue owner (#597)
- fix: add session work identity for queue ownership (#598)
- fix(queue): close already-merged queue cards (#599)
- fix(queue): require closing keywords for close-merged
- fix(queue): preserve issue titles
- feat(queue): recommend next work for idle agents
- feat(queue): allow cross-repo close-merged
- feat(queue): add metronome idle pulse
- fix(queue): prevent accidental claim takeovers
- docs(readme): document AI work queue workflow (#614)
- feat(queue): warn on stale PR branches (#617)
- refactor(queue): split command helpers (#618)
- fix(queue): default planning view and unclaimed-owner semantics (#620)
- Fix collaboration health for same-nick peers (#625)
- fix(lane): hydrate submodules after worktree add (continuum#1252) (#624)
- feat(queue): personalized dispatch verb (closes continuum#1192 broadcast→idle gap) (#623)
- fix(queue): dispatch metronome hand-outs (#627)
- feat: add hygiene policy command (#632)
- fix: fail closed on update conflicts (#633)
- docs: design rust sqlite substrate (#634)
- docs: design realtime event bus (#635)
- feat(queue): add steward dry-run digest (#636)
- feat(core): add Rust transcript primitives (#637)
- feat(logs): add json transcript pages (#638)
- fix(logs): avoid strict-mode crash without json flag (#639)
- refactor(logs): use one render path for human and json modes (#640)
- feat(queue): metronome fan-out across active roster (airc#607, continuum#1192) (#641)
- docs: propose manager-role + lane substrate for airc (#642)
- docs: add lane-kanban-protocol — engineering spec for the lane substrate (#643)
- feat(heartbeat): peer-liveness envelope kind + cmd_peers tracking (airc#644 PR-1) (#645)
- hotfix: cmd_peers Python comment backtick broke airc peers in production (#645 follow-up) (#646)
- feat(heartbeat): wire emission — cmd_send --heartbeat + reminder_timer_loop hook + monitor filter (airc#644 PR-2) (#647)
- fix(heartbeat): allow empty body when --heartbeat (caught live; airc#644 PR-2 follow-up) (#648)
- fix(heartbeat): second empty-body rejection path also needed exemption (airc#644 PR-2 follow-up #2) (#649)
- fix(airc): surface sender client_id on pm-tag so multi-tab agents are distinguishable (#650)
- docs(architecture): airc-rust substrate design — generic messaging/event/network layer (DRAFT) (#651)
- feat(airc-blobs): Phase 1 scaffold — ContentAddressedStore trait + ContentHash + MediaRef (#653)
- feat(airc-blobs): FsStore — filesystem-backed sha256-addressed content store (#655)
- docs(airc-rust): Contract Layer: forge-alloy (substrate vs contract boundary) (#657)
- feat(airc-core): Identity struct + modular split (one concern per file) (#654)
- feat(airc-core): Body enum (Json | Binary) — opaque payload primitive (#656)
- feat(airc-blobs): GC + retention policy — age-based + capacity-based (#660)
- feat(airc-core): convert ID newtypes from String to UUIDv4
- feat(airc-core): envelope Headers dictionary + HeaderFilter predicate
- feat(airc-protocol): wire-level envelope, Frame, signature, subscription, LiftPolicy
- feat(airc-transport): Transport trait + LocalFsAdapter (same-Mac wire)
- fix(airc-transport): tail_loop recovers from frames.jsonl truncation/recreation
- feat(airc-protocol): real Ed25519 signing + verify (closes PR-1 stub)
- feat(airc-transport): TLS peer-pinning infrastructure (cert gen + verifiers)
- feat(airc-transport): LanTcpAdapter — TLS-wrapped TCP with peer-pinned mTLS
- feat(airc-transport): SignedTransport<T> — per-frame Ed25519 sign + verify wrapper
- feat(airc-cli): airc-rs binary — first Rust replacement for Python airc
- test(airc-cli): e2e — two airc-rs subprocesses chat over the substrate
- feat(airc-cli): daemon mode — Unix socket IPC + typed Request/Response
- fix(airc-transport): LAN-TCP readiness race + subscribers-lock-during-await
- feat(airc-cli): daemon Subscribe + Inbox — buffered consume-once reads (#678)
- style(airc-blobs): apply current rustfmt rules (#677)
- feat(airc-transport): multi-peer LanTcpAdapter (#679)
- refactor(airc-transport): split lan_tcp::adapter into module (one concern per file) (#680)
- feat(airc-cli): persisted identity state — stable peer_id + client_id (#681)
- feat(airc-cli): persistent peer registry — peers.json + daemon AddPeer/ListPeers (#682)
- feat(airc-cli): cross-platform daemon — Unix sockets + Windows named pipes (#683)
- ci: rust quality gates — fmt + clippy (deny warnings) + test on every Rust PR (#661)
- docs(airc-rust): replace body_hint with HTTP-style Headers dictionary (reopen of #658) (#662)
- docs(airc-rust): UUIDv4 for every identifier + three-field identity model (reopen of #659) (#663)
- feat(airc-cli): per-user room state — drop --wire/--channel parameter hell (#684)
- fix(airc-cli): Windows pipe-name uniqueness — UUIDv5 over full path (#685)
- fix(codex-hooks): rename TOML key codex_hooks → hooks + auto-migrate (#686)
- fix(airc-transport): LAN-TCP send pre-validates payload, no silent drops (#687)
- feat(airc-store): SeaORM-backed event store crate (slice 4 foundation) (#688)
- refactor: split daemon runtime into airc-daemon crate (slice 5 relocation) (#689)
- feat(airc-daemon): wire airc-store as the inbox backing (slice 5b) (#690)
- feat(airc-lib): consumer-facing facade crate (slice 6) (#691)
- feat(airc-lib): live subscriptions + auto-populate store on say (slice 6b) (#692)
- refactor(airc-cli): commands route through airc_lib::Airc (slice 6c) (#693)
- docs(operating-board): work-coordination domain plan (Codex design) (#694)
- feat(airc-work): typed work coordination domain (#695)
- feat(airc-work): add routable event codec (#696)
- feat(airc-work): replay work events from transcripts (#697)
- feat(airc-work-store): project persisted work events (#698)
- feat(airc-lib): expose work coordination API (#699)
- feat(airc-cli): add work coordination commands (#700)
- feat(airc-cli): add lane coordination commands (#701)
- feat(airc-cli): add workspace lease commands (#702)
- feat(airc-cli): add manager hat commands (#703)
- feat(airc-lib): add filtered event subscriptions (#704)
- feat(airc-cli): add Rust Codex hook context (#705)
- feat(airc-cli): install Codex hooks from Rust (#706)
- feat(codex): route hooks through Rust CLI (#707)
- feat(install): build and install airc-rs (#708)
- refactor(codex): remove Python hook adapters (#709)
- ci: add runtime guard checks for rust-rewrite (#710)
- refactor(codex): move detached start into Rust (#711)
- feat(airc-rs): move client identity mnemonics to rust (#712)
- feat(airc-rs): move iso timestamp parsing to rust (#713)
- feat(airc-rs): move log append and rotate to rust (#714)
- feat(airc-rs): move bearer state reads to rust (#715)
- feat(airc-rs): move logs render to rust (#716)
- feat(airc-rs): move gist JSON parsing to rust (#717)
- feat(airc-transport): add gh gist bootstrap adapter (#718)
- feat(airc-lib): add explicit transport route policy (#719)
- feat(airc-lib): add transport resolver shell (#720)
- feat(airc-lib): feed resolver from transport health (#721)
- feat(airc-rs): expose transport route status (#722)
- feat(airc-rs): move transport health to rust (#723)
- feat(airc-rs): read subscribed channels from rust (#724)
- feat(airc-rs): move channel gist config reads to rust (#725)
- feat(airc-rs): move channel config writes to rust (#726)
- feat(airc-rs): move generic config state to rust (#727)
- feat(airc-rs): move host config block to rust (#728)
- feat(airc-rs): derive daemon scope ids in rust (#729)
- feat(airc-rs): parse doctor rate-limit json in rust (#730)
- feat(airc-rs): render whois identity output in rust (#731)
- feat(airc-cli): move message crypto helpers to Rust (#732)
- feat(airc-cli): move control-plane helpers to Rust (#733)
- feat(airc-cli): build legacy message JSON in Rust (#734)
- feat(airc-cli): move channel gist discovery to Rust (#735)
- feat(airc-cli): move channel gist resolve to Rust (#736)
- feat(airc-cli): move bearer send to Rust (#737)
- refactor(airc-cli): split bearer send modules (#738)
- feat(airc-cli): move bearer recv to Rust (#739)
- feat(airc-cli): move monitor formatter to Rust (#740)
- feat(airc-cli): move local attach tail to Rust (#741)
- feat(airc-cli): move pair handshake to Rust (#742)
- feat(airc-cli): move scope repair to Rust (#743)
- feat(airc-cli): move collaboration health to Rust (#744)
- feat(airc-cli): move inbox cursoring to Rust (#745)
- feat(airc-cli): move hygiene policy to Rust (#746)
- feat(airc-cli): move knock approval crypto to Rust (#747)
- feat(airc-cli): move knock identity JSON to Rust (#748)
- feat(airc-cli): move kick peer ssh lookup to Rust (#749)
- feat(airc-cli): move worktree lane registry to Rust (#750)
- feat(airc-cli): move local identity state to Rust (#751)
- feat(airc-cli): move runtime JSON helpers to Rust (#752)
- feat(airc-cli): move queue card core to Rust (#753)
- feat(airc-cli): move queue projections to Rust (#754)
- feat(airc-cli): move queue runtime summaries to Rust (#755)
- feat(airc-cli): move queue staleness metadata to Rust (#756)
- feat(airc-cli): move queue staleness analyzer to Rust (#757)
- feat(airc-cli): move queue close-merged parsing to Rust (#758)
- feat(queue): move plan and steward projections to rust (#759)
- feat(collaboration): move peers listing to rust (#760)
- fix(invite): read channel gist through rust config (#761)
- feat(identity): move rename collision scan to rust (#762)
- feat(network): move LAN IP probe to rust (#763)
- feat(runtime): drop wrapper python startup (#764)
- feat(install): remove python runtime bootstrap (#765)
- chore(runtime): remove python debug path (#766)
- test(integration): drop legacy python unit gate (#767)
- test(integration): probe bearer kinds through rust (#768)
- test(integration): scaffold ed25519 identity through rust (#769)
- test(integration): edit top-level config through rust (#770)
- feat(config): probe quit fixtures through rust (#771)
- test(integration): probe away status through rust (#772)
- test(integration): probe tabs state through rust (#773)
- test(integration): probe heartbeat gist through rust (#774)
- fix(heartbeat): patch takeover gist lease deterministically (#775)
- test(integration): probe status outage through rust (#776)
- test(integration): probe bearer config through rust (#777)
- test(integration): probe sidecar channels through rust (#778)
- test(integration): probe channel gists through rust (#779)
- test(integration): probe bearer outcome through rust (#780)
- feat(gist): extract named file content through rust (#781)
- test(integration): probe JSON predicates through rust (#782)
- test(integration): route bearer and channel gist through rust (#783)
- test(integration): probe liveness events through rust (#784)
- fix(handshake): accept hyphen-leading public key values (#785)
- test(integration): delete legacy python bearer scenarios (#786)
- test(integration): route gh bearer scenario through rust (#787)
- test(integration): fake gone gist sends through airc-rs (#788)
- test(integration): generate gist rotation seed without python (#789)
- test(integration): remove python from platform adapters scenario (#790)
- install: stop documenting python runtime setup (#791)
- runtime: remove live airc_core references (#792)
- runtime: delete python airc_core layer (#793)
- fix(status): host health ignores joiner bearer pidfiles (#794)
- docs(architecture): transport control plane admission (#795)
- fix: fail closed on production fallback paths (#796)
- docs: define robustness integration plan (#797)
- refactor: remove fallback runtime surfaces (#798)
- ci: enforce Rust quality contracts (#799)
- fix(doctor): keep local health independent of GitHub (#800)
- docs: define invite-only gist routing architecture (#801)
- feat(routes): enforce invite-only gist admission (#802)
- feat(lib): gate sends through route resolver (#803)
- feat(lib): execute SDK sends over LAN routes (#804)
- refactor(cli): route LAN commands through airc-lib (#805)
- feat(lib): organize route discovery and health (#806)
- docs: update route requirements status (#807)
- docs: group route work into PR slices (#808)
- feat(lib): discover local route health (#809)
- feat(route): make gist an invite beacon (#810)
- feat(lib): attach SDK to daemon IPC (#811)
- refactor(cli): route daemon msg and inbox through SDK (#812)
- fix(cli): accept legacy message build command (#814)
- feat(airc-work): drain typing — workspace pressure/drain events + projection (Slice 7 PR 3a) (#813)
- feat(shell): route plain msg through rust local substrate (#815)
- feat(shell): read rust local inbox by default (#817)
- feat(airc-relay): baseline relay server + transport adapter (PR-E) (#816)
- feat(airc-transport): add realtime UDP adapter (#818)
- feat(trust-rotation): signed peer trust rotation contract + daemon application (PR-H) (#819)
- feat(airc-transport): add WebRTC datachannel adapter (#820)
- test(examples): prove SDK consumer embedding path (#821)
- test(examples): prove agent dogfood consumer path (#822)
- feat(examples): consumer integration shape contracts — Continuum/OpenClaw/Hermes (PR-I3) (#823)
- test(cli): prove installed agent identities dogfood live room (#824)
- fix(status): surface rust local data plane before gh bearer (#825)
- fix(codex-hook): pin rust hook executable and honor cursor overrides (#826)
- docs(readme): rework for the post-rewrite substrate (#827)
- fix(workspace): keep lane roots under airc home (#828)
- fix(monitor): attach to Rust event stream (#830)
- fix(teardown): verify live process reaping (#832)
- fix(install): remove rust suffix from airc surface (#833)
- fix(install): use ~/.airc/src as the source root (#835)
- feat(work): drain policy evaluator — pure substrate primitive (#834)
- fix(install): use source command as POSIX entrypoint (#836)
- fix(shell): resolve airc-core from source install (#837)
- fix(status): treat rust-local as routine health (#838)
- fix(install): PATH-augment is newline-safe + strips stale airc lines
- fix(install): rc reconcile no longer short-circuits on in-shell PATH
- fix(codex-hook): install source command path (#839)
- fix(msg): distinguish local store from peer delivery (#840)
- feat(lib): SubscriptionSet + ChannelName + identity-namespaced RoomId (#841)
- fix(events): monitor hooks use subscribed channels (#842)
- feat(lib): mesh identity resolution — replace MeshIdentity::unset() (#843)
- fix(lib): share same-machine account local wire (#844)
- feat(lib): add account room coordinator (#845)
- fix(join): seed rust account rooms from wrapper (#846)
- fix(install): put airc shim on POSIX PATH (#847)
- test(install): gate public airc shim path (#848)
- docs(install): define AI agent install contract (#849)
- test(install): prove public airc account-room runtime (#851)
- feat(lib): machine-global account coordinator (Gap 8) (#850)
- feat(lib): wire account join discovery into local delivery (#852)
- test(install): prove public monitor and hook delivery (#853)
- feat(lib): add account registry bootstrap contract (#854)
- fix(cli): route local join and broadcast through Rust (#855)
- fix(status): show rust command mode after stale startup (#856)
- fix(lib): cross-process chat actually delivers — live_tx fans out on DuplicateEventId (#857)
- fix(status): count Rust-substrate peers, not just legacy peers/ dir (#858)
- fix(send/msg): receipt no longer lies about non-delivery on shared-home wire (#859)
- feat(join): explicit scope + mesh-kind in output (#860)
- fix(join): label canonical HOME scope as machine-account home (#861)
- feat(lib): cross-machine bootstrap via gh-gist account-mesh registry (#862)
- fix(airc): restore project scope and runtime hook identity (#863)
- feat: demolition — bash wrapper deleted, airc IS the Rust binary (#864)
- fix(ci): runtime-guards green post-demolition (#865)
- fix(registry): no --paginate; bound sync with timeout; tests disable (#867)
- fix(mesh-identity): Operator-source cache never expires; bound shell-outs (#868)
- fix(airc): make join own daemon live delivery (#866)
- fix(codex-hook): trust airc.client header on shared-HOME identity (#869)
- feat(cli): restore airc join --attach and airc version subcommand (#870)
- fix(join): ensure Codex hook setup (#871)
- docs(skill): tab-loop semantics for bidirectional agent coordination (#872)
- fix(install): prefer current source tree (#873)
- fix(cli): airc join always streams ALL subscribed rooms; remove --attach (#876)
- test(join): pin runtime attach decision (#877)
- fix(join): detect Codex runtime via client identity (#878)
- docs(architecture): establish grid substrate audit (#879)
- fix(join): persist live feed cursor (#880)
- fix(store): persist runtime cursors through SeaORM (#882)
- docs(architecture): Phase 3.5 ORM end-to-end + Phase 3.6 perf hotpaths (#881)
- fix(store): persist peer trust through ORM (#883)
- fix(store): persist subscriptions through ORM (#884)
- fix(store): persist local identity metadata through ORM (#885)
- fix(store): persist mesh identity through ORM (#886)
- fix(store): persist account registry through ORM (#887)
- fix(store): persist coordinator beacons through ORM (#888)
- cleanup(lib): remove file-backed coordinator beacons (#889)
- cleanup(cli): remove config.json command shim (#890)
- refactor(identity): store-backed identity commands (#891)
- refactor(cli): remove config repair scope command (#892)
- refactor(transport): report substrate route health (#893)
- refactor(cli): remove bearer state command (#894)
- refactor(cli): remove recent senders command (#895)
- refactor(cli): remove legacy log scraping surface (#896)
- refactor(collaboration): remove jsonl presence scans (#897)
- refactor(identity): remove jsonl rename collision helper (#898)
- refactor(cli): remove legacy bearer command (#899)
- refactor(cli): remove jsonl message builder (#900)
- fix(install): copy artifacts instead of symlinking (#901)
- fix(identity): migrate identity json into orm state (#902)
- fix(lib): report peers from account mesh registry (#903)
- fix(cli): agent-runtime attach decision wins over piped-stdout (#904)
- fix(lib): wire replay skips unverifiable frames instead of aborting (#905)
- docs(codex): clarify live feed contract (#906)
- refactor(cli): isolate runtime context classification (#908)
- docs: AR/Cambrian/grid framing + data-model + Phase 3.5 migration (#907)
- refactor(cli): move codex integration behind boundary (#910)
- feat(cli): airc doctor — install + identity + scope self-diagnosis (#909)
- feat(lib): expose subscription query API (#911)
- feat(lib): command-bus primitive (Airc::request / reply / await_reply) (#912)
- docs: CI fidelity as substrate non-negotiable (#10) (#913)
- test(cli): emulate join attach in e2e harness (#915)
- feat(lib): typed lifecycle events (Phase 2) (#914)
- feat(work): add git and PR event contracts (#917)
- feat(lib): emit PeerArrived lifecycle event on add_peer (Phase 2 cont.) (#916)
- feat(work): add local git watcher adapter (#918)
- feat(lib): emit WireEstablished lifecycle event (Phase 2 cont.) (#919)
- docs: require roadmap reference in PR template (#920)
- ci: enforce PR roadmap references (#921)
- feat(lib): emit SubscriptionAdvanced on cursor saves (#922)
- feat(lib): emit RoomParted lifecycle events (#924)
- feat(lib): emit PeerDeparted lifecycle events (#925)
- ci: keep roadmap references as PR template guidance (#926)
- feat(airc-lib): WireLost emit on stream-end + teardown (#923)
- feat(codex): add pollable AIRC feed command (#927)
- test(install): prove Codex poll in public runtime (#928)
- fix(lib): keep routine wire replay quiet (#929)
- feat(cli): add Rust update command (#930)
- refactor(store): move coordinator refresh lock into ORM (#931)
- perf(lib): use set-backed event dedup (#932)
- perf(lib): broadcast live events by arc (#933)
- perf(protocol): remove global peer registry lock (#934)
- perf(lib): remove global route table locks (#935)
- perf(lib): own local ingest task lifecycle (#936)
- perf(lib): use set-backed subscription dedup (#937)
- perf(lib): shorten subscriber setup locks (#938)
- perf(lib): make event filter channels set-backed (#939)
- refactor(daemon): length-frame ipc with cbor (#940)
- fix(cli): restart daemon during update (#941)
- refactor(ipc): split daemon IPC contract into crate (#942)
- refactor(identity): split local identity into crate (#943)
- refactor(trust): split peer trust into crate (#944)
- test(command-bus): prove request reply over LAN (#945)
- feat(airc-lib): execute relay routes through SDK (#946)
- test(consumer-shapes): prove command bus integration (#948)
- feat(airc-work): PR observation adapter skeleton (#947)
- docs(audit): refresh immediate queue after PR adapter (#949)
- feat(airc-work): real gh PullRequestSource over GhCommandRunner (#950)
- docs(readme): restore generic agent IRC framing (#951)
- fix(ipc): version daemon endpoint by protocol (#952)
- fix(daemon): refresh wire trust for live ingest (#953)
- test(airc-lib): prove Continuum-shaped room throughput (#954)
- feat(airc-lib): wire UDP route execution + WebRTC signaling types (#955)
- feat(airc-lib): WebRTC DataChannel orchestration over AIRC mesh (#957)
- docs(webrtc): media tracks plan and implementation split (#959)
- feat(airc-lib): surface incoming WebRTC media tracks (#960)
- feat(airc-lib): add WebRTC media track builder (#961)
- test(airc-lib): prove WebRTC audio and video tracks (#962)
- test(airc-lib): prove WebRTC media and control share a session (#963)
- docs(audit): note observed AIRC coordination flaws (#964)
- fix(cli): restore IRC-shaped peers and whois commands (#966)
- docs(webrtc): show Continuum live-room integration example (#967)
- feat(work): heartbeat claims and surface stale owners (#969)
- feat(work): publish agent availability state (#971)
- feat(diagnostics): add typed substrate diagnostic sink (#973)
- feat(airc-lib): typed lane-coordination events (#965)
- feat(airc-lib): active-agent heartbeat events (#968)
- feat(airc-cli): bake build sha + drift detection in doctor (#972)
- feat(work): suggest claimable cards for agents (#975)
- feat(work): surface claimable queue suggestions in agent feeds (#976)
- feat(airc-lib): typed work-event subscription API (#974)
- feat(work): close completed cards (#977)
- fix(work): tolerate bounded board replay windows (#979)
- feat(airc-lib): AIRC-event diagnostic sink + doctor surface (#978)
- fix(work): preserve terminal state on claim release (#980)
- docs(audit): consumer integration gap audit + follow-up cards (#981)
- docs(audit): roadmap-to-card coverage + missing-card cleanup (#982)
- feat(work): surface agent availability in queue status (#983)
- test(lib): prove Continuum pose fan-out throughput (#984)
- feat(work): render typed agent roster (#986)
- fix(work): make duplicate claim release idempotent (#987)
- feat(airc-lib): external-identity bridge contract (#985)
- feat(work): enforce lease-zone for work claim + heartbeat diagnostic (#988)
- feat(route): add JSON route proof harness (#989)
- feat(publish): structured publish API + airc publish JSON-receipt CLI (#990)
- feat(events): add JSON list output (#991)
- docs: define cooperative coordination training signal (#992)
- fix(work): reject card transitions from wrong room (#993)
- fix(join): replace stale daemon builds from typed status (#994)
- fix(work): tolerate superseded claim release + ghost heartbeat (#996)
- feat(work): publish active-agent roster heartbeats from join (#997)
- fix(work): correlate peer claims to live roster clients (#998)
- feat(work): add typed manager loop evaluation (#999)
- docs(airc): add runtime planning and consumer audit lanes (#1000)
- docs(airc): define autonomous development roadmap (#1001)
- fix(work): find active cards beyond small recent windows (#1004)
- fix(work-store): tolerate orphaned events in complete projection (#1005)
- fix(work): schedule from complete work projection (#1006)
- feat(work): seed backlog from manager candidates (#1008)
- fix(work): make stale claims recoverable by default (#1009)
- feat(ipc): add ResolveWireRequest (channel uuid -> wire path lookup) (#1011)
- feat(inbox): --json flag for machine-readable output (#1010)
- fix(work): exclude terminal cards from stale recovery (#1012)
- fix(identity): resolve mesh identity against machine-global coordinator store (#1014)
- perf(bus): decoupled delivery bus — kill same-machine poll/fsync latency (#1015)
- fix(test): isolate two-machine bridge test via explicit wire roots — repairs Windows CI (#1016)
- docs(arch): airc event-server design — efficient ORM+push routing server (#1017)
- feat(airc-bus): owner-core event router — sharded router + hot ring + generational cursor + zero-copy fan-out (#1018)
- test(e2e): realistic timeout for process-spawn round-trips (fix macOS flake) (#1020)
- fix(reliability): LAN send-flush + lan-listen subscribe order + daemon-shutdown hang (#1021)
- feat(store): SQLite-backed DurableSink — owner-core ORM durable tier (§3.3) (#1019)
- feat(store): persistent EpochStore — generational epoch survives daemon restart (§3.8) (#1022)
- feat(wire): airc-wire — FlatBuffers binary codec for the envelope (zero-copy payload) (#1023)
- feat(work+lib+cli): autonomous-team substrate end-to-end (19 cards) (#1025)
- fix(cli): airc work state review uses Command::current_dir, not gh -C (card a4fe899f) (#1027)
- fix(cli): airc work state X merged refused — only PullRequestMerged event sets Merged (card a1bc62b3) (#1028)
- feat(store): add agent_name column to local_identity (card 8384cc18 Sub-A) (#1030)
- fix(identity): provisional git-email identity self-heals to gh login (one identity per machine) (#1024)
- fix(cli): default_home_dir skips machine-account ~/.airc + resolves to main working tree from a worktree (card a1b4552a) (#1029)
- fix(lib): work_board filters heartbeats out of the projection page (card 79953b4d) (#1031)
- fix(cli): airc work state Closed refuses unless from Merged or pre-work state (card 9656a836) (#1026)
- docs(agents): encode engineering-staff framing — CI-green-before-merge, branch hygiene, monitoring (card 53698eb9) (#1032)
- fix(install): recover from stale Rust toolchain instead of cryptic build abort (#1013)
- ef168afe/airc ci re green rust rewrite accumulate (#1033)
- fix(cli): gh pr create reads commit subject as title — not branch slug (card 13131f1c) (#1034)
- 28f1440c/airc work state review open pr and link (#1035)
- feat(cli+lib): continuous-merge — `airc work merger run` auto-merges Review cards whose PRs are CI-green (card f16650cd) (#1037)
- feat(work+cli+merger): peer LGTM convention — non-author approval gates auto-merge in multi-author rooms (card 267d68f5)
