### PR TITLE
feat(store): load_local_identity_by_agent_name read API (8384cc18 Sub-C)

### DIFF
--- a/crates/airc-store/src/entities/local_identity.rs
+++ b/crates/airc-store/src/entities/local_identity.rs
@@ -8,26 +8,24 @@
 //! **metadata that callers need to pair with the on-disk key**:
 //! `peer_id`, `client_id`, schema version, the originally recorded
 //! creation timestamp, the user-facing identity-card fields, and
-//! (since card 8384cc18 Sub-A) an `agent_name` discriminator.
+//! an `agent_name` discriminator.
 //!
-//! Singleton today, multi-agent target: the migration still uses an
-//! integer primary key fixed at `1` (CHECK constraint enforced),
-//! so a fresh DB has exactly zero or one row. Card 8384cc18 Sub-A
-//! adds `agent_name TEXT NOT NULL DEFAULT 'default'` purely
-//! additively — every existing row gets named `"default"`. Sub-B
-//! drops the CHECK + table-recreates so multiple rows become legal;
-//! Sub-C surfaces the agent-name read API; Sub-D wires
-//! `AIRC_AGENT_ID` / `airc init --as <name>`.
+//! Multi-agent target: card 8384cc18 Sub-A added
+//! `agent_name TEXT NOT NULL DEFAULT 'default'` additively, and
+//! Sub-B table-recreated this schema to drop the former
+//! `CHECK (id = 1)` singleton constraint. Multiple rows are now
+//! legal at the schema layer; Sub-C surfaces the agent-name read API
+//! and Sub-D wires `AIRC_AGENT_ID` / `airc init --as <name>`.
 //!
-//! [`SINGLETON_ID`] stays the documented primary-key value until
-//! Sub-B lands.
+//! [`SINGLETON_ID`] remains the documented primary-key value for the
+//! legacy/default agent row until the higher-level APIs stop using a
+//! singleton fallback.
 
 use sea_orm::entity::prelude::*;
 
-/// The only legal primary-key value while the singleton CHECK is in
-/// place (card 8384cc18 Sub-A → Sub-B will drop it). Encoded as `i32`
-/// so SQLite stores it as INTEGER (cheap) rather than a TEXT
-/// singleton key.
+/// The legacy/default primary-key value. Sub-B removed the database
+/// CHECK that made this the only legal id, but existing callers still
+/// use it until Sub-C/Sub-D route identity lookup by agent name.
 pub const SINGLETON_ID: i32 = 1;
 
 /// The default agent name used for every pre-card-8384cc18 row and
@@ -39,10 +37,9 @@ pub const DEFAULT_AGENT_NAME: &str = "default";
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
 #[sea_orm(table_name = "local_identity")]
 pub struct Model {
-    /// Currently always [`SINGLETON_ID`] (migration enforces it via
-    /// CHECK). Card 8384cc18 Sub-B drops the CHECK to allow multiple
-    /// rows; at that point `agent_name` becomes the natural read-key
-    /// and `id` becomes a non-meaningful row sequence number.
+    /// Existing/default identities use [`SINGLETON_ID`]. Sub-B removed
+    /// the singleton CHECK so additional rows can use other ids;
+    /// `agent_name` is the natural read key for multi-agent callers.
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: i32,
     pub peer_id: Uuid,

--- a/crates/airc-store/src/memory.rs
+++ b/crates/airc-store/src/memory.rs
@@ -50,11 +50,8 @@ impl Default for InMemoryEventStore {
 #[async_trait]
 impl EventStore for InMemoryEventStore {
     async fn load_local_identity(&self) -> Result<Option<StoredLocalIdentity>, StoreError> {
-        let identity = self
-            .local_identity
-            .lock()
-            .map_err(|_| StoreError::LockPoisoned)?;
-        Ok(identity.clone())
+        self.load_local_identity_by_agent_name(crate::DEFAULT_AGENT_NAME)
+            .await
     }
 
     async fn load_local_identity_by_agent_name(
@@ -395,6 +392,32 @@ mod tests {
 
         let stored = store_api.load_local_identity().await.unwrap().unwrap();
         assert_eq!(stored.identity, updated);
+    }
+
+    #[tokio::test]
+    async fn in_memory_load_local_identity_is_default_agent_path() {
+        let store = InMemoryEventStore::new();
+        let store_api: &dyn EventStore = &store;
+
+        store_api
+            .insert_local_identity(StoredLocalIdentity {
+                peer_id: PeerId::from_u128(0xa2),
+                client_id: airc_core::ClientId::from_u128(0xc2),
+                version: 1,
+                created_at_ms: 43,
+                identity: airc_core::identity::Identity::new("codex"),
+                agent_name: "codex".to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert!(store_api.load_local_identity().await.unwrap().is_none());
+        let by_name = store_api
+            .load_local_identity_by_agent_name("codex")
+            .await
+            .unwrap()
+            .expect("codex row");
+        assert_eq!(by_name.agent_name, "codex");
     }
 
     #[tokio::test]

--- a/crates/airc-store/src/memory.rs
+++ b/crates/airc-store/src/memory.rs
@@ -57,6 +57,23 @@ impl EventStore for InMemoryEventStore {
         Ok(identity.clone())
     }
 
+    async fn load_local_identity_by_agent_name(
+        &self,
+        agent_name: &str,
+    ) -> Result<Option<StoredLocalIdentity>, StoreError> {
+        // The in-memory store still holds one identity; faithfully
+        // honour the trait contract by filtering on agent_name and
+        // returning None for a mismatch. Card 8384cc18 Sub-C.
+        let identity = self
+            .local_identity
+            .lock()
+            .map_err(|_| StoreError::LockPoisoned)?;
+        Ok(identity
+            .as_ref()
+            .filter(|i| i.agent_name == agent_name)
+            .cloned())
+    }
+
     async fn insert_local_identity(&self, identity: StoredLocalIdentity) -> Result<(), StoreError> {
         let mut stored = self
             .local_identity

--- a/crates/airc-store/src/migration/m20260528_000014_drop_local_identity_singleton_check.rs
+++ b/crates/airc-store/src/migration/m20260528_000014_drop_local_identity_singleton_check.rs
@@ -1,0 +1,187 @@
+//! Card 8384cc18 Sub-B — drop the singleton `CHECK (id = 1)` from
+//! `local_identity`.
+//!
+//! SQLite cannot drop a CHECK constraint in-place, so this migration
+//! recreates the table with the same columns, copies every row across,
+//! and drops the legacy table. The existing row keeps `id = 1` and
+//! `agent_name = 'default'`; after this migration, additional rows
+//! with distinct ids and agent names are legal.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const AGENT_NAME_INDEX: &str = "idx_local_identity_agent_name";
+const LEGACY_TABLE: &str = "local_identity_legacy";
+
+const COPY_COLUMNS: [LocalIdentity; 13] = [
+    LocalIdentity::Id,
+    LocalIdentity::PeerId,
+    LocalIdentity::ClientId,
+    LocalIdentity::Version,
+    LocalIdentity::CreatedAtMs,
+    LocalIdentity::Name,
+    LocalIdentity::Pronouns,
+    LocalIdentity::Role,
+    LocalIdentity::Bio,
+    LocalIdentity::Status,
+    LocalIdentity::Fingerprint,
+    LocalIdentity::IntegrationsJson,
+    LocalIdentity::AgentName,
+];
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .rename_table(
+                Table::rename()
+                    .table(LocalIdentity::Table, Alias::new(LEGACY_TABLE))
+                    .to_owned(),
+            )
+            .await?;
+        manager.create_table(local_identity_table(false)).await?;
+        copy_rows(manager, false).await?;
+        manager
+            .drop_table(Table::drop().table(Alias::new(LEGACY_TABLE)).to_owned())
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name(AGENT_NAME_INDEX)
+                    .table(LocalIdentity::Table)
+                    .col(LocalIdentity::AgentName)
+                    .unique()
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name(AGENT_NAME_INDEX)
+                    .table(LocalIdentity::Table)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .rename_table(
+                Table::rename()
+                    .table(LocalIdentity::Table, Alias::new(LEGACY_TABLE))
+                    .to_owned(),
+            )
+            .await?;
+        manager.create_table(local_identity_table(true)).await?;
+        copy_rows(manager, true).await?;
+        manager
+            .drop_table(Table::drop().table(Alias::new(LEGACY_TABLE)).to_owned())
+            .await
+    }
+}
+
+fn local_identity_table(with_singleton_check: bool) -> TableCreateStatement {
+    let mut id = ColumnDef::new(LocalIdentity::Id);
+    id.integer().not_null().primary_key();
+    if with_singleton_check {
+        id.check(Expr::col(LocalIdentity::Id).eq(1));
+    }
+
+    Table::create()
+        .table(LocalIdentity::Table)
+        .col(id)
+        .col(ColumnDef::new(LocalIdentity::PeerId).uuid().not_null())
+        .col(ColumnDef::new(LocalIdentity::ClientId).uuid().not_null())
+        .col(ColumnDef::new(LocalIdentity::Version).integer().not_null())
+        .col(
+            ColumnDef::new(LocalIdentity::CreatedAtMs)
+                .big_integer()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(LocalIdentity::Name)
+                .string()
+                .not_null()
+                .default(""),
+        )
+        .col(
+            ColumnDef::new(LocalIdentity::Pronouns)
+                .string()
+                .not_null()
+                .default(""),
+        )
+        .col(
+            ColumnDef::new(LocalIdentity::Role)
+                .string()
+                .not_null()
+                .default(""),
+        )
+        .col(
+            ColumnDef::new(LocalIdentity::Bio)
+                .string()
+                .not_null()
+                .default(""),
+        )
+        .col(
+            ColumnDef::new(LocalIdentity::Status)
+                .string()
+                .not_null()
+                .default(""),
+        )
+        .col(
+            ColumnDef::new(LocalIdentity::Fingerprint)
+                .string()
+                .not_null()
+                .default(""),
+        )
+        .col(
+            ColumnDef::new(LocalIdentity::IntegrationsJson)
+                .json()
+                .not_null()
+                .default("{}"),
+        )
+        .col(
+            ColumnDef::new(LocalIdentity::AgentName)
+                .string()
+                .not_null()
+                .default("default"),
+        )
+        .to_owned()
+}
+
+async fn copy_rows(manager: &SchemaManager<'_>, singleton_only: bool) -> Result<(), DbErr> {
+    let mut select = Query::select();
+    select.columns(COPY_COLUMNS).from(Alias::new(LEGACY_TABLE));
+    if singleton_only {
+        select.and_where(Expr::col(LocalIdentity::Id).eq(1));
+    }
+
+    let mut insert = Query::insert();
+    insert
+        .into_table(LocalIdentity::Table)
+        .columns(COPY_COLUMNS);
+    insert
+        .select_from(select.to_owned())
+        .map_err(|err| DbErr::Migration(err.to_string()))?;
+    manager.exec_stmt(insert.to_owned()).await
+}
+
+#[derive(DeriveIden, Copy, Clone)]
+enum LocalIdentity {
+    Table,
+    Id,
+    PeerId,
+    ClientId,
+    Version,
+    CreatedAtMs,
+    Name,
+    Pronouns,
+    Role,
+    Bio,
+    Status,
+    Fingerprint,
+    IntegrationsJson,
+    AgentName,
+}

--- a/crates/airc-store/src/migration/mod.rs
+++ b/crates/airc-store/src/migration/mod.rs
@@ -1,9 +1,10 @@
 //! SeaORM migrations.
 //!
 //! Run automatically by `SqliteEventStore::open` so consumers don't
-//! need a separate "init" step. Each migration is an additive change
-//! (new table / new column / new index) and never destructive — the
-//! store treats older databases as forward-compatible.
+//! need a separate "init" step. Migrations preserve user data; most are
+//! additive, and the few SQLite table-recreate migrations copy rows
+//! before dropping their legacy tables. The store treats older
+//! databases as forward-compatible.
 
 use sea_orm::{DatabaseConnection, EntityTrait};
 use sea_orm_migration::prelude::*;
@@ -22,6 +23,7 @@ mod m20260523_000010_create_refresh_locks;
 mod m20260526_000011_create_bus_events;
 mod m20260527_000012_create_bus_epoch;
 mod m20260528_000013_add_local_identity_agent_name;
+mod m20260528_000014_drop_local_identity_singleton_check;
 
 pub struct Migrator;
 
@@ -42,6 +44,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260526_000011_create_bus_events::Migration),
             Box::new(m20260527_000012_create_bus_epoch::Migration),
             Box::new(m20260528_000013_add_local_identity_agent_name::Migration),
+            Box::new(m20260528_000014_drop_local_identity_singleton_check::Migration),
         ]
     }
 }
@@ -53,13 +56,13 @@ impl MigratorTrait for Migrator {
 /// binary has no file for (SeaORM: "migration file is missing"). That
 /// happens under version skew — a newer build migrates the DB forward,
 /// then an older binary opens it (e.g. a stale `~/.local/bin/airc`
-/// against a DB a dev build already migrated). Our migrations are
-/// additive and never destructive, so a DB ahead of us is harmless: the
-/// extra tables/columns are simply unused. So if `up` fails ONLY because
-/// the DB is ahead — every migration WE define is already applied — we
-/// proceed. A genuine divergence (we still have unapplied migrations of
-/// our own) surfaces the error instead of silently skipping schema we
-/// actually need.
+/// against a DB a dev build already migrated). Our migrations preserve
+/// existing data and older binaries simply ignore schema they do not
+/// understand, so a DB ahead of us is harmless: the extra tables/columns
+/// are unused. If `up` fails ONLY because the DB is ahead — every
+/// migration WE define is already applied — we proceed. A genuine
+/// divergence (we still have unapplied migrations of our own) surfaces
+/// the error instead of silently skipping schema we actually need.
 pub async fn apply_migrations(db: &DatabaseConnection) -> Result<(), sea_orm::DbErr> {
     match Migrator::up(db, None).await {
         Ok(()) => Ok(()),

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -327,7 +327,26 @@ impl SqliteEventStore {
     /// with the on-disk `identity.key` to decide whether to load,
     /// generate, or surface a partial-state error.
     pub async fn load_local_identity(&self) -> Result<Option<StoredLocalIdentity>, StoreError> {
-        let row = local_identity::Entity::find_by_id(local_identity::SINGLETON_ID)
+        // Backwards-compat path: the default-agent row. Card 8384cc18
+        // Sub-C added a by-name variant; this one resolves to the
+        // legacy/default discriminator so pre-Sub-D callers keep
+        // working unchanged.
+        self.load_local_identity_by_agent_name(local_identity::DEFAULT_AGENT_NAME)
+            .await
+    }
+
+    /// Look up a `local_identity` row by its `agent_name`
+    /// discriminator. Card 8384cc18 Sub-C — multi-agent read API.
+    ///
+    /// `agent_name` is the natural read key now that Sub-B dropped
+    /// the singleton CHECK; the unique index added in
+    /// `m20260528_000014` makes this an O(log n) point lookup.
+    pub async fn load_local_identity_by_agent_name(
+        &self,
+        agent_name: &str,
+    ) -> Result<Option<StoredLocalIdentity>, StoreError> {
+        let row = local_identity::Entity::find()
+            .filter(local_identity::Column::AgentName.eq(agent_name))
             .one(&self.db)
             .await?;
         row.map(|m| {
@@ -579,6 +598,13 @@ fn has_windows_drive_prefix(path: &str) -> bool {
 impl EventStore for SqliteEventStore {
     async fn load_local_identity(&self) -> Result<Option<StoredLocalIdentity>, StoreError> {
         SqliteEventStore::load_local_identity(self).await
+    }
+
+    async fn load_local_identity_by_agent_name(
+        &self,
+        agent_name: &str,
+    ) -> Result<Option<StoredLocalIdentity>, StoreError> {
+        SqliteEventStore::load_local_identity_by_agent_name(self, agent_name).await
     }
 
     async fn insert_local_identity(&self, identity: StoredLocalIdentity) -> Result<(), StoreError> {
@@ -1185,8 +1211,15 @@ mod tests {
             .await
             .unwrap();
 
+        // Card 8384cc18 Sub-C: `load_local_identity()` is now
+        // explicitly the default-agent path; round-tripping a
+        // non-default name uses the by-name lookup. This is the
+        // change in contract Sub-C ships — the test still proves
+        // the original intent (Sub-A's "agent_name actually
+        // persists, not silently re-defaults") but routes through
+        // the API surface that multi-agent callers will use.
         let stored = store_api
-            .load_local_identity()
+            .load_local_identity_by_agent_name("claude-tab-2")
             .await
             .unwrap()
             .expect("local identity row");
@@ -1198,6 +1231,16 @@ mod tests {
         // INSERT … SELECT step.)
         assert_eq!(stored.peer_id, PeerId::from_u128(0xa2));
         assert_eq!(stored.client_id, ClientId::from_u128(0xc2));
+
+        // And the legacy `load_local_identity()` path (which now
+        // means "default agent") correctly returns None when no
+        // default-agent row exists in the table.
+        let legacy_default = store_api.load_local_identity().await.unwrap();
+        assert!(
+            legacy_default.is_none(),
+            "load_local_identity() now resolves to the default agent only; \
+             a table holding only `claude-tab-2` must surface None",
+        );
     }
 
     /// Card 8384cc18 Sub-B — the final schema no longer enforces the
@@ -1250,6 +1293,87 @@ mod tests {
         assert_eq!(rows[0].agent_name, crate::DEFAULT_AGENT_NAME);
         assert_eq!(rows[1].id, 2);
         assert_eq!(rows[1].agent_name, "codex");
+    }
+
+    /// Card 8384cc18 Sub-C — `load_local_identity_by_agent_name`
+    /// resolves the row whose `agent_name` matches. With two distinct
+    /// agents in the table, looking up "default" returns the original
+    /// row and "codex" returns the second; the legacy
+    /// `load_local_identity()` keeps returning the default-agent row
+    /// (backwards-compat: every pre-Sub-C caller is implicitly
+    /// asking for that one).
+    #[tokio::test]
+    async fn load_local_identity_by_agent_name_disambiguates_rows() {
+        let store = SqliteEventStore::in_memory().await.unwrap();
+        let store_api: &dyn EventStore = &store;
+
+        // Default-agent row via the API (id auto-resolved to
+        // SINGLETON_ID by insert_local_identity).
+        store_api
+            .insert_local_identity(StoredLocalIdentity {
+                peer_id: PeerId::from_u128(0xb1),
+                client_id: ClientId::from_u128(0xd1),
+                version: 1,
+                created_at_ms: 200,
+                identity: Identity::new("primary"),
+                agent_name: crate::DEFAULT_AGENT_NAME.to_string(),
+            })
+            .await
+            .unwrap();
+
+        // Second agent inserted directly (Sub-D will wire the
+        // multi-row write surface; for Sub-C's read-side test, the
+        // direct insert is enough to populate the schema).
+        local_identity::Entity::insert(local_identity::ActiveModel {
+            id: Set(2),
+            peer_id: Set(PeerId::from_u128(0xb2).as_uuid()),
+            client_id: Set(ClientId::from_u128(0xd2).as_uuid()),
+            version: Set(1),
+            created_at_ms: Set(201),
+            name: Set("codex".to_string()),
+            pronouns: Set("".to_string()),
+            role: Set("agent".to_string()),
+            bio: Set("".to_string()),
+            status: Set("active".to_string()),
+            fingerprint: Set("".to_string()),
+            integrations_json: Set(json!({})),
+            agent_name: Set("codex".to_string()),
+        })
+        .exec(&store.db)
+        .await
+        .unwrap();
+
+        // By-name lookup: default vs codex resolves to distinct rows.
+        let default_row = store_api
+            .load_local_identity_by_agent_name(crate::DEFAULT_AGENT_NAME)
+            .await
+            .unwrap()
+            .expect("default-agent row present");
+        assert_eq!(default_row.peer_id, PeerId::from_u128(0xb1));
+        assert_eq!(default_row.identity.name, "primary");
+
+        let codex_row = store_api
+            .load_local_identity_by_agent_name("codex")
+            .await
+            .unwrap()
+            .expect("codex-agent row present");
+        assert_eq!(codex_row.peer_id, PeerId::from_u128(0xb2));
+        assert_eq!(codex_row.identity.name, "codex");
+        assert_ne!(default_row.peer_id, codex_row.peer_id);
+
+        // Missing agent_name resolves to None — the substrate contract
+        // for "this scope has never been initialized for that agent."
+        let missing = store_api
+            .load_local_identity_by_agent_name("hermes")
+            .await
+            .unwrap();
+        assert!(missing.is_none());
+
+        // Backwards-compat: legacy load_local_identity() still
+        // returns the default-agent row. Sub-D wires the override.
+        let legacy = store_api.load_local_identity().await.unwrap().unwrap();
+        assert_eq!(legacy.peer_id, default_row.peer_id);
+        assert_eq!(legacy.agent_name, crate::DEFAULT_AGENT_NAME);
     }
 
     #[tokio::test]

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -1200,6 +1200,58 @@ mod tests {
         assert_eq!(stored.client_id, ClientId::from_u128(0xc2));
     }
 
+    /// Card 8384cc18 Sub-B — the final schema no longer enforces the
+    /// singleton `CHECK (id = 1)`. Store APIs still load the default row
+    /// until Sub-C/Sub-D add agent-name lookup and init surfaces, but
+    /// the database must now accept a second agent row so those slices
+    /// have a schema to target.
+    #[tokio::test]
+    async fn local_identity_schema_accepts_a_second_agent_row() {
+        let store = SqliteEventStore::in_memory().await.unwrap();
+        let store_api: &dyn EventStore = &store;
+        store_api
+            .insert_local_identity(StoredLocalIdentity {
+                peer_id: PeerId::from_u128(0xa3),
+                client_id: ClientId::from_u128(0xc3),
+                version: 1,
+                created_at_ms: 100,
+                identity: Identity::new("default-agent"),
+                agent_name: crate::DEFAULT_AGENT_NAME.to_string(),
+            })
+            .await
+            .unwrap();
+
+        local_identity::Entity::insert(local_identity::ActiveModel {
+            id: Set(2),
+            peer_id: Set(PeerId::from_u128(0xa4).as_uuid()),
+            client_id: Set(ClientId::from_u128(0xc4).as_uuid()),
+            version: Set(1),
+            created_at_ms: Set(101),
+            name: Set("codex".to_string()),
+            pronouns: Set("".to_string()),
+            role: Set("agent".to_string()),
+            bio: Set("".to_string()),
+            status: Set("active".to_string()),
+            fingerprint: Set("".to_string()),
+            integrations_json: Set(json!({})),
+            agent_name: Set("codex".to_string()),
+        })
+        .exec(&store.db)
+        .await
+        .expect("Sub-B schema accepts a non-singleton local_identity row");
+
+        let rows = local_identity::Entity::find()
+            .order_by_asc(local_identity::Column::Id)
+            .all(&store.db)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].id, local_identity::SINGLETON_ID);
+        assert_eq!(rows[0].agent_name, crate::DEFAULT_AGENT_NAME);
+        assert_eq!(rows[1].id, 2);
+        assert_eq!(rows[1].agent_name, "codex");
+    }
+
     #[tokio::test]
     async fn page_recent_returns_oldest_to_newest_with_limit() {
         // Substrate contract: page is ordered oldest → newest within

--- a/crates/airc-store/src/store.rs
+++ b/crates/airc-store/src/store.rs
@@ -23,13 +23,41 @@ use crate::subscriptions::StoredSubscription;
 /// is the deterministic tiebreaker.
 #[async_trait]
 pub trait EventStore: Send + Sync {
-    /// Load this install's singleton local identity row, if present.
+    /// Load the default-agent local identity row, if present.
+    ///
+    /// Equivalent to [`Self::load_local_identity_by_agent_name`] with
+    /// `"default"`. Kept for backwards compatibility with every
+    /// pre-card-8384cc18 callsite that resolves identity without
+    /// being multi-agent-aware. New code that knows its agent
+    /// discriminator should call the by-name variant directly so
+    /// `AIRC_AGENT_NAME` / `airc init --as <name>` (Sub-D, card
+    /// 0f749d4c) can override it.
     async fn load_local_identity(&self) -> Result<Option<StoredLocalIdentity>, StoreError>;
 
-    /// Insert this install's singleton local identity row.
+    /// Load the local identity row whose `agent_name` matches.
     ///
-    /// Implementations must fail if a row already exists; changing
-    /// peer/client identity is a new identity, not an update.
+    /// Card 8384cc18 Sub-C — the multi-agent read surface that
+    /// Sub-B's schema (unique index on `agent_name`) enables. Returns
+    /// `Ok(None)` when no row is named `agent_name` so callers can
+    /// distinguish "fresh database for this agent" from a real I/O
+    /// error and decide whether to generate vs. surface a partial
+    /// state.
+    ///
+    /// Sub-D wires this through `AIRC_AGENT_NAME` and
+    /// `airc init --as <name>`; until that ships, the default-agent
+    /// path via [`Self::load_local_identity`] remains the entrypoint
+    /// for every existing caller.
+    async fn load_local_identity_by_agent_name(
+        &self,
+        agent_name: &str,
+    ) -> Result<Option<StoredLocalIdentity>, StoreError>;
+
+    /// Insert a local identity row.
+    ///
+    /// Implementations must fail if a row with the same
+    /// `agent_name` already exists; changing peer/client identity
+    /// is a new identity, not an update. Multiple rows with
+    /// distinct `agent_name`s are legal post-Sub-B (8384cc18).
     async fn insert_local_identity(&self, identity: StoredLocalIdentity) -> Result<(), StoreError>;
 
     /// Replace only the user-facing identity card fields on the


### PR DESCRIPTION
**Card:** [51ac4c87](https://github.com/CambrianTech/airc/issues?q=51ac4c87) — 8384cc18 Sub-C
**Stacked on:** #1051 (8384cc18 Sub-B, @codex)

#1051 dropped the singleton `CHECK (id = 1)` on `local_identity` + added the unique index on `agent_name`. Multi-agent rows are now legal at the schema layer. This PR adds the matching read API so callers can resolve identity by `agent_name` instead of always pulling `SINGLETON_ID`.

### What changed

| File | Change |
|---|---|
| `airc-store/src/store.rs` | `EventStore::load_local_identity_by_agent_name(&str)` trait method |
| `airc-store/src/sqlite.rs` | Impl: `.filter(Column::AgentName.eq(name)).one()` — O(log n) against Sub-B's unique index |
| `airc-store/src/memory.rs` | InMemoryEventStore impl: filters the single stored row by agent_name, returns None on mismatch |
| `airc-store/src/store.rs` | `load_local_identity()` doc reframed: now explicitly the **default-agent path** (delegates to by-name(`"default"`)) |

### Contract change: `load_local_identity()` now means "default agent"

Pre-Sub-A, `load_local_identity()` returned "the singleton" — there was exactly one row, so the call was unambiguous. With Sub-B's multi-row schema, that semantics is ambiguous. The new contract:

- `load_local_identity()` → default-agent row (delegates to `by_name("default")`)
- `load_local_identity_by_agent_name(name)` → that named row
- Sub-D (0f749d4c, @codex) wires the env-var / init-flag override on top of this

Pre-Sub-A callers continue to work unchanged because every existing row has `agent_name="default"` (the migration backfill).

### Test surface

**New:** `load_local_identity_by_agent_name_disambiguates_rows`
- Two agents in the table (default + codex via direct insert)
- By-name lookup resolves each distinctly
- Missing names return None — the substrate contract for "scope not initialized for that agent"
- Legacy `load_local_identity()` still returns the default-agent row

**Updated:** `explicit_agent_name_round_trips_through_local_identity`
- Pre-Sub-C: called `load_local_identity()` on a row with `agent_name="claude-tab-2"` and expected it back. That semantics is gone — `load_local_identity()` now means "default agent".
- Post-Sub-C: routes through `load_local_identity_by_agent_name("claude-tab-2")` — Sub-A's original intent ("agent_name actually persists, not silently re-defaults") proved more directly. Test also pins the new contract: `load_local_identity()` returns None when no default row exists.

### Validation

- `cargo test -p airc-store --lib`: 39/39 ✓
- `cargo test -p airc-identity --lib`: 7/7 ✓
- `cargo fmt --all -- --check`: clean ✓
- `cargo clippy -p airc-store -p airc-identity --all-targets -D warnings`: clean ✓

### Stacked-PR note

Base is #1051's branch `ee93aecd/airc-identity-drop-singleton-check-const`. When Sub-B lands, GitHub auto-rebases this onto `rust-rewrite`. Same pattern as #1043/#1041.

### What Sub-D builds on top

@codex's Sub-D (0f749d4c) does the init-time resolution:
```rust
let agent_name = env::var("AIRC_AGENT_NAME")
    .unwrap_or_else(|_| "default".to_string());
let identity = store
    .load_local_identity_by_agent_name(&agent_name)
    .await?;
```
This Sub-C is the underlying API that surface depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
