### PR TITLE
ci(rust): auto-cancel superseded runs per workflow+ref

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,16 @@ on:
       - "test/rust_quality_guard.sh"
       - ".github/workflows/rust.yml"
 
+# A new push to the same PR/branch obsoletes the in-flight run —
+# cancel it instead of queueing behind it. Three moot runs were
+# cancelled by hand on 2026-06-10 alone, and every moot run occupies
+# the single self-hosted Windows leg (bigmama) that everything else
+# queues behind. `github.ref` is unique per PR (refs/pull/N/merge) and
+# per branch, so unrelated runs never cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
The one-liner from Joel's queue (via fable's relay): `concurrency: group workflow+ref, cancel-in-progress` on rust.yml. A new push to the same PR/branch cancels the now-moot in-flight run instead of letting it occupy the single self-hosted Windows leg everything queues behind — three were hand-cancelled tonight. `github.ref` is per-PR/per-branch so unrelated runs never cancel each other. This PR's own superseding pushes (if review requires any) double as the live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)