### PR TITLE
ci(rust): add merge_group trigger (enables merge queue on rust-rewrite)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,17 @@ on:
       - "Cargo.lock"
       - "test/rust_quality_guard.sh"
       - ".github/workflows/rust.yml"
+  # Merge queue: GitHub builds the queued PR(s) on top of the latest
+  # rust-rewrite on a `gh-readonly-queue/...` ref and emits a
+  # `merge_group` event. Without this trigger those checks never run,
+  # so the queue would wait forever. No `paths` filter here on purpose
+  # — `merge_group` doesn't honour path filters, and a queued docs-only
+  # PR still needs to report the required contexts (the rust legs pass
+  # trivially with no crate changes). This is the gate that catches the
+  # merge-race class that broke rust-rewrite on 2026-06-11 (#1127×#1137
+  # each green alone, broken combined): the queue compiles the COMBINED
+  # result before it can land.
+  merge_group:
   push:
     branches: [canary, main, rust-rewrite]
     paths:


### PR DESCRIPTION
Prerequisite for enabling a GitHub **merge queue** on rust-rewrite (your call, 2026-06-11).

The queue builds queued PR(s) on top of the latest base on a `gh-readonly-queue/...` ref and emits a `merge_group` event; without this trigger the required checks never run and the queue stalls. No `paths` filter — `merge_group` ignores them and queued docs PRs still need to report the contexts (rust legs pass trivially with no crate changes).

**Why:** closes the merge-race class that broke rust-rewrite today — #1127 (added `CardCreated.origin`) and #1137 (added a constructor without it) each passed CI alone but broke the COMBINED base (#1139 fixed it). A merge queue compiles the combined result before landing.

After this merges I'll create the ruleset (merge_queue rule + required hosted checks — fmt/clippy/ubuntu/macos/quality, NOT the windows leg, to avoid the single-runner bottleneck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)