### PR TITLE
fix(work): unbreak rust-rewrite — missing CardCreated.origin in projection test (merge race #1127×#1137)

### DIFF
--- a/crates/airc-work/src/projection/tests.rs
+++ b/crates/airc-work/src/projection/tests.rs
@@ -1603,6 +1603,7 @@ fn apply_windowed_skips_missing_anchor_and_fails_structural_errors() {
         created_by: peer(3),
         created_at_ms: 100,
         reviews: None,
+        origin: None,
     });
     projection.apply_windowed(&created).unwrap();
     assert!(projection.card(card_id).is_some());


### PR DESCRIPTION
rust-rewrite tip fails to compile: `error[E0063]: missing field `origin` in initializer of `event::CardCreated`` at `crates/airc-work/src/projection/tests.rs:1596`.

**Merge race:** #1127 added `CardCreated.origin` + updated all then-existing constructors; #1137's projection test was authored against the pre-#1127 base and added a constructor without `origin`. Git saw no textual conflict, so both passed CI individually — the *combination* doesn't build. This reds `cargo test` + `cargo clippy --all-targets` on every leg and blocks all PRs (incl. #1138).

**Fix:** `origin: None` — the legacy/operator default every other test constructor uses. `cargo check --workspace --all-targets` is green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)