### PR TITLE
fix(transport): delivery acks + loud undeliverable diagnostics for lan-send silent drops (card 39d37629)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,7 @@ name = "airc-transport"
 version = "0.1.0"
 dependencies = [
  "airc-core",
+ "airc-diagnostics",
  "airc-protocol",
  "async-trait",
  "ed25519-dalek",

--- a/crates/airc-cli/src/cli.rs
+++ b/crates/airc-cli/src/cli.rs
@@ -452,8 +452,10 @@ pub enum Command {
         replay: bool,
     },
 
-    /// Same-LAN secure send: dial a peer over TLS and send a single
-    /// text frame to the current room's channel.
+    /// Same-LAN secure send: dial a peer over TLS, send a single
+    /// text frame to the current room's channel, and wait for the
+    /// receiver's typed delivery ack (card 39d37629). Exit 0 only on
+    /// `delivered`; undeliverable or no-ack outcomes exit nonzero.
     LanSend {
         /// Address of the listening peer (e.g. `127.0.0.1:7474`).
         #[arg(long)]
@@ -461,6 +463,10 @@ pub enum Command {
         /// UUID of the listening peer (for cert pinning).
         #[arg(long)]
         expected_peer: String,
+        /// How long to wait for the receiver's delivery ack before
+        /// reporting no-ack (older receivers never ack).
+        #[arg(long, default_value_t = 10_000)]
+        ack_timeout_ms: u64,
         /// Message body.
         text: String,
     },

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1162,22 +1162,20 @@ pub async fn run_daemon(
             .map(|ip| (ip, "Tailscale"))
             .or_else(|| crate::network_commands::detect_lan_ip().map(|ip| (ip, "LAN")));
         match advertise {
-            Some((ip, kind)) => {
-                match airc.listen_lan(std::net::SocketAddr::from((ip, 0))).await {
-                    Ok(addr) => {
-                        eprintln!(
-                            "airc daemon: advertising {kind} endpoint {addr} in the account registry"
-                        );
-                    }
-                    Err(error) => {
-                        eprintln!(
-                            "airc daemon: {kind} listener bind failed ({error}) — account beacon \
+            Some((ip, kind)) => match airc.listen_lan(std::net::SocketAddr::from((ip, 0))).await {
+                Ok(addr) => {
+                    eprintln!(
+                        "airc daemon: advertising {kind} endpoint {addr} in the account registry"
+                    );
+                }
+                Err(error) => {
+                    eprintln!(
+                        "airc daemon: {kind} listener bind failed ({error}) — account beacon \
                              carries no endpoint; this node reaches the mesh by dialing out / \
                              relay but is not itself dialable"
-                        );
-                    }
+                    );
                 }
-            }
+            },
             None => {
                 eprintln!(
                     "airc daemon: no Tailscale or routable LAN IPv4 detected — account beacon \

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -873,12 +873,22 @@ pub async fn run_listen(
 }
 
 /// `lan-send` — TLS-wrapped single-shot send to a remote peer, on
-/// the current room's channel.
+/// the current room's channel, with a delivery-ack wait.
+///
+/// Card 39d37629: "sent" used to mean "bytes flushed to the TLS
+/// socket" — a receiver could accept the frame and silently lose it
+/// before transcript persistence (live repro 2026-06-12 02:36Z: 5090
+/// → mac printed "sent over lan-tcp to general", exit 0; the frame
+/// reached NO store on the receiving machine). The verb now requests
+/// a typed ack that the receiver emits only AFTER its persistence
+/// decision, waits up to `ack_timeout_ms`, prints the typed outcome,
+/// and exits nonzero for anything that is not `delivered`.
 pub async fn run_lan_send(
     home: &Path,
     peers: Vec<PeerSpec>,
     to: std::net::SocketAddr,
     expected_peer: PeerId,
+    ack_timeout_ms: u64,
     text: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Card bf7c30e2: fail FAST with a self-diagnosing error before
@@ -905,12 +915,54 @@ pub async fn run_lan_send(
     preflight_expected_peer(&airc, home, &peers, expected_peer).await?;
     let current = airc.current_room().await?;
     airc.connect_lan(to, expected_peer).await?;
-    airc.say_with_headers(text, runtime_headers()?).await?;
-    println!(
-        "sent over lan-tcp to {} ({}).",
-        current.name, current.channel
-    );
-    Ok(())
+    let timeout = std::time::Duration::from_millis(ack_timeout_ms);
+    let outcome = airc
+        .send_with_delivery_ack(text, runtime_headers()?, timeout)
+        .await?;
+    match outcome {
+        airc_lib::DeliverySendOutcome::Delivered { event_id, ack } => {
+            match ack.outcome {
+                airc_lib::DeliveryOutcome::Delivered { channel, cursor } => {
+                    println!(
+                        "delivered over lan-tcp to {} ({channel}) — receiver {} persisted \
+                         event {event_id} at lamport {}.",
+                        current.name, ack.receiver, cursor.lamport
+                    );
+                }
+                // `DeliverySendOutcome::Delivered` is constructed only
+                // from a Delivered ack; keep the match honest anyway.
+                airc_lib::DeliveryOutcome::Undeliverable { reason } => {
+                    return Err(format!(
+                        "internal: delivered outcome carried undeliverable ack ({})",
+                        reason.as_str()
+                    )
+                    .into());
+                }
+            }
+            Ok(())
+        }
+        airc_lib::DeliverySendOutcome::Undeliverable { event_id, ack } => {
+            let reason = match ack.outcome {
+                airc_lib::DeliveryOutcome::Undeliverable { reason } => reason.as_str(),
+                airc_lib::DeliveryOutcome::Delivered { .. } => "unknown",
+            };
+            Err(format!(
+                "NOT delivered: receiver {} reports event {event_id} undeliverable \
+                 (reason: {reason}). The frame was accepted on the wire but will not \
+                 appear in the receiving scope's {} transcript.",
+                ack.receiver, current.name
+            )
+            .into())
+        }
+        airc_lib::DeliverySendOutcome::NoAck { event_id, waited } => Err(format!(
+            "NOT confirmed: no delivery ack for event {event_id} within {}ms. The frame \
+             was flushed to the wire, but the receiver never confirmed persistence — it \
+             may be running an older build (which never acks) or it dropped the frame. \
+             Treat as undelivered.",
+            waited.as_millis()
+        )
+        .into()),
+    }
 }
 
 /// Card bf7c30e2: verify `expected_peer` is known to the SAME trust

--- a/crates/airc-cli/src/main.rs
+++ b/crates/airc-cli/src/main.rs
@@ -351,10 +351,11 @@ async fn dispatch(parsed: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::LanSend {
             to,
             expected_peer,
+            ack_timeout_ms,
             text,
         } => {
             let expected = parse_peer_id(&expected_peer)?;
-            commands::run_lan_send(&home, parsed.peers, to, expected, &text).await
+            commands::run_lan_send(&home, parsed.peers, to, expected, ack_timeout_ms, &text).await
         }
 
         Command::LanListen { bind, replay } => {

--- a/crates/airc-cli/src/network_commands.rs
+++ b/crates/airc-cli/src/network_commands.rs
@@ -39,7 +39,9 @@ fn is_routable_lan_ipv4(ip: Ipv4Addr) -> bool {
 /// a `192.168.x` endpoint only works same-subnet and dies behind a firewall.
 pub(crate) fn detect_tailscale_ip() -> Option<Ipv4Addr> {
     let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).ok()?;
-    socket.connect((Ipv4Addr::new(100, 100, 100, 100), 80)).ok()?;
+    socket
+        .connect((Ipv4Addr::new(100, 100, 100, 100), 80))
+        .ok()?;
     match socket.local_addr().ok()?.ip() {
         IpAddr::V4(ip) if is_tailscale_ipv4(ip) => Some(ip),
         IpAddr::V4(_) | IpAddr::V6(_) => None,

--- a/crates/airc-diagnostics/src/lib.rs
+++ b/crates/airc-diagnostics/src/lib.rs
@@ -70,6 +70,19 @@ pub enum DiagnosticCode {
     /// an outbound route-discovery dial. Offline peers are normal mesh
     /// weather — but every failed dial attempt must be visible.
     PeerDialFailed,
+    /// Card 39d37629: an accepted inbound frame could not be routed /
+    /// persisted into a bound room transcript (unknown channel, store
+    /// append failure, decode failure, verification failure, or no
+    /// attached subscriber). Every such frame MUST emit this — silent
+    /// drops between transport accept and transcript persistence are
+    /// the bug class this code makes impossible.
+    FrameUndeliverable,
+    /// Card 39d37629: a delivery-ack response could not be written
+    /// back to the requesting sender (no live connection, dead
+    /// socket). The frame's own fate was already decided and logged;
+    /// this only means the SENDER sees an ack timeout instead of the
+    /// typed outcome.
+    DeliveryAckSendFailed,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -206,7 +206,21 @@ pub(crate) struct AircInner {
     /// share it and the equality check would (incorrectly) suppress
     /// the cross-process peer's frames as "our own."
     pub(crate) recently_broadcast: std::sync::Mutex<BroadcastDeduper>,
+    /// Card 39d37629: in-process fan-out of delivery-ack responses.
+    /// Ack frames are intercepted by `append_received_frame` BEFORE
+    /// persistence (they are receipts, not transcript content) and
+    /// published here for `send_with_delivery_ack` waiters.
+    pub(crate) ack_tx: broadcast::Sender<airc_protocol::DeliveryAck>,
+    /// Card 39d37629: where receive-path diagnostics land. Defaults to
+    /// stderr JSON; tests inject a `MemoryDiagnosticSink` so "the
+    /// diagnostic fired" is a hard assertion, not a log-scrape.
+    pub(crate) diag_sink: std::sync::RwLock<Arc<dyn airc_diagnostics::DiagnosticSink>>,
 }
+
+/// Capacity of the delivery-ack fan-out channel. Acks are tiny,
+/// short-lived, and consumed by at most a handful of in-flight
+/// `send_with_delivery_ack` waiters; lag just drops stale receipts.
+pub(crate) const ACK_BROADCAST_CAPACITY: usize = 64;
 
 /// Capacity of the recently-broadcast ring. Sized to a multiple of
 /// [`LIVE_BROADCAST_CAPACITY`] so even a maximally-lagging consumer
@@ -422,6 +436,10 @@ impl Airc {
                 recently_broadcast: std::sync::Mutex::new(BroadcastDeduper::with_capacity(
                     RECENTLY_BROADCAST_CAPACITY,
                 )),
+                ack_tx: broadcast::channel(ACK_BROADCAST_CAPACITY).0,
+                diag_sink: std::sync::RwLock::new(Arc::new(
+                    airc_diagnostics::StderrJsonDiagnosticSink,
+                )),
             }),
         })
     }
@@ -435,6 +453,32 @@ impl Airc {
             Err(poisoned) => poisoned.into_inner(),
         };
         ring.mark(event_id)
+    }
+
+    /// Replace the diagnostic sink used by this handle's receive
+    /// path (card 39d37629). Production keeps the stderr-JSON
+    /// default; tests inject a `MemoryDiagnosticSink` to assert that
+    /// undeliverable frames emit a typed diagnostic — making the
+    /// "suppress the diagnostic" mutation a test failure.
+    pub fn set_diagnostic_sink(&self, sink: Arc<dyn airc_diagnostics::DiagnosticSink>) {
+        let mut guard = match self.inner.diag_sink.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *guard = sink;
+    }
+
+    pub(crate) fn diag_sink(&self) -> Arc<dyn airc_diagnostics::DiagnosticSink> {
+        let guard = match self.inner.diag_sink.read() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        guard.clone()
+    }
+
+    /// Emit a diagnostic through this handle's configured sink.
+    pub(crate) fn emit_diag(&self, event: airc_diagnostics::DiagnosticEvent) {
+        self.diag_sink().emit(event);
     }
 
     /// Return the home directory backing this handle.
@@ -850,6 +894,8 @@ impl Airc {
             recently_broadcast: std::sync::Mutex::new(BroadcastDeduper::with_capacity(
                 RECENTLY_BROADCAST_CAPACITY,
             )),
+            ack_tx: self.inner.ack_tx.clone(),
+            diag_sink: std::sync::RwLock::new(self.diag_sink()),
         };
         Self {
             inner: Arc::new(inner),

--- a/crates/airc-lib/src/delivery_ack.rs
+++ b/crates/airc-lib/src/delivery_ack.rs
@@ -1,0 +1,296 @@
+//! Delivery-ack send + respond surface (card 39d37629).
+//!
+//! The receiving half lives in `transport.rs::append_received_frame`
+//! (interception of ack responses, ack emission after the persistence
+//! decision); this module owns:
+//!
+//!   - [`Airc::send_with_delivery_ack`] — the sender verb: request an
+//!     ack on an ordinary send, wait (bounded) for the typed receipt;
+//!   - [`Airc::conclude_delivery_ack`] / [`Airc::respond_delivery_ack`]
+//!     — the receiver-side helpers that decide delivered vs
+//!     undeliverable AFTER persistence and write the signed ack back
+//!     over the point-to-point LAN connection.
+//!
+//! Routed daemon sends are untouched: nothing here runs unless the
+//! inbound frame carries the `airc.delivery_ack: request` header,
+//! which only the ack-requesting verb sets.
+
+use std::time::Duration;
+
+use airc_core::{Body, EventId, Headers, PeerId, RoomId, TranscriptCursor};
+use airc_diagnostics::{DiagnosticCode, DiagnosticComponent, DiagnosticEvent};
+use airc_protocol::{
+    DeliveryAck, DeliveryOutcome, Envelope, Frame, FrameKind, Signature, UndeliverableReason,
+    DELIVERY_ACK_REQUEST, DELIVERY_ACK_RESPONSE, HEADER_AIRC_DELIVERY_ACK,
+};
+
+use crate::error::AircError;
+use crate::time::now_ms;
+use crate::Airc;
+
+/// Typed outcome of an ack-requesting send, as seen by the SENDER.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeliverySendOutcome {
+    /// The receiver persisted the frame into a bound room transcript
+    /// and said so. `ack.outcome` carries the channel + cursor.
+    Delivered { event_id: EventId, ack: DeliveryAck },
+    /// The receiver accepted the frame but reported it undeliverable
+    /// (unknown channel, persist failure, ...).
+    Undeliverable { event_id: EventId, ack: DeliveryAck },
+    /// No ack arrived within the timeout. Distinct from undeliverable:
+    /// the receiver may be running an older build (which never acks)
+    /// or may have dropped the frame — the sender cannot tell, and
+    /// MUST NOT claim delivery.
+    NoAck { event_id: EventId, waited: Duration },
+}
+
+impl Airc {
+    /// Send `text` to the current room requesting a delivery ack, and
+    /// wait up to `timeout` for the receiver's typed receipt.
+    ///
+    /// This is the `lan-send` verb's contract fix (card 39d37629):
+    /// "sent" used to mean "bytes flushed to the TLS socket", which a
+    /// receiver could accept and then silently lose before transcript
+    /// persistence (live repro 2026-06-12 02:36Z). With this verb the
+    /// sender's outcome is `Delivered` only when the receiver persisted
+    /// the frame on a bound channel — anything else is loud and typed.
+    ///
+    /// Scope: the point-to-point verb path (a direct `Airc::open`
+    /// handle with a live `connect_lan` link, as `lan-send` builds).
+    /// On a daemon-attached handle the ingest — and therefore the ack
+    /// interception — happens in the daemon process, so this method
+    /// would always report `NoAck`; routed-ack is a follow-up card.
+    pub async fn send_with_delivery_ack(
+        &self,
+        text: &str,
+        mut headers: Headers,
+        timeout: Duration,
+    ) -> Result<DeliverySendOutcome, AircError> {
+        // Subscribe BEFORE sending so an ack racing back faster than
+        // this task resumes cannot be missed (broadcast receivers see
+        // only what is sent after they exist).
+        let mut ack_rx = self.inner.ack_tx.subscribe();
+        headers.insert(
+            HEADER_AIRC_DELIVERY_ACK.to_string(),
+            DELIVERY_ACK_REQUEST.to_string(),
+        );
+        let event_id = self.send(Body::text(text), headers).await?;
+
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let ack = match tokio::time::timeout_at(deadline, ack_rx.recv()).await {
+                Err(_elapsed) => {
+                    return Ok(DeliverySendOutcome::NoAck {
+                        event_id,
+                        waited: timeout,
+                    });
+                }
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
+                    return Ok(DeliverySendOutcome::NoAck {
+                        event_id,
+                        waited: timeout,
+                    });
+                }
+                Ok(Ok(ack)) => ack,
+            };
+            if ack.for_event != event_id {
+                continue;
+            }
+            return Ok(match ack.outcome {
+                DeliveryOutcome::Delivered { .. } => {
+                    DeliverySendOutcome::Delivered { event_id, ack }
+                }
+                DeliveryOutcome::Undeliverable { .. } => {
+                    DeliverySendOutcome::Undeliverable { event_id, ack }
+                }
+            });
+        }
+    }
+
+    /// Receiver side, after a successful persist: decide delivered vs
+    /// unknown-channel and send the receipt. "Delivered" requires the
+    /// frame's channel to be BOUND in this scope's subscription set —
+    /// a frame persisted onto a channel no local transcript surface
+    /// reads is exactly the invisible-delivery failure the live repro
+    /// hit, so it is reported as undeliverable{unknown_channel} (the
+    /// event itself stays persisted in case the channel is bound
+    /// later; the diagnostic says so).
+    pub(crate) async fn conclude_delivery_ack(
+        &self,
+        origin: PeerId,
+        for_event: EventId,
+        channel: RoomId,
+        cursor: TranscriptCursor,
+    ) {
+        let bound = match self.subscription_set().await {
+            Ok(set) => set.all().any(|sub| sub.room_id == channel),
+            Err(error) => {
+                // Can't read the subscription set ⇒ can't honestly
+                // claim the channel is bound. Loud + undeliverable.
+                self.emit_diag(
+                    DiagnosticEvent::error(
+                        DiagnosticComponent::Subscriber,
+                        DiagnosticCode::FrameUndeliverable,
+                        "subscription set unreadable while concluding delivery ack",
+                    )
+                    .with_field("reason", UndeliverableReason::UnknownChannel.as_str())
+                    .with_field("event_id", for_event)
+                    .with_field("error", error),
+                );
+                false
+            }
+        };
+        if bound {
+            self.respond_delivery_ack(
+                origin,
+                for_event,
+                channel,
+                DeliveryOutcome::Delivered { channel, cursor },
+            )
+            .await;
+        } else {
+            self.emit_diag(
+                DiagnosticEvent::error(
+                    DiagnosticComponent::Subscriber,
+                    DiagnosticCode::FrameUndeliverable,
+                    "accepted frame addressed to a channel this scope has not bound — \
+                     persisted but no local transcript surface will show it",
+                )
+                .with_field("reason", UndeliverableReason::UnknownChannel.as_str())
+                .with_field("event_id", for_event)
+                .with_field("sender", origin)
+                .with_field("channel", channel)
+                .with_field("persisted", true),
+            );
+            self.respond_delivery_ack(
+                origin,
+                for_event,
+                channel,
+                DeliveryOutcome::Undeliverable {
+                    reason: UndeliverableReason::UnknownChannel,
+                },
+            )
+            .await;
+        }
+    }
+
+    /// Build, sign, and unicast a delivery-ack response back to the
+    /// requesting sender over the LAN connection the frame arrived on
+    /// (point-to-point verb path). Failure to send the ack is itself
+    /// loud — the frame's fate was already decided and logged; the
+    /// sender will see an ack timeout instead of the typed outcome.
+    pub(crate) async fn respond_delivery_ack(
+        &self,
+        origin: PeerId,
+        for_event: EventId,
+        channel: RoomId,
+        outcome: DeliveryOutcome,
+    ) {
+        let ack = DeliveryAck {
+            for_event,
+            receiver: self.inner.identity.peer_id,
+            outcome,
+        };
+        let body_json = match serde_json::to_value(&ack) {
+            Ok(value) => value,
+            Err(error) => {
+                self.emit_diag(
+                    DiagnosticEvent::error(
+                        DiagnosticComponent::Subscriber,
+                        DiagnosticCode::DeliveryAckSendFailed,
+                        "delivery ack body did not encode",
+                    )
+                    .with_field("for_event", for_event)
+                    .with_field("error", error),
+                );
+                return;
+            }
+        };
+        let occurred_at_ms = match now_ms() {
+            Ok(ms) => ms,
+            Err(error) => {
+                self.emit_diag(
+                    DiagnosticEvent::error(
+                        DiagnosticComponent::Subscriber,
+                        DiagnosticCode::DeliveryAckSendFailed,
+                        "clock unavailable while building delivery ack",
+                    )
+                    .with_field("for_event", for_event)
+                    .with_field("error", error),
+                );
+                return;
+            }
+        };
+        let mut headers = Headers::new();
+        headers.insert(
+            HEADER_AIRC_DELIVERY_ACK.to_string(),
+            DELIVERY_ACK_RESPONSE.to_string(),
+        );
+        let lamport = self.next_lamport(occurred_at_ms);
+        let mut frame = Frame {
+            kind: FrameKind::Control,
+            envelope: Envelope {
+                event_id: EventId::new(),
+                sender: self.inner.identity.peer_id,
+                sender_client: self.inner.identity.client_id,
+                channel,
+                target: airc_core::transcript::MentionTarget::Peer(origin),
+                lamport,
+                occurred_at_ms,
+                reply_to: None,
+                headers,
+                body: Some(Body::Json(body_json)),
+                media: Vec::new(),
+                signature: Signature::Unsigned,
+            },
+        };
+        frame.envelope.signature = match self.inner.identity.keypair.sign_envelope(
+            &frame.envelope,
+            self.inner.identity.peer_id,
+            0,
+        ) {
+            Ok(signature) => signature,
+            Err(error) => {
+                self.emit_diag(
+                    DiagnosticEvent::error(
+                        DiagnosticComponent::Subscriber,
+                        DiagnosticCode::DeliveryAckSendFailed,
+                        "delivery ack envelope did not sign",
+                    )
+                    .with_field("for_event", for_event)
+                    .with_field("error", error),
+                );
+                return;
+            }
+        };
+        let adapter = match self.lan_adapter().await {
+            Ok(adapter) => adapter,
+            Err(error) => {
+                self.emit_diag(
+                    DiagnosticEvent::warn(
+                        DiagnosticComponent::Subscriber,
+                        DiagnosticCode::DeliveryAckSendFailed,
+                        "no LAN adapter available to return delivery ack",
+                    )
+                    .with_field("for_event", for_event)
+                    .with_field("origin", origin)
+                    .with_field("error", error),
+                );
+                return;
+            }
+        };
+        if let Err(error) = adapter.send_to(origin, frame).await {
+            self.emit_diag(
+                DiagnosticEvent::warn(
+                    DiagnosticComponent::Subscriber,
+                    DiagnosticCode::DeliveryAckSendFailed,
+                    "delivery ack could not be written back to the sender",
+                )
+                .with_field("for_event", for_event)
+                .with_field("origin", origin)
+                .with_field("error", error),
+            );
+        }
+    }
+}

--- a/crates/airc-lib/src/diagnostic_event_sink.rs
+++ b/crates/airc-lib/src/diagnostic_event_sink.rs
@@ -197,6 +197,8 @@ fn code_header_value(code: DiagnosticCode) -> &'static str {
         DiagnosticCode::WorkspaceLeaseViolation => "workspace_lease_violation",
         DiagnosticCode::RouteRefreshFailed => "route_refresh_failed",
         DiagnosticCode::PeerDialFailed => "peer_dial_failed",
+        DiagnosticCode::FrameUndeliverable => "frame_undeliverable",
+        DiagnosticCode::DeliveryAckSendFailed => "delivery_ack_send_failed",
     }
 }
 

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -43,6 +43,7 @@ pub mod capability_registry;
 pub mod command_bus;
 pub mod coordinator;
 mod daemon;
+pub mod delivery_ack;
 pub mod diagnostic_event_sink;
 pub mod error;
 pub mod external_identity;
@@ -90,6 +91,10 @@ pub use airc_protocol::{
     AssertionError, IdentityAssertion, HEADER_AIRC_CORRELATION_ID, HEADER_AIRC_DEADLINE,
     HEADER_AIRC_REPLY_TO,
 };
+pub use airc_protocol::{
+    DeliveryAck, DeliveryOutcome, UndeliverableReason, DELIVERY_ACK_REQUEST, DELIVERY_ACK_RESPONSE,
+    HEADER_AIRC_DELIVERY_ACK,
+};
 pub use capability_registry::{
     CapabilityCandidate, CapabilityEntry, CapabilityQuery, CapabilityRegistry, DEFAULT_OFFER_TTL_MS,
 };
@@ -106,6 +111,7 @@ pub use coordinator::{
     DEFAULT_REFRESH_INTERVAL_MS as COORDINATOR_REFRESH_INTERVAL_MS,
 };
 pub use daemon::decode_wire_event;
+pub use delivery_ack::DeliverySendOutcome;
 pub use diagnostic_event_sink::{
     AircEventDiagnosticSink, HEADER_DIAG_CODE, HEADER_DIAG_COMPONENT, HEADER_DIAG_SEVERITY,
 };

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -212,7 +212,7 @@ impl Airc {
                         item = stream.next() => match item {
                             Some(Ok(frame)) => airc.append_received_frame(frame).await,
                             Some(Err(verify_err)) => {
-                                warn_frame_verify_failed(&verify_err);
+                                airc.warn_frame_verify_failed(&verify_err);
                             }
                             None => break "stream_ended",
                         }
@@ -222,7 +222,7 @@ impl Airc {
                     match stream.next().await {
                         Some(Ok(frame)) => airc.append_received_frame(frame).await,
                         Some(Err(verify_err)) => {
-                            warn_frame_verify_failed(&verify_err);
+                            airc.warn_frame_verify_failed(&verify_err);
                         }
                         None => break "stream_ended",
                     }
@@ -278,6 +278,23 @@ impl Airc {
     }
 
     pub(crate) async fn append_received_frame(&self, frame: Frame) {
+        // Card 39d37629: delivery-ack responses are receipts, not
+        // transcript content — intercept them ahead of persistence
+        // and hand them to in-process `send_with_delivery_ack`
+        // waiters. Old peers never request acks, so they never see
+        // these frames at all.
+        if let Some(ack) = airc_protocol::decode_delivery_ack(&frame) {
+            let _ = self.inner.ack_tx.send(ack);
+            return;
+        }
+        let ack_requested = airc_protocol::wants_delivery_ack(&frame);
+        let ack_origin = frame.envelope.sender;
+        let frame_channel = frame.envelope.channel;
+        let frame_cursor = airc_core::TranscriptCursor {
+            lamport: frame.envelope.lamport,
+            event_id: frame.envelope.event_id,
+        };
+
         let event = frame.into_transcript_event();
         let event_id = event.event_id;
         // The store dedups persistence by event_id —
@@ -306,34 +323,81 @@ impl Airc {
         // wire tail is async) but still wasted work that contends
         // for the DB connection with subsequent sends.
         if !self.mark_broadcast(event_id) {
+            // Already broadcast in-process ⇒ already persisted; an
+            // ack-requesting duplicate still deserves its receipt.
+            if ack_requested {
+                self.conclude_delivery_ack(ack_origin, event_id, frame_channel, frame_cursor)
+                    .await;
+            }
             return;
         }
         match self.inner.store.append(event.clone()).await {
             Ok(()) | Err(airc_store::StoreError::DuplicateEventId(_)) => {
                 let _ = self.inner.live_tx.send(Arc::new(event));
+                // Card 39d37629: the receipt fires only AFTER the
+                // append committed (or was already durable) — never
+                // on mere transport accept.
+                if ack_requested {
+                    self.conclude_delivery_ack(ack_origin, event_id, frame_channel, frame_cursor)
+                        .await;
+                }
             }
             Err(err) => {
-                StderrJsonDiagnosticSink.emit(
+                self.emit_diag(
                     DiagnosticEvent::error(
                         DiagnosticComponent::Subscriber,
                         DiagnosticCode::StoreAppendFailed,
                         "subscriber store append failed",
                     )
                     .with_field("event_id", event_id)
-                    .with_field("error", err),
+                    .with_field("error", &err),
                 );
+                if ack_requested {
+                    self.emit_diag(
+                        DiagnosticEvent::error(
+                            DiagnosticComponent::Subscriber,
+                            DiagnosticCode::FrameUndeliverable,
+                            "accepted frame could not be persisted — undeliverable",
+                        )
+                        .with_field(
+                            "reason",
+                            airc_protocol::UndeliverableReason::PersistFailed.as_str(),
+                        )
+                        .with_field("event_id", event_id)
+                        .with_field("sender", ack_origin)
+                        .with_field("error", err),
+                    );
+                    self.respond_delivery_ack(
+                        ack_origin,
+                        event_id,
+                        frame_channel,
+                        airc_protocol::DeliveryOutcome::Undeliverable {
+                            reason: airc_protocol::UndeliverableReason::PersistFailed,
+                        },
+                    )
+                    .await;
+                }
             }
         }
     }
-}
 
-fn warn_frame_verify_failed(error: &impl std::fmt::Display) {
-    if std::env::var_os("AIRC_REPLAY_WARN").is_some() {
-        StderrJsonDiagnosticSink.emit(
+    fn warn_frame_verify_failed(&self, error: &impl std::fmt::Display) {
+        // Card 39d37629: this used to be gated behind AIRC_REPLAY_WARN
+        // — a live frame failing verification was a SILENT drop. The
+        // subscriber streams here carry live frames (from_cursor:
+        // None, no replay backlog), so every failure is a frame a
+        // sender believes was sent. Loud, always; the dedicated
+        // Malformed/UnverifiableReplayFrameSkipped codes still cover
+        // the replay path separately.
+        self.emit_diag(
             DiagnosticEvent::warn(
                 DiagnosticComponent::Subscriber,
-                DiagnosticCode::FrameVerificationFailed,
-                "subscriber frame verification failed",
+                DiagnosticCode::FrameUndeliverable,
+                "subscriber frame verification failed — frame dropped",
+            )
+            .with_field(
+                "reason",
+                airc_protocol::UndeliverableReason::VerificationFailed.as_str(),
             )
             .with_field("error", error),
         );

--- a/crates/airc-lib/tests/lan_delivery_ack.rs
+++ b/crates/airc-lib/tests/lan_delivery_ack.rs
@@ -1,0 +1,250 @@
+//! Card 39d37629 — delivery acks for point-to-point LAN sends.
+//!
+//! Live repro this closes: 5090 → mac `lan-send` printed "sent over
+//! lan-tcp to general" (exit 0) at 2026-06-12 02:36Z, TLS pinning
+//! succeeded, and the frame appeared in NO store on the receiving
+//! machine. Sender-side "sent" proved only a TLS flush; every failure
+//! between transport accept and transcript persistence was silent.
+//!
+//! Contract proven here (two hermetic temp-home handles over a real
+//! TLS LAN link; no production daemon, no production route touched):
+//!
+//!   1. send → delivered ack with the receiver-side channel + cursor,
+//!      emitted only AFTER the receiver persisted the frame (the
+//!      persistence assertion reads the receiver's store).
+//!   2. send to a channel the receiving scope has NOT bound →
+//!      undeliverable{unknown_channel} ack + a loud typed
+//!      `frame_undeliverable` diagnostic on the receiver (asserted
+//!      through an injected MemoryDiagnosticSink — suppressing the
+//!      diagnostic fails this test).
+//!   3. receiver alive on the wire but its ingest is gone (handle
+//!      dropped mid-conversation — the "receiver killed mid-send" /
+//!      old-build shape) → the sender reports NoAck, distinctly from
+//!      both delivered and undeliverable.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use airc_core::Headers;
+use airc_diagnostics::{DiagnosticCode, MemoryDiagnosticSink};
+use airc_lib::{Airc, DeliveryOutcome, DeliverySendOutcome, UndeliverableReason};
+use tempfile::TempDir;
+
+async fn paired_handles(tmp_a: &TempDir, tmp_b: &TempDir) -> (Airc, Airc) {
+    let alice = Airc::open(tmp_a.path().join(".airc"))
+        .await
+        .expect("alice open");
+    let bob = Airc::open(tmp_b.path().join(".airc"))
+        .await
+        .expect("bob open");
+    let alice_spec = alice.peer_spec().parse().expect("alice spec");
+    let bob_spec = bob.peer_spec().parse().expect("bob spec");
+    alice.add_peer(bob_spec).await.expect("alice trusts bob");
+    bob.add_peer(alice_spec).await.expect("bob trusts alice");
+    (alice, bob)
+}
+
+#[tokio::test]
+async fn lan_send_yields_delivered_ack_only_after_receiver_persistence() {
+    let tmp_a = TempDir::new().expect("alice tempdir");
+    let tmp_b = TempDir::new().expect("bob tempdir");
+    let (alice, bob) = paired_handles(&tmp_a, &tmp_b).await;
+
+    // Both scopes bind the same channel name; same-machine mesh
+    // identity resolution makes the derived RoomId identical, which
+    // is the cross-machine production shape for a shared room.
+    let alice_room = alice.join("delivery-ack-room").await.expect("alice joins");
+    bob.join("delivery-ack-room").await.expect("bob joins");
+
+    let alice_addr: SocketAddr = alice
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("alice listens");
+    bob.connect_lan(alice_addr, alice.peer_id())
+        .await
+        .expect("bob dials alice");
+
+    let outcome = bob
+        .send_with_delivery_ack(
+            "ack me when persisted",
+            Headers::new(),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("ack-requesting send succeeds");
+
+    let (event_id, ack) = match outcome {
+        DeliverySendOutcome::Delivered { event_id, ack } => (event_id, ack),
+        DeliverySendOutcome::Undeliverable { .. } | DeliverySendOutcome::NoAck { .. } => {
+            panic!("expected Delivered, got {outcome:?}")
+        }
+    };
+    assert_eq!(ack.receiver, alice.peer_id(), "ack must name the receiver");
+    let (ack_channel, ack_cursor) = match ack.outcome {
+        DeliveryOutcome::Delivered { channel, cursor } => (channel, cursor),
+        DeliveryOutcome::Undeliverable { reason } => {
+            panic!("delivered ack must carry channel+cursor, got undeliverable {reason:?}")
+        }
+    };
+    assert_eq!(
+        ack_channel, alice_room.channel,
+        "delivered ack channel must be the receiver's bound room"
+    );
+    assert_eq!(
+        ack_cursor.event_id, event_id,
+        "delivered cursor must point at the acked event"
+    );
+
+    // The ack's claim must be true: the event is durably in ALICE's
+    // store, queryable through her room transcript surface. (Mutation
+    // check: with `store.append` skipped on the receive path, no
+    // delivered ack is emitted and this test fails on the match
+    // above; with the ack moved before persistence, this read is the
+    // backstop.)
+    let recent = alice.page_recent(16).await.expect("alice page_recent");
+    assert!(
+        recent.iter().any(|event| event.event_id == event_id),
+        "delivered-acked event must be visible in the receiver's room transcript; got {} events",
+        recent.len()
+    );
+}
+
+#[tokio::test]
+async fn send_to_unbound_channel_is_undeliverable_with_loud_receiver_diagnostic() {
+    let tmp_a = TempDir::new().expect("alice tempdir");
+    let tmp_b = TempDir::new().expect("bob tempdir");
+    let (alice, bob) = paired_handles(&tmp_a, &tmp_b).await;
+
+    // Receiver-side diagnostics become assertable: inject a memory
+    // sink. Suppressing the frame_undeliverable emission makes this
+    // test fail (mutation-verified during development).
+    let sink = MemoryDiagnosticSink::default();
+    alice.set_diagnostic_sink(Arc::new(sink.clone()));
+
+    // Bob binds + sends on a channel alice NEVER binds.
+    bob.join("zzz-unbound-39d37629").await.expect("bob joins");
+
+    let alice_addr: SocketAddr = alice
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("alice listens");
+    bob.connect_lan(alice_addr, alice.peer_id())
+        .await
+        .expect("bob dials alice");
+
+    let outcome = bob
+        .send_with_delivery_ack(
+            "nobody on the receiving side reads this channel",
+            Headers::new(),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("ack-requesting send succeeds");
+
+    let ack = match outcome {
+        DeliverySendOutcome::Undeliverable { ack, .. } => ack,
+        DeliverySendOutcome::Delivered { .. } | DeliverySendOutcome::NoAck { .. } => {
+            panic!("expected Undeliverable, got {outcome:?}")
+        }
+    };
+    assert_eq!(
+        ack.outcome,
+        DeliveryOutcome::Undeliverable {
+            reason: UndeliverableReason::UnknownChannel
+        },
+        "the typed reason must be unknown_channel"
+    );
+
+    // The receiver-side diagnostic is part of the contract — silent
+    // drops are the bug class under test.
+    let undeliverable_diags: Vec<_> = sink
+        .events()
+        .into_iter()
+        .filter(|event| event.code == DiagnosticCode::FrameUndeliverable)
+        .collect();
+    assert!(
+        !undeliverable_diags.is_empty(),
+        "receiver MUST emit a frame_undeliverable diagnostic for an unbound-channel frame"
+    );
+    assert!(
+        undeliverable_diags.iter().any(|event| event
+            .fields
+            .get("reason")
+            .is_some_and(|reason| reason == "unknown_channel")),
+        "diagnostic must carry reason=unknown_channel; got {undeliverable_diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn receiver_that_accepts_but_never_persists_yields_no_ack() {
+    // The "receiver killed mid-send" / old-build wire shape: a
+    // TLS-pinned listener that accepts the connection and the frame
+    // but has NO ingest/persist/ack path behind it. Built from the
+    // raw transport adapter — exactly what the sender's TLS layer
+    // sees when the remote daemon's ingest is gone (live repro
+    // 2026-06-12 02:36Z: TLS succeeded, frame in no store, sender
+    // printed "sent"). The fixed verb must report NoAck, distinct
+    // from both delivered and undeliverable.
+    use airc_protocol::{PeerKeyRegistry, PeerKeypair};
+    use airc_transport::LanTcpAdapter;
+
+    let tmp_b = TempDir::new().expect("bob tempdir");
+    let bob = Airc::open(tmp_b.path().join(".airc"))
+        .await
+        .expect("bob open");
+    bob.join("delivery-ack-room").await.expect("bob joins");
+
+    let hollow_id = airc_core::PeerId::from_u128(0x710c_39d3_7629);
+    let hollow_kp = PeerKeypair::generate();
+    let hollow_pubkey = hollow_kp.public_bytes();
+
+    // Mutual pinning: the hollow listener trusts bob, bob trusts the
+    // hollow listener — the handshake succeeds like production.
+    let bob_spec: airc_lib::PeerSpec = bob.peer_spec().parse().expect("bob spec");
+    let registry = PeerKeyRegistry::new();
+    registry
+        .enrol(hollow_id, 0, hollow_pubkey)
+        .expect("enrol hollow self");
+    registry
+        .enrol(bob_spec.peer_id, 0, bob_spec.pubkey)
+        .expect("enrol bob");
+    let hollow = LanTcpAdapter::new(hollow_id, hollow_kp, Arc::new(registry))
+        .expect("hollow adapter builds");
+    bob.add_peer(airc_lib::PeerSpec {
+        peer_id: hollow_id,
+        pubkey: hollow_pubkey,
+    })
+    .await
+    .expect("bob trusts hollow listener");
+
+    let hollow_addr: SocketAddr = hollow
+        .listen(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("hollow listener binds");
+    bob.connect_lan(hollow_addr, hollow_id)
+        .await
+        .expect("bob dials the hollow listener");
+
+    let outcome = bob
+        .send_with_delivery_ack(
+            "is anyone actually persisting this?",
+            Headers::new(),
+            Duration::from_millis(1_500),
+        )
+        .await
+        .expect("send still flushes to the live TLS connection");
+
+    match outcome {
+        DeliverySendOutcome::NoAck { waited, .. } => {
+            assert_eq!(
+                waited,
+                Duration::from_millis(1_500),
+                "NoAck must report the bounded wait that elapsed"
+            );
+        }
+        DeliverySendOutcome::Delivered { .. } | DeliverySendOutcome::Undeliverable { .. } => {
+            panic!("a receiver with no live ingest must yield NoAck, got {outcome:?}")
+        }
+    }
+}

--- a/crates/airc-protocol/src/delivery_ack.rs
+++ b/crates/airc-protocol/src/delivery_ack.rs
@@ -1,0 +1,317 @@
+//! Delivery-ack vocabulary for point-to-point sends (card 39d37629).
+//!
+//! ## The bug this closes
+//!
+//! `airc lan-send` used to print "sent" the moment the frame bytes
+//! were flushed to the TLS socket — write-success, NOT delivery. A
+//! frame could be accepted by the remote TLS listener and then vanish
+//! before room-transcript persistence (decode failure on a skewed
+//! build, signature-verification failure, store error, or persistence
+//! into a store no bound channel reads), with zero signal on either
+//! side. Live repro 2026-06-12 02:36Z: 5090 → mac `lan-send` printed
+//! "sent over lan-tcp to general", exit 0; the frame appears in NO
+//! store on the receiving machine.
+//!
+//! ## The contract
+//!
+//! A sender that wants a delivery receipt sets the
+//! [`HEADER_AIRC_DELIVERY_ACK`] header to [`DELIVERY_ACK_REQUEST`] on
+//! an ordinary frame. A receiver that understands the header responds
+//! on the same connection with a `FrameKind::Control` frame whose
+//! headers carry [`DELIVERY_ACK_RESPONSE`] and whose JSON body is a
+//! [`DeliveryAck`] — emitted only AFTER the persistence decision, so
+//! `delivered` means "durably in my transcript store on a channel this
+//! scope has bound", never "accepted".
+//!
+//! ## Wire compatibility
+//!
+//! No new `FrameKind` and no new top-level wire shape: both the
+//! request marker and the response travel as plain headers + JSON body
+//! on existing frame kinds, so peers running older builds decode them
+//! as ordinary frames. An old receiver simply never responds — the new
+//! sender times out and reports "no ack" distinctly (the frame may
+//! still have been delivered). An old sender never sets the request
+//! header, so it never receives ack frames at all. The JSON shapes
+//! below are pinned by literal-JSON tests; renaming any field or
+//! variant breaks the pins (mutation-verified).
+
+use serde::{Deserialize, Serialize};
+
+use airc_core::{Body, EventId, PeerId, RoomId, TranscriptCursor};
+
+use crate::envelope::Frame;
+
+/// Header key marking a frame as ack-requesting (value
+/// [`DELIVERY_ACK_REQUEST`]) or as an ack response (value
+/// [`DELIVERY_ACK_RESPONSE`]). Substrate-owned `airc.*` namespace.
+pub const HEADER_AIRC_DELIVERY_ACK: &str = "airc.delivery_ack";
+
+/// Header value: "sender requests a delivery ack for this frame."
+pub const DELIVERY_ACK_REQUEST: &str = "request";
+
+/// Header value: "this frame's body is a [`DeliveryAck`]."
+pub const DELIVERY_ACK_RESPONSE: &str = "response";
+
+/// Typed delivery receipt — the JSON body of an ack-response frame.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeliveryAck {
+    /// The `event_id` of the frame this ack answers.
+    pub for_event: EventId,
+    /// The peer that produced this ack (the receiving side).
+    pub receiver: PeerId,
+    /// What happened to the frame on the receiving side.
+    pub outcome: DeliveryOutcome,
+}
+
+/// Receiver-side outcome for an ack-requesting frame. `Delivered` is
+/// emitted only after the frame is durably persisted AND addressed to
+/// a channel the receiving scope has bound.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum DeliveryOutcome {
+    /// Persisted into the receiver's transcript store on a bound
+    /// channel. `cursor` is the receiver-side transcript position.
+    Delivered {
+        channel: RoomId,
+        cursor: TranscriptCursor,
+    },
+    /// Accepted but NOT delivered to any bound room transcript.
+    Undeliverable { reason: UndeliverableReason },
+}
+
+/// Why an accepted frame could not be delivered. Mirrors the
+/// `frame_undeliverable` diagnostic's reason vocabulary; only the
+/// reasons a receiver can still respond to travel on the wire
+/// (decode/verification failures kill the frame before the receiver
+/// can correlate an ack — the sender sees those as ack timeouts).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UndeliverableReason {
+    /// The frame's channel is not bound in the receiving scope's
+    /// subscription set — no transcript surface will ever show it.
+    UnknownChannel,
+    /// The receiver's durable store rejected the append.
+    PersistFailed,
+    /// The receiving adapter had no subscriber to hand the frame to.
+    NoSubscriber,
+    /// The frame bytes did not decode (diagnostic-only; never acked).
+    DecodeFailure,
+    /// The frame failed signature verification (diagnostic-only;
+    /// never acked).
+    VerificationFailed,
+}
+
+impl UndeliverableReason {
+    /// Stable snake_case label — used in diagnostics fields and CLI
+    /// output. Matches the serde wire encoding by construction (the
+    /// pin tests assert both).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UnknownChannel => "unknown_channel",
+            Self::PersistFailed => "persist_failed",
+            Self::NoSubscriber => "no_subscriber",
+            Self::DecodeFailure => "decode_failure",
+            Self::VerificationFailed => "verification_failed",
+        }
+    }
+}
+
+/// Does this frame ask its receiver for a delivery ack?
+pub fn wants_delivery_ack(frame: &Frame) -> bool {
+    frame
+        .envelope
+        .headers
+        .get(HEADER_AIRC_DELIVERY_ACK)
+        .map(String::as_str)
+        == Some(DELIVERY_ACK_REQUEST)
+}
+
+/// If this frame is an ack response, decode its [`DeliveryAck`] body.
+/// Returns `None` for ordinary frames (no header / wrong value) and
+/// for marked frames whose body does not parse — callers treat those
+/// as ordinary frames rather than failing the ingest path.
+pub fn decode_delivery_ack(frame: &Frame) -> Option<DeliveryAck> {
+    if frame
+        .envelope
+        .headers
+        .get(HEADER_AIRC_DELIVERY_ACK)
+        .map(String::as_str)
+        != Some(DELIVERY_ACK_RESPONSE)
+    {
+        return None;
+    }
+    let body = frame.envelope.body.as_ref()?;
+    match body {
+        Body::Json(value) => serde_json::from_value(value.clone()).ok(),
+        Body::Binary(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{Envelope, FrameKind};
+    use crate::signature::Signature;
+    use airc_core::{headers::Headers, transcript::MentionTarget, ClientId};
+
+    fn frame_with_headers(headers: Headers, body: Option<Body>) -> Frame {
+        Frame {
+            kind: FrameKind::Control,
+            envelope: Envelope {
+                event_id: EventId::from_u128(0x1),
+                sender: PeerId::from_u128(0xa1),
+                sender_client: ClientId::from_u128(0xc1),
+                channel: RoomId::from_u128(0xc0ffee),
+                target: MentionTarget::All,
+                lamport: 7,
+                occurred_at_ms: 1_700_000_000_000,
+                reply_to: None,
+                headers,
+                body,
+                media: Vec::new(),
+                signature: Signature::Unsigned,
+            },
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Literal-JSON wire pins. These strings are the wire contract for
+    // the new vocabulary: if a field or variant is renamed, these
+    // tests fail BEFORE a cross-build peer silently fails to decode.
+    // Mutation-verified during development: renaming `for_event` →
+    // `for_event_id` and `unknown_channel` → `channel_unknown` each
+    // broke the corresponding pin; restoring fixed it.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn delivered_ack_wire_pin() {
+        let ack = DeliveryAck {
+            for_event: EventId::from_u128(0x1),
+            receiver: PeerId::from_u128(0xb2),
+            outcome: DeliveryOutcome::Delivered {
+                channel: RoomId::from_u128(0xc0ffee),
+                cursor: TranscriptCursor {
+                    lamport: 42,
+                    event_id: EventId::from_u128(0x1),
+                },
+            },
+        };
+        let expected = serde_json::json!({
+            "for_event": "00000000-0000-0000-0000-000000000001",
+            "receiver": "00000000-0000-0000-0000-0000000000b2",
+            "outcome": {
+                "status": "delivered",
+                "channel": "00000000-0000-0000-0000-000000c0ffee",
+                "cursor": {
+                    "lamport": 42,
+                    "event_id": "00000000-0000-0000-0000-000000000001"
+                }
+            }
+        });
+        let encoded = serde_json::to_value(&ack).expect("encode");
+        assert_eq!(encoded, expected, "delivered ack wire shape is pinned");
+        let decoded: DeliveryAck = serde_json::from_value(expected).expect("decode");
+        assert_eq!(decoded, ack, "delivered ack decodes from pinned JSON");
+    }
+
+    #[test]
+    fn undeliverable_ack_wire_pin() {
+        let ack = DeliveryAck {
+            for_event: EventId::from_u128(0x2),
+            receiver: PeerId::from_u128(0xb2),
+            outcome: DeliveryOutcome::Undeliverable {
+                reason: UndeliverableReason::UnknownChannel,
+            },
+        };
+        let expected = serde_json::json!({
+            "for_event": "00000000-0000-0000-0000-000000000002",
+            "receiver": "00000000-0000-0000-0000-0000000000b2",
+            "outcome": {
+                "status": "undeliverable",
+                "reason": "unknown_channel"
+            }
+        });
+        let encoded = serde_json::to_value(&ack).expect("encode");
+        assert_eq!(encoded, expected, "undeliverable ack wire shape is pinned");
+        let decoded: DeliveryAck = serde_json::from_value(expected).expect("decode");
+        assert_eq!(decoded, ack, "undeliverable ack decodes from pinned JSON");
+    }
+
+    #[test]
+    fn undeliverable_reason_labels_match_wire_encoding() {
+        for reason in [
+            UndeliverableReason::UnknownChannel,
+            UndeliverableReason::PersistFailed,
+            UndeliverableReason::NoSubscriber,
+            UndeliverableReason::DecodeFailure,
+            UndeliverableReason::VerificationFailed,
+        ] {
+            let wire = serde_json::to_value(reason).expect("encode reason");
+            assert_eq!(
+                wire,
+                serde_json::Value::String(reason.as_str().to_string()),
+                "as_str must equal the serde wire label for {reason:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn header_constants_are_pinned() {
+        // These strings travel on the wire as header keys/values —
+        // pinned so a rename is caught here, not in the field.
+        assert_eq!(HEADER_AIRC_DELIVERY_ACK, "airc.delivery_ack");
+        assert_eq!(DELIVERY_ACK_REQUEST, "request");
+        assert_eq!(DELIVERY_ACK_RESPONSE, "response");
+    }
+
+    #[test]
+    fn wants_delivery_ack_requires_exact_request_value() {
+        let mut headers = Headers::new();
+        headers.insert(
+            HEADER_AIRC_DELIVERY_ACK.to_string(),
+            DELIVERY_ACK_REQUEST.to_string(),
+        );
+        assert!(wants_delivery_ack(&frame_with_headers(headers, None)));
+
+        assert!(!wants_delivery_ack(&frame_with_headers(
+            Headers::new(),
+            None
+        )));
+
+        let mut response_headers = Headers::new();
+        response_headers.insert(
+            HEADER_AIRC_DELIVERY_ACK.to_string(),
+            DELIVERY_ACK_RESPONSE.to_string(),
+        );
+        assert!(!wants_delivery_ack(&frame_with_headers(
+            response_headers,
+            None
+        )));
+    }
+
+    #[test]
+    fn decode_delivery_ack_roundtrips_through_a_frame_body() {
+        let ack = DeliveryAck {
+            for_event: EventId::from_u128(0x3),
+            receiver: PeerId::from_u128(0xb2),
+            outcome: DeliveryOutcome::Undeliverable {
+                reason: UndeliverableReason::PersistFailed,
+            },
+        };
+        let mut headers = Headers::new();
+        headers.insert(
+            HEADER_AIRC_DELIVERY_ACK.to_string(),
+            DELIVERY_ACK_RESPONSE.to_string(),
+        );
+        let frame = frame_with_headers(
+            headers,
+            Some(Body::Json(serde_json::to_value(&ack).expect("encode"))),
+        );
+        assert_eq!(decode_delivery_ack(&frame), Some(ack));
+
+        // Ordinary frames (no marker header) never decode as acks even
+        // if their body happens to look like one.
+        let plain = frame_with_headers(Headers::new(), None);
+        assert_eq!(decode_delivery_ack(&plain), None);
+    }
+}

--- a/crates/airc-protocol/src/lib.rs
+++ b/crates/airc-protocol/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod assertion;
 pub mod canonical;
+pub mod delivery_ack;
 pub mod envelope;
 pub mod headers_keys;
 pub mod keypair;
@@ -36,6 +37,10 @@ pub mod trust_rotation;
 
 pub use assertion::{AssertionError, IdentityAssertion, ASSERTION_DOMAIN};
 pub use canonical::{canonical_signed_bytes, CanonicalError};
+pub use delivery_ack::{
+    decode_delivery_ack, wants_delivery_ack, DeliveryAck, DeliveryOutcome, UndeliverableReason,
+    DELIVERY_ACK_REQUEST, DELIVERY_ACK_RESPONSE, HEADER_AIRC_DELIVERY_ACK,
+};
 pub use envelope::{ChannelId, Envelope, Frame, FrameKind};
 pub use headers_keys::{
     HEADER_AIRC_BODY_ENC_AAD, HEADER_AIRC_BODY_ENC_KEY_ID, HEADER_AIRC_BODY_ENC_SCHEME,

--- a/crates/airc-transport/Cargo.toml
+++ b/crates/airc-transport/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 airc-core = { path = "../airc-core" }
+airc-diagnostics = { path = "../airc-diagnostics" }
 airc-protocol = { path = "../airc-protocol" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/airc-transport/src/lan_tcp/adapter/connection.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/connection.rs
@@ -13,6 +13,9 @@ use tokio_rustls::client::TlsStream as ClientTlsStream;
 use tokio_rustls::server::TlsStream as ServerTlsStream;
 
 use airc_core::PeerId;
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
+};
 use airc_protocol::Frame;
 
 use crate::lan_tcp::adapter::dispatch::dispatch_to_subscribers;
@@ -130,9 +133,23 @@ where
 
         let frame: Frame = match serde_json::from_slice(&payload) {
             Ok(frame) => frame,
-            Err(_error) => {
-                // Malformed payload — drop the connection rather
-                // than silently skipping.
+            Err(error) => {
+                // Malformed payload — drop the connection rather than
+                // silently skipping. Card 39d37629: this is a frame the
+                // sender saw flushed ("sent") that will never reach a
+                // transcript — it MUST be loud. Build skew between
+                // peers (frame schema drift) lands exactly here.
+                StderrJsonDiagnosticSink.emit(
+                    DiagnosticEvent::error(
+                        DiagnosticComponent::Transport,
+                        DiagnosticCode::FrameUndeliverable,
+                        "inbound lan-tcp frame did not decode — frame dropped, connection closed",
+                    )
+                    .with_field("reason", "decode_failure")
+                    .with_field("peer", peer_id)
+                    .with_field("payload_bytes", payload.len())
+                    .with_field("error", error),
+                );
                 inner.connections.lock().await.remove(&peer_id);
                 return;
             }

--- a/crates/airc-transport/src/lan_tcp/adapter/dispatch.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/dispatch.rs
@@ -10,6 +10,9 @@ use std::sync::Arc;
 
 use tokio::sync::mpsc;
 
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
+};
 use airc_protocol::{Frame, FrameKind, Subscription};
 
 use crate::lan_tcp::adapter::error::LanTcpError;
@@ -26,6 +29,26 @@ pub(super) async fn dispatch_to_subscribers(inner: &Arc<Inner>, frame: Frame) {
             .map(|sub| (sub.id, sub.tx.clone()))
             .collect()
     };
+
+    // Card 39d37629: a durable frame that matches NO subscriber will
+    // never reach the ingest/persist path — the sender saw "sent", and
+    // without this line nothing anywhere would record the loss (live
+    // repro 2026-06-12 02:36Z: accepted frame in no store). Event-kind
+    // frames are lossy by contract, so only Message/Control are loud.
+    if targets.is_empty() && matches!(frame.kind, FrameKind::Message | FrameKind::Control) {
+        StderrJsonDiagnosticSink.emit(
+            DiagnosticEvent::error(
+                DiagnosticComponent::Transport,
+                DiagnosticCode::FrameUndeliverable,
+                "inbound lan-tcp frame matched no subscriber — frame dropped before persistence",
+            )
+            .with_field("reason", "no_subscriber")
+            .with_field("event_id", frame.envelope.event_id)
+            .with_field("sender", frame.envelope.sender)
+            .with_field("channel", frame.envelope.channel),
+        );
+        return;
+    }
 
     // 2. Dispatch outside the lock — slow consumers no longer block
     //    other subscribers or new registrations.

--- a/crates/airc-transport/src/lan_tcp/adapter/mod.rs
+++ b/crates/airc-transport/src/lan_tcp/adapter/mod.rs
@@ -193,6 +193,36 @@ impl LanTcpAdapter {
         handle_client_connection(self.inner.clone(), tls_stream).await?;
         Ok(())
     }
+
+    /// Targeted unicast: send `frame` to exactly one connected peer.
+    ///
+    /// Card 39d37629 — delivery-ack responses must travel back to the
+    /// requesting sender only, not broadcast to every connection. Same
+    /// flush-to-wire contract as `send()`: returns `Ok` only after the
+    /// write loop confirmed the frame is in the kernel send buffer.
+    pub async fn send_to(&self, peer: PeerId, frame: Frame) -> Result<(), LanTcpError> {
+        let payload = serde_json::to_vec(&frame)?;
+        if payload.len() > MAX_FRAME_BYTES as usize {
+            return Err(LanTcpError::FrameTooLarge {
+                announced: u32::try_from(payload.len()).unwrap_or(u32::MAX),
+                limit: MAX_FRAME_BYTES,
+            });
+        }
+        let tx = {
+            let connections = self.inner.connections.lock().await;
+            connections
+                .get(&peer)
+                .cloned()
+                .ok_or(LanTcpError::NoActivePeers)?
+        };
+        let (flushed, flushed_rx) = oneshot::channel();
+        tx.send(Outbound { payload, flushed })
+            .await
+            .map_err(|_closed| LanTcpError::NoActivePeers)?;
+        flushed_rx
+            .await
+            .map_err(|_dropped| LanTcpError::NoActivePeers)
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## Root cause (card 39d37629 — live repro 2026-06-12 02:36Z)

`lan-send` printed `sent over lan-tcp to general` (exit 0) the moment the frame bytes were flushed to the TLS socket. Forensics on the receiving machine (this Mac, the live repro receiver) show the frame was **accepted at TLS and persisted nowhere**: the machine store (`~/.airc/events.sqlite`) has a 5090 message at 02:32:10Z and then nothing until 19:01Z, and a sweep of every `events.sqlite` on the box (scope stores, temp homes) finds no event in the 02:25–02:50Z window beyond `subscription_advanced` ticks.

Mapping the receive path exposed an entire class of **silent drop points between transport accept and room-transcript persistence**, any of which matches the repro:

1. `lan_tcp` `read_loop` decode failure (`serde_json::from_slice` err) — connection dropped, frame gone, **zero diagnostics** (build-skew schema drift lands here).
2. `dispatch_to_subscribers` with no matching subscriber — frame parsed then dropped, **zero diagnostics** (a listener whose ingest task died, or a raw listener with no consumer).
3. `SignedTransport` verification failure — ingest loop warned **only when `AIRC_REPLAY_WARN` was set**, i.e. silent by default.
4. ingest `store.append` failure — stderr diagnostic only; sender never learns.
5. frame persisted onto a channel the receiving scope never bound — durable but invisible to every transcript surface (the store-split shape: the daemon's LAN handle persists to the machine store while scope transcripts read scope stores — observed live with the 02:32:10Z message, present in `~/.airc/events.sqlite` but absent from `/Users/joel/Development/airc/.airc/events.sqlite`).

Sender-side `Ok` was load-bearing only down to the kernel send buffer. Earlier finding (2026-06-10 23:52Z) confirmed lan-send frames are point-to-point and bypass the route layer, so no other layer could catch the loss.

## Fix, layer by layer

**airc-protocol (`delivery_ack.rs`, new):** typed ack vocabulary that is wire-compatible by construction — no new `FrameKind`, no new top-level shape. Requesting senders set header `airc.delivery_ack=request` on an ordinary frame; receivers answer with a Control frame whose JSON body is `DeliveryAck {for_event, receiver, outcome: delivered{channel, cursor} | undeliverable{reason}}` under header `airc.delivery_ack=response`. Old peers decode both directions as ordinary frames; old receivers simply never ack and the new sender reports **no-ack** distinctly. Literal-JSON wire pins for both variants, the reason labels, and the header constants.

**airc-transport:** `read_loop` decode failure and zero-subscriber dispatch now emit `frame_undeliverable` diagnostics (`decode_failure` / `no_subscriber`); new `LanTcpAdapter::send_to(peer, frame)` unicast for the ack return path (same flush-to-wire contract as `send`).

**airc-lib:** `append_received_frame` intercepts ack responses ahead of persistence (receipts, not transcript content) and fans them to waiters; for ack-requesting frames it answers **only after the persistence decision** — `delivered{channel,cursor}` requires the append to have committed AND the frame's channel to be bound in the receiving scope's subscription set; unbound channel → `undeliverable{unknown_channel}` + loud diagnostic (frame stays persisted, diagnostic says so); append failure → `undeliverable{persist_failed}`; live verification failures are now always loud (the `AIRC_REPLAY_WARN` gate is gone for the live ingest path — replay skips keep their dedicated codes). New `Airc::send_with_delivery_ack(text, headers, timeout)`; new injectable per-handle diagnostic sink so tests assert emissions instead of scraping stderr.

**airc-cli:** `lan-send` now waits for the receipt (`--ack-timeout-ms`, default 10 000) and prints the typed outcome; **anything that is not `delivered` exits nonzero** — including no-ack, which names the old-build possibility explicitly.

**Routed daemon path:** untouched — nothing in the ack machinery runs unless the request header is present, which only the point-to-point verb sets. Routed-ack filed as follow-up.

## Why the ack cannot false-positive

`conclude_delivery_ack` is reachable only from the two post-persistence arms of `append_received_frame` (`store.append` returned `Ok`/`DuplicateEventId`, or the broadcast ring proved a prior persist). The delivered e2e test additionally reads the event back out of the **receiver's** store, so an "ack on accept" regression fails the test even if the ack plumbing is intact (proven by mutation 2 below).

## Mutation evidence (all restored, suite green after each)

1. rename wire field `for_event` → `for_event_id`: `delivered_ack_wire_pin` + `undeliverable_ack_wire_pin` **FAILED**.
2. rename `unknown_channel` wire label → `channel_unknown`: pins + label test **FAILED**.
3. skip `store.append` on ingest while still acking: `lan_send_yields_delivered_ack_only_after_receiver_persistence` **FAILED** (store read-back caught the false delivered).
4. suppress the unknown-channel `frame_undeliverable` emission: `send_to_unbound_channel_is_undeliverable_with_loud_receiver_diagnostic` **FAILED**.

## Tests

- `crates/airc-protocol/src/delivery_ack.rs` — 6 unit/pin tests.
- `crates/airc-lib/tests/lan_delivery_ack.rs` — 3 e2e tests over real TLS LAN links between hermetic temp-home handles (no production daemon or route touched): delivered-with-cursor + receiver-store read-back; unbound-channel undeliverable + sink-asserted diagnostic; hollow receiver (accepts, never persists/acks — the killed-mid-send / old-build wire shape) → NoAck.

Production gate: clippy (workspace, `-D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm`) clean; `cargo fmt --all -- --check` clean; `cargo test --workspace -- --skip codex_hook` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
