### PR TITLE
fix(install): bootstrap the full Rust toolchain on fresh Windows boxes (DEV PATH)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -172,17 +172,71 @@ Test-WingetAvailable
 # removes a 30+ second prereq install (and the visible UAC prompt).
 
 Install-IfMissing -Name 'Git for Windows'    -WingetId 'Git.Git'             -TestCmd { Get-Command git -ErrorAction SilentlyContinue }
-Install-IfMissing -Name 'Python 3'           -WingetId 'Python.Python.3.12'  -TestCmd {
-    # Probe both the launcher (`py -3`) and direct `python`. Either is fine
-    # for airc.ps1's Python invocations. Skip the App Execution Alias stub
-    # at $env:LOCALAPPDATA\Microsoft\WindowsApps\python.exe which prints
-    # "Python was not found; run without arguments to install ..." on call.
-    $py = Get-Command python -ErrorAction SilentlyContinue
-    if ($py -and $py.Source -notlike '*\WindowsApps\*') { return $true }
-    return [bool](Get-Command py -ErrorAction SilentlyContinue)
-}
 Install-IfMissing -Name 'GitHub CLI (gh)'    -WingetId 'GitHub.cli'          -TestCmd { Get-Command gh -ErrorAction SilentlyContinue }
-Install-IfMissing -Name 'jq'                 -WingetId 'jqlang.jq'           -TestCmd { Get-Command jq -ErrorAction SilentlyContinue }
+# Python + jq dropped as prereqs (parity with install.sh, issue #341):
+# identity, signing, hooks, config, and JSON handling are Rust-owned.
+
+# -- Rust toolchain ------------------------------------------------------
+# airc IS a Rust binary; cargo is a hard prereq. install.sh auto-installs
+# Rustlang.Rustup on the winget path -- mirror that here instead of the
+# old hard-exit "go install Rust yourself". winget's Rustup package runs
+# rustup-init, which installs the stable-msvc toolchain and adds
+# %USERPROFILE%\.cargo\bin to the User PATH; Update-SessionPath inside
+# Install-IfMissing makes it visible to THIS session.
+Install-IfMissing -Name 'Rust (rustup)'      -WingetId 'Rustlang.Rustup'     -TestCmd { Get-Command cargo -ErrorAction SilentlyContinue }
+if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+    # rustup installed but cargo not resolving: a fresh rustup-init may
+    # not have set a default toolchain (non-interactive install). Fix it
+    # directly rather than telling the user to open a new shell and guess.
+    $rustupExe = Join-Path $env:USERPROFILE '.cargo\bin\rustup.exe'
+    if (Test-Path $rustupExe) {
+        & $rustupExe default stable
+        Update-SessionPath
+    }
+}
+
+# -- MSVC C++ build tools ------------------------------------------------
+# Validated live on a fresh Windows 11 box (2026-06-10): rustup's default
+# x86_64-pc-windows-msvc target CANNOT LINK without the Visual Studio C++
+# build tools -- `cargo build` dies with a wall of per-crate
+# `error: linking with link.exe failed: exit code: 1` and no guidance.
+# The windows-gnu toolchain is NOT a viable fallback for airc: windows-sys
+# raw-dylib import libs trip the upstream bundled-dlltool bug
+# (rust-lang/rust#103939) and `ring` needs a real C compiler regardless.
+# So: probe for the VC.Tools component via vswhere and auto-install the
+# (license-free) VS 2022 Build Tools with the C++ workload when absent.
+function Test-MsvcToolchain {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+    if (-not (Test-Path $vswhere)) { return $false }
+    $vsPath = & $vswhere -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>$null
+    return [bool]$vsPath
+}
+
+if (Test-MsvcToolchain) {
+    Write-Ok 'MSVC C++ build tools already installed'
+} else {
+    Write-Step 'Installing Visual Studio 2022 Build Tools + C++ workload (required to link Rust on Windows; ~2 GB, several minutes) ...'
+    $btArgs = @(
+        'install', '--id', 'Microsoft.VisualStudio.2022.BuildTools',
+        '--exact', '--silent',
+        '--accept-package-agreements', '--accept-source-agreements',
+        '--disable-interactivity',
+        '--override', '--quiet --wait --norestart --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended'
+    )
+    & winget @btArgs
+    if (Test-MsvcToolchain) {
+        Write-Ok 'MSVC C++ build tools installed'
+    } else {
+        # Most likely: VS/BuildTools product exists but lacks the C++
+        # workload, and winget won't modify an existing install. Send the
+        # user to the one place that fixes it instead of letting cargo
+        # produce the inscrutable link.exe wall.
+        Write-Fail 'MSVC C++ build tools still missing after install attempt.'
+        Write-Host '  Open "Visual Studio Installer" -> Modify -> check "Desktop development with C++" -> Install.'
+        Write-Host '  Then re-run this script. (Without it, cargo cannot link on Windows.)'
+        exit 1
+    }
+}
 
 
 Write-Host ''

--- a/install.ps1
+++ b/install.ps1
@@ -4,13 +4,23 @@
 # same channel persistence -- but bootstraps the Windows-native PS port
 # (airc.ps1) with auto-install of every prereq via winget.
 #
-# Designed for FIRST-TIME Windows users with NOTHING pre-installed.
+# DEV PATH ONLY (zero-friction doctrine, docs/ZERO-FRICTION-PATH.md):
+# users get prebuilt signed binaries and never see this script or a
+# compiler. This source-build path serves contributors, grid-node
+# operators on unreleased branches, and CI; it moves behind --dev once
+# the release pipeline lands.
+#
+# Designed for a FIRST-TIME dev box with NOTHING pre-installed.
 # Runs on the default Windows PowerShell 5.1 (ships with Windows 10+).
 # Installs:
 #   - Git              (clone + update)
-#   - Python 3         (envelope crypto, formatter, helpers)
 #   - GitHub CLI (gh)  (gist transport -- the room IS a private gist)
-#   - jq               (JSON wrangling for the bash scripts)
+#   - Rust (rustup)    (airc IS a Rust binary)
+#   - VS 2022 Build Tools C++ workload (MSVC linker; machine-scope, so
+#     an interactive non-admin session may see ONE OS UAC consent --
+#     winget flags suppress winget's own prompts, not UAC. Run elevated
+#     or be ready to click consent; non-interactive non-admin fails
+#     loudly with recovery guidance.)
 #
 # Post-Phase-3c: no OpenSSH server, no Tailscale, no sshd, no pwsh.
 # The substrate is gh + envelope encryption (X25519 + ChaCha20-Poly1305).
@@ -165,8 +175,8 @@ Write-Host ''
 Test-WingetAvailable
 
 # -- Install prereqs -----------------------------------------------------
-# Order matters lightly: git first so we can clone, then python for the
-# runtime helpers, then gh + jq for the substrate (gist transport).
+# Order matters lightly: git first so we can clone, then gh for the
+# substrate (gist transport), then the Rust toolchain to build airc.
 # pwsh (PowerShell 7+) is intentionally NOT installed -- airc.ps1 is a
 # thin bash shim that runs fine on the built-in PS 5.1, and dropping it
 # removes a 30+ second prereq install (and the visible UAC prompt).

--- a/install.sh
+++ b/install.sh
@@ -162,6 +162,69 @@ install_with_pkgmgr() {
 
 
 
+# Windows (Git Bash / MSYS / Cygwin): rustup's default target is
+# x86_64-pc-windows-msvc, which CANNOT LINK without the Visual Studio C++
+# build tools — `cargo build` dies with a per-crate wall of
+# `error: linking with link.exe failed: exit code: 1` and no guidance.
+# Validated live on a fresh Windows 11 box (2026-06-10). The windows-gnu
+# toolchain is NOT a viable fallback for airc: windows-sys raw-dylib
+# import libs hit the upstream bundled-dlltool bug (rust-lang/rust#103939)
+# and `ring` needs a real C compiler regardless. So when we're on Windows
+# with winget available, probe for the VC.Tools component via vswhere and
+# auto-install the (license-free) VS 2022 Build Tools C++ workload.
+_ensure_windows_msvc_toolchain() {
+  local mgr="$1"
+  case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*) ;;
+    *) return 0 ;;
+  esac
+
+  # %ProgramFiles(x86)% can't be read as a bash variable (parens are
+  # invalid in names) — ask cmd for it, fall back to the standard path.
+  local pf86
+  pf86=$(cmd //c 'echo %ProgramFiles(x86)%' 2>/dev/null | tr -d '\r')
+  [ -z "$pf86" ] || [ "$pf86" = '%ProgramFiles(x86)%' ] && pf86='C:\Program Files (x86)'
+  local vswhere
+  vswhere="$(_to_bash_path "$pf86")/Microsoft Visual Studio/Installer/vswhere.exe"
+  [ -x "$vswhere" ] || vswhere=""
+
+  if [ -n "$vswhere" ]; then
+    local vs_path
+    vs_path=$("$vswhere" -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>/dev/null || true)
+    if [ -n "$vs_path" ]; then
+      ok "MSVC C++ build tools already installed"
+      return 0
+    fi
+  fi
+
+  if [ "$mgr" != "winget" ]; then
+    warn "MSVC C++ build tools not found and winget unavailable — cargo cannot link on Windows without them."
+    warn "  Install 'Visual Studio 2022 Build Tools' with the 'Desktop development with C++' workload, then re-run."
+    return 0
+  fi
+
+  info "Installing Visual Studio 2022 Build Tools + C++ workload (required to link Rust on Windows; ~2 GB, several minutes)..."
+  local wbin; wbin=$(command -v winget.exe 2>/dev/null || command -v winget 2>/dev/null || true)
+  [ -z "$wbin" ] && return 0
+  "$wbin" install --id Microsoft.VisualStudio.2022.BuildTools --exact --silent \
+    --accept-source-agreements --accept-package-agreements --disable-interactivity \
+    --override "--quiet --wait --norestart --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended" \
+    || warn "winget BuildTools install returned non-zero; probing anyway"
+
+  # Re-probe: vswhere ships with Build Tools, so it exists now if the
+  # install worked even when it didn't exist before.
+  vswhere="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+  if [ -x "$vswhere" ] && [ -n "$("$vswhere" -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>/dev/null)" ]; then
+    ok "MSVC C++ build tools installed"
+  else
+    # Most likely: a VS/BuildTools product exists but lacks the C++
+    # workload, and winget won't modify an existing install.
+    fail "MSVC C++ build tools still missing after install attempt.
+       Open 'Visual Studio Installer' -> Modify -> check 'Desktop development with C++' -> Install.
+       Then re-run install.sh. (Without it, cargo cannot link on Windows.)"
+  fi
+}
+
 ensure_prereqs() {
   [ "${AIRC_SKIP_PREREQS:-0}" = "1" ] && { info "AIRC_SKIP_PREREQS=1 -- skipping prereq install"; return 0; }
 
@@ -265,6 +328,22 @@ ensure_prereqs() {
   else
     ok "All required prereqs present"
   fi
+
+  # Session PATH refresh after a winget rustup install. rustup-init puts
+  # %USERPROFILE%\.cargo\bin on the *registry* User PATH, but this Git
+  # Bash session inherited its PATH at launch — without this export the
+  # script auto-installs Rust and then immediately dies at
+  # _install_airc_binary's "cargo is required" probe. Caught live on a
+  # fresh Windows 11 box, 2026-06-10.
+  if ! command -v cargo >/dev/null 2>&1; then
+    if [ -x "$HOME/.cargo/bin/cargo" ] || [ -x "$HOME/.cargo/bin/cargo.exe" ]; then
+      export PATH="$HOME/.cargo/bin:$PATH"
+      ok "Added ~/.cargo/bin to this session's PATH (rustup install is brand-new)"
+    fi
+  fi
+
+  _ensure_windows_msvc_toolchain "$mgr"
+
   # Issue #341 follow-up: openssl/Python crypto bootstrap removed.
   # Identity gen + signing live in Rust, so system OpenSSL and Python
   # package state are irrelevant to airc install correctness.

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 #
-# AIRC installer
+# AIRC installer — DEV PATH ONLY (zero-friction doctrine,
+# docs/ZERO-FRICTION-PATH.md): users get prebuilt signed binaries and
+# never see this script or a compiler. This source-build path serves
+# contributors, grid operators on unreleased branches, and CI; it moves
+# behind --dev once the release pipeline lands.
 #
 # curl -fsSL https://raw.githubusercontent.com/CambrianTech/airc/main/install.sh | bash
 #
@@ -212,8 +216,10 @@ _ensure_windows_msvc_toolchain() {
     || warn "winget BuildTools install returned non-zero; probing anyway"
 
   # Re-probe: vswhere ships with Build Tools, so it exists now if the
-  # install worked even when it didn't exist before.
-  vswhere="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+  # install worked even when it didn't exist before. Reuse the resolved
+  # pf86 (not a hardcoded /c/...) so Cygwin (/cygdrive/c) and relocated
+  # ProgramFiles(x86) do not false-fail after a successful install.
+  vswhere="$(_to_bash_path "$pf86")/Microsoft Visual Studio/Installer/vswhere.exe"
   if [ -x "$vswhere" ] && [ -n "$("$vswhere" -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>/dev/null)" ]; then
     ok "MSVC C++ build tools installed"
   else


### PR DESCRIPTION
## Scope reframe per Joel's zero-friction doctrine (2026-06-11)

**This is the DEVELOPER bootstrap path, not the user path.** Users get prebuilt signed binaries and never see a compiler; the zero-friction P0 doctrine card owns that track. This PR fixes `install.sh`/`install.ps1` for the people who DO build from source: contributors, grid-node operators on unreleased branches, CI.

## Problem

Validated live on a fresh Windows 11 box (the 5090 grid node, 2026-06-10): both installers leave a from-source builder unable to build airc.

- `install.ps1` **doesn't install Rust at all** — if cargo is missing it hard-exits with "go install Rust yourself", breaking parity with `install.sh` which auto-installs Rustup on the winget path.
- **Neither installer handles the MSVC C++ toolchain.** rustup's default `x86_64-pc-windows-msvc` target cannot link without VS Build Tools; `cargo build` dies with a per-crate wall of `error: linking with link.exe failed: exit code: 1` and zero guidance.
- `install.sh` on Git Bash auto-installs Rustup and then **immediately dies at its own "cargo is required" probe**, because the session PATH predates the install (rustup-init only updates the registry User PATH).
- `install.ps1` still installs Python + jq, which `install.sh` dropped in #341 (Rust owns crypto/JSON/hooks now).

## Fix

- `install.ps1`: auto-install `Rustlang.Rustup` via winget (same `Install-IfMissing` pattern as the other prereqs) + `rustup default stable` repair when no default toolchain is set; probe for `Microsoft.VisualStudio.Component.VC.Tools.x86.x64` via vswhere and auto-install **VS 2022 Build Tools + VCTools workload** when absent, with a loud actionable failure if a VS product exists but lacks the workload (winget can't modify an existing install); drop Python + jq.
- `install.sh`: same vswhere probe + Build Tools auto-install on the winget branch; refresh session PATH with `~/.cargo/bin` after a fresh rustup install. `%ProgramFiles(x86)%` is resolved via `cmd //c` since parens are invalid in bash variable names.

Both winget paths are fully non-interactive (`--silent --accept-package-agreements --accept-source-agreements --disable-interactivity`, BuildTools `--override` with `--quiet --wait --norestart`) — validated unattended on the 5090.

## Not done / considered

- `windows-gnu` as a no-MSVC fallback is **not viable** for airc and is deliberately not encoded: `windows-sys` raw-dylib import libs hit the upstream bundled-dlltool bug (rust-lang/rust#103939, getrandom#723 — confirmed live on this box even with the self-contained dlltool on PATH), and `ring` needs a real C compiler regardless.
- Programmatic firewall rule for `lan-listen` needs elevation; per the outbound-only doctrine the **user** path must never need inbound rules, so that work moves to the transport design (card 625abe6d), not the installer.

## Testing

All on the live fresh box where the failures were originally hit:

1. The manual equivalent of each automated step was executed first and produced the working build (winget Rustup → link.exe wall → winget BuildTools+VCTools → clean MSVC build of `airc-cli` @ 48abb24, `airc join` works, daemon ipc v5).
2. Patched `install.sh` re-run end-to-end (env-isolated `AIRC_DIR`/`BIN_DIR`/`SKILLS_TARGET`, `AIRC_INSTALL_NO_PULL=1`): exit 0, working `airc.exe` built from this branch, all probes green.
3. Patched `install.ps1` re-run end-to-end (env-isolated `BIN_TARGET`/`SKILLS_TARGET`): exit 0, build + install + skills wiring green, MSVC probe correctly detects the installed toolchain.
4. `bash -n` + PSParser tokenize clean.

Fresh-box-without-MSVC retest of the *automated* path isn't reproducible on this box anymore (Build Tools now installed); the winget command the script runs is byte-identical to the one validated manually in step 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)