### PR TITLE
perf(work): persistent work-board projection cache — resume from cursor instead of replaying the log (card 1291173d)

### DIFF
--- a/crates/airc-cli/src/merger.rs
+++ b/crates/airc-cli/src/merger.rs
@@ -112,11 +112,15 @@ async fn tick_once(
     airc: &Airc,
     dry_run: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Limit chosen large enough to surface every Review card with a
-    // PR in practice. The board fetch already filters heartbeats
-    // (card 79953b4d), so 256 work events back is several days of
-    // realistic mutation rate.
-    let board = airc.work_board(256).await?;
+    // Card 1291173d: the COMPLETE board, not a recent window — a
+    // Review card whose last event scrolled out of a fixed 256-event
+    // window would silently never merge. `work_board_complete` is the
+    // documented surface for scheduling code, and with the persistent
+    // projection cache each tick costs one incremental resume from
+    // the last-applied cursor instead of a full event-log replay.
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
     let snapshot = board.snapshot();
 
     // Card d5b7b07d: fetch the baseline (rust-rewrite HEAD's failing

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -308,23 +308,29 @@ impl Airc {
         Ok(merged)
     }
 
-    /// Fetch ALL transcript events on `channel` via the daemon, paging
-    /// forward from the start. The daemon-attached source for projections
-    /// that need the complete history (e.g. the work board).
-    pub(crate) async fn daemon_room_transcripts(
+    /// Fetch every transcript event on `channel` strictly after
+    /// `cursor`, paging forward. The daemon-attached source for
+    /// complete-history projections (the work board): pass the zero
+    /// cursor for the full history, or a cached projection's
+    /// last-applied cursor to resume incrementally (card 1291173d)
+    /// instead of replaying the room from event zero. The SDK
+    /// `lamport` is the losslessly-packed owner-core `(epoch,
+    /// counter)` seq, so unpacking it reproduces the exact IPC
+    /// cursor the daemon paged with.
+    pub(crate) async fn daemon_room_transcripts_since(
         &self,
         channel: RoomId,
+        cursor: &TranscriptCursor,
         page_size: usize,
     ) -> Result<Vec<TranscriptEvent>, AircError> {
         let page_size = page_size.max(1);
         let client = self.require_daemon_client()?;
         let mut all = Vec::new();
-        // Start strictly after the zero cursor ⇒ from the first event
-        // (epochs begin at 1, so (0,0) precedes everything).
+        let (epoch, counter) = unpack_seq(cursor.lamport);
         let mut since = Some(IpcCursor {
-            epoch: 0,
-            counter: 0,
-            event_id: airc_core::EventId::from_u128(0),
+            epoch,
+            counter,
+            event_id: cursor.event_id,
         });
         loop {
             let response = client
@@ -347,6 +353,31 @@ impl Airc {
             }
         }
         Ok(all)
+    }
+
+    /// Cursor of the newest transcript event on `channel` via the
+    /// daemon, or `None` for an empty room. The cheap freshness probe
+    /// for a cached work-board projection (card 1291173d): when an
+    /// incremental resume returns no events, the cache is only valid
+    /// if its cursor IS the room tip — anything else (log rewound,
+    /// store wiped) is a mismatch and the caller rebuilds from
+    /// scratch instead of serving stale state.
+    pub(crate) async fn daemon_latest_transcript_cursor(
+        &self,
+        channel: RoomId,
+    ) -> Result<Option<TranscriptCursor>, AircError> {
+        let response = self
+            .require_daemon_client()?
+            .inbox(InboxRequest {
+                since: None,
+                channel: Some(channel),
+                limit: Some(1),
+            })
+            .await?;
+        let Some(bytes) = response.envelopes.into_iter().next_back() else {
+            return Ok(None);
+        };
+        Ok(Some(decode_wire_event(bytes)?.cursor()))
     }
 
     /// Live subscribe across `channels` via the daemon: open one IPC

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -71,6 +71,7 @@ mod webrtc;
 pub mod webrtc_media;
 pub mod webrtc_signaling;
 pub mod work;
+pub(crate) mod work_board_cache;
 pub mod work_manager;
 pub mod work_roster;
 pub mod work_subscription;

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -15,6 +15,10 @@ use airc_work::{
 use airc_work_store::WorkEventStore;
 
 use crate::time::now_ms;
+use crate::work_board_cache::{
+    cursor_strictly_before, zero_transcript_cursor, WorkBoardCache, WorkBoardCacheSource,
+    WORK_BOARD_CACHE_FORMAT_VERSION,
+};
 use crate::{Airc, AircError};
 
 const WORK_MUTATION_PAGE_SIZE: usize = 512;
@@ -814,21 +818,174 @@ impl Airc {
     /// otherwise. Centralises the read so the whole work subsystem is
     /// daemon-aware — work is event-sourced, so its reads must follow the
     /// same path as its writes (`send_frame` → daemon when attached).
+    ///
+    /// Card 1291173d: the complete projection no longer replays the
+    /// room from event zero on every read. A snapshot of the
+    /// projection, keyed by the cursor of the last transcript event
+    /// folded into it, is persisted under this scope's home; the next
+    /// read resumes strictly after that cursor and applies only the
+    /// new events. Any cache anomaly (corrupt file, version bump,
+    /// source mismatch, a cursor the log no longer agrees with) is
+    /// logged loudly and recovered by a full from-scratch replay —
+    /// the cache is an accelerator, never an authority.
     async fn project_room_work_board(
         &self,
         room: &crate::Room,
         page_size: usize,
     ) -> Result<WorkBoardProjection, AircError> {
-        if self.is_daemon_attached() {
-            let transcripts = self
-                .daemon_room_transcripts(room.channel, page_size)
-                .await?;
-            return Ok(airc_work_store::project_transcripts(transcripts)?);
+        let source = if self.is_daemon_attached() {
+            WorkBoardCacheSource::Daemon
+        } else {
+            WorkBoardCacheSource::Store
+        };
+        if let Some(cache) = WorkBoardCache::load(self.home(), room.channel, source) {
+            if let Some(projection) = self
+                .resume_work_board(room, cache, source, page_size)
+                .await?
+            {
+                return Ok(projection);
+            }
         }
-        let store = WorkEventStore::new(self.event_store());
-        Ok(store
-            .project_complete(Some(room.channel), page_size)
-            .await?)
+
+        // Cold start or discarded cache: full replay from event zero.
+        let transcripts = self
+            .room_transcripts_since(room, &zero_transcript_cursor(), page_size)
+            .await?;
+        let cursor = transcripts.last().map(airc_core::TranscriptEvent::cursor);
+        let projection = airc_work_store::project_transcripts(transcripts)?;
+        if let Some(cursor) = cursor {
+            WorkBoardCache {
+                version: WORK_BOARD_CACHE_FORMAT_VERSION,
+                channel: room.channel,
+                source,
+                cursor,
+                projection: projection.clone(),
+            }
+            .save(self.home());
+        }
+        Ok(projection)
+    }
+
+    /// Resume the work-board projection from a persisted snapshot:
+    /// fetch only the transcript events strictly after the snapshot's
+    /// cursor and fold them in with the same windowed-apply rule the
+    /// full replay uses. Returns `Ok(None)` when the snapshot must be
+    /// discarded (the log disagrees with its cursor) — the caller
+    /// rebuilds from scratch. Transport/store errors propagate; they
+    /// are not a cache problem.
+    async fn resume_work_board(
+        &self,
+        room: &crate::Room,
+        cache: WorkBoardCache,
+        source: WorkBoardCacheSource,
+        page_size: usize,
+    ) -> Result<Option<WorkBoardProjection>, AircError> {
+        let new_transcripts = self
+            .room_transcripts_since(room, &cache.cursor, page_size)
+            .await?;
+
+        let Some(first) = new_transcripts.first() else {
+            // Nothing strictly after the cached cursor. That is only
+            // consistent with the log if the cursor IS the room tip;
+            // anything else (rewound / wiped store, foreign cursor)
+            // means the snapshot describes a log that no longer
+            // exists — rebuild, never serve it.
+            let tip = self.room_latest_cursor(room).await?;
+            if tip.as_ref() == Some(&cache.cursor) {
+                return Ok(Some(cache.projection));
+            }
+            eprintln!(
+                "work board cache: snapshot cursor (lamport {}) is not the tip of channel {} — \
+                 log rewound or replaced; rebuilding projection from scratch",
+                cache.cursor.lamport, room.channel
+            );
+            return Ok(None);
+        };
+
+        // Resume is strictly-after: the first new event must sort after
+        // the cached cursor or the log's ordering contradicts the
+        // snapshot.
+        let first_cursor = first.cursor();
+        if !cursor_strictly_before(&cache.cursor, &first_cursor) {
+            eprintln!(
+                "work board cache: channel {} returned event at lamport {} not strictly after \
+                 snapshot cursor (lamport {}) — rebuilding projection from scratch",
+                room.channel, first_cursor.lamport, cache.cursor.lamport
+            );
+            return Ok(None);
+        }
+
+        let mut projection = cache.projection;
+        // Non-empty page ⇒ a newest cursor always exists; track it from
+        // the same fetch that produced the events so the snapshot can
+        // never run ahead of what was actually folded in.
+        let newest = new_transcripts
+            .last()
+            .map(airc_core::TranscriptEvent::cursor)
+            .unwrap_or(first_cursor);
+        airc_work_store::apply_transcripts(&mut projection, new_transcripts)?;
+        WorkBoardCache {
+            version: WORK_BOARD_CACHE_FORMAT_VERSION,
+            channel: room.channel,
+            source,
+            cursor: newest,
+            projection: projection.clone(),
+        }
+        .save(self.home());
+        Ok(Some(projection))
+    }
+
+    /// Every transcript event on `room`'s channel strictly after
+    /// `cursor`, in transcript order — via the daemon when attached,
+    /// the local store otherwise. Pass the zero cursor for the
+    /// complete history.
+    async fn room_transcripts_since(
+        &self,
+        room: &crate::Room,
+        cursor: &airc_core::TranscriptCursor,
+        page_size: usize,
+    ) -> Result<Vec<airc_core::TranscriptEvent>, AircError> {
+        if self.is_daemon_attached() {
+            return self
+                .daemon_room_transcripts_since(room.channel, cursor, page_size)
+                .await;
+        }
+        let store = self.event_store();
+        let page_size = page_size.max(1);
+        let mut cursor = cursor.clone();
+        let mut all = Vec::new();
+        loop {
+            let page = store
+                .resume_from(&cursor, Some(room.channel), page_size)
+                .await
+                .map_err(AircError::from)?;
+            let count = page.len();
+            let Some(newest) = page.last().map(airc_core::TranscriptEvent::cursor) else {
+                break;
+            };
+            all.extend(page);
+            if count < page_size {
+                break;
+            }
+            cursor = newest;
+        }
+        Ok(all)
+    }
+
+    /// Cursor of the newest transcript event on `room`'s channel, or
+    /// `None` for an empty room — via the daemon when attached, the
+    /// local store otherwise.
+    async fn room_latest_cursor(
+        &self,
+        room: &crate::Room,
+    ) -> Result<Option<airc_core::TranscriptCursor>, AircError> {
+        if self.is_daemon_attached() {
+            return self.daemon_latest_transcript_cursor(room.channel).await;
+        }
+        self.event_store()
+            .latest_cursor(Some(room.channel))
+            .await
+            .map_err(AircError::from)
     }
 
     /// Return work cards this peer could reasonably take next. This

--- a/crates/airc-lib/src/work_board_cache.rs
+++ b/crates/airc-lib/src/work_board_cache.rs
@@ -1,0 +1,273 @@
+//! Persistent work-board projection cache (card 1291173d).
+//!
+//! Every complete work-board read used to replay the room's full
+//! transcript from event zero — `airc work board`, `airc work next`,
+//! every claim/state mutation guard, every merger tick. The daemon's
+//! owner-core resume model already pages strictly-after a cursor, so
+//! the complete projection is incrementalizable: snapshot the
+//! projection keyed by the last-applied transcript cursor, and on the
+//! next read apply only the events that landed after it.
+//!
+//! Invariants:
+//!
+//! - **Projection semantics are untouched.** The cache stores the
+//!   output of the exact same decode + `apply_windowed` pipeline the
+//!   from-scratch rebuild uses; resuming from snapshot `S` at cursor
+//!   `c` with events `(c, tip]` is the same fold as replaying
+//!   `[0, tip]` — first-write-wins arbitration and close-guards
+//!   included.
+//! - **Fail loud, rebuild from scratch.** Any anomaly — unreadable or
+//!   corrupt cache file, format-version bump, channel or source
+//!   mismatch, a cursor the log no longer agrees with (rewound /
+//!   wiped store) — logs a warning and falls back to the full
+//!   replay. The cache is never trusted over the log; stale state is
+//!   never served silently.
+//! - **Crash-safe writes.** Snapshots are written to a temp file and
+//!   atomically renamed; a torn write is an unreadable cache, which
+//!   is just a rebuild.
+
+use std::path::{Path, PathBuf};
+
+use airc_core::{EventId, RoomId, TranscriptCursor};
+use airc_work::WorkBoardProjection;
+use serde::{Deserialize, Serialize};
+
+/// Bump when the persisted shape (or projection semantics feeding it)
+/// changes; old snapshots are then discarded and rebuilt.
+pub(crate) const WORK_BOARD_CACHE_FORMAT_VERSION: u32 = 1;
+
+/// Subdirectory of the scope home holding one snapshot per room.
+const CACHE_DIR: &str = "work-board-cache";
+
+/// The strictly-before-everything resume point: epochs begin at 1 and
+/// lamport packs `(epoch, counter)`, so `(0, 0)` precedes every real
+/// event on both the daemon and the direct-store read paths.
+pub(crate) fn zero_transcript_cursor() -> TranscriptCursor {
+    TranscriptCursor {
+        lamport: 0,
+        event_id: EventId::from_u128(0),
+    }
+}
+
+/// True iff `left` is strictly before `right` in transcript order —
+/// lamport first, event_id tiebreaker. Same total order the stores
+/// page by.
+pub(crate) fn cursor_strictly_before(left: &TranscriptCursor, right: &TranscriptCursor) -> bool {
+    left.lamport < right.lamport
+        || (left.lamport == right.lamport && left.event_id.0 < right.event_id.0)
+}
+
+/// Which log the snapshot was projected from. A daemon-attached scope
+/// reads the owner-core's transcript over IPC; a detached scope reads
+/// its local store. They are the same log on a healthy machine, but
+/// the cache never assumes that — a snapshot is only resumed on the
+/// read path that produced it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WorkBoardCacheSource {
+    Daemon,
+    Store,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct WorkBoardCache {
+    pub version: u32,
+    pub channel: RoomId,
+    pub source: WorkBoardCacheSource,
+    /// Cursor of the newest transcript event folded into `projection`
+    /// (work event or not) — the strictly-after resume point.
+    pub cursor: TranscriptCursor,
+    pub projection: WorkBoardProjection,
+}
+
+impl WorkBoardCache {
+    pub fn path(home: &Path, channel: RoomId) -> PathBuf {
+        home.join(CACHE_DIR).join(format!("{channel}.json"))
+    }
+
+    /// Load the snapshot for `channel`, or `None` when the caller must
+    /// rebuild from scratch. A missing file is the normal cold start
+    /// (silent); anything else — unreadable file, corrupt JSON,
+    /// version/channel/source mismatch — is loud, because it means a
+    /// snapshot existed and is being discarded.
+    pub fn load(home: &Path, channel: RoomId, source: WorkBoardCacheSource) -> Option<Self> {
+        let path = Self::path(home, channel);
+        let bytes = match std::fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(error) => {
+                eprintln!(
+                    "work board cache: failed to read {} ({error}) — rebuilding projection from scratch",
+                    path.display()
+                );
+                return None;
+            }
+        };
+        let cache: Self = match serde_json::from_slice(&bytes) {
+            Ok(cache) => cache,
+            Err(error) => {
+                eprintln!(
+                    "work board cache: corrupt snapshot {} ({error}) — rebuilding projection from scratch",
+                    path.display()
+                );
+                return None;
+            }
+        };
+        if cache.version != WORK_BOARD_CACHE_FORMAT_VERSION {
+            eprintln!(
+                "work board cache: snapshot {} has format v{} (current v{WORK_BOARD_CACHE_FORMAT_VERSION}) — rebuilding projection from scratch",
+                path.display(),
+                cache.version
+            );
+            return None;
+        }
+        if cache.channel != channel {
+            eprintln!(
+                "work board cache: snapshot {} is for channel {} (expected {channel}) — rebuilding projection from scratch",
+                path.display(),
+                cache.channel
+            );
+            return None;
+        }
+        if cache.source != source {
+            eprintln!(
+                "work board cache: snapshot {} was projected from the {:?} log but this read uses {:?} — rebuilding projection from scratch",
+                path.display(),
+                cache.source,
+                source
+            );
+            return None;
+        }
+        Some(cache)
+    }
+
+    /// Persist atomically (temp file + rename). Failure to persist is
+    /// loud but non-fatal: the projection just returned to the caller
+    /// is correct either way; only the next read's fast path is lost.
+    pub fn save(&self, home: &Path) {
+        let path = Self::path(home, self.channel);
+        if let Err(error) = self.try_save(&path) {
+            eprintln!(
+                "work board cache: failed to persist snapshot {} ({error}) — next read rebuilds from scratch",
+                path.display()
+            );
+        }
+    }
+
+    fn try_save(&self, path: &Path) -> std::io::Result<()> {
+        let dir = path
+            .parent()
+            .ok_or_else(|| std::io::Error::other("cache path has no parent directory"))?;
+        std::fs::create_dir_all(dir)?;
+        let bytes = serde_json::to_vec(self).map_err(std::io::Error::other)?;
+        let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+        std::fs::write(&tmp, bytes)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(channel: RoomId) -> WorkBoardCache {
+        WorkBoardCache {
+            version: WORK_BOARD_CACHE_FORMAT_VERSION,
+            channel,
+            source: WorkBoardCacheSource::Daemon,
+            cursor: TranscriptCursor {
+                lamport: 42,
+                event_id: EventId::from_u128(7),
+            },
+            projection: WorkBoardProjection::new(),
+        }
+    }
+
+    #[test]
+    fn round_trips_through_disk() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let channel = RoomId::from_u128(1);
+        let cache = sample(channel);
+        cache.save(home.path());
+        let loaded = WorkBoardCache::load(home.path(), channel, WorkBoardCacheSource::Daemon)
+            .expect("snapshot loads back");
+        assert_eq!(loaded, cache);
+    }
+
+    #[test]
+    fn missing_file_is_silent_cold_start() {
+        let home = tempfile::tempdir().expect("tempdir");
+        assert!(WorkBoardCache::load(
+            home.path(),
+            RoomId::from_u128(1),
+            WorkBoardCacheSource::Daemon
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn corrupt_json_is_discarded() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let channel = RoomId::from_u128(1);
+        let path = WorkBoardCache::path(home.path(), channel);
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&path, b"{ not json").expect("write garbage");
+        assert!(WorkBoardCache::load(home.path(), channel, WorkBoardCacheSource::Daemon).is_none());
+    }
+
+    #[test]
+    fn version_mismatch_is_discarded() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let channel = RoomId::from_u128(1);
+        let mut cache = sample(channel);
+        cache.version = WORK_BOARD_CACHE_FORMAT_VERSION + 1;
+        cache.save(home.path());
+        assert!(WorkBoardCache::load(home.path(), channel, WorkBoardCacheSource::Daemon).is_none());
+    }
+
+    #[test]
+    fn channel_mismatch_is_discarded() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let written = RoomId::from_u128(1);
+        let cache = sample(written);
+        // Force the file under a DIFFERENT channel's name.
+        let path = WorkBoardCache::path(home.path(), RoomId::from_u128(2));
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&path, serde_json::to_vec(&cache).expect("encode")).expect("write");
+        assert!(WorkBoardCache::load(
+            home.path(),
+            RoomId::from_u128(2),
+            WorkBoardCacheSource::Daemon
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn source_mismatch_is_discarded() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let channel = RoomId::from_u128(1);
+        sample(channel).save(home.path());
+        assert!(WorkBoardCache::load(home.path(), channel, WorkBoardCacheSource::Store).is_none());
+    }
+
+    #[test]
+    fn cursor_order_is_lamport_then_event_id() {
+        let a = TranscriptCursor {
+            lamport: 1,
+            event_id: EventId::from_u128(9),
+        };
+        let b = TranscriptCursor {
+            lamport: 2,
+            event_id: EventId::from_u128(1),
+        };
+        let b_tie = TranscriptCursor {
+            lamport: 2,
+            event_id: EventId::from_u128(2),
+        };
+        assert!(cursor_strictly_before(&a, &b));
+        assert!(cursor_strictly_before(&b, &b_tie));
+        assert!(!cursor_strictly_before(&b, &b));
+        assert!(!cursor_strictly_before(&b, &a));
+    }
+}

--- a/crates/airc-lib/tests/work_board_cache.rs
+++ b/crates/airc-lib/tests/work_board_cache.rs
@@ -1,0 +1,209 @@
+//! Integration: persistent work-board projection cache (card 1291173d).
+//!
+//! `Airc::work_board_complete` used to replay the room's full
+//! transcript from event zero on every call; it now snapshots the
+//! projection keyed by the last-applied transcript cursor and resumes
+//! incrementally. These tests run the REAL daemon path (in-process
+//! owner-core, real Unix socket, isolated temp homes — never the
+//! operator's `~/.airc`) and pin:
+//!
+//! - the incremental resume produces the same board as a from-scratch
+//!   rebuild (delete the snapshot, rebuild, compare);
+//! - the snapshot is actually served (a doctored snapshot at the true
+//!   tip cursor is visible in the result — this is the mutation pin:
+//!   breaking the increment path and always rebuilding fails it);
+//! - a snapshot whose cursor the log no longer agrees with is
+//!   discarded and rebuilt from scratch, never served stale;
+//! - a corrupt snapshot file is discarded and rebuilt.
+
+mod common;
+
+use airc_lib::{Airc, CreateWorkCard, Priority, RepoId};
+use common::Machine;
+
+const CACHE_DIR: &str = "work-board-cache";
+
+async fn create_card(airc: &Airc, title: &str) -> airc_lib::WorkCardId {
+    airc.create_work_card(CreateWorkCard {
+        repo: RepoId::new("test-org/test-repo").unwrap(),
+        title: title.to_string(),
+        body: None,
+        priority: Priority::P1,
+        lane_id: None,
+        reviews: None,
+    })
+    .await
+    .expect("create work card")
+}
+
+/// The single snapshot file this scope's board reads persisted.
+fn cache_file(airc: &Airc) -> std::path::PathBuf {
+    let dir = airc.home().join(CACHE_DIR);
+    let mut entries: Vec<_> = std::fs::read_dir(&dir)
+        .expect("cache dir exists after a board read")
+        .map(|entry| entry.expect("cache dir entry").path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "expected exactly one room snapshot in {}",
+        dir.display()
+    );
+    entries.pop().expect("one entry")
+}
+
+fn card_titles(board: &airc_lib::WorkBoardProjection) -> Vec<String> {
+    let mut titles: Vec<String> = board
+        .snapshot()
+        .cards
+        .into_iter()
+        .map(|card| card.title)
+        .collect();
+    titles.sort();
+    titles
+}
+
+#[tokio::test]
+async fn incremental_resume_matches_from_scratch_rebuild() {
+    let machine = Machine::boot().await;
+    let airc = machine.solo("board-cache-equivalence").await;
+
+    create_card(&airc, "first card").await;
+    let cold = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await
+        .expect("cold board");
+    assert_eq!(card_titles(&cold), vec!["first card".to_string()]);
+    let path = cache_file(&airc);
+    assert!(path.exists(), "first board read persists a snapshot");
+
+    // New events after the snapshot: the next read resumes from the
+    // cached cursor and folds them in.
+    create_card(&airc, "second card").await;
+    let resumed = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await
+        .expect("resumed board");
+    assert_eq!(
+        card_titles(&resumed),
+        vec!["first card".to_string(), "second card".to_string()]
+    );
+
+    // Ground truth: delete the snapshot and replay from event zero.
+    // The incremental fold must be indistinguishable from it.
+    std::fs::remove_file(&path).expect("drop snapshot");
+    let rebuilt = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await
+        .expect("rebuilt board");
+    assert_eq!(
+        resumed.snapshot().cards,
+        rebuilt.snapshot().cards,
+        "incremental resume diverged from full replay"
+    );
+}
+
+#[tokio::test]
+async fn snapshot_at_tip_is_served_without_replay() {
+    let machine = Machine::boot().await;
+    let airc = machine.solo("board-cache-served").await;
+
+    create_card(&airc, "true title").await;
+    airc.work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await
+        .expect("board read to persist snapshot");
+
+    // Doctor the snapshot's projection while leaving its cursor at the
+    // true room tip. A served snapshot shows the doctored title; a
+    // code path that quietly rebuilt from the log instead would show
+    // the true title and this pin would fail — that is the point: it
+    // proves the increment path is live.
+    let path = cache_file(&airc);
+    let mut cache: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&path).expect("read snapshot")).expect("decode");
+    let cards = cache["projection"]["cards"]
+        .as_object_mut()
+        .expect("projection has cards");
+    assert_eq!(cards.len(), 1);
+    for card in cards.values_mut() {
+        card["title"] = serde_json::Value::String("doctored title".to_string());
+    }
+    std::fs::write(&path, serde_json::to_vec(&cache).expect("encode")).expect("write snapshot");
+
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await
+        .expect("board");
+    assert_eq!(
+        card_titles(&board),
+        vec!["doctored title".to_string()],
+        "snapshot at the tip cursor must be served, not rebuilt"
+    );
+}
+
+#[tokio::test]
+async fn snapshot_with_rewound_log_is_rebuilt_never_served_stale() {
+    let machine = Machine::boot().await;
+    let airc = machine.solo("board-cache-stale").await;
+
+    create_card(&airc, "true title").await;
+    airc.work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await
+        .expect("board read to persist snapshot");
+
+    // Doctor the snapshot AND push its cursor past the log tip — the
+    // shape a wiped/rewound store leaves behind. The read must detect
+    // that the log no longer agrees with the cursor and rebuild; the
+    // doctored state must never surface.
+    let path = cache_file(&airc);
+    let mut cache: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&path).expect("read snapshot")).expect("decode");
+    for card in cache["projection"]["cards"]
+        .as_object_mut()
+        .expect("projection has cards")
+        .values_mut()
+    {
+        card["title"] = serde_json::Value::String("stale title".to_string());
+    }
+    cache["cursor"]["lamport"] = serde_json::Value::from(u64::MAX);
+    std::fs::write(&path, serde_json::to_vec(&cache).expect("encode")).expect("write snapshot");
+
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await
+        .expect("board");
+    assert_eq!(
+        card_titles(&board),
+        vec!["true title".to_string()],
+        "a snapshot the log disagrees with must be rebuilt from scratch"
+    );
+
+    // And the recovery rewrites a healthy snapshot at the real tip.
+    let healed: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&path).expect("read snapshot")).expect("decode");
+    assert_ne!(
+        healed["cursor"]["lamport"],
+        serde_json::Value::from(u64::MAX)
+    );
+}
+
+#[tokio::test]
+async fn corrupt_snapshot_is_discarded_and_rebuilt() {
+    let machine = Machine::boot().await;
+    let airc = machine.solo("board-cache-corrupt").await;
+
+    create_card(&airc, "survives corruption").await;
+    airc.work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await
+        .expect("board read to persist snapshot");
+
+    let path = cache_file(&airc);
+    std::fs::write(&path, b"{ definitely not a snapshot").expect("corrupt snapshot");
+
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await
+        .expect("board");
+    assert_eq!(card_titles(&board), vec!["survives corruption".to_string()]);
+}

--- a/crates/airc-lib/tests/work_board_cache_perf.rs
+++ b/crates/airc-lib/tests/work_board_cache_perf.rs
@@ -1,0 +1,100 @@
+//! Perf harness for the persistent work-board projection cache
+//! (card 1291173d). `#[ignore]` — run on demand:
+//!
+//! ```sh
+//! cargo test -p airc-lib --release --test work_board_cache_perf -- --ignored --nocapture
+//! ```
+//!
+//! Seeds a synthetic 5k-work-event room through the real in-process
+//! daemon (isolated temp homes — never the operator's `~/.airc`),
+//! then times `work_board_complete`:
+//!
+//! - **cold** (no snapshot) — the from-scratch full replay every call
+//!   paid before this card;
+//! - **warm** (snapshot at tip) — the steady-state board/merger tick;
+//! - **incremental** (snapshot + a handful of new events) — the
+//!   typical agent loop between two reads.
+
+mod common;
+
+use std::time::Instant;
+
+use airc_lib::{Airc, CardState, ChangeWorkCardState, CreateWorkCard, Priority, RepoId};
+use common::Machine;
+
+const SEED_CARDS: usize = 2_500; // 2 events per card ⇒ 5k work events
+const CACHE_DIR: &str = "work-board-cache";
+
+async fn board(airc: &Airc) -> airc_lib::WorkBoardProjection {
+    airc.work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await
+        .expect("work board")
+}
+
+#[tokio::test]
+#[ignore = "perf harness — run with --ignored --nocapture"]
+async fn measure_board_projection_cold_vs_cached() {
+    let machine = Machine::boot().await;
+    let airc = machine.solo("board-cache-perf").await;
+    let repo = RepoId::new("test-org/test-repo").expect("repo id");
+
+    let seed_start = Instant::now();
+    for n in 0..SEED_CARDS {
+        let card_id = airc
+            .create_work_card(CreateWorkCard {
+                repo: repo.clone(),
+                title: format!("synthetic card {n}"),
+                body: None,
+                priority: Priority::P2,
+                lane_id: None,
+                reviews: None,
+            })
+            .await
+            .expect("seed card");
+        airc.change_work_card_state(ChangeWorkCardState {
+            card_id,
+            state: CardState::Closed,
+        })
+        .await
+        .expect("close card");
+    }
+    eprintln!(
+        "seeded {} work events in {:.1?}",
+        SEED_CARDS * 2,
+        seed_start.elapsed()
+    );
+
+    // Cold: no snapshot ⇒ the full from-scratch replay (the only path
+    // that existed before card 1291173d).
+    let cache_dir = airc.home().join(CACHE_DIR);
+    let _ = std::fs::remove_dir_all(&cache_dir);
+    let cold_start = Instant::now();
+    let cold = board(&airc).await;
+    let cold_elapsed = cold_start.elapsed();
+    assert_eq!(cold.snapshot().cards.len(), SEED_CARDS);
+    eprintln!("cold full replay:        {cold_elapsed:.1?}");
+
+    // Warm: snapshot at tip ⇒ one empty resume + one tip probe.
+    let warm_start = Instant::now();
+    let warm = board(&airc).await;
+    let warm_elapsed = warm_start.elapsed();
+    assert_eq!(warm.snapshot().cards.len(), SEED_CARDS);
+    eprintln!("warm cached (at tip):    {warm_elapsed:.1?}");
+
+    // Incremental: a few new events since the snapshot.
+    airc.create_work_card(CreateWorkCard {
+        repo: repo.clone(),
+        title: "fresh card".to_string(),
+        body: None,
+        priority: Priority::P1,
+        lane_id: None,
+        reviews: None,
+    })
+    .await
+    .expect("fresh card");
+    let inc_start = Instant::now();
+    let incremental = board(&airc).await;
+    let inc_elapsed = inc_start.elapsed();
+    assert_eq!(incremental.snapshot().cards.len(), SEED_CARDS + 1);
+    eprintln!("incremental (+2 events): {inc_elapsed:.1?}");
+}

--- a/crates/airc-work-store/src/lib.rs
+++ b/crates/airc-work-store/src/lib.rs
@@ -118,8 +118,28 @@ where
 pub fn project_transcripts(
     transcripts: Vec<TranscriptEvent>,
 ) -> Result<WorkBoardProjection, WorkStoreError> {
+    let mut projection = WorkBoardProjection::new();
+    apply_transcripts(&mut projection, transcripts)?;
+    Ok(projection)
+}
+
+/// Apply a caller-supplied transcript page **incrementally** onto an
+/// existing projection (card 1291173d: cached work-board resume).
+/// Decode + apply rule is byte-identical to [`project_transcripts`] —
+/// both funnel through `WorkBoardProjection::apply_windowed` — so
+/// `project_transcripts(a ++ b)` ≡ `project_transcripts(a)` then
+/// `apply_transcripts(b)`. Returns the cursor of the newest transcript
+/// event consumed (work event or not), i.e. the resume point for the
+/// next increment.
+pub fn apply_transcripts(
+    projection: &mut WorkBoardProjection,
+    transcripts: Vec<TranscriptEvent>,
+) -> Result<Option<TranscriptCursor>, WorkStoreError> {
     let page = decode_page(transcripts)?;
-    Ok(WorkBoardProjection::replay_window(page.events)?)
+    for event in &page.events {
+        projection.apply_windowed(event)?;
+    }
+    Ok(page.newest_cursor)
 }
 
 fn decode_page(transcripts: Vec<TranscriptEvent>) -> Result<WorkEventPage, WorkStoreError> {

--- a/crates/airc-work-store/src/tests.rs
+++ b/crates/airc-work-store/src/tests.rs
@@ -323,3 +323,96 @@ async fn drain_sequence_through_store_replays_into_projection_state() {
     assert_eq!(history.len(), 1);
     assert_eq!(history[0].outcome.bytes_reclaimed, 800);
 }
+
+// ---------------------------------------------------------------------
+// Card 1291173d: incremental resume (`apply_transcripts`) must be the
+// SAME fold as the from-scratch replay (`project_transcripts`) — split
+// anywhere, including across a first-write-wins arbitration boundary.
+// ---------------------------------------------------------------------
+
+fn card_claimed(card_id: WorkCardId, claim: u128, owner: u128, claimed_at_ms: u64) -> WorkEvent {
+    WorkEvent::CardClaimed(airc_work::WorkCardClaimed {
+        card_id,
+        claim_id: airc_work::ClaimId::from_u128(claim),
+        owner: PeerId::from_u128(owner),
+        ttl_ms: 600_000,
+        claimed_at_ms,
+    })
+}
+
+#[test]
+fn apply_transcripts_resume_equals_full_replay_across_claim_arbitration() {
+    let room = RoomId::from_u128(10);
+    let card_a = WorkCardId::from_u128(20);
+    let card_b = WorkCardId::from_u128(21);
+
+    // Claim by peer 300 lands first; peer 301's racing claim arrives
+    // AFTER the snapshot boundary and must still lose first-write-wins
+    // arbitration against state restored from the snapshot.
+    let transcripts = vec![
+        work_transcript(1, room, 1, &card_created(card_a)),
+        work_transcript(2, room, 2, &card_claimed(card_a, 90, 300, 5_000)),
+        // ---- snapshot boundary ----
+        work_transcript(3, room, 3, &card_claimed(card_a, 91, 301, 6_000)),
+        work_transcript(4, room, 4, &card_created(card_b)),
+    ];
+
+    let full = project_transcripts(transcripts.clone()).unwrap();
+
+    let mut resumed = project_transcripts(transcripts[..2].to_vec()).unwrap();
+    let newest = apply_transcripts(&mut resumed, transcripts[2..].to_vec())
+        .unwrap()
+        .expect("non-empty increment yields a cursor");
+
+    assert_eq!(resumed, full, "incremental fold diverged from full replay");
+    assert_eq!(newest.event_id, EventId::from_u128(4));
+    // The arbitration itself: the pre-boundary claim won, the
+    // post-boundary racer was dropped without state change.
+    let card = resumed.card(card_a).expect("card A projected");
+    assert_eq!(card.owner, Some(PeerId::from_u128(300)));
+    assert_eq!(card.claim_id, Some(airc_work::ClaimId::from_u128(90)));
+}
+
+#[test]
+fn apply_transcripts_advances_cursor_past_non_work_events() {
+    let room = RoomId::from_u128(10);
+    let card_id = WorkCardId::from_u128(20);
+    let mut projection =
+        project_transcripts(vec![work_transcript(1, room, 1, &card_created(card_id))]).unwrap();
+    let before = projection.clone();
+
+    // A chat-only increment applies nothing but still advances the
+    // resume cursor — otherwise every subsequent resume would refetch
+    // the same chat tail forever.
+    let newest = apply_transcripts(&mut projection, vec![chat_transcript(9, room, 9)])
+        .unwrap()
+        .expect("chat transcript still yields a cursor");
+    assert_eq!(newest.event_id, EventId::from_u128(9));
+    assert_eq!(newest.lamport, 9);
+    assert_eq!(projection, before);
+}
+
+#[test]
+fn apply_transcripts_skips_missing_anchor_but_fails_structural_errors() {
+    let room = RoomId::from_u128(10);
+    let card_a = WorkCardId::from_u128(20);
+    let mut projection =
+        project_transcripts(vec![work_transcript(1, room, 1, &card_created(card_a))]).unwrap();
+
+    // Missing anchor (state change for a card the snapshot never saw):
+    // skipped, same as replay_window.
+    let unknown = WorkCardId::from_u128(99);
+    apply_transcripts(
+        &mut projection,
+        vec![work_transcript(2, room, 2, &card_state_changed(unknown))],
+    )
+    .unwrap();
+    assert!(projection.card(unknown).is_none());
+
+    // Structural error (duplicate create): loud failure, not a skip.
+    let result = apply_transcripts(
+        &mut projection,
+        vec![work_transcript(3, room, 3, &card_created(card_a))],
+    );
+    assert!(matches!(result, Err(WorkStoreError::Projection(_))));
+}

--- a/crates/airc-work/src/projection/apply.rs
+++ b/crates/airc-work/src/projection/apply.rs
@@ -73,6 +73,21 @@ impl WorkBoardProjection {
         Ok(projection)
     }
 
+    /// Apply one event with bounded-window tolerance: an event whose
+    /// anchor entity is missing (its creation predates the window /
+    /// snapshot) is skipped, exactly as [`Self::replay_window`] skips
+    /// it; structural errors still fail. This is the single apply
+    /// rule shared by windowed replay AND incremental resume from a
+    /// cached projection (card 1291173d) — the two paths stay
+    /// semantically identical by construction.
+    pub fn apply_windowed(&mut self, event: &WorkEvent) -> Result<(), ProjectionError> {
+        match self.apply(event) {
+            Ok(()) => Ok(()),
+            Err(error) if error.is_missing_window_anchor() => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
     /// Replay a bounded transcript window. Events whose anchor entity
     /// was created before the window are skipped; structural errors
     /// inside the window still fail.
@@ -81,11 +96,7 @@ impl WorkBoardProjection {
     ) -> Result<Self, ProjectionError> {
         let mut projection = Self::new();
         for event in events {
-            match projection.apply(&event) {
-                Ok(()) => {}
-                Err(error) if error.is_missing_window_anchor() => {}
-                Err(error) => return Err(error),
-            }
+            projection.apply_windowed(&event)?;
         }
         Ok(projection)
     }

--- a/crates/airc-work/src/projection/tests.rs
+++ b/crates/airc-work/src/projection/tests.rs
@@ -1549,3 +1549,45 @@ fn bench_projection_snapshot_clone_cost() {
         "projection.snapshot regressed to {ns_per_snapshot} ns/snapshot"
     );
 }
+
+// Card 1291173d: `apply_windowed` is the one apply rule shared by
+// `replay_window` and incremental resume from a cached snapshot —
+// missing-anchor events are skipped, structural errors stay loud.
+#[test]
+fn apply_windowed_skips_missing_anchor_and_fails_structural_errors() {
+    let card_id = WorkCardId::from_u128(1);
+    let mut projection = WorkBoardProjection::new();
+
+    // Anchor missing: the card was created before this window /
+    // snapshot — skip, exactly like replay_window.
+    projection
+        .apply_windowed(&WorkEvent::CardStateChanged(CardStateChanged {
+            card_id,
+            state: CardState::Review,
+            changed_by: peer(3),
+            changed_at_ms: 100,
+        }))
+        .unwrap();
+    assert!(projection.card(card_id).is_none());
+
+    let created = WorkEvent::CardCreated(CardCreated {
+        card_id,
+        repo: repo(),
+        title: "windowed apply".to_string(),
+        body: None,
+        priority: Priority::P1,
+        lane_id: None,
+        created_by: peer(3),
+        created_at_ms: 100,
+        reviews: None,
+    });
+    projection.apply_windowed(&created).unwrap();
+    assert!(projection.card(card_id).is_some());
+
+    // Structural error (duplicate create) is NOT window tolerance —
+    // it must stay loud on both the replay and the resume paths.
+    assert_eq!(
+        projection.apply_windowed(&created),
+        Err(ProjectionError::DuplicateCard(card_id))
+    );
+}


### PR DESCRIPTION
## Card

`1291173d-d6fc-4027-9f65-0c2efed0c7e2` — perf(work): WorkBoardProjection rebuild cost — every airc work board / merger tick replays from the event log.

## Problem

Every complete work-board read replayed the room transcript from event zero: `airc work board`, `airc work next`, every claim/state mutation guard, and every merger tick paged the ENTIRE log over IPC — and the daemon's `resume_from_cursor` re-scans from the cursor on every page, making the full rebuild effectively quadratic daemon-side. The e2dd08a benchmarks already showed the in-memory fold is cheap (~200ns/event); the cost is the I/O replay around it.

## Fix: snapshot keyed by last-applied cursor, apply only NEW events

- **`WorkBoardProjection::apply_windowed`** (airc-work) — the one missing-anchor-tolerant apply rule, now shared by `replay_window` AND incremental resume, so the two paths are semantically identical **by construction**. First-write-wins claim arbitration and close-guards are untouched.
- **`apply_transcripts`** (airc-work-store) — fold a transcript page onto an existing projection; returns the newest cursor consumed. `project_transcripts(a ++ b)` ≡ `project_transcripts(a)` then `apply_transcripts(b)`, pinned by a test that splits the log across a claim-arbitration boundary.
- **`WorkBoardCache`** (airc-lib) — projection snapshot keyed by the cursor of the last transcript event folded in, persisted per room under the scope home (`<home>/work-board-cache/<channel>.json`, atomic tmp+rename). `project_room_work_board` resumes strictly after the cached cursor on both the daemon and direct-store read paths (the SDK lamport is the losslessly-packed owner-core `(epoch, counter)` seq, so the cached cursor reproduces the exact IPC resume cursor).
- **Fail loud, rebuild as recovery — never serve stale silently.** Corrupt/unreadable snapshot, format-version bump, channel or daemon/store source mismatch, an empty resume whose cursor is not the room tip (rewound/wiped log), or a first event not strictly after the cursor: all warn to stderr and fall back to the full from-scratch replay.
- **Merger tick** now uses `work_board_complete` (the doc-comment-mandated surface for scheduling code) instead of a 256-recent-event window — a Review card whose last event scrolled out of the window could silently never merge; with the cache each tick is one incremental resume instead of a log replay.

## Measurement (synthetic 5k-work-event room, release build, real in-process daemon)

| read | time | vs before |
|---|---|---|
| cold full replay (= behavior before this PR) | **447.8 ms** | 1x |
| warm cached (snapshot at tip) | **53.3 ms** | 8.4x |
| incremental (+2 events since snapshot) | **6.9 ms** | 65x |

Reproduce: `cargo test -p airc-lib --release --test work_board_cache_perf -- --ignored --nocapture` (hermetic temp homes — never touches a real `~/.airc`). The warm path's residual 53ms is the tip-freshness probe (`inbox since=None limit=1` still scans the room daemon-side); a cheap daemon-side latest-cursor op is follow-up material.

## Tests

Hermetic integration over the real in-process daemon (`crates/airc-lib/tests/work_board_cache.rs`):

- incremental resume == from-scratch rebuild (delete snapshot, rebuild, compare);
- snapshot at tip is actually **served** (doctored-snapshot pin — an always-rebuild mutation fails it);
- snapshot whose cursor the log no longer agrees with is rebuilt, never served stale (and the recovery rewrites a healthy snapshot);
- corrupt snapshot file is discarded and rebuilt.

Unit pins: `apply_windowed` skip/loud split (airc-work); `apply_transcripts` equivalence across an arbitration boundary, cursor advance past non-work events, structural errors stay loud (airc-work-store); cache file round-trip + version/channel/source mismatch discards (airc-lib).

**Mutation-checked** both load-bearing pins by hand: killing the serve path (`return Ok(None)`) fails `snapshot_at_tip_is_served_without_replay`; skipping the fold fails `incremental_resume_matches_from_scratch_rebuild`. Both reverted.

## Gates

- `cargo test --workspace -- --skip codex_hook` — green (60 suites)
- `cargo fmt --check` — clean
- `cargo clippy --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)