### PR TITLE
refactor(cli): split work_commands.rs phase 2 — extract lifecycle module (card 5aa9e780)

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -75,6 +75,7 @@ mod transport_commands;
 mod update_commands;
 mod work_cli;
 mod work_commands;
+mod work_commands_lifecycle;
 mod work_suggestions;
 mod workspace_cli;
 mod workspace_commands;

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -9,77 +9,16 @@
 
 use std::path::Path;
 
-use airc_diagnostics::{DiagnosticCode, DiagnosticComponent, DiagnosticEvent};
 use uuid::Uuid;
 
 use airc_lib::{
-    AgentAvailabilityState, CardState, ChangeWorkCardState, ClaimId, ClaimWorkCard, CreateWorkCard,
-    LaneId, Priority, ReleaseWorkClaim, RepoId, UpdateWorkCard, WorkBacklogSeedCandidate,
-    WorkBacklogSeedOutcome, WorkBoardProjection, WorkCardId, WorkManagerRecommendation,
-    WorkManagerRecommendationKind, WorkManagerStatus, WorkQueueStatus, WorkRosterStatus,
+    AgentAvailabilityState, CardState, ClaimId, CreateWorkCard, LaneId, Priority, RepoId,
+    WorkBoardProjection, WorkCardId, WorkManagerRecommendation, WorkManagerRecommendationKind,
+    WorkManagerStatus, WorkQueueStatus, WorkRosterStatus,
 };
 
 use crate::lease;
 use crate::work_cli::{CliAvailabilityState, CliCardState, CliPriority};
-
-pub async fn run_create(
-    home: &Path,
-    repo: String,
-    title: String,
-    body: Option<String>,
-    lane_id: Option<String>,
-    priority: CliPriority,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let airc = crate::commands::attached_airc(home).await?;
-    let card_id = airc
-        .create_work_card(CreateWorkCard {
-            repo: RepoId::new(repo)?,
-            title,
-            body,
-            priority: priority.into(),
-            lane_id: parse_optional_lane_id(lane_id.as_deref())?,
-            reviews: None,
-        })
-        .await?;
-    println!("card_id: {card_id}");
-    Ok(())
-}
-
-pub async fn run_seed(
-    home: &Path,
-    repo: String,
-    title: String,
-    body: Option<String>,
-    lane_id: Option<String>,
-    priority: CliPriority,
-    evidence_key: Option<String>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let airc = crate::commands::attached_airc(home).await?;
-    let result = airc
-        .seed_work_backlog(vec![WorkBacklogSeedCandidate {
-            repo: RepoId::new(repo)?,
-            title,
-            body,
-            priority: priority.into(),
-            lane_id: parse_optional_lane_id(lane_id.as_deref())?,
-            evidence_key,
-        }])
-        .await?;
-    for item in result.items {
-        let outcome = match item.outcome {
-            WorkBacklogSeedOutcome::Created => "created",
-            WorkBacklogSeedOutcome::AlreadyRepresented => "already_represented",
-            WorkBacklogSeedOutcome::AlreadyCompleted => "already_completed",
-        };
-        println!(
-            "seeded: outcome={outcome} card_id={card_id} repo={repo} title={title}",
-            card_id = item.card_id,
-            repo = item.candidate.repo,
-            title = item.candidate.title,
-        );
-    }
-    Ok(())
-}
 
 /// `airc work review <PARENT> [--pr URL] [--priority P] [--body B]` —
 /// spawn a sibling review card with a typed `reviews` link back to
@@ -173,47 +112,6 @@ fn format_review_title(parent_title: &str) -> String {
     }
 }
 
-pub async fn run_claim(
-    home: &Path,
-    card_id: String,
-    ttl_ms: u64,
-    no_lease_required: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    if !no_lease_required {
-        let check = lease::check_current_dir()?;
-        if !check.under_lease {
-            return Err(format!(
-                "refusing to claim work card from {cwd}: not under lease zone {root}.\n\
-                 Allocate a worktree under ~/.airc/worktrees/ first, or pass \
-                 --no-lease-required to override.",
-                cwd = check.path.display(),
-                root = check.lease_root.display(),
-            )
-            .into());
-        }
-    }
-    let airc = crate::commands::attached_airc(home).await?;
-    let card_uuid = parse_work_card_id(&card_id)?;
-    let claim_id = airc
-        .claim_work_card(ClaimWorkCard {
-            card_id: card_uuid,
-            ttl_ms,
-        })
-        .await?;
-    println!("claim_id: {claim_id}");
-
-    // Card d1b2798d: auto-spawn a worktree + branch on successful
-    // claim. Eliminates the shared-checkout friction two agents on
-    // the same machine hit (`--no-lease-required` everywhere is the
-    // tell). Best-effort: a git failure does NOT undo the claim or
-    // the lease — the claim is the authoritative record, the
-    // worktree is convenience around it.
-    if let Err(error) = spawn_claim_worktree(&airc, card_uuid).await {
-        eprintln!("airc: worktree spawn skipped — {error}");
-    }
-    Ok(())
-}
-
 /// Best-effort: allocate `~/.airc/worktrees/<card_short>/` and a
 /// branch `<card_short>/<slug>` off the current feature branch HEAD
 /// so the agent who just claimed the card can `cd` into a clean,
@@ -223,7 +121,7 @@ pub async fn run_claim(
 /// git command failure) so run_claim can surface it as a warning
 /// without aborting. Skips silently (Ok) when the worktree already
 /// exists, which lets re-claim after release work without surprise.
-async fn spawn_claim_worktree(
+pub(crate) async fn spawn_claim_worktree(
     airc: &airc_lib::Airc,
     card_id: airc_lib::WorkCardId,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -368,208 +266,11 @@ fn slugify(title: &str, max_len: usize) -> String {
     out
 }
 
-pub async fn run_release(
-    home: &Path,
-    card_id: String,
-    claim_id: Option<String>,
-    reason: Option<String>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let airc = crate::commands::attached_airc(home).await?;
-    let card_uuid = parse_work_card_id(&card_id)?;
-    // Default: resolve THIS peer's active claim from the board so
-    // callers don't have to track claim_ids the system already knows
-    // (kink card acb8bfcd: release ergonomics).
-    let claim_uuid = match claim_id {
-        Some(raw) => parse_claim_id(&raw)?,
-        None => resolve_my_active_claim(&airc, card_uuid).await?,
-    };
-    airc.release_work_claim(ReleaseWorkClaim {
-        card_id: card_uuid,
-        claim_id: claim_uuid,
-        reason,
-    })
-    .await?;
-    println!("released: card_id={card_id} claim_id={claim_uuid}");
-    Ok(())
-}
-
-/// Look up the active claim on `card_id` held by this peer via the
-/// board projection. Surfaces clear errors when there is no claim, or
-/// the claim is held by another peer — so the default never silently
-/// releases someone else's work.
-async fn resolve_my_active_claim(
-    airc: &airc_lib::Airc,
-    card_id: airc_lib::WorkCardId,
-) -> Result<airc_lib::ClaimId, Box<dyn std::error::Error>> {
-    let board = airc.work_board(usize::MAX).await?;
-    let card = board
-        .card(card_id)
-        .ok_or_else(|| format!("card {card_id} not present in the board projection"))?;
-    let me = airc.peer_id();
-    match (card.owner, card.claim_id) {
-        (Some(owner), Some(claim_id)) if owner == me => Ok(claim_id),
-        (Some(owner), _) => Err(format!(
-            "card {card_id} is currently claimed by {owner}, not this peer ({me}); \
-             pass CLAIM_ID explicitly to release a claim you don't own"
-        )
-        .into()),
-        (None, _) => Err(format!("card {card_id} has no active claim to release").into()),
-    }
-}
-
-pub async fn run_heartbeat(
-    home: &Path,
-    card_id: String,
-    claim_id: String,
-    ttl_ms: u64,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let airc = crate::commands::attached_airc(home).await?;
-    let card_uuid = parse_work_card_id(&card_id)?;
-    let claim_uuid = parse_claim_id(&claim_id)?;
-    airc.heartbeat_work_claim(airc_lib::HeartbeatWorkClaim {
-        card_id: card_uuid,
-        claim_id: claim_uuid,
-        ttl_ms,
-    })
-    .await?;
-    println!("claim_heartbeat: card_id={card_id} claim_id={claim_id} ttl_ms={ttl_ms}");
-
-    // Heartbeat doesn't refuse on lease drift — the claim was
-    // already granted, and refusing here would just orphan it. But
-    // we DO record the drift as a typed diagnostic so a substrate
-    // observer can see when an agent has wandered out of its lease.
-    if let Ok(check) = lease::check_current_dir() {
-        if !check.under_lease {
-            let diag = DiagnosticEvent::warn(
-                DiagnosticComponent::Work,
-                DiagnosticCode::WorkspaceLeaseViolation,
-                "work heartbeat fired from a path outside the lease zone",
-            )
-            .with_field("card_id", &card_id)
-            .with_field("claim_id", &claim_id)
-            .with_field("cwd", check.path.display())
-            .with_field("lease_root", check.lease_root.display());
-            // Best-effort: a publish failure shouldn't break the
-            // heartbeat from the user's perspective. Surface to
-            // stderr so it isn't silently swallowed.
-            if let Err(error) = airc.publish_diagnostic_event(&diag).await {
-                eprintln!("airc: failed to publish lease-violation diagnostic: {error}");
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Card 5ac0a359 — `airc work update <CARD_ID> [--title T] [--body B]
-/// [--priority P]`. Amend a card's editable fields post-creation.
-/// Omitted flags leave the projection's existing values alone;
-/// `--body ""` clears (empty string is the markdown "no body"
-/// idiom).
-pub async fn run_update(
-    home: &Path,
-    card_id: String,
-    title: Option<String>,
-    body: Option<String>,
-    priority: Option<CliPriority>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let card_uuid = parse_work_card_id(&card_id)?;
-    let airc = crate::commands::attached_airc(home).await?;
-
-    let mut request = UpdateWorkCard::amend(card_uuid);
-    if let Some(title) = title {
-        request = request.with_title(title);
-    }
-    if let Some(body) = body {
-        request = request.with_body(body);
-    }
-    if let Some(priority) = priority {
-        request = request.with_priority(priority.into());
-    }
-
-    airc.update_work_card(request).await?;
-    println!("card_updated: card_id={card_uuid}");
-    Ok(())
-}
-
-pub async fn run_state(
-    home: &Path,
-    card_id: String,
-    state: CliCardState,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let airc = crate::commands::attached_airc(home).await?;
-    let card_uuid = parse_work_card_id(&card_id)?;
-    let card_state = CardState::from(state);
-
-    // Card a1bc62b3 (substrate-target gate): refuse direct CLI writes
-    // to states that should only come from substrate observers (e.g.
-    // Merged must come from PullRequestMerged, not `airc work state X
-    // merged` by an agent). Architectural boundary: agent input goes
-    // through this CLI guard; substrate mechanisms write events
-    // directly via Airc::change_work_card_state.
-    if !cli_can_set_state_directly(card_state) {
-        return Err(refusal_message(card_uuid, card_state).into());
-    }
-
-    // Card 9656a836 (close-lifecycle gate): Closed must come from
-    // Merged (PR merged) or {Open, Claimed, Blocked} (cancellation
-    // before any real work landed). Refuses Closed from InProgress
-    // or Review — there's claimed work in flight; the agent should
-    // either ship via state review → merge, or release the claim.
-    // Complementary to a1bc62b3 above: that one refuses agents from
-    // self-attesting Merged; this one refuses agents from
-    // self-attesting Closed without a Merged predecessor.
-    if card_state == CardState::Closed {
-        let board = airc.work_board(usize::MAX).await?;
-        let card = board.card(card_uuid).ok_or_else(|| {
-            format!("card {card_uuid} not visible in current room's board projection")
-        })?;
-        if !close_transition_allowed_from(card.state) {
-            return Err(format!(
-                "refusing to close card {card_uuid}: current state is {actual:?}, but \
-                 Closed requires Merged (PR merged) or {{Open, Claimed, Blocked}} \
-                 (cancellation before work landed).\n\n\
-                 If work is in flight ({actual:?}), the next step is:\n  \
-                 - state Review: open a PR via `airc work state {card_uuid} review`\n  \
-                 - wait for the PR to merge (state → Merged via gh observer)\n  \
-                 - THEN `airc work close {card_uuid}` succeeds.\n\n\
-                 If you want to abandon the work, `airc work release {card_uuid}` \
-                 drops the claim and returns the card to its prior state — close \
-                 from there.",
-                actual = card.state,
-            )
-            .into());
-        }
-    }
-
-    airc.change_work_card_state(ChangeWorkCardState {
-        card_id: card_uuid,
-        state: card_state,
-    })
-    .await?;
-    println!("card_state_changed: card_id={card_uuid} state={card_state:?}");
-
-    // Card 820629e9: on transition to Review, open a PR via `gh` from
-    // the card's worktree and link it to the card. Best-effort — a gh
-    // failure (no commits, no remote, gh not installed) prints a
-    // warning but does not undo the state transition. The link is
-    // recorded as a separate WorkEvent::PullRequestLinked, whose
-    // projection re-sets state=Review idempotently and populates
-    // card.pull_request — so downstream consumers (ad7e100b Sub-C
-    // auto-spawn review card, board renderers) read one source of
-    // truth.
-    if card_state == CardState::Review {
-        if let Err(error) = open_pr_and_link(&airc, card_uuid).await {
-            eprintln!("airc: gh pr create skipped — {error}");
-        }
-    }
-    Ok(())
-}
-
 /// Best-effort: open a GitHub PR for the work card's worktree branch
 /// and link it via `WorkEvent::PullRequestLinked`. Returns Err so
 /// run_state can surface as a warning without aborting the state
 /// transition.
-async fn open_pr_and_link(
+pub(crate) async fn open_pr_and_link(
     airc: &airc_lib::Airc,
     card_id: airc_lib::WorkCardId,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -696,7 +397,7 @@ async fn open_pr_and_link(
 /// out of the CLI for consumers that bypass it (Continuum, OpenClaw),
 /// but the wire shape is stable — that move doesn't break this
 /// emit.
-async fn auto_spawn_review_card(
+pub(crate) async fn auto_spawn_review_card(
     airc: &airc_lib::Airc,
     parent_id: airc_lib::WorkCardId,
     pr_url: &str,
@@ -811,88 +512,6 @@ fn gh_default_branch(worktree: &str) -> Result<String, Box<dyn std::error::Error
     Ok(String::from_utf8(out.stdout)?.trim().to_string())
 }
 
-/// Card a1bc62b3 — gate on direct CLI state writes.
-///
-/// Returns `true` when the CLI's `airc work state <id> <target>` is
-/// allowed to drive a card into `target` by direct event emission.
-///
-/// `false` for substrate-owned target states:
-///   * [`CardState::Merged`] — only the gh observer's
-///     `WorkEvent::PullRequestMerged` should set Merged; an agent
-///     self-attesting Merged from the CLI defeats 9656a836's
-///     close-guard.
-///
-/// `true` for everything else the workflow currently surfaces
-/// (Open / Claimed / InProgress / Blocked / Review / Closed). 9656a836's
-/// `close_transition_allowed_from` already gates Closed by FROM-state.
-/// This gate is its sibling on the TO-state axis.
-///
-/// "Workflow is workflow" — for non-coding recipes, swap PR-merged
-/// for the recipe-specific verified-done signal; the substrate gate
-/// is the same shape.
-pub(crate) fn cli_can_set_state_directly(target: CardState) -> bool {
-    !matches!(target, CardState::Merged)
-}
-
-/// Per-state actionable refusal message for the gate above. Lesser-
-/// capable agents read this verbatim, so the corrective steps for
-/// each refused state are explicit.
-fn refusal_message(card_uuid: airc_lib::WorkCardId, target: CardState) -> String {
-    match target {
-        CardState::Merged => format!(
-            "refusing to set card {card_uuid} to Merged from the CLI: Merged is \
-             reserved for the PullRequestMerged event from the gh observer, \
-             which fires automatically when the linked PR merges on github.\n\n\
-             What you almost certainly want instead:\n  \
-             - If the PR has been merged on github: wait for the gh observer \
-             event to land (or check the card's pull_request field on the \
-             board — if it shows merged_at populated, the observer event is \
-             in flight).\n  \
-             - If you want to mark the card done without going through \
-             github (e.g. cancellation): `airc work close {card_uuid}` from \
-             a pre-work state (Open / Claimed / Blocked) succeeds directly \
-             per card 9656a836's close-guard.\n  \
-             - If you want to override for testing / recovery: this CLI \
-             surface is deliberately disabled (card a1bc62b3); patch the \
-             substrate or use a substrate-internal recovery tool."
-        ),
-        // Future substrate-owned states extend this match. The
-        // compiler enforces exhaustiveness on the gate function;
-        // the refusal message follows it.
-        other => format!(
-            "refusing to set card {card_uuid} to {other:?} from the CLI \
-             (no actionable next step encoded yet — this is a bug in \
-             airc-cli's refusal_message)"
-        ),
-    }
-}
-
-pub async fn run_close(home: &Path, card_id: String) -> Result<(), Box<dyn std::error::Error>> {
-    run_state(home, card_id, CliCardState::Closed).await
-}
-
-/// Card 9656a836: gate the close transition. Returns `true` when a
-/// card in `state` is allowed to transition to Closed.
-///
-/// Closed has substrate meaning: this card was shipped (PR merged)
-/// OR cancelled before any real work landed. An agent who calls
-/// `airc work close` from InProgress/Review/Closed is doing the
-/// thing we caught today — self-reporting work as done without it
-/// actually going through review + merge. Per Joel's "lesser persona
-/// intelligences" framing, this MUST refuse strictly — the persona
-/// can't be trusted to "know better," the substrate refuses.
-///
-/// "Workflow is workflow" — for non-coding recipes, swap PR-merged
-/// for the recipe-specific "verified done" signal; this rule's
-/// shape (Closed requires verified-done OR pre-work cancellation)
-/// generalizes.
-pub(crate) fn close_transition_allowed_from(state: CardState) -> bool {
-    matches!(
-        state,
-        CardState::Merged | CardState::Open | CardState::Claimed | CardState::Blocked
-    )
-}
-
 /// First 8 chars of a UUID-style id — enough to disambiguate at the
 /// board's typical scale, much easier on the eye than 36-char UUIDs.
 /// We deliberately do NOT shorten card_id in the board output because
@@ -928,13 +547,8 @@ fn format_peer(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BoardFilter {
     All,
-    /// No active claim, or claim's lease has expired (eligible for
-    /// reclaim per the flywheel-continuity doctrine). Closed/Merged
-    /// terminal cards are excluded.
     Available,
-    /// Owned by this peer right now.
     Mine,
-    /// Owned by another peer (active claim).
     Others,
 }
 
@@ -1390,32 +1004,32 @@ fn print_manager_recommendation(recommendation: &WorkManagerRecommendation) {
     );
 }
 
-fn now_ms() -> u64 {
+pub(crate) fn now_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
         .unwrap_or(0)
 }
 
-fn parse_work_card_id(input: &str) -> Result<WorkCardId, Box<dyn std::error::Error>> {
+pub(crate) fn parse_work_card_id(input: &str) -> Result<WorkCardId, Box<dyn std::error::Error>> {
     let uuid = Uuid::parse_str(input)
         .map_err(|error| format!("work card id {input:?} is not a valid UUID: {error}"))?;
     Ok(WorkCardId::from_uuid(uuid))
 }
 
-fn parse_claim_id(input: &str) -> Result<ClaimId, Box<dyn std::error::Error>> {
+pub(crate) fn parse_claim_id(input: &str) -> Result<ClaimId, Box<dyn std::error::Error>> {
     let uuid = Uuid::parse_str(input)
         .map_err(|error| format!("claim id {input:?} is not a valid UUID: {error}"))?;
     Ok(ClaimId::from_uuid(uuid))
 }
 
-fn parse_optional_lane_id(
+pub(crate) fn parse_optional_lane_id(
     input: Option<&str>,
 ) -> Result<Option<LaneId>, Box<dyn std::error::Error>> {
     input.map(parse_lane_id).transpose()
 }
 
-fn parse_lane_id(input: &str) -> Result<LaneId, Box<dyn std::error::Error>> {
+pub(crate) fn parse_lane_id(input: &str) -> Result<LaneId, Box<dyn std::error::Error>> {
     let uuid = Uuid::parse_str(input)
         .map_err(|error| format!("lane id {input:?} is not a valid UUID: {error}"))?;
     Ok(LaneId::from_uuid(uuid))
@@ -1459,6 +1073,9 @@ impl From<CliCardState> for CardState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::work_commands_lifecycle::{
+        cli_can_set_state_directly, close_transition_allowed_from, refusal_message,
+    };
 
     #[test]
     fn lease_renders_dash_when_no_claim() {
@@ -1821,3 +1438,12 @@ mod tests {
         assert!(msg.contains(&card_id.to_string()), "carries the card UUID");
     }
 }
+
+// Phase 2 (card 5aa9e780): lifecycle handlers + their state
+// guards extracted to a sibling module. Re-exported here so
+// callers (main.rs dispatchers, tests) still address them as
+// `work_commands::run_create` etc. — no churn on the public
+// surface.
+pub use crate::work_commands_lifecycle::{
+    run_claim, run_close, run_create, run_heartbeat, run_release, run_seed, run_state, run_update,
+};

--- a/crates/airc-cli/src/work_commands_lifecycle.rs
+++ b/crates/airc-cli/src/work_commands_lifecycle.rs
@@ -1,0 +1,366 @@
+//! Card lifecycle handlers — `airc work create | seed | claim | release |
+//! heartbeat | update | state | close`.
+//!
+//! Card c0bd865c phase 2 (5aa9e780): extracted from
+//! `work_commands.rs` to shrink that file's 1823-line drift and give
+//! consumer-embedders (continuum / hermes / openclaw / codex when they
+//! read this code to plan integrations) a focused surface for the
+//! card-state-machine.
+//!
+//! The state-machine transitions Open → Claimed → InProgress → Review
+//! → Merged → Closed are governed here; the substrate-side guards
+//! (`close_transition_allowed_from`, `cli_can_set_state_directly`,
+//! `refusal_message`) refuse the persona-trash-the-card paths that
+//! `airc-lib` doesn't yet refuse at the substrate layer.
+//!
+//! Cross-module helpers (parsers, `now_ms`, `spawn_claim_worktree`,
+//! `open_pr_and_link`, `auto_spawn_review_card`) stay in
+//! `work_commands.rs` and are called via the crate path. They're
+//! `pub(crate)` so this module reaches them; phases 3-5 (`git`, `gh`,
+//! `review`) will pull each into its own sibling module and tighten
+//! the visibility back down.
+
+use std::path::Path;
+
+use airc_diagnostics::{DiagnosticCode, DiagnosticComponent, DiagnosticEvent};
+
+use airc_lib::{
+    CardState, ChangeWorkCardState, ClaimWorkCard, CreateWorkCard, ReleaseWorkClaim, RepoId,
+    UpdateWorkCard, WorkBacklogSeedCandidate, WorkBacklogSeedOutcome,
+};
+
+use crate::lease;
+use crate::work_cli::{CliCardState, CliPriority};
+
+pub async fn run_create(
+    home: &Path,
+    repo: String,
+    title: String,
+    body: Option<String>,
+    lane_id: Option<String>,
+    priority: CliPriority,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = crate::commands::attached_airc(home).await?;
+    let card_id = airc
+        .create_work_card(CreateWorkCard {
+            repo: RepoId::new(repo)?,
+            title,
+            body,
+            priority: priority.into(),
+            lane_id: crate::work_commands::parse_optional_lane_id(lane_id.as_deref())?,
+            reviews: None,
+        })
+        .await?;
+    println!("card_id: {card_id}");
+    Ok(())
+}
+
+pub async fn run_seed(
+    home: &Path,
+    repo: String,
+    title: String,
+    body: Option<String>,
+    lane_id: Option<String>,
+    priority: CliPriority,
+    evidence_key: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = crate::commands::attached_airc(home).await?;
+    let result = airc
+        .seed_work_backlog(vec![WorkBacklogSeedCandidate {
+            repo: RepoId::new(repo)?,
+            title,
+            body,
+            priority: priority.into(),
+            lane_id: crate::work_commands::parse_optional_lane_id(lane_id.as_deref())?,
+            evidence_key,
+        }])
+        .await?;
+    for item in result.items {
+        let outcome = match item.outcome {
+            WorkBacklogSeedOutcome::Created => "created",
+            WorkBacklogSeedOutcome::AlreadyRepresented => "already_represented",
+            WorkBacklogSeedOutcome::AlreadyCompleted => "already_completed",
+        };
+        println!(
+            "seeded: outcome={outcome} card_id={card_id} repo={repo} title={title}",
+            card_id = item.card_id,
+            repo = item.candidate.repo,
+            title = item.candidate.title,
+        );
+    }
+    Ok(())
+}
+
+pub async fn run_claim(
+    home: &Path,
+    card_id: String,
+    ttl_ms: u64,
+    no_lease_required: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !no_lease_required {
+        let check = lease::check_current_dir()?;
+        if !check.under_lease {
+            return Err(format!(
+                "refusing to claim work card from {cwd}: not under lease zone {root}.\n\
+                 Allocate a worktree under ~/.airc/worktrees/ first, or pass \
+                 --no-lease-required to override.",
+                cwd = check.path.display(),
+                root = check.lease_root.display(),
+            )
+            .into());
+        }
+    }
+    let airc = crate::commands::attached_airc(home).await?;
+    let card_uuid = crate::work_commands::parse_work_card_id(&card_id)?;
+    let claim_id = airc
+        .claim_work_card(ClaimWorkCard {
+            card_id: card_uuid,
+            ttl_ms,
+        })
+        .await?;
+    println!("claim_id: {claim_id}");
+
+    // Card d1b2798d: auto-spawn a worktree + branch on successful
+    // claim. Eliminates the shared-checkout friction two agents on
+    // the same machine hit (`--no-lease-required` everywhere is the
+    // tell). Best-effort: a git failure does NOT undo the claim or
+    // the lease — the claim is the authoritative record, the
+    // worktree is convenience around it.
+    if let Err(error) = crate::work_commands::spawn_claim_worktree(&airc, card_uuid).await {
+        eprintln!("airc: worktree spawn skipped — {error}");
+    }
+    Ok(())
+}
+
+pub async fn run_release(
+    home: &Path,
+    card_id: String,
+    claim_id: Option<String>,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = crate::commands::attached_airc(home).await?;
+    let card_uuid = crate::work_commands::parse_work_card_id(&card_id)?;
+    // Default: resolve THIS peer's active claim from the board so
+    // callers don't have to track claim_ids the system already knows
+    // (kink card acb8bfcd: release ergonomics).
+    let claim_uuid = match claim_id {
+        Some(raw) => crate::work_commands::parse_claim_id(&raw)?,
+        None => resolve_my_active_claim(&airc, card_uuid).await?,
+    };
+    airc.release_work_claim(ReleaseWorkClaim {
+        card_id: card_uuid,
+        claim_id: claim_uuid,
+        reason,
+    })
+    .await?;
+    println!("released: card_id={card_id} claim_id={claim_uuid}");
+    Ok(())
+}
+
+async fn resolve_my_active_claim(
+    airc: &airc_lib::Airc,
+    card_id: airc_lib::WorkCardId,
+) -> Result<airc_lib::ClaimId, Box<dyn std::error::Error>> {
+    let board = airc.work_board(usize::MAX).await?;
+    let card = board
+        .card(card_id)
+        .ok_or_else(|| format!("card {card_id} not present in the board projection"))?;
+    let me = airc.peer_id();
+    match (card.owner, card.claim_id) {
+        (Some(owner), Some(claim_id)) if owner == me => Ok(claim_id),
+        (Some(owner), _) => Err(format!(
+            "card {card_id} is currently claimed by {owner}, not this peer ({me}); \
+             pass CLAIM_ID explicitly to release a claim you don't own"
+        )
+        .into()),
+        (None, _) => Err(format!("card {card_id} has no active claim to release").into()),
+    }
+}
+
+pub async fn run_heartbeat(
+    home: &Path,
+    card_id: String,
+    claim_id: String,
+    ttl_ms: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = crate::commands::attached_airc(home).await?;
+    let card_uuid = crate::work_commands::parse_work_card_id(&card_id)?;
+    let claim_uuid = crate::work_commands::parse_claim_id(&claim_id)?;
+    airc.heartbeat_work_claim(airc_lib::HeartbeatWorkClaim {
+        card_id: card_uuid,
+        claim_id: claim_uuid,
+        ttl_ms,
+    })
+    .await?;
+    println!("claim_heartbeat: card_id={card_id} claim_id={claim_id} ttl_ms={ttl_ms}");
+
+    // Heartbeat doesn't refuse on lease drift — the claim was
+    // already granted, and refusing here would just orphan it. But
+    // we DO record the drift as a typed diagnostic so a substrate
+    // observer can see when an agent has wandered out of its lease.
+    if let Ok(check) = lease::check_current_dir() {
+        if !check.under_lease {
+            let diag = DiagnosticEvent::warn(
+                DiagnosticComponent::Work,
+                DiagnosticCode::WorkspaceLeaseViolation,
+                "work heartbeat fired from a path outside the lease zone",
+            )
+            .with_field("card_id", &card_id)
+            .with_field("claim_id", &claim_id)
+            .with_field("cwd", check.path.display())
+            .with_field("lease_root", check.lease_root.display());
+            // Best-effort: a publish failure shouldn't break the
+            // heartbeat from the user's perspective. Surface to
+            // stderr so it isn't silently swallowed.
+            if let Err(error) = airc.publish_diagnostic_event(&diag).await {
+                eprintln!("airc: failed to publish lease-violation diagnostic: {error}");
+            }
+        }
+    }
+    Ok(())
+}
+
+pub async fn run_update(
+    home: &Path,
+    card_id: String,
+    title: Option<String>,
+    body: Option<String>,
+    priority: Option<CliPriority>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let card_uuid = crate::work_commands::parse_work_card_id(&card_id)?;
+    let airc = crate::commands::attached_airc(home).await?;
+
+    let mut request = UpdateWorkCard::amend(card_uuid);
+    if let Some(title) = title {
+        request = request.with_title(title);
+    }
+    if let Some(body) = body {
+        request = request.with_body(body);
+    }
+    if let Some(priority) = priority {
+        request = request.with_priority(priority.into());
+    }
+
+    airc.update_work_card(request).await?;
+    println!("card_updated: card_id={card_uuid}");
+    Ok(())
+}
+
+pub async fn run_state(
+    home: &Path,
+    card_id: String,
+    state: CliCardState,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = crate::commands::attached_airc(home).await?;
+    let card_uuid = crate::work_commands::parse_work_card_id(&card_id)?;
+    let card_state = CardState::from(state);
+
+    // Card a1bc62b3 (substrate-target gate): refuse direct CLI writes
+    // to states that should only come from substrate observers (e.g.
+    // Merged must come from PullRequestMerged, not `airc work state X
+    // merged` by an agent). Architectural boundary: agent input goes
+    // through this CLI guard; substrate mechanisms write events
+    // directly via Airc::change_work_card_state.
+    if !cli_can_set_state_directly(card_state) {
+        return Err(refusal_message(card_uuid, card_state).into());
+    }
+
+    // Card 9656a836 (close-lifecycle gate): Closed must come from
+    // Merged (PR merged) or {Open, Claimed, Blocked} (cancellation
+    // before any real work landed). Refuses Closed from InProgress
+    // or Review — there's claimed work in flight; the agent should
+    // either ship via state review → merge, or release the claim.
+    // Complementary to a1bc62b3 above: that one refuses agents from
+    // self-attesting Merged; this one refuses agents from
+    // self-attesting Closed without a Merged predecessor.
+    if card_state == CardState::Closed {
+        let board = airc.work_board(usize::MAX).await?;
+        let card = board.card(card_uuid).ok_or_else(|| {
+            format!("card {card_uuid} not visible in current room's board projection")
+        })?;
+        if !close_transition_allowed_from(card.state) {
+            return Err(format!(
+                "refusing to close card {card_uuid}: current state is {actual:?}, but \
+                 Closed requires Merged (PR merged) or {{Open, Claimed, Blocked}} \
+                 (cancellation before work landed).\n\n\
+                 If work is in flight ({actual:?}), the next step is:\n  \
+                 - state Review: open a PR via `airc work state {card_uuid} review`\n  \
+                 - wait for the PR to merge (state → Merged via gh observer)\n  \
+                 - THEN `airc work close {card_uuid}` succeeds.\n\n\
+                 If you want to abandon the work, `airc work release {card_uuid}` \
+                 drops the claim and returns the card to its prior state — close \
+                 from there.",
+                actual = card.state,
+            )
+            .into());
+        }
+    }
+
+    airc.change_work_card_state(ChangeWorkCardState {
+        card_id: card_uuid,
+        state: card_state,
+    })
+    .await?;
+    println!("card_state_changed: card_id={card_uuid} state={card_state:?}");
+
+    // Card 820629e9: on transition to Review, open a PR via `gh` from
+    // the card's worktree and link it to the card. Best-effort — a gh
+    // failure (no commits, no remote, gh not installed) prints a
+    // warning but does not undo the state transition. The link is
+    // recorded as a separate WorkEvent::PullRequestLinked, whose
+    // projection re-sets state=Review idempotently and populates
+    // card.pull_request — so downstream consumers (ad7e100b Sub-C
+    // auto-spawn review card, board renderers) read one source of
+    // truth.
+    if card_state == CardState::Review {
+        if let Err(error) = crate::work_commands::open_pr_and_link(&airc, card_uuid).await {
+            eprintln!("airc: gh pr create skipped — {error}");
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn cli_can_set_state_directly(target: CardState) -> bool {
+    !matches!(target, CardState::Merged)
+}
+
+pub(crate) fn refusal_message(card_uuid: airc_lib::WorkCardId, target: CardState) -> String {
+    match target {
+        CardState::Merged => format!(
+            "refusing to set card {card_uuid} to Merged from the CLI: Merged is \
+             reserved for the PullRequestMerged event from the gh observer, \
+             which fires automatically when the linked PR merges on github.\n\n\
+             What you almost certainly want instead:\n  \
+             - If the PR has been merged on github: wait for the gh observer \
+             event to land (or check the card's pull_request field on the \
+             board — if it shows merged_at populated, the observer event is \
+             in flight).\n  \
+             - If you want to mark the card done without going through \
+             github (e.g. cancellation): `airc work close {card_uuid}` from \
+             a pre-work state (Open / Claimed / Blocked) succeeds directly \
+             per card 9656a836's close-guard.\n  \
+             - If you want to override for testing / recovery: this CLI \
+             surface is deliberately disabled (card a1bc62b3); patch the \
+             substrate or use a substrate-internal recovery tool."
+        ),
+        // Future substrate-owned states extend this match. The
+        // compiler enforces exhaustiveness on the gate function;
+        // the refusal message follows it.
+        other => format!(
+            "refusing to set card {card_uuid} to {other:?} from the CLI \
+             (no actionable next step encoded yet — this is a bug in \
+             airc-cli's refusal_message)"
+        ),
+    }
+}
+
+pub async fn run_close(home: &Path, card_id: String) -> Result<(), Box<dyn std::error::Error>> {
+    run_state(home, card_id, CliCardState::Closed).await
+}
+
+pub(crate) fn close_transition_allowed_from(state: CardState) -> bool {
+    matches!(
+        state,
+        CardState::Merged | CardState::Open | CardState::Claimed | CardState::Blocked
+    )
+}


### PR DESCRIPTION
- fix(codex): poll inbox after sending airc messages (#556)
- feat(knock): public collaboration knock entrypoint (airc#559 PR-1) (#560)
- feat(approve): forward-secret room-invite handoff (airc#559 PR-2) (#561)
- feat(queue): add issue-backed queue add/list
- feat(queue): claim/release/set-status verbs (airc#562 PR-2) (#568)
- feat(queue): nudge verb — surface card to peers (airc#562 PR-3) (#573)
- fix(#571): route every gh body write through --body-file (lib_gh.sh) (#574)
- feat(queue): repo-scoped nudge status sweep (#578)
- fix(gh): safely close issues with markdown comments (#582)
- feat(queue): adopt existing issues into queue cards (#583)
- feat(lane): add worktree lanes for agents (#585)
- feat(queue): summarize repo nudge pongs (#586)
- feat(#576): auto-close queue cards when PRs merge into canary (#581)
- fix(#576): detect queue refs in PR titles (#587)
- feat(#572): queue heartbeat and stale scan (#588)
- feat(#570): embeddable queue and room widgets (#589)
- feat(#591): summarize queue availability (#592)
- fix(#593): ignore repo-nudge templates in pongs (#594)
- fix(#596): honor per-agent queue owner (#597)
- fix: add session work identity for queue ownership (#598)
- fix(queue): close already-merged queue cards (#599)
- fix(queue): require closing keywords for close-merged
- fix(queue): preserve issue titles
- feat(queue): recommend next work for idle agents
- feat(queue): allow cross-repo close-merged
- feat(queue): add metronome idle pulse
- fix(queue): prevent accidental claim takeovers
- docs(readme): document AI work queue workflow (#614)
- feat(queue): warn on stale PR branches (#617)
- refactor(queue): split command helpers (#618)
- fix(queue): default planning view and unclaimed-owner semantics (#620)
- Fix collaboration health for same-nick peers (#625)
- fix(lane): hydrate submodules after worktree add (continuum#1252) (#624)
- feat(queue): personalized dispatch verb (closes continuum#1192 broadcast→idle gap) (#623)
- fix(queue): dispatch metronome hand-outs (#627)
- feat: add hygiene policy command (#632)
- fix: fail closed on update conflicts (#633)
- docs: design rust sqlite substrate (#634)
- docs: design realtime event bus (#635)
- feat(queue): add steward dry-run digest (#636)
- feat(core): add Rust transcript primitives (#637)
- feat(logs): add json transcript pages (#638)
- fix(logs): avoid strict-mode crash without json flag (#639)
- refactor(logs): use one render path for human and json modes (#640)
- feat(queue): metronome fan-out across active roster (airc#607, continuum#1192) (#641)
- docs: propose manager-role + lane substrate for airc (#642)
- docs: add lane-kanban-protocol — engineering spec for the lane substrate (#643)
- feat(heartbeat): peer-liveness envelope kind + cmd_peers tracking (airc#644 PR-1) (#645)
- hotfix: cmd_peers Python comment backtick broke airc peers in production (#645 follow-up) (#646)
- feat(heartbeat): wire emission — cmd_send --heartbeat + reminder_timer_loop hook + monitor filter (airc#644 PR-2) (#647)
- fix(heartbeat): allow empty body when --heartbeat (caught live; airc#644 PR-2 follow-up) (#648)
- fix(heartbeat): second empty-body rejection path also needed exemption (airc#644 PR-2 follow-up #2) (#649)
- fix(airc): surface sender client_id on pm-tag so multi-tab agents are distinguishable (#650)
- docs(architecture): airc-rust substrate design — generic messaging/event/network layer (DRAFT) (#651)
- feat(airc-blobs): Phase 1 scaffold — ContentAddressedStore trait + ContentHash + MediaRef (#653)
- feat(airc-blobs): FsStore — filesystem-backed sha256-addressed content store (#655)
- docs(airc-rust): Contract Layer: forge-alloy (substrate vs contract boundary) (#657)
- feat(airc-core): Identity struct + modular split (one concern per file) (#654)
- feat(airc-core): Body enum (Json | Binary) — opaque payload primitive (#656)
- feat(airc-blobs): GC + retention policy — age-based + capacity-based (#660)
- feat(airc-core): convert ID newtypes from String to UUIDv4
- feat(airc-core): envelope Headers dictionary + HeaderFilter predicate
- feat(airc-protocol): wire-level envelope, Frame, signature, subscription, LiftPolicy
- feat(airc-transport): Transport trait + LocalFsAdapter (same-Mac wire)
- fix(airc-transport): tail_loop recovers from frames.jsonl truncation/recreation
- feat(airc-protocol): real Ed25519 signing + verify (closes PR-1 stub)
- feat(airc-transport): TLS peer-pinning infrastructure (cert gen + verifiers)
- feat(airc-transport): LanTcpAdapter — TLS-wrapped TCP with peer-pinned mTLS
- feat(airc-transport): SignedTransport<T> — per-frame Ed25519 sign + verify wrapper
- feat(airc-cli): airc-rs binary — first Rust replacement for Python airc
- test(airc-cli): e2e — two airc-rs subprocesses chat over the substrate
- feat(airc-cli): daemon mode — Unix socket IPC + typed Request/Response
- fix(airc-transport): LAN-TCP readiness race + subscribers-lock-during-await
- feat(airc-cli): daemon Subscribe + Inbox — buffered consume-once reads (#678)
- style(airc-blobs): apply current rustfmt rules (#677)
- feat(airc-transport): multi-peer LanTcpAdapter (#679)
- refactor(airc-transport): split lan_tcp::adapter into module (one concern per file) (#680)
- feat(airc-cli): persisted identity state — stable peer_id + client_id (#681)
- feat(airc-cli): persistent peer registry — peers.json + daemon AddPeer/ListPeers (#682)
- feat(airc-cli): cross-platform daemon — Unix sockets + Windows named pipes (#683)
- ci: rust quality gates — fmt + clippy (deny warnings) + test on every Rust PR (#661)
- docs(airc-rust): replace body_hint with HTTP-style Headers dictionary (reopen of #658) (#662)
- docs(airc-rust): UUIDv4 for every identifier + three-field identity model (reopen of #659) (#663)
- feat(airc-cli): per-user room state — drop --wire/--channel parameter hell (#684)
- fix(airc-cli): Windows pipe-name uniqueness — UUIDv5 over full path (#685)
- fix(codex-hooks): rename TOML key codex_hooks → hooks + auto-migrate (#686)
- fix(airc-transport): LAN-TCP send pre-validates payload, no silent drops (#687)
- feat(airc-store): SeaORM-backed event store crate (slice 4 foundation) (#688)
- refactor: split daemon runtime into airc-daemon crate (slice 5 relocation) (#689)
- feat(airc-daemon): wire airc-store as the inbox backing (slice 5b) (#690)
- feat(airc-lib): consumer-facing facade crate (slice 6) (#691)
- feat(airc-lib): live subscriptions + auto-populate store on say (slice 6b) (#692)
- refactor(airc-cli): commands route through airc_lib::Airc (slice 6c) (#693)
- docs(operating-board): work-coordination domain plan (Codex design) (#694)
- feat(airc-work): typed work coordination domain (#695)
- feat(airc-work): add routable event codec (#696)
- feat(airc-work): replay work events from transcripts (#697)
- feat(airc-work-store): project persisted work events (#698)
- feat(airc-lib): expose work coordination API (#699)
- feat(airc-cli): add work coordination commands (#700)
- feat(airc-cli): add lane coordination commands (#701)
- feat(airc-cli): add workspace lease commands (#702)
- feat(airc-cli): add manager hat commands (#703)
- feat(airc-lib): add filtered event subscriptions (#704)
- feat(airc-cli): add Rust Codex hook context (#705)
- feat(airc-cli): install Codex hooks from Rust (#706)
- feat(codex): route hooks through Rust CLI (#707)
- feat(install): build and install airc-rs (#708)
- refactor(codex): remove Python hook adapters (#709)
- ci: add runtime guard checks for rust-rewrite (#710)
- refactor(codex): move detached start into Rust (#711)
- feat(airc-rs): move client identity mnemonics to rust (#712)
- feat(airc-rs): move iso timestamp parsing to rust (#713)
- feat(airc-rs): move log append and rotate to rust (#714)
- feat(airc-rs): move bearer state reads to rust (#715)
- feat(airc-rs): move logs render to rust (#716)
- feat(airc-rs): move gist JSON parsing to rust (#717)
- feat(airc-transport): add gh gist bootstrap adapter (#718)
- feat(airc-lib): add explicit transport route policy (#719)
- feat(airc-lib): add transport resolver shell (#720)
- feat(airc-lib): feed resolver from transport health (#721)
- feat(airc-rs): expose transport route status (#722)
- feat(airc-rs): move transport health to rust (#723)
- feat(airc-rs): read subscribed channels from rust (#724)
- feat(airc-rs): move channel gist config reads to rust (#725)
- feat(airc-rs): move channel config writes to rust (#726)
- feat(airc-rs): move generic config state to rust (#727)
- feat(airc-rs): move host config block to rust (#728)
- feat(airc-rs): derive daemon scope ids in rust (#729)
- feat(airc-rs): parse doctor rate-limit json in rust (#730)
- feat(airc-rs): render whois identity output in rust (#731)
- feat(airc-cli): move message crypto helpers to Rust (#732)
- feat(airc-cli): move control-plane helpers to Rust (#733)
- feat(airc-cli): build legacy message JSON in Rust (#734)
- feat(airc-cli): move channel gist discovery to Rust (#735)
- feat(airc-cli): move channel gist resolve to Rust (#736)
- feat(airc-cli): move bearer send to Rust (#737)
- refactor(airc-cli): split bearer send modules (#738)
- feat(airc-cli): move bearer recv to Rust (#739)
- feat(airc-cli): move monitor formatter to Rust (#740)
- feat(airc-cli): move local attach tail to Rust (#741)
- feat(airc-cli): move pair handshake to Rust (#742)
- feat(airc-cli): move scope repair to Rust (#743)
- feat(airc-cli): move collaboration health to Rust (#744)
- feat(airc-cli): move inbox cursoring to Rust (#745)
- feat(airc-cli): move hygiene policy to Rust (#746)
- feat(airc-cli): move knock approval crypto to Rust (#747)
- feat(airc-cli): move knock identity JSON to Rust (#748)
- feat(airc-cli): move kick peer ssh lookup to Rust (#749)
- feat(airc-cli): move worktree lane registry to Rust (#750)
- feat(airc-cli): move local identity state to Rust (#751)
- feat(airc-cli): move runtime JSON helpers to Rust (#752)
- feat(airc-cli): move queue card core to Rust (#753)
- feat(airc-cli): move queue projections to Rust (#754)
- feat(airc-cli): move queue runtime summaries to Rust (#755)
- feat(airc-cli): move queue staleness metadata to Rust (#756)
- feat(airc-cli): move queue staleness analyzer to Rust (#757)
- feat(airc-cli): move queue close-merged parsing to Rust (#758)
- feat(queue): move plan and steward projections to rust (#759)
- feat(collaboration): move peers listing to rust (#760)
- fix(invite): read channel gist through rust config (#761)
- feat(identity): move rename collision scan to rust (#762)
- feat(network): move LAN IP probe to rust (#763)
- feat(runtime): drop wrapper python startup (#764)
- feat(install): remove python runtime bootstrap (#765)
- chore(runtime): remove python debug path (#766)
- test(integration): drop legacy python unit gate (#767)
- test(integration): probe bearer kinds through rust (#768)
- test(integration): scaffold ed25519 identity through rust (#769)
- test(integration): edit top-level config through rust (#770)
- feat(config): probe quit fixtures through rust (#771)
- test(integration): probe away status through rust (#772)
- test(integration): probe tabs state through rust (#773)
- test(integration): probe heartbeat gist through rust (#774)
- fix(heartbeat): patch takeover gist lease deterministically (#775)
- test(integration): probe status outage through rust (#776)
- test(integration): probe bearer config through rust (#777)
- test(integration): probe sidecar channels through rust (#778)
- test(integration): probe channel gists through rust (#779)
- test(integration): probe bearer outcome through rust (#780)
- feat(gist): extract named file content through rust (#781)
- test(integration): probe JSON predicates through rust (#782)
- test(integration): route bearer and channel gist through rust (#783)
- test(integration): probe liveness events through rust (#784)
- fix(handshake): accept hyphen-leading public key values (#785)
- test(integration): delete legacy python bearer scenarios (#786)
- test(integration): route gh bearer scenario through rust (#787)
- test(integration): fake gone gist sends through airc-rs (#788)
- test(integration): generate gist rotation seed without python (#789)
- test(integration): remove python from platform adapters scenario (#790)
- install: stop documenting python runtime setup (#791)
- runtime: remove live airc_core references (#792)
- runtime: delete python airc_core layer (#793)
- fix(status): host health ignores joiner bearer pidfiles (#794)
- docs(architecture): transport control plane admission (#795)
- fix: fail closed on production fallback paths (#796)
- docs: define robustness integration plan (#797)
- refactor: remove fallback runtime surfaces (#798)
- ci: enforce Rust quality contracts (#799)
- fix(doctor): keep local health independent of GitHub (#800)
- docs: define invite-only gist routing architecture (#801)
- feat(routes): enforce invite-only gist admission (#802)
- feat(lib): gate sends through route resolver (#803)
- feat(lib): execute SDK sends over LAN routes (#804)
- refactor(cli): route LAN commands through airc-lib (#805)
- feat(lib): organize route discovery and health (#806)
- docs: update route requirements status (#807)
- docs: group route work into PR slices (#808)
- feat(lib): discover local route health (#809)
- feat(route): make gist an invite beacon (#810)
- feat(lib): attach SDK to daemon IPC (#811)
- refactor(cli): route daemon msg and inbox through SDK (#812)
- fix(cli): accept legacy message build command (#814)
- feat(airc-work): drain typing — workspace pressure/drain events + projection (Slice 7 PR 3a) (#813)
- feat(shell): route plain msg through rust local substrate (#815)
- feat(shell): read rust local inbox by default (#817)
- feat(airc-relay): baseline relay server + transport adapter (PR-E) (#816)
- feat(airc-transport): add realtime UDP adapter (#818)
- feat(trust-rotation): signed peer trust rotation contract + daemon application (PR-H) (#819)
- feat(airc-transport): add WebRTC datachannel adapter (#820)
- test(examples): prove SDK consumer embedding path (#821)
- test(examples): prove agent dogfood consumer path (#822)
- feat(examples): consumer integration shape contracts — Continuum/OpenClaw/Hermes (PR-I3) (#823)
- test(cli): prove installed agent identities dogfood live room (#824)
- fix(status): surface rust local data plane before gh bearer (#825)
- fix(codex-hook): pin rust hook executable and honor cursor overrides (#826)
- docs(readme): rework for the post-rewrite substrate (#827)
- fix(workspace): keep lane roots under airc home (#828)
- fix(monitor): attach to Rust event stream (#830)
- fix(teardown): verify live process reaping (#832)
- fix(install): remove rust suffix from airc surface (#833)
- fix(install): use ~/.airc/src as the source root (#835)
- feat(work): drain policy evaluator — pure substrate primitive (#834)
- fix(install): use source command as POSIX entrypoint (#836)
- fix(shell): resolve airc-core from source install (#837)
- fix(status): treat rust-local as routine health (#838)
- fix(install): PATH-augment is newline-safe + strips stale airc lines
- fix(install): rc reconcile no longer short-circuits on in-shell PATH
- fix(codex-hook): install source command path (#839)
- fix(msg): distinguish local store from peer delivery (#840)
- feat(lib): SubscriptionSet + ChannelName + identity-namespaced RoomId (#841)
- fix(events): monitor hooks use subscribed channels (#842)
- feat(lib): mesh identity resolution — replace MeshIdentity::unset() (#843)
- fix(lib): share same-machine account local wire (#844)
- feat(lib): add account room coordinator (#845)
- fix(join): seed rust account rooms from wrapper (#846)
- fix(install): put airc shim on POSIX PATH (#847)
- test(install): gate public airc shim path (#848)
- docs(install): define AI agent install contract (#849)
- test(install): prove public airc account-room runtime (#851)
- feat(lib): machine-global account coordinator (Gap 8) (#850)
- feat(lib): wire account join discovery into local delivery (#852)
- test(install): prove public monitor and hook delivery (#853)
- feat(lib): add account registry bootstrap contract (#854)
- fix(cli): route local join and broadcast through Rust (#855)
- fix(status): show rust command mode after stale startup (#856)
- fix(lib): cross-process chat actually delivers — live_tx fans out on DuplicateEventId (#857)
- fix(status): count Rust-substrate peers, not just legacy peers/ dir (#858)
- fix(send/msg): receipt no longer lies about non-delivery on shared-home wire (#859)
- feat(join): explicit scope + mesh-kind in output (#860)
- fix(join): label canonical HOME scope as machine-account home (#861)
- feat(lib): cross-machine bootstrap via gh-gist account-mesh registry (#862)
- fix(airc): restore project scope and runtime hook identity (#863)
- feat: demolition — bash wrapper deleted, airc IS the Rust binary (#864)
- fix(ci): runtime-guards green post-demolition (#865)
- fix(registry): no --paginate; bound sync with timeout; tests disable (#867)
- fix(mesh-identity): Operator-source cache never expires; bound shell-outs (#868)
- fix(airc): make join own daemon live delivery (#866)
- fix(codex-hook): trust airc.client header on shared-HOME identity (#869)
- feat(cli): restore airc join --attach and airc version subcommand (#870)
- fix(join): ensure Codex hook setup (#871)
- docs(skill): tab-loop semantics for bidirectional agent coordination (#872)
- fix(install): prefer current source tree (#873)
- fix(cli): airc join always streams ALL subscribed rooms; remove --attach (#876)
- test(join): pin runtime attach decision (#877)
- fix(join): detect Codex runtime via client identity (#878)
- docs(architecture): establish grid substrate audit (#879)
- fix(join): persist live feed cursor (#880)
- fix(store): persist runtime cursors through SeaORM (#882)
- docs(architecture): Phase 3.5 ORM end-to-end + Phase 3.6 perf hotpaths (#881)
- fix(store): persist peer trust through ORM (#883)
- fix(store): persist subscriptions through ORM (#884)
- fix(store): persist local identity metadata through ORM (#885)
- fix(store): persist mesh identity through ORM (#886)
- fix(store): persist account registry through ORM (#887)
- fix(store): persist coordinator beacons through ORM (#888)
- cleanup(lib): remove file-backed coordinator beacons (#889)
- cleanup(cli): remove config.json command shim (#890)
- refactor(identity): store-backed identity commands (#891)
- refactor(cli): remove config repair scope command (#892)
- refactor(transport): report substrate route health (#893)
- refactor(cli): remove bearer state command (#894)
- refactor(cli): remove recent senders command (#895)
- refactor(cli): remove legacy log scraping surface (#896)
- refactor(collaboration): remove jsonl presence scans (#897)
- refactor(identity): remove jsonl rename collision helper (#898)
- refactor(cli): remove legacy bearer command (#899)
- refactor(cli): remove jsonl message builder (#900)
- fix(install): copy artifacts instead of symlinking (#901)
- fix(identity): migrate identity json into orm state (#902)
- fix(lib): report peers from account mesh registry (#903)
- fix(cli): agent-runtime attach decision wins over piped-stdout (#904)
- fix(lib): wire replay skips unverifiable frames instead of aborting (#905)
- docs(codex): clarify live feed contract (#906)
- refactor(cli): isolate runtime context classification (#908)
- docs: AR/Cambrian/grid framing + data-model + Phase 3.5 migration (#907)
- refactor(cli): move codex integration behind boundary (#910)
- feat(cli): airc doctor — install + identity + scope self-diagnosis (#909)
- feat(lib): expose subscription query API (#911)
- feat(lib): command-bus primitive (Airc::request / reply / await_reply) (#912)
- docs: CI fidelity as substrate non-negotiable (#10) (#913)
- test(cli): emulate join attach in e2e harness (#915)
- feat(lib): typed lifecycle events (Phase 2) (#914)
- feat(work): add git and PR event contracts (#917)
- feat(lib): emit PeerArrived lifecycle event on add_peer (Phase 2 cont.) (#916)
- feat(work): add local git watcher adapter (#918)
- feat(lib): emit WireEstablished lifecycle event (Phase 2 cont.) (#919)
- docs: require roadmap reference in PR template (#920)
- ci: enforce PR roadmap references (#921)
- feat(lib): emit SubscriptionAdvanced on cursor saves (#922)
- feat(lib): emit RoomParted lifecycle events (#924)
- feat(lib): emit PeerDeparted lifecycle events (#925)
- ci: keep roadmap references as PR template guidance (#926)
- feat(airc-lib): WireLost emit on stream-end + teardown (#923)
- feat(codex): add pollable AIRC feed command (#927)
- test(install): prove Codex poll in public runtime (#928)
- fix(lib): keep routine wire replay quiet (#929)
- feat(cli): add Rust update command (#930)
- refactor(store): move coordinator refresh lock into ORM (#931)
- perf(lib): use set-backed event dedup (#932)
- perf(lib): broadcast live events by arc (#933)
- perf(protocol): remove global peer registry lock (#934)
- perf(lib): remove global route table locks (#935)
- perf(lib): own local ingest task lifecycle (#936)
- perf(lib): use set-backed subscription dedup (#937)
- perf(lib): shorten subscriber setup locks (#938)
- perf(lib): make event filter channels set-backed (#939)
- refactor(daemon): length-frame ipc with cbor (#940)
- fix(cli): restart daemon during update (#941)
- refactor(ipc): split daemon IPC contract into crate (#942)
- refactor(identity): split local identity into crate (#943)
- refactor(trust): split peer trust into crate (#944)
- test(command-bus): prove request reply over LAN (#945)
- feat(airc-lib): execute relay routes through SDK (#946)
- test(consumer-shapes): prove command bus integration (#948)
- feat(airc-work): PR observation adapter skeleton (#947)
- docs(audit): refresh immediate queue after PR adapter (#949)
- feat(airc-work): real gh PullRequestSource over GhCommandRunner (#950)
- docs(readme): restore generic agent IRC framing (#951)
- fix(ipc): version daemon endpoint by protocol (#952)
- fix(daemon): refresh wire trust for live ingest (#953)
- test(airc-lib): prove Continuum-shaped room throughput (#954)
- feat(airc-lib): wire UDP route execution + WebRTC signaling types (#955)
- feat(airc-lib): WebRTC DataChannel orchestration over AIRC mesh (#957)
- docs(webrtc): media tracks plan and implementation split (#959)
- feat(airc-lib): surface incoming WebRTC media tracks (#960)
- feat(airc-lib): add WebRTC media track builder (#961)
- test(airc-lib): prove WebRTC audio and video tracks (#962)
- test(airc-lib): prove WebRTC media and control share a session (#963)
- docs(audit): note observed AIRC coordination flaws (#964)
- fix(cli): restore IRC-shaped peers and whois commands (#966)
- docs(webrtc): show Continuum live-room integration example (#967)
- feat(work): heartbeat claims and surface stale owners (#969)
- feat(work): publish agent availability state (#971)
- feat(diagnostics): add typed substrate diagnostic sink (#973)
- feat(airc-lib): typed lane-coordination events (#965)
- feat(airc-lib): active-agent heartbeat events (#968)
- feat(airc-cli): bake build sha + drift detection in doctor (#972)
- feat(work): suggest claimable cards for agents (#975)
- feat(work): surface claimable queue suggestions in agent feeds (#976)
- feat(airc-lib): typed work-event subscription API (#974)
- feat(work): close completed cards (#977)
- fix(work): tolerate bounded board replay windows (#979)
- feat(airc-lib): AIRC-event diagnostic sink + doctor surface (#978)
- fix(work): preserve terminal state on claim release (#980)
- docs(audit): consumer integration gap audit + follow-up cards (#981)
- docs(audit): roadmap-to-card coverage + missing-card cleanup (#982)
- feat(work): surface agent availability in queue status (#983)
- test(lib): prove Continuum pose fan-out throughput (#984)
- feat(work): render typed agent roster (#986)
- fix(work): make duplicate claim release idempotent (#987)
- feat(airc-lib): external-identity bridge contract (#985)
- feat(work): enforce lease-zone for work claim + heartbeat diagnostic (#988)
- feat(route): add JSON route proof harness (#989)
- feat(publish): structured publish API + airc publish JSON-receipt CLI (#990)
- feat(events): add JSON list output (#991)
- docs: define cooperative coordination training signal (#992)
- fix(work): reject card transitions from wrong room (#993)
- fix(join): replace stale daemon builds from typed status (#994)
- fix(work): tolerate superseded claim release + ghost heartbeat (#996)
- feat(work): publish active-agent roster heartbeats from join (#997)
- fix(work): correlate peer claims to live roster clients (#998)
- feat(work): add typed manager loop evaluation (#999)
- docs(airc): add runtime planning and consumer audit lanes (#1000)
- docs(airc): define autonomous development roadmap (#1001)
- fix(work): find active cards beyond small recent windows (#1004)
- fix(work-store): tolerate orphaned events in complete projection (#1005)
- fix(work): schedule from complete work projection (#1006)
- feat(work): seed backlog from manager candidates (#1008)
- fix(work): make stale claims recoverable by default (#1009)
- feat(ipc): add ResolveWireRequest (channel uuid -> wire path lookup) (#1011)
- feat(inbox): --json flag for machine-readable output (#1010)
- fix(work): exclude terminal cards from stale recovery (#1012)
- fix(identity): resolve mesh identity against machine-global coordinator store (#1014)
- perf(bus): decoupled delivery bus — kill same-machine poll/fsync latency (#1015)
- fix(test): isolate two-machine bridge test via explicit wire roots — repairs Windows CI (#1016)
- docs(arch): airc event-server design — efficient ORM+push routing server (#1017)
- feat(airc-bus): owner-core event router — sharded router + hot ring + generational cursor + zero-copy fan-out (#1018)
- test(e2e): realistic timeout for process-spawn round-trips (fix macOS flake) (#1020)
- fix(reliability): LAN send-flush + lan-listen subscribe order + daemon-shutdown hang (#1021)
- feat(store): SQLite-backed DurableSink — owner-core ORM durable tier (§3.3) (#1019)
- feat(store): persistent EpochStore — generational epoch survives daemon restart (§3.8) (#1022)
- feat(wire): airc-wire — FlatBuffers binary codec for the envelope (zero-copy payload) (#1023)
- feat(work+lib+cli): autonomous-team substrate end-to-end (19 cards) (#1025)
- fix(cli): airc work state review uses Command::current_dir, not gh -C (card a4fe899f) (#1027)
- fix(cli): airc work state X merged refused — only PullRequestMerged event sets Merged (card a1bc62b3) (#1028)
- feat(store): add agent_name column to local_identity (card 8384cc18 Sub-A) (#1030)
- fix(identity): provisional git-email identity self-heals to gh login (one identity per machine) (#1024)
- fix(cli): default_home_dir skips machine-account ~/.airc + resolves to main working tree from a worktree (card a1b4552a) (#1029)
- fix(lib): work_board filters heartbeats out of the projection page (card 79953b4d) (#1031)
- fix(cli): airc work state Closed refuses unless from Merged or pre-work state (card 9656a836) (#1026)
- docs(agents): encode engineering-staff framing — CI-green-before-merge, branch hygiene, monitoring (card 53698eb9) (#1032)
- fix(install): recover from stale Rust toolchain instead of cryptic build abort (#1013)
- ef168afe/airc ci re green rust rewrite accumulate (#1033)
- fix(cli): gh pr create reads commit subject as title — not branch slug (card 13131f1c) (#1034)
- refactor(cli): extract card-lifecycle handlers into work_commands_lifecycle.rs (card c0bd865c phase 2 / 5aa9e780)
