### PR TITLE
feat(hooks): fetch + behind-check before commit/push — sync before building on a stale base (card 64621946)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -396,6 +396,80 @@ if (Test-Path $skillsSrc) {
     }
 }
 
+# -- Git fetch-before-commit/push staleness guard (card 64621946) --------
+# Parity with install.sh's _install_airc_git_hooks. The hooks themselves
+# are bash and run under git-bash on Windows, so the cleanest Windows path
+# is to drive the SAME composition logic through bash rather than maintain
+# a divergent PowerShell reimplementation. We invoke git-bash to run the
+# composer that writes the wrapper hooks, composing (not clobbering) any
+# pre-existing hooks — identical contract to the .sh side.
+if ($env:AIRC_SKIP_GIT_HOOKS -ne '1') {
+    $gitHooksWorker = Join-Path $CLONE_DIR 'integrations\git-hooks\airc-fetch-base.sh'
+    $bashExe = $null
+    foreach ($cand in @(
+        (Get-Command bash.exe -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Source),
+        'C:\Program Files\Git\bin\bash.exe',
+        'C:\Program Files\Git\usr\bin\bash.exe'
+    )) {
+        if ($cand -and (Test-Path $cand)) { $bashExe = $cand; break }
+    }
+    if (-not (Test-Path $gitHooksWorker)) {
+        Write-Warn2 "Git hook worker not found: $gitHooksWorker (skipping hook install)"
+    } elseif (-not $bashExe) {
+        Write-Warn2 'git-bash not found; skipping git fetch-before-commit/push hook install'
+    } else {
+        Write-Step 'Wiring git fetch-before-commit/push staleness guard (card 64621946)'
+        $cloneForBash = $CLONE_DIR -replace '\\','/'
+        $composer = @'
+set -u
+CLONE_DIR="$1"
+hooks_dir="$CLONE_DIR/.git/hooks"
+worker="$CLONE_DIR/integrations/git-hooks/airc-fetch-base.sh"
+hp="$(git -C "$CLONE_DIR" config --get core.hooksPath 2>/dev/null || true)"
+if [ -n "$hp" ]; then
+  case "$hp" in
+    /*|[A-Za-z]:*) hooks_dir="$hp" ;;
+    *) hooks_dir="$CLONE_DIR/$hp" ;;
+  esac
+fi
+[ -d "$CLONE_DIR/.git" ] || exit 0
+[ -f "$worker" ] || exit 0
+mkdir -p "$hooks_dir" || exit 0
+chmod +x "$worker" 2>/dev/null || true
+marker="# AIRC-FETCH-HOOK"
+for phase in pre-commit pre-push; do
+  hook="$hooks_dir/$phase"
+  if [ -f "$hook" ] && ! grep -qF "$marker" "$hook" 2>/dev/null; then
+    if [ ! -f "$hook.local" ]; then
+      mv "$hook" "$hook.local"
+      chmod +x "$hook.local" 2>/dev/null || true
+    else
+      rm -f "$hook"
+    fi
+  fi
+  tmp="$hook.airc-tmp.$$"
+  {
+    printf '%s\n' "#!/usr/bin/env bash"
+    printf '%s %s\n' "$marker" "— managed by airc install.ps1 (card 64621946); do not edit."
+    printf '%s\n' "set -u"
+    printf 'WORKER=%q\n' "$worker"
+    printf 'LOCAL="${BASH_SOURCE[0]}.local"\n'
+    printf 'if [ -x "$WORKER" ] || [ -f "$WORKER" ]; then\n'
+    printf '  bash "$WORKER" %q "$@" || exit $?\n' "$phase"
+    printf 'fi\n'
+    printf 'if [ -x "$LOCAL" ]; then exec "$LOCAL" "$@"; fi\n'
+    printf 'exit 0\n'
+  } > "$tmp"
+  mv "$tmp" "$hook"
+  chmod +x "$hook" 2>/dev/null || true
+  echo "  + Git hook installed: $phase"
+done
+'@
+        & $bashExe --noprofile --norc -c $composer 'airc-githooks' $cloneForBash 2>&1 | ForEach-Object { Write-Host "  $_" }
+        Write-Ok 'Git fetch-before-commit/push staleness guard wired'
+    }
+}
+
 # -- Final guidance ------------------------------------------------------
 Write-Host ''
 Write-Ok 'airc installed.'

--- a/install.sh
+++ b/install.sh
@@ -924,6 +924,78 @@ if command -v codex >/dev/null 2>&1 && [ -d "$HOME/.codex" ]; then
   _install_airc_codex_hooks
 fi
 
+# ── Git fetch-before-commit/push staleness guard (card 64621946) ───────
+# Wire the repo's own dev workflow with a pre-commit (advisory) + pre-push
+# (may hard-gate) hook that fetches the integration base and warns/blocks
+# when the local base is stale. This is what stops tonight's hazard:
+# branches cut off a 5-commits-behind rust-rewrite → E0063 between slices.
+#
+# Composition contract (CBAR Extension Bar — extend, don't clobber):
+# if $CLONE_DIR already has a pre-commit / pre-push hook that is NOT
+# ours, we preserve it: the original is moved to <hook>.local and our
+# wrapper chains to it after running the guard. Re-running install
+# rewrites only the airc-owned wrapper (marker-gated), so it is fully
+# idempotent. Installs ONLY into the airc clone's own .git/hooks — this
+# is a dev-tree guard, not a product-surface change for end users.
+
+_install_airc_git_hooks() {
+  [ "${AIRC_SKIP_GIT_HOOKS:-0}" = "1" ] && return 0
+  local hooks_dir="$CLONE_DIR/.git/hooks"
+  local worker="$CLONE_DIR/integrations/git-hooks/airc-fetch-base.sh"
+  # core.hooksPath override (e.g. when the repo points hooks elsewhere).
+  local hp
+  hp="$(git -C "$CLONE_DIR" config --get core.hooksPath 2>/dev/null || true)"
+  if [ -n "$hp" ]; then
+    case "$hp" in
+      /*|[A-Za-z]:*) hooks_dir="$hp" ;;
+      *) hooks_dir="$CLONE_DIR/$hp" ;;
+    esac
+  fi
+  [ -d "$CLONE_DIR/.git" ] || { return 0; }   # not a clone (curl-piped src tree edge case)
+  [ -f "$worker" ] || { warn "Git hook worker not found: $worker"; return 0; }
+  mkdir -p "$hooks_dir" 2>/dev/null || { warn "Could not create $hooks_dir"; return 0; }
+  chmod +x "$worker" 2>/dev/null || true
+
+  local phase hook tmp marker="# AIRC-FETCH-HOOK"
+  for phase in pre-commit pre-push; do
+    hook="$hooks_dir/$phase"
+    # If a foreign (non-airc) hook is already here, preserve it as .local
+    # so our wrapper can chain to it. Don't re-stash our own wrapper.
+    if [ -f "$hook" ] && ! grep -qF "$marker" "$hook" 2>/dev/null; then
+      if [ ! -f "$hook.local" ]; then
+        mv "$hook" "$hook.local"
+        chmod +x "$hook.local" 2>/dev/null || true
+        info "Preserved existing $phase hook as $phase.local (chained)"
+      else
+        # A .local already exists; drop the un-marked file rather than clobber it.
+        rm -f "$hook"
+      fi
+    fi
+    tmp="$hook.airc-tmp.$$"
+    {
+      printf '%s\n' "#!/usr/bin/env bash"
+      printf '%s %s\n' "$marker" "— managed by airc install.sh (card 64621946); do not edit."
+      printf '%s\n' "# Runs the fetch-before-commit/push staleness guard, then chains any"
+      printf '%s\n' "# pre-existing hook preserved as this file + .local."
+      printf '%s\n' "set -u"
+      printf 'WORKER=%q\n' "$worker"
+      printf 'LOCAL="${BASH_SOURCE[0]}.local"\n'
+      printf '%s\n' "# Guard runs first. pre-push may exit non-zero (hard-gate when behind)."
+      printf 'if [ -x "$WORKER" ] || [ -f "$WORKER" ]; then\n'
+      printf '  bash "$WORKER" %q "$@" || exit $?\n' "$phase"
+      printf 'fi\n'
+      printf '%s\n' "# Chain a preserved local hook, forwarding stdin (pre-push gets refs on stdin)."
+      printf 'if [ -x "$LOCAL" ]; then exec "$LOCAL" "$@"; fi\n'
+      printf 'exit 0\n'
+    } > "$tmp"
+    mv "$tmp" "$hook"
+    chmod +x "$hook" 2>/dev/null || true
+    ok "Git hook installed: $phase (fetch-before-$phase staleness guard)"
+  done
+}
+
+_install_airc_git_hooks
+
 # ── Codex GH_TOKEN env injection ───────────────────────────────────────
 # Codex's sandbox can't reliably reach the macOS Keychain to validate
 # gh's stored token. Result: gh auth status flakes between ✓ and X

--- a/integrations/git-hooks/airc-fetch-base.sh
+++ b/integrations/git-hooks/airc-fetch-base.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# airc-fetch-base.sh — fetch-before-commit/push staleness guard.
+#
+# Card 64621946. Tonight's merge-order hazard: branches were cut off a
+# rust-rewrite that was already 5 commits behind, so a slice built on a
+# stale base and the integration produced E0063 between slices. This hook
+# fetches the integration base (timeout-bounded, throttled, offline-safe)
+# and compares local HEAD against it BEFORE a commit (advisory) or a push
+# (may hard-gate) so the agent syncs first instead of building stale.
+#
+# Invoked by .git/hooks/pre-commit and .git/hooks/pre-push, which pass the
+# phase as $1:
+#   pre-commit  → advisory: warn if behind, ALWAYS exit 0 (never block a commit)
+#   pre-push    → gating:   warn if behind AND exit 1 (pushing stale is the hazard)
+#
+# Optional-transport doctrine applied to git: a failed/slow fetch (offline,
+# rate-limited, no network) NEVER blocks. It prints a brief note and the
+# behind-check falls back to whatever the last successful fetch left in the
+# local origin/<base> ref.
+#
+# Runs in git-bash on Windows (no visible console window — the calling hook
+# is already a bash script invoked by git). Pure bash + git; no airc binary
+# dependency, so it works even on a half-installed tree.
+#
+# Env knobs (all optional):
+#   AIRC_HOOK_SKIP=1            disable the guard entirely (escape hatch)
+#   AIRC_HOOK_FETCH_TIMEOUT=5   fetch timeout in seconds
+#   AIRC_HOOK_THROTTLE=180      skip fetch if one ran < this many seconds ago
+#   AIRC_HOOK_BASE=<ref>        force the integration base (else auto-detect)
+#   AIRC_HOOK_PUSH_BLOCK=1      pre-push hard-gates when behind (default 1; set 0 for advisory-only push)
+
+set -u
+
+PHASE="${1:-pre-commit}"
+
+# Hard escape hatch — never let the guard be the thing that wedges a commit.
+[ "${AIRC_HOOK_SKIP:-0}" = "1" ] && exit 0
+
+FETCH_TIMEOUT="${AIRC_HOOK_FETCH_TIMEOUT:-5}"
+THROTTLE="${AIRC_HOOK_THROTTLE:-180}"
+PUSH_BLOCK="${AIRC_HOOK_PUSH_BLOCK:-1}"
+
+# Resolve repo root and the marker file. If we are not in a git repo, do
+# nothing (defensive; git would not invoke a hook outside one, but the
+# script may be sourced or run by tests).
+GIT_DIR="$(git rev-parse --git-dir 2>/dev/null)" || exit 0
+[ -n "$GIT_DIR" ] || exit 0
+MARKER="$GIT_DIR/airc-last-fetch"
+
+# ── Determine the integration base ──────────────────────────────────────
+# Preference order:
+#   1. AIRC_HOOK_BASE override.
+#   2. The branch's own upstream (@{u}), stripped of remote prefix, IF that
+#      upstream is a known integration line. A feature branch usually tracks
+#      its base (origin/rust-rewrite) once pushed, which is exactly what we
+#      want to measure against.
+#   3. First of rust-rewrite / canary / main that exists on origin.
+_remote="origin"
+
+_base_branch=""
+if [ -n "${AIRC_HOOK_BASE:-}" ]; then
+  _base_branch="$AIRC_HOOK_BASE"
+else
+  # Upstream of the current branch, if set (e.g. "origin/rust-rewrite").
+  _up="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+  case "$_up" in
+    origin/*)
+      _cand="${_up#origin/}"
+      case "$_cand" in
+        rust-rewrite|canary|main) _base_branch="$_cand" ;;
+      esac
+      ;;
+  esac
+  if [ -z "$_base_branch" ]; then
+    for _cand in rust-rewrite canary main; do
+      if git show-ref --verify --quiet "refs/remotes/$_remote/$_cand" \
+         || git ls-remote --exit-code --heads "$_remote" "$_cand" >/dev/null 2>&1; then
+        _base_branch="$_cand"
+        break
+      fi
+    done
+  fi
+fi
+
+# No discoverable base → nothing to compare; succeed silently.
+[ -n "$_base_branch" ] || exit 0
+
+BASE_REF="$_remote/$_base_branch"
+
+# ── Throttle: skip the network fetch if one ran recently ────────────────
+# mtime-age of the marker. On any successful OR attempted fetch we touch it
+# so a flapping-offline machine still backs off the network. The behind-check
+# below always runs against whatever local origin/<base> we have, throttled
+# or not, so rapid commits still get the cheap local advisory.
+_now="$(date +%s 2>/dev/null || echo 0)"
+_should_fetch=1
+if [ -f "$MARKER" ]; then
+  _mtime="$(date -r "$MARKER" +%s 2>/dev/null || echo 0)"
+  if [ "$_mtime" -gt 0 ] && [ "$_now" -gt 0 ]; then
+    _age=$(( _now - _mtime ))
+    if [ "$_age" -ge 0 ] && [ "$_age" -lt "$THROTTLE" ]; then
+      _should_fetch=0
+    fi
+  fi
+fi
+
+# ── Timeout-bounded fetch helper ────────────────────────────────────────
+# Prefer coreutils `timeout` (present in git-bash on Windows). Fall back to
+# a background+wait+kill if it is missing. Either way a hung/slow fetch is
+# bounded and never blocks. Returns 0 on a successful fetch, non-zero on
+# failure OR timeout — the caller treats both as "fetch skipped".
+_bounded_fetch() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$FETCH_TIMEOUT" git fetch --quiet "$_remote" "$_base_branch" >/dev/null 2>&1
+    return $?
+  fi
+  # Fallback: background the fetch, kill it if it overruns the budget.
+  git fetch --quiet "$_remote" "$_base_branch" >/dev/null 2>&1 &
+  local _pid=$!
+  local _waited=0
+  while kill -0 "$_pid" 2>/dev/null; do
+    if [ "$_waited" -ge "$FETCH_TIMEOUT" ]; then
+      kill "$_pid" 2>/dev/null
+      wait "$_pid" 2>/dev/null
+      return 124
+    fi
+    sleep 1
+    _waited=$(( _waited + 1 ))
+  done
+  wait "$_pid"
+  return $?
+}
+
+_fetch_ok=skip
+if [ "$_should_fetch" = "1" ]; then
+  # Touch the marker BEFORE the fetch so even a hung/killed fetch advances
+  # the throttle clock (offline machines must not retry every commit).
+  : > "$MARKER" 2>/dev/null || true
+  if _bounded_fetch; then
+    _fetch_ok=yes
+    : > "$MARKER" 2>/dev/null || true
+  else
+    _fetch_ok=no
+  fi
+fi
+
+# ── Behind-check (cheap, local) ─────────────────────────────────────────
+# Always run, throttled or not. Counts commits reachable from BASE_REF but
+# not from HEAD. If origin/<base> ref does not exist locally (never fetched,
+# offline first run) the rev-list fails → treat as "unknown", do not block.
+_behind=""
+if git show-ref --verify --quiet "refs/remotes/$BASE_REF"; then
+  _behind="$(git rev-list --count "HEAD..$BASE_REF" 2>/dev/null || echo "")"
+fi
+
+# Brief offline note (only when we actually tried and failed — not on throttle).
+if [ "$_fetch_ok" = "no" ]; then
+  printf '  \033[1;33m!\033[0m airc: fetch skipped (offline?) — staleness check used last-known %s\n' "$BASE_REF" >&2
+fi
+
+# Nothing to say if we could not compute a behind-count.
+if [ -z "$_behind" ] || [ "$_behind" = "0" ]; then
+  exit 0
+fi
+
+# ── Behind by N>0 → LOUD advisory ───────────────────────────────────────
+RED=$'\033[1;31m'; YEL=$'\033[1;33m'; RST=$'\033[0m'
+{
+  printf '%s\n' "$YEL┌──────────────────────────────────────────────────────────────$RST"
+  printf '%s\n' "$YEL│ ⚠  BEHIND $BASE_REF BY $_behind COMMIT(S)$RST"
+  printf '%s\n' "$YEL│    Your base is stale — building on it risks merge-order"
+  printf '%s\n' "$YEL│    breakage (E0063-between-slices class).$RST"
+  printf '%s\n' "$YEL│    Sync first:$RST"
+  printf '%s\n' "$YEL│      git pull --ff-only $_remote $_base_branch$RST"
+  printf '%s\n' "$YEL│      # or: git rebase $BASE_REF$RST"
+  printf '%s\n' "$YEL└──────────────────────────────────────────────────────────────$RST"
+} >&2
+
+if [ "$PHASE" = "pre-push" ] && [ "$PUSH_BLOCK" = "1" ]; then
+  printf '%s\n' "${RED}✗ airc: refusing to push a branch built on a base $_behind commit(s) behind $BASE_REF.$RST" >&2
+  printf '%s\n' "${RED}  Sync and retry, or set AIRC_HOOK_PUSH_BLOCK=0 to override for this push.$RST" >&2
+  exit 1
+fi
+
+# pre-commit (or advisory-only push) — warn but never block.
+exit 0

--- a/test/fetch_before_commit_hook.sh
+++ b/test/fetch_before_commit_hook.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# fetch_before_commit_hook.sh — tests for the fetch-before-commit/push
+# staleness guard (card 64621946: integrations/git-hooks/airc-fetch-base.sh).
+#
+# Spins up throwaway repos with a fake "origin" (a local bare repo) so no
+# network is touched, and asserts the binding behaviors:
+#   1. origin ahead  → behind-advisory printed.
+#   2. pre-push when behind → hard-gate (exit 1).
+#   3. pre-commit when behind → advisory only (exit 0, never blocks).
+#   4. origin unreachable → warns "fetch skipped (offline?)" AND exit 0
+#      (the key one — a failed fetch must never block).
+#   5. recent .git/airc-last-fetch marker → fetch is throttled (skipped),
+#      behind-check still runs against the last-known ref.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORKER="$ROOT/integrations/git-hooks/airc-fetch-base.sh"
+[ -f "$WORKER" ] || { echo "fetch-hook test failed: worker not found: $WORKER" >&2; exit 1; }
+
+PASS=0
+fail() { echo "fetch-hook test FAILED: $*" >&2; exit 1; }
+ok()   { PASS=$((PASS+1)); echo "  ok: $*"; }
+
+TMP="$(mktemp -d 2>/dev/null || mktemp -d -t airchook)"
+cleanup() { rm -rf "$TMP" 2>/dev/null || true; }
+trap cleanup EXIT
+
+export GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="test@test" \
+       GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="test@test"
+# Deterministic + fast.
+export AIRC_HOOK_BASE="rust-rewrite" AIRC_HOOK_FETCH_TIMEOUT="5" AIRC_HOOK_THROTTLE="180"
+
+# ── Build: bare origin on rust-rewrite, a clone, then advance origin ────
+ORIGIN="$TMP/origin.git"
+WORK="$TMP/work"
+git init --quiet --bare "$ORIGIN"
+
+# Seed the bare repo via a scratch clone on rust-rewrite.
+SEED="$TMP/seed"
+git clone --quiet "$ORIGIN" "$SEED"
+( cd "$SEED"
+  git checkout --quiet -b rust-rewrite
+  echo one > f.txt; git add f.txt; git commit --quiet -m "c1"
+  git push --quiet -u origin rust-rewrite
+)
+
+# The work clone tracks origin/rust-rewrite at c1.
+git clone --quiet "$ORIGIN" "$WORK"
+( cd "$WORK" && git checkout --quiet rust-rewrite )
+
+# Advance origin by 2 commits so the work clone is "behind by 2".
+( cd "$SEED"
+  echo two >> f.txt; git add f.txt; git commit --quiet -m "c2"
+  echo three >> f.txt; git add f.txt; git commit --quiet -m "c3"
+  git push --quiet origin rust-rewrite
+)
+
+run_hook() { # phase, cwd  → prints output, returns hook rc
+  ( cd "$2" && bash "$WORKER" "$1" 2>&1 )
+}
+
+# ── 1+3. pre-commit advisory: warns "behind ... by 2", exits 0 ──────────
+rm -f "$WORK/.git/airc-last-fetch"
+set +e
+out="$(cd "$WORK" && bash "$WORKER" pre-commit 2>&1)"; rc=$?
+set -e
+echo "$out" | grep -qiE "behind .*rust-rewrite.* by 2" || fail "pre-commit did not warn behind-by-2; got: $out"
+[ "$rc" -eq 0 ] || fail "pre-commit must exit 0 (advisory) even when behind; got rc=$rc"
+ok "pre-commit advisory: warns behind-by-2 and exits 0"
+
+# ── 2. pre-push hard-gate when behind (exit 1) ──────────────────────────
+rm -f "$WORK/.git/airc-last-fetch"
+set +e
+out="$(cd "$WORK" && bash "$WORKER" pre-push 2>&1)"; rc=$?
+set -e
+echo "$out" | grep -qiE "behind .*rust-rewrite.* by 2" || fail "pre-push did not warn behind; got: $out"
+[ "$rc" -eq 1 ] || fail "pre-push must hard-gate (exit 1) when behind; got rc=$rc"
+ok "pre-push hard-gates (exit 1) when behind"
+
+# ── pre-push override AIRC_HOOK_PUSH_BLOCK=0 → advisory only ─────────────
+rm -f "$WORK/.git/airc-last-fetch"
+set +e
+out="$(cd "$WORK" && AIRC_HOOK_PUSH_BLOCK=0 bash "$WORKER" pre-push 2>&1)"; rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "pre-push with PUSH_BLOCK=0 must exit 0; got rc=$rc"
+ok "pre-push respects AIRC_HOOK_PUSH_BLOCK=0 (advisory)"
+
+# ── 4. origin UNREACHABLE → warns offline AND exits 0 (never blocks) ────
+# Point origin at a dead path so the fetch fails fast. Remove the local
+# tracking ref so there is no behind-count to compute — proves a failed
+# fetch alone never blocks, on the most stale-prone phase (pre-push).
+DEAD="$TMP/work_offline"
+git clone --quiet "$ORIGIN" "$DEAD"
+( cd "$DEAD" && git checkout --quiet rust-rewrite )
+( cd "$DEAD" && git remote set-url origin "$TMP/does-not-exist.git" )
+rm -f "$DEAD/.git/airc-last-fetch"
+set +e
+out="$(cd "$DEAD" && bash "$WORKER" pre-push 2>&1)"; rc=$?
+set -e
+echo "$out" | grep -qiE "fetch skipped \(offline" || fail "offline run did not print 'fetch skipped (offline?)'; got: $out"
+[ "$rc" -eq 0 ] || fail "offline fetch must NOT block (exit 0); got rc=$rc"
+ok "offline (fetch fails) → warns + exits 0, never blocks (KEY behavior)"
+
+# ── 5. recent marker → fetch throttled (skipped) ────────────────────────
+# Set the marker to "now" and point origin at a dead URL. If the hook
+# honored the throttle it will NOT attempt the fetch, so it must NOT print
+# the offline note. Behind-check still runs against the last-known ref
+# (none here for this fresh clone → no advisory, clean exit 0).
+THROT="$TMP/work_throttle"
+git clone --quiet "$ORIGIN" "$THROT"
+( cd "$THROT" && git checkout --quiet rust-rewrite )
+( cd "$THROT" && git remote set-url origin "$TMP/does-not-exist.git" )
+: > "$THROT/.git/airc-last-fetch"   # fresh mtime = now
+set +e
+out="$(cd "$THROT" && bash "$WORKER" pre-commit 2>&1)"; rc=$?
+set -e
+if echo "$out" | grep -qiE "fetch skipped \(offline"; then
+  fail "throttle did not skip the fetch (got offline note from a dead remote): $out"
+fi
+[ "$rc" -eq 0 ] || fail "throttled pre-commit must exit 0; got rc=$rc"
+ok "recent marker throttles the fetch (no network attempt)"
+
+echo "fetch-before-commit hook: all $PASS checks passed"


### PR DESCRIPTION
Joel's request — catches the stale-base hazard that caused tonight's merge-order pain (branches cut off a 5-commits-behind rust-rewrite → E0063 between slices).

- `integrations/git-hooks/airc-fetch-base.sh`: one pure-bash worker (no airc-binary dep — works on a half-built tree). Auto-detects the integration base (AIRC_HOOK_BASE → branch's @{u} if it tracks rust-rewrite/canary/main → first of those on origin), timeout-bounded `git fetch` (5s, with a background+kill fallback), then `HEAD..origin/<base>` behind-check.
- **Non-brittle (the whole point):** fetch failure (offline/rate-limited) → "fetch skipped (offline?)" + EXIT 0, NEVER blocks the commit (optional-transport doctrine for git). Throttle: skips the network fetch if one ran <180s ago (marker touched BEFORE fetch so a hung fetch still advances the clock); cheap local behind-check still runs. pre-commit = advisory (warn, exit 0); pre-push = hard-gate (exit 1) when behind, still non-blocking on fetch failure. Escape hatches AIRC_HOOK_SKIP / AIRC_HOOK_PUSH_BLOCK / AIRC_SKIP_GIT_HOOKS. No console window.
- **Composes, doesn't clobber (CBAR Extension Bar):** a pre-existing hook is moved to `<hook>.local` and exec'd after the guard (stdin forwarded for pre-push refs); marker-gated + idempotent (re-install never double-stashes). Mirrors the existing codex-hook/skills installer conventions — no parallel installer.
- Wired into install.sh (`_install_airc_git_hooks`) + install.ps1 (drives the same bash composer via git-bash — hooks are bash, no divergent PS reimplementation).

Tests (`test/fetch_before_commit_hook.sh`, no network — throwaway ahead-origin): 5/5 — advisory-warns-on-behind, pre-push-hard-gates, PUSH_BLOCK=0 respected, **offline→warns+exits-0 (never blocks)**, recent-marker-throttles. bash -n clean; install.ps1 PSParser 0 errors; existing guards still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)