### PR TITLE
dec35ec7/airc cli introduce typed ghclient gitcli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "sha2",
  "temp-env",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "toml_edit",
  "uuid",

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -43,6 +43,7 @@ hkdf = "0.12"
 rand_core = { version = "0.6", features = ["getrandom"] }
 fs2 = "0.4"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+thiserror = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/airc-cli/src/gh_client.rs
+++ b/crates/airc-cli/src/gh_client.rs
@@ -1,0 +1,501 @@
+// Card dec35ec7 ships the substrate; the merger consumes pr_view +
+// pr_merge in this PR. The remaining methods (pr_create, pr_edit_base,
+// parse_pr_url, the OutputParse error variant, the pr_create-shaped
+// argument types) are wired into work_commands.rs as a follow-up
+// (#1041) so this PR doesn't conflict with peer's c0bd865c
+// (work_commands split). Each is dead-code today; the allowlist is
+// per-module and scoped to that explicit follow-up.
+#![allow(dead_code)]
+
+//! Typed wrapper around the `gh` CLI.
+//!
+//! Card dec35ec7. Before this module, every airc-cli command that
+//! talked to GitHub built its own `tokio::process::Command::new("gh")`,
+//! parsed stderr into a human string, decoded stdout via inline
+//! `serde_json::from_slice`, and returned `Box<dyn std::error::Error>`.
+//! 21+ sites across the workspace; three of them lived in
+//! `work_commands.rs` alone, none sharing helpers.
+//!
+//! Net effect: every consumer (continuum, openclaw, hermes, codex)
+//! looking to embed airc had to re-implement the same gh
+//! orchestration in their language, or fork the airc CLI per
+//! operation. Neither is what the substrate is for.
+//!
+//! [`GhClient`] is the typed boundary. Callers get:
+//!
+//! - **Typed responses** ([`PrView`], [`PrCreated`], [`MergeReceipt`])
+//!   instead of raw JSON `Value`.
+//! - **Typed errors** ([`GhError`]) instead of `Box<dyn Error>`. The
+//!   merger can match `GhError::RateLimited` and back off; the
+//!   close-guard can match `GhError::PrConflicts` and refuse rather
+//!   than swallowing.
+//! - **One place** for the "set cwd, not `gh -C`" lesson (card
+//!   a4fe899f), for the rate-limit detection logic, for the JSON
+//!   parsing that has to evolve as gh's schema does.
+//! - **Pure parse helpers** ([`parse_pr_view`], [`parse_pr_url`])
+//!   that don't need a real `gh` to test — synthetic JSON in,
+//!   typed value out.
+//!
+//! Future cards expand the surface (gh issue, gh repo view's other
+//! fields, gh api PATCH for the body-edit workaround tracked as
+//! 3bf62fbb). This module is the place to add them.
+
+use std::path::Path;
+
+use serde::Deserialize;
+use thiserror::Error;
+use tokio::process::Command;
+
+/// Typed errors from any `gh` invocation. Variants are the *actions*
+/// a caller can take in response, not the exit codes — so a future
+/// migration to `gh api`'s structured error shape doesn't churn the
+/// downstream `match`es.
+#[derive(Debug, Error)]
+pub enum GhError {
+    /// `gh` binary not on PATH or not executable. Operator config
+    /// problem; nothing to retry.
+    #[error("gh binary not found on PATH: {0}")]
+    GhNotFound(std::io::Error),
+
+    /// `gh auth status` failed when the call attempted authentication.
+    /// Operator needs `gh auth login`.
+    #[error("gh authentication required: run `gh auth login` ({stderr})")]
+    AuthRequired { stderr: String },
+
+    /// `gh` ran but the cwd isn't a github checkout (no `origin`
+    /// remote, non-github origin, etc.). Card 59243bee already gates
+    /// some of this on the airc side; this is the gh-side surface.
+    #[error("not in a github checkout: {stderr}")]
+    NotInGithubRepo { stderr: String },
+
+    /// Hit GitHub's rate limit. Callers should back off and retry.
+    /// The merger's tick failure path should match this and skip
+    /// rather than logging an opaque "tick failed".
+    #[error("github rate limit reached: {stderr}")]
+    RateLimited { stderr: String },
+
+    /// The PR exists but cannot be merged in its current state —
+    /// conflicts, branch protection failure, or non-OPEN state.
+    /// Distinct from a JSON-parse failure so the merger can hold
+    /// the card in Review and wait.
+    #[error("pr not mergeable: {stderr}")]
+    PrNotMergeable { stderr: String },
+
+    /// Catch-all for `gh` exiting non-zero in a way we haven't
+    /// classified yet. Includes the stderr so the operator can act,
+    /// but downstream code should NOT pattern-match on the string —
+    /// upgrade to a typed variant if the case recurs.
+    #[error("gh exited {code:?}: {stderr}")]
+    GhExited { code: Option<i32>, stderr: String },
+
+    /// `gh`'s JSON output didn't deserialize. Either a gh schema
+    /// drift or we passed the wrong --json fields. Bug, not runtime
+    /// condition.
+    #[error("could not parse gh json output: {0}")]
+    JsonParse(#[from] serde_json::Error),
+
+    /// `gh`'s stdout was the wrong shape (e.g. expected a PR URL on
+    /// the last non-empty line, got something else). Distinct from
+    /// `JsonParse` because gh's pr-create output is plain text, not
+    /// JSON.
+    #[error("could not parse gh output: {0}")]
+    OutputParse(String),
+
+    /// Process management failed (couldn't spawn, couldn't read
+    /// stdout). Underlying io::Error included.
+    #[error("gh process failed: {0}")]
+    Process(#[from] std::io::Error),
+}
+
+/// Stateless typed wrapper around `gh`. Held by the CLI for the
+/// session; methods are `&self` so callers can share one instance.
+///
+/// Holding a wrapper rather than a free function is deliberate: it
+/// gives a place to add session-scoped state (a cached `gh auth
+/// status`, a rate-limit backoff cursor, a shared tokio runtime) and
+/// makes mocking possible in tests without polluting every callsite
+/// with a generic parameter.
+#[derive(Debug, Default, Clone)]
+pub struct GhClient {
+    // Reserved for session state. Empty struct today; adding fields
+    // here doesn't break callers because `GhClient::default()` is
+    // the only ctor.
+}
+
+impl GhClient {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `gh pr view <number> --repo <owner/name> --json state,mergeable,statusCheckRollup`.
+    ///
+    /// Used by the continuous-merger (#1037) to gate auto-merge.
+    /// `cwd` is the worktree the call should run from — gh resolves
+    /// the origin remote from cwd, NOT from `-C` (card a4fe899f).
+    pub async fn pr_view(&self, args: PrViewArgs<'_>) -> Result<PrView, GhError> {
+        let mut cmd = Command::new("gh");
+        if let Some(cwd) = args.cwd {
+            cmd.current_dir(cwd);
+        }
+        let output = cmd
+            .args([
+                "pr",
+                "view",
+                &args.number.to_string(),
+                "--repo",
+                args.repo,
+                "--json",
+                "state,mergeable,statusCheckRollup",
+            ])
+            .output()
+            .await
+            .map_err(self::map_spawn_error)?;
+        if !output.status.success() {
+            return Err(classify_gh_failure(&output));
+        }
+        parse_pr_view(&output.stdout)
+    }
+
+    /// `gh pr create --fill --base <branch>` from `cwd`.
+    ///
+    /// gh's pr-create output is plain text (the PR URL on the last
+    /// non-empty line of stdout), not JSON. Card 13131f1c tracks
+    /// the title-derivation issue; not this module's concern.
+    pub async fn pr_create(&self, args: PrCreateArgs<'_>) -> Result<PrCreated, GhError> {
+        let output = Command::new("gh")
+            .current_dir(args.cwd)
+            .args(["pr", "create", "--fill", "--base", args.base])
+            .output()
+            .await
+            .map_err(self::map_spawn_error)?;
+        if !output.status.success() {
+            return Err(classify_gh_failure(&output));
+        }
+        let stdout = std::str::from_utf8(&output.stdout)
+            .map_err(|e| GhError::OutputParse(format!("non-utf8 gh output: {e}")))?;
+        parse_pr_url(stdout)
+    }
+
+    /// `gh pr merge <number> --repo <owner/name> --squash --delete-branch`.
+    /// The merger's terminal call once gate logic passes.
+    pub async fn pr_merge(&self, args: PrMergeArgs<'_>) -> Result<MergeReceipt, GhError> {
+        let output = Command::new("gh")
+            .args([
+                "pr",
+                "merge",
+                &args.number.to_string(),
+                "--repo",
+                args.repo,
+                "--squash",
+                "--delete-branch",
+            ])
+            .output()
+            .await
+            .map_err(self::map_spawn_error)?;
+        if !output.status.success() {
+            return Err(classify_gh_failure(&output));
+        }
+        Ok(MergeReceipt {
+            number: args.number,
+            repo: args.repo.to_string(),
+        })
+    }
+
+    /// `gh api -X PATCH repos/{owner}/{repo}/pulls/{number}` with the
+    /// supplied `base` ref. Workaround for the Projects-classic
+    /// deprecation that breaks `gh pr edit --base` (card 3bf62fbb).
+    /// The plain `gh pr edit` path emits a hard error from the
+    /// GraphQL projectCards subselection; the REST PATCH route is
+    /// the documented workaround until gh upgrades.
+    pub async fn pr_edit_base(&self, args: PrEditBaseArgs<'_>) -> Result<(), GhError> {
+        let path = format!("repos/{}/pulls/{}", args.repo, args.number);
+        let base_field = format!("base={}", args.base);
+        let output = Command::new("gh")
+            .args(["api", "-X", "PATCH", &path, "-f", &base_field])
+            .output()
+            .await
+            .map_err(self::map_spawn_error)?;
+        if !output.status.success() {
+            return Err(classify_gh_failure(&output));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PrViewArgs<'a> {
+    pub repo: &'a str,
+    pub number: u64,
+    /// Optional cwd. None = process cwd; Some(p) = gh resolves
+    /// origin remote from p.
+    pub cwd: Option<&'a Path>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrCreateArgs<'a> {
+    /// Worktree directory the new PR is opened from. gh reads
+    /// `git remote get-url origin` here.
+    pub cwd: &'a Path,
+    /// Integration branch the PR targets. For airc that's
+    /// `rust-rewrite` (card 28f1440c).
+    pub base: &'a str,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrMergeArgs<'a> {
+    pub repo: &'a str,
+    pub number: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrEditBaseArgs<'a> {
+    pub repo: &'a str,
+    pub number: u64,
+    pub base: &'a str,
+}
+
+/// `gh pr view --json state,mergeable,statusCheckRollup` shape.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct PrView {
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub mergeable: String,
+    #[serde(default, rename = "statusCheckRollup")]
+    pub status_check_rollup: Option<Vec<GhCheck>>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct GhCheck {
+    #[serde(default)]
+    pub conclusion: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrCreated {
+    pub url: String,
+    pub number: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MergeReceipt {
+    pub repo: String,
+    pub number: u64,
+}
+
+// --- pure parsers (testable without spawning gh) ---
+
+/// Decode the JSON body of `gh pr view --json ...` into [`PrView`].
+/// Pure — synthetic JSON in, typed value out. The merger and the
+/// close-guard both depend on this shape, so this is where the
+/// schema round-trip is pinned in tests.
+pub fn parse_pr_view(json: &[u8]) -> Result<PrView, GhError> {
+    Ok(serde_json::from_slice(json)?)
+}
+
+/// Extract the PR URL + number from `gh pr create`'s plain-text
+/// stdout. gh prints the URL on the last non-empty line; the number
+/// is the trailing path segment.
+///
+/// Returns [`GhError::OutputParse`] when the shape doesn't match —
+/// callers should NOT fall back to "extract from any line that looks
+/// URL-shaped" (gh's output evolves; bug surface should surface).
+pub fn parse_pr_url(stdout: &str) -> Result<PrCreated, GhError> {
+    let url = stdout
+        .lines()
+        .map(str::trim)
+        .rfind(|l| !l.is_empty())
+        .ok_or_else(|| GhError::OutputParse("gh pr create produced no output lines".into()))?;
+    let number = url
+        .rsplit('/')
+        .next()
+        .and_then(|tail| tail.parse::<u64>().ok())
+        .ok_or_else(|| {
+            GhError::OutputParse(format!(
+                "could not extract PR number from gh output line: {url:?}"
+            ))
+        })?;
+    Ok(PrCreated {
+        url: url.to_string(),
+        number,
+    })
+}
+
+/// Classify a non-zero `gh` exit. The substrings are intentionally
+/// matched against gh's English error messages — if gh's locale or
+/// error wording changes, this stops working, which is exactly what
+/// we want (silent mis-classification would be worse). Each branch
+/// here exists because the calling code has a different action to
+/// take per case.
+fn classify_gh_failure(output: &std::process::Output) -> GhError {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let lowered = stderr.to_lowercase();
+    if lowered.contains("rate limit") || lowered.contains("api rate-limit") {
+        GhError::RateLimited { stderr }
+    } else if lowered.contains("authentication") || lowered.contains("gh auth login") {
+        GhError::AuthRequired { stderr }
+    } else if lowered.contains("not a github")
+        || lowered.contains("no git remote")
+        || lowered.contains("could not determine repository")
+    {
+        GhError::NotInGithubRepo { stderr }
+    } else if lowered.contains("conflict") || lowered.contains("not mergeable") {
+        GhError::PrNotMergeable { stderr }
+    } else {
+        GhError::GhExited {
+            code: output.status.code(),
+            stderr,
+        }
+    }
+}
+
+/// Map a `tokio::process::Command::output()` io::Error into the
+/// typed shape. The "gh not found on PATH" case is special because
+/// it's actionable as operator config — distinguish it from a
+/// generic process failure.
+fn map_spawn_error(error: std::io::Error) -> GhError {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        GhError::GhNotFound(error)
+    } else {
+        GhError::Process(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_pr_view_decodes_all_fields() {
+        let json = br#"{
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"name": "fmt",     "status": "COMPLETED",  "conclusion": "SUCCESS"},
+                {"name": "tests",   "status": "IN_PROGRESS", "conclusion": null},
+                {"name": "clippy",  "status": "COMPLETED",  "conclusion": "FAILURE"}
+            ]
+        }"#;
+        let view = parse_pr_view(json).expect("parse");
+        assert_eq!(view.state, "OPEN");
+        assert_eq!(view.mergeable, "MERGEABLE");
+        let checks = view.status_check_rollup.unwrap();
+        assert_eq!(checks.len(), 3);
+        assert_eq!(
+            checks[1].conclusion, None,
+            "in-flight check has null conclusion"
+        );
+    }
+
+    #[test]
+    fn parse_pr_view_tolerates_missing_optional_fields() {
+        let json = br#"{}"#;
+        let view = parse_pr_view(json).expect("empty object decodes");
+        assert!(view.state.is_empty());
+        assert!(view.mergeable.is_empty());
+        assert!(view.status_check_rollup.is_none());
+    }
+
+    #[test]
+    fn parse_pr_url_extracts_last_url_and_number() {
+        let stdout = "Creating draft pull request for refs/heads/feat/x into rust-rewrite\n\
+                      https://github.com/CambrianTech/airc/pull/1038\n";
+        let created = parse_pr_url(stdout).expect("parse");
+        assert_eq!(created.number, 1038);
+        assert_eq!(
+            created.url,
+            "https://github.com/CambrianTech/airc/pull/1038"
+        );
+    }
+
+    #[test]
+    fn parse_pr_url_rejects_unparseable_tail() {
+        let stdout = "https://github.com/owner/repo/pull/not-a-number\n";
+        assert!(matches!(parse_pr_url(stdout), Err(GhError::OutputParse(_))));
+    }
+
+    #[test]
+    fn parse_pr_url_rejects_empty_output() {
+        assert!(matches!(parse_pr_url(""), Err(GhError::OutputParse(_))));
+        assert!(matches!(
+            parse_pr_url("\n\n  \n"),
+            Err(GhError::OutputParse(_))
+        ));
+    }
+
+    /// Card a4fe899f's gh-not-found case (operator missing gh CLI):
+    /// distinguish from generic IO failure so the operator gets a
+    /// real corrective hint.
+    #[test]
+    fn map_spawn_error_distinguishes_not_found_from_other_io() {
+        let not_found = std::io::Error::new(std::io::ErrorKind::NotFound, "gh");
+        assert!(matches!(map_spawn_error(not_found), GhError::GhNotFound(_)));
+
+        let permission = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "gh");
+        assert!(matches!(map_spawn_error(permission), GhError::Process(_)));
+    }
+
+    /// classify_gh_failure pins the substring matches the merger
+    /// will rely on. If gh changes its wording, these break loudly
+    /// — better than silently bucketing everything into GhExited.
+    fn output_with_stderr(stderr: &str) -> std::process::Output {
+        std::process::Output {
+            status: {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::ExitStatusExt;
+                    std::process::ExitStatus::from_raw(256) // non-zero exit
+                }
+                #[cfg(windows)]
+                {
+                    use std::os::windows::process::ExitStatusExt;
+                    std::process::ExitStatus::from_raw(1)
+                }
+            },
+            stdout: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
+    #[test]
+    fn classify_rate_limit_message() {
+        let err = classify_gh_failure(&output_with_stderr(
+            "API rate limit exceeded for installation",
+        ));
+        assert!(matches!(err, GhError::RateLimited { .. }));
+    }
+
+    #[test]
+    fn classify_auth_required_message() {
+        let err = classify_gh_failure(&output_with_stderr(
+            "authentication failed; run `gh auth login`",
+        ));
+        assert!(matches!(err, GhError::AuthRequired { .. }));
+    }
+
+    #[test]
+    fn classify_not_in_repo_message() {
+        let err = classify_gh_failure(&output_with_stderr(
+            "could not determine repository: no git remote",
+        ));
+        assert!(matches!(err, GhError::NotInGithubRepo { .. }));
+    }
+
+    #[test]
+    fn classify_merge_conflict_message() {
+        let err = classify_gh_failure(&output_with_stderr(
+            "Pull request not mergeable: conflicts with base branch",
+        ));
+        assert!(matches!(err, GhError::PrNotMergeable { .. }));
+    }
+
+    #[test]
+    fn classify_unknown_message_buckets_to_gh_exited() {
+        let err = classify_gh_failure(&output_with_stderr("something went sideways"));
+        assert!(matches!(err, GhError::GhExited { .. }));
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -36,6 +36,7 @@ mod event_render;
 mod events_cli;
 mod events_commands;
 mod gh_cli;
+mod gh_client;
 mod gh_commands;
 mod gh_state;
 mod gist_cli;

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -76,6 +76,12 @@ pub async fn run(
     );
     eprintln!("airc-merger: peer_id={}", airc.peer_id());
 
+    // Card dec35ec7: one GhClient per merger session. Reserved for
+    // future session-scoped state (rate-limit backoff cursor, cached
+    // auth status); today it's stateless but lives at the right
+    // scope.
+    let gh = crate::gh_client::GhClient::new();
+
     let mut ticker = tokio::time::interval(interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -90,7 +96,7 @@ pub async fn run(
                 return Ok(());
             }
             _ = ticker.tick() => {
-                if let Err(error) = tick_once(&airc, dry_run).await {
+                if let Err(error) = tick_once(&gh, &airc, dry_run).await {
                     // A tick failing should NOT bring down the loop —
                     // gh might be rate-limited, the daemon might be
                     // momentarily unreachable, etc. Log and continue.
@@ -102,7 +108,11 @@ pub async fn run(
 }
 
 /// One pass over the board: scan eligible cards, gate, merge.
-async fn tick_once(airc: &Airc, dry_run: bool) -> Result<(), Box<dyn std::error::Error>> {
+async fn tick_once(
+    gh: &crate::gh_client::GhClient,
+    airc: &Airc,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Limit chosen large enough to surface every Review card with a
     // PR in practice. The board fetch already filters heartbeats
     // (card 79953b4d), so 256 work events back is several days of
@@ -111,7 +121,7 @@ async fn tick_once(airc: &Airc, dry_run: bool) -> Result<(), Box<dyn std::error:
     let snapshot = board.snapshot();
 
     for card in &snapshot.cards {
-        let Some(decision) = evaluate(card).await? else {
+        let Some(decision) = evaluate(gh, card).await? else {
             continue;
         };
         match decision {
@@ -123,7 +133,7 @@ async fn tick_once(airc: &Airc, dry_run: bool) -> Result<(), Box<dyn std::error:
                     );
                     continue;
                 }
-                match perform_merge(card, &pr, airc).await {
+                match perform_merge(gh, card, &pr, airc).await {
                     Ok(()) => eprintln!(
                         "airc-merger: merged card={} pr=#{} ({})",
                         card.card_id, pr.number, pr.repo
@@ -151,7 +161,10 @@ enum MergeDecision {
 /// even a candidate (not in Review, no PR linked); `Ok(Some(Merge))`
 /// if everything passes; `Ok(Some(Skip(reason)))` if it's a candidate
 /// that failed a gate (so we can log it instead of silently dropping).
-async fn evaluate(card: &WorkCard) -> Result<Option<MergeDecision>, Box<dyn std::error::Error>> {
+async fn evaluate(
+    gh: &crate::gh_client::GhClient,
+    card: &WorkCard,
+) -> Result<Option<MergeDecision>, Box<dyn std::error::Error>> {
     use airc_work::model::CardState;
     if card.state != CardState::Review {
         return Ok(None);
@@ -160,7 +173,7 @@ async fn evaluate(card: &WorkCard) -> Result<Option<MergeDecision>, Box<dyn std:
         return Ok(None);
     };
 
-    match check_pr_gate(&pr).await {
+    match check_pr_gate(gh, &pr).await {
         Ok(GateResult::Green) => Ok(Some(MergeDecision::Merge(pr))),
         Ok(GateResult::NotReady(reason)) => Ok(Some(MergeDecision::Skip(reason))),
         Err(error) => Ok(Some(MergeDecision::Skip(format!(
@@ -175,35 +188,26 @@ enum GateResult {
 }
 
 /// Query `gh pr view --json statusCheckRollup,mergeable,state` and
-/// apply [`evaluate_gh_view`] to the response. The IO half is here;
-/// the decision half is the pure function so it can be unit-tested
-/// without shelling out.
+/// apply [`evaluate_gh_view`] to the response.
+///
+/// Card dec35ec7: the IO half routes through the typed
+/// [`crate::gh_client::GhClient`] instead of a raw
+/// `tokio::process::Command::new("gh")`. Errors come back as
+/// typed [`crate::gh_client::GhError`] variants (rate-limited,
+/// auth-required, …) so callers can pattern-match on them; the
+/// decision half (`evaluate_gh_view`) remains pure for unit tests.
 async fn check_pr_gate(
+    gh: &crate::gh_client::GhClient,
     pr: &airc_work::model::PullRequestRef,
-) -> Result<GateResult, Box<dyn std::error::Error>> {
-    let pr_ref = format!("{}#{}", pr.repo.as_str(), pr.number);
-    let output = tokio::process::Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            &pr.number.to_string(),
-            "--repo",
-            pr.repo.as_str(),
-            "--json",
-            "statusCheckRollup,mergeable,state",
-        ])
-        .output()
+) -> Result<GateResult, crate::gh_client::GhError> {
+    let view = gh
+        .pr_view(crate::gh_client::PrViewArgs {
+            repo: pr.repo.as_str(),
+            number: pr.number,
+            cwd: None,
+        })
         .await?;
-    if !output.status.success() {
-        return Err(format!(
-            "gh pr view {pr_ref} failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        )
-        .into());
-    }
-
-    let parsed: GhPrView = serde_json::from_slice(&output.stdout)?;
-    Ok(evaluate_gh_view(&parsed))
+    Ok(evaluate_gh_view(&view))
 }
 
 /// Decide whether a PR is ready to merge, given the parsed `gh pr
@@ -216,7 +220,7 @@ async fn check_pr_gate(
 ///
 /// The strictly-less-red-than-base doctrine refinement (#1033) is a
 /// separate, more lenient gate carded as a follow-up.
-fn evaluate_gh_view(view: &GhPrView) -> GateResult {
+fn evaluate_gh_view(view: &crate::gh_client::PrView) -> GateResult {
     if view.state != "OPEN" {
         return GateResult::NotReady(format!("PR state is {} (not OPEN)", view.state));
     }
@@ -251,31 +255,22 @@ fn evaluate_gh_view(view: &GhPrView) -> GateResult {
 /// convention every recent PR has used (see merged-PR survey in card
 /// 28f1440c). On success, publish `MarkPullRequestMerged` so the
 /// projection transitions to `Merged`.
+/// Card dec35ec7: typed `gh pr merge` via `GhClient`. `GhError`
+/// surfaces conflicts as `PrNotMergeable` so an upcoming
+/// less-red-than-base bypass can match the case and skip rather
+/// than retry indefinitely. `MarkPullRequestMerged` still fires
+/// after the merge succeeds — the projection contract is unchanged.
 async fn perform_merge(
+    gh: &crate::gh_client::GhClient,
     card: &WorkCard,
     pr: &airc_work::model::PullRequestRef,
     airc: &Airc,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let output = tokio::process::Command::new("gh")
-        .args([
-            "pr",
-            "merge",
-            &pr.number.to_string(),
-            "--repo",
-            pr.repo.as_str(),
-            "--squash",
-            "--delete-branch",
-        ])
-        .output()
-        .await?;
-    if !output.status.success() {
-        return Err(format!(
-            "gh pr merge #{} failed: {}",
-            pr.number,
-            String::from_utf8_lossy(&output.stderr).trim()
-        )
-        .into());
-    }
+    gh.pr_merge(crate::gh_client::PrMergeArgs {
+        repo: pr.repo.as_str(),
+        number: pr.number,
+    })
+    .await?;
 
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -288,24 +283,6 @@ async fn perform_merge(
     })
     .await?;
     Ok(())
-}
-
-#[derive(serde::Deserialize)]
-struct GhPrView {
-    #[serde(default)]
-    state: String,
-    #[serde(default, rename = "mergeable")]
-    mergeable: String,
-    #[serde(default, rename = "statusCheckRollup")]
-    status_check_rollup: Option<Vec<GhCheck>>,
-}
-
-#[derive(serde::Deserialize)]
-struct GhCheck {
-    #[serde(default)]
-    conclusion: Option<String>,
-    #[serde(default)]
-    status: Option<String>,
 }
 
 /// Acquire a non-blocking exclusive lock at `<home>/merger.lock`.
@@ -342,7 +319,9 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    fn parse(payload: serde_json::Value) -> GhPrView {
+    fn parse(payload: serde_json::Value) -> crate::gh_client::PrView {
+        // Card dec35ec7: tests now exercise the typed PrView from
+        // GhClient, not a merger-local duplicate struct.
         serde_json::from_value(payload).expect("test fixture must parse")
     }
 

--- a/crates/airc-cli/tests/work_commands.rs
+++ b/crates/airc-cli/tests/work_commands.rs
@@ -60,7 +60,16 @@ fn work_create_claim_release_projects_on_board() {
 
     let claimed_board = run_ok(&home, &["work", "board"]);
     assert!(claimed_board.contains(card_id));
-    assert!(claimed_board.contains(claim_id));
+    // Card 0e8e6fa shipped short claim_id rendering in the board
+    // output; the assertion needs to match the rendered prefix, not
+    // the full UUID. Same fix peer applied to the sibling
+    // work_board_surfaces_stale_claims test in e9b12e6 (kink
+    // b1735261). Drive-by while landing dec35ec7.
+    let claim_short: String = claim_id.chars().take(8).collect();
+    assert!(
+        claimed_board.contains(&claim_short),
+        "expected short claim_id prefix {claim_short} in: {claimed_board}",
+    );
     assert!(claimed_board.contains("Claimed"));
 
     let heartbeat = run_ok(


### PR DESCRIPTION
- fix(codex): poll inbox after sending airc messages (#556)
- feat(knock): public collaboration knock entrypoint (airc#559 PR-1) (#560)
- feat(approve): forward-secret room-invite handoff (airc#559 PR-2) (#561)
- feat(queue): add issue-backed queue add/list
- feat(queue): claim/release/set-status verbs (airc#562 PR-2) (#568)
- feat(queue): nudge verb — surface card to peers (airc#562 PR-3) (#573)
- fix(#571): route every gh body write through --body-file (lib_gh.sh) (#574)
- feat(queue): repo-scoped nudge status sweep (#578)
- fix(gh): safely close issues with markdown comments (#582)
- feat(queue): adopt existing issues into queue cards (#583)
- feat(lane): add worktree lanes for agents (#585)
- feat(queue): summarize repo nudge pongs (#586)
- feat(#576): auto-close queue cards when PRs merge into canary (#581)
- fix(#576): detect queue refs in PR titles (#587)
- feat(#572): queue heartbeat and stale scan (#588)
- feat(#570): embeddable queue and room widgets (#589)
- feat(#591): summarize queue availability (#592)
- fix(#593): ignore repo-nudge templates in pongs (#594)
- fix(#596): honor per-agent queue owner (#597)
- fix: add session work identity for queue ownership (#598)
- fix(queue): close already-merged queue cards (#599)
- fix(queue): require closing keywords for close-merged
- fix(queue): preserve issue titles
- feat(queue): recommend next work for idle agents
- feat(queue): allow cross-repo close-merged
- feat(queue): add metronome idle pulse
- fix(queue): prevent accidental claim takeovers
- docs(readme): document AI work queue workflow (#614)
- feat(queue): warn on stale PR branches (#617)
- refactor(queue): split command helpers (#618)
- fix(queue): default planning view and unclaimed-owner semantics (#620)
- Fix collaboration health for same-nick peers (#625)
- fix(lane): hydrate submodules after worktree add (continuum#1252) (#624)
- feat(queue): personalized dispatch verb (closes continuum#1192 broadcast→idle gap) (#623)
- fix(queue): dispatch metronome hand-outs (#627)
- feat: add hygiene policy command (#632)
- fix: fail closed on update conflicts (#633)
- docs: design rust sqlite substrate (#634)
- docs: design realtime event bus (#635)
- feat(queue): add steward dry-run digest (#636)
- feat(core): add Rust transcript primitives (#637)
- feat(logs): add json transcript pages (#638)
- fix(logs): avoid strict-mode crash without json flag (#639)
- refactor(logs): use one render path for human and json modes (#640)
- feat(queue): metronome fan-out across active roster (airc#607, continuum#1192) (#641)
- docs: propose manager-role + lane substrate for airc (#642)
- docs: add lane-kanban-protocol — engineering spec for the lane substrate (#643)
- feat(heartbeat): peer-liveness envelope kind + cmd_peers tracking (airc#644 PR-1) (#645)
- hotfix: cmd_peers Python comment backtick broke airc peers in production (#645 follow-up) (#646)
- feat(heartbeat): wire emission — cmd_send --heartbeat + reminder_timer_loop hook + monitor filter (airc#644 PR-2) (#647)
- fix(heartbeat): allow empty body when --heartbeat (caught live; airc#644 PR-2 follow-up) (#648)
- fix(heartbeat): second empty-body rejection path also needed exemption (airc#644 PR-2 follow-up #2) (#649)
- fix(airc): surface sender client_id on pm-tag so multi-tab agents are distinguishable (#650)
- docs(architecture): airc-rust substrate design — generic messaging/event/network layer (DRAFT) (#651)
- feat(airc-blobs): Phase 1 scaffold — ContentAddressedStore trait + ContentHash + MediaRef (#653)
- feat(airc-blobs): FsStore — filesystem-backed sha256-addressed content store (#655)
- docs(airc-rust): Contract Layer: forge-alloy (substrate vs contract boundary) (#657)
- feat(airc-core): Identity struct + modular split (one concern per file) (#654)
- feat(airc-core): Body enum (Json | Binary) — opaque payload primitive (#656)
- feat(airc-blobs): GC + retention policy — age-based + capacity-based (#660)
- feat(airc-core): convert ID newtypes from String to UUIDv4
- feat(airc-core): envelope Headers dictionary + HeaderFilter predicate
- feat(airc-protocol): wire-level envelope, Frame, signature, subscription, LiftPolicy
- feat(airc-transport): Transport trait + LocalFsAdapter (same-Mac wire)
- fix(airc-transport): tail_loop recovers from frames.jsonl truncation/recreation
- feat(airc-protocol): real Ed25519 signing + verify (closes PR-1 stub)
- feat(airc-transport): TLS peer-pinning infrastructure (cert gen + verifiers)
- feat(airc-transport): LanTcpAdapter — TLS-wrapped TCP with peer-pinned mTLS
- feat(airc-transport): SignedTransport<T> — per-frame Ed25519 sign + verify wrapper
- feat(airc-cli): airc-rs binary — first Rust replacement for Python airc
- test(airc-cli): e2e — two airc-rs subprocesses chat over the substrate
- feat(airc-cli): daemon mode — Unix socket IPC + typed Request/Response
- fix(airc-transport): LAN-TCP readiness race + subscribers-lock-during-await
- feat(airc-cli): daemon Subscribe + Inbox — buffered consume-once reads (#678)
- style(airc-blobs): apply current rustfmt rules (#677)
- feat(airc-transport): multi-peer LanTcpAdapter (#679)
- refactor(airc-transport): split lan_tcp::adapter into module (one concern per file) (#680)
- feat(airc-cli): persisted identity state — stable peer_id + client_id (#681)
- feat(airc-cli): persistent peer registry — peers.json + daemon AddPeer/ListPeers (#682)
- feat(airc-cli): cross-platform daemon — Unix sockets + Windows named pipes (#683)
- ci: rust quality gates — fmt + clippy (deny warnings) + test on every Rust PR (#661)
- docs(airc-rust): replace body_hint with HTTP-style Headers dictionary (reopen of #658) (#662)
- docs(airc-rust): UUIDv4 for every identifier + three-field identity model (reopen of #659) (#663)
- feat(airc-cli): per-user room state — drop --wire/--channel parameter hell (#684)
- fix(airc-cli): Windows pipe-name uniqueness — UUIDv5 over full path (#685)
- fix(codex-hooks): rename TOML key codex_hooks → hooks + auto-migrate (#686)
- fix(airc-transport): LAN-TCP send pre-validates payload, no silent drops (#687)
- feat(airc-store): SeaORM-backed event store crate (slice 4 foundation) (#688)
- refactor: split daemon runtime into airc-daemon crate (slice 5 relocation) (#689)
- feat(airc-daemon): wire airc-store as the inbox backing (slice 5b) (#690)
- feat(airc-lib): consumer-facing facade crate (slice 6) (#691)
- feat(airc-lib): live subscriptions + auto-populate store on say (slice 6b) (#692)
- refactor(airc-cli): commands route through airc_lib::Airc (slice 6c) (#693)
- docs(operating-board): work-coordination domain plan (Codex design) (#694)
- feat(airc-work): typed work coordination domain (#695)
- feat(airc-work): add routable event codec (#696)
- feat(airc-work): replay work events from transcripts (#697)
- feat(airc-work-store): project persisted work events (#698)
- feat(airc-lib): expose work coordination API (#699)
- feat(airc-cli): add work coordination commands (#700)
- feat(airc-cli): add lane coordination commands (#701)
- feat(airc-cli): add workspace lease commands (#702)
- feat(airc-cli): add manager hat commands (#703)
- feat(airc-lib): add filtered event subscriptions (#704)
- feat(airc-cli): add Rust Codex hook context (#705)
- feat(airc-cli): install Codex hooks from Rust (#706)
- feat(codex): route hooks through Rust CLI (#707)
- feat(install): build and install airc-rs (#708)
- refactor(codex): remove Python hook adapters (#709)
- ci: add runtime guard checks for rust-rewrite (#710)
- refactor(codex): move detached start into Rust (#711)
- feat(airc-rs): move client identity mnemonics to rust (#712)
- feat(airc-rs): move iso timestamp parsing to rust (#713)
- feat(airc-rs): move log append and rotate to rust (#714)
- feat(airc-rs): move bearer state reads to rust (#715)
- feat(airc-rs): move logs render to rust (#716)
- feat(airc-rs): move gist JSON parsing to rust (#717)
- feat(airc-transport): add gh gist bootstrap adapter (#718)
- feat(airc-lib): add explicit transport route policy (#719)
- feat(airc-lib): add transport resolver shell (#720)
- feat(airc-lib): feed resolver from transport health (#721)
- feat(airc-rs): expose transport route status (#722)
- feat(airc-rs): move transport health to rust (#723)
- feat(airc-rs): read subscribed channels from rust (#724)
- feat(airc-rs): move channel gist config reads to rust (#725)
- feat(airc-rs): move channel config writes to rust (#726)
- feat(airc-rs): move generic config state to rust (#727)
- feat(airc-rs): move host config block to rust (#728)
- feat(airc-rs): derive daemon scope ids in rust (#729)
- feat(airc-rs): parse doctor rate-limit json in rust (#730)
- feat(airc-rs): render whois identity output in rust (#731)
- feat(airc-cli): move message crypto helpers to Rust (#732)
- feat(airc-cli): move control-plane helpers to Rust (#733)
- feat(airc-cli): build legacy message JSON in Rust (#734)
- feat(airc-cli): move channel gist discovery to Rust (#735)
- feat(airc-cli): move channel gist resolve to Rust (#736)
- feat(airc-cli): move bearer send to Rust (#737)
- refactor(airc-cli): split bearer send modules (#738)
- feat(airc-cli): move bearer recv to Rust (#739)
- feat(airc-cli): move monitor formatter to Rust (#740)
- feat(airc-cli): move local attach tail to Rust (#741)
- feat(airc-cli): move pair handshake to Rust (#742)
- feat(airc-cli): move scope repair to Rust (#743)
- feat(airc-cli): move collaboration health to Rust (#744)
- feat(airc-cli): move inbox cursoring to Rust (#745)
- feat(airc-cli): move hygiene policy to Rust (#746)
- feat(airc-cli): move knock approval crypto to Rust (#747)
- feat(airc-cli): move knock identity JSON to Rust (#748)
- feat(airc-cli): move kick peer ssh lookup to Rust (#749)
- feat(airc-cli): move worktree lane registry to Rust (#750)
- feat(airc-cli): move local identity state to Rust (#751)
- feat(airc-cli): move runtime JSON helpers to Rust (#752)
- feat(airc-cli): move queue card core to Rust (#753)
- feat(airc-cli): move queue projections to Rust (#754)
- feat(airc-cli): move queue runtime summaries to Rust (#755)
- feat(airc-cli): move queue staleness metadata to Rust (#756)
- feat(airc-cli): move queue staleness analyzer to Rust (#757)
- feat(airc-cli): move queue close-merged parsing to Rust (#758)
- feat(queue): move plan and steward projections to rust (#759)
- feat(collaboration): move peers listing to rust (#760)
- fix(invite): read channel gist through rust config (#761)
- feat(identity): move rename collision scan to rust (#762)
- feat(network): move LAN IP probe to rust (#763)
- feat(runtime): drop wrapper python startup (#764)
- feat(install): remove python runtime bootstrap (#765)
- chore(runtime): remove python debug path (#766)
- test(integration): drop legacy python unit gate (#767)
- test(integration): probe bearer kinds through rust (#768)
- test(integration): scaffold ed25519 identity through rust (#769)
- test(integration): edit top-level config through rust (#770)
- feat(config): probe quit fixtures through rust (#771)
- test(integration): probe away status through rust (#772)
- test(integration): probe tabs state through rust (#773)
- test(integration): probe heartbeat gist through rust (#774)
- fix(heartbeat): patch takeover gist lease deterministically (#775)
- test(integration): probe status outage through rust (#776)
- test(integration): probe bearer config through rust (#777)
- test(integration): probe sidecar channels through rust (#778)
- test(integration): probe channel gists through rust (#779)
- test(integration): probe bearer outcome through rust (#780)
- feat(gist): extract named file content through rust (#781)
- test(integration): probe JSON predicates through rust (#782)
- test(integration): route bearer and channel gist through rust (#783)
- test(integration): probe liveness events through rust (#784)
- fix(handshake): accept hyphen-leading public key values (#785)
- test(integration): delete legacy python bearer scenarios (#786)
- test(integration): route gh bearer scenario through rust (#787)
- test(integration): fake gone gist sends through airc-rs (#788)
- test(integration): generate gist rotation seed without python (#789)
- test(integration): remove python from platform adapters scenario (#790)
- install: stop documenting python runtime setup (#791)
- runtime: remove live airc_core references (#792)
- runtime: delete python airc_core layer (#793)
- fix(status): host health ignores joiner bearer pidfiles (#794)
- docs(architecture): transport control plane admission (#795)
- fix: fail closed on production fallback paths (#796)
- docs: define robustness integration plan (#797)
- refactor: remove fallback runtime surfaces (#798)
- ci: enforce Rust quality contracts (#799)
- fix(doctor): keep local health independent of GitHub (#800)
- docs: define invite-only gist routing architecture (#801)
- feat(routes): enforce invite-only gist admission (#802)
- feat(lib): gate sends through route resolver (#803)
- feat(lib): execute SDK sends over LAN routes (#804)
- refactor(cli): route LAN commands through airc-lib (#805)
- feat(lib): organize route discovery and health (#806)
- docs: update route requirements status (#807)
- docs: group route work into PR slices (#808)
- feat(lib): discover local route health (#809)
- feat(route): make gist an invite beacon (#810)
- feat(lib): attach SDK to daemon IPC (#811)
- refactor(cli): route daemon msg and inbox through SDK (#812)
- fix(cli): accept legacy message build command (#814)
- feat(airc-work): drain typing — workspace pressure/drain events + projection (Slice 7 PR 3a) (#813)
- feat(shell): route plain msg through rust local substrate (#815)
- feat(shell): read rust local inbox by default (#817)
- feat(airc-relay): baseline relay server + transport adapter (PR-E) (#816)
- feat(airc-transport): add realtime UDP adapter (#818)
- feat(trust-rotation): signed peer trust rotation contract + daemon application (PR-H) (#819)
- feat(airc-transport): add WebRTC datachannel adapter (#820)
- test(examples): prove SDK consumer embedding path (#821)
- test(examples): prove agent dogfood consumer path (#822)
- feat(examples): consumer integration shape contracts — Continuum/OpenClaw/Hermes (PR-I3) (#823)
- test(cli): prove installed agent identities dogfood live room (#824)
- fix(status): surface rust local data plane before gh bearer (#825)
- fix(codex-hook): pin rust hook executable and honor cursor overrides (#826)
- docs(readme): rework for the post-rewrite substrate (#827)
- fix(workspace): keep lane roots under airc home (#828)
- fix(monitor): attach to Rust event stream (#830)
- fix(teardown): verify live process reaping (#832)
- fix(install): remove rust suffix from airc surface (#833)
- fix(install): use ~/.airc/src as the source root (#835)
- feat(work): drain policy evaluator — pure substrate primitive (#834)
- fix(install): use source command as POSIX entrypoint (#836)
- fix(shell): resolve airc-core from source install (#837)
- fix(status): treat rust-local as routine health (#838)
- fix(install): PATH-augment is newline-safe + strips stale airc lines
- fix(install): rc reconcile no longer short-circuits on in-shell PATH
- fix(codex-hook): install source command path (#839)
- fix(msg): distinguish local store from peer delivery (#840)
- feat(lib): SubscriptionSet + ChannelName + identity-namespaced RoomId (#841)
- fix(events): monitor hooks use subscribed channels (#842)
- feat(lib): mesh identity resolution — replace MeshIdentity::unset() (#843)
- fix(lib): share same-machine account local wire (#844)
- feat(lib): add account room coordinator (#845)
- fix(join): seed rust account rooms from wrapper (#846)
- fix(install): put airc shim on POSIX PATH (#847)
- test(install): gate public airc shim path (#848)
- docs(install): define AI agent install contract (#849)
- test(install): prove public airc account-room runtime (#851)
- feat(lib): machine-global account coordinator (Gap 8) (#850)
- feat(lib): wire account join discovery into local delivery (#852)
- test(install): prove public monitor and hook delivery (#853)
- feat(lib): add account registry bootstrap contract (#854)
- fix(cli): route local join and broadcast through Rust (#855)
- fix(status): show rust command mode after stale startup (#856)
- fix(lib): cross-process chat actually delivers — live_tx fans out on DuplicateEventId (#857)
- fix(status): count Rust-substrate peers, not just legacy peers/ dir (#858)
- fix(send/msg): receipt no longer lies about non-delivery on shared-home wire (#859)
- feat(join): explicit scope + mesh-kind in output (#860)
- fix(join): label canonical HOME scope as machine-account home (#861)
- feat(lib): cross-machine bootstrap via gh-gist account-mesh registry (#862)
- fix(airc): restore project scope and runtime hook identity (#863)
- feat: demolition — bash wrapper deleted, airc IS the Rust binary (#864)
- fix(ci): runtime-guards green post-demolition (#865)
- fix(registry): no --paginate; bound sync with timeout; tests disable (#867)
- fix(mesh-identity): Operator-source cache never expires; bound shell-outs (#868)
- fix(airc): make join own daemon live delivery (#866)
- fix(codex-hook): trust airc.client header on shared-HOME identity (#869)
- feat(cli): restore airc join --attach and airc version subcommand (#870)
- fix(join): ensure Codex hook setup (#871)
- docs(skill): tab-loop semantics for bidirectional agent coordination (#872)
- fix(install): prefer current source tree (#873)
- fix(cli): airc join always streams ALL subscribed rooms; remove --attach (#876)
- test(join): pin runtime attach decision (#877)
- fix(join): detect Codex runtime via client identity (#878)
- docs(architecture): establish grid substrate audit (#879)
- fix(join): persist live feed cursor (#880)
- fix(store): persist runtime cursors through SeaORM (#882)
- docs(architecture): Phase 3.5 ORM end-to-end + Phase 3.6 perf hotpaths (#881)
- fix(store): persist peer trust through ORM (#883)
- fix(store): persist subscriptions through ORM (#884)
- fix(store): persist local identity metadata through ORM (#885)
- fix(store): persist mesh identity through ORM (#886)
- fix(store): persist account registry through ORM (#887)
- fix(store): persist coordinator beacons through ORM (#888)
- cleanup(lib): remove file-backed coordinator beacons (#889)
- cleanup(cli): remove config.json command shim (#890)
- refactor(identity): store-backed identity commands (#891)
- refactor(cli): remove config repair scope command (#892)
- refactor(transport): report substrate route health (#893)
- refactor(cli): remove bearer state command (#894)
- refactor(cli): remove recent senders command (#895)
- refactor(cli): remove legacy log scraping surface (#896)
- refactor(collaboration): remove jsonl presence scans (#897)
- refactor(identity): remove jsonl rename collision helper (#898)
- refactor(cli): remove legacy bearer command (#899)
- refactor(cli): remove jsonl message builder (#900)
- fix(install): copy artifacts instead of symlinking (#901)
- fix(identity): migrate identity json into orm state (#902)
- fix(lib): report peers from account mesh registry (#903)
- fix(cli): agent-runtime attach decision wins over piped-stdout (#904)
- fix(lib): wire replay skips unverifiable frames instead of aborting (#905)
- docs(codex): clarify live feed contract (#906)
- refactor(cli): isolate runtime context classification (#908)
- docs: AR/Cambrian/grid framing + data-model + Phase 3.5 migration (#907)
- refactor(cli): move codex integration behind boundary (#910)
- feat(cli): airc doctor — install + identity + scope self-diagnosis (#909)
- feat(lib): expose subscription query API (#911)
- feat(lib): command-bus primitive (Airc::request / reply / await_reply) (#912)
- docs: CI fidelity as substrate non-negotiable (#10) (#913)
- test(cli): emulate join attach in e2e harness (#915)
- feat(lib): typed lifecycle events (Phase 2) (#914)
- feat(work): add git and PR event contracts (#917)
- feat(lib): emit PeerArrived lifecycle event on add_peer (Phase 2 cont.) (#916)
- feat(work): add local git watcher adapter (#918)
- feat(lib): emit WireEstablished lifecycle event (Phase 2 cont.) (#919)
- docs: require roadmap reference in PR template (#920)
- ci: enforce PR roadmap references (#921)
- feat(lib): emit SubscriptionAdvanced on cursor saves (#922)
- feat(lib): emit RoomParted lifecycle events (#924)
- feat(lib): emit PeerDeparted lifecycle events (#925)
- ci: keep roadmap references as PR template guidance (#926)
- feat(airc-lib): WireLost emit on stream-end + teardown (#923)
- feat(codex): add pollable AIRC feed command (#927)
- test(install): prove Codex poll in public runtime (#928)
- fix(lib): keep routine wire replay quiet (#929)
- feat(cli): add Rust update command (#930)
- refactor(store): move coordinator refresh lock into ORM (#931)
- perf(lib): use set-backed event dedup (#932)
- perf(lib): broadcast live events by arc (#933)
- perf(protocol): remove global peer registry lock (#934)
- perf(lib): remove global route table locks (#935)
- perf(lib): own local ingest task lifecycle (#936)
- perf(lib): use set-backed subscription dedup (#937)
- perf(lib): shorten subscriber setup locks (#938)
- perf(lib): make event filter channels set-backed (#939)
- refactor(daemon): length-frame ipc with cbor (#940)
- fix(cli): restart daemon during update (#941)
- refactor(ipc): split daemon IPC contract into crate (#942)
- refactor(identity): split local identity into crate (#943)
- refactor(trust): split peer trust into crate (#944)
- test(command-bus): prove request reply over LAN (#945)
- feat(airc-lib): execute relay routes through SDK (#946)
- test(consumer-shapes): prove command bus integration (#948)
- feat(airc-work): PR observation adapter skeleton (#947)
- docs(audit): refresh immediate queue after PR adapter (#949)
- feat(airc-work): real gh PullRequestSource over GhCommandRunner (#950)
- docs(readme): restore generic agent IRC framing (#951)
- fix(ipc): version daemon endpoint by protocol (#952)
- fix(daemon): refresh wire trust for live ingest (#953)
- test(airc-lib): prove Continuum-shaped room throughput (#954)
- feat(airc-lib): wire UDP route execution + WebRTC signaling types (#955)
- feat(airc-lib): WebRTC DataChannel orchestration over AIRC mesh (#957)
- docs(webrtc): media tracks plan and implementation split (#959)
- feat(airc-lib): surface incoming WebRTC media tracks (#960)
- feat(airc-lib): add WebRTC media track builder (#961)
- test(airc-lib): prove WebRTC audio and video tracks (#962)
- test(airc-lib): prove WebRTC media and control share a session (#963)
- docs(audit): note observed AIRC coordination flaws (#964)
- fix(cli): restore IRC-shaped peers and whois commands (#966)
- docs(webrtc): show Continuum live-room integration example (#967)
- feat(work): heartbeat claims and surface stale owners (#969)
- feat(work): publish agent availability state (#971)
- feat(diagnostics): add typed substrate diagnostic sink (#973)
- feat(airc-lib): typed lane-coordination events (#965)
- feat(airc-lib): active-agent heartbeat events (#968)
- feat(airc-cli): bake build sha + drift detection in doctor (#972)
- feat(work): suggest claimable cards for agents (#975)
- feat(work): surface claimable queue suggestions in agent feeds (#976)
- feat(airc-lib): typed work-event subscription API (#974)
- feat(work): close completed cards (#977)
- fix(work): tolerate bounded board replay windows (#979)
- feat(airc-lib): AIRC-event diagnostic sink + doctor surface (#978)
- fix(work): preserve terminal state on claim release (#980)
- docs(audit): consumer integration gap audit + follow-up cards (#981)
- docs(audit): roadmap-to-card coverage + missing-card cleanup (#982)
- feat(work): surface agent availability in queue status (#983)
- test(lib): prove Continuum pose fan-out throughput (#984)
- feat(work): render typed agent roster (#986)
- fix(work): make duplicate claim release idempotent (#987)
- feat(airc-lib): external-identity bridge contract (#985)
- feat(work): enforce lease-zone for work claim + heartbeat diagnostic (#988)
- feat(route): add JSON route proof harness (#989)
- feat(publish): structured publish API + airc publish JSON-receipt CLI (#990)
- feat(events): add JSON list output (#991)
- docs: define cooperative coordination training signal (#992)
- fix(work): reject card transitions from wrong room (#993)
- fix(join): replace stale daemon builds from typed status (#994)
- fix(work): tolerate superseded claim release + ghost heartbeat (#996)
- feat(work): publish active-agent roster heartbeats from join (#997)
- fix(work): correlate peer claims to live roster clients (#998)
- feat(work): add typed manager loop evaluation (#999)
- docs(airc): add runtime planning and consumer audit lanes (#1000)
- docs(airc): define autonomous development roadmap (#1001)
- fix(work): find active cards beyond small recent windows (#1004)
- fix(work-store): tolerate orphaned events in complete projection (#1005)
- fix(work): schedule from complete work projection (#1006)
- feat(work): seed backlog from manager candidates (#1008)
- fix(work): make stale claims recoverable by default (#1009)
- feat(ipc): add ResolveWireRequest (channel uuid -> wire path lookup) (#1011)
- feat(inbox): --json flag for machine-readable output (#1010)
- fix(work): exclude terminal cards from stale recovery (#1012)
- fix(identity): resolve mesh identity against machine-global coordinator store (#1014)
- perf(bus): decoupled delivery bus — kill same-machine poll/fsync latency (#1015)
- fix(test): isolate two-machine bridge test via explicit wire roots — repairs Windows CI (#1016)
- docs(arch): airc event-server design — efficient ORM+push routing server (#1017)
- feat(airc-bus): owner-core event router — sharded router + hot ring + generational cursor + zero-copy fan-out (#1018)
- test(e2e): realistic timeout for process-spawn round-trips (fix macOS flake) (#1020)
- fix(reliability): LAN send-flush + lan-listen subscribe order + daemon-shutdown hang (#1021)
- feat(store): SQLite-backed DurableSink — owner-core ORM durable tier (§3.3) (#1019)
- feat(store): persistent EpochStore — generational epoch survives daemon restart (§3.8) (#1022)
- feat(wire): airc-wire — FlatBuffers binary codec for the envelope (zero-copy payload) (#1023)
- feat(work+lib+cli): autonomous-team substrate end-to-end (19 cards) (#1025)
- fix(cli): airc work state review uses Command::current_dir, not gh -C (card a4fe899f) (#1027)
- fix(cli): airc work state X merged refused — only PullRequestMerged event sets Merged (card a1bc62b3) (#1028)
- feat(store): add agent_name column to local_identity (card 8384cc18 Sub-A) (#1030)
- fix(identity): provisional git-email identity self-heals to gh login (one identity per machine) (#1024)
- fix(cli): default_home_dir skips machine-account ~/.airc + resolves to main working tree from a worktree (card a1b4552a) (#1029)
- fix(lib): work_board filters heartbeats out of the projection page (card 79953b4d) (#1031)
- fix(cli): airc work state Closed refuses unless from Merged or pre-work state (card 9656a836) (#1026)
- docs(agents): encode engineering-staff framing — CI-green-before-merge, branch hygiene, monitoring (card 53698eb9) (#1032)
- fix(install): recover from stale Rust toolchain instead of cryptic build abort (#1013)
- ef168afe/airc ci re green rust rewrite accumulate (#1033)
- fix(cli): gh pr create reads commit subject as title — not branch slug (card 13131f1c) (#1034)
- 28f1440c/airc work state review open pr and link (#1035)
- feat(cli+lib): continuous-merge — `airc work merger run` auto-merges Review cards whose PRs are CI-green (card f16650cd) (#1037)
- feat(cli): cross-sandbox daemon discovery — sandboxed agents attach to project daemon (card 282850c2) (#1036)
- feat(cli): typed GhClient — replace raw gh shell-outs with thiserror-typed boundary (card dec35ec7)
