### PR TITLE
fix(lib): daemon_subscribe attaches at live edge — stop full-history replay on airc join (card bf0b5790)

### DIFF
--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -372,9 +372,21 @@ impl Airc {
         for channel in channels {
             // Initial attach + ack — fail fast so `subscribe()` errors if
             // the daemon is down right now (don't silently spin).
+            //
+            // Card bf0b5790: `from_now: true` — this is the LIVE
+            // subscribe surface. Without it the daemon interprets
+            // `from: None, from_now: false` as "resume from the start
+            // of the transcript" and full-replays days of history
+            // through the live stream (`airc join` flooded every
+            // attach with the entire event log). Catch-up is a
+            // separate, bounded concern (`resume_from_subscribed_filtered`
+            // with a stored cursor — see `join_feed`); the live stream
+            // starts at the live edge, same as the monitor attach
+            // (card 7d5b6a65).
             let mut stream = client
                 .attach(AttachRequest {
                     channel: Some(channel),
+                    from_now: true,
                     ..Default::default()
                 })
                 .await
@@ -463,10 +475,16 @@ impl Airc {
                         if tx.is_closed() {
                             return; // consumer dropped while we were down
                         }
+                        // Card bf0b5790: a drop BEFORE the first
+                        // delivered event leaves `from: None`; without
+                        // `from_now` that re-attach would full-replay
+                        // the transcript. With a cursor, resume the gap
+                        // exactly as before.
                         let mut s = match client
                             .attach(AttachRequest {
                                 channel: Some(channel),
                                 from,
+                                from_now: from.is_none(),
                                 ..Default::default()
                             })
                             .await

--- a/crates/airc-lib/tests/subscribe_live_edge.rs
+++ b/crates/airc-lib/tests/subscribe_live_edge.rs
@@ -1,0 +1,70 @@
+//! Card bf0b5790: a daemon-attached live subscription starts at the
+//! live edge — it must NOT replay the transcript backlog as if it
+//! were live traffic.
+//!
+//! `Airc::subscribe` / `subscribe_subscribed_filtered` document live
+//! semantics ("events emitted after the call surface here; for
+//! historical events, use `recent_work_events` / `page_recent`").
+//! Before this pin, the SDK attached with `from: None, from_now:
+//! false`, which the daemon interprets as "resume from the start of
+//! the transcript" — so every `airc join` flooded its consumer with
+//! days of history indistinguishable from live events.
+
+mod common;
+
+use std::time::Duration;
+
+use airc_core::Body;
+use common::Machine;
+use futures::stream::StreamExt;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn subscribe_starts_at_live_edge_not_transcript_start() {
+    let machine = Machine::boot().await;
+    let (alice, bob) = machine.pair_in("live-edge-room").await;
+
+    // History that exists BEFORE bob subscribes. If the subscription
+    // replays the transcript, these are what arrive first.
+    alice.say("history-1").await.expect("alice says history-1");
+    alice.say("history-2").await.expect("alice says history-2");
+
+    let mut bob_stream = bob.subscribe().await.expect("bob subscribes");
+
+    // The first live event after the subscription.
+    alice.say("live-1").await.expect("alice says live-1");
+
+    // Drain until the live marker arrives; anything textual seen on
+    // the way that predates the subscription is a backlog replay.
+    let mut seen_before_live: Vec<String> = Vec::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut got_live = false;
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), bob_stream.next()).await {
+            Ok(Some(Ok(event))) => {
+                if let Some(text) = event.body.as_ref().and_then(Body::as_text) {
+                    if text == "live-1" {
+                        got_live = true;
+                        break;
+                    }
+                    seen_before_live.push(text.to_string());
+                }
+            }
+            Ok(Some(Err(_))) => {} // lag marker — keep reading
+            Ok(None) => break,
+            Err(_) => {} // poll timeout — keep waiting until deadline
+        }
+    }
+
+    assert!(
+        got_live,
+        "the live event published after subscribing must arrive"
+    );
+    let replayed: Vec<&String> = seen_before_live
+        .iter()
+        .filter(|text| text.starts_with("history-"))
+        .collect();
+    assert!(
+        replayed.is_empty(),
+        "subscription replayed pre-subscribe backlog as live events: {replayed:?}"
+    );
+}


### PR DESCRIPTION
## Card
bf0b5790 — P1: `airc join` replays full event history on attach.

## Root cause
The daemon supports `from_now`/`coalesce_backlog` since card 7d5b6a65 (PR #1086), and the **monitor CLI** passes `from_now: true` — but `airc-lib::daemon_subscribe` (behind `Airc::subscribe` / `subscribe_subscribed_filtered`, i.e. the `airc join` live feed and every SDK live consumer) still attached with `AttachRequest::default()` → `from: None, from_now: false`, which the daemon interprets as **resume from the start of the transcript**. Every join replayed days of card lifecycle + chat history through the "live" stream, indistinguishable from live events, and tripped monitor rate-limit suppression during normal joins.

Reproduced live from a fresh positron scope before fixing: the flood arrives *after* the `attached —` line, i.e. from the live stream, not the (correctly capped) join-feed cursor catch-up.

## Fix
- Initial attach: `from_now: true`. This is the documented contract — "Subscription is live … for historical events, use `recent_work_events` / `page_recent`". Bounded catch-up stays the join_feed cursor's job (cap 64).
- Reconnect: `from_now: from.is_none()` — a drop before the first delivered event would otherwise full-replay; cursor-resume of the gap unchanged.

## Tests
- New `subscribe_live_edge` integration test: publish history → subscribe → publish live marker → assert the live marker arrives and **no** pre-subscribe backlog does. Verified **red without the fix**, green with it.
- Full `airc-lib` + `airc-daemon` suites green (incl. `daemon_reconnect`, `attach_backlog_coalesce`, `work_subscription`, `command_bus_round_trip`). `cargo fmt --check` + clippy clean.

## Note for reviewers
Cards bf0b5790 / 45d84182 don't appear in my scope's `airc work board` projection (filed from the continuum scope) — possibly related to the fan-out diagnostics on 800ce5bd. Couldn't `airc work link` from the shared checkout (lease-zone guard); filer please link if the card exists in your store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)