### PR TITLE
perf(daemon): O(1) room_tip IPC op — tip probe no longer scans the room (card a1562dbc)

### DIFF
--- a/crates/airc-bus/src/ring.rs
+++ b/crates/airc-bus/src/ring.rs
@@ -112,6 +112,23 @@ impl HotRing {
         self.slots.back().map(|slot| slot.env.cursor())
     }
 
+    /// **Card a1562dbc.** The cursor of the most-recent **`Durable`**
+    /// entry currently retained, if any — the transcript tip as seen
+    /// from RAM. Walks back-to-front, so the cost is bounded by the
+    /// ring capacity (a constant), never by room history.
+    ///
+    /// Eviction pops from the front (oldest first), so whenever the
+    /// ring holds *any* durable entry, the newest one in the ring IS
+    /// the globally newest durable event on this channel — the sink
+    /// only ever lags the ring (write-behind), never leads it.
+    pub fn newest_durable_cursor(&self) -> Option<Cursor> {
+        self.slots
+            .iter()
+            .rev()
+            .find(|slot| slot.env.delivery.is_durable())
+            .map(|slot| slot.env.cursor())
+    }
+
     /// The cursor of the oldest entry currently retained, if any. A
     /// `from_cursor` older than this means the ring cannot serve the full
     /// replay and the deep (sink) leg must cover `(from, oldest_in_ring)`.
@@ -187,6 +204,34 @@ mod tests {
         ring.mark_persisted(EventId::from_u128(1)); // counter 0
         assert_eq!(ring.len(), 2, "unpinned oldest reclaimed back to capacity");
         assert_eq!(ring.oldest_cursor().unwrap().seq.counter, 1);
+    }
+
+    /// Card a1562dbc: the durable tip skips non-durable tail entries
+    /// (a StreamChunk burst after the last chat message must not move
+    /// the transcript tip) and is `None` when no durable is retained.
+    #[test]
+    fn newest_durable_cursor_skips_non_durable_tail() {
+        let mut ring = HotRing::new(10);
+        assert_eq!(ring.newest_durable_cursor(), None, "empty ring");
+
+        ring.push(Arc::new(env_at(0, DeliveryClass::StreamChunk)));
+        assert_eq!(
+            ring.newest_durable_cursor(),
+            None,
+            "non-durable only ⇒ no transcript tip in RAM"
+        );
+
+        ring.push(Arc::new(env_at(1, DeliveryClass::Durable)));
+        ring.push(Arc::new(env_at(2, DeliveryClass::StreamChunk)));
+        ring.push(Arc::new(env_at(3, DeliveryClass::EphemeralWindow)));
+
+        let tip = ring.newest_durable_cursor().expect("durable tip");
+        assert_eq!(tip.seq.counter, 1, "tip is the durable, not the ring back");
+        assert_eq!(
+            ring.newest_cursor().expect("ring back").seq.counter,
+            3,
+            "sanity: the unfiltered newest IS the non-durable back"
+        );
     }
 
     #[test]

--- a/crates/airc-bus/src/router.rs
+++ b/crates/airc-bus/src/router.rs
@@ -378,6 +378,35 @@ impl EventRouter {
         self.inner.sink.head_cursor(channel).await.ok().flatten()
     }
 
+    /// **Card a1562dbc.** The channel's **durable transcript tip**: the
+    /// cursor of the newest `Durable` envelope on `channel`, or `None`
+    /// for a room with no durable history. Constant work regardless of
+    /// room depth — this is the O(1) probe behind the `room_tip` IPC op
+    /// (reconnect watermarking, idle detection, projection-cache
+    /// validation), replacing the "replay the whole room, keep the last
+    /// event" scan.
+    ///
+    /// Two constant-cost legs, NOT a perf fallback:
+    /// - the hot ring's newest durable entry (bounded by ring capacity).
+    ///   Eviction is oldest-first, so when the ring holds any durable,
+    ///   its newest durable IS the channel's global durable tip — the
+    ///   sink only lags the ring (write-behind), never leads it.
+    /// - otherwise the sink's [`DurableSink::head_cursor`] (one indexed
+    ///   row on SQLite). A sink error propagates — it is never papered
+    ///   over with a scan.
+    pub async fn durable_tip(&self, channel: airc_core::RoomId) -> crate::Result<Option<Cursor>> {
+        let ring_tip = {
+            let shard = self.shard_for(channel);
+            let map = shard.channels.lock().unwrap_or_else(|p| p.into_inner());
+            map.get(&channel.0.as_u128())
+                .and_then(|state| state.ring.newest_durable_cursor())
+        }; // shard lock released before the sink await
+        if ring_tip.is_some() {
+            return Ok(ring_tip);
+        }
+        self.inner.sink.head_cursor(channel).await
+    }
+
     /// Subscribe (§4 subscribe, §3.5 cursor contract).
     ///
     /// Returns a stream that yields **every** envelope on the filter strictly

--- a/crates/airc-bus/src/sink.rs
+++ b/crates/airc-bus/src/sink.rs
@@ -52,17 +52,14 @@ pub trait DurableSink: Send + Sync {
     /// transcript replay because `ring.newest_cursor()` returned None
     /// and the deep-replay leg pages from `None` (= beginning).
     ///
-    /// Default impl walks the full sink page to find the last cursor;
-    /// concrete impls should override with an efficient query
-    /// (`SELECT max((epoch, counter, event_id))` on SQLite, back-of-vec
-    /// on in-memory).
-    async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>> {
-        Ok(self
-            .page(channel, None, usize::MAX)
-            .await?
-            .last()
-            .map(|env| env.cursor()))
-    }
+    /// **Card a1562dbc — required, no scan default.** This is also the
+    /// sink leg of [`crate::EventRouter::durable_tip`], the O(1) room
+    /// tip probe. The previous default impl paged the entire channel to
+    /// find the last cursor — exactly the silent O(n) fallback that the
+    /// tip probe exists to kill — so every impl must now answer in
+    /// constant work (one indexed `ORDER BY … DESC LIMIT 1` row on
+    /// SQLite, back-of-vec on in-memory) or fail loudly.
+    async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>>;
 }
 
 /// In-memory durable tier for tests. Records append count so the

--- a/crates/airc-bus/tests/common/mod.rs
+++ b/crates/airc-bus/tests/common/mod.rs
@@ -136,4 +136,8 @@ impl DurableSink for GatedSink {
     ) -> Result<Vec<Envelope>, BusError> {
         self.inner.page(channel, from_cursor, limit).await
     }
+
+    async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>, BusError> {
+        self.inner.head_cursor(channel).await
+    }
 }

--- a/crates/airc-bus/tests/durable_tip.rs
+++ b/crates/airc-bus/tests/durable_tip.rs
@@ -1,0 +1,314 @@
+//! Card a1562dbc — `EventRouter::durable_tip`, the O(1) room-tip probe.
+//!
+//! The perf claim is tested STRUCTURALLY, not by timing: the sink is
+//! wrapped in a counting decorator, and every probe must complete with
+//! **zero `page` calls** (the O(n) scan primitive) regardless of how
+//! deep the room's history is. The sink leg, when taken, is exactly one
+//! `head_cursor` call (one indexed row on the real SQLite sink).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use airc_bus::envelope::{Cursor, DeliveryClass, Envelope, Kind};
+use airc_bus::{
+    BusError, DurableSink, EventRouter, InMemoryDurableSink, InMemoryEpochStore, ManualClock,
+    RouterConfig, SeqSource,
+};
+use airc_core::{ClientId, EventId, PeerId, RoomId};
+
+/// A [`DurableSink`] decorator that counts how the router reads from
+/// the durable tier: `page` is the O(n) scan primitive, `head_cursor`
+/// the O(1) index probe. The tip tests assert on these counters — a
+/// probe that pages even once is a failed O(1) claim.
+struct CountingSink {
+    inner: Arc<InMemoryDurableSink>,
+    page_calls: AtomicU64,
+    head_cursor_calls: AtomicU64,
+}
+
+impl CountingSink {
+    fn new(inner: Arc<InMemoryDurableSink>) -> Self {
+        Self {
+            inner,
+            page_calls: AtomicU64::new(0),
+            head_cursor_calls: AtomicU64::new(0),
+        }
+    }
+
+    fn page_calls(&self) -> u64 {
+        self.page_calls.load(Ordering::SeqCst)
+    }
+
+    fn head_cursor_calls(&self) -> u64 {
+        self.head_cursor_calls.load(Ordering::SeqCst)
+    }
+
+    fn reset(&self) {
+        self.page_calls.store(0, Ordering::SeqCst);
+        self.head_cursor_calls.store(0, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl DurableSink for CountingSink {
+    async fn append(&self, e: &Envelope) -> Result<(), BusError> {
+        self.inner.append(e).await
+    }
+
+    async fn page(
+        &self,
+        channel: RoomId,
+        from_cursor: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.page_calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.page(channel, from_cursor, limit).await
+    }
+
+    async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>, BusError> {
+        self.head_cursor_calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.head_cursor(channel).await
+    }
+}
+
+/// A sink whose `head_cursor` fails — proves the tip probe surfaces a
+/// store error loudly instead of falling back to a scan.
+struct FailingHeadSink;
+
+#[async_trait]
+impl DurableSink for FailingHeadSink {
+    async fn append(&self, _e: &Envelope) -> Result<(), BusError> {
+        Ok(())
+    }
+
+    async fn page(
+        &self,
+        _channel: RoomId,
+        _from_cursor: Option<Cursor>,
+        _limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        panic!("durable_tip must NEVER page the room — that is the scan it replaces");
+    }
+
+    async fn head_cursor(&self, _channel: RoomId) -> Result<Option<Cursor>, BusError> {
+        Err(BusError::Sink("index unavailable".to_string()))
+    }
+}
+
+/// Router over a counting sink. Small ring so deep history genuinely
+/// lives only in the sink; large write-behind so a publish burst never
+/// sheds.
+fn counted_router(ring_capacity: usize) -> (EventRouter, Arc<CountingSink>) {
+    let sink = Arc::new(CountingSink::new(Arc::new(InMemoryDurableSink::new())));
+    let epoch_store = InMemoryEpochStore::new();
+    let seq = Arc::new(SeqSource::start(&epoch_store));
+    let router = EventRouter::new(
+        RouterConfig {
+            ring_capacity,
+            write_behind_buffer: 16_384,
+            ..RouterConfig::default()
+        },
+        Arc::new(ManualClock::new(1_700_000_000_000)),
+        seq,
+        sink.clone(),
+    );
+    (router, sink)
+}
+
+fn event(channel: RoomId, marker: u128, delivery: DeliveryClass) -> Envelope {
+    Envelope::new(
+        channel,
+        (PeerId::from_u128(1), ClientId::from_u128(1)),
+        Kind::Message,
+        delivery,
+        Bytes::from_static(b"tip-probe"),
+    )
+    .with_event_id(EventId::from_u128(marker + 1))
+}
+
+#[tokio::test]
+async fn empty_room_tip_is_none_via_one_index_probe() {
+    let (router, sink) = counted_router(64);
+    let channel = RoomId::from_u128(0xe);
+
+    let tip = router.durable_tip(channel).await.expect("tip probe");
+
+    assert_eq!(tip, None, "no history ⇒ no tip");
+    assert_eq!(sink.page_calls(), 0, "an empty room must not be scanned");
+    assert_eq!(sink.head_cursor_calls(), 1, "exactly one index probe");
+}
+
+#[tokio::test]
+async fn single_event_room_tip_is_that_event() {
+    let (router, sink) = counted_router(64);
+    let channel = RoomId::from_u128(0x1);
+
+    let env = event(channel, 0, DeliveryClass::Durable);
+    let event_id = env.event_id;
+    let seq = router.publish(env).await.expect("publish");
+
+    sink.reset();
+    let tip = router
+        .durable_tip(channel)
+        .await
+        .expect("tip probe")
+        .expect("tip exists");
+
+    assert_eq!(tip.seq, seq, "tip seq IS the publish receipt seq");
+    assert_eq!(tip.event_id, event_id);
+    assert_eq!(sink.page_calls(), 0);
+    assert_eq!(sink.head_cursor_calls(), 0, "served from the hot ring");
+}
+
+/// The O(1) proof: a room thousands of events deep answers its tip with
+/// ZERO scan (`page`) calls — identical store work to a tiny room. The
+/// ring is far smaller than the history, so the depth genuinely lives
+/// in the sink; the probe still never touches the scan primitive.
+#[tokio::test]
+async fn tip_probe_on_deep_room_does_constant_store_work() {
+    let (router, sink) = counted_router(64);
+    let channel = RoomId::from_u128(0xdeeb);
+
+    let mut last_seq = None;
+    let mut last_event_id = None;
+    for n in 0..5_000u128 {
+        let env = event(channel, n, DeliveryClass::Durable);
+        last_event_id = Some(env.event_id);
+        last_seq = Some(router.publish(env).await.expect("publish"));
+        if n % 256 == 0 {
+            // Let the write-behind drain so the bounded queue never sheds.
+            tokio::task::yield_now().await;
+        }
+    }
+
+    sink.reset();
+    let tip = router
+        .durable_tip(channel)
+        .await
+        .expect("tip probe")
+        .expect("tip exists");
+
+    assert_eq!(Some(tip.seq), last_seq, "tip is the newest durable");
+    assert_eq!(Some(tip.event_id), last_event_id);
+    assert_eq!(
+        sink.page_calls(),
+        0,
+        "5000-deep room: the tip probe must not page (scan) the room"
+    );
+    assert!(
+        sink.head_cursor_calls() <= 1,
+        "at most one index probe, got {}",
+        sink.head_cursor_calls()
+    );
+}
+
+#[tokio::test]
+async fn tip_ignores_newer_non_durable_traffic() {
+    let (router, sink) = counted_router(64);
+    let channel = RoomId::from_u128(0x5c);
+
+    let durable_seq = router
+        .publish(event(channel, 0, DeliveryClass::Durable))
+        .await
+        .expect("publish durable");
+    // A media burst after the last chat message: newer in the ring,
+    // but not transcript — must not move the tip.
+    for n in 1..10u128 {
+        router
+            .publish(event(channel, n, DeliveryClass::StreamChunk))
+            .await
+            .expect("publish chunk");
+    }
+
+    sink.reset();
+    let tip = router
+        .durable_tip(channel)
+        .await
+        .expect("tip probe")
+        .expect("tip exists");
+
+    assert_eq!(tip.seq, durable_seq, "stream chunks do not move the tip");
+    assert_eq!(sink.page_calls(), 0);
+}
+
+/// Fresh-start shape: the ring holds no durable (only live non-durable
+/// traffic since start), the durable history lives in the sink. The tip
+/// comes from the sink's index — one `head_cursor`, zero `page`.
+#[tokio::test]
+async fn tip_falls_through_to_sink_index_when_ring_has_no_durable() {
+    let inner = Arc::new(InMemoryDurableSink::new());
+    let channel = RoomId::from_u128(0xc01d);
+
+    // Pre-seed the durable tier (models history persisted before a
+    // daemon restart). Cursor seqs are owner-assigned epoch 1.
+    let mut persisted_tip = None;
+    for n in 0..100u128 {
+        let mut env = event(channel, n, DeliveryClass::Durable);
+        env.seq = airc_bus::Seq::new(1, n as u64);
+        persisted_tip = Some(env.cursor());
+        inner.append(&env).await.expect("seed sink");
+    }
+
+    let sink = Arc::new(CountingSink::new(inner));
+    let epoch_store = InMemoryEpochStore::new();
+    // First start consumed epoch 1 (the seeded history); this source
+    // models the restart and stamps epoch 2.
+    let _ = SeqSource::start(&epoch_store);
+    let seq = Arc::new(SeqSource::start(&epoch_store));
+    let router = EventRouter::new(
+        RouterConfig::default(),
+        Arc::new(ManualClock::new(1_700_000_000_000)),
+        seq,
+        sink.clone(),
+    );
+
+    // Only non-durable traffic since "restart" — ring has no durable.
+    router
+        .publish(event(channel, 0xbeef, DeliveryClass::StreamChunk))
+        .await
+        .expect("publish chunk");
+
+    sink.reset();
+    let tip = router
+        .durable_tip(channel)
+        .await
+        .expect("tip probe")
+        .expect("tip exists");
+
+    assert_eq!(
+        Some(tip),
+        persisted_tip,
+        "tip is the persisted durable head"
+    );
+    assert_eq!(
+        sink.page_calls(),
+        0,
+        "the sink leg is the index, not a scan"
+    );
+    assert_eq!(sink.head_cursor_calls(), 1);
+}
+
+/// No-fallback contract: when the store index cannot answer, the probe
+/// fails loudly. It must never quietly degrade to paging the room (the
+/// failing sink's `page` panics to enforce that).
+#[tokio::test]
+async fn tip_probe_surfaces_sink_error_instead_of_scanning() {
+    let epoch_store = InMemoryEpochStore::new();
+    let seq = Arc::new(SeqSource::start(&epoch_store));
+    let router = EventRouter::new(
+        RouterConfig::default(),
+        Arc::new(ManualClock::new(1_700_000_000_000)),
+        seq,
+        Arc::new(FailingHeadSink),
+    );
+
+    let result = router.durable_tip(RoomId::from_u128(0xbad)).await;
+
+    assert!(
+        result.is_err(),
+        "index failure is loud, not a scan fallback"
+    );
+}

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -18,10 +18,11 @@ use airc_bus::{Clock, Seq, SystemClock};
 use airc_core::{Body, ClientId, PeerId, RoomId};
 use airc_ipc::request::{
     AddPeerRequest, InboxRequest, IpcCursor, IpcDelivery, IpcKind, IpcTarget, PublishRequest,
-    RemovePeerRequest, Request, SendRequest,
+    RemovePeerRequest, Request, RoomTipRequest, SendRequest,
 };
 use airc_ipc::response::{
-    InboxResponse, PeerEntry, PeersResponse, PublishResponse, Response, StatusResponse,
+    InboxResponse, PeerEntry, PeersResponse, PublishResponse, Response, RoomTipResponse,
+    StatusResponse,
 };
 use bytes::Bytes;
 
@@ -48,6 +49,7 @@ pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
         Request::Send(send) => handle_send(state, send).await,
         Request::Publish(publish) => handle_publish(state, publish).await,
         Request::Inbox(inbox) => handle_inbox(state, inbox).await,
+        Request::RoomTip(tip) => handle_room_tip(state, tip).await,
         Request::Attach(_) => Response::Error {
             message: "attach is a streaming request handled by the server".to_string(),
         },
@@ -237,6 +239,25 @@ async fn handle_inbox(state: Arc<DaemonState>, request: InboxRequest) -> Respons
         }
     });
     Response::Inbox(InboxResponse { envelopes, newest })
+}
+
+/// Card a1562dbc: the O(1) tip probe. Answered by the router's
+/// `durable_tip` — hot-ring newest-durable, else one indexed sink row —
+/// NEVER by replaying the room. A store error is surfaced loudly; there
+/// is no scan fallback.
+async fn handle_room_tip(state: Arc<DaemonState>, request: RoomTipRequest) -> Response {
+    match state.router.durable_tip(request.channel).await {
+        Ok(tip) => Response::RoomTip(RoomTipResponse {
+            tip: tip.map(|cursor| IpcCursor {
+                epoch: cursor.seq.epoch,
+                counter: cursor.seq.counter,
+                event_id: cursor.event_id,
+            }),
+        }),
+        Err(error) => Response::Error {
+            message: format!("room_tip: {error}"),
+        },
+    }
 }
 
 async fn handle_add_peer(state: Arc<DaemonState>, add: AddPeerRequest) -> Response {

--- a/crates/airc-daemon/tests/room_tip_probe.rs
+++ b/crates/airc-daemon/tests/room_tip_probe.rs
@@ -125,11 +125,31 @@ fn stream_chunk(channel: RoomId, bytes: &[u8]) -> PublishRequest {
 async fn publish_n(client: &DaemonClient, channel: RoomId, n: usize) -> PublishResponse {
     let mut last = None;
     for i in 0..n {
-        let receipt = client
-            .publish(durable_text(channel, &format!("event {i}")))
-            .await
-            .expect("publish");
-        last = Some(receipt);
+        let request = durable_text(channel, &format!("event {i}"));
+        // The write-behind queue is bounded: on a slow runner a tight
+        // publish loop can outpace the SQLite drain, and the daemon
+        // sheds with a LOUD typed error (§3.8 — the designed
+        // back-pressure signal, never a silent drop). Honour the
+        // contract the way a real producer would: back off and retry
+        // the same event. Any other error is a real failure.
+        let mut receipt = None;
+        for _ in 0..500 {
+            match client.publish(request.clone()).await {
+                Ok(r) => {
+                    receipt = Some(r);
+                    break;
+                }
+                Err(error) => {
+                    let message = error.to_string();
+                    assert!(
+                        message.contains("saturated"),
+                        "unexpected publish error: {message}"
+                    );
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            }
+        }
+        last = Some(receipt.expect("publish kept saturating after 500 backoff retries"));
     }
     last.expect("n > 0")
 }

--- a/crates/airc-daemon/tests/room_tip_probe.rs
+++ b/crates/airc-daemon/tests/room_tip_probe.rs
@@ -1,0 +1,380 @@
+//! Card a1562dbc — `room_tip` against the LIVE daemon: the O(1) probe
+//! for "what is the newest durable cursor on this room?"
+//!
+//! Before this op, the only way to learn the tip over IPC was
+//! `Inbox { since: None, limit: 1 }` — which makes the daemon replay
+//! the ENTIRE room (`resume_from_cursor(channel, None)` materializes
+//! every durable envelope) and throw away all but the last. These tests
+//! prove the typed probe returns exactly the same cursor the scan
+//! would, and print the measured cost of both paths on a deep room so
+//! the O(n)→O(1) claim is backed by real numbers (the structural
+//! zero-scan proof lives in `airc-bus/tests/durable_tip.rs`).
+//!
+//! The test model IS the production model: a real `DaemonState` over a
+//! real SQLite ORM on a Unix socket, driven by the real `DaemonClient`.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use airc_core::{Headers, PeerId, RoomId};
+use airc_daemon::{run, DaemonRuntimeInfo, DaemonState};
+use airc_ipc::{
+    DaemonClient, InboxRequest, IpcDelivery, IpcKind, IpcTarget, PublishRequest, PublishResponse,
+    RoomTipRequest,
+};
+use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
+use airc_store::{EventStore, InMemoryEventStore};
+use tokio::task::JoinHandle;
+
+/// A live daemon on a Unix socket, owning a real router + SQLite ORM.
+struct TestDaemon {
+    socket: PathBuf,
+    handle: JoinHandle<()>,
+    _home: tempfile::TempDir,
+}
+
+fn unique_socket() -> PathBuf {
+    // Short /tmp path keeps us well under macOS SUN_LEN (104 bytes).
+    static N: AtomicU64 = AtomicU64::new(0);
+    let n = N.fetch_add(1, Ordering::Relaxed);
+    PathBuf::from(format!("/tmp/airc-rtp-{}-{n}.sock", std::process::id()))
+}
+
+async fn start_daemon() -> TestDaemon {
+    let home = tempfile::TempDir::new().expect("tempdir");
+    let db_path = home.path().join("events.sqlite");
+    let peer_id = PeerId::new();
+    let keypair = PeerKeypair::generate();
+    let registry = PeerKeyRegistry::new();
+    registry
+        .enrol(peer_id, 0, keypair.public_bytes())
+        .expect("enrol self");
+    let coordinator: Arc<dyn EventStore> = Arc::new(InMemoryEventStore::new());
+    let state = Arc::new(
+        DaemonState::build(
+            peer_id,
+            keypair,
+            Arc::new(registry),
+            VerificationPolicy::Strict,
+            home.path().to_path_buf(),
+            &db_path,
+            coordinator,
+            DaemonRuntimeInfo::unknown(),
+        )
+        .await
+        .expect("build daemon state"),
+    );
+    let socket = unique_socket();
+    let server_state = state.clone();
+    let server_socket = socket.clone();
+    let handle = tokio::spawn(async move {
+        let _ = run(server_state, server_socket).await;
+    });
+    for _ in 0..200 {
+        if socket.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    TestDaemon {
+        socket,
+        handle,
+        _home: home,
+    }
+}
+
+impl TestDaemon {
+    async fn stop(self) {
+        let _ = DaemonClient::new(self.socket.clone()).stop().await;
+        let _ = tokio::time::timeout(Duration::from_secs(3), self.handle).await;
+    }
+}
+
+fn durable_text(channel: RoomId, text: &str) -> PublishRequest {
+    PublishRequest {
+        channel: channel.as_uuid(),
+        from_peer: uuid::Uuid::from_u128(0xA11CE),
+        from_client: uuid::Uuid::from_u128(0x7AB),
+        kind: IpcKind::Message,
+        delivery: IpcDelivery::Durable,
+        target: IpcTarget::All,
+        correlation_id: None,
+        coalesce_key: None,
+        payload: text.as_bytes().to_vec(),
+        headers: Headers::new(),
+    }
+}
+
+fn stream_chunk(channel: RoomId, bytes: &[u8]) -> PublishRequest {
+    PublishRequest {
+        channel: channel.as_uuid(),
+        from_peer: uuid::Uuid::from_u128(0xA11CE),
+        from_client: uuid::Uuid::from_u128(0x7AB),
+        kind: IpcKind::StreamChunk,
+        delivery: IpcDelivery::StreamChunk,
+        target: IpcTarget::All,
+        correlation_id: None,
+        coalesce_key: None,
+        payload: bytes.to_vec(),
+        headers: Headers::new(),
+    }
+}
+
+async fn publish_n(client: &DaemonClient, channel: RoomId, n: usize) -> PublishResponse {
+    let mut last = None;
+    for i in 0..n {
+        let receipt = client
+            .publish(durable_text(channel, &format!("event {i}")))
+            .await
+            .expect("publish");
+        last = Some(receipt);
+    }
+    last.expect("n > 0")
+}
+
+#[tokio::test]
+async fn room_tip_is_none_for_empty_room_and_tracks_publishes() {
+    let daemon = start_daemon().await;
+    let client = DaemonClient::new(daemon.socket.clone());
+    let channel = RoomId::from_u128(0x711);
+
+    // Empty room: no tip.
+    let tip = client
+        .room_tip(RoomTipRequest { channel })
+        .await
+        .expect("room_tip");
+    assert_eq!(tip.tip, None, "empty room has no tip");
+
+    // One publish: the tip IS the receipt.
+    let receipt = publish_n(&client, channel, 1).await;
+    let tip = client
+        .room_tip(RoomTipRequest { channel })
+        .await
+        .expect("room_tip")
+        .tip
+        .expect("tip after publish");
+    assert_eq!((tip.epoch, tip.counter), (receipt.epoch, receipt.counter));
+    assert_eq!(tip.event_id, receipt.event_id);
+
+    // More publishes: the tip advances to each newest receipt.
+    let receipt = publish_n(&client, channel, 5).await;
+    let tip = client
+        .room_tip(RoomTipRequest { channel })
+        .await
+        .expect("room_tip")
+        .tip
+        .expect("tip");
+    assert_eq!((tip.epoch, tip.counter), (receipt.epoch, receipt.counter));
+
+    // A non-durable burst after the last message must NOT move the
+    // durable tip (it is the transcript tip, not the ring back).
+    for _ in 0..8 {
+        client
+            .publish(stream_chunk(channel, b"\x01\x02\x03"))
+            .await
+            .expect("publish chunk");
+    }
+    let tip_after_chunks = client
+        .room_tip(RoomTipRequest { channel })
+        .await
+        .expect("room_tip")
+        .tip
+        .expect("tip");
+    assert_eq!(
+        (tip_after_chunks.epoch, tip_after_chunks.counter),
+        (receipt.epoch, receipt.counter),
+        "stream chunks do not move the durable tip"
+    );
+
+    // Rooms are isolated: another room's tip is still None.
+    let other = client
+        .room_tip(RoomTipRequest {
+            channel: RoomId::from_u128(0x712),
+        })
+        .await
+        .expect("room_tip");
+    assert_eq!(other.tip, None);
+
+    daemon.stop().await;
+}
+
+/// The honest perf evidence (card a1562dbc): on a room thousands of
+/// events deep, the typed tip probe answers the same cursor as the old
+/// `Inbox { since: None, limit: 1 }` shape — which forces a full-room
+/// replay inside the daemon — at a fraction of the cost. Real measured
+/// numbers are printed for the PR body; the hard structural O(1) gate
+/// (zero scan calls) lives in `airc-bus/tests/durable_tip.rs`.
+#[tokio::test]
+async fn deep_room_tip_probe_matches_inbox_scan_and_is_cheaper() {
+    const DEEP: usize = 5_000;
+    const PROBES: u32 = 20;
+
+    let daemon = start_daemon().await;
+    let client = DaemonClient::new(daemon.socket.clone());
+    let channel = RoomId::from_u128(0xd33b);
+
+    let receipt = publish_n(&client, channel, DEEP).await;
+
+    // Old path: inbox with no cursor — daemon replays all DEEP events
+    // and returns the newest 1.
+    let scan_start = Instant::now();
+    let mut scan_newest = None;
+    for _ in 0..PROBES {
+        let page = client
+            .inbox(InboxRequest {
+                since: None,
+                channel: Some(channel),
+                limit: Some(1),
+            })
+            .await
+            .expect("inbox");
+        scan_newest = page.newest;
+    }
+    let scan_elapsed = scan_start.elapsed();
+
+    // New path: the typed O(1) probe.
+    let probe_start = Instant::now();
+    let mut probe_tip = None;
+    for _ in 0..PROBES {
+        probe_tip = client
+            .room_tip(RoomTipRequest { channel })
+            .await
+            .expect("room_tip")
+            .tip;
+    }
+    let probe_elapsed = probe_start.elapsed();
+
+    // Same answer…
+    let scan_newest = scan_newest.expect("scan newest");
+    let probe_tip = probe_tip.expect("probe tip");
+    assert_eq!(probe_tip, scan_newest, "probe and scan agree on the tip");
+    assert_eq!(
+        (probe_tip.epoch, probe_tip.counter),
+        (receipt.epoch, receipt.counter),
+        "and both are the last publish receipt"
+    );
+
+    let scan_us = scan_elapsed.as_micros() / u128::from(PROBES);
+    let probe_us = probe_elapsed.as_micros() / u128::from(PROBES);
+    eprintln!(
+        "card a1562dbc: room depth {DEEP}, {PROBES} probes each — \
+         inbox(limit:1) full-room scan: {scan_us} µs/op; \
+         room_tip probe: {probe_us} µs/op"
+    );
+
+    // …at strictly lower cost. The scan materializes DEEP envelopes per
+    // call; the probe reads one ring slot / one indexed row. A generous
+    // margin (2x) keeps this stable under CI scheduling noise — locally
+    // the gap is orders of magnitude.
+    assert!(
+        probe_elapsed * 2 < scan_elapsed,
+        "tip probe ({probe_us} µs/op) should be far cheaper than the \
+         full-room inbox scan ({scan_us} µs/op) on a {DEEP}-deep room"
+    );
+
+    daemon.stop().await;
+}
+
+/// Restart shape: the tip must come from the durable tier's index when
+/// the hot ring is empty (fresh daemon, history only in SQLite) — the
+/// reconnect-watermark case the probe exists for.
+#[tokio::test]
+async fn room_tip_survives_daemon_restart_from_sqlite_index() {
+    let home = tempfile::TempDir::new().expect("tempdir");
+    let db_path = home.path().join("events.sqlite");
+    let channel = RoomId::from_u128(0x4e57);
+
+    let build = |home_path: PathBuf, db: PathBuf| async move {
+        let peer_id = PeerId::new();
+        let keypair = PeerKeypair::generate();
+        let registry = PeerKeyRegistry::new();
+        registry
+            .enrol(peer_id, 0, keypair.public_bytes())
+            .expect("enrol self");
+        let coordinator: Arc<dyn EventStore> = Arc::new(InMemoryEventStore::new());
+        Arc::new(
+            DaemonState::build(
+                peer_id,
+                keypair,
+                Arc::new(registry),
+                VerificationPolicy::Strict,
+                home_path,
+                &db,
+                coordinator,
+                DaemonRuntimeInfo::unknown(),
+            )
+            .await
+            .expect("build daemon state"),
+        )
+    };
+
+    // First daemon lifetime: publish, capture the receipt, stop.
+    let socket1 = unique_socket();
+    let state1 = build(home.path().to_path_buf(), db_path.clone()).await;
+    let s1 = socket1.clone();
+    let h1 = tokio::spawn(async move {
+        let _ = run(state1, s1).await;
+    });
+    for _ in 0..200 {
+        if socket1.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    let client1 = DaemonClient::new(socket1.clone());
+    let receipt = publish_n(&client1, channel, 25).await;
+    // Persistence barrier: write-behind is async, so poll the durable
+    // tier's own index until the last receipt is on disk before the
+    // restart — never a blind sleep.
+    {
+        use airc_bus::DurableSink;
+        let probe_sink = airc_store::SqliteDurableSink::open_path(&db_path)
+            .await
+            .expect("open probe sink");
+        let mut persisted = false;
+        for _ in 0..400 {
+            if let Some(cursor) = probe_sink.head_cursor(channel).await.expect("head_cursor") {
+                if (cursor.seq.epoch, cursor.seq.counter) == (receipt.epoch, receipt.counter) {
+                    persisted = true;
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(persisted, "write-behind never flushed the last publish");
+    }
+    client1.stop().await.expect("stop daemon 1");
+    let _ = tokio::time::timeout(Duration::from_secs(3), h1).await;
+
+    // Second lifetime over the SAME ORM: ring is empty, the tip must
+    // come from the SQLite index.
+    let socket2 = unique_socket();
+    let state2 = build(home.path().to_path_buf(), db_path.clone()).await;
+    let s2 = socket2.clone();
+    let h2 = tokio::spawn(async move {
+        let _ = run(state2, s2).await;
+    });
+    for _ in 0..200 {
+        if socket2.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    let client2 = DaemonClient::new(socket2.clone());
+    let tip = client2
+        .room_tip(RoomTipRequest { channel })
+        .await
+        .expect("room_tip")
+        .tip
+        .expect("tip persisted across restart");
+    assert_eq!(
+        (tip.epoch, tip.counter, tip.event_id),
+        (receipt.epoch, receipt.counter, receipt.event_id),
+        "post-restart tip is the persisted durable head"
+    );
+
+    client2.stop().await.expect("stop daemon 2");
+    let _ = tokio::time::timeout(Duration::from_secs(3), h2).await;
+}

--- a/crates/airc-ipc/src/client.rs
+++ b/crates/airc-ipc/src/client.rs
@@ -18,9 +18,11 @@ use crate::transport::IpcStream;
 
 use crate::request::{
     AddPeerRequest, AttachRequest, InboxRequest, PublishRequest, RemovePeerRequest, Request,
-    SendRequest,
+    RoomTipRequest, SendRequest,
 };
-use crate::response::{InboxResponse, PeersResponse, PublishResponse, Response, StatusResponse};
+use crate::response::{
+    InboxResponse, PeersResponse, PublishResponse, Response, RoomTipResponse, StatusResponse,
+};
 
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -175,6 +177,17 @@ impl DaemonClient {
     pub async fn inbox(&self, request: InboxRequest) -> Result<InboxResponse, ClientError> {
         match self.call(Request::Inbox(request)).await? {
             Response::Inbox(response) => Ok(response),
+            other => Err(ClientError::UnexpectedResponse(other)),
+        }
+    }
+
+    /// Card a1562dbc: the O(1) tip probe — cursor of the newest durable
+    /// event on a channel, without replaying the room. The cheap
+    /// freshness/watermark query; pair the returned cursor with
+    /// `inbox(since: tip)` or `AttachStart::After(tip)`.
+    pub async fn room_tip(&self, request: RoomTipRequest) -> Result<RoomTipResponse, ClientError> {
+        match self.call(Request::RoomTip(request)).await? {
+            Response::RoomTip(response) => Ok(response),
             other => Err(ClientError::UnexpectedResponse(other)),
         }
     }

--- a/crates/airc-ipc/src/lib.rs
+++ b/crates/airc-ipc/src/lib.rs
@@ -43,9 +43,11 @@ pub const IPC_PROTOCOL_VERSION: u16 = 5;
 pub use client::{ClientError, DaemonClient};
 pub use request::{
     AddPeerRequest, AttachParts, AttachRequest, AttachStart, InboxRequest, IpcCursor, IpcDelivery,
-    IpcKind, IpcTarget, PublishRequest, RemovePeerRequest, Request, SendRequest,
+    IpcKind, IpcTarget, PublishRequest, RemovePeerRequest, Request, RoomTipRequest, SendRequest,
 };
-pub use response::{InboxResponse, PeersResponse, PublishResponse, Response, StatusResponse};
+pub use response::{
+    InboxResponse, PeersResponse, PublishResponse, Response, RoomTipResponse, StatusResponse,
+};
 pub use sdk_conversions::{COUNTER_BITS, COUNTER_MASK};
 // IpcListener / IpcStream stay under `transport` because only the
 // daemon host and low-level tests need the raw byte transport.

--- a/crates/airc-ipc/src/request.rs
+++ b/crates/airc-ipc/src/request.rs
@@ -114,6 +114,14 @@ pub enum Request {
     /// tier (no gap at the ring/sink seam). Pass back the response's
     /// `newest` cursor for consume-once paging.
     Inbox(InboxRequest),
+    /// **Card a1562dbc.** The O(1) tip probe: cursor of the newest
+    /// durable event on a channel, answered from the router's hot ring
+    /// / the sink's index — never by replaying the room. The cheap
+    /// "what is the newest cursor?" op for reconnect watermarking, idle
+    /// detection, and projection-cache validation; a first-class typed
+    /// op, not a `limit: 1` flag on the `Inbox` scan. Returns
+    /// `Response::RoomTip`.
+    RoomTip(RoomTipRequest),
     /// Attach to the daemon's live event stream. Long-lived: after an
     /// initial `Response::Ok`, the daemon streams `Response::Event`
     /// frames (airc-wire bytes) until the client disconnects. Optionally
@@ -139,6 +147,15 @@ pub struct InboxRequest {
     /// reasonable cap (32) so a slow client doesn't pull megabytes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,
+}
+
+/// Parameters for `RoomTip` (card a1562dbc). The channel is mandatory:
+/// the tip is a per-room property in the owner-core model, exactly like
+/// `Inbox` paging.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RoomTipRequest {
+    /// The channel (room) whose durable tip is being probed.
+    pub channel: airc_core::RoomId,
 }
 
 /// Where an attach stream starts. One intentional choice — not a
@@ -590,6 +607,59 @@ mod tests {
         let encoded = serde_json::to_string(&original).unwrap();
         let decoded: Request = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, original);
+    }
+
+    /// Card a1562dbc: the EXACT wire bytes of `RoomTip` are the
+    /// cross-version contract — `op` tag and `channel` field name
+    /// pinned as literal strings. A serde rename (even a symmetric
+    /// one) must fail here, not silently strand old daemons.
+    #[test]
+    fn room_tip_wire_bytes_are_pinned() {
+        let request = Request::RoomTip(RoomTipRequest {
+            channel: airc_core::RoomId(Uuid::nil()),
+        });
+        let encoded = serde_json::to_string(&request).unwrap();
+        assert_eq!(
+            encoded,
+            r#"{"op":"room_tip","channel":"00000000-0000-0000-0000-000000000000"}"#
+        );
+    }
+
+    /// Card a1562dbc: decode-side pin — the literal wire JSON an
+    /// already-shipped client would send must decode to the typed
+    /// variant. Pins the decode half independently of the encode half
+    /// so a symmetric rename cannot pass both.
+    #[test]
+    fn room_tip_literal_wire_json_decodes() {
+        let decoded: Request = serde_json::from_str(
+            r#"{"op":"room_tip","channel":"00000000-0000-0000-0000-000000000042"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            decoded,
+            Request::RoomTip(RoomTipRequest {
+                channel: airc_core::RoomId::from_u128(0x42),
+            })
+        );
+    }
+
+    /// Card a1562dbc: adding the `RoomTip` variant must not perturb the
+    /// decoding of pre-existing ops — the literal pre-RoomTip wire
+    /// bytes of a neighbouring op still decode unchanged.
+    #[test]
+    fn room_tip_addition_keeps_existing_inbox_wire_compat() {
+        let decoded: Request = serde_json::from_str(
+            r#"{"op":"inbox","channel":"00000000-0000-0000-0000-000000000042","limit":1}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            decoded,
+            Request::Inbox(InboxRequest {
+                since: None,
+                channel: Some(airc_core::RoomId::from_u128(0x42)),
+                limit: Some(1),
+            })
+        );
     }
 
     #[test]

--- a/crates/airc-ipc/src/response.rs
+++ b/crates/airc-ipc/src/response.rs
@@ -25,6 +25,11 @@ pub enum Response {
     /// "newest cursor" the caller threads back on the next call to keep
     /// the stream consume-once.
     Inbox(InboxResponse),
+    /// **Card a1562dbc.** Response to `RoomTip` — the cursor of the
+    /// newest durable event on the requested channel, straight from the
+    /// store's index. No envelope bytes ride along: the probe returns
+    /// the cursor value only, never a copy of an event body.
+    RoomTip(RoomTipResponse),
     /// One live event emitted by an `Attach` stream — the airc-wire
     /// encoding of the bus `Envelope`. The client decodes via
     /// `airc_wire::decode`.
@@ -111,6 +116,18 @@ pub struct InboxResponse {
     /// page was empty — the caller's `since` stays authoritative.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub newest: Option<IpcCursor>,
+}
+
+/// Result of a `RoomTip` probe (card a1562dbc): the durable tip of one
+/// channel. Mirrors `InboxResponse.newest`'s wire shape (`tip` absent
+/// when the room has no durable history) so the two cursors are
+/// interchangeable as watermark inputs.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RoomTipResponse {
+    /// Cursor of the newest durable event on the channel. `None` (and
+    /// absent on the wire) when the room has no durable events.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tip: Option<IpcCursor>,
 }
 
 /// Owner-assigned receipt returned by `Send` / `Publish`. The
@@ -214,6 +231,36 @@ mod tests {
         let encoded = serde_json::to_string(&original).unwrap();
         let decoded: Response = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, original);
+    }
+
+    /// Card a1562dbc: the EXACT wire bytes of `RoomTip` are pinned per
+    /// shape — `kind` tag, `tip` field name, nested cursor field names
+    /// all literal. Both shapes covered: a populated tip, and the
+    /// empty-room shape where `tip` is ABSENT (not `null`), mirroring
+    /// `InboxResponse.newest`.
+    #[test]
+    fn room_tip_response_wire_bytes_are_pinned_per_shape() {
+        for (response, expected) in [
+            (
+                Response::RoomTip(RoomTipResponse {
+                    tip: Some(IpcCursor {
+                        epoch: 3,
+                        counter: 17,
+                        event_id: EventId::from_u128(0xfeed),
+                    }),
+                }),
+                r#"{"kind":"room_tip","tip":{"epoch":3,"counter":17,"event_id":"00000000-0000-0000-0000-00000000feed"}}"#,
+            ),
+            (
+                Response::RoomTip(RoomTipResponse { tip: None }),
+                r#"{"kind":"room_tip"}"#,
+            ),
+        ] {
+            let encoded = serde_json::to_string(&response).unwrap();
+            assert_eq!(encoded, expected, "wire bytes of {response:?}");
+            let decoded: Response = serde_json::from_str(expected).unwrap();
+            assert_eq!(decoded, response, "decode of pinned literal");
+        }
     }
 
     #[test]

--- a/crates/airc-lib/src/daemon.rs
+++ b/crates/airc-lib/src/daemon.rs
@@ -20,7 +20,7 @@ use airc_core::{Body, MentionTarget, RoomId, TranscriptCursor, TranscriptEvent, 
 use airc_ipc::codec::read_frame;
 use airc_ipc::{
     AttachRequest, AttachStart, InboxRequest, IpcCursor, IpcDelivery, IpcTarget, PublishRequest,
-    Response, SendRequest,
+    Response, RoomTipRequest, SendRequest,
 };
 use airc_protocol::FrameKind;
 use tokio::sync::mpsc;
@@ -362,22 +362,24 @@ impl Airc {
     /// if its cursor IS the room tip — anything else (log rewound,
     /// store wiped) is a mismatch and the caller rebuilds from
     /// scratch instead of serving stale state.
+    ///
+    /// Card a1562dbc: served by the typed `room_tip` IPC op — the
+    /// daemon answers from its ring/sink index in constant work. The
+    /// previous shape (`Inbox { since: None, limit: 1 }`) made the
+    /// daemon replay the ENTIRE room and keep the last envelope: O(n)
+    /// in room history for a probe whose answer is one cursor.
     pub(crate) async fn daemon_latest_transcript_cursor(
         &self,
         channel: RoomId,
     ) -> Result<Option<TranscriptCursor>, AircError> {
         let response = self
             .require_daemon_client()?
-            .inbox(InboxRequest {
-                since: None,
-                channel: Some(channel),
-                limit: Some(1),
-            })
+            .room_tip(RoomTipRequest { channel })
             .await?;
-        let Some(bytes) = response.envelopes.into_iter().next_back() else {
-            return Ok(None);
-        };
-        Ok(Some(decode_wire_event(bytes)?.cursor()))
+        Ok(response.tip.map(|tip| TranscriptCursor {
+            lamport: pack_seq(tip.epoch, tip.counter),
+            event_id: tip.event_id,
+        }))
     }
 
     /// Live subscribe across `channels` via the daemon: open one IPC

--- a/crates/airc-store/tests/bus_router_durable_tier.rs
+++ b/crates/airc-store/tests/bus_router_durable_tier.rs
@@ -74,6 +74,10 @@ impl DurableSink for GatedSqliteSink {
     ) -> Result<Vec<Envelope>, BusError> {
         self.inner.page(channel, from_cursor, limit).await
     }
+
+    async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>, BusError> {
+        self.inner.head_cursor(channel).await
+    }
 }
 
 /// Deterministic durable envelope with a stable event_id so replayed


### PR DESCRIPTION
## What / why

Card `a1562dbc` (P2): discovering a room's latest cursor (the "tip") required `Inbox { since: None, limit: 1 }`, which makes the daemon **replay the entire room** — `EventRouter::resume_from_cursor(channel, None)` materializes every durable envelope (deep sink page with `usize::MAX` + ring merge), then the handler throws away all but the last. O(n) in room history for a probe whose answer is a single cursor. Callers that only need "what is the newest cursor?" (reconnect watermarking, idle detection, work-board projection-cache validation) paid the full scan on every probe.

This adds a first-class **typed O(1) tip probe**, wired daemon → store, surfaced through airc-lib:

- **airc-bus**: `HotRing::newest_durable_cursor()` (back-to-front walk, bounded by ring capacity — constant wrt room history) and `EventRouter::durable_tip(channel)`: the ring's newest durable when present (eviction is oldest-first, so a ring durable IS the global durable tip — the sink only lags the ring via write-behind, never leads it), otherwise ONE indexed `DurableSink::head_cursor` row (`ORDER BY epoch,counter,event_id DESC LIMIT 1` on SQLite). A sink error **propagates** — no scan fallback. The trait's scan-shaped default `head_cursor` impl (page the whole channel, find the last) is **removed**: every impl must answer in constant work or fail loudly.
- **airc-ipc**: new typed `Request::RoomTip(RoomTipRequest { channel })` → `Response::RoomTip(RoomTipResponse { tip: Option<IpcCursor> })` — an intentional new op, NOT a flag on the `Inbox` scan. `DaemonClient::room_tip` helper. Returns the cursor value only; no envelope bytes ride along.
- **airc-daemon**: dispatch arm `room_tip` → `router.durable_tip`.
- **airc-lib**: `daemon_latest_transcript_cursor` (the work-board cache freshness probe, card 1291173d) migrated from the inbox scan to the typed probe — no event decode at all now.

Tip semantics are the **durable transcript tip** (matching what the inbox-scan path returned after its durable filter): a newer `StreamChunk`/ephemeral burst does not move the tip, so cache-cursor comparisons stay exact.

## O(n) → O(1) evidence

**Measured, live daemon over a Unix socket, real SQLite ORM, debug build** (`airc-daemon/tests/room_tip_probe.rs::deep_room_tip_probe_matches_inbox_scan_and_is_cheaper`, 5,000-event room, 20 probes each, same cursor returned by both paths):

```
card a1562dbc: room depth 5000, 20 probes each —
  inbox(limit:1) full-room scan: 99,129 µs/op
  room_tip probe:                    441 µs/op        (~225x)
```

The probe's 441 µs is dominated by the IPC connect/round-trip, not room depth.

**Structural proof, not vibes** (`airc-bus/tests/durable_tip.rs`): the sink is wrapped in a counting decorator; the tip probe on a 5,000-deep room (ring capacity 64, so depth genuinely lives in the sink) must complete with **zero `page` calls** (the scan primitive) and at most one `head_cursor` call. The no-fallback contract is enforced with a sink whose `page` *panics* and whose `head_cursor` errors: `durable_tip` surfaces the error, never scans.

## Tests

- `airc-bus/tests/durable_tip.rs` (6): empty room, single event, 5,000-deep constant-work proof, non-durable traffic doesn't move the tip, sink-index leg when ring has no durable (fresh-start shape), sink error is loud (no scan fallback).
- `airc-bus/src/ring.rs`: `newest_durable_cursor` skips non-durable tail / None on empty.
- `airc-daemon/tests/room_tip_probe.rs` (3): live-daemon tip tracking + room isolation + chunk immunity; deep-room probe/scan agreement + measured numbers; daemon **restart** — tip served from the SQLite index with an empty ring (write-behind drained via a polled persistence barrier, no blind sleep).
- `airc-ipc` wire pins (encode + decode literals): `{"op":"room_tip","channel":…}`, `{"kind":"room_tip","tip":{…}}`, empty-room shape `{"kind":"room_tip"}` (tip ABSENT, not null), and a pre-RoomTip `inbox` literal still decoding (additive-variant compat). **Mutation-tested**: 4 mutations (request tag rename, request field rename, response tag rename, response field rename) — each broke the corresponding pin, then restored. `IPC_PROTOCOL_VERSION` unchanged, matching the additive-variant precedent (card 7d5b6a65's `AttachCursorAdvanced`).

## Gate

- `cargo clippy --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm` → clean
- `cargo fmt --all -- --check` → clean
- `cargo test --workspace -- --skip codex_hook` → 95 test binaries, all green (codex_hook skipped per macOS hang)

## Residual notes

- `Airc::latest_cursor` / `subscription_cursor` read the **local store** (already an indexed `LIMIT 1`) and don't branch to the daemon when attached — pre-existing semantics, out of scope here; worth a follow-up card if daemon-mode consumers need the daemon's view.
- The general `Inbox { since: None }` "most recent N" path still materializes the room before truncating; the tip probe removes its dominant caller, the rest is a separate paging card.

Card: a1562dbc-69cc-4b21-99c0-a310d718e951

🤖 Generated with [Claude Code](https://claude.com/claude-code)
