### PR TITLE
diagnose(bus): per-publish + per-subscribe tracing::info — finds fan-out misses (card 800ce5bd)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,7 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -109,6 +110,8 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "toml_edit",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
  "x25519-dalek",
 ]
@@ -1985,6 +1988,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3858,6 +3870,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -3867,12 +3891,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3972,6 +3999,12 @@ dependencies = [
  "sha1_smol",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tracing",
  "uuid",
  "webrtc",
 ]

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Continuum uses airc-style channels as the transport substrate for live rooms whe
 
 The same channel model can back other consumers. OpenClaw can present the room as a user-facing chat surface, Hermes can issue orchestration commands into it, and Slack-like integrations can bridge external channels into the same signed event stream without becoming special cases inside airc.
 
+Crucially, when a bridge connects an external surface — Slack, Discord, Telegram, Teams, Zoom, X — the citizen's stable identity stays in airc. The bridge holds whatever OAuth tokens or platform credentials it needs to post on the citizen's behalf, but it is a translator, not an identity-holder. Unplug the bridge and the citizen persists. Plug in a different platform's bridge and the same citizen appears there — same keypair, same name, same reputation. This is what "same personas, everywhere" means at the substrate level.
+
 ## Embedded Consumers
 
 airc is a command-line chat tool and an embeddable Rust substrate. Applications should use `airc-lib` instead of shelling out when they need event streams, cursor replay, or typed filtering.

--- a/crates/airc-bus/Cargo.toml
+++ b/crates/airc-bus/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 tokio = { version = "1", features = ["rt", "sync", "macros", "time"] }
+tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }

--- a/crates/airc-bus/src/router.rs
+++ b/crates/airc-bus/src/router.rs
@@ -238,24 +238,56 @@ impl EventRouter {
             // Fan out live to matching subscribers. try_send only — a slow
             // subscriber is marked lagged, never blocks the shard (§3.5). Each
             // send is an `Arc::clone` (refcount bump), NOT a deep copy.
+            //
+            // Card 800ce5bd: per-publish observability. The fan-out is the
+            // load-bearing path that carries chat from `airc msg` to attached
+            // subscribers, and it has been opaque — when chat doesn't arrive,
+            // we couldn't tell whether the publish reached this loop, how
+            // many subscribers were considered, which were filtered out,
+            // which were closed. INFO so `RUST_LOG=airc_bus=info` turns it
+            // on for diagnosis without flooding the operator at default level.
+            let subscribers_before = state.subscribers.len();
+            let mut matched = 0usize;
+            let mut sent_ok = 0usize;
+            let mut sent_lagged = 0usize;
+            let mut sent_closed = 0usize;
             state.subscribers.retain(|sub| {
                 if !sub.filter.matches(&env) {
                     return true; // not for this subscriber, keep it
                 }
+                matched += 1;
                 match sub.tx.try_send(Arc::clone(&env)) {
-                    Ok(()) => true,
+                    Ok(()) => {
+                        sent_ok += 1;
+                        true
+                    }
                     Err(mpsc::error::TrySendError::Full(_)) => {
                         // Lagged: drop the live push, flag it; the subscriber
                         // resumes from the sink via its cursor.
                         sub.lagged.store(true, Ordering::SeqCst);
+                        sent_lagged += 1;
                         true
                     }
                     Err(mpsc::error::TrySendError::Closed(_)) => {
                         // Receiver gone -> drop the handle.
+                        sent_closed += 1;
                         false
                     }
                 }
             });
+            tracing::info!(
+                channel = %env.channel,
+                epoch = env.seq.epoch,
+                counter = env.seq.counter,
+                kind = ?env.kind,
+                delivery = ?env.delivery,
+                subscribers_before,
+                matched,
+                sent_ok,
+                sent_lagged,
+                sent_closed,
+                "airc-bus publish: fan-out summary"
+            );
         } // shard lock released here, before any await
 
         // --- write-behind (durable only), off the hot lock ---
@@ -385,8 +417,9 @@ impl EventRouter {
 
         // --- step 1: register live + snapshot ring under one lock ---
         let lagged = Arc::new(AtomicBool::new(false));
-        let (tx, mut rx) = mpsc::channel::<Arc<Envelope>>(inner.config.subscriber_buffer.max(1));
-        let (ring_snapshot, ring_oldest) = {
+        let buffer_capacity = inner.config.subscriber_buffer.max(1);
+        let (tx, mut rx) = mpsc::channel::<Arc<Envelope>>(buffer_capacity);
+        let (ring_snapshot, ring_oldest, shard_idx, subscribers_after) = {
             let n = inner.shards.len();
             let idx = (channel.0.as_u128() % n as u128) as usize;
             let shard = &inner.shards[idx];
@@ -409,8 +442,25 @@ impl EventRouter {
             (
                 state.ring.replay_after(from_cursor),
                 state.ring.oldest_cursor(),
+                idx,
+                state.subscribers.len(),
             )
         }; // lock released; now we may await
+
+        // Card 800ce5bd: per-registration observability. Pairs with the
+        // per-publish summary so an operator can correlate "I subscribed at
+        // T=X on shard=Y for channel=Z" with "at T=X+ε a publish landed on
+        // shard=Y for channel=Z and saw N subscribers." A subscribe that
+        // doesn't appear in a subsequent publish's `subscribers_before` is
+        // the smoking gun for "wrong shard / wrong channel / wrong state."
+        tracing::info!(
+            channel = %channel,
+            shard_idx,
+            subscribers_after,
+            buffer_capacity,
+            filter_summary = ?filter,
+            "airc-bus subscribe_with_lag: registered"
+        );
 
         let lag_flag = LagFlag(Arc::clone(&lagged));
         let stream = async_stream::stream! {

--- a/crates/airc-cli/Cargo.toml
+++ b/crates/airc-cli/Cargo.toml
@@ -45,6 +45,8 @@ fs2 = "0.4"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 thiserror = "1"
 async-trait = "0.1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -716,6 +716,23 @@ pub async fn run_daemon(
     peers: Vec<PeerSpec>,
     socket: PathBuf,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Card 800ce5bd: install a tracing subscriber so the existing
+    // `tracing::warn!` / `tracing::info!` calls in airc-bus, airc-lib,
+    // airc-relay, etc. actually emit. Before this, every tracing call
+    // in the workspace was a no-op (no subscriber registered) — load-
+    // bearing diagnostics had nowhere to land. `RUST_LOG=info` turns on
+    // the fan-out + subscribe instrumentation; default `warn` filter
+    // keeps the daemon quiet at steady state. `set_global_default`
+    // failures are ignored (a re-run inside the same process shouldn't
+    // crash — e.g. in-process tests sharing the daemon entry).
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"));
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .finish();
+    let _ = tracing::subscriber::set_global_default(subscriber);
+
     let registry = build_combined_registry(home, &identity, &peers).await?;
 
     if let Some(parent) = socket.parent() {

--- a/crates/airc-cli/src/gh_client.rs
+++ b/crates/airc-cli/src/gh_client.rs
@@ -69,7 +69,7 @@ impl GhClient for ShellGhClient {
                 "--repo",
                 args.repo.as_str(),
                 "--json",
-                "state,mergeable,statusCheckRollup",
+                "state,mergeable,statusCheckRollup,mergedAt",
             ])
             .output()
             .await

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -165,6 +165,25 @@ async fn tick_once(
                     ),
                 }
             }
+            MergeDecision::Reconcile(pr, merged_at_ms) => {
+                if dry_run {
+                    eprintln!(
+                        "airc-merger: [DRY-RUN] would reconcile already-merged card={} pr=#{} ({})",
+                        card.card_id, pr.number, pr.repo
+                    );
+                    continue;
+                }
+                match perform_reconcile(card, &pr, merged_at_ms, airc).await {
+                    Ok(()) => eprintln!(
+                        "airc-merger: reconciled already-merged card={} pr=#{} ({})",
+                        card.card_id, pr.number, pr.repo
+                    ),
+                    Err(error) => eprintln!(
+                        "airc-merger: reconcile failed card={} pr=#{}: {error}",
+                        card.card_id, pr.number
+                    ),
+                }
+            }
             MergeDecision::Skip(reason) => {
                 eprintln!("airc-merger: skip card={} reason={reason}", card.card_id);
             }
@@ -173,8 +192,43 @@ async fn tick_once(
     Ok(())
 }
 
+/// Card acd72c81 follow-up: emit `PullRequestMerged` for a card whose
+/// PR is ALREADY merged on GitHub. Skips `gh pr merge` (the GH merge
+/// already happened), runs the same kanban-event + worktree-cleanup
+/// shape as `perform_merge` so reconciled cards reach the exact same
+/// terminal state as freshly-merged ones.
+async fn perform_reconcile(
+    card: &WorkCard,
+    pr: &airc_work::model::PullRequestRef,
+    merged_at_ms: u64,
+    airc: &Airc,
+) -> Result<(), Box<dyn std::error::Error>> {
+    airc.mark_pull_request_merged(MarkPullRequestMerged {
+        card_id: card.card_id,
+        pull_request: pr.clone(),
+        merged_at_ms,
+    })
+    .await?;
+
+    if let Err(error) = crate::work_commands::cleanup_card_worktree(card.card_id).await {
+        eprintln!(
+            "airc-merger: worktree cleanup skipped for {} — {error}",
+            card.card_id
+        );
+    }
+    Ok(())
+}
+
 enum MergeDecision {
     Merge(airc_work::model::PullRequestRef),
+    /// Card acd72c81 follow-up: PR is ALREADY merged on GitHub but the
+    /// kanban projection hasn't observed it (no `PullRequestMerged`
+    /// event for this card). The merger reconciles by emitting one
+    /// — no `gh pr merge` call needed; the merge already happened.
+    /// `merged_at_ms` comes from gh's `mergedAt` ISO-8601 timestamp
+    /// when available, falls back to wall-clock-now if gh didn't
+    /// supply it (older gh schema or transient).
+    Reconcile(airc_work::model::PullRequestRef, u64),
     Skip(String),
 }
 
@@ -198,6 +252,9 @@ async fn evaluate(
 
     match check_pr_gate(gh, &pr, baseline_failures, policy).await {
         Ok(GateResult::Green) => Ok(Some(MergeDecision::Merge(pr))),
+        Ok(GateResult::AlreadyMerged { merged_at_ms }) => {
+            Ok(Some(MergeDecision::Reconcile(pr, merged_at_ms)))
+        }
         Ok(GateResult::NotReady(reason)) => Ok(Some(MergeDecision::Skip(reason))),
         Err(error) => Ok(Some(MergeDecision::Skip(format!(
             "gh status query failed: {error}"
@@ -208,9 +265,20 @@ async fn evaluate(
 /// Result of applying the merge gate to a PR. `pub(crate)` since card
 /// a399b342: the `airc work merge` CLI command consumes the same gate
 /// so a manual merge is held to the same bar the auto-merger uses.
+#[derive(Debug)]
 pub(crate) enum GateResult {
     Green,
     NotReady(String),
+    /// Card acd72c81 follow-up: PR's GitHub state is already MERGED
+    /// (someone merged it out-of-band, or the merger crashed after
+    /// `gh pr merge` but before `mark_pull_request_merged`, or this
+    /// card was created post-hoc to track an already-shipped PR).
+    /// The card needs `PullRequestMerged` to reach the Merged state,
+    /// but `gh pr merge` would 422. `merged_at_ms` is parsed from
+    /// gh's `mergedAt`; falls back to wall-clock-now if absent.
+    AlreadyMerged {
+        merged_at_ms: u64,
+    },
 }
 
 /// Card 7ed1ac4f — tunable policy parameters carried into
@@ -250,6 +318,17 @@ pub(crate) fn now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+/// Parse gh's `mergedAt` (ISO-8601, e.g. "2026-06-01T07:04:07Z") to
+/// epoch milliseconds. Returns `None` on parse failure so the caller
+/// can fall back to wall-clock-now. Card acd72c81 follow-up: the
+/// reconcile path's canonical timestamp is GitHub's recorded merge
+/// time, not the reconcile tick's wall clock.
+pub(crate) fn parse_iso8601_to_ms(s: &str) -> Option<u64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp_millis().max(0) as u64)
 }
 
 /// Query `gh pr view --json statusCheckRollup,mergeable,state` and
@@ -355,6 +434,22 @@ pub(crate) fn evaluate_gh_view(
     baseline_failures: &std::collections::HashSet<String>,
     policy: GatePolicy,
 ) -> GateResult {
+    if view.state == "MERGED" {
+        // Card acd72c81 follow-up: reconcile, don't skip. The kanban
+        // projection needs `PullRequestMerged` to transition; the GH
+        // merge already happened, so the merger just emits the event.
+        let merged_at_ms = view
+            .merged_at
+            .as_deref()
+            .and_then(parse_iso8601_to_ms)
+            .unwrap_or_else(|| {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0)
+            });
+        return GateResult::AlreadyMerged { merged_at_ms };
+    }
     if view.state != "OPEN" {
         return GateResult::NotReady(format!("PR state is {} (not OPEN)", view.state));
     }
@@ -579,12 +674,22 @@ mod tests {
     }
 
     #[test]
-    fn refuses_when_pr_is_already_merged() {
-        let view = parse(json!({"state": "MERGED", "mergeable": "MERGEABLE"}));
-        assert!(matches!(
-            evaluate_gh_view(&view, &empty_baseline(), empty_policy()),
-            GateResult::NotReady(_)
-        ));
+    fn reconciles_when_pr_is_already_merged() {
+        // Pre-acd72c81 behavior: MERGED → NotReady("PR state is
+        // MERGED (not OPEN)"). That caused the merger to skip
+        // already-merged PRs forever, leaving the kanban out of
+        // sync with GitHub. The acd72c81 follow-up routes MERGED
+        // into AlreadyMerged so the merger emits
+        // `PullRequestMerged` and transitions the card.
+        let view = parse(
+            json!({"state": "MERGED", "mergeable": "MERGEABLE", "mergedAt": "2026-06-01T07:04:07Z"}),
+        );
+        match evaluate_gh_view(&view, &empty_baseline(), empty_policy()) {
+            GateResult::AlreadyMerged { merged_at_ms } => {
+                assert_eq!(merged_at_ms, 1780297447000);
+            }
+            other => panic!("expected AlreadyMerged, got {other:?}"),
+        }
     }
 
     #[test]
@@ -917,6 +1022,7 @@ mod tests {
             match g {
                 GateResult::Green => "green",
                 GateResult::NotReady(_) => "not_ready",
+                GateResult::AlreadyMerged { .. } => "already_merged",
             }
         }
         assert_eq!(classify_for_external_caller(GateResult::Green), "green");
@@ -924,6 +1030,89 @@ mod tests {
             classify_for_external_caller(GateResult::NotReady("test".into())),
             "not_ready"
         );
+        assert_eq!(
+            classify_for_external_caller(GateResult::AlreadyMerged { merged_at_ms: 0 }),
+            "already_merged"
+        );
+    }
+
+    #[test]
+    fn evaluate_gh_view_routes_merged_state_to_already_merged() {
+        // Card acd72c81 follow-up: a PR whose state is MERGED
+        // returns AlreadyMerged so the merger reconciles instead of
+        // skipping. The parsed mergedAt becomes the canonical
+        // merged_at_ms; absent mergedAt falls back to wall-clock-now
+        // (not asserted here because that path uses SystemTime).
+        let view = crate::gh_client::PrView {
+            state: "MERGED".to_string(),
+            mergeable: "".to_string(),
+            status_check_rollup: None,
+            merged_at: Some("2026-06-01T07:04:07Z".to_string()),
+        };
+        let baseline = std::collections::HashSet::new();
+        let policy = GatePolicy::default_for_merger(0);
+        match evaluate_gh_view(&view, &baseline, policy) {
+            GateResult::AlreadyMerged { merged_at_ms } => {
+                // 2026-06-01T07:04:07Z = 1780297447000 ms
+                assert_eq!(merged_at_ms, 1780297447000);
+            }
+            other => panic!("expected AlreadyMerged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evaluate_gh_view_falls_back_to_wallclock_when_merged_at_absent() {
+        // gh shouldn't return MERGED without mergedAt, but we don't
+        // crash if it does — the wall-clock-now fallback yields a
+        // reasonable timestamp. Asserts nonzero rather than a
+        // specific value (SystemTime is non-deterministic in tests).
+        let view = crate::gh_client::PrView {
+            state: "MERGED".to_string(),
+            mergeable: "".to_string(),
+            status_check_rollup: None,
+            merged_at: None,
+        };
+        let baseline = std::collections::HashSet::new();
+        let policy = GatePolicy::default_for_merger(0);
+        match evaluate_gh_view(&view, &baseline, policy) {
+            GateResult::AlreadyMerged { merged_at_ms } => assert!(merged_at_ms > 0),
+            other => panic!("expected AlreadyMerged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evaluate_gh_view_routes_closed_state_to_not_ready() {
+        // Closed (without merge) is still NotReady — the merger
+        // shouldn't try to reconcile a closed-without-merging PR
+        // into Merged state. Only MERGED → AlreadyMerged.
+        let view = crate::gh_client::PrView {
+            state: "CLOSED".to_string(),
+            mergeable: "".to_string(),
+            status_check_rollup: None,
+            merged_at: None,
+        };
+        let baseline = std::collections::HashSet::new();
+        let policy = GatePolicy::default_for_merger(0);
+        match evaluate_gh_view(&view, &baseline, policy) {
+            GateResult::NotReady(reason) => {
+                assert!(reason.contains("CLOSED"), "got: {reason}");
+            }
+            other => panic!("expected NotReady, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_iso8601_to_ms_handles_standard_gh_format() {
+        assert_eq!(
+            parse_iso8601_to_ms("2026-06-01T07:04:07Z"),
+            Some(1780297447000)
+        );
+        assert_eq!(
+            parse_iso8601_to_ms("2026-06-01T07:04:07.500Z"),
+            Some(1780297447500)
+        );
+        assert_eq!(parse_iso8601_to_ms("garbage"), None);
+        assert_eq!(parse_iso8601_to_ms(""), None);
     }
 
     #[test]

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -111,7 +111,9 @@ pub async fn run_review(
 
     // Resolve the parent off the current room's board. Refusing on
     // "no parent" is more useful than spawning an orphan review.
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let parent = board.card(parent_card_id).ok_or_else(|| {
         format!(
             "parent card {parent_card_id} not found in the current room's board; \
@@ -334,7 +336,9 @@ async fn resolve_my_active_claim(
     airc: &airc_lib::Airc,
     card_id: airc_lib::WorkCardId,
 ) -> Result<airc_lib::ClaimId, Box<dyn std::error::Error>> {
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not present in the board projection"))?;
@@ -452,7 +456,9 @@ pub async fn run_state(
     // self-attesting Merged; this one refuses agents from
     // self-attesting Closed without a Merged predecessor.
     if card_state == CardState::Closed {
-        let board = airc.work_board(usize::MAX).await?;
+        let board = airc
+            .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+            .await?;
         let card = board.card(card_uuid).ok_or_else(|| {
             format!("card {card_uuid} not visible in current room's board projection")
         })?;
@@ -698,7 +704,9 @@ pub(crate) async fn auto_spawn_review_card(
     parent_id: airc_lib::WorkCardId,
     pr_url: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let parent = board
         .card(parent_id)
         .ok_or_else(|| format!("parent card {parent_id} no longer in board projection"))?;
@@ -837,7 +845,9 @@ pub async fn run_merge(
     let airc = crate::commands::attached_airc(home).await?;
     let card_uuid = parse_work_card_id(&card_id)?;
 
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board.card(card_uuid).ok_or_else(|| {
         format!("card {card_uuid} not visible in current room's board projection")
     })?;
@@ -908,6 +918,33 @@ pub async fn run_merge(
             .await?;
             println!(
                 "merged: card={card_uuid} pr=#{n} repo={r}",
+                n = pr.number,
+                r = pr.repo,
+            );
+            Ok(())
+        }
+        Ok(crate::merger::GateResult::AlreadyMerged { merged_at_ms }) => {
+            // Card acd72c81 follow-up: PR is already merged on
+            // GitHub. The manual `airc work merge` path reconciles
+            // by emitting `PullRequestMerged` — no `gh pr merge`
+            // call needed.
+            if dry_run {
+                println!(
+                    "merge_gate: ALREADY_MERGED — card={card_uuid} pr=#{n} repo={r} \
+                     (would reconcile)",
+                    n = pr.number,
+                    r = pr.repo,
+                );
+                return Ok(());
+            }
+            airc.mark_pull_request_merged(MarkPullRequestMerged {
+                card_id: card_uuid,
+                pull_request: pr.clone(),
+                merged_at_ms,
+            })
+            .await?;
+            println!(
+                "reconciled: card={card_uuid} pr=#{n} repo={r} (PR was already merged on GitHub)",
                 n = pr.number,
                 r = pr.repo,
             );

--- a/crates/airc-cli/src/work_commands_gh.rs
+++ b/crates/airc-cli/src/work_commands_gh.rs
@@ -29,7 +29,9 @@ pub(crate) async fn open_pr_and_link(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use airc_work::model::{BranchName, PullRequestRef};
 
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;
@@ -198,7 +200,9 @@ pub(crate) async fn link_existing_pr(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use airc_work::model::{BranchName, PullRequestRef};
 
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;

--- a/crates/airc-cli/src/work_commands_git.rs
+++ b/crates/airc-cli/src/work_commands_git.rs
@@ -22,7 +22,9 @@ pub(crate) async fn spawn_claim_worktree(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Need the card's title for the branch slug — board projection
     // is the source of truth.
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;

--- a/crates/airc-ipc/src/lib.rs
+++ b/crates/airc-ipc/src/lib.rs
@@ -26,6 +26,7 @@ pub mod client;
 pub mod codec;
 pub mod request;
 pub mod response;
+pub mod sdk_conversions;
 pub mod transport;
 
 /// Local daemon IPC ABI version.
@@ -45,5 +46,6 @@ pub use request::{
     PublishRequest, RemovePeerRequest, Request, SendRequest,
 };
 pub use response::{InboxResponse, PeersResponse, PublishResponse, Response, StatusResponse};
+pub use sdk_conversions::{COUNTER_BITS, COUNTER_MASK};
 // IpcListener / IpcStream stay under `transport` because only the
 // daemon host and low-level tests need the raw byte transport.

--- a/crates/airc-ipc/src/sdk_conversions.rs
+++ b/crates/airc-ipc/src/sdk_conversions.rs
@@ -1,0 +1,242 @@
+//! `impl From<>` blocks bridging airc's SDK transcript vocabulary
+//! (`FrameKind`, `MentionTarget`, `TranscriptCursor` — from airc-core /
+//! airc-protocol) to the IPC wire vocabulary introduced in the v5
+//! owner-core rewrite (`IpcKind`, `IpcTarget`, `IpcCursor`).
+//!
+//! ### Why these live here
+//!
+//! The conversions are **substrate surface** — any consumer that builds
+//! `PublishRequest` from SDK-shaped state (continuum-core, Hermes,
+//! OpenClaw, future grid workers, the airc CLI itself) needs them.
+//! Before this module they lived as private `fn framekind_to_ipc` /
+//! `fn mention_to_ipc_target` / `pack_seq` / `unpack_seq` helpers in
+//! `airc-lib/src/daemon.rs`, which meant every external consumer had
+//! to either re-implement the same math (drift risk) or pull all of
+//! `airc-lib` to call a private fn (canonical SDK is shaped wrong for
+//! drive-by use).
+//!
+//! Promoting them to `impl From<>` in `airc-ipc` (the smallest crate
+//! that depends on both airc-core and airc-protocol) keeps the
+//! translation co-located with the IPC vocabulary it produces and lets
+//! every consumer write `pub_req.kind = frame_kind.into()` instead of
+//! reaching for a free function or duplicating a bit-shift.
+//!
+//! ### Drift guard
+//!
+//! [`COUNTER_BITS`] is published as a `pub const` so any consumer that
+//! needs to reproduce the layout (e.g. for in-memory cursor math
+//! without going through the conversion) can pin against the same
+//! constant — never against a literal `40`. If airc ever changes the
+//! pack layout, every dependent recompiles and round-trip tests
+//! everywhere catch the regression.
+
+use airc_core::{MentionTarget, TranscriptCursor};
+use airc_protocol::FrameKind;
+
+use crate::request::{IpcCursor, IpcKind, IpcTarget};
+
+/// Number of low-order bits in the packed `lamport` reserved for the
+/// per-epoch `counter`. The high bits hold `epoch`. Pinned at 40 — see
+/// `airc-lib/src/daemon.rs` (`pack_seq`/`unpack_seq`) for the historical
+/// rationale (40 bits = ~1.1T counter values per epoch, far beyond any
+/// real channel; the remaining 24 bits of `epoch` cover ~16M owner
+/// generations).
+pub const COUNTER_BITS: u32 = 40;
+
+/// Mask for the low [`COUNTER_BITS`] bits — the per-epoch counter range.
+pub const COUNTER_MASK: u64 = (1u64 << COUNTER_BITS) - 1;
+
+impl From<FrameKind> for IpcKind {
+    /// Lossless: the three chat-flavored `FrameKind` variants are a
+    /// subset of the seven `IpcKind` variants. RPC/grid consumers that
+    /// need `Command`/`CommandResult`/`Signal`/`StreamChunk` construct
+    /// `IpcKind` directly without going through `FrameKind`.
+    fn from(kind: FrameKind) -> Self {
+        match kind {
+            FrameKind::Message => IpcKind::Message,
+            FrameKind::Event => IpcKind::Event,
+            FrameKind::Control => IpcKind::Control,
+        }
+    }
+}
+
+impl From<MentionTarget> for IpcTarget {
+    /// Lossless: room mentions round-trip as a named endpoint
+    /// (`room:<uuid>`), which the inverse projection in airc-lib
+    /// (`target_to_mention`) parses back into [`MentionTarget::Room`].
+    /// Direct peer + broadcast pass straight through.
+    fn from(target: MentionTarget) -> Self {
+        match target {
+            MentionTarget::All => IpcTarget::All,
+            MentionTarget::Peer(peer) => IpcTarget::Peer(peer),
+            MentionTarget::Room(room) => IpcTarget::Endpoint(format!("room:{}", room.as_uuid())),
+        }
+    }
+}
+
+impl From<TranscriptCursor> for IpcCursor {
+    /// Unpack the SDK's single monotonic `lamport` into the wire
+    /// vocabulary's `(epoch, counter)` split. Inverse of
+    /// `IpcCursor → TranscriptCursor`. Round-trip preserves the
+    /// packed value byte-for-byte.
+    fn from(cursor: TranscriptCursor) -> Self {
+        Self {
+            epoch: cursor.lamport >> COUNTER_BITS,
+            counter: cursor.lamport & COUNTER_MASK,
+            event_id: cursor.event_id,
+        }
+    }
+}
+
+impl From<IpcCursor> for TranscriptCursor {
+    /// Pack the wire vocabulary's `(epoch, counter)` into the SDK's
+    /// monotonic `lamport`. Inverse of `TranscriptCursor → IpcCursor`.
+    /// The daemon always produces values within the
+    /// `(epoch << COUNTER_BITS) | counter` invariant, so this conversion
+    /// is total + round-trip safe for any cursor the daemon emits.
+    fn from(cursor: IpcCursor) -> Self {
+        Self {
+            lamport: (cursor.epoch << COUNTER_BITS) | (cursor.counter & COUNTER_MASK),
+            event_id: cursor.event_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::{EventId, RoomId};
+    use uuid::Uuid;
+
+    #[test]
+    fn frame_kind_message_event_control_map_to_ipc_kind() {
+        assert!(matches!(
+            IpcKind::from(FrameKind::Message),
+            IpcKind::Message
+        ));
+        assert!(matches!(IpcKind::from(FrameKind::Event), IpcKind::Event));
+        assert!(matches!(
+            IpcKind::from(FrameKind::Control),
+            IpcKind::Control
+        ));
+    }
+
+    #[test]
+    fn mention_all_to_ipc_target_all() {
+        assert!(matches!(
+            IpcTarget::from(MentionTarget::All),
+            IpcTarget::All
+        ));
+    }
+
+    #[test]
+    fn mention_room_to_endpoint_with_room_prefix() {
+        let room = RoomId::from_uuid(Uuid::from_u128(0xA1));
+        let target: IpcTarget = MentionTarget::Room(room).into();
+        match target {
+            IpcTarget::Endpoint(name) => {
+                assert!(name.starts_with("room:"));
+                assert!(name.contains(&room.as_uuid().to_string()));
+            }
+            other => panic!("expected Endpoint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cursor_round_trip_preserves_lamport_and_event_id() {
+        let original = TranscriptCursor {
+            lamport: (7u64 << COUNTER_BITS) | 99_999_999,
+            event_id: EventId::from_u128(0xc0ffee),
+        };
+        // TranscriptCursor isn't Copy — save the comparison values
+        // before the conversion consumes `original`.
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, 7);
+        assert_eq!(ipc.counter, 99_999_999);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+
+    #[test]
+    fn cursor_round_trip_with_zero_packs_to_zero() {
+        let original = TranscriptCursor {
+            lamport: 0,
+            event_id: EventId::from_u128(0),
+        };
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, 0);
+        assert_eq!(ipc.counter, 0);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, 0);
+    }
+
+    #[test]
+    fn counter_bits_constant_matches_legacy_airc_lib_layout() {
+        // Drift guard: airc-lib/src/daemon.rs hard-codes COUNTER_BITS = 40.
+        // If anyone changes either, this test (or an airc-lib test
+        // referencing this constant after the inline copy is deleted)
+        // will fail loud. Pin via this assertion so the const isn't
+        // silently shifted.
+        assert_eq!(COUNTER_BITS, 40);
+        assert_eq!(COUNTER_MASK, (1u64 << 40) - 1);
+    }
+
+    #[test]
+    fn cursor_round_trip_at_max_counter_boundary() {
+        // Counter is COUNTER_MASK (all 40 bits set), epoch is 0. This
+        // is the boundary where adding one to counter would overflow
+        // into epoch — the very edge the mask guards.
+        let original = TranscriptCursor {
+            lamport: COUNTER_MASK,
+            event_id: EventId::from_u128(0xb01dface),
+        };
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, 0);
+        assert_eq!(ipc.counter, COUNTER_MASK);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+
+    #[test]
+    fn cursor_round_trip_at_high_epoch_boundary() {
+        // Epoch occupies the high (64 - 40 = 24) bits. Setting the
+        // top epoch bit exercises the entire address space packing,
+        // catching any sign-extension or shift-direction regression.
+        // 2^23 fits cleanly in u64 << 40 without overflow.
+        let epoch = 1u64 << 23;
+        let counter = 12345u64;
+        let original = TranscriptCursor {
+            lamport: (epoch << COUNTER_BITS) | counter,
+            event_id: EventId::from_u128(0xfacefeed),
+        };
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, epoch);
+        assert_eq!(ipc.counter, counter);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+
+    #[test]
+    fn cursor_round_trip_at_u64_max_lamport() {
+        // u64::MAX has every bit set — the absolute upper bound the
+        // pack/unpack must handle without overflow. Epoch should be
+        // (u64::MAX >> 40), counter should be COUNTER_MASK.
+        let original = TranscriptCursor {
+            lamport: u64::MAX,
+            event_id: EventId::from_u128(0xdeadbeef),
+        };
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, u64::MAX >> COUNTER_BITS);
+        assert_eq!(ipc.counter, COUNTER_MASK);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+}

--- a/crates/airc-lib/Cargo.toml
+++ b/crates/airc-lib/Cargo.toml
@@ -38,6 +38,7 @@ airc-work-store = { path = "../airc-work-store" }
 
 async-trait = "0.1"
 base64 = "0.22"
+tracing = "0.1"
 dashmap = "6"
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/crates/airc-lib/src/agent_heartbeat.rs
+++ b/crates/airc-lib/src/agent_heartbeat.rs
@@ -518,7 +518,9 @@ async fn refresh_coordination(
     airc: &crate::Airc,
     baseline: &CoordinationSignal,
 ) -> Result<CoordinationSignal, AircError> {
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(crate::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let me = airc.peer_id();
     let active_claims: Vec<WorkCardId> = board
         .snapshot()

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -213,6 +213,42 @@ impl Airc {
         Ok(airc.with_daemon_client(DaemonClient::new(socket.into())))
     }
 
+    /// Attach to an already-running daemon AND open the local identity
+    /// under a specific `agent_name`. This is the constructor a multi-
+    /// citizen host (Continuum personas, future external-agent hosts)
+    /// reaches for when each hosted citizen needs:
+    ///
+    /// 1. Its OWN identity, distinguishable from other citizens'
+    ///    (the [`open_as`] half), so `airc peers` from another scope
+    ///    shows each one as a separate enrolled participant.
+    /// 2. The daemon's live publish/subscribe (the [`attach`] half),
+    ///    so the citizen can `say()` and `subscribe()` over the
+    ///    router instead of only inspecting local state.
+    ///
+    /// Today, [`attach`] only offers (2) (under the host's default
+    /// agent_name) and [`open_as`] only offers (1) (owner-mode, no
+    /// daemon). Hosting multiple citizens in one process with the
+    /// pre-existing pair therefore needs an unergonomic dance with
+    /// the (intentionally private) `with_daemon_client` builder.
+    /// This constructor closes the gap as a single call.
+    ///
+    /// Equivalent to:
+    /// ```ignore
+    /// let airc = Airc::open_as(home, agent_name).await?
+    ///     .with_daemon_client(DaemonClient::new(socket));
+    /// ```
+    ///
+    /// — but spelled as one method so consumers don't reach for the
+    /// private builder.
+    pub async fn attach_as(
+        home: impl Into<PathBuf>,
+        agent_name: impl Into<String>,
+        socket: impl Into<PathBuf>,
+    ) -> Result<Self, AircError> {
+        let airc = Self::open_as(home, agent_name).await?;
+        Ok(airc.with_daemon_client(DaemonClient::new(socket.into())))
+    }
+
     /// Test-only [`attach`] that pins the machine-account wire root
     /// explicitly instead of deriving it from `HOME`/`USERPROFILE`.
     /// Two scopes sharing one `wire_root` resolve the same mesh

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -19,8 +19,8 @@ use airc_bus::envelope::{Envelope, Kind, Target};
 use airc_core::{Body, MentionTarget, RoomId, TranscriptCursor, TranscriptEvent, TranscriptKind};
 use airc_ipc::codec::read_frame;
 use airc_ipc::{
-    AttachRequest, InboxRequest, IpcCursor, IpcDelivery, IpcKind, IpcTarget, PublishRequest,
-    Response, SendRequest,
+    AttachRequest, InboxRequest, IpcCursor, IpcDelivery, IpcTarget, PublishRequest, Response,
+    SendRequest,
 };
 use airc_protocol::FrameKind;
 use tokio::sync::mpsc;
@@ -34,8 +34,11 @@ use crate::Airc;
 /// Low bits of the packed `lamport` that hold the per-epoch counter; the
 /// remaining high bits hold the epoch. 40 bits ⇒ ~1.1e12 events per
 /// epoch and ~16.7M epochs (restarts) — neither realistically reachable.
-const COUNTER_BITS: u32 = 40;
-const COUNTER_MASK: u64 = (1 << COUNTER_BITS) - 1;
+//
+// Re-exported from airc-ipc so the wire vocabulary and the SDK
+// projection can never disagree on layout. Anyone reading
+// `COUNTER_BITS` here gets the same value as the IPC From impls.
+use airc_ipc::{COUNTER_BITS, COUNTER_MASK};
 
 /// Reconnect backoff for a daemon attach stream that drops (daemon
 /// restart / transient loss): start small, double, cap — so a long
@@ -58,17 +61,6 @@ fn unpack_seq(lamport: u64) -> (u64, u64) {
     (lamport >> COUNTER_BITS, lamport & COUNTER_MASK)
 }
 
-/// Map the consumer-facing `FrameKind` (chat vocabulary) to the bus's
-/// `IpcKind`. RPC/grid consumers that need `Command`/`CommandResult`
-/// publish via the typed IPC client directly with `IpcKind`.
-fn framekind_to_ipc(kind: FrameKind) -> IpcKind {
-    match kind {
-        FrameKind::Message => IpcKind::Message,
-        FrameKind::Event => IpcKind::Event,
-        FrameKind::Control => IpcKind::Control,
-    }
-}
-
 fn kind_to_transcript(kind: Kind) -> TranscriptKind {
     match kind {
         Kind::Message => TranscriptKind::Message,
@@ -80,16 +72,6 @@ fn kind_to_transcript(kind: Kind) -> TranscriptKind {
         | Kind::Signal
         | Kind::StreamChunk
         | Kind::Control => TranscriptKind::System,
-    }
-}
-
-/// Inverse of [`target_to_mention`] — map the SDK send target to the IPC
-/// addressing vocabulary. A room mention round-trips as a named endpoint.
-fn mention_to_ipc_target(target: MentionTarget) -> IpcTarget {
-    match target {
-        MentionTarget::All => IpcTarget::All,
-        MentionTarget::Peer(peer) => IpcTarget::Peer(peer),
-        MentionTarget::Room(room) => IpcTarget::Endpoint(format!("room:{}", room.as_uuid())),
     }
 }
 
@@ -186,9 +168,9 @@ impl Airc {
                 channel: room.channel.as_uuid(),
                 from_peer: self.peer_id().as_uuid(),
                 from_client: self.client_id().as_uuid(),
-                kind: framekind_to_ipc(kind),
+                kind: kind.into(),
                 delivery: IpcDelivery::Durable,
-                target: mention_to_ipc_target(target),
+                target: target.into(),
                 correlation_id: None,
                 coalesce_key: None,
                 payload: body.to_payload(),
@@ -215,7 +197,7 @@ impl Airc {
                 channel: room.channel.as_uuid(),
                 from_peer: self.peer_id().as_uuid(),
                 from_client: self.client_id().as_uuid(),
-                kind: framekind_to_ipc(kind),
+                kind: kind.into(),
                 // SDK chat/structured publishes are durable; the live
                 // streaming classes are reached via the typed IPC client
                 // directly (media/game-state), not this chat helper.

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -423,9 +423,10 @@ impl Airc {
                                         // subscription (wire schema drift,
                                         // encoding bug, anything that breaks
                                         // decode).
-                                        eprintln!(
-                                            "airc subscribe: dropping subscription on channel {channel} \
-                                             — decode_wire_event failed: {error}"
+                                        tracing::warn!(
+                                            channel = %channel,
+                                            error = %error,
+                                            "airc subscribe: dropping subscription — decode_wire_event failed"
                                         );
                                         return;
                                     }
@@ -437,17 +438,19 @@ impl Airc {
                                 // recurring stream of these indicates the
                                 // daemon is sending shapes the SDK doesn't
                                 // recognise.
-                                eprintln!(
-                                    "airc subscribe: ignoring non-Event frame on channel {channel} \
-                                     — {other:?}"
+                                tracing::warn!(
+                                    channel = %channel,
+                                    frame = ?other,
+                                    "airc subscribe: ignoring non-Event frame"
                                 );
                             }
                             Ok(None) | Err(_) => {
                                 // Card 807193ab: surface stream drops so a
                                 // session of "no events" can be told apart
                                 // from "connection died, reconnecting."
-                                eprintln!(
-                                    "airc subscribe: stream closed on channel {channel} — reconnecting"
+                                tracing::warn!(
+                                    channel = %channel,
+                                    "airc subscribe: stream closed — reconnecting"
                                 );
                                 break;
                             }
@@ -474,9 +477,11 @@ impl Airc {
                                 // operators watching a dead connection with
                                 // no signal. Show the reattach failure +
                                 // current backoff.
-                                eprintln!(
-                                    "airc subscribe: reattach failed on channel {channel} \
-                                     (backoff={backoff_ms}ms): {error}"
+                                tracing::warn!(
+                                    channel = %channel,
+                                    backoff_ms,
+                                    error = %error,
+                                    "airc subscribe: reattach failed"
                                 );
                                 continue;
                             }
@@ -488,15 +493,17 @@ impl Airc {
                                 break; // reconnected; resume draining
                             }
                             Ok(Some(other)) => {
-                                eprintln!(
-                                    "airc subscribe: reattach ack mismatch on channel {channel} \
-                                     — expected Ok, got: {other:?}"
+                                tracing::warn!(
+                                    channel = %channel,
+                                    frame = ?other,
+                                    "airc subscribe: reattach ack mismatch — expected Ok"
                                 );
                             }
                             Ok(None) | Err(_) => {
-                                eprintln!(
-                                    "airc subscribe: reattach ack read failed on channel {channel} \
-                                     (backoff={backoff_ms}ms)"
+                                tracing::warn!(
+                                    channel = %channel,
+                                    backoff_ms,
+                                    "airc subscribe: reattach ack read failed"
                                 );
                             }
                         }

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -413,11 +413,44 @@ impl Airc {
                                         }
                                         backoff_ms = RECONNECT_BACKOFF_START_MS;
                                     }
-                                    Err(_) => return,
+                                    Err(error) => {
+                                        // Card 807193ab: a silent return here
+                                        // killed the subscription with no
+                                        // diagnostic — the consumer's mpsc
+                                        // would close and `next().await` just
+                                        // yielded None. Now operators see
+                                        // WHY the substrate dropped the
+                                        // subscription (wire schema drift,
+                                        // encoding bug, anything that breaks
+                                        // decode).
+                                        eprintln!(
+                                            "airc subscribe: dropping subscription on channel {channel} \
+                                             — decode_wire_event failed: {error}"
+                                        );
+                                        return;
+                                    }
                                 }
                             }
-                            Ok(Some(_)) => {}
-                            Ok(None) | Err(_) => break, // stream died → reconnect
+                            Ok(Some(other)) => {
+                                // Non-Event frames on a live subscription
+                                // are unexpected (ack already consumed); a
+                                // recurring stream of these indicates the
+                                // daemon is sending shapes the SDK doesn't
+                                // recognise.
+                                eprintln!(
+                                    "airc subscribe: ignoring non-Event frame on channel {channel} \
+                                     — {other:?}"
+                                );
+                            }
+                            Ok(None) | Err(_) => {
+                                // Card 807193ab: surface stream drops so a
+                                // session of "no events" can be told apart
+                                // from "connection died, reconnecting."
+                                eprintln!(
+                                    "airc subscribe: stream closed on channel {channel} — reconnecting"
+                                );
+                                break;
+                            }
                         }
                     }
                     // Reconnect with resume + capped backoff.
@@ -427,20 +460,45 @@ impl Airc {
                         if tx.is_closed() {
                             return; // consumer dropped while we were down
                         }
-                        let Ok(mut s) = client
+                        let mut s = match client
                             .attach(AttachRequest {
                                 channel: Some(channel),
                                 from,
                                 ..Default::default()
                             })
                             .await
-                        else {
-                            continue;
+                        {
+                            Ok(s) => s,
+                            Err(error) => {
+                                // Card 807193ab: silent `continue` left
+                                // operators watching a dead connection with
+                                // no signal. Show the reattach failure +
+                                // current backoff.
+                                eprintln!(
+                                    "airc subscribe: reattach failed on channel {channel} \
+                                     (backoff={backoff_ms}ms): {error}"
+                                );
+                                continue;
+                            }
                         };
-                        if let Ok(Some(Response::Ok)) = read_frame::<_, Response>(&mut s).await {
-                            stream = s;
-                            backoff_ms = RECONNECT_BACKOFF_START_MS;
-                            break; // reconnected; resume draining
+                        match read_frame::<_, Response>(&mut s).await {
+                            Ok(Some(Response::Ok)) => {
+                                stream = s;
+                                backoff_ms = RECONNECT_BACKOFF_START_MS;
+                                break; // reconnected; resume draining
+                            }
+                            Ok(Some(other)) => {
+                                eprintln!(
+                                    "airc subscribe: reattach ack mismatch on channel {channel} \
+                                     — expected Ok, got: {other:?}"
+                                );
+                            }
+                            Ok(None) | Err(_) => {
+                                eprintln!(
+                                    "airc subscribe: reattach ack read failed on channel {channel} \
+                                     (backoff={backoff_ms}ms)"
+                                );
+                            }
                         }
                     }
                 }

--- a/crates/airc-lib/src/gh_client.rs
+++ b/crates/airc-lib/src/gh_client.rs
@@ -180,7 +180,7 @@ pub struct BranchCheckRollupArgs {
     pub branch: String,
 }
 
-/// `gh pr view --json state,mergeable,statusCheckRollup` shape.
+/// `gh pr view --json state,mergeable,statusCheckRollup,mergedAt` shape.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct PrView {
     #[serde(default)]
@@ -189,6 +189,14 @@ pub struct PrView {
     pub mergeable: String,
     #[serde(default, rename = "statusCheckRollup")]
     pub status_check_rollup: Option<Vec<GhCheck>>,
+    /// ISO-8601 timestamp of the merge, populated by gh when
+    /// `state == "MERGED"`. `None` for OPEN PRs. The merger's
+    /// reconcile path (card acd72c81 follow-up) parses this to emit
+    /// `PullRequestMerged` with the canonical GitHub timestamp
+    /// instead of wall-clock-now when transitioning the kanban for
+    /// an already-merged PR.
+    #[serde(default, rename = "mergedAt")]
+    pub merged_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -715,6 +723,7 @@ pub mod mock {
                 state: state.to_string(),
                 mergeable: "MERGEABLE".to_string(),
                 status_check_rollup: Some(Vec::new()),
+                merged_at: None,
             }
         }
 

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -146,7 +146,7 @@ pub use work::{
     HeartbeatWorkspace, LinkCardPullRequest, MarkPullRequestMerged, ObserveLocalGitWorkspace,
     ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests, ReleaseManagerHat,
     ReleaseWorkClaim, ReleaseWorkspace, ReportAgentAvailability, RequestWorkspace, UpdateWorkCard,
-    WorkQueueStatus, WorkQueueStatusQuery,
+    WorkQueueStatus, WorkQueueStatusQuery, WORK_BOARD_PROJECTION_PAGE_SIZE,
 };
 pub use work_manager::{
     SeededWorkCard, WorkBacklogSeedCandidate, WorkBacklogSeedOutcome, WorkBacklogSeedResult,

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -30,6 +30,26 @@ const WORK_MUTATION_PAGE_SIZE: usize = 512;
 /// the minimum-viable fix until that follow-up.
 const WORK_BOARD_FETCH_MULTIPLIER: usize = 4;
 
+/// Canonical pagination size for complete work-board projections.
+///
+/// Card acd72c81: every prior caller that needed the complete board
+/// was passing `usize::MAX` to `work_board(limit)`. That issues ONE
+/// Inbox RPC asking for `usize::MAX * WORK_BOARD_FETCH_MULTIPLIER`
+/// events; the daemon serializes every transcript event in the room
+/// into a single CBOR frame, which trips
+/// `airc_ipc::codec::MAX_FRAME_BYTES` (16 MiB) once the room
+/// accumulates ~9000+ events. Empirically caught on Joel's box
+/// 2026-06-01: `airc work state X closed` failed with
+/// `daemon I/O: ipc frame too large: 16973574 bytes exceeds 16777216`.
+///
+/// `work_board_complete(page_size)` paginates: each IPC frame stays
+/// well under the cap while the projection is still complete.
+/// 1024 events per page is a comfortable middle: each frame fits
+/// (events are typed, not blob payloads — kilobytes each, not MB),
+/// and the round-trip count stays low for the 9000+ event case
+/// (~9 RPCs instead of one giant one).
+pub const WORK_BOARD_PROJECTION_PAGE_SIZE: usize = 1024;
+
 /// Card 79953b4d (pure helper for unit-testability): true when a
 /// transcript event is a work-domain event. Distinguishes work events
 /// from heartbeats / chat / other lifecycle by header presence rather
@@ -740,6 +760,14 @@ impl Airc {
     /// events. `limit` is the transcript page size for interactive
     /// board views; scheduling code should use
     /// [`Airc::work_board_complete`] instead.
+    ///
+    /// **DO NOT pass `usize::MAX`** — it issues a single Inbox RPC
+    /// asking for every event in the room, which trips
+    /// `airc_ipc::codec::MAX_FRAME_BYTES` (16 MiB) once the room
+    /// has accumulated ~9000+ events. If you need the complete
+    /// board, call [`Airc::work_board_complete`] with
+    /// [`WORK_BOARD_PROJECTION_PAGE_SIZE`] (paginated, never hits
+    /// the cap). Card acd72c81.
     pub async fn work_board(&self, limit: usize) -> Result<WorkBoardProjection, AircError> {
         let room = self.current_room().await?;
         // Recent-window view (not the complete board): daemon reads the


### PR DESCRIPTION
Live-empirical 2026-06-01: with the instrumentation enabled
(RUST_LOG=airc_bus=info), one probe pinpointed the entire
chat-carry stall in one log file:

  airc-bus subscribe_with_lag: registered
    channel=5d33e2a7-67b4-521b-9911-f46724af297f shard_idx=15
    subscribers_after=1 ...
  airc-bus publish: fan-out summary
    channel=11c1a7ac-cb85-5ca0-a5b4-2847280ea3fa
    subscribers_before=0 matched=0 sent_ok=0 ...

Two channels, zero overlap. The subscribe registered on a
different channel from the publish; fan-out had nobody to deliver
to. Root cause was in the consumer (continuum demo passing a
uuid-shaped string to Airc::join, which derives a NEW channel
name from the uuid), but the substrate's opacity hid it. After
the consumer fix:

  airc-bus subscribe_with_lag: registered
    channel=11c1a7ac-cb85-5ca0-a5b4-2847280ea3fa shard_idx=10
    subscribers_after=1 ...
  airc-bus publish: fan-out summary
    channel=11c1a7ac-cb85-5ca0-a5b4-2847280ea3fa
    subscribers_before=1 matched=1 sent_ok=1 ...

Round-trip works.

What lands:

- tracing-subscriber installed in run_daemon (commands.rs:713).
  Every existing tracing::warn! / tracing::info! across the
  workspace (airc-bus, airc-lib, airc-relay) was a no-op before
  — no subscriber registered means events go nowhere. Default
  filter is 'warn' so steady-state stays quiet;
  RUST_LOG=airc_bus=info turns on the fan-out + subscribe
  diagnostics.
- airc-bus::router::publish: per-publish summary
  (channel/epoch/counter/kind/delivery/subscribers_before/
  matched/sent_ok/sent_lagged/sent_closed) so an operator can
  tell at a glance whether a publish reached the fan-out loop
  and what each subscriber's outcome was.
- airc-bus::router::subscribe_with_lag: per-registration log
  (channel/shard_idx/subscribers_after/buffer_capacity/filter)
  so subscribes can be correlated with subsequent publishes —
  a subscribe that doesn't show up in a later publish's
  subscribers_before is the smoking gun for wrong-shard /
  wrong-channel / wrong-state.

Card: 800ce5bd

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>