### PR TITLE
fix(registry): stale-self publish pins + union-merge endpoint retention + dialable manual sync (cards cbbcf18d, 4b6a0ffa)

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1126,6 +1126,26 @@ pub async fn run_daemon(
                 );
             }
         }
+        // Card 4b6a0ffa (#33): record the endpoints this handle now
+        // advertises into the daemon's IPC-served state, so a manual
+        // `airc registry sync` can read them back over
+        // `Request::RouteEndpoints` and publish a DIALABLE beacon
+        // instead of an endpoint-less overwrite. Loud on failure —
+        // an unreadable endpoint table is a bug, not a shrug.
+        match airc.route_endpoints() {
+            Ok(endpoints) => {
+                *registry_state.route_endpoints.write().await = endpoints
+                    .into_iter()
+                    .map(crate::registry_commands::route_endpoint_to_ipc)
+                    .collect();
+            }
+            Err(error) => {
+                eprintln!(
+                    "airc daemon: could not record route endpoints for IPC read-back \
+                     ({error}) — `airc registry sync` will refuse endpoint-less publishes"
+                );
+            }
+        }
         let db_path = airc_lib::machine_account_home(&registry_home).join("events.sqlite");
         let event_store = match SqliteEventStore::open_path(&db_path).await {
             Ok(store) => Arc::new(store),

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -443,7 +443,9 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         },
 
         Command::Registry(args) => match args.action {
-            registry_cli::RegistryAction::Sync => registry_commands::run_sync(&home).await,
+            registry_cli::RegistryAction::Sync { allow_endpointless } => {
+                registry_commands::run_sync(&home, allow_endpointless).await
+            }
         },
 
         Command::Transport(args) => match args.action {

--- a/crates/airc-cli/src/registry_cli.rs
+++ b/crates/airc-cli/src/registry_cli.rs
@@ -15,5 +15,18 @@ pub enum RegistryAction {
     /// to bootstrap a fresh machine (Mac onboarding) or to prove
     /// discovery without waiting for the next daemon tick. Skips
     /// cleanly with a notice if `gh` isn't authenticated.
-    Sync,
+    ///
+    /// Publishes the running daemon's dialable endpoints (read back
+    /// over IPC). If no daemon is running — or it advertises no
+    /// endpoints — the sync REFUSES rather than overwrite this
+    /// machine's registry gist with an endpoint-less beacon (card
+    /// 4b6a0ffa / #33).
+    Sync {
+        /// Publish a key-only (endpoint-less) beacon even when no
+        /// daemon endpoint can be read back. Same-account peers can
+        /// then enrol this machine's key but CANNOT dial it until a
+        /// daemon publishes real endpoints.
+        #[arg(long)]
+        allow_endpointless: bool,
+    },
 }

--- a/crates/airc-cli/src/registry_commands.rs
+++ b/crates/airc-cli/src/registry_commands.rs
@@ -2,16 +2,127 @@
 //! publish/refresh the daemon otherwise runs on a cadence (keystone
 //! card a134b370-10b1-49c6-aa42-e1a05446e887). Bootstraps a fresh
 //! machine and proves same-account discovery on demand.
+//!
+//! ## Dialable-endpoint requirement (card 4b6a0ffa / #33)
+//!
+//! This verb opens its own short-lived `Airc` handle with no listener,
+//! so its `route_endpoints()` is empty. It used to publish that
+//! anyway, OVERWRITING this machine's registry gist with an
+//! endpoint-less self-beacon — a fresh same-account reader then got
+//! enrol-but-never-route (#33's exact shape, narrowed to
+//! first-contact-after-manual-sync). Binding a listener here would be
+//! WORSE: the advertised port dies with this process.
+//!
+//! The fix: read back the DAEMON's live endpoints over typed IPC
+//! (`Request::RouteEndpoints`) and publish those. If no daemon is
+//! running — or it has no endpoints — REFUSE the endpoint-less
+//! overwrite with an actionable message, unless the operator
+//! explicitly passes `--allow-endpointless`. No silent endpoint-less
+//! publishes.
 
 use std::path::Path;
-use std::sync::Arc;
 
+use airc_ipc::{DaemonClient, IpcRouteEndpoint};
 use airc_lib::{
-    machine_account_home, Airc, GateBlock, GhAccountRegistryStore, RegistryRefreshGate, SyncOutcome,
+    machine_account_home, Airc, GateBlock, GhAccountRegistryStore, RegistryRefreshGate,
+    RouteEndpoint, SyncOutcome,
 };
 use airc_store::SqliteEventStore;
+use std::sync::Arc;
 
-pub async fn run_sync(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
+/// Convert the daemon's IPC endpoint mirror back to the lib type.
+/// Explicit per-variant mapping — this crate is the only one that
+/// sees both types, and the exhaustive match means a new variant on
+/// either side is a compile error here, not silent drift.
+pub(crate) fn route_endpoint_from_ipc(endpoint: IpcRouteEndpoint) -> RouteEndpoint {
+    match endpoint {
+        IpcRouteEndpoint::LanTcp { addr } => RouteEndpoint::LanTcp { addr },
+        IpcRouteEndpoint::TailscaleTcp { addr } => RouteEndpoint::TailscaleTcp { addr },
+        IpcRouteEndpoint::Udp { addr } => RouteEndpoint::Udp { addr },
+        IpcRouteEndpoint::Relay { url } => RouteEndpoint::Relay { url },
+        IpcRouteEndpoint::Reticulum { destination } => RouteEndpoint::Reticulum { destination },
+        IpcRouteEndpoint::WebRtcSignaling { url } => RouteEndpoint::WebRtcSignaling { url },
+    }
+}
+
+/// Inverse of [`route_endpoint_from_ipc`] — what the daemon's registry
+/// glue records into `DaemonState.route_endpoints` after binding its
+/// listener.
+pub(crate) fn route_endpoint_to_ipc(endpoint: RouteEndpoint) -> IpcRouteEndpoint {
+    match endpoint {
+        RouteEndpoint::LanTcp { addr } => IpcRouteEndpoint::LanTcp { addr },
+        RouteEndpoint::TailscaleTcp { addr } => IpcRouteEndpoint::TailscaleTcp { addr },
+        RouteEndpoint::Udp { addr } => IpcRouteEndpoint::Udp { addr },
+        RouteEndpoint::Relay { url } => IpcRouteEndpoint::Relay { url },
+        RouteEndpoint::Reticulum { destination } => IpcRouteEndpoint::Reticulum { destination },
+        RouteEndpoint::WebRtcSignaling { url } => IpcRouteEndpoint::WebRtcSignaling { url },
+    }
+}
+
+/// The endpoint decision for a manual publish, separated from I/O so
+/// the refusal policy is unit-testable (and mutation-verifiable).
+///
+/// - `handle_endpoints`: this process's own `route_endpoints()`
+///   (normally empty for the CLI — no listener);
+/// - `daemon_endpoints`: `Ok(endpoints)` from the daemon probe, or
+///   `Err(reason)` when no daemon answered (not running, or too old
+///   to speak the verb);
+/// - `allow_endpointless`: the explicit operator override.
+///
+/// Returns the endpoints to publish, or `Err` with the loud,
+/// actionable refusal text. NO arm returns publishable-empty unless
+/// the operator named it.
+pub(crate) fn resolve_publish_endpoints(
+    handle_endpoints: Vec<RouteEndpoint>,
+    daemon_endpoints: Result<Vec<RouteEndpoint>, String>,
+    allow_endpointless: bool,
+) -> Result<Vec<RouteEndpoint>, String> {
+    if !handle_endpoints.is_empty() {
+        return Ok(handle_endpoints);
+    }
+    let daemon_reason = match daemon_endpoints {
+        Ok(endpoints) if !endpoints.is_empty() => return Ok(endpoints),
+        Ok(_) => "the daemon is running but advertises no endpoints \
+                  (its LAN listener may have failed to bind — check the \
+                  daemon's stderr)"
+            .to_string(),
+        Err(reason) => format!("no daemon answered the endpoint probe: {reason}"),
+    };
+    if allow_endpointless {
+        return Ok(Vec::new());
+    }
+    Err(format!(
+        "registry sync REFUSED: this machine has no dialable endpoint to publish.\n  \
+         {daemon_reason}\n  \
+         Publishing anyway would OVERWRITE this machine's registry gist with an \
+         endpoint-less self-beacon, so same-account peers could enrol this key but \
+         never route to it (#33).\n  \
+         Fix: start the daemon (`airc join` starts it) so its live endpoints can be \
+         read back and published, or re-run with --allow-endpointless to publish a \
+         key-only beacon on purpose."
+    ))
+}
+
+/// Probe the daemon that owns this home's socket for its advertised
+/// endpoints. `Err(reason)` covers every can't-answer shape: no
+/// daemon, stale pre-verb daemon, RPC failure.
+async fn daemon_route_endpoints(home: &Path) -> Result<Vec<RouteEndpoint>, String> {
+    let socket = crate::cli::default_socket_path_in(home);
+    let client = DaemonClient::new(socket.clone());
+    match client.route_endpoints().await {
+        Ok(response) => Ok(response
+            .endpoints
+            .into_iter()
+            .map(route_endpoint_from_ipc)
+            .collect()),
+        Err(error) => Err(format!("{error} (socket: {})", socket.display())),
+    }
+}
+
+pub async fn run_sync(
+    home: &Path,
+    allow_endpointless: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let airc = Airc::open(home).await?;
 
     // The gh sentinel + registry rows live in the machine-account
@@ -23,6 +134,31 @@ pub async fn run_sync(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
         gh_bin: None,
         scope_home: home.to_path_buf(),
     };
+
+    // Gate FIRST (hermetic, then gh-auth): a blocked scope must hear
+    // the gate's reason, not an endpoint refusal it can't act on.
+    if let Some(block) = gate.block().await {
+        print_gate_skip(&block);
+        return Ok(());
+    }
+
+    // Card 4b6a0ffa / #33: a manual sync must publish a DIALABLE
+    // endpoint — the daemon's live one, read back over typed IPC —
+    // or refuse. Never silently endpoint-less.
+    let publish_endpoints = resolve_publish_endpoints(
+        airc.route_endpoints()?,
+        daemon_route_endpoints(home).await,
+        allow_endpointless,
+    )?;
+    if publish_endpoints.is_empty() {
+        println!(
+            "registry sync: publishing WITHOUT endpoints (--allow-endpointless): \
+             same-account peers can enrol this key but cannot dial this machine."
+        );
+    }
+    for endpoint in publish_endpoints {
+        airc.upsert_route_endpoint(endpoint)?;
+    }
 
     match airc_lib::registry_sync_once(&airc, &store, &gate).await? {
         SyncOutcome::Ran(report) => {
@@ -38,14 +174,23 @@ pub async fn run_sync(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
                 );
             }
         }
+        // The gate re-checks inside sync_once; if it flipped between
+        // our check and the tick, surface the reason the same way.
+        SyncOutcome::Skipped(block) => print_gate_skip(&block),
+    }
+    Ok(())
+}
+
+fn print_gate_skip(block: &GateBlock) {
+    match block {
         // HERMETIC GATE (card d793c242): this scope must not touch the
         // gh account rendezvous — say exactly why, loudly. The manual
         // verb honors the same gate as the daemon loop; there is no
         // CLI path around it (the gh store enforces it again inside).
-        SyncOutcome::Skipped(GateBlock::Hermetic(block)) => {
-            println!("registry sync REFUSED (hermetic gate): {block}");
+        GateBlock::Hermetic(reason) => {
+            println!("registry sync REFUSED (hermetic gate): {reason}");
         }
-        SyncOutcome::Skipped(GateBlock::GhNotReady) => {
+        GateBlock::GhNotReady => {
             println!(
                 "registry sync skipped: `gh` is not authenticated. The account-mesh \
                  rendezvous is the same-account gist transport — sign in with `gh auth \
@@ -54,5 +199,102 @@ pub async fn run_sync(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
             );
         }
     }
-    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::SocketAddr;
+
+    fn lan(port: u16) -> RouteEndpoint {
+        RouteEndpoint::LanTcp {
+            addr: SocketAddr::from(([10, 0, 0, 2], port)),
+        }
+    }
+
+    // Card 4b6a0ffa / #33 — the refusal policy, pinned. Mutation
+    // check (verified at authoring time): making the no-endpoint arm
+    // return Ok(Vec::new()) instead of refusing fails
+    // `refuses_endpointless_publish_without_override`.
+    #[test]
+    fn refuses_endpointless_publish_without_override() {
+        let refusal =
+            resolve_publish_endpoints(Vec::new(), Err("daemon not reachable".to_string()), false)
+                .expect_err("no endpoints anywhere must refuse");
+        assert!(refusal.contains("REFUSED"), "loud refusal, got: {refusal}");
+        assert!(
+            refusal.contains("--allow-endpointless"),
+            "actionable override named, got: {refusal}"
+        );
+        assert!(
+            refusal.contains("daemon not reachable"),
+            "probe failure reason surfaced, got: {refusal}"
+        );
+    }
+
+    #[test]
+    fn refuses_when_daemon_is_up_but_endpointless() {
+        let refusal = resolve_publish_endpoints(Vec::new(), Ok(Vec::new()), false)
+            .expect_err("a non-dialable daemon must also refuse");
+        assert!(refusal.contains("advertises no endpoints"), "{refusal}");
+    }
+
+    #[test]
+    fn publishes_daemon_endpoints_when_available() {
+        let endpoints = resolve_publish_endpoints(Vec::new(), Ok(vec![lan(7717)]), false)
+            .expect("daemon endpoints must be publishable");
+        assert_eq!(endpoints, vec![lan(7717)]);
+    }
+
+    #[test]
+    fn own_handle_endpoints_win_over_daemon_probe() {
+        let endpoints = resolve_publish_endpoints(
+            vec![lan(1)],
+            Err("irrelevant — handle already dialable".to_string()),
+            false,
+        )
+        .expect("handle endpoints must be publishable");
+        assert_eq!(endpoints, vec![lan(1)]);
+    }
+
+    #[test]
+    fn explicit_override_allows_endpointless_publish() {
+        let endpoints =
+            resolve_publish_endpoints(Vec::new(), Err("daemon not reachable".to_string()), true)
+                .expect("the named override must allow a key-only beacon");
+        assert!(endpoints.is_empty());
+    }
+
+    // The IPC mirror conversion is total and lossless in both
+    // directions — a new RouteEndpoint variant breaks this at compile
+    // time (exhaustive matches), and a field mix-up breaks it here.
+    #[test]
+    fn ipc_endpoint_conversion_round_trips_every_variant() {
+        let endpoints = vec![
+            RouteEndpoint::LanTcp {
+                addr: SocketAddr::from(([10, 0, 0, 2], 7717)),
+            },
+            RouteEndpoint::TailscaleTcp {
+                addr: SocketAddr::from(([100, 64, 0, 7], 7717)),
+            },
+            RouteEndpoint::Udp {
+                addr: SocketAddr::from(([10, 0, 0, 2], 7718)),
+            },
+            RouteEndpoint::Relay {
+                url: "https://relay.example.test".to_string(),
+            },
+            RouteEndpoint::Reticulum {
+                destination: "abcdef0123456789".to_string(),
+            },
+            RouteEndpoint::WebRtcSignaling {
+                url: "wss://signal.example.test".to_string(),
+            },
+        ];
+        for endpoint in endpoints {
+            assert_eq!(
+                route_endpoint_from_ipc(route_endpoint_to_ipc(endpoint.clone())),
+                endpoint
+            );
+        }
+    }
 }

--- a/crates/airc-daemon/src/handlers.rs
+++ b/crates/airc-daemon/src/handlers.rs
@@ -22,7 +22,7 @@ use airc_ipc::request::{
 };
 use airc_ipc::response::{
     InboxResponse, PeerEntry, PeersResponse, PublishResponse, Response, RoomTipResponse,
-    StatusResponse,
+    RouteEndpointsResponse, StatusResponse,
 };
 use bytes::Bytes;
 
@@ -56,6 +56,12 @@ pub async fn dispatch(state: Arc<DaemonState>, request: Request) -> Response {
         Request::AddPeer(add) => handle_add_peer(state, add).await,
         Request::RemovePeer(remove) => handle_remove_peer(state, remove).await,
         Request::ListPeers => handle_list_peers(state).await,
+        // Card 4b6a0ffa (#33): serve the endpoints the registry glue
+        // recorded after binding its listener. Empty means "up but not
+        // dialable" — the client decides what that implies.
+        Request::RouteEndpoints => Response::RouteEndpoints(RouteEndpointsResponse {
+            endpoints: state.route_endpoints.read().await.clone(),
+        }),
         Request::Stop => {
             // Don't actually stop here; just signal. The server's accept
             // loop watches the same notifier and exits after sending

--- a/crates/airc-daemon/src/state.rs
+++ b/crates/airc-daemon/src/state.rs
@@ -18,10 +18,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::{Mutex, Notify, RwLock};
 
 use airc_bus::{BusError, Clock, EventRouter, RouterConfig, SeqSource, SystemClock};
 use airc_core::PeerId;
+use airc_ipc::IpcRouteEndpoint;
 use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
 use airc_store::{EventStore, SqliteDurableSink};
 
@@ -54,6 +55,14 @@ pub struct DaemonState {
     /// Runtime metadata reported through IPC status so clients can
     /// replace stale daemons after updates.
     pub runtime: DaemonRuntimeInfo,
+    /// Card 4b6a0ffa (#33): the dialable endpoints this daemon
+    /// currently advertises in its account-registry beacon. Written by
+    /// the registry glue after it binds its LAN listener; served to
+    /// clients via `Request::RouteEndpoints` so a short-lived CLI
+    /// publisher (`airc registry sync`) can publish the daemon's LIVE
+    /// endpoints instead of an endpoint-less beacon. Empty = this
+    /// daemon is not dialable (no listener bound).
+    pub route_endpoints: RwLock<Vec<IpcRouteEndpoint>>,
 }
 
 impl DaemonState {
@@ -96,6 +105,7 @@ impl DaemonState {
             trusted_roots: Mutex::new(HashMap::new()),
             shutdown: Notify::new(),
             runtime,
+            route_endpoints: RwLock::new(Vec::new()),
         })
     }
 

--- a/crates/airc-daemon/tests/route_endpoints_probe.rs
+++ b/crates/airc-daemon/tests/route_endpoints_probe.rs
@@ -1,0 +1,137 @@
+//! Card 4b6a0ffa (#33) — `route_endpoints` against the LIVE daemon:
+//! the typed probe a short-lived CLI publisher (`airc registry sync`)
+//! uses to read back the daemon's dialable endpoints instead of
+//! publishing an endpoint-less beacon (or advertising its own
+//! about-to-die listener port).
+//!
+//! The test model IS the production model: a real `DaemonState` over a
+//! real SQLite ORM on a Unix socket, driven by the real `DaemonClient`.
+//!
+//! Mutation checks (both verified at authoring time):
+//!   - removing the `Request::RouteEndpoints` dispatch arm fails to
+//!     compile (exhaustive match) — the compiler is the pin;
+//!   - serving an empty vec instead of `state.route_endpoints` fails
+//!     `daemon_serves_recorded_route_endpoints`.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use airc_core::PeerId;
+use airc_daemon::{run, DaemonRuntimeInfo, DaemonState};
+use airc_ipc::{DaemonClient, IpcRouteEndpoint};
+use airc_protocol::{PeerKeyRegistry, PeerKeypair, VerificationPolicy};
+use airc_store::{EventStore, InMemoryEventStore};
+use tokio::task::JoinHandle;
+
+/// A live daemon on a Unix socket, owning a real router + SQLite ORM.
+struct TestDaemon {
+    socket: PathBuf,
+    state: Arc<DaemonState>,
+    handle: JoinHandle<()>,
+    _home: tempfile::TempDir,
+}
+
+fn unique_socket() -> PathBuf {
+    // Short /tmp path keeps us well under macOS SUN_LEN (104 bytes).
+    static N: AtomicU64 = AtomicU64::new(0);
+    let n = N.fetch_add(1, Ordering::Relaxed);
+    PathBuf::from(format!("/tmp/airc-rep-{}-{n}.sock", std::process::id()))
+}
+
+async fn start_daemon() -> TestDaemon {
+    let home = tempfile::TempDir::new().expect("tempdir");
+    let db_path = home.path().join("events.sqlite");
+    let peer_id = PeerId::new();
+    let keypair = PeerKeypair::generate();
+    let registry = PeerKeyRegistry::new();
+    registry
+        .enrol(peer_id, 0, keypair.public_bytes())
+        .expect("enrol self");
+    let coordinator: Arc<dyn EventStore> = Arc::new(InMemoryEventStore::new());
+    let state = Arc::new(
+        DaemonState::build(
+            peer_id,
+            keypair,
+            Arc::new(registry),
+            VerificationPolicy::Strict,
+            home.path().to_path_buf(),
+            &db_path,
+            coordinator,
+            DaemonRuntimeInfo::unknown(),
+        )
+        .await
+        .expect("build daemon state"),
+    );
+    let socket = unique_socket();
+    let server_state = state.clone();
+    let server_socket = socket.clone();
+    let handle = tokio::spawn(async move {
+        let _ = run(server_state, server_socket).await;
+    });
+    for _ in 0..200 {
+        if socket.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    TestDaemon {
+        socket,
+        state,
+        handle,
+        _home: home,
+    }
+}
+
+impl TestDaemon {
+    async fn stop(self) {
+        let _ = DaemonClient::new(self.socket.clone()).stop().await;
+        let _ = tokio::time::timeout(Duration::from_secs(3), self.handle).await;
+    }
+}
+
+/// A daemon that has not bound a listener serves an EMPTY endpoint
+/// list — "up but not dialable", which callers must treat exactly
+/// like "no daemon" for publish decisions.
+#[tokio::test]
+async fn daemon_without_listener_serves_empty_endpoints() {
+    let daemon = start_daemon().await;
+    let client = DaemonClient::new(daemon.socket.clone());
+
+    let response = client.route_endpoints().await.expect("probe must answer");
+    assert!(
+        response.endpoints.is_empty(),
+        "no registry glue ran — endpoints must be empty, got {:?}",
+        response.endpoints
+    );
+
+    daemon.stop().await;
+}
+
+/// Endpoints recorded by the registry glue come back through the typed
+/// probe byte-for-byte — the read-back path `airc registry sync` uses.
+#[tokio::test]
+async fn daemon_serves_recorded_route_endpoints() {
+    let daemon = start_daemon().await;
+    let recorded = vec![
+        IpcRouteEndpoint::LanTcp {
+            addr: "10.0.0.2:7717".parse().expect("valid socket addr"),
+        },
+        IpcRouteEndpoint::Relay {
+            url: "https://relay.example.test".to_string(),
+        },
+    ];
+    // The same write the daemon's registry glue performs after
+    // `listen_lan` succeeds (crates/airc-cli/src/commands.rs).
+    *daemon.state.route_endpoints.write().await = recorded.clone();
+
+    let client = DaemonClient::new(daemon.socket.clone());
+    let response = client.route_endpoints().await.expect("probe must answer");
+    assert_eq!(
+        response.endpoints, recorded,
+        "the daemon must serve exactly the endpoints the registry glue recorded"
+    );
+
+    daemon.stop().await;
+}

--- a/crates/airc-ipc/src/client.rs
+++ b/crates/airc-ipc/src/client.rs
@@ -21,7 +21,8 @@ use crate::request::{
     RoomTipRequest, SendRequest,
 };
 use crate::response::{
-    InboxResponse, PeersResponse, PublishResponse, Response, RoomTipResponse, StatusResponse,
+    InboxResponse, PeersResponse, PublishResponse, Response, RoomTipResponse,
+    RouteEndpointsResponse, StatusResponse,
 };
 
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(5);
@@ -209,6 +210,18 @@ impl DaemonClient {
     pub async fn remove_peer(&self, request: RemovePeerRequest) -> Result<(), ClientError> {
         match self.call(Request::RemovePeer(request)).await? {
             Response::Ok => Ok(()),
+            other => Err(ClientError::UnexpectedResponse(other)),
+        }
+    }
+
+    /// Card 4b6a0ffa (#33): the dialable endpoints this daemon
+    /// currently advertises in its account-registry beacon. An old
+    /// daemon that predates the verb fails the call (decode error or
+    /// `Response::Error`) — callers must treat ANY failure as
+    /// "endpoints unavailable", never as publishable-empty.
+    pub async fn route_endpoints(&self) -> Result<RouteEndpointsResponse, ClientError> {
+        match self.call(Request::RouteEndpoints).await? {
+            Response::RouteEndpoints(response) => Ok(response),
             other => Err(ClientError::UnexpectedResponse(other)),
         }
     }

--- a/crates/airc-ipc/src/lib.rs
+++ b/crates/airc-ipc/src/lib.rs
@@ -46,7 +46,8 @@ pub use request::{
     IpcKind, IpcTarget, PublishRequest, RemovePeerRequest, Request, RoomTipRequest, SendRequest,
 };
 pub use response::{
-    InboxResponse, PeersResponse, PublishResponse, Response, RoomTipResponse, StatusResponse,
+    InboxResponse, IpcRouteEndpoint, PeersResponse, PublishResponse, Response, RoomTipResponse,
+    RouteEndpointsResponse, StatusResponse,
 };
 pub use sdk_conversions::{COUNTER_BITS, COUNTER_MASK};
 // IpcListener / IpcStream stay under `transport` because only the

--- a/crates/airc-ipc/src/request.rs
+++ b/crates/airc-ipc/src/request.rs
@@ -102,6 +102,14 @@ pub enum Request {
     /// Snapshot of currently-enrolled peers (peer_id + pubkey).
     /// Returned via `Response::Peers`.
     ListPeers,
+    /// **Card 4b6a0ffa (#33).** The dialable endpoints this daemon
+    /// currently advertises (its registry glue's LAN listener, relay,
+    /// …). Returned via `Response::RouteEndpoints`. Lets a short-lived
+    /// CLI publisher (`airc registry sync`) publish the DAEMON's live
+    /// endpoints instead of an endpoint-less beacon — a CLI binding
+    /// its own listener would advertise a port that dies with the
+    /// process.
+    RouteEndpoints,
     /// Send a text Message on a channel. The daemon publishes it to its
     /// `EventRouter` as a `Durable` envelope and returns a receipt.
     Send(SendRequest),
@@ -660,6 +668,18 @@ mod tests {
                 limit: Some(1),
             })
         );
+    }
+
+    /// Card 4b6a0ffa (#33): the EXACT wire bytes of `RouteEndpoints`
+    /// are the cross-version contract — the `op` tag pinned as a
+    /// literal on both the encode and decode side, so a symmetric
+    /// serde rename cannot pass.
+    #[test]
+    fn route_endpoints_wire_bytes_are_pinned() {
+        let encoded = serde_json::to_string(&Request::RouteEndpoints).unwrap();
+        assert_eq!(encoded, r#"{"op":"route_endpoints"}"#);
+        let decoded: Request = serde_json::from_str(r#"{"op":"route_endpoints"}"#).unwrap();
+        assert_eq!(decoded, Request::RouteEndpoints);
     }
 
     #[test]

--- a/crates/airc-ipc/src/response.rs
+++ b/crates/airc-ipc/src/response.rs
@@ -7,6 +7,8 @@
 //! ignorant of the envelope's shape (no `airc-bus` dependency leaks
 //! here, no per-hop re-serialize).
 
+use std::net::SocketAddr;
+
 use serde::{Deserialize, Serialize};
 
 use airc_core::{EventId, PeerId, RoomId};
@@ -57,6 +59,12 @@ pub enum Response {
     /// Response to `ListPeers` — the daemon's currently-enrolled
     /// peers (peer_id + URL-safe-no-padding base64 pubkey).
     Peers(PeersResponse),
+    /// **Card 4b6a0ffa (#33).** Response to `RouteEndpoints` — the
+    /// dialable endpoints this daemon currently advertises in its
+    /// account-registry beacon. Short-lived CLI publishers (`airc
+    /// registry sync`) read these back instead of advertising their
+    /// own dead listener or overwriting the gist endpoint-less.
+    RouteEndpoints(RouteEndpointsResponse),
     /// Generic success for ops that don't return data (`AddPeer`,
     /// `RemovePeer`, `Stop`, and the initial `Attach` ack).
     Ok,
@@ -128,6 +136,68 @@ pub struct RoomTipResponse {
     /// absent on the wire) when the room has no durable events.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tip: Option<IpcCursor>,
+}
+
+/// One dialable endpoint advertised by the daemon (card 4b6a0ffa /
+/// #33). Mirrors `airc_lib::RouteEndpoint` — same `kind`-tagged
+/// snake_case wire shape — without leaking the lib type across the
+/// IPC boundary (this crate sits below `airc-lib` in the dependency
+/// graph, exactly like `IpcDelivery` mirrors the bus class). The
+/// conversion lives in `airc-cli`, the only crate that sees both.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum IpcRouteEndpoint {
+    LanTcp {
+        #[serde(with = "socket_addr_string")]
+        addr: SocketAddr,
+    },
+    TailscaleTcp {
+        #[serde(with = "socket_addr_string")]
+        addr: SocketAddr,
+    },
+    Udp {
+        #[serde(with = "socket_addr_string")]
+        addr: SocketAddr,
+    },
+    Relay {
+        url: String,
+    },
+    Reticulum {
+        destination: String,
+    },
+    WebRtcSignaling {
+        url: String,
+    },
+}
+
+/// `SocketAddr` as its `Display`/`FromStr` string on the wire,
+/// EXPLICITLY. std's serde impl picks string vs. struct form off the
+/// format's `is_human_readable`, which does not round-trip through
+/// the CBOR frame codec — and an implicit format-dependent shape is
+/// not a contract. One spelled-out shape (`"10.0.0.2:7717"`), pinned
+/// by the literal-JSON tests below, identical in JSON and CBOR.
+mod socket_addr_string {
+    use std::net::SocketAddr;
+
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(addr: &SocketAddr, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(addr)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<SocketAddr, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        raw.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+/// Result of a `RouteEndpoints` probe: every endpoint the daemon's
+/// registry glue currently advertises. Empty means the daemon is up
+/// but not dialable (no LAN listener bound, no relay) — the caller
+/// must treat that exactly like "no daemon" for publish decisions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RouteEndpointsResponse {
+    pub endpoints: Vec<IpcRouteEndpoint>,
 }
 
 /// Owner-assigned receipt returned by `Send` / `Publish`. The
@@ -259,6 +329,55 @@ mod tests {
             let encoded = serde_json::to_string(&response).unwrap();
             assert_eq!(encoded, expected, "wire bytes of {response:?}");
             let decoded: Response = serde_json::from_str(expected).unwrap();
+            assert_eq!(decoded, response, "decode of pinned literal");
+        }
+    }
+
+    /// Card 4b6a0ffa (#33): the EXACT wire bytes of `RouteEndpoints`
+    /// are the cross-version contract — outer `kind` tag, `endpoints`
+    /// field, and every endpoint variant's tag + field names pinned as
+    /// literals. The endpoint shape deliberately matches
+    /// `airc_lib::RouteEndpoint`'s serde shape (`kind`-tagged,
+    /// snake_case) so the two sides of the CLI conversion can never
+    /// drift apart silently: a rename on either side fails here.
+    #[test]
+    fn route_endpoints_response_wire_bytes_are_pinned_per_variant() {
+        for (response, expected) in [
+            (
+                Response::RouteEndpoints(RouteEndpointsResponse {
+                    endpoints: vec![
+                        IpcRouteEndpoint::LanTcp {
+                            addr: "10.0.0.2:7717".parse().expect("valid socket addr"),
+                        },
+                        IpcRouteEndpoint::TailscaleTcp {
+                            addr: "100.64.0.7:7717".parse().expect("valid socket addr"),
+                        },
+                        IpcRouteEndpoint::Udp {
+                            addr: "10.0.0.2:7718".parse().expect("valid socket addr"),
+                        },
+                        IpcRouteEndpoint::Relay {
+                            url: "https://relay.example.test".to_string(),
+                        },
+                        IpcRouteEndpoint::Reticulum {
+                            destination: "abcdef0123456789".to_string(),
+                        },
+                        IpcRouteEndpoint::WebRtcSignaling {
+                            url: "wss://signal.example.test".to_string(),
+                        },
+                    ],
+                }),
+                r#"{"kind":"route_endpoints","endpoints":[{"kind":"lan_tcp","addr":"10.0.0.2:7717"},{"kind":"tailscale_tcp","addr":"100.64.0.7:7717"},{"kind":"udp","addr":"10.0.0.2:7718"},{"kind":"relay","url":"https://relay.example.test"},{"kind":"reticulum","destination":"abcdef0123456789"},{"kind":"web_rtc_signaling","url":"wss://signal.example.test"}]}"#,
+            ),
+            (
+                Response::RouteEndpoints(RouteEndpointsResponse {
+                    endpoints: Vec::new(),
+                }),
+                r#"{"kind":"route_endpoints","endpoints":[]}"#,
+            ),
+        ] {
+            let encoded = serde_json::to_string(&response).expect("encode");
+            assert_eq!(encoded, expected, "wire bytes of {response:?}");
+            let decoded: Response = serde_json::from_str(expected).expect("decode");
             assert_eq!(decoded, response, "decode of pinned literal");
         }
     }

--- a/crates/airc-lib/src/account_registry.rs
+++ b/crates/airc-lib/src/account_registry.rs
@@ -98,6 +98,12 @@ pub struct RegistryMergeOutcome {
 /// - per `peer_id`, the FRESHEST beacon wins (highest
 ///   `heartbeat_at_ms`, tie-broken by the carrying document's
 ///   `generated_at_ms`);
+/// - if the freshest beacon for a peer carries NO endpoints but an
+///   older beacon for the same peer does, the merged beacon keeps the
+///   freshest presence and retains the freshest NON-EMPTY endpoint
+///   set (card 4b6a0ffa / #33: an endpoint-less manual-sync document
+///   must not shadow a dialable daemon document — same doctrine as
+///   the import guard "empty beacons leave the column alone");
 /// - channels are the sorted union; `generated_at_ms` is the max of
 ///   the contributing documents.
 pub fn merge_registry_documents(
@@ -109,6 +115,11 @@ pub fn merge_registry_documents(
     let mut channels: Vec<ChannelName> = Vec::new();
     // peer_id -> (heartbeat_at_ms, doc generated_at_ms, beacon)
     let mut freshest: HashMap<airc_core::PeerId, (u64, u64, AccountPeerBeacon)> = HashMap::new();
+    // peer_id -> (heartbeat_at_ms, doc generated_at_ms, endpoints) of
+    // the freshest beacon that actually CARRIES endpoints — the
+    // backfill source when the overall-freshest beacon is endpoint-less.
+    type EndpointKey = (u64, u64, Vec<RouteEndpoint>);
+    let mut endpoint_carriers: HashMap<airc_core::PeerId, EndpointKey> = HashMap::new();
     let mut matched_any = false;
 
     for document in documents {
@@ -128,6 +139,15 @@ pub fn merge_registry_documents(
                 continue;
             }
             let key = (beacon.presence.heartbeat_at_ms, document.generated_at_ms);
+            if !beacon.endpoints.is_empty() {
+                match endpoint_carriers.get(&beacon.peer_id()) {
+                    Some((heartbeat, doc_ms, _)) if (*heartbeat, *doc_ms) >= key => {}
+                    _ => {
+                        endpoint_carriers
+                            .insert(beacon.peer_id(), (key.0, key.1, beacon.endpoints.clone()));
+                    }
+                }
+            }
             match freshest.get(&beacon.peer_id()) {
                 Some((heartbeat, doc_ms, _)) if (*heartbeat, *doc_ms) >= key => {}
                 _ => {
@@ -148,6 +168,16 @@ pub fn merge_registry_documents(
         .into_values()
         .map(|(_, _, beacon)| beacon)
         .collect();
+    // Endpoint retention (card 4b6a0ffa / #33): an endpoint-less winner
+    // (e.g. a fresher manual-sync doc) must not erase a peer's known
+    // dialable endpoints from the merged view.
+    for peer in &mut peers {
+        if peer.endpoints.is_empty() {
+            if let Some((_, _, endpoints)) = endpoint_carriers.remove(&peer.peer_id()) {
+                peer.endpoints = endpoints;
+            }
+        }
+    }
     peers.sort_by_key(|peer| peer.peer_id().to_string());
     channels.sort_by(|a, b| a.as_str().cmp(b.as_str()));
 
@@ -420,10 +450,30 @@ impl Airc {
         // layer. Stamp a fresh self-beacon (we are definitionally live: we
         // are publishing right now) carrying our dialable endpoints.
         if !document.peers.iter().any(|peer| peer.peer_id() == self_id) {
+            // Card cbbcf18d (post-#1146 audit): the stamped self-beacon's
+            // channel list comes from `self.subscriptions()` — the LOCAL
+            // single source of truth — not from presence-derived
+            // `snapshot.live_channels`. In the exact stale-self scenario
+            // this branch exists for, `live` is empty, so live_channels
+            // is [] even while this scope is subscribed; identity, key,
+            // and endpoints already follow the publisher-is-alive
+            // doctrine and the channel list must too.
+            let subscribed_channels: Vec<ChannelName> = self
+                .subscriptions()
+                .await?
+                .into_iter()
+                .map(|subscription| subscription.name)
+                .collect();
+            for channel in &subscribed_channels {
+                if !document.channels.contains(channel) {
+                    document.channels.push(channel.clone());
+                }
+            }
+            document.channels.sort_by(|a, b| a.as_str().cmp(b.as_str()));
             let presence = crate::coordinator::beacon_now(
                 self_id,
                 self.inner.home.clone(),
-                snapshot.live_channels.clone(),
+                subscribed_channels,
                 std::process::id(),
                 crate::time::now_ms()?,
             );
@@ -894,6 +944,72 @@ mod tests {
         assert!(merged.peers.iter().any(|p| p.peer_id() == only_in_old));
     }
 
+    // Card 4b6a0ffa / #33 (endpoint-less shadow): when the FRESHEST
+    // beacon for a peer carries no endpoints (the manual `registry
+    // sync` overwrite shape), the merge keeps the fresh presence but
+    // retains the freshest NON-EMPTY endpoint set from an older
+    // beacon — a first-contact reader still learns a dialable
+    // endpoint. Mutation check: removing the endpoint-retention
+    // backfill from merge_registry_documents leaves the merged beacon
+    // endpoint-less and the endpoints assert fails.
+    #[test]
+    fn merge_retains_endpoints_when_fresher_beacon_is_endpointless() {
+        let peer = PeerId::new();
+        let spec = peer_spec(peer);
+        let daemon_beacon = AccountPeerBeacon {
+            presence: crate::coordinator::beacon_now(
+                peer,
+                "/machine/a/.airc".into(),
+                vec![channel("general")],
+                123,
+                1_000,
+            ),
+            peer_spec: spec.clone(),
+            endpoints: vec![RouteEndpoint::LanTcp {
+                addr: SocketAddr::from(([10, 0, 0, 2], 7717)),
+            }],
+        };
+        let manual_sync_beacon = AccountPeerBeacon {
+            presence: crate::coordinator::beacon_now(
+                peer,
+                "/machine/a/.airc".into(),
+                vec![channel("general")],
+                456,
+                5_000,
+            ),
+            peer_spec: spec,
+            endpoints: Vec::new(),
+        };
+        let daemon_doc = AccountRegistryDocument::new(
+            mesh(),
+            2_000,
+            vec![channel("general")],
+            vec![daemon_beacon],
+        );
+        let manual_doc = AccountRegistryDocument::new(
+            mesh(),
+            6_000,
+            vec![channel("general")],
+            vec![manual_sync_beacon],
+        );
+
+        let outcome = merge_registry_documents(vec![daemon_doc, manual_doc], &mesh());
+
+        let merged = outcome.document.expect("document must merge");
+        assert_eq!(merged.peers.len(), 1);
+        assert_eq!(
+            merged.peers[0].presence.heartbeat_at_ms, 5_000,
+            "freshest presence still wins"
+        );
+        assert_eq!(
+            merged.peers[0].endpoints,
+            vec![RouteEndpoint::LanTcp {
+                addr: SocketAddr::from(([10, 0, 0, 2], 7717)),
+            }],
+            "endpoint-less fresh beacon must not erase known dialable endpoints"
+        );
+    }
+
     #[test]
     fn merge_skips_foreign_mesh_documents() {
         let peer = PeerId::new();
@@ -956,5 +1072,110 @@ mod tests {
             .stale
             .iter()
             .any(|peer| peer.peer_id == airc_a.peer_id()));
+    }
+
+    // THE KEYSTONE PIN (card cbbcf18d, post-#1146 audit — the mutation
+    // that SURVIVED). The #1146 fix stamps a fresh self-beacon into the
+    // published document when this peer's own presence heartbeat has
+    // outlived the coordinator TTL (`snapshot.stale`, NOT `live`).
+    // Every pre-existing publish-path test joined a channel immediately
+    // before publishing, keeping self coordinator-live and bypassing
+    // the fix's branch entirely — so removing the branch left all
+    // tests green. This test reproduces the bug's ACTUAL trigger:
+    // self's beacon is past-TTL at document time.
+    //
+    // Mutation checks (both verified):
+    //   1. bypass the self-insertion branch in
+    //      `account_registry_document` (`if false && …`) → the
+    //      exactly-one-self-beacon assert fails;
+    //   2. revert the stamped beacon's channels to presence-derived
+    //      `snapshot.live_channels` → the subscribed_channels assert
+    //      fails (live is empty here, subscriptions are not).
+    #[tokio::test]
+    async fn stale_self_publish_stamps_one_self_beacon_with_endpoints_and_channels() {
+        let dir = tempdir().unwrap();
+        let machine = dir.path().join("machine/.airc");
+        let wire = dir.path().join("wire");
+        write_identity(&wire).await;
+        let airc = Airc::open_with_wire_root_for_test(&machine, &wire)
+            .await
+            .unwrap();
+
+        // Subscribe (local SoT: subscriptions exist) and give self a
+        // dialable endpoint, as the daemon's registry glue does.
+        airc.join("general").await.unwrap();
+        airc.upsert_route_endpoint(RouteEndpoint::Relay {
+            url: "https://self.example.test".to_string(),
+        })
+        .unwrap();
+
+        // Overwrite self's presence with a PAST-TTL heartbeat — the
+        // registry tick landing after the heartbeat TTL, the exact
+        // trigger verified live on bigmama. heartbeat_at_ms=1_000 is
+        // ~56 years past any real `now_ms`, far beyond the 60s TTL.
+        let stale_self = crate::coordinator::beacon_now(
+            airc.peer_id(),
+            machine.clone(),
+            vec![channel("general")],
+            std::process::id(),
+            1_000,
+        );
+        crate::coordinator::publish_store(airc.coordinator_store(), &mesh(), &stale_self)
+            .await
+            .unwrap();
+
+        // Sanity: self must be STALE, not live — otherwise this test
+        // degenerates into the bypassing shape the audit flagged.
+        let snapshot = crate::coordinator::snapshot_store(
+            airc.coordinator_store(),
+            &mesh(),
+            &crate::coordinator::CoordinatorConfig::default(),
+            crate::time::now_ms().unwrap(),
+        )
+        .await
+        .unwrap();
+        assert!(
+            snapshot.live.iter().all(|p| p.peer_id != airc.peer_id()),
+            "precondition: self must NOT be coordinator-live"
+        );
+        assert!(
+            snapshot.stale.iter().any(|p| p.peer_id == airc.peer_id()),
+            "precondition: self must be in snapshot.stale"
+        );
+
+        let document = airc.account_registry_document().await.unwrap();
+
+        let self_beacons: Vec<_> = document
+            .peers
+            .iter()
+            .filter(|peer| peer.peer_id() == airc.peer_id())
+            .collect();
+        assert_eq!(
+            self_beacons.len(),
+            1,
+            "stale-self publish must stamp exactly one self-beacon"
+        );
+        let self_beacon = self_beacons[0];
+        let expected_endpoints = airc.route_endpoints().unwrap();
+        assert!(
+            !expected_endpoints.is_empty(),
+            "precondition: this handle has endpoints to advertise"
+        );
+        assert_eq!(
+            self_beacon.endpoints, expected_endpoints,
+            "self-beacon must carry route_endpoints()"
+        );
+        // Card cbbcf18d item 2: channels from the LOCAL SoT
+        // (self.subscriptions()), not presence-derived live_channels
+        // (empty in this exact scenario).
+        assert_eq!(
+            self_beacon.presence.subscribed_channels,
+            vec![channel("general")],
+            "stamped self-beacon channels must come from self.subscriptions()"
+        );
+        assert!(
+            document.channels.contains(&channel("general")),
+            "document channels must include the local subscriptions"
+        );
     }
 }

--- a/crates/airc-lib/src/gh_account_registry.rs
+++ b/crates/airc-lib/src/gh_account_registry.rs
@@ -1109,5 +1109,66 @@ exit 0
                 "freshest beacon wins"
             );
         }
+
+        // Card 4b6a0ffa item 1 (post-#1146 audit): refresh is a UNION
+        // across per-machine writer gists, exactly as the module doc
+        // promises — a peer present only in an OLDER writer's document
+        // (with its endpoints) survives a refresh even when a newer
+        // writer's document lacks it. Mutation check: reverting
+        // `refresh` to pick the single newest document drops peer A
+        // entirely and both asserts fail.
+        #[tokio::test]
+        async fn refresh_unions_peers_across_writer_gists_keeping_endpoints() {
+            let dir = tempfile::tempdir().unwrap();
+            let stub = StubGh::install(dir.path());
+            let store = store_at(&stub, &dir.path().join("db"), "/machine/prod/.airc").await;
+
+            let peer_a = beacon_for(
+                PeerId::new(),
+                "/machine/a/.airc",
+                1_000,
+                "https://machine-a.example.test",
+            );
+            let peer_b = beacon_for(
+                PeerId::new(),
+                "/machine/b/.airc",
+                5_000,
+                "https://machine-b.example.test",
+            );
+
+            // Older writer gist carries peer A (with endpoints); the
+            // NEWER writer gist does not mention A at all.
+            stub.seed_gist(
+                "older-writer",
+                "airc-account-mesh-registry.older-machine.json",
+                &document(2_000, vec![peer_a.clone()]),
+            );
+            stub.seed_gist(
+                "newer-writer",
+                "airc-account-mesh-registry.newer-machine.json",
+                &document(6_000, vec![peer_b.clone()]),
+            );
+
+            let merged = store
+                .refresh(&mesh())
+                .await
+                .unwrap()
+                .expect("documents must merge");
+
+            assert_eq!(
+                merged.peers.len(),
+                2,
+                "refresh must union per-machine documents, not pick the newest"
+            );
+            let merged_a = merged
+                .peers
+                .iter()
+                .find(|peer| peer.peer_id() == peer_a.peer_id())
+                .expect("peer A from the older writer must survive the merge");
+            assert_eq!(
+                merged_a.endpoints, peer_a.endpoints,
+                "peer A's dialable endpoints must survive the merge"
+            );
+        }
     }
 }

--- a/crates/airc-lib/src/registry_refresh.rs
+++ b/crates/airc-lib/src/registry_refresh.rs
@@ -123,8 +123,12 @@ impl std::fmt::Display for GateBlock {
 impl RegistryRefreshGate {
     /// Returns `None` if a tick should proceed, or the reason it must
     /// not. The hermetic gate is checked FIRST: a hermetic scope must
-    /// not even probe `gh auth status`.
-    async fn block(&self) -> Option<GateBlock> {
+    /// not even probe `gh auth status`. Public so the manual `registry
+    /// sync` CLI verb can order its checks intentionally: gate first,
+    /// THEN the dialable-endpoint requirement (card 4b6a0ffa / #33) —
+    /// a gh-unauthed box must hear "gh not ready", not a misleading
+    /// endpoint refusal.
+    pub async fn block(&self) -> Option<GateBlock> {
         match self {
             RegistryRefreshGate::GhAuth { gh_bin, scope_home } => {
                 if let Some(block) = crate::gh_account_registry::account_registry_block(scope_home)

--- a/crates/airc-lib/src/route/invite.rs
+++ b/crates/airc-lib/src/route/invite.rs
@@ -208,7 +208,13 @@ impl Airc {
         Ok(Some(beacon))
     }
 
-    pub(crate) fn upsert_route_endpoint(&self, endpoint: RouteEndpoint) -> Result<(), AircError> {
+    /// Record an endpoint this handle advertises (one slot per
+    /// endpoint kind, latest wins). Public since card 4b6a0ffa (#33):
+    /// the manual `registry sync` CLI seeds its short-lived handle
+    /// with the DAEMON's read-back endpoints before publishing, so
+    /// the account beacon carries a dialable address instead of an
+    /// endpoint-less overwrite.
+    pub fn upsert_route_endpoint(&self, endpoint: RouteEndpoint) -> Result<(), AircError> {
         self.inner.route_endpoints.upsert(endpoint);
         Ok(())
     }


### PR DESCRIPTION
## Registry: stale-self publish pins + convergence + dialable manual sync

Cards (one PR, sibling P1s touching the same registry files):
- `cbbcf18d-f1cf-4378-adb8-9885148397d3` — registry: pin the stale-self publish path + self-beacon channels from local SoT (post-#1146 audit — mutation SURVIVED)
- `4b6a0ffa-3266-4dce-a572-1d5a83e94f9d` — registry convergence: union-merge across per-machine gists + manual sync publishes a dialable endpoint (#33 closure)

Source: #1146 post-merge audit (review of record), https://github.com/CambrianTech/airc/pull/1146#issuecomment-4686802126

### Item 1 — pin the stale-self publish path (the keystone fix had NO failing test)
`account_registry.rs::stale_self_publish_stamps_one_self_beacon_with_endpoints_and_channels`: joins a channel, then OVERWRITES self's presence beacon with a past-TTL heartbeat so self lands in `snapshot.stale` (asserted as a precondition — every prior test kept self coordinator-live and bypassed the #1146 branch). Asserts `account_registry_document()` carries exactly one self-beacon with `route_endpoints()`.

### Item 2 — self-beacon `subscribed_channels` from local SoT
The stamped self-beacon now derives its channel list from `self.subscriptions()` (local single source of truth) instead of presence-derived `snapshot.live_channels` (empty in the exact stale-self scenario). The document's `channels` union also picks up the local subscriptions. Pinned in the same test.

### Item 3 — registry convergence (union-merge across per-machine gists)
`GhAccountRegistryStore::refresh` already union-merges via `merge_registry_documents` since #1150; this PR adds the missing cross-writer pin (`refresh_unions_peers_across_writer_gists_keeping_endpoints`: peer present only in an OLDER writer's gist survives, with endpoints — fails if refresh reverts to newest-only) and EXTENDS the merger with endpoint retention: per peer, the freshest beacon still wins presence, but if it is endpoint-less the freshest NON-EMPTY endpoint set is retained (`merge_retains_endpoints_when_fresher_beacon_is_endpointless`). This closes the "endpoint-less manual-sync doc shadows a good daemon doc" half of #33 on the READER side, mirroring the import guard's "empty beacons leave the column alone" doctrine.

### Item 4 — manual `airc registry sync` publishes a DIALABLE endpoint (#33 closure)
The CLI verb used to open a listener-less handle and overwrite this machine's gist with `endpoints: []`. Binding a LAN listener in the CLI would be worse — it would advertise a port that dies with the process (flagged by the 5090). Instead:
- new typed IPC verb `Request::RouteEndpoints` → `Response::RouteEndpoints { endpoints: Vec<IpcRouteEndpoint> }` (wire bytes pinned as literal JSON on both sides; `IpcRouteEndpoint` mirrors `airc_lib::RouteEndpoint` exactly, with `SocketAddr` explicitly pinned to its string form so the CBOR frame codec round-trips it);
- the daemon's registry glue records its post-`listen_lan` `route_endpoints()` into `DaemonState.route_endpoints` for IPC read-back;
- `airc registry sync` probes the daemon and publishes the daemon's LIVE endpoints; if no daemon answers (not running / pre-verb) or it advertises none, the sync REFUSES the endpoint-less overwrite with an actionable message — publish only happens with `--allow-endpointless` named explicitly. No silent endpoint-less publishes.
- gate ordering is intentional: hermetic/gh-auth gate first, endpoint requirement second, so a gh-unauthed box hears the right reason.

### Mutation evidence (all run locally, break → fail → restore)
| # | Mutation | Test that failed |
|---|----------|------------------|
| A | bypass self-insertion branch in `account_registry_document` (`if false && …`) | `stale_self_publish_stamps_one_self_beacon_with_endpoints_and_channels` ("must stamp exactly one self-beacon") |
| B | revert stamped channels to `snapshot.live_channels.clone()` | same test ("channels must come from self.subscriptions()") |
| C | disable endpoint-retention backfill in `merge_registry_documents` | `merge_retains_endpoints_when_fresher_beacon_is_endpointless` |
| D | revert `GhAccountRegistryStore::refresh` to single-newest-document | `refresh_unions_peers_across_writer_gists_keeping_endpoints` |
| E | refusal arm returns `Ok(vec![])` instead of refusing | `refuses_endpointless_publish_without_override` + `refuses_when_daemon_is_up_but_endpointless` |
| F | handler serves hardcoded `Vec::new()` instead of `state.route_endpoints` | `daemon_serves_recorded_route_endpoints` (live daemon over real socket) |

### Gates
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm` — clean
- `cargo test --workspace -- --skip codex_hook` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
