### PR TITLE
feat(persona): turns as command-bus request/reply — correlation+deadline (card ee2a339f, 3/8)

### DIFF
--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -82,7 +82,10 @@ pub use agent_heartbeat::{
     DEFAULT_HEARTBEAT_INTERVAL, HEADER_HEARTBEAT_KIND, HEADER_HEARTBEAT_RUNTIME,
 };
 pub use airc::{machine_account_home, Airc};
-pub use airc_protocol::{AssertionError, IdentityAssertion};
+pub use airc_protocol::{
+    AssertionError, IdentityAssertion, HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_DEADLINE,
+    HEADER_AIRC_REPLY_TO,
+};
 pub use command_bus::PendingCommand;
 pub use coordinator::{
     account_root as coordinator_account_root, beacon_now,

--- a/crates/examples/consumer_shapes/Cargo.toml
+++ b/crates/examples/consumer_shapes/Cargo.toml
@@ -13,10 +13,10 @@ workspace = true
 airc-lib = { path = "../../airc-lib" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 futures = "0.3"
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
-uuid = { version = "1", features = ["v4"] }

--- a/crates/examples/consumer_shapes/src/continuum.rs
+++ b/crates/examples/consumer_shapes/src/continuum.rs
@@ -14,10 +14,26 @@
 //!   - `forge.persona.id`    — the persona that emitted the event
 //!   - `forge.continuum.activity_id` — scoping activity, when applicable
 //!   - `forge.continuum.turn_id`     — per-turn id, when applicable
+//!   - `forge.persona.model_hint`    — optional model preference on a
+//!     `TurnRequested`, when set
+//!
+//! Command-bus carriage (card ee2a339f): `TurnRequested` /
+//! `TurnEmitted` double as the request/reply pair of
+//! [`airc_lib::command_bus`]. The substrate stamps its own
+//! `airc.correlation_id` / `airc.reply_to` / `airc.deadline` headers
+//! on the request (via [`Airc::request`]); the persona-side responder
+//! reads them back through [`turn_reply_address`] and echoes the
+//! correlation via [`reply_turn_emitted`] so the requester's
+//! [`Airc::await_reply`] resolves with the `TurnEmitted` event.
 
-use airc_lib::{Body, EventFilter, HeaderFilter, Headers};
+use airc_lib::{
+    Airc, AircError, Body, EventFilter, HeaderFilter, Headers, MentionTarget, PeerId,
+    PendingCommand, HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_DEADLINE, HEADER_AIRC_REPLY_TO,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashSet};
+use std::time::Duration;
+use uuid::Uuid;
 
 pub const BODY_HINT_FORGE_PERSONA_EVENT: &str = "forge.persona.event.v1";
 
@@ -25,6 +41,10 @@ pub const HEADER_FORGE_PERSONA_KIND: &str = "forge.persona.kind";
 pub const HEADER_FORGE_PERSONA_ID: &str = "forge.persona.id";
 pub const HEADER_FORGE_CONTINUUM_ACTIVITY_ID: &str = "forge.continuum.activity_id";
 pub const HEADER_FORGE_CONTINUUM_TURN_ID: &str = "forge.continuum.turn_id";
+/// Optional model preference projected off a [`TurnRequested`] so
+/// schedulers can route a turn to a capable persona host without
+/// decoding the body. Consumer-owned `forge.persona.*` namespace.
+pub const HEADER_FORGE_PERSONA_MODEL_HINT: &str = "forge.persona.model_hint";
 
 const HEADER_FORGE_BODY_HINT: &str = "forge.body_hint";
 
@@ -51,6 +71,12 @@ pub struct TurnRequested {
     pub activity_id: String,
     pub turn_id: String,
     pub prompt: String,
+    /// Optional model preference (adapter / checkpoint label) the
+    /// requester wants the persona runtime to honor. Additive +
+    /// optional so pre-existing encoded bodies still decode.
+    /// Projected to `forge.persona.model_hint` when set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_hint: Option<String>,
     pub requested_at_ms: u64,
 }
 
@@ -108,6 +134,13 @@ impl PersonaEvent {
         }
     }
 
+    pub fn model_hint(&self) -> Option<&str> {
+        match self {
+            Self::TurnRequested(e) => e.model_hint.as_deref(),
+            Self::TurnEmitted(_) | Self::ActivityStarted(_) | Self::ActivityEnded(_) => None,
+        }
+    }
+
     fn variant_kind(&self) -> &'static str {
         match self {
             Self::TurnRequested(_) => "turn_requested",
@@ -126,6 +159,17 @@ pub enum PersonaCodecError {
         actual: Option<String>,
         expected: &'static str,
     },
+    /// A command-bus header required for the turn request/reply pairing
+    /// is absent (the request did not travel via [`Airc::request`]).
+    MissingHeader {
+        header: &'static str,
+    },
+    /// A command-bus header is present but does not parse (correlation /
+    /// reply-to must be UUIDs; deadline must be decimal epoch-ms).
+    MalformedHeader {
+        header: &'static str,
+        value: String,
+    },
     Json(serde_json::Error),
 }
 
@@ -138,6 +182,15 @@ impl std::fmt::Display for PersonaCodecError {
                 f,
                 "persona event body hint mismatch: actual={actual:?}, expected={expected:?}",
             ),
+            Self::MissingHeader { header } => {
+                write!(f, "persona turn request missing required header {header:?}")
+            }
+            Self::MalformedHeader { header, value } => {
+                write!(
+                    f,
+                    "persona turn request header {header:?} malformed: {value:?}"
+                )
+            }
             Self::Json(error) => write!(f, "persona event JSON codec failed: {error}"),
         }
     }
@@ -178,6 +231,12 @@ pub fn encode_persona_event(event: &PersonaEvent) -> Result<(Headers, Body), Per
             turn_id.to_string(),
         );
     }
+    if let Some(model_hint) = event.model_hint() {
+        headers.insert(
+            HEADER_FORGE_PERSONA_MODEL_HINT.to_string(),
+            model_hint.to_string(),
+        );
+    }
     let body = Body::Json(serde_json::to_value(event)?);
     Ok((headers, body))
 }
@@ -200,6 +259,153 @@ pub fn decode_persona_event(
         return Err(PersonaCodecError::NonJsonBody);
     };
     Ok(serde_json::from_value(value.clone())?)
+}
+
+// ---------------------------------------------------------------------------
+// Command-bus carriage — card ee2a339f (persona-peer 3/8)
+// ---------------------------------------------------------------------------
+//
+// The header names below are NOT a parallel vocabulary: they are the
+// exact `airc.correlation_id` / `airc.reply_to` / `airc.deadline`
+// constants the command bus itself stamps (re-exported by airc-lib
+// from airc-protocol's `headers_keys`). The persona contract only
+// reads them back; generic correlation plumbing stays in
+// `airc_lib::command_bus`.
+
+/// Command-bus addressing read off a [`TurnRequested`] request event.
+///
+/// [`Airc::request`] stamps `airc.correlation_id`, `airc.reply_to`,
+/// and `airc.deadline` on the outgoing event; the persona-side
+/// responder recovers them through this typed view to reply.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnReplyAddress {
+    /// Pairs the reply with the in-flight request
+    /// (`airc.correlation_id`). [`Airc::await_reply`] resolves only
+    /// when the reply echoes this exact value.
+    pub correlation_id: Uuid,
+    /// Requester peer the reply is directed at (`airc.reply_to`).
+    pub reply_to: PeerId,
+    /// Requester-stamped wall-clock deadline (`airc.deadline`,
+    /// epoch-ms). Responders may drop turns whose deadline already
+    /// passed instead of doing dead work.
+    pub deadline_at_ms: Option<u64>,
+}
+
+/// Read the command-bus reply address off a request event's headers.
+/// Errors loudly when the correlation/reply-to pairing is absent or
+/// malformed — a turn request that cannot be replied to is a bug, not
+/// a silently droppable event.
+pub fn turn_reply_address(headers: &Headers) -> Result<TurnReplyAddress, PersonaCodecError> {
+    let correlation =
+        headers
+            .get(HEADER_AIRC_CORRELATION_ID)
+            .ok_or(PersonaCodecError::MissingHeader {
+                header: HEADER_AIRC_CORRELATION_ID,
+            })?;
+    let correlation_id =
+        Uuid::parse_str(correlation).map_err(|_| PersonaCodecError::MalformedHeader {
+            header: HEADER_AIRC_CORRELATION_ID,
+            value: correlation.clone(),
+        })?;
+    let reply_to_raw =
+        headers
+            .get(HEADER_AIRC_REPLY_TO)
+            .ok_or(PersonaCodecError::MissingHeader {
+                header: HEADER_AIRC_REPLY_TO,
+            })?;
+    let reply_to = Uuid::parse_str(reply_to_raw)
+        .map(PeerId::from_uuid)
+        .map_err(|_| PersonaCodecError::MalformedHeader {
+            header: HEADER_AIRC_REPLY_TO,
+            value: reply_to_raw.clone(),
+        })?;
+    let deadline_at_ms = match headers.get(HEADER_AIRC_DEADLINE) {
+        Some(raw) => Some(
+            raw.parse::<u64>()
+                .map_err(|_| PersonaCodecError::MalformedHeader {
+                    header: HEADER_AIRC_DEADLINE,
+                    value: raw.clone(),
+                })?,
+        ),
+        None => None,
+    };
+    Ok(TurnReplyAddress {
+        correlation_id,
+        reply_to,
+        deadline_at_ms,
+    })
+}
+
+/// Errors from the turn request/reply helpers: either the persona
+/// codec rejected the payload/headers, or the substrate send failed.
+#[derive(Debug)]
+pub enum PersonaTurnError {
+    Codec(PersonaCodecError),
+    Substrate(AircError),
+}
+
+impl std::fmt::Display for PersonaTurnError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Codec(error) => write!(f, "persona turn codec failed: {error}"),
+            Self::Substrate(error) => write!(f, "persona turn substrate send failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for PersonaTurnError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Codec(error) => Some(error),
+            Self::Substrate(error) => Some(error),
+        }
+    }
+}
+
+impl From<PersonaCodecError> for PersonaTurnError {
+    fn from(error: PersonaCodecError) -> Self {
+        Self::Codec(error)
+    }
+}
+
+impl From<AircError> for PersonaTurnError {
+    fn from(error: AircError) -> Self {
+        Self::Substrate(error)
+    }
+}
+
+/// Send a [`TurnRequested`] through the command-bus request path.
+///
+/// The persona codec headers (body hint, kind, persona/activity/turn
+/// ids, optional model hint) ride alongside the substrate-stamped
+/// `airc.correlation_id` / `airc.reply_to` / `airc.deadline`. Await
+/// the turn with [`Airc::await_reply`] — it resolves with the
+/// responder's [`TurnEmitted`] event, or errors with
+/// `AircError::CommandDeadline` when the deadline elapses first.
+pub async fn request_turn(
+    airc: &Airc,
+    target: MentionTarget,
+    request: &TurnRequested,
+    deadline: Duration,
+) -> Result<PendingCommand, PersonaTurnError> {
+    let (headers, body) = encode_persona_event(&PersonaEvent::TurnRequested(request.clone()))?;
+    Ok(airc.request(target, headers, body, deadline).await?)
+}
+
+/// Reply to a command-bus [`TurnRequested`] with a [`TurnEmitted`],
+/// echoing the request's correlation id so the requester's
+/// [`Airc::await_reply`] resolves with this event. `request_headers`
+/// are the headers off the request event as received.
+pub async fn reply_turn_emitted(
+    airc: &Airc,
+    request_headers: &Headers,
+    emitted: &TurnEmitted,
+) -> Result<(), PersonaTurnError> {
+    let address = turn_reply_address(request_headers)?;
+    let (headers, body) = encode_persona_event(&PersonaEvent::TurnEmitted(emitted.clone()))?;
+    airc.reply(address.reply_to, address.correlation_id, headers, body)
+        .await?;
+    Ok(())
 }
 
 /// A consumer-side filter that admits any persona event. Combine

--- a/crates/examples/consumer_shapes/tests/command_bus_integration.rs
+++ b/crates/examples/consumer_shapes/tests/command_bus_integration.rs
@@ -172,6 +172,7 @@ async fn request_persona_turn(alice: &Airc) -> PersonaEvent {
         activity_id: "activity-chat".to_string(),
         turn_id: "turn-001".to_string(),
         prompt: "take a turn".to_string(),
+        model_hint: None,
         requested_at_ms: 1_700_000_000_000,
     });
     let reply = request_typed(alice, encode_persona_event(&request).unwrap()).await;

--- a/crates/examples/consumer_shapes/tests/continuum_roundtrip.rs
+++ b/crates/examples/consumer_shapes/tests/continuum_roundtrip.rs
@@ -6,13 +6,17 @@
 //! the on-wire shape — any change here must coordinate with the
 //! Continuum consumer that subscribes against the same filters.
 
-use airc_lib::{Body, Headers};
+use airc_lib::{
+    Body, Headers, PeerId, HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_DEADLINE, HEADER_AIRC_REPLY_TO,
+};
 use consumer_shapes::continuum::{
     activity_event_filter, any_persona_event_filter, decode_persona_event, encode_persona_event,
-    ActivityEnded, ActivityStarted, PersonaCodecError, PersonaEvent, TurnEmitted, TurnRequested,
-    BODY_HINT_FORGE_PERSONA_EVENT, HEADER_FORGE_CONTINUUM_ACTIVITY_ID,
+    turn_reply_address, ActivityEnded, ActivityStarted, PersonaCodecError, PersonaEvent,
+    TurnEmitted, TurnRequested, BODY_HINT_FORGE_PERSONA_EVENT, HEADER_FORGE_CONTINUUM_ACTIVITY_ID,
     HEADER_FORGE_CONTINUUM_TURN_ID, HEADER_FORGE_PERSONA_ID, HEADER_FORGE_PERSONA_KIND,
+    HEADER_FORGE_PERSONA_MODEL_HINT,
 };
+use uuid::Uuid;
 
 fn turn_requested() -> PersonaEvent {
     PersonaEvent::TurnRequested(TurnRequested {
@@ -20,6 +24,7 @@ fn turn_requested() -> PersonaEvent {
         activity_id: "session-42".to_string(),
         turn_id: "turn-1".to_string(),
         prompt: "what's the meta-goal?".to_string(),
+        model_hint: None,
         requested_at_ms: 1_700_000_000_000,
     })
 }
@@ -101,6 +106,7 @@ fn activity_filter_admits_matching_and_rejects_unrelated() {
         activity_id: "other-activity".to_string(),
         turn_id: "turn-9".to_string(),
         prompt: "unrelated".to_string(),
+        model_hint: None,
         requested_at_ms: 0,
     });
     let (off_headers, _) = encode_persona_event(&off_activity).unwrap();
@@ -147,4 +153,138 @@ fn empty_headers_have_no_body_hint_so_decode_errors_loudly() {
         err,
         PersonaCodecError::BodyHintMismatch { actual: None, .. }
     ));
+}
+
+// ---------------------------------------------------------------------------
+// Command-bus carriage — card ee2a339f
+// ---------------------------------------------------------------------------
+
+#[test]
+fn model_hint_projects_header_and_roundtrips() {
+    let event = PersonaEvent::TurnRequested(TurnRequested {
+        persona_id: "skylar".to_string(),
+        activity_id: "session-42".to_string(),
+        turn_id: "turn-2".to_string(),
+        prompt: "route me to the right model".to_string(),
+        model_hint: Some("lora-clio-v3".to_string()),
+        requested_at_ms: 1_700_000_000_000,
+    });
+    let (headers, body) = encode_persona_event(&event).unwrap();
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_PERSONA_MODEL_HINT)
+            .map(String::as_str),
+        Some("lora-clio-v3"),
+    );
+    let decoded = decode_persona_event(&headers, Some(&body)).unwrap();
+    assert_eq!(decoded, event);
+}
+
+#[test]
+fn absent_model_hint_projects_no_header() {
+    let (headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    assert!(
+        !headers.contains_key(HEADER_FORGE_PERSONA_MODEL_HINT),
+        "model-hint header must be absent when the request sets none",
+    );
+}
+
+#[test]
+fn legacy_turn_requested_body_without_model_hint_still_decodes() {
+    // Bodies encoded before the model_hint field existed carry no such
+    // key — the contract extension is additive, so they must decode.
+    let (headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    let legacy_body = Body::Json(serde_json::json!({
+        "kind": "turn_requested",
+        "persona_id": "skylar",
+        "activity_id": "session-42",
+        "turn_id": "turn-1",
+        "prompt": "what's the meta-goal?",
+        "requested_at_ms": 1_700_000_000_000u64,
+    }));
+    let decoded = decode_persona_event(&headers, Some(&legacy_body)).unwrap();
+    assert_eq!(decoded, turn_requested());
+}
+
+#[test]
+fn turn_reply_address_reads_command_bus_headers() {
+    // Stamp the same headers Airc::request stamps (same constants —
+    // re-exported from airc-protocol, not a parallel vocabulary).
+    let correlation_id = Uuid::new_v4();
+    let reply_peer = PeerId::new();
+    let (mut headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    headers.insert(
+        HEADER_AIRC_CORRELATION_ID.to_string(),
+        correlation_id.to_string(),
+    );
+    headers.insert(HEADER_AIRC_REPLY_TO.to_string(), reply_peer.to_string());
+    headers.insert(
+        HEADER_AIRC_DEADLINE.to_string(),
+        "1700000000000".to_string(),
+    );
+
+    let address = turn_reply_address(&headers).unwrap();
+    assert_eq!(address.correlation_id, correlation_id);
+    assert_eq!(address.reply_to, reply_peer);
+    assert_eq!(address.deadline_at_ms, Some(1_700_000_000_000));
+}
+
+#[test]
+fn turn_reply_address_missing_correlation_errors_loudly() {
+    let (mut headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    headers.insert(HEADER_AIRC_REPLY_TO.to_string(), PeerId::new().to_string());
+    let err = turn_reply_address(&headers).unwrap_err();
+    assert!(matches!(
+        err,
+        PersonaCodecError::MissingHeader {
+            header: HEADER_AIRC_CORRELATION_ID
+        }
+    ));
+}
+
+#[test]
+fn turn_reply_address_missing_reply_to_errors_loudly() {
+    let (mut headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    headers.insert(
+        HEADER_AIRC_CORRELATION_ID.to_string(),
+        Uuid::new_v4().to_string(),
+    );
+    let err = turn_reply_address(&headers).unwrap_err();
+    assert!(matches!(
+        err,
+        PersonaCodecError::MissingHeader {
+            header: HEADER_AIRC_REPLY_TO
+        }
+    ));
+}
+
+#[test]
+fn turn_reply_address_malformed_deadline_errors_loudly() {
+    let (mut headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    headers.insert(
+        HEADER_AIRC_CORRELATION_ID.to_string(),
+        Uuid::new_v4().to_string(),
+    );
+    headers.insert(HEADER_AIRC_REPLY_TO.to_string(), PeerId::new().to_string());
+    headers.insert(HEADER_AIRC_DEADLINE.to_string(), "soon-ish".to_string());
+    let err = turn_reply_address(&headers).unwrap_err();
+    assert!(matches!(
+        err,
+        PersonaCodecError::MalformedHeader {
+            header: HEADER_AIRC_DEADLINE,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn turn_reply_address_without_deadline_is_open_ended() {
+    let (mut headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    headers.insert(
+        HEADER_AIRC_CORRELATION_ID.to_string(),
+        Uuid::new_v4().to_string(),
+    );
+    headers.insert(HEADER_AIRC_REPLY_TO.to_string(), PeerId::new().to_string());
+    let address = turn_reply_address(&headers).unwrap();
+    assert_eq!(address.deadline_at_ms, None);
 }

--- a/crates/examples/consumer_shapes/tests/persona_turn_command_bus.rs
+++ b/crates/examples/consumer_shapes/tests/persona_turn_command_bus.rs
@@ -1,0 +1,221 @@
+//! Persona turn request/reply over the command bus — card ee2a339f
+//! (persona-peer 3/8).
+//!
+//! Proves `TurnRequested` / `TurnEmitted` double as the command-bus
+//! request/reply pair: the requester rides `Airc::request` (which
+//! stamps `airc.correlation_id` + `airc.reply_to` + `airc.deadline`),
+//! the persona-side responder decodes the typed turn, reads the
+//! reply address back via `turn_reply_address`, and answers through
+//! `reply_turn_emitted` so the requester's `await_reply` resolves
+//! with the `TurnEmitted` body before the deadline. LAN-TCP with
+//! separate homes so it cannot pass through shared local-fs.
+//!
+//! All waits bounded (d2ba719c): `await_reply` is deadline-bounded by
+//! construction, and the responder task only runs while the requester
+//! side is still in flight.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use airc_lib::{Airc, AircError, MentionTarget};
+use consumer_shapes::continuum::{
+    decode_persona_event, reply_turn_emitted, request_turn, turn_reply_address, PersonaEvent,
+    TurnEmitted, TurnRequested, BODY_HINT_FORGE_PERSONA_EVENT, HEADER_FORGE_PERSONA_MODEL_HINT,
+};
+use futures::StreamExt;
+use tempfile::TempDir;
+
+const HEADER_FORGE_BODY_HINT: &str = "forge.body_hint";
+
+fn turn_request() -> TurnRequested {
+    TurnRequested {
+        persona_id: "clio".to_string(),
+        activity_id: "activity-chat".to_string(),
+        turn_id: "turn-007".to_string(),
+        prompt: "take a correlated turn".to_string(),
+        model_hint: Some("lora-clio-v3".to_string()),
+        requested_at_ms: 1_700_000_000_000,
+    }
+}
+
+fn turn_reply() -> TurnEmitted {
+    TurnEmitted {
+        persona_id: "clio".to_string(),
+        activity_id: "activity-chat".to_string(),
+        turn_id: "turn-007".to_string(),
+        text: "correlated turn complete".to_string(),
+        emitted_at_ms: 1_700_000_000_100,
+    }
+}
+
+#[tokio::test]
+async fn turn_request_reply_resolves_await_reply_before_deadline() {
+    let requester_home = TempDir::new().expect("requester home");
+    let persona_home = TempDir::new().expect("persona home");
+
+    let requester = Airc::open(requester_home.path())
+        .await
+        .expect("requester opens");
+    let persona = Airc::open(persona_home.path())
+        .await
+        .expect("persona opens");
+
+    let requester_spec = requester.peer_spec().parse().expect("requester peer spec");
+    let persona_spec = persona.peer_spec().parse().expect("persona peer spec");
+    requester
+        .add_peer(persona_spec)
+        .await
+        .expect("requester trusts persona");
+    persona
+        .add_peer(requester_spec)
+        .await
+        .expect("persona trusts requester");
+
+    requester.join("persona-turn-bus").await.unwrap();
+    persona.join("persona-turn-bus").await.unwrap();
+
+    let persona_addr = persona
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("persona listens on LAN");
+    requester
+        .connect_lan(persona_addr, persona.peer_id())
+        .await
+        .expect("requester connects to persona over LAN");
+
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let responder = tokio::spawn(handle_one_turn_request(persona.clone(), ready_tx));
+    ready_rx.await.expect("persona subscriber is ready");
+
+    let pending = request_turn(
+        &requester,
+        MentionTarget::All,
+        &turn_request(),
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("turn request emits");
+
+    // await_reply is bounded by the 5s deadline; resolving at all
+    // proves the reply landed before it.
+    let reply = requester
+        .await_reply(pending)
+        .await
+        .expect("await_reply resolves with the TurnEmitted reply");
+    let decoded = decode_persona_event(&reply.headers, reply.body.as_ref())
+        .expect("reply decodes as a persona event");
+    assert_eq!(decoded, PersonaEvent::TurnEmitted(turn_reply()));
+
+    responder.await.expect("responder completes");
+}
+
+async fn handle_one_turn_request(persona: Airc, ready: tokio::sync::oneshot::Sender<()>) {
+    let mut stream = persona.subscribe().await.unwrap();
+    let _ = ready.send(());
+    loop {
+        let Some(Ok(event)) = stream.next().await else {
+            continue;
+        };
+        if event.peer_id == persona.peer_id() {
+            continue;
+        }
+        if event
+            .headers
+            .get(HEADER_FORGE_BODY_HINT)
+            .map(String::as_str)
+            != Some(BODY_HINT_FORGE_PERSONA_EVENT)
+        {
+            continue;
+        }
+        let PersonaEvent::TurnRequested(request) =
+            decode_persona_event(&event.headers, event.body.as_ref()).unwrap()
+        else {
+            continue;
+        };
+
+        // The model hint rides as a filterable header alongside the body.
+        assert_eq!(request.model_hint.as_deref(), Some("lora-clio-v3"));
+        assert_eq!(
+            event
+                .headers
+                .get(HEADER_FORGE_PERSONA_MODEL_HINT)
+                .map(String::as_str),
+            Some("lora-clio-v3"),
+        );
+
+        // The command bus stamped its correlation + reply-to + deadline
+        // headers on the request; the typed view recovers all three.
+        let address = turn_reply_address(&event.headers).unwrap();
+        assert!(
+            address.deadline_at_ms.is_some(),
+            "Airc::request must stamp airc.deadline on the turn request",
+        );
+
+        reply_turn_emitted(&persona, &event.headers, &turn_reply())
+            .await
+            .expect("turn reply emits");
+        return;
+    }
+}
+
+#[tokio::test]
+async fn turn_request_with_no_responder_errors_at_deadline() {
+    let requester_home = TempDir::new().expect("requester home");
+    let silent_home = TempDir::new().expect("silent peer home");
+
+    let requester = Airc::open(requester_home.path())
+        .await
+        .expect("requester opens");
+    // A live, trusted, connected peer that simply never replies —
+    // the request emits fine, but no TurnEmitted ever comes back.
+    let silent = Airc::open(silent_home.path()).await.expect("silent opens");
+
+    let requester_spec = requester.peer_spec().parse().expect("requester peer spec");
+    let silent_spec = silent.peer_spec().parse().expect("silent peer spec");
+    requester
+        .add_peer(silent_spec)
+        .await
+        .expect("requester trusts silent peer");
+    silent
+        .add_peer(requester_spec)
+        .await
+        .expect("silent peer trusts requester");
+
+    requester.join("persona-turn-bus-silent").await.unwrap();
+    silent.join("persona-turn-bus-silent").await.unwrap();
+
+    let silent_addr = silent
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("silent peer listens on LAN");
+    requester
+        .connect_lan(silent_addr, silent.peer_id())
+        .await
+        .expect("requester connects to silent peer over LAN");
+
+    let pending = request_turn(
+        &requester,
+        MentionTarget::All,
+        &turn_request(),
+        Duration::from_millis(300),
+    )
+    .await
+    .expect("turn request emits");
+    let correlation_id = pending.correlation_id;
+
+    // Nobody is listening: await_reply must fail loudly AT the
+    // deadline (bounded wait), not hang.
+    let err = requester
+        .await_reply(pending)
+        .await
+        .expect_err("await_reply must error once the deadline elapses");
+    assert!(
+        matches!(
+            err,
+            AircError::CommandDeadline {
+                correlation_id: expired
+            } if expired == correlation_id
+        ),
+        "expected CommandDeadline for {correlation_id}, got: {err:?}",
+    );
+}


### PR DESCRIPTION
Persona-peer 3/8. TurnRequested/TurnEmitted now double as command-bus request/reply — the spine cross-grid inference (card 8/8) rides on.

- Reuses the EXACT command-bus header constants `Airc::request` stamps (`airc.correlation_id`/`airc.reply_to`/`airc.deadline`, re-exported through airc-lib so consumer_shapes needs no airc-protocol dep). command_bus.rs untouched — generic plumbing stays there.
- New: `TurnRequested.model_hint` (additive serde field → `forge.persona.model_hint` header, for capability routing in 4/8); `turn_reply_address(&Headers)` (typed, loud-failing read — new MissingHeader/MalformedHeader codec errors); `reply_turn_emitted` (echoes correlation via `Airc::reply` so `await_reply` resolves); `request_turn` convenience.
- Tests: LAN happy path — requester `request_turn` → silent... no: responder decodes → `reply_turn_emitted` → requester's `await_reply` resolves with the TurnEmitted body before deadline; deadline-expiry — connected-but-silent peer → `await_reply` errors `CommandDeadline{correlation_id}` at the bound (loud). Plus model_hint projection/roundtrip + legacy-body-without-model_hint decode + all three reply-address loud-failure paths.

Validation (native Windows MSVC): consumer-shapes 28/0 (incl. new persona_turn_command_bus 2/2); airc-lib command_bus 3/3 + round_trip 2/2; fmt + clippy --all-targets + production no-silent-fallback gate all clean. No SAC interference this run.

Stacks conceptually on #1129 (persona foundation) but bases cleanly on rust-rewrite (command_bus + PersonaEvent already there). Next: 4/8 capability registry (model_hint consumer), then 8/8 cross-grid inference (the imminent grid milestone — M5 arrives next week as inference node #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)