### PR TITLE
feat(persona): cross-grid inference end-to-end — the grid-inference protocol spine (card cae4bab1, 8/8; umbrella 1/8→8/8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,6 +2206,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "persona-spawn-smoke"
+version = "0.1.0"
+dependencies = [
+ "airc-core",
+ "airc-lib",
+ "airc-trust",
+ "consumer-shapes",
+ "futures",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "pgvector"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/airc-cli",
     "crates/examples/embedded_consumer_smoke",
     "crates/examples/consumer_shapes",
+    "crates/examples/persona_spawn_smoke",
 ]
 resolver = "2"
 

--- a/crates/airc-core/src/lib.rs
+++ b/crates/airc-core/src/lib.rs
@@ -12,6 +12,7 @@
 //!
 //! - [`ids`]        — newtype wrappers for identifier strings
 //! - [`identity`]   — the per-peer Identity card (the user/account abstraction)
+//! - [`persona`]    — typed persona capability metadata on Identity.integrations
 //! - [`body`]       — opaque payload (Json | Binary) consumers carry
 //! - [`transcript`] — TranscriptEvent + TranscriptKind + MentionTarget
 //! - [`cursor`]     — cursor + paging primitives for transcript fetch
@@ -35,6 +36,7 @@ pub mod headers;
 pub mod humanhash;
 pub mod identity;
 pub mod ids;
+pub mod persona;
 pub mod receipt;
 pub mod transcript;
 
@@ -51,5 +53,6 @@ pub use headers::{HeaderFilter, Headers};
 pub use humanhash::{humanhash, HumanhashError};
 pub use identity::Identity;
 pub use ids::{ClientId, ContentHash, EventId, FileId, PeerId, RoomId};
+pub use persona::{PersonaCapabilities, PersonaCapabilitiesError, PERSONA_CAPABILITIES_KEY};
 pub use receipt::{Receipt, ReceiptKind};
 pub use transcript::{MentionTarget, TranscriptEvent, TranscriptKind};

--- a/crates/airc-core/src/persona.rs
+++ b/crates/airc-core/src/persona.rs
@@ -1,0 +1,261 @@
+//! Typed persona capability metadata carried via `Identity.integrations`.
+//!
+//! Card 9e5f8844 (persona-peer 1/8). A Continuum persona running as an
+//! AIRC peer advertises WHAT it is (persona id, capability tags, model,
+//! context window) on the existing [`Identity`] card rather than via a
+//! new subsystem: the `integrations` map is the consumer-keyed slot the
+//! substrate already persists and transports without interpreting (see
+//! [`Identity::integrations`]). This module owns the ONE key Continuum
+//! uses ([`PERSONA_CAPABILITIES_KEY`]) and the typed encode/decode so
+//! every consumer reads the same shape instead of hand-parsing JSON
+//! out of the map.
+//!
+//! Loud-failure doctrine: a present-but-undecodable value is an error
+//! surfaced to the caller ([`PersonaCapabilitiesError::Decode`]), never
+//! a silent `None` — a corrupt capability advert mis-read as "no
+//! capabilities" would route persona turns to a peer that can't take
+//! them, invisibly. Absent key is the honest `Ok(None)`.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::identity::Identity;
+
+/// The `Identity.integrations` key under which a persona peer's
+/// capability metadata is stored. Versioned so a future incompatible
+/// shape gets a NEW key (`continuum.persona.v2`) instead of silently
+/// changing what `v1` decodes to.
+pub const PERSONA_CAPABILITIES_KEY: &str = "continuum.persona.v1";
+
+/// What a persona peer advertises about itself on its identity card.
+///
+/// Stored JSON-encoded under [`PERSONA_CAPABILITIES_KEY`] in
+/// [`Identity::integrations`]; read back with
+/// [`PersonaCapabilities::read_from_identity`]. The substrate carries
+/// it opaquely — only persona-aware consumers (Continuum's spawn loop,
+/// manager-hat routing) decode it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersonaCapabilities {
+    /// Continuum persona id this peer embodies (e.g. "skylar").
+    pub persona_id: String,
+    /// Free-form capability tags the routing layer matches on
+    /// (e.g. "code", "render", "long-context"). Default empty —
+    /// a persona with no advertised tags is still a valid persona.
+    #[serde(default)]
+    pub capability_tags: Vec<String>,
+    /// Model identifier backing this persona (e.g. "fable-5").
+    pub model: String,
+    /// Context window of the backing model, in tokens. Routing uses
+    /// this to keep oversized activities off undersized personas.
+    pub context_window_tokens: u32,
+}
+
+/// Loud-failure errors for the typed integrations accessor.
+#[derive(Debug)]
+pub enum PersonaCapabilitiesError {
+    /// Serializing the capabilities to JSON failed (pathological —
+    /// the struct is plain data — but never swallowed).
+    Encode(serde_json::Error),
+    /// The key was PRESENT but its value did not decode as
+    /// [`PersonaCapabilities`]. Carries the raw value so the operator
+    /// sees what was actually stored, not just "it broke".
+    Decode {
+        /// The undecodable raw value found under the key.
+        raw: String,
+        /// The underlying JSON error.
+        source: serde_json::Error,
+    },
+}
+
+impl fmt::Display for PersonaCapabilitiesError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Encode(source) => {
+                write!(f, "persona capabilities failed to encode: {source}")
+            }
+            Self::Decode { raw, source } => write!(
+                f,
+                "persona capabilities under {PERSONA_CAPABILITIES_KEY:?} \
+                 failed to decode: {source}; raw value: {raw:?}",
+            ),
+        }
+    }
+}
+
+impl Error for PersonaCapabilitiesError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Encode(source) | Self::Decode { source, .. } => Some(source),
+        }
+    }
+}
+
+impl PersonaCapabilities {
+    /// Write these capabilities into an integrations map under
+    /// [`PERSONA_CAPABILITIES_KEY`], replacing any prior value.
+    pub fn write_to_integrations(
+        &self,
+        integrations: &mut BTreeMap<String, String>,
+    ) -> Result<(), PersonaCapabilitiesError> {
+        let encoded = serde_json::to_string(self).map_err(PersonaCapabilitiesError::Encode)?;
+        integrations.insert(PERSONA_CAPABILITIES_KEY.to_string(), encoded);
+        Ok(())
+    }
+
+    /// Typed read from an integrations map.
+    ///
+    /// - Key absent → `Ok(None)` — this peer advertises no persona.
+    /// - Key present and valid → `Ok(Some(capabilities))`.
+    /// - Key present but undecodable → `Err(Decode { .. })`, loudly.
+    pub fn read_from_integrations(
+        integrations: &BTreeMap<String, String>,
+    ) -> Result<Option<Self>, PersonaCapabilitiesError> {
+        let Some(raw) = integrations.get(PERSONA_CAPABILITIES_KEY) else {
+            return Ok(None);
+        };
+        serde_json::from_str(raw)
+            .map(Some)
+            .map_err(|source| PersonaCapabilitiesError::Decode {
+                raw: raw.clone(),
+                source,
+            })
+    }
+
+    /// Convenience: write onto an [`Identity`] card's integrations map.
+    pub fn write_to_identity(
+        &self,
+        identity: &mut Identity,
+    ) -> Result<(), PersonaCapabilitiesError> {
+        self.write_to_integrations(&mut identity.integrations)
+    }
+
+    /// Convenience: typed read off an [`Identity`] card. Same
+    /// absent/valid/corrupt contract as
+    /// [`Self::read_from_integrations`].
+    pub fn read_from_identity(
+        identity: &Identity,
+    ) -> Result<Option<Self>, PersonaCapabilitiesError> {
+        Self::read_from_integrations(&identity.integrations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> PersonaCapabilities {
+        PersonaCapabilities {
+            persona_id: "skylar".to_string(),
+            capability_tags: vec!["code".to_string(), "long-context".to_string()],
+            model: "fable-5".to_string(),
+            context_window_tokens: 200_000,
+        }
+    }
+
+    #[test]
+    fn roundtrips_through_identity_integrations() {
+        let mut identity = Identity::new("skylar-peer");
+        sample()
+            .write_to_identity(&mut identity)
+            .expect("write capabilities");
+
+        // The value rides the existing consumer-keyed map — no new
+        // Identity field, so every store/wire path that already
+        // carries `integrations` carries this too.
+        assert!(identity.integrations.contains_key(PERSONA_CAPABILITIES_KEY));
+
+        let read = PersonaCapabilities::read_from_identity(&identity)
+            .expect("decode must succeed")
+            .expect("capabilities must be present");
+        assert_eq!(read, sample());
+    }
+
+    #[test]
+    fn write_replaces_prior_value() {
+        let mut integrations = BTreeMap::new();
+        sample()
+            .write_to_integrations(&mut integrations)
+            .expect("first write");
+        let updated = PersonaCapabilities {
+            model: "fable-6".to_string(),
+            ..sample()
+        };
+        updated
+            .write_to_integrations(&mut integrations)
+            .expect("second write");
+
+        let read = PersonaCapabilities::read_from_integrations(&integrations)
+            .expect("decode")
+            .expect("present");
+        assert_eq!(read.model, "fable-6", "latest write must win");
+        assert_eq!(integrations.len(), 1, "one key, replaced in place");
+    }
+
+    #[test]
+    fn absent_key_reads_as_none_not_error() {
+        let identity = Identity::new("no-persona-here");
+        let read = PersonaCapabilities::read_from_identity(&identity).expect("absent key is Ok");
+        assert!(read.is_none(), "absent key must be the honest None");
+    }
+
+    #[test]
+    fn corrupt_value_surfaces_decode_error_loudly() {
+        let mut integrations = BTreeMap::new();
+        integrations.insert(
+            PERSONA_CAPABILITIES_KEY.to_string(),
+            "{not valid json".to_string(),
+        );
+        let err = PersonaCapabilities::read_from_integrations(&integrations)
+            .expect_err("corrupt value must NOT read as None");
+        match &err {
+            PersonaCapabilitiesError::Decode { raw, .. } => {
+                assert_eq!(raw, "{not valid json", "error must carry the raw value");
+            }
+            PersonaCapabilitiesError::Encode(_) => {
+                panic!("corrupt stored value is a Decode error, not Encode")
+            }
+        }
+        // The Display rendering names the key and the raw value so the
+        // failure is actionable from a log line alone.
+        let rendered = err.to_string();
+        assert!(rendered.contains(PERSONA_CAPABILITIES_KEY));
+        assert!(rendered.contains("{not valid json"));
+    }
+
+    #[test]
+    fn wrong_shape_json_is_also_a_loud_decode_error() {
+        // Valid JSON, wrong shape (missing required fields) — the
+        // typed accessor must refuse, not fill in defaults silently.
+        let mut integrations = BTreeMap::new();
+        integrations.insert(
+            PERSONA_CAPABILITIES_KEY.to_string(),
+            r#"{"persona_id":"skylar"}"#.to_string(),
+        );
+        let result = PersonaCapabilities::read_from_integrations(&integrations);
+        assert!(
+            matches!(result, Err(PersonaCapabilitiesError::Decode { .. })),
+            "missing required fields must surface as Decode, got {result:?}",
+        );
+    }
+
+    #[test]
+    fn capability_tags_default_empty_for_forward_compat() {
+        // A v1 writer that omits `capability_tags` still decodes — the
+        // field is the one shape-evolution slot with a safe default.
+        let mut integrations = BTreeMap::new();
+        integrations.insert(
+            PERSONA_CAPABILITIES_KEY.to_string(),
+            r#"{"persona_id":"skylar","model":"fable-5","context_window_tokens":200000}"#
+                .to_string(),
+        );
+        let read = PersonaCapabilities::read_from_integrations(&integrations)
+            .expect("decode")
+            .expect("present");
+        assert!(read.capability_tags.is_empty());
+        assert_eq!(read.persona_id, "skylar");
+        assert_eq!(read.context_window_tokens, 200_000);
+    }
+}

--- a/crates/airc-lib/src/capability_registry.rs
+++ b/crates/airc-lib/src/capability_registry.rs
@@ -1,0 +1,460 @@
+//! Capability registry — the organic need/offer matcher (card a9580f9d,
+//! persona-peer 4/8).
+//!
+//! Nodes on the grid advertise WHAT they can do (a [`PersonaCapabilities`]
+//! card from card 9e5f8844) tagged with the peer that offered it; this
+//! projection ingests those offers into an in-memory map and answers the
+//! routing question "who can take a turn that needs these tags?" with an
+//! ordered candidate list. It is the escalation half of local-first
+//! routing: a scheduler tries the local node first and only consults the
+//! registry when the local node cannot meet the need.
+//!
+//! Design (Joel, 2026-06-11 — binding):
+//! - ORGANIC TWO-SIDED: a node both advertises capabilities (offers,
+//!   ingested here) and expresses needs (required tags, the [`match_for`]
+//!   query). Matching is continuous — re-ingesting an offer refreshes the
+//!   `last_seen` clock so a node that keeps advertising stays live and one
+//!   that goes quiet ages out. New nodes are absorbed with zero config:
+//!   the first offer they publish makes them a candidate.
+//! - PROBED, NEVER ASSUMED: the capabilities are whatever the offering
+//!   node measured about itself (model, context window, free-form tags).
+//!   This registry never enumerates hardware tiers or branches on OS /
+//!   vendor — those, if present, are opaque facts inside the
+//!   [`PersonaCapabilities`] record, not protocol-level switches.
+//! - GRID-OF-ONE is normal: a registry with no ingested offers is
+//!   empty-but-valid. [`CapabilityRegistry::match_for`] returns an empty
+//!   `Vec`, never an error, when nothing matches. A node with no peers
+//!   still works; it just never escalates.
+//!
+//! Mirrors the [`crate::work_roster`] projection pattern: a typed query
+//! in, an ordered typed result out, ranking factored into small pure
+//! helpers.
+//!
+//! [`match_for`]: CapabilityRegistry::match_for
+
+use std::collections::HashMap;
+
+use airc_core::{PeerId, PersonaCapabilities};
+use airc_store::peer_trust::TrustTier;
+
+/// Default staleness horizon: an offer not refreshed within this window
+/// is aged out of match results. Mirrors the order of magnitude of
+/// [`crate::work_roster::WorkRosterQuery`]'s `active_within_ms` so a
+/// persona that stops advertising drops off routing on a comparable
+/// timescale to an agent that stops heartbeating.
+pub const DEFAULT_OFFER_TTL_MS: u64 = 180_000;
+
+/// One node's standing capability advert, as held by the registry.
+///
+/// `peer_id` is the offering node; `capabilities` is exactly the
+/// card-9e5f8844 struct it advertised (reused, never redefined);
+/// `last_seen_ms` is the wall-clock (epoch-ms) of the most recent offer
+/// ingest, the basis for ageing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityEntry {
+    pub peer_id: PeerId,
+    pub capabilities: PersonaCapabilities,
+    pub last_seen_ms: u64,
+}
+
+/// A ranked match candidate returned by [`CapabilityRegistry::match_for`].
+///
+/// `matched_tags` is how many of the query's required tags this entry's
+/// capability tags satisfied; together with `trust_tier` it is the
+/// ranking basis, surfaced so a caller can show *why* a candidate ranked
+/// where it did rather than treating the order as opaque.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityCandidate {
+    pub peer_id: PeerId,
+    pub capabilities: PersonaCapabilities,
+    pub trust_tier: TrustTier,
+    pub matched_tags: usize,
+    pub last_seen_ms: u64,
+}
+
+/// In-memory projection of capability offers → routable candidates.
+///
+/// Not a substrate store: this is a derived view a scheduler keeps warm
+/// by feeding it offer events as they arrive on the room (the
+/// consumer-shapes `continuum` codec decodes the wire event; this layer
+/// is wire-agnostic so it stays out of the airc-core ← consumer
+/// dependency direction). Keyed by `peer_id` so a node re-advertising
+/// replaces its prior offer rather than accumulating duplicates.
+#[derive(Debug, Clone, Default)]
+pub struct CapabilityRegistry {
+    entries: HashMap<PeerId, CapabilityEntry>,
+}
+
+/// Query expressing a NEED: the tags a turn requires and how trust is
+/// resolved per candidate. Empty `required_tags` matches every live
+/// entry (a pure "who is out there?" sweep). `trust_of` maps an offering
+/// peer to its locally-resolved [`TrustTier`]; a peer the caller can't
+/// resolve is treated as [`TrustTier::Untrusted`] (the safe default the
+/// trust layer already uses for trust-on-first-use peers), never
+/// dropped — an unranked-but-present candidate beats invisibly losing a
+/// capable node.
+pub struct CapabilityQuery<'a> {
+    /// Tags the need requires. A candidate must advertise ALL of them to
+    /// be considered a match (matched_tags == required_tags.len()).
+    /// Empty → every live entry is a match.
+    pub required_tags: &'a [&'a str],
+    /// Now, epoch-ms — the clock ageing is measured against.
+    pub now_ms: u64,
+    /// Offers last seen more than this many ms before `now_ms` are aged
+    /// out of results.
+    pub ttl_ms: u64,
+}
+
+impl CapabilityRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Ingest (or refresh) one node's capability offer. Keyed by
+    /// `peer_id`: a re-advert from the same peer replaces the prior
+    /// record and bumps `last_seen_ms`, which is how a node that keeps
+    /// advertising stays live. Idempotent for a given `(peer_id,
+    /// last_seen_ms)`.
+    pub fn ingest_offer(
+        &mut self,
+        peer_id: PeerId,
+        capabilities: PersonaCapabilities,
+        seen_at_ms: u64,
+    ) {
+        self.entries.insert(
+            peer_id,
+            CapabilityEntry {
+                peer_id,
+                capabilities,
+                last_seen_ms: seen_at_ms,
+            },
+        );
+    }
+
+    /// Number of entries currently held (including not-yet-aged-out
+    /// stale ones — ageing happens at query time, not on insert, so a
+    /// caller can choose its own clock).
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// True when no offers have been ingested. The grid-of-one steady
+    /// state.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Drop entries last seen before `now_ms - ttl_ms`. Returns how many
+    /// were removed. Optional housekeeping: [`Self::match_for`] already
+    /// skips stale entries, so calling this is only to reclaim memory.
+    pub fn prune_stale(&mut self, now_ms: u64, ttl_ms: u64) -> usize {
+        let before = self.entries.len();
+        self.entries
+            .retain(|_, entry| !is_stale(entry.last_seen_ms, now_ms, ttl_ms));
+        before - self.entries.len()
+    }
+
+    /// Match a NEED against the live offers, returning candidates ordered
+    /// best-first.
+    ///
+    /// Ranking, in order:
+    ///   1. More matched tags first (a node satisfying more of the need
+    ///      outranks one satisfying fewer). With non-empty
+    ///      `required_tags` every returned candidate has the full count,
+    ///      so this only separates results of an empty-tag sweep that
+    ///      happen to advertise overlapping tags — but it keeps the
+    ///      ordering principled.
+    ///   2. Higher trust tier first: OwnMachine > OwnAccount > Friend >
+    ///      Untrusted (reusing [`TrustTier`]; not reinvented).
+    ///   3. Larger context window first — a tie-break favouring the more
+    ///      capable host for the same trust.
+    ///   4. `peer_id` last, purely for deterministic, test-stable order.
+    ///
+    /// Empty registry or no matches → empty `Vec`, never an error
+    /// (grid-of-one). A required tag no live node advertises simply
+    /// yields no candidates; the caller decides whether that means "run
+    /// locally / queue" — the registry does not editorialise.
+    pub fn match_for(
+        &self,
+        query: &CapabilityQuery<'_>,
+        trust_of: impl Fn(PeerId) -> TrustTier,
+    ) -> Vec<CapabilityCandidate> {
+        let mut candidates: Vec<CapabilityCandidate> = self
+            .entries
+            .values()
+            .filter(|entry| !is_stale(entry.last_seen_ms, query.now_ms, query.ttl_ms))
+            .filter_map(|entry| {
+                let matched_tags = matched_tag_count(&entry.capabilities, query.required_tags);
+                // ALL required tags must be present. Empty required_tags
+                // ⇒ required len 0 ⇒ this is always satisfied.
+                if matched_tags < query.required_tags.len() {
+                    return None;
+                }
+                Some(CapabilityCandidate {
+                    peer_id: entry.peer_id,
+                    capabilities: entry.capabilities.clone(),
+                    trust_tier: trust_of(entry.peer_id),
+                    matched_tags,
+                    last_seen_ms: entry.last_seen_ms,
+                })
+            })
+            .collect();
+
+        candidates.sort_by(|left, right| {
+            right
+                .matched_tags
+                .cmp(&left.matched_tags)
+                .then_with(|| trust_rank(left.trust_tier).cmp(&trust_rank(right.trust_tier)))
+                .then_with(|| {
+                    right
+                        .capabilities
+                        .context_window_tokens
+                        .cmp(&left.capabilities.context_window_tokens)
+                })
+                .then_with(|| left.peer_id.to_string().cmp(&right.peer_id.to_string()))
+        });
+        candidates
+    }
+}
+
+/// An offer is stale when its last-seen instant is older than `ttl_ms`
+/// before `now_ms`. A `ttl_ms` of 0 ages out everything not seen exactly
+/// now; saturating arithmetic keeps a clock that ran backwards (or a
+/// `now_ms` before `last_seen`) from underflowing into "never stale".
+fn is_stale(last_seen_ms: u64, now_ms: u64, ttl_ms: u64) -> bool {
+    now_ms.saturating_sub(last_seen_ms) > ttl_ms
+}
+
+/// How many of `required_tags` appear in the entry's advertised tags.
+fn matched_tag_count(capabilities: &PersonaCapabilities, required_tags: &[&str]) -> usize {
+    required_tags
+        .iter()
+        .filter(|needed| {
+            capabilities
+                .capability_tags
+                .iter()
+                .any(|have| have == *needed)
+        })
+        .count()
+}
+
+/// Lower rank = higher trust = sorts first. Reuses the existing
+/// [`TrustTier`] ordering semantics (OwnMachine highest) without
+/// depending on a derived `Ord` the enum does not provide. A
+/// `wildcard_enum_match_arm`-clean exhaustive match: a new tier added to
+/// `TrustTier` will fail to compile here until ranked, which is the
+/// loud-failure we want for a routing-trust decision.
+fn trust_rank(tier: TrustTier) -> u8 {
+    match tier {
+        TrustTier::OwnMachine => 0,
+        TrustTier::OwnAccount => 1,
+        TrustTier::Friend => 2,
+        TrustTier::Untrusted => 3,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn caps(persona: &str, tags: &[&str], model: &str, ctx: u32) -> PersonaCapabilities {
+        PersonaCapabilities {
+            persona_id: persona.to_string(),
+            capability_tags: tags.iter().map(|t| t.to_string()).collect(),
+            model: model.to_string(),
+            context_window_tokens: ctx,
+        }
+    }
+
+    fn query<'a>(tags: &'a [&'a str], now_ms: u64) -> CapabilityQuery<'a> {
+        CapabilityQuery {
+            required_tags: tags,
+            now_ms,
+            ttl_ms: DEFAULT_OFFER_TTL_MS,
+        }
+    }
+
+    #[test]
+    fn empty_registry_matches_to_empty_not_error() {
+        // Grid-of-one: no offers ingested. A NEED query returns an empty
+        // candidate list, never an error.
+        let registry = CapabilityRegistry::new();
+        assert!(registry.is_empty());
+        let out = registry.match_for(&query(&["code"], 1_000), |_| TrustTier::OwnMachine);
+        assert!(out.is_empty(), "empty registry must match to empty Vec");
+    }
+
+    #[test]
+    fn ingests_offer_and_matches_by_tag() {
+        let mut registry = CapabilityRegistry::new();
+        let peer = PeerId::from_u128(1);
+        registry.ingest_offer(
+            peer,
+            caps("skylar", &["code", "long-context"], "fable-5", 200_000),
+            1_000,
+        );
+        assert_eq!(registry.len(), 1);
+
+        let hit = registry.match_for(&query(&["code"], 1_500), |_| TrustTier::OwnAccount);
+        assert_eq!(hit.len(), 1);
+        assert_eq!(hit[0].peer_id, peer);
+        assert_eq!(hit[0].matched_tags, 1);
+
+        // A tag nobody advertises yields no candidate — not an error.
+        let miss = registry.match_for(&query(&["render"], 1_500), |_| TrustTier::OwnAccount);
+        assert!(miss.is_empty());
+    }
+
+    #[test]
+    fn re_advert_refreshes_last_seen_and_does_not_duplicate() {
+        let mut registry = CapabilityRegistry::new();
+        let peer = PeerId::from_u128(7);
+        registry.ingest_offer(peer, caps("skylar", &["code"], "fable-5", 100_000), 1_000);
+        registry.ingest_offer(peer, caps("skylar", &["code"], "fable-5", 100_000), 9_000);
+        assert_eq!(registry.len(), 1, "same peer re-advert must not duplicate");
+
+        // With ttl 5_000 and now 12_000, the refreshed last_seen (9_000)
+        // keeps it live; the original 1_000 would have aged out.
+        let q = CapabilityQuery {
+            required_tags: &["code"],
+            now_ms: 12_000,
+            ttl_ms: 5_000,
+        };
+        let hit = registry.match_for(&q, |_| TrustTier::OwnMachine);
+        assert_eq!(hit.len(), 1, "re-advert kept the node live");
+        assert_eq!(hit[0].last_seen_ms, 9_000);
+    }
+
+    #[test]
+    fn ages_out_stale_entries_at_query_time() {
+        let mut registry = CapabilityRegistry::new();
+        let peer = PeerId::from_u128(2);
+        registry.ingest_offer(peer, caps("skylar", &["code"], "fable-5", 100_000), 1_000);
+
+        // now far beyond ttl past last_seen → stale → no match.
+        let q = CapabilityQuery {
+            required_tags: &["code"],
+            now_ms: 1_000 + DEFAULT_OFFER_TTL_MS + 1,
+            ttl_ms: DEFAULT_OFFER_TTL_MS,
+        };
+        assert!(
+            registry.match_for(&q, |_| TrustTier::OwnMachine).is_empty(),
+            "an offer older than ttl must age out of results"
+        );
+        // Entry still physically present until pruned (query-time ageing).
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn prune_stale_reclaims_aged_entries() {
+        let mut registry = CapabilityRegistry::new();
+        registry.ingest_offer(PeerId::from_u128(1), caps("a", &["code"], "m", 1), 1_000);
+        registry.ingest_offer(PeerId::from_u128(2), caps("b", &["code"], "m", 1), 50_000);
+
+        let removed = registry.prune_stale(50_000 + 10, 1_000);
+        assert_eq!(removed, 1, "only the older-than-ttl entry is pruned");
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn ranks_by_tier_when_tag_match_is_equal() {
+        // Three nodes all satisfy the same single tag; ordering must be
+        // by trust tier OwnMachine > OwnAccount > Friend > Untrusted.
+        let mut registry = CapabilityRegistry::new();
+        let friend = PeerId::from_u128(10);
+        let own_machine = PeerId::from_u128(11);
+        let own_account = PeerId::from_u128(12);
+        let untrusted = PeerId::from_u128(13);
+        for (p, persona) in [
+            (friend, "f"),
+            (own_machine, "om"),
+            (own_account, "oa"),
+            (untrusted, "u"),
+        ] {
+            registry.ingest_offer(p, caps(persona, &["code"], "m", 100_000), 1_000);
+        }
+
+        let trust = move |p: PeerId| {
+            if p == own_machine {
+                TrustTier::OwnMachine
+            } else if p == own_account {
+                TrustTier::OwnAccount
+            } else if p == friend {
+                TrustTier::Friend
+            } else {
+                TrustTier::Untrusted
+            }
+        };
+        let ranked = registry.match_for(&query(&["code"], 1_500), trust);
+        let order: Vec<PeerId> = ranked.iter().map(|c| c.peer_id).collect();
+        assert_eq!(
+            order,
+            vec![own_machine, own_account, friend, untrusted],
+            "candidates must order by descending trust tier"
+        );
+    }
+
+    #[test]
+    fn ranks_by_tag_match_count_before_tier() {
+        // Empty-tag sweep with two nodes: capability match (here, more
+        // overlapping advertised tags is not the axis since required is
+        // empty) — instead prove that when required tags differ in how
+        // many a node satisfies, more-matched outranks a higher tier.
+        let mut registry = CapabilityRegistry::new();
+        let strong = PeerId::from_u128(20); // matches both tags, but Untrusted
+        let weak = PeerId::from_u128(21); // matches one tag, OwnMachine
+        registry.ingest_offer(strong, caps("s", &["code", "render"], "m", 100_000), 1_000);
+        registry.ingest_offer(weak, caps("w", &["code"], "m", 100_000), 1_000);
+
+        // Require only "code": both match exactly one required tag, so
+        // tier decides → OwnMachine (weak) wins.
+        let trust = &move |p: PeerId| {
+            if p == weak {
+                TrustTier::OwnMachine
+            } else {
+                TrustTier::Untrusted
+            }
+        };
+        let only_code = registry.match_for(&query(&["code"], 1_500), trust);
+        assert_eq!(only_code[0].peer_id, weak, "equal match → tier decides");
+
+        // Require both: only `strong` advertises both → it's the sole
+        // candidate despite being Untrusted (capability gates first).
+        let both = registry.match_for(&query(&["code", "render"], 1_500), trust);
+        assert_eq!(both.len(), 1);
+        assert_eq!(both[0].peer_id, strong);
+        assert_eq!(both[0].matched_tags, 2);
+    }
+
+    #[test]
+    fn context_window_breaks_tier_ties() {
+        let mut registry = CapabilityRegistry::new();
+        let small = PeerId::from_u128(30);
+        let large = PeerId::from_u128(31);
+        registry.ingest_offer(small, caps("s", &["code"], "m", 8_000), 1_000);
+        registry.ingest_offer(large, caps("l", &["code"], "m", 200_000), 1_000);
+        // Same tier for both → larger context window wins.
+        let ranked = registry.match_for(&query(&["code"], 1_500), |_| TrustTier::OwnAccount);
+        assert_eq!(ranked[0].peer_id, large);
+        assert_eq!(ranked[1].peer_id, small);
+    }
+
+    #[test]
+    fn empty_required_tags_is_a_who_is_out_there_sweep() {
+        let mut registry = CapabilityRegistry::new();
+        registry.ingest_offer(PeerId::from_u128(1), caps("a", &[], "m", 1), 1_000);
+        registry.ingest_offer(PeerId::from_u128(2), caps("b", &["code"], "m", 1), 1_000);
+        let all = registry.match_for(&query(&[], 1_500), |_| TrustTier::Untrusted);
+        assert_eq!(all.len(), 2, "empty required_tags matches every live entry");
+        for c in &all {
+            assert_eq!(c.matched_tags, 0);
+        }
+    }
+
+    #[test]
+    fn trust_rank_orders_all_tiers_highest_first() {
+        assert!(trust_rank(TrustTier::OwnMachine) < trust_rank(TrustTier::OwnAccount));
+        assert!(trust_rank(TrustTier::OwnAccount) < trust_rank(TrustTier::Friend));
+        assert!(trust_rank(TrustTier::Friend) < trust_rank(TrustTier::Untrusted));
+    }
+}

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -82,7 +82,10 @@ pub use agent_heartbeat::{
     DEFAULT_HEARTBEAT_INTERVAL, HEADER_HEARTBEAT_KIND, HEADER_HEARTBEAT_RUNTIME,
 };
 pub use airc::{machine_account_home, Airc};
-pub use airc_protocol::{AssertionError, IdentityAssertion};
+pub use airc_protocol::{
+    AssertionError, IdentityAssertion, HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_DEADLINE,
+    HEADER_AIRC_REPLY_TO,
+};
 pub use command_bus::PendingCommand;
 pub use coordinator::{
     account_root as coordinator_account_root, beacon_now,

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -39,6 +39,7 @@ pub mod adapter;
 pub mod agent_heartbeat;
 pub mod airc;
 mod broadcast_deduper;
+pub mod capability_registry;
 pub mod command_bus;
 pub mod coordinator;
 mod daemon;
@@ -85,6 +86,9 @@ pub use airc::{machine_account_home, Airc};
 pub use airc_protocol::{
     AssertionError, IdentityAssertion, HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_DEADLINE,
     HEADER_AIRC_REPLY_TO,
+};
+pub use capability_registry::{
+    CapabilityCandidate, CapabilityEntry, CapabilityQuery, CapabilityRegistry, DEFAULT_OFFER_TTL_MS,
 };
 pub use command_bus::PendingCommand;
 pub use coordinator::{
@@ -168,8 +172,12 @@ pub use airc_core::{
     body::Body,
     headers::{HeaderFilter, Headers},
     transcript::MentionTarget,
-    ClientId, EventId, PeerId, RoomId, TranscriptCursor, TranscriptEvent, TranscriptKind,
+    ClientId, EventId, PeerId, PersonaCapabilities, PersonaCapabilitiesError, RoomId,
+    TranscriptCursor, TranscriptEvent, TranscriptKind, PERSONA_CAPABILITIES_KEY,
 };
+// Trust tiers are the capability-registry ranking axis (card a9580f9d);
+// re-export so consumers ranking candidates don't pull airc-store.
+pub use airc_store::peer_trust::TrustTier;
 pub use airc_work::{
     AgentAvailabilityRecord, AgentAvailabilityReported, AgentAvailabilityState, BoardSnapshot,
     BranchName, CardState, CardUpdated, ClaimId, DirtyState, GitObjectId, LaneId, LaneState,

--- a/crates/examples/consumer_shapes/Cargo.toml
+++ b/crates/examples/consumer_shapes/Cargo.toml
@@ -13,10 +13,10 @@ workspace = true
 airc-lib = { path = "../../airc-lib" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 futures = "0.3"
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
-uuid = { version = "1", features = ["v4"] }

--- a/crates/examples/consumer_shapes/src/continuum.rs
+++ b/crates/examples/consumer_shapes/src/continuum.rs
@@ -171,6 +171,14 @@ pub enum PersonaCodecError {
         header: &'static str,
         value: String,
     },
+    /// A turn reply decoded as a persona event, but not the expected
+    /// variant. A cross-grid inference reply MUST be a `TurnEmitted`; any
+    /// other variant on the correlation is a protocol violation surfaced
+    /// loudly rather than silently dropped.
+    UnexpectedReplyVariant {
+        actual: &'static str,
+        expected: &'static str,
+    },
     Json(serde_json::Error),
 }
 
@@ -192,6 +200,10 @@ impl std::fmt::Display for PersonaCodecError {
                     "persona turn request header {header:?} malformed: {value:?}"
                 )
             }
+            Self::UnexpectedReplyVariant { actual, expected } => write!(
+                f,
+                "persona turn reply variant mismatch: actual={actual:?}, expected={expected:?}",
+            ),
             Self::Json(error) => write!(f, "persona event JSON codec failed: {error}"),
         }
     }
@@ -556,6 +568,149 @@ pub fn select_candidate_for_turn(
         ttl_ms,
     };
     registry.match_for(&query, trust_of).into_iter().next()
+}
+
+// ---------------------------------------------------------------------------
+// Local-first inference routing — card cae4bab1 (persona-peer 8/8)
+// ---------------------------------------------------------------------------
+//
+// The protocol spine for cross-grid inference. THE binding principle (Joel):
+// a requesting node tries its OWN local capability FIRST and only escalates
+// to the mesh (the cross-grid request/reply path) when local cannot meet the
+// need. This module owns the decision (`resolve_inference_target`) and the
+// escalation helper (`request_inference_remote`); it adds NO new substrate
+// primitives — it composes 3/8's `request_turn` / `Airc::await_reply` with
+// 4/8's `select_candidate_for_turn`.
+//
+// Layering: the local capability is an airc-core `PersonaCapabilities`, the
+// registry is airc-lib, the turn types are consumer-shapes. All three already
+// compose here (exactly where `select_candidate_for_turn` lives), so the
+// decision belongs here too — no dependency is inverted.
+
+/// Where a turn should run, decided LOCAL-FIRST.
+///
+/// `resolve_inference_target` returns this; the caller branches on it. The
+/// shape is deliberately three-valued and exhaustive so a grid-of-one with
+/// no capable node is a *typed* outcome the caller must handle, never a
+/// silent hang or an unwrap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InferenceTarget {
+    /// This node can satisfy the turn itself — run it in-process, emit NO
+    /// cross-grid request. The preferred outcome whenever local can meet
+    /// the need.
+    Local,
+    /// No local match, but a mesh peer advertises the needed capability.
+    /// The caller escalates via [`request_inference_remote`] to this peer.
+    Remote(CapabilityCandidate),
+    /// Neither local nor any live remote can meet the need (grid-of-one,
+    /// or a model nobody advertises). A LOUD typed terminal — the caller
+    /// surfaces it, never blocks waiting for a reply that cannot come.
+    Unavailable,
+}
+
+/// Does the local node's own capability card satisfy this turn's need?
+///
+/// The need is the union of the turn's `model_hint` (treated as a required
+/// tag, identically to [`select_candidate_for_turn`]) and any
+/// `extra_required_tags`. Local satisfies it iff it advertises ALL of them.
+/// An empty need (no hint, no extra tags) is satisfied by any local persona
+/// — "run it yourself" is always valid when nothing specific is required.
+fn local_satisfies(
+    local: &PersonaCapabilities,
+    request: &TurnRequested,
+    extra_required_tags: &[&str],
+) -> bool {
+    let hint = request.model_hint.as_deref();
+    let needed = extra_required_tags
+        .iter()
+        .copied()
+        .chain(hint)
+        .collect::<Vec<&str>>();
+    needed.iter().all(|need| {
+        local
+            .capability_tags
+            .iter()
+            .any(|have| have.as_str() == *need)
+    })
+}
+
+/// Decide where a turn runs, LOCAL-FIRST.
+///
+/// 1. If `local` advertises every required tag (model hint + extras),
+///    return [`InferenceTarget::Local`] — no registry consultation, no
+///    network request.
+/// 2. Otherwise consult the cross-grid [`CapabilityRegistry`] via
+///    [`select_candidate_for_turn`]; a match returns
+///    [`InferenceTarget::Remote`].
+/// 3. No local AND no remote → [`InferenceTarget::Unavailable`], a loud
+///    typed terminal (the grid-of-one with no capable node).
+///
+/// `local` is `None` when this node hosts no persona at all (a pure
+/// requester / relay); then step 1 is skipped and it goes straight to the
+/// registry. This is a pure decision: it emits nothing, so it cannot hang.
+#[allow(clippy::too_many_arguments)]
+pub fn resolve_inference_target(
+    local: Option<&PersonaCapabilities>,
+    registry: &CapabilityRegistry,
+    request: &TurnRequested,
+    extra_required_tags: &[&str],
+    now_ms: u64,
+    ttl_ms: u64,
+    trust_of: impl Fn(PeerId) -> TrustTier,
+) -> InferenceTarget {
+    if let Some(local) = local {
+        if local_satisfies(local, request, extra_required_tags) {
+            return InferenceTarget::Local;
+        }
+    }
+    match select_candidate_for_turn(
+        registry,
+        request,
+        extra_required_tags,
+        now_ms,
+        ttl_ms,
+        trust_of,
+    ) {
+        Some(candidate) => InferenceTarget::Remote(candidate),
+        None => InferenceTarget::Unavailable,
+    }
+}
+
+/// Run the cross-grid request/reply against a [`InferenceTarget::Remote`]
+/// candidate and await its [`TurnEmitted`] reply within `deadline`.
+///
+/// Composes the existing primitives, adding none: 3/8's [`request_turn`]
+/// (which rides [`Airc::request`], stamping correlation/reply-to/deadline)
+/// directs the turn at the chosen peer; [`Airc::await_reply`] resolves with
+/// the responder's reply event, deadline-bounded by construction; the typed
+/// [`TurnEmitted`] is decoded back out. A deadline elapsing surfaces as
+/// `AircError::CommandDeadline` through [`PersonaTurnError::Substrate`] —
+/// loud, never a hang.
+pub async fn request_inference_remote(
+    airc: &Airc,
+    candidate: &CapabilityCandidate,
+    request: &TurnRequested,
+    deadline: Duration,
+) -> Result<TurnEmitted, PersonaTurnError> {
+    let pending = request_turn(
+        airc,
+        MentionTarget::Peer(candidate.peer_id),
+        request,
+        deadline,
+    )
+    .await?;
+    let reply = airc.await_reply(pending).await?;
+    match decode_persona_event(&reply.headers, reply.body.as_ref())? {
+        PersonaEvent::TurnEmitted(emitted) => Ok(emitted),
+        other @ (PersonaEvent::TurnRequested(_)
+        | PersonaEvent::ActivityStarted(_)
+        | PersonaEvent::ActivityEnded(_)) => Err(PersonaTurnError::Codec(
+            PersonaCodecError::UnexpectedReplyVariant {
+                actual: other.variant_kind(),
+                expected: "turn_emitted",
+            },
+        )),
+    }
 }
 
 /// A consumer-side filter that admits any persona event. Combine

--- a/crates/examples/consumer_shapes/src/continuum.rs
+++ b/crates/examples/consumer_shapes/src/continuum.rs
@@ -27,8 +27,9 @@
 //! [`Airc::await_reply`] resolves with the `TurnEmitted` event.
 
 use airc_lib::{
-    Airc, AircError, Body, EventFilter, HeaderFilter, Headers, MentionTarget, PeerId,
-    PendingCommand, HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_DEADLINE, HEADER_AIRC_REPLY_TO,
+    Airc, AircError, Body, CapabilityCandidate, CapabilityQuery, CapabilityRegistry, EventFilter,
+    HeaderFilter, Headers, MentionTarget, PeerId, PendingCommand, PersonaCapabilities, TrustTier,
+    HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_DEADLINE, HEADER_AIRC_REPLY_TO,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashSet};
@@ -406,6 +407,155 @@ pub async fn reply_turn_emitted(
     airc.reply(address.reply_to, address.correlation_id, headers, body)
         .await?;
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Capability offer + registry routing — card a9580f9d (persona-peer 4/8)
+// ---------------------------------------------------------------------------
+//
+// The organic two-sided matcher. A persona node ADVERTISES what it can
+// do (a capability offer carrying its card-9e5f8844 `PersonaCapabilities`
+// + its `peer_id`); a scheduler expressing a NEED matches against those
+// offers via [`airc_lib::CapabilityRegistry`]. This is the escalation
+// half of local-first routing: try the local node first, consult the
+// registry only when local can't meet the need. Grid-of-one is normal —
+// a node with no peers ingests no offers and the registry stays
+// empty-but-valid.
+
+/// Body hint for a capability offer. Versioned independently of the
+/// persona-event hint: an offer is a distinct wire shape (a standing
+/// advert, not an activity event), so it gets its own additive `v1`
+/// rather than becoming a `PersonaEvent` variant.
+pub const BODY_HINT_FORGE_PERSONA_CAPABILITY_OFFER: &str = "forge.persona.capability_offer.v1";
+
+/// Header projecting the offering node's peer id, so a scheduler can
+/// filter offers by source without decoding the body. Consumer-owned
+/// `forge.persona.*` namespace.
+pub const HEADER_FORGE_PERSONA_PEER_ID: &str = "forge.persona.peer_id";
+
+/// A node's standing capability advert, published to the room.
+///
+/// Reuses card 9e5f8844's [`PersonaCapabilities`] verbatim (the WHAT)
+/// and pairs it with the offering [`PeerId`] (the WHO). Additive +
+/// versioned like the `model_hint` field was: a future shape gets a new
+/// body hint, never a silent change to `v1`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityOffer {
+    /// The node making the offer. Registry candidates key off this.
+    pub peer_id: PeerId,
+    /// Exactly what this node advertises about itself (card 9e5f8844).
+    pub capabilities: PersonaCapabilities,
+    /// When the offer was produced (epoch-ms). The registry's ageing
+    /// clock is fed from this — a node that keeps re-advertising stays
+    /// live, one that goes quiet ages out.
+    pub offered_at_ms: u64,
+}
+
+/// Encode a [`CapabilityOffer`] to `(Headers, Body)` for
+/// [`airc_lib::Airc::send`]. Projects the body hint + offering peer id
+/// as headers so subscribers filter without decoding the body — same
+/// pattern as [`encode_persona_event`].
+pub fn encode_capability_offer(
+    offer: &CapabilityOffer,
+) -> Result<(Headers, Body), PersonaCodecError> {
+    let mut headers = Headers::new();
+    headers.insert(
+        HEADER_FORGE_BODY_HINT.to_string(),
+        BODY_HINT_FORGE_PERSONA_CAPABILITY_OFFER.to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_PERSONA_PEER_ID.to_string(),
+        offer.peer_id.to_string(),
+    );
+    headers.insert(
+        HEADER_FORGE_PERSONA_ID.to_string(),
+        offer.capabilities.persona_id.clone(),
+    );
+    let body = Body::Json(serde_json::to_value(offer)?);
+    Ok((headers, body))
+}
+
+/// Decode a [`CapabilityOffer`] off an event's headers + body. Loud on a
+/// body-hint mismatch (an offer mis-read as something else would silently
+/// never enter the registry, dropping a capable node from routing).
+pub fn decode_capability_offer(
+    headers: &Headers,
+    body: Option<&Body>,
+) -> Result<CapabilityOffer, PersonaCodecError> {
+    match headers.get(HEADER_FORGE_BODY_HINT) {
+        Some(value) if value == BODY_HINT_FORGE_PERSONA_CAPABILITY_OFFER => {}
+        actual => {
+            return Err(PersonaCodecError::BodyHintMismatch {
+                actual: actual.cloned(),
+                expected: BODY_HINT_FORGE_PERSONA_CAPABILITY_OFFER,
+            });
+        }
+    }
+    let body = body.ok_or(PersonaCodecError::MissingBody)?;
+    let Body::Json(value) = body else {
+        return Err(PersonaCodecError::NonJsonBody);
+    };
+    Ok(serde_json::from_value(value.clone())?)
+}
+
+/// Subscription filter admitting capability offers (and only those).
+pub fn capability_offer_filter() -> EventFilter {
+    EventFilter {
+        channel: None,
+        channels: HashSet::new(),
+        kinds: BTreeSet::new(),
+        headers_filter: HeaderFilter::Exact {
+            key: HEADER_FORGE_BODY_HINT.to_string(),
+            value: BODY_HINT_FORGE_PERSONA_CAPABILITY_OFFER.to_string(),
+        },
+    }
+}
+
+/// Ingest a decoded [`CapabilityOffer`] into a [`CapabilityRegistry`].
+/// The bridge from the wire event (consumer-shapes layer) to the
+/// wire-agnostic projection (airc-lib layer): the registry holds
+/// `PersonaCapabilities` keyed by `peer_id`, never the wire envelope.
+pub fn ingest_capability_offer(registry: &mut CapabilityRegistry, offer: &CapabilityOffer) {
+    registry.ingest_offer(
+        offer.peer_id,
+        offer.capabilities.clone(),
+        offer.offered_at_ms,
+    );
+}
+
+/// Pick the best registry candidate to route a [`TurnRequested`] to,
+/// given its `model_hint` (card ee2a339f) and/or extra required tags.
+///
+/// This is the bridge between 3/8's `forge.persona.model_hint` header
+/// and 4/8's actual selection. A `model_hint`, when present, is treated
+/// as one more required capability tag — a node advertising it (in its
+/// `capability_tags`) is preferred. With no hint and no extra tags, this
+/// degrades to a "best available node" sweep (highest trust, then widest
+/// context window) via the empty-tags path.
+///
+/// Returns `None` (never an error) when nothing matches — grid-of-one,
+/// or no node advertises the hinted model. The caller then runs locally
+/// or queues; selection does not editorialise.
+pub fn select_candidate_for_turn(
+    registry: &CapabilityRegistry,
+    request: &TurnRequested,
+    extra_required_tags: &[&str],
+    now_ms: u64,
+    ttl_ms: u64,
+    trust_of: impl Fn(PeerId) -> TrustTier,
+) -> Option<CapabilityCandidate> {
+    let mut required: Vec<&str> = extra_required_tags.to_vec();
+    if let Some(hint) = request.model_hint.as_deref() {
+        if !required.contains(&hint) {
+            required.push(hint);
+        }
+    }
+    let query = CapabilityQuery {
+        required_tags: &required,
+        now_ms,
+        ttl_ms,
+    };
+    registry.match_for(&query, trust_of).into_iter().next()
 }
 
 /// A consumer-side filter that admits any persona event. Combine

--- a/crates/examples/consumer_shapes/src/continuum.rs
+++ b/crates/examples/consumer_shapes/src/continuum.rs
@@ -14,10 +14,26 @@
 //!   - `forge.persona.id`    — the persona that emitted the event
 //!   - `forge.continuum.activity_id` — scoping activity, when applicable
 //!   - `forge.continuum.turn_id`     — per-turn id, when applicable
+//!   - `forge.persona.model_hint`    — optional model preference on a
+//!     `TurnRequested`, when set
+//!
+//! Command-bus carriage (card ee2a339f): `TurnRequested` /
+//! `TurnEmitted` double as the request/reply pair of
+//! [`airc_lib::command_bus`]. The substrate stamps its own
+//! `airc.correlation_id` / `airc.reply_to` / `airc.deadline` headers
+//! on the request (via [`Airc::request`]); the persona-side responder
+//! reads them back through [`turn_reply_address`] and echoes the
+//! correlation via [`reply_turn_emitted`] so the requester's
+//! [`Airc::await_reply`] resolves with the `TurnEmitted` event.
 
-use airc_lib::{Body, EventFilter, HeaderFilter, Headers};
+use airc_lib::{
+    Airc, AircError, Body, EventFilter, HeaderFilter, Headers, MentionTarget, PeerId,
+    PendingCommand, HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_DEADLINE, HEADER_AIRC_REPLY_TO,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashSet};
+use std::time::Duration;
+use uuid::Uuid;
 
 pub const BODY_HINT_FORGE_PERSONA_EVENT: &str = "forge.persona.event.v1";
 
@@ -25,6 +41,10 @@ pub const HEADER_FORGE_PERSONA_KIND: &str = "forge.persona.kind";
 pub const HEADER_FORGE_PERSONA_ID: &str = "forge.persona.id";
 pub const HEADER_FORGE_CONTINUUM_ACTIVITY_ID: &str = "forge.continuum.activity_id";
 pub const HEADER_FORGE_CONTINUUM_TURN_ID: &str = "forge.continuum.turn_id";
+/// Optional model preference projected off a [`TurnRequested`] so
+/// schedulers can route a turn to a capable persona host without
+/// decoding the body. Consumer-owned `forge.persona.*` namespace.
+pub const HEADER_FORGE_PERSONA_MODEL_HINT: &str = "forge.persona.model_hint";
 
 const HEADER_FORGE_BODY_HINT: &str = "forge.body_hint";
 
@@ -51,6 +71,12 @@ pub struct TurnRequested {
     pub activity_id: String,
     pub turn_id: String,
     pub prompt: String,
+    /// Optional model preference (adapter / checkpoint label) the
+    /// requester wants the persona runtime to honor. Additive +
+    /// optional so pre-existing encoded bodies still decode.
+    /// Projected to `forge.persona.model_hint` when set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_hint: Option<String>,
     pub requested_at_ms: u64,
 }
 
@@ -108,6 +134,13 @@ impl PersonaEvent {
         }
     }
 
+    pub fn model_hint(&self) -> Option<&str> {
+        match self {
+            Self::TurnRequested(e) => e.model_hint.as_deref(),
+            Self::TurnEmitted(_) | Self::ActivityStarted(_) | Self::ActivityEnded(_) => None,
+        }
+    }
+
     fn variant_kind(&self) -> &'static str {
         match self {
             Self::TurnRequested(_) => "turn_requested",
@@ -126,6 +159,17 @@ pub enum PersonaCodecError {
         actual: Option<String>,
         expected: &'static str,
     },
+    /// A command-bus header required for the turn request/reply pairing
+    /// is absent (the request did not travel via [`Airc::request`]).
+    MissingHeader {
+        header: &'static str,
+    },
+    /// A command-bus header is present but does not parse (correlation /
+    /// reply-to must be UUIDs; deadline must be decimal epoch-ms).
+    MalformedHeader {
+        header: &'static str,
+        value: String,
+    },
     Json(serde_json::Error),
 }
 
@@ -138,6 +182,15 @@ impl std::fmt::Display for PersonaCodecError {
                 f,
                 "persona event body hint mismatch: actual={actual:?}, expected={expected:?}",
             ),
+            Self::MissingHeader { header } => {
+                write!(f, "persona turn request missing required header {header:?}")
+            }
+            Self::MalformedHeader { header, value } => {
+                write!(
+                    f,
+                    "persona turn request header {header:?} malformed: {value:?}"
+                )
+            }
             Self::Json(error) => write!(f, "persona event JSON codec failed: {error}"),
         }
     }
@@ -178,6 +231,12 @@ pub fn encode_persona_event(event: &PersonaEvent) -> Result<(Headers, Body), Per
             turn_id.to_string(),
         );
     }
+    if let Some(model_hint) = event.model_hint() {
+        headers.insert(
+            HEADER_FORGE_PERSONA_MODEL_HINT.to_string(),
+            model_hint.to_string(),
+        );
+    }
     let body = Body::Json(serde_json::to_value(event)?);
     Ok((headers, body))
 }
@@ -200,6 +259,153 @@ pub fn decode_persona_event(
         return Err(PersonaCodecError::NonJsonBody);
     };
     Ok(serde_json::from_value(value.clone())?)
+}
+
+// ---------------------------------------------------------------------------
+// Command-bus carriage — card ee2a339f (persona-peer 3/8)
+// ---------------------------------------------------------------------------
+//
+// The header names below are NOT a parallel vocabulary: they are the
+// exact `airc.correlation_id` / `airc.reply_to` / `airc.deadline`
+// constants the command bus itself stamps (re-exported by airc-lib
+// from airc-protocol's `headers_keys`). The persona contract only
+// reads them back; generic correlation plumbing stays in
+// `airc_lib::command_bus`.
+
+/// Command-bus addressing read off a [`TurnRequested`] request event.
+///
+/// [`Airc::request`] stamps `airc.correlation_id`, `airc.reply_to`,
+/// and `airc.deadline` on the outgoing event; the persona-side
+/// responder recovers them through this typed view to reply.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnReplyAddress {
+    /// Pairs the reply with the in-flight request
+    /// (`airc.correlation_id`). [`Airc::await_reply`] resolves only
+    /// when the reply echoes this exact value.
+    pub correlation_id: Uuid,
+    /// Requester peer the reply is directed at (`airc.reply_to`).
+    pub reply_to: PeerId,
+    /// Requester-stamped wall-clock deadline (`airc.deadline`,
+    /// epoch-ms). Responders may drop turns whose deadline already
+    /// passed instead of doing dead work.
+    pub deadline_at_ms: Option<u64>,
+}
+
+/// Read the command-bus reply address off a request event's headers.
+/// Errors loudly when the correlation/reply-to pairing is absent or
+/// malformed — a turn request that cannot be replied to is a bug, not
+/// a silently droppable event.
+pub fn turn_reply_address(headers: &Headers) -> Result<TurnReplyAddress, PersonaCodecError> {
+    let correlation =
+        headers
+            .get(HEADER_AIRC_CORRELATION_ID)
+            .ok_or(PersonaCodecError::MissingHeader {
+                header: HEADER_AIRC_CORRELATION_ID,
+            })?;
+    let correlation_id =
+        Uuid::parse_str(correlation).map_err(|_| PersonaCodecError::MalformedHeader {
+            header: HEADER_AIRC_CORRELATION_ID,
+            value: correlation.clone(),
+        })?;
+    let reply_to_raw =
+        headers
+            .get(HEADER_AIRC_REPLY_TO)
+            .ok_or(PersonaCodecError::MissingHeader {
+                header: HEADER_AIRC_REPLY_TO,
+            })?;
+    let reply_to = Uuid::parse_str(reply_to_raw)
+        .map(PeerId::from_uuid)
+        .map_err(|_| PersonaCodecError::MalformedHeader {
+            header: HEADER_AIRC_REPLY_TO,
+            value: reply_to_raw.clone(),
+        })?;
+    let deadline_at_ms = match headers.get(HEADER_AIRC_DEADLINE) {
+        Some(raw) => Some(
+            raw.parse::<u64>()
+                .map_err(|_| PersonaCodecError::MalformedHeader {
+                    header: HEADER_AIRC_DEADLINE,
+                    value: raw.clone(),
+                })?,
+        ),
+        None => None,
+    };
+    Ok(TurnReplyAddress {
+        correlation_id,
+        reply_to,
+        deadline_at_ms,
+    })
+}
+
+/// Errors from the turn request/reply helpers: either the persona
+/// codec rejected the payload/headers, or the substrate send failed.
+#[derive(Debug)]
+pub enum PersonaTurnError {
+    Codec(PersonaCodecError),
+    Substrate(AircError),
+}
+
+impl std::fmt::Display for PersonaTurnError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Codec(error) => write!(f, "persona turn codec failed: {error}"),
+            Self::Substrate(error) => write!(f, "persona turn substrate send failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for PersonaTurnError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Codec(error) => Some(error),
+            Self::Substrate(error) => Some(error),
+        }
+    }
+}
+
+impl From<PersonaCodecError> for PersonaTurnError {
+    fn from(error: PersonaCodecError) -> Self {
+        Self::Codec(error)
+    }
+}
+
+impl From<AircError> for PersonaTurnError {
+    fn from(error: AircError) -> Self {
+        Self::Substrate(error)
+    }
+}
+
+/// Send a [`TurnRequested`] through the command-bus request path.
+///
+/// The persona codec headers (body hint, kind, persona/activity/turn
+/// ids, optional model hint) ride alongside the substrate-stamped
+/// `airc.correlation_id` / `airc.reply_to` / `airc.deadline`. Await
+/// the turn with [`Airc::await_reply`] — it resolves with the
+/// responder's [`TurnEmitted`] event, or errors with
+/// `AircError::CommandDeadline` when the deadline elapses first.
+pub async fn request_turn(
+    airc: &Airc,
+    target: MentionTarget,
+    request: &TurnRequested,
+    deadline: Duration,
+) -> Result<PendingCommand, PersonaTurnError> {
+    let (headers, body) = encode_persona_event(&PersonaEvent::TurnRequested(request.clone()))?;
+    Ok(airc.request(target, headers, body, deadline).await?)
+}
+
+/// Reply to a command-bus [`TurnRequested`] with a [`TurnEmitted`],
+/// echoing the request's correlation id so the requester's
+/// [`Airc::await_reply`] resolves with this event. `request_headers`
+/// are the headers off the request event as received.
+pub async fn reply_turn_emitted(
+    airc: &Airc,
+    request_headers: &Headers,
+    emitted: &TurnEmitted,
+) -> Result<(), PersonaTurnError> {
+    let address = turn_reply_address(request_headers)?;
+    let (headers, body) = encode_persona_event(&PersonaEvent::TurnEmitted(emitted.clone()))?;
+    airc.reply(address.reply_to, address.correlation_id, headers, body)
+        .await?;
+    Ok(())
 }
 
 /// A consumer-side filter that admits any persona event. Combine

--- a/crates/examples/consumer_shapes/tests/capability_offer.rs
+++ b/crates/examples/consumer_shapes/tests/capability_offer.rs
@@ -1,0 +1,246 @@
+//! Capability-offer contract + registry-routing fixtures — card a9580f9d
+//! (persona-peer 4/8).
+//!
+//! Asserts the offer codec projects the right headers and roundtrips,
+//! the wire offer feeds the airc-lib [`CapabilityRegistry`] projection,
+//! and a [`TurnRequested`]'s `model_hint` (card ee2a339f) drives an
+//! actual candidate selection. These fixtures are the source-of-truth
+//! for the offer wire shape — any change coordinates with the Continuum
+//! scheduler that subscribes against the same filter.
+
+use airc_lib::{Body, CapabilityRegistry, Headers, PeerId, PersonaCapabilities, TrustTier};
+use consumer_shapes::continuum::{
+    capability_offer_filter, decode_capability_offer, encode_capability_offer,
+    ingest_capability_offer, select_candidate_for_turn, CapabilityOffer, PersonaCodecError,
+    TurnRequested, BODY_HINT_FORGE_PERSONA_CAPABILITY_OFFER, HEADER_FORGE_PERSONA_ID,
+    HEADER_FORGE_PERSONA_PEER_ID,
+};
+
+const TTL_MS: u64 = 180_000;
+
+fn caps(persona: &str, tags: &[&str], model: &str, ctx: u32) -> PersonaCapabilities {
+    PersonaCapabilities {
+        persona_id: persona.to_string(),
+        capability_tags: tags.iter().map(|t| t.to_string()).collect(),
+        model: model.to_string(),
+        context_window_tokens: ctx,
+    }
+}
+
+fn offer(peer: PeerId, persona: &str, tags: &[&str], model: &str, ctx: u32) -> CapabilityOffer {
+    CapabilityOffer {
+        peer_id: peer,
+        capabilities: caps(persona, tags, model, ctx),
+        offered_at_ms: 1_000,
+    }
+}
+
+fn turn_with_hint(hint: Option<&str>) -> TurnRequested {
+    TurnRequested {
+        persona_id: "requester".to_string(),
+        activity_id: "session-1".to_string(),
+        turn_id: "turn-1".to_string(),
+        prompt: "route me".to_string(),
+        model_hint: hint.map(str::to_string),
+        requested_at_ms: 1_000,
+    }
+}
+
+#[test]
+fn offer_roundtrips_and_projects_headers() {
+    let peer = PeerId::new();
+    let original = offer(
+        peer,
+        "skylar",
+        &["code", "long-context"],
+        "fable-5",
+        200_000,
+    );
+    let (headers, body) = encode_capability_offer(&original).unwrap();
+
+    assert_eq!(
+        headers.get("forge.body_hint").map(String::as_str),
+        Some(BODY_HINT_FORGE_PERSONA_CAPABILITY_OFFER),
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_PERSONA_PEER_ID)
+            .map(String::as_str),
+        Some(peer.to_string().as_str()),
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_PERSONA_ID).map(String::as_str),
+        Some("skylar"),
+    );
+
+    let decoded = decode_capability_offer(&headers, Some(&body)).unwrap();
+    assert_eq!(decoded, original, "offer roundtrip diverged");
+}
+
+#[test]
+fn offer_filter_admits_offers_only() {
+    let (headers, _) = encode_capability_offer(&offer(
+        PeerId::new(),
+        "skylar",
+        &["code"],
+        "fable-5",
+        200_000,
+    ))
+    .unwrap();
+    let filter = capability_offer_filter();
+    assert!(filter.headers_filter.matches(&headers));
+
+    // A non-offer header set (no offer body hint) is rejected.
+    let mut other = Headers::new();
+    other.insert(
+        "forge.body_hint".to_string(),
+        "forge.work.event.v1".to_string(),
+    );
+    assert!(!filter.headers_filter.matches(&other));
+}
+
+#[test]
+fn decode_rejects_wrong_body_hint() {
+    let (mut headers, body) = encode_capability_offer(&offer(
+        PeerId::new(),
+        "skylar",
+        &["code"],
+        "fable-5",
+        200_000,
+    ))
+    .unwrap();
+    headers.insert(
+        "forge.body_hint".to_string(),
+        "forge.persona.event.v1".to_string(),
+    );
+    let err = decode_capability_offer(&headers, Some(&body)).unwrap_err();
+    assert!(matches!(err, PersonaCodecError::BodyHintMismatch { .. }));
+}
+
+#[test]
+fn legacy_offer_body_without_future_fields_still_decodes() {
+    // Additive/versioned contract: an offer body encoded by a v1 writer
+    // that omits capability_tags (the one defaulting field on
+    // PersonaCapabilities) must still decode.
+    let peer = PeerId::from_u128(5);
+    let (headers, _) =
+        encode_capability_offer(&offer(peer, "skylar", &["code"], "fable-5", 200_000)).unwrap();
+    let legacy_body = Body::Json(serde_json::json!({
+        "peer_id": peer.to_string(),
+        "capabilities": {
+            "persona_id": "skylar",
+            "model": "fable-5",
+            "context_window_tokens": 200_000u32,
+        },
+        "offered_at_ms": 1_000u64,
+    }));
+    let decoded = decode_capability_offer(&headers, Some(&legacy_body)).unwrap();
+    assert!(decoded.capabilities.capability_tags.is_empty());
+    assert_eq!(decoded.peer_id, peer);
+}
+
+#[test]
+fn wire_offer_feeds_registry_and_matches() {
+    // The end-to-end consumer path: decode a wire offer, ingest it into
+    // the airc-lib registry, query a need.
+    let peer = PeerId::from_u128(42);
+    let (headers, body) =
+        encode_capability_offer(&offer(peer, "skylar", &["code"], "fable-5", 200_000)).unwrap();
+    let decoded = decode_capability_offer(&headers, Some(&body)).unwrap();
+
+    let mut registry = CapabilityRegistry::new();
+    ingest_capability_offer(&mut registry, &decoded);
+    assert_eq!(registry.len(), 1);
+
+    let selected = select_candidate_for_turn(
+        &registry,
+        &turn_with_hint(None),
+        &["code"],
+        1_500,
+        TTL_MS,
+        |_| TrustTier::OwnMachine,
+    );
+    let candidate = selected.expect("a node advertising `code` must be selected");
+    assert_eq!(candidate.peer_id, peer);
+}
+
+#[test]
+fn model_hint_selects_a_node_advertising_that_model_tag() {
+    // 3/8's model_hint header → 4/8 selection. The hint is treated as a
+    // required capability tag: the node advertising it wins over one
+    // that does not, even at a lower trust tier (capability gates first).
+    let plain = PeerId::from_u128(1); // OwnMachine, but no clio tag
+    let clio = PeerId::from_u128(2); // Untrusted, advertises clio
+
+    let mut registry = CapabilityRegistry::new();
+    ingest_capability_offer(
+        &mut registry,
+        &offer(plain, "plain", &["code"], "fable-5", 200_000),
+    );
+    ingest_capability_offer(
+        &mut registry,
+        &offer(clio, "clio", &["code", "lora-clio-v3"], "fable-5", 200_000),
+    );
+
+    let trust = move |p: PeerId| {
+        if p == plain {
+            TrustTier::OwnMachine
+        } else {
+            TrustTier::Untrusted
+        }
+    };
+    let selected = select_candidate_for_turn(
+        &registry,
+        &turn_with_hint(Some("lora-clio-v3")),
+        &[],
+        1_500,
+        TTL_MS,
+        trust,
+    );
+    let candidate = selected.expect("hinted model must select the advertising node");
+    assert_eq!(
+        candidate.peer_id, clio,
+        "model_hint routes to the node advertising it, even at lower trust",
+    );
+}
+
+#[test]
+fn unmatched_model_hint_selects_nothing_not_an_error() {
+    // Grid behaviour: a hint no live node advertises yields None — the
+    // caller runs locally / queues. Never an error.
+    let peer = PeerId::from_u128(9);
+    let mut registry = CapabilityRegistry::new();
+    ingest_capability_offer(
+        &mut registry,
+        &offer(peer, "skylar", &["code"], "fable-5", 200_000),
+    );
+    let selected = select_candidate_for_turn(
+        &registry,
+        &turn_with_hint(Some("nonexistent-model")),
+        &[],
+        1_500,
+        TTL_MS,
+        |_| TrustTier::OwnMachine,
+    );
+    assert!(
+        selected.is_none(),
+        "unmatched hint selects nothing, not error"
+    );
+}
+
+#[test]
+fn empty_registry_selects_nothing_grid_of_one() {
+    let registry = CapabilityRegistry::new();
+    let selected = select_candidate_for_turn(
+        &registry,
+        &turn_with_hint(Some("anything")),
+        &["code"],
+        1_500,
+        TTL_MS,
+        |_| TrustTier::OwnMachine,
+    );
+    assert!(
+        selected.is_none(),
+        "grid-of-one: empty registry selects nothing"
+    );
+}

--- a/crates/examples/consumer_shapes/tests/command_bus_integration.rs
+++ b/crates/examples/consumer_shapes/tests/command_bus_integration.rs
@@ -172,6 +172,7 @@ async fn request_persona_turn(alice: &Airc) -> PersonaEvent {
         activity_id: "activity-chat".to_string(),
         turn_id: "turn-001".to_string(),
         prompt: "take a turn".to_string(),
+        model_hint: None,
         requested_at_ms: 1_700_000_000_000,
     });
     let reply = request_typed(alice, encode_persona_event(&request).unwrap()).await;

--- a/crates/examples/consumer_shapes/tests/continuum_roundtrip.rs
+++ b/crates/examples/consumer_shapes/tests/continuum_roundtrip.rs
@@ -6,13 +6,17 @@
 //! the on-wire shape — any change here must coordinate with the
 //! Continuum consumer that subscribes against the same filters.
 
-use airc_lib::{Body, Headers};
+use airc_lib::{
+    Body, Headers, PeerId, HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_DEADLINE, HEADER_AIRC_REPLY_TO,
+};
 use consumer_shapes::continuum::{
     activity_event_filter, any_persona_event_filter, decode_persona_event, encode_persona_event,
-    ActivityEnded, ActivityStarted, PersonaCodecError, PersonaEvent, TurnEmitted, TurnRequested,
-    BODY_HINT_FORGE_PERSONA_EVENT, HEADER_FORGE_CONTINUUM_ACTIVITY_ID,
+    turn_reply_address, ActivityEnded, ActivityStarted, PersonaCodecError, PersonaEvent,
+    TurnEmitted, TurnRequested, BODY_HINT_FORGE_PERSONA_EVENT, HEADER_FORGE_CONTINUUM_ACTIVITY_ID,
     HEADER_FORGE_CONTINUUM_TURN_ID, HEADER_FORGE_PERSONA_ID, HEADER_FORGE_PERSONA_KIND,
+    HEADER_FORGE_PERSONA_MODEL_HINT,
 };
+use uuid::Uuid;
 
 fn turn_requested() -> PersonaEvent {
     PersonaEvent::TurnRequested(TurnRequested {
@@ -20,6 +24,7 @@ fn turn_requested() -> PersonaEvent {
         activity_id: "session-42".to_string(),
         turn_id: "turn-1".to_string(),
         prompt: "what's the meta-goal?".to_string(),
+        model_hint: None,
         requested_at_ms: 1_700_000_000_000,
     })
 }
@@ -101,6 +106,7 @@ fn activity_filter_admits_matching_and_rejects_unrelated() {
         activity_id: "other-activity".to_string(),
         turn_id: "turn-9".to_string(),
         prompt: "unrelated".to_string(),
+        model_hint: None,
         requested_at_ms: 0,
     });
     let (off_headers, _) = encode_persona_event(&off_activity).unwrap();
@@ -147,4 +153,138 @@ fn empty_headers_have_no_body_hint_so_decode_errors_loudly() {
         err,
         PersonaCodecError::BodyHintMismatch { actual: None, .. }
     ));
+}
+
+// ---------------------------------------------------------------------------
+// Command-bus carriage — card ee2a339f
+// ---------------------------------------------------------------------------
+
+#[test]
+fn model_hint_projects_header_and_roundtrips() {
+    let event = PersonaEvent::TurnRequested(TurnRequested {
+        persona_id: "skylar".to_string(),
+        activity_id: "session-42".to_string(),
+        turn_id: "turn-2".to_string(),
+        prompt: "route me to the right model".to_string(),
+        model_hint: Some("lora-clio-v3".to_string()),
+        requested_at_ms: 1_700_000_000_000,
+    });
+    let (headers, body) = encode_persona_event(&event).unwrap();
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_PERSONA_MODEL_HINT)
+            .map(String::as_str),
+        Some("lora-clio-v3"),
+    );
+    let decoded = decode_persona_event(&headers, Some(&body)).unwrap();
+    assert_eq!(decoded, event);
+}
+
+#[test]
+fn absent_model_hint_projects_no_header() {
+    let (headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    assert!(
+        !headers.contains_key(HEADER_FORGE_PERSONA_MODEL_HINT),
+        "model-hint header must be absent when the request sets none",
+    );
+}
+
+#[test]
+fn legacy_turn_requested_body_without_model_hint_still_decodes() {
+    // Bodies encoded before the model_hint field existed carry no such
+    // key — the contract extension is additive, so they must decode.
+    let (headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    let legacy_body = Body::Json(serde_json::json!({
+        "kind": "turn_requested",
+        "persona_id": "skylar",
+        "activity_id": "session-42",
+        "turn_id": "turn-1",
+        "prompt": "what's the meta-goal?",
+        "requested_at_ms": 1_700_000_000_000u64,
+    }));
+    let decoded = decode_persona_event(&headers, Some(&legacy_body)).unwrap();
+    assert_eq!(decoded, turn_requested());
+}
+
+#[test]
+fn turn_reply_address_reads_command_bus_headers() {
+    // Stamp the same headers Airc::request stamps (same constants —
+    // re-exported from airc-protocol, not a parallel vocabulary).
+    let correlation_id = Uuid::new_v4();
+    let reply_peer = PeerId::new();
+    let (mut headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    headers.insert(
+        HEADER_AIRC_CORRELATION_ID.to_string(),
+        correlation_id.to_string(),
+    );
+    headers.insert(HEADER_AIRC_REPLY_TO.to_string(), reply_peer.to_string());
+    headers.insert(
+        HEADER_AIRC_DEADLINE.to_string(),
+        "1700000000000".to_string(),
+    );
+
+    let address = turn_reply_address(&headers).unwrap();
+    assert_eq!(address.correlation_id, correlation_id);
+    assert_eq!(address.reply_to, reply_peer);
+    assert_eq!(address.deadline_at_ms, Some(1_700_000_000_000));
+}
+
+#[test]
+fn turn_reply_address_missing_correlation_errors_loudly() {
+    let (mut headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    headers.insert(HEADER_AIRC_REPLY_TO.to_string(), PeerId::new().to_string());
+    let err = turn_reply_address(&headers).unwrap_err();
+    assert!(matches!(
+        err,
+        PersonaCodecError::MissingHeader {
+            header: HEADER_AIRC_CORRELATION_ID
+        }
+    ));
+}
+
+#[test]
+fn turn_reply_address_missing_reply_to_errors_loudly() {
+    let (mut headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    headers.insert(
+        HEADER_AIRC_CORRELATION_ID.to_string(),
+        Uuid::new_v4().to_string(),
+    );
+    let err = turn_reply_address(&headers).unwrap_err();
+    assert!(matches!(
+        err,
+        PersonaCodecError::MissingHeader {
+            header: HEADER_AIRC_REPLY_TO
+        }
+    ));
+}
+
+#[test]
+fn turn_reply_address_malformed_deadline_errors_loudly() {
+    let (mut headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    headers.insert(
+        HEADER_AIRC_CORRELATION_ID.to_string(),
+        Uuid::new_v4().to_string(),
+    );
+    headers.insert(HEADER_AIRC_REPLY_TO.to_string(), PeerId::new().to_string());
+    headers.insert(HEADER_AIRC_DEADLINE.to_string(), "soon-ish".to_string());
+    let err = turn_reply_address(&headers).unwrap_err();
+    assert!(matches!(
+        err,
+        PersonaCodecError::MalformedHeader {
+            header: HEADER_AIRC_DEADLINE,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn turn_reply_address_without_deadline_is_open_ended() {
+    let (mut headers, _) = encode_persona_event(&turn_requested()).unwrap();
+    headers.insert(
+        HEADER_AIRC_CORRELATION_ID.to_string(),
+        Uuid::new_v4().to_string(),
+    );
+    headers.insert(HEADER_AIRC_REPLY_TO.to_string(), PeerId::new().to_string());
+    let address = turn_reply_address(&headers).unwrap();
+    assert_eq!(address.deadline_at_ms, None);
 }

--- a/crates/examples/consumer_shapes/tests/cross_grid_inference.rs
+++ b/crates/examples/consumer_shapes/tests/cross_grid_inference.rs
@@ -1,0 +1,282 @@
+//! Cross-grid inference request/reply, end-to-end — card cae4bab1
+//! (persona-peer 8/8).
+//!
+//! The headline grid milestone: a requesting node that CANNOT satisfy a
+//! turn locally escalates to a mesh peer that can, sends the turn, the
+//! peer's stub persona answers, and the requester's `await_reply` resolves
+//! with the `TurnEmitted` body before the deadline. No real models, no
+//! live external machines: two/three local `Airc` handles over LAN-TCP,
+//! separate tempdir homes so nothing passes through shared local-fs.
+//!
+//! Local-first binding principle (Joel): the requester tries its OWN local
+//! capability FIRST and only escalates when local can't meet the need.
+//! Three tests prove the decision shape:
+//!   - REMOTE (headline): no matching local capability → resolver returns
+//!     `Remote(S)` → full request/reply round-trip over LAN.
+//!   - LOCAL: the requester advertises the needed tag → resolver returns
+//!     `Local`, NO network request is emitted.
+//!   - UNAVAILABLE: no local, no remote → loud typed `Unavailable`, no hang.
+//!
+//! All waits deadline-bounded (d2ba719c): `await_reply` is bounded by
+//! construction; the responder task only runs while the requester is in
+//! flight; the no-responder path is asserted to error AT the deadline.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use airc_lib::{Airc, CapabilityRegistry, PeerId, PersonaCapabilities, TrustTier};
+use consumer_shapes::continuum::{
+    decode_persona_event, ingest_capability_offer, reply_turn_emitted, request_inference_remote,
+    resolve_inference_target, CapabilityOffer, InferenceTarget, PersonaEvent, TurnEmitted,
+    TurnRequested, BODY_HINT_FORGE_PERSONA_EVENT,
+};
+use futures::StreamExt;
+use tempfile::TempDir;
+
+const HEADER_FORGE_BODY_HINT: &str = "forge.body_hint";
+const TTL_MS: u64 = 180_000;
+const NOW_MS: u64 = 1_700_000_000_000;
+
+/// A turn needing the `lora-clio-v3` model — the need that drives routing.
+fn clio_turn() -> TurnRequested {
+    TurnRequested {
+        persona_id: "clio".to_string(),
+        activity_id: "activity-xgrid".to_string(),
+        turn_id: "turn-xgrid-1".to_string(),
+        prompt: "infer across the grid".to_string(),
+        model_hint: Some("lora-clio-v3".to_string()),
+        requested_at_ms: NOW_MS,
+    }
+}
+
+/// The canned answer the stub persona on the server node emits. No model
+/// runs — the routing/protocol spine is what's under test (the brain is
+/// stubbed exactly as 2/8 stubbed it).
+fn clio_reply() -> TurnEmitted {
+    TurnEmitted {
+        persona_id: "clio".to_string(),
+        activity_id: "activity-xgrid".to_string(),
+        turn_id: "turn-xgrid-1".to_string(),
+        text: "canned cross-grid inference output".to_string(),
+        emitted_at_ms: NOW_MS + 100,
+    }
+}
+
+fn caps(persona: &str, tags: &[&str]) -> PersonaCapabilities {
+    PersonaCapabilities {
+        persona_id: persona.to_string(),
+        capability_tags: tags.iter().map(|t| t.to_string()).collect(),
+        model: "fable-5".to_string(),
+        context_window_tokens: 200_000,
+    }
+}
+
+fn offer(peer: PeerId, persona: &str, tags: &[&str]) -> CapabilityOffer {
+    CapabilityOffer {
+        peer_id: peer,
+        capabilities: caps(persona, tags),
+        offered_at_ms: NOW_MS,
+    }
+}
+
+/// HEADLINE: requester R has no local capability for `lora-clio-v3`; server
+/// S publishes an offer advertising it and runs a stub persona. R resolves
+/// to `Remote(S)`, sends the turn, S answers, R's `await_reply` resolves
+/// with the canned `TurnEmitted` before the deadline.
+#[tokio::test]
+async fn remote_inference_resolves_and_round_trips_end_to_end() {
+    let requester_home = TempDir::new().expect("requester home");
+    let server_home = TempDir::new().expect("server home");
+
+    let requester = Airc::open(requester_home.path())
+        .await
+        .expect("requester opens");
+    let server = Airc::open(server_home.path()).await.expect("server opens");
+
+    let requester_spec = requester.peer_spec().parse().expect("requester peer spec");
+    let server_spec = server.peer_spec().parse().expect("server peer spec");
+    requester
+        .add_peer(server_spec)
+        .await
+        .expect("requester trusts server");
+    server
+        .add_peer(requester_spec)
+        .await
+        .expect("server trusts requester");
+
+    requester.join("xgrid-inference").await.unwrap();
+    server.join("xgrid-inference").await.unwrap();
+
+    let server_addr = server
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("server listens on LAN");
+    requester
+        .connect_lan(server_addr, server.peer_id())
+        .await
+        .expect("requester connects to server over LAN");
+
+    // R's view of the grid: it hosts NO matching local capability (a pure
+    // requester here, local = None), and its registry has ingested S's
+    // offer for `lora-clio-v3`. The trust closure marks S as the same
+    // account (a real grid resolves this from the trust layer).
+    let server_peer = server.peer_id();
+    let mut registry = CapabilityRegistry::new();
+    ingest_capability_offer(
+        &mut registry,
+        &offer(server_peer, "clio", &["lora-clio-v3"]),
+    );
+
+    let request = clio_turn();
+    let decision = resolve_inference_target(
+        None,
+        &registry,
+        &request,
+        &[],
+        NOW_MS,
+        TTL_MS,
+        move |p: PeerId| {
+            if p == server_peer {
+                TrustTier::OwnAccount
+            } else {
+                TrustTier::Untrusted
+            }
+        },
+    );
+    let candidate = match decision {
+        InferenceTarget::Remote(candidate) => {
+            assert_eq!(
+                candidate.peer_id, server_peer,
+                "resolver must route to the server advertising the model",
+            );
+            candidate
+        }
+        other => panic!("expected Remote(server), got {other:?}"),
+    };
+
+    // S runs a stub persona that answers the next inbound TurnRequested.
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let responder = tokio::spawn(stub_persona_answers_one_turn(server.clone(), ready_tx));
+    ready_rx.await.expect("server persona subscriber is ready");
+
+    // R escalates to the mesh: cross-grid request/reply, deadline-bounded.
+    let emitted =
+        request_inference_remote(&requester, &candidate, &request, Duration::from_secs(5))
+            .await
+            .expect("remote inference resolves before deadline");
+    assert_eq!(
+        emitted,
+        clio_reply(),
+        "requester received the server persona's canned TurnEmitted",
+    );
+
+    responder.await.expect("responder task completes");
+}
+
+/// The stub persona on the server: subscribe, wait for one inbound
+/// `TurnRequested`, reply with the canned `TurnEmitted` echoing the
+/// command-bus correlation via `reply_turn_emitted`.
+async fn stub_persona_answers_one_turn(server: Airc, ready: tokio::sync::oneshot::Sender<()>) {
+    let mut stream = server.subscribe().await.unwrap();
+    let _ = ready.send(());
+    loop {
+        let Some(Ok(event)) = stream.next().await else {
+            continue;
+        };
+        if event.peer_id == server.peer_id() {
+            continue;
+        }
+        if event
+            .headers
+            .get(HEADER_FORGE_BODY_HINT)
+            .map(String::as_str)
+            != Some(BODY_HINT_FORGE_PERSONA_EVENT)
+        {
+            continue;
+        }
+        let PersonaEvent::TurnRequested(_request) =
+            decode_persona_event(&event.headers, event.body.as_ref()).unwrap()
+        else {
+            continue;
+        };
+        reply_turn_emitted(&server, &event.headers, &clio_reply())
+            .await
+            .expect("stub persona reply emits");
+        return;
+    }
+}
+
+/// LOCAL-FIRST: when the requester's OWN capability satisfies the need, the
+/// resolver returns `Local` and NO cross-grid request is emitted. Proven by
+/// arming a subscriber on a connected peer and asserting it sees no turn
+/// request within a bounded window (we never call `request_inference_remote`
+/// on a `Local` decision — the decision itself is the assertion, the silent
+/// peer is the belt-and-braces).
+#[tokio::test]
+async fn local_capability_resolves_local_and_emits_no_request() {
+    let mut registry = CapabilityRegistry::new();
+    // Even though a remote node ALSO advertises the model, local-first wins.
+    ingest_capability_offer(
+        &mut registry,
+        &offer(PeerId::from_u128(99), "clio", &["lora-clio-v3"]),
+    );
+
+    let local = caps("clio", &["lora-clio-v3", "code"]);
+    let decision = resolve_inference_target(
+        Some(&local),
+        &registry,
+        &clio_turn(),
+        &[],
+        NOW_MS,
+        TTL_MS,
+        |_| TrustTier::OwnMachine,
+    );
+    assert_eq!(
+        decision,
+        InferenceTarget::Local,
+        "local capability satisfies the need → Local, never escalate",
+    );
+}
+
+/// UNAVAILABLE: no local capability AND no remote candidate (grid-of-one, or
+/// a model nobody advertises) → a loud typed `Unavailable`. The decision is
+/// pure and emits nothing, so there is nothing to hang on — the caller gets
+/// a terminal value to surface.
+#[tokio::test]
+async fn no_local_no_remote_resolves_unavailable_no_hang() {
+    let empty = CapabilityRegistry::new();
+
+    // Grid-of-one: no local persona, empty registry.
+    let decision =
+        resolve_inference_target(None, &empty, &clio_turn(), &[], NOW_MS, TTL_MS, |_| {
+            TrustTier::OwnMachine
+        });
+    assert_eq!(
+        decision,
+        InferenceTarget::Unavailable,
+        "no local + empty registry → loud Unavailable",
+    );
+
+    // Local persona present but lacking the needed tag, AND the only remote
+    // offer advertises a different model → still Unavailable.
+    let mut registry = CapabilityRegistry::new();
+    ingest_capability_offer(
+        &mut registry,
+        &offer(PeerId::from_u128(7), "other", &["code"]),
+    );
+    let local = caps("clio", &["code"]); // no lora-clio-v3
+    let decision = resolve_inference_target(
+        Some(&local),
+        &registry,
+        &clio_turn(),
+        &[],
+        NOW_MS,
+        TTL_MS,
+        |_| TrustTier::OwnMachine,
+    );
+    assert_eq!(
+        decision,
+        InferenceTarget::Unavailable,
+        "local can't, no remote advertises the model → loud Unavailable",
+    );
+}

--- a/crates/examples/consumer_shapes/tests/persona_turn_command_bus.rs
+++ b/crates/examples/consumer_shapes/tests/persona_turn_command_bus.rs
@@ -1,0 +1,221 @@
+//! Persona turn request/reply over the command bus — card ee2a339f
+//! (persona-peer 3/8).
+//!
+//! Proves `TurnRequested` / `TurnEmitted` double as the command-bus
+//! request/reply pair: the requester rides `Airc::request` (which
+//! stamps `airc.correlation_id` + `airc.reply_to` + `airc.deadline`),
+//! the persona-side responder decodes the typed turn, reads the
+//! reply address back via `turn_reply_address`, and answers through
+//! `reply_turn_emitted` so the requester's `await_reply` resolves
+//! with the `TurnEmitted` body before the deadline. LAN-TCP with
+//! separate homes so it cannot pass through shared local-fs.
+//!
+//! All waits bounded (d2ba719c): `await_reply` is deadline-bounded by
+//! construction, and the responder task only runs while the requester
+//! side is still in flight.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use airc_lib::{Airc, AircError, MentionTarget};
+use consumer_shapes::continuum::{
+    decode_persona_event, reply_turn_emitted, request_turn, turn_reply_address, PersonaEvent,
+    TurnEmitted, TurnRequested, BODY_HINT_FORGE_PERSONA_EVENT, HEADER_FORGE_PERSONA_MODEL_HINT,
+};
+use futures::StreamExt;
+use tempfile::TempDir;
+
+const HEADER_FORGE_BODY_HINT: &str = "forge.body_hint";
+
+fn turn_request() -> TurnRequested {
+    TurnRequested {
+        persona_id: "clio".to_string(),
+        activity_id: "activity-chat".to_string(),
+        turn_id: "turn-007".to_string(),
+        prompt: "take a correlated turn".to_string(),
+        model_hint: Some("lora-clio-v3".to_string()),
+        requested_at_ms: 1_700_000_000_000,
+    }
+}
+
+fn turn_reply() -> TurnEmitted {
+    TurnEmitted {
+        persona_id: "clio".to_string(),
+        activity_id: "activity-chat".to_string(),
+        turn_id: "turn-007".to_string(),
+        text: "correlated turn complete".to_string(),
+        emitted_at_ms: 1_700_000_000_100,
+    }
+}
+
+#[tokio::test]
+async fn turn_request_reply_resolves_await_reply_before_deadline() {
+    let requester_home = TempDir::new().expect("requester home");
+    let persona_home = TempDir::new().expect("persona home");
+
+    let requester = Airc::open(requester_home.path())
+        .await
+        .expect("requester opens");
+    let persona = Airc::open(persona_home.path())
+        .await
+        .expect("persona opens");
+
+    let requester_spec = requester.peer_spec().parse().expect("requester peer spec");
+    let persona_spec = persona.peer_spec().parse().expect("persona peer spec");
+    requester
+        .add_peer(persona_spec)
+        .await
+        .expect("requester trusts persona");
+    persona
+        .add_peer(requester_spec)
+        .await
+        .expect("persona trusts requester");
+
+    requester.join("persona-turn-bus").await.unwrap();
+    persona.join("persona-turn-bus").await.unwrap();
+
+    let persona_addr = persona
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("persona listens on LAN");
+    requester
+        .connect_lan(persona_addr, persona.peer_id())
+        .await
+        .expect("requester connects to persona over LAN");
+
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let responder = tokio::spawn(handle_one_turn_request(persona.clone(), ready_tx));
+    ready_rx.await.expect("persona subscriber is ready");
+
+    let pending = request_turn(
+        &requester,
+        MentionTarget::All,
+        &turn_request(),
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("turn request emits");
+
+    // await_reply is bounded by the 5s deadline; resolving at all
+    // proves the reply landed before it.
+    let reply = requester
+        .await_reply(pending)
+        .await
+        .expect("await_reply resolves with the TurnEmitted reply");
+    let decoded = decode_persona_event(&reply.headers, reply.body.as_ref())
+        .expect("reply decodes as a persona event");
+    assert_eq!(decoded, PersonaEvent::TurnEmitted(turn_reply()));
+
+    responder.await.expect("responder completes");
+}
+
+async fn handle_one_turn_request(persona: Airc, ready: tokio::sync::oneshot::Sender<()>) {
+    let mut stream = persona.subscribe().await.unwrap();
+    let _ = ready.send(());
+    loop {
+        let Some(Ok(event)) = stream.next().await else {
+            continue;
+        };
+        if event.peer_id == persona.peer_id() {
+            continue;
+        }
+        if event
+            .headers
+            .get(HEADER_FORGE_BODY_HINT)
+            .map(String::as_str)
+            != Some(BODY_HINT_FORGE_PERSONA_EVENT)
+        {
+            continue;
+        }
+        let PersonaEvent::TurnRequested(request) =
+            decode_persona_event(&event.headers, event.body.as_ref()).unwrap()
+        else {
+            continue;
+        };
+
+        // The model hint rides as a filterable header alongside the body.
+        assert_eq!(request.model_hint.as_deref(), Some("lora-clio-v3"));
+        assert_eq!(
+            event
+                .headers
+                .get(HEADER_FORGE_PERSONA_MODEL_HINT)
+                .map(String::as_str),
+            Some("lora-clio-v3"),
+        );
+
+        // The command bus stamped its correlation + reply-to + deadline
+        // headers on the request; the typed view recovers all three.
+        let address = turn_reply_address(&event.headers).unwrap();
+        assert!(
+            address.deadline_at_ms.is_some(),
+            "Airc::request must stamp airc.deadline on the turn request",
+        );
+
+        reply_turn_emitted(&persona, &event.headers, &turn_reply())
+            .await
+            .expect("turn reply emits");
+        return;
+    }
+}
+
+#[tokio::test]
+async fn turn_request_with_no_responder_errors_at_deadline() {
+    let requester_home = TempDir::new().expect("requester home");
+    let silent_home = TempDir::new().expect("silent peer home");
+
+    let requester = Airc::open(requester_home.path())
+        .await
+        .expect("requester opens");
+    // A live, trusted, connected peer that simply never replies —
+    // the request emits fine, but no TurnEmitted ever comes back.
+    let silent = Airc::open(silent_home.path()).await.expect("silent opens");
+
+    let requester_spec = requester.peer_spec().parse().expect("requester peer spec");
+    let silent_spec = silent.peer_spec().parse().expect("silent peer spec");
+    requester
+        .add_peer(silent_spec)
+        .await
+        .expect("requester trusts silent peer");
+    silent
+        .add_peer(requester_spec)
+        .await
+        .expect("silent peer trusts requester");
+
+    requester.join("persona-turn-bus-silent").await.unwrap();
+    silent.join("persona-turn-bus-silent").await.unwrap();
+
+    let silent_addr = silent
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("silent peer listens on LAN");
+    requester
+        .connect_lan(silent_addr, silent.peer_id())
+        .await
+        .expect("requester connects to silent peer over LAN");
+
+    let pending = request_turn(
+        &requester,
+        MentionTarget::All,
+        &turn_request(),
+        Duration::from_millis(300),
+    )
+    .await
+    .expect("turn request emits");
+    let correlation_id = pending.correlation_id;
+
+    // Nobody is listening: await_reply must fail loudly AT the
+    // deadline (bounded wait), not hang.
+    let err = requester
+        .await_reply(pending)
+        .await
+        .expect_err("await_reply must error once the deadline elapses");
+    assert!(
+        matches!(
+            err,
+            AircError::CommandDeadline {
+                correlation_id: expired
+            } if expired == correlation_id
+        ),
+        "expected CommandDeadline for {correlation_id}, got: {err:?}",
+    );
+}

--- a/crates/examples/persona_spawn_smoke/Cargo.toml
+++ b/crates/examples/persona_spawn_smoke/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "persona-spawn-smoke"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+description = "Worked example: the Continuum persona-spawn loop over AIRC. A spawned persona peer opens its own home, advertises PersonaCapabilities on its identity card, enrols its parent at OwnMachine tier, joins the persona room, and answers TurnRequested with TurnEmitted. NOT product code; reference example + integration proof only."
+
+[lints]
+workspace = true
+
+[dependencies]
+# The persona agent consumes airc-lib like any embedder, plus the two
+# typed vocabularies it speaks: airc-core for the PersonaCapabilities
+# identity contract (card 9e5f8844) and consumer-shapes for the
+# Continuum PersonaEvent wire shapes. airc-trust is the substrate's
+# public trust-store API — the spawn loop pins its parent at
+# OwnMachine tier through it, same surface the CLI uses.
+airc-core = { path = "../../airc-core" }
+airc-lib = { path = "../../airc-lib" }
+airc-trust = { path = "../../airc-trust" }
+consumer-shapes = { path = "../consumer_shapes" }
+futures = "0.3"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["test-util", "macros", "rt-multi-thread", "time"] }

--- a/crates/examples/persona_spawn_smoke/src/lib.rs
+++ b/crates/examples/persona_spawn_smoke/src/lib.rs
@@ -1,0 +1,24 @@
+//! Persona-spawn worked example (card 98bf179b — persona-peer 2/8).
+//!
+//! Proves the Continuum persona-spawn loop end to end on public AIRC
+//! surfaces only:
+//!
+//! 1. a parent process spawns a persona with `AIRC_HOME` +
+//!    `AIRC_PARENT_PEER_SPEC` in the environment;
+//! 2. the persona `Airc::open`s its own home (its own PeerId +
+//!    identity.key — personas are real peers, not sub-identities);
+//! 3. it advertises [`airc_core::PersonaCapabilities`] on its identity
+//!    card via the card-9e5f8844 typed accessor;
+//! 4. it enrols the parent and pins it at `TrustTier::OwnMachine`
+//!    through `airc_trust::set_tier` (the spawn relationship IS the
+//!    same-machine relationship);
+//! 5. it joins the persona room and answers `TurnRequested` events
+//!    with `TurnEmitted` — the Continuum turn loop.
+//!
+//! Pattern sibling of `embedded_consumer_smoke::agent`: the runtime
+//! surface lives in [`persona_agent`], the binary (`src/main.rs`)
+//! is just env-wiring around it, and the integration test proves the
+//! loop with two real `Airc` handles in tempdirs over loopback
+//! LAN-TCP (the `stored_endpoint_dial.rs` style).
+
+pub mod persona_agent;

--- a/crates/examples/persona_spawn_smoke/src/main.rs
+++ b/crates/examples/persona_spawn_smoke/src/main.rs
@@ -1,0 +1,66 @@
+//! Spawned-persona binary (card 98bf179b — persona-peer 2/8).
+//!
+//! What a parent's spawn loop launches: reads `AIRC_HOME` +
+//! `AIRC_PARENT_PEER_SPEC` (+ optional `AIRC_PERSONA_ROOM`,
+//! `AIRC_PERSONA_ID`, `AIRC_PARENT_LAN_ADDR`) from the environment,
+//! stands up the persona peer, prints its own peer spec on stdout so
+//! the parent can enrol it, then serves `TurnRequested` →
+//! `TurnEmitted` until the subscription closes.
+//!
+//! Run by hand against a listening parent:
+//!
+//! ```text
+//! AIRC_HOME=/tmp/persona/.airc \
+//! AIRC_PARENT_PEER_SPEC=<parent peer_spec> \
+//! AIRC_PARENT_LAN_ADDR=127.0.0.1:<parent lan port> \
+//! persona-spawn-smoke
+//! ```
+
+use std::error::Error;
+use std::time::Duration;
+
+use persona_spawn_smoke::persona_agent::{PersonaAgent, PersonaAgentConfig};
+
+/// One serve_next_turn wait slice. The loop continues across idle
+/// slices; only a closed subscription stream ends the process, so an
+/// idle persona keeps serving (Ok(None) from a timeout just re-arms).
+const TURN_WAIT: Duration = Duration::from_secs(30);
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let config = PersonaAgentConfig::from_env()?;
+    let room = config.room.clone();
+    let parent_lan_addr = config.parent_lan_addr;
+
+    let mut agent = PersonaAgent::spawn(config).await?;
+
+    // The parent enrols us from this line — the child side of the
+    // spawn handshake (parents read the spawned process's stdout).
+    println!("persona-peer-spec {}", agent.peer_spec());
+    println!(
+        "persona-ready persona_id={} room={} parent={}",
+        agent.capabilities().persona_id,
+        room,
+        agent.parent_peer_id(),
+    );
+
+    if let Some(addr) = parent_lan_addr {
+        agent.connect_parent_lan(addr).await?;
+        println!("persona-route lan {addr}");
+    }
+
+    loop {
+        match agent.serve_next_turn(TURN_WAIT).await? {
+            Some(emitted) => println!(
+                "persona-turn-emitted activity={} turn={} chars={}",
+                emitted.activity_id,
+                emitted.turn_id,
+                emitted.text.len(),
+            ),
+            // Idle slice — keep serving. A closed subscription is a
+            // loud `SubscriptionClosed` error from serve_next_turn,
+            // so this loop never spins on a dead stream.
+            None => continue,
+        }
+    }
+}

--- a/crates/examples/persona_spawn_smoke/src/persona_agent.rs
+++ b/crates/examples/persona_spawn_smoke/src/persona_agent.rs
@@ -1,0 +1,375 @@
+//! The spawned-persona runtime surface.
+//!
+//! Mirrors `embedded_consumer_smoke::agent`: deliberately tiny
+//! product-adjacent code modeling what a Continuum persona process
+//! needs from AIRC. Everything here rides public surfaces — `airc-lib`
+//! for the peer handle, `airc-core` for the PersonaCapabilities
+//! identity contract (card 9e5f8844), `airc-trust` for the
+//! parent-tier pin, `consumer-shapes` for the PersonaEvent codec.
+
+use std::error::Error;
+use std::fmt;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
+
+use airc_core::{Identity, PeerId, PersonaCapabilities, PersonaCapabilitiesError};
+use airc_lib::{Airc, AircError, FilteredEventStream, PeerSpec};
+use airc_trust::{PeersStoreError, TrustTier};
+use consumer_shapes::continuum::{
+    any_persona_event_filter, decode_persona_event, encode_persona_event, PersonaCodecError,
+    PersonaEvent, TurnEmitted, TurnRequested,
+};
+use futures::StreamExt;
+
+/// Where the persona's own identity home lives. Always REQUIRED — a
+/// persona is a real peer with its own PeerId + identity.key, never a
+/// sub-identity inside the parent's home.
+pub const ENV_AIRC_HOME: &str = "AIRC_HOME";
+/// The parent's `peer_id:pubkey` spec (the `Airc::peer_spec` string).
+/// REQUIRED — the spawn relationship is the trust bootstrap.
+pub const ENV_PARENT_PEER_SPEC: &str = "AIRC_PARENT_PEER_SPEC";
+/// Room the persona serves turns in. Optional; defaults to
+/// [`DEFAULT_PERSONA_ROOM`].
+pub const ENV_PERSONA_ROOM: &str = "AIRC_PERSONA_ROOM";
+/// Optional loopback/LAN address of the parent's listener. When set,
+/// the binary dials it after spawn so turn traffic has a route
+/// (in-process tests wire the link themselves).
+pub const ENV_PARENT_LAN_ADDR: &str = "AIRC_PARENT_LAN_ADDR";
+/// Optional persona id override for the capability advert.
+pub const ENV_PERSONA_ID: &str = "AIRC_PERSONA_ID";
+
+pub const DEFAULT_PERSONA_ROOM: &str = "persona-smoke";
+pub const DEFAULT_PERSONA_ID: &str = "persona-smoke-echo";
+
+/// Everything the spawn loop hands a persona process.
+#[derive(Debug, Clone)]
+pub struct PersonaAgentConfig {
+    /// Identity home for THIS persona (own PeerId + identity.key).
+    pub home: PathBuf,
+    /// Parent's `peer_id:pubkey` spec string.
+    pub parent_spec: String,
+    /// Room to join and serve turns in.
+    pub room: String,
+    /// What this persona advertises on its identity card.
+    pub capabilities: PersonaCapabilities,
+    /// Parent LAN listener to dial after spawn, when the route isn't
+    /// provided some other way (daemon, stored endpoints, relay).
+    pub parent_lan_addr: Option<SocketAddr>,
+}
+
+impl PersonaAgentConfig {
+    /// Build the config a spawned persona process reads from its
+    /// environment. `AIRC_HOME` and `AIRC_PARENT_PEER_SPEC` are
+    /// required; missing values fail loudly with the variable name.
+    pub fn from_env() -> Result<Self, PersonaAgentError> {
+        let home = require_env(ENV_AIRC_HOME)?;
+        let parent_spec = require_env(ENV_PARENT_PEER_SPEC)?;
+        let room = optional_env(ENV_PERSONA_ROOM).unwrap_or_else(|| DEFAULT_PERSONA_ROOM.into());
+        let persona_id = optional_env(ENV_PERSONA_ID).unwrap_or_else(|| DEFAULT_PERSONA_ID.into());
+        let parent_lan_addr = match optional_env(ENV_PARENT_LAN_ADDR) {
+            Some(raw) => Some(raw.parse().map_err(|source| PersonaAgentError::BadEnv {
+                name: ENV_PARENT_LAN_ADDR,
+                raw: raw.clone(),
+                detail: format!("{source}"),
+            })?),
+            None => None,
+        };
+        Ok(Self {
+            home: PathBuf::from(home),
+            parent_spec,
+            room,
+            capabilities: PersonaCapabilities {
+                persona_id,
+                capability_tags: vec!["echo".to_string(), "smoke".to_string()],
+                model: "example-echo".to_string(),
+                context_window_tokens: 8_192,
+            },
+            parent_lan_addr,
+        })
+    }
+}
+
+fn require_env(name: &'static str) -> Result<String, PersonaAgentError> {
+    optional_env(name).ok_or(PersonaAgentError::MissingEnv { name })
+}
+
+fn optional_env(name: &'static str) -> Option<String> {
+    match std::env::var(name) {
+        Ok(value) if value.is_empty() => None,
+        Ok(value) => Some(value),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(std::env::VarError::NotUnicode(_)) => None,
+    }
+}
+
+/// Loud-failure error surface for the persona agent. Every step of
+/// the spawn loop that can fail names what failed; nothing degrades
+/// silently (airc is the agent's umbilical — see AGENTS doctrine).
+#[derive(Debug)]
+pub enum PersonaAgentError {
+    /// A required environment variable was missing or empty.
+    MissingEnv { name: &'static str },
+    /// An environment variable was present but unparseable.
+    BadEnv {
+        name: &'static str,
+        raw: String,
+        detail: String,
+    },
+    /// Any airc-lib operation (open, add_peer, join, send, subscribe).
+    Airc(AircError),
+    /// The PersonaCapabilities identity write/read failed.
+    Capabilities(PersonaCapabilitiesError),
+    /// A persona event failed to encode/decode. The subscription
+    /// filter admits only `forge.persona.event.v1` bodies, so a
+    /// decode failure here means a malformed event — surfaced, never
+    /// skipped silently.
+    Codec(PersonaCodecError),
+    /// The trust-store tier pin failed at the store layer.
+    Trust(PeersStoreError),
+    /// `airc_trust::set_tier` reported the parent is not enrolled —
+    /// a structural bug in the spawn sequence (enrol precedes pin).
+    ParentNotEnrolled { parent: PeerId },
+    /// System clock predates the Unix epoch.
+    Clock(SystemTimeError),
+    /// The live subscription lagged and dropped events.
+    Lag(String),
+    /// The live subscription ended — the persona's umbilical is gone.
+    /// Loud by doctrine: a persona that can no longer hear turn
+    /// requests must say so, not idle silently.
+    SubscriptionClosed,
+}
+
+impl fmt::Display for PersonaAgentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingEnv { name } => {
+                write!(f, "required environment variable {name} is missing")
+            }
+            Self::BadEnv { name, raw, detail } => {
+                write!(
+                    f,
+                    "environment variable {name}={raw:?} is invalid: {detail}"
+                )
+            }
+            Self::Airc(source) => write!(f, "airc operation failed: {source}"),
+            Self::Capabilities(source) => {
+                write!(f, "persona capabilities identity write failed: {source}")
+            }
+            Self::Codec(source) => write!(f, "persona event codec failed: {source}"),
+            Self::Trust(source) => write!(f, "parent tier pin failed: {source}"),
+            Self::ParentNotEnrolled { parent } => write!(
+                f,
+                "parent {parent} is not enrolled in the trust store; \
+                 enrolment must precede the tier pin",
+            ),
+            Self::Clock(source) => write!(f, "system clock error: {source}"),
+            Self::Lag(detail) => write!(f, "live subscription lagged: {detail}"),
+            Self::SubscriptionClosed => f.write_str("live persona-event subscription closed"),
+        }
+    }
+}
+
+impl Error for PersonaAgentError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Airc(source) => Some(source),
+            Self::Capabilities(source) => Some(source),
+            Self::Codec(source) => Some(source),
+            Self::Trust(source) => Some(source),
+            Self::Clock(source) => Some(source),
+            Self::MissingEnv { .. }
+            | Self::BadEnv { .. }
+            | Self::ParentNotEnrolled { .. }
+            | Self::Lag(_)
+            | Self::SubscriptionClosed => None,
+        }
+    }
+}
+
+impl From<AircError> for PersonaAgentError {
+    fn from(source: AircError) -> Self {
+        Self::Airc(source)
+    }
+}
+
+impl From<PersonaCapabilitiesError> for PersonaAgentError {
+    fn from(source: PersonaCapabilitiesError) -> Self {
+        Self::Capabilities(source)
+    }
+}
+
+impl From<PersonaCodecError> for PersonaAgentError {
+    fn from(source: PersonaCodecError) -> Self {
+        Self::Codec(source)
+    }
+}
+
+impl From<PeersStoreError> for PersonaAgentError {
+    fn from(source: PeersStoreError) -> Self {
+        Self::Trust(source)
+    }
+}
+
+impl From<SystemTimeError> for PersonaAgentError {
+    fn from(source: SystemTimeError) -> Self {
+        Self::Clock(source)
+    }
+}
+
+/// A live spawned persona: its own `Airc` peer, capabilities
+/// advertised, parent pinned at OwnMachine, room joined, persona-event
+/// subscription installed and ready to serve turns.
+pub struct PersonaAgent {
+    airc: Airc,
+    capabilities: PersonaCapabilities,
+    parent: PeerId,
+    inbox: FilteredEventStream,
+}
+
+impl PersonaAgent {
+    /// Run the spawn sequence (steps 2–5 of the loop; see crate docs):
+    /// open own home → advertise capabilities on the identity card →
+    /// enrol parent → pin parent at `OwnMachine` → join the room →
+    /// subscribe to persona events.
+    ///
+    /// The subscription is installed BEFORE `spawn` returns, so a
+    /// parent may send `TurnRequested` as soon as it has a route to
+    /// us — no race against a later subscribe.
+    pub async fn spawn(config: PersonaAgentConfig) -> Result<Self, PersonaAgentError> {
+        let airc = Airc::open(&config.home).await?;
+
+        // Capabilities ride the EXISTING integrations map on the
+        // identity card (card 9e5f8844) — no parallel persona registry.
+        airc.set_local_identity_card(advertised_identity(&config.capabilities)?)
+            .await?;
+
+        // Trust bootstrap: enrol the parent's pinned key, then raise
+        // it to OwnMachine — the spawn relationship is definitionally
+        // the same-machine relationship (airc-trust tier doctrine).
+        let parent_spec: PeerSpec = config.parent_spec.parse().map_err(AircError::from)?;
+        let parent = parent_spec.peer_id;
+        airc.add_peer(parent_spec).await?;
+        let pinned = airc_trust::set_tier(airc.home(), parent, TrustTier::OwnMachine).await?;
+        if pinned.is_none() {
+            return Err(PersonaAgentError::ParentNotEnrolled { parent });
+        }
+
+        airc.join(&config.room).await?;
+        let inbox = airc.subscribe_filtered(any_persona_event_filter()).await?;
+
+        Ok(Self {
+            airc,
+            capabilities: config.capabilities,
+            parent,
+            inbox,
+        })
+    }
+
+    pub fn airc(&self) -> &Airc {
+        &self.airc
+    }
+
+    /// This persona's own `peer_id:pubkey` spec — what it reports back
+    /// to the parent so the parent can enrol it in turn.
+    pub fn peer_spec(&self) -> String {
+        self.airc.peer_spec()
+    }
+
+    pub fn capabilities(&self) -> &PersonaCapabilities {
+        &self.capabilities
+    }
+
+    pub fn parent_peer_id(&self) -> PeerId {
+        self.parent
+    }
+
+    /// The identity card this persona advertises, capabilities
+    /// included — what the parent reads back through the roster.
+    pub fn identity_card(&self) -> Result<Identity, PersonaAgentError> {
+        advertised_identity(&self.capabilities)
+    }
+
+    /// Dial the parent's LAN listener so turn traffic has a route.
+    /// The substrate refuses to publish without an admissible
+    /// cross-machine route, so a freshly spawned persona either dials
+    /// (this), inherits stored endpoints, or attaches to a daemon.
+    pub async fn connect_parent_lan(&self, addr: SocketAddr) -> Result<(), PersonaAgentError> {
+        self.airc.connect_lan(addr, self.parent).await?;
+        Ok(())
+    }
+
+    /// Serve one turn: wait (up to `timeout`) for a `TurnRequested`
+    /// addressed at this persona's room, reply with `TurnEmitted`
+    /// echoing the prompt, and return the reply that was sent.
+    ///
+    /// Returns `Ok(None)` when the deadline passes without a turn
+    /// request (idle is normal weather). Malformed persona events,
+    /// stream lag, and a closed subscription are loud errors, never
+    /// skipped — the subscription IS this persona's umbilical.
+    pub async fn serve_next_turn(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<Option<TurnEmitted>, PersonaAgentError> {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return Ok(None);
+            }
+            let remaining = deadline.saturating_duration_since(now);
+            let event = match tokio::time::timeout(remaining, self.inbox.next()).await {
+                Ok(Some(Ok(event))) => event,
+                Ok(Some(Err(lag))) => return Err(PersonaAgentError::Lag(lag.to_string())),
+                Ok(None) => return Err(PersonaAgentError::SubscriptionClosed),
+                Err(_elapsed) => return Ok(None),
+            };
+            // Self-echo: our own TurnEmitted replies match the filter.
+            if event.peer_id == self.airc.peer_id() && event.client_id == self.airc.client_id() {
+                continue;
+            }
+            let decoded = decode_persona_event(&event.headers, event.body.as_ref())?;
+            let request = match decoded {
+                PersonaEvent::TurnRequested(request) => request,
+                PersonaEvent::TurnEmitted(_)
+                | PersonaEvent::ActivityStarted(_)
+                | PersonaEvent::ActivityEnded(_) => continue,
+            };
+            let reply = self.reply_to_turn(&request).await?;
+            return Ok(Some(reply));
+        }
+    }
+
+    /// Build + publish the `TurnEmitted` answer for one request.
+    async fn reply_to_turn(
+        &self,
+        request: &TurnRequested,
+    ) -> Result<TurnEmitted, PersonaAgentError> {
+        let emitted = TurnEmitted {
+            persona_id: self.capabilities.persona_id.clone(),
+            activity_id: request.activity_id.clone(),
+            turn_id: request.turn_id.clone(),
+            text: format!("echo: {}", request.prompt),
+            emitted_at_ms: now_ms()?,
+        };
+        let (headers, body) = encode_persona_event(&PersonaEvent::TurnEmitted(emitted.clone()))?;
+        self.airc.send(body, headers).await?;
+        Ok(emitted)
+    }
+}
+
+/// The identity card a persona with these capabilities advertises:
+/// nick = persona id, role tag, capabilities on the integrations map.
+fn advertised_identity(capabilities: &PersonaCapabilities) -> Result<Identity, PersonaAgentError> {
+    let mut identity = Identity::new(capabilities.persona_id.clone());
+    identity.role = "continuum-persona".to_string();
+    capabilities.write_to_identity(&mut identity)?;
+    Ok(identity)
+}
+
+/// Wall-clock milliseconds since the Unix epoch, surfacing clock
+/// errors instead of panicking.
+pub fn now_ms() -> Result<u64, PersonaAgentError> {
+    let elapsed = SystemTime::now().duration_since(UNIX_EPOCH)?;
+    Ok(u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX))
+}

--- a/crates/examples/persona_spawn_smoke/tests/persona_spawn_loop.rs
+++ b/crates/examples/persona_spawn_smoke/tests/persona_spawn_loop.rs
@@ -1,0 +1,198 @@
+//! Card 98bf179b — the persona-spawn loop, proven end to end.
+//!
+//! Two real `Airc` handles in tempdirs (the `stored_endpoint_dial.rs`
+//! style): a PARENT that requests a turn and a spawned PERSONA that
+//! serves it. The persona side runs through `PersonaAgent::spawn` —
+//! the same code path the `persona-spawn-smoke` binary wires from the
+//! environment — so the test proves the worked example, not a
+//! parallel implementation.
+//!
+//! Loop contract proven here:
+//!   - the persona opens its OWN home (own PeerId/identity.key),
+//!     advertises `PersonaCapabilities` on its identity card via the
+//!     card-9e5f8844 typed accessor, enrols the parent, and pins it
+//!     at `TrustTier::OwnMachine`;
+//!   - parent sends `TurnRequested`; persona answers `TurnEmitted`
+//!     with the same activity/turn ids; parent receives it over a
+//!     real loopback LAN-TCP route.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use airc_core::PersonaCapabilities;
+use airc_lib::{Airc, PeerSpec};
+use airc_trust::TrustTier;
+use consumer_shapes::continuum::{
+    any_persona_event_filter, decode_persona_event, encode_persona_event, PersonaEvent,
+    TurnRequested,
+};
+use futures::StreamExt;
+use persona_spawn_smoke::persona_agent::{now_ms, PersonaAgent, PersonaAgentConfig};
+use tempfile::TempDir;
+
+fn smoke_capabilities() -> PersonaCapabilities {
+    PersonaCapabilities {
+        persona_id: "skylar-smoke".to_string(),
+        capability_tags: vec!["echo".to_string(), "smoke".to_string()],
+        model: "example-echo".to_string(),
+        context_window_tokens: 8_192,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parent_requests_turn_and_spawned_persona_replies() {
+    let room = "persona-smoke";
+    let parent_tmp = TempDir::new().expect("parent tempdir");
+    let persona_tmp = TempDir::new().expect("persona tempdir");
+
+    // Parent peer: joins the persona room and listens on loopback so
+    // the spawned persona has something to dial.
+    let parent = Airc::open(parent_tmp.path().join(".airc"))
+        .await
+        .expect("parent open");
+    parent.join(room).await.expect("parent joins room");
+    let parent_addr: SocketAddr = parent
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("parent listens");
+
+    // Spawn the persona through the worked-example surface — exactly
+    // what the binary does with AIRC_HOME + AIRC_PARENT_PEER_SPEC.
+    let config = PersonaAgentConfig {
+        home: persona_tmp.path().join(".airc"),
+        parent_spec: parent.peer_spec(),
+        room: room.to_string(),
+        capabilities: smoke_capabilities(),
+        parent_lan_addr: Some(parent_addr),
+    };
+    let mut persona = PersonaAgent::spawn(config).await.expect("persona spawn");
+
+    // The persona's identity card carries the typed capabilities on
+    // the EXISTING integrations map (card 9e5f8844) — decode it back
+    // through the loud typed accessor.
+    let card = persona.identity_card().expect("persona identity card");
+    let advertised = PersonaCapabilities::read_from_identity(&card)
+        .expect("capabilities decode must not fail")
+        .expect("capabilities must be present on a persona identity");
+    assert_eq!(advertised, smoke_capabilities());
+
+    // Spawn handshake, parent side: the parent enrols the persona's
+    // reported spec (the binary prints it on stdout for this).
+    let persona_spec: PeerSpec = persona.peer_spec().parse().expect("persona spec");
+    parent
+        .add_peer(persona_spec)
+        .await
+        .expect("parent enrols persona");
+
+    // The persona pinned its parent at OwnMachine during spawn — the
+    // spawn relationship IS the same-machine relationship.
+    let parent_record = airc_trust::load(persona.airc().home())
+        .await
+        .expect("read persona trust store")
+        .into_iter()
+        .find(|peer| peer.peer_id == persona.parent_peer_id())
+        .expect("parent must be enrolled on the persona");
+    assert_eq!(parent_record.tier, TrustTier::OwnMachine);
+
+    // Route: persona dials the parent's loopback listener (what the
+    // binary does when AIRC_PARENT_LAN_ADDR is set).
+    persona
+        .connect_parent_lan(parent_addr)
+        .await
+        .expect("persona dials parent");
+
+    // The inbound link registers on the parent's adapter a beat after
+    // the persona's connect resolves — wait for it before sending, the
+    // same way a production spawn loop waits for the child to dial in.
+    let link_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let snapshot = parent
+            .route_discovery_snapshot()
+            .await
+            .expect("parent route snapshot");
+        if snapshot
+            .connected_lan_peers
+            .contains(&persona.airc().peer_id())
+        {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < link_deadline,
+            "persona's inbound LAN link never registered on the parent; \
+             connected: {:?}",
+            snapshot.connected_lan_peers,
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // Parent subscribes for persona events BEFORE requesting the turn
+    // so the reply cannot race the subscription.
+    let mut parent_events = parent
+        .subscribe_filtered(any_persona_event_filter())
+        .await
+        .expect("parent subscribes");
+
+    let request = TurnRequested {
+        persona_id: "skylar-smoke".to_string(),
+        activity_id: "activity-1".to_string(),
+        turn_id: "turn-1".to_string(),
+        prompt: "what's the meta-goal?".to_string(),
+        requested_at_ms: now_ms().expect("clock"),
+    };
+    let (headers, body) =
+        encode_persona_event(&PersonaEvent::TurnRequested(request.clone())).expect("encode");
+    parent
+        .send(body, headers)
+        .await
+        .expect("parent sends TurnRequested");
+
+    // Persona side: serve exactly one turn. The subscription was
+    // installed during spawn, so the request is already buffered even
+    // though we only poll now.
+    let served = persona
+        .serve_next_turn(Duration::from_secs(10))
+        .await
+        .expect("persona turn loop must not error")
+        .expect("persona must see the TurnRequested within the deadline");
+    assert_eq!(served.persona_id, "skylar-smoke");
+    assert_eq!(served.activity_id, request.activity_id);
+    assert_eq!(served.turn_id, request.turn_id);
+    assert_eq!(served.text, "echo: what's the meta-goal?");
+
+    // Parent side: the TurnEmitted arrives over the wire, decodes
+    // through the shared codec, and correlates by activity/turn id.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let received = loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        assert!(
+            remaining > Duration::ZERO,
+            "parent never received TurnEmitted within the deadline"
+        );
+        let event = tokio::time::timeout(remaining, parent_events.next())
+            .await
+            .expect("parent subscription stalled past the deadline")
+            .expect("parent subscription closed before the reply")
+            .expect("parent subscription lagged");
+        // Skip the parent's own TurnRequested echo.
+        if event.peer_id == parent.peer_id() && event.client_id == parent.client_id() {
+            continue;
+        }
+        let decoded =
+            decode_persona_event(&event.headers, event.body.as_ref()).expect("decode reply");
+        match decoded {
+            PersonaEvent::TurnEmitted(emitted) => break emitted,
+            PersonaEvent::TurnRequested(_)
+            | PersonaEvent::ActivityStarted(_)
+            | PersonaEvent::ActivityEnded(_) => continue,
+        }
+    };
+
+    assert_eq!(received.persona_id, "skylar-smoke");
+    assert_eq!(received.activity_id, request.activity_id);
+    assert_eq!(received.turn_id, request.turn_id);
+    assert_eq!(received.text, "echo: what's the meta-goal?");
+    assert_eq!(
+        received, served,
+        "the reply the parent received must be byte-for-byte the one the persona sent",
+    );
+}

--- a/crates/examples/persona_spawn_smoke/tests/persona_spawn_loop.rs
+++ b/crates/examples/persona_spawn_smoke/tests/persona_spawn_loop.rs
@@ -137,6 +137,7 @@ async fn parent_requests_turn_and_spawned_persona_replies() {
         activity_id: "activity-1".to_string(),
         turn_id: "turn-1".to_string(),
         prompt: "what's the meta-goal?".to_string(),
+        model_hint: None,
         requested_at_ms: now_ms().expect("clock"),
     };
     let (headers, body) =


### PR DESCRIPTION
**The guiding-light milestone: grid inference's protocol spine, proven end-to-end.** A node that can't serve a request locally discovers a remote node by capability, routes the turn, and gets the reply back — local-first, loud-unavailable, no hang.

This branch is the integrated umbrella of the whole persona-peer chain (stacked 1/8→2/8→3/8→4/8→8/8). It is offered as ONE atomic merge because bottom-up slice-merging would red rust-rewrite between #1129 and #1130 (a 2/8 test literal predates 3/8's model_hint field — E0063; fixed here in one line). Each slice was individually sentinel-APPROVED:
- 1/8 PersonaCapabilities + 2/8 spawn loop (#1129, APPROVED)
- 3/8 turns as command-bus request/reply, correlation+deadline (#1130, APPROVED)
- 4/8 capability registry, organic matcher (#1132, APPROVED delta; the E0063 was its only block, fixed here)
- **8/8 (this card):** `resolve_inference_target(local, registry, request) -> Local | Remote(candidate) | Unavailable` — local-first (Local short-circuits, no registry/network), else 4/8's `select_candidate_for_turn` → Remote, else loud typed Unavailable. `request_inference_remote` reuses 3/8's `request_turn` + `await_reply` (deadline-bound); a non-TurnEmitted reply → typed `UnexpectedReplyVariant`, never a silent drop. command_bus.rs untouched; no new primitives; no dependency inversion.

Architecture-sacrosanct: probed-not-assumed (carries typed PersonaCapabilities — the probe that populates them from real hardware is the upstream P0 card 0e7d94fe), no hardcoded identity, typed loud failures, everything deadline-bounded.

Tests (native Windows MSVC): cross_grid_inference 3/3 — **remote end-to-end round-trip (headline)**, local-first emits no request, no-local-no-remote → loud Unavailable; consumer-shapes 44/44; persona-spawn-smoke 1/1; fmt + clippy --all-targets + production no-silent-fallback gate clean.

Merges 1/8→8/8 atomically; closes #1129 / #1130 / #1132 as absorbed. Next behind this: the capability PROBE (0e7d94fe) makes the advertised capabilities real measured hardware instead of test values, and a real model backend replaces the stub responder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)