### PR TITLE
fix(codex): restore polling turn contract

### DIFF
--- a/crates/airc-cli/src/integrations/codex/config.rs
+++ b/crates/airc-cli/src/integrations/codex/config.rs
@@ -6,6 +6,17 @@ use toml_edit::{value, DocumentMut, Item, Table};
 
 const INSTRUCTIONS_START: &str = "# AIRC-CODEX-INSTRUCTIONS-START";
 const INSTRUCTIONS_END: &str = "# AIRC-CODEX-INSTRUCTIONS-END";
+const MANAGED_DEVELOPER_INSTRUCTIONS: &str = r#"# AIRC-CODEX-INSTRUCTIONS-START - managed by airc codex-hook install-hooks; remove this section through AIRC-CODEX-INSTRUCTIONS-END to opt out
+developer_instructions = """
+AIRC Codex runtime contract:
+- Keep airc join running as this session's live AIRC feed when coordinating with peer agents.
+- If no live join session id is available during a turn, run airc codex-hook poll --wait-ms 1000 between tool steps. It is the bounded mid-turn feed and shares the same runtime cursor as the hook.
+- The installed airc codex-hook user-prompt-submit hook is prompt-boundary catch-up only. Treat injected peer messages as active work context, but do not mistake hook delivery for a live monitor.
+- Reply to direct peer questions with airc msg, not user-chat stdout. The peer sees AIRC, not this transcript.
+- Distinguish transport/process liveness from whether this Codex session has actually seen peer traffic.
+"""
+# AIRC-CODEX-INSTRUCTIONS-END
+"#;
 
 pub fn enable_hooks_feature(path: &Path) -> Result<bool, Box<dyn std::error::Error>> {
     let original = read_text(path)?;
@@ -55,24 +66,38 @@ pub fn remove_managed_developer_instructions(
     if !original.contains(INSTRUCTIONS_START) {
         return Ok(false);
     }
-    let mut out = Vec::new();
-    let mut skipping = false;
-    for line in original.lines() {
-        if line.starts_with(INSTRUCTIONS_START) {
-            skipping = true;
-            continue;
-        }
-        if skipping {
-            if line.starts_with(INSTRUCTIONS_END) {
-                skipping = false;
-            }
-            continue;
-        }
-        out.push(line);
-    }
-    let rendered = out.join("\n").trim().to_string();
+    let rendered = strip_managed_developer_instructions(&original)
+        .trim()
+        .to_string();
     write_text(path, &(rendered + "\n"))?;
     Ok(true)
+}
+
+pub fn upsert_managed_developer_instructions(
+    path: &Path,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let original = read_text(path)?;
+    let without_managed = strip_managed_developer_instructions(&original);
+    let doc = parse_toml_document(&without_managed)?;
+    if doc.get("developer_instructions").is_some() {
+        if without_managed != original {
+            write_text(path, &without_managed)?;
+            return Ok(true);
+        }
+        return Ok(false);
+    }
+
+    let mut rendered = String::new();
+    rendered.push_str(MANAGED_DEVELOPER_INSTRUCTIONS);
+    if !without_managed.trim().is_empty() {
+        rendered.push('\n');
+        rendered.push_str(without_managed.trim_start());
+    }
+    if rendered != original {
+        write_text(path, &rendered)?;
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 pub fn remove_stale_airc_filesystem_permissions(
@@ -111,6 +136,28 @@ pub fn remove_stale_airc_filesystem_permissions(
     }
     write_text(path, &rendered)?;
     Ok(true)
+}
+
+fn strip_managed_developer_instructions(text: &str) -> String {
+    if !text.contains(INSTRUCTIONS_START) {
+        return text.to_string();
+    }
+    let mut out = Vec::new();
+    let mut skipping = false;
+    for line in text.lines() {
+        if line.starts_with(INSTRUCTIONS_START) {
+            skipping = true;
+            continue;
+        }
+        if skipping {
+            if line.starts_with(INSTRUCTIONS_END) {
+                skipping = false;
+            }
+            continue;
+        }
+        out.push(line);
+    }
+    collapse_blank_lines(&out.join("\n"))
 }
 
 fn parse_toml_document(text: &str) -> Result<DocumentMut, Box<dyn std::error::Error>> {

--- a/crates/airc-cli/src/integrations/codex/hook.rs
+++ b/crates/airc-cli/src/integrations/codex/hook.rs
@@ -299,7 +299,7 @@ fn dedupe(events: &[TranscriptEvent]) -> Vec<DigestMessage> {
     let mut seen = BTreeSet::new();
     let mut messages = Vec::new();
     for event in events {
-        if is_work_queue_event(event) {
+        if is_work_queue_event(event) || is_runtime_alive_event(event) {
             continue;
         }
         let peer = event.peer_id.to_string();
@@ -309,6 +309,26 @@ fn dedupe(events: &[TranscriptEvent]) -> Vec<DigestMessage> {
         }
     }
     messages
+}
+
+fn is_runtime_alive_event(event: &TranscriptEvent) -> bool {
+    let Some(body) = &event.body else {
+        return false;
+    };
+    match body {
+        Body::Binary(_) => false,
+        Body::Json(value) => {
+            body_kind_is_alive(value)
+                || body.as_text().is_some_and(|text| {
+                    serde_json::from_str::<serde_json::Value>(text)
+                        .is_ok_and(|value| body_kind_is_alive(&value))
+                })
+        }
+    }
+}
+
+fn body_kind_is_alive(value: &serde_json::Value) -> bool {
+    value.get("kind").and_then(|kind| kind.as_str()) == Some("alive")
 }
 
 fn summarize_body(event: &TranscriptEvent) -> String {
@@ -338,7 +358,13 @@ fn summarize_text(value: &str, max_len: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::consumer_id;
+    use airc_core::{
+        Body, ClientId, EventId, Headers, MentionTarget, PeerId, RoomId, TranscriptEvent,
+        TranscriptKind,
+    };
+    use serde_json::json;
+
+    use super::{consumer_id, render_digest, render_raw};
 
     #[test]
     fn consumer_id_uses_runtime_client_when_present() {
@@ -347,5 +373,58 @@ mod tests {
             "codex-hook:codex:thread-1"
         );
         assert_eq!(consumer_id(None), "codex-hook:default");
+    }
+
+    #[test]
+    fn digest_suppresses_runtime_alive_events() {
+        let events = vec![
+            event(Body::Json(json!({
+                "kind": "alive",
+                "client_id": "claude:session-1",
+            }))),
+            event(Body::text("real update")),
+        ];
+
+        let digest = render_digest(&events, 8);
+
+        assert!(digest.contains("AIRC: 1 unread"));
+        assert!(digest.contains("real update"));
+        assert!(!digest.contains("\"kind\":\"alive\""));
+    }
+
+    #[test]
+    fn raw_output_keeps_runtime_alive_events_for_debugging() {
+        let events = vec![event(Body::Json(json!({ "kind": "alive" })))];
+
+        let raw = render_raw(&events);
+
+        assert!(raw.contains("\"kind\":\"alive\""));
+    }
+
+    #[test]
+    fn digest_suppresses_text_encoded_runtime_alive_events() {
+        let events = vec![event(Body::text(r#"{"kind":"alive"}"#))];
+
+        let digest = render_digest(&events, 8);
+
+        assert!(digest.is_empty());
+    }
+
+    fn event(body: Body) -> TranscriptEvent {
+        TranscriptEvent {
+            event_id: EventId::new(),
+            room_id: RoomId::new(),
+            peer_id: PeerId::new(),
+            client_id: ClientId::new(),
+            kind: TranscriptKind::System,
+            occurred_at_ms: 1,
+            lamport: 1,
+            target: MentionTarget::All,
+            headers: Headers::new(),
+            body: Some(body),
+            attachment: None,
+            receipt: None,
+            metadata: serde_json::Value::Null,
+        }
     }
 }

--- a/crates/airc-cli/src/integrations/codex/install.rs
+++ b/crates/airc-cli/src/integrations/codex/install.rs
@@ -52,9 +52,9 @@ pub fn install_hooks_at(
             hooks_json.display()
         ));
     }
-    if config::remove_managed_developer_instructions(&config)? {
+    if config::upsert_managed_developer_instructions(&config)? {
         report.push(format!(
-            "removed legacy AIRC Codex polling instructions from {}",
+            "installed AIRC Codex turn contract in {}",
             config.display()
         ));
     }
@@ -88,6 +88,9 @@ pub async fn run_uninstall_hooks(
             "removed AIRC UserPromptSubmit hook from {}",
             hooks_json.display()
         );
+    }
+    if config::remove_managed_developer_instructions(&config)? {
+        println!("removed AIRC Codex turn contract from {}", config.display());
     }
     Ok(())
 }

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -350,6 +350,60 @@ fn codex_hook_installer_replaces_existing_managed_hook_command() {
 }
 
 #[test]
+fn codex_hook_installer_adds_turn_contract_when_unset() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("airc");
+    let codex_home = workspace.path().join("codex");
+    std::fs::create_dir_all(&codex_home).expect("codex home");
+    std::fs::write(codex_home.join("config.toml"), "[features]\n").expect("write config");
+
+    run_ok(
+        &home,
+        &[
+            "codex-hook",
+            "install-hooks",
+            "--codex-home",
+            codex_home.to_str().unwrap(),
+        ],
+    );
+
+    let config = std::fs::read_to_string(codex_home.join("config.toml")).expect("read config");
+    assert!(config.contains("AIRC-CODEX-INSTRUCTIONS-START"));
+    assert!(config.contains("developer_instructions"));
+    assert!(config.contains("airc codex-hook poll --wait-ms 1000"));
+    assert!(config.contains("hooks = true"));
+}
+
+#[test]
+fn codex_hook_installer_preserves_custom_developer_instructions() {
+    let workspace = TempDir::new().expect("tempdir");
+    let home = workspace.path().join("airc");
+    let codex_home = workspace.path().join("codex");
+    std::fs::create_dir_all(&codex_home).expect("codex home");
+    std::fs::write(
+        codex_home.join("config.toml"),
+        "developer_instructions = \"custom contract\"\n",
+    )
+    .expect("write config");
+
+    run_ok(
+        &home,
+        &[
+            "codex-hook",
+            "install-hooks",
+            "--codex-home",
+            codex_home.to_str().unwrap(),
+        ],
+    );
+
+    let config = std::fs::read_to_string(codex_home.join("config.toml")).expect("read config");
+    assert!(config.contains("developer_instructions = \"custom contract\""));
+    assert!(!config.contains("AIRC-CODEX-INSTRUCTIONS-START"));
+    assert!(!config.contains("airc codex-hook poll --wait-ms 1000"));
+    assert!(config.contains("hooks = true"));
+}
+
+#[test]
 fn codex_hook_installer_removes_managed_filesystem_profile() {
     let workspace = TempDir::new().expect("tempdir");
     let home = workspace.path().join("airc");

--- a/install.sh
+++ b/install.sh
@@ -760,21 +760,8 @@ fi
 
 _install_airc_codex_developer_instructions() {
   local config="$HOME/.codex/config.toml"
-  local hooks_json="$HOME/.codex/hooks.json"
   [ "${AIRC_SKIP_CODEX_INSTRUCTIONS:-0}" = "1" ] && return 0
   [ -f "$config" ] || return 0
-
-  if grep -qE '^[[:space:]]*(hooks|codex_hooks)[[:space:]]*=[[:space:]]*true' "$config" 2>/dev/null \
-     && [ -f "$hooks_json" ] \
-     && grep -qF 'airc codex-hook user-prompt-submit' "$hooks_json" 2>/dev/null; then
-    if grep -qF 'AIRC-CODEX-INSTRUCTIONS-START' "$config" 2>/dev/null; then
-      local _tmp; _tmp=$(mktemp)
-      sed '/^# AIRC-CODEX-INSTRUCTIONS-START/,/^# AIRC-CODEX-INSTRUCTIONS-END/d' "$config" > "$_tmp"
-      mv "$_tmp" "$config"
-    fi
-    info "  Codex AIRC hook already installed; skipping developer_instructions polling contract"
-    return 0
-  fi
 
   if grep -qF 'AIRC-CODEX-INSTRUCTIONS-START' "$config" 2>/dev/null; then
     local _tmp; _tmp=$(mktemp)


### PR DESCRIPTION
Install a model-visible Codex AIRC turn contract when no custom developer_instructions are present, preserve custom config, remove the old install.sh skip path, and suppress routine runtime alive heartbeats from the default hook digest while keeping raw output inspectable.

Also restores the rust-rewrite PR base helper after the gh module split so the local clippy gate remains green.