### PR TITLE
feat(ipc): typed AttachStart — the flood-by-default footgun dies at the type level (card c0cb6cdc)

### DIFF
--- a/crates/airc-cli/src/monitor/attach.rs
+++ b/crates/airc-cli/src/monitor/attach.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::Path;
 
 use airc_core::{Body, MentionTarget, RoomId, TranscriptEvent, TranscriptKind};
-use airc_ipc::{codec::read_frame, AttachRequest, DaemonClient, Response};
+use airc_ipc::{codec::read_frame, AttachRequest, AttachStart, DaemonClient, Response};
 use airc_lib::{decode_wire_event, Airc};
 use airc_protocol::HEADER_AIRC_CLIENT;
 
@@ -47,28 +47,28 @@ pub(crate) async fn run(
     // feed. Each daemon `Event` carries airc-wire bytes — decoded once
     // here via the shared projection.
     //
-    // Card 7d5b6a65: `from_now=true` (the default) asks the daemon to
-    // skip transcript replay and start at the live edge — no backlog
-    // flood. `coalesce_backlog=true` (only meaningful when `from_now`
-    // is false) asks the daemon to collapse the catch-up phase into a
-    // single `AttachCursorAdvanced` summary frame which the renderer
-    // surfaces as ONE stdout line instead of N historical events.
+    // Card 7d5b6a65: `from_now` (the CLI default) maps to
+    // `AttachStart::Live` — no backlog flood. Without it the monitor
+    // replays the transcript (`FromTranscriptStart`), where
+    // `coalesce_backlog` collapses the catch-up phase into a single
+    // `AttachCursorAdvanced` summary frame which the renderer surfaces
+    // as ONE stdout line instead of N historical events.
+    let start = if from_now {
+        AttachStart::Live
+    } else {
+        AttachStart::FromTranscriptStart
+    };
     let (tx, mut rx) = tokio::sync::mpsc::channel::<MonitorFrame>(1024);
     for channel in channels {
         let socket = socket.clone();
         let tx = tx.clone();
         tokio::spawn(async move {
             let client = DaemonClient::new(socket);
-            let mut stream = match client
-                .attach(AttachRequest {
-                    channel: Some(channel),
-                    from: None,
-                    from_now,
-                    coalesce_backlog,
-                    ..Default::default()
-                })
-                .await
-            {
+            let mut request = AttachRequest::new(channel, start);
+            if coalesce_backlog {
+                request = request.with_coalesced_backlog();
+            }
+            let mut stream = match client.attach(request).await {
                 Ok(stream) => stream,
                 Err(_) => return,
             };

--- a/crates/airc-daemon/src/server.rs
+++ b/crates/airc-daemon/src/server.rs
@@ -26,7 +26,7 @@ use airc_diagnostics::{
     DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
 };
 use airc_ipc::codec::{read_frame, write_frame};
-use airc_ipc::request::{AttachRequest, IpcDelivery, IpcKind, Request};
+use airc_ipc::request::{AttachRequest, AttachStart, IpcDelivery, IpcKind, Request};
 use airc_ipc::response::Response;
 use airc_ipc::transport::{IpcListener, IpcStream};
 
@@ -269,9 +269,14 @@ async fn stream_attach<W>(
 where
     W: AsyncWriteExt + Unpin,
 {
+    // Card c0cb6cdc: the request destructures into typed parts — the
+    // start position is already an `AttachStart`, decoded once in
+    // `AttachRequest::start`. No flag precedence to re-derive here.
+    let parts = attach.into_parts();
+
     // The owner-core router subscribes per channel (no global table to
     // scan). A client attaches once per room it cares about.
-    let channel = match attach.channel {
+    let channel = match parts.channel {
         Some(channel) => channel,
         None => {
             return write_response(
@@ -283,33 +288,28 @@ where
             .await;
         }
     };
-    // Resume strictly after the client's cursor (replay the gap missed
-    // while detached), then go live with no dup at the seam. `from` is
-    // advanced as we send, so a re-subscribe after a lag drop resumes
-    // exactly where we left off.
+    // Map the typed start onto the router cursor. `from` is advanced as
+    // we send, so a re-subscribe after a lag drop resumes exactly where
+    // we left off (replay the gap, no dup at the seam).
     //
-    // Card 7d5b6a65: `from_now` overrides any cursor the client passed
-    // with the channel's current head — the agent-Monitor live-tail
-    // shape. The router's `subscribe_with_lag` interprets a
-    // forward-pointing cursor as "nothing newer than this yet," so the
-    // ring snapshot + deep replay legs return empty and we go straight
-    // to live.
+    // `Live` (card 7d5b6a65): start at the channel's current head. The
+    // router's `subscribe_with_lag` interprets a forward-pointing cursor
+    // as "nothing newer than this yet," so the ring snapshot + deep
+    // replay legs return empty and we go straight to live.
     //
     // Critical: when the in-memory ring is empty (fresh daemon, no
     // events yet this process-lifetime), `router.head_cursor` returns
     // None — but the SINK still has the durable transcript. Without
-    // the sink fallback below, `from: None` would fall through to a
-    // full sink replay (the very bug card 7d5b6a65 closes). Query the
-    // sink for its head when the ring is empty.
-    let mut from = if attach.from_now {
-        match state.router.head_cursor(channel) {
+    // the sink fallback below, `Live` would fall through to a full
+    // sink replay (the very bug card 7d5b6a65 closes). Query the sink
+    // for its head when the ring is empty.
+    let mut from = match parts.start {
+        AttachStart::Live => match state.router.head_cursor(channel) {
             Some(c) => Some(c),
             None => state.router.sink_head_cursor(channel).await,
-        }
-    } else {
-        attach
-            .from
-            .map(|c| Cursor::new(Seq::new(c.epoch, c.counter), c.event_id))
+        },
+        AttachStart::After(c) => Some(Cursor::new(Seq::new(c.epoch, c.counter), c.event_id)),
+        AttachStart::FromTranscriptStart => None,
     };
 
     // Card 7d5b6a65: `coalesce_backlog` lets the daemon collapse all
@@ -317,21 +317,21 @@ where
     // frame instead of streaming each event individually. We track the
     // ring-snapshot's high-water cursor; everything at or before it is
     // backlog (collapsed), everything after it is live (streamed
-    // event-by-event as before).
-    let coalesce_backlog = attach.coalesce_backlog && !attach.from_now;
+    // event-by-event as before). `Live` has no backlog to coalesce.
+    let coalesce_backlog = parts.coalesce_backlog && parts.start != AttachStart::Live;
 
     // Compile the consumer's kind/delivery/header filters into the router
     // filter, applied ROUTER-SIDE — the daemon never fans out an event a
     // consumer would discard (Hermes → Command/CommandResult; Continuum →
     // scoped `forge.*` headers; a media tap → StreamChunk only).
     let mut filter = Filter::channel(channel);
-    if let Some(kinds) = attach.kinds {
+    if let Some(kinds) = parts.kinds {
         filter = filter.with_kinds(kinds.into_iter().map(map_ipc_kind).collect());
     }
-    if let Some(delivery) = attach.delivery {
+    if let Some(delivery) = parts.delivery {
         filter = filter.with_delivery(delivery.into_iter().map(map_ipc_delivery).collect());
     }
-    filter = filter.with_headers(attach.headers);
+    filter = filter.with_headers(parts.headers);
 
     // Subscribe BEFORE acking. Once the client sees `Ok`, the
     // subscription is already registered at the live edge, so a publish

--- a/crates/airc-daemon/tests/attach_backlog_coalesce.rs
+++ b/crates/airc-daemon/tests/attach_backlog_coalesce.rs
@@ -18,11 +18,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use airc_core::{HeaderFilter, Headers, PeerId, RoomId};
+use airc_core::{Headers, PeerId, RoomId};
 use airc_daemon::{run, DaemonRuntimeInfo, DaemonState};
 use airc_ipc::codec::read_frame;
 use airc_ipc::{
-    AttachRequest, DaemonClient, IpcDelivery, IpcKind, IpcTarget, PublishRequest, Response,
+    AttachRequest, AttachStart, DaemonClient, IpcDelivery, IpcKind, IpcTarget, PublishRequest,
+    Response,
 };
 use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
 use airc_store::{EventStore, InMemoryEventStore};
@@ -129,15 +130,7 @@ async fn attach_from_now_skips_full_backlog() {
 
     let client = DaemonClient::new(daemon.socket.clone());
     let mut stream = client
-        .attach(AttachRequest {
-            channel: Some(channel),
-            from: None,
-            from_now: true,
-            coalesce_backlog: false,
-            kinds: None,
-            delivery: None,
-            headers: HeaderFilter::default(),
-        })
+        .attach(AttachRequest::new(channel, AttachStart::Live))
         .await
         .expect("attach");
     match read_frame::<_, Response>(&mut stream).await {
@@ -215,15 +208,9 @@ async fn attach_coalesce_backlog_emits_one_summary_then_live() {
 
     let client = DaemonClient::new(daemon.socket.clone());
     let mut stream = client
-        .attach(AttachRequest {
-            channel: Some(channel),
-            from: None,
-            from_now: false,
-            coalesce_backlog: true,
-            kinds: None,
-            delivery: None,
-            headers: HeaderFilter::default(),
-        })
+        .attach(
+            AttachRequest::new(channel, AttachStart::FromTranscriptStart).with_coalesced_backlog(),
+        )
         .await
         .expect("attach");
     match read_frame::<_, Response>(&mut stream).await {
@@ -307,12 +294,11 @@ async fn attach_legacy_shape_still_replays_event_by_event() {
 
     let client = DaemonClient::new(daemon.socket.clone());
     let mut stream = client
-        .attach(AttachRequest {
-            channel: Some(channel),
-            from: None,
-            // Both new fields default to false — the legacy wire shape.
-            ..Default::default()
-        })
+        // The legacy wire shape: full transcript replay, named explicitly.
+        .attach(AttachRequest::new(
+            channel,
+            AttachStart::FromTranscriptStart,
+        ))
         .await
         .expect("attach");
     match read_frame::<_, Response>(&mut stream).await {

--- a/crates/airc-daemon/tests/owner_core_proof.rs
+++ b/crates/airc-daemon/tests/owner_core_proof.rs
@@ -109,11 +109,7 @@ async fn persona_collect(
 ) -> Vec<Vec<u8>> {
     let client = DaemonClient::new(socket);
     let mut stream = client
-        .attach(AttachRequest {
-            channel: Some(channel),
-            from: None,
-            ..Default::default()
-        })
+        .attach(AttachRequest::live(channel))
         .await
         .expect("attach");
     match read_frame::<_, Response>(&mut stream).await {
@@ -152,11 +148,7 @@ async fn collect_envelopes(
 ) -> Vec<Envelope> {
     let client = DaemonClient::new(socket);
     let mut stream = client
-        .attach(AttachRequest {
-            channel: Some(channel),
-            from: None,
-            ..Default::default()
-        })
+        .attach(AttachRequest::live(channel))
         .await
         .expect("attach");
     match read_frame::<_, Response>(&mut stream).await {
@@ -591,11 +583,7 @@ async fn request_response_rpc_correlates_across_kind_filtered_sessions() {
     let worker = tokio::spawn(async move {
         let client = DaemonClient::new(worker_socket);
         let mut stream = client
-            .attach(AttachRequest {
-                channel: Some(channel),
-                kinds: Some(vec![IpcKind::Command]),
-                ..Default::default()
-            })
+            .attach(AttachRequest::live(channel).with_kinds(vec![IpcKind::Command]))
             .await
             .expect("worker attach");
         assert!(matches!(
@@ -643,11 +631,7 @@ async fn request_response_rpc_correlates_across_kind_filtered_sessions() {
     let requester = tokio::spawn(async move {
         let client = DaemonClient::new(req_socket);
         let mut stream = client
-            .attach(AttachRequest {
-                channel: Some(channel),
-                kinds: Some(vec![IpcKind::CommandResult]),
-                ..Default::default()
-            })
+            .attach(AttachRequest::live(channel).with_kinds(vec![IpcKind::CommandResult]))
             .await
             .expect("requester attach");
         assert!(matches!(
@@ -724,14 +708,12 @@ async fn attach_header_filter_scopes_subscription_router_side() {
     let collector = tokio::spawn(async move {
         let client = DaemonClient::new(socket);
         let mut stream = client
-            .attach(AttachRequest {
-                channel: Some(channel),
-                headers: HeaderFilter::Exact {
+            .attach(
+                AttachRequest::live(channel).with_headers(HeaderFilter::Exact {
                     key: "forge.room".to_string(),
                     value: "alpha".to_string(),
-                },
-                ..Default::default()
-            })
+                }),
+            )
             .await
             .expect("attach");
         assert!(matches!(

--- a/crates/airc-daemon/tests/work_churn_survival_proof.rs
+++ b/crates/airc-daemon/tests/work_churn_survival_proof.rs
@@ -142,11 +142,7 @@ async fn collect_envelopes(
 ) -> Vec<Envelope> {
     let client = DaemonClient::new(socket);
     let mut stream = client
-        .attach(AttachRequest {
-            channel: Some(channel),
-            from: None,
-            ..Default::default()
-        })
+        .attach(AttachRequest::live(channel))
         .await
         .expect("attach");
     match read_frame::<_, Response>(&mut stream).await {

--- a/crates/airc-daemon/tests/work_event_propagation_proof.rs
+++ b/crates/airc-daemon/tests/work_event_propagation_proof.rs
@@ -123,11 +123,7 @@ async fn collect_envelopes(
 ) -> Vec<Envelope> {
     let client = DaemonClient::new(socket);
     let mut stream = client
-        .attach(AttachRequest {
-            channel: Some(channel),
-            from: None,
-            ..Default::default()
-        })
+        .attach(AttachRequest::live(channel))
         .await
         .expect("attach");
     match read_frame::<_, Response>(&mut stream).await {

--- a/crates/airc-ipc/src/lib.rs
+++ b/crates/airc-ipc/src/lib.rs
@@ -42,8 +42,8 @@ pub const IPC_PROTOCOL_VERSION: u16 = 5;
 
 pub use client::{ClientError, DaemonClient};
 pub use request::{
-    AddPeerRequest, AttachRequest, InboxRequest, IpcCursor, IpcDelivery, IpcKind, IpcTarget,
-    PublishRequest, RemovePeerRequest, Request, SendRequest,
+    AddPeerRequest, AttachParts, AttachRequest, AttachStart, InboxRequest, IpcCursor, IpcDelivery,
+    IpcKind, IpcTarget, PublishRequest, RemovePeerRequest, Request, SendRequest,
 };
 pub use response::{InboxResponse, PeersResponse, PublishResponse, Response, StatusResponse};
 pub use sdk_conversions::{COUNTER_BITS, COUNTER_MASK};

--- a/crates/airc-ipc/src/request.rs
+++ b/crates/airc-ipc/src/request.rs
@@ -141,67 +141,178 @@ pub struct InboxRequest {
     pub limit: Option<usize>,
 }
 
+/// Where an attach stream starts. One intentional choice — not a
+/// `from`/`from_now` flag pair whose precedence lived in a server-side
+/// comment (card c0cb6cdc; the pair let `..Default::default()` mean
+/// "replay days of transcript," which is how bf0b5790 happened).
+///
+/// `Live` is the default because it is the only start that can never
+/// flood a consumer. Both replaying variants must be named at the call
+/// site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AttachStart {
+    /// Start at the channel's live edge: deliver only events published
+    /// after the subscription is registered. The subscribe contract.
+    #[default]
+    Live,
+    /// Resume strictly after this cursor — replay the gap the client
+    /// missed while detached, then continue live with no duplicate at
+    /// the seam.
+    After(IpcCursor),
+    /// Replay the full transcript before going live. Audit/replay
+    /// tools only — on a long-lived room this is days of backlog, so
+    /// pair it with [`AttachRequest::with_coalesced_backlog`] unless
+    /// every historical envelope is genuinely wanted.
+    FromTranscriptStart,
+}
+
 /// Parameters for `Attach`. Filters are applied **router-side** so the
 /// daemon never fans out events the consumer would discard — the
 /// adaptable/performant subscription: Hermes attaches to
 /// Command/CommandResult, Continuum scopes by `forge.continuum.*`
 /// headers, a game attaches to one room's StreamChunk only.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+///
+/// Fields are private: construction goes through [`AttachRequest::new`]
+/// / [`AttachRequest::live`] so the start position is always a typed
+/// [`AttachStart`], never an implicit flag combination. The wire shape
+/// is unchanged (`from` + `from_now` encode the enum), so version-skewed
+/// daemon/client pairs interoperate: an old client's bare request decodes
+/// as [`AttachStart::FromTranscriptStart`], exactly its legacy meaning.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AttachRequest {
     /// The channel (room) to attach to.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub channel: Option<airc_core::RoomId>,
-    /// Resume strictly after this cursor before going live — replay the
-    /// gap the client missed while detached, then continue live with no
-    /// duplicate at the seam.
-    ///
-    /// `None` historically meant "give me everything from the beginning
-    /// of the transcript" (despite the prior docstring claiming "live
-    /// edge"). Card 7d5b6a65 splits intent: pair `from: None` with
-    /// `from_now: true` for "skip backlog, just go live," and pair it
-    /// with `from_now: false` for the legacy full-backlog behavior.
-    /// Existing callers that omit `from_now` keep the prior shape (no
-    /// behavior change on the wire for pre-card-7d5b6a65 clients).
+    channel: Option<airc_core::RoomId>,
+    /// Wire encoding of [`AttachStart::After`]. See [`Self::start`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub from: Option<IpcCursor>,
-    /// **Card 7d5b6a65.** When `true`, the daemon overrides any `from`
-    /// value with the current head cursor at attach time — the client
-    /// gets no backlog at all, only events published strictly after
-    /// the attach call returns. This is the agent-Monitor live-tail
-    /// shape (the existing `from: None` behaviour replayed days of
-    /// transcript and fired one notification per historical event).
-    ///
-    /// Default `false` preserves the prior `from: None` = full-replay
-    /// behaviour for tools that depend on it (audit, replay,
-    /// codex-hook poll's first-attach catch-up).
+    from: Option<IpcCursor>,
+    /// Wire encoding of [`AttachStart::Live`] (card 7d5b6a65): the
+    /// daemon starts at the channel head, ignoring `from`. See
+    /// [`Self::start`] — the precedence lives there, nowhere else.
     #[serde(default, skip_serializing_if = "is_false")]
-    pub from_now: bool,
+    from_now: bool,
     /// **Card 7d5b6a65.** When `true`, the daemon emits ONE
     /// [`Response::AttachCursorAdvanced`] summary frame at the end of
     /// the backlog catch-up phase instead of streaming each historical
-    /// event individually, then transitions to live tail. Live events
-    /// still arrive one-at-a-time as before.
-    ///
-    /// Has no effect when there is no backlog to coalesce
-    /// (`from_now: true` or `from` already at head). Has no effect on
-    /// live events — only on the catch-up phase.
-    ///
-    /// Default `false` preserves the prior event-by-event replay so
-    /// audit/replay tools that need to see every historical envelope
-    /// keep working unchanged.
+    /// event individually, then transitions to live tail. Orthogonal to
+    /// [`AttachStart`]: it shapes how backlog is delivered, not where
+    /// the stream starts, and is a no-op when there is no backlog
+    /// (`Live`, or a cursor already at head).
     #[serde(default, skip_serializing_if = "is_false")]
-    pub coalesce_backlog: bool,
+    coalesce_backlog: bool,
     /// If set, only these kinds are delivered.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub kinds: Option<Vec<IpcKind>>,
+    kinds: Option<Vec<IpcKind>>,
     /// If set, only these delivery classes are delivered (e.g. just
     /// `StreamChunk` for a media tap, or just `Durable` for a transcript
     /// tail).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub delivery: Option<Vec<IpcDelivery>>,
+    delivery: Option<Vec<IpcDelivery>>,
     /// Header predicate evaluated router-side. `Any` (default) matches
     /// all; consumers scope by their `forge.*` projection headers.
     #[serde(default)]
+    headers: HeaderFilter,
+}
+
+impl AttachRequest {
+    /// Attach to `channel`, starting at `start`. No filters: every
+    /// event class on the channel is delivered. Narrow with the
+    /// `with_*` builders.
+    pub fn new(channel: airc_core::RoomId, start: AttachStart) -> Self {
+        let (from, from_now) = match start {
+            AttachStart::Live => (None, true),
+            AttachStart::After(cursor) => (Some(cursor), false),
+            AttachStart::FromTranscriptStart => (None, false),
+        };
+        Self {
+            channel: Some(channel),
+            from,
+            from_now,
+            coalesce_backlog: false,
+            kinds: None,
+            delivery: None,
+            headers: HeaderFilter::default(),
+        }
+    }
+
+    /// [`Self::new`] with [`AttachStart::Live`] — the common shape.
+    pub fn live(channel: airc_core::RoomId) -> Self {
+        Self::new(channel, AttachStart::Live)
+    }
+
+    /// Decode the wire flag pair back into the typed start position.
+    /// This is the ONLY place the `from_now`-overrides-`from`
+    /// precedence exists.
+    pub fn start(&self) -> AttachStart {
+        if self.from_now {
+            AttachStart::Live
+        } else if let Some(cursor) = self.from {
+            AttachStart::After(cursor)
+        } else {
+            AttachStart::FromTranscriptStart
+        }
+    }
+
+    /// The channel this request attaches to, if one was set (requests
+    /// from legacy clients may omit it; the daemon rejects those).
+    pub fn channel(&self) -> Option<airc_core::RoomId> {
+        self.channel
+    }
+
+    /// Whether backlog catch-up is collapsed into one summary frame.
+    pub fn coalesces_backlog(&self) -> bool {
+        self.coalesce_backlog
+    }
+
+    /// Deliver only these event kinds.
+    pub fn with_kinds(mut self, kinds: Vec<IpcKind>) -> Self {
+        self.kinds = Some(kinds);
+        self
+    }
+
+    /// Deliver only these delivery classes.
+    pub fn with_delivery(mut self, delivery: Vec<IpcDelivery>) -> Self {
+        self.delivery = Some(delivery);
+        self
+    }
+
+    /// Scope by header predicate (router-side).
+    pub fn with_headers(mut self, headers: HeaderFilter) -> Self {
+        self.headers = headers;
+        self
+    }
+
+    /// Collapse backlog catch-up into one summary frame (card 7d5b6a65).
+    pub fn with_coalesced_backlog(mut self) -> Self {
+        self.coalesce_backlog = true;
+        self
+    }
+
+    /// Destructure for the daemon's attach handler: moves the filter
+    /// vectors out (no clone) with the start already decoded. One-way —
+    /// there is no path from parts back to a request, so the typed
+    /// start cannot be bypassed.
+    pub fn into_parts(self) -> AttachParts {
+        let start = self.start();
+        AttachParts {
+            channel: self.channel,
+            start,
+            coalesce_backlog: self.coalesce_backlog,
+            kinds: self.kinds,
+            delivery: self.delivery,
+            headers: self.headers,
+        }
+    }
+}
+
+/// Owned view of an [`AttachRequest`] for the serving side. Produced by
+/// [`AttachRequest::into_parts`]; not constructible into a request.
+pub struct AttachParts {
+    pub channel: Option<airc_core::RoomId>,
+    pub start: AttachStart,
+    pub coalesce_backlog: bool,
+    pub kinds: Option<Vec<IpcKind>>,
+    pub delivery: Option<Vec<IpcDelivery>>,
     pub headers: HeaderFilter,
 }
 
@@ -298,6 +409,77 @@ pub struct PublishRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn cursor(counter: u64) -> IpcCursor {
+        IpcCursor {
+            epoch: 1,
+            counter,
+            event_id: airc_core::EventId::from_u128(0xfeed),
+        }
+    }
+
+    /// Card c0cb6cdc: every `AttachStart` survives the wire round-trip —
+    /// the legacy flag-pair encoding decodes back to the same typed start.
+    #[test]
+    fn attach_start_roundtrips_through_wire_encoding() {
+        for start in [
+            AttachStart::Live,
+            AttachStart::After(cursor(7)),
+            AttachStart::FromTranscriptStart,
+        ] {
+            let request = AttachRequest::new(airc_core::RoomId(Uuid::nil()), start);
+            let encoded = serde_json::to_string(&request).unwrap();
+            let decoded: AttachRequest = serde_json::from_str(&encoded).unwrap();
+            assert_eq!(decoded.start(), start, "round-trip of {start:?}");
+            assert_eq!(decoded, request);
+        }
+    }
+
+    /// Card c0cb6cdc: a bare request from a pre-AttachStart client
+    /// (no `from`, no `from_now` on the wire) keeps its legacy meaning —
+    /// full transcript replay — so version-skewed peers interoperate.
+    #[test]
+    fn legacy_bare_attach_decodes_as_transcript_start() {
+        let legacy = format!(r#"{{"channel":"{}"}}"#, Uuid::nil());
+        let decoded: AttachRequest = serde_json::from_str(&legacy).unwrap();
+        assert_eq!(decoded.start(), AttachStart::FromTranscriptStart);
+        assert!(!decoded.coalesces_backlog());
+    }
+
+    /// Card c0cb6cdc: `from_now` wins over a cursor on the wire — the
+    /// precedence exists in exactly one place (`AttachRequest::start`),
+    /// pinned here so it never silently drifts.
+    #[test]
+    fn from_now_takes_precedence_over_cursor_on_the_wire() {
+        let skewed = format!(
+            r#"{{"channel":"{}","from":{},"from_now":true}}"#,
+            Uuid::nil(),
+            serde_json::to_string(&cursor(3)).unwrap(),
+        );
+        let decoded: AttachRequest = serde_json::from_str(&skewed).unwrap();
+        assert_eq!(decoded.start(), AttachStart::Live);
+    }
+
+    /// Card c0cb6cdc: the dangerous start must be named — the safe
+    /// default of the typed enum is `Live`.
+    #[test]
+    fn attach_start_default_is_live() {
+        assert_eq!(AttachStart::default(), AttachStart::Live);
+    }
+
+    #[test]
+    fn into_parts_moves_filters_with_decoded_start() {
+        let parts = AttachRequest::new(
+            airc_core::RoomId(Uuid::nil()),
+            AttachStart::After(cursor(9)),
+        )
+        .with_kinds(vec![IpcKind::Command])
+        .with_coalesced_backlog()
+        .into_parts();
+        assert_eq!(parts.start, AttachStart::After(cursor(9)));
+        assert!(parts.coalesce_backlog);
+        assert_eq!(parts.kinds.as_deref(), Some(&[IpcKind::Command][..]));
+    }
 
     #[test]
     fn ping_serializes_compactly() {

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -19,8 +19,8 @@ use airc_bus::envelope::{Envelope, Kind, Target};
 use airc_core::{Body, MentionTarget, RoomId, TranscriptCursor, TranscriptEvent, TranscriptKind};
 use airc_ipc::codec::read_frame;
 use airc_ipc::{
-    AttachRequest, InboxRequest, IpcCursor, IpcDelivery, IpcTarget, PublishRequest, Response,
-    SendRequest,
+    AttachRequest, AttachStart, InboxRequest, IpcCursor, IpcDelivery, IpcTarget, PublishRequest,
+    Response, SendRequest,
 };
 use airc_protocol::FrameKind;
 use tokio::sync::mpsc;
@@ -373,22 +373,12 @@ impl Airc {
             // Initial attach + ack — fail fast so `subscribe()` errors if
             // the daemon is down right now (don't silently spin).
             //
-            // Card bf0b5790: `from_now: true` — this is the LIVE
-            // subscribe surface. Without it the daemon interprets
-            // `from: None, from_now: false` as "resume from the start
-            // of the transcript" and full-replays days of history
-            // through the live stream (`airc join` flooded every
-            // attach with the entire event log). Catch-up is a
-            // separate, bounded concern (`resume_from_subscribed_filtered`
-            // with a stored cursor — see `join_feed`); the live stream
-            // starts at the live edge, same as the monitor attach
-            // (card 7d5b6a65).
+            // Card bf0b5790: this is the LIVE subscribe surface, so the
+            // stream starts at the live edge. Catch-up is a separate,
+            // bounded concern (`resume_from_subscribed_filtered` with a
+            // stored cursor — see `join_feed`).
             let mut stream = client
-                .attach(AttachRequest {
-                    channel: Some(channel),
-                    from_now: true,
-                    ..Default::default()
-                })
+                .attach(AttachRequest::live(channel))
                 .await
                 .map_err(|e| AircError::Route(format!("daemon attach: {e}")))?;
             match read_frame::<_, Response>(&mut stream).await {
@@ -476,17 +466,16 @@ impl Airc {
                             return; // consumer dropped while we were down
                         }
                         // Card bf0b5790: a drop BEFORE the first
-                        // delivered event leaves `from: None`; without
-                        // `from_now` that re-attach would full-replay
-                        // the transcript. With a cursor, resume the gap
+                        // delivered event leaves no cursor — re-attach
+                        // at the live edge rather than replaying the
+                        // transcript. With a cursor, resume the gap
                         // exactly as before.
+                        let start = match from {
+                            Some(cursor) => AttachStart::After(cursor),
+                            None => AttachStart::Live,
+                        };
                         let mut s = match client
-                            .attach(AttachRequest {
-                                channel: Some(channel),
-                                from,
-                                from_now: from.is_none(),
-                                ..Default::default()
-                            })
+                            .attach(AttachRequest::new(channel, start))
                             .await
                         {
                             Ok(s) => s,


### PR DESCRIPTION
bf0b5790 existed because AttachRequest's DEFAULT was the dangerous
behavior: '..Default::default()' silently meant full-transcript
replay, and three interacting fields (from, from_now,
coalesce_backlog) carried precedence rules documented in a server-side
comment. PR #1113 fixed the symptom at one call site; any of the 11
construction sites could re-create the flood by forgetting a flag.

The protocol now states intent in one type:

- AttachStart { Live (#[default]), After(IpcCursor),
  FromTranscriptStart }. Live is the only start that can never flood
  a consumer; both replaying variants must be named at the call site.
- AttachRequest fields go private. Construction only via
  AttachRequest::new(channel, start) / ::live(channel) plus with_*
  builders; '..Default::default()' literals are impossible outside
  airc-ipc.
- Wire encoding unchanged (from + from_now encode the enum), so
  version-skewed daemon/client pairs interoperate; a legacy bare
  request still decodes as FromTranscriptStart. The
  from_now-overrides-from precedence now exists in exactly ONE place
  (AttachRequest::start) instead of a comment, pinned by unit tests.
- Daemon stream_attach matches on the typed start via into_parts()
  (moves filter vectors, no clone); 'Live + coalesce' is structurally
  a no-op rather than a documented caveat.
- airc-lib daemon_subscribe + monitor CLI + 9 daemon-test sites move
  to constructors.

Tests: 5 new unit tests pin wire round-trip per variant, legacy
bare-request decode, precedence, Live-by-default, and into_parts.
Full workspace suite green (81 test binaries); fmt + clippy clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>