### PR TITLE
fix(daemon): hermetic CLI tests must not reach host gh token (#1145 regression)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -479,6 +479,22 @@ async fn wait_for_daemon_exit(client: &DaemonClient, max_wait: Duration) {
 /// either, we set nothing and the daemon degrades exactly as before
 /// (skips the optional rendezvous cleanly).
 fn inject_gh_token(command: &mut Command) {
+    // Hermetic-isolation opt-out. Integration tests (and any caller
+    // that deliberately runs against a throwaway `$HOME`) set
+    // `AIRC_NO_GH_TOKEN_INJECT=1` so a daemon spawned under that clean
+    // room does NOT reach out to the host's real `gh` credential for
+    // the OPTIONAL account rendezvous. Without this, on a gh-authed
+    // host the daemon is handed the real machine token but points at a
+    // mismatched throwaway home, the rendezvous fails, and the
+    // foreground command that spawned it inherits the failure. The
+    // rendezvous is best-effort; it must never be the reason a clean
+    // CLI invocation exits non-zero.
+    if std::env::var("AIRC_NO_GH_TOKEN_INJECT")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false)
+    {
+        return;
+    }
     // Only inherit an existing token if it is NON-EMPTY — an
     // exported-but-empty `GITHUB_TOKEN=""` (common in some shells/CI)
     // must NOT short-circuit extraction, or the daemon inherits a blank

--- a/crates/airc-cli/tests/codex_hook_commands.rs
+++ b/crates/airc-cli/tests/codex_hook_commands.rs
@@ -579,6 +579,12 @@ fn command_for_home(home: &Path) -> Command {
     let account_home = home.parent().unwrap_or(home);
     command.env("HOME", account_home);
     command.env("USERPROFILE", account_home);
+    // Hermetic: these tests run against a throwaway $HOME. Forbid the
+    // daemon from reaching the host's real `gh` token for the optional
+    // account rendezvous — on a gh-authed runner that token + the
+    // throwaway home are mismatched, the rendezvous fails, and the
+    // command exits non-zero. See `inject_gh_token` in commands.rs.
+    command.env("AIRC_NO_GH_TOKEN_INJECT", "1");
     command
 }
 


### PR DESCRIPTION
## Problem

`#1145`'s `inject_gh_token` resolves the host's real `gh` credential to hand the spawned daemon a `GH_TOKEN` for the optional account-registry rendezvous. The codex_hook integration tests run `airc-core` against a **throwaway `$HOME`**. On a gh-authed host (our self-hosted Windows runner) the daemon is handed the real machine token but pointed at a mismatched home → rendezvous fails → the foreground command exits non-zero → **4 codex_hook tests go red on `windows-self-hosted`**.

This is the only red on that runner; required checks (clippy + ubuntu) stay green, so merges still flow — but it's the signal card 8763f167 restored, so it shouldn't stay broken.

## Fix

- `inject_gh_token` honors a new `AIRC_NO_GH_TOKEN_INJECT` opt-out (hermetic isolation).
- The codex_hook test harness sets it, so daemons spawned under a throwaway home never reach the host credential.
- Production behavior (matching home + real token) is unchanged.

## Follow-up

The account rendezvous is best-effort and should **never** be able to fail a foreground command, even in production — a rendezvous error should be logged and swallowed, not propagated. Filing separately; this PR restores the CI signal.