### PR TITLE
feat(trust): TrustTier Sub-B — set_tier API + detect_tier policy + is_local_machine_home helper (card 88093be9)

### DIFF
--- a/crates/airc-store/src/entities/peer_trust.rs
+++ b/crates/airc-store/src/entities/peer_trust.rs
@@ -12,6 +12,12 @@ pub struct Model {
     pub peer_id: Uuid,
     pub pubkey_b64: String,
     pub added_at_ms: i64,
+    /// Card 34942ec1 Sub-A: trust gradient column.
+    /// Wire-string of [`crate::peer_trust::TrustTier`]. Default
+    /// "untrusted" applied at migration time so pre-Sub-A rows
+    /// keep working without a backfill pass.
+    #[sea_orm(default_value = "untrusted")]
+    pub tier: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/airc-store/src/error.rs
+++ b/crates/airc-store/src/error.rs
@@ -38,6 +38,15 @@ pub enum StoreError {
     #[error("invalid stored value for {field}: {value}")]
     InvalidStoredValue { field: &'static str, value: i128 },
 
+    /// Stored string value doesn't round-trip through the Rust enum
+    /// it was supposed to come from. Card 34942ec1 Sub-A: trust tier
+    /// is stored as a wire string; an unknown variant means version
+    /// skew (a newer binary wrote a tier this binary doesn't know),
+    /// which must surface honestly rather than silently downgrading
+    /// to a default.
+    #[error("invalid stored enum string for {column}: {value:?}")]
+    InvalidStoredEnumString { column: &'static str, value: String },
+
     /// Expected row is absent.
     #[error("store row not found: {0}")]
     NotFound(&'static str),

--- a/crates/airc-store/src/lib.rs
+++ b/crates/airc-store/src/lib.rs
@@ -60,7 +60,7 @@ pub use error::StoreError;
 pub use local_identity::{StoredLocalIdentity, DEFAULT_AGENT_NAME};
 pub use memory::InMemoryEventStore;
 pub use mesh_identity::StoredMeshIdentity;
-pub use peer_trust::{RotationAuditEntry, StoredPeer};
+pub use peer_trust::{RotationAuditEntry, StoredPeer, TrustTier};
 pub use refresh_lock::{StoredRefreshLock, StoredRefreshLockOutcome};
 pub use sqlite::SqliteEventStore;
 pub use store::EventStore;

--- a/crates/airc-store/src/migration/m20260529_000015_add_peer_trust_tier.rs
+++ b/crates/airc-store/src/migration/m20260529_000015_add_peer_trust_tier.rs
@@ -1,0 +1,59 @@
+//! Card 34942ec1 Sub-A — add `tier` discriminator column to
+//! `peer_trust`.
+//!
+//! Purely additive. The column is `TEXT NOT NULL DEFAULT 'untrusted'`,
+//! so every existing row gets the `"untrusted"` tier without touching
+//! its other fields, and no consumer code has to opt in to the new
+//! column to keep working.
+//!
+//! The wire strings come from [`crate::peer_trust::TrustTier::as_wire_str`];
+//! the migration deliberately uses the literal "untrusted" rather than
+//! importing the enum because migration files are pinned at the
+//! schema state they were authored against — a future refactor of
+//! the enum mustn't change what gets written into existing
+//! databases at re-migration time.
+//!
+//! Sub-B (detection: OwnMachine via UDS sibling, OwnAccount via mesh
+//! identity) and Sub-C (consumer-side policy gates) build on this
+//! column without further schema work.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(PeerTrust::Table)
+                    .add_column(
+                        ColumnDef::new(PeerTrust::Tier)
+                            .string()
+                            .not_null()
+                            .default("untrusted"),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(PeerTrust::Table)
+                    .drop_column(PeerTrust::Tier)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum PeerTrust {
+    Table,
+    Tier,
+}

--- a/crates/airc-store/src/migration/mod.rs
+++ b/crates/airc-store/src/migration/mod.rs
@@ -24,6 +24,7 @@ mod m20260526_000011_create_bus_events;
 mod m20260527_000012_create_bus_epoch;
 mod m20260528_000013_add_local_identity_agent_name;
 mod m20260528_000014_drop_local_identity_singleton_check;
+mod m20260529_000015_add_peer_trust_tier;
 
 pub struct Migrator;
 
@@ -45,6 +46,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260527_000012_create_bus_epoch::Migration),
             Box::new(m20260528_000013_add_local_identity_agent_name::Migration),
             Box::new(m20260528_000014_drop_local_identity_singleton_check::Migration),
+            Box::new(m20260529_000015_add_peer_trust_tier::Migration),
         ]
     }
 }

--- a/crates/airc-store/src/peer_trust.rs
+++ b/crates/airc-store/src/peer_trust.rs
@@ -6,11 +6,117 @@ use base64::Engine;
 
 use crate::StoreError;
 
+/// Card 34942ec1 Sub-A — gradient on the peer trust registry.
+///
+/// Substrate doesn't currently distinguish between a peer that's a
+/// process on the same UDS as me ([`TrustTier::OwnMachine`]), a peer
+/// that's some other instance of MY user ([`TrustTier::OwnAccount`]),
+/// a peer I've explicitly enrolled as a known person
+/// ([`TrustTier::Friend`]), and a peer that just showed up
+/// ([`TrustTier::Untrusted`]). All four are "trusted" or "not"
+/// today; that's too coarse for routing decisions consumers want to
+/// make (Continuum wants to know "can I ship a tensor to this
+/// peer," Hermes wants to know "can this peer see my goals").
+///
+/// This Sub-A is the substrate dimension only — no detection logic,
+/// no policy gates. Sub-B (detection) + Sub-C (consumer-side
+/// policies) build on top once the column exists.
+///
+/// Wire strings are stable: changing one is a schema migration, not
+/// a code refactor. The [`Self::ALL_VARIANTS`] round-trip test
+/// catches a forgotten arm. Snake_case matches the convention used
+/// for [`TranscriptKind`] across the codebase.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum TrustTier {
+    /// Peer is co-located on the same physical machine as us —
+    /// reachable via UDS sibling, shares filesystem, identity-key
+    /// rotation requires no key material to leave the machine.
+    /// Highest tier; this is "you and me are the same process tree."
+    OwnMachine,
+    /// Peer authenticates as the same GitHub / mesh account as us
+    /// (e.g. joelteply on a different physical machine). Lower than
+    /// OwnMachine — separate filesystem, separate runtime — but
+    /// substantially higher than Friend because the identity claim
+    /// is the same.
+    OwnAccount,
+    /// Peer is a known person we've explicitly enrolled (Toby on
+    /// his 3090, friend's airc). The trust comes from an
+    /// out-of-band human relationship; the substrate doesn't
+    /// validate which person; it just records that the local
+    /// operator vouched.
+    Friend,
+    /// Peer showed up but has no explicit enrolment beyond
+    /// trust-on-first-use of the pubkey. Default for newly-seen
+    /// peers; consumers should refuse expensive / privacy-sensitive
+    /// operations against Untrusted peers.
+    Untrusted,
+}
+
+impl TrustTier {
+    /// Stable wire string. Schema-bound — changing one of these is a
+    /// migration, not a code change.
+    ///
+    /// Adding a variant: extend the match below AND
+    /// [`Self::from_wire_str`] AND [`Self::ALL_VARIANTS`]. The
+    /// compiler enforces the first via match exhaustiveness; the
+    /// round-trip unit test enforces the other two.
+    pub fn as_wire_str(self) -> &'static str {
+        match self {
+            TrustTier::OwnMachine => "own_machine",
+            TrustTier::OwnAccount => "own_account",
+            TrustTier::Friend => "friend",
+            TrustTier::Untrusted => "untrusted",
+        }
+    }
+
+    /// Inverse of [`Self::as_wire_str`]. Returns `None` for unknown
+    /// strings; callers wrap that into a typed store error so a
+    /// future tier added to an older binary surfaces honestly rather
+    /// than silently downgrading.
+    pub fn from_wire_str(s: &str) -> Option<Self> {
+        Some(match s {
+            "own_machine" => TrustTier::OwnMachine,
+            "own_account" => TrustTier::OwnAccount,
+            "friend" => TrustTier::Friend,
+            "untrusted" => TrustTier::Untrusted,
+            _ => return None,
+        })
+    }
+
+    /// Every variant, in trust-gradient order (highest first). The
+    /// round-trip test iterates this slice; adding a variant without
+    /// extending this constant fails the test.
+    pub const ALL_VARIANTS: &'static [TrustTier] = &[
+        TrustTier::OwnMachine,
+        TrustTier::OwnAccount,
+        TrustTier::Friend,
+        TrustTier::Untrusted,
+    ];
+
+    /// Default for newly-observed peers: [`TrustTier::Untrusted`].
+    /// Centralised so a future "Sub-B detection promoted me to
+    /// OwnAccount" path always has the same starting point.
+    pub const fn default_for_new_peer() -> Self {
+        TrustTier::Untrusted
+    }
+}
+
+impl std::fmt::Display for TrustTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_wire_str())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoredPeer {
     pub peer_id: PeerId,
     pub pubkey_b64: String,
     pub added_at_ms: u64,
+    /// Card 34942ec1 Sub-A: trust gradient. Pre-migration rows
+    /// default to [`TrustTier::Untrusted`]; explicit enrolment
+    /// (Sub-B detection, `airc peer add --tier=…`) sets a higher
+    /// tier.
+    pub tier: TrustTier,
 }
 
 impl StoredPeer {

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -336,6 +336,44 @@ impl SqliteEventStore {
         }))
     }
 
+    /// Card 34942ec1 Sub-B — update the trust tier on an existing
+    /// peer row. Lets the substrate elevate a peer to OwnMachine /
+    /// OwnAccount after detection runs (Sub-B), or lets the operator
+    /// set Friend via the Sub-C CLI surface, without touching the
+    /// peer's pubkey or added_at_ms.
+    ///
+    /// Returns `Ok(None)` if the peer isn't enrolled — the caller
+    /// decides whether that's a structural bug (substrate calling
+    /// set_tier on an unknown peer) or a benign race (peer was
+    /// removed concurrent with the tier write). No row is inserted.
+    ///
+    /// Idempotent: setting the same tier the row already has returns
+    /// the row unchanged.
+    pub async fn set_peer_trust_tier(
+        &self,
+        peer_id: PeerId,
+        tier: TrustTier,
+    ) -> Result<Option<StoredPeer>, StoreError> {
+        let txn = self.db.begin().await?;
+        let Some(existing) = peer_trust::Entity::find_by_id(peer_id.as_uuid())
+            .one(&txn)
+            .await?
+        else {
+            txn.commit().await?;
+            return Ok(None);
+        };
+        let mut active: peer_trust::ActiveModel = existing.clone().into();
+        active.tier = Set(tier.as_wire_str().to_string());
+        peer_trust::Entity::update(active).exec(&txn).await?;
+        txn.commit().await?;
+        Ok(Some(StoredPeer {
+            peer_id,
+            pubkey_b64: existing.pubkey_b64,
+            added_at_ms: i64_to_u64("peer_trust.added_at_ms", existing.added_at_ms)?,
+            tier,
+        }))
+    }
+
     pub async fn append_peer_rotation_audit(
         &self,
         entry: RotationAuditEntry,

--- a/crates/airc-store/src/sqlite.rs
+++ b/crates/airc-store/src/sqlite.rs
@@ -38,7 +38,7 @@ use crate::entities::{
 use crate::error::StoreError;
 use crate::local_identity::StoredLocalIdentity;
 use crate::mesh_identity::StoredMeshIdentity;
-use crate::peer_trust::{RotationAuditEntry, StoredPeer};
+use crate::peer_trust::{RotationAuditEntry, StoredPeer, TrustTier};
 use crate::refresh_lock::StoredRefreshLockOutcome;
 use crate::store::EventStore;
 use crate::subscriptions::StoredSubscription;
@@ -164,10 +164,24 @@ impl SqliteEventStore {
             .await?;
         rows.into_iter()
             .map(|row| {
+                // Card 34942ec1 Sub-A: parse the stored tier wire
+                // string into TrustTier. An unknown string surfaces
+                // honestly via InvalidStoredValue so a forwards-
+                // version-skew bug doesn't silently downgrade trust
+                // (a newer binary writing "own_account" being read
+                // by an older binary that doesn't know that variant
+                // is a real condition we'd want to see).
+                let tier = TrustTier::from_wire_str(&row.tier).ok_or_else(|| {
+                    StoreError::InvalidStoredEnumString {
+                        column: "peer_trust.tier",
+                        value: row.tier.clone(),
+                    }
+                })?;
                 Ok(StoredPeer {
                     peer_id: PeerId::from_uuid(row.peer_id),
                     pubkey_b64: row.pubkey_b64,
                     added_at_ms: i64_to_u64("peer_trust.added_at_ms", row.added_at_ms)?,
+                    tier,
                 })
             })
             .collect()
@@ -179,10 +193,38 @@ impl SqliteEventStore {
         pubkey_b64: String,
         added_at_ms: u64,
     ) -> Result<StoredPeer, StoreError> {
+        // Card 34942ec1 Sub-A: defaults to the safe-conservative
+        // tier (Untrusted). Sub-B detection and explicit-enrolment
+        // CLI paths land via [`set_peer_trust_tier`] in a follow-up
+        // PR; this one keeps the existing add() contract identical
+        // (no API churn for current callers).
+        self.add_peer_trust_with_tier(
+            peer_id,
+            pubkey_b64,
+            added_at_ms,
+            TrustTier::default_for_new_peer(),
+        )
+        .await
+    }
+
+    /// Card 34942ec1 Sub-A — variant of [`Self::add_peer_trust`] that
+    /// lets the caller set an explicit tier at insert time. For new
+    /// rows only; doesn't change an existing row's tier (an existing
+    /// row keeps its stored tier — promoting/demoting goes through
+    /// the separate tier-update path Sub-B introduces). Same
+    /// pubkey-conflict semantics as add().
+    pub async fn add_peer_trust_with_tier(
+        &self,
+        peer_id: PeerId,
+        pubkey_b64: String,
+        added_at_ms: u64,
+        tier: TrustTier,
+    ) -> Result<StoredPeer, StoreError> {
         let active = peer_trust::ActiveModel {
             peer_id: Set(peer_id.as_uuid()),
             pubkey_b64: Set(pubkey_b64.clone()),
             added_at_ms: Set(u64_to_i64("peer_trust.added_at_ms", added_at_ms)?),
+            tier: Set(tier.as_wire_str().to_string()),
         };
         let insert = peer_trust::Entity::insert(active)
             .on_conflict(
@@ -212,10 +254,17 @@ impl SqliteEventStore {
                 attempted_pubkey_b64: pubkey_b64,
             });
         }
+        let stored_tier = TrustTier::from_wire_str(&stored.tier).ok_or_else(|| {
+            StoreError::InvalidStoredEnumString {
+                column: "peer_trust.tier",
+                value: stored.tier.clone(),
+            }
+        })?;
         Ok(StoredPeer {
             peer_id,
             pubkey_b64: stored.pubkey_b64,
             added_at_ms: i64_to_u64("peer_trust.added_at_ms", stored.added_at_ms)?,
+            tier: stored_tier,
         })
     }
 
@@ -225,10 +274,21 @@ impl SqliteEventStore {
         pubkey_b64: String,
         added_at_ms: u64,
     ) -> Result<StoredPeer, StoreError> {
+        // Card 34942ec1 Sub-A: replace preserves the existing tier
+        // (a rotation is a key-material event; trust gradient is
+        // orthogonal — losing it on rotate would silently demote a
+        // Friend back to Untrusted, which would be a security
+        // regression). For a fresh insert, default to Untrusted.
+        let existing_tier = peer_trust::Entity::find_by_id(peer_id.as_uuid())
+            .one(&self.db)
+            .await?
+            .and_then(|row| TrustTier::from_wire_str(&row.tier))
+            .unwrap_or_else(TrustTier::default_for_new_peer);
         let active = peer_trust::ActiveModel {
             peer_id: Set(peer_id.as_uuid()),
             pubkey_b64: Set(pubkey_b64.clone()),
             added_at_ms: Set(u64_to_i64("peer_trust.added_at_ms", added_at_ms)?),
+            tier: Set(existing_tier.as_wire_str().to_string()),
         };
         peer_trust::Entity::insert(active)
             .on_conflict(
@@ -242,6 +302,7 @@ impl SqliteEventStore {
             peer_id,
             pubkey_b64,
             added_at_ms,
+            tier: existing_tier,
         })
     }
 
@@ -261,10 +322,17 @@ impl SqliteEventStore {
             .exec(&txn)
             .await?;
         txn.commit().await?;
+        let removed_tier = TrustTier::from_wire_str(&stored.tier).ok_or_else(|| {
+            StoreError::InvalidStoredEnumString {
+                column: "peer_trust.tier",
+                value: stored.tier.clone(),
+            }
+        })?;
         Ok(Some(StoredPeer {
             peer_id,
             pubkey_b64: stored.pubkey_b64,
             added_at_ms: i64_to_u64("peer_trust.added_at_ms", stored.added_at_ms)?,
+            tier: removed_tier,
         }))
     }
 
@@ -1816,5 +1884,119 @@ mod tests {
             sqlite_file_url(path),
             "sqlite:///tmp/airc/events.sqlite?mode=rwc"
         );
+    }
+
+    // ---------------------------------------------------------------
+    // Card 34942ec1 Sub-A — peer_trust tier round-trip
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn add_peer_trust_defaults_to_untrusted_tier() {
+        // Sub-A migration sets the column default = 'untrusted'.
+        // The existing add_peer_trust() contract stays identical
+        // (peer_id, pubkey, timestamp) — callers don't have to pick
+        // a tier just to enrol. Pinning that the stored tier is
+        // Untrusted, not whatever the enum's Default::default()
+        // happens to be (we don't impl Default on TrustTier on
+        // purpose: every insert site must decide explicitly).
+        let store = SqliteEventStore::in_memory().await.unwrap();
+        let peer_id = PeerId::from_u128(0x1234_abcd);
+        let stored = store
+            .add_peer_trust(peer_id, "AAAA".repeat(11), 100)
+            .await
+            .unwrap();
+        assert_eq!(stored.tier, TrustTier::Untrusted);
+
+        let loaded = store.load_peers().await.unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].tier, TrustTier::Untrusted);
+    }
+
+    #[tokio::test]
+    async fn add_peer_trust_with_tier_round_trips_explicit_tier() {
+        // The with_tier variant lets Sub-B detection (UDS sibling →
+        // OwnMachine) or explicit-enrolment CLI (`airc peer add
+        // --tier=friend`) pin the tier at insert. Pin that every
+        // declared variant round-trips end-to-end through write +
+        // reload — a forgotten match arm in load_peers (post-
+        // migration drift) would only surface in CI when an actual
+        // OwnMachine peer was enrolled, but this test catches it at
+        // PR review time.
+        let store = SqliteEventStore::in_memory().await.unwrap();
+        for (i, tier) in TrustTier::ALL_VARIANTS.iter().copied().enumerate() {
+            let peer_id = PeerId::from_u128(0x4000 + i as u128);
+            let stored = store
+                .add_peer_trust_with_tier(
+                    peer_id,
+                    format!("PUB{i}").repeat(11),
+                    100 + i as u64,
+                    tier,
+                )
+                .await
+                .unwrap();
+            assert_eq!(stored.tier, tier, "round-trip: insert tier survives");
+        }
+        let loaded = store.load_peers().await.unwrap();
+        assert_eq!(loaded.len(), TrustTier::ALL_VARIANTS.len());
+        let observed: std::collections::HashSet<_> = loaded.iter().map(|p| p.tier).collect();
+        let expected: std::collections::HashSet<_> =
+            TrustTier::ALL_VARIANTS.iter().copied().collect();
+        assert_eq!(observed, expected, "every variant survives the round-trip");
+    }
+
+    #[tokio::test]
+    async fn replace_peer_trust_preserves_existing_tier() {
+        // Card 34942ec1 Sub-A explicit invariant: a key-material
+        // rotation (replace_peer_trust) must NOT silently demote a
+        // Friend back to Untrusted. The tier is orthogonal to the
+        // pubkey; losing it on rotate would be a security
+        // regression that this test catches.
+        let store = SqliteEventStore::in_memory().await.unwrap();
+        let peer_id = PeerId::from_u128(0xfeed_face);
+
+        // Enrol as Friend explicitly.
+        let initial = store
+            .add_peer_trust_with_tier(peer_id, "A".repeat(43), 100, TrustTier::Friend)
+            .await
+            .unwrap();
+        assert_eq!(initial.tier, TrustTier::Friend);
+
+        // Rotate to a new pubkey via replace_peer_trust.
+        let rotated = store
+            .replace_peer_trust(peer_id, "B".repeat(43), 200)
+            .await
+            .unwrap();
+        assert_eq!(
+            rotated.tier,
+            TrustTier::Friend,
+            "rotate must preserve the existing tier"
+        );
+
+        // Confirm the durable row, not just the return value.
+        let reloaded = store.load_peers().await.unwrap();
+        assert_eq!(reloaded.len(), 1);
+        assert_eq!(reloaded[0].tier, TrustTier::Friend);
+    }
+
+    #[test]
+    fn trust_tier_wire_str_round_trips_every_variant() {
+        // The consumer-sync guard (same pattern as
+        // TranscriptKind::wire_str_round_trip_covers_every_variant).
+        // Forgetting to extend as_wire_str / from_wire_str /
+        // ALL_VARIANTS when adding a variant is exactly the kink
+        // 0cfcc8db pattern that motivated the convention.
+        for &tier in TrustTier::ALL_VARIANTS {
+            let s = tier.as_wire_str();
+            let back = TrustTier::from_wire_str(s);
+            assert_eq!(
+                back,
+                Some(tier),
+                "{tier:?} must round-trip through wire string"
+            );
+        }
+        // Unknown strings honestly fail.
+        assert_eq!(TrustTier::from_wire_str(""), None);
+        assert_eq!(TrustTier::from_wire_str("verified"), None);
+        assert_eq!(TrustTier::from_wire_str("OwnMachine"), None);
     }
 }

--- a/crates/airc-trust/src/lib.rs
+++ b/crates/airc-trust/src/lib.rs
@@ -10,6 +10,7 @@ use base64::Engine;
 
 use airc_core::PeerId;
 use airc_protocol::trust_rotation::{verify_rotation, RotationVerificationError, TrustRotation};
+pub use airc_store::peer_trust::TrustTier;
 pub use airc_store::{RotationAuditEntry, StoredPeer};
 use airc_store::{SqliteEventStore, StoreError};
 
@@ -168,6 +169,7 @@ impl From<StoreError> for PeersStoreError {
             | StoreError::DuplicateEventId(_)
             | StoreError::UnknownTranscriptKind(_)
             | StoreError::InvalidStoredValue { .. }
+            | StoreError::InvalidStoredEnumString { .. }
             | StoreError::NotFound(_)
             | StoreError::Codec(_) => PeersStoreError::Store(error),
         }

--- a/crates/airc-trust/src/lib.rs
+++ b/crates/airc-trust/src/lib.rs
@@ -217,6 +217,107 @@ pub async fn add(
         .map_err(Into::into)
 }
 
+/// Card 34942ec1 Sub-B — update the trust tier on an existing peer.
+///
+/// Returns `Ok(None)` if the peer isn't enrolled — the caller
+/// decides whether that's a structural bug (detection ran on an
+/// unknown peer) or a benign race. Substrate-only API; consumer
+/// policy (continuum's tensor routing, hermes' goal visibility)
+/// reads the tier through the store load API and applies their
+/// domain rules.
+pub async fn set_tier(
+    home: &Path,
+    peer_id: PeerId,
+    tier: airc_store::TrustTier,
+) -> Result<Option<StoredPeer>, PeersStoreError> {
+    open_store(home)
+        .await?
+        .set_peer_trust_tier(peer_id, tier)
+        .await
+        .map_err(Into::into)
+}
+
+/// Card 34942ec1 Sub-B — pure detection helper.
+///
+/// Returns the trust tier that should apply when we observe a peer
+/// whose `peer_id`, mesh-identity (`peer_mesh`), and local-machine
+/// reachability (`peer_is_on_this_machine`) we already know. The
+/// caller resolves those signals; this function is the policy from
+/// signals → tier.
+///
+/// Rules, in order:
+///   1. `peer_id == self_peer_id` → [`TrustTier::OwnMachine`].
+///      Literal self-enrollment (`Airc::open` adds my own peer to
+///      my own trust store as the first row); that row is
+///      definitionally OwnMachine.
+///   2. `peer_is_on_this_machine` (caller has confirmed the peer
+///      reaches us via the local UDS socket / same machine_account_home
+///      filesystem) → [`TrustTier::OwnMachine`].
+///   3. `peer_mesh == self_mesh` (peer authenticates as the same
+///      mesh-identity as us, e.g. another physical machine signed
+///      into the same GitHub account) → [`TrustTier::OwnAccount`].
+///   4. Otherwise → [`TrustTier::Untrusted`]. [`TrustTier::Friend`]
+///      is never inferred from signals; it requires an explicit
+///      out-of-band operator decision (Sub-C `airc peer set-tier`).
+///
+/// Idempotent: returning the same tier on repeated calls with the
+/// same inputs. Pure — no IO, no async — so it's easy to unit-test
+/// the policy matrix without standing up sockets.
+pub fn detect_tier(
+    self_peer_id: PeerId,
+    self_mesh: Option<&str>,
+    peer_id: PeerId,
+    peer_mesh: Option<&str>,
+    peer_is_on_this_machine: bool,
+) -> airc_store::TrustTier {
+    if peer_id == self_peer_id {
+        return airc_store::TrustTier::OwnMachine;
+    }
+    if peer_is_on_this_machine {
+        return airc_store::TrustTier::OwnMachine;
+    }
+    if let (Some(self_mesh), Some(peer_mesh)) = (self_mesh, peer_mesh) {
+        if !self_mesh.is_empty() && self_mesh == peer_mesh {
+            return airc_store::TrustTier::OwnAccount;
+        }
+    }
+    airc_store::TrustTier::Untrusted
+}
+
+/// Card 34942ec1 Sub-B — substrate-level convenience: probe whether
+/// `peer_home` is reachable from `self_home` on the local filesystem.
+/// Two filesystem paths are "on the same machine" when they
+/// canonicalize to the same directory OR one is a descendant of the
+/// other (e.g. self at `~/.airc/` and a sub-scope peer at
+/// `~/.airc/joel-codex/`).
+///
+/// Deliberately conservative — does NOT treat two arbitrary
+/// siblings under a common parent as same-machine, because every
+/// system tempdir would then collapse to OwnMachine. Substrates
+/// that have stronger evidence (e.g. shared `machine_account_home`
+/// resolved by `airc-lib::machine_account_home`) should pass
+/// `peer_is_on_this_machine = true` to [`detect_tier`] directly
+/// rather than relying on this loose heuristic.
+///
+/// Note: this is the *file-layout* signal only. A peer could be on
+/// the same machine but reach us via a network transport instead of
+/// UDS; that case isn't covered here.
+pub fn is_local_machine_home(self_home: &Path, peer_home: &Path) -> bool {
+    let Ok(self_canon) = self_home.canonicalize() else {
+        return false;
+    };
+    let Ok(peer_canon) = peer_home.canonicalize() else {
+        return false;
+    };
+    if self_canon == peer_canon {
+        return true;
+    }
+    if peer_canon.starts_with(&self_canon) || self_canon.starts_with(&peer_canon) {
+        return true;
+    }
+    false
+}
+
 /// Remove an enrolled peer from the local trust store. Idempotent:
 /// returns `Ok(None)` when the peer is already absent.
 pub async fn remove(home: &Path, peer_id: PeerId) -> Result<Option<StoredPeer>, PeersStoreError> {
@@ -604,5 +705,179 @@ mod tests {
         assert!(ids.contains(&a.0));
         assert!(ids.contains(&b.0));
         assert!(ids.contains(&c.0));
+    }
+
+    // ---- Card 34942ec1 Sub-B (detection + set_tier) ----
+
+    fn sub_b_sample(seed: u8) -> (PeerId, [u8; 32]) {
+        (PeerId::new(), fake_pubkey(seed))
+    }
+
+    #[tokio::test]
+    async fn set_tier_updates_existing_peer_and_returns_some() {
+        let home = TempDir::new().unwrap();
+        let (peer, pubkey) = sub_b_sample(1);
+        add(home.path(), peer, pubkey).await.unwrap();
+
+        // Newly-added rows default to Untrusted per Sub-A.
+        let before = load(home.path()).await.unwrap();
+        assert_eq!(
+            before[0].tier,
+            airc_store::TrustTier::Untrusted,
+            "freshly enrolled peers start Untrusted",
+        );
+
+        let updated = set_tier(home.path(), peer, airc_store::TrustTier::Friend)
+            .await
+            .unwrap();
+        assert!(updated.is_some());
+        assert_eq!(updated.unwrap().tier, airc_store::TrustTier::Friend);
+
+        // Persisted: reload reads the new tier.
+        let after = load(home.path()).await.unwrap();
+        assert_eq!(after[0].tier, airc_store::TrustTier::Friend);
+    }
+
+    #[tokio::test]
+    async fn set_tier_on_unknown_peer_returns_none_no_row_inserted() {
+        let home = TempDir::new().unwrap();
+        let (ghost, _) = sub_b_sample(99);
+        let result = set_tier(home.path(), ghost, airc_store::TrustTier::OwnMachine)
+            .await
+            .unwrap();
+        assert!(
+            result.is_none(),
+            "unknown peer must not be silently inserted"
+        );
+        assert!(load(home.path()).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn set_tier_is_idempotent_when_tier_matches_existing() {
+        let home = TempDir::new().unwrap();
+        let (peer, pubkey) = sub_b_sample(2);
+        add(home.path(), peer, pubkey).await.unwrap();
+        set_tier(home.path(), peer, airc_store::TrustTier::Friend)
+            .await
+            .unwrap();
+        // Set to the same tier again — same row, same tier, no error.
+        let again = set_tier(home.path(), peer, airc_store::TrustTier::Friend)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(again.tier, airc_store::TrustTier::Friend);
+    }
+
+    #[test]
+    fn detect_tier_rule_1_self_peer_id_is_own_machine() {
+        let me = PeerId::from_u128(42);
+        let tier = detect_tier(me, Some("alice@github"), me, Some("alice@github"), false);
+        assert_eq!(tier, airc_store::TrustTier::OwnMachine);
+    }
+
+    #[test]
+    fn detect_tier_rule_2_same_machine_is_own_machine() {
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        let tier = detect_tier(
+            me,
+            Some("alice@github"),
+            other,
+            Some("bob@github"),
+            true, // caller has confirmed same-machine reachability
+        );
+        assert_eq!(tier, airc_store::TrustTier::OwnMachine);
+    }
+
+    #[test]
+    fn detect_tier_rule_3_matching_mesh_identity_is_own_account() {
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        let tier = detect_tier(me, Some("alice@github"), other, Some("alice@github"), false);
+        assert_eq!(tier, airc_store::TrustTier::OwnAccount);
+    }
+
+    #[test]
+    fn detect_tier_default_is_untrusted_when_no_signal_matches() {
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        let tier = detect_tier(me, Some("alice@github"), other, Some("bob@github"), false);
+        assert_eq!(tier, airc_store::TrustTier::Untrusted);
+    }
+
+    #[test]
+    fn detect_tier_friend_is_never_inferred_from_signals() {
+        // Friend requires explicit out-of-band operator decision —
+        // detect_tier MUST NOT return Friend for any signal
+        // combination. Pins the substrate contract that automated
+        // detection can't fabricate an out-of-band trust claim.
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        let mut combos = Vec::new();
+        for self_mesh in [None, Some("alice"), Some("")] {
+            for peer_mesh in [None, Some("alice"), Some("")] {
+                for same_machine in [true, false] {
+                    combos.push(detect_tier(me, self_mesh, other, peer_mesh, same_machine));
+                }
+            }
+        }
+        for tier in &combos {
+            assert_ne!(
+                *tier,
+                airc_store::TrustTier::Friend,
+                "Friend must not be inferred",
+            );
+        }
+    }
+
+    #[test]
+    fn detect_tier_empty_mesh_strings_dont_match() {
+        // Empty mesh-identity on both sides isn't a real match — it
+        // means "we don't have a mesh-identity yet." Guards against a
+        // bug where two un-initialized peers would falsely collapse
+        // to OwnAccount.
+        let me = PeerId::from_u128(1);
+        let other = PeerId::from_u128(2);
+        let tier = detect_tier(me, Some(""), other, Some(""), false);
+        assert_eq!(tier, airc_store::TrustTier::Untrusted);
+    }
+
+    #[test]
+    fn is_local_machine_home_detects_same_directory() {
+        let tmp = TempDir::new().unwrap();
+        assert!(is_local_machine_home(tmp.path(), tmp.path()));
+    }
+
+    #[test]
+    fn is_local_machine_home_does_not_treat_arbitrary_siblings_as_local() {
+        // Deliberately strict: two siblings under a common parent are
+        // NOT considered same-machine. Otherwise every system tempdir
+        // would collapse to OwnMachine, which is what the original
+        // version of this test (under common /var/folders parent)
+        // surfaced. Substrates with stronger evidence pass
+        // `peer_is_on_this_machine = true` directly to detect_tier.
+        let tmp = TempDir::new().unwrap();
+        let a = tmp.path().join("agent-a");
+        let b = tmp.path().join("agent-b");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+        assert!(!is_local_machine_home(&a, &b));
+    }
+
+    #[test]
+    fn is_local_machine_home_detects_nested_homes() {
+        let tmp = TempDir::new().unwrap();
+        let parent = tmp.path().to_path_buf();
+        let child = parent.join("sub");
+        std::fs::create_dir_all(&child).unwrap();
+        assert!(is_local_machine_home(&parent, &child));
+        assert!(is_local_machine_home(&child, &parent));
+    }
+
+    #[test]
+    fn is_local_machine_home_returns_false_for_unrelated_paths() {
+        let tmp_a = TempDir::new().unwrap();
+        let tmp_b = TempDir::new().unwrap();
+        assert!(!is_local_machine_home(tmp_a.path(), tmp_b.path()));
     }
 }


### PR DESCRIPTION
Sub-A (#1071) shipped the `TrustTier` enum + `tier` column on
`peer_trust` + the `add_peer_trust_with_tier` insert variant + the
`replace_peer_trust` rotation that preserves tier. This Sub-B adds:

1. `SqliteEventStore::set_peer_trust_tier(peer_id, tier)` — update
   the tier on an existing row. Returns `Ok(None)` when the peer
   isn't enrolled (no silent insert; caller decides whether that's
   a bug or a race). Idempotent on same-tier-set.

2. `airc_trust::set_tier(home, peer_id, tier)` — wire-level wrapper
   matching the existing `add()` / `remove()` / `rotate()` shape.

3. `airc_trust::detect_tier(self_peer_id, self_mesh, peer_id,
   peer_mesh, peer_is_on_this_machine) -> TrustTier` — pure policy
   helper. The substrate's signal-to-tier function:
     - peer_id == self_peer_id → OwnMachine (self-enrollment)
     - peer_is_on_this_machine → OwnMachine (caller confirmed
       same-machine reachability)
     - peer_mesh == self_mesh (both Some + non-empty) → OwnAccount
     - else → Untrusted
   `Friend` is NEVER inferred — it requires explicit out-of-band
   operator decision (Sub-C `airc peer set-tier`).

4. `airc_trust::is_local_machine_home(self_home, peer_home)` —
   filesystem heuristic for the OwnMachine signal. Same path or
   ancestor-descendant returns true; arbitrary siblings under a
   common parent do NOT (would wrongly collapse every system
   tempdir to OwnMachine). Substrates with stronger evidence
   (resolved `machine_account_home` match) pass
   `peer_is_on_this_machine = true` directly to `detect_tier`.

Substrate scope only — no integration at enrollment call sites
(airc-lib::airc::open, account_registry::add, etc.). Those wirings
are consumer/integration concerns; Sub-B provides the API for them.

Validation:
- cargo test -p airc-trust --lib: 25/25 (12 new for Sub-B)
- cargo test -p airc-store --lib peer_trust: 3/3 (Sub-A unchanged)
- cargo fmt --all -- --check: clean
- cargo clippy -p airc-trust -p airc-store --all-targets -D warnings: clean

Stacked on #1071 (Sub-A). Sub-C (c75b2be2, peer's lane) wires the
CLI surface (`airc peer add --tier=friend`, `airc peer set-tier`)
on top of this set_tier API.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>