### PR TITLE
feat(cli): airc peer add --tier + airc peer set-tier — explicit grid-topology bootstrap (card 34942ec1 Sub-C)

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -677,6 +677,13 @@ pub enum PeerAction {
         /// Override the default daemon IPC endpoint.
         #[arg(long)]
         socket: Option<PathBuf>,
+        /// Card 34942ec1 Sub-C: enrol at this trust tier instead of
+        /// the substrate-default Untrusted. Used to manually pin
+        /// Friend / OwnAccount / OwnMachine when the operator knows
+        /// the relationship out-of-band (Joel pinning Friend on
+        /// Toby's airc, OwnAccount on his other machine, etc.).
+        #[arg(long, value_enum)]
+        tier: Option<CliTrustTier>,
     },
     /// Remove a peer from local trust.
     Remove {
@@ -686,8 +693,55 @@ pub enum PeerAction {
         #[arg(long)]
         socket: Option<PathBuf>,
     },
+    /// Card 34942ec1 Sub-C: update the trust tier of an
+    /// already-enrolled peer without rotating the key. Pubkey-
+    /// rotation has its own path (`peer add` with a re-pair flow);
+    /// this is the orthogonal tier-update.
+    ///
+    /// Refuses for unknown peers (no implicit add). Idempotent for
+    /// no-op transitions.
+    SetTier {
+        /// Peer UUID to re-tier.
+        peer_id: String,
+        /// New trust tier.
+        #[arg(value_enum)]
+        tier: CliTrustTier,
+        /// Override the default daemon IPC endpoint.
+        #[arg(long)]
+        socket: Option<PathBuf>,
+    },
     /// List enrolled peers from the peer trust store.
-    List,
+    List {
+        /// Print as JSON ({peer_id, pubkey_b64, tier, added_at_ms}
+        /// per row). Consumers (continuum bridge, hermes router)
+        /// read this to build their grid routing tables — see card
+        /// 34942ec1 Sub-C V4.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// CLI mirror of `airc_store::TrustTier`. Kept distinct so clap's
+/// value_enum machinery can derive the snake-case rename without
+/// pulling clap into the storage layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "snake_case")]
+pub enum CliTrustTier {
+    OwnMachine,
+    OwnAccount,
+    Friend,
+    Untrusted,
+}
+
+impl From<CliTrustTier> for airc_store::TrustTier {
+    fn from(value: CliTrustTier) -> Self {
+        match value {
+            CliTrustTier::OwnMachine => airc_store::TrustTier::OwnMachine,
+            CliTrustTier::OwnAccount => airc_store::TrustTier::OwnAccount,
+            CliTrustTier::Friend => airc_store::TrustTier::Friend,
+            CliTrustTier::Untrusted => airc_store::TrustTier::Untrusted,
+        }
+    }
 }
 
 /// Frame kind selector for `airc publish`. Maps 1:1 onto

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1013,6 +1013,7 @@ pub async fn run_peer_add(
     home: &Path,
     spec: PeerSpec,
     socket: PathBuf,
+    tier: Option<airc_store::TrustTier>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let airc = Airc::open(home).await?;
     let pubkey_b64 = base64::Engine::encode(
@@ -1021,7 +1022,27 @@ pub async fn run_peer_add(
     );
     let peer_id = spec.peer_id;
     airc.add_peer(spec).await?;
-    println!("enroled peer_id={peer_id} (pubkey 32 bytes)");
+    // Card 34942ec1 Sub-C: --tier override. If unset, the substrate
+    // default (Untrusted) from Sub-A applies — no surface change for
+    // existing callers. If set, promote the freshly-added row to the
+    // requested tier in a separate set_peer_trust_tier call. The
+    // two-step write isn't atomic at the SQL level but the
+    // substrate's invariant is "tier is orthogonal to key material"
+    // — a peer briefly visible at Untrusted before the promotion
+    // commits is the same state any honest peer starts at.
+    if let Some(tier) = tier {
+        airc_trust::set_tier(home, peer_id, tier)
+            .await?
+            .ok_or_else(|| {
+                format!(
+                    "internal: just-added peer {peer_id} missing during tier-set — \
+                     report this as a substrate bug"
+                )
+            })?;
+        println!("enroled peer_id={peer_id} (pubkey 32 bytes) tier={tier}");
+    } else {
+        println!("enroled peer_id={peer_id} (pubkey 32 bytes) tier=untrusted (default)");
+    }
 
     // Best-effort daemon sync. If the daemon isn't running, that's
     // fine — it'll pick up the trust store on next start.
@@ -1077,18 +1098,95 @@ pub async fn run_peer_remove(
     Ok(())
 }
 
+/// Card 34942ec1 Sub-C: update an enrolled peer's tier without
+/// touching key material. Refuses for unknown peers (no implicit
+/// add — the operator should `peer add <spec> --tier=…` instead).
+/// Idempotent for no-op transitions.
+pub async fn run_peer_set_tier(
+    home: &Path,
+    peer_id: airc_core::PeerId,
+    tier: airc_store::TrustTier,
+    socket: PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Look up the prior tier so the output can name both old + new
+    // (operator audit trail) AND so the idempotent no-op path can
+    // honestly say "no change."
+    let prior = airc_trust::load(home)
+        .await?
+        .into_iter()
+        .find(|p| p.peer_id == peer_id);
+    let Some(prior) = prior else {
+        return Err(format!(
+            "peer {peer_id} is not enrolled in this scope's trust store. \
+             Use `airc peer add <spec> --tier={tier}` to enrol fresh, \
+             or check `airc peer list` for the right peer_id."
+        )
+        .into());
+    };
+    if prior.tier == tier {
+        println!("no change: peer_id={peer_id} already at tier={tier} (idempotent)");
+        return Ok(());
+    }
+    let prior_tier = prior.tier;
+    let updated = airc_trust::set_tier(home, peer_id, tier)
+        .await?
+        .ok_or_else(|| {
+            format!(
+                "internal: peer {peer_id} disappeared between load and set_tier — \
+             likely a concurrent `peer remove`; retry or check the trust store"
+            )
+        })?;
+    println!(
+        "tier_changed: peer_id={peer_id} {prior_tier} → {new}",
+        new = updated.tier
+    );
+
+    // Best-effort daemon sync — same shape as run_peer_add /
+    // run_peer_remove. The daemon currently has no SetTier RPC; on
+    // a follow-up Sub-D it should subscribe to a TrustTierChanged
+    // event and re-evaluate its in-memory verifier policy. For now
+    // the trust store is the source of truth; the daemon will pick
+    // up the new tier on its next read.
+    let _ = socket; // placeholder until SetTier RPC ships (Sub-D)
+    Ok(())
+}
+
 /// `peer list` — print enroled peers via `Airc::peers`. The daemon
-/// writes the same trust store, so this view stays
-/// consistent whether the daemon is running or not.
-pub async fn run_peer_list(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let airc = Airc::open(home).await?;
-    let peers = airc.peers().await?;
+/// writes the same trust store, so this view stays consistent
+/// whether the daemon is running or not. `--json` produces the
+/// machine-readable shape consumers (bridge, router) read off of.
+pub async fn run_peer_list(home: &Path, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let peers = airc_trust::load(home).await?;
+    if json {
+        // Card 34942ec1 Sub-C V4: JSON shape is the contract
+        // consumers read. Pin the field names + the tier wire
+        // string so a future schema drift breaks the test in
+        // peer_commands.rs, not the consumer at runtime.
+        let rows: Vec<serde_json::Value> = peers
+            .iter()
+            .map(|p| {
+                serde_json::json!({
+                    "peer_id": p.peer_id.to_string(),
+                    "pubkey_b64": p.pubkey_b64,
+                    "added_at_ms": p.added_at_ms,
+                    "tier": p.tier.as_wire_str(),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+        return Ok(());
+    }
     if peers.is_empty() {
         println!("(no enroled peers — use `airc peer add <spec>` to enrol)");
         return Ok(());
     }
     for peer in &peers {
-        println!("{}  {}", peer.peer_id, peer.pubkey_b64);
+        println!(
+            "{}  {}  tier={}",
+            peer.peer_id,
+            peer.pubkey_b64,
+            peer.tier.as_wire_str()
+        );
     }
     println!();
     println!("{} peer(s) enroled at {}", peers.len(), home.display());

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -392,17 +392,27 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::Part { room } => commands::run_part(&home, room).await,
 
         Command::Peer(args) => match args.action {
-            PeerAction::Add { spec, socket } => {
-                commands::run_peer_add(&home, spec, default_or(socket, &home)).await
+            PeerAction::Add { spec, socket, tier } => {
+                commands::run_peer_add(&home, spec, default_or(socket, &home), tier.map(Into::into))
+                    .await
             }
             PeerAction::Remove { peer_id, socket } => {
                 let peer_id = parse_peer_id(&peer_id)?;
                 commands::run_peer_remove(&home, peer_id, default_or(socket, &home)).await
             }
-            PeerAction::List => commands::run_peer_list(&home).await,
+            PeerAction::SetTier {
+                peer_id,
+                tier,
+                socket,
+            } => {
+                let peer_id = parse_peer_id(&peer_id)?;
+                commands::run_peer_set_tier(&home, peer_id, tier.into(), default_or(socket, &home))
+                    .await
+            }
+            PeerAction::List { json } => commands::run_peer_list(&home, json).await,
         },
 
-        Command::Peers => commands::run_peer_list(&home).await,
+        Command::Peers => commands::run_peer_list(&home, false).await,
 
         Command::Whois { peer } => match peer {
             Some(peer) => commands::run_whois_peer(&home, &peer).await,

--- a/crates/airc-cli/tests/peer_commands.rs
+++ b/crates/airc-cli/tests/peer_commands.rs
@@ -1,0 +1,329 @@
+//! Card 34942ec1 Sub-C — `airc peer add --tier=…` + `airc peer
+//! set-tier` integration tests.
+//!
+//! Written FIRST per Joel's TDD/VDD directive: these tests pin the
+//! validation criteria (V1-V7 in the card) before the implementation
+//! lands, so the surface is locked at the desired shape and the
+//! implementation has to satisfy the validation we've already agreed
+//! on.
+//!
+//! Failure mode the suite is shaped to catch:
+//!   - Sub-A's default-Untrusted contract is preserved (V1 default arm)
+//!   - --tier= takes the explicit override (V1 explicit arm)
+//!   - set-tier on unknown peer surfaces a useful error (V3)
+//!   - set-tier is idempotent (V6)
+//!   - list --json surfaces tier so consumers can route on it (V4)
+//!   - the security invariant from Sub-A's
+//!     `replace_peer_trust_preserves_existing_tier` survives a
+//!     set-tier path (V5)
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn airc_core() -> &'static str {
+    env!("CARGO_BIN_EXE_airc")
+}
+
+/// Sub-C tests need a peer with a real-shape Ed25519 pubkey because
+/// `airc peer add` crypto-verifies decompression. Mint by initialising
+/// a throwaway scope, harvesting its peer_spec line, and discarding the
+/// scope. Each call returns a distinct spec — keeps the tests honest
+/// about working with real key material.
+fn mint_peer_spec(seed: &str) -> String {
+    let probe = TempDir::new().expect("probe tempdir");
+    let probe_home = probe.path().join(seed);
+    let output = Command::new(airc_core())
+        .arg("--home")
+        .arg(&probe_home)
+        .arg("init")
+        .env("HOME", probe.path())
+        .env("USERPROFILE", probe.path())
+        .output()
+        .expect("airc init must spawn for spec mint");
+    assert!(
+        output.status.success(),
+        "init failed for mint_peer_spec({seed}): {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("init stdout utf-8");
+    stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("peer_spec:").map(str::trim))
+        .expect("init prints peer_spec line")
+        .to_string()
+}
+
+/// Extract the peer_id (UUID) prefix from a peer_spec string.
+fn peer_id_of(spec: &str) -> &str {
+    spec.split(':').next().expect("spec has uuid prefix")
+}
+
+fn run_ok(home: &Path, args: &[&str]) -> String {
+    // Card 303f2384: --no-lease-required gate needs HOME pointing at
+    // a scope-owner. Sub-C's peer commands inherit the same harness.
+    let machine_home = home.parent().unwrap_or(home);
+    let output = Command::new(airc_core())
+        .current_dir(machine_home)
+        .env("HOME", machine_home)
+        .env("USERPROFILE", machine_home)
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .output()
+        .expect("airc-core command must spawn");
+    assert!(
+        output.status.success(),
+        "airc-core {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout utf-8")
+}
+
+fn run_expect_failure(home: &Path, args: &[&str]) -> (String, String) {
+    let machine_home = home.parent().unwrap_or(home);
+    let output = Command::new(airc_core())
+        .current_dir(machine_home)
+        .env("HOME", machine_home)
+        .env("USERPROFILE", machine_home)
+        .arg("--home")
+        .arg(home)
+        .args(args)
+        .output()
+        .expect("airc-core command must spawn");
+    assert!(
+        !output.status.success(),
+        "airc-core {:?} unexpectedly succeeded: stdout={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+    );
+    (
+        String::from_utf8(output.stdout).expect("stdout utf-8"),
+        String::from_utf8(output.stderr).expect("stderr utf-8"),
+    )
+}
+
+// ====================================================================
+// V1 — `airc peer add` defaults to Untrusted; `--tier=…` overrides
+// ====================================================================
+
+#[test]
+fn peer_add_without_tier_flag_defaults_to_untrusted() {
+    // Card 34942ec1 Sub-A contract: a fresh peer has tier=Untrusted
+    // until something explicitly promotes it. Sub-C must not change
+    // that default — existing scripts/sessions stay correct.
+    let ws = TempDir::new().expect("tempdir");
+    let home = ws.path().join("agent");
+    run_ok(&home, &["init"]);
+    let spec = mint_peer_spec("seed-1");
+
+    run_ok(&home, &["peer", "add", &spec]);
+    let list = run_ok(&home, &["peer", "list", "--json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&list).expect("peer list --json parses");
+    let peers = parsed.as_array().expect("list returns an array");
+    assert_eq!(peers.len(), 1);
+    assert_eq!(
+        peers[0]["tier"].as_str(),
+        Some("untrusted"),
+        "Sub-A default contract: no --tier flag means Untrusted"
+    );
+}
+
+#[test]
+fn peer_add_with_tier_flag_persists_explicit_tier() {
+    // V1 explicit arm: --tier=friend lands the row at Friend, not
+    // the default. This is what Joel + Toby will use to pin trust
+    // on each other's machine accounts.
+    let ws = TempDir::new().expect("tempdir");
+    let home = ws.path().join("agent");
+    run_ok(&home, &["init"]);
+    let spec = mint_peer_spec("seed-2");
+
+    run_ok(&home, &["peer", "add", &spec, "--tier", "friend"]);
+    let list = run_ok(&home, &["peer", "list", "--json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&list).expect("peer list --json parses");
+    assert_eq!(
+        parsed[0]["tier"].as_str(),
+        Some("friend"),
+        "--tier flag overrides the default"
+    );
+}
+
+#[test]
+fn peer_add_accepts_every_trust_tier_variant() {
+    // ALL_VARIANTS round-trip discipline — every tier the substrate
+    // declares must be reachable from the CLI. Forgetting to wire
+    // a new variant into the clap value_enum would silently fall
+    // through to "default-Untrusted" without this test.
+    let ws = TempDir::new().expect("tempdir");
+    let home = ws.path().join("agent");
+    run_ok(&home, &["init"]);
+
+    let tiers = [
+        ("own_machine", 0xa1),
+        ("own_account", 0xa2),
+        ("friend", 0xa3),
+        ("untrusted", 0xa4),
+    ];
+    for (tier_str, peer_seed) in tiers {
+        let spec = mint_peer_spec(&format!("tier-{peer_seed:x}"));
+        run_ok(&home, &["peer", "add", &spec, "--tier", tier_str]);
+    }
+    let list = run_ok(&home, &["peer", "list", "--json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&list).expect("peer list --json parses");
+    let observed: std::collections::HashSet<String> = parsed
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p["tier"].as_str().unwrap().to_string())
+        .collect();
+    let expected: std::collections::HashSet<String> =
+        tiers.iter().map(|(t, _)| t.to_string()).collect();
+    assert_eq!(observed, expected, "every declared tier must round-trip");
+}
+
+// ====================================================================
+// V2 — `airc peer set-tier` updates an existing peer
+// ====================================================================
+
+#[test]
+fn peer_set_tier_updates_existing_peer() {
+    // V2 happy path. Sub-B shipped the store-side
+    // set_peer_trust_tier; Sub-C is the CLI surface that consumers
+    // (Joel manually pinning Friend on Toby) reach for.
+    let ws = TempDir::new().expect("tempdir");
+    let home = ws.path().join("agent");
+    run_ok(&home, &["init"]);
+    let spec = mint_peer_spec("seed-3");
+    let peer_id = peer_id_of(&spec).to_string();
+
+    // Start at default Untrusted, then promote.
+    run_ok(&home, &["peer", "add", &spec]);
+    let promoted = run_ok(&home, &["peer", "set-tier", &peer_id, "friend"]);
+    assert!(
+        promoted.contains("untrusted") && promoted.contains("friend"),
+        "set-tier output should name both the old and new tier so \
+         the operator can audit the change: {promoted}"
+    );
+
+    let list = run_ok(&home, &["peer", "list", "--json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&list).expect("peer list --json parses");
+    assert_eq!(
+        parsed[0]["tier"].as_str(),
+        Some("friend"),
+        "set-tier must persist to the trust store"
+    );
+}
+
+// ====================================================================
+// V3 — `set-tier` refuses unknown peer
+// ====================================================================
+
+#[test]
+fn peer_set_tier_refuses_unknown_peer() {
+    // V3: no implicit add. The substrate-side store layer returns
+    // Ok(None) when the peer is missing; the CLI must surface this
+    // as a non-zero exit with an explanatory error — silently doing
+    // nothing would be misleading ("did it work? did it not?").
+    let ws = TempDir::new().expect("tempdir");
+    let home = ws.path().join("agent");
+    run_ok(&home, &["init"]);
+
+    let ghost = uuid::Uuid::from_u128(0xc0c0_a0a0).to_string();
+    let (_stdout, stderr) = run_expect_failure(&home, &["peer", "set-tier", &ghost, "own_machine"]);
+    assert!(
+        stderr.contains("not enrolled") || stderr.contains("not enroled"),
+        "refusal must name the cause: {stderr}"
+    );
+    assert!(
+        stderr.contains("peer add"),
+        "refusal must point at the corrective command (peer add): {stderr}"
+    );
+}
+
+// ====================================================================
+// V6 — `set-tier` is idempotent
+// ====================================================================
+
+#[test]
+fn peer_set_tier_is_idempotent_when_already_at_target() {
+    // V6: setting to the current tier returns Ok with a no-op
+    // marker. Sub-B's set_peer_trust_tier already shipped this at
+    // the store layer; Sub-C must not crash or claim a change
+    // happened when nothing did.
+    let ws = TempDir::new().expect("tempdir");
+    let home = ws.path().join("agent");
+    run_ok(&home, &["init"]);
+    let spec = mint_peer_spec("seed-4");
+    let peer_id = peer_id_of(&spec).to_string();
+
+    run_ok(&home, &["peer", "add", &spec, "--tier", "friend"]);
+    let same = run_ok(&home, &["peer", "set-tier", &peer_id, "friend"]);
+    assert!(
+        same.contains("no change") || same.contains("already") || same.contains("idempotent"),
+        "idempotent path should be honest about doing nothing: {same}"
+    );
+}
+
+// ====================================================================
+// V4 — `peer list --json` exposes the tier field
+// ====================================================================
+
+#[test]
+fn peer_list_json_exposes_tier_field() {
+    // V4: consumers (bridge daemon, continuum router) read the tier
+    // off this output to build their routing tables. Without
+    // --json, the substrate forces them to scrape human-format
+    // text — guaranteed to break. JSON shape is the contract.
+    let ws = TempDir::new().expect("tempdir");
+    let home = ws.path().join("agent");
+    run_ok(&home, &["init"]);
+    let spec_friend = mint_peer_spec("seed-5");
+    let spec_untrusted = mint_peer_spec("seed-6");
+    run_ok(&home, &["peer", "add", &spec_friend, "--tier", "friend"]);
+    run_ok(&home, &["peer", "add", &spec_untrusted]);
+
+    let list = run_ok(&home, &["peer", "list", "--json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&list).expect("peer list --json parses");
+    let peers = parsed.as_array().expect("array");
+    assert_eq!(peers.len(), 2);
+    for peer in peers {
+        assert!(
+            peer["peer_id"].is_string(),
+            "peer entry must carry peer_id: {peer}"
+        );
+        assert!(
+            peer["pubkey_b64"].is_string(),
+            "peer entry must carry pubkey_b64: {peer}"
+        );
+        assert!(
+            peer["tier"].is_string(),
+            "peer entry must carry tier: {peer}"
+        );
+        let tier = peer["tier"].as_str().unwrap();
+        assert!(
+            matches!(tier, "own_machine" | "own_account" | "friend" | "untrusted"),
+            "tier must be one of the four declared variants: {tier}"
+        );
+    }
+}
+
+// ====================================================================
+// V5 — set-tier interacts cleanly with the rotation invariant
+// ====================================================================
+//
+// Sub-A pinned `replace_peer_trust_preserves_existing_tier`. Sub-C
+// adds a path that explicitly sets the tier; the invariant must
+// still hold across the new path — i.e. if I `set-tier friend`
+// then a rotation lands, the tier stays Friend, not the rotate
+// path's "preserve whatever was there" which could have raced.
+//
+// This is a substrate-layer invariant that the CLI can't directly
+// exercise without a real rotation, but Sub-B's
+// `replace_peer_trust_preserves_existing_tier` already pins it. We
+// note the cross-reference here so the CLI test file documents the
+// invariant Sub-C relies on, even though the assertion lives in
+// the airc-store crate.


### PR DESCRIPTION
Sub-A (#1071) gave the substrate the TrustTier dimension. Sub-B
(#1072) shipped detection helpers + the store-side
`set_peer_trust_tier`. Sub-C is the human-assertable CLI surface
that lets the operator pin Friend on Toby's airc, OwnAccount on
their other machine, etc. — without this, the grid topology
described in continuum's L1-L5 cache hierarchy has no way to be
bootstrapped by hand.

## TDD/VDD methodology

Tests in `crates/airc-cli/tests/peer_commands.rs` were written
FIRST against V1-V7 of the card spec, then the implementation was
shaped to satisfy them. All 7 tests passed on the first complete
run; the validation criteria are pinned for the lifetime of the
substrate.

## What ships

- `PeerAction::Add { ..., tier: Option<CliTrustTier> }` —
  `airc peer add <spec> --tier=friend`. Default unchanged (Sub-A
  Untrusted contract preserved).
- `PeerAction::SetTier { peer_id, tier }` —
  `airc peer set-tier <peer_id> <tier>`. Refuses for unknown peers
  (no implicit add; the operator should `peer add` first); honest
  idempotent path when target tier == current tier.
- `PeerAction::List { json: bool }` — `airc peer list --json`
  outputs `{peer_id, pubkey_b64, added_at_ms, tier}` per row. The
  contract continuum's bridge daemon reads off when building its
  grid routing tables.
- `CliTrustTier` enum with snake_case clap value_enum rename,
  `From<CliTrustTier> for airc_store::TrustTier` so the storage
  layer doesn't depend on clap.

## Validation criteria (all green)

- V1 default + explicit-override tier on `add`
- V2 `set-tier` updates existing peer
- V3 `set-tier` refuses unknown peer with a useful error
- V4 `list --json` exposes tier
- V5 Sub-A's `replace_peer_trust_preserves_existing_tier`
  invariant remains green (rotation doesn't reset tier)
- V6 `set-tier` is idempotent
- V7 daemon RPC deferred to Sub-D (placeholder `let _ = socket;`
  in run_peer_set_tier marks the open seam)

## Tests (7 new in peer_commands.rs)

- `peer_add_without_tier_flag_defaults_to_untrusted` — Sub-A
  contract preserved
- `peer_add_with_tier_flag_persists_explicit_tier` — V1 explicit
- `peer_add_accepts_every_trust_tier_variant` — ALL_VARIANTS
  round-trip discipline (a forgotten clap variant would silently
  fall through to default-Untrusted without this)
- `peer_set_tier_updates_existing_peer` — V2
- `peer_set_tier_refuses_unknown_peer` — V3
- `peer_set_tier_is_idempotent_when_already_at_target` — V6
- `peer_list_json_exposes_tier_field` — V4

All 7 pass; workspace clippy clean; fmt clean. Live CLI dogfood
shows `tier_changed: ... friend → own_account` and the JSON
output the bridge will read.

## Why this matters

Bootstrap layer for the cache-hierarchy architecture: until the
operator can manually pin tiers, the grid topology has no
foundation. Sub-D will add tier broadcasting so other peers can
SEE my tier assessment of a peer, enabling the transitive
trust graph that makes multi-grid composition work.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>