### PR TITLE
feat(headers): canonical body-encryption header convention (card 1224aac2 slice 2)

### DIFF
--- a/crates/airc-protocol/src/headers_keys.rs
+++ b/crates/airc-protocol/src/headers_keys.rs
@@ -55,3 +55,79 @@ pub const HEADER_AIRC_CORRELATION_ID: &str = "airc.correlation_id";
 /// opaque routing metadata. Useful for receivers to dispatch
 /// matching handlers without parsing the body.
 pub const HEADER_AIRC_COMMAND_KIND: &str = "airc.command_kind";
+
+// ---------------------------------------------------------------------------
+// Body-encryption convention — card 1224aac2 slice 2
+// ---------------------------------------------------------------------------
+//
+// The substrate's wire crypto (frame signing, TLS-pinned transport) authenticates
+// + opaque-wraps the on-the-wire frame. Consumers that need their bodies to be
+// opaque ALSO to the substrate (defense-in-depth, content-key escrow, "even my
+// own daemon can't read this") wrap the body with their crypto of choice (JWE,
+// age, noise-box, whatever) BEFORE handing it to `publish`. The three headers
+// below are the canonical labeling convention so:
+//
+//   - UI / renderer surfaces show `[encrypted: <scheme>]` instead of rendering
+//     ciphertext as garbled text
+//   - key-rotation jobs can find every event using a given key by `key_id`
+//   - audit logs surface the scheme without decrypting
+//
+// Substrate ships the convention; consumers ship the crypto. Substrate does NOT
+// validate any of these — set them or don't, the daemon routes opaque either way.
+
+/// Body-encryption scheme identifier. Opaque consumer-defined string —
+/// `"jwe.A256GCM"`, `"age.v1"`, `"continuum.aead.v1"`, etc. Absence of the
+/// header is the substrate-visible signal that the body is plaintext.
+///
+/// Consumers MUST choose a scheme id that round-trips through their decode
+/// path — the substrate compares it only for equality across events (key
+/// rotation, audit grouping); never parses it.
+pub const HEADER_AIRC_BODY_ENC_SCHEME: &str = "airc.body.enc.scheme";
+
+/// Identifier of the key that encrypted this body. Free-form consumer string —
+/// could be a UUID, a key thumbprint, a label like `"continuum.user.<uid>.v3"`.
+/// Used by key-rotation jobs to enumerate events still encrypted under a
+/// rotated key; the substrate does no key management itself.
+pub const HEADER_AIRC_BODY_ENC_KEY_ID: &str = "airc.body.enc.key_id";
+
+/// Additional authenticated data (AAD) the encryptor bound the ciphertext
+/// to. Present when the consumer's scheme uses an AEAD that binds context
+/// (room id, sender peer, intended audience, etc.) into the ciphertext. The
+/// substrate stores + delivers it opaque; the decryptor must supply the same
+/// AAD on decrypt or authentication will fail closed.
+pub const HEADER_AIRC_BODY_ENC_AAD: &str = "airc.body.enc.aad";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Card 1224aac2 slice 2: the substrate's body-encryption convention
+    /// must STAY in the `airc.body.enc.*` namespace — adapters + audit
+    /// surfaces look up by exact string, so a rename here would silently
+    /// break renderer / rotation tooling without a compile error.
+    #[test]
+    fn body_encryption_header_names_are_stable() {
+        assert_eq!(HEADER_AIRC_BODY_ENC_SCHEME, "airc.body.enc.scheme");
+        assert_eq!(HEADER_AIRC_BODY_ENC_KEY_ID, "airc.body.enc.key_id");
+        assert_eq!(HEADER_AIRC_BODY_ENC_AAD, "airc.body.enc.aad");
+    }
+
+    /// Card 1224aac2 slice 2: every encryption header lives under the
+    /// substrate's `airc.*` namespace and never collides with the
+    /// consumer-owned `forge.*` / `continuum.*` / `openclaw.*` /
+    /// `hermes.*` / `opencode.*` / `x-*` spaces (see substrate design
+    /// doc, "Header namespaces" section).
+    #[test]
+    fn body_encryption_headers_in_substrate_namespace() {
+        for header in [
+            HEADER_AIRC_BODY_ENC_SCHEME,
+            HEADER_AIRC_BODY_ENC_KEY_ID,
+            HEADER_AIRC_BODY_ENC_AAD,
+        ] {
+            assert!(
+                header.starts_with("airc."),
+                "{header:?} must be in the substrate-owned `airc.*` namespace"
+            );
+        }
+    }
+}

--- a/crates/airc-protocol/src/lib.rs
+++ b/crates/airc-protocol/src/lib.rs
@@ -38,6 +38,7 @@ pub use assertion::{AssertionError, IdentityAssertion, ASSERTION_DOMAIN};
 pub use canonical::{canonical_signed_bytes, CanonicalError};
 pub use envelope::{ChannelId, Envelope, Frame, FrameKind};
 pub use headers_keys::{
+    HEADER_AIRC_BODY_ENC_AAD, HEADER_AIRC_BODY_ENC_KEY_ID, HEADER_AIRC_BODY_ENC_SCHEME,
     HEADER_AIRC_CLIENT, HEADER_AIRC_COMMAND_KIND, HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_DEADLINE,
     HEADER_AIRC_PRIORITY, HEADER_AIRC_REPLY_TO, HEADER_AIRC_TRACE_ID, HEADER_FORGE_BODY_HINT,
 };


### PR DESCRIPTION
## What

Three substrate-owned header constants under `airc.body.enc.*` so every consumer that wraps a body in its own crypto (JWE, age, AEAD, whatever) labels it the same way. The substrate does NOT decrypt — it routes opaque. The convention exists so consumer-side and observability tools (UI renderers, key-rotation jobs, audit surfaces) share one vocabulary.

## Why

Per Joel 2026-05-30: "this way you can communicate efficiently... the idea was within the settings room/channel you could get help from persona ais either in the widget/ux and this is within airc as well, as a room. you could join too."

A settings room is a live airc room where the user + persona AIs collaborate via chat (and a settings-editor widget renders the resulting state). Chat in that room about an API key is as sensitive as the key itself — consumer wraps both with its crypto of choice, substrate carries opaque, and the convention here is the labeling so:

| Header | Meaning |
| --- | --- |
| `airc.body.enc.scheme` | Opaque scheme id — `jwe.A256GCM`, `age.v1`, `continuum.aead.v1`, etc. Absence = plaintext. |
| `airc.body.enc.key_id` | Free-form key identifier — UUID, thumbprint, label. Enables rotation tracking. |
| `airc.body.enc.aad` | Additional authenticated data the encryptor bound the ciphertext to (room id, sender peer, audience). |

Substrate ships the convention; consumers ship the crypto. Same substrate-vs-consumer doctrine as `body_hint`, `TrustTier`, `wall` — substrate ships the mechanism, consumers ship the schema.

## Scope

Pure-additive. Three constants in `crates/airc-protocol/src/headers_keys.rs` plus re-export. No behavior change at the wire level. Routing, signing, verification all stay identical.

## Tests

Two unit-test pins:

- `body_encryption_header_names_are_stable` — string equality on each constant. Renames here silently break renderer + rotation tooling without a compile error, so this is the cheap belt-and-suspenders pin.
- `body_encryption_headers_in_substrate_namespace` — every constant starts with `airc.`. Prevents accidental drift into the consumer-owned `forge.*` / `continuum.*` / etc. namespaces.

Workspace tests + clippy + fmt clean locally.

## Card 1224aac2 context

This is slice 2 of card 1224aac2 (substrate primitives for recipe-instantiated rooms). The card was previously framed as "reserved \`#settings\` channel + auto-subscribe" — Joel corrected that 2026-05-30: rooms are DYNAMICALLY CREATED via continuum recipes, substrate provides primitives not categories. The reshape:

- **Slice 1** (per-room trust-tier route gate, wall-driven): next, but a separate PR.
- **Slice 2** (this PR): canonical encryption headers.
- **Slice 3** (latest-wins-per-key projection helper): also a follow-up PR.

Other cards that reference `airc.body.enc.*`:
- 89146139 (content-addressed blob store) — encrypted blob payloads carry the scheme header.
- ae3e1a47 (review-as-airc-event) — review notes carry the scheme header when the reviewer encrypts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)