### PR TITLE
feat(daemon): periodic route-discovery refresh — routes self-heal without operator action (625abe6d slice 2)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -22,6 +22,9 @@ use airc_protocol::{PeerKeyRegistry, VerificationPolicy, HEADER_AIRC_CLIENT};
 use futures::stream::StreamExt;
 
 use airc_daemon::{run as run_daemon_server, DaemonRuntimeInfo, DaemonState};
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
+};
 use airc_identity::LocalIdentity;
 use airc_ipc::{AddPeerRequest, DaemonClient, RemovePeerRequest, Request, Response};
 use airc_lib::{Airc, Headers, HeartbeatTask, PeerSpec, DEFAULT_HEARTBEAT_INTERVAL};
@@ -828,9 +831,101 @@ pub async fn run_daemon(
         identity.peer_id,
         socket.display()
     );
+    // Card 625abe6d slice 2: the daemon, not the operator, keeps
+    // routes alive. Spawn the periodic route-discovery refresh before
+    // the accept loop blocks; it exits on the same shutdown notifier.
+    let route_refresh_task = spawn_route_refresh(home.to_path_buf(), state.clone());
     run_daemon_server(state, socket).await?;
+    // The refresh loop exits on the shutdown `Notify` that ended the
+    // accept loop; abort is the backstop for the listener-error path,
+    // where Stop never fired (same abort discipline as
+    // `HeartbeatTask::stop`).
+    route_refresh_task.abort();
     println!("airc daemon: stopped.");
     Ok(())
+}
+
+/// Card 625abe6d slice 2 — daemon-resident continuous route
+/// discovery. `refresh_route_discovery` (slice 1) dials every
+/// enrolled peer's stored endpoints outbound; this task calls it on
+/// the daemon clock (`route_refresh::FIRST_REFRESH_DELAY` after
+/// start, then every `route_refresh::REFRESH_INTERVAL`) so stored-
+/// endpoint dials and route health are continuous — sleep/wake and
+/// daemon restarts re-establish routes with zero operator action,
+/// instead of waiting for someone to run `airc transport health`.
+///
+/// The `Airc` handle is opened lazily and then kept for the daemon's
+/// lifetime: LAN connections established by discovery dials live on
+/// the handle's adapter, so re-opening per tick would sever them on
+/// every refresh. Lazy-with-retry (rather than open-or-die at spawn)
+/// is the no-single-point-of-failure posture: a transient store
+/// failure at boot must neither take the IPC daemon down nor
+/// permanently disable route refresh — the open is retried, loudly,
+/// on every tick until it succeeds.
+fn spawn_route_refresh(home: PathBuf, state: Arc<DaemonState>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let handle: tokio::sync::Mutex<Option<Airc>> = tokio::sync::Mutex::new(None);
+        airc_daemon::route_refresh::run_periodic_refresh(&state.shutdown, || {
+            refresh_routes_once(&home, &handle)
+        })
+        .await;
+    })
+}
+
+/// One periodic route refresh: ensure the daemon's substrate handle
+/// is open, run discovery (which dials stored peer endpoints
+/// outbound, 3s-bounded each), and surface every failure through the
+/// daemon's diagnostic sink — loud, never silent. Failures never
+/// propagate: the loop's next tick is the retry path (self-heal
+/// doctrine, card 625abe6d).
+async fn refresh_routes_once(home: &Path, handle: &tokio::sync::Mutex<Option<Airc>>) {
+    let mut guard = handle.lock().await;
+    if guard.is_none() {
+        match Airc::open(home).await {
+            Ok(airc) => *guard = Some(airc),
+            Err(error) => {
+                StderrJsonDiagnosticSink.emit(
+                    DiagnosticEvent::error(
+                        DiagnosticComponent::Daemon,
+                        DiagnosticCode::RouteRefreshFailed,
+                        "route refresh could not open the substrate handle; retrying next interval",
+                    )
+                    .with_field("home", home.display())
+                    .with_field("error", error),
+                );
+                return;
+            }
+        }
+    }
+    let Some(airc) = guard.as_ref() else {
+        return;
+    };
+    match airc.refresh_route_discovery().await {
+        Ok(snapshot) => {
+            for failure in &snapshot.peer_dial_failures {
+                StderrJsonDiagnosticSink.emit(
+                    DiagnosticEvent::warn(
+                        DiagnosticComponent::Daemon,
+                        DiagnosticCode::PeerDialFailed,
+                        "stored peer endpoint did not answer a route-discovery dial",
+                    )
+                    .with_field("peer_id", failure.peer_id)
+                    .with_field("endpoint", format!("{:?}", failure.endpoint))
+                    .with_field("error", &failure.error),
+                );
+            }
+        }
+        Err(error) => {
+            StderrJsonDiagnosticSink.emit(
+                DiagnosticEvent::error(
+                    DiagnosticComponent::Daemon,
+                    DiagnosticCode::RouteRefreshFailed,
+                    "periodic route-discovery refresh failed; retrying next interval",
+                )
+                .with_field("error", error),
+            );
+        }
+    }
 }
 
 fn current_daemon_runtime_info() -> DaemonRuntimeInfo {

--- a/crates/airc-cli/tests/daemon_route_refresh.rs
+++ b/crates/airc-cli/tests/daemon_route_refresh.rs
@@ -1,0 +1,148 @@
+//! Card 625abe6d slice 2 — the DAEMON, not the operator, keeps routes
+//! alive.
+//!
+//! Slice 1 proved `refresh_route_discovery` dials stored peer
+//! endpoints outbound — when something calls it. This test pins the
+//! slice-2 contract: a freshly started daemon whose trust store
+//! carries a stored peer endpoint establishes the LAN connection on
+//! its own clock, WITHOUT anyone running `airc transport health` (or
+//! any other CLI verb). That is the sleep/wake + restart requirement:
+//! bring the daemon up, routes come back, zero operator action.
+//!
+//! Hazard notes (card d2ba719c): daemon-class tests can hang — every
+//! wait here is bounded, and the spawned daemon is killed on drop.
+
+use std::net::SocketAddr;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use airc_lib::{endpoints_to_json, Airc, PeerSpec, RouteEndpoint};
+use tempfile::TempDir;
+
+fn airc_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_airc")
+}
+
+/// Kill the daemon process on every exit path (success, assert
+/// failure, timeout panic) so a wedged daemon can't outlive the test.
+struct DaemonGuard {
+    child: Child,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn the real `airc daemon` for `home`. One retry for the
+/// Windows Smart App Control race on freshly built binaries
+/// (os error 4551) — environmental, not a product failure.
+fn spawn_daemon(home: &std::path::Path, socket: &std::path::Path) -> DaemonGuard {
+    let log_path = home.join("daemon-test.log");
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        let log = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .expect("daemon log file");
+        let stderr = log.try_clone().expect("clone log handle");
+        let spawned = Command::new(airc_bin())
+            .arg("--home")
+            .arg(home)
+            .arg("daemon")
+            .arg("--socket")
+            .arg(socket)
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(log))
+            .stderr(Stdio::from(stderr))
+            .spawn();
+        match spawned {
+            Ok(child) => return DaemonGuard { child },
+            Err(error) if attempt == 1 => {
+                // Smart App Control may block a just-linked binary
+                // once; retry after a beat.
+                eprintln!("daemon spawn attempt 1 failed ({error}); retrying once");
+                std::thread::sleep(Duration::from_millis(500));
+            }
+            Err(error) => panic!("daemon must spawn: {error}"),
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn daemon_dials_stored_endpoint_without_transport_health() {
+    // Outer bound: this entire test must finish or fail loudly —
+    // never hang (card d2ba719c).
+    tokio::time::timeout(Duration::from_secs(120), scenario())
+        .await
+        .expect("daemon route-refresh scenario must finish inside 120s");
+}
+
+async fn scenario() {
+    let tmp_alice = TempDir::new().expect("alice tempdir");
+    let tmp_bob = TempDir::new().expect("bob tempdir");
+    let alice_home = tmp_alice.path().join(".airc");
+    let bob_home = tmp_bob.path().join(".airc");
+
+    // Alice: an in-process listener — the peer bob's daemon must reach.
+    let alice = Airc::open(&alice_home).await.expect("alice open");
+    let alice_addr: SocketAddr = alice
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("alice listens");
+
+    // Bob: enrol mutual trust + store alice's endpoint on bob's trust
+    // record, exactly what the account-registry import produces. The
+    // in-process handle is then DROPPED — from here on, the only
+    // thing that can dial is bob's daemon process.
+    let bob_peer_id = {
+        let bob = Airc::open(&bob_home).await.expect("bob open");
+        let alice_spec: PeerSpec = alice.peer_spec().parse().expect("alice spec");
+        let bob_spec: PeerSpec = bob.peer_spec().parse().expect("bob spec");
+        alice.add_peer(bob_spec).await.expect("alice trusts bob");
+        bob.add_peer(alice_spec).await.expect("bob trusts alice");
+
+        let endpoints_json = endpoints_to_json(&[RouteEndpoint::LanTcp { addr: alice_addr }])
+            .expect("encode endpoints");
+        airc_trust::set_endpoints_json(bob.home(), alice.peer_id(), Some(endpoints_json))
+            .await
+            .expect("store endpoints")
+            .expect("alice must be enrolled on bob");
+        bob.peer_id()
+    };
+
+    // Bob's daemon comes up. Nothing else runs against it — no
+    // `transport health`, no `doctor`, no IPC client at all.
+    let socket = bob_home.join("daemon.sock");
+    let _daemon = spawn_daemon(&bob_home, &socket);
+
+    // The daemon's first refresh fires FIRST_REFRESH_DELAY (5s) after
+    // start; give it generous-but-bounded room. Observe from alice's
+    // side: her listener registers the inbound TLS connection keyed by
+    // bob's peer id. `route_discovery_snapshot` reads state without
+    // dialing, so alice can't be the one establishing the link.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let snapshot = alice
+            .route_discovery_snapshot()
+            .await
+            .expect("alice snapshot");
+        if snapshot.connected_lan_peers.contains(&bob_peer_id) {
+            break;
+        }
+        if Instant::now() >= deadline {
+            let log = std::fs::read_to_string(bob_home.join("daemon-test.log"))
+                .unwrap_or_else(|error| format!("<no daemon log: {error}>"));
+            panic!(
+                "bob's daemon never dialed alice's stored endpoint on its own \
+                 clock; connected: {:?}; daemon log:\n{log}",
+                snapshot.connected_lan_peers
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}

--- a/crates/airc-daemon/Cargo.toml
+++ b/crates/airc-daemon/Cargo.toml
@@ -43,3 +43,7 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "s
 # work-domain agnostic — payloads are opaque to the router.
 airc-work = { path = "../airc-work" }
 tempfile = "3"
+# `start_paused` time-control for the route_refresh scheduling tests
+# (card 625abe6d slice 2) — dev-only; the daemon itself runs on the
+# real clock.
+tokio = { version = "1", features = ["test-util"] }

--- a/crates/airc-daemon/src/lib.rs
+++ b/crates/airc-daemon/src/lib.rs
@@ -13,6 +13,9 @@
 //!   - `state` — shared daemon state ([`DaemonState`]).
 //!   - `handlers` — match arms for each `Request` variant.
 //!   - `trust_refresh` — durable peer-trust store -> live verifier sync.
+//!   - `route_refresh` — clock for the daemon-resident periodic route
+//!     discovery loop (card 625abe6d slice 2); the host supplies what
+//!     one refresh does.
 //!   - `airc-ipc` — wire-protocol types shared by daemon and clients.
 //!
 //! Adding a new operation:
@@ -30,6 +33,7 @@
 #![deny(unsafe_code)]
 
 pub mod handlers;
+pub mod route_refresh;
 pub mod server;
 pub mod state;
 pub mod trust_refresh;

--- a/crates/airc-daemon/src/route_refresh.rs
+++ b/crates/airc-daemon/src/route_refresh.rs
@@ -1,0 +1,266 @@
+//! Card 625abe6d slice 2 — daemon-resident periodic route refresh.
+//!
+//! Slice 1 taught `refresh_route_discovery` to dial every enrolled
+//! peer's stored endpoints outbound, but nothing invoked it except an
+//! operator running `airc transport health`. That fails the card's
+//! design constraints: route health-checks must be CONTINUOUS, and
+//! sleep/wake or a daemon restart must re-establish routes with zero
+//! operator action. This module is the daemon-side clock for that —
+//! it owns *when* a refresh runs; *what* one refresh does is supplied
+//! by the daemon host as a closure, because the concrete substrate
+//! handle lives in `airc-lib`, which this crate must not depend on
+//! (the CLI host wires the two together in `run_daemon`).
+//!
+//! Failure posture (self-heal doctrine): the loop never exits on a
+//! failed refresh — the closure reports failures loudly through the
+//! daemon's diagnostic sink and the clock keeps ticking. The only
+//! exit is the daemon's own shutdown notifier.
+
+use std::future::Future;
+use std::time::Duration;
+
+use tokio::sync::Notify;
+
+/// How long after daemon start the FIRST refresh runs.
+///
+/// Card 625abe6d: "sleep/wake + daemon restart re-establish routes
+/// with zero operator action." A restarted (or woken) daemon must
+/// come back onto the mesh in seconds, not wait out a full steady-
+/// state interval. 5s gives the IPC listener and trust import time
+/// to settle without competing with startup I/O, while staying well
+/// under human-noticeable downtime.
+pub const FIRST_REFRESH_DELAY: Duration = Duration::from_secs(5);
+
+/// Steady-state refresh cadence.
+///
+/// 60s bounds route-outage detection (and stored-endpoint redial) to
+/// about a minute — the same liveness granularity as the 60s agent
+/// heartbeat cadence. It also leaves wide headroom over the refresh's
+/// own worst case: each stored-endpoint dial is bounded at 3s
+/// (`PEER_DIAL_TIMEOUT`, slice 1) and dials run sequentially, so even
+/// a registry poisoned with a dozen tarpit endpoints (~36s) finishes
+/// inside one interval. Overruns still cannot pile up: the interval
+/// is measured from refresh COMPLETION to the next start (see
+/// [`run_periodic_refresh`]), never start-to-start.
+pub const REFRESH_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Pure scheduling rule: how long to wait before the next refresh,
+/// given how many refreshes have already completed.
+///
+/// Tick 0 (nothing completed yet) waits [`FIRST_REFRESH_DELAY`] so a
+/// restarted daemon re-establishes routes fast; every later tick
+/// waits the steady [`REFRESH_INTERVAL`].
+pub fn delay_before_refresh(completed_refreshes: u64) -> Duration {
+    if completed_refreshes == 0 {
+        FIRST_REFRESH_DELAY
+    } else {
+        REFRESH_INTERVAL
+    }
+}
+
+/// Drive `refresh` on the daemon clock until `shutdown` fires.
+///
+/// Pile-up guard: the refresh future is awaited IN this loop — the
+/// next delay only starts after the previous refresh completes, so
+/// two refreshes can never run concurrently by construction (a
+/// refresh involves up-to-3s-per-endpoint outbound dials; a timer
+/// that fired regardless of in-flight work would stack them).
+///
+/// Shutdown: one `Notified` future is created up front and kept
+/// pinned across iterations — the same discipline as `server::run`.
+/// The daemon's Stop handler signals with `notify_waiters()`, which
+/// wakes only waiters registered at that instant and stores no
+/// permit; re-creating `notified()` each turn would leave windows
+/// where the signal is lost and the loop never exits.
+pub async fn run_periodic_refresh<F, Fut>(shutdown: &Notify, mut refresh: F)
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let notified = shutdown.notified();
+    tokio::pin!(notified);
+
+    let mut completed: u64 = 0;
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut notified => return,
+            () = tokio::time::sleep(delay_before_refresh(completed)) => {}
+        }
+        tokio::select! {
+            biased;
+            _ = &mut notified => return,
+            () = refresh() => {
+                completed = completed.saturating_add(1);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::Notify;
+
+    use super::{
+        delay_before_refresh, run_periodic_refresh, FIRST_REFRESH_DELAY, REFRESH_INTERVAL,
+    };
+
+    /// Pin the scheduling rule: a fresh daemon refreshes fast (the
+    /// sleep/wake requirement), then settles into the steady cadence.
+    #[test]
+    fn first_refresh_is_fast_then_steady_interval() {
+        assert_eq!(delay_before_refresh(0), FIRST_REFRESH_DELAY);
+        assert_eq!(delay_before_refresh(1), REFRESH_INTERVAL);
+        assert_eq!(delay_before_refresh(1_000), REFRESH_INTERVAL);
+        assert!(
+            FIRST_REFRESH_DELAY < REFRESH_INTERVAL,
+            "the first refresh must run sooner than a steady-state tick, \
+             or a daemon restart waits out a full interval before \
+             re-establishing routes"
+        );
+    }
+
+    /// The first refresh fires after the warm-up delay, not after a
+    /// full steady-state interval — a restarted daemon must redial
+    /// stored endpoints in seconds.
+    #[tokio::test(start_paused = true)]
+    async fn first_refresh_fires_after_warmup_not_a_full_interval() {
+        let shutdown = Arc::new(Notify::new());
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let task = tokio::spawn({
+            let shutdown = shutdown.clone();
+            let count = count.clone();
+            async move {
+                run_periodic_refresh(&shutdown, move || {
+                    let count = count.clone();
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                    }
+                })
+                .await;
+            }
+        });
+
+        // Just before the warm-up boundary: nothing yet.
+        tokio::time::sleep(FIRST_REFRESH_DELAY - Duration::from_millis(1)).await;
+        assert_eq!(count.load(Ordering::SeqCst), 0, "no refresh before warm-up");
+
+        // Crossing it: exactly the first refresh.
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        assert_eq!(count.load(Ordering::SeqCst), 1, "first refresh at warm-up");
+
+        // Just before the first steady interval elapses: still one.
+        tokio::time::sleep(REFRESH_INTERVAL - Duration::from_millis(1)).await;
+        assert_eq!(count.load(Ordering::SeqCst), 1, "steady cadence respected");
+
+        // Crossing the steady interval: the second refresh.
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            2,
+            "second refresh on interval"
+        );
+
+        shutdown.notify_waiters();
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("loop must exit on shutdown")
+            .expect("loop task must not panic");
+    }
+
+    /// The pile-up guard: a refresh that takes LONGER than the
+    /// interval (worst-case dial walks) must delay the next tick, not
+    /// stack a second refresh on top of it.
+    #[tokio::test(start_paused = true)]
+    async fn refreshes_never_overlap_when_one_outlasts_the_interval() {
+        let shutdown = Arc::new(Notify::new());
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let completed = Arc::new(AtomicUsize::new(0));
+
+        let task = tokio::spawn({
+            let shutdown = shutdown.clone();
+            let in_flight = in_flight.clone();
+            let max_in_flight = max_in_flight.clone();
+            let completed = completed.clone();
+            async move {
+                run_periodic_refresh(&shutdown, move || {
+                    let in_flight = in_flight.clone();
+                    let max_in_flight = max_in_flight.clone();
+                    let completed = completed.clone();
+                    async move {
+                        let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_in_flight.fetch_max(now, Ordering::SeqCst);
+                        // A pathological refresh: 3x the interval.
+                        tokio::time::sleep(REFRESH_INTERVAL * 3).await;
+                        in_flight.fetch_sub(1, Ordering::SeqCst);
+                        completed.fetch_add(1, Ordering::SeqCst);
+                    }
+                })
+                .await;
+            }
+        });
+
+        // Enough simulated time for several full slow refreshes.
+        tokio::time::sleep(REFRESH_INTERVAL * 12).await;
+
+        assert!(
+            completed.load(Ordering::SeqCst) >= 2,
+            "the loop must keep refreshing despite slow refreshes"
+        );
+        assert_eq!(
+            max_in_flight.load(Ordering::SeqCst),
+            1,
+            "refreshes must never overlap — the next delay starts only \
+             after the previous refresh completes"
+        );
+
+        shutdown.notify_waiters();
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("loop must exit on shutdown")
+            .expect("loop task must not panic");
+    }
+
+    /// Shutdown mid-sleep exits the loop without waiting out the
+    /// delay — the daemon's Stop must not hang on the refresh clock.
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_stops_the_loop_mid_sleep() {
+        let shutdown = Arc::new(Notify::new());
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let task = tokio::spawn({
+            let shutdown = shutdown.clone();
+            let count = count.clone();
+            async move {
+                run_periodic_refresh(&shutdown, move || {
+                    let count = count.clone();
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                    }
+                })
+                .await;
+            }
+        });
+
+        // Mid warm-up delay: the loop is parked on its sleep with the
+        // pinned shutdown waiter registered.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        shutdown.notify_waiters();
+
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("loop must exit promptly on shutdown")
+            .expect("loop task must not panic");
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "no refresh ran before shutdown"
+        );
+    }
+}

--- a/crates/airc-diagnostics/src/lib.rs
+++ b/crates/airc-diagnostics/src/lib.rs
@@ -45,6 +45,14 @@ pub enum DiagnosticCode {
     ReplayFramesSkipped,
     WebRtcOfferAnswerFailed,
     WorkspaceLeaseViolation,
+    /// Card 625abe6d slice 2: the daemon's periodic route-discovery
+    /// refresh failed as a whole (substrate handle could not open, or
+    /// the refresh itself errored). The loop retries next interval.
+    RouteRefreshFailed,
+    /// Card 625abe6d slice 2: one stored peer endpoint did not answer
+    /// an outbound route-discovery dial. Offline peers are normal mesh
+    /// weather — but every failed dial attempt must be visible.
+    PeerDialFailed,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/airc-lib/src/diagnostic_event_sink.rs
+++ b/crates/airc-lib/src/diagnostic_event_sink.rs
@@ -189,6 +189,8 @@ fn code_header_value(code: DiagnosticCode) -> &'static str {
         DiagnosticCode::ReplayFramesSkipped => "replay_frames_skipped",
         DiagnosticCode::WebRtcOfferAnswerFailed => "webrtc_offer_answer_failed",
         DiagnosticCode::WorkspaceLeaseViolation => "workspace_lease_violation",
+        DiagnosticCode::RouteRefreshFailed => "route_refresh_failed",
+        DiagnosticCode::PeerDialFailed => "peer_dial_failed",
     }
 }
 
@@ -233,6 +235,8 @@ mod tests {
             DiagnosticCode::ReplayFramesSkipped,
             DiagnosticCode::WebRtcOfferAnswerFailed,
             DiagnosticCode::WorkspaceLeaseViolation,
+            DiagnosticCode::RouteRefreshFailed,
+            DiagnosticCode::PeerDialFailed,
         ] {
             let header = code_header_value(code);
             assert!(!header.is_empty(), "{code:?} should map to non-empty");


### PR DESCRIPTION
Routes slice 2, first leg: the daemon now re-runs route discovery on a cadence, so stored-endpoint dials and route health are continuous instead of happening only when someone runs `airc transport health`.

- New `crates/airc-daemon/src/route_refresh.rs`: the clock (`run_periodic_refresh`) — first refresh at 5s after daemon start (restart/wake re-establishes routes fast, per the self-heal requirement), then every 60s (doc-justified: minute-bounded outage detection, matches the agent-heartbeat cadence; a worst-case poisoned-registry dial walk ~36s fits inside one interval).
- Pile-up impossible by construction: the next delay starts only after the previous refresh completes (completion-to-start sequencing, not start-to-start timers).
- Shutdown discipline mirrors `server::run` (one pinned `Notified` waiter held across iterations) + post-exit abort backstop.
- The daemon's `Airc` handle is opened lazily in the loop and kept for the daemon's lifetime — dial-established LAN connections live on its adapter; reopening per tick would sever them. A failed open emits a diagnostic and retries next tick; it never kills the IPC daemon.
- Loud, never silent: new typed `DiagnosticCode::RouteRefreshFailed` + `DiagnosticCode::PeerDialFailed` (per-failure, with peer/endpoint/error) through the existing `StderrJsonDiagnosticSink` convention.

Validation (native Windows MSVC): route_refresh unit tests 4/4 (paused-time: first-at-5s, 60s cadence, no-overlap when refresh outlasts interval 3×, prompt shutdown mid-sleep); NEW integration test `daemon_dials_stored_endpoint_without_transport_health` 1/1 in 8.9s — a real spawned daemon with a stored endpoint brings up the LAN link with zero CLI invocations (whole scenario bounded 120s, daemon killed on drop per the d2ba719c hang hazard); slice-1 pin `stored_endpoint_dial` 4/4; fmt + clippy (incl. the production no-silent-fallback gate) clean.

Live relevance: this is the leg that makes tonight's 5090↔mac route survive daemon restarts and sleep/wake without anyone touching a CLI — verified manually on this box when the machine-account store was rebuilt mid-incident and the route re-established itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)