### PR TITLE
feat(work): `airc work cleanup` — auto-prune merged-card worktrees (card c9b28925)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Continuum uses airc-style channels as the transport substrate for live rooms whe
 
 The same channel model can back other consumers. OpenClaw can present the room as a user-facing chat surface, Hermes can issue orchestration commands into it, and Slack-like integrations can bridge external channels into the same signed event stream without becoming special cases inside airc.
 
+Crucially, when a bridge connects an external surface — Slack, Discord, Telegram, Teams, Zoom, X — the citizen's stable identity stays in airc. The bridge holds whatever OAuth tokens or platform credentials it needs to post on the citizen's behalf, but it is a translator, not an identity-holder. Unplug the bridge and the citizen persists. Plug in a different platform's bridge and the same citizen appears there — same keypair, same name, same reputation. This is what "same personas, everywhere" means at the substrate level.
+
 ## Embedded Consumers
 
 airc is a command-line chat tool and an embeddable Rust substrate. Applications should use `airc-lib` instead of shelling out when they need event streams, cursor replay, or typed filtering.

--- a/crates/airc-cli/src/gh_client.rs
+++ b/crates/airc-cli/src/gh_client.rs
@@ -69,7 +69,7 @@ impl GhClient for ShellGhClient {
                 "--repo",
                 args.repo.as_str(),
                 "--json",
-                "state,mergeable,statusCheckRollup",
+                "state,mergeable,statusCheckRollup,mergedAt",
             ])
             .output()
             .await

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -656,6 +656,9 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 work_commands::run_state(&home, card_id, state).await
             }
             WorkAction::Close { card_id } => work_commands::run_close(&home, card_id).await,
+            WorkAction::Cleanup { dry_run, force } => {
+                work_commands::run_cleanup(&home, dry_run, force).await
+            }
             WorkAction::Board {
                 limit,
                 available,

--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -165,6 +165,25 @@ async fn tick_once(
                     ),
                 }
             }
+            MergeDecision::Reconcile(pr, merged_at_ms) => {
+                if dry_run {
+                    eprintln!(
+                        "airc-merger: [DRY-RUN] would reconcile already-merged card={} pr=#{} ({})",
+                        card.card_id, pr.number, pr.repo
+                    );
+                    continue;
+                }
+                match perform_reconcile(card, &pr, merged_at_ms, airc).await {
+                    Ok(()) => eprintln!(
+                        "airc-merger: reconciled already-merged card={} pr=#{} ({})",
+                        card.card_id, pr.number, pr.repo
+                    ),
+                    Err(error) => eprintln!(
+                        "airc-merger: reconcile failed card={} pr=#{}: {error}",
+                        card.card_id, pr.number
+                    ),
+                }
+            }
             MergeDecision::Skip(reason) => {
                 eprintln!("airc-merger: skip card={} reason={reason}", card.card_id);
             }
@@ -173,8 +192,43 @@ async fn tick_once(
     Ok(())
 }
 
+/// Card acd72c81 follow-up: emit `PullRequestMerged` for a card whose
+/// PR is ALREADY merged on GitHub. Skips `gh pr merge` (the GH merge
+/// already happened), runs the same kanban-event + worktree-cleanup
+/// shape as `perform_merge` so reconciled cards reach the exact same
+/// terminal state as freshly-merged ones.
+async fn perform_reconcile(
+    card: &WorkCard,
+    pr: &airc_work::model::PullRequestRef,
+    merged_at_ms: u64,
+    airc: &Airc,
+) -> Result<(), Box<dyn std::error::Error>> {
+    airc.mark_pull_request_merged(MarkPullRequestMerged {
+        card_id: card.card_id,
+        pull_request: pr.clone(),
+        merged_at_ms,
+    })
+    .await?;
+
+    if let Err(error) = crate::work_commands::cleanup_card_worktree(card.card_id).await {
+        eprintln!(
+            "airc-merger: worktree cleanup skipped for {} — {error}",
+            card.card_id
+        );
+    }
+    Ok(())
+}
+
 enum MergeDecision {
     Merge(airc_work::model::PullRequestRef),
+    /// Card acd72c81 follow-up: PR is ALREADY merged on GitHub but the
+    /// kanban projection hasn't observed it (no `PullRequestMerged`
+    /// event for this card). The merger reconciles by emitting one
+    /// — no `gh pr merge` call needed; the merge already happened.
+    /// `merged_at_ms` comes from gh's `mergedAt` ISO-8601 timestamp
+    /// when available, falls back to wall-clock-now if gh didn't
+    /// supply it (older gh schema or transient).
+    Reconcile(airc_work::model::PullRequestRef, u64),
     Skip(String),
 }
 
@@ -198,6 +252,9 @@ async fn evaluate(
 
     match check_pr_gate(gh, &pr, baseline_failures, policy).await {
         Ok(GateResult::Green) => Ok(Some(MergeDecision::Merge(pr))),
+        Ok(GateResult::AlreadyMerged { merged_at_ms }) => {
+            Ok(Some(MergeDecision::Reconcile(pr, merged_at_ms)))
+        }
         Ok(GateResult::NotReady(reason)) => Ok(Some(MergeDecision::Skip(reason))),
         Err(error) => Ok(Some(MergeDecision::Skip(format!(
             "gh status query failed: {error}"
@@ -208,9 +265,20 @@ async fn evaluate(
 /// Result of applying the merge gate to a PR. `pub(crate)` since card
 /// a399b342: the `airc work merge` CLI command consumes the same gate
 /// so a manual merge is held to the same bar the auto-merger uses.
+#[derive(Debug)]
 pub(crate) enum GateResult {
     Green,
     NotReady(String),
+    /// Card acd72c81 follow-up: PR's GitHub state is already MERGED
+    /// (someone merged it out-of-band, or the merger crashed after
+    /// `gh pr merge` but before `mark_pull_request_merged`, or this
+    /// card was created post-hoc to track an already-shipped PR).
+    /// The card needs `PullRequestMerged` to reach the Merged state,
+    /// but `gh pr merge` would 422. `merged_at_ms` is parsed from
+    /// gh's `mergedAt`; falls back to wall-clock-now if absent.
+    AlreadyMerged {
+        merged_at_ms: u64,
+    },
 }
 
 /// Card 7ed1ac4f — tunable policy parameters carried into
@@ -250,6 +318,17 @@ pub(crate) fn now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+/// Parse gh's `mergedAt` (ISO-8601, e.g. "2026-06-01T07:04:07Z") to
+/// epoch milliseconds. Returns `None` on parse failure so the caller
+/// can fall back to wall-clock-now. Card acd72c81 follow-up: the
+/// reconcile path's canonical timestamp is GitHub's recorded merge
+/// time, not the reconcile tick's wall clock.
+pub(crate) fn parse_iso8601_to_ms(s: &str) -> Option<u64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp_millis().max(0) as u64)
 }
 
 /// Query `gh pr view --json statusCheckRollup,mergeable,state` and
@@ -355,6 +434,22 @@ pub(crate) fn evaluate_gh_view(
     baseline_failures: &std::collections::HashSet<String>,
     policy: GatePolicy,
 ) -> GateResult {
+    if view.state == "MERGED" {
+        // Card acd72c81 follow-up: reconcile, don't skip. The kanban
+        // projection needs `PullRequestMerged` to transition; the GH
+        // merge already happened, so the merger just emits the event.
+        let merged_at_ms = view
+            .merged_at
+            .as_deref()
+            .and_then(parse_iso8601_to_ms)
+            .unwrap_or_else(|| {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0)
+            });
+        return GateResult::AlreadyMerged { merged_at_ms };
+    }
     if view.state != "OPEN" {
         return GateResult::NotReady(format!("PR state is {} (not OPEN)", view.state));
     }
@@ -579,12 +674,22 @@ mod tests {
     }
 
     #[test]
-    fn refuses_when_pr_is_already_merged() {
-        let view = parse(json!({"state": "MERGED", "mergeable": "MERGEABLE"}));
-        assert!(matches!(
-            evaluate_gh_view(&view, &empty_baseline(), empty_policy()),
-            GateResult::NotReady(_)
-        ));
+    fn reconciles_when_pr_is_already_merged() {
+        // Pre-acd72c81 behavior: MERGED → NotReady("PR state is
+        // MERGED (not OPEN)"). That caused the merger to skip
+        // already-merged PRs forever, leaving the kanban out of
+        // sync with GitHub. The acd72c81 follow-up routes MERGED
+        // into AlreadyMerged so the merger emits
+        // `PullRequestMerged` and transitions the card.
+        let view = parse(
+            json!({"state": "MERGED", "mergeable": "MERGEABLE", "mergedAt": "2026-06-01T07:04:07Z"}),
+        );
+        match evaluate_gh_view(&view, &empty_baseline(), empty_policy()) {
+            GateResult::AlreadyMerged { merged_at_ms } => {
+                assert_eq!(merged_at_ms, 1780297447000);
+            }
+            other => panic!("expected AlreadyMerged, got {other:?}"),
+        }
     }
 
     #[test]
@@ -917,6 +1022,7 @@ mod tests {
             match g {
                 GateResult::Green => "green",
                 GateResult::NotReady(_) => "not_ready",
+                GateResult::AlreadyMerged { .. } => "already_merged",
             }
         }
         assert_eq!(classify_for_external_caller(GateResult::Green), "green");
@@ -924,6 +1030,89 @@ mod tests {
             classify_for_external_caller(GateResult::NotReady("test".into())),
             "not_ready"
         );
+        assert_eq!(
+            classify_for_external_caller(GateResult::AlreadyMerged { merged_at_ms: 0 }),
+            "already_merged"
+        );
+    }
+
+    #[test]
+    fn evaluate_gh_view_routes_merged_state_to_already_merged() {
+        // Card acd72c81 follow-up: a PR whose state is MERGED
+        // returns AlreadyMerged so the merger reconciles instead of
+        // skipping. The parsed mergedAt becomes the canonical
+        // merged_at_ms; absent mergedAt falls back to wall-clock-now
+        // (not asserted here because that path uses SystemTime).
+        let view = crate::gh_client::PrView {
+            state: "MERGED".to_string(),
+            mergeable: "".to_string(),
+            status_check_rollup: None,
+            merged_at: Some("2026-06-01T07:04:07Z".to_string()),
+        };
+        let baseline = std::collections::HashSet::new();
+        let policy = GatePolicy::default_for_merger(0);
+        match evaluate_gh_view(&view, &baseline, policy) {
+            GateResult::AlreadyMerged { merged_at_ms } => {
+                // 2026-06-01T07:04:07Z = 1780297447000 ms
+                assert_eq!(merged_at_ms, 1780297447000);
+            }
+            other => panic!("expected AlreadyMerged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evaluate_gh_view_falls_back_to_wallclock_when_merged_at_absent() {
+        // gh shouldn't return MERGED without mergedAt, but we don't
+        // crash if it does — the wall-clock-now fallback yields a
+        // reasonable timestamp. Asserts nonzero rather than a
+        // specific value (SystemTime is non-deterministic in tests).
+        let view = crate::gh_client::PrView {
+            state: "MERGED".to_string(),
+            mergeable: "".to_string(),
+            status_check_rollup: None,
+            merged_at: None,
+        };
+        let baseline = std::collections::HashSet::new();
+        let policy = GatePolicy::default_for_merger(0);
+        match evaluate_gh_view(&view, &baseline, policy) {
+            GateResult::AlreadyMerged { merged_at_ms } => assert!(merged_at_ms > 0),
+            other => panic!("expected AlreadyMerged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evaluate_gh_view_routes_closed_state_to_not_ready() {
+        // Closed (without merge) is still NotReady — the merger
+        // shouldn't try to reconcile a closed-without-merging PR
+        // into Merged state. Only MERGED → AlreadyMerged.
+        let view = crate::gh_client::PrView {
+            state: "CLOSED".to_string(),
+            mergeable: "".to_string(),
+            status_check_rollup: None,
+            merged_at: None,
+        };
+        let baseline = std::collections::HashSet::new();
+        let policy = GatePolicy::default_for_merger(0);
+        match evaluate_gh_view(&view, &baseline, policy) {
+            GateResult::NotReady(reason) => {
+                assert!(reason.contains("CLOSED"), "got: {reason}");
+            }
+            other => panic!("expected NotReady, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_iso8601_to_ms_handles_standard_gh_format() {
+        assert_eq!(
+            parse_iso8601_to_ms("2026-06-01T07:04:07Z"),
+            Some(1780297447000)
+        );
+        assert_eq!(
+            parse_iso8601_to_ms("2026-06-01T07:04:07.500Z"),
+            Some(1780297447500)
+        );
+        assert_eq!(parse_iso8601_to_ms("garbage"), None);
+        assert_eq!(parse_iso8601_to_ms(""), None);
     }
 
     #[test]

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -138,6 +138,25 @@ pub enum WorkAction {
         /// Work card UUID.
         card_id: String,
     },
+    /// Prune worktrees whose work card has reached a terminal state
+    /// (Closed or Merged). Card c9b28925: the substrate accumulates a
+    /// worktree per claimed card; once the card ships, the worktree
+    /// is L1 cache, not durable state ([[local-worktree-is-temp-dir]]).
+    /// Default is dry-run (prints what WOULD be removed); pass
+    /// `--force` to actually remove. Worktrees with uncommitted /
+    /// unpushed changes are NEVER removed silently — the operator's
+    /// WIP outranks hygiene.
+    Cleanup {
+        /// Explicit dry-run flag. Default behaviour even without it,
+        /// but useful in scripts so the intent is loud.
+        #[arg(long)]
+        dry_run: bool,
+        /// Actually `git worktree remove` everything classified as
+        /// Removable. Dirty / unknown / locked worktrees are still
+        /// reported but NEVER touched.
+        #[arg(long)]
+        force: bool,
+    },
     /// Print the current room's projected work board.
     ///
     /// `--available`, `--mine`, `--others` are mutually exclusive filters

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -548,19 +548,26 @@ pub async fn run_state(
 /// Disk-pressure substrate fix; the 2026-05-28 session sat on
 /// ~25 GB of orphan target/ before a manual sweep.
 ///
-/// Contract:
+/// Contract (PR #1105 reviewer round 1 fix — describes ACTUAL
+/// behavior, not the previous version's mis-stated guarantees):
 ///   * Resolves `~/.airc/worktrees/<card_short>/` from `lease_root`.
 ///   * Skips silently (Ok) if the worktree doesn't exist — re-close
 ///     on an already-cleaned card is a no-op.
-///   * REFUSES with an error if the worktree has uncommitted
-///     changes (`git status --porcelain` non-empty). The agent
-///     recovers manually; we never silently nuke pending work.
-///   * REFUSES if the worktree has unpushed commits AND its branch
-///     is the worktree's current HEAD — those commits would be
-///     unreachable after pruning. Pushed commits are fine because
-///     origin still has them.
+///   * REFUSES via `probe_dirty_status` if EITHER of:
+///       - `git status --porcelain` non-empty (uncommitted /
+///         untracked work) — that's WIP on disk
+///       - `git rev-list --count @{u}..HEAD > 0` (committed but
+///         unpushed work) — that's WIP only-on-this-machine
+///       - probe is ambiguous (no upstream, detached HEAD, broken
+///         git) — refuse to classify per `[[no-fallbacks-ever]]`
+///     The agent recovers manually; we never silently nuke
+///     pending work. This is the "operator's WIP outranks hygiene"
+///     contract.
 ///   * On the happy path: `git worktree remove --force` then
-///     `git branch -D` if the branch has no other reachable refs.
+///     `git branch -d` (lowercase — refuses unmerged) as a
+///     second line of defense if probe somehow missed unpushed
+///     work, or if the branch was used by a different worktree
+///     too.
 ///   * All operations run from the MAIN working tree (the cwd's
 ///     repo root), not from the worktree being removed.
 ///
@@ -582,25 +589,31 @@ pub(crate) async fn cleanup_card_worktree(
     }
     let worktree_str = worktree_path.to_string_lossy().to_string();
 
-    // Uncommitted-change guard.
-    let status_out = std::process::Command::new("git")
-        .args(["-C", &worktree_str, "status", "--porcelain"])
-        .output()?;
-    if !status_out.status.success() {
-        return Err(format!(
-            "git status --porcelain failed on worktree {worktree_str}: {}",
-            String::from_utf8_lossy(&status_out.stderr).trim()
-        )
-        .into());
-    }
-    let porcelain = String::from_utf8(status_out.stdout)?;
-    if !porcelain.trim().is_empty() {
-        return Err(format!(
-            "worktree at {worktree_str} has uncommitted changes — refusing \
-             to remove. commit + push or discard manually, then re-close \
-             the card to retry cleanup."
-        )
-        .into());
+    // WIP guard: refuse if either uncommitted/untracked OR
+    // committed-but-unpushed work exists, OR the probe is ambiguous.
+    // Same `probe_dirty_status` the run_cleanup classifier uses so
+    // both terminal paths apply identical safety.
+    match probe_dirty_status(&worktree_path) {
+        DirtyStatus::Clean => {}
+        DirtyStatus::Dirty => {
+            return Err(format!(
+                "worktree at {worktree_str} has uncommitted or unpushed work — \
+                 refusing to remove. commit + push or discard manually, then \
+                 re-close the card to retry cleanup."
+            )
+            .into());
+        }
+        DirtyStatus::Unknown => {
+            return Err(format!(
+                "worktree at {worktree_str} could not be classified \
+                 (not a git dir / no upstream tracking / detached HEAD / \
+                 broken repo) — refusing to remove. Per [[no-fallbacks-ever]] \
+                 the substrate refuses to nuke worktrees it can't \
+                 confidently call clean. Inspect with `git -C {worktree_str} \
+                 status` and resolve manually."
+            )
+            .into());
+        }
     }
 
     // Identify the worktree's branch so we can prune it after removal.
@@ -859,8 +872,9 @@ pub async fn run_cleanup(
             .and_then(|c| c.pull_request.as_ref().map(|pr| pr.number));
         let repo = card.as_ref().map(|c| c.repo.to_string());
 
-        // Check git status (`--porcelain` => empty stdout means clean).
-        let dirty_status = git_status_porcelain(&path);
+        // Probe for both uncommitted AND unpushed work — see
+        // `probe_dirty_status` for the WIP-outranks-hygiene contract.
+        let dirty_status = probe_dirty_status(&path);
 
         let disposition = classify_worktree(card_state.as_ref(), &dirty_status);
 
@@ -975,8 +989,9 @@ pub(crate) enum Disposition {
     /// Card is still active (Open / Claimed / InProgress / Review /
     /// Blocked / Merged-but-projection-not-caught-up). Keep.
     KeepActive,
-    /// Worktree has uncommitted / unpushed changes. Operator's WIP
-    /// outranks hygiene; print, never remove.
+    /// Worktree has uncommitted or unpushed work (detected by
+    /// `probe_dirty_status`). Operator's WIP outranks hygiene;
+    /// print, never remove.
     SkipDirty,
     /// Couldn't run `git status` (not a git dir, permissions, etc).
     SkipNotGit,
@@ -1011,20 +1026,28 @@ impl Disposition {
         match self {
             Disposition::Removable => "  (would remove on --force)",
             Disposition::KeepActive => "",
-            Disposition::SkipDirty => "  uncommitted changes",
+            Disposition::SkipDirty => "  uncommitted or unpushed work",
             Disposition::SkipNotGit => "  not a git worktree",
             Disposition::SkipUnknownCard => "  no matching card on board",
         }
     }
 }
 
-/// Whether the worktree has uncommitted / unpushed changes. Outcome
-/// of `git status --porcelain` (empty == clean) or a probe failure.
+/// Whether the worktree carries work the operator has not yet
+/// captured upstream. Outcome of `probe_dirty_status` — see that
+/// function for the two-pass check (porcelain + `@{u}..HEAD`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DirtyStatus {
+    /// Working tree matches HEAD AND HEAD is fully pushed upstream.
     Clean,
+    /// Either uncommitted/untracked files OR committed-but-unpushed
+    /// commits exist. Either way the worktree's files are WIP that
+    /// may not be captured anywhere else; refuse to remove.
     Dirty,
-    /// Probe failed — `git status` errored, not a git dir, etc.
+    /// Probe failed — `git status` errored, no upstream tracking,
+    /// detached HEAD, or not a git dir. Per `[[no-fallbacks-ever]]`
+    /// the classifier treats Unknown as SkipNotGit and refuses
+    /// rather than guessing Clean.
     Unknown,
 }
 
@@ -1067,25 +1090,73 @@ pub(crate) fn parse_worktree_short_id(basename: &str) -> Option<String> {
     Some(prefix)
 }
 
-/// Probe `git status --porcelain` in `path`. Empty stdout ⇒ clean.
-/// Non-empty ⇒ Dirty. Probe failure ⇒ Unknown (caller treats as
-/// SkipNotGit per the safety doctrine: refuse to remove anything we
-/// can't confidently classify).
-fn git_status_porcelain(path: &std::path::Path) -> DirtyStatus {
+/// Probe `path` for any state that means "this worktree carries
+/// work the operator has not yet captured upstream." Two passes:
+///
+///   1. `git status --porcelain` — catches uncommitted-in-working-tree
+///      AND untracked files. Non-empty ⇒ Dirty.
+///   2. `git rev-list --count @{u}..HEAD` — catches committed-but-
+///      not-pushed work. Non-zero ⇒ Dirty. The branch survives
+///      the per-card cleanup (because `git branch -d` refuses
+///      unmerged), but per `[[local-worktree-is-temp-dir]]` the
+///      worktree's *files on disk* are the WIP an operator may
+///      still be editing; we don't remove them silently.
+///
+/// Probe failures (git not on PATH, broken repo, branch with no
+/// upstream tracking, detached HEAD) ⇒ Unknown. The classifier
+/// treats Unknown as SkipNotGit — refuse to remove anything we
+/// can't confidently classify. Per `[[no-fallbacks-ever]]` we
+/// surface the ambiguity rather than assume Clean.
+///
+/// PR #1105 reviewer round 1: the prior version only ran the
+/// porcelain probe and silently let committed-but-unpushed work
+/// classify as Clean → Removable. A closed-card worktree with
+/// unpushed WIP would have been destroyed by `--force`. This is
+/// the WIP-outranks-hygiene contract the PR claims to enforce.
+fn probe_dirty_status(path: &std::path::Path) -> DirtyStatus {
     let path_str = path.to_string_lossy().to_string();
-    match std::process::Command::new("git")
+
+    // Step 1: porcelain probe.
+    let porcelain_out = match std::process::Command::new("git")
         .args(["-C", &path_str, "status", "--porcelain"])
         .output()
     {
-        Ok(out) if out.status.success() => {
-            if String::from_utf8_lossy(&out.stdout).trim().is_empty() {
-                DirtyStatus::Clean
-            } else {
-                DirtyStatus::Dirty
-            }
-        }
-        _ => DirtyStatus::Unknown,
+        Ok(out) => out,
+        Err(_) => return DirtyStatus::Unknown,
+    };
+    if !porcelain_out.status.success() {
+        return DirtyStatus::Unknown;
     }
+    if !String::from_utf8_lossy(&porcelain_out.stdout).trim().is_empty() {
+        return DirtyStatus::Dirty;
+    }
+
+    // Step 2: unpushed-commits probe. `git rev-list --count @{u}..HEAD`
+    // counts commits reachable from HEAD but not from the upstream
+    // tracking branch. If `@{u}` errors (no upstream / detached HEAD),
+    // we can't classify safely — return Unknown rather than guess.
+    let unpushed_out = match std::process::Command::new("git")
+        .args(["-C", &path_str, "rev-list", "--count", "@{u}..HEAD"])
+        .output()
+    {
+        Ok(out) => out,
+        Err(_) => return DirtyStatus::Unknown,
+    };
+    if !unpushed_out.status.success() {
+        // Likely "no upstream configured for branch X" or detached
+        // HEAD. Per `[[no-fallbacks-ever]]` refuse to classify
+        // rather than assume the operator pushed.
+        return DirtyStatus::Unknown;
+    }
+    let count_text = String::from_utf8_lossy(&unpushed_out.stdout)
+        .trim()
+        .to_string();
+    let count: u64 = count_text.parse().unwrap_or(0);
+    if count > 0 {
+        return DirtyStatus::Dirty;
+    }
+
+    DirtyStatus::Clean
 }
 
 /// Run `git worktree remove <path>` against the worktree's repo root.
@@ -2023,6 +2094,146 @@ mod tests {
         // surfaces the diagnostic and the operator decides.
         let d = classify_worktree(Some(&CardState::Closed), &DirtyStatus::Unknown);
         assert_eq!(d, Disposition::SkipNotGit);
+    }
+
+    // ─── probe_dirty_status: PR #1105 reviewer round 1 fix ───────────
+    //
+    // Tests that exercise the actual `probe_dirty_status` function
+    // against real git fixtures, not just the classifier's reaction
+    // to the enum. The reviewer's BLOCK 2 was specifically that the
+    // probe didn't check unpushed commits — these tests pin the
+    // contract on the function itself, where the bug lived.
+
+    /// Build a tempdir, init a bare "origin" repo + a working clone
+    /// that tracks it. Returns the working clone's path (which we
+    /// pass to `probe_dirty_status`) and the tempdir handle (which
+    /// owns both, kept alive by the caller).
+    fn git_fixture_with_upstream(seed_commit: bool) -> (std::path::PathBuf, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let origin = tmp.path().join("origin.git");
+        let clone = tmp.path().join("clone");
+
+        let run = |args: &[&str], cwd: Option<&std::path::Path>| {
+            let mut cmd = std::process::Command::new("git");
+            cmd.args(args);
+            if let Some(d) = cwd {
+                cmd.current_dir(d);
+            }
+            let out = cmd.output().expect("git spawn");
+            assert!(out.status.success(), "git {args:?} failed: {}", String::from_utf8_lossy(&out.stderr));
+        };
+
+        run(&["init", "--bare", origin.to_str().unwrap()], None);
+        run(&["clone", origin.to_str().unwrap(), clone.to_str().unwrap()], None);
+        // Configure identity so commits don't fail in CI containers.
+        run(&["-C", clone.to_str().unwrap(), "config", "user.email", "test@example.invalid"], None);
+        run(&["-C", clone.to_str().unwrap(), "config", "user.name", "Test"], None);
+
+        if seed_commit {
+            // Empty bare origin has no HEAD; create an initial commit
+            // on clone + push so the upstream branch exists.
+            std::fs::write(clone.join("README"), "seed\n").expect("write seed");
+            run(&["-C", clone.to_str().unwrap(), "add", "README"], None);
+            run(&["-C", clone.to_str().unwrap(), "commit", "-m", "seed"], None);
+            // Detect default branch (master vs main depending on git config)
+            let branch_out = std::process::Command::new("git")
+                .args(["-C", clone.to_str().unwrap(), "rev-parse", "--abbrev-ref", "HEAD"])
+                .output()
+                .expect("rev-parse");
+            let branch = String::from_utf8(branch_out.stdout).unwrap().trim().to_string();
+            run(&["-C", clone.to_str().unwrap(), "push", "-u", "origin", &branch], None);
+        }
+
+        (clone, tmp)
+    }
+
+    #[test]
+    fn probe_dirty_status_clean_when_committed_and_pushed() {
+        let (clone, _tmp) = git_fixture_with_upstream(true);
+        assert_eq!(
+            probe_dirty_status(&clone),
+            DirtyStatus::Clean,
+            "freshly-cloned + pushed state must be Clean"
+        );
+    }
+
+    #[test]
+    fn probe_dirty_status_dirty_on_uncommitted_change() {
+        let (clone, _tmp) = git_fixture_with_upstream(true);
+        std::fs::write(clone.join("scratch"), "untracked\n").expect("write scratch");
+        assert_eq!(
+            probe_dirty_status(&clone),
+            DirtyStatus::Dirty,
+            "untracked file must classify as Dirty (porcelain stage)"
+        );
+    }
+
+    /// PR #1105 reviewer round 1 BLOCK 2: the prior probe only ran
+    /// `git status --porcelain` and silently classified
+    /// committed-but-unpushed work as Clean. A closed-card worktree
+    /// with this state would have been silently destroyed by
+    /// `airc work cleanup --force`. This test pins the new
+    /// behavior: unpushed commits ⇒ Dirty.
+    #[test]
+    fn probe_dirty_status_dirty_on_unpushed_commit() {
+        let (clone, _tmp) = git_fixture_with_upstream(true);
+
+        // Make a clean commit but DON'T push it.
+        std::fs::write(clone.join("local-only"), "committed but not pushed\n").expect("write");
+        let run = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&clone)
+                .output()
+                .expect("git spawn");
+            assert!(out.status.success(), "{args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        run(&["add", "local-only"]);
+        run(&["commit", "-m", "local-only WIP"]);
+
+        assert_eq!(
+            probe_dirty_status(&clone),
+            DirtyStatus::Dirty,
+            "committed-but-unpushed work must classify as Dirty — \
+             this is the [[local-worktree-is-temp-dir]] safety contract \
+             reviewer round 1 BLOCK 2 caught"
+        );
+    }
+
+    /// A branch with NO upstream tracking is ambiguous — could be
+    /// pure local WIP, could be already-pushed-by-someone-else.
+    /// Per `[[no-fallbacks-ever]]` refuse to classify.
+    #[test]
+    fn probe_dirty_status_unknown_when_no_upstream_tracking() {
+        let (clone, _tmp) = git_fixture_with_upstream(true);
+
+        // Switch to a fresh branch that has no upstream configured.
+        let run = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&clone)
+                .output()
+                .expect("git spawn");
+            assert!(out.status.success(), "{args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        run(&["checkout", "-b", "local-only-branch"]);
+
+        assert_eq!(
+            probe_dirty_status(&clone),
+            DirtyStatus::Unknown,
+            "branch with no upstream tracking must be Unknown — \
+             ambiguous state, classifier refuses rather than assuming"
+        );
+    }
+
+    #[test]
+    fn probe_dirty_status_unknown_when_not_a_git_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            probe_dirty_status(tmp.path()),
+            DirtyStatus::Unknown,
+            "non-git dir must be Unknown"
+        );
     }
 
     #[test]

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -111,7 +111,9 @@ pub async fn run_review(
 
     // Resolve the parent off the current room's board. Refusing on
     // "no parent" is more useful than spawning an orphan review.
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let parent = board.card(parent_card_id).ok_or_else(|| {
         format!(
             "parent card {parent_card_id} not found in the current room's board; \
@@ -334,7 +336,9 @@ async fn resolve_my_active_claim(
     airc: &airc_lib::Airc,
     card_id: airc_lib::WorkCardId,
 ) -> Result<airc_lib::ClaimId, Box<dyn std::error::Error>> {
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not present in the board projection"))?;
@@ -452,7 +456,9 @@ pub async fn run_state(
     // self-attesting Merged; this one refuses agents from
     // self-attesting Closed without a Merged predecessor.
     if card_state == CardState::Closed {
-        let board = airc.work_board(usize::MAX).await?;
+        let board = airc
+            .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+            .await?;
         let card = board.card(card_uuid).ok_or_else(|| {
             format!("card {card_uuid} not visible in current room's board projection")
         })?;
@@ -698,7 +704,9 @@ pub(crate) async fn auto_spawn_review_card(
     parent_id: airc_lib::WorkCardId,
     pr_url: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let parent = board
         .card(parent_id)
         .ok_or_else(|| format!("parent card {parent_id} no longer in board projection"))?;
@@ -837,7 +845,9 @@ pub async fn run_merge(
     let airc = crate::commands::attached_airc(home).await?;
     let card_uuid = parse_work_card_id(&card_id)?;
 
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board.card(card_uuid).ok_or_else(|| {
         format!("card {card_uuid} not visible in current room's board projection")
     })?;
@@ -908,6 +918,33 @@ pub async fn run_merge(
             .await?;
             println!(
                 "merged: card={card_uuid} pr=#{n} repo={r}",
+                n = pr.number,
+                r = pr.repo,
+            );
+            Ok(())
+        }
+        Ok(crate::merger::GateResult::AlreadyMerged { merged_at_ms }) => {
+            // Card acd72c81 follow-up: PR is already merged on
+            // GitHub. The manual `airc work merge` path reconciles
+            // by emitting `PullRequestMerged` — no `gh pr merge`
+            // call needed.
+            if dry_run {
+                println!(
+                    "merge_gate: ALREADY_MERGED — card={card_uuid} pr=#{n} repo={r} \
+                     (would reconcile)",
+                    n = pr.number,
+                    r = pr.repo,
+                );
+                return Ok(());
+            }
+            airc.mark_pull_request_merged(MarkPullRequestMerged {
+                card_id: card_uuid,
+                pull_request: pr.clone(),
+                merged_at_ms,
+            })
+            .await?;
+            println!(
+                "reconciled: card={card_uuid} pr=#{n} repo={r} (PR was already merged on GitHub)",
                 n = pr.number,
                 r = pr.repo,
             );

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -801,6 +801,334 @@ pub async fn run_close(home: &Path, card_id: String) -> Result<(), Box<dyn std::
     run_state(home, card_id, CliCardState::Closed).await
 }
 
+/// Card c9b28925: prune worktrees whose card has reached a terminal
+/// state. Doctrinally the always-on side of two principles from the
+/// substrate handbook: `local-worktree-is-temp-dir` (worktrees are L1
+/// cache, not durable state) and `substrate-is-a-good-citizen-on-the-host`
+/// (no disk filling). This slice is the manual command so operators
+/// can audit before automating.
+///
+/// Default behaviour is dry-run. `--force` actually runs `git worktree
+/// remove`. Dirty / locked / orphan worktrees are NEVER touched: the
+/// operator's WIP outranks hygiene.
+pub async fn run_cleanup(
+    home: &Path,
+    dry_run: bool,
+    force: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = crate::commands::attached_airc(home).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
+
+    let lease_root = lease::lease_root()
+        .ok_or_else(|| "HOME/USERPROFILE not set; cannot resolve ~/.airc/worktrees/".to_string())?;
+    if !lease_root.exists() {
+        println!(
+            "no worktrees to inspect: {} does not exist",
+            lease_root.display()
+        );
+        return Ok(());
+    }
+
+    // Collect classifications. Pure-function classifier lives below so
+    // every disposition gets a unit test.
+    let mut classifications: Vec<WorktreeClassification> = Vec::new();
+    for entry in std::fs::read_dir(&lease_root)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let basename = entry.file_name().to_string_lossy().to_string();
+        let Some(short) = parse_worktree_short_id(&basename) else {
+            continue;
+        };
+        let card = board
+            .snapshot()
+            .cards
+            .iter()
+            .find(|c| {
+                let card_short: String = c.card_id.to_string().chars().take(8).collect();
+                card_short == short
+            })
+            .cloned();
+        let card_state = card.as_ref().map(|c| c.state);
+        let pr_number = card
+            .as_ref()
+            .and_then(|c| c.pull_request.as_ref().map(|pr| pr.number));
+        let repo = card.as_ref().map(|c| c.repo.to_string());
+
+        // Check git status (`--porcelain` => empty stdout means clean).
+        let dirty_status = git_status_porcelain(&path);
+
+        let disposition = classify_worktree(card_state.as_ref(), &dirty_status);
+
+        classifications.push(WorktreeClassification {
+            short,
+            path: path.clone(),
+            card_state,
+            pr_number,
+            repo,
+            dirty_status: dirty_status.clone(),
+            disposition,
+        });
+    }
+
+    // Sort: Removable first (most actionable), then KeepActive, then
+    // SkipX (least urgent, but still surface). Inside each bucket sort
+    // by short id for determinism.
+    classifications.sort_by(|a, b| {
+        a.disposition
+            .display_priority()
+            .cmp(&b.disposition.display_priority())
+            .then_with(|| a.short.cmp(&b.short))
+    });
+
+    // Always print the table — that's the diagnostic the operator
+    // wants. `--force` then takes destructive action; `--dry-run` is
+    // the explicit-intent alias of the default.
+    println!("worktrees scanned: {}", classifications.len());
+    if classifications.is_empty() {
+        return Ok(());
+    }
+
+    let mut last_bucket = "";
+    for c in &classifications {
+        let bucket = c.disposition.bucket_label();
+        if bucket != last_bucket {
+            println!("  {bucket}:");
+            last_bucket = bucket;
+        }
+        let pr_label = c
+            .pr_number
+            .map(|n| format!("PR #{n}"))
+            .unwrap_or_else(|| "no PR".to_string());
+        let state_label = c
+            .card_state
+            .map(|s| format!("{s:?}"))
+            .unwrap_or_else(|| "unknown card".to_string());
+        let suffix = c.disposition.suffix();
+        println!(
+            "    {short}  {pr_label}  {state_label}{suffix}",
+            short = c.short
+        );
+    }
+    println!();
+
+    let removable: Vec<&WorktreeClassification> = classifications
+        .iter()
+        .filter(|c| matches!(c.disposition, Disposition::Removable))
+        .collect();
+
+    if removable.is_empty() {
+        println!("Nothing to remove.");
+        return Ok(());
+    }
+
+    if !force {
+        let suffix = if dry_run { " (--dry-run)" } else { "" };
+        println!(
+            "Would remove {n} worktree(s) on --force{suffix}.",
+            n = removable.len()
+        );
+        return Ok(());
+    }
+
+    // --force: actually remove. Per-worktree error doesn't kill the
+    // batch — surface the diagnostic, keep going. The operator
+    // re-runs after fixing the specific issue.
+    let mut removed = 0usize;
+    for c in removable {
+        match git_worktree_remove(&c.path) {
+            Ok(()) => {
+                println!("✓ removed {}", c.path.display());
+                removed += 1;
+            }
+            Err(error) => {
+                eprintln!("✗ {} — {error}", c.path.display());
+            }
+        }
+    }
+    println!("{removed} worktree(s) removed.");
+    Ok(())
+}
+
+/// One scan result for `run_cleanup`'s table + the force loop.
+struct WorktreeClassification {
+    short: String,
+    path: std::path::PathBuf,
+    card_state: Option<airc_work::CardState>,
+    pr_number: Option<u64>,
+    #[allow(dead_code)]
+    repo: Option<String>,
+    #[allow(dead_code)]
+    dirty_status: DirtyStatus,
+    disposition: Disposition,
+}
+
+/// What the operator should do with this worktree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Disposition {
+    /// Card is Closed or Merged; worktree is clean. Safe to remove.
+    Removable,
+    /// Card is still active (Open / Claimed / InProgress / Review /
+    /// Blocked / Merged-but-projection-not-caught-up). Keep.
+    KeepActive,
+    /// Worktree has uncommitted / unpushed changes. Operator's WIP
+    /// outranks hygiene; print, never remove.
+    SkipDirty,
+    /// Couldn't run `git status` (not a git dir, permissions, etc).
+    SkipNotGit,
+    /// No card matches the worktree's short id. Orphan — surface but
+    /// don't touch; could be from a deleted card or a different scope.
+    SkipUnknownCard,
+}
+
+impl Disposition {
+    /// Sort key: lower → earlier in the printed table.
+    fn display_priority(self) -> u8 {
+        match self {
+            Disposition::Removable => 0,
+            Disposition::KeepActive => 1,
+            Disposition::SkipDirty => 2,
+            Disposition::SkipNotGit => 3,
+            Disposition::SkipUnknownCard => 4,
+        }
+    }
+
+    fn bucket_label(self) -> &'static str {
+        match self {
+            Disposition::Removable => "Removable",
+            Disposition::KeepActive => "KeepActive",
+            Disposition::SkipDirty => "SkipDirty",
+            Disposition::SkipNotGit => "SkipNotGit",
+            Disposition::SkipUnknownCard => "SkipUnknownCard",
+        }
+    }
+
+    fn suffix(self) -> &'static str {
+        match self {
+            Disposition::Removable => "  (would remove on --force)",
+            Disposition::KeepActive => "",
+            Disposition::SkipDirty => "  uncommitted changes",
+            Disposition::SkipNotGit => "  not a git worktree",
+            Disposition::SkipUnknownCard => "  no matching card on board",
+        }
+    }
+}
+
+/// Whether the worktree has uncommitted / unpushed changes. Outcome
+/// of `git status --porcelain` (empty == clean) or a probe failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DirtyStatus {
+    Clean,
+    Dirty,
+    /// Probe failed — `git status` errored, not a git dir, etc.
+    Unknown,
+}
+
+/// Pure classifier. Card c9b28925 — table-driven so every disposition
+/// gets exercised in tests without spinning up a real worktree.
+pub(crate) fn classify_worktree(
+    card_state: Option<&airc_work::CardState>,
+    dirty: &DirtyStatus,
+) -> Disposition {
+    use airc_work::CardState;
+    let Some(state) = card_state else {
+        return Disposition::SkipUnknownCard;
+    };
+    if matches!(dirty, DirtyStatus::Unknown) {
+        return Disposition::SkipNotGit;
+    }
+    if matches!(dirty, DirtyStatus::Dirty) {
+        return Disposition::SkipDirty;
+    }
+    match state {
+        CardState::Closed | CardState::Merged => Disposition::Removable,
+        CardState::Open
+        | CardState::Claimed
+        | CardState::InProgress
+        | CardState::Review
+        | CardState::Blocked => Disposition::KeepActive,
+    }
+}
+
+/// Extract a worktree's short card id from its directory name. The
+/// convention from `airc work claim` is the first 8 hex chars of the
+/// card UUID; allow trailing extras (slash, branch slug) for
+/// robustness against future naming changes.
+pub(crate) fn parse_worktree_short_id(basename: &str) -> Option<String> {
+    let trimmed = basename.trim().trim_end_matches('/');
+    let prefix: String = trimmed.chars().take(8).collect();
+    if prefix.len() != 8 || !prefix.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(prefix)
+}
+
+/// Probe `git status --porcelain` in `path`. Empty stdout ⇒ clean.
+/// Non-empty ⇒ Dirty. Probe failure ⇒ Unknown (caller treats as
+/// SkipNotGit per the safety doctrine: refuse to remove anything we
+/// can't confidently classify).
+fn git_status_porcelain(path: &std::path::Path) -> DirtyStatus {
+    let path_str = path.to_string_lossy().to_string();
+    match std::process::Command::new("git")
+        .args(["-C", &path_str, "status", "--porcelain"])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            if String::from_utf8_lossy(&out.stdout).trim().is_empty() {
+                DirtyStatus::Clean
+            } else {
+                DirtyStatus::Dirty
+            }
+        }
+        _ => DirtyStatus::Unknown,
+    }
+}
+
+/// Run `git worktree remove <path>` against the worktree's repo root.
+/// Failure surfaces as a stringified error so the batch loop can
+/// log + continue.
+fn git_worktree_remove(path: &std::path::Path) -> Result<(), String> {
+    let path_str = path.to_string_lossy().to_string();
+    // First find the repo's git-common-dir so `git worktree remove` runs
+    // from the right place. Without `-C path`, git would refuse from the
+    // worktree itself ("cannot remove main working tree").
+    let common_out = std::process::Command::new("git")
+        .args(["-C", &path_str, "rev-parse", "--git-common-dir"])
+        .output()
+        .map_err(|e| format!("spawn git rev-parse: {e}"))?;
+    if !common_out.status.success() {
+        return Err(format!(
+            "git rev-parse --git-common-dir failed: {}",
+            String::from_utf8_lossy(&common_out.stderr).trim()
+        ));
+    }
+    let common_dir = String::from_utf8(common_out.stdout)
+        .map_err(|e| format!("git common-dir utf8: {e}"))?
+        .trim()
+        .to_string();
+    // `git-common-dir` is the .git directory; the main worktree's repo
+    // root is its parent.
+    let repo_root = std::path::Path::new(&common_dir)
+        .parent()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| common_dir.clone());
+    let rm_out = std::process::Command::new("git")
+        .args(["-C", &repo_root, "worktree", "remove", &path_str])
+        .output()
+        .map_err(|e| format!("spawn git worktree remove: {e}"))?;
+    if !rm_out.status.success() {
+        return Err(format!(
+            "git worktree remove failed: {}",
+            String::from_utf8_lossy(&rm_out.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
 /// Card 70e87d33: retroactively link an already-open PR to a card so
 /// the merger can pick it up. Thin orchestration over
 /// `work_commands_gh::link_existing_pr` — attach, parse the card id,
@@ -1614,6 +1942,109 @@ mod tests {
     fn short_id_truncates_to_8_chars() {
         assert_eq!(short_id("cdff6a9d-e995-4b4a-a119-10bc1faf1747"), "cdff6a9d");
         assert_eq!(short_id("short"), "short");
+    }
+
+    // Card c9b28925 — `airc work cleanup` classifier tests. Pure
+    // functions, no real filesystem or daemon — every Disposition
+    // gets exercised at least once.
+
+    #[test]
+    fn parse_worktree_short_id_accepts_canonical_shape() {
+        assert_eq!(
+            parse_worktree_short_id("acd72c81"),
+            Some("acd72c81".to_string())
+        );
+        assert_eq!(
+            parse_worktree_short_id("c9b28925/extra"),
+            Some("c9b28925".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_worktree_short_id_rejects_non_hex_basenames() {
+        // Could be unrelated dirs in the lease zone — e.g. a README.
+        assert_eq!(parse_worktree_short_id("README"), None);
+        assert_eq!(parse_worktree_short_id("notes-here"), None);
+        // Too short to be a card prefix.
+        assert_eq!(parse_worktree_short_id("ab"), None);
+    }
+
+    #[test]
+    fn classifier_closed_clean_removes() {
+        let d = classify_worktree(Some(&CardState::Closed), &DirtyStatus::Clean);
+        assert_eq!(d, Disposition::Removable);
+    }
+
+    #[test]
+    fn classifier_merged_clean_removes() {
+        let d = classify_worktree(Some(&CardState::Merged), &DirtyStatus::Clean);
+        assert_eq!(d, Disposition::Removable);
+    }
+
+    #[test]
+    fn classifier_active_states_keep() {
+        for state in [
+            CardState::Open,
+            CardState::Claimed,
+            CardState::InProgress,
+            CardState::Review,
+            CardState::Blocked,
+        ] {
+            let d = classify_worktree(Some(&state), &DirtyStatus::Clean);
+            assert_eq!(d, Disposition::KeepActive, "state={state:?}");
+        }
+    }
+
+    #[test]
+    fn classifier_dirty_never_removes_even_when_card_closed() {
+        // Operator's WIP outranks hygiene. Closed card + dirty
+        // worktree still classifies as SkipDirty — print, never
+        // remove silently.
+        let d = classify_worktree(Some(&CardState::Closed), &DirtyStatus::Dirty);
+        assert_eq!(d, Disposition::SkipDirty);
+        let d = classify_worktree(Some(&CardState::Merged), &DirtyStatus::Dirty);
+        assert_eq!(d, Disposition::SkipDirty);
+    }
+
+    #[test]
+    fn classifier_no_card_returns_skip_unknown_card() {
+        // Orphan worktree — basename matches the short-id pattern but
+        // no card is on the current board. Could be from a deleted
+        // card, a different scope, or scope drift. Surface but don't
+        // touch.
+        let d = classify_worktree(None, &DirtyStatus::Clean);
+        assert_eq!(d, Disposition::SkipUnknownCard);
+    }
+
+    #[test]
+    fn classifier_not_git_returns_skip_not_git() {
+        // git status probe failure (not a git dir, permissions) ⇒
+        // refuse to classify as either Clean or Dirty. SkipNotGit
+        // surfaces the diagnostic and the operator decides.
+        let d = classify_worktree(Some(&CardState::Closed), &DirtyStatus::Unknown);
+        assert_eq!(d, Disposition::SkipNotGit);
+    }
+
+    #[test]
+    fn disposition_display_priority_orders_removable_first() {
+        let mut order = [
+            Disposition::SkipUnknownCard,
+            Disposition::Removable,
+            Disposition::KeepActive,
+            Disposition::SkipDirty,
+            Disposition::SkipNotGit,
+        ];
+        order.sort_by_key(|d| d.display_priority());
+        assert_eq!(
+            order,
+            [
+                Disposition::Removable,
+                Disposition::KeepActive,
+                Disposition::SkipDirty,
+                Disposition::SkipNotGit,
+                Disposition::SkipUnknownCard,
+            ]
+        );
     }
 
     use airc_core::PeerId;

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -553,16 +553,14 @@ pub async fn run_state(
 ///   * Resolves `~/.airc/worktrees/<card_short>/` from `lease_root`.
 ///   * Skips silently (Ok) if the worktree doesn't exist — re-close
 ///     on an already-cleaned card is a no-op.
-///   * REFUSES via `probe_dirty_status` if EITHER of:
-///       - `git status --porcelain` non-empty (uncommitted /
-///         untracked work) — that's WIP on disk
-///       - `git rev-list --count @{u}..HEAD > 0` (committed but
-///         unpushed work) — that's WIP only-on-this-machine
-///       - probe is ambiguous (no upstream, detached HEAD, broken
-///         git) — refuse to classify per `[[no-fallbacks-ever]]`
-///     The agent recovers manually; we never silently nuke
-///     pending work. This is the "operator's WIP outranks hygiene"
-///     contract.
+///   * REFUSES via `probe_dirty_status` if any of: (a) `git status
+///     --porcelain` non-empty (uncommitted / untracked work — WIP
+///     on disk), (b) `git rev-list --count @{u}..HEAD > 0`
+///     (committed but unpushed work — WIP only-on-this-machine),
+///     or (c) the probe is ambiguous (no upstream, detached HEAD,
+///     broken git — refuse to classify per [[no-fallbacks-ever]]).
+///     The agent recovers manually; we never silently nuke pending
+///     work. This is the "operator's WIP outranks hygiene" contract.
 ///   * On the happy path: `git worktree remove --force` then
 ///     `git branch -d` (lowercase — refuses unmerged) as a
 ///     second line of defense if probe somehow missed unpushed
@@ -1127,7 +1125,10 @@ fn probe_dirty_status(path: &std::path::Path) -> DirtyStatus {
     if !porcelain_out.status.success() {
         return DirtyStatus::Unknown;
     }
-    if !String::from_utf8_lossy(&porcelain_out.stdout).trim().is_empty() {
+    if !String::from_utf8_lossy(&porcelain_out.stdout)
+        .trim()
+        .is_empty()
+    {
         return DirtyStatus::Dirty;
     }
 
@@ -2120,28 +2121,69 @@ mod tests {
                 cmd.current_dir(d);
             }
             let out = cmd.output().expect("git spawn");
-            assert!(out.status.success(), "git {args:?} failed: {}", String::from_utf8_lossy(&out.stderr));
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
         };
 
         run(&["init", "--bare", origin.to_str().unwrap()], None);
-        run(&["clone", origin.to_str().unwrap(), clone.to_str().unwrap()], None);
+        run(
+            &["clone", origin.to_str().unwrap(), clone.to_str().unwrap()],
+            None,
+        );
         // Configure identity so commits don't fail in CI containers.
-        run(&["-C", clone.to_str().unwrap(), "config", "user.email", "test@example.invalid"], None);
-        run(&["-C", clone.to_str().unwrap(), "config", "user.name", "Test"], None);
+        run(
+            &[
+                "-C",
+                clone.to_str().unwrap(),
+                "config",
+                "user.email",
+                "test@example.invalid",
+            ],
+            None,
+        );
+        run(
+            &["-C", clone.to_str().unwrap(), "config", "user.name", "Test"],
+            None,
+        );
 
         if seed_commit {
             // Empty bare origin has no HEAD; create an initial commit
             // on clone + push so the upstream branch exists.
             std::fs::write(clone.join("README"), "seed\n").expect("write seed");
             run(&["-C", clone.to_str().unwrap(), "add", "README"], None);
-            run(&["-C", clone.to_str().unwrap(), "commit", "-m", "seed"], None);
+            run(
+                &["-C", clone.to_str().unwrap(), "commit", "-m", "seed"],
+                None,
+            );
             // Detect default branch (master vs main depending on git config)
             let branch_out = std::process::Command::new("git")
-                .args(["-C", clone.to_str().unwrap(), "rev-parse", "--abbrev-ref", "HEAD"])
+                .args([
+                    "-C",
+                    clone.to_str().unwrap(),
+                    "rev-parse",
+                    "--abbrev-ref",
+                    "HEAD",
+                ])
                 .output()
                 .expect("rev-parse");
-            let branch = String::from_utf8(branch_out.stdout).unwrap().trim().to_string();
-            run(&["-C", clone.to_str().unwrap(), "push", "-u", "origin", &branch], None);
+            let branch = String::from_utf8(branch_out.stdout)
+                .unwrap()
+                .trim()
+                .to_string();
+            run(
+                &[
+                    "-C",
+                    clone.to_str().unwrap(),
+                    "push",
+                    "-u",
+                    "origin",
+                    &branch,
+                ],
+                None,
+            );
         }
 
         (clone, tmp)
@@ -2186,7 +2228,11 @@ mod tests {
                 .current_dir(&clone)
                 .output()
                 .expect("git spawn");
-            assert!(out.status.success(), "{args:?}: {}", String::from_utf8_lossy(&out.stderr));
+            assert!(
+                out.status.success(),
+                "{args:?}: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
         };
         run(&["add", "local-only"]);
         run(&["commit", "-m", "local-only WIP"]);
@@ -2214,7 +2260,11 @@ mod tests {
                 .current_dir(&clone)
                 .output()
                 .expect("git spawn");
-            assert!(out.status.success(), "{args:?}: {}", String::from_utf8_lossy(&out.stderr));
+            assert!(
+                out.status.success(),
+                "{args:?}: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
         };
         run(&["checkout", "-b", "local-only-branch"]);
 

--- a/crates/airc-cli/src/work_commands_gh.rs
+++ b/crates/airc-cli/src/work_commands_gh.rs
@@ -29,7 +29,9 @@ pub(crate) async fn open_pr_and_link(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use airc_work::model::{BranchName, PullRequestRef};
 
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;
@@ -198,7 +200,9 @@ pub(crate) async fn link_existing_pr(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use airc_work::model::{BranchName, PullRequestRef};
 
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;

--- a/crates/airc-cli/src/work_commands_git.rs
+++ b/crates/airc-cli/src/work_commands_git.rs
@@ -22,7 +22,9 @@ pub(crate) async fn spawn_claim_worktree(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Need the card's title for the branch slug — board projection
     // is the source of truth.
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let card = board
         .card(card_id)
         .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;

--- a/crates/airc-ipc/src/lib.rs
+++ b/crates/airc-ipc/src/lib.rs
@@ -26,6 +26,7 @@ pub mod client;
 pub mod codec;
 pub mod request;
 pub mod response;
+pub mod sdk_conversions;
 pub mod transport;
 
 /// Local daemon IPC ABI version.
@@ -45,5 +46,6 @@ pub use request::{
     PublishRequest, RemovePeerRequest, Request, SendRequest,
 };
 pub use response::{InboxResponse, PeersResponse, PublishResponse, Response, StatusResponse};
+pub use sdk_conversions::{COUNTER_BITS, COUNTER_MASK};
 // IpcListener / IpcStream stay under `transport` because only the
 // daemon host and low-level tests need the raw byte transport.

--- a/crates/airc-ipc/src/sdk_conversions.rs
+++ b/crates/airc-ipc/src/sdk_conversions.rs
@@ -1,0 +1,242 @@
+//! `impl From<>` blocks bridging airc's SDK transcript vocabulary
+//! (`FrameKind`, `MentionTarget`, `TranscriptCursor` — from airc-core /
+//! airc-protocol) to the IPC wire vocabulary introduced in the v5
+//! owner-core rewrite (`IpcKind`, `IpcTarget`, `IpcCursor`).
+//!
+//! ### Why these live here
+//!
+//! The conversions are **substrate surface** — any consumer that builds
+//! `PublishRequest` from SDK-shaped state (continuum-core, Hermes,
+//! OpenClaw, future grid workers, the airc CLI itself) needs them.
+//! Before this module they lived as private `fn framekind_to_ipc` /
+//! `fn mention_to_ipc_target` / `pack_seq` / `unpack_seq` helpers in
+//! `airc-lib/src/daemon.rs`, which meant every external consumer had
+//! to either re-implement the same math (drift risk) or pull all of
+//! `airc-lib` to call a private fn (canonical SDK is shaped wrong for
+//! drive-by use).
+//!
+//! Promoting them to `impl From<>` in `airc-ipc` (the smallest crate
+//! that depends on both airc-core and airc-protocol) keeps the
+//! translation co-located with the IPC vocabulary it produces and lets
+//! every consumer write `pub_req.kind = frame_kind.into()` instead of
+//! reaching for a free function or duplicating a bit-shift.
+//!
+//! ### Drift guard
+//!
+//! [`COUNTER_BITS`] is published as a `pub const` so any consumer that
+//! needs to reproduce the layout (e.g. for in-memory cursor math
+//! without going through the conversion) can pin against the same
+//! constant — never against a literal `40`. If airc ever changes the
+//! pack layout, every dependent recompiles and round-trip tests
+//! everywhere catch the regression.
+
+use airc_core::{MentionTarget, TranscriptCursor};
+use airc_protocol::FrameKind;
+
+use crate::request::{IpcCursor, IpcKind, IpcTarget};
+
+/// Number of low-order bits in the packed `lamport` reserved for the
+/// per-epoch `counter`. The high bits hold `epoch`. Pinned at 40 — see
+/// `airc-lib/src/daemon.rs` (`pack_seq`/`unpack_seq`) for the historical
+/// rationale (40 bits = ~1.1T counter values per epoch, far beyond any
+/// real channel; the remaining 24 bits of `epoch` cover ~16M owner
+/// generations).
+pub const COUNTER_BITS: u32 = 40;
+
+/// Mask for the low [`COUNTER_BITS`] bits — the per-epoch counter range.
+pub const COUNTER_MASK: u64 = (1u64 << COUNTER_BITS) - 1;
+
+impl From<FrameKind> for IpcKind {
+    /// Lossless: the three chat-flavored `FrameKind` variants are a
+    /// subset of the seven `IpcKind` variants. RPC/grid consumers that
+    /// need `Command`/`CommandResult`/`Signal`/`StreamChunk` construct
+    /// `IpcKind` directly without going through `FrameKind`.
+    fn from(kind: FrameKind) -> Self {
+        match kind {
+            FrameKind::Message => IpcKind::Message,
+            FrameKind::Event => IpcKind::Event,
+            FrameKind::Control => IpcKind::Control,
+        }
+    }
+}
+
+impl From<MentionTarget> for IpcTarget {
+    /// Lossless: room mentions round-trip as a named endpoint
+    /// (`room:<uuid>`), which the inverse projection in airc-lib
+    /// (`target_to_mention`) parses back into [`MentionTarget::Room`].
+    /// Direct peer + broadcast pass straight through.
+    fn from(target: MentionTarget) -> Self {
+        match target {
+            MentionTarget::All => IpcTarget::All,
+            MentionTarget::Peer(peer) => IpcTarget::Peer(peer),
+            MentionTarget::Room(room) => IpcTarget::Endpoint(format!("room:{}", room.as_uuid())),
+        }
+    }
+}
+
+impl From<TranscriptCursor> for IpcCursor {
+    /// Unpack the SDK's single monotonic `lamport` into the wire
+    /// vocabulary's `(epoch, counter)` split. Inverse of
+    /// `IpcCursor → TranscriptCursor`. Round-trip preserves the
+    /// packed value byte-for-byte.
+    fn from(cursor: TranscriptCursor) -> Self {
+        Self {
+            epoch: cursor.lamport >> COUNTER_BITS,
+            counter: cursor.lamport & COUNTER_MASK,
+            event_id: cursor.event_id,
+        }
+    }
+}
+
+impl From<IpcCursor> for TranscriptCursor {
+    /// Pack the wire vocabulary's `(epoch, counter)` into the SDK's
+    /// monotonic `lamport`. Inverse of `TranscriptCursor → IpcCursor`.
+    /// The daemon always produces values within the
+    /// `(epoch << COUNTER_BITS) | counter` invariant, so this conversion
+    /// is total + round-trip safe for any cursor the daemon emits.
+    fn from(cursor: IpcCursor) -> Self {
+        Self {
+            lamport: (cursor.epoch << COUNTER_BITS) | (cursor.counter & COUNTER_MASK),
+            event_id: cursor.event_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::{EventId, RoomId};
+    use uuid::Uuid;
+
+    #[test]
+    fn frame_kind_message_event_control_map_to_ipc_kind() {
+        assert!(matches!(
+            IpcKind::from(FrameKind::Message),
+            IpcKind::Message
+        ));
+        assert!(matches!(IpcKind::from(FrameKind::Event), IpcKind::Event));
+        assert!(matches!(
+            IpcKind::from(FrameKind::Control),
+            IpcKind::Control
+        ));
+    }
+
+    #[test]
+    fn mention_all_to_ipc_target_all() {
+        assert!(matches!(
+            IpcTarget::from(MentionTarget::All),
+            IpcTarget::All
+        ));
+    }
+
+    #[test]
+    fn mention_room_to_endpoint_with_room_prefix() {
+        let room = RoomId::from_uuid(Uuid::from_u128(0xA1));
+        let target: IpcTarget = MentionTarget::Room(room).into();
+        match target {
+            IpcTarget::Endpoint(name) => {
+                assert!(name.starts_with("room:"));
+                assert!(name.contains(&room.as_uuid().to_string()));
+            }
+            other => panic!("expected Endpoint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cursor_round_trip_preserves_lamport_and_event_id() {
+        let original = TranscriptCursor {
+            lamport: (7u64 << COUNTER_BITS) | 99_999_999,
+            event_id: EventId::from_u128(0xc0ffee),
+        };
+        // TranscriptCursor isn't Copy — save the comparison values
+        // before the conversion consumes `original`.
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, 7);
+        assert_eq!(ipc.counter, 99_999_999);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+
+    #[test]
+    fn cursor_round_trip_with_zero_packs_to_zero() {
+        let original = TranscriptCursor {
+            lamport: 0,
+            event_id: EventId::from_u128(0),
+        };
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, 0);
+        assert_eq!(ipc.counter, 0);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, 0);
+    }
+
+    #[test]
+    fn counter_bits_constant_matches_legacy_airc_lib_layout() {
+        // Drift guard: airc-lib/src/daemon.rs hard-codes COUNTER_BITS = 40.
+        // If anyone changes either, this test (or an airc-lib test
+        // referencing this constant after the inline copy is deleted)
+        // will fail loud. Pin via this assertion so the const isn't
+        // silently shifted.
+        assert_eq!(COUNTER_BITS, 40);
+        assert_eq!(COUNTER_MASK, (1u64 << 40) - 1);
+    }
+
+    #[test]
+    fn cursor_round_trip_at_max_counter_boundary() {
+        // Counter is COUNTER_MASK (all 40 bits set), epoch is 0. This
+        // is the boundary where adding one to counter would overflow
+        // into epoch — the very edge the mask guards.
+        let original = TranscriptCursor {
+            lamport: COUNTER_MASK,
+            event_id: EventId::from_u128(0xb01dface),
+        };
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, 0);
+        assert_eq!(ipc.counter, COUNTER_MASK);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+
+    #[test]
+    fn cursor_round_trip_at_high_epoch_boundary() {
+        // Epoch occupies the high (64 - 40 = 24) bits. Setting the
+        // top epoch bit exercises the entire address space packing,
+        // catching any sign-extension or shift-direction regression.
+        // 2^23 fits cleanly in u64 << 40 without overflow.
+        let epoch = 1u64 << 23;
+        let counter = 12345u64;
+        let original = TranscriptCursor {
+            lamport: (epoch << COUNTER_BITS) | counter,
+            event_id: EventId::from_u128(0xfacefeed),
+        };
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, epoch);
+        assert_eq!(ipc.counter, counter);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+
+    #[test]
+    fn cursor_round_trip_at_u64_max_lamport() {
+        // u64::MAX has every bit set — the absolute upper bound the
+        // pack/unpack must handle without overflow. Epoch should be
+        // (u64::MAX >> 40), counter should be COUNTER_MASK.
+        let original = TranscriptCursor {
+            lamport: u64::MAX,
+            event_id: EventId::from_u128(0xdeadbeef),
+        };
+        let (orig_lamport, orig_event_id) = (original.lamport, original.event_id);
+        let ipc: IpcCursor = original.into();
+        assert_eq!(ipc.epoch, u64::MAX >> COUNTER_BITS);
+        assert_eq!(ipc.counter, COUNTER_MASK);
+        let back: TranscriptCursor = ipc.into();
+        assert_eq!(back.lamport, orig_lamport);
+        assert_eq!(back.event_id, orig_event_id);
+    }
+}

--- a/crates/airc-lib/src/agent_heartbeat.rs
+++ b/crates/airc-lib/src/agent_heartbeat.rs
@@ -518,7 +518,9 @@ async fn refresh_coordination(
     airc: &crate::Airc,
     baseline: &CoordinationSignal,
 ) -> Result<CoordinationSignal, AircError> {
-    let board = airc.work_board(usize::MAX).await?;
+    let board = airc
+        .work_board_complete(crate::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let me = airc.peer_id();
     let active_claims: Vec<WorkCardId> = board
         .snapshot()

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -213,6 +213,42 @@ impl Airc {
         Ok(airc.with_daemon_client(DaemonClient::new(socket.into())))
     }
 
+    /// Attach to an already-running daemon AND open the local identity
+    /// under a specific `agent_name`. This is the constructor a multi-
+    /// citizen host (Continuum personas, future external-agent hosts)
+    /// reaches for when each hosted citizen needs:
+    ///
+    /// 1. Its OWN identity, distinguishable from other citizens'
+    ///    (the [`open_as`] half), so `airc peers` from another scope
+    ///    shows each one as a separate enrolled participant.
+    /// 2. The daemon's live publish/subscribe (the [`attach`] half),
+    ///    so the citizen can `say()` and `subscribe()` over the
+    ///    router instead of only inspecting local state.
+    ///
+    /// Today, [`attach`] only offers (2) (under the host's default
+    /// agent_name) and [`open_as`] only offers (1) (owner-mode, no
+    /// daemon). Hosting multiple citizens in one process with the
+    /// pre-existing pair therefore needs an unergonomic dance with
+    /// the (intentionally private) `with_daemon_client` builder.
+    /// This constructor closes the gap as a single call.
+    ///
+    /// Equivalent to:
+    /// ```ignore
+    /// let airc = Airc::open_as(home, agent_name).await?
+    ///     .with_daemon_client(DaemonClient::new(socket));
+    /// ```
+    ///
+    /// — but spelled as one method so consumers don't reach for the
+    /// private builder.
+    pub async fn attach_as(
+        home: impl Into<PathBuf>,
+        agent_name: impl Into<String>,
+        socket: impl Into<PathBuf>,
+    ) -> Result<Self, AircError> {
+        let airc = Self::open_as(home, agent_name).await?;
+        Ok(airc.with_daemon_client(DaemonClient::new(socket.into())))
+    }
+
     /// Test-only [`attach`] that pins the machine-account wire root
     /// explicitly instead of deriving it from `HOME`/`USERPROFILE`.
     /// Two scopes sharing one `wire_root` resolve the same mesh

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -19,8 +19,8 @@ use airc_bus::envelope::{Envelope, Kind, Target};
 use airc_core::{Body, MentionTarget, RoomId, TranscriptCursor, TranscriptEvent, TranscriptKind};
 use airc_ipc::codec::read_frame;
 use airc_ipc::{
-    AttachRequest, InboxRequest, IpcCursor, IpcDelivery, IpcKind, IpcTarget, PublishRequest,
-    Response, SendRequest,
+    AttachRequest, InboxRequest, IpcCursor, IpcDelivery, IpcTarget, PublishRequest, Response,
+    SendRequest,
 };
 use airc_protocol::FrameKind;
 use tokio::sync::mpsc;
@@ -34,8 +34,11 @@ use crate::Airc;
 /// Low bits of the packed `lamport` that hold the per-epoch counter; the
 /// remaining high bits hold the epoch. 40 bits ⇒ ~1.1e12 events per
 /// epoch and ~16.7M epochs (restarts) — neither realistically reachable.
-const COUNTER_BITS: u32 = 40;
-const COUNTER_MASK: u64 = (1 << COUNTER_BITS) - 1;
+//
+// Re-exported from airc-ipc so the wire vocabulary and the SDK
+// projection can never disagree on layout. Anyone reading
+// `COUNTER_BITS` here gets the same value as the IPC From impls.
+use airc_ipc::{COUNTER_BITS, COUNTER_MASK};
 
 /// Reconnect backoff for a daemon attach stream that drops (daemon
 /// restart / transient loss): start small, double, cap — so a long
@@ -58,17 +61,6 @@ fn unpack_seq(lamport: u64) -> (u64, u64) {
     (lamport >> COUNTER_BITS, lamport & COUNTER_MASK)
 }
 
-/// Map the consumer-facing `FrameKind` (chat vocabulary) to the bus's
-/// `IpcKind`. RPC/grid consumers that need `Command`/`CommandResult`
-/// publish via the typed IPC client directly with `IpcKind`.
-fn framekind_to_ipc(kind: FrameKind) -> IpcKind {
-    match kind {
-        FrameKind::Message => IpcKind::Message,
-        FrameKind::Event => IpcKind::Event,
-        FrameKind::Control => IpcKind::Control,
-    }
-}
-
 fn kind_to_transcript(kind: Kind) -> TranscriptKind {
     match kind {
         Kind::Message => TranscriptKind::Message,
@@ -80,16 +72,6 @@ fn kind_to_transcript(kind: Kind) -> TranscriptKind {
         | Kind::Signal
         | Kind::StreamChunk
         | Kind::Control => TranscriptKind::System,
-    }
-}
-
-/// Inverse of [`target_to_mention`] — map the SDK send target to the IPC
-/// addressing vocabulary. A room mention round-trips as a named endpoint.
-fn mention_to_ipc_target(target: MentionTarget) -> IpcTarget {
-    match target {
-        MentionTarget::All => IpcTarget::All,
-        MentionTarget::Peer(peer) => IpcTarget::Peer(peer),
-        MentionTarget::Room(room) => IpcTarget::Endpoint(format!("room:{}", room.as_uuid())),
     }
 }
 
@@ -186,9 +168,9 @@ impl Airc {
                 channel: room.channel.as_uuid(),
                 from_peer: self.peer_id().as_uuid(),
                 from_client: self.client_id().as_uuid(),
-                kind: framekind_to_ipc(kind),
+                kind: kind.into(),
                 delivery: IpcDelivery::Durable,
-                target: mention_to_ipc_target(target),
+                target: target.into(),
                 correlation_id: None,
                 coalesce_key: None,
                 payload: body.to_payload(),
@@ -215,7 +197,7 @@ impl Airc {
                 channel: room.channel.as_uuid(),
                 from_peer: self.peer_id().as_uuid(),
                 from_client: self.client_id().as_uuid(),
-                kind: framekind_to_ipc(kind),
+                kind: kind.into(),
                 // SDK chat/structured publishes are durable; the live
                 // streaming classes are reached via the typed IPC client
                 // directly (media/game-state), not this chat helper.

--- a/crates/airc-lib/src/gh_client.rs
+++ b/crates/airc-lib/src/gh_client.rs
@@ -180,7 +180,7 @@ pub struct BranchCheckRollupArgs {
     pub branch: String,
 }
 
-/// `gh pr view --json state,mergeable,statusCheckRollup` shape.
+/// `gh pr view --json state,mergeable,statusCheckRollup,mergedAt` shape.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct PrView {
     #[serde(default)]
@@ -189,6 +189,14 @@ pub struct PrView {
     pub mergeable: String,
     #[serde(default, rename = "statusCheckRollup")]
     pub status_check_rollup: Option<Vec<GhCheck>>,
+    /// ISO-8601 timestamp of the merge, populated by gh when
+    /// `state == "MERGED"`. `None` for OPEN PRs. The merger's
+    /// reconcile path (card acd72c81 follow-up) parses this to emit
+    /// `PullRequestMerged` with the canonical GitHub timestamp
+    /// instead of wall-clock-now when transitioning the kanban for
+    /// an already-merged PR.
+    #[serde(default, rename = "mergedAt")]
+    pub merged_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -715,6 +723,7 @@ pub mod mock {
                 state: state.to_string(),
                 mergeable: "MERGEABLE".to_string(),
                 status_check_rollup: Some(Vec::new()),
+                merged_at: None,
             }
         }
 

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -146,7 +146,7 @@ pub use work::{
     HeartbeatWorkspace, LinkCardPullRequest, MarkPullRequestMerged, ObserveLocalGitWorkspace,
     ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests, ReleaseManagerHat,
     ReleaseWorkClaim, ReleaseWorkspace, ReportAgentAvailability, RequestWorkspace, UpdateWorkCard,
-    WorkQueueStatus, WorkQueueStatusQuery,
+    WorkQueueStatus, WorkQueueStatusQuery, WORK_BOARD_PROJECTION_PAGE_SIZE,
 };
 pub use work_manager::{
     SeededWorkCard, WorkBacklogSeedCandidate, WorkBacklogSeedOutcome, WorkBacklogSeedResult,

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -30,6 +30,26 @@ const WORK_MUTATION_PAGE_SIZE: usize = 512;
 /// the minimum-viable fix until that follow-up.
 const WORK_BOARD_FETCH_MULTIPLIER: usize = 4;
 
+/// Canonical pagination size for complete work-board projections.
+///
+/// Card acd72c81: every prior caller that needed the complete board
+/// was passing `usize::MAX` to `work_board(limit)`. That issues ONE
+/// Inbox RPC asking for `usize::MAX * WORK_BOARD_FETCH_MULTIPLIER`
+/// events; the daemon serializes every transcript event in the room
+/// into a single CBOR frame, which trips
+/// `airc_ipc::codec::MAX_FRAME_BYTES` (16 MiB) once the room
+/// accumulates ~9000+ events. Empirically caught on Joel's box
+/// 2026-06-01: `airc work state X closed` failed with
+/// `daemon I/O: ipc frame too large: 16973574 bytes exceeds 16777216`.
+///
+/// `work_board_complete(page_size)` paginates: each IPC frame stays
+/// well under the cap while the projection is still complete.
+/// 1024 events per page is a comfortable middle: each frame fits
+/// (events are typed, not blob payloads — kilobytes each, not MB),
+/// and the round-trip count stays low for the 9000+ event case
+/// (~9 RPCs instead of one giant one).
+pub const WORK_BOARD_PROJECTION_PAGE_SIZE: usize = 1024;
+
 /// Card 79953b4d (pure helper for unit-testability): true when a
 /// transcript event is a work-domain event. Distinguishes work events
 /// from heartbeats / chat / other lifecycle by header presence rather
@@ -740,6 +760,14 @@ impl Airc {
     /// events. `limit` is the transcript page size for interactive
     /// board views; scheduling code should use
     /// [`Airc::work_board_complete`] instead.
+    ///
+    /// **DO NOT pass `usize::MAX`** — it issues a single Inbox RPC
+    /// asking for every event in the room, which trips
+    /// `airc_ipc::codec::MAX_FRAME_BYTES` (16 MiB) once the room
+    /// has accumulated ~9000+ events. If you need the complete
+    /// board, call [`Airc::work_board_complete`] with
+    /// [`WORK_BOARD_PROJECTION_PAGE_SIZE`] (paginated, never hits
+    /// the cap). Card acd72c81.
     pub async fn work_board(&self, limit: usize) -> Result<WorkBoardProjection, AircError> {
         let room = self.current_room().await?;
         // Recent-window view (not the complete board): daemon reads the


### PR DESCRIPTION
Today's session manually ran `git worktree remove acd72c81` after PR
#1100 merged, then cleaned 75+ GiB of stale build caches by hand
across two repos and four worktrees. Multi-session reality is worse —
a sustained operator builds up 10+ stale worktrees over weeks, each
holding a checkout + (when rebuilt) GiB of target cache. The
substrate already names the principle (`local-worktree-is-temp-dir`,
`substrate-is-a-good-citizen-on-the-host`); this commit starts
automating it.

## What ships

`airc work cleanup [--dry-run] [--force]`:

  $ airc work cleanup
  worktrees scanned: 4
    KeepActive:
      800ce5bd  PR #1103  Review
      807193ab  PR #1102  Review
      c409eaf5  PR #1104  Review
    SkipDirty:
      c9b28925  no PR  InProgress  uncommitted changes
  Nothing to remove.

Scan logic:

- List `~/.airc/worktrees/*/`.
- Resolve each worktree's card by short id (first 8 hex chars of the
  worktree dir name) via `work_board_complete`.
- Probe `git status --porcelain` for dirty / clean / unknown.
- Classify into one of five dispositions:
    - `Removable`     — card is Closed or Merged, worktree is clean.
    - `KeepActive`    — card is Open / Claimed / InProgress / Review / Blocked.
    - `SkipDirty`     — worktree has uncommitted changes.
    - `SkipNotGit`    — `git status` probe failed.
    - `SkipUnknownCard` — basename matches the short-id pattern but no
                          card on the current board (orphan).

Default behaviour: classify + print + do nothing destructive.
`--force` runs `git worktree remove` against everything in
`Removable`. `--dry-run` is the explicit-intent alias of the default.

## Safety: operator's WIP outranks hygiene

Worktrees in `SkipDirty`, `SkipNotGit`, or `SkipUnknownCard` are
NEVER removed silently — even with `--force`. The first slice
refuses to make destructive decisions on dirty / unknown state. The
operator commits, pushes, deletes manually, then re-runs cleanup —
which is the same discipline a careful human applies today.

## What this DOES NOT do (yet)

- Doesn't touch `target/` dirs. Build caches are per-project under
  operator-owned paths; the substrate can't safely wipe them without
  consent. Follow-up.
- Doesn't run on a timer. The always-on hygiene tick (with typed
  `WorkspaceCleaned` / `WorkspaceSkipped` events, disk-pressure
  thresholds) is the next slice on continuum task #88.
- Doesn't detect `git worktree lock`. The locked .claude/worktrees
  in Joel's setup are under `Development/airc/.claude/worktrees/`
  (outside the lease zone), so they're never seen by the scan
  today; explicit lock detection is a follow-up.

## Tests

Pure-function classifier + parser get unit-tested in isolation:

- `parse_worktree_short_id_accepts_canonical_shape` / rejects /
  truncates — covers the parser.
- `classifier_closed_clean_removes`
- `classifier_merged_clean_removes`
- `classifier_active_states_keep` — table-drive every active state.
- `classifier_dirty_never_removes_even_when_card_closed` — pins the
  WIP-outranks-hygiene contract.
- `classifier_no_card_returns_skip_unknown_card`
- `classifier_not_git_returns_skip_not_git`
- `disposition_display_priority_orders_removable_first` — pin the
  table sort so the operator sees actionable items first.

34/34 work_commands tests pass.

## Live smoke

Built + reinstalled + ran on Joel's machine after today's session.
Result above: 3 open PRs correctly identified as KeepActive, this
card's own worktree correctly identified as SkipDirty (in-flight
code), nothing destroyed. Exactly the desired safety posture.

Card: c9b28925

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>