### PR TITLE
docs(AGENTS): never idle on review/CI — 24/7 continuous-work doctrine (companion to d327b903)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,22 @@ yours. Specifically:
   feature branches (the `feat/owner-daemon-slice1` pattern earlier
   this session was the anti-pattern — `airc work claim` spawns
   per-card branches that get deleted on merge, not persistent lanes).
+- **Never idle on review or CI — they are asynchronous and
+  self-resolving.** A PR in Review or a CI run in flight is **not** a
+  blocker and **not** a reason to stop; the author does not wait on
+  their own PR. The moment you hand a card to Review, claim the next
+  card (airc work next) and keep moving. When work is continuous, stack
+  the next branch on your last rather than waiting for the predecessor
+  to merge. Arm an auto-merge-on-green watcher (or lean on the merger
+  daemon once it exists) instead of polling — arm a sentinel and go.
+  The **only** real blockers are: a failing gate you must fix, a
+  genuine human-only decision, or code that cannot compile without
+  unmerged work (and then base the branch on the one that has it).
+  Idle while claimable work exists is a defect, not a rest state — for
+  every agent, and for personas, which inherit this by attaching to the
+  same room. Structural enforcement (Review state not marking the
+  author busy, work-next auto-suggest, the merger daemon) is tracked as
+  the companion P0 card `d327b903`.
 - **Self-review during edits.** `cargo fmt` + `cargo clippy
   --all-targets -- -D warnings` LOCALLY before commit, not relying on
   CI to catch what you should have caught. Drift across 26 files


### PR DESCRIPTION
The prose half of the no-idle formalization (structural half = P0 card d327b903). Loads on every join via `doctrine-publish`, so every peer — Claude tabs AND personas — inherits it.

One bullet added to AGENTS.md §0 ("engineering staff, not an assistant"), adjacent to the existing PR-review/branch-hygiene duties: review and CI are asynchronous and self-resolving; the author never waits on their own PR; on hand-off to Review, claim the next card (`airc work next`) and stack the next branch on the last; arm auto-merge-on-green + a sentinel and move on; the only real blockers are a failing gate, a human-only decision, or code that can't compile without unmerged work. Idle-while-claimable-work-exists is a defect, not a rest state.

Doc-only: `git diff --name-only` = AGENTS.md alone, 16 insertions. No doc-lint config in repo. Branch off rust-rewrite @ 006e264.

After merge: `airc doctrine-publish` so attaching peers pick it up. Companion 24/7-continuity dimension (session-end = shift handoff, state-in-substrate, merger daemon) folded into card d327b903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)