### PR TITLE
fix(transport): advertise the Tailscale endpoint, not LAN — reach-anywhere mesh

### DIFF
--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1099,30 +1099,37 @@ pub async fn run_daemon(
         // routable LAN (or a bind failure) still reaches the mesh by
         // dialing OUT to listening peers / relay — it just isn't
         // dialable itself, which we say plainly rather than swallow.
-        match crate::network_commands::detect_lan_ip() {
-            Some(lan_ip) => {
-                match airc
-                    .listen_lan(std::net::SocketAddr::from((lan_ip, 0)))
-                    .await
-                {
+        // Prefer the Tailscale endpoint over LAN. Every node on the same
+        // gh account is on the Tailscale mesh, so a 100.x address is
+        // dialable from ANY network and traverses NAT/firewalls, whereas a
+        // 192.168.x LAN address only works same-subnet and dies behind a
+        // firewall (the cross-machine keystone failure: nodes advertised
+        // LAN-only and could enrol each other but never connect). Fall back
+        // to LAN when Tailscale is down.
+        let advertise = crate::network_commands::detect_tailscale_ip()
+            .map(|ip| (ip, "Tailscale"))
+            .or_else(|| crate::network_commands::detect_lan_ip().map(|ip| (ip, "LAN")));
+        match advertise {
+            Some((ip, kind)) => {
+                match airc.listen_lan(std::net::SocketAddr::from((ip, 0))).await {
                     Ok(addr) => {
                         eprintln!(
-                            "airc daemon: advertising LAN endpoint {addr} in the account registry"
+                            "airc daemon: advertising {kind} endpoint {addr} in the account registry"
                         );
                     }
                     Err(error) => {
                         eprintln!(
-                            "airc daemon: LAN listener bind failed ({error}) — account beacon \
-                             carries no LAN endpoint; this node reaches the mesh by dialing out \
-                             / relay but is not itself dialable on LAN"
+                            "airc daemon: {kind} listener bind failed ({error}) — account beacon \
+                             carries no endpoint; this node reaches the mesh by dialing out / \
+                             relay but is not itself dialable"
                         );
                     }
                 }
             }
             None => {
                 eprintln!(
-                    "airc daemon: no routable LAN IPv4 detected — account beacon carries no LAN \
-                     endpoint (outbound-dial / relay only)"
+                    "airc daemon: no Tailscale or routable LAN IPv4 detected — account beacon \
+                     carries no endpoint (outbound-dial / relay only)"
                 );
             }
         }

--- a/crates/airc-cli/src/network_commands.rs
+++ b/crates/airc-cli/src/network_commands.rs
@@ -25,6 +25,33 @@ fn is_routable_lan_ipv4(ip: Ipv4Addr) -> bool {
     !ip.is_loopback() && !ip.is_unspecified()
 }
 
+/// Best-effort Tailscale IPv4 (the host's `100.64.0.0/10` CGNAT address),
+/// if a Tailscale interface is up. Same source-address trick as
+/// `detect_lan_ip`, but aimed at Tailscale's MagicDNS resolver
+/// (`100.100.100.100`) — an address only routable over the Tailscale
+/// interface, so the OS selects that interface and `local_addr()` reveals
+/// our `100.x`. Returns `None` when Tailscale is down (the OS falls back to
+/// the LAN interface, whose IP fails the CGNAT check).
+///
+/// The daemon prefers this over the LAN IP for its advertised endpoint:
+/// every node on the same gh-account mesh is on Tailscale, so a `100.x`
+/// endpoint is dialable from ANY network and traverses NAT/firewalls, while
+/// a `192.168.x` endpoint only works same-subnet and dies behind a firewall.
+pub(crate) fn detect_tailscale_ip() -> Option<Ipv4Addr> {
+    let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).ok()?;
+    socket.connect((Ipv4Addr::new(100, 100, 100, 100), 80)).ok()?;
+    match socket.local_addr().ok()?.ip() {
+        IpAddr::V4(ip) if is_tailscale_ipv4(ip) => Some(ip),
+        IpAddr::V4(_) | IpAddr::V6(_) => None,
+    }
+}
+
+/// Tailscale's CGNAT range is `100.64.0.0/10` (100.64.0.0 – 100.127.255.255).
+fn is_tailscale_ipv4(ip: Ipv4Addr) -> bool {
+    let o = ip.octets();
+    o[0] == 100 && (64..=127).contains(&o[1])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -34,5 +61,17 @@ mod tests {
         assert!(!is_routable_lan_ipv4(Ipv4Addr::LOCALHOST));
         assert!(!is_routable_lan_ipv4(Ipv4Addr::UNSPECIFIED));
         assert!(is_routable_lan_ipv4(Ipv4Addr::new(192, 168, 1, 2)));
+    }
+
+    #[test]
+    fn tailscale_filter_matches_cgnat_range_only() {
+        // In-range (100.64.0.0/10)
+        assert!(is_tailscale_ipv4(Ipv4Addr::new(100, 79, 156, 3)));
+        assert!(is_tailscale_ipv4(Ipv4Addr::new(100, 64, 0, 0)));
+        assert!(is_tailscale_ipv4(Ipv4Addr::new(100, 127, 255, 255)));
+        // Out of range
+        assert!(!is_tailscale_ipv4(Ipv4Addr::new(100, 63, 0, 1))); // below
+        assert!(!is_tailscale_ipv4(Ipv4Addr::new(100, 128, 0, 1))); // above
+        assert!(!is_tailscale_ipv4(Ipv4Addr::new(192, 168, 1, 2))); // LAN
     }
 }


### PR DESCRIPTION
## The cross-machine keystone, root cause

The daemon advertised **only its LAN IP** — `detect_lan_ip()` does a default-route source lookup, which returns `192.168.x`. It never advertised the Tailscale `100.x`, even though `RouteEndpoint::TailscaleTcp` is already a defined type and **every node on a same-gh-account mesh is on Tailscale.**

A `192.168.x` endpoint only works same-subnet and dies behind a firewall. So nodes enrolled each other via the gist rendezvous but **could never connect cross-machine** — "publishing peer_ids nobody can dial." That's the keystone failure the team's been chasing; it's not a firewall problem, it's advertising the wrong address.

## Fix

- `detect_tailscale_ip()` — same source-address trick as `detect_lan_ip`, aimed at Tailscale's MagicDNS `100.100.100.100` (routable only over the Tailscale interface); validated against the `100.64.0.0/10` CGNAT range. Returns `None` when Tailscale is down → clean LAN fallback.
- Daemon **prefers the Tailscale endpoint** over LAN. A `100.x` address is dialable from any network and traverses NAT/firewalls — so no firewall rule and no at-box setup is ever needed (the resilient design: same gh account = discovery, Tailscale = transport).

## Tested
- Unit test: CGNAT-range filter (`tailscale_filter_matches_cgnat_range_only`).
- Runtime on bigmama (Windows, behind a firewall): `Find-NetRoute 100.100.100.100` → source `100.79.156.3` (this host's Tailscale IP), vs `8.8.8.8` → `192.168.1.232`. So the daemon now advertises `100.79.156.3:port`, dialable from any node on the mesh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)