### PR TITLE
fix(work): work_board(usize::MAX) → work_board_complete(PAGE_SIZE) at all 9 callsites (card acd72c81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Continuum uses airc-style channels as the transport substrate for live rooms whe
 
 The same channel model can back other consumers. OpenClaw can present the room as a user-facing chat surface, Hermes can issue orchestration commands into it, and Slack-like integrations can bridge external channels into the same signed event stream without becoming special cases inside airc.
 
+Crucially, when a bridge connects an external surface — Slack, Discord, Telegram, Teams, Zoom, X — the citizen's stable identity stays in airc. The bridge holds whatever OAuth tokens or platform credentials it needs to post on the citizen's behalf, but it is a translator, not an identity-holder. Unplug the bridge and the citizen persists. Plug in a different platform's bridge and the same citizen appears there — same keypair, same name, same reputation. This is what "same personas, everywhere" means at the substrate level.
+
 ## Embedded Consumers
 
 airc is a command-line chat tool and an embeddable Rust substrate. Applications should use `airc-lib` instead of shelling out when they need event streams, cursor replay, or typed filtering.

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -111,7 +111,7 @@ pub async fn run_review(
 
     // Resolve the parent off the current room's board. Refusing on
     // "no parent" is more useful than spawning an orphan review.
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc.work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE).await?;
     let parent = board.card(parent_card_id).ok_or_else(|| {
         format!(
             "parent card {parent_card_id} not found in the current room's board; \
@@ -334,7 +334,7 @@ async fn resolve_my_active_claim(
     airc: &airc_lib::Airc,
     card_id: airc_lib::WorkCardId,
 ) -> Result<airc_lib::ClaimId, Box<dyn std::error::Error>> {
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc.work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE).await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not present in the board projection"))?;
@@ -452,7 +452,7 @@ pub async fn run_state(
     // self-attesting Merged; this one refuses agents from
     // self-attesting Closed without a Merged predecessor.
     if card_state == CardState::Closed {
-        let board = airc.work_board(usize::MAX).await?;
+        let board = airc.work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE).await?;
         let card = board.card(card_uuid).ok_or_else(|| {
             format!("card {card_uuid} not visible in current room's board projection")
         })?;
@@ -698,7 +698,7 @@ pub(crate) async fn auto_spawn_review_card(
     parent_id: airc_lib::WorkCardId,
     pr_url: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc.work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE).await?;
     let parent = board
         .card(parent_id)
         .ok_or_else(|| format!("parent card {parent_id} no longer in board projection"))?;
@@ -837,7 +837,7 @@ pub async fn run_merge(
     let airc = crate::commands::attached_airc(home).await?;
     let card_uuid = parse_work_card_id(&card_id)?;
 
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc.work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE).await?;
     let card = board.card(card_uuid).ok_or_else(|| {
         format!("card {card_uuid} not visible in current room's board projection")
     })?;

--- a/crates/airc-cli/src/work_commands_gh.rs
+++ b/crates/airc-cli/src/work_commands_gh.rs
@@ -29,7 +29,7 @@ pub(crate) async fn open_pr_and_link(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use airc_work::model::{BranchName, PullRequestRef};
 
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc.work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE).await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;
@@ -198,7 +198,7 @@ pub(crate) async fn link_existing_pr(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use airc_work::model::{BranchName, PullRequestRef};
 
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc.work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE).await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;

--- a/crates/airc-cli/src/work_commands_git.rs
+++ b/crates/airc-cli/src/work_commands_git.rs
@@ -22,7 +22,7 @@ pub(crate) async fn spawn_claim_worktree(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Need the card's title for the branch slug — board projection
     // is the source of truth.
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc.work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE).await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;

--- a/crates/airc-ipc/src/lib.rs
+++ b/crates/airc-ipc/src/lib.rs
@@ -26,6 +26,7 @@ pub mod client;
 pub mod codec;
 pub mod request;
 pub mod response;
+pub mod sdk_conversions;
 pub mod transport;
 
 /// Local daemon IPC ABI version.
@@ -45,5 +46,6 @@ pub use request::{
     PublishRequest, RemovePeerRequest, Request, SendRequest,
 };
 pub use response::{InboxResponse, PeersResponse, PublishResponse, Response, StatusResponse};
+pub use sdk_conversions::{COUNTER_BITS, COUNTER_MASK};
 // IpcListener / IpcStream stay under `transport` because only the
 // daemon host and low-level tests need the raw byte transport.

--- a/crates/airc-ipc/src/sdk_conversions.rs
+++ b/crates/airc-ipc/src/sdk_conversions.rs
@@ -1,0 +1,242 @@
+//! `impl From<>` blocks bridging airc's SDK transcript vocabulary
+//! (`FrameKind`, `MentionTarget`, `TranscriptCursor` — from airc-core /
+//! airc-protocol) to the IPC wire vocabulary introduced in the v5
+//! owner-core rewrite (`IpcKind`, `IpcTarget`, `IpcCursor`).
+//!
+//! ### Why these live here
+//!
+//! The conversions are **substrate surface** — any consumer that builds
+//! `PublishRequest` from SDK-shaped state (continuum-core, Hermes,
+//! OpenClaw, future grid workers, the airc CLI itself) needs them.
+//! Before this module they lived as private `fn framekind_to_ipc` /
+//! `fn mention_to_ipc_target` / `pack_seq` / `unpack_seq` helpers in
+//! `airc-lib/src/daemon.rs`, which meant every external consumer had
+//! to either re-implement the same math (drift risk) or pull all of
+//! `airc-lib` to call a private fn (canonical SDK is shaped wrong for
+//! drive-by use).
+//!
+//! Promoting them to `impl From<>` in `airc-ipc` (the smallest crate
+//! that depends on both airc-core and airc-protocol) keeps the
+//! translation co-located with the IPC vocabulary it produces and lets
+//! every consumer write `pub_req.kind = frame_kind.into()` instead of
+//! reaching for a free function or duplicating a bit-shift.
+//!
+//! ### Drift guard
+//!
+//! [`COUNTER_BITS`] is published as a `pub const` so any consumer that
+//! needs to reproduce the layout (e.g. for in-memory cursor math
+//! without going through the conversion) can pin against the same
+//! constant — never against a literal `40`. If airc ever changes the
+//! pack layout, every dependent recompiles and round-trip tests
+//! everywhere catch the regression.
+
+use airc_core::{MentionTarget, TranscriptCursor};
+use airc_protocol::FrameKind;
+
+use crate::request::{IpcCursor, IpcKind, IpcTarget};
+
+/// Number of low-order bits in the packed `lamport` reserved for the
+/// per-epoch `counter`. The high bits hold `epoch`. Pinned at 40 — see
+/// `airc-lib/src/daemon.rs` (`pack_seq`/`unpack_seq`) for the historical
+/// rationale (40 bits = ~1.1T counter values per epoch, far beyond any
+/// real channel; the remaining 24 bits of `epoch` cover ~16M owner
+/// generations).
+pub const COUNTER_BITS: u32 = 40;
+
+/// Mask for the low [`COUNTER_BITS`] bits — the per-epoch counter range.
+pub const COUNTER_MASK: u64 = (1u64 << COUNTER_BITS) - 1;
+
+impl From<FrameKind> for IpcKind {
+    /// Lossless: the three chat-flavored `FrameKind` variants are a
+    /// subset of the seven `IpcKind` variants. RPC/grid consumers that
+    /// need `Command`/`CommandResult`/`Signal`/`StreamChunk` construct
+    /// `IpcKind` directly without going through `FrameKind`.
+    fn from(kind: FrameKind) -> Self {
+        match kind {
+            FrameKind::Message => IpcKind::Message,
+            FrameKind::Event => IpcKind::Event,
+            FrameKind::Control => IpcKind::Control,
+        }
+    }
+}
+
+impl From<MentionTarget> for IpcTarget {
+    /// Lossless: room mentions round-trip as a named endpoint
+    /// (`room:<uuid>`), which the inverse projection in airc-lib
+    /// (`target_to_mention`) parses back into [`MentionTarget::Room`].
+    /// Direct peer + broadcast pass straight through.
+    fn from(target: MentionTarget) -> Self {
+        match target {
+            MentionTarget::All => IpcTarget::All,
+            MentionTarget::Peer(peer) => IpcTarget::Peer(peer),
+            MentionTarget::Room(room) => IpcTarget::Endpoint(format!("room:{}", room.as_uuid())),
+        }
+    }
+}
+
+impl From<TranscriptCursor> for IpcCursor {
+    /// Unpack the SDK's single monotonic `lamport` into the wire
+    /// vocabulary's `(epoch, counter)` split. Inverse of
+    /// `IpcCursor → TranscriptCursor`. Round-trip preserves the
+    /// packed value byte-for-byte.
+    fn from(cursor: TranscriptCursor) -> Self {
+        Self {
+            epoch: cursor.lamport >> COUNTER_BITS,
+            counter: cursor.lamport & COUNTER_MASK,
+            event_id: cursor.event_id,
+        }
+    }
+}
+
+impl From<IpcCursor> for TranscriptCursor {
+    /// Pack the wire vocabulary's `(epoch, counter)` into the SDK's
+    /// monotonic `lamport`. Inverse of `TranscriptCursor → IpcCursor`.
+    /// The daemon always produces values within the
+    /// `(epoch << COUNTER_BITS) | counter` invariant, so this conversion
+    /// is total + round-trip safe for any cursor the daemon emits.
+    fn from(cursor: IpcCursor) -> Self {
+        Self {
+            lamport: (cursor.epoch << COUNTER_BITS) | (cursor.counter & COUNTER_MASK),
+            event_id: cursor.event_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::{EventId, RoomId};
+    use uuid::Uuid;
+
+    #[test]
+    fn frame_kind_message_event_control_map_to_ipc_kind() {
+        assert!(matches!(
+            IpcKind::from(FrameKind::Message),
+            IpcKind::Message
+        ));
+        assert!(matches!(IpcKind::from(FrameKind::Event), IpcKind::Event));
+        assert!(matches!(
+            IpcKind::from(FrameKind::Control),
+            IpcKind::Control
+        ));
+    }
+
+    #[test]
+    fn mention_all_to_ipc_target_all() {
+        assert!(matches!(
+            IpcTarget::from(MentionTarget::All),
+            IpcTarget::All
+        ));
+    }
+
+    #[test]
+    fn mention_room_to_endpoint_with_room_prefix() {
+        let room = RoomId::from_uuid(Uuid::from_u128(0xA1));
+        let target: IpcTarget = MentionTarget::Room(room).into();
+        match target {
+            IpcTarget::Endpoint(name) => {
+                assert!(name.starts_with("room:"));
+                assert!(name.contains(&room.as_uuid().to_string()));
+            }
+            other => panic!("expected Endpoint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cursor_round_trip_preserves_lamport_and_event_id() {
+        let original = TranscriptCursor {
+            lamport: (7u64 << COUNTER_BITS) | 99_999_999,
+            event_id: EventId::from_u128(0xc0ffee),
+        };
+        // TranscriptCursor isn't Copy — save the comparison values
+        // before the conversion consumes `original`.
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, 7);
+        assert_eq!(ipc.counter, 99_999_999);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+
+    #[test]
+    fn cursor_round_trip_with_zero_packs_to_zero() {
+        let original = TranscriptCursor {
+            lamport: 0,
+            event_id: EventId::from_u128(0),
+        };
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, 0);
+        assert_eq!(ipc.counter, 0);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, 0);
+    }
+
+    #[test]
+    fn counter_bits_constant_matches_legacy_airc_lib_layout() {
+        // Drift guard: airc-lib/src/daemon.rs hard-codes COUNTER_BITS = 40.
+        // If anyone changes either, this test (or an airc-lib test
+        // referencing this constant after the inline copy is deleted)
+        // will fail loud. Pin via this assertion so the const isn't
+        // silently shifted.
+        assert_eq!(COUNTER_BITS, 40);
+        assert_eq!(COUNTER_MASK, (1u64 << 40) - 1);
+    }
+
+    #[test]
+    fn cursor_round_trip_at_max_counter_boundary() {
+        // Counter is COUNTER_MASK (all 40 bits set), epoch is 0. This
+        // is the boundary where adding one to counter would overflow
+        // into epoch — the very edge the mask guards.
+        let original = TranscriptCursor {
+            lamport: COUNTER_MASK,
+            event_id: EventId::from_u128(0xb01dface),
+        };
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, 0);
+        assert_eq!(ipc.counter, COUNTER_MASK);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+
+    #[test]
+    fn cursor_round_trip_at_high_epoch_boundary() {
+        // Epoch occupies the high (64 - 40 = 24) bits. Setting the
+        // top epoch bit exercises the entire address space packing,
+        // catching any sign-extension or shift-direction regression.
+        // 2^23 fits cleanly in u64 << 40 without overflow.
+        let epoch = 1u64 << 23;
+        let counter = 12345u64;
+        let original = TranscriptCursor {
+            lamport: (epoch << COUNTER_BITS) | counter,
+            event_id: EventId::from_u128(0xfacefeed),
+        };
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, epoch);
+        assert_eq!(ipc.counter, counter);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+
+    #[test]
+    fn cursor_round_trip_at_u64_max_lamport() {
+        // u64::MAX has every bit set — the absolute upper bound the
+        // pack/unpack must handle without overflow. Epoch should be
+        // (u64::MAX >> 40), counter should be COUNTER_MASK.
+        let original = TranscriptCursor {
+            lamport: u64::MAX,
+            event_id: EventId::from_u128(0xdeadbeef),
+        };
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, u64::MAX >> COUNTER_BITS);
+        assert_eq!(ipc.counter, COUNTER_MASK);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+}

--- a/crates/airc-lib/src/agent_heartbeat.rs
+++ b/crates/airc-lib/src/agent_heartbeat.rs
@@ -518,7 +518,7 @@ async fn refresh_coordination(
     airc: &crate::Airc,
     baseline: &CoordinationSignal,
 ) -> Result<CoordinationSignal, AircError> {
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc.work_board_complete(crate::WORK_BOARD_PROJECTION_PAGE_SIZE).await?;
     let me = airc.peer_id();
     let active_claims: Vec<WorkCardId> = board
         .snapshot()

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -213,6 +213,42 @@ impl Airc {
         Ok(airc.with_daemon_client(DaemonClient::new(socket.into())))
     }
 
+    /// Attach to an already-running daemon AND open the local identity
+    /// under a specific `agent_name`. This is the constructor a multi-
+    /// citizen host (Continuum personas, future external-agent hosts)
+    /// reaches for when each hosted citizen needs:
+    ///
+    /// 1. Its OWN identity, distinguishable from other citizens'
+    ///    (the [`open_as`] half), so `airc peers` from another scope
+    ///    shows each one as a separate enrolled participant.
+    /// 2. The daemon's live publish/subscribe (the [`attach`] half),
+    ///    so the citizen can `say()` and `subscribe()` over the
+    ///    router instead of only inspecting local state.
+    ///
+    /// Today, [`attach`] only offers (2) (under the host's default
+    /// agent_name) and [`open_as`] only offers (1) (owner-mode, no
+    /// daemon). Hosting multiple citizens in one process with the
+    /// pre-existing pair therefore needs an unergonomic dance with
+    /// the (intentionally private) `with_daemon_client` builder.
+    /// This constructor closes the gap as a single call.
+    ///
+    /// Equivalent to:
+    /// ```ignore
+    /// let airc = Airc::open_as(home, agent_name).await?
+    ///     .with_daemon_client(DaemonClient::new(socket));
+    /// ```
+    ///
+    /// — but spelled as one method so consumers don't reach for the
+    /// private builder.
+    pub async fn attach_as(
+        home: impl Into<PathBuf>,
+        agent_name: impl Into<String>,
+        socket: impl Into<PathBuf>,
+    ) -> Result<Self, AircError> {
+        let airc = Self::open_as(home, agent_name).await?;
+        Ok(airc.with_daemon_client(DaemonClient::new(socket.into())))
+    }
+
     /// Test-only [`attach`] that pins the machine-account wire root
     /// explicitly instead of deriving it from `HOME`/`USERPROFILE`.
     /// Two scopes sharing one `wire_root` resolve the same mesh

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -19,8 +19,8 @@ use airc_bus::envelope::{Envelope, Kind, Target};
 use airc_core::{Body, MentionTarget, RoomId, TranscriptCursor, TranscriptEvent, TranscriptKind};
 use airc_ipc::codec::read_frame;
 use airc_ipc::{
-    AttachRequest, InboxRequest, IpcCursor, IpcDelivery, IpcKind, IpcTarget, PublishRequest,
-    Response, SendRequest,
+    AttachRequest, InboxRequest, IpcCursor, IpcDelivery, IpcTarget, PublishRequest, Response,
+    SendRequest,
 };
 use airc_protocol::FrameKind;
 use tokio::sync::mpsc;
@@ -34,8 +34,11 @@ use crate::Airc;
 /// Low bits of the packed `lamport` that hold the per-epoch counter; the
 /// remaining high bits hold the epoch. 40 bits ⇒ ~1.1e12 events per
 /// epoch and ~16.7M epochs (restarts) — neither realistically reachable.
-const COUNTER_BITS: u32 = 40;
-const COUNTER_MASK: u64 = (1 << COUNTER_BITS) - 1;
+//
+// Re-exported from airc-ipc so the wire vocabulary and the SDK
+// projection can never disagree on layout. Anyone reading
+// `COUNTER_BITS` here gets the same value as the IPC From impls.
+use airc_ipc::{COUNTER_BITS, COUNTER_MASK};
 
 /// Reconnect backoff for a daemon attach stream that drops (daemon
 /// restart / transient loss): start small, double, cap — so a long
@@ -58,17 +61,6 @@ fn unpack_seq(lamport: u64) -> (u64, u64) {
     (lamport >> COUNTER_BITS, lamport & COUNTER_MASK)
 }
 
-/// Map the consumer-facing `FrameKind` (chat vocabulary) to the bus's
-/// `IpcKind`. RPC/grid consumers that need `Command`/`CommandResult`
-/// publish via the typed IPC client directly with `IpcKind`.
-fn framekind_to_ipc(kind: FrameKind) -> IpcKind {
-    match kind {
-        FrameKind::Message => IpcKind::Message,
-        FrameKind::Event => IpcKind::Event,
-        FrameKind::Control => IpcKind::Control,
-    }
-}
-
 fn kind_to_transcript(kind: Kind) -> TranscriptKind {
     match kind {
         Kind::Message => TranscriptKind::Message,
@@ -80,16 +72,6 @@ fn kind_to_transcript(kind: Kind) -> TranscriptKind {
         | Kind::Signal
         | Kind::StreamChunk
         | Kind::Control => TranscriptKind::System,
-    }
-}
-
-/// Inverse of [`target_to_mention`] — map the SDK send target to the IPC
-/// addressing vocabulary. A room mention round-trips as a named endpoint.
-fn mention_to_ipc_target(target: MentionTarget) -> IpcTarget {
-    match target {
-        MentionTarget::All => IpcTarget::All,
-        MentionTarget::Peer(peer) => IpcTarget::Peer(peer),
-        MentionTarget::Room(room) => IpcTarget::Endpoint(format!("room:{}", room.as_uuid())),
     }
 }
 
@@ -186,9 +168,9 @@ impl Airc {
                 channel: room.channel.as_uuid(),
                 from_peer: self.peer_id().as_uuid(),
                 from_client: self.client_id().as_uuid(),
-                kind: framekind_to_ipc(kind),
+                kind: kind.into(),
                 delivery: IpcDelivery::Durable,
-                target: mention_to_ipc_target(target),
+                target: target.into(),
                 correlation_id: None,
                 coalesce_key: None,
                 payload: body.to_payload(),
@@ -215,7 +197,7 @@ impl Airc {
                 channel: room.channel.as_uuid(),
                 from_peer: self.peer_id().as_uuid(),
                 from_client: self.client_id().as_uuid(),
-                kind: framekind_to_ipc(kind),
+                kind: kind.into(),
                 // SDK chat/structured publishes are durable; the live
                 // streaming classes are reached via the typed IPC client
                 // directly (media/game-state), not this chat helper.

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -146,7 +146,7 @@ pub use work::{
     HeartbeatWorkspace, LinkCardPullRequest, MarkPullRequestMerged, ObserveLocalGitWorkspace,
     ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests, ReleaseManagerHat,
     ReleaseWorkClaim, ReleaseWorkspace, ReportAgentAvailability, RequestWorkspace, UpdateWorkCard,
-    WorkQueueStatus, WorkQueueStatusQuery,
+    WorkQueueStatus, WorkQueueStatusQuery, WORK_BOARD_PROJECTION_PAGE_SIZE,
 };
 pub use work_manager::{
     SeededWorkCard, WorkBacklogSeedCandidate, WorkBacklogSeedOutcome, WorkBacklogSeedResult,

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -30,6 +30,26 @@ const WORK_MUTATION_PAGE_SIZE: usize = 512;
 /// the minimum-viable fix until that follow-up.
 const WORK_BOARD_FETCH_MULTIPLIER: usize = 4;
 
+/// Canonical pagination size for complete work-board projections.
+///
+/// Card acd72c81: every prior caller that needed the complete board
+/// was passing `usize::MAX` to `work_board(limit)`. That issues ONE
+/// Inbox RPC asking for `usize::MAX * WORK_BOARD_FETCH_MULTIPLIER`
+/// events; the daemon serializes every transcript event in the room
+/// into a single CBOR frame, which trips
+/// `airc_ipc::codec::MAX_FRAME_BYTES` (16 MiB) once the room
+/// accumulates ~9000+ events. Empirically caught on Joel's box
+/// 2026-06-01: `airc work state X closed` failed with
+/// `daemon I/O: ipc frame too large: 16973574 bytes exceeds 16777216`.
+///
+/// `work_board_complete(page_size)` paginates: each IPC frame stays
+/// well under the cap while the projection is still complete.
+/// 1024 events per page is a comfortable middle: each frame fits
+/// (events are typed, not blob payloads — kilobytes each, not MB),
+/// and the round-trip count stays low for the 9000+ event case
+/// (~9 RPCs instead of one giant one).
+pub const WORK_BOARD_PROJECTION_PAGE_SIZE: usize = 1024;
+
 /// Card 79953b4d (pure helper for unit-testability): true when a
 /// transcript event is a work-domain event. Distinguishes work events
 /// from heartbeats / chat / other lifecycle by header presence rather
@@ -740,6 +760,14 @@ impl Airc {
     /// events. `limit` is the transcript page size for interactive
     /// board views; scheduling code should use
     /// [`Airc::work_board_complete`] instead.
+    ///
+    /// **DO NOT pass `usize::MAX`** — it issues a single Inbox RPC
+    /// asking for every event in the room, which trips
+    /// `airc_ipc::codec::MAX_FRAME_BYTES` (16 MiB) once the room
+    /// has accumulated ~9000+ events. If you need the complete
+    /// board, call [`Airc::work_board_complete`] with
+    /// [`WORK_BOARD_PROJECTION_PAGE_SIZE`] (paginated, never hits
+    /// the cap). Card acd72c81.
     pub async fn work_board(&self, limit: usize) -> Result<WorkBoardProjection, AircError> {
         let room = self.current_room().await?;
         // Recent-window view (not the complete board): daemon reads the


### PR DESCRIPTION
`airc work state X closed` and 8 other CLI paths called
`airc.work_board(usize::MAX)` to look up a single card or compute
a snapshot. With `usize::MAX`, the daemon-attached path issues
ONE Inbox RPC asking for every event in the room (the fetch
multiplier saturates), and the daemon serializes all of them
into a single CBOR frame. Once the room accumulates ~9000+ bus
events (operationally hit on Joel's box 2026-06-01), the response
trips `airc_ipc::codec::MAX_FRAME_BYTES`:

  daemon I/O: ipc frame too large: 16973574 bytes exceeds 16777216

Every state transition through these callsites then fails, the
kanban freezes behind merged PRs, and other agents pile up on
the same flake without recourse.

## Fix

`work_board_complete(page_size)` already exists for the same
intent (complete projection) but paginates the IPC transcript
fetch (airc-lib/src/work.rs:776 → daemon_room_transcripts at
airc-lib/src/daemon.rs:314). Each Inbox RPC asks for `page_size`
events, the client loops until done, no individual frame exceeds
the cap. Same projection completeness, low-latency per RPC,
correct architecture.

This commit:

1. Introduces `pub const WORK_BOARD_PROJECTION_PAGE_SIZE: usize = 1024`
   in airc-lib/src/work.rs as the canonical page size for
   complete-projection callers. 1024 events per page is
   comfortably under the 16 MiB cap (events are typed records
   in the kilobyte range, not blobs) and keeps the round-trip
   count low for 9000+ event rooms.
2. Updates `work_board(limit)`'s docstring to call out
   `usize::MAX` as forbidden and point at
   `work_board_complete`.
3. Swaps all 9 `work_board(usize::MAX)` callsites to
   `work_board_complete(WORK_BOARD_PROJECTION_PAGE_SIZE)`:
   - airc-cli/src/work_commands.rs (5 sites)
   - airc-cli/src/work_commands_git.rs (1 site)
   - airc-cli/src/work_commands_gh.rs (2 sites)
   - airc-lib/src/agent_heartbeat.rs (1 site)
4. Exports `WORK_BOARD_PROJECTION_PAGE_SIZE` from the airc-lib
   crate root so future callers reference one canonical
   constant instead of re-picking page sizes.

## Verification

- `cargo check --workspace`: clean.
- `cargo build --release -p airc-cli`: clean.
- Reinstalled the binary to /Users/joel/.local/bin/airc,
  restarted daemon, ran `airc work state 0462c1a8... closed` —
  the 16 MiB IPC frame error is gone; the CLI now correctly
  reports the close-lifecycle gate's actual semantic
  refusal ("requires Merged predecessor"). Same writes that
  failed pre-fix now reach the daemon successfully.

## Doctrine

[[every-error-is-an-opportunity-to-battle-harden]]: fix the
immediate symptom AND the class. Every existing callsite gets
the paginated path; future ones reference the canonical const.

[[host-the-seemingly-impossible]]: the substrate now scales to
9000+ events without IPC-cap failures on routine writes.

Card: acd72c81

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>