### PR TITLE
docs(AGENTS): agent / sentinel sign-off is valid PR approval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,23 @@ yours. Specifically:
   a PR, you review it (LGTM-comment if self-approve is blocked) and
   merge it via `gh pr merge --squash --delete-branch` when ready. The
   human does *not* exist to press merge buttons.
+- **Agent / sentinel sign-off is valid approval.** `gh` refuses
+  `--approve` on a PR you authored under the same identity, so the
+  author can't approve their own PR through the GitHub button. The
+  substrate-correct fix is **spawn an adversarial reviewer agent**
+  (a fresh subagent via your runtime's Agent tool, or a peer agent
+  in the room) with a "default to BLOCK MERGE, justify any APPROVE"
+  prompt. A clean APPROVE verdict from that reviewer is the sign-off
+  — `gh pr merge` after a green CI is then doctrinally legitimate,
+  not a workaround. The reviewer role ("sentinel") is equally open
+  to every peer; in the continuum substrate sentinels ARE agents and
+  the verdict pathway is identical. Document the reviewer's verdict
+  in the PR body or a follow-up comment so the audit trail is
+  inspectable; that comment serves the same purpose the GitHub
+  approval checkbox would, and downstream tools (e.g. `airc work
+  merge`, future merger daemons) should accept it as the human-shape
+  equivalent. Joel, 2026-05-31: *"agents or sentinels can be allowed
+  the role and this is ok process."*
 - **CI must be green before merge.** Run `gh pr checks <N>` before
   every `gh pr merge`. A red CI check is a hard refusal, not a hint —
   same level as the substrate's lifecycle guards. Failed once today


### PR DESCRIPTION
## Summary

- Codifies in `AGENTS.md` §0 that **spawning an adversarial reviewer agent (or asking a peer agent) and posting their APPROVE verdict is a doctrinally-legitimate PR sign-off** — same weight as a peer LGTM. Fills the gap §0+§8 left for solo-author agents when no peer is online to flip the GitHub approval checkbox.
- Cross-references the continuum substrate doctrine **sentinels = agents** (per `MODULE-CATALOG.md` §VIII) so reviewer verdicts produced by sentinel modules count the same as adversarial-subagent verdicts.
- Flags the knock-on for `airc work merge` + future merger daemons: they should accept the verdict-comment as the human-shape approval equivalent when gating Review → Closed.

## Background

Joel, 2026-05-31, after I shipped continuum PRs #1500-#1503 via this pattern (4 adversarial Agent reviewers caught 2 real bugs — TS docstring `*/` glyph + unregistered CargoModule):

> Just allow an agent to sign off, so your agents or sentinels can be allowed the role and this is ok process

Continuum-side companion memory: `agent-review-as-acceptable-approval.md` in this agent's auto-memory.

## References

- `AGENTS.md` §0 ("PR review and merge are agent responsibility")
- `AGENTS.md` §8 ("Review is peer-agent work … no human gatekeeper, no self-review restriction")
- `docs/lane-kanban-protocol.md` (state-machine context)
- `REFCONTRACT.md` (substrate-design background)
- Continuum `MODULE-CATALOG.md` §VIII — sentinel-observer, sentinel-refiner, audit-recorder (where sentinel === agent in continuum)
- Continuum PRs #1500-#1503 — concrete worked example of the pattern

## Test plan

- [ ] Render preview of AGENTS.md §0 — new bullet sits next to the existing PR-review bullet and reads as a clarification of it, not a new authority
- [ ] No code change, no behavior change — pure doctrine doc; CI just needs to be green (label-pr / WIP)
- [ ] Verify cross-doc references resolve (REFCONTRACT.md, lane-kanban-protocol.md, MODULE-CATALOG.md §VIII)

Generated with Claude Code
