### PR TITLE
fix(merger): reclaim card worktree on merge — close the orphan-worktree leak (card cdb477a2)

### DIFF
--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -33,7 +33,6 @@
 //!   should require a non-author LGTM. For now, ANY Review card
 //!   auto-merges if green — appropriate for single-author scopes; for
 //!   multi-author, the doctrine says "review before Review state."
-//! - Worktree cleanup on merge (card abe9fe4c).
 //! - Card-close on merged (currently relies on projection state and an
 //!   agent's explicit close; an observer would automate it).
 //!
@@ -474,6 +473,20 @@ async fn perform_merge(
         merged_at_ms: now_ms,
     })
     .await?;
+
+    // Card cdb477a2: reclaim the card's worktree now that its PR is
+    // merged. The CLI `airc work close` path already does this, but the
+    // merger closes the majority of cards and previously left every
+    // worktree behind (~/.airc/worktrees/<short> accumulated to 84).
+    // Best-effort: a cleanup refusal (uncommitted/unpushed work) logs a
+    // warning but must NOT fail the merge — the PR is already merged and
+    // the projection has transitioned.
+    if let Err(error) = crate::work_commands::cleanup_card_worktree(card.card_id).await {
+        eprintln!(
+            "airc-merger: worktree cleanup skipped for {} — {error}",
+            card.card_id
+        );
+    }
     Ok(())
 }
 

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -557,7 +557,14 @@ pub async fn run_state(
 ///     `git branch -D` if the branch has no other reachable refs.
 ///   * All operations run from the MAIN working tree (the cwd's
 ///     repo root), not from the worktree being removed.
-async fn cleanup_card_worktree(
+///
+/// Called from TWO terminal paths so a card's worktree is reclaimed
+/// regardless of who closes it: (1) the CLI `airc work close` path
+/// below, and (2) the merger's `perform_merge` after a successful
+/// `MarkPullRequestMerged` (card cdb477a2). The merger closes the
+/// majority of cards; without path (2) every merger-merged card
+/// leaked its worktree — the 84-orphan accumulation this fix targets.
+pub(crate) async fn cleanup_card_worktree(
     card_id: airc_lib::WorkCardId,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let short: String = card_id.to_string().chars().take(8).collect();


### PR DESCRIPTION
perform_merge published MarkPullRequestMerged but never removed the
card's worktree. The CLI `airc work close` path already calls
cleanup_card_worktree; the merger — which closes the majority of cards
— did not, so every merger-merged card left ~/.airc/worktrees/<short>
behind. 80+ accumulated (this session swept 79 verified clean+pushed).

The line-524 comment in work_commands.rs predicted this exact follow-up
("called from the merger's perform_merge path once that wiring lands");
this lands it.

- cleanup_card_worktree: now pub(crate); doc notes the two terminal
  callers (CLI close + merger merge).
- perform_merge: call cleanup_card_worktree after the merge succeeds.
  Best-effort — a refusal (uncommitted/unpushed work) logs and does NOT
  fail the merge, since the PR is already merged and the projection has
  transitioned.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>