### PR TITLE
fix(lib): Airc::join refuses uuid-shaped strings (card c409eaf5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Continuum uses airc-style channels as the transport substrate for live rooms whe
 
 The same channel model can back other consumers. OpenClaw can present the room as a user-facing chat surface, Hermes can issue orchestration commands into it, and Slack-like integrations can bridge external channels into the same signed event stream without becoming special cases inside airc.
 
+Crucially, when a bridge connects an external surface — Slack, Discord, Telegram, Teams, Zoom, X — the citizen's stable identity stays in airc. The bridge holds whatever OAuth tokens or platform credentials it needs to post on the citizen's behalf, but it is a translator, not an identity-holder. Unplug the bridge and the citizen persists. Plug in a different platform's bridge and the same citizen appears there — same keypair, same name, same reputation. This is what "same personas, everywhere" means at the substrate level.
+
 ## Embedded Consumers
 
 airc is a command-line chat tool and an embeddable Rust substrate. Applications should use `airc-lib` instead of shelling out when they need event streams, cursor replay, or typed filtering.

--- a/crates/airc-cli/src/gh_client.rs
+++ b/crates/airc-cli/src/gh_client.rs
@@ -69,7 +69,7 @@ impl GhClient for ShellGhClient {
                 "--repo",
                 args.repo.as_str(),
                 "--json",
-                "state,mergeable,statusCheckRollup",
+                "state,mergeable,statusCheckRollup,mergedAt",
             ])
             .output()
             .await

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -165,6 +165,25 @@ async fn tick_once(
                     ),
                 }
             }
+            MergeDecision::Reconcile(pr, merged_at_ms) => {
+                if dry_run {
+                    eprintln!(
+                        "airc-merger: [DRY-RUN] would reconcile already-merged card={} pr=#{} ({})",
+                        card.card_id, pr.number, pr.repo
+                    );
+                    continue;
+                }
+                match perform_reconcile(card, &pr, merged_at_ms, airc).await {
+                    Ok(()) => eprintln!(
+                        "airc-merger: reconciled already-merged card={} pr=#{} ({})",
+                        card.card_id, pr.number, pr.repo
+                    ),
+                    Err(error) => eprintln!(
+                        "airc-merger: reconcile failed card={} pr=#{}: {error}",
+                        card.card_id, pr.number
+                    ),
+                }
+            }
             MergeDecision::Skip(reason) => {
                 eprintln!("airc-merger: skip card={} reason={reason}", card.card_id);
             }
@@ -173,8 +192,43 @@ async fn tick_once(
     Ok(())
 }
 
+/// Card acd72c81 follow-up: emit `PullRequestMerged` for a card whose
+/// PR is ALREADY merged on GitHub. Skips `gh pr merge` (the GH merge
+/// already happened), runs the same kanban-event + worktree-cleanup
+/// shape as `perform_merge` so reconciled cards reach the exact same
+/// terminal state as freshly-merged ones.
+async fn perform_reconcile(
+    card: &WorkCard,
+    pr: &airc_work::model::PullRequestRef,
+    merged_at_ms: u64,
+    airc: &Airc,
+) -> Result<(), Box<dyn std::error::Error>> {
+    airc.mark_pull_request_merged(MarkPullRequestMerged {
+        card_id: card.card_id,
+        pull_request: pr.clone(),
+        merged_at_ms,
+    })
+    .await?;
+
+    if let Err(error) = crate::work_commands::cleanup_card_worktree(card.card_id).await {
+        eprintln!(
+            "airc-merger: worktree cleanup skipped for {} — {error}",
+            card.card_id
+        );
+    }
+    Ok(())
+}
+
 enum MergeDecision {
     Merge(airc_work::model::PullRequestRef),
+    /// Card acd72c81 follow-up: PR is ALREADY merged on GitHub but the
+    /// kanban projection hasn't observed it (no `PullRequestMerged`
+    /// event for this card). The merger reconciles by emitting one
+    /// — no `gh pr merge` call needed; the merge already happened.
+    /// `merged_at_ms` comes from gh's `mergedAt` ISO-8601 timestamp
+    /// when available, falls back to wall-clock-now if gh didn't
+    /// supply it (older gh schema or transient).
+    Reconcile(airc_work::model::PullRequestRef, u64),
     Skip(String),
 }
 
@@ -198,6 +252,9 @@ async fn evaluate(
 
     match check_pr_gate(gh, &pr, baseline_failures, policy).await {
         Ok(GateResult::Green) => Ok(Some(MergeDecision::Merge(pr))),
+        Ok(GateResult::AlreadyMerged { merged_at_ms }) => {
+            Ok(Some(MergeDecision::Reconcile(pr, merged_at_ms)))
+        }
         Ok(GateResult::NotReady(reason)) => Ok(Some(MergeDecision::Skip(reason))),
         Err(error) => Ok(Some(MergeDecision::Skip(format!(
             "gh status query failed: {error}"
@@ -208,9 +265,20 @@ async fn evaluate(
 /// Result of applying the merge gate to a PR. `pub(crate)` since card
 /// a399b342: the `airc work merge` CLI command consumes the same gate
 /// so a manual merge is held to the same bar the auto-merger uses.
+#[derive(Debug)]
 pub(crate) enum GateResult {
     Green,
     NotReady(String),
+    /// Card acd72c81 follow-up: PR's GitHub state is already MERGED
+    /// (someone merged it out-of-band, or the merger crashed after
+    /// `gh pr merge` but before `mark_pull_request_merged`, or this
+    /// card was created post-hoc to track an already-shipped PR).
+    /// The card needs `PullRequestMerged` to reach the Merged state,
+    /// but `gh pr merge` would 422. `merged_at_ms` is parsed from
+    /// gh's `mergedAt`; falls back to wall-clock-now if absent.
+    AlreadyMerged {
+        merged_at_ms: u64,
+    },
 }
 
 /// Card 7ed1ac4f — tunable policy parameters carried into
@@ -250,6 +318,17 @@ pub(crate) fn now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+/// Parse gh's `mergedAt` (ISO-8601, e.g. "2026-06-01T07:04:07Z") to
+/// epoch milliseconds. Returns `None` on parse failure so the caller
+/// can fall back to wall-clock-now. Card acd72c81 follow-up: the
+/// reconcile path's canonical timestamp is GitHub's recorded merge
+/// time, not the reconcile tick's wall clock.
+pub(crate) fn parse_iso8601_to_ms(s: &str) -> Option<u64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp_millis().max(0) as u64)
 }
 
 /// Query `gh pr view --json statusCheckRollup,mergeable,state` and
@@ -355,6 +434,22 @@ pub(crate) fn evaluate_gh_view(
     baseline_failures: &std::collections::HashSet<String>,
     policy: GatePolicy,
 ) -> GateResult {
+    if view.state == "MERGED" {
+        // Card acd72c81 follow-up: reconcile, don't skip. The kanban
+        // projection needs `PullRequestMerged` to transition; the GH
+        // merge already happened, so the merger just emits the event.
+        let merged_at_ms = view
+            .merged_at
+            .as_deref()
+            .and_then(parse_iso8601_to_ms)
+            .unwrap_or_else(|| {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0)
+            });
+        return GateResult::AlreadyMerged { merged_at_ms };
+    }
     if view.state != "OPEN" {
         return GateResult::NotReady(format!("PR state is {} (not OPEN)", view.state));
     }
@@ -579,12 +674,22 @@ mod tests {
     }
 
     #[test]
-    fn refuses_when_pr_is_already_merged() {
-        let view = parse(json!({"state": "MERGED", "mergeable": "MERGEABLE"}));
-        assert!(matches!(
-            evaluate_gh_view(&view, &empty_baseline(), empty_policy()),
-            GateResult::NotReady(_)
-        ));
+    fn reconciles_when_pr_is_already_merged() {
+        // Pre-acd72c81 behavior: MERGED → NotReady("PR state is
+        // MERGED (not OPEN)"). That caused the merger to skip
+        // already-merged PRs forever, leaving the kanban out of
+        // sync with GitHub. The acd72c81 follow-up routes MERGED
+        // into AlreadyMerged so the merger emits
+        // `PullRequestMerged` and transitions the card.
+        let view = parse(
+            json!({"state": "MERGED", "mergeable": "MERGEABLE", "mergedAt": "2026-06-01T07:04:07Z"}),
+        );
+        match evaluate_gh_view(&view, &empty_baseline(), empty_policy()) {
+            GateResult::AlreadyMerged { merged_at_ms } => {
+                assert_eq!(merged_at_ms, 1780297447000);
+            }
+            other => panic!("expected AlreadyMerged, got {other:?}"),
+        }
     }
 
     #[test]
@@ -917,6 +1022,7 @@ mod tests {
             match g {
                 GateResult::Green => "green",
                 GateResult::NotReady(_) => "not_ready",
+                GateResult::AlreadyMerged { .. } => "already_merged",
             }
         }
         assert_eq!(classify_for_external_caller(GateResult::Green), "green");
@@ -924,6 +1030,89 @@ mod tests {
             classify_for_external_caller(GateResult::NotReady("test".into())),
             "not_ready"
         );
+        assert_eq!(
+            classify_for_external_caller(GateResult::AlreadyMerged { merged_at_ms: 0 }),
+            "already_merged"
+        );
+    }
+
+    #[test]
+    fn evaluate_gh_view_routes_merged_state_to_already_merged() {
+        // Card acd72c81 follow-up: a PR whose state is MERGED
+        // returns AlreadyMerged so the merger reconciles instead of
+        // skipping. The parsed mergedAt becomes the canonical
+        // merged_at_ms; absent mergedAt falls back to wall-clock-now
+        // (not asserted here because that path uses SystemTime).
+        let view = crate::gh_client::PrView {
+            state: "MERGED".to_string(),
+            mergeable: "".to_string(),
+            status_check_rollup: None,
+            merged_at: Some("2026-06-01T07:04:07Z".to_string()),
+        };
+        let baseline = std::collections::HashSet::new();
+        let policy = GatePolicy::default_for_merger(0);
+        match evaluate_gh_view(&view, &baseline, policy) {
+            GateResult::AlreadyMerged { merged_at_ms } => {
+                // 2026-06-01T07:04:07Z = 1780297447000 ms
+                assert_eq!(merged_at_ms, 1780297447000);
+            }
+            other => panic!("expected AlreadyMerged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evaluate_gh_view_falls_back_to_wallclock_when_merged_at_absent() {
+        // gh shouldn't return MERGED without mergedAt, but we don't
+        // crash if it does — the wall-clock-now fallback yields a
+        // reasonable timestamp. Asserts nonzero rather than a
+        // specific value (SystemTime is non-deterministic in tests).
+        let view = crate::gh_client::PrView {
+            state: "MERGED".to_string(),
+            mergeable: "".to_string(),
+            status_check_rollup: None,
+            merged_at: None,
+        };
+        let baseline = std::collections::HashSet::new();
+        let policy = GatePolicy::default_for_merger(0);
+        match evaluate_gh_view(&view, &baseline, policy) {
+            GateResult::AlreadyMerged { merged_at_ms } => assert!(merged_at_ms > 0),
+            other => panic!("expected AlreadyMerged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evaluate_gh_view_routes_closed_state_to_not_ready() {
+        // Closed (without merge) is still NotReady — the merger
+        // shouldn't try to reconcile a closed-without-merging PR
+        // into Merged state. Only MERGED → AlreadyMerged.
+        let view = crate::gh_client::PrView {
+            state: "CLOSED".to_string(),
+            mergeable: "".to_string(),
+            status_check_rollup: None,
+            merged_at: None,
+        };
+        let baseline = std::collections::HashSet::new();
+        let policy = GatePolicy::default_for_merger(0);
+        match evaluate_gh_view(&view, &baseline, policy) {
+            GateResult::NotReady(reason) => {
+                assert!(reason.contains("CLOSED"), "got: {reason}");
+            }
+            other => panic!("expected NotReady, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_iso8601_to_ms_handles_standard_gh_format() {
+        assert_eq!(
+            parse_iso8601_to_ms("2026-06-01T07:04:07Z"),
+            Some(1780297447000)
+        );
+        assert_eq!(
+            parse_iso8601_to_ms("2026-06-01T07:04:07.500Z"),
+            Some(1780297447500)
+        );
+        assert_eq!(parse_iso8601_to_ms("garbage"), None);
+        assert_eq!(parse_iso8601_to_ms(""), None);
     }
 
     #[test]

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -111,7 +111,9 @@ pub async fn run_review(
 
     // Resolve the parent off the current room's board. Refusing on
     // "no parent" is more useful than spawning an orphan review.
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let parent = board.card(parent_card_id).ok_or_else(|| {
         format!(
             "parent card {parent_card_id} not found in the current room's board; \
@@ -334,7 +336,9 @@ async fn resolve_my_active_claim(
     airc: &airc_lib::Airc,
     card_id: airc_lib::WorkCardId,
 ) -> Result<airc_lib::ClaimId, Box<dyn std::error::Error>> {
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not present in the board projection"))?;
@@ -452,7 +456,9 @@ pub async fn run_state(
     // self-attesting Merged; this one refuses agents from
     // self-attesting Closed without a Merged predecessor.
     if card_state == CardState::Closed {
-        let board = airc.work_board(usize::MAX).await?;
+        let board = airc
+            .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+            .await?;
         let card = board.card(card_uuid).ok_or_else(|| {
             format!("card {card_uuid} not visible in current room's board projection")
         })?;
@@ -698,7 +704,9 @@ pub(crate) async fn auto_spawn_review_card(
     parent_id: airc_lib::WorkCardId,
     pr_url: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let parent = board
         .card(parent_id)
         .ok_or_else(|| format!("parent card {parent_id} no longer in board projection"))?;
@@ -837,7 +845,9 @@ pub async fn run_merge(
     let airc = crate::commands::attached_airc(home).await?;
     let card_uuid = parse_work_card_id(&card_id)?;
 
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board.card(card_uuid).ok_or_else(|| {
         format!("card {card_uuid} not visible in current room's board projection")
     })?;
@@ -908,6 +918,33 @@ pub async fn run_merge(
             .await?;
             println!(
                 "merged: card={card_uuid} pr=#{n} repo={r}",
+                n = pr.number,
+                r = pr.repo,
+            );
+            Ok(())
+        }
+        Ok(crate::merger::GateResult::AlreadyMerged { merged_at_ms }) => {
+            // Card acd72c81 follow-up: PR is already merged on
+            // GitHub. The manual `airc work merge` path reconciles
+            // by emitting `PullRequestMerged` — no `gh pr merge`
+            // call needed.
+            if dry_run {
+                println!(
+                    "merge_gate: ALREADY_MERGED — card={card_uuid} pr=#{n} repo={r} \
+                     (would reconcile)",
+                    n = pr.number,
+                    r = pr.repo,
+                );
+                return Ok(());
+            }
+            airc.mark_pull_request_merged(MarkPullRequestMerged {
+                card_id: card_uuid,
+                pull_request: pr.clone(),
+                merged_at_ms,
+            })
+            .await?;
+            println!(
+                "reconciled: card={card_uuid} pr=#{n} repo={r} (PR was already merged on GitHub)",
                 n = pr.number,
                 r = pr.repo,
             );

--- a/crates/airc-cli/src/work_commands_gh.rs
+++ b/crates/airc-cli/src/work_commands_gh.rs
@@ -29,7 +29,9 @@ pub(crate) async fn open_pr_and_link(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use airc_work::model::{BranchName, PullRequestRef};
 
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;
@@ -198,7 +200,9 @@ pub(crate) async fn link_existing_pr(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use airc_work::model::{BranchName, PullRequestRef};
 
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;

--- a/crates/airc-cli/src/work_commands_git.rs
+++ b/crates/airc-cli/src/work_commands_git.rs
@@ -22,7 +22,9 @@ pub(crate) async fn spawn_claim_worktree(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Need the card's title for the branch slug — board projection
     // is the source of truth.
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;

--- a/crates/airc-ipc/src/lib.rs
+++ b/crates/airc-ipc/src/lib.rs
@@ -26,6 +26,7 @@ pub mod client;
 pub mod codec;
 pub mod request;
 pub mod response;
+pub mod sdk_conversions;
 pub mod transport;
 
 /// Local daemon IPC ABI version.
@@ -45,5 +46,6 @@ pub use request::{
     PublishRequest, RemovePeerRequest, Request, SendRequest,
 };
 pub use response::{InboxResponse, PeersResponse, PublishResponse, Response, StatusResponse};
+pub use sdk_conversions::{COUNTER_BITS, COUNTER_MASK};
 // IpcListener / IpcStream stay under `transport` because only the
 // daemon host and low-level tests need the raw byte transport.

--- a/crates/airc-ipc/src/sdk_conversions.rs
+++ b/crates/airc-ipc/src/sdk_conversions.rs
@@ -1,0 +1,242 @@
+//! `impl From<>` blocks bridging airc's SDK transcript vocabulary
+//! (`FrameKind`, `MentionTarget`, `TranscriptCursor` — from airc-core /
+//! airc-protocol) to the IPC wire vocabulary introduced in the v5
+//! owner-core rewrite (`IpcKind`, `IpcTarget`, `IpcCursor`).
+//!
+//! ### Why these live here
+//!
+//! The conversions are **substrate surface** — any consumer that builds
+//! `PublishRequest` from SDK-shaped state (continuum-core, Hermes,
+//! OpenClaw, future grid workers, the airc CLI itself) needs them.
+//! Before this module they lived as private `fn framekind_to_ipc` /
+//! `fn mention_to_ipc_target` / `pack_seq` / `unpack_seq` helpers in
+//! `airc-lib/src/daemon.rs`, which meant every external consumer had
+//! to either re-implement the same math (drift risk) or pull all of
+//! `airc-lib` to call a private fn (canonical SDK is shaped wrong for
+//! drive-by use).
+//!
+//! Promoting them to `impl From<>` in `airc-ipc` (the smallest crate
+//! that depends on both airc-core and airc-protocol) keeps the
+//! translation co-located with the IPC vocabulary it produces and lets
+//! every consumer write `pub_req.kind = frame_kind.into()` instead of
+//! reaching for a free function or duplicating a bit-shift.
+//!
+//! ### Drift guard
+//!
+//! [`COUNTER_BITS`] is published as a `pub const` so any consumer that
+//! needs to reproduce the layout (e.g. for in-memory cursor math
+//! without going through the conversion) can pin against the same
+//! constant — never against a literal `40`. If airc ever changes the
+//! pack layout, every dependent recompiles and round-trip tests
+//! everywhere catch the regression.
+
+use airc_core::{MentionTarget, TranscriptCursor};
+use airc_protocol::FrameKind;
+
+use crate::request::{IpcCursor, IpcKind, IpcTarget};
+
+/// Number of low-order bits in the packed `lamport` reserved for the
+/// per-epoch `counter`. The high bits hold `epoch`. Pinned at 40 — see
+/// `airc-lib/src/daemon.rs` (`pack_seq`/`unpack_seq`) for the historical
+/// rationale (40 bits = ~1.1T counter values per epoch, far beyond any
+/// real channel; the remaining 24 bits of `epoch` cover ~16M owner
+/// generations).
+pub const COUNTER_BITS: u32 = 40;
+
+/// Mask for the low [`COUNTER_BITS`] bits — the per-epoch counter range.
+pub const COUNTER_MASK: u64 = (1u64 << COUNTER_BITS) - 1;
+
+impl From<FrameKind> for IpcKind {
+    /// Lossless: the three chat-flavored `FrameKind` variants are a
+    /// subset of the seven `IpcKind` variants. RPC/grid consumers that
+    /// need `Command`/`CommandResult`/`Signal`/`StreamChunk` construct
+    /// `IpcKind` directly without going through `FrameKind`.
+    fn from(kind: FrameKind) -> Self {
+        match kind {
+            FrameKind::Message => IpcKind::Message,
+            FrameKind::Event => IpcKind::Event,
+            FrameKind::Control => IpcKind::Control,
+        }
+    }
+}
+
+impl From<MentionTarget> for IpcTarget {
+    /// Lossless: room mentions round-trip as a named endpoint
+    /// (`room:<uuid>`), which the inverse projection in airc-lib
+    /// (`target_to_mention`) parses back into [`MentionTarget::Room`].
+    /// Direct peer + broadcast pass straight through.
+    fn from(target: MentionTarget) -> Self {
+        match target {
+            MentionTarget::All => IpcTarget::All,
+            MentionTarget::Peer(peer) => IpcTarget::Peer(peer),
+            MentionTarget::Room(room) => IpcTarget::Endpoint(format!("room:{}", room.as_uuid())),
+        }
+    }
+}
+
+impl From<TranscriptCursor> for IpcCursor {
+    /// Unpack the SDK's single monotonic `lamport` into the wire
+    /// vocabulary's `(epoch, counter)` split. Inverse of
+    /// `IpcCursor → TranscriptCursor`. Round-trip preserves the
+    /// packed value byte-for-byte.
+    fn from(cursor: TranscriptCursor) -> Self {
+        Self {
+            epoch: cursor.lamport >> COUNTER_BITS,
+            counter: cursor.lamport & COUNTER_MASK,
+            event_id: cursor.event_id,
+        }
+    }
+}
+
+impl From<IpcCursor> for TranscriptCursor {
+    /// Pack the wire vocabulary's `(epoch, counter)` into the SDK's
+    /// monotonic `lamport`. Inverse of `TranscriptCursor → IpcCursor`.
+    /// The daemon always produces values within the
+    /// `(epoch << COUNTER_BITS) | counter` invariant, so this conversion
+    /// is total + round-trip safe for any cursor the daemon emits.
+    fn from(cursor: IpcCursor) -> Self {
+        Self {
+            lamport: (cursor.epoch << COUNTER_BITS) | (cursor.counter & COUNTER_MASK),
+            event_id: cursor.event_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::{EventId, RoomId};
+    use uuid::Uuid;
+
+    #[test]
+    fn frame_kind_message_event_control_map_to_ipc_kind() {
+        assert!(matches!(
+            IpcKind::from(FrameKind::Message),
+            IpcKind::Message
+        ));
+        assert!(matches!(IpcKind::from(FrameKind::Event), IpcKind::Event));
+        assert!(matches!(
+            IpcKind::from(FrameKind::Control),
+            IpcKind::Control
+        ));
+    }
+
+    #[test]
+    fn mention_all_to_ipc_target_all() {
+        assert!(matches!(
+            IpcTarget::from(MentionTarget::All),
+            IpcTarget::All
+        ));
+    }
+
+    #[test]
+    fn mention_room_to_endpoint_with_room_prefix() {
+        let room = RoomId::from_uuid(Uuid::from_u128(0xA1));
+        let target: IpcTarget = MentionTarget::Room(room).into();
+        match target {
+            IpcTarget::Endpoint(name) => {
+                assert!(name.starts_with("room:"));
+                assert!(name.contains(&room.as_uuid().to_string()));
+            }
+            other => panic!("expected Endpoint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cursor_round_trip_preserves_lamport_and_event_id() {
+        let original = TranscriptCursor {
+            lamport: (7u64 << COUNTER_BITS) | 99_999_999,
+            event_id: EventId::from_u128(0xc0ffee),
+        };
+        // TranscriptCursor isn't Copy — save the comparison values
+        // before the conversion consumes `original`.
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, 7);
+        assert_eq!(ipc.counter, 99_999_999);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+
+    #[test]
+    fn cursor_round_trip_with_zero_packs_to_zero() {
+        let original = TranscriptCursor {
+            lamport: 0,
+            event_id: EventId::from_u128(0),
+        };
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, 0);
+        assert_eq!(ipc.counter, 0);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, 0);
+    }
+
+    #[test]
+    fn counter_bits_constant_matches_legacy_airc_lib_layout() {
+        // Drift guard: airc-lib/src/daemon.rs hard-codes COUNTER_BITS = 40.
+        // If anyone changes either, this test (or an airc-lib test
+        // referencing this constant after the inline copy is deleted)
+        // will fail loud. Pin via this assertion so the const isn't
+        // silently shifted.
+        assert_eq!(COUNTER_BITS, 40);
+        assert_eq!(COUNTER_MASK, (1u64 << 40) - 1);
+    }
+
+    #[test]
+    fn cursor_round_trip_at_max_counter_boundary() {
+        // Counter is COUNTER_MASK (all 40 bits set), epoch is 0. This
+        // is the boundary where adding one to counter would overflow
+        // into epoch — the very edge the mask guards.
+        let original = TranscriptCursor {
+            lamport: COUNTER_MASK,
+            event_id: EventId::from_u128(0xb01dface),
+        };
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, 0);
+        assert_eq!(ipc.counter, COUNTER_MASK);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+
+    #[test]
+    fn cursor_round_trip_at_high_epoch_boundary() {
+        // Epoch occupies the high (64 - 40 = 24) bits. Setting the
+        // top epoch bit exercises the entire address space packing,
+        // catching any sign-extension or shift-direction regression.
+        // 2^23 fits cleanly in u64 << 40 without overflow.
+        let epoch = 1u64 << 23;
+        let counter = 12345u64;
+        let original = TranscriptCursor {
+            lamport: (epoch << COUNTER_BITS) | counter,
+            event_id: EventId::from_u128(0xfacefeed),
+        };
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, epoch);
+        assert_eq!(ipc.counter, counter);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+
+    #[test]
+    fn cursor_round_trip_at_u64_max_lamport() {
+        // u64::MAX has every bit set — the absolute upper bound the
+        // pack/unpack must handle without overflow. Epoch should be
+        // (u64::MAX >> 40), counter should be COUNTER_MASK.
+        let original = TranscriptCursor {
+            lamport: u64::MAX,
+            event_id: EventId::from_u128(0xdeadbeef),
+        };
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, u64::MAX >> COUNTER_BITS);
+        assert_eq!(ipc.counter, COUNTER_MASK);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+}

--- a/crates/airc-lib/src/agent_heartbeat.rs
+++ b/crates/airc-lib/src/agent_heartbeat.rs
@@ -518,7 +518,9 @@ async fn refresh_coordination(
     airc: &crate::Airc,
     baseline: &CoordinationSignal,
 ) -> Result<CoordinationSignal, AircError> {
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(crate::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let me = airc.peer_id();
     let active_claims: Vec<WorkCardId> = board
         .snapshot()

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -213,6 +213,42 @@ impl Airc {
         Ok(airc.with_daemon_client(DaemonClient::new(socket.into())))
     }
 
+    /// Attach to an already-running daemon AND open the local identity
+    /// under a specific `agent_name`. This is the constructor a multi-
+    /// citizen host (Continuum personas, future external-agent hosts)
+    /// reaches for when each hosted citizen needs:
+    ///
+    /// 1. Its OWN identity, distinguishable from other citizens'
+    ///    (the [`open_as`] half), so `airc peers` from another scope
+    ///    shows each one as a separate enrolled participant.
+    /// 2. The daemon's live publish/subscribe (the [`attach`] half),
+    ///    so the citizen can `say()` and `subscribe()` over the
+    ///    router instead of only inspecting local state.
+    ///
+    /// Today, [`attach`] only offers (2) (under the host's default
+    /// agent_name) and [`open_as`] only offers (1) (owner-mode, no
+    /// daemon). Hosting multiple citizens in one process with the
+    /// pre-existing pair therefore needs an unergonomic dance with
+    /// the (intentionally private) `with_daemon_client` builder.
+    /// This constructor closes the gap as a single call.
+    ///
+    /// Equivalent to:
+    /// ```ignore
+    /// let airc = Airc::open_as(home, agent_name).await?
+    ///     .with_daemon_client(DaemonClient::new(socket));
+    /// ```
+    ///
+    /// — but spelled as one method so consumers don't reach for the
+    /// private builder.
+    pub async fn attach_as(
+        home: impl Into<PathBuf>,
+        agent_name: impl Into<String>,
+        socket: impl Into<PathBuf>,
+    ) -> Result<Self, AircError> {
+        let airc = Self::open_as(home, agent_name).await?;
+        Ok(airc.with_daemon_client(DaemonClient::new(socket.into())))
+    }
+
     /// Test-only [`attach`] that pins the machine-account wire root
     /// explicitly instead of deriving it from `HOME`/`USERPROFILE`.
     /// Two scopes sharing one `wire_root` resolve the same mesh

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -912,6 +912,18 @@ impl Airc {
     /// Subscribe to `name` and make it the default channel for
     /// short-shape commands.
     pub async fn join(&self, name: &str) -> Result<Room, AircError> {
+        // Card c409eaf5: refuse uuid-shaped names. `ChannelName::new`
+        // hashes the name into a derived UUID; a uuid-shaped string
+        // re-hashes into a DIFFERENT channel UUID, silently. The
+        // resulting subscription registers on the wrong channel and
+        // the fan-out misses every publish. Better to fail loudly at
+        // the API boundary than to let the trap close on the next
+        // consumer like it closed on the continuum demo 2026-06-01.
+        if uuid::Uuid::parse_str(name.trim()).is_ok() {
+            return Err(AircError::JoinUuidString {
+                string: name.to_string(),
+            });
+        }
         let channel = ChannelName::new(name)?;
         let identity = self.mesh_identity().await?;
         let mut set = subscriptions::load_or_init(self.event_store()).await?;

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -19,8 +19,8 @@ use airc_bus::envelope::{Envelope, Kind, Target};
 use airc_core::{Body, MentionTarget, RoomId, TranscriptCursor, TranscriptEvent, TranscriptKind};
 use airc_ipc::codec::read_frame;
 use airc_ipc::{
-    AttachRequest, InboxRequest, IpcCursor, IpcDelivery, IpcKind, IpcTarget, PublishRequest,
-    Response, SendRequest,
+    AttachRequest, InboxRequest, IpcCursor, IpcDelivery, IpcTarget, PublishRequest, Response,
+    SendRequest,
 };
 use airc_protocol::FrameKind;
 use tokio::sync::mpsc;
@@ -34,8 +34,11 @@ use crate::Airc;
 /// Low bits of the packed `lamport` that hold the per-epoch counter; the
 /// remaining high bits hold the epoch. 40 bits ⇒ ~1.1e12 events per
 /// epoch and ~16.7M epochs (restarts) — neither realistically reachable.
-const COUNTER_BITS: u32 = 40;
-const COUNTER_MASK: u64 = (1 << COUNTER_BITS) - 1;
+//
+// Re-exported from airc-ipc so the wire vocabulary and the SDK
+// projection can never disagree on layout. Anyone reading
+// `COUNTER_BITS` here gets the same value as the IPC From impls.
+use airc_ipc::{COUNTER_BITS, COUNTER_MASK};
 
 /// Reconnect backoff for a daemon attach stream that drops (daemon
 /// restart / transient loss): start small, double, cap — so a long
@@ -58,17 +61,6 @@ fn unpack_seq(lamport: u64) -> (u64, u64) {
     (lamport >> COUNTER_BITS, lamport & COUNTER_MASK)
 }
 
-/// Map the consumer-facing `FrameKind` (chat vocabulary) to the bus's
-/// `IpcKind`. RPC/grid consumers that need `Command`/`CommandResult`
-/// publish via the typed IPC client directly with `IpcKind`.
-fn framekind_to_ipc(kind: FrameKind) -> IpcKind {
-    match kind {
-        FrameKind::Message => IpcKind::Message,
-        FrameKind::Event => IpcKind::Event,
-        FrameKind::Control => IpcKind::Control,
-    }
-}
-
 fn kind_to_transcript(kind: Kind) -> TranscriptKind {
     match kind {
         Kind::Message => TranscriptKind::Message,
@@ -80,16 +72,6 @@ fn kind_to_transcript(kind: Kind) -> TranscriptKind {
         | Kind::Signal
         | Kind::StreamChunk
         | Kind::Control => TranscriptKind::System,
-    }
-}
-
-/// Inverse of [`target_to_mention`] — map the SDK send target to the IPC
-/// addressing vocabulary. A room mention round-trips as a named endpoint.
-fn mention_to_ipc_target(target: MentionTarget) -> IpcTarget {
-    match target {
-        MentionTarget::All => IpcTarget::All,
-        MentionTarget::Peer(peer) => IpcTarget::Peer(peer),
-        MentionTarget::Room(room) => IpcTarget::Endpoint(format!("room:{}", room.as_uuid())),
     }
 }
 
@@ -186,9 +168,9 @@ impl Airc {
                 channel: room.channel.as_uuid(),
                 from_peer: self.peer_id().as_uuid(),
                 from_client: self.client_id().as_uuid(),
-                kind: framekind_to_ipc(kind),
+                kind: kind.into(),
                 delivery: IpcDelivery::Durable,
-                target: mention_to_ipc_target(target),
+                target: target.into(),
                 correlation_id: None,
                 coalesce_key: None,
                 payload: body.to_payload(),
@@ -215,7 +197,7 @@ impl Airc {
                 channel: room.channel.as_uuid(),
                 from_peer: self.peer_id().as_uuid(),
                 from_client: self.client_id().as_uuid(),
-                kind: framekind_to_ipc(kind),
+                kind: kind.into(),
                 // SDK chat/structured publishes are durable; the live
                 // streaming classes are reached via the typed IPC client
                 // directly (media/game-state), not this chat helper.

--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -80,6 +80,25 @@ pub enum AircError {
     #[error("not subscribed to channel: {0}")]
     NotSubscribed(String),
 
+    /// Caller passed a uuid-shaped string to [`crate::Airc::join`].
+    /// `join(name)` takes a channel NAME and hashes it into the
+    /// channel UUID; a uuid-shaped string gets re-hashed and
+    /// produces a brand-new channel whose UUID does NOT match the
+    /// caller's intent. Card c409eaf5 makes that class of silent
+    /// failure loud. Either pass the channel NAME (like "continuum"
+    /// or "general"), or — if you already hold a channel UUID and
+    /// want to attach to the existing channel — look it up via the
+    /// subscription set and pass its actual name. UUIDs do not
+    /// round-trip through `ChannelName::new`.
+    #[error(
+        "join refused: {string:?} looks like a UUID. \
+         `Airc::join(name)` takes a channel NAME and derives the channel UUID by hashing — \
+         passing a UUID string re-hashes it into a different channel. \
+         If you want to attach to an existing channel by its UUID, look it up via the \
+         subscription set and pass its name to join."
+    )]
+    JoinUuidString { string: String },
+
     /// Caller attempted to mutate a work card from a room whose work
     /// projection does not contain that card. Work cards are
     /// room-scoped coordination state; transitions from another room
@@ -120,4 +139,59 @@ pub enum AircError {
     /// correlation id rather than reusing the timed-out one.
     #[error("command deadline elapsed (correlation_id={correlation_id})")]
     CommandDeadline { correlation_id: uuid::Uuid },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn join_uuid_string_error_names_the_input() {
+        let err = AircError::JoinUuidString {
+            string: "11c1a7ac-cb85-5ca0-a5b4-2847280ea3fa".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("11c1a7ac-cb85-5ca0-a5b4-2847280ea3fa"),
+            "{msg}"
+        );
+        assert!(msg.contains("looks like a UUID"), "{msg}");
+        assert!(msg.contains("channel NAME"), "{msg}");
+    }
+
+    /// Card c409eaf5 — pin the canonical detection: every uuid shape
+    /// the standard parser accepts MUST trip the guard, otherwise the
+    /// trap re-opens for the next consumer that picks an alternate
+    /// uuid format. Bare hex (no hyphens) and braced are both valid
+    /// per uuid::Uuid::parse_str.
+    #[test]
+    fn uuid_detection_canonical_shapes_all_trip() {
+        let shapes = [
+            "11c1a7ac-cb85-5ca0-a5b4-2847280ea3fa",     // hyphenated
+            "11c1a7accb855ca0a5b42847280ea3fa",         // bare hex
+            "{11c1a7ac-cb85-5ca0-a5b4-2847280ea3fa}",   // braced
+            "  11c1a7ac-cb85-5ca0-a5b4-2847280ea3fa  ", // padded
+        ];
+        for s in shapes {
+            assert!(
+                uuid::Uuid::parse_str(s.trim()).is_ok(),
+                "uuid::parse_str must accept {s:?} — if this fails, \
+                 either the guard needs to broaden or the test case is wrong"
+            );
+        }
+    }
+
+    /// Card c409eaf5 — false-positive guard. Real channel names must
+    /// pass through; the predicate is uuid-specific, not "anything
+    /// hex-looking."
+    #[test]
+    fn uuid_detection_rejects_real_channel_names() {
+        let names = ["continuum", "general", "cambriantech", "ai-dev", "room-1"];
+        for s in names {
+            assert!(
+                uuid::Uuid::parse_str(s.trim()).is_err(),
+                "uuid::parse_str must REJECT real channel name {s:?}"
+            );
+        }
+    }
 }

--- a/crates/airc-lib/src/gh_client.rs
+++ b/crates/airc-lib/src/gh_client.rs
@@ -180,7 +180,7 @@ pub struct BranchCheckRollupArgs {
     pub branch: String,
 }
 
-/// `gh pr view --json state,mergeable,statusCheckRollup` shape.
+/// `gh pr view --json state,mergeable,statusCheckRollup,mergedAt` shape.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct PrView {
     #[serde(default)]
@@ -189,6 +189,14 @@ pub struct PrView {
     pub mergeable: String,
     #[serde(default, rename = "statusCheckRollup")]
     pub status_check_rollup: Option<Vec<GhCheck>>,
+    /// ISO-8601 timestamp of the merge, populated by gh when
+    /// `state == "MERGED"`. `None` for OPEN PRs. The merger's
+    /// reconcile path (card acd72c81 follow-up) parses this to emit
+    /// `PullRequestMerged` with the canonical GitHub timestamp
+    /// instead of wall-clock-now when transitioning the kanban for
+    /// an already-merged PR.
+    #[serde(default, rename = "mergedAt")]
+    pub merged_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -715,6 +723,7 @@ pub mod mock {
                 state: state.to_string(),
                 mergeable: "MERGEABLE".to_string(),
                 status_check_rollup: Some(Vec::new()),
+                merged_at: None,
             }
         }
 

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -146,7 +146,7 @@ pub use work::{
     HeartbeatWorkspace, LinkCardPullRequest, MarkPullRequestMerged, ObserveLocalGitWorkspace,
     ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests, ReleaseManagerHat,
     ReleaseWorkClaim, ReleaseWorkspace, ReportAgentAvailability, RequestWorkspace, UpdateWorkCard,
-    WorkQueueStatus, WorkQueueStatusQuery,
+    WorkQueueStatus, WorkQueueStatusQuery, WORK_BOARD_PROJECTION_PAGE_SIZE,
 };
 pub use work_manager::{
     SeededWorkCard, WorkBacklogSeedCandidate, WorkBacklogSeedOutcome, WorkBacklogSeedResult,

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -30,6 +30,26 @@ const WORK_MUTATION_PAGE_SIZE: usize = 512;
 /// the minimum-viable fix until that follow-up.
 const WORK_BOARD_FETCH_MULTIPLIER: usize = 4;
 
+/// Canonical pagination size for complete work-board projections.
+///
+/// Card acd72c81: every prior caller that needed the complete board
+/// was passing `usize::MAX` to `work_board(limit)`. That issues ONE
+/// Inbox RPC asking for `usize::MAX * WORK_BOARD_FETCH_MULTIPLIER`
+/// events; the daemon serializes every transcript event in the room
+/// into a single CBOR frame, which trips
+/// `airc_ipc::codec::MAX_FRAME_BYTES` (16 MiB) once the room
+/// accumulates ~9000+ events. Empirically caught on Joel's box
+/// 2026-06-01: `airc work state X closed` failed with
+/// `daemon I/O: ipc frame too large: 16973574 bytes exceeds 16777216`.
+///
+/// `work_board_complete(page_size)` paginates: each IPC frame stays
+/// well under the cap while the projection is still complete.
+/// 1024 events per page is a comfortable middle: each frame fits
+/// (events are typed, not blob payloads — kilobytes each, not MB),
+/// and the round-trip count stays low for the 9000+ event case
+/// (~9 RPCs instead of one giant one).
+pub const WORK_BOARD_PROJECTION_PAGE_SIZE: usize = 1024;
+
 /// Card 79953b4d (pure helper for unit-testability): true when a
 /// transcript event is a work-domain event. Distinguishes work events
 /// from heartbeats / chat / other lifecycle by header presence rather
@@ -740,6 +760,14 @@ impl Airc {
     /// events. `limit` is the transcript page size for interactive
     /// board views; scheduling code should use
     /// [`Airc::work_board_complete`] instead.
+    ///
+    /// **DO NOT pass `usize::MAX`** — it issues a single Inbox RPC
+    /// asking for every event in the room, which trips
+    /// `airc_ipc::codec::MAX_FRAME_BYTES` (16 MiB) once the room
+    /// has accumulated ~9000+ events. If you need the complete
+    /// board, call [`Airc::work_board_complete`] with
+    /// [`WORK_BOARD_PROJECTION_PAGE_SIZE`] (paginated, never hits
+    /// the cap). Card acd72c81.
     pub async fn work_board(&self, limit: usize) -> Result<WorkBoardProjection, AircError> {
         let room = self.current_room().await?;
         // Recent-window view (not the complete board): daemon reads the


### PR DESCRIPTION
`Airc::join(name)` ran `ChannelName::new(name)` which hashes the
name into the channel UUID. Passing a uuid-shaped string as the
"name" silently re-hashed it into a DIFFERENT channel UUID — the
subscription registered on a channel nobody else was publishing
to, fan-out missed every publish, the substrate looked broken.

Empirically captured 2026-06-01 (card 800ce5bd diagnostics on
the live daemon): the continuum airc_chat_demo passed a uuid
string '11c1a7ac-...' to .join(), Paige landed on derived
channel '5d33e2a7-...' (shard 15), Joel's `airc msg` published
to the real '11c1a7ac-...' (shard 10), and the fan-out summary
showed subscribers_before=0. Hours of substrate diagnostic work
to surface a one-line consumer bug.

This commit makes the trap loud at the API boundary. `Airc::join`
now refuses uuid-shaped names with a typed error
`AircError::JoinUuidString { string }` whose Display names the
offending string, explains the hash-derivation, and points at the
two correct remedies:

- Pass the channel NAME (like "continuum" or "general").
- If you have a channel UUID and want to attach to the existing
  channel, look it up via the subscription set and pass its
  actual name.

Tests:

- `join_uuid_string_error_names_the_input` — the Display
  surfaces the offending string + the doctrinal phrases
  ("looks like a UUID", "channel NAME"). If a future refactor
  drops the diagnostic detail, this test catches it.
- `uuid_detection_canonical_shapes_all_trip` — pins that every
  shape `uuid::Uuid::parse_str` accepts (hyphenated, bare hex,
  braced, whitespace-padded) trips the guard. The guard
  delegates to the standard parser; if any of these stops
  tripping it, the trap re-opens for whoever's holding that
  format.
- `uuid_detection_rejects_real_channel_names` — false-positive
  guard. Real channel names ("continuum", "general", "ai-dev",
  "room-1") must pass through unchanged; the predicate is
  uuid-specific, not "anything hex-looking."

Doctrine: every load-bearing API gets a typed-error path for
its silent-failure modes. The next consumer who reaches for
`.join()` with a uuid in hand gets a refusal that names the
remedy, not a silent wrong-channel subscription.

Card: c409eaf5

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>