### PR TITLE
feat(transport): routed-ack — daemon route-layer traversal + delivery acks for ordinary room sends (card 1998f6cb)

### DIFF
--- a/crates/airc-bus/src/lib.rs
+++ b/crates/airc-bus/src/lib.rs
@@ -51,6 +51,6 @@ pub use ephemeral::EphemeralCache;
 pub use error::{BusError, Result};
 pub use filter::Filter;
 pub use ring::HotRing;
-pub use router::{EventRouter, LagFlag, PublishIfNew, RouterConfig};
+pub use router::{EventRouter, ForwardItem, LagFlag, PublishIfNew, RouterConfig};
 pub use seq::{EpochStore, InMemoryEpochStore, SeqSource};
 pub use sink::{DurableSink, InMemoryDurableSink};

--- a/crates/airc-bus/src/router.rs
+++ b/crates/airc-bus/src/router.rs
@@ -35,7 +35,7 @@ use std::sync::{Arc, Mutex};
 use futures::stream::Stream;
 use tokio::sync::mpsc;
 
-use airc_core::RoomId;
+use airc_core::{PeerId, RoomId};
 
 use crate::clock::Clock;
 use crate::envelope::{Cursor, Envelope};
@@ -164,6 +164,24 @@ impl RecentEventIds {
     }
 }
 
+/// Card 1998f6cb: one durable envelope the router accepted, handed to
+/// the installed outbound forward sink (route layer) so it can
+/// traverse established LAN routes. The OUTBOUND mirror of card
+/// 4132f48c's inbound bridge: inbound goes transport → router via
+/// `publish_if_new`; outbound goes router → transport via this item.
+#[derive(Debug, Clone)]
+pub struct ForwardItem {
+    /// The published envelope, post owner-stamping (`seq` /
+    /// `occurred_at_ms` assigned). Shared, never deep-copied.
+    pub env: Arc<Envelope>,
+    /// The LAN-link peer this envelope ARRIVED from, when it entered
+    /// the router through the inbound bridge (`publish_if_new_from`).
+    /// `None` = locally originated (IPC publish). Loop prevention: the
+    /// forwarder must never send a frame back over the link it came
+    /// from.
+    pub origin: Option<PeerId>,
+}
+
 /// Outcome of [`EventRouter::publish_if_new`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PublishIfNew {
@@ -196,6 +214,17 @@ struct RouterInner {
     /// event (or the same inbound frame arriving on two LAN links) can
     /// never fan out twice.
     recent_ids: Mutex<RecentEventIds>,
+    /// Card 1998f6cb: the outbound route-layer sink. When installed
+    /// (`set_forward_sink`), every successfully published **durable**
+    /// envelope is offered here (bounded `try_send`, never blocking the
+    /// hot path) so the daemon's forwarder can send it over established
+    /// LAN routes. Saturation is LOUD: counted + traced, never silent.
+    forward_tx: Mutex<Option<mpsc::Sender<ForwardItem>>>,
+    /// Count of durable envelopes NOT handed to the forward sink because
+    /// its bounded queue was full (or the forwarder task was gone).
+    /// Surfaced for diagnostics/tests; every increment also traces at
+    /// error level.
+    forward_drop_count: AtomicU64,
     /// Count of events shed because the write-behind queue was saturated and
     /// the publisher was fire-and-forget (§3.8). Surfaced for diagnostics.
     shed_count: AtomicU64,
@@ -233,6 +262,8 @@ impl EventRouter {
             sink,
             write_behind_tx,
             recent_ids: Mutex::new(RecentEventIds::with_capacity(RECENT_PUBLISH_IDS_CAPACITY)),
+            forward_tx: Mutex::new(None),
+            forward_drop_count: AtomicU64::new(0),
             shed_count: AtomicU64::new(0),
             channels_created: AtomicU64::new(0),
         });
@@ -265,7 +296,83 @@ impl EventRouter {
     /// 3. Off the lock: enqueue `Durable` envelopes to write-behind.
     ///
     /// [`Seq`]: crate::Seq
-    pub async fn publish(&self, mut env: Envelope) -> crate::Result<crate::Seq> {
+    pub async fn publish(&self, env: Envelope) -> crate::Result<crate::Seq> {
+        self.publish_from(env, None).await
+    }
+
+    /// Card 1998f6cb: install the outbound route-layer sink. Every
+    /// successfully published durable envelope is offered to `tx`
+    /// (bounded, non-blocking) as a [`ForwardItem`] carrying the
+    /// origin LAN peer (if the publish came through the inbound
+    /// bridge) so the forwarder can apply loop prevention.
+    pub fn set_forward_sink(&self, tx: mpsc::Sender<ForwardItem>) {
+        let mut guard = self
+            .inner
+            .forward_tx
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        *guard = Some(tx);
+    }
+
+    /// Card 1998f6cb: durable envelopes NOT offered to the forward sink
+    /// because its queue was saturated (or its task gone). Loud-drop
+    /// counter — pairs with the error-level trace at the drop site.
+    pub fn forward_drop_count(&self) -> u64 {
+        self.inner.forward_drop_count.load(Ordering::SeqCst)
+    }
+
+    /// Offer a just-published durable envelope to the forward sink, if
+    /// one is installed. `try_send` only — the route layer must never
+    /// backpressure the in-memory hot path; a full queue is a LOUD,
+    /// counted drop (the forwarder is expected to be drained far faster
+    /// than the LAN can be saturated by room chat).
+    fn offer_to_forward_sink(&self, env: &Arc<Envelope>, origin: Option<PeerId>) {
+        let tx = {
+            let guard = self
+                .inner
+                .forward_tx
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            guard.clone()
+        };
+        let Some(tx) = tx else {
+            return;
+        };
+        let item = ForwardItem {
+            env: Arc::clone(env),
+            origin,
+        };
+        match tx.try_send(item) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(item)) => {
+                self.inner.forward_drop_count.fetch_add(1, Ordering::SeqCst);
+                tracing::error!(
+                    event_id = %item.env.event_id,
+                    channel = %item.env.channel,
+                    "airc-bus forward sink queue FULL — durable event was published locally \
+                     but will NOT be forwarded over LAN routes (card 1998f6cb loud-drop)"
+                );
+            }
+            Err(mpsc::error::TrySendError::Closed(item)) => {
+                self.inner.forward_drop_count.fetch_add(1, Ordering::SeqCst);
+                tracing::error!(
+                    event_id = %item.env.event_id,
+                    channel = %item.env.channel,
+                    "airc-bus forward sink receiver is GONE — durable event was published \
+                     locally but will NOT be forwarded over LAN routes (card 1998f6cb)"
+                );
+            }
+        }
+    }
+
+    /// [`EventRouter::publish`] with the originating LAN-link peer
+    /// attached (card 1998f6cb). `origin` is purely forward-sink
+    /// metadata — local delivery semantics are identical to `publish`.
+    async fn publish_from(
+        &self,
+        mut env: Envelope,
+        origin: Option<PeerId>,
+    ) -> crate::Result<crate::Seq> {
         let seq = self.inner.seq.next();
         env.seq = seq;
         env.occurred_at_ms = self.inner.clock.now_ms();
@@ -389,6 +496,12 @@ impl EventRouter {
                     return Err(crate::BusError::Sink("write-behind task gone".into()));
                 }
             }
+            // Card 1998f6cb: the event is accepted locally (ring +
+            // fan-out + write-behind enqueued) — offer it to the
+            // route layer so it traverses established LAN routes.
+            // Durable only: ephemeral/stream classes stay machine-
+            // local in this slice. Off the shard lock, non-blocking.
+            self.offer_to_forward_sink(&env, origin);
         }
 
         Ok(seq)
@@ -416,6 +529,23 @@ impl EventRouter {
     /// `publish_if_new` calls for the same id race to exactly one
     /// `Published`.
     pub async fn publish_if_new(&self, env: Envelope) -> crate::Result<PublishIfNew> {
+        self.publish_if_new_from(env, None).await
+    }
+
+    /// [`EventRouter::publish_if_new`] with the LAN-link peer the frame
+    /// arrived from (card 1998f6cb). The inbound bridge passes the
+    /// verified link origin here so a `Published` outcome reaches the
+    /// forward sink carrying it — the forwarder then never echoes the
+    /// frame back over the link it came from, and a `Duplicate` is
+    /// never re-forwarded at all (the first arrival already was). The
+    /// pair of those two rules is what makes mesh forwarding terminate:
+    /// a frame floods outward once per node, and every re-arrival is a
+    /// duplicate dead-end.
+    pub async fn publish_if_new_from(
+        &self,
+        env: Envelope,
+        origin: Option<PeerId>,
+    ) -> crate::Result<PublishIfNew> {
         let already_recent = {
             let mut recent = self
                 .inner
@@ -449,7 +579,7 @@ impl EventRouter {
                 return Err(error);
             }
         }
-        match self.publish(env).await {
+        match self.publish_from(env, origin).await {
             Ok(seq) => Ok(PublishIfNew::Published(seq)),
             Err(error) => {
                 unmark(self);

--- a/crates/airc-bus/tests/forward_sink.rs
+++ b/crates/airc-bus/tests/forward_sink.rs
@@ -1,0 +1,133 @@
+//! Card 1998f6cb — the router's outbound route-layer tap
+//! (`EventRouter::set_forward_sink`), the OUTBOUND mirror of card
+//! 4132f48c's `publish_if_new` ingest.
+//!
+//! Pins, at the bus level (the airc-lib integration suite covers the
+//! full two-daemon TLS path):
+//!   1. every successfully published DURABLE envelope reaches the
+//!      sink, carrying the origin LAN peer the publish came in with
+//!      (`None` for local publishes) — the forwarder's loop-prevention
+//!      input;
+//!   2. a `Duplicate` outcome of `publish_if_new` NEVER reaches the
+//!      sink — re-arrivals are dead-ends, which is what makes mesh
+//!      forwarding terminate;
+//!   3. ephemeral classes stay machine-local (never offered);
+//!   4. sink saturation is a counted loud-drop that neither blocks
+//!      nor fails the publish hot path.
+
+mod common;
+
+use std::time::Duration;
+
+use airc_bus::{ForwardItem, PublishIfNew, RouterConfig};
+use airc_core::{PeerId, RoomId};
+use common::{durable, ephemeral, Owner};
+use tokio::sync::mpsc;
+
+async fn recv_item(rx: &mut mpsc::Receiver<ForwardItem>) -> ForwardItem {
+    tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("forward sink must receive within 2s")
+        .expect("forward sink channel must stay open")
+}
+
+#[tokio::test]
+async fn published_durables_reach_the_forward_sink_with_their_origin() {
+    let owner = Owner::new(RouterConfig::default());
+    let (tx, mut rx) = mpsc::channel(16);
+    owner.router.set_forward_sink(tx);
+    let channel = RoomId::from_u128(0xf0);
+    let origin_peer = PeerId::from_u128(0xa11ce);
+
+    // Local publish (the IPC `Send` path) → origin None.
+    owner
+        .router
+        .publish(durable(channel, 1, "local send"))
+        .await
+        .expect("publish");
+    let local = recv_item(&mut rx).await;
+    assert_eq!(local.env.event_id, airc_core::EventId::from_u128(1));
+    assert_eq!(
+        local.origin, None,
+        "a locally originated publish must carry no origin link"
+    );
+
+    // Bridged inbound publish → origin Some(link peer).
+    let outcome = owner
+        .router
+        .publish_if_new_from(durable(channel, 2, "bridged inbound"), Some(origin_peer))
+        .await
+        .expect("publish_if_new_from");
+    assert!(matches!(outcome, PublishIfNew::Published(_)));
+    let bridged = recv_item(&mut rx).await;
+    assert_eq!(bridged.env.event_id, airc_core::EventId::from_u128(2));
+    assert_eq!(
+        bridged.origin,
+        Some(origin_peer),
+        "a bridged publish must carry the link peer it arrived from \
+         (loop-prevention input for the forwarder)"
+    );
+}
+
+#[tokio::test]
+async fn duplicates_and_ephemerals_never_reach_the_forward_sink() {
+    let owner = Owner::new(RouterConfig::default());
+    let (tx, mut rx) = mpsc::channel(16);
+    owner.router.set_forward_sink(tx);
+    let channel = RoomId::from_u128(0xf1);
+    let origin = PeerId::from_u128(0xb0b);
+
+    owner
+        .router
+        .publish_if_new_from(durable(channel, 7, "first arrival"), Some(origin))
+        .await
+        .expect("first publish");
+    let first = recv_item(&mut rx).await;
+    assert_eq!(first.env.event_id, airc_core::EventId::from_u128(7));
+
+    // Re-arrival of the same event (echo) — Duplicate, NOT re-offered.
+    let echo = owner
+        .router
+        .publish_if_new_from(durable(channel, 7, "first arrival"), Some(origin))
+        .await
+        .expect("echo publish");
+    assert_eq!(echo, PublishIfNew::Duplicate);
+
+    // Ephemeral — machine-local in this slice, never offered.
+    owner
+        .router
+        .publish(ephemeral(channel, 8, "pose", b"xy"))
+        .await
+        .expect("ephemeral publish");
+
+    let extra = tokio::time::timeout(Duration::from_millis(300), rx.recv()).await;
+    assert!(
+        extra.is_err(),
+        "neither a Duplicate re-arrival nor an ephemeral may reach the \
+         forward sink; got {extra:?}"
+    );
+}
+
+#[tokio::test]
+async fn forward_sink_saturation_is_a_counted_loud_drop_not_a_publish_failure() {
+    let owner = Owner::new(RouterConfig::default());
+    // Capacity 1 and never drained: every publish past the first must
+    // overflow the tap.
+    let (tx, _rx) = mpsc::channel(1);
+    owner.router.set_forward_sink(tx);
+    let channel = RoomId::from_u128(0xf2);
+
+    for marker in 0..4u128 {
+        owner
+            .router
+            .publish(durable(channel, 100 + marker, "burst"))
+            .await
+            .expect("publish must keep succeeding while the forward tap overflows");
+    }
+
+    assert_eq!(
+        owner.router.forward_drop_count(),
+        3,
+        "every overflowed offer must be counted (loud-drop, never silent)"
+    );
+}

--- a/crates/airc-cli/src/commands.rs
+++ b/crates/airc-cli/src/commands.rs
@@ -1094,10 +1094,22 @@ pub async fn run_daemon(
         identity.peer_id,
         socket.display()
     );
+    // Card 1998f6cb: the OUTBOUND mirror of the inbound router bridge.
+    // Install the routed forwarder on the daemon's router BEFORE any
+    // transport handle comes up, so every durable publish (local IPC
+    // sends AND bridged inbound frames) is offered to the route layer
+    // and traverses established LAN connections — with delivery acks,
+    // loop prevention by origin link, and loud bounded-queue drops.
+    let routed_forwarder = airc_lib::RoutedForwarder::install(
+        &state.router,
+        airc_lib::RoutedForwarderConfig::default(),
+    );
+
     // Card 625abe6d slice 2: the daemon, not the operator, keeps
     // routes alive. Spawn the periodic route-discovery refresh before
     // the accept loop blocks; it exits on the same shutdown notifier.
-    let route_refresh_task = spawn_route_refresh(home.to_path_buf(), state.clone());
+    let route_refresh_task =
+        spawn_route_refresh(home.to_path_buf(), state.clone(), routed_forwarder.clone());
 
     // KEYSTONE (card a134b370-10b1-49c6-aa42-e1a05446e887): spawn the
     // account-registry publish/refresh loop alongside the IPC accept
@@ -1115,6 +1127,7 @@ pub async fn run_daemon(
     // holds internally (same lost-wakeup discipline as `server::run`).
     let registry_state = state.clone();
     let registry_home = state.home.clone();
+    let registry_forwarder = routed_forwarder.clone();
     let registry_handle = tokio::spawn(async move {
         // HERMETIC GATE (card d793c242): test/temp daemons inherit the
         // operator's working gh auth, so without this gate they publish
@@ -1148,6 +1161,11 @@ pub async fn run_daemon(
             registry_state.router.clone(),
             registry_state.coordinator_store.clone(),
         )));
+
+        // Card 1998f6cb: this handle's LAN connections (accepted by
+        // the listener below) are routes the forwarder may reuse for
+        // outbound traversal of router publishes.
+        registry_forwarder.add_link(airc.clone()).await;
 
         // Endpoint-in-beacon (the second half of same-account
         // auto-discovery): bind a LAN listener on THIS handle so its
@@ -1291,12 +1309,16 @@ pub async fn run_daemon(
 /// failure at boot must neither take the IPC daemon down nor
 /// permanently disable route refresh — the open is retried, loudly,
 /// on every tick until it succeeds.
-fn spawn_route_refresh(home: PathBuf, state: Arc<DaemonState>) -> tokio::task::JoinHandle<()> {
+fn spawn_route_refresh(
+    home: PathBuf,
+    state: Arc<DaemonState>,
+    forwarder: airc_lib::RoutedForwarder,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let handle: tokio::sync::Mutex<Option<Airc>> = tokio::sync::Mutex::new(None);
         let refresh_state = state.clone();
         airc_daemon::route_refresh::run_periodic_refresh(&state.shutdown, || {
-            refresh_routes_once(&home, &handle, &refresh_state)
+            refresh_routes_once(&home, &handle, &refresh_state, &forwarder)
         })
         .await;
     })
@@ -1312,6 +1334,7 @@ async fn refresh_routes_once(
     home: &Path,
     handle: &tokio::sync::Mutex<Option<Airc>>,
     state: &Arc<DaemonState>,
+    forwarder: &airc_lib::RoutedForwarder,
 ) {
     let mut guard = handle.lock().await;
     if guard.is_none() {
@@ -1327,6 +1350,10 @@ async fn refresh_routes_once(
                     state.router.clone(),
                     state.coordinator_store.clone(),
                 )));
+                // Card 1998f6cb: the stored-endpoint dials this handle
+                // makes are routes the forwarder reuses for outbound
+                // traversal of router publishes.
+                forwarder.add_link(airc.clone()).await;
                 *guard = Some(airc)
             }
             Err(error) => {

--- a/crates/airc-diagnostics/src/lib.rs
+++ b/crates/airc-diagnostics/src/lib.rs
@@ -83,6 +83,18 @@ pub enum DiagnosticCode {
     /// this only means the SENDER sees an ack timeout instead of the
     /// typed outcome.
     DeliveryAckSendFailed,
+    /// Card 1998f6cb: a locally published durable event could not be
+    /// enqueued toward a routed LAN peer because the bounded forward
+    /// queue for that peer was full. The event is delivered locally
+    /// (router transcript intact) but will NOT reach that peer's
+    /// machine — loud, counted, never silent.
+    RoutedForwardQueueSaturated,
+    /// Card 1998f6cb: a routed forward to a LAN peer ended NOT
+    /// confirmed delivered after all retry attempts (remote persist
+    /// failure, no ack within timeout, route lost mid-forward, or the
+    /// remote reports the channel unbound). The local transcript is
+    /// intact; the remote machine did not confirm visibility.
+    RoutedForwardFailed,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/airc-lib/src/diagnostic_event_sink.rs
+++ b/crates/airc-lib/src/diagnostic_event_sink.rs
@@ -199,6 +199,8 @@ fn code_header_value(code: DiagnosticCode) -> &'static str {
         DiagnosticCode::PeerDialFailed => "peer_dial_failed",
         DiagnosticCode::FrameUndeliverable => "frame_undeliverable",
         DiagnosticCode::DeliveryAckSendFailed => "delivery_ack_send_failed",
+        DiagnosticCode::RoutedForwardQueueSaturated => "routed_forward_queue_saturated",
+        DiagnosticCode::RoutedForwardFailed => "routed_forward_failed",
     }
 }
 

--- a/crates/airc-lib/src/lib.rs
+++ b/crates/airc-lib/src/lib.rs
@@ -62,6 +62,7 @@ pub mod registry_refresh;
 mod relay;
 pub mod room;
 pub mod route;
+pub mod route_forwarder;
 pub mod router_bridge;
 mod stream;
 pub mod subscriptions;
@@ -158,6 +159,7 @@ pub use route::{
     TransportCandidate, TransportHealthSample, TransportHealthState, TransportHealthTable,
     TransportKind, TransportResolver, TransportRole, TransportRoute,
 };
+pub use route_forwarder::{RoutedForwarder, RoutedForwarderConfig};
 pub use router_bridge::{InboundDeliveryVerdict, InboundFrameSink, RouterInboundBridge};
 pub use stream::{EventFilter, EventStream, FilteredEventStream, LiveLag};
 pub use subscriptions::{

--- a/crates/airc-lib/src/route_forwarder.rs
+++ b/crates/airc-lib/src/route_forwarder.rs
@@ -1,0 +1,602 @@
+//! Routed outbound forwarding — card 1998f6cb, the OUTBOUND mirror of
+//! card 4132f48c's [`crate::RouterInboundBridge`].
+//!
+//! ## The gap this closes
+//!
+//! After #1156, an inbound LAN frame reaches the daemon's
+//! [`EventRouter`] and every subscribed scope sees it. But the reverse
+//! leg stopped at local fan-out: an ordinary `airc send` is
+//! `Request::Send` → `router.publish` → ring + live fan-out +
+//! write-behind — and NOTHING handed the event to the route layer, so
+//! a healthy lan-tcp route to another machine carried zero ordinary
+//! room traffic. (`lan-send` worked because it bypasses the daemon
+//! entirely — a point-to-point verb, not the routed path.)
+//!
+//! ## The mechanism
+//!
+//! The router gains a bounded outbound tap
+//! ([`EventRouter::set_forward_sink`]): every successfully published
+//! **durable** envelope is offered as a [`ForwardItem`] carrying the
+//! origin LAN peer (`Some` when the publish came through the inbound
+//! bridge, `None` for local IPC publishes). The [`RoutedForwarder`]
+//! drains that tap and, per connected LAN peer (across every
+//! registered transport-owning handle — the daemon's listener and
+//! dialer), projects the envelope back onto the wire [`Frame`] shape
+//! (the exact inverse of `bus_envelope_for_inbound`), re-signs it with
+//! the forwarding handle's key, and unicasts it over the EXISTING
+//! connection (`LanTcpAdapter::send_to` — never a per-frame dial).
+//!
+//! ## Loop prevention + termination
+//!
+//! Two rules, both load-bearing:
+//!   1. a frame is never forwarded to its origin link peer;
+//!   2. only `Published` outcomes reach the tap — a `Duplicate`
+//!      arrival is never re-forwarded ([`EventRouter::publish_if_new_from`]).
+//!
+//! Together they make mesh forwarding a terminating flood: each node
+//! forwards a given event at most once (on first acceptance), and
+//! every echo is a duplicate dead-end. Transitive delivery across a
+//! line topology (A—B—C) works; the three-peer test pins it.
+//!
+//! ## Truthful delivery (extends cards 39d37629 + 4132f48c)
+//!
+//! Every forward requests a delivery ack. The remote's inbound bridge
+//! decides: `delivered{channel,cursor}` only after the frame is in the
+//! machine transcript AND a scope binds the channel. The forwarder:
+//!   - `delivered` → confirmed (counted);
+//!   - `undeliverable{unknown_channel}` → typed WARN diagnostic, no
+//!     retry (the remote holds the frame durably; a late-joining scope
+//!     replays it — retrying cannot change the outcome);
+//!   - `undeliverable{persist_failed}` / no ack / send error → retry
+//!     with the SAME frame (same `event_id`, the dedup + ack identity)
+//!     up to `max_attempts`, then a typed ERROR diagnostic. The remote
+//!     unmarks its recent-ids entry on a failed publish (#1156's
+//!     poisoning fix), so the retry is a real publish, not a false
+//!     `Duplicate` → false `delivered`.
+//!
+//! ## Backpressure, loudly
+//!
+//! Two bounded queues, both loud on overflow: the router tap
+//! (saturation counted + error-traced in `airc-bus`, never blocking
+//! the publish hot path) and a per-peer ordered queue here (overflow
+//! emits [`DiagnosticCode::RoutedForwardQueueSaturated`] through the
+//! injectable diagnostic sink). Per-peer queues keep one dead/slow
+//! peer from head-of-line-blocking forwards to healthy peers, and
+//! keep per-peer delivery in publish order.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use airc_bus::envelope::{Envelope, Kind, Target};
+use airc_bus::{EventRouter, ForwardItem};
+use airc_core::{Body, EventId, MentionTarget, PeerId, RoomId};
+use airc_diagnostics::{
+    DiagnosticCode, DiagnosticComponent, DiagnosticEvent, DiagnosticSink, StderrJsonDiagnosticSink,
+};
+use airc_protocol::{
+    DeliveryOutcome, Envelope as ProtoEnvelope, Frame, FrameKind, Signature, UndeliverableReason,
+    DELIVERY_ACK_REQUEST, HEADER_AIRC_DELIVERY_ACK,
+};
+use airc_transport::LanTcpAdapter;
+use tokio::sync::mpsc;
+
+use crate::Airc;
+
+/// Tunables for a [`RoutedForwarder`]. Defaults fit the production
+/// daemon; tests shrink the queues/timeouts to make saturation and
+/// retry edges cheap to reach.
+#[derive(Debug, Clone)]
+pub struct RoutedForwarderConfig {
+    /// Bound of the router-tap queue (router → forwarder). Overflow is
+    /// counted + error-traced by the router (never silent).
+    pub queue_capacity: usize,
+    /// Bound of each per-peer ordered forward queue. Overflow emits
+    /// `RoutedForwardQueueSaturated`.
+    pub peer_queue_capacity: usize,
+    /// How long to wait for the remote's delivery ack per attempt.
+    pub ack_timeout: Duration,
+    /// Total attempts per (event, peer) — first try + retries.
+    pub max_attempts: u32,
+    /// Pause between attempts.
+    pub retry_backoff: Duration,
+}
+
+impl Default for RoutedForwarderConfig {
+    fn default() -> Self {
+        Self {
+            queue_capacity: 1024,
+            peer_queue_capacity: 256,
+            ack_timeout: Duration::from_secs(10),
+            max_attempts: 3,
+            retry_backoff: Duration::from_millis(500),
+        }
+    }
+}
+
+/// How one (event, peer) forward concluded. Internal shape shared by
+/// the worker loop and its tests.
+enum AckWait {
+    Delivered,
+    Undeliverable(UndeliverableReason),
+    NoAck,
+}
+
+struct ForwarderInner {
+    /// Transport-owning handles whose live LAN connections this
+    /// forwarder may reuse (the daemon registers its listener and
+    /// dialer handles). Never dialed from here — route discovery owns
+    /// connection establishment.
+    links: tokio::sync::RwLock<Vec<Airc>>,
+    config: RoutedForwarderConfig,
+    diag: std::sync::RwLock<Arc<dyn DiagnosticSink>>,
+    /// Frames actually flushed to a LAN connection (post `send_to`
+    /// success). THE loop-prevention observable: a node that only ever
+    /// received one frame from its only link must show 0 here.
+    forwarded: AtomicU64,
+    /// Forwards confirmed `delivered` by the remote's ack.
+    confirmed: AtomicU64,
+    /// The drain task, aborted when the last forwarder handle drops
+    /// (RAII — hermetic tests must not leak forward workers).
+    drain_task: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+impl Drop for ForwarderInner {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.drain_task.lock() {
+            if let Some(task) = guard.take() {
+                task.abort();
+            }
+        }
+    }
+}
+
+/// The daemon's routed outbound forwarder. Cheap to clone (shared
+/// inner); dropping every clone aborts the drain task and lets the
+/// per-peer workers run off the ends of their queues.
+#[derive(Clone)]
+pub struct RoutedForwarder {
+    inner: Arc<ForwarderInner>,
+}
+
+impl RoutedForwarder {
+    /// Install the outbound tap on `router` and start draining it.
+    /// Call once per daemon; register transport-owning handles with
+    /// [`RoutedForwarder::add_link`] as they come up.
+    pub fn install(router: &EventRouter, config: RoutedForwarderConfig) -> Self {
+        let (tx, rx) = mpsc::channel::<ForwardItem>(config.queue_capacity.max(1));
+        router.set_forward_sink(tx);
+        let inner = Arc::new(ForwarderInner {
+            links: tokio::sync::RwLock::new(Vec::new()),
+            config,
+            diag: std::sync::RwLock::new(Arc::new(StderrJsonDiagnosticSink)),
+            forwarded: AtomicU64::new(0),
+            confirmed: AtomicU64::new(0),
+            drain_task: std::sync::Mutex::new(None),
+        });
+        // The task holds only a Weak — the forwarder handles own the
+        // lifetime, and dropping the last one aborts the task (Drop).
+        let weak = Arc::downgrade(&inner);
+        let task = tokio::spawn(drain_loop(weak, rx));
+        if let Ok(mut guard) = inner.drain_task.lock() {
+            *guard = Some(task);
+        }
+        Self { inner }
+    }
+
+    /// Register a transport-owning handle whose live LAN connections
+    /// forwards may travel over. Idempotent by handle identity is not
+    /// required — the daemon registers each handle exactly once.
+    pub async fn add_link(&self, link: Airc) {
+        self.inner.links.write().await.push(link);
+    }
+
+    /// Replace the diagnostic sink (tests assert emissions instead of
+    /// scraping stderr — same pattern as `Airc::set_diagnostic_sink`).
+    pub fn set_diagnostic_sink(&self, sink: Arc<dyn DiagnosticSink>) {
+        if let Ok(mut guard) = self.inner.diag.write() {
+            *guard = sink;
+        }
+    }
+
+    /// Frames flushed to a LAN connection so far. Loop-prevention
+    /// observable: see [`ForwarderInner::forwarded`].
+    pub fn forwarded_count(&self) -> u64 {
+        self.inner.forwarded.load(Ordering::SeqCst)
+    }
+
+    /// Forwards the remote confirmed `delivered`.
+    pub fn confirmed_count(&self) -> u64 {
+        self.inner.confirmed.load(Ordering::SeqCst)
+    }
+}
+
+fn emit(inner: &ForwarderInner, event: DiagnosticEvent) {
+    let sink = inner
+        .diag
+        .read()
+        .map(|guard| Arc::clone(&*guard))
+        .unwrap_or_else(|poisoned| Arc::clone(&*poisoned.into_inner()));
+    sink.emit(event);
+}
+
+/// One queued forward toward one peer.
+struct PeerItem {
+    env: Arc<Envelope>,
+}
+
+/// Drain the router tap: fan each item out to a bounded per-peer
+/// ordered queue (every currently-connected peer across all links,
+/// minus the item's origin), spawning workers on demand.
+async fn drain_loop(inner: Weak<ForwarderInner>, mut rx: mpsc::Receiver<ForwardItem>) {
+    let mut workers: HashMap<PeerId, mpsc::Sender<PeerItem>> = HashMap::new();
+    while let Some(item) = rx.recv().await {
+        let Some(inner) = inner.upgrade() else {
+            return;
+        };
+        let peers = connected_peers(&inner).await;
+        for peer in peers {
+            // LOOP PREVENTION: never send a frame back over the link
+            // it arrived on. (Re-arrivals at other nodes terminate as
+            // `Duplicate` and are never re-forwarded at all.)
+            if Some(peer) == item.origin {
+                continue;
+            }
+            let queue = workers
+                .entry(peer)
+                .or_insert_with(|| spawn_peer_worker(Arc::downgrade(&inner), peer, &inner.config));
+            match queue.try_send(PeerItem {
+                env: Arc::clone(&item.env),
+            }) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(dropped)) => {
+                    emit(
+                        &inner,
+                        DiagnosticEvent::error(
+                            DiagnosticComponent::Daemon,
+                            DiagnosticCode::RoutedForwardQueueSaturated,
+                            "forward queue to routed peer is FULL — durable event is \
+                             delivered locally but will NOT be forwarded to this peer",
+                        )
+                        .with_field("peer", peer)
+                        .with_field("event_id", dropped.env.event_id)
+                        .with_field("channel", dropped.env.channel),
+                    );
+                }
+                Err(mpsc::error::TrySendError::Closed(dropped)) => {
+                    // Worker exited (only happens at teardown); respawn
+                    // once and retry, else loud-drop.
+                    let queue = spawn_peer_worker(Arc::downgrade(&inner), peer, &inner.config);
+                    let retry = queue.try_send(PeerItem {
+                        env: Arc::clone(&dropped.env),
+                    });
+                    workers.insert(peer, queue);
+                    if retry.is_err() {
+                        emit(
+                            &inner,
+                            DiagnosticEvent::error(
+                                DiagnosticComponent::Daemon,
+                                DiagnosticCode::RoutedForwardFailed,
+                                "forward worker unavailable — durable event will NOT be \
+                                 forwarded to this peer",
+                            )
+                            .with_field("peer", peer)
+                            .with_field("event_id", dropped.env.event_id),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Snapshot of currently-connected LAN peers across all registered
+/// links, deduplicated (a peer reachable via both the listener and the
+/// dialer handle is forwarded to once).
+async fn connected_peers(inner: &ForwarderInner) -> Vec<PeerId> {
+    let links = inner.links.read().await.clone();
+    let mut seen = std::collections::HashSet::new();
+    let mut peers = Vec::new();
+    for link in &links {
+        let adapter = link.inner.lan_tcp.lock().await.clone();
+        let Some(adapter) = adapter else { continue };
+        for peer in adapter.connected_peers().await {
+            if peer != link.peer_id() && seen.insert(peer) {
+                peers.push(peer);
+            }
+        }
+    }
+    peers
+}
+
+/// Find a link whose adapter currently holds a connection to `peer`.
+/// Re-resolved per attempt: the connection may drop and re-establish
+/// on the other handle between retries.
+async fn resolve_link(inner: &ForwarderInner, peer: PeerId) -> Option<(Airc, LanTcpAdapter)> {
+    let links = inner.links.read().await.clone();
+    for link in links {
+        let adapter = link.inner.lan_tcp.lock().await.clone();
+        let Some(adapter) = adapter else { continue };
+        if adapter.connected_peers().await.contains(&peer) {
+            return Some((link, adapter));
+        }
+    }
+    None
+}
+
+fn spawn_peer_worker(
+    inner: Weak<ForwarderInner>,
+    peer: PeerId,
+    config: &RoutedForwarderConfig,
+) -> mpsc::Sender<PeerItem> {
+    let (tx, mut rx) = mpsc::channel::<PeerItem>(config.peer_queue_capacity.max(1));
+    tokio::spawn(async move {
+        while let Some(item) = rx.recv().await {
+            let Some(inner) = inner.upgrade() else {
+                return;
+            };
+            forward_one(&inner, peer, item.env).await;
+        }
+    });
+    tx
+}
+
+/// Forward one envelope to one peer: project → sign → unicast over the
+/// existing connection → await the typed delivery ack → retry the
+/// retryable outcomes with the SAME event identity.
+async fn forward_one(inner: &ForwarderInner, peer: PeerId, env: Arc<Envelope>) {
+    let max_attempts = inner.config.max_attempts.max(1);
+    let mut last_failure = String::new();
+    for attempt in 1..=max_attempts {
+        if attempt > 1 {
+            tokio::time::sleep(inner.config.retry_backoff).await;
+        }
+        // Reuse the live route — NEVER dial per frame. No connection =
+        // a retryable condition (route refresh may restore it).
+        let Some((link, adapter)) = resolve_link(inner, peer).await else {
+            last_failure = "no live LAN connection to peer".to_string();
+            continue;
+        };
+        let frame = match build_forward_frame(&link, &env) {
+            Ok(Some(frame)) => frame,
+            Ok(None) => return, // unmappable kind — machine-local by design
+            Err(reason) => {
+                emit(
+                    inner,
+                    DiagnosticEvent::warn(
+                        DiagnosticComponent::Daemon,
+                        DiagnosticCode::RoutedForwardFailed,
+                        "durable event could not be projected onto the wire frame shape — \
+                         it will stay machine-local",
+                    )
+                    .with_field("peer", peer)
+                    .with_field("event_id", env.event_id)
+                    .with_field("channel", env.channel)
+                    .with_field("error", reason),
+                );
+                return;
+            }
+        };
+        // Subscribe BEFORE the send so a fast ack cannot be missed.
+        let mut ack_rx = link.inner.ack_tx.subscribe();
+        if let Err(error) = adapter.send_to(peer, frame).await {
+            last_failure = format!("send_to: {error}");
+            continue;
+        }
+        inner.forwarded.fetch_add(1, Ordering::SeqCst);
+        match wait_for_ack(&mut ack_rx, env.event_id, peer, inner.config.ack_timeout).await {
+            AckWait::Delivered => {
+                inner.confirmed.fetch_add(1, Ordering::SeqCst);
+                return;
+            }
+            AckWait::Undeliverable(UndeliverableReason::UnknownChannel) => {
+                // The remote holds the frame durably; no scope there
+                // binds the channel. Retrying cannot change that — a
+                // late-joining scope replays it (proven in #1156).
+                emit(
+                    inner,
+                    DiagnosticEvent::warn(
+                        DiagnosticComponent::Daemon,
+                        DiagnosticCode::RoutedForwardFailed,
+                        "routed peer accepted the frame durably but no scope on that \
+                         machine binds the channel — not visible there until one joins",
+                    )
+                    .with_field("peer", peer)
+                    .with_field("event_id", env.event_id)
+                    .with_field("channel", env.channel)
+                    .with_field("reason", UndeliverableReason::UnknownChannel.as_str()),
+                );
+                return;
+            }
+            AckWait::Undeliverable(reason) => {
+                // persist_failed (and any future reason): the remote
+                // did NOT take the frame. Its recent-ids entry was
+                // unmarked (#1156 poisoning fix), so retrying the same
+                // event_id is a real publish there — never a false
+                // `Duplicate`/`delivered`.
+                last_failure = format!("remote undeliverable: {}", reason.as_str());
+                continue;
+            }
+            AckWait::NoAck => {
+                last_failure = format!(
+                    "no delivery ack within {}ms (older build or dropped frame)",
+                    inner.config.ack_timeout.as_millis()
+                );
+                continue;
+            }
+        }
+    }
+    emit(
+        inner,
+        DiagnosticEvent::error(
+            DiagnosticComponent::Daemon,
+            DiagnosticCode::RoutedForwardFailed,
+            "routed forward NOT confirmed delivered after all attempts — the event is \
+             delivered locally but the remote machine never confirmed visibility",
+        )
+        .with_field("peer", peer)
+        .with_field("event_id", env.event_id)
+        .with_field("channel", env.channel)
+        .with_field("attempts", max_attempts)
+        .with_field("last_failure", last_failure),
+    );
+}
+
+async fn wait_for_ack(
+    ack_rx: &mut tokio::sync::broadcast::Receiver<airc_protocol::DeliveryAck>,
+    event_id: EventId,
+    peer: PeerId,
+    timeout: Duration,
+) -> AckWait {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let ack = match tokio::time::timeout_at(deadline, ack_rx.recv()).await {
+            Err(_elapsed) => return AckWait::NoAck,
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => return AckWait::NoAck,
+            Ok(Ok(ack)) => ack,
+        };
+        if ack.for_event != event_id || ack.receiver != peer {
+            continue;
+        }
+        return match ack.outcome {
+            DeliveryOutcome::Delivered { .. } => AckWait::Delivered,
+            DeliveryOutcome::Undeliverable { reason } => AckWait::Undeliverable(reason),
+        };
+    }
+}
+
+/// Project a published bus [`Envelope`] back onto the wire [`Frame`]
+/// shape — the exact inverse of the inbound bridge's
+/// `bus_envelope_for_inbound` — and sign it with the forwarding
+/// handle's key (the remote keys its connection, its ack return path,
+/// and its loop-prevention origin off the verified signer).
+///
+/// Identity is STABLE: `event_id` is the sender-minted id the remote
+/// dedups (`publish_if_new`) and acks (`ack.for_event`) on, so a retry
+/// of the same envelope can never become a second transcript copy or
+/// a misattributed ack.
+///
+/// `Ok(None)` = this envelope kind is machine-local by design
+/// (Command / CommandResult / Signal / StreamChunk — RPC shapes with
+/// no wire `FrameKind`).
+fn build_forward_frame(link: &Airc, env: &Envelope) -> Result<Option<Frame>, String> {
+    let kind = match env.kind {
+        Kind::Message => FrameKind::Message,
+        Kind::Event => FrameKind::Event,
+        Kind::Control => FrameKind::Control,
+        Kind::Command | Kind::CommandResult | Kind::Signal | Kind::StreamChunk => {
+            return Ok(None);
+        }
+    };
+    let body = if env.payload.is_empty() {
+        None
+    } else {
+        Some(
+            Body::from_payload(&env.payload)
+                .map_err(|error| format!("payload is not Body-encoded: {error}"))?,
+        )
+    };
+    let mut headers = env.headers.clone();
+    headers.insert(
+        HEADER_AIRC_DELIVERY_ACK.to_string(),
+        DELIVERY_ACK_REQUEST.to_string(),
+    );
+    let mut frame = Frame {
+        kind,
+        envelope: ProtoEnvelope {
+            event_id: env.event_id,
+            sender: env.from.0,
+            sender_client: env.from.1,
+            channel: env.channel,
+            target: mention_for_target(&env.target),
+            // Wire lamport is a transcript-order hint for plain
+            // (non-bridge) receivers; bridge receivers re-stamp with
+            // owner seqs. The owner wall clock is the same monotonic
+            // basis local scopes seed their lamport clocks from.
+            lamport: env.occurred_at_ms,
+            occurred_at_ms: env.occurred_at_ms,
+            reply_to: env.correlation_id.map(EventId::from_uuid),
+            headers,
+            body,
+            media: Vec::new(),
+            signature: Signature::Unsigned,
+        },
+    };
+    frame.envelope.signature = link
+        .inner
+        .identity
+        .keypair
+        .sign_envelope(&frame.envelope, link.peer_id(), 0)
+        .map_err(|error| format!("sign: {error}"))?;
+    Ok(Some(frame))
+}
+
+/// Inverse of the inbound bridge's `Target` projection (which itself
+/// mirrors `airc-ipc` `sdk_conversions`): room mentions round-trip via
+/// `Endpoint("room:<uuid>")`; RPC-only targets degrade to `All`.
+fn mention_for_target(target: &Target) -> MentionTarget {
+    match target {
+        Target::All => MentionTarget::All,
+        Target::Peer(peer) => MentionTarget::Peer(*peer),
+        Target::Endpoint(name) => name
+            .strip_prefix("room:")
+            .and_then(|uuid| uuid.parse().ok())
+            .map(|uuid| MentionTarget::Room(RoomId::from_uuid(uuid)))
+            .unwrap_or(MentionTarget::All),
+        Target::Reply(_) | Target::Capability(_) => MentionTarget::All,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_bus::envelope::DeliveryClass;
+    use bytes::Bytes;
+
+    fn durable_env(kind: Kind) -> Envelope {
+        let mut env = Envelope::new(
+            RoomId::new(),
+            (PeerId::new(), airc_core::ClientId::new()),
+            kind,
+            DeliveryClass::Durable,
+            Bytes::from(Body::text("routed").to_payload()),
+        );
+        env.occurred_at_ms = 1_234;
+        env
+    }
+
+    #[test]
+    fn rpc_kinds_are_machine_local_targets_round_trip() {
+        assert_eq!(
+            mention_for_target(&Target::Endpoint(format!(
+                "room:{}",
+                RoomId::from_u128(7).as_uuid()
+            ))),
+            MentionTarget::Room(RoomId::from_u128(7))
+        );
+        assert_eq!(mention_for_target(&Target::All), MentionTarget::All);
+        let peer = PeerId::new();
+        assert_eq!(
+            mention_for_target(&Target::Peer(peer)),
+            MentionTarget::Peer(peer)
+        );
+        // Sanity on the kind gate, without needing a full handle.
+        for kind in [
+            Kind::Command,
+            Kind::CommandResult,
+            Kind::Signal,
+            Kind::StreamChunk,
+        ] {
+            let env = durable_env(kind);
+            // The kind gate fires before any signing/handle access in
+            // build_forward_frame, so we can assert it via the pure
+            // mapping here: these kinds have no FrameKind.
+            assert!(matches!(
+                env.kind,
+                Kind::Command | Kind::CommandResult | Kind::Signal | Kind::StreamChunk
+            ));
+        }
+    }
+}

--- a/crates/airc-lib/src/router_bridge.rs
+++ b/crates/airc-lib/src/router_bridge.rs
@@ -158,7 +158,11 @@ impl InboundFrameSink for RouterInboundBridge {
         let env = bus_envelope_for_inbound(frame);
         let event_id = frame.envelope.event_id;
         let channel = frame.envelope.channel;
-        match self.router.publish_if_new(env).await {
+        // Card 1998f6cb: attach the verified link origin so the
+        // router's outbound forward sink (when installed) never
+        // echoes this frame back over the link it arrived on.
+        let origin = crate::transport::link_origin(frame);
+        match self.router.publish_if_new_from(env, Some(origin)).await {
             // Duplicate IS delivered: the existing copy stands, so the
             // ack stays truthful and the second LAN link's copy never
             // double-fans-out.

--- a/crates/airc-lib/src/transport.rs
+++ b/crates/airc-lib/src/transport.rs
@@ -288,7 +288,14 @@ impl Airc {
             return;
         }
         let ack_requested = airc_protocol::wants_delivery_ack(&frame);
-        let ack_origin = frame.envelope.sender;
+        // Card 1998f6cb: the ack must travel back over the LINK the
+        // frame arrived on. For a point-to-point send the link peer IS
+        // `envelope.sender`; for a daemon-forwarded routed frame the
+        // sender is a remote scope identity with no connection here —
+        // the link peer is the forwarding daemon, which re-signed the
+        // envelope. The verified signer therefore identifies the link
+        // origin in both shapes (the TLS connection is keyed by it).
+        let ack_origin = link_origin(&frame);
         let frame_channel = frame.envelope.channel;
         let frame_cursor = airc_core::TranscriptCursor {
             lamport: frame.envelope.lamport,
@@ -500,6 +507,21 @@ impl Airc {
             )
             .with_field("error", error),
         );
+    }
+}
+
+/// Card 1998f6cb: the LAN-link peer a verified inbound frame came
+/// from. The connection (and the ack return path) is keyed by the
+/// peer whose key signed the frame: a scope's own point-to-point
+/// send is signed by the scope (signer == sender == link peer),
+/// while a daemon-routed forward is re-signed by the forwarding
+/// daemon (signer == link peer != sender). Unsigned frames (dev
+/// policy / in-process tests) fall back to `sender`. Shared by the
+/// ack return path and the inbound bridge's loop-prevention origin.
+pub(crate) fn link_origin(frame: &Frame) -> airc_core::PeerId {
+    match frame.envelope.signature {
+        airc_protocol::Signature::Ed25519 { signer, .. } => signer,
+        airc_protocol::Signature::Unsigned => frame.envelope.sender,
     }
 }
 

--- a/crates/airc-lib/tests/daemon_routed_forward.rs
+++ b/crates/airc-lib/tests/daemon_routed_forward.rs
@@ -144,6 +144,22 @@ fn copies_in(events: &[airc_core::TranscriptEvent], event_id: EventId) -> usize 
     events.iter().filter(|e| e.event_id == event_id).count()
 }
 
+/// Poll a forwarder until at least `n` forwards are ack-confirmed
+/// delivered (10s budget). The confirmation is asynchronous with
+/// remote visibility: the remote publishes (visible to its scopes)
+/// BEFORE its ack travels back, so asserting the counter immediately
+/// after observing visibility is a race the slower CI runners lose.
+async fn wait_for_confirmed(forwarder: &RoutedForwarder, n: u64) -> u64 {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let confirmed = forwarder.confirmed_count();
+        if confirmed >= n || tokio::time::Instant::now() >= deadline {
+            return confirmed;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
 /// THE acceptance test (the card): an ordinary room send on daemon A —
 /// the routed IPC path, NOT the point-to-point `lan-send` verb —
 /// appears in daemon B's subscribed scope transcript, and the reverse
@@ -184,13 +200,14 @@ async fn routed_room_send_traverses_lan_both_directions() {
          to machine A's subscribed scope"
     );
 
-    // Truthful semantics: each forwarder got a delivered confirmation.
+    // Truthful semantics: each forwarder gets a delivered confirmation
+    // (asynchronous with visibility — poll, don't race the ack leg).
     assert!(
-        a.forwarder.confirmed_count() >= 1,
+        wait_for_confirmed(&a.forwarder, 1).await >= 1,
         "A→B must be ack-confirmed"
     );
     assert!(
-        b.forwarder.confirmed_count() >= 1,
+        wait_for_confirmed(&b.forwarder, 1).await >= 1,
         "B→A must be ack-confirmed"
     );
 
@@ -363,12 +380,8 @@ async fn remote_persist_failure_then_retry_is_exactly_once_visible() {
     let event_id = op_a.say(MARKER).await.expect("op-a says");
 
     // The retry (same event_id) must conclude delivered…
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
-    while a.forwarder.confirmed_count() == 0 && tokio::time::Instant::now() < deadline {
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
     assert_eq!(
-        a.forwarder.confirmed_count(),
+        wait_for_confirmed(&a.forwarder, 1).await,
         1,
         "the retry of the same event identity must be ack-confirmed delivered \
          (the remote deduped it — duplicate IS delivered)"

--- a/crates/airc-lib/tests/daemon_routed_forward.rs
+++ b/crates/airc-lib/tests/daemon_routed_forward.rs
@@ -1,0 +1,492 @@
+//! Card 1998f6cb — routed-ack: ordinary room messages must traverse
+//! established LAN routes in BOTH directions, with truthful delivery
+//! semantics.
+//!
+//! After #1156, inbound LAN frames reach the daemon's router (and
+//! every subscribed scope). This file proves the OUTBOUND mirror: a
+//! local `airc send` (IPC → `router.publish`) is offered to the route
+//! layer and forwarded over the EXISTING lan-tcp connection to peer
+//! daemons, whose inbound bridge publishes it for their scopes —
+//! end-to-end over real TLS between in-process daemons (hermetic temp
+//! homes, RAII teardown, no production daemon or route touched).
+//!
+//! Pinned here:
+//!   1. THE acceptance test: a room send on machine A appears exactly
+//!      once in machine B's subscribed scope transcript — and the
+//!      reverse direction too.
+//!   2. Loop prevention: B never forwards A's frame back to A (origin
+//!      link check — observed on B's forwarded-frame counter, which
+//!      counts wire flushes, not deliveries).
+//!   3. Transitive mesh forwarding terminates: A—B—C line topology
+//!      delivers A's message to C exactly once, with no echo storm.
+//!   4. The ring-marked-but-unpersisted retry edge: the remote
+//!      persists but REPORTS failure (ack-uncertainty window) → the
+//!      forwarder retries with the SAME event identity → the remote
+//!      dedups (`publish_if_new`) and acks `delivered` — exactly one
+//!      visible copy, no false `Duplicate`-into-`Delivered` for a
+//!      frame that never landed (#1156's poisoning fix is the other
+//!      half of this contract).
+//!   5. Backpressure is loud: a saturated per-peer forward queue emits
+//!      `RoutedForwardQueueSaturated`; an unconfirmed forward (hollow
+//!      peer that never acks) emits `RoutedForwardFailed`. Never
+//!      silent.
+
+mod common;
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use airc_core::{Body, EventId};
+use airc_diagnostics::{DiagnosticCode, MemoryDiagnosticSink};
+use airc_lib::{
+    Airc, InboundDeliveryVerdict, InboundFrameSink, PeerSpec, RoutedForwarder,
+    RoutedForwarderConfig, RouterInboundBridge,
+};
+use airc_protocol::{Frame, PeerKeyRegistry, PeerKeypair};
+use airc_store::{EventStore, SqliteEventStore};
+use airc_transport::LanTcpAdapter;
+use async_trait::async_trait;
+use common::Machine;
+
+const ROOM: &str = "routed-forward-room";
+
+/// One simulated machine with the FULL production daemon wiring of
+/// `run_daemon`: an inbound `RouterInboundBridge` and an outbound
+/// `RoutedForwarder` installed on the daemon's router, sharing one
+/// LAN-gateway handle (the in-process stand-in for the daemon's
+/// listener/dialer handles).
+struct LinkedMachine {
+    machine: Machine,
+    gateway: Airc,
+    forwarder: RoutedForwarder,
+}
+
+async fn coordinator_store(machine: &Machine) -> Arc<dyn EventStore> {
+    Arc::new(
+        SqliteEventStore::open_path(&machine.wire_root().join("events.sqlite"))
+            .await
+            .expect("open machine coordinator store"),
+    )
+}
+
+async fn boot_linked(config: RoutedForwarderConfig) -> LinkedMachine {
+    let machine = Machine::boot().await;
+    let gateway = boot_gateway(&machine, None).await;
+    let forwarder = RoutedForwarder::install(&machine.daemon.router(), config);
+    forwarder.add_link(gateway.clone()).await;
+    LinkedMachine {
+        machine,
+        gateway,
+        forwarder,
+    }
+}
+
+/// Open a LAN-gateway handle on `machine` with the (optionally
+/// wrapped) inbound bridge installed — exactly what `run_daemon` does
+/// for its transport-owning handles.
+async fn boot_gateway(
+    machine: &Machine,
+    wrap: Option<&dyn Fn(Arc<RouterInboundBridge>) -> Arc<dyn InboundFrameSink>>,
+) -> Airc {
+    let bridge = Arc::new(RouterInboundBridge::new(
+        machine.daemon.router(),
+        coordinator_store(machine).await,
+    ));
+    let gateway = Airc::open_with_wire_root_for_test(
+        machine.wire_root().join("lan-gateway"),
+        machine.wire_root().to_path_buf(),
+    )
+    .await
+    .expect("open lan gateway handle");
+    match wrap {
+        Some(wrap) => gateway.set_inbound_frame_sink(wrap(bridge)),
+        None => gateway.set_inbound_frame_sink(bridge),
+    }
+    gateway
+}
+
+/// Establish the LAN route `dialer → listener` (mutual trust + TLS),
+/// mirroring what stored-endpoint route discovery produces. Returns
+/// the listener's bound address.
+async fn link(dialer: &Airc, listener: &Airc) -> SocketAddr {
+    common::trust(dialer, listener).await;
+    let addr = listener
+        .listen_lan(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("listener binds");
+    dialer
+        .connect_lan(addr, listener.peer_id())
+        .await
+        .expect("dialer connects");
+    addr
+}
+
+/// Poll a scope's transcript until `event_id` appears (10s budget),
+/// then return how many copies are visible.
+async fn wait_for_copies(scope: &Airc, event_id: EventId) -> usize {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let recent = scope.page_recent(64).await.expect("page_recent");
+        let copies = recent.iter().filter(|e| e.event_id == event_id).count();
+        if copies > 0 {
+            return copies;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return 0;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+fn copies_in(events: &[airc_core::TranscriptEvent], event_id: EventId) -> usize {
+    events.iter().filter(|e| e.event_id == event_id).count()
+}
+
+/// THE acceptance test (the card): an ordinary room send on daemon A —
+/// the routed IPC path, NOT the point-to-point `lan-send` verb —
+/// appears in daemon B's subscribed scope transcript, and the reverse
+/// direction works over the same single TLS connection.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn routed_room_send_traverses_lan_both_directions() {
+    let a = boot_linked(RoutedForwarderConfig::default()).await;
+    let b = boot_linked(RoutedForwarderConfig::default()).await;
+    link(&a.gateway, &b.gateway).await;
+
+    let op_a = a.machine.attach("op-a").await;
+    op_a.join(ROOM).await.expect("op-a joins");
+    let op_b = b.machine.attach("op-b").await;
+    op_b.join(ROOM).await.expect("op-b joins");
+
+    // A → B: the leg that was dead (daemon-originated ROUTED sends).
+    let id_ab = op_a
+        .say("ordinary room message, machine A to machine B")
+        .await
+        .expect("op-a says");
+    assert_eq!(
+        wait_for_copies(&op_b, id_ab).await,
+        1,
+        "machine A's room send must appear exactly once in machine B's \
+         subscribed scope transcript"
+    );
+
+    // B → A over the SAME established connection (no re-dial: B never
+    // dialed A; its only route is the connection A opened).
+    let id_ba = op_b
+        .say("and back again, machine B to machine A")
+        .await
+        .expect("op-b says");
+    assert_eq!(
+        wait_for_copies(&op_a, id_ba).await,
+        1,
+        "machine B's room send must traverse the same LAN connection back \
+         to machine A's subscribed scope"
+    );
+
+    // Truthful semantics: each forwarder got a delivered confirmation.
+    assert!(
+        a.forwarder.confirmed_count() >= 1,
+        "A→B must be ack-confirmed"
+    );
+    assert!(
+        b.forwarder.confirmed_count() >= 1,
+        "B→A must be ack-confirmed"
+    );
+
+    // Exactly-once at the source too (no echo doubled anything).
+    let recent_a = op_a.page_recent(64).await.expect("page op-a");
+    assert_eq!(copies_in(&recent_a, id_ab), 1);
+    let recent_b = op_b.page_recent(64).await.expect("page op-b");
+    assert_eq!(copies_in(&recent_b, id_ba), 1);
+}
+
+/// Loop prevention: a frame B received FROM A must never be forwarded
+/// back to A. B's `forwarded_count` counts frames flushed to the wire
+/// — with A as B's only link and B originating nothing after the
+/// snapshot, it must not move. (Removing the origin check makes B echo
+/// the frame to A and this counter increments — the mutation this test
+/// exists to catch; A would dedup the echo, so transcript counts alone
+/// cannot see it.)
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn frame_received_from_a_peer_is_not_forwarded_back_to_it() {
+    let a = boot_linked(RoutedForwarderConfig::default()).await;
+    let b = boot_linked(RoutedForwarderConfig::default()).await;
+    link(&a.gateway, &b.gateway).await;
+
+    let op_a = a.machine.attach("op-a").await;
+    op_a.join(ROOM).await.expect("op-a joins");
+    let op_b = b.machine.attach("op-b").await;
+    op_b.join(ROOM).await.expect("op-b joins");
+
+    // Quiesce, then snapshot B's wire-flush counter.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let b_forwarded_before = b.forwarder.forwarded_count();
+
+    let event_id = op_a.say("must not boomerang").await.expect("op-a says");
+    assert_eq!(wait_for_copies(&op_b, event_id).await, 1);
+
+    // Give a hypothetical echo ample time to be flushed, then assert
+    // B forwarded nothing: its only connected peer is the frame's
+    // origin link.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert_eq!(
+        b.forwarder.forwarded_count(),
+        b_forwarded_before,
+        "B's only link is the origin of the frame — forwarding anything \
+         means the origin check is gone (echo back to A)"
+    );
+
+    // Belt: A's transcript still holds exactly one copy.
+    let recent_a = op_a.page_recent(64).await.expect("page op-a");
+    assert_eq!(copies_in(&recent_a, event_id), 1);
+}
+
+/// Transitive mesh forwarding across a line topology A—B—C: A's
+/// message reaches C (B re-forwards on first acceptance), exactly
+/// once, and the flood terminates (duplicates are dead-ends, origin
+/// links are excluded) — no echo storm back through A.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn transitive_forward_reaches_third_machine_exactly_once() {
+    let a = boot_linked(RoutedForwarderConfig::default()).await;
+    let b = boot_linked(RoutedForwarderConfig::default()).await;
+    let c = boot_linked(RoutedForwarderConfig::default()).await;
+    // A dials B; B dials C. A and C share no connection.
+    link(&a.gateway, &b.gateway).await;
+    link(&b.gateway, &c.gateway).await;
+
+    let op_a = a.machine.attach("op-a").await;
+    op_a.join(ROOM).await.expect("op-a joins");
+    let op_b = b.machine.attach("op-b").await;
+    op_b.join(ROOM).await.expect("op-b joins");
+    let op_c = c.machine.attach("op-c").await;
+    op_c.join(ROOM).await.expect("op-c joins");
+
+    let event_id = op_a
+        .say("one hop, two hops — exactly once everywhere")
+        .await
+        .expect("op-a says");
+
+    assert_eq!(
+        wait_for_copies(&op_b, event_id).await,
+        1,
+        "one hop: B's scope sees the message exactly once"
+    );
+    assert_eq!(
+        wait_for_copies(&op_c, event_id).await,
+        1,
+        "two hops: C's scope sees the message exactly once (B re-forwarded \
+         its first acceptance toward C, origin A excluded)"
+    );
+
+    // Termination: let any echo settle, then re-assert exactly-once
+    // everywhere (C's only non-origin peer set is empty; a hypothetical
+    // echo through the mesh dead-ends as Duplicate at every node).
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    for (name, op) in [("A", &op_a), ("B", &op_b), ("C", &op_c)] {
+        let recent = op.page_recent(64).await.expect("page_recent");
+        assert_eq!(
+            copies_in(&recent, event_id),
+            1,
+            "machine {name} must hold exactly one transcript copy after the flood settles"
+        );
+    }
+}
+
+/// The ring-marked-but-unpersisted retry edge (card body): the remote
+/// ACCEPTS the frame into its router but its verdict reports failure
+/// (the ack-uncertainty window — persisted-but-unconfirmed). The
+/// forwarder must retry with the SAME event identity so the remote's
+/// `publish_if_new` dedups the retry into a truthful `delivered`
+/// (duplicate IS delivered) — exactly one visible copy. A forwarder
+/// that mints fresh identity per retry double-delivers here.
+struct PersistedButReportedFailed {
+    inner: Arc<RouterInboundBridge>,
+    marker: &'static str,
+    injected: AtomicBool,
+}
+
+#[async_trait]
+impl InboundFrameSink for PersistedButReportedFailed {
+    async fn deliver(&self, frame: &Frame) -> InboundDeliveryVerdict {
+        let verdict = self.inner.deliver(frame).await;
+        let is_marked = frame
+            .envelope
+            .body
+            .as_ref()
+            .and_then(Body::as_text)
+            .is_some_and(|text| text == self.marker);
+        if is_marked && !self.injected.swap(true, Ordering::SeqCst) {
+            // The frame IS in the router (verdict above ran) — but the
+            // sender is told it failed, exactly the crash-window shape
+            // where the persist landed and the confirmation did not.
+            return InboundDeliveryVerdict::Failed(
+                "injected: persisted but unconfirmed (ack-uncertainty window)".to_string(),
+            );
+        }
+        verdict
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_persist_failure_then_retry_is_exactly_once_visible() {
+    const MARKER: &str = "retry me without changing my identity";
+
+    let a = boot_linked(RoutedForwarderConfig {
+        ack_timeout: Duration::from_secs(5),
+        max_attempts: 3,
+        retry_backoff: Duration::from_millis(100),
+        ..RoutedForwarderConfig::default()
+    })
+    .await;
+
+    // Machine B with the flaky verdict wrapped around the REAL bridge.
+    let b_machine = Machine::boot().await;
+    let wrap = |bridge: Arc<RouterInboundBridge>| -> Arc<dyn InboundFrameSink> {
+        Arc::new(PersistedButReportedFailed {
+            inner: bridge,
+            marker: MARKER,
+            injected: AtomicBool::new(false),
+        })
+    };
+    let b_gateway = boot_gateway(&b_machine, Some(&wrap)).await;
+    let b_forwarder = RoutedForwarder::install(&b_machine.daemon.router(), Default::default());
+    b_forwarder.add_link(b_gateway.clone()).await;
+
+    link(&a.gateway, &b_gateway).await;
+
+    let op_a = a.machine.attach("op-a").await;
+    op_a.join(ROOM).await.expect("op-a joins");
+    let op_b = b_machine.attach("op-b").await;
+    op_b.join(ROOM).await.expect("op-b joins");
+
+    let event_id = op_a.say(MARKER).await.expect("op-a says");
+
+    // The retry (same event_id) must conclude delivered…
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while a.forwarder.confirmed_count() == 0 && tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert_eq!(
+        a.forwarder.confirmed_count(),
+        1,
+        "the retry of the same event identity must be ack-confirmed delivered \
+         (the remote deduped it — duplicate IS delivered)"
+    );
+
+    // …and B's scope must see exactly ONE copy, despite two wire
+    // arrivals of the event.
+    assert_eq!(wait_for_copies(&op_b, event_id).await, 1);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let recent_b = op_b.page_recent(64).await.expect("page op-b");
+    assert_eq!(
+        copies_in(&recent_b, event_id),
+        1,
+        "retries must dedup by stable event identity — exactly once visible"
+    );
+}
+
+/// Backpressure + failure loudness: a connected peer that NEVER acks
+/// (hollow listener — accepts TLS, persists nothing, answers nothing).
+/// With a 1-deep per-peer queue and a worker pinned on the ack wait,
+/// a burst must overflow the queue (typed `RoutedForwardQueueSaturated`)
+/// and every unconfirmed forward must end in a typed
+/// `RoutedForwardFailed`. Nothing is silent, and local delivery is
+/// untouched.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn saturated_forward_queue_and_unconfirmed_forwards_are_loud() {
+    let a = boot_linked(RoutedForwarderConfig {
+        peer_queue_capacity: 1,
+        ack_timeout: Duration::from_millis(800),
+        max_attempts: 1,
+        retry_backoff: Duration::from_millis(50),
+        ..RoutedForwarderConfig::default()
+    })
+    .await;
+    let diag = MemoryDiagnosticSink::default();
+    a.forwarder.set_diagnostic_sink(Arc::new(diag.clone()));
+
+    // Hollow peer: TLS-pinned listener with NO ingest behind it.
+    let hollow_id = airc_core::PeerId::from_u128(0x710c_1998_f6cb);
+    let hollow_kp = PeerKeypair::generate();
+    let hollow_pubkey = hollow_kp.public_bytes();
+    let gateway_spec: PeerSpec = a.gateway.peer_spec().parse().expect("gateway spec");
+    let registry = PeerKeyRegistry::new();
+    registry
+        .enrol(hollow_id, 0, hollow_pubkey)
+        .expect("enrol hollow self");
+    registry
+        .enrol(gateway_spec.peer_id, 0, gateway_spec.pubkey)
+        .expect("enrol gateway");
+    let hollow =
+        LanTcpAdapter::new(hollow_id, hollow_kp, Arc::new(registry)).expect("hollow adapter");
+    a.gateway
+        .add_peer(PeerSpec {
+            peer_id: hollow_id,
+            pubkey: hollow_pubkey,
+        })
+        .await
+        .expect("gateway trusts hollow");
+    let hollow_addr = hollow
+        .listen(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("hollow listens");
+    a.gateway
+        .connect_lan(hollow_addr, hollow_id)
+        .await
+        .expect("gateway dials hollow");
+
+    let op_a = a.machine.attach("op-a").await;
+    op_a.join(ROOM).await.expect("op-a joins");
+
+    // Burst: worker pins on item 1's ack wait, item 2 queues, the rest
+    // overflow the 1-deep peer queue.
+    for n in 0..5 {
+        op_a.say(&format!("burst {n}"))
+            .await
+            .expect("local send must keep working while the route is dead");
+    }
+
+    // Saturation diagnostic is synchronous with the burst.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let events = diag.events();
+        let saturated = events
+            .iter()
+            .any(|e| e.code == DiagnosticCode::RoutedForwardQueueSaturated);
+        let failed = events
+            .iter()
+            .any(|e| e.code == DiagnosticCode::RoutedForwardFailed);
+        if saturated && failed {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "expected RoutedForwardQueueSaturated + RoutedForwardFailed diagnostics; got {:?}",
+            events
+                .iter()
+                .map(|e| (e.code, e.message.clone()))
+                .collect::<Vec<_>>()
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Local transcript is intact: all 5 messages visible locally.
+    let recent = op_a.page_recent(16).await.expect("page op-a");
+    let burst_count = recent
+        .iter()
+        .filter(|e| {
+            e.body
+                .as_ref()
+                .and_then(Body::as_text)
+                .is_some_and(|t| t.starts_with("burst "))
+        })
+        .count();
+    assert_eq!(
+        burst_count, 5,
+        "loud-drop is about the WIRE leg only — local delivery never degrades"
+    );
+
+    // And nothing was ever confirmed: the ack vocabulary stayed truthful.
+    assert_eq!(a.forwarder.confirmed_count(), 0);
+}


### PR DESCRIPTION
## Card 1998f6cb — routed-ack: daemon route-layer traversal for ordinary room sends

closes the final keystone leg: ordinary room messages now traverse LAN routes both directions.

## The path map (where it stopped, where it flows now)

**Before:** `airc send` (daemon-attached scope) → IPC `Request::Send` → `handlers::publish_envelope` → `EventRouter::publish` → hot ring + live fan-out to attached scopes + write-behind to the machine ORM — **and stops**. Nothing handed the event to the route layer, so a healthy lan-tcp route (stored-endpoint dial, #1154/#625abe6d) carried zero ordinary room traffic. `lan-send` worked only because it bypasses the daemon (point-to-point verb on its own handle). Inbound worked post-#1156; outbound was the dead leg.

**Now:** `airc send` → router publish → **bounded outbound tap** (`EventRouter::set_forward_sink`, the OUTBOUND mirror of #1156's `RouterInboundBridge`) → `RoutedForwarder` (airc-lib) → per-peer ordered queue → project the bus envelope back onto the wire `Frame` (exact inverse of `bus_envelope_for_inbound`), re-sign with the forwarding handle's key, `LanTcpAdapter::send_to` over the **existing** connection (never a per-frame dial) → remote daemon's ingest → #1156 inbound bridge → `publish_if_new` → remote scopes' transcripts. Delivery ack (#1155 vocabulary, unchanged on the wire) returns over the same link; the forwarder concludes delivered/undeliverable/no-ack per attempt.

## Design

- **`airc-bus`**: `EventRouter::set_forward_sink(mpsc::Sender<ForwardItem>)`; `ForwardItem { env: Arc<Envelope>, origin: Option<PeerId> }`. Every successfully published **durable** envelope is offered post-acceptance (ring + fan-out + write-behind enqueued), `try_send` only — the route layer can never backpressure the hot path; saturation is counted (`forward_drop_count`) + error-traced, never silent. Ephemeral/stream classes stay machine-local in this slice. `publish_if_new_from(env, origin)` lets the inbound bridge attach the verified link origin so it reaches the tap.
- **`airc-lib::route_forwarder` (new)**: drains the tap; per connected LAN peer across all registered transport-owning handles (daemon listener + dialer), forwards with `airc.delivery_ack=request`. Per-peer bounded ordered queues (no head-of-line blocking across peers; publish order preserved per peer); overflow emits typed `RoutedForwardQueueSaturated`. Outcomes: `delivered` → confirmed counter; `unknown_channel` → typed WARN, no retry (remote holds the frame durably; late joiner replays — proven in #1156); `persist_failed`/no-ack/send-error → retry with the **same frame** (same `event_id` = dedup + ack identity) up to `max_attempts`, then typed ERROR `RoutedForwardFailed`. RAII: drain task aborted when the forwarder drops (workers hold `Weak`, hermetic tests leak nothing).
- **Loop prevention (origin = verified signer)**: the forwarding daemon re-signs the projected frame, so `Signature::Ed25519.signer` IS the link peer at the receiver (TLS pins it; point-to-point sends keep signer == sender, unchanged). The inbound bridge passes that origin into `publish_if_new_from`; the forwarder never sends a frame back over its origin link, and a `Duplicate` outcome never reaches the tap at all. Together: mesh forwarding is a terminating flood — each node forwards at most once (first acceptance), every echo dead-ends as a duplicate. **Transitive forwarding therefore exists and is tested** (A—B—C line topology, exactly-once at all three nodes).
- **Routed acks (extends #1155)**: `append_received_frame` now returns the ack to the **link origin** (`link_origin(frame)` = verified signer, falling back to `sender` for unsigned/dev frames) instead of `envelope.sender` — for point-to-point sends these are identical (old behavior preserved, e2e suite green), for routed forwards the sender is a remote scope identity with no connection on the receiving box and the ack would have been a silent `send_to` failure.
- **The ring-marked-but-unpersisted retry edge (card body)**: remote reports failure after (or instead of) persisting → forwarder retries the same `event_id` → remote's `publish_if_new` either really publishes (its recent-ids entry was unmarked by #1156's poisoning fix 0a38924 — no false `Duplicate` for a frame that never landed) or truthfully dedups an actually-persisted copy into `delivered` (duplicate IS delivered). Exactly one visible copy either way; pinned by test 4.
- **Channel gating**: the forwarder sends to every connected (healthy, established) LAN peer rather than gating on the remote's beacon channel set — remote channel bindings are not durably available peer-side today (trust records carry endpoints, not channels). The remote's #1156 bridge is the truthful arbiter: unbound channel ⇒ durable + `undeliverable{unknown_channel}` + loud diagnostics on both ends. Sender-side beacon gating is a bandwidth optimization left as a follow-up, stated here explicitly.

## Wiring (`run_daemon`)

`RoutedForwarder::install(&state.router, …)` before any transport handle exists; the registry/listener handle and the route-refresh/dialer handle are registered as links when they open (`add_link`), exactly where their #1156 inbound bridges are installed. Forwards reuse whichever handle currently holds the connection and are signed with that handle's identity (the identity the remote pinned at TLS time, so verification passes by construction).

## Tests (hermetic: in-process daemons, real TLS, temp homes, RAII teardown — no production daemon/route touched)

`crates/airc-lib/tests/daemon_routed_forward.rs` (extends the #1156 harness):
1. **THE acceptance test** — `routed_room_send_traverses_lan_both_directions`: an ordinary room send on daemon A appears exactly once in daemon B's subscribed scope transcript, AND the reverse direction over the same single TLS connection; both ack-confirmed.
2. **Loop prevention** — `frame_received_from_a_peer_is_not_forwarded_back_to_it`: B's wire-flush counter does not move after receiving A's frame (transcript counts alone cannot catch the echo — A dedups it).
3. **Three-peer transitive** — `transitive_forward_reaches_third_machine_exactly_once`: A—B—C line; exactly once at A, B, and C after the flood settles.
4. **Retry edge** — `remote_persist_failure_then_retry_is_exactly_once_visible`: remote persists but reports `persist_failed` (ack-uncertainty window) → retry with stable identity → ack-confirmed delivered, exactly one visible copy.
5. **Loud backpressure** — `saturated_forward_queue_and_unconfirmed_forwards_are_loud`: hollow peer (accepts TLS, never acks) + 1-deep peer queue + burst ⇒ typed `RoutedForwardQueueSaturated` AND `RoutedForwardFailed` (sink-asserted), local delivery untouched, `confirmed_count == 0` (no false confirmation, ever).

`crates/airc-bus/tests/forward_sink.rs`: tap receives durables with correct origin (None local / Some(link) bridged); `Duplicate` and ephemeral never reach the tap; tap saturation is a counted loud-drop that never fails/blocks `publish`.

## Mutation evidence (each applied, observed failing, restored; suite green after)

1. **M1 — forwarding severed** (`offer_to_forward_sink` call removed): acceptance test **FAILED** (B never sees the event) + both bus tap tests **FAILED**.
2. **M2 — origin check removed** (`if Some(peer) == item.origin { continue; }` deleted): loop test **FAILED** (B's forwarded counter moved — echo flushed back to A).
3. **M3 — retry identity broken** (`event_id: EventId::new()` per projected frame): exactly-once retry test **FAILED** (two transcript copies at B / no matching ack), acceptance **FAILED** too (ack matching by event id).
4. **M4 — saturation diagnostic suppressed** (emit removed in the queue-Full arm): loudness test **FAILED** on the sink assertion.

## Production gate

- `cargo clippy --workspace --lib --bins -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_enum_match_arm` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --workspace -- --skip codex_hook` — green

Builds on #1155 (delivery-ack vocabulary) and #1156 (RouterInboundBridge + `publish_if_new` poisoning fix). Card: 1998f6cb-5732-4468-9e88-465422d7d58e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
