### PR TITLE
feat(daemon): auto-advertise LAN endpoint in account beacon — finishes same-account auto-dial (keystone)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -494,6 +494,12 @@ fn detach_daemon(command: &mut Command) {
     // deadlocks. Clearing the inherit flag on our own std handles makes
     // the next CreateProcess (this daemon) leave them behind; the
     // daemon's log-file handles are separate and still inherit fine.
+    //
+    // SAFETY: `clear_std_handle_inheritance` only calls `GetStdHandle` +
+    // `SetHandleInformation` (kernel32) on this process's own standard
+    // handles, with valid in-range arguments and the result ignored —
+    // no raw pointers, no aliasing, no lifetime concerns. It is sound to
+    // call at any point; worst case a handle we can't touch is left as-is.
     unsafe {
         clear_std_handle_inheritance();
     }
@@ -924,6 +930,48 @@ pub async fn run_daemon(
                 return;
             }
         };
+
+        // Endpoint-in-beacon (the second half of same-account
+        // auto-discovery): bind a LAN listener on THIS handle so its
+        // `route_endpoints()` carries a dialable address, which the
+        // registry-refresh loop below then publishes in the account
+        // beacon. Without this the beacon advertises `endpoints: none`
+        // and a same-account peer that imports our record has nothing
+        // to dial — auto-discovery enrols but never routes (validated
+        // 2026-06-11: `registry sync` published with no endpoint, so the
+        // Mac side could enrol 5090 but not reach it). Bind to the
+        // detected LAN IP (not 0.0.0.0) so the advertised addr is the
+        // one peers actually dial. Best-effort + loud: a node with no
+        // routable LAN (or a bind failure) still reaches the mesh by
+        // dialing OUT to listening peers / relay — it just isn't
+        // dialable itself, which we say plainly rather than swallow.
+        match crate::network_commands::detect_lan_ip() {
+            Some(lan_ip) => {
+                match airc
+                    .listen_lan(std::net::SocketAddr::from((lan_ip, 0)))
+                    .await
+                {
+                    Ok(addr) => {
+                        eprintln!(
+                            "airc daemon: advertising LAN endpoint {addr} in the account registry"
+                        );
+                    }
+                    Err(error) => {
+                        eprintln!(
+                            "airc daemon: LAN listener bind failed ({error}) — account beacon \
+                             carries no LAN endpoint; this node reaches the mesh by dialing out \
+                             / relay but is not itself dialable on LAN"
+                        );
+                    }
+                }
+            }
+            None => {
+                eprintln!(
+                    "airc daemon: no routable LAN IPv4 detected — account beacon carries no LAN \
+                     endpoint (outbound-dial / relay only)"
+                );
+            }
+        }
         let db_path = airc_lib::machine_account_home(&registry_home).join("events.sqlite");
         let event_store = match SqliteEventStore::open_path(&db_path).await {
             Ok(store) => Arc::new(store),

--- a/crates/airc-cli/src/network_commands.rs
+++ b/crates/airc-cli/src/network_commands.rs
@@ -8,7 +8,11 @@ pub fn run_lan_ip() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn detect_lan_ip() -> Option<Ipv4Addr> {
+/// Best-effort primary LAN IPv4 of this host (the source address the OS
+/// would use to reach the internet). `pub(crate)` so the daemon can
+/// advertise it as its dialable LAN endpoint in the account-registry
+/// beacon — the endpoint-in-beacon half of same-account auto-discovery.
+pub(crate) fn detect_lan_ip() -> Option<Ipv4Addr> {
     let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).ok()?;
     socket.connect((Ipv4Addr::new(8, 8, 8, 8), 80)).ok()?;
     match socket.local_addr().ok()?.ip() {


### PR DESCRIPTION
The **endpoint-in-beacon** half of the account-registry auto-discovery keystone (#1134).

## The gap
The daemon's registry loop publishes `route_endpoints()` in the account beacon — but never bound a LAN listener, so `route_endpoints()` was empty and the beacon advertised `endpoints: none`. A same-account peer that imported our record via `registry sync` could **enrol** us but had **nothing to dial**: discovery enrols, routes never form.

**Validated live tonight:** `airc registry sync` published this 5090 node with no endpoint; the Mac side (fable) saw `55536f5f` but couldn't reach it. That's why cross-machine has needed the manual `lan-send` courier.

## The fix
On daemon startup the registry handle detects the primary LAN IPv4 (`detect_lan_ip`, now `pub(crate)`) and binds `listen_lan(lan_ip:0)`, registering a dialable `LanTcp` endpoint the refresh loop then publishes. Bind to the detected LAN IP (not `0.0.0.0`) so the advertised addr is the one peers dial. **Best-effort + loud:** no routable LAN / bind failure logs the reason and the node still reaches the mesh by dialing out / relay (outbound-only doctrine) — it just isn't itself dialable on LAN.

**Isolated-verified:** daemon logs `advertising LAN endpoint 192.168.1.232:<port> in the account registry`. Post-merge cross-machine validation: deploy → `registry sync` → fable's sync should now auto-**route** to 5090, not courier (the killer dual-run test fable's been waiting to run).

## Also
Adds the missing `SAFETY` comment on `detach_daemon`'s Windows `unsafe` block (#1138). It slipped CI because **ubuntu clippy doesn't compile `cfg(windows)` and the windows leg only runs tests, not clippy** — a real CI gap worth a follow-up (run clippy on the windows-self-hosted leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)