### PR TITLE
feat(core+lib): wall — multi-post pinned content per room, supersede chains, consumer-defined categories (card b4742d9c)

### DIFF
--- a/crates/airc-core/src/doctrine.rs
+++ b/crates/airc-core/src/doctrine.rs
@@ -15,18 +15,27 @@
 
 use crate::ids::{PeerId, RoomId};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
-/// Typed room-doctrine domain events. Wire shape mirrors
+/// Typed room-doctrine + wall domain events. Wire shape mirrors
 /// `airc_core::identity::IdentityEvent` and `airc_work::WorkEvent`:
 /// internally tagged via serde so a JSON body always carries a `kind`
 /// field consumers can switch on without parsing the entire payload.
 ///
-/// Today one variant; future doctrine-deprecated / doctrine-amended
-/// events can join here without breaking the consumer codec.
+/// Two variants today:
+///   - `RoomDoctrinePublished` — the original engine-keystone slice
+///     (card 2903a8ef): one-doc-per-room operating doctrine
+///     auto-loaded on attach.
+///   - `WallPostPublished` — card b4742d9c: the generalized "wall"
+///     of pinned typed posts per room. Doctrine becomes the special
+///     case of a wall post with `category = "doctrine"`; rules,
+///     agendas, RAG knowledge, decisions, principles, and any
+///     consumer-defined category ride the same mechanism.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum DoctrineEvent {
     RoomDoctrinePublished(RoomDoctrinePublished),
+    WallPostPublished(WallPostPublished),
 }
 
 /// A room's operating doctrine published on the substrate. Body is
@@ -62,6 +71,73 @@ pub struct RoomDoctrinePublished {
     pub published_at_ms: u64,
 }
 
+/// A pinned typed post on a room's wall — the living-document
+/// mechanism that captures every room's purpose + evolving rules +
+/// agreed decisions (card b4742d9c). Every room has a wall; new
+/// attachees walk in and see the current set of pinned posts
+/// (by category) on join.
+///
+/// The substrate guarantees delivery + replay; it does NOT define
+/// what a post MEANS. `category` is a free-form string — common
+/// values include `"doctrine"`, `"rules"`, `"agenda"`,
+/// `"principles"`, `"rag"`, `"decision"`, but the substrate has no
+/// opinion. `body` is opaque text (markdown is convention; consumers
+/// may store JSON, references, whatever fits their schema).
+///
+/// Living-document via supersede chains:
+///   - Each post has a stable `post_id`. Edits never mutate the
+///     post in place — they publish a NEW WallPostPublished with
+///     `supersedes = Some(prior.post_id)`.
+///   - The wall projection (`Airc::wall_posts`) follows supersede
+///     chains: only the latest version per chain shows up as
+///     "currently pinned." History remains in the transcript so
+///     anyone walking in months later can see how the wall evolved
+///     ("Joel proposed X, we tried Y, settled on Z").
+///   - Unpinning (archival) is a supersede whose body is empty (or
+///     a tombstone marker the consumer recognizes).
+///
+/// `category` is informational — consumers filter on it via header
+/// to subscribe to (e.g.) only `"doctrine"` updates. The substrate
+/// doesn't enforce category semantics; if hermes invents
+/// `"plan-step"` and openclaw invents `"tool-permission"`, they
+/// coexist on the same wall without coordination.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WallPostPublished {
+    /// The room whose wall this post is pinned on.
+    pub room_id: RoomId,
+    /// Stable id for this post across its supersede chain.
+    /// A new pin generates a fresh UUID; revisions (supersedes)
+    /// generate a NEW UUID and point at the prior one — so every
+    /// post can be referenced unambiguously by URL/anchor even
+    /// after it's been superseded.
+    pub post_id: Uuid,
+    /// Consumer-defined category. Common values: `"doctrine"`,
+    /// `"rules"`, `"agenda"`, `"principles"`, `"rag"`. The substrate
+    /// makes no inference from the string; it's the same shape as
+    /// a header — middleware (continuum routers, agent renderers,
+    /// hermes adapters) filter on it.
+    pub category: String,
+    /// Opaque post body. Markdown is the convention for
+    /// human-readable categories; structured categories (e.g.
+    /// `"rag"` indexes, `"decision"` records) ship JSON. No
+    /// substrate-side schema.
+    pub body: String,
+    /// `Some(prior_post_id)` when this post revises an earlier one.
+    /// `None` when this is a fresh pin. The wall projection walks
+    /// the chain to surface only currently-pinned posts; history
+    /// stays in the transcript for audit / "how did we get here"
+    /// queries.
+    pub supersedes: Option<Uuid>,
+    /// Peer that emitted this version. Authority is flat in the
+    /// substrate; consumers MAY enforce author rules in their own
+    /// middleware (e.g. "only room-owner may pin in 'rules'").
+    pub published_by: PeerId,
+    /// Monotonic emission time. Projection ordering is by
+    /// `published_at_ms` then durable-log order, same as other
+    /// substrate events.
+    pub published_at_ms: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -82,11 +158,7 @@ mod tests {
         let event = DoctrineEvent::RoomDoctrinePublished(sample_card());
         let json = serde_json::to_string(&event).expect("serialize");
         let decoded: DoctrineEvent = serde_json::from_str(&json).expect("deserialize");
-        match (event, decoded) {
-            (DoctrineEvent::RoomDoctrinePublished(a), DoctrineEvent::RoomDoctrinePublished(b)) => {
-                assert_eq!(a, b)
-            }
-        }
+        assert_eq!(event, decoded);
     }
 
     #[test]
@@ -129,8 +201,167 @@ mod tests {
         let event = DoctrineEvent::RoomDoctrinePublished(card.clone());
         let json = serde_json::to_string(&event).unwrap();
         let decoded: DoctrineEvent = serde_json::from_str(&json).unwrap();
-        match decoded {
-            DoctrineEvent::RoomDoctrinePublished(got) => assert_eq!(got, card),
+        assert_eq!(decoded, DoctrineEvent::RoomDoctrinePublished(card));
+    }
+
+    // ========================================================================
+    // Wall post tests — card b4742d9c.
+    //
+    // The substrate guarantees: serde round-trip stability, kind
+    // discriminator stability, supersede-chain integrity at the wire
+    // level. The PROJECTION (apply supersedes, return the currently-
+    // pinned set per category) lives in `airc-lib`'s wall_posts
+    // method — tests for that ride alongside it.
+    // ========================================================================
+
+    fn sample_wall_post() -> WallPostPublished {
+        WallPostPublished {
+            room_id: RoomId::from_u128(11),
+            post_id: Uuid::from_u128(0x1234_5678_9abc_def0_1234_5678_9abc_def0),
+            category: "rules".to_string(),
+            body: "Branches: rust-rewrite is the integration branch. No PRs to main.".to_string(),
+            supersedes: None,
+            published_by: PeerId::from_u128(42),
+            published_at_ms: 1_700_000_000_000,
         }
+    }
+
+    #[test]
+    fn wall_post_event_round_trips_through_serde() {
+        let event = DoctrineEvent::WallPostPublished(sample_wall_post());
+        let json = serde_json::to_string(&event).expect("serialize");
+        let decoded: DoctrineEvent = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(event, decoded);
+    }
+
+    #[test]
+    fn wall_post_wire_kind_discriminator_is_stable() {
+        // Renaming the variant would break every consumer that filters
+        // wall events by `kind`. Pin it so a serde change can't
+        // silently shift the discriminator.
+        let event = DoctrineEvent::WallPostPublished(sample_wall_post());
+        let value: serde_json::Value = serde_json::to_value(&event).expect("to_value");
+        assert_eq!(
+            value.get("kind").and_then(serde_json::Value::as_str),
+            Some("wall_post_published"),
+            "wall post wire kind must be stable across serde upgrades",
+        );
+        for field in [
+            "room_id",
+            "post_id",
+            "category",
+            "body",
+            "supersedes",
+            "published_by",
+            "published_at_ms",
+        ] {
+            assert!(value.get(field).is_some(), "wire shape must carry {field}");
+        }
+    }
+
+    #[test]
+    fn wall_post_supersedes_round_trips_when_some_and_when_none() {
+        // The supersede chain is the living-document mechanism. A
+        // post with no supersede is a fresh pin; a post that
+        // supersedes another links via the prior post_id. Both
+        // shapes MUST round-trip cleanly.
+        let fresh = WallPostPublished {
+            supersedes: None,
+            ..sample_wall_post()
+        };
+        let revision = WallPostPublished {
+            post_id: Uuid::from_u128(2),
+            supersedes: Some(sample_wall_post().post_id),
+            body: "Branches: rust-rewrite is the integration branch. Main is frozen.".to_string(),
+            ..sample_wall_post()
+        };
+
+        for evt in [
+            DoctrineEvent::WallPostPublished(fresh),
+            DoctrineEvent::WallPostPublished(revision),
+        ] {
+            let json = serde_json::to_string(&evt).unwrap();
+            let decoded: DoctrineEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(evt, decoded);
+        }
+    }
+
+    #[test]
+    fn wall_posts_in_different_categories_coexist_independently() {
+        // A "doctrine" post and a "rules" post in the same room are
+        // independent items; the substrate doesn't impose a cross-
+        // category ordering or supersede relationship. Verified by
+        // confirming both wire shapes are valid + that the category
+        // string is preserved verbatim (the substrate isn't allowed
+        // to normalize / canonicalize it).
+        for cat in [
+            "doctrine",
+            "rules",
+            "agenda",
+            "principles",
+            "rag",
+            "decision",
+        ] {
+            let post = WallPostPublished {
+                category: cat.to_string(),
+                ..sample_wall_post()
+            };
+            let json = serde_json::to_string(&DoctrineEvent::WallPostPublished(post.clone()))
+                .expect("serialize");
+            let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                value.get("category").and_then(serde_json::Value::as_str),
+                Some(cat),
+                "category string preserved verbatim for {cat}",
+            );
+        }
+    }
+
+    #[test]
+    fn wall_post_category_can_be_consumer_defined_arbitrary_string() {
+        // The substrate has no enum of categories. A future consumer
+        // (hermes, continuum, openclaw, codex, a friend's adapter)
+        // can invent its own category — `"plan-step"`,
+        // `"tool-permission"`, `"recipe"` — and the substrate carries
+        // it without rejecting. This test pins that property.
+        for cat in [
+            "hermes:plan-step",
+            "continuum:capability-ad",
+            "openclaw:tool-permission",
+            "joel:reminders",
+            "",
+        ] {
+            let post = WallPostPublished {
+                category: cat.to_string(),
+                ..sample_wall_post()
+            };
+            let event = DoctrineEvent::WallPostPublished(post);
+            let json = serde_json::to_string(&event).unwrap();
+            let decoded: DoctrineEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(decoded, event);
+        }
+    }
+
+    #[test]
+    fn mixed_doctrine_and_wall_events_decode_via_same_enum() {
+        // Wire-compatibility: a room's transcript will carry both
+        // legacy RoomDoctrinePublished events (from before b4742d9c)
+        // AND new WallPostPublished events. A consumer decoding the
+        // transcript via DoctrineEvent MUST handle both variants
+        // without coordinating with the publisher about which version
+        // to expect.
+        let doctrine_json =
+            serde_json::to_string(&DoctrineEvent::RoomDoctrinePublished(sample_card())).unwrap();
+        let wall_json =
+            serde_json::to_string(&DoctrineEvent::WallPostPublished(sample_wall_post())).unwrap();
+
+        let doctrine_decoded: DoctrineEvent = serde_json::from_str(&doctrine_json).unwrap();
+        let wall_decoded: DoctrineEvent = serde_json::from_str(&wall_json).unwrap();
+
+        assert!(matches!(
+            doctrine_decoded,
+            DoctrineEvent::RoomDoctrinePublished(_)
+        ));
+        assert!(matches!(wall_decoded, DoctrineEvent::WallPostPublished(_)));
     }
 }

--- a/crates/airc-core/src/transcript.rs
+++ b/crates/airc-core/src/transcript.rs
@@ -94,6 +94,15 @@ pub enum TranscriptKind {
     /// the latest per room_id (LWW on published_at_ms). Part of
     /// card 2903a8ef — engine keystone "the user is not the engine."
     DoctrinePublished,
+    /// A peer pinned (or revised) a wall post — the room's living-
+    /// document mechanism (card b4742d9c). Body: serialized
+    /// `DoctrineEvent::WallPostPublished` carrying { room_id, post_id,
+    /// category, body, supersedes, published_by, published_at_ms }.
+    /// `category` is consumer-defined ("doctrine" / "rules" /
+    /// "agenda" / "rag" / anything). Doctrine becomes the special
+    /// case `category="doctrine"`; the legacy `DoctrinePublished`
+    /// remains for back-compat replay.
+    WallPostPublished,
 }
 
 impl TranscriptKind {
@@ -112,6 +121,7 @@ impl TranscriptKind {
                 | TranscriptKind::SubscriptionAdvanced
                 | TranscriptKind::IdentityPublished
                 | TranscriptKind::DoctrinePublished
+                | TranscriptKind::WallPostPublished
         )
     }
 
@@ -149,6 +159,7 @@ impl TranscriptKind {
             TranscriptKind::SubscriptionAdvanced => "subscription_advanced",
             TranscriptKind::IdentityPublished => "identity_published",
             TranscriptKind::DoctrinePublished => "doctrine_published",
+            TranscriptKind::WallPostPublished => "wall_post_published",
         }
     }
 
@@ -172,6 +183,7 @@ impl TranscriptKind {
             "subscription_advanced" => TranscriptKind::SubscriptionAdvanced,
             "identity_published" => TranscriptKind::IdentityPublished,
             "doctrine_published" => TranscriptKind::DoctrinePublished,
+            "wall_post_published" => TranscriptKind::WallPostPublished,
             _ => return None,
         })
     }
@@ -197,6 +209,7 @@ impl TranscriptKind {
         TranscriptKind::SubscriptionAdvanced,
         TranscriptKind::IdentityPublished,
         TranscriptKind::DoctrinePublished,
+        TranscriptKind::WallPostPublished,
     ];
 }
 

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -471,6 +471,91 @@ impl Airc {
         .await
     }
 
+    /// Card b4742d9c: pin a wall post in the current room.
+    ///
+    /// The wall is the room's living document — multiple typed posts
+    /// (rules / agenda / principles / rag / consumer-defined) that any
+    /// attaching agent or human can browse. Each post has a stable
+    /// `post_id`; edits don't mutate the original, they emit a new
+    /// post with `supersedes = Some(prior.post_id)` so the audit trail
+    /// remains in the transcript.
+    ///
+    /// `category` is consumer-defined — common values include
+    /// `"doctrine"`, `"rules"`, `"agenda"`, `"principles"`, `"rag"`,
+    /// `"decision"`. The substrate has no opinion on the string;
+    /// middleware (continuum routers, agent renderers, hermes /
+    /// openclaw adapters) filter on it via header pattern.
+    ///
+    /// Returns the new post's `post_id` so the caller can later
+    /// supersede it.
+    pub async fn publish_wall_post(
+        &self,
+        category: String,
+        body: String,
+        supersedes: Option<uuid::Uuid>,
+    ) -> Result<uuid::Uuid, AircError> {
+        let room = self.current_room().await?;
+        let post_id = uuid::Uuid::new_v4();
+        let event = airc_core::doctrine::DoctrineEvent::WallPostPublished(
+            airc_core::doctrine::WallPostPublished {
+                room_id: room.channel,
+                post_id,
+                category,
+                body,
+                supersedes,
+                published_by: self.inner.identity.peer_id,
+                published_at_ms: crate::time::now_ms()?,
+            },
+        );
+        let body_json = serde_json::to_value(&event)
+            .map_err(|e| AircError::Crypto(format!("wall post serialize: {e}")))?;
+        self.emit_lifecycle(
+            airc_core::TranscriptKind::WallPostPublished,
+            room.channel,
+            airc_core::Body::Json(body_json),
+        )
+        .await?;
+        Ok(post_id)
+    }
+
+    /// Card b4742d9c: fetch the current pinned wall posts for the
+    /// current room, optionally filtered by `category`.
+    ///
+    /// Walks the recent transcript window, applies the supersede
+    /// chain (a post is dropped from the result if a later post
+    /// points to it via `supersedes`), and returns the surviving
+    /// posts in published-time order. History (superseded versions)
+    /// stays in the transcript — call `page_recent` directly to
+    /// inspect it.
+    ///
+    /// Window size is generous (500) because a busy room may
+    /// accumulate many pinned posts over time. If profiling shows
+    /// this is too small for a long-lived room, the projection
+    /// moves to a durable index — but for the substrate slice,
+    /// scan-on-query is honest and avoids a cache that can drift.
+    pub async fn wall_posts(
+        &self,
+        category_filter: Option<&str>,
+    ) -> Result<Vec<airc_core::doctrine::WallPostPublished>, AircError> {
+        let events = self.page_recent(500).await?;
+        let mut posts = Vec::with_capacity(events.len());
+        for event in events {
+            if event.kind != airc_core::TranscriptKind::WallPostPublished {
+                continue;
+            }
+            let Some(airc_core::Body::Json(value)) = event.body else {
+                continue;
+            };
+            let Ok(airc_core::doctrine::DoctrineEvent::WallPostPublished(post)) =
+                serde_json::from_value::<airc_core::doctrine::DoctrineEvent>(value)
+            else {
+                continue;
+            };
+            posts.push(post);
+        }
+        Ok(project_wall_posts(posts, category_filter))
+    }
+
     /// MVP identity-roster lookup (card e414817b, sub of 66d7e607).
     ///
     /// Scans recent transcript events in the current room for the
@@ -964,5 +1049,235 @@ impl Airc {
                 Err(observed) => current = observed,
             }
         }
+    }
+}
+
+/// Card b4742d9c — pure projection: walk a set of WallPostPublished
+/// events (in transcript order) and return the currently-pinned set,
+/// applying supersede chains.
+///
+/// The substrate guarantees the transcript replay order is stable;
+/// this function takes that as input and applies the supersede
+/// semantics: if a later post points at an earlier `post_id` via
+/// `supersedes`, the earlier post is no longer "pinned" — only the
+/// latest in each chain survives.
+///
+/// `category_filter` is applied BEFORE supersede resolution. This
+/// matters: a `Some("doctrine")` filter shows only doctrine posts
+/// and their doctrine-category supersedes; doctrine posts don't
+/// supersede `"rules"` posts even if they share a post_id by
+/// accident (post_ids are UUIDv4, so accidental sharing is
+/// astronomically unlikely, but the semantics MUST be category-
+/// scoped regardless).
+///
+/// Pure, sync, no IO — the IO half is `Airc::wall_posts`, which
+/// reads the transcript and hands the result here.
+fn project_wall_posts(
+    mut events: Vec<airc_core::doctrine::WallPostPublished>,
+    category_filter: Option<&str>,
+) -> Vec<airc_core::doctrine::WallPostPublished> {
+    if let Some(cat) = category_filter {
+        events.retain(|p| p.category == cat);
+    }
+    // Two-pass: first collect the set of post_ids that have been
+    // superseded by ANY later post in the SAME CATEGORY. Then return
+    // only the posts that aren't in that set.
+    //
+    // Same-category gate: a `"rules"` post's supersedes pointing at
+    // a `"doctrine"` post_id is treated as a no-op (consumer bug),
+    // not as a cross-category supersede. The substrate doesn't let
+    // categories interfere with each other.
+    let mut superseded: std::collections::HashSet<uuid::Uuid> = std::collections::HashSet::new();
+    // Group by category for the integrity gate.
+    let mut category_of: std::collections::HashMap<uuid::Uuid, String> =
+        std::collections::HashMap::new();
+    for p in &events {
+        category_of.insert(p.post_id, p.category.clone());
+    }
+    for p in &events {
+        if let Some(parent) = p.supersedes {
+            if category_of.get(&parent) == Some(&p.category) {
+                superseded.insert(parent);
+            }
+        }
+    }
+    let mut result: Vec<_> = events
+        .into_iter()
+        .filter(|p| !superseded.contains(&p.post_id))
+        .collect();
+    // Stable order by published_at_ms so a consumer rendering the
+    // wall sees posts in pin-time order regardless of how the
+    // transcript scan happened to traverse them.
+    result.sort_by_key(|p| p.published_at_ms);
+    result
+}
+
+#[cfg(test)]
+mod wall_projection_tests {
+    use super::project_wall_posts;
+    use airc_core::doctrine::WallPostPublished;
+    use airc_core::{PeerId, RoomId};
+    use uuid::Uuid;
+
+    fn post(
+        post_id: u128,
+        category: &str,
+        body: &str,
+        supersedes: Option<u128>,
+        published_at_ms: u64,
+    ) -> WallPostPublished {
+        WallPostPublished {
+            room_id: RoomId::from_u128(1),
+            post_id: Uuid::from_u128(post_id),
+            category: category.to_string(),
+            body: body.to_string(),
+            supersedes: supersedes.map(Uuid::from_u128),
+            published_by: PeerId::from_u128(99),
+            published_at_ms,
+        }
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        let result = project_wall_posts(Vec::new(), None);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn single_post_with_no_supersedes_survives() {
+        let events = vec![post(1, "rules", "use rust-rewrite", None, 100)];
+        let result = project_wall_posts(events.clone(), None);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].body, "use rust-rewrite");
+    }
+
+    #[test]
+    fn revision_supersedes_original_within_same_category() {
+        // The living-document core case: edit a "rules" post and
+        // the original drops off the wall.
+        let events = vec![
+            post(1, "rules", "original", None, 100),
+            post(2, "rules", "revised", Some(1), 200),
+        ];
+        let result = project_wall_posts(events, None);
+        assert_eq!(result.len(), 1, "only the latest revision survives");
+        assert_eq!(result[0].body, "revised");
+    }
+
+    #[test]
+    fn supersede_chain_of_three_yields_only_the_latest() {
+        // A series of revisions: v1 → v2 → v3. The wall shows v3
+        // only; v1 and v2 are history (still in the transcript,
+        // not in the result).
+        let events = vec![
+            post(1, "rules", "v1", None, 100),
+            post(2, "rules", "v2", Some(1), 200),
+            post(3, "rules", "v3", Some(2), 300),
+        ];
+        let result = project_wall_posts(events, None);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].body, "v3");
+    }
+
+    #[test]
+    fn cross_category_supersede_is_a_noop_substrate_does_not_let_categories_interfere() {
+        // A "rules" post whose supersedes points at a "doctrine"
+        // post_id is a CONSUMER bug. The substrate must NOT honor
+        // it — categories are independent walls sharing the same
+        // event-kind discriminator.
+        let events = vec![
+            post(1, "doctrine", "auto-loaded on attach", None, 100),
+            post(
+                2,
+                "rules",
+                "this rules post tries to supersede the doctrine",
+                Some(1),
+                200,
+            ),
+        ];
+        let result = project_wall_posts(events, None);
+        // BOTH posts survive: the cross-category supersede was a no-op.
+        assert_eq!(result.len(), 2);
+        // The doctrine post is still pinned despite the rules-post
+        // claiming to supersede it.
+        assert!(result.iter().any(|p| p.body == "auto-loaded on attach"));
+        assert!(result.iter().any(|p| p.body.contains("rules post tries")));
+    }
+
+    #[test]
+    fn category_filter_returns_only_matching_posts() {
+        let events = vec![
+            post(1, "doctrine", "agent ops", None, 100),
+            post(2, "rules", "use rust-rewrite", None, 200),
+            post(3, "agenda", "ship cell-grid", None, 300),
+        ];
+        let result = project_wall_posts(events.clone(), Some("rules"));
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].body, "use rust-rewrite");
+    }
+
+    #[test]
+    fn category_filter_applied_before_supersede_so_chains_remain_intact() {
+        // The filter must NOT make a supersede chain disappear by
+        // hiding the parent: if the filter is "rules", both rules
+        // posts are visible to the projection, supersede is applied
+        // within rules, and only the latest survives.
+        let events = vec![
+            post(1, "rules", "v1", None, 100),
+            post(2, "doctrine", "unrelated", None, 150),
+            post(3, "rules", "v2", Some(1), 200),
+        ];
+        let result = project_wall_posts(events, Some("rules"));
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].body, "v2");
+    }
+
+    #[test]
+    fn results_ordered_by_published_at_ms_ascending() {
+        // Wall renderers display posts in pin-time order so the
+        // room's evolution reads naturally top-to-bottom. Pin this
+        // order so a consumer can always count on it.
+        let events = vec![
+            post(3, "rules", "latest", None, 300),
+            post(1, "rules", "earliest", None, 100),
+            post(2, "rules", "middle", None, 200),
+        ];
+        let result = project_wall_posts(events, None);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].published_at_ms, 100);
+        assert_eq!(result[1].published_at_ms, 200);
+        assert_eq!(result[2].published_at_ms, 300);
+    }
+
+    #[test]
+    fn consumer_defined_category_strings_are_carried_verbatim() {
+        // The substrate doesn't normalize / canonicalize category
+        // strings. hermes can use `"plan-step"`, continuum can use
+        // `"capability-ad"`, openclaw can use `"tool-permission"`,
+        // a friend's adapter can use whatever — and filtering on
+        // the exact string works without coordination.
+        let events = vec![
+            post(1, "hermes:plan-step", "extract intent", None, 100),
+            post(2, "continuum:capability-ad", "gpu 5090 24gb", None, 200),
+            post(3, "joel:reminders", "ship the wall card", None, 300),
+        ];
+        let hermes = project_wall_posts(events.clone(), Some("hermes:plan-step"));
+        let continuum = project_wall_posts(events.clone(), Some("continuum:capability-ad"));
+        let reminders = project_wall_posts(events, Some("joel:reminders"));
+        assert_eq!(hermes.len(), 1);
+        assert_eq!(continuum.len(), 1);
+        assert_eq!(reminders.len(), 1);
+    }
+
+    #[test]
+    fn supersedes_pointing_at_unknown_post_id_is_a_noop() {
+        // A post whose supersedes references a post_id we've never
+        // seen (window-truncation, replay-from-future) is treated
+        // as a fresh pin in the visible window. Conservative: the
+        // unknown parent isn't in our view, so we can't honor the
+        // supersede; we just keep the new post.
+        let events = vec![post(1, "rules", "supersedes a phantom", Some(999_999), 100)];
+        let result = project_wall_posts(events, None);
+        assert_eq!(result.len(), 1, "post survives despite unknown parent");
     }
 }


### PR DESCRIPTION
- fix(codex): poll inbox after sending airc messages (#556)
- feat(knock): public collaboration knock entrypoint (airc#559 PR-1) (#560)
- feat(approve): forward-secret room-invite handoff (airc#559 PR-2) (#561)
- feat(queue): add issue-backed queue add/list
- feat(queue): claim/release/set-status verbs (airc#562 PR-2) (#568)
- feat(queue): nudge verb — surface card to peers (airc#562 PR-3) (#573)
- fix(#571): route every gh body write through --body-file (lib_gh.sh) (#574)
- feat(queue): repo-scoped nudge status sweep (#578)
- fix(gh): safely close issues with markdown comments (#582)
- feat(queue): adopt existing issues into queue cards (#583)
- feat(lane): add worktree lanes for agents (#585)
- feat(queue): summarize repo nudge pongs (#586)
- feat(#576): auto-close queue cards when PRs merge into canary (#581)
- fix(#576): detect queue refs in PR titles (#587)
- feat(#572): queue heartbeat and stale scan (#588)
- feat(#570): embeddable queue and room widgets (#589)
- feat(#591): summarize queue availability (#592)
- fix(#593): ignore repo-nudge templates in pongs (#594)
- fix(#596): honor per-agent queue owner (#597)
- fix: add session work identity for queue ownership (#598)
- fix(queue): close already-merged queue cards (#599)
- fix(queue): require closing keywords for close-merged
- fix(queue): preserve issue titles
- feat(queue): recommend next work for idle agents
- feat(queue): allow cross-repo close-merged
- feat(queue): add metronome idle pulse
- fix(queue): prevent accidental claim takeovers
- docs(readme): document AI work queue workflow (#614)
- feat(queue): warn on stale PR branches (#617)
- refactor(queue): split command helpers (#618)
- fix(queue): default planning view and unclaimed-owner semantics (#620)
- Fix collaboration health for same-nick peers (#625)
- fix(lane): hydrate submodules after worktree add (continuum#1252) (#624)
- feat(queue): personalized dispatch verb (closes continuum#1192 broadcast→idle gap) (#623)
- fix(queue): dispatch metronome hand-outs (#627)
- feat: add hygiene policy command (#632)
- fix: fail closed on update conflicts (#633)
- docs: design rust sqlite substrate (#634)
- docs: design realtime event bus (#635)
- feat(queue): add steward dry-run digest (#636)
- feat(core): add Rust transcript primitives (#637)
- feat(logs): add json transcript pages (#638)
- fix(logs): avoid strict-mode crash without json flag (#639)
- refactor(logs): use one render path for human and json modes (#640)
- feat(queue): metronome fan-out across active roster (airc#607, continuum#1192) (#641)
- docs: propose manager-role + lane substrate for airc (#642)
- docs: add lane-kanban-protocol — engineering spec for the lane substrate (#643)
- feat(heartbeat): peer-liveness envelope kind + cmd_peers tracking (airc#644 PR-1) (#645)
- hotfix: cmd_peers Python comment backtick broke airc peers in production (#645 follow-up) (#646)
- feat(heartbeat): wire emission — cmd_send --heartbeat + reminder_timer_loop hook + monitor filter (airc#644 PR-2) (#647)
- fix(heartbeat): allow empty body when --heartbeat (caught live; airc#644 PR-2 follow-up) (#648)
- fix(heartbeat): second empty-body rejection path also needed exemption (airc#644 PR-2 follow-up #2) (#649)
- fix(airc): surface sender client_id on pm-tag so multi-tab agents are distinguishable (#650)
- docs(architecture): airc-rust substrate design — generic messaging/event/network layer (DRAFT) (#651)
- feat(airc-blobs): Phase 1 scaffold — ContentAddressedStore trait + ContentHash + MediaRef (#653)
- feat(airc-blobs): FsStore — filesystem-backed sha256-addressed content store (#655)
- docs(airc-rust): Contract Layer: forge-alloy (substrate vs contract boundary) (#657)
- feat(airc-core): Identity struct + modular split (one concern per file) (#654)
- feat(airc-core): Body enum (Json | Binary) — opaque payload primitive (#656)
- feat(airc-blobs): GC + retention policy — age-based + capacity-based (#660)
- feat(airc-core): convert ID newtypes from String to UUIDv4
- feat(airc-core): envelope Headers dictionary + HeaderFilter predicate
- feat(airc-protocol): wire-level envelope, Frame, signature, subscription, LiftPolicy
- feat(airc-transport): Transport trait + LocalFsAdapter (same-Mac wire)
- fix(airc-transport): tail_loop recovers from frames.jsonl truncation/recreation
- feat(airc-protocol): real Ed25519 signing + verify (closes PR-1 stub)
- feat(airc-transport): TLS peer-pinning infrastructure (cert gen + verifiers)
- feat(airc-transport): LanTcpAdapter — TLS-wrapped TCP with peer-pinned mTLS
- feat(airc-transport): SignedTransport<T> — per-frame Ed25519 sign + verify wrapper
- feat(airc-cli): airc-rs binary — first Rust replacement for Python airc
- test(airc-cli): e2e — two airc-rs subprocesses chat over the substrate
- feat(airc-cli): daemon mode — Unix socket IPC + typed Request/Response
- fix(airc-transport): LAN-TCP readiness race + subscribers-lock-during-await
- feat(airc-cli): daemon Subscribe + Inbox — buffered consume-once reads (#678)
- style(airc-blobs): apply current rustfmt rules (#677)
- feat(airc-transport): multi-peer LanTcpAdapter (#679)
- refactor(airc-transport): split lan_tcp::adapter into module (one concern per file) (#680)
- feat(airc-cli): persisted identity state — stable peer_id + client_id (#681)
- feat(airc-cli): persistent peer registry — peers.json + daemon AddPeer/ListPeers (#682)
- feat(airc-cli): cross-platform daemon — Unix sockets + Windows named pipes (#683)
- ci: rust quality gates — fmt + clippy (deny warnings) + test on every Rust PR (#661)
- docs(airc-rust): replace body_hint with HTTP-style Headers dictionary (reopen of #658) (#662)
- docs(airc-rust): UUIDv4 for every identifier + three-field identity model (reopen of #659) (#663)
- feat(airc-cli): per-user room state — drop --wire/--channel parameter hell (#684)
- fix(airc-cli): Windows pipe-name uniqueness — UUIDv5 over full path (#685)
- fix(codex-hooks): rename TOML key codex_hooks → hooks + auto-migrate (#686)
- fix(airc-transport): LAN-TCP send pre-validates payload, no silent drops (#687)
- feat(airc-store): SeaORM-backed event store crate (slice 4 foundation) (#688)
- refactor: split daemon runtime into airc-daemon crate (slice 5 relocation) (#689)
- feat(airc-daemon): wire airc-store as the inbox backing (slice 5b) (#690)
- feat(airc-lib): consumer-facing facade crate (slice 6) (#691)
- feat(airc-lib): live subscriptions + auto-populate store on say (slice 6b) (#692)
- refactor(airc-cli): commands route through airc_lib::Airc (slice 6c) (#693)
- docs(operating-board): work-coordination domain plan (Codex design) (#694)
- feat(airc-work): typed work coordination domain (#695)
- feat(airc-work): add routable event codec (#696)
- feat(airc-work): replay work events from transcripts (#697)
- feat(airc-work-store): project persisted work events (#698)
- feat(airc-lib): expose work coordination API (#699)
- feat(airc-cli): add work coordination commands (#700)
- feat(airc-cli): add lane coordination commands (#701)
- feat(airc-cli): add workspace lease commands (#702)
- feat(airc-cli): add manager hat commands (#703)
- feat(airc-lib): add filtered event subscriptions (#704)
- feat(airc-cli): add Rust Codex hook context (#705)
- feat(airc-cli): install Codex hooks from Rust (#706)
- feat(codex): route hooks through Rust CLI (#707)
- feat(install): build and install airc-rs (#708)
- refactor(codex): remove Python hook adapters (#709)
- ci: add runtime guard checks for rust-rewrite (#710)
- refactor(codex): move detached start into Rust (#711)
- feat(airc-rs): move client identity mnemonics to rust (#712)
- feat(airc-rs): move iso timestamp parsing to rust (#713)
- feat(airc-rs): move log append and rotate to rust (#714)
- feat(airc-rs): move bearer state reads to rust (#715)
- feat(airc-rs): move logs render to rust (#716)
- feat(airc-rs): move gist JSON parsing to rust (#717)
- feat(airc-transport): add gh gist bootstrap adapter (#718)
- feat(airc-lib): add explicit transport route policy (#719)
- feat(airc-lib): add transport resolver shell (#720)
- feat(airc-lib): feed resolver from transport health (#721)
- feat(airc-rs): expose transport route status (#722)
- feat(airc-rs): move transport health to rust (#723)
- feat(airc-rs): read subscribed channels from rust (#724)
- feat(airc-rs): move channel gist config reads to rust (#725)
- feat(airc-rs): move channel config writes to rust (#726)
- feat(airc-rs): move generic config state to rust (#727)
- feat(airc-rs): move host config block to rust (#728)
- feat(airc-rs): derive daemon scope ids in rust (#729)
- feat(airc-rs): parse doctor rate-limit json in rust (#730)
- feat(airc-rs): render whois identity output in rust (#731)
- feat(airc-cli): move message crypto helpers to Rust (#732)
- feat(airc-cli): move control-plane helpers to Rust (#733)
- feat(airc-cli): build legacy message JSON in Rust (#734)
- feat(airc-cli): move channel gist discovery to Rust (#735)
- feat(airc-cli): move channel gist resolve to Rust (#736)
- feat(airc-cli): move bearer send to Rust (#737)
- refactor(airc-cli): split bearer send modules (#738)
- feat(airc-cli): move bearer recv to Rust (#739)
- feat(airc-cli): move monitor formatter to Rust (#740)
- feat(airc-cli): move local attach tail to Rust (#741)
- feat(airc-cli): move pair handshake to Rust (#742)
- feat(airc-cli): move scope repair to Rust (#743)
- feat(airc-cli): move collaboration health to Rust (#744)
- feat(airc-cli): move inbox cursoring to Rust (#745)
- feat(airc-cli): move hygiene policy to Rust (#746)
- feat(airc-cli): move knock approval crypto to Rust (#747)
- feat(airc-cli): move knock identity JSON to Rust (#748)
- feat(airc-cli): move kick peer ssh lookup to Rust (#749)
- feat(airc-cli): move worktree lane registry to Rust (#750)
- feat(airc-cli): move local identity state to Rust (#751)
- feat(airc-cli): move runtime JSON helpers to Rust (#752)
- feat(airc-cli): move queue card core to Rust (#753)
- feat(airc-cli): move queue projections to Rust (#754)
- feat(airc-cli): move queue runtime summaries to Rust (#755)
- feat(airc-cli): move queue staleness metadata to Rust (#756)
- feat(airc-cli): move queue staleness analyzer to Rust (#757)
- feat(airc-cli): move queue close-merged parsing to Rust (#758)
- feat(queue): move plan and steward projections to rust (#759)
- feat(collaboration): move peers listing to rust (#760)
- fix(invite): read channel gist through rust config (#761)
- feat(identity): move rename collision scan to rust (#762)
- feat(network): move LAN IP probe to rust (#763)
- feat(runtime): drop wrapper python startup (#764)
- feat(install): remove python runtime bootstrap (#765)
- chore(runtime): remove python debug path (#766)
- test(integration): drop legacy python unit gate (#767)
- test(integration): probe bearer kinds through rust (#768)
- test(integration): scaffold ed25519 identity through rust (#769)
- test(integration): edit top-level config through rust (#770)
- feat(config): probe quit fixtures through rust (#771)
- test(integration): probe away status through rust (#772)
- test(integration): probe tabs state through rust (#773)
- test(integration): probe heartbeat gist through rust (#774)
- fix(heartbeat): patch takeover gist lease deterministically (#775)
- test(integration): probe status outage through rust (#776)
- test(integration): probe bearer config through rust (#777)
- test(integration): probe sidecar channels through rust (#778)
- test(integration): probe channel gists through rust (#779)
- test(integration): probe bearer outcome through rust (#780)
- feat(gist): extract named file content through rust (#781)
- test(integration): probe JSON predicates through rust (#782)
- test(integration): route bearer and channel gist through rust (#783)
- test(integration): probe liveness events through rust (#784)
- fix(handshake): accept hyphen-leading public key values (#785)
- test(integration): delete legacy python bearer scenarios (#786)
- test(integration): route gh bearer scenario through rust (#787)
- test(integration): fake gone gist sends through airc-rs (#788)
- test(integration): generate gist rotation seed without python (#789)
- test(integration): remove python from platform adapters scenario (#790)
- install: stop documenting python runtime setup (#791)
- runtime: remove live airc_core references (#792)
- runtime: delete python airc_core layer (#793)
- fix(status): host health ignores joiner bearer pidfiles (#794)
- docs(architecture): transport control plane admission (#795)
- fix: fail closed on production fallback paths (#796)
- docs: define robustness integration plan (#797)
- refactor: remove fallback runtime surfaces (#798)
- ci: enforce Rust quality contracts (#799)
- fix(doctor): keep local health independent of GitHub (#800)
- docs: define invite-only gist routing architecture (#801)
- feat(routes): enforce invite-only gist admission (#802)
- feat(lib): gate sends through route resolver (#803)
- feat(lib): execute SDK sends over LAN routes (#804)
- refactor(cli): route LAN commands through airc-lib (#805)
- feat(lib): organize route discovery and health (#806)
- docs: update route requirements status (#807)
- docs: group route work into PR slices (#808)
- feat(lib): discover local route health (#809)
- feat(route): make gist an invite beacon (#810)
- feat(lib): attach SDK to daemon IPC (#811)
- refactor(cli): route daemon msg and inbox through SDK (#812)
- fix(cli): accept legacy message build command (#814)
- feat(airc-work): drain typing — workspace pressure/drain events + projection (Slice 7 PR 3a) (#813)
- feat(shell): route plain msg through rust local substrate (#815)
- feat(shell): read rust local inbox by default (#817)
- feat(airc-relay): baseline relay server + transport adapter (PR-E) (#816)
- feat(airc-transport): add realtime UDP adapter (#818)
- feat(trust-rotation): signed peer trust rotation contract + daemon application (PR-H) (#819)
- feat(airc-transport): add WebRTC datachannel adapter (#820)
- test(examples): prove SDK consumer embedding path (#821)
- test(examples): prove agent dogfood consumer path (#822)
- feat(examples): consumer integration shape contracts — Continuum/OpenClaw/Hermes (PR-I3) (#823)
- test(cli): prove installed agent identities dogfood live room (#824)
- fix(status): surface rust local data plane before gh bearer (#825)
- fix(codex-hook): pin rust hook executable and honor cursor overrides (#826)
- docs(readme): rework for the post-rewrite substrate (#827)
- fix(workspace): keep lane roots under airc home (#828)
- fix(monitor): attach to Rust event stream (#830)
- fix(teardown): verify live process reaping (#832)
- fix(install): remove rust suffix from airc surface (#833)
- fix(install): use ~/.airc/src as the source root (#835)
- feat(work): drain policy evaluator — pure substrate primitive (#834)
- fix(install): use source command as POSIX entrypoint (#836)
- fix(shell): resolve airc-core from source install (#837)
- fix(status): treat rust-local as routine health (#838)
- fix(install): PATH-augment is newline-safe + strips stale airc lines
- fix(install): rc reconcile no longer short-circuits on in-shell PATH
- fix(codex-hook): install source command path (#839)
- fix(msg): distinguish local store from peer delivery (#840)
- feat(lib): SubscriptionSet + ChannelName + identity-namespaced RoomId (#841)
- fix(events): monitor hooks use subscribed channels (#842)
- feat(lib): mesh identity resolution — replace MeshIdentity::unset() (#843)
- fix(lib): share same-machine account local wire (#844)
- feat(lib): add account room coordinator (#845)
- fix(join): seed rust account rooms from wrapper (#846)
- fix(install): put airc shim on POSIX PATH (#847)
- test(install): gate public airc shim path (#848)
- docs(install): define AI agent install contract (#849)
- test(install): prove public airc account-room runtime (#851)
- feat(lib): machine-global account coordinator (Gap 8) (#850)
- feat(lib): wire account join discovery into local delivery (#852)
- test(install): prove public monitor and hook delivery (#853)
- feat(lib): add account registry bootstrap contract (#854)
- fix(cli): route local join and broadcast through Rust (#855)
- fix(status): show rust command mode after stale startup (#856)
- fix(lib): cross-process chat actually delivers — live_tx fans out on DuplicateEventId (#857)
- fix(status): count Rust-substrate peers, not just legacy peers/ dir (#858)
- fix(send/msg): receipt no longer lies about non-delivery on shared-home wire (#859)
- feat(join): explicit scope + mesh-kind in output (#860)
- fix(join): label canonical HOME scope as machine-account home (#861)
- feat(lib): cross-machine bootstrap via gh-gist account-mesh registry (#862)
- fix(airc): restore project scope and runtime hook identity (#863)
- feat: demolition — bash wrapper deleted, airc IS the Rust binary (#864)
- fix(ci): runtime-guards green post-demolition (#865)
- fix(registry): no --paginate; bound sync with timeout; tests disable (#867)
- fix(mesh-identity): Operator-source cache never expires; bound shell-outs (#868)
- fix(airc): make join own daemon live delivery (#866)
- fix(codex-hook): trust airc.client header on shared-HOME identity (#869)
- feat(cli): restore airc join --attach and airc version subcommand (#870)
- fix(join): ensure Codex hook setup (#871)
- docs(skill): tab-loop semantics for bidirectional agent coordination (#872)
- fix(install): prefer current source tree (#873)
- fix(cli): airc join always streams ALL subscribed rooms; remove --attach (#876)
- test(join): pin runtime attach decision (#877)
- fix(join): detect Codex runtime via client identity (#878)
- docs(architecture): establish grid substrate audit (#879)
- fix(join): persist live feed cursor (#880)
- fix(store): persist runtime cursors through SeaORM (#882)
- docs(architecture): Phase 3.5 ORM end-to-end + Phase 3.6 perf hotpaths (#881)
- fix(store): persist peer trust through ORM (#883)
- fix(store): persist subscriptions through ORM (#884)
- fix(store): persist local identity metadata through ORM (#885)
- fix(store): persist mesh identity through ORM (#886)
- fix(store): persist account registry through ORM (#887)
- fix(store): persist coordinator beacons through ORM (#888)
- cleanup(lib): remove file-backed coordinator beacons (#889)
- cleanup(cli): remove config.json command shim (#890)
- refactor(identity): store-backed identity commands (#891)
- refactor(cli): remove config repair scope command (#892)
- refactor(transport): report substrate route health (#893)
- refactor(cli): remove bearer state command (#894)
- refactor(cli): remove recent senders command (#895)
- refactor(cli): remove legacy log scraping surface (#896)
- refactor(collaboration): remove jsonl presence scans (#897)
- refactor(identity): remove jsonl rename collision helper (#898)
- refactor(cli): remove legacy bearer command (#899)
- refactor(cli): remove jsonl message builder (#900)
- fix(install): copy artifacts instead of symlinking (#901)
- fix(identity): migrate identity json into orm state (#902)
- fix(lib): report peers from account mesh registry (#903)
- fix(cli): agent-runtime attach decision wins over piped-stdout (#904)
- fix(lib): wire replay skips unverifiable frames instead of aborting (#905)
- docs(codex): clarify live feed contract (#906)
- refactor(cli): isolate runtime context classification (#908)
- docs: AR/Cambrian/grid framing + data-model + Phase 3.5 migration (#907)
- refactor(cli): move codex integration behind boundary (#910)
- feat(cli): airc doctor — install + identity + scope self-diagnosis (#909)
- feat(lib): expose subscription query API (#911)
- feat(lib): command-bus primitive (Airc::request / reply / await_reply) (#912)
- docs: CI fidelity as substrate non-negotiable (#10) (#913)
- test(cli): emulate join attach in e2e harness (#915)
- feat(lib): typed lifecycle events (Phase 2) (#914)
- feat(work): add git and PR event contracts (#917)
- feat(lib): emit PeerArrived lifecycle event on add_peer (Phase 2 cont.) (#916)
- feat(work): add local git watcher adapter (#918)
- feat(lib): emit WireEstablished lifecycle event (Phase 2 cont.) (#919)
- docs: require roadmap reference in PR template (#920)
- ci: enforce PR roadmap references (#921)
- feat(lib): emit SubscriptionAdvanced on cursor saves (#922)
- feat(lib): emit RoomParted lifecycle events (#924)
- feat(lib): emit PeerDeparted lifecycle events (#925)
- ci: keep roadmap references as PR template guidance (#926)
- feat(airc-lib): WireLost emit on stream-end + teardown (#923)
- feat(codex): add pollable AIRC feed command (#927)
- test(install): prove Codex poll in public runtime (#928)
- fix(lib): keep routine wire replay quiet (#929)
- feat(cli): add Rust update command (#930)
- refactor(store): move coordinator refresh lock into ORM (#931)
- perf(lib): use set-backed event dedup (#932)
- perf(lib): broadcast live events by arc (#933)
- perf(protocol): remove global peer registry lock (#934)
- perf(lib): remove global route table locks (#935)
- perf(lib): own local ingest task lifecycle (#936)
- perf(lib): use set-backed subscription dedup (#937)
- perf(lib): shorten subscriber setup locks (#938)
- perf(lib): make event filter channels set-backed (#939)
- refactor(daemon): length-frame ipc with cbor (#940)
- fix(cli): restart daemon during update (#941)
- refactor(ipc): split daemon IPC contract into crate (#942)
- refactor(identity): split local identity into crate (#943)
- refactor(trust): split peer trust into crate (#944)
- test(command-bus): prove request reply over LAN (#945)
- feat(airc-lib): execute relay routes through SDK (#946)
- test(consumer-shapes): prove command bus integration (#948)
- feat(airc-work): PR observation adapter skeleton (#947)
- docs(audit): refresh immediate queue after PR adapter (#949)
- feat(airc-work): real gh PullRequestSource over GhCommandRunner (#950)
- docs(readme): restore generic agent IRC framing (#951)
- fix(ipc): version daemon endpoint by protocol (#952)
- fix(daemon): refresh wire trust for live ingest (#953)
- test(airc-lib): prove Continuum-shaped room throughput (#954)
- feat(airc-lib): wire UDP route execution + WebRTC signaling types (#955)
- feat(airc-lib): WebRTC DataChannel orchestration over AIRC mesh (#957)
- docs(webrtc): media tracks plan and implementation split (#959)
- feat(airc-lib): surface incoming WebRTC media tracks (#960)
- feat(airc-lib): add WebRTC media track builder (#961)
- test(airc-lib): prove WebRTC audio and video tracks (#962)
- test(airc-lib): prove WebRTC media and control share a session (#963)
- docs(audit): note observed AIRC coordination flaws (#964)
- fix(cli): restore IRC-shaped peers and whois commands (#966)
- docs(webrtc): show Continuum live-room integration example (#967)
- feat(work): heartbeat claims and surface stale owners (#969)
- feat(work): publish agent availability state (#971)
- feat(diagnostics): add typed substrate diagnostic sink (#973)
- feat(airc-lib): typed lane-coordination events (#965)
- feat(airc-lib): active-agent heartbeat events (#968)
- feat(airc-cli): bake build sha + drift detection in doctor (#972)
- feat(work): suggest claimable cards for agents (#975)
- feat(work): surface claimable queue suggestions in agent feeds (#976)
- feat(airc-lib): typed work-event subscription API (#974)
- feat(work): close completed cards (#977)
- fix(work): tolerate bounded board replay windows (#979)
- feat(airc-lib): AIRC-event diagnostic sink + doctor surface (#978)
- fix(work): preserve terminal state on claim release (#980)
- docs(audit): consumer integration gap audit + follow-up cards (#981)
- docs(audit): roadmap-to-card coverage + missing-card cleanup (#982)
- feat(work): surface agent availability in queue status (#983)
- test(lib): prove Continuum pose fan-out throughput (#984)
- feat(work): render typed agent roster (#986)
- fix(work): make duplicate claim release idempotent (#987)
- feat(airc-lib): external-identity bridge contract (#985)
- feat(work): enforce lease-zone for work claim + heartbeat diagnostic (#988)
- feat(route): add JSON route proof harness (#989)
- feat(publish): structured publish API + airc publish JSON-receipt CLI (#990)
- feat(events): add JSON list output (#991)
- docs: define cooperative coordination training signal (#992)
- fix(work): reject card transitions from wrong room (#993)
- fix(join): replace stale daemon builds from typed status (#994)
- fix(work): tolerate superseded claim release + ghost heartbeat (#996)
- feat(work): publish active-agent roster heartbeats from join (#997)
- fix(work): correlate peer claims to live roster clients (#998)
- feat(work): add typed manager loop evaluation (#999)
- docs(airc): add runtime planning and consumer audit lanes (#1000)
- docs(airc): define autonomous development roadmap (#1001)
- fix(work): find active cards beyond small recent windows (#1004)
- fix(work-store): tolerate orphaned events in complete projection (#1005)
- fix(work): schedule from complete work projection (#1006)
- feat(work): seed backlog from manager candidates (#1008)
- fix(work): make stale claims recoverable by default (#1009)
- feat(ipc): add ResolveWireRequest (channel uuid -> wire path lookup) (#1011)
- feat(inbox): --json flag for machine-readable output (#1010)
- fix(work): exclude terminal cards from stale recovery (#1012)
- fix(identity): resolve mesh identity against machine-global coordinator store (#1014)
- perf(bus): decoupled delivery bus — kill same-machine poll/fsync latency (#1015)
- fix(test): isolate two-machine bridge test via explicit wire roots — repairs Windows CI (#1016)
- docs(arch): airc event-server design — efficient ORM+push routing server (#1017)
- feat(airc-bus): owner-core event router — sharded router + hot ring + generational cursor + zero-copy fan-out (#1018)
- test(e2e): realistic timeout for process-spawn round-trips (fix macOS flake) (#1020)
- fix(reliability): LAN send-flush + lan-listen subscribe order + daemon-shutdown hang (#1021)
- feat(store): SQLite-backed DurableSink — owner-core ORM durable tier (§3.3) (#1019)
- feat(store): persistent EpochStore — generational epoch survives daemon restart (§3.8) (#1022)
- feat(wire): airc-wire — FlatBuffers binary codec for the envelope (zero-copy payload) (#1023)
- feat(work+lib+cli): autonomous-team substrate end-to-end (19 cards) (#1025)
- fix(cli): airc work state review uses Command::current_dir, not gh -C (card a4fe899f) (#1027)
- fix(cli): airc work state X merged refused — only PullRequestMerged event sets Merged (card a1bc62b3) (#1028)
- feat(store): add agent_name column to local_identity (card 8384cc18 Sub-A) (#1030)
- fix(identity): provisional git-email identity self-heals to gh login (one identity per machine) (#1024)
- fix(cli): default_home_dir skips machine-account ~/.airc + resolves to main working tree from a worktree (card a1b4552a) (#1029)
- fix(lib): work_board filters heartbeats out of the projection page (card 79953b4d) (#1031)
- fix(cli): airc work state Closed refuses unless from Merged or pre-work state (card 9656a836) (#1026)
- docs(agents): encode engineering-staff framing — CI-green-before-merge, branch hygiene, monitoring (card 53698eb9) (#1032)
- fix(install): recover from stale Rust toolchain instead of cryptic build abort (#1013)
- ef168afe/airc ci re green rust rewrite accumulate (#1033)
- fix(cli): gh pr create reads commit subject as title — not branch slug (card 13131f1c) (#1034)
- 28f1440c/airc work state review open pr and link (#1035)
- feat(cli+lib): continuous-merge — `airc work merger run` auto-merges Review cards whose PRs are CI-green (card f16650cd) (#1037)
- feat(cli): cross-sandbox daemon discovery — sandboxed agents attach to project daemon (card 282850c2) (#1036)
- feat(core+lib): wall — multi-post pinned content per room, supersede chains, consumer-defined categories (card b4742d9c)
