### PR TITLE
feat(merger): strictly-less-red-than-base — ignore failures inherited from rust-rewrite (card d5b7b07d)

### DIFF
--- a/crates/airc-cli/src/gh_client.rs
+++ b/crates/airc-cli/src/gh_client.rs
@@ -29,9 +29,12 @@ use async_trait::async_trait;
 use tokio::process::Command;
 
 pub use airc_lib::gh_client::{
-    parse_pr_url, parse_pr_view, GhClient, GhError, MergeReceipt, PrCreateArgs, PrCreated,
-    PrEditBaseArgs, PrMergeArgs, PrView, PrViewArgs,
+    parse_pr_url, parse_pr_view, BranchCheckRollupArgs, GhCheck, GhClient, GhError, MergeReceipt,
+    PrCreateArgs, PrCreated, PrEditBaseArgs, PrMergeArgs, PrView, PrViewArgs,
 };
+// parse_check_runs is only used inside merger's #[cfg(test)] block — accessed
+// via the airc_lib path there to avoid a "unused re-export" lint in non-test
+// builds. The shell impl above uses the same path directly.
 
 /// Default [`GhClient`] backed by spawning `gh` as a subprocess.
 ///
@@ -127,6 +130,27 @@ impl GhClient for ShellGhClient {
             return Err(classify_gh_failure(&output));
         }
         Ok(())
+    }
+
+    async fn branch_check_rollup(
+        &self,
+        args: BranchCheckRollupArgs,
+    ) -> Result<Vec<GhCheck>, GhError> {
+        // Card d5b7b07d: REST `/check-runs` for the integration branch's
+        // HEAD. `--paginate` so a workflow with >30 checks doesn't
+        // silently lose the failing ones to pagination. The REST shape
+        // is {total_count, check_runs:[...]}; parse_check_runs in
+        // airc-lib projects to just the run list.
+        let path = format!("repos/{}/commits/{}/check-runs", args.repo, args.branch);
+        let output = Command::new("gh")
+            .args(["api", "--paginate", &path])
+            .output()
+            .await
+            .map_err(map_spawn_error)?;
+        if !output.status.success() {
+            return Err(classify_gh_failure(&output));
+        }
+        airc_lib::gh_client::parse_check_runs(&output.stdout)
     }
 }
 

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -120,8 +120,21 @@ async fn tick_once(
     let board = airc.work_board(256).await?;
     let snapshot = board.snapshot();
 
+    // Card d5b7b07d: fetch the baseline (rust-rewrite HEAD's failing
+    // check names) ONCE per tick — every per-card gate consults the
+    // same snapshot. The set is small (handful of check names) and
+    // the query is one REST call; cheap relative to per-PR pr_view.
+    let baseline_failures = fetch_baseline_failures(gh).await;
+    if !baseline_failures.is_empty() {
+        eprintln!(
+            "airc-merger: baseline has {} failing check(s) on rust-rewrite — \
+             those won't block per-PR gates this tick",
+            baseline_failures.len()
+        );
+    }
+
     for card in &snapshot.cards {
-        let Some(decision) = evaluate(gh, card).await? else {
+        let Some(decision) = evaluate(gh, card, &baseline_failures).await? else {
             continue;
         };
         match decision {
@@ -164,6 +177,7 @@ enum MergeDecision {
 async fn evaluate(
     gh: &dyn crate::gh_client::GhClient,
     card: &WorkCard,
+    baseline_failures: &std::collections::HashSet<String>,
 ) -> Result<Option<MergeDecision>, Box<dyn std::error::Error>> {
     use airc_work::model::CardState;
     if card.state != CardState::Review {
@@ -173,7 +187,7 @@ async fn evaluate(
         return Ok(None);
     };
 
-    match check_pr_gate(gh, &pr).await {
+    match check_pr_gate(gh, &pr, baseline_failures).await {
         Ok(GateResult::Green) => Ok(Some(MergeDecision::Merge(pr))),
         Ok(GateResult::NotReady(reason)) => Ok(Some(MergeDecision::Skip(reason))),
         Err(error) => Ok(Some(MergeDecision::Skip(format!(
@@ -199,6 +213,7 @@ enum GateResult {
 async fn check_pr_gate(
     gh: &dyn crate::gh_client::GhClient,
     pr: &airc_work::model::PullRequestRef,
+    baseline_failures: &std::collections::HashSet<String>,
 ) -> Result<GateResult, crate::gh_client::GhError> {
     let view = gh
         .pr_view(crate::gh_client::PrViewArgs {
@@ -207,7 +222,58 @@ async fn check_pr_gate(
             cwd: None,
         })
         .await?;
-    Ok(evaluate_gh_view(&view))
+    Ok(evaluate_gh_view(&view, baseline_failures))
+}
+
+/// Fetch the rust-rewrite HEAD's check-run rollup and return the SET
+/// of names that are currently FAILURE on base. The merger calls this
+/// once per tick; each per-card gate consults the same snapshot. On
+/// error (rate-limit, network), returns empty set — the gate
+/// degrades to "no allowance" rather than over-trusting.
+async fn fetch_baseline_failures(
+    gh: &dyn crate::gh_client::GhClient,
+) -> std::collections::HashSet<String> {
+    let base_branch = crate::work_commands_gh::pr_create_base_branch();
+    let runs = match gh
+        .branch_check_rollup(crate::gh_client::BranchCheckRollupArgs {
+            repo: "CambrianTech/airc".to_string(),
+            branch: base_branch.to_string(),
+        })
+        .await
+    {
+        Ok(runs) => runs,
+        Err(error) => {
+            eprintln!(
+                "airc-merger: baseline-failures lookup failed for {base_branch}: {error} \
+                 (degrading to no-allowance gate)"
+            );
+            return std::collections::HashSet::new();
+        }
+    };
+    baseline_failing_names(&runs)
+}
+
+/// Pure projection: rollup → set of check NAMES whose conclusion is
+/// failure-shaped (case-insensitive). Kept separate from the IO half
+/// so the strictly-less-red logic is unit-testable without a live
+/// `gh`.
+pub(crate) fn baseline_failing_names(
+    runs: &[crate::gh_client::GhCheck],
+) -> std::collections::HashSet<String> {
+    let mut set = std::collections::HashSet::new();
+    for c in runs {
+        let conc_upper = c
+            .conclusion
+            .as_deref()
+            .map(|s| s.to_ascii_uppercase())
+            .unwrap_or_default();
+        if matches!(conc_upper.as_str(), "FAILURE" | "CANCELLED" | "TIMED_OUT") {
+            if let Some(name) = c.name.as_deref() {
+                set.insert(name.to_string());
+            }
+        }
+    }
+    set
 }
 
 /// Decide whether a PR is ready to merge, given the parsed `gh pr
@@ -218,9 +284,14 @@ async fn check_pr_gate(
 /// - no `FAILURE` / `CANCELLED` / `TIMED_OUT` conclusions
 /// - no still-running checks (status != COMPLETED with no conclusion)
 ///
-/// The strictly-less-red-than-base doctrine refinement (#1033) is a
-/// separate, more lenient gate carded as a follow-up.
-fn evaluate_gh_view(view: &crate::gh_client::PrView) -> GateResult {
+/// Card d5b7b07d adds the strictly-less-red-than-base refinement:
+/// a FAILURE whose check name is ALSO failing on base is treated as
+/// effectively neutral (the PR didn't cause it). Pass an empty set
+/// to disable the bypass — that's the f16650cd-original strict gate.
+fn evaluate_gh_view(
+    view: &crate::gh_client::PrView,
+    baseline_failures: &std::collections::HashSet<String>,
+) -> GateResult {
     if view.state != "OPEN" {
         return GateResult::NotReady(format!("PR state is {} (not OPEN)", view.state));
     }
@@ -228,12 +299,28 @@ fn evaluate_gh_view(view: &crate::gh_client::PrView) -> GateResult {
         return GateResult::NotReady("PR has merge conflicts; needs rebase".to_string());
     }
     let rollup = view.status_check_rollup.as_deref().unwrap_or(&[]);
-    let mut failures = 0usize;
+    let mut new_failures = 0usize;
+    let mut inherited_failures = 0usize;
     let mut pending = 0usize;
     for c in rollup {
         match c.conclusion.as_deref() {
             Some("SUCCESS") | Some("NEUTRAL") | Some("SKIPPED") => {}
-            Some("FAILURE") | Some("CANCELLED") | Some("TIMED_OUT") => failures += 1,
+            Some("FAILURE") | Some("CANCELLED") | Some("TIMED_OUT") => {
+                // Strictly-less-red: if the PR-side check name is
+                // also failing on base, the PR isn't responsible.
+                // Counts as inherited (doesn't block) so the log line
+                // can surface that we noticed.
+                let is_inherited = c
+                    .name
+                    .as_deref()
+                    .map(|n| baseline_failures.contains(n))
+                    .unwrap_or(false);
+                if is_inherited {
+                    inherited_failures += 1;
+                } else {
+                    new_failures += 1;
+                }
+            }
             _ => {
                 // No conclusion → in flight (IN_PROGRESS / QUEUED / PENDING).
                 if c.status.as_deref() != Some("COMPLETED") {
@@ -242,8 +329,13 @@ fn evaluate_gh_view(view: &crate::gh_client::PrView) -> GateResult {
             }
         }
     }
-    if failures > 0 {
-        return GateResult::NotReady(format!("{failures} failing check(s)"));
+    if new_failures > 0 {
+        let inherited_note = if inherited_failures > 0 {
+            format!(" ({inherited_failures} inherited from base, ignored)")
+        } else {
+            String::new()
+        };
+        return GateResult::NotReady(format!("{new_failures} failing check(s){inherited_note}"));
     }
     if pending > 0 {
         return GateResult::NotReady(format!("{pending} check(s) still running"));
@@ -325,6 +417,13 @@ mod tests {
         serde_json::from_value(payload).expect("test fixture must parse")
     }
 
+    /// Empty baseline = no inherited failures known. Old strict-gate
+    /// behavior. Used by all the pre-d5b7b07d tests which pre-date
+    /// the strictly-less-red bypass.
+    fn empty_baseline() -> std::collections::HashSet<String> {
+        std::collections::HashSet::new()
+    }
+
     #[test]
     fn merges_when_state_open_no_conflicts_all_checks_green() {
         let view = parse(json!({
@@ -336,13 +435,16 @@ mod tests {
                 {"conclusion": "SKIPPED", "status": "COMPLETED"},
             ]
         }));
-        assert!(matches!(evaluate_gh_view(&view), GateResult::Green));
+        assert!(matches!(
+            evaluate_gh_view(&view, &empty_baseline()),
+            GateResult::Green
+        ));
     }
 
     #[test]
     fn refuses_when_pr_is_closed() {
         let view = parse(json!({"state": "CLOSED", "mergeable": "MERGEABLE"}));
-        let result = evaluate_gh_view(&view);
+        let result = evaluate_gh_view(&view, &empty_baseline());
         let GateResult::NotReady(reason) = result else {
             panic!("expected NotReady, got Green");
         };
@@ -352,7 +454,10 @@ mod tests {
     #[test]
     fn refuses_when_pr_is_already_merged() {
         let view = parse(json!({"state": "MERGED", "mergeable": "MERGEABLE"}));
-        assert!(matches!(evaluate_gh_view(&view), GateResult::NotReady(_)));
+        assert!(matches!(
+            evaluate_gh_view(&view, &empty_baseline()),
+            GateResult::NotReady(_)
+        ));
     }
 
     #[test]
@@ -362,7 +467,7 @@ mod tests {
             "mergeable": "CONFLICTING",
             "statusCheckRollup": [{"conclusion": "SUCCESS", "status": "COMPLETED"}]
         }));
-        let GateResult::NotReady(reason) = evaluate_gh_view(&view) else {
+        let GateResult::NotReady(reason) = evaluate_gh_view(&view, &empty_baseline()) else {
             panic!("expected NotReady");
         };
         assert!(
@@ -382,7 +487,7 @@ mod tests {
                 {"conclusion": "SUCCESS", "status": "COMPLETED"},
             ]
         }));
-        let GateResult::NotReady(reason) = evaluate_gh_view(&view) else {
+        let GateResult::NotReady(reason) = evaluate_gh_view(&view, &empty_baseline()) else {
             panic!("expected NotReady");
         };
         assert!(reason.contains("failing"), "reason should mention failures");
@@ -397,7 +502,10 @@ mod tests {
                 {"conclusion": "CANCELLED", "status": "COMPLETED"},
             ]
         }));
-        assert!(matches!(evaluate_gh_view(&view), GateResult::NotReady(_)));
+        assert!(matches!(
+            evaluate_gh_view(&view, &empty_baseline()),
+            GateResult::NotReady(_)
+        ));
     }
 
     #[test]
@@ -409,7 +517,10 @@ mod tests {
                 {"conclusion": "TIMED_OUT", "status": "COMPLETED"},
             ]
         }));
-        assert!(matches!(evaluate_gh_view(&view), GateResult::NotReady(_)));
+        assert!(matches!(
+            evaluate_gh_view(&view, &empty_baseline()),
+            GateResult::NotReady(_)
+        ));
     }
 
     #[test]
@@ -422,7 +533,7 @@ mod tests {
                 {"conclusion": null, "status": "IN_PROGRESS"},
             ]
         }));
-        let GateResult::NotReady(reason) = evaluate_gh_view(&view) else {
+        let GateResult::NotReady(reason) = evaluate_gh_view(&view, &empty_baseline()) else {
             panic!("expected NotReady");
         };
         assert!(
@@ -441,7 +552,10 @@ mod tests {
             "mergeable": "MERGEABLE",
             "statusCheckRollup": [],
         }));
-        assert!(matches!(evaluate_gh_view(&view), GateResult::Green));
+        assert!(matches!(
+            evaluate_gh_view(&view, &empty_baseline()),
+            GateResult::Green
+        ));
     }
 
     #[test]
@@ -450,7 +564,10 @@ mod tests {
         // as the explicit-empty case above. The serde default keeps
         // the gate robust to gh CLI version drift.
         let view = parse(json!({"state": "OPEN", "mergeable": "MERGEABLE"}));
-        assert!(matches!(evaluate_gh_view(&view), GateResult::Green));
+        assert!(matches!(
+            evaluate_gh_view(&view, &empty_baseline()),
+            GateResult::Green
+        ));
     }
 
     #[test]
@@ -481,5 +598,157 @@ mod tests {
         let _third = acquire_singleton_lock(&tmp).expect("after drop, third acquire succeeds");
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // ------------------------------------------------------------------
+    // Card d5b7b07d — strictly-less-red-than-base
+    // ------------------------------------------------------------------
+
+    fn baseline_with(names: &[&str]) -> std::collections::HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn evaluate_ignores_failure_whose_name_is_in_baseline() {
+        // Card d5b7b07d: the PR has one FAILURE, but that check name
+        // is already failing on base. PR didn't cause it; gate must
+        // pass.
+        let view = parse(json!({
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"conclusion": "SUCCESS", "status": "COMPLETED", "name": "cargo test (macos-latest)"},
+                {"conclusion": "FAILURE", "status": "COMPLETED", "name": "shell syntax + rust cutover guards"},
+            ]
+        }));
+        let baseline = baseline_with(&["shell syntax + rust cutover guards"]);
+        assert!(matches!(
+            evaluate_gh_view(&view, &baseline),
+            GateResult::Green
+        ));
+    }
+
+    #[test]
+    fn evaluate_still_refuses_when_pr_introduces_new_failure() {
+        // Card d5b7b07d: even with one inherited failure, a NEW
+        // PR-side failure (different name) blocks. The bypass is
+        // narrow — it only forgives names that also fail on base.
+        let view = parse(json!({
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"conclusion": "FAILURE", "status": "COMPLETED", "name": "shell syntax + rust cutover guards"},
+                {"conclusion": "FAILURE", "status": "COMPLETED", "name": "cargo test (ubuntu-latest)"},
+            ]
+        }));
+        let baseline = baseline_with(&["shell syntax + rust cutover guards"]);
+        let GateResult::NotReady(reason) = evaluate_gh_view(&view, &baseline) else {
+            panic!("expected NotReady");
+        };
+        assert!(
+            reason.contains("1 failing") && reason.contains("inherited"),
+            "reason should distinguish new from inherited: {reason}"
+        );
+    }
+
+    #[test]
+    fn evaluate_with_empty_baseline_matches_old_strict_behavior() {
+        // Regression: when no baseline known (lookup failed) the gate
+        // falls back to the f16650cd-original strict behavior — no
+        // free passes.
+        let view = parse(json!({
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [
+                {"conclusion": "FAILURE", "status": "COMPLETED", "name": "shell syntax + rust cutover guards"},
+            ]
+        }));
+        let GateResult::NotReady(reason) = evaluate_gh_view(&view, &empty_baseline()) else {
+            panic!("expected NotReady");
+        };
+        assert!(
+            reason.contains("1 failing"),
+            "reason should be unchanged: {reason}"
+        );
+    }
+
+    #[test]
+    fn baseline_failing_names_picks_up_failure_shaped_conclusions() {
+        // Card d5b7b07d: the REST endpoint uses lowercase ("failure")
+        // while gh pr view uses uppercase. baseline_failing_names
+        // must accept both — a case mismatch would silently drop the
+        // base failure and re-block every PR. Also: CANCELLED /
+        // TIMED_OUT count as failure-shaped because they're
+        // failure-shaped from the merger's perspective (something
+        // went wrong, not "the PR passed").
+        let runs = vec![
+            crate::gh_client::GhCheck {
+                conclusion: Some("failure".to_string()),
+                status: Some("completed".to_string()),
+                name: Some("shell syntax + rust cutover guards".to_string()),
+            },
+            crate::gh_client::GhCheck {
+                conclusion: Some("FAILURE".to_string()),
+                status: Some("COMPLETED".to_string()),
+                name: Some("clean-install-linux".to_string()),
+            },
+            crate::gh_client::GhCheck {
+                conclusion: Some("cancelled".to_string()),
+                status: Some("completed".to_string()),
+                name: Some("clean-install-macos".to_string()),
+            },
+            crate::gh_client::GhCheck {
+                conclusion: Some("success".to_string()),
+                status: Some("completed".to_string()),
+                name: Some("cargo fmt --check".to_string()),
+            },
+        ];
+        let set = baseline_failing_names(&runs);
+        assert_eq!(set.len(), 3);
+        assert!(set.contains("shell syntax + rust cutover guards"));
+        assert!(set.contains("clean-install-linux"));
+        assert!(set.contains("clean-install-macos"));
+        assert!(!set.contains("cargo fmt --check"));
+    }
+
+    #[test]
+    fn baseline_failing_names_returns_empty_when_base_is_green() {
+        // Regression: when base is all-green, the set is empty and
+        // the merger gates as old-strict — exactly what we want.
+        let runs = vec![
+            crate::gh_client::GhCheck {
+                conclusion: Some("success".to_string()),
+                status: Some("completed".to_string()),
+                name: Some("cargo fmt --check".to_string()),
+            },
+            crate::gh_client::GhCheck {
+                conclusion: Some("success".to_string()),
+                status: Some("completed".to_string()),
+                name: Some("cargo test (ubuntu-latest)".to_string()),
+            },
+        ];
+        assert!(baseline_failing_names(&runs).is_empty());
+    }
+
+    #[test]
+    fn parse_check_runs_handles_rest_envelope() {
+        // The REST `/check-runs` endpoint wraps results in a
+        // {total_count, check_runs: [...]} envelope. Pin that we
+        // project to just the run list — anything else (like
+        // returning the whole envelope) and the merger can't
+        // typecheck against GhCheck.
+        let json = serde_json::json!({
+            "total_count": 2,
+            "check_runs": [
+                {"name": "cargo fmt --check", "status": "completed", "conclusion": "success"},
+                {"name": "cargo test (windows-latest)", "status": "in_progress", "conclusion": null},
+            ]
+        });
+        let runs = airc_lib::gh_client::parse_check_runs(json.to_string().as_bytes())
+            .expect("envelope parses");
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].name.as_deref(), Some("cargo fmt --check"));
+        assert_eq!(runs[1].conclusion.as_deref(), None);
+        assert_eq!(runs[1].status.as_deref(), Some("in_progress"));
     }
 }

--- a/crates/airc-lib/src/gh_client.rs
+++ b/crates/airc-lib/src/gh_client.rs
@@ -128,6 +128,16 @@ pub trait GhClient: Send + Sync {
     /// supplied `base` ref. Workaround for the Projects-classic
     /// deprecation that breaks `gh pr edit --base` (card 3bf62fbb).
     async fn pr_edit_base(&self, args: PrEditBaseArgs) -> Result<(), GhError>;
+
+    /// `gh api repos/{owner}/{repo}/commits/{branch}/check-runs`.
+    /// Card d5b7b07d — fetches the check-run rollup for an arbitrary
+    /// branch's HEAD so the merger can implement the
+    /// strictly-less-red-than-base doctrine (failures inherited from
+    /// the integration branch don't block per-PR gates).
+    async fn branch_check_rollup(
+        &self,
+        args: BranchCheckRollupArgs,
+    ) -> Result<Vec<GhCheck>, GhError>;
 }
 
 #[derive(Debug, Clone)]
@@ -160,6 +170,14 @@ pub struct PrEditBaseArgs {
     pub repo: String,
     pub number: u64,
     pub base: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct BranchCheckRollupArgs {
+    pub repo: String,
+    /// Branch name (e.g. `"rust-rewrite"`). Resolved by gh against
+    /// `repos/{owner}/{repo}/commits/{branch}/check-runs`. Card d5b7b07d.
+    pub branch: String,
 }
 
 /// `gh pr view --json state,mergeable,statusCheckRollup` shape.
@@ -203,6 +221,22 @@ pub struct MergeReceipt {
 /// schema round-trip is pinned in tests.
 pub fn parse_pr_view(json: &[u8]) -> Result<PrView, GhError> {
     Ok(serde_json::from_slice(json)?)
+}
+
+/// Decode `gh api /repos/.../check-runs` (REST shape) into the same
+/// [`GhCheck`] type the merger uses for PR rollups. Pure — synthetic
+/// JSON in, typed values out. The REST endpoint wraps results in
+/// `{total_count, check_runs: [...]}`; we project to just the run
+/// list since the merger doesn't care about pagination metadata.
+/// Card d5b7b07d.
+pub fn parse_check_runs(json: &[u8]) -> Result<Vec<GhCheck>, GhError> {
+    #[derive(Deserialize)]
+    struct Envelope {
+        #[serde(default)]
+        check_runs: Vec<GhCheck>,
+    }
+    let env: Envelope = serde_json::from_slice(json)?;
+    Ok(env.check_runs)
 }
 
 /// Extract the PR URL + number from `gh pr create`'s plain-text


### PR DESCRIPTION
- fix(codex): poll inbox after sending airc messages (#556)
- feat(knock): public collaboration knock entrypoint (airc#559 PR-1) (#560)
- feat(approve): forward-secret room-invite handoff (airc#559 PR-2) (#561)
- feat(queue): add issue-backed queue add/list
- feat(queue): claim/release/set-status verbs (airc#562 PR-2) (#568)
- feat(queue): nudge verb — surface card to peers (airc#562 PR-3) (#573)
- fix(#571): route every gh body write through --body-file (lib_gh.sh) (#574)
- feat(queue): repo-scoped nudge status sweep (#578)
- fix(gh): safely close issues with markdown comments (#582)
- feat(queue): adopt existing issues into queue cards (#583)
- feat(lane): add worktree lanes for agents (#585)
- feat(queue): summarize repo nudge pongs (#586)
- feat(#576): auto-close queue cards when PRs merge into canary (#581)
- fix(#576): detect queue refs in PR titles (#587)
- feat(#572): queue heartbeat and stale scan (#588)
- feat(#570): embeddable queue and room widgets (#589)
- feat(#591): summarize queue availability (#592)
- fix(#593): ignore repo-nudge templates in pongs (#594)
- fix(#596): honor per-agent queue owner (#597)
- fix: add session work identity for queue ownership (#598)
- fix(queue): close already-merged queue cards (#599)
- fix(queue): require closing keywords for close-merged
- fix(queue): preserve issue titles
- feat(queue): recommend next work for idle agents
- feat(queue): allow cross-repo close-merged
- feat(queue): add metronome idle pulse
- fix(queue): prevent accidental claim takeovers
- docs(readme): document AI work queue workflow (#614)
- feat(queue): warn on stale PR branches (#617)
- refactor(queue): split command helpers (#618)
- fix(queue): default planning view and unclaimed-owner semantics (#620)
- Fix collaboration health for same-nick peers (#625)
- fix(lane): hydrate submodules after worktree add (continuum#1252) (#624)
- feat(queue): personalized dispatch verb (closes continuum#1192 broadcast→idle gap) (#623)
- fix(queue): dispatch metronome hand-outs (#627)
- feat: add hygiene policy command (#632)
- fix: fail closed on update conflicts (#633)
- docs: design rust sqlite substrate (#634)
- docs: design realtime event bus (#635)
- feat(queue): add steward dry-run digest (#636)
- feat(core): add Rust transcript primitives (#637)
- feat(logs): add json transcript pages (#638)
- fix(logs): avoid strict-mode crash without json flag (#639)
- refactor(logs): use one render path for human and json modes (#640)
- feat(queue): metronome fan-out across active roster (airc#607, continuum#1192) (#641)
- docs: propose manager-role + lane substrate for airc (#642)
- docs: add lane-kanban-protocol — engineering spec for the lane substrate (#643)
- feat(heartbeat): peer-liveness envelope kind + cmd_peers tracking (airc#644 PR-1) (#645)
- hotfix: cmd_peers Python comment backtick broke airc peers in production (#645 follow-up) (#646)
- feat(heartbeat): wire emission — cmd_send --heartbeat + reminder_timer_loop hook + monitor filter (airc#644 PR-2) (#647)
- fix(heartbeat): allow empty body when --heartbeat (caught live; airc#644 PR-2 follow-up) (#648)
- fix(heartbeat): second empty-body rejection path also needed exemption (airc#644 PR-2 follow-up #2) (#649)
- fix(airc): surface sender client_id on pm-tag so multi-tab agents are distinguishable (#650)
- docs(architecture): airc-rust substrate design — generic messaging/event/network layer (DRAFT) (#651)
- feat(airc-blobs): Phase 1 scaffold — ContentAddressedStore trait + ContentHash + MediaRef (#653)
- feat(airc-blobs): FsStore — filesystem-backed sha256-addressed content store (#655)
- docs(airc-rust): Contract Layer: forge-alloy (substrate vs contract boundary) (#657)
- feat(airc-core): Identity struct + modular split (one concern per file) (#654)
- feat(airc-core): Body enum (Json | Binary) — opaque payload primitive (#656)
- feat(airc-blobs): GC + retention policy — age-based + capacity-based (#660)
- feat(airc-core): convert ID newtypes from String to UUIDv4
- feat(airc-core): envelope Headers dictionary + HeaderFilter predicate
- feat(airc-protocol): wire-level envelope, Frame, signature, subscription, LiftPolicy
- feat(airc-transport): Transport trait + LocalFsAdapter (same-Mac wire)
- fix(airc-transport): tail_loop recovers from frames.jsonl truncation/recreation
- feat(airc-protocol): real Ed25519 signing + verify (closes PR-1 stub)
- feat(airc-transport): TLS peer-pinning infrastructure (cert gen + verifiers)
- feat(airc-transport): LanTcpAdapter — TLS-wrapped TCP with peer-pinned mTLS
- feat(airc-transport): SignedTransport<T> — per-frame Ed25519 sign + verify wrapper
- feat(airc-cli): airc-rs binary — first Rust replacement for Python airc
- test(airc-cli): e2e — two airc-rs subprocesses chat over the substrate
- feat(airc-cli): daemon mode — Unix socket IPC + typed Request/Response
- fix(airc-transport): LAN-TCP readiness race + subscribers-lock-during-await
- feat(airc-cli): daemon Subscribe + Inbox — buffered consume-once reads (#678)
- style(airc-blobs): apply current rustfmt rules (#677)
- feat(airc-transport): multi-peer LanTcpAdapter (#679)
- refactor(airc-transport): split lan_tcp::adapter into module (one concern per file) (#680)
- feat(airc-cli): persisted identity state — stable peer_id + client_id (#681)
- feat(airc-cli): persistent peer registry — peers.json + daemon AddPeer/ListPeers (#682)
- feat(airc-cli): cross-platform daemon — Unix sockets + Windows named pipes (#683)
- ci: rust quality gates — fmt + clippy (deny warnings) + test on every Rust PR (#661)
- docs(airc-rust): replace body_hint with HTTP-style Headers dictionary (reopen of #658) (#662)
- docs(airc-rust): UUIDv4 for every identifier + three-field identity model (reopen of #659) (#663)
- feat(airc-cli): per-user room state — drop --wire/--channel parameter hell (#684)
- fix(airc-cli): Windows pipe-name uniqueness — UUIDv5 over full path (#685)
- fix(codex-hooks): rename TOML key codex_hooks → hooks + auto-migrate (#686)
- fix(airc-transport): LAN-TCP send pre-validates payload, no silent drops (#687)
- feat(airc-store): SeaORM-backed event store crate (slice 4 foundation) (#688)
- refactor: split daemon runtime into airc-daemon crate (slice 5 relocation) (#689)
- feat(airc-daemon): wire airc-store as the inbox backing (slice 5b) (#690)
- feat(airc-lib): consumer-facing facade crate (slice 6) (#691)
- feat(airc-lib): live subscriptions + auto-populate store on say (slice 6b) (#692)
- refactor(airc-cli): commands route through airc_lib::Airc (slice 6c) (#693)
- docs(operating-board): work-coordination domain plan (Codex design) (#694)
- feat(airc-work): typed work coordination domain (#695)
- feat(airc-work): add routable event codec (#696)
- feat(airc-work): replay work events from transcripts (#697)
- feat(airc-work-store): project persisted work events (#698)
- feat(airc-lib): expose work coordination API (#699)
- feat(airc-cli): add work coordination commands (#700)
- feat(airc-cli): add lane coordination commands (#701)
- feat(airc-cli): add workspace lease commands (#702)
- feat(airc-cli): add manager hat commands (#703)
- feat(airc-lib): add filtered event subscriptions (#704)
- feat(airc-cli): add Rust Codex hook context (#705)
- feat(airc-cli): install Codex hooks from Rust (#706)
- feat(codex): route hooks through Rust CLI (#707)
- feat(install): build and install airc-rs (#708)
- refactor(codex): remove Python hook adapters (#709)
- ci: add runtime guard checks for rust-rewrite (#710)
- refactor(codex): move detached start into Rust (#711)
- feat(airc-rs): move client identity mnemonics to rust (#712)
- feat(airc-rs): move iso timestamp parsing to rust (#713)
- feat(airc-rs): move log append and rotate to rust (#714)
- feat(airc-rs): move bearer state reads to rust (#715)
- feat(airc-rs): move logs render to rust (#716)
- feat(airc-rs): move gist JSON parsing to rust (#717)
- feat(airc-transport): add gh gist bootstrap adapter (#718)
- feat(airc-lib): add explicit transport route policy (#719)
- feat(airc-lib): add transport resolver shell (#720)
- feat(airc-lib): feed resolver from transport health (#721)
- feat(airc-rs): expose transport route status (#722)
- feat(airc-rs): move transport health to rust (#723)
- feat(airc-rs): read subscribed channels from rust (#724)
- feat(airc-rs): move channel gist config reads to rust (#725)
- feat(airc-rs): move channel config writes to rust (#726)
- feat(airc-rs): move generic config state to rust (#727)
- feat(airc-rs): move host config block to rust (#728)
- feat(airc-rs): derive daemon scope ids in rust (#729)
- feat(airc-rs): parse doctor rate-limit json in rust (#730)
- feat(airc-rs): render whois identity output in rust (#731)
- feat(airc-cli): move message crypto helpers to Rust (#732)
- feat(airc-cli): move control-plane helpers to Rust (#733)
- feat(airc-cli): build legacy message JSON in Rust (#734)
- feat(airc-cli): move channel gist discovery to Rust (#735)
- feat(airc-cli): move channel gist resolve to Rust (#736)
- feat(airc-cli): move bearer send to Rust (#737)
- refactor(airc-cli): split bearer send modules (#738)
- feat(airc-cli): move bearer recv to Rust (#739)
- feat(airc-cli): move monitor formatter to Rust (#740)
- feat(airc-cli): move local attach tail to Rust (#741)
- feat(airc-cli): move pair handshake to Rust (#742)
- feat(airc-cli): move scope repair to Rust (#743)
- feat(airc-cli): move collaboration health to Rust (#744)
- feat(airc-cli): move inbox cursoring to Rust (#745)
- feat(airc-cli): move hygiene policy to Rust (#746)
- feat(airc-cli): move knock approval crypto to Rust (#747)
- feat(airc-cli): move knock identity JSON to Rust (#748)
- feat(airc-cli): move kick peer ssh lookup to Rust (#749)
- feat(airc-cli): move worktree lane registry to Rust (#750)
- feat(airc-cli): move local identity state to Rust (#751)
- feat(airc-cli): move runtime JSON helpers to Rust (#752)
- feat(airc-cli): move queue card core to Rust (#753)
- feat(airc-cli): move queue projections to Rust (#754)
- feat(airc-cli): move queue runtime summaries to Rust (#755)
- feat(airc-cli): move queue staleness metadata to Rust (#756)
- feat(airc-cli): move queue staleness analyzer to Rust (#757)
- feat(airc-cli): move queue close-merged parsing to Rust (#758)
- feat(queue): move plan and steward projections to rust (#759)
- feat(collaboration): move peers listing to rust (#760)
- fix(invite): read channel gist through rust config (#761)
- feat(identity): move rename collision scan to rust (#762)
- feat(network): move LAN IP probe to rust (#763)
- feat(runtime): drop wrapper python startup (#764)
- feat(install): remove python runtime bootstrap (#765)
- chore(runtime): remove python debug path (#766)
- test(integration): drop legacy python unit gate (#767)
- test(integration): probe bearer kinds through rust (#768)
- test(integration): scaffold ed25519 identity through rust (#769)
- test(integration): edit top-level config through rust (#770)
- feat(config): probe quit fixtures through rust (#771)
- test(integration): probe away status through rust (#772)
- test(integration): probe tabs state through rust (#773)
- test(integration): probe heartbeat gist through rust (#774)
- fix(heartbeat): patch takeover gist lease deterministically (#775)
- test(integration): probe status outage through rust (#776)
- test(integration): probe bearer config through rust (#777)
- test(integration): probe sidecar channels through rust (#778)
- test(integration): probe channel gists through rust (#779)
- test(integration): probe bearer outcome through rust (#780)
- feat(gist): extract named file content through rust (#781)
- test(integration): probe JSON predicates through rust (#782)
- test(integration): route bearer and channel gist through rust (#783)
- test(integration): probe liveness events through rust (#784)
- fix(handshake): accept hyphen-leading public key values (#785)
- test(integration): delete legacy python bearer scenarios (#786)
- test(integration): route gh bearer scenario through rust (#787)
- test(integration): fake gone gist sends through airc-rs (#788)
- test(integration): generate gist rotation seed without python (#789)
- test(integration): remove python from platform adapters scenario (#790)
- install: stop documenting python runtime setup (#791)
- runtime: remove live airc_core references (#792)
- runtime: delete python airc_core layer (#793)
- fix(status): host health ignores joiner bearer pidfiles (#794)
- docs(architecture): transport control plane admission (#795)
- fix: fail closed on production fallback paths (#796)
- docs: define robustness integration plan (#797)
- refactor: remove fallback runtime surfaces (#798)
- ci: enforce Rust quality contracts (#799)
- fix(doctor): keep local health independent of GitHub (#800)
- docs: define invite-only gist routing architecture (#801)
- feat(routes): enforce invite-only gist admission (#802)
- feat(lib): gate sends through route resolver (#803)
- feat(lib): execute SDK sends over LAN routes (#804)
- refactor(cli): route LAN commands through airc-lib (#805)
- feat(lib): organize route discovery and health (#806)
- docs: update route requirements status (#807)
- docs: group route work into PR slices (#808)
- feat(lib): discover local route health (#809)
- feat(route): make gist an invite beacon (#810)
- feat(lib): attach SDK to daemon IPC (#811)
- refactor(cli): route daemon msg and inbox through SDK (#812)
- fix(cli): accept legacy message build command (#814)
- feat(airc-work): drain typing — workspace pressure/drain events + projection (Slice 7 PR 3a) (#813)
- feat(shell): route plain msg through rust local substrate (#815)
- feat(shell): read rust local inbox by default (#817)
- feat(airc-relay): baseline relay server + transport adapter (PR-E) (#816)
- feat(airc-transport): add realtime UDP adapter (#818)
- feat(trust-rotation): signed peer trust rotation contract + daemon application (PR-H) (#819)
- feat(airc-transport): add WebRTC datachannel adapter (#820)
- test(examples): prove SDK consumer embedding path (#821)
- test(examples): prove agent dogfood consumer path (#822)
- feat(examples): consumer integration shape contracts — Continuum/OpenClaw/Hermes (PR-I3) (#823)
- test(cli): prove installed agent identities dogfood live room (#824)
- fix(status): surface rust local data plane before gh bearer (#825)
- fix(codex-hook): pin rust hook executable and honor cursor overrides (#826)
- docs(readme): rework for the post-rewrite substrate (#827)
- fix(workspace): keep lane roots under airc home (#828)
- fix(monitor): attach to Rust event stream (#830)
- fix(teardown): verify live process reaping (#832)
- fix(install): remove rust suffix from airc surface (#833)
- fix(install): use ~/.airc/src as the source root (#835)
- feat(work): drain policy evaluator — pure substrate primitive (#834)
- fix(install): use source command as POSIX entrypoint (#836)
- fix(shell): resolve airc-core from source install (#837)
- fix(status): treat rust-local as routine health (#838)
- fix(install): PATH-augment is newline-safe + strips stale airc lines
- fix(install): rc reconcile no longer short-circuits on in-shell PATH
- fix(codex-hook): install source command path (#839)
- fix(msg): distinguish local store from peer delivery (#840)
- feat(lib): SubscriptionSet + ChannelName + identity-namespaced RoomId (#841)
- fix(events): monitor hooks use subscribed channels (#842)
- feat(lib): mesh identity resolution — replace MeshIdentity::unset() (#843)
- fix(lib): share same-machine account local wire (#844)
- feat(lib): add account room coordinator (#845)
- fix(join): seed rust account rooms from wrapper (#846)
- fix(install): put airc shim on POSIX PATH (#847)
- test(install): gate public airc shim path (#848)
- docs(install): define AI agent install contract (#849)
- test(install): prove public airc account-room runtime (#851)
- feat(lib): machine-global account coordinator (Gap 8) (#850)
- feat(lib): wire account join discovery into local delivery (#852)
- test(install): prove public monitor and hook delivery (#853)
- feat(lib): add account registry bootstrap contract (#854)
- fix(cli): route local join and broadcast through Rust (#855)
- fix(status): show rust command mode after stale startup (#856)
- fix(lib): cross-process chat actually delivers — live_tx fans out on DuplicateEventId (#857)
- fix(status): count Rust-substrate peers, not just legacy peers/ dir (#858)
- fix(send/msg): receipt no longer lies about non-delivery on shared-home wire (#859)
- feat(join): explicit scope + mesh-kind in output (#860)
- fix(join): label canonical HOME scope as machine-account home (#861)
- feat(lib): cross-machine bootstrap via gh-gist account-mesh registry (#862)
- fix(airc): restore project scope and runtime hook identity (#863)
- feat: demolition — bash wrapper deleted, airc IS the Rust binary (#864)
- fix(ci): runtime-guards green post-demolition (#865)
- fix(registry): no --paginate; bound sync with timeout; tests disable (#867)
- fix(mesh-identity): Operator-source cache never expires; bound shell-outs (#868)
- fix(airc): make join own daemon live delivery (#866)
- fix(codex-hook): trust airc.client header on shared-HOME identity (#869)
- feat(cli): restore airc join --attach and airc version subcommand (#870)
- fix(join): ensure Codex hook setup (#871)
- docs(skill): tab-loop semantics for bidirectional agent coordination (#872)
- fix(install): prefer current source tree (#873)
- fix(cli): airc join always streams ALL subscribed rooms; remove --attach (#876)
- test(join): pin runtime attach decision (#877)
- fix(join): detect Codex runtime via client identity (#878)
- docs(architecture): establish grid substrate audit (#879)
- fix(join): persist live feed cursor (#880)
- fix(store): persist runtime cursors through SeaORM (#882)
- docs(architecture): Phase 3.5 ORM end-to-end + Phase 3.6 perf hotpaths (#881)
- fix(store): persist peer trust through ORM (#883)
- fix(store): persist subscriptions through ORM (#884)
- fix(store): persist local identity metadata through ORM (#885)
- fix(store): persist mesh identity through ORM (#886)
- fix(store): persist account registry through ORM (#887)
- fix(store): persist coordinator beacons through ORM (#888)
- cleanup(lib): remove file-backed coordinator beacons (#889)
- cleanup(cli): remove config.json command shim (#890)
- refactor(identity): store-backed identity commands (#891)
- refactor(cli): remove config repair scope command (#892)
- refactor(transport): report substrate route health (#893)
- refactor(cli): remove bearer state command (#894)
- refactor(cli): remove recent senders command (#895)
- refactor(cli): remove legacy log scraping surface (#896)
- refactor(collaboration): remove jsonl presence scans (#897)
- refactor(identity): remove jsonl rename collision helper (#898)
- refactor(cli): remove legacy bearer command (#899)
- refactor(cli): remove jsonl message builder (#900)
- fix(install): copy artifacts instead of symlinking (#901)
- fix(identity): migrate identity json into orm state (#902)
- fix(lib): report peers from account mesh registry (#903)
- fix(cli): agent-runtime attach decision wins over piped-stdout (#904)
- fix(lib): wire replay skips unverifiable frames instead of aborting (#905)
- docs(codex): clarify live feed contract (#906)
- refactor(cli): isolate runtime context classification (#908)
- docs: AR/Cambrian/grid framing + data-model + Phase 3.5 migration (#907)
- refactor(cli): move codex integration behind boundary (#910)
- feat(cli): airc doctor — install + identity + scope self-diagnosis (#909)
- feat(lib): expose subscription query API (#911)
- feat(lib): command-bus primitive (Airc::request / reply / await_reply) (#912)
- docs: CI fidelity as substrate non-negotiable (#10) (#913)
- test(cli): emulate join attach in e2e harness (#915)
- feat(lib): typed lifecycle events (Phase 2) (#914)
- feat(work): add git and PR event contracts (#917)
- feat(lib): emit PeerArrived lifecycle event on add_peer (Phase 2 cont.) (#916)
- feat(work): add local git watcher adapter (#918)
- feat(lib): emit WireEstablished lifecycle event (Phase 2 cont.) (#919)
- docs: require roadmap reference in PR template (#920)
- ci: enforce PR roadmap references (#921)
- feat(lib): emit SubscriptionAdvanced on cursor saves (#922)
- feat(lib): emit RoomParted lifecycle events (#924)
- feat(lib): emit PeerDeparted lifecycle events (#925)
- ci: keep roadmap references as PR template guidance (#926)
- feat(airc-lib): WireLost emit on stream-end + teardown (#923)
- feat(codex): add pollable AIRC feed command (#927)
- test(install): prove Codex poll in public runtime (#928)
- fix(lib): keep routine wire replay quiet (#929)
- feat(cli): add Rust update command (#930)
- refactor(store): move coordinator refresh lock into ORM (#931)
- perf(lib): use set-backed event dedup (#932)
- perf(lib): broadcast live events by arc (#933)
- perf(protocol): remove global peer registry lock (#934)
- perf(lib): remove global route table locks (#935)
- perf(lib): own local ingest task lifecycle (#936)
- perf(lib): use set-backed subscription dedup (#937)
- perf(lib): shorten subscriber setup locks (#938)
- perf(lib): make event filter channels set-backed (#939)
- refactor(daemon): length-frame ipc with cbor (#940)
- fix(cli): restart daemon during update (#941)
- refactor(ipc): split daemon IPC contract into crate (#942)
- refactor(identity): split local identity into crate (#943)
- refactor(trust): split peer trust into crate (#944)
- test(command-bus): prove request reply over LAN (#945)
- feat(airc-lib): execute relay routes through SDK (#946)
- test(consumer-shapes): prove command bus integration (#948)
- feat(airc-work): PR observation adapter skeleton (#947)
- docs(audit): refresh immediate queue after PR adapter (#949)
- feat(airc-work): real gh PullRequestSource over GhCommandRunner (#950)
- docs(readme): restore generic agent IRC framing (#951)
- fix(ipc): version daemon endpoint by protocol (#952)
- fix(daemon): refresh wire trust for live ingest (#953)
- test(airc-lib): prove Continuum-shaped room throughput (#954)
- feat(airc-lib): wire UDP route execution + WebRTC signaling types (#955)
- feat(airc-lib): WebRTC DataChannel orchestration over AIRC mesh (#957)
- docs(webrtc): media tracks plan and implementation split (#959)
- feat(airc-lib): surface incoming WebRTC media tracks (#960)
- feat(airc-lib): add WebRTC media track builder (#961)
- test(airc-lib): prove WebRTC audio and video tracks (#962)
- test(airc-lib): prove WebRTC media and control share a session (#963)
- docs(audit): note observed AIRC coordination flaws (#964)
- fix(cli): restore IRC-shaped peers and whois commands (#966)
- docs(webrtc): show Continuum live-room integration example (#967)
- feat(work): heartbeat claims and surface stale owners (#969)
- feat(work): publish agent availability state (#971)
- feat(diagnostics): add typed substrate diagnostic sink (#973)
- feat(airc-lib): typed lane-coordination events (#965)
- feat(airc-lib): active-agent heartbeat events (#968)
- feat(airc-cli): bake build sha + drift detection in doctor (#972)
- feat(work): suggest claimable cards for agents (#975)
- feat(work): surface claimable queue suggestions in agent feeds (#976)
- feat(airc-lib): typed work-event subscription API (#974)
- feat(work): close completed cards (#977)
- fix(work): tolerate bounded board replay windows (#979)
- feat(airc-lib): AIRC-event diagnostic sink + doctor surface (#978)
- fix(work): preserve terminal state on claim release (#980)
- docs(audit): consumer integration gap audit + follow-up cards (#981)
- docs(audit): roadmap-to-card coverage + missing-card cleanup (#982)
- feat(work): surface agent availability in queue status (#983)
- test(lib): prove Continuum pose fan-out throughput (#984)
- feat(work): render typed agent roster (#986)
- fix(work): make duplicate claim release idempotent (#987)
- feat(airc-lib): external-identity bridge contract (#985)
- feat(work): enforce lease-zone for work claim + heartbeat diagnostic (#988)
- feat(route): add JSON route proof harness (#989)
- feat(publish): structured publish API + airc publish JSON-receipt CLI (#990)
- feat(events): add JSON list output (#991)
- docs: define cooperative coordination training signal (#992)
- fix(work): reject card transitions from wrong room (#993)
- fix(join): replace stale daemon builds from typed status (#994)
- fix(work): tolerate superseded claim release + ghost heartbeat (#996)
- feat(work): publish active-agent roster heartbeats from join (#997)
- fix(work): correlate peer claims to live roster clients (#998)
- feat(work): add typed manager loop evaluation (#999)
- docs(airc): add runtime planning and consumer audit lanes (#1000)
- docs(airc): define autonomous development roadmap (#1001)
- fix(work): find active cards beyond small recent windows (#1004)
- fix(work-store): tolerate orphaned events in complete projection (#1005)
- fix(work): schedule from complete work projection (#1006)
- feat(work): seed backlog from manager candidates (#1008)
- fix(work): make stale claims recoverable by default (#1009)
- feat(ipc): add ResolveWireRequest (channel uuid -> wire path lookup) (#1011)
- feat(inbox): --json flag for machine-readable output (#1010)
- fix(work): exclude terminal cards from stale recovery (#1012)
- fix(identity): resolve mesh identity against machine-global coordinator store (#1014)
- perf(bus): decoupled delivery bus — kill same-machine poll/fsync latency (#1015)
- fix(test): isolate two-machine bridge test via explicit wire roots — repairs Windows CI (#1016)
- docs(arch): airc event-server design — efficient ORM+push routing server (#1017)
- feat(airc-bus): owner-core event router — sharded router + hot ring + generational cursor + zero-copy fan-out (#1018)
- test(e2e): realistic timeout for process-spawn round-trips (fix macOS flake) (#1020)
- fix(reliability): LAN send-flush + lan-listen subscribe order + daemon-shutdown hang (#1021)
- feat(store): SQLite-backed DurableSink — owner-core ORM durable tier (§3.3) (#1019)
- feat(store): persistent EpochStore — generational epoch survives daemon restart (§3.8) (#1022)
- feat(wire): airc-wire — FlatBuffers binary codec for the envelope (zero-copy payload) (#1023)
- feat(work+lib+cli): autonomous-team substrate end-to-end (19 cards) (#1025)
- fix(cli): airc work state review uses Command::current_dir, not gh -C (card a4fe899f) (#1027)
- fix(cli): airc work state X merged refused — only PullRequestMerged event sets Merged (card a1bc62b3) (#1028)
- feat(store): add agent_name column to local_identity (card 8384cc18 Sub-A) (#1030)
- fix(identity): provisional git-email identity self-heals to gh login (one identity per machine) (#1024)
- fix(cli): default_home_dir skips machine-account ~/.airc + resolves to main working tree from a worktree (card a1b4552a) (#1029)
- fix(lib): work_board filters heartbeats out of the projection page (card 79953b4d) (#1031)
- fix(cli): airc work state Closed refuses unless from Merged or pre-work state (card 9656a836) (#1026)
- docs(agents): encode engineering-staff framing — CI-green-before-merge, branch hygiene, monitoring (card 53698eb9) (#1032)
- fix(install): recover from stale Rust toolchain instead of cryptic build abort (#1013)
- ef168afe/airc ci re green rust rewrite accumulate (#1033)
- fix(cli): gh pr create reads commit subject as title — not branch slug (card 13131f1c) (#1034)
- 28f1440c/airc work state review open pr and link (#1035)
- feat(cli+lib): continuous-merge — `airc work merger run` auto-merges Review cards whose PRs are CI-green (card f16650cd) (#1037)
- feat(cli): cross-sandbox daemon discovery — sandboxed agents attach to project daemon (card 282850c2) (#1036)
- dec35ec7/airc cli introduce typed ghclient gitcli (#1041)
- refactor(cli): split work_commands.rs phase 4 — extract gh module (FINAL, card c7bdf2df) (#1049)
- fix(cli): airc status auto-spawns daemon on miss — restores onboarding contract (card 2bdae532) (#1050)
- fix(work): wire pr_create_base_branch into gh pr create --base (card 812b5a1b) (#1058)
- fix(store): drop local identity singleton check (#1051)
- feat(store): load_local_identity_by_agent_name read API (8384cc18 Sub-C) (#1053)
- feat(merger): strictly-less-red-than-base — ignore failures inherited from rust-rewrite (card d5b7b07d)
