### PR TITLE
feat(persona): PersonaCapabilities + persona-spawn worked example (cards 9e5f8844, 98bf179b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,6 +2206,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "persona-spawn-smoke"
+version = "0.1.0"
+dependencies = [
+ "airc-core",
+ "airc-lib",
+ "airc-trust",
+ "consumer-shapes",
+ "futures",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "pgvector"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/airc-cli",
     "crates/examples/embedded_consumer_smoke",
     "crates/examples/consumer_shapes",
+    "crates/examples/persona_spawn_smoke",
 ]
 resolver = "2"
 

--- a/crates/airc-core/src/lib.rs
+++ b/crates/airc-core/src/lib.rs
@@ -12,6 +12,7 @@
 //!
 //! - [`ids`]        — newtype wrappers for identifier strings
 //! - [`identity`]   — the per-peer Identity card (the user/account abstraction)
+//! - [`persona`]    — typed persona capability metadata on Identity.integrations
 //! - [`body`]       — opaque payload (Json | Binary) consumers carry
 //! - [`transcript`] — TranscriptEvent + TranscriptKind + MentionTarget
 //! - [`cursor`]     — cursor + paging primitives for transcript fetch
@@ -35,6 +36,7 @@ pub mod headers;
 pub mod humanhash;
 pub mod identity;
 pub mod ids;
+pub mod persona;
 pub mod receipt;
 pub mod transcript;
 
@@ -51,5 +53,6 @@ pub use headers::{HeaderFilter, Headers};
 pub use humanhash::{humanhash, HumanhashError};
 pub use identity::Identity;
 pub use ids::{ClientId, ContentHash, EventId, FileId, PeerId, RoomId};
+pub use persona::{PersonaCapabilities, PersonaCapabilitiesError, PERSONA_CAPABILITIES_KEY};
 pub use receipt::{Receipt, ReceiptKind};
 pub use transcript::{MentionTarget, TranscriptEvent, TranscriptKind};

--- a/crates/airc-core/src/persona.rs
+++ b/crates/airc-core/src/persona.rs
@@ -1,0 +1,261 @@
+//! Typed persona capability metadata carried via `Identity.integrations`.
+//!
+//! Card 9e5f8844 (persona-peer 1/8). A Continuum persona running as an
+//! AIRC peer advertises WHAT it is (persona id, capability tags, model,
+//! context window) on the existing [`Identity`] card rather than via a
+//! new subsystem: the `integrations` map is the consumer-keyed slot the
+//! substrate already persists and transports without interpreting (see
+//! [`Identity::integrations`]). This module owns the ONE key Continuum
+//! uses ([`PERSONA_CAPABILITIES_KEY`]) and the typed encode/decode so
+//! every consumer reads the same shape instead of hand-parsing JSON
+//! out of the map.
+//!
+//! Loud-failure doctrine: a present-but-undecodable value is an error
+//! surfaced to the caller ([`PersonaCapabilitiesError::Decode`]), never
+//! a silent `None` — a corrupt capability advert mis-read as "no
+//! capabilities" would route persona turns to a peer that can't take
+//! them, invisibly. Absent key is the honest `Ok(None)`.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::identity::Identity;
+
+/// The `Identity.integrations` key under which a persona peer's
+/// capability metadata is stored. Versioned so a future incompatible
+/// shape gets a NEW key (`continuum.persona.v2`) instead of silently
+/// changing what `v1` decodes to.
+pub const PERSONA_CAPABILITIES_KEY: &str = "continuum.persona.v1";
+
+/// What a persona peer advertises about itself on its identity card.
+///
+/// Stored JSON-encoded under [`PERSONA_CAPABILITIES_KEY`] in
+/// [`Identity::integrations`]; read back with
+/// [`PersonaCapabilities::read_from_identity`]. The substrate carries
+/// it opaquely — only persona-aware consumers (Continuum's spawn loop,
+/// manager-hat routing) decode it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersonaCapabilities {
+    /// Continuum persona id this peer embodies (e.g. "skylar").
+    pub persona_id: String,
+    /// Free-form capability tags the routing layer matches on
+    /// (e.g. "code", "render", "long-context"). Default empty —
+    /// a persona with no advertised tags is still a valid persona.
+    #[serde(default)]
+    pub capability_tags: Vec<String>,
+    /// Model identifier backing this persona (e.g. "fable-5").
+    pub model: String,
+    /// Context window of the backing model, in tokens. Routing uses
+    /// this to keep oversized activities off undersized personas.
+    pub context_window_tokens: u32,
+}
+
+/// Loud-failure errors for the typed integrations accessor.
+#[derive(Debug)]
+pub enum PersonaCapabilitiesError {
+    /// Serializing the capabilities to JSON failed (pathological —
+    /// the struct is plain data — but never swallowed).
+    Encode(serde_json::Error),
+    /// The key was PRESENT but its value did not decode as
+    /// [`PersonaCapabilities`]. Carries the raw value so the operator
+    /// sees what was actually stored, not just "it broke".
+    Decode {
+        /// The undecodable raw value found under the key.
+        raw: String,
+        /// The underlying JSON error.
+        source: serde_json::Error,
+    },
+}
+
+impl fmt::Display for PersonaCapabilitiesError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Encode(source) => {
+                write!(f, "persona capabilities failed to encode: {source}")
+            }
+            Self::Decode { raw, source } => write!(
+                f,
+                "persona capabilities under {PERSONA_CAPABILITIES_KEY:?} \
+                 failed to decode: {source}; raw value: {raw:?}",
+            ),
+        }
+    }
+}
+
+impl Error for PersonaCapabilitiesError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Encode(source) | Self::Decode { source, .. } => Some(source),
+        }
+    }
+}
+
+impl PersonaCapabilities {
+    /// Write these capabilities into an integrations map under
+    /// [`PERSONA_CAPABILITIES_KEY`], replacing any prior value.
+    pub fn write_to_integrations(
+        &self,
+        integrations: &mut BTreeMap<String, String>,
+    ) -> Result<(), PersonaCapabilitiesError> {
+        let encoded = serde_json::to_string(self).map_err(PersonaCapabilitiesError::Encode)?;
+        integrations.insert(PERSONA_CAPABILITIES_KEY.to_string(), encoded);
+        Ok(())
+    }
+
+    /// Typed read from an integrations map.
+    ///
+    /// - Key absent → `Ok(None)` — this peer advertises no persona.
+    /// - Key present and valid → `Ok(Some(capabilities))`.
+    /// - Key present but undecodable → `Err(Decode { .. })`, loudly.
+    pub fn read_from_integrations(
+        integrations: &BTreeMap<String, String>,
+    ) -> Result<Option<Self>, PersonaCapabilitiesError> {
+        let Some(raw) = integrations.get(PERSONA_CAPABILITIES_KEY) else {
+            return Ok(None);
+        };
+        serde_json::from_str(raw)
+            .map(Some)
+            .map_err(|source| PersonaCapabilitiesError::Decode {
+                raw: raw.clone(),
+                source,
+            })
+    }
+
+    /// Convenience: write onto an [`Identity`] card's integrations map.
+    pub fn write_to_identity(
+        &self,
+        identity: &mut Identity,
+    ) -> Result<(), PersonaCapabilitiesError> {
+        self.write_to_integrations(&mut identity.integrations)
+    }
+
+    /// Convenience: typed read off an [`Identity`] card. Same
+    /// absent/valid/corrupt contract as
+    /// [`Self::read_from_integrations`].
+    pub fn read_from_identity(
+        identity: &Identity,
+    ) -> Result<Option<Self>, PersonaCapabilitiesError> {
+        Self::read_from_integrations(&identity.integrations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> PersonaCapabilities {
+        PersonaCapabilities {
+            persona_id: "skylar".to_string(),
+            capability_tags: vec!["code".to_string(), "long-context".to_string()],
+            model: "fable-5".to_string(),
+            context_window_tokens: 200_000,
+        }
+    }
+
+    #[test]
+    fn roundtrips_through_identity_integrations() {
+        let mut identity = Identity::new("skylar-peer");
+        sample()
+            .write_to_identity(&mut identity)
+            .expect("write capabilities");
+
+        // The value rides the existing consumer-keyed map — no new
+        // Identity field, so every store/wire path that already
+        // carries `integrations` carries this too.
+        assert!(identity.integrations.contains_key(PERSONA_CAPABILITIES_KEY));
+
+        let read = PersonaCapabilities::read_from_identity(&identity)
+            .expect("decode must succeed")
+            .expect("capabilities must be present");
+        assert_eq!(read, sample());
+    }
+
+    #[test]
+    fn write_replaces_prior_value() {
+        let mut integrations = BTreeMap::new();
+        sample()
+            .write_to_integrations(&mut integrations)
+            .expect("first write");
+        let updated = PersonaCapabilities {
+            model: "fable-6".to_string(),
+            ..sample()
+        };
+        updated
+            .write_to_integrations(&mut integrations)
+            .expect("second write");
+
+        let read = PersonaCapabilities::read_from_integrations(&integrations)
+            .expect("decode")
+            .expect("present");
+        assert_eq!(read.model, "fable-6", "latest write must win");
+        assert_eq!(integrations.len(), 1, "one key, replaced in place");
+    }
+
+    #[test]
+    fn absent_key_reads_as_none_not_error() {
+        let identity = Identity::new("no-persona-here");
+        let read = PersonaCapabilities::read_from_identity(&identity).expect("absent key is Ok");
+        assert!(read.is_none(), "absent key must be the honest None");
+    }
+
+    #[test]
+    fn corrupt_value_surfaces_decode_error_loudly() {
+        let mut integrations = BTreeMap::new();
+        integrations.insert(
+            PERSONA_CAPABILITIES_KEY.to_string(),
+            "{not valid json".to_string(),
+        );
+        let err = PersonaCapabilities::read_from_integrations(&integrations)
+            .expect_err("corrupt value must NOT read as None");
+        match &err {
+            PersonaCapabilitiesError::Decode { raw, .. } => {
+                assert_eq!(raw, "{not valid json", "error must carry the raw value");
+            }
+            PersonaCapabilitiesError::Encode(_) => {
+                panic!("corrupt stored value is a Decode error, not Encode")
+            }
+        }
+        // The Display rendering names the key and the raw value so the
+        // failure is actionable from a log line alone.
+        let rendered = err.to_string();
+        assert!(rendered.contains(PERSONA_CAPABILITIES_KEY));
+        assert!(rendered.contains("{not valid json"));
+    }
+
+    #[test]
+    fn wrong_shape_json_is_also_a_loud_decode_error() {
+        // Valid JSON, wrong shape (missing required fields) — the
+        // typed accessor must refuse, not fill in defaults silently.
+        let mut integrations = BTreeMap::new();
+        integrations.insert(
+            PERSONA_CAPABILITIES_KEY.to_string(),
+            r#"{"persona_id":"skylar"}"#.to_string(),
+        );
+        let result = PersonaCapabilities::read_from_integrations(&integrations);
+        assert!(
+            matches!(result, Err(PersonaCapabilitiesError::Decode { .. })),
+            "missing required fields must surface as Decode, got {result:?}",
+        );
+    }
+
+    #[test]
+    fn capability_tags_default_empty_for_forward_compat() {
+        // A v1 writer that omits `capability_tags` still decodes — the
+        // field is the one shape-evolution slot with a safe default.
+        let mut integrations = BTreeMap::new();
+        integrations.insert(
+            PERSONA_CAPABILITIES_KEY.to_string(),
+            r#"{"persona_id":"skylar","model":"fable-5","context_window_tokens":200000}"#
+                .to_string(),
+        );
+        let read = PersonaCapabilities::read_from_integrations(&integrations)
+            .expect("decode")
+            .expect("present");
+        assert!(read.capability_tags.is_empty());
+        assert_eq!(read.persona_id, "skylar");
+        assert_eq!(read.context_window_tokens, 200_000);
+    }
+}

--- a/crates/examples/persona_spawn_smoke/Cargo.toml
+++ b/crates/examples/persona_spawn_smoke/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "persona-spawn-smoke"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+description = "Worked example: the Continuum persona-spawn loop over AIRC. A spawned persona peer opens its own home, advertises PersonaCapabilities on its identity card, enrols its parent at OwnMachine tier, joins the persona room, and answers TurnRequested with TurnEmitted. NOT product code; reference example + integration proof only."
+
+[lints]
+workspace = true
+
+[dependencies]
+# The persona agent consumes airc-lib like any embedder, plus the two
+# typed vocabularies it speaks: airc-core for the PersonaCapabilities
+# identity contract (card 9e5f8844) and consumer-shapes for the
+# Continuum PersonaEvent wire shapes. airc-trust is the substrate's
+# public trust-store API — the spawn loop pins its parent at
+# OwnMachine tier through it, same surface the CLI uses.
+airc-core = { path = "../../airc-core" }
+airc-lib = { path = "../../airc-lib" }
+airc-trust = { path = "../../airc-trust" }
+consumer-shapes = { path = "../consumer_shapes" }
+futures = "0.3"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["test-util", "macros", "rt-multi-thread", "time"] }

--- a/crates/examples/persona_spawn_smoke/src/lib.rs
+++ b/crates/examples/persona_spawn_smoke/src/lib.rs
@@ -1,0 +1,24 @@
+//! Persona-spawn worked example (card 98bf179b — persona-peer 2/8).
+//!
+//! Proves the Continuum persona-spawn loop end to end on public AIRC
+//! surfaces only:
+//!
+//! 1. a parent process spawns a persona with `AIRC_HOME` +
+//!    `AIRC_PARENT_PEER_SPEC` in the environment;
+//! 2. the persona `Airc::open`s its own home (its own PeerId +
+//!    identity.key — personas are real peers, not sub-identities);
+//! 3. it advertises [`airc_core::PersonaCapabilities`] on its identity
+//!    card via the card-9e5f8844 typed accessor;
+//! 4. it enrols the parent and pins it at `TrustTier::OwnMachine`
+//!    through `airc_trust::set_tier` (the spawn relationship IS the
+//!    same-machine relationship);
+//! 5. it joins the persona room and answers `TurnRequested` events
+//!    with `TurnEmitted` — the Continuum turn loop.
+//!
+//! Pattern sibling of `embedded_consumer_smoke::agent`: the runtime
+//! surface lives in [`persona_agent`], the binary (`src/main.rs`)
+//! is just env-wiring around it, and the integration test proves the
+//! loop with two real `Airc` handles in tempdirs over loopback
+//! LAN-TCP (the `stored_endpoint_dial.rs` style).
+
+pub mod persona_agent;

--- a/crates/examples/persona_spawn_smoke/src/main.rs
+++ b/crates/examples/persona_spawn_smoke/src/main.rs
@@ -1,0 +1,66 @@
+//! Spawned-persona binary (card 98bf179b — persona-peer 2/8).
+//!
+//! What a parent's spawn loop launches: reads `AIRC_HOME` +
+//! `AIRC_PARENT_PEER_SPEC` (+ optional `AIRC_PERSONA_ROOM`,
+//! `AIRC_PERSONA_ID`, `AIRC_PARENT_LAN_ADDR`) from the environment,
+//! stands up the persona peer, prints its own peer spec on stdout so
+//! the parent can enrol it, then serves `TurnRequested` →
+//! `TurnEmitted` until the subscription closes.
+//!
+//! Run by hand against a listening parent:
+//!
+//! ```text
+//! AIRC_HOME=/tmp/persona/.airc \
+//! AIRC_PARENT_PEER_SPEC=<parent peer_spec> \
+//! AIRC_PARENT_LAN_ADDR=127.0.0.1:<parent lan port> \
+//! persona-spawn-smoke
+//! ```
+
+use std::error::Error;
+use std::time::Duration;
+
+use persona_spawn_smoke::persona_agent::{PersonaAgent, PersonaAgentConfig};
+
+/// One serve_next_turn wait slice. The loop continues across idle
+/// slices; only a closed subscription stream ends the process, so an
+/// idle persona keeps serving (Ok(None) from a timeout just re-arms).
+const TURN_WAIT: Duration = Duration::from_secs(30);
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let config = PersonaAgentConfig::from_env()?;
+    let room = config.room.clone();
+    let parent_lan_addr = config.parent_lan_addr;
+
+    let mut agent = PersonaAgent::spawn(config).await?;
+
+    // The parent enrols us from this line — the child side of the
+    // spawn handshake (parents read the spawned process's stdout).
+    println!("persona-peer-spec {}", agent.peer_spec());
+    println!(
+        "persona-ready persona_id={} room={} parent={}",
+        agent.capabilities().persona_id,
+        room,
+        agent.parent_peer_id(),
+    );
+
+    if let Some(addr) = parent_lan_addr {
+        agent.connect_parent_lan(addr).await?;
+        println!("persona-route lan {addr}");
+    }
+
+    loop {
+        match agent.serve_next_turn(TURN_WAIT).await? {
+            Some(emitted) => println!(
+                "persona-turn-emitted activity={} turn={} chars={}",
+                emitted.activity_id,
+                emitted.turn_id,
+                emitted.text.len(),
+            ),
+            // Idle slice — keep serving. A closed subscription is a
+            // loud `SubscriptionClosed` error from serve_next_turn,
+            // so this loop never spins on a dead stream.
+            None => continue,
+        }
+    }
+}

--- a/crates/examples/persona_spawn_smoke/src/persona_agent.rs
+++ b/crates/examples/persona_spawn_smoke/src/persona_agent.rs
@@ -1,0 +1,375 @@
+//! The spawned-persona runtime surface.
+//!
+//! Mirrors `embedded_consumer_smoke::agent`: deliberately tiny
+//! product-adjacent code modeling what a Continuum persona process
+//! needs from AIRC. Everything here rides public surfaces — `airc-lib`
+//! for the peer handle, `airc-core` for the PersonaCapabilities
+//! identity contract (card 9e5f8844), `airc-trust` for the
+//! parent-tier pin, `consumer-shapes` for the PersonaEvent codec.
+
+use std::error::Error;
+use std::fmt;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
+
+use airc_core::{Identity, PeerId, PersonaCapabilities, PersonaCapabilitiesError};
+use airc_lib::{Airc, AircError, FilteredEventStream, PeerSpec};
+use airc_trust::{PeersStoreError, TrustTier};
+use consumer_shapes::continuum::{
+    any_persona_event_filter, decode_persona_event, encode_persona_event, PersonaCodecError,
+    PersonaEvent, TurnEmitted, TurnRequested,
+};
+use futures::StreamExt;
+
+/// Where the persona's own identity home lives. Always REQUIRED — a
+/// persona is a real peer with its own PeerId + identity.key, never a
+/// sub-identity inside the parent's home.
+pub const ENV_AIRC_HOME: &str = "AIRC_HOME";
+/// The parent's `peer_id:pubkey` spec (the `Airc::peer_spec` string).
+/// REQUIRED — the spawn relationship is the trust bootstrap.
+pub const ENV_PARENT_PEER_SPEC: &str = "AIRC_PARENT_PEER_SPEC";
+/// Room the persona serves turns in. Optional; defaults to
+/// [`DEFAULT_PERSONA_ROOM`].
+pub const ENV_PERSONA_ROOM: &str = "AIRC_PERSONA_ROOM";
+/// Optional loopback/LAN address of the parent's listener. When set,
+/// the binary dials it after spawn so turn traffic has a route
+/// (in-process tests wire the link themselves).
+pub const ENV_PARENT_LAN_ADDR: &str = "AIRC_PARENT_LAN_ADDR";
+/// Optional persona id override for the capability advert.
+pub const ENV_PERSONA_ID: &str = "AIRC_PERSONA_ID";
+
+pub const DEFAULT_PERSONA_ROOM: &str = "persona-smoke";
+pub const DEFAULT_PERSONA_ID: &str = "persona-smoke-echo";
+
+/// Everything the spawn loop hands a persona process.
+#[derive(Debug, Clone)]
+pub struct PersonaAgentConfig {
+    /// Identity home for THIS persona (own PeerId + identity.key).
+    pub home: PathBuf,
+    /// Parent's `peer_id:pubkey` spec string.
+    pub parent_spec: String,
+    /// Room to join and serve turns in.
+    pub room: String,
+    /// What this persona advertises on its identity card.
+    pub capabilities: PersonaCapabilities,
+    /// Parent LAN listener to dial after spawn, when the route isn't
+    /// provided some other way (daemon, stored endpoints, relay).
+    pub parent_lan_addr: Option<SocketAddr>,
+}
+
+impl PersonaAgentConfig {
+    /// Build the config a spawned persona process reads from its
+    /// environment. `AIRC_HOME` and `AIRC_PARENT_PEER_SPEC` are
+    /// required; missing values fail loudly with the variable name.
+    pub fn from_env() -> Result<Self, PersonaAgentError> {
+        let home = require_env(ENV_AIRC_HOME)?;
+        let parent_spec = require_env(ENV_PARENT_PEER_SPEC)?;
+        let room = optional_env(ENV_PERSONA_ROOM).unwrap_or_else(|| DEFAULT_PERSONA_ROOM.into());
+        let persona_id = optional_env(ENV_PERSONA_ID).unwrap_or_else(|| DEFAULT_PERSONA_ID.into());
+        let parent_lan_addr = match optional_env(ENV_PARENT_LAN_ADDR) {
+            Some(raw) => Some(raw.parse().map_err(|source| PersonaAgentError::BadEnv {
+                name: ENV_PARENT_LAN_ADDR,
+                raw: raw.clone(),
+                detail: format!("{source}"),
+            })?),
+            None => None,
+        };
+        Ok(Self {
+            home: PathBuf::from(home),
+            parent_spec,
+            room,
+            capabilities: PersonaCapabilities {
+                persona_id,
+                capability_tags: vec!["echo".to_string(), "smoke".to_string()],
+                model: "example-echo".to_string(),
+                context_window_tokens: 8_192,
+            },
+            parent_lan_addr,
+        })
+    }
+}
+
+fn require_env(name: &'static str) -> Result<String, PersonaAgentError> {
+    optional_env(name).ok_or(PersonaAgentError::MissingEnv { name })
+}
+
+fn optional_env(name: &'static str) -> Option<String> {
+    match std::env::var(name) {
+        Ok(value) if value.is_empty() => None,
+        Ok(value) => Some(value),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(std::env::VarError::NotUnicode(_)) => None,
+    }
+}
+
+/// Loud-failure error surface for the persona agent. Every step of
+/// the spawn loop that can fail names what failed; nothing degrades
+/// silently (airc is the agent's umbilical — see AGENTS doctrine).
+#[derive(Debug)]
+pub enum PersonaAgentError {
+    /// A required environment variable was missing or empty.
+    MissingEnv { name: &'static str },
+    /// An environment variable was present but unparseable.
+    BadEnv {
+        name: &'static str,
+        raw: String,
+        detail: String,
+    },
+    /// Any airc-lib operation (open, add_peer, join, send, subscribe).
+    Airc(AircError),
+    /// The PersonaCapabilities identity write/read failed.
+    Capabilities(PersonaCapabilitiesError),
+    /// A persona event failed to encode/decode. The subscription
+    /// filter admits only `forge.persona.event.v1` bodies, so a
+    /// decode failure here means a malformed event — surfaced, never
+    /// skipped silently.
+    Codec(PersonaCodecError),
+    /// The trust-store tier pin failed at the store layer.
+    Trust(PeersStoreError),
+    /// `airc_trust::set_tier` reported the parent is not enrolled —
+    /// a structural bug in the spawn sequence (enrol precedes pin).
+    ParentNotEnrolled { parent: PeerId },
+    /// System clock predates the Unix epoch.
+    Clock(SystemTimeError),
+    /// The live subscription lagged and dropped events.
+    Lag(String),
+    /// The live subscription ended — the persona's umbilical is gone.
+    /// Loud by doctrine: a persona that can no longer hear turn
+    /// requests must say so, not idle silently.
+    SubscriptionClosed,
+}
+
+impl fmt::Display for PersonaAgentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingEnv { name } => {
+                write!(f, "required environment variable {name} is missing")
+            }
+            Self::BadEnv { name, raw, detail } => {
+                write!(
+                    f,
+                    "environment variable {name}={raw:?} is invalid: {detail}"
+                )
+            }
+            Self::Airc(source) => write!(f, "airc operation failed: {source}"),
+            Self::Capabilities(source) => {
+                write!(f, "persona capabilities identity write failed: {source}")
+            }
+            Self::Codec(source) => write!(f, "persona event codec failed: {source}"),
+            Self::Trust(source) => write!(f, "parent tier pin failed: {source}"),
+            Self::ParentNotEnrolled { parent } => write!(
+                f,
+                "parent {parent} is not enrolled in the trust store; \
+                 enrolment must precede the tier pin",
+            ),
+            Self::Clock(source) => write!(f, "system clock error: {source}"),
+            Self::Lag(detail) => write!(f, "live subscription lagged: {detail}"),
+            Self::SubscriptionClosed => f.write_str("live persona-event subscription closed"),
+        }
+    }
+}
+
+impl Error for PersonaAgentError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Airc(source) => Some(source),
+            Self::Capabilities(source) => Some(source),
+            Self::Codec(source) => Some(source),
+            Self::Trust(source) => Some(source),
+            Self::Clock(source) => Some(source),
+            Self::MissingEnv { .. }
+            | Self::BadEnv { .. }
+            | Self::ParentNotEnrolled { .. }
+            | Self::Lag(_)
+            | Self::SubscriptionClosed => None,
+        }
+    }
+}
+
+impl From<AircError> for PersonaAgentError {
+    fn from(source: AircError) -> Self {
+        Self::Airc(source)
+    }
+}
+
+impl From<PersonaCapabilitiesError> for PersonaAgentError {
+    fn from(source: PersonaCapabilitiesError) -> Self {
+        Self::Capabilities(source)
+    }
+}
+
+impl From<PersonaCodecError> for PersonaAgentError {
+    fn from(source: PersonaCodecError) -> Self {
+        Self::Codec(source)
+    }
+}
+
+impl From<PeersStoreError> for PersonaAgentError {
+    fn from(source: PeersStoreError) -> Self {
+        Self::Trust(source)
+    }
+}
+
+impl From<SystemTimeError> for PersonaAgentError {
+    fn from(source: SystemTimeError) -> Self {
+        Self::Clock(source)
+    }
+}
+
+/// A live spawned persona: its own `Airc` peer, capabilities
+/// advertised, parent pinned at OwnMachine, room joined, persona-event
+/// subscription installed and ready to serve turns.
+pub struct PersonaAgent {
+    airc: Airc,
+    capabilities: PersonaCapabilities,
+    parent: PeerId,
+    inbox: FilteredEventStream,
+}
+
+impl PersonaAgent {
+    /// Run the spawn sequence (steps 2–5 of the loop; see crate docs):
+    /// open own home → advertise capabilities on the identity card →
+    /// enrol parent → pin parent at `OwnMachine` → join the room →
+    /// subscribe to persona events.
+    ///
+    /// The subscription is installed BEFORE `spawn` returns, so a
+    /// parent may send `TurnRequested` as soon as it has a route to
+    /// us — no race against a later subscribe.
+    pub async fn spawn(config: PersonaAgentConfig) -> Result<Self, PersonaAgentError> {
+        let airc = Airc::open(&config.home).await?;
+
+        // Capabilities ride the EXISTING integrations map on the
+        // identity card (card 9e5f8844) — no parallel persona registry.
+        airc.set_local_identity_card(advertised_identity(&config.capabilities)?)
+            .await?;
+
+        // Trust bootstrap: enrol the parent's pinned key, then raise
+        // it to OwnMachine — the spawn relationship is definitionally
+        // the same-machine relationship (airc-trust tier doctrine).
+        let parent_spec: PeerSpec = config.parent_spec.parse().map_err(AircError::from)?;
+        let parent = parent_spec.peer_id;
+        airc.add_peer(parent_spec).await?;
+        let pinned = airc_trust::set_tier(airc.home(), parent, TrustTier::OwnMachine).await?;
+        if pinned.is_none() {
+            return Err(PersonaAgentError::ParentNotEnrolled { parent });
+        }
+
+        airc.join(&config.room).await?;
+        let inbox = airc.subscribe_filtered(any_persona_event_filter()).await?;
+
+        Ok(Self {
+            airc,
+            capabilities: config.capabilities,
+            parent,
+            inbox,
+        })
+    }
+
+    pub fn airc(&self) -> &Airc {
+        &self.airc
+    }
+
+    /// This persona's own `peer_id:pubkey` spec — what it reports back
+    /// to the parent so the parent can enrol it in turn.
+    pub fn peer_spec(&self) -> String {
+        self.airc.peer_spec()
+    }
+
+    pub fn capabilities(&self) -> &PersonaCapabilities {
+        &self.capabilities
+    }
+
+    pub fn parent_peer_id(&self) -> PeerId {
+        self.parent
+    }
+
+    /// The identity card this persona advertises, capabilities
+    /// included — what the parent reads back through the roster.
+    pub fn identity_card(&self) -> Result<Identity, PersonaAgentError> {
+        advertised_identity(&self.capabilities)
+    }
+
+    /// Dial the parent's LAN listener so turn traffic has a route.
+    /// The substrate refuses to publish without an admissible
+    /// cross-machine route, so a freshly spawned persona either dials
+    /// (this), inherits stored endpoints, or attaches to a daemon.
+    pub async fn connect_parent_lan(&self, addr: SocketAddr) -> Result<(), PersonaAgentError> {
+        self.airc.connect_lan(addr, self.parent).await?;
+        Ok(())
+    }
+
+    /// Serve one turn: wait (up to `timeout`) for a `TurnRequested`
+    /// addressed at this persona's room, reply with `TurnEmitted`
+    /// echoing the prompt, and return the reply that was sent.
+    ///
+    /// Returns `Ok(None)` when the deadline passes without a turn
+    /// request (idle is normal weather). Malformed persona events,
+    /// stream lag, and a closed subscription are loud errors, never
+    /// skipped — the subscription IS this persona's umbilical.
+    pub async fn serve_next_turn(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<Option<TurnEmitted>, PersonaAgentError> {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return Ok(None);
+            }
+            let remaining = deadline.saturating_duration_since(now);
+            let event = match tokio::time::timeout(remaining, self.inbox.next()).await {
+                Ok(Some(Ok(event))) => event,
+                Ok(Some(Err(lag))) => return Err(PersonaAgentError::Lag(lag.to_string())),
+                Ok(None) => return Err(PersonaAgentError::SubscriptionClosed),
+                Err(_elapsed) => return Ok(None),
+            };
+            // Self-echo: our own TurnEmitted replies match the filter.
+            if event.peer_id == self.airc.peer_id() && event.client_id == self.airc.client_id() {
+                continue;
+            }
+            let decoded = decode_persona_event(&event.headers, event.body.as_ref())?;
+            let request = match decoded {
+                PersonaEvent::TurnRequested(request) => request,
+                PersonaEvent::TurnEmitted(_)
+                | PersonaEvent::ActivityStarted(_)
+                | PersonaEvent::ActivityEnded(_) => continue,
+            };
+            let reply = self.reply_to_turn(&request).await?;
+            return Ok(Some(reply));
+        }
+    }
+
+    /// Build + publish the `TurnEmitted` answer for one request.
+    async fn reply_to_turn(
+        &self,
+        request: &TurnRequested,
+    ) -> Result<TurnEmitted, PersonaAgentError> {
+        let emitted = TurnEmitted {
+            persona_id: self.capabilities.persona_id.clone(),
+            activity_id: request.activity_id.clone(),
+            turn_id: request.turn_id.clone(),
+            text: format!("echo: {}", request.prompt),
+            emitted_at_ms: now_ms()?,
+        };
+        let (headers, body) = encode_persona_event(&PersonaEvent::TurnEmitted(emitted.clone()))?;
+        self.airc.send(body, headers).await?;
+        Ok(emitted)
+    }
+}
+
+/// The identity card a persona with these capabilities advertises:
+/// nick = persona id, role tag, capabilities on the integrations map.
+fn advertised_identity(capabilities: &PersonaCapabilities) -> Result<Identity, PersonaAgentError> {
+    let mut identity = Identity::new(capabilities.persona_id.clone());
+    identity.role = "continuum-persona".to_string();
+    capabilities.write_to_identity(&mut identity)?;
+    Ok(identity)
+}
+
+/// Wall-clock milliseconds since the Unix epoch, surfacing clock
+/// errors instead of panicking.
+pub fn now_ms() -> Result<u64, PersonaAgentError> {
+    let elapsed = SystemTime::now().duration_since(UNIX_EPOCH)?;
+    Ok(u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX))
+}

--- a/crates/examples/persona_spawn_smoke/tests/persona_spawn_loop.rs
+++ b/crates/examples/persona_spawn_smoke/tests/persona_spawn_loop.rs
@@ -1,0 +1,198 @@
+//! Card 98bf179b — the persona-spawn loop, proven end to end.
+//!
+//! Two real `Airc` handles in tempdirs (the `stored_endpoint_dial.rs`
+//! style): a PARENT that requests a turn and a spawned PERSONA that
+//! serves it. The persona side runs through `PersonaAgent::spawn` —
+//! the same code path the `persona-spawn-smoke` binary wires from the
+//! environment — so the test proves the worked example, not a
+//! parallel implementation.
+//!
+//! Loop contract proven here:
+//!   - the persona opens its OWN home (own PeerId/identity.key),
+//!     advertises `PersonaCapabilities` on its identity card via the
+//!     card-9e5f8844 typed accessor, enrols the parent, and pins it
+//!     at `TrustTier::OwnMachine`;
+//!   - parent sends `TurnRequested`; persona answers `TurnEmitted`
+//!     with the same activity/turn ids; parent receives it over a
+//!     real loopback LAN-TCP route.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use airc_core::PersonaCapabilities;
+use airc_lib::{Airc, PeerSpec};
+use airc_trust::TrustTier;
+use consumer_shapes::continuum::{
+    any_persona_event_filter, decode_persona_event, encode_persona_event, PersonaEvent,
+    TurnRequested,
+};
+use futures::StreamExt;
+use persona_spawn_smoke::persona_agent::{now_ms, PersonaAgent, PersonaAgentConfig};
+use tempfile::TempDir;
+
+fn smoke_capabilities() -> PersonaCapabilities {
+    PersonaCapabilities {
+        persona_id: "skylar-smoke".to_string(),
+        capability_tags: vec!["echo".to_string(), "smoke".to_string()],
+        model: "example-echo".to_string(),
+        context_window_tokens: 8_192,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parent_requests_turn_and_spawned_persona_replies() {
+    let room = "persona-smoke";
+    let parent_tmp = TempDir::new().expect("parent tempdir");
+    let persona_tmp = TempDir::new().expect("persona tempdir");
+
+    // Parent peer: joins the persona room and listens on loopback so
+    // the spawned persona has something to dial.
+    let parent = Airc::open(parent_tmp.path().join(".airc"))
+        .await
+        .expect("parent open");
+    parent.join(room).await.expect("parent joins room");
+    let parent_addr: SocketAddr = parent
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("parent listens");
+
+    // Spawn the persona through the worked-example surface — exactly
+    // what the binary does with AIRC_HOME + AIRC_PARENT_PEER_SPEC.
+    let config = PersonaAgentConfig {
+        home: persona_tmp.path().join(".airc"),
+        parent_spec: parent.peer_spec(),
+        room: room.to_string(),
+        capabilities: smoke_capabilities(),
+        parent_lan_addr: Some(parent_addr),
+    };
+    let mut persona = PersonaAgent::spawn(config).await.expect("persona spawn");
+
+    // The persona's identity card carries the typed capabilities on
+    // the EXISTING integrations map (card 9e5f8844) — decode it back
+    // through the loud typed accessor.
+    let card = persona.identity_card().expect("persona identity card");
+    let advertised = PersonaCapabilities::read_from_identity(&card)
+        .expect("capabilities decode must not fail")
+        .expect("capabilities must be present on a persona identity");
+    assert_eq!(advertised, smoke_capabilities());
+
+    // Spawn handshake, parent side: the parent enrols the persona's
+    // reported spec (the binary prints it on stdout for this).
+    let persona_spec: PeerSpec = persona.peer_spec().parse().expect("persona spec");
+    parent
+        .add_peer(persona_spec)
+        .await
+        .expect("parent enrols persona");
+
+    // The persona pinned its parent at OwnMachine during spawn — the
+    // spawn relationship IS the same-machine relationship.
+    let parent_record = airc_trust::load(persona.airc().home())
+        .await
+        .expect("read persona trust store")
+        .into_iter()
+        .find(|peer| peer.peer_id == persona.parent_peer_id())
+        .expect("parent must be enrolled on the persona");
+    assert_eq!(parent_record.tier, TrustTier::OwnMachine);
+
+    // Route: persona dials the parent's loopback listener (what the
+    // binary does when AIRC_PARENT_LAN_ADDR is set).
+    persona
+        .connect_parent_lan(parent_addr)
+        .await
+        .expect("persona dials parent");
+
+    // The inbound link registers on the parent's adapter a beat after
+    // the persona's connect resolves — wait for it before sending, the
+    // same way a production spawn loop waits for the child to dial in.
+    let link_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let snapshot = parent
+            .route_discovery_snapshot()
+            .await
+            .expect("parent route snapshot");
+        if snapshot
+            .connected_lan_peers
+            .contains(&persona.airc().peer_id())
+        {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < link_deadline,
+            "persona's inbound LAN link never registered on the parent; \
+             connected: {:?}",
+            snapshot.connected_lan_peers,
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // Parent subscribes for persona events BEFORE requesting the turn
+    // so the reply cannot race the subscription.
+    let mut parent_events = parent
+        .subscribe_filtered(any_persona_event_filter())
+        .await
+        .expect("parent subscribes");
+
+    let request = TurnRequested {
+        persona_id: "skylar-smoke".to_string(),
+        activity_id: "activity-1".to_string(),
+        turn_id: "turn-1".to_string(),
+        prompt: "what's the meta-goal?".to_string(),
+        requested_at_ms: now_ms().expect("clock"),
+    };
+    let (headers, body) =
+        encode_persona_event(&PersonaEvent::TurnRequested(request.clone())).expect("encode");
+    parent
+        .send(body, headers)
+        .await
+        .expect("parent sends TurnRequested");
+
+    // Persona side: serve exactly one turn. The subscription was
+    // installed during spawn, so the request is already buffered even
+    // though we only poll now.
+    let served = persona
+        .serve_next_turn(Duration::from_secs(10))
+        .await
+        .expect("persona turn loop must not error")
+        .expect("persona must see the TurnRequested within the deadline");
+    assert_eq!(served.persona_id, "skylar-smoke");
+    assert_eq!(served.activity_id, request.activity_id);
+    assert_eq!(served.turn_id, request.turn_id);
+    assert_eq!(served.text, "echo: what's the meta-goal?");
+
+    // Parent side: the TurnEmitted arrives over the wire, decodes
+    // through the shared codec, and correlates by activity/turn id.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let received = loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        assert!(
+            remaining > Duration::ZERO,
+            "parent never received TurnEmitted within the deadline"
+        );
+        let event = tokio::time::timeout(remaining, parent_events.next())
+            .await
+            .expect("parent subscription stalled past the deadline")
+            .expect("parent subscription closed before the reply")
+            .expect("parent subscription lagged");
+        // Skip the parent's own TurnRequested echo.
+        if event.peer_id == parent.peer_id() && event.client_id == parent.client_id() {
+            continue;
+        }
+        let decoded =
+            decode_persona_event(&event.headers, event.body.as_ref()).expect("decode reply");
+        match decoded {
+            PersonaEvent::TurnEmitted(emitted) => break emitted,
+            PersonaEvent::TurnRequested(_)
+            | PersonaEvent::ActivityStarted(_)
+            | PersonaEvent::ActivityEnded(_) => continue,
+        }
+    };
+
+    assert_eq!(received.persona_id, "skylar-smoke");
+    assert_eq!(received.activity_id, request.activity_id);
+    assert_eq!(received.turn_id, request.turn_id);
+    assert_eq!(received.text, "echo: what's the meta-goal?");
+    assert_eq!(
+        received, served,
+        "the reply the parent received must be byte-for-byte the one the persona sent",
+    );
+}


### PR DESCRIPTION
Persona-as-peer foundation, slices 1/8 + 2/8 of the architecture (room-crit window closed unanswered; design per the 2026-06-11 sketch: every persona is a first-class cryptographic peer — own PeerId, own Ed25519 keypair, independently rotatable — not bridge metadata).

**Card 9e5f8844 — `airc_core::persona::PersonaCapabilities`** (`f65e966`): typed capability metadata (persona_id, capability_tags, model, context_window_tokens) riding the existing `Identity.integrations` map under versioned key `continuum.persona.v1`. Corrupt stored value = loud `Decode` error carrying the raw value (no silent None); absent key = `Ok(None)`. 6 unit tests incl. corrupt/wrong-shape/forward-compat.

**Card 98bf179b — `persona_spawn_smoke` worked example** (`3ea8e7b`): the Continuum spawn loop, proven end-to-end. Env contract (`AIRC_HOME`, `AIRC_PARENT_PEER_SPEC`, `AIRC_PERSONA_ROOM`), `Airc::open` mints the persona's own identity, capability advert via card-1 helpers, parent enrolment at `OwnMachine` with loud `ParentNotEnrolled`, room join, TurnRequested→TurnEmitted over the proven consumer-shapes codec. Integration test: two handles in tempdirs, parent requests a turn, spawned persona replies — 0.96s, every wait deadline-bounded (d2ba719c hang doctrine).

This is the seam continuum's runtime consumes for Joel's headline (personas on the 5090 joining the grid as teammates): spawn subprocess with the env contract → persona is on the mesh. Next slices: correlation_id/deadline turn-as-request-reply (3/8), capability registry (4/8), cross-grid inference (8/8, P0).

Validation (native Windows MSVC): fmt clean; clippy workspace clean; production no-silent-fallback gate clean; airc-core 60/0; spawn-loop test 1/1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)