### PR TITLE
feat(work): airc work relink — supersede a card's stale PR link with a successor PR (card 09fddedd)

### DIFF
--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -764,6 +764,9 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 pending_timeout_secs,
             } => work_commands::run_merge(&home, card_id, dry_run, pending_timeout_secs).await,
             WorkAction::Link { card_id, pr } => work_commands::run_link(&home, card_id, pr).await,
+            WorkAction::Relink { card_id, pr } => {
+                work_commands::run_relink(&home, card_id, pr).await
+            }
         },
 
         Command::Lane(args) => match args.action {

--- a/crates/airc-cli/src/work_cli.rs
+++ b/crates/airc-cli/src/work_cli.rs
@@ -349,6 +349,25 @@ pub enum WorkAction {
         #[arg(long)]
         pr: u64,
     },
+    /// Card 09fddedd: re-point a card's linked PR at a successor PR.
+    /// `airc work link` is first-write-wins — a card whose round-1 PR
+    /// was closed/superseded (orphaned stacked PRs, recovered lanes)
+    /// could never track the round-2 PR carrying the real fix, so the
+    /// merger skipped the card forever and Review cards orphaned
+    /// (failure class: card 6967921d). Relink emits a typed
+    /// `PullRequestRelinked` event recording the superseded link for
+    /// audit. Refuses loudly when the card has no linked PR (use
+    /// `link`), is already Merged/Closed, the successor IS the current
+    /// PR, or the successor doesn't exist / targets a different base
+    /// than the link it supersedes (validated via `gh --json`).
+    Relink {
+        /// Work card UUID whose PR link to supersede.
+        card_id: String,
+        /// Successor PR: a number (e.g. 1137) or a full GitHub PR URL
+        /// (e.g. https://github.com/CambrianTech/airc/pull/1137).
+        #[arg(long)]
+        pr: String,
+    },
 }
 
 #[derive(Debug, clap::Subcommand)]

--- a/crates/airc-cli/src/work_commands.rs
+++ b/crates/airc-cli/src/work_commands.rs
@@ -1403,6 +1403,45 @@ pub async fn run_link(
     crate::work_commands_gh::link_existing_pr(&airc, card_uuid, pr).await
 }
 
+/// Card 09fddedd: `airc work relink <CARD_ID> --pr <number-or-url>` —
+/// supersede a card's stale PR link with a successor PR. Thin
+/// orchestration over `work_commands_gh::relink_card_pr` — attach,
+/// parse the card id + PR spec, delegate. Sibling of [`run_link`].
+pub async fn run_relink(
+    home: &Path,
+    card_id: String,
+    pr: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let airc = crate::commands::attached_airc(home).await?;
+    let card_uuid = parse_work_card_id(&card_id)?;
+    let pr_number = parse_pr_spec(&pr)?;
+    crate::work_commands_gh::relink_card_pr(&airc, card_uuid, pr_number).await
+}
+
+/// Parse a `--pr` argument that is either a bare PR number (`1137`) or
+/// a full GitHub PR URL (`https://github.com/owner/repo/pull/1137`).
+/// Anything else is a loud error — no guessing, no substring scraping.
+fn parse_pr_spec(input: &str) -> Result<u64, Box<dyn std::error::Error>> {
+    let trimmed = input.trim();
+    if let Ok(number) = trimmed.parse::<u64>() {
+        return Ok(number);
+    }
+    // URL form: require the `/pull/<number>` path segment explicitly
+    // so an arbitrary URL (or a branch name with digits) can't sneak
+    // through as a PR number.
+    if let Some((_, tail)) = trimmed.split_once("/pull/") {
+        let digits = tail.split(['/', '?', '#']).next().unwrap_or("");
+        if let Ok(number) = digits.parse::<u64>() {
+            return Ok(number);
+        }
+    }
+    Err(format!(
+        "--pr {input:?} is neither a PR number nor a GitHub PR URL \
+         (expected e.g. 1137 or https://github.com/owner/repo/pull/1137)"
+    )
+    .into())
+}
+
 /// Card a399b342: `airc work merge <CARD_ID>` — manual one-shot merge
 /// behind the same gate the auto-merger uses. Refuses unless the card
 /// is in Review state with a PR linked AND the PR's CI is green per
@@ -2165,6 +2204,56 @@ impl From<CliCardState> for CardState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Card 09fddedd — `--pr <number-or-url>` parser for `airc work
+    // relink`. Loud failures only: anything that is not a bare PR
+    // number or a URL with an explicit `/pull/<n>` segment refuses.
+
+    #[test]
+    fn parse_pr_spec_accepts_bare_number_and_pull_url() {
+        assert_eq!(parse_pr_spec("1137").unwrap(), 1137);
+        assert_eq!(parse_pr_spec("  1137 ").unwrap(), 1137);
+        assert_eq!(
+            parse_pr_spec("https://github.com/CambrianTech/airc/pull/1137").unwrap(),
+            1137
+        );
+        // Trailing path / query / fragment after the number is fine —
+        // gh emits and humans paste all three shapes.
+        assert_eq!(
+            parse_pr_spec("https://github.com/CambrianTech/airc/pull/1137/files").unwrap(),
+            1137
+        );
+        assert_eq!(
+            parse_pr_spec("https://github.com/CambrianTech/airc/pull/1137?diff=split").unwrap(),
+            1137
+        );
+        assert_eq!(
+            parse_pr_spec("https://github.com/CambrianTech/airc/pull/1137#discussion_r1").unwrap(),
+            1137
+        );
+    }
+
+    #[test]
+    fn parse_pr_spec_refuses_non_pr_shapes_loudly() {
+        // what this catches: the parser degrading into digit-scraping.
+        // An issue URL, a branch name with digits, or an empty string
+        // must refuse — guessing a PR number here would relink a card
+        // to an arbitrary PR.
+        for input in [
+            "",
+            "abc",
+            "-5",
+            "https://github.com/CambrianTech/airc/issues/1137",
+            "https://github.com/CambrianTech/airc/pull/",
+            "https://github.com/CambrianTech/airc/pull/not-a-number",
+            "feat/1137-branch",
+        ] {
+            assert!(
+                parse_pr_spec(input).is_err(),
+                "parse_pr_spec({input:?}) must refuse, not guess"
+            );
+        }
+    }
 
     #[test]
     fn lease_renders_dash_when_no_claim() {

--- a/crates/airc-cli/src/work_commands_gh.rs
+++ b/crates/airc-cli/src/work_commands_gh.rs
@@ -274,6 +274,111 @@ pub(crate) async fn link_existing_pr(
     Ok(())
 }
 
+/// Card 09fddedd — supersede a card's linked PR with a successor PR.
+/// Sibling of [`link_existing_pr`]: same `gh pr view --json` read (no
+/// stdout scraping of human output), same explicit `--repo` so it
+/// works after the card's worktree is gone.
+///
+/// Division of labour: this adapter validates the things only the
+/// forge knows — the successor PR must EXIST and must target the SAME
+/// base branch as the link it supersedes (a relink across bases is a
+/// retarget, not a supersede, and would hand the merger a PR landing
+/// somewhere the card never promised). Projection-side validation
+/// (card exists, currently linked, not terminal, successor differs)
+/// lives in `Airc::relink_card_pull_request`, the single emit path.
+pub(crate) async fn relink_card_pr(
+    airc: &airc_lib::Airc,
+    card_id: airc_lib::WorkCardId,
+    pr_number: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use airc_work::model::{BranchName, PullRequestRef};
+
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?;
+    let card = board
+        .card(card_id)
+        .ok_or_else(|| format!("card {card_id} not visible in board projection"))?;
+    let Some(current) = &card.pull_request else {
+        return Err(format!(
+            "card {card_id} has no linked pull_request to supersede — \
+             use `airc work link {card_id} --pr {pr_number}` for the first link"
+        )
+        .into());
+    };
+    let repo = card.repo.clone();
+
+    // Read the successor PR's actual head/base/state from GitHub —
+    // typed JSON, explicit --repo, never parsed from human output.
+    let out = std::process::Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &pr_number.to_string(),
+            "--repo",
+            repo.as_str(),
+            "--json",
+            "state,headRefName,baseRefName",
+            "--jq",
+            ".state + \"\\t\" + .headRefName + \"\\t\" + .baseRefName",
+        ])
+        .output()?;
+    if !out.status.success() {
+        return Err(format!(
+            "gh pr view #{pr_number} ({}) failed — successor PR must exist: {}",
+            repo.as_str(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        )
+        .into());
+    }
+    let line = String::from_utf8(out.stdout)?;
+    let mut fields = line.trim().split('\t');
+    let state = fields.next().unwrap_or("").trim().to_string();
+    let head = fields.next().unwrap_or("").trim().to_string();
+    let base = fields.next().unwrap_or("").trim().to_string();
+    if head.is_empty() || base.is_empty() {
+        return Err(format!(
+            "could not parse head/base for PR #{pr_number} ({}) — got state={state:?}",
+            repo.as_str()
+        )
+        .into());
+    }
+    if base != current.base.as_str() {
+        return Err(format!(
+            "refusing to relink card {card_id}: successor PR #{pr_number} targets base {base:?} \
+             but the superseded PR #{} targets {:?} — a cross-base relink is a retarget, not a \
+             supersede; open the successor against the same base first",
+            current.number,
+            current.base.as_str()
+        )
+        .into());
+    }
+    if state != "OPEN" {
+        // Same convention as `airc work link`: a non-OPEN successor is
+        // recorded (history is honest) but the merger won't act on it,
+        // so the caller hears about it loudly.
+        eprintln!("airc: warning — successor PR #{pr_number} state is {state}, not OPEN");
+    }
+
+    let new_pull_request = PullRequestRef {
+        repo,
+        number: pr_number,
+        head: BranchName::new(head)?,
+        base: BranchName::new(base)?,
+    };
+    let superseded = airc
+        .relink_card_pull_request(airc_lib::RelinkCardPullRequest {
+            card_id,
+            new_pull_request,
+        })
+        .await?;
+    println!(
+        "pull_request_relinked: card={card_id} old=#{} new=#{pr_number}",
+        superseded.number
+    );
+    Ok(())
+}
+
 pub(crate) fn gh_default_branch(worktree: &str) -> Result<String, Box<dyn std::error::Error>> {
     // Card a4fe899f: `gh` does NOT accept `-C`; set cwd via
     // `Command::current_dir(...)` so `gh repo view` resolves the

--- a/crates/airc-lib/src/error.rs
+++ b/crates/airc-lib/src/error.rs
@@ -122,6 +122,42 @@ pub enum AircError {
         owner: Option<airc_core::PeerId>,
     },
 
+    /// Card 09fddedd: `relink` supersedes an EXISTING link — a card
+    /// with no linked PR has nothing to supersede. Use `airc work
+    /// link` for the first link; refusing here keeps the audit
+    /// semantics honest (`PullRequestRelinked.old_pull_request` must
+    /// record a real prior link, never a fabricated placeholder).
+    #[error(
+        "work card {card_id} has no linked pull_request to supersede; use `airc work link` for the first link"
+    )]
+    WorkCardHasNoLinkedPullRequest { card_id: airc_work::WorkCardId },
+
+    /// Card 09fddedd: relinking a card to the PR it already tracks is
+    /// always an operator mistake (wrong card id or wrong PR number) —
+    /// emitting a no-op supersede event would only pollute the audit
+    /// trail, so the SDK refuses loudly instead.
+    #[error(
+        "work card {card_id} is already linked to PR #{number} ({repo}); relink requires a different successor PR"
+    )]
+    WorkCardRelinkSamePullRequest {
+        card_id: airc_work::WorkCardId,
+        repo: airc_work::RepoId,
+        number: u64,
+    },
+
+    /// Card 09fddedd: a card in a terminal state (`Merged`/`Closed`)
+    /// has finished its lifecycle; superseding its PR link would point
+    /// the merger at a successor for work that already shipped. The
+    /// projection drops such events defensively on replay; the SDK
+    /// refuses up front so the operator hears about it.
+    #[error(
+        "work card {card_id} is in terminal state {state:?}; its pull_request link cannot be superseded"
+    )]
+    WorkCardRelinkTerminalState {
+        card_id: airc_work::WorkCardId,
+        state: airc_work::CardState,
+    },
+
     /// Caller passed a peer registry operation referencing a peer
     /// not in the local registry.
     #[error("unknown peer: {0}")]

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -164,8 +164,9 @@ pub use work::{
     ClaimableWorkItem, ClaimableWorkQuery, CreateWorkCard, CreateWorkLane, HeartbeatWorkClaim,
     HeartbeatWorkspace, LinkCardPullRequest, MarkPullRequestMerged, ObserveLocalGitWorkspace,
     ObservePullRequests, ObservedLocalGitWorkspace, ObservedPullRequests, ReleaseManagerHat,
-    ReleaseWorkClaim, ReleaseWorkspace, ReportAgentAvailability, RequestWorkspace, UpdateWorkCard,
-    WorkQueueStatus, WorkQueueStatusQuery, WORK_BOARD_PROJECTION_PAGE_SIZE,
+    ReleaseWorkClaim, ReleaseWorkspace, RelinkCardPullRequest, ReportAgentAvailability,
+    RequestWorkspace, UpdateWorkCard, WorkQueueStatus, WorkQueueStatusQuery,
+    WORK_BOARD_PROJECTION_PAGE_SIZE,
 };
 pub use work_manager::{
     SeededWorkCard, WorkBacklogSeedCandidate, WorkBacklogSeedOutcome, WorkBacklogSeedResult,

--- a/crates/airc-lib/src/work.rs
+++ b/crates/airc-lib/src/work.rs
@@ -185,6 +185,28 @@ pub struct LinkCardPullRequest {
     pub pull_request: airc_work::model::PullRequestRef,
 }
 
+/// Card 09fddedd: supersede a card's linked PR with a successor PR.
+/// `LinkCardPullRequest` is first-write-wins at every CLI entry point
+/// (`airc work link` and `state review` both no-op on an already-linked
+/// card), so a card whose round-1 PR was closed/merged without the real
+/// fix could never track the round-2 PR — the merger skipped the card
+/// forever (failure class: orphaned Review cards, 6967921d). The
+/// emitted `PullRequestRelinked` event records the superseded link for
+/// auditability; the projection adopts the successor and (re)enters
+/// `CardState::Review`.
+///
+/// `Airc::relink_card_pull_request` validates loudly before emitting:
+/// the card must exist in the current room, must currently have a
+/// linked PR, must not be in a terminal state, and the successor must
+/// be a different PR. Forge-side validation (successor exists, targets
+/// the same base) is the CLI adapter's job — the SDK stays free of any
+/// hard GitHub dependency.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelinkCardPullRequest {
+    pub card_id: WorkCardId,
+    pub new_pull_request: airc_work::model::PullRequestRef,
+}
+
 /// Card f16650cd: attest that a PR has been merged. Published by the
 /// continuous-merge background task (`airc work merger run`) AFTER it
 /// successfully calls `gh pr merge`. The projection picks this up and
@@ -550,6 +572,40 @@ impl Airc {
         });
         self.publish_work_event(&event).await?;
         Ok(())
+    }
+
+    /// Card 09fddedd: supersede the card's linked PR with a successor
+    /// (see [`RelinkCardPullRequest`]). Validates against the current
+    /// room's projection and refuses loudly — no fallback link, no
+    /// silent no-op — then emits `WorkEvent::PullRequestRelinked`
+    /// carrying BOTH links (old for audit, new as the projection's
+    /// new source of truth). Returns the superseded link so callers
+    /// can surface what was replaced.
+    pub async fn relink_card_pull_request(
+        &self,
+        request: RelinkCardPullRequest,
+    ) -> Result<airc_work::model::PullRequestRef, AircError> {
+        let room = self.current_room().await?;
+        let board = self
+            .project_room_work_board(&room, WORK_MUTATION_PAGE_SIZE)
+            .await?;
+        let Some(card) = board.card(request.card_id) else {
+            return Err(AircError::WorkCardNotInCurrentRoom {
+                card_id: request.card_id,
+                room_name: room.name,
+                room_id: room.channel,
+            });
+        };
+        let old_pull_request = validate_relink_card_pull_request(card, &request.new_pull_request)?;
+        let event = WorkEvent::PullRequestRelinked(airc_work::event::PullRequestRelinked {
+            card_id: request.card_id,
+            old_pull_request: old_pull_request.clone(),
+            new_pull_request: request.new_pull_request,
+            relinked_by: self.peer_id(),
+            relinked_at_ms: now_ms()?,
+        });
+        self.publish_work_event(&event).await?;
+        Ok(old_pull_request)
     }
 
     /// Card f16650cd: attest that the linked PR has been merged. The
@@ -1176,6 +1232,46 @@ impl Airc {
     }
 }
 
+/// Card 09fddedd — pure relink gate, extracted from
+/// `Airc::relink_card_pull_request` so each refusal is unit-testable
+/// without standing up a full Airc instance. Returns the superseded
+/// link on success; every refusal is a typed `AircError`, never a
+/// silent no-op (`[[no-fallbacks-ever]]`).
+///
+/// Order of the checks is deliberate: terminal state first (the card's
+/// lifecycle is over — reporting "no linked PR" on a Closed card would
+/// send the operator to `airc work link`, which is the wrong tool),
+/// then link presence, then same-PR.
+fn validate_relink_card_pull_request(
+    card: &WorkCard,
+    new_pull_request: &airc_work::model::PullRequestRef,
+) -> Result<airc_work::model::PullRequestRef, AircError> {
+    if matches!(card.state, CardState::Merged | CardState::Closed) {
+        return Err(AircError::WorkCardRelinkTerminalState {
+            card_id: card.card_id,
+            state: card.state,
+        });
+    }
+    let Some(old_pull_request) = card.pull_request.clone() else {
+        return Err(AircError::WorkCardHasNoLinkedPullRequest {
+            card_id: card.card_id,
+        });
+    };
+    // Identity of a PR is (repo, number) — head/base can legitimately
+    // drift on the forge side (retarget, force-push) without making
+    // the PR a different PR, so they do not participate in this check.
+    if old_pull_request.repo == new_pull_request.repo
+        && old_pull_request.number == new_pull_request.number
+    {
+        return Err(AircError::WorkCardRelinkSamePullRequest {
+            card_id: card.card_id,
+            repo: old_pull_request.repo,
+            number: old_pull_request.number,
+        });
+    }
+    Ok(old_pull_request)
+}
+
 fn availability_state_rank(state: AgentAvailabilityState) -> u8 {
     match state {
         AgentAvailabilityState::Ready => 0,
@@ -1287,5 +1383,113 @@ mod tests {
         // Belt-and-suspenders: `created_by` and the `Operator.peer_id`
         // are the same identity by construction at the operator emitter.
         assert_eq!(event.created_by, peer_id);
+    }
+
+    // Card 09fddedd — relink gate. Each refusal is pinned as a typed
+    // error variant so the CLI surface can't drift into a silent no-op
+    // (the failure class this card fixes was exactly a silent skip:
+    // first-write-wins link + no supersede path = orphaned Review
+    // cards, 6967921d).
+
+    fn pr_ref(number: u64) -> airc_work::model::PullRequestRef {
+        airc_work::model::PullRequestRef {
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            number,
+            head: airc_work::BranchName::new(format!("feat/pr-{number}")).unwrap(),
+            base: airc_work::BranchName::new("rust-rewrite").unwrap(),
+        }
+    }
+
+    fn card_in(
+        state: CardState,
+        pull_request: Option<airc_work::model::PullRequestRef>,
+    ) -> WorkCard {
+        WorkCard {
+            card_id: WorkCardId::from_u128(1),
+            repo: RepoId::new("CambrianTech/airc").unwrap(),
+            title: "relink gate".to_string(),
+            body: None,
+            priority: Priority::P2,
+            lane_id: None,
+            state,
+            owner: None,
+            claim_id: None,
+            claim_expires_at_ms: None,
+            last_heartbeat_at_ms: None,
+            pull_request,
+            created_by: airc_core::PeerId::from_u128(2),
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            reviews: None,
+        }
+    }
+
+    #[test]
+    fn relink_gate_returns_superseded_link_for_review_card() {
+        // what this catches: the success path must hand back the OLD
+        // link (the audit payload for PullRequestRelinked), not the new
+        // one — returning the new ref would silently fabricate the
+        // audit trail while every assertion on "did it error" passes.
+        let old = pr_ref(1078);
+        let card = card_in(CardState::Review, Some(old.clone()));
+        let superseded = validate_relink_card_pull_request(&card, &pr_ref(1137))
+            .expect("review card with a stale link must be relinkable");
+        assert_eq!(superseded, old, "gate must return the superseded link");
+    }
+
+    #[test]
+    fn relink_gate_refuses_card_without_linked_pr() {
+        // what this catches: relink degrading into a first-link path.
+        // `airc work link` owns the first link; relink on an unlinked
+        // card must refuse loudly so old_pull_request is never faked.
+        let card = card_in(CardState::InProgress, None);
+        match validate_relink_card_pull_request(&card, &pr_ref(1137)) {
+            Err(AircError::WorkCardHasNoLinkedPullRequest { card_id }) => {
+                assert_eq!(card_id, card.card_id);
+            }
+            other => panic!("expected WorkCardHasNoLinkedPullRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn relink_gate_refuses_same_pull_request() {
+        // what this catches: emitting a no-op supersede event (old ==
+        // new), which would pollute the transcript's audit trail and
+        // mask an operator typo. Identity is (repo, number): a changed
+        // head branch on the same PR number is still the same PR.
+        let mut old = pr_ref(1137);
+        old.head = airc_work::BranchName::new("feat/old-head").unwrap();
+        let card = card_in(CardState::Review, Some(old));
+        match validate_relink_card_pull_request(&card, &pr_ref(1137)) {
+            Err(AircError::WorkCardRelinkSamePullRequest { number, .. }) => {
+                assert_eq!(number, 1137);
+            }
+            other => panic!("expected WorkCardRelinkSamePullRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn relink_gate_refuses_merged_and_closed_cards() {
+        // what this catches: pointing the merger at a successor PR for
+        // work that already shipped. Terminal-state refusal must win
+        // over every other check — even a merged card WITH a link and a
+        // distinct successor refuses on state, and a closed card
+        // WITHOUT a link reports the terminal state (not "no linked
+        // PR", which would misdirect the operator to `airc work link`).
+        let merged = card_in(CardState::Merged, Some(pr_ref(1078)));
+        match validate_relink_card_pull_request(&merged, &pr_ref(1137)) {
+            Err(AircError::WorkCardRelinkTerminalState { state, .. }) => {
+                assert_eq!(state, CardState::Merged);
+            }
+            other => panic!("expected WorkCardRelinkTerminalState, got {other:?}"),
+        }
+
+        let closed = card_in(CardState::Closed, None);
+        match validate_relink_card_pull_request(&closed, &pr_ref(1137)) {
+            Err(AircError::WorkCardRelinkTerminalState { state, .. }) => {
+                assert_eq!(state, CardState::Closed);
+            }
+            other => panic!("expected WorkCardRelinkTerminalState, got {other:?}"),
+        }
     }
 }

--- a/crates/airc-work-store/src/tests.rs
+++ b/crates/airc-work-store/src/tests.rs
@@ -417,3 +417,60 @@ fn apply_transcripts_skips_missing_anchor_but_fails_structural_errors() {
     );
     assert!(matches!(result, Err(WorkStoreError::Projection(_))));
 }
+
+#[test]
+fn apply_transcripts_resume_applies_relink_after_snapshot_boundary() {
+    // Card 09fddedd — the work-board-cache resume path (card 1291173d:
+    // projection snapshot keyed by last-applied cursor) must fold a
+    // `PullRequestRelinked` event that lands AFTER the snapshot
+    // boundary identically to a full from-zero replay. If the resume
+    // rule and the full-replay rule ever diverge on the new variant,
+    // cached boards would keep pointing the merger at the superseded
+    // PR — the exact stale-link failure the relink verb exists to fix.
+    let room = RoomId::from_u128(11);
+    let card = WorkCardId::from_u128(30);
+    let pr = |number: u64, head: &str| airc_work::PullRequestRef {
+        repo: RepoId::new("CambrianTech/airc").unwrap(),
+        number,
+        head: airc_work::BranchName::new(head).unwrap(),
+        base: airc_work::BranchName::new("rust-rewrite").unwrap(),
+    };
+    let linked = WorkEvent::PullRequestLinked(airc_work::PullRequestLinked {
+        card_id: card,
+        pull_request: pr(1078, "feat/round-1"),
+        linked_by: PeerId::from_u128(200),
+        linked_at_ms: 1100,
+    });
+    let relinked = WorkEvent::PullRequestRelinked(airc_work::PullRequestRelinked {
+        card_id: card,
+        old_pull_request: pr(1078, "feat/round-1"),
+        new_pull_request: pr(1137, "feat/round-2"),
+        relinked_by: PeerId::from_u128(201),
+        relinked_at_ms: 1200,
+    });
+
+    let transcripts = vec![
+        work_transcript(1, room, 1, &card_created(card)),
+        work_transcript(2, room, 2, &linked),
+        // ---- snapshot boundary (cache cursor parked here) ----
+        work_transcript(3, room, 3, &relinked),
+    ];
+
+    let full = project_transcripts(transcripts.clone()).unwrap();
+
+    let mut resumed = project_transcripts(transcripts[..2].to_vec()).unwrap();
+    assert_eq!(
+        resumed.card(card).unwrap().pull_request,
+        Some(pr(1078, "feat/round-1")),
+        "snapshot state must hold the superseded link before catch-up"
+    );
+    let newest = apply_transcripts(&mut resumed, transcripts[2..].to_vec())
+        .unwrap()
+        .expect("non-empty increment yields a cursor");
+
+    assert_eq!(resumed, full, "cache catch-up diverged from full replay");
+    assert_eq!(newest.event_id, EventId::from_u128(3));
+    let caught_up = resumed.card(card).unwrap();
+    assert_eq!(caught_up.pull_request, Some(pr(1137, "feat/round-2")));
+    assert_eq!(caught_up.state, CardState::Review);
+}

--- a/crates/airc-work/src/codec/headers.rs
+++ b/crates/airc-work/src/codec/headers.rs
@@ -126,6 +126,13 @@ fn project_domain_headers(event: &WorkEvent, headers: &mut Headers) {
             insert_display_header(headers, HEADER_FORGE_WORK_CARD_ID, e.card_id);
             project_pull_request(headers, &e.pull_request);
         }
+        WorkEvent::PullRequestRelinked(e) => {
+            insert_display_header(headers, HEADER_FORGE_WORK_CARD_ID, e.card_id);
+            // Route on the SUCCESSOR — it is the card's new source of
+            // truth and what subscribers (merger, board renderers)
+            // care about. The superseded PR rides the body for audit.
+            project_pull_request(headers, &e.new_pull_request);
+        }
         WorkEvent::PullRequestMerged(e) => {
             insert_display_header(headers, HEADER_FORGE_WORK_CARD_ID, e.card_id);
             project_pull_request(headers, &e.pull_request);

--- a/crates/airc-work/src/codec/mod.rs
+++ b/crates/airc-work/src/codec/mod.rs
@@ -106,6 +106,7 @@ pub(crate) fn event_kind(event: &WorkEvent) -> &'static str {
         WorkEvent::PullRequestReviewSubmitted(_) => "pull_request_review_submitted",
         WorkEvent::PullRequestMergeStateChanged(_) => "pull_request_merge_state_changed",
         WorkEvent::PullRequestLinked(_) => "pull_request_linked",
+        WorkEvent::PullRequestRelinked(_) => "pull_request_relinked",
         WorkEvent::PullRequestMerged(_) => "pull_request_merged",
         WorkEvent::HygieneReportRecorded(_) => "hygiene_report_recorded",
         WorkEvent::ManagerHatClaimed(_) => "manager_hat_claimed",

--- a/crates/airc-work/src/codec/tests.rs
+++ b/crates/airc-work/src/codec/tests.rs
@@ -634,6 +634,176 @@ fn goal_dry_tick_recorded_body_serde_tag_is_pinned_literal() {
     );
 }
 
+// Card 09fddedd — wire pins for `PullRequestRelinked`. Three layers,
+// per this repo's known failure class ("a pin that pins nothing"):
+// round-trip (tag-blind, catches struct drift), literal body-tag +
+// field-name pins (catch serde renames the round-trip can't see), and
+// a hand-written literal payload decode (proves the pinned names are
+// the ACTUAL decode contract, not just the encode shape).
+
+fn pull_request_relinked_event() -> WorkEvent {
+    let repo = RepoId::new("CambrianTech/airc").unwrap();
+    WorkEvent::PullRequestRelinked(crate::event::PullRequestRelinked {
+        card_id: WorkCardId::from_u128(0x09f),
+        old_pull_request: PullRequestRef {
+            repo: repo.clone(),
+            number: 1078,
+            head: BranchName::new("feat/round-1").unwrap(),
+            base: BranchName::new("rust-rewrite").unwrap(),
+        },
+        new_pull_request: PullRequestRef {
+            repo,
+            number: 1137,
+            head: BranchName::new("feat/round-2").unwrap(),
+            base: BranchName::new("rust-rewrite").unwrap(),
+        },
+        relinked_by: peer(0x6967),
+        relinked_at_ms: 7,
+    })
+}
+
+#[test]
+fn pull_request_relinked_roundtrips_with_card_and_successor_pr_headers() {
+    // what this catches: regression where the new variant fails to
+    // round-trip, or its routing headers drop. Headers must route on
+    // the SUCCESSOR PR — the card's new source of truth — with the
+    // superseded PR riding only the body for audit.
+    let event = pull_request_relinked_event();
+    let (headers, body) = encode_work_event(&event).unwrap();
+    assert_eq!(decode_work_event(&headers, Some(&body)).unwrap(), event);
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_WORK_EVENT_KIND)
+            .map(String::as_str),
+        Some("pull_request_relinked")
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_WORK_CARD_ID).map(String::as_str),
+        Some("00000000-0000-0000-0000-00000000009f")
+    );
+    assert_eq!(
+        headers.get(HEADER_FORGE_WORK_PR_NUMBER).map(String::as_str),
+        Some("1137"),
+        "pr_number header must carry the SUCCESSOR, not the superseded PR"
+    );
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_WORK_GIT_BRANCH)
+            .map(String::as_str),
+        Some("feat/round-2"),
+        "branch header must carry the successor's head"
+    );
+}
+
+#[test]
+fn pull_request_relinked_body_wire_shape_is_pinned_literal() {
+    // what this catches: a serde rename of the variant tag or of any
+    // field (`old_pull_request` → `previous`, etc.). Round-trip tests
+    // are tag- and field-name-blind; these literal assertions are the
+    // wire contract. Renaming anything here is a deliberate wire break
+    // and must update this test in the same commit.
+    let event = pull_request_relinked_event();
+    let (headers, body) = encode_work_event(&event).unwrap();
+    let value = body_value(&body);
+    assert_eq!(
+        value.get("kind").and_then(|v| v.as_str()),
+        Some("pull_request_relinked"),
+        "WorkEvent::PullRequestRelinked body MUST encode `\"kind\":\"pull_request_relinked\"`"
+    );
+    // Header/body consistency — same rule the goal-event pins enforce.
+    assert_eq!(
+        headers
+            .get(HEADER_FORGE_WORK_EVENT_KIND)
+            .map(String::as_str),
+        value.get("kind").and_then(|v| v.as_str()),
+        "envelope kind header must equal body serde tag"
+    );
+    for field in [
+        "card_id",
+        "old_pull_request",
+        "new_pull_request",
+        "relinked_by",
+        "relinked_at_ms",
+    ] {
+        assert!(
+            value.get(field).is_some(),
+            "PullRequestRelinked body MUST encode field {field:?}; got {value}"
+        );
+    }
+    // The two PR refs are full PullRequestRef objects, not bare
+    // numbers — the audit payload must be self-contained.
+    assert_eq!(
+        value
+            .get("old_pull_request")
+            .and_then(|v| v.get("number"))
+            .and_then(|v| v.as_u64()),
+        Some(1078)
+    );
+    assert_eq!(
+        value
+            .get("new_pull_request")
+            .and_then(|v| v.get("number"))
+            .and_then(|v| v.as_u64()),
+        Some(1137)
+    );
+}
+
+#[test]
+fn pull_request_relinked_literal_wire_payload_decodes() {
+    // what this catches: drift where the encode side and the pinned
+    // names move together but a hand-authored / cross-version payload
+    // no longer decodes. This literal JSON is frozen as the v1 wire
+    // shape of the event.
+    let payload = serde_json::json!({
+        "kind": "pull_request_relinked",
+        "card_id": "00000000-0000-0000-0000-00000000009f",
+        "old_pull_request": {
+            "repo": "CambrianTech/airc",
+            "number": 1078,
+            "head": "feat/round-1",
+            "base": "rust-rewrite"
+        },
+        "new_pull_request": {
+            "repo": "CambrianTech/airc",
+            "number": 1137,
+            "head": "feat/round-2",
+            "base": "rust-rewrite"
+        },
+        "relinked_by": "00000000-0000-0000-0000-000000006967",
+        "relinked_at_ms": 7
+    });
+    let decoded: WorkEvent = serde_json::from_value(payload).unwrap();
+    assert_eq!(decoded, pull_request_relinked_event());
+}
+
+#[test]
+fn pull_request_linked_literal_wire_payload_still_decodes() {
+    // what this catches: the new `PullRequestRelinked` variant (or any
+    // future enum surgery) breaking decode of EXISTING events on the
+    // wire. Every `pull_request_linked` event already in transcripts
+    // must keep decoding byte-for-byte — wire-compat is the hard
+    // constraint on extending `WorkEvent`.
+    let payload = serde_json::json!({
+        "kind": "pull_request_linked",
+        "card_id": "00000000-0000-0000-0000-00000000009f",
+        "pull_request": {
+            "repo": "CambrianTech/airc",
+            "number": 1078,
+            "head": "feat/round-1",
+            "base": "rust-rewrite"
+        },
+        "linked_by": "00000000-0000-0000-0000-000000006967",
+        "linked_at_ms": 5
+    });
+    let decoded: WorkEvent = serde_json::from_value(payload).unwrap();
+    let WorkEvent::PullRequestLinked(linked) = decoded else {
+        panic!("legacy pull_request_linked payload must decode to PullRequestLinked");
+    };
+    assert_eq!(linked.card_id, WorkCardId::from_u128(0x09f));
+    assert_eq!(linked.pull_request.number, 1078);
+    assert_eq!(linked.linked_at_ms, 5);
+}
+
 #[test]
 fn card_created_origin_field_name_is_pinned_literal() {
     // what this catches: mutation of `CardCreated.origin` field name

--- a/crates/airc-work/src/event.rs
+++ b/crates/airc-work/src/event.rs
@@ -39,6 +39,7 @@ pub enum WorkEvent {
     PullRequestReviewSubmitted(PullRequestReviewSubmitted),
     PullRequestMergeStateChanged(PullRequestMergeStateChanged),
     PullRequestLinked(PullRequestLinked),
+    PullRequestRelinked(PullRequestRelinked),
     PullRequestMerged(PullRequestMerged),
     HygieneReportRecorded(HygieneReportRecorded),
     ManagerHatClaimed(ManagerHatClaimed),
@@ -85,6 +86,7 @@ impl WorkEvent {
             WorkEvent::PullRequestReviewSubmitted(e) => e.submitted_at_ms,
             WorkEvent::PullRequestMergeStateChanged(e) => e.changed_at_ms,
             WorkEvent::PullRequestLinked(e) => e.linked_at_ms,
+            WorkEvent::PullRequestRelinked(e) => e.relinked_at_ms,
             WorkEvent::PullRequestMerged(e) => e.merged_at_ms,
             WorkEvent::HygieneReportRecorded(e) => e.report.recorded_at_ms,
             WorkEvent::ManagerHatClaimed(e) => e.claimed_at_ms,
@@ -400,6 +402,36 @@ pub struct PullRequestLinked {
     pub pull_request: PullRequestRef,
     pub linked_by: PeerId,
     pub linked_at_ms: u64,
+}
+
+/// Card 09fddedd: re-point a card's linked PR at a successor PR.
+///
+/// `PullRequestLinked` is effectively first-write-wins at the CLI
+/// layer (`airc work link` / `state review` both no-op on an
+/// already-linked card), so a card whose round-1 PR was closed or
+/// merged without the real fix (orphaned stacked PRs, recovered
+/// lanes — failure class: card 6967921d) could never be pointed at
+/// the round-2 PR carrying the actual work. The merger then skips
+/// the card forever and the successor PR needs a manual merge.
+///
+/// This event is the intentional-supersede path: it records BOTH
+/// links — `old_pull_request` for auditability (which PR the card
+/// abandoned, and why the transcript shows two), `new_pull_request`
+/// as the new single source of truth the projection adopts. It is
+/// deliberately a distinct variant rather than a second
+/// `PullRequestLinked` so replayers can tell a supersede from a
+/// duplicate link without diffing projection state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestRelinked {
+    pub card_id: WorkCardId,
+    /// The link being superseded, exactly as the projection held it
+    /// when the relink was emitted. Audit trail — the projection
+    /// drops it, the transcript keeps it.
+    pub old_pull_request: PullRequestRef,
+    /// The successor PR the card now tracks.
+    pub new_pull_request: PullRequestRef,
+    pub relinked_by: PeerId,
+    pub relinked_at_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/airc-work/src/lib.rs
+++ b/crates/airc-work/src/lib.rs
@@ -35,8 +35,8 @@ pub use event::{
     ClaimReleased, GitBranchMoved, GitCommitObserved, GitDirtyStateChanged, HygieneReportRecorded,
     LaneCreated, LaneStateChanged, ManagerHatClaimed, ManagerHatReleased,
     PullRequestCheckSuiteChanged, PullRequestLinked, PullRequestMergeStateChanged,
-    PullRequestMerged, PullRequestReviewSubmitted, WorkCardClaimed, WorkEvent, WorkspaceAllocated,
-    WorkspaceDrainCompleted, WorkspaceDrainRequested, WorkspaceHeartbeat,
+    PullRequestMerged, PullRequestRelinked, PullRequestReviewSubmitted, WorkCardClaimed, WorkEvent,
+    WorkspaceAllocated, WorkspaceDrainCompleted, WorkspaceDrainRequested, WorkspaceHeartbeat,
     WorkspacePressureReported, WorkspaceReleased, WorkspaceRequested,
 };
 pub use goal::{ExitCondition, Goal, GoalState};

--- a/crates/airc-work/src/projection/apply.rs
+++ b/crates/airc-work/src/projection/apply.rs
@@ -3,8 +3,8 @@ use crate::event::{
     ClaimReleased, GitBranchMoved, GitCommitObserved, GitDirtyStateChanged, HygieneReportRecorded,
     LaneCreated, LaneStateChanged, ManagerHatClaimed, ManagerHatReleased,
     PullRequestCheckSuiteChanged, PullRequestLinked, PullRequestMergeStateChanged,
-    PullRequestMerged, PullRequestReviewSubmitted, WorkCardClaimed, WorkEvent, WorkspaceAllocated,
-    WorkspaceDrainCompleted, WorkspaceDrainRequested, WorkspaceHeartbeat,
+    PullRequestMerged, PullRequestRelinked, PullRequestReviewSubmitted, WorkCardClaimed, WorkEvent,
+    WorkspaceAllocated, WorkspaceDrainCompleted, WorkspaceDrainRequested, WorkspaceHeartbeat,
     WorkspacePressureReported, WorkspaceReleased, WorkspaceRequested,
 };
 use crate::ids::{WorkCardId, WorkspaceId};
@@ -54,6 +54,7 @@ impl WorkBoardProjection {
                 Ok(())
             }
             WorkEvent::PullRequestLinked(e) => self.apply_pull_request_linked(e),
+            WorkEvent::PullRequestRelinked(e) => self.apply_pull_request_relinked(e),
             WorkEvent::PullRequestMerged(e) => self.apply_pull_request_merged(e),
             WorkEvent::HygieneReportRecorded(e) => self.apply_hygiene_report_recorded(e),
             WorkEvent::ManagerHatClaimed(e) => self.apply_manager_hat_claimed(e),
@@ -495,6 +496,41 @@ impl WorkBoardProjection {
         card.pull_request = Some(e.pull_request.clone());
         card.state = CardState::Review;
         card.updated_at_ms = e.linked_at_ms;
+        Ok(())
+    }
+
+    /// Card 09fddedd: supersede a card's linked PR with a successor.
+    ///
+    /// The emitter (`Airc::relink_card_pull_request`) is the loud
+    /// validation layer — card must exist, must currently have a
+    /// linked PR, the successor must differ and target the same base.
+    /// The projection apply is the deterministic replay layer:
+    ///
+    ///   * Unknown card → `ProjectionError::UnknownCard`, same as
+    ///     `apply_pull_request_linked` (and equally tolerated by
+    ///     `apply_windowed` as a missing window anchor).
+    ///   * Card already `Merged`/`Closed` → drop silently. A relink
+    ///     racing a terminal transition lost the race; flipping a
+    ///     Merged card back into Review would make the merger merge a
+    ///     successor for work that already shipped, and erroring would
+    ///     poison every consumer's board (same tolerant-replay rule as
+    ///     ghost claim heartbeats above).
+    ///   * Otherwise: adopt the successor and (re)enter Review, exactly
+    ///     like `apply_pull_request_linked`, so the merger gate sees
+    ///     the new PR as the card's single source of truth. The
+    ///     superseded link survives in the transcript event, not in
+    ///     projection state.
+    fn apply_pull_request_relinked(
+        &mut self,
+        e: &PullRequestRelinked,
+    ) -> Result<(), ProjectionError> {
+        let card = self.card_mut(e.card_id)?;
+        if matches!(card.state, CardState::Merged | CardState::Closed) {
+            return Ok(());
+        }
+        card.pull_request = Some(e.new_pull_request.clone());
+        card.state = CardState::Review;
+        card.updated_at_ms = e.relinked_at_ms;
         Ok(())
     }
 

--- a/crates/airc-work/src/projection/tests.rs
+++ b/crates/airc-work/src/projection/tests.rs
@@ -1615,3 +1615,202 @@ fn apply_windowed_skips_missing_anchor_and_fails_structural_errors() {
         Err(ProjectionError::DuplicateCard(card_id))
     );
 }
+
+// Card 09fddedd — `PullRequestRelinked` projection semantics. The
+// loud-refusal layer lives in `Airc::relink_card_pull_request`
+// (airc-lib); the projection layer is the deterministic-replay rule:
+// adopt the successor on live cards, drop silently on terminal cards,
+// error (window-anchor-tolerantly) on unknown cards.
+
+fn relink_pr(number: u64, head: &str) -> PullRequestRef {
+    PullRequestRef {
+        repo: repo(),
+        number,
+        head: BranchName::new(head).unwrap(),
+        base: BranchName::new("rust-rewrite").unwrap(),
+    }
+}
+
+fn relink_card_created(card_id: WorkCardId, owner: PeerId) -> WorkEvent {
+    WorkEvent::CardCreated(CardCreated {
+        card_id,
+        repo: repo(),
+        title: "relink projection".to_string(),
+        body: None,
+        priority: Priority::P2,
+        lane_id: None,
+        created_by: owner,
+        created_at_ms: 1,
+        reviews: None,
+        origin: None,
+    })
+}
+
+#[test]
+fn relink_supersedes_stale_link_and_reenters_review() {
+    // what this catches: the exact failure class of card 6967921d —
+    // a card whose round-1 PR went stale could never adopt the
+    // round-2 PR. After PullRequestRelinked the projection must hold
+    // ONLY the successor (the superseded link survives in the
+    // transcript event, not in projection state) and the card must be
+    // in Review so the merger gate sees it.
+    let card_id = WorkCardId::from_u128(1);
+    let owner = peer(2);
+    let old = relink_pr(1078, "feat/round-1");
+    let new = relink_pr(1137, "feat/round-2");
+
+    let mut projection = WorkBoardProjection::new();
+    projection
+        .apply(&relink_card_created(card_id, owner))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::PullRequestLinked(PullRequestLinked {
+            card_id,
+            pull_request: old.clone(),
+            linked_by: owner,
+            linked_at_ms: 2,
+        }))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::PullRequestRelinked(PullRequestRelinked {
+            card_id,
+            old_pull_request: old,
+            new_pull_request: new.clone(),
+            relinked_by: owner,
+            relinked_at_ms: 3,
+        }))
+        .unwrap();
+
+    let card = projection.card(card_id).unwrap();
+    assert_eq!(
+        card.pull_request,
+        Some(new),
+        "successor is the single source of truth"
+    );
+    assert_eq!(
+        card.state,
+        CardState::Review,
+        "relink must (re)enter Review for the merger"
+    );
+    assert_eq!(card.updated_at_ms, 3);
+}
+
+#[test]
+fn relink_racing_terminal_state_is_dropped_without_poisoning_projection() {
+    // what this catches: a relink event that lost a race against
+    // PullRequestMerged (or a close) flipping a finished card back
+    // into Review — the merger would then merge a successor for work
+    // that already shipped. The projection must drop the event
+    // silently (same tolerant-replay rule as ghost claim heartbeats):
+    // state, link, and updated_at_ms all stay exactly as the terminal
+    // transition left them.
+    let card_id = WorkCardId::from_u128(1);
+    let owner = peer(2);
+    let old = relink_pr(1078, "feat/round-1");
+
+    let mut projection = WorkBoardProjection::new();
+    projection
+        .apply(&relink_card_created(card_id, owner))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::PullRequestLinked(PullRequestLinked {
+            card_id,
+            pull_request: old.clone(),
+            linked_by: owner,
+            linked_at_ms: 2,
+        }))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::PullRequestMerged(PullRequestMerged {
+            card_id,
+            pull_request: old.clone(),
+            merged_by: owner,
+            merged_at_ms: 3,
+        }))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::PullRequestRelinked(PullRequestRelinked {
+            card_id,
+            old_pull_request: old.clone(),
+            new_pull_request: relink_pr(1137, "feat/round-2"),
+            relinked_by: owner,
+            relinked_at_ms: 4,
+        }))
+        .unwrap();
+
+    let card = projection.card(card_id).unwrap();
+    assert_eq!(
+        card.state,
+        CardState::Merged,
+        "merged card must stay merged"
+    );
+    assert_eq!(
+        card.pull_request,
+        Some(old),
+        "merged card keeps the PR that shipped"
+    );
+    assert_eq!(
+        card.updated_at_ms, 3,
+        "dropped relink must not even bump updated_at_ms"
+    );
+
+    // Closed cards get the same drop.
+    let closed_id = WorkCardId::from_u128(10);
+    projection
+        .apply(&relink_card_created(closed_id, owner))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::PullRequestLinked(PullRequestLinked {
+            card_id: closed_id,
+            pull_request: relink_pr(1200, "feat/closed-round-1"),
+            linked_by: owner,
+            linked_at_ms: 5,
+        }))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::CardStateChanged(CardStateChanged {
+            card_id: closed_id,
+            state: CardState::Closed,
+            changed_by: owner,
+            changed_at_ms: 6,
+        }))
+        .unwrap();
+    projection
+        .apply(&WorkEvent::PullRequestRelinked(PullRequestRelinked {
+            card_id: closed_id,
+            old_pull_request: relink_pr(1200, "feat/closed-round-1"),
+            new_pull_request: relink_pr(1201, "feat/closed-round-2"),
+            relinked_by: owner,
+            relinked_at_ms: 7,
+        }))
+        .unwrap();
+    let closed = projection.card(closed_id).unwrap();
+    assert_eq!(closed.state, CardState::Closed);
+    assert_eq!(
+        closed.pull_request,
+        Some(relink_pr(1200, "feat/closed-round-1"))
+    );
+}
+
+#[test]
+fn relink_for_unknown_card_errors_strict_and_skips_windowed() {
+    // what this catches: drift in the missing-window-anchor contract.
+    // Strict apply must surface UnknownCard (loud failure for full
+    // replays); apply_windowed must skip it (bounded windows and
+    // cache resume legally start after the card's creation event).
+    let owner = peer(2);
+    let event = WorkEvent::PullRequestRelinked(PullRequestRelinked {
+        card_id: WorkCardId::from_u128(404),
+        old_pull_request: relink_pr(1078, "feat/round-1"),
+        new_pull_request: relink_pr(1137, "feat/round-2"),
+        relinked_by: owner,
+        relinked_at_ms: 1,
+    });
+
+    let mut projection = WorkBoardProjection::new();
+    assert_eq!(
+        projection.apply(&event),
+        Err(ProjectionError::UnknownCard(WorkCardId::from_u128(404)))
+    );
+    assert_eq!(projection.apply_windowed(&event), Ok(()));
+}


### PR DESCRIPTION
## What

First-class relink verb: `airc work relink <card-id> --pr <number-or-url>` — supersede a work card's stale `pull_request` link with a successor PR via a new typed event, `WorkEvent::PullRequestRelinked { card_id, old_pull_request, new_pull_request, relinked_by, relinked_at_ms }`.

Card: `09fddedd-2b06-4801-a2c6-76f3f155922c`.

## Why — failure class fixed

`PullRequestLinked` is first-write-wins at every CLI entry point (`airc work link` and `airc work state review` both no-op on an already-linked card), so a card whose round-1 PR was closed/superseded (orphaned stacked PRs, recovered lanes) could never track the round-2 PR carrying the real fix. The merger then skipped the card forever (linked PR state MERGED/CLOSED) and Review cards orphaned — failure class: card **6967921d**; observed live as #1078 → #1137 during card 1291173d.

## Design (per doctrine)

- **Intentional protocol, not field mutation**: a distinct `pull_request_relinked` event variant that records BOTH links — `old_pull_request` for auditability (the transcript keeps the superseded link; the projection drops it), `new_pull_request` as the card's new single source of truth. The projection adopts the successor and (re)enters `Review` so the merger gate sees it.
- **Loud failures, no fallbacks** (each a typed `AircError` variant at the single emit path `Airc::relink_card_pull_request`): card must exist in the current room; must currently have a linked PR (first link belongs to `airc work link`); must not be `Merged`/`Closed`; successor must be a different PR (identity = repo+number).
- **Forge validation via `gh --json`, never stdout scraping** (`relink_card_pr`, sibling of `link_existing_pr`): successor PR must EXIST, and must target the SAME base branch as the link it supersedes (a cross-base relink is a retarget, not a supersede → refusal). Non-OPEN successor is recorded with a loud warning, same convention as `airc work link`. Explicit `--repo`, works after the worktree is cleaned up.
- **`--pr` arg parsing**: bare number or a URL with an explicit `/pull/<n>` segment; anything else refuses (no digit-scraping; issue URLs and digit-bearing branch names refuse).
- **Replay semantics**: terminal-state (Merged/Closed) cards drop a racing relink silently — same tolerant-replay rule as ghost claim heartbeats — so a lost race can't flip a shipped card back into Review or poison any consumer's board. Unknown card = `ProjectionError::UnknownCard`, tolerated by `apply_windowed` as a missing window anchor (cache resume + bounded windows).
- **Work-board-cache (card 1291173d)**: the cursor-keyed resume path folds a post-snapshot relink through the same `apply_windowed` rule as full replay; pinned by an `apply_transcripts`-vs-`project_transcripts` equivalence test.

## Wire compat + mutation-tested pins

- Literal-JSON pins: body tag `"kind":"pull_request_relinked"` (header/body consistency asserted), every field name (`card_id`, `old_pull_request`, `new_pull_request`, `relinked_by`, `relinked_at_ms`), full PR-ref objects in both link fields, and a frozen literal payload decode.
- Legacy decode pinned: a hand-written literal `pull_request_linked` payload still decodes — adding the variant breaks no existing event on the wire.
- **Mutation-tested**: temporarily applied `#[serde(rename = "pull_request_superseded")]` on the variant, then `#[serde(rename = "previous_pull_request")]` on the field — in both runs exactly the two pin tests FAILED (`pull_request_relinked_body_wire_shape_is_pinned_literal`, `pull_request_relinked_literal_wire_payload_decodes`) while the tag-blind round-trip stayed green, proving the pins are load-bearing. Mutations restored; suite green.

## Tests

- Projection: relink supersedes link + re-enters Review; relink racing Merged/Closed is dropped without state or `updated_at_ms` change; unknown card errors strict / skips windowed.
- SDK gate (pure, unit-tested per refusal): no-linked-PR, same-PR (head drift on same number still refuses), Merged and Closed terminal refusals, success returns the superseded link.
- Cache catch-up: resume-after-snapshot-boundary ≡ full replay for the new event.
- CLI: `--pr` parser accept/refuse matrix.

## Gate evidence

- `cargo clippy --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm` → clean.
- `cargo fmt --all -- --check` → clean.
- `cargo test --workspace -- --skip codex_hook` → 0 failures (codex_hook skipped per macOS hang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
