### PR TITLE
fix(scope): temp-rooted scopes never resolve the machine account (card b0a81c31)

### DIFF
--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -263,11 +263,18 @@ fn resolve_socket_path(
     // `machine_home == home`, two distinct cases:
     //   (a) `home` IS literally `$HOME/.airc` — already
     //       machine-singular; share.
-    //   (b) `home` is outside `$HOME` (CI temp dir, test root) —
-    //       isolated; use the per-project socket so parallel
-    //       isolated scopes don't collide.
+    //   (b) `home` is an isolated scope (CI temp dir, test root) —
+    //       use the per-project socket so parallel isolated scopes
+    //       don't collide.
+    // Case (a) must be an EQUALITY check, not "machine_home under
+    // user_home": on Windows `%TEMP%` lives under `%USERPROFILE%`, so
+    // the prefix form classified temp-rooted isolated scopes as
+    // machine-account scopes and resolved the PRODUCTION socket —
+    // `ensure_daemon_running`'s build-mismatch path then stopped the
+    // real daemon (bite 3 of card b0a81c31; flagged by the #1119
+    // sentinel).
     let is_machine_account_scope =
-        machine_home != home || path_starts_with(machine_home, user_home);
+        machine_home != home || user_home.map(|uh| machine_home == uh.join(".airc")) == Some(true);
     let legacy_fallback =
         machine_home.join(format!("daemon-v{}.sock", airc_ipc::IPC_PROTOCOL_VERSION));
     if is_machine_account_scope {
@@ -373,19 +380,6 @@ fn machine_account_key(path: &std::path::Path) -> String {
         s.push(HEX[(b & 0xf) as usize] as char);
     }
     s
-}
-
-/// `Path::starts_with` with canonicalization on both sides + a tolerant
-/// fallback when one side fails to canonicalize (test paths that don't
-/// exist yet). Used by [`resolve_socket_path`] to test "this scope is
-/// inside the OS user account."
-fn path_starts_with(path: &std::path::Path, base: Option<&std::path::Path>) -> bool {
-    let Some(base) = base else {
-        return false;
-    };
-    let normalized_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    let normalized_base = base.canonicalize().unwrap_or_else(|_| base.to_path_buf());
-    normalized_path.starts_with(&normalized_base)
 }
 
 /// AIRC substrate CLI.
@@ -896,6 +890,64 @@ mod tests {
             rendered.contains("airc-machine-"),
             "machine-account scopes must use the machine-singular \
              socket name 'airc-machine-<account-hash>-v<N>.sock', got: {rendered}"
+        );
+    }
+
+    /// Card b0a81c31 bite 3 (#1119 sentinel): on Windows, `%TEMP%`
+    /// lives UNDER `%USERPROFILE%`. The old clause classified any
+    /// `machine_home` under `user_home` as a machine-account scope, so
+    /// a temp-rooted `--home` (integration tests spawning the binary
+    /// without a HOME override) resolved the PRODUCTION machine socket
+    /// — and `ensure_daemon_running`'s build-mismatch path then stopped
+    /// the real daemon. Pure path math, so this pins the Windows shape
+    /// on every platform. With the b0a81c31 lib fix,
+    /// `machine_account_home(temp_scope)` returns the scope itself, and
+    /// this function must then treat it as ISOLATED (per-project
+    /// socket), never the machine-account socket.
+    #[test]
+    fn temp_rooted_scope_under_userprofile_never_resolves_the_machine_socket() {
+        use super::resolve_socket_path;
+        let user_home = std::path::PathBuf::from("/synthetic/userprofile");
+        let runtime_dir = std::path::PathBuf::from("/synthetic/runtime");
+        // Windows shape: the temp dir nests INSIDE the user home.
+        let temp_scope = user_home
+            .join("AppData/Local/Temp/.tmpAbC123")
+            .join("agent");
+        let project_socket = runtime_dir.join("airc-temp-scope-v0.sock");
+
+        let socket = resolve_socket_path(
+            &temp_scope,
+            // Post-fix lib behavior: temp-rooted scope is its own
+            // account boundary.
+            &temp_scope,
+            Some(user_home.as_path()),
+            Some(runtime_dir.as_path()),
+            None,
+            Some(project_socket.clone()),
+        );
+
+        assert_eq!(
+            socket, project_socket,
+            "a temp-rooted scope under the user profile must stay \
+             isolated (per-project socket); resolving the machine \
+             socket here is how integration tests reached — and \
+             stopped — the production daemon (card b0a81c31 bite 3)"
+        );
+        // And the literal machine home keeps sharing (case (a) of the
+        // clause this test tightened — equality, not prefix).
+        let machine_home = user_home.join(".airc");
+        let machine_socket = resolve_socket_path(
+            &machine_home,
+            &machine_home,
+            Some(user_home.as_path()),
+            Some(runtime_dir.as_path()),
+            None,
+            Some(project_socket.clone()),
+        );
+        assert!(
+            machine_socket.to_string_lossy().contains("airc-machine-"),
+            "literal $HOME/.airc must still resolve the machine-singular \
+             socket, got {machine_socket:?}"
         );
     }
 

--- a/crates/airc-cli/src/collaboration_commands.rs
+++ b/crates/airc-cli/src/collaboration_commands.rs
@@ -129,23 +129,24 @@ fn machine_account_home_for(scope_home: &Path) -> Option<std::path::PathBuf> {
     // guard the `starts_with($HOME)` check below pulls the REAL machine
     // registry into hermetic tempdir scopes (CI, tests) and real
     // enrolled peers leak into the count. Card b0a81c31; mirrors the
-    // same guard in `airc_lib::machine_account_home`.
+    // same guard in `airc_lib::machine_account_home`, including the
+    // PR #1119 sentinel carve-out: a HOME that is ITSELF temp-rooted is
+    // a test harness simulating a machine account — its temp scopes
+    // legitimately share it, so the guard must not fire.
+    let user_home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(std::path::PathBuf::from)?;
+    let canon_user_home = user_home.canonicalize().unwrap_or(user_home);
     let temp = std::env::temp_dir();
     let canon_temp = temp.canonicalize().unwrap_or(temp);
     let canon_scope_for_temp = scope_home
         .canonicalize()
         .unwrap_or_else(|_| scope_home.to_path_buf());
-    if canon_scope_for_temp.starts_with(&canon_temp) {
+    let home_is_temp_rooted = canon_user_home.starts_with(&canon_temp);
+    if !home_is_temp_rooted && canon_scope_for_temp.starts_with(&canon_temp) {
         return None;
     }
-
-    let user_home = std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .map(std::path::PathBuf::from)?;
-    let canon_user_home = user_home.canonicalize().unwrap_or(user_home);
-    let canon_scope = scope_home
-        .canonicalize()
-        .unwrap_or_else(|_| scope_home.to_path_buf());
+    let canon_scope = canon_scope_for_temp;
     if canon_scope.starts_with(&canon_user_home) {
         Some(canon_user_home.join(".airc"))
     } else {

--- a/crates/airc-cli/src/collaboration_commands.rs
+++ b/crates/airc-cli/src/collaboration_commands.rs
@@ -124,6 +124,21 @@ fn rust_peer_registry_paths(home: &Path) -> Vec<std::path::PathBuf> {
 /// state. Keeps `peer_record_count` hermetic in tests while still
 /// surfacing same-machine peers when the user actually runs `airc`.
 fn machine_account_home_for(scope_home: &Path) -> Option<std::path::PathBuf> {
+    // Temp-rooted scopes never resolve a machine-account home. On
+    // Windows `%TEMP%` lives INSIDE `%USERPROFILE%`, so without this
+    // guard the `starts_with($HOME)` check below pulls the REAL machine
+    // registry into hermetic tempdir scopes (CI, tests) and real
+    // enrolled peers leak into the count. Card b0a81c31; mirrors the
+    // same guard in `airc_lib::machine_account_home`.
+    let temp = std::env::temp_dir();
+    let canon_temp = temp.canonicalize().unwrap_or(temp);
+    let canon_scope_for_temp = scope_home
+        .canonicalize()
+        .unwrap_or_else(|_| scope_home.to_path_buf());
+    if canon_scope_for_temp.starts_with(&canon_temp) {
+        return None;
+    }
+
     let user_home = std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
         .map(std::path::PathBuf::from)?;

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -129,9 +129,13 @@ fn parse_peer_id(input: &str) -> Result<PeerId, Box<dyn std::error::Error>> {
 const WINDOWS_MAIN_STACK_BYTES: usize = 8 * 1024 * 1024;
 
 fn main() -> ExitCode {
+    // Clippy on Windows flags an early `return` here as unneeded — and
+    // it's right: with the cfg-split, each branch is the function's
+    // tail expression. (First caught by the first-ever Windows clippy
+    // run, on bigmama; the hosted clippy gate is ubuntu-only.)
     #[cfg(windows)]
     {
-        return match std::thread::Builder::new()
+        match std::thread::Builder::new()
             .name("airc-main".to_string())
             .stack_size(WINDOWS_MAIN_STACK_BYTES)
             .spawn(run_main)
@@ -147,7 +151,7 @@ fn main() -> ExitCode {
                 eprintln!("airc: failed to start main thread: {error}");
                 ExitCode::FAILURE
             }
-        };
+        }
     }
 
     #[cfg(not(windows))]

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -72,12 +72,29 @@ pub fn machine_account_home(scope_home: &Path) -> PathBuf {
     // `peer_record_count_requires_valid_json_files` started failing the
     // moment a real peer was enrolled on the machine, while virgin
     // boxes (and therefore CI) kept passing.
+    //
+    // Carve-out (sentinel on PR #1119): when HOME/USERPROFILE is ITSELF
+    // temp-rooted, a test harness is simulating a machine account by
+    // pointing the home at a TempDir (daemon_lifecycle does exactly
+    // this) — its scopes legitimately share that simulated account, so
+    // the temp guard must not fire. Real boxes never have a temp-rooted
+    // home, so the b0a81c31 fix is unaffected.
     let temp = std::env::temp_dir();
     let normalized_temp = temp.canonicalize().unwrap_or(temp);
     let normalized_scope_for_temp = scope_home
         .canonicalize()
         .unwrap_or_else(|_| scope_home.to_path_buf());
-    if normalized_scope_for_temp.starts_with(&normalized_temp) {
+    let home_var = std::env::var_os("HOME").map(PathBuf::from);
+    let profile_var = std::env::var_os("USERPROFILE").map(PathBuf::from);
+    let any_home_is_temp_rooted = [home_var.as_ref(), profile_var.as_ref()]
+        .into_iter()
+        .flatten()
+        .any(|h| {
+            h.canonicalize()
+                .unwrap_or_else(|_| h.clone())
+                .starts_with(&normalized_temp)
+        });
+    if !any_home_is_temp_rooted && normalized_scope_for_temp.starts_with(&normalized_temp) {
         return scope_home.to_path_buf();
     }
 

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -62,6 +62,25 @@ const LIVE_BROADCAST_CAPACITY: usize = 1024;
 /// outside `$HOME` (CI temp dirs, isolated test roots) get their own
 /// `scope_home` back — they are their own account boundary.
 pub fn machine_account_home(scope_home: &Path) -> PathBuf {
+    // Temp-rooted scopes are their own account boundary on EVERY
+    // platform. On Linux/macOS that falls out of `/tmp` living outside
+    // `$HOME`, but on Windows `%TEMP%` is
+    // `C:\Users\<user>\AppData\Local\Temp` — INSIDE `%USERPROFILE%` —
+    // so without this guard a tempdir scope (CI, hermetic tests)
+    // resolves to the REAL machine account and leaks real-world state.
+    // Caught live on the 5090 node (card b0a81c31):
+    // `peer_record_count_requires_valid_json_files` started failing the
+    // moment a real peer was enrolled on the machine, while virgin
+    // boxes (and therefore CI) kept passing.
+    let temp = std::env::temp_dir();
+    let normalized_temp = temp.canonicalize().unwrap_or(temp);
+    let normalized_scope_for_temp = scope_home
+        .canonicalize()
+        .unwrap_or_else(|_| scope_home.to_path_buf());
+    if normalized_scope_for_temp.starts_with(&normalized_temp) {
+        return scope_home.to_path_buf();
+    }
+
     if let Some(home) = std::env::var_os("HOME") {
         let home = PathBuf::from(home);
         let normalized_home = home.canonicalize().unwrap_or(home);
@@ -1521,5 +1540,19 @@ mod room_trust_policy_tests {
     #[test]
     fn wall_category_constant_is_stable() {
         assert_eq!(super::Airc::WALL_CATEGORY_TRUST_POLICY, "trust-policy");
+    }
+
+    /// Card b0a81c31: a temp-rooted scope must stay its own account
+    /// boundary on every platform. On Windows `%TEMP%` lives inside
+    /// `%USERPROFILE%`, so before the temp_dir guard this resolved to
+    /// the REAL machine account (`$USERPROFILE/.airc`) and leaked real
+    /// peer registries / daemon state into hermetic tests — failing
+    /// only on machines with actual enrolled peers, never in CI.
+    #[test]
+    fn machine_account_home_keeps_temp_scopes_isolated() {
+        let dir = tempfile::tempdir().unwrap();
+        let scope = dir.path().join("scope-home");
+        std::fs::create_dir(&scope).unwrap();
+        assert_eq!(super::machine_account_home(&scope), scope);
     }
 }


### PR DESCRIPTION
## The bug (card b0a81c31, P1)

On Windows, `%TEMP%` lives **inside** `%USERPROFILE%`. Both machine-account resolvers — `airc_lib::machine_account_home` and the `airc-cli` status probe's `machine_account_home_for` — decide "scope under the user's home → share the machine account" by prefix check, so every tempdir scope (CI, hermetic tests, `tempfile::TempDir`) resolves onto the **real** machine account and leaks real peer registries + daemon state into tests.

Found by the first native Windows `cargo test --workspace` ever run with real airc state on the box: `peer_record_count_requires_valid_json_files` counted 2 peers instead of 1 **because a real peer had been enrolled hours earlier**. Virgin boxes — and therefore hosted CI — pass, so the leak is invisible exactly where tests run. The self-hosted `bigmama` runner then independently reproduced it from a clean checkout on PR #1116's run (226/1), which is also why **this PR gates #1116** (and through it #1114).

The leak is not theoretical beyond the test failure: during tonight's test runs an un-hermetic integration test (pre-fix code) reached the real machine scope and **stopped the production daemon** on the grid node mid-session.

## The fix

Both resolvers now treat `std::env::temp_dir()`-rooted scopes as their own account boundary *before* any HOME/USERPROFILE prefix check — the behavior both functions' doc comments already promised, and the behavior Linux/macOS get naturally from `/tmp` living outside `$HOME`. Canonicalized comparison on both sides, mirroring the existing prefix logic.

Regression test `machine_account_home_keeps_temp_scopes_isolated` added in airc-lib next to the existing cli test that caught the bug.

## Testing (native Windows MSVC, the platform that exposes it)

- `airc-lib`: full crate green, `rc=0` — 195 unit + integration + doc-tests, regression test passes by name
- `airc-cli` bin unit tests: **227 passed / 0 failed** (+1 ignored) twice — the previously-failing test flips green with real peer state present on the box
- airc-blobs / airc-bus unit + integration: green
- **Known, unrelated, pre-existing failure class**: the daemon-touching airc-cli integration binaries (`codex_hook_commands`, `daemon_lifecycle`, `events_commands`, …) hang indefinitely — carded **d2ba719c (P0)**, confirmed cross-platform (fable reproduced the hang on macOS; their runs use `--skip codex_hook`). Those binaries have never completed on any platform's CI: hosted windows-latest was starved and default fail-fast stopped at THIS bug's unit failure first.

After merge: rerun the Windows leg on #1116 — `bigmama` should flip it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)