### PR TITLE
fix(monitor): from_now + coalesce_backlog — agents get live attention without backlog flood (card 7d5b6a65)

### DIFF
--- a/crates/airc-bus/src/ring.rs
+++ b/crates/airc-bus/src/ring.rs
@@ -102,6 +102,16 @@ impl HotRing {
             .collect()
     }
 
+    /// **Card 7d5b6a65.** The cursor of the most-recent entry currently
+    /// retained, if any. Used by [`EventRouter::head_cursor`] to
+    /// implement the "subscribe from the live edge" attach shape — pass
+    /// this cursor as `from_cursor` and the replay-after predicate
+    /// returns nothing, so the subscriber sees only events strictly
+    /// after the call (the agent-Monitor live-tail).
+    pub fn newest_cursor(&self) -> Option<Cursor> {
+        self.slots.back().map(|slot| slot.env.cursor())
+    }
+
     /// The cursor of the oldest entry currently retained, if any. A
     /// `from_cursor` older than this means the ring cannot serve the full
     /// replay and the deep (sink) leg must cover `(from, oldest_in_ring)`.

--- a/crates/airc-bus/src/router.rs
+++ b/crates/airc-bus/src/router.rs
@@ -307,6 +307,26 @@ impl EventRouter {
         }
     }
 
+    /// **Card 7d5b6a65.** Return the cursor of the most-recent envelope
+    /// in the channel's ring snapshot, or `None` if the channel has not
+    /// yet received any envelope.
+    ///
+    /// Callers use this to implement "subscribe from the live edge":
+    /// pass the returned cursor as `from_cursor` to [`Self::subscribe`]
+    /// and the deep-replay + ring-snapshot legs return empty (their
+    /// `is_after` predicate filters them out), so the subscriber gets
+    /// only events published strictly after the call. This is the
+    /// agent-Monitor live-tail shape — the `AttachRequest::from_now`
+    /// flag.
+    pub fn head_cursor(&self, channel: airc_core::RoomId) -> Option<Cursor> {
+        let n = self.inner.shards.len();
+        let idx = (channel.0.as_u128() % n as u128) as usize;
+        let shard = &self.inner.shards[idx];
+        let map = shard.channels.lock().unwrap_or_else(|p| p.into_inner());
+        map.get(&channel.0.as_u128())
+            .and_then(|state| state.ring.newest_cursor())
+    }
+
     /// Subscribe (§4 subscribe, §3.5 cursor contract).
     ///
     /// Returns a stream that yields **every** envelope on the filter strictly

--- a/crates/airc-bus/src/router.rs
+++ b/crates/airc-bus/src/router.rs
@@ -327,6 +327,25 @@ impl EventRouter {
             .and_then(|state| state.ring.newest_cursor())
     }
 
+    /// **Card 7d5b6a65.** Async fallback for [`Self::head_cursor`] that
+    /// queries the durable sink. Callers use this when the in-memory
+    /// ring is empty (fresh daemon start with backlog in the sink):
+    ///
+    /// ```ignore
+    /// let from = match router.head_cursor(channel) {
+    ///     Some(c) => Some(c),
+    ///     None => router.sink_head_cursor(channel).await,
+    /// };
+    /// ```
+    ///
+    /// Without this fallback, an `AttachRequest::from_now: true`
+    /// against a freshly-started daemon would fall through to
+    /// `from: None` and replay the whole sink — the exact bug card
+    /// 7d5b6a65 closes.
+    pub async fn sink_head_cursor(&self, channel: airc_core::RoomId) -> Option<Cursor> {
+        self.inner.sink.head_cursor(channel).await.ok().flatten()
+    }
+
     /// Subscribe (§4 subscribe, §3.5 cursor contract).
     ///
     /// Returns a stream that yields **every** envelope on the filter strictly

--- a/crates/airc-bus/src/sink.rs
+++ b/crates/airc-bus/src/sink.rs
@@ -41,6 +41,28 @@ pub trait DurableSink: Send + Sync {
         from_cursor: Option<Cursor>,
         limit: usize,
     ) -> Result<Vec<Envelope>>;
+
+    /// **Card 7d5b6a65.** Return the cursor of the most-recent persisted
+    /// event on `channel`, or `None` if the sink has no event for it.
+    ///
+    /// Used by [`crate::EventRouter::head_cursor`] to compute the
+    /// live edge when the in-memory ring is empty (fresh daemon
+    /// start with backlog in the sink — without this, an
+    /// `AttachRequest::from_now: true` would fall through to a full
+    /// transcript replay because `ring.newest_cursor()` returned None
+    /// and the deep-replay leg pages from `None` (= beginning).
+    ///
+    /// Default impl walks the full sink page to find the last cursor;
+    /// concrete impls should override with an efficient query
+    /// (`SELECT max((epoch, counter, event_id))` on SQLite, back-of-vec
+    /// on in-memory).
+    async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>> {
+        Ok(self
+            .page(channel, None, usize::MAX)
+            .await?
+            .last()
+            .map(|env| env.cursor()))
+    }
 }
 
 /// In-memory durable tier for tests. Records append count so the
@@ -117,6 +139,15 @@ impl DurableSink for InMemoryDurableSink {
         });
         guard.append_count += 1;
         Ok(())
+    }
+
+    async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>> {
+        let guard = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        Ok(guard
+            .events
+            .get(&channel.0.as_u128())
+            .and_then(|bucket| bucket.last())
+            .map(|env| env.cursor()))
     }
 
     async fn page(

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -792,14 +792,25 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
             MonitorAction::Format { peers_dir, my_name } => {
                 monitor::run_format(&peers_dir, &my_name)
             }
-            MonitorAction::Attach { my_name } => {
+            MonitorAction::Attach {
+                my_name,
+                from_now,
+                include_backlog,
+                coalesce_backlog,
+            } => {
                 let socket = default_or(None, &home);
                 // Return-value ignored: this call site only uses the
                 // daemon-side state (monitor::run_attach reads the
                 // store, not the socket). If discovery routes to a
                 // different socket, the home is what matters here.
                 let _socket = commands::ensure_daemon_running(&home, socket, parsed.peers).await?;
-                monitor::run_attach(&home, &my_name).await
+                // Card 7d5b6a65: clap resolves --include-backlog as
+                // the inverse of --from-now (they're conflicting
+                // flags). Defaults: from_now=true. coalesce_backlog
+                // defaults to true; flipped to false by user only
+                // when they want event-by-event replay (audit case).
+                let live_only = from_now && !include_backlog;
+                monitor::run_attach(&home, &my_name, live_only, coalesce_backlog).await
             }
         },
 

--- a/crates/airc-cli/src/monitor/attach.rs
+++ b/crates/airc-cli/src/monitor/attach.rs
@@ -11,7 +11,31 @@ use super::render::{normalize_channel, xml_escape, Sandbox};
 use crate::client_id::current_client_id;
 use crate::work_suggestions::render_claimable_work_for_event;
 
-pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error>> {
+/// One frame to surface on stdout — either a decoded transcript event
+/// or a one-shot summary line (the card-7d5b6a65 catch-up coalesce).
+///
+/// `Event` is boxed because `TranscriptEvent` is ~400 bytes (headers,
+/// body, signature, etc.) while `CatchUpSummary` is ~24 bytes; without
+/// the box every enum slot is sized for the largest variant and the
+/// channel buffer balloons. Box-on-the-heavy-variant is the standard
+/// fix and matches clippy's `large_enum_variant` lint guidance.
+enum MonitorFrame {
+    Event(Box<TranscriptEvent>),
+    /// Card 7d5b6a65 summary frame. Carries the daemon's catch-up
+    /// summary so the merger that joins multiple per-channel streams
+    /// can render it on the main thread without extra plumbing.
+    CatchUpSummary {
+        channel: RoomId,
+        skipped: u64,
+    },
+}
+
+pub(crate) async fn run(
+    home: &Path,
+    _my_name: &str,
+    from_now: bool,
+    coalesce_backlog: bool,
+) -> Result<(), Box<dyn Error>> {
     let airc = Airc::open(home).await?;
     let client_id = current_client_id().ok().flatten();
     let socket = crate::cli::default_socket_path_in(home);
@@ -22,7 +46,14 @@ pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error
     // attach stream per subscribed room and merges them into a single
     // feed. Each daemon `Event` carries airc-wire bytes — decoded once
     // here via the shared projection.
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<TranscriptEvent>(1024);
+    //
+    // Card 7d5b6a65: `from_now=true` (the default) asks the daemon to
+    // skip transcript replay and start at the live edge — no backlog
+    // flood. `coalesce_backlog=true` (only meaningful when `from_now`
+    // is false) asks the daemon to collapse the catch-up phase into a
+    // single `AttachCursorAdvanced` summary frame which the renderer
+    // surfaces as ONE stdout line instead of N historical events.
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<MonitorFrame>(1024);
     for channel in channels {
         let socket = socket.clone();
         let tx = tx.clone();
@@ -32,6 +63,8 @@ pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error
                 .attach(AttachRequest {
                     channel: Some(channel),
                     from: None,
+                    from_now,
+                    coalesce_backlog,
                     ..Default::default()
                 })
                 .await
@@ -40,15 +73,24 @@ pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error
                 Err(_) => return,
             };
             while let Ok(Some(response)) = read_frame::<_, Response>(&mut stream).await {
-                if let Response::Event { envelope } = response {
-                    match decode_wire_event(envelope) {
+                match response {
+                    Response::Event { envelope } => match decode_wire_event(envelope) {
                         Ok(event) => {
-                            if tx.send(event).await.is_err() {
+                            if tx.send(MonitorFrame::Event(Box::new(event))).await.is_err() {
                                 return;
                             }
                         }
                         Err(_) => return,
+                    },
+                    Response::AttachCursorAdvanced { skipped, .. }
+                        if tx
+                            .send(MonitorFrame::CatchUpSummary { channel, skipped })
+                            .await
+                            .is_err() =>
+                    {
+                        return;
                     }
+                    _ => {}
                 }
             }
         });
@@ -59,12 +101,30 @@ pub(crate) async fn run(home: &Path, _my_name: &str) -> Result<(), Box<dyn Error
     println!("airc: attached to Rust event stream for subscribed channels");
     std::io::stdout().flush()?;
 
-    while let Some(event) = rx.recv().await {
-        if let Some(text) = render_claimable_work_for_event(&airc, &event).await? {
-            sandbox.emit_contract_once();
-            render_text_event(&event, client_id.as_deref(), &text, &mut sandbox);
-        } else if matches!(event.kind, TranscriptKind::Message | TranscriptKind::System) {
-            render_event(&event, client_id.as_deref(), &mut sandbox);
+    while let Some(frame) = rx.recv().await {
+        match frame {
+            MonitorFrame::Event(event) => {
+                let event = *event;
+                if let Some(text) = render_claimable_work_for_event(&airc, &event).await? {
+                    sandbox.emit_contract_once();
+                    render_text_event(&event, client_id.as_deref(), &text, &mut sandbox);
+                } else if matches!(event.kind, TranscriptKind::Message | TranscriptKind::System) {
+                    render_event(&event, client_id.as_deref(), &mut sandbox);
+                }
+            }
+            MonitorFrame::CatchUpSummary { channel, skipped } => {
+                // ONE stdout line per channel that had backlog to
+                // catch up on. Card 7d5b6a65: the substrate
+                // contribution to keeping live-tail notification
+                // cost bounded regardless of backlog depth.
+                println!(
+                    "airc: caught up — skipped {} event{} on channel {} during backlog catch-up",
+                    skipped,
+                    if skipped == 1 { "" } else { "s" },
+                    channel.0
+                );
+                std::io::stdout().flush()?;
+            }
         }
     }
     Ok(())

--- a/crates/airc-cli/src/monitor/cli.rs
+++ b/crates/airc-cli/src/monitor/cli.rs
@@ -25,5 +25,30 @@ pub enum MonitorAction {
         /// Current local display name.
         #[arg(long)]
         my_name: String,
+        /// **Card 7d5b6a65.** Subscribe from the LIVE EDGE — only
+        /// events published strictly after the attach call return.
+        ///
+        /// Default. The agent-Monitor live-tail shape: no transcript
+        /// replay, no per-historical-event notification flood. Pass
+        /// `--include-backlog` for the legacy "give me everything"
+        /// behaviour.
+        #[arg(long, default_value_t = true, overrides_with = "include_backlog")]
+        from_now: bool,
+        /// **Card 7d5b6a65.** Opt INTO backlog replay. When set, the
+        /// daemon replays historical events on attach. With
+        /// `--coalesce-backlog` (default ON when this is set), the
+        /// catch-up is collapsed to ONE `caught up: skipped N events`
+        /// summary line; without it, each historical event is rendered
+        /// individually.
+        #[arg(long, default_value_t = false, conflicts_with = "from_now")]
+        include_backlog: bool,
+        /// **Card 7d5b6a65.** When backlog is replayed, collapse the
+        /// catch-up phase to ONE summary line instead of N
+        /// per-historical-event lines. Default ON whenever backlog is
+        /// included — pass `--no-coalesce-backlog` for the legacy
+        /// event-by-event replay (audit / replay tooling that needs
+        /// every historical envelope on stdout).
+        #[arg(long, default_value_t = true)]
+        coalesce_backlog: bool,
     },
 }

--- a/crates/airc-cli/src/monitor/mod.rs
+++ b/crates/airc-cli/src/monitor/mod.rs
@@ -24,6 +24,11 @@ pub fn run_format(peers_dir: &Path, my_name: &str) -> Result<(), Box<dyn Error>>
     }
 }
 
-pub async fn run_attach(home: &Path, my_name: &str) -> Result<(), Box<dyn Error>> {
-    attach::run(home, my_name).await
+pub async fn run_attach(
+    home: &Path,
+    my_name: &str,
+    from_now: bool,
+    coalesce_backlog: bool,
+) -> Result<(), Box<dyn Error>> {
+    attach::run(home, my_name, from_now, coalesce_backlog).await
 }

--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -294,8 +294,18 @@ where
     // forward-pointing cursor as "nothing newer than this yet," so the
     // ring snapshot + deep replay legs return empty and we go straight
     // to live.
+    //
+    // Critical: when the in-memory ring is empty (fresh daemon, no
+    // events yet this process-lifetime), `router.head_cursor` returns
+    // None — but the SINK still has the durable transcript. Without
+    // the sink fallback below, `from: None` would fall through to a
+    // full sink replay (the very bug card 7d5b6a65 closes). Query the
+    // sink for its head when the ring is empty.
     let mut from = if attach.from_now {
-        state.router.head_cursor(channel)
+        match state.router.head_cursor(channel) {
+            Some(c) => Some(c),
+            None => state.router.sink_head_cursor(channel).await,
+        }
     } else {
         attach
             .from
@@ -342,7 +352,16 @@ where
     // subscribe time) is reached, then emit ONE summary frame and
     // switch to per-event live streaming.
     let mut catchup = if coalesce_backlog {
-        Some(BacklogCatchup::new(state.router.head_cursor(channel)))
+        // Same ring-then-sink fallback as the `from_now` path above so
+        // a freshly-started daemon catching up on a real durable
+        // backlog actually has a `live_edge` to compare against (an
+        // empty ring with non-empty sink would otherwise treat every
+        // historical event as live and emit no summary).
+        let edge = match state.router.head_cursor(channel) {
+            Some(c) => Some(c),
+            None => state.router.sink_head_cursor(channel).await,
+        };
+        Some(BacklogCatchup::new(edge))
     } else {
         None
     };

--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -287,9 +287,28 @@ where
     // while detached), then go live with no dup at the seam. `from` is
     // advanced as we send, so a re-subscribe after a lag drop resumes
     // exactly where we left off.
-    let mut from = attach
-        .from
-        .map(|c| Cursor::new(Seq::new(c.epoch, c.counter), c.event_id));
+    //
+    // Card 7d5b6a65: `from_now` overrides any cursor the client passed
+    // with the channel's current head — the agent-Monitor live-tail
+    // shape. The router's `subscribe_with_lag` interprets a
+    // forward-pointing cursor as "nothing newer than this yet," so the
+    // ring snapshot + deep replay legs return empty and we go straight
+    // to live.
+    let mut from = if attach.from_now {
+        state.router.head_cursor(channel)
+    } else {
+        attach
+            .from
+            .map(|c| Cursor::new(Seq::new(c.epoch, c.counter), c.event_id))
+    };
+
+    // Card 7d5b6a65: `coalesce_backlog` lets the daemon collapse all
+    // historical catch-up into ONE `AttachCursorAdvanced` summary
+    // frame instead of streaming each event individually. We track the
+    // ring-snapshot's high-water cursor; everything at or before it is
+    // backlog (collapsed), everything after it is live (streamed
+    // event-by-event as before).
+    let coalesce_backlog = attach.coalesce_backlog && !attach.from_now;
 
     // Compile the consumer's kind/delivery/header filters into the router
     // filter, applied ROUTER-SIDE — the daemon never fans out an event a
@@ -318,6 +337,16 @@ where
     let shutdown = state.shutdown.notified();
     tokio::pin!(shutdown);
 
+    // Card 7d5b6a65 catch-up tracking. When `coalesce_backlog` is set,
+    // we count events until the ring's live-edge cursor (captured at
+    // subscribe time) is reached, then emit ONE summary frame and
+    // switch to per-event live streaming.
+    let mut catchup = if coalesce_backlog {
+        Some(BacklogCatchup::new(state.router.head_cursor(channel)))
+    } else {
+        None
+    };
+
     loop {
         let (stream, lag) = pending
             .take()
@@ -330,13 +359,33 @@ where
                 next = stream.next() => match next {
                     Some(env) => {
                         from = Some(env.cursor());
-                        write_response(
-                            &mut writer,
-                            &Response::Event {
-                                envelope: airc_wire::encode(&env).to_vec(),
-                            },
-                        )
-                        .await?;
+                        let suppressed = match catchup.as_mut() {
+                            Some(c) => c.observe(env.cursor()),
+                            None => false,
+                        };
+                        if suppressed {
+                            // Inside catch-up window — count and skip,
+                            // a single AttachCursorAdvanced will flush
+                            // when we cross the live edge.
+                        } else {
+                            // Flush a pending summary BEFORE the first
+                            // live event so the client sees the seam.
+                            if let Some(summary) =
+                                catchup.as_mut().and_then(BacklogCatchup::take_summary)
+                            {
+                                if summary.skipped > 0 {
+                                    write_response(&mut writer, &summary.into_response())
+                                        .await?;
+                                }
+                            }
+                            write_response(
+                                &mut writer,
+                                &Response::Event {
+                                    envelope: airc_wire::encode(&env).to_vec(),
+                                },
+                            )
+                            .await?;
+                        }
                         if lag.is_lagged() {
                             // Dropped a live push — break to re-resume
                             // from the last cursor we sent (no gap).
@@ -346,6 +395,98 @@ where
                     None => return Ok(()),
                 },
             }
+        }
+    }
+}
+
+/// Card 7d5b6a65: tracks the catch-up phase of an `attach` with
+/// `coalesce_backlog: true`. Counts envelopes at or before the
+/// snapshot live edge (captured at subscribe time) so the daemon can
+/// emit ONE `Response::AttachCursorAdvanced` summary at the live seam
+/// instead of forwarding each historical envelope.
+struct BacklogCatchup {
+    /// Cursor of the most recent envelope in the ring at subscribe
+    /// time. Anything at or before is backlog; anything after is live.
+    /// `None` means the channel was empty at subscribe — there is no
+    /// backlog phase to coalesce; the first event is live.
+    live_edge: Option<Cursor>,
+    /// Number of envelopes suppressed during catch-up so far.
+    skipped: u64,
+    /// Cursor of the most recent suppressed envelope; advances as we
+    /// observe more backlog. Reported in the summary so the client
+    /// can persist it for future reconnects.
+    last_skipped_cursor: Option<Cursor>,
+    /// Set once when we cross the live edge so subsequent events skip
+    /// the per-cursor comparison and stream as live.
+    crossed: bool,
+}
+
+impl BacklogCatchup {
+    fn new(live_edge: Option<Cursor>) -> Self {
+        Self {
+            live_edge,
+            skipped: 0,
+            last_skipped_cursor: None,
+            crossed: live_edge.is_some(),
+        }
+    }
+
+    /// Observe one envelope's cursor. Returns `true` when the envelope
+    /// is inside the catch-up window (caller should suppress it) and
+    /// `false` once we've crossed the live edge.
+    fn observe(&mut self, cursor: Cursor) -> bool {
+        if !self.crossed {
+            // No live_edge means the channel was empty at subscribe,
+            // so EVERYTHING that arrives is by definition live (no
+            // backlog phase).
+            return false;
+        }
+        if let Some(edge) = self.live_edge {
+            if cursor.is_after(&edge) {
+                self.crossed = false; // we've moved past catchup
+                return false;
+            }
+            self.skipped = self.skipped.saturating_add(1);
+            self.last_skipped_cursor = Some(cursor);
+            return true;
+        }
+        false
+    }
+
+    /// Pull the catch-up summary once we've crossed the live edge.
+    /// Returns `None` if there's nothing pending (already taken or
+    /// catch-up never had backlog).
+    fn take_summary(&mut self) -> Option<BacklogSummary> {
+        if self.crossed {
+            return None;
+        }
+        // crossed=false at this point means either (a) we observed
+        // something past the edge — pull the summary OR (b) we never
+        // had a live_edge to begin with. Mark crossed so we don't
+        // re-emit.
+        let skipped = self.skipped;
+        let advanced_to = self.last_skipped_cursor;
+        self.skipped = 0;
+        self.last_skipped_cursor = None;
+        self.crossed = true;
+        advanced_to.map(|cursor| BacklogSummary { skipped, cursor })
+    }
+}
+
+struct BacklogSummary {
+    skipped: u64,
+    cursor: Cursor,
+}
+
+impl BacklogSummary {
+    fn into_response(self) -> Response {
+        Response::AttachCursorAdvanced {
+            skipped: self.skipped,
+            advanced_to: airc_ipc::request::IpcCursor {
+                epoch: self.cursor.seq.epoch,
+                counter: self.cursor.seq.counter,
+                event_id: self.cursor.event_id,
+            },
         }
     }
 }

--- a/crates/airc-daemon/tests/attach_backlog_coalesce.rs
+++ b/crates/airc-daemon/tests/attach_backlog_coalesce.rs
@@ -1,0 +1,343 @@
+//! Card 7d5b6a65 acceptance proof: `attach` with `from_now: true`
+//! delivers no backlog, and `attach` with `coalesce_backlog: true`
+//! collapses the catch-up phase into ONE
+//! `Response::AttachCursorAdvanced` summary frame instead of streaming
+//! N historical events.
+//!
+//! Why this matters (Joel directive 2026-05-29): the agent-Monitor
+//! pattern (live attention-routing) breaks when every fresh attach
+//! replays days of transcript and fires one notification per
+//! historical event. The doctrine for `AttachRequest::from = None`
+//! said "starts from the live edge" but the implementation returned
+//! the whole ring; this card splits that intent: explicit `from_now`
+//! for the live-tail shape, explicit `coalesce_backlog` for the
+//! summary-frame catch-up shape.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use airc_core::{HeaderFilter, Headers, PeerId, RoomId};
+use airc_daemon::{run, DaemonRuntimeInfo, DaemonState};
+use airc_ipc::codec::read_frame;
+use airc_ipc::{
+    AttachRequest, DaemonClient, IpcDelivery, IpcKind, IpcTarget, PublishRequest, Response,
+};
+use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
+use airc_store::{EventStore, InMemoryEventStore};
+use tokio::task::JoinHandle;
+
+struct TestDaemon {
+    socket: PathBuf,
+    handle: JoinHandle<()>,
+    peer_id: PeerId,
+    _home: tempfile::TempDir,
+}
+
+fn unique_socket() -> PathBuf {
+    static N: AtomicU64 = AtomicU64::new(0);
+    let n = N.fetch_add(1, Ordering::Relaxed);
+    PathBuf::from(format!("/tmp/airc-abc-{}-{n}.sock", std::process::id()))
+}
+
+async fn start_daemon() -> TestDaemon {
+    let home = tempfile::TempDir::new().expect("tempdir");
+    let db_path = home.path().join("events.sqlite");
+    let peer_id = PeerId::new();
+    let keypair = PeerKeypair::generate();
+    let registry = PeerKeyRegistry::new();
+    registry
+        .enrol(peer_id, 0, keypair.public_bytes())
+        .expect("enrol self");
+    let coordinator: Arc<dyn EventStore> = Arc::new(InMemoryEventStore::new());
+    let state = Arc::new(
+        DaemonState::build(
+            peer_id,
+            keypair,
+            Arc::new(registry),
+            VerificationPolicy::Strict,
+            home.path().to_path_buf(),
+            &db_path,
+            coordinator,
+            DaemonRuntimeInfo::unknown(),
+        )
+        .await
+        .expect("build daemon state"),
+    );
+    let socket = unique_socket();
+    let server_state = state.clone();
+    let server_socket = socket.clone();
+    let handle = tokio::spawn(async move {
+        let _ = run(server_state, server_socket).await;
+    });
+    for _ in 0..200 {
+        if socket.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    TestDaemon {
+        socket,
+        handle,
+        peer_id,
+        _home: home,
+    }
+}
+
+impl TestDaemon {
+    async fn stop(self) {
+        let _ = DaemonClient::new(self.socket.clone()).stop().await;
+        let _ = tokio::time::timeout(Duration::from_secs(3), self.handle).await;
+    }
+}
+
+/// Publish `n` payloads through the daemon so they land in the ring +
+/// sink; the next attach will see them as backlog.
+async fn publish_n(daemon: &TestDaemon, channel: RoomId, n: usize) {
+    let client = DaemonClient::new(daemon.socket.clone());
+    let from_client = uuid::Uuid::new_v4();
+    for i in 0..n {
+        client
+            .publish(PublishRequest {
+                channel: channel.as_uuid(),
+                from_peer: daemon.peer_id.as_uuid(),
+                from_client,
+                target: IpcTarget::All,
+                kind: IpcKind::Message,
+                delivery: IpcDelivery::Durable,
+                correlation_id: None,
+                coalesce_key: None,
+                payload: format!("backlog event {i}").into_bytes(),
+                headers: Headers::new(),
+            })
+            .await
+            .expect("publish");
+    }
+}
+
+/// Card 7d5b6a65 acceptance: `from_now: true` sends NO historical
+/// envelopes, only events published strictly after the attach call
+/// returns.
+#[tokio::test]
+async fn attach_from_now_skips_full_backlog() {
+    let daemon = start_daemon().await;
+    let channel = RoomId::new();
+    publish_n(&daemon, channel, 30).await;
+    // Small breather so the ring is fully populated before attach.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = DaemonClient::new(daemon.socket.clone());
+    let mut stream = client
+        .attach(AttachRequest {
+            channel: Some(channel),
+            from: None,
+            from_now: true,
+            coalesce_backlog: false,
+            kinds: None,
+            delivery: None,
+            headers: HeaderFilter::default(),
+        })
+        .await
+        .expect("attach");
+    match read_frame::<_, Response>(&mut stream).await {
+        Ok(Some(Response::Ok)) => {}
+        other => panic!("expected Ok ack from attach, got {other:?}"),
+    }
+
+    // No event for a generous window. If the daemon were replaying
+    // backlog we'd see 30 Event frames here.
+    match tokio::time::timeout(
+        Duration::from_millis(300),
+        read_frame::<_, Response>(&mut stream),
+    )
+    .await
+    {
+        Err(_) => { /* timeout = no backlog delivered, expected */ }
+        Ok(Ok(Some(Response::Event { .. }))) => {
+            panic!("attach from_now=true must not deliver backlog events")
+        }
+        Ok(Ok(Some(Response::AttachCursorAdvanced { .. }))) => {
+            panic!("attach from_now=true must not deliver a catch-up summary either")
+        }
+        Ok(other) => panic!("unexpected frame on from_now stream: {other:?}"),
+    }
+
+    // Now publish a LIVE event; it MUST arrive.
+    let live_client = DaemonClient::new(daemon.socket.clone());
+    let from_client = uuid::Uuid::new_v4();
+    live_client
+        .publish(PublishRequest {
+            channel: channel.as_uuid(),
+            from_peer: daemon.peer_id.as_uuid(),
+            from_client,
+            target: IpcTarget::All,
+            kind: IpcKind::Message,
+            delivery: IpcDelivery::Durable,
+            correlation_id: None,
+            coalesce_key: None,
+            payload: b"live event".to_vec(),
+            headers: Headers::new(),
+        })
+        .await
+        .expect("publish live");
+
+    let live = tokio::time::timeout(
+        Duration::from_secs(2),
+        read_frame::<_, Response>(&mut stream),
+    )
+    .await
+    .expect("live event arrives")
+    .expect("frame")
+    .expect("Some");
+    match live {
+        Response::Event { envelope } => {
+            let env = airc_wire::decode(envelope.into()).expect("decode");
+            assert_eq!(env.payload.to_vec(), b"live event".to_vec());
+        }
+        other => panic!("expected Event frame for live, got {other:?}"),
+    }
+    daemon.stop().await;
+}
+
+/// Card 7d5b6a65 acceptance: `coalesce_backlog: true` causes the
+/// daemon to emit ONE `AttachCursorAdvanced` summary frame at the
+/// catch-up→live seam instead of streaming N historical Event frames.
+/// Live events that arrive after the summary still stream
+/// event-by-event as before.
+#[tokio::test]
+async fn attach_coalesce_backlog_emits_one_summary_then_live() {
+    let daemon = start_daemon().await;
+    let channel = RoomId::new();
+    const BACKLOG_N: usize = 30;
+    publish_n(&daemon, channel, BACKLOG_N).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = DaemonClient::new(daemon.socket.clone());
+    let mut stream = client
+        .attach(AttachRequest {
+            channel: Some(channel),
+            from: None,
+            from_now: false,
+            coalesce_backlog: true,
+            kinds: None,
+            delivery: None,
+            headers: HeaderFilter::default(),
+        })
+        .await
+        .expect("attach");
+    match read_frame::<_, Response>(&mut stream).await {
+        Ok(Some(Response::Ok)) => {}
+        other => panic!("expected Ok ack from attach, got {other:?}"),
+    }
+
+    // Publish ONE live event AFTER attach; arriving live, it triggers
+    // the catch-up summary flush + then its own Event frame.
+    let live_client = DaemonClient::new(daemon.socket.clone());
+    let from_client = uuid::Uuid::new_v4();
+    live_client
+        .publish(PublishRequest {
+            channel: channel.as_uuid(),
+            from_peer: daemon.peer_id.as_uuid(),
+            from_client,
+            target: IpcTarget::All,
+            kind: IpcKind::Message,
+            delivery: IpcDelivery::Durable,
+            correlation_id: None,
+            coalesce_key: None,
+            payload: b"after seam".to_vec(),
+            headers: Headers::new(),
+        })
+        .await
+        .expect("publish live");
+
+    // Frame 1: catch-up summary.
+    let summary = tokio::time::timeout(
+        Duration::from_secs(3),
+        read_frame::<_, Response>(&mut stream),
+    )
+    .await
+    .expect("first frame within timeout")
+    .expect("frame")
+    .expect("Some");
+    match summary {
+        Response::AttachCursorAdvanced { skipped, .. } => {
+            assert_eq!(
+                skipped, BACKLOG_N as u64,
+                "summary must account for every backlog envelope; \
+                 expected {BACKLOG_N}, got {skipped}"
+            );
+        }
+        other => panic!(
+            "expected AttachCursorAdvanced as first frame, got {other:?} \
+             — coalesce_backlog should collapse backlog into ONE summary"
+        ),
+    }
+
+    // Frame 2: the live event we published AFTER attach.
+    let live = tokio::time::timeout(
+        Duration::from_secs(2),
+        read_frame::<_, Response>(&mut stream),
+    )
+    .await
+    .expect("live event after summary")
+    .expect("frame")
+    .expect("Some");
+    match live {
+        Response::Event { envelope } => {
+            let env = airc_wire::decode(envelope.into()).expect("decode");
+            assert_eq!(env.payload.to_vec(), b"after seam".to_vec());
+        }
+        other => panic!("expected Event frame after summary, got {other:?}"),
+    }
+    daemon.stop().await;
+}
+
+/// Card 7d5b6a65 backward-compat acceptance: a client that omits
+/// `from_now` and `coalesce_backlog` (the pre-card-7d5b6a65 wire
+/// shape) gets the legacy event-by-event replay so audit / replay
+/// tooling that needs every historical envelope keeps working.
+#[tokio::test]
+async fn attach_legacy_shape_still_replays_event_by_event() {
+    let daemon = start_daemon().await;
+    let channel = RoomId::new();
+    const BACKLOG_N: usize = 5;
+    publish_n(&daemon, channel, BACKLOG_N).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = DaemonClient::new(daemon.socket.clone());
+    let mut stream = client
+        .attach(AttachRequest {
+            channel: Some(channel),
+            from: None,
+            // Both new fields default to false — the legacy wire shape.
+            ..Default::default()
+        })
+        .await
+        .expect("attach");
+    match read_frame::<_, Response>(&mut stream).await {
+        Ok(Some(Response::Ok)) => {}
+        other => panic!("expected Ok ack from attach, got {other:?}"),
+    }
+
+    // Collect BACKLOG_N Event frames — legacy event-by-event replay.
+    for i in 0..BACKLOG_N {
+        let frame = tokio::time::timeout(
+            Duration::from_secs(2),
+            read_frame::<_, Response>(&mut stream),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("backlog event {i} timeout"))
+        .expect("frame")
+        .expect("Some");
+        match frame {
+            Response::Event { .. } => { /* expected */ }
+            Response::AttachCursorAdvanced { .. } => panic!(
+                "legacy shape (no coalesce_backlog) must NOT emit \
+                 AttachCursorAdvanced; got it at event index {i}"
+            ),
+            other => panic!("unexpected frame at index {i}: {other:?}"),
+        }
+    }
+    daemon.stop().await;
+}

--- a/crates/airc-ipc/src/request.rs
+++ b/crates/airc-ipc/src/request.rs
@@ -153,9 +153,44 @@ pub struct AttachRequest {
     pub channel: Option<airc_core::RoomId>,
     /// Resume strictly after this cursor before going live — replay the
     /// gap the client missed while detached, then continue live with no
-    /// duplicate at the seam. `None` starts from the live edge.
+    /// duplicate at the seam.
+    ///
+    /// `None` historically meant "give me everything from the beginning
+    /// of the transcript" (despite the prior docstring claiming "live
+    /// edge"). Card 7d5b6a65 splits intent: pair `from: None` with
+    /// `from_now: true` for "skip backlog, just go live," and pair it
+    /// with `from_now: false` for the legacy full-backlog behavior.
+    /// Existing callers that omit `from_now` keep the prior shape (no
+    /// behavior change on the wire for pre-card-7d5b6a65 clients).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub from: Option<IpcCursor>,
+    /// **Card 7d5b6a65.** When `true`, the daemon overrides any `from`
+    /// value with the current head cursor at attach time — the client
+    /// gets no backlog at all, only events published strictly after
+    /// the attach call returns. This is the agent-Monitor live-tail
+    /// shape (the existing `from: None` behaviour replayed days of
+    /// transcript and fired one notification per historical event).
+    ///
+    /// Default `false` preserves the prior `from: None` = full-replay
+    /// behaviour for tools that depend on it (audit, replay,
+    /// codex-hook poll's first-attach catch-up).
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub from_now: bool,
+    /// **Card 7d5b6a65.** When `true`, the daemon emits ONE
+    /// [`Response::AttachCursorAdvanced`] summary frame at the end of
+    /// the backlog catch-up phase instead of streaming each historical
+    /// event individually, then transitions to live tail. Live events
+    /// still arrive one-at-a-time as before.
+    ///
+    /// Has no effect when there is no backlog to coalesce
+    /// (`from_now: true` or `from` already at head). Has no effect on
+    /// live events — only on the catch-up phase.
+    ///
+    /// Default `false` preserves the prior event-by-event replay so
+    /// audit/replay tools that need to see every historical envelope
+    /// keep working unchanged.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub coalesce_backlog: bool,
     /// If set, only these kinds are delivered.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kinds: Option<Vec<IpcKind>>,
@@ -168,6 +203,11 @@ pub struct AttachRequest {
     /// all; consumers scope by their `forge.*` projection headers.
     #[serde(default)]
     pub headers: HeaderFilter,
+}
+
+#[inline]
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// Parameters for `AddPeer`. `pubkey_b64` is the URL-safe-no-padding

--- a/crates/airc-ipc/src/response.rs
+++ b/crates/airc-ipc/src/response.rs
@@ -29,6 +29,24 @@ pub enum Response {
     /// encoding of the bus `Envelope`. The client decodes via
     /// `airc_wire::decode`.
     Event { envelope: Vec<u8> },
+    /// **Card 7d5b6a65.** Emitted by an `Attach` stream when the
+    /// client requested `coalesce_backlog: true` and the daemon had
+    /// backlog to catch up on. ONE summary frame per attach catch-up,
+    /// then the stream transitions to live tail; each subsequent live
+    /// event arrives as its own `Event` frame.
+    ///
+    /// `skipped` is the count of historical events the daemon
+    /// suppressed during catch-up. `advanced_to` is the cursor the
+    /// daemon resumed from — the client may persist this and pass it
+    /// as `from` on a future reconnect to skip the same backlog
+    /// without `from_now`. When `skipped: 0`, the catch-up phase was
+    /// empty (no backlog at attach time) and the frame is suppressed
+    /// — the daemon emits this variant only when it actually omitted
+    /// at least one event.
+    AttachCursorAdvanced {
+        skipped: u64,
+        advanced_to: IpcCursor,
+    },
     /// Response to `Publish` / `Send` — the owner-assigned receipt.
     Publish(PublishResponse),
     /// Response to `ListPeers` — the daemon's currently-enrolled

--- a/crates/airc-store/src/bus_sink.rs
+++ b/crates/airc-store/src/bus_sink.rs
@@ -179,6 +179,28 @@ impl DurableSink for SqliteDurableSink {
 
         rows.into_iter().map(from_model).collect()
     }
+
+    /// Card 7d5b6a65: efficient head-cursor query for the
+    /// `AttachRequest::from_now` path. The trait's default impl pages
+    /// the entire channel to find the last cursor; the SQLite override
+    /// picks the single row at the top of total order via the existing
+    /// composite index — bounded cost regardless of channel depth.
+    async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>, BusError> {
+        let row = bus_event::Entity::find()
+            .filter(bus_event::Column::RoomId.eq(channel.as_uuid()))
+            .order_by_desc(bus_event::Column::Epoch)
+            .order_by_desc(bus_event::Column::Counter)
+            .order_by_desc(bus_event::Column::EventId)
+            .one(&self.db)
+            .await
+            .map_err(|e| BusError::Sink(e.to_string()))?;
+        Ok(row.map(|r| {
+            Cursor::new(
+                airc_bus::Seq::new(r.epoch as u64, r.counter as u64),
+                airc_core::EventId(r.event_id),
+            )
+        }))
+    }
 }
 
 /// Put the connection in WAL journal mode (§3.3). WAL lets the


### PR DESCRIPTION
## What

Two compounding bugs broke the agent-Monitor live-tail pattern. Splits AttachRequest intent into explicit `from_now` (live edge) + `coalesce_backlog` (one summary frame for catch-up).

## Why

Joel direct quote 2026-05-29 observing the substrate-driven Monitor I'd started: **"a gazillion Monitor events ... should have been ONE ... inefficient."**

Two root causes:

1. **Implementation contradicts doctrine**. `AttachRequest::from`'s docstring said "`None` starts from the live edge," but `Ring::replay_after(None)` returns the whole ring and `Sink::page(None)` returns the whole tail. Result: every `monitor attach` replays days of transcript.
2. **Each historical event fires its own stream frame**. A fresh attach after backlog accumulated wakes the agent once per replayed event. 30 historical msgs = 30 interrupts.

This breaks the autonomous-personas-developing-continuum loop ([[airc-is-idp-and-bus-for-continuum]]) — without reliable live attention-routing, agents can't coordinate as teams.

## Substrate fix

### `AttachRequest` gains two fields (default false = wire-compat)

`from_now: bool` — daemon overrides any `from` cursor with the channel's current head via the new `EventRouter::head_cursor` / `Ring::newest_cursor` primitives. Subscriber gets only events published strictly after the attach call returns.

`coalesce_backlog: bool` — daemon collapses backlog catch-up into ONE summary frame instead of streaming N historical events.

### `Response` gains one variant

`AttachCursorAdvanced { skipped: u64, advanced_to: IpcCursor }` — emitted when `coalesce_backlog: true` and the daemon suppressed at least one envelope during catch-up. Daemon tracks a `BacklogCatchup` state machine that counts suppressed envelopes until the live-edge cursor (captured at subscribe time) is crossed, then flushes the summary BEFORE the first live event so the client sees the seam. Live events stream event-by-event as before.

## CLI

```
airc monitor attach --my-name <NAME>
  --from-now           (default ON)  live edge, no backlog
  --include-backlog    opt INTO backlog replay
  --coalesce-backlog   (default ON when --include-backlog)
                       emit ONE 'caught up: skipped N events on
                       channel <id>' line instead of N events
```

Renderer surfaces `AttachCursorAdvanced` as one stdout line per channel. Live events render unchanged.

## Acceptance proofs

In `crates/airc-daemon/tests/attach_backlog_coalesce.rs`:

| Test | Asserts |
| --- | --- |
| `attach_from_now_skips_full_backlog` | publish 30, attach `from_now=true`, observe no Event/AttachCursorAdvanced for 300ms, publish 1 live event, observe it arrives |
| `attach_coalesce_backlog_emits_one_summary_then_live` | publish 30, attach `coalesce_backlog=true`, observe AttachCursorAdvanced with skipped=30 as first frame, then the live event |
| `attach_legacy_shape_still_replays_event_by_event` | default both fields off (pre-card wire shape) replays N Events individually with NO summary frame — backward compat |

All 3 acceptance tests + the full workspace test suite green locally. Clippy clean (boxed `MonitorFrame::Event` for `large_enum_variant`, match-guard collapsed the nested if).

## Substrate doctrine

- Backward compat: existing IPC clients that omit the new fields get prior behaviour (full replay event-by-event). The new flags are opt-in additions.
- Substrate ships the mechanism; the CLI decides defaults (agent-friendly: `--from-now` ON).
- The `AttachCursorAdvanced.advanced_to` cursor is the natural payload for slice 3 (daemon-side per-client cursor) — clients can persist it and pass it as `from` on reconnect to skip the same backlog without `from_now`. Slice 3 is a follow-up card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)