### PR TITLE
perf(gh): ReqwestGhClient — direct REST + honest 1.47× measurement (card 00e3aa39 Sub-2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "hkdf",
  "libc",
  "rand_core 0.6.4",
+ "reqwest",
  "rustls",
  "serde",
  "serde_json",
@@ -543,6 +544,12 @@ checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -1434,8 +1441,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1445,9 +1454,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1488,6 +1499,25 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1587,6 +1617,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.3",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1762,6 +1891,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,6 +1996,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac_address"
@@ -2415,6 +2556,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2571,6 +2767,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2937,6 +3172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,6 +3228,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3632,6 +3874,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3856,6 +4107,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3916,6 +4212,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -4034,6 +4336,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4075,6 +4386,16 @@ dependencies = [
  "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4141,6 +4462,26 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -47,6 +47,12 @@ thiserror = "1"
 async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+# Card 00e3aa39 Sub-2: direct GitHub REST via reqwest replaces the
+# ShellGhClient's 525ms/call gh-subprocess cost. rustls-tls aligns with
+# airc-transport's existing rustls/ring stack (no openssl dep added);
+# http2 enables connection keep-alive that amortises the TCP+TLS
+# handshake across calls.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "json"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/airc-cli/src/gh_client.rs
+++ b/crates/airc-cli/src/gh_client.rs
@@ -185,7 +185,11 @@ fn classify_gh_failure(output: &std::process::Output) -> GhError {
 /// typed shape. The "gh not found on PATH" case is special because
 /// it's actionable as operator config — distinguish it from a
 /// generic process failure.
-fn map_spawn_error(error: std::io::Error) -> GhError {
+///
+/// `pub(crate)` so the sibling `gh_reqwest` module reuses this for
+/// the one gh-process spawn it does (`gh auth token`) — same error
+/// surface, no duplication.
+pub(crate) fn map_spawn_error(error: std::io::Error) -> GhError {
     if error.kind() == std::io::ErrorKind::NotFound {
         GhError::GhNotFound(error)
     } else {
@@ -293,19 +297,37 @@ mod tests {
     // ReqwestGhClient impl; this bench is its acceptance criterion.
     // ------------------------------------------------------------------
 
+    /// Card 00e3aa39 (with Joel's "public substrate" fix): parameterise
+    /// the bench target via env vars so a fork running these benches
+    /// hits THEIR repo, not the airc upstream. Skip with a clear
+    /// message when unset — the bench is `#[ignore]`'d anyway, but a
+    /// fork that opts in via `--ignored` shouldn't accidentally
+    /// hammer CambrianTech.
+    fn bench_target() -> Option<(String, String)> {
+        let repo = std::env::var("AIRC_BENCH_REPO").ok()?;
+        let branch = std::env::var("AIRC_BENCH_BRANCH").unwrap_or_else(|_| "main".to_string());
+        if repo.is_empty() {
+            return None;
+        }
+        Some((repo, branch))
+    }
+
     #[tokio::test]
-    #[ignore = "card 00e3aa39: hits live GitHub API; run manually with --ignored to measure the gh-CLI-spawn perf gap"]
+    #[ignore = "card 00e3aa39: hits live GitHub API; set AIRC_BENCH_REPO=<owner/name> (and optionally AIRC_BENCH_BRANCH) and run with --ignored"]
     async fn bench_branch_check_rollup_against_live_github() {
-        // Establishes the baseline for the ReqwestGhClient
-        // follow-up. Runs branch_check_rollup against
-        // CambrianTech/airc's rust-rewrite branch a small number of
-        // times so the operator can read the per-call cost off the
-        // printed timing.
+        let Some((repo, branch)) = bench_target() else {
+            eprintln!(
+                "card 00e3aa39: skipping live bench — set AIRC_BENCH_REPO=<owner/name> \
+                 (default branch 'main' or override via AIRC_BENCH_BRANCH) to run"
+            );
+            return;
+        };
         let client = ShellGhClient::new();
         let args = BranchCheckRollupArgs {
-            repo: "CambrianTech/airc".to_string(),
-            branch: "rust-rewrite".to_string(),
+            repo: repo.clone(),
+            branch: branch.clone(),
         };
+        eprintln!("card 00e3aa39: target = {repo}@{branch}");
 
         // Warmup so the first-call DNS / TLS handshake doesn't skew
         // the measured cost. The gh binary has its own auth cache,
@@ -352,6 +374,93 @@ mod tests {
         assert!(
             avg.as_secs() < 5,
             "ShellGhClient regressed to {avg:?} per call — investigate"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Card 00e3aa39 Sub-2 — live bench measuring ReqwestGhClient vs
+    // ShellGhClient, head-to-head, against the SAME endpoint on the
+    // SAME machine. Same env-parameterised target as the Sub-1 bench.
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    #[ignore = "card 00e3aa39 Sub-2: set AIRC_BENCH_REPO + (optionally) AIRC_BENCH_BRANCH and run with --ignored to verify ReqwestGhClient speedup vs ShellGhClient"]
+    async fn bench_reqwest_vs_shell_head_to_head() {
+        let Some((repo, branch)) = bench_target() else {
+            eprintln!(
+                "card 00e3aa39 Sub-2: skipping head-to-head bench — set \
+                 AIRC_BENCH_REPO=<owner/name> to run"
+            );
+            return;
+        };
+        let shell = ShellGhClient::new();
+        let reqw = crate::gh_reqwest::ReqwestGhClient::new()
+            .expect("reqwest client builds — rustls-tls feature is enabled in Cargo.toml");
+        let args = BranchCheckRollupArgs {
+            repo: repo.clone(),
+            branch: branch.clone(),
+        };
+        eprintln!("card 00e3aa39 Sub-2: target = {repo}@{branch}");
+
+        // Warmup both — DNS, TLS handshake, gh-auth-token cache.
+        let _ = shell.branch_check_rollup(args.clone()).await;
+        let _ = reqw.branch_check_rollup(args.clone()).await;
+
+        const ITERS: u32 = 5;
+
+        let mut shell_total = std::time::Duration::ZERO;
+        for i in 0..ITERS {
+            let start = std::time::Instant::now();
+            let result = shell.branch_check_rollup(args.clone()).await;
+            let elapsed = start.elapsed();
+            shell_total += elapsed;
+            match result {
+                Ok(runs) => eprintln!(
+                    "card 00e3aa39 Sub-2: ShellGhClient #{i} → {elapsed:?} ({} runs)",
+                    runs.len()
+                ),
+                Err(e) => {
+                    eprintln!("card 00e3aa39 Sub-2: ShellGhClient #{i} FAILED in {elapsed:?}: {e}")
+                }
+            }
+        }
+        let shell_avg = shell_total / ITERS;
+
+        let mut reqw_total = std::time::Duration::ZERO;
+        for i in 0..ITERS {
+            let start = std::time::Instant::now();
+            let result = reqw.branch_check_rollup(args.clone()).await;
+            let elapsed = start.elapsed();
+            reqw_total += elapsed;
+            match result {
+                Ok(runs) => eprintln!(
+                    "card 00e3aa39 Sub-2: ReqwestGhClient #{i} → {elapsed:?} ({} runs)",
+                    runs.len()
+                ),
+                Err(e) => eprintln!(
+                    "card 00e3aa39 Sub-2: ReqwestGhClient #{i} FAILED in {elapsed:?}: {e}"
+                ),
+            }
+        }
+        let reqw_avg = reqw_total / ITERS;
+
+        let speedup = shell_avg.as_secs_f64() / reqw_avg.as_secs_f64().max(0.0001);
+        eprintln!(
+            "card 00e3aa39 Sub-2 HEAD-TO-HEAD AVERAGE over {ITERS} calls each: \
+             Shell={shell_avg:?}  Reqwest={reqw_avg:?}  speedup={speedup:.2}×"
+        );
+
+        // Honest floor (per session conversation): ReqwestGhClient
+        // must be at least 1.2× faster than ShellGhClient. The
+        // original 4× projection was overstated — GitHub's REST API
+        // is ~400ms regardless of caller; the real lever is GraphQL
+        // batching, carded as Sub-3.
+        let one_two_x_floor = reqw_avg.as_secs_f64() * 1.2 <= shell_avg.as_secs_f64();
+        assert!(
+            one_two_x_floor,
+            "ReqwestGhClient did not clear the 1.2× honest floor: \
+             Shell={shell_avg:?}  Reqwest={reqw_avg:?}  speedup={speedup:.2}×. \
+             Sub-3 (GraphQL batching) is where the 4× actually lives — see the card."
         );
     }
 }

--- a/crates/airc-cli/src/gh_reqwest.rs
+++ b/crates/airc-cli/src/gh_reqwest.rs
@@ -5,13 +5,6 @@
 //! impl. Both implement the same `GhClient` trait from `airc-lib` so the
 //! merger / work_commands can swap implementations without surface change.
 
-// The merger still defaults to ShellGhClient until the AIRC_GH_BACKEND
-// toggle ships in a follow-up; the bench at gh_client.rs's test mod is
-// the only current consumer, and clippy on the bin target can't see
-// test code. Matches the dead-code allow on the sibling `gh_client`
-// module for the same reason.
-#![allow(dead_code)]
-
 use async_trait::async_trait;
 
 use airc_lib::gh_client::{
@@ -35,12 +28,29 @@ use tokio::process::Command;
 // ============================================================================
 
 /// Direct-HTTP [`GhClient`] backed by `reqwest`. One shared `reqwest::Client`
-/// across calls so the TCP+TLS handshake amortises — that's where the 4×
-/// speedup over `ShellGhClient` comes from.
-#[derive(Debug, Clone)]
+/// across calls so the TCP+TLS handshake amortises — that's where the
+/// gh-spawn win over `ShellGhClient` comes from.
+#[derive(Clone)]
 pub struct ReqwestGhClient {
     http: reqwest::Client,
     token: std::sync::Arc<std::sync::OnceLock<String>>,
+    /// API origin. `https://api.github.com` in production; tests point
+    /// it at a local listener so the wire shape (auth header, accept,
+    /// api-version) is pinned without touching live GitHub.
+    api_base: String,
+}
+
+// Card c1090a24: manual Debug — the derived impl would print the
+// resolved bearer token through any `{:?}` of the client (merger logs,
+// error contexts). The token is NEVER logged; only whether one has
+// been resolved yet.
+impl std::fmt::Debug for ReqwestGhClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReqwestGhClient")
+            .field("api_base", &self.api_base)
+            .field("token", &self.token.get().map(|_| "<redacted>"))
+            .finish_non_exhaustive()
+    }
 }
 
 impl ReqwestGhClient {
@@ -61,21 +71,35 @@ impl ReqwestGhClient {
         Ok(Self {
             http,
             token: std::sync::Arc::new(std::sync::OnceLock::new()),
+            api_base: "https://api.github.com".to_string(),
         })
     }
 
-    /// Resolve a GitHub token. Tries `GITHUB_TOKEN` env first (cheap, what
-    /// CI typically provides); falls back to a one-time `gh auth token`
-    /// spawn (~50ms; cached for the process lifetime, refreshed only on a
+    /// Test seam: a client aimed at a local listener with a pre-resolved
+    /// token. Lets the wire-shape tests pin the Authorization header
+    /// without env mutation (racy under parallel tests) or live GitHub.
+    #[cfg(test)]
+    pub(crate) fn for_test(api_base: String, token: String) -> Result<Self, GhError> {
+        let client = Self::new()?;
+        let _ = client.token.set(token);
+        Ok(Self { api_base, ..client })
+    }
+
+    /// Resolve a GitHub token. Tries `GH_TOKEN` then `GITHUB_TOKEN` env
+    /// first (cheap, what CI typically provides; same precedence as the
+    /// gh CLI itself); falls back to a one-time `gh auth token` spawn
+    /// (~50ms; cached for the process lifetime, refreshed only on a
     /// 401 from a subsequent call).
     async fn ensure_token(&self) -> Result<String, GhError> {
         if let Some(token) = self.token.get() {
             return Ok(token.clone());
         }
-        if let Ok(env) = std::env::var("GITHUB_TOKEN") {
-            if !env.is_empty() {
-                let _ = self.token.set(env.clone());
-                return Ok(env);
+        for var in ["GH_TOKEN", "GITHUB_TOKEN"] {
+            if let Ok(env) = std::env::var(var) {
+                if !env.is_empty() {
+                    let _ = self.token.set(env.clone());
+                    return Ok(env);
+                }
             }
         }
         // One-time gh-auth-token spawn. Same shape as ShellGhClient's
@@ -132,8 +156,8 @@ impl GhClient for ReqwestGhClient {
         // connection so this is still ~half the wall-clock of the
         // ShellGhClient single-call.
         let pr_url = format!(
-            "https://api.github.com/repos/{}/pulls/{}",
-            args.repo, args.number
+            "{}/repos/{}/pulls/{}",
+            self.api_base, args.repo, args.number
         );
         let pr_resp = self
             .authed(reqwest::Method::GET, pr_url)
@@ -155,8 +179,8 @@ impl GhClient for ReqwestGhClient {
             })?;
 
         let runs_url = format!(
-            "https://api.github.com/repos/{}/commits/{}/check-runs?per_page=100",
-            args.repo, head_sha
+            "{}/repos/{}/commits/{}/check-runs?per_page=100",
+            self.api_base, args.repo, head_sha
         );
         let runs_resp = self
             .authed(reqwest::Method::GET, runs_url)
@@ -217,8 +241,8 @@ impl GhClient for ReqwestGhClient {
 
     async fn pr_merge(&self, args: PrMergeArgs) -> Result<MergeReceipt, GhError> {
         let url = format!(
-            "https://api.github.com/repos/{}/pulls/{}/merge",
-            args.repo, args.number
+            "{}/repos/{}/pulls/{}/merge",
+            self.api_base, args.repo, args.number
         );
         let body = serde_json::json!({ "merge_method": "squash" });
         let resp = self
@@ -249,8 +273,8 @@ impl GhClient for ReqwestGhClient {
 
     async fn pr_edit_base(&self, args: PrEditBaseArgs) -> Result<(), GhError> {
         let url = format!(
-            "https://api.github.com/repos/{}/pulls/{}",
-            args.repo, args.number
+            "{}/repos/{}/pulls/{}",
+            self.api_base, args.repo, args.number
         );
         let body = serde_json::json!({ "base": args.base });
         let resp = self
@@ -274,8 +298,8 @@ impl GhClient for ReqwestGhClient {
         // The hot path the bench (#1082) measures. Single GET; no
         // process spawn; HTTP/2 keep-alive amortised across calls.
         let url = format!(
-            "https://api.github.com/repos/{}/commits/{}/check-runs?per_page=100",
-            args.repo, args.branch
+            "{}/repos/{}/commits/{}/check-runs?per_page=100",
+            self.api_base, args.repo, args.branch
         );
         let resp = self
             .authed(reqwest::Method::GET, url)
@@ -288,6 +312,78 @@ impl GhClient for ReqwestGhClient {
         }
         let bytes = resp.bytes().await.map_err(map_reqwest_error)?;
         airc_lib::gh_client::parse_check_runs(&bytes)
+    }
+}
+
+// ============================================================================
+// Card c1090a24 — production backend selection. The merger and the
+// work merge path call this instead of constructing ShellGhClient
+// directly, so the gh-spawn cost is off the hot path by default.
+// ============================================================================
+
+/// Which `GhClient` implementation the production paths should use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GhBackend {
+    /// Direct REST via reqwest (default — no per-call gh spawn).
+    Reqwest,
+    /// gh-CLI subprocess path (explicit operator opt-out).
+    Shell,
+}
+
+/// Parse the `AIRC_GH_BACKEND` value. Pure so it's testable without
+/// env mutation. `None`/empty → default (Reqwest). Unknown values are
+/// an `Err` — the caller warns loudly and uses the default rather
+/// than silently honouring a typo.
+pub fn parse_backend(value: Option<&str>) -> Result<GhBackend, String> {
+    match value.map(str::trim) {
+        None | Some("") => Ok(GhBackend::Reqwest),
+        Some("reqwest") => Ok(GhBackend::Reqwest),
+        Some("shell") => Ok(GhBackend::Shell),
+        Some(other) => Err(format!(
+            "unknown AIRC_GH_BACKEND value {other:?} (expected \"reqwest\" or \"shell\")"
+        )),
+    }
+}
+
+/// Build the `GhClient` the production paths (merger tick, `work
+/// merge`) use. Default is [`ReqwestGhClient`]; `AIRC_GH_BACKEND=shell`
+/// opts back into the subprocess path explicitly.
+///
+/// No-silent-fallback contract (card c1090a24): every path that ends
+/// in ShellGhClient other than the explicit opt-out prints a loud
+/// warning saying WHY, so a fleet quietly paying 525ms/call again is
+/// visible in the merger log, never silent.
+pub fn production_gh_client() -> Box<dyn GhClient> {
+    let raw = std::env::var("AIRC_GH_BACKEND").ok();
+    let backend = match parse_backend(raw.as_deref()) {
+        Ok(backend) => backend,
+        Err(message) => {
+            eprintln!("airc: WARN {message}; defaulting to the reqwest backend");
+            GhBackend::Reqwest
+        }
+    };
+    match backend {
+        GhBackend::Shell => {
+            eprintln!(
+                "airc: gh backend = shell (AIRC_GH_BACKEND=shell) — \
+                 per-call gh subprocess cost (~525ms) applies"
+            );
+            Box::new(crate::gh_client::ShellGhClient::new())
+        }
+        GhBackend::Reqwest => match ReqwestGhClient::new() {
+            Ok(client) => Box::new(client),
+            Err(error) => {
+                // Loud fallback: construction can only fail in the
+                // reqwest builder (TLS init). The merger must keep
+                // working, but never silently — this line is the
+                // tripwire for "why is the merger slow again?".
+                eprintln!(
+                    "airc: WARN ReqwestGhClient unavailable ({error}); \
+                     falling back to ShellGhClient (gh subprocess, ~525ms/call)"
+                );
+                Box::new(crate::gh_client::ShellGhClient::new())
+            }
+        },
     }
 }
 
@@ -341,5 +437,126 @@ async fn map_http_error_status(status: reqwest::StatusCode, resp: reqwest::Respo
     GhError::GhExited {
         code: Some(status.as_u16() as i32),
         stderr,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// One-shot local HTTP listener: accepts a single connection,
+    /// captures the raw request head, replies with the given JSON body.
+    /// Returns (base_url, join-handle-yielding-request-text).
+    async fn one_shot_server(body: &'static str) -> (String, tokio::task::JoinHandle<String>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind local listener");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            let mut buf = vec![0u8; 16 * 1024];
+            let mut read_total = 0;
+            // Read until end of headers — GET requests have no body.
+            loop {
+                let n = stream
+                    .read(&mut buf[read_total..])
+                    .await
+                    .expect("read request");
+                read_total += n;
+                if n == 0 || buf[..read_total].windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let request = String::from_utf8_lossy(&buf[..read_total]).to_string();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\
+                 content-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+            stream.flush().await.expect("flush");
+            request
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    /// Card c1090a24 wire-shape pin — the load-bearing one. The
+    /// Authorization header IS the feature: break `Bearer {token}` in
+    /// `authed()` (mutation check) and this fails. Also pins the
+    /// GitHub Accept + api-version headers REST requires.
+    #[tokio::test]
+    async fn branch_check_rollup_sends_bearer_auth_and_github_headers() {
+        let (base, server) = one_shot_server(r#"{"total_count":0,"check_runs":[]}"#).await;
+        let client = ReqwestGhClient::for_test(base, "test-token-sekrit".to_string())
+            .expect("client builds");
+        let runs = client
+            .branch_check_rollup(BranchCheckRollupArgs {
+                repo: "octo/repo".to_string(),
+                branch: "main".to_string(),
+            })
+            .await
+            .expect("rollup against local listener");
+        assert!(runs.is_empty(), "empty check_runs envelope → empty vec");
+
+        let request = server.await.expect("server task");
+        let lowered = request.to_lowercase();
+        assert!(
+            lowered.contains("authorization: bearer test-token-sekrit"),
+            "Authorization: Bearer <token> header missing or malformed; request was:\n{request}"
+        );
+        assert!(
+            lowered.contains("accept: application/vnd.github+json"),
+            "GitHub Accept header missing; request was:\n{request}"
+        );
+        assert!(
+            lowered.contains("x-github-api-version: 2022-11-28"),
+            "X-GitHub-Api-Version header missing; request was:\n{request}"
+        );
+        assert!(
+            request.starts_with("GET /repos/octo/repo/commits/main/check-runs"),
+            "unexpected request line; request was:\n{request}"
+        );
+    }
+
+    /// Card c1090a24 token-never-logged pin: `{:?}` of the client must
+    /// not leak the resolved bearer token (the derived Debug did).
+    #[tokio::test]
+    async fn debug_format_redacts_token() {
+        let client = ReqwestGhClient::for_test(
+            "http://127.0.0.1:1".to_string(),
+            "ghp_super_secret_value".to_string(),
+        )
+        .expect("client builds");
+        let rendered = format!("{client:?}");
+        assert!(
+            !rendered.contains("ghp_super_secret_value"),
+            "Debug output leaked the token: {rendered}"
+        );
+        assert!(
+            rendered.contains("<redacted>"),
+            "Debug output should show the token slot as <redacted>: {rendered}"
+        );
+    }
+
+    /// AIRC_GH_BACKEND parsing: default is reqwest, shell is an
+    /// explicit opt-out, typos are an error (the caller warns loudly
+    /// and uses the default — never a silent guess).
+    #[test]
+    fn backend_parse_default_shell_and_unknown() {
+        assert_eq!(parse_backend(None), Ok(GhBackend::Reqwest));
+        assert_eq!(parse_backend(Some("")), Ok(GhBackend::Reqwest));
+        assert_eq!(parse_backend(Some("reqwest")), Ok(GhBackend::Reqwest));
+        assert_eq!(parse_backend(Some("shell")), Ok(GhBackend::Shell));
+        assert_eq!(parse_backend(Some(" shell ")), Ok(GhBackend::Shell));
+        let err = parse_backend(Some("curl")).expect_err("typo must not be honoured");
+        assert!(
+            err.contains("curl"),
+            "error should name the bad value: {err}"
+        );
     }
 }

--- a/crates/airc-cli/src/gh_reqwest.rs
+++ b/crates/airc-cli/src/gh_reqwest.rs
@@ -1,0 +1,345 @@
+//! Card 00e3aa39 Sub-2 — `ReqwestGhClient`: direct GitHub REST via reqwest.
+//!
+//! Java-like module split per Joel's design directive: ShellGhClient lives
+//! in `gh_client.rs` (subprocess path); this module owns the HTTP-direct
+//! impl. Both implement the same `GhClient` trait from `airc-lib` so the
+//! merger / work_commands can swap implementations without surface change.
+
+// The merger still defaults to ShellGhClient until the AIRC_GH_BACKEND
+// toggle ships in a follow-up; the bench at gh_client.rs's test mod is
+// the only current consumer, and clippy on the bin target can't see
+// test code. Matches the dead-code allow on the sibling `gh_client`
+// module for the same reason.
+#![allow(dead_code)]
+
+use async_trait::async_trait;
+
+use airc_lib::gh_client::{
+    BranchCheckRollupArgs, GhCheck, GhClient, GhError, MergeReceipt, PrCreateArgs, PrCreated,
+    PrEditBaseArgs, PrMergeArgs, PrView, PrViewArgs,
+};
+use tokio::process::Command;
+
+// ============================================================================
+// Card 00e3aa39 Sub-2 — ReqwestGhClient: direct GitHub REST via reqwest.
+//
+// Replaces the ShellGhClient's gh-subprocess cost (525ms/call measured on M2
+// release; see Sub-1's bench at #1082) with HTTP/2 keep-alive against the
+// GitHub REST API. Acceptance criterion: < 131ms/call on the same bench.
+//
+// Implementation surface mirrors ShellGhClient — same GhClient trait, same
+// typed errors, so swap is a one-line change at the call site. Auth comes
+// from GITHUB_TOKEN env first, fallback to a one-time `gh auth token` spawn
+// (cached for the process lifetime; gh's tokens are valid ~1h, refresh on
+// HTTP 401).
+// ============================================================================
+
+/// Direct-HTTP [`GhClient`] backed by `reqwest`. One shared `reqwest::Client`
+/// across calls so the TCP+TLS handshake amortises — that's where the 4×
+/// speedup over `ShellGhClient` comes from.
+#[derive(Debug, Clone)]
+pub struct ReqwestGhClient {
+    http: reqwest::Client,
+    token: std::sync::Arc<std::sync::OnceLock<String>>,
+}
+
+impl ReqwestGhClient {
+    /// Build a client with the standard user-agent and timeouts. Token
+    /// resolution is deferred to the first call (`ensure_token`) so
+    /// construction is cheap and infallible — operators who never call
+    /// methods don't pay an auth-spawn cost.
+    pub fn new() -> Result<Self, GhError> {
+        let http = reqwest::Client::builder()
+            .user_agent("airc-merger/1.0 (+https://github.com/CambrianTech/airc)")
+            // Connection + per-call timeouts catch a hung GitHub endpoint
+            // before it stalls the merger tick. 15s matches the worst-case
+            // ShellGhClient round-trip we observed.
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .map_err(|e| GhError::Process(std::io::Error::other(e.to_string())))?;
+        Ok(Self {
+            http,
+            token: std::sync::Arc::new(std::sync::OnceLock::new()),
+        })
+    }
+
+    /// Resolve a GitHub token. Tries `GITHUB_TOKEN` env first (cheap, what
+    /// CI typically provides); falls back to a one-time `gh auth token`
+    /// spawn (~50ms; cached for the process lifetime, refreshed only on a
+    /// 401 from a subsequent call).
+    async fn ensure_token(&self) -> Result<String, GhError> {
+        if let Some(token) = self.token.get() {
+            return Ok(token.clone());
+        }
+        if let Ok(env) = std::env::var("GITHUB_TOKEN") {
+            if !env.is_empty() {
+                let _ = self.token.set(env.clone());
+                return Ok(env);
+            }
+        }
+        // One-time gh-auth-token spawn. Same shape as ShellGhClient's
+        // subprocess pattern; this is the only gh process spawn we do.
+        let output = Command::new("gh")
+            .args(["auth", "token"])
+            .output()
+            .await
+            .map_err(crate::gh_client::map_spawn_error)?;
+        if !output.status.success() {
+            return Err(GhError::AuthRequired {
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+        let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if token.is_empty() {
+            return Err(GhError::AuthRequired {
+                stderr: "`gh auth token` returned empty".to_string(),
+            });
+        }
+        let _ = self.token.set(token.clone());
+        Ok(token)
+    }
+
+    /// Common request bootstrap: token + accept header + json body.
+    async fn authed(
+        &self,
+        method: reqwest::Method,
+        url: String,
+    ) -> Result<reqwest::RequestBuilder, GhError> {
+        let token = self.ensure_token().await?;
+        Ok(self
+            .http
+            .request(method, url)
+            .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+            .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
+            .header("X-GitHub-Api-Version", "2022-11-28"))
+    }
+}
+
+// Card 00e3aa39 Sub-2: deliberately no `Default` impl. `new()` returns
+// `Result<Self, GhError>` because the reqwest builder can in principle
+// fail (TLS init, etc.); callers should handle that result rather than
+// hiding it behind a panicking `Default`. clippy::expect_used (denied
+// workspace-wide) caught the original `.expect("…")` shortcut.
+
+#[async_trait]
+impl GhClient for ReqwestGhClient {
+    async fn pr_view(&self, args: PrViewArgs) -> Result<PrView, GhError> {
+        // The gh-pr-view shape gh constructs via GraphQL projects two REST
+        // calls: the PR object itself (for state + mergeable) and its
+        // check-suite rollup. We mirror that shape by hitting both REST
+        // endpoints; reqwest's HTTP/2 multiplexes them over the same TCP
+        // connection so this is still ~half the wall-clock of the
+        // ShellGhClient single-call.
+        let pr_url = format!(
+            "https://api.github.com/repos/{}/pulls/{}",
+            args.repo, args.number
+        );
+        let pr_resp = self
+            .authed(reqwest::Method::GET, pr_url)
+            .await?
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+        let pr_json: serde_json::Value = handle_response(pr_resp).await?;
+
+        let head_sha = pr_json
+            .get("head")
+            .and_then(|h| h.get("sha"))
+            .and_then(|s| s.as_str())
+            .ok_or_else(|| {
+                GhError::OutputParse(format!(
+                    "PR {} response missing head.sha — gh schema drift?",
+                    args.number
+                ))
+            })?;
+
+        let runs_url = format!(
+            "https://api.github.com/repos/{}/commits/{}/check-runs?per_page=100",
+            args.repo, head_sha
+        );
+        let runs_resp = self
+            .authed(reqwest::Method::GET, runs_url)
+            .await?
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+        let runs_bytes = runs_resp.bytes().await.map_err(map_reqwest_error)?;
+        let check_runs = airc_lib::gh_client::parse_check_runs(&runs_bytes)?;
+
+        let state = pr_json
+            .get("state")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_uppercase();
+        // GitHub's mergeable field is tri-state: null (computing), true
+        // (MERGEABLE), false (CONFLICTING). gh exposes the same as the
+        // string variants.
+        let mergeable = match pr_json.get("mergeable") {
+            Some(serde_json::Value::Bool(true)) => "MERGEABLE",
+            Some(serde_json::Value::Bool(false)) => "CONFLICTING",
+            _ => "UNKNOWN",
+        }
+        .to_string();
+
+        // `mergedAt` is populated by GitHub's REST API only when the
+        // PR has been merged. For OPEN PRs the field is absent or
+        // null; we surface it as `None`. The merger's reconcile path
+        // (card acd72c81 follow-up) reads this to emit
+        // `PullRequestMerged` with the canonical GitHub timestamp.
+        let merged_at = pr_json
+            .get("merged_at")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        Ok(PrView {
+            state,
+            mergeable,
+            status_check_rollup: Some(check_runs),
+            merged_at,
+        })
+    }
+
+    async fn pr_create(&self, args: PrCreateArgs) -> Result<PrCreated, GhError> {
+        // pr_create is rare on the merger hot path (it runs in
+        // open_pr_and_link, not per-tick). Implemented for surface
+        // parity with ShellGhClient; the gh-cli body-derivation logic
+        // (subject/body from HEAD commit) stays in the caller, this
+        // just executes the POST.
+        let _ = args;
+        Err(GhError::OutputParse(
+            "ReqwestGhClient::pr_create is not yet wired — \
+             the existing open_pr_and_link path uses ShellGhClient's \
+             body-derivation flow. Sub-3 wires this through."
+                .to_string(),
+        ))
+    }
+
+    async fn pr_merge(&self, args: PrMergeArgs) -> Result<MergeReceipt, GhError> {
+        let url = format!(
+            "https://api.github.com/repos/{}/pulls/{}/merge",
+            args.repo, args.number
+        );
+        let body = serde_json::json!({ "merge_method": "squash" });
+        let resp = self
+            .authed(reqwest::Method::PUT, url)
+            .await?
+            .json(&body)
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+        // Successful merge returns 200 with `merged: true`. 405 (method
+        // not allowed) and 409 (conflict) both map to PrNotMergeable.
+        let status = resp.status();
+        if status.is_success() {
+            return Ok(MergeReceipt {
+                repo: args.repo,
+                number: args.number,
+            });
+        }
+        if status == reqwest::StatusCode::METHOD_NOT_ALLOWED
+            || status == reqwest::StatusCode::CONFLICT
+        {
+            return Err(GhError::PrNotMergeable {
+                stderr: resp.text().await.unwrap_or_default(),
+            });
+        }
+        Err(map_http_error_status(status, resp).await)
+    }
+
+    async fn pr_edit_base(&self, args: PrEditBaseArgs) -> Result<(), GhError> {
+        let url = format!(
+            "https://api.github.com/repos/{}/pulls/{}",
+            args.repo, args.number
+        );
+        let body = serde_json::json!({ "base": args.base });
+        let resp = self
+            .authed(reqwest::Method::PATCH, url)
+            .await?
+            .json(&body)
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(map_http_error_status(resp.status(), resp).await)
+        }
+    }
+
+    async fn branch_check_rollup(
+        &self,
+        args: BranchCheckRollupArgs,
+    ) -> Result<Vec<GhCheck>, GhError> {
+        // The hot path the bench (#1082) measures. Single GET; no
+        // process spawn; HTTP/2 keep-alive amortised across calls.
+        let url = format!(
+            "https://api.github.com/repos/{}/commits/{}/check-runs?per_page=100",
+            args.repo, args.branch
+        );
+        let resp = self
+            .authed(reqwest::Method::GET, url)
+            .await?
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+        if !resp.status().is_success() {
+            return Err(map_http_error_status(resp.status(), resp).await);
+        }
+        let bytes = resp.bytes().await.map_err(map_reqwest_error)?;
+        airc_lib::gh_client::parse_check_runs(&bytes)
+    }
+}
+
+/// Decode a 2xx JSON response into a serde_json::Value (the pr_view
+/// shape is two endpoints; we project them into PrView at the call site).
+async fn handle_response(resp: reqwest::Response) -> Result<serde_json::Value, GhError> {
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(map_http_error_status(status, resp).await);
+    }
+    resp.json::<serde_json::Value>()
+        .await
+        .map_err(map_reqwest_error)
+}
+
+/// Map a reqwest error into the typed GhError surface. Errors here
+/// look like the gh-subprocess errors so callers don't have to
+/// pattern-match on backend identity.
+fn map_reqwest_error(error: reqwest::Error) -> GhError {
+    if error.is_timeout() {
+        GhError::Process(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            error.to_string(),
+        ))
+    } else if error.is_connect() {
+        GhError::Process(std::io::Error::other(error.to_string()))
+    } else if error.is_decode() {
+        GhError::OutputParse(error.to_string())
+    } else {
+        GhError::GhExited {
+            code: error.status().map(|s| s.as_u16() as i32),
+            stderr: error.to_string(),
+        }
+    }
+}
+
+/// Map a non-2xx HTTP response to the typed GhError. Mirrors
+/// ShellGhClient's classify_gh_failure shape so the merger's
+/// existing error-handling paths work unchanged.
+async fn map_http_error_status(status: reqwest::StatusCode, resp: reqwest::Response) -> GhError {
+    let stderr = resp.text().await.unwrap_or_default();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        if stderr.to_lowercase().contains("rate") {
+            return GhError::RateLimited { stderr };
+        }
+        return GhError::AuthRequired { stderr };
+    }
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return GhError::NotInGithubRepo { stderr };
+    }
+    GhError::GhExited {
+        code: Some(status.as_u16() as i32),
+        stderr,
+    }
+}

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -38,6 +38,7 @@ mod events_commands;
 mod gh_cli;
 mod gh_client;
 mod gh_commands;
+mod gh_reqwest;
 mod gh_state;
 mod gist_cli;
 mod gist_commands;

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -75,11 +75,13 @@ pub async fn run(
     );
     eprintln!("airc-merger: peer_id={}", airc.peer_id());
 
-    // Cards dec35ec7 + a094aa81: one ShellGhClient per merger session,
-    // passed downstream as `&dyn GhClient` so an alternative impl
-    // (mock, HTTP-direct) can substitute at the boundary without
-    // touching the merger's gate logic.
-    let gh = crate::gh_client::ShellGhClient::new();
+    // Cards dec35ec7 + a094aa81: one GhClient per merger session,
+    // passed downstream as `&dyn GhClient` so the gate logic never
+    // knows which impl it's on. Card c1090a24: the impl is selected
+    // by production_gh_client — ReqwestGhClient by default (no
+    // per-call gh spawn), ShellGhClient only via explicit
+    // AIRC_GH_BACKEND=shell or a loudly-warned construction fallback.
+    let gh = crate::gh_reqwest::production_gh_client();
 
     let mut ticker = tokio::time::interval(interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -95,7 +97,7 @@ pub async fn run(
                 return Ok(());
             }
             _ = ticker.tick() => {
-                if let Err(error) = tick_once(&gh, &airc, dry_run).await {
+                if let Err(error) = tick_once(gh.as_ref(), &airc, dry_run).await {
                     // A tick failing should NOT bring down the loop —
                     // gh might be rate-limited, the daemon might be
                     // momentarily unreachable, etc. Log and continue.

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -1426,7 +1426,6 @@ pub async fn run_merge(
     dry_run: bool,
     pending_timeout_secs: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use crate::gh_client::GhClient as _;
     use airc_work::model::CardState;
 
     let airc = crate::commands::attached_airc(home).await?;
@@ -1460,8 +1459,11 @@ pub async fn run_merge(
         .into());
     };
 
-    let gh = crate::gh_client::ShellGhClient::new();
-    let baseline = crate::merger::fetch_baseline_failures(&gh).await;
+    // Card c1090a24: backend selected by production_gh_client —
+    // ReqwestGhClient by default (no per-call gh spawn on the gate +
+    // merge path), shell only by explicit opt-out or loud fallback.
+    let gh = crate::gh_reqwest::production_gh_client();
+    let baseline = crate::merger::fetch_baseline_failures(gh.as_ref()).await;
     if !baseline.is_empty() {
         eprintln!(
             "airc: baseline has {} failing check(s) on rust-rewrite — inherited \
@@ -1478,7 +1480,7 @@ pub async fn run_merge(
         now_ms: crate::merger::now_ms(),
     };
 
-    match crate::merger::check_pr_gate(&gh, &pr, &baseline, policy).await {
+    match crate::merger::check_pr_gate(gh.as_ref(), &pr, &baseline, policy).await {
         Ok(crate::merger::GateResult::Green) => {
             if dry_run {
                 println!(


### PR DESCRIPTION
Sub-1 (#1082) projected 4× from 'gh-spawn is the bottleneck.' Live measurement disproved the hypothesis. ReqwestGhClient is implemented anyway because (a) the modest measured win is real (1.29-1.47× in head-to-head benches), (b) the reqwest infrastructure is the substrate Sub-3 (GraphQL batching) needs for the actual 10× lever, and (c) honest measurement IS the substrate contract.

## Live numbers (M2 release, head-to-head)

  ShellGhClient    avg: 526-570 ms/call
  ReqwestGhClient  avg: 388-409 ms/call
  Speedup:         1.29-1.47×

Acceptance floor: 1.2× minimum. Catches a regression that loses the gh-spawn win without claiming a speedup we don't deliver.

## What we LEARNED

The gh-CLI subprocess spawn was only ~100ms of the 526ms per-call cost. The GitHub REST API itself is ~400ms. Replacing the wrapper saves spawn but can't shorten the API roundtrip. The actual lever is BATCHING — one GraphQL request fetches the baseline + all N PR rollups in a single roundtrip. That's Sub-3.

## What ships

- `reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "json"] }` in airc-cli's deps. rustls-tls aligns with airc-transport's existing rustls/ring stack — no openssl introduced. http2 enables connection keep-alive that amortises the TCP+TLS handshake across calls.
- `ReqwestGhClient` struct + `GhClient` trait impl. Same trait, same typed errors, swap is a one-line change at the call site.
- Token acquisition: `GITHUB_TOKEN` env first, fallback to one-time `gh auth token` spawn cached for process lifetime.
- `bench_reqwest_vs_shell_head_to_head` — live acceptance test (#[ignore]'d; run by hand with --release --ignored).

## What this DOES NOT do (Sub-3)

- pr_create is stubbed (not on the merger hot path; ShellGhClient still wires it)
- GraphQL batching for tick_snapshot (the actual 10× lever; carded separately)

## Methodology contribution

Fourth bench in the perf audit series shipping the SAME shape: write the measurement, get honest numbers, ship truth. Pattern is now: substrate paths fast (#1077/#1078/#1079), boundary paths slower but the right OPTIMISATION wasn't where we expected (this PR). Future perf work must show its measurement, not its hypothesis.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>