### PR TITLE
fix(routes): enumerate non-dialable endpoint variants — no wildcard arm

### DIFF
--- a/crates/airc-lib/src/route/discovery.rs
+++ b/crates/airc-lib/src/route/discovery.rs
@@ -175,8 +175,17 @@ impl Airc {
                     // Relay/UDP/WebRTC/Reticulum dialing lands in later
                     // slices; recording them as failures here would be
                     // noise about unimplemented transports, not signal
-                    // about unreachable peers.
-                    _ => continue,
+                    // about unreachable peers. Variants enumerated, not
+                    // wildcarded, per the production no-silent-fallback
+                    // clippy gate: a FUTURE endpoint variant must force
+                    // this match to be revisited, not silently fall into
+                    // "skip" (the wildcard slipped past #1120's review
+                    // because the merge-push CI run was hand-cancelled —
+                    // caught by the #1121 sentinel).
+                    RouteEndpoint::Udp { .. }
+                    | RouteEndpoint::Relay { .. }
+                    | RouteEndpoint::Reticulum { .. }
+                    | RouteEndpoint::WebRtcSignaling { .. } => continue,
                 };
                 // #1120 sentinel blocking-2: connect_lan has no inner
                 // timeout, and a SYN-dropping firewall (the default


### PR DESCRIPTION
4-line lint fix unblocking #1121: the `_ => continue` in `dial_stored_peer_endpoints` (landed via #1120 with its merge-push run hand-cancelled before clippy finished) violates the production no-silent-fallback gate. Variants now enumerated so a future `RouteEndpoint` addition is a compile error here, not a silent skip. Validated locally with the byte-exact CI gate invocation (rc=0). After merge: re-run #1121's checks (its merge ref picks this up) and merge it per its sentinel APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)