### PR TITLE
fix(registry): hermetic gate — test daemons must never reach the production gh account rendezvous (card d793c242)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1048,6 +1048,17 @@ pub async fn run_daemon(
     let registry_state = state.clone();
     let registry_home = state.home.clone();
     let registry_handle = tokio::spawn(async move {
+        // HERMETIC GATE (card d793c242): test/temp daemons inherit the
+        // operator's working gh auth, so without this gate they publish
+        // test identities to the PRODUCTION account rendezvous (live
+        // evidence: temp-scoped Windows test daemon landed in joelteply
+        // gist 1214fb43d2c00d667c4712e6023b2165). Blocked scopes never
+        // spawn the loop at all — ONE loud line says why. The same gate
+        // is re-checked per tick and inside the gh store itself.
+        if let Some(block) = airc_lib::account_registry_block(&registry_home) {
+            eprintln!("airc daemon: account-registry loop DISABLED — {block}");
+            return;
+        }
         let airc = match Airc::open(&registry_home).await {
             Ok(airc) => airc,
             Err(error) => {
@@ -1125,11 +1136,13 @@ pub async fn run_daemon(
             );
         }
         let store = match &gh_bin {
-            Some(bin) => airc_lib::GhAccountRegistryStore::new(event_store).with_bin(bin.clone()),
-            None => airc_lib::GhAccountRegistryStore::new(event_store),
+            Some(bin) => airc_lib::GhAccountRegistryStore::new(event_store, &registry_home)
+                .with_bin(bin.clone()),
+            None => airc_lib::GhAccountRegistryStore::new(event_store, &registry_home),
         };
         let gate = airc_lib::RegistryRefreshGate::GhAuth {
             gh_bin: gh_bin.clone(),
+            scope_home: registry_home.clone(),
         };
         airc_lib::run_registry_refresh_loop(
             airc,

--- a/crates/airc-cli/src/registry_commands.rs
+++ b/crates/airc-cli/src/registry_commands.rs
@@ -7,8 +7,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use airc_lib::{
-    machine_account_home, Airc, GateBlock, GhAccountRegistryStore, RegistryRefreshGate,
-    SyncOutcome,
+    machine_account_home, Airc, GateBlock, GhAccountRegistryStore, RegistryRefreshGate, SyncOutcome,
 };
 use airc_store::SqliteEventStore;
 

--- a/crates/airc-cli/src/registry_commands.rs
+++ b/crates/airc-cli/src/registry_commands.rs
@@ -6,7 +6,10 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use airc_lib::{machine_account_home, Airc, GhAccountRegistryStore, RegistryRefreshGate};
+use airc_lib::{
+    machine_account_home, Airc, GateBlock, GhAccountRegistryStore, RegistryRefreshGate,
+    SyncOutcome,
+};
 use airc_store::SqliteEventStore;
 
 pub async fn run_sync(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
@@ -16,11 +19,14 @@ pub async fn run_sync(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
     // home's events.sqlite — the same DB the daemon's store uses.
     let db_path = machine_account_home(home).join("events.sqlite");
     let event_store = Arc::new(SqliteEventStore::open_path(&db_path).await?);
-    let store = GhAccountRegistryStore::new(event_store);
-    let gate = RegistryRefreshGate::GhAuth { gh_bin: None };
+    let store = GhAccountRegistryStore::new(event_store, home);
+    let gate = RegistryRefreshGate::GhAuth {
+        gh_bin: None,
+        scope_home: home.to_path_buf(),
+    };
 
     match airc_lib::registry_sync_once(&airc, &store, &gate).await? {
-        Some(report) => {
+        SyncOutcome::Ran(report) => {
             println!(
                 "registry sync ok: published {} peer(s) to the account rendezvous; \
                  enrolled {} peer(s) from the merged registry.",
@@ -33,7 +39,14 @@ pub async fn run_sync(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
                 );
             }
         }
-        None => {
+        // HERMETIC GATE (card d793c242): this scope must not touch the
+        // gh account rendezvous — say exactly why, loudly. The manual
+        // verb honors the same gate as the daemon loop; there is no
+        // CLI path around it (the gh store enforces it again inside).
+        SyncOutcome::Skipped(GateBlock::Hermetic(block)) => {
+            println!("registry sync REFUSED (hermetic gate): {block}");
+        }
+        SyncOutcome::Skipped(GateBlock::GhNotReady) => {
             println!(
                 "registry sync skipped: `gh` is not authenticated. The account-mesh \
                  rendezvous is the same-account gist transport — sign in with `gh auth \

--- a/crates/airc-cli/tests/daemon_lifecycle.rs
+++ b/crates/airc-cli/tests/daemon_lifecycle.rs
@@ -33,6 +33,10 @@ fn tab(account: &Path, scope: &str, client: &str, args: &[&str]) -> std::process
         .env("HOME", account)
         .env("USERPROFILE", account)
         .env("AIRC_CLIENT_ID", client)
+        // Hermetic gate (card d793c242): tabs spawn-or-connect the
+        // daemon, which inherits this env — the spawned daemon must
+        // never touch the operator's real gh account rendezvous.
+        .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
         .output()
         .expect("airc must spawn")
 }

--- a/crates/airc-cli/tests/daemon_route_refresh.rs
+++ b/crates/airc-cli/tests/daemon_route_refresh.rs
@@ -56,6 +56,11 @@ fn spawn_daemon(home: &std::path::Path, socket: &std::path::Path) -> DaemonGuard
             .arg("daemon")
             .arg("--socket")
             .arg(socket)
+            // Hermetic gate (card d793c242): test daemons must never
+            // touch the operator's real gh account rendezvous. The
+            // temp-rooted home blocks it too — this is the intentional
+            // layer.
+            .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
             .stdin(Stdio::null())
             .stdout(Stdio::from(log))
             .stderr(Stdio::from(stderr))

--- a/crates/airc-cli/tests/registry_hermetic.rs
+++ b/crates/airc-cli/tests/registry_hermetic.rs
@@ -243,7 +243,11 @@ fn daemon_with_disable_env_never_runs_registry_loop() {
     let socket = tmp.path().join("d.sock");
 
     let _daemon = spawn_daemon(&home, &socket, &stub, true);
-    let log = wait_for_log(&home, "account-registry loop DISABLED", Duration::from_secs(30));
+    let log = wait_for_log(
+        &home,
+        "account-registry loop DISABLED",
+        Duration::from_secs(30),
+    );
 
     assert!(
         log.contains("AIRC_DISABLE_ACCOUNT_REGISTRY"),
@@ -268,7 +272,11 @@ fn daemon_with_temp_home_never_runs_registry_loop() {
     let socket = tmp.path().join("d2.sock");
 
     let _daemon = spawn_daemon(&home, &socket, &stub, false);
-    let log = wait_for_log(&home, "account-registry loop DISABLED", Duration::from_secs(30));
+    let log = wait_for_log(
+        &home,
+        "account-registry loop DISABLED",
+        Duration::from_secs(30),
+    );
 
     assert!(
         log.contains("temp-rooted"),

--- a/crates/airc-cli/tests/registry_hermetic.rs
+++ b/crates/airc-cli/tests/registry_hermetic.rs
@@ -1,0 +1,282 @@
+//! Card d793c242 — the hermetic gate, walked through the REAL CLI
+//! surfaces a test/temp daemon actually uses.
+//!
+//! Live evidence: a hermetic Windows test daemon (scope_home
+//! `C:\Users\green\AppData\Local\Temp\tmp.YYavgmVUxz\.airc`) inherited
+//! the operator's gh auth and published itself to the production
+//! joelteply rendezvous (gist 1214fb43d2c00d667c4712e6023b2165). These
+//! tests pin that NEITHER the daemon's registry loop NOR the manual
+//! `airc registry sync` verb can reach gh from a hermetic scope — and
+//! that every suppression is LOUD.
+//!
+//! gh is replaced by a recording stub on PATH + AIRC_GH_BIN, so even a
+//! gate regression cannot touch the real rendezvous from here (a
+//! counting stub is the proof medium: zero gist calls = nothing
+//! published). Unix-only: the stub is a shell script. Hosted CI runs
+//! ubuntu + macos, so the gate is pinned on both.
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn airc_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_airc")
+}
+
+/// Recording gh stub: every invocation appends argv to `calls.log`;
+/// `auth status` reports success so any auth-gate that is reached
+/// would PROCEED — proving a quiet log means the hermetic gate fired,
+/// not that auth happened to fail.
+const STUB_SCRIPT: &str = r#"#!/bin/sh
+S="__STATE__"
+printf '%s\n' "$*" >> "$S/calls.log"
+case "$1" in
+  auth) exit 0 ;;
+  gist)
+    if [ "$2" = "create" ]; then
+      cat > /dev/null
+      echo "https://gist.github.com/stub/stubgist1"
+    elif [ "$2" = "edit" ]; then
+      cat > /dev/null
+    fi
+    ;;
+  api) : ;;
+esac
+exit 0
+"#;
+
+struct StubGh {
+    dir: PathBuf,
+    state: PathBuf,
+}
+
+impl StubGh {
+    fn install(root: &Path) -> Self {
+        let dir = root.join("gh-stub-bin");
+        let state = root.join("gh-stub-state");
+        std::fs::create_dir_all(&dir).expect("stub bin dir");
+        std::fs::create_dir_all(&state).expect("stub state dir");
+        let bin = dir.join("gh");
+        std::fs::write(
+            &bin,
+            STUB_SCRIPT.replace("__STATE__", &state.to_string_lossy()),
+        )
+        .expect("write stub gh");
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod stub gh");
+        Self { dir, state }
+    }
+
+    fn bin(&self) -> PathBuf {
+        self.dir.join("gh")
+    }
+
+    fn path_env(&self) -> String {
+        format!(
+            "{}:{}",
+            self.dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        )
+    }
+
+    fn calls(&self) -> Vec<String> {
+        std::fs::read_to_string(self.state.join("calls.log"))
+            .map(|log| log.lines().map(str::to_string).collect())
+            .unwrap_or_default()
+    }
+
+    /// The pollution-relevant slice of the log: anything that writes
+    /// or reads gists. (Identity resolution may legitimately probe
+    /// `gh api user` — that is not the account rendezvous.)
+    fn rendezvous_calls(&self) -> Vec<String> {
+        self.calls()
+            .into_iter()
+            .filter(|line| line.starts_with("gist ") || line.contains("/gists"))
+            .collect()
+    }
+}
+
+fn sync_command(home: &Path, stub: &StubGh) -> Command {
+    let mut command = Command::new(airc_bin());
+    command
+        .arg("--home")
+        .arg(home)
+        .arg("registry")
+        .arg("sync")
+        .env("PATH", stub.path_env())
+        .env("AIRC_GH_BIN", stub.bin())
+        .stdin(Stdio::null());
+    command
+}
+
+/// MUTATION PIN (a): drop the env-gate honor and this fails — with the
+/// env var set, the refusal must name AIRC_DISABLE_ACCOUNT_REGISTRY
+/// (the env check precedes the temp check by contract), and the stub
+/// must record zero rendezvous calls.
+#[test]
+fn registry_sync_honors_disable_env_and_publishes_nothing() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let stub = StubGh::install(tmp.path());
+    let home = tmp.path().join("scope/.airc");
+    std::fs::create_dir_all(&home).expect("home");
+
+    let output = sync_command(&home, &stub)
+        .env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1")
+        .output()
+        .expect("airc registry sync runs");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "hermetic skip is a clean exit, got {:?}: {stdout}",
+        output.status
+    );
+    assert!(
+        stdout.contains("REFUSED"),
+        "the skip must be loud, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("AIRC_DISABLE_ACCOUNT_REGISTRY"),
+        "the refusal must name the env gate (not the temp gate), got: {stdout}"
+    );
+    assert_eq!(
+        stub.rendezvous_calls(),
+        Vec::<String>::new(),
+        "the gh rendezvous must never be touched"
+    );
+}
+
+/// MUTATION PIN (b): drop the temp-dir refusal and this fails — a
+/// temp-rooted home with NO env var and a SUCCEEDING gh auth stub must
+/// still refuse, loudly, with zero rendezvous calls.
+#[test]
+fn registry_sync_refuses_temp_home_even_without_env() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let stub = StubGh::install(tmp.path());
+    let home = tmp.path().join("scope/.airc");
+    std::fs::create_dir_all(&home).expect("home");
+
+    let output = sync_command(&home, &stub)
+        .env_remove("AIRC_DISABLE_ACCOUNT_REGISTRY")
+        .output()
+        .expect("airc registry sync runs");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "hermetic skip is a clean exit");
+    assert!(
+        stdout.contains("REFUSED") && stdout.contains("temp-rooted"),
+        "temp-rooted home must refuse loudly, got: {stdout}"
+    );
+    assert_eq!(
+        stub.rendezvous_calls(),
+        Vec::<String>::new(),
+        "the gh rendezvous must never be touched"
+    );
+}
+
+struct DaemonGuard {
+    child: Child,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn spawn_daemon(home: &Path, socket: &Path, stub: &StubGh, disable_env: bool) -> DaemonGuard {
+    let log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(home.join("daemon-test.log"))
+        .expect("daemon log");
+    let stderr = log.try_clone().expect("clone log");
+    let mut command = Command::new(airc_bin());
+    command
+        .arg("--home")
+        .arg(home)
+        .arg("daemon")
+        .arg("--socket")
+        .arg(socket)
+        .env("PATH", stub.path_env())
+        .env("AIRC_GH_BIN", stub.bin())
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(stderr));
+    if disable_env {
+        command.env("AIRC_DISABLE_ACCOUNT_REGISTRY", "1");
+    } else {
+        command.env_remove("AIRC_DISABLE_ACCOUNT_REGISTRY");
+    }
+    DaemonGuard {
+        child: command.spawn().expect("daemon must spawn"),
+    }
+}
+
+fn wait_for_log(home: &Path, needle: &str, budget: Duration) -> String {
+    let log_path = home.join("daemon-test.log");
+    let deadline = Instant::now() + budget;
+    loop {
+        let log = std::fs::read_to_string(&log_path).unwrap_or_default();
+        if log.contains(needle) {
+            return log;
+        }
+        if Instant::now() >= deadline {
+            panic!("daemon log never contained {needle:?} within {budget:?}; log:\n{log}");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// The DAEMON path of the gate: a hermetic daemon with the env var set
+/// disables its account-registry loop at startup with ONE loud line
+/// naming the env gate, and never touches gh.
+#[test]
+fn daemon_with_disable_env_never_runs_registry_loop() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let stub = StubGh::install(tmp.path());
+    let home = tmp.path().join("scope/.airc");
+    std::fs::create_dir_all(&home).expect("home");
+    let socket = tmp.path().join("d.sock");
+
+    let _daemon = spawn_daemon(&home, &socket, &stub, true);
+    let log = wait_for_log(&home, "account-registry loop DISABLED", Duration::from_secs(30));
+
+    assert!(
+        log.contains("AIRC_DISABLE_ACCOUNT_REGISTRY"),
+        "the disable line must name the env gate, got:\n{log}"
+    );
+    assert_eq!(
+        stub.rendezvous_calls(),
+        Vec::<String>::new(),
+        "a hermetic daemon must never touch the gh rendezvous"
+    );
+}
+
+/// Defense in depth on the daemon path: even WITHOUT the env var, a
+/// temp-rooted home (exactly the live-evidence shape) disables the
+/// loop loudly.
+#[test]
+fn daemon_with_temp_home_never_runs_registry_loop() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let stub = StubGh::install(tmp.path());
+    let home = tmp.path().join("scope/.airc");
+    std::fs::create_dir_all(&home).expect("home");
+    let socket = tmp.path().join("d2.sock");
+
+    let _daemon = spawn_daemon(&home, &socket, &stub, false);
+    let log = wait_for_log(&home, "account-registry loop DISABLED", Duration::from_secs(30));
+
+    assert!(
+        log.contains("temp-rooted"),
+        "the disable line must name the temp gate, got:\n{log}"
+    );
+    assert_eq!(
+        stub.rendezvous_calls(),
+        Vec::<String>::new(),
+        "a hermetic daemon must never touch the gh rendezvous"
+    );
+}

--- a/crates/airc-diagnostics/src/lib.rs
+++ b/crates/airc-diagnostics/src/lib.rs
@@ -47,6 +47,15 @@ pub enum DiagnosticCode {
     TrustRefreshFailed,
     AccountRegistryPublishFailed,
     AccountRegistryRefreshFailed,
+    /// Card d793c242: the account-registry gh transport was
+    /// intentionally suppressed — `AIRC_DISABLE_ACCOUNT_REGISTRY` is
+    /// set, or the scope home is temp-rooted (hermetic test daemon).
+    /// LOUD by doctrine: every suppressed tick says why.
+    AccountRegistryHermeticSkip,
+    /// Card d793c242: reader-merge dropped beacons whose scope_home is
+    /// temp-rooted (phantom hermetic-test peers in polluted documents).
+    /// Carries the count, not the dump.
+    AccountRegistryTempBeaconsIgnored,
     WireLostEmitFailed,
     MalformedReplayFrameSkipped,
     UnverifiableReplayFrameSkipped,

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -63,13 +63,12 @@ pub fn scope_home_is_temp_rooted(scope_home: &Path) -> bool {
         .to_string_lossy()
         .replace('\\', "/")
         .to_ascii_lowercase();
-    let tempish = lossy == "/tmp"
+    lossy == "/tmp"
         || lossy.starts_with("/tmp/")
         || lossy.starts_with("/private/tmp/")
         || lossy.starts_with("/var/folders/")
         || lossy.starts_with("/private/var/folders/")
-        || lossy.contains("/appdata/local/temp/");
-    tempish
+        || lossy.contains("/appdata/local/temp/")
 }
 
 /// Outcome of [`merge_registry_documents`]: the merged view plus the
@@ -145,8 +144,10 @@ pub fn merge_registry_documents(
         };
     }
 
-    let mut peers: Vec<AccountPeerBeacon> =
-        freshest.into_values().map(|(_, _, beacon)| beacon).collect();
+    let mut peers: Vec<AccountPeerBeacon> = freshest
+        .into_values()
+        .map(|(_, _, beacon)| beacon)
+        .collect();
     peers.sort_by_key(|peer| peer.peer_id().to_string());
     channels.sort_by(|a, b| a.as_str().cmp(b.as_str()));
 

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -11,6 +11,7 @@
 //! media, and model payloads are explicitly out of scope.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -27,6 +28,138 @@ use crate::time;
 use crate::Airc;
 
 pub const ACCOUNT_REGISTRY_SCHEMA_VERSION: u16 = 1;
+
+/// True when `scope_home` is rooted under a temp directory — the
+/// signature of a hermetic test / CI daemon, NEVER a production scope.
+///
+/// Two layers, because this is consulted on BOTH sides of the wire:
+///
+/// 1. **Local resolution** (publish gate): canonicalized-prefix match
+///    against this machine's `std::env::temp_dir()` — the same check
+///    `machine_account_home` uses for state isolation (card b0a81c31).
+/// 2. **Cross-platform markers** (reader hygiene): a beacon read from
+///    the rendezvous carries a `scope_home` minted on a DIFFERENT
+///    machine/OS, where our local `temp_dir()` prefix is meaningless.
+///    Recognize the well-known temp roots of every platform airc runs
+///    on: live evidence for card d793c242 was a beacon with scope_home
+///    `C:\Users\green\AppData\Local\Temp\tmp.YYavgmVUxz\.airc` published
+///    to the production joelteply rendezvous.
+pub fn scope_home_is_temp_rooted(scope_home: &Path) -> bool {
+    // Layer 1: this machine's temp root (canonicalize both sides so
+    // macOS's `/tmp` -> `/private/tmp` symlink can't dodge the check).
+    let temp = std::env::temp_dir();
+    let temp = temp.canonicalize().unwrap_or(temp);
+    let resolved = scope_home
+        .canonicalize()
+        .unwrap_or_else(|_| scope_home.to_path_buf());
+    if resolved.starts_with(&temp) {
+        return true;
+    }
+
+    // Layer 2: cross-platform markers, for paths minted elsewhere.
+    // Normalize separators + case so `C:\Users\…\AppData\Local\Temp\…`
+    // and `/tmp/…` both land in one comparison space.
+    let lossy = scope_home
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase();
+    let tempish = lossy == "/tmp"
+        || lossy.starts_with("/tmp/")
+        || lossy.starts_with("/private/tmp/")
+        || lossy.starts_with("/var/folders/")
+        || lossy.starts_with("/private/var/folders/")
+        || lossy.contains("/appdata/local/temp/");
+    tempish
+}
+
+/// Outcome of [`merge_registry_documents`]: the merged view plus the
+/// hygiene counters the caller must surface (count, not full dump).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryMergeOutcome {
+    pub document: Option<AccountRegistryDocument>,
+    /// Beacons dropped because their `scope_home` is temp-rooted —
+    /// phantom hermetic-test peers from old polluted documents
+    /// (card d793c242). Never enrolled, never dialed.
+    pub ignored_temp_beacons: usize,
+}
+
+/// Reader-side merge across per-machine registry documents.
+///
+/// The rendezvous is one document per WRITER (machine); a reader must
+/// combine them. Previously the reader picked the single newest
+/// document wholesale, which (a) dropped beacons only present in older
+/// machines' documents and (b) trusted whatever a polluted document
+/// carried. This merge is intentional:
+///
+/// - documents that fail validation or belong to a different mesh
+///   identity are skipped;
+/// - beacons whose `scope_home` is temp-rooted are IGNORED and counted
+///   ([`scope_home_is_temp_rooted`]) — belt-and-braces against the
+///   already-published phantom test peers of card d793c242;
+/// - per `peer_id`, the FRESHEST beacon wins (highest
+///   `heartbeat_at_ms`, tie-broken by the carrying document's
+///   `generated_at_ms`);
+/// - channels are the sorted union; `generated_at_ms` is the max of
+///   the contributing documents.
+pub fn merge_registry_documents(
+    documents: Vec<AccountRegistryDocument>,
+    mesh_identity: &MeshIdentity,
+) -> RegistryMergeOutcome {
+    let mut ignored_temp_beacons = 0usize;
+    let mut generated_at_ms = 0u64;
+    let mut channels: Vec<ChannelName> = Vec::new();
+    // peer_id -> (heartbeat_at_ms, doc generated_at_ms, beacon)
+    let mut freshest: HashMap<airc_core::PeerId, (u64, u64, AccountPeerBeacon)> = HashMap::new();
+    let mut matched_any = false;
+
+    for document in documents {
+        if document.mesh_identity != *mesh_identity || document.validate().is_err() {
+            continue;
+        }
+        matched_any = true;
+        generated_at_ms = generated_at_ms.max(document.generated_at_ms);
+        for channel in &document.channels {
+            if !channels.contains(channel) {
+                channels.push(channel.clone());
+            }
+        }
+        for beacon in document.peers {
+            if scope_home_is_temp_rooted(&beacon.presence.scope_home) {
+                ignored_temp_beacons += 1;
+                continue;
+            }
+            let key = (beacon.presence.heartbeat_at_ms, document.generated_at_ms);
+            match freshest.get(&beacon.peer_id()) {
+                Some((heartbeat, doc_ms, _)) if (*heartbeat, *doc_ms) >= key => {}
+                _ => {
+                    freshest.insert(beacon.peer_id(), (key.0, key.1, beacon));
+                }
+            }
+        }
+    }
+
+    if !matched_any {
+        return RegistryMergeOutcome {
+            document: None,
+            ignored_temp_beacons,
+        };
+    }
+
+    let mut peers: Vec<AccountPeerBeacon> =
+        freshest.into_values().map(|(_, _, beacon)| beacon).collect();
+    peers.sort_by_key(|peer| peer.peer_id().to_string());
+    channels.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+
+    RegistryMergeOutcome {
+        document: Some(AccountRegistryDocument::new(
+            mesh_identity.clone(),
+            generated_at_ms,
+            channels,
+            peers,
+        )),
+        ignored_temp_beacons,
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccountRegistryDocument {
@@ -614,6 +747,163 @@ mod tests {
                 url: "https://relay.example.test".to_string()
             }]
         );
+    }
+
+    fn beacon_at(peer_id: PeerId, scope_home: &str, heartbeat_ms: u64) -> AccountPeerBeacon {
+        AccountPeerBeacon {
+            presence: crate::coordinator::beacon_now(
+                peer_id,
+                scope_home.into(),
+                vec![channel("general")],
+                123,
+                heartbeat_ms,
+            ),
+            peer_spec: peer_spec(peer_id),
+            endpoints: Vec::new(),
+        }
+    }
+
+    // Card d793c242: temp-rooted scope homes are the signature of
+    // hermetic test daemons — recognized for THIS machine (via
+    // std::env::temp_dir) and cross-platform (a beacon's scope_home is
+    // minted on another OS). The Windows path below is the literal
+    // live-evidence scope_home that polluted the joelteply rendezvous.
+    #[test]
+    fn temp_scope_home_detection_is_cross_platform() {
+        assert!(scope_home_is_temp_rooted(Path::new(
+            r"C:\Users\green\AppData\Local\Temp\tmp.YYavgmVUxz\.airc"
+        )));
+        assert!(scope_home_is_temp_rooted(Path::new("/tmp/airc-test/.airc")));
+        assert!(scope_home_is_temp_rooted(Path::new(
+            "/private/tmp/scope/.airc"
+        )));
+        assert!(scope_home_is_temp_rooted(Path::new(
+            "/var/folders/ab/c123/T/tmp.xyz/.airc"
+        )));
+        // This machine's real temp root, however it is spelled.
+        let dir = tempdir().unwrap();
+        assert!(scope_home_is_temp_rooted(dir.path()));
+
+        // Production shapes must NOT match — the gate may never block
+        // a real daemon.
+        assert!(!scope_home_is_temp_rooted(Path::new("/Users/joel/.airc")));
+        assert!(!scope_home_is_temp_rooted(Path::new(
+            "/Users/joel/Development/airc/.airc"
+        )));
+        assert!(!scope_home_is_temp_rooted(Path::new(
+            r"C:\Users\green\.airc"
+        )));
+        assert!(!scope_home_is_temp_rooted(Path::new("/home/ci/.airc")));
+    }
+
+    // Card d793c242 item 3 (reader hygiene): merge drops temp-scoped
+    // phantom beacons and COUNTS them. Mutation check: removing the
+    // temp filter from merge_registry_documents leaves the phantom in
+    // `peers` and zeroes the count — both asserts fail.
+    #[test]
+    fn merge_ignores_temp_scoped_beacons_and_counts_them() {
+        let prod = PeerId::new();
+        let phantom_windows = PeerId::new();
+        let phantom_unix = PeerId::new();
+        let document = AccountRegistryDocument::new(
+            mesh(),
+            2_000,
+            vec![channel("general")],
+            vec![
+                beacon_at(prod, "/machine/a/.airc", 1_000),
+                beacon_at(
+                    phantom_windows,
+                    r"C:\Users\green\AppData\Local\Temp\tmp.YYavgmVUxz\.airc",
+                    1_500,
+                ),
+                beacon_at(phantom_unix, "/tmp/airc-hermetic/.airc", 1_500),
+            ],
+        );
+
+        let outcome = merge_registry_documents(vec![document], &mesh());
+
+        assert_eq!(outcome.ignored_temp_beacons, 2);
+        let merged = outcome.document.expect("document must merge");
+        assert_eq!(merged.peers.len(), 1);
+        assert_eq!(merged.peers[0].peer_id(), prod);
+    }
+
+    // Card d793c242 item 3: per peer_id the FRESHEST beacon wins
+    // across per-machine documents, and peers present in only one
+    // document survive the merge (the old pick-newest-document reader
+    // dropped them).
+    #[test]
+    fn merge_prefers_freshest_beacon_per_peer_and_unions_documents() {
+        let shared = PeerId::new();
+        let only_in_old = PeerId::new();
+        let shared_spec = peer_spec(shared);
+
+        let stale = AccountPeerBeacon {
+            presence: crate::coordinator::beacon_now(
+                shared,
+                "/machine/a/.airc".into(),
+                vec![channel("general")],
+                123,
+                1_000,
+            ),
+            peer_spec: shared_spec.clone(),
+            endpoints: vec![RouteEndpoint::Relay {
+                url: "https://stale.example.test".to_string(),
+            }],
+        };
+        let fresh = AccountPeerBeacon {
+            presence: crate::coordinator::beacon_now(
+                shared,
+                "/machine/a/.airc".into(),
+                vec![channel("general")],
+                123,
+                5_000,
+            ),
+            peer_spec: shared_spec,
+            endpoints: vec![RouteEndpoint::Relay {
+                url: "https://fresh.example.test".to_string(),
+            }],
+        };
+        let old_doc = AccountRegistryDocument::new(
+            mesh(),
+            2_000,
+            vec![channel("general")],
+            vec![stale, beacon_at(only_in_old, "/machine/b/.airc", 900)],
+        );
+        let new_doc = AccountRegistryDocument::new(mesh(), 6_000, vec![], vec![fresh]);
+
+        let outcome = merge_registry_documents(vec![old_doc, new_doc], &mesh());
+
+        let merged = outcome.document.expect("document must merge");
+        assert_eq!(outcome.ignored_temp_beacons, 0);
+        assert_eq!(merged.generated_at_ms, 6_000);
+        assert_eq!(merged.peers.len(), 2, "union across documents");
+        let shared_beacon = merged
+            .peers
+            .iter()
+            .find(|peer| peer.peer_id() == shared)
+            .expect("shared peer present");
+        assert_eq!(
+            shared_beacon.endpoints,
+            vec![RouteEndpoint::Relay {
+                url: "https://fresh.example.test".to_string()
+            }],
+            "freshest beacon per peer_id must win"
+        );
+        assert!(merged.peers.iter().any(|p| p.peer_id() == only_in_old));
+    }
+
+    #[test]
+    fn merge_skips_foreign_mesh_documents() {
+        let peer = PeerId::new();
+        let foreign = AccountRegistryDocument::new(
+            MeshIdentity::new("someone-else"),
+            2_000,
+            vec![],
+            vec![beacon_at(peer, "/machine/a/.airc", 1_000)],
+        );
+        let outcome = merge_registry_documents(vec![foreign], &mesh());
+        assert!(outcome.document.is_none());
     }
 
     // Two SEPARATE machine accounts, same gh identity, bridged ONLY

--- a/crates/airc-lib/src/diagnostic_event_sink.rs
+++ b/crates/airc-lib/src/diagnostic_event_sink.rs
@@ -185,6 +185,10 @@ fn code_header_value(code: DiagnosticCode) -> &'static str {
         DiagnosticCode::TrustRefreshFailed => "trust_refresh_failed",
         DiagnosticCode::AccountRegistryPublishFailed => "account_registry_publish_failed",
         DiagnosticCode::AccountRegistryRefreshFailed => "account_registry_refresh_failed",
+        DiagnosticCode::AccountRegistryHermeticSkip => "account_registry_hermetic_skip",
+        DiagnosticCode::AccountRegistryTempBeaconsIgnored => {
+            "account_registry_temp_beacons_ignored"
+        }
         DiagnosticCode::WireLostEmitFailed => "wire_lost_emit_failed",
         DiagnosticCode::MalformedReplayFrameSkipped => "malformed_replay_frame_skipped",
         DiagnosticCode::UnverifiableReplayFrameSkipped => "unverifiable_replay_frame_skipped",

--- a/crates/airc-lib/src/gh_account_registry.rs
+++ b/crates/airc-lib/src/gh_account_registry.rs
@@ -449,7 +449,10 @@ impl GhAccountRegistryStore {
         // `gh gist edit <id> --filename <name> -` reads new content
         // from stdin.
         let (ok, _stdout, stderr) = self
-            .gh_run(&["gist", "edit", id, "--filename", filename, "-"], Some(body))
+            .gh_run(
+                &["gist", "edit", id, "--filename", filename, "-"],
+                Some(body),
+            )
             .await?;
         if !ok {
             return Err(AccountRegistryError::Adapter(format!(
@@ -704,7 +707,10 @@ mod tests {
 
     #[test]
     fn sanitize_writer_component_is_stable_and_safe() {
-        assert_eq!(sanitize_writer_component("Joels-MacBook-Pro.local"), "joels-macbook-pro-local");
+        assert_eq!(
+            sanitize_writer_component("Joels-MacBook-Pro.local"),
+            "joels-macbook-pro-local"
+        );
         assert_eq!(sanitize_writer_component("BIGMAMA"), "bigmama");
         assert_eq!(sanitize_writer_component("  weird host!! "), "weird-host");
         assert_eq!(sanitize_writer_component(""), "unknown");
@@ -836,8 +842,11 @@ exit 0
                 let state = dir.join("gh-state");
                 std::fs::create_dir_all(&state).unwrap();
                 let bin = dir.join("gh");
-                std::fs::write(&bin, STUB_SCRIPT.replace("__STATE__", &state.to_string_lossy()))
-                    .unwrap();
+                std::fs::write(
+                    &bin,
+                    STUB_SCRIPT.replace("__STATE__", &state.to_string_lossy()),
+                )
+                .unwrap();
                 std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
                 Self { bin, state }
             }
@@ -916,7 +925,10 @@ exit 0
             }
         }
 
-        fn document(generated_at_ms: u64, peers: Vec<AccountPeerBeacon>) -> AccountRegistryDocument {
+        fn document(
+            generated_at_ms: u64,
+            peers: Vec<AccountPeerBeacon>,
+        ) -> AccountRegistryDocument {
             AccountRegistryDocument::new(mesh(), generated_at_ms, Vec::new(), peers)
         }
 
@@ -935,7 +947,11 @@ exit 0
             let tick_two = document(2_000, Vec::new());
             store.publish(&tick_two).await.unwrap();
 
-            assert_eq!(stub.create_count(), 1, "same writer -> same gist, no duplicates");
+            assert_eq!(
+                stub.create_count(),
+                1,
+                "same writer -> same gist, no duplicates"
+            );
             assert!(
                 stub.calls()
                     .iter()
@@ -1003,20 +1019,22 @@ exit 0
             let dir = tempfile::tempdir().unwrap();
             let stub = StubGh::install(dir.path());
             let scope_home = dir.path().join("scope/.airc");
-            let store = store_at(
-                &stub,
-                &dir.path().join("db"),
-                &scope_home.to_string_lossy(),
-            )
-            .await;
+            let store =
+                store_at(&stub, &dir.path().join("db"), &scope_home.to_string_lossy()).await;
 
             let publish_error = store
                 .publish(&document(1_000, Vec::new()))
                 .await
                 .expect_err("temp-rooted scope must refuse to publish");
             let message = publish_error.to_string();
-            assert!(message.contains("HERMETIC GATE"), "loud refusal, got: {message}");
-            assert!(message.contains("temp-rooted"), "reason named, got: {message}");
+            assert!(
+                message.contains("HERMETIC GATE"),
+                "loud refusal, got: {message}"
+            );
+            assert!(
+                message.contains("temp-rooted"),
+                "reason named, got: {message}"
+            );
 
             let refresh_error = store
                 .refresh(&mesh())
@@ -1042,8 +1060,18 @@ exit 0
             let store = store_at(&stub, &dir.path().join("db"), "/machine/prod/.airc").await;
 
             let shared = PeerId::new();
-            let stale = beacon_for(shared, "/machine/a/.airc", 1_000, "https://stale.example.test");
-            let fresh = beacon_for(shared, "/machine/a/.airc", 5_000, "https://fresh.example.test");
+            let stale = beacon_for(
+                shared,
+                "/machine/a/.airc",
+                1_000,
+                "https://stale.example.test",
+            );
+            let fresh = beacon_for(
+                shared,
+                "/machine/a/.airc",
+                5_000,
+                "https://fresh.example.test",
+            );
             let phantom = beacon(
                 r"C:\Users\green\AppData\Local\Temp\tmp.YYavgmVUxz\.airc",
                 9_000,
@@ -1058,7 +1086,11 @@ exit 0
                 "airc-account-mesh-registry.json",
                 &document(2_000, vec![stale, phantom]),
             );
-            stub.seed_gist("g2", &writer_filename(), &document(6_000, vec![fresh.clone()]));
+            stub.seed_gist(
+                "g2",
+                &writer_filename(),
+                &document(6_000, vec![fresh.clone()]),
+            );
 
             let merged = store
                 .refresh(&mesh())
@@ -1066,9 +1098,16 @@ exit 0
                 .unwrap()
                 .expect("documents must merge");
 
-            assert_eq!(merged.peers.len(), 1, "phantom dropped, shared peer deduped");
+            assert_eq!(
+                merged.peers.len(),
+                1,
+                "phantom dropped, shared peer deduped"
+            );
             assert_eq!(merged.peers[0].peer_id(), shared);
-            assert_eq!(merged.peers[0].endpoints, fresh.endpoints, "freshest beacon wins");
+            assert_eq!(
+                merged.peers[0].endpoints, fresh.endpoints,
+                "freshest beacon wins"
+            );
         }
     }
 }

--- a/crates/airc-lib/src/gh_account_registry.rs
+++ b/crates/airc-lib/src/gh_account_registry.rs
@@ -11,18 +11,36 @@
 //!
 //! ## Contract
 //!
-//! - **Filename:** `airc-account-mesh-registry.json` (single file per
-//!   gist; gist private)
+//! - **Filename:** `airc-account-mesh-registry.<writer-key>.json`
+//!   (single file per gist; gist private). The writer key derives
+//!   from MACHINE identity ([`writer_key`]) so a writer can re-find
+//!   its own gist even after its local state rotates. Legacy gists
+//!   named `airc-account-mesh-registry.json` stay readable — readers
+//!   are filename-agnostic (they take the gist's first file) and
+//!   sentinel-tracked edits reuse the gist's existing filename.
 //! - **Description marker:** `airc-account-mesh-registry` (used for
 //!   discovery filtering on `gh gist list`)
-//! - **One gist per machine.** The per-mesh-identity gist-id
-//!   sentinel row in `account_registry_gist_sentinel` records this
-//!   machine's gist id so subsequent publishes update the same gist
-//!   instead of creating duplicates. If the sentinel is missing on
-//!   first publish, a new gist is created and the id is persisted.
+//! - **One gist per machine, find-or-update.** The per-mesh-identity
+//!   gist-id sentinel row in `account_registry_gist_sentinel` records
+//!   this machine's gist id so subsequent publishes update the same
+//!   gist instead of creating duplicates. If the sentinel is missing,
+//!   the publisher RE-FINDS its own gist by writer filename before
+//!   ever creating one (card d793c242: create-on-miss proliferated
+//!   duplicate registry gists every time local identity rotated).
 //! - **Refresh merges all matching gists.** A scope joining on a
 //!   third+ machine sees both other machines' beacons without any
-//!   server-side coordination.
+//!   server-side coordination. The merge keeps the freshest beacon
+//!   per peer and drops temp-scoped phantom test peers.
+//!
+//! ## Hermetic gate (card d793c242)
+//!
+//! Hermetic test daemons inherit the operator's working gh auth, so
+//! without a gate they publish test identities to the PRODUCTION
+//! account rendezvous. [`account_registry_block`] blocks the gh
+//! transport when `AIRC_DISABLE_ACCOUNT_REGISTRY` is set (intentional
+//! harness gate) or the scope home is temp-rooted (defense in depth).
+//! Enforced at daemon startup, per refresh-loop tick, AND inside this
+//! store — loudly, never silently.
 //!
 //! ## Why not a single shared gist
 //!
@@ -40,7 +58,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -49,26 +67,175 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 use tokio::time::{timeout, Duration};
 
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
+};
 use airc_store::{SqliteEventStore, StoredAccountRegistryGistSentinel};
 
 use crate::account_registry::{
-    AccountRegistryDocument, AccountRegistryError, AccountRegistryStore,
+    merge_registry_documents, scope_home_is_temp_rooted, AccountRegistryDocument,
+    AccountRegistryError, AccountRegistryStore,
 };
 use crate::subscriptions::MeshIdentity;
 use crate::time;
 
-/// Filename used for the registry blob inside each per-machine gist.
-const REGISTRY_FILENAME: &str = "airc-account-mesh-registry.json";
 /// Description marker used by `gh gist list` for discovery. Stable
 /// across versions — bumping this constant would orphan existing
 /// registries.
 const REGISTRY_DESCRIPTION: &str = "airc-account-mesh-registry";
+
+/// Hermetic gate env var (card d793c242). When set (non-empty, not
+/// `"0"`), this process must NEVER touch the gh account rendezvous —
+/// neither publish nor refresh. Test-daemon spawn helpers set it
+/// unconditionally; operators can set it to opt a box out.
+pub const AIRC_DISABLE_ACCOUNT_REGISTRY_ENV: &str = "AIRC_DISABLE_ACCOUNT_REGISTRY";
+
+/// Why the gh account-registry transport is blocked for this scope.
+///
+/// Live evidence for this gate (card d793c242, 2026-06-12 ~01:11Z): a
+/// hermetic Windows test daemon with scope_home
+/// `C:\Users\green\AppData\Local\Temp\tmp.YYavgmVUxz\.airc` inherited
+/// the operator's gh auth and published itself to the REAL joelteply
+/// rendezvous (gist 1214fb43d2c00d667c4712e6023b2165) — reader-merge
+/// then enrolled the phantom test peer and auto-dialed its garbage
+/// endpoints.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AccountRegistryBlock {
+    /// `AIRC_DISABLE_ACCOUNT_REGISTRY` is set — the intentional gate
+    /// the test harness arms.
+    DisabledByEnv,
+    /// The scope home resolves under a temp directory — defense in
+    /// depth for hermetic daemons whose harness forgot the env var.
+    TempScopeHome { scope_home: PathBuf },
+}
+
+impl std::fmt::Display for AccountRegistryBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DisabledByEnv => write!(
+                f,
+                "{AIRC_DISABLE_ACCOUNT_REGISTRY_ENV} is set — this scope must not touch the \
+                 gh account rendezvous (hermetic gate, card d793c242)"
+            ),
+            Self::TempScopeHome { scope_home } => write!(
+                f,
+                "scope home {} is temp-rooted — hermetic test/CI daemons must NEVER publish \
+                 to the production account rendezvous (card d793c242)",
+                scope_home.display()
+            ),
+        }
+    }
+}
+
+/// The hermetic gate: returns why the gh account-registry transport is
+/// blocked for `scope_home`, or `None` for production scopes. Checked
+/// at daemon startup (loop not spawned), per refresh-loop tick, and —
+/// belt and braces — inside [`GhAccountRegistryStore`] itself so no
+/// caller can route around it. The env check deliberately precedes the
+/// temp check so a blocked publish names the INTENTIONAL gate when
+/// both apply.
+pub fn account_registry_block(scope_home: &Path) -> Option<AccountRegistryBlock> {
+    if disable_env_set() {
+        return Some(AccountRegistryBlock::DisabledByEnv);
+    }
+    if scope_home_is_temp_rooted(scope_home) {
+        return Some(AccountRegistryBlock::TempScopeHome {
+            scope_home: scope_home.to_path_buf(),
+        });
+    }
+    None
+}
+
+fn disable_env_set() -> bool {
+    match std::env::var_os(AIRC_DISABLE_ACCOUNT_REGISTRY_ENV) {
+        Some(value) => {
+            let value = value.to_string_lossy();
+            let trimmed = value.trim();
+            !trimmed.is_empty() && trimmed != "0"
+        }
+        None => false,
+    }
+}
+
+/// Stable per-writer key: `<host>-<user>`, sanitized. Derives from
+/// MACHINE identity (hostname + user), NOT from the rotating
+/// peer/mesh identity — so the same box always maps to the same
+/// registry gist even when its local sentinel or events.sqlite is
+/// wiped. Create-on-miss keyed off rotating identity is exactly what
+/// proliferated 5+ duplicate registry gists under joelteply.
+pub fn writer_key() -> &'static str {
+    static KEY: OnceLock<String> = OnceLock::new();
+    KEY.get_or_init(|| {
+        let host = first_nonempty_env(&["HOSTNAME", "COMPUTERNAME"])
+            .or_else(hostname_from_command)
+            .unwrap_or_else(|| "unknown-host".to_string());
+        let user = first_nonempty_env(&["USER", "LOGNAME", "USERNAME"])
+            .unwrap_or_else(|| "unknown-user".to_string());
+        format!(
+            "{}-{}",
+            sanitize_writer_component(&host),
+            sanitize_writer_component(&user)
+        )
+    })
+}
+
+/// Per-writer registry filename: the stable marker this writer uses to
+/// re-find its own gist among the account's registry gists.
+pub fn writer_filename() -> String {
+    format!("airc-account-mesh-registry.{}.json", writer_key())
+}
+
+fn first_nonempty_env(names: &[&str]) -> Option<String> {
+    names
+        .iter()
+        .filter_map(|name| std::env::var(name).ok())
+        .map(|value| value.trim().to_string())
+        .find(|value| !value.is_empty())
+}
+
+fn hostname_from_command() -> Option<String> {
+    let output = std::process::Command::new("hostname").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let host = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if host.is_empty() {
+        None
+    } else {
+        Some(host)
+    }
+}
+
+fn sanitize_writer_component(raw: &str) -> String {
+    let mut out = String::new();
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else if !out.is_empty() && !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    let mut component: String = trimmed.chars().take(24).collect();
+    while component.ends_with('-') {
+        component.pop();
+    }
+    if component.is_empty() {
+        "unknown".to_string()
+    } else {
+        component
+    }
+}
 
 /// gh-gist-backed account-registry store.
 #[derive(Clone)]
 pub struct GhAccountRegistryStore {
     gh_bin: PathBuf,
     store: Arc<SqliteEventStore>,
+    /// The publishing scope's AIRC_HOME — the hermetic gate's input.
+    /// Required at construction so no gh-backed store can exist
+    /// without a gate (no silent ungated path).
+    scope_home: PathBuf,
 }
 
 impl GhAccountRegistryStore {
@@ -77,8 +244,10 @@ impl GhAccountRegistryStore {
     /// lets subsequent publishes update the same gist rather than
     /// creating duplicates. Typically the same SqliteEventStore the
     /// machine-account home (`~/.airc/events.sqlite`) uses, but any
-    /// store with the account_registry tables works.
-    pub fn new(store: Arc<SqliteEventStore>) -> Self {
+    /// store with the account_registry tables works. `scope_home` is
+    /// the publishing scope's AIRC_HOME, fed to the hermetic gate
+    /// ([`account_registry_block`]) on every publish/refresh.
+    pub fn new(store: Arc<SqliteEventStore>, scope_home: impl Into<PathBuf>) -> Self {
         Self {
             gh_bin: PathBuf::from(
                 std::env::var_os("AIRC_GH_BIN")
@@ -86,6 +255,7 @@ impl GhAccountRegistryStore {
                     .unwrap_or_else(|| "gh".into()),
             ),
             store,
+            scope_home: scope_home.into(),
         }
     }
 
@@ -176,90 +346,17 @@ impl GhAccountRegistryStore {
             String::from_utf8_lossy(&output.stderr).to_string(),
         ))
     }
-}
 
-#[async_trait]
-impl AccountRegistryStore for GhAccountRegistryStore {
-    async fn publish(
-        &self,
-        document: &AccountRegistryDocument,
-    ) -> Result<(), AccountRegistryError> {
-        document.validate()?;
-        let body = serde_json::to_string_pretty(document).map_err(|error| {
-            AccountRegistryError::Adapter(format!("serialize registry: {error}"))
-        })?;
-
-        match self.load_gist_id(&document.mesh_identity).await? {
-            Some(id) => {
-                // Update existing gist. `gh gist edit <id> --filename
-                // <name> -` reads new content from stdin.
-                let (ok, _stdout, stderr) = self
-                    .gh_run(
-                        &["gist", "edit", &id, "--filename", REGISTRY_FILENAME, "-"],
-                        Some(&body),
-                    )
-                    .await?;
-                if !ok {
-                    // Probably the recorded gist was deleted out-of-
-                    // band. Drop the sentinel and retry as create.
-                    let _ = self.clear_gist_id(&document.mesh_identity).await;
-                    return Err(AccountRegistryError::Adapter(format!(
-                        "gh gist edit {id} failed; sentinel cleared so next publish will recreate. stderr: {stderr}"
-                    )));
-                }
-                Ok(())
-            }
-            None => {
-                // Create a new private gist. `gh gist create -` reads
-                // content from stdin; the new gist's URL is on stdout.
-                let (ok, stdout, stderr) = self
-                    .gh_run(
-                        &[
-                            "gist",
-                            "create",
-                            "--filename",
-                            REGISTRY_FILENAME,
-                            "--desc",
-                            REGISTRY_DESCRIPTION,
-                            "-",
-                        ],
-                        Some(&body),
-                    )
-                    .await?;
-                if !ok {
-                    return Err(AccountRegistryError::Adapter(format!(
-                        "gh gist create failed: {stderr}"
-                    )));
-                }
-                let id = extract_gist_id(stdout.trim()).ok_or_else(|| {
-                    AccountRegistryError::Adapter(format!(
-                        "could not parse gist id from gh output: {stdout}"
-                    ))
-                })?;
-                self.save_gist_id(&document.mesh_identity, &id).await?;
-                Ok(())
-            }
-        }
-    }
-
-    async fn refresh(
-        &self,
-        mesh_identity: &MeshIdentity,
-    ) -> Result<Option<AccountRegistryDocument>, AccountRegistryError> {
-        // List the authenticated user's gists with our marker
-        // description. Returns at most one gist per machine on the
-        // account — refresh merges them all by picking the newest
-        // matching the requested mesh_identity. Operator-supplied
-        // identity mismatches (e.g., a stale gist from a previous
-        // account) are ignored, not surfaced as errors.
-        // Discovery scans only the user's MOST RECENT 100 gists. The
-        // account-mesh-registry beacon is updated on every `airc
-        // join`, so it stays at the top of the user's gist list
-        // sorted by recency — there's no reason to iterate the
-        // entire account's gist history (which can take minutes for
-        // high-gist-count operators). Dropped `--paginate`
-        // deliberately. If an operator legitimately needs deeper
-        // discovery, that's a separate explicit verb later.
+    /// List the authenticated account's registry gists (one per
+    /// writer/machine). Shared by refresh (merge them all) and by the
+    /// publish find-or-update path (re-find OUR gist by writer
+    /// filename when the local sentinel is gone).
+    ///
+    /// Discovery scans only the user's MOST RECENT 100 gists. The
+    /// account-mesh-registry beacons are updated on a cadence, so they
+    /// stay at the top of the recency-sorted list — no `--paginate`
+    /// (which can take minutes for high-gist-count operators).
+    async fn list_registry_gists(&self) -> Result<Vec<GistListEntry>, AccountRegistryError> {
         let (ok, stdout, stderr) = self
             .gh_run(
                 &[
@@ -267,8 +364,8 @@ impl AccountRegistryStore for GhAccountRegistryStore {
                     "/gists?per_page=100",
                     "--jq",
                     // Filter to gists whose description matches and which
-                    // contain our registry filename. Returns one line of
-                    // JSON per match: {"id":"...","filename":"..."}.
+                    // contain a registry file. Returns one line of JSON
+                    // per match: {"id":"...","filename":"..."}.
                     "[.[] | select(.description == \"airc-account-mesh-registry\") | {id, filename: (.files | keys | .[0])}] | .[]",
                 ],
                 None,
@@ -279,44 +376,243 @@ impl AccountRegistryStore for GhAccountRegistryStore {
                 "gh api /gists failed: {stderr}"
             )));
         }
+        Ok(stdout
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .filter_map(|line| serde_json::from_str(line).ok())
+            .collect())
+    }
 
-        let mut best: Option<AccountRegistryDocument> = None;
-        for line in stdout.lines().filter(|l| !l.trim().is_empty()) {
-            let entry: GistListEntry = match serde_json::from_str(line) {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-            // Pull the gist content and parse as a registry document.
-            let (ok, content, _stderr) = self
-                .gh_run(
-                    &[
-                        "api",
-                        &format!("/gists/{}", entry.id),
-                        "--jq",
-                        &format!(".files[\"{}\"].content", entry.filename),
-                    ],
-                    None,
-                )
-                .await?;
-            if !ok {
-                continue;
+    /// Fetch one registry gist's document. Individual fetch/parse
+    /// failures return `None` (foreign or corrupt gists are skipped,
+    /// not fatal — the reader merges what it can read).
+    async fn fetch_gist_document(
+        &self,
+        entry: &GistListEntry,
+    ) -> Result<Option<AccountRegistryDocument>, AccountRegistryError> {
+        let (ok, content, _stderr) = self
+            .gh_run(
+                &[
+                    "api",
+                    &format!("/gists/{}", entry.id),
+                    "--jq",
+                    &format!(".files[\"{}\"].content", entry.filename),
+                ],
+                None,
+            )
+            .await?;
+        if !ok {
+            return Ok(None);
+        }
+        Ok(serde_json::from_str(content.trim()).ok())
+    }
+
+    /// Probe the sentinel-recorded gist: `Found(filename)` when it
+    /// still exists (filename = the file to edit in place — legacy
+    /// gists keep their legacy filename), `Gone` when GitHub says 404
+    /// (deleted out-of-band). Any OTHER failure is an error: clearing
+    /// the sentinel on a transient network blip would recreate a
+    /// duplicate gist, which is the proliferation this card kills.
+    async fn probe_gist(&self, id: &str) -> Result<GistProbe, AccountRegistryError> {
+        let (ok, stdout, stderr) = self
+            .gh_run(
+                &[
+                    "api",
+                    &format!("/gists/{id}"),
+                    "--jq",
+                    ".files | keys | .[0]",
+                ],
+                None,
+            )
+            .await?;
+        if !ok {
+            if stderr.contains("404") || stderr.contains("Not Found") {
+                return Ok(GistProbe::Gone);
             }
-            let doc: AccountRegistryDocument = match serde_json::from_str(content.trim()) {
-                Ok(d) => d,
-                Err(_) => continue,
-            };
-            if doc.mesh_identity != *mesh_identity {
-                continue;
-            }
-            if doc.validate().is_err() {
-                continue;
-            }
-            match &best {
-                Some(prev) if prev.generated_at_ms >= doc.generated_at_ms => {}
-                _ => best = Some(doc),
+            return Err(AccountRegistryError::Adapter(format!(
+                "gh api /gists/{id} probe failed (sentinel kept): {stderr}"
+            )));
+        }
+        let filename = stdout.trim();
+        if filename.is_empty() || filename == "null" {
+            return Ok(GistProbe::Gone);
+        }
+        Ok(GistProbe::Found(filename.to_string()))
+    }
+
+    async fn edit_gist(
+        &self,
+        id: &str,
+        filename: &str,
+        body: &str,
+    ) -> Result<(), AccountRegistryError> {
+        // `gh gist edit <id> --filename <name> -` reads new content
+        // from stdin.
+        let (ok, _stdout, stderr) = self
+            .gh_run(&["gist", "edit", id, "--filename", filename, "-"], Some(body))
+            .await?;
+        if !ok {
+            return Err(AccountRegistryError::Adapter(format!(
+                "gh gist edit {id} failed: {stderr}"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn create_gist(&self, body: &str) -> Result<String, AccountRegistryError> {
+        // Create a new private gist with this writer's stable
+        // filename. `gh gist create -` reads content from stdin; the
+        // new gist's URL is on stdout.
+        let filename = writer_filename();
+        let (ok, stdout, stderr) = self
+            .gh_run(
+                &[
+                    "gist",
+                    "create",
+                    "--filename",
+                    &filename,
+                    "--desc",
+                    REGISTRY_DESCRIPTION,
+                    "-",
+                ],
+                Some(body),
+            )
+            .await?;
+        if !ok {
+            return Err(AccountRegistryError::Adapter(format!(
+                "gh gist create failed: {stderr}"
+            )));
+        }
+        extract_gist_id(stdout.trim()).ok_or_else(|| {
+            AccountRegistryError::Adapter(format!(
+                "could not parse gist id from gh output: {stdout}"
+            ))
+        })
+    }
+}
+
+/// Outcome of probing the sentinel-recorded gist.
+enum GistProbe {
+    /// Gist exists; payload is the filename to edit in place.
+    Found(String),
+    /// GitHub reports the gist gone (404) — recreate is safe.
+    Gone,
+}
+
+#[async_trait]
+impl AccountRegistryStore for GhAccountRegistryStore {
+    async fn publish(
+        &self,
+        document: &AccountRegistryDocument,
+    ) -> Result<(), AccountRegistryError> {
+        // HERMETIC GATE (card d793c242), innermost layer: even if a
+        // caller skips the daemon-startup and per-tick gates, the gh
+        // transport itself refuses. A refusal is an ERROR, not a
+        // silent no-op — the caller's diagnostics say exactly why
+        // nothing was published.
+        if let Some(block) = account_registry_block(&self.scope_home) {
+            return Err(AccountRegistryError::Adapter(format!(
+                "HERMETIC GATE: refusing account-registry publish — {block}"
+            )));
+        }
+        document.validate()?;
+        let body = serde_json::to_string_pretty(document).map_err(|error| {
+            AccountRegistryError::Adapter(format!("serialize registry: {error}"))
+        })?;
+
+        // Find-or-update (card d793c242 item 2): same writer -> same
+        // gist, update in place. Resolution order:
+        //   1. local sentinel (fast path) — probe it still exists and
+        //      edit using its CURRENT filename (legacy gists keep
+        //      their legacy filename; no second file is ever added);
+        //   2. sentinel missing/stale -> re-find OUR gist on the
+        //      account by this writer's stable filename marker;
+        //   3. genuinely absent -> create ONE gist with the writer
+        //      filename and persist the sentinel.
+        if let Some(id) = self.load_gist_id(&document.mesh_identity).await? {
+            match self.probe_gist(&id).await? {
+                GistProbe::Found(filename) => {
+                    return match self.edit_gist(&id, &filename, &body).await {
+                        Ok(()) => Ok(()),
+                        Err(error) => {
+                            // Edit failed on a gist that just probed as
+                            // present — clear the sentinel so the next
+                            // publish runs find-or-create, and surface
+                            // the failure loudly.
+                            let _ = self.clear_gist_id(&document.mesh_identity).await;
+                            Err(AccountRegistryError::Adapter(format!(
+                                "{error}; sentinel cleared so next publish will re-find or recreate"
+                            )))
+                        }
+                    };
+                }
+                GistProbe::Gone => {
+                    // Deleted out-of-band; fall through to find-or-create.
+                    self.clear_gist_id(&document.mesh_identity).await?;
+                }
             }
         }
-        Ok(best)
+
+        let own_filename = writer_filename();
+        if let Some(entry) = self
+            .list_registry_gists()
+            .await?
+            .into_iter()
+            .find(|entry| entry.filename == own_filename)
+        {
+            // This writer already has a gist on the account (sentinel
+            // was lost — e.g. wiped events.sqlite). Adopt it instead
+            // of creating a duplicate.
+            self.edit_gist(&entry.id, &entry.filename, &body).await?;
+            self.save_gist_id(&document.mesh_identity, &entry.id)
+                .await?;
+            return Ok(());
+        }
+
+        let id = self.create_gist(&body).await?;
+        self.save_gist_id(&document.mesh_identity, &id).await?;
+        Ok(())
+    }
+
+    async fn refresh(
+        &self,
+        mesh_identity: &MeshIdentity,
+    ) -> Result<Option<AccountRegistryDocument>, AccountRegistryError> {
+        // HERMETIC GATE (card d793c242): a hermetic scope must not
+        // READ the production rendezvous either — importing real
+        // peers into a test daemon (or vice versa) is the same class
+        // of cross-contamination as publishing.
+        if let Some(block) = account_registry_block(&self.scope_home) {
+            return Err(AccountRegistryError::Adapter(format!(
+                "HERMETIC GATE: refusing account-registry refresh — {block}"
+            )));
+        }
+        // One registry gist per writer/machine on the account: fetch
+        // every readable document and MERGE (freshest beacon per
+        // peer_id; temp-scoped beacons ignored with a counted, loud
+        // line — see merge_registry_documents). Identity mismatches
+        // (e.g. a stale gist from a previous account) are skipped by
+        // the merge, not surfaced as errors.
+        let entries = self.list_registry_gists().await?;
+        let mut documents = Vec::with_capacity(entries.len());
+        for entry in &entries {
+            if let Some(document) = self.fetch_gist_document(entry).await? {
+                documents.push(document);
+            }
+        }
+        let outcome = merge_registry_documents(documents, mesh_identity);
+        if outcome.ignored_temp_beacons > 0 {
+            StderrJsonDiagnosticSink.emit(
+                DiagnosticEvent::warn(
+                    DiagnosticComponent::Daemon,
+                    DiagnosticCode::AccountRegistryTempBeaconsIgnored,
+                    "account-registry reader-merge ignored temp-scoped beacon(s): phantom \
+                     hermetic-test peers are never enrolled or dialed (card d793c242)",
+                )
+                .with_field("ignored_count", outcome.ignored_temp_beacons),
+            );
+        }
+        Ok(outcome.document)
     }
 }
 
@@ -406,6 +702,39 @@ mod tests {
         assert!(extract_gist_id("https://gist.github.com/joelteply/").is_none());
     }
 
+    #[test]
+    fn sanitize_writer_component_is_stable_and_safe() {
+        assert_eq!(sanitize_writer_component("Joels-MacBook-Pro.local"), "joels-macbook-pro-local");
+        assert_eq!(sanitize_writer_component("BIGMAMA"), "bigmama");
+        assert_eq!(sanitize_writer_component("  weird host!! "), "weird-host");
+        assert_eq!(sanitize_writer_component(""), "unknown");
+        assert_eq!(sanitize_writer_component("---"), "unknown");
+    }
+
+    #[test]
+    fn writer_filename_is_marked_and_stable() {
+        let filename = writer_filename();
+        assert!(filename.starts_with("airc-account-mesh-registry."));
+        assert!(filename.ends_with(".json"));
+        // Stable across calls in one process — the find-or-update key.
+        assert_eq!(filename, writer_filename());
+    }
+
+    // Hermetic gate inputs (env-set arm is pinned by the CLI
+    // subprocess tests in crates/airc-cli/tests/registry_hermetic.rs,
+    // where the env can be set without racing parallel tests).
+    #[test]
+    fn account_registry_block_states() {
+        assert_eq!(account_registry_block(Path::new("/Users/joel/.airc")), None);
+        let dir = tempfile::tempdir().unwrap();
+        match account_registry_block(dir.path()) {
+            Some(AccountRegistryBlock::TempScopeHome { scope_home }) => {
+                assert_eq!(scope_home, dir.path());
+            }
+            other => panic!("temp scope must be blocked, got {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn save_and_load_gist_id_round_trips() {
         let dir = tempfile::tempdir().unwrap();
@@ -413,7 +742,7 @@ mod tests {
             airc_store::SqliteEventStore::open_path(&dir.path().join("events.sqlite"))
                 .await
                 .unwrap();
-        let store = GhAccountRegistryStore::new(Arc::new(event_store));
+        let store = GhAccountRegistryStore::new(Arc::new(event_store), "/machine/a/.airc");
         let mesh = MeshIdentity::new("joelteply");
         assert!(store.load_gist_id(&mesh).await.unwrap().is_none());
         store.save_gist_id(&mesh, "abc123").await.unwrap();
@@ -423,5 +752,323 @@ mod tests {
         );
         store.clear_gist_id(&mesh).await.unwrap();
         assert!(store.load_gist_id(&mesh).await.unwrap().is_none());
+    }
+
+    // Stub-gh integration tests (unix: the stub is a shell script).
+    // The stub implements a filesystem-backed mini gist service so the
+    // FULL publish/refresh round-trips run with ZERO real gh — hitting
+    // the real gh from tests is the very bug this card fixes.
+    #[cfg(unix)]
+    mod gh_stub {
+        use super::*;
+        use crate::account_registry::AccountPeerBeacon;
+        use crate::registry::PeerSpec;
+        use crate::route::RouteEndpoint;
+        use airc_core::PeerId;
+        use airc_protocol::PeerKeypair;
+        use std::os::unix::fs::PermissionsExt;
+
+        const STUB_SCRIPT: &str = r#"#!/bin/sh
+S="__STATE__"
+printf '%s\n' "$*" >> "$S/calls.log"
+case "$1" in
+  auth)
+    exit 0
+    ;;
+  gist)
+    if [ "$2" = "create" ]; then
+      fn=""
+      prev=""
+      for a in "$@"; do
+        [ "$prev" = "--filename" ] && fn="$a"
+        prev="$a"
+      done
+      n=$(cat "$S/count" 2>/dev/null || echo 0)
+      n=$((n+1))
+      echo "$n" > "$S/count"
+      id="stubgist$n"
+      cat > "$S/$id.content"
+      printf '%s' "$fn" > "$S/$id.filename"
+      echo "https://gist.github.com/stub/$id"
+    elif [ "$2" = "edit" ]; then
+      id="$3"
+      if [ ! -f "$S/$id.filename" ]; then
+        echo "HTTP 404: Not Found" >&2
+        exit 1
+      fi
+      cat > "$S/$id.content"
+    fi
+    ;;
+  api)
+    path="$2"
+    if [ "$path" = "/gists?per_page=100" ]; then
+      for f in "$S"/*.filename; do
+        [ -e "$f" ] || continue
+        id=$(basename "$f" .filename)
+        fn=$(cat "$f")
+        printf '{"id":"%s","filename":"%s"}\n' "$id" "$fn"
+      done
+    else
+      id="${path#/gists/}"
+      if [ ! -f "$S/$id.filename" ]; then
+        echo "HTTP 404: Not Found" >&2
+        exit 1
+      fi
+      if [ "$4" = ".files | keys | .[0]" ]; then
+        cat "$S/$id.filename"
+        echo
+      else
+        cat "$S/$id.content"
+      fi
+    fi
+    ;;
+esac
+exit 0
+"#;
+
+        struct StubGh {
+            bin: std::path::PathBuf,
+            state: std::path::PathBuf,
+        }
+
+        impl StubGh {
+            fn install(dir: &Path) -> Self {
+                let state = dir.join("gh-state");
+                std::fs::create_dir_all(&state).unwrap();
+                let bin = dir.join("gh");
+                std::fs::write(&bin, STUB_SCRIPT.replace("__STATE__", &state.to_string_lossy()))
+                    .unwrap();
+                std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+                Self { bin, state }
+            }
+
+            fn calls(&self) -> Vec<String> {
+                std::fs::read_to_string(self.state.join("calls.log"))
+                    .map(|log| log.lines().map(str::to_string).collect())
+                    .unwrap_or_default()
+            }
+
+            fn create_count(&self) -> usize {
+                self.calls()
+                    .iter()
+                    .filter(|line| line.starts_with("gist create"))
+                    .count()
+            }
+
+            fn gist_content(&self, id: &str) -> String {
+                std::fs::read_to_string(self.state.join(format!("{id}.content"))).unwrap()
+            }
+
+            fn seed_gist(&self, id: &str, filename: &str, document: &AccountRegistryDocument) {
+                std::fs::write(self.state.join(format!("{id}.filename")), filename).unwrap();
+                std::fs::write(
+                    self.state.join(format!("{id}.content")),
+                    serde_json::to_string(document).unwrap(),
+                )
+                .unwrap();
+            }
+        }
+
+        async fn store_at(
+            stub: &StubGh,
+            db_dir: &Path,
+            scope_home: &str,
+        ) -> GhAccountRegistryStore {
+            std::fs::create_dir_all(db_dir).unwrap();
+            let event_store =
+                airc_store::SqliteEventStore::open_path(&db_dir.join("events.sqlite"))
+                    .await
+                    .unwrap();
+            GhAccountRegistryStore::new(Arc::new(event_store), scope_home).with_bin(&stub.bin)
+        }
+
+        fn mesh() -> MeshIdentity {
+            MeshIdentity::new("joelteply")
+        }
+
+        fn beacon(scope_home: &str, heartbeat_ms: u64, relay: &str) -> AccountPeerBeacon {
+            let peer_id = PeerId::new();
+            beacon_for(peer_id, scope_home, heartbeat_ms, relay)
+        }
+
+        fn beacon_for(
+            peer_id: PeerId,
+            scope_home: &str,
+            heartbeat_ms: u64,
+            relay: &str,
+        ) -> AccountPeerBeacon {
+            let keypair = PeerKeypair::generate();
+            AccountPeerBeacon {
+                presence: crate::coordinator::beacon_now(
+                    peer_id,
+                    scope_home.into(),
+                    Vec::new(),
+                    123,
+                    heartbeat_ms,
+                ),
+                peer_spec: PeerSpec {
+                    peer_id,
+                    pubkey: keypair.public_bytes(),
+                },
+                endpoints: vec![RouteEndpoint::Relay {
+                    url: relay.to_string(),
+                }],
+            }
+        }
+
+        fn document(generated_at_ms: u64, peers: Vec<AccountPeerBeacon>) -> AccountRegistryDocument {
+            AccountRegistryDocument::new(mesh(), generated_at_ms, Vec::new(), peers)
+        }
+
+        // Production-shaped home + env unset → publish goes through
+        // (stubbed), AND two ticks land on the SAME gist: one create,
+        // then edit in place. Mutation check (find-or-update broken to
+        // always-create): the second tick creates stubgist2 and the
+        // create_count assert fails.
+        #[tokio::test]
+        async fn publish_creates_once_then_edits_same_gist() {
+            let dir = tempfile::tempdir().unwrap();
+            let stub = StubGh::install(dir.path());
+            let store = store_at(&stub, &dir.path().join("db"), "/machine/prod/.airc").await;
+
+            store.publish(&document(1_000, Vec::new())).await.unwrap();
+            let tick_two = document(2_000, Vec::new());
+            store.publish(&tick_two).await.unwrap();
+
+            assert_eq!(stub.create_count(), 1, "same writer -> same gist, no duplicates");
+            assert!(
+                stub.calls()
+                    .iter()
+                    .any(|line| line.starts_with("gist edit stubgist1")),
+                "second tick must edit the first gist in place: {:?}",
+                stub.calls()
+            );
+            // The gist carries the latest document, under this
+            // writer's stable filename marker.
+            let stored: AccountRegistryDocument =
+                serde_json::from_str(&stub.gist_content("stubgist1")).unwrap();
+            assert_eq!(stored, tick_two);
+            assert_eq!(
+                std::fs::read_to_string(stub.state.join("stubgist1.filename")).unwrap(),
+                writer_filename()
+            );
+        }
+
+        // PROLIFERATION PIN (card d793c242 item 2): when the local
+        // sentinel is GONE (fresh events.sqlite — the rotated-identity
+        // case that minted 5+ duplicate gists under joelteply), the
+        // publisher re-finds its own gist by writer filename and
+        // updates it instead of creating another. Mutation check:
+        // removing the find step creates stubgist2 here.
+        #[tokio::test]
+        async fn sentinel_loss_refinds_own_gist_instead_of_creating() {
+            let dir = tempfile::tempdir().unwrap();
+            let stub = StubGh::install(dir.path());
+
+            let first = store_at(&stub, &dir.path().join("db-a"), "/machine/prod/.airc").await;
+            first.publish(&document(1_000, Vec::new())).await.unwrap();
+            assert_eq!(stub.create_count(), 1);
+
+            // Same machine, same stub state — but a FRESH sqlite store,
+            // so the gist-id sentinel is gone.
+            let reborn = store_at(&stub, &dir.path().join("db-b"), "/machine/prod/.airc").await;
+            let tick = document(2_000, Vec::new());
+            reborn.publish(&tick).await.unwrap();
+
+            assert_eq!(
+                stub.create_count(),
+                1,
+                "sentinel loss must NOT create a duplicate gist: {:?}",
+                stub.calls()
+            );
+            assert!(
+                stub.calls()
+                    .iter()
+                    .any(|line| line.starts_with("gist edit stubgist1")),
+                "the writer's existing gist must be adopted and edited: {:?}",
+                stub.calls()
+            );
+            let stored: AccountRegistryDocument =
+                serde_json::from_str(&stub.gist_content("stubgist1")).unwrap();
+            assert_eq!(stored, tick);
+        }
+
+        // HERMETIC GATE, innermost layer (card d793c242 item 1): a
+        // temp-rooted scope home refuses BOTH publish and refresh with
+        // a loud, reasoned error — and gh is NEVER spawned. Mutation
+        // check: removing the gate from publish/refresh makes the stub
+        // log non-empty (and publish succeed), failing every assert.
+        #[tokio::test]
+        async fn temp_scope_home_never_reaches_gh() {
+            let dir = tempfile::tempdir().unwrap();
+            let stub = StubGh::install(dir.path());
+            let scope_home = dir.path().join("scope/.airc");
+            let store = store_at(
+                &stub,
+                &dir.path().join("db"),
+                &scope_home.to_string_lossy(),
+            )
+            .await;
+
+            let publish_error = store
+                .publish(&document(1_000, Vec::new()))
+                .await
+                .expect_err("temp-rooted scope must refuse to publish");
+            let message = publish_error.to_string();
+            assert!(message.contains("HERMETIC GATE"), "loud refusal, got: {message}");
+            assert!(message.contains("temp-rooted"), "reason named, got: {message}");
+
+            let refresh_error = store
+                .refresh(&mesh())
+                .await
+                .expect_err("temp-rooted scope must refuse to refresh");
+            assert!(refresh_error.to_string().contains("HERMETIC GATE"));
+
+            assert!(
+                stub.calls().is_empty(),
+                "gh must never be spawned for a hermetic scope: {:?}",
+                stub.calls()
+            );
+        }
+
+        // Reader-side (card d793c242 item 3) through the REAL gh-store
+        // refresh: documents from multiple writer gists merge with
+        // freshest-beacon-per-peer, and temp-scoped phantom beacons in
+        // old polluted documents are dropped.
+        #[tokio::test]
+        async fn refresh_merges_writer_gists_and_drops_temp_beacons() {
+            let dir = tempfile::tempdir().unwrap();
+            let stub = StubGh::install(dir.path());
+            let store = store_at(&stub, &dir.path().join("db"), "/machine/prod/.airc").await;
+
+            let shared = PeerId::new();
+            let stale = beacon_for(shared, "/machine/a/.airc", 1_000, "https://stale.example.test");
+            let fresh = beacon_for(shared, "/machine/a/.airc", 5_000, "https://fresh.example.test");
+            let phantom = beacon(
+                r"C:\Users\green\AppData\Local\Temp\tmp.YYavgmVUxz\.airc",
+                9_000,
+                "https://phantom.example.test",
+            );
+
+            // Legacy-filename gist (old writer) with a stale beacon +
+            // a temp-scoped phantom; writer-keyed gist with the fresh
+            // beacon.
+            stub.seed_gist(
+                "g1",
+                "airc-account-mesh-registry.json",
+                &document(2_000, vec![stale, phantom]),
+            );
+            stub.seed_gist("g2", &writer_filename(), &document(6_000, vec![fresh.clone()]));
+
+            let merged = store
+                .refresh(&mesh())
+                .await
+                .unwrap()
+                .expect("documents must merge");
+
+            assert_eq!(merged.peers.len(), 1, "phantom dropped, shared peer deduped");
+            assert_eq!(merged.peers[0].peer_id(), shared);
+            assert_eq!(merged.peers[0].endpoints, fresh.endpoints, "freshest beacon wins");
+        }
     }
 }

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -77,7 +77,8 @@ pub mod work_roster;
 pub mod work_subscription;
 
 pub use account_registry::{
-    AccountPeerBeacon, AccountRegistryDocument, AccountRegistryError, AccountRegistryStore,
+    merge_registry_documents, scope_home_is_temp_rooted, AccountPeerBeacon,
+    AccountRegistryDocument, AccountRegistryError, AccountRegistryStore, RegistryMergeOutcome,
     SqliteAccountRegistryStore, ACCOUNT_REGISTRY_SCHEMA_VERSION,
 };
 pub use agent_heartbeat::{
@@ -118,7 +119,10 @@ pub use external_identity::{
     BridgedMessage, BridgedMessageFilter, ExternalIdentity, ExternalIdentitySource,
     HEADER_BRIDGE_HANDLE, HEADER_BRIDGE_SOURCE,
 };
-pub use gh_account_registry::{gh_auth_ready, GhAccountRegistryStore};
+pub use gh_account_registry::{
+    account_registry_block, gh_auth_ready, writer_filename, writer_key, AccountRegistryBlock,
+    GhAccountRegistryStore, AIRC_DISABLE_ACCOUNT_REGISTRY_ENV,
+};
 pub use gh_client::{
     parse_pr_url, parse_pr_view, GhCheck, GhClient, GhError, MergeReceipt, PrCreateArgs, PrCreated,
     PrEditBaseArgs, PrMergeArgs, PrView, PrViewArgs,
@@ -137,8 +141,8 @@ pub use peers::EnrolledPeer;
 pub use publish::{PublishReceipt, PublishTarget};
 pub use registry::{format_peer_spec, PeerSpec, PeerSpecError};
 pub use registry_refresh::{
-    run_loop as run_registry_refresh_loop, sync_once as registry_sync_once, RegistryRefreshConfig,
-    RegistryRefreshGate, TickReport as RegistrySyncReport,
+    run_loop as run_registry_refresh_loop, sync_once as registry_sync_once, GateBlock,
+    RegistryRefreshConfig, RegistryRefreshGate, SyncOutcome, TickReport as RegistrySyncReport,
 };
 pub use room::Room;
 pub use route::{

--- a/crates/airc-lib/src/registry_refresh.rs
+++ b/crates/airc-lib/src/registry_refresh.rs
@@ -79,25 +79,65 @@ impl Default for RegistryRefreshConfig {
 /// Whether (and how) to gate a tick on transport availability.
 #[derive(Debug, Clone)]
 pub enum RegistryRefreshGate {
-    /// gh gist rendezvous: skip the tick unless `gh auth status` is
-    /// ready. `gh_bin` is the gh binary path override (`None` = `gh`
-    /// on PATH). This is the production gate for `GhAccountRegistryStore`.
-    GhAuth { gh_bin: Option<PathBuf> },
+    /// gh gist rendezvous: skip the tick unless the hermetic gate
+    /// (card d793c242) allows this scope to touch gh AND `gh auth
+    /// status` is ready. `gh_bin` is the gh binary path override
+    /// (`None` = `gh` on PATH); `scope_home` is the publishing
+    /// scope's AIRC_HOME (the hermetic gate's input). This is the
+    /// production gate for `GhAccountRegistryStore`.
+    GhAuth {
+        gh_bin: Option<PathBuf>,
+        scope_home: PathBuf,
+    },
     /// No gate — always run the tick. Used by Sqlite/in-memory stores
     /// that need no external auth (acceptance test + manual `registry
     /// sync` against a local store).
     Always,
 }
 
-impl RegistryRefreshGate {
-    /// Returns `true` if a tick should proceed. A `false` here is the
-    /// "transport not ready, skip cleanly" path — NOT an error.
-    async fn ready(&self) -> bool {
+/// Why a tick was skipped. Both variants are clean skips, NOT errors —
+/// but they are LOUD skips: every caller logs the reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GateBlock {
+    /// Hermetic gate (card d793c242): this scope must never touch the
+    /// gh account rendezvous. The payload says exactly why.
+    Hermetic(crate::gh_account_registry::AccountRegistryBlock),
+    /// `gh` is not authenticated — the optional same-account
+    /// rendezvous transport is simply unavailable.
+    GhNotReady,
+}
+
+impl std::fmt::Display for GateBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RegistryRefreshGate::GhAuth { gh_bin } => {
-                crate::gh_account_registry::gh_auth_ready(gh_bin.as_deref()).await
+            Self::Hermetic(block) => write!(f, "{block}"),
+            Self::GhNotReady => write!(
+                f,
+                "gh transport not ready (not authenticated); this is the optional \
+                 same-account rendezvous — skipping cleanly"
+            ),
+        }
+    }
+}
+
+impl RegistryRefreshGate {
+    /// Returns `None` if a tick should proceed, or the reason it must
+    /// not. The hermetic gate is checked FIRST: a hermetic scope must
+    /// not even probe `gh auth status`.
+    async fn block(&self) -> Option<GateBlock> {
+        match self {
+            RegistryRefreshGate::GhAuth { gh_bin, scope_home } => {
+                if let Some(block) =
+                    crate::gh_account_registry::account_registry_block(scope_home)
+                {
+                    return Some(GateBlock::Hermetic(block));
+                }
+                if !crate::gh_account_registry::gh_auth_ready(gh_bin.as_deref()).await {
+                    return Some(GateBlock::GhNotReady);
+                }
+                None
             }
-            RegistryRefreshGate::Always => true,
+            RegistryRefreshGate::Always => None,
         }
     }
 }
@@ -156,19 +196,29 @@ pub struct TickReport {
     pub enrolled_peers: usize,
 }
 
+/// Outcome of [`sync_once`]: the tick either ran, or was skipped for
+/// a typed, printable reason. The reason is part of the contract —
+/// callers MUST surface it (no silent skips, card d793c242).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyncOutcome {
+    Ran(TickReport),
+    Skipped(GateBlock),
+}
+
 /// Run exactly one publish+refresh, honoring the gate. Used by the
 /// `registry sync` CLI verb (manual proof + Mac bootstrap surface) and
-/// composable into the loop. A gate-skip returns `Ok(None)`.
+/// composable into the loop. A gate-skip returns
+/// `Ok(SyncOutcome::Skipped(reason))`.
 pub async fn sync_once(
     airc: &Airc,
     store: &dyn AccountRegistryStore,
     gate: &RegistryRefreshGate,
-) -> Result<Option<TickReport>, crate::error::AircError> {
-    if !gate.ready().await {
-        return Ok(None);
+) -> Result<SyncOutcome, crate::error::AircError> {
+    if let Some(block) = gate.block().await {
+        return Ok(SyncOutcome::Skipped(block));
     }
     let report = run_tick(airc, store, &StderrJsonDiagnosticSink).await?;
-    Ok(Some(report))
+    Ok(SyncOutcome::Ran(report))
 }
 
 /// The daemon-resident loop. Ticks publish+refresh on a cadence until
@@ -205,13 +255,16 @@ pub async fn run_loop<S>(
             biased;
             _ = &mut shutdown => break,
             _ = ticker.tick() => {
-                if !gate.ready().await {
+                if let Some(block) = gate.block().await {
+                    let code = match &block {
+                        GateBlock::Hermetic(_) => DiagnosticCode::AccountRegistryHermeticSkip,
+                        GateBlock::GhNotReady => DiagnosticCode::AccountRegistryPublishFailed,
+                    };
                     sink.emit(
                         DiagnosticEvent::warn(
                             DiagnosticComponent::Daemon,
-                            DiagnosticCode::AccountRegistryPublishFailed,
-                            "account registry tick skipped: gh transport not ready (not authenticated); \
-                             this is the optional same-account rendezvous — skipping cleanly",
+                            code,
+                            format!("account registry tick skipped: {block}"),
                         ),
                     );
                     continue;
@@ -314,10 +367,12 @@ mod tests {
         // `sqlite_registry_bridges_two_isolated_machine_homes` test
         // models, now asserted through the wired `sync_once` entry.
         let gate = RegistryRefreshGate::Always;
-        let a_report = sync_once(&airc_a, &store, &gate).await.unwrap();
-        assert!(a_report.is_some(), "gate Always must run A's tick");
+        let a_report = match sync_once(&airc_a, &store, &gate).await.unwrap() {
+            SyncOutcome::Ran(report) => report,
+            SyncOutcome::Skipped(block) => panic!("gate Always must run A's tick: {block}"),
+        };
         assert!(
-            a_report.map(|r| r.published_peers).unwrap_or(0) >= 1,
+            a_report.published_peers >= 1,
             "A must publish at least its own beacon"
         );
 
@@ -384,12 +439,47 @@ mod tests {
             .unwrap();
 
         // A gh binary that does not exist → gh_auth_ready is false →
-        // gate skips. Bounded (gh_auth_ready has its own 750ms timeout).
+        // gate skips. Bounded (gh_auth_ready has its own timeout).
+        // scope_home is production-shaped so the HERMETIC gate does
+        // not fire first — this test pins the auth-skip arm.
         let gate = RegistryRefreshGate::GhAuth {
             gh_bin: Some(PathBuf::from("airc-nonexistent-gh-binary-for-gate-test")),
+            scope_home: PathBuf::from("/machine/prod/.airc"),
         };
-        let report = sync_once(&airc, &store, &gate).await.unwrap();
-        assert!(report.is_none(), "unready gate must skip, returning None");
+        let outcome = sync_once(&airc, &store, &gate).await.unwrap();
+        assert_eq!(
+            outcome,
+            SyncOutcome::Skipped(GateBlock::GhNotReady),
+            "unready gate must skip with the gh-not-ready reason"
+        );
+    }
+
+    // HERMETIC GATE (card d793c242): a gh-gated scope whose home is
+    // temp-rooted must skip the tick with the hermetic reason — gh is
+    // never probed, nothing is published. Mutation check: removing the
+    // hermetic arm from `RegistryRefreshGate::block` makes this fall
+    // through to GhNotReady (or run), failing the assert.
+    #[tokio::test]
+    async fn sync_once_skips_hermetically_for_temp_scope_home() {
+        let dir = tempdir().unwrap();
+        let machine = dir.path().join("machine/.airc");
+        let wire = dir.path().join("wire");
+        write_identity(&wire).await;
+        let store = sqlite_registry_store_at(&dir.path().join("rendezvous")).await;
+        let airc = Airc::open_with_wire_root_for_test(&machine, &wire)
+            .await
+            .unwrap();
+
+        let gate = RegistryRefreshGate::GhAuth {
+            gh_bin: Some(PathBuf::from("airc-nonexistent-gh-binary-for-gate-test")),
+            scope_home: machine.clone(),
+        };
+        match sync_once(&airc, &store, &gate).await.unwrap() {
+            SyncOutcome::Skipped(GateBlock::Hermetic(
+                crate::gh_account_registry::AccountRegistryBlock::TempScopeHome { scope_home },
+            )) => assert_eq!(scope_home, machine),
+            other => panic!("temp-rooted scope must skip hermetically, got {other:?}"),
+        }
     }
 
     // The loop honors shutdown promptly even with a long cadence —

--- a/crates/airc-lib/src/registry_refresh.rs
+++ b/crates/airc-lib/src/registry_refresh.rs
@@ -127,8 +127,7 @@ impl RegistryRefreshGate {
     async fn block(&self) -> Option<GateBlock> {
         match self {
             RegistryRefreshGate::GhAuth { gh_bin, scope_home } => {
-                if let Some(block) =
-                    crate::gh_account_registry::account_registry_block(scope_home)
+                if let Some(block) = crate::gh_account_registry::account_registry_block(scope_home)
                 {
                     return Some(GateBlock::Hermetic(block));
                 }

--- a/test/public_installed_runtime_proof.sh
+++ b/test/public_installed_runtime_proof.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Hermetic gate (card d793c242): every daemon this proof spawns runs
+# under the operator's real gh auth — it must NEVER publish its test
+# identities to the production account rendezvous. (The temp-rooted
+# homes below are the defense-in-depth layer; this is the intentional
+# one.)
+export AIRC_DISABLE_ACCOUNT_REGISTRY=1
+
 # Public installed-command proof.
 #
 # Verifies the contract a stranger landing at the repo + running


### PR DESCRIPTION
## P1: hermetic test daemons publish to the PRODUCTION account rendezvous (card d793c242)

### Live evidence
2026-06-12 ~01:11Z: a Windows **test** daemon with scope_home `C:\Users\green\AppData\Local\Temp\tmp.YYavgmVUxz\.airc` published itself to the REAL joelteply account rendezvous (gist `1214fb43d2c00d667c4712e6023b2165`). Hermetic daemons inherit the operator's working gh auth (`ensure_daemon_running` even injects `GH_TOKEN`), so the account-registry loop happily publishes test identities to production. Consequences: (a) reader-merge enrols PHANTOM TEST PEERS and the #1146 import loop auto-dials their garbage endpoints; (b) duplicate `airc-account-mesh-registry` gists proliferate — 5+ under joelteply, because create-on-miss fires every time a fresh writer identity appears.

### What each layer does

**1. Hermetic gate (the P1 core)** — `account_registry_block(scope_home)` in `gh_account_registry.rs`:
- **Intentional layer**: `AIRC_DISABLE_ACCOUNT_REGISTRY` env var, honored by the daemon (loop never spawns, ONE loud `account-registry loop DISABLED — …` line), by the per-tick gate in `run_registry_refresh_loop`, and by `airc registry sync` (prints `registry sync REFUSED (hermetic gate): …`). Set automatically by the test-daemon spawn helpers (`daemon_route_refresh.rs`, `daemon_lifecycle.rs`, `test/public_installed_runtime_proof.sh`) and inherited by daemons spawned via `ensure_daemon_running`.
- **Defense in depth**: a scope_home resolved under a temp dir (canonicalized `std::env::temp_dir()` prefix + cross-platform markers incl. `AppData\Local\Temp`) refuses BOTH publish and refresh.
- **No silent path**: the gate is enforced at daemon startup, per loop tick (typed `GateBlock`, warn diagnostic `account_registry_hermetic_skip`), and INSIDE `GhAccountRegistryStore` itself (`HERMETIC GATE: refusing …` error) — `scope_home` is a required constructor argument, so no gh-backed store can exist ungated. Every suppression logs the exact reason.

**2. Writer-doc find-or-update** — same writer → same gist, update in place:
- New gists are created as `airc-account-mesh-registry.<writer-key>.json` where the writer key derives from MACHINE identity (hostname + user, sanitized), not the rotating peer/mesh identity.
- On sentinel miss the publisher LISTS the account's registry gists and re-finds its own by writer filename before ever creating one.
- The sentinel-edit path probes the gist and edits its CURRENT filename (legacy `airc-account-mesh-registry.json` gists keep their name — no second file, no orphaning). A transient (non-404) probe failure keeps the sentinel and errors loudly, so a network blip can't mint a duplicate. 404 → sentinel cleared → find-or-create in the same tick.
- Readers are filename-agnostic (they already take the gist's first file), so old and new binaries interoperate in a mixed fleet.

**3. Reader-side hygiene** — `merge_registry_documents` (pure, unit-tested) replaces the old pick-newest-document reader:
- Beacons whose scope_home is temp-rooted are IGNORED and counted (warn diagnostic `account_registry_temp_beacons_ignored`, count not dump) — belt and braces against the polluted documents already published.
- Freshest beacon per `peer_id` across all per-machine gists (by `heartbeat_at_ms`, doc `generated_at_ms` tiebreak); peers present only in older machines' documents now survive the merge; channels are unioned.

### Tests (all stubbed — no test touches the real gh; that's the bug)
- `crates/airc-cli/tests/registry_hermetic.rs`: recording gh stub on PATH+`AIRC_GH_BIN` with `auth status` succeeding (so a quiet log proves the gate fired, not auth luck). Env-set sync + daemon publish NOTHING and name the env gate; temp-home sync + daemon refuse without the env var.
- `gh_account_registry::tests::gh_stub` (filesystem-backed mini gist service): production-shaped home publishes (create once → edit in place); sentinel loss re-finds the writer gist (proliferation pin); temp scope never spawns gh; refresh merges writer gists freshest-per-peer and drops temp beacons through the real store path.
- `account_registry::tests`: cross-platform temp detection (incl. the literal live-evidence Windows path), merge filter+count, freshest-per-peer union, foreign-mesh skip.
- `registry_refresh::tests`: typed `SyncOutcome`/`GateBlock`; hermetic skip pinned separately from gh-not-ready skip.

### Mutation evidence (each mutated, observed FAIL, restored)
| Mutation | Failing tests |
|---|---|
| (a) env-gate honor removed from `account_registry_block` | `registry_sync_honors_disable_env_and_publishes_nothing`, `daemon_with_disable_env_never_runs_registry_loop` |
| (b1) temp-dir arm removed from `account_registry_block` | `registry_sync_refuses_temp_home_even_without_env`, `daemon_with_temp_home_never_runs_registry_loop`, `account_registry_block_states`, `gh_stub::temp_scope_home_never_reaches_gh` |
| (b2) store-internal publish refusal removed (gate left intact) | `gh_stub::temp_scope_home_never_reaches_gh` (innermost layer independently pinned) |
| (c) find-or-update broken to always-create | `gh_stub::publish_creates_once_then_edits_same_gist`, `gh_stub::sentinel_loss_refinds_own_gist_instead_of_creating` |
| (d) reader temp filter removed from merge | `merge_ignores_temp_scoped_beacons_and_counts_them` |

### Gate
- `cargo clippy --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --workspace -- --skip codex_hook` — green

### Scope / notes
- All three card items shipped (none descoped). The diff is test-heavy; production-code delta is concentrated in `gh_account_registry.rs` / `account_registry.rs` / `registry_refresh.rs` + the two CLI call sites.
- Existing duplicate gists under joelteply are NOT auto-deleted (reader hygiene neutralizes their phantom beacons; writers with intact sentinels keep editing their legacy gist in place). Manual cleanup of the stale duplicates can follow.
- The stub-gh integration tests are `#[cfg(unix)]` (shell-script stub); hosted CI legs are ubuntu + macos so they run on both. Windows compiles them out.

Card: d793c242-815e-4758-ac21-c2e279a55d6f

🤖 Generated with [Claude Code](https://claude.com/claude-code)
