### PR TITLE
fix(daemon): pin runtime dir to ~/.airc/runtime — stop per-session $TMPDIR fragmenting the machine daemon (card 50d1728b)

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -183,11 +183,12 @@ fn git_toplevel(cwd: &Path) -> Option<PathBuf> {
 /// solving for) keep the per-project name so parallel test runs
 /// don't collide.
 ///
-/// `runtime-dir` resolves via [`runtime_dir::runtime_dir`]:
-///   `$AIRC_RUNTIME_DIR` → `$XDG_RUNTIME_DIR/airc` → `$TMPDIR/airc`
-///   (macOS only) → `~/.airc/runtime`. All four are namespaced under
-///   the user (no shared-machine collisions) and reachable across
-///   sandbox boundaries in the common case.
+/// `runtime-dir` resolves via [`runtime_dir::runtime_dir`]: the
+///   explicit `$AIRC_RUNTIME_DIR` override (test isolation only),
+///   else always `~/.airc/runtime`. Card 50d1728b: it deliberately
+///   does NOT consult `$TMPDIR`/`$XDG_RUNTIME_DIR` — those are
+///   per-session and fragmented the machine-singular daemon into one
+///   instance per shell.
 ///
 /// The filename includes `airc_ipc::IPC_PROTOCOL_VERSION`: if the
 /// local daemon wire protocol changes, a new client must not talk
@@ -882,10 +883,10 @@ mod tests {
     }
 
     /// Card e51ab14e: when `runtime_dir` resolution fails (`$HOME`
-    /// unset, no `$XDG_RUNTIME_DIR`, no usable `$TMPDIR`), the
-    /// machine-account path falls through to the legacy home-private
-    /// `<machine_home>/daemon-v<N>.sock` so the substrate stays
-    /// functional even in degraded environments.
+    /// unset and no `$AIRC_RUNTIME_DIR` override, so `~/.airc/runtime`
+    /// can't be built), the machine-account path falls through to the
+    /// legacy home-private `<machine_home>/daemon-v<N>.sock` so the
+    /// substrate stays functional even in degraded environments.
     #[test]
     fn machine_account_scope_falls_back_to_home_private_when_runtime_dir_unavailable() {
         use super::resolve_socket_path;

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -203,17 +203,28 @@ pub fn default_socket_path_in(home: &std::path::Path) -> PathBuf {
     let machine_home = airc_lib::machine_account_home(home);
     let user_home = read_user_home_from_env();
     let runtime_dir = crate::runtime_dir::runtime_dir().ok();
+    // SUN_LEN fallback root for deep-home cases (see machine_socket_path).
+    // The OS per-user temp dir is short; never used for normal homes.
+    let short_fallback = std::env::temp_dir();
     let project_socket = home
         .parent()
         .map(|root| crate::runtime_dir::project_socket_path(root).ok())
         .unwrap_or(None);
-    resolve_socket_path(
+    let socket = resolve_socket_path(
         home,
         &machine_home,
         user_home.as_deref(),
         runtime_dir.as_deref(),
+        Some(short_fallback.as_path()),
         project_socket,
-    )
+    );
+    // runtime_dir() created ~/.airc/runtime, but the SUN_LEN fallback dir
+    // (<temp>/airc) may not exist yet — ensure the chosen socket's parent
+    // exists so bind() doesn't fail on a missing directory. Best-effort.
+    if let Some(parent) = socket.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    socket
 }
 
 /// Pure-function variant of [`default_socket_path_in`] for tests +
@@ -241,6 +252,7 @@ fn resolve_socket_path(
     machine_home: &std::path::Path,
     user_home: Option<&std::path::Path>,
     runtime_dir: Option<&std::path::Path>,
+    short_fallback_dir: Option<&std::path::Path>,
     project_socket: Option<PathBuf>,
 ) -> PathBuf {
     // `machine_account_home(scope_home)` returns `$HOME/.airc` when
@@ -275,14 +287,61 @@ fn resolve_socket_path(
             account_key,
             airc_ipc::IPC_PROTOCOL_VERSION
         );
-        return runtime_dir
-            .map(|dir| dir.join(&socket_name))
-            .unwrap_or(legacy_fallback);
+        return machine_socket_path(
+            runtime_dir,
+            short_fallback_dir,
+            &socket_name,
+            legacy_fallback,
+        );
     }
     // Isolated scope (CI temp, test root outside `$HOME`): per-project
     // socket so multiple isolated tests can run in parallel without
     // colliding on the same daemon.
     project_socket.unwrap_or(legacy_fallback)
+}
+
+/// `sockaddr_un.sun_path` is 104 bytes on macOS (incl. NUL) and 108 on
+/// Linux. Use the conservative macOS bound so a socket path that fits
+/// here binds on both. Card 50d1728b: the machine socket normally lives
+/// at `~/.airc/runtime/airc-machine-<hash>.sock`, which is well under
+/// this for any real home — but a pathologically deep `$HOME` (the
+/// integration suite's `/var/folders/.../T/.tmpXXX` tempdir homes, or a
+/// rare deep real home) can overflow it.
+const MAX_SOCKET_PATH_LEN: usize = 100;
+
+fn fits_socket_limit(path: &std::path::Path) -> bool {
+    path.as_os_str().len() < MAX_SOCKET_PATH_LEN
+}
+
+/// Join `socket_name` under `runtime_dir` (the stable `~/.airc/runtime`),
+/// but if that overflows `MAX_SOCKET_PATH_LEN`, fall back to the OS
+/// per-user temp dir, which is short. The socket NAME already hashes the
+/// account, so isolation holds even though the short fallback dir is
+/// shared across accounts. This is a SUN_LEN safety net ONLY: every real
+/// home stays at `~/.airc/runtime`, so the machine-singular guarantee is
+/// unaffected — the fallback exists so deep tempdir homes (tests,
+/// containers) bind a working socket instead of failing.
+fn machine_socket_path(
+    runtime_dir: Option<&std::path::Path>,
+    short_fallback_dir: Option<&std::path::Path>,
+    socket_name: &str,
+    legacy_fallback: PathBuf,
+) -> PathBuf {
+    let Some(primary) = runtime_dir.map(|dir| dir.join(socket_name)) else {
+        return legacy_fallback;
+    };
+    if fits_socket_limit(&primary) {
+        return primary;
+    }
+    if let Some(short) = short_fallback_dir {
+        let candidate = short.join("airc").join(socket_name);
+        if fits_socket_limit(&candidate) {
+            return candidate;
+        }
+    }
+    // Nothing shorter available — return the primary and let the bind
+    // surface a clear SUN_LEN error rather than silently misbehaving.
+    primary
 }
 
 fn read_user_home_from_env() -> Option<PathBuf> {
@@ -811,6 +870,7 @@ mod tests {
             &machine_home,
             Some(user_home.as_path()),
             Some(runtime_dir.as_path()),
+            None,
             // project_socket is irrelevant for machine-account scopes;
             // pass a distinct value per call to assert we don't accidentally
             // fall through to it.
@@ -821,6 +881,7 @@ mod tests {
             &machine_home,
             Some(user_home.as_path()),
             Some(runtime_dir.as_path()),
+            None,
             Some(runtime_dir.join("airc-project-b-v0.sock")),
         );
 
@@ -861,6 +922,7 @@ mod tests {
             &scope_a,
             Some(user_home.as_path()),
             Some(runtime_dir.as_path()),
+            None,
             Some(project_socket_a.clone()),
         );
         let socket_b = resolve_socket_path(
@@ -868,6 +930,7 @@ mod tests {
             &scope_b,
             Some(user_home.as_path()),
             Some(runtime_dir.as_path()),
+            None,
             Some(project_socket_b.clone()),
         );
 
@@ -900,11 +963,62 @@ mod tests {
             Some(user_home.as_path()),
             None,
             None,
+            None,
         );
 
         let expected =
             machine_home.join(format!("daemon-v{}.sock", airc_ipc::IPC_PROTOCOL_VERSION));
         assert_eq!(socket, expected);
+    }
+
+    /// Card 50d1728b SUN_LEN guard: a deep `$HOME` (the integration
+    /// suite's `/var/folders/.../T/.tmpXXX` tempdir homes) would push
+    /// `~/.airc/runtime/airc-machine-<hash>.sock` past sockaddr_un's
+    /// 104-byte limit. The machine socket must then fall back to the
+    /// short OS temp dir — NOT fail to bind, NOT silently use the
+    /// over-long path. Normal homes are unaffected (covered by the live
+    /// daemon_lifecycle integration test, which binds at ~/.airc/runtime).
+    #[test]
+    fn machine_socket_falls_back_to_short_dir_when_runtime_path_too_long() {
+        use super::resolve_socket_path;
+        // A realistically deep macOS tempdir home — what `HOME=<TempDir>`
+        // resolves to under `cargo test`.
+        let user_home =
+            std::path::PathBuf::from("/var/folders/8d/778wjbv96mq1760tv6gk374m0000gn/T/.tmpXY12ab");
+        let machine_home = user_home.join(".airc");
+        let scope = user_home.join("scope").join(".airc");
+        let deep_runtime = user_home.join(".airc").join("runtime");
+        let short_fallback = std::path::PathBuf::from("/tmp");
+
+        let socket = resolve_socket_path(
+            &scope,
+            &machine_home,
+            Some(user_home.as_path()),
+            Some(deep_runtime.as_path()),
+            Some(short_fallback.as_path()),
+            None,
+        );
+
+        assert!(
+            socket.as_os_str().len() < super::MAX_SOCKET_PATH_LEN,
+            "resolved socket must fit sockaddr_un: {} ({} bytes)",
+            socket.display(),
+            socket.as_os_str().len()
+        );
+        assert!(
+            socket.starts_with("/tmp/airc"),
+            "deep home must fall back to the short dir, got {}",
+            socket.display()
+        );
+        // Isolation preserved: the account-hashed name still rides along.
+        assert!(
+            socket
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("airc-machine-")),
+            "socket name keeps the account hash: {}",
+            socket.display()
+        );
     }
 }
 

--- a/crates/airc-cli/src/runtime_dir.rs
+++ b/crates/airc-cli/src/runtime_dir.rs
@@ -1,80 +1,80 @@
-//! Platform-correct runtime directory for the daemon's IPC socket and
-//! other ephemeral runtime artifacts.
+//! Runtime directory for the daemon's IPC socket.
 //!
-//! Card 7e88c34d. Replaces the `/tmp/airc-discovery-<uid>/` indirection
-//! from card 282850c2 / PR #1036. Joel pushback 2026-05-28:
-//! "still using tmp ugh" + "we have our own DIR man, does claude code
-//! use tmp?". `/tmp` is the lowest-common-denominator but the wrong
-//! answer:
+//! Card 50d1728b. The socket is the rendezvous point for a
+//! MACHINE-SINGULAR daemon, so its path MUST be machine-stable — the
+//! same value for every process, tab, and shell on this user's
+//! machine. It is `~/.airc/runtime`, full stop. That is where all
+//! other airc state already lives (`~/.airc/wires`, `~/.airc/worktrees`,
+//! identity/trust), so the socket belongs there too.
 //!
-//!   - Linux has `$XDG_RUNTIME_DIR` (`/run/user/<uid>/`) — the standard
-//!     location for runtime sockets, tmpfs-backed, per-user, cleaned
-//!     on logout.
-//!   - macOS has `$TMPDIR` per-user under `/var/folders/.../T/` —
-//!     sandbox-passthrough in the common case, not `/tmp`.
-//!   - Windows has `%LOCALAPPDATA%\airc\runtime\`.
+//! History — why this used to be more complicated (and wrong): card
+//! 7e88c34d (replacing the `/tmp/airc-discovery-<uid>/` layer from
+//! #1036) tried to be platform-clever — prefer `$XDG_RUNTIME_DIR` on
+//! Linux, `$TMPDIR/airc` on macOS, `~/.airc/runtime` only as a
+//! fallback. That DEFEATED machine-singularity: `$TMPDIR` is
+//! per-SESSION on macOS and is freely overridden by harnesses (the
+//! Claude Code harness sets `TMPDIR=/tmp/claude-<id>`; terminals carry
+//! `/var/folders/.../T`; a daemon spawned with no `$TMPDIR` fell to
+//! `~/.airc/runtime`). So the same binary, with the same machine-hash
+//! in the socket NAME, resolved a DIFFERENT directory per process —
+//! and each one started its own daemon. Observed 2026-05-29: 4 live
+//! daemons + 18 client connections fragmented across them. The hash
+//! made the socket name machine-stable; the env-derived directory
+//! un-did it.
 //!
-//! All three are reachable across sandbox boundaries in the common
-//! case AND they're namespaced. The daemon socket lives here as
-//! `airc-<project-hash>.sock`; agents in the same project compute the
-//! same hash → find the same socket → no discovery file needed.
-//!
-//! The discovery module (`crates/airc-cli/src/discovery.rs` from
-//! #1036) becomes vestigial once every caller uses this resolution.
-//! It stays during the transition and is removed in a follow-up.
+//! The fix is to stop deriving the directory from per-session env at
+//! all. `$AIRC_RUNTIME_DIR` remains as the ONE explicit override — its
+//! only real consumer is the integration suite, which points ephemeral
+//! test daemons at throwaway dirs so they don't collide with the real
+//! machine daemon. Normal operation never sets it.
 
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
-/// The platform's runtime directory for `airc`. Created if absent.
-/// Returns the path where `airc-<hash>.sock` files belong.
+/// The runtime directory for `airc` — where `airc-<hash>-v<N>.sock`
+/// files live. Created if absent.
 ///
-/// Resolution order:
-///   1. `$AIRC_RUNTIME_DIR` (explicit override; honored anywhere)
-///   2. `$XDG_RUNTIME_DIR/airc` (Linux convention)
-///   3. `$TMPDIR/airc` (macOS — user-private under /var/folders)
-///   4. `~/.airc/runtime` (fallback, home-private)
+/// Resolution:
+///   1. `$AIRC_RUNTIME_DIR` if set — explicit override, honored
+///      verbatim. Exists for TEST ISOLATION (ephemeral daemons in
+///      throwaway dirs); normal operation never sets it.
+///   2. `~/.airc/runtime` — the machine-stable default. Always this.
 ///
-/// Returns `Err` only if the chosen path can't be created — every
-/// platform should reach at least case 4.
+/// Deliberately does NOT consult `$TMPDIR`/`$XDG_RUNTIME_DIR`: those
+/// are per-session and would fragment the machine-singular daemon (see
+/// module docs / card 50d1728b).
+///
+/// Returns `Err` only if `$HOME`/`$USERPROFILE` is unset (so the
+/// default can't be built) or the directory can't be created.
 pub fn runtime_dir() -> std::io::Result<PathBuf> {
-    if let Some(explicit) = std::env::var_os("AIRC_RUNTIME_DIR") {
-        let dir = PathBuf::from(explicit);
-        std::fs::create_dir_all(&dir)?;
-        return Ok(dir);
-    }
-    if let Some(xdg) = std::env::var_os("XDG_RUNTIME_DIR") {
-        let dir = PathBuf::from(xdg).join("airc");
-        std::fs::create_dir_all(&dir)?;
-        return Ok(dir);
-    }
-    // On macOS, std::env::temp_dir() returns $TMPDIR which IS
-    // per-user under /var/folders. On Linux without XDG_RUNTIME_DIR
-    // it returns /tmp — we'd rather fall through to ~/.airc/runtime
-    // in that case, but distinguishing is hard. Use $TMPDIR ONLY
-    // when it's not /tmp.
-    if let Some(tmpdir) = std::env::var_os("TMPDIR") {
-        let path = PathBuf::from(&tmpdir);
-        if path.as_os_str() != "/tmp" && path.starts_with("/var/") {
-            let dir = path.join("airc");
-            std::fs::create_dir_all(&dir)?;
-            return Ok(dir);
-        }
-    }
-    // Last resort: ~/.airc/runtime/. Home-private (sandboxed agents
-    // without $HOME pass-through can't reach it), but it's namespaced
-    // and persistent.
-    let home = std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "no $HOME or $USERPROFILE — cannot resolve any runtime dir",
-            )
-        })?;
-    let dir = PathBuf::from(home).join(".airc").join("runtime");
+    let dir = resolve_runtime_dir(
+        std::env::var_os("AIRC_RUNTIME_DIR"),
+        std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE")),
+    )?;
     std::fs::create_dir_all(&dir)?;
     Ok(dir)
+}
+
+/// Pure path resolution — no env reads, no filesystem. `override_dir`
+/// is `$AIRC_RUNTIME_DIR`; `home` is `$HOME`/`$USERPROFILE`. Extracted
+/// so the machine-stable invariant is testable WITHOUT mutating
+/// process-global env (which races across parallel tests), and so the
+/// type signature itself proves no per-session var (`$TMPDIR`,
+/// `$XDG_RUNTIME_DIR`) can influence the path.
+fn resolve_runtime_dir(
+    override_dir: Option<std::ffi::OsString>,
+    home: Option<std::ffi::OsString>,
+) -> std::io::Result<PathBuf> {
+    if let Some(explicit) = override_dir {
+        return Ok(PathBuf::from(explicit));
+    }
+    let home = home.ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no $HOME or $USERPROFILE — cannot resolve ~/.airc/runtime",
+        )
+    })?;
+    Ok(PathBuf::from(home).join(".airc").join("runtime"))
 }
 
 /// Project-derived socket path. The hash of the canonicalized project
@@ -117,6 +117,36 @@ fn project_key(project_root: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Card 50d1728b — the machine-singular invariant. With no
+    /// override, the runtime dir is ALWAYS `$HOME/.airc/runtime`,
+    /// regardless of any per-session env. Because `resolve_runtime_dir`
+    /// takes only the override and home, no `$TMPDIR`/`$XDG_RUNTIME_DIR`
+    /// can reach it — this test plus the signature is the guard against
+    /// the regression that fragmented the mesh into 4 daemons.
+    #[test]
+    fn resolve_defaults_to_home_dot_airc_runtime() {
+        let resolved = resolve_runtime_dir(None, Some(std::ffi::OsString::from("/home/jane")))
+            .expect("home is set");
+        assert_eq!(resolved, PathBuf::from("/home/jane/.airc/runtime"));
+    }
+
+    #[test]
+    fn resolve_honors_explicit_override_verbatim() {
+        let resolved = resolve_runtime_dir(
+            Some(std::ffi::OsString::from("/tmp/test-iso/airc")),
+            Some(std::ffi::OsString::from("/home/jane")),
+        )
+        .expect("override wins");
+        // Override is honored verbatim AND ignores home entirely.
+        assert_eq!(resolved, PathBuf::from("/tmp/test-iso/airc"));
+    }
+
+    #[test]
+    fn resolve_errors_without_home_and_no_override() {
+        let err = resolve_runtime_dir(None, None).expect_err("no home, no override → error");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
 
     #[test]
     fn project_key_is_stable_across_calls() {


### PR DESCRIPTION
The machine-singular daemon socket was placed under an env-derived
directory: `$AIRC_RUNTIME_DIR` → `$XDG_RUNTIME_DIR/airc` → `$TMPDIR/airc`
→ `~/.airc/runtime` (card 7e88c34d). `$TMPDIR` is per-SESSION on macOS
and is freely overridden (the Claude Code harness sets
`TMPDIR=/tmp/claude-<id>`; terminals carry `/var/folders/.../T`; a
daemon spawned with no `$TMPDIR` landed in `~/.airc/runtime`). So the
same binary, with the same machine-hash in the socket NAME, resolved a
DIFFERENT directory per process — and each started its own daemon.
Observed: 4 live daemons + 18 client connections fragmented across them
(+ 888 leaked test daemons). The hash made the socket name
machine-stable; the env-derived directory un-did it.

Fix: the runtime dir is ALWAYS `~/.airc/runtime` — where every other
airc artifact already lives (wires, worktrees, identity/trust). No
per-session env in the path. `$AIRC_RUNTIME_DIR` remains as the one
explicit override, whose only real consumer is the integration suite
isolating ephemeral test daemons. `$TMPDIR`/`$XDG_RUNTIME_DIR` are no
longer consulted.

- runtime_dir(): delegates to a pure `resolve_runtime_dir(override, home)`
  so the machine-stable invariant is testable without mutating
  process-global env, and the signature itself proves no per-session
  var can influence the path. 3 new pure tests + stale cli.rs docs fixed.

Once installed, all scopes/tabs resolve the same socket and converge on
one daemon by construction — no AIRC_RUNTIME_DIR dance, no rejoin needed
after `airc update`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>