### PR TITLE
feat(identity): select local agent by name

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -199,7 +199,12 @@ pub enum Command {
     /// plus ORM-backed metadata), then print this peer's spec for
     /// out-of-band sharing. Idempotent — repeat runs return the same
     /// peer_id.
-    Init,
+    Init {
+        /// Local agent identity name. Same effect as `AIRC_AGENT_NAME`,
+        /// but explicit CLI input takes precedence.
+        #[arg(long = "as", value_name = "AGENT_NAME")]
+        agent_name: Option<String>,
+    },
 
     /// Print the primary non-loopback LAN IPv4 address, if detectable.
     LanIp,

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -32,12 +32,19 @@ use airc_trust as peers_store;
 /// generates the identity, opens the event store, applies any
 /// pending migrations, and primes the peer registry. The CLI then
 /// prints the local peer's spec so the user can share it.
-pub async fn run_init(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let airc = Airc::open(home).await?;
+pub async fn run_init(
+    home: &Path,
+    agent_name: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = match agent_name {
+        Some(agent_name) => Airc::open_as(home, agent_name).await?,
+        None => Airc::open(home).await?,
+    };
     let current = airc.current_room().await?;
     println!("home:        {}", airc.home().display());
     println!("peer_id:     {}", airc.peer_id());
     println!("client_id:   {}", airc.client_id());
+    println!("agent_name:  {}", airc.agent_name());
     println!("room:        {} ({})", current.name, current.channel);
     println!("peer_spec:   {}", airc.peer_spec());
     println!();

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -191,7 +191,7 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let home = parsed.home.clone().unwrap_or_else(cli::default_home_dir);
 
     match parsed.command {
-        Command::Init => commands::run_init(&home).await,
+        Command::Init { agent_name } => commands::run_init(&home, agent_name).await,
 
         Command::LanIp => network_commands::run_lan_ip(),
 

--- a/crates/airc-cli/tests/identity_commands.rs
+++ b/crates/airc-cli/tests/identity_commands.rs
@@ -58,6 +58,41 @@ fn identity_pretty_defaults_unset_fields() {
 }
 
 #[test]
+fn init_as_records_agent_name() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+
+    let init = run_ok(home, &["init", "--as", "codex"], "");
+    assert!(init.contains("agent_name:  codex\n"));
+
+    let repeat = run_ok(home, &["init", "--as", "codex"], "");
+    assert!(repeat.contains("agent_name:  codex\n"));
+}
+
+#[test]
+fn init_uses_airc_agent_name_env_when_as_is_absent() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path();
+
+    let output = Command::new(airc_core())
+        .arg("--home")
+        .arg(home)
+        .arg("init")
+        .env("AIRC_AGENT_NAME", "claude")
+        .output()
+        .expect("airc-core must spawn");
+
+    assert!(
+        output.status.success(),
+        "airc-core failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("agent_name:  claude\n"));
+}
+
+#[test]
 fn identity_set_link_and_show_round_trip_through_store() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path();

--- a/crates/airc-identity/src/lib.rs
+++ b/crates/airc-identity/src/lib.rs
@@ -35,9 +35,13 @@ use airc_protocol::PeerKeypair;
 use airc_store::{SqliteEventStore, StoreError, StoredLocalIdentity};
 use serde::Deserialize;
 
-/// On-disk schema version for the singleton row. Bump when the
+/// On-disk schema version for local identity rows. Bump when the
 /// stored shape changes incompatibly.
 const IDENTITY_STATE_VERSION: u32 = 1;
+
+/// Environment override for selecting the local agent identity row.
+/// Card 8384cc18 Sub-D pairs this with `airc init --as <name>`.
+pub const AIRC_AGENT_NAME_ENV: &str = "AIRC_AGENT_NAME";
 
 const IDENTITY_KEY_FILENAME: &str = "identity.key";
 const LEGACY_IDENTITY_JSON_FILENAME: &str = "identity.json";
@@ -49,6 +53,7 @@ pub struct LocalIdentity {
     pub keypair: PeerKeypair,
     pub peer_id: PeerId,
     pub client_id: ClientId,
+    pub agent_name: String,
 }
 
 #[derive(Debug)]
@@ -61,7 +66,7 @@ pub enum IdentityError {
         found: u32,
         expected: u32,
     },
-    /// `identity.key` exists but the paired singleton row is missing
+    /// `identity.key` exists but the paired local-identity row is missing
     /// (or vice versa). The pair is required to disambiguate
     /// identity — refusing rather than regenerating prevents silent
     /// peer-id rotation.
@@ -77,6 +82,16 @@ pub enum IdentityError {
     /// System clock is before UNIX_EPOCH; refuse to write a corrupt
     /// timestamp into the identity audit record.
     Clock(std::time::SystemTimeError),
+    /// Requested local agent names are persisted as stable keys, so
+    /// they must be explicit and printable.
+    InvalidAgentName(String),
+    /// A caller requested one local agent, but the only row available
+    /// through the current store API describes another. Sub-C replaces
+    /// the singleton read with lookup-by-agent-name.
+    AgentNameMismatch {
+        requested: String,
+        found: String,
+    },
 }
 
 impl std::fmt::Display for IdentityError {
@@ -111,6 +126,14 @@ impl std::fmt::Display for IdentityError {
                 )
             }
             IdentityError::Clock(error) => write!(f, "identity timestamp clock error: {error}"),
+            IdentityError::InvalidAgentName(value) => write!(
+                f,
+                "invalid agent name {value:?}; use a non-empty printable name"
+            ),
+            IdentityError::AgentNameMismatch { requested, found } => write!(
+                f,
+                "requested local agent {requested:?}, but stored local_identity row is {found:?}"
+            ),
         }
     }
 }
@@ -124,7 +147,9 @@ impl std::error::Error for IdentityError {
             IdentityError::Clock(error) => Some(error),
             IdentityError::SchemaVersionMismatch { .. }
             | IdentityError::PartialState { .. }
-            | IdentityError::BadKeyLength(_) => None,
+            | IdentityError::BadKeyLength(_)
+            | IdentityError::InvalidAgentName(_)
+            | IdentityError::AgentNameMismatch { .. } => None,
         }
     }
 }
@@ -159,20 +184,39 @@ impl LocalIdentity {
     /// one (writing both halves) if neither exists. Refuses to
     /// recover from a half-initialised state.
     pub async fn load_or_generate(home: &Path) -> Result<Self, IdentityError> {
+        let agent_name = requested_agent_name(None)?;
+        Self::load_or_generate_as(home, agent_name).await
+    }
+
+    /// Load or generate the local identity for an explicit agent name.
+    /// This is the programmatic partner of `airc init --as <name>`.
+    pub async fn load_or_generate_as(
+        home: &Path,
+        agent_name: impl AsRef<str>,
+    ) -> Result<Self, IdentityError> {
+        let agent_name = normalise_agent_name(agent_name.as_ref())?;
         let store = open_store(home).await?;
         let key_path = Self::key_path(home);
         let key_exists = key_path.exists();
-        let stored = store.load_local_identity().await?;
+        let stored = store.load_local_identity_by_agent_name(&agent_name).await?;
         match (key_exists, stored) {
-            (true, Some(stored)) => Self::load_with_metadata(home, stored),
+            (true, Some(stored)) => Self::load_with_metadata_for_agent(home, stored, &agent_name),
             (true, None) => match migrate_legacy_identity_json(home, &store).await? {
-                Some(stored) => Self::load_with_metadata(home, stored),
+                Some(stored) if stored.agent_name == agent_name => {
+                    Self::load_with_metadata(home, stored)
+                }
+                Some(_) => {
+                    Self::generate_and_save_agent_with_existing_key(home, &store, &agent_name).await
+                }
+                None if store.has_local_identity_rows().await? => {
+                    Self::generate_and_save_agent_with_existing_key(home, &store, &agent_name).await
+                }
                 None => Err(IdentityError::PartialState {
                     key_exists: true,
                     state_exists: false,
                 }),
             },
-            (false, None) => Self::generate_and_save(home, &store).await,
+            (false, None) => Self::generate_and_save_as(home, &store, &agent_name).await,
             (key, state) => Err(IdentityError::PartialState {
                 key_exists: key,
                 state_exists: state.is_some(),
@@ -184,14 +228,29 @@ impl LocalIdentity {
     /// for the cases that already know they have a populated
     /// install and want to fail loudly if either half is missing.
     pub async fn load(home: &Path) -> Result<Self, IdentityError> {
+        let agent_name = requested_agent_name(None)?;
         let store = open_store(home).await?;
         let stored = store
-            .load_local_identity()
+            .load_local_identity_by_agent_name(&agent_name)
             .await?
             .ok_or(IdentityError::PartialState {
                 key_exists: Self::key_path(home).exists(),
                 state_exists: false,
             })?;
+        Self::load_with_metadata(home, stored)
+    }
+
+    fn load_with_metadata_for_agent(
+        home: &Path,
+        stored: StoredLocalIdentity,
+        requested_agent_name: &str,
+    ) -> Result<Self, IdentityError> {
+        if stored.agent_name != requested_agent_name {
+            return Err(IdentityError::AgentNameMismatch {
+                requested: requested_agent_name.to_string(),
+                found: stored.agent_name,
+            });
+        }
         Self::load_with_metadata(home, stored)
     }
 
@@ -213,17 +272,63 @@ impl LocalIdentity {
             keypair,
             peer_id: stored.peer_id,
             client_id: stored.client_id,
+            agent_name: stored.agent_name,
+        })
+    }
+
+    async fn generate_and_save_agent_with_existing_key(
+        home: &Path,
+        store: &SqliteEventStore,
+        agent_name: &str,
+    ) -> Result<Self, IdentityError> {
+        let key_bytes = std::fs::read(Self::key_path(home))?;
+        if key_bytes.len() != 32 {
+            return Err(IdentityError::BadKeyLength(key_bytes.len()));
+        }
+        let mut secret = [0u8; 32];
+        secret.copy_from_slice(&key_bytes);
+        let keypair = PeerKeypair::from_secret_bytes(&secret);
+        let peer_id = PeerId::new();
+        let client_id = ClientId::new();
+        let created_at_ms = now_ms()?;
+
+        store
+            .insert_local_identity(StoredLocalIdentity {
+                peer_id,
+                client_id,
+                version: IDENTITY_STATE_VERSION,
+                created_at_ms,
+                identity: Identity::default(),
+                agent_name: agent_name.to_string(),
+            })
+            .await?;
+
+        Ok(Self {
+            keypair,
+            peer_id,
+            client_id,
+            agent_name: agent_name.to_string(),
         })
     }
 
     /// Generate a fresh identity + persist it. Writes the secret
-    /// key file (0600) and inserts the singleton row in one logical
-    /// step; if the row insert fails after the key was written, the
-    /// caller can clean up by removing `identity.key` and retrying.
+    /// key file (0600) and inserts the default-agent row in one
+    /// logical step; if the row insert fails after the key was
+    /// written, the caller can clean up by removing `identity.key`
+    /// and retrying.
     pub async fn generate_and_save(
         home: &Path,
         store: &SqliteEventStore,
     ) -> Result<Self, IdentityError> {
+        Self::generate_and_save_as(home, store, airc_store::DEFAULT_AGENT_NAME).await
+    }
+
+    pub async fn generate_and_save_as(
+        home: &Path,
+        store: &SqliteEventStore,
+        agent_name: impl AsRef<str>,
+    ) -> Result<Self, IdentityError> {
+        let agent_name = normalise_agent_name(agent_name.as_ref())?;
         ensure_home_dir(home)?;
         let keypair = PeerKeypair::generate();
         let peer_id = PeerId::new();
@@ -239,7 +344,7 @@ impl LocalIdentity {
                 version: IDENTITY_STATE_VERSION,
                 created_at_ms,
                 identity: Identity::default(),
-                agent_name: airc_store::DEFAULT_AGENT_NAME.to_string(),
+                agent_name: agent_name.clone(),
             })
             .await?;
 
@@ -247,6 +352,7 @@ impl LocalIdentity {
             keypair,
             peer_id,
             client_id,
+            agent_name,
         })
     }
 }
@@ -286,6 +392,24 @@ async fn migrate_legacy_identity_json(
     store.insert_local_identity(stored.clone()).await?;
     let _ = std::fs::remove_file(path);
     Ok(Some(stored))
+}
+
+fn requested_agent_name(explicit: Option<&str>) -> Result<String, IdentityError> {
+    if let Some(value) = explicit {
+        return normalise_agent_name(value);
+    }
+    match std::env::var_os(AIRC_AGENT_NAME_ENV) {
+        Some(value) => normalise_agent_name(&value.to_string_lossy()),
+        None => Ok(airc_store::DEFAULT_AGENT_NAME.to_string()),
+    }
+}
+
+fn normalise_agent_name(value: &str) -> Result<String, IdentityError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.chars().any(char::is_control) {
+        return Err(IdentityError::InvalidAgentName(value.to_string()));
+    }
+    Ok(trimmed.to_string())
 }
 
 async fn open_store(home: &Path) -> Result<SqliteEventStore, IdentityError> {
@@ -356,6 +480,76 @@ mod tests {
         assert_eq!(first.keypair.secret_bytes(), second.keypair.secret_bytes());
         assert_eq!(first.peer_id, second.peer_id);
         assert_eq!(first.client_id, second.client_id);
+        assert_eq!(first.agent_name, airc_store::DEFAULT_AGENT_NAME);
+    }
+
+    #[tokio::test]
+    async fn load_or_generate_as_records_agent_name() {
+        let home = TempDir::new().unwrap();
+        let identity = LocalIdentity::load_or_generate_as(home.path(), "codex")
+            .await
+            .unwrap();
+
+        assert_eq!(identity.agent_name, "codex");
+        let store = open_store(home.path()).await.unwrap();
+        let stored = store
+            .load_local_identity_by_agent_name("codex")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.agent_name, "codex");
+        assert!(store.load_local_identity().await.unwrap().is_none());
+
+        let second = LocalIdentity::load_or_generate_as(home.path(), "codex")
+            .await
+            .unwrap();
+        assert_eq!(second.peer_id, identity.peer_id);
+        assert_eq!(second.agent_name, "codex");
+
+        let default = LocalIdentity::load_or_generate(home.path()).await.unwrap();
+        assert_eq!(default.agent_name, airc_store::DEFAULT_AGENT_NAME);
+        assert_ne!(default.peer_id, identity.peer_id);
+        assert_eq!(
+            default.keypair.secret_bytes(),
+            identity.keypair.secret_bytes()
+        );
+    }
+
+    #[tokio::test]
+    async fn load_or_generate_as_adds_named_agent_to_existing_scope() {
+        let home = TempDir::new().unwrap();
+        let default = LocalIdentity::load_or_generate(home.path()).await.unwrap();
+        let codex = LocalIdentity::load_or_generate_as(home.path(), "codex")
+            .await
+            .unwrap();
+
+        assert_eq!(codex.agent_name, "codex");
+        assert_ne!(default.peer_id, codex.peer_id);
+        assert_ne!(default.client_id, codex.client_id);
+        assert_eq!(default.keypair.secret_bytes(), codex.keypair.secret_bytes());
+
+        let store = open_store(home.path()).await.unwrap();
+        let default_row = store.load_local_identity().await.unwrap().unwrap();
+        let codex_row = store
+            .load_local_identity_by_agent_name("codex")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(default_row.peer_id, default.peer_id);
+        assert_eq!(codex_row.peer_id, codex.peer_id);
+    }
+
+    #[test]
+    fn agent_name_is_trimmed_and_must_be_printable() {
+        assert_eq!(normalise_agent_name("  codex  ").unwrap(), "codex");
+        assert!(matches!(
+            normalise_agent_name(" \n "),
+            Err(IdentityError::InvalidAgentName(_))
+        ));
+        assert!(matches!(
+            normalise_agent_name("codex\nmain"),
+            Err(IdentityError::InvalidAgentName(_))
+        ));
     }
 
     #[tokio::test]

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -189,6 +189,16 @@ impl Airc {
         Self::open_with_policy(home, VerificationPolicy::Strict).await
     }
 
+    /// Open the substrate for an explicit local agent name. This is
+    /// the embeddable API behind `airc init --as <name>`; callers that
+    /// do not pass a name can set `AIRC_AGENT_NAME` and use [`open`].
+    pub async fn open_as(
+        home: impl Into<PathBuf>,
+        agent_name: impl Into<String>,
+    ) -> Result<Self, AircError> {
+        Self::open_with_policy_as(home, VerificationPolicy::Strict, agent_name).await
+    }
+
     /// Attach to an already-running daemon. The handle still opens
     /// local identity/store state so consumers can inspect identity,
     /// room, and replay state through the same `Airc` facade, but
@@ -227,7 +237,20 @@ impl Airc {
         let home: PathBuf = home.into();
         std::fs::create_dir_all(&home).map_err(IdentityError::Io)?;
         let wire_root = machine_account_home(&home);
-        Self::open_inner(home, wire_root, policy).await
+        Self::open_inner(home, wire_root, policy, None).await
+    }
+
+    /// Variant of [`open_with_policy`] that pins the local agent name
+    /// explicitly instead of reading `AIRC_AGENT_NAME`.
+    pub async fn open_with_policy_as(
+        home: impl Into<PathBuf>,
+        policy: VerificationPolicy,
+        agent_name: impl Into<String>,
+    ) -> Result<Self, AircError> {
+        let home: PathBuf = home.into();
+        std::fs::create_dir_all(&home).map_err(IdentityError::Io)?;
+        let wire_root = machine_account_home(&home);
+        Self::open_inner(home, wire_root, policy, Some(agent_name.into())).await
     }
 
     /// Test-only: open with an explicit machine-account wire root rather
@@ -241,16 +264,26 @@ impl Airc {
         home: impl Into<PathBuf>,
         wire_root: impl Into<PathBuf>,
     ) -> Result<Self, AircError> {
-        Self::open_inner(home.into(), wire_root.into(), VerificationPolicy::Strict).await
+        Self::open_inner(
+            home.into(),
+            wire_root.into(),
+            VerificationPolicy::Strict,
+            None,
+        )
+        .await
     }
 
     async fn open_inner(
         home: PathBuf,
         wire_root: PathBuf,
         policy: VerificationPolicy,
+        agent_name: Option<String>,
     ) -> Result<Self, AircError> {
         std::fs::create_dir_all(&home).map_err(IdentityError::Io)?;
-        let identity = LocalIdentity::load_or_generate(&home).await?;
+        let identity = match agent_name {
+            Some(agent_name) => LocalIdentity::load_or_generate_as(&home, agent_name).await?,
+            None => LocalIdentity::load_or_generate(&home).await?,
+        };
         std::fs::create_dir_all(&wire_root).map_err(IdentityError::Io)?;
         peers_store::add(
             &wire_root,
@@ -343,6 +376,11 @@ impl Airc {
     /// Return the per-session client identifier.
     pub fn client_id(&self) -> ClientId {
         self.inner.identity.client_id
+    }
+
+    /// Local agent-name discriminator for this identity row.
+    pub fn agent_name(&self) -> &str {
+        &self.inner.identity.agent_name
     }
 
     /// Persist a new local-identity card and broadcast the update to

--- a/crates/airc-store/src/entities/local_identity.rs
+++ b/crates/airc-store/src/entities/local_identity.rs
@@ -15,7 +15,7 @@
 //! Sub-B table-recreated this schema to drop the former
 //! `CHECK (id = 1)` singleton constraint. Multiple rows are now
 //! legal at the schema layer; Sub-C surfaces the agent-name read API
-//! and Sub-D wires `AIRC_AGENT_ID` / `airc init --as <name>`.
+//! and Sub-D wires `AIRC_AGENT_NAME` / `airc init --as <name>`.
 //!
 //! [`SINGLETON_ID`] remains the documented primary-key value for the
 //! legacy/default agent row until the higher-level APIs stop using a

--- a/crates/airc-store/src/local_identity.rs
+++ b/crates/airc-store/src/local_identity.rs
@@ -1,10 +1,10 @@
-//! Backend-neutral DTO for the singleton local identity row.
+//! Backend-neutral DTO for a local identity row.
 
 use airc_core::{identity::Identity, ClientId, PeerId};
 
 pub use crate::entities::local_identity::DEFAULT_AGENT_NAME;
 
-/// Public DTO mirroring the singleton `local_identity` row.
+/// Public DTO mirroring a `local_identity` row.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoredLocalIdentity {
     pub peer_id: PeerId,
@@ -13,8 +13,8 @@ pub struct StoredLocalIdentity {
     pub created_at_ms: u64,
     pub identity: Identity,
     /// Discriminator for which agent this row describes (card
-    /// 8384cc18 Sub-A). Today every row carries the default name
-    /// [`DEFAULT_AGENT_NAME`]; Sub-D ships the CLI surface for
-    /// distinct names.
+    /// 8384cc18 Sub-A). Existing legacy rows carry
+    /// [`DEFAULT_AGENT_NAME`]; Sub-D's CLI surface creates distinct
+    /// names.
     pub agent_name: String,
 }

--- a/crates/airc-store/src/memory.rs
+++ b/crates/airc-store/src/memory.rs
@@ -18,7 +18,7 @@ use crate::store::EventStore;
 use crate::subscriptions::StoredSubscription;
 
 pub struct InMemoryEventStore {
-    local_identity: Mutex<Option<StoredLocalIdentity>>,
+    local_identities: Mutex<BTreeMap<String, StoredLocalIdentity>>,
     events: Mutex<Vec<TranscriptEvent>>,
     runtime_cursors: Mutex<BTreeMap<String, TranscriptCursor>>,
     subscriptions: Mutex<Vec<StoredSubscription>>,
@@ -30,7 +30,7 @@ pub struct InMemoryEventStore {
 impl InMemoryEventStore {
     pub fn new() -> Self {
         Self {
-            local_identity: Mutex::new(None),
+            local_identities: Mutex::new(BTreeMap::new()),
             events: Mutex::new(Vec::new()),
             runtime_cursors: Mutex::new(BTreeMap::new()),
             subscriptions: Mutex::new(Vec::new()),
@@ -58,28 +58,22 @@ impl EventStore for InMemoryEventStore {
         &self,
         agent_name: &str,
     ) -> Result<Option<StoredLocalIdentity>, StoreError> {
-        // The in-memory store still holds one identity; faithfully
-        // honour the trait contract by filtering on agent_name and
-        // returning None for a mismatch. Card 8384cc18 Sub-C.
-        let identity = self
-            .local_identity
+        let identities = self
+            .local_identities
             .lock()
             .map_err(|_| StoreError::LockPoisoned)?;
-        Ok(identity
-            .as_ref()
-            .filter(|i| i.agent_name == agent_name)
-            .cloned())
+        Ok(identities.get(agent_name).cloned())
     }
 
     async fn insert_local_identity(&self, identity: StoredLocalIdentity) -> Result<(), StoreError> {
         let mut stored = self
-            .local_identity
+            .local_identities
             .lock()
             .map_err(|_| StoreError::LockPoisoned)?;
-        if stored.is_some() {
+        if stored.contains_key(&identity.agent_name) {
             return Err(StoreError::Database(sea_orm::DbErr::RecordNotInserted));
         }
-        *stored = Some(identity);
+        stored.insert(identity.agent_name.clone(), identity);
         Ok(())
     }
 
@@ -88,10 +82,10 @@ impl EventStore for InMemoryEventStore {
         identity: airc_core::identity::Identity,
     ) -> Result<(), StoreError> {
         let mut stored = self
-            .local_identity
+            .local_identities
             .lock()
             .map_err(|_| StoreError::LockPoisoned)?;
-        let Some(row) = stored.as_mut() else {
+        let Some(row) = stored.get_mut(crate::DEFAULT_AGENT_NAME) else {
             return Err(StoreError::NotFound("local_identity"));
         };
         row.identity = identity;

--- a/crates/airc-store/src/migration/m20260528_000013_add_local_identity_agent_name.rs
+++ b/crates/airc-store/src/migration/m20260528_000013_add_local_identity_agent_name.rs
@@ -16,7 +16,7 @@
 //!
 //! After Sub-B drops the CHECK, multiple rows become possible and
 //! `agent_name` becomes the natural read-key for "which agent am
-//! I?" — Sub-C ships the API, Sub-D wires `AIRC_AGENT_ID` /
+//! I?" — Sub-C ships the API, Sub-D wires `AIRC_AGENT_NAME` /
 //! `airc init --as <name>`.
 
 use sea_orm_migration::prelude::*;

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -365,17 +365,27 @@ impl SqliteEventStore {
         .transpose()
     }
 
-    /// Persist the singleton local-identity row. Insert-only by
-    /// design — there is no `replace_local_identity` because a
-    /// peer_id / client_id change IS a new identity, not an update.
-    /// Calling this with a row already present returns an error
-    /// from the singleton CHECK + PK collision.
+    /// Return whether any local-identity row exists.
+    ///
+    /// Used by `airc-identity` to distinguish key-only partial state
+    /// from an already-initialized scope adding a second agent row.
+    pub async fn has_local_identity_rows(&self) -> Result<bool, StoreError> {
+        Ok(local_identity::Entity::find()
+            .one(&self.db)
+            .await?
+            .is_some())
+    }
+
+    /// Persist a local-identity row. Insert-only by design — there
+    /// is no `replace_local_identity` because a peer_id / client_id
+    /// change IS a new identity, not an update. Calling this with an
+    /// existing `agent_name` returns an error from the unique index.
     pub async fn insert_local_identity(
         &self,
         identity: StoredLocalIdentity,
     ) -> Result<(), StoreError> {
         let active = local_identity::ActiveModel {
-            id: Set(local_identity::SINGLETON_ID),
+            id: ActiveValue::NotSet,
             peer_id: Set(identity.peer_id.as_uuid()),
             client_id: Set(identity.client_id.as_uuid()),
             version: Set(i32::try_from(identity.version).map_err(|_| {
@@ -1264,24 +1274,17 @@ mod tests {
             .await
             .unwrap();
 
-        local_identity::Entity::insert(local_identity::ActiveModel {
-            id: Set(2),
-            peer_id: Set(PeerId::from_u128(0xa4).as_uuid()),
-            client_id: Set(ClientId::from_u128(0xc4).as_uuid()),
-            version: Set(1),
-            created_at_ms: Set(101),
-            name: Set("codex".to_string()),
-            pronouns: Set("".to_string()),
-            role: Set("agent".to_string()),
-            bio: Set("".to_string()),
-            status: Set("active".to_string()),
-            fingerprint: Set("".to_string()),
-            integrations_json: Set(json!({})),
-            agent_name: Set("codex".to_string()),
-        })
-        .exec(&store.db)
-        .await
-        .expect("Sub-B schema accepts a non-singleton local_identity row");
+        store_api
+            .insert_local_identity(StoredLocalIdentity {
+                peer_id: PeerId::from_u128(0xa4),
+                client_id: ClientId::from_u128(0xc4),
+                version: 1,
+                created_at_ms: 101,
+                identity: Identity::new("codex"),
+                agent_name: "codex".to_string(),
+            })
+            .await
+            .expect("Sub-D write path inserts a non-singleton local_identity row");
 
         let rows = local_identity::Entity::find()
             .order_by_asc(local_identity::Column::Id)
@@ -1321,27 +1324,17 @@ mod tests {
             .await
             .unwrap();
 
-        // Second agent inserted directly (Sub-D will wire the
-        // multi-row write surface; for Sub-C's read-side test, the
-        // direct insert is enough to populate the schema).
-        local_identity::Entity::insert(local_identity::ActiveModel {
-            id: Set(2),
-            peer_id: Set(PeerId::from_u128(0xb2).as_uuid()),
-            client_id: Set(ClientId::from_u128(0xd2).as_uuid()),
-            version: Set(1),
-            created_at_ms: Set(201),
-            name: Set("codex".to_string()),
-            pronouns: Set("".to_string()),
-            role: Set("agent".to_string()),
-            bio: Set("".to_string()),
-            status: Set("active".to_string()),
-            fingerprint: Set("".to_string()),
-            integrations_json: Set(json!({})),
-            agent_name: Set("codex".to_string()),
-        })
-        .exec(&store.db)
-        .await
-        .unwrap();
+        store_api
+            .insert_local_identity(StoredLocalIdentity {
+                peer_id: PeerId::from_u128(0xb2),
+                client_id: ClientId::from_u128(0xd2),
+                version: 1,
+                created_at_ms: 201,
+                identity: Identity::new("codex"),
+                agent_name: "codex".to_string(),
+            })
+            .await
+            .unwrap();
 
         // By-name lookup: default vs codex resolves to distinct rows.
         let default_row = store_api


### PR DESCRIPTION
## Summary
- add `AIRC_AGENT_NAME` and `airc init --as <AGENT_NAME>` for selecting a local agent identity
- expose `Airc::open_as` / `open_with_policy_as` for embedders
- use Sub-C `load_local_identity_by_agent_name` for by-name reads
- complete the multi-row write path: `insert_local_identity` now lets SQLite allocate row ids and in-memory store tracks rows by `agent_name`
- when adding a second agent to an initialized scope, reuse the existing `identity.key` but generate a distinct peer/client id row

## Stack
- stacked on #1053 / `51ac4c87/airc-store-load-local-identity-by-agent`
- #1053 is stacked on #1051 / `ee93aecd/airc-identity-drop-singleton-check-const`

## Tests
- `cargo fmt`
- `cargo test -p airc-store --lib`
- `cargo test -p airc-identity --lib`
- `cargo test -p airc-cli --test identity_commands`
- `cargo clippy --all-targets -- -D warnings`