### PR TITLE
fix(daemon): route inbound LAN frames into the owner-core router — store-split visibility (card 4132f48c)

### DIFF
--- a/crates/airc-bus/src/lib.rs
+++ b/crates/airc-bus/src/lib.rs
@@ -51,6 +51,6 @@ pub use ephemeral::EphemeralCache;
 pub use error::{BusError, Result};
 pub use filter::Filter;
 pub use ring::HotRing;
-pub use router::{EventRouter, LagFlag, RouterConfig};
+pub use router::{EventRouter, LagFlag, PublishIfNew, RouterConfig};
 pub use seq::{EpochStore, InMemoryEpochStore, SeqSource};
 pub use sink::{DurableSink, InMemoryDurableSink};

--- a/crates/airc-bus/src/router.rs
+++ b/crates/airc-bus/src/router.rs
@@ -151,6 +151,17 @@ impl RecentEventIds {
         self.order.push_back(id);
         true
     }
+
+    /// Forget `id`. Used by [`EventRouter::publish_if_new`] when a
+    /// publish FAILED after the id was optimistically marked — a
+    /// poisoned entry would make a legitimate retry of the same frame
+    /// report `Duplicate` (and the receiver ack delivered) for an
+    /// event that never entered the router.
+    fn remove(&mut self, id: &airc_core::EventId) {
+        if self.seen.remove(id) {
+            self.order.retain(|other| other != id);
+        }
+    }
 }
 
 /// Outcome of [`EventRouter::publish_if_new`].
@@ -418,11 +429,33 @@ impl EventRouter {
         }
         // Off-lock durable probe. The id is already marked, so even if
         // this await parks, a concurrent same-id call short-circuits.
-        if self.inner.sink.contains(env.event_id).await? {
-            return Ok(PublishIfNew::Duplicate);
+        // On ANY failure from here on, unmark the id: a poisoned entry
+        // would turn a legitimate retry into a false `Duplicate` (and a
+        // false delivered ack) for an event the router never took.
+        let event_id = env.event_id;
+        let unmark = |router: &Self| {
+            let mut recent = router
+                .inner
+                .recent_ids
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            recent.remove(&event_id);
+        };
+        match self.inner.sink.contains(event_id).await {
+            Ok(true) => return Ok(PublishIfNew::Duplicate),
+            Ok(false) => {}
+            Err(error) => {
+                unmark(self);
+                return Err(error);
+            }
         }
-        let seq = self.publish(env).await?;
-        Ok(PublishIfNew::Published(seq))
+        match self.publish(env).await {
+            Ok(seq) => Ok(PublishIfNew::Published(seq)),
+            Err(error) => {
+                unmark(self);
+                Err(error)
+            }
+        }
     }
 
     /// The write-behind drain loop (§3.3 deliver-first / persist-async, §3.8

--- a/crates/airc-bus/src/router.rs
+++ b/crates/airc-bus/src/router.rs
@@ -114,6 +114,56 @@ struct WriteBehindItem {
     env: Arc<Envelope>,
 }
 
+/// Capacity of the router's recent-event-ids window (card 4132f48c).
+/// Sized well past the per-channel ring capacity so a same-moment echo
+/// of any event still in flight is always caught in memory; older
+/// re-injections fall through to the durable [`DurableSink::contains`]
+/// probe in [`EventRouter::publish_if_new`].
+const RECENT_PUBLISH_IDS_CAPACITY: usize = 4096;
+
+/// Bounded FIFO set of recently published event ids (card 4132f48c).
+/// `insert` answers "was this id already recorded?" and records it;
+/// capacity overflow rolls the oldest id off.
+struct RecentEventIds {
+    order: std::collections::VecDeque<airc_core::EventId>,
+    seen: std::collections::HashSet<airc_core::EventId>,
+}
+
+impl RecentEventIds {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            order: std::collections::VecDeque::with_capacity(capacity),
+            seen: std::collections::HashSet::with_capacity(capacity),
+        }
+    }
+
+    /// Record `id`. Returns `true` if it was new, `false` if already
+    /// present (already published through this router recently).
+    fn insert(&mut self, id: airc_core::EventId) -> bool {
+        if !self.seen.insert(id) {
+            return false;
+        }
+        if self.order.len() == RECENT_PUBLISH_IDS_CAPACITY {
+            if let Some(evicted) = self.order.pop_front() {
+                self.seen.remove(&evicted);
+            }
+        }
+        self.order.push_back(id);
+        true
+    }
+}
+
+/// Outcome of [`EventRouter::publish_if_new`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublishIfNew {
+    /// The envelope was new: published with this owner-assigned seq.
+    Published(crate::Seq),
+    /// An event with this `event_id` already went through this router
+    /// (recent-ids window) or is already in the durable tier — the
+    /// envelope was NOT re-published. The existing copy stands.
+    Duplicate,
+}
+
 /// The owner-core event router (§3).
 ///
 /// Cheap to clone via the `Arc` fields; clones share the same router.
@@ -129,6 +179,12 @@ struct RouterInner {
     seq: Arc<SeqSource>,
     sink: Arc<dyn DurableSink>,
     write_behind_tx: mpsc::Sender<WriteBehindItem>,
+    /// Recently published event ids (card 4132f48c) — the in-memory leg of
+    /// [`EventRouter::publish_if_new`]'s idempotency check. Every publish
+    /// records its id here so a transport echo of a locally published
+    /// event (or the same inbound frame arriving on two LAN links) can
+    /// never fan out twice.
+    recent_ids: Mutex<RecentEventIds>,
     /// Count of events shed because the write-behind queue was saturated and
     /// the publisher was fire-and-forget (§3.8). Surfaced for diagnostics.
     shed_count: AtomicU64,
@@ -165,6 +221,7 @@ impl EventRouter {
             seq,
             sink,
             write_behind_tx,
+            recent_ids: Mutex::new(RecentEventIds::with_capacity(RECENT_PUBLISH_IDS_CAPACITY)),
             shed_count: AtomicU64::new(0),
             channels_created: AtomicU64::new(0),
         });
@@ -201,6 +258,18 @@ impl EventRouter {
         let seq = self.inner.seq.next();
         env.seq = seq;
         env.occurred_at_ms = self.inner.clock.now_ms();
+
+        // Card 4132f48c: record the id so a later `publish_if_new` of the
+        // same event (a transport echo of this publish) is a duplicate.
+        // One short mutex hold; never crosses an await.
+        {
+            let mut recent = self
+                .inner
+                .recent_ids
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            recent.insert(env.event_id);
+        }
 
         // Wrap ONCE: from here on every delivery (ring, ephemeral, fan-out,
         // write-behind) is an `Arc::clone` — a refcount bump, never a deep copy
@@ -312,6 +381,48 @@ impl EventRouter {
         }
 
         Ok(seq)
+    }
+
+    /// Idempotent publish keyed on `env.event_id` (card 4132f48c).
+    ///
+    /// This is the transport-ingest entry point: inbound LAN/relay frames
+    /// carry sender-minted event ids and can legitimately reach the
+    /// router more than once (the same frame arriving on two LAN links,
+    /// an echo of a locally published event, a re-inject after restart).
+    /// [`EventRouter::publish`] assumes a fresh id and would fan the copy
+    /// out to every live subscriber a second time; the durable sink alone
+    /// can't prevent that because its idempotency only covers the
+    /// write-behind tier, not the ring/live legs.
+    ///
+    /// Check order:
+    /// 1. recent-ids window (in-memory, covers everything this router
+    ///    instance published recently — including local IPC publishes,
+    ///    so a wire echo of a local send can never double-deliver);
+    /// 2. [`DurableSink::contains`] (covers ids older than the window
+    ///    and publishes from before a daemon restart).
+    ///
+    /// The id is recorded *before* the checks complete so two concurrent
+    /// `publish_if_new` calls for the same id race to exactly one
+    /// `Published`.
+    pub async fn publish_if_new(&self, env: Envelope) -> crate::Result<PublishIfNew> {
+        let already_recent = {
+            let mut recent = self
+                .inner
+                .recent_ids
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            !recent.insert(env.event_id)
+        };
+        if already_recent {
+            return Ok(PublishIfNew::Duplicate);
+        }
+        // Off-lock durable probe. The id is already marked, so even if
+        // this await parks, a concurrent same-id call short-circuits.
+        if self.inner.sink.contains(env.event_id).await? {
+            return Ok(PublishIfNew::Duplicate);
+        }
+        let seq = self.publish(env).await?;
+        Ok(PublishIfNew::Published(seq))
     }
 
     /// The write-behind drain loop (§3.3 deliver-first / persist-async, §3.8

--- a/crates/airc-bus/src/sink.rs
+++ b/crates/airc-bus/src/sink.rs
@@ -60,6 +60,19 @@ pub trait DurableSink: Send + Sync {
     /// constant work (one indexed `ORDER BY … DESC LIMIT 1` row on
     /// SQLite, back-of-vec on in-memory) or fail loudly.
     async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>>;
+
+    /// **Card 4132f48c.** Whether an event with this `event_id` is already
+    /// persisted. This is the durable leg of
+    /// [`crate::EventRouter::publish_if_new`]'s idempotency check: an
+    /// inbound transport frame re-injected after the router's in-memory
+    /// recent-ids window rolled (daemon restart, late echo) must not
+    /// re-enter the hot ring / live fan-out as a second copy.
+    ///
+    /// Required, no scan default (same posture as `head_cursor`, card
+    /// a1562dbc): every impl answers in indexed work — one primary-key
+    /// probe on SQLite, a per-bucket id check on the in-memory test
+    /// sinks — or fails loudly.
+    async fn contains(&self, event_id: airc_core::EventId) -> Result<bool>;
 }
 
 /// In-memory durable tier for tests. Records append count so the
@@ -167,6 +180,14 @@ impl DurableSink for InMemoryDurableSink {
             .cloned()
             .collect();
         Ok(out)
+    }
+
+    async fn contains(&self, event_id: airc_core::EventId) -> Result<bool> {
+        let guard = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        Ok(guard
+            .events
+            .values()
+            .any(|bucket| bucket.iter().any(|e| e.event_id == event_id)))
     }
 }
 

--- a/crates/airc-bus/tests/common/mod.rs
+++ b/crates/airc-bus/tests/common/mod.rs
@@ -140,4 +140,8 @@ impl DurableSink for GatedSink {
     async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>, BusError> {
         self.inner.head_cursor(channel).await
     }
+
+    async fn contains(&self, event_id: airc_core::EventId) -> Result<bool, BusError> {
+        self.inner.contains(event_id).await
+    }
 }

--- a/crates/airc-bus/tests/durable_tip.rs
+++ b/crates/airc-bus/tests/durable_tip.rs
@@ -72,6 +72,10 @@ impl DurableSink for CountingSink {
         self.head_cursor_calls.fetch_add(1, Ordering::SeqCst);
         self.inner.head_cursor(channel).await
     }
+
+    async fn contains(&self, event_id: airc_core::EventId) -> Result<bool, BusError> {
+        self.inner.contains(event_id).await
+    }
 }
 
 /// A sink whose `head_cursor` fails — proves the tip probe surfaces a
@@ -95,6 +99,10 @@ impl DurableSink for FailingHeadSink {
 
     async fn head_cursor(&self, _channel: RoomId) -> Result<Option<Cursor>, BusError> {
         Err(BusError::Sink("index unavailable".to_string()))
+    }
+
+    async fn contains(&self, _event_id: airc_core::EventId) -> Result<bool, BusError> {
+        Ok(false)
     }
 }
 

--- a/crates/airc-bus/tests/publish_if_new.rs
+++ b/crates/airc-bus/tests/publish_if_new.rs
@@ -1,0 +1,130 @@
+//! Card 4132f48c — `EventRouter::publish_if_new` idempotency pins.
+//!
+//! Inbound transport frames carry sender-minted event ids and can
+//! legitimately reach the router more than once (same frame on two
+//! LAN links, a wire echo of a locally published event, a re-inject
+//! after a daemon restart). The plain `publish` assumes a fresh id;
+//! `publish_if_new` is the ingest entry point that makes the second
+//! arrival a no-op at EVERY tier — live fan-out, hot ring, and sink.
+
+mod common;
+
+use std::time::Duration;
+
+use futures::StreamExt;
+
+use airc_bus::{Filter, PublishIfNew, RouterConfig};
+use airc_core::RoomId;
+
+use common::{durable, Owner};
+
+#[tokio::test]
+async fn second_arrival_of_same_event_id_is_duplicate_at_every_tier() {
+    let ch = RoomId::from_u128(0x4132);
+    let owner = Owner::new(RouterConfig::default());
+    let r = &owner.router;
+
+    let stream = r.subscribe(Filter::channel(ch), None);
+    futures::pin_mut!(stream);
+
+    let first = r
+        .publish_if_new(durable(ch, 0xA, "from the wire"))
+        .await
+        .unwrap();
+    assert!(
+        matches!(first, PublishIfNew::Published(_)),
+        "fresh id must publish; got {first:?}"
+    );
+    let second = r
+        .publish_if_new(durable(ch, 0xA, "from the wire"))
+        .await
+        .unwrap();
+    assert_eq!(
+        second,
+        PublishIfNew::Duplicate,
+        "the same event_id arriving again (second LAN link) must not re-publish"
+    );
+
+    // Live tier: exactly one delivery reaches the subscriber. Publish a
+    // sentinel after the duplicate; if the duplicate had fanned out, it
+    // would arrive before the sentinel.
+    r.publish(durable(ch, 0xB, "sentinel")).await.unwrap();
+    let first_seen = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("first event")
+        .expect("stream open");
+    assert_eq!(first_seen.payload.as_ref(), b"from the wire");
+    let next_seen = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("second event")
+        .expect("stream open");
+    assert_eq!(
+        next_seen.payload.as_ref(),
+        b"sentinel",
+        "the duplicate must NOT appear between the original and the sentinel"
+    );
+
+    // Durable tier: one row.
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    assert_eq!(owner.sink.len(ch), 2, "original + sentinel, no dup row");
+}
+
+#[tokio::test]
+async fn wire_echo_of_a_locally_published_event_is_duplicate() {
+    // The local-sender + LAN-receiver shape: a scope publishes through
+    // the daemon (plain `publish`), then the same event id comes back
+    // over a transport link (`publish_if_new`).
+    let ch = RoomId::from_u128(0x4133);
+    let owner = Owner::new(RouterConfig::default());
+    let r = &owner.router;
+
+    r.publish(durable(ch, 0xC, "local original")).await.unwrap();
+    let echo = r
+        .publish_if_new(durable(ch, 0xC, "local original"))
+        .await
+        .unwrap();
+    assert_eq!(
+        echo,
+        PublishIfNew::Duplicate,
+        "plain publishes must be visible to the idempotency window"
+    );
+
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    assert_eq!(owner.sink.len(ch), 1);
+}
+
+#[tokio::test]
+async fn already_durable_event_is_duplicate_even_for_a_fresh_router() {
+    // The post-restart shape: the in-memory recent-ids window is gone,
+    // but the event is in the durable tier — `DurableSink::contains`
+    // is the leg that catches it.
+    let ch = RoomId::from_u128(0x4134);
+    let owner = Owner::new(RouterConfig::default());
+    owner
+        .router
+        .publish(durable(ch, 0xD, "before restart"))
+        .await
+        .unwrap();
+    // Let write-behind persist before "restarting".
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    assert_eq!(owner.sink.len(ch), 1);
+
+    let restarted = Owner::with_parts(
+        RouterConfig::default(),
+        owner.epoch_store.clone(),
+        owner.sink.clone(),
+        0,
+    );
+    let outcome = restarted
+        .router
+        .publish_if_new(durable(ch, 0xD, "before restart"))
+        .await
+        .unwrap();
+    assert_eq!(
+        outcome,
+        PublishIfNew::Duplicate,
+        "a durably persisted id must never re-enter the ring/live tiers"
+    );
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    assert_eq!(restarted.sink.len(ch), 1, "still exactly one row");
+}

--- a/crates/airc-bus/tests/publish_if_new.rs
+++ b/crates/airc-bus/tests/publish_if_new.rs
@@ -128,3 +128,85 @@ async fn already_durable_event_is_duplicate_even_for_a_fresh_router() {
     tokio::time::sleep(Duration::from_millis(30)).await;
     assert_eq!(restarted.sink.len(ch), 1, "still exactly one row");
 }
+
+// --- failure does not poison the idempotency window ------------------------
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use airc_bus::envelope::{Cursor, Envelope};
+use airc_bus::{
+    BusError, Clock, DurableSink, EventRouter, InMemoryDurableSink, InMemoryEpochStore, SeqSource,
+    SystemClock,
+};
+use airc_core::EventId;
+use async_trait::async_trait;
+
+/// A sink whose `contains` fails exactly once — the transient-store
+/// shape a retried inbound frame hits.
+struct FlakyContainsSink {
+    inner: Arc<InMemoryDurableSink>,
+    fail_next_contains: AtomicBool,
+}
+
+#[async_trait]
+impl DurableSink for FlakyContainsSink {
+    async fn append(&self, e: &Envelope) -> Result<(), BusError> {
+        self.inner.append(e).await
+    }
+
+    async fn page(
+        &self,
+        channel: RoomId,
+        from_cursor: Option<Cursor>,
+        limit: usize,
+    ) -> Result<Vec<Envelope>, BusError> {
+        self.inner.page(channel, from_cursor, limit).await
+    }
+
+    async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>, BusError> {
+        self.inner.head_cursor(channel).await
+    }
+
+    async fn contains(&self, event_id: EventId) -> Result<bool, BusError> {
+        if self.fail_next_contains.swap(false, Ordering::SeqCst) {
+            return Err(BusError::Sink("transient store outage".into()));
+        }
+        self.inner.contains(event_id).await
+    }
+}
+
+#[tokio::test]
+async fn failed_publish_does_not_poison_the_window_for_a_retry() {
+    let ch = RoomId::from_u128(0x4135);
+    let sink = Arc::new(FlakyContainsSink {
+        inner: Arc::new(InMemoryDurableSink::new()),
+        fail_next_contains: AtomicBool::new(true),
+    });
+    let epoch_store = InMemoryEpochStore::new();
+    let seq = Arc::new(SeqSource::start(&epoch_store));
+    let router = EventRouter::new(
+        RouterConfig::default(),
+        Arc::new(SystemClock) as Arc<dyn Clock>,
+        seq,
+        sink.clone(),
+    );
+
+    // First attempt fails on the durable probe.
+    let first = router.publish_if_new(durable(ch, 0xE, "retry me")).await;
+    assert!(first.is_err(), "transient sink outage must surface");
+
+    // The retry must PUBLISH — a poisoned recent-ids entry would
+    // report Duplicate for an event the router never took (and the
+    // receiver would ack delivered falsely).
+    let second = router
+        .publish_if_new(durable(ch, 0xE, "retry me"))
+        .await
+        .unwrap();
+    assert!(
+        matches!(second, PublishIfNew::Published(_)),
+        "retry after failure must publish, got {second:?}"
+    );
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    assert_eq!(sink.inner.len(ch), 1, "the retried event is durable once");
+}

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1137,6 +1137,18 @@ pub async fn run_daemon(
             }
         };
 
+        // Card 4132f48c: this handle owns the daemon's LAN listener, so
+        // every inbound cross-machine frame is ingested HERE. Route it
+        // into the daemon's owner-core router — the transcript every
+        // attached scope reads — instead of this handle's private store
+        // (the store-split bug: durable in `~/.airc` events, invisible
+        // to every operator scope). Must be installed BEFORE the
+        // listener binds so no frame can race past it.
+        airc.set_inbound_frame_sink(Arc::new(airc_lib::RouterInboundBridge::new(
+            registry_state.router.clone(),
+            registry_state.coordinator_store.clone(),
+        )));
+
         // Endpoint-in-beacon (the second half of same-account
         // auto-discovery): bind a LAN listener on THIS handle so its
         // `route_endpoints()` carries a dialable address, which the
@@ -1282,8 +1294,9 @@ pub async fn run_daemon(
 fn spawn_route_refresh(home: PathBuf, state: Arc<DaemonState>) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let handle: tokio::sync::Mutex<Option<Airc>> = tokio::sync::Mutex::new(None);
+        let refresh_state = state.clone();
         airc_daemon::route_refresh::run_periodic_refresh(&state.shutdown, || {
-            refresh_routes_once(&home, &handle)
+            refresh_routes_once(&home, &handle, &refresh_state)
         })
         .await;
     })
@@ -1295,11 +1308,27 @@ fn spawn_route_refresh(home: PathBuf, state: Arc<DaemonState>) -> tokio::task::J
 /// daemon's diagnostic sink — loud, never silent. Failures never
 /// propagate: the loop's next tick is the retry path (self-heal
 /// doctrine, card 625abe6d).
-async fn refresh_routes_once(home: &Path, handle: &tokio::sync::Mutex<Option<Airc>>) {
+async fn refresh_routes_once(
+    home: &Path,
+    handle: &tokio::sync::Mutex<Option<Airc>>,
+    state: &Arc<DaemonState>,
+) {
     let mut guard = handle.lock().await;
     if guard.is_none() {
         match Airc::open(home).await {
-            Ok(airc) => *guard = Some(airc),
+            Ok(airc) => {
+                // Card 4132f48c: discovery dials open LAN connections
+                // whose inbound frames are ingested on THIS handle —
+                // same router bridge as the listener handle, so a frame
+                // arriving on either (or both — `publish_if_new` dedups
+                // by event_id) lands in the machine transcript scopes
+                // read.
+                airc.set_inbound_frame_sink(Arc::new(airc_lib::RouterInboundBridge::new(
+                    state.router.clone(),
+                    state.coordinator_store.clone(),
+                )));
+                *guard = Some(airc)
+            }
             Err(error) => {
                 StderrJsonDiagnosticSink.emit(
                     DiagnosticEvent::error(

--- a/crates/airc-lib/Cargo.toml
+++ b/crates/airc-lib/Cargo.toml
@@ -38,6 +38,7 @@ airc-work-store = { path = "../airc-work-store" }
 
 async-trait = "0.1"
 base64 = "0.22"
+bytes = "1"
 tracing = "0.1"
 dashmap = "6"
 futures = "0.3"

--- a/crates/airc-lib/src/airc.rs
+++ b/crates/airc-lib/src/airc.rs
@@ -215,6 +215,14 @@ pub(crate) struct AircInner {
     /// stderr JSON; tests inject a `MemoryDiagnosticSink` so "the
     /// diagnostic fired" is a hard assertion, not a log-scrape.
     pub(crate) diag_sink: std::sync::RwLock<Arc<dyn airc_diagnostics::DiagnosticSink>>,
+    /// Card 4132f48c: where inbound transport frames are delivered when
+    /// a daemon hosts this handle. `None` (every non-daemon handle) =
+    /// the classic path: append to this scope's store + in-process
+    /// fan-out. `Some` = the daemon's router bridge owns delivery, so
+    /// inbound LAN/relay frames land in the machine transcript every
+    /// attached scope reads — not in this handle's private scope store.
+    pub(crate) inbound_sink:
+        std::sync::RwLock<Option<Arc<dyn crate::router_bridge::InboundFrameSink>>>,
 }
 
 /// Capacity of the delivery-ack fan-out channel. Acks are tiny,
@@ -440,6 +448,7 @@ impl Airc {
                 diag_sink: std::sync::RwLock::new(Arc::new(
                     airc_diagnostics::StderrJsonDiagnosticSink,
                 )),
+                inbound_sink: std::sync::RwLock::new(None),
             }),
         })
     }
@@ -466,6 +475,30 @@ impl Airc {
             Err(poisoned) => poisoned.into_inner(),
         };
         *guard = sink;
+    }
+
+    /// Install the inbound-frame delivery sink (card 4132f48c). Daemon
+    /// hosts call this on their transport-owning handles so inbound
+    /// LAN/relay frames are delivered into the owner-core router —
+    /// the transcript every attached scope reads — instead of this
+    /// handle's private scope store. See
+    /// [`crate::router_bridge::RouterInboundBridge`].
+    pub fn set_inbound_frame_sink(&self, sink: Arc<dyn crate::router_bridge::InboundFrameSink>) {
+        let mut guard = match self.inner.inbound_sink.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *guard = Some(sink);
+    }
+
+    pub(crate) fn inbound_frame_sink(
+        &self,
+    ) -> Option<Arc<dyn crate::router_bridge::InboundFrameSink>> {
+        let guard = match self.inner.inbound_sink.read() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        guard.clone()
     }
 
     pub(crate) fn diag_sink(&self) -> Arc<dyn airc_diagnostics::DiagnosticSink> {
@@ -896,6 +929,7 @@ impl Airc {
             )),
             ack_tx: self.inner.ack_tx.clone(),
             diag_sink: std::sync::RwLock::new(self.diag_sink()),
+            inbound_sink: std::sync::RwLock::new(self.inbound_frame_sink()),
         };
         Self {
             inner: Arc::new(inner),

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -62,6 +62,7 @@ pub mod registry_refresh;
 mod relay;
 pub mod room;
 pub mod route;
+pub mod router_bridge;
 mod stream;
 pub mod subscriptions;
 pub mod task_negotiation;
@@ -157,6 +158,7 @@ pub use route::{
     TransportCandidate, TransportHealthSample, TransportHealthState, TransportHealthTable,
     TransportKind, TransportResolver, TransportRole, TransportRoute,
 };
+pub use router_bridge::{InboundDeliveryVerdict, InboundFrameSink, RouterInboundBridge};
 pub use stream::{EventFilter, EventStream, FilteredEventStream, LiveLag};
 pub use subscriptions::{
     derive_room_id, ChannelName, ChannelNameError, MeshIdentity, Subscription, SubscriptionError,

--- a/crates/airc-lib/src/router_bridge.rs
+++ b/crates/airc-lib/src/router_bridge.rs
@@ -1,0 +1,276 @@
+//! Inbound-frame delivery into the daemon's owner-core router
+//! (card 4132f48c — the store-split fix).
+//!
+//! ## The split this closes
+//!
+//! The daemon process owns embedded `Airc` handles for its LAN
+//! listener (account-registry glue) and its outbound route-discovery
+//! dials. Before this module, an inbound LAN frame was ingested by
+//! `append_received_frame` into that handle's **SDK store** (the
+//! `events` table of `~/.airc/events.sqlite`) and fanned out only on
+//! that handle's private in-process broadcast. Nothing reached the
+//! daemon's [`EventRouter`] — but the router IS the transcript every
+//! operator scope actually reads: `airc inbox` / `airc msg` /
+//! monitors attach to the machine-singular daemon and page or stream
+//! the router's hot ring + durable tier (`bus_events`). Result: the
+//! frame was durable, acked (post-#1155), and invisible to every
+//! operator surface.
+//!
+//! ## The mechanism (mirrors local delivery)
+//!
+//! A local `airc msg` propagates across scopes on one machine by ONE
+//! mechanism: `Request::Send`/`Publish` → `router.publish` → hot ring,
+//! live fan-out to attached scopes, write-behind to the machine
+//! ORM. This module gives inbound transport frames the SAME path:
+//! the daemon installs a [`RouterInboundBridge`] as the
+//! [`InboundFrameSink`] of its transport-owning handles, and
+//! `append_received_frame` hands every received frame to the bridge
+//! INSTEAD of the handle's scope store. Fan-out at delivery, no
+//! per-scope copies, one durable transcript per machine (§3.3).
+//!
+//! ## No double delivery
+//!
+//! The router's [`EventRouter::publish_if_new`] is idempotent on the
+//! sender-minted `event_id`: the same frame arriving on two LAN links
+//! (listener + dialer handles), or a wire echo of an event a local
+//! scope already published through the router, publishes exactly
+//! once. Cursor coherence is free: bridged events receive owner-
+//! assigned `(epoch, counter)` seqs exactly like local publishes, so
+//! subscription cursors stay monotonic per the router's total order.
+//!
+//! ## Truthful delivery acks (extends card 39d37629)
+//!
+//! With a sink installed, "delivered" means: published into the
+//! router (visible to every scope subscribed to the channel) AND at
+//! least one scope on this machine has the channel bound (presence
+//! beacons in the coordinator store). A frame on a channel no scope
+//! binds is still published durably (no data loss; a later subscriber
+//! replays it) but is acked `undeliverable{unknown_channel}` and
+//! diagnosed loudly — exactly the #1155 posture, upgraded from
+//! "bound in the receiving handle's scope" to "bound by any scope the
+//! machine serves".
+
+use std::sync::Arc;
+
+use airc_bus::envelope::{DeliveryClass, Kind, Target};
+use airc_bus::{EventRouter, PublishIfNew};
+use airc_core::transcript::MentionTarget;
+use airc_core::RoomId;
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
+};
+use airc_protocol::{Frame, FrameKind};
+use airc_store::EventStore;
+use async_trait::async_trait;
+
+use crate::coordinator::{self, CoordinatorConfig};
+use crate::subscriptions::derive_room_id;
+use crate::time;
+
+/// Verdict of an [`InboundFrameSink::deliver`] call. This is the
+/// persistence decision the delivery ack (card 39d37629) reports when
+/// a sink owns inbound delivery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InboundDeliveryVerdict {
+    /// The frame is (or already was) in the machine transcript every
+    /// subscribed scope reads, and at least one scope binds the
+    /// channel.
+    Delivered,
+    /// Durably stored, but no scope on this machine has the frame's
+    /// channel bound — no transcript surface will show it until one
+    /// does. Reported as `undeliverable{unknown_channel}`.
+    UnknownChannel,
+    /// The frame could not be made durable/visible. Reported as
+    /// `undeliverable{persist_failed}`.
+    Failed(String),
+}
+
+/// Where a daemon host routes inbound transport frames. When a sink
+/// is installed on an [`crate::Airc`] handle
+/// ([`crate::Airc::set_inbound_frame_sink`]), the transport ingest
+/// hands every received frame here INSTEAD of appending it to the
+/// handle's scope store; the verdict is the persistence decision the
+/// delivery ack reports.
+#[async_trait]
+pub trait InboundFrameSink: Send + Sync {
+    async fn deliver(&self, frame: &Frame) -> InboundDeliveryVerdict;
+}
+
+/// The production sink: delivers inbound frames into the daemon's
+/// [`EventRouter`] — the same fan-out + durable tier local sends use.
+pub struct RouterInboundBridge {
+    router: EventRouter,
+    coordinator_store: Arc<dyn EventStore>,
+    diag_sink: Arc<dyn DiagnosticSink>,
+}
+
+impl RouterInboundBridge {
+    /// `router` and `coordinator_store` are the daemon's own (the
+    /// owner-core engine and the machine coordinator store its
+    /// presence beacons live in).
+    pub fn new(router: EventRouter, coordinator_store: Arc<dyn EventStore>) -> Self {
+        Self {
+            router,
+            coordinator_store,
+            diag_sink: Arc::new(StderrJsonDiagnosticSink),
+        }
+    }
+
+    /// Replace the diagnostic sink (tests assert emissions instead of
+    /// scraping stderr — same pattern as `Airc::set_diagnostic_sink`).
+    #[must_use]
+    pub fn with_diagnostic_sink(mut self, sink: Arc<dyn DiagnosticSink>) -> Self {
+        self.diag_sink = sink;
+        self
+    }
+
+    /// Does any scope on this machine bind `channel`? Source of truth:
+    /// presence beacons in the coordinator store — every scope's
+    /// `join`/`ensure_join_context` publishes its subscribed channel
+    /// names there. Stale beacons count: a subscription is durable
+    /// scope state, and a quiet scope still reads its transcript later.
+    async fn channel_has_subscribed_scope(&self, channel: RoomId) -> Result<bool, String> {
+        let cached = crate::mesh_identity::resolve(self.coordinator_store.as_ref())
+            .await
+            .map_err(|e| format!("mesh identity: {e}"))?;
+        let identity = cached.as_mesh_identity();
+        let now_ms = time::now_ms().map_err(|e| format!("clock: {e}"))?;
+        let snapshot = coordinator::snapshot_store(
+            self.coordinator_store.as_ref(),
+            &identity,
+            &CoordinatorConfig::default(),
+            now_ms,
+        )
+        .await
+        .map_err(|e| format!("beacon snapshot: {e}"))?;
+        Ok(snapshot
+            .live
+            .iter()
+            .chain(snapshot.stale.iter())
+            .flat_map(|beacon| beacon.subscribed_channels.iter())
+            .any(|name| derive_room_id(&identity, name) == channel))
+    }
+}
+
+#[async_trait]
+impl InboundFrameSink for RouterInboundBridge {
+    async fn deliver(&self, frame: &Frame) -> InboundDeliveryVerdict {
+        let env = bus_envelope_for_inbound(frame);
+        let event_id = frame.envelope.event_id;
+        let channel = frame.envelope.channel;
+        match self.router.publish_if_new(env).await {
+            // Duplicate IS delivered: the existing copy stands, so the
+            // ack stays truthful and the second LAN link's copy never
+            // double-fans-out.
+            Ok(PublishIfNew::Published(_)) | Ok(PublishIfNew::Duplicate) => {
+                match self.channel_has_subscribed_scope(channel).await {
+                    Ok(true) => InboundDeliveryVerdict::Delivered,
+                    Ok(false) => InboundDeliveryVerdict::UnknownChannel,
+                    Err(error) => {
+                        // Can't read the beacon set ⇒ can't honestly
+                        // claim a subscribed scope will see it. Loud,
+                        // then the unknown-channel verdict (the frame
+                        // IS durable in the router — `persist_failed`
+                        // would be the lie here).
+                        self.diag_sink.emit(
+                            DiagnosticEvent::error(
+                                DiagnosticComponent::Subscriber,
+                                DiagnosticCode::FrameUndeliverable,
+                                "beacon set unreadable while concluding inbound delivery",
+                            )
+                            .with_field("event_id", event_id)
+                            .with_field("channel", channel)
+                            .with_field("error", error),
+                        );
+                        InboundDeliveryVerdict::UnknownChannel
+                    }
+                }
+            }
+            Err(error) => InboundDeliveryVerdict::Failed(format!("router publish: {error}")),
+        }
+    }
+}
+
+/// Project an inbound transport [`Frame`] onto the owner-core envelope
+/// shape — the exact inverse pairing of the daemon's IPC publish path
+/// (`airc-daemon::handlers::publish_envelope` + the SDK's
+/// `daemon_send_frame`), so a bridged LAN frame and a locally published
+/// frame of the same content are indistinguishable to readers.
+///
+/// The sender-minted `event_id` is preserved: it is the dedup key in
+/// [`EventRouter::publish_if_new`] and the identity the delivery ack
+/// (`ack.for_event`) refers to. `seq`/`occurred_at_ms` are owner-
+/// stamped at publish, exactly like local sends.
+fn bus_envelope_for_inbound(frame: &Frame) -> airc_bus::envelope::Envelope {
+    let payload = frame
+        .envelope
+        .body
+        .as_ref()
+        .map(airc_core::Body::to_payload)
+        .unwrap_or_default();
+    let kind = match frame.kind {
+        FrameKind::Message => Kind::Message,
+        FrameKind::Event => Kind::Event,
+        FrameKind::Control => Kind::Control,
+    };
+    let mut env = airc_bus::envelope::Envelope::new(
+        frame.envelope.channel,
+        (frame.envelope.sender, frame.envelope.sender_client),
+        kind,
+        DeliveryClass::Durable,
+        bytes::Bytes::from(payload),
+    );
+    env.event_id = frame.envelope.event_id;
+    // Mirrors `From<MentionTarget> for IpcTarget` (airc-ipc
+    // sdk_conversions): room mentions round-trip as `room:<uuid>`
+    // endpoints, which `target_to_mention` parses back.
+    env.target = match frame.envelope.target {
+        MentionTarget::All => Target::All,
+        MentionTarget::Peer(peer) => Target::Peer(peer),
+        MentionTarget::Room(room) => Target::Endpoint(format!("room:{}", room.as_uuid())),
+    };
+    env.correlation_id = frame.envelope.reply_to.map(|id| id.as_uuid());
+    env.headers = frame.envelope.headers.clone();
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::{Body, EventId, Headers, PeerId};
+    use airc_protocol::{Envelope as ProtoEnvelope, Signature};
+
+    fn frame(channel: RoomId, event_id: EventId) -> Frame {
+        Frame {
+            kind: FrameKind::Message,
+            envelope: ProtoEnvelope {
+                event_id,
+                sender: PeerId::new(),
+                sender_client: airc_core::ClientId::new(),
+                channel,
+                target: MentionTarget::All,
+                lamport: 7,
+                occurred_at_ms: 1_000,
+                reply_to: None,
+                headers: Headers::new(),
+                body: Some(Body::text("bridged")),
+                media: Vec::new(),
+                signature: Signature::Unsigned,
+            },
+        }
+    }
+
+    #[test]
+    fn inbound_projection_preserves_identity_and_payload() {
+        let channel = RoomId::new();
+        let event_id = EventId::new();
+        let f = frame(channel, event_id);
+        let env = bus_envelope_for_inbound(&f);
+        assert_eq!(env.event_id, event_id, "sender-minted id must survive");
+        assert_eq!(env.channel, channel);
+        assert_eq!(env.kind, Kind::Message);
+        assert_eq!(env.delivery, DeliveryClass::Durable);
+        let body = Body::from_payload(&env.payload).expect("payload round-trips");
+        assert_eq!(body, Body::text("bridged"));
+    }
+}

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -295,6 +295,105 @@ impl Airc {
             event_id: frame.envelope.event_id,
         };
 
+        // Card 4132f48c: daemon-host mode. When an inbound sink is
+        // installed, the machine's owner-core router — the transcript
+        // every attached scope reads — owns delivery. Persisting into
+        // this handle's scope store instead is exactly the store-split
+        // bug (durable in `~/.airc` events, invisible to every operator
+        // scope), so the sink REPLACES the store append; its verdict is
+        // the persistence decision the delivery ack reports. The sink
+        // is idempotent on event_id (router-level recent-ids window +
+        // durable-tier probe), so a frame arriving on both the daemon's
+        // listener and dialer handles delivers exactly once.
+        if let Some(sink) = self.inbound_frame_sink() {
+            let verdict = sink.deliver(&frame).await;
+            let event_id = frame.envelope.event_id;
+            match verdict {
+                crate::router_bridge::InboundDeliveryVerdict::Delivered => {
+                    // In-process fan-out for any subscriber of THIS
+                    // handle, ring-deduped exactly like the store path.
+                    let event = frame.into_transcript_event();
+                    if self.mark_broadcast(event_id) {
+                        let _ = self.inner.live_tx.send(Arc::new(event));
+                    }
+                    if ack_requested {
+                        self.respond_delivery_ack(
+                            ack_origin,
+                            event_id,
+                            frame_channel,
+                            airc_protocol::DeliveryOutcome::Delivered {
+                                channel: frame_channel,
+                                cursor: frame_cursor,
+                            },
+                        )
+                        .await;
+                    }
+                }
+                crate::router_bridge::InboundDeliveryVerdict::UnknownChannel => {
+                    // Loud regardless of whether an ack was requested —
+                    // a durable frame no scope will surface is the
+                    // silent-drop class this card closes.
+                    self.emit_diag(
+                        DiagnosticEvent::error(
+                            DiagnosticComponent::Subscriber,
+                            DiagnosticCode::FrameUndeliverable,
+                            "inbound frame routed to the machine transcript, but no scope \
+                             on this machine has the channel bound — no transcript surface \
+                             will show it",
+                        )
+                        .with_field(
+                            "reason",
+                            airc_protocol::UndeliverableReason::UnknownChannel.as_str(),
+                        )
+                        .with_field("event_id", event_id)
+                        .with_field("sender", ack_origin)
+                        .with_field("channel", frame_channel)
+                        .with_field("persisted", true),
+                    );
+                    if ack_requested {
+                        self.respond_delivery_ack(
+                            ack_origin,
+                            event_id,
+                            frame_channel,
+                            airc_protocol::DeliveryOutcome::Undeliverable {
+                                reason: airc_protocol::UndeliverableReason::UnknownChannel,
+                            },
+                        )
+                        .await;
+                    }
+                }
+                crate::router_bridge::InboundDeliveryVerdict::Failed(error) => {
+                    self.emit_diag(
+                        DiagnosticEvent::error(
+                            DiagnosticComponent::Subscriber,
+                            DiagnosticCode::FrameUndeliverable,
+                            "inbound frame could not be delivered into the machine \
+                             transcript — undeliverable",
+                        )
+                        .with_field(
+                            "reason",
+                            airc_protocol::UndeliverableReason::PersistFailed.as_str(),
+                        )
+                        .with_field("event_id", event_id)
+                        .with_field("sender", ack_origin)
+                        .with_field("error", error),
+                    );
+                    if ack_requested {
+                        self.respond_delivery_ack(
+                            ack_origin,
+                            event_id,
+                            frame_channel,
+                            airc_protocol::DeliveryOutcome::Undeliverable {
+                                reason: airc_protocol::UndeliverableReason::PersistFailed,
+                            },
+                        )
+                        .await;
+                    }
+                }
+            }
+            return;
+        }
+
         let event = frame.into_transcript_event();
         let event_id = event.event_id;
         // The store dedups persistence by event_id —

--- a/crates/airc-lib/tests/common/mod.rs
+++ b/crates/airc-lib/tests/common/mod.rs
@@ -100,6 +100,13 @@ impl DaemonFixture {
         (state, handle)
     }
 
+    /// The daemon's owner-core router. Card 4132f48c tests build the
+    /// production `RouterInboundBridge` against it, exactly like
+    /// `run_daemon` does.
+    pub fn router(&self) -> airc_bus::EventRouter {
+        self.state.router.clone()
+    }
+
     /// Faithful daemon restart on the same socket + durable db. Fires the
     /// shutdown notifier (graceful `airc stop` equivalent) so the accept
     /// loop AND every live connection handler return — that's what closes
@@ -146,6 +153,13 @@ impl Machine {
     /// Hard-restart this machine's daemon (same socket + durable db).
     pub async fn restart_daemon(&mut self) {
         self.daemon.restart().await;
+    }
+
+    /// The shared wire root every scope on this machine resolves —
+    /// where presence beacons + the mesh-identity cache live
+    /// (`<root>/events.sqlite`), i.e. the machine coordinator store.
+    pub fn wire_root(&self) -> &std::path::Path {
+        self.root.path()
     }
 
     /// Attach a new scope ("tab"/agent) to this machine's daemon.

--- a/crates/airc-lib/tests/daemon_lan_visibility.rs
+++ b/crates/airc-lib/tests/daemon_lan_visibility.rs
@@ -1,0 +1,421 @@
+//! Card 4132f48c — store-split: inbound LAN frames must land in the
+//! transcript operator scopes actually read.
+//!
+//! Live forensics (#1155): a cross-machine message from the 5090
+//! (02:32:10Z) sat durable in the machine store's SDK `events` table
+//! — written by the daemon's LAN-receiving handle — while every
+//! operator surface (`airc inbox`, monitors) reads the daemon's
+//! owner-core router (hot ring + `bus_events` durable tier). Route
+//! healthy, frame delivered + acked, visible to nobody.
+//!
+//! The fix mirrors how local sends already propagate across scopes on
+//! one machine: ONE mechanism, the daemon's `EventRouter`. The
+//! daemon's transport-owning handles install a `RouterInboundBridge`
+//! ([`Airc::set_inbound_frame_sink`]) so every inbound frame is
+//! published into the router — fan-out at delivery, no per-scope
+//! copies — via the idempotent `EventRouter::publish_if_new`.
+//!
+//! Proven here, over a real TLS LAN link into a real in-process
+//! daemon (hermetic temp homes + sockets, RAII teardown, no
+//! production state touched):
+//!
+//!   1. THE test: an inbound LAN frame becomes visible in a
+//!      subscribed scope's transcript (`page_recent` through the
+//!      daemon), and the sender's delivery ack says `delivered`.
+//!   2. A scope subscribed to a different room does NOT see it.
+//!   3. No duplicate when the same event reaches the router twice
+//!      (local publish + LAN echo, or the same frame on two LAN
+//!      links) — exactly one transcript copy.
+//!   4. Cursors stay monotonic across interleaved local and bridged
+//!      events.
+//!   5. Ack truthfulness (extends card 39d37629): with NO scope
+//!      subscribed on the receiving machine the ack is
+//!      `undeliverable{unknown_channel}` + a loud receiver
+//!      diagnostic; after a scope joins, the ack is `delivered` —
+//!      and the earlier frame was durably kept (late join replays
+//!      it).
+
+mod common;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use airc_core::{Body, EventId, Headers, PeerId, RoomId};
+use airc_diagnostics::{DiagnosticCode, MemoryDiagnosticSink};
+use airc_lib::{
+    Airc, DeliveryOutcome, DeliverySendOutcome, InboundDeliveryVerdict, InboundFrameSink, PeerSpec,
+    RouterInboundBridge, UndeliverableReason,
+};
+use airc_protocol::{Envelope as ProtoEnvelope, Frame, FrameKind, Signature};
+use airc_store::{EventStore, SqliteEventStore};
+use common::Machine;
+use tempfile::TempDir;
+
+/// The store every scope on this simulated machine publishes presence
+/// beacons + the mesh-identity cache into (their shared wire root) —
+/// the same store the production daemon passes the bridge as its
+/// coordinator store.
+async fn machine_coordinator_store(machine: &Machine) -> Arc<dyn EventStore> {
+    Arc::new(
+        SqliteEventStore::open_path(&machine.wire_root().join("events.sqlite"))
+            .await
+            .expect("open machine coordinator store"),
+    )
+}
+
+/// Build the production bridge against this machine's daemon router +
+/// coordinator store and install it on a LAN-gateway handle — the
+/// in-process equivalent of what `run_daemon` does for its listener
+/// and dialer handles.
+async fn lan_gateway_with_bridge(machine: &Machine) -> (Airc, Arc<RouterInboundBridge>) {
+    let bridge = Arc::new(RouterInboundBridge::new(
+        machine.daemon.router(),
+        machine_coordinator_store(machine).await,
+    ));
+    let gateway = Airc::open_with_wire_root_for_test(
+        machine.wire_root().join("lan-gateway"),
+        machine.wire_root().to_path_buf(),
+    )
+    .await
+    .expect("open lan gateway handle");
+    gateway.set_inbound_frame_sink(bridge.clone());
+    (gateway, bridge)
+}
+
+/// A remote peer on its own "machine" (isolated temp home), joined to
+/// `room`, mutually trusted and dialed into the gateway's listener.
+async fn dialed_remote(gateway: &Airc, remote_home: &TempDir, room: &str) -> Airc {
+    let remote = Airc::open(remote_home.path().join(".airc"))
+        .await
+        .expect("open remote");
+    remote.join(room).await.expect("remote joins room");
+    let remote_spec: PeerSpec = remote.peer_spec().parse().expect("remote spec");
+    let gateway_spec: PeerSpec = gateway.peer_spec().parse().expect("gateway spec");
+    gateway
+        .add_peer(remote_spec)
+        .await
+        .expect("gateway trusts remote");
+    remote
+        .add_peer(gateway_spec)
+        .await
+        .expect("remote trusts gateway");
+    let addr: SocketAddr = gateway
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("gateway listens");
+    remote
+        .connect_lan(addr, gateway.peer_id())
+        .await
+        .expect("remote dials gateway");
+    remote
+}
+
+fn expect_delivered(outcome: DeliverySendOutcome) -> EventId {
+    match outcome {
+        DeliverySendOutcome::Delivered { event_id, .. } => event_id,
+        DeliverySendOutcome::Undeliverable { .. } | DeliverySendOutcome::NoAck { .. } => {
+            panic!("expected Delivered, got {outcome:?}")
+        }
+    }
+}
+
+/// A bare inbound frame as the bridge sees one post-verification —
+/// used to exercise echo/duplicate shapes where the wire would carry
+/// an event_id we control.
+fn inbound_frame(channel: RoomId, event_id: EventId, text: &str) -> Frame {
+    Frame {
+        kind: FrameKind::Message,
+        envelope: ProtoEnvelope {
+            event_id,
+            sender: PeerId::new(),
+            sender_client: airc_core::ClientId::new(),
+            channel,
+            target: airc_core::MentionTarget::All,
+            lamport: 1,
+            occurred_at_ms: 1_000,
+            reply_to: None,
+            headers: Headers::new(),
+            body: Some(Body::text(text)),
+            media: Vec::new(),
+            signature: Signature::Unsigned,
+        },
+    }
+}
+
+/// THE test (the card): a cross-machine room message arrives over a
+/// real TLS LAN link and must appear in the transcript a subscribed
+/// operator scope reads through the daemon — and the sender's
+/// delivery ack must say so.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn inbound_lan_frame_is_visible_in_subscribed_scope_transcript() {
+    let machine = Machine::boot().await;
+    let operator = machine.attach("operator").await;
+    operator
+        .join("store-split-room")
+        .await
+        .expect("operator joins");
+
+    let (gateway, _bridge) = lan_gateway_with_bridge(&machine).await;
+    let remote_home = TempDir::new().expect("remote home");
+    let remote = dialed_remote(&gateway, &remote_home, "store-split-room").await;
+
+    let outcome = remote
+        .send_with_delivery_ack(
+            "cross-machine hello, visible at last",
+            Headers::new(),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("ack-requesting send succeeds");
+    let event_id = expect_delivered(outcome);
+
+    // The keystone: the OPERATOR SCOPE's transcript surface (daemon
+    // inbox on its current room) shows the cross-machine message.
+    let recent = operator
+        .page_recent(16)
+        .await
+        .expect("operator page_recent");
+    let delivered: Vec<_> = recent
+        .iter()
+        .filter(|event| event.event_id == event_id)
+        .collect();
+    assert_eq!(
+        delivered.len(),
+        1,
+        "the delivered-acked cross-machine event must appear exactly once in the \
+         subscribed scope's transcript; got {} of it among {} events",
+        delivered.len(),
+        recent.len()
+    );
+    assert_eq!(
+        delivered[0].body.as_ref().and_then(Body::as_text),
+        Some("cross-machine hello, visible at last"),
+        "transcript body must round-trip"
+    );
+}
+
+/// A scope on the same machine subscribed to a DIFFERENT room must not
+/// see the inbound frame — visibility is read-side channel scoping,
+/// exactly like local sends.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unsubscribed_scope_does_not_see_inbound_frame() {
+    let machine = Machine::boot().await;
+    let operator = machine.attach("operator").await;
+    operator
+        .join("store-split-room")
+        .await
+        .expect("operator joins");
+    let bystander = machine.attach("bystander").await;
+    bystander
+        .join("uninvolved-room")
+        .await
+        .expect("bystander joins");
+
+    let (gateway, _bridge) = lan_gateway_with_bridge(&machine).await;
+    let remote_home = TempDir::new().expect("remote home");
+    let remote = dialed_remote(&gateway, &remote_home, "store-split-room").await;
+
+    let outcome = remote
+        .send_with_delivery_ack(
+            "not for the bystander",
+            Headers::new(),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("send succeeds");
+    let event_id = expect_delivered(outcome);
+
+    let bystander_view = bystander
+        .page_recent(32)
+        .await
+        .expect("bystander page_recent");
+    assert!(
+        !bystander_view
+            .iter()
+            .any(|event| event.event_id == event_id),
+        "a scope subscribed to a different room must not see the frame"
+    );
+}
+
+/// No double delivery (card constraint): the same event_id reaching
+/// the router twice — a LAN echo of a locally published event, or the
+/// same frame arriving on the daemon's listener AND dialer handles —
+/// must keep exactly one transcript copy.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn same_event_id_through_local_publish_and_lan_echo_delivers_once() {
+    let machine = Machine::boot().await;
+    let operator = machine.attach("operator").await;
+    let room = operator.join("store-split-room").await.expect("join");
+    let (_gateway, bridge) = lan_gateway_with_bridge(&machine).await;
+
+    // Shape A: local-sender + LAN-receiver. The scope publishes
+    // through the daemon; the same event then echoes back over a LAN
+    // link onto the bridge.
+    let local_id = operator.say("local original").await.expect("local say");
+    let verdict = bridge
+        .deliver(&inbound_frame(room.channel, local_id, "local original"))
+        .await;
+    assert_eq!(
+        verdict,
+        InboundDeliveryVerdict::Delivered,
+        "an already-delivered duplicate still acks delivered (it IS delivered)"
+    );
+
+    // Shape B: the same inbound frame on two LAN links.
+    let wire_id = EventId::new();
+    let first = bridge
+        .deliver(&inbound_frame(room.channel, wire_id, "wire frame"))
+        .await;
+    let second = bridge
+        .deliver(&inbound_frame(room.channel, wire_id, "wire frame"))
+        .await;
+    assert_eq!(first, InboundDeliveryVerdict::Delivered);
+    assert_eq!(second, InboundDeliveryVerdict::Delivered);
+
+    let recent = operator.page_recent(32).await.expect("page_recent");
+    let local_copies = recent
+        .iter()
+        .filter(|event| event.event_id == local_id)
+        .count();
+    let wire_copies = recent
+        .iter()
+        .filter(|event| event.event_id == wire_id)
+        .count();
+    assert_eq!(
+        local_copies, 1,
+        "locally published event must not duplicate when its LAN echo arrives"
+    );
+    assert_eq!(
+        wire_copies, 1,
+        "the same inbound frame on two links must deliver exactly once"
+    );
+}
+
+/// Cursor coherence (card constraint): bridged events take owner-
+/// assigned seqs exactly like local publishes, so the transcript's
+/// cursor order stays strictly monotonic across interleaving.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cursors_stay_monotonic_across_local_and_bridged_events() {
+    let machine = Machine::boot().await;
+    let operator = machine.attach("operator").await;
+    let room = operator.join("store-split-room").await.expect("join");
+    let (_gateway, bridge) = lan_gateway_with_bridge(&machine).await;
+
+    operator.say("local-1").await.expect("say 1");
+    let bridged_1 = EventId::new();
+    assert_eq!(
+        bridge
+            .deliver(&inbound_frame(room.channel, bridged_1, "bridged-1"))
+            .await,
+        InboundDeliveryVerdict::Delivered
+    );
+    operator.say("local-2").await.expect("say 2");
+    let bridged_2 = EventId::new();
+    assert_eq!(
+        bridge
+            .deliver(&inbound_frame(room.channel, bridged_2, "bridged-2"))
+            .await,
+        InboundDeliveryVerdict::Delivered
+    );
+
+    let recent = operator.page_recent(32).await.expect("page_recent");
+    assert!(
+        recent.len() >= 4,
+        "expected at least the four interleaved events, got {}",
+        recent.len()
+    );
+    for pair in recent.windows(2) {
+        assert!(
+            pair[1].cursor().lamport > pair[0].cursor().lamport
+                || (pair[1].cursor().lamport == pair[0].cursor().lamport
+                    && pair[1].event_id.0 > pair[0].event_id.0),
+            "transcript order must be strictly monotonic; got {:?} then {:?}",
+            pair[0].cursor(),
+            pair[1].cursor()
+        );
+    }
+    let ids: Vec<EventId> = recent.iter().map(|event| event.event_id).collect();
+    assert!(ids.contains(&bridged_1) && ids.contains(&bridged_2));
+}
+
+/// Ack truthfulness (extends #1155): after this card, `delivered`
+/// means visible-to-subscribed-scopes — not just machine-durable.
+/// With no scope subscribed the receiver says unknown_channel (loud),
+/// keeps the frame durably, and flips to delivered once a scope joins
+/// — at which point the late joiner replays the earlier frame too.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delivered_ack_means_visible_to_subscribed_scopes_not_just_durable() {
+    let machine = Machine::boot().await;
+    let (gateway, _bridge) = lan_gateway_with_bridge(&machine).await;
+    let diag = MemoryDiagnosticSink::default();
+    gateway.set_diagnostic_sink(Arc::new(diag.clone()));
+
+    let remote_home = TempDir::new().expect("remote home");
+    let remote = dialed_remote(&gateway, &remote_home, "store-split-room").await;
+
+    // Nobody on the receiving machine subscribes yet.
+    let outcome = remote
+        .send_with_delivery_ack(
+            "durable but nobody reads this yet",
+            Headers::new(),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("send succeeds");
+    let first_id = match outcome {
+        DeliverySendOutcome::Undeliverable { event_id, ack } => {
+            assert_eq!(
+                ack.outcome,
+                DeliveryOutcome::Undeliverable {
+                    reason: UndeliverableReason::UnknownChannel
+                },
+                "no subscribed scope => unknown_channel, even though the frame is durable"
+            );
+            event_id
+        }
+        DeliverySendOutcome::Delivered { .. } | DeliverySendOutcome::NoAck { .. } => {
+            panic!("expected Undeliverable while no scope subscribes, got {outcome:?}")
+        }
+    };
+    assert!(
+        diag.events()
+            .iter()
+            .any(|event| event.code == DiagnosticCode::FrameUndeliverable
+                && event
+                    .fields
+                    .get("reason")
+                    .is_some_and(|reason| reason == "unknown_channel")),
+        "the receiver must say LOUDLY that a durable frame has no reader"
+    );
+
+    // An operator scope joins the room — now there is a reader.
+    let operator = machine.attach("operator").await;
+    operator
+        .join("store-split-room")
+        .await
+        .expect("operator joins");
+
+    let outcome = remote
+        .send_with_delivery_ack(
+            "now someone reads it",
+            Headers::new(),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("second send succeeds");
+    let second_id = expect_delivered(outcome);
+
+    // The late joiner sees BOTH: the delivered one and the earlier
+    // durably-kept frame (no data loss on unknown_channel).
+    let recent = operator.page_recent(32).await.expect("page_recent");
+    let ids: Vec<EventId> = recent.iter().map(|event| event.event_id).collect();
+    assert!(
+        ids.contains(&second_id),
+        "delivered-acked event must be in the subscribed scope's transcript"
+    );
+    assert!(
+        ids.contains(&first_id),
+        "the pre-subscription frame stays durable and replays to a late joiner"
+    );
+}

--- a/crates/airc-store/src/bus_sink.rs
+++ b/crates/airc-store/src/bus_sink.rs
@@ -201,6 +201,16 @@ impl DurableSink for SqliteDurableSink {
             )
         }))
     }
+
+    /// Card 4132f48c: one indexed primary-key probe (`event_id` is the
+    /// PK) — the durable leg of `EventRouter::publish_if_new`.
+    async fn contains(&self, event_id: EventId) -> Result<bool, BusError> {
+        let row = bus_event::Entity::find_by_id(event_id.as_uuid())
+            .one(&self.db)
+            .await
+            .map_err(|e| BusError::Sink(e.to_string()))?;
+        Ok(row.is_some())
+    }
 }
 
 /// Put the connection in WAL journal mode (§3.3). WAL lets the

--- a/crates/airc-store/tests/bus_router_durable_tier.rs
+++ b/crates/airc-store/tests/bus_router_durable_tier.rs
@@ -78,6 +78,10 @@ impl DurableSink for GatedSqliteSink {
     async fn head_cursor(&self, channel: RoomId) -> Result<Option<Cursor>, BusError> {
         self.inner.head_cursor(channel).await
     }
+
+    async fn contains(&self, event_id: airc_core::EventId) -> Result<bool, BusError> {
+        self.inner.contains(event_id).await
+    }
 }
 
 /// Deterministic durable envelope with a stable event_id so replayed


### PR DESCRIPTION
## Card 4132f48c — store-split: delivered frames invisible to operator scopes

Forensic origin: #1155 (live repro 2026-06-12 02:32:10Z — a 5090→Mac message durable in `~/.airc/events.sqlite`, visible in NO operator scope transcript). This PR closes the last leg blocking visible cross-machine room delivery.

## Store topology map (who writes where, who reads where)

**Writes (inbound LAN, before this PR):**
- The daemon process owns two embedded `Airc` handles: the account-registry glue handle (binds the LAN listener, `home = machine ~/.airc`) and the route-refresh handle (outbound discovery dials, `home =` daemon launch scope).
- Frames arriving on either handle were ingested by `append_received_frame` → that handle's **SDK store** (`events` table of its home's `events.sqlite`) + that handle's private in-process broadcast. The machine store's `events` table is where the 02:32:10Z frame sat.
- Nothing reached the daemon's `EventRouter`.

**Reads (operator scopes):**
- `airc inbox` / `airc msg` / monitors all attach to the machine-singular daemon (`attached_airc` → `ensure_daemon_running` → `Airc::attach`). `page_recent`/`resume_from`/live subscribe go over IPC to the daemon's **router** — hot ring + `bus_events` durable tier of the machine ORM (`DaemonState` doc: "durable transcript lives in the router's sink, not the coordinator store").
- So the precise split is **SDK `events` table (write side) vs router hot-ring/`bus_events` (read side)** — same physical sqlite file on the machine home, two disjoint transcripts. Scope stores never see inbound frames either; the channel UUID (#1085, identical across scopes by design) never diverges — the *store placement* does.

**How local scope→scope already works (the mechanism mirrored):** a local send is `Request::Send/Publish` → `router.publish` → hot ring + live fan-out to every attached scope + write-behind to the machine ORM. One mechanism, fan-out at delivery, no per-scope copies.

## Design chosen: (c)-shaped — single transcript per machine, deliver inbound frames into the router

- **airc-lib `router_bridge` (new):** `InboundFrameSink` trait + `RouterInboundBridge`. With a sink installed (`Airc::set_inbound_frame_sink`), `append_received_frame` hands every received frame to the sink INSTEAD of the handle's scope store — the sink's verdict is the persistence decision the delivery ack reports. The bridge projects the frame onto the owner-core envelope shape (mirror of `handlers::publish_envelope` + `daemon_send_frame`, sender-minted `event_id` preserved) and publishes through the router.
- **airc-bus:** `EventRouter::publish_if_new` — idempotent ingest publish. Two legs: a router-level recent-event-ids window (every `publish` records its id, so a wire echo of a *locally published* event dedups too) and the new required `DurableSink::contains` (indexed PK probe; covers post-restart re-injects). Read-side `resume_from_cursor` dedup is adjacency-only `dedup_by`, so this write-side idempotency is load-bearing for the ring/live tiers.
- **airc-cli `run_daemon`:** installs the bridge on both daemon handles (registry listener — *before* the listener binds — and the route-refresh dialer).

**Why not (a) fan-out copies into every scope store:** contradicts §3.3 (ONE ORM per machine, no per-scope transcript), multiplies writes, and scope stores are not the read path the daemon-attached surfaces use. **Why not (b) read-side union:** every read pays a two-store merge across two incompatible cursor domains (SDK lamport vs generational seq) forever; the broken leg is the write side, not the read side.

**Cursor coherence:** bridged events get owner-assigned `(epoch, counter)` seqs exactly like local publishes — one total order, `room_tip` (#1144) and resume semantics untouched. **Wire compat:** no frame/transcript format change; no new ack vocabulary (#1155 labels reused).

## Ack truthfulness (extends #1155)

`delivered{channel,cursor}` now means **visible-to-subscribed-scopes**: published into the router AND at least one scope on the machine binds the channel (presence beacons in the coordinator store — every scope's join publishes its channel set there; stale beacons count because a subscription is durable scope state). No subscribed scope ⇒ `undeliverable{unknown_channel}` + loud `frame_undeliverable` diagnostic, frame kept durable (a late joiner replays it — proven in test). Duplicate arrival acks `delivered` (it IS delivered). Durability note: like every local send, the receipt is issued after ring+fan-out with write-behind enqueued (§3.8 ring pinned until persisted) — identical crash window to `handle_send`, no new class.

## Tests (hermetic: temp homes, in-process daemon + real TLS LAN links, RAII teardown; no production daemon/route touched)

`crates/airc-lib/tests/daemon_lan_visibility.rs`:
1. **THE card test** — inbound LAN frame (real `send_with_delivery_ack` over TLS) appears exactly once in a subscribed scope's transcript read through the daemon; ack says delivered.
2. Scope subscribed to a different room does NOT see it.
3. No duplicate: local-publish + LAN echo of the same event_id, and the same frame on two links — exactly one transcript copy.
4. Cursor monotonicity across interleaved local and bridged events.
5. Ack truthfulness: no subscribed scope ⇒ unknown_channel + loud diagnostic (MemoryDiagnosticSink-asserted); after a scope joins ⇒ delivered, and the earlier frame replays to the late joiner.

`crates/airc-bus/tests/publish_if_new.rs`: duplicate is a no-op at every tier (live fan-out order-pinned with a sentinel, sink row count); wire echo of a plain `publish` is a duplicate; already-durable id is duplicate even for a fresh router (restart shape, `DurableSink::contains` leg).

## Mutation evidence (each applied, observed failing, restored; suite green after)

1. **M1 — bridge severed** (`inbound_frame_sink()` → `None`): `inbound_lan_frame_is_visible_in_subscribed_scope_transcript` **FAILED**.
2. **M2 — dedup disabled** (`publish_if_new` always publishes): all 3 `publish_if_new` pins **FAILED** (live-tier sentinel ordering + sink row counts caught it; noted: the lib-level inbox read alone was insensitive because of read-side adjacent `dedup_by` — which is exactly why the bus-level pins exist).
3. **M3 — ack lies** (UnknownChannel verdict acks delivered): `delivered_ack_means_visible_to_subscribed_scopes_not_just_durable` **FAILED**.
4. **M4 — diagnostic suppressed** (unknown-channel `frame_undeliverable` removed): same test **FAILED** on the sink assertion.

## Production gate

- `cargo clippy --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --workspace -- --skip codex_hook` — green (exit 0)

Forensics: #1155. Card: 4132f48c-6131-4a22-9f73-d4b60dc56a63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
