### PR TITLE
fix(rooms): default room is durable — join-context re-infer must not demote it (card 1eae6f3e)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -175,11 +175,26 @@ pub async fn run_join(home: &Path, room: Option<String>) -> Result<(), Box<dyn s
         }
         None => {
             let cwd = std::env::current_dir()?;
+            // Card 1eae6f3e: snapshot the durable default BEFORE the
+            // context re-infer (raw read — `subscription_set` has no
+            // lazy-seed side effects) so a default change is reported
+            // loudly instead of silently re-targeting `airc msg`.
+            let default_before = airc.subscription_set().await?.default;
             let rooms = airc.join_default_context(cwd).await?;
             let current = airc.current_room().await?;
             println!("joined default account context:");
             for room in rooms {
                 println!("  #{} ({})", room.name, room.channel);
+            }
+            if let Some(before) = default_before {
+                if before.as_str() != current.name {
+                    eprintln!(
+                        "WARNING: default room CHANGED: {} -> #{} — `airc msg` now targets #{}",
+                        before.display_with_hash(),
+                        current.name,
+                        current.name
+                    );
+                }
             }
             println!("default: #{}", current.name);
             println!("wire:    {}", current.wire.display());

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -1060,6 +1060,19 @@ impl Airc {
         let mut set = subscriptions::load_or_init(self.event_store()).await?;
         let mut rooms = Vec::new();
 
+        // Card 1eae6f3e: the default room is DURABLE scope state. This
+        // method re-runs constantly (init re-runs, daemon-bounce
+        // recovery, monitor resume) and often from a cwd with no git
+        // checkout, where the inferred context default degrades to
+        // `#general`. Treating that inference as authoritative on every
+        // run silently demoted `#cambriantech` → `#general` and the
+        // next `airc msg` misrouted. Snapshot what was subscribed
+        // BEFORE this run so the context default is promoted only when
+        // it is genuinely new to this scope (first entry into a project
+        // context) — never to overwrite an established default.
+        let previous_default = set.default.clone();
+        let context_default_was_subscribed = set.subscribed.contains_key(&context.default);
+
         for channel in context.channels {
             if set.parted.contains(&channel) {
                 continue;
@@ -1069,8 +1082,27 @@ impl Airc {
             rooms.push(subscription.as_room());
         }
 
-        if set.subscribed.contains_key(&context.default) {
+        let default_missing_or_dangling = match &set.default {
+            None => true,
+            Some(name) => !set.subscribed.contains_key(name),
+        };
+        if set.subscribed.contains_key(&context.default)
+            && (default_missing_or_dangling || !context_default_was_subscribed)
+        {
             set.set_default(context.default)?;
+        }
+        if let (Some(old), Some(new)) = (&previous_default, &set.default) {
+            if old != new {
+                // LOUD state-change visibility (card 1eae6f3e): a
+                // default-room change re-targets every short-shape
+                // `airc msg` in this scope. Never let it happen
+                // silently.
+                tracing::warn!(
+                    old = %old.display_with_hash(),
+                    new = %new.display_with_hash(),
+                    "default room CHANGED by join context — short-shape sends now target the new room"
+                );
+            }
         }
         subscriptions::save(self.event_store(), &set).await?;
         self.publish_presence(&identity, &set).await?;

--- a/crates/airc-lib/tests/default_room_durability.rs
+++ b/crates/airc-lib/tests/default_room_durability.rs
@@ -1,0 +1,191 @@
+//! Card 1eae6f3e: the scope's default room is DURABLE scope state.
+//!
+//! Observed 3+ times in 36h: after `airc init` or a daemon bounce the
+//! scope's default room silently flipped `#cambriantech` → `#general`,
+//! and the next `airc msg` misrouted. Root cause: `ensure_join_context`
+//! treated the cwd-inferred context default as authoritative on EVERY
+//! run. Recovery paths (resume/update skills, monitor reattach, init
+//! re-runs) invoke bare `airc join` — often from a cwd with no git
+//! checkout, where `JoinContext::from_cwd` infers `#general` — and the
+//! re-run demoted the durable default.
+//!
+//! Contract pinned here:
+//! 1. Re-running `join_default_context` from a non-repo cwd must NOT
+//!    flip an existing default.
+//! 2. Re-running it with the SAME context is idempotent for default.
+//! 3. Reopening the scope (daemon bounce / `airc init` re-run)
+//!    preserves the default.
+//! 4. FIRST entry into a project context still promotes the project
+//!    room over a lazily-seeded `#general` (the fix must not
+//!    overcorrect into "never set the default").
+//!
+//! All scopes use isolated homes + wire roots (hermetic; no shared
+//! machine state).
+
+use std::path::Path;
+
+use airc_lib::airc::Airc;
+use tempfile::TempDir;
+
+const REPO_ORIGIN: &str = "https://github.com/CambrianTech/airc.git";
+
+/// A fake checkout whose origin owner resolves to `cambriantech`.
+fn repo_dir() -> TempDir {
+    let dir = TempDir::new().expect("create repo tempdir");
+    std::fs::create_dir_all(dir.path().join(".git")).expect("create .git");
+    std::fs::write(
+        dir.path().join(".git/config"),
+        format!(
+            r#"[core]
+    repositoryformatversion = 0
+[remote "origin"]
+    url = {REPO_ORIGIN}
+"#
+        ),
+    )
+    .expect("write git config");
+    dir
+}
+
+async fn open_scope(home: &Path, wire_root: &Path) -> Airc {
+    Airc::open_with_wire_root_for_test(home, wire_root)
+        .await
+        .expect("open scope")
+}
+
+async fn default_channel(airc: &Airc) -> Option<String> {
+    let set = airc.subscription_set().await.expect("load subscriptions");
+    set.default.map(|name| name.as_str().to_string())
+}
+
+/// THE BUG: bare `airc join` re-run from a cwd outside any git
+/// checkout (daemon-bounce recovery, monitor resume, init re-run)
+/// infers a `#general`-only context and silently demoted the durable
+/// default. It must not.
+#[tokio::test]
+async fn rejoin_from_non_repo_cwd_must_not_flip_default() {
+    let home = TempDir::new().expect("home");
+    let wire_root = TempDir::new().expect("wire root");
+    let repo = repo_dir();
+    let non_repo = TempDir::new().expect("non-repo cwd");
+
+    let airc = open_scope(home.path(), wire_root.path()).await;
+    airc.join_default_context(repo.path())
+        .await
+        .expect("join from repo cwd");
+    assert_eq!(
+        default_channel(&airc).await.as_deref(),
+        Some("cambriantech"),
+        "first join inside the repo makes the project room default"
+    );
+
+    airc.join_default_context(non_repo.path())
+        .await
+        .expect("rejoin from non-repo cwd");
+    assert_eq!(
+        default_channel(&airc).await.as_deref(),
+        Some("cambriantech"),
+        "re-running join from a non-repo cwd must NOT flip the durable \
+         default to #general — this is the silent-misroute bug (card 1eae6f3e)"
+    );
+}
+
+/// Same context twice: pure idempotence — default and subscription set
+/// unchanged.
+#[tokio::test]
+async fn rejoin_same_context_is_idempotent_for_default() {
+    let home = TempDir::new().expect("home");
+    let wire_root = TempDir::new().expect("wire root");
+    let repo = repo_dir();
+
+    let airc = open_scope(home.path(), wire_root.path()).await;
+    airc.join_default_context(repo.path())
+        .await
+        .expect("first join");
+    let before = airc.subscription_set().await.expect("set before");
+
+    airc.join_default_context(repo.path())
+        .await
+        .expect("second join");
+    let after = airc.subscription_set().await.expect("set after");
+
+    assert_eq!(
+        before.default, after.default,
+        "idempotent re-join must not move the default"
+    );
+    assert_eq!(
+        before.subscribed.keys().collect::<Vec<_>>(),
+        after.subscribed.keys().collect::<Vec<_>>(),
+        "idempotent re-join must not change the subscription set"
+    );
+}
+
+/// Daemon bounce / `airc init` re-run: a fresh handle over the same
+/// scope store sees the same default, and a recovery re-join from a
+/// bare cwd still doesn't demote it.
+#[tokio::test]
+async fn reopen_scope_preserves_default_across_bounce() {
+    let home = TempDir::new().expect("home");
+    let wire_root = TempDir::new().expect("wire root");
+    let repo = repo_dir();
+    let non_repo = TempDir::new().expect("non-repo cwd");
+
+    {
+        let airc = open_scope(home.path(), wire_root.path()).await;
+        airc.join_default_context(repo.path())
+            .await
+            .expect("join from repo cwd");
+        assert_eq!(
+            default_channel(&airc).await.as_deref(),
+            Some("cambriantech")
+        );
+    } // handle dropped — the "daemon died" half of the bounce
+
+    let reopened = open_scope(home.path(), wire_root.path()).await;
+    assert_eq!(
+        default_channel(&reopened).await.as_deref(),
+        Some("cambriantech"),
+        "default must survive a scope reopen (daemon bounce / init re-run)"
+    );
+    let current = reopened.current_room().await.expect("current room");
+    assert_eq!(
+        current.name, "cambriantech",
+        "current_room (what `airc msg` targets) must match the durable default"
+    );
+
+    // The typical post-bounce recovery: bare `airc join` from $HOME.
+    reopened
+        .join_default_context(non_repo.path())
+        .await
+        .expect("recovery rejoin");
+    assert_eq!(
+        default_channel(&reopened).await.as_deref(),
+        Some("cambriantech"),
+        "post-bounce recovery join must not demote the default"
+    );
+}
+
+/// Guard against overcorrection: the FIRST entry into a project
+/// context must still promote the project room, even when `#general`
+/// was already lazily seeded as default (fresh scope that sent a
+/// message before ever joining a repo context).
+#[tokio::test]
+async fn first_repo_join_promotes_project_room_over_seeded_general() {
+    let home = TempDir::new().expect("home");
+    let wire_root = TempDir::new().expect("wire root");
+    let repo = repo_dir();
+
+    let airc = open_scope(home.path(), wire_root.path()).await;
+    let seeded = airc.current_room().await.expect("lazy seed");
+    assert_eq!(seeded.name, "general", "fresh scope seeds #general");
+    assert_eq!(default_channel(&airc).await.as_deref(), Some("general"));
+
+    airc.join_default_context(repo.path())
+        .await
+        .expect("first repo join");
+    assert_eq!(
+        default_channel(&airc).await.as_deref(),
+        Some("cambriantech"),
+        "first entry into a project context still promotes the project room"
+    );
+}


### PR DESCRIPTION
Card `1eae6f3e-259f-4e5b-9afb-88f80c0d6cd2` — room default flips mid-session; `airc msg` silently misroutes to `#general` after init/daemon bounce.

## Root cause

`Airc::ensure_join_context` treated the cwd-inferred context default as authoritative on **every** run:

```rust
if set.subscribed.contains_key(&context.default) {
    set.set_default(context.default)?;
}
```

Recovery paths (resume/update skills, monitor reattach, init re-runs) invoke bare `airc join`. When that runs from a cwd outside any git checkout — daemon-bounce recovery from `$HOME`, hook contexts, sandboxed agents — `JoinContext::from_cwd` degrades to a `#general`-only context, and the re-run **overwrote the durable default** `#cambriantech -> #general`. `#general` is always subscribed, so the guard never saved us. Next short-shape `airc msg` misrouted.

Repro-hypothesis triage from the card:
- **init resets default** — indirectly true: init flows that end in bare `airc join` from the wrong cwd hit the path above. `airc init` itself (`run_init` → `current_room`) cannot flip an existing default.
- **daemon restart loses room state** — false: subscriptions/default live in the per-scope `events.sqlite` and survive the bounce. It's the post-bounce *recovery join* that demoted it.
- **`subscribed_channels[0]` ordering instability** — false: the `load_or_init` fallback is a `BTreeMap` (deterministic, and `cambriantech` sorts before `general` anyway).

## Fix

The default room is durable scope state. The context default is now promoted only when:
- it is genuinely **new** to this scope (first entry into a project context), or
- the stored default is missing/dangling.

An idempotent re-run — same context, or a degraded `#general`-only context where `#general` is already subscribed — leaves the default untouched. Explicit `airc join <room>` still promotes unconditionally (user intent, unchanged).

## Visibility (the LOUD line)

A default change is never silent now:
- lib: `tracing::warn!` at the change site in `ensure_join_context` (lands in the daemon log when a subscriber is installed);
- CLI: `airc join` snapshots the default before the re-infer (raw `subscription_set` read, no lazy-seed side effects) and prints a stderr `WARNING: default room CHANGED: #old -> #new` when it moved.

Skipped the per-send "default changed since last send" warn: it requires persisted last-send-target state (new store surface) — invasive for this slice, per card guidance. `airc msg` already prints its target on every send.

## Tests (failing-first, hermetic — isolated homes + wire roots, no shared machine state)

`crates/airc-lib/tests/default_room_durability.rs`:
- `rejoin_from_non_repo_cwd_must_not_flip_default` — **repro, failed pre-fix** (`Some("general")` vs `Some("cambriantech")`)
- `reopen_scope_preserves_default_across_bounce` — **repro, failed pre-fix** (reopen + recovery join)
- `rejoin_same_context_is_idempotent_for_default` — default and subscription set unchanged on re-run
- `first_repo_join_promotes_project_room_over_seeded_general` — overcorrection guard: first project-context entry still promotes over a lazily-seeded `#general`

**Mutation-checked:** disabling the promote branch (`if false`) fails the promotion test; the pre-fix overwrite fails both repro tests.

## Gates

- `cargo test --workspace -- --skip codex_hook` — exit 0, 93 suites ok, 0 failed (rebased onto #1139 first; the prior head's `CardCreated.origin` breakage was the #1127×#1137 merge race, already fixed upstream)
- `cargo fmt --check` — clean
- `cargo clippy --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
