### PR TITLE
refactor(cli): split work_commands.rs phase 4 — extract gh module (FINAL, card c7bdf2df)

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -78,6 +78,7 @@ mod transport_commands;
 mod update_commands;
 mod work_cli;
 mod work_commands;
+mod work_commands_gh;
 mod work_suggestions;
 mod workspace_cli;
 mod workspace_commands;

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -558,135 +558,10 @@ pub async fn run_state(
     // auto-spawn review card, board renderers) read one source of
     // truth.
     if card_state == CardState::Review {
-        if let Err(error) = open_pr_and_link(&airc, card_uuid).await {
+        if let Err(error) = crate::work_commands_gh::open_pr_and_link(&airc, card_uuid).await {
             eprintln!("airc: gh pr create skipped — {error}");
         }
     }
-    Ok(())
-}
-
-/// Best-effort: open a GitHub PR for the work card's worktree branch
-/// and link it via `WorkEvent::PullRequestLinked`. Returns Err so
-/// run_state can surface as a warning without aborting the state
-/// transition.
-async fn open_pr_and_link(
-    airc: &airc_lib::Airc,
-    card_id: airc_lib::WorkCardId,
-) -> Result<(), Box<dyn std::error::Error>> {
-    use airc_work::model::{BranchName, PullRequestRef};
-
-    let board = airc.work_board(usize::MAX).await?;
-    let card = board
-        .card(card_id)
-        .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;
-    if card.pull_request.is_some() {
-        // Already linked; nothing to do. Re-running `state review` on
-        // a card that's already been reviewed is a no-op for the PR
-        // side.
-        return Ok(());
-    }
-
-    let short: String = card.card_id.to_string().chars().take(8).collect();
-    let lease_root = lease::lease_root()
-        .ok_or_else(|| "HOME/USERPROFILE not set; cannot resolve ~/.airc/worktrees/".to_string())?;
-    let worktree_path = lease_root.join(&short);
-    if !worktree_path.exists() {
-        return Err(format!(
-            "no worktree at {} — claim was made before card d1b2798d shipped, or with --no-lease-required (re-claim from a worktree to get auto-PR on review)",
-            worktree_path.display()
-        )
-        .into());
-    }
-    let worktree_str = worktree_path.to_string_lossy().to_string();
-
-    // gh pr create — pass --title + --body explicitly from the HEAD
-    // commit's metadata. `--fill` SOUNDS right but its heuristic
-    // sometimes falls back to a slugified branch name as the title
-    // (observed live on cards 53698eb9 and ef168afe — branch
-    // `53698eb9/agents-md-encode-engineering-staff-not-a` became
-    // PR title `53698eb9/agents md encode engineering staff not a`,
-    // which stripped the `docs(agents):` prefix the canary-gate's
-    // bypass regex needs). Reading the commit subject directly is
-    // deterministic and matches what the author actually wrote.
-    //
-    // Card a4fe899f: `gh` does NOT accept `-C` (that's git's flag).
-    // The cwd has to be set via `Command::current_dir(...)` so gh's
-    // own repo-resolution (which scans `git remote get-url origin`
-    // from cwd) picks the worktree's branch.
-    //
-    // Card 28f1440c: `--base` is set explicitly to the workflow's
-    // integration branch (`rust-rewrite`) rather than letting gh
-    // fall back to the repo's GitHub default (`main` here). Main is
-    // the legacy snapshot; every PR landing there bypasses the
-    // substrate work. Hardcoded for the MVP; a follow-up card
-    // surfaces it as configurable for consumers whose integration
-    // branch differs.
-    //
-    // Card 13131f1c: `--title` + `--body` are passed explicitly from
-    // the HEAD commit instead of relying on `--fill`. `--fill`'s
-    // heuristic sometimes substitutes a slugified branch name as the
-    // title (observed on #1032 and #1033 — `docs(agents):`/`fix(ci):`
-    // prefixes stripped, breaking the canary-gate bypass). Reading
-    // the commit subject directly is deterministic.
-    let base_branch = pr_create_base_branch();
-    let subject = git_show_format(&worktree_str, "%s")?;
-    let body = git_show_format(&worktree_str, "%b")?;
-    let create_out = std::process::Command::new("gh")
-        .current_dir(&worktree_str)
-        .args([
-            "pr",
-            "create",
-            "--title",
-            subject.trim(),
-            "--body",
-            body.trim(),
-            "--base",
-            base_branch,
-        ])
-        .output()?;
-    if !create_out.status.success() {
-        return Err(format!(
-            "gh pr create failed: {}",
-            String::from_utf8_lossy(&create_out.stderr).trim()
-        )
-        .into());
-    }
-    let stdout = String::from_utf8(create_out.stdout)?;
-    let pr_url = stdout.trim().lines().last().unwrap_or("").trim();
-    let pr_number = extract_pr_number(pr_url)
-        .ok_or_else(|| format!("could not parse PR number from gh output: {pr_url}"))?;
-
-    // Resolve head from the worktree's git state. Base is the same
-    // value we passed to `gh pr create` above (card 28f1440c) — must
-    // not drift between the substrate's PullRequestRef and the
-    // actual PR target, or downstream consumers (review-spawn,
-    // close-guard) reason about the wrong branch.
-    let head_branch = git_rev_parse_branch(&worktree_str)?;
-
-    let pull_request = PullRequestRef {
-        repo: card.repo.clone(),
-        number: pr_number,
-        head: BranchName::new(head_branch)?,
-        base: BranchName::new(base_branch.to_string())?,
-    };
-    airc.link_card_pull_request(airc_lib::LinkCardPullRequest {
-        card_id,
-        pull_request,
-    })
-    .await?;
-
-    println!("pull_request: {pr_url}");
-
-    // Card ad7e100b Sub-C: with PR linked, spawn a sibling review
-    // card so any peer (other than the author) can claim it and
-    // review the diff. Best-effort and idempotent — a spawn failure
-    // here must not undo the state transition or the PR link, and
-    // re-running `state review` on a card whose review card already
-    // exists is a no-op.
-    if let Err(error) = auto_spawn_review_card(airc, card_id, pr_url).await {
-        eprintln!("airc: review card auto-spawn skipped — {error}");
-    }
-
     Ok(())
 }
 
@@ -714,7 +589,7 @@ async fn open_pr_and_link(
 /// out of the CLI for consumers that bypass it (Continuum, OpenClaw),
 /// but the wire shape is stable — that move doesn't break this
 /// emit.
-async fn auto_spawn_review_card(
+pub(crate) async fn auto_spawn_review_card(
     airc: &airc_lib::Airc,
     parent_id: airc_lib::WorkCardId,
     pr_url: &str,
@@ -754,16 +629,7 @@ async fn auto_spawn_review_card(
     Ok(())
 }
 
-/// Extract the PR number from a gh pr create URL line like
-/// `https://github.com/owner/repo/pull/123`. Returns None for any
-/// shape we don't recognise (so callers can degrade gracefully).
-fn extract_pr_number(url: &str) -> Option<u64> {
-    let trimmed = url.trim();
-    let tail = trimmed.rsplit('/').next()?;
-    tail.parse::<u64>().ok()
-}
-
-fn git_rev_parse_branch(worktree: &str) -> Result<String, Box<dyn std::error::Error>> {
+pub(crate) fn git_rev_parse_branch(worktree: &str) -> Result<String, Box<dyn std::error::Error>> {
     let out = std::process::Command::new("git")
         .args(["-C", worktree, "rev-parse", "--abbrev-ref", "HEAD"])
         .output()?;
@@ -783,7 +649,10 @@ fn git_rev_parse_branch(worktree: &str) -> Result<String, Box<dyn std::error::Er
 /// heuristic sometimes falls back to a slugified branch name (card
 /// 13131f1c). Empty stdout is valid (commits often have an empty
 /// body) and propagates as an empty `String`.
-fn git_show_format(worktree: &str, format: &str) -> Result<String, Box<dyn std::error::Error>> {
+pub(crate) fn git_show_format(
+    worktree: &str,
+    format: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
     let out = std::process::Command::new("git")
         .args([
             "-C",
@@ -802,47 +671,6 @@ fn git_show_format(worktree: &str, format: &str) -> Result<String, Box<dyn std::
         .into());
     }
     Ok(String::from_utf8(out.stdout)?)
-}
-
-/// Card 28f1440c — the integration branch every per-card PR opens
-/// against. Hardcoded to the airc substrate's working branch for
-/// MVP; a follow-up surfaces this as configurable (e.g. via
-/// `.airc/work.toml`) for consumers whose integration branch is
-/// different.
-///
-/// MUST NOT change to a runtime read of `gh repo view --json defaultBranchRef` —
-/// that returns the repo's GitHub `default_branch` (`main` on this
-/// repo today), and every PR landing on `main` bypasses
-/// `rust-rewrite`'s substrate work. The whole point of this card
-/// is to refuse that fallback.
-pub(crate) fn pr_create_base_branch() -> &'static str {
-    "rust-rewrite"
-}
-
-#[allow(dead_code)]
-fn gh_default_branch(worktree: &str) -> Result<String, Box<dyn std::error::Error>> {
-    // Card a4fe899f: `gh` does NOT accept `-C`; set cwd via
-    // `Command::current_dir(...)` so `gh repo view` resolves the
-    // worktree's origin remote, not the shell cwd's.
-    let out = std::process::Command::new("gh")
-        .current_dir(worktree)
-        .args([
-            "repo",
-            "view",
-            "--json",
-            "defaultBranchRef",
-            "--jq",
-            ".defaultBranchRef.name",
-        ])
-        .output()?;
-    if !out.status.success() {
-        return Err(format!(
-            "gh repo view failed: {}",
-            String::from_utf8_lossy(&out.stderr).trim()
-        )
-        .into());
-    }
-    Ok(String::from_utf8(out.stdout)?.trim().to_string())
 }
 
 /// Card a1bc62b3 — gate on direct CLI state writes.
@@ -1618,16 +1446,21 @@ mod tests {
     #[test]
     fn extract_pr_number_parses_gh_url_or_returns_none() {
         assert_eq!(
-            extract_pr_number("https://github.com/CambrianTech/airc/pull/123"),
+            crate::work_commands_gh::extract_pr_number(
+                "https://github.com/CambrianTech/airc/pull/123"
+            ),
             Some(123),
         );
         assert_eq!(
-            extract_pr_number("  https://github.com/owner/repo/pull/1  "),
+            crate::work_commands_gh::extract_pr_number("  https://github.com/owner/repo/pull/1  "),
             Some(1),
         );
         // Non-numeric tail → None (degrade gracefully).
-        assert_eq!(extract_pr_number("https://example.com/no-pr-here"), None);
-        assert_eq!(extract_pr_number(""), None);
+        assert_eq!(
+            crate::work_commands_gh::extract_pr_number("https://example.com/no-pr-here"),
+            None
+        );
+        assert_eq!(crate::work_commands_gh::extract_pr_number(""), None);
     }
 
     #[test]
@@ -1867,7 +1700,7 @@ mod tests {
     #[test]
     fn pr_create_base_branch_targets_rust_rewrite() {
         assert_eq!(
-            pr_create_base_branch(),
+            crate::work_commands_gh::pr_create_base_branch(),
             "rust-rewrite",
             "card 28f1440c: PR target must be the substrate working \
              branch, never the repo's GitHub default ('main' on this \
@@ -1875,6 +1708,6 @@ mod tests {
         );
         // Specifically: it must NOT be 'main'. The doctrine treats
         // main as the legacy snapshot.
-        assert_ne!(pr_create_base_branch(), "main");
+        assert_ne!(crate::work_commands_gh::pr_create_base_branch(), "main");
     }
 }

--- a/crates/airc-cli/src/work_commands_gh.rs
+++ b/crates/airc-cli/src/work_commands_gh.rs
@@ -1,0 +1,175 @@
+//! GitHub operations — PR creation + linking + base-branch resolution.
+//! Currently shells out via `std::process::Command::new("gh")`; card
+//! dec35ec7 will migrate these to the typed `GhClient` trait from
+//! `airc-lib::tools` once that lands.
+//!
+//! Card c0bd865c phase 4 (c7bdf2df). The extracted handlers:
+//!
+//!   - `open_pr_and_link` — best-effort: from a card's worktree,
+//!     run `gh pr create` against the configured base, parse the
+//!     created PR's URL/number, and emit `PullRequestLinked` so the
+//!     projection picks it up.
+//!   - `gh_default_branch` — query github for the repo's GitHub
+//!     default branch; kept for back-compat (no longer the source
+//!     of truth for the per-card base, see card 28f1440c).
+//!   - `extract_pr_number` — pure parser for `gh pr create`'s URL
+//!     output.
+//!   - `pr_create_base_branch` — the integration branch the merger
+//!     opens PRs against (rust-rewrite). Hardcoded per card 28f1440c.
+
+use crate::lease;
+
+/// Best-effort: open a GitHub PR for the work card's worktree branch
+/// and link it via `WorkEvent::PullRequestLinked`. Returns Err so
+/// run_state can surface as a warning without aborting the state
+/// transition.
+pub(crate) async fn open_pr_and_link(
+    airc: &airc_lib::Airc,
+    card_id: airc_lib::WorkCardId,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use airc_work::model::{BranchName, PullRequestRef};
+
+    let board = airc.work_board(usize::MAX).await?;
+    let card = board
+        .card(card_id)
+        .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;
+    if card.pull_request.is_some() {
+        // Already linked; nothing to do. Re-running `state review` on
+        // a card that's already been reviewed is a no-op for the PR
+        // side.
+        return Ok(());
+    }
+
+    let short: String = card.card_id.to_string().chars().take(8).collect();
+    let lease_root = lease::lease_root()
+        .ok_or_else(|| "HOME/USERPROFILE not set; cannot resolve ~/.airc/worktrees/".to_string())?;
+    let worktree_path = lease_root.join(&short);
+    if !worktree_path.exists() {
+        return Err(format!(
+            "no worktree at {} — claim was made before card d1b2798d shipped, or with --no-lease-required (re-claim from a worktree to get auto-PR on review)",
+            worktree_path.display()
+        )
+        .into());
+    }
+    let worktree_str = worktree_path.to_string_lossy().to_string();
+
+    // gh pr create — pass --title + --body explicitly from the HEAD
+    // commit's metadata. `--fill` SOUNDS right but its heuristic
+    // sometimes falls back to a slugified branch name as the title
+    // (observed live on cards 53698eb9 and ef168afe — branch
+    // `53698eb9/agents-md-encode-engineering-staff-not-a` became
+    // PR title `53698eb9/agents md encode engineering staff not a`,
+    // which stripped the `docs(agents):` prefix the canary-gate's
+    // bypass regex needs). Reading the commit subject directly is
+    // deterministic and matches what the author actually wrote.
+    //
+    // Card a4fe899f: `gh` does NOT accept `-C` (that's git's flag).
+    // The cwd has to be set via `Command::current_dir(...)` so gh's
+    // own repo-resolution (which scans `git remote get-url origin`
+    // from cwd) picks the worktree's branch. Without this, gh
+    // silently ran against whatever the shell's cwd was at invoke
+    // time — usually the wrong repo — and the whole Review-state →
+    // PR-link pipeline failed (best-effort warning was swallowed).
+    let subject = crate::work_commands::git_show_format(&worktree_str, "%s")?;
+    let body = crate::work_commands::git_show_format(&worktree_str, "%b")?;
+    let create_out = std::process::Command::new("gh")
+        .current_dir(&worktree_str)
+        .args([
+            "pr",
+            "create",
+            "--title",
+            subject.trim(),
+            "--body",
+            body.trim(),
+        ])
+        .output()?;
+    if !create_out.status.success() {
+        return Err(format!(
+            "gh pr create failed: {}",
+            String::from_utf8_lossy(&create_out.stderr).trim()
+        )
+        .into());
+    }
+    let stdout = String::from_utf8(create_out.stdout)?;
+    let pr_url = stdout.trim().lines().last().unwrap_or("").trim();
+    let pr_number = extract_pr_number(pr_url)
+        .ok_or_else(|| format!("could not parse PR number from gh output: {pr_url}"))?;
+
+    // Resolve head/base from the worktree's git state.
+    let head_branch = crate::work_commands::git_rev_parse_branch(&worktree_str)?;
+    let base_branch = gh_default_branch(&worktree_str).unwrap_or_else(|_| "main".to_string());
+
+    let pull_request = PullRequestRef {
+        repo: card.repo.clone(),
+        number: pr_number,
+        head: BranchName::new(head_branch)?,
+        base: BranchName::new(base_branch)?,
+    };
+    airc.link_card_pull_request(airc_lib::LinkCardPullRequest {
+        card_id,
+        pull_request,
+    })
+    .await?;
+
+    println!("pull_request: {pr_url}");
+
+    // Card ad7e100b Sub-C: with PR linked, spawn a sibling review
+    // card so any peer (other than the author) can claim it and
+    // review the diff. Best-effort and idempotent — a spawn failure
+    // here must not undo the state transition or the PR link, and
+    // re-running `state review` on a card whose review card already
+    // exists is a no-op.
+    if let Err(error) = crate::work_commands::auto_spawn_review_card(airc, card_id, pr_url).await {
+        eprintln!("airc: review card auto-spawn skipped — {error}");
+    }
+
+    Ok(())
+}
+/// Extract the PR number from a gh pr create URL line like
+/// `https://github.com/owner/repo/pull/123`. Returns None for any
+/// shape we don't recognise (so callers can degrade gracefully).
+pub(crate) fn extract_pr_number(url: &str) -> Option<u64> {
+    let trimmed = url.trim();
+    let tail = trimmed.rsplit('/').next()?;
+    tail.parse::<u64>().ok()
+}
+/// Card 28f1440c — the integration branch every per-card PR opens
+/// against. Hardcoded to the airc substrate's working branch for
+/// MVP; a follow-up surfaces this as configurable (e.g. via
+/// `.airc/work.toml`) for consumers whose integration branch is
+/// different.
+///
+/// MUST NOT change to a runtime read of `gh repo view --json defaultBranchRef` —
+/// that returns the repo's GitHub `default_branch` (`main` on this
+/// repo today), and every PR landing on `main` bypasses
+/// `rust-rewrite`'s substrate work. The whole point of this card
+/// is to refuse that fallback.
+pub(crate) fn pr_create_base_branch() -> &'static str {
+    "rust-rewrite"
+}
+
+#[allow(dead_code)]
+pub(crate) fn gh_default_branch(worktree: &str) -> Result<String, Box<dyn std::error::Error>> {
+    // Card a4fe899f: `gh` does NOT accept `-C`; set cwd via
+    // `Command::current_dir(...)` so `gh repo view` resolves the
+    // worktree's origin remote, not the shell cwd's.
+    let out = std::process::Command::new("gh")
+        .current_dir(worktree)
+        .args([
+            "repo",
+            "view",
+            "--json",
+            "defaultBranchRef",
+            "--jq",
+            ".defaultBranchRef.name",
+        ])
+        .output()?;
+    if !out.status.success() {
+        return Err(format!(
+            "gh repo view failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )
+        .into());
+    }
+    Ok(String::from_utf8(out.stdout)?.trim().to_string())
+}


### PR DESCRIPTION
- fix(codex): poll inbox after sending airc messages (#556)
- feat(knock): public collaboration knock entrypoint (airc#559 PR-1) (#560)
- feat(approve): forward-secret room-invite handoff (airc#559 PR-2) (#561)
- feat(queue): add issue-backed queue add/list
- feat(queue): claim/release/set-status verbs (airc#562 PR-2) (#568)
- feat(queue): nudge verb — surface card to peers (airc#562 PR-3) (#573)
- fix(#571): route every gh body write through --body-file (lib_gh.sh) (#574)
- feat(queue): repo-scoped nudge status sweep (#578)
- fix(gh): safely close issues with markdown comments (#582)
- feat(queue): adopt existing issues into queue cards (#583)
- feat(lane): add worktree lanes for agents (#585)
- feat(queue): summarize repo nudge pongs (#586)
- feat(#576): auto-close queue cards when PRs merge into canary (#581)
- fix(#576): detect queue refs in PR titles (#587)
- feat(#572): queue heartbeat and stale scan (#588)
- feat(#570): embeddable queue and room widgets (#589)
- feat(#591): summarize queue availability (#592)
- fix(#593): ignore repo-nudge templates in pongs (#594)
- fix(#596): honor per-agent queue owner (#597)
- fix: add session work identity for queue ownership (#598)
- fix(queue): close already-merged queue cards (#599)
- fix(queue): require closing keywords for close-merged
- fix(queue): preserve issue titles
- feat(queue): recommend next work for idle agents
- feat(queue): allow cross-repo close-merged
- feat(queue): add metronome idle pulse
- fix(queue): prevent accidental claim takeovers
- docs(readme): document AI work queue workflow (#614)
- feat(queue): warn on stale PR branches (#617)
- refactor(queue): split command helpers (#618)
- fix(queue): default planning view and unclaimed-owner semantics (#620)
- Fix collaboration health for same-nick peers (#625)
- fix(lane): hydrate submodules after worktree add (continuum#1252) (#624)
- feat(queue): personalized dispatch verb (closes continuum#1192 broadcast→idle gap) (#623)
- fix(queue): dispatch metronome hand-outs (#627)
- feat: add hygiene policy command (#632)
- fix: fail closed on update conflicts (#633)
- docs: design rust sqlite substrate (#634)
- docs: design realtime event bus (#635)
- feat(queue): add steward dry-run digest (#636)
- feat(core): add Rust transcript primitives (#637)
- feat(logs): add json transcript pages (#638)
- fix(logs): avoid strict-mode crash without json flag (#639)
- refactor(logs): use one render path for human and json modes (#640)
- feat(queue): metronome fan-out across active roster (airc#607, continuum#1192) (#641)
- docs: propose manager-role + lane substrate for airc (#642)
- docs: add lane-kanban-protocol — engineering spec for the lane substrate (#643)
- feat(heartbeat): peer-liveness envelope kind + cmd_peers tracking (airc#644 PR-1) (#645)
- hotfix: cmd_peers Python comment backtick broke airc peers in production (#645 follow-up) (#646)
- feat(heartbeat): wire emission — cmd_send --heartbeat + reminder_timer_loop hook + monitor filter (airc#644 PR-2) (#647)
- fix(heartbeat): allow empty body when --heartbeat (caught live; airc#644 PR-2 follow-up) (#648)
- fix(heartbeat): second empty-body rejection path also needed exemption (airc#644 PR-2 follow-up #2) (#649)
- fix(airc): surface sender client_id on pm-tag so multi-tab agents are distinguishable (#650)
- docs(architecture): airc-rust substrate design — generic messaging/event/network layer (DRAFT) (#651)
- feat(airc-blobs): Phase 1 scaffold — ContentAddressedStore trait + ContentHash + MediaRef (#653)
- feat(airc-blobs): FsStore — filesystem-backed sha256-addressed content store (#655)
- docs(airc-rust): Contract Layer: forge-alloy (substrate vs contract boundary) (#657)
- feat(airc-core): Identity struct + modular split (one concern per file) (#654)
- feat(airc-core): Body enum (Json | Binary) — opaque payload primitive (#656)
- feat(airc-blobs): GC + retention policy — age-based + capacity-based (#660)
- feat(airc-core): convert ID newtypes from String to UUIDv4
- feat(airc-core): envelope Headers dictionary + HeaderFilter predicate
- feat(airc-protocol): wire-level envelope, Frame, signature, subscription, LiftPolicy
- feat(airc-transport): Transport trait + LocalFsAdapter (same-Mac wire)
- fix(airc-transport): tail_loop recovers from frames.jsonl truncation/recreation
- feat(airc-protocol): real Ed25519 signing + verify (closes PR-1 stub)
- feat(airc-transport): TLS peer-pinning infrastructure (cert gen + verifiers)
- feat(airc-transport): LanTcpAdapter — TLS-wrapped TCP with peer-pinned mTLS
- feat(airc-transport): SignedTransport<T> — per-frame Ed25519 sign + verify wrapper
- feat(airc-cli): airc-rs binary — first Rust replacement for Python airc
- test(airc-cli): e2e — two airc-rs subprocesses chat over the substrate
- feat(airc-cli): daemon mode — Unix socket IPC + typed Request/Response
- fix(airc-transport): LAN-TCP readiness race + subscribers-lock-during-await
- feat(airc-cli): daemon Subscribe + Inbox — buffered consume-once reads (#678)
- style(airc-blobs): apply current rustfmt rules (#677)
- feat(airc-transport): multi-peer LanTcpAdapter (#679)
- refactor(airc-transport): split lan_tcp::adapter into module (one concern per file) (#680)
- feat(airc-cli): persisted identity state — stable peer_id + client_id (#681)
- feat(airc-cli): persistent peer registry — peers.json + daemon AddPeer/ListPeers (#682)
- feat(airc-cli): cross-platform daemon — Unix sockets + Windows named pipes (#683)
- ci: rust quality gates — fmt + clippy (deny warnings) + test on every Rust PR (#661)
- docs(airc-rust): replace body_hint with HTTP-style Headers dictionary (reopen of #658) (#662)
- docs(airc-rust): UUIDv4 for every identifier + three-field identity model (reopen of #659) (#663)
- feat(airc-cli): per-user room state — drop --wire/--channel parameter hell (#684)
- fix(airc-cli): Windows pipe-name uniqueness — UUIDv5 over full path (#685)
- fix(codex-hooks): rename TOML key codex_hooks → hooks + auto-migrate (#686)
- fix(airc-transport): LAN-TCP send pre-validates payload, no silent drops (#687)
- feat(airc-store): SeaORM-backed event store crate (slice 4 foundation) (#688)
- refactor: split daemon runtime into airc-daemon crate (slice 5 relocation) (#689)
- feat(airc-daemon): wire airc-store as the inbox backing (slice 5b) (#690)
- feat(airc-lib): consumer-facing facade crate (slice 6) (#691)
- feat(airc-lib): live subscriptions + auto-populate store on say (slice 6b) (#692)
- refactor(airc-cli): commands route through airc_lib::Airc (slice 6c) (#693)
- docs(operating-board): work-coordination domain plan (Codex design) (#694)
- feat(airc-work): typed work coordination domain (#695)
- feat(airc-work): add routable event codec (#696)
- feat(airc-work): replay work events from transcripts (#697)
- feat(airc-work-store): project persisted work events (#698)
- feat(airc-lib): expose work coordination API (#699)
- feat(airc-cli): add work coordination commands (#700)
- feat(airc-cli): add lane coordination commands (#701)
- feat(airc-cli): add workspace lease commands (#702)
- feat(airc-cli): add manager hat commands (#703)
- feat(airc-lib): add filtered event subscriptions (#704)
- feat(airc-cli): add Rust Codex hook context (#705)
- feat(airc-cli): install Codex hooks from Rust (#706)
- feat(codex): route hooks through Rust CLI (#707)
- feat(install): build and install airc-rs (#708)
- refactor(codex): remove Python hook adapters (#709)
- ci: add runtime guard checks for rust-rewrite (#710)
- refactor(codex): move detached start into Rust (#711)
- feat(airc-rs): move client identity mnemonics to rust (#712)
- feat(airc-rs): move iso timestamp parsing to rust (#713)
- feat(airc-rs): move log append and rotate to rust (#714)
- feat(airc-rs): move bearer state reads to rust (#715)
- feat(airc-rs): move logs render to rust (#716)
- feat(airc-rs): move gist JSON parsing to rust (#717)
- feat(airc-transport): add gh gist bootstrap adapter (#718)
- feat(airc-lib): add explicit transport route policy (#719)
- feat(airc-lib): add transport resolver shell (#720)
- feat(airc-lib): feed resolver from transport health (#721)
- feat(airc-rs): expose transport route status (#722)
- feat(airc-rs): move transport health to rust (#723)
- feat(airc-rs): read subscribed channels from rust (#724)
- feat(airc-rs): move channel gist config reads to rust (#725)
- feat(airc-rs): move channel config writes to rust (#726)
- feat(airc-rs): move generic config state to rust (#727)
- feat(airc-rs): move host config block to rust (#728)
- feat(airc-rs): derive daemon scope ids in rust (#729)
- feat(airc-rs): parse doctor rate-limit json in rust (#730)
- feat(airc-rs): render whois identity output in rust (#731)
- feat(airc-cli): move message crypto helpers to Rust (#732)
- feat(airc-cli): move control-plane helpers to Rust (#733)
- feat(airc-cli): build legacy message JSON in Rust (#734)
- feat(airc-cli): move channel gist discovery to Rust (#735)
- feat(airc-cli): move channel gist resolve to Rust (#736)
- feat(airc-cli): move bearer send to Rust (#737)
- refactor(airc-cli): split bearer send modules (#738)
- feat(airc-cli): move bearer recv to Rust (#739)
- feat(airc-cli): move monitor formatter to Rust (#740)
- feat(airc-cli): move local attach tail to Rust (#741)
- feat(airc-cli): move pair handshake to Rust (#742)
- feat(airc-cli): move scope repair to Rust (#743)
- feat(airc-cli): move collaboration health to Rust (#744)
- feat(airc-cli): move inbox cursoring to Rust (#745)
- feat(airc-cli): move hygiene policy to Rust (#746)
- feat(airc-cli): move knock approval crypto to Rust (#747)
- feat(airc-cli): move knock identity JSON to Rust (#748)
- feat(airc-cli): move kick peer ssh lookup to Rust (#749)
- feat(airc-cli): move worktree lane registry to Rust (#750)
- feat(airc-cli): move local identity state to Rust (#751)
- feat(airc-cli): move runtime JSON helpers to Rust (#752)
- feat(airc-cli): move queue card core to Rust (#753)
- feat(airc-cli): move queue projections to Rust (#754)
- feat(airc-cli): move queue runtime summaries to Rust (#755)
- feat(airc-cli): move queue staleness metadata to Rust (#756)
- feat(airc-cli): move queue staleness analyzer to Rust (#757)
- feat(airc-cli): move queue close-merged parsing to Rust (#758)
- feat(queue): move plan and steward projections to rust (#759)
- feat(collaboration): move peers listing to rust (#760)
- fix(invite): read channel gist through rust config (#761)
- feat(identity): move rename collision scan to rust (#762)
- feat(network): move LAN IP probe to rust (#763)
- feat(runtime): drop wrapper python startup (#764)
- feat(install): remove python runtime bootstrap (#765)
- chore(runtime): remove python debug path (#766)
- test(integration): drop legacy python unit gate (#767)
- test(integration): probe bearer kinds through rust (#768)
- test(integration): scaffold ed25519 identity through rust (#769)
- test(integration): edit top-level config through rust (#770)
- feat(config): probe quit fixtures through rust (#771)
- test(integration): probe away status through rust (#772)
- test(integration): probe tabs state through rust (#773)
- test(integration): probe heartbeat gist through rust (#774)
- fix(heartbeat): patch takeover gist lease deterministically (#775)
- test(integration): probe status outage through rust (#776)
- test(integration): probe bearer config through rust (#777)
- test(integration): probe sidecar channels through rust (#778)
- test(integration): probe channel gists through rust (#779)
- test(integration): probe bearer outcome through rust (#780)
- feat(gist): extract named file content through rust (#781)
- test(integration): probe JSON predicates through rust (#782)
- test(integration): route bearer and channel gist through rust (#783)
- test(integration): probe liveness events through rust (#784)
- fix(handshake): accept hyphen-leading public key values (#785)
- test(integration): delete legacy python bearer scenarios (#786)
- test(integration): route gh bearer scenario through rust (#787)
- test(integration): fake gone gist sends through airc-rs (#788)
- test(integration): generate gist rotation seed without python (#789)
- test(integration): remove python from platform adapters scenario (#790)
- install: stop documenting python runtime setup (#791)
- runtime: remove live airc_core references (#792)
- runtime: delete python airc_core layer (#793)
- fix(status): host health ignores joiner bearer pidfiles (#794)
- docs(architecture): transport control plane admission (#795)
- fix: fail closed on production fallback paths (#796)
- docs: define robustness integration plan (#797)
- refactor: remove fallback runtime surfaces (#798)
- ci: enforce Rust quality contracts (#799)
- fix(doctor): keep local health independent of GitHub (#800)
- docs: define invite-only gist routing architecture (#801)
- feat(routes): enforce invite-only gist admission (#802)
- feat(lib): gate sends through route resolver (#803)
- feat(lib): execute SDK sends over LAN routes (#804)
- refactor(cli): route LAN commands through airc-lib (#805)
- feat(lib): organize route discovery and health (#806)
- docs: update route requirements status (#807)
- docs: group route work into PR slices (#808)
- feat(lib): discover local route health (#809)
- feat(route): make gist an invite beacon (#810)
- feat(lib): attach SDK to daemon IPC (#811)
- refactor(cli): route daemon msg and inbox through SDK (#812)
- fix(cli): accept legacy message build command (#814)
- feat(airc-work): drain typing — workspace pressure/drain events + projection (Slice 7 PR 3a) (#813)
- feat(shell): route plain msg through rust local substrate (#815)
- feat(shell): read rust local inbox by default (#817)
- feat(airc-relay): baseline relay server + transport adapter (PR-E) (#816)
- feat(airc-transport): add realtime UDP adapter (#818)
- feat(trust-rotation): signed peer trust rotation contract + daemon application (PR-H) (#819)
- feat(airc-transport): add WebRTC datachannel adapter (#820)
- test(examples): prove SDK consumer embedding path (#821)
- test(examples): prove agent dogfood consumer path (#822)
- feat(examples): consumer integration shape contracts — Continuum/OpenClaw/Hermes (PR-I3) (#823)
- test(cli): prove installed agent identities dogfood live room (#824)
- fix(status): surface rust local data plane before gh bearer (#825)
- fix(codex-hook): pin rust hook executable and honor cursor overrides (#826)
- docs(readme): rework for the post-rewrite substrate (#827)
- fix(workspace): keep lane roots under airc home (#828)
- fix(monitor): attach to Rust event stream (#830)
- fix(teardown): verify live process reaping (#832)
- fix(install): remove rust suffix from airc surface (#833)
- fix(install): use ~/.airc/src as the source root (#835)
- feat(work): drain policy evaluator — pure substrate primitive (#834)
- fix(install): use source command as POSIX entrypoint (#836)
- fix(shell): resolve airc-core from source install (#837)
- fix(status): treat rust-local as routine health (#838)
- fix(install): PATH-augment is newline-safe + strips stale airc lines
- fix(install): rc reconcile no longer short-circuits on in-shell PATH
- fix(codex-hook): install source command path (#839)
- fix(msg): distinguish local store from peer delivery (#840)
- feat(lib): SubscriptionSet + ChannelName + identity-namespaced RoomId (#841)
- fix(events): monitor hooks use subscribed channels (#842)
- feat(lib): mesh identity resolution — replace MeshIdentity::unset() (#843)
- fix(lib): share same-machine account local wire (#844)
- feat(lib): add account room coordinator (#845)
- fix(join): seed rust account rooms from wrapper (#846)
- fix(install): put airc shim on POSIX PATH (#847)
- test(install): gate public airc shim path (#848)
- docs(install): define AI agent install contract (#849)
- test(install): prove public airc account-room runtime (#851)
- feat(lib): machine-global account coordinator (Gap 8) (#850)
- feat(lib): wire account join discovery into local delivery (#852)
- test(install): prove public monitor and hook delivery (#853)
- feat(lib): add account registry bootstrap contract (#854)
- fix(cli): route local join and broadcast through Rust (#855)
- fix(status): show rust command mode after stale startup (#856)
- fix(lib): cross-process chat actually delivers — live_tx fans out on DuplicateEventId (#857)
- fix(status): count Rust-substrate peers, not just legacy peers/ dir (#858)
- fix(send/msg): receipt no longer lies about non-delivery on shared-home wire (#859)
- feat(join): explicit scope + mesh-kind in output (#860)
- fix(join): label canonical HOME scope as machine-account home (#861)
- feat(lib): cross-machine bootstrap via gh-gist account-mesh registry (#862)
- fix(airc): restore project scope and runtime hook identity (#863)
- feat: demolition — bash wrapper deleted, airc IS the Rust binary (#864)
- fix(ci): runtime-guards green post-demolition (#865)
- fix(registry): no --paginate; bound sync with timeout; tests disable (#867)
- fix(mesh-identity): Operator-source cache never expires; bound shell-outs (#868)
- fix(airc): make join own daemon live delivery (#866)
- fix(codex-hook): trust airc.client header on shared-HOME identity (#869)
- feat(cli): restore airc join --attach and airc version subcommand (#870)
- fix(join): ensure Codex hook setup (#871)
- docs(skill): tab-loop semantics for bidirectional agent coordination (#872)
- fix(install): prefer current source tree (#873)
- fix(cli): airc join always streams ALL subscribed rooms; remove --attach (#876)
- test(join): pin runtime attach decision (#877)
- fix(join): detect Codex runtime via client identity (#878)
- docs(architecture): establish grid substrate audit (#879)
- fix(join): persist live feed cursor (#880)
- fix(store): persist runtime cursors through SeaORM (#882)
- docs(architecture): Phase 3.5 ORM end-to-end + Phase 3.6 perf hotpaths (#881)
- fix(store): persist peer trust through ORM (#883)
- fix(store): persist subscriptions through ORM (#884)
- fix(store): persist local identity metadata through ORM (#885)
- fix(store): persist mesh identity through ORM (#886)
- fix(store): persist account registry through ORM (#887)
- fix(store): persist coordinator beacons through ORM (#888)
- cleanup(lib): remove file-backed coordinator beacons (#889)
- cleanup(cli): remove config.json command shim (#890)
- refactor(identity): store-backed identity commands (#891)
- refactor(cli): remove config repair scope command (#892)
- refactor(transport): report substrate route health (#893)
- refactor(cli): remove bearer state command (#894)
- refactor(cli): remove recent senders command (#895)
- refactor(cli): remove legacy log scraping surface (#896)
- refactor(collaboration): remove jsonl presence scans (#897)
- refactor(identity): remove jsonl rename collision helper (#898)
- refactor(cli): remove legacy bearer command (#899)
- refactor(cli): remove jsonl message builder (#900)
- fix(install): copy artifacts instead of symlinking (#901)
- fix(identity): migrate identity json into orm state (#902)
- fix(lib): report peers from account mesh registry (#903)
- fix(cli): agent-runtime attach decision wins over piped-stdout (#904)
- fix(lib): wire replay skips unverifiable frames instead of aborting (#905)
- docs(codex): clarify live feed contract (#906)
- refactor(cli): isolate runtime context classification (#908)
- docs: AR/Cambrian/grid framing + data-model + Phase 3.5 migration (#907)
- refactor(cli): move codex integration behind boundary (#910)
- feat(cli): airc doctor — install + identity + scope self-diagnosis (#909)
- feat(lib): expose subscription query API (#911)
- feat(lib): command-bus primitive (Airc::request / reply / await_reply) (#912)
- docs: CI fidelity as substrate non-negotiable (#10) (#913)
- test(cli): emulate join attach in e2e harness (#915)
- feat(lib): typed lifecycle events (Phase 2) (#914)
- feat(work): add git and PR event contracts (#917)
- feat(lib): emit PeerArrived lifecycle event on add_peer (Phase 2 cont.) (#916)
- feat(work): add local git watcher adapter (#918)
- feat(lib): emit WireEstablished lifecycle event (Phase 2 cont.) (#919)
- docs: require roadmap reference in PR template (#920)
- ci: enforce PR roadmap references (#921)
- feat(lib): emit SubscriptionAdvanced on cursor saves (#922)
- feat(lib): emit RoomParted lifecycle events (#924)
- feat(lib): emit PeerDeparted lifecycle events (#925)
- ci: keep roadmap references as PR template guidance (#926)
- feat(airc-lib): WireLost emit on stream-end + teardown (#923)
- feat(codex): add pollable AIRC feed command (#927)
- test(install): prove Codex poll in public runtime (#928)
- fix(lib): keep routine wire replay quiet (#929)
- feat(cli): add Rust update command (#930)
- refactor(store): move coordinator refresh lock into ORM (#931)
- perf(lib): use set-backed event dedup (#932)
- perf(lib): broadcast live events by arc (#933)
- perf(protocol): remove global peer registry lock (#934)
- perf(lib): remove global route table locks (#935)
- perf(lib): own local ingest task lifecycle (#936)
- perf(lib): use set-backed subscription dedup (#937)
- perf(lib): shorten subscriber setup locks (#938)
- perf(lib): make event filter channels set-backed (#939)
- refactor(daemon): length-frame ipc with cbor (#940)
- fix(cli): restart daemon during update (#941)
- refactor(ipc): split daemon IPC contract into crate (#942)
- refactor(identity): split local identity into crate (#943)
- refactor(trust): split peer trust into crate (#944)
- test(command-bus): prove request reply over LAN (#945)
- feat(airc-lib): execute relay routes through SDK (#946)
- test(consumer-shapes): prove command bus integration (#948)
- feat(airc-work): PR observation adapter skeleton (#947)
- docs(audit): refresh immediate queue after PR adapter (#949)
- feat(airc-work): real gh PullRequestSource over GhCommandRunner (#950)
- docs(readme): restore generic agent IRC framing (#951)
- fix(ipc): version daemon endpoint by protocol (#952)
- fix(daemon): refresh wire trust for live ingest (#953)
- test(airc-lib): prove Continuum-shaped room throughput (#954)
- feat(airc-lib): wire UDP route execution + WebRTC signaling types (#955)
- feat(airc-lib): WebRTC DataChannel orchestration over AIRC mesh (#957)
- docs(webrtc): media tracks plan and implementation split (#959)
- feat(airc-lib): surface incoming WebRTC media tracks (#960)
- feat(airc-lib): add WebRTC media track builder (#961)
- test(airc-lib): prove WebRTC audio and video tracks (#962)
- test(airc-lib): prove WebRTC media and control share a session (#963)
- docs(audit): note observed AIRC coordination flaws (#964)
- fix(cli): restore IRC-shaped peers and whois commands (#966)
- docs(webrtc): show Continuum live-room integration example (#967)
- feat(work): heartbeat claims and surface stale owners (#969)
- feat(work): publish agent availability state (#971)
- feat(diagnostics): add typed substrate diagnostic sink (#973)
- feat(airc-lib): typed lane-coordination events (#965)
- feat(airc-lib): active-agent heartbeat events (#968)
- feat(airc-cli): bake build sha + drift detection in doctor (#972)
- feat(work): suggest claimable cards for agents (#975)
- feat(work): surface claimable queue suggestions in agent feeds (#976)
- feat(airc-lib): typed work-event subscription API (#974)
- feat(work): close completed cards (#977)
- fix(work): tolerate bounded board replay windows (#979)
- feat(airc-lib): AIRC-event diagnostic sink + doctor surface (#978)
- fix(work): preserve terminal state on claim release (#980)
- docs(audit): consumer integration gap audit + follow-up cards (#981)
- docs(audit): roadmap-to-card coverage + missing-card cleanup (#982)
- feat(work): surface agent availability in queue status (#983)
- test(lib): prove Continuum pose fan-out throughput (#984)
- feat(work): render typed agent roster (#986)
- fix(work): make duplicate claim release idempotent (#987)
- feat(airc-lib): external-identity bridge contract (#985)
- feat(work): enforce lease-zone for work claim + heartbeat diagnostic (#988)
- feat(route): add JSON route proof harness (#989)
- feat(publish): structured publish API + airc publish JSON-receipt CLI (#990)
- feat(events): add JSON list output (#991)
- docs: define cooperative coordination training signal (#992)
- fix(work): reject card transitions from wrong room (#993)
- fix(join): replace stale daemon builds from typed status (#994)
- fix(work): tolerate superseded claim release + ghost heartbeat (#996)
- feat(work): publish active-agent roster heartbeats from join (#997)
- fix(work): correlate peer claims to live roster clients (#998)
- feat(work): add typed manager loop evaluation (#999)
- docs(airc): add runtime planning and consumer audit lanes (#1000)
- docs(airc): define autonomous development roadmap (#1001)
- fix(work): find active cards beyond small recent windows (#1004)
- fix(work-store): tolerate orphaned events in complete projection (#1005)
- fix(work): schedule from complete work projection (#1006)
- feat(work): seed backlog from manager candidates (#1008)
- fix(work): make stale claims recoverable by default (#1009)
- feat(ipc): add ResolveWireRequest (channel uuid -> wire path lookup) (#1011)
- feat(inbox): --json flag for machine-readable output (#1010)
- fix(work): exclude terminal cards from stale recovery (#1012)
- fix(identity): resolve mesh identity against machine-global coordinator store (#1014)
- perf(bus): decoupled delivery bus — kill same-machine poll/fsync latency (#1015)
- fix(test): isolate two-machine bridge test via explicit wire roots — repairs Windows CI (#1016)
- docs(arch): airc event-server design — efficient ORM+push routing server (#1017)
- feat(airc-bus): owner-core event router — sharded router + hot ring + generational cursor + zero-copy fan-out (#1018)
- test(e2e): realistic timeout for process-spawn round-trips (fix macOS flake) (#1020)
- fix(reliability): LAN send-flush + lan-listen subscribe order + daemon-shutdown hang (#1021)
- feat(store): SQLite-backed DurableSink — owner-core ORM durable tier (§3.3) (#1019)
- feat(store): persistent EpochStore — generational epoch survives daemon restart (§3.8) (#1022)
- feat(wire): airc-wire — FlatBuffers binary codec for the envelope (zero-copy payload) (#1023)
- feat(work+lib+cli): autonomous-team substrate end-to-end (19 cards) (#1025)
- fix(cli): airc work state review uses Command::current_dir, not gh -C (card a4fe899f) (#1027)
- fix(cli): airc work state X merged refused — only PullRequestMerged event sets Merged (card a1bc62b3) (#1028)
- feat(store): add agent_name column to local_identity (card 8384cc18 Sub-A) (#1030)
- fix(identity): provisional git-email identity self-heals to gh login (one identity per machine) (#1024)
- fix(cli): default_home_dir skips machine-account ~/.airc + resolves to main working tree from a worktree (card a1b4552a) (#1029)
- fix(lib): work_board filters heartbeats out of the projection page (card 79953b4d) (#1031)
- fix(cli): airc work state Closed refuses unless from Merged or pre-work state (card 9656a836) (#1026)
- docs(agents): encode engineering-staff framing — CI-green-before-merge, branch hygiene, monitoring (card 53698eb9) (#1032)
- fix(install): recover from stale Rust toolchain instead of cryptic build abort (#1013)
- ef168afe/airc ci re green rust rewrite accumulate (#1033)
- fix(cli): gh pr create reads commit subject as title — not branch slug (card 13131f1c) (#1034)
- refactor(cli): extract GitHub PR ops into work_commands_gh.rs — c0bd865c split COMPLETE (phase 4 / c7bdf2df)
